### PR TITLE
Add reserved property name validation for metamodel

### DIFF
--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -95,12 +95,12 @@ func TestExportEntitiesJSON(t *testing.T) {
 
 	var buf bytes.Buffer
 	buf.ReadFrom(r)
-	output := buf.String()
+	jsonOutput := buf.String()
 
 	// Parse JSON
 	var entities []ExportEntity
-	if err := json.Unmarshal([]byte(output), &entities); err != nil {
-		t.Fatalf("Failed to parse JSON output: %v\nOutput was: %s", err, output)
+	if err := json.Unmarshal([]byte(jsonOutput), &entities); err != nil {
+		t.Fatalf("Failed to parse JSON output: %v\nOutput was: %s", err, jsonOutput)
 	}
 
 	if len(entities) != 2 {
@@ -138,10 +138,10 @@ func TestExportEntitiesWithRelations(t *testing.T) {
 
 	var buf bytes.Buffer
 	buf.ReadFrom(r)
-	output := buf.String()
+	jsonOutput := buf.String()
 
 	var entities []ExportEntity
-	if err := json.Unmarshal([]byte(output), &entities); err != nil {
+	if err := json.Unmarshal([]byte(jsonOutput), &entities); err != nil {
 		t.Fatalf("Failed to parse JSON output: %v", err)
 	}
 
@@ -207,10 +207,10 @@ func TestExportEntitiesCSV(t *testing.T) {
 
 	var buf bytes.Buffer
 	buf.ReadFrom(r)
-	output := buf.String()
+	csvOutput := buf.String()
 
 	// Parse CSV
-	reader := csv.NewReader(strings.NewReader(output))
+	reader := csv.NewReader(strings.NewReader(csvOutput))
 	records, err := reader.ReadAll()
 	if err != nil {
 		t.Fatalf("Failed to parse CSV: %v", err)
@@ -261,12 +261,12 @@ func TestExportEntitiesYAML(t *testing.T) {
 
 	var buf bytes.Buffer
 	buf.ReadFrom(r)
-	output := buf.String()
+	yamlOutput := buf.String()
 
 	// Parse YAML
 	var entities []ExportEntity
-	if err := yaml.Unmarshal([]byte(output), &entities); err != nil {
-		t.Fatalf("Failed to parse YAML output: %v\nOutput was: %s", err, output)
+	if err := yaml.Unmarshal([]byte(yamlOutput), &entities); err != nil {
+		t.Fatalf("Failed to parse YAML output: %v\nOutput was: %s", err, yamlOutput)
 	}
 
 	if len(entities) != 2 {
@@ -294,10 +294,10 @@ func TestExportAllData(t *testing.T) {
 
 	var buf bytes.Buffer
 	buf.ReadFrom(r)
-	output := buf.String()
+	jsonOutput := buf.String()
 
 	var fullExport FullExport
-	if err := json.Unmarshal([]byte(output), &fullExport); err != nil {
+	if err := json.Unmarshal([]byte(jsonOutput), &fullExport); err != nil {
 		t.Fatalf("Failed to parse JSON output: %v", err)
 	}
 
@@ -338,10 +338,10 @@ func TestExportEmptyResult(t *testing.T) {
 
 	var buf bytes.Buffer
 	buf.ReadFrom(r)
-	output := strings.TrimSpace(buf.String())
+	jsonOutput := strings.TrimSpace(buf.String())
 
-	if output != "[]" {
-		t.Errorf("Expected empty array '[]', got: %s", output)
+	if jsonOutput != "[]" {
+		t.Errorf("Expected empty array '[]', got: %s", jsonOutput)
 	}
 }
 

--- a/internal/filter/sort.go
+++ b/internal/filter/sort.go
@@ -9,7 +9,10 @@ import (
 
 // Sort sorts entities by a property with type-aware comparison.
 // The meta parameter is optional but required for proper enum/custom type ordering.
-func Sort(entities []*model.Entity, propName string, propDef *metamodel.PropertyDef, meta *metamodel.Metamodel, descending bool) {
+func Sort(
+	entities []*model.Entity, propName string, propDef *metamodel.PropertyDef,
+	meta *metamodel.Metamodel, descending bool,
+) {
 	// Build enum value index map for efficient lookup
 	enumIndex := buildEnumIndex(propDef, meta)
 

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -32,6 +32,21 @@ func Parse(data []byte) (*Metamodel, error) {
 			return nil, &InvalidIDTypeError{EntityType: name, IDType: def.IDType}
 		}
 
+		// Validate property names
+		for propName := range def.Properties {
+			// Reject property names with leading or trailing whitespace
+			// This prevents bypassing reserved name checks with " id" or "type " etc.
+			trimmedName := strings.TrimSpace(propName)
+			if trimmedName != propName {
+				return nil, &WhitespacePropertyError{EntityType: name, PropertyName: propName}
+			}
+
+			// Check for reserved property names
+			if ReservedPropertyNames[propName] {
+				return nil, &ReservedPropertyError{EntityType: name, PropertyName: propName}
+			}
+		}
+
 		// Add lowercase name as self-reference
 		m.aliasMap[strings.ToLower(name)] = name
 		// Add all aliases

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -1,0 +1,342 @@
+package metamodel
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParse_ReservedPropertyNames(t *testing.T) {
+	tests := []struct {
+		name         string
+		yaml         string
+		wantErr      bool
+		wantPropName string
+	}{
+		{
+			name: "valid properties",
+			yaml: `
+version: "1.0"
+entities:
+  task:
+    label: Task
+    id_patterns: ["TASK-"]
+    properties:
+      title:
+        type: string
+        required: true
+      status:
+        type: string
+`,
+			wantErr: false,
+		},
+		{
+			name: "reserved property id",
+			yaml: `
+version: "1.0"
+entities:
+  task:
+    label: Task
+    id_patterns: ["TASK-"]
+    properties:
+      id:
+        type: string
+      title:
+        type: string
+`,
+			wantErr:      true,
+			wantPropName: "id",
+		},
+		{
+			name: "reserved property type",
+			yaml: `
+version: "1.0"
+entities:
+  task:
+    label: Task
+    id_patterns: ["TASK-"]
+    properties:
+      type:
+        type: string
+      title:
+        type: string
+`,
+			wantErr:      true,
+			wantPropName: "type",
+		},
+		{
+			name: "reserved property in second entity",
+			yaml: `
+version: "1.0"
+entities:
+  task:
+    label: Task
+    id_patterns: ["TASK-"]
+    properties:
+      title:
+        type: string
+  requirement:
+    label: Requirement
+    id_patterns: ["REQ-"]
+    properties:
+      id:
+        type: string
+`,
+			wantErr:      true,
+			wantPropName: "id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.yaml))
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error for reserved property, got nil")
+				}
+
+				var reservedErr *ReservedPropertyError
+				if !errors.As(err, &reservedErr) {
+					t.Fatalf("expected ReservedPropertyError, got %T: %v", err, err)
+				}
+
+				if reservedErr.PropertyName != tt.wantPropName {
+					t.Errorf("expected property name %q, got %q", tt.wantPropName, reservedErr.PropertyName)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestReservedPropertyError_Error(t *testing.T) {
+	err := &ReservedPropertyError{
+		EntityType:   "task",
+		PropertyName: "type",
+	}
+
+	expected := `entity task: property "type" is reserved and cannot be used`
+	if err.Error() != expected {
+		t.Errorf("expected %q, got %q", expected, err.Error())
+	}
+}
+
+func TestWhitespacePropertyError_Error(t *testing.T) {
+	err := &WhitespacePropertyError{
+		EntityType:   "task",
+		PropertyName: " id",
+	}
+
+	expected := `entity task: property name " id" has leading or trailing whitespace`
+	if err.Error() != expected {
+		t.Errorf("expected %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReservedPropertyNames(t *testing.T) {
+	// Verify the reserved names are what we expect
+	expectedReserved := []string{"id", "type"}
+
+	for _, name := range expectedReserved {
+		if !ReservedPropertyNames[name] {
+			t.Errorf("expected %q to be reserved", name)
+		}
+	}
+
+	// Verify non-reserved names are not in the map
+	notReserved := []string{"title", "status", "description", "name"}
+	for _, name := range notReserved {
+		if ReservedPropertyNames[name] {
+			t.Errorf("expected %q to NOT be reserved", name)
+		}
+	}
+}
+
+func TestParse_ReservedPropertyNames_WhitespaceBypas(t *testing.T) {
+	// Test that reserved property names cannot be bypassed with whitespace
+	// See TICKET-001: Reserved property validation can be bypassed with whitespace
+	tests := []struct {
+		name         string
+		yaml         string
+		wantErr      bool
+		wantPropName string // the original property name (with whitespace)
+	}{
+		{
+			name: "leading space on id",
+			yaml: `
+version: "1.0"
+entities:
+  task:
+    label: Task
+    id_patterns: ["TASK-"]
+    properties:
+      " id":
+        type: string
+      title:
+        type: string
+`,
+			wantErr:      true,
+			wantPropName: " id",
+		},
+		{
+			name: "trailing space on id",
+			yaml: `
+version: "1.0"
+entities:
+  task:
+    label: Task
+    id_patterns: ["TASK-"]
+    properties:
+      "id ":
+        type: string
+      title:
+        type: string
+`,
+			wantErr:      true,
+			wantPropName: "id ",
+		},
+		{
+			name: "both leading and trailing space on id",
+			yaml: `
+version: "1.0"
+entities:
+  task:
+    label: Task
+    id_patterns: ["TASK-"]
+    properties:
+      " id ":
+        type: string
+      title:
+        type: string
+`,
+			wantErr:      true,
+			wantPropName: " id ",
+		},
+		{
+			name: "leading space on type",
+			yaml: `
+version: "1.0"
+entities:
+  task:
+    label: Task
+    id_patterns: ["TASK-"]
+    properties:
+      " type":
+        type: string
+      title:
+        type: string
+`,
+			wantErr:      true,
+			wantPropName: " type",
+		},
+		{
+			name: "trailing space on type",
+			yaml: `
+version: "1.0"
+entities:
+  task:
+    label: Task
+    id_patterns: ["TASK-"]
+    properties:
+      "type ":
+        type: string
+      title:
+        type: string
+`,
+			wantErr:      true,
+			wantPropName: "type ",
+		},
+		{
+			name: "whitespace-only property name",
+			yaml: `
+version: "1.0"
+entities:
+  task:
+    label: Task
+    id_patterns: ["TASK-"]
+    properties:
+      "   ":
+        type: string
+      title:
+        type: string
+`,
+			wantErr:      true,
+			wantPropName: "   ",
+		},
+		{
+			name: "property with internal whitespace is allowed",
+			yaml: `
+version: "1.0"
+entities:
+  task:
+    label: Task
+    id_patterns: ["TASK-"]
+    properties:
+      "some property":
+        type: string
+      title:
+        type: string
+`,
+			wantErr: false,
+		},
+		{
+			name: "tab character in property name",
+			yaml: `
+version: "1.0"
+entities:
+  task:
+    label: Task
+    id_patterns: ["TASK-"]
+    properties:
+      "	id":
+        type: string
+      title:
+        type: string
+`,
+			wantErr:      true,
+			wantPropName: "\tid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.yaml))
+
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected error for property name with whitespace issue, got nil")
+			}
+
+			// Verify the property name in the error matches what we expect
+			gotPropName := extractPropertyName(t, err)
+			if gotPropName != tt.wantPropName {
+				t.Errorf("expected property name %q, got %q", tt.wantPropName, gotPropName)
+			}
+		})
+	}
+}
+
+// extractPropertyName extracts the property name from a ReservedPropertyError or WhitespacePropertyError
+func extractPropertyName(t *testing.T, err error) string {
+	t.Helper()
+
+	var reservedErr *ReservedPropertyError
+	if errors.As(err, &reservedErr) {
+		return reservedErr.PropertyName
+	}
+
+	var whitespaceErr *WhitespacePropertyError
+	if errors.As(err, &whitespaceErr) {
+		return whitespaceErr.PropertyName
+	}
+
+	t.Fatalf("expected ReservedPropertyError or WhitespacePropertyError, got %T: %v", err, err)
+	return ""
+}

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -99,6 +99,13 @@ const (
 	IDTypeString     = "string"     // IDs are manually specified strings (e.g., auth-module)
 )
 
+// ReservedPropertyNames contains property names that cannot be used in metamodel definitions
+// because they conflict with built-in entity fields.
+var ReservedPropertyNames = map[string]bool{
+	"id":   true, // Entity.ID
+	"type": true, // Entity.Type
+}
+
 // DefaultDateFormat is the default format for date properties (ISO 8601)
 const DefaultDateFormat = "2006-01-02"
 
@@ -395,6 +402,25 @@ type InvalidIDTypeError struct {
 
 func (e *InvalidIDTypeError) Error() string {
 	return "invalid id_type for entity " + e.EntityType + ": " + e.IDType + " (must be 'sequential' or 'string')"
+}
+
+type ReservedPropertyError struct {
+	EntityType   string
+	PropertyName string
+}
+
+func (e *ReservedPropertyError) Error() string {
+	return "entity " + e.EntityType + ": property \"" + e.PropertyName + "\" is reserved and cannot be used"
+}
+
+// WhitespacePropertyError is returned when a property name has leading or trailing whitespace
+type WhitespacePropertyError struct {
+	EntityType   string
+	PropertyName string
+}
+
+func (e *WhitespacePropertyError) Error() string {
+	return "entity " + e.EntityType + ": property name \"" + e.PropertyName + "\" has leading or trailing whitespace"
 }
 
 // Schema output interface methods for Metamodel

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -477,13 +477,13 @@ func (w *Writer) WriteAnalysisResult(result AnalysisResult) error {
 	// Text format based on status
 	switch result.Status {
 	case "success":
-		w.WriteSuccess(result.Message)
+		w.WriteSuccess("%s", result.Message)
 	case "warning":
-		w.WriteWarning(result.Message)
+		w.WriteWarning("%s", result.Message)
 	case "error":
-		w.WriteError(result.Message)
+		w.WriteError("%s", result.Message)
 	default:
-		w.WriteMessage(result.Message)
+		w.WriteMessage("%s", result.Message)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Prevents user-defined properties from conflicting with built-in entity fields (`id`, `type`)
- Validates property names at metamodel load time with clear error messages
- Blocks whitespace bypass attempts (e.g., ` id`, `type `)

## Changes

- **types.go**: Added `ReservedPropertyNames` map and `ReservedPropertyError`/`WhitespacePropertyError` types
- **loader.go**: Added validation in `Parse()` to check property names
- **loader_test.go**: Added comprehensive tests (reserved names, whitespace edge cases)

## Error Examples

```
entity task: property "id" is reserved and cannot be used
entity task: property name " id" has leading or trailing whitespace
```

## Test plan

- [x] Unit tests pass (`go test ./internal/metamodel/...`)
- [x] Linter passes (`golangci-lint run ./internal/metamodel/...`)
- [x] Manual QA testing verified all edge cases