### PR TITLE
Add schema migration system for project files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ relations/*.md → Relation ↗      ↓
 | `internal/project` | Project discovery, paths (`Context`) |
 | `internal/output` | CLI output formatting (table, JSON) |
 | `internal/filter` | Entity filtering by properties |
+| `internal/migration` | Schema migration system for project files |
 
 ### Key Types
 
@@ -169,3 +170,96 @@ templates/entities/<type>.md  # Optional: entity templates for defaults
 templates/relations/<type>.md # Optional: relation templates for defaults
 .rela/cache.json            # Graph cache (gitignored)
 ```
+
+## Migration System
+
+The migration system (`internal/migration/`) handles schema evolution for project files like `metamodel.yaml`. It uses AST-level YAML transformations to preserve comments and formatting.
+
+### Architecture
+
+```
+Migration Interface
+       ↓
+   Registry (ordered list of migrations)
+       ↓
+   Runner (detect → apply → write)
+       ↓
+   yaml.Node helpers (AST manipulation)
+```
+
+### Key Types
+
+- **Migration** (`migration.go`): Interface for schema migrations
+- **FileType** (`migration.go`): Enum for file types (`metamodel`, `views`, etc.)
+- **Result** (`runner.go`): Result of applying a single migration
+- **FileResult** (`runner.go`): Result of migrating a file
+
+### Adding a New Migration
+
+1. Create a new file in `internal/migration/` (e.g., `my_migration.go`)
+
+2. Implement the `Migration` interface:
+
+```go
+package migration
+
+import "gopkg.in/yaml.v3"
+
+func init() {
+    Register(&MyMigration{})
+}
+
+type MyMigration struct{}
+
+func (m *MyMigration) Name() string {
+    return "my-migration"
+}
+
+func (m *MyMigration) Description() string {
+    return "Description shown to users"
+}
+
+func (m *MyMigration) FileTypes() []FileType {
+    return []FileType{FileTypeMetamodel}
+}
+
+func (m *MyMigration) Detect(doc *yaml.Node) bool {
+    // Return true if this migration should be applied
+    root := GetDocumentRoot(doc)
+    // Use yaml_util.go helpers to inspect the document
+    return false
+}
+
+func (m *MyMigration) Apply(doc *yaml.Node) error {
+    // Transform the document in-place
+    root := GetDocumentRoot(doc)
+    // Use yaml_util.go helpers to modify the document
+    return nil
+}
+```
+
+3. Add tests in `internal/migration/my_migration_test.go`
+
+### yaml.Node Helpers
+
+`yaml_util.go` provides helpers for safe AST manipulation:
+
+| Function | Purpose |
+|----------|---------|
+| `GetDocumentRoot(doc)` | Get root mapping from document node |
+| `GetMapValue(node, key)` | Get value node by key |
+| `SetMapValue(node, key, val)` | Set/add value in mapping |
+| `RenameMapKey(node, old, new)` | Rename a key |
+| `FindMapEntriesByKey(node, key)` | Find all entries with key |
+| `ReplaceMapValueByKey(node, key, old, new)` | Replace values by key |
+| `WalkMappings(node, fn)` | Walk all mapping nodes |
+
+### Integration with Loader
+
+The metamodel loader (`internal/metamodel/loader.go`) checks for migrations on load:
+
+1. Before parsing, it runs `migration.Detect()` on the file
+2. If migrations are detected, it returns a `migration.Error`
+3. The error message tells users to run `rela migrate`
+
+Commands that don't need the metamodel (init, migrate, version, etc.) are excluded from this check in `internal/cli/root.go`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -821,6 +821,56 @@ rela create requirement --title "My Requirement"
 
 ---
 
+### rela migrate
+
+Migrate project files to the current schema format.
+
+```bash
+rela migrate [flags]
+```
+
+**Flags:**
+| Flag | Description |
+|------|-------------|
+| `--check` | Check for pending migrations without applying (useful for CI) |
+
+This command detects deprecated syntax patterns in your project files (e.g., `metamodel.yaml`) and transforms them to the current format while preserving comments and formatting.
+
+**When to use:**
+
+If you see an error like this when running any rela command:
+
+```
+metamodel.yaml uses deprecated syntax:
+  - Rename id_type values: "sequential" → "auto", "string" → "manual"
+
+Run 'rela migrate' to update your project files.
+```
+
+Run `rela migrate` to automatically update your files.
+
+**Examples:**
+
+```bash
+# Apply all pending migrations
+rela migrate
+
+# Check for migrations without applying (for CI pipelines)
+rela migrate --check
+```
+
+**CI Integration:**
+
+Add to your CI pipeline to ensure project files are up-to-date:
+
+```yaml
+- run: rela migrate --check
+```
+
+This will exit with code 1 if migrations are needed.
+
+---
+
 ### rela version
 
 Print version information.

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Sourcehaven-BV/rela/internal/migration"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+)
+
+var (
+	migrateCheck bool
+)
+
+var migrateCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: "Migrate project files to current schema",
+	Long: `Migrate project files (metamodel.yaml, etc.) to the current schema format.
+
+This command detects deprecated syntax patterns and transforms them to the
+current format while preserving comments and formatting.
+
+Examples:
+  rela migrate         # Apply all pending migrations
+  rela migrate --check # Check for pending migrations (for CI)`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Discover project (we need the paths but not the metamodel)
+		ctx, err := project.Discover("")
+		if err != nil {
+			return fmt.Errorf("no project found: run 'rela init' to create one")
+		}
+
+		// Define files to check
+		files := []struct {
+			path     string
+			fileType migration.FileType
+			name     string
+		}{
+			{ctx.MetamodelPath, migration.FileTypeMetamodel, "metamodel.yaml"},
+			// Future: add views.yaml, templates, etc.
+		}
+
+		if migrateCheck {
+			return runMigrateCheck(files)
+		}
+
+		return runMigrate(files)
+	},
+}
+
+func runMigrateCheck(files []struct {
+	path     string
+	fileType migration.FileType
+	name     string
+}) error {
+	needsMigration := false
+
+	for _, f := range files {
+		// Skip files that don't exist
+		if _, err := os.Stat(f.path); os.IsNotExist(err) {
+			continue
+		}
+
+		result, err := migration.CheckOnly(f.path, f.fileType)
+		if err != nil {
+			return fmt.Errorf("checking %s: %w", f.name, err)
+		}
+
+		if result.NeedsMigration() {
+			needsMigration = true
+			fmt.Printf("%s needs migration:\n", f.name)
+			for _, d := range result.Detections {
+				fmt.Printf("  - %s\n", d.Description)
+			}
+		}
+	}
+
+	if needsMigration {
+		fmt.Println("\nRun 'rela migrate' to apply these migrations.")
+		os.Exit(1)
+	}
+
+	fmt.Println("No migrations needed.")
+	return nil
+}
+
+func runMigrate(files []struct {
+	path     string
+	fileType migration.FileType
+	name     string
+}) error {
+	filesUpdated := 0
+	totalMigrations := 0
+
+	for _, f := range files {
+		// Skip files that don't exist
+		if _, err := os.Stat(f.path); os.IsNotExist(err) {
+			continue
+		}
+
+		result, err := migration.Apply(f.path, f.fileType)
+		if err != nil {
+			return fmt.Errorf("migrating %s: %w", f.name, err)
+		}
+
+		if result.HasErrors() {
+			return fmt.Errorf("migrating %s: %w", f.name, result.Error)
+		}
+
+		if result.NeedsMigration() {
+			filesUpdated++
+			fmt.Printf("Migrating %s...\n", f.name)
+			for _, mr := range result.Results {
+				if mr.Applied {
+					totalMigrations++
+					fmt.Printf("  ✓ %s: %s\n", mr.Migration.Name(), mr.Migration.Description())
+				}
+			}
+		}
+	}
+
+	if filesUpdated == 0 {
+		fmt.Println("No migrations needed.")
+	} else {
+		fmt.Printf("\nDone. %d file(s) updated with %d migration(s).\n", filesUpdated, totalMigrations)
+	}
+
+	return nil
+}
+
+func init() {
+	migrateCmd.Flags().BoolVar(&migrateCheck, "check", false, "Check for pending migrations without applying (for CI)")
+	rootCmd.AddCommand(migrateCmd)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -48,7 +48,7 @@ and maintain semantic relationships between them.`,
 		cmdName := cmd.Name()
 		parent := cmd.Parent()
 		isRootChild := parent == nil || parent.Name() == "rela"
-		if isRootChild && (cmdName == "init" || cmdName == "version" || cmdName == "help" || cmdName == "completion" || cmdName == "tui") {
+		if isRootChild && (cmdName == "init" || cmdName == "version" || cmdName == "help" || cmdName == "completion" || cmdName == "tui" || cmdName == "migrate") {
 			out = output.New(output.Format(outputFormat))
 			return nil
 		}

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -5,13 +5,28 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/migration"
 )
 
-// Load reads and parses a metamodel from a YAML file
+// Load reads and parses a metamodel from a YAML file.
+// Returns a MigrationError if the file contains deprecated syntax that needs migration.
 func Load(path string) (*Metamodel, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
+	}
+
+	// Check for deprecated syntax that needs migration
+	detections, err := migration.Detect(path, migration.FileTypeMetamodel)
+	if err != nil {
+		return nil, err
+	}
+	if len(detections) > 0 {
+		return nil, &migration.Error{
+			FilePath:   path,
+			Detections: detections,
+		}
 	}
 
 	return Parse(data)
@@ -28,7 +43,7 @@ func Parse(data []byte) (*Metamodel, error) {
 	m.aliasMap = make(map[string]string)
 	for name, def := range m.Entities {
 		// Validate id_type if specified
-		if def.IDType != "" && def.IDType != IDTypeSequential && def.IDType != IDTypeString {
+		if !IsValidIDType(def.IDType) {
 			return nil, &InvalidIDTypeError{EntityType: name, IDType: def.IDType}
 		}
 

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -574,7 +574,7 @@ func TestInvalidIDTypeError_Error(t *testing.T) {
 		IDType:     "invalid",
 	}
 
-	expected := `invalid id_type for entity task: invalid (must be 'sequential' or 'string')`
+	expected := `invalid id_type for entity task: invalid (must be 'auto' or 'manual')`
 	if err.Error() != expected {
 		t.Errorf("expected %q, got %q", expected, err.Error())
 	}

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -66,7 +66,7 @@ type EntityDef struct {
 	LabelPlural string                 `yaml:"label_plural,omitempty"`
 	Plural      string                 `yaml:"plural,omitempty"` // Used for directory names (e.g., "policies" for "policy")
 	Aliases     []string               `yaml:"aliases,omitempty"`
-	IDType      string                 `yaml:"id_type,omitempty"` // "sequential" (default) or "string"
+	IDType      string                 `yaml:"id_type,omitempty"` // "auto" (default) or "manual"
 	IDPatterns  []string               `yaml:"id_patterns"`
 	RDFType     string                 `yaml:"rdf_type,omitempty"`
 	Properties  map[string]PropertyDef `yaml:"properties"`
@@ -95,9 +95,42 @@ const (
 
 // ID types for entities
 const (
-	IDTypeSequential = "sequential" // IDs are auto-generated with numeric suffix (e.g., REQ-001)
-	IDTypeString     = "string"     // IDs are manually specified strings (e.g., auth-module)
+	// New canonical values
+	IDTypeAuto   = "auto"   // IDs are auto-generated with numeric suffix (e.g., REQ-001)
+	IDTypeManual = "manual" // IDs are manually specified strings (e.g., auth-module)
+
+	// Deprecated aliases (still accepted for backwards compatibility, but will trigger migration warning)
+	IDTypeSequential = "sequential" // Deprecated: use "auto" instead
+	IDTypeString     = "string"     // Deprecated: use "manual" instead
 )
+
+// IsValidIDType returns true if the given id_type value is valid.
+// Accepts both new values (auto, manual) and deprecated aliases (sequential, string).
+func IsValidIDType(idType string) bool {
+	switch idType {
+	case IDTypeAuto, IDTypeManual, IDTypeSequential, IDTypeString, "":
+		return true
+	}
+	return false
+}
+
+// IsDeprecatedIDType returns true if the id_type uses deprecated syntax.
+func IsDeprecatedIDType(idType string) bool {
+	return idType == IDTypeSequential || idType == IDTypeString
+}
+
+// NormalizeIDType converts an id_type value to its canonical form.
+// Maps deprecated values to their new equivalents.
+func NormalizeIDType(idType string) string {
+	switch idType {
+	case IDTypeManual, IDTypeString:
+		return IDTypeManual
+	case IDTypeAuto, IDTypeSequential, "":
+		return IDTypeAuto
+	default:
+		return idType // Return as-is for invalid values (caught by validation)
+	}
+}
 
 // ReservedPropertyNames contains property names that cannot be used in metamodel definitions
 // because they conflict with built-in entity fields.
@@ -233,22 +266,32 @@ func (e *EntityDef) GetPrimaryProperty() string {
 	return ""
 }
 
-// GetIDType returns the ID type for this entity, defaulting to "sequential"
+// GetIDType returns the normalized ID type for this entity, defaulting to "auto".
+// Always returns the canonical value ("auto" or "manual"), even if deprecated syntax was used.
 func (e *EntityDef) GetIDType() string {
-	if e.IDType == "" {
-		return IDTypeSequential
-	}
-	return e.IDType
+	return NormalizeIDType(e.IDType)
 }
 
-// IsSequentialID returns true if this entity type uses sequential IDs
+// IsAutoID returns true if this entity type uses auto-generated IDs.
+func (e *EntityDef) IsAutoID() bool {
+	return e.GetIDType() == IDTypeAuto
+}
+
+// IsManualID returns true if this entity type uses manually-specified IDs.
+func (e *EntityDef) IsManualID() bool {
+	return e.GetIDType() == IDTypeManual
+}
+
+// IsSequentialID returns true if this entity type uses sequential IDs.
+// Deprecated: Use IsAutoID instead.
 func (e *EntityDef) IsSequentialID() bool {
-	return e.GetIDType() == IDTypeSequential
+	return e.IsAutoID()
 }
 
-// IsStringID returns true if this entity type uses string IDs
+// IsStringID returns true if this entity type uses string IDs.
+// Deprecated: Use IsManualID instead.
 func (e *EntityDef) IsStringID() bool {
-	return e.GetIDType() == IDTypeString
+	return e.IsManualID()
 }
 
 // HasPattern checks if the entity type matches a given ID pattern
@@ -401,7 +444,7 @@ type InvalidIDTypeError struct {
 }
 
 func (e *InvalidIDTypeError) Error() string {
-	return "invalid id_type for entity " + e.EntityType + ": " + e.IDType + " (must be 'sequential' or 'string')"
+	return "invalid id_type for entity " + e.EntityType + ": " + e.IDType + " (must be 'auto' or 'manual')"
 }
 
 type ReservedPropertyError struct {

--- a/internal/metamodel/types_test.go
+++ b/internal/metamodel/types_test.go
@@ -284,6 +284,78 @@ func TestGetPrimaryPropertyDeterministic(t *testing.T) {
 	}
 }
 
+func TestNormalizeIDType(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty defaults to auto", input: "", want: IDTypeAuto},
+		{name: "auto returns auto", input: "auto", want: IDTypeAuto},
+		{name: "manual returns manual", input: "manual", want: IDTypeManual},
+		{name: "deprecated sequential normalizes to auto", input: "sequential", want: IDTypeAuto},
+		{name: "deprecated string normalizes to manual", input: "string", want: IDTypeManual},
+		{name: "invalid returns as-is", input: "invalid", want: "invalid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeIDType(tt.input)
+			if got != tt.want {
+				t.Errorf("NormalizeIDType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsValidIDType(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "empty is valid", input: "", want: true},
+		{name: "auto is valid", input: "auto", want: true},
+		{name: "manual is valid", input: "manual", want: true},
+		{name: "deprecated sequential is valid", input: "sequential", want: true},
+		{name: "deprecated string is valid", input: "string", want: true},
+		{name: "invalid is not valid", input: "invalid", want: false},
+		{name: "uuid is not valid", input: "uuid", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsValidIDType(tt.input)
+			if got != tt.want {
+				t.Errorf("IsValidIDType(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDeprecatedIDType(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "empty is not deprecated", input: "", want: false},
+		{name: "auto is not deprecated", input: "auto", want: false},
+		{name: "manual is not deprecated", input: "manual", want: false},
+		{name: "sequential is deprecated", input: "sequential", want: true},
+		{name: "string is deprecated", input: "string", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsDeprecatedIDType(tt.input)
+			if got != tt.want {
+				t.Errorf("IsDeprecatedIDType(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEntityDef_GetIDType(t *testing.T) {
 	tests := []struct {
 		name string
@@ -291,19 +363,29 @@ func TestEntityDef_GetIDType(t *testing.T) {
 		want string
 	}{
 		{
-			name: "empty defaults to sequential",
+			name: "empty defaults to auto",
 			def:  EntityDef{},
-			want: IDTypeSequential,
+			want: IDTypeAuto,
 		},
 		{
-			name: "explicit sequential",
+			name: "explicit auto",
+			def:  EntityDef{IDType: IDTypeAuto},
+			want: IDTypeAuto,
+		},
+		{
+			name: "explicit manual",
+			def:  EntityDef{IDType: IDTypeManual},
+			want: IDTypeManual,
+		},
+		{
+			name: "deprecated sequential normalizes to auto",
 			def:  EntityDef{IDType: IDTypeSequential},
-			want: IDTypeSequential,
+			want: IDTypeAuto,
 		},
 		{
-			name: "explicit string",
+			name: "deprecated string normalizes to manual",
 			def:  EntityDef{IDType: IDTypeString},
-			want: IDTypeString,
+			want: IDTypeManual,
 		},
 	}
 
@@ -317,27 +399,64 @@ func TestEntityDef_GetIDType(t *testing.T) {
 	}
 }
 
+func TestEntityDef_IsAutoID(t *testing.T) {
+	tests := []struct {
+		name string
+		def  EntityDef
+		want bool
+	}{
+		{name: "empty is auto", def: EntityDef{}, want: true},
+		{name: "explicit auto", def: EntityDef{IDType: IDTypeAuto}, want: true},
+		{name: "manual is not auto", def: EntityDef{IDType: IDTypeManual}, want: false},
+		{name: "deprecated sequential is auto", def: EntityDef{IDType: IDTypeSequential}, want: true},
+		{name: "deprecated string is not auto", def: EntityDef{IDType: IDTypeString}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.def.IsAutoID()
+			if got != tt.want {
+				t.Errorf("IsAutoID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEntityDef_IsManualID(t *testing.T) {
+	tests := []struct {
+		name string
+		def  EntityDef
+		want bool
+	}{
+		{name: "empty is not manual", def: EntityDef{}, want: false},
+		{name: "auto is not manual", def: EntityDef{IDType: IDTypeAuto}, want: false},
+		{name: "explicit manual", def: EntityDef{IDType: IDTypeManual}, want: true},
+		{name: "deprecated sequential is not manual", def: EntityDef{IDType: IDTypeSequential}, want: false},
+		{name: "deprecated string is manual", def: EntityDef{IDType: IDTypeString}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.def.IsManualID()
+			if got != tt.want {
+				t.Errorf("IsManualID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test that deprecated methods still work correctly (they delegate to new methods)
 func TestEntityDef_IsSequentialID(t *testing.T) {
 	tests := []struct {
 		name string
 		def  EntityDef
 		want bool
 	}{
-		{
-			name: "empty is sequential",
-			def:  EntityDef{},
-			want: true,
-		},
-		{
-			name: "explicit sequential",
-			def:  EntityDef{IDType: IDTypeSequential},
-			want: true,
-		},
-		{
-			name: "string is not sequential",
-			def:  EntityDef{IDType: IDTypeString},
-			want: false,
-		},
+		{name: "empty is sequential", def: EntityDef{}, want: true},
+		{name: "auto is sequential", def: EntityDef{IDType: IDTypeAuto}, want: true},
+		{name: "manual is not sequential", def: EntityDef{IDType: IDTypeManual}, want: false},
+		{name: "deprecated sequential is sequential", def: EntityDef{IDType: IDTypeSequential}, want: true},
+		{name: "deprecated string is not sequential", def: EntityDef{IDType: IDTypeString}, want: false},
 	}
 
 	for _, tt := range tests {
@@ -356,21 +475,11 @@ func TestEntityDef_IsStringID(t *testing.T) {
 		def  EntityDef
 		want bool
 	}{
-		{
-			name: "empty is not string",
-			def:  EntityDef{},
-			want: false,
-		},
-		{
-			name: "sequential is not string",
-			def:  EntityDef{IDType: IDTypeSequential},
-			want: false,
-		},
-		{
-			name: "string is string",
-			def:  EntityDef{IDType: IDTypeString},
-			want: true,
-		},
+		{name: "empty is not string", def: EntityDef{}, want: false},
+		{name: "auto is not string", def: EntityDef{IDType: IDTypeAuto}, want: false},
+		{name: "manual is string", def: EntityDef{IDType: IDTypeManual}, want: true},
+		{name: "deprecated sequential is not string", def: EntityDef{IDType: IDTypeSequential}, want: false},
+		{name: "deprecated string is string", def: EntityDef{IDType: IDTypeString}, want: true},
 	}
 
 	for _, tt := range tests {
@@ -391,7 +500,30 @@ func TestParse_IDTypeValidation(t *testing.T) {
 		errType error
 	}{
 		{
-			name: "valid sequential id_type",
+			name: "valid auto id_type",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_type: auto
+    id_patterns: ["REQ-"]
+`,
+			wantErr: false,
+		},
+		{
+			name: "valid manual id_type",
+			yaml: `
+version: "1.0"
+entities:
+  component:
+    label: Component
+    id_type: manual
+`,
+			wantErr: false,
+		},
+		{
+			name: "deprecated sequential id_type still valid",
 			yaml: `
 version: "1.0"
 entities:
@@ -403,7 +535,7 @@ entities:
 			wantErr: false,
 		},
 		{
-			name: "valid string id_type",
+			name: "deprecated string id_type still valid",
 			yaml: `
 version: "1.0"
 entities:
@@ -414,7 +546,7 @@ entities:
 			wantErr: false,
 		},
 		{
-			name: "empty id_type is valid (defaults to sequential)",
+			name: "empty id_type is valid (defaults to auto)",
 			yaml: `
 version: "1.0"
 entities:

--- a/internal/migration/id_type_rename.go
+++ b/internal/migration/id_type_rename.go
@@ -1,0 +1,131 @@
+package migration
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func init() {
+	Register(&IDTypeRenameMigration{})
+}
+
+// IDTypeRenameMigration renames deprecated id_type values:
+// - "sequential" -> "auto"
+// - "string" -> "manual"
+type IDTypeRenameMigration struct{}
+
+func (m *IDTypeRenameMigration) Name() string {
+	return "id-type-rename"
+}
+
+func (m *IDTypeRenameMigration) Description() string {
+	return `Rename id_type values: "sequential" → "auto", "string" → "manual"`
+}
+
+func (m *IDTypeRenameMigration) FileTypes() []FileType {
+	return []FileType{FileTypeMetamodel}
+}
+
+func (m *IDTypeRenameMigration) Detect(doc *yaml.Node) bool {
+	root := GetDocumentRoot(doc)
+	if root == nil {
+		return false
+	}
+
+	// Look for entities section
+	entities := GetMapValue(root, "entities")
+	if entities == nil || entities.Kind != yaml.MappingNode {
+		return false
+	}
+
+	// Check each entity definition for deprecated id_type values
+	for i := 1; i < len(entities.Content); i += 2 {
+		entityDef := entities.Content[i]
+		if entityDef.Kind != yaml.MappingNode {
+			continue
+		}
+
+		idTypeValue := GetMapValue(entityDef, "id_type")
+		if idTypeValue != nil && idTypeValue.Kind == yaml.ScalarNode {
+			if idTypeValue.Value == "sequential" || idTypeValue.Value == "string" {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (m *IDTypeRenameMigration) Apply(doc *yaml.Node) error {
+	root := GetDocumentRoot(doc)
+	if root == nil {
+		return fmt.Errorf("empty document")
+	}
+
+	entities := GetMapValue(root, "entities")
+	if entities == nil || entities.Kind != yaml.MappingNode {
+		return nil // No entities section, nothing to migrate
+	}
+
+	count := 0
+
+	// Iterate through entity definitions
+	for i := 1; i < len(entities.Content); i += 2 {
+		entityDef := entities.Content[i]
+		if entityDef.Kind != yaml.MappingNode {
+			continue
+		}
+
+		idTypeValue := GetMapValue(entityDef, "id_type")
+		if idTypeValue != nil && idTypeValue.Kind == yaml.ScalarNode {
+			switch idTypeValue.Value {
+			case "sequential":
+				idTypeValue.Value = "auto"
+				count++
+			case "string":
+				idTypeValue.Value = "manual"
+				count++
+			}
+		}
+	}
+
+	// Note: count == 0 is valid if Apply is called on a file that was already migrated
+	// The runner checks Detect() before Apply(), so this shouldn't normally happen,
+	// but we don't treat it as an error.
+
+	return nil
+}
+
+// CountDeprecatedIDTypes returns the number of deprecated id_type values found.
+// Useful for detailed reporting.
+func (m *IDTypeRenameMigration) CountDeprecatedIDTypes(doc *yaml.Node) (sequential, stringType int) {
+	root := GetDocumentRoot(doc)
+	if root == nil {
+		return 0, 0
+	}
+
+	entities := GetMapValue(root, "entities")
+	if entities == nil || entities.Kind != yaml.MappingNode {
+		return 0, 0
+	}
+
+	for i := 1; i < len(entities.Content); i += 2 {
+		entityDef := entities.Content[i]
+		if entityDef.Kind != yaml.MappingNode {
+			continue
+		}
+
+		idTypeValue := GetMapValue(entityDef, "id_type")
+		if idTypeValue != nil && idTypeValue.Kind == yaml.ScalarNode {
+			switch idTypeValue.Value {
+			case "sequential":
+				sequential++
+			case "string":
+				stringType++
+			}
+		}
+	}
+
+	return sequential, stringType
+}

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -1,0 +1,65 @@
+// Package migration provides schema migration support for rela project files.
+// It detects deprecated syntax patterns and transforms files while preserving
+// comments and formatting using yaml.Node AST manipulation.
+package migration
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+// FileType identifies which project files a migration applies to.
+type FileType string
+
+const (
+	FileTypeMetamodel FileType = "metamodel" // metamodel.yaml
+	FileTypeViews     FileType = "views"     // views.yaml (future)
+)
+
+// Migration defines the interface for schema migrations.
+// Migrations operate on yaml.Node trees to preserve comments and formatting.
+type Migration interface {
+	// Name returns a unique identifier for this migration (e.g., "id-type-rename").
+	Name() string
+
+	// Description returns a human-readable description of what this migration does.
+	Description() string
+
+	// FileTypes returns which file types this migration applies to.
+	FileTypes() []FileType
+
+	// Detect checks if the given YAML document needs this migration.
+	// It should return true if deprecated patterns are found.
+	Detect(doc *yaml.Node) bool
+
+	// Apply transforms the YAML document in-place.
+	// It should only be called if Detect returned true.
+	Apply(doc *yaml.Node) error
+}
+
+// registry holds all registered migrations in order of application.
+var registry []Migration
+
+// Register adds a migration to the registry.
+// Migrations are applied in registration order.
+func Register(m Migration) {
+	registry = append(registry, m)
+}
+
+// All returns all registered migrations.
+func All() []Migration {
+	return registry
+}
+
+// ForFileType returns migrations that apply to the given file type.
+func ForFileType(ft FileType) []Migration {
+	var result []Migration
+	for _, m := range registry {
+		for _, t := range m.FileTypes() {
+			if t == ft {
+				result = append(result, m)
+				break
+			}
+		}
+	}
+	return result
+}

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -1,0 +1,412 @@
+package migration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestIDTypeRenameMigration_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantFind bool
+	}{
+		{
+			name: "detects sequential",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_type: sequential
+`,
+			wantFind: true,
+		},
+		{
+			name: "detects string",
+			yaml: `
+version: "1.0"
+entities:
+  component:
+    label: Component
+    id_type: string
+`,
+			wantFind: true,
+		},
+		{
+			name: "detects both",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_type: sequential
+  component:
+    label: Component
+    id_type: string
+`,
+			wantFind: true,
+		},
+		{
+			name: "no detection for auto",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_type: auto
+`,
+			wantFind: false,
+		},
+		{
+			name: "no detection for manual",
+			yaml: `
+version: "1.0"
+entities:
+  component:
+    label: Component
+    id_type: manual
+`,
+			wantFind: false,
+		},
+		{
+			name: "no detection when id_type is missing",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+`,
+			wantFind: false,
+		},
+		{
+			name: "no detection for empty entities",
+			yaml: `
+version: "1.0"
+entities: {}
+`,
+			wantFind: false,
+		},
+	}
+
+	m := &IDTypeRenameMigration{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var doc yaml.Node
+			if err := yaml.Unmarshal([]byte(tt.yaml), &doc); err != nil {
+				t.Fatalf("failed to parse YAML: %v", err)
+			}
+
+			got := m.Detect(&doc)
+			if got != tt.wantFind {
+				t.Errorf("Detect() = %v, want %v", got, tt.wantFind)
+			}
+		})
+	}
+}
+
+func TestIDTypeRenameMigration_Apply(t *testing.T) {
+	tests := []struct {
+		name       string
+		yaml       string
+		wantValues map[string]string // entity name -> expected id_type value
+	}{
+		{
+			name: "converts sequential to auto",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_type: sequential
+`,
+			wantValues: map[string]string{"requirement": "auto"},
+		},
+		{
+			name: "converts string to manual",
+			yaml: `
+version: "1.0"
+entities:
+  component:
+    label: Component
+    id_type: string
+`,
+			wantValues: map[string]string{"component": "manual"},
+		},
+		{
+			name: "converts multiple entities",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_type: sequential
+  component:
+    label: Component
+    id_type: string
+`,
+			wantValues: map[string]string{
+				"requirement": "auto",
+				"component":   "manual",
+			},
+		},
+		{
+			name: "leaves auto unchanged",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_type: auto
+`,
+			wantValues: map[string]string{"requirement": "auto"},
+		},
+	}
+
+	m := &IDTypeRenameMigration{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var doc yaml.Node
+			if err := yaml.Unmarshal([]byte(tt.yaml), &doc); err != nil {
+				t.Fatalf("failed to parse YAML: %v", err)
+			}
+
+			if err := m.Apply(&doc); err != nil {
+				t.Fatalf("Apply() error = %v", err)
+			}
+
+			// Verify the values
+			root := GetDocumentRoot(&doc)
+			entities := GetMapValue(root, "entities")
+			if entities == nil {
+				t.Fatal("entities not found")
+			}
+
+			for i := 0; i < len(entities.Content)-1; i += 2 {
+				entityName := entities.Content[i].Value
+				entityDef := entities.Content[i+1]
+				idTypeValue := GetMapValue(entityDef, "id_type")
+
+				if expected, ok := tt.wantValues[entityName]; ok {
+					if idTypeValue == nil {
+						t.Errorf("entity %s: id_type not found", entityName)
+					} else if idTypeValue.Value != expected {
+						t.Errorf("entity %s: id_type = %q, want %q", entityName, idTypeValue.Value, expected)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestIDTypeRenameMigration_PreservesComments(t *testing.T) {
+	input := `# Metamodel config
+version: "1.0"
+
+entities:
+  # Requirements entity
+  requirement:
+    label: Requirement
+    id_type: sequential  # Use sequential IDs
+    id_patterns: ["REQ-"]
+`
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(input), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+
+	m := &IDTypeRenameMigration{}
+	if err := m.Apply(&doc); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	// Re-encode and check for comments
+	output, err := yaml.Marshal(&doc)
+	if err != nil {
+		t.Fatalf("failed to marshal YAML: %v", err)
+	}
+
+	outputStr := string(output)
+
+	// Check that the value was changed
+	if !strings.Contains(outputStr, "id_type: auto") {
+		t.Error("id_type was not changed to auto")
+	}
+
+	// Check that comments are preserved (yaml.v3 preserves head comments)
+	if !strings.Contains(outputStr, "# Metamodel config") {
+		t.Error("top comment was not preserved")
+	}
+	if !strings.Contains(outputStr, "# Requirements entity") {
+		t.Error("entity comment was not preserved")
+	}
+}
+
+func TestDetect_Integration(t *testing.T) {
+	// Create a temp file with deprecated syntax
+	content := `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_type: sequential
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "metamodel.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	detections, err := Detect(tmpFile, FileTypeMetamodel)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	if len(detections) != 1 {
+		t.Errorf("got %d detections, want 1", len(detections))
+	}
+
+	if len(detections) > 0 && detections[0].Migration.Name() != "id-type-rename" {
+		t.Errorf("got migration %q, want %q", detections[0].Migration.Name(), "id-type-rename")
+	}
+}
+
+func TestApply_Integration(t *testing.T) {
+	// Create a temp file with deprecated syntax
+	content := `version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_type: sequential
+  component:
+    label: Component
+    id_type: string
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "metamodel.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	result, err := Apply(tmpFile, FileTypeMetamodel)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	if !result.NeedsMigration() {
+		t.Error("expected migration to be needed")
+	}
+
+	if result.HasErrors() {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+
+	if result.MigrationsApplied() != 1 {
+		t.Errorf("got %d migrations applied, want 1", result.MigrationsApplied())
+	}
+
+	// Read the file and verify it was updated
+	updated, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read updated file: %v", err)
+	}
+
+	updatedStr := string(updated)
+
+	if strings.Contains(updatedStr, "id_type: sequential") {
+		t.Error("file still contains 'sequential'")
+	}
+	if strings.Contains(updatedStr, "id_type: string") {
+		t.Error("file still contains 'string'")
+	}
+	if !strings.Contains(updatedStr, "id_type: auto") {
+		t.Error("file does not contain 'auto'")
+	}
+	if !strings.Contains(updatedStr, "id_type: manual") {
+		t.Error("file does not contain 'manual'")
+	}
+}
+
+func TestCheckOnly_DoesNotModify(t *testing.T) {
+	content := `version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_type: sequential
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "metamodel.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	result, err := CheckOnly(tmpFile, FileTypeMetamodel)
+	if err != nil {
+		t.Fatalf("CheckOnly() error = %v", err)
+	}
+
+	if !result.NeedsMigration() {
+		t.Error("expected migration to be needed")
+	}
+
+	// Verify file was not modified
+	after, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+
+	if string(after) != content {
+		t.Error("CheckOnly modified the file")
+	}
+}
+
+func TestMigrationError(t *testing.T) {
+	err := &Error{
+		FilePath: "metamodel.yaml",
+		Detections: []DetectionResult{
+			{Description: "test migration"},
+		},
+	}
+
+	errStr := err.Error()
+
+	if !strings.Contains(errStr, "metamodel.yaml") {
+		t.Error("error should contain file path")
+	}
+	if !strings.Contains(errStr, "test migration") {
+		t.Error("error should contain migration description")
+	}
+	if !strings.Contains(errStr, "rela migrate") {
+		t.Error("error should suggest running rela migrate")
+	}
+}
+
+func TestForFileType(t *testing.T) {
+	migrations := ForFileType(FileTypeMetamodel)
+
+	if len(migrations) == 0 {
+		t.Error("expected at least one migration for metamodel files")
+	}
+
+	found := false
+	for _, m := range migrations {
+		if m.Name() == "id-type-rename" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("expected to find id-type-rename migration")
+	}
+}

--- a/internal/migration/runner.go
+++ b/internal/migration/runner.go
@@ -1,0 +1,191 @@
+package migration
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DetectionResult holds information about a detected migration need.
+type DetectionResult struct {
+	Migration   Migration
+	Description string
+	Count       int // Number of occurrences found (for informational purposes)
+}
+
+// Result holds information about an applied migration.
+type Result struct {
+	Migration Migration
+	Applied   bool
+	Error     error
+}
+
+// FileResult holds the results of migrating a single file.
+type FileResult struct {
+	Path       string
+	FileType   FileType
+	Detections []DetectionResult
+	Results    []Result
+	Error      error
+}
+
+// Detect checks a YAML file for migrations that need to be applied.
+// Returns a list of migrations that detected deprecated patterns.
+func Detect(path string, ft FileType) ([]DetectionResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading file: %w", err)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing YAML: %w", err)
+	}
+
+	return DetectFromNode(&doc, ft), nil
+}
+
+// DetectFromNode checks a parsed YAML document for migrations.
+func DetectFromNode(doc *yaml.Node, ft FileType) []DetectionResult {
+	var results []DetectionResult
+	migrations := ForFileType(ft)
+
+	for _, m := range migrations {
+		if m.Detect(doc) {
+			results = append(results, DetectionResult{
+				Migration:   m,
+				Description: m.Description(),
+			})
+		}
+	}
+
+	return results
+}
+
+// Apply runs all applicable migrations on a file.
+// Returns results for each migration attempted.
+func Apply(path string, ft FileType) (*FileResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading file: %w", err)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing YAML: %w", err)
+	}
+
+	result := &FileResult{
+		Path:     path,
+		FileType: ft,
+	}
+
+	// First detect what needs migration
+	result.Detections = DetectFromNode(&doc, ft)
+
+	if len(result.Detections) == 0 {
+		return result, nil
+	}
+
+	// Apply each detected migration
+	for _, detection := range result.Detections {
+		mr := Result{Migration: detection.Migration}
+
+		if err := detection.Migration.Apply(&doc); err != nil {
+			mr.Error = err
+		} else {
+			mr.Applied = true
+		}
+
+		result.Results = append(result.Results, mr)
+	}
+
+	// Check if any migrations failed - store error in result but don't return it as function error
+	for _, mr := range result.Results {
+		if mr.Error != nil {
+			result.Error = fmt.Errorf("migration %s failed: %w", mr.Migration.Name(), mr.Error)
+			return result, result.Error
+		}
+	}
+
+	// Write the migrated file back
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(&doc); err != nil {
+		result.Error = fmt.Errorf("encoding YAML: %w", err)
+		return result, nil
+	}
+	if err := encoder.Close(); err != nil {
+		result.Error = fmt.Errorf("closing encoder: %w", err)
+		return result, nil
+	}
+
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		result.Error = fmt.Errorf("writing file: %w", err)
+		return result, nil
+	}
+
+	return result, nil
+}
+
+// CheckOnly runs detection without applying changes.
+// Useful for CI or pre-flight checks.
+func CheckOnly(path string, ft FileType) (*FileResult, error) {
+	detections, err := Detect(path, ft)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FileResult{
+		Path:       path,
+		FileType:   ft,
+		Detections: detections,
+	}, nil
+}
+
+// NeedsMigration returns true if any migrations were detected.
+func (r *FileResult) NeedsMigration() bool {
+	return len(r.Detections) > 0
+}
+
+// MigrationsApplied returns the count of successfully applied migrations.
+func (r *FileResult) MigrationsApplied() int {
+	count := 0
+	for _, mr := range r.Results {
+		if mr.Applied {
+			count++
+		}
+	}
+	return count
+}
+
+// HasErrors returns true if any migrations failed.
+func (r *FileResult) HasErrors() bool {
+	return r.Error != nil
+}
+
+// Error represents an error that includes suggestions for migration.
+type Error struct {
+	FilePath   string
+	Detections []DetectionResult
+}
+
+func (e *Error) Error() string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%s uses deprecated syntax:\n", e.FilePath)
+	for _, d := range e.Detections {
+		fmt.Fprintf(&buf, "  - %s\n", d.Description)
+	}
+	buf.WriteString("\nRun 'rela migrate' to update your project files.")
+	return buf.String()
+}
+
+// IsMigrationError checks if an error is a migration Error.
+func IsMigrationError(err error) bool {
+	var migErr *Error
+	return errors.As(err, &migErr)
+}

--- a/internal/migration/yaml_util.go
+++ b/internal/migration/yaml_util.go
@@ -1,0 +1,182 @@
+package migration
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+// NodeKind helpers for yaml.Node navigation.
+
+// GetMapValue finds a value in a mapping node by key name.
+// Returns nil if the key doesn't exist or the node isn't a mapping.
+func GetMapValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// GetMapKey finds a key node in a mapping node by key name.
+// Returns nil if the key doesn't exist or the node isn't a mapping.
+func GetMapKey(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i]
+		}
+	}
+	return nil
+}
+
+// SetMapValue sets a value in a mapping node by key name.
+// If the key exists, the value is updated. If not, the key-value pair is added.
+func SetMapValue(node *yaml.Node, key, value string) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			node.Content[i+1].Value = value
+			return
+		}
+	}
+	// Key doesn't exist, add it
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: key}
+	valueNode := &yaml.Node{Kind: yaml.ScalarNode, Value: value}
+	node.Content = append(node.Content, keyNode, valueNode)
+}
+
+// RenameMapKey renames a key in a mapping node.
+// Returns true if the key was found and renamed.
+func RenameMapKey(node *yaml.Node, oldKey, newKey string) bool {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == oldKey {
+			node.Content[i].Value = newKey
+			return true
+		}
+	}
+	return false
+}
+
+// WalkMappings calls fn for each mapping node in the tree (depth-first).
+// If fn returns false, traversal stops.
+func WalkMappings(node *yaml.Node, fn func(node *yaml.Node) bool) bool {
+	if node == nil {
+		return true
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode:
+		for _, child := range node.Content {
+			if !WalkMappings(child, fn) {
+				return false
+			}
+		}
+	case yaml.MappingNode:
+		if !fn(node) {
+			return false
+		}
+		for _, child := range node.Content {
+			if !WalkMappings(child, fn) {
+				return false
+			}
+		}
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			if !WalkMappings(child, fn) {
+				return false
+			}
+		}
+	case yaml.ScalarNode, yaml.AliasNode:
+		// Scalar and alias nodes have no children to walk
+	}
+	return true
+}
+
+// FindScalarValues finds all scalar nodes with the given value anywhere in the tree.
+// Useful for detecting deprecated values.
+func FindScalarValues(node *yaml.Node, value string) []*yaml.Node {
+	var results []*yaml.Node
+	walkAll(node, func(n *yaml.Node) {
+		if n.Kind == yaml.ScalarNode && n.Value == value {
+			results = append(results, n)
+		}
+	})
+	return results
+}
+
+// FindMapEntriesByKey finds all mapping entries where the key matches.
+// Returns pairs of (key node, value node).
+func FindMapEntriesByKey(node *yaml.Node, key string) [][2]*yaml.Node {
+	var results [][2]*yaml.Node
+	WalkMappings(node, func(mapping *yaml.Node) bool {
+		for i := 0; i < len(mapping.Content)-1; i += 2 {
+			if mapping.Content[i].Value == key {
+				results = append(results, [2]*yaml.Node{mapping.Content[i], mapping.Content[i+1]})
+			}
+		}
+		return true
+	})
+	return results
+}
+
+// ReplaceScalarValue replaces all occurrences of oldValue with newValue.
+// Only affects scalar nodes. Returns count of replacements made.
+func ReplaceScalarValue(node *yaml.Node, oldValue, newValue string) int {
+	count := 0
+	walkAll(node, func(n *yaml.Node) {
+		if n.Kind == yaml.ScalarNode && n.Value == oldValue {
+			n.Value = newValue
+			count++
+		}
+	})
+	return count
+}
+
+// ReplaceMapValueByKey replaces values of entries with matching key.
+// Only replaces if the current value matches oldValue.
+// Returns count of replacements made.
+func ReplaceMapValueByKey(node *yaml.Node, key, oldValue, newValue string) int {
+	count := 0
+	entries := FindMapEntriesByKey(node, key)
+	for _, entry := range entries {
+		valueNode := entry[1]
+		if valueNode.Kind == yaml.ScalarNode && valueNode.Value == oldValue {
+			valueNode.Value = newValue
+			count++
+		}
+	}
+	return count
+}
+
+// walkAll visits every node in the tree.
+func walkAll(node *yaml.Node, fn func(*yaml.Node)) {
+	if node == nil {
+		return
+	}
+	fn(node)
+	for _, child := range node.Content {
+		walkAll(child, fn)
+	}
+}
+
+// GetDocumentRoot returns the root mapping node from a document node.
+// YAML documents typically have a single document node containing the actual content.
+func GetDocumentRoot(doc *yaml.Node) *yaml.Node {
+	if doc == nil {
+		return nil
+	}
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		return doc.Content[0]
+	}
+	return doc
+}

--- a/internal/migration/yaml_util_test.go
+++ b/internal/migration/yaml_util_test.go
@@ -1,0 +1,288 @@
+package migration
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestGetMapValue(t *testing.T) {
+	yamlContent := `
+key1: value1
+key2: value2
+nested:
+  inner: innervalue
+`
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlContent), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+
+	root := GetDocumentRoot(&doc)
+
+	tests := []struct {
+		name    string
+		key     string
+		wantVal string
+		wantNil bool
+	}{
+		{name: "existing key", key: "key1", wantVal: "value1"},
+		{name: "another existing key", key: "key2", wantVal: "value2"},
+		{name: "non-existing key", key: "key3", wantNil: true},
+		{name: "nested key", key: "nested", wantNil: false}, // Returns the nested map
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetMapValue(root, tt.key)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("GetMapValue() = %v, want nil", got)
+				}
+			} else {
+				if got == nil {
+					t.Error("GetMapValue() = nil, want non-nil")
+				} else if tt.wantVal != "" && got.Value != tt.wantVal {
+					t.Errorf("GetMapValue().Value = %q, want %q", got.Value, tt.wantVal)
+				}
+			}
+		})
+	}
+}
+
+func TestGetMapValue_NilAndNonMap(t *testing.T) {
+	// Test nil node
+	if got := GetMapValue(nil, "key"); got != nil {
+		t.Error("GetMapValue(nil) should return nil")
+	}
+
+	// Test non-map node
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(`- item1`), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+
+	root := GetDocumentRoot(&doc)
+	if got := GetMapValue(root, "key"); got != nil {
+		t.Error("GetMapValue on sequence should return nil")
+	}
+}
+
+func TestSetMapValue(t *testing.T) {
+	yamlContent := `
+key1: value1
+key2: value2
+`
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlContent), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+
+	root := GetDocumentRoot(&doc)
+
+	// Update existing key
+	SetMapValue(root, "key1", "newvalue1")
+	if got := GetMapValue(root, "key1"); got == nil || got.Value != "newvalue1" {
+		t.Errorf("SetMapValue didn't update existing key")
+	}
+
+	// Add new key
+	SetMapValue(root, "key3", "value3")
+	if got := GetMapValue(root, "key3"); got == nil || got.Value != "value3" {
+		t.Errorf("SetMapValue didn't add new key")
+	}
+}
+
+func TestRenameMapKey(t *testing.T) {
+	yamlContent := `
+oldkey: value
+other: othervalue
+`
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlContent), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+
+	root := GetDocumentRoot(&doc)
+
+	// Rename existing key
+	if !RenameMapKey(root, "oldkey", "newkey") {
+		t.Error("RenameMapKey should return true for existing key")
+	}
+
+	if got := GetMapValue(root, "oldkey"); got != nil {
+		t.Error("old key should not exist after rename")
+	}
+
+	if got := GetMapValue(root, "newkey"); got == nil || got.Value != "value" {
+		t.Error("new key should exist with original value")
+	}
+
+	// Try to rename non-existing key
+	if RenameMapKey(root, "nonexistent", "something") {
+		t.Error("RenameMapKey should return false for non-existing key")
+	}
+}
+
+func TestFindMapEntriesByKey(t *testing.T) {
+	yamlContent := `
+entities:
+  req:
+    id_type: sequential
+  comp:
+    id_type: string
+  other:
+    label: Other
+`
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlContent), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+
+	entries := FindMapEntriesByKey(&doc, "id_type")
+
+	if len(entries) != 2 {
+		t.Errorf("got %d entries, want 2", len(entries))
+	}
+
+	values := make(map[string]bool)
+	for _, entry := range entries {
+		values[entry[1].Value] = true
+	}
+
+	if !values["sequential"] || !values["string"] {
+		t.Error("expected to find both 'sequential' and 'string' values")
+	}
+}
+
+func TestReplaceMapValueByKey(t *testing.T) {
+	yamlContent := `
+entities:
+  req:
+    id_type: sequential
+  comp:
+    id_type: string
+  req2:
+    id_type: sequential
+`
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlContent), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+
+	// Replace all 'sequential' with 'auto'
+	count := ReplaceMapValueByKey(&doc, "id_type", "sequential", "auto")
+
+	if count != 2 {
+		t.Errorf("replaced %d values, want 2", count)
+	}
+
+	// Verify replacements
+	entries := FindMapEntriesByKey(&doc, "id_type")
+	for _, entry := range entries {
+		if entry[1].Value == "sequential" {
+			t.Error("found unreplaced 'sequential' value")
+		}
+	}
+
+	// Count 'auto' values
+	autoCount := 0
+	for _, entry := range entries {
+		if entry[1].Value == "auto" {
+			autoCount++
+		}
+	}
+	if autoCount != 2 {
+		t.Errorf("got %d 'auto' values, want 2", autoCount)
+	}
+}
+
+func TestWalkMappings(t *testing.T) {
+	yamlContent := `
+level1:
+  level2:
+    level3:
+      key: value
+  another: value
+`
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlContent), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+
+	count := 0
+	WalkMappings(&doc, func(_ *yaml.Node) bool {
+		count++
+		return true
+	})
+
+	// Should visit: root, level1, level2, level3
+	if count != 4 {
+		t.Errorf("visited %d mappings, want 4", count)
+	}
+
+	// Test early termination
+	count = 0
+	WalkMappings(&doc, func(_ *yaml.Node) bool {
+		count++
+		return count < 2 // Stop after 2
+	})
+
+	if count != 2 {
+		t.Errorf("early termination: visited %d mappings, want 2", count)
+	}
+}
+
+func TestFindScalarValues(t *testing.T) {
+	yamlContent := `
+entities:
+  req:
+    id_type: sequential
+  comp:
+    id_type: sequential
+  other:
+    id_type: string
+`
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlContent), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+
+	found := FindScalarValues(&doc, "sequential")
+	if len(found) != 2 {
+		t.Errorf("found %d occurrences of 'sequential', want 2", len(found))
+	}
+
+	found = FindScalarValues(&doc, "string")
+	if len(found) != 1 {
+		t.Errorf("found %d occurrences of 'string', want 1", len(found))
+	}
+
+	found = FindScalarValues(&doc, "nonexistent")
+	if len(found) != 0 {
+		t.Errorf("found %d occurrences of 'nonexistent', want 0", len(found))
+	}
+}
+
+func TestGetDocumentRoot(t *testing.T) {
+	yamlContent := `key: value`
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlContent), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+
+	root := GetDocumentRoot(&doc)
+	if root == nil {
+		t.Fatal("GetDocumentRoot returned nil")
+	}
+
+	if root.Kind != yaml.MappingNode {
+		t.Errorf("root kind = %d, want %d (MappingNode)", root.Kind, yaml.MappingNode)
+	}
+
+	// Test nil
+	if GetDocumentRoot(nil) != nil {
+		t.Error("GetDocumentRoot(nil) should return nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Implement a migration system that automatically detects and transforms deprecated syntax in project files (metamodel.yaml, etc.) while preserving comments and formatting
- Add `rela migrate` command with `--check` flag for CI integration
- First migration: rename deprecated id_type values (`sequential` → `auto`, `string` → `manual`)

## Features

- **AST-level transformation**: Uses `yaml.Node` to preserve comments and formatting during migration
- **Automatic detection**: Metamodel loader detects deprecated syntax and exits with helpful error message
- **CI-friendly**: `rela migrate --check` exits with code 1 if migrations are needed
- **Extensible**: Simple `Migration` interface for adding new migrations

## Architecture

New `internal/migration/` package:
- `migration.go` - Migration interface and registry
- `runner.go` - Detection and application logic
- `yaml_util.go` - Helpers for safe AST manipulation  
- `id_type_rename.go` - First migration implementation

## Test plan

- [x] Unit tests for migration detection and application
- [x] Unit tests for YAML AST helpers
- [x] Integration test for file round-trip with comment preservation
- [x] Manual test of `rela migrate` and `rela migrate --check`
- [x] All existing tests pass