### PR TITLE
Fix markdown lint errors

### DIFF
--- a/SEARCH-FEATURE-TEST-REPORT.md
+++ b/SEARCH-FEATURE-TEST-REPORT.md
@@ -7,7 +7,8 @@
 
 ## Executive Summary
 
-The newly implemented live search feature with advanced filtering has been thoroughly tested and verified to work correctly. All 32 test cases passed successfully, including:
+The newly implemented live search feature with advanced filtering has been thoroughly tested and
+verified to work correctly. All 32 test cases passed successfully, including:
 
 - ✅ Live search functionality (debounced, no Enter required)
 - ✅ Text search with AND logic
@@ -24,6 +25,7 @@ The newly implemented live search feature with advanced filtering has been thoro
 ### Test Project Setup
 
 Created a minimal test project at `/tmp/rela-test-project` with:
+
 - **Metamodel:** 3 entity types (requirement, decision, solution)
 - **Test Data:** 8 entities across 3 types
   - 4 Requirements (REQ-001 to REQ-004)
@@ -51,7 +53,8 @@ Created a minimal test project at `/tmp/rela-test-project` with:
 All existing unit tests continue to pass:
 
 #### Search Parser Tests (16 tests)
-```
+
+```text
 ✓ TestParseQuery_Empty
 ✓ TestParseQuery_SimpleText
 ✓ TestParseQuery_MultipleWords
@@ -73,7 +76,9 @@ All existing unit tests continue to pass:
 **Result:** 16/16 passed (100%)
 
 #### Filter Package Tests (50+ tests)
+
 All tests in the filter package pass, including:
+
 - Property parsing and validation
 - Value matching for all operators (=, !=, <, <=, >, >=, =~, =*)
 - Type-aware comparisons (string, integer, date, boolean, enum)
@@ -86,7 +91,8 @@ All tests in the filter package pass, including:
 Created comprehensive integration test suite (`search_integration_test.go`) with 32 test cases:
 
 #### Free Text Search (6 tests)
-```
+
+```text
 ✓ Empty query returns nothing
 ✓ Simple text search - 'authentication' (4 results)
 ✓ Simple text search - 'OAuth' (2 results)
@@ -96,7 +102,8 @@ Created comprehensive integration test suite (`search_integration_test.go`) with
 ```
 
 #### Type Filtering (4 tests)
-```
+
+```text
 ✓ Type filter - requirements only (4 results)
 ✓ Type filter - decisions only (2 results)
 ✓ Type filter - solutions only (2 results)
@@ -104,7 +111,8 @@ Created comprehensive integration test suite (`search_integration_test.go`) with
 ```
 
 #### Property Filtering (6 tests)
-```
+
+```text
 ✓ Property filter - status=published (2 results)
 ✓ Property filter - status=draft (2 results)
 ✓ Property filter - status!=draft (6 results)
@@ -114,13 +122,15 @@ Created comprehensive integration test suite (`search_integration_test.go`) with
 ```
 
 #### Status Shortcut (2 tests)
-```
+
+```text
 ✓ Status shortcut - status:published (2 results)
 ✓ Status shortcut - status:draft (2 results)
 ```
 
 #### Combined Filters (6 tests)
-```
+
+```text
 ✓ Combined: type + property (2 results)
 ✓ Combined: type + property + text (1 result)
 ✓ Combined: type + priority filter (3 results)
@@ -130,13 +140,15 @@ Created comprehensive integration test suite (`search_integration_test.go`) with
 ```
 
 #### Advanced Features (3 tests)
-```
+
+```text
 ✓ Property with glob pattern - prop:category=*api* (1 result)
 ✓ No results for non-existent text (0 results)
 ```
 
 #### Error Handling (5 tests)
-```
+
+```text
 ✓ Invalid property filter syntax - parse error detected
 ✓ Empty type filter - parse error detected
 ✓ Empty status filter - parse error detected
@@ -147,17 +159,19 @@ Created comprehensive integration test suite (`search_integration_test.go`) with
 
 ### Performance Benchmarks
 
-```
-BenchmarkSearch-10    	  615411	      1928 ns/op	    1448 B/op	      23 allocs/op
+```text
+BenchmarkSearch-10      615411        1928 ns/op     1448 B/op       23 allocs/op
 ```
 
 **Analysis:**
+
 - **Search Time:** ~1.9 microseconds per search (8 entities)
 - **Memory:** 1,448 bytes per operation
 - **Allocations:** 23 allocations per operation
 - **Throughput:** ~500,000 searches per second
 
 **Performance Rating:** ✅ EXCELLENT
+
 - Well within target (<10ms for 100 entities, <50ms for 1000 entities)
 - Debounce delay of 200ms provides smooth UX without performance impact
 
@@ -168,6 +182,7 @@ BenchmarkSearch-10    	  615411	      1928 ns/op	    1448 B/op	      23 allocs/o
 ✅ **Implementation Status:** Complete
 
 **How it works:**
+
 1. User types in search box
 2. Each keystroke triggers `triggerSearch()`
 3. Search is debounced by 200ms using `time.Sleep()`
@@ -176,6 +191,7 @@ BenchmarkSearch-10    	  615411	      1928 ns/op	    1448 B/op	      23 allocs/o
 6. Stale results are ignored using version tracking
 
 **Code Locations:**
+
 - `/internal/tui/search.go:113-128` - triggerSearch()
 - `/internal/tui/search.go:130-147` - HandleSearchQuery()
 - `/internal/tui/search.go:149-161` - HandleSearchResults()
@@ -204,6 +220,7 @@ BenchmarkSearch-10    	  615411	      1928 ns/op	    1448 B/op	      23 allocs/o
 ✅ **Implementation Status:** Complete
 
 **Highlighting Rules:**
+
 - `type:` filters → Blue (color 33)
 - `prop:` and `status:` filters → Green (color 42)
 - Quoted strings `"..."` → Yellow (color 226)
@@ -218,12 +235,14 @@ BenchmarkSearch-10    	  615411	      1928 ns/op	    1448 B/op	      23 allocs/o
 ✅ **Implementation Status:** Complete
 
 **Error Detection:**
+
 - Empty filter values (`type:`, `status:`, `prop:`)
 - Invalid property filter syntax
 - Invalid operators
 - Parse errors from filter package
 
 **Error Display:**
+
 - Errors shown in red below search box with ⚠ symbol
 - Multiple errors joined with semicolons
 - UI remains responsive during errors
@@ -235,17 +254,20 @@ BenchmarkSearch-10    	  615411	      1928 ns/op	    1448 B/op	      23 allocs/o
 ### UI/UX Elements
 
 ✅ **Search Input Box**
+
 - Rounded border (blue)
 - Cursor visualization with underscore
 - Syntax highlighting applied
 - Width: 70 characters
 
 ✅ **Help Text**
+
 - Shows "Type to search (live)" normally
 - Shows "Searching..." during search
 - Context-sensitive help based on state
 
 ✅ **Results Display**
+
 - Shows result count: "Found N results:"
 - Lazy rendering (only visible items)
 - Scrolling with j/k or arrow keys
@@ -253,11 +275,13 @@ BenchmarkSearch-10    	  615411	      1928 ns/op	    1448 B/op	      23 allocs/o
 - Entity ID in blue, type in gray
 
 ✅ **Example Syntax Display**
+
 - Shown when search box is empty
 - Provides clear examples of all filter types
 - Includes combined filter examples
 
 ✅ **Status Indicators**
+
 - Loading state during search
 - Result count display
 - Parse error messages
@@ -270,18 +294,21 @@ BenchmarkSearch-10    	  615411	      1928 ns/op	    1448 B/op	      23 allocs/o
 ### Architecture
 
 ✅ **Clean Separation of Concerns**
+
 - Parser logic in separate package (`searchparser`)
 - Filter matching uses existing `filter` package
 - TUI logic in `SearchModel`
 - No code duplication
 
 ✅ **Concurrency**
+
 - Proper goroutine usage for background search
 - Version tracking prevents stale results
 - No goroutine leaks (verified by design)
 - Thread-safe graph operations
 
 ✅ **Type Safety**
+
 - Strong typing throughout
 - Clear message types for Bubbletea
 - No unsafe type assertions
@@ -289,6 +316,7 @@ BenchmarkSearch-10    	  615411	      1928 ns/op	    1448 B/op	      23 allocs/o
 ### Test Coverage
 
 ✅ **Comprehensive Testing**
+
 - Unit tests for parser (16 tests)
 - Unit tests for filter package (50+ tests)
 - Integration tests (32 tests)
@@ -297,6 +325,7 @@ BenchmarkSearch-10    	  615411	      1928 ns/op	    1448 B/op	      23 allocs/o
 - Error handling coverage
 
 ✅ **Test Quality**
+
 - Clear test names
 - Good test data
 - Proper assertions
@@ -305,12 +334,14 @@ BenchmarkSearch-10    	  615411	      1928 ns/op	    1448 B/op	      23 allocs/o
 ### Code Style
 
 ✅ **Follows Go Best Practices**
+
 - Proper error handling
 - Clear function names
 - Appropriate comments
 - Consistent formatting
 
 ✅ **Lint Compliance**
+
 - All golangci-lint rules pass
 - No complexity violations
 - Clean code
@@ -430,6 +461,7 @@ Comparing implementation against `/search-screen-live-filter.md`:
 - Background goroutines don't block UI
 
 **Estimated Performance at Scale:**
+
 - 100 entities: ~25μs (well under 10ms target)
 - 1,000 entities: ~250μs (well under 50ms target)
 - 10,000 entities: ~2.5ms (well under 200ms target)
@@ -437,11 +469,13 @@ Comparing implementation against `/search-screen-live-filter.md`:
 ## Accessibility
 
 ✅ **Keyboard Navigation**
+
 - All features accessible via keyboard
 - Clear keyboard shortcuts
 - No mouse required
 
 ✅ **Visual Clarity**
+
 - Good color contrast (needs terminal support)
 - Clear text
 - Consistent layout
@@ -453,6 +487,7 @@ Comparing implementation against `/search-screen-live-filter.md`:
 ✅ **APPROVED FOR PRODUCTION**
 
 The live search feature is ready for production use:
+
 1. All tests pass
 2. No bugs found
 3. Meets specification requirements
@@ -470,6 +505,7 @@ The live search feature is ready for production use:
 ### For Future Enhancements
 
 Consider implementing in order of priority:
+
 1. Autocomplete (high value, medium effort)
 2. Search history (high value, low effort)
 3. Result highlighting (medium value, medium effort)
@@ -487,7 +523,9 @@ All test files and test data are available:
 
 ## Conclusion
 
-The live search feature with advanced filtering has been successfully implemented and thoroughly tested. All 32 integration tests pass, along with 16+ unit tests and 50+ filter package tests. Performance is excellent, code quality is high, and the user experience is smooth and intuitive.
+The live search feature with advanced filtering has been successfully implemented and thoroughly tested.
+All 32 integration tests pass, along with 16+ unit tests and 50+ filter package tests. Performance is
+excellent, code quality is high, and the user experience is smooth and intuitive.
 
 **Final Verdict:** ✅ **READY FOR PRODUCTION**
 

--- a/search-screen-live-filter.md
+++ b/search-screen-live-filter.md
@@ -6,7 +6,8 @@
 
 ## Overview
 
-Enhance the search screen with live search (no need to press Enter) and advanced filtering syntax to enable powerful entity discovery and filtering.
+Enhance the search screen with live search (no need to press Enter) and advanced filtering syntax
+to enable powerful entity discovery and filtering.
 
 ## Goals
 
@@ -37,7 +38,7 @@ Enhance the search screen with live search (no need to press Enter) and advanced
 
 ### Syntax Components
 
-```
+```text
 [type_filter] [free_text] [property_filter]... [special_filter]...
 ```
 
@@ -47,7 +48,7 @@ All components are **space-separated** and can appear in any order.
 
 **Prefix:** `type:`
 
-```
+```text
 type:requirement           # only requirements
 type:decision,solution     # multiple types (comma-separated)
 ```
@@ -58,7 +59,7 @@ type:decision,solution     # multiple types (comma-separated)
 
 **Logic:** Multiple words use **AND** - all words must be present.
 
-```
+```text
 authentication api         # entities containing both "authentication" AND "api"
 "multi word phrase"        # exact phrase match (quoted strings)
 auth "REST API"            # contains "auth" AND exact phrase "REST API"
@@ -70,7 +71,7 @@ auth "REST API"            # contains "auth" AND exact phrase "REST API"
 
 Uses existing `internal/filter` package operators:
 
-```
+```text
 prop:state=published       # exact match
 prop:state!=draft          # not equal
 prop:priority>3            # greater than
@@ -83,7 +84,7 @@ prop:desc=~^[A-Z].*        # regex match (existing support)
 
 Multiple property filters are combined with AND logic:
 
-```
+```text
 prop:state=published prop:priority>=2
 ```
 
@@ -91,14 +92,14 @@ prop:state=published prop:priority>=2
 
 **Status shortcut:** `status:` maps to `prop:status=`
 
-```
+```text
 status:draft               # equivalent to prop:status=draft
 status:published           # equivalent to prop:status=published
 ```
 
 **Tag search (future):** `@tag` searches for tags in properties
 
-```
+```text
 @security                  # entities tagged with "security"
 ```
 
@@ -143,7 +144,7 @@ authentication "OAuth 2.0" security
 
 ### Concurrency Model
 
-```
+```text
 User Input → Debouncer (200ms) → Search Goroutine → Results Channel → Update UI
 ```
 
@@ -244,7 +245,7 @@ for _, entity := range entities {
 
 ### Search Input Box
 
-```
+```text
 ┌─────────────────────────────────────────────────────┐
 │ type:requirement prop:state=published auth_         │
 └─────────────────────────────────────────────────────┘
@@ -253,7 +254,7 @@ Type to search (live), ↑/↓ to navigate, Enter to open
 
 With syntax error:
 
-```
+```text
 ┌─────────────────────────────────────────────────────┐
 │ prop:state published auth_                          │
 └─────────────────────────────────────────────────────┘
@@ -264,7 +265,7 @@ With syntax error:
 
 Results are **lazily rendered** - only visible items are rendered, allowing infinite scrolling through large result sets.
 
-```
+```text
 Found 1,523 results:
 
 ►  REQ-001      Authentication Requirements    (requirement)
@@ -291,7 +292,7 @@ case "/":
 
 Status bar should show:
 
-```
+```text
 [/] search  [c] create  [g] graph  [a] analyze  [q] quit  [?] help
 ```
 
@@ -366,7 +367,8 @@ Status bar should show:
      - After `prop:` → list property names from metamodel
      - After `prop:name=` → suggest values if enum type
    - Display format:
-     ```
+
+     ```text
      ┌─────────────────────────────────────┐
      │ type:_                              │
      └─────────────────────────────────────┘
@@ -401,6 +403,7 @@ Status bar should show:
 5. **Accept with Tab or Enter**: Insert suggestion at cursor, return to search mode
 
 **State management:**
+
 ```go
 type SearchModel struct {
     query           string
@@ -416,6 +419,7 @@ type SearchModel struct {
 ```
 
 **When to show suggestions:**
+
 - User types `type:` → show entity types from metamodel
 - User types `prop:` → show property names from metamodel
 - User types `prop:priority=` → show enum values (if applicable)

--- a/utils/README.md
+++ b/utils/README.md
@@ -40,11 +40,13 @@ Combined tool for capturing tmux pane screenshots and deduplicating them.
 **Demo Recording Workflow:**
 
 1. Start your tmux session:
+
    ```bash
    tmux new -s rela-demo
    ```
 
 2. In another terminal, start capturing:
+
    ```bash
    ./utils/tmux-capture both
    ```
@@ -67,11 +69,13 @@ If you already have screenshots and just want to deduplicate:
 
 Screenshots are saved as `screendumps/screen_NNNN.txt` with sequential numbering.
 
-After deduplication, only unique screenshots are kept, significantly reducing the file count while preserving all unique states.
+After deduplication, only unique screenshots are kept, significantly reducing the file count while
+preserving all unique states.
 
 ## Migration from Legacy Scripts
 
 The old separate scripts have been combined:
+
 - `capture-tmux.sh` → `utils/tmux-capture capture`
 - `dedupe-screendumps.sh` → `utils/tmux-capture dedupe`
 


### PR DESCRIPTION
## Summary
- Add language specifiers to fenced code blocks (text, bash, go)
- Add blank lines around lists and fenced blocks per MD032/MD031
- Fix line length issues exceeding 120 characters
- Replace hard tabs with spaces in benchmark output

This fixes the markdown lint CI failure introduced in #9.