### PR TITLE
Add rename entity type command

### DIFF
--- a/internal/cli/rename.go
+++ b/internal/cli/rename.go
@@ -1,0 +1,231 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Sourcehaven-BV/rela/internal/markdown"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+var (
+	renameForce  bool
+	renamePlural string
+)
+
+var renameCmd = &cobra.Command{
+	Use:   "rename",
+	Short: "Rename entities or relations",
+	Long:  `Rename entity types or relation types across the project.`,
+}
+
+var renameEntityCmd = &cobra.Command{
+	Use:   "entity <old-type> <new-type>",
+	Short: "Rename an entity type",
+	Long: `Renames an entity type across the entire project.
+
+This updates:
+  - The entity key in metamodel.yaml
+  - All relation from/to references in metamodel.yaml
+  - All validation entity_type references in metamodel.yaml
+  - The entity directory (e.g., entities/issues/ → entities/tickets/)
+  - The type field in all entity markdown files
+  - Entity templates (if they exist)
+
+Examples:
+  rela rename entity issue ticket
+  rela rename entity issue ticket --plural tickets
+  rela rename entity requirement feature --force`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runRenameEntity(args[0], args[1])
+	},
+}
+
+// renameEntityInfo holds the resolved information needed for a rename operation.
+type renameEntityInfo struct {
+	resolvedOld     string
+	newType         string
+	oldPlural       string
+	newPlural       string
+	oldDir          string
+	newDir          string
+	entityCount     int
+	relCount        int
+	oldTemplatePath string
+	hasTemplate     bool
+}
+
+// coverage-ignore: interactive CLI - tested via integration tests
+func runRenameEntity(oldType, newType string) error {
+	info, err := resolveRenameEntity(oldType, newType)
+	if err != nil {
+		return err
+	}
+
+	showRenamePreview(info)
+
+	if !renameForce {
+		confirmed, confirmErr := confirmRename()
+		if confirmErr != nil {
+			return confirmErr
+		}
+		if !confirmed {
+			out.WriteMessage("Cancelled")
+			return nil
+		}
+	}
+
+	return applyRenameEntity(info)
+}
+
+func resolveRenameEntity(oldType, newType string) (*renameEntityInfo, error) {
+	resolvedOld := meta.ResolveAlias(oldType)
+	oldDef, ok := meta.GetEntityDef(resolvedOld)
+	if !ok {
+		return nil, fmt.Errorf("entity type %q not found in metamodel", oldType)
+	}
+
+	if err := validateTypeName(newType); err != nil {
+		return nil, err
+	}
+
+	if _, exists := meta.GetEntityDef(newType); exists {
+		return nil, fmt.Errorf("entity type %q already exists in metamodel", newType)
+	}
+
+	oldPlural := oldDef.GetDirPlural(resolvedOld)
+	newPlural := renamePlural
+	if newPlural == "" {
+		newPlural = newType + "s"
+	}
+
+	oldTemplatePath := projectCtx.EntityTemplatePath(resolvedOld)
+	_, statErr := os.Stat(oldTemplatePath)
+
+	return &renameEntityInfo{
+		resolvedOld:     resolvedOld,
+		newType:         newType,
+		oldPlural:       oldPlural,
+		newPlural:       newPlural,
+		oldDir:          projectCtx.EntityTypeDirWithPlural(oldPlural),
+		newDir:          projectCtx.EntityTypeDirWithPlural(newPlural),
+		entityCount:     len(g.NodesByType(resolvedOld)),
+		relCount:        countAffectedRelations(resolvedOld),
+		oldTemplatePath: oldTemplatePath,
+		hasTemplate:     statErr == nil,
+	}, nil
+}
+
+func countAffectedRelations(entityType string) int {
+	count := 0
+	for _, relName := range meta.RelationTypes() {
+		relDef, _ := meta.GetRelationDef(relName)
+		if relDef == nil {
+			continue
+		}
+		if sliceContains(relDef.From, entityType) {
+			count++
+		}
+		if sliceContains(relDef.To, entityType) {
+			count++
+		}
+	}
+	return count
+}
+
+func showRenamePreview(info *renameEntityInfo) {
+	out.WriteMessage("Rename entity type: %s → %s", info.resolvedOld, info.newType)
+	out.WriteMessage("  metamodel.yaml:  entity key + %d relation reference(s)", info.relCount)
+	if info.entityCount > 0 {
+		out.WriteMessage("  directory:       %s → %s", info.oldPlural, info.newPlural)
+		out.WriteMessage("  entity files:    %d file(s) will be updated", info.entityCount)
+	}
+	if info.hasTemplate {
+		out.WriteMessage("  template:        %s.md → %s.md", info.resolvedOld, info.newType)
+	}
+}
+
+// coverage-ignore: interactive prompt
+func confirmRename() (bool, error) {
+	fmt.Print("\nProceed? [y/N] ")
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("failed to read input: %w", err)
+	}
+	response = strings.TrimSpace(strings.ToLower(response))
+	return response == "y" || response == "yes", nil
+}
+
+func applyRenameEntity(info *renameEntityInfo) error {
+	if err := metamodel.RenameEntityType(projectCtx.MetamodelPath, info.resolvedOld, info.newType); err != nil {
+		return fmt.Errorf("failed to update metamodel: %w", err)
+	}
+
+	if _, err := os.Stat(info.oldDir); err == nil {
+		if renameErr := os.Rename(info.oldDir, info.newDir); renameErr != nil {
+			return fmt.Errorf("failed to rename directory: %w", renameErr)
+		}
+	}
+
+	if _, err := os.Stat(info.newDir); err == nil {
+		count, updateErr := markdown.UpdateEntityTypesInDir(info.newDir, info.newType, meta)
+		if updateErr != nil {
+			return fmt.Errorf("failed to update entity files: %w", updateErr)
+		}
+		if count > 0 {
+			out.WriteMessage("  Updated %d entity file(s)", count)
+		}
+	}
+
+	if info.hasTemplate {
+		newTemplatePath := projectCtx.EntityTemplatePath(info.newType)
+		if mkdirErr := os.MkdirAll(projectCtx.EntityTemplatesDir, 0755); mkdirErr != nil {
+			out.WriteWarning("Failed to create templates directory: %v", mkdirErr)
+		} else if renameErr := os.Rename(info.oldTemplatePath, newTemplatePath); renameErr != nil {
+			out.WriteWarning("Failed to rename template: %v", renameErr)
+		}
+	}
+
+	if err := os.Remove(projectCtx.CachePath); err != nil && !os.IsNotExist(err) {
+		out.WriteWarning("Failed to remove cache: %v", err)
+	}
+
+	out.WriteSuccess("Renamed entity type: %s → %s", info.resolvedOld, info.newType)
+	return nil
+}
+
+// validateTypeName checks that a type name is valid for use in the metamodel.
+func validateTypeName(name string) error {
+	if name == "" {
+		return fmt.Errorf("type name cannot be empty")
+	}
+
+	if strings.Contains(name, "..") || strings.Contains(name, "/") || strings.Contains(name, "\\") {
+		return fmt.Errorf("invalid characters in type name: %s", name)
+	}
+
+	valid := regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+	if !valid.MatchString(name) {
+		return fmt.Errorf(
+			"invalid type name %q: must start with a lowercase letter and contain only lowercase letters, digits, hyphens, and underscores",
+			name,
+		)
+	}
+
+	return nil
+}
+
+func init() {
+	renameEntityCmd.Flags().BoolVarP(&renameForce, "force", "f", false, "Skip confirmation prompt")
+	renameEntityCmd.Flags().StringVar(&renamePlural, "plural", "", "Override plural form for directory name")
+
+	renameCmd.AddCommand(renameEntityCmd)
+	rootCmd.AddCommand(renameCmd)
+}

--- a/internal/cli/rename_test.go
+++ b/internal/cli/rename_test.go
@@ -1,0 +1,290 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/graph"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/output"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+)
+
+func setupRenameTestEnv(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	g = graph.New()
+	out = output.New(output.FormatTable)
+	projectCtx = &project.Context{
+		Root:               dir,
+		EntitiesDir:        filepath.Join(dir, "entities"),
+		RelationsDir:       filepath.Join(dir, "relations"),
+		CacheDir:           filepath.Join(dir, ".rela"),
+		CachePath:          filepath.Join(dir, ".rela", "cache.json"),
+		MetamodelPath:      filepath.Join(dir, "metamodel.yaml"),
+		TemplatesDir:       filepath.Join(dir, "templates"),
+		EntityTemplatesDir: filepath.Join(dir, "templates", "entities"),
+	}
+
+	// Create directories
+	os.MkdirAll(filepath.Join(dir, ".rela"), 0755)
+	os.MkdirAll(filepath.Join(dir, "entities", "requirements"), 0755)
+	os.MkdirAll(filepath.Join(dir, "relations"), 0755)
+
+	// Write metamodel
+	metamodelYAML := `version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+        required: true
+      status:
+        type: string
+  decision:
+    label: Decision
+    id_prefix: "DEC-"
+    properties:
+      title:
+        type: string
+        required: true
+relations:
+  addresses:
+    label: addresses
+    from: [decision]
+    to: [requirement]
+`
+	os.WriteFile(projectCtx.MetamodelPath, []byte(metamodelYAML), 0644)
+
+	// Load metamodel
+	var err error
+	meta, err = metamodel.Parse([]byte(metamodelYAML))
+	if err != nil {
+		t.Fatalf("failed to parse metamodel: %v", err)
+	}
+
+	return dir
+}
+
+func writeEntityFile(t *testing.T, path, id, entityType, title string) {
+	t.Helper()
+	os.MkdirAll(filepath.Dir(path), 0755)
+	content := "---\nid: " + id + "\ntype: " + entityType + "\ntitle: " + title + "\n---\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write entity file: %v", err)
+	}
+}
+
+func TestValidateTypeName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid lowercase", "ticket", false},
+		{"valid with hyphen", "risk-item", false},
+		{"valid with underscore", "risk_item", false},
+		{"valid with digits", "issue2", false},
+		{"empty", "", true},
+		{"uppercase", "Ticket", true},
+		{"starts with digit", "1ticket", true},
+		{"path traversal dots", "a..b", true},
+		{"path traversal slash", "a/b", true},
+		{"path traversal backslash", "a\\b", true},
+		{"spaces", "risk item", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTypeName(tt.input)
+			if tt.wantErr && err == nil {
+				t.Errorf("validateTypeName(%q) expected error, got nil", tt.input)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("validateTypeName(%q) unexpected error: %v", tt.input, err)
+			}
+		})
+	}
+}
+
+func TestRenameEntityCommand(t *testing.T) {
+	t.Run("renames entity type end to end", func(t *testing.T) {
+		dir := setupRenameTestEnv(t)
+
+		// Create entity files
+		writeEntityFile(t,
+			filepath.Join(dir, "entities", "requirements", "REQ-001.md"),
+			"REQ-001", "requirement", "First Requirement")
+		writeEntityFile(t,
+			filepath.Join(dir, "entities", "requirements", "REQ-002.md"),
+			"REQ-002", "requirement", "Second Requirement")
+
+		// Add to graph
+		g.AddNode(&model.Entity{ID: "REQ-001", Type: "requirement", Properties: map[string]interface{}{"title": "First Requirement"}})
+		g.AddNode(&model.Entity{ID: "REQ-002", Type: "requirement", Properties: map[string]interface{}{"title": "Second Requirement"}})
+
+		// Run rename
+		renameForce = true
+		renamePlural = ""
+		err := runRenameEntity("requirement", "feature")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Check metamodel was updated
+		mmData, err := os.ReadFile(projectCtx.MetamodelPath)
+		if err != nil {
+			t.Fatalf("failed to read metamodel: %v", err)
+		}
+		mmContent := string(mmData)
+
+		if strings.Contains(mmContent, "requirement:") {
+			t.Error("metamodel should not contain 'requirement:' key")
+		}
+		if !strings.Contains(mmContent, "feature:") {
+			t.Error("metamodel should contain 'feature:' key")
+		}
+		if !strings.Contains(mmContent, "to: [feature]") && !strings.Contains(mmContent, "- feature") {
+			t.Error("metamodel relation 'to' should reference 'feature'")
+		}
+
+		// Check directory was renamed
+		if _, statErr := os.Stat(filepath.Join(dir, "entities", "requirements")); !os.IsNotExist(statErr) {
+			t.Error("old directory should not exist")
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, "entities", "features")); statErr != nil {
+			t.Error("new directory should exist")
+		}
+
+		// Check entity files were updated
+		data, err := os.ReadFile(filepath.Join(dir, "entities", "features", "REQ-001.md"))
+		if err != nil {
+			t.Fatalf("failed to read renamed entity: %v", err)
+		}
+		content := string(data)
+		if !strings.Contains(content, "type: feature") {
+			t.Errorf("entity file should have type 'feature', got:\n%s", content)
+		}
+		if !strings.Contains(content, "id: REQ-001") {
+			t.Errorf("entity file should keep original ID, got:\n%s", content)
+		}
+
+		// Check cache was removed
+		if _, err := os.Stat(projectCtx.CachePath); !os.IsNotExist(err) {
+			t.Error("cache should be removed")
+		}
+	})
+
+	t.Run("error when old type not found", func(t *testing.T) {
+		setupRenameTestEnv(t)
+
+		renameForce = true
+		err := runRenameEntity("nonexistent", "feature")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("expected 'not found' error, got: %v", err)
+		}
+	})
+
+	t.Run("error when new type already exists", func(t *testing.T) {
+		setupRenameTestEnv(t)
+
+		renameForce = true
+		err := runRenameEntity("requirement", "decision")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "already exists") {
+			t.Errorf("expected 'already exists' error, got: %v", err)
+		}
+	})
+
+	t.Run("error when new type name is invalid", func(t *testing.T) {
+		setupRenameTestEnv(t)
+
+		renameForce = true
+		err := runRenameEntity("requirement", "Bad-Name")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "invalid type name") {
+			t.Errorf("expected 'invalid type name' error, got: %v", err)
+		}
+	})
+
+	t.Run("custom plural form", func(t *testing.T) {
+		dir := setupRenameTestEnv(t)
+
+		writeEntityFile(t,
+			filepath.Join(dir, "entities", "requirements", "REQ-001.md"),
+			"REQ-001", "requirement", "Test")
+
+		g.AddNode(&model.Entity{ID: "REQ-001", Type: "requirement", Properties: map[string]interface{}{"title": "Test"}})
+
+		renameForce = true
+		renamePlural = "policies"
+		err := runRenameEntity("requirement", "policy")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Check custom plural was used for directory
+		if _, err := os.Stat(filepath.Join(dir, "entities", "policies")); err != nil {
+			t.Error("directory should use custom plural 'policies'")
+		}
+	})
+
+	t.Run("renames template if exists", func(t *testing.T) {
+		dir := setupRenameTestEnv(t)
+
+		// Create template
+		templateDir := filepath.Join(dir, "templates", "entities")
+		os.MkdirAll(templateDir, 0755)
+		templatePath := filepath.Join(templateDir, "requirement.md")
+		os.WriteFile(templatePath, []byte("---\nstatus: draft\n---\n"), 0644)
+
+		renameForce = true
+		renamePlural = ""
+		err := runRenameEntity("requirement", "feature")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Check template was renamed
+		if _, err := os.Stat(filepath.Join(templateDir, "requirement.md")); !os.IsNotExist(err) {
+			t.Error("old template should not exist")
+		}
+		if _, err := os.Stat(filepath.Join(templateDir, "feature.md")); err != nil {
+			t.Error("new template should exist")
+		}
+	})
+
+	t.Run("handles no entity directory", func(t *testing.T) {
+		setupRenameTestEnv(t)
+
+		// Remove the entities directory entirely
+		os.RemoveAll(projectCtx.EntitiesDir)
+		os.MkdirAll(projectCtx.EntitiesDir, 0755)
+
+		renameForce = true
+		renamePlural = ""
+		err := runRenameEntity("requirement", "feature")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Metamodel should still be updated
+		mmData, _ := os.ReadFile(projectCtx.MetamodelPath)
+		if !strings.Contains(string(mmData), "feature:") {
+			t.Error("metamodel should contain 'feature:' key even with no entity directory")
+		}
+	})
+}

--- a/internal/markdown/rename.go
+++ b/internal/markdown/rename.go
@@ -1,0 +1,53 @@
+package markdown
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// UpdateEntityType reads an entity file, updates the type field, and writes it back.
+func UpdateEntityType(path, newType string, meta *metamodel.Metamodel) error {
+	entity, err := ReadEntity(path, meta)
+	if err != nil {
+		return fmt.Errorf("failed to read entity: %w", err)
+	}
+
+	entity.Type = newType
+
+	if err := WriteEntity(entity, path); err != nil {
+		return fmt.Errorf("failed to write entity: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateEntityTypesInDir updates the `type` field in all entity markdown files in a directory.
+// Returns the number of files updated and any error encountered.
+func UpdateEntityTypesInDir(dir, newType string, meta *metamodel.Metamodel) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	count := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		if err := UpdateEntityType(path, newType, meta); err != nil {
+			return count, fmt.Errorf("failed to update %s: %w", entry.Name(), err)
+		}
+		count++
+	}
+
+	return count, nil
+}

--- a/internal/metamodel/rename.go
+++ b/internal/metamodel/rename.go
@@ -1,0 +1,163 @@
+package metamodel
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RenameEntityType performs an AST-level rename of an entity type in a metamodel YAML file.
+// It preserves comments, formatting, and key ordering.
+//
+// Updates:
+//   - The entity key under `entities:`
+//   - All references in `relations:` `from:` and `to:` arrays
+//   - All references in `validations:` `entity_type:` fields
+func RenameEntityType(path, oldType, newType string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read metamodel: %w", err)
+	}
+
+	var doc yaml.Node
+	if unmarshalErr := yaml.Unmarshal(data, &doc); unmarshalErr != nil {
+		return fmt.Errorf("failed to parse metamodel: %w", unmarshalErr)
+	}
+
+	root := getDocRoot(&doc)
+	if root == nil {
+		return fmt.Errorf("empty metamodel document")
+	}
+
+	// Rename entity key under entities:
+	entities := getMapValue(root, "entities")
+	if entities == nil {
+		return fmt.Errorf("no entities section found in metamodel")
+	}
+
+	if !renameMapKey(entities, oldType, newType) {
+		return fmt.Errorf("entity type %q not found in metamodel", oldType)
+	}
+
+	// Check new type doesn't conflict with existing types (other than the one we just renamed)
+	// We already renamed it, so check if there are duplicates
+	count := 0
+	for i := 0; i < len(entities.Content)-1; i += 2 {
+		if entities.Content[i].Value == newType {
+			count++
+		}
+	}
+	if count > 1 {
+		// Undo the rename
+		renameMapKey(entities, newType, oldType)
+		return fmt.Errorf("entity type %q already exists in metamodel", newType)
+	}
+
+	// Update relation from/to references
+	relations := getMapValue(root, "relations")
+	if relations != nil && relations.Kind == yaml.MappingNode {
+		for i := 1; i < len(relations.Content); i += 2 {
+			relDef := relations.Content[i]
+			if relDef.Kind != yaml.MappingNode {
+				continue
+			}
+			replaceInSequence(getMapValue(relDef, "from"), oldType, newType)
+			replaceInSequence(getMapValue(relDef, "to"), oldType, newType)
+		}
+	}
+
+	// Update validation entity_type references
+	validations := getMapValue(root, "validations")
+	if validations != nil && validations.Kind == yaml.SequenceNode {
+		for _, item := range validations.Content {
+			if item.Kind != yaml.MappingNode {
+				continue
+			}
+			replaceMapScalar(item, "entity_type", oldType, newType)
+		}
+	}
+
+	// Write back
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return fmt.Errorf("failed to marshal metamodel: %w", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("failed to stat metamodel: %w", err)
+	}
+
+	if err := os.WriteFile(path, out, info.Mode()); err != nil {
+		return fmt.Errorf("failed to write metamodel: %w", err)
+	}
+
+	return nil
+}
+
+// getDocRoot returns the root mapping from a document node.
+func getDocRoot(doc *yaml.Node) *yaml.Node {
+	if doc == nil {
+		return nil
+	}
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		return doc.Content[0]
+	}
+	return doc
+}
+
+// getMapValue finds a value in a mapping node by key name.
+func getMapValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// renameMapKey renames a key in a mapping node. Returns true if found.
+func renameMapKey(node *yaml.Node, oldKey, newKey string) bool {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == oldKey {
+			node.Content[i].Value = newKey
+			return true
+		}
+	}
+	return false
+}
+
+// replaceInSequence replaces scalar values in a sequence node.
+func replaceInSequence(seq *yaml.Node, oldVal, newVal string) {
+	if seq == nil || seq.Kind != yaml.SequenceNode {
+		return
+	}
+	for _, item := range seq.Content {
+		if item.Kind == yaml.ScalarNode && item.Value == oldVal {
+			item.Value = newVal
+		}
+	}
+}
+
+// replaceMapScalar replaces a scalar value for a given key in a mapping node.
+func replaceMapScalar(node *yaml.Node, key, oldVal, newVal string) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			valNode := node.Content[i+1]
+			if valNode.Kind == yaml.ScalarNode && valNode.Value == oldVal {
+				valNode.Value = newVal
+			}
+			return
+		}
+	}
+}

--- a/internal/metamodel/rename_test.go
+++ b/internal/metamodel/rename_test.go
@@ -1,0 +1,235 @@
+package metamodel
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenameEntityType(t *testing.T) {
+	t.Run("renames entity key", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metamodel.yaml")
+
+		input := `version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+relations: {}
+`
+		writeFile(t, path, input)
+
+		if err := RenameEntityType(path, "requirement", "feature"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got := readFile(t, path)
+		if !strings.Contains(got, "feature:") {
+			t.Errorf("expected 'feature:' key, got:\n%s", got)
+		}
+		if strings.Contains(got, "requirement:") {
+			t.Errorf("old key 'requirement:' should be gone, got:\n%s", got)
+		}
+	})
+
+	t.Run("updates relation from and to", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metamodel.yaml")
+
+		input := `version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+  decision:
+    label: Decision
+relations:
+  addresses:
+    label: addresses
+    from: [decision]
+    to: [requirement]
+  dependsOn:
+    label: depends on
+    from: [requirement, decision]
+    to: [requirement, decision]
+`
+		writeFile(t, path, input)
+
+		if err := RenameEntityType(path, "requirement", "feature"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got := readFile(t, path)
+
+		// Check relations are updated
+		if strings.Contains(got, "to: [requirement]") {
+			t.Errorf("relation 'to' should reference 'feature', got:\n%s", got)
+		}
+		if !strings.Contains(got, "feature") {
+			t.Errorf("expected 'feature' in relations, got:\n%s", got)
+		}
+		// Decision should be untouched
+		if !strings.Contains(got, "decision") {
+			t.Errorf("decision should be untouched, got:\n%s", got)
+		}
+	})
+
+	t.Run("updates validation entity_type", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metamodel.yaml")
+
+		input := `version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+relations: {}
+validations:
+  - name: req-needs-priority
+    entity_type: requirement
+    then:
+      - "priority!="
+  - name: other-rule
+    entity_type: decision
+    then:
+      - "title!="
+`
+		writeFile(t, path, input)
+
+		if err := RenameEntityType(path, "requirement", "feature"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got := readFile(t, path)
+		if strings.Contains(got, "entity_type: requirement") {
+			t.Errorf("validation entity_type should be updated, got:\n%s", got)
+		}
+		if !strings.Contains(got, "entity_type: feature") {
+			t.Errorf("expected 'entity_type: feature', got:\n%s", got)
+		}
+		// Other validation should be untouched
+		if !strings.Contains(got, "entity_type: decision") {
+			t.Errorf("decision validation should be untouched, got:\n%s", got)
+		}
+	})
+
+	t.Run("error when type not found", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metamodel.yaml")
+
+		input := `version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+relations: {}
+`
+		writeFile(t, path, input)
+
+		err := RenameEntityType(path, "nonexistent", "feature")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("expected 'not found' error, got: %v", err)
+		}
+	})
+
+	t.Run("error when new type already exists", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metamodel.yaml")
+
+		input := `version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+  decision:
+    label: Decision
+relations: {}
+`
+		writeFile(t, path, input)
+
+		err := RenameEntityType(path, "requirement", "decision")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "already exists") {
+			t.Errorf("expected 'already exists' error, got: %v", err)
+		}
+
+		// Verify file was not modified
+		got := readFile(t, path)
+		if !strings.Contains(got, "requirement:") {
+			t.Error("original file should not be modified on error")
+		}
+	})
+
+	t.Run("error when file not found", func(t *testing.T) {
+		err := RenameEntityType("/nonexistent/path/metamodel.yaml", "old", "new")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("handles no relations section", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metamodel.yaml")
+
+		input := `version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+`
+		writeFile(t, path, input)
+
+		if err := RenameEntityType(path, "requirement", "feature"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got := readFile(t, path)
+		if !strings.Contains(got, "feature:") {
+			t.Errorf("expected 'feature:', got:\n%s", got)
+		}
+	})
+
+	t.Run("preserves comments", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metamodel.yaml")
+
+		input := `version: "1.0"
+# Entity definitions
+entities:
+  requirement: # The main requirement type
+    label: Requirement
+relations: {}
+`
+		writeFile(t, path, input)
+
+		if err := RenameEntityType(path, "requirement", "feature"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got := readFile(t, path)
+		if !strings.Contains(got, "# Entity definitions") {
+			t.Errorf("comments should be preserved, got:\n%s", got)
+		}
+	})
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
## Summary

- Adds `rela rename entity <old-type> <new-type>` command to rename an entity type across the entire project
- Updates metamodel.yaml (entity key, relation from/to references, validation entity_type) using AST-level YAML transformation to preserve comments and formatting
- Renames entity directory, updates type field in all entity markdown files, renames templates, and invalidates cache
- Supports `--force` flag to skip confirmation and `--plural` flag to override directory name pluralization

## Test plan

- [x] Unit tests for metamodel YAML transformation (`internal/metamodel/rename_test.go` — 8 cases)
- [x] Unit tests for CLI command (`internal/cli/rename_test.go` — 7 cases + type name validation)
- [x] Manual QA: basic rename, plural override, alias resolution, error cases, template rename
- [x] Manual QA: post-rename operations (list, show, create, link) all work correctly
- [x] All pre-commit checks pass (lint, tests, coverage thresholds)