### PR TITLE
Add scoped browse mode for sequential entity navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ test-tui*.sh
 tickets/
 other-ci.yml
 .claude/
+.ignored/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,3 +269,15 @@ The metamodel loader (`internal/metamodel/loader.go`) checks for migrations on l
 3. The error message tells users to run `rela migrate`
 
 Commands that don't need the metamodel (init, migrate, version, etc.) are excluded from this check in `internal/cli/root.go`.
+
+## Working Documents
+
+Place temporary working documents in the `.ignored/` directory:
+
+- Design documents
+- Bug/ticket tracking files
+- QA reports
+- Test reports
+- Scratch notes
+
+This directory is gitignored. Never commit design docs, tickets, or reports to the repository.

--- a/internal/tui/browse_scope.go
+++ b/internal/tui/browse_scope.go
@@ -1,0 +1,107 @@
+package tui
+
+import "fmt"
+
+// BrowseScope defines a subset of entities for sequential navigation.
+// When a scope is present, the detail screen enables prev/next navigation
+// within the scope and shows progress indicators.
+type BrowseScope struct {
+	IDs    []string // Ordered list of entity IDs to browse
+	Index  int      // Current position in IDs (0-based)
+	Label  string   // Human-readable description, e.g., "12 search results"
+	Origin Screen   // Screen to return to when exiting browse mode
+}
+
+// NewBrowseScope creates a new browse scope from a list of entity IDs.
+func NewBrowseScope(ids []string, label string, origin Screen) *BrowseScope {
+	if len(ids) == 0 {
+		return nil
+	}
+	return &BrowseScope{
+		IDs:    ids,
+		Index:  0,
+		Label:  label,
+		Origin: origin,
+	}
+}
+
+// Current returns the entity ID at the current position.
+func (s *BrowseScope) Current() string {
+	if s == nil || len(s.IDs) == 0 || s.Index < 0 || s.Index >= len(s.IDs) {
+		return ""
+	}
+	return s.IDs[s.Index]
+}
+
+// HasNext returns true if there is a next entity in the scope.
+func (s *BrowseScope) HasNext() bool {
+	if s == nil {
+		return false
+	}
+	return s.Index < len(s.IDs)-1
+}
+
+// HasPrev returns true if there is a previous entity in the scope.
+func (s *BrowseScope) HasPrev() bool {
+	if s == nil {
+		return false
+	}
+	return s.Index > 0
+}
+
+// Next advances to the next entity. Returns true if the move was successful.
+func (s *BrowseScope) Next() bool {
+	if s == nil || !s.HasNext() {
+		return false
+	}
+	s.Index++
+	return true
+}
+
+// Prev moves to the previous entity. Returns true if the move was successful.
+func (s *BrowseScope) Prev() bool {
+	if s == nil || !s.HasPrev() {
+		return false
+	}
+	s.Index--
+	return true
+}
+
+// Progress returns a progress string like "[3/12]".
+func (s *BrowseScope) Progress() string {
+	if s == nil || len(s.IDs) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("[%d/%d]", s.Index+1, len(s.IDs))
+}
+
+// Count returns the total number of entities in the scope.
+func (s *BrowseScope) Count() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.IDs)
+}
+
+// SetIndex sets the current position to a specific index.
+// Returns false if the index is out of bounds.
+func (s *BrowseScope) SetIndex(idx int) bool {
+	if s == nil || idx < 0 || idx >= len(s.IDs) {
+		return false
+	}
+	s.Index = idx
+	return true
+}
+
+// IndexOf returns the index of the given entity ID, or -1 if not found.
+func (s *BrowseScope) IndexOf(id string) int {
+	if s == nil {
+		return -1
+	}
+	for i, scopeID := range s.IDs {
+		if scopeID == id {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/tui/browse_scope_test.go
+++ b/internal/tui/browse_scope_test.go
@@ -1,0 +1,518 @@
+package tui
+
+import (
+	"testing"
+)
+
+func TestNewBrowseScope(t *testing.T) {
+	tests := []struct {
+		name   string
+		ids    []string
+		label  string
+		origin Screen
+		want   bool // nil expected?
+	}{
+		{
+			name:   "creates scope with valid IDs",
+			ids:    []string{"REQ-001", "REQ-002", "REQ-003"},
+			label:  "3 requirements",
+			origin: ScreenSearch,
+			want:   false,
+		},
+		{
+			name:   "returns nil for empty IDs",
+			ids:    []string{},
+			label:  "empty",
+			origin: ScreenSearch,
+			want:   true,
+		},
+		{
+			name:   "returns nil for nil IDs",
+			ids:    nil,
+			label:  "nil",
+			origin: ScreenBrowser,
+			want:   true,
+		},
+		{
+			name:   "single item scope is valid",
+			ids:    []string{"REQ-001"},
+			label:  "1 requirement",
+			origin: ScreenBrowser,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scope := NewBrowseScope(tt.ids, tt.label, tt.origin)
+			if tt.want && scope != nil {
+				t.Errorf("expected nil, got %+v", scope)
+			}
+			if !tt.want && scope == nil {
+				t.Error("expected non-nil scope, got nil")
+			}
+			if scope != nil {
+				if scope.Label != tt.label {
+					t.Errorf("label = %q, want %q", scope.Label, tt.label)
+				}
+				if scope.Origin != tt.origin {
+					t.Errorf("origin = %v, want %v", scope.Origin, tt.origin)
+				}
+				if scope.Index != 0 {
+					t.Errorf("initial index = %d, want 0", scope.Index)
+				}
+			}
+		})
+	}
+}
+
+func TestBrowseScope_Current(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope *BrowseScope
+		want  string
+	}{
+		{
+			name:  "returns current ID",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 1},
+			want:  "B",
+		},
+		{
+			name:  "returns first ID at index 0",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 0},
+			want:  "A",
+		},
+		{
+			name:  "returns empty for nil scope",
+			scope: nil,
+			want:  "",
+		},
+		{
+			name:  "returns empty for empty IDs",
+			scope: &BrowseScope{IDs: []string{}, Index: 0},
+			want:  "",
+		},
+		{
+			name:  "returns empty for out of bounds index",
+			scope: &BrowseScope{IDs: []string{"A"}, Index: 5},
+			want:  "",
+		},
+		{
+			name:  "returns empty for negative index",
+			scope: &BrowseScope{IDs: []string{"A"}, Index: -1},
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.scope.Current()
+			if got != tt.want {
+				t.Errorf("Current() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBrowseScope_HasNext(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope *BrowseScope
+		want  bool
+	}{
+		{
+			name:  "true when not at end",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 0},
+			want:  true,
+		},
+		{
+			name:  "true in middle",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 1},
+			want:  true,
+		},
+		{
+			name:  "false at last item",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 2},
+			want:  false,
+		},
+		{
+			name:  "false for single item",
+			scope: &BrowseScope{IDs: []string{"A"}, Index: 0},
+			want:  false,
+		},
+		{
+			name:  "false for nil scope",
+			scope: nil,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.scope.HasNext()
+			if got != tt.want {
+				t.Errorf("HasNext() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBrowseScope_HasPrev(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope *BrowseScope
+		want  bool
+	}{
+		{
+			name:  "false at first item",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 0},
+			want:  false,
+		},
+		{
+			name:  "true in middle",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 1},
+			want:  true,
+		},
+		{
+			name:  "true at last item",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 2},
+			want:  true,
+		},
+		{
+			name:  "false for single item",
+			scope: &BrowseScope{IDs: []string{"A"}, Index: 0},
+			want:  false,
+		},
+		{
+			name:  "false for nil scope",
+			scope: nil,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.scope.HasPrev()
+			if got != tt.want {
+				t.Errorf("HasPrev() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBrowseScope_Next(t *testing.T) {
+	tests := []struct {
+		name      string
+		scope     *BrowseScope
+		wantOK    bool
+		wantIndex int
+	}{
+		{
+			name:      "advances index",
+			scope:     &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 0},
+			wantOK:    true,
+			wantIndex: 1,
+		},
+		{
+			name:      "fails at end",
+			scope:     &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 2},
+			wantOK:    false,
+			wantIndex: 2,
+		},
+		{
+			name:      "fails for nil scope",
+			scope:     nil,
+			wantOK:    false,
+			wantIndex: 0, // N/A
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.scope.Next()
+			if got != tt.wantOK {
+				t.Errorf("Next() = %v, want %v", got, tt.wantOK)
+			}
+			if tt.scope != nil && tt.scope.Index != tt.wantIndex {
+				t.Errorf("Index = %d, want %d", tt.scope.Index, tt.wantIndex)
+			}
+		})
+	}
+}
+
+func TestBrowseScope_Prev(t *testing.T) {
+	tests := []struct {
+		name      string
+		scope     *BrowseScope
+		wantOK    bool
+		wantIndex int
+	}{
+		{
+			name:      "decrements index",
+			scope:     &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 2},
+			wantOK:    true,
+			wantIndex: 1,
+		},
+		{
+			name:      "fails at start",
+			scope:     &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 0},
+			wantOK:    false,
+			wantIndex: 0,
+		},
+		{
+			name:      "fails for nil scope",
+			scope:     nil,
+			wantOK:    false,
+			wantIndex: 0, // N/A
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.scope.Prev()
+			if got != tt.wantOK {
+				t.Errorf("Prev() = %v, want %v", got, tt.wantOK)
+			}
+			if tt.scope != nil && tt.scope.Index != tt.wantIndex {
+				t.Errorf("Index = %d, want %d", tt.scope.Index, tt.wantIndex)
+			}
+		})
+	}
+}
+
+func TestBrowseScope_Progress(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope *BrowseScope
+		want  string
+	}{
+		{
+			name:  "first of three",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 0},
+			want:  "[1/3]",
+		},
+		{
+			name:  "middle of three",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 1},
+			want:  "[2/3]",
+		},
+		{
+			name:  "last of three",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 2},
+			want:  "[3/3]",
+		},
+		{
+			name:  "single item",
+			scope: &BrowseScope{IDs: []string{"A"}, Index: 0},
+			want:  "[1/1]",
+		},
+		{
+			name:  "nil scope",
+			scope: nil,
+			want:  "",
+		},
+		{
+			name:  "empty IDs",
+			scope: &BrowseScope{IDs: []string{}, Index: 0},
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.scope.Progress()
+			if got != tt.want {
+				t.Errorf("Progress() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBrowseScope_Count(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope *BrowseScope
+		want  int
+	}{
+		{
+			name:  "returns count",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 0},
+			want:  3,
+		},
+		{
+			name:  "nil scope returns 0",
+			scope: nil,
+			want:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.scope.Count()
+			if got != tt.want {
+				t.Errorf("Count() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBrowseScope_SetIndex(t *testing.T) {
+	tests := []struct {
+		name      string
+		scope     *BrowseScope
+		idx       int
+		wantOK    bool
+		wantIndex int
+	}{
+		{
+			name:      "sets valid index",
+			scope:     &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 0},
+			idx:       2,
+			wantOK:    true,
+			wantIndex: 2,
+		},
+		{
+			name:      "fails for negative index",
+			scope:     &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 0},
+			idx:       -1,
+			wantOK:    false,
+			wantIndex: 0,
+		},
+		{
+			name:      "fails for out of bounds",
+			scope:     &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 0},
+			idx:       5,
+			wantOK:    false,
+			wantIndex: 0,
+		},
+		{
+			name:      "fails for nil scope",
+			scope:     nil,
+			idx:       0,
+			wantOK:    false,
+			wantIndex: 0, // N/A
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.scope.SetIndex(tt.idx)
+			if got != tt.wantOK {
+				t.Errorf("SetIndex(%d) = %v, want %v", tt.idx, got, tt.wantOK)
+			}
+			if tt.scope != nil && tt.scope.Index != tt.wantIndex {
+				t.Errorf("Index = %d, want %d", tt.scope.Index, tt.wantIndex)
+			}
+		})
+	}
+}
+
+func TestBrowseScope_IndexOf(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope *BrowseScope
+		id    string
+		want  int
+	}{
+		{
+			name:  "finds existing ID",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 0},
+			id:    "B",
+			want:  1,
+		},
+		{
+			name:  "returns -1 for missing ID",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 0},
+			id:    "D",
+			want:  -1,
+		},
+		{
+			name:  "returns -1 for nil scope",
+			scope: nil,
+			id:    "A",
+			want:  -1,
+		},
+		{
+			name:  "finds first ID",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 0},
+			id:    "A",
+			want:  0,
+		},
+		{
+			name:  "finds last ID",
+			scope: &BrowseScope{IDs: []string{"A", "B", "C"}, Index: 0},
+			id:    "C",
+			want:  2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.scope.IndexOf(tt.id)
+			if got != tt.want {
+				t.Errorf("IndexOf(%q) = %d, want %d", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBrowseScope_Navigation(t *testing.T) {
+	// Integration test: navigate through a scope
+	scope := NewBrowseScope([]string{"A", "B", "C", "D"}, "test", ScreenSearch)
+	if scope == nil {
+		t.Fatal("expected non-nil scope")
+	}
+
+	// Start at first
+	if scope.Current() != "A" {
+		t.Errorf("initial current = %q, want A", scope.Current())
+	}
+	if scope.Progress() != "[1/4]" {
+		t.Errorf("initial progress = %q, want [1/4]", scope.Progress())
+	}
+
+	// Navigate forward
+	if !scope.Next() {
+		t.Error("Next() should succeed")
+	}
+	if scope.Current() != "B" {
+		t.Errorf("after Next() current = %q, want B", scope.Current())
+	}
+
+	// Continue to end
+	scope.Next() // C
+	scope.Next() // D
+	if scope.Current() != "D" {
+		t.Errorf("at end current = %q, want D", scope.Current())
+	}
+	if scope.HasNext() {
+		t.Error("HasNext() should be false at end")
+	}
+	if !scope.HasPrev() {
+		t.Error("HasPrev() should be true at end")
+	}
+
+	// Can't go past end
+	if scope.Next() {
+		t.Error("Next() should fail at end")
+	}
+	if scope.Current() != "D" {
+		t.Errorf("current should still be D after failed Next(), got %q", scope.Current())
+	}
+
+	// Navigate backward
+	scope.Prev() // C
+	scope.Prev() // B
+	scope.Prev() // A
+	if scope.Current() != "A" {
+		t.Errorf("at start current = %q, want A", scope.Current())
+	}
+	if scope.HasPrev() {
+		t.Error("HasPrev() should be false at start")
+	}
+
+	// Can't go past start
+	if scope.Prev() {
+		t.Error("Prev() should fail at start")
+	}
+}

--- a/internal/tui/browser.go
+++ b/internal/tui/browser.go
@@ -137,11 +137,8 @@ func (b *BrowserModel) updateEntities(app *App, msg tea.KeyMsg) (tea.Model, tea.
 			b.entityIndex--
 		}
 	case "enter":
-		if b.entityIndex < len(b.entities) {
-			entity := b.entities[b.entityIndex]
-			app.detail = NewDetailModel(app, entity.ID)
-			return app, app.pushScreen(ScreenDetail)
-		}
+		// Browse all entities of this type with scope navigation
+		return b.enterBrowseMode(app)
 	case "backspace", "h", "left":
 		b.level = LevelTypes
 		b.entities = nil
@@ -174,6 +171,46 @@ func (b *BrowserModel) updateEntities(app *App, msg tea.KeyMsg) (tea.Model, tea.
 		return app, SetMessage("Refreshed from disk", false)
 	}
 	return app, nil
+}
+
+// enterBrowseMode creates a browse scope from the current entity list and enters detail view
+func (b *BrowserModel) enterBrowseMode(app *App) (tea.Model, tea.Cmd) {
+	if len(b.entities) == 0 {
+		return app, nil
+	}
+
+	// Collect entity IDs
+	ids := make([]string, len(b.entities))
+	for i, entity := range b.entities {
+		ids[i] = entity.ID
+	}
+
+	// Create scope label using the type label
+	typeLabel := b.selectedType
+	for _, t := range b.types {
+		if t.name == b.selectedType {
+			typeLabel = t.label
+			break
+		}
+	}
+	label := fmt.Sprintf("%d %ss", len(ids), typeLabel)
+
+	// Create browse scope starting at the currently selected entity
+	scope := NewBrowseScope(ids, label, ScreenBrowser)
+	if scope == nil {
+		return app, nil
+	}
+
+	// Set scope to currently selected item
+	scope.SetIndex(b.entityIndex)
+
+	// Create detail model with scope
+	app.detail = NewDetailModelWithScope(app, scope)
+	if app.detail == nil {
+		return app, SetMessage("Failed to open entity", true)
+	}
+
+	return app, app.pushScreen(ScreenDetail)
 }
 
 // View renders the browser
@@ -328,11 +365,10 @@ func (b *BrowserModel) Help() [][2]string {
 	case LevelEntities:
 		return [][2]string{
 			{"↑/↓", "navigate"},
-			{"enter", "view"},
+			{"enter", "browse"},
 			{"←", "back"},
 			{"c", "create"},
 			{"l", "link"},
-			{"r", "refresh"},
 		}
 	}
 	return nil

--- a/internal/tui/browser_test.go
+++ b/internal/tui/browser_test.go
@@ -474,7 +474,7 @@ func TestBrowserModel_Help(t *testing.T) {
 	foundView := false
 	foundBack := false
 	for _, item := range help {
-		if item[1] == "view" {
+		if item[1] == "browse" {
 			foundView = true
 		}
 		if item[1] == "back" {
@@ -482,7 +482,7 @@ func TestBrowserModel_Help(t *testing.T) {
 		}
 	}
 	if !foundView {
-		t.Error("Help should contain 'view'")
+		t.Error("Help should contain 'browse'")
 	}
 	if !foundBack {
 		t.Error("Help should contain 'back'")

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -27,12 +27,28 @@ type DetailModel struct {
 	// Delete confirmation state
 	confirmDelete       bool
 	confirmDeleteEntity bool // true = delete entity, false = delete relation
+
+	// Browse scope for sequential navigation through a set of entities
+	scope *BrowseScope
 }
 
 // NewDetailModel creates a new detail view
 func NewDetailModel(app *App, entityID string) *DetailModel {
 	d := &DetailModel{
 		entityID: entityID,
+	}
+	d.load(app)
+	return d
+}
+
+// NewDetailModelWithScope creates a new detail view with browse scope
+func NewDetailModelWithScope(app *App, scope *BrowseScope) *DetailModel {
+	if scope == nil || scope.Current() == "" {
+		return nil
+	}
+	d := &DetailModel{
+		entityID: scope.Current(),
+		scope:    scope,
 	}
 	d.load(app)
 	return d
@@ -73,6 +89,26 @@ func (d *DetailModel) Update(app *App, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// Handle browse scope navigation (when in scope mode)
+	if d.scope != nil {
+		switch msg.String() {
+		case "n", "right":
+			// Next entity in scope
+			if d.scope.HasNext() {
+				d.scope.Next()
+				return d.navigateToCurrentScope(app)
+			}
+			return app, SetMessage("At last item", false)
+		case "p", "left":
+			// Previous entity in scope
+			if d.scope.HasPrev() {
+				d.scope.Prev()
+				return d.navigateToCurrentScope(app)
+			}
+			return app, SetMessage("At first item", false)
+		}
+	}
+
 	switch msg.String() {
 	case "j", "down":
 		if d.relMode {
@@ -102,10 +138,18 @@ func (d *DetailModel) Update(app *App, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if rel.To == d.entityID {
 				targetID = rel.From
 			}
+			// When following a relation, leave scope mode (push new detail without scope)
 			app.detail = NewDetailModel(app, targetID)
 			return app, app.pushScreen(ScreenDetail)
 		}
 	case "l":
+		// Don't conflict with scope navigation - only handle 'l' for link when NOT in scope mode
+		if d.scope == nil {
+			app.link = NewLinkModel(app, d.entityID)
+			return app, app.pushScreen(ScreenLink)
+		}
+	case "L":
+		// Capital L for link (available in both scope and non-scope mode)
 		app.link = NewLinkModel(app, d.entityID)
 		return app, app.pushScreen(ScreenLink)
 	case "g":
@@ -137,6 +181,34 @@ func (d *DetailModel) Update(app *App, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			d.confirmDeleteEntity = true
 		}
 	}
+	return app, nil
+}
+
+// navigateToCurrentScope updates the detail view to show the current scope item
+func (d *DetailModel) navigateToCurrentScope(app *App) (tea.Model, tea.Cmd) {
+	entityID := d.scope.Current()
+	if entityID == "" {
+		return app, SetMessage("Entity not found in scope", true)
+	}
+
+	// Check if entity exists
+	entity, ok := app.graph.GetNode(entityID)
+	if !ok {
+		return app, SetMessage(fmt.Sprintf("Entity %s not found", entityID), true)
+	}
+
+	// Update detail model to show new entity
+	d.entityID = entityID
+	d.entity = entity
+	d.scrollPos = 0
+	d.relMode = false
+	d.relIndex = 0
+	d.allRels = nil
+	d.incoming = app.graph.IncomingEdges(entityID)
+	d.outgoing = app.graph.OutgoingEdges(entityID)
+	d.allRels = append(d.allRels, d.incoming...)
+	d.allRels = append(d.allRels, d.outgoing...)
+
 	return app, nil
 }
 
@@ -395,10 +467,30 @@ func (d *DetailModel) View(_, height int) string {
 		Bold(true)
 
 	// Build all lines first
-	lines := []string{
-		idStyle.Render(d.entity.ID) + labelStyle.Render(fmt.Sprintf(" (%s)", d.entity.Type)),
-		headerStyle.Render(d.entity.Title()),
-		"",
+	// Show progress indicator if in browse scope
+	progressLine := ""
+	if d.scope != nil {
+		progressStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("39")).
+			Bold(true)
+		scopeLabelStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("240"))
+		progressLine = progressStyle.Render(d.scope.Progress()) + " " + scopeLabelStyle.Render(d.scope.Label)
+	}
+
+	var lines []string
+	if progressLine != "" {
+		lines = append(lines, progressLine,
+			idStyle.Render(d.entity.ID)+labelStyle.Render(fmt.Sprintf(" (%s)", d.entity.Type)),
+			headerStyle.Render(d.entity.Title()),
+			"",
+		)
+	} else {
+		lines = append(lines,
+			idStyle.Render(d.entity.ID)+labelStyle.Render(fmt.Sprintf(" (%s)", d.entity.Type)),
+			headerStyle.Render(d.entity.Title()),
+			"",
+		)
 	}
 
 	// Properties
@@ -533,6 +625,30 @@ func (d *DetailModel) Help() [][2]string {
 			{"n/esc", "cancel"},
 		}
 	}
+
+	// In browse scope mode, show navigation help
+	if d.scope != nil {
+		if d.relMode {
+			return [][2]string{
+				{"n/→", "next"},
+				{"p/←", "prev"},
+				{"↑/↓", "navigate"},
+				{"tab", "scroll mode"},
+				{"enter", "follow"},
+				{"e", "edit"},
+			}
+		}
+		return [][2]string{
+			{"n/→", "next"},
+			{"p/←", "prev"},
+			{"↑/↓", "scroll"},
+			{"tab", "rel mode"},
+			{"e", "edit"},
+			{"g", "graph"},
+		}
+	}
+
+	// Normal detail mode (no browse scope)
 	if d.relMode {
 		return [][2]string{
 			{"↑/↓", "navigate"},

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -229,11 +229,18 @@ func (s *SearchModel) Update(app *App, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			s.updateSuggestions(app)
 			return app, s.triggerSearch()
 		}
-		// Otherwise, open selected result
+		// Otherwise, open selected result (single item, no scope)
 		if len(s.results) > 0 {
 			entity := s.results[s.resultIndex]
 			app.detail = NewDetailModel(app, entity.ID)
 			return app, app.pushScreen(ScreenDetail)
+		}
+		return app, nil
+
+	case "b":
+		// Browse all results with scope navigation
+		if !s.showSuggestions && len(s.results) > 0 {
+			return s.enterBrowseMode(app)
 		}
 		return app, nil
 
@@ -760,12 +767,54 @@ func (s *SearchModel) highlightSyntax(text string) string {
 	return result.String()
 }
 
+// enterBrowseMode creates a browse scope from search results and enters detail view
+func (s *SearchModel) enterBrowseMode(app *App) (tea.Model, tea.Cmd) {
+	if len(s.results) == 0 {
+		return app, nil
+	}
+
+	// Collect entity IDs from results
+	ids := make([]string, len(s.results))
+	for i, entity := range s.results {
+		ids[i] = entity.ID
+	}
+
+	// Create scope label
+	label := fmt.Sprintf("%d search results", len(ids))
+	if s.lastQuery != "" {
+		// Truncate long queries
+		query := s.lastQuery
+		if len(query) > 30 {
+			query = query[:27] + "..."
+		}
+		label = fmt.Sprintf("%d results for \"%s\"", len(ids), query)
+	}
+
+	// Create browse scope starting at the currently selected result
+	scope := NewBrowseScope(ids, label, ScreenSearch)
+	if scope == nil {
+		return app, nil
+	}
+
+	// Set scope to currently selected item
+	scope.SetIndex(s.resultIndex)
+
+	// Create detail model with scope
+	app.detail = NewDetailModelWithScope(app, scope)
+	if app.detail == nil {
+		return app, SetMessage("Failed to open entity", true)
+	}
+
+	return app, app.pushScreen(ScreenDetail)
+}
+
 // Help returns help items
 func (s *SearchModel) Help() [][2]string {
 	if len(s.results) > 0 {
 		return [][2]string{
 			{"↑/↓", "navigate"},
 			{"enter", "open"},
+			{"b", "browse all"},
 			{"ctrl+u", "clear"},
 			{"esc", "back"},
 		}


### PR DESCRIPTION
## Summary

- Adds a `BrowseScope` concept for navigating through a subset of entities using prev/next controls while viewing full details
- Integrates with search results (`b` key to browse all matches) and entity browser (`enter` to browse all of a type)
- Shows progress indicator (`[3/12]`) and scope label in the detail view header
- Scope uses snapshot behavior: edits don't change the browse list

## New files

- `internal/tui/browse_scope.go` — Core `BrowseScope` struct with navigation logic
- `internal/tui/browse_scope_test.go` — Comprehensive unit tests

## Key bindings (in scope mode)

| Key | Action |
|-----|--------|
| `n` / `→` | Next entity |
| `p` / `←` | Previous entity |
| `e` | Edit current entity in `$EDITOR` |
| `q` / `Esc` | Exit browse mode |

## Test plan

- [x] All existing tests pass
- [x] New BrowseScope unit tests pass (navigation, bounds, progress formatting, nil safety)
- [x] Lint clean
- [x] Coverage thresholds met
- [ ] Manual TUI testing: search → browse, browser → browse, edit flow, boundary behavior