### PR TITLE
Add metamodel error handling: user-friendly validation and fuzz testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,8 @@ fuzz:
 	$(GO) test -run='^$$' -fuzz='^FuzzParseEntityID$$' -fuzztime=30s ./internal/model/
 	$(GO) test -run='^$$' -fuzz='^FuzzValidateID$$' -fuzztime=30s ./internal/model/
 	$(GO) test -run='^$$' -fuzz='^FuzzParseRelationFilename$$' -fuzztime=30s ./internal/markdown/
+	$(GO) test -run='^$$' -fuzz='^FuzzParse$$' -fuzztime=30s ./internal/metamodel/
+	$(GO) test -run='^$$' -fuzz='^FuzzParseErrorQuality$$' -fuzztime=30s ./internal/metamodel/
 
 # Run quick fuzz tests (5 seconds each)
 fuzz-short:
@@ -74,6 +76,8 @@ fuzz-short:
 	$(GO) test -run='^$$' -fuzz='^FuzzParseEntityID$$' -fuzztime=5s ./internal/model/
 	$(GO) test -run='^$$' -fuzz='^FuzzValidateID$$' -fuzztime=5s ./internal/model/
 	$(GO) test -run='^$$' -fuzz='^FuzzParseRelationFilename$$' -fuzztime=5s ./internal/markdown/
+	$(GO) test -run='^$$' -fuzz='^FuzzParse$$' -fuzztime=5s ./internal/metamodel/
+	$(GO) test -run='^$$' -fuzz='^FuzzParseErrorQuality$$' -fuzztime=5s ./internal/metamodel/
 
 # Run linter (Go)
 lint:

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -34,7 +34,7 @@ entities:
   requirement:
     label: Requirement
     aliases: [req]
-    id_patterns: ["REQ-"]
+    id_prefix: "REQ-"
     properties:
       title:
         type: string
@@ -45,7 +45,7 @@ entities:
   control:
     label: Control
     aliases: [ctrl]
-    id_patterns: ["CTRL-"]
+    id_prefix: "CTRL-"
     properties:
       title:
         type: string
@@ -130,7 +130,7 @@ entities:
   requirement:
     label: Requirement
     aliases: [req]
-    id_patterns: ["REQ-"]
+    id_prefix: "REQ-"
     properties:
       title:
         type: string
@@ -191,7 +191,7 @@ entities:
   requirement:
     label: Requirement
     aliases: [req]
-    id_patterns: ["REQ-"]
+    id_prefix: "REQ-"
     properties:
       title:
         type: string
@@ -202,7 +202,7 @@ entities:
   bus:
     label: Bus
     aliases: [autobus]
-    id_patterns: ["BUS-"]
+    id_prefix: "BUS-"
     properties:
       title:
         type: string

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -1,13 +1,33 @@
 package metamodel
 
 import (
+	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/migration"
 )
+
+// validTopLevelKeys are the recognized top-level keys in a metamodel YAML file.
+var validTopLevelKeys = map[string]bool{
+	"version":     true,
+	"namespace":   true,
+	"types":       true,
+	"entities":    true,
+	"relations":   true,
+	"validations": true,
+}
+
+// knownTypos maps common misspellings to the correct key name.
+var knownTypos = map[string]string{
+	"entity":     "entities",
+	"type":       "types",
+	"relation":   "relations",
+	"validation": "validations",
+}
 
 // Load reads and parses a metamodel from a YAML file.
 // Returns a MigrationError if the file contains deprecated syntax that needs migration.
@@ -36,6 +56,11 @@ func Load(path string) (*Metamodel, error) {
 func Parse(data []byte) (*Metamodel, error) {
 	var m Metamodel
 	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, humanizeYAMLError(err)
+	}
+
+	// Check for unknown/misspelled top-level keys
+	if err := checkUnknownKeys(data); err != nil {
 		return nil, err
 	}
 
@@ -46,43 +71,186 @@ func Parse(data []byte) (*Metamodel, error) {
 		}
 	}
 
-	// Build alias map and validate entity definitions
+	// Validate entity definitions (returns hard errors for structural issues)
+	if err := validateEntityStructure(&m); err != nil {
+		return nil, err
+	}
+
+	// Collect semantic validation errors so users see all problems at once
+	var validationErrors []string
+
+	if len(m.Entities) == 0 {
+		validationErrors = append(validationErrors, "metamodel has no entity types defined")
+	}
+
+	validationErrors = append(validationErrors, validateEntitySemantics(&m)...)
+	validationErrors = append(validationErrors, validateRelationReferences(&m)...)
+
+	if len(validationErrors) > 0 {
+		return nil, &SchemaValidationError{Errors: validationErrors}
+	}
+
+	return &m, nil
+}
+
+// validateEntityStructure checks for hard structural errors in entity definitions
+// (reserved names, whitespace, conflicting IDs) and builds the alias map.
+// Returns immediately on the first error found.
+func validateEntityStructure(m *Metamodel) error {
 	m.aliasMap = make(map[string]string)
+
 	for name, def := range m.Entities {
-		// Validate id_type if specified
 		if def.IDType != "" && def.IDType != IDTypeAuto && def.IDType != IDTypeManual {
-			return nil, &InvalidIDTypeError{EntityType: name, IDType: def.IDType}
+			return &InvalidIDTypeError{EntityType: name, IDType: def.IDType}
 		}
 
-		// Validate property names
 		for propName := range def.Properties {
-			// Reject property names with leading or trailing whitespace
-			// This prevents bypassing reserved name checks with " id" or "type " etc.
 			trimmedName := strings.TrimSpace(propName)
 			if trimmedName != propName {
-				return nil, &WhitespacePropertyError{EntityType: name, PropertyName: propName}
+				return &WhitespacePropertyError{EntityType: name, PropertyName: propName}
 			}
-
-			// Check for reserved property names
 			if ReservedPropertyNames[propName] {
-				return nil, &ReservedPropertyError{EntityType: name, PropertyName: propName}
+				return &ReservedPropertyError{EntityType: name, PropertyName: propName}
 			}
 		}
 
-		// Validate id_prefix/id_prefixes are not both specified
 		if def.IDPrefix != "" && len(def.IDPrefixes) > 0 {
-			return nil, &ConflictingIDPrefixError{EntityType: name}
+			return &ConflictingIDPrefixError{EntityType: name}
 		}
 
-		// Add lowercase name as self-reference
 		m.aliasMap[strings.ToLower(name)] = name
-		// Add all aliases
 		for _, alias := range def.Aliases {
 			m.aliasMap[strings.ToLower(alias)] = name
 		}
 	}
 
-	return &m, nil
+	return nil
+}
+
+// validateEntitySemantics collects semantic warnings/errors about entity definitions
+// (missing labels, properties, ID prefixes, unknown types).
+func validateEntitySemantics(m *Metamodel) []string {
+	var errs []string
+
+	entityNames := sortedKeys(m.Entities)
+	for _, name := range entityNames {
+		def := m.Entities[name]
+
+		if def.Label == "" {
+			errs = append(errs, fmt.Sprintf("entity %q: missing 'label'", name))
+		}
+		if len(def.Properties) == 0 {
+			errs = append(errs, fmt.Sprintf("entity %q: no properties defined", name))
+		}
+		if def.GetIDType() == IDTypeAuto && def.IDPrefix == "" && len(def.IDPrefixes) == 0 {
+			errs = append(errs, fmt.Sprintf(
+				"entity %q: no ID prefix defined (set 'id_prefix' or 'id_prefixes', or use 'id_type: manual')", name))
+		}
+
+		for propName, propDef := range def.Properties {
+			if propDef.Type == "" {
+				errs = append(errs, fmt.Sprintf("entity %q: property %q has no type specified", name, propName))
+				continue
+			}
+			if !isKnownPropertyType(propDef.Type, m) {
+				errs = append(errs, fmt.Sprintf(
+					"entity %q: property %q has unknown type %q (not a built-in type and not defined in 'types')",
+					name, propName, propDef.Type))
+			}
+			if propDef.Type == PropertyTypeEnum && len(propDef.Values) == 0 {
+				errs = append(errs, fmt.Sprintf(
+					"entity %q: property %q is type \"enum\" but has no 'values' list", name, propName))
+			}
+		}
+	}
+
+	return errs
+}
+
+// validateRelationReferences checks that all entity types referenced in relations exist.
+func validateRelationReferences(m *Metamodel) []string {
+	var errs []string
+
+	relNames := sortedKeys(m.Relations)
+	for _, name := range relNames {
+		rel := m.Relations[name]
+		for _, fromType := range rel.From {
+			if _, ok := m.Entities[fromType]; !ok {
+				errs = append(errs, fmt.Sprintf(
+					"relation %q: references unknown entity type %q in 'from'", name, fromType))
+			}
+		}
+		for _, toType := range rel.To {
+			if _, ok := m.Entities[toType]; !ok {
+				errs = append(errs, fmt.Sprintf(
+					"relation %q: references unknown entity type %q in 'to'", name, toType))
+			}
+		}
+	}
+
+	return errs
+}
+
+// sortedKeys returns the keys of a map sorted alphabetically.
+// Works with any map type using a generic constraint would be ideal,
+// but we use interface{} maps here.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// isKnownPropertyType checks if a property type is valid (built-in, legacy, or custom).
+func isKnownPropertyType(typeName string, m *Metamodel) bool {
+	if IsBuiltinType(typeName) {
+		return true
+	}
+	// Legacy built-in types
+	if typeName == "status" || typeName == "priority" {
+		return true
+	}
+	// Custom types
+	_, ok := m.Types[typeName]
+	return ok
+}
+
+// checkUnknownKeys detects unknown top-level keys in the metamodel YAML.
+// This catches common typos like "entity" instead of "entities".
+func checkUnknownKeys(data []byte) error {
+	var raw map[string]interface{}
+	if unmarshalErr := yaml.Unmarshal(data, &raw); unmarshalErr != nil {
+		// If we can't unmarshal as a map, the struct unmarshal already failed
+		// with a better error, so skip this check
+		return nil //nolint:nilerr // intentional: struct unmarshal error is better
+	}
+
+	var unknownKeyErrors []string
+	for key := range raw {
+		if validTopLevelKeys[key] {
+			continue
+		}
+		if suggestion, ok := knownTypos[key]; ok {
+			unknownKeyErrors = append(unknownKeyErrors,
+				fmt.Sprintf("unknown key %q (did you mean %q?)", key, suggestion))
+		} else {
+			keys := make([]string, 0, len(validTopLevelKeys))
+			for k := range validTopLevelKeys {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			unknownKeyErrors = append(unknownKeyErrors,
+				fmt.Sprintf("unknown key %q (valid keys: %s)", key, strings.Join(keys, ", ")))
+		}
+	}
+
+	if len(unknownKeyErrors) > 0 {
+		sort.Strings(unknownKeyErrors)
+		return &SchemaValidationError{Errors: unknownKeyErrors}
+	}
+	return nil
 }
 
 // DefaultMetamodel returns a minimal default metamodel

--- a/internal/metamodel/loader_fuzz_test.go
+++ b/internal/metamodel/loader_fuzz_test.go
@@ -1,0 +1,529 @@
+package metamodel
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// forbiddenPatterns are Go/YAML internals that should never leak into user-facing errors.
+// If Parse() returns an error containing any of these, the error message is confusing.
+var forbiddenPatterns = []*regexp.Regexp{
+	// YAML tag internals
+	regexp.MustCompile(`!!\w+`), // !!str, !!seq, !!map, !!int, !!float, !!bool, !!null
+
+	// Go type names that leak through yaml.TypeError
+	regexp.MustCompile(`metamodel\.\w+`),           // metamodel.PropertyDef, metamodel.EntityDef, etc.
+	regexp.MustCompile(`\bmap\[string\]\w+`),       // map[string]PropertyDef, map[string]interface{}
+	regexp.MustCompile(`\[\]\w+\.\w+`),             // []metamodel.ValidationRule
+	regexp.MustCompile(`cannot unmarshal`),         // raw yaml.TypeError language
+	regexp.MustCompile(`\binto\b.*\b(map|struct)`), // "into map[string]..." or "into struct"
+}
+
+// allowedErrorPrefixes are patterns that user-friendly errors should match.
+// Every error from Parse() should contain at least one of these to be considered friendly.
+var allowedErrorPrefixes = []string{
+	// Structural YAML issues (humanized)
+	"line ",             // "line 7: expected a list, got a string"
+	"yaml:",             // "yaml: ..." (syntax errors from yaml library)
+	"did not find",      // yaml syntax error
+	"invalid YAML",      // fallback sanitized message
+	"invalid value for", // fallback sanitized message with line number
+
+	// Schema validation (our custom messages)
+	"entity ",           // entity "x": missing 'label' / property issues
+	"relation ",         // relation "x": references unknown entity type
+	"metamodel ",        // metamodel has no entity types / metamodel validation errors
+	"unknown key ",      // unknown key "entity" (did you mean "entities"?)
+	"cannot define",     // cannot define custom type "string": name is reserved
+	"invalid id_type",   // invalid id_type for entity x
+	"no ID prefix",      // no ID prefix defined
+	"missing ",          // missing 'label', missing required property
+	"no properties",     // no properties defined
+	"no entity types",   // no entity types defined
+	"unknown type",      // property x has unknown type "y"
+	"no type specified", // property "x" has no type specified
+	"has unknown type",  // property x has unknown type
+	"is type \"enum\"",  // is type "enum" but has no 'values' list
+	"expected ",         // "expected a list, got a string" (humanized yaml errors)
+	"invalid ",          // invalid value, invalid date, etc.
+	"property ",         // property x has unknown type
+	"references ",       // references unknown entity type
+	"specifies both",    // specifies both id_prefix and id_prefixes
+}
+
+// FuzzParse tests that Parse never panics and always returns user-friendly errors.
+// Run with: go test -fuzz=FuzzParse -fuzztime=30s ./internal/metamodel/
+func FuzzParse(f *testing.F) {
+	// Seed corpus: valid metamodels
+	seeds := []string{
+		// Minimal valid
+		`version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+`,
+		// Full valid metamodel
+		DefaultMetamodelYAML(),
+
+		// Empty
+		"",
+
+		// Just a scalar
+		"hello",
+
+		// YAML list instead of mapping
+		"- item1\n- item2",
+
+		// Completely wrong structure
+		`entities: "not a map"`,
+
+		// Properties as a list instead of a map
+		`version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+    properties:
+      - title
+      - status
+`,
+
+		// Type mismatch: aliases as string instead of list
+		`version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+    aliases: not-a-list
+    properties:
+      title:
+        type: string
+`,
+
+		// Type mismatch: from as string instead of list
+		`version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+relations:
+  depends:
+    label: depends
+    from: task
+    to: task
+`,
+
+		// Misspelled top-level keys
+		`version: "1.0"
+entity:
+  task:
+    label: Task
+`,
+		`version: "1.0"
+type:
+  status:
+    values: [draft]
+`,
+		`version: "1.0"
+relation:
+  depends:
+    from: [task]
+`,
+
+		// Unknown property type
+		`version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+      severity:
+        type: nonexistent
+`,
+
+		// Enum without values
+		`version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+      size:
+        type: enum
+`,
+
+		// Relation referencing nonexistent entity
+		`version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+relations:
+  depends:
+    label: depends
+    from: [ghost]
+    to: [task]
+`,
+
+		// Missing label
+		`version: "1.0"
+entities:
+  task:
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+`,
+
+		// Missing properties
+		`version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+`,
+
+		// Missing id_prefix for auto
+		`version: "1.0"
+entities:
+  task:
+    label: Task
+    properties:
+      title:
+        type: string
+`,
+
+		// Both id_prefix and id_prefixes
+		`version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+    id_prefixes: ["TASK-", "T-"]
+    properties:
+      title:
+        type: string
+`,
+
+		// Invalid id_type
+		`version: "1.0"
+entities:
+  task:
+    label: Task
+    id_type: bogus
+    properties:
+      title:
+        type: string
+`,
+
+		// Reserved property name
+		`version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+    properties:
+      id:
+        type: string
+`,
+
+		// Reserved type name
+		`version: "1.0"
+types:
+  string:
+    values: [a, b]
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+`,
+
+		// Empty entities
+		`version: "1.0"
+entities: {}
+`,
+
+		// Deeply nested nonsense
+		`version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+        required:
+          nested: true
+`,
+
+		// Validations as a map instead of a list
+		`version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+validations:
+  rule1:
+    name: test
+`,
+
+		// Unicode entity names
+		`version: "1.0"
+entities:
+  要件:
+    label: 要件
+    id_prefix: "要件-"
+    properties:
+      タイトル:
+        type: string
+`,
+
+		// Very long entity name
+		`version: "1.0"
+entities:
+  ` + strings.Repeat("a", 200) + `:
+    label: Long
+    id_prefix: "L-"
+    properties:
+      title:
+        type: string
+`,
+
+		// Null values
+		`version: "1.0"
+entities:
+  task:
+    label: ~
+    id_prefix: ~
+    properties: ~
+`,
+
+		// Boolean where string expected
+		`version: "1.0"
+entities:
+  task:
+    label: true
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+`,
+
+		// Number where string expected
+		`version: "1.0"
+entities:
+  task:
+    label: 42
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+`,
+
+		// Duplicate keys (YAML spec says last wins)
+		`version: "1.0"
+entities:
+  task:
+    label: First
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+  task:
+    label: Second
+    id_prefix: "T-"
+    properties:
+      name:
+        type: string
+`,
+
+		// Tab indentation (common YAML mistake)
+		"version: \"1.0\"\nentities:\n\ttask:\n\t\tlabel: Task\n",
+
+		// Anchor/alias usage
+		`version: "1.0"
+entities:
+  task: &task_def
+    label: Task
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+  cloned_task: *task_def
+`,
+	}
+
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		// Parse should NEVER panic, regardless of input
+		meta, err := Parse([]byte(input))
+
+		if err == nil {
+			// Valid parse — verify basic invariants
+			if meta == nil {
+				t.Fatal("Parse returned nil metamodel without error")
+			}
+			return
+		}
+
+		// Error path: verify the error message is user-friendly
+		errMsg := err.Error()
+
+		// Check for forbidden Go/YAML internals
+		for _, pattern := range forbiddenPatterns {
+			if pattern.MatchString(errMsg) {
+				t.Errorf("error contains Go/YAML internal %q:\n  %s", pattern.String(), errMsg)
+			}
+		}
+	})
+}
+
+// FuzzParseErrorQuality is a property-based test that validates error messages
+// are always comprehensible. It uses structured fuzzing to generate YAML-like
+// documents that are more likely to exercise validation paths.
+func FuzzParseErrorQuality(f *testing.F) {
+	// Seeds are (version, entityName, label, idPrefix, propName, propType, extraKey)
+	// These are combined to generate metamodel YAML documents with controlled variation.
+	f.Add("1.0", "task", "Task", "TASK-", "title", "string", "")
+	f.Add("1.0", "req", "Requirement", "REQ-", "title", "nonexistent", "")
+	f.Add("1.0", "task", "", "TASK-", "title", "string", "")           // missing label
+	f.Add("1.0", "task", "Task", "", "title", "string", "")            // missing prefix
+	f.Add("1.0", "task", "Task", "TASK-", "title", "enum", "")         // enum without values
+	f.Add("1.0", "task", "Task", "TASK-", "id", "string", "")          // reserved prop
+	f.Add("1.0", "task", "Task", "TASK-", "title", "string", "entity") // misspelled key
+	f.Add("1.0", "task", "Task", "TASK-", "title", "string", "widgets")
+	f.Add("", "task", "Task", "TASK-", "title", "string", "")
+	f.Add("1.0", "", "Task", "TASK-", "title", "string", "")
+
+	f.Fuzz(func(t *testing.T, version, entityName, label, idPrefix, propName, propType, extraKey string) {
+		// Skip inputs that would make invalid YAML (control chars, colons, etc.)
+		for _, s := range []string{version, entityName, label, idPrefix, propName, propType, extraKey} {
+			if strings.ContainsAny(s, ":\n\r\t{}[]#&*!|>'\",") {
+				return
+			}
+			if len(s) > 100 {
+				return
+			}
+		}
+
+		// Skip empty entity names (not valid YAML keys)
+		if entityName == "" {
+			return
+		}
+
+		// Build a metamodel YAML document
+		var b strings.Builder
+		if version != "" {
+			b.WriteString("version: \"" + version + "\"\n")
+		}
+
+		if extraKey != "" && extraKey != "version" && extraKey != "entities" {
+			b.WriteString(extraKey + ": {}\n")
+		}
+
+		b.WriteString("entities:\n")
+		b.WriteString("  " + entityName + ":\n")
+		if label != "" {
+			b.WriteString("    label: " + label + "\n")
+		}
+		if idPrefix != "" {
+			b.WriteString("    id_prefix: \"" + idPrefix + "\"\n")
+		}
+		if propName != "" {
+			b.WriteString("    properties:\n")
+			b.WriteString("      " + propName + ":\n")
+			if propType != "" {
+				b.WriteString("        type: " + propType + "\n")
+			}
+		}
+
+		input := b.String()
+
+		meta, err := Parse([]byte(input))
+
+		if err == nil {
+			if meta == nil {
+				t.Fatal("Parse returned nil metamodel without error")
+			}
+			return
+		}
+
+		errMsg := err.Error()
+
+		// PROPERTY 1: No Go/YAML internal leakage
+		for _, pattern := range forbiddenPatterns {
+			if pattern.MatchString(errMsg) {
+				t.Errorf("error leaks Go/YAML internal %q for input:\n%s\nerror: %s",
+					pattern.String(), input, errMsg)
+			}
+		}
+
+		// PROPERTY 2: Error is not empty
+		if errMsg == "" {
+			t.Errorf("Parse returned error with empty message for input:\n%s", input)
+		}
+
+		// PROPERTY 3: Error must match at least one known-friendly pattern.
+		// This ensures we never return a raw/confusing error that we haven't accounted for.
+		assertFriendlyError(t, err, errMsg, input)
+	})
+}
+
+// assertFriendlyError verifies that an error message matches at least one known-friendly pattern.
+// For SchemaValidationError, it checks each sub-error individually.
+func assertFriendlyError(t *testing.T, err error, errMsg, input string) {
+	t.Helper()
+
+	if matchesAnyFriendlyPattern(errMsg) {
+		return
+	}
+
+	// Check if it's a SchemaValidationError with multiple sub-errors
+	var schemaErr *SchemaValidationError
+	if errors.As(err, &schemaErr) {
+		for _, subErr := range schemaErr.Errors {
+			if !matchesAnyFriendlyPattern(subErr) {
+				t.Errorf("sub-error does not match any friendly pattern: %q\nfull error: %s\ninput:\n%s",
+					subErr, errMsg, input)
+			}
+		}
+		return
+	}
+
+	t.Errorf("error does not match any friendly pattern: %q\ninput:\n%s", errMsg, input)
+}
+
+// matchesAnyFriendlyPattern checks if an error message contains any known-friendly substring.
+func matchesAnyFriendlyPattern(errMsg string) bool {
+	for _, prefix := range allowedErrorPrefixes {
+		if strings.Contains(errMsg, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -455,6 +456,7 @@ entities:
   task:
     label: Task
     id_type: auto
+    id_prefix: "TASK-"
     properties:
       title:
         type: string
@@ -489,12 +491,14 @@ entities:
   requirement:
     label: Requirement
     aliases: [req, reqs]
+    id_prefix: "REQ-"
     properties:
       title:
         type: string
   decision:
     label: Decision
     aliases: [dec]
+    id_prefix: "DEC-"
     properties:
       title:
         type: string
@@ -578,4 +582,385 @@ func TestInvalidIDTypeError_Error(t *testing.T) {
 	if err.Error() != expected {
 		t.Errorf("expected %q, got %q", expected, err.Error())
 	}
+}
+
+func TestParse_UnknownTopLevelKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "entity instead of entities",
+			yaml: `
+version: "1.0"
+entity:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+types: {}
+relations: {}
+`,
+			wantErr: `unknown key "entity" (did you mean "entities"?)`,
+		},
+		{
+			name: "type instead of types",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+type:
+  status:
+    values: [draft]
+relations: {}
+`,
+			wantErr: `unknown key "type" (did you mean "types"?)`,
+		},
+		{
+			name: "relation instead of relations",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+types: {}
+relation:
+  addresses:
+    label: addresses
+`,
+			wantErr: `unknown key "relation" (did you mean "relations"?)`,
+		},
+		{
+			name: "completely unknown key",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+types: {}
+relations: {}
+widgets:
+  fancy: true
+`,
+			wantErr: `unknown key "widgets"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.yaml))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			var validationErr *SchemaValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("expected SchemaValidationError, got %T: %v", err, err)
+			}
+
+			found := false
+			for _, e := range validationErr.Errors {
+				if strings.Contains(e, tt.wantErr) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestParse_UnknownPropertyType(t *testing.T) {
+	yaml := `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+        required: true
+      priority:
+        type: mypriority
+types: {}
+relations: {}
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+
+	if !strings.Contains(err.Error(), "unknown type") {
+		t.Errorf("expected 'unknown type' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "mypriority") {
+		t.Errorf("expected 'mypriority' in error, got: %v", err)
+	}
+}
+
+func TestParse_EnumWithoutValues(t *testing.T) {
+	yaml := `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+        required: true
+      priority:
+        type: enum
+types: {}
+relations: {}
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+
+	if !strings.Contains(err.Error(), "enum") {
+		t.Errorf("expected 'enum' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "values") {
+		t.Errorf("expected 'values' in error, got: %v", err)
+	}
+}
+
+func TestParse_RelationReferencesUnknownEntityType(t *testing.T) {
+	yaml := `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+types: {}
+relations:
+  addresses:
+    label: addresses
+    from: [nonexistent]
+    to: [requirement]
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+
+	if !strings.Contains(err.Error(), "unknown entity type") {
+		t.Errorf("expected 'unknown entity type' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("expected 'nonexistent' in error, got: %v", err)
+	}
+}
+
+func TestParse_EmptyEntities(t *testing.T) {
+	yaml := `
+version: "1.0"
+entities: {}
+types: {}
+relations: {}
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+
+	if !strings.Contains(err.Error(), "no entity types defined") {
+		t.Errorf("expected 'no entity types defined' in error, got: %v", err)
+	}
+}
+
+func TestParse_MissingEntityLabel(t *testing.T) {
+	yaml := `
+version: "1.0"
+entities:
+  requirement:
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+types: {}
+relations: {}
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+
+	if !strings.Contains(err.Error(), "missing 'label'") {
+		t.Errorf("expected \"missing 'label'\" in error, got: %v", err)
+	}
+}
+
+func TestParse_MissingEntityProperties(t *testing.T) {
+	yaml := `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+types: {}
+relations: {}
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+
+	if !strings.Contains(err.Error(), "no properties defined") {
+		t.Errorf("expected 'no properties defined' in error, got: %v", err)
+	}
+}
+
+func TestParse_MissingIDPrefix(t *testing.T) {
+	yaml := `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    properties:
+      title:
+        type: string
+types: {}
+relations: {}
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+
+	if !strings.Contains(err.Error(), "no ID prefix defined") {
+		t.Errorf("expected 'no ID prefix defined' in error, got: %v", err)
+	}
+}
+
+func TestParse_MissingIDPrefixManualIDTypeOK(t *testing.T) {
+	yaml := `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_type: manual
+    properties:
+      title:
+        type: string
+types: {}
+relations: {}
+`
+	_, err := Parse([]byte(yaml))
+	assertNoError(t, err)
+}
+
+func TestParse_EmptyPropertyType(t *testing.T) {
+	yaml := `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+      notes:
+        type:
+types: {}
+relations: {}
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+
+	if !strings.Contains(err.Error(), "no type specified") {
+		t.Errorf("expected 'no type specified' in error, got: %v", err)
+	}
+}
+
+func TestParse_MultipleValidationErrors(t *testing.T) {
+	// Multiple issues should all be reported at once
+	yaml := `
+version: "1.0"
+entities:
+  requirement:
+    id_prefix: "REQ-"
+  decision:
+    id_prefix: "DEC-"
+types: {}
+relations: {}
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+
+	var validationErr *SchemaValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected SchemaValidationError, got %T: %v", err, err)
+	}
+
+	// Should have multiple errors (missing label, missing properties for both entities)
+	if len(validationErr.Errors) < 2 {
+		t.Errorf("expected multiple validation errors, got %d: %v", len(validationErr.Errors), validationErr.Errors)
+	}
+}
+
+func TestParse_ValidMetamodel(t *testing.T) {
+	// Ensure a fully valid metamodel still passes
+	yaml := `
+version: "1.0"
+namespace: "https://example.org/test#"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+        required: true
+      status:
+        type: status
+  decision:
+    label: Decision
+    id_prefix: "DEC-"
+    properties:
+      title:
+        type: string
+        required: true
+types:
+  status:
+    values: [draft, accepted]
+relations:
+  addresses:
+    label: addresses
+    from: [decision]
+    to: [requirement]
+`
+	meta, err := Parse([]byte(yaml))
+	assertNoError(t, err)
+
+	if meta == nil {
+		t.Fatal("expected metamodel, got nil")
+	}
+	assertEqual(t, len(meta.Entities), 2)
+	assertEqual(t, len(meta.Relations), 1)
+}
+
+func TestSchemaValidationError_SingleError(t *testing.T) {
+	err := &SchemaValidationError{
+		Errors: []string{"something is wrong"},
+	}
+	assertEqual(t, err.Error(), "something is wrong")
+}
+
+func TestSchemaValidationError_MultipleErrors(t *testing.T) {
+	err := &SchemaValidationError{
+		Errors: []string{"first problem", "second problem"},
+	}
+	expected := "metamodel validation errors:\n  - first problem\n  - second problem"
+	assertEqual(t, err.Error(), expected)
 }

--- a/internal/metamodel/testdata/fuzz/FuzzParse/3b5e07993f43a6b1
+++ b/internal/metamodel/testdata/fuzz/FuzzParse/3b5e07993f43a6b1
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0!!0\n\n0")

--- a/internal/metamodel/testdata/fuzz/FuzzParse/441be9b9cd8083c4
+++ b/internal/metamodel/testdata/fuzz/FuzzParse/441be9b9cd8083c4
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("!!0")

--- a/internal/metamodel/testdata/fuzz/FuzzParse/55fcc5eb67c9cd1d
+++ b/internal/metamodel/testdata/fuzz/FuzzParse/55fcc5eb67c9cd1d
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\n!0$ !00000\n0: 000000000")

--- a/internal/metamodel/testdata/fuzz/FuzzParse/5b78419896df61a4
+++ b/internal/metamodel/testdata/fuzz/FuzzParse/5b78419896df61a4
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("!%09")

--- a/internal/metamodel/testdata/fuzz/FuzzParseErrorQuality/11c61679f9327985
+++ b/internal/metamodel/testdata/fuzz/FuzzParseErrorQuality/11c61679f9327985
@@ -1,0 +1,8 @@
+go test fuzz v1
+string("0")
+string("  0")
+string("0")
+string("`")
+string("0")
+string("0")
+string("")

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -1,5 +1,7 @@
 package metamodel
 
+import "strings"
+
 // Metamodel represents the full metamodel configuration
 type Metamodel struct {
 	Version     string                 `yaml:"version"`
@@ -531,6 +533,18 @@ type ReservedTypeNameError struct {
 func (e *ReservedTypeNameError) Error() string {
 	return "cannot define custom type \"" + e.TypeName +
 		"\": name is reserved for built-in type (reserved: string, date, integer, boolean, enum)"
+}
+
+// SchemaValidationError collects multiple validation issues found in a metamodel.
+type SchemaValidationError struct {
+	Errors []string
+}
+
+func (e *SchemaValidationError) Error() string {
+	if len(e.Errors) == 1 {
+		return e.Errors[0]
+	}
+	return "metamodel validation errors:\n  - " + strings.Join(e.Errors, "\n  - ")
 }
 
 // Schema output interface methods for Metamodel

--- a/internal/metamodel/types_test.go
+++ b/internal/metamodel/types_test.go
@@ -375,6 +375,9 @@ entities:
     label: Requirement
     id_type: auto
     id_prefixes: ["REQ-"]
+    properties:
+      title:
+        type: string
 `,
 			wantErr: false,
 		},
@@ -386,6 +389,9 @@ entities:
   component:
     label: Component
     id_type: manual
+    properties:
+      title:
+        type: string
 `,
 			wantErr: false,
 		},
@@ -397,6 +403,9 @@ entities:
   requirement:
     label: Requirement
     id_prefixes: ["REQ-"]
+    properties:
+      title:
+        type: string
 `,
 			wantErr: false,
 		},
@@ -457,6 +466,10 @@ types:
 entities:
   requirement:
     label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
 `,
 			wantErr: false,
 		},
@@ -1243,7 +1256,7 @@ version: "1.0"
 entities:
   requirement:
     label: Requirement
-    id_patterns: ["REQ-"]
+    id_prefix: "REQ-"
     properties:
       status:
         type: string

--- a/internal/metamodel/validation.go
+++ b/internal/metamodel/validation.go
@@ -163,6 +163,8 @@ func (m *Metamodel) ValidatePropertyValue(propName string, propDef *PropertyDef,
 			if !valid {
 				return fmt.Errorf("invalid value for %s: %s (allowed: %v)", propName, s, customType.Values)
 			}
+		} else {
+			return fmt.Errorf("property %s has unknown type %q", propName, propDef.Type)
 		}
 	}
 

--- a/internal/metamodel/validation_test.go
+++ b/internal/metamodel/validation_test.go
@@ -1,6 +1,7 @@
 package metamodel
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
@@ -430,5 +431,26 @@ func TestValidatePropertyValue_CustomType(t *testing.T) {
 	err = meta.ValidatePropertyValue("severity", propDef, 123)
 	if err == nil {
 		t.Error("expected error for non-string custom type")
+	}
+}
+
+func TestValidatePropertyValue_UnknownType(t *testing.T) {
+	// Previously, unknown types were silently accepted (no validation).
+	// Now they should return an error.
+	meta := &Metamodel{
+		Types: map[string]CustomType{}, // no custom types defined
+	}
+	propDef := &PropertyDef{Type: "nonexistent"}
+
+	err := meta.ValidatePropertyValue("myprop", propDef, "any value")
+	if err == nil {
+		t.Fatal("expected error for unknown property type, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "unknown type") {
+		t.Errorf("expected 'unknown type' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("expected 'nonexistent' in error, got: %v", err)
 	}
 }

--- a/internal/metamodel/yaml_errors.go
+++ b/internal/metamodel/yaml_errors.go
@@ -1,0 +1,174 @@
+package metamodel
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// yamlTagNames maps YAML !!tags to human-readable descriptions.
+var yamlTagNames = map[string]string{
+	"!!str":   "a string",
+	"!!seq":   "a list",
+	"!!map":   "a mapping",
+	"!!int":   "a number",
+	"!!float": "a number",
+	"!!bool":  "a boolean",
+	"!!null":  "null",
+}
+
+// goTypeDescriptions maps Go type strings to human-readable descriptions.
+var goTypeDescriptions = map[string]string{
+	"[]string": "a list",
+	"bool":     "true/false",
+	"int":      "a number",
+	"*int":     "a number",
+	"string":   "a string",
+	"float64":  "a number",
+}
+
+// humanizeYAMLError rewrites yaml.TypeError messages to be more user-friendly.
+// For non-yaml.TypeError errors, it returns the original error unchanged.
+func humanizeYAMLError(err error) error {
+	var typeErr *yaml.TypeError
+	if !errors.As(err, &typeErr) {
+		return err
+	}
+
+	humanized := make([]string, 0, len(typeErr.Errors))
+	for _, msg := range typeErr.Errors {
+		humanized = append(humanized, humanizeUnmarshalError(msg))
+	}
+
+	if len(humanized) == 1 {
+		return fmt.Errorf("%s", humanized[0])
+	}
+	return fmt.Errorf("yaml: unmarshal errors:\n  %s", strings.Join(humanized, "\n  "))
+}
+
+// humanizeUnmarshalError converts a single YAML unmarshal error message
+// into a more readable form. It parses the message structure rather than
+// relying on regex to handle edge cases (backtick values containing newlines,
+// custom YAML tags, etc.).
+//
+// Expected input format from yaml library:
+//
+//	"line <N>: cannot unmarshal <tag> `<value>` into <GoType>"
+//	"line <N>: cannot unmarshal <tag> into <GoType>"
+func humanizeUnmarshalError(msg string) string {
+	parsed := parseUnmarshalMsg(msg)
+	if parsed.goType == "" {
+		// Could not extract the Go type — return a safe generic message
+		return sanitizeErrorMessage(msg)
+	}
+
+	gotDesc := describeYAMLTag(parsed.yamlTag)
+	expectedDesc := describeGoType(parsed.goType)
+
+	if parsed.lineNum != "" {
+		return fmt.Sprintf("line %s: expected %s, got %s", parsed.lineNum, expectedDesc, gotDesc)
+	}
+	return fmt.Sprintf("expected %s, got %s", expectedDesc, gotDesc)
+}
+
+// unmarshalParts holds the parsed components of a YAML unmarshal error message.
+type unmarshalParts struct {
+	lineNum string // e.g., "7", or "" if no line number
+	yamlTag string // e.g., "!!str", "!!seq", "!custom"
+	goType  string // e.g., "[]string", "metamodel.EntityDef"
+}
+
+// parseUnmarshalMsg extracts structured parts from a YAML unmarshal error message.
+// It handles all variations: with/without line numbers, with/without backtick values,
+// values containing newlines or special characters, custom YAML tags, etc.
+func parseUnmarshalMsg(msg string) unmarshalParts {
+	var parts unmarshalParts
+	remaining := msg
+
+	// Step 1: Extract optional "line <N>: " prefix
+	if strings.HasPrefix(remaining, "line ") {
+		remaining = remaining[5:]
+		colonIdx := strings.Index(remaining, ": ")
+		if colonIdx > 0 {
+			parts.lineNum = remaining[:colonIdx]
+			remaining = remaining[colonIdx+2:]
+		}
+	}
+
+	// Step 2: Expect "cannot unmarshal "
+	const unmarshalPrefix = "cannot unmarshal "
+	if !strings.HasPrefix(remaining, unmarshalPrefix) {
+		return parts
+	}
+	remaining = remaining[len(unmarshalPrefix):]
+
+	// Step 3: Extract the YAML tag (starts with !, continues until whitespace)
+	tagEnd := 0
+	for tagEnd < len(remaining) && remaining[tagEnd] != ' ' && remaining[tagEnd] != '\t' && remaining[tagEnd] != '\n' {
+		tagEnd++
+	}
+	if tagEnd == 0 {
+		return parts
+	}
+	parts.yamlTag = remaining[:tagEnd]
+	remaining = remaining[tagEnd:]
+
+	// Step 4: Extract the Go type from after the last " into " in the remainder.
+	// The remainder may contain: ` <whitespace> `<value>` into <GoType> `
+	// The value in backticks can contain anything (newlines, "into", etc.),
+	// so we find the LAST " into " to get the Go type reliably.
+	const intoSep = " into "
+	if idx := strings.LastIndex(remaining, intoSep); idx >= 0 {
+		parts.goType = remaining[idx+len(intoSep):]
+	} else if trimmed := strings.TrimSpace(remaining); strings.HasPrefix(trimmed, "into ") {
+		parts.goType = trimmed[5:]
+	}
+
+	return parts
+}
+
+// sanitizeErrorMessage removes Go/YAML internals from an error message
+// that couldn't be fully parsed. This is a safety net.
+func sanitizeErrorMessage(msg string) string {
+	// Try to at least extract line number and give a generic message
+	if strings.HasPrefix(msg, "line ") {
+		colonIdx := strings.Index(msg, ": ")
+		if colonIdx > 0 {
+			lineNum := msg[5:colonIdx]
+			return fmt.Sprintf("line %s: invalid value for this field", lineNum)
+		}
+	}
+	return "invalid YAML structure"
+}
+
+// describeYAMLTag returns a human-readable description for a YAML tag.
+// Falls back to "an unexpected value" for unknown tags to avoid leaking YAML internals.
+func describeYAMLTag(tag string) string {
+	if desc, ok := yamlTagNames[tag]; ok {
+		return desc
+	}
+	return "an unexpected value"
+}
+
+// describeGoType returns a human-readable description of a Go type string.
+func describeGoType(goType string) string {
+	// Exact matches first
+	if desc, ok := goTypeDescriptions[goType]; ok {
+		return desc
+	}
+	// Prefix/pattern matches
+	if strings.HasPrefix(goType, "[]") {
+		return "a list"
+	}
+	if strings.HasPrefix(goType, "map[") {
+		return "a mapping"
+	}
+	// Struct types like "metamodel.Metamodel" or "metamodel.EntityDef"
+	if strings.Contains(goType, ".") {
+		return "a mapping"
+	}
+	// Unknown Go type — use generic description to avoid leaking internals
+	return "a valid value"
+}

--- a/internal/metamodel/yaml_errors_test.go
+++ b/internal/metamodel/yaml_errors_test.go
@@ -1,0 +1,208 @@
+package metamodel
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHumanizeYAMLErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantMsgs []string // substrings expected in the error
+		notWant  []string // substrings that should NOT appear
+	}{
+		{
+			name: "string instead of list for aliases",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    aliases: req
+    properties:
+      title:
+        type: string
+`,
+			wantMsgs: []string{"expected a list", "got a string"},
+			notWant:  []string{"!!str", "!!seq", "[]string"},
+		},
+		{
+			name: "list instead of mapping for properties",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      - title
+      - description
+`,
+			wantMsgs: []string{"expected a mapping", "got a list"},
+			notWant:  []string{"!!seq", "PropertyDef"},
+		},
+		{
+			name: "string instead of list for from in relation",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+relations:
+  addresses:
+    label: addresses
+    from: decision
+    to: requirement
+`,
+			wantMsgs: []string{"expected a list", "got a string"},
+			notWant:  []string{"!!str", "[]string"},
+		},
+		{
+			name: "string instead of bool for required",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+        required: "true"
+`,
+			wantMsgs: []string{"expected true/false", "got a string"},
+			notWant:  []string{"!!str", "bool"},
+		},
+		{
+			name: "string instead of int for cardinality",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+relations:
+  test:
+    label: test
+    from: [requirement]
+    to: [requirement]
+    source_min: "one"
+`,
+			wantMsgs: []string{"expected a number", "got a string"},
+			notWant:  []string{"!!str", "int"},
+		},
+		{
+			name: "map instead of list for validations",
+			yaml: `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+validations:
+  my-rule:
+    then:
+      - "title!="
+`,
+			wantMsgs: []string{"expected a list", "got a mapping"},
+			notWant:  []string{"!!map", "ValidationRule"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.yaml))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			errMsg := err.Error()
+
+			for _, want := range tt.wantMsgs {
+				if !strings.Contains(errMsg, want) {
+					t.Errorf("expected error to contain %q, got: %s", want, errMsg)
+				}
+			}
+
+			for _, notWant := range tt.notWant {
+				if strings.Contains(errMsg, notWant) {
+					t.Errorf("error should not contain Go internal %q, got: %s", notWant, errMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestHumanizeYAMLError_NonTypeError(t *testing.T) {
+	// Non-yaml.TypeError errors should pass through unchanged
+	_, err := Parse([]byte(`invalid yaml [`))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// The error should still be present (not nil) - just not rewritten
+	if err.Error() == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestHumanizeUnmarshalError(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `line 7: cannot unmarshal !!str ` + "`req`" + ` into []string`,
+			want:  "line 7: expected a list, got a string",
+		},
+		{
+			input: `line 12: cannot unmarshal !!seq into map[string]metamodel.PropertyDef`,
+			want:  "line 12: expected a mapping, got a list",
+		},
+		{
+			input: `line 5: cannot unmarshal !!str ` + "`true`" + ` into bool`,
+			want:  "line 5: expected true/false, got a string",
+		},
+		{
+			input: `line 9: cannot unmarshal !!str ` + "`one`" + ` into int`,
+			want:  "line 9: expected a number, got a string",
+		},
+		{
+			input: `line 3: cannot unmarshal !!map into []metamodel.ValidationRule`,
+			want:  "line 3: expected a list, got a mapping",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := humanizeUnmarshalError(tt.input)
+			if got != tt.want {
+				t.Errorf("humanizeUnmarshalError(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHumanizeUnmarshalError_NoMatch(t *testing.T) {
+	// Non-matching messages should be sanitized to a safe generic message
+	got := humanizeUnmarshalError("some other error message")
+	if got == "" {
+		t.Error("expected non-empty sanitized message for non-matching input")
+	}
+	// Should not contain any Go internals
+	if strings.Contains(got, "!!") || strings.Contains(got, "metamodel.") {
+		t.Errorf("sanitized message should not contain Go internals, got %q", got)
+	}
+}

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -345,7 +345,7 @@ func SimpleMetamodelYAML() string {
 entities:
   requirement:
     label: Requirement
-    id_patterns: ["REQ-"]
+    id_prefix: "REQ-"
     properties:
       title:
         type: string
@@ -354,7 +354,7 @@ entities:
         type: status
   decision:
     label: Decision
-    id_patterns: ["DEC-"]
+    id_prefix: "DEC-"
     properties:
       title:
         type: string


### PR DESCRIPTION
## Summary

- Replace confusing Go/YAML internal error messages (`!!str`, `metamodel.PropertyDef`, `cannot unmarshal`) with clear, actionable messages users can understand
- Add post-parse semantic validation to catch issues that Go's `yaml.Unmarshal` silently ignores (misspelled top-level keys, unknown property types, missing labels/properties/prefixes)
- Add fuzz tests that enforce error messages never leak Go internals — the fuzzer found and fixed 4 additional edge cases in the error humanization

### Validation improvements

| Before | After |
|---|---|
| `entity:` silently ignored | `unknown key "entity" (did you mean "entities"?)` |
| Unknown property type silently accepted | `entity "x": property "y" has unknown type "z"` |
| `cannot unmarshal !!seq into map[string]metamodel.PropertyDef` | `expected a mapping, got a list` |
| Missing label silently accepted | `entity "x": missing 'label'` |
| All errors reported one at a time | All validation errors collected and shown at once |

### Fuzz tests

- **`FuzzParse`**: Feeds arbitrary strings to `Parse()`, verifies no panics and no Go internal leakage in errors (forbidden patterns: `!!\w+`, `metamodel.\w+`, `cannot unmarshal`, Go type names)
- **`FuzzParseErrorQuality`**: Structured property-based test generating metamodel YAML from 7 parameters, verifies every error matches a known-friendly pattern allow-list

### Files changed

| File | Change |
|---|---|
| `internal/metamodel/loader.go` | Post-parse semantic validation, "did you mean?" key checks |
| `internal/metamodel/yaml_errors.go` | **New**: string-based parser to humanize `yaml.TypeError` messages |
| `internal/metamodel/types.go` | `SchemaValidationError` for multi-error reporting |
| `internal/metamodel/validation.go` | Fix silent fallthrough for unknown property types |
| `internal/metamodel/loader_fuzz_test.go` | **New**: `FuzzParse` + `FuzzParseErrorQuality` |
| `internal/metamodel/*_test.go` | 15+ new validation tests, fixture updates |
| `Makefile` | Added metamodel fuzz targets |

## Test plan

- [x] All 14 packages pass (`go test ./...`)
- [x] Lint clean (`make lint`)
- [x] Coverage thresholds met (metamodel at 91.7%, minimum 65%)
- [x] `FuzzParse` passes 30s (185K+ executions, 0 failures)
- [x] `FuzzParseErrorQuality` passes 30s (6M+ executions, 0 failures)
- [x] Pre-commit hook passes (format, lint, test, coverage)