### PR TITLE
Add metamodel includes for composing schema from multiple files

### DIFF
--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -19,6 +19,131 @@ relations:
   # Relation definitions
 ```
 
+## Including Partial Metamodels
+
+For larger projects, you can split your metamodel across multiple files using the
+`includes:` key. This keeps each domain's definitions in a focused, manageable file.
+
+### Syntax
+
+```yaml
+# metamodel.yaml
+version: "1.0"
+namespace: "https://example.org/ontology/architecture#"
+
+includes:
+  - compliance/controls.yaml
+  - risk.yaml
+
+types:
+  status:
+    values: [draft, proposed, accepted, deprecated]
+    default: draft
+
+entities:
+  requirement:
+    label: Requirement
+    id_patterns: ["REQ-"]
+    properties:
+      title:
+        type: string
+        required: true
+```
+
+The `includes:` key is always a YAML list of file paths, resolved relative to the
+project root (where `metamodel.yaml` lives).
+
+### Included File Format
+
+Each included file is a partial metamodel. It can contain any combination of
+`types:`, `entities:`, `relations:`, and `validations:` — but **must not** contain
+`version:` or `namespace:` (these are only allowed in the root `metamodel.yaml`).
+
+```yaml
+# compliance/controls.yaml
+types:
+  applicability:
+    values: [applicable, not_applicable, partial]
+
+entities:
+  control:
+    label: Control
+    id_patterns: ["CTL-"]
+    properties:
+      title:
+        type: string
+        required: true
+      applicability:
+        type: applicability
+
+relations:
+  implements_control:
+    label: implements
+    from: [requirement]
+    to: [control]
+    inverse: implementedBy
+
+validations:
+  - name: controls-need-applicability
+    description: "Controls must have applicability set"
+    entity_type: control
+    then:
+      - "applicability!="
+    severity: warning
+```
+
+### Nested Includes
+
+Included files can themselves include other files:
+
+```yaml
+# compliance/controls.yaml
+includes:
+  - shared/audit-types.yaml
+
+entities:
+  control:
+    # ...
+```
+
+Circular includes are detected and produce a clear error:
+
+```text
+circular include detected: metamodel.yaml → compliance/controls.yaml → shared/audit-types.yaml → compliance/controls.yaml
+```
+
+### Diamond Includes
+
+If the same file is reachable from multiple include paths (a "diamond" pattern),
+it is loaded only once. This is not an error.
+
+```yaml
+# metamodel.yaml
+includes:
+  - a.yaml    # includes shared.yaml
+  - b.yaml    # also includes shared.yaml — loaded once, no conflict
+```
+
+### Conflict Handling
+
+If the same type, entity, relation, or validation name is defined in more than
+one file, loading fails with an error identifying both files:
+
+```text
+duplicate entity "control": defined in both compliance/controls.yaml and risk.yaml
+```
+
+To resolve conflicts, rename one of the definitions or move it to a shared file.
+
+### Error Messages
+
+| Situation | Error |
+| --- | --- |
+| Duplicate definition | `duplicate entity "control": defined in both a.yaml and b.yaml` |
+| Circular include | `circular include detected: a.yaml → b.yaml → a.yaml` |
+| File not found | `include file not found: missing.yaml (included from metamodel.yaml)` |
+| Root-only field | `included file a.yaml must not contain "version" (only allowed in root metamodel.yaml)` |
+
 ## Custom Types
 
 Define reusable enum types that can be used in entity properties:

--- a/internal/metamodel/include.go
+++ b/internal/metamodel/include.go
@@ -1,0 +1,239 @@
+package metamodel
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// partialMetamodel holds the parsed content of an included file
+type partialMetamodel struct {
+	sourcePath string // relative path for error messages
+
+	Types       map[string]CustomType  `yaml:"types"`
+	Entities    map[string]EntityDef   `yaml:"entities"`
+	Relations   map[string]RelationDef `yaml:"relations"`
+	Validations []ValidationRule       `yaml:"validations"`
+	Includes    []string               `yaml:"includes"`
+
+	// Fields that are not allowed in included files
+	Version   string `yaml:"version"`
+	Namespace string `yaml:"namespace"`
+}
+
+// includeState tracks file processing state during recursive include resolution.
+// It distinguishes between files currently being processed (in the call stack,
+// indicating a circular include) and files that have been fully processed
+// (allowing diamond includes where the same file is included from multiple paths).
+type includeState struct {
+	inStack   map[string]bool // files currently in the recursion stack (circular detection)
+	processed map[string]bool // files already fully resolved (diamond skip)
+}
+
+// loadWithIncludes loads a metamodel and recursively resolves all includes.
+// rootDir is the project root directory (where the root metamodel.yaml lives).
+// All include paths are resolved relative to rootDir.
+func loadWithIncludes(root *Metamodel, rootPath, rootDir string) error {
+	if len(root.Includes) == 0 {
+		return nil
+	}
+
+	absRoot, err := filepath.Abs(rootPath)
+	if err != nil {
+		return err
+	}
+
+	state := &includeState{
+		inStack:   map[string]bool{absRoot: true},
+		processed: map[string]bool{},
+	}
+
+	// Collect all partials in depth-first order
+	var partials []*partialMetamodel
+	for _, inc := range root.Includes {
+		collected, err := resolveIncludes(rootDir, inc, rootPath, state, []string{rootPath})
+		if err != nil {
+			return err
+		}
+		partials = append(partials, collected...)
+	}
+
+	// Merge all partials into the root metamodel
+	if err := mergeIncludes(root, rootPath, partials); err != nil {
+		return err
+	}
+
+	// Rebuild the alias map to include entities from all files
+	root.rebuildAliasMap()
+
+	return nil
+}
+
+// resolveIncludes recursively resolves an include file and all its nested includes.
+// Returns a flat list of partials in depth-first order.
+func resolveIncludes(
+	rootDir, includePath, includedFrom string,
+	state *includeState, chain []string,
+) ([]*partialMetamodel, error) {
+	// Resolve path relative to the project root
+	fullPath := filepath.Join(rootDir, includePath)
+
+	absPath, err := filepath.Abs(fullPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for circular includes (file is in the current recursion stack)
+	if state.inStack[absPath] {
+		return nil, &CircularIncludeError{
+			Chain: append(chain, includePath),
+		}
+	}
+
+	// Diamond include: file was already fully processed from another path — skip
+	if state.processed[absPath] {
+		return nil, nil
+	}
+
+	// Check file exists
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, &IncludeNotFoundError{
+				Path:         includePath,
+				IncludedFrom: includedFrom,
+			}
+		}
+		return nil, err
+	}
+
+	// Parse the partial metamodel
+	var partial partialMetamodel
+	if err := yaml.Unmarshal(data, &partial); err != nil {
+		return nil, err
+	}
+	partial.sourcePath = includePath
+
+	// Validate no root-only fields
+	if partial.Version != "" {
+		return nil, &IncludeHasRootFieldError{Path: includePath, Field: "version"}
+	}
+	if partial.Namespace != "" {
+		return nil, &IncludeHasRootFieldError{Path: includePath, Field: "namespace"}
+	}
+
+	// Push onto stack for circular detection
+	state.inStack[absPath] = true
+
+	// Recursively resolve nested includes (depth-first)
+	var partials []*partialMetamodel
+	newChain := append(chain, includePath) //nolint:gocritic // intentional append to new slice
+	for _, nestedInc := range partial.Includes {
+		collected, err := resolveIncludes(rootDir, nestedInc, includePath, state, newChain)
+		if err != nil {
+			return nil, err
+		}
+		partials = append(partials, collected...)
+	}
+
+	// Pop from stack, mark as fully processed
+	delete(state.inStack, absPath)
+	state.processed[absPath] = true
+
+	// Add this partial after its dependencies (depth-first)
+	partials = append(partials, &partial)
+
+	return partials, nil
+}
+
+// mergeIncludes merges all partial metamodels into the root metamodel.
+// Returns an error if any duplicate definitions are found.
+func mergeIncludes(root *Metamodel, rootPath string, partials []*partialMetamodel) error {
+	// Track which file defined each name (for duplicate detection)
+	typeOwner := make(map[string]string)
+	entityOwner := make(map[string]string)
+	relationOwner := make(map[string]string)
+	validationOwner := make(map[string]string)
+
+	// Register root's existing definitions
+	for name := range root.Types {
+		typeOwner[name] = rootPath
+	}
+	for name := range root.Entities {
+		entityOwner[name] = rootPath
+	}
+	for name := range root.Relations {
+		relationOwner[name] = rootPath
+	}
+	for _, v := range root.Validations {
+		validationOwner[v.Name] = rootPath
+	}
+
+	// Initialize maps if nil (root may not define any)
+	if root.Types == nil {
+		root.Types = make(map[string]CustomType)
+	}
+	if root.Entities == nil {
+		root.Entities = make(map[string]EntityDef)
+	}
+	if root.Relations == nil {
+		root.Relations = make(map[string]RelationDef)
+	}
+
+	// Merge each partial
+	for _, p := range partials {
+		// Merge types
+		for name, def := range p.Types {
+			if owner, exists := typeOwner[name]; exists {
+				return &DuplicateDefinitionError{
+					Kind: "type", Name: name,
+					File1: owner, File2: p.sourcePath,
+				}
+			}
+			typeOwner[name] = p.sourcePath
+			root.Types[name] = def
+		}
+
+		// Merge entities
+		for name, def := range p.Entities {
+			if owner, exists := entityOwner[name]; exists {
+				return &DuplicateDefinitionError{
+					Kind: "entity", Name: name,
+					File1: owner, File2: p.sourcePath,
+				}
+			}
+			entityOwner[name] = p.sourcePath
+			root.Entities[name] = def
+		}
+
+		// Merge relations
+		for name, def := range p.Relations {
+			if owner, exists := relationOwner[name]; exists {
+				return &DuplicateDefinitionError{
+					Kind: "relation", Name: name,
+					File1: owner, File2: p.sourcePath,
+				}
+			}
+			relationOwner[name] = p.sourcePath
+			root.Relations[name] = def
+		}
+
+		// Merge validations (check name uniqueness)
+		for _, v := range p.Validations {
+			if owner, exists := validationOwner[v.Name]; exists {
+				return &DuplicateDefinitionError{
+					Kind: "validation", Name: v.Name,
+					File1: owner, File2: p.sourcePath,
+				}
+			}
+			validationOwner[v.Name] = p.sourcePath
+			root.Validations = append(root.Validations, v)
+		}
+	}
+
+	// Clear includes from the final result (they've been resolved)
+	root.Includes = nil
+
+	return nil
+}

--- a/internal/metamodel/include_test.go
+++ b/internal/metamodel/include_test.go
@@ -1,0 +1,861 @@
+package metamodel
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadWithIncludes_Basic(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+namespace: "https://example.org/ontology#"
+includes:
+  - compliance.yaml
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+        required: true
+`)
+
+	createFile(t, filepath.Join(tmpDir, "compliance.yaml"), `
+entities:
+  control:
+    label: Control
+    id_prefix: "CTL-"
+    properties:
+      title:
+        type: string
+        required: true
+`)
+
+	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertNoError(t, err)
+
+	if _, ok := meta.Entities["requirement"]; !ok {
+		t.Error("expected requirement entity from root")
+	}
+	if _, ok := meta.Entities["control"]; !ok {
+		t.Error("expected control entity from included file")
+	}
+	if len(meta.Includes) != 0 {
+		t.Error("expected includes to be cleared after merging")
+	}
+}
+
+func TestLoadWithIncludes_MultipleFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - types.yaml
+  - entities.yaml
+  - relations.yaml
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+        required: true
+`)
+
+	createFile(t, filepath.Join(tmpDir, "types.yaml"), `
+types:
+  severity:
+    values: [low, medium, high, critical]
+`)
+
+	createFile(t, filepath.Join(tmpDir, "entities.yaml"), `
+entities:
+  risk:
+    label: Risk
+    id_prefix: "RISK-"
+    properties:
+      title:
+        type: string
+        required: true
+      severity:
+        type: severity
+`)
+
+	createFile(t, filepath.Join(tmpDir, "relations.yaml"), `
+relations:
+  mitigates:
+    label: mitigates
+    from: [requirement]
+    to: [risk]
+    inverse: mitigatedBy
+`)
+
+	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertNoError(t, err)
+
+	// Types from types.yaml
+	if _, ok := meta.Types["severity"]; !ok {
+		t.Error("expected severity type from included file")
+	}
+
+	// Entities from root + entities.yaml
+	if _, ok := meta.Entities["requirement"]; !ok {
+		t.Error("expected requirement entity from root")
+	}
+	if _, ok := meta.Entities["risk"]; !ok {
+		t.Error("expected risk entity from included file")
+	}
+
+	// Relations from relations.yaml
+	if _, ok := meta.Relations["mitigates"]; !ok {
+		t.Error("expected mitigates relation from included file")
+	}
+}
+
+func TestLoadWithIncludes_Nested(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - a.yaml
+entities:
+  root_entity:
+    label: Root
+    id_prefix: "ROOT-"
+    properties:
+      title:
+        type: string
+`)
+
+	createFile(t, filepath.Join(tmpDir, "a.yaml"), `
+includes:
+  - b.yaml
+entities:
+  entity_a:
+    label: Entity A
+    id_prefix: "A-"
+    properties:
+      title:
+        type: string
+`)
+
+	createFile(t, filepath.Join(tmpDir, "b.yaml"), `
+entities:
+  entity_b:
+    label: Entity B
+    id_prefix: "B-"
+    properties:
+      title:
+        type: string
+`)
+
+	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertNoError(t, err)
+
+	if _, ok := meta.Entities["root_entity"]; !ok {
+		t.Error("expected root_entity from root")
+	}
+	if _, ok := meta.Entities["entity_a"]; !ok {
+		t.Error("expected entity_a from a.yaml")
+	}
+	if _, ok := meta.Entities["entity_b"]; !ok {
+		t.Error("expected entity_b from b.yaml (nested include)")
+	}
+}
+
+func TestLoadWithIncludes_CircularDetection(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - a.yaml
+`)
+
+	createFile(t, filepath.Join(tmpDir, "a.yaml"), `
+includes:
+  - b.yaml
+entities:
+  entity_a:
+    label: A
+    id_prefix: "A-"
+    properties:
+      title:
+        type: string
+`)
+
+	createFile(t, filepath.Join(tmpDir, "b.yaml"), `
+includes:
+  - a.yaml
+entities:
+  entity_b:
+    label: B
+    id_prefix: "B-"
+    properties:
+      title:
+        type: string
+`)
+
+	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertError(t, err)
+
+	var circularErr *CircularIncludeError
+	if !errors.As(err, &circularErr) {
+		t.Fatalf("expected CircularIncludeError, got %T: %v", err, err)
+	}
+}
+
+func TestLoadWithIncludes_SelfInclude(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - metamodel.yaml
+`)
+
+	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertError(t, err)
+
+	var circularErr *CircularIncludeError
+	if !errors.As(err, &circularErr) {
+		t.Fatalf("expected CircularIncludeError, got %T: %v", err, err)
+	}
+}
+
+func TestLoadWithIncludes_DuplicateEntity(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - a.yaml
+  - b.yaml
+`)
+
+	createFile(t, filepath.Join(tmpDir, "a.yaml"), `
+entities:
+  control:
+    label: Control
+    id_prefix: "CTL-"
+    properties:
+      title:
+        type: string
+`)
+
+	createFile(t, filepath.Join(tmpDir, "b.yaml"), `
+entities:
+  control:
+    label: Control Duplicate
+    id_prefix: "CTL-"
+    properties:
+      title:
+        type: string
+`)
+
+	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertError(t, err)
+
+	var dupErr *DuplicateDefinitionError
+	if !errors.As(err, &dupErr) {
+		t.Fatalf("expected DuplicateDefinitionError, got %T: %v", err, err)
+	}
+	assertEqual(t, dupErr.Kind, "entity")
+	assertEqual(t, dupErr.Name, "control")
+	assertEqual(t, dupErr.File1, "a.yaml")
+	assertEqual(t, dupErr.File2, "b.yaml")
+}
+
+func TestLoadWithIncludes_DuplicateType(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - a.yaml
+types:
+  severity:
+    values: [low, medium, high]
+`)
+
+	createFile(t, filepath.Join(tmpDir, "a.yaml"), `
+types:
+  severity:
+    values: [low, high, critical]
+`)
+
+	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertError(t, err)
+
+	var dupErr *DuplicateDefinitionError
+	if !errors.As(err, &dupErr) {
+		t.Fatalf("expected DuplicateDefinitionError, got %T: %v", err, err)
+	}
+	assertEqual(t, dupErr.Kind, "type")
+	assertEqual(t, dupErr.Name, "severity")
+}
+
+func TestLoadWithIncludes_DuplicateRelation(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - a.yaml
+  - b.yaml
+`)
+
+	createFile(t, filepath.Join(tmpDir, "a.yaml"), `
+relations:
+  mitigates:
+    label: mitigates
+    from: [decision]
+    to: [risk]
+`)
+
+	createFile(t, filepath.Join(tmpDir, "b.yaml"), `
+relations:
+  mitigates:
+    label: mitigates
+    from: [solution]
+    to: [risk]
+`)
+
+	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertError(t, err)
+
+	var dupErr *DuplicateDefinitionError
+	if !errors.As(err, &dupErr) {
+		t.Fatalf("expected DuplicateDefinitionError, got %T: %v", err, err)
+	}
+	assertEqual(t, dupErr.Kind, "relation")
+	assertEqual(t, dupErr.Name, "mitigates")
+}
+
+func TestLoadWithIncludes_DuplicateValidation(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - a.yaml
+validations:
+  - name: needs-title
+    description: "Must have title"
+    then:
+      - "title!="
+`)
+
+	createFile(t, filepath.Join(tmpDir, "a.yaml"), `
+validations:
+  - name: needs-title
+    description: "Duplicate rule"
+    then:
+      - "title!="
+`)
+
+	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertError(t, err)
+
+	var dupErr *DuplicateDefinitionError
+	if !errors.As(err, &dupErr) {
+		t.Fatalf("expected DuplicateDefinitionError, got %T: %v", err, err)
+	}
+	assertEqual(t, dupErr.Kind, "validation")
+	assertEqual(t, dupErr.Name, "needs-title")
+}
+
+func TestLoadWithIncludes_FileNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - nonexistent.yaml
+`)
+
+	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertError(t, err)
+
+	var notFoundErr *IncludeNotFoundError
+	if !errors.As(err, &notFoundErr) {
+		t.Fatalf("expected IncludeNotFoundError, got %T: %v", err, err)
+	}
+	assertEqual(t, notFoundErr.Path, "nonexistent.yaml")
+}
+
+func TestLoadWithIncludes_IncludeHasVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - bad.yaml
+`)
+
+	createFile(t, filepath.Join(tmpDir, "bad.yaml"), `
+version: "1.0"
+entities:
+  control:
+    label: Control
+    id_prefix: "CTL-"
+    properties:
+      title:
+        type: string
+`)
+
+	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertError(t, err)
+
+	var rootFieldErr *IncludeHasRootFieldError
+	if !errors.As(err, &rootFieldErr) {
+		t.Fatalf("expected IncludeHasRootFieldError, got %T: %v", err, err)
+	}
+	assertEqual(t, rootFieldErr.Field, "version")
+}
+
+func TestLoadWithIncludes_IncludeHasNamespace(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - bad.yaml
+`)
+
+	createFile(t, filepath.Join(tmpDir, "bad.yaml"), `
+namespace: "https://example.org"
+entities:
+  control:
+    label: Control
+    id_prefix: "CTL-"
+    properties:
+      title:
+        type: string
+`)
+
+	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertError(t, err)
+
+	var rootFieldErr *IncludeHasRootFieldError
+	if !errors.As(err, &rootFieldErr) {
+		t.Fatalf("expected IncludeHasRootFieldError, got %T: %v", err, err)
+	}
+	assertEqual(t, rootFieldErr.Field, "namespace")
+}
+
+func TestLoadWithIncludes_EmptyIncludes(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes: []
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+        required: true
+`)
+
+	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertNoError(t, err)
+
+	if _, ok := meta.Entities["requirement"]; !ok {
+		t.Error("expected requirement entity")
+	}
+}
+
+func TestLoadWithIncludes_CrossFileTypeReferences(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Root defines entities that use types from an included file
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - types.yaml
+entities:
+  risk:
+    label: Risk
+    id_prefix: "RISK-"
+    properties:
+      title:
+        type: string
+        required: true
+      severity:
+        type: severity
+`)
+
+	createFile(t, filepath.Join(tmpDir, "types.yaml"), `
+types:
+  severity:
+    values: [low, medium, high, critical]
+`)
+
+	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertNoError(t, err)
+
+	// Verify cross-file reference works: entity uses type from included file
+	if _, ok := meta.Types["severity"]; !ok {
+		t.Error("expected severity type from included file")
+	}
+	riskDef, ok := meta.Entities["risk"]
+	if !ok {
+		t.Fatal("expected risk entity")
+	}
+	severityProp, ok := riskDef.Properties["severity"]
+	if !ok {
+		t.Fatal("expected severity property on risk entity")
+	}
+	assertEqual(t, severityProp.Type, "severity")
+}
+
+func TestLoadWithIncludes_CrossFileRelationReferences(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - entities.yaml
+  - relations.yaml
+`)
+
+	createFile(t, filepath.Join(tmpDir, "entities.yaml"), `
+entities:
+  decision:
+    label: Decision
+    id_prefix: "DEC-"
+    properties:
+      title:
+        type: string
+        required: true
+  risk:
+    label: Risk
+    id_prefix: "RISK-"
+    properties:
+      title:
+        type: string
+        required: true
+`)
+
+	createFile(t, filepath.Join(tmpDir, "relations.yaml"), `
+relations:
+  mitigates:
+    label: mitigates
+    from: [decision]
+    to: [risk]
+    inverse: mitigatedBy
+`)
+
+	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertNoError(t, err)
+
+	// Verify relation references entities from another included file
+	rel, ok := meta.Relations["mitigates"]
+	if !ok {
+		t.Fatal("expected mitigates relation")
+	}
+	if len(rel.From) != 1 || rel.From[0] != "decision" {
+		t.Errorf("expected from=[decision], got %v", rel.From)
+	}
+	if len(rel.To) != 1 || rel.To[0] != "risk" {
+		t.Errorf("expected to=[risk], got %v", rel.To)
+	}
+}
+
+func TestLoadWithIncludes_DiamondInclude(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// A includes B and C, both B and C include D
+	// D should be loaded once, not cause a duplicate error
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - b.yaml
+  - c.yaml
+`)
+
+	createFile(t, filepath.Join(tmpDir, "b.yaml"), `
+includes:
+  - d.yaml
+entities:
+  entity_b:
+    label: B
+    id_prefix: "B-"
+    properties:
+      title:
+        type: string
+`)
+
+	createFile(t, filepath.Join(tmpDir, "c.yaml"), `
+includes:
+  - d.yaml
+entities:
+  entity_c:
+    label: C
+    id_prefix: "C-"
+    properties:
+      title:
+        type: string
+`)
+
+	createFile(t, filepath.Join(tmpDir, "d.yaml"), `
+types:
+  shared_type:
+    values: [a, b, c]
+`)
+
+	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertNoError(t, err)
+
+	// All entities should be present
+	if _, ok := meta.Entities["entity_b"]; !ok {
+		t.Error("expected entity_b from b.yaml")
+	}
+	if _, ok := meta.Entities["entity_c"]; !ok {
+		t.Error("expected entity_c from c.yaml")
+	}
+	// Shared type from d.yaml should be loaded once
+	if _, ok := meta.Types["shared_type"]; !ok {
+		t.Error("expected shared_type from d.yaml")
+	}
+}
+
+func TestLoadWithIncludes_Subdirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - modules/compliance.yaml
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+        required: true
+`)
+
+	createFile(t, filepath.Join(tmpDir, "modules", "compliance.yaml"), `
+entities:
+  control:
+    label: Control
+    id_prefix: "CTL-"
+    properties:
+      title:
+        type: string
+        required: true
+`)
+
+	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertNoError(t, err)
+
+	if _, ok := meta.Entities["control"]; !ok {
+		t.Error("expected control entity from modules/compliance.yaml")
+	}
+}
+
+func TestLoadWithIncludes_DuplicateEntityWithRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Entity defined in root AND in included file
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - extra.yaml
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+        required: true
+`)
+
+	createFile(t, filepath.Join(tmpDir, "extra.yaml"), `
+entities:
+  requirement:
+    label: Requirement Duplicate
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+`)
+
+	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertError(t, err)
+
+	var dupErr *DuplicateDefinitionError
+	if !errors.As(err, &dupErr) {
+		t.Fatalf("expected DuplicateDefinitionError, got %T: %v", err, err)
+	}
+	assertEqual(t, dupErr.Kind, "entity")
+	assertEqual(t, dupErr.Name, "requirement")
+}
+
+func TestLoadWithIncludes_ValidationsMerged(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - rules.yaml
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+        required: true
+      priority:
+        type: string
+validations:
+  - name: root-rule
+    description: "Root validation"
+    then:
+      - "title!="
+`)
+
+	createFile(t, filepath.Join(tmpDir, "rules.yaml"), `
+validations:
+  - name: included-rule
+    description: "Included validation"
+    entity_type: requirement
+    then:
+      - "priority!="
+    severity: warning
+`)
+
+	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertNoError(t, err)
+
+	if len(meta.Validations) != 2 {
+		t.Fatalf("expected 2 validations, got %d", len(meta.Validations))
+	}
+
+	names := map[string]bool{}
+	for _, v := range meta.Validations {
+		names[v.Name] = true
+	}
+	if !names["root-rule"] {
+		t.Error("expected root-rule validation")
+	}
+	if !names["included-rule"] {
+		t.Error("expected included-rule validation")
+	}
+}
+
+func TestLoadWithIncludes_AliasMapBuilt(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - extra.yaml
+entities:
+  requirement:
+    label: Requirement
+    aliases: [req]
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+        required: true
+`)
+
+	createFile(t, filepath.Join(tmpDir, "extra.yaml"), `
+entities:
+  control:
+    label: Control
+    aliases: [ctl, ctrl]
+    id_prefix: "CTL-"
+    properties:
+      title:
+        type: string
+        required: true
+`)
+
+	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertNoError(t, err)
+
+	// Aliases from root
+	assertEqual(t, meta.ResolveAlias("req"), "requirement")
+
+	// Aliases from included file
+	assertEqual(t, meta.ResolveAlias("ctl"), "control")
+	assertEqual(t, meta.ResolveAlias("ctrl"), "control")
+}
+
+func TestLoadWithIncludes_NoIncludes(t *testing.T) {
+	// A regular metamodel without includes should work exactly as before
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    properties:
+      title:
+        type: string
+        required: true
+`)
+
+	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"))
+	assertNoError(t, err)
+
+	if _, ok := meta.Entities["requirement"]; !ok {
+		t.Error("expected requirement entity")
+	}
+}
+
+// Error message tests
+
+func TestDuplicateDefinitionError_Error(t *testing.T) {
+	err := &DuplicateDefinitionError{
+		Kind: "entity", Name: "control",
+		File1: "compliance.yaml", File2: "risk.yaml",
+	}
+	expected := `duplicate entity "control": defined in both compliance.yaml and risk.yaml`
+	assertEqual(t, err.Error(), expected)
+}
+
+func TestCircularIncludeError_Error(t *testing.T) {
+	err := &CircularIncludeError{
+		Chain: []string{"metamodel.yaml", "a.yaml", "b.yaml", "a.yaml"},
+	}
+	expected := "circular include detected: metamodel.yaml → a.yaml → b.yaml → a.yaml"
+	assertEqual(t, err.Error(), expected)
+}
+
+func TestIncludeNotFoundError_Error(t *testing.T) {
+	err := &IncludeNotFoundError{
+		Path:         "compliance.yaml",
+		IncludedFrom: "metamodel.yaml",
+	}
+	expected := "include file not found: compliance.yaml (included from metamodel.yaml)"
+	assertEqual(t, err.Error(), expected)
+}
+
+func TestIncludeHasRootFieldError_Error(t *testing.T) {
+	err := &IncludeHasRootFieldError{
+		Path:  "compliance.yaml",
+		Field: "version",
+	}
+	expected := `included file compliance.yaml must not contain "version" (only allowed in root metamodel.yaml)`
+	assertEqual(t, err.Error(), expected)
+}

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -2,6 +2,7 @@ package metamodel
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -10,6 +11,9 @@ import (
 )
 
 // Load reads and parses a metamodel from a YAML file.
+// If the metamodel contains an `includes:` key, included files are recursively
+// loaded and merged. Include paths are resolved relative to the directory
+// containing the metamodel file.
 // Returns a MigrationError if the file contains deprecated syntax that needs migration.
 func Load(path string) (*Metamodel, error) {
 	data, err := os.ReadFile(path)
@@ -29,7 +33,20 @@ func Load(path string) (*Metamodel, error) {
 		}
 	}
 
-	return Parse(data)
+	m, err := Parse(data)
+	if err != nil {
+		return nil, err
+	}
+
+	// If includes are present, resolve and merge them
+	if len(m.Includes) > 0 {
+		rootDir := filepath.Dir(path)
+		if err := loadWithIncludes(m, path, rootDir); err != nil {
+			return nil, err
+		}
+	}
+
+	return m, nil
 }
 
 // Parse parses metamodel YAML content

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -1,9 +1,12 @@
 package metamodel
 
+import "strings"
+
 // Metamodel represents the full metamodel configuration
 type Metamodel struct {
 	Version     string                 `yaml:"version"`
 	Namespace   string                 `yaml:"namespace"`
+	Includes    []string               `yaml:"includes,omitempty"`
 	Types       map[string]CustomType  `yaml:"types"`
 	Entities    map[string]EntityDef   `yaml:"entities"`
 	Relations   map[string]RelationDef `yaml:"relations"`
@@ -362,6 +365,18 @@ func (e *EntityDef) MatchesID(id string) bool {
 	return false
 }
 
+// rebuildAliasMap rebuilds the alias map from all entity definitions.
+// Called after merging includes to ensure aliases from included files are registered.
+func (m *Metamodel) rebuildAliasMap() {
+	m.aliasMap = make(map[string]string)
+	for name, def := range m.Entities {
+		m.aliasMap[strings.ToLower(name)] = name
+		for _, alias := range def.Aliases {
+			m.aliasMap[strings.ToLower(alias)] = name
+		}
+	}
+}
+
 // ResolveAlias returns the canonical entity type name for an alias
 func (m *Metamodel) ResolveAlias(alias string) string {
 	if m.aliasMap == nil {
@@ -531,6 +546,48 @@ type ReservedTypeNameError struct {
 func (e *ReservedTypeNameError) Error() string {
 	return "cannot define custom type \"" + e.TypeName +
 		"\": name is reserved for built-in type (reserved: string, date, integer, boolean, enum)"
+}
+
+// DuplicateDefinitionError is returned when the same name is defined in multiple included files
+type DuplicateDefinitionError struct {
+	Kind  string // "type", "entity", "relation", or "validation"
+	Name  string
+	File1 string
+	File2 string
+}
+
+func (e *DuplicateDefinitionError) Error() string {
+	return "duplicate " + e.Kind + " \"" + e.Name + "\": defined in both " + e.File1 + " and " + e.File2
+}
+
+// CircularIncludeError is returned when a circular include chain is detected
+type CircularIncludeError struct {
+	Chain []string // e.g., ["a.yaml", "b.yaml", "a.yaml"]
+}
+
+func (e *CircularIncludeError) Error() string {
+	return "circular include detected: " + strings.Join(e.Chain, " → ")
+}
+
+// IncludeNotFoundError is returned when an included file does not exist
+type IncludeNotFoundError struct {
+	Path         string
+	IncludedFrom string
+}
+
+func (e *IncludeNotFoundError) Error() string {
+	return "include file not found: " + e.Path + " (included from " + e.IncludedFrom + ")"
+}
+
+// IncludeHasRootFieldError is returned when an included file contains version or namespace
+type IncludeHasRootFieldError struct {
+	Path  string
+	Field string
+}
+
+func (e *IncludeHasRootFieldError) Error() string {
+	return "included file " + e.Path + " must not contain \"" + e.Field +
+		"\" (only allowed in root metamodel.yaml)"
 }
 
 // Schema output interface methods for Metamodel


### PR DESCRIPTION
## Summary

- Add `includes:` key to `metamodel.yaml` for splitting schema definitions across multiple files
- Each included file is a partial metamodel containing any combination of `types:`, `entities:`, `relations:`, and `validations:`
- Support nested includes with circular detection and diamond include deduplication
- Duplicate definitions across files produce clear errors identifying both source files
- Document the feature in `docs/metamodel.md`

## Test plan

- [x] 25 unit tests covering all scenarios: basic include, multiple files, nested, circular detection, self-include, diamond, duplicates (entity/type/relation/validation), file not found, forbidden root fields, cross-file references, alias map rebuild, subdirectories, validations merge
- [x] All existing tests pass (no regressions)
- [x] Lint clean (Go + markdown)
- [x] Coverage: metamodel package at 91.5% (threshold: 65%)
- [x] Full CI suite passes (`make ci`)