### PR TITLE
Fix TUI browser scrolling for long lists

### DIFF
--- a/internal/tui/browser.go
+++ b/internal/tui/browser.go
@@ -19,6 +19,9 @@ const (
 	LevelEntities
 )
 
+// pageSize is the number of items to jump for PageUp/PageDown
+const pageSize = 10
+
 // BrowserModel is the main entity browser screen
 type BrowserModel struct {
 	level        BrowserLevel
@@ -90,6 +93,16 @@ func (b *BrowserModel) updateTypes(app *App, msg tea.KeyMsg) (tea.Model, tea.Cmd
 		if b.typeIndex > 0 {
 			b.typeIndex--
 		}
+	case "pgdown", "ctrl+d":
+		b.typeIndex += pageSize
+		if b.typeIndex > len(b.types)-1 {
+			b.typeIndex = len(b.types) - 1
+		}
+	case "pgup", "ctrl+u":
+		b.typeIndex -= pageSize
+		if b.typeIndex < 0 {
+			b.typeIndex = 0
+		}
 	case "enter":
 		if b.typeIndex < len(b.types) {
 			b.loadEntities(app, b.types[b.typeIndex].name)
@@ -135,6 +148,16 @@ func (b *BrowserModel) updateEntities(app *App, msg tea.KeyMsg) (tea.Model, tea.
 	case "k", "up":
 		if b.entityIndex > 0 {
 			b.entityIndex--
+		}
+	case "pgdown", "ctrl+d":
+		b.entityIndex += pageSize
+		if b.entityIndex > len(b.entities)-1 {
+			b.entityIndex = len(b.entities) - 1
+		}
+	case "pgup", "ctrl+u":
+		b.entityIndex -= pageSize
+		if b.entityIndex < 0 {
+			b.entityIndex = 0
 		}
 	case "enter":
 		// Browse all entities of this type with scope navigation
@@ -224,7 +247,7 @@ func (b *BrowserModel) View(width, height int) string {
 	return ""
 }
 
-func (b *BrowserModel) viewTypes(_, _ int) string {
+func (b *BrowserModel) viewTypes(_, height int) string {
 	var sb strings.Builder
 
 	titleStyle := lipgloss.NewStyle().
@@ -245,7 +268,30 @@ func (b *BrowserModel) viewTypes(_, _ int) string {
 	sb.WriteString(titleStyle.Render("Entity Types"))
 	sb.WriteString("\n\n")
 
-	for i, t := range b.types {
+	// Calculate visible range for scrolling
+	// Header takes ~3 lines (title + margin + blank), scroll indicator takes 2 lines
+	headerLines := 3
+	scrollIndicatorLines := 2
+	needsScroll := len(b.types) > height-headerLines
+	visibleCount := height - headerLines
+	if needsScroll {
+		visibleCount -= scrollIndicatorLines
+	}
+	if visibleCount < 1 {
+		visibleCount = 1
+	}
+
+	startIdx := 0
+	if b.typeIndex >= visibleCount {
+		startIdx = b.typeIndex - visibleCount + 1
+	}
+	endIdx := startIdx + visibleCount
+	if endIdx > len(b.types) {
+		endIdx = len(b.types)
+	}
+
+	for i := startIdx; i < endIdx; i++ {
+		t := b.types[i]
 		marker := "  "
 		style := normalStyle
 		if i == b.typeIndex {
@@ -256,6 +302,14 @@ func (b *BrowserModel) viewTypes(_, _ int) string {
 		line := fmt.Sprintf("%s%-20s", marker, t.label)
 		count := countStyle.Render(fmt.Sprintf("(%d)", t.count))
 		sb.WriteString(style.Render(line) + " " + count + "\n")
+	}
+
+	// Show scroll indicator
+	if needsScroll {
+		scrollInfo := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("240")).
+			Render(fmt.Sprintf("\n[%d/%d]", b.typeIndex+1, len(b.types)))
+		sb.WriteString(scrollInfo)
 	}
 
 	return sb.String()
@@ -300,7 +354,14 @@ func (b *BrowserModel) viewEntities(_, height int) string {
 	}
 
 	// Calculate visible range for scrolling
-	visibleCount := height - 4
+	// Header takes ~3 lines (title + margin + blank), scroll indicator takes 2 lines
+	headerLines := 3
+	scrollIndicatorLines := 2
+	needsScroll := len(b.entities) > height-headerLines
+	visibleCount := height - headerLines
+	if needsScroll {
+		visibleCount -= scrollIndicatorLines
+	}
 	if visibleCount < 1 {
 		visibleCount = 1
 	}
@@ -340,7 +401,7 @@ func (b *BrowserModel) viewEntities(_, height int) string {
 	}
 
 	// Show scroll indicator
-	if len(b.entities) > visibleCount {
+	if needsScroll {
 		scrollInfo := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("240")).
 			Render(fmt.Sprintf("\n[%d/%d]", b.entityIndex+1, len(b.entities)))
@@ -356,6 +417,7 @@ func (b *BrowserModel) Help() [][2]string {
 	case LevelTypes:
 		return [][2]string{
 			{"↑/↓", "navigate"},
+			{"PgUp/PgDn", "page"},
 			{"enter", "select"},
 			{"c", "create"},
 			{"/", "search"},
@@ -365,6 +427,7 @@ func (b *BrowserModel) Help() [][2]string {
 	case LevelEntities:
 		return [][2]string{
 			{"↑/↓", "navigate"},
+			{"PgUp/PgDn", "page"},
 			{"enter", "browse"},
 			{"←", "back"},
 			{"c", "create"},

--- a/internal/tui/browser_test.go
+++ b/internal/tui/browser_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -512,6 +513,232 @@ func TestBrowserModel_Refresh(t *testing.T) {
 				t.Errorf("after refresh, requirement count = %d, want 3", typ.count)
 			}
 		}
+	}
+}
+
+// createTestAppWithManyEntities creates a test app with many entities for scrolling tests.
+func createTestAppWithManyEntities(count int) (*App, *BrowserModel) {
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"requirement": {
+				Label:    "Requirement",
+				IDPrefix: "REQ-",
+				Properties: map[string]metamodel.PropertyDef{
+					"title":  {Type: "string", Required: true},
+					"status": {Type: "string", Required: false},
+				},
+			},
+		},
+	}
+
+	g := graph.New()
+	for i := 1; i <= count; i++ {
+		g.AddNode(&model.Entity{
+			ID:   fmt.Sprintf("REQ-%03d", i),
+			Type: "requirement",
+			Properties: map[string]interface{}{
+				"title":  fmt.Sprintf("Requirement %d", i),
+				"status": "draft",
+			},
+		})
+	}
+
+	app := &App{
+		metamodel: meta,
+		graph:     g,
+		project:   &project.Context{Root: "/tmp/test"},
+	}
+
+	browser := NewBrowserModel(app)
+	browser.loadEntities(app, "requirement")
+	browser.level = LevelEntities
+
+	return app, browser
+}
+
+// createTestAppWithManyTypes creates a test app with many entity types for scrolling tests.
+func createTestAppWithManyTypes(count int) (*App, *BrowserModel) {
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{},
+	}
+	for i := 1; i <= count; i++ {
+		name := fmt.Sprintf("type%02d", i)
+		meta.Entities[name] = metamodel.EntityDef{
+			Label:    fmt.Sprintf("Type %02d", i),
+			IDPrefix: fmt.Sprintf("T%02d-", i),
+		}
+	}
+
+	app := &App{
+		metamodel: meta,
+		graph:     graph.New(),
+		project:   &project.Context{Root: "/tmp/test"},
+	}
+
+	browser := NewBrowserModel(app)
+	return app, browser
+}
+
+func TestBrowserModel_PageDownEntities(t *testing.T) {
+	app, browser := createTestAppWithManyEntities(30)
+
+	// Start at 0
+	if browser.entityIndex != 0 {
+		t.Fatalf("entityIndex should start at 0, got %d", browser.entityIndex)
+	}
+
+	// Page down
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyPgDown})
+	if browser.entityIndex != 10 {
+		t.Errorf("after pgdown, entityIndex = %d, want 10", browser.entityIndex)
+	}
+
+	// Page down again
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyPgDown})
+	if browser.entityIndex != 20 {
+		t.Errorf("after second pgdown, entityIndex = %d, want 20", browser.entityIndex)
+	}
+
+	// Page down past the end should clamp
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyPgDown})
+	if browser.entityIndex != 29 {
+		t.Errorf("after pgdown past end, entityIndex = %d, want 29", browser.entityIndex)
+	}
+}
+
+func TestBrowserModel_PageUpEntities(t *testing.T) {
+	app, browser := createTestAppWithManyEntities(30)
+
+	// Move to end first
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyEnd})
+	if browser.entityIndex != 29 {
+		t.Fatalf("entityIndex should be 29 after End, got %d", browser.entityIndex)
+	}
+
+	// Page up
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyPgUp})
+	if browser.entityIndex != 19 {
+		t.Errorf("after pgup, entityIndex = %d, want 19", browser.entityIndex)
+	}
+
+	// Page up again
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyPgUp})
+	if browser.entityIndex != 9 {
+		t.Errorf("after second pgup, entityIndex = %d, want 9", browser.entityIndex)
+	}
+
+	// Page up past the beginning should clamp
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyPgUp})
+	if browser.entityIndex != 0 {
+		t.Errorf("after pgup past start, entityIndex = %d, want 0", browser.entityIndex)
+	}
+}
+
+func TestBrowserModel_CtrlD_CtrlU_Entities(t *testing.T) {
+	app, browser := createTestAppWithManyEntities(30)
+
+	// Ctrl+D (page down)
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyCtrlD})
+	if browser.entityIndex != 10 {
+		t.Errorf("after ctrl+d, entityIndex = %d, want 10", browser.entityIndex)
+	}
+
+	// Ctrl+U (page up)
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyCtrlU})
+	if browser.entityIndex != 0 {
+		t.Errorf("after ctrl+u, entityIndex = %d, want 0", browser.entityIndex)
+	}
+}
+
+func TestBrowserModel_PageDownTypes(t *testing.T) {
+	app, browser := createTestAppWithManyTypes(25)
+
+	// Start at 0
+	if browser.typeIndex != 0 {
+		t.Fatalf("typeIndex should start at 0, got %d", browser.typeIndex)
+	}
+
+	// Page down
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyPgDown})
+	if browser.typeIndex != 10 {
+		t.Errorf("after pgdown, typeIndex = %d, want 10", browser.typeIndex)
+	}
+
+	// Page down again
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyPgDown})
+	if browser.typeIndex != 20 {
+		t.Errorf("after second pgdown, typeIndex = %d, want 20", browser.typeIndex)
+	}
+
+	// Page down past end should clamp
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyPgDown})
+	if browser.typeIndex != 24 {
+		t.Errorf("after pgdown past end, typeIndex = %d, want 24", browser.typeIndex)
+	}
+}
+
+func TestBrowserModel_PageUpTypes(t *testing.T) {
+	app, browser := createTestAppWithManyTypes(25)
+
+	// Move to end
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyEnd})
+	if browser.typeIndex != 24 {
+		t.Fatalf("typeIndex should be 24 after End, got %d", browser.typeIndex)
+	}
+
+	// Page up
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyPgUp})
+	if browser.typeIndex != 14 {
+		t.Errorf("after pgup, typeIndex = %d, want 14", browser.typeIndex)
+	}
+
+	// Page up past start should clamp
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyPgUp})
+	if browser.typeIndex != 4 {
+		t.Errorf("after second pgup, typeIndex = %d, want 4", browser.typeIndex)
+	}
+
+	browser.Update(app, tea.KeyMsg{Type: tea.KeyPgUp})
+	if browser.typeIndex != 0 {
+		t.Errorf("after pgup past start, typeIndex = %d, want 0", browser.typeIndex)
+	}
+}
+
+func TestBrowserModel_ViewTypesScrolling(t *testing.T) {
+	_, browser := createTestAppWithManyTypes(25)
+
+	// Render with small height — only some types should be visible
+	view := browser.View(80, 10)
+
+	// Should show scroll indicator since there are more types than fit
+	if !contains(view, "[1/25]") {
+		t.Errorf("View should contain scroll indicator '[1/25]', got:\n%s", view)
+	}
+
+	// Move to item 20 and check indicator
+	browser.typeIndex = 19
+	view = browser.View(80, 10)
+	if !contains(view, "[20/25]") {
+		t.Errorf("View should contain '[20/25]', got:\n%s", view)
+	}
+}
+
+func TestBrowserModel_ViewEntitiesScrolling(t *testing.T) {
+	_, browser := createTestAppWithManyEntities(30)
+
+	// Render with small height
+	view := browser.View(80, 10)
+
+	// Should show scroll indicator
+	if !contains(view, "[1/30]") {
+		t.Errorf("View should contain '[1/30]', got:\n%s", view)
+	}
+
+	// Move cursor to entity 15
+	browser.entityIndex = 14
+	view = browser.View(80, 10)
+	if !contains(view, "[15/30]") {
+		t.Errorf("View should contain '[15/30]', got:\n%s", view)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix types list having no scroll windowing, causing overflow/truncation with many entity types
- Fix scroll indicator `[n/total]` being cut off in both types and entities views due to incorrect line budget
- Add PageUp/PageDown and Ctrl+D/Ctrl+U support for faster navigation in both levels

## Test plan
- [x] Verified in tmux with 41 entities — viewport scrolls correctly, indicator visible
- [x] All existing browser tests pass
- [x] 7 new tests for pagination and scroll indicator rendering
- [x] Pre-commit checks pass (lint, test, coverage)