### PR TITLE
Add Dependabot with supply-chain-safe auto-merge policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      charm-tui:
+        patterns:
+          - "github.com/charmbracelet/*"
+          - "github.com/muesli/*"
+      golang-org:
+        patterns:
+          - "golang.org/x/*"
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,93 @@
+name: Dependabot Auto-Merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Go toolchain updates (go itself) — merge immediately after CI
+      - name: Auto-merge Go toolchain updates
+        if: steps.metadata.outputs.dependency-names == 'go' && steps.metadata.outputs.package-ecosystem == 'gomod'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # GitHub Actions — check if all updated actions are from trusted orgs
+      - name: Check if Actions are from trusted orgs
+        id: trusted
+        if: steps.metadata.outputs.package-ecosystem == 'github_actions'
+        run: |
+          TRUSTED_ORGS="actions/ dependabot/ github/"
+          DEPS="${{ steps.metadata.outputs.dependency-names }}"
+
+          all_trusted=true
+          IFS=',' read -ra deps <<< "$DEPS"
+          for dep in "${deps[@]}"; do
+            dep=$(echo "$dep" | xargs)  # trim whitespace
+            trusted=false
+            for org in $TRUSTED_ORGS; do
+              if [[ "$dep" == ${org}* ]]; then
+                trusted=true
+                break
+              fi
+            done
+            if [ "$trusted" = false ]; then
+              echo "Untrusted action: $dep"
+              all_trusted=false
+            fi
+          done
+
+          echo "all_trusted=$all_trusted" >> "$GITHUB_OUTPUT"
+
+      # Trusted GitHub Actions (actions/*, dependabot/*, github/*) — merge immediately
+      - name: Auto-merge trusted GitHub Actions updates
+        if: >-
+          steps.metadata.outputs.package-ecosystem == 'github_actions'
+          && steps.trusted.outputs.all_trusted == 'true'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Third-party GitHub Actions — defer 7 days
+      - name: Approve third-party Actions updates (merge deferred 7 days)
+        if: >-
+          steps.metadata.outputs.package-ecosystem == 'github_actions'
+          && steps.trusted.outputs.all_trusted == 'false'
+        run: |
+          gh pr review --approve "$PR_URL" \
+            --body "Auto-approved. Merge deferred 7 days from PR creation for supply chain safety."
+          gh pr edit "$PR_URL" --add-label "dependabot-deferred"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Go package updates — defer 7 days
+      - name: Approve package updates (merge deferred 7 days)
+        if: >-
+          steps.metadata.outputs.package-ecosystem == 'gomod'
+          && steps.metadata.outputs.dependency-names != 'go'
+        run: |
+          gh pr review --approve "$PR_URL" \
+            --body "Auto-approved. Merge deferred 7 days from PR creation for supply chain safety."
+          gh pr edit "$PR_URL" --add-label "dependabot-deferred"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-deferred-merge.yml
+++ b/.github/workflows/dependabot-deferred-merge.yml
@@ -1,0 +1,44 @@
+name: Dependabot Deferred Merge
+
+on:
+  schedule:
+    # Runs daily at 09:00 UTC
+    - cron: "0 9 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge-aged-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge deferred Dependabot PRs older than 7 days
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cutoff=$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+                || date -u -v-7d '+%Y-%m-%dT%H:%M:%SZ')
+
+          prs=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "dependabot-deferred" \
+            --state open \
+            --json number,createdAt \
+            --jq ".[] | select(.createdAt < \"$cutoff\") | .number")
+
+          if [ -z "$prs" ]; then
+            echo "No deferred PRs older than 7 days."
+            exit 0
+          fi
+
+          for pr in $prs; do
+            echo "Merging PR #$pr (older than 7 days)..."
+            gh pr merge "$pr" \
+              --repo "$GITHUB_REPOSITORY" \
+              --squash \
+              --auto \
+            && echo "  → Enabled auto-merge for #$pr" \
+            || echo "  → Failed to merge #$pr (CI may not have passed)"
+          done


### PR DESCRIPTION
## Summary
- Configure weekly Dependabot checks for Go modules and GitHub Actions
- Auto-merge Go toolchain and trusted GitHub Actions (`actions/`, `dependabot/`, `github/`) immediately after CI passes
- Defer third-party Actions and Go package updates by 7 days before auto-merging, allowing time for community detection of malicious updates
- Add scheduled workflow to merge deferred PRs after the waiting period
- Tighten CI permissions to `contents: read` (least privilege)
- Use `pull_request_target` for Dependabot workflow to get write permissions

## Test plan
- [ ] Verify CI passes on this PR with the new `permissions: contents: read`
- [ ] After merge, confirm Dependabot opens PRs within a week (or trigger manually via Insights > Dependency Graph > Dependabot)
- [ ] Verify auto-merge workflow triggers on Dependabot PRs
- [ ] Confirm `dependabot-deferred` label is created and applied to package update PRs