### PR TITLE
Fix MCP server setup docs for Claude Code

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -735,7 +735,13 @@ clients. The server runs on stdin/stdout using JSON-RPC and provides:
 
 **Client Configuration (Claude Code):**
 
-Add to your project's `.mcp.json`:
+Setup with `claude mcp add` (recommended):
+
+```bash
+claude mcp add rela -s local -- /path/to/rela mcp
+```
+
+Setup with `.mcp.json` (for sharing via git):
 
 ```json
 {

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -6,13 +6,23 @@ and other MCP-compatible clients to query, create, and analyze entities and rela
 
 ## Quick Start
 
-Start the server:
+Start the server manually (for testing):
 
 ```bash
 rela mcp
 ```
 
-Configure Claude Code by adding to your project's `.mcp.json`:
+### Claude Code Setup
+
+**Option 1: `claude mcp add` (recommended)**
+
+```bash
+claude mcp add rela -s local -- /path/to/rela mcp
+```
+
+This stores the server configuration privately per-user per-project in `~/.claude.json`.
+
+**Option 2: `.mcp.json` (for sharing via git)**
 
 ```json
 {
@@ -24,6 +34,13 @@ Configure Claude Code by adding to your project's `.mcp.json`:
   }
 }
 ```
+
+Project-scoped servers defined in `.mcp.json` require interactive approval on first use.
+
+> **Notes:**
+> - Claude Code launches MCP servers with the project directory as cwd, so `rela mcp` finds
+>   `metamodel.yaml` automatically — no cwd configuration is needed (or supported).
+> - If both a local server and `.mcp.json` define `rela`, the local server takes priority.
 
 The server communicates over stdio using JSON-RPC. It automatically discovers the project root
 (by finding `metamodel.yaml`), loads the metamodel, and syncs the graph from markdown files.

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -21,16 +21,21 @@ var mcpCmd = &cobra.Command{
 The MCP server exposes rela's capabilities to AI assistants and other MCP clients.
 It provides tools for entity/relation management, graph analysis, and tracing.
 
-Configuration for Claude Code (.claude.json):
+Setup with claude mcp add (recommended):
+  claude mcp add rela -s local -- /path/to/rela mcp
+
+Setup with .mcp.json (for sharing via git):
   {
     "mcpServers": {
       "rela": {
         "command": "rela",
-        "args": ["mcp"],
-        "cwd": "/path/to/project"
+        "args": ["mcp"]
       }
     }
   }
+
+Claude Code launches MCP servers with the project directory as cwd,
+so rela mcp finds metamodel.yaml automatically.
 
 The server communicates via JSON-RPC over stdin/stdout.
 Logs are written to stderr.`,


### PR DESCRIPTION
## Summary
- Replace incorrect `.mcp.json`-only instructions with both setup methods: `claude mcp add` (recommended, per-user) and `.mcp.json` (shareable via git)
- Remove incorrect `cwd` field from the CLI help text
- Add notes about Claude Code cwd behavior, scope, and priority when both methods are configured

## Test plan
- [x] Pre-commit checks pass (lint, tests, coverage)
- [ ] Verify `rela mcp --help` shows updated setup instructions