### PR TITLE
Add MCP hot reload for metamodel changes

### DIFF
--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -145,11 +145,12 @@ func (s *Server) handleReviewOrphansPrompt(
 	}
 
 	// Get available relation types
-	relTypes := s.meta.RelationTypes()
+	meta := s.getMeta()
+	relTypes := meta.RelationTypes()
 	sort.Strings(relTypes)
 	var relInfo strings.Builder
 	for _, name := range relTypes {
-		def, _ := s.meta.GetRelationDef(name)
+		def, _ := meta.GetRelationDef(name)
 		if def == nil {
 			continue
 		}
@@ -189,14 +190,15 @@ func (s *Server) handleSummarizeProjectPrompt(
 	_ context.Context, _ mcp.GetPromptRequest,
 ) (*mcp.GetPromptResult, error) {
 	// Entity counts by type
-	entityTypes := s.meta.EntityTypes()
+	meta := s.getMeta()
+	entityTypes := meta.EntityTypes()
 	sort.Strings(entityTypes)
 	var entityCounts strings.Builder
 	totalEntities := 0
 	for _, t := range entityTypes {
 		count := len(s.graph.NodesByType(t))
 		totalEntities += count
-		def, _ := s.meta.GetEntityDef(t)
+		def, _ := meta.GetEntityDef(t)
 		label := t
 		if def != nil {
 			label = def.GetLabel()
@@ -205,7 +207,7 @@ func (s *Server) handleSummarizeProjectPrompt(
 	}
 
 	// Relation counts by type
-	relTypes := s.meta.RelationTypes()
+	relTypes := meta.RelationTypes()
 	sort.Strings(relTypes)
 	var relCounts strings.Builder
 	totalRelations := 0
@@ -245,7 +247,7 @@ Please provide:
 4. Recommendations for improving the project's traceability`,
 		totalEntities, totalRelations, orphanCount,
 		entityCounts.String(), relCounts.String(),
-		s.meta.GetVersion(), s.meta.GetNamespace(),
+		meta.GetVersion(), meta.GetNamespace(),
 		len(entityTypes), len(relTypes))
 
 	return &mcp.GetPromptResult{
@@ -275,7 +277,8 @@ func (s *Server) handleReviewEntityPrompt(
 	}
 
 	// Get entity type schema
-	def, _ := s.meta.GetEntityDef(entity.Type)
+	meta := s.getMeta()
+	def, _ := meta.GetEntityDef(entity.Type)
 	var schemaText string
 	if def != nil {
 		schemaJSON, _ := marshalJSON(def.Properties)
@@ -285,7 +288,7 @@ func (s *Server) handleReviewEntityPrompt(
 	}
 
 	// Run validations for this entity
-	errs := s.meta.ValidateEntity(entity)
+	errs := meta.ValidateEntity(entity)
 	var validationText string
 	if len(errs) == 0 {
 		validationText = "All validations passed"

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -62,15 +62,16 @@ func (s *Server) registerResources() {
 func (s *Server) handleReadMetamodel(
 	_ context.Context, _ mcp.ReadResourceRequest,
 ) ([]mcp.ResourceContents, error) {
+	meta := s.getMeta()
 	result := map[string]interface{}{
-		"version":   s.meta.GetVersion(),
-		"namespace": s.meta.GetNamespace(),
-		"entities":  s.meta.GetEntities(),
-		"relations": s.meta.GetRelations(),
-		"types":     s.meta.GetTypes(),
+		"version":   meta.GetVersion(),
+		"namespace": meta.GetNamespace(),
+		"entities":  meta.GetEntities(),
+		"relations": meta.GetRelations(),
+		"types":     meta.GetTypes(),
 	}
-	if len(s.meta.Validations) > 0 {
-		result["validations"] = s.meta.Validations
+	if len(meta.Validations) > 0 {
+		result["validations"] = meta.Validations
 	}
 
 	text, err := marshalJSON(result)
@@ -148,17 +149,18 @@ func (s *Server) handleReadView(
 		return nil, fmt.Errorf("view not found: %s (available: %s)", viewName, strings.Join(names, ", "))
 	}
 
-	if validationErr := viewDef.Validate(s.meta, viewName); validationErr != nil {
+	meta := s.getMeta()
+	if validationErr := viewDef.Validate(meta, viewName); validationErr != nil {
 		return nil, fmt.Errorf("view validation failed: %w", validationErr)
 	}
 
-	engine := views.NewEngine(s.graph, s.meta)
+	engine := views.NewEngine(s.graph, meta)
 	result, execErr := engine.Execute(viewDef, entryID)
 	if execErr != nil {
 		return nil, fmt.Errorf("view execution failed: %w", execErr)
 	}
 
-	output, fmtErr := views.Format(result, "json", s.graph, s.meta)
+	output, fmtErr := views.Format(result, "json", s.graph, meta)
 	if fmtErr != nil {
 		return nil, fmt.Errorf("failed to format view output: %w", fmtErr)
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4,6 +4,7 @@ package mcp
 import (
 	"log"
 	"os"
+	"sync"
 
 	"github.com/mark3labs/mcp-go/server"
 
@@ -17,9 +18,24 @@ type Server struct {
 	mcp        *server.MCPServer
 	graph      *graph.Graph
 	meta       *metamodel.Metamodel
+	metaMu     sync.RWMutex // protects meta
 	projectCtx *project.Context
 	watcher    *Watcher
 	logger     *log.Logger
+}
+
+// getMeta returns the current metamodel, safe for concurrent access.
+func (s *Server) getMeta() *metamodel.Metamodel {
+	s.metaMu.RLock()
+	defer s.metaMu.RUnlock()
+	return s.meta
+}
+
+// setMeta replaces the current metamodel, safe for concurrent access.
+func (s *Server) setMeta(m *metamodel.Metamodel) {
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.meta = m
 }
 
 // NewServer creates a new MCP server for a rela project.

--- a/internal/mcp/tools_analysis.go
+++ b/internal/mcp/tools_analysis.go
@@ -52,7 +52,7 @@ func (s *Server) handleAnalyzeCardinality(
 ) (*mcp.CallToolResult, error) {
 	var violations []cardinalityViolation
 
-	for relName, relDef := range s.meta.Relations {
+	for relName, relDef := range s.getMeta().Relations {
 		violations = append(violations, s.checkCardinalityForRelation(relName, relDef)...)
 	}
 
@@ -135,7 +135,7 @@ func (s *Server) handleAnalyzeProperties(
 
 	var allErrors []entityErrors
 	for _, entity := range s.graph.AllNodes() {
-		errs := s.meta.ValidateEntity(entity)
+		errs := s.getMeta().ValidateEntity(entity)
 		if len(errs) > 0 {
 			errStrings := make([]string, len(errs))
 			for i, e := range errs {
@@ -169,7 +169,7 @@ func (s *Server) handleAnalyzeProperties(
 func (s *Server) handleAnalyzeValidations(
 	_ context.Context, _ mcp.CallToolRequest,
 ) (*mcp.CallToolResult, error) {
-	rules := s.meta.Validations
+	rules := s.getMeta().Validations
 	if len(rules) == 0 {
 		return mcp.NewToolResultText("No custom validation rules defined in metamodel"), nil
 	}

--- a/internal/mcp/tools_entity.go
+++ b/internal/mcp/tools_entity.go
@@ -170,7 +170,7 @@ func (s *Server) handleCreateEntity(
 
 	// Set default status if not provided
 	if entity.GetString("status") == "" {
-		entity.SetString("status", entityDef.GetDefaultStatus(s.meta))
+		entity.SetString("status", entityDef.GetDefaultStatus(s.getMeta()))
 	}
 
 	entity.Content = content
@@ -234,7 +234,7 @@ func (s *Server) handleUpdateEntity(
 	// Write to file
 	filePath := entity.FilePath
 	if filePath == "" {
-		entityDef, _ := s.meta.GetEntityDef(entity.Type)
+		entityDef, _ := s.getMeta().GetEntityDef(entity.Type)
 		if entityDef != nil {
 			plural := entityDef.GetDirPlural(entity.Type)
 			filePath = s.projectCtx.EntityFilePathWithPlural(plural, id)
@@ -300,7 +300,7 @@ func (s *Server) handleDeleteEntity(
 	// Delete entity file
 	filePath := entity.FilePath
 	if filePath == "" {
-		entityDef, _ := s.meta.GetEntityDef(entity.Type)
+		entityDef, _ := s.getMeta().GetEntityDef(entity.Type)
 		if entityDef != nil {
 			plural := entityDef.GetDirPlural(entity.Type)
 			filePath = s.projectCtx.EntityFilePathWithPlural(plural, id)

--- a/internal/mcp/tools_export.go
+++ b/internal/mcp/tools_export.go
@@ -12,13 +12,22 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/markdown"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
 func (s *Server) handleRefresh(
 	_ context.Context, _ mcp.CallToolRequest,
 ) (*mcp.CallToolResult, error) {
-	syncResult, err := markdown.SyncFromFiles(s.projectCtx, s.meta, s.graph)
+	// Reload metamodel in case it changed
+	newMeta, err := metamodel.Load(s.projectCtx.MetamodelPath)
+	if err != nil {
+		s.logger.Printf("Metamodel reload error (keeping previous version): %v", err)
+	} else {
+		s.setMeta(newMeta)
+	}
+
+	syncResult, err := markdown.SyncFromFiles(s.projectCtx, s.getMeta(), s.graph)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("sync failed: %v", err)), nil
 	}

--- a/internal/mcp/tools_helpers.go
+++ b/internal/mcp/tools_helpers.go
@@ -13,8 +13,9 @@ import (
 )
 
 func (s *Server) resolveType(typeName string) string {
-	resolved := s.meta.ResolveAlias(typeName)
-	if _, ok := s.meta.GetEntityDef(resolved); ok {
+	meta := s.getMeta()
+	resolved := meta.ResolveAlias(typeName)
+	if _, ok := meta.GetEntityDef(resolved); ok {
 		return resolved
 	}
 	// Try stripping plural
@@ -22,8 +23,8 @@ func (s *Server) resolveType(typeName string) string {
 		replacements := map[string]string{"ies": "y", "es": "", "s": ""}
 		if strings.HasSuffix(typeName, suffix) {
 			singular := strings.TrimSuffix(typeName, suffix) + replacements[suffix]
-			resolved = s.meta.ResolveAlias(singular)
-			if _, ok := s.meta.GetEntityDef(resolved); ok {
+			resolved = meta.ResolveAlias(singular)
+			if _, ok := meta.GetEntityDef(resolved); ok {
 				return resolved
 			}
 		}
@@ -33,7 +34,7 @@ func (s *Server) resolveType(typeName string) string {
 
 func (s *Server) resolveEntityType(typeName string) (string, *metamodel.EntityDef, error) {
 	resolved := s.resolveType(typeName)
-	def, ok := s.meta.GetEntityDef(resolved)
+	def, ok := s.getMeta().GetEntityDef(resolved)
 	if !ok {
 		return "", nil, fmt.Errorf("unknown entity type: %s", typeName)
 	}
@@ -61,7 +62,7 @@ func (s *Server) extractProperties(request mcp.CallToolRequest) map[string]inter
 }
 
 func (s *Server) validateEntity(entity *model.Entity) *mcp.CallToolResult {
-	errs := s.meta.ValidateEntity(entity)
+	errs := s.getMeta().ValidateEntity(entity)
 	if len(errs) == 0 {
 		return nil
 	}
@@ -97,21 +98,22 @@ func (s *Server) checkValidationRule(rule metamodel.ValidationRule) []*model.Ent
 		entities = s.graph.AllNodes()
 	}
 
+	meta := s.getMeta()
 	var violations []*model.Entity
 	for _, entity := range entities {
-		entityDef, ok := s.meta.GetEntityDef(entity.Type)
+		entityDef, ok := meta.GetEntityDef(entity.Type)
 		if !ok {
 			continue
 		}
 
 		if len(whenFilters) > 0 {
-			matches, matchErr := filter.MatchAll(entity, whenFilters, entityDef, s.meta)
+			matches, matchErr := filter.MatchAll(entity, whenFilters, entityDef, meta)
 			if matchErr != nil || !matches {
 				continue
 			}
 		}
 
-		satisfies, matchErr := filter.MatchAll(entity, thenFilters, entityDef, s.meta)
+		satisfies, matchErr := filter.MatchAll(entity, thenFilters, entityDef, meta)
 		if matchErr != nil || !satisfies {
 			violations = append(violations, entity)
 		}

--- a/internal/mcp/tools_relation.go
+++ b/internal/mcp/tools_relation.go
@@ -85,7 +85,7 @@ func (s *Server) handleCreateRelation(
 	}
 
 	// Validate relation
-	if valErr := s.meta.ValidateRelation(relType, fromEntity.Type, toEntity.Type); valErr != nil {
+	if valErr := s.getMeta().ValidateRelation(relType, fromEntity.Type, toEntity.Type); valErr != nil {
 		return mcp.NewToolResultError(valErr.Error()), nil
 	}
 

--- a/internal/mcp/tools_schema.go
+++ b/internal/mcp/tools_schema.go
@@ -13,15 +13,16 @@ import (
 func (s *Server) handleGetMetamodel(
 	_ context.Context, _ mcp.CallToolRequest,
 ) (*mcp.CallToolResult, error) {
+	meta := s.getMeta()
 	result := map[string]interface{}{
-		"version":   s.meta.GetVersion(),
-		"namespace": s.meta.GetNamespace(),
-		"entities":  s.meta.GetEntities(),
-		"relations": s.meta.GetRelations(),
-		"types":     s.meta.GetTypes(),
+		"version":   meta.GetVersion(),
+		"namespace": meta.GetNamespace(),
+		"entities":  meta.GetEntities(),
+		"relations": meta.GetRelations(),
+		"types":     meta.GetTypes(),
 	}
-	if len(s.meta.Validations) > 0 {
-		result["validations"] = s.meta.Validations
+	if len(meta.Validations) > 0 {
+		result["validations"] = meta.Validations
 	}
 
 	text, err := marshalJSON(result)
@@ -43,12 +44,13 @@ func (s *Server) handleListEntityTypes(
 		Count      int                              `json:"count"`
 	}
 
-	types := s.meta.EntityTypes()
+	meta := s.getMeta()
+	types := meta.EntityTypes()
 	sort.Strings(types)
 
 	result := make([]entityTypeInfo, 0, len(types))
 	for _, name := range types {
-		def, _ := s.meta.GetEntityDef(name)
+		def, _ := meta.GetEntityDef(name)
 		if def == nil {
 			continue
 		}
@@ -82,12 +84,13 @@ func (s *Server) handleListRelationTypes(
 		Count       int      `json:"count"`
 	}
 
-	types := s.meta.RelationTypes()
+	meta := s.getMeta()
+	types := meta.RelationTypes()
 	sort.Strings(types)
 
 	result := make([]relationTypeInfo, 0, len(types))
 	for _, name := range types {
-		def, _ := s.meta.GetRelationDef(name)
+		def, _ := meta.GetRelationDef(name)
 		if def == nil {
 			continue
 		}

--- a/internal/mcp/tools_views.go
+++ b/internal/mcp/tools_views.go
@@ -79,17 +79,18 @@ func (s *Server) handleExecuteView(
 			fmt.Sprintf("view not found: %s (available: %s)", viewName, strings.Join(names, ", "))), nil
 	}
 
-	if validationErr := viewDef.Validate(s.meta, viewName); validationErr != nil {
+	meta := s.getMeta()
+	if validationErr := viewDef.Validate(meta, viewName); validationErr != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("view validation failed: %v", validationErr)), nil
 	}
 
-	engine := views.NewEngine(s.graph, s.meta)
+	engine := views.NewEngine(s.graph, meta)
 	result, execErr := engine.Execute(viewDef, entryID)
 	if execErr != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("view execution failed: %v", execErr)), nil
 	}
 
-	output, fmtErr := views.Format(result, format, s.graph, s.meta)
+	output, fmtErr := views.Format(result, format, s.graph, meta)
 	if fmtErr != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to format output: %v", fmtErr)), nil
 	}

--- a/internal/mcp/watcher.go
+++ b/internal/mcp/watcher.go
@@ -10,6 +10,8 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/Sourcehaven-BV/rela/internal/markdown"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/migration"
 )
 
 // Watcher watches entity and relation files for changes and notifies MCP clients.
@@ -107,7 +109,19 @@ func (w *Watcher) Stop() {
 }
 
 func (w *Watcher) syncAndNotify() {
-	_, err := markdown.SyncFromFiles(w.server.projectCtx, w.server.meta, w.server.graph)
+	// Reload metamodel in case it changed
+	newMeta, err := metamodel.Load(w.server.projectCtx.MetamodelPath)
+	if err != nil {
+		if migration.IsMigrationError(err) {
+			w.server.logger.Printf("Metamodel needs migration, skipping reload: run 'rela migrate'")
+		} else {
+			w.server.logger.Printf("Metamodel reload error (keeping previous version): %v", err)
+		}
+	} else {
+		w.server.setMeta(newMeta)
+	}
+
+	_, err = markdown.SyncFromFiles(w.server.projectCtx, w.server.getMeta(), w.server.graph)
 	if err != nil {
 		w.server.logger.Printf("Sync error: %v", err)
 		return


### PR DESCRIPTION
## Summary
- Reload `metamodel.yaml` from disk in the file watcher before re-syncing the graph, fixing the bug where schema changes were never picked up by the running MCP server
- Protect `server.meta` with `sync.RWMutex` (`getMeta()`/`setMeta()`) to prevent data races between the watcher goroutine and concurrent MCP request handlers
- Add metamodel reload to the `refresh` tool for consistency
- Handle migration errors specially with a clear log message directing users to run `rela migrate`

## Test plan
- [x] All existing tests pass (`go test -race ./...`)
- [x] Lint passes (`make lint`)
- [x] Coverage thresholds met (`make coverage-check`)
- [x] Pre-commit hooks pass