### PR TITLE
Fix CI: upgrade Go to 1.24, golangci-lint to v1.64.8, fix markdown lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Download dependencies
         run: go mod download
@@ -72,12 +72,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.62.2
+          version: v1.64.8
 
   lint-markdown:
     name: Lint Markdown
@@ -104,7 +104,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Run fuzz tests
         run: |
@@ -122,7 +122,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Run govulncheck
         run: |
@@ -139,7 +139,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Build
         run: go build -o bin/rela ./cmd/rela

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Run tests
         run: go test -v -race ./...
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
@@ -88,7 +88,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Install Linux dependencies
         if: matrix.os_name == 'linux'

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -38,6 +38,7 @@ This stores the server configuration privately per-user per-project in `~/.claud
 Project-scoped servers defined in `.mcp.json` require interactive approval on first use.
 
 > **Notes:**
+>
 > - Claude Code launches MCP servers with the project directory as cwd, so `rela mcp` finds
 >   `metamodel.yaml` automatically — no cwd configuration is needed (or supported).
 > - If both a local server and `.mcp.json` define `rela`, the local server takes priority.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Sourcehaven-BV/rela
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/charmbracelet/bubbletea v0.25.0

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -16,9 +16,9 @@ func TestApplyFilters(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		filters  []FilterConfig
-		wantIDs  []string
+		name    string
+		filters []FilterConfig
+		wantIDs []string
 	}{
 		{
 			name:    "no filters returns all",
@@ -36,7 +36,7 @@ func TestApplyFilters(t *testing.T) {
 			wantIDs: []string{"E-001", "E-003"},
 		},
 		{
-			name:    "multiple filters (AND)",
+			name: "multiple filters (AND)",
 			filters: []FilterConfig{
 				{Property: "status", Operator: "=", Value: "open"},
 				{Property: "priority", Operator: "=", Value: "high"},
@@ -488,10 +488,10 @@ func TestTemplateFuncs(t *testing.T) {
 
 func TestAppendToastParam(t *testing.T) {
 	tests := []struct {
-		name     string
-		url      string
-		message  string
-		want     string
+		name    string
+		url     string
+		message string
+		want    string
 	}{
 		{
 			"simple path",


### PR DESCRIPTION
## Summary
- Upgrade Go from 1.23 to 1.24 in `go.mod` and all CI/release workflows to resolve govulncheck stdlib vulnerabilities (GO-2026-4341 net/url, GO-2026-4340 crypto/tls)
- Upgrade golangci-lint from v1.62.2 to v1.64.8 to match local version and eliminate `gofmt -s` discrepancy caused by pre-built binary version mismatch
- Apply `gofmt -s` struct alignment normalization in `helpers_test.go`
- Add blank line in `docs/mcp-server.md` blockquote to satisfy MD032 rule

## Test plan
- [ ] CI Lint job passes (golangci-lint v1.64.8 matches local)
- [ ] CI Lint Markdown job passes (MD032 fixed)
- [ ] CI Security job passes (Go 1.24 resolves stdlib vulns)
- [ ] CI Test and Fuzz jobs pass with Go 1.24
- [ ] All pre-commit checks pass locally (verified)