### PR TITLE
Fix macOS desktop app "damaged" error with ad-hoc code signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,12 @@ jobs:
           sed "s/VERSION_PLACEHOLDER/${{ steps.version.outputs.version }}/g" \
             build/package/macos/Info.plist > "$APP_DIR/Info.plist"
 
+      - name: Ad-hoc sign macOS app
+        if: matrix.os_name == 'darwin'
+        run: |
+          codesign --force --deep -s - "Rela Desktop.app"
+          codesign --verify "Rela Desktop.app"
+
       - name: Create DMG
         if: matrix.os_name == 'darwin'
         run: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -87,6 +87,17 @@ release:
   draft: false
   prerelease: auto
   name_template: "{{.Tag}}"
+  header: |
+    ## macOS Desktop App
+
+    The macOS desktop app is ad-hoc signed. After opening the DMG and dragging the app
+    to Applications, macOS Gatekeeper may block it. To allow it to run:
+
+    ```bash
+    xattr -cr "/Applications/Rela Desktop.app"
+    ```
+
+    Alternatively, right-click the app and select **Open**, then confirm in the dialog.
 
 # Homebrew tap (optional - uncomment when you have a homebrew-tap repo)
 # brews:


### PR DESCRIPTION
## Summary
- Ad-hoc sign the macOS `.app` bundle before creating the DMG to fix the "app is damaged" Gatekeeper error
- Add macOS install instructions to release notes via GoReleaser `release.header`

## Context
macOS marks downloaded files with `com.apple.quarantine`. Without any code signature, Gatekeeper reports the app as "damaged" rather than showing the standard "unidentified developer" dialog. Ad-hoc signing (`codesign -s -`) provides a valid signature structure that resolves this.

## Test plan
- [ ] Tag a pre-release and verify the macOS DMG installs without the "damaged" error
- [ ] Verify the release notes include the macOS instructions