### PR TITLE
Add collapsible grouped navigation to data entry sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ go build -o rela ./cmd/rela
 | [Export Guide](docs/export.md) | Export, import, and data integration |
 | [Best Practices](docs/best-practices.md) | Maintenance tips and team workflows |
 | [MCP Server](docs/mcp-server.md) | AI assistant integration via MCP |
+| [Data Entry Web App](docs/data-entry.md) | Config-driven web UI for entity management |
 
 ### Tutorials
 

--- a/docs-project/entities/feature/FEAT-data-entry.md
+++ b/docs-project/entities/feature/FEAT-data-entry.md
@@ -1,0 +1,11 @@
+---
+id: FEAT-data-entry
+type: feature
+title: "Data Entry Web App"
+status: published
+summary: "Config-driven web UI for creating, editing, and browsing entities"
+---
+
+HTMX-based web application configured entirely through `data-entry.yaml`.
+Provides forms, filterable lists, detail views, dashboards, search, and
+sidebar navigation with optional grouping.

--- a/docs-project/entities/feature/FEAT-grouped-navigation.md
+++ b/docs-project/entities/feature/FEAT-grouped-navigation.md
@@ -1,0 +1,11 @@
+---
+id: FEAT-grouped-navigation
+type: feature
+title: "Grouped Navigation"
+status: published
+summary: "Collapsible sidebar groups for organizing navigation items in the data entry web app"
+---
+
+Navigation items in `data-entry.yaml` can be organized into named collapsible
+groups. Collapsed state is persisted server-side, and groups auto-expand when
+they contain the active page. Nested groups are rejected at validation time.

--- a/docs-project/entities/guide/GUIDE-data-entry.md
+++ b/docs-project/entities/guide/GUIDE-data-entry.md
@@ -1,0 +1,1041 @@
+---
+id: GUIDE-data-entry
+type: guide
+title: "Data Entry Web App"
+status: published
+order: 10
+audience: intermediate
+summary: "Config-driven web UI for entity management"
+---
+
+The data entry application provides a web-based UI for creating, editing, and browsing entities
+stored in a rela project. It is configured entirely through a `data-entry.yaml` file placed
+alongside your `metamodel.yaml`.
+
+## Overview
+
+A `data-entry.yaml` file defines:
+
+- **App metadata** - Name and description shown in the UI
+- **Git settings** - Protected branches that require pull requests
+- **Styles** - Color mappings for enum values displayed in lists and forms
+- **Forms** - Create and edit forms for entity types, with fields and relation pickers
+- **Lists** - Tabular views with sorting, filtering, and pagination
+- **Views** - Read-only detail pages that traverse the graph to show related entities
+- **Dashboard** - An overview page with query-driven cards showing counts, breakdowns, and tables
+- **Navigation** - Sidebar menu entries with optional grouping
+
+The file drives the entire UI without writing any code. The server reads `data-entry.yaml` and
+your `metamodel.yaml` together, validates them, and serves a fully functional CRUD application.
+
+## Quick Start
+
+### 1. Create data-entry.yaml
+
+Place a `data-entry.yaml` in your project root (next to `metamodel.yaml`):
+
+```yaml
+version: "1.0"
+
+app:
+  name: "My Project"
+  description: "Project management system"
+
+forms:
+  create_task:
+    entity_type: task
+    title: "New Task"
+    body: true
+    fields:
+      - property: title
+        label: "Title"
+        required: true
+      - property: status
+        label: "Status"
+        default: open
+
+lists:
+  all_tasks:
+    entity_type: task
+    title: "All Tasks"
+    columns:
+      - property: title
+        label: "Title"
+        sortable: true
+        link: true
+      - property: status
+        label: "Status"
+        sortable: true
+    create_form: create_task
+    page_size: 25
+
+navigation:
+  - label: "Tasks"
+    list: all_tasks
+```
+
+### 2. Start the Server
+
+```bash
+rela-server -project /path/to/project
+```
+
+Or with a custom config path:
+
+```bash
+rela-server -project /path/to/project -config /path/to/data-entry.yaml
+```
+
+The server starts on port 8080 by default. Open `http://localhost:8080` in your browser.
+
+## File Structure
+
+```yaml
+version: "1.0"            # Config format version
+
+app:                       # Application metadata
+  name: "..."
+  description: "..."
+
+git:                       # Git sync settings
+  require_pr: [main]
+
+styles:                    # Color mappings for enum values
+  status:
+    open: blue
+    closed: gray
+
+forms:                     # Create/edit form definitions
+  form_name:
+    entity_type: task
+    ...
+
+lists:                     # List view definitions
+  list_name:
+    entity_type: task
+    ...
+
+views:                     # Detail view definitions
+  view_name:
+    entry:
+      type: task
+    ...
+
+dashboard:                 # Optional overview page
+  title: "Dashboard"
+  cards:
+    - title: "Open"
+      query: "type:task status:open"
+      display: count
+
+navigation:                # Sidebar menu (supports groups)
+  - label: "Dashboard"
+    dashboard: true
+  - group: "Tasks"
+    items:
+      - label: "All Tasks"
+        list: all_tasks
+```
+
+## App
+
+Display metadata shown in the header:
+
+```yaml
+app:
+  name: "Support Tickets"
+  description: "Internal ticket management system"
+```
+
+| Field         | Description                      |
+| ------------- | -------------------------------- |
+| `name`        | Application title in the header  |
+| `description` | Subtitle shown below the title   |
+
+## Git
+
+Configure git synchronization behavior:
+
+```yaml
+git:
+  require_pr: [main, production]
+```
+
+| Field        | Description                                                           |
+| ------------ | --------------------------------------------------------------------- |
+| `require_pr` | List of branch names where direct push is blocked (protected branches) |
+
+When editing on a protected branch, the UI shows a banner suggesting the user create a working
+branch. Commits are auto-created on every entity change, but push is blocked until the user
+switches to a non-protected branch.
+
+## Styles
+
+Map enum values to colors for visual display in lists and forms:
+
+```yaml
+styles:
+  status:
+    draft: gray
+    review: blue
+    approved: green
+    active: green
+    retired: gray
+
+  priority:
+    critical: red
+    high: orange
+    medium: yellow
+    low: green
+```
+
+The key is the custom type name (as defined in `metamodel.yaml` under `types:`). Each value maps
+to a color name. These colors are applied everywhere that enum value appears: list cells, badges,
+and form select options.
+
+**Available colors:** `red`, `orange`, `yellow`, `green`, `blue`, `purple`, `gray`.
+
+## Forms
+
+Forms define the UI for creating and editing entities. Each form is a named entry under `forms:`.
+
+### Basic Form
+
+```yaml
+forms:
+  create_ticket:
+    entity_type: ticket
+    title: "New Ticket"
+    description: "Submit a new support ticket"
+    body: true
+
+    fields:
+      - property: title
+        label: "Title"
+        placeholder: "Brief summary..."
+        required: true
+
+      - property: priority
+        label: "Priority"
+        default: medium
+
+    relations:
+      - relation: belongs-to
+        direction: outgoing
+        target_type: category
+        label: "Category"
+        widget: select
+```
+
+### Form Fields
+
+| Field            | Type   | Description                                               |
+| ---------------- | ------ | --------------------------------------------------------- |
+| `entity_type`    | string | Entity type this form operates on (must exist in metamodel) |
+| `title`          | string | Form heading                                              |
+| `description`    | string | Help text shown below the heading                         |
+| `mode`           | string | `"edit"` for edit forms (omit for create forms)           |
+| `body`           | bool   | Show a markdown body editor                               |
+| `fields`         | list   | Property fields                                           |
+| `relations`      | list   | Relation picker fields                                    |
+
+### Field Options
+
+Each entry in `fields:` configures one property input:
+
+| Field         | Type              | Description                                                    |
+| ------------- | ----------------- | -------------------------------------------------------------- |
+| `property`    | string            | Property name from the metamodel                               |
+| `label`       | string            | Display label (defaults to property name)                      |
+| `placeholder` | string            | Placeholder text for empty inputs                              |
+| `help`        | string            | Help text shown below the field                                |
+| `required`    | bool              | Field must be filled before submission                         |
+| `default`     | string            | Default value for new entities                                 |
+| `hidden`      | bool              | Include in form data but hide from UI                          |
+| `widget`      | string            | Input widget type (see below)                                  |
+| `transitions` | map[string]list   | Allowed state transitions for enum fields (edit forms only)    |
+
+### Widget Types
+
+| Widget     | Description                                      | Use For                        |
+| ---------- | ------------------------------------------------ | ------------------------------ |
+| *(default)* | Auto-detected from property type                | Strings, enums                 |
+| `text`     | Single-line text input                           | Short strings                  |
+| `textarea` | Multi-line text area                             | Descriptions, notes            |
+| `number`   | Numeric input                                    | Integers                       |
+| `date`     | Date picker                                      | Date properties                |
+| `checkbox` | Toggle checkbox                                  | Boolean properties             |
+
+When no widget is specified, the system auto-detects from the property's type in the metamodel:
+enum types render as a `<select>`, booleans as checkboxes, dates as date pickers, and everything
+else as text inputs.
+
+### State Transitions
+
+For edit forms, you can restrict which enum values are selectable based on the current value:
+
+```yaml
+fields:
+  - property: status
+    label: "Status"
+    transitions:
+      open: [in-progress, closed]
+      in-progress: [open, resolved]
+      resolved: [closed, in-progress]
+      closed: [open]
+```
+
+Each key is a current value; its list contains the values the user can transition to. The current
+value is always implicitly included. If `transitions` is omitted, all enum values are shown.
+
+### Relation Fields
+
+Each entry in `relations:` configures a relation picker:
+
+| Field          | Type   | Description                                                    |
+| -------------- | ------ | -------------------------------------------------------------- |
+| `relation`     | string | Relation type name from the metamodel                          |
+| `direction`    | string | `"outgoing"` or `"incoming"`                                   |
+| `target_type`  | string | Entity type of the related entity                              |
+| `label`        | string | Display label                                                  |
+| `required`     | bool   | At least one relation must be selected                         |
+| `widget`       | string | `"select"`, `"multi-select"`, or `"search"`                   |
+| `allow_create` | bool   | Show an inline "create new" button                             |
+| `create_form`  | string | Form name to use for inline creation                           |
+| `properties`   | list   | Editable properties on the relation itself                     |
+
+**Relation widget types:**
+
+| Widget         | Description                                                  |
+| -------------- | ------------------------------------------------------------ |
+| `select`       | Dropdown listing all entities of the target type (pick one)  |
+| `multi-select` | Tag-style picker for selecting multiple entities             |
+| `search`       | Type-ahead search field for large entity sets                |
+
+**Inline creation:** When `allow_create: true` and `create_form` is set, a button appears next to
+the relation picker. Clicking it opens a modal with the referenced form, and the newly created
+entity is automatically linked.
+
+### Relation Properties
+
+Relations can have their own editable properties:
+
+```yaml
+relations:
+  - relation: blocks
+    direction: outgoing
+    target_type: ticket
+    label: "Blocks"
+    widget: search
+    properties:
+      - property: reason
+        label: "Block Reason"
+        widget: text
+```
+
+| Field      | Type   | Description                       |
+| ---------- | ------ | --------------------------------- |
+| `property` | string | Relation property name            |
+| `label`    | string | Display label                     |
+| `widget`   | string | Input widget (`text`, `textarea`) |
+| `required` | bool   | Must be filled                    |
+
+## Lists
+
+Lists display entities in a sortable, filterable table with optional create/edit actions.
+
+### Basic List
+
+```yaml
+lists:
+  all_tickets:
+    entity_type: ticket
+    title: "All Tickets"
+    description: "View all tickets"
+
+    columns:
+      - property: title
+        label: "Title"
+        sortable: true
+        link: true
+      - property: status
+        label: "Status"
+        sortable: true
+      - property: priority
+        label: "Priority"
+        sortable: true
+
+    sort:
+      property: priority
+      direction: asc
+
+    create_form: create_ticket
+    edit_form: edit_ticket
+    detail_view: ticket_report
+    page_size: 25
+```
+
+### List Fields
+
+| Field             | Type   | Description                                                 |
+| ----------------- | ------ | ----------------------------------------------------------- |
+| `entity_type`     | string | Entity type to list                                         |
+| `title`           | string | List heading                                                |
+| `description`     | string | Subtitle                                                    |
+| `columns`         | list   | Column definitions                                          |
+| `sort`            | object | Default sort order                                          |
+| `filters`         | list   | Static filters (always applied)                             |
+| `filter_controls` | list   | Interactive filter controls shown to the user               |
+| `create_form`     | string | Form name for the "New" button                              |
+| `edit_form`       | string | Form name for the row edit action                           |
+| `detail_view`     | string | View name for the row detail action                         |
+| `page_size`       | int    | Rows per page (default: 25)                                 |
+
+### Column Options
+
+| Field      | Type   | Description                                    |
+| ---------- | ------ | ---------------------------------------------- |
+| `property` | string | Property name to display                       |
+| `label`    | string | Column header (defaults to property name)      |
+| `sortable` | bool   | Column can be sorted by clicking the header    |
+| `link`     | bool   | Cell value links to the entity's detail page   |
+
+### Static Filters
+
+Apply filters that are always active (the user cannot remove them):
+
+```yaml
+filters:
+  - property: status
+    operator: "="
+    value: open
+```
+
+| Field      | Type   | Description                              |
+| ---------- | ------ | ---------------------------------------- |
+| `property` | string | Property to filter on                    |
+| `operator` | string | `"="`, `"!="`, `"<"`, `"<="`, `">"`, `">="` |
+| `value`    | string | Value to compare against                 |
+
+**Special values:**
+
+- `$USER` - Replaced with the current system username at runtime
+
+```yaml
+filters:
+  - property: assignee
+    operator: "="
+    value: "$USER"
+```
+
+### Filter Controls
+
+Interactive filters shown above the table:
+
+```yaml
+filter_controls:
+  - property: status
+    widget: multi-select
+  - property: priority
+    widget: select
+  - property: assignee
+    widget: search
+```
+
+| Field      | Type   | Description                                              |
+| ---------- | ------ | -------------------------------------------------------- |
+| `property` | string | Property to filter on                                    |
+| `widget`   | string | `"select"`, `"multi-select"`, or `"search"`             |
+
+### Sort Configuration
+
+```yaml
+sort:
+  property: priority
+  direction: asc    # "asc" or "desc"
+```
+
+## Views
+
+Views define read-only detail pages that traverse the entity graph to display related data.
+They are the data-entry equivalent of the CLI's views.yaml concept, adapted for
+rendering as HTML sections.
+
+### Basic View
+
+```yaml
+views:
+  ticket_report:
+    title: "Ticket Report"
+    entry:
+      type: ticket
+
+    traverse:
+      - from: entry
+        follow: blocks
+        collect_as: blocked_tickets
+      - from: entry
+        follow_incoming: blocks
+        collect_as: blocked_by
+      - from: entry
+        follow: tagged
+        collect_as: labels
+
+    sections:
+      - heading: "Ticket"
+        source: entry
+        display: properties
+        fields:
+          - property: status
+          - property: priority
+          - property: assignee
+
+      - source: entry
+        display: content
+
+      - heading: "Blocks"
+        source: blocked_tickets
+        display: table
+        columns:
+          - property: title
+            label: "Title"
+            link: true
+          - property: status
+            label: "Status"
+        empty_message: "No blocked tickets"
+```
+
+### View Fields
+
+| Field      | Type   | Description                                    |
+| ---------- | ------ | ---------------------------------------------- |
+| `title`    | string | Page heading                                   |
+| `entry`    | object | Entry entity type                              |
+| `traverse` | list   | Graph traversal rules (same as views.yaml)     |
+| `sections` | list   | Display sections                               |
+
+### Entry
+
+```yaml
+entry:
+  type: ticket   # Entity type of the entry entity
+```
+
+When a user opens a view, the entry entity is determined by the URL. For example,
+clicking a list row that references `detail_view: ticket_report` opens the view for that
+specific ticket entity.
+
+### Traverse Rules
+
+Traverse rules collect related entities into named collections. They work identically to
+views.yaml traverse rules:
+
+```yaml
+traverse:
+  # Follow outgoing relations
+  - from: entry
+    follow: blocks
+    collect_as: blocked_tickets
+
+  # Follow incoming relations
+  - from: entry
+    follow_incoming: tagged
+    collect_as: labels
+
+  # Chain from a previous collection
+  - from: blocked_tickets
+    follow: tagged
+    collect_as: blocked_labels
+
+  # Recursive traversal
+  - from: entry
+    follow: dependsOn
+    recursive: true
+    max_depth: 5
+    collect_as: dependencies
+```
+
+| Field             | Type   | Description                                        |
+| ----------------- | ------ | -------------------------------------------------- |
+| `from`            | string | Source: `"entry"` or a collection name              |
+| `follow`          | string | Outgoing relation type to follow                   |
+| `follow_incoming` | string | Incoming relation type to follow (reverse)         |
+| `collect_as`      | string | Name for the collected entities                    |
+| `recursive`       | bool   | Follow the relation transitively                   |
+| `max_depth`       | int    | Maximum recursion depth                            |
+
+### Sections
+
+Sections define how collected entities are rendered on the page:
+
+```yaml
+sections:
+  - heading: "Properties"
+    source: entry
+    display: properties
+    fields:
+      - property: status
+      - property: priority
+        label: "Priority Level"
+
+  - heading: "Description"
+    source: entry
+    display: content
+
+  - heading: "Related Items"
+    source: related_items
+    display: table
+    columns:
+      - property: title
+        label: "Title"
+        link: true
+      - property: status
+        label: "Status"
+    empty_message: "No related items found"
+```
+
+| Field           | Type   | Description                                             |
+| --------------- | ------ | ------------------------------------------------------- |
+| `heading`       | string | Section heading (optional; omit for no heading)         |
+| `source`        | string | `"entry"` or a traverse collection name                 |
+| `display`       | string | Display mode (see below)                                |
+| `fields`        | list   | Properties to show (`properties`, `content`, `cards`, `list` modes) |
+| `columns`       | list   | Column definitions (`table` mode)                       |
+| `group_by`      | string | Property to group entities by                           |
+| `empty_message` | string | Text shown when the collection is empty                 |
+| `link`          | bool   | Link entity titles to their detail pages                |
+
+### Display Modes
+
+| Mode         | Description                                                     |
+| ------------ | --------------------------------------------------------------- |
+| `properties` | Key-value pairs rendered as a definition list                   |
+| `content`    | Markdown body of the entity rendered as HTML                    |
+| `table`      | Tabular layout with configurable columns (like a mini-list)     |
+| `cards`      | Card layout showing each entity with selected property badges   |
+| `list`       | Simple bulleted list of entity titles with optional fields      |
+
+**`properties`** is best for the entry entity's metadata. **`content`** renders the markdown body.
+**`table`** works well for collections with many items. **`cards`** provides a visual layout for
+smaller collections. **`list`** is the most compact.
+
+## Dashboard
+
+The dashboard is an optional overview page that displays a grid of query-driven cards. Each card
+runs a search query against your entities and renders the results as a count, a property breakdown,
+or a mini-table. The query syntax is the same as the search page: `type:`, `prop:`, `status:`,
+and free text.
+
+### Basic Dashboard
+
+```yaml
+dashboard:
+  title: "Dashboard"
+  description: "Project overview"
+  cards:
+    - title: "Open Tickets"
+      query: "type:ticket status:open"
+      display: count
+
+    - title: "By Priority"
+      query: "type:ticket"
+      display: breakdown
+      group_by: priority
+
+    - title: "Critical Issues"
+      query: "type:ticket prop:priority=critical"
+      display: table
+      columns:
+        - property: title
+          label: "Title"
+          link: true
+        - property: status
+          label: "Status"
+        - property: assignee
+          label: "Assignee"
+      sort:
+        property: status
+        direction: asc
+      limit: 10
+```
+
+### Dashboard Fields
+
+| Field         | Type   | Description                            |
+| ------------- | ------ | -------------------------------------- |
+| `title`       | string | Page heading                           |
+| `description` | string | Subtitle shown below the heading       |
+| `cards`       | list   | Card definitions                       |
+
+### Card Options
+
+| Field     | Type   | Description                                                        |
+| --------- | ------ | ------------------------------------------------------------------ |
+| `title`   | string | Card heading                                                       |
+| `query`   | string | Search query (same syntax as the search page)                      |
+| `display` | string | Display mode: `"count"`, `"breakdown"`, or `"table"`               |
+| `group_by`| string | Property to group by (`breakdown` mode only)                       |
+| `columns` | list   | Column definitions (`table` mode only, same format as list columns) |
+| `sort`    | object | Sort order (`table` mode only)                                     |
+| `limit`   | int    | Maximum rows to display (`table` mode only)                        |
+
+### Display Modes
+
+**`count`** shows a single large number — the count of entities matching the query. Use this for
+quick status indicators like "5 open tickets" or "3 overdue items".
+
+**`breakdown`** groups matching entities by a property and shows each value with a count and a
+horizontal bar. The property should be an enum or custom type so values can be styled with badge
+colors from `styles`. For example, grouping by `status` shows "open: 2, in-progress: 1, closed: 1"
+with colored bars.
+
+**`table`** shows matching entities as a compact table. It supports the same `columns` format as
+list definitions (with `property`, `label`, `sortable`, `link`), plus `sort` and `limit` to control
+ordering and row count.
+
+### Query Syntax
+
+Cards use the same search query syntax available on the search page:
+
+| Syntax                   | Example                           | Description                      |
+| ------------------------ | --------------------------------- | -------------------------------- |
+| `type:<entity_type>`     | `type:ticket`                     | Filter by entity type            |
+| `type:<a>,<b>`           | `type:ticket,category`            | Multiple entity types            |
+| `status:<value>`         | `status:open`                     | Shortcut for `prop:status=value` |
+| `prop:<name>=<value>`    | `prop:priority=critical`          | Property equals value            |
+| `prop:<name>!=<value>`   | `prop:assignee!=`                 | Property not equal               |
+| `prop:<name>=~<regex>`   | `prop:title=~auth.*`              | Regex match                      |
+| `prop:<name><<value>`    | `prop:due_date<2025-06-01`        | Less than (dates, numbers)       |
+| free text                | `authentication`                  | Substring match across all fields|
+| `"quoted phrase"`        | `"REST API"`                      | Exact phrase match               |
+
+Multiple terms are combined with AND logic. For example,
+`type:ticket status:open prop:priority=critical` matches tickets that are both open and critical.
+
+Every card includes a link icon that opens the same query on the search page for further
+exploration.
+
+## Navigation
+
+The navigation section defines the sidebar menu. Each entry is either a direct item (linking to a
+list, dashboard, or graph) or a **group** containing multiple items:
+
+```yaml
+navigation:
+  - label: "Dashboard"
+    dashboard: true
+  - group: "Tickets"
+    items:
+      - label: "Open Tickets"
+        list: open_tickets
+      - label: "All Tickets"
+        list: all_tickets
+  - group: "Reference Data"
+    collapsed: true
+    items:
+      - label: "Categories"
+        list: categories
+  - label: "Graph Explorer"
+    graph: true
+```
+
+### Direct Items
+
+| Field       | Type   | Description                                                    |
+| ----------- | ------ | -------------------------------------------------------------- |
+| `label`     | string | Menu item text                                                 |
+| `list`      | string | List name to navigate to (mutually exclusive with other types) |
+| `dashboard` | bool   | Link to the dashboard page                                     |
+| `graph`     | bool   | Link to the graph explorer                                     |
+
+### Groups
+
+| Field       | Type   | Description                                              |
+| ----------- | ------ | -------------------------------------------------------- |
+| `group`     | string | Group header text (displayed as uppercase label)         |
+| `collapsed` | bool   | Default collapsed state (optional, default: `false`)     |
+| `items`     | list   | List of direct navigation items within the group         |
+
+Groups appear as collapsible sections in the sidebar. Clicking the group header toggles
+expand/collapse. The collapsed state is persisted server-side in `.rela/ui-state.json`, so it
+survives page reloads. If the active page is inside a collapsed group, the group auto-expands.
+
+Nested groups are not supported. If an item inside `items` has a `group` field, config validation
+will reject it with a clear error message.
+
+The first navigable entry is the default landing page — the first direct item, or the first item
+inside the first group. Order matters; items appear in the sidebar in the order listed.
+
+List entries show an entity count badge next to the label (based on the list's filters). Dashboard
+and graph entries do not show a count.
+
+Direct items and groups can be freely mixed in any order.
+
+## Complete Example
+
+A ticket management system with forms, lists, views, dashboard, and grouped navigation:
+
+```yaml
+version: "1.0"
+
+app:
+  name: "Support Tickets"
+  description: "Internal ticket management"
+
+git:
+  require_pr: [main]
+
+styles:
+  ticket_status:
+    open: blue
+    in-progress: purple
+    resolved: green
+    closed: gray
+  priority:
+    critical: red
+    high: orange
+    medium: yellow
+    low: green
+
+forms:
+  create_ticket:
+    entity_type: ticket
+    title: "New Ticket"
+    body: true
+    fields:
+      - property: title
+        label: "Title"
+        required: true
+      - property: priority
+        label: "Priority"
+        default: medium
+      - property: assignee
+        label: "Assignee"
+      - property: due_date
+        label: "Due Date"
+        widget: date
+      - property: status
+        hidden: true
+        default: open
+    relations:
+      - relation: belongs-to
+        direction: outgoing
+        target_type: category
+        label: "Category"
+        widget: select
+        allow_create: true
+        create_form: create_category
+
+  edit_ticket:
+    entity_type: ticket
+    title: "Edit Ticket"
+    mode: edit
+    body: true
+    fields:
+      - property: title
+        label: "Title"
+      - property: status
+        label: "Status"
+        transitions:
+          open: [in-progress, closed]
+          in-progress: [open, resolved]
+          resolved: [closed, in-progress]
+          closed: [open]
+      - property: priority
+        label: "Priority"
+      - property: assignee
+        label: "Assignee"
+      - property: due_date
+        label: "Due Date"
+        widget: date
+
+  create_category:
+    entity_type: category
+    title: "New Category"
+    fields:
+      - property: name
+        label: "Name"
+        required: true
+
+lists:
+  all_tickets:
+    entity_type: ticket
+    title: "All Tickets"
+    columns:
+      - property: title
+        label: "Title"
+        sortable: true
+        link: true
+      - property: status
+        label: "Status"
+        sortable: true
+      - property: priority
+        label: "Priority"
+        sortable: true
+      - property: assignee
+        label: "Assignee"
+      - property: due_date
+        label: "Due"
+        sortable: true
+    sort:
+      property: priority
+      direction: asc
+    filter_controls:
+      - property: status
+        widget: multi-select
+      - property: priority
+        widget: select
+    create_form: create_ticket
+    edit_form: edit_ticket
+    detail_view: ticket_detail
+    page_size: 25
+
+  open_tickets:
+    entity_type: ticket
+    title: "Open Tickets"
+    columns:
+      - property: title
+        link: true
+        sortable: true
+      - property: priority
+        sortable: true
+      - property: assignee
+    filters:
+      - property: status
+        operator: "="
+        value: open
+    create_form: create_ticket
+    edit_form: edit_ticket
+    page_size: 25
+
+  my_tickets:
+    entity_type: ticket
+    title: "My Tickets"
+    columns:
+      - property: title
+        link: true
+        sortable: true
+      - property: status
+        sortable: true
+      - property: priority
+        sortable: true
+    filters:
+      - property: assignee
+        operator: "="
+        value: "$USER"
+    create_form: create_ticket
+    edit_form: edit_ticket
+    page_size: 25
+
+views:
+  ticket_detail:
+    title: "Ticket Detail"
+    entry:
+      type: ticket
+    traverse:
+      - from: entry
+        follow: blocks
+        collect_as: blocks
+      - from: entry
+        follow_incoming: blocks
+        collect_as: blocked_by
+    sections:
+      - heading: "Ticket"
+        source: entry
+        display: properties
+        fields:
+          - property: status
+          - property: priority
+          - property: assignee
+          - property: due_date
+            label: "Due Date"
+      - source: entry
+        display: content
+      - heading: "Blocks"
+        source: blocks
+        display: cards
+        fields:
+          - property: status
+          - property: priority
+        empty_message: "Not blocking any tickets"
+      - heading: "Blocked By"
+        source: blocked_by
+        display: cards
+        fields:
+          - property: status
+        empty_message: "Not blocked"
+
+dashboard:
+  title: "Dashboard"
+  description: "Ticket overview"
+  cards:
+    - title: "Open Tickets"
+      query: "type:ticket status:open"
+      display: count
+    - title: "By Status"
+      query: "type:ticket"
+      display: breakdown
+      group_by: ticket_status
+    - title: "Critical"
+      query: "type:ticket prop:priority=critical"
+      display: table
+      columns:
+        - property: title
+          label: "Title"
+          link: true
+        - property: assignee
+          label: "Assignee"
+      limit: 5
+
+navigation:
+  - label: "Dashboard"
+    dashboard: true
+  - group: "Tickets"
+    items:
+      - label: "My Tickets"
+        list: my_tickets
+      - label: "Open Tickets"
+        list: open_tickets
+      - label: "All Tickets"
+        list: all_tickets
+```
+
+## Relationship to views.yaml
+
+The `views` section in `data-entry.yaml` uses the same traversal engine as the CLI's
+views.yaml, but adapted for HTML rendering:
+
+| Feature                | views.yaml (CLI)                     | data-entry.yaml views                |
+| ---------------------- | ------------------------------------ | ------------------------------------ |
+| Traversal rules        | Same `from`/`follow`/`collect_as`    | Same `from`/`follow`/`collect_as`    |
+| Output                 | YAML/JSON data                       | HTML sections                        |
+| Display control        | N/A (raw data)                       | `sections` with display modes        |
+| Filters/derived        | `filters`, `derived`                 | Not yet supported                    |
+| Relation exports       | `relation_exports`                   | Not yet supported                    |
+
+If you already have a `views.yaml`, you can reuse the same traverse rules in your data-entry
+views and add `sections` for HTML rendering.
+
+## Best Practices
+
+1. **Start with navigation** - Decide which entity types users will work with most, and create
+   lists for those first. Add forms as needed. Consider adding a dashboard as the landing page
+   for an at-a-glance overview.
+
+2. **Create before edit** - Define a create form with sensible defaults and hidden fields (like
+   `status: open`). Then define an edit form with transitions and all fields visible.
+
+3. **Use `link: true`** on the primary column (usually `title` or `name`) so users can click
+   through to entity details.
+
+4. **Filter strategically** - Use static filters for focused views (e.g., "Open Tickets") and
+   filter controls for exploratory views (e.g., "All Tickets").
+
+5. **Group related lists** - Use navigation groups to organize related lists under collapsible
+   headers. Keep 3-5 items per group for clarity.
+
+6. **Style all enums** - Add color mappings for every custom type to make lists scannable.
+
+7. **Views for key entities** - Create detail views for entities that aggregate related data.
+   A risk detail view showing assets, controls, and incidents is more useful than viewing the
+   risk entity alone.

--- a/docs-project/relations/GUIDE-data-entry--covers--FEAT-data-entry.md
+++ b/docs-project/relations/GUIDE-data-entry--covers--FEAT-data-entry.md
@@ -1,0 +1,5 @@
+---
+from: GUIDE-data-entry
+relation: covers
+to: FEAT-data-entry
+---

--- a/docs-project/relations/GUIDE-data-entry--covers--FEAT-grouped-navigation.md
+++ b/docs-project/relations/GUIDE-data-entry--covers--FEAT-grouped-navigation.md
@@ -1,0 +1,5 @@
+---
+from: GUIDE-data-entry
+relation: covers
+to: FEAT-grouped-navigation
+---

--- a/docs-project/relations/GUIDE-data-entry--covers--FEAT-views.md
+++ b/docs-project/relations/GUIDE-data-entry--covers--FEAT-views.md
@@ -1,0 +1,5 @@
+---
+from: GUIDE-data-entry
+relation: covers
+to: FEAT-views
+---

--- a/docs-project/relations/GUIDE-data-entry--prerequisite--GUIDE-getting-started.md
+++ b/docs-project/relations/GUIDE-data-entry--prerequisite--GUIDE-getting-started.md
@@ -1,0 +1,5 @@
+---
+from: GUIDE-data-entry
+relation: prerequisite
+to: GUIDE-getting-started
+---

--- a/docs-project/relations/GUIDE-data-entry--prerequisite--GUIDE-metamodel.md
+++ b/docs-project/relations/GUIDE-data-entry--prerequisite--GUIDE-metamodel.md
@@ -1,0 +1,5 @@
+---
+from: GUIDE-data-entry
+relation: prerequisite
+to: GUIDE-metamodel
+---

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1,4 +1,4 @@
-# Data Entry Configuration
+# Data Entry Web App
 
 The data entry application provides a web-based UI for creating, editing, and browsing entities
 stored in a rela project. It is configured entirely through a `data-entry.yaml` file placed
@@ -15,7 +15,7 @@ A `data-entry.yaml` file defines:
 - **Lists** - Tabular views with sorting, filtering, and pagination
 - **Views** - Read-only detail pages that traverse the graph to show related entities
 - **Dashboard** - An overview page with query-driven cards showing counts, breakdowns, and tables
-- **Navigation** - Sidebar menu entries that link to lists or the dashboard
+- **Navigation** - Sidebar menu entries with optional grouping
 
 The file drives the entire UI without writing any code. The server reads `data-entry.yaml` and
 your `metamodel.yaml` together, validates them, and serves a fully functional CRUD application.
@@ -120,11 +120,13 @@ dashboard:                 # Optional overview page
       query: "type:task status:open"
       display: count
 
-navigation:                # Sidebar menu
+navigation:                # Sidebar menu (supports groups)
   - label: "Dashboard"
     dashboard: true
-  - label: "Tasks"
-    list: all_tasks
+  - group: "Tasks"
+    items:
+      - label: "All Tasks"
+        list: all_tasks
 ```
 
 ## App
@@ -448,7 +450,7 @@ sort:
 ## Views
 
 Views define read-only detail pages that traverse the entity graph to display related data.
-They are the data-entry equivalent of the CLI's [views.yaml](views.md) concept, adapted for
+They are the data-entry equivalent of the CLI's views.yaml concept, adapted for
 rendering as HTML sections.
 
 ### Basic View
@@ -518,7 +520,7 @@ specific ticket entity.
 ### Traverse Rules
 
 Traverse rules collect related entities into named collections. They work identically to
-[views.yaml traverse rules](views.md):
+views.yaml traverse rules:
 
 ```yaml
 traverse:
@@ -702,40 +704,68 @@ Cards use the same search query syntax available on the search page:
 Multiple terms are combined with AND logic. For example,
 `type:ticket status:open prop:priority=critical` matches tickets that are both open and critical.
 
-Every card includes a link icon (↗) that opens the same query on the search page for further
+Every card includes a link icon that opens the same query on the search page for further
 exploration.
 
 ## Navigation
 
-The navigation section defines the sidebar menu. Each entry links to a named list or the dashboard:
+The navigation section defines the sidebar menu. Each entry is either a direct item (linking to a
+list, dashboard, or graph) or a **group** containing multiple items:
 
 ```yaml
 navigation:
   - label: "Dashboard"
     dashboard: true
-  - label: "Open Tickets"
-    list: open_tickets
-  - label: "All Tickets"
-    list: all_tickets
-  - label: "Categories"
-    list: categories
+  - group: "Tickets"
+    items:
+      - label: "Open Tickets"
+        list: open_tickets
+      - label: "All Tickets"
+        list: all_tickets
+  - group: "Reference Data"
+    collapsed: true
+    items:
+      - label: "Categories"
+        list: categories
+  - label: "Graph Explorer"
+    graph: true
 ```
+
+### Direct Items
+
+| Field       | Type   | Description                                                    |
+| ----------- | ------ | -------------------------------------------------------------- |
+| `label`     | string | Menu item text                                                 |
+| `list`      | string | List name to navigate to (mutually exclusive with other types) |
+| `dashboard` | bool   | Link to the dashboard page                                     |
+| `graph`     | bool   | Link to the graph explorer                                     |
+
+### Groups
 
 | Field       | Type   | Description                                              |
 | ----------- | ------ | -------------------------------------------------------- |
-| `label`     | string | Menu item text                                           |
-| `list`      | string | List name to navigate to (mutually exclusive with `dashboard`) |
-| `dashboard` | bool   | Link to the dashboard page (mutually exclusive with `list`)    |
+| `group`     | string | Group header text (displayed as uppercase label)         |
+| `collapsed` | bool   | Default collapsed state (optional, default: `false`)     |
+| `items`     | list   | List of direct navigation items within the group         |
 
-The first entry is the default landing page. If the first entry is a dashboard, the root URL
-(`/`) shows the dashboard. Order matters; items appear in the sidebar in the order listed.
+Groups appear as collapsible sections in the sidebar. Clicking the group header toggles
+expand/collapse. The collapsed state is persisted server-side in `.rela/ui-state.json`, so it
+survives page reloads. If the active page is inside a collapsed group, the group auto-expands.
+
+Nested groups are not supported. If an item inside `items` has a `group` field, config validation
+will reject it with a clear error message.
+
+The first navigable entry is the default landing page — the first direct item, or the first item
+inside the first group. Order matters; items appear in the sidebar in the order listed.
 
 List entries show an entity count badge next to the label (based on the list's filters). Dashboard
-entries do not show a count.
+and graph entries do not show a count.
+
+Direct items and groups can be freely mixed in any order.
 
 ## Complete Example
 
-A ticket management system with forms, lists, views, and navigation:
+A ticket management system with forms, lists, views, dashboard, and grouped navigation:
 
 ```yaml
 version: "1.0"
@@ -952,18 +982,20 @@ dashboard:
 navigation:
   - label: "Dashboard"
     dashboard: true
-  - label: "My Tickets"
-    list: my_tickets
-  - label: "Open Tickets"
-    list: open_tickets
-  - label: "All Tickets"
-    list: all_tickets
+  - group: "Tickets"
+    items:
+      - label: "My Tickets"
+        list: my_tickets
+      - label: "Open Tickets"
+        list: open_tickets
+      - label: "All Tickets"
+        list: all_tickets
 ```
 
 ## Relationship to views.yaml
 
 The `views` section in `data-entry.yaml` uses the same traversal engine as the CLI's
-[views.yaml](views.md), but adapted for HTML rendering:
+views.yaml, but adapted for HTML rendering:
 
 | Feature                | views.yaml (CLI)                     | data-entry.yaml views                |
 | ---------------------- | ------------------------------------ | ------------------------------------ |
@@ -991,17 +1023,11 @@ views and add `sections` for HTML rendering.
 4. **Filter strategically** - Use static filters for focused views (e.g., "Open Tickets") and
    filter controls for exploratory views (e.g., "All Tickets").
 
-5. **Keep navigation focused** - 8-15 items is a comfortable sidebar. Group related lists
-   logically (e.g., ISMS items first, then Sales items).
+5. **Group related lists** - Use navigation groups to organize related lists under collapsible
+   headers. Keep 3-5 items per group for clarity.
 
 6. **Style all enums** - Add color mappings for every custom type to make lists scannable.
 
 7. **Views for key entities** - Create detail views for entities that aggregate related data.
    A risk detail view showing assets, controls, and incidents is more useful than viewing the
    risk entity alone.
-
-## See Also
-
-- [Views](views.md) - Declarative views for the CLI
-- [Metamodel](metamodel.md) - Entity types and relations that forms/lists reference
-- [Getting Started](getting-started.md) - Project initialization

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -1,6 +1,7 @@
 package dataentry
 
 import (
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"log"
@@ -23,6 +24,9 @@ import (
 // ConfigFile is the conventional filename for data-entry configuration within a rela project.
 const ConfigFile = "data-entry.yaml"
 
+// uiStateFile is the filename for persisted UI state within the .rela directory.
+const uiStateFile = "ui-state.json"
+
 // App is the central application struct holding config, metamodel, graph, and templates.
 type App struct {
 	Cfg  *Config
@@ -34,6 +38,10 @@ type App struct {
 	styleMap map[string]map[string]string
 	// styledTypes: set of property type names that have style entries
 	styledTypes map[string]bool
+	// fs is the filesystem abstraction used for reading/writing UI state.
+	fs storage.FS
+	// uiStatePath is the path to .rela/ui-state.json for persisting UI preferences.
+	uiStatePath string
 }
 
 // NewApp creates and initializes an App using the given filesystem.
@@ -103,6 +111,8 @@ func NewApp(projectDir string, fs storage.FS) (*App, error) {
 		tmpl:        tmpl,
 		styleMap:    styleMap,
 		styledTypes: styledTypes,
+		fs:          fs,
+		uiStatePath: filepath.Join(projCtx.CacheDir, uiStateFile),
 	}, nil
 }
 
@@ -116,22 +126,115 @@ type NavItem struct {
 	Count      int
 }
 
-// navItems returns enriched navigation entries with entity types resolved from list config.
-func (a *App) navItems() []NavItem {
-	items := make([]NavItem, len(a.Cfg.Navigation))
-	for i, nav := range a.Cfg.Navigation {
-		items[i] = NavItem{Label: nav.Label, List: nav.List, Dashboard: nav.Dashboard, Graph: nav.Graph}
-		if nav.Dashboard || nav.Graph {
-			continue
-		}
-		if list, ok := a.Cfg.Lists[nav.List]; ok {
-			items[i].EntityType = list.EntityType
-			entities := a.g.NodesByType(list.EntityType)
-			entities = applyFilters(entities, list.Filters)
-			items[i].Count = len(entities)
+// NavGroup is an enriched navigation group containing resolved nav items.
+type NavGroup struct {
+	Group     string
+	Collapsed bool
+	Items     []NavItem
+}
+
+// NavElement is a union of either a direct NavItem or a NavGroup.
+// Exactly one of Item or Group is non-nil.
+type NavElement struct {
+	Item  *NavItem
+	Group *NavGroup
+}
+
+// enrichNavEntry resolves a single NavigationEntry into a NavItem with entity type and count.
+func (a *App) enrichNavEntry(nav NavigationEntry) NavItem {
+	item := NavItem{Label: nav.Label, List: nav.List, Dashboard: nav.Dashboard, Graph: nav.Graph}
+	if nav.Dashboard || nav.Graph {
+		return item
+	}
+	if list, ok := a.Cfg.Lists[nav.List]; ok {
+		item.EntityType = list.EntityType
+		entities := a.g.NodesByType(list.EntityType)
+		entities = applyFilters(entities, list.Filters)
+		item.Count = len(entities)
+	}
+	return item
+}
+
+// navElements returns the navigation structure with groups and items resolved.
+// The activeList parameter is used to auto-expand the group containing the active item.
+func (a *App) navElements(activeList string) []NavElement {
+	uiState := a.loadUIState()
+	elements := make([]NavElement, 0, len(a.Cfg.Navigation))
+	for _, nav := range a.Cfg.Navigation {
+		if nav.IsGroup() {
+			grp := NavGroup{Group: nav.Group}
+			// Determine collapsed state: UIState overrides config default
+			if override, ok := uiState.CollapsedGroups[nav.Group]; ok {
+				grp.Collapsed = override
+			} else {
+				grp.Collapsed = nav.Collapsed
+			}
+			grp.Items = make([]NavItem, len(nav.Items))
+			for i, child := range nav.Items {
+				grp.Items[i] = a.enrichNavEntry(child)
+				// Auto-expand group if it contains the active list
+				if child.List == activeList && activeList != "" {
+					grp.Collapsed = false
+				}
+			}
+			elements = append(elements, NavElement{Group: &grp})
+		} else {
+			item := a.enrichNavEntry(nav)
+			elements = append(elements, NavElement{Item: &item})
 		}
 	}
-	return items
+	return elements
+}
+
+// loadUIState reads .rela/ui-state.json and returns the persisted state.
+// Returns an empty UIState if the file doesn't exist or can't be parsed.
+func (a *App) loadUIState() UIState {
+	state := UIState{CollapsedGroups: make(map[string]bool)}
+	if a.uiStatePath == "" {
+		return state
+	}
+	data, err := a.fs.ReadFile(a.uiStatePath)
+	if err != nil {
+		return state
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		return UIState{CollapsedGroups: make(map[string]bool)}
+	}
+	if state.CollapsedGroups == nil {
+		state.CollapsedGroups = make(map[string]bool)
+	}
+	return state
+}
+
+// saveUIState writes the UI state to .rela/ui-state.json.
+func (a *App) saveUIState(state UIState) error {
+	if a.uiStatePath == "" {
+		return nil
+	}
+	// Ensure .rela directory exists
+	if err := a.fs.MkdirAll(filepath.Dir(a.uiStatePath), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return a.fs.WriteFile(a.uiStatePath, data, 0o644)
+}
+
+// firstNavTarget returns the first navigable item from the navigation config,
+// walking into groups as needed.
+func firstNavTarget(nav []NavigationEntry) *NavigationEntry {
+	for i := range nav {
+		if nav[i].IsGroup() {
+			if target := firstNavTarget(nav[i].Items); target != nil {
+				return target
+			}
+			continue
+		}
+		return &nav[i]
+	}
+	return nil
 }
 
 // editFormForType returns the first edit form ID configured for the given entity type,
@@ -191,9 +294,19 @@ func (a *App) entityDisplayTitle(e *model.Entity) string {
 }
 
 // activeListForEntityType returns the first navigation list ID whose entity type
-// matches the given type, or "" if none match.
+// matches the given type, or "" if none match. Walks into groups.
 func (a *App) activeListForEntityType(entityType string) string {
-	for _, nav := range a.Cfg.Navigation {
+	return a.findListByEntityType(a.Cfg.Navigation, entityType)
+}
+
+func (a *App) findListByEntityType(entries []NavigationEntry, entityType string) string {
+	for _, nav := range entries {
+		if nav.IsGroup() {
+			if found := a.findListByEntityType(nav.Items, entityType); found != "" {
+				return found
+			}
+			continue
+		}
 		if list, ok := a.Cfg.Lists[nav.List]; ok && list.EntityType == entityType {
 			return nav.List
 		}
@@ -298,6 +411,18 @@ func buildStyleMap(cfg *Config, meta *metamodel.Metamodel) (styleMap map[string]
 
 func validateConfig(cfg *Config, meta *metamodel.Metamodel) []string {
 	var errs []string
+	// Validate navigation: reject nested groups
+	for _, nav := range cfg.Navigation {
+		if nav.IsGroup() {
+			for _, child := range nav.Items {
+				if child.IsGroup() {
+					errs = append(errs, fmt.Sprintf(
+						"navigation: group %q contains nested group %q — nested groups are not supported",
+						nav.Group, child.Group))
+				}
+			}
+		}
+	}
 	for formID, form := range cfg.Forms {
 		if _, ok := meta.GetEntityDef(form.EntityType); !ok {
 			errs = append(errs, fmt.Sprintf("form %q: unknown entity type %q", formID, form.EntityType))

--- a/internal/dataentry/app_test.go
+++ b/internal/dataentry/app_test.go
@@ -3,11 +3,14 @@ package dataentry
 import (
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
 // testMeta returns a metamodel suitable for testing app-level functions.
@@ -138,6 +141,7 @@ func testAppInstance() *App {
 		Cfg:         cfg,
 		meta:        meta,
 		g:           g,
+		fs:          storage.NewOsFS(),
 		styleMap:    styleMap,
 		styledTypes: styledTypes,
 	}
@@ -482,28 +486,36 @@ func TestResolveActiveList(t *testing.T) {
 	})
 }
 
-func TestNavItems(t *testing.T) {
+func TestNavElements(t *testing.T) {
 	app := testAppInstance()
 
-	t.Run("returns items with counts", func(t *testing.T) {
-		items := app.navItems()
-		if len(items) != 2 {
-			t.Fatalf("expected 2 items, got %d", len(items))
+	t.Run("flat items with counts", func(t *testing.T) {
+		elements := app.navElements("")
+		if len(elements) != 2 {
+			t.Fatalf("expected 2 elements, got %d", len(elements))
 		}
-		if items[0].Label != "Tickets" {
-			t.Errorf("expected label 'Tickets', got %q", items[0].Label)
+		item0 := elements[0].Item
+		if item0 == nil {
+			t.Fatal("expected first element to be an item, got group")
 		}
-		if items[0].EntityType != "ticket" {
-			t.Errorf("expected entity type 'ticket', got %q", items[0].EntityType)
+		if item0.Label != "Tickets" {
+			t.Errorf("expected label 'Tickets', got %q", item0.Label)
 		}
-		if items[0].Count != 2 {
-			t.Errorf("expected count 2, got %d", items[0].Count)
+		if item0.EntityType != "ticket" {
+			t.Errorf("expected entity type 'ticket', got %q", item0.EntityType)
 		}
-		if items[1].Label != "Components" {
-			t.Errorf("expected label 'Components', got %q", items[1].Label)
+		if item0.Count != 2 {
+			t.Errorf("expected count 2, got %d", item0.Count)
 		}
-		if items[1].Count != 1 {
-			t.Errorf("expected count 1, got %d", items[1].Count)
+		item1 := elements[1].Item
+		if item1 == nil {
+			t.Fatal("expected second element to be an item, got group")
+		}
+		if item1.Label != "Components" {
+			t.Errorf("expected label 'Components', got %q", item1.Label)
+		}
+		if item1.Count != 1 {
+			t.Errorf("expected count 1, got %d", item1.Count)
 		}
 	})
 
@@ -513,15 +525,15 @@ func TestNavItems(t *testing.T) {
 			{Label: "Dashboard", Dashboard: true},
 			{Label: "Tickets", List: "tickets"},
 		}
-		items := app2.navItems()
-		if len(items) != 2 {
-			t.Fatalf("expected 2 items, got %d", len(items))
+		elements := app2.navElements("")
+		if len(elements) != 2 {
+			t.Fatalf("expected 2 elements, got %d", len(elements))
 		}
-		if items[0].Dashboard != true {
+		if elements[0].Item == nil || !elements[0].Item.Dashboard {
 			t.Error("expected first item to be dashboard")
 		}
-		if items[0].EntityType != "" {
-			t.Errorf("expected empty entity type for dashboard, got %q", items[0].EntityType)
+		if elements[0].Item.EntityType != "" {
+			t.Errorf("expected empty entity type for dashboard, got %q", elements[0].Item.EntityType)
 		}
 	})
 
@@ -533,10 +545,286 @@ func TestNavItems(t *testing.T) {
 				{Property: "status", Operator: "=", Value: "open"},
 			},
 		}
-		items := app2.navItems()
+		elements := app2.navElements("")
 		// Only TKT-001 has status=open
-		if items[0].Count != 1 {
-			t.Errorf("expected count 1 (filtered), got %d", items[0].Count)
+		if elements[0].Item == nil {
+			t.Fatal("expected first element to be an item")
+		}
+		if elements[0].Item.Count != 1 {
+			t.Errorf("expected count 1 (filtered), got %d", elements[0].Item.Count)
+		}
+	})
+
+	t.Run("groups with items", func(t *testing.T) {
+		app2 := testAppInstance()
+		app2.Cfg.Navigation = []NavigationEntry{
+			{Label: "Dashboard", Dashboard: true},
+			{
+				Group: "Tickets",
+				Items: []NavigationEntry{
+					{Label: "All Tickets", List: "tickets"},
+				},
+			},
+			{Label: "Components", List: "components"},
+		}
+		elements := app2.navElements("")
+		if len(elements) != 3 {
+			t.Fatalf("expected 3 elements, got %d", len(elements))
+		}
+		// First: dashboard item
+		if elements[0].Item == nil || !elements[0].Item.Dashboard {
+			t.Error("expected first element to be dashboard item")
+		}
+		// Second: group
+		if elements[1].Group == nil {
+			t.Fatal("expected second element to be a group")
+		}
+		grp := elements[1].Group
+		if grp.Group != "Tickets" {
+			t.Errorf("expected group name 'Tickets', got %q", grp.Group)
+		}
+		if len(grp.Items) != 1 {
+			t.Fatalf("expected 1 item in group, got %d", len(grp.Items))
+		}
+		if grp.Items[0].Label != "All Tickets" {
+			t.Errorf("expected label 'All Tickets', got %q", grp.Items[0].Label)
+		}
+		if grp.Items[0].Count != 2 {
+			t.Errorf("expected count 2, got %d", grp.Items[0].Count)
+		}
+		// Third: flat item
+		if elements[2].Item == nil || elements[2].Item.Label != "Components" {
+			t.Error("expected third element to be 'Components' item")
+		}
+	})
+
+	t.Run("group collapsed from config", func(t *testing.T) {
+		app2 := testAppInstance()
+		app2.Cfg.Navigation = []NavigationEntry{
+			{
+				Group:     "Hidden",
+				Collapsed: true,
+				Items: []NavigationEntry{
+					{Label: "Tickets", List: "tickets"},
+				},
+			},
+		}
+		elements := app2.navElements("")
+		if elements[0].Group == nil {
+			t.Fatal("expected group element")
+		}
+		if !elements[0].Group.Collapsed {
+			t.Error("expected group to be collapsed")
+		}
+	})
+
+	t.Run("auto-expand group containing active list", func(t *testing.T) {
+		app2 := testAppInstance()
+		app2.Cfg.Navigation = []NavigationEntry{
+			{
+				Group:     "Tickets",
+				Collapsed: true,
+				Items: []NavigationEntry{
+					{Label: "All Tickets", List: "tickets"},
+				},
+			},
+		}
+		elements := app2.navElements("tickets")
+		if elements[0].Group == nil {
+			t.Fatal("expected group element")
+		}
+		if elements[0].Group.Collapsed {
+			t.Error("expected group to be auto-expanded because it contains the active list")
+		}
+	})
+}
+
+func TestFirstNavTarget(t *testing.T) {
+	t.Run("flat items returns first", func(t *testing.T) {
+		nav := []NavigationEntry{
+			{Label: "Tickets", List: "tickets"},
+			{Label: "Dashboard", Dashboard: true},
+		}
+		target := firstNavTarget(nav)
+		if target == nil {
+			t.Fatal("expected non-nil target")
+		}
+		if target.List != "tickets" {
+			t.Errorf("expected 'tickets', got %q", target.List)
+		}
+	})
+
+	t.Run("group first item", func(t *testing.T) {
+		nav := []NavigationEntry{
+			{
+				Group: "Tickets",
+				Items: []NavigationEntry{
+					{Label: "All Tickets", List: "tickets"},
+				},
+			},
+		}
+		target := firstNavTarget(nav)
+		if target == nil {
+			t.Fatal("expected non-nil target")
+		}
+		if target.List != "tickets" {
+			t.Errorf("expected 'tickets', got %q", target.List)
+		}
+	})
+
+	t.Run("empty group skipped", func(t *testing.T) {
+		nav := []NavigationEntry{
+			{Group: "Empty", Items: []NavigationEntry{}},
+			{Label: "Dashboard", Dashboard: true},
+		}
+		target := firstNavTarget(nav)
+		if target == nil {
+			t.Fatal("expected non-nil target")
+		}
+		if !target.Dashboard {
+			t.Error("expected dashboard target")
+		}
+	})
+
+	t.Run("empty navigation returns nil", func(t *testing.T) {
+		target := firstNavTarget(nil)
+		if target != nil {
+			t.Error("expected nil for empty navigation")
+		}
+	})
+}
+
+func TestUIStateLoadSave(t *testing.T) {
+	dir := t.TempDir()
+	app := testAppInstance()
+	app.uiStatePath = filepath.Join(dir, "ui-state.json")
+
+	t.Run("load returns defaults when file missing", func(t *testing.T) {
+		state := app.loadUIState()
+		if len(state.CollapsedGroups) != 0 {
+			t.Errorf("expected empty collapsed groups, got %v", state.CollapsedGroups)
+		}
+	})
+
+	t.Run("save and load round-trip", func(t *testing.T) {
+		state := UIState{CollapsedGroups: map[string]bool{"Tickets": true}}
+		if err := app.saveUIState(state); err != nil {
+			t.Fatalf("save error: %v", err)
+		}
+		loaded := app.loadUIState()
+		if !loaded.CollapsedGroups["Tickets"] {
+			t.Error("expected Tickets to be collapsed after load")
+		}
+	})
+
+	t.Run("UIState overrides config default", func(t *testing.T) {
+		app2 := testAppInstance()
+		app2.uiStatePath = filepath.Join(dir, "ui-state.json")
+		app2.Cfg.Navigation = []NavigationEntry{
+			{
+				Group:     "Tickets",
+				Collapsed: false,
+				Items: []NavigationEntry{
+					{Label: "All", List: "tickets"},
+				},
+			},
+		}
+		// UIState says collapsed
+		state := UIState{CollapsedGroups: map[string]bool{"Tickets": true}}
+		if err := app2.saveUIState(state); err != nil {
+			t.Fatalf("save error: %v", err)
+		}
+		elements := app2.navElements("")
+		if elements[0].Group == nil {
+			t.Fatal("expected group element")
+		}
+		if !elements[0].Group.Collapsed {
+			t.Error("expected group to be collapsed via UIState override")
+		}
+	})
+
+	t.Run("empty uiStatePath is safe", func(t *testing.T) {
+		app2 := testAppInstance()
+		app2.uiStatePath = ""
+		state := app2.loadUIState()
+		if len(state.CollapsedGroups) != 0 {
+			t.Error("expected empty state")
+		}
+		if err := app2.saveUIState(state); err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}
+
+func TestValidateConfigNestedGroups(t *testing.T) {
+	meta := testMeta()
+
+	t.Run("nested groups rejected", func(t *testing.T) {
+		cfg := &Config{
+			Navigation: []NavigationEntry{
+				{
+					Group: "Outer",
+					Items: []NavigationEntry{
+						{
+							Group: "Inner",
+							Items: []NavigationEntry{
+								{Label: "Tickets", List: "tickets"},
+							},
+						},
+					},
+				},
+			},
+		}
+		errs := validateConfig(cfg, meta)
+		if len(errs) != 1 {
+			t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+		}
+		if !strings.Contains(errs[0], "nested group") {
+			t.Errorf("expected nested group error, got: %s", errs[0])
+		}
+	})
+
+	t.Run("flat groups are valid", func(t *testing.T) {
+		cfg := &Config{
+			Navigation: []NavigationEntry{
+				{
+					Group: "Tickets",
+					Items: []NavigationEntry{
+						{Label: "All", List: "tickets"},
+					},
+				},
+			},
+		}
+		errs := validateConfig(cfg, meta)
+		if len(errs) != 0 {
+			t.Errorf("expected no errors, got %v", errs)
+		}
+	})
+}
+
+func TestActiveListForEntityTypeWithGroups(t *testing.T) {
+	app := testAppInstance()
+	app.Cfg.Navigation = []NavigationEntry{
+		{
+			Group: "Tickets",
+			Items: []NavigationEntry{
+				{Label: "All Tickets", List: "tickets"},
+			},
+		},
+		{Label: "Components", List: "components"},
+	}
+
+	t.Run("finds list inside group", func(t *testing.T) {
+		got := app.activeListForEntityType("ticket")
+		if got != "tickets" {
+			t.Errorf("expected 'tickets', got %q", got)
+		}
+	})
+
+	t.Run("finds flat list", func(t *testing.T) {
+		got := app.activeListForEntityType("component")
+		if got != "components" {
+			t.Errorf("expected 'components', got %q", got)
 		}
 	})
 }

--- a/internal/dataentry/config.go
+++ b/internal/dataentry/config.go
@@ -109,12 +109,30 @@ type FilterControl struct {
 	Widget   string `yaml:"widget"`
 }
 
-// NavigationEntry defines a sidebar navigation item.
+// NavigationEntry defines a sidebar navigation item or a group of items.
+// It is a union type: either a direct item (Label + List/Dashboard/Graph)
+// or a group (Group + Items). Nested groups are not supported.
 type NavigationEntry struct {
-	Label     string `yaml:"label"`
+	// Direct item fields
+	Label     string `yaml:"label,omitempty"`
 	List      string `yaml:"list,omitempty"`
 	Dashboard bool   `yaml:"dashboard,omitempty"`
 	Graph     bool   `yaml:"graph,omitempty"`
+
+	// Group fields
+	Group     string            `yaml:"group,omitempty"`
+	Collapsed bool              `yaml:"collapsed,omitempty"`
+	Items     []NavigationEntry `yaml:"items,omitempty"`
+}
+
+// IsGroup returns true if this entry is a navigation group.
+func (n NavigationEntry) IsGroup() bool {
+	return n.Group != ""
+}
+
+// UIState holds user-specific UI preferences persisted in .rela/ui-state.json.
+type UIState struct {
+	CollapsedGroups map[string]bool `json:"collapsed_groups"`
 }
 
 // DashboardConfig defines a dashboard page with query-driven cards.

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -23,8 +23,8 @@ func (a *App) handleIndex(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	if len(a.Cfg.Navigation) > 0 {
-		first := a.Cfg.Navigation[0]
+	first := firstNavTarget(a.Cfg.Navigation)
+	if first != nil {
 		if first.Dashboard {
 			r.URL.Path = "/dashboard"
 			a.handleDashboard(w, r)
@@ -250,7 +250,7 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 
 	data := map[string]interface{}{
 		"App":              a.Cfg.App,
-		"Navigation":       a.navItems(),
+		"Navigation":       a.navElements(listID),
 		"ActiveList":       listID,
 		"List":             list,
 		"ListID":           listID,
@@ -423,10 +423,11 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 		mode = "create"
 	}
 
+	activeList := a.resolveActiveList(form.EntityType, r)
 	data := map[string]interface{}{
 		"App":          a.Cfg.App,
-		"Navigation":   a.navItems(),
-		"ActiveList":   a.resolveActiveList(form.EntityType, r),
+		"Navigation":   a.navElements(activeList),
+		"ActiveList":   activeList,
 		"FormID":       formID,
 		"Form":         form,
 		"Fields":       fields,
@@ -535,10 +536,11 @@ func (a *App) handleEntity(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	entityActiveList := a.resolveActiveList(entity.Type, r)
 	data := map[string]interface{}{
 		"App":        a.Cfg.App,
-		"Navigation": a.navItems(),
-		"ActiveList": a.resolveActiveList(entity.Type, r),
+		"Navigation": a.navElements(entityActiveList),
+		"ActiveList": entityActiveList,
 		"Entity":     entity,
 		"EntityDef":  entDef,
 		"EditFormID": editFormID,
@@ -874,10 +876,11 @@ func (a *App) handleView(w http.ResponseWriter, r *http.Request) {
 		returnTo += "?" + r.URL.RawQuery
 	}
 
+	viewActiveList := a.resolveActiveList(result.Entry.Type, r)
 	data := map[string]interface{}{
 		"App":        a.Cfg.App,
-		"Navigation": a.navItems(),
-		"ActiveList": a.resolveActiveList(result.Entry.Type, r),
+		"Navigation": a.navElements(viewActiveList),
+		"ActiveList": viewActiveList,
 		"View":       view,
 		"ViewID":     viewID,
 		"EntityID":   entityID,
@@ -1402,7 +1405,7 @@ func (a *App) handleSearch(w http.ResponseWriter, r *http.Request) {
 
 	data := map[string]interface{}{
 		"App":             a.Cfg.App,
-		"Navigation":      a.navItems(),
+		"Navigation":      a.navElements(""),
 		"ActiveList":      "",
 		"Query":           query,
 		"Results":         results,
@@ -1553,7 +1556,7 @@ func (a *App) handleDashboard(w http.ResponseWriter, r *http.Request) {
 
 	data := map[string]interface{}{
 		"App":        a.Cfg.App,
-		"Navigation": a.navItems(),
+		"Navigation": a.navElements("_dashboard"),
 		"ActiveList": "_dashboard",
 		"Dashboard":  dash,
 		"Cards":      cards,
@@ -1565,4 +1568,29 @@ func (a *App) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	} else {
 		a.tmpl.ExecuteTemplate(w, "dashboard-page", data) //nolint:errcheck // template errors logged by http
 	}
+}
+
+func (a *App) handleToggleGroup(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	r.ParseForm() //nolint:errcheck // form parse errors handled by empty values
+	group := r.FormValue("group")
+	if group == "" {
+		http.Error(w, "Missing group parameter", http.StatusBadRequest)
+		return
+	}
+
+	state := a.loadUIState()
+	// Toggle: if currently collapsed, expand; if expanded (or absent), collapse
+	state.CollapsedGroups[group] = !state.CollapsedGroups[group]
+	// Clean up false entries to keep the file tidy
+	if !state.CollapsedGroups[group] {
+		delete(state.CollapsedGroups, group)
+	}
+	if err := a.saveUIState(state); err != nil {
+		log.Printf("Failed to save UI state: %v", err)
+	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/dataentry/handlers_graph.go
+++ b/internal/dataentry/handlers_graph.go
@@ -11,7 +11,7 @@ import (
 func (a *App) handleGraph(w http.ResponseWriter, _ *http.Request) {
 	data := map[string]interface{}{
 		"App":        a.Cfg.App,
-		"Navigation": a.navItems(),
+		"Navigation": a.navElements("_graph"),
 		"ActiveList": "_graph",
 	}
 	a.tmpl.ExecuteTemplate(w, "graph-page", data) //nolint:errcheck // template errors logged by http

--- a/internal/dataentry/handlers_graph_test.go
+++ b/internal/dataentry/handlers_graph_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
 // newGraphTestApp builds a full App with graph templates for graph handler tests.
@@ -35,6 +36,7 @@ func newGraphTestApp(t *testing.T) *App {
 		Cfg:         cfg,
 		meta:        meta,
 		g:           g,
+		fs:          storage.NewOsFS(),
 		tmpl:        tmpl,
 		styleMap:    styleMap,
 		styledTypes: styledTypes,
@@ -395,24 +397,24 @@ func TestHandleIndexGraphRedirect(t *testing.T) {
 	})
 }
 
-func TestNavItemsGraphSkipsCount(t *testing.T) {
+func TestNavElementsGraphSkipsCount(t *testing.T) {
 	app := newGraphTestApp(t)
 	app.Cfg.Navigation = []NavigationEntry{
 		{Label: "Graph", Graph: true},
 		{Label: "Tickets", List: "tickets"},
 	}
-	items := app.navItems()
-	if len(items) != 2 {
-		t.Fatalf("expected 2 items, got %d", len(items))
+	elements := app.navElements("")
+	if len(elements) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(elements))
 	}
-	if !items[0].Graph {
-		t.Error("expected first item to be graph")
+	if elements[0].Item == nil || !elements[0].Item.Graph {
+		t.Error("expected first element to be a graph item")
 	}
-	if items[0].EntityType != "" {
-		t.Errorf("expected empty entity type for graph, got %q", items[0].EntityType)
+	if elements[0].Item.EntityType != "" {
+		t.Errorf("expected empty entity type for graph, got %q", elements[0].Item.EntityType)
 	}
-	if items[0].Count != 0 {
-		t.Errorf("expected count 0 for graph, got %d", items[0].Count)
+	if elements[0].Item.Count != 0 {
+		t.Errorf("expected count 0 for graph, got %d", elements[0].Item.Count)
 	}
 }
 
@@ -427,7 +429,7 @@ func TestBuildContentGraphDataEmptyGraph(t *testing.T) {
 	}
 
 	styleMap, styledTypes := buildStyleMap(cfg, meta)
-	app := &App{Cfg: cfg, meta: meta, g: g, styleMap: styleMap, styledTypes: styledTypes}
+	app := &App{Cfg: cfg, meta: meta, g: g, fs: storage.NewOsFS(), styleMap: styleMap, styledTypes: styledTypes}
 	resp := app.buildContentGraphData()
 
 	if len(resp.Nodes) != 0 {

--- a/internal/dataentry/handlers_test.go
+++ b/internal/dataentry/handlers_test.go
@@ -5,10 +5,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
 // newHandlerTestApp builds a full App (including parsed templates) for handler tests.
@@ -56,6 +58,7 @@ func newHandlerTestApp(t *testing.T) *App {
 		Cfg:         cfg,
 		meta:        meta,
 		g:           g,
+		fs:          storage.NewOsFS(),
 		tmpl:        tmpl,
 		styleMap:    styleMap,
 		styledTypes: styledTypes,
@@ -592,6 +595,89 @@ func TestHandleExecuteQuery(t *testing.T) {
 		results := app.executeQuery("type:ticket status:open")
 		if len(results) != 1 || results[0].ID != "TKT-001" {
 			t.Errorf("expected [TKT-001], got %v", collectIDs(results))
+		}
+	})
+}
+
+func TestHandleToggleGroup(t *testing.T) {
+	t.Run("toggles group collapsed state", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.uiStatePath = filepath.Join(t.TempDir(), "ui-state.json")
+
+		// Toggle "Tickets" group to collapsed
+		body := strings.NewReader("group=Tickets")
+		r := httptest.NewRequest(http.MethodPost, "/api/ui/toggle-group", body)
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		app.handleToggleGroup(w, r)
+		if w.Code != http.StatusNoContent {
+			t.Errorf("expected 204, got %d", w.Code)
+		}
+
+		state := app.loadUIState()
+		if !state.CollapsedGroups["Tickets"] {
+			t.Error("expected Tickets to be collapsed")
+		}
+
+		// Toggle again to expand
+		body = strings.NewReader("group=Tickets")
+		r = httptest.NewRequest(http.MethodPost, "/api/ui/toggle-group", body)
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w = httptest.NewRecorder()
+		app.handleToggleGroup(w, r)
+		if w.Code != http.StatusNoContent {
+			t.Errorf("expected 204, got %d", w.Code)
+		}
+
+		state = app.loadUIState()
+		if state.CollapsedGroups["Tickets"] {
+			t.Error("expected Tickets to be expanded after second toggle")
+		}
+	})
+
+	t.Run("missing group returns 400", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		body := strings.NewReader("")
+		r := httptest.NewRequest(http.MethodPost, "/api/ui/toggle-group", body)
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		app.handleToggleGroup(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("GET not allowed", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		r := httptest.NewRequest(http.MethodGet, "/api/ui/toggle-group", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleToggleGroup(w, r)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", w.Code)
+		}
+	})
+}
+
+func TestHandleIndexWithGroupedNav(t *testing.T) {
+	t.Run("first item inside group", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.Cfg.Navigation = []NavigationEntry{
+			{
+				Group: "Tickets",
+				Items: []NavigationEntry{
+					{Label: "All Tickets", List: "tickets"},
+				},
+			},
+		}
+		r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleIndex(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "TKT-001") {
+			t.Error("expected list page content")
 		}
 	})
 }

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -420,6 +420,14 @@ func templateFuncs(styleMap map[string]map[string]string, styledTypes map[string
 		},
 		"add":            func(a, b int) int { return a + b },
 		"renderMarkdown": simpleMarkdownToHTML,
+		"map": func(pairs ...interface{}) map[string]interface{} {
+			m := make(map[string]interface{}, len(pairs)/2)
+			for i := 0; i+1 < len(pairs); i += 2 {
+				key, _ := pairs[i].(string)
+				m[key] = pairs[i+1]
+			}
+			return m
+		},
 		"formatValue": func(val string) string {
 			if t, err := time.Parse(time.RFC3339, val); err == nil {
 				return t.Format("2006-01-02")

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -27,5 +27,6 @@ func (a *App) NewRouter() http.Handler {
 	mux.HandleFunc("/api/inline-form/", a.handleInlineForm)
 	mux.HandleFunc("/graph", a.handleGraph)
 	mux.HandleFunc("/api/graph-data", a.handleGraphData)
+	mux.HandleFunc("/api/ui/toggle-group", a.handleToggleGroup)
 	return mux
 }

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -32,6 +32,14 @@ body { font-family: var(--font); background: var(--bg); color: var(--text); line
 .sidebar nav a { display: flex; align-items: center; gap: 10px; padding: 8px 20px; color: var(--text-sidebar); text-decoration: none; font-size: 14px; font-weight: 500; transition: all 0.15s; border-left: 3px solid transparent; }
 .sidebar nav a:hover { background: var(--bg-sidebar-hover); color: var(--text-sidebar-active); }
 .sidebar nav a.active { background: var(--bg-sidebar-active); color: var(--text-sidebar-active); border-left-color: var(--primary); }
+.nav-group { margin: 0; }
+.nav-group-toggle { display: flex; align-items: center; gap: 6px; width: 100%; padding: 8px 20px; background: none; border: none; border-left: 3px solid transparent; color: var(--text-sidebar); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; cursor: pointer; font-family: var(--font); transition: color 0.15s; }
+.nav-group-toggle:hover { color: var(--text-sidebar-active); }
+.nav-group-chevron { display: inline-block; font-size: 20px; line-height: 1; transition: transform 0.15s ease; transform: rotate(90deg); }
+.nav-group-chevron.collapsed { transform: rotate(0deg); }
+.nav-group-items { overflow: hidden; }
+.nav-group-items.hidden { display: none; }
+.sidebar nav .nav-group-items a { padding-left: 40px; }
 
 .main { margin-left: 240px; flex: 1; padding: 32px; max-width: 1100px; }
 .page-header { margin-bottom: 24px; display: flex; align-items: center; justify-content: space-between; }
@@ -257,6 +265,25 @@ function confirmDelete(entityID, returnTo) {
 </script>
 {{- end -}}
 
+{{- define "nav-item" -}}
+{{ if .Dashboard }}
+    <a href="/dashboard"{{ if eq "_dashboard" .ActiveList }} class="active"{{ end }}
+       hx-get="/dashboard" hx-target="#content" hx-push-url="true">
+      {{ .Label }}
+    </a>
+{{ else if .Graph }}
+    <a href="/graph"{{ if eq "_graph" .ActiveList }} class="active"{{ end }}>
+      {{ .Label }}
+    </a>
+{{ else }}
+    <a href="/list/{{ .List }}"{{ if eq .List .ActiveList }} class="active"{{ end }}
+       data-entity-type="{{ .EntityType }}"
+       hx-get="/list/{{ .List }}" hx-target="#content" hx-push-url="true">
+      {{ .Label }}<span class="nav-count">{{ .Count }}</span>
+    </a>
+{{ end }}
+{{- end -}}
+
 {{- define "sidebar" -}}
 <aside class="sidebar">
   <div class="sidebar-header">
@@ -270,26 +297,38 @@ function confirmDelete(entityID, returnTo) {
       &#128269; Search
     </a>
     {{ range .Navigation }}
-    {{ if .Dashboard }}
-    <a href="/dashboard"{{ if eq "_dashboard" $.ActiveList }} class="active"{{ end }}
-       hx-get="/dashboard" hx-target="#content" hx-push-url="true">
-      {{ .Label }}
-    </a>
-    {{ else if .Graph }}
-    <a href="/graph"{{ if eq "_graph" $.ActiveList }} class="active"{{ end }}>
-      {{ .Label }}
-    </a>
+    {{ if .Group }}
+    <div class="nav-group">
+      <button class="nav-group-toggle" onclick="toggleNavGroup(this)" data-group="{{ .Group.Group }}">
+        <span class="nav-group-chevron{{ if .Group.Collapsed }} collapsed{{ end }}">&#9656;</span>
+        {{ .Group.Group }}
+      </button>
+      <div class="nav-group-items{{ if .Group.Collapsed }} hidden{{ end }}">
+        {{ range .Group.Items }}
+        {{ template "nav-item" (map "Dashboard" .Dashboard "Graph" .Graph "Label" .Label "List" .List "EntityType" .EntityType "Count" .Count "ActiveList" $.ActiveList) }}
+        {{ end }}
+      </div>
+    </div>
     {{ else }}
-    <a href="/list/{{ .List }}"{{ if eq .List $.ActiveList }} class="active"{{ end }}
-       data-entity-type="{{ .EntityType }}"
-       hx-get="/list/{{ .List }}" hx-target="#content" hx-push-url="true">
-      {{ .Label }}<span class="nav-count">{{ .Count }}</span>
-    </a>
+    {{ template "nav-item" (map "Dashboard" .Item.Dashboard "Graph" .Item.Graph "Label" .Item.Label "List" .Item.List "EntityType" .Item.EntityType "Count" .Item.Count "ActiveList" $.ActiveList) }}
     {{ end }}
     {{ end }}
   </nav>
 </aside>
 <script>
+function toggleNavGroup(btn) {
+  var chevron = btn.querySelector('.nav-group-chevron');
+  var items = btn.nextElementSibling;
+  var isCollapsed = chevron.classList.toggle('collapsed');
+  items.classList.toggle('hidden', isCollapsed);
+  // Persist state to server in the background
+  var group = btn.getAttribute('data-group');
+  fetch('/api/ui/toggle-group', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    body: 'group=' + encodeURIComponent(group)
+  });
+}
 document.body.addEventListener('htmx:pushedIntoHistory', function() {
   var path = window.location.pathname;
   var links = document.querySelectorAll('.sidebar nav a');
@@ -303,6 +342,17 @@ document.body.addEventListener('htmx:pushedIntoHistory', function() {
     links.forEach(function(a) {
       var href = a.getAttribute('href');
       a.classList.toggle('active', path === href || path.startsWith(href + '?'));
+    });
+    // Auto-expand group containing the active link
+    links.forEach(function(a) {
+      if (a.classList.contains('active')) {
+        var group = a.closest('.nav-group-items');
+        if (group && group.classList.contains('hidden')) {
+          group.classList.remove('hidden');
+          var chevron = group.previousElementSibling.querySelector('.nav-group-chevron');
+          if (chevron) chevron.classList.remove('collapsed');
+        }
+      }
     });
     return;
   }

--- a/prototypes/data-entry/catalog/data-entry.yaml
+++ b/prototypes/data-entry/catalog/data-entry.yaml
@@ -289,11 +289,13 @@ lists:
     page_size: 50
 
 navigation:
-  - label: "All Products"
-    list: all_products
-  - label: "In Stock"
-    list: in_stock
-  - label: "Low / Out of Stock"
-    list: low_stock
+  - group: "Products"
+    items:
+      - label: "All Products"
+        list: all_products
+      - label: "In Stock"
+        list: in_stock
+      - label: "Low / Out of Stock"
+        list: low_stock
   - label: "Brands"
     list: brands

--- a/prototypes/data-entry/project/data-entry.yaml
+++ b/prototypes/data-entry/project/data-entry.yaml
@@ -509,13 +509,18 @@ dashboard:
 navigation:
   - label: "Dashboard"
     dashboard: true
-  - label: "My Tickets"
-    list: my_tickets
-  - label: "Open Tickets"
-    list: open_tickets
-  - label: "All Tickets"
-    list: all_tickets
-  - label: "Categories"
-    list: categories
+  - group: "Tickets"
+    items:
+      - label: "My Tickets"
+        list: my_tickets
+      - label: "Open Tickets"
+        list: open_tickets
+      - label: "All Tickets"
+        list: all_tickets
+  - group: "Reference Data"
+    collapsed: true
+    items:
+      - label: "Categories"
+        list: categories
   - label: "Graph Explorer"
     graph: true

--- a/prototypes/data-entry/project/relations/TKT-001--tagged--urgent.md
+++ b/prototypes/data-entry/project/relations/TKT-001--tagged--urgent.md
@@ -1,0 +1,5 @@
+---
+from: TKT-001
+type: tagged
+to: urgent
+---

--- a/prototypes/data-entry/project/relations/TKT-003--belongs-to--backend.md
+++ b/prototypes/data-entry/project/relations/TKT-003--belongs-to--backend.md
@@ -1,0 +1,5 @@
+---
+from: TKT-003
+type: belongs-to
+to: backend
+---

--- a/prototypes/data-entry/project/relations/TKT-006--blocks--TKT-002.md
+++ b/prototypes/data-entry/project/relations/TKT-006--blocks--TKT-002.md
@@ -1,0 +1,5 @@
+---
+from: TKT-006
+type: blocks
+to: TKT-002
+---


### PR DESCRIPTION
## Summary

- Navigation items can now be organized into named **collapsible groups** in the sidebar, configured via `group`/`items` fields in `data-entry.yaml`
- Collapsed state is **persisted server-side** in `.rela/ui-state.json` (survives page reloads, works with Wails desktop app)
- Groups containing the active page **auto-expand**, nested groups are **rejected at config validation time**

## Config example

```yaml
navigation:
  - label: "Dashboard"
    dashboard: true
  - group: "Tickets"
    items:
      - label: "Open Tickets"
        list: open_tickets
      - label: "All Tickets"
        list: all_tickets
  - group: "Reference Data"
    collapsed: true
    items:
      - label: "Categories"
        list: categories
  - label: "Graph Explorer"
    graph: true
```

## Changes

| File | Change |
|------|--------|
| `config.go` | Add `Group`/`Collapsed`/`Items` to `NavigationEntry`, add `UIState` type |
| `app.go` | `NavGroup`/`NavElement` types, `navElements()`, UIState load/save, `firstNavTarget()`, nested group validation |
| `handlers.go` | Update 6 handlers to pass `navElements(activeList)`, add `handleToggleGroup` endpoint |
| `handlers_graph.go` | Update to use `navElements()` |
| `router.go` | Add `POST /api/ui/toggle-group` route |
| `templates.go` | Sidebar template with groups, CSS (chevron, indentation), JS (optimistic toggle + persist) |
| `helpers.go` | Add `map` template function for passing data to sub-templates |
| `app_test.go` | Tests for `navElements`, UIState, validation, `firstNavTarget`, active list in groups |
| `handlers_test.go` | Tests for toggle endpoint, grouped nav in `handleIndex` |
| `data-entry.md` | Updated navigation docs with group syntax and behavior |
| Example configs | Updated both prototype configs to demonstrate grouping |

## Backward compatibility

Flat navigation entries continue to work unchanged. The `group`/`items` fields are optional — a config with no groups behaves identically to before.

## Test plan

- [x] `just test` passes with race detection
- [x] `just lint` passes
- [x] Visual testing: groups expand/collapse, chevron rotates, active state highlights inside groups
- [x] Persistence: collapsed state survives page reload
- [x] Auto-expand: navigating to a grouped item expands its parent group
- [x] Config validation: nested groups produce clear error
- [ ] CI passes