### PR TITLE
Add configurable commands to data-entry web app

### DIFF
--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -452,5 +452,34 @@ func validateConfig(cfg *Config, meta *metamodel.Metamodel) []string {
 			}
 		}
 	}
+	validContexts := map[string]bool{"entity": true, "list": true, "view": true, "global": true}
+	for cmdID, cmd := range cfg.Commands {
+		if cmd.Label == "" {
+			errs = append(errs, fmt.Sprintf("command %q: label is required", cmdID))
+		}
+		if cmd.Script == "" {
+			errs = append(errs, fmt.Sprintf("command %q: script is required", cmdID))
+		}
+		if !validContexts[cmd.Context] {
+			errs = append(errs, fmt.Sprintf("command %q: invalid context %q (must be entity, list, view, or global)", cmdID, cmd.Context))
+		}
+		if cmd.AvailableOn != nil {
+			for _, v := range cmd.AvailableOn.Views {
+				if _, ok := cfg.Views[v]; !ok {
+					errs = append(errs, fmt.Sprintf("command %q: available_on references unknown view %q", cmdID, v))
+				}
+			}
+			for _, l := range cmd.AvailableOn.Lists {
+				if _, ok := cfg.Lists[l]; !ok {
+					errs = append(errs, fmt.Sprintf("command %q: available_on references unknown list %q", cmdID, l))
+				}
+			}
+			for _, et := range cmd.AvailableOn.EntityTypes {
+				if _, ok := meta.GetEntityDef(et); !ok {
+					errs = append(errs, fmt.Sprintf("command %q: available_on references unknown entity type %q", cmdID, et))
+				}
+			}
+		}
+	}
 	return errs
 }

--- a/internal/dataentry/commands.go
+++ b/internal/dataentry/commands.go
@@ -1,0 +1,552 @@
+package dataentry
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+// Protocol prefix for structured command output messages.
+const commandOutputPrefix = "::rela::"
+
+// ResolvedCommand is a command that has been matched to a specific page context.
+type ResolvedCommand struct {
+	ID      string
+	Label   string
+	Confirm string
+	Context string
+}
+
+// resolveCommands returns commands available for a given page context.
+// pageType is "entity", "list", "view", or "dashboard".
+// qualifier is the specific list ID or view ID.
+// entityType is the entity type shown on the page (empty for dashboard).
+func (a *App) resolveCommands(pageType, qualifier, entityType string) []ResolvedCommand {
+	if len(a.Cfg.Commands) == 0 {
+		return nil
+	}
+
+	// Sort command IDs for deterministic order.
+	ids := make([]string, 0, len(a.Cfg.Commands))
+	for id := range a.Cfg.Commands {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	var result []ResolvedCommand
+	for _, id := range ids {
+		cmd := a.Cfg.Commands[id]
+		if matchesPage(cmd, pageType, qualifier, entityType) {
+			result = append(result, ResolvedCommand{
+				ID:      id,
+				Label:   cmd.Label,
+				Confirm: cmd.Confirm,
+				Context: cmd.Context,
+			})
+		}
+	}
+	return result
+}
+
+// matchesPage checks if a command should appear on the given page.
+func matchesPage(cmd CommandConfig, pageType, qualifier, entityType string) bool {
+	scope := cmd.AvailableOn
+
+	// No scope restriction: show on any page that matches the command's context.
+	if scope == nil {
+		return contextMatchesPage(cmd.Context, pageType)
+	}
+
+	// Check explicit scope matches.
+	switch pageType {
+	case "view":
+		if contains(scope.Views, qualifier) {
+			return true
+		}
+		if contains(scope.EntityTypes, entityType) {
+			return true
+		}
+	case "entity":
+		if contains(scope.EntityTypes, entityType) {
+			return true
+		}
+	case "list":
+		if contains(scope.Lists, qualifier) {
+			return true
+		}
+	case "dashboard":
+		if scope.Dashboard {
+			return true
+		}
+	}
+	return false
+}
+
+// contextMatchesPage returns true when a command's context type is compatible
+// with the page type. Entity and view commands both appear on entity/view pages.
+func contextMatchesPage(context, pageType string) bool {
+	switch context {
+	case "entity":
+		return pageType == "entity" || pageType == "view"
+	case "view":
+		return pageType == "view"
+	case "list":
+		return pageType == "list"
+	case "global":
+		return pageType == "dashboard"
+	}
+	return false
+}
+
+// contains checks if a string slice contains a value.
+func contains(slice []string, val string) bool {
+	for _, s := range slice {
+		if s == val {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Stdin JSON builders ---
+
+// commandInput is the JSON structure passed to a command script on stdin.
+type commandInput struct {
+	Context     string                     `json:"context"`
+	Entity      *model.Entity              `json:"entity,omitempty"`
+	Entities    []*model.Entity            `json:"entities,omitempty"`
+	Collections map[string][]*model.Entity `json:"collections,omitempty"`
+	Relations   []*model.Relation          `json:"relations,omitempty"`
+	ListID      string                     `json:"list_id,omitempty"`
+	ViewID      string                     `json:"view_id,omitempty"`
+	Project     commandProjectInfo         `json:"project"`
+}
+
+type commandProjectInfo struct {
+	Root      string `json:"root"`
+	Metamodel string `json:"metamodel"`
+}
+
+func (a *App) buildEntityInput(entity *model.Entity) *commandInput {
+	// Collect all relations involving this entity.
+	outgoing := a.g.OutgoingEdges(entity.ID)
+	incoming := a.g.IncomingEdges(entity.ID)
+	rels := make([]*model.Relation, 0, len(outgoing)+len(incoming))
+	rels = append(rels, outgoing...)
+	rels = append(rels, incoming...)
+	return &commandInput{
+		Context:   "entity",
+		Entity:    entity,
+		Relations: rels,
+		Project:   a.projectInfo(),
+	}
+}
+
+func (a *App) buildListInput(listID string, entities []*model.Entity) *commandInput {
+	return &commandInput{
+		Context:  "list",
+		ListID:   listID,
+		Entities: entities,
+		Project:  a.projectInfo(),
+	}
+}
+
+func (a *App) buildViewInput(viewID string, vr *viewResult) *commandInput {
+	// Collect all entity IDs in the result set.
+	idSet := map[string]bool{vr.Entry.ID: true}
+	for _, entities := range vr.Collections {
+		for _, e := range entities {
+			idSet[e.ID] = true
+		}
+	}
+
+	// Gather relations between entities in the result set.
+	var rels []*model.Relation
+	for id := range idSet {
+		for _, e := range a.g.OutgoingEdges(id) {
+			if idSet[e.To] {
+				rels = append(rels, e)
+			}
+		}
+	}
+
+	return &commandInput{
+		Context:     "view",
+		ViewID:      viewID,
+		Entity:      vr.Entry,
+		Collections: vr.Collections,
+		Relations:   rels,
+		Project:     a.projectInfo(),
+	}
+}
+
+func (a *App) buildGlobalInput() *commandInput {
+	return &commandInput{
+		Context: "global",
+		Project: a.projectInfo(),
+	}
+}
+
+func (a *App) projectInfo() commandProjectInfo {
+	return commandProjectInfo{
+		Root:      a.ProjectRoot(),
+		Metamodel: "metamodel.yaml",
+	}
+}
+
+// --- Protocol parser ---
+
+// CommandMessage is a structured message parsed from a command's stdout.
+type CommandMessage struct {
+	Type       string `json:"type"`
+	Text       string `json:"text,omitempty"`
+	Level      string `json:"level,omitempty"`
+	Path       string `json:"path,omitempty"`
+	Label      string `json:"label,omitempty"`
+	Action     string `json:"action,omitempty"`
+	ID         string `json:"id,omitempty"`
+	EntityType string `json:"entity_type,omitempty"`
+	URL        string `json:"url,omitempty"`
+}
+
+// parseCommandOutput parses a single line of command stdout.
+// If the line has the ::rela:: prefix, it returns the parsed message.
+// Otherwise it returns a log-type message with the raw text.
+func parseCommandOutput(line string) CommandMessage {
+	if strings.HasPrefix(line, commandOutputPrefix) {
+		payload := strings.TrimPrefix(line, commandOutputPrefix)
+		var msg CommandMessage
+		if err := json.Unmarshal([]byte(payload), &msg); err == nil {
+			return msg
+		}
+	}
+	return CommandMessage{Type: "log", Text: line}
+}
+
+// --- Process management ---
+
+type runningCommand struct {
+	cmd *exec.Cmd
+}
+
+var (
+	runningCommands sync.Map
+)
+
+// --- HTTP Handlers ---
+
+// handleCommandExec handles POST /api/command/{commandID} and streams results as SSE.
+func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	commandID := strings.TrimPrefix(r.URL.Path, "/api/command/")
+	cmd, ok := a.Cfg.Commands[commandID]
+	if !ok {
+		http.Error(w, "Unknown command: "+commandID, http.StatusNotFound)
+		return
+	}
+
+	execID := r.URL.Query().Get("exec_id")
+	if execID == "" {
+		execID = fmt.Sprintf("cmd-%d", time.Now().UnixNano())
+	}
+
+	// Build stdin JSON based on context.
+	var input *commandInput
+	switch cmd.Context {
+	case "entity":
+		entityID := r.URL.Query().Get("entity_id")
+		entity, found := a.g.GetNode(entityID)
+		if !found {
+			http.Error(w, "Entity not found: "+entityID, http.StatusNotFound)
+			return
+		}
+		input = a.buildEntityInput(entity)
+	case "list":
+		listID := r.URL.Query().Get("list_id")
+		listCfg, found := a.Cfg.Lists[listID]
+		if !found {
+			http.Error(w, "List not found: "+listID, http.StatusNotFound)
+			return
+		}
+		entities := a.g.NodesByType(listCfg.EntityType)
+		entities = applyFilters(entities, listCfg.Filters)
+		input = a.buildListInput(listID, entities)
+	case "view":
+		viewID := r.URL.Query().Get("view_id")
+		entityID := r.URL.Query().Get("entity_id")
+		viewCfg, found := a.Cfg.Views[viewID]
+		if !found {
+			http.Error(w, "View not found: "+viewID, http.StatusNotFound)
+			return
+		}
+		vr, err := a.executeView(viewCfg, entityID)
+		if err != nil {
+			http.Error(w, "View error: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		input = a.buildViewInput(viewID, vr)
+	case "global":
+		input = a.buildGlobalInput()
+	default:
+		http.Error(w, "Invalid command context: "+cmd.Context, http.StatusBadRequest)
+		return
+	}
+
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		http.Error(w, "Failed to build input: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Set up SSE response. Flusher is optional — Wails' asset server on
+	// macOS/Linux delivers each Write() immediately without needing Flush().
+	flusher, _ := w.(http.Flusher)
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	// Start the script.
+	proc := exec.Command("sh", "-c", cmd.Script)
+	proc.Dir = a.ProjectRoot()
+	proc.Env = a.buildCommandEnv(cmd, input)
+	proc.Stdin = strings.NewReader(string(inputJSON))
+
+	stdout, err := proc.StdoutPipe()
+	if err != nil {
+		writeSSEEvent(w, flusher, "error", `{"text":"Failed to create stdout pipe"}`)
+		writeSSEDone(w, flusher, false)
+		return
+	}
+	stderr, err := proc.StderrPipe()
+	if err != nil {
+		writeSSEEvent(w, flusher, "error", `{"text":"Failed to create stderr pipe"}`)
+		writeSSEDone(w, flusher, false)
+		return
+	}
+
+	if startErr := proc.Start(); startErr != nil {
+		msg, _ := json.Marshal(map[string]string{"text": "Failed to start: " + startErr.Error()})
+		writeSSEEvent(w, flusher, "error", string(msg))
+		writeSSEDone(w, flusher, false)
+		return
+	}
+
+	// Register for cancellation.
+	runningCommands.Store(execID, &runningCommand{cmd: proc})
+	defer runningCommands.Delete(execID)
+
+	// Capture stderr in background.
+	var stderrBuf strings.Builder
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			stderrBuf.WriteString(scanner.Text())
+			stderrBuf.WriteString("\n")
+		}
+	}()
+
+	// Stream stdout as SSE events.
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		line := scanner.Text()
+		msg := parseCommandOutput(line)
+		data, _ := json.Marshal(msg)
+		writeSSEEvent(w, flusher, msg.Type, string(data))
+	}
+
+	// Wait for stderr goroutine and process to finish.
+	<-stderrDone
+	waitErr := proc.Wait()
+
+	if waitErr != nil {
+		errText := "Command failed"
+		if stderrBuf.Len() > 0 {
+			errText = strings.TrimSpace(stderrBuf.String())
+		}
+		msg, _ := json.Marshal(map[string]string{"text": errText})
+		writeSSEEvent(w, flusher, "error", string(msg))
+		writeSSEDone(w, flusher, false)
+		return
+	}
+
+	writeSSEDone(w, flusher, true)
+}
+
+// handleCommandCancel handles POST /api/command-cancel/{execID}.
+func (a *App) handleCommandCancel(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	execID := strings.TrimPrefix(r.URL.Path, "/api/command-cancel/")
+	val, ok := runningCommands.Load(execID)
+	if !ok {
+		http.Error(w, "No running command: "+execID, http.StatusNotFound)
+		return
+	}
+	rc, castOK := val.(*runningCommand)
+	if !castOK {
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Send SIGINT for graceful shutdown.
+	if rc.cmd.Process != nil {
+		_ = rc.cmd.Process.Signal(syscall.SIGINT)
+	}
+
+	// Wait briefly, then force kill.
+	go func() {
+		time.Sleep(3 * time.Second)
+		if rc.cmd.Process != nil {
+			_ = rc.cmd.Process.Kill()
+		}
+	}()
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleOpenFile handles POST /api/open-file to open or reveal files.
+func (a *App) handleOpenFile(w http.ResponseWriter, r *http.Request) { // coverage-ignore: requires OS interaction
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	filePath := r.URL.Query().Get("path")
+	action := r.URL.Query().Get("action")
+	if filePath == "" {
+		http.Error(w, "path is required", http.StatusBadRequest)
+		return
+	}
+
+	// Resolve relative paths against project root.
+	if !filepath.IsAbs(filePath) {
+		filePath = filepath.Join(a.ProjectRoot(), filePath)
+	}
+
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		if action == "reveal" {
+			cmd = exec.Command("open", "-R", filePath)
+		} else {
+			cmd = exec.Command("open", filePath)
+		}
+	case "linux":
+		if action == "reveal" {
+			cmd = exec.Command("xdg-open", filepath.Dir(filePath))
+		} else {
+			cmd = exec.Command("xdg-open", filePath)
+		}
+	case "windows":
+		if action == "reveal" {
+			cmd = exec.Command("explorer", "/select,", filePath)
+		} else {
+			cmd = exec.Command("cmd", "/c", "start", "", filePath)
+		}
+	default:
+		http.Error(w, "Unsupported platform", http.StatusInternalServerError)
+		return
+	}
+
+	if err := cmd.Start(); err != nil {
+		http.Error(w, "Failed to open file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleOpenURL handles POST /api/open-url to open URLs in the default browser.
+func (a *App) handleOpenURL(w http.ResponseWriter, r *http.Request) { // coverage-ignore: requires OS interaction
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	rawURL := r.URL.Query().Get("url")
+	if rawURL == "" {
+		http.Error(w, "url is required", http.StatusBadRequest)
+		return
+	}
+	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
+		http.Error(w, "Invalid URL scheme", http.StatusBadRequest)
+		return
+	}
+
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", rawURL)
+	case "linux":
+		cmd = exec.Command("xdg-open", rawURL)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", "", rawURL)
+	default:
+		http.Error(w, "Unsupported platform", http.StatusInternalServerError)
+		return
+	}
+
+	if err := cmd.Start(); err != nil {
+		http.Error(w, "Failed to open URL: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// --- Helpers ---
+
+func (a *App) buildCommandEnv(cmd CommandConfig, input *commandInput) []string {
+	env := os.Environ()
+	env = append(env,
+		"RELA_PROJECT_ROOT="+a.ProjectRoot(),
+		"RELA_CONTEXT="+cmd.Context,
+	)
+	if input.Entity != nil {
+		env = append(env,
+			"RELA_ENTITY_ID="+input.Entity.ID,
+			"RELA_ENTITY_TYPE="+input.Entity.Type,
+		)
+	}
+	if input.ListID != "" {
+		env = append(env, "RELA_LIST_ID="+input.ListID)
+	}
+	if input.ViewID != "" {
+		env = append(env, "RELA_VIEW_ID="+input.ViewID)
+	}
+	for k, v := range cmd.Env {
+		env = append(env, k+"="+v)
+	}
+	return env
+}
+
+func writeSSEEvent(w http.ResponseWriter, flusher http.Flusher, event, data string) {
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data)
+	if flusher != nil {
+		flusher.Flush()
+	}
+}
+
+func writeSSEDone(w http.ResponseWriter, flusher http.Flusher, success bool) {
+	data, _ := json.Marshal(map[string]bool{"success": success})
+	writeSSEEvent(w, flusher, "done", string(data))
+}

--- a/internal/dataentry/commands_test.go
+++ b/internal/dataentry/commands_test.go
@@ -1,0 +1,890 @@
+package dataentry
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// --- resolveCommands ---
+
+func TestResolveCommands(t *testing.T) {
+	app := testAppInstance()
+	app.Cfg.Views = map[string]ViewConfig{
+		"ticket_detail": {Title: "Ticket Detail", Entry: ViewEntry{Type: "ticket"}},
+	}
+	app.Cfg.Commands = map[string]CommandConfig{
+		"entity-cmd": {
+			Label:   "Entity Cmd",
+			Script:  "echo hi",
+			Context: "entity",
+			AvailableOn: &CommandScope{
+				EntityTypes: []string{"ticket"},
+			},
+		},
+		"view-cmd": {
+			Label:   "View Cmd",
+			Script:  "echo hi",
+			Context: "view",
+			AvailableOn: &CommandScope{
+				Views: []string{"ticket_detail"},
+			},
+		},
+		"list-cmd": {
+			Label:   "List Cmd",
+			Script:  "echo hi",
+			Context: "list",
+			AvailableOn: &CommandScope{
+				Lists: []string{"tickets"},
+			},
+		},
+		"global-cmd": {
+			Label:   "Global Cmd",
+			Script:  "echo hi",
+			Context: "global",
+			AvailableOn: &CommandScope{
+				Dashboard: true,
+			},
+		},
+		"unscoped-entity": {
+			Label:   "Unscoped",
+			Script:  "echo hi",
+			Context: "entity",
+		},
+	}
+
+	t.Run("entity page shows entity commands", func(t *testing.T) {
+		cmds := app.resolveCommands("entity", "", "ticket")
+		ids := cmdIDs(cmds)
+		assertContains(t, ids, "entity-cmd")
+		assertContains(t, ids, "unscoped-entity")
+		assertNotContains(t, ids, "view-cmd")
+		assertNotContains(t, ids, "list-cmd")
+		assertNotContains(t, ids, "global-cmd")
+	})
+
+	t.Run("entity page for non-matching type", func(t *testing.T) {
+		cmds := app.resolveCommands("entity", "", "component")
+		ids := cmdIDs(cmds)
+		// unscoped entity command still shows (context matches)
+		assertContains(t, ids, "unscoped-entity")
+		// scoped to ticket only
+		assertNotContains(t, ids, "entity-cmd")
+	})
+
+	t.Run("view page shows entity and view commands", func(t *testing.T) {
+		cmds := app.resolveCommands("view", "ticket_detail", "ticket")
+		ids := cmdIDs(cmds)
+		assertContains(t, ids, "entity-cmd")
+		assertContains(t, ids, "view-cmd")
+		assertContains(t, ids, "unscoped-entity")
+		assertNotContains(t, ids, "list-cmd")
+		assertNotContains(t, ids, "global-cmd")
+	})
+
+	t.Run("list page shows list commands", func(t *testing.T) {
+		cmds := app.resolveCommands("list", "tickets", "ticket")
+		ids := cmdIDs(cmds)
+		assertContains(t, ids, "list-cmd")
+		assertNotContains(t, ids, "entity-cmd")
+		assertNotContains(t, ids, "view-cmd")
+	})
+
+	t.Run("dashboard shows global commands", func(t *testing.T) {
+		cmds := app.resolveCommands("dashboard", "", "")
+		ids := cmdIDs(cmds)
+		assertContains(t, ids, "global-cmd")
+		assertNotContains(t, ids, "entity-cmd")
+	})
+
+	t.Run("empty commands returns nil", func(t *testing.T) {
+		app2 := testAppInstance()
+		cmds := app2.resolveCommands("entity", "", "ticket")
+		if cmds != nil {
+			t.Errorf("expected nil, got %v", cmds)
+		}
+	})
+
+	t.Run("deterministic order", func(t *testing.T) {
+		cmds := app.resolveCommands("view", "ticket_detail", "ticket")
+		if len(cmds) < 2 {
+			t.Skip("need at least 2 commands")
+		}
+		// Run multiple times and check order is stable
+		for i := 0; i < 5; i++ {
+			cmds2 := app.resolveCommands("view", "ticket_detail", "ticket")
+			for j := range cmds {
+				if cmds[j].ID != cmds2[j].ID {
+					t.Fatalf("order not deterministic: %v vs %v", cmdIDs(cmds), cmdIDs(cmds2))
+				}
+			}
+		}
+	})
+}
+
+// --- parseCommandOutput ---
+
+func TestParseCommandOutput(t *testing.T) {
+	t.Run("structured message", func(t *testing.T) {
+		msg := parseCommandOutput(`::rela::{"type":"message","text":"hello"}`)
+		if msg.Type != "message" || msg.Text != "hello" {
+			t.Errorf("unexpected: %+v", msg)
+		}
+	})
+
+	t.Run("file message", func(t *testing.T) {
+		msg := parseCommandOutput(`::rela::{"type":"file","path":"/tmp/report.pdf","label":"Report","action":"open"}`)
+		if msg.Type != "file" || msg.Path != "/tmp/report.pdf" || msg.Action != "open" {
+			t.Errorf("unexpected: %+v", msg)
+		}
+	})
+
+	t.Run("entity message", func(t *testing.T) {
+		msg := parseCommandOutput(`::rela::{"type":"entity","id":"TKT-001","entity_type":"ticket","action":"updated"}`)
+		if msg.Type != "entity" || msg.ID != "TKT-001" || msg.EntityType != "ticket" {
+			t.Errorf("unexpected: %+v", msg)
+		}
+	})
+
+	t.Run("error message", func(t *testing.T) {
+		msg := parseCommandOutput(`::rela::{"type":"error","text":"something failed"}`)
+		if msg.Type != "error" || msg.Text != "something failed" {
+			t.Errorf("unexpected: %+v", msg)
+		}
+	})
+
+	t.Run("group and endgroup", func(t *testing.T) {
+		msg := parseCommandOutput(`::rela::{"type":"group","label":"Files"}`)
+		if msg.Type != "group" || msg.Label != "Files" {
+			t.Errorf("unexpected: %+v", msg)
+		}
+		msg2 := parseCommandOutput(`::rela::{"type":"endgroup"}`)
+		if msg2.Type != "endgroup" {
+			t.Errorf("unexpected: %+v", msg2)
+		}
+	})
+
+	t.Run("open URL", func(t *testing.T) {
+		msg := parseCommandOutput(`::rela::{"type":"open","url":"https://example.com"}`)
+		if msg.Type != "open" || msg.URL != "https://example.com" {
+			t.Errorf("unexpected: %+v", msg)
+		}
+	})
+
+	t.Run("warning level", func(t *testing.T) {
+		msg := parseCommandOutput(`::rela::{"type":"message","level":"warning","text":"watch out"}`)
+		if msg.Level != "warning" {
+			t.Errorf("unexpected level: %s", msg.Level)
+		}
+	})
+
+	t.Run("raw log line", func(t *testing.T) {
+		msg := parseCommandOutput("some raw output")
+		if msg.Type != "log" || msg.Text != "some raw output" {
+			t.Errorf("unexpected: %+v", msg)
+		}
+	})
+
+	t.Run("malformed JSON falls back to log", func(t *testing.T) {
+		msg := parseCommandOutput("::rela::{broken json")
+		if msg.Type != "log" {
+			t.Errorf("expected log type for malformed JSON, got: %s", msg.Type)
+		}
+	})
+
+	t.Run("empty line", func(t *testing.T) {
+		msg := parseCommandOutput("")
+		if msg.Type != "log" {
+			t.Errorf("expected log type for empty line, got: %s", msg.Type)
+		}
+	})
+
+	t.Run("prefix only", func(t *testing.T) {
+		msg := parseCommandOutput("::rela::")
+		// Empty JSON after prefix — should fall back to log
+		if msg.Type != "log" {
+			t.Errorf("expected log for prefix-only, got: %s", msg.Type)
+		}
+	})
+}
+
+// --- Stdin JSON builders ---
+
+func TestBuildEntityInput(t *testing.T) {
+	app := testAppInstance()
+	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"})
+	entity, _ := app.g.GetNode("TKT-001")
+	app.g.AddEdge(model.NewRelation("TKT-001", "depends_on", "TKT-002"))
+
+	input := app.buildEntityInput(entity)
+
+	if input.Context != "entity" {
+		t.Errorf("expected entity context, got %s", input.Context)
+	}
+	if input.Entity.ID != "TKT-001" {
+		t.Errorf("expected TKT-001, got %s", input.Entity.ID)
+	}
+	if input.Project.Root != "/test/project" {
+		t.Errorf("expected /test/project, got %s", input.Project.Root)
+	}
+	if len(input.Relations) == 0 {
+		t.Error("expected relations to be populated")
+	}
+
+	// Verify it marshals to valid JSON
+	data, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if decoded["context"] != "entity" {
+		t.Error("JSON context field mismatch")
+	}
+}
+
+func TestBuildListInput(t *testing.T) {
+	app := testAppInstance()
+	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"})
+	entities := app.g.NodesByType("ticket")
+
+	input := app.buildListInput("tickets", entities)
+
+	if input.Context != "list" {
+		t.Errorf("expected list context, got %s", input.Context)
+	}
+	if input.ListID != "tickets" {
+		t.Errorf("expected tickets, got %s", input.ListID)
+	}
+	if len(input.Entities) != 2 {
+		t.Errorf("expected 2 entities, got %d", len(input.Entities))
+	}
+}
+
+func TestBuildViewInput(t *testing.T) {
+	app := testAppInstance()
+	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"})
+	app.g.AddEdge(model.NewRelation("TKT-001", "belongs_to", "CMP-001"))
+
+	view := ViewConfig{
+		Title: "Test View",
+		Entry: ViewEntry{Type: "ticket"},
+		Traverse: []ViewTraverse{
+			{From: "entry", Follow: "belongs_to", CollectAs: "components"},
+		},
+	}
+	vr, err := app.executeView(view, "TKT-001")
+	if err != nil {
+		t.Fatalf("executeView: %v", err)
+	}
+
+	input := app.buildViewInput("test_view", vr)
+
+	if input.Context != "view" {
+		t.Errorf("expected view context, got %s", input.Context)
+	}
+	if input.ViewID != "test_view" {
+		t.Errorf("expected test_view, got %s", input.ViewID)
+	}
+	if input.Entity.ID != "TKT-001" {
+		t.Errorf("expected TKT-001, got %s", input.Entity.ID)
+	}
+	if len(input.Collections["components"]) == 0 {
+		t.Error("expected components collection")
+	}
+	if len(input.Relations) == 0 {
+		t.Error("expected relations between entities in view")
+	}
+}
+
+func TestBuildGlobalInput(t *testing.T) {
+	app := testAppInstance()
+	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"})
+
+	input := app.buildGlobalInput()
+
+	if input.Context != "global" {
+		t.Errorf("expected global context, got %s", input.Context)
+	}
+	if input.Entity != nil {
+		t.Error("expected no entity for global context")
+	}
+}
+
+// --- buildCommandEnv ---
+
+func TestBuildCommandEnv(t *testing.T) {
+	app := testAppInstance()
+	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"})
+
+	cmd := CommandConfig{
+		Script:  "echo hi",
+		Context: "entity",
+		Env:     map[string]string{"FORMAT": "pdf"},
+	}
+	entity, _ := app.g.GetNode("TKT-001")
+	input := app.buildEntityInput(entity)
+	env := app.buildCommandEnv(cmd, input)
+
+	envMap := envToMap(env)
+	if envMap["RELA_PROJECT_ROOT"] != "/test/project" {
+		t.Errorf("expected project root, got %s", envMap["RELA_PROJECT_ROOT"])
+	}
+	if envMap["RELA_CONTEXT"] != "entity" {
+		t.Errorf("expected entity context, got %s", envMap["RELA_CONTEXT"])
+	}
+	if envMap["RELA_ENTITY_ID"] != "TKT-001" {
+		t.Errorf("expected TKT-001, got %s", envMap["RELA_ENTITY_ID"])
+	}
+	if envMap["RELA_ENTITY_TYPE"] != "ticket" {
+		t.Errorf("expected ticket, got %s", envMap["RELA_ENTITY_TYPE"])
+	}
+	if envMap["FORMAT"] != "pdf" {
+		t.Errorf("expected custom env FORMAT=pdf, got %s", envMap["FORMAT"])
+	}
+}
+
+func TestBuildCommandEnvListContext(t *testing.T) {
+	app := testAppInstance()
+	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"})
+
+	cmd := CommandConfig{Script: "echo hi", Context: "list"}
+	input := app.buildListInput("tickets", nil)
+	env := app.buildCommandEnv(cmd, input)
+
+	envMap := envToMap(env)
+	if envMap["RELA_LIST_ID"] != "tickets" {
+		t.Errorf("expected tickets, got %s", envMap["RELA_LIST_ID"])
+	}
+}
+
+func TestBuildCommandEnvViewContext(t *testing.T) {
+	app := testAppInstance()
+	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"})
+
+	cmd := CommandConfig{Script: "echo hi", Context: "view"}
+	entity, _ := app.g.GetNode("TKT-001")
+	input := &commandInput{
+		Context: "view",
+		ViewID:  "ticket_detail",
+		Entity:  entity,
+		Project: app.projectInfo(),
+	}
+	env := app.buildCommandEnv(cmd, input)
+
+	envMap := envToMap(env)
+	if envMap["RELA_VIEW_ID"] != "ticket_detail" {
+		t.Errorf("expected ticket_detail, got %s", envMap["RELA_VIEW_ID"])
+	}
+	if envMap["RELA_ENTITY_ID"] != "TKT-001" {
+		t.Errorf("expected TKT-001, got %s", envMap["RELA_ENTITY_ID"])
+	}
+}
+
+// --- Config validation ---
+
+func TestValidateCommandConfig(t *testing.T) {
+	meta := testMeta()
+
+	t.Run("valid command", func(t *testing.T) {
+		cfg := &Config{
+			Lists: map[string]List{"tickets": {EntityType: "ticket"}},
+			Views: map[string]ViewConfig{"ticket_detail": {}},
+			Commands: map[string]CommandConfig{
+				"test": {
+					Label:   "Test",
+					Script:  "echo hi",
+					Context: "entity",
+					AvailableOn: &CommandScope{
+						EntityTypes: []string{"ticket"},
+						Views:       []string{"ticket_detail"},
+						Lists:       []string{"tickets"},
+					},
+				},
+			},
+		}
+		errs := validateConfig(cfg, meta)
+		if len(errs) != 0 {
+			t.Errorf("expected no errors, got %v", errs)
+		}
+	})
+
+	t.Run("missing label", func(t *testing.T) {
+		cfg := &Config{Commands: map[string]CommandConfig{
+			"bad": {Script: "echo", Context: "entity"},
+		}}
+		errs := validateConfig(cfg, meta)
+		if !hasError(errs, "label") {
+			t.Errorf("expected label error, got %v", errs)
+		}
+	})
+
+	t.Run("missing script", func(t *testing.T) {
+		cfg := &Config{Commands: map[string]CommandConfig{
+			"bad": {Label: "Test", Context: "entity"},
+		}}
+		errs := validateConfig(cfg, meta)
+		if !hasError(errs, "script") {
+			t.Errorf("expected script error, got %v", errs)
+		}
+	})
+
+	t.Run("invalid context", func(t *testing.T) {
+		cfg := &Config{Commands: map[string]CommandConfig{
+			"bad": {Label: "Test", Script: "echo", Context: "invalid"},
+		}}
+		errs := validateConfig(cfg, meta)
+		if !hasError(errs, "invalid context") {
+			t.Errorf("expected context error, got %v", errs)
+		}
+	})
+
+	t.Run("unknown view reference", func(t *testing.T) {
+		cfg := &Config{Commands: map[string]CommandConfig{
+			"bad": {
+				Label: "Test", Script: "echo", Context: "view",
+				AvailableOn: &CommandScope{Views: []string{"nonexistent"}},
+			},
+		}}
+		errs := validateConfig(cfg, meta)
+		if !hasError(errs, "unknown view") {
+			t.Errorf("expected view error, got %v", errs)
+		}
+	})
+
+	t.Run("unknown list reference", func(t *testing.T) {
+		cfg := &Config{Commands: map[string]CommandConfig{
+			"bad": {
+				Label: "Test", Script: "echo", Context: "list",
+				AvailableOn: &CommandScope{Lists: []string{"nonexistent"}},
+			},
+		}}
+		errs := validateConfig(cfg, meta)
+		if !hasError(errs, "unknown list") {
+			t.Errorf("expected list error, got %v", errs)
+		}
+	})
+
+	t.Run("unknown entity type reference", func(t *testing.T) {
+		cfg := &Config{Commands: map[string]CommandConfig{
+			"bad": {
+				Label: "Test", Script: "echo", Context: "entity",
+				AvailableOn: &CommandScope{EntityTypes: []string{"nonexistent"}},
+			},
+		}}
+		errs := validateConfig(cfg, meta)
+		if !hasError(errs, "unknown entity type") {
+			t.Errorf("expected entity type error, got %v", errs)
+		}
+	})
+}
+
+// --- SSE Handler integration test ---
+
+func TestHandleCommandExec(t *testing.T) {
+	app := newHandlerTestApp(t)
+	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()})
+	app.Cfg.Commands = map[string]CommandConfig{
+		"test-echo": {
+			Label:   "Test Echo",
+			Script:  `echo '::rela::{"type":"message","text":"hello from test"}' && echo 'raw log line'`,
+			Context: "entity",
+		},
+	}
+
+	t.Run("success stream", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/api/command/test-echo?entity_id=TKT-001&entity_type=ticket", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleCommandExec(w, r)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		if ct := w.Header().Get("Content-Type"); ct != "text/event-stream" {
+			t.Errorf("expected text/event-stream, got %s", ct)
+		}
+
+		events := parseSSEEvents(t, w.Body)
+		// Should have a message event, a log event, and a done event
+		var hasMessage, hasLog, hasDone bool
+		for _, ev := range events {
+			switch ev.event {
+			case "message":
+				hasMessage = true
+				if !strings.Contains(ev.data, "hello from test") {
+					t.Errorf("unexpected message data: %s", ev.data)
+				}
+			case "log":
+				hasLog = true
+			case "done":
+				hasDone = true
+				if !strings.Contains(ev.data, `"success":true`) {
+					t.Errorf("expected success=true, got: %s", ev.data)
+				}
+			}
+		}
+		if !hasMessage {
+			t.Error("expected message event")
+		}
+		if !hasLog {
+			t.Error("expected log event")
+		}
+		if !hasDone {
+			t.Error("expected done event")
+		}
+	})
+
+	t.Run("unknown command", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/api/command/nonexistent", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleCommandExec(w, r)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("entity not found", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/api/command/test-echo?entity_id=NOPE", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleCommandExec(w, r)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodDelete, "/api/command/test-echo", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleCommandExec(w, r)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", w.Code)
+		}
+	})
+}
+
+func TestHandleCommandExecFailing(t *testing.T) {
+	app := newHandlerTestApp(t)
+	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()})
+	app.Cfg.Commands = map[string]CommandConfig{
+		"fail-cmd": {
+			Label:   "Fail",
+			Script:  "echo 'failing' >&2 && exit 1",
+			Context: "entity",
+		},
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/command/fail-cmd?entity_id=TKT-001", http.NoBody)
+	w := httptest.NewRecorder()
+	app.handleCommandExec(w, r)
+
+	events := parseSSEEvents(t, w.Body)
+	var hasError, hasDone bool
+	for _, ev := range events {
+		if ev.event == "error" {
+			hasError = true
+		}
+		if ev.event == "done" {
+			hasDone = true
+			if strings.Contains(ev.data, `"success":true`) {
+				t.Error("expected success=false for failing command")
+			}
+		}
+	}
+	if !hasError {
+		t.Error("expected error event for failing command")
+	}
+	if !hasDone {
+		t.Error("expected done event for failing command")
+	}
+}
+
+func TestHandleCommandExecGlobalContext(t *testing.T) {
+	app := newHandlerTestApp(t)
+	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()})
+	app.Cfg.Commands = map[string]CommandConfig{
+		"global-cmd": {
+			Label:   "Global",
+			Script:  `echo '::rela::{"type":"message","text":"global ok"}'`,
+			Context: "global",
+		},
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/command/global-cmd", http.NoBody)
+	w := httptest.NewRecorder()
+	app.handleCommandExec(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	events := parseSSEEvents(t, w.Body)
+	var hasMessage bool
+	for _, ev := range events {
+		if ev.event == "message" && strings.Contains(ev.data, "global ok") {
+			hasMessage = true
+		}
+	}
+	if !hasMessage {
+		t.Error("expected global message")
+	}
+}
+
+func TestHandleCommandExecListContext(t *testing.T) {
+	app := newHandlerTestApp(t)
+	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()})
+	app.Cfg.Commands = map[string]CommandConfig{
+		"list-cmd": {
+			Label:   "List",
+			Script:  `echo '::rela::{"type":"message","text":"list ok"}'`,
+			Context: "list",
+		},
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/command/list-cmd?list_id=tickets", http.NoBody)
+	w := httptest.NewRecorder()
+	app.handleCommandExec(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleCommandExecViewContext(t *testing.T) {
+	app := newHandlerTestApp(t)
+	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()})
+	app.Cfg.Commands = map[string]CommandConfig{
+		"view-cmd": {
+			Label:   "View",
+			Script:  `echo '::rela::{"type":"message","text":"view ok"}'`,
+			Context: "view",
+		},
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/command/view-cmd?view_id=ticket_detail&entity_id=TKT-001", http.NoBody)
+	w := httptest.NewRecorder()
+	app.handleCommandExec(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- Cancel handler ---
+
+func TestHandleCommandCancel(t *testing.T) {
+	t.Run("no running command", func(t *testing.T) {
+		app := testAppInstance()
+		r := httptest.NewRequest(http.MethodPost, "/api/command-cancel/nonexistent", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleCommandCancel(w, r)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		app := testAppInstance()
+		r := httptest.NewRequest(http.MethodGet, "/api/command-cancel/test", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleCommandCancel(w, r)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", w.Code)
+		}
+	})
+}
+
+// --- Open URL handler ---
+
+func TestHandleOpenURL(t *testing.T) {
+	app := testAppInstance()
+
+	t.Run("missing url", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodPost, "/api/open-url", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleOpenURL(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid scheme", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodPost, "/api/open-url?url=ftp://evil.com", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleOpenURL(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/api/open-url?url=https://example.com", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleOpenURL(w, r)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", w.Code)
+		}
+	})
+}
+
+// --- Open File handler ---
+
+func TestHandleOpenFile(t *testing.T) {
+	app := testAppInstance()
+
+	t.Run("missing path", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodPost, "/api/open-file", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleOpenFile(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/api/open-file?path=/tmp/test", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleOpenFile(w, r)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", w.Code)
+		}
+	})
+}
+
+// --- matchesPage ---
+
+func TestMatchesPage(t *testing.T) {
+	t.Run("nil scope matches context", func(t *testing.T) {
+		cmd := CommandConfig{Context: "entity"}
+		if !matchesPage(cmd, "entity", "", "ticket") {
+			t.Error("expected entity command to match entity page")
+		}
+		if !matchesPage(cmd, "view", "", "ticket") {
+			t.Error("expected entity command to match view page")
+		}
+		if matchesPage(cmd, "list", "", "") {
+			t.Error("entity command should not match list page")
+		}
+	})
+
+	t.Run("view context only matches view", func(t *testing.T) {
+		cmd := CommandConfig{Context: "view"}
+		if matchesPage(cmd, "entity", "", "ticket") {
+			t.Error("view command should not match entity page")
+		}
+		if !matchesPage(cmd, "view", "", "ticket") {
+			t.Error("view command should match view page")
+		}
+	})
+
+	t.Run("global context matches dashboard", func(t *testing.T) {
+		cmd := CommandConfig{Context: "global"}
+		if !matchesPage(cmd, "dashboard", "", "") {
+			t.Error("global command should match dashboard")
+		}
+		if matchesPage(cmd, "entity", "", "ticket") {
+			t.Error("global command should not match entity page")
+		}
+	})
+}
+
+// --- contains ---
+
+func TestContains(t *testing.T) {
+	if !contains([]string{"a", "b", "c"}, "b") {
+		t.Error("expected true")
+	}
+	if contains([]string{"a", "b", "c"}, "d") {
+		t.Error("expected false")
+	}
+	if contains(nil, "a") {
+		t.Error("expected false for nil")
+	}
+}
+
+// --- Helpers ---
+
+type sseEvent struct {
+	event string
+	data  string
+}
+
+func parseSSEEvents(t *testing.T, body io.Reader) []sseEvent {
+	t.Helper()
+	var events []sseEvent
+	scanner := bufio.NewScanner(body)
+	var current sseEvent
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "event: "):
+			current.event = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			current.data = strings.TrimPrefix(line, "data: ")
+		case line == "" && current.event != "":
+			events = append(events, current)
+			current = sseEvent{}
+		}
+	}
+	if current.event != "" {
+		events = append(events, current)
+	}
+	return events
+}
+
+func cmdIDs(cmds []ResolvedCommand) []string {
+	ids := make([]string, len(cmds))
+	for i, c := range cmds {
+		ids[i] = c.ID
+	}
+	return ids
+}
+
+func assertContains(t *testing.T, ids []string, expected string) {
+	t.Helper()
+	for _, id := range ids {
+		if id == expected {
+			return
+		}
+	}
+	t.Errorf("expected %q in %v", expected, ids)
+}
+
+func assertNotContains(t *testing.T, ids []string, unexpected string) {
+	t.Helper()
+	for _, id := range ids {
+		if id == unexpected {
+			t.Errorf("did not expect %q in %v", unexpected, ids)
+			return
+		}
+	}
+}
+
+func hasError(errs []string, substring string) bool {
+	for _, e := range errs {
+		if strings.Contains(strings.ToLower(e), strings.ToLower(substring)) {
+			return true
+		}
+	}
+	return false
+}
+
+func envToMap(env []string) map[string]string {
+	m := make(map[string]string)
+	for _, e := range env {
+		parts := strings.SplitN(e, "=", 2)
+		if len(parts) == 2 {
+			m[parts[0]] = parts[1]
+		}
+	}
+	return m
+}

--- a/internal/dataentry/config.go
+++ b/internal/dataentry/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Lists      map[string]List              `yaml:"lists"`
 	Views      map[string]ViewConfig        `yaml:"views"`
 	Dashboard  *DashboardConfig             `yaml:"dashboard,omitempty"`
+	Commands   map[string]CommandConfig     `yaml:"commands,omitempty"`
 	Navigation []NavigationEntry            `yaml:"navigation"`
 }
 
@@ -192,4 +193,23 @@ type ViewSection struct {
 type ViewSectionField struct {
 	Property string `yaml:"property"`
 	Label    string `yaml:"label,omitempty"`
+}
+
+// CommandConfig defines an executable command triggered from the UI.
+// Context must be one of: entity, list, view, global.
+type CommandConfig struct {
+	Label       string            `yaml:"label"`
+	Script      string            `yaml:"script"`
+	Context     string            `yaml:"context"`
+	AvailableOn *CommandScope     `yaml:"available_on,omitempty"`
+	Confirm     string            `yaml:"confirm,omitempty"`
+	Env         map[string]string `yaml:"env,omitempty"`
+}
+
+// CommandScope controls where a command button appears in the UI.
+type CommandScope struct {
+	Views       []string `yaml:"views,omitempty"`
+	Lists       []string `yaml:"lists,omitempty"`
+	EntityTypes []string `yaml:"entity_types,omitempty"`
+	Dashboard   bool     `yaml:"dashboard,omitempty"`
 }

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -269,6 +269,7 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 		"PrevPageURL":      prevPageURL,
 		"NextPageURL":      nextPageURL,
 		"HasPagination":    pageSize > 0 && totalPages > 1,
+		"Commands":         a.resolveCommands("list", listID, list.EntityType),
 	}
 
 	if r.Header.Get("HX-Request") == "true" {
@@ -546,6 +547,7 @@ func (a *App) handleEntity(w http.ResponseWriter, r *http.Request) {
 		"EditFormID": editFormID,
 		"Relations":  rels,
 		"PropTypes":  propTypes,
+		"Commands":   a.resolveCommands("entity", "", entity.Type),
 		"IsHTMX":     r.Header.Get("HX-Request") == "true",
 	}
 
@@ -889,6 +891,7 @@ func (a *App) handleView(w http.ResponseWriter, r *http.Request) {
 		"EditFormID": a.editFormForType(result.Entry.Type),
 		"ReturnTo":   returnTo,
 		"Sections":   sections,
+		"Commands":   a.resolveCommands("view", viewID, result.Entry.Type),
 		"IsHTMX":     r.Header.Get("HX-Request") == "true",
 	}
 
@@ -1560,6 +1563,7 @@ func (a *App) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		"ActiveList": "_dashboard",
 		"Dashboard":  dash,
 		"Cards":      cards,
+		"Commands":   a.resolveCommands("dashboard", "", ""),
 		"IsHTMX":     r.Header.Get("HX-Request") == "true",
 	}
 

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -28,5 +28,9 @@ func (a *App) NewRouter() http.Handler {
 	mux.HandleFunc("/graph", a.handleGraph)
 	mux.HandleFunc("/api/graph-data", a.handleGraphData)
 	mux.HandleFunc("/api/ui/toggle-group", a.handleToggleGroup)
+	mux.HandleFunc("/api/command/", a.handleCommandExec)
+	mux.HandleFunc("/api/command-cancel/", a.handleCommandCancel)
+	mux.HandleFunc("/api/open-file", a.handleOpenFile)
+	mux.HandleFunc("/api/open-url", a.handleOpenURL)
 	return mux
 }

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -196,6 +196,39 @@ thead th.sortable { user-select: none; }
 .jump-link:hover { background: var(--primary-light); }
 .nav-count { margin-left: auto; font-size: 11px; color: rgba(255,255,255,0.4); font-weight: 400; }
 
+/* Command toast */
+#command-toast-container { position: fixed; bottom: 16px; right: 16px; z-index: 1000; display: flex; flex-direction: column-reverse; gap: 8px; max-width: 380px; }
+.command-toast { background: var(--bg-card); border: 1px solid var(--border); border-radius: 10px; box-shadow: 0 4px 16px rgba(0,0,0,0.12); overflow: hidden; animation: toastIn 0.3s; font-size: 13px; }
+.command-toast-header { display: flex; align-items: center; gap: 8px; padding: 10px 12px; border-bottom: 1px solid var(--border); background: var(--bg); }
+.command-toast-label { font-weight: 600; font-size: 13px; flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.command-toast-icon { width: 18px; height: 18px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-size: 14px; }
+.command-toast-btn { background: none; border: none; cursor: pointer; font-size: 16px; color: var(--text-muted); padding: 2px 4px; border-radius: 4px; line-height: 1; }
+.command-toast-btn:hover { background: var(--bg); color: var(--text); }
+.command-toast-body { padding: 8px 12px; max-height: 200px; overflow-y: auto; }
+.command-toast-body:empty { display: none; }
+.command-toast-msg { padding: 3px 0; color: var(--text-muted); line-height: 1.4; }
+.command-toast-msg.warning { color: #b45309; }
+.command-toast-msg.error-msg { color: #dc2626; }
+.command-toast-file, .command-toast-entity { display: flex; align-items: center; gap: 6px; padding: 4px 0; }
+.command-toast-file a, .command-toast-entity a { font-size: 12px; color: var(--primary); text-decoration: none; padding: 2px 8px; border: 1px solid var(--primary); border-radius: 4px; white-space: nowrap; }
+.command-toast-file a:hover, .command-toast-entity a:hover { background: var(--primary-light); }
+.command-toast-file span, .command-toast-entity span { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.command-toast-expand { font-size: 12px; color: var(--primary); cursor: pointer; padding: 4px 0; border: none; background: none; }
+.command-toast-expand:hover { text-decoration: underline; }
+.command-toast-group-label { font-size: 12px; font-weight: 600; color: var(--text); padding: 4px 0 2px; cursor: pointer; }
+.command-toast-group-label::before { content: '\25B6'; font-size: 9px; margin-right: 4px; display: inline-block; transition: transform 0.15s; }
+.command-toast-group-label.open::before { transform: rotate(90deg); }
+.command-toast-group-items { display: none; padding-left: 14px; }
+.command-toast-group-label.open + .command-toast-group-items { display: block; }
+.command-toast.running .command-toast-header { border-left: 3px solid var(--primary); }
+.command-toast.success .command-toast-header { border-left: 3px solid #16a34a; }
+.command-toast.error .command-toast-header { border-left: 3px solid #dc2626; }
+.command-toast.cancelled .command-toast-header { border-left: 3px solid var(--text-muted); }
+@keyframes cmdSpin { to { transform: rotate(360deg); } }
+.cmd-spinner { display: inline-block; width: 14px; height: 14px; border: 2px solid var(--border); border-top-color: var(--primary); border-radius: 50%; animation: cmdSpin 0.6s linear infinite; }
+.command-toast-log { display: none; }
+.command-toast-log.show { display: block; padding: 8px 12px; background: #f8fafc; border-top: 1px solid var(--border); font-family: var(--font-mono); font-size: 11px; max-height: 150px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; color: var(--text-muted); }
+
 </style>
 <script>
 // SlimSelect progressive enhancement
@@ -262,6 +295,304 @@ function confirmDelete(entityID, returnTo) {
     overlay.remove();
   });
 }
+
+// --- Command execution ---
+var _cmdToasts = {};
+var _CMD_MAX_VISIBLE = 5;
+
+function runCommand(commandID, params) {
+  var btn = event.currentTarget;
+  // Close parent dropdown if command was picked from a menu
+  var dd = btn.closest('details.add-dropdown');
+  if (dd) dd.removeAttribute('open');
+  var confirmMsg = btn.getAttribute('data-confirm');
+  if (confirmMsg && !window.confirm(confirmMsg)) return;
+
+  var execID = 'cmd-' + Date.now() + '-' + Math.random().toString(36).substr(2, 6);
+  var label = btn.textContent.trim();
+
+  var container = document.getElementById('command-toast-container');
+  var toast = _createToast(execID, label);
+  container.appendChild(toast);
+
+  var qs = new URLSearchParams(params);
+  qs.set('exec_id', execID);
+
+  _cmdToasts[execID] = { toast: toast, messages: [], logs: [], hoverPause: false, aborted: false };
+
+  toast.addEventListener('mouseenter', function() { _cmdToasts[execID].hoverPause = true; });
+  toast.addEventListener('mouseleave', function() { _cmdToasts[execID].hoverPause = false; });
+
+  // Use fetch+ReadableStream instead of EventSource for Wails compatibility.
+  var url = '/api/command/' + encodeURIComponent(commandID) + '?' + qs.toString();
+  fetch(url).then(function(resp) {
+    if (!resp.ok) {
+      return resp.text().then(function(t) { throw new Error(t || resp.statusText); });
+    }
+    var reader = resp.body.getReader();
+    var decoder = new TextDecoder();
+    var buf = '';
+    function pump() {
+      return reader.read().then(function(result) {
+        if (result.done) return;
+        buf += decoder.decode(result.value, {stream: true});
+        var lines = buf.split('\n');
+        buf = lines.pop(); // keep incomplete last line
+        for (var i = 0; i < lines.length; i++) _processSSELine(execID, lines[i]);
+        return pump();
+      });
+    }
+    return pump();
+  }).then(function() {
+    // If stream ended without a done event, finish as success.
+    var state = _cmdToasts[execID];
+    if (state && !state.finished) _finishToast(execID, true);
+  }).catch(function(err) {
+    var state = _cmdToasts[execID];
+    if (state && !state.aborted && !state.finished) {
+      _addMsg(execID, {type: 'error', text: err.message || 'Connection failed'});
+      _finishToast(execID, false);
+    }
+  });
+}
+
+// Parse SSE lines from the fetch stream.
+var _sseEvent = {};
+function _processSSELine(execID, line) {
+  if (line.indexOf('event: ') === 0) {
+    _sseEvent[execID] = line.substring(7).trim();
+  } else if (line.indexOf('data: ') === 0) {
+    var evtType = _sseEvent[execID] || 'message';
+    var data = line.substring(6);
+    _sseEvent[execID] = '';
+    _dispatchSSE(execID, evtType, data);
+  }
+  // blank lines (SSE delimiter) are handled by clearing event state above
+}
+
+function _dispatchSSE(execID, evtType, raw) {
+  var d;
+  try { d = JSON.parse(raw); } catch(e) { return; }
+  switch (evtType) {
+    case 'message': _addMsg(execID, d); break;
+    case 'file':    _addFile(execID, d); break;
+    case 'entity':  _addEntity(execID, d); break;
+    case 'open':    _handleOpen(d); break;
+    case 'log':     _addLog(execID, d); break;
+    case 'group':   _startGroup(execID, d); break;
+    case 'endgroup': _endGroup(execID); break;
+    case 'error':
+      _addMsg(execID, {type: 'error', text: d.text || 'Command error'});
+      _finishToast(execID, false);
+      break;
+    case 'done':
+      _finishToast(execID, !!d.success);
+      break;
+  }
+}
+
+function cancelCommand(execID) {
+  fetch('/api/command-cancel/' + execID, { method: 'POST' });
+  var state = _cmdToasts[execID];
+  if (!state) return;
+  state.aborted = true;
+  state.finished = true;
+  var t = state.toast;
+  t.className = 'command-toast cancelled';
+  t.querySelector('.command-toast-icon').innerHTML = '&#8709;';
+  var btnEl = t.querySelector('.command-toast-btn');
+  btnEl.innerHTML = '&times;';
+  btnEl.onclick = function() { t.remove(); delete _cmdToasts[execID]; };
+  _autoHide(execID, 3000);
+}
+
+function _createToast(execID, label) {
+  var t = document.createElement('div');
+  t.className = 'command-toast running';
+  t.id = 'toast-' + execID;
+  t.innerHTML =
+    '<div class="command-toast-header">' +
+      '<span class="command-toast-icon"><span class="cmd-spinner"></span></span>' +
+      '<span class="command-toast-label">' + _esc(label) + '</span>' +
+      '<button class="command-toast-btn" onclick="cancelCommand(\'' + execID + '\')" title="Cancel">&#9632;</button>' +
+    '</div>' +
+    '<div class="command-toast-body" id="toast-body-' + execID + '"></div>' +
+    '<div class="command-toast-log" id="toast-log-' + execID + '"></div>';
+  return t;
+}
+
+function _addMsg(execID, msg) {
+  var state = _cmdToasts[execID];
+  if (!state) return;
+  var cls = 'command-toast-msg';
+  if (msg.level === 'warning') cls += ' warning';
+  if (msg.type === 'error') cls += ' error-msg';
+  if (msg.level === 'debug') return;
+  _appendBody(execID, '<div class="' + cls + '">' + _esc(msg.text) + '</div>');
+}
+
+function _addFile(execID, msg) {
+  var state = _cmdToasts[execID];
+  if (!state) return;
+  var label = msg.label || msg.path.split('/').pop();
+  var action = msg.action || 'none';
+  var actionHtml = '';
+  if (action === 'open') {
+    actionHtml = '<a href="#" onclick="event.preventDefault();_openFile(\'' + _escAttr(execID) + '\',\'' + _escAttr(msg.path) + '\',\'open\')">Open</a>' +
+      '<a href="#" onclick="event.preventDefault();_openFile(\'' + _escAttr(execID) + '\',\'' + _escAttr(msg.path) + '\',\'reveal\')">Reveal</a>';
+  } else if (action === 'reveal') {
+    actionHtml = '<a href="#" onclick="event.preventDefault();_openFile(\'' + _escAttr(execID) + '\',\'' + _escAttr(msg.path) + '\',\'reveal\')">Reveal</a>';
+  }
+  _appendBody(execID, '<div class="command-toast-file"><span title="' + _escAttr(msg.path) + '">&#128196; ' + _esc(label) + '</span>' + actionHtml + '</div>');
+  state.hasActions = true;
+}
+
+function _addEntity(execID, msg) {
+  var state = _cmdToasts[execID];
+  if (!state) return;
+  var verb = msg.action || 'updated';
+  var link = '/entity/' + encodeURIComponent(msg.entity_type) + '/' + encodeURIComponent(msg.id);
+  _appendBody(execID,
+    '<div class="command-toast-entity">' +
+      '<span>' + _esc(msg.id) + ' ' + verb + '</span>' +
+      '<a href="' + link + '" hx-get="' + link + '" hx-target="#content" hx-push-url="true">Go to</a>' +
+    '</div>');
+  state.hasActions = true;
+}
+
+function _handleOpen(msg) {
+  if (msg.url) {
+    fetch('/api/open-url?url=' + encodeURIComponent(msg.url), { method: 'POST' });
+  }
+}
+
+function _addLog(execID, msg) {
+  var state = _cmdToasts[execID];
+  if (!state) return;
+  state.logs.push(msg.text || '');
+}
+
+function _startGroup(execID, msg) {
+  var state = _cmdToasts[execID];
+  if (!state) return;
+  state._groupID = 'grp-' + Date.now();
+  _appendBody(execID,
+    '<div class="command-toast-group-label" onclick="this.classList.toggle(\'open\')">' + _esc(msg.label || 'Group') + '</div>' +
+    '<div class="command-toast-group-items" id="' + state._groupID + '"></div>');
+}
+
+function _endGroup(execID) {
+  var state = _cmdToasts[execID];
+  if (state) state._groupID = null;
+}
+
+function _appendBody(execID, html) {
+  var state = _cmdToasts[execID];
+  if (!state) return;
+  state.messages.push(html);
+  var target;
+  if (state._groupID) {
+    target = document.getElementById(state._groupID);
+  }
+  if (!target) {
+    target = document.getElementById('toast-body-' + execID);
+  }
+  if (!target) return;
+  // Message limiting: hide older items beyond _CMD_MAX_VISIBLE
+  var body = document.getElementById('toast-body-' + execID);
+  var items = body.children;
+  target.insertAdjacentHTML('beforeend', html);
+  // Re-check visible count (only direct children of body, not group contents)
+  var directItems = [];
+  for (var i = 0; i < body.children.length; i++) {
+    var ch = body.children[i];
+    if (!ch.classList.contains('command-toast-expand')) directItems.push(ch);
+  }
+  if (directItems.length > _CMD_MAX_VISIBLE + 1) {
+    // Hide overflow items and show expand link
+    var hidden = 0;
+    for (var j = 0; j < directItems.length - _CMD_MAX_VISIBLE; j++) {
+      directItems[j].style.display = 'none';
+      hidden++;
+    }
+    var existing = body.querySelector('.command-toast-expand');
+    if (existing) existing.remove();
+    var expand = document.createElement('button');
+    expand.className = 'command-toast-expand';
+    expand.textContent = hidden + ' more messages';
+    expand.onclick = function() {
+      for (var k = 0; k < body.children.length; k++) body.children[k].style.display = '';
+      expand.remove();
+    };
+    body.insertBefore(expand, body.firstChild);
+  }
+}
+
+function _finishToast(execID, success) {
+  var state = _cmdToasts[execID];
+  if (!state || state.finished) return;
+  state.finished = true;
+  var t = state.toast;
+  var btnEl = t.querySelector('.command-toast-btn');
+  btnEl.innerHTML = '&times;';
+  btnEl.onclick = function() { t.remove(); delete _cmdToasts[execID]; };
+
+  if (success) {
+    t.className = 'command-toast success';
+    t.querySelector('.command-toast-icon').innerHTML = '&#10003;';
+    if (!state.hasActions) _autoHide(execID, 5000);
+  } else {
+    t.className = 'command-toast error';
+    t.querySelector('.command-toast-icon').innerHTML = '&#10007;';
+    // Show log output on error
+    if (state.logs.length > 0) {
+      var logEl = document.getElementById('toast-log-' + execID);
+      logEl.textContent = state.logs.join('\n');
+      var showBtn = document.createElement('button');
+      showBtn.className = 'command-toast-expand';
+      showBtn.textContent = 'Show output';
+      showBtn.onclick = function() { logEl.classList.toggle('show'); showBtn.textContent = logEl.classList.contains('show') ? 'Hide output' : 'Show output'; };
+      var body = document.getElementById('toast-body-' + execID);
+      body.appendChild(showBtn);
+    }
+  }
+}
+
+function _autoHide(execID, ms) {
+  setTimeout(function _tick() {
+    var state = _cmdToasts[execID];
+    if (!state) return;
+    if (state.hoverPause) { setTimeout(_tick, 500); return; }
+    var t = state.toast;
+    t.style.opacity = '0';
+    t.style.transition = 'opacity 0.3s';
+    setTimeout(function() { t.remove(); delete _cmdToasts[execID]; }, 300);
+  }, ms);
+}
+
+function _openFile(execID, path, action) {
+  fetch('/api/open-file?path=' + encodeURIComponent(path) + '&action=' + encodeURIComponent(action), { method: 'POST' });
+  _dismissToast(execID);
+}
+
+function _dismissToast(execID) {
+  var state = _cmdToasts[execID];
+  if (!state) return;
+  var t = state.toast;
+  t.style.opacity = '0';
+  t.style.transition = 'opacity 0.3s';
+  setTimeout(function() { t.remove(); delete _cmdToasts[execID]; }, 300);
+}
+
+function _esc(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+function _escAttr(s) { return s.replace(/'/g, "\\'").replace(/"/g, '&quot;'); }
+
+// Close dropdown menus on outside click
+document.addEventListener('click', function(e) {
+  document.querySelectorAll('details.add-dropdown[open]').forEach(function(d) {
+    if (!d.contains(e.target)) d.removeAttribute('open');
+  });
+});
 </script>
 {{- end -}}
 
@@ -389,6 +720,7 @@ document.body.addEventListener('htmx:pushedIntoHistory', function() {
 <main class="main" id="content">
 {{ template "list-content" . }}
 </main>
+<div id="command-toast-container"></div>
 </body>
 </html>
 {{- end -}}
@@ -405,6 +737,17 @@ document.body.addEventListener('htmx:pushedIntoHistory', function() {
     <a href="/form/{{ .List.CreateForm }}" class="btn btn-primary btn-sm"
        hx-get="/form/{{ .List.CreateForm }}" hx-target="#content" hx-push-url="true">+ New</a>
     {{ end }}
+    {{ if .Commands }}{{ if gt (len .Commands) 2 }}
+    <details class="add-dropdown">
+      <summary class="btn btn-secondary btn-sm">Commands &#9662;</summary>
+      <div class="add-dropdown-menu">
+        {{ range .Commands }}<a href="#" onclick="event.preventDefault();runCommand('{{ .ID }}', {list_id:'{{ $.ListID }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</a>
+        {{ end }}
+      </div>
+    </details>
+    {{ else }}{{ range .Commands }}
+    <button class="btn btn-secondary btn-sm" onclick="runCommand('{{ .ID }}', {list_id:'{{ $.ListID }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</button>
+    {{ end }}{{ end }}{{ end }}
   </div>
 </div>
 
@@ -745,6 +1088,7 @@ function submitInlineCreate() {
 <main class="main" id="content">
 {{ template "entity-content" . }}
 </main>
+<div id="command-toast-container"></div>
 </body>
 </html>
 {{- end -}}
@@ -760,6 +1104,17 @@ function submitInlineCreate() {
     <a href="/form/{{ .EditFormID }}/{{ .Entity.ID }}" class="btn btn-primary btn-sm"
        hx-get="/form/{{ .EditFormID }}/{{ .Entity.ID }}" hx-target="#content" hx-push-url="true">Edit</a>
     {{ end }}
+    {{ if .Commands }}{{ if gt (len .Commands) 2 }}
+    <details class="add-dropdown">
+      <summary class="btn btn-secondary btn-sm">Commands &#9662;</summary>
+      <div class="add-dropdown-menu">
+        {{ range .Commands }}<a href="#" onclick="event.preventDefault();runCommand('{{ .ID }}', {entity_id:'{{ $.Entity.ID }}',entity_type:'{{ $.Entity.Type }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</a>
+        {{ end }}
+      </div>
+    </details>
+    {{ else }}{{ range .Commands }}
+    <button class="btn btn-secondary btn-sm" onclick="runCommand('{{ .ID }}', {entity_id:'{{ $.Entity.ID }}',entity_type:'{{ $.Entity.Type }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</button>
+    {{ end }}{{ end }}{{ end }}
     <a href="javascript:history.back()" class="btn btn-secondary btn-sm">&larr; Back</a>
   </div>
 </div>
@@ -822,6 +1177,7 @@ function submitInlineCreate() {
 <main class="main" id="content">
 {{ template "view-content" . }}
 </main>
+<div id="command-toast-container"></div>
 </body>
 </html>
 {{- end -}}
@@ -837,6 +1193,17 @@ function submitInlineCreate() {
     <a href="/form/{{ .EditFormID }}/{{ .Entry.ID }}?return_to={{ urlquery .ReturnTo }}" class="btn btn-primary btn-sm"
        hx-get="/form/{{ .EditFormID }}/{{ .Entry.ID }}?return_to={{ urlquery .ReturnTo }}" hx-target="#content" hx-push-url="true">Edit</a>
     {{ end }}
+    {{ if .Commands }}{{ if gt (len .Commands) 2 }}
+    <details class="add-dropdown">
+      <summary class="btn btn-secondary btn-sm">Commands &#9662;</summary>
+      <div class="add-dropdown-menu">
+        {{ range .Commands }}<a href="#" onclick="event.preventDefault();runCommand('{{ .ID }}', {entity_id:'{{ $.Entry.ID }}',entity_type:'{{ $.Entry.Type }}',view_id:'{{ $.ViewID }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</a>
+        {{ end }}
+      </div>
+    </details>
+    {{ else }}{{ range .Commands }}
+    <button class="btn btn-secondary btn-sm" onclick="runCommand('{{ .ID }}', {entity_id:'{{ $.Entry.ID }}',entity_type:'{{ $.Entry.Type }}',view_id:'{{ $.ViewID }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</button>
+    {{ end }}{{ end }}{{ end }}
     <a href="javascript:history.back()" class="btn btn-secondary btn-sm">&larr; Back</a>
   </div>
 </div>
@@ -1458,6 +1825,7 @@ function submitInlineCreate() {
 <main class="main" id="content">
 {{ template "dashboard-content" . }}
 </main>
+<div id="command-toast-container"></div>
 </body>
 </html>
 {{- end -}}
@@ -1468,6 +1836,21 @@ function submitInlineCreate() {
     <h2>{{ .Dashboard.Title }}</h2>
     {{ if .Dashboard.Description }}<p>{{ .Dashboard.Description }}</p>{{ end }}
   </div>
+  {{ if .Commands }}
+  <div style="display:flex;gap:8px;">
+    {{ if gt (len .Commands) 2 }}
+    <details class="add-dropdown">
+      <summary class="btn btn-secondary btn-sm">Commands &#9662;</summary>
+      <div class="add-dropdown-menu">
+        {{ range .Commands }}<a href="#" onclick="event.preventDefault();runCommand('{{ .ID }}', {})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</a>
+        {{ end }}
+      </div>
+    </details>
+    {{ else }}{{ range .Commands }}
+    <button class="btn btn-secondary btn-sm" onclick="runCommand('{{ .ID }}', {})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</button>
+    {{ end }}{{ end }}
+  </div>
+  {{ end }}
 </div>
 
 <div class="dashboard-grid">

--- a/prototypes/data-entry/project/data-entry.yaml
+++ b/prototypes/data-entry/project/data-entry.yaml
@@ -506,6 +506,49 @@ dashboard:
           label: "Assignee"
       limit: 5
 
+# ──────────────────────────────────────────────
+# Commands: executable scripts triggered from the UI
+# ──────────────────────────────────────────────
+commands:
+  export-json:
+    label: "Export JSON"
+    script: |
+      echo '::rela::{"type":"message","text":"Exporting entity data..."}'
+      cat
+      echo '::rela::{"type":"message","text":"Done!"}'
+    context: entity
+    available_on:
+      entity_types: [ticket]
+
+  ticket-summary:
+    label: "View Summary"
+    script: |
+      echo "::rela::{\"type\":\"message\",\"text\":\"Ticket: $RELA_ENTITY_ID\"}"
+      echo "::rela::{\"type\":\"message\",\"text\":\"View: $RELA_VIEW_ID\"}"
+    context: view
+    available_on:
+      views: [ticket_report]
+
+  generate-pdf:
+    label: "Generate PDF"
+    script: |
+      echo '::rela::{"type":"message","text":"Generating PDF report..."}'
+      PDF="/tmp/rela-ticket-${RELA_ENTITY_ID:-report}.pdf"
+      printf '%%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj\n4 0 obj<</Length 44>>stream\nBT /F1 24 Tf 100 700 Td (Hello from rela!) Tj ET\nendstream\nendobj\n5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj\nxref\n0 6\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \n0000000115 00000 n \n0000000266 00000 n \n0000000360 00000 n \ntrailer<</Size 6/Root 1 0 R>>\nstartxref\n430\n%%%%EOF\n' > "$PDF"
+      echo "::rela::{\"type\":\"message\",\"text\":\"PDF saved to $PDF\"}"
+      echo "::rela::{\"type\":\"file\",\"path\":\"$PDF\",\"label\":\"Ticket Report PDF\",\"action\":\"open\"}"
+    context: entity
+    available_on:
+      entity_types: [ticket]
+
+  project-info:
+    label: "Project Info"
+    script: |
+      echo "::rela::{\"type\":\"message\",\"text\":\"Project root: $RELA_PROJECT_ROOT\"}"
+    context: global
+    available_on:
+      dashboard: true
+
 navigation:
   - label: "Dashboard"
     dashboard: true


### PR DESCRIPTION
## Summary

- Add a `commands` section to `data-entry.yaml` allowing users to define scripts that execute from the UI with entity, list, view, or global context
- Commands receive context data via stdin JSON and environment variables (`RELA_PROJECT_ROOT`, `RELA_ENTITY_ID`, etc.) and communicate results back using a `::rela::` line protocol on stdout
- Results stream via SSE into stacked toast notifications with support for messages, file open/reveal, entity links, groups, and cancel
- Uses `fetch()` + `ReadableStream` instead of `EventSource` for Wails desktop compatibility (Wails' asset server doesn't implement `http.Flusher`)
- Includes example commands in the prototype project: export JSON, view summary, generate PDF, and project info

## Changes

| File | Change |
|------|--------|
| `internal/dataentry/config.go` | `CommandConfig` and `CommandScope` types |
| `internal/dataentry/app.go` | Command config validation in `validateConfig()` |
| `internal/dataentry/commands.go` | Command resolver, SSE execution handler, stdin JSON builders, `::rela::` protocol parser, file/URL open handlers, process management |
| `internal/dataentry/commands_test.go` | Tests for all command logic (resolver, parser, builders, handlers, validation) |
| `internal/dataentry/router.go` | 4 new routes (`/api/command/`, `/api/command-cancel/`, `/api/open-file`, `/api/open-url`) |
| `internal/dataentry/handlers.go` | Pass resolved commands to template data in entity, view, list, and dashboard handlers |
| `internal/dataentry/templates.go` | Toast CSS, command execution JS (fetch+ReadableStream SSE), command buttons/dropdowns in page headers |
| `prototypes/data-entry/project/data-entry.yaml` | Example command configs |

## Test plan

- [x] All existing tests pass (`go test -race ./...` — 21 packages)
- [x] New `commands_test.go` covers: command resolution, `::rela::` protocol parsing, stdin JSON builders, config validation, SSE handler integration (success, failure, global/list/view contexts), cancel handler, open-file/open-url handlers
- [ ] Manual testing in Wails desktop app (toast streaming, file open/reveal, dropdown behavior)
- [ ] Manual testing in browser via `rela-server` (SSE streaming with standard EventSource-compatible fetch)