### PR TITLE
Fix data entry create failing silently for multi-segment ID prefixes

### DIFF
--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -130,6 +130,7 @@ tbody tr:last-child td { border-bottom: none; }
 .pagination { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-top: 1px solid var(--border); font-size: 13px; color: var(--text-muted); }
 
 .toast { position: fixed; top: 16px; right: 16px; padding: 12px 20px; background: #166534; color: #fff; border-radius: 8px; font-size: 14px; font-weight: 500; z-index: 999; box-shadow: 0 4px 12px rgba(0,0,0,0.15); animation: toastIn 0.3s; }
+.toast-error { background: #991b1b; }
 @keyframes toastIn { from { opacity: 0; transform: translateY(-8px); } to { opacity: 1; transform: translateY(0); } }
 
 .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 200; display: flex; align-items: center; justify-content: center; animation: fadeIn 0.15s; }
@@ -274,6 +275,15 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 });
 document.addEventListener('htmx:afterSettle', function(evt) { enhanceSelects(evt.detail.target); });
+document.addEventListener('htmx:responseError', function(evt) {
+  var xhr = evt.detail.xhr;
+  var msg = xhr.responseText || ('Request failed: ' + xhr.status);
+  var div = document.createElement('div');
+  div.className = 'toast toast-error';
+  div.textContent = msg;
+  document.body.appendChild(div);
+  setTimeout(function() { div.remove(); }, 5000);
+});
 function confirmDelete(entityID, returnTo) {
   var existing = document.getElementById('delete-confirm-modal');
   if (existing) existing.remove();

--- a/internal/model/id.go
+++ b/internal/model/id.go
@@ -14,8 +14,8 @@ type EntityID struct {
 	Raw    string // Original string
 }
 
-// Common ID pattern: PREFIX-NUMBER (e.g., REQ-001, DEC-42)
-var idPattern = regexp.MustCompile(`^([A-Za-z]+-?)(\d+)$`)
+// Common ID pattern: PREFIX-NUMBER (e.g., REQ-001, DEC-42, ISO-CA-001)
+var idPattern = regexp.MustCompile(`^([A-Za-z]+(?:-[A-Za-z]+)*-?)(\d+)$`)
 
 // ParseEntityID parses an entity ID string into its components
 func ParseEntityID(s string) (EntityID, error) {

--- a/internal/model/id_fuzz_test.go
+++ b/internal/model/id_fuzz_test.go
@@ -18,6 +18,9 @@ func FuzzParseEntityID(f *testing.F) {
 		"COMP-999",
 		"A1",
 		"ABC123",
+		"ISO-CA-001",
+		"ISO-CA-XX-042",
+		"A-B-1",
 
 		// Edge cases
 		"",
@@ -189,6 +192,7 @@ func FuzzExtractHighestNumber(f *testing.F) {
 	f.Add("DEC", "DEC-1,DEC-10,DEC-2")
 	f.Add("COMP", "")
 	f.Add("REQ", "invalid,REQ-001,alsoinvalid")
+	f.Add("ISO-CA", "ISO-CA-001,ISO-CA-002,ISO-CA-003")
 
 	f.Fuzz(func(t *testing.T, prefix, idsJoined string) {
 		ids := strings.Split(idsJoined, ",")
@@ -208,6 +212,7 @@ func FuzzGenerateNextID(f *testing.F) {
 	f.Add("REQ", "REQ-001,REQ-002")
 	f.Add("DEC-", "DEC-1")
 	f.Add("COMP", "")
+	f.Add("ISO-CA-", "ISO-CA-001,ISO-CA-002")
 
 	f.Fuzz(func(t *testing.T, prefix, idsJoined string) {
 		// Skip very long prefixes to avoid memory issues

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -190,6 +190,203 @@ func TestEntityIDMatchesPattern(t *testing.T) {
 	}
 }
 
+// TestParseEntityID_MultiSegmentPrefix tests parsing IDs with multi-segment prefixes
+func TestParseEntityID_MultiSegmentPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantPrefix string
+		wantNumber int
+		wantRaw    string
+	}{
+		{
+			name:       "single segment prefix",
+			input:      "REQ-001",
+			wantPrefix: "REQ-",
+			wantNumber: 1,
+			wantRaw:    "REQ-001",
+		},
+		{
+			name:       "two segment prefix",
+			input:      "ISO-CA-001",
+			wantPrefix: "ISO-CA-",
+			wantNumber: 1,
+			wantRaw:    "ISO-CA-001",
+		},
+		{
+			name:       "three segment prefix",
+			input:      "ISO-CA-XX-042",
+			wantPrefix: "ISO-CA-XX-",
+			wantNumber: 42,
+			wantRaw:    "ISO-CA-XX-042",
+		},
+		{
+			name:       "two segment no trailing dash",
+			input:      "ISO-CA001",
+			wantPrefix: "ISO-CA",
+			wantNumber: 1,
+			wantRaw:    "ISO-CA001",
+		},
+		{
+			name:       "single letter segments",
+			input:      "A-B-1",
+			wantPrefix: "A-B-",
+			wantNumber: 1,
+			wantRaw:    "A-B-1",
+		},
+		{
+			name:    "opaque id with no number",
+			input:   "PERS-JV",
+			wantRaw: "PERS-JV",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := ParseEntityID(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			assertEqual(t, id.Prefix, tt.wantPrefix)
+			assertEqual(t, id.Number, tt.wantNumber)
+			assertEqual(t, id.Raw, tt.wantRaw)
+		})
+	}
+}
+
+// TestExtractHighestNumber_MultiSegmentPrefix tests number extraction with multi-segment prefixes
+func TestExtractHighestNumber_MultiSegmentPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		ids    []string
+		prefix string
+		want   int
+	}{
+		{
+			name:   "single segment",
+			ids:    []string{"REQ-001", "REQ-002", "REQ-003"},
+			prefix: "REQ-",
+			want:   3,
+		},
+		{
+			name:   "multi segment ISO-CA",
+			ids:    []string{"ISO-CA-001", "ISO-CA-002", "ISO-CA-010"},
+			prefix: "ISO-CA-",
+			want:   10,
+		},
+		{
+			name:   "mixed with other prefixes",
+			ids:    []string{"ISO-CA-001", "REQ-005", "ISO-CA-003"},
+			prefix: "ISO-CA-",
+			want:   3,
+		},
+		{
+			name:   "no matches",
+			ids:    []string{"REQ-001", "DEC-002"},
+			prefix: "ISO-CA-",
+			want:   0,
+		},
+		{
+			name:   "empty list",
+			ids:    []string{},
+			prefix: "ISO-CA-",
+			want:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractHighestNumber(tt.ids, tt.prefix)
+			assertEqual(t, got, tt.want)
+		})
+	}
+}
+
+// TestGenerateNextID_MultiSegmentPrefix tests ID generation with multi-segment prefixes
+func TestGenerateNextID_MultiSegmentPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		ids    []string
+		prefix string
+		want   string
+	}{
+		{
+			name:   "first ISO-CA ID",
+			ids:    []string{},
+			prefix: "ISO-CA-",
+			want:   "ISO-CA-001",
+		},
+		{
+			name:   "next ISO-CA ID",
+			ids:    []string{"ISO-CA-001"},
+			prefix: "ISO-CA-",
+			want:   "ISO-CA-002",
+		},
+		{
+			name:   "gap in sequence",
+			ids:    []string{"ISO-CA-001", "ISO-CA-005"},
+			prefix: "ISO-CA-",
+			want:   "ISO-CA-006",
+		},
+		{
+			name:   "single segment still works",
+			ids:    []string{"REQ-001", "REQ-002"},
+			prefix: "REQ-",
+			want:   "REQ-003",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateNextID(tt.ids, tt.prefix)
+			assertEqual(t, got, tt.want)
+		})
+	}
+}
+
+// TestEntityIDMatchesPattern_MultiSegment tests pattern matching with multi-segment prefixes
+func TestEntityIDMatchesPattern_MultiSegment(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       EntityID
+		pattern  string
+		expected bool
+	}{
+		{
+			name:     "multi segment exact",
+			id:       EntityID{Prefix: "ISO-CA-"},
+			pattern:  "ISO-CA-",
+			expected: true,
+		},
+		{
+			name:     "multi segment without trailing dash",
+			id:       EntityID{Prefix: "ISO-CA-"},
+			pattern:  "ISO-CA",
+			expected: true,
+		},
+		{
+			name:     "multi segment case insensitive",
+			id:       EntityID{Prefix: "ISO-CA-"},
+			pattern:  "iso-ca",
+			expected: true,
+		},
+		{
+			name:     "multi segment no match",
+			id:       EntityID{Prefix: "ISO-CA-"},
+			pattern:  "ISO-CB",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.id.MatchesPattern(tt.pattern); got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
 // TestStatusIsValid tests Status validation
 func TestStatusIsValid(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- The ID pattern regex only supported single-segment prefixes (e.g. `REQ-`, `DEC-`) but not multi-segment ones (e.g. `ISO-CA-`). This caused `GenerateNextID` to always produce the same ID (e.g. `ISO-CA-001`), resulting in a 409 conflict on every create attempt after the first.
- HTMX forms with `hx-swap="none"` silently swallowed server error responses (4xx/5xx), giving users no feedback when creation failed.
- Adds an `htmx:responseError` event handler that displays server errors as a red toast notification.
- Adds comprehensive unit tests for multi-segment prefix parsing, extraction, and ID generation.

## Test plan
- [x] Existing tests pass (model, dataentry, all packages)
- [x] New tests cover multi-segment prefixes: `ISO-CA-001`, `ISO-CA-XX-042`, `A-B-1`
- [x] Fuzz test seeds updated with multi-segment cases
- [x] Lint and coverage checks pass
- [ ] Manual: create entity with `ISO-CA-` prefix, verify sequential IDs generated
- [ ] Manual: trigger a server error (e.g. duplicate ID) and verify red toast appears