### PR TITLE
Fix relation field not prefilled when creating from a view's Add button

### DIFF
--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -371,6 +371,9 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 		Properties    []RelationProperty
 		SelectedProps map[string]map[string]string
 	}
+	linkRelation := r.URL.Query().Get("link_relation")
+	linkPeer := r.URL.Query().Get("link_peer")
+
 	relations := make([]ResolvedRelation, 0, len(form.Relations))
 	for _, rel := range form.Relations {
 		targetDef, _ := a.meta.GetEntityDef(rel.TargetType)
@@ -411,6 +414,13 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 						rr.SelectedProps[edge.To] = props
 					}
 				}
+			}
+		}
+
+		// Prefill relation from link params (when creating from a view's "Add" button).
+		if entity == nil && linkPeer != "" && linkRelation != "" {
+			if a.isRelationLinked(rel.Relation, linkRelation) {
+				rr.Selected = append(rr.Selected, linkPeer)
 			}
 		}
 

--- a/internal/dataentry/handlers_test.go
+++ b/internal/dataentry/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
@@ -230,6 +231,41 @@ func TestHandleForm(t *testing.T) {
 		app.handleForm(w, r)
 		if w.Code != http.StatusOK {
 			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("prefills relation from link params via inverse", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		// Add inverse to depends_on so we can test inverse matching.
+		rels := app.meta.Relations
+		dep := rels["depends_on"]
+		dep.Inverse = &metamodel.InverseDef{ID: "dependency_of"}
+		rels["depends_on"] = dep
+
+		// Add a form with a relation using the inverse name.
+		app.Cfg.Forms["create-dep-ticket"] = Form{
+			EntityType: "ticket",
+			Fields:     []FormField{{Property: "title"}},
+			Relations: []FormRelation{{
+				Relation:   "dependency_of",
+				TargetType: "ticket",
+				Label:      "Dependency Of",
+				Widget:     "multi-select",
+			}},
+		}
+
+		r := httptest.NewRequest(http.MethodGet,
+			"/form/create-dep-ticket?link_relation=depends_on&link_peer=TKT-001&link_as=to",
+			http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleForm(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		// The TKT-001 option should be marked as selected.
+		if !strings.Contains(body, `value="TKT-001" selected`) {
+			t.Error("expected TKT-001 to be pre-selected in the dependency_of relation")
 		}
 	})
 }

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -442,3 +442,26 @@ func templateFuncs(styleMap map[string]map[string]string, styledTypes map[string
 		},
 	}
 }
+
+// isRelationLinked checks whether a form relation field (formRel) corresponds
+// to a link relation (linkRel) coming from a view's "Add" button. It returns
+// true when the link relation's inverse matches the form relation, when the
+// form relation's inverse matches the link relation, or when they are equal.
+func (a *App) isRelationLinked(formRel, linkRel string) bool {
+	if formRel == linkRel {
+		return true
+	}
+	// Check if linkRel has an inverse that equals formRel.
+	if def, ok := a.meta.GetRelationDef(linkRel); ok && def.Inverse != nil {
+		if def.Inverse.GetID() == formRel {
+			return true
+		}
+	}
+	// Check if formRel has an inverse that equals linkRel.
+	if def, ok := a.meta.GetRelationDef(formRel); ok && def.Inverse != nil {
+		if def.Inverse.GetID() == linkRel {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -528,3 +528,64 @@ func TestAppendToastParam(t *testing.T) {
 		})
 	}
 }
+
+func TestIsRelationLinked(t *testing.T) {
+	meta := &metamodel.Metamodel{
+		Relations: map[string]metamodel.RelationDef{
+			"assessedBy": {
+				Label:   "assessed by",
+				From:    []string{"annex_a_control"},
+				To:      []string{"iso_control_assessment"},
+				Inverse: &metamodel.InverseDef{ID: "assesses"},
+			},
+			"depends_on": {
+				Label: "depends on",
+				From:  []string{"ticket"},
+				To:    []string{"ticket"},
+			},
+		},
+	}
+	app := &App{meta: meta}
+
+	tests := []struct {
+		name     string
+		formRel  string
+		linkRel  string
+		expected bool
+	}{
+		{
+			name:     "direct match",
+			formRel:  "depends_on",
+			linkRel:  "depends_on",
+			expected: true,
+		},
+		{
+			name:     "inverse of link relation matches form relation",
+			formRel:  "assesses",
+			linkRel:  "assessedBy",
+			expected: true,
+		},
+		{
+			name:     "no match",
+			formRel:  "assesses",
+			linkRel:  "depends_on",
+			expected: false,
+		},
+		{
+			name:     "unknown relations",
+			formRel:  "unknown_a",
+			linkRel:  "unknown_b",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := app.isRelationLinked(tt.formRel, tt.linkRel)
+			if got != tt.expected {
+				t.Errorf("isRelationLinked(%q, %q) = %v, want %v",
+					tt.formRel, tt.linkRel, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- When navigating from a detail view (e.g. `annex_a_control_detail/A-6-01`) and clicking "+ Add ISO Control Assessment", the `link_relation` and `link_peer` query params were only stored as hidden form fields. The visible relation multi-select (e.g. "Annex A Controls") was never pre-selected with the originating entity.
- Adds `isRelationLinked` helper that matches a form relation to a link relation via direct name equality, inverse of the link relation, or inverse of the form relation.
- `handleForm` now pre-selects the `link_peer` in the matching relation select during create mode.

## Test plan
- [x] New unit test `TestIsRelationLinked` covers direct match, inverse match, no match, unknown relations
- [x] New handler test `TestHandleForm/prefills_relation_from_link_params_via_inverse` verifies HTML output contains `selected` on the peer option
- [x] All existing tests pass
- [x] Lint and coverage checks pass
- [ ] Manual: navigate to annex_a_control detail, click "+ Add ISO Control Assessment", verify the Annex A Control field is pre-selected