### PR TITLE
Add relation column support to data entry tables

### DIFF
--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -456,7 +456,11 @@ func validateConfig(cfg *Config, meta *metamodel.Metamodel) []string {
 		}
 		entDef, _ := meta.GetEntityDef(list.EntityType)
 		for _, c := range list.Columns {
-			if _, ok := entDef.Properties[c.Property]; !ok {
+			if c.Relation != "" {
+				if _, ok := meta.GetRelationDef(c.Relation); !ok {
+					errs = append(errs, fmt.Sprintf("list %q: column relation %q not in metamodel", listID, c.Relation))
+				}
+			} else if _, ok := entDef.Properties[c.Property]; !ok {
 				errs = append(errs, fmt.Sprintf("list %q: column %q not in metamodel for entity %q", listID, c.Property, list.EntityType))
 			}
 		}

--- a/internal/dataentry/config.go
+++ b/internal/dataentry/config.go
@@ -84,8 +84,11 @@ type List struct {
 }
 
 // ListColumn defines a column in a list view.
+// A column references either a Property (entity property) or a Relation
+// (outgoing relation type whose target titles are shown comma-separated).
 type ListColumn struct {
 	Property string `yaml:"property"`
+	Relation string `yaml:"relation"`
 	Label    string `yaml:"label"`
 	Sortable bool   `yaml:"sortable"`
 	Link     bool   `yaml:"link"`

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -138,11 +138,17 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 	for _, e := range entities {
 		var cells []CellData
 		for _, col := range list.Columns {
-			val := fmt.Sprintf("%v", e.Properties[col.Property])
-			if e.Properties[col.Property] == nil {
-				val = ""
+			var val string
+			var propType string
+			if col.Relation != "" {
+				val = a.resolveRelationColumnValue(e.ID, col.Relation)
+			} else {
+				val = fmt.Sprintf("%v", e.Properties[col.Property])
+				if e.Properties[col.Property] == nil {
+					val = ""
+				}
+				propType = resolvePropertyType(col.Property, list.EntityType, a.meta)
 			}
-			propType := resolvePropertyType(col.Property, list.EntityType, a.meta)
 			cells = append(cells, CellData{
 				Value:      val,
 				Property:   col.Property,
@@ -732,6 +738,30 @@ func (a *App) handleView(w http.ResponseWriter, r *http.Request) {
 				}
 			case "table":
 				sd.Columns = sec.Columns
+				buildRow := func(e *model.Entity) SectionRowData {
+					eDef, _ := a.meta.GetEntityDef(e.Type)
+					row := SectionRowData{EntityID: e.ID, EntityType: e.Type, EditFormID: a.editFormForType(e.Type)}
+					for _, col := range sec.Columns {
+						var val string
+						var propType string
+						if col.Relation != "" {
+							val = a.resolveRelationColumnValue(e.ID, col.Relation)
+						} else {
+							if v := e.Properties[col.Property]; v != nil {
+								val = fmt.Sprintf("%v", v)
+							}
+							if eDef != nil {
+								if pd, ok := eDef.Properties[col.Property]; ok {
+									propType = pd.Type
+								}
+							}
+						}
+						row.Cells = append(row.Cells, SectionColumnData{
+							Value: val, PropType: propType, Link: col.Link, EntityID: e.ID, EntityType: e.Type,
+						})
+					}
+					return row
+				}
 				if sec.GroupBy != "" {
 					sd.IsGrouped = true
 					groups := map[string][]*model.Entity{}
@@ -750,47 +780,13 @@ func (a *App) handleView(w http.ResponseWriter, r *http.Request) {
 					for _, gName := range groupOrder {
 						gd := GroupData{GroupName: gName}
 						for _, e := range groups[gName] {
-							eDef, _ := a.meta.GetEntityDef(e.Type)
-							row := SectionRowData{EntityID: e.ID, EntityType: e.Type, EditFormID: a.editFormForType(e.Type)}
-							for _, col := range sec.Columns {
-								val := ""
-								if v := e.Properties[col.Property]; v != nil {
-									val = fmt.Sprintf("%v", v)
-								}
-								propType := ""
-								if eDef != nil {
-									if pd, ok := eDef.Properties[col.Property]; ok {
-										propType = pd.Type
-									}
-								}
-								row.Cells = append(row.Cells, SectionColumnData{
-									Value: val, PropType: propType, Link: col.Link, EntityID: e.ID, EntityType: e.Type,
-								})
-							}
-							gd.Rows = append(gd.Rows, row)
+							gd.Rows = append(gd.Rows, buildRow(e))
 						}
 						sd.Groups = append(sd.Groups, gd)
 					}
 				} else {
 					for _, e := range entities {
-						eDef, _ := a.meta.GetEntityDef(e.Type)
-						row := SectionRowData{EntityID: e.ID, EntityType: e.Type, EditFormID: a.editFormForType(e.Type)}
-						for _, col := range sec.Columns {
-							val := ""
-							if v := e.Properties[col.Property]; v != nil {
-								val = fmt.Sprintf("%v", v)
-							}
-							propType := ""
-							if eDef != nil {
-								if pd, ok := eDef.Properties[col.Property]; ok {
-									propType = pd.Type
-								}
-							}
-							row.Cells = append(row.Cells, SectionColumnData{
-								Value: val, PropType: propType, Link: col.Link, EntityID: e.ID, EntityType: e.Type,
-							})
-						}
-						sd.Rows = append(sd.Rows, row)
+						sd.Rows = append(sd.Rows, buildRow(e))
 					}
 				}
 
@@ -1547,13 +1543,19 @@ func (a *App) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			for _, e := range entities {
 				row := make([]CellData, len(card.Columns))
 				for j, col := range card.Columns {
-					val := ""
-					if v := e.Properties[col.Property]; v != nil {
-						val = fmt.Sprintf("%v", v)
+					var val string
+					var propType string
+					if col.Relation != "" {
+						val = a.resolveRelationColumnValue(e.ID, col.Relation)
+					} else {
+						if v := e.Properties[col.Property]; v != nil {
+							val = fmt.Sprintf("%v", v)
+						}
+						propType = resolvePropertyType(col.Property, e.Type, a.meta)
 					}
 					cd := CellData{
 						Value:    val,
-						PropType: resolvePropertyType(col.Property, e.Type, a.meta),
+						PropType: propType,
 					}
 					if col.Link {
 						cd.Link = "/entity/" + e.Type + "/" + e.ID

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -443,6 +443,24 @@ func templateFuncs(styleMap map[string]map[string]string, styledTypes map[string
 	}
 }
 
+// resolveRelationColumnValue returns a comma-separated string of display titles
+// for all targets of the given relation type from an entity.
+func (a *App) resolveRelationColumnValue(entityID, relationType string) string {
+	edges := a.g.OutgoingEdges(entityID)
+	titles := make([]string, 0, len(edges))
+	for _, edge := range edges {
+		if edge.Type != relationType {
+			continue
+		}
+		target, ok := a.g.GetNode(edge.To)
+		if !ok {
+			continue
+		}
+		titles = append(titles, a.entityDisplayTitle(target))
+	}
+	return strings.Join(titles, ", ")
+}
+
 // isRelationLinked checks whether a form relation field (formRel) corresponds
 // to a link relation (linkRel) coming from a view's "Add" button. It returns
 // true when the link relation's inverse matches the form relation, when the

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"html/template"
 	"testing"
 
+	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
@@ -527,6 +528,70 @@ func TestAppendToastParam(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveRelationColumnValue(t *testing.T) {
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"assessment": {
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string"},
+				},
+			},
+			"person": {
+				Properties: map[string]metamodel.PropertyDef{
+					"name": {Type: "string", Required: true},
+				},
+			},
+		},
+	}
+
+	g := graph.New()
+	assessment := model.NewEntity("ASS-001", "assessment")
+	assessment.SetString("title", "Q1 Review")
+	g.AddNode(assessment)
+
+	person1 := model.NewEntity("PER-001", "person")
+	person1.SetString("name", "Alice")
+	g.AddNode(person1)
+
+	person2 := model.NewEntity("PER-002", "person")
+	person2.SetString("name", "Bob")
+	g.AddNode(person2)
+
+	g.AddEdge(&model.Relation{From: "ASS-001", Type: "assessmentBy", To: "PER-001"})
+	g.AddEdge(&model.Relation{From: "ASS-001", Type: "assessmentBy", To: "PER-002"})
+	g.AddEdge(&model.Relation{From: "ASS-001", Type: "otherRel", To: "PER-001"})
+
+	app := &App{meta: meta, g: g}
+
+	t.Run("resolves multiple targets comma-separated", func(t *testing.T) {
+		got := app.resolveRelationColumnValue("ASS-001", "assessmentBy")
+		if got != "Alice, Bob" {
+			t.Errorf("got %q, want %q", got, "Alice, Bob")
+		}
+	})
+
+	t.Run("filters by relation type", func(t *testing.T) {
+		got := app.resolveRelationColumnValue("ASS-001", "otherRel")
+		if got != "Alice" {
+			t.Errorf("got %q, want %q", got, "Alice")
+		}
+	})
+
+	t.Run("returns empty for no matching relations", func(t *testing.T) {
+		got := app.resolveRelationColumnValue("ASS-001", "nonexistent")
+		if got != "" {
+			t.Errorf("got %q, want empty string", got)
+		}
+	})
+
+	t.Run("returns empty for unknown entity", func(t *testing.T) {
+		got := app.resolveRelationColumnValue("UNKNOWN", "assessmentBy")
+		if got != "" {
+			t.Errorf("got %q, want empty string", got)
+		}
+	})
 }
 
 func TestIsRelationLinked(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `Relation` field to `ListColumn` struct so `relation:` keys in YAML column definitions are properly deserialized
- Resolves outgoing relation targets into comma-separated display titles in all three table renderers (list, view, dashboard)
- Updates config validation to accept relation columns and validate the relation exists in the metamodel
- Extracts a `buildRow` closure in the view handler to deduplicate grouped/non-grouped table row construction

Fixes the blank "Assessors" column on the `annex_a_control_detail` view and all other `relation:` columns across ~60 list/view definitions.

## Test plan

- [x] Added `TestResolveRelationColumnValue` with 4 cases (multiple targets, type filtering, no matches, unknown entity)
- [x] All existing tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run ./internal/dataentry/`)
- [ ] Manually verify assessor names appear on http://localhost:8080/view/annex_a_control_detail/A-6-01
- [ ] Spot-check other list views with `relation:` columns (e.g. risks list with `threatens`/`mitigatedBy`)