### PR TITLE
Fix form ignoring direction:incoming relations and deleting display-only relations on save

### DIFF
--- a/internal/dataentry/config.go
+++ b/internal/dataentry/config.go
@@ -49,15 +49,18 @@ type FormField struct {
 
 // FormRelation defines a relation field in a form.
 type FormRelation struct {
-	Relation    string             `yaml:"relation"`
-	Direction   string             `yaml:"direction"`
-	TargetType  string             `yaml:"target_type"`
-	Label       string             `yaml:"label"`
-	Required    bool               `yaml:"required"`
-	Widget      string             `yaml:"widget"`
-	AllowCreate bool               `yaml:"allow_create"`
-	CreateForm  string             `yaml:"create_form"`
-	Properties  []RelationProperty `yaml:"properties"`
+	Relation     string             `yaml:"relation"`
+	Direction    string             `yaml:"direction"`
+	TargetType   string             `yaml:"target_type"`
+	Label        string             `yaml:"label"`
+	Required     bool               `yaml:"required"`
+	Widget       string             `yaml:"widget"`
+	Display      string             `yaml:"display"`
+	AllowCreate  bool               `yaml:"allow_create"`
+	CreateForm   string             `yaml:"create_form"`
+	Properties   []RelationProperty `yaml:"properties"`
+	Fields       []ViewSectionField `yaml:"fields"`
+	EmptyMessage string             `yaml:"empty_message"`
 }
 
 // RelationProperty defines an editable property on a relation.

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -382,6 +382,11 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 
 	relations := make([]ResolvedRelation, 0, len(form.Relations))
 	for _, rel := range form.Relations {
+		// display-only relations (cards, etc.) are not editable form fields
+		if rel.Display != "" {
+			continue
+		}
+
 		targetDef, _ := a.meta.GetEntityDef(rel.TargetType)
 		targetLabel := ""
 		if targetDef != nil {
@@ -407,17 +412,34 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if entity != nil {
-			for _, edge := range a.g.OutgoingEdges(entity.ID) {
-				if edge.Type == rel.Relation {
-					rr.Selected = append(rr.Selected, edge.To)
-					if len(rel.Properties) > 0 {
-						props := make(map[string]string)
-						for _, rp := range rel.Properties {
-							if v, ok := edge.Properties[rp.Property]; ok {
-								props[rp.Property] = fmt.Sprintf("%v", v)
+			if rel.Direction == "incoming" {
+				for _, edge := range a.g.IncomingEdges(entity.ID) {
+					if edge.Type == rel.Relation {
+						rr.Selected = append(rr.Selected, edge.From)
+						if len(rel.Properties) > 0 {
+							props := make(map[string]string)
+							for _, rp := range rel.Properties {
+								if v, ok := edge.Properties[rp.Property]; ok {
+									props[rp.Property] = fmt.Sprintf("%v", v)
+								}
 							}
+							rr.SelectedProps[edge.From] = props
 						}
-						rr.SelectedProps[edge.To] = props
+					}
+				}
+			} else {
+				for _, edge := range a.g.OutgoingEdges(entity.ID) {
+					if edge.Type == rel.Relation {
+						rr.Selected = append(rr.Selected, edge.To)
+						if len(rel.Properties) > 0 {
+							props := make(map[string]string)
+							for _, rp := range rel.Properties {
+								if v, ok := edge.Properties[rp.Property]; ok {
+									props[rp.Property] = fmt.Sprintf("%v", v)
+								}
+							}
+							rr.SelectedProps[edge.To] = props
+						}
 					}
 				}
 			}
@@ -972,12 +994,20 @@ func (a *App) handleCreate(w http.ResponseWriter, r *http.Request) {
 	a.g.AddNode(entity)
 
 	for _, rel := range form.Relations {
+		if rel.Display != "" {
+			continue
+		}
 		values := r.Form[rel.Relation]
 		for _, targetID := range values {
 			if targetID == "" {
 				continue
 			}
-			relation := model.NewRelation(entityID, rel.Relation, targetID)
+			var relation *model.Relation
+			if rel.Direction == "incoming" {
+				relation = model.NewRelation(targetID, rel.Relation, entityID)
+			} else {
+				relation = model.NewRelation(entityID, rel.Relation, targetID)
+			}
 			for _, rp := range rel.Properties {
 				propKey := fmt.Sprintf("_relprop_%s_%s_%s", rel.Relation, targetID, rp.Property)
 				if pv := r.FormValue(propKey); pv != "" {
@@ -1072,12 +1102,26 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, rel := range form.Relations {
-		for _, edge := range a.g.OutgoingEdges(entityID) {
-			if edge.Type == rel.Relation {
-				if delErr := a.repo.DeleteRelation(edge.From, edge.Type, edge.To); delErr != nil {
-					log.Printf("Failed to delete relation file: %v", delErr)
+		if rel.Display != "" {
+			continue
+		}
+		if rel.Direction == "incoming" {
+			for _, edge := range a.g.IncomingEdges(entityID) {
+				if edge.Type == rel.Relation {
+					if delErr := a.repo.DeleteRelation(edge.From, edge.Type, edge.To); delErr != nil {
+						log.Printf("Failed to delete relation file: %v", delErr)
+					}
+					a.g.RemoveEdge(edge.From, edge.Type, edge.To)
 				}
-				a.g.RemoveEdge(edge.From, edge.Type, edge.To)
+			}
+		} else {
+			for _, edge := range a.g.OutgoingEdges(entityID) {
+				if edge.Type == rel.Relation {
+					if delErr := a.repo.DeleteRelation(edge.From, edge.Type, edge.To); delErr != nil {
+						log.Printf("Failed to delete relation file: %v", delErr)
+					}
+					a.g.RemoveEdge(edge.From, edge.Type, edge.To)
+				}
 			}
 		}
 		values := r.Form[rel.Relation]
@@ -1085,7 +1129,12 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 			if targetID == "" {
 				continue
 			}
-			relation := model.NewRelation(entityID, rel.Relation, targetID)
+			var relation *model.Relation
+			if rel.Direction == "incoming" {
+				relation = model.NewRelation(targetID, rel.Relation, entityID)
+			} else {
+				relation = model.NewRelation(entityID, rel.Relation, targetID)
+			}
 			for _, rp := range rel.Properties {
 				propKey := fmt.Sprintf("_relprop_%s_%s_%s", rel.Relation, targetID, rp.Property)
 				if pv := r.FormValue(propKey); pv != "" {

--- a/internal/dataentry/handlers_test.go
+++ b/internal/dataentry/handlers_test.go
@@ -234,6 +234,72 @@ func TestHandleForm(t *testing.T) {
 		}
 	})
 
+	t.Run("edit form shows incoming relations as selected", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+
+		// Add an incoming relation: TKT-001 --belongs_to--> CMP-001
+		// This means CMP-001 has an incoming "belongs_to" edge from TKT-001.
+		app.g.AddEdge(model.NewRelation("TKT-001", "belongs_to", "CMP-001"))
+
+		// Add a form for component with an incoming relation
+		app.Cfg.Forms["edit-component-incoming"] = Form{
+			EntityType: "component",
+			Mode:       "edit",
+			Fields:     []FormField{{Property: "name"}},
+			Relations: []FormRelation{{
+				Relation:   "belongs_to",
+				Direction:  "incoming",
+				TargetType: "ticket",
+				Label:      "Tickets",
+				Widget:     "multi-select",
+			}},
+		}
+
+		r := httptest.NewRequest(http.MethodGet, "/form/edit-component-incoming/CMP-001", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleForm(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		// TKT-001 should be selected (it's the source of the incoming belongs_to edge)
+		if !strings.Contains(body, `value="TKT-001" selected`) {
+			t.Error("expected TKT-001 to be pre-selected as incoming relation")
+		}
+	})
+
+	t.Run("edit form shows outgoing relations as selected", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+
+		// TKT-001 --depends_on--> TKT-002 already added in newHandlerTestApp
+
+		// Add a form for ticket with an outgoing relation
+		app.Cfg.Forms["edit-ticket-outgoing"] = Form{
+			EntityType: "ticket",
+			Mode:       "edit",
+			Fields:     []FormField{{Property: "title"}},
+			Relations: []FormRelation{{
+				Relation:   "depends_on",
+				Direction:  "outgoing",
+				TargetType: "ticket",
+				Label:      "Dependencies",
+				Widget:     "multi-select",
+			}},
+		}
+
+		r := httptest.NewRequest(http.MethodGet, "/form/edit-ticket-outgoing/TKT-001", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleForm(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		// TKT-002 should be selected (it's the target of the outgoing depends_on edge)
+		if !strings.Contains(body, `value="TKT-002" selected`) {
+			t.Error("expected TKT-002 to be pre-selected as outgoing relation")
+		}
+	})
+
 	t.Run("prefills relation from link params via inverse", func(t *testing.T) {
 		app := newHandlerTestApp(t)
 		// Add inverse to depends_on so we can test inverse matching.


### PR DESCRIPTION
## Summary
- Fix `direction: incoming` relations not being shown as selected on edit forms and being saved with swapped from/to on create/update
- Fix `display: cards` (read-only) relations being deleted on every form save because the delete-and-recreate cycle ran on them despite having no form fields
- Add `Display`, `Fields`, and `EmptyMessage` fields to `FormRelation` config struct so display-only relation sections are properly recognized

## Test plan
- [x] New tests: edit form correctly pre-selects incoming relations
- [x] New tests: edit form correctly pre-selects outgoing relations
- [x] All existing tests pass
- [ ] Manual: open edit form for an annex_a_control with incoming `implements` relations — verify they appear selected
- [ ] Manual: save an entity with `display: cards` relations (e.g. `hasTasks`, `assessedBy`) — verify those relations are preserved