### PR TITLE
Add version info to rela-desktop app menu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,17 +96,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential libgtk-3-dev libwebkit2gtk-4.1-dev
 
+      - name: Extract version
+        id: version
+        shell: bash
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Build
         env:
           CGO_ENABLED: "1"
           GOARCH: ${{ matrix.goarch }}
           CGO_LDFLAGS: ${{ matrix.cgo_ldflags }}
-        run: go build -tags ${{ matrix.build_tags }} -trimpath -ldflags "-s -w" -o rela-desktop${{ matrix.ext }} ./cmd/rela-desktop
-
-      - name: Extract version
-        id: version
-        shell: bash
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: go build -tags ${{ matrix.build_tags }} -trimpath -ldflags "-s -w -X main.Version=${{ steps.version.outputs.version }}" -o rela-desktop${{ matrix.ext }} ./cmd/rela-desktop
 
       # --- macOS: Create .app bundle and DMG ---
 

--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -28,6 +28,9 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
+// Version is set at build time via -ldflags.
+var Version = "dev"
+
 // Desktop is the backend bound to the Wails frontend.
 // It manages project lifecycle: opening a directory picker, loading a project,
 // and persisting recent projects in user preferences.
@@ -137,12 +140,25 @@ func (d *Desktop) openProjectFromMenu(_ *menu.CallbackData) {
 	runtime.WindowReloadApp(d.ctx)
 }
 
+// showAbout displays a dialog with version and build information.
+// coverage-ignore: menu callback - requires Wails runtime
+func (d *Desktop) showAbout(_ *menu.CallbackData) {
+	runtime.MessageDialog(d.ctx, runtime.MessageDialogOptions{ //nolint:errcheck // best-effort
+		Type:    runtime.InfoDialog,
+		Title:   "About Rela Desktop",
+		Message: fmt.Sprintf("Rela Desktop\nVersion %s\n\n%s/%s", Version, goruntime.GOOS, goruntime.GOARCH),
+	})
+}
+
 // buildAppMenu constructs the application menu bar including recent projects.
 func (d *Desktop) buildAppMenu() *menu.Menu {
 	appMenu := menu.NewMenu()
 
 	if goruntime.GOOS == "darwin" {
-		appMenu.Append(menu.AppMenu())
+		macAppMenu := appMenu.AddSubmenu("Rela Desktop")
+		macAppMenu.AddText("About Rela Desktop", nil, d.showAbout)
+		macAppMenu.AddSeparator()
+		macAppMenu.Append(menu.AppMenu())
 	}
 
 	fileMenu := appMenu.AddSubmenu("File")
@@ -193,6 +209,11 @@ func (d *Desktop) buildAppMenu() *menu.Menu {
 
 	if goruntime.GOOS == "darwin" {
 		appMenu.Append(menu.EditMenu())
+	}
+
+	if goruntime.GOOS != "darwin" {
+		helpMenu := appMenu.AddSubmenu("Help")
+		helpMenu.AddText("About Rela Desktop", nil, d.showAbout)
 	}
 
 	return appMenu


### PR DESCRIPTION
## Summary
- Add an "About Rela Desktop" dialog showing version, OS, and architecture
- On macOS: appears in the app menu (Rela Desktop > About Rela Desktop)
- On Windows/Linux: appears in a Help menu (Help > About Rela Desktop)
- Version is injected at build time via `-X main.Version=...` ldflags in the release workflow
- Moved the "Extract version" step before the "Build" step in the release workflow so the version output is available during compilation

## Test plan
- [ ] Build locally with `just build-desktop` and verify the About dialog shows "dev" version
- [ ] On macOS: verify "About Rela Desktop" appears in the app menu
- [ ] On non-macOS: verify "About Rela Desktop" appears under Help menu
- [ ] Verify release workflow injects correct version from git tag