### PR TITLE
Add link-existing support for view sections in data entry

### DIFF
--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -662,6 +662,12 @@ func (a *App) handleView(w http.ResponseWriter, r *http.Request) {
 		PeerID   string // entry entity ID
 		Targets  []SectionAddTarget
 	}
+	type SectionLinkInfo struct {
+		Relation    string   // relation type name
+		LinkAs      string   // "from" or "to" — role of the linked entity
+		PeerID      string   // entry entity ID
+		EntityTypes []string // valid target entity types
+	}
 	type SectionData struct {
 		Heading      string
 		SectionID    string
@@ -678,6 +684,7 @@ func (a *App) handleView(w http.ResponseWriter, r *http.Request) {
 		Content      string
 		HasContent   bool
 		AddInfo      *SectionAddInfo
+		LinkInfo     *SectionLinkInfo
 	}
 
 	sections := make([]SectionData, 0, len(view.Sections))
@@ -847,7 +854,7 @@ func (a *App) handleView(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// Resolve add info: for sections populated by a traverse from "entry",
+		// Resolve add/link info: for sections populated by a traverse from "entry",
 		// determine which entity types can be created and linked.
 		if sec.Source != "entry" {
 			for _, rule := range view.Traverse {
@@ -891,6 +898,15 @@ func (a *App) handleView(w http.ResponseWriter, r *http.Request) {
 						LinkAs:   linkAs,
 						PeerID:   result.Entry.ID,
 						Targets:  targets,
+					}
+				}
+				// Link existing: always available when candidate types exist
+				if len(candidateTypes) > 0 {
+					sd.LinkInfo = &SectionLinkInfo{
+						Relation:    relName,
+						LinkAs:      linkAs,
+						PeerID:      result.Entry.ID,
+						EntityTypes: candidateTypes,
 					}
 				}
 				break
@@ -1352,6 +1368,126 @@ func (a *App) handleInlineForm(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(sb.String())) //nolint:errcheck // best-effort HTTP response
+}
+
+func (a *App) handleLinkCandidates(w http.ResponseWriter, r *http.Request) {
+	relation := r.URL.Query().Get("relation")
+	linkAs := r.URL.Query().Get("link_as")
+	peerID := r.URL.Query().Get("peer")
+	entityTypesStr := r.URL.Query().Get("entity_types")
+	q := strings.ToLower(r.URL.Query().Get("q"))
+
+	if relation == "" || peerID == "" || entityTypesStr == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Missing required parameters"}) //nolint:errcheck // best-effort JSON response
+		return
+	}
+
+	entityTypes := strings.Split(entityTypesStr, ",")
+
+	// Collect already-linked entity IDs to exclude them
+	alreadyLinked := map[string]bool{}
+	if linkAs == "to" {
+		for _, edge := range a.g.OutgoingEdges(peerID) {
+			if edge.Type == relation {
+				alreadyLinked[edge.To] = true
+			}
+		}
+	} else {
+		for _, edge := range a.g.IncomingEdges(peerID) {
+			if edge.Type == relation {
+				alreadyLinked[edge.From] = true
+			}
+		}
+	}
+
+	type candidate struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+		Type  string `json:"type"`
+	}
+	var candidates []candidate
+	for _, et := range entityTypes {
+		for _, e := range a.g.NodesByType(et) {
+			if alreadyLinked[e.ID] || e.ID == peerID {
+				continue
+			}
+			title := a.entityDisplayTitle(e)
+			if q != "" && !strings.Contains(strings.ToLower(title), q) && !strings.Contains(strings.ToLower(e.ID), q) {
+				continue
+			}
+			candidates = append(candidates, candidate{ID: e.ID, Title: title, Type: e.Type})
+		}
+	}
+	if candidates == nil {
+		candidates = []candidate{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(candidates) //nolint:errcheck // best-effort JSON response
+}
+
+func (a *App) handleLinkExisting(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Method not allowed"}) //nolint:errcheck // best-effort JSON response
+		return
+	}
+	r.ParseForm() //nolint:errcheck // parse errors handled by empty values
+
+	relation := r.FormValue("relation")
+	linkAs := r.FormValue("link_as")
+	peerID := r.FormValue("peer")
+	targetID := r.FormValue("target")
+
+	if relation == "" || linkAs == "" || peerID == "" || targetID == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Missing required parameters"}) //nolint:errcheck // best-effort JSON response
+		return
+	}
+
+	if _, ok := a.meta.GetRelationDef(relation); !ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Unknown relation type"}) //nolint:errcheck // best-effort JSON response
+		return
+	}
+	if _, ok := a.g.GetNode(peerID); !ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Unknown peer entity"}) //nolint:errcheck // best-effort JSON response
+		return
+	}
+	if _, ok := a.g.GetNode(targetID); !ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Unknown target entity"}) //nolint:errcheck // best-effort JSON response
+		return
+	}
+
+	var fromID, toID string
+	if linkAs == "to" {
+		fromID, toID = peerID, targetID
+	} else {
+		fromID, toID = targetID, peerID
+	}
+
+	rel := model.NewRelation(fromID, relation, toID)
+	if err := a.repo.WriteRelation(rel); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()}) //nolint:errcheck // best-effort JSON response
+		return
+	}
+	a.g.AddEdge(rel)
+
+	log.Printf("Linked %s --%s--> %s", fromID, relation, toID)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"ok": "true"}) //nolint:errcheck // best-effort JSON response
 }
 
 func (a *App) handleSearch(w http.ResponseWriter, r *http.Request) {

--- a/internal/dataentry/handlers_test.go
+++ b/internal/dataentry/handlers_test.go
@@ -1,6 +1,7 @@
 package dataentry
 
 import (
+	"encoding/json"
 	"html/template"
 	"net/http"
 	"net/http/httptest"
@@ -445,6 +446,23 @@ func TestHandleView(t *testing.T) {
 			t.Errorf("expected 200, got %d", w.Code)
 		}
 	})
+
+	t.Run("link existing button rendered for traversal section", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		r := httptest.NewRequest(http.MethodGet, "/view/ticket_detail/TKT-001", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleView(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "Link existing") {
+			t.Error("expected 'Link existing' button in view page for traversal section")
+		}
+		if !strings.Contains(body, "openLinkExisting") {
+			t.Error("expected openLinkExisting JS call in view page")
+		}
+	})
 }
 
 func TestHandleSearch(t *testing.T) {
@@ -780,6 +798,168 @@ func TestHandleIndexWithGroupedNav(t *testing.T) {
 		body := w.Body.String()
 		if !strings.Contains(body, "TKT-001") {
 			t.Error("expected list page content")
+		}
+	})
+}
+
+func TestHandleLinkCandidates(t *testing.T) {
+	t.Run("missing params returns 400", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		r := httptest.NewRequest(http.MethodGet, "/api/link-candidates", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleLinkCandidates(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("returns candidates excluding already linked", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		// TKT-001 depends_on TKT-002 (added in newHandlerTestApp)
+		r := httptest.NewRequest(http.MethodGet,
+			"/api/link-candidates?relation=depends_on&link_as=to&peer=TKT-001&entity_types=ticket",
+			http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleLinkCandidates(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var candidates []struct {
+			ID    string `json:"id"`
+			Title string `json:"title"`
+			Type  string `json:"type"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&candidates); err != nil {
+			t.Fatalf("decoding response: %v", err)
+		}
+		// TKT-002 is already linked, TKT-001 is self — expect empty
+		for _, c := range candidates {
+			if c.ID == "TKT-002" {
+				t.Error("TKT-002 should be excluded (already linked)")
+			}
+			if c.ID == "TKT-001" {
+				t.Error("TKT-001 should be excluded (self)")
+			}
+		}
+	})
+
+	t.Run("filters by search query", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		// Add a third ticket
+		e3 := model.NewEntity("TKT-003", "ticket")
+		e3.SetString("title", "Third Ticket")
+		app.g.AddNode(e3)
+
+		r := httptest.NewRequest(http.MethodGet,
+			"/api/link-candidates?relation=depends_on&link_as=to&peer=TKT-001&entity_types=ticket&q=Third",
+			http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleLinkCandidates(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var candidates []struct {
+			ID string `json:"id"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&candidates); err != nil {
+			t.Fatalf("decoding response: %v", err)
+		}
+		if len(candidates) != 1 {
+			t.Fatalf("expected 1 candidate, got %d", len(candidates))
+		}
+		if candidates[0].ID != "TKT-003" {
+			t.Errorf("expected TKT-003, got %s", candidates[0].ID)
+		}
+	})
+
+	t.Run("returns empty array when no candidates", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		r := httptest.NewRequest(http.MethodGet,
+			"/api/link-candidates?relation=depends_on&link_as=to&peer=TKT-001&entity_types=ticket&q=nonexistent",
+			http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleLinkCandidates(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		if strings.TrimSpace(body) != "[]" {
+			t.Errorf("expected empty JSON array, got %s", body)
+		}
+	})
+}
+
+func TestHandleLinkExisting(t *testing.T) {
+	t.Run("method not allowed for GET", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		r := httptest.NewRequest(http.MethodGet, "/api/link-existing", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleLinkExisting(w, r)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", w.Code)
+		}
+	})
+
+	t.Run("missing params returns 400", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		form := url.Values{"relation": {"depends_on"}}
+		r := httptest.NewRequest(http.MethodPost, "/api/link-existing", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		app.handleLinkExisting(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("unknown relation returns 400", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		form := url.Values{
+			"relation": {"nonexistent"},
+			"link_as":  {"to"},
+			"peer":     {"TKT-001"},
+			"target":   {"TKT-002"},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/api/link-existing", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		app.handleLinkExisting(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("unknown peer returns 400", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		form := url.Values{
+			"relation": {"depends_on"},
+			"link_as":  {"to"},
+			"peer":     {"NONEXISTENT"},
+			"target":   {"TKT-002"},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/api/link-existing", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		app.handleLinkExisting(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("unknown target returns 400", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		form := url.Values{
+			"relation": {"depends_on"},
+			"link_as":  {"to"},
+			"peer":     {"TKT-001"},
+			"target":   {"NONEXISTENT"},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/api/link-existing", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		app.handleLinkExisting(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
 		}
 	})
 }

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -34,6 +34,8 @@ func (a *App) NewRouter() http.Handler {
 	inner.HandleFunc("/api/delete", a.handleDelete)
 	inner.HandleFunc("/api/inline-create", a.handleInlineCreate)
 	inner.HandleFunc("/api/inline-form/", a.handleInlineForm)
+	inner.HandleFunc("/api/link-candidates", a.handleLinkCandidates)
+	inner.HandleFunc("/api/link-existing", a.handleLinkExisting)
 	inner.HandleFunc("/graph", a.handleGraph)
 	inner.HandleFunc("/api/graph-data", a.handleGraphData)
 	inner.HandleFunc("/api/ui/toggle-group", a.handleToggleGroup)

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -1289,6 +1289,11 @@ function submitInlineCreate() {
   {{ if .Heading }}
   <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;">
     <h3 class="view-section-heading" style="margin-bottom:0;">{{ .Heading }}</h3>
+    <div style="display:flex;gap:6px;">
+    {{ if .LinkInfo }}
+    {{ $lnk := .LinkInfo }}
+    <button class="btn btn-secondary btn-sm" onclick="openLinkExisting('{{ $lnk.Relation }}','{{ $lnk.LinkAs }}','{{ $lnk.PeerID }}','{{ join $lnk.EntityTypes "," }}','{{ .SectionID }}')">&#128279; Link existing</button>
+    {{ end }}
     {{ if .AddInfo }}
     {{ $info := .AddInfo }}
     {{ $returnTo := printf "%s#%s" $.ReturnTo .SectionID }}
@@ -1311,6 +1316,7 @@ function submitInlineCreate() {
     </details>
     {{ end }}
     {{ end }}
+    </div>
   </div>
   {{ end }}
 
@@ -1550,6 +1556,102 @@ function submitInlineCreate() {
 
 </div>
 {{ end }}
+
+<div id="link-existing-modal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)closeLinkExisting()">
+  <div class="modal" style="width:520px;">
+    <div class="modal-header">
+      <h3>Link Existing</h3>
+      <button class="modal-close" onclick="closeLinkExisting()">&times;</button>
+    </div>
+    <div class="modal-body" style="padding:12px 20px;">
+      <input type="text" id="link-existing-search" class="search-input" placeholder="Search..." autocomplete="off"
+             style="margin-bottom:12px;" oninput="searchLinkCandidates()">
+      <div id="link-existing-results" style="max-height:320px;overflow-y:auto;"></div>
+    </div>
+  </div>
+</div>
+
+<script>
+(function() {
+  var _leRelation = '', _leLinkAs = '', _lePeer = '', _leEntityTypes = '', _leSectionID = '';
+  var _leDebounce = null;
+
+  window.openLinkExisting = function(relation, linkAs, peer, entityTypes, sectionID) {
+    _leRelation = relation;
+    _leLinkAs = linkAs;
+    _lePeer = peer;
+    _leEntityTypes = entityTypes;
+    _leSectionID = sectionID;
+    document.getElementById('link-existing-search').value = '';
+    document.getElementById('link-existing-results').innerHTML = '<p style="color:var(--text-muted);text-align:center;">Loading...</p>';
+    document.getElementById('link-existing-modal').style.display = 'flex';
+    searchLinkCandidates();
+    setTimeout(function() { document.getElementById('link-existing-search').focus(); }, 100);
+  };
+
+  window.closeLinkExisting = function() {
+    document.getElementById('link-existing-modal').style.display = 'none';
+    document.getElementById('link-existing-results').innerHTML = '';
+  };
+
+  window.searchLinkCandidates = function() {
+    clearTimeout(_leDebounce);
+    _leDebounce = setTimeout(function() {
+      var q = document.getElementById('link-existing-search').value;
+      var url = '/api/link-candidates?relation=' + encodeURIComponent(_leRelation) +
+        '&link_as=' + encodeURIComponent(_leLinkAs) +
+        '&peer=' + encodeURIComponent(_lePeer) +
+        '&entity_types=' + encodeURIComponent(_leEntityTypes) +
+        '&q=' + encodeURIComponent(q);
+      fetch(url)
+        .then(function(r) { return r.json(); })
+        .then(function(candidates) {
+          var container = document.getElementById('link-existing-results');
+          if (candidates.length === 0) {
+            container.innerHTML = '<p style="color:var(--text-muted);text-align:center;padding:16px 0;">No candidates found</p>';
+            return;
+          }
+          var html = '<div style="display:flex;flex-direction:column;gap:4px;">';
+          candidates.forEach(function(c) {
+            html += '<div style="display:flex;align-items:center;justify-content:space-between;padding:8px 12px;border:1px solid var(--border);border-radius:6px;cursor:pointer;" ' +
+              'onmouseenter="this.style.background=\'var(--primary-light)\'" onmouseleave="this.style.background=\'\'">' +
+              '<div>' +
+              '<div style="font-weight:500;font-size:14px;">' + escHTML(c.title) + '</div>' +
+              '<div style="font-size:11px;color:var(--text-muted);font-family:var(--font-mono);">' + escHTML(c.id) + ' &middot; ' + escHTML(c.type) + '</div>' +
+              '</div>' +
+              '<button class="btn btn-primary btn-sm" onclick="event.stopPropagation();doLinkExisting(\'' + escAttr(c.id) + '\')">Link</button>' +
+              '</div>';
+          });
+          html += '</div>';
+          container.innerHTML = html;
+        })
+        .catch(function() {
+          document.getElementById('link-existing-results').innerHTML = '<p style="color:var(--danger);text-align:center;">Failed to load candidates.</p>';
+        });
+    }, 200);
+  };
+
+  window.doLinkExisting = function(targetID) {
+    var formData = new FormData();
+    formData.append('relation', _leRelation);
+    formData.append('link_as', _leLinkAs);
+    formData.append('peer', _lePeer);
+    formData.append('target', targetID);
+    fetch('/api/link-existing', { method: 'POST', body: formData })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (data.error) { alert('Error: ' + data.error); return; }
+        closeLinkExisting();
+        // Reload the current view to reflect the new link
+        window.location.reload();
+      })
+      .catch(function(e) { alert('Error linking: ' + e); });
+  };
+
+  function escHTML(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+  function escAttr(s) { return s.replace(/'/g, "\\'").replace(/"/g, '&quot;'); }
+})();
+</script>
 {{- end -}}
 
 {{- define "search-page" -}}


### PR DESCRIPTION
## Summary
- View sections populated by traversal rules now show a "Link existing" button alongside the existing "Add" button
- Clicking it opens a searchable modal listing candidate entities of the valid target types, excluding already-linked entities and the entry itself
- Selecting a candidate creates the relation file on disk and reloads the view
- Two new API endpoints: `GET /api/link-candidates` (filterable JSON candidates) and `POST /api/link-existing` (creates a relation between existing entities)

## Test plan
- [x] Unit tests for `handleLinkCandidates` (missing params, exclusion of already-linked, search filtering, empty results)
- [x] Unit tests for `handleLinkExisting` (method validation, unknown relation/peer/target)
- [x] Unit test verifying "Link existing" button renders in view sections with traversal rules
- [x] QA tested against example project: button visibility, candidate API, link creation, dynamic exclusion, view updates
- [ ] Manual browser test: modal open/close, search debounce, link button click, page reload