### PR TITLE
Rename cardinality fields from source/target to outgoing/incoming

### DIFF
--- a/docs-project/entities/guide/GUIDE-concepts.md
+++ b/docs-project/entities/guide/GUIDE-concepts.md
@@ -205,7 +205,7 @@ relations:
   addresses:
     from: [decision]
     to: [requirement]
-    target_min: 1  # Every requirement must be addressed by at least one decision
+    min_incoming: 1  # Every requirement must be addressed by at least one decision
 ```
 
 Check constraints with:
@@ -214,7 +214,7 @@ Check constraints with:
 rela analyze cardinality
 ```
 
-This checks all `source_min`, `source_max`, `target_min`, and `target_max`
+This checks all `min_outgoing`, `max_outgoing`, `min_incoming`, and `max_incoming`
 constraints defined on relations.
 
 ### Orphan Detection
@@ -272,7 +272,7 @@ entity should have:
 rela analyze cardinality
 ```
 
-For example, if the metamodel specifies `source_min: 1` for `addresses`, every
+For example, if the metamodel specifies `min_outgoing: 1` for `addresses`, every
 decision must address at least one requirement.
 
 ## Best Practices

--- a/docs-project/entities/guide/GUIDE-metamodel.md
+++ b/docs-project/entities/guide/GUIDE-metamodel.md
@@ -345,18 +345,18 @@ properties:
 
 Relations define how entity types can be connected:
 
-| Field         | Description                                    |
-| ------------- | ---------------------------------------------- |
-| `label`       | Display name                                   |
-| `description` | Explanation of the relation's meaning          |
-| `from`        | Source entity types (list)                     |
-| `to`          | Target entity types (list)                     |
-| `inverse`     | Inverse relation definition (string or object) |
-| `symmetric`   | `true` if relation is bidirectional            |
-| `source_min`  | Minimum outgoing relations per source entity   |
-| `source_max`  | Maximum outgoing relations per source entity   |
-| `target_min`  | Minimum incoming relations per target entity   |
-| `target_max`  | Maximum incoming relations per target entity   |
+| Field            | Description                                        |
+| ---------------- | -------------------------------------------------- |
+| `label`          | Display name                                       |
+| `description`    | Explanation of the relation's meaning              |
+| `from`           | Source entity types (list)                         |
+| `to`             | Target entity types (list)                         |
+| `inverse`        | Inverse relation definition (string or object)     |
+| `symmetric`      | `true` if relation is bidirectional                |
+| `min_outgoing`   | Minimum outgoing relations per from-side entity    |
+| `max_outgoing`   | Maximum outgoing relations per from-side entity    |
+| `min_incoming`   | Minimum incoming relations per to-side entity      |
+| `max_incoming`   | Maximum incoming relations per to-side entity      |
 
 ### Example Relation
 
@@ -367,7 +367,7 @@ relations:
     description: A decision addresses a requirement
     from: [decision]
     to: [requirement]
-    source_min: 1 # Each decision must address at least one requirement
+    min_outgoing: 1 # Each decision must address at least one requirement
     inverse: addressedBy # Simple form - label auto-derived as "addressed by"
 ```
 
@@ -404,8 +404,8 @@ relations:
     label: implements
     from: [solution]
     to: [decision]
-    source_min: 1 # Every solution must implement at least one decision
-    target_max: 1 # Each decision can only be implemented by one solution
+    min_outgoing: 1 # Every solution must implement at least one decision
+    max_incoming: 1 # Each decision can only be implemented by one solution
 ```
 
 Check violations with:

--- a/docs-project/entities/scenario/SCN-devops-runbooks.md
+++ b/docs-project/entities/scenario/SCN-devops-runbooks.md
@@ -336,7 +336,7 @@ relations:
     description: A runbook remediates a failure mode
     from: [runbook]
     to: [failure_mode]
-    source_min: 1 # Every runbook must address at least one failure mode
+    min_outgoing: 1 # Every runbook must address at least one failure mode
     inverse: remediatedBy
 
   linkedToAlert:
@@ -344,7 +344,7 @@ relations:
     description: An alert links to a runbook
     from: [alert]
     to: [runbook]
-    source_min: 1 # Every alert should have a runbook
+    min_outgoing: 1 # Every alert should have a runbook
     inverse: triggeredBy
 
   operatesOn:

--- a/docs-project/entities/scenario/SCN-iso27001-isms.md
+++ b/docs-project/entities/scenario/SCN-iso27001-isms.md
@@ -264,7 +264,7 @@ relations:
     description: A risk is treated by a control
     from: [risk]
     to: [control]
-    source_min: 1 # Every risk must have at least one treatment
+    min_outgoing: 1 # Every risk must have at least one treatment
     inverse: treats
 
   # Control relationships
@@ -310,7 +310,7 @@ relations:
     description: A nonconformity is addressed by a corrective action
     from: [nonconformity]
     to: [corrective_action]
-    source_min: 1 # Every NC must have at least one CA
+    min_outgoing: 1 # Every NC must have at least one CA
     inverse: addresses
 
   # Cross-references

--- a/docs-project/entities/scenario/SCN-project-management.md
+++ b/docs-project/entities/scenario/SCN-project-management.md
@@ -479,7 +479,7 @@ relations:
     description: A goal or feature is owned by a stakeholder
     from: [goal, feature, epic]
     to: [stakeholder]
-    target_max: 1 # Each item has one owner
+    max_incoming: 1 # Each item has one owner
     inverse: owns
 
   interestedIn:

--- a/docs-project/entities/tutorial/TUT-iso27001-isms-tutorial.md
+++ b/docs-project/entities/tutorial/TUT-iso27001-isms-tutorial.md
@@ -251,7 +251,7 @@ relations:
     description: A risk is treated by a control
     from: [risk]
     to: [control]
-    source_min: 1
+    min_outgoing: 1
     inverse: treats
 
   implementedBy:
@@ -294,7 +294,7 @@ relations:
     description: A nonconformity is addressed by a corrective action
     from: [nonconformity]
     to: [corrective_action]
-    source_min: 1
+    min_outgoing: 1
     inverse: addresses
 
   relatesTo:

--- a/docs-project/entities/tutorial/TUT-project-management-tutorial.md
+++ b/docs-project/entities/tutorial/TUT-project-management-tutorial.md
@@ -461,7 +461,7 @@ relations:
     description: A goal or feature is owned by a stakeholder
     from: [goal, feature, epic]
     to: [stakeholder]
-    target_max: 1
+    max_incoming: 1
     inverse: owns
 
   interestedIn:

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -197,7 +197,7 @@ relations:
   addresses:
     from: [decision]
     to: [requirement]
-    target_min: 1  # Every requirement must be addressed by at least one decision
+    min_incoming: 1  # Every requirement must be addressed by at least one decision
 ```
 
 Check constraints with:
@@ -206,7 +206,7 @@ Check constraints with:
 rela analyze cardinality
 ```
 
-This checks all `source_min`, `source_max`, `target_min`, and `target_max`
+This checks all `min_outgoing`, `max_outgoing`, `min_incoming`, and `max_incoming`
 constraints defined on relations.
 
 ### Orphan Detection
@@ -264,7 +264,7 @@ entity should have:
 rela analyze cardinality
 ```
 
-For example, if the metamodel specifies `source_min: 1` for `addresses`, every
+For example, if the metamodel specifies `min_outgoing: 1` for `addresses`, every
 decision must address at least one requirement.
 
 ## Best Practices

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -337,18 +337,18 @@ properties:
 
 Relations define how entity types can be connected:
 
-| Field         | Description                                    |
-| ------------- | ---------------------------------------------- |
-| `label`       | Display name                                   |
-| `description` | Explanation of the relation's meaning          |
-| `from`        | Source entity types (list)                     |
-| `to`          | Target entity types (list)                     |
-| `inverse`     | Inverse relation definition (string or object) |
-| `symmetric`   | `true` if relation is bidirectional            |
-| `source_min`  | Minimum outgoing relations per source entity   |
-| `source_max`  | Maximum outgoing relations per source entity   |
-| `target_min`  | Minimum incoming relations per target entity   |
-| `target_max`  | Maximum incoming relations per target entity   |
+| Field            | Description                                        |
+| ---------------- | -------------------------------------------------- |
+| `label`          | Display name                                       |
+| `description`    | Explanation of the relation's meaning              |
+| `from`           | Source entity types (list)                         |
+| `to`             | Target entity types (list)                         |
+| `inverse`        | Inverse relation definition (string or object)     |
+| `symmetric`      | `true` if relation is bidirectional                |
+| `min_outgoing`   | Minimum outgoing relations per from-side entity    |
+| `max_outgoing`   | Maximum outgoing relations per from-side entity    |
+| `min_incoming`   | Minimum incoming relations per to-side entity      |
+| `max_incoming`   | Maximum incoming relations per to-side entity      |
 
 ### Example Relation
 
@@ -359,7 +359,7 @@ relations:
     description: A decision addresses a requirement
     from: [decision]
     to: [requirement]
-    source_min: 1 # Each decision must address at least one requirement
+    min_outgoing: 1 # Each decision must address at least one requirement
     inverse: addressedBy # Simple form - label auto-derived as "addressed by"
 ```
 
@@ -396,8 +396,8 @@ relations:
     label: implements
     from: [solution]
     to: [decision]
-    source_min: 1 # Every solution must implement at least one decision
-    target_max: 1 # Each decision can only be implemented by one solution
+    min_outgoing: 1 # Every solution must implement at least one decision
+    max_incoming: 1 # Each decision can only be implemented by one solution
 ```
 
 Check violations with:

--- a/docs/scenarios/devops-runbooks.md
+++ b/docs/scenarios/devops-runbooks.md
@@ -329,7 +329,7 @@ relations:
     description: A runbook remediates a failure mode
     from: [runbook]
     to: [failure_mode]
-    source_min: 1 # Every runbook must address at least one failure mode
+    min_outgoing: 1 # Every runbook must address at least one failure mode
     inverse: remediatedBy
 
   linkedToAlert:
@@ -337,7 +337,7 @@ relations:
     description: An alert links to a runbook
     from: [alert]
     to: [runbook]
-    source_min: 1 # Every alert should have a runbook
+    min_outgoing: 1 # Every alert should have a runbook
     inverse: triggeredBy
 
   operatesOn:

--- a/docs/scenarios/iso27001-isms.md
+++ b/docs/scenarios/iso27001-isms.md
@@ -257,7 +257,7 @@ relations:
     description: A risk is treated by a control
     from: [risk]
     to: [control]
-    source_min: 1 # Every risk must have at least one treatment
+    min_outgoing: 1 # Every risk must have at least one treatment
     inverse: treats
 
   # Control relationships
@@ -303,7 +303,7 @@ relations:
     description: A nonconformity is addressed by a corrective action
     from: [nonconformity]
     to: [corrective_action]
-    source_min: 1 # Every NC must have at least one CA
+    min_outgoing: 1 # Every NC must have at least one CA
     inverse: addresses
 
   # Cross-references

--- a/docs/scenarios/project-management.md
+++ b/docs/scenarios/project-management.md
@@ -472,7 +472,7 @@ relations:
     description: A goal or feature is owned by a stakeholder
     from: [goal, feature, epic]
     to: [stakeholder]
-    target_max: 1 # Each item has one owner
+    max_incoming: 1 # Each item has one owner
     inverse: owns
 
   interestedIn:

--- a/docs/tutorials/iso27001-isms-tutorial.md
+++ b/docs/tutorials/iso27001-isms-tutorial.md
@@ -244,7 +244,7 @@ relations:
     description: A risk is treated by a control
     from: [risk]
     to: [control]
-    source_min: 1
+    min_outgoing: 1
     inverse: treats
 
   implementedBy:
@@ -287,7 +287,7 @@ relations:
     description: A nonconformity is addressed by a corrective action
     from: [nonconformity]
     to: [corrective_action]
-    source_min: 1
+    min_outgoing: 1
     inverse: addresses
 
   relatesTo:

--- a/docs/tutorials/project-management-tutorial.md
+++ b/docs/tutorials/project-management-tutorial.md
@@ -454,7 +454,7 @@ relations:
     description: A goal or feature is owned by a stakeholder
     from: [goal, feature, epic]
     to: [stakeholder]
-    target_max: 1
+    max_incoming: 1
     inverse: owns
 
   interestedIn:

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -162,9 +162,9 @@ var analyzeCardinalityCmd = &cobra.Command{
 		violations := 0
 
 		for relName, relDef := range meta.Relations {
-			// Check source_min constraint
-			if relDef.SourceMin != nil && *relDef.SourceMin > 0 {
-				// For each entity type in From, check they have at least SourceMin outgoing relations
+			// Check min_outgoing constraint
+			if relDef.MinOutgoing != nil && *relDef.MinOutgoing > 0 {
+				// For each entity type in From, check they have at least MinOutgoing outgoing relations of this type
 				for _, sourceType := range relDef.From {
 					entities := g.NodesByType(sourceType)
 					for _, e := range entities {
@@ -174,17 +174,17 @@ var analyzeCardinalityCmd = &cobra.Command{
 								count++
 							}
 						}
-						if count < *relDef.SourceMin {
+						if count < *relDef.MinOutgoing {
 							out.WriteWarning("%s must have at least %d '%s' relation(s), has %d",
-								e.ID, *relDef.SourceMin, relName, count)
+								e.ID, *relDef.MinOutgoing, relName, count)
 							violations++
 						}
 					}
 				}
 			}
 
-			// Check source_max constraint
-			if relDef.SourceMax != nil {
+			// Check max_outgoing constraint
+			if relDef.MaxOutgoing != nil {
 				for _, sourceType := range relDef.From {
 					entities := g.NodesByType(sourceType)
 					for _, e := range entities {
@@ -194,18 +194,18 @@ var analyzeCardinalityCmd = &cobra.Command{
 								count++
 							}
 						}
-						if count > *relDef.SourceMax {
+						if count > *relDef.MaxOutgoing {
 							out.WriteWarning("%s has more than %d '%s' relation(s): %d",
-								e.ID, *relDef.SourceMax, relName, count)
+								e.ID, *relDef.MaxOutgoing, relName, count)
 							violations++
 						}
 					}
 				}
 			}
 
-			// Check target_min constraint
-			// For each entity type in To, check they have at least TargetMin incoming relations of this type
-			if relDef.TargetMin != nil && *relDef.TargetMin > 0 {
+			// Check min_incoming constraint
+			// For each entity type in To, check they have at least MinIncoming incoming relations of this type
+			if relDef.MinIncoming != nil && *relDef.MinIncoming > 0 {
 				for _, targetType := range relDef.To {
 					entities := g.NodesByType(targetType)
 					for _, e := range entities {
@@ -215,22 +215,22 @@ var analyzeCardinalityCmd = &cobra.Command{
 								count++
 							}
 						}
-						if count < *relDef.TargetMin {
+						if count < *relDef.MinIncoming {
 							// Get the inverse relation name for the message if available
 							relLabel := relName
 							if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
 								relLabel = relDef.Inverse.GetID()
 							}
 							out.WriteWarning("%s must have at least %d '%s' relation(s), has %d",
-								e.ID, *relDef.TargetMin, relLabel, count)
+								e.ID, *relDef.MinIncoming, relLabel, count)
 							violations++
 						}
 					}
 				}
 			}
 
-			// Check target_max constraint
-			if relDef.TargetMax != nil {
+			// Check max_incoming constraint
+			if relDef.MaxIncoming != nil {
 				for _, targetType := range relDef.To {
 					entities := g.NodesByType(targetType)
 					for _, e := range entities {
@@ -240,14 +240,14 @@ var analyzeCardinalityCmd = &cobra.Command{
 								count++
 							}
 						}
-						if count > *relDef.TargetMax {
+						if count > *relDef.MaxIncoming {
 							// Get the inverse relation name for the message if available
 							relLabel := relName
 							if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
 								relLabel = relDef.Inverse.GetID()
 							}
 							out.WriteWarning("%s has more than %d '%s' relation(s): %d",
-								e.ID, *relDef.TargetMax, relLabel, count)
+								e.ID, *relDef.MaxIncoming, relLabel, count)
 							violations++
 						}
 					}
@@ -509,23 +509,23 @@ func countValidationIssues() (errors, warnings int) {
 func countCardinalityViolations() int {
 	violations := 0
 	for relName, relDef := range meta.Relations {
-		violations += countSourceMinViolations(relName, relDef)
-		violations += countSourceMaxViolations(relName, relDef)
-		violations += countTargetMinViolations(relName, relDef)
-		violations += countTargetMaxViolations(relName, relDef)
+		violations += countMinOutgoingViolations(relName, relDef)
+		violations += countMaxOutgoingViolations(relName, relDef)
+		violations += countMinIncomingViolations(relName, relDef)
+		violations += countMaxIncomingViolations(relName, relDef)
 	}
 	return violations
 }
 
-// countSourceMinViolations checks source_min constraint violations
-func countSourceMinViolations(relName string, relDef metamodel.RelationDef) int {
-	if relDef.SourceMin == nil || *relDef.SourceMin == 0 {
+// countMinOutgoingViolations checks min_outgoing constraint violations
+func countMinOutgoingViolations(relName string, relDef metamodel.RelationDef) int {
+	if relDef.MinOutgoing == nil || *relDef.MinOutgoing == 0 {
 		return 0
 	}
 	violations := 0
 	for _, sourceType := range relDef.From {
 		for _, e := range g.NodesByType(sourceType) {
-			if countOutgoingByType(e.ID, relName) < *relDef.SourceMin {
+			if countOutgoingByType(e.ID, relName) < *relDef.MinOutgoing {
 				violations++
 			}
 		}
@@ -533,15 +533,15 @@ func countSourceMinViolations(relName string, relDef metamodel.RelationDef) int 
 	return violations
 }
 
-// countSourceMaxViolations checks source_max constraint violations
-func countSourceMaxViolations(relName string, relDef metamodel.RelationDef) int {
-	if relDef.SourceMax == nil {
+// countMaxOutgoingViolations checks max_outgoing constraint violations
+func countMaxOutgoingViolations(relName string, relDef metamodel.RelationDef) int {
+	if relDef.MaxOutgoing == nil {
 		return 0
 	}
 	violations := 0
 	for _, sourceType := range relDef.From {
 		for _, e := range g.NodesByType(sourceType) {
-			if countOutgoingByType(e.ID, relName) > *relDef.SourceMax {
+			if countOutgoingByType(e.ID, relName) > *relDef.MaxOutgoing {
 				violations++
 			}
 		}
@@ -549,15 +549,15 @@ func countSourceMaxViolations(relName string, relDef metamodel.RelationDef) int 
 	return violations
 }
 
-// countTargetMinViolations checks target_min constraint violations
-func countTargetMinViolations(relName string, relDef metamodel.RelationDef) int {
-	if relDef.TargetMin == nil || *relDef.TargetMin == 0 {
+// countMinIncomingViolations checks min_incoming constraint violations
+func countMinIncomingViolations(relName string, relDef metamodel.RelationDef) int {
+	if relDef.MinIncoming == nil || *relDef.MinIncoming == 0 {
 		return 0
 	}
 	violations := 0
 	for _, targetType := range relDef.To {
 		for _, e := range g.NodesByType(targetType) {
-			if countIncomingByType(e.ID, relName) < *relDef.TargetMin {
+			if countIncomingByType(e.ID, relName) < *relDef.MinIncoming {
 				violations++
 			}
 		}
@@ -565,15 +565,15 @@ func countTargetMinViolations(relName string, relDef metamodel.RelationDef) int 
 	return violations
 }
 
-// countTargetMaxViolations checks target_max constraint violations
-func countTargetMaxViolations(relName string, relDef metamodel.RelationDef) int {
-	if relDef.TargetMax == nil {
+// countMaxIncomingViolations checks max_incoming constraint violations
+func countMaxIncomingViolations(relName string, relDef metamodel.RelationDef) int {
+	if relDef.MaxIncoming == nil {
 		return 0
 	}
 	violations := 0
 	for _, targetType := range relDef.To {
 		for _, e := range g.NodesByType(targetType) {
-			if countIncomingByType(e.ID, relName) > *relDef.TargetMax {
+			if countIncomingByType(e.ID, relName) > *relDef.MaxIncoming {
 				violations++
 			}
 		}

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -240,17 +240,17 @@ func runSchemaRelations() error {
 
 		// Cardinality constraints
 		cardParts := []string{}
-		if def.SourceMin != nil {
-			cardParts = append(cardParts, fmt.Sprintf("source_min=%d", *def.SourceMin))
+		if def.MinOutgoing != nil {
+			cardParts = append(cardParts, fmt.Sprintf("min_outgoing=%d", *def.MinOutgoing))
 		}
-		if def.SourceMax != nil {
-			cardParts = append(cardParts, fmt.Sprintf("source_max=%d", *def.SourceMax))
+		if def.MaxOutgoing != nil {
+			cardParts = append(cardParts, fmt.Sprintf("max_outgoing=%d", *def.MaxOutgoing))
 		}
-		if def.TargetMin != nil {
-			cardParts = append(cardParts, fmt.Sprintf("target_min=%d", *def.TargetMin))
+		if def.MinIncoming != nil {
+			cardParts = append(cardParts, fmt.Sprintf("min_incoming=%d", *def.MinIncoming))
 		}
-		if def.TargetMax != nil {
-			cardParts = append(cardParts, fmt.Sprintf("target_max=%d", *def.TargetMax))
+		if def.MaxIncoming != nil {
+			cardParts = append(cardParts, fmt.Sprintf("max_incoming=%d", *def.MaxIncoming))
 		}
 		if len(cardParts) > 0 {
 			out.WriteMessage("  Cardinality: %s", strings.Join(cardParts, ", "))
@@ -450,20 +450,20 @@ func runSchemaRelation(name string) error {
 	}
 
 	// Cardinality constraints
-	if def.SourceMin != nil || def.SourceMax != nil || def.TargetMin != nil || def.TargetMax != nil {
+	if def.MinOutgoing != nil || def.MaxOutgoing != nil || def.MinIncoming != nil || def.MaxIncoming != nil {
 		out.WriteMessage("")
 		out.WriteMessage("Cardinality Constraints:")
-		if def.SourceMin != nil {
-			out.WriteMessage("  Source Min: %d", *def.SourceMin)
+		if def.MinOutgoing != nil {
+			out.WriteMessage("  Min Outgoing: %d", *def.MinOutgoing)
 		}
-		if def.SourceMax != nil {
-			out.WriteMessage("  Source Max: %d", *def.SourceMax)
+		if def.MaxOutgoing != nil {
+			out.WriteMessage("  Max Outgoing: %d", *def.MaxOutgoing)
 		}
-		if def.TargetMin != nil {
-			out.WriteMessage("  Target Min: %d", *def.TargetMin)
+		if def.MinIncoming != nil {
+			out.WriteMessage("  Min Incoming: %d", *def.MinIncoming)
 		}
-		if def.TargetMax != nil {
-			out.WriteMessage("  Target Max: %d", *def.TargetMax)
+		if def.MaxIncoming != nil {
+			out.WriteMessage("  Max Incoming: %d", *def.MaxIncoming)
 		}
 	}
 
@@ -598,17 +598,17 @@ func buildConstraintLabel(relDef metamodel.RelationDef) string {
 }
 
 func formatCardinality(relDef metamodel.RelationDef) string {
-	// Format: source[min..max] -> target[min..max]
+	// Format: out[min..max] in[min..max]
 	var parts []string
 
-	sourceCard := formatCardinalityRange(relDef.SourceMin, relDef.SourceMax)
-	if sourceCard != "" {
-		parts = append(parts, "src:"+sourceCard)
+	outCard := formatCardinalityRange(relDef.MinOutgoing, relDef.MaxOutgoing)
+	if outCard != "" {
+		parts = append(parts, "out:"+outCard)
 	}
 
-	targetCard := formatCardinalityRange(relDef.TargetMin, relDef.TargetMax)
-	if targetCard != "" {
-		parts = append(parts, "tgt:"+targetCard)
+	inCard := formatCardinalityRange(relDef.MinIncoming, relDef.MaxIncoming)
+	if inCard != "" {
+		parts = append(parts, "in:"+inCard)
 	}
 
 	return strings.Join(parts, " ")

--- a/internal/cli/schema_test.go
+++ b/internal/cli/schema_test.go
@@ -565,11 +565,11 @@ func TestSchemaWithCardinality(t *testing.T) {
 		},
 		Relations: map[string]metamodel.RelationDef{
 			"links": {
-				Label:     "links",
-				From:      []string{"entity1"},
-				To:        []string{"entity2"},
-				SourceMin: &sourceMin,
-				SourceMax: &sourceMax,
+				Label:       "links",
+				From:        []string{"entity1"},
+				To:          []string{"entity2"},
+				MinOutgoing: &sourceMin,
+				MaxOutgoing: &sourceMax,
 			},
 		},
 	}
@@ -588,11 +588,11 @@ func TestSchemaWithCardinality(t *testing.T) {
 	if !strings.Contains(result, "Cardinality:") {
 		t.Errorf("expected 'Cardinality:' in output, got: %s", result)
 	}
-	if !strings.Contains(result, "source_min=1") {
-		t.Errorf("expected 'source_min=1' in output, got: %s", result)
+	if !strings.Contains(result, "min_outgoing=1") {
+		t.Errorf("expected 'min_outgoing=1' in output, got: %s", result)
 	}
-	if !strings.Contains(result, "source_max=5") {
-		t.Errorf("expected 'source_max=5' in output, got: %s", result)
+	if !strings.Contains(result, "max_outgoing=5") {
+		t.Errorf("expected 'max_outgoing=5' in output, got: %s", result)
 	}
 }
 
@@ -736,11 +736,11 @@ func TestSchemaGraphvizWithConstraints(t *testing.T) {
 		},
 		Relations: map[string]metamodel.RelationDef{
 			"links": {
-				Label:     "links to",
-				From:      []string{"source"},
-				To:        []string{"target"},
-				SourceMin: &sourceMin,
-				TargetMax: &targetMax,
+				Label:       "links to",
+				From:        []string{"source"},
+				To:          []string{"target"},
+				MinOutgoing: &sourceMin,
+				MaxIncoming: &targetMax,
 			},
 		},
 	}
@@ -758,11 +758,11 @@ func TestSchemaGraphvizWithConstraints(t *testing.T) {
 	})
 
 	// Check for cardinality in label
-	if !strings.Contains(result, "src:1..*") {
-		t.Errorf("expected 'src:1..*' cardinality in output, got: %s", result)
+	if !strings.Contains(result, "out:1..*") {
+		t.Errorf("expected 'out:1..*' cardinality in output, got: %s", result)
 	}
-	if !strings.Contains(result, "tgt:0..1") {
-		t.Errorf("expected 'tgt:0..1' cardinality in output, got: %s", result)
+	if !strings.Contains(result, "in:0..1") {
+		t.Errorf("expected 'in:0..1' cardinality in output, got: %s", result)
 	}
 }
 
@@ -865,53 +865,53 @@ func TestSchemaGraphvizMultipleFromTo(t *testing.T) {
 
 func TestFormatCardinality(t *testing.T) {
 	tests := []struct {
-		name      string
-		sourceMin *int
-		sourceMax *int
-		targetMin *int
-		targetMax *int
-		expected  string
+		name        string
+		minOutgoing *int
+		maxOutgoing *int
+		minIncoming *int
+		maxIncoming *int
+		expected    string
 	}{
 		{
 			name:     "no constraints",
 			expected: "",
 		},
 		{
-			name:      "source min only",
-			sourceMin: intPtr(1),
-			expected:  "src:1..*",
+			name:        "min outgoing only",
+			minOutgoing: intPtr(1),
+			expected:    "out:1..*",
 		},
 		{
-			name:      "source max only",
-			sourceMax: intPtr(5),
-			expected:  "src:0..5",
+			name:        "max outgoing only",
+			maxOutgoing: intPtr(5),
+			expected:    "out:0..5",
 		},
 		{
-			name:      "source min and max same",
-			sourceMin: intPtr(1),
-			sourceMax: intPtr(1),
-			expected:  "src:1",
+			name:        "min and max outgoing same",
+			minOutgoing: intPtr(1),
+			maxOutgoing: intPtr(1),
+			expected:    "out:1",
 		},
 		{
-			name:      "target min only",
-			targetMin: intPtr(1),
-			expected:  "tgt:1..*",
+			name:        "min incoming only",
+			minIncoming: intPtr(1),
+			expected:    "in:1..*",
 		},
 		{
-			name:      "both source and target",
-			sourceMin: intPtr(1),
-			targetMax: intPtr(1),
-			expected:  "src:1..* tgt:0..1",
+			name:        "both outgoing and incoming",
+			minOutgoing: intPtr(1),
+			maxIncoming: intPtr(1),
+			expected:    "out:1..* in:0..1",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			relDef := metamodel.RelationDef{
-				SourceMin: tt.sourceMin,
-				SourceMax: tt.sourceMax,
-				TargetMin: tt.targetMin,
-				TargetMax: tt.targetMax,
+				MinOutgoing: tt.minOutgoing,
+				MaxOutgoing: tt.maxOutgoing,
+				MinIncoming: tt.minIncoming,
+				MaxIncoming: tt.maxIncoming,
 			}
 			result := formatCardinality(relDef)
 			if result != tt.expected {

--- a/internal/mcp/tools_analysis.go
+++ b/internal/mcp/tools_analysis.go
@@ -73,13 +73,13 @@ func (s *Server) checkCardinalityForRelation(
 ) []cardinalityViolation {
 	var violations []cardinalityViolation
 
-	// Check source constraints (outgoing edges from source types)
+	// Check outgoing constraints (from-side: outgoing edges from source types)
 	violations = append(violations,
-		s.checkCardinalityBound(relName, relDef.From, relDef.SourceMin, relDef.SourceMax, true)...)
+		s.checkCardinalityBound(relName, relDef.From, relDef.MinOutgoing, relDef.MaxOutgoing, true)...)
 
-	// Check target constraints (incoming edges to target types)
+	// Check incoming constraints (to-side: incoming edges to target types)
 	violations = append(violations,
-		s.checkCardinalityBound(relName, relDef.To, relDef.TargetMin, relDef.TargetMax, false)...)
+		s.checkCardinalityBound(relName, relDef.To, relDef.MinIncoming, relDef.MaxIncoming, false)...)
 
 	return violations
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -525,9 +525,9 @@ func TestHandleAnalyzeCardinality_WithViolation(t *testing.T) {
 	// Set a minimum cardinality that won't be met
 	minVal := 5
 	s.meta.Relations["addresses"] = metamodel.RelationDef{
-		From:      []string{"decision"},
-		To:        []string{"requirement"},
-		SourceMin: &minVal,
+		From:        []string{"decision"},
+		To:          []string{"requirement"},
+		MinOutgoing: &minVal,
 	}
 	result, err := s.handleAnalyzeCardinality(context.Background(), mcp.CallToolRequest{})
 	if err != nil {

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -143,10 +143,10 @@ type RelationDef struct {
 	To          []string    `yaml:"to"`
 	Inverse     *InverseDef `yaml:"inverse,omitempty"`
 	Symmetric   bool        `yaml:"symmetric,omitempty"`
-	SourceMin   *int        `yaml:"source_min,omitempty"`
-	SourceMax   *int        `yaml:"source_max,omitempty"`
-	TargetMin   *int        `yaml:"target_min,omitempty"`
-	TargetMax   *int        `yaml:"target_max,omitempty"`
+	MinOutgoing *int        `yaml:"min_outgoing,omitempty"`
+	MaxOutgoing *int        `yaml:"max_outgoing,omitempty"`
+	MinIncoming *int        `yaml:"min_incoming,omitempty"`
+	MaxIncoming *int        `yaml:"max_incoming,omitempty"`
 }
 
 // InverseDef defines the inverse of a relation.
@@ -702,22 +702,22 @@ func (r *RelationDef) IsSymmetric() bool {
 	return r.Symmetric
 }
 
-// GetSourceMin returns the source minimum cardinality
-func (r *RelationDef) GetSourceMin() *int {
-	return r.SourceMin
+// GetMinOutgoing returns the minimum outgoing cardinality (from-side constraint)
+func (r *RelationDef) GetMinOutgoing() *int {
+	return r.MinOutgoing
 }
 
-// GetSourceMax returns the source maximum cardinality
-func (r *RelationDef) GetSourceMax() *int {
-	return r.SourceMax
+// GetMaxOutgoing returns the maximum outgoing cardinality (from-side constraint)
+func (r *RelationDef) GetMaxOutgoing() *int {
+	return r.MaxOutgoing
 }
 
-// GetTargetMin returns the target minimum cardinality
-func (r *RelationDef) GetTargetMin() *int {
-	return r.TargetMin
+// GetMinIncoming returns the minimum incoming cardinality (to-side constraint)
+func (r *RelationDef) GetMinIncoming() *int {
+	return r.MinIncoming
 }
 
-// GetTargetMax returns the target maximum cardinality
-func (r *RelationDef) GetTargetMax() *int {
-	return r.TargetMax
+// GetMaxIncoming returns the maximum incoming cardinality (to-side constraint)
+func (r *RelationDef) GetMaxIncoming() *int {
+	return r.MaxIncoming
 }

--- a/internal/metamodel/types_test.go
+++ b/internal/metamodel/types_test.go
@@ -1101,10 +1101,10 @@ func TestRelationDef_GetterMethods(t *testing.T) {
 		From:        []string{"design"},
 		To:          []string{"requirement"},
 		Symmetric:   false,
-		SourceMin:   &minOne,
-		SourceMax:   &maxFive,
-		TargetMin:   &minOne,
-		TargetMax:   &maxFive,
+		MinOutgoing: &minOne,
+		MaxOutgoing: &maxFive,
+		MinIncoming: &minOne,
+		MaxIncoming: &maxFive,
 		Inverse:     &InverseDef{ID: "implementedBy"},
 	}
 
@@ -1140,31 +1140,31 @@ func TestRelationDef_GetterMethods(t *testing.T) {
 		}
 	})
 
-	t.Run("GetSourceMin", func(t *testing.T) {
-		got := rel.GetSourceMin()
+	t.Run("GetMinOutgoing", func(t *testing.T) {
+		got := rel.GetMinOutgoing()
 		if got == nil || *got != 1 {
-			t.Errorf("GetSourceMin() = %v, want 1", got)
+			t.Errorf("GetMinOutgoing() = %v, want 1", got)
 		}
 	})
 
-	t.Run("GetSourceMax", func(t *testing.T) {
-		got := rel.GetSourceMax()
+	t.Run("GetMaxOutgoing", func(t *testing.T) {
+		got := rel.GetMaxOutgoing()
 		if got == nil || *got != 5 {
-			t.Errorf("GetSourceMax() = %v, want 5", got)
+			t.Errorf("GetMaxOutgoing() = %v, want 5", got)
 		}
 	})
 
-	t.Run("GetTargetMin", func(t *testing.T) {
-		got := rel.GetTargetMin()
+	t.Run("GetMinIncoming", func(t *testing.T) {
+		got := rel.GetMinIncoming()
 		if got == nil || *got != 1 {
-			t.Errorf("GetTargetMin() = %v, want 1", got)
+			t.Errorf("GetMinIncoming() = %v, want 1", got)
 		}
 	})
 
-	t.Run("GetTargetMax", func(t *testing.T) {
-		got := rel.GetTargetMax()
+	t.Run("GetMaxIncoming", func(t *testing.T) {
+		got := rel.GetMaxIncoming()
 		if got == nil || *got != 5 {
-			t.Errorf("GetTargetMax() = %v, want 5", got)
+			t.Errorf("GetMaxIncoming() = %v, want 5", got)
 		}
 	})
 

--- a/internal/metamodel/yaml_errors_test.go
+++ b/internal/metamodel/yaml_errors_test.go
@@ -95,7 +95,7 @@ relations:
     label: test
     from: [requirement]
     to: [requirement]
-    source_min: "one"
+    min_outgoing: "one"
 `,
 			wantMsgs: []string{"expected a number", "got a string"},
 			notWant:  []string{"!!str", "int"},

--- a/internal/migration/cardinality_rename.go
+++ b/internal/migration/cardinality_rename.go
@@ -1,0 +1,90 @@
+package migration
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func init() {
+	Register(&CardinalityRenameMigration{})
+}
+
+// CardinalityRenameMigration renames cardinality constraint keys in relation definitions:
+// - "source_min" -> "min_outgoing"
+// - "source_max" -> "max_outgoing"
+// - "target_min" -> "min_incoming"
+// - "target_max" -> "max_incoming"
+type CardinalityRenameMigration struct{}
+
+func (m *CardinalityRenameMigration) Name() string {
+	return "cardinality-rename"
+}
+
+func (m *CardinalityRenameMigration) Description() string {
+	return `Rename cardinality keys: source_min → min_outgoing, source_max → max_outgoing, ` +
+		`target_min → min_incoming, target_max → max_incoming`
+}
+
+func (m *CardinalityRenameMigration) FileTypes() []FileType {
+	return []FileType{FileTypeMetamodel}
+}
+
+var cardinalityRenames = [][2]string{
+	{"source_min", "min_outgoing"},
+	{"source_max", "max_outgoing"},
+	{"target_min", "min_incoming"},
+	{"target_max", "max_incoming"},
+}
+
+func (m *CardinalityRenameMigration) Detect(doc *yaml.Node) bool {
+	root := GetDocumentRoot(doc)
+	if root == nil {
+		return false
+	}
+
+	relations := GetMapValue(root, "relations")
+	if relations == nil || relations.Kind != yaml.MappingNode {
+		return false
+	}
+
+	for i := 1; i < len(relations.Content); i += 2 {
+		relDef := relations.Content[i]
+		if relDef.Kind != yaml.MappingNode {
+			continue
+		}
+
+		for _, rename := range cardinalityRenames {
+			if GetMapValue(relDef, rename[0]) != nil {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (m *CardinalityRenameMigration) Apply(doc *yaml.Node) error {
+	root := GetDocumentRoot(doc)
+	if root == nil {
+		return fmt.Errorf("empty document")
+	}
+
+	relations := GetMapValue(root, "relations")
+	if relations == nil || relations.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	for i := 1; i < len(relations.Content); i += 2 {
+		relDef := relations.Content[i]
+		if relDef.Kind != yaml.MappingNode {
+			continue
+		}
+
+		for _, rename := range cardinalityRenames {
+			RenameMapKey(relDef, rename[0], rename[1])
+		}
+	}
+
+	return nil
+}

--- a/internal/migration/cardinality_rename_test.go
+++ b/internal/migration/cardinality_rename_test.go
@@ -1,0 +1,296 @@
+package migration
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestCardinalityRenameMigration_Detect(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		detect bool
+	}{
+		{
+			name: "detects source_min",
+			input: `
+relations:
+  addresses:
+    from: [decision]
+    to: [requirement]
+    source_min: 1
+`,
+			detect: true,
+		},
+		{
+			name: "detects source_max",
+			input: `
+relations:
+  addresses:
+    from: [decision]
+    to: [requirement]
+    source_max: 5
+`,
+			detect: true,
+		},
+		{
+			name: "detects target_min",
+			input: `
+relations:
+  addresses:
+    from: [decision]
+    to: [requirement]
+    target_min: 1
+`,
+			detect: true,
+		},
+		{
+			name: "detects target_max",
+			input: `
+relations:
+  addresses:
+    from: [decision]
+    to: [requirement]
+    target_max: 3
+`,
+			detect: true,
+		},
+		{
+			name: "no detection for new keys",
+			input: `
+relations:
+  addresses:
+    from: [decision]
+    to: [requirement]
+    min_outgoing: 1
+    max_incoming: 3
+`,
+			detect: false,
+		},
+		{
+			name: "no detection without cardinality",
+			input: `
+relations:
+  addresses:
+    from: [decision]
+    to: [requirement]
+`,
+			detect: false,
+		},
+		{
+			name: "no detection without relations",
+			input: `
+entities:
+  requirement:
+    label: Requirement
+`,
+			detect: false,
+		},
+		{
+			name: "detects mixed old and new keys",
+			input: `
+relations:
+  addresses:
+    from: [decision]
+    to: [requirement]
+    min_outgoing: 1
+    target_max: 3
+`,
+			detect: true,
+		},
+	}
+
+	m := &CardinalityRenameMigration{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var doc yaml.Node
+			if err := yaml.Unmarshal([]byte(tt.input), &doc); err != nil {
+				t.Fatalf("failed to parse YAML: %v", err)
+			}
+
+			got := m.Detect(&doc)
+			if got != tt.detect {
+				t.Errorf("Detect() = %v, want %v", got, tt.detect)
+			}
+		})
+	}
+}
+
+func TestCardinalityRenameMigration_Apply(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		checkKey map[string]bool // key -> should exist after apply
+	}{
+		{
+			name: "renames all four keys",
+			input: `
+relations:
+  addresses:
+    from: [decision]
+    to: [requirement]
+    source_min: 1
+    source_max: 5
+    target_min: 1
+    target_max: 3
+`,
+			checkKey: map[string]bool{
+				"min_outgoing": true,
+				"max_outgoing": true,
+				"min_incoming": true,
+				"max_incoming": true,
+				"source_min":   false,
+				"source_max":   false,
+				"target_min":   false,
+				"target_max":   false,
+			},
+		},
+		{
+			name: "renames only old keys, preserves new keys",
+			input: `
+relations:
+  addresses:
+    from: [decision]
+    to: [requirement]
+    min_outgoing: 1
+    target_max: 3
+`,
+			checkKey: map[string]bool{
+				"min_outgoing": true,
+				"max_incoming": true,
+				"target_max":   false,
+			},
+		},
+		{
+			name: "renames across multiple relations",
+			input: `
+relations:
+  addresses:
+    from: [decision]
+    to: [requirement]
+    source_min: 1
+  implements:
+    from: [solution]
+    to: [decision]
+    target_max: 1
+`,
+			checkKey: map[string]bool{},
+		},
+	}
+
+	m := &CardinalityRenameMigration{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var doc yaml.Node
+			if err := yaml.Unmarshal([]byte(tt.input), &doc); err != nil {
+				t.Fatalf("failed to parse YAML: %v", err)
+			}
+
+			if err := m.Apply(&doc); err != nil {
+				t.Fatalf("Apply() error: %v", err)
+			}
+
+			// Verify the migration should no longer be detected
+			if m.Detect(&doc) {
+				t.Error("Detect() still returns true after Apply()")
+			}
+
+			// Check specific keys if provided
+			if len(tt.checkKey) > 0 {
+				root := GetDocumentRoot(&doc)
+				relations := GetMapValue(root, "relations")
+				// Check first relation definition
+				if relations == nil || len(relations.Content) < 2 {
+					t.Fatal("expected relations section with at least one definition")
+				}
+				relDef := relations.Content[1]
+				for key, shouldExist := range tt.checkKey {
+					exists := GetMapValue(relDef, key) != nil
+					if shouldExist && !exists {
+						t.Errorf("expected key %q to exist after Apply()", key)
+					} else if !shouldExist && exists {
+						t.Errorf("expected key %q to be removed after Apply()", key)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCardinalityRenameMigration_Apply_PreservesValues(t *testing.T) {
+	input := `
+relations:
+  addresses:
+    from: [decision]
+    to: [requirement]
+    source_min: 1
+    source_max: 5
+    target_min: 2
+    target_max: 10
+`
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(input), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+
+	m := &CardinalityRenameMigration{}
+	if err := m.Apply(&doc); err != nil {
+		t.Fatalf("Apply() error: %v", err)
+	}
+
+	root := GetDocumentRoot(&doc)
+	relations := GetMapValue(root, "relations")
+	relDef := relations.Content[1]
+
+	checks := map[string]string{
+		"min_outgoing": "1",
+		"max_outgoing": "5",
+		"min_incoming": "2",
+		"max_incoming": "10",
+	}
+
+	for key, expectedVal := range checks {
+		val := GetMapValue(relDef, key)
+		if val == nil {
+			t.Errorf("expected key %q after Apply()", key)
+			continue
+		}
+		if val.Value != expectedVal {
+			t.Errorf("key %q: got value %q, want %q", key, val.Value, expectedVal)
+		}
+	}
+}
+
+func TestCardinalityRenameMigration_Apply_EmptyDocument(t *testing.T) {
+	m := &CardinalityRenameMigration{}
+	err := m.Apply(nil)
+	if err == nil {
+		t.Error("expected error for nil document")
+	}
+}
+
+func TestCardinalityRenameMigration_Name(t *testing.T) {
+	m := &CardinalityRenameMigration{}
+	if m.Name() != "cardinality-rename" {
+		t.Errorf("Name() = %q, want %q", m.Name(), "cardinality-rename")
+	}
+}
+
+func TestCardinalityRenameMigration_Description(t *testing.T) {
+	m := &CardinalityRenameMigration{}
+	desc := m.Description()
+	if desc == "" {
+		t.Error("Description() should not be empty")
+	}
+}
+
+func TestCardinalityRenameMigration_FileTypes(t *testing.T) {
+	m := &CardinalityRenameMigration{}
+	ft := m.FileTypes()
+	if len(ft) != 1 || ft[0] != FileTypeMetamodel {
+		t.Errorf("FileTypes() = %v, want [FileTypeMetamodel]", ft)
+	}
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -555,17 +555,17 @@ func (w *Writer) WriteSchemaRelationDetail(name string, def SchemaRelationDef) e
 	if def.IsSymmetric() {
 		data["symmetric"] = true
 	}
-	if srcMin := def.GetSourceMin(); srcMin != nil {
-		data["source_min"] = *srcMin
+	if minOut := def.GetMinOutgoing(); minOut != nil {
+		data["min_outgoing"] = *minOut
 	}
-	if srcMax := def.GetSourceMax(); srcMax != nil {
-		data["source_max"] = *srcMax
+	if maxOut := def.GetMaxOutgoing(); maxOut != nil {
+		data["max_outgoing"] = *maxOut
 	}
-	if tgtMin := def.GetTargetMin(); tgtMin != nil {
-		data["target_min"] = *tgtMin
+	if minIn := def.GetMinIncoming(); minIn != nil {
+		data["min_incoming"] = *minIn
 	}
-	if tgtMax := def.GetTargetMax(); tgtMax != nil {
-		data["target_max"] = *tgtMax
+	if maxIn := def.GetMaxIncoming(); maxIn != nil {
+		data["max_incoming"] = *maxIn
 	}
 	return w.writeJSON(data)
 }
@@ -598,8 +598,8 @@ type SchemaRelationDef interface {
 	GetDescription() string
 	GetInverse() interface{}
 	IsSymmetric() bool
-	GetSourceMin() *int
-	GetSourceMax() *int
-	GetTargetMin() *int
-	GetTargetMax() *int
+	GetMinOutgoing() *int
+	GetMaxOutgoing() *int
+	GetMinIncoming() *int
+	GetMaxIncoming() *int
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -910,10 +910,10 @@ func (r *mockRelationDef) GetDescription() string {
 }
 func (r *mockRelationDef) GetInverse() interface{} { return r.inverse }
 func (r *mockRelationDef) IsSymmetric() bool       { return r.symmetric }
-func (r *mockRelationDef) GetSourceMin() *int      { return r.srcMin }
-func (r *mockRelationDef) GetSourceMax() *int      { return r.srcMax }
-func (r *mockRelationDef) GetTargetMin() *int      { return r.tgtMin }
-func (r *mockRelationDef) GetTargetMax() *int      { return r.tgtMax }
+func (r *mockRelationDef) GetMinOutgoing() *int    { return r.srcMin }
+func (r *mockRelationDef) GetMaxOutgoing() *int    { return r.srcMax }
+func (r *mockRelationDef) GetMinIncoming() *int    { return r.tgtMin }
+func (r *mockRelationDef) GetMaxIncoming() *int    { return r.tgtMax }
 
 // TestWriteSchemaOverview tests schema overview output
 func TestWriteSchemaOverview(t *testing.T) {
@@ -1058,7 +1058,7 @@ func TestWriteSchemaRelationDetail(t *testing.T) {
 	if result2["symmetric"] != true {
 		t.Error("expected symmetric in output")
 	}
-	if result2["source_min"] != float64(1) {
-		t.Error("expected source_min in output")
+	if result2["min_outgoing"] != float64(1) {
+		t.Error("expected min_outgoing in output")
 	}
 }

--- a/internal/tui/analysis.go
+++ b/internal/tui/analysis.go
@@ -202,7 +202,7 @@ func (a *AnalysisModel) runCardinality(app *App) {
 	violations := 0
 
 	for relName, relDef := range app.metamodel.Relations {
-		if relDef.SourceMin != nil && *relDef.SourceMin > 0 {
+		if relDef.MinOutgoing != nil && *relDef.MinOutgoing > 0 {
 			for _, sourceType := range relDef.From {
 				entities := app.graph.NodesByType(sourceType)
 				for _, e := range entities {
@@ -212,7 +212,7 @@ func (a *AnalysisModel) runCardinality(app *App) {
 							count++
 						}
 					}
-					if count < *relDef.SourceMin {
+					if count < *relDef.MinOutgoing {
 						violations++
 					}
 				}


### PR DESCRIPTION
## Summary

- Renames the four cardinality constraint fields to remove ambiguity:
  - `source_min` → `min_outgoing`, `source_max` → `max_outgoing`
  - `target_min` → `min_incoming`, `target_max` → `max_incoming`
- Adds a schema migration (`cardinality-rename`) so existing `metamodel.yaml` files are auto-updated via `rela migrate`
- Updates all Go code (types, interfaces, CLI, MCP, TUI), tests, and documentation

The old names were ambiguous — `source_min: 1` on an `addresses` relation (`from: [decision], to: [requirement]`) could be read as either "each decision must address at least 1 requirement" or "each requirement must have at least 1 source decision". The new names (`min_outgoing`/`max_incoming`) make the direction explicit: outgoing = from-side, incoming = to-side.

## Test plan

- [x] All existing tests pass (`go test -race ./...`)
- [x] Lint passes (`golangci-lint run`)
- [x] New migration tests cover: detect old keys, apply rename, preserve values, no-op on already-migrated files
- [ ] Verify `rela migrate` correctly renames keys in a real `metamodel.yaml` with cardinality constraints