### PR TITLE
Add sort support to search query syntax and data entry

### DIFF
--- a/docs-project/entities/guide/GUIDE-data-entry.md
+++ b/docs-project/entities/guide/GUIDE-data-entry.md
@@ -449,11 +449,25 @@ filter_controls:
 
 ### Sort Configuration
 
+Sort supports multiple criteria as a list. The first entry is the primary sort key:
+
 ```yaml
 sort:
-  property: priority
-  direction: asc    # "asc" or "desc"
+  - property: priority
+    direction: desc
+  - property: due_date
+    direction: asc   # "asc" (default) or "desc"
 ```
+
+You can also sort by the virtual properties `id` (entity ID) and `modified` (file modification time).
+
+If no sort is configured, the list falls back to the entity type's `default_sort` from the metamodel,
+or sorts by ID ascending.
+
+The search bar also supports `sort:` clauses (see [Query Syntax](#query-syntax) below).
+
+> **Migration**: If your config uses the old single-object format (`sort: {property: ..., direction: ...}`),
+> run `rela migrate` to convert it to the list format.
 
 ## Views
 
@@ -706,6 +720,9 @@ Cards use the same search query syntax available on the search page:
 | `prop:<name>!=<value>`   | `prop:assignee!=`                 | Property not equal               |
 | `prop:<name>=~<regex>`   | `prop:title=~auth.*`              | Regex match                      |
 | `prop:<name><<value>`    | `prop:due_date<2025-06-01`        | Less than (dates, numbers)       |
+| `sort:<property>`        | `sort:priority`                   | Sort ascending by property       |
+| `sort:<property>:desc`   | `sort:priority:desc`              | Sort descending by property      |
+| `sort:id` / `sort:modified` | `sort:modified:desc`           | Sort by ID or modification time  |
 | free text                | `authentication`                  | Substring match across all fields|
 | `"quoted phrase"`        | `"REST API"`                      | Exact phrase match               |
 

--- a/docs-project/entities/guide/GUIDE-metamodel.md
+++ b/docs-project/entities/guide/GUIDE-metamodel.md
@@ -683,12 +683,56 @@ rela list control --sort id
 
 Sorting is type-aware:
 
-- `string`, `enum`: Lexicographic (alphabetical)
+- `string`: Lexicographic (alphabetical)
+- `enum`/custom types: By the order defined in the type's `values` list (not alphabetical)
 - `date`: Chronological
 - `integer`: Numeric
 - `boolean`: `false` before `true`
 
 Entities with missing values for the sort property are placed at the end.
+
+### Default Sort Order
+
+Entity types can declare a default sort order in the metamodel. This is used when no explicit
+sort is specified in a query or CLI command:
+
+```yaml
+entities:
+  ticket:
+    label: Ticket
+    id_prefix: "TKT-"
+    default_sort:
+      - property: priority
+      - property: due_date
+        direction: asc
+    properties:
+      # ...
+```
+
+Each entry in `default_sort` is a sort criterion applied in order (first entry is the primary key).
+The `direction` field is optional and defaults to `"asc"`. Supported values: `"asc"` or `"desc"`.
+
+You can sort by any property defined on the entity, plus two virtual properties:
+
+- `id` — sorts by entity ID
+- `modified` — sorts by file modification time
+
+### Sort in Search Queries
+
+The TUI search screen and data entry search bar support a `sort:` clause:
+
+```text
+sort:priority                     # sort by priority ascending
+sort:priority:desc                # sort by priority descending
+sort:id:desc                      # sort by entity ID descending
+sort:modified:desc                # sort by modification time (newest first)
+sort:priority:desc sort:title     # multi-sort: priority desc, then title asc
+```
+
+When no `sort:` clause is present:
+
+1. If all results are the same entity type and that type has `default_sort`, it is used
+2. Otherwise, results are sorted by ID ascending
 
 ## Custom Validation Rules
 

--- a/docs-project/entities/guide/GUIDE-tui.md
+++ b/docs-project/entities/guide/GUIDE-tui.md
@@ -157,7 +157,7 @@ The entity ID is auto-generated based on the type's ID pattern.
 
 ### Search
 
-Full-text search across all entities.
+Full-text search across all entities with structured query support.
 
 ```text
 ┌─────────────────────────────────────────┐
@@ -176,12 +176,29 @@ Full-text search across all entities.
 └─────────────────────────────────────────┘
 ```
 
-Searches in:
+**Query syntax:**
 
-- Entity IDs
-- Titles
-- Descriptions
-- Free-form content
+| Syntax                     | Description                                    |
+| -------------------------- | ---------------------------------------------- |
+| `type:requirement`         | Filter by entity type                          |
+| `type:requirement,decision`| Filter by multiple types                       |
+| `status:draft`             | Shortcut for `prop:status=draft`               |
+| `prop:priority=high`       | Property equals value                          |
+| `prop:assignee!=`          | Property not equal / not empty                 |
+| `prop:title=~auth.*`       | Regex match                                    |
+| `prop:score>5`             | Greater than (dates, integers)                 |
+| `sort:priority`            | Sort ascending by property                     |
+| `sort:priority:desc`       | Sort descending                                |
+| `sort:modified:desc`       | Sort by modification time (newest first)       |
+| `sort:id`                  | Sort by entity ID                              |
+| `"quoted phrase"`          | Exact phrase match                             |
+| free text                  | Substring match across IDs, titles, content    |
+
+Multiple filter terms combine with AND logic. Multiple `sort:` clauses apply in order
+(first is the primary key, second is the tiebreaker).
+
+When no `sort:` clause is given, results use the entity type's `default_sort` from the
+metamodel (if all results are the same type), otherwise sort by ID ascending.
 
 **Shortcuts:**
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -441,11 +441,25 @@ filter_controls:
 
 ### Sort Configuration
 
+Sort supports multiple criteria as a list. The first entry is the primary sort key:
+
 ```yaml
 sort:
-  property: priority
-  direction: asc    # "asc" or "desc"
+  - property: priority
+    direction: desc
+  - property: due_date
+    direction: asc   # "asc" (default) or "desc"
 ```
+
+You can also sort by the virtual properties `id` (entity ID) and `modified` (file modification time).
+
+If no sort is configured, the list falls back to the entity type's `default_sort` from the metamodel,
+or sorts by ID ascending.
+
+The search bar also supports `sort:` clauses (see [Query Syntax](#query-syntax) below).
+
+> **Migration**: If your config uses the old single-object format (`sort: {property: ..., direction: ...}`),
+> run `rela migrate` to convert it to the list format.
 
 ## Views
 
@@ -698,6 +712,9 @@ Cards use the same search query syntax available on the search page:
 | `prop:<name>!=<value>`   | `prop:assignee!=`                 | Property not equal               |
 | `prop:<name>=~<regex>`   | `prop:title=~auth.*`              | Regex match                      |
 | `prop:<name><<value>`    | `prop:due_date<2025-06-01`        | Less than (dates, numbers)       |
+| `sort:<property>`        | `sort:priority`                   | Sort ascending by property       |
+| `sort:<property>:desc`   | `sort:priority:desc`              | Sort descending by property      |
+| `sort:id` / `sort:modified` | `sort:modified:desc`           | Sort by ID or modification time  |
 | free text                | `authentication`                  | Substring match across all fields|
 | `"quoted phrase"`        | `"REST API"`                      | Exact phrase match               |
 

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -675,12 +675,56 @@ rela list control --sort id
 
 Sorting is type-aware:
 
-- `string`, `enum`: Lexicographic (alphabetical)
+- `string`: Lexicographic (alphabetical)
+- `enum`/custom types: By the order defined in the type's `values` list (not alphabetical)
 - `date`: Chronological
 - `integer`: Numeric
 - `boolean`: `false` before `true`
 
 Entities with missing values for the sort property are placed at the end.
+
+### Default Sort Order
+
+Entity types can declare a default sort order in the metamodel. This is used when no explicit
+sort is specified in a query or CLI command:
+
+```yaml
+entities:
+  ticket:
+    label: Ticket
+    id_prefix: "TKT-"
+    default_sort:
+      - property: priority
+      - property: due_date
+        direction: asc
+    properties:
+      # ...
+```
+
+Each entry in `default_sort` is a sort criterion applied in order (first entry is the primary key).
+The `direction` field is optional and defaults to `"asc"`. Supported values: `"asc"` or `"desc"`.
+
+You can sort by any property defined on the entity, plus two virtual properties:
+
+- `id` — sorts by entity ID
+- `modified` — sorts by file modification time
+
+### Sort in Search Queries
+
+The TUI search screen and data entry search bar support a `sort:` clause:
+
+```text
+sort:priority                     # sort by priority ascending
+sort:priority:desc                # sort by priority descending
+sort:id:desc                      # sort by entity ID descending
+sort:modified:desc                # sort by modification time (newest first)
+sort:priority:desc sort:title     # multi-sort: priority desc, then title asc
+```
+
+When no `sort:` clause is present:
+
+1. If all results are the same entity type and that type has `default_sort`, it is used
+2. Otherwise, results are sorted by ID ascending
 
 ## Custom Validation Rules
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -149,7 +149,7 @@ The entity ID is auto-generated based on the type's ID pattern.
 
 ### Search
 
-Full-text search across all entities.
+Full-text search across all entities with structured query support.
 
 ```text
 ┌─────────────────────────────────────────┐
@@ -168,12 +168,29 @@ Full-text search across all entities.
 └─────────────────────────────────────────┘
 ```
 
-Searches in:
+**Query syntax:**
 
-- Entity IDs
-- Titles
-- Descriptions
-- Free-form content
+| Syntax                     | Description                                    |
+| -------------------------- | ---------------------------------------------- |
+| `type:requirement`         | Filter by entity type                          |
+| `type:requirement,decision`| Filter by multiple types                       |
+| `status:draft`             | Shortcut for `prop:status=draft`               |
+| `prop:priority=high`       | Property equals value                          |
+| `prop:assignee!=`          | Property not equal / not empty                 |
+| `prop:title=~auth.*`       | Regex match                                    |
+| `prop:score>5`             | Greater than (dates, integers)                 |
+| `sort:priority`            | Sort ascending by property                     |
+| `sort:priority:desc`       | Sort descending                                |
+| `sort:modified:desc`       | Sort by modification time (newest first)       |
+| `sort:id`                  | Sort by entity ID                              |
+| `"quoted phrase"`          | Exact phrase match                             |
+| free text                  | Substring match across IDs, titles, content    |
+
+Multiple filter terms combine with AND logic. Multiple `sort:` clauses apply in order
+(first is the primary key, second is the tiebreaker).
+
+When no `sort:` clause is given, results use the entity type's `default_sort` from the
+metamodel (if all results are the same type), otherwise sort by ID ascending.
 
 **Shortcuts:**
 

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -3,9 +3,11 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
+	"github.com/Sourcehaven-BV/rela/internal/dataentry"
 	"github.com/Sourcehaven-BV/rela/internal/migration"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 )
@@ -33,13 +35,15 @@ Examples:
 		}
 
 		// Define files to check
+		dataEntryPath := filepath.Join(ctx.Root, dataentry.ConfigFile)
+
 		files := []struct {
 			path     string
 			fileType migration.FileType
 			name     string
 		}{
 			{ctx.MetamodelPath, migration.FileTypeMetamodel, "metamodel.yaml"},
-			// Future: add views.yaml, templates, etc.
+			{dataEntryPath, migration.FileTypeDataEntry, dataentry.ConfigFile},
 		}
 
 		if migrateCheck {

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/migration"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
@@ -69,6 +70,15 @@ func NewApp(projectDir string, fs storage.FS) (*App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", ConfigFile, err)
 	}
+	// Check for deprecated syntax that needs migration
+	detections, detectErr := migration.Detect(configPath, migration.FileTypeDataEntry, fs)
+	if detectErr == nil && len(detections) > 0 {
+		return nil, &migration.Error{
+			FilePath:   configPath,
+			Detections: detections,
+		}
+	}
+
 	var cfg Config
 	if unmarshalErr := yaml.Unmarshal(cfgData, &cfg); unmarshalErr != nil {
 		return nil, fmt.Errorf("parsing %s: %w", ConfigFile, unmarshalErr)

--- a/internal/dataentry/config.go
+++ b/internal/dataentry/config.go
@@ -4,6 +4,8 @@
 // on entities stored as markdown files.
 package dataentry
 
+import "github.com/Sourcehaven-BV/rela/internal/model"
+
 // Config is the top-level configuration for a data entry application.
 type Config struct {
 	Version    string                       `yaml:"version"`
@@ -77,7 +79,7 @@ type List struct {
 	Title          string          `yaml:"title"`
 	Description    string          `yaml:"description"`
 	Columns        []ListColumn    `yaml:"columns"`
-	Sort           *SortConfig     `yaml:"sort,omitempty"`
+	Sort           []SortSpec      `yaml:"sort,omitempty"`
 	Filters        []FilterConfig  `yaml:"filters"`
 	FilterControls []FilterControl `yaml:"filter_controls"`
 	CreateForm     string          `yaml:"create_form"`
@@ -97,11 +99,10 @@ type ListColumn struct {
 	Link     bool   `yaml:"link"`
 }
 
-// SortConfig defines default sort order for a list.
-type SortConfig struct {
-	Property  string `yaml:"property"`
-	Direction string `yaml:"direction"`
-}
+// SortSpec defines a single sort criterion for a list or dashboard card.
+// This is the data-entry-specific alias matching the YAML config format.
+// The migration system converts the legacy single-object format to a list.
+type SortSpec = model.SortSpec
 
 // FilterConfig defines a static filter applied to a list.
 type FilterConfig struct {
@@ -156,7 +157,7 @@ type DashboardCard struct {
 	Display string       `yaml:"display"` // "count", "table", "breakdown"
 	GroupBy string       `yaml:"group_by,omitempty"`
 	Columns []ListColumn `yaml:"columns,omitempty"`
-	Sort    *SortConfig  `yaml:"sort,omitempty"`
+	Sort    []SortSpec   `yaml:"sort,omitempty"`
 	Limit   int          `yaml:"limit,omitempty"`
 }
 

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -80,12 +80,12 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 	sortProp := r.URL.Query().Get("sort")
 	sortDir := r.URL.Query().Get("sort_dir")
 	if sortProp != "" {
-		sortEntities(entities, &SortConfig{Property: sortProp, Direction: sortDir})
+		a.sortEntitiesMulti(entities, []model.SortSpec{{Property: sortProp, Direction: sortDir}})
 	} else {
-		sortEntities(entities, list.Sort)
-		if list.Sort != nil {
-			sortProp = list.Sort.Property
-			sortDir = list.Sort.Direction
+		a.sortEntitiesMulti(entities, list.Sort)
+		if len(list.Sort) > 0 {
+			sortProp = list.Sort[0].Property
+			sortDir = list.Sort[0].Direction
 		}
 	}
 
@@ -1459,6 +1459,27 @@ func (a *App) handleSearch(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	// Add sort suggestions: virtual properties + all entity properties
+	sortSeen := make(map[string]bool)
+	for _, vp := range []string{"id", "modified"} {
+		key := "sort:" + vp
+		suggestions = append(suggestions, searchSuggestion{Value: key, Category: "sort"})
+		sortSeen[key] = true
+	}
+	for _, entityTypeName := range a.meta.EntityTypes() {
+		entDef, ok := a.meta.GetEntityDef(entityTypeName)
+		if !ok {
+			continue
+		}
+		for propName := range entDef.Properties {
+			key := "sort:" + propName
+			if !sortSeen[key] {
+				suggestions = append(suggestions, searchSuggestion{Value: key, Category: "sort"})
+				sortSeen[key] = true
+			}
+		}
+	}
+
 	suggestionsJSON, _ := json.Marshal(suggestions)
 
 	data := map[string]interface{}{
@@ -1584,7 +1605,7 @@ func (a *App) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			rc.GroupByLabel = titleCase(card.GroupBy)
 
 		case "table":
-			sortEntities(entities, card.Sort)
+			a.sortEntitiesMulti(entities, card.Sort)
 			if card.Limit > 0 && len(entities) > card.Limit {
 				entities = entities[:card.Limit]
 			}

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"sort"
 	"strings"
 	"time"
 
@@ -48,25 +47,20 @@ func applyFilters(entities []*model.Entity, filters []FilterConfig) []*model.Ent
 	return result
 }
 
-// sortEntities sorts entities by a property according to the given config.
-func sortEntities(entities []*model.Entity, cfg *SortConfig) {
-	if cfg == nil || cfg.Property == "" {
+// sortEntitiesMulti sorts entities by multiple sort specs using type-aware comparison.
+func (a *App) sortEntitiesMulti(entities []*model.Entity, specs []model.SortSpec) {
+	if len(specs) == 0 {
 		return
 	}
-	sort.Slice(entities, func(i, j int) bool {
-		vi := fmt.Sprintf("%v", entities[i].Properties[cfg.Property])
-		vj := fmt.Sprintf("%v", entities[j].Properties[cfg.Property])
-		if entities[i].Properties[cfg.Property] == nil {
-			vi = ""
+	entityDefs := make(map[string]*metamodel.EntityDef)
+	for _, e := range entities {
+		if _, ok := entityDefs[e.Type]; !ok {
+			if def, ok := a.meta.GetEntityDef(e.Type); ok {
+				entityDefs[e.Type] = def
+			}
 		}
-		if entities[j].Properties[cfg.Property] == nil {
-			vj = ""
-		}
-		if cfg.Direction == "desc" {
-			return vi > vj
-		}
-		return vi < vj
-	})
+	}
+	filter.SortMulti(entities, specs, entityDefs, a.meta)
 }
 
 // resolvePropertyValues returns allowed values for a property from its definition or custom type.
@@ -388,6 +382,12 @@ func (a *App) executeQuery(query string) []*model.Entity {
 
 		results = append(results, e)
 	}
+
+	// Apply sort from query syntax
+	if sq.HasSort() {
+		a.sortEntitiesMulti(results, sq.SortClauses)
+	}
+
 	return results
 }
 

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -80,26 +80,38 @@ func TestApplyFilters(t *testing.T) {
 	}
 }
 
-func TestSortEntities(t *testing.T) {
+func TestSortEntitiesMulti(t *testing.T) {
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"item": {
+				Properties: map[string]metamodel.PropertyDef{
+					"name": {Type: "string"},
+				},
+			},
+		},
+	}
+
 	makeEntities := func() []*model.Entity {
 		return []*model.Entity{
-			{ID: "E-003", Properties: map[string]interface{}{"name": "Charlie"}},
-			{ID: "E-001", Properties: map[string]interface{}{"name": "Alice"}},
-			{ID: "E-002", Properties: map[string]interface{}{"name": "Bob"}},
+			{ID: "E-003", Type: "item", Properties: map[string]interface{}{"name": "Charlie"}},
+			{ID: "E-001", Type: "item", Properties: map[string]interface{}{"name": "Alice"}},
+			{ID: "E-002", Type: "item", Properties: map[string]interface{}{"name": "Bob"}},
 		}
 	}
 
-	t.Run("nil config does nothing", func(t *testing.T) {
+	app := &App{meta: meta}
+
+	t.Run("nil specs does nothing", func(t *testing.T) {
 		entities := makeEntities()
-		sortEntities(entities, nil)
+		app.sortEntitiesMulti(entities, nil)
 		if entities[0].ID != "E-003" {
 			t.Errorf("expected no reorder, got %s first", entities[0].ID)
 		}
 	})
 
-	t.Run("empty property does nothing", func(t *testing.T) {
+	t.Run("empty specs does nothing", func(t *testing.T) {
 		entities := makeEntities()
-		sortEntities(entities, &SortConfig{Property: ""})
+		app.sortEntitiesMulti(entities, []model.SortSpec{})
 		if entities[0].ID != "E-003" {
 			t.Errorf("expected no reorder, got %s first", entities[0].ID)
 		}
@@ -107,7 +119,7 @@ func TestSortEntities(t *testing.T) {
 
 	t.Run("ascending sort", func(t *testing.T) {
 		entities := makeEntities()
-		sortEntities(entities, &SortConfig{Property: "name", Direction: "asc"})
+		app.sortEntitiesMulti(entities, []model.SortSpec{{Property: "name", Direction: "asc"}})
 		if entities[0].ID != "E-001" || entities[1].ID != "E-002" || entities[2].ID != "E-003" {
 			t.Errorf("expected Alice, Bob, Charlie; got %s, %s, %s",
 				entities[0].Properties["name"], entities[1].Properties["name"], entities[2].Properties["name"])
@@ -116,23 +128,29 @@ func TestSortEntities(t *testing.T) {
 
 	t.Run("descending sort", func(t *testing.T) {
 		entities := makeEntities()
-		sortEntities(entities, &SortConfig{Property: "name", Direction: "desc"})
+		app.sortEntitiesMulti(entities, []model.SortSpec{{Property: "name", Direction: "desc"}})
 		if entities[0].ID != "E-003" || entities[1].ID != "E-002" || entities[2].ID != "E-001" {
 			t.Errorf("expected Charlie, Bob, Alice; got %s, %s, %s",
 				entities[0].Properties["name"], entities[1].Properties["name"], entities[2].Properties["name"])
 		}
 	})
 
-	t.Run("nil property values sort as empty", func(t *testing.T) {
+	t.Run("nil property values sort to end", func(t *testing.T) {
 		entities := []*model.Entity{
-			{ID: "E-001", Properties: map[string]interface{}{"name": "Bob"}},
-			{ID: "E-002", Properties: map[string]interface{}{}},
-			{ID: "E-003", Properties: map[string]interface{}{"name": "Alice"}},
+			{ID: "E-001", Type: "item", Properties: map[string]interface{}{"name": "Bob"}},
+			{ID: "E-002", Type: "item", Properties: map[string]interface{}{}},
+			{ID: "E-003", Type: "item", Properties: map[string]interface{}{"name": "Alice"}},
 		}
-		sortEntities(entities, &SortConfig{Property: "name", Direction: "asc"})
-		// empty string sorts before "Alice"
-		if entities[0].ID != "E-002" {
-			t.Errorf("expected nil property to sort first, got %s", entities[0].ID)
+		app.sortEntitiesMulti(entities, []model.SortSpec{{Property: "name", Direction: "asc"}})
+		// With type-aware sorting, nil values sort to end
+		if entities[0].ID != "E-003" {
+			t.Errorf("expected Alice first, got %s", entities[0].ID)
+		}
+		if entities[1].ID != "E-001" {
+			t.Errorf("expected Bob second, got %s", entities[1].ID)
+		}
+		if entities[2].ID != "E-002" {
+			t.Errorf("expected nil property last, got %s", entities[2].ID)
 		}
 	})
 }

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -1584,6 +1584,7 @@ function submitInlineCreate() {
 .search-chip-type { background: #dbeafe; color: #1e40af; }
 .search-chip-status { background: #dcfce7; color: #166534; }
 .search-chip-property { background: #e9d5ff; color: #6b21a8; }
+.search-chip-sort { background: #fce7f3; color: #9d174d; }
 .search-chip button { background: none; border: none; cursor: pointer; padding: 0 0 0 2px; font-size: 15px; line-height: 1; opacity: 0.6; color: inherit; }
 .search-chip button:hover { opacity: 1; }
 .search-input { width: 100%; padding: 10px 12px; border: 1px solid var(--border); border-radius: 6px; font-family: var(--font); font-size: 14px; color: var(--text); background: var(--bg-card); outline: none; }
@@ -1600,6 +1601,7 @@ function submitInlineCreate() {
 .search-dd-cat-type { background: #dbeafe; color: #1e40af; }
 .search-dd-cat-status { background: #dcfce7; color: #166534; }
 .search-dd-cat-property { background: #e9d5ff; color: #6b21a8; }
+.search-dd-cat-sort { background: #fce7f3; color: #9d174d; }
 </style>
 
 <div class="card" style="padding:20px;margin-bottom:20px;">
@@ -1614,6 +1616,7 @@ function submitInlineCreate() {
     <code>type:ticket</code> filter by entity type &middot;
     <code>status:open</code> filter by status &middot;
     <code>prop:priority=high</code> filter by property &middot;
+    <code>sort:priority:desc</code> sort results &middot;
     <code>"exact phrase"</code> exact match &middot;
     plain words (AND logic)
   </div>
@@ -1642,15 +1645,16 @@ function submitInlineCreate() {
   var activeIdx = -1;
   var filtered = [];
 
-  var catClass = {type: 'search-chip-type', status: 'search-chip-status', property: 'search-chip-property'};
-  var ddCatClass = {type: 'search-dd-cat-type', status: 'search-dd-cat-status', property: 'search-dd-cat-property'};
+  var catClass = {type: 'search-chip-type', status: 'search-chip-status', property: 'search-chip-property', sort: 'search-chip-sort'};
+  var ddCatClass = {type: 'search-dd-cat-type', status: 'search-dd-cat-status', property: 'search-dd-cat-property', sort: 'search-dd-cat-sort'};
 
-  function isFilter(val) { return /^(type|status|prop):/.test(val); }
+  function isFilter(val) { return /^(type|status|prop|sort):/.test(val); }
 
   function detectCategory(val) {
     if (val.lastIndexOf('type:', 0) === 0) return 'type';
     if (val.lastIndexOf('status:', 0) === 0) return 'status';
     if (val.lastIndexOf('prop:', 0) === 0) return 'property';
+    if (val.lastIndexOf('sort:', 0) === 0) return 'sort';
     return '';
   }
 
@@ -1732,6 +1736,24 @@ function submitInlineCreate() {
   function selectItem(idx) {
     if (idx < 0 || idx >= filtered.length) return;
     var sel = filtered[idx];
+    // For first-stage sort suggestions (no direction yet), advance to direction picker
+    if (sel.category === 'sort' && sel.value.split(':').length === 2) {
+      // Replace the current token with sort:prop: to trigger direction dropdown
+      var text = input.value;
+      var words = text.split(/\s+/);
+      var replaced = false;
+      for (var i = words.length - 1; i >= 0; i--) {
+        if (!replaced && /^sort(:|$)/.test(words[i])) {
+          words[i] = sel.value + ':';
+          replaced = true;
+        }
+      }
+      input.value = words.join(' ');
+      closeDropdown();
+      input.focus();
+      updateDropdown();
+      return;
+    }
     addChip(sel.value, sel.category);
     // Remove the filter token from the input, keep other text
     var text = input.value;
@@ -1739,7 +1761,7 @@ function submitInlineCreate() {
     var remaining = [];
     var removed = false;
     for (var i = 0; i < words.length; i++) {
-      if (!removed && /^(type|status|prop)(:|$)/.test(words[i])) {
+      if (!removed && /^(type|status|prop|sort)(:|$)/.test(words[i])) {
         removed = true;
       } else {
         remaining.push(words[i]);
@@ -1755,9 +1777,30 @@ function submitInlineCreate() {
     var text = input.value;
     var words = text.split(/\s+/);
     var last = words[words.length - 1] || '';
-    if (!last || !/^(type|status|prop)(:|$)/.test(last)) {
+    if (!last || !/^(type|status|prop|sort)(:|$)/.test(last)) {
       closeDropdown();
       return;
+    }
+    // Second-stage: sort direction picker (e.g. "sort:priority:" -> asc/desc)
+    var sortDirMatch = last.match(/^(sort:[^:]+):(.*)$/);
+    if (sortDirMatch) {
+      var base = sortDirMatch[1];
+      var dirPrefix = sortDirMatch[2].toLowerCase();
+      // Only offer directions if base matches a known sort suggestion
+      var knownBase = false;
+      for (var s = 0; s < suggestions.length; s++) {
+        if (suggestions[s].value === base && suggestions[s].category === 'sort') { knownBase = true; break; }
+      }
+      if (knownBase) {
+        var dirs = [{value: base + ':asc', category: 'sort'}, {value: base + ':desc', category: 'sort'}];
+        var dirMatches = [];
+        for (var d = 0; d < dirs.length; d++) {
+          if (dirs[d].value.toLowerCase().indexOf(last.toLowerCase()) === 0) dirMatches.push(dirs[d]);
+        }
+        if (dirMatches.length > 0) { showDropdown(dirMatches); return; }
+        closeDropdown();
+        return;
+      }
     }
     var matches = [];
     var q = last.toLowerCase();

--- a/internal/filter/sort.go
+++ b/internal/filter/sort.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"sort"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
@@ -139,22 +140,32 @@ func compareStrings(valI, valJ interface{}) bool {
 	return sI < sJ
 }
 
-// compareDates compares two values as dates
+// compareDates compares two values as dates.
+// Handles both string values (from JSON cache) and time.Time values (from YAML parsing).
 func compareDates(valI, valJ interface{}, propDef *metamodel.PropertyDef) bool {
-	sI, okI := valI.(string)
-	sJ, okJ := valJ.(string)
+	dateI, okI := toTime(valI, propDef)
+	dateJ, okJ := toTime(valJ, propDef)
 	if !okI || !okJ {
-		return false
+		return compareStrings(valI, valJ)
 	}
-
-	dateI, errI := metamodel.ParseDateValue(sI, propDef)
-	dateJ, errJ := metamodel.ParseDateValue(sJ, propDef)
-	if errI != nil || errJ != nil {
-		// Fall back to string comparison if parsing fails
-		return sI < sJ
-	}
-
 	return dateI.Before(dateJ)
+}
+
+// toTime converts a property value to time.Time.
+// Supports string values (parsed via metamodel) and native time.Time values.
+func toTime(val interface{}, propDef *metamodel.PropertyDef) (time.Time, bool) {
+	switch v := val.(type) {
+	case time.Time:
+		return v, true
+	case string:
+		t, err := metamodel.ParseDateValue(v, propDef)
+		if err != nil {
+			return time.Time{}, false
+		}
+		return t, true
+	default:
+		return time.Time{}, false
+	}
 }
 
 // compareIntegers compares two values as integers
@@ -182,4 +193,221 @@ func compareBooleans(valI, valJ interface{}) bool {
 		return true
 	}
 	return false
+}
+
+// SortMulti sorts entities by multiple criteria using stable sort.
+// Specs are applied in priority order: first spec is the primary sort key,
+// second spec is the tiebreaker, etc.
+//
+// The entityDefs map provides type definitions keyed by entity type name,
+// enabling type-aware comparison for properties across different entity types.
+// Both entityDefs and meta may be nil for basic string-only comparison.
+//
+// Virtual properties "id" and "modified" are supported:
+//   - "id" sorts by Entity.ID
+//   - "modified" sorts by Entity.ModTime
+func SortMulti(
+	entities []*model.Entity,
+	specs []model.SortSpec,
+	entityDefs map[string]*metamodel.EntityDef,
+	meta *metamodel.Metamodel,
+) {
+	if len(specs) == 0 || len(entities) == 0 {
+		return
+	}
+
+	// Apply sorts in reverse order (least significant key first).
+	// Because SliceStable preserves order for equal elements,
+	// the primary (first) key ends up dominant.
+	for idx := len(specs) - 1; idx >= 0; idx-- {
+		spec := specs[idx]
+		sortBySingleSpec(entities, spec, entityDefs, meta)
+	}
+}
+
+// sortBySingleSpec sorts entities by a single SortSpec with type-aware comparison.
+func sortBySingleSpec(
+	entities []*model.Entity,
+	spec model.SortSpec,
+	entityDefs map[string]*metamodel.EntityDef,
+	meta *metamodel.Metamodel,
+) {
+	descending := spec.IsDescending()
+
+	switch spec.Property {
+	case "id":
+		SortByID(entities, descending)
+	case "modified":
+		sortByModified(entities, descending)
+	default:
+		sortByProperty(entities, spec.Property, descending, entityDefs, meta)
+	}
+}
+
+// sortByModified sorts entities by file modification time.
+func sortByModified(entities []*model.Entity, descending bool) {
+	sort.SliceStable(entities, func(i, j int) bool {
+		ti := entities[i].ModTime
+		tj := entities[j].ModTime
+
+		// Zero times (unset) sort to end
+		zi := ti.IsZero()
+		zj := tj.IsZero()
+		if zi && zj {
+			return false
+		}
+		if zi {
+			return false
+		}
+		if zj {
+			return true
+		}
+
+		less := ti.Before(tj)
+		if descending {
+			return !less
+		}
+		return less
+	})
+}
+
+// propInfo caches the property definition and enum index for a specific
+// entity type, used during cross-type property sorting.
+type propInfo struct {
+	def       *metamodel.PropertyDef
+	enumIndex map[string]int
+}
+
+// sortByProperty sorts entities by a named property with cross-type awareness.
+func sortByProperty(
+	entities []*model.Entity,
+	propName string,
+	descending bool,
+	entityDefs map[string]*metamodel.EntityDef,
+	meta *metamodel.Metamodel,
+) {
+	propInfoCache := make(map[string]*propInfo)
+
+	getPropInfo := func(entityType string) *propInfo {
+		if pi, ok := propInfoCache[entityType]; ok {
+			return pi
+		}
+		var pi propInfo
+		if entityDefs != nil {
+			if entDef, ok := entityDefs[entityType]; ok {
+				if pd, ok := entDef.Properties[propName]; ok {
+					pi.def = &pd
+					pi.enumIndex = buildEnumIndex(&pd, meta)
+				}
+			}
+		}
+		propInfoCache[entityType] = &pi
+		return &pi
+	}
+
+	sort.SliceStable(entities, func(i, j int) bool {
+		valI := entities[i].Properties[propName]
+		valJ := entities[j].Properties[propName]
+
+		// Handle nil values - sort them to the end
+		if valI == nil && valJ == nil {
+			return false
+		}
+		if valI == nil {
+			return false
+		}
+		if valJ == nil {
+			return true
+		}
+
+		piI := getPropInfo(entities[i].Type)
+		piJ := getPropInfo(entities[j].Type)
+
+		less := comparePropValues(valI, valJ, piI, piJ, meta)
+
+		if descending {
+			return !less
+		}
+		return less
+	})
+}
+
+// comparePropValues compares two property values using their respective property definitions.
+func comparePropValues(valI, valJ interface{}, piI, piJ *propInfo, meta *metamodel.Metamodel) bool {
+	switch {
+	case piI.def != nil && piJ.def != nil && piI.def.Type == piJ.def.Type:
+		// Same property type on both entities — use type-aware comparison
+		return compareByPropDef(valI, valJ, piI.def, piI.enumIndex)
+	case piI.def != nil && piJ.def != nil:
+		// Different property types — compare by type rank
+		rankI := typeRank(piI.def, meta)
+		rankJ := typeRank(piJ.def, meta)
+		if rankI != rankJ {
+			return rankI < rankJ
+		}
+		return compareStrings(valI, valJ)
+	case piI.def != nil:
+		// Only I has a property def — I comes first
+		return true
+	case piJ.def != nil:
+		// Only J has a property def — J comes first
+		return false
+	default:
+		// Neither has a property def — string comparison
+		return compareStrings(valI, valJ)
+	}
+}
+
+// compareByPropDef compares two values using the given property definition.
+func compareByPropDef(valI, valJ interface{}, propDef *metamodel.PropertyDef, enumIndex map[string]int) bool {
+	switch propDef.Type {
+	case metamodel.PropertyTypeDate:
+		return compareDates(valI, valJ, propDef)
+	case metamodel.PropertyTypeInteger:
+		return compareIntegers(valI, valJ)
+	case metamodel.PropertyTypeBoolean:
+		return compareBooleans(valI, valJ)
+	case metamodel.PropertyTypeEnum:
+		return compareEnums(valI, valJ, enumIndex)
+	default:
+		if enumIndex != nil {
+			return compareEnums(valI, valJ, enumIndex)
+		}
+		return compareStrings(valI, valJ)
+	}
+}
+
+// Type rank constants for cross-type property comparison.
+// Lower rank sorts first when property types differ.
+const (
+	typeRankInteger = iota + 1
+	typeRankDate
+	typeRankBoolean
+	typeRankEnum
+	typeRankString
+)
+
+// typeRank returns a numeric rank for property types, used when comparing
+// values across different property types. Lower rank sorts first.
+func typeRank(propDef *metamodel.PropertyDef, meta *metamodel.Metamodel) int {
+	switch propDef.Type {
+	case metamodel.PropertyTypeInteger:
+		return typeRankInteger
+	case metamodel.PropertyTypeDate:
+		return typeRankDate
+	case metamodel.PropertyTypeBoolean:
+		return typeRankBoolean
+	case metamodel.PropertyTypeEnum:
+		return typeRankEnum
+	case metamodel.PropertyTypeString:
+		return typeRankString
+	default:
+		// Custom types (enums) rank with enum
+		if meta != nil {
+			if _, ok := meta.Types[propDef.Type]; ok {
+				return typeRankEnum
+			}
+		}
+		return typeRankString
+	}
 }

--- a/internal/filter/sort_test.go
+++ b/internal/filter/sort_test.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
@@ -77,6 +78,50 @@ func TestSortDate(t *testing.T) {
 		got := e.Properties["date"].(string)
 		if got != want[i] {
 			t.Errorf("Sort[%d].date = %s, want %s", i, got, want[i])
+		}
+	}
+}
+
+func TestSortDateTimeValues(t *testing.T) {
+	// YAML parser produces time.Time values for dates, not strings.
+	// This test verifies that compareDates handles time.Time correctly.
+	propDef := &metamodel.PropertyDef{
+		Type:   metamodel.PropertyTypeDate,
+		Format: "2006-01-02",
+	}
+
+	d1 := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	d2 := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+	d3 := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	entities := []*model.Entity{
+		{ID: "1", Properties: map[string]interface{}{"date": d1}},
+		{ID: "2", Properties: map[string]interface{}{"date": d2}},
+		{ID: "3", Properties: map[string]interface{}{"date": d3}},
+	}
+
+	Sort(entities, "date", propDef, nil, false)
+
+	wantIDs := []string{"2", "3", "1"}
+	for i, e := range entities {
+		if e.ID != wantIDs[i] {
+			t.Errorf("Sort[%d].ID = %s, want %s", i, e.ID, wantIDs[i])
+		}
+	}
+
+	// Test with nil date sorts to end
+	entities = []*model.Entity{
+		{ID: "1", Properties: map[string]interface{}{"date": d1}},
+		{ID: "2", Properties: map[string]interface{}{}},
+		{ID: "3", Properties: map[string]interface{}{"date": d2}},
+	}
+
+	Sort(entities, "date", propDef, nil, false)
+
+	wantIDs = []string{"3", "1", "2"}
+	for i, e := range entities {
+		if e.ID != wantIDs[i] {
+			t.Errorf("Sort with nil[%d].ID = %s, want %s", i, e.ID, wantIDs[i])
 		}
 	}
 }
@@ -298,5 +343,434 @@ func TestSortEnumUnknownValue(t *testing.T) {
 	// Known values should come first (in order), unknown values sorted alphabetically at end
 	if entities[0].Properties["priority"] != "critical" {
 		t.Errorf("Expected critical first, got %v", entities[0].Properties["priority"])
+	}
+}
+
+// --- SortMulti tests ---
+
+func TestSortMulti_SingleSpec(t *testing.T) {
+	entityDefs := map[string]*metamodel.EntityDef{
+		"item": {Properties: map[string]metamodel.PropertyDef{
+			"title": {Type: metamodel.PropertyTypeString},
+		}},
+	}
+
+	entities := []*model.Entity{
+		{ID: "1", Type: "item", Properties: map[string]interface{}{"title": "Charlie"}},
+		{ID: "2", Type: "item", Properties: map[string]interface{}{"title": "Alice"}},
+		{ID: "3", Type: "item", Properties: map[string]interface{}{"title": "Bob"}},
+	}
+
+	SortMulti(entities, []model.SortSpec{{Property: "title"}}, entityDefs, nil)
+
+	want := []string{"Alice", "Bob", "Charlie"}
+	for i, e := range entities {
+		if e.Properties["title"] != want[i] {
+			t.Errorf("SortMulti[%d].title = %v, want %s", i, e.Properties["title"], want[i])
+		}
+	}
+}
+
+func TestSortMulti_MultipleSpecs(t *testing.T) {
+	meta := &metamodel.Metamodel{
+		Types: map[string]metamodel.CustomType{
+			"priority": {Values: []string{"high", "medium", "low"}},
+		},
+	}
+	entityDefs := map[string]*metamodel.EntityDef{
+		"item": {Properties: map[string]metamodel.PropertyDef{
+			"priority": {Type: "priority"},
+			"title":    {Type: metamodel.PropertyTypeString},
+		}},
+	}
+
+	entities := []*model.Entity{
+		{ID: "1", Type: "item", Properties: map[string]interface{}{"priority": "high", "title": "Zebra"}},
+		{ID: "2", Type: "item", Properties: map[string]interface{}{"priority": "high", "title": "Alpha"}},
+		{ID: "3", Type: "item", Properties: map[string]interface{}{"priority": "low", "title": "Beta"}},
+		{ID: "4", Type: "item", Properties: map[string]interface{}{"priority": "medium", "title": "Gamma"}},
+	}
+
+	// Sort by priority asc, then title asc as tiebreaker
+	SortMulti(entities, []model.SortSpec{
+		{Property: "priority"},
+		{Property: "title"},
+	}, entityDefs, meta)
+
+	// Expected: high+Alpha, high+Zebra, medium+Gamma, low+Beta
+	wantIDs := []string{"2", "1", "4", "3"}
+	for i, e := range entities {
+		if e.ID != wantIDs[i] {
+			t.Errorf("SortMulti multiple [%d].ID = %s, want %s", i, e.ID, wantIDs[i])
+		}
+	}
+}
+
+func TestSortMulti_IDVirtualProperty(t *testing.T) {
+	entities := []*model.Entity{
+		{ID: "C-001", Type: "item"},
+		{ID: "A-001", Type: "item"},
+		{ID: "B-001", Type: "item"},
+	}
+
+	SortMulti(entities, []model.SortSpec{{Property: "id"}}, nil, nil)
+
+	wantIDs := []string{"A-001", "B-001", "C-001"}
+	for i, e := range entities {
+		if e.ID != wantIDs[i] {
+			t.Errorf("SortMulti id [%d] = %s, want %s", i, e.ID, wantIDs[i])
+		}
+	}
+
+	// Descending
+	SortMulti(entities, []model.SortSpec{{Property: "id", Direction: "desc"}}, nil, nil)
+
+	wantIDs = []string{"C-001", "B-001", "A-001"}
+	for i, e := range entities {
+		if e.ID != wantIDs[i] {
+			t.Errorf("SortMulti id desc [%d] = %s, want %s", i, e.ID, wantIDs[i])
+		}
+	}
+}
+
+func TestSortMulti_ModifiedVirtualProperty(t *testing.T) {
+	now := time.Now()
+	entities := []*model.Entity{
+		{ID: "1", Type: "item", ModTime: now.Add(-2 * time.Hour)},
+		{ID: "2", Type: "item", ModTime: now},
+		{ID: "3", Type: "item", ModTime: now.Add(-1 * time.Hour)},
+	}
+
+	SortMulti(entities, []model.SortSpec{{Property: "modified"}}, nil, nil)
+
+	// Oldest first
+	wantIDs := []string{"1", "3", "2"}
+	for i, e := range entities {
+		if e.ID != wantIDs[i] {
+			t.Errorf("SortMulti modified [%d] = %s, want %s", i, e.ID, wantIDs[i])
+		}
+	}
+
+	// Newest first
+	SortMulti(entities, []model.SortSpec{{Property: "modified", Direction: "desc"}}, nil, nil)
+
+	wantIDs = []string{"2", "3", "1"}
+	for i, e := range entities {
+		if e.ID != wantIDs[i] {
+			t.Errorf("SortMulti modified desc [%d] = %s, want %s", i, e.ID, wantIDs[i])
+		}
+	}
+}
+
+func TestSortMulti_ModifiedZeroTimeSortsToEnd(t *testing.T) {
+	now := time.Now()
+	entities := []*model.Entity{
+		{ID: "1", Type: "item"}, // zero time
+		{ID: "2", Type: "item", ModTime: now},
+		{ID: "3", Type: "item"}, // zero time
+	}
+
+	SortMulti(entities, []model.SortSpec{{Property: "modified"}}, nil, nil)
+
+	if entities[0].ID != "2" {
+		t.Errorf("Expected entity with ModTime first, got %s", entities[0].ID)
+	}
+}
+
+func TestSortMulti_MixedEntityTypes(t *testing.T) {
+	entityDefs := map[string]*metamodel.EntityDef{
+		"requirement": {Properties: map[string]metamodel.PropertyDef{
+			"title": {Type: metamodel.PropertyTypeString},
+		}},
+		"decision": {Properties: map[string]metamodel.PropertyDef{
+			"title": {Type: metamodel.PropertyTypeString},
+		}},
+	}
+
+	entities := []*model.Entity{
+		{ID: "1", Type: "requirement", Properties: map[string]interface{}{"title": "Zulu"}},
+		{ID: "2", Type: "decision", Properties: map[string]interface{}{"title": "Alpha"}},
+		{ID: "3", Type: "requirement", Properties: map[string]interface{}{"title": "Mike"}},
+	}
+
+	SortMulti(entities, []model.SortSpec{{Property: "title"}}, entityDefs, nil)
+
+	wantIDs := []string{"2", "3", "1"}
+	for i, e := range entities {
+		if e.ID != wantIDs[i] {
+			t.Errorf("SortMulti mixed types [%d] = %s, want %s", i, e.ID, wantIDs[i])
+		}
+	}
+}
+
+func TestSortMulti_NilPropertyOnSomeEntities(t *testing.T) {
+	entityDefs := map[string]*metamodel.EntityDef{
+		"item": {Properties: map[string]metamodel.PropertyDef{
+			"priority": {Type: metamodel.PropertyTypeInteger},
+		}},
+	}
+
+	entities := []*model.Entity{
+		{ID: "1", Type: "item", Properties: map[string]interface{}{}},
+		{ID: "2", Type: "item", Properties: map[string]interface{}{"priority": 5}},
+		{ID: "3", Type: "item", Properties: map[string]interface{}{"priority": 1}},
+	}
+
+	SortMulti(entities, []model.SortSpec{{Property: "priority"}}, entityDefs, nil)
+
+	// Entities with values first (sorted), nil at end
+	if entities[0].ID != "3" {
+		t.Errorf("Expected entity 3 (priority 1) first, got %s", entities[0].ID)
+	}
+	if entities[1].ID != "2" {
+		t.Errorf("Expected entity 2 (priority 5) second, got %s", entities[1].ID)
+	}
+	if entities[2].ID != "1" {
+		t.Errorf("Expected entity 1 (no priority) last, got %s", entities[2].ID)
+	}
+}
+
+func TestSortMulti_EmptySpecs(t *testing.T) {
+	entities := []*model.Entity{
+		{ID: "C-001"},
+		{ID: "A-001"},
+	}
+
+	// Should not panic or change order
+	SortMulti(entities, nil, nil, nil)
+	if entities[0].ID != "C-001" {
+		t.Error("SortMulti with nil specs should not change order")
+	}
+
+	SortMulti(entities, []model.SortSpec{}, nil, nil)
+	if entities[0].ID != "C-001" {
+		t.Error("SortMulti with empty specs should not change order")
+	}
+}
+
+func TestSortMulti_EmptyEntities(_ *testing.T) {
+	// Should not panic
+	SortMulti(nil, []model.SortSpec{{Property: "id"}}, nil, nil)
+	SortMulti([]*model.Entity{}, []model.SortSpec{{Property: "id"}}, nil, nil)
+}
+
+func TestSortMulti_CrossTypeSamePropertyType(t *testing.T) {
+	// Two different entity types with the same property type — should use type-aware comparison
+	entityDefs := map[string]*metamodel.EntityDef{
+		"bug": {Properties: map[string]metamodel.PropertyDef{
+			"score": {Type: metamodel.PropertyTypeInteger},
+		}},
+		"feature": {Properties: map[string]metamodel.PropertyDef{
+			"score": {Type: metamodel.PropertyTypeInteger},
+		}},
+	}
+
+	entities := []*model.Entity{
+		{ID: "1", Type: "bug", Properties: map[string]interface{}{"score": 10}},
+		{ID: "2", Type: "feature", Properties: map[string]interface{}{"score": 3}},
+		{ID: "3", Type: "bug", Properties: map[string]interface{}{"score": 7}},
+	}
+
+	SortMulti(entities, []model.SortSpec{{Property: "score"}}, entityDefs, nil)
+
+	wantIDs := []string{"2", "3", "1"} // 3, 7, 10
+	for i, e := range entities {
+		if e.ID != wantIDs[i] {
+			t.Errorf("CrossType same prop type [%d] = %s, want %s", i, e.ID, wantIDs[i])
+		}
+	}
+}
+
+func TestSortMulti_CrossTypeDifferentPropertyType(t *testing.T) {
+	// Different entity types with different property types for the same name
+	// Should compare by type rank: integer (1) < date (2) < boolean (3) < enum (4) < string (5)
+	entityDefs := map[string]*metamodel.EntityDef{
+		"typeA": {Properties: map[string]metamodel.PropertyDef{
+			"value": {Type: metamodel.PropertyTypeString},
+		}},
+		"typeB": {Properties: map[string]metamodel.PropertyDef{
+			"value": {Type: metamodel.PropertyTypeInteger},
+		}},
+	}
+
+	entities := []*model.Entity{
+		{ID: "1", Type: "typeA", Properties: map[string]interface{}{"value": "hello"}},
+		{ID: "2", Type: "typeB", Properties: map[string]interface{}{"value": 42}},
+	}
+
+	SortMulti(entities, []model.SortSpec{{Property: "value"}}, entityDefs, nil)
+
+	// Integer rank (1) < String rank (5), so typeB entity should come first
+	if entities[0].ID != "2" {
+		t.Errorf("Expected integer-typed entity first, got %s", entities[0].ID)
+	}
+	if entities[1].ID != "1" {
+		t.Errorf("Expected string-typed entity second, got %s", entities[1].ID)
+	}
+}
+
+func TestSortMulti_CrossTypeDifferentPropertyTypeSameRankFallback(t *testing.T) {
+	// Two different types with same rank — should fall back to string comparison
+	entityDefs := map[string]*metamodel.EntityDef{
+		"typeA": {Properties: map[string]metamodel.PropertyDef{
+			"value": {Type: metamodel.PropertyTypeString},
+		}},
+		"typeB": {Properties: map[string]metamodel.PropertyDef{
+			"value": {Type: metamodel.PropertyTypeString},
+		}},
+	}
+
+	entities := []*model.Entity{
+		{ID: "1", Type: "typeA", Properties: map[string]interface{}{"value": "zebra"}},
+		{ID: "2", Type: "typeB", Properties: map[string]interface{}{"value": "alpha"}},
+	}
+
+	SortMulti(entities, []model.SortSpec{{Property: "value"}}, entityDefs, nil)
+
+	if entities[0].ID != "2" {
+		t.Errorf("Expected 'alpha' first, got entity %s", entities[0].ID)
+	}
+}
+
+func TestSortMulti_OnlyOneEntityHasPropertyDef(t *testing.T) {
+	// One entity type has the property, the other doesn't
+	entityDefs := map[string]*metamodel.EntityDef{
+		"typeA": {Properties: map[string]metamodel.PropertyDef{
+			"priority": {Type: metamodel.PropertyTypeString},
+		}},
+		"typeB": {Properties: map[string]metamodel.PropertyDef{
+			// no "priority" property
+		}},
+	}
+
+	entities := []*model.Entity{
+		{ID: "1", Type: "typeB", Properties: map[string]interface{}{"priority": "low"}},
+		{ID: "2", Type: "typeA", Properties: map[string]interface{}{"priority": "high"}},
+	}
+
+	SortMulti(entities, []model.SortSpec{{Property: "priority"}}, entityDefs, nil)
+
+	// Entity with property def comes first
+	if entities[0].ID != "2" {
+		t.Errorf("Expected entity with prop def first, got %s", entities[0].ID)
+	}
+}
+
+func TestSortMulti_NeitherEntityHasPropertyDef(t *testing.T) {
+	// Neither entity type has the property defined — falls back to string comparison
+	entityDefs := map[string]*metamodel.EntityDef{
+		"typeA": {Properties: map[string]metamodel.PropertyDef{}},
+		"typeB": {Properties: map[string]metamodel.PropertyDef{}},
+	}
+
+	entities := []*model.Entity{
+		{ID: "1", Type: "typeA", Properties: map[string]interface{}{"name": "Zulu"}},
+		{ID: "2", Type: "typeB", Properties: map[string]interface{}{"name": "Alpha"}},
+	}
+
+	SortMulti(entities, []model.SortSpec{{Property: "name"}}, entityDefs, nil)
+
+	if entities[0].ID != "2" {
+		t.Errorf("Expected 'Alpha' first via string comparison, got entity %s", entities[0].ID)
+	}
+}
+
+func TestSortMulti_NilEntityDefs(t *testing.T) {
+	// entityDefs is nil — all properties compared as strings
+	entities := []*model.Entity{
+		{ID: "1", Type: "item", Properties: map[string]interface{}{"name": "Zulu"}},
+		{ID: "2", Type: "item", Properties: map[string]interface{}{"name": "Alpha"}},
+	}
+
+	SortMulti(entities, []model.SortSpec{{Property: "name"}}, nil, nil)
+
+	if entities[0].ID != "2" {
+		t.Errorf("Expected 'Alpha' first, got entity %s", entities[0].ID)
+	}
+}
+
+func TestTypeRank(t *testing.T) {
+	meta := &metamodel.Metamodel{
+		Types: map[string]metamodel.CustomType{
+			"priority": {Values: []string{"high", "low"}},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		propDef  *metamodel.PropertyDef
+		wantRank int
+	}{
+		{"integer", &metamodel.PropertyDef{Type: metamodel.PropertyTypeInteger}, typeRankInteger},
+		{"date", &metamodel.PropertyDef{Type: metamodel.PropertyTypeDate}, typeRankDate},
+		{"boolean", &metamodel.PropertyDef{Type: metamodel.PropertyTypeBoolean}, typeRankBoolean},
+		{"enum", &metamodel.PropertyDef{Type: metamodel.PropertyTypeEnum}, typeRankEnum},
+		{"string", &metamodel.PropertyDef{Type: metamodel.PropertyTypeString}, typeRankString},
+		{"custom type (known)", &metamodel.PropertyDef{Type: "priority"}, typeRankEnum},
+		{"custom type (unknown)", &metamodel.PropertyDef{Type: "nonexistent"}, typeRankString},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := typeRank(tt.propDef, meta)
+			if got != tt.wantRank {
+				t.Errorf("typeRank(%s) = %d, want %d", tt.name, got, tt.wantRank)
+			}
+		})
+	}
+
+	// Test with nil meta — unknown types fall back to string
+	got := typeRank(&metamodel.PropertyDef{Type: "priority"}, nil)
+	if got != typeRankString {
+		t.Errorf("typeRank with nil meta = %d, want %d", got, typeRankString)
+	}
+}
+
+func TestCompareByPropDef_AllTypes(t *testing.T) {
+	// Test date comparison through compareByPropDef
+	dateDef := &metamodel.PropertyDef{Type: metamodel.PropertyTypeDate, Format: "2006-01-02"}
+	if !compareByPropDef("2025-01-01", "2025-06-01", dateDef, nil) {
+		t.Error("compareByPropDef date: expected 2025-01-01 < 2025-06-01")
+	}
+
+	// Test boolean comparison through compareByPropDef
+	boolDef := &metamodel.PropertyDef{Type: metamodel.PropertyTypeBoolean}
+	if !compareByPropDef(false, true, boolDef, nil) {
+		t.Error("compareByPropDef bool: expected false < true")
+	}
+
+	// Test custom enum type via default branch
+	enumIndex := map[string]int{"high": 0, "medium": 1, "low": 2}
+	customDef := &metamodel.PropertyDef{Type: "priority"}
+	if !compareByPropDef("high", "low", customDef, enumIndex) {
+		t.Error("compareByPropDef custom enum: expected high < low")
+	}
+
+	// Test custom type without enum index — falls back to string
+	if !compareByPropDef("alpha", "beta", customDef, nil) {
+		t.Error("compareByPropDef custom no enum: expected alpha < beta")
+	}
+}
+
+func TestSortMulti_DescendingProperty(t *testing.T) {
+	entityDefs := map[string]*metamodel.EntityDef{
+		"item": {Properties: map[string]metamodel.PropertyDef{
+			"score": {Type: metamodel.PropertyTypeInteger},
+		}},
+	}
+
+	entities := []*model.Entity{
+		{ID: "1", Type: "item", Properties: map[string]interface{}{"score": 1}},
+		{ID: "2", Type: "item", Properties: map[string]interface{}{"score": 3}},
+		{ID: "3", Type: "item", Properties: map[string]interface{}{"score": 2}},
+	}
+
+	SortMulti(entities, []model.SortSpec{{Property: "score", Direction: "desc"}}, entityDefs, nil)
+
+	wantIDs := []string{"2", "3", "1"} // 3, 2, 1
+	for i, e := range entities {
+		if e.ID != wantIDs[i] {
+			t.Errorf("SortMulti descending [%d] = %s, want %s", i, e.ID, wantIDs[i])
+		}
 	}
 }

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -209,8 +209,35 @@ func validateEntitySemantics(m *Metamodel) []string {
 					"entity %q: property %q is type \"enum\" but has no 'values' list", name, propName))
 			}
 		}
+
+		errs = append(errs, validateDefaultSort(name, def)...)
 	}
 
+	return errs
+}
+
+// validateDefaultSort checks default_sort entries for an entity definition.
+func validateDefaultSort(entityName string, def EntityDef) []string {
+	var errs []string
+	for i, ss := range def.DefaultSort {
+		if ss.Property == "" {
+			errs = append(errs, fmt.Sprintf(
+				"entity %q: default_sort[%d] has no property specified", entityName, i))
+			continue
+		}
+		// "id" and "modified" are virtual sort properties
+		if ss.Property != "id" && ss.Property != "modified" {
+			if _, ok := def.Properties[ss.Property]; !ok {
+				errs = append(errs, fmt.Sprintf(
+					"entity %q: default_sort references unknown property %q", entityName, ss.Property))
+			}
+		}
+		if ss.Direction != "" && ss.Direction != "asc" && ss.Direction != "desc" {
+			errs = append(errs, fmt.Sprintf(
+				"entity %q: default_sort[%d] has invalid direction %q (use \"asc\" or \"desc\")",
+				entityName, i, ss.Direction))
+		}
+	}
 	return errs
 }
 

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -1,6 +1,10 @@
 package metamodel
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
 
 // Metamodel represents the full metamodel configuration
 type Metamodel struct {
@@ -74,6 +78,7 @@ type EntityDef struct {
 	IDPrefixes  []string               `yaml:"id_prefixes,omitempty"` // Multiple ID prefixes
 	RDFType     string                 `yaml:"rdf_type,omitempty"`
 	Properties  map[string]PropertyDef `yaml:"properties"`
+	DefaultSort []model.SortSpec       `yaml:"default_sort,omitempty"` // Default sort order for this entity type
 	Color       string                 `yaml:"color,omitempty"`
 	BorderColor string                 `yaml:"border_color,omitempty"`
 }

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -11,8 +11,9 @@ import (
 type FileType string
 
 const (
-	FileTypeMetamodel FileType = "metamodel" // metamodel.yaml
-	FileTypeViews     FileType = "views"     // views.yaml (future)
+	FileTypeMetamodel FileType = "metamodel"  // metamodel.yaml
+	FileTypeViews     FileType = "views"      // views.yaml (future)
+	FileTypeDataEntry FileType = "data-entry" // data-entry.yaml
 )
 
 // Migration defines the interface for schema migrations.

--- a/internal/migration/sort_config_list.go
+++ b/internal/migration/sort_config_list.go
@@ -1,0 +1,74 @@
+package migration
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func init() {
+	Register(&SortConfigListMigration{})
+}
+
+// SortConfigListMigration converts the sort config from a single mapping object
+// to a list (sequence) format in data-entry.yaml files.
+//
+// Before:
+//
+//	sort:
+//	  property: priority
+//	  direction: desc
+//
+// After:
+//
+//	sort:
+//	  - property: priority
+//	    direction: desc
+type SortConfigListMigration struct{}
+
+func (m *SortConfigListMigration) Name() string {
+	return "sort-config-to-list"
+}
+
+func (m *SortConfigListMigration) Description() string {
+	return `Convert sort config from single object to list format`
+}
+
+func (m *SortConfigListMigration) FileTypes() []FileType {
+	return []FileType{FileTypeDataEntry}
+}
+
+func (m *SortConfigListMigration) Detect(doc *yaml.Node) bool {
+	entries := FindMapEntriesByKey(doc, "sort")
+	for _, entry := range entries {
+		if entry[1].Kind == yaml.MappingNode {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *SortConfigListMigration) Apply(doc *yaml.Node) error {
+	root := GetDocumentRoot(doc)
+	if root == nil {
+		return fmt.Errorf("empty document")
+	}
+
+	WalkMappings(doc, func(node *yaml.Node) bool {
+		for i := 0; i < len(node.Content)-1; i += 2 {
+			keyNode := node.Content[i]
+			valNode := node.Content[i+1]
+			if keyNode.Value == "sort" && valNode.Kind == yaml.MappingNode {
+				// Wrap the mapping in a sequence
+				seqNode := &yaml.Node{
+					Kind:    yaml.SequenceNode,
+					Tag:     "!!seq",
+					Content: []*yaml.Node{valNode},
+				}
+				node.Content[i+1] = seqNode
+			}
+		}
+		return true
+	})
+	return nil
+}

--- a/internal/migration/sort_config_list_test.go
+++ b/internal/migration/sort_config_list_test.go
@@ -1,0 +1,204 @@
+package migration
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestSortConfigListMigration_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		expected bool
+	}{
+		{
+			name: "detects single sort object in list",
+			yaml: `
+lists:
+  tickets:
+    entity_type: ticket
+    sort:
+      property: priority
+      direction: desc
+`,
+			expected: true,
+		},
+		{
+			name: "detects single sort object in dashboard card",
+			yaml: `
+dashboard:
+  cards:
+    - title: Recent
+      query: "type:ticket"
+      display: table
+      sort:
+        property: modified
+        direction: desc
+`,
+			expected: true,
+		},
+		{
+			name: "no detection when sort is already a list",
+			yaml: `
+lists:
+  tickets:
+    entity_type: ticket
+    sort:
+      - property: priority
+        direction: desc
+`,
+			expected: false,
+		},
+		{
+			name: "no detection when no sort key",
+			yaml: `
+lists:
+  tickets:
+    entity_type: ticket
+    columns:
+      - property: title
+`,
+			expected: false,
+		},
+		{
+			name: "detects sort object in one of multiple lists",
+			yaml: `
+lists:
+  tickets:
+    entity_type: ticket
+    sort:
+      - property: priority
+        direction: desc
+  bugs:
+    entity_type: bug
+    sort:
+      property: severity
+      direction: desc
+`,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var doc yaml.Node
+			if err := yaml.Unmarshal([]byte(tt.yaml), &doc); err != nil {
+				t.Fatalf("failed to parse yaml: %v", err)
+			}
+
+			migration := &SortConfigListMigration{}
+			result := migration.Detect(&doc)
+
+			if result != tt.expected {
+				t.Errorf("Detect() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSortConfigListMigration_Apply(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "converts single sort object to list",
+			input: `lists:
+  tickets:
+    sort:
+      property: priority
+      direction: desc
+`,
+			expected: `lists:
+    tickets:
+        sort:
+            - property: priority
+              direction: desc
+`,
+		},
+		{
+			name: "converts sort in dashboard card",
+			input: `dashboard:
+  cards:
+    - title: Recent
+      sort:
+        property: modified
+        direction: desc
+`,
+			expected: `dashboard:
+    cards:
+        - title: Recent
+          sort:
+            - property: modified
+              direction: desc
+`,
+		},
+		{
+			name: "preserves existing list format",
+			input: `lists:
+  tickets:
+    sort:
+      - property: priority
+        direction: desc
+`,
+			expected: `lists:
+    tickets:
+        sort:
+            - property: priority
+              direction: desc
+`,
+		},
+		{
+			name: "converts multiple sort objects across sections",
+			input: `lists:
+  tickets:
+    sort:
+      property: priority
+      direction: desc
+dashboard:
+  cards:
+    - title: Recent
+      sort:
+        property: modified
+        direction: desc
+`,
+			expected: `lists:
+    tickets:
+        sort:
+            - property: priority
+              direction: desc
+dashboard:
+    cards:
+        - title: Recent
+          sort:
+            - property: modified
+              direction: desc
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var doc yaml.Node
+			if err := yaml.Unmarshal([]byte(tt.input), &doc); err != nil {
+				t.Fatalf("failed to parse input yaml: %v", err)
+			}
+
+			migration := &SortConfigListMigration{}
+			if err := migration.Apply(&doc); err != nil {
+				t.Fatalf("Apply() error = %v", err)
+			}
+
+			result, err := yaml.Marshal(&doc)
+			if err != nil {
+				t.Fatalf("failed to marshal result: %v", err)
+			}
+
+			if string(result) != tt.expected {
+				t.Errorf("Apply() result mismatch\nGot:\n%s\nWant:\n%s", string(result), tt.expected)
+			}
+		})
+	}
+}

--- a/internal/model/sort.go
+++ b/internal/model/sort.go
@@ -1,0 +1,14 @@
+package model
+
+// SortSpec describes a single sort criterion used in queries, metamodel default_sort,
+// and data entry config. Property can be a real entity property name or a virtual
+// property: "id" (entity ID) or "modified" (file modification time).
+type SortSpec struct {
+	Property  string `yaml:"property"  json:"property"`
+	Direction string `yaml:"direction,omitempty" json:"direction,omitempty"` // "asc" (default) or "desc"
+}
+
+// IsDescending returns true if direction is "desc".
+func (s SortSpec) IsDescending() bool {
+	return s.Direction == "desc"
+}

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/Sourcehaven-BV/rela/internal/filter"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/tui/searchparser"
 )
@@ -187,6 +188,35 @@ func (s *SearchModel) updateSuggestions(app *App) {
 	case "status":
 		// Status is a common property shortcut, use same logic as propvalue
 		s.suggestions = s.getPropertyValueSuggestions(app, "status", ctx.Prefix)
+		s.showSuggestions = len(s.suggestions) > 0
+
+	case "sort":
+		// Suggest property names plus virtual properties "id" and "modified"
+		propMap := make(map[string]bool)
+		propMap["id"] = true
+		propMap["modified"] = true
+		for _, entityDef := range app.metamodel.Entities {
+			for propName := range entityDef.Properties {
+				propMap[propName] = true
+			}
+		}
+		s.suggestions = []string{}
+		for propName := range propMap {
+			if strings.HasPrefix(strings.ToLower(propName), strings.ToLower(ctx.Prefix)) {
+				s.suggestions = append(s.suggestions, propName)
+			}
+		}
+		sort.Strings(s.suggestions)
+		s.showSuggestions = len(s.suggestions) > 0
+
+	case "sortdir":
+		// Suggest "asc" and "desc"
+		s.suggestions = []string{}
+		for _, dir := range []string{"asc", "desc"} {
+			if strings.HasPrefix(dir, strings.ToLower(ctx.Prefix)) {
+				s.suggestions = append(s.suggestions, dir)
+			}
+		}
 		s.showSuggestions = len(s.suggestions) > 0
 
 	default:
@@ -402,6 +432,20 @@ func (s *SearchModel) acceptSuggestion() {
 	case "status":
 		s.query = prefix + "status:" + suggestion + " " + suffix
 		s.cursorPos = len(prefix) + len("status:") + len(suggestion) + 1
+	case "sort":
+		// After accepting a sort property, add ":" so user can type direction
+		s.query = prefix + "sort:" + suggestion + ":" + suffix
+		s.cursorPos = len(prefix) + len("sort:") + len(suggestion) + 1
+	case "sortdir":
+		// Find the sort: token start, rebuild with chosen direction
+		currentToken := s.query[tokenStart:s.cursorPos]
+		// currentToken is like "sort:property:de" — replace everything after last ":"
+		lastColon := strings.LastIndex(currentToken, ":")
+		if lastColon != -1 {
+			beforeDir := s.query[:tokenStart] + currentToken[:lastColon+1]
+			s.query = beforeDir + suggestion + " " + suffix
+			s.cursorPos = len(beforeDir) + len(suggestion) + 1
+		}
 	}
 
 	// Hide suggestions after accepting
@@ -487,7 +531,83 @@ func (s *SearchModel) performSearch(app *App, query string) (results []*model.En
 		}
 	}
 
+	// Validate sort properties against result set
+	if sq.HasSort() {
+		allProps := collectAllPropertyNames(app.metamodel, filtered)
+		for _, sc := range sq.SortClauses {
+			if sc.Property != "id" && sc.Property != "modified" && !allProps[sc.Property] {
+				errors = append(errors, fmt.Sprintf("sort: unknown property %q", sc.Property))
+			}
+		}
+		if len(errors) > 0 {
+			return filtered, errors
+		}
+	}
+
+	// Apply sort
+	if sq.HasSort() {
+		entityDefs := collectEntityDefs(app.metamodel, filtered)
+		filter.SortMulti(filtered, sq.SortClauses, entityDefs, app.metamodel)
+	} else {
+		// Apply default_sort if single entity type
+		types := uniqueTypes(filtered)
+		if len(types) == 1 {
+			if def, ok := app.metamodel.GetEntityDef(types[0]); ok && len(def.DefaultSort) > 0 {
+				entityDefs := map[string]*metamodel.EntityDef{types[0]: def}
+				filter.SortMulti(filtered, def.DefaultSort, entityDefs, app.metamodel)
+			} else {
+				filter.SortByID(filtered, false)
+			}
+		} else {
+			filter.SortByID(filtered, false)
+		}
+	}
+
 	return filtered, nil
+}
+
+// collectEntityDefs builds a map of entity type definitions for the given entities.
+func collectEntityDefs(meta *metamodel.Metamodel, entities []*model.Entity) map[string]*metamodel.EntityDef {
+	defs := make(map[string]*metamodel.EntityDef)
+	for _, e := range entities {
+		if _, ok := defs[e.Type]; !ok {
+			if def, ok := meta.GetEntityDef(e.Type); ok {
+				defs[e.Type] = def
+			}
+		}
+	}
+	return defs
+}
+
+// collectAllPropertyNames returns a set of all property names across all entity types in the result set.
+func collectAllPropertyNames(meta *metamodel.Metamodel, entities []*model.Entity) map[string]bool {
+	seen := make(map[string]bool)
+	typesSeen := make(map[string]bool)
+	for _, e := range entities {
+		if typesSeen[e.Type] {
+			continue
+		}
+		typesSeen[e.Type] = true
+		if def, ok := meta.GetEntityDef(e.Type); ok {
+			for propName := range def.Properties {
+				seen[propName] = true
+			}
+		}
+	}
+	return seen
+}
+
+// uniqueTypes returns the distinct entity types in the given slice.
+func uniqueTypes(entities []*model.Entity) []string {
+	seen := make(map[string]bool)
+	var types []string
+	for _, e := range entities {
+		if !seen[e.Type] {
+			seen[e.Type] = true
+			types = append(types, e.Type)
+		}
+	}
+	return types
 }
 
 // matchesFilters checks if an entity matches all search criteria
@@ -699,9 +819,12 @@ func (s *SearchModel) View(_, height int) string {
 		sb.WriteString("  prop:status=published         - filter by property\n")
 		sb.WriteString("  authentication                - free text search\n")
 		sb.WriteString("  \"exact phrase\"                - exact phrase match\n")
+		sb.WriteString("  sort:priority:desc            - sort by property\n")
+		sb.WriteString("  sort:modified:desc            - sort by last modified\n")
 		sb.WriteString("\n")
 		sb.WriteString("  type:requirement prop:priority>3 auth\n")
 		sb.WriteString("  type:decision,solution \"REST API\"\n")
+		sb.WriteString("  type:requirement sort:priority:desc sort:title\n")
 	}
 
 	return sb.String()
@@ -716,6 +839,7 @@ func (s *SearchModel) highlightSyntax(text string) string {
 	typeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("33"))   // blue
 	propStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("42"))   // green
 	quoteStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("226")) // yellow
+	sortStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("213"))  // magenta
 
 	// Parse text to handle quoted strings correctly
 	var result strings.Builder
@@ -759,6 +883,8 @@ func (s *SearchModel) highlightSyntax(text string) string {
 			result.WriteString(typeStyle.Render(token))
 		case strings.HasPrefix(token, "prop:"), strings.HasPrefix(token, "status:"):
 			result.WriteString(propStyle.Render(token))
+		case strings.HasPrefix(token, "sort:"):
+			result.WriteString(sortStyle.Render(token))
 		default:
 			result.WriteString(token)
 		}

--- a/internal/tui/searchparser/parser.go
+++ b/internal/tui/searchparser/parser.go
@@ -6,6 +6,7 @@ import (
 	"unicode"
 
 	"github.com/Sourcehaven-BV/rela/internal/filter"
+	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
 // SearchQuery represents parsed search query components
@@ -14,6 +15,7 @@ type SearchQuery struct {
 	PropertyFilters []*filter.Filter // Property filters (e.g., status=published)
 	FreeTextWords   []string         // Free text words (AND logic)
 	FreeTextPhrases []string         // Exact phrase matches (quoted strings)
+	SortClauses     []model.SortSpec // Sort criteria (e.g., sort:priority:desc)
 	ParseErrors     []string         // Any parsing errors encountered
 }
 
@@ -25,6 +27,7 @@ func ParseQuery(query string) *SearchQuery {
 		PropertyFilters: []*filter.Filter{},
 		FreeTextWords:   []string{},
 		FreeTextPhrases: []string{},
+		SortClauses:     []model.SortSpec{},
 		ParseErrors:     []string{},
 	}
 
@@ -85,6 +88,33 @@ func ParseQuery(query string) *SearchQuery {
 				continue
 			}
 			sq.PropertyFilters = append(sq.PropertyFilters, f)
+			continue
+		}
+
+		// Check for sort clause
+		if strings.HasPrefix(token, "sort:") {
+			sortStr := strings.TrimPrefix(token, "sort:")
+			if sortStr == "" {
+				sq.ParseErrors = append(sq.ParseErrors, "sort: requires a property name")
+				continue
+			}
+			parts := strings.SplitN(sortStr, ":", 2)
+			property := parts[0]
+			direction := "asc"
+			if len(parts) == 2 {
+				switch parts[1] {
+				case "asc", "desc":
+					direction = parts[1]
+				default:
+					sq.ParseErrors = append(sq.ParseErrors,
+						fmt.Sprintf("sort: invalid direction %q (use \"asc\" or \"desc\")", parts[1]))
+					continue
+				}
+			}
+			sq.SortClauses = append(sq.SortClauses, model.SortSpec{
+				Property:  property,
+				Direction: direction,
+			})
 			continue
 		}
 
@@ -165,7 +195,13 @@ func (sq *SearchQuery) HasFreeText() bool {
 	return len(sq.FreeTextWords) > 0 || len(sq.FreeTextPhrases) > 0
 }
 
-// IsEmpty returns true if the query has no search components
+// HasSort returns true if the query has any sort clauses
+func (sq *SearchQuery) HasSort() bool {
+	return len(sq.SortClauses) > 0
+}
+
+// IsEmpty returns true if the query has no search components.
+// A query with only sort clauses is still considered empty (sort without results is meaningless).
 func (sq *SearchQuery) IsEmpty() bool {
 	return !sq.HasFilters() && !sq.HasFreeText()
 }
@@ -242,6 +278,24 @@ func GetAutocompleteContext(query string, cursorPos int) *AutocompleteContext {
 		return &AutocompleteContext{
 			Type:   "status",
 			Prefix: prefix,
+		}
+	}
+
+	// Check if we're in the middle of a sort: clause
+	if strings.HasPrefix(currentToken, "sort:") {
+		sortPart := strings.TrimPrefix(currentToken, "sort:")
+		parts := strings.SplitN(sortPart, ":", 2)
+		if len(parts) == 2 {
+			// After property name, completing direction
+			return &AutocompleteContext{
+				Type:   "sortdir",
+				Prefix: parts[1],
+			}
+		}
+		// Completing property name
+		return &AutocompleteContext{
+			Type:   "sort",
+			Prefix: parts[0],
 		}
 	}
 

--- a/internal/tui/searchparser/parser_test.go
+++ b/internal/tui/searchparser/parser_test.go
@@ -197,6 +197,162 @@ func TestTokenize(t *testing.T) {
 	}
 }
 
+func TestParseQuery_SortClause(t *testing.T) {
+	sq := ParseQuery("sort:priority")
+	if len(sq.SortClauses) != 1 {
+		t.Fatalf("Expected 1 sort clause, got %d", len(sq.SortClauses))
+	}
+	if sq.SortClauses[0].Property != "priority" {
+		t.Errorf("Expected property 'priority', got %s", sq.SortClauses[0].Property)
+	}
+	if sq.SortClauses[0].Direction != "asc" {
+		t.Errorf("Expected direction 'asc', got %s", sq.SortClauses[0].Direction)
+	}
+}
+
+func TestParseQuery_SortClauseDesc(t *testing.T) {
+	sq := ParseQuery("sort:priority:desc")
+	if len(sq.SortClauses) != 1 {
+		t.Fatalf("Expected 1 sort clause, got %d", len(sq.SortClauses))
+	}
+	if sq.SortClauses[0].Property != "priority" {
+		t.Errorf("Expected property 'priority', got %s", sq.SortClauses[0].Property)
+	}
+	if sq.SortClauses[0].Direction != "desc" {
+		t.Errorf("Expected direction 'desc', got %s", sq.SortClauses[0].Direction)
+	}
+}
+
+func TestParseQuery_SortClauseAscExplicit(t *testing.T) {
+	sq := ParseQuery("sort:title:asc")
+	if len(sq.SortClauses) != 1 {
+		t.Fatalf("Expected 1 sort clause, got %d", len(sq.SortClauses))
+	}
+	if sq.SortClauses[0].Direction != "asc" {
+		t.Errorf("Expected direction 'asc', got %s", sq.SortClauses[0].Direction)
+	}
+}
+
+func TestParseQuery_SortVirtualProperties(t *testing.T) {
+	sq := ParseQuery("sort:id sort:modified:desc")
+	if len(sq.SortClauses) != 2 {
+		t.Fatalf("Expected 2 sort clauses, got %d", len(sq.SortClauses))
+	}
+	if sq.SortClauses[0].Property != "id" {
+		t.Errorf("Expected 'id', got %s", sq.SortClauses[0].Property)
+	}
+	if sq.SortClauses[1].Property != "modified" {
+		t.Errorf("Expected 'modified', got %s", sq.SortClauses[1].Property)
+	}
+	if sq.SortClauses[1].Direction != "desc" {
+		t.Errorf("Expected 'desc', got %s", sq.SortClauses[1].Direction)
+	}
+}
+
+func TestParseQuery_MultipleSortClauses(t *testing.T) {
+	sq := ParseQuery("sort:priority:desc sort:title")
+	if len(sq.SortClauses) != 2 {
+		t.Fatalf("Expected 2 sort clauses, got %d", len(sq.SortClauses))
+	}
+	if sq.SortClauses[0].Property != "priority" || sq.SortClauses[0].Direction != "desc" {
+		t.Errorf("First sort clause wrong: %+v", sq.SortClauses[0])
+	}
+	if sq.SortClauses[1].Property != "title" || sq.SortClauses[1].Direction != "asc" {
+		t.Errorf("Second sort clause wrong: %+v", sq.SortClauses[1])
+	}
+}
+
+func TestParseQuery_SortEmpty(t *testing.T) {
+	sq := ParseQuery("sort:")
+	if len(sq.ParseErrors) == 0 {
+		t.Error("Expected parse error for empty sort")
+	}
+}
+
+func TestParseQuery_SortInvalidDirection(t *testing.T) {
+	sq := ParseQuery("sort:priority:invalid")
+	if len(sq.ParseErrors) == 0 {
+		t.Error("Expected parse error for invalid sort direction")
+	}
+	if len(sq.SortClauses) != 0 {
+		t.Error("Expected no sort clauses for invalid direction")
+	}
+}
+
+func TestParseQuery_SortCombined(t *testing.T) {
+	sq := ParseQuery(`type:requirement prop:status=draft sort:priority:desc auth`)
+	if len(sq.EntityTypes) != 1 || sq.EntityTypes[0] != "requirement" {
+		t.Errorf("Expected type 'requirement', got %v", sq.EntityTypes)
+	}
+	if len(sq.PropertyFilters) != 1 {
+		t.Errorf("Expected 1 property filter, got %d", len(sq.PropertyFilters))
+	}
+	if len(sq.SortClauses) != 1 || sq.SortClauses[0].Property != "priority" {
+		t.Errorf("Expected sort by priority, got %v", sq.SortClauses)
+	}
+	if len(sq.FreeTextWords) != 1 || sq.FreeTextWords[0] != "auth" {
+		t.Errorf("Expected free text 'auth', got %v", sq.FreeTextWords)
+	}
+}
+
+func TestParseQuery_SortOnlyIsEmpty(t *testing.T) {
+	sq := ParseQuery("sort:priority:desc")
+	// A query with only sort and no filters/text is considered empty
+	if !sq.IsEmpty() {
+		t.Error("Expected query with only sort to be empty")
+	}
+	if !sq.HasSort() {
+		t.Error("Expected HasSort to be true")
+	}
+}
+
+func TestParseQuery_SortNotAFilter(t *testing.T) {
+	sq := ParseQuery("sort:priority")
+	if sq.HasFilters() {
+		t.Error("Sort clauses should not count as filters")
+	}
+}
+
+func TestAutocompleteContext_Sort(t *testing.T) {
+	ctx := GetAutocompleteContext("sort:", 5)
+	if ctx.Type != "sort" {
+		t.Errorf("Expected type 'sort', got %s", ctx.Type)
+	}
+	if ctx.Prefix != "" {
+		t.Errorf("Expected empty prefix, got %s", ctx.Prefix)
+	}
+}
+
+func TestAutocompleteContext_SortWithPrefix(t *testing.T) {
+	ctx := GetAutocompleteContext("sort:pri", 8)
+	if ctx.Type != "sort" {
+		t.Errorf("Expected type 'sort', got %s", ctx.Type)
+	}
+	if ctx.Prefix != "pri" {
+		t.Errorf("Expected prefix 'pri', got %s", ctx.Prefix)
+	}
+}
+
+func TestAutocompleteContext_SortDir(t *testing.T) {
+	ctx := GetAutocompleteContext("sort:priority:", 14)
+	if ctx.Type != "sortdir" {
+		t.Errorf("Expected type 'sortdir', got %s", ctx.Type)
+	}
+	if ctx.Prefix != "" {
+		t.Errorf("Expected empty prefix, got %s", ctx.Prefix)
+	}
+}
+
+func TestAutocompleteContext_SortDirWithPrefix(t *testing.T) {
+	ctx := GetAutocompleteContext("sort:priority:de", 16)
+	if ctx.Type != "sortdir" {
+		t.Errorf("Expected type 'sortdir', got %s", ctx.Type)
+	}
+	if ctx.Prefix != "de" {
+		t.Errorf("Expected prefix 'de', got %s", ctx.Prefix)
+	}
+}
+
 func TestErrorString(t *testing.T) {
 	sq := &SearchQuery{
 		ParseErrors: []string{"error1", "error2"},


### PR DESCRIPTION
## Summary

- Add `sort:` clause to search query syntax with multi-key sorting support (`sort:priority:desc sort:title`)
- Add `default_sort` field to metamodel entity definitions for declarative sort order
- Add `SortMulti()` function for type-aware multi-key sorting with cross-type property resolution
- Add sort chip/pill support to data entry search UI with two-stage autocomplete (property, then direction)
- Add data entry config migration from single sort object to list format
- Wire sort into TUI search, CLI `--sort`/`--desc` flags, and data entry list/dashboard handlers

## Query syntax examples

```
sort:priority                           # sort by priority ascending
sort:priority:desc                      # sort by priority descending  
sort:id:desc                            # sort by entity ID descending
sort:modified:desc                      # newest modified first
sort:priority:desc sort:title           # multi-sort: priority desc, then title asc
type:ticket sort:status sort:due_date   # tickets sorted by status then due date
```

## Test plan

- [x] `SortMulti` unit tests (single key, multi-key, virtual properties, nil handling, cross-type)
- [x] Search parser tests for `sort:` clauses, autocomplete contexts, error cases
- [x] Migration tests for sort config object-to-list conversion
- [x] Metamodel `default_sort` validation tests (unknown property, invalid direction)
- [x] Data entry helpers tests updated for `[]model.SortSpec`
- [x] Manual QA: CLI sort, data entry server sort, TUI search sort, dashboard sort
- [x] Manual QA: data entry search chips with sort autocomplete and direction picker
- [x] Full test suite passes with race detection