### PR TITLE
Add auto_open option for command file output

### DIFF
--- a/docs-project/entities/feature/FEAT-data-entry.md
+++ b/docs-project/entities/feature/FEAT-data-entry.md
@@ -9,3 +9,5 @@ summary: "Config-driven web UI for creating, editing, and browsing entities"
 HTMX-based web application configured entirely through `data-entry.yaml`.
 Provides forms, filterable lists, detail views, dashboards, search,
 sidebar navigation with optional grouping, and user-defined commands.
+Commands run shell scripts with structured output and can auto-open
+generated files.

--- a/docs-project/entities/guide/GUIDE-data-entry.md
+++ b/docs-project/entities/guide/GUIDE-data-entry.md
@@ -812,6 +812,7 @@ commands:
 | `available_on` | object | Restrict where the button appears (optional)           |
 | `confirm`      | string | Confirmation prompt before execution (optional)        |
 | `env`          | map    | Custom environment variables (optional)                |
+| `auto_open`    | bool   | Auto-open output files on completion (optional)        |
 
 ### Context Scopes
 
@@ -889,6 +890,28 @@ echo '::rela::{"type":"file","path":"/tmp/data.csv","label":"CSV Data","action":
 echo '::rela::{"type":"endgroup"}'
 echo '::rela::{"type":"message","text":"Done!","level":"info"}'
 ```
+
+### Auto-Open
+
+When `auto_open: true` is set on a command, all output files with `action: "open"` are
+automatically opened when the command completes successfully, and the toast is dismissed.
+This is useful for commands that produce a single output file where the extra click to
+open it would be redundant:
+
+```yaml
+commands:
+  generate-pdf:
+    label: "Generate PDF"
+    script: |
+      PDF="/tmp/report-${RELA_ENTITY_ID}.pdf"
+      # ... generate PDF ...
+      echo "::rela::{\"type\":\"file\",\"path\":\"$PDF\",\"label\":\"Report\",\"action\":\"open\"}"
+    context: entity
+    auto_open: true
+```
+
+If the command fails or no files have `action: "open"`, the toast stays visible with
+the normal interactive buttons.
 
 ### Streaming and Cancellation
 
@@ -1110,6 +1133,18 @@ dashboard:
         - property: assignee
           label: "Assignee"
       limit: 5
+
+commands:
+  generate-pdf:
+    label: "Generate PDF"
+    script: |
+      PDF="/tmp/ticket-${RELA_ENTITY_ID}.pdf"
+      # ... generate PDF ...
+      echo "::rela::{\"type\":\"file\",\"path\":\"$PDF\",\"label\":\"Ticket PDF\",\"action\":\"open\"}"
+    context: entity
+    auto_open: true
+    available_on:
+      entity_types: [ticket]
 
 navigation:
   - label: "Dashboard"

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -804,6 +804,7 @@ commands:
 | `available_on` | object | Restrict where the button appears (optional)           |
 | `confirm`      | string | Confirmation prompt before execution (optional)        |
 | `env`          | map    | Custom environment variables (optional)                |
+| `auto_open`    | bool   | Auto-open output files on completion (optional)        |
 
 ### Context Scopes
 
@@ -881,6 +882,28 @@ echo '::rela::{"type":"file","path":"/tmp/data.csv","label":"CSV Data","action":
 echo '::rela::{"type":"endgroup"}'
 echo '::rela::{"type":"message","text":"Done!","level":"info"}'
 ```
+
+### Auto-Open
+
+When `auto_open: true` is set on a command, all output files with `action: "open"` are
+automatically opened when the command completes successfully, and the toast is dismissed.
+This is useful for commands that produce a single output file where the extra click to
+open it would be redundant:
+
+```yaml
+commands:
+  generate-pdf:
+    label: "Generate PDF"
+    script: |
+      PDF="/tmp/report-${RELA_ENTITY_ID}.pdf"
+      # ... generate PDF ...
+      echo "::rela::{\"type\":\"file\",\"path\":\"$PDF\",\"label\":\"Report\",\"action\":\"open\"}"
+    context: entity
+    auto_open: true
+```
+
+If the command fails or no files have `action: "open"`, the toast stays visible with
+the normal interactive buttons.
 
 ### Streaming and Cancellation
 
@@ -1102,6 +1125,18 @@ dashboard:
         - property: assignee
           label: "Assignee"
       limit: 5
+
+commands:
+  generate-pdf:
+    label: "Generate PDF"
+    script: |
+      PDF="/tmp/ticket-${RELA_ENTITY_ID}.pdf"
+      # ... generate PDF ...
+      echo "::rela::{\"type\":\"file\",\"path\":\"$PDF\",\"label\":\"Ticket PDF\",\"action\":\"open\"}"
+    context: entity
+    auto_open: true
+    available_on:
+      entity_types: [ticket]
 
 navigation:
   - label: "Dashboard"

--- a/internal/dataentry/commands.go
+++ b/internal/dataentry/commands.go
@@ -23,10 +23,11 @@ const commandOutputPrefix = "::rela::"
 
 // ResolvedCommand is a command that has been matched to a specific page context.
 type ResolvedCommand struct {
-	ID      string
-	Label   string
-	Confirm string
-	Context string
+	ID       string
+	Label    string
+	Confirm  string
+	Context  string
+	AutoOpen *bool
 }
 
 // resolveCommands returns commands available for a given page context.
@@ -50,10 +51,11 @@ func (a *App) resolveCommands(pageType, qualifier, entityType string) []Resolved
 		cmd := a.Cfg.Commands[id]
 		if matchesPage(cmd, pageType, qualifier, entityType) {
 			result = append(result, ResolvedCommand{
-				ID:      id,
-				Label:   cmd.Label,
-				Confirm: cmd.Confirm,
-				Context: cmd.Context,
+				ID:       id,
+				Label:    cmd.Label,
+				Confirm:  cmd.Confirm,
+				Context:  cmd.Context,
+				AutoOpen: cmd.AutoOpen,
 			})
 		}
 	}

--- a/internal/dataentry/commands_test.go
+++ b/internal/dataentry/commands_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
@@ -111,6 +113,37 @@ func TestResolveCommands(t *testing.T) {
 		cmds := app2.resolveCommands("entity", "", "ticket")
 		if cmds != nil {
 			t.Errorf("expected nil, got %v", cmds)
+		}
+	})
+
+	t.Run("auto_open propagated to resolved command", func(t *testing.T) {
+		app2 := testAppInstance()
+		trueVal := true
+		app2.Cfg.Commands = map[string]CommandConfig{
+			"auto-cmd": {
+				Label:    "Auto",
+				Script:   "echo hi",
+				Context:  "entity",
+				AutoOpen: &trueVal,
+			},
+			"normal-cmd": {
+				Label:   "Normal",
+				Script:  "echo hi",
+				Context: "entity",
+			},
+		}
+		cmds := app2.resolveCommands("entity", "", "ticket")
+		for _, c := range cmds {
+			if c.ID == "auto-cmd" {
+				if c.AutoOpen == nil || !*c.AutoOpen {
+					t.Error("expected auto-cmd to have AutoOpen=true")
+				}
+			}
+			if c.ID == "normal-cmd" {
+				if c.AutoOpen != nil {
+					t.Error("expected normal-cmd to have AutoOpen=nil")
+				}
+			}
 		}
 	})
 
@@ -486,6 +519,63 @@ func TestValidateCommandConfig(t *testing.T) {
 		errs := validateConfig(cfg, meta)
 		if !hasError(errs, "unknown entity type") {
 			t.Errorf("expected entity type error, got %v", errs)
+		}
+	})
+}
+
+func TestCommandConfigAutoOpenYAML(t *testing.T) {
+	t.Run("true, false, and omitted", func(t *testing.T) {
+		yamlData := []byte(`
+commands:
+  gen-pdf:
+    label: Generate PDF
+    script: echo hi
+    context: entity
+    auto_open: true
+  no-auto:
+    label: No Auto
+    script: echo hi
+    context: entity
+    auto_open: false
+  export:
+    label: Export
+    script: echo hi
+    context: entity
+`)
+		var cfg Config
+		if err := yaml.Unmarshal(yamlData, &cfg); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		genPDF := cfg.Commands["gen-pdf"]
+		if genPDF.AutoOpen == nil || !*genPDF.AutoOpen {
+			t.Error("expected gen-pdf auto_open to be true")
+		}
+		noAuto := cfg.Commands["no-auto"]
+		if noAuto.AutoOpen == nil {
+			t.Fatal("expected no-auto auto_open to be non-nil")
+		}
+		if *noAuto.AutoOpen {
+			t.Error("expected no-auto auto_open to be false")
+		}
+		export := cfg.Commands["export"]
+		if export.AutoOpen != nil {
+			t.Errorf("expected export auto_open to be nil, got %v", *export.AutoOpen)
+		}
+	})
+
+	t.Run("boolTrue template func", func(t *testing.T) {
+		funcs := templateFuncs(nil, nil)
+		fn := funcs["boolTrue"].(func(*bool) bool)
+		trueVal := true
+		falseVal := false
+		if !fn(&trueVal) {
+			t.Error("boolTrue(&true) should be true")
+		}
+		if fn(&falseVal) {
+			t.Error("boolTrue(&false) should be false")
+		}
+		if fn(nil) {
+			t.Error("boolTrue(nil) should be false")
 		}
 	})
 }

--- a/internal/dataentry/config.go
+++ b/internal/dataentry/config.go
@@ -210,6 +210,7 @@ type CommandConfig struct {
 	AvailableOn *CommandScope     `yaml:"available_on,omitempty"`
 	Confirm     string            `yaml:"confirm,omitempty"`
 	Env         map[string]string `yaml:"env,omitempty"`
+	AutoOpen    *bool             `yaml:"auto_open,omitempty"`
 }
 
 // CommandScope controls where a command button appears in the UI.

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -419,6 +419,7 @@ func templateFuncs(styleMap map[string]map[string]string, styledTypes map[string
 			return styledTypes[propType]
 		},
 		"add":            func(a, b int) int { return a + b },
+		"boolTrue":       func(b *bool) bool { return b != nil && *b },
 		"renderMarkdown": simpleMarkdownToHTML,
 		"map": func(pairs ...interface{}) map[string]interface{} {
 			m := make(map[string]interface{}, len(pairs)/2)

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -320,6 +320,7 @@ function runCommand(commandID, params) {
 
   var execID = 'cmd-' + Date.now() + '-' + Math.random().toString(36).substr(2, 6);
   var label = btn.textContent.trim();
+  var autoOpen = btn.getAttribute('data-auto-open') === 'true';
 
   var container = document.getElementById('command-toast-container');
   var toast = _createToast(execID, label);
@@ -328,7 +329,7 @@ function runCommand(commandID, params) {
   var qs = new URLSearchParams(params);
   qs.set('exec_id', execID);
 
-  _cmdToasts[execID] = { toast: toast, messages: [], logs: [], hoverPause: false, aborted: false };
+  _cmdToasts[execID] = { toast: toast, messages: [], logs: [], hoverPause: false, aborted: false, autoOpen: autoOpen, files: [] };
 
   toast.addEventListener('mouseenter', function() { _cmdToasts[execID].hoverPause = true; });
   toast.addEventListener('mouseleave', function() { _cmdToasts[execID].hoverPause = false; });
@@ -446,6 +447,7 @@ function _addFile(execID, msg) {
   if (!state) return;
   var label = msg.label || msg.path.split('/').pop();
   var action = msg.action || 'none';
+  if (state.files) state.files.push({ path: msg.path, action: action });
   var actionHtml = '';
   if (action === 'open') {
     actionHtml = '<a href="#" onclick="event.preventDefault();_openFile(\'' + _escAttr(execID) + '\',\'' + _escAttr(msg.path) + '\',\'open\')">Open</a>' +
@@ -550,6 +552,21 @@ function _finishToast(execID, success) {
   if (success) {
     t.className = 'command-toast success';
     t.querySelector('.command-toast-icon').innerHTML = '&#10003;';
+    // Auto-open: open all files with action "open" and dismiss toast.
+    if (state.autoOpen && state.files && state.files.length > 0) {
+      var opened = 0;
+      for (var i = 0; i < state.files.length; i++) {
+        var f = state.files[i];
+        if (f.action === 'open') {
+          fetch('/api/open-file?path=' + encodeURIComponent(f.path) + '&action=open', { method: 'POST' });
+          opened++;
+        }
+      }
+      if (opened > 0) {
+        _dismissToast(execID);
+        return;
+      }
+    }
     if (!state.hasActions) _autoHide(execID, 5000);
   } else {
     t.className = 'command-toast error';
@@ -810,12 +827,12 @@ document.body.addEventListener('htmx:pushedIntoHistory', function() {
     <details class="add-dropdown">
       <summary class="btn btn-secondary btn-sm">Commands &#9662;</summary>
       <div class="add-dropdown-menu">
-        {{ range .Commands }}<a href="#" onclick="event.preventDefault();runCommand('{{ .ID }}', {list_id:'{{ $.ListID }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</a>
+        {{ range .Commands }}<a href="#" onclick="event.preventDefault();runCommand('{{ .ID }}', {list_id:'{{ $.ListID }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}{{ if boolTrue .AutoOpen }} data-auto-open="true"{{ end }}>{{ .Label }}</a>
         {{ end }}
       </div>
     </details>
     {{ else }}{{ range .Commands }}
-    <button class="btn btn-secondary btn-sm" onclick="runCommand('{{ .ID }}', {list_id:'{{ $.ListID }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</button>
+    <button class="btn btn-secondary btn-sm" onclick="runCommand('{{ .ID }}', {list_id:'{{ $.ListID }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}{{ if boolTrue .AutoOpen }} data-auto-open="true"{{ end }}>{{ .Label }}</button>
     {{ end }}{{ end }}{{ end }}
   </div>
 </div>
@@ -1179,12 +1196,12 @@ function submitInlineCreate() {
     <details class="add-dropdown">
       <summary class="btn btn-secondary btn-sm">Commands &#9662;</summary>
       <div class="add-dropdown-menu">
-        {{ range .Commands }}<a href="#" onclick="event.preventDefault();runCommand('{{ .ID }}', {entity_id:'{{ $.Entity.ID }}',entity_type:'{{ $.Entity.Type }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</a>
+        {{ range .Commands }}<a href="#" onclick="event.preventDefault();runCommand('{{ .ID }}', {entity_id:'{{ $.Entity.ID }}',entity_type:'{{ $.Entity.Type }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}{{ if boolTrue .AutoOpen }} data-auto-open="true"{{ end }}>{{ .Label }}</a>
         {{ end }}
       </div>
     </details>
     {{ else }}{{ range .Commands }}
-    <button class="btn btn-secondary btn-sm" onclick="runCommand('{{ .ID }}', {entity_id:'{{ $.Entity.ID }}',entity_type:'{{ $.Entity.Type }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</button>
+    <button class="btn btn-secondary btn-sm" onclick="runCommand('{{ .ID }}', {entity_id:'{{ $.Entity.ID }}',entity_type:'{{ $.Entity.Type }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}{{ if boolTrue .AutoOpen }} data-auto-open="true"{{ end }}>{{ .Label }}</button>
     {{ end }}{{ end }}{{ end }}
     <a href="{{ .BackURL }}" class="btn btn-secondary btn-sm"
        hx-get="{{ .BackURL }}" hx-target="#content" hx-push-url="true">&larr; Back</a>
@@ -1269,12 +1286,12 @@ function submitInlineCreate() {
     <details class="add-dropdown">
       <summary class="btn btn-secondary btn-sm">Commands &#9662;</summary>
       <div class="add-dropdown-menu">
-        {{ range .Commands }}<a href="#" onclick="event.preventDefault();runCommand('{{ .ID }}', {entity_id:'{{ $.Entry.ID }}',entity_type:'{{ $.Entry.Type }}',view_id:'{{ $.ViewID }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</a>
+        {{ range .Commands }}<a href="#" onclick="event.preventDefault();runCommand('{{ .ID }}', {entity_id:'{{ $.Entry.ID }}',entity_type:'{{ $.Entry.Type }}',view_id:'{{ $.ViewID }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}{{ if boolTrue .AutoOpen }} data-auto-open="true"{{ end }}>{{ .Label }}</a>
         {{ end }}
       </div>
     </details>
     {{ else }}{{ range .Commands }}
-    <button class="btn btn-secondary btn-sm" onclick="runCommand('{{ .ID }}', {entity_id:'{{ $.Entry.ID }}',entity_type:'{{ $.Entry.Type }}',view_id:'{{ $.ViewID }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</button>
+    <button class="btn btn-secondary btn-sm" onclick="runCommand('{{ .ID }}', {entity_id:'{{ $.Entry.ID }}',entity_type:'{{ $.Entry.Type }}',view_id:'{{ $.ViewID }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}{{ if boolTrue .AutoOpen }} data-auto-open="true"{{ end }}>{{ .Label }}</button>
     {{ end }}{{ end }}{{ end }}
     <a href="{{ .BackURL }}" class="btn btn-secondary btn-sm"
        hx-get="{{ .BackURL }}" hx-target="#content" hx-push-url="true">&larr; Back</a>
@@ -2017,12 +2034,12 @@ function submitInlineCreate() {
     <details class="add-dropdown">
       <summary class="btn btn-secondary btn-sm">Commands &#9662;</summary>
       <div class="add-dropdown-menu">
-        {{ range .Commands }}<a href="#" onclick="event.preventDefault();runCommand('{{ .ID }}', {})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</a>
+        {{ range .Commands }}<a href="#" onclick="event.preventDefault();runCommand('{{ .ID }}', {})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}{{ if boolTrue .AutoOpen }} data-auto-open="true"{{ end }}>{{ .Label }}</a>
         {{ end }}
       </div>
     </details>
     {{ else }}{{ range .Commands }}
-    <button class="btn btn-secondary btn-sm" onclick="runCommand('{{ .ID }}', {})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}>{{ .Label }}</button>
+    <button class="btn btn-secondary btn-sm" onclick="runCommand('{{ .ID }}', {})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}{{ if boolTrue .AutoOpen }} data-auto-open="true"{{ end }}>{{ .Label }}</button>
     {{ end }}{{ end }}
   </div>
   {{ end }}


### PR DESCRIPTION
## Summary
- Add `auto_open: true` config option to commands in `data-entry.yaml` that automatically opens output files when a command completes successfully, eliminating the extra click for single-file outputs
- Fix edge case where toast was dismissed even when no files had `action: "open"` (only `"reveal"` files present)
- Document the full commands configuration in the data entry guide: fields, context types, output protocol, scoping, auto-open behavior, and button layout

## Test plan
- [x] Unit tests for YAML parsing of `auto_open` (true, false, omitted)
- [x] Unit test for `boolTrue` template helper (true, false, nil)
- [x] Unit test for `AutoOpen` propagation through `resolveCommands`
- [x] All existing tests pass (no regressions)
- [x] Lint clean
- [x] Race detector clean
- [ ] Manual test: command with `auto_open: true` producing 1 file → auto-opens
- [ ] Manual test: command without `auto_open` → normal toast behavior
- [ ] Manual test: command with `auto_open: true` that fails → toast stays with error