### PR TITLE
Add analysis page to data entry app

### DIFF
--- a/docs-project/entities/guide/GUIDE-data-entry.md
+++ b/docs-project/entities/guide/GUIDE-data-entry.md
@@ -1192,6 +1192,18 @@ views.yaml, but adapted for HTML rendering:
 If you already have a `views.yaml`, you can reuse the same traverse rules in your data-entry
 views and add `sections` for HTML rendering.
 
+## Analysis
+
+The data entry app includes a built-in analysis page at `/analyze` that runs the same quality
+checks as the CLI's `rela analyze all` command. It checks properties, cardinality constraints,
+custom validations, orphans, duplicates, and ID gaps — displaying results grouped by category
+with links to affected entities.
+
+When a dashboard is configured, a validation summary card is automatically appended showing the
+total error and warning counts with a link to the full analysis page.
+
+No configuration is needed — the analysis page is always available in the sidebar.
+
 ## Best Practices
 
 1. **Start with navigation** - Decide which entity types users will work with most, and create

--- a/docs-project/relations/GUIDE-data-entry--covers--FEAT-analysis.md
+++ b/docs-project/relations/GUIDE-data-entry--covers--FEAT-analysis.md
@@ -1,0 +1,5 @@
+---
+from: GUIDE-data-entry
+relation: covers
+to: FEAT-analysis
+---

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1184,6 +1184,18 @@ views.yaml, but adapted for HTML rendering:
 If you already have a `views.yaml`, you can reuse the same traverse rules in your data-entry
 views and add `sections` for HTML rendering.
 
+## Analysis
+
+The data entry app includes a built-in analysis page at `/analyze` that runs the same quality
+checks as the CLI's `rela analyze all` command. It checks properties, cardinality constraints,
+custom validations, orphans, duplicates, and ID gaps — displaying results grouped by category
+with links to affected entities.
+
+When a dashboard is configured, a validation summary card is automatically appended showing the
+total error and warning counts with a link to the full analysis page.
+
+No configuration is needed — the analysis page is always available in the sidebar.
+
 ## Best Practices
 
 1. **Start with navigation** - Decide which entity types users will work with most, and create

--- a/internal/dataentry/analyze.go
+++ b/internal/dataentry/analyze.go
@@ -1,0 +1,446 @@
+package dataentry
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/filter"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+// AnalysisIssue represents a single validation issue, optionally linked to an entity.
+type AnalysisIssue struct {
+	EntityID   string // Empty for non-entity issues (e.g., ID gaps)
+	EntityType string
+	Title      string
+	Message    string
+	Severity   string // "error" or "warning"
+}
+
+// AnalysisSection groups issues by analysis category.
+type AnalysisSection struct {
+	Name        string
+	Description string
+	Issues      []AnalysisIssue
+}
+
+// ErrorCount returns the number of error-severity issues in this section.
+func (s AnalysisSection) ErrorCount() int {
+	n := 0
+	for _, issue := range s.Issues {
+		if issue.Severity == "error" {
+			n++
+		}
+	}
+	return n
+}
+
+// WarningCount returns the number of warning-severity issues in this section.
+func (s AnalysisSection) WarningCount() int {
+	n := 0
+	for _, issue := range s.Issues {
+		if issue.Severity == "warning" {
+			n++
+		}
+	}
+	return n
+}
+
+// AnalysisResult is the complete output of running all analyses.
+type AnalysisResult struct {
+	Sections     []AnalysisSection
+	ErrorCount   int
+	WarningCount int
+}
+
+// runAnalysis executes all analysis checks and returns a combined result.
+func (a *App) runAnalysis() AnalysisResult {
+	sections := []AnalysisSection{
+		a.analyzeProperties(),
+		a.analyzeCardinality(),
+		a.analyzeValidations(),
+		a.analyzeOrphans(),
+		a.analyzeDuplicates(),
+		a.analyzeGaps(),
+	}
+
+	var errors, warnings int
+	for _, s := range sections {
+		errors += s.ErrorCount()
+		warnings += s.WarningCount()
+	}
+
+	return AnalysisResult{
+		Sections:     sections,
+		ErrorCount:   errors,
+		WarningCount: warnings,
+	}
+}
+
+// analysisIssueCounts returns just the total error and warning counts
+// without building the full issue details. Used by the dashboard.
+func (a *App) analysisIssueCounts() (errors, warnings int) {
+	result := a.runAnalysis()
+	return result.ErrorCount, result.WarningCount
+}
+
+// analyzeOrphans finds entities with no connections.
+func (a *App) analyzeOrphans() AnalysisSection {
+	section := AnalysisSection{
+		Name:        "Orphans",
+		Description: "Entities with no incoming or outgoing relations",
+	}
+
+	orphans := a.g.FindOrphans()
+	sortEntitiesByID(orphans)
+
+	for _, e := range orphans {
+		section.Issues = append(section.Issues, AnalysisIssue{
+			EntityID:   e.ID,
+			EntityType: e.Type,
+			Title:      a.entityDisplayTitle(e),
+			Message:    "No relations",
+			Severity:   "warning",
+		})
+	}
+
+	return section
+}
+
+// analyzeDuplicates finds entities with identical normalized titles.
+func (a *App) analyzeDuplicates() AnalysisSection {
+	section := AnalysisSection{
+		Name:        "Duplicates",
+		Description: "Entities with identical titles",
+	}
+
+	entities := a.g.AllNodes()
+	titleGroups := make(map[string][]*model.Entity)
+	for _, e := range entities {
+		title := normalizeTitle(a.entityDisplayTitle(e))
+		if title != "" {
+			titleGroups[title] = append(titleGroups[title], e)
+		}
+	}
+
+	// Collect groups with duplicates, sorted by title
+	var titles []string
+	for title, group := range titleGroups {
+		if len(group) > 1 {
+			titles = append(titles, title)
+		}
+	}
+	sort.Strings(titles)
+
+	for _, title := range titles {
+		group := titleGroups[title]
+		sortEntitiesByID(group)
+		ids := make([]string, len(group))
+		for i, e := range group {
+			ids[i] = e.ID
+		}
+		for _, e := range group {
+			section.Issues = append(section.Issues, AnalysisIssue{
+				EntityID:   e.ID,
+				EntityType: e.Type,
+				Title:      a.entityDisplayTitle(e),
+				Message:    fmt.Sprintf("Duplicate title (shared by %s)", strings.Join(ids, ", ")),
+				Severity:   "warning",
+			})
+		}
+	}
+
+	return section
+}
+
+// analyzeGaps finds gaps in ID sequences for auto-numbered entity types.
+func (a *App) analyzeGaps() AnalysisSection {
+	section := AnalysisSection{
+		Name:        "ID Gaps",
+		Description: "Missing numbers in auto-generated ID sequences",
+	}
+
+	// Build set of manual ID prefixes to skip
+	manualPrefixes := make(map[string]bool)
+	for _, entityDef := range a.meta.Entities {
+		if entityDef.IsManualID() {
+			for _, idPrefix := range entityDef.GetIDPrefixes() {
+				manualPrefixes[strings.TrimSuffix(idPrefix, "-")] = true
+			}
+		}
+	}
+
+	// Group IDs by prefix
+	prefixGroups := make(map[string][]int)
+	for _, id := range a.g.AllIDs() {
+		parsed, err := model.ParseEntityID(id)
+		if err != nil || parsed.Prefix == "" {
+			continue
+		}
+		if manualPrefixes[strings.TrimSuffix(parsed.Prefix, "-")] {
+			continue
+		}
+		prefixGroups[parsed.Prefix] = append(prefixGroups[parsed.Prefix], parsed.Number)
+	}
+
+	// Sort prefixes for deterministic output
+	prefixes := make([]string, 0, len(prefixGroups))
+	for prefix := range prefixGroups {
+		prefixes = append(prefixes, prefix)
+	}
+	sort.Strings(prefixes)
+
+	for _, prefix := range prefixes {
+		numbers := prefixGroups[prefix]
+		sort.Ints(numbers)
+
+		var gaps []int
+		for i := 1; i < len(numbers); i++ {
+			for j := numbers[i-1] + 1; j < numbers[i]; j++ {
+				gaps = append(gaps, j)
+			}
+		}
+
+		for _, n := range gaps {
+			missingID := fmt.Sprintf("%s%03d", prefix, n)
+			section.Issues = append(section.Issues, AnalysisIssue{
+				Message:  fmt.Sprintf("Missing ID: %s", missingID),
+				Severity: "warning",
+			})
+		}
+	}
+
+	return section
+}
+
+// analyzeCardinality checks relation cardinality constraints.
+func (a *App) analyzeCardinality() AnalysisSection {
+	section := AnalysisSection{
+		Name:        "Cardinality",
+		Description: "Relation cardinality constraint violations",
+	}
+
+	// Sort relation names for deterministic output
+	relNames := make([]string, 0, len(a.meta.Relations))
+	for name := range a.meta.Relations {
+		relNames = append(relNames, name)
+	}
+	sort.Strings(relNames)
+
+	for _, relName := range relNames {
+		relDef := a.meta.Relations[relName]
+
+		// Check min_outgoing
+		if relDef.MinOutgoing != nil && *relDef.MinOutgoing > 0 {
+			for _, sourceType := range relDef.From {
+				entities := a.g.NodesByType(sourceType)
+				sortEntitiesByID(entities)
+				for _, e := range entities {
+					count := countEdgesByType(a.g.OutgoingEdges(e.ID), relName)
+					if count < *relDef.MinOutgoing {
+						section.Issues = append(section.Issues, AnalysisIssue{
+							EntityID:   e.ID,
+							EntityType: e.Type,
+							Title:      a.entityDisplayTitle(e),
+							Message:    fmt.Sprintf("Must have at least %d '%s' relation(s), has %d", *relDef.MinOutgoing, relName, count),
+							Severity:   "error",
+						})
+					}
+				}
+			}
+		}
+
+		// Check max_outgoing
+		if relDef.MaxOutgoing != nil {
+			for _, sourceType := range relDef.From {
+				entities := a.g.NodesByType(sourceType)
+				sortEntitiesByID(entities)
+				for _, e := range entities {
+					count := countEdgesByType(a.g.OutgoingEdges(e.ID), relName)
+					if count > *relDef.MaxOutgoing {
+						section.Issues = append(section.Issues, AnalysisIssue{
+							EntityID:   e.ID,
+							EntityType: e.Type,
+							Title:      a.entityDisplayTitle(e),
+							Message:    fmt.Sprintf("Has more than %d '%s' relation(s): %d", *relDef.MaxOutgoing, relName, count),
+							Severity:   "error",
+						})
+					}
+				}
+			}
+		}
+
+		// Check min_incoming
+		if relDef.MinIncoming != nil && *relDef.MinIncoming > 0 {
+			for _, targetType := range relDef.To {
+				entities := a.g.NodesByType(targetType)
+				sortEntitiesByID(entities)
+				for _, e := range entities {
+					count := countEdgesByType(a.g.IncomingEdges(e.ID), relName)
+					if count < *relDef.MinIncoming {
+						relLabel := relName
+						if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
+							relLabel = relDef.Inverse.GetID()
+						}
+						section.Issues = append(section.Issues, AnalysisIssue{
+							EntityID:   e.ID,
+							EntityType: e.Type,
+							Title:      a.entityDisplayTitle(e),
+							Message:    fmt.Sprintf("Must have at least %d '%s' relation(s), has %d", *relDef.MinIncoming, relLabel, count),
+							Severity:   "error",
+						})
+					}
+				}
+			}
+		}
+
+		// Check max_incoming
+		if relDef.MaxIncoming != nil {
+			for _, targetType := range relDef.To {
+				entities := a.g.NodesByType(targetType)
+				sortEntitiesByID(entities)
+				for _, e := range entities {
+					count := countEdgesByType(a.g.IncomingEdges(e.ID), relName)
+					if count > *relDef.MaxIncoming {
+						relLabel := relName
+						if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
+							relLabel = relDef.Inverse.GetID()
+						}
+						section.Issues = append(section.Issues, AnalysisIssue{
+							EntityID:   e.ID,
+							EntityType: e.Type,
+							Title:      a.entityDisplayTitle(e),
+							Message:    fmt.Sprintf("Has more than %d '%s' relation(s): %d", *relDef.MaxIncoming, relLabel, count),
+							Severity:   "error",
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return section
+}
+
+// analyzeProperties validates all entity properties against the metamodel.
+func (a *App) analyzeProperties() AnalysisSection {
+	section := AnalysisSection{
+		Name:        "Properties",
+		Description: "Property validation errors (required fields, invalid values, ID patterns)",
+	}
+
+	entities := a.g.AllNodes()
+	sortEntitiesByID(entities)
+
+	for _, entity := range entities {
+		errs := a.meta.ValidateEntity(entity)
+		for _, err := range errs {
+			section.Issues = append(section.Issues, AnalysisIssue{
+				EntityID:   entity.ID,
+				EntityType: entity.Type,
+				Title:      a.entityDisplayTitle(entity),
+				Message:    err.Error(),
+				Severity:   "error",
+			})
+		}
+	}
+
+	return section
+}
+
+// analyzeValidations runs custom validation rules from the metamodel.
+func (a *App) analyzeValidations() AnalysisSection {
+	section := AnalysisSection{
+		Name:        "Validations",
+		Description: "Custom validation rules defined in the metamodel",
+	}
+
+	for _, rule := range a.meta.Validations {
+		violations := a.checkValidationRule(rule)
+		severity := rule.GetSeverity()
+		for _, e := range violations {
+			section.Issues = append(section.Issues, AnalysisIssue{
+				EntityID:   e.ID,
+				EntityType: e.Type,
+				Title:      a.entityDisplayTitle(e),
+				Message:    rule.Description,
+				Severity:   severity,
+			})
+		}
+	}
+
+	return section
+}
+
+// checkValidationRule checks a single validation rule against applicable entities.
+func (a *App) checkValidationRule(rule metamodel.ValidationRule) []*model.Entity {
+	whenFilters, err := filter.ParseAll(rule.When)
+	if err != nil {
+		return nil
+	}
+	thenFilters, err := filter.ParseAll(rule.Then)
+	if err != nil {
+		return nil
+	}
+
+	var entities []*model.Entity
+	if rule.EntityType != "" {
+		entities = a.g.NodesByType(rule.EntityType)
+	} else {
+		entities = a.g.AllNodes()
+	}
+
+	var violations []*model.Entity
+	for _, entity := range entities {
+		entityDef, ok := a.meta.GetEntityDef(entity.Type)
+		if !ok {
+			continue
+		}
+
+		if len(whenFilters) > 0 {
+			matches, err := filter.MatchAll(entity, whenFilters, entityDef, a.meta)
+			if err != nil || !matches {
+				continue
+			}
+		}
+
+		satisfies, err := filter.MatchAll(entity, thenFilters, entityDef, a.meta)
+		if err != nil {
+			violations = append(violations, entity)
+			continue
+		}
+		if !satisfies {
+			violations = append(violations, entity)
+		}
+	}
+
+	return violations
+}
+
+// countEdgesByType counts relations of a specific type in a slice.
+func countEdgesByType(edges []*model.Relation, relType string) int {
+	n := 0
+	for _, e := range edges {
+		if e.Type == relType {
+			n++
+		}
+	}
+	return n
+}
+
+// sortEntitiesByID sorts entities by their ID for deterministic output.
+func sortEntitiesByID(entities []*model.Entity) {
+	sort.Slice(entities, func(i, j int) bool {
+		return entities[i].ID < entities[j].ID
+	})
+}
+
+// normalizeTitle normalizes a title for duplicate comparison.
+func normalizeTitle(s string) string {
+	s = strings.ToLower(s)
+	s = strings.TrimSpace(s)
+	fields := strings.Fields(s)
+	return strings.Join(fields, " ")
+}

--- a/internal/dataentry/analyze_test.go
+++ b/internal/dataentry/analyze_test.go
@@ -1,0 +1,477 @@
+package dataentry
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/graph"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+// newTestApp creates a minimal App with the given graph and metamodel for testing.
+func newTestApp(g *graph.Graph, meta *metamodel.Metamodel) *App {
+	return &App{
+		g:    g,
+		meta: meta,
+		Cfg:  &Config{},
+	}
+}
+
+func TestAnalyzeOrphans(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {Properties: map[string]metamodel.PropertyDef{
+				"title": {Type: "string", Required: true},
+			}},
+		},
+	}
+
+	g.AddNode(&model.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{"title": "Orphan"}})
+	g.AddNode(&model.Entity{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{"title": "Connected A"}})
+	g.AddNode(&model.Entity{ID: "T-003", Type: "ticket", Properties: map[string]interface{}{"title": "Connected B"}})
+	g.AddEdge(&model.Relation{From: "T-002", Type: "blocks", To: "T-003"})
+
+	app := newTestApp(g, meta)
+	section := app.analyzeOrphans()
+
+	if section.Name != "Orphans" {
+		t.Errorf("expected section name 'Orphans', got %q", section.Name)
+	}
+	if len(section.Issues) != 1 {
+		t.Fatalf("expected 1 orphan, got %d", len(section.Issues))
+	}
+	if section.Issues[0].EntityID != "T-001" {
+		t.Errorf("expected orphan T-001, got %s", section.Issues[0].EntityID)
+	}
+	if section.Issues[0].Severity != "warning" {
+		t.Errorf("expected severity 'warning', got %q", section.Issues[0].Severity)
+	}
+}
+
+func TestAnalyzeOrphans_NoOrphans(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {Properties: map[string]metamodel.PropertyDef{}},
+		},
+	}
+
+	g.AddNode(&model.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{}})
+	g.AddNode(&model.Entity{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{}})
+	g.AddEdge(&model.Relation{From: "T-001", Type: "blocks", To: "T-002"})
+
+	app := newTestApp(g, meta)
+	section := app.analyzeOrphans()
+
+	if len(section.Issues) != 0 {
+		t.Errorf("expected 0 orphans, got %d", len(section.Issues))
+	}
+}
+
+func TestAnalyzeDuplicates(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {Properties: map[string]metamodel.PropertyDef{
+				"title": {Type: "string", Required: true},
+			}},
+		},
+	}
+
+	g.AddNode(&model.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{"title": "Setup CI"}})
+	g.AddNode(&model.Entity{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{"title": "setup ci"}})
+	g.AddNode(&model.Entity{ID: "T-003", Type: "ticket", Properties: map[string]interface{}{"title": "Unique"}})
+
+	app := newTestApp(g, meta)
+	section := app.analyzeDuplicates()
+
+	if len(section.Issues) != 2 {
+		t.Fatalf("expected 2 duplicate issues (for the pair), got %d", len(section.Issues))
+	}
+	// Both should reference the same title group
+	if section.Issues[0].EntityID != "T-001" || section.Issues[1].EntityID != "T-002" {
+		t.Errorf("expected T-001 and T-002, got %s and %s",
+			section.Issues[0].EntityID, section.Issues[1].EntityID)
+	}
+}
+
+func TestAnalyzeDuplicates_NoDuplicates(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {Properties: map[string]metamodel.PropertyDef{
+				"title": {Type: "string"},
+			}},
+		},
+	}
+
+	g.AddNode(&model.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{"title": "Alpha"}})
+	g.AddNode(&model.Entity{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{"title": "Beta"}})
+
+	app := newTestApp(g, meta)
+	section := app.analyzeDuplicates()
+
+	if len(section.Issues) != 0 {
+		t.Errorf("expected 0 duplicate issues, got %d", len(section.Issues))
+	}
+}
+
+func TestAnalyzeGaps(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {IDPrefix: "T-", Properties: map[string]metamodel.PropertyDef{}},
+		},
+	}
+
+	g.AddNode(&model.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{}})
+	// T-002 missing
+	g.AddNode(&model.Entity{ID: "T-003", Type: "ticket", Properties: map[string]interface{}{}})
+
+	app := newTestApp(g, meta)
+	section := app.analyzeGaps()
+
+	if len(section.Issues) != 1 {
+		t.Fatalf("expected 1 gap issue, got %d", len(section.Issues))
+	}
+	if section.Issues[0].Message != "Missing ID: T-002" {
+		t.Errorf("expected 'Missing ID: T-002', got %q", section.Issues[0].Message)
+	}
+}
+
+func TestAnalyzeGaps_ManualIDsSkipped(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"component": {IDType: "manual", IDPrefix: "C-", Properties: map[string]metamodel.PropertyDef{}},
+		},
+	}
+
+	g.AddNode(&model.Entity{ID: "C-001", Type: "component", Properties: map[string]interface{}{}})
+	g.AddNode(&model.Entity{ID: "C-005", Type: "component", Properties: map[string]interface{}{}})
+
+	app := newTestApp(g, meta)
+	section := app.analyzeGaps()
+
+	if len(section.Issues) != 0 {
+		t.Errorf("expected 0 gap issues for manual ID type, got %d", len(section.Issues))
+	}
+}
+
+func TestAnalyzeCardinality(t *testing.T) {
+	g := graph.New()
+	min1 := 1
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {Properties: map[string]metamodel.PropertyDef{
+				"title": {Type: "string"},
+			}},
+			"component": {Properties: map[string]metamodel.PropertyDef{
+				"name": {Type: "string"},
+			}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"implements": {
+				From:        []string{"ticket"},
+				To:          []string{"component"},
+				MinOutgoing: &min1, // Each ticket must implement at least 1 component
+			},
+		},
+	}
+
+	g.AddNode(&model.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{"title": "A"}})
+	g.AddNode(&model.Entity{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{"title": "B"}})
+	g.AddNode(&model.Entity{ID: "C-001", Type: "component", Properties: map[string]interface{}{"name": "Auth"}})
+	// Only T-001 implements C-001; T-002 has no implements relation
+	g.AddEdge(&model.Relation{From: "T-001", Type: "implements", To: "C-001"})
+
+	app := newTestApp(g, meta)
+	section := app.analyzeCardinality()
+
+	if len(section.Issues) != 1 {
+		t.Fatalf("expected 1 cardinality violation, got %d", len(section.Issues))
+	}
+	if section.Issues[0].EntityID != "T-002" {
+		t.Errorf("expected violation on T-002, got %s", section.Issues[0].EntityID)
+	}
+	if section.Issues[0].Severity != "error" {
+		t.Errorf("expected severity 'error', got %q", section.Issues[0].Severity)
+	}
+}
+
+func TestAnalyzeCardinality_AllSatisfied(t *testing.T) {
+	g := graph.New()
+	min1 := 1
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket":    {Properties: map[string]metamodel.PropertyDef{}},
+			"component": {Properties: map[string]metamodel.PropertyDef{}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"implements": {
+				From:        []string{"ticket"},
+				To:          []string{"component"},
+				MinOutgoing: &min1,
+			},
+		},
+	}
+
+	g.AddNode(&model.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{}})
+	g.AddNode(&model.Entity{ID: "C-001", Type: "component", Properties: map[string]interface{}{}})
+	g.AddEdge(&model.Relation{From: "T-001", Type: "implements", To: "C-001"})
+
+	app := newTestApp(g, meta)
+	section := app.analyzeCardinality()
+
+	if len(section.Issues) != 0 {
+		t.Errorf("expected 0 violations, got %d", len(section.Issues))
+	}
+}
+
+func TestAnalyzeProperties(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				IDPrefix: "T-",
+				Properties: map[string]metamodel.PropertyDef{
+					"title":  {Type: "string", Required: true},
+					"status": {Type: "enum", Values: []string{"open", "closed"}},
+				},
+			},
+		},
+	}
+
+	// Missing required title, invalid enum value
+	g.AddNode(&model.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{"status": "invalid"}})
+	// Valid entity
+	g.AddNode(&model.Entity{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{"title": "Good", "status": "open"}})
+
+	app := newTestApp(g, meta)
+	section := app.analyzeProperties()
+
+	if len(section.Issues) < 2 {
+		t.Fatalf("expected at least 2 property errors (missing title + invalid enum), got %d", len(section.Issues))
+	}
+	// All issues for T-001
+	for _, issue := range section.Issues {
+		if issue.EntityID != "T-001" {
+			t.Errorf("expected all issues for T-001, got issue for %s", issue.EntityID)
+		}
+		if issue.Severity != "error" {
+			t.Errorf("expected severity 'error', got %q", issue.Severity)
+		}
+	}
+}
+
+func TestAnalyzeProperties_AllValid(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				IDPrefix: "T-",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
+			},
+		},
+	}
+
+	g.AddNode(&model.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{"title": "Valid"}})
+
+	app := newTestApp(g, meta)
+	section := app.analyzeProperties()
+
+	if len(section.Issues) != 0 {
+		t.Errorf("expected 0 property issues, got %d", len(section.Issues))
+	}
+}
+
+func TestAnalyzeValidations(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {Properties: map[string]metamodel.PropertyDef{
+				"status":   {Type: "string"},
+				"priority": {Type: "string"},
+			}},
+		},
+		Validations: []metamodel.ValidationRule{
+			{
+				Name:        "accepted-needs-priority",
+				Description: "Accepted tickets must have priority",
+				EntityType:  "ticket",
+				When:        []string{"status=accepted"},
+				Then:        []string{"priority!="},
+				Severity:    "error",
+			},
+		},
+	}
+
+	// Accepted without priority — violation
+	g.AddNode(&model.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{"status": "accepted"}})
+	// Accepted with priority — OK
+	g.AddNode(&model.Entity{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{"status": "accepted", "priority": "high"}})
+	// Draft — rule doesn't apply
+	g.AddNode(&model.Entity{ID: "T-003", Type: "ticket", Properties: map[string]interface{}{"status": "draft"}})
+
+	app := newTestApp(g, meta)
+	section := app.analyzeValidations()
+
+	if len(section.Issues) != 1 {
+		t.Fatalf("expected 1 validation issue, got %d", len(section.Issues))
+	}
+	if section.Issues[0].EntityID != "T-001" {
+		t.Errorf("expected violation on T-001, got %s", section.Issues[0].EntityID)
+	}
+	if section.Issues[0].Severity != "error" {
+		t.Errorf("expected severity 'error', got %q", section.Issues[0].Severity)
+	}
+}
+
+func TestAnalyzeValidations_NoRules(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {Properties: map[string]metamodel.PropertyDef{}},
+		},
+	}
+
+	app := newTestApp(g, meta)
+	section := app.analyzeValidations()
+
+	if len(section.Issues) != 0 {
+		t.Errorf("expected 0 issues with no rules, got %d", len(section.Issues))
+	}
+}
+
+func TestRunAnalysis(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				IDPrefix: "T-",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
+			},
+		},
+	}
+
+	// Orphan with missing required property
+	g.AddNode(&model.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{}})
+
+	app := newTestApp(g, meta)
+	result := app.runAnalysis()
+
+	if len(result.Sections) != 6 {
+		t.Errorf("expected 6 sections, got %d", len(result.Sections))
+	}
+	// Should have at least 1 error (missing required property) and 1 warning (orphan)
+	if result.ErrorCount < 1 {
+		t.Errorf("expected at least 1 error, got %d", result.ErrorCount)
+	}
+	if result.WarningCount < 1 {
+		t.Errorf("expected at least 1 warning, got %d", result.WarningCount)
+	}
+}
+
+func TestRunAnalysis_EmptyGraph(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{},
+	}
+
+	app := newTestApp(g, meta)
+	result := app.runAnalysis()
+
+	if result.ErrorCount != 0 {
+		t.Errorf("expected 0 errors for empty graph, got %d", result.ErrorCount)
+	}
+	if result.WarningCount != 0 {
+		t.Errorf("expected 0 warnings for empty graph, got %d", result.WarningCount)
+	}
+}
+
+func TestAnalysisSectionCounts(t *testing.T) {
+	section := AnalysisSection{
+		Issues: []AnalysisIssue{
+			{Severity: "error"},
+			{Severity: "warning"},
+			{Severity: "error"},
+			{Severity: "warning"},
+			{Severity: "warning"},
+		},
+	}
+
+	if section.ErrorCount() != 2 {
+		t.Errorf("expected 2 errors, got %d", section.ErrorCount())
+	}
+	if section.WarningCount() != 3 {
+		t.Errorf("expected 3 warnings, got %d", section.WarningCount())
+	}
+}
+
+func TestAnalysisIssueCounts(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				IDPrefix: "T-",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
+			},
+		},
+	}
+
+	// Orphan (warning) + missing required title (error)
+	g.AddNode(&model.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{}})
+
+	app := newTestApp(g, meta)
+	errors, warnings := app.analysisIssueCounts()
+
+	if errors < 1 {
+		t.Errorf("expected at least 1 error, got %d", errors)
+	}
+	if warnings < 1 {
+		t.Errorf("expected at least 1 warning, got %d", warnings)
+	}
+}
+
+func TestCountEdgesByType(t *testing.T) {
+	edges := []*model.Relation{
+		{From: "A", Type: "blocks", To: "B"},
+		{From: "A", Type: "implements", To: "C"},
+		{From: "A", Type: "blocks", To: "D"},
+	}
+
+	if got := countEdgesByType(edges, "blocks"); got != 2 {
+		t.Errorf("expected 2 'blocks' edges, got %d", got)
+	}
+	if got := countEdgesByType(edges, "implements"); got != 1 {
+		t.Errorf("expected 1 'implements' edge, got %d", got)
+	}
+	if got := countEdgesByType(edges, "unknown"); got != 0 {
+		t.Errorf("expected 0 'unknown' edges, got %d", got)
+	}
+}
+
+func TestNormalizeTitle(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Hello World", "hello world"},
+		{"  Hello   World  ", "hello world"},
+		{"", ""},
+		{"UPPER", "upper"},
+	}
+	for _, tt := range tests {
+		got := normalizeTitle(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizeTitle(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -1798,20 +1798,44 @@ func (a *App) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		cards[i] = rc
 	}
 
+	// Compute analysis summary for the validation card
+	analysisErrors, analysisWarnings := a.analysisIssueCounts()
+
 	data := map[string]interface{}{
-		"App":        a.Cfg.App,
-		"Navigation": a.navElements("_dashboard"),
-		"ActiveList": "_dashboard",
-		"Dashboard":  dash,
-		"Cards":      cards,
-		"Commands":   a.resolveCommands("dashboard", "", ""),
-		"IsHTMX":     r.Header.Get("HX-Request") == "true",
+		"App":              a.Cfg.App,
+		"Navigation":       a.navElements("_dashboard"),
+		"ActiveList":       "_dashboard",
+		"Dashboard":        dash,
+		"Cards":            cards,
+		"Commands":         a.resolveCommands("dashboard", "", ""),
+		"AnalysisErrors":   analysisErrors,
+		"AnalysisWarnings": analysisWarnings,
+		"IsHTMX":           r.Header.Get("HX-Request") == "true",
 	}
 
 	if r.Header.Get("HX-Request") == "true" {
 		a.tmpl.ExecuteTemplate(w, "dashboard-content", data) //nolint:errcheck // template errors logged by http
 	} else {
 		a.tmpl.ExecuteTemplate(w, "dashboard-page", data) //nolint:errcheck // template errors logged by http
+	}
+}
+
+// coverage-ignore: analyze handler - tested via integration/manual testing
+func (a *App) handleAnalyze(w http.ResponseWriter, r *http.Request) {
+	result := a.runAnalysis()
+
+	data := map[string]interface{}{
+		"App":        a.Cfg.App,
+		"Navigation": a.navElements("_analyze"),
+		"ActiveList": "_analyze",
+		"Analysis":   result,
+		"IsHTMX":     r.Header.Get("HX-Request") == "true",
+	}
+
+	if r.Header.Get("HX-Request") == "true" {
+		a.tmpl.ExecuteTemplate(w, "analyze-content", data) //nolint:errcheck // template errors logged by http
+	} else {
+		a.tmpl.ExecuteTemplate(w, "analyze-page", data) //nolint:errcheck // template errors logged by http
 	}
 }
 

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -24,6 +24,7 @@ func (a *App) NewRouter() http.Handler {
 	inner := http.NewServeMux()
 	inner.HandleFunc("/", a.handleIndex)
 	inner.HandleFunc("/dashboard", a.handleDashboard)
+	inner.HandleFunc("/analyze", a.handleAnalyze)
 	inner.HandleFunc("/search", a.handleSearch)
 	inner.HandleFunc("/list/", a.handleList)
 	inner.HandleFunc("/form/", a.handleForm)

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -709,9 +709,13 @@ document.addEventListener('click', function(e) {
   </div>
   <nav>
     <a href="/search"{{ if eq $.ActiveList "_search" }} class="active"{{ end }}
-       hx-get="/search" hx-target="#content" hx-push-url="true"
-       style="border-bottom:1px solid rgba(255,255,255,0.1);margin-bottom:4px;">
+       hx-get="/search" hx-target="#content" hx-push-url="true">
       &#128269; Search
+    </a>
+    <a href="/analyze"{{ if eq $.ActiveList "_analyze" }} class="active"{{ end }}
+       hx-get="/analyze" hx-target="#content" hx-push-url="true"
+       style="border-bottom:1px solid rgba(255,255,255,0.1);margin-bottom:4px;">
+      &#9888; Analysis
     </a>
     {{ range .Navigation }}
     {{ if .Group }}
@@ -2156,6 +2160,25 @@ function submitInlineCreate() {
 {{ end }}
 </div>
 
+<div class="card dashboard-validation-card" style="margin-top:20px;">
+  <div class="dashboard-card-header">
+    <h3>&#9888; Validation</h3>
+    <a href="/analyze" class="dashboard-query-link"
+       hx-get="/analyze" hx-target="#content" hx-push-url="true"
+       title="View full analysis">&#8599;</a>
+  </div>
+  <div style="padding:16px;display:flex;align-items:center;gap:12px;">
+    {{ if and (eq .AnalysisErrors 0) (eq .AnalysisWarnings 0) }}
+    <span style="color:#166534;font-weight:600;font-size:14px;">&#10003; All checks passed</span>
+    {{ else }}
+    {{ if gt .AnalysisErrors 0 }}<span class="badge badge-red" style="font-size:12px;">{{ .AnalysisErrors }} {{ if eq .AnalysisErrors 1 }}error{{ else }}errors{{ end }}</span>{{ end }}
+    {{ if gt .AnalysisWarnings 0 }}<span class="badge badge-orange" style="font-size:12px;">{{ .AnalysisWarnings }} {{ if eq .AnalysisWarnings 1 }}warning{{ else }}warnings{{ end }}</span>{{ end }}
+    <a href="/analyze" style="margin-left:auto;font-size:13px;color:var(--primary);text-decoration:none;font-weight:500;"
+       hx-get="/analyze" hx-target="#content" hx-push-url="true">View details &rarr;</a>
+    {{ end }}
+  </div>
+</div>
+
 <style>
 .dashboard-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 16px; }
 .dashboard-card { padding: 0; overflow: hidden; }
@@ -2181,6 +2204,103 @@ function submitInlineCreate() {
 .dashboard-table { width: 100%; font-size: 13px; }
 .dashboard-table thead th { padding: 8px 16px; font-size: 11px; }
 .dashboard-table tbody td { padding: 6px 16px; }
+</style>
+{{- end -}}
+
+{{- define "analyze-page" -}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>{{ .App.Name }} - Analysis</title>
+{{ template "head" . }}
+</head>
+<body>
+{{ template "sidebar" . }}
+<main class="main" id="content">
+{{ template "analyze-content" . }}
+</main>
+<div id="command-toast-container"></div>
+</body>
+</html>
+{{- end -}}
+
+{{- define "analyze-content" -}}
+<div class="page-header">
+  <div>
+    <h2>Analysis</h2>
+    <p>Validation checks across all entities and relations</p>
+  </div>
+</div>
+
+<div class="analyze-summary">
+  {{ if and (eq .Analysis.ErrorCount 0) (eq .Analysis.WarningCount 0) }}
+  <span class="analyze-chip analyze-chip-ok">&#10003; All checks passed</span>
+  {{ else }}
+  {{ if gt .Analysis.ErrorCount 0 }}<span class="analyze-chip analyze-chip-error">{{ .Analysis.ErrorCount }} {{ if eq .Analysis.ErrorCount 1 }}error{{ else }}errors{{ end }}</span>{{ end }}
+  {{ if gt .Analysis.WarningCount 0 }}<span class="analyze-chip analyze-chip-warning">{{ .Analysis.WarningCount }} {{ if eq .Analysis.WarningCount 1 }}warning{{ else }}warnings{{ end }}</span>{{ end }}
+  {{ end }}
+</div>
+
+{{ range .Analysis.Sections }}
+<div class="card analyze-section">
+  <div class="analyze-section-header">
+    <div class="analyze-section-title">
+      <h3>{{ .Name }}</h3>
+      {{ if .Issues }}
+      {{ if gt (.ErrorCount) 0 }}<span class="badge badge-red">{{ .ErrorCount }}</span>{{ end }}
+      {{ if gt (.WarningCount) 0 }}<span class="badge badge-orange">{{ .WarningCount }}</span>{{ end }}
+      {{ else }}
+      <span class="badge badge-green">0</span>
+      {{ end }}
+    </div>
+    <span class="analyze-section-desc">{{ .Description }}</span>
+  </div>
+  {{ if .Issues }}
+  <table>
+    <thead>
+      <tr>
+        <th>Entity</th>
+        <th>Type</th>
+        <th>Message</th>
+        <th>Severity</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{ range .Issues }}
+      <tr>
+        <td>{{ if .EntityID }}<a href="/entity/{{ .EntityType }}/{{ .EntityID }}" class="cell-link"
+               hx-get="/entity/{{ .EntityType }}/{{ .EntityID }}" hx-target="#content" hx-push-url="true"
+            >{{ if .Title }}{{ .Title }}{{ else }}{{ .EntityID }}{{ end }}</a>
+            <div style="font-size:11px;color:var(--text-muted);">{{ .EntityID }}</div>
+            {{ else }}&mdash;{{ end }}</td>
+        <td>{{ if .EntityType }}<span class="badge badge-gray">{{ .EntityType }}</span>{{ else }}&mdash;{{ end }}</td>
+        <td>{{ .Message }}</td>
+        <td>{{ if eq .Severity "error" }}<span class="badge badge-red">error</span>{{ else }}<span class="badge badge-orange">warning</span>{{ end }}</td>
+      </tr>
+      {{ end }}
+    </tbody>
+  </table>
+  {{ else }}
+  <div class="analyze-section-ok">&#10003; No issues</div>
+  {{ end }}
+</div>
+{{ end }}
+
+<style>
+.analyze-summary { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 20px; }
+.analyze-chip { display: inline-flex; align-items: center; gap: 4px; padding: 6px 14px; border-radius: 9999px; font-size: 13px; font-weight: 600; }
+.analyze-chip-error { background: #fee2e2; color: #991b1b; }
+.analyze-chip-warning { background: #fed7aa; color: #9a3412; }
+.analyze-chip-ok { background: #dcfce7; color: #166534; }
+.analyze-section { margin-bottom: 12px; overflow: hidden; }
+.analyze-section-header { padding: 14px 16px; }
+.analyze-section-title { display: flex; align-items: center; gap: 8px; }
+.analyze-section-title h3 { font-size: 14px; font-weight: 600; margin: 0; }
+.analyze-section-desc { font-size: 12px; color: var(--text-muted); margin-top: 2px; }
+.analyze-section table { font-size: 13px; border-top: 1px solid var(--border); }
+.analyze-section thead th { padding: 8px 16px; font-size: 11px; }
+.analyze-section tbody td { padding: 8px 16px; vertical-align: top; }
+.analyze-section-ok { padding: 16px; color: #166534; font-size: 13px; font-weight: 500; border-top: 1px solid var(--border); }
 </style>
 {{- end -}}
 `


### PR DESCRIPTION
## Summary

- Adds a dedicated `/analyze` page to the data entry web app that runs all 6 quality checks (properties, cardinality, custom validations, orphans, duplicates, ID gaps) and displays results grouped by category with links to affected entities
- Adds a compact validation summary card to the dashboard showing error/warning counts with a link to the full analysis page
- Adds an "Analysis" link in the sidebar for quick access

## Test plan

- [x] Pre-commit hook passes (lint, format, tests)
- [ ] CI passes (lint, test, coverage, build)
- [ ] Manual verification: open `/analyze` page and review issue display
- [ ] Manual verification: dashboard shows validation summary card
- [ ] Manual verification: sidebar shows Analysis link with correct active state