### PR TITLE
Add browse scope navigation to data entry detail/view pages

### DIFF
--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -254,6 +254,13 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Build scope params for detail links (sort + filter state for scope reconstruction)
+	var scopeParams string
+	if sortProp != "" {
+		scopeParams += "&sort=" + url.QueryEscape(sortProp) + "&sort_dir=" + url.QueryEscape(sortDir)
+	}
+	scopeParams += filterParams
+
 	data := map[string]interface{}{
 		"App":              a.Cfg.App,
 		"Navigation":       a.navElements(listID),
@@ -267,6 +274,7 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 		"TotalCount":       totalCount,
 		"EditForm":         list.EditForm,
 		"DetailLinkPrefix": detailLinkPrefix,
+		"ScopeParams":      scopeParams,
 		"IsHTMX":           r.Header.Get("HX-Request") == "true",
 		"SortProperty":     sortProp,
 		"SortDirection":    sortDir,
@@ -599,6 +607,12 @@ func (a *App) handleEntity(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Build return URL for edit links (preserves scope params)
+	returnTo := r.URL.Path
+	if r.URL.RawQuery != "" {
+		returnTo += "?" + r.URL.RawQuery
+	}
+
 	entityActiveList := a.resolveActiveList(entity.Type, r)
 	backURL := "/"
 	if entityActiveList != "" {
@@ -613,6 +627,8 @@ func (a *App) handleEntity(w http.ResponseWriter, r *http.Request) {
 		"EditFormID": editFormID,
 		"Relations":  rels,
 		"PropTypes":  propTypes,
+		"ReturnTo":   returnTo,
+		"Scope":      a.resolveScope(entity.ID, r),
 		"Commands":   a.resolveCommands("entity", "", entity.Type),
 		"BackURL":    backURL,
 		"IsHTMX":     r.Header.Get("HX-Request") == "true",
@@ -968,6 +984,7 @@ func (a *App) handleView(w http.ResponseWriter, r *http.Request) {
 		"EditFormID": a.editFormForType(result.Entry.Type),
 		"ReturnTo":   returnTo,
 		"Sections":   sections,
+		"Scope":      a.resolveScope(entityID, r),
 		"Commands":   a.resolveCommands("view", viewID, result.Entry.Type),
 		"BackURL":    backURL,
 		"IsHTMX":     r.Header.Get("HX-Request") == "true",
@@ -1556,6 +1573,7 @@ func (a *App) handleSearch(w http.ResponseWriter, r *http.Request) {
 
 	if !sq.IsEmpty() {
 		entities := a.executeQuery(query)
+		sort.Slice(entities, func(i, j int) bool { return entities[i].ID < entities[j].ID })
 		const maxResults = 100
 		for _, e := range entities {
 			if len(results) >= maxResults {
@@ -1673,6 +1691,7 @@ func (a *App) handleSearch(w http.ResponseWriter, r *http.Request) {
 		"ResultCount":     len(results),
 		"HasQuery":        query != "",
 		"ParseErrors":     parseErrors,
+		"ScopeParams":     "scope=search:" + url.QueryEscape(query),
 		"IsHTMX":          r.Header.Get("HX-Request") == "true",
 		"SuggestionsJSON": htmltemplate.JS(suggestionsJSON), //nolint:gosec // controlled data from metamodel
 	}

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -464,6 +466,123 @@ func (a *App) resolveRelationColumnValue(entityID, relationType string) string {
 		titles = append(titles, a.entityDisplayTitle(target))
 	}
 	return strings.Join(titles, ", ")
+}
+
+// ScopeNav holds prev/next navigation context for browsing through a list of entities.
+type ScopeNav struct {
+	PrevURL  string // URL for previous entity (empty if at first)
+	NextURL  string // URL for next entity (empty if at last)
+	Progress string // e.g. "[3/12]"
+	Label    string // e.g. "12 tickets" or "5 results for 'auth'"
+}
+
+// resolveScope parses the "scope" query parameter and reconstructs the ordered
+// entity list to determine prev/next navigation links. Returns nil when no
+// scope is present or the current entity isn't found in the scope.
+func (a *App) resolveScope(currentEntityID string, r *http.Request) *ScopeNav {
+	scope := r.URL.Query().Get("scope")
+	if scope == "" {
+		return nil
+	}
+
+	var ids []string
+	var label string
+
+	switch {
+	case strings.HasPrefix(scope, "list:"):
+		listID := strings.TrimPrefix(scope, "list:")
+		list, ok := a.Cfg.Lists[listID]
+		if !ok {
+			return nil
+		}
+		entities := a.g.NodesByType(list.EntityType)
+		entities = applyFilters(entities, list.Filters)
+
+		// Apply dynamic filter params (same as handleList)
+		for _, fc := range list.FilterControls {
+			val := r.URL.Query().Get("filter_" + fc.Property)
+			if val != "" {
+				entities = applyFilters(entities, []FilterConfig{{
+					Property: fc.Property,
+					Operator: "=",
+					Value:    val,
+				}})
+			}
+		}
+
+		// Apply sort (same as handleList)
+		sortProp := r.URL.Query().Get("sort")
+		sortDir := r.URL.Query().Get("sort_dir")
+		if sortProp != "" {
+			a.sortEntitiesMulti(entities, []model.SortSpec{{Property: sortProp, Direction: sortDir}})
+		} else {
+			a.sortEntitiesMulti(entities, list.Sort)
+		}
+
+		ids = make([]string, len(entities))
+		for i, e := range entities {
+			ids[i] = e.ID
+		}
+		label = fmt.Sprintf("%d %s", len(ids), list.Title)
+
+	case strings.HasPrefix(scope, "search:"):
+		query := strings.TrimPrefix(scope, "search:")
+		entities := a.executeQuery(query)
+		sort.Slice(entities, func(i, j int) bool { return entities[i].ID < entities[j].ID })
+		ids = make([]string, len(entities))
+		for i, e := range entities {
+			ids[i] = e.ID
+		}
+		displayQuery := query
+		if len(displayQuery) > 30 {
+			displayQuery = displayQuery[:30] + "..."
+		}
+		label = fmt.Sprintf("%d results for \"%s\"", len(ids), displayQuery)
+
+	default:
+		return nil
+	}
+
+	// Find current entity in the scope
+	idx := -1
+	for i, id := range ids {
+		if id == currentEntityID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return nil
+	}
+
+	nav := &ScopeNav{
+		Progress: fmt.Sprintf("[%d/%d]", idx+1, len(ids)),
+		Label:    label,
+	}
+
+	// Build prev/next URLs by swapping the entity ID in the path
+	buildURL := func(targetID string) string {
+		// Replace the last path segment (entity ID) with the target ID
+		path := r.URL.Path
+		lastSlash := strings.LastIndex(path, "/")
+		if lastSlash < 0 {
+			return ""
+		}
+		newPath := path[:lastSlash+1] + targetID
+
+		// Preserve all query params
+		q := r.URL.Query()
+		return newPath + "?" + q.Encode()
+	}
+
+	if idx > 0 {
+		nav.PrevURL = buildURL(ids[idx-1])
+	}
+	if idx < len(ids)-1 {
+		nav.NextURL = buildURL(ids[idx+1])
+	}
+
+	return nav
 }
 
 // isRelationLinked checks whether a form relation field (formRel) corresponds

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -2,6 +2,9 @@ package dataentry
 
 import (
 	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/graph"
@@ -671,4 +674,229 @@ func TestIsRelationLinked(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveScope(t *testing.T) {
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Properties: map[string]metamodel.PropertyDef{
+					"status":   {Type: "string"},
+					"priority": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	makeGraph := func() *graph.Graph {
+		g := graph.New()
+		for _, e := range []*model.Entity{
+			{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{"status": "open", "priority": "high"}},
+			{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{"status": "closed", "priority": "low"}},
+			{ID: "T-003", Type: "ticket", Properties: map[string]interface{}{"status": "open", "priority": "medium"}},
+			{ID: "T-004", Type: "ticket", Properties: map[string]interface{}{"status": "open", "priority": "low"}},
+		} {
+			g.AddNode(e)
+		}
+		return g
+	}
+
+	makeApp := func() *App {
+		return &App{
+			meta: meta,
+			g:    makeGraph(),
+			Cfg: &Config{
+				Lists: map[string]List{
+					"tickets": {
+						EntityType: "ticket",
+						Title:      "Tickets",
+						Sort:       []SortSpec{{Property: "priority", Direction: "asc"}},
+						Filters:    nil,
+						FilterControls: []FilterControl{
+							{Property: "status"},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	makeRequest := func(urlStr string) *http.Request {
+		return httptest.NewRequest(http.MethodGet, urlStr, http.NoBody)
+	}
+
+	t.Run("no scope param returns nil", func(t *testing.T) {
+		app := makeApp()
+		r := makeRequest("/entity/ticket/T-002")
+		got := app.resolveScope("T-002", r)
+		if got != nil {
+			t.Errorf("expected nil, got %+v", got)
+		}
+	})
+
+	t.Run("empty scope param returns nil", func(t *testing.T) {
+		app := makeApp()
+		r := makeRequest("/entity/ticket/T-002?scope=")
+		got := app.resolveScope("T-002", r)
+		if got != nil {
+			t.Errorf("expected nil, got %+v", got)
+		}
+	})
+
+	t.Run("invalid scope prefix returns nil", func(t *testing.T) {
+		app := makeApp()
+		r := makeRequest("/entity/ticket/T-002?scope=bogus:foo")
+		got := app.resolveScope("T-002", r)
+		if got != nil {
+			t.Errorf("expected nil, got %+v", got)
+		}
+	})
+
+	t.Run("unknown list returns nil", func(t *testing.T) {
+		app := makeApp()
+		r := makeRequest("/entity/ticket/T-002?scope=list:nonexistent")
+		got := app.resolveScope("T-002", r)
+		if got != nil {
+			t.Errorf("expected nil, got %+v", got)
+		}
+	})
+
+	t.Run("entity not in scope returns nil", func(t *testing.T) {
+		app := makeApp()
+		r := makeRequest("/entity/ticket/T-999?scope=list:tickets")
+		got := app.resolveScope("T-999", r)
+		if got != nil {
+			t.Errorf("expected nil, got %+v", got)
+		}
+	})
+
+	t.Run("list scope middle item has prev and next", func(t *testing.T) {
+		app := makeApp()
+		// Sort by status asc: closed(T-002), open(T-001), open(T-003), open(T-004)
+		// T-001 has status=open which sorts after closed.
+		r := makeRequest("/entity/ticket/T-001?scope=list:tickets&sort=status&sort_dir=asc")
+		got := app.resolveScope("T-001", r)
+		if got == nil {
+			t.Fatal("expected non-nil scope")
+		}
+		if got.PrevURL == "" {
+			t.Error("expected PrevURL to be set for non-first item")
+		}
+		if got.Label != "4 Tickets" {
+			t.Errorf("Label = %q, want %q", got.Label, "4 Tickets")
+		}
+	})
+
+	t.Run("list scope first item has no prev", func(t *testing.T) {
+		app := makeApp()
+		r := makeRequest("/entity/ticket/T-001?scope=list:tickets&sort=status&sort_dir=asc")
+		got := app.resolveScope("T-001", r)
+		if got == nil {
+			t.Fatal("expected non-nil scope")
+		}
+		if got.Progress == "[1/4]" && got.PrevURL != "" {
+			t.Error("first item should not have PrevURL")
+		}
+	})
+
+	t.Run("list scope last item has no next", func(t *testing.T) {
+		app := makeApp()
+		r := makeRequest("/entity/ticket/T-001?scope=list:tickets&sort=priority&sort_dir=desc")
+		got := app.resolveScope("T-001", r)
+		if got == nil {
+			t.Fatal("expected non-nil scope")
+		}
+		if got.Progress == "[4/4]" && got.NextURL != "" {
+			t.Error("last item should not have NextURL")
+		}
+	})
+
+	t.Run("list scope with filter narrows results", func(t *testing.T) {
+		app := makeApp()
+		// Filter to status=open should give T-001, T-003, T-004 (3 items)
+		r := makeRequest("/entity/ticket/T-003?scope=list:tickets&filter_status=open")
+		got := app.resolveScope("T-003", r)
+		if got == nil {
+			t.Fatal("expected non-nil scope")
+		}
+		if got.Label != "3 Tickets" {
+			t.Errorf("Label = %q, want %q", got.Label, "3 Tickets")
+		}
+	})
+
+	t.Run("list scope preserves query params in prev/next URLs", func(t *testing.T) {
+		app := makeApp()
+		r := makeRequest("/entity/ticket/T-003?from=tickets&scope=list:tickets&filter_status=open")
+		got := app.resolveScope("T-003", r)
+		if got == nil {
+			t.Fatal("expected non-nil scope")
+		}
+		checkURL := got.NextURL
+		if checkURL == "" {
+			checkURL = got.PrevURL
+		}
+		if checkURL == "" {
+			t.Fatal("expected at least one nav URL")
+		}
+		for _, param := range []string{"scope=list%3Atickets", "filter_status=open", "from=tickets"} {
+			if !strings.Contains(checkURL, param) {
+				t.Errorf("URL %q missing expected param %q", checkURL, param)
+			}
+		}
+	})
+
+	t.Run("single item scope has no prev or next", func(t *testing.T) {
+		app := makeApp()
+		// Filter to status=closed should give only T-002
+		r := makeRequest("/entity/ticket/T-002?scope=list:tickets&filter_status=closed")
+		got := app.resolveScope("T-002", r)
+		if got == nil {
+			t.Fatal("expected non-nil scope")
+		}
+		if got.PrevURL != "" {
+			t.Errorf("single item should have empty PrevURL, got %q", got.PrevURL)
+		}
+		if got.NextURL != "" {
+			t.Errorf("single item should have empty NextURL, got %q", got.NextURL)
+		}
+		if got.Progress != "[1/1]" {
+			t.Errorf("Progress = %q, want [1/1]", got.Progress)
+		}
+	})
+
+	t.Run("search scope finds entity", func(t *testing.T) {
+		app := makeApp()
+		r := makeRequest("/entity/ticket/T-002?scope=search:type:ticket")
+		got := app.resolveScope("T-002", r)
+		if got == nil {
+			t.Fatal("expected non-nil scope for search")
+		}
+		if got.Label == "" {
+			t.Error("expected non-empty label for search scope")
+		}
+	})
+
+	t.Run("search scope with no results returns nil", func(t *testing.T) {
+		app := makeApp()
+		r := makeRequest("/entity/ticket/T-002?scope=search:type:nonexistent")
+		got := app.resolveScope("T-002", r)
+		if got != nil {
+			t.Errorf("expected nil for search with no results, got %+v", got)
+		}
+	})
+
+	t.Run("view path scope replaces entity ID correctly", func(t *testing.T) {
+		app := makeApp()
+		r := makeRequest("/view/ticket-detail/T-002?scope=list:tickets&sort=priority&sort_dir=asc")
+		got := app.resolveScope("T-002", r)
+		if got == nil {
+			t.Fatal("expected non-nil scope")
+		}
+		if got.PrevURL != "" && !strings.Contains(got.PrevURL, "/view/ticket-detail/") {
+			t.Errorf("PrevURL should preserve view path prefix, got %q", got.PrevURL)
+		}
+		if got.NextURL != "" && !strings.Contains(got.NextURL, "/view/ticket-detail/") {
+			t.Errorf("NextURL should preserve view path prefix, got %q", got.NextURL)
+		}
+	})
 }

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -284,9 +284,24 @@ tbody tr.row-selected { background: #dbeafe; outline: 2px solid var(--primary); 
 .shortcut-row { display: flex; align-items: center; justify-content: space-between; padding: 6px 0; font-size: 14px; }
 .shortcut-row + .shortcut-row { border-top: 1px solid #f1f5f9; }
 .shortcut-keys { display: flex; gap: 4px; align-items: center; font-size: 12px; color: var(--text-muted); }
+.scope-nav { display:flex; align-items:center; gap:8px; padding:6px 12px; margin-bottom:12px; background:var(--bg-card); border:1px solid var(--border); border-radius:6px; font-size:13px; }
+.scope-nav-btn { text-decoration:none; color:var(--primary); padding:2px 8px; border-radius:4px; transition:background 0.15s; }
+.scope-nav-btn:hover { background:var(--primary-light); }
+.scope-nav-disabled { opacity:0.35; pointer-events:none; color:var(--text-muted); padding:2px 8px; }
+.scope-nav-progress { font-weight:600; font-family:var(--font-mono); }
+.scope-nav-label { color:var(--text-muted); }
 
 </style>
 <script>
+// Scope navigation keyboard shortcuts (left/right arrow keys)
+document.addEventListener('keydown', function(e) {
+  if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
+  var nav = document.querySelector('.scope-nav');
+  if (!nav) return;
+  if (e.key === 'ArrowLeft') { var btn = nav.querySelector('a.scope-nav-btn'); if (btn) btn.click(); }
+  if (e.key === 'ArrowRight') { var btns = nav.querySelectorAll('a.scope-nav-btn'); if (btns.length > 0) btns[btns.length-1].click(); }
+});
+
 // SlimSelect progressive enhancement
 function enhanceSelects(root) {
   if (typeof SlimSelect === 'undefined') return;
@@ -1517,8 +1532,8 @@ document.body.addEventListener('htmx:pushedIntoHistory', function() {
           {{ $dlp := $.DetailLinkPrefix }}
           {{ range .Cells }}
           <td>
-            {{ if .Link }}<a href="{{ $dlp }}{{ .EntityID }}?from={{ $.ListID }}" class="cell-link"
-               hx-get="{{ $dlp }}{{ .EntityID }}?from={{ $.ListID }}" hx-target="#content" hx-push-url="true">{{ .Value }}</a>
+            {{ if .Link }}<a href="{{ $dlp }}{{ .EntityID }}?from={{ $.ListID }}&scope=list:{{ $.ListID }}{{ $.ScopeParams }}" class="cell-link"
+               hx-get="{{ $dlp }}{{ .EntityID }}?from={{ $.ListID }}&scope=list:{{ $.ListID }}{{ $.ScopeParams }}" hx-target="#content" hx-push-url="true">{{ .Value }}</a>
             {{ else if isBadgeType .PropType }}<span class="badge {{ badgeClass .PropType .Value }}">{{ .Value }}</span>
             {{ else }}{{ if .Value }}{{ .Value }}{{ else }}&mdash;{{ end }}{{ end }}
           </td>
@@ -1885,7 +1900,27 @@ function submitInlineCreate() {
 </html>
 {{- end -}}
 
+{{- define "scope-nav" -}}
+{{ if .Scope }}
+<div class="scope-nav">
+  {{ if .Scope.PrevURL }}
+  <a href="{{ .Scope.PrevURL }}" hx-get="{{ .Scope.PrevURL }}" hx-target="#content" hx-push-url="true" class="scope-nav-btn">&larr; Prev</a>
+  {{ else }}
+  <span class="scope-nav-disabled">&larr; Prev</span>
+  {{ end }}
+  <span class="scope-nav-progress">{{ .Scope.Progress }}</span>
+  <span class="scope-nav-label">{{ .Scope.Label }}</span>
+  {{ if .Scope.NextURL }}
+  <a href="{{ .Scope.NextURL }}" hx-get="{{ .Scope.NextURL }}" hx-target="#content" hx-push-url="true" class="scope-nav-btn">Next &rarr;</a>
+  {{ else }}
+  <span class="scope-nav-disabled">Next &rarr;</span>
+  {{ end }}
+</div>
+{{ end }}
+{{- end -}}
+
 {{- define "entity-content" -}}
+{{ template "scope-nav" . }}
 <div class="page-header">
   <div>
     <h2>{{ .Entity.Title }}{{ if not .Entity.Title }}{{ .Entity.ID }}{{ end }}</h2>
@@ -1893,8 +1928,8 @@ function submitInlineCreate() {
   </div>
   <div style="display:flex;gap:8px;">
     {{ if .EditFormID }}
-    <a href="/form/{{ .EditFormID }}/{{ .Entity.ID }}" class="btn btn-primary btn-sm"
-       hx-get="/form/{{ .EditFormID }}/{{ .Entity.ID }}" hx-target="#content" hx-push-url="true">Edit <kbd>E</kbd></a>
+    <a href="/form/{{ .EditFormID }}/{{ .Entity.ID }}?return_to={{ urlquery .ReturnTo }}" class="btn btn-primary btn-sm"
+       hx-get="/form/{{ .EditFormID }}/{{ .Entity.ID }}?return_to={{ urlquery .ReturnTo }}" hx-target="#content" hx-push-url="true">Edit <kbd>E</kbd></a>
     {{ end }}
     {{ if .Commands }}{{ if gt (len .Commands) 2 }}
     <details class="add-dropdown">
@@ -1907,8 +1942,6 @@ function submitInlineCreate() {
     {{ else }}{{ range .Commands }}
     <button class="btn btn-secondary btn-sm" onclick="runCommand('{{ .ID }}', {entity_id:'{{ $.Entity.ID }}',entity_type:'{{ $.Entity.Type }}'})" {{ if .Confirm }}data-confirm="{{ .Confirm }}"{{ end }}{{ if boolTrue .AutoOpen }} data-auto-open="true"{{ end }}>{{ .Label }}</button>
     {{ end }}{{ end }}{{ end }}
-    <a href="{{ .BackURL }}" class="btn btn-secondary btn-sm"
-       hx-get="{{ .BackURL }}" hx-target="#content" hx-push-url="true">&larr; Back <kbd>Esc</kbd></a>
   </div>
 </div>
 
@@ -1976,6 +2009,7 @@ function submitInlineCreate() {
 {{- end -}}
 
 {{- define "view-content" -}}
+{{ template "scope-nav" . }}
 <div class="page-header">
   <div>
     <h2>{{ .EntryTitle }}</h2>
@@ -2734,8 +2768,8 @@ function submitInlineCreate() {
 {{ range .Results }}
 <div class="card" style="padding:16px;margin-bottom:8px;">
   <div style="display:flex;align-items:center;gap:10px;margin-bottom:4px;">
-    <a href="/entity/{{ .EntityType }}/{{ .ID }}" class="cell-link" style="font-size:15px;font-weight:600;"
-       hx-get="/entity/{{ .EntityType }}/{{ .ID }}" hx-target="#content" hx-push-url="true">{{ .Title }}</a>
+    <a href="/entity/{{ .EntityType }}/{{ .ID }}?{{ $.ScopeParams }}" class="cell-link" style="font-size:15px;font-weight:600;"
+       hx-get="/entity/{{ .EntityType }}/{{ .ID }}?{{ $.ScopeParams }}" hx-target="#content" hx-push-url="true">{{ .Title }}</a>
     <span style="font-size:11px;font-family:var(--font-mono);color:var(--text-muted);background:#f1f5f9;padding:1px 6px;border-radius:3px;">{{ .ID }}</span>
     <span class="badge badge-blue" style="font-size:10px;">{{ .EntityType }}</span>
   </div>


### PR DESCRIPTION
## Summary

- Adds prev/next navigation bar to entity detail and view pages when navigating from a list or search, inspired by the TUI's `BrowseScope` concept
- Scope is encoded in URL query parameters (`scope=list:{id}` or `scope=search:{query}`) and reconstructed server-side on each request — stateless, bookmarkable, works with browser back button
- Includes keyboard shortcuts (left/right arrow keys) and preserves scope through edit form round-trips

## Test plan

- [ ] Navigate from a list to an entity detail — verify scope bar shows with correct `[n/m]` progress and list title
- [ ] Click Prev/Next buttons — verify correct entity loads and progress updates
- [ ] Use left/right arrow keys — verify same navigation behavior
- [ ] Apply filters/sort on a list, then navigate to detail — verify scope respects the active filters and sort order
- [ ] Search for entities, click a result — verify scope bar shows with search result count
- [ ] Navigate next/prev through search results — verify stable ordering (no jumping)
- [ ] Click Edit on a scoped detail page, save — verify return to the same scoped detail view
- [ ] Navigate to a detail page without scope (e.g. direct URL) — verify no scope bar appears
- [ ] Verify scope bar does not appear when typing in form inputs (keyboard shortcuts disabled in inputs)