### PR TITLE
Add user-configurable default values with Settings page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,35 @@ relations/                  # Markdown relation files (FROM--type--TO.md)
 templates/entities/<type>.md  # Optional: entity templates for defaults
 templates/relations/<type>.md # Optional: relation templates for defaults
 .rela/cache.json            # Graph cache (gitignored)
+.rela/ui-state.json         # Persisted UI state (gitignored)
+.rela/user-defaults.yaml    # User-specific default values (gitignored)
 ```
+
+### User Defaults
+
+The data entry app supports user-configurable default values for entity creation,
+stored in `.rela/user-defaults.yaml` (gitignored, per-user). Users configure these
+via the Settings page in the web UI.
+
+**Types and resolution** (`internal/dataentry/config.go`):
+
+- `UserDefaults` holds global property defaults, global relation defaults, and entity-type overrides
+- `DefaultOverride` scopes defaults to a list of entity types
+- `ResolvePropertyDefault(entityType, property)` checks overrides first, then global defaults
+- `ResolveRelationDefault(entityType, relation)` same resolution order for relations
+
+**Default resolution chain** (highest to lowest priority):
+
+1. Entity-type override from user defaults
+2. Global user default
+3. Form-level default (from `data-entry.yaml`)
+4. Metamodel default (from `metamodel.yaml`)
+
+**Integration points**:
+
+- `handleForm`: user defaults populate `ResolvedField.Default` via `coalesce()` and pre-select relations
+- `handleCreate` / `handleInlineCreate`: user defaults fill empty properties and create default relations
+- `handleSettings` / `handleSaveSettings`: Settings page renders metamodel-aware widgets and persists to YAML
 
 ## Migration System
 

--- a/docs-project/entities/feature/FEAT-data-entry.md
+++ b/docs-project/entities/feature/FEAT-data-entry.md
@@ -8,6 +8,6 @@ summary: "Config-driven web UI for creating, editing, and browsing entities"
 
 HTMX-based web application configured entirely through `data-entry.yaml`.
 Provides forms, filterable lists, detail views, dashboards, search,
-sidebar navigation with optional grouping, and user-defined commands.
-Commands run shell scripts with structured output and can auto-open
-generated files.
+sidebar navigation with optional grouping, user-defined commands,
+and per-user default values via a Settings page (stored in
+`.rela/user-defaults.yaml`).

--- a/docs-project/entities/guide/GUIDE-data-entry.md
+++ b/docs-project/entities/guide/GUIDE-data-entry.md
@@ -25,6 +25,7 @@ A `data-entry.yaml` file defines:
 - **Dashboard** - An overview page with query-driven cards showing counts, breakdowns, and tables
 - **Navigation** - Sidebar menu entries with optional grouping
 - **Commands** - User-defined scripts triggered from the UI with streamed results
+- **User Defaults** - Per-user default values for properties and relations, configurable via Settings page
 
 The file drives the entire UI without writing any code. The server reads `data-entry.yaml` and
 your `metamodel.yaml` together, validates them, and serves a fully functional CRUD application.
@@ -934,6 +935,58 @@ the normal interactive buttons.
 
 Command output streams in real time into stacked toast notifications. Long-running commands
 can be cancelled by the user via a cancel button.
+
+## User Defaults
+
+The data entry app includes a **Settings** page where users can configure default values for
+properties and relations. These defaults are applied automatically when creating new entities,
+reducing repetitive data entry.
+
+### Storage
+
+User defaults are stored in `.rela/user-defaults.yaml` (gitignored, per-user). The file is
+created automatically when a user saves settings for the first time.
+
+```yaml
+# .rela/user-defaults.yaml
+defaults:
+    assignee: alice
+    priority: high
+relations:
+    belongs-to: backend
+overrides:
+    - entity_types:
+        - ticket
+      defaults:
+          reporter: bob
+      relations:
+          tagged: bug
+```
+
+### Settings Page
+
+The Settings page is accessible from the sidebar (gear icon at the bottom). It has three sections:
+
+**Property Defaults** — Set default values for any property defined in the metamodel. The widget
+type (text input, dropdown, date picker, etc.) matches the property's type. For enum/custom types,
+a dropdown shows the allowed values.
+
+**Relation Defaults** — Set a default target entity for any relation type. When creating a new
+entity, the relation will be pre-filled with this target.
+
+**Overrides** — Scope defaults to specific entity types. For example, set `priority: critical`
+only when creating tickets, while leaving the global default as `medium`.
+
+### Resolution Order
+
+When creating a new entity, default values are resolved in this order (highest priority first):
+
+1. **Entity-type override** from user defaults (e.g., ticket-specific override)
+2. **Global user default** (e.g., `assignee: alice`)
+3. **Form-level default** (from `data-entry.yaml`, e.g., `default: medium`)
+4. **Metamodel default** (from `metamodel.yaml` type definition)
+
+User defaults never override values explicitly set by the user in the form.
 
 ## Complete Example
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -17,6 +17,7 @@ A `data-entry.yaml` file defines:
 - **Dashboard** - An overview page with query-driven cards showing counts, breakdowns, and tables
 - **Navigation** - Sidebar menu entries with optional grouping
 - **Commands** - User-defined scripts triggered from the UI with streamed results
+- **User Defaults** - Per-user default values for properties and relations, configurable via Settings page
 
 The file drives the entire UI without writing any code. The server reads `data-entry.yaml` and
 your `metamodel.yaml` together, validates them, and serves a fully functional CRUD application.
@@ -926,6 +927,58 @@ the normal interactive buttons.
 
 Command output streams in real time into stacked toast notifications. Long-running commands
 can be cancelled by the user via a cancel button.
+
+## User Defaults
+
+The data entry app includes a **Settings** page where users can configure default values for
+properties and relations. These defaults are applied automatically when creating new entities,
+reducing repetitive data entry.
+
+### Storage
+
+User defaults are stored in `.rela/user-defaults.yaml` (gitignored, per-user). The file is
+created automatically when a user saves settings for the first time.
+
+```yaml
+# .rela/user-defaults.yaml
+defaults:
+    assignee: alice
+    priority: high
+relations:
+    belongs-to: backend
+overrides:
+    - entity_types:
+        - ticket
+      defaults:
+          reporter: bob
+      relations:
+          tagged: bug
+```
+
+### Settings Page
+
+The Settings page is accessible from the sidebar (gear icon at the bottom). It has three sections:
+
+**Property Defaults** — Set default values for any property defined in the metamodel. The widget
+type (text input, dropdown, date picker, etc.) matches the property's type. For enum/custom types,
+a dropdown shows the allowed values.
+
+**Relation Defaults** — Set a default target entity for any relation type. When creating a new
+entity, the relation will be pre-filled with this target.
+
+**Overrides** — Scope defaults to specific entity types. For example, set `priority: critical`
+only when creating tickets, while leaving the global default as `medium`.
+
+### Resolution Order
+
+When creating a new entity, default values are resolved in this order (highest priority first):
+
+1. **Entity-type override** from user defaults (e.g., ticket-specific override)
+2. **Global user default** (e.g., `assignee: alice`)
+3. **Form-level default** (from `data-entry.yaml`, e.g., `default: medium`)
+4. **Metamodel default** (from `metamodel.yaml` type definition)
+
+User defaults never override values explicitly set by the user in the form.
 
 ## Complete Example
 

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -29,6 +29,9 @@ const ConfigFile = "data-entry.yaml"
 // uiStateFile is the filename for persisted UI state within the .rela directory.
 const uiStateFile = "ui-state.json"
 
+// userDefaultsFile is the filename for user-specific default values within the .rela directory.
+const userDefaultsFile = "user-defaults.yaml"
+
 // App is the central application struct holding config, metamodel, graph, and templates.
 type App struct {
 	Cfg  *Config
@@ -45,6 +48,10 @@ type App struct {
 	fs      storage.FS
 	// uiStatePath is the path to .rela/ui-state.json for persisting UI preferences.
 	uiStatePath string
+	// userDefaultsPath is the path to .rela/user-defaults.yaml for user-specific defaults.
+	userDefaultsPath string
+	// userDefaults holds the loaded user defaults (nil if not yet loaded or no file).
+	userDefaults *UserDefaults
 	// mu protects reloadable state (Cfg, meta, g, tmpl, styleMap, styledTypes)
 	// during live-reload. Handlers acquire RLock; reload acquires Lock.
 	mu sync.RWMutex
@@ -120,19 +127,22 @@ func NewApp(projectDir string, fs storage.FS) (*App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing graph templates: %w", err)
 	}
-	return &App{
-		Cfg:         &cfg,
-		meta:        meta,
-		g:           g,
-		repo:        repo,
-		tmpl:        tmpl,
-		styleMap:    styleMap,
-		styledTypes: styledTypes,
-		projCtx:     projCtx,
-		fs:          fs,
-		uiStatePath: filepath.Join(projCtx.CacheDir, uiStateFile),
-		broker:      newEventBroker(),
-	}, nil
+	app := &App{
+		Cfg:              &cfg,
+		meta:             meta,
+		g:                g,
+		repo:             repo,
+		tmpl:             tmpl,
+		styleMap:         styleMap,
+		styledTypes:      styledTypes,
+		projCtx:          projCtx,
+		fs:               fs,
+		uiStatePath:      filepath.Join(projCtx.CacheDir, uiStateFile),
+		userDefaultsPath: filepath.Join(projCtx.CacheDir, userDefaultsFile),
+		broker:           newEventBroker(),
+	}
+	app.userDefaults = app.loadUserDefaults()
+	return app, nil
 }
 
 // NavItem is an enriched navigation entry that includes the entity type for client-side matching.
@@ -239,6 +249,38 @@ func (a *App) saveUIState(state UIState) error {
 		return err
 	}
 	return a.fs.WriteFile(a.uiStatePath, data, 0o644)
+}
+
+// loadUserDefaults reads .rela/user-defaults.yaml and returns the parsed defaults.
+// Returns nil if the file doesn't exist or can't be parsed.
+func (a *App) loadUserDefaults() *UserDefaults {
+	if a.userDefaultsPath == "" {
+		return nil
+	}
+	data, err := a.fs.ReadFile(a.userDefaultsPath)
+	if err != nil {
+		return nil
+	}
+	var ud UserDefaults
+	if err := yaml.Unmarshal(data, &ud); err != nil {
+		return nil
+	}
+	return &ud
+}
+
+// saveUserDefaults writes the user defaults to .rela/user-defaults.yaml.
+func (a *App) saveUserDefaults(ud *UserDefaults) error {
+	if a.userDefaultsPath == "" {
+		return nil
+	}
+	if err := a.fs.MkdirAll(filepath.Dir(a.userDefaultsPath), 0o755); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(ud)
+	if err != nil {
+		return err
+	}
+	return a.fs.WriteFile(a.userDefaultsPath, data, 0o644)
 }
 
 // firstNavTarget returns the first navigable item from the navigation config,

--- a/internal/dataentry/app_test.go
+++ b/internal/dataentry/app_test.go
@@ -756,6 +756,67 @@ func TestUIStateLoadSave(t *testing.T) {
 	})
 }
 
+func TestUserDefaultsLoadSave(t *testing.T) {
+	dir := t.TempDir()
+	app := testAppInstance()
+	app.userDefaultsPath = filepath.Join(dir, "user-defaults.yaml")
+
+	t.Run("load returns nil when file missing", func(t *testing.T) {
+		ud := app.loadUserDefaults()
+		if ud != nil {
+			t.Errorf("expected nil, got %+v", ud)
+		}
+	})
+
+	t.Run("save and load round-trip", func(t *testing.T) {
+		ud := &UserDefaults{
+			Defaults:         map[string]string{"priority": "medium"},
+			RelationDefaults: map[string]string{"belongs_to": "CMP-001"},
+			Overrides: []DefaultOverride{
+				{
+					Types:            []string{"ticket"},
+					Defaults:         map[string]string{"status": "open"},
+					RelationDefaults: map[string]string{"assigned_to": "PER-001"},
+				},
+			},
+		}
+		if err := app.saveUserDefaults(ud); err != nil {
+			t.Fatalf("save error: %v", err)
+		}
+		loaded := app.loadUserDefaults()
+		if loaded == nil {
+			t.Fatal("expected non-nil loaded defaults")
+		}
+		if loaded.Defaults["priority"] != "medium" {
+			t.Errorf("expected priority=medium, got %q", loaded.Defaults["priority"])
+		}
+		if loaded.RelationDefaults["belongs_to"] != "CMP-001" {
+			t.Errorf("expected belongs_to=CMP-001, got %q", loaded.RelationDefaults["belongs_to"])
+		}
+		if len(loaded.Overrides) != 1 {
+			t.Fatalf("expected 1 override, got %d", len(loaded.Overrides))
+		}
+		if loaded.Overrides[0].Defaults["status"] != "open" {
+			t.Errorf("expected override status=open, got %q", loaded.Overrides[0].Defaults["status"])
+		}
+		if loaded.Overrides[0].RelationDefaults["assigned_to"] != "PER-001" {
+			t.Errorf("expected override assigned_to=PER-001, got %q", loaded.Overrides[0].RelationDefaults["assigned_to"])
+		}
+	})
+
+	t.Run("empty userDefaultsPath is safe", func(t *testing.T) {
+		app2 := testAppInstance()
+		app2.userDefaultsPath = ""
+		ud := app2.loadUserDefaults()
+		if ud != nil {
+			t.Errorf("expected nil, got %+v", ud)
+		}
+		if err := app2.saveUserDefaults(&UserDefaults{}); err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}
+
 func TestValidateConfigNestedGroups(t *testing.T) {
 	meta := testMeta()
 

--- a/internal/dataentry/config.go
+++ b/internal/dataentry/config.go
@@ -143,6 +143,63 @@ type UIState struct {
 	CollapsedGroups map[string]bool `json:"collapsed_groups"`
 }
 
+// UserDefaults holds user-configurable default values for entity creation,
+// persisted in .rela/user-defaults.yaml.
+type UserDefaults struct {
+	Defaults         map[string]string `yaml:"defaults,omitempty"`
+	RelationDefaults map[string]string `yaml:"relation_defaults,omitempty"`
+	Overrides        []DefaultOverride `yaml:"overrides,omitempty"`
+}
+
+// DefaultOverride defines property and relation defaults for specific entity types.
+type DefaultOverride struct {
+	Types            []string          `yaml:"entity_types"`
+	Defaults         map[string]string `yaml:"defaults,omitempty"`
+	RelationDefaults map[string]string `yaml:"relation_defaults,omitempty"`
+}
+
+// ResolvePropertyDefault returns the best default value for a property on the given entity type.
+// It checks overrides first (first matching), then global defaults.
+func (ud *UserDefaults) ResolvePropertyDefault(entityType, property string) string {
+	if ud == nil {
+		return ""
+	}
+	for _, o := range ud.Overrides {
+		for _, t := range o.Types {
+			if t == entityType {
+				if val, ok := o.Defaults[property]; ok {
+					return val
+				}
+			}
+		}
+	}
+	if val, ok := ud.Defaults[property]; ok {
+		return val
+	}
+	return ""
+}
+
+// ResolveRelationDefault returns the best default target for a relation on the given entity type.
+// It checks overrides first (first matching), then global relation defaults.
+func (ud *UserDefaults) ResolveRelationDefault(entityType, relation string) string {
+	if ud == nil {
+		return ""
+	}
+	for _, o := range ud.Overrides {
+		for _, t := range o.Types {
+			if t == entityType {
+				if val, ok := o.RelationDefaults[relation]; ok {
+					return val
+				}
+			}
+		}
+	}
+	if val, ok := ud.RelationDefaults[relation]; ok {
+		return val
+	}
+	return ""
+}
+
 // DashboardConfig defines a dashboard page with query-driven cards.
 type DashboardConfig struct {
 	Title       string          `yaml:"title"`

--- a/internal/dataentry/config_test.go
+++ b/internal/dataentry/config_test.go
@@ -1,0 +1,136 @@
+package dataentry
+
+import "testing"
+
+func TestUserDefaultsResolvePropertyDefault(t *testing.T) {
+	ud := &UserDefaults{
+		Defaults: map[string]string{
+			"priority": "medium",
+			"reporter": "jeroen",
+		},
+		Overrides: []DefaultOverride{
+			{
+				Types: []string{"ticket", "bug"},
+				Defaults: map[string]string{
+					"priority": "high",
+					"status":   "triaged",
+				},
+			},
+			{
+				Types: []string{"decision"},
+				Defaults: map[string]string{
+					"status": "proposed",
+				},
+			},
+		},
+	}
+
+	t.Run("global default", func(t *testing.T) {
+		got := ud.ResolvePropertyDefault("component", "priority")
+		if got != "medium" {
+			t.Errorf("expected 'medium', got %q", got)
+		}
+	})
+
+	t.Run("global default for reporter", func(t *testing.T) {
+		got := ud.ResolvePropertyDefault("ticket", "reporter")
+		if got != "jeroen" {
+			t.Errorf("expected 'jeroen', got %q", got)
+		}
+	})
+
+	t.Run("override takes precedence over global", func(t *testing.T) {
+		got := ud.ResolvePropertyDefault("ticket", "priority")
+		if got != "high" {
+			t.Errorf("expected 'high', got %q", got)
+		}
+	})
+
+	t.Run("override for second type in list", func(t *testing.T) {
+		got := ud.ResolvePropertyDefault("bug", "priority")
+		if got != "high" {
+			t.Errorf("expected 'high', got %q", got)
+		}
+	})
+
+	t.Run("override-only property", func(t *testing.T) {
+		got := ud.ResolvePropertyDefault("ticket", "status")
+		if got != "triaged" {
+			t.Errorf("expected 'triaged', got %q", got)
+		}
+	})
+
+	t.Run("different override group", func(t *testing.T) {
+		got := ud.ResolvePropertyDefault("decision", "status")
+		if got != "proposed" {
+			t.Errorf("expected 'proposed', got %q", got)
+		}
+	})
+
+	t.Run("unknown property returns empty", func(t *testing.T) {
+		got := ud.ResolvePropertyDefault("ticket", "nonexistent")
+		if got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("nil UserDefaults returns empty", func(t *testing.T) {
+		var nilUD *UserDefaults
+		got := nilUD.ResolvePropertyDefault("ticket", "priority")
+		if got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+}
+
+func TestUserDefaultsResolveRelationDefault(t *testing.T) {
+	ud := &UserDefaults{
+		RelationDefaults: map[string]string{
+			"reported-by": "jeroen",
+		},
+		Overrides: []DefaultOverride{
+			{
+				Types: []string{"ticket"},
+				RelationDefaults: map[string]string{
+					"assigned-to": "jeroen",
+				},
+			},
+		},
+	}
+
+	t.Run("global relation default", func(t *testing.T) {
+		got := ud.ResolveRelationDefault("decision", "reported-by")
+		if got != "jeroen" {
+			t.Errorf("expected 'jeroen', got %q", got)
+		}
+	})
+
+	t.Run("override relation default", func(t *testing.T) {
+		got := ud.ResolveRelationDefault("ticket", "assigned-to")
+		if got != "jeroen" {
+			t.Errorf("expected 'jeroen', got %q", got)
+		}
+	})
+
+	t.Run("no override for other entity types", func(t *testing.T) {
+		got := ud.ResolveRelationDefault("decision", "assigned-to")
+		if got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("unknown relation returns empty", func(t *testing.T) {
+		got := ud.ResolveRelationDefault("ticket", "nonexistent")
+		if got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("nil UserDefaults returns empty", func(t *testing.T) {
+		var nilUD *UserDefaults
+		got := nilUD.ResolveRelationDefault("ticket", "reported-by")
+		if got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+}

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -325,12 +325,16 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 	fields := make([]ResolvedField, 0, len(form.Fields))
 	for _, f := range form.Fields {
 		prop := entDef.Properties[f.Property]
+		userDefault := ""
+		if a.userDefaults != nil {
+			userDefault = a.userDefaults.ResolvePropertyDefault(form.EntityType, f.Property)
+		}
 		rf := ResolvedField{
 			Property:    f.Property,
 			Label:       coalesce(f.Label, titleCase(f.Property)),
 			Placeholder: f.Placeholder,
 			Help:        f.Help,
-			Default:     coalesce(f.Default, prop.Default),
+			Default:     coalesce(userDefault, f.Default, prop.Default),
 			Hidden:      f.Hidden,
 			Widget:      resolveWidget(f.Widget, prop, a.meta),
 			Values:      resolvePropertyValues(prop, a.meta),
@@ -449,6 +453,13 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 		if entity == nil && linkPeer != "" && linkRelation != "" {
 			if a.isRelationLinked(rel.Relation, linkRelation) {
 				rr.Selected = append(rr.Selected, linkPeer)
+			}
+		}
+
+		// Prefill relation from user defaults (only when creating and not already selected).
+		if entity == nil && len(rr.Selected) == 0 && a.userDefaults != nil {
+			if defaultTarget := a.userDefaults.ResolveRelationDefault(form.EntityType, rel.Relation); defaultTarget != "" {
+				rr.Selected = append(rr.Selected, defaultTarget)
 			}
 		}
 
@@ -1010,6 +1021,9 @@ func (a *App) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	for _, f := range form.Fields {
 		val := r.FormValue(f.Property)
+		if val == "" && a.userDefaults != nil {
+			val = a.userDefaults.ResolvePropertyDefault(form.EntityType, f.Property)
+		}
 		if val == "" && f.Default != "" {
 			val = f.Default
 		}
@@ -1037,6 +1051,12 @@ func (a *App) handleCreate(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		values := r.Form[rel.Relation]
+		// Apply user default relation if no value was submitted.
+		if len(values) == 0 && a.userDefaults != nil {
+			if defaultTarget := a.userDefaults.ResolveRelationDefault(form.EntityType, rel.Relation); defaultTarget != "" {
+				values = []string{defaultTarget}
+			}
+		}
 		for _, targetID := range values {
 			if targetID == "" {
 				continue
@@ -1290,6 +1310,9 @@ func (a *App) handleInlineCreate(w http.ResponseWriter, r *http.Request) {
 
 	for _, f := range form.Fields {
 		val := r.FormValue(f.Property)
+		if val == "" && a.userDefaults != nil {
+			val = a.userDefaults.ResolvePropertyDefault(form.EntityType, f.Property)
+		}
 		if val == "" && f.Default != "" {
 			val = f.Default
 		}
@@ -1862,4 +1885,221 @@ func (a *App) handleToggleGroup(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Failed to save UI state: %v", err)
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleSettings renders the settings page for user defaults.
+// coverage-ignore: UI handler
+func (a *App) handleSettings(w http.ResponseWriter, r *http.Request) {
+	ud := a.userDefaults
+	if ud == nil {
+		ud = &UserDefaults{}
+	}
+
+	// Collect all property names across entity types with their type info.
+	type PropertyInfo struct {
+		Name   string
+		Type   string
+		Values []string
+	}
+	propMap := make(map[string]PropertyInfo)
+	for _, entTypeName := range a.meta.EntityTypes() {
+		entDef, ok := a.meta.GetEntityDef(entTypeName)
+		if !ok {
+			continue
+		}
+		for propName, propDef := range entDef.Properties {
+			if _, exists := propMap[propName]; !exists {
+				propMap[propName] = PropertyInfo{
+					Name:   propName,
+					Type:   propDef.Type,
+					Values: resolvePropertyValues(propDef, a.meta),
+				}
+			} else {
+				// Merge values (union) for properties that appear on multiple types.
+				existing := propMap[propName]
+				seen := make(map[string]bool)
+				for _, v := range existing.Values {
+					seen[v] = true
+				}
+				for _, v := range resolvePropertyValues(propDef, a.meta) {
+					if !seen[v] {
+						existing.Values = append(existing.Values, v)
+						seen[v] = true
+					}
+				}
+				propMap[propName] = existing
+			}
+		}
+	}
+	propNames := make([]string, 0, len(propMap))
+	for name := range propMap {
+		propNames = append(propNames, name)
+	}
+	sort.Strings(propNames)
+	allProperties := make([]PropertyInfo, 0, len(propNames))
+	for _, name := range propNames {
+		allProperties = append(allProperties, propMap[name])
+	}
+
+	// Collect all relation types with their target entity types.
+	type RelationInfo struct {
+		Name       string
+		Label      string
+		TargetType string
+		Targets    []struct{ ID, Title string }
+	}
+	relNames := a.meta.RelationTypes()
+	sort.Strings(relNames)
+	allRelations := make([]RelationInfo, 0, len(relNames))
+	for _, relName := range relNames {
+		relDef, ok := a.meta.GetRelationDef(relName)
+		if !ok {
+			continue
+		}
+		ri := RelationInfo{
+			Name:  relName,
+			Label: relDef.Label,
+		}
+		// Use the first "to" type as the target type for default selection.
+		if len(relDef.To) > 0 {
+			ri.TargetType = relDef.To[0]
+			for _, targetType := range relDef.To {
+				for _, e := range a.g.NodesByType(targetType) {
+					ri.Targets = append(ri.Targets, struct{ ID, Title string }{e.ID, a.entityDisplayTitle(e)})
+				}
+			}
+		}
+		allRelations = append(allRelations, ri)
+	}
+
+	// Entity types for override type selection.
+	entityTypes := a.meta.EntityTypes()
+	sort.Strings(entityTypes)
+
+	activeList := "_settings"
+	data := map[string]interface{}{
+		"App":           a.Cfg.App,
+		"Navigation":    a.navElements(activeList),
+		"ActiveList":    activeList,
+		"UserDefaults":  ud,
+		"AllProperties": allProperties,
+		"AllRelations":  allRelations,
+		"EntityTypes":   entityTypes,
+	}
+
+	if r.Header.Get("HX-Request") == "true" {
+		a.tmpl.ExecuteTemplate(w, "settings-content", data) //nolint:errcheck // template errors logged by http
+	} else {
+		a.tmpl.ExecuteTemplate(w, "settings-page", data) //nolint:errcheck // template errors logged by http
+	}
+}
+
+// handleSaveSettings persists user defaults from the settings form.
+func (a *App) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	r.ParseForm() //nolint:errcheck // form parse errors handled by empty values
+
+	ud := UserDefaults{
+		Defaults:         make(map[string]string),
+		RelationDefaults: make(map[string]string),
+	}
+
+	// Parse global property defaults: default_prop[<name>] = value
+	for key, vals := range r.Form {
+		if strings.HasPrefix(key, "default_prop[") && strings.HasSuffix(key, "]") {
+			propName := key[len("default_prop[") : len(key)-1]
+			if len(vals) > 0 && vals[0] != "" {
+				ud.Defaults[propName] = vals[0]
+			}
+		}
+	}
+
+	// Parse global relation defaults: default_rel[<name>] = value
+	for key, vals := range r.Form {
+		if strings.HasPrefix(key, "default_rel[") && strings.HasSuffix(key, "]") {
+			relName := key[len("default_rel[") : len(key)-1]
+			if len(vals) > 0 && vals[0] != "" {
+				ud.RelationDefaults[relName] = vals[0]
+			}
+		}
+	}
+
+	// Parse override groups: override[<idx>][types], override[<idx>][prop][<name>], override[<idx>][rel][<name>]
+	overrideTypes := make(map[string][]string)          // idx -> types
+	overrideProps := make(map[string]map[string]string) // idx -> prop -> val
+	overrideRels := make(map[string]map[string]string)  // idx -> rel -> val
+	for key, vals := range r.Form {
+		if !strings.HasPrefix(key, "override[") {
+			continue
+		}
+		rest := key[len("override["):]
+		idx, rest, ok := strings.Cut(rest, "]")
+		if !ok {
+			continue
+		}
+		switch {
+		case rest == "[types]":
+			// Multiple values (multi-select)
+			overrideTypes[idx] = vals
+		case strings.HasPrefix(rest, "[prop][") && strings.HasSuffix(rest, "]"):
+			propName := rest[len("[prop][") : len(rest)-1]
+			if overrideProps[idx] == nil {
+				overrideProps[idx] = make(map[string]string)
+			}
+			if len(vals) > 0 && vals[0] != "" {
+				overrideProps[idx][propName] = vals[0]
+			}
+		case strings.HasPrefix(rest, "[rel][") && strings.HasSuffix(rest, "]"):
+			relName := rest[len("[rel][") : len(rest)-1]
+			if overrideRels[idx] == nil {
+				overrideRels[idx] = make(map[string]string)
+			}
+			if len(vals) > 0 && vals[0] != "" {
+				overrideRels[idx][relName] = vals[0]
+			}
+		}
+	}
+
+	// Collect override indices and sort them for deterministic order.
+	idxSet := make(map[string]bool)
+	for idx := range overrideTypes {
+		idxSet[idx] = true
+	}
+	for idx := range overrideProps {
+		idxSet[idx] = true
+	}
+	for idx := range overrideRels {
+		idxSet[idx] = true
+	}
+	indices := make([]string, 0, len(idxSet))
+	for idx := range idxSet {
+		indices = append(indices, idx)
+	}
+	sort.Strings(indices)
+
+	for _, idx := range indices {
+		types := overrideTypes[idx]
+		if len(types) == 0 {
+			continue
+		}
+		o := DefaultOverride{
+			Types:            types,
+			Defaults:         overrideProps[idx],
+			RelationDefaults: overrideRels[idx],
+		}
+		ud.Overrides = append(ud.Overrides, o)
+	}
+
+	if err := a.saveUserDefaults(&ud); err != nil {
+		log.Printf("Failed to save user defaults: %v", err)
+		http.Error(w, "Failed to save settings", http.StatusInternalServerError)
+		return
+	}
+	a.userDefaults = &ud
+
+	w.Header().Set("HX-Redirect", appendToastParam("/settings", "Settings saved"))
+	w.WriteHeader(http.StatusOK)
 }

--- a/internal/dataentry/handlers_test.go
+++ b/internal/dataentry/handlers_test.go
@@ -778,6 +778,319 @@ func TestHandleToggleGroup(t *testing.T) {
 	})
 }
 
+func TestHandleSettings(t *testing.T) {
+	t.Run("renders settings page", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
+		app.userDefaults = nil
+		r := httptest.NewRequest(http.MethodGet, "/settings", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleSettings(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "Settings") {
+			t.Error("expected 'Settings' in page")
+		}
+	})
+
+	t.Run("renders settings with existing defaults", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
+		app.userDefaults = &UserDefaults{
+			Defaults: map[string]string{"priority": "high"},
+		}
+		r := httptest.NewRequest(http.MethodGet, "/settings", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleSettings(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("HTMX request returns partial", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
+		app.userDefaults = nil
+		r := httptest.NewRequest(http.MethodGet, "/settings", http.NoBody)
+		r.Header.Set("HX-Request", "true")
+		w := httptest.NewRecorder()
+		app.handleSettings(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+}
+
+func TestHandleSaveSettings(t *testing.T) {
+	t.Run("saves global property defaults", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
+		app.userDefaults = nil
+
+		form := url.Values{
+			"default_prop[priority]": {"high"},
+			"default_prop[status]":   {"open"},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/api/settings", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		app.handleSaveSettings(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		if app.userDefaults == nil {
+			t.Fatal("expected userDefaults to be set")
+		}
+		if app.userDefaults.Defaults["priority"] != "high" {
+			t.Errorf("expected priority=high, got %q", app.userDefaults.Defaults["priority"])
+		}
+		if app.userDefaults.Defaults["status"] != "open" {
+			t.Errorf("expected status=open, got %q", app.userDefaults.Defaults["status"])
+		}
+	})
+
+	t.Run("saves global relation defaults", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
+
+		form := url.Values{
+			"default_rel[belongs_to]": {"CMP-001"},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/api/settings", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		app.handleSaveSettings(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		if app.userDefaults.RelationDefaults["belongs_to"] != "CMP-001" {
+			t.Errorf("expected belongs_to=CMP-001, got %q", app.userDefaults.RelationDefaults["belongs_to"])
+		}
+	})
+
+	t.Run("saves override groups", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
+
+		form := url.Values{
+			"override[0][types]":           {"ticket"},
+			"override[0][prop][priority]":  {"high"},
+			"override[0][rel][depends_on]": {"TKT-002"},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/api/settings", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		app.handleSaveSettings(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		if len(app.userDefaults.Overrides) != 1 {
+			t.Fatalf("expected 1 override, got %d", len(app.userDefaults.Overrides))
+		}
+		o := app.userDefaults.Overrides[0]
+		if len(o.Types) != 1 || o.Types[0] != "ticket" {
+			t.Errorf("expected types=[ticket], got %v", o.Types)
+		}
+		if o.Defaults["priority"] != "high" {
+			t.Errorf("expected priority=high, got %q", o.Defaults["priority"])
+		}
+		if o.RelationDefaults["depends_on"] != "TKT-002" {
+			t.Errorf("expected depends_on=TKT-002, got %q", o.RelationDefaults["depends_on"])
+		}
+	})
+
+	t.Run("skips overrides without types", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
+
+		form := url.Values{
+			"override[0][prop][priority]": {"high"},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/api/settings", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		app.handleSaveSettings(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		if len(app.userDefaults.Overrides) != 0 {
+			t.Errorf("expected 0 overrides (no types), got %d", len(app.userDefaults.Overrides))
+		}
+	})
+
+	t.Run("empty values are not saved", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
+
+		form := url.Values{
+			"default_prop[priority]":  {""},
+			"default_rel[belongs_to]": {""},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/api/settings", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		app.handleSaveSettings(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		if len(app.userDefaults.Defaults) != 0 {
+			t.Errorf("expected 0 defaults, got %d", len(app.userDefaults.Defaults))
+		}
+		if len(app.userDefaults.RelationDefaults) != 0 {
+			t.Errorf("expected 0 relation defaults, got %d", len(app.userDefaults.RelationDefaults))
+		}
+	})
+
+	t.Run("GET not allowed", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		r := httptest.NewRequest(http.MethodGet, "/api/settings", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleSaveSettings(w, r)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", w.Code)
+		}
+	})
+
+	t.Run("persists to file and reloads", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
+
+		form := url.Values{
+			"default_prop[priority]": {"medium"},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/api/settings", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		app.handleSaveSettings(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+
+		// Reload from file
+		loaded := app.loadUserDefaults()
+		if loaded == nil {
+			t.Fatal("expected non-nil loaded defaults")
+		}
+		if loaded.Defaults["priority"] != "medium" {
+			t.Errorf("expected priority=medium, got %q", loaded.Defaults["priority"])
+		}
+	})
+}
+
+func TestHandleFormWithUserDefaults(t *testing.T) {
+	t.Run("create form uses user defaults for property", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.userDefaults = &UserDefaults{
+			Defaults: map[string]string{"status": "in_progress"},
+		}
+		// Use the edit-ticket form which has the status field, for creating
+		app.Cfg.Forms["create-ticket-status"] = Form{
+			EntityType: "ticket",
+			Mode:       "create",
+			Fields: []FormField{
+				{Property: "title"},
+				{Property: "status"},
+			},
+		}
+		r := httptest.NewRequest(http.MethodGet, "/form/create-ticket-status", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleForm(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		// The status field should be pre-selected to "in_progress"
+		if !strings.Contains(body, `value="in_progress" selected`) {
+			t.Error("expected user default 'in_progress' to be selected in form")
+		}
+	})
+
+	t.Run("create form uses user defaults for relation", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.userDefaults = &UserDefaults{
+			RelationDefaults: map[string]string{"belongs_to": "CMP-001"},
+		}
+		// Need a form with a relation field
+		app.Cfg.Forms["create-ticket-rel"] = Form{
+			EntityType: "ticket",
+			Mode:       "create",
+			Fields:     []FormField{{Property: "title"}},
+			Relations: []FormRelation{{
+				Relation:   "belongs_to",
+				TargetType: "component",
+				Label:      "Component",
+				Widget:     "select",
+			}},
+		}
+		r := httptest.NewRequest(http.MethodGet, "/form/create-ticket-rel", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleForm(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		// CMP-001 should be pre-selected as the default relation target
+		if !strings.Contains(body, `value="CMP-001" selected`) {
+			t.Error("expected CMP-001 to be pre-selected as user default relation")
+		}
+	})
+
+	t.Run("edit form does not use user defaults", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.userDefaults = &UserDefaults{
+			Defaults: map[string]string{"status": "in_progress"},
+		}
+		// TKT-001 has status=open, user default is in_progress.
+		// Edit should show actual value, not user default.
+		r := httptest.NewRequest(http.MethodGet, "/form/edit-ticket/TKT-001", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleForm(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		// The actual value "open" should be in the form, not the user default
+		if !strings.Contains(body, "open") {
+			t.Error("expected actual value 'open' in edit form")
+		}
+	})
+
+	t.Run("override takes precedence in create form", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		app.userDefaults = &UserDefaults{
+			Defaults: map[string]string{"priority": "low"},
+			Overrides: []DefaultOverride{
+				{
+					Types:    []string{"ticket"},
+					Defaults: map[string]string{"priority": "high"},
+				},
+			},
+		}
+		// Add priority to create-ticket form fields
+		app.Cfg.Forms["create-ticket"] = Form{
+			EntityType: "ticket",
+			Mode:       "create",
+			Fields: []FormField{
+				{Property: "title"},
+				{Property: "priority"},
+			},
+		}
+		r := httptest.NewRequest(http.MethodGet, "/form/create-ticket", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleForm(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		// Should use override "high", not global "low"
+		if !strings.Contains(body, `value="high" selected`) {
+			t.Error("expected override 'high' to be selected for ticket priority")
+		}
+	})
+}
+
 func TestHandleIndexWithGroupedNav(t *testing.T) {
 	t.Run("first item inside group", func(t *testing.T) {
 		app := newHandlerTestApp(t)

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -399,6 +399,10 @@ func templateFuncs(styleMap map[string]map[string]string, styledTypes map[string
 			b, _ := json.Marshal(v)
 			return string(b)
 		},
+		"jsJSON": func(v interface{}) template.JS {
+			b, _ := json.Marshal(v)
+			return template.JS(b) //nolint:gosec // controlled data from metamodel
+		},
 		"contains": func(slice []string, val string) bool {
 			for _, s := range slice {
 				if s == val {

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -44,6 +44,8 @@ func (a *App) NewRouter() http.Handler {
 	inner.HandleFunc("/api/command-cancel/", a.handleCommandCancel)
 	inner.HandleFunc("/api/open-file", a.handleOpenFile)
 	inner.HandleFunc("/api/open-url", a.handleOpenURL)
+	inner.HandleFunc("/settings", a.handleSettings)
+	inner.HandleFunc("/api/settings", a.handleSaveSettings)
 
 	locked := a.reloadLockMiddleware(inner)
 	mux.Handle("/", locked)

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -744,6 +744,13 @@ document.addEventListener('click', function(e) {
     {{ end }}
     {{ end }}
   </nav>
+  <div style="padding:8px 0;border-top:1px solid rgba(255,255,255,0.1);">
+    <a href="/settings"{{ if eq $.ActiveList "_settings" }} class="active"{{ end }}
+       hx-get="/settings" hx-target="#content" hx-push-url="true"
+       style="display:flex;align-items:center;gap:10px;padding:8px 20px;color:var(--text-sidebar);text-decoration:none;font-size:14px;font-weight:500;transition:all 0.15s;border-left:3px solid transparent;">
+      &#9881; Settings
+    </a>
+  </div>
 </aside>
 <script>
 function toggleNavGroup(btn) {
@@ -2381,6 +2388,415 @@ function submitInlineCreate() {
 .analyze-section thead th { padding: 8px 16px; font-size: 11px; }
 .analyze-section tbody td { padding: 8px 16px; vertical-align: top; }
 .analyze-section-ok { padding: 16px; color: #166534; font-size: 13px; font-weight: 500; border-top: 1px solid var(--border); }
+</style>
+{{- end -}}
+
+{{- define "settings-page" -}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>{{ .App.Name }} - Settings</title>
+{{ template "head" . }}
+{{ template "settings-head" . }}
+</head>
+<body>
+{{ template "sidebar" . }}
+<main class="main" id="content">
+{{ template "settings-content" . }}
+</main>
+</body>
+</html>
+{{- end -}}
+
+{{- define "settings-content" -}}
+<div class="page-header">
+  <div>
+    <h2>Settings</h2>
+    <p>Configure default values for new entities</p>
+    <p style="font-size:12px;color:var(--text-muted);font-family:var(--font-mono);margin-top:4px;">.rela/user-defaults.yaml</p>
+  </div>
+</div>
+
+<div class="card form-card" style="max-width:720px;">
+  <form hx-post="/api/settings" hx-swap="none">
+
+    <h3 style="font-size:15px;font-weight:600;margin-bottom:4px;">Property Defaults</h3>
+    <p style="font-size:13px;color:var(--text-muted);margin-bottom:16px;">
+      Default values applied when creating any entity type.
+    </p>
+
+    <div id="prop-defaults">
+    {{ range $propName, $propVal := .UserDefaults.Defaults }}
+      <div class="settings-row" data-property="{{ $propName }}">
+        <span class="settings-row-label">{{ $propName }}</span>
+        <div class="settings-row-value">
+          {{ $found := false }}
+          {{ range $.AllProperties }}{{ if eq .Name $propName }}{{ $found = true }}
+            {{ if .Values }}
+            <select name="default_prop[{{ $propName }}]">
+              <option value="">—</option>
+              {{ $matched := false }}
+              {{ range .Values }}<option value="{{ . }}"{{ if eq . $propVal }} selected{{ end }}>{{ . }}</option>{{ if eq . $propVal }}{{ $matched = true }}{{ end }}{{ end }}
+              {{ if and (ne $propVal "") (not $matched) }}<option value="{{ $propVal }}" selected class="stale-option">{{ $propVal }} (not in schema)</option>{{ end }}
+            </select>
+            {{ if and (ne $propVal "") (not $matched) }}<span class="settings-stale-badge" title="This value is no longer in the metamodel schema">stale</span>{{ end }}
+            {{ else if eq .Type "boolean" }}
+            <select name="default_prop[{{ $propName }}]">
+              <option value="">—</option>
+              <option value="true"{{ if eq $propVal "true" }} selected{{ end }}>true</option>
+              <option value="false"{{ if eq $propVal "false" }} selected{{ end }}>false</option>
+            </select>
+            {{ else if eq .Type "date" }}
+            <input type="date" name="default_prop[{{ $propName }}]" value="{{ $propVal }}">
+            {{ else if eq .Type "integer" }}
+            <input type="number" name="default_prop[{{ $propName }}]" value="{{ $propVal }}">
+            {{ else }}
+            <input type="text" name="default_prop[{{ $propName }}]" value="{{ $propVal }}">
+            {{ end }}
+          {{ end }}{{ end }}
+          {{ if not $found }}
+          <input type="text" name="default_prop[{{ $propName }}]" value="{{ $propVal }}">
+          <span class="settings-stale-badge" title="This property is not in the current metamodel">unknown</span>
+          {{ end }}
+        </div>
+        <button type="button" class="settings-row-remove" onclick="this.closest('.settings-row').remove()" title="Remove">&times;</button>
+      </div>
+    {{ end }}
+    </div>
+
+    <div style="margin-top:12px;">
+      <select id="add-prop-select" style="width:100%;" onchange="addPropertyDefault(this)">
+        <option value="">Add property default...</option>
+        {{ range .AllProperties }}
+        <option value="{{ .Name }}" data-type="{{ .Type }}" data-values="{{ join .Values "," }}">{{ .Name }} ({{ .Type }})</option>
+        {{ end }}
+      </select>
+    </div>
+
+    <p class="form-section-label">Relation Defaults</p>
+    <p style="font-size:13px;color:var(--text-muted);margin-bottom:16px;">
+      Default relations created when making a new entity.
+    </p>
+
+    <div id="rel-defaults">
+    {{ range $relName, $relVal := .UserDefaults.RelationDefaults }}
+      <div class="settings-row" data-relation="{{ $relName }}">
+        <span class="settings-row-label">{{ $relName }}</span>
+        <div class="settings-row-value">
+          {{ $found := false }}
+          {{ range $.AllRelations }}{{ if eq .Name $relName }}{{ $found = true }}
+            <select name="default_rel[{{ $relName }}]">
+              <option value="">—</option>
+              {{ $matched := false }}
+              {{ range .Targets }}<option value="{{ .ID }}"{{ if eq .ID $relVal }} selected{{ end }}>{{ .Title }}</option>{{ if eq .ID $relVal }}{{ $matched = true }}{{ end }}{{ end }}
+              {{ if and (ne $relVal "") (not $matched) }}<option value="{{ $relVal }}" selected class="stale-option">{{ $relVal }} (not found)</option>{{ end }}
+            </select>
+            {{ if and (ne $relVal "") (not $matched) }}<span class="settings-stale-badge" title="This target entity no longer exists">stale</span>{{ end }}
+          {{ end }}{{ end }}
+          {{ if not $found }}
+          <input type="text" name="default_rel[{{ $relName }}]" value="{{ $relVal }}" readonly>
+          <span class="settings-stale-badge" title="This relation type is not in the current metamodel">unknown</span>
+          {{ end }}
+        </div>
+        <button type="button" class="settings-row-remove" onclick="this.closest('.settings-row').remove()" title="Remove">&times;</button>
+      </div>
+    {{ end }}
+    </div>
+
+    <div style="margin-top:12px;">
+      <select id="add-rel-select" style="width:100%;" onchange="addRelationDefault(this)">
+        <option value="">Add relation default...</option>
+        {{ range .AllRelations }}<option value="{{ .Name }}" data-targets="{{ json .Targets }}">{{ .Name }}{{ if .TargetType }} &rarr; {{ .TargetType }}{{ end }}</option>{{ end }}
+      </select>
+    </div>
+
+    <p class="form-section-label">Overrides</p>
+    <p style="font-size:13px;color:var(--text-muted);margin-bottom:16px;">
+      Override defaults for specific entity types. First matching override takes precedence.
+    </p>
+
+    <div id="overrides">
+    {{ range $idx, $override := .UserDefaults.Overrides }}
+      <div class="override-group" data-idx="{{ $idx }}">
+        <div class="override-header">
+          <div style="flex:1;">
+            <label style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.04em;color:var(--text-muted);margin-bottom:6px;display:block;">Entity Types</label>
+            <select name="override[{{ $idx }}][types]" multiple style="width:100%;">
+              {{ range $.EntityTypes }}<option value="{{ . }}"{{ if contains $override.Types . }} selected{{ end }}>{{ . }}</option>{{ end }}
+              {{ range $override.Types }}{{ $t := . }}{{ $known := false }}{{ range $.EntityTypes }}{{ if eq . $t }}{{ $known = true }}{{ end }}{{ end }}{{ if not $known }}<option value="{{ $t }}" selected class="stale-option">{{ $t }} (unknown)</option>{{ end }}{{ end }}
+            </select>
+          </div>
+          <button type="button" class="settings-row-remove" style="font-size:20px;align-self:start;margin-top:18px;" onclick="this.closest('.override-group').remove()" title="Remove group">&times;</button>
+        </div>
+
+        <div style="margin-top:12px;">
+          <label style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.04em;color:var(--text-muted);margin-bottom:6px;display:block;">Properties</label>
+          <div class="override-props">
+          {{ range $propName, $propVal := $override.Defaults }}
+            <div class="settings-row" data-property="{{ $propName }}">
+              <span class="settings-row-label">{{ $propName }}</span>
+              <div class="settings-row-value">
+                {{ $found := false }}
+                {{ range $.AllProperties }}{{ if eq .Name $propName }}{{ $found = true }}
+                  {{ if .Values }}
+                  <select name="override[{{ $idx }}][prop][{{ $propName }}]">
+                    <option value="">—</option>
+                    {{ $matched := false }}
+                    {{ range .Values }}<option value="{{ . }}"{{ if eq . $propVal }} selected{{ end }}>{{ . }}</option>{{ if eq . $propVal }}{{ $matched = true }}{{ end }}{{ end }}
+                    {{ if and (ne $propVal "") (not $matched) }}<option value="{{ $propVal }}" selected class="stale-option">{{ $propVal }} (not in schema)</option>{{ end }}
+                  </select>
+                  {{ if and (ne $propVal "") (not $matched) }}<span class="settings-stale-badge" title="This value is no longer in the metamodel schema">stale</span>{{ end }}
+                  {{ else if eq .Type "boolean" }}
+                  <select name="override[{{ $idx }}][prop][{{ $propName }}]">
+                    <option value="">—</option>
+                    <option value="true"{{ if eq $propVal "true" }} selected{{ end }}>true</option>
+                    <option value="false"{{ if eq $propVal "false" }} selected{{ end }}>false</option>
+                  </select>
+                  {{ else if eq .Type "date" }}
+                  <input type="date" name="override[{{ $idx }}][prop][{{ $propName }}]" value="{{ $propVal }}">
+                  {{ else if eq .Type "integer" }}
+                  <input type="number" name="override[{{ $idx }}][prop][{{ $propName }}]" value="{{ $propVal }}">
+                  {{ else }}
+                  <input type="text" name="override[{{ $idx }}][prop][{{ $propName }}]" value="{{ $propVal }}">
+                  {{ end }}
+                {{ end }}{{ end }}
+                {{ if not $found }}
+                <input type="text" name="override[{{ $idx }}][prop][{{ $propName }}]" value="{{ $propVal }}">
+                <span class="settings-stale-badge" title="This property is not in the current metamodel">unknown</span>
+                {{ end }}
+              </div>
+              <button type="button" class="settings-row-remove" onclick="this.closest('.settings-row').remove()" title="Remove">&times;</button>
+            </div>
+          {{ end }}
+          </div>
+          <select class="override-add-prop" style="width:100%;margin-top:8px;" onchange="addOverrideProp(this)">
+            <option value="">Add property...</option>
+            {{ range $.AllProperties }}<option value="{{ .Name }}" data-type="{{ .Type }}" data-values="{{ join .Values "," }}">{{ .Name }} ({{ .Type }})</option>{{ end }}
+          </select>
+        </div>
+
+        <div style="margin-top:12px;">
+          <label style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.04em;color:var(--text-muted);margin-bottom:6px;display:block;">Relations</label>
+          <div class="override-rels">
+          {{ range $relName, $relVal := $override.RelationDefaults }}
+            <div class="settings-row" data-relation="{{ $relName }}">
+              <span class="settings-row-label">{{ $relName }}</span>
+              <div class="settings-row-value">
+                {{ $found := false }}
+                {{ range $.AllRelations }}{{ if eq .Name $relName }}{{ $found = true }}
+                  <select name="override[{{ $idx }}][rel][{{ $relName }}]">
+                    <option value="">—</option>
+                    {{ $matched := false }}
+                    {{ range .Targets }}<option value="{{ .ID }}"{{ if eq .ID $relVal }} selected{{ end }}>{{ .Title }}</option>{{ if eq .ID $relVal }}{{ $matched = true }}{{ end }}{{ end }}
+                    {{ if and (ne $relVal "") (not $matched) }}<option value="{{ $relVal }}" selected class="stale-option">{{ $relVal }} (not found)</option>{{ end }}
+                  </select>
+                  {{ if and (ne $relVal "") (not $matched) }}<span class="settings-stale-badge" title="This target entity no longer exists">stale</span>{{ end }}
+                {{ end }}{{ end }}
+                {{ if not $found }}
+                <input type="text" name="override[{{ $idx }}][rel][{{ $relName }}]" value="{{ $relVal }}" readonly>
+                <span class="settings-stale-badge" title="This relation type is not in the current metamodel">unknown</span>
+                {{ end }}
+              </div>
+              <button type="button" class="settings-row-remove" onclick="this.closest('.settings-row').remove()" title="Remove">&times;</button>
+            </div>
+          {{ end }}
+          </div>
+          <select class="override-add-rel" style="width:100%;margin-top:8px;" onchange="addOverrideRel(this)">
+            <option value="">Add relation...</option>
+            {{ range $.AllRelations }}<option value="{{ .Name }}" data-targets="{{ json .Targets }}">{{ .Name }}{{ if .TargetType }} &rarr; {{ .TargetType }}{{ end }}</option>{{ end }}
+          </select>
+        </div>
+      </div>
+    {{ end }}
+    </div>
+
+    <button type="button" class="btn btn-secondary btn-sm" style="margin-top:16px;" onclick="addOverrideGroup()">+ Add override group</button>
+
+    <div class="form-actions">
+      <button type="submit" class="btn btn-primary">Save</button>
+      <a href="/settings" class="btn btn-secondary">Reset</a>
+    </div>
+  </form>
+</div>
+
+<script>
+var overrideCounter = {{ len .UserDefaults.Overrides }};
+var allPropertiesJSON = {{ jsJSON .AllProperties }};
+var allRelationsJSON = {{ jsJSON .AllRelations }};
+var entityTypesJSON = {{ jsJSON .EntityTypes }};
+
+function makeValueInput(name, propInfo, currentVal) {
+  if (propInfo && propInfo.Values && propInfo.Values.length > 0) {
+    var sel = '<select name="' + name + '"><option value="">—</option>';
+    propInfo.Values.forEach(function(v) {
+      sel += '<option value="' + v + '"' + (v === currentVal ? ' selected' : '') + '>' + v + '</option>';
+    });
+    sel += '</select>';
+    return sel;
+  }
+  if (propInfo) {
+    if (propInfo.Type === 'boolean') {
+      return '<select name="' + name + '"><option value="">—</option>' +
+        '<option value="true"' + (currentVal === 'true' ? ' selected' : '') + '>true</option>' +
+        '<option value="false"' + (currentVal === 'false' ? ' selected' : '') + '>false</option></select>';
+    }
+    if (propInfo.Type === 'date') {
+      return '<input type="date" name="' + name + '" value="' + (currentVal || '') + '">';
+    }
+    if (propInfo.Type === 'integer') {
+      return '<input type="number" name="' + name + '" value="' + (currentVal || '') + '">';
+    }
+  }
+  return '<input type="text" name="' + name + '" value="' + (currentVal || '') + '">';
+}
+
+function makeRelationSelect(name, targets, currentVal) {
+  var sel = '<select name="' + name + '"><option value="">—</option>';
+  (targets || []).forEach(function(t) {
+    sel += '<option value="' + t.ID + '"' + (t.ID === currentVal ? ' selected' : '') + '>' + t.Title + '</option>';
+  });
+  sel += '</select>';
+  return sel;
+}
+
+function findPropInfo(propName) {
+  for (var i = 0; i < allPropertiesJSON.length; i++) {
+    if (allPropertiesJSON[i].Name === propName) return allPropertiesJSON[i];
+  }
+  return null;
+}
+
+function findRelInfo(relName) {
+  for (var i = 0; i < allRelationsJSON.length; i++) {
+    if (allRelationsJSON[i].Name === relName) return allRelationsJSON[i];
+  }
+  return null;
+}
+
+function addPropertyDefault(selectEl) {
+  var propName = selectEl.value;
+  if (!propName) return;
+  selectEl.value = '';
+  if (selectEl._slimSelect) selectEl._slimSelect.setSelected('');
+  var container = document.getElementById('prop-defaults');
+  if (container.querySelector('[data-property="' + propName + '"]')) return;
+  var propInfo = findPropInfo(propName);
+  var html = '<div class="settings-row" data-property="' + propName + '">' +
+    '<span class="settings-row-label">' + propName + '</span>' +
+    '<div class="settings-row-value">' + makeValueInput('default_prop[' + propName + ']', propInfo, '') + '</div>' +
+    '<button type="button" class="settings-row-remove" onclick="this.closest(\'.settings-row\').remove()" title="Remove">&times;</button>' +
+    '</div>';
+  container.insertAdjacentHTML('beforeend', html);
+  enhanceSelects(container.lastElementChild);
+}
+
+function addRelationDefault(selectEl) {
+  var relName = selectEl.value;
+  if (!relName) return;
+  selectEl.value = '';
+  if (selectEl._slimSelect) selectEl._slimSelect.setSelected('');
+  var container = document.getElementById('rel-defaults');
+  if (container.querySelector('[data-relation="' + relName + '"]')) return;
+  var relInfo = findRelInfo(relName);
+  var targets = relInfo ? relInfo.Targets : [];
+  var html = '<div class="settings-row" data-relation="' + relName + '">' +
+    '<span class="settings-row-label">' + relName + '</span>' +
+    '<div class="settings-row-value">' + makeRelationSelect('default_rel[' + relName + ']', targets, '') + '</div>' +
+    '<button type="button" class="settings-row-remove" onclick="this.closest(\'.settings-row\').remove()" title="Remove">&times;</button>' +
+    '</div>';
+  container.insertAdjacentHTML('beforeend', html);
+  enhanceSelects(container.lastElementChild);
+}
+
+function addOverrideProp(selectEl) {
+  var propName = selectEl.value;
+  if (!propName) return;
+  selectEl.value = '';
+  if (selectEl._slimSelect) selectEl._slimSelect.setSelected('');
+  var group = selectEl.closest('.override-group');
+  var idx = group.getAttribute('data-idx');
+  var container = group.querySelector('.override-props');
+  if (container.querySelector('[data-property="' + propName + '"]')) return;
+  var propInfo = findPropInfo(propName);
+  var html = '<div class="settings-row" data-property="' + propName + '">' +
+    '<span class="settings-row-label">' + propName + '</span>' +
+    '<div class="settings-row-value">' + makeValueInput('override[' + idx + '][prop][' + propName + ']', propInfo, '') + '</div>' +
+    '<button type="button" class="settings-row-remove" onclick="this.closest(\'.settings-row\').remove()" title="Remove">&times;</button>' +
+    '</div>';
+  container.insertAdjacentHTML('beforeend', html);
+  enhanceSelects(container.lastElementChild);
+}
+
+function addOverrideRel(selectEl) {
+  var relName = selectEl.value;
+  if (!relName) return;
+  selectEl.value = '';
+  if (selectEl._slimSelect) selectEl._slimSelect.setSelected('');
+  var group = selectEl.closest('.override-group');
+  var idx = group.getAttribute('data-idx');
+  var container = group.querySelector('.override-rels');
+  if (container.querySelector('[data-relation="' + relName + '"]')) return;
+  var relInfo = findRelInfo(relName);
+  var targets = relInfo ? relInfo.Targets : [];
+  var html = '<div class="settings-row" data-relation="' + relName + '">' +
+    '<span class="settings-row-label">' + relName + '</span>' +
+    '<div class="settings-row-value">' + makeRelationSelect('override[' + idx + '][rel][' + relName + ']', targets, '') + '</div>' +
+    '<button type="button" class="settings-row-remove" onclick="this.closest(\'.settings-row\').remove()" title="Remove">&times;</button>' +
+    '</div>';
+  container.insertAdjacentHTML('beforeend', html);
+  enhanceSelects(container.lastElementChild);
+}
+
+function addOverrideGroup() {
+  var idx = overrideCounter++;
+  var html = '<div class="override-group" data-idx="' + idx + '">' +
+    '<div class="override-header">' +
+    '<div style="flex:1;">' +
+    '<label style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.04em;color:var(--text-muted);margin-bottom:6px;display:block;">Entity Types</label>' +
+    '<select name="override[' + idx + '][types]" multiple style="width:100%;">';
+  entityTypesJSON.forEach(function(t) {
+    html += '<option value="' + t + '">' + t + '</option>';
+  });
+  html += '</select></div>' +
+    '<button type="button" class="settings-row-remove" style="font-size:20px;align-self:start;margin-top:18px;" onclick="this.closest(\'.override-group\').remove()" title="Remove group">&times;</button>' +
+    '</div>' +
+    '<div style="margin-top:12px;">' +
+    '<label style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.04em;color:var(--text-muted);margin-bottom:6px;display:block;">Properties</label>' +
+    '<div class="override-props"></div>' +
+    '<select class="override-add-prop" style="width:100%;margin-top:8px;" onchange="addOverrideProp(this)"><option value="">Add property...</option>';
+  allPropertiesJSON.forEach(function(p) {
+    html += '<option value="' + p.Name + '" data-type="' + p.Type + '" data-values="' + (p.Values||[]).join(',') + '">' + p.Name + ' (' + p.Type + ')</option>';
+  });
+  html += '</select></div>' +
+    '<div style="margin-top:12px;">' +
+    '<label style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.04em;color:var(--text-muted);margin-bottom:6px;display:block;">Relations</label>' +
+    '<div class="override-rels"></div>' +
+    '<select class="override-add-rel" style="width:100%;margin-top:8px;" onchange="addOverrideRel(this)"><option value="">Add relation...</option>';
+  allRelationsJSON.forEach(function(r) {
+    html += '<option value="' + r.Name + '">'+r.Name + (r.TargetType ? ' → ' + r.TargetType : '') + '</option>';
+  });
+  html += '</select></div></div>';
+  document.getElementById('overrides').insertAdjacentHTML('beforeend', html);
+  var lastGroup = document.getElementById('overrides').lastElementChild;
+  enhanceSelects(lastGroup);
+}
+</script>
+{{- end -}}
+
+{{- define "settings-head" -}}
+<style>
+.settings-row { display: flex; align-items: center; gap: 8px; padding: 8px 0; border-bottom: 1px solid var(--border); }
+.settings-row:first-child { border-top: 1px solid var(--border); }
+.settings-row-label { font-size: 13px; font-weight: 500; font-family: var(--font-mono); color: var(--text); min-width: 140px; flex-shrink: 0; }
+.settings-row-value { flex: 1; }
+.settings-row-value select, .settings-row-value input { width: 100%; padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; font-size: 13px; font-family: var(--font); background: var(--bg-card); color: var(--text); }
+.settings-row-value select:focus, .settings-row-value input:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-light); }
+.settings-row-remove { background: none; border: none; cursor: pointer; color: var(--text-muted); font-size: 18px; padding: 4px; border-radius: 4px; transition: all 0.15s; line-height: 1; flex-shrink: 0; }
+.settings-row-remove:hover { color: var(--danger); background: #fef2f2; }
+.override-group { border: 1px solid var(--border); border-radius: var(--radius); padding: 20px; margin-top: 12px; background: var(--bg); }
+.override-header { display: flex; align-items: start; gap: 12px; }
+.settings-stale-badge { display: inline-block; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; padding: 2px 6px; border-radius: 4px; background: #fef3c7; color: #92400e; border: 1px solid #fcd34d; margin-left: 6px; flex-shrink: 0; white-space: nowrap; }
+.stale-option { color: #92400e; font-style: italic; }
 </style>
 {{- end -}}
 `

--- a/prototypes/data-entry/project/entities/labels/documentation.md
+++ b/prototypes/data-entry/project/entities/labels/documentation.md
@@ -1,0 +1,5 @@
+---
+id: documentation
+type: label
+name: documentation
+---

--- a/prototypes/data-entry/project/entities/labels/feature.md
+++ b/prototypes/data-entry/project/entities/labels/feature.md
@@ -1,0 +1,5 @@
+---
+id: feature
+type: label
+name: feature
+---

--- a/prototypes/data-entry/project/entities/labels/performance.md
+++ b/prototypes/data-entry/project/entities/labels/performance.md
@@ -1,0 +1,5 @@
+---
+id: performance
+type: label
+name: performance
+---

--- a/prototypes/data-entry/project/relations/TKT-002--tagged--feature.md
+++ b/prototypes/data-entry/project/relations/TKT-002--tagged--feature.md
@@ -1,0 +1,5 @@
+---
+from: TKT-002
+relation: tagged
+to: feature
+---

--- a/prototypes/data-entry/project/relations/TKT-003--tagged--bug.md
+++ b/prototypes/data-entry/project/relations/TKT-003--tagged--bug.md
@@ -1,0 +1,5 @@
+---
+from: TKT-003
+relation: tagged
+to: bug
+---

--- a/prototypes/data-entry/project/relations/TKT-004--tagged--feature.md
+++ b/prototypes/data-entry/project/relations/TKT-004--tagged--feature.md
@@ -1,0 +1,5 @@
+---
+from: TKT-004
+relation: tagged
+to: feature
+---

--- a/prototypes/data-entry/project/relations/TKT-005--tagged--bug.md
+++ b/prototypes/data-entry/project/relations/TKT-005--tagged--bug.md
@@ -1,0 +1,5 @@
+---
+from: TKT-005
+relation: tagged
+to: bug
+---

--- a/prototypes/data-entry/project/relations/TKT-005--tagged--performance.md
+++ b/prototypes/data-entry/project/relations/TKT-005--tagged--performance.md
@@ -1,0 +1,5 @@
+---
+from: TKT-005
+relation: tagged
+to: performance
+---

--- a/prototypes/data-entry/project/relations/TKT-006--belongs-to--frontend.md
+++ b/prototypes/data-entry/project/relations/TKT-006--belongs-to--frontend.md
@@ -1,0 +1,5 @@
+---
+from: TKT-006
+relation: belongs-to
+to: frontend
+---

--- a/prototypes/data-entry/project/relations/TKT-006--tagged--documentation.md
+++ b/prototypes/data-entry/project/relations/TKT-006--tagged--documentation.md
@@ -1,0 +1,5 @@
+---
+from: TKT-006
+relation: tagged
+to: documentation
+---

--- a/prototypes/data-entry/project/relations/TKT-007--belongs-to--backend.md
+++ b/prototypes/data-entry/project/relations/TKT-007--belongs-to--backend.md
@@ -1,0 +1,5 @@
+---
+from: TKT-007
+relation: belongs-to
+to: backend
+---

--- a/prototypes/data-entry/project/relations/TKT-007--tagged--feature.md
+++ b/prototypes/data-entry/project/relations/TKT-007--tagged--feature.md
@@ -1,0 +1,5 @@
+---
+from: TKT-007
+relation: tagged
+to: feature
+---

--- a/prototypes/data-entry/project/relations/TKT-008--belongs-to--frontend.md
+++ b/prototypes/data-entry/project/relations/TKT-008--belongs-to--frontend.md
@@ -1,0 +1,5 @@
+---
+from: TKT-008
+relation: belongs-to
+to: frontend
+---

--- a/prototypes/data-entry/project/relations/TKT-008--tagged--bug.md
+++ b/prototypes/data-entry/project/relations/TKT-008--tagged--bug.md
@@ -1,0 +1,5 @@
+---
+from: TKT-008
+relation: tagged
+to: bug
+---

--- a/prototypes/data-entry/project/relations/TKT-009--belongs-to--backend.md
+++ b/prototypes/data-entry/project/relations/TKT-009--belongs-to--backend.md
@@ -1,0 +1,5 @@
+---
+from: TKT-009
+relation: belongs-to
+to: backend
+---

--- a/prototypes/data-entry/project/relations/TKT-009--tagged--feature.md
+++ b/prototypes/data-entry/project/relations/TKT-009--tagged--feature.md
@@ -1,0 +1,5 @@
+---
+from: TKT-009
+relation: tagged
+to: feature
+---

--- a/prototypes/data-entry/project/relations/TKT-010--belongs-to--backend.md
+++ b/prototypes/data-entry/project/relations/TKT-010--belongs-to--backend.md
@@ -1,0 +1,5 @@
+---
+from: TKT-010
+relation: belongs-to
+to: backend
+---

--- a/prototypes/data-entry/project/relations/TKT-010--tagged--bug.md
+++ b/prototypes/data-entry/project/relations/TKT-010--tagged--bug.md
@@ -1,0 +1,5 @@
+---
+from: TKT-010
+relation: tagged
+to: bug
+---

--- a/prototypes/data-entry/project/relations/TKT-010--tagged--performance.md
+++ b/prototypes/data-entry/project/relations/TKT-010--tagged--performance.md
@@ -1,0 +1,5 @@
+---
+from: TKT-010
+relation: tagged
+to: performance
+---

--- a/prototypes/data-entry/project/relations/TKT-011--belongs-to--backend.md
+++ b/prototypes/data-entry/project/relations/TKT-011--belongs-to--backend.md
@@ -1,0 +1,5 @@
+---
+from: TKT-011
+relation: belongs-to
+to: backend
+---


### PR DESCRIPTION
## Summary

- Adds a **Settings page** (`/settings`) to the data entry web app for configuring per-user default values stored in `.rela/user-defaults.yaml`
- Supports **global property defaults**, **relation defaults**, and **per-entity-type overrides** with first-match resolution order
- Renders **type-aware widgets** (date picker, number input, boolean select, enum dropdowns) based on metamodel property types
- Gracefully handles **stale/mismatched defaults** from schema changes: stale enum values shown with "(not in schema)" + STALE badge, unknown relations with UNKNOWN badge, stale relation targets with "(not found)" — all preserved through save roundtrips
- Default values are automatically applied when creating new entities via forms

## Test plan

- [x] Settings page renders with correct widgets for all property types (boolean, date, integer, enum, text)
- [x] Stale enum values display with warning badge and are preserved on save
- [x] Stale relation targets display with warning badge and are preserved on save
- [x] Unknown properties/relations display with UNKNOWN badge and are preserved on save
- [x] Override entity types show unknown types with "(unknown)" suffix
- [x] Save roundtrip preserves all values identically in YAML
- [x] Default values applied when creating new entities
- [x] Lint passes, all tests pass
- [ ] Verify coverage thresholds in CI