### PR TITLE
chore: use PR with auto-merge for coverage ratchet updates

### DIFF
--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -1,12 +1,13 @@
 name: Coverage Ratchet
 
-# After a PR merges, regenerate the coverage baseline and commit if it improved.
+# After a PR merges, regenerate the coverage baseline and open a PR if it improved.
 on:
   push:
     branches: [main, develop]
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-baseline:
@@ -18,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Download dependencies
         run: go mod download
@@ -32,14 +33,34 @@ jobs:
       - name: Generate new coverage baseline
         run: go-test-coverage --config=.testcoverage.yml --breakdown-file-name=.coverage-baseline
 
-      - name: Commit updated baseline
+      - name: Create PR for updated baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if git diff --quiet .coverage-baseline; then
+            echo "No coverage baseline changes"
+            exit 0
+          fi
+
+          BRANCH="chore/coverage-baseline-update"
+          BASE="${{ github.ref_name }}"
+
+          # Clean up any existing branch/PR
+          git push origin --delete "$BRANCH" 2>/dev/null || true
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add .coverage-baseline
-          if git diff --cached --quiet; then
-            echo "No coverage baseline changes to commit"
-          else
-            git commit -m "chore: update coverage baseline [skip ci]"
-            git push
-          fi
+          git commit -m "chore: update coverage baseline"
+          git push -u origin "$BRANCH"
+
+          PR_URL=$(gh pr create \
+            --base "$BASE" \
+            --head "$BRANCH" \
+            --title "chore: update coverage baseline" \
+            --body "Auto-generated coverage baseline update after merge to \`$BASE\`.
+
+          Coverage can only ratchet upward — this PR records improved coverage.")
+
+          gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Summary
- The coverage ratchet workflow can no longer push directly to the default branch since it requires PRs
- Changed the workflow to create a PR with the updated `.coverage-baseline` and enable auto-merge (`gh pr merge --auto --squash`)
- Also fixed Go version from 1.23 to 1.24 to match `ci.yml`

## Test plan
- [ ] Merge a PR that improves coverage and verify the ratchet workflow creates a PR instead of pushing directly
- [ ] Verify auto-merge is enabled on the created PR
- [ ] Verify the PR merges automatically once CI passes