### PR TITLE
Refactor data entry to use Store interface

### DIFF
--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/dataentry"
 	"github.com/Sourcehaven-BV/rela/internal/desktop"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
@@ -78,7 +80,14 @@ func (d *Desktop) OpenRecentProject(path string) string {
 
 // LoadProject loads a rela project from the given directory.
 func (d *Desktop) LoadProject(dir string) string {
-	app, err := dataentry.NewApp(dir, storage.NewSafeFS(storage.NewOsFS()))
+	repo, err := createRepo(dir)
+	if err != nil {
+		d.mu.Lock()
+		d.loadErr = err.Error()
+		d.mu.Unlock()
+		return err.Error()
+	}
+	app, err := dataentry.NewApp(repo)
 	if err != nil {
 		d.mu.Lock()
 		d.loadErr = err.Error()
@@ -290,4 +299,18 @@ func resolveProjectDir(flagValue string, prefs *desktop.Preferences) string {
 func isRelaProject(dir string) bool {
 	_, err := os.Stat(filepath.Join(dir, "metamodel.yaml"))
 	return err == nil
+}
+
+// createRepo discovers the project and creates a repository.
+func createRepo(projectDir string) (repository.Store, error) {
+	absDir, err := filepath.Abs(projectDir)
+	if err != nil {
+		return nil, err
+	}
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	projCtx, err := project.Discover(absDir, fs)
+	if err != nil {
+		return nil, fmt.Errorf("discovering project: %w", err)
+	}
+	return repository.New(fs, projCtx), nil
 }

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -7,11 +7,15 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
+	"path/filepath"
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/dataentry"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
@@ -21,7 +25,12 @@ func main() {
 	port := flag.String("port", "8080", "HTTP port to listen on")
 	flag.Parse()
 
-	app, err := dataentry.NewApp(*projectDir, storage.NewSafeFS(storage.NewOsFS()))
+	repo, err := createRepo(*projectDir)
+	if err != nil {
+		log.Fatalf("Failed to initialize repository: %v", err)
+	}
+
+	app, err := dataentry.NewApp(repo)
 	if err != nil {
 		log.Fatalf("Failed to initialize: %v", err)
 	}
@@ -45,4 +54,18 @@ func main() {
 
 	log.Printf("Starting %s on http://localhost:%s", app.Cfg.App.Name, *port)
 	log.Fatal(srv.ListenAndServe())
+}
+
+// createRepo discovers the project and creates a repository.
+func createRepo(projectDir string) (repository.Store, error) {
+	absDir, err := filepath.Abs(projectDir)
+	if err != nil {
+		return nil, err
+	}
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	projCtx, err := project.Discover(absDir, fs)
+	if err != nil {
+		return nil, fmt.Errorf("discovering project: %w", err)
+	}
+	return repository.New(fs, projCtx), nil
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,7 +30,7 @@ var (
 	g          *graph.Graph
 	out        *output.Writer
 	cliFS      storage.FS = storage.NewSafeFS(storage.NewOsFS())
-	repo       *repository.Repository
+	repo       repository.Store
 )
 
 // rootCmd represents the base command

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -18,9 +18,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/migration"
 	"github.com/Sourcehaven-BV/rela/internal/model"
-	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
-	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
 // ConfigFile is the conventional filename for data-entry configuration within a rela project.
@@ -37,19 +35,12 @@ type App struct {
 	Cfg  *Config
 	meta *metamodel.Metamodel
 	g    *graph.Graph
-	repo *repository.Repository
+	repo repository.Store
 	tmpl *template.Template
 	// styleMap: property type name -> value -> CSS class name
 	styleMap map[string]map[string]string
 	// styledTypes: set of property type names that have style entries
 	styledTypes map[string]bool
-	// projCtx and fs are stored for live-reload and UI state support.
-	projCtx *project.Context
-	fs      storage.FS
-	// uiStatePath is the path to .rela/ui-state.json for persisting UI preferences.
-	uiStatePath string
-	// userDefaultsPath is the path to .rela/user-defaults.yaml for user-specific defaults.
-	userDefaultsPath string
 	// userDefaults holds the loaded user defaults (nil if not yet loaded or no file).
 	userDefaults *UserDefaults
 	// mu protects reloadable state (Cfg, meta, g, tmpl, styleMap, styledTypes)
@@ -59,27 +50,17 @@ type App struct {
 	broker *eventBroker
 }
 
-// NewApp creates and initializes an App using the given filesystem.
-func NewApp(projectDir string, fs storage.FS) (*App, error) {
-	// Discover rela project
-	absDir, err := filepath.Abs(projectDir)
-	if err != nil {
-		return nil, err
-	}
-	projCtx, err := project.Discover(absDir, fs)
-	if err != nil {
-		return nil, fmt.Errorf("discovering project: %w", err)
-	}
-
+// NewApp creates and initializes an App using the given Store.
+func NewApp(repo repository.Store) (*App, error) {
 	// Load data-entry config from project root
-	configPath := filepath.Join(projCtx.Root, ConfigFile)
-	cfgData, err := fs.ReadFile(configPath)
+	cfgData, err := repo.ReadProjectFile(ConfigFile)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", ConfigFile, err)
 	}
 	// Check for deprecated syntax that needs migration
-	detections, detectErr := migration.Detect(configPath, migration.FileTypeDataEntry, fs)
-	if detectErr == nil && len(detections) > 0 {
+	configPath := filepath.Join(repo.Paths().Root, ConfigFile)
+	detections := migration.DetectBytes(cfgData, migration.FileTypeDataEntry)
+	if len(detections) > 0 {
 		return nil, &migration.Error{
 			FilePath:   configPath,
 			Detections: detections,
@@ -90,9 +71,6 @@ func NewApp(projectDir string, fs storage.FS) (*App, error) {
 	if unmarshalErr := yaml.Unmarshal(cfgData, &cfg); unmarshalErr != nil {
 		return nil, fmt.Errorf("parsing %s: %w", ConfigFile, unmarshalErr)
 	}
-
-	// Create repository
-	repo := repository.New(fs, projCtx)
 
 	// Load metamodel
 	meta, err := repo.LoadMetamodel()
@@ -128,18 +106,14 @@ func NewApp(projectDir string, fs storage.FS) (*App, error) {
 		return nil, fmt.Errorf("parsing graph templates: %w", err)
 	}
 	app := &App{
-		Cfg:              &cfg,
-		meta:             meta,
-		g:                g,
-		repo:             repo,
-		tmpl:             tmpl,
-		styleMap:         styleMap,
-		styledTypes:      styledTypes,
-		projCtx:          projCtx,
-		fs:               fs,
-		uiStatePath:      filepath.Join(projCtx.CacheDir, uiStateFile),
-		userDefaultsPath: filepath.Join(projCtx.CacheDir, userDefaultsFile),
-		broker:           newEventBroker(),
+		Cfg:         &cfg,
+		meta:        meta,
+		g:           g,
+		repo:        repo,
+		tmpl:        tmpl,
+		styleMap:    styleMap,
+		styledTypes: styledTypes,
+		broker:      newEventBroker(),
 	}
 	app.userDefaults = app.loadUserDefaults()
 	return app, nil
@@ -219,10 +193,10 @@ func (a *App) navElements(activeList string) []NavElement {
 // Returns an empty UIState if the file doesn't exist or can't be parsed.
 func (a *App) loadUIState() UIState {
 	state := UIState{CollapsedGroups: make(map[string]bool)}
-	if a.uiStatePath == "" {
+	if a.repo == nil {
 		return state
 	}
-	data, err := a.fs.ReadFile(a.uiStatePath)
+	data, err := a.repo.ReadCacheFile(uiStateFile)
 	if err != nil {
 		return state
 	}
@@ -237,27 +211,23 @@ func (a *App) loadUIState() UIState {
 
 // saveUIState writes the UI state to .rela/ui-state.json.
 func (a *App) saveUIState(state UIState) error {
-	if a.uiStatePath == "" {
+	if a.repo == nil {
 		return nil
-	}
-	// Ensure .rela directory exists
-	if err := a.fs.MkdirAll(filepath.Dir(a.uiStatePath), 0o755); err != nil {
-		return err
 	}
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return err
 	}
-	return a.fs.WriteFile(a.uiStatePath, data, 0o644)
+	return a.repo.WriteCacheFile(uiStateFile, data)
 }
 
 // loadUserDefaults reads .rela/user-defaults.yaml and returns the parsed defaults.
 // Returns nil if the file doesn't exist or can't be parsed.
 func (a *App) loadUserDefaults() *UserDefaults {
-	if a.userDefaultsPath == "" {
+	if a.repo == nil {
 		return nil
 	}
-	data, err := a.fs.ReadFile(a.userDefaultsPath)
+	data, err := a.repo.ReadCacheFile(userDefaultsFile)
 	if err != nil {
 		return nil
 	}
@@ -270,17 +240,14 @@ func (a *App) loadUserDefaults() *UserDefaults {
 
 // saveUserDefaults writes the user defaults to .rela/user-defaults.yaml.
 func (a *App) saveUserDefaults(ud *UserDefaults) error {
-	if a.userDefaultsPath == "" {
+	if a.repo == nil {
 		return nil
-	}
-	if err := a.fs.MkdirAll(filepath.Dir(a.userDefaultsPath), 0o755); err != nil {
-		return err
 	}
 	data, err := yaml.Marshal(ud)
 	if err != nil {
 		return err
 	}
-	return a.fs.WriteFile(a.userDefaultsPath, data, 0o644)
+	return a.repo.WriteCacheFile(userDefaultsFile, data)
 }
 
 // firstNavTarget returns the first navigable item from the navigation config,

--- a/internal/dataentry/app_test.go
+++ b/internal/dataentry/app_test.go
@@ -3,13 +3,14 @@ package dataentry
 import (
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
@@ -141,7 +142,6 @@ func testAppInstance() *App {
 		Cfg:         cfg,
 		meta:        meta,
 		g:           g,
-		fs:          storage.NewOsFS(),
 		styleMap:    styleMap,
 		styledTypes: styledTypes,
 	}
@@ -695,9 +695,17 @@ func TestFirstNavTarget(t *testing.T) {
 }
 
 func TestUIStateLoadSave(t *testing.T) {
-	dir := t.TempDir()
+	// Create an app with a real repository backed by memfs
+	fs := storage.NewMemFS()
+	ctx := &project.Context{
+		Root:     "/project",
+		CacheDir: "/project/.rela",
+	}
+	_ = fs.MkdirAll(ctx.CacheDir, 0o755)
+	repo := repository.New(fs, ctx)
+
 	app := testAppInstance()
-	app.uiStatePath = filepath.Join(dir, "ui-state.json")
+	app.repo = repo
 
 	t.Run("load returns defaults when file missing", func(t *testing.T) {
 		state := app.loadUIState()
@@ -719,7 +727,7 @@ func TestUIStateLoadSave(t *testing.T) {
 
 	t.Run("UIState overrides config default", func(t *testing.T) {
 		app2 := testAppInstance()
-		app2.uiStatePath = filepath.Join(dir, "ui-state.json")
+		app2.repo = repo
 		app2.Cfg.Navigation = []NavigationEntry{
 			{
 				Group:     "Tickets",
@@ -743,9 +751,9 @@ func TestUIStateLoadSave(t *testing.T) {
 		}
 	})
 
-	t.Run("empty uiStatePath is safe", func(t *testing.T) {
+	t.Run("nil repo is safe", func(t *testing.T) {
 		app2 := testAppInstance()
-		app2.uiStatePath = ""
+		app2.repo = nil
 		state := app2.loadUIState()
 		if len(state.CollapsedGroups) != 0 {
 			t.Error("expected empty state")
@@ -757,9 +765,16 @@ func TestUIStateLoadSave(t *testing.T) {
 }
 
 func TestUserDefaultsLoadSave(t *testing.T) {
-	dir := t.TempDir()
+	fs := storage.NewMemFS()
+	ctx := &project.Context{
+		Root:     "/project",
+		CacheDir: "/project/.rela",
+	}
+	_ = fs.MkdirAll(ctx.CacheDir, 0o755)
+	repo := repository.New(fs, ctx)
+
 	app := testAppInstance()
-	app.userDefaultsPath = filepath.Join(dir, "user-defaults.yaml")
+	app.repo = repo
 
 	t.Run("load returns nil when file missing", func(t *testing.T) {
 		ud := app.loadUserDefaults()
@@ -804,9 +819,9 @@ func TestUserDefaultsLoadSave(t *testing.T) {
 		}
 	})
 
-	t.Run("empty userDefaultsPath is safe", func(t *testing.T) {
+	t.Run("nil repo is safe", func(t *testing.T) {
 		app2 := testAppInstance()
-		app2.userDefaultsPath = ""
+		app2.repo = nil
 		ud := app2.loadUserDefaults()
 		if ud != nil {
 			t.Errorf("expected nil, got %+v", ud)

--- a/internal/dataentry/handlers_graph_test.go
+++ b/internal/dataentry/handlers_graph_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
-	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
 // newGraphTestApp builds a full App with graph templates for graph handler tests.
@@ -36,7 +35,6 @@ func newGraphTestApp(t *testing.T) *App {
 		Cfg:         cfg,
 		meta:        meta,
 		g:           g,
-		fs:          storage.NewOsFS(),
 		tmpl:        tmpl,
 		styleMap:    styleMap,
 		styledTypes: styledTypes,
@@ -429,7 +427,7 @@ func TestBuildContentGraphDataEmptyGraph(t *testing.T) {
 	}
 
 	styleMap, styledTypes := buildStyleMap(cfg, meta)
-	app := &App{Cfg: cfg, meta: meta, g: g, fs: storage.NewOsFS(), styleMap: styleMap, styledTypes: styledTypes}
+	app := &App{Cfg: cfg, meta: meta, g: g, styleMap: styleMap, styledTypes: styledTypes}
 	resp := app.buildContentGraphData()
 
 	if len(resp.Nodes) != 0 {

--- a/internal/dataentry/handlers_test.go
+++ b/internal/dataentry/handlers_test.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
@@ -56,14 +57,20 @@ func newHandlerTestApp(t *testing.T) *App {
 		t.Fatalf("parsing templates: %v", err)
 	}
 
+	// Set up a repo for tests that need to read/write cache files
+	fs := storage.NewMemFS()
+	ctx := &project.Context{Root: "/project", CacheDir: "/project/.rela"}
+	_ = fs.MkdirAll(ctx.CacheDir, 0o755)
+	repo := repository.New(fs, ctx)
+
 	return &App{
 		Cfg:         cfg,
 		meta:        meta,
 		g:           g,
-		fs:          storage.NewOsFS(),
 		tmpl:        tmpl,
 		styleMap:    styleMap,
 		styledTypes: styledTypes,
+		repo:        repo,
 	}
 }
 
@@ -722,7 +729,11 @@ func TestHandleExecuteQuery(t *testing.T) {
 func TestHandleToggleGroup(t *testing.T) {
 	t.Run("toggles group collapsed state", func(t *testing.T) {
 		app := newHandlerTestApp(t)
-		app.uiStatePath = filepath.Join(t.TempDir(), "ui-state.json")
+		// Set up a repo for UI state persistence
+		fs := storage.NewMemFS()
+		ctx := &project.Context{Root: "/project", CacheDir: "/project/.rela"}
+		_ = fs.MkdirAll(ctx.CacheDir, 0o755)
+		app.repo = repository.New(fs, ctx)
 
 		// Toggle "Tickets" group to collapsed
 		body := strings.NewReader("group=Tickets")
@@ -781,7 +792,6 @@ func TestHandleToggleGroup(t *testing.T) {
 func TestHandleSettings(t *testing.T) {
 	t.Run("renders settings page", func(t *testing.T) {
 		app := newHandlerTestApp(t)
-		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
 		app.userDefaults = nil
 		r := httptest.NewRequest(http.MethodGet, "/settings", http.NoBody)
 		w := httptest.NewRecorder()
@@ -797,7 +807,6 @@ func TestHandleSettings(t *testing.T) {
 
 	t.Run("renders settings with existing defaults", func(t *testing.T) {
 		app := newHandlerTestApp(t)
-		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
 		app.userDefaults = &UserDefaults{
 			Defaults: map[string]string{"priority": "high"},
 		}
@@ -811,7 +820,6 @@ func TestHandleSettings(t *testing.T) {
 
 	t.Run("HTMX request returns partial", func(t *testing.T) {
 		app := newHandlerTestApp(t)
-		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
 		app.userDefaults = nil
 		r := httptest.NewRequest(http.MethodGet, "/settings", http.NoBody)
 		r.Header.Set("HX-Request", "true")
@@ -826,7 +834,6 @@ func TestHandleSettings(t *testing.T) {
 func TestHandleSaveSettings(t *testing.T) {
 	t.Run("saves global property defaults", func(t *testing.T) {
 		app := newHandlerTestApp(t)
-		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
 		app.userDefaults = nil
 
 		form := url.Values{
@@ -853,7 +860,6 @@ func TestHandleSaveSettings(t *testing.T) {
 
 	t.Run("saves global relation defaults", func(t *testing.T) {
 		app := newHandlerTestApp(t)
-		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
 
 		form := url.Values{
 			"default_rel[belongs_to]": {"CMP-001"},
@@ -872,7 +878,6 @@ func TestHandleSaveSettings(t *testing.T) {
 
 	t.Run("saves override groups", func(t *testing.T) {
 		app := newHandlerTestApp(t)
-		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
 
 		form := url.Values{
 			"override[0][types]":           {"ticket"},
@@ -903,7 +908,6 @@ func TestHandleSaveSettings(t *testing.T) {
 
 	t.Run("skips overrides without types", func(t *testing.T) {
 		app := newHandlerTestApp(t)
-		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
 
 		form := url.Values{
 			"override[0][prop][priority]": {"high"},
@@ -922,7 +926,6 @@ func TestHandleSaveSettings(t *testing.T) {
 
 	t.Run("empty values are not saved", func(t *testing.T) {
 		app := newHandlerTestApp(t)
-		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
 
 		form := url.Values{
 			"default_prop[priority]":  {""},
@@ -955,7 +958,6 @@ func TestHandleSaveSettings(t *testing.T) {
 
 	t.Run("persists to file and reloads", func(t *testing.T) {
 		app := newHandlerTestApp(t)
-		app.userDefaultsPath = filepath.Join(t.TempDir(), "user-defaults.yaml")
 
 		form := url.Values{
 			"default_prop[priority]": {"medium"},

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -7,13 +7,13 @@ import (
 	"net/http"
 	"path/filepath"
 	"sync"
-	"time"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/migration"
-	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
 )
 
 // eventBroker manages SSE client connections for live-reload notifications.
@@ -56,38 +56,29 @@ func (b *eventBroker) broadcast(event string) {
 //
 // coverage-ignore: requires real filesystem events via fsnotify
 func (a *App) StartWatching() (stop func(), err error) {
-	configPath := filepath.Join(a.projCtx.Root, ConfigFile)
+	configPath := filepath.Join(a.repo.Paths().Root, ConfigFile)
 
-	w, err := storage.NewWatcher(storage.WatchConfig{
-		Dirs:       []string{a.projCtx.EntitiesDir, a.projCtx.RelationsDir},
-		Files:      []string{a.projCtx.MetamodelPath, configPath},
-		Extensions: []string{".md", ".yaml", ".yml"},
-		Debounce:   500 * time.Millisecond,
-		SkipHidden: true,
-		OnChange: func(events []storage.ChangeEvent) {
-			for _, e := range events {
-				log.Printf("File changed: %s (%s)", e.Path, e.Op)
-			}
-			a.reload(events)
-			a.broker.broadcast("refresh")
-		},
-	})
-	if err != nil {
-		return nil, err
+	opts := repository.WatchOptions{
+		ExtraFiles: []string{configPath},
 	}
-
-	go w.Start()
-	return w.Stop, nil
+	return a.repo.Watch(opts, func(events []model.ChangeEvent) {
+		for _, e := range events {
+			log.Printf("File changed: %s (%s)", e.Path, e.Op)
+		}
+		a.reload(events)
+		a.broker.broadcast("refresh")
+	})
 }
 
 // reload re-syncs the graph and optionally reloads metamodel/config when
 // the corresponding files have changed. It holds the write lock to ensure
 // no handlers are reading stale state during the swap.
-func (a *App) reload(events []storage.ChangeEvent) {
+func (a *App) reload(events []model.ChangeEvent) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	configPath := filepath.Join(a.projCtx.Root, ConfigFile)
+	paths := a.repo.Paths()
+	configPath := filepath.Join(paths.Root, ConfigFile)
 	needConfigReload := false
 	needMetamodelReload := false
 
@@ -95,7 +86,7 @@ func (a *App) reload(events []storage.ChangeEvent) {
 		switch e.Path {
 		case configPath:
 			needConfigReload = true
-		case a.projCtx.MetamodelPath:
+		case paths.MetamodelPath:
 			needMetamodelReload = true
 		}
 	}
@@ -115,7 +106,7 @@ func (a *App) reload(events []storage.ChangeEvent) {
 	}
 
 	if needConfigReload {
-		cfgData, err := a.fs.ReadFile(configPath)
+		cfgData, err := a.repo.ReadProjectFile(ConfigFile)
 		if err != nil {
 			log.Printf("Config reload error: %v", err)
 		} else {

--- a/internal/dataentry/watcher_test.go
+++ b/internal/dataentry/watcher_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/graph"
+	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
@@ -132,8 +133,6 @@ status: open
 		tmpl:        tmpl,
 		styleMap:    styleMap,
 		styledTypes: styledTypes,
-		projCtx:     ctx,
-		fs:          fs,
 		broker:      newEventBroker(),
 	}
 
@@ -270,7 +269,7 @@ func TestReloadEntityChanges(t *testing.T) {
 	initialCount := len(app.g.AllNodes())
 
 	// Add a new entity file
-	_ = fs.WriteFile(app.projCtx.EntitiesDir+"/tickets/TKT-002.md", []byte(`---
+	_ = fs.WriteFile(app.repo.Paths().EntitiesDir+"/tickets/TKT-002.md", []byte(`---
 id: TKT-002
 type: ticket
 title: Second Ticket
@@ -279,8 +278,8 @@ status: open
 `), 0o644)
 
 	// Reload with a generic entity change (not metamodel or config)
-	app.reload([]storage.ChangeEvent{
-		{Path: app.projCtx.EntitiesDir + "/tickets/TKT-002.md", Op: storage.OpCreate},
+	app.reload([]model.ChangeEvent{
+		{Path: app.repo.Paths().EntitiesDir + "/tickets/TKT-002.md", Op: model.OpCreate},
 	})
 
 	newCount := len(app.g.AllNodes())
@@ -324,10 +323,10 @@ relations:
     from: [ticket]
     to: [ticket]
 `
-	_ = fs.WriteFile(app.projCtx.MetamodelPath, []byte(updatedMeta), 0o644)
+	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(updatedMeta), 0o644)
 
-	app.reload([]storage.ChangeEvent{
-		{Path: app.projCtx.MetamodelPath, Op: storage.OpModify},
+	app.reload([]model.ChangeEvent{
+		{Path: app.repo.Paths().MetamodelPath, Op: model.OpModify},
 	})
 
 	if _, ok := app.meta.GetEntityDef("component"); !ok {
@@ -348,11 +347,11 @@ lists: {}
 forms: {}
 navigation: []
 `
-	configPath := app.projCtx.Root + "/" + ConfigFile
+	configPath := app.repo.Paths().Root + "/" + ConfigFile
 	_ = fs.WriteFile(configPath, []byte(updatedConfig), 0o644)
 
-	app.reload([]storage.ChangeEvent{
-		{Path: configPath, Op: storage.OpModify},
+	app.reload([]model.ChangeEvent{
+		{Path: configPath, Op: model.OpModify},
 	})
 
 	if app.Cfg.App.Name == originalName {
@@ -369,10 +368,10 @@ func TestReloadBadMetamodelKeepsPrevious(t *testing.T) {
 	original := app.meta
 
 	// Write invalid metamodel
-	_ = fs.WriteFile(app.projCtx.MetamodelPath, []byte(`not: valid: metamodel: {{{`), 0o644)
+	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(`not: valid: metamodel: {{{`), 0o644)
 
-	app.reload([]storage.ChangeEvent{
-		{Path: app.projCtx.MetamodelPath, Op: storage.OpModify},
+	app.reload([]model.ChangeEvent{
+		{Path: app.repo.Paths().MetamodelPath, Op: model.OpModify},
 	})
 
 	// Metamodel should be unchanged
@@ -385,13 +384,13 @@ func TestReloadBadConfigKeepsPrevious(t *testing.T) {
 	app, fs := setupReloadTestApp(t)
 
 	originalName := app.Cfg.App.Name
-	configPath := app.projCtx.Root + "/" + ConfigFile
+	configPath := app.repo.Paths().Root + "/" + ConfigFile
 
 	// Write invalid YAML config
 	_ = fs.WriteFile(configPath, []byte(`not: valid: yaml: {{{`), 0o644)
 
-	app.reload([]storage.ChangeEvent{
-		{Path: configPath, Op: storage.OpModify},
+	app.reload([]model.ChangeEvent{
+		{Path: configPath, Op: model.OpModify},
 	})
 
 	// Config should be unchanged
@@ -403,7 +402,7 @@ func TestReloadBadConfigKeepsPrevious(t *testing.T) {
 func TestReloadMixedEvents(t *testing.T) {
 	app, fs := setupReloadTestApp(t)
 
-	configPath := app.projCtx.Root + "/" + ConfigFile
+	configPath := app.repo.Paths().Root + "/" + ConfigFile
 	updatedConfig := `version: "1.0"
 app:
   name: "Mixed Update"
@@ -433,12 +432,12 @@ relations:
     from: [ticket]
     to: [ticket]
 `
-	_ = fs.WriteFile(app.projCtx.MetamodelPath, []byte(updatedMeta), 0o644)
+	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(updatedMeta), 0o644)
 
 	// Reload with both config and metamodel changes at once
-	app.reload([]storage.ChangeEvent{
-		{Path: configPath, Op: storage.OpModify},
-		{Path: app.projCtx.MetamodelPath, Op: storage.OpModify},
+	app.reload([]model.ChangeEvent{
+		{Path: configPath, Op: model.OpModify},
+		{Path: app.repo.Paths().MetamodelPath, Op: model.OpModify},
 	})
 
 	if app.Cfg.App.Name != "Mixed Update" {

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -108,7 +108,7 @@ func (s *ImportSource) Open(path string) (io.ReadCloser, error) {
 
 // Importer handles importing data into a rela project
 type Importer struct {
-	repo   *repository.Repository
+	repo   repository.Store
 	meta   *metamodel.Metamodel
 	g      *graph.Graph
 	opts   Options
@@ -117,7 +117,7 @@ type Importer struct {
 
 // New creates a new Importer that reads input files from the given source.
 func New(
-	repo *repository.Repository, meta *metamodel.Metamodel, g *graph.Graph, opts Options, source *ImportSource,
+	repo repository.Store, meta *metamodel.Metamodel, g *graph.Graph, opts Options, source *ImportSource,
 ) *Importer {
 	return &Importer{
 		repo:   repo,

--- a/internal/markdown/sync.go
+++ b/internal/markdown/sync.go
@@ -3,19 +3,15 @@ package markdown
 import (
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 )
 
-// SyncResult contains statistics from a sync operation
-type SyncResult struct {
-	EntitiesLoaded  int
-	RelationsLoaded int
-	Errors          []error
-}
-
 // SyncFromFiles rebuilds the graph from markdown files.
-func (f *FileIO) SyncFromFiles(ctx *project.Context, meta *metamodel.Metamodel, g *graph.Graph) (*SyncResult, error) {
-	result := &SyncResult{}
+func (f *FileIO) SyncFromFiles(
+	ctx *project.Context, meta *metamodel.Metamodel, g *graph.Graph,
+) (*model.SyncResult, error) {
+	result := &model.SyncResult{}
 
 	// Clear the graph
 	g.Clear()
@@ -40,14 +36,14 @@ func (f *FileIO) SyncFromFiles(ctx *project.Context, meta *metamodel.Metamodel, 
 	for _, relation := range relations {
 		// Validate that both ends exist
 		if _, ok := g.GetNode(relation.From); !ok {
-			result.Errors = append(result.Errors, &SyncError{
+			result.Errors = append(result.Errors, &model.SyncError{
 				File:    relation.FilePath,
 				Message: "source entity not found: " + relation.From,
 			})
 			continue
 		}
 		if _, ok := g.GetNode(relation.To); !ok {
-			result.Errors = append(result.Errors, &SyncError{
+			result.Errors = append(result.Errors, &model.SyncError{
 				File:    relation.FilePath,
 				Message: "target entity not found: " + relation.To,
 			})
@@ -59,14 +55,4 @@ func (f *FileIO) SyncFromFiles(ctx *project.Context, meta *metamodel.Metamodel, 
 	}
 
 	return result, nil
-}
-
-// SyncError represents an error during sync
-type SyncError struct {
-	File    string
-	Message string
-}
-
-func (e *SyncError) Error() string {
-	return e.File + ": " + e.Message
 }

--- a/internal/markdown/sync_test.go
+++ b/internal/markdown/sync_test.go
@@ -300,7 +300,7 @@ type: requirement
 }
 
 func TestSyncError_Error(t *testing.T) {
-	err := &SyncError{
+	err := &model.SyncError{
 		File:    "/path/to/file.md",
 		Message: "something went wrong",
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -21,7 +21,7 @@ type Server struct {
 	meta       *metamodel.Metamodel
 	metaMu     sync.RWMutex // protects meta
 	projectCtx *project.Context
-	repo       *repository.Repository
+	repo       repository.Store
 	watcher    *Watcher
 	logger     *log.Logger
 }
@@ -41,7 +41,7 @@ func (s *Server) setMeta(m *metamodel.Metamodel) {
 }
 
 // NewServer creates a new MCP server for a rela project.
-func NewServer(g *graph.Graph, meta *metamodel.Metamodel, repo *repository.Repository, version string) *Server {
+func NewServer(g *graph.Graph, meta *metamodel.Metamodel, repo repository.Store, version string) *Server {
 	logger := log.New(os.Stderr, "[rela-mcp] ", log.LstdFlags)
 
 	s := &Server{
@@ -86,7 +86,6 @@ func (s *Server) Serve() error {
 		s.logger.Printf("Warning: file watcher not started: %v", err)
 	} else {
 		s.watcher = watcher
-		go s.watcher.Start()
 	}
 
 	defer func() {

--- a/internal/mcp/watcher.go
+++ b/internal/mcp/watcher.go
@@ -2,55 +2,41 @@
 package mcp
 
 import (
-	"path/filepath"
-	"time"
-
 	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/Sourcehaven-BV/rela/internal/migration"
-	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
 )
 
 // Watcher watches entity and relation files for changes and notifies MCP clients.
 type Watcher struct {
-	server  *Server
-	watcher *storage.Watcher
+	server *Server
+	stop   func()
 }
 
-// NewWatcher creates a new file watcher for the rela project.
+// NewWatcher creates a new file watcher for the rela project using the
+// Store's Watch method.
 func NewWatcher(s *Server) (*Watcher, error) {
-	viewsPath := filepath.Join(s.projectCtx.Root, "views.yaml")
-
 	w := &Watcher{server: s}
 
-	sw, err := storage.NewWatcher(storage.WatchConfig{
-		Dirs:       []string{s.projectCtx.EntitiesDir, s.projectCtx.RelationsDir},
-		Files:      []string{s.projectCtx.MetamodelPath, viewsPath},
-		Extensions: []string{".md", ".yaml", ".yml"},
-		Debounce:   200 * time.Millisecond,
-		OnChange: func(events []storage.ChangeEvent) {
-			for _, e := range events {
-				s.logger.Printf("File changed: %s (%s)", e.Path, e.Op)
-			}
-			w.syncAndNotify()
-		},
+	stop, err := s.repo.Watch(repository.WatchOptions{}, func(events []model.ChangeEvent) {
+		for _, e := range events {
+			s.logger.Printf("File changed: %s (%s)", e.Path, e.Op)
+		}
+		w.syncAndNotify()
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	w.watcher = sw
+	w.stop = stop
 	return w, nil
-}
-
-// Start begins watching for file changes. Should be called in a goroutine.
-func (w *Watcher) Start() {
-	w.watcher.Start()
 }
 
 // Stop stops the file watcher.
 func (w *Watcher) Stop() {
-	w.watcher.Stop()
+	w.stop()
 }
 
 func (w *Watcher) syncAndNotify() {

--- a/internal/mcp/watcher_test.go
+++ b/internal/mcp/watcher_test.go
@@ -4,15 +4,20 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
 func TestWatcherStop(t *testing.T) {
 	s := makeTestServer(t)
 
-	// Create required directories so NewWatcher doesn't fail
-	entitiesDir := filepath.Join(s.projectCtx.Root, "entities")
-	relationsDir := filepath.Join(s.projectCtx.Root, "relations")
-	metamodelPath := filepath.Join(s.projectCtx.Root, "metamodel.yaml")
+	// Create required directories so Watch doesn't fail
+	root := s.projectCtx.Root
+	entitiesDir := filepath.Join(root, "entities")
+	relationsDir := filepath.Join(root, "relations")
+	metamodelPath := filepath.Join(root, "metamodel.yaml")
 	if err := os.MkdirAll(entitiesDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -23,23 +28,20 @@ func TestWatcherStop(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s.projectCtx.EntitiesDir = entitiesDir
-	s.projectCtx.RelationsDir = relationsDir
-	s.projectCtx.MetamodelPath = metamodelPath
+	ctx := &project.Context{
+		Root:          root,
+		EntitiesDir:   entitiesDir,
+		RelationsDir:  relationsDir,
+		MetamodelPath: metamodelPath,
+	}
+	s.repo = repository.New(storage.NewOsFS(), ctx)
+	s.projectCtx = ctx
 
 	w, err := NewWatcher(s)
 	if err != nil {
 		t.Fatalf("NewWatcher failed: %v", err)
 	}
 
-	// Start in goroutine
-	done := make(chan struct{})
-	go func() {
-		w.Start()
-		close(done)
-	}()
-
-	// Stop should cause Start to return
+	// Stop should shut down the watcher started by Watch
 	w.Stop()
-	<-done
 }

--- a/internal/migration/runner.go
+++ b/internal/migration/runner.go
@@ -49,6 +49,16 @@ func Detect(path string, ft FileType, fs storage.FS) ([]DetectionResult, error) 
 	return DetectFromNode(&doc, ft), nil
 }
 
+// DetectBytes checks YAML content for migrations that need to be applied.
+// This is useful when the file content is already available.
+func DetectBytes(data []byte, ft FileType) []DetectionResult {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil // Invalid YAML, no migrations to detect
+	}
+	return DetectFromNode(&doc, ft)
+}
+
 // DetectFromNode checks a parsed YAML document for migrations.
 func DetectFromNode(doc *yaml.Node, ft FileType) []DetectionResult {
 	var results []DetectionResult

--- a/internal/model/change.go
+++ b/internal/model/change.go
@@ -1,0 +1,37 @@
+package model
+
+// ChangeOp represents the type of change to stored data.
+type ChangeOp int
+
+const (
+	// OpCreate indicates an item was created.
+	OpCreate ChangeOp = iota
+	// OpModify indicates an item was modified.
+	OpModify
+	// OpDelete indicates an item was deleted.
+	OpDelete
+	// OpRename indicates an item was renamed.
+	OpRename
+)
+
+// String returns a human-readable representation of the change operation.
+func (op ChangeOp) String() string {
+	switch op {
+	case OpCreate:
+		return "CREATE"
+	case OpModify:
+		return "MODIFY"
+	case OpDelete:
+		return "DELETE"
+	case OpRename:
+		return "RENAME"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// ChangeEvent represents a single change to stored data.
+type ChangeEvent struct {
+	Path string
+	Op   ChangeOp
+}

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -464,3 +464,60 @@ func TestAllPriorities(t *testing.T) {
 		}
 	}
 }
+
+// TestChangeOpString tests the String method for ChangeOp
+func TestChangeOpString(t *testing.T) {
+	tests := []struct {
+		op   ChangeOp
+		want string
+	}{
+		{OpCreate, "CREATE"},
+		{OpModify, "MODIFY"},
+		{OpDelete, "DELETE"},
+		{OpRename, "RENAME"},
+		{ChangeOp(99), "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.op.String(); got != tt.want {
+				t.Errorf("ChangeOp.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSyncErrorError tests the Error method for SyncError
+func TestSyncErrorError(t *testing.T) {
+	err := &SyncError{
+		File:    "entities/req/REQ-001.md",
+		Message: "invalid YAML frontmatter",
+	}
+	want := "entities/req/REQ-001.md: invalid YAML frontmatter"
+	if got := err.Error(); got != want {
+		t.Errorf("SyncError.Error() = %q, want %q", got, want)
+	}
+}
+
+// TestSortSpecIsDescending tests the IsDescending method for SortSpec
+func TestSortSpecIsDescending(t *testing.T) {
+	tests := []struct {
+		name      string
+		direction string
+		want      bool
+	}{
+		{"empty direction", "", false},
+		{"asc direction", "asc", false},
+		{"desc direction", "desc", true},
+		{"other value", "ascending", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := SortSpec{Property: "title", Direction: tt.direction}
+			if got := s.IsDescending(); got != tt.want {
+				t.Errorf("SortSpec.IsDescending() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/model/sync.go
+++ b/internal/model/sync.go
@@ -1,0 +1,18 @@
+package model
+
+// SyncResult contains statistics from a sync operation.
+type SyncResult struct {
+	EntitiesLoaded  int
+	RelationsLoaded int
+	Errors          []error
+}
+
+// SyncError represents an error during sync.
+type SyncError struct {
+	File    string
+	Message string
+}
+
+func (e *SyncError) Error() string {
+	return e.File + ": " + e.Message
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -10,8 +10,8 @@ package repository
 
 import (
 	"fmt"
-
 	"path/filepath"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/markdown"
@@ -21,6 +21,96 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/views"
 )
+
+// Store defines the domain-level persistence contract for entities,
+// relations, cache, metamodel, views, and templates. Implementations may
+// be backed by markdown files on disk, an SQLite database, a remote API,
+// or any other storage mechanism.
+type Store interface {
+	// Paths returns the project context (root directory, entity/relation dirs, etc.).
+	Paths() *project.Context
+
+	// --- Entity CRUD ---
+
+	ReadEntity(entityType, id string, meta *metamodel.Metamodel) (*model.Entity, error)
+	WriteEntity(entity *model.Entity, meta *metamodel.Metamodel) error
+	DeleteEntity(entityType, id string, meta *metamodel.Metamodel) error
+	ListEntities(meta *metamodel.Metamodel) ([]*model.Entity, error)
+
+	// --- Relation CRUD ---
+
+	ReadRelation(from, relType, to string) (*model.Relation, error)
+	WriteRelation(relation *model.Relation) error
+	DeleteRelation(from, relType, to string) error
+	ListRelations() ([]*model.Relation, error)
+
+	// --- Sync ---
+
+	Sync(meta *metamodel.Metamodel, g *graph.Graph) (*model.SyncResult, error)
+
+	// --- Cache ---
+
+	SaveCache(g *graph.Graph) error
+	LoadCache(g *graph.Graph) error
+	CacheExists() bool
+
+	// --- Metamodel ---
+
+	LoadMetamodel() (*metamodel.Metamodel, error)
+
+	// --- Views ---
+
+	LoadViews() (*views.File, error)
+
+	// --- Project Files ---
+
+	// ReadProjectFile reads a file relative to the project root.
+	// This allows consumers to read app-specific config files (e.g. data-entry.yaml)
+	// without needing direct filesystem access.
+	ReadProjectFile(filename string) ([]byte, error)
+
+	// WriteProjectFile writes a file relative to the project root.
+	WriteProjectFile(filename string, data []byte) error
+
+	// ReadCacheFile reads a file relative to the cache directory (.rela/).
+	// This is for app-specific state files (e.g. ui-state.json).
+	ReadCacheFile(filename string) ([]byte, error)
+
+	// WriteCacheFile writes a file relative to the cache directory (.rela/).
+	// Creates the cache directory if it doesn't exist.
+	WriteCacheFile(filename string, data []byte) error
+
+	// --- Templates ---
+
+	LoadEntityTemplate(entityType string) (*markdown.Document, error)
+	LoadRelationTemplate(relationType string) (*markdown.Document, error)
+	GenerateEntityTemplate(meta *metamodel.Metamodel, entityType string, force bool) (bool, error)
+	GenerateRelationTemplate(meta *metamodel.Metamodel, relationType string, force bool) (bool, error)
+
+	// --- Path Helpers ---
+
+	EntityFilePath(entityType, id string, meta *metamodel.Metamodel) string
+	EntityTypeDir(entityType string, meta *metamodel.Metamodel) string
+
+	// --- Change Notification ---
+
+	// Watch starts watching for changes to stored data. The onChange callback
+	// is called with batched change events after a debounce period. Returns a
+	// stop function to shut down the watcher. Implementations may use
+	// filesystem notifications, database triggers, polling, etc.
+	Watch(opts WatchOptions, onChange func(events []model.ChangeEvent)) (stop func(), err error)
+}
+
+// WatchOptions configures optional parameters for Store.Watch.
+type WatchOptions struct {
+	// ExtraFiles lists additional files to watch beyond the standard set
+	// (entities, relations, metamodel, views). This allows consumers to
+	// watch app-specific config files (e.g. data-entry.yaml).
+	ExtraFiles []string
+}
+
+// Compile-time check: *Repository implements Store.
+var _ Store = (*Repository)(nil)
 
 // Repository provides domain-level CRUD for entities, relations, cache,
 // metamodel, and templates. It does NOT hold the Graph — it only handles
@@ -112,7 +202,7 @@ func (r *Repository) ListRelations() ([]*model.Relation, error) {
 // --- Sync ---
 
 // Sync rebuilds the graph from all entity and relation files on disk.
-func (r *Repository) Sync(meta *metamodel.Metamodel, g *graph.Graph) (*markdown.SyncResult, error) {
+func (r *Repository) Sync(meta *metamodel.Metamodel, g *graph.Graph) (*model.SyncResult, error) {
 	return r.fio.SyncFromFiles(r.paths, meta, g)
 }
 
@@ -149,6 +239,32 @@ func (r *Repository) LoadViews() (*views.File, error) {
 	return views.Load(viewsPath, r.fs)
 }
 
+// --- Project Files ---
+
+// ReadProjectFile reads a file relative to the project root.
+func (r *Repository) ReadProjectFile(filename string) ([]byte, error) {
+	return r.fs.ReadFile(filepath.Join(r.paths.Root, filename))
+}
+
+// WriteProjectFile writes a file relative to the project root.
+func (r *Repository) WriteProjectFile(filename string, data []byte) error {
+	return r.fs.WriteFile(filepath.Join(r.paths.Root, filename), data, 0o644)
+}
+
+// ReadCacheFile reads a file relative to the cache directory (.rela/).
+func (r *Repository) ReadCacheFile(filename string) ([]byte, error) {
+	return r.fs.ReadFile(filepath.Join(r.paths.CacheDir, filename))
+}
+
+// WriteCacheFile writes a file relative to the cache directory (.rela/).
+// Creates the cache directory if it doesn't exist.
+func (r *Repository) WriteCacheFile(filename string, data []byte) error {
+	if err := r.fs.MkdirAll(r.paths.CacheDir, 0o755); err != nil {
+		return err
+	}
+	return r.fs.WriteFile(filepath.Join(r.paths.CacheDir, filename), data, 0o644)
+}
+
 // --- Templates ---
 
 // LoadEntityTemplate loads the template for the given entity type, or
@@ -177,6 +293,34 @@ func (r *Repository) GenerateRelationTemplate(
 	meta *metamodel.Metamodel, relationType string, force bool,
 ) (bool, error) {
 	return r.fio.GenerateRelationTemplate(r.paths, meta, relationType, force)
+}
+
+// --- Change Notification ---
+
+// Watch starts watching for changes to entities, relations, metamodel, and
+// views files. The onChange callback is called with batched change events.
+// Returns a stop function to shut down the watcher.
+func (r *Repository) Watch(
+	opts WatchOptions, onChange func(events []model.ChangeEvent),
+) (stop func(), err error) {
+	viewsPath := filepath.Join(r.paths.Root, "views.yaml")
+	files := []string{r.paths.MetamodelPath, viewsPath}
+	files = append(files, opts.ExtraFiles...)
+
+	w, err := storage.NewWatcher(storage.WatchConfig{
+		Dirs:       []string{r.paths.EntitiesDir, r.paths.RelationsDir},
+		Files:      files,
+		Extensions: []string{".md", ".yaml", ".yml"},
+		Debounce:   200 * time.Millisecond,
+		SkipHidden: true,
+		OnChange:   onChange,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	go w.Start()
+	return w.Stop, nil
 }
 
 // --- Path Helpers ---

--- a/internal/storage/watcher.go
+++ b/internal/storage/watcher.go
@@ -9,43 +9,9 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+
+	"github.com/Sourcehaven-BV/rela/internal/model"
 )
-
-// ChangeOp represents the type of file system change.
-type ChangeOp int
-
-const (
-	// OpCreate indicates a file was created.
-	OpCreate ChangeOp = iota
-	// OpModify indicates a file was modified.
-	OpModify
-	// OpDelete indicates a file was deleted.
-	OpDelete
-	// OpRename indicates a file was renamed.
-	OpRename
-)
-
-// String returns a human-readable representation of the change operation.
-func (op ChangeOp) String() string {
-	switch op {
-	case OpCreate:
-		return "CREATE"
-	case OpModify:
-		return "MODIFY"
-	case OpDelete:
-		return "DELETE"
-	case OpRename:
-		return "RENAME"
-	default:
-		return "UNKNOWN"
-	}
-}
-
-// ChangeEvent represents a single file system change.
-type ChangeEvent struct {
-	Path string
-	Op   ChangeOp
-}
 
 // WatchConfig configures a Watcher.
 type WatchConfig struct {
@@ -61,7 +27,7 @@ type WatchConfig struct {
 	// SkipHidden skips hidden directories (names starting with ".").
 	SkipHidden bool
 	// OnChange is called after debounce with the batched change events.
-	OnChange func(events []ChangeEvent)
+	OnChange func(events []model.ChangeEvent)
 }
 
 // Watcher watches files and directories for changes, debouncing events
@@ -71,7 +37,7 @@ type Watcher struct {
 	fsWatcher *fsnotify.Watcher
 	done      chan struct{}
 	mu        sync.Mutex
-	pending   []ChangeEvent
+	pending   []model.ChangeEvent
 }
 
 // NewWatcher creates a file watcher with the given configuration.
@@ -130,7 +96,7 @@ func (w *Watcher) Start() {
 			}
 
 			w.mu.Lock()
-			w.pending = append(w.pending, ChangeEvent{
+			w.pending = append(w.pending, model.ChangeEvent{
 				Path: event.Name,
 				Op:   toChangeOp(event.Op),
 			})
@@ -198,15 +164,15 @@ func (w *Watcher) isRelevantFile(path string) bool {
 	return false
 }
 
-func toChangeOp(op fsnotify.Op) ChangeOp {
+func toChangeOp(op fsnotify.Op) model.ChangeOp {
 	switch {
 	case op.Has(fsnotify.Create):
-		return OpCreate
+		return model.OpCreate
 	case op.Has(fsnotify.Remove):
-		return OpDelete
+		return model.OpDelete
 	case op.Has(fsnotify.Rename):
-		return OpRename
+		return model.OpRename
 	default:
-		return OpModify
+		return model.OpModify
 	}
 }

--- a/internal/storage/watcher_test.go
+++ b/internal/storage/watcher_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+
+	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
 func TestWatcher_NewAndStop(t *testing.T) {
@@ -176,12 +178,12 @@ func TestIsRelevantFile(t *testing.T) {
 func TestToChangeOp(t *testing.T) {
 	tests := []struct {
 		op   fsnotify.Op
-		want ChangeOp
+		want model.ChangeOp
 	}{
-		{fsnotify.Create, OpCreate},
-		{fsnotify.Write, OpModify},
-		{fsnotify.Remove, OpDelete},
-		{fsnotify.Rename, OpRename},
+		{fsnotify.Create, model.OpCreate},
+		{fsnotify.Write, model.OpModify},
+		{fsnotify.Remove, model.OpDelete},
+		{fsnotify.Rename, model.OpRename},
 	}
 
 	for _, tt := range tests {
@@ -194,14 +196,14 @@ func TestToChangeOp(t *testing.T) {
 
 func TestChangeOp_String(t *testing.T) {
 	tests := []struct {
-		op   ChangeOp
+		op   model.ChangeOp
 		want string
 	}{
-		{OpCreate, "CREATE"},
-		{OpModify, "MODIFY"},
-		{OpDelete, "DELETE"},
-		{OpRename, "RENAME"},
-		{ChangeOp(99), "UNKNOWN"},
+		{model.OpCreate, "CREATE"},
+		{model.OpModify, "MODIFY"},
+		{model.OpDelete, "DELETE"},
+		{model.OpRename, "RENAME"},
+		{model.ChangeOp(99), "UNKNOWN"},
 	}
 
 	for _, tt := range tests {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -41,7 +41,7 @@ type App struct {
 	project    *project.Context
 	metamodel  *metamodel.Metamodel
 	graph      *graph.Graph
-	repo       *repository.Repository
+	repo       repository.Store
 	screen     Screen
 	message    string
 	messageErr bool
@@ -69,7 +69,7 @@ type App struct {
 
 // NewApp creates a new TUI application
 // coverage-ignore: TUI initialization - unreasonable to unit test interactive terminal UI
-func NewApp(meta *metamodel.Metamodel, g *graph.Graph, repo *repository.Repository) *App {
+func NewApp(meta *metamodel.Metamodel, g *graph.Graph, repo repository.Store) *App {
 	app := &App{
 		project:     repo.Paths(),
 		metamodel:   meta,
@@ -88,7 +88,7 @@ func NewApp(meta *metamodel.Metamodel, g *graph.Graph, repo *repository.Reposito
 
 // Run starts the TUI
 // coverage-ignore: TUI entry point - unreasonable to unit test interactive terminal UI
-func Run(meta *metamodel.Metamodel, g *graph.Graph, repo *repository.Repository) error {
+func Run(meta *metamodel.Metamodel, g *graph.Graph, repo repository.Store) error {
 	app := NewApp(meta, g, repo)
 	p := tea.NewProgram(app, tea.WithAltScreen())
 	_, err := p.Run()

--- a/prototypes/data-entry/project/data-entry.yaml
+++ b/prototypes/data-entry/project/data-entry.yaml
@@ -1,9 +1,7 @@
 version: "1.0"
-
 app:
   name: "Support Tickets"
   description: "Internal ticket management system"
-
 # Colors for enum/custom type values from the metamodel.
 # Referenced by type name — applies everywhere that value appears.
 styles:
@@ -12,56 +10,45 @@ styles:
     in-progress: purple
     resolved: green
     closed: gray
-
   priority:
     critical: red
     high: orange
     medium: yellow
     low: green
-
 forms:
   create_ticket:
     entity_type: ticket
     title: "New Ticket"
     description: "Submit a new support ticket"
     body: true
-
     fields:
       - property: title
         label: "Title"
         placeholder: "Brief summary of the issue..."
         help: "A short, descriptive title for the ticket"
         required: true
-
       - property: description
         label: "Description"
         widget: textarea
         help: "Detailed description of the issue"
-
       - property: priority
         label: "Priority"
         default: medium
-
       - property: reporter
         label: "Reported by"
         placeholder: "your.name"
-
       - property: assignee
         label: "Assign to"
         placeholder: "assignee.name"
-
       - property: due_date
         label: "Due Date"
         widget: date
-
       - property: estimated_hours
         label: "Estimated Hours"
         widget: number
-
       - property: status
         hidden: true
         default: open
-
     relations:
       - relation: belongs-to
         direction: outgoing
@@ -71,7 +58,6 @@ forms:
         widget: select
         allow_create: true
         create_form: create_category
-
       - relation: tagged
         direction: outgoing
         target_type: label
@@ -79,24 +65,19 @@ forms:
         widget: multi-select
         allow_create: true
         create_form: create_label
-
   edit_ticket:
     entity_type: ticket
     title: "Edit Ticket"
     mode: edit
     body: true
-
     fields:
       - property: title
         label: "Title"
-
       - property: description
         label: "Description"
         widget: textarea
-
       - property: priority
         label: "Priority"
-
       - property: status
         label: "Status"
         transitions:
@@ -104,25 +85,19 @@ forms:
           in-progress: [open, resolved]
           resolved: [closed, in-progress]
           closed: [open]
-
       - property: assignee
         label: "Assign to"
-
       - property: reporter
         label: "Reported by"
-
       - property: due_date
         label: "Due Date"
         widget: date
-
       - property: estimated_hours
         label: "Estimated Hours"
         widget: number
-
       - property: is_blocked
         label: "Blocked"
         widget: checkbox
-
     relations:
       - relation: belongs-to
         direction: outgoing
@@ -132,7 +107,6 @@ forms:
         widget: select
         allow_create: true
         create_form: create_category
-
       - relation: tagged
         direction: outgoing
         target_type: label
@@ -140,7 +114,6 @@ forms:
         widget: multi-select
         allow_create: true
         create_form: create_label
-
       - relation: blocks
         direction: outgoing
         target_type: ticket
@@ -150,74 +123,59 @@ forms:
           - property: reason
             label: "Block Reason"
             widget: text
-
   create_category:
     entity_type: category
     title: "New Category"
     description: "Create a ticket category"
-
     fields:
       - property: name
         label: "Category Name"
         required: true
         placeholder: "e.g., Backend, Frontend, DevOps"
-
       - property: description
         label: "Description"
         widget: textarea
-
       - property: color
         label: "Color"
         placeholder: "#3b82f6"
         help: "Hex color code for visual identification"
-
   create_label:
     entity_type: label
     title: "New Label"
     description: "Create a ticket label"
-
     fields:
       - property: name
         label: "Label Name"
         required: true
         placeholder: "e.g., bug, enhancement, urgent"
-
 lists:
   all_tickets:
     entity_type: ticket
     title: "All Tickets"
     description: "View all tickets"
-
     columns:
       - property: title
         label: "Title"
         sortable: true
         link: true
-
       - property: status
         label: "Status"
         sortable: true
-
       - property: priority
         label: "Priority"
         sortable: true
-
       - property: assignee
         label: "Assignee"
         sortable: true
-
       - property: reporter
         label: "Reporter"
         sortable: true
-
       - property: due_date
         label: "Due"
         sortable: true
-
     sort:
-      property: priority
-      direction: asc
-
+      - property: priority
+        direction: asc
     filter_controls:
       - property: status
         widget: multi-select
@@ -225,16 +183,13 @@ lists:
         widget: select
       - property: assignee
         widget: search
-
     create_form: create_ticket
     edit_form: edit_ticket
     detail_view: ticket_report
     page_size: 25
-
   open_tickets:
     entity_type: ticket
     title: "Open Tickets"
-
     columns:
       - property: title
         label: "Title"
@@ -249,24 +204,19 @@ lists:
       - property: due_date
         label: "Due"
         sortable: true
-
     filters:
       - property: status
         operator: "="
         value: open
-
     sort:
-      property: priority
-      direction: asc
-
+      - property: priority
+        direction: asc
     create_form: create_ticket
     edit_form: edit_ticket
     page_size: 25
-
   my_tickets:
     entity_type: ticket
     title: "My Tickets"
-
     columns:
       - property: title
         link: true
@@ -278,24 +228,19 @@ lists:
       - property: due_date
         label: "Due"
         sortable: true
-
     filters:
       - property: assignee
         operator: "="
         value: "$USER"
-
     sort:
-      property: due_date
-      direction: asc
-
+      - property: due_date
+        direction: asc
     create_form: create_ticket
     edit_form: edit_ticket
     page_size: 25
-
   categories:
     entity_type: category
     title: "Categories"
-
     columns:
       - property: name
         label: "Name"
@@ -303,15 +248,12 @@ lists:
         link: true
       - property: description
         label: "Description"
-
     sort:
-      property: name
-      direction: asc
-
+      - property: name
+        direction: asc
     create_form: create_category
     detail_view: category_report
     page_size: 50
-
 # ──────────────────────────────────────────────
 # Views: read-only detail views with graph traversal
 # ──────────────────────────────────────────────
@@ -320,23 +262,19 @@ views:
     title: "Category Report"
     entry:
       type: category
-
     traverse:
       # Pull in all tickets that belong to this category (incoming relation)
       - from: entry
         follow_incoming: belongs-to
         collect_as: tickets
-
       # From those tickets, find what they block
       - from: tickets
         follow: blocks
         collect_as: blocked_tickets
-
       # From those tickets, find their labels
       - from: tickets
         follow: tagged
         collect_as: labels
-
     sections:
       # Category properties
       - heading: "Category"
@@ -347,7 +285,6 @@ views:
             label: "Name"
           - property: description
             label: "Description"
-
       # All tickets as full content cards
       - heading: "Tickets"
         source: tickets
@@ -359,7 +296,6 @@ views:
           - property: due_date
             label: "Due"
         empty_message: "No tickets in this category"
-
       # Blocked tickets as a table
       - heading: "Blocked Tickets"
         source: blocked_tickets
@@ -375,7 +311,6 @@ views:
           - property: assignee
             label: "Assignee"
         empty_message: "No blocking relationships"
-
       # Labels used by tickets in this category
       - heading: "Labels Used"
         source: labels
@@ -383,28 +318,23 @@ views:
         fields:
           - property: name
         empty_message: "No labels applied"
-
   ticket_report:
     title: "Ticket Report"
     entry:
       type: ticket
-
     traverse:
       # What tickets does this block?
       - from: entry
         follow: blocks
         collect_as: blocks
-
       # What tickets block this one?
       - from: entry
         follow_incoming: blocks
         collect_as: blocked_by
-
       # Labels on this ticket
       - from: entry
         follow: tagged
         collect_as: labels
-
     sections:
       # Ticket properties
       - heading: "Ticket"
@@ -419,11 +349,9 @@ views:
             label: "Due Date"
           - property: estimated_hours
             label: "Estimated Hours"
-
       # Ticket body (markdown content)
       - source: entry
         display: content
-
       # What this ticket blocks
       - heading: "Blocks"
         source: blocks
@@ -433,7 +361,6 @@ views:
           - property: priority
           - property: assignee
         empty_message: "This ticket does not block any others"
-
       # What blocks this ticket
       - heading: "Blocked By"
         source: blocked_by
@@ -443,7 +370,6 @@ views:
           - property: priority
           - property: assignee
         empty_message: "This ticket is not blocked"
-
       # Labels
       - heading: "Labels"
         source: labels
@@ -451,7 +377,6 @@ views:
         fields:
           - property: name
         empty_message: "No labels"
-
 # ──────────────────────────────────────────────
 # Dashboard: query-driven overview cards
 # ──────────────────────────────────────────────
@@ -462,21 +387,17 @@ dashboard:
     - title: "Open Tickets"
       query: "type:ticket status:open"
       display: count
-
     - title: "In Progress"
       query: "type:ticket status:in-progress"
       display: count
-
     - title: "By Status"
       query: "type:ticket"
       display: breakdown
       group_by: status
-
     - title: "By Priority"
       query: "type:ticket"
       display: breakdown
       group_by: priority
-
     - title: "Critical Issues"
       query: "type:ticket prop:priority=critical"
       display: table
@@ -489,10 +410,9 @@ dashboard:
         - property: assignee
           label: "Assignee"
       sort:
-        property: status
-        direction: asc
+        - property: status
+          direction: asc
       limit: 10
-
     - title: "Recently Blocked"
       query: "type:ticket prop:is_blocked=true"
       display: table
@@ -505,7 +425,6 @@ dashboard:
         - property: assignee
           label: "Assignee"
       limit: 5
-
 # ──────────────────────────────────────────────
 # Commands: executable scripts triggered from the UI
 # ──────────────────────────────────────────────
@@ -519,7 +438,6 @@ commands:
     context: entity
     available_on:
       entity_types: [ticket]
-
   ticket-summary:
     label: "View Summary"
     script: |
@@ -528,7 +446,6 @@ commands:
     context: view
     available_on:
       views: [ticket_report]
-
   generate-pdf:
     label: "Generate PDF"
     script: |
@@ -540,7 +457,6 @@ commands:
     context: entity
     available_on:
       entity_types: [ticket]
-
   project-info:
     label: "Project Info"
     script: |
@@ -548,7 +464,6 @@ commands:
     context: global
     available_on:
       dashboard: true
-
 navigation:
   - label: "Dashboard"
     dashboard: true


### PR DESCRIPTION
## Summary

- Refactors data entry module to use `Store` interface consistently, treating it as a core feature like metamodel and views
- Adds `ReadProjectFile`, `WriteProjectFile`, `ReadCacheFile`, `WriteCacheFile` methods to Store interface for file operations
- Adds `WatchOptions` struct with `ExtraFiles` field for configuring file watching
- Moves `ChangeOp`, `ChangeEvent` from storage to model package, and `SyncResult`, `SyncError` from markdown to model package to avoid import cycles
- Adds `migration.DetectBytes` for checking raw config data before parsing

## Test plan

- [x] All existing tests pass
- [x] Coverage check passes (model package at 100%)
- [x] Lint passes
- [x] CI suite passes
- [x] Data entry server starts and renders all pages correctly (dashboard, lists, forms, graph explorer)
- [x] File watcher initializes for live-reload