### PR TITLE
Add keyboard shortcut hint to view page edit button

### DIFF
--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -2018,7 +2018,7 @@ function submitInlineCreate() {
   <div style="display:flex;gap:8px;">
     {{ if .EditFormID }}
     <a href="/form/{{ .EditFormID }}/{{ .Entry.ID }}?return_to={{ urlquery .ReturnTo }}" class="btn btn-primary btn-sm"
-       hx-get="/form/{{ .EditFormID }}/{{ .Entry.ID }}?return_to={{ urlquery .ReturnTo }}" hx-target="#content" hx-push-url="true">Edit</a>
+       hx-get="/form/{{ .EditFormID }}/{{ .Entry.ID }}?return_to={{ urlquery .ReturnTo }}" hx-target="#content" hx-push-url="true">Edit <kbd>E</kbd></a>
     {{ end }}
     {{ if .Commands }}{{ if gt (len .Commands) 2 }}
     <details class="add-dropdown">


### PR DESCRIPTION
## Summary
- Add missing `<kbd>E</kbd>` shortcut hint to the edit button on view pages
- The entity detail page already had this hint, but the view page was missing it

## Test plan
- [x] Open a view page (e.g., document_detail)
- [x] Verify the Edit button shows "Edit E" with the keyboard hint
- [x] Press E to confirm the shortcut works