### PR TITLE
Add Entity.GetAttribute for uniform field/property access

### DIFF
--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -143,10 +143,7 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 			if col.Relation != "" {
 				val = a.resolveRelationColumnValue(e.ID, col.Relation)
 			} else {
-				val = fmt.Sprintf("%v", e.Properties[col.Property])
-				if e.Properties[col.Property] == nil {
-					val = ""
-				}
+				val = e.GetAttributeString(col.Property)
 				propType = resolvePropertyType(col.Property, list.EntityType, a.meta)
 			}
 			cells = append(cells, CellData{

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -27,10 +27,7 @@ func applyFilters(entities []*model.Entity, filters []FilterConfig) []*model.Ent
 			if strings.HasPrefix(f.Value, "$") {
 				continue // skip variable substitution
 			}
-			val := fmt.Sprintf("%v", e.Properties[f.Property])
-			if e.Properties[f.Property] == nil {
-				val = ""
-			}
+			val := e.GetAttributeString(f.Property)
 			switch f.Operator {
 			case "=":
 				if val != f.Value {

--- a/internal/model/entity.go
+++ b/internal/model/entity.go
@@ -1,6 +1,9 @@
 package model
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // Entity represents any architecture entity (requirement, decision, etc.)
 type Entity struct {
@@ -52,6 +55,33 @@ func (e *Entity) Status() Status {
 // Description returns the entity's description
 func (e *Entity) Description() string {
 	return e.GetString("description")
+}
+
+// GetAttribute returns struct fields (id, type) or property map values uniformly.
+// This allows renderers to access both built-in fields and custom properties
+// without special-case handling.
+func (e *Entity) GetAttribute(name string) interface{} {
+	switch name {
+	case "id":
+		return e.ID
+	case "type":
+		return e.Type
+	default:
+		return e.Properties[name]
+	}
+}
+
+// GetAttributeString returns the string representation of an attribute.
+// Returns empty string for nil values.
+func (e *Entity) GetAttributeString(name string) string {
+	val := e.GetAttribute(name)
+	if val == nil {
+		return ""
+	}
+	if s, ok := val.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", val)
 }
 
 // Relation represents a directed relationship between two entities

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -82,6 +82,66 @@ func TestEntityDescription(t *testing.T) {
 	assertEqual(t, e.Description(), "My Description")
 }
 
+// TestEntityGetAttribute tests the GetAttribute method for uniform field/property access
+func TestEntityGetAttribute(t *testing.T) {
+	e := NewEntity("REQ-001", "requirement")
+	e.Properties["title"] = "Test Title"
+	e.Properties["priority"] = "high"
+	e.Properties["count"] = 42
+
+	tests := []struct {
+		name     string
+		attrName string
+		expected interface{}
+	}{
+		{"id field", "id", "REQ-001"},
+		{"type field", "type", "requirement"},
+		{"title property", "title", "Test Title"},
+		{"priority property", "priority", "high"},
+		{"count property (int)", "count", 42},
+		{"missing property", "missing", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := e.GetAttribute(tt.attrName)
+			if got != tt.expected {
+				t.Errorf("GetAttribute(%q) = %v, want %v", tt.attrName, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestEntityGetAttributeString tests the GetAttributeString method
+func TestEntityGetAttributeString(t *testing.T) {
+	e := NewEntity("REQ-001", "requirement")
+	e.Properties["title"] = "Test Title"
+	e.Properties["count"] = 42
+	e.Properties["active"] = true
+
+	tests := []struct {
+		name     string
+		attrName string
+		expected string
+	}{
+		{"id field", "id", "REQ-001"},
+		{"type field", "type", "requirement"},
+		{"title property", "title", "Test Title"},
+		{"count property (int to string)", "count", "42"},
+		{"bool property", "active", "true"},
+		{"missing property", "missing", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := e.GetAttributeString(tt.attrName)
+			if got != tt.expected {
+				t.Errorf("GetAttributeString(%q) = %q, want %q", tt.attrName, got, tt.expected)
+			}
+		})
+	}
+}
+
 // TestNewRelation tests relation creation
 func TestNewRelation(t *testing.T) {
 	r := NewRelation("REQ-001", "implements", "DEC-001")


### PR DESCRIPTION
## Summary
- Adds `GetAttribute(name)` method to `Entity` that returns struct fields (`id`, `type`) or `Properties` map values uniformly
- Adds `GetAttributeString(name)` helper that returns the string representation
- Updates list column and filter renderers to use the new method, simplifying code

## Test plan
- [x] Added unit tests for `GetAttribute` and `GetAttributeString`
- [x] Verified existing tests pass
- [x] CI checks pass (lint, test, coverage)