### PR TITLE
Fix view table ID column and add install recipe

### DIFF
--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -818,9 +818,7 @@ func (a *App) handleView(w http.ResponseWriter, r *http.Request) {
 						if col.Relation != "" {
 							val = a.resolveRelationColumnValue(e.ID, col.Relation)
 						} else {
-							if v := e.Properties[col.Property]; v != nil {
-								val = fmt.Sprintf("%v", v)
-							}
+							val = e.GetAttributeString(col.Property)
 							if eDef != nil {
 								if pd, ok := eDef.Properties[col.Property]; ok {
 									propType = pd.Type

--- a/justfile
+++ b/justfile
@@ -30,6 +30,13 @@ build-desktop:
 # Build all binaries
 build: build-cli build-server build-desktop
 
+# Install CLI to ~/bin
+install: build-cli
+    @echo "Installing rela to ~/bin..."
+    @mkdir -p ~/bin
+    @install {{build_dir}}/rela ~/bin/rela
+    @echo "Done! Make sure ~/bin is in your PATH."
+
 # Clean build artifacts
 clean:
     @echo "Cleaning..."


### PR DESCRIPTION
## Summary
- Use `GetAttributeString` in view table rendering to properly access entity `id` field
- Add `just install` command to install CLI to ~/bin without macOS provenance issues

## Test plan
- [x] Existing tests pass
- [ ] Verify ID column shows values in view tables