### PR TITLE
Add normalize command to standardize markdown headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/wailsapp/mimetype v1.4.1 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	github.com/yuin/goldmark v1.7.16 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -359,6 +359,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=
+github.com/yuin/goldmark v1.7.16/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=

--- a/internal/cli/normalize.go
+++ b/internal/cli/normalize.go
@@ -1,0 +1,279 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+const (
+	targetHeaderLevel = 2
+	maxHeaderLevel    = 6
+)
+
+var (
+	normalizeDryRun bool
+)
+
+var normalizeCmd = &cobra.Command{
+	Use:   "normalize [type]",
+	Short: "Normalize markdown headers in entity files",
+	Long: `Normalizes markdown headers in entity files to start at level 2 (##).
+
+This command adjusts header levels so the minimum header level in each entity
+is ##, preserving the relative hierarchy. For example, if an entity has:
+  # Overview
+  ## Details
+  ### Subsection
+
+It will be normalized to:
+  ## Overview
+  ### Details
+  #### Subsection
+
+Setext-style headers (underlined with === or ---) are converted to ATX style (##).
+
+If headers already start at ## or deeper, no changes are made.
+
+Examples:
+  rela normalize                # Normalize all entities
+  rela normalize requirements   # Normalize only requirements
+  rela normalize req            # Alias works too
+  rela normalize --dry-run      # Preview changes without writing`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var entities []*model.Entity
+
+		if len(args) > 0 {
+			typeName := args[0]
+			resolvedType, _, err := resolveEntityType(typeName)
+			if err != nil {
+				return err
+			}
+			entities = g.NodesByType(resolvedType)
+		} else {
+			entities = g.AllNodes()
+		}
+
+		if len(entities) == 0 {
+			out.WriteMessage("No entities found")
+			return nil
+		}
+
+		modified := 0
+		for _, entity := range entities {
+			normalized := normalizeHeaders(entity.Content)
+			if normalized == entity.Content {
+				continue
+			}
+
+			if normalizeDryRun {
+				out.WriteMessage("Would normalize: %s", entity.ID)
+				modified++
+				continue
+			}
+
+			entity.Content = normalized
+
+			if err := repo.WriteEntity(entity, meta); err != nil {
+				out.WriteWarning("Failed to write %s: %v", entity.ID, err)
+				continue
+			}
+
+			g.AddNode(entity)
+			modified++
+
+			if verbose {
+				out.WriteMessage("Normalized: %s", entity.ID)
+			}
+		}
+
+		if !normalizeDryRun && modified > 0 {
+			if err := saveCache(); err != nil {
+				out.WriteWarning("Failed to save cache: %v", err)
+			}
+		}
+
+		if normalizeDryRun {
+			out.WriteMessage("Dry run: %d entities would be modified", modified)
+		} else {
+			out.WriteSuccess("Normalized %d entities", modified)
+		}
+
+		return nil
+	},
+}
+
+// headerInfo stores information about a heading found in the document.
+type headerInfo struct {
+	level     int
+	lineStart int    // byte position of line start
+	isSetext  bool   // true if setext-style (underlined)
+	fullEnd   int    // byte position after the entire header (including underline + newline)
+	text      string // header text content
+}
+
+// normalizeHeaders adjusts markdown headers so the minimum level is 2 (##).
+// It uses goldmark to parse the markdown AST, ensuring proper handling of
+// code blocks and other markdown constructs. Setext headers are converted to ATX.
+func normalizeHeaders(content string) string {
+	if content == "" {
+		return content
+	}
+
+	source := []byte(content)
+	headers := collectHeaders(source)
+
+	if len(headers) == 0 {
+		return content
+	}
+
+	minLevel := findMinLevel(headers)
+	if minLevel >= targetHeaderLevel {
+		return content
+	}
+
+	shift := targetHeaderLevel - minLevel
+	return applyHeaderShift(source, headers, shift)
+}
+
+// collectHeaders parses the markdown and returns information about all headers.
+func collectHeaders(source []byte) []headerInfo {
+	md := goldmark.New()
+	reader := text.NewReader(source)
+	doc := md.Parser().Parse(reader)
+
+	var headers []headerInfo
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if heading, ok := n.(*ast.Heading); ok {
+			if h := parseHeading(heading, source); h != nil {
+				headers = append(headers, *h)
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+	return headers
+}
+
+// parseHeading extracts header information from an AST heading node.
+func parseHeading(heading *ast.Heading, source []byte) *headerInfo {
+	lines := heading.Lines()
+	if lines.Len() == 0 {
+		return nil
+	}
+
+	seg := lines.At(0)
+	headerText := string(source[seg.Start:seg.Stop])
+
+	lineStart := seg.Start
+	for lineStart > 0 && source[lineStart-1] != '\n' {
+		lineStart--
+	}
+
+	isATX := lineStart < len(source) && source[lineStart] == '#'
+
+	h := &headerInfo{
+		level:     heading.Level,
+		lineStart: lineStart,
+		text:      headerText,
+		isSetext:  !isATX,
+	}
+
+	if isATX {
+		h.fullEnd = findLineEnd(source, seg.Stop)
+	} else {
+		h.fullEnd = findSetextEnd(source, seg.Stop)
+	}
+
+	return h
+}
+
+// findLineEnd returns the position at the end of the current line.
+func findLineEnd(source []byte, pos int) int {
+	for pos < len(source) && source[pos] != '\n' {
+		pos++
+	}
+	return pos
+}
+
+// findSetextEnd returns the position after the setext underline.
+func findSetextEnd(source []byte, pos int) int {
+	// Skip to end of header text line
+	for pos < len(source) && source[pos] != '\n' {
+		pos++
+	}
+	if pos < len(source) {
+		pos++ // skip newline
+	}
+	// Skip underline characters
+	for pos < len(source) && (source[pos] == '=' || source[pos] == '-') {
+		pos++
+	}
+	// Skip trailing whitespace on underline
+	for pos < len(source) && source[pos] != '\n' {
+		pos++
+	}
+	return pos
+}
+
+// findMinLevel returns the minimum header level in the slice.
+func findMinLevel(headers []headerInfo) int {
+	minLevel := maxHeaderLevel + 1
+	for _, h := range headers {
+		if h.level < minLevel {
+			minLevel = h.level
+		}
+	}
+	return minLevel
+}
+
+// applyHeaderShift modifies the source by shifting all header levels.
+func applyHeaderShift(source []byte, headers []headerInfo, shift int) string {
+	result := source
+	// Process in reverse order to maintain correct positions
+	for i := len(headers) - 1; i >= 0; i-- {
+		h := headers[i]
+		newLevel := h.level + shift
+		if newLevel > maxHeaderLevel {
+			newLevel = maxHeaderLevel
+		}
+
+		if h.isSetext {
+			newHeader := strings.Repeat("#", newLevel) + " " + h.text
+			result = replaceRange(result, h.lineStart, h.fullEnd, []byte(newHeader))
+		} else {
+			oldHashes := strings.Repeat("#", h.level)
+			newHashes := strings.Repeat("#", newLevel)
+			if h.lineStart+len(oldHashes) <= len(result) &&
+				string(result[h.lineStart:h.lineStart+len(oldHashes)]) == oldHashes {
+
+				result = replaceRange(result, h.lineStart, h.lineStart+len(oldHashes), []byte(newHashes))
+			}
+		}
+	}
+	return string(result)
+}
+
+// replaceRange replaces bytes from start to end with replacement.
+func replaceRange(data []byte, start, end int, replacement []byte) []byte {
+	var buf bytes.Buffer
+	buf.Write(data[:start])
+	buf.Write(replacement)
+	buf.Write(data[end:])
+	return buf.Bytes()
+}
+
+func init() {
+	normalizeCmd.Flags().BoolVar(&normalizeDryRun, "dry-run", false, "Preview changes without writing")
+
+	rootCmd.AddCommand(normalizeCmd)
+}

--- a/internal/cli/normalize_test.go
+++ b/internal/cli/normalize_test.go
@@ -1,0 +1,123 @@
+package cli
+
+import "testing"
+
+func TestNormalizeHeaders(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty content",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "no headers",
+			input: "Just some text\nwithout headers",
+			want:  "Just some text\nwithout headers",
+		},
+		{
+			name:  "already at level 2",
+			input: "## Overview\n### Details",
+			want:  "## Overview\n### Details",
+		},
+		{
+			name:  "already at level 3",
+			input: "### Overview\n#### Details",
+			want:  "### Overview\n#### Details",
+		},
+		{
+			name:  "shift from level 1 to level 2",
+			input: "# Overview\n## Details\n### Subsection",
+			want:  "## Overview\n### Details\n#### Subsection",
+		},
+		{
+			name:  "shift from level 1 with content",
+			input: "# Title\n\nSome paragraph.\n\n## Section\n\nMore content.",
+			want:  "## Title\n\nSome paragraph.\n\n### Section\n\nMore content.",
+		},
+		{
+			name:  "preserve text after header",
+			input: "# Header with text",
+			want:  "## Header with text",
+		},
+		{
+			name:  "skip headers in code blocks",
+			input: "# Real Header\n```\n# Not a header\n## Also not\n```\n## Another real one",
+			want:  "## Real Header\n```\n# Not a header\n## Also not\n```\n### Another real one",
+		},
+		{
+			name:  "multiple code blocks",
+			input: "# Title\n```bash\n# comment\n```\nText\n```\n# another\n```\n## Section",
+			want:  "## Title\n```bash\n# comment\n```\nText\n```\n# another\n```\n### Section",
+		},
+		{
+			name:  "cap at level 6",
+			input: "# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6",
+			want:  "## H1\n### H2\n#### H3\n##### H4\n###### H5\n###### H6",
+		},
+		{
+			name:  "only level 1 headers",
+			input: "# First\n# Second\n# Third",
+			want:  "## First\n## Second\n## Third",
+		},
+		{
+			name:  "mixed levels starting at 1",
+			input: "Some intro\n\n# Main\n\n## Sub\n\n# Another Main",
+			want:  "Some intro\n\n## Main\n\n### Sub\n\n## Another Main",
+		},
+		{
+			name:  "trailing newline preserved",
+			input: "# Header\n",
+			want:  "## Header\n",
+		},
+		{
+			name:  "hash in middle of line not affected",
+			input: "# Header\nSome text with # in it\nMore # hashes",
+			want:  "## Header\nSome text with # in it\nMore # hashes",
+		},
+		{
+			name:  "hash without space not a header",
+			input: "#hashtag\n# Real header",
+			want:  "#hashtag\n## Real header",
+		},
+		{
+			name:  "setext h1 converted to ATX",
+			input: "Title\n=====\n\nContent",
+			want:  "## Title\n\nContent",
+		},
+		{
+			name:  "setext h2 not changed when min is h2",
+			input: "Title\n-----\n\nContent",
+			want:  "Title\n-----\n\nContent",
+		},
+		{
+			name:  "mixed setext and ATX",
+			input: "Main\n====\n\nSub\n---\n\n# ATX",
+			want:  "## Main\n\n### Sub\n\n## ATX",
+		},
+		{
+			name:  "setext with trailing spaces",
+			input: "Title\n=====   \n\nContent",
+			want:  "## Title\n\nContent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeHeaders(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeHeaders() =\n%q\nwant:\n%q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeCmd_DryRunFlagExists(t *testing.T) {
+	flag := normalizeCmd.Flags().Lookup("dry-run")
+	if flag == nil {
+		t.Error("normalize command should have --dry-run flag")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `rela normalize` command to standardize markdown header levels
- Uses goldmark parser to properly handle code blocks and other markdown constructs
- Shifts all headers so minimum level is `##` (h2), preserving hierarchy
- Converts setext-style headers (`===`/`---`) to ATX format (`##`)

## Usage
```bash
rela normalize                # Normalize all entities
rela normalize requirements   # Normalize only one type
rela normalize --dry-run      # Preview changes
```

## Test plan
- [x] Unit tests for header normalization (20 test cases)
- [x] Manual QA: ATX headers, setext headers, code blocks, edge cases
- [x] Lint passes
- [x] All existing tests pass