### PR TITLE
Add stable sorting to graph and data entry

### DIFF
--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -577,8 +577,13 @@ func (a *App) handleEntity(w http.ResponseWriter, r *http.Request) {
 			targetType = target.Type
 		}
 		rd := RelDisplay{e.Type, e.To, targetType, title, "outgoing", nil}
-		for k, v := range e.Properties {
-			rd.Properties = append(rd.Properties, RelPropDisplay{k, fmt.Sprintf("%v", v)})
+		propKeys := make([]string, 0, len(e.Properties))
+		for k := range e.Properties {
+			propKeys = append(propKeys, k)
+		}
+		sort.Strings(propKeys)
+		for _, k := range propKeys {
+			rd.Properties = append(rd.Properties, RelPropDisplay{k, fmt.Sprintf("%v", e.Properties[k])})
 		}
 		rels = append(rels, rd)
 	}
@@ -591,16 +596,26 @@ func (a *App) handleEntity(w http.ResponseWriter, r *http.Request) {
 			sourceType = source.Type
 		}
 		rd := RelDisplay{e.Type, e.From, sourceType, title, "incoming", nil}
-		for k, v := range e.Properties {
-			rd.Properties = append(rd.Properties, RelPropDisplay{k, fmt.Sprintf("%v", v)})
+		propKeys := make([]string, 0, len(e.Properties))
+		for k := range e.Properties {
+			propKeys = append(propKeys, k)
+		}
+		sort.Strings(propKeys)
+		for _, k := range propKeys {
+			rd.Properties = append(rd.Properties, RelPropDisplay{k, fmt.Sprintf("%v", e.Properties[k])})
 		}
 		rels = append(rels, rd)
 	}
 
 	propTypes := make(map[string]string)
 	if entDef != nil {
-		for propName, propDef := range entDef.Properties {
-			propTypes[propName] = propDef.Type
+		propTypeKeys := make([]string, 0, len(entDef.Properties))
+		for propName := range entDef.Properties {
+			propTypeKeys = append(propTypeKeys, propName)
+		}
+		sort.Strings(propTypeKeys)
+		for _, propName := range propTypeKeys {
+			propTypes[propName] = entDef.Properties[propName].Type
 		}
 	}
 
@@ -848,6 +863,7 @@ func (a *App) handleView(w http.ResponseWriter, r *http.Request) {
 					}
 					for _, gName := range groupOrder {
 						gd := GroupData{GroupName: gName}
+						sortEntitiesByID(groups[gName])
 						for _, e := range groups[gName] {
 							gd.Rows = append(gd.Rows, buildRow(e))
 						}
@@ -1780,6 +1796,8 @@ func (a *App) handleDashboard(w http.ResponseWriter, r *http.Request) {
 				}
 				groups[val]++
 			}
+			// Sort values alphabetically for consistent display
+			sort.Strings(orderedValues)
 			// Determine property type for badge styling
 			propType := ""
 			if len(entities) > 0 {

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -444,6 +444,14 @@ func templateFuncs(styleMap map[string]map[string]string, styledTypes map[string
 			}
 			return val
 		},
+		"sortedKeys": func(m map[string]interface{}) []string {
+			keys := make([]string, 0, len(m))
+			for k := range m {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			return keys
+		},
 	}
 }
 

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -506,6 +506,34 @@ func TestTemplateFuncs(t *testing.T) {
 			t.Errorf("formatValue = %q, want 'just text'", got)
 		}
 	})
+
+	t.Run("sortedKeys returns sorted keys", func(t *testing.T) {
+		fn := funcs["sortedKeys"].(func(map[string]interface{}) []string)
+		m := map[string]interface{}{
+			"zebra":  1,
+			"apple":  2,
+			"mango":  3,
+			"banana": 4,
+		}
+		got := fn(m)
+		want := []string{"apple", "banana", "mango", "zebra"}
+		if len(got) != len(want) {
+			t.Fatalf("sortedKeys length = %d, want %d", len(got), len(want))
+		}
+		for i, k := range got {
+			if k != want[i] {
+				t.Errorf("sortedKeys[%d] = %q, want %q", i, k, want[i])
+			}
+		}
+	})
+
+	t.Run("sortedKeys empty map", func(t *testing.T) {
+		fn := funcs["sortedKeys"].(func(map[string]interface{}) []string)
+		got := fn(map[string]interface{}{})
+		if len(got) != 0 {
+			t.Errorf("sortedKeys empty map = %v, want empty slice", got)
+		}
+	})
 }
 
 func TestAppendToastParam(t *testing.T) {

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -1954,7 +1954,9 @@ function submitInlineCreate() {
 <div class="card" style="padding:24px;">
   <div id="properties" class="detail-grid">
     {{ $propTypes := .PropTypes }}
-    {{ range $key, $val := .Entity.Properties }}
+    {{ $props := .Entity.Properties }}
+    {{ range $key := sortedKeys $props }}
+    {{ $val := index $props $key }}
     {{ $ptype := index $propTypes $key }}
     <div class="detail-label">{{ $key }}</div>
     <div class="detail-value">

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
@@ -206,21 +207,37 @@ func (g *Graph) GetEdge(from, relationType, to string) (*model.Relation, bool) {
 	return nil, false
 }
 
-// OutgoingEdges returns all outgoing relations from a node
+// OutgoingEdges returns all outgoing relations from a node, sorted by type then target ID
 func (g *Graph) OutgoingEdges(id string) []*model.Relation {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
-	return g.outgoing[id]
+	edges := make([]*model.Relation, len(g.outgoing[id]))
+	copy(edges, g.outgoing[id])
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].Type != edges[j].Type {
+			return edges[i].Type < edges[j].Type
+		}
+		return edges[i].To < edges[j].To
+	})
+	return edges
 }
 
-// IncomingEdges returns all incoming relations to a node
+// IncomingEdges returns all incoming relations to a node, sorted by type then source ID
 func (g *Graph) IncomingEdges(id string) []*model.Relation {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
-	return g.incoming[id]
+	edges := make([]*model.Relation, len(g.incoming[id]))
+	copy(edges, g.incoming[id])
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].Type != edges[j].Type {
+			return edges[i].Type < edges[j].Type
+		}
+		return edges[i].From < edges[j].From
+	})
+	return edges
 }
 
-// AllNodes returns all entities in the graph
+// AllNodes returns all entities in the graph, sorted by ID
 func (g *Graph) AllNodes() []*model.Entity {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
@@ -229,20 +246,32 @@ func (g *Graph) AllNodes() []*model.Entity {
 	for _, node := range g.nodes {
 		nodes = append(nodes, node)
 	}
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].ID < nodes[j].ID
+	})
 	return nodes
 }
 
-// AllEdges returns all relations in the graph
+// AllEdges returns all relations in the graph, sorted by source ID, type, then target ID
 func (g *Graph) AllEdges() []*model.Relation {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
 	edges := make([]*model.Relation, len(g.edges))
 	copy(edges, g.edges)
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].From != edges[j].From {
+			return edges[i].From < edges[j].From
+		}
+		if edges[i].Type != edges[j].Type {
+			return edges[i].Type < edges[j].Type
+		}
+		return edges[i].To < edges[j].To
+	})
 	return edges
 }
 
-// NodesByType returns all entities of a given type
+// NodesByType returns all entities of a given type, sorted by ID
 func (g *Graph) NodesByType(entityType string) []*model.Entity {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
@@ -253,6 +282,9 @@ func (g *Graph) NodesByType(entityType string) []*model.Entity {
 			nodes = append(nodes, node)
 		}
 	}
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].ID < nodes[j].ID
+	})
 	return nodes
 }
 
@@ -270,7 +302,7 @@ func (g *Graph) EdgeCount() int {
 	return len(g.edges)
 }
 
-// AllIDs returns all entity IDs in the graph
+// AllIDs returns all entity IDs in the graph, sorted
 func (g *Graph) AllIDs() []string {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
@@ -279,10 +311,11 @@ func (g *Graph) AllIDs() []string {
 	for id := range g.nodes {
 		ids = append(ids, id)
 	}
+	sort.Strings(ids)
 	return ids
 }
 
-// IDsByType returns all entity IDs of a given type
+// IDsByType returns all entity IDs of a given type, sorted
 func (g *Graph) IDsByType(entityType string) []string {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
@@ -293,6 +326,7 @@ func (g *Graph) IDsByType(entityType string) []string {
 			ids = append(ids, id)
 		}
 	}
+	sort.Strings(ids)
 	return ids
 }
 

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -413,3 +413,119 @@ func TestRelationsOfType(t *testing.T) {
 	dependsOn := g.RelationsOfType("depends_on")
 	assertEqual(t, len(dependsOn), 1)
 }
+
+// TestAllNodesSorted verifies that AllNodes returns entities sorted by ID.
+func TestAllNodesSorted(t *testing.T) {
+	g := New()
+	// Add nodes in reverse order to ensure sorting is tested
+	g.AddNode(newEntity("ZZZ-003", "test"))
+	g.AddNode(newEntity("AAA-001", "test"))
+	g.AddNode(newEntity("MMM-002", "test"))
+
+	nodes := g.AllNodes()
+	assertEqual(t, len(nodes), 3)
+	assertEqual(t, nodes[0].ID, "AAA-001")
+	assertEqual(t, nodes[1].ID, "MMM-002")
+	assertEqual(t, nodes[2].ID, "ZZZ-003")
+}
+
+// TestNodesByTypeSorted verifies that NodesByType returns entities sorted by ID.
+func TestNodesByTypeSorted(t *testing.T) {
+	g := New()
+	g.AddNode(newEntity("REQ-003", "requirement"))
+	g.AddNode(newEntity("REQ-001", "requirement"))
+	g.AddNode(newEntity("DEC-001", "decision"))
+	g.AddNode(newEntity("REQ-002", "requirement"))
+
+	reqs := g.NodesByType("requirement")
+	assertEqual(t, len(reqs), 3)
+	assertEqual(t, reqs[0].ID, "REQ-001")
+	assertEqual(t, reqs[1].ID, "REQ-002")
+	assertEqual(t, reqs[2].ID, "REQ-003")
+}
+
+// TestAllIDsSorted verifies that AllIDs returns IDs in sorted order.
+func TestAllIDsSorted(t *testing.T) {
+	g := New()
+	g.AddNode(newEntity("ZZZ-003", "test"))
+	g.AddNode(newEntity("AAA-001", "test"))
+	g.AddNode(newEntity("MMM-002", "test"))
+
+	ids := g.AllIDs()
+	assertEqual(t, len(ids), 3)
+	assertEqual(t, ids[0], "AAA-001")
+	assertEqual(t, ids[1], "MMM-002")
+	assertEqual(t, ids[2], "ZZZ-003")
+}
+
+// TestIDsByTypeSorted verifies that IDsByType returns IDs in sorted order.
+func TestIDsByTypeSorted(t *testing.T) {
+	g := New()
+	g.AddNode(newEntity("REQ-003", "requirement"))
+	g.AddNode(newEntity("REQ-001", "requirement"))
+	g.AddNode(newEntity("REQ-002", "requirement"))
+
+	ids := g.IDsByType("requirement")
+	assertEqual(t, len(ids), 3)
+	assertEqual(t, ids[0], "REQ-001")
+	assertEqual(t, ids[1], "REQ-002")
+	assertEqual(t, ids[2], "REQ-003")
+}
+
+// TestAllEdgesSorted verifies that AllEdges returns edges sorted by from, type, to.
+func TestAllEdgesSorted(t *testing.T) {
+	g := New()
+	g.AddEdge(newRelation("C", "implements", "D"))
+	g.AddEdge(newRelation("A", "depends_on", "B"))
+	g.AddEdge(newRelation("A", "implements", "C"))
+	g.AddEdge(newRelation("A", "implements", "B"))
+
+	edges := g.AllEdges()
+	assertEqual(t, len(edges), 4)
+	// Should be sorted by From, then Type, then To
+	assertEqual(t, edges[0].From, "A")
+	assertEqual(t, edges[0].Type, "depends_on")
+	assertEqual(t, edges[1].From, "A")
+	assertEqual(t, edges[1].Type, "implements")
+	assertEqual(t, edges[1].To, "B")
+	assertEqual(t, edges[2].From, "A")
+	assertEqual(t, edges[2].Type, "implements")
+	assertEqual(t, edges[2].To, "C")
+	assertEqual(t, edges[3].From, "C")
+}
+
+// TestOutgoingEdgesSorted verifies that OutgoingEdges returns edges sorted by type, then target.
+func TestOutgoingEdgesSorted(t *testing.T) {
+	g := New()
+	g.AddEdge(newRelation("A", "implements", "Z"))
+	g.AddEdge(newRelation("A", "depends_on", "B"))
+	g.AddEdge(newRelation("A", "implements", "C"))
+
+	edges := g.OutgoingEdges("A")
+	assertEqual(t, len(edges), 3)
+	// Should be sorted by Type, then To
+	assertEqual(t, edges[0].Type, "depends_on")
+	assertEqual(t, edges[0].To, "B")
+	assertEqual(t, edges[1].Type, "implements")
+	assertEqual(t, edges[1].To, "C")
+	assertEqual(t, edges[2].Type, "implements")
+	assertEqual(t, edges[2].To, "Z")
+}
+
+// TestIncomingEdgesSorted verifies that IncomingEdges returns edges sorted by type, then source.
+func TestIncomingEdgesSorted(t *testing.T) {
+	g := New()
+	g.AddEdge(newRelation("Z", "implements", "TARGET"))
+	g.AddEdge(newRelation("A", "depends_on", "TARGET"))
+	g.AddEdge(newRelation("C", "implements", "TARGET"))
+
+	edges := g.IncomingEdges("TARGET")
+	assertEqual(t, len(edges), 3)
+	// Should be sorted by Type, then From
+	assertEqual(t, edges[0].Type, "depends_on")
+	assertEqual(t, edges[0].From, "A")
+	assertEqual(t, edges[1].Type, "implements")
+	assertEqual(t, edges[1].From, "C")
+	assertEqual(t, edges[2].Type, "implements")
+	assertEqual(t, edges[2].From, "Z")
+}


### PR DESCRIPTION
## Summary
- Sort all graph collection methods (AllNodes, NodesByType, AllIDs, IDsByType, AllEdges, OutgoingEdges, IncomingEdges) by ID for deterministic output
- Sort entities within grouped views, dashboard breakdown values, and relation properties in data entry handlers
- Add `sortedKeys` template function for sorted map iteration in templates

## Test plan
- [x] Added tests for all graph sorting methods
- [x] Added tests for sortedKeys template function
- [x] All existing tests pass