### PR TITLE
Add comprehensive validation for data-entry.yaml config

### DIFF
--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -6,10 +6,12 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -32,6 +34,14 @@ func main() {
 
 	app, err := dataentry.NewApp(repo)
 	if err != nil {
+		var configErr *dataentry.ConfigValidationError
+		if errors.As(err, &configErr) {
+			fmt.Fprintln(os.Stderr, "Configuration validation failed:")
+			for _, e := range configErr.Errors {
+				fmt.Fprintf(os.Stderr, "  - %s\n", e)
+			}
+			os.Exit(1)
+		}
 		log.Fatalf("Failed to initialize: %v", err)
 	}
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -51,7 +51,7 @@ and maintain semantic relationships between them.`,
 		cmdName := cmd.Name()
 		parent := cmd.Parent()
 		isRootChild := parent == nil || parent.Name() == "rela"
-		if isRootChild && (cmdName == "init" || cmdName == "version" || cmdName == "help" || cmdName == "completion" || cmdName == "tui" || cmdName == "migrate" || cmdName == "mcp") {
+		if isRootChild && (cmdName == "init" || cmdName == "version" || cmdName == "help" || cmdName == "completion" || cmdName == "tui" || cmdName == "migrate" || cmdName == "mcp" || cmdName == "validate") {
 			out = output.New(output.Format(outputFormat))
 			return nil
 		}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentry"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
+)
+
+var validateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate project configuration files",
+	Long: `Validate metamodel.yaml and data-entry.yaml configuration files.
+
+Checks for:
+- Unknown/misspelled keys
+- Invalid cross-references (forms, lists, views)
+- Invalid entity types, relations, and properties
+- View traversal correctness
+- Dashboard and command configuration
+
+Examples:
+  rela validate    # Validate all config files`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Discover project (we need the paths)
+		ctx, err := project.Discover("", cliFS)
+		if err != nil {
+			return fmt.Errorf("no project found: run 'rela init' to create one")
+		}
+
+		hasErrors := false
+
+		// Initialize repository
+		repoInstance := repository.New(cliFS, ctx)
+
+		// 1. Validate metamodel
+		fmt.Println("Validating metamodel.yaml...")
+		mm, err := repoInstance.LoadMetamodel()
+		if err != nil {
+			fmt.Printf("  ✗ %v\n", err)
+			hasErrors = true
+			mm = nil
+		} else {
+			fmt.Println("  ✓ metamodel.yaml is valid")
+		}
+
+		// 2. Validate data-entry.yaml if it exists
+		dataEntryPath := filepath.Join(ctx.Root, dataentry.ConfigFile)
+		if _, statErr := cliFS.Stat(dataEntryPath); statErr == nil {
+			fmt.Printf("Validating %s...\n", dataentry.ConfigFile)
+
+			if mm == nil {
+				fmt.Println("  ⚠ Skipping data-entry validation (metamodel has errors)")
+			} else {
+				if err := validateDataEntryConfig(dataEntryPath, mm); err != nil {
+					fmt.Printf("  ✗ %v\n", err)
+					hasErrors = true
+				} else {
+					fmt.Printf("  ✓ %s is valid\n", dataentry.ConfigFile)
+				}
+			}
+		} else {
+			fmt.Printf("Skipping %s (file not found)\n", dataentry.ConfigFile)
+		}
+
+		if hasErrors {
+			fmt.Println("\nValidation failed.")
+			os.Exit(1)
+		}
+
+		fmt.Println("\nAll configuration files are valid.")
+		return nil
+	},
+}
+
+// validateDataEntryConfig validates the data-entry.yaml file.
+func validateDataEntryConfig(path string, mm *metamodel.Metamodel) error {
+	data, err := cliFS.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	var cfg dataentry.Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parsing YAML: %w", err)
+	}
+
+	return dataentry.ValidateConfig(data, &cfg, mm)
+}
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+}

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -79,10 +79,8 @@ func NewApp(repo repository.Store) (*App, error) {
 	}
 
 	// Validate config against metamodel
-	if errs := validateConfig(&cfg, meta); len(errs) > 0 {
-		for _, e := range errs {
-			log.Printf("Config warning: %s", e)
-		}
+	if validationErr := ValidateConfig(cfgData, &cfg, meta); validationErr != nil {
+		return nil, fmt.Errorf("invalid %s: %w", ConfigFile, validationErr)
 	}
 
 	// Build graph from files
@@ -435,83 +433,4 @@ func buildStyleMap(cfg *Config, meta *metamodel.Metamodel) (styleMap map[string]
 	}
 
 	return sm, st
-}
-
-func validateConfig(cfg *Config, meta *metamodel.Metamodel) []string {
-	var errs []string
-	// Validate navigation: reject nested groups
-	for _, nav := range cfg.Navigation {
-		if nav.IsGroup() {
-			for _, child := range nav.Items {
-				if child.IsGroup() {
-					errs = append(errs, fmt.Sprintf(
-						"navigation: group %q contains nested group %q — nested groups are not supported",
-						nav.Group, child.Group))
-				}
-			}
-		}
-	}
-	for formID, form := range cfg.Forms {
-		if _, ok := meta.GetEntityDef(form.EntityType); !ok {
-			errs = append(errs, fmt.Sprintf("form %q: unknown entity type %q", formID, form.EntityType))
-			continue
-		}
-		entDef, _ := meta.GetEntityDef(form.EntityType)
-		for _, f := range form.Fields {
-			if _, ok := entDef.Properties[f.Property]; !ok {
-				errs = append(errs, fmt.Sprintf("form %q: field %q not in metamodel for entity %q", formID, f.Property, form.EntityType))
-			}
-		}
-		for _, r := range form.Relations {
-			if _, ok := meta.GetRelationDef(r.Relation); !ok {
-				errs = append(errs, fmt.Sprintf("form %q: unknown relation %q", formID, r.Relation))
-			}
-		}
-	}
-	for listID, list := range cfg.Lists {
-		if _, ok := meta.GetEntityDef(list.EntityType); !ok {
-			errs = append(errs, fmt.Sprintf("list %q: unknown entity type %q", listID, list.EntityType))
-			continue
-		}
-		entDef, _ := meta.GetEntityDef(list.EntityType)
-		for _, c := range list.Columns {
-			if c.Relation != "" {
-				if _, ok := meta.GetRelationDef(c.Relation); !ok {
-					errs = append(errs, fmt.Sprintf("list %q: column relation %q not in metamodel", listID, c.Relation))
-				}
-			} else if _, ok := entDef.Properties[c.Property]; !ok {
-				errs = append(errs, fmt.Sprintf("list %q: column %q not in metamodel for entity %q", listID, c.Property, list.EntityType))
-			}
-		}
-	}
-	validContexts := map[string]bool{"entity": true, "list": true, "view": true, "global": true}
-	for cmdID, cmd := range cfg.Commands {
-		if cmd.Label == "" {
-			errs = append(errs, fmt.Sprintf("command %q: label is required", cmdID))
-		}
-		if cmd.Script == "" {
-			errs = append(errs, fmt.Sprintf("command %q: script is required", cmdID))
-		}
-		if !validContexts[cmd.Context] {
-			errs = append(errs, fmt.Sprintf("command %q: invalid context %q (must be entity, list, view, or global)", cmdID, cmd.Context))
-		}
-		if cmd.AvailableOn != nil {
-			for _, v := range cmd.AvailableOn.Views {
-				if _, ok := cfg.Views[v]; !ok {
-					errs = append(errs, fmt.Sprintf("command %q: available_on references unknown view %q", cmdID, v))
-				}
-			}
-			for _, l := range cmd.AvailableOn.Lists {
-				if _, ok := cfg.Lists[l]; !ok {
-					errs = append(errs, fmt.Sprintf("command %q: available_on references unknown list %q", cmdID, l))
-				}
-			}
-			for _, et := range cmd.AvailableOn.EntityTypes {
-				if _, ok := meta.GetEntityDef(et); !ok {
-					errs = append(errs, fmt.Sprintf("command %q: available_on references unknown entity type %q", cmdID, et))
-				}
-			}
-		}
-	}
-	return errs
 }

--- a/internal/dataentry/app_test.go
+++ b/internal/dataentry/app_test.go
@@ -1,6 +1,7 @@
 package dataentry
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -149,12 +150,13 @@ func testAppInstance() *App {
 
 func TestValidateConfig(t *testing.T) {
 	meta := testMeta()
+	emptyYAML := []byte(`version: "1.0"`)
 
 	t.Run("valid config", func(t *testing.T) {
 		cfg := testConfig()
-		errs := validateConfig(cfg, meta)
-		if len(errs) != 0 {
-			t.Errorf("expected no errors, got %v", errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if err != nil {
+			t.Errorf("expected no errors, got %v", err)
 		}
 	})
 
@@ -164,11 +166,18 @@ func TestValidateConfig(t *testing.T) {
 				"bad-form": {EntityType: "nonexistent", Fields: []FormField{{Property: "title"}}},
 			},
 		}
-		errs := validateConfig(cfg, meta)
-		if len(errs) != 1 {
-			t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
-		if got := errs[0]; got != `form "bad-form": unknown entity type "nonexistent"` {
+		var configErr *ConfigValidationError
+		if !errors.As(err, &configErr) {
+			t.Fatalf("expected ConfigValidationError, got %T", err)
+		}
+		if len(configErr.Errors) != 1 {
+			t.Fatalf("expected 1 error, got %d: %v", len(configErr.Errors), configErr.Errors)
+		}
+		if got := configErr.Errors[0]; got != `form "bad-form": unknown entity type "nonexistent"` {
 			t.Errorf("unexpected error: %s", got)
 		}
 	})
@@ -179,9 +188,9 @@ func TestValidateConfig(t *testing.T) {
 				"bad-form": {EntityType: "ticket", Fields: []FormField{{Property: "nonexistent"}}},
 			},
 		}
-		errs := validateConfig(cfg, meta)
-		if len(errs) != 1 {
-			t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
 	})
 
@@ -191,9 +200,9 @@ func TestValidateConfig(t *testing.T) {
 				"bad-form": {EntityType: "ticket", Relations: []FormRelation{{Relation: "nonexistent"}}},
 			},
 		}
-		errs := validateConfig(cfg, meta)
-		if len(errs) != 1 {
-			t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
 	})
 
@@ -203,9 +212,9 @@ func TestValidateConfig(t *testing.T) {
 				"bad-list": {EntityType: "nonexistent"},
 			},
 		}
-		errs := validateConfig(cfg, meta)
-		if len(errs) != 1 {
-			t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
 	})
 
@@ -215,17 +224,17 @@ func TestValidateConfig(t *testing.T) {
 				"bad-list": {EntityType: "ticket", Columns: []ListColumn{{Property: "nonexistent"}}},
 			},
 		}
-		errs := validateConfig(cfg, meta)
-		if len(errs) != 1 {
-			t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
 	})
 
 	t.Run("empty config is valid", func(t *testing.T) {
 		cfg := &Config{}
-		errs := validateConfig(cfg, meta)
-		if len(errs) != 0 {
-			t.Errorf("expected no errors, got %v", errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if err != nil {
+			t.Errorf("expected no errors, got %v", err)
 		}
 	})
 }
@@ -834,6 +843,7 @@ func TestUserDefaultsLoadSave(t *testing.T) {
 
 func TestValidateConfigNestedGroups(t *testing.T) {
 	meta := testMeta()
+	emptyYAML := []byte(`version: "1.0"`)
 
 	t.Run("nested groups rejected", func(t *testing.T) {
 		cfg := &Config{
@@ -851,17 +861,20 @@ func TestValidateConfigNestedGroups(t *testing.T) {
 				},
 			},
 		}
-		errs := validateConfig(cfg, meta)
-		if len(errs) != 1 {
-			t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
-		if !strings.Contains(errs[0], "nested group") {
-			t.Errorf("expected nested group error, got: %s", errs[0])
+		if !strings.Contains(err.Error(), "nested group") {
+			t.Errorf("expected nested group error, got: %s", err.Error())
 		}
 	})
 
 	t.Run("flat groups are valid", func(t *testing.T) {
 		cfg := &Config{
+			Lists: map[string]List{
+				"tickets": {EntityType: "ticket"},
+			},
 			Navigation: []NavigationEntry{
 				{
 					Group: "Tickets",
@@ -871,9 +884,9 @@ func TestValidateConfigNestedGroups(t *testing.T) {
 				},
 			},
 		}
-		errs := validateConfig(cfg, meta)
-		if len(errs) != 0 {
-			t.Errorf("expected no errors, got %v", errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if err != nil {
+			t.Errorf("expected no errors, got %v", err)
 		}
 	})
 }

--- a/internal/dataentry/commands_test.go
+++ b/internal/dataentry/commands_test.go
@@ -429,11 +429,12 @@ func TestBuildCommandEnvViewContext(t *testing.T) {
 
 func TestValidateCommandConfig(t *testing.T) {
 	meta := testMeta()
+	emptyYAML := []byte(`version: "1.0"`)
 
 	t.Run("valid command", func(t *testing.T) {
 		cfg := &Config{
 			Lists: map[string]List{"tickets": {EntityType: "ticket"}},
-			Views: map[string]ViewConfig{"ticket_detail": {}},
+			Views: map[string]ViewConfig{"ticket_detail": {Entry: ViewEntry{Type: "ticket"}}},
 			Commands: map[string]CommandConfig{
 				"test": {
 					Label:   "Test",
@@ -447,9 +448,9 @@ func TestValidateCommandConfig(t *testing.T) {
 				},
 			},
 		}
-		errs := validateConfig(cfg, meta)
-		if len(errs) != 0 {
-			t.Errorf("expected no errors, got %v", errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if err != nil {
+			t.Errorf("expected no errors, got %v", err)
 		}
 	})
 
@@ -457,9 +458,9 @@ func TestValidateCommandConfig(t *testing.T) {
 		cfg := &Config{Commands: map[string]CommandConfig{
 			"bad": {Script: "echo", Context: "entity"},
 		}}
-		errs := validateConfig(cfg, meta)
-		if !hasError(errs, "label") {
-			t.Errorf("expected label error, got %v", errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if !hasErrorStr(err, "label") {
+			t.Errorf("expected label error, got %v", err)
 		}
 	})
 
@@ -467,9 +468,9 @@ func TestValidateCommandConfig(t *testing.T) {
 		cfg := &Config{Commands: map[string]CommandConfig{
 			"bad": {Label: "Test", Context: "entity"},
 		}}
-		errs := validateConfig(cfg, meta)
-		if !hasError(errs, "script") {
-			t.Errorf("expected script error, got %v", errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if !hasErrorStr(err, "script") {
+			t.Errorf("expected script error, got %v", err)
 		}
 	})
 
@@ -477,9 +478,9 @@ func TestValidateCommandConfig(t *testing.T) {
 		cfg := &Config{Commands: map[string]CommandConfig{
 			"bad": {Label: "Test", Script: "echo", Context: "invalid"},
 		}}
-		errs := validateConfig(cfg, meta)
-		if !hasError(errs, "invalid context") {
-			t.Errorf("expected context error, got %v", errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if !hasErrorStr(err, "invalid context") {
+			t.Errorf("expected context error, got %v", err)
 		}
 	})
 
@@ -490,9 +491,9 @@ func TestValidateCommandConfig(t *testing.T) {
 				AvailableOn: &CommandScope{Views: []string{"nonexistent"}},
 			},
 		}}
-		errs := validateConfig(cfg, meta)
-		if !hasError(errs, "unknown view") {
-			t.Errorf("expected view error, got %v", errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if !hasErrorStr(err, "unknown view") {
+			t.Errorf("expected view error, got %v", err)
 		}
 	})
 
@@ -503,9 +504,9 @@ func TestValidateCommandConfig(t *testing.T) {
 				AvailableOn: &CommandScope{Lists: []string{"nonexistent"}},
 			},
 		}}
-		errs := validateConfig(cfg, meta)
-		if !hasError(errs, "unknown list") {
-			t.Errorf("expected list error, got %v", errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if !hasErrorStr(err, "unknown list") {
+			t.Errorf("expected list error, got %v", err)
 		}
 	})
 
@@ -516,9 +517,9 @@ func TestValidateCommandConfig(t *testing.T) {
 				AvailableOn: &CommandScope{EntityTypes: []string{"nonexistent"}},
 			},
 		}}
-		errs := validateConfig(cfg, meta)
-		if !hasError(errs, "unknown entity type") {
-			t.Errorf("expected entity type error, got %v", errs)
+		err := ValidateConfig(emptyYAML, cfg, meta)
+		if !hasErrorStr(err, "unknown entity type") {
+			t.Errorf("expected entity type error, got %v", err)
 		}
 	})
 }
@@ -959,13 +960,11 @@ func assertNotContains(t *testing.T, ids []string, unexpected string) {
 	}
 }
 
-func hasError(errs []string, substring string) bool {
-	for _, e := range errs {
-		if strings.Contains(strings.ToLower(e), strings.ToLower(substring)) {
-			return true
-		}
+func hasErrorStr(err error, substring string) bool {
+	if err == nil {
+		return false
 	}
-	return false
+	return strings.Contains(strings.ToLower(err.Error()), strings.ToLower(substring))
 }
 
 func envToMap(env []string) map[string]string {

--- a/internal/dataentry/errors.go
+++ b/internal/dataentry/errors.go
@@ -1,0 +1,15 @@
+package dataentry
+
+import "strings"
+
+// ConfigValidationError collects multiple validation issues found in data-entry config.
+type ConfigValidationError struct {
+	Errors []string
+}
+
+func (e *ConfigValidationError) Error() string {
+	if len(e.Errors) == 1 {
+		return e.Errors[0]
+	}
+	return "data-entry config validation errors:\n  - " + strings.Join(e.Errors, "\n  - ")
+}

--- a/internal/dataentry/validate.go
+++ b/internal/dataentry/validate.go
@@ -1,0 +1,819 @@
+package dataentry
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// Valid top-level keys in data-entry.yaml
+var validTopLevelKeys = map[string]bool{
+	"version":    true,
+	"app":        true,
+	"styles":     true,
+	"forms":      true,
+	"lists":      true,
+	"views":      true,
+	"dashboard":  true,
+	"commands":   true,
+	"navigation": true,
+}
+
+// Known typos with suggestions
+var knownTypos = map[string]string{
+	"form":        "forms",
+	"list":        "lists",
+	"view":        "views",
+	"command":     "commands",
+	"style":       "styles",
+	"nav":         "navigation",
+	"navaigation": "navigation",
+}
+
+// Valid widget types for form fields
+var validFormWidgets = map[string]bool{
+	"":             true, // default (auto-detected)
+	"text":         true,
+	"textarea":     true,
+	"select":       true,
+	"multi-select": true,
+	"search":       true,
+	"date":         true,
+	"number":       true,
+	"checkbox":     true,
+}
+
+// Valid widget types for filter controls
+var validFilterWidgets = map[string]bool{
+	"":             true, // default
+	"select":       true,
+	"multi-select": true,
+	"search":       true,
+}
+
+// Valid filter operators
+var validFilterOperators = map[string]bool{
+	"=":  true,
+	"!=": true,
+	"<":  true,
+	"<=": true,
+	">":  true,
+	">=": true,
+	"=~": true,
+}
+
+// Valid sort directions
+var validSortDirections = map[string]bool{
+	"":     true, // default (asc)
+	"asc":  true,
+	"desc": true,
+}
+
+// Valid display modes for view sections
+var validSectionDisplayModes = map[string]bool{
+	"properties": true,
+	"content":    true,
+	"table":      true,
+	"list":       true,
+	"cards":      true,
+	"breakdown":  true,
+}
+
+// Valid display modes for dashboard cards
+var validDashboardDisplayModes = map[string]bool{
+	"count":     true,
+	"table":     true,
+	"breakdown": true,
+}
+
+// Valid command contexts
+var validCommandContexts = map[string]bool{
+	"entity": true,
+	"list":   true,
+	"view":   true,
+	"global": true,
+}
+
+// Valid relation directions
+var validRelationDirections = map[string]bool{
+	"":         true, // default (outgoing)
+	"outgoing": true,
+	"incoming": true,
+}
+
+// ValidateConfig performs comprehensive validation of a data-entry config.
+// It returns a ConfigValidationError containing all validation issues,
+// or nil if the config is valid.
+func ValidateConfig(data []byte, cfg *Config, meta *metamodel.Metamodel) error {
+	var errs []string
+
+	// Phase 1: Structural validation (unknown keys)
+	errs = append(errs, checkUnknownKeys(data)...)
+
+	// Phase 2: Semantic validation (cross-references, types, etc.)
+	errs = append(errs, validateNavigation(cfg)...)
+	errs = append(errs, validateForms(cfg, meta)...)
+	errs = append(errs, validateLists(cfg, meta)...)
+	errs = append(errs, validateViews(cfg, meta)...)
+	errs = append(errs, validateDashboard(cfg, meta)...)
+	errs = append(errs, validateCommands(cfg, meta)...)
+	errs = append(errs, validateStyles(cfg, meta)...)
+	errs = append(errs, validateCrossReferences(cfg)...)
+
+	if len(errs) > 0 {
+		sort.Strings(errs)
+		return &ConfigValidationError{Errors: errs}
+	}
+	return nil
+}
+
+// checkUnknownKeys detects unknown top-level keys in the config YAML.
+func checkUnknownKeys(data []byte) []string {
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil // struct unmarshal already caught this
+	}
+
+	var errs []string
+	for key := range raw {
+		if validTopLevelKeys[key] {
+			continue
+		}
+		if suggestion, ok := knownTypos[key]; ok {
+			errs = append(errs, fmt.Sprintf("unknown key %q (did you mean %q?)", key, suggestion))
+		} else {
+			keys := sortedMapKeys(validTopLevelKeys)
+			errs = append(errs, fmt.Sprintf("unknown key %q (valid keys: %s)", key, strings.Join(keys, ", ")))
+		}
+	}
+	return errs
+}
+
+// validateNavigation validates navigation entries.
+func validateNavigation(cfg *Config) []string {
+	var errs []string
+
+	for _, nav := range cfg.Navigation {
+		if nav.IsGroup() {
+			for _, child := range nav.Items {
+				if child.IsGroup() {
+					errs = append(errs, fmt.Sprintf(
+						"navigation: group %q contains nested group %q (nested groups are not supported)",
+						nav.Group, child.Group))
+				}
+			}
+		}
+	}
+
+	// Validate list references in navigation
+	for _, nav := range cfg.Navigation {
+		errs = append(errs, validateNavEntry(nav, cfg)...)
+	}
+
+	return errs
+}
+
+func validateNavEntry(nav NavigationEntry, cfg *Config) []string {
+	var errs []string
+
+	if nav.List != "" {
+		if _, ok := cfg.Lists[nav.List]; !ok {
+			errs = append(errs, fmt.Sprintf(
+				"navigation: references unknown list %q", nav.List))
+		}
+	}
+
+	if nav.IsGroup() {
+		for _, child := range nav.Items {
+			errs = append(errs, validateNavEntry(child, cfg)...)
+		}
+	}
+
+	return errs
+}
+
+// validateForms validates form definitions.
+func validateForms(cfg *Config, meta *metamodel.Metamodel) []string {
+	var errs []string
+
+	for formID, form := range cfg.Forms {
+		entDef, ok := meta.GetEntityDef(form.EntityType)
+		if !ok {
+			errs = append(errs, fmt.Sprintf("form %q: unknown entity type %q", formID, form.EntityType))
+			continue
+		}
+
+		// Validate fields
+		for i, f := range form.Fields {
+			if _, ok := entDef.Properties[f.Property]; !ok {
+				errs = append(errs, fmt.Sprintf(
+					"form %q: field[%d] property %q not in metamodel for entity %q",
+					formID, i, f.Property, form.EntityType))
+			}
+
+			// Validate widget
+			if !validFormWidgets[f.Widget] {
+				errs = append(errs, fmt.Sprintf(
+					"form %q: field[%d] has unknown widget %q (valid: %s)",
+					formID, i, f.Widget, joinMapKeys(validFormWidgets)))
+			}
+
+			// Validate transitions (if specified, must be valid enum values)
+			if len(f.Transitions) > 0 {
+				propDef, hasProp := entDef.Properties[f.Property]
+				if hasProp {
+					errs = append(errs, validateTransitions(formID, i, f, propDef, meta)...)
+				}
+			}
+		}
+
+		// Validate relations
+		for i, r := range form.Relations {
+			if _, ok := meta.GetRelationDef(r.Relation); !ok {
+				errs = append(errs, fmt.Sprintf(
+					"form %q: relation[%d] references unknown relation %q",
+					formID, i, r.Relation))
+			}
+
+			// Validate direction
+			if !validRelationDirections[r.Direction] {
+				errs = append(errs, fmt.Sprintf(
+					"form %q: relation[%d] has invalid direction %q (valid: outgoing, incoming)",
+					formID, i, r.Direction))
+			}
+
+			// Validate create_form reference
+			if r.CreateForm != "" {
+				if _, ok := cfg.Forms[r.CreateForm]; !ok {
+					errs = append(errs, fmt.Sprintf(
+						"form %q: relation[%d] references unknown create_form %q",
+						formID, i, r.CreateForm))
+				}
+			}
+		}
+	}
+
+	return errs
+}
+
+// validateTransitions checks that transition values are valid for the property's type.
+func validateTransitions(formID string, fieldIdx int, field FormField, propDef metamodel.PropertyDef, meta *metamodel.Metamodel) []string {
+	var errs []string
+
+	// Get valid values for this property type
+	validValues := getValidEnumValues(propDef, meta)
+	if len(validValues) == 0 {
+		return errs // not an enum type, skip validation
+	}
+
+	validSet := make(map[string]bool)
+	for _, v := range validValues {
+		validSet[v] = true
+	}
+
+	// Check all transition keys and values
+	for fromState, toStates := range field.Transitions {
+		if !validSet[fromState] {
+			errs = append(errs, fmt.Sprintf(
+				"form %q: field[%d] transitions has invalid from-state %q",
+				formID, fieldIdx, fromState))
+		}
+		for _, toState := range toStates {
+			if !validSet[toState] {
+				errs = append(errs, fmt.Sprintf(
+					"form %q: field[%d] transitions has invalid to-state %q",
+					formID, fieldIdx, toState))
+			}
+		}
+	}
+
+	return errs
+}
+
+// getValidEnumValues returns the valid values for an enum or custom type property.
+func getValidEnumValues(propDef metamodel.PropertyDef, meta *metamodel.Metamodel) []string {
+	if propDef.Type == metamodel.PropertyTypeEnum {
+		return propDef.Values
+	}
+	// Check if it's a custom type
+	if customType, ok := meta.Types[propDef.Type]; ok {
+		return customType.Values
+	}
+	return nil
+}
+
+// validateLists validates list definitions.
+func validateLists(cfg *Config, meta *metamodel.Metamodel) []string {
+	var errs []string
+
+	for listID, list := range cfg.Lists {
+		entDef, ok := meta.GetEntityDef(list.EntityType)
+		if !ok {
+			errs = append(errs, fmt.Sprintf("list %q: unknown entity type %q", listID, list.EntityType))
+			continue
+		}
+
+		// Validate columns
+		for i, c := range list.Columns {
+			if c.Relation != "" {
+				if _, ok := meta.GetRelationDef(c.Relation); !ok {
+					errs = append(errs, fmt.Sprintf(
+						"list %q: column[%d] references unknown relation %q",
+						listID, i, c.Relation))
+				}
+			} else if c.Property != "" {
+				if _, ok := entDef.Properties[c.Property]; !ok {
+					errs = append(errs, fmt.Sprintf(
+						"list %q: column[%d] property %q not in metamodel for entity %q",
+						listID, i, c.Property, list.EntityType))
+				}
+			}
+		}
+
+		// Validate sort
+		for i, s := range list.Sort {
+			if !validSortDirections[s.Direction] {
+				errs = append(errs, fmt.Sprintf(
+					"list %q: sort[%d] has invalid direction %q (valid: asc, desc)",
+					listID, i, s.Direction))
+			}
+			if s.Property != "" && s.Property != "id" && s.Property != "modified" {
+				if _, ok := entDef.Properties[s.Property]; !ok {
+					errs = append(errs, fmt.Sprintf(
+						"list %q: sort[%d] references unknown property %q",
+						listID, i, s.Property))
+				}
+			}
+		}
+
+		// Validate filters
+		for i, f := range list.Filters {
+			if !validFilterOperators[f.Operator] {
+				errs = append(errs, fmt.Sprintf(
+					"list %q: filter[%d] has invalid operator %q (valid: %s)",
+					listID, i, f.Operator, joinMapKeys(validFilterOperators)))
+			}
+			if f.Property != "" && f.Property != "id" && f.Property != "type" {
+				if _, ok := entDef.Properties[f.Property]; !ok {
+					errs = append(errs, fmt.Sprintf(
+						"list %q: filter[%d] references unknown property %q",
+						listID, i, f.Property))
+				}
+			}
+		}
+
+		// Validate filter_controls
+		for i, fc := range list.FilterControls {
+			if !validFilterWidgets[fc.Widget] {
+				errs = append(errs, fmt.Sprintf(
+					"list %q: filter_controls[%d] has invalid widget %q (valid: %s)",
+					listID, i, fc.Widget, joinMapKeys(validFilterWidgets)))
+			}
+			if fc.Property != "" {
+				if _, ok := entDef.Properties[fc.Property]; !ok {
+					errs = append(errs, fmt.Sprintf(
+						"list %q: filter_controls[%d] references unknown property %q",
+						listID, i, fc.Property))
+				}
+			}
+		}
+	}
+
+	return errs
+}
+
+// validateViews validates view definitions with their traversal rules and sections.
+func validateViews(cfg *Config, meta *metamodel.Metamodel) []string {
+	var errs []string
+
+	for viewID, view := range cfg.Views {
+		// Validate entry type
+		entDef, ok := meta.GetEntityDef(view.Entry.Type)
+		if !ok {
+			errs = append(errs, fmt.Sprintf(
+				"view %q: entry type %q not in metamodel",
+				viewID, view.Entry.Type))
+			continue
+		}
+
+		// Build collection map: tracks what collections are available at each point
+		// Start with "entry" which refers to the entry entity type
+		collections := map[string]string{
+			"entry": view.Entry.Type, // collection name -> entity type
+		}
+
+		// Validate traverse rules and track collections
+		for i, t := range view.Traverse {
+			// Validate from
+			if t.From != "*" {
+				if _, ok := collections[t.From]; !ok {
+					validCollections := sortedMapKeys(collections)
+					validCollections = append(validCollections, "*")
+					errs = append(errs, fmt.Sprintf(
+						"view %q: traverse[%d] references unknown collection %q in from (valid: %s)",
+						viewID, i, t.From, strings.Join(validCollections, ", ")))
+				}
+			}
+
+			// Validate follow/follow_incoming relation
+			var relType string
+			if t.Follow != "" {
+				relType = t.Follow
+				if _, ok := meta.GetRelationDef(t.Follow); !ok {
+					if suggestion := suggestRelation(t.Follow, meta); suggestion != "" {
+						errs = append(errs, fmt.Sprintf(
+							"view %q: traverse[%d] references unknown relation %q in follow (did you mean %q?)",
+							viewID, i, t.Follow, suggestion))
+					} else {
+						errs = append(errs, fmt.Sprintf(
+							"view %q: traverse[%d] references unknown relation %q in follow",
+							viewID, i, t.Follow))
+					}
+				}
+			}
+			if t.FollowIncoming != "" {
+				relType = t.FollowIncoming
+				if _, ok := meta.GetRelationDef(t.FollowIncoming); !ok {
+					if suggestion := suggestRelation(t.FollowIncoming, meta); suggestion != "" {
+						errs = append(errs, fmt.Sprintf(
+							"view %q: traverse[%d] references unknown relation %q in follow_incoming (did you mean %q?)",
+							viewID, i, t.FollowIncoming, suggestion))
+					} else {
+						errs = append(errs, fmt.Sprintf(
+							"view %q: traverse[%d] references unknown relation %q in follow_incoming",
+							viewID, i, t.FollowIncoming))
+					}
+				}
+			}
+			if t.Follow == "" && t.FollowIncoming == "" {
+				errs = append(errs, fmt.Sprintf(
+					"view %q: traverse[%d] must specify either follow or follow_incoming",
+					viewID, i))
+			}
+			if t.Follow != "" && t.FollowIncoming != "" {
+				errs = append(errs, fmt.Sprintf(
+					"view %q: traverse[%d] cannot specify both follow and follow_incoming",
+					viewID, i))
+			}
+
+			// Validate collect_as is specified
+			if t.CollectAs == "" {
+				errs = append(errs, fmt.Sprintf(
+					"view %q: traverse[%d] must specify collect_as",
+					viewID, i))
+			} else {
+				// Determine target entity type for this collection
+				targetType := determineTargetType(t, relType, meta)
+				collections[t.CollectAs] = targetType
+			}
+		}
+
+		// Validate sections
+		for i, s := range view.Sections {
+			// Validate source
+			sourceType := ""
+			if s.Source != "" {
+				if entityType, ok := collections[s.Source]; ok {
+					sourceType = entityType
+				} else {
+					validSources := sortedMapKeys(collections)
+					errs = append(errs, fmt.Sprintf(
+						"view %q: section[%d] references unknown collection %q in source (valid: %s)",
+						viewID, i, s.Source, strings.Join(validSources, ", ")))
+				}
+			}
+
+			// Validate display mode
+			if !validSectionDisplayModes[s.Display] {
+				errs = append(errs, fmt.Sprintf(
+					"view %q: section[%d] has invalid display mode %q (valid: %s)",
+					viewID, i, s.Display, joinMapKeys(validSectionDisplayModes)))
+			}
+
+			// Validate fields (if source type is known)
+			if sourceType != "" {
+				if sourceDef, ok := meta.GetEntityDef(sourceType); ok {
+					for j, f := range s.Fields {
+						if f.Property != "" && f.Property != "title" && f.Property != "id" {
+							if _, ok := sourceDef.Properties[f.Property]; !ok {
+								errs = append(errs, fmt.Sprintf(
+									"view %q: section[%d] field[%d] property %q not in entity %q",
+									viewID, i, j, f.Property, sourceType))
+							}
+						}
+					}
+
+					// Validate columns
+					for j, c := range s.Columns {
+						if c.Property != "" && c.Property != "title" && c.Property != "id" {
+							if _, ok := sourceDef.Properties[c.Property]; !ok {
+								errs = append(errs, fmt.Sprintf(
+									"view %q: section[%d] column[%d] property %q not in entity %q",
+									viewID, i, j, c.Property, sourceType))
+							}
+						}
+						if c.Relation != "" {
+							if _, ok := meta.GetRelationDef(c.Relation); !ok {
+								errs = append(errs, fmt.Sprintf(
+									"view %q: section[%d] column[%d] references unknown relation %q",
+									viewID, i, j, c.Relation))
+							}
+						}
+					}
+
+					// Validate group_by
+					if s.GroupBy != "" {
+						if _, ok := sourceDef.Properties[s.GroupBy]; !ok {
+							errs = append(errs, fmt.Sprintf(
+								"view %q: section[%d] group_by references unknown property %q",
+								viewID, i, s.GroupBy))
+						}
+					}
+				}
+			} else if s.Source == "entry" {
+				// Source is entry, use entry entity def
+				for j, f := range s.Fields {
+					if f.Property != "" && f.Property != "title" && f.Property != "id" {
+						if _, ok := entDef.Properties[f.Property]; !ok {
+							errs = append(errs, fmt.Sprintf(
+								"view %q: section[%d] field[%d] property %q not in entity %q",
+								viewID, i, j, f.Property, view.Entry.Type))
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return errs
+}
+
+// determineTargetType determines the entity type that a traverse rule collects.
+func determineTargetType(t ViewTraverse, relType string, meta *metamodel.Metamodel) string {
+	if relType == "" {
+		return ""
+	}
+	relDef, ok := meta.GetRelationDef(relType)
+	if !ok {
+		return ""
+	}
+
+	// For outgoing (follow), target is relation's To types
+	// For incoming (follow_incoming), target is relation's From types
+	if t.Follow != "" {
+		if len(relDef.To) == 1 {
+			return relDef.To[0]
+		}
+
+		return "" // multiple possible types, can't determine statically
+	}
+	if t.FollowIncoming != "" {
+		if len(relDef.From) == 1 {
+			return relDef.From[0]
+		}
+
+		return "" // multiple possible types
+	}
+
+	return ""
+}
+
+// suggestRelation finds a similar relation name for typo suggestions.
+func suggestRelation(name string, meta *metamodel.Metamodel) string {
+	nameLower := strings.ToLower(name)
+	for relName := range meta.Relations {
+		if strings.EqualFold(relName, name) {
+			return relName
+		}
+		// Simple similarity: check if one contains the other
+		relNameLower := strings.ToLower(relName)
+		if strings.Contains(relNameLower, nameLower) || strings.Contains(nameLower, relNameLower) {
+			return relName
+		}
+	}
+
+	return ""
+}
+
+// validateDashboard validates dashboard configuration.
+func validateDashboard(cfg *Config, _ *metamodel.Metamodel) []string {
+	var errs []string
+
+	if cfg.Dashboard == nil {
+		return errs
+	}
+
+	for i, card := range cfg.Dashboard.Cards {
+		// Validate display mode
+		if !validDashboardDisplayModes[card.Display] {
+			errs = append(errs, fmt.Sprintf(
+				"dashboard: card[%d] %q has invalid display mode %q (valid: %s)",
+				i, card.Title, card.Display, joinMapKeys(validDashboardDisplayModes)))
+		}
+
+		// Validate sort directions
+		for j, s := range card.Sort {
+			if !validSortDirections[s.Direction] {
+				errs = append(errs, fmt.Sprintf(
+					"dashboard: card[%d] %q sort[%d] has invalid direction %q (valid: asc, desc)",
+					i, card.Title, j, s.Direction))
+			}
+		}
+
+		// For breakdown display, group_by should be specified
+		if card.Display == "breakdown" && card.GroupBy == "" {
+			errs = append(errs, fmt.Sprintf(
+				"dashboard: card[%d] %q uses breakdown display but has no group_by",
+				i, card.Title))
+		}
+
+		// For table display, columns should be specified
+		if card.Display == "table" && len(card.Columns) == 0 {
+			errs = append(errs, fmt.Sprintf(
+				"dashboard: card[%d] %q uses table display but has no columns",
+				i, card.Title))
+		}
+	}
+
+	return errs
+}
+
+// validateCommands validates command definitions.
+func validateCommands(cfg *Config, meta *metamodel.Metamodel) []string {
+	var errs []string
+
+	for cmdID, cmd := range cfg.Commands {
+		if cmd.Label == "" {
+			errs = append(errs, fmt.Sprintf("command %q: label is required", cmdID))
+		}
+		if cmd.Script == "" {
+			errs = append(errs, fmt.Sprintf("command %q: script is required", cmdID))
+		}
+		if !validCommandContexts[cmd.Context] {
+			errs = append(errs, fmt.Sprintf(
+				"command %q: invalid context %q (valid: %s)",
+				cmdID, cmd.Context, joinMapKeys(validCommandContexts)))
+		}
+		if cmd.AvailableOn != nil {
+			for _, v := range cmd.AvailableOn.Views {
+				if _, ok := cfg.Views[v]; !ok {
+					errs = append(errs, fmt.Sprintf(
+						"command %q: available_on references unknown view %q", cmdID, v))
+				}
+			}
+			for _, l := range cmd.AvailableOn.Lists {
+				if _, ok := cfg.Lists[l]; !ok {
+					errs = append(errs, fmt.Sprintf(
+						"command %q: available_on references unknown list %q", cmdID, l))
+				}
+			}
+			for _, et := range cmd.AvailableOn.EntityTypes {
+				if _, ok := meta.GetEntityDef(et); !ok {
+					errs = append(errs, fmt.Sprintf(
+						"command %q: available_on references unknown entity type %q", cmdID, et))
+				}
+			}
+		}
+	}
+
+	return errs
+}
+
+// validateStyles validates style definitions reference valid metamodel types.
+func validateStyles(cfg *Config, meta *metamodel.Metamodel) []string {
+	var errs []string
+
+	for typeName := range cfg.Styles {
+		// Check if it's a custom type in metamodel
+		if _, ok := meta.Types[typeName]; ok {
+			continue
+		}
+		// Check if it's used as a property type in any entity
+		found := false
+		for _, entDef := range meta.Entities {
+			for _, propDef := range entDef.Properties {
+				if propDef.Type == typeName {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			errs = append(errs, fmt.Sprintf(
+				"styles: type %q is not defined in metamodel", typeName))
+		}
+	}
+
+	return errs
+}
+
+// validateCrossReferences validates that all cross-references between config sections are valid.
+func validateCrossReferences(cfg *Config) []string {
+	var errs []string
+
+	// Validate list references to forms and views
+	for listID, list := range cfg.Lists {
+		if list.CreateForm != "" {
+			if _, ok := cfg.Forms[list.CreateForm]; !ok {
+				if suggestion := suggestForm(list.CreateForm, cfg); suggestion != "" {
+					errs = append(errs, fmt.Sprintf(
+						"list %q: references unknown form %q in create_form (did you mean %q?)",
+						listID, list.CreateForm, suggestion))
+				} else {
+					errs = append(errs, fmt.Sprintf(
+						"list %q: references unknown form %q in create_form",
+						listID, list.CreateForm))
+				}
+			}
+		}
+		if list.EditForm != "" {
+			if _, ok := cfg.Forms[list.EditForm]; !ok {
+				if suggestion := suggestForm(list.EditForm, cfg); suggestion != "" {
+					errs = append(errs, fmt.Sprintf(
+						"list %q: references unknown form %q in edit_form (did you mean %q?)",
+						listID, list.EditForm, suggestion))
+				} else {
+					errs = append(errs, fmt.Sprintf(
+						"list %q: references unknown form %q in edit_form",
+						listID, list.EditForm))
+				}
+			}
+		}
+		if list.DetailView != "" {
+			if _, ok := cfg.Views[list.DetailView]; !ok {
+				if suggestion := suggestView(list.DetailView, cfg); suggestion != "" {
+					errs = append(errs, fmt.Sprintf(
+						"list %q: references unknown view %q in detail_view (did you mean %q?)",
+						listID, list.DetailView, suggestion))
+				} else {
+					errs = append(errs, fmt.Sprintf(
+						"list %q: references unknown view %q in detail_view",
+						listID, list.DetailView))
+				}
+			}
+		}
+	}
+
+	return errs
+}
+
+// suggestForm finds a similar form name for typo suggestions.
+func suggestForm(name string, cfg *Config) string {
+	nameLower := strings.ToLower(name)
+	for formName := range cfg.Forms {
+		if strings.EqualFold(formName, name) {
+			return formName
+		}
+		formNameLower := strings.ToLower(formName)
+		if strings.Contains(formNameLower, nameLower) || strings.Contains(nameLower, formNameLower) {
+			return formName
+		}
+	}
+
+	return ""
+}
+
+// suggestView finds a similar view name for typo suggestions.
+func suggestView(name string, cfg *Config) string {
+	nameLower := strings.ToLower(name)
+	for viewName := range cfg.Views {
+		if strings.EqualFold(viewName, name) {
+			return viewName
+		}
+		viewNameLower := strings.ToLower(viewName)
+		if strings.Contains(viewNameLower, nameLower) || strings.Contains(nameLower, viewNameLower) {
+			return viewName
+		}
+	}
+
+	return ""
+}
+
+// Helper functions
+
+func sortedMapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func joinMapKeys(m map[string]bool) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		if k != "" { // skip empty string (default)
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}

--- a/internal/dataentry/validate_test.go
+++ b/internal/dataentry/validate_test.go
@@ -1,0 +1,927 @@
+package dataentry
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// testMetamodel returns a metamodel for testing
+func testMetamodel() *metamodel.Metamodel {
+	m := &metamodel.Metamodel{
+		Version: "1.0",
+		Types: map[string]metamodel.CustomType{
+			"status": {
+				Values:  []string{"open", "in-progress", "closed"},
+				Default: "open",
+			},
+			"priority": {
+				Values: []string{"high", "medium", "low"},
+			},
+		},
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Label:    "Ticket",
+				IDPrefix: "TKT-",
+				Properties: map[string]metamodel.PropertyDef{
+					"title":    {Type: "string", Required: true},
+					"status":   {Type: "status"},
+					"priority": {Type: "priority"},
+					"assignee": {Type: "string"},
+				},
+			},
+			"category": {
+				Label:    "Category",
+				IDPrefix: "CAT-",
+				Properties: map[string]metamodel.PropertyDef{
+					"name":        {Type: "string", Required: true},
+					"description": {Type: "string"},
+				},
+			},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"belongs-to": {
+				Label: "belongs to",
+				From:  []string{"ticket"},
+				To:    []string{"category"},
+			},
+			"blocks": {
+				Label: "blocks",
+				From:  []string{"ticket"},
+				To:    []string{"ticket"},
+			},
+		},
+	}
+	return m
+}
+
+func TestValidateConfig_ValidConfig(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Version: "1.0",
+		App:     AppConfig{Name: "Test App"},
+		Forms: map[string]Form{
+			"create_ticket": {
+				EntityType: "ticket",
+				Title:      "New Ticket",
+				Fields: []FormField{
+					{Property: "title"},
+					{Property: "status", Widget: "select"},
+				},
+				Relations: []FormRelation{
+					{Relation: "belongs-to", Direction: "outgoing"},
+				},
+			},
+		},
+		Lists: map[string]List{
+			"all_tickets": {
+				EntityType: "ticket",
+				Title:      "All Tickets",
+				Columns: []ListColumn{
+					{Property: "title"},
+					{Property: "status"},
+				},
+				CreateForm: "create_ticket",
+				DetailView: "ticket_view",
+			},
+		},
+		Views: map[string]ViewConfig{
+			"ticket_view": {
+				Title: "Ticket View",
+				Entry: ViewEntry{Type: "ticket"},
+				Traverse: []ViewTraverse{
+					{From: "entry", Follow: "blocks", CollectAs: "blocked"},
+				},
+				Sections: []ViewSection{
+					{Source: "entry", Display: "properties"},
+					{Source: "blocked", Display: "table"},
+				},
+			},
+		},
+		Navigation: []NavigationEntry{
+			{Label: "Tickets", List: "all_tickets"},
+		},
+	}
+
+	data := []byte(`version: "1.0"`)
+
+	err := ValidateConfig(data, cfg, meta)
+	if err != nil {
+		t.Errorf("expected valid config to pass, got error: %v", err)
+	}
+}
+
+func TestValidateConfig_UnknownTopLevelKey(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{}
+
+	data := []byte(`
+version: "1.0"
+form:
+  test: {}
+`)
+
+	err := ValidateConfig(data, cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown key 'form'")
+	}
+	if !strings.Contains(err.Error(), `unknown key "form"`) {
+		t.Errorf("expected error about unknown key, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), `did you mean "forms"`) {
+		t.Errorf("expected suggestion for 'forms', got: %v", err)
+	}
+}
+
+func TestValidateConfig_UnknownFormEntityType(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Forms: map[string]Form{
+			"test": {EntityType: "unknown_type"},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown entity type")
+	}
+	if !strings.Contains(err.Error(), `form "test": unknown entity type "unknown_type"`) {
+		t.Errorf("expected error about unknown entity type, got: %v", err)
+	}
+}
+
+func TestValidateConfig_UnknownFormFieldProperty(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Forms: map[string]Form{
+			"test": {
+				EntityType: "ticket",
+				Fields:     []FormField{{Property: "unknown_prop"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown property")
+	}
+	if !strings.Contains(err.Error(), `property "unknown_prop" not in metamodel`) {
+		t.Errorf("expected error about unknown property, got: %v", err)
+	}
+}
+
+func TestValidateConfig_InvalidFormWidget(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Forms: map[string]Form{
+			"test": {
+				EntityType: "ticket",
+				Fields:     []FormField{{Property: "title", Widget: "dropdown"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for invalid widget")
+	}
+	if !strings.Contains(err.Error(), `unknown widget "dropdown"`) {
+		t.Errorf("expected error about unknown widget, got: %v", err)
+	}
+}
+
+func TestValidateConfig_InvalidTransitions(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Forms: map[string]Form{
+			"test": {
+				EntityType: "ticket",
+				Fields: []FormField{{
+					Property: "status",
+					Transitions: map[string][]string{
+						"invalid_state": {"open"},
+						"open":          {"invalid_target"},
+					},
+				}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for invalid transitions")
+	}
+	if !strings.Contains(err.Error(), `invalid from-state "invalid_state"`) {
+		t.Errorf("expected error about invalid from-state, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), `invalid to-state "invalid_target"`) {
+		t.Errorf("expected error about invalid to-state, got: %v", err)
+	}
+}
+
+func TestValidateConfig_UnknownFormRelation(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Forms: map[string]Form{
+			"test": {
+				EntityType: "ticket",
+				Relations:  []FormRelation{{Relation: "unknown_rel"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown relation")
+	}
+	if !strings.Contains(err.Error(), `unknown relation "unknown_rel"`) {
+		t.Errorf("expected error about unknown relation, got: %v", err)
+	}
+}
+
+func TestValidateConfig_InvalidRelationDirection(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Forms: map[string]Form{
+			"test": {
+				EntityType: "ticket",
+				Relations:  []FormRelation{{Relation: "blocks", Direction: "both"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for invalid direction")
+	}
+	if !strings.Contains(err.Error(), `invalid direction "both"`) {
+		t.Errorf("expected error about invalid direction, got: %v", err)
+	}
+}
+
+func TestValidateConfig_FormRelationUnknownCreateForm(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Forms: map[string]Form{
+			"test": {
+				EntityType: "ticket",
+				Relations:  []FormRelation{{Relation: "blocks", CreateForm: "nonexistent"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown create_form")
+	}
+	if !strings.Contains(err.Error(), `unknown create_form "nonexistent"`) {
+		t.Errorf("expected error about unknown create_form, got: %v", err)
+	}
+}
+
+func TestValidateConfig_UnknownListEntityType(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Lists: map[string]List{
+			"test": {EntityType: "unknown_type"},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown entity type")
+	}
+	if !strings.Contains(err.Error(), `list "test": unknown entity type "unknown_type"`) {
+		t.Errorf("expected error about unknown entity type, got: %v", err)
+	}
+}
+
+func TestValidateConfig_UnknownListColumnProperty(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Lists: map[string]List{
+			"test": {
+				EntityType: "ticket",
+				Columns:    []ListColumn{{Property: "unknown_prop"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown column property")
+	}
+	if !strings.Contains(err.Error(), `column[0] property "unknown_prop" not in metamodel`) {
+		t.Errorf("expected error about unknown column property, got: %v", err)
+	}
+}
+
+func TestValidateConfig_UnknownListColumnRelation(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Lists: map[string]List{
+			"test": {
+				EntityType: "ticket",
+				Columns:    []ListColumn{{Relation: "unknown_rel"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown column relation")
+	}
+	if !strings.Contains(err.Error(), `column[0] references unknown relation "unknown_rel"`) {
+		t.Errorf("expected error about unknown column relation, got: %v", err)
+	}
+}
+
+func TestValidateConfig_InvalidSortDirection(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Lists: map[string]List{
+			"test": {
+				EntityType: "ticket",
+				Sort:       []SortSpec{{Property: "title", Direction: "up"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for invalid sort direction")
+	}
+	if !strings.Contains(err.Error(), `invalid direction "up"`) {
+		t.Errorf("expected error about invalid direction, got: %v", err)
+	}
+}
+
+func TestValidateConfig_InvalidFilterOperator(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Lists: map[string]List{
+			"test": {
+				EntityType: "ticket",
+				Filters:    []FilterConfig{{Property: "status", Operator: "=="}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for invalid filter operator")
+	}
+	if !strings.Contains(err.Error(), `invalid operator "=="`) {
+		t.Errorf("expected error about invalid operator, got: %v", err)
+	}
+}
+
+func TestValidateConfig_InvalidFilterControlWidget(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Lists: map[string]List{
+			"test": {
+				EntityType:     "ticket",
+				FilterControls: []FilterControl{{Property: "status", Widget: "dropdown"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for invalid filter control widget")
+	}
+	if !strings.Contains(err.Error(), `invalid widget "dropdown"`) {
+		t.Errorf("expected error about invalid widget, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ListReferencesUnknownForm(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Forms: map[string]Form{
+			"create_ticket": {EntityType: "ticket"},
+		},
+		Lists: map[string]List{
+			"test": {
+				EntityType: "ticket",
+				CreateForm: "nonexistent_form",
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown create_form")
+	}
+	if !strings.Contains(err.Error(), `references unknown form "nonexistent_form"`) {
+		t.Errorf("expected error about unknown form, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ListReferencesUnknownView(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"ticket_view": {Entry: ViewEntry{Type: "ticket"}},
+		},
+		Lists: map[string]List{
+			"test": {
+				EntityType: "ticket",
+				DetailView: "nonexistent_view",
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown detail_view")
+	}
+	if !strings.Contains(err.Error(), `references unknown view "nonexistent_view"`) {
+		t.Errorf("expected error about unknown view, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ViewUnknownEntryType(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"test": {Entry: ViewEntry{Type: "unknown_type"}},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown entry type")
+	}
+	if !strings.Contains(err.Error(), `entry type "unknown_type" not in metamodel`) {
+		t.Errorf("expected error about unknown entry type, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ViewTraverseUnknownCollection(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"test": {
+				Entry: ViewEntry{Type: "ticket"},
+				Traverse: []ViewTraverse{
+					{From: "nonexistent", Follow: "blocks", CollectAs: "blocked"},
+				},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown collection in from")
+	}
+	if !strings.Contains(err.Error(), `unknown collection "nonexistent" in from`) {
+		t.Errorf("expected error about unknown collection, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ViewTraverseUnknownRelation(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"test": {
+				Entry: ViewEntry{Type: "ticket"},
+				Traverse: []ViewTraverse{
+					{From: "entry", Follow: "block", CollectAs: "blocked"}, // typo: block vs blocks
+				},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown relation")
+	}
+	if !strings.Contains(err.Error(), `unknown relation "block"`) {
+		t.Errorf("expected error about unknown relation, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), `did you mean "blocks"`) {
+		t.Errorf("expected suggestion, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ViewTraverseMissingFollowOrFollowIncoming(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"test": {
+				Entry: ViewEntry{Type: "ticket"},
+				Traverse: []ViewTraverse{
+					{From: "entry", CollectAs: "blocked"},
+				},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for missing follow/follow_incoming")
+	}
+	if !strings.Contains(err.Error(), "must specify either follow or follow_incoming") {
+		t.Errorf("expected error about missing follow, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ViewTraverseBothFollowAndFollowIncoming(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"test": {
+				Entry: ViewEntry{Type: "ticket"},
+				Traverse: []ViewTraverse{
+					{From: "entry", Follow: "blocks", FollowIncoming: "blocks", CollectAs: "blocked"},
+				},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for both follow and follow_incoming")
+	}
+	if !strings.Contains(err.Error(), "cannot specify both follow and follow_incoming") {
+		t.Errorf("expected error about both follow, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ViewTraverseMissingCollectAs(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"test": {
+				Entry: ViewEntry{Type: "ticket"},
+				Traverse: []ViewTraverse{
+					{From: "entry", Follow: "blocks"},
+				},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for missing collect_as")
+	}
+	if !strings.Contains(err.Error(), "must specify collect_as") {
+		t.Errorf("expected error about missing collect_as, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ViewSectionUnknownSource(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"test": {
+				Entry: ViewEntry{Type: "ticket"},
+				Sections: []ViewSection{
+					{Source: "nonexistent", Display: "table"},
+				},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown section source")
+	}
+	if !strings.Contains(err.Error(), `unknown collection "nonexistent" in source`) {
+		t.Errorf("expected error about unknown source, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ViewSectionInvalidDisplay(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"test": {
+				Entry: ViewEntry{Type: "ticket"},
+				Sections: []ViewSection{
+					{Source: "entry", Display: "grid"},
+				},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for invalid display mode")
+	}
+	if !strings.Contains(err.Error(), `invalid display mode "grid"`) {
+		t.Errorf("expected error about invalid display, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ViewSectionUnknownFieldProperty(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"test": {
+				Entry: ViewEntry{Type: "ticket"},
+				Sections: []ViewSection{
+					{Source: "entry", Display: "properties", Fields: []ViewSectionField{{Property: "unknown_prop"}}},
+				},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown field property")
+	}
+	if !strings.Contains(err.Error(), `property "unknown_prop" not in entity`) {
+		t.Errorf("expected error about unknown property, got: %v", err)
+	}
+}
+
+func TestValidateConfig_DashboardInvalidDisplay(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Dashboard: &DashboardConfig{
+			Cards: []DashboardCard{
+				{Title: "Test", Display: "pie"},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for invalid dashboard display")
+	}
+	if !strings.Contains(err.Error(), `invalid display mode "pie"`) {
+		t.Errorf("expected error about invalid display, got: %v", err)
+	}
+}
+
+func TestValidateConfig_DashboardBreakdownMissingGroupBy(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Dashboard: &DashboardConfig{
+			Cards: []DashboardCard{
+				{Title: "Test", Display: "breakdown"},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for breakdown without group_by")
+	}
+	if !strings.Contains(err.Error(), "uses breakdown display but has no group_by") {
+		t.Errorf("expected error about missing group_by, got: %v", err)
+	}
+}
+
+func TestValidateConfig_DashboardTableMissingColumns(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Dashboard: &DashboardConfig{
+			Cards: []DashboardCard{
+				{Title: "Test", Display: "table"},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for table without columns")
+	}
+	if !strings.Contains(err.Error(), "uses table display but has no columns") {
+		t.Errorf("expected error about missing columns, got: %v", err)
+	}
+}
+
+func TestValidateConfig_CommandMissingLabel(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Commands: map[string]CommandConfig{
+			"test": {Script: "echo hello", Context: "global"},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for missing label")
+	}
+	if !strings.Contains(err.Error(), `command "test": label is required`) {
+		t.Errorf("expected error about missing label, got: %v", err)
+	}
+}
+
+func TestValidateConfig_CommandMissingScript(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Commands: map[string]CommandConfig{
+			"test": {Label: "Test", Context: "global"},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for missing script")
+	}
+	if !strings.Contains(err.Error(), `command "test": script is required`) {
+		t.Errorf("expected error about missing script, got: %v", err)
+	}
+}
+
+func TestValidateConfig_CommandInvalidContext(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Commands: map[string]CommandConfig{
+			"test": {Label: "Test", Script: "echo", Context: "anywhere"},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for invalid context")
+	}
+	if !strings.Contains(err.Error(), `invalid context "anywhere"`) {
+		t.Errorf("expected error about invalid context, got: %v", err)
+	}
+}
+
+func TestValidateConfig_CommandUnknownAvailableOnView(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Commands: map[string]CommandConfig{
+			"test": {
+				Label:       "Test",
+				Script:      "echo",
+				Context:     "view",
+				AvailableOn: &CommandScope{Views: []string{"unknown_view"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown view")
+	}
+	if !strings.Contains(err.Error(), `references unknown view "unknown_view"`) {
+		t.Errorf("expected error about unknown view, got: %v", err)
+	}
+}
+
+func TestValidateConfig_StyleUnknownType(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Styles: map[string]map[string]string{
+			"unknown_type": {"value": "blue"},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown style type")
+	}
+	if !strings.Contains(err.Error(), `type "unknown_type" is not defined in metamodel`) {
+		t.Errorf("expected error about unknown type, got: %v", err)
+	}
+}
+
+func TestValidateConfig_StyleValidCustomType(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Styles: map[string]map[string]string{
+			"status":   {"open": "blue"},
+			"priority": {"high": "red"},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err != nil {
+		t.Errorf("expected valid styles to pass, got: %v", err)
+	}
+}
+
+func TestValidateConfig_NavigationUnknownList(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Navigation: []NavigationEntry{
+			{Label: "Test", List: "unknown_list"},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown list in navigation")
+	}
+	if !strings.Contains(err.Error(), `references unknown list "unknown_list"`) {
+		t.Errorf("expected error about unknown list, got: %v", err)
+	}
+}
+
+func TestValidateConfig_NavigationNestedGroups(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Navigation: []NavigationEntry{
+			{
+				Group: "Outer",
+				Items: []NavigationEntry{
+					{Group: "Inner"},
+				},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for nested groups")
+	}
+	if !strings.Contains(err.Error(), "nested groups are not supported") {
+		t.Errorf("expected error about nested groups, got: %v", err)
+	}
+}
+
+func TestValidateConfig_MultipleErrors(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Forms: map[string]Form{
+			"test": {EntityType: "unknown1"},
+		},
+		Lists: map[string]List{
+			"test": {EntityType: "unknown2"},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected multiple errors")
+	}
+
+	var configErr *ConfigValidationError
+	if !errors.As(err, &configErr) {
+		t.Fatalf("expected ConfigValidationError, got %T", err)
+	}
+	if len(configErr.Errors) != 2 {
+		t.Errorf("expected 2 errors, got %d: %v", len(configErr.Errors), configErr.Errors)
+	}
+}
+
+func TestValidateConfig_ViewTraverseWildcardFrom(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"test": {
+				Entry: ViewEntry{Type: "ticket"},
+				Traverse: []ViewTraverse{
+					{From: "entry", Follow: "blocks", CollectAs: "blocked"},
+					{From: "*", Follow: "belongs-to", CollectAs: "categories"},
+				},
+				Sections: []ViewSection{
+					{Source: "categories", Display: "list"},
+				},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err != nil {
+		t.Errorf("expected wildcard from to be valid, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ViewSectionUsesPreviousCollectAs(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"test": {
+				Entry: ViewEntry{Type: "ticket"},
+				Traverse: []ViewTraverse{
+					{From: "entry", Follow: "blocks", CollectAs: "blocked"},
+				},
+				Sections: []ViewSection{
+					{Source: "blocked", Display: "table", Columns: []ListColumn{{Property: "title"}}},
+				},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err != nil {
+		t.Errorf("expected section using collect_as to be valid, got: %v", err)
+	}
+}
+
+func TestConfigValidationError_SingleError(t *testing.T) {
+	err := &ConfigValidationError{Errors: []string{"single error"}}
+	if err.Error() != "single error" {
+		t.Errorf("expected 'single error', got %q", err.Error())
+	}
+}
+
+func TestConfigValidationError_MultipleErrors(t *testing.T) {
+	err := &ConfigValidationError{Errors: []string{"error 1", "error 2"}}
+	expected := "data-entry config validation errors:\n  - error 1\n  - error 2"
+	if err.Error() != expected {
+		t.Errorf("expected %q, got %q", expected, err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- Add `ConfigValidationError` type for collecting multiple validation errors
- Add `ValidateConfig()` with comprehensive validation for all config sections
- Change from warnings to hard errors at load time
- Add `rela validate` CLI command for standalone validation
- Format validation errors nicely to stderr in rela-server

## Validation coverage
- **Unknown keys** at top level with typo suggestions
- **Forms**: entity types, field properties, widgets, transitions, relation directions, create_form refs
- **Lists**: entity types, columns (property/relation), sort directions, filter operators, filter widgets, cross-refs
- **Views**: entry types, traverse rules (from/follow/collect_as), sections (source/display/fields/columns/group_by)
- **Dashboard**: display modes, group_by for breakdown, columns for table
- **Commands**: label, script, context, available_on references
- **Styles**: type names must exist in metamodel
- **Navigation**: nested groups rejected, list references validated

## Test plan
- [x] All existing tests pass
- [x] New validation tests cover all rules
- [x] Lint passes
- [x] Manual test with broken config shows clear errors