### PR TITLE
Add inline validation errors to data entry forms

### DIFF
--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -292,7 +292,7 @@ func runPropertyValidation() error {
 	// Group errors by entity for cleaner output
 	type entityErrors struct {
 		entity *model.Entity
-		errs   []error
+		errs   []*metamodel.ValidationError
 	}
 	var allErrors []entityErrors
 
@@ -310,7 +310,7 @@ func runPropertyValidation() error {
 		for _, ee := range allErrors {
 			errStrings := make([]string, len(ee.errs))
 			for i, err := range ee.errs {
-				errStrings[i] = err.Error()
+				errStrings[i] = err.Message
 			}
 			results = append(results, output.PropertyValidationResult{
 				EntityID:   ee.entity.ID,

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -315,6 +315,7 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 		InputType   string
 		Values      []string
 		Transitions map[string][]string
+		Error       string
 	}
 
 	var entity *model.Entity
@@ -969,6 +970,193 @@ func (a *App) handleView(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// renderFormWithErrors re-renders the form with validation errors.
+// fieldErrors is a map of property name to error message.
+func (a *App) renderFormWithErrors(w http.ResponseWriter, r *http.Request, formID string, entity *model.Entity, fieldErrors map[string]string) {
+	form, ok := a.Cfg.Forms[formID]
+	if !ok {
+		http.Error(w, "Unknown form", http.StatusBadRequest)
+		return
+	}
+
+	entDef, _ := a.meta.GetEntityDef(form.EntityType)
+
+	// Resolve fields with errors
+	type ResolvedField struct {
+		Property    string
+		Label       string
+		Placeholder string
+		Help        string
+		Required    bool
+		Default     string
+		Value       string
+		Hidden      bool
+		Widget      string
+		InputType   string
+		Values      []string
+		Transitions map[string][]string
+		Error       string
+	}
+
+	fields := make([]ResolvedField, 0, len(form.Fields))
+	for _, f := range form.Fields {
+		prop := entDef.Properties[f.Property]
+		rf := ResolvedField{
+			Property:    f.Property,
+			Label:       coalesce(f.Label, titleCase(f.Property)),
+			Placeholder: f.Placeholder,
+			Help:        f.Help,
+			Default:     coalesce(f.Default, prop.Default),
+			Hidden:      f.Hidden,
+			Widget:      resolveWidget(f.Widget, prop, a.meta),
+			Values:      resolvePropertyValues(prop, a.meta),
+			Transitions: f.Transitions,
+			Error:       fieldErrors[f.Property],
+		}
+		if f.Required != nil {
+			rf.Required = *f.Required
+		} else {
+			rf.Required = prop.Required
+		}
+		rf.InputType = widgetToInputType(rf.Widget)
+
+		// Use submitted value from entity properties
+		if val := entity.Properties[f.Property]; val != nil {
+			rf.Value = fmt.Sprintf("%v", val)
+		}
+
+		fields = append(fields, rf)
+	}
+
+	// Resolve body content
+	var bodyContent string
+	showBody := form.Body != nil && *form.Body
+	if showBody {
+		bodyContent = entity.Content
+	}
+
+	// Resolve relation fields (similar to handleForm but using form values)
+	type ResolvedRelation struct {
+		Relation      string
+		Label         string
+		Required      bool
+		Widget        string
+		TargetType    string
+		TargetLabel   string
+		Options       []struct{ ID, Title string }
+		Selected      []string
+		AllowCreate   bool
+		CreateForm    string
+		Properties    []RelationProperty
+		SelectedProps map[string]map[string]string
+	}
+	linkRelation := r.FormValue("_link_relation")
+	linkPeer := r.FormValue("_link_peer")
+
+	relations := make([]ResolvedRelation, 0, len(form.Relations))
+	for _, rel := range form.Relations {
+		if rel.Display != "" {
+			continue
+		}
+
+		targetDef, _ := a.meta.GetEntityDef(rel.TargetType)
+		targetLabel := ""
+		if targetDef != nil {
+			targetLabel = targetDef.Label
+		}
+
+		rr := ResolvedRelation{
+			Relation:      rel.Relation,
+			Label:         rel.Label,
+			Required:      rel.Required,
+			Widget:        coalesce(rel.Widget, "select"),
+			TargetType:    rel.TargetType,
+			TargetLabel:   targetLabel,
+			AllowCreate:   rel.AllowCreate,
+			CreateForm:    rel.CreateForm,
+			Properties:    rel.Properties,
+			SelectedProps: make(map[string]map[string]string),
+		}
+
+		targets := a.g.NodesByType(rel.TargetType)
+		for _, t := range targets {
+			rr.Options = append(rr.Options, struct{ ID, Title string }{t.ID, a.entityDisplayTitle(t)})
+		}
+
+		// Preserve submitted relation values from form
+		rr.Selected = r.Form[rel.Relation]
+
+		relations = append(relations, rr)
+	}
+
+	var mode string
+	if entity.ID != "" {
+		if _, exists := a.g.GetNode(entity.ID); exists {
+			mode = "edit"
+		} else {
+			mode = "create"
+		}
+	} else {
+		mode = "create"
+	}
+
+	activeList := a.resolveActiveList(form.EntityType, r)
+	returnTo := r.FormValue("_return_to")
+	backURL := returnTo
+	switch {
+	case backURL != "":
+		// keep explicit return_to
+	case mode == "edit" && entity.ID != "":
+		backURL = "/entity/" + form.EntityType + "/" + entity.ID
+	case activeList != "":
+		backURL = "/list/" + activeList
+	default:
+		backURL = "/"
+	}
+
+	data := map[string]interface{}{
+		"App":          a.Cfg.App,
+		"Navigation":   a.navElements(activeList),
+		"ActiveList":   activeList,
+		"FormID":       formID,
+		"Form":         form,
+		"Fields":       fields,
+		"Relations":    relations,
+		"Mode":         mode,
+		"EntityID":     entity.ID,
+		"EntityType":   form.EntityType,
+		"ShowBody":     showBody,
+		"Body":         bodyContent,
+		"ReturnTo":     returnTo,
+		"BackURL":      backURL,
+		"LinkRelation": linkRelation,
+		"LinkPeer":     linkPeer,
+		"LinkAs":       r.FormValue("_link_as"),
+		"IsHTMX":       true, // Always true since this is a form submission response
+		"HasErrors":    len(fieldErrors) > 0,
+	}
+
+	// Return 422 Unprocessable Entity for validation errors.
+	// HX-Retarget and HX-Reswap tell HTMX to swap the response into #content,
+	// overriding the form's hx-swap="none" which is used for successful submissions.
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("HX-Retarget", "#content")
+	w.Header().Set("HX-Reswap", "innerHTML")
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	a.tmpl.ExecuteTemplate(w, "form-content", data) //nolint:errcheck // template errors logged by http
+}
+
+// validationErrorsToFieldMap converts structured ValidationErrors to a map of field names to error messages.
+func validationErrorsToFieldMap(errs []*metamodel.ValidationError) map[string]string {
+	fieldErrors := make(map[string]string)
+	for _, err := range errs {
+		if err.Property != "" {
+			fieldErrors[err.Property] = err.Message
+		}
+	}
+	return fieldErrors
+}
+
 func (a *App) handleCreate(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -1023,6 +1211,12 @@ func (a *App) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	if form.Body != nil && *form.Body {
 		entity.Content = r.FormValue("_body")
+	}
+
+	// Validate entity before writing
+	if validationErrs := a.meta.ValidateEntity(entity); len(validationErrs) > 0 {
+		a.renderFormWithErrors(w, r, formID, entity, validationErrorsToFieldMap(validationErrs))
+		return
 	}
 
 	if err := a.repo.WriteEntity(entity, a.meta); err != nil {
@@ -1133,6 +1327,12 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 
 	if form.Body != nil && *form.Body {
 		entity.Content = r.FormValue("_body")
+	}
+
+	// Validate entity before writing
+	if validationErrs := a.meta.ValidateEntity(entity); len(validationErrs) > 0 {
+		a.renderFormWithErrors(w, r, formID, entity, validationErrorsToFieldMap(validationErrs))
+		return
 	}
 
 	if err := a.repo.WriteEntity(entity, a.meta); err != nil {

--- a/internal/dataentry/handlers_test.go
+++ b/internal/dataentry/handlers_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
@@ -960,6 +962,157 @@ func TestHandleLinkExisting(t *testing.T) {
 		app.handleLinkExisting(w, r)
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+}
+
+func newTestRepository(t *testing.T, tmpDir string) *repository.Repository {
+	t.Helper()
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	ctx := &project.Context{Root: tmpDir}
+	return repository.New(fs, ctx)
+}
+
+func TestValidationErrorsToFieldMap(t *testing.T) {
+	t.Run("converts required property error", func(t *testing.T) {
+		errs := []*metamodel.ValidationError{
+			{Type: metamodel.ValidationErrorRequired, Property: "title", Message: "This field is required"},
+		}
+		result := validationErrorsToFieldMap(errs)
+		if result["title"] != "This field is required" {
+			t.Errorf("expected 'This field is required', got %q", result["title"])
+		}
+	})
+
+	t.Run("converts invalid value error", func(t *testing.T) {
+		errs := []*metamodel.ValidationError{
+			{Type: metamodel.ValidationErrorInvalidValue, Property: "status", Message: "Invalid value"},
+		}
+		result := validationErrorsToFieldMap(errs)
+		if result["status"] != "Invalid value" {
+			t.Errorf("expected 'Invalid value', got %q", result["status"])
+		}
+	})
+
+	t.Run("handles multiple errors", func(t *testing.T) {
+		errs := []*metamodel.ValidationError{
+			{Type: metamodel.ValidationErrorRequired, Property: "title", Message: "This field is required"},
+			{Type: metamodel.ValidationErrorRequired, Property: "status", Message: "This field is required"},
+		}
+		result := validationErrorsToFieldMap(errs)
+		if len(result) != 2 {
+			t.Errorf("expected 2 errors, got %d", len(result))
+		}
+	})
+
+	t.Run("skips entity-level errors without property", func(t *testing.T) {
+		errs := []*metamodel.ValidationError{
+			{Type: metamodel.ValidationErrorIDPrefix, Property: "", Message: "ID prefix mismatch"},
+		}
+		result := validationErrorsToFieldMap(errs)
+		if len(result) != 0 {
+			t.Errorf("expected empty map, got %d entries", len(result))
+		}
+	})
+
+	t.Run("handles empty errors", func(t *testing.T) {
+		result := validationErrorsToFieldMap(nil)
+		if len(result) != 0 {
+			t.Errorf("expected empty map, got %d entries", len(result))
+		}
+	})
+}
+
+func TestHandleCreateWithValidationErrors(t *testing.T) {
+	t.Run("returns 422 with validation errors for missing required field", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		// Configure temp directory for repository to avoid writing to real filesystem
+		tmpDir := t.TempDir()
+		app.repo = newTestRepository(t, tmpDir)
+
+		// Make title required in the metamodel
+		entDef := app.meta.Entities["ticket"]
+		titleProp := entDef.Properties["title"]
+		titleProp.Required = true
+		entDef.Properties["title"] = titleProp
+		app.meta.Entities["ticket"] = entDef
+
+		// Submit form without title (required field)
+		form := url.Values{
+			"_form_id":   {"create-ticket"},
+			"_entity_id": {"TKT-NEW"},
+			"status":     {"open"},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/api/create", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.Header.Set("HX-Request", "true")
+		w := httptest.NewRecorder()
+		app.handleCreate(w, r)
+
+		if w.Code != http.StatusUnprocessableEntity {
+			t.Errorf("expected 422, got %d", w.Code)
+		}
+
+		// Verify HX-Retarget and HX-Reswap headers for HTMX swap override
+		if got := w.Header().Get("HX-Retarget"); got != "#content" {
+			t.Errorf("expected HX-Retarget=#content, got %q", got)
+		}
+		if got := w.Header().Get("HX-Reswap"); got != "innerHTML" {
+			t.Errorf("expected HX-Reswap=innerHTML, got %q", got)
+		}
+
+		body := w.Body.String()
+		if !strings.Contains(body, "field-error") {
+			t.Error("expected field-error class in response")
+		}
+		if !strings.Contains(body, "This field is required") {
+			t.Error("expected validation error message in response")
+		}
+	})
+}
+
+func TestHandleUpdateWithValidationErrors(t *testing.T) {
+	t.Run("returns 422 with validation errors for invalid field", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+		// Configure temp directory for repository to avoid writing to real filesystem
+		tmpDir := t.TempDir()
+		app.repo = newTestRepository(t, tmpDir)
+
+		// Make title required in the metamodel
+		entDef := app.meta.Entities["ticket"]
+		titleProp := entDef.Properties["title"]
+		titleProp.Required = true
+		entDef.Properties["title"] = titleProp
+		app.meta.Entities["ticket"] = entDef
+
+		// Submit form with empty title (required field)
+		form := url.Values{
+			"_form_id":   {"edit-ticket"},
+			"_entity_id": {"TKT-001"},
+			"title":      {""}, // Empty required field
+			"status":     {"open"},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/api/update", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.Header.Set("HX-Request", "true")
+		w := httptest.NewRecorder()
+		app.handleUpdate(w, r)
+
+		if w.Code != http.StatusUnprocessableEntity {
+			t.Errorf("expected 422, got %d", w.Code)
+		}
+
+		// Verify HX-Retarget and HX-Reswap headers
+		if got := w.Header().Get("HX-Retarget"); got != "#content" {
+			t.Errorf("expected HX-Retarget=#content, got %q", got)
+		}
+		if got := w.Header().Get("HX-Reswap"); got != "innerHTML" {
+			t.Errorf("expected HX-Reswap=innerHTML, got %q", got)
+		}
+
+		body := w.Body.String()
+		if !strings.Contains(body, "field-error") {
+			t.Error("expected field-error class in response")
 		}
 	})
 }

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -110,6 +110,10 @@ tbody tr:last-child td { border-bottom: none; }
 .form-section-label { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted); margin: 28px 0 16px; padding-top: 20px; border-top: 1px solid var(--border); }
 .form-actions { margin-top: 28px; padding-top: 20px; border-top: 1px solid var(--border); display: flex; gap: 12px; }
 
+.form-group.has-error input, .form-group.has-error textarea, .form-group.has-error select { border-color: var(--danger); background-color: #fef2f2; }
+.form-group.has-error input:focus, .form-group.has-error textarea:focus, .form-group.has-error select:focus { border-color: var(--danger); box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1); }
+.field-error { color: var(--danger); font-size: 12px; margin-top: 4px; font-weight: 500; }
+
 .transitions-info { margin-top: 6px; padding: 8px 12px; background: #f8fafc; border-radius: 6px; border: 1px solid var(--border); }
 .transitions-info .t-title { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); margin-bottom: 4px; }
 .transitions-info .t-row { font-size: 12px; font-family: var(--font-mono); color: var(--text-muted); line-height: 1.8; }
@@ -274,7 +278,37 @@ document.addEventListener('DOMContentLoaded', function() {
     history.replaceState(null, '', clean);
   }
 });
-document.addEventListener('htmx:afterSettle', function(evt) { enhanceSelects(evt.detail.target); });
+document.addEventListener('htmx:beforeSwap', function(evt) {
+  // Allow 422 validation error responses to be swapped (HTMX ignores non-2xx by default).
+  // The server sends HX-Retarget and HX-Reswap headers to control where/how the swap happens.
+  if (evt.detail.xhr.status === 422) {
+    evt.detail.shouldSwap = true;
+    evt.detail.isError = false;
+  }
+});
+document.addEventListener('htmx:afterSettle', function(evt) {
+  enhanceSelects(evt.detail.target);
+  // Scroll to first validation error if present
+  var firstError = evt.detail.target.querySelector('[data-has-error]');
+  if (firstError) {
+    firstError.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    var input = firstError.querySelector('input, textarea, select');
+    if (input) setTimeout(function() { input.focus(); }, 300);
+  }
+});
+// Clear validation error styling when user modifies a field.
+// Only respond to trusted (real user) events, not programmatic ones (e.g. SlimSelect init).
+function clearFieldError(evt) {
+  if (!evt.isTrusted) return;
+  var group = evt.target.closest('.form-group.has-error');
+  if (!group) return;
+  group.classList.remove('has-error');
+  group.removeAttribute('data-has-error');
+  var err = group.querySelector('.field-error');
+  if (err) err.remove();
+}
+document.addEventListener('input', clearFieldError);
+document.addEventListener('change', clearFieldError);
 document.addEventListener('htmx:responseError', function(evt) {
   var xhr = evt.detail.xhr;
   var msg = xhr.responseText || ('Request failed: ' + xhr.status);
@@ -946,7 +980,7 @@ document.body.addEventListener('htmx:pushedIntoHistory', function() {
 
 <div class="card form-card">
   <form {{ if eq .Mode "edit" }}hx-post="/api/update"{{ else }}hx-post="/api/create"{{ end }}
-        hx-swap="none">
+        hx-swap="none" novalidate>
     <input type="hidden" name="_form_id" value="{{ .FormID }}">
     <input type="hidden" name="_entity_id" value="{{ .EntityID }}">
     {{ if .ReturnTo }}<input type="hidden" name="_return_to" value="{{ .ReturnTo }}">{{ end }}
@@ -958,27 +992,30 @@ document.body.addEventListener('htmx:pushedIntoHistory', function() {
     {{ if .Hidden }}
     <input type="hidden" name="{{ .Property }}" value="{{ .Value }}">
     {{ else if eq .Widget "checkbox" }}
-    <div class="form-group">
+    <div class="form-group{{ if .Error }} has-error{{ end }}"{{ if .Error }} data-has-error="true"{{ end }}>
       <div class="form-row-checkbox">
         <input type="checkbox" name="{{ .Property }}" value="true" id="f-{{ .Property }}"{{ if eq .Value "true" }} checked{{ end }}>
         <label for="f-{{ .Property }}">{{ .Label }}</label>
       </div>
+      {{ if .Error }}<p class="field-error">{{ .Error }}</p>{{ end }}
       {{ if .Help }}<p class="help-text">{{ .Help }}</p>{{ end }}
     </div>
     {{ else if eq .Widget "textarea" }}
-    <div class="form-group">
+    <div class="form-group{{ if .Error }} has-error{{ end }}"{{ if .Error }} data-has-error="true"{{ end }}>
       <label for="f-{{ .Property }}">{{ .Label }}{{ if .Required }}<span class="required">*</span>{{ end }}</label>
       <textarea name="{{ .Property }}" id="f-{{ .Property }}" placeholder="{{ .Placeholder }}"{{ if .Required }} required{{ end }}>{{ .Value }}</textarea>
+      {{ if .Error }}<p class="field-error">{{ .Error }}</p>{{ end }}
       {{ if .Help }}<p class="help-text">{{ .Help }}</p>{{ end }}
     </div>
     {{ else if or (eq .Widget "select") (eq .Widget "multi-select") }}
-    <div class="form-group">
+    <div class="form-group{{ if .Error }} has-error{{ end }}"{{ if .Error }} data-has-error="true"{{ end }}>
       <label for="f-{{ .Property }}">{{ .Label }}{{ if .Required }}<span class="required">*</span>{{ end }}</label>
       <select name="{{ .Property }}" id="f-{{ .Property }}"{{ if eq .Widget "multi-select" }} multiple{{ end }}{{ if .Required }} required{{ end }}>
         {{ if ne .Widget "multi-select" }}<option value="">Select...</option>{{ end }}
         {{ $val := .Value }}
         {{ range .Values }}<option value="{{ . }}"{{ if eq . $val }} selected{{ end }}>{{ . }}</option>{{ end }}
       </select>
+      {{ if .Error }}<p class="field-error">{{ .Error }}</p>{{ end }}
       {{ if .Help }}<p class="help-text">{{ .Help }}</p>{{ end }}
       {{ if .Transitions }}
       <div class="transitions-info">
@@ -990,10 +1027,11 @@ document.body.addEventListener('htmx:pushedIntoHistory', function() {
       {{ end }}
     </div>
     {{ else }}
-    <div class="form-group">
+    <div class="form-group{{ if .Error }} has-error{{ end }}"{{ if .Error }} data-has-error="true"{{ end }}>
       <label for="f-{{ .Property }}">{{ .Label }}{{ if .Required }}<span class="required">*</span>{{ end }}</label>
       <input type="{{ .InputType }}" name="{{ .Property }}" id="f-{{ .Property }}"
              placeholder="{{ .Placeholder }}" value="{{ .Value }}"{{ if .Required }} required{{ end }}>
+      {{ if .Error }}<p class="field-error">{{ .Error }}</p>{{ end }}
       {{ if .Help }}<p class="help-text">{{ .Help }}</p>{{ end }}
     </div>
     {{ end }}

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -436,7 +436,7 @@ func TestImportValidationErrors(t *testing.T) {
 			data: &ImportData{
 				Entities: []EntityData{{ID: "REQ-001", Type: "requirement", Properties: map[string]interface{}{}}},
 			},
-			wantErr: "missing required property: title",
+			wantErr: "This field is required",
 		},
 	}
 

--- a/internal/metamodel/validation.go
+++ b/internal/metamodel/validation.go
@@ -8,13 +8,40 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
-// ValidateEntity validates an entity against the metamodel
-func (m *Metamodel) ValidateEntity(entity *model.Entity) []error {
-	var errs []error
+// ValidationErrorType indicates the kind of validation error.
+type ValidationErrorType string
+
+const (
+	ValidationErrorRequired     ValidationErrorType = "required"
+	ValidationErrorInvalidValue ValidationErrorType = "invalid_value"
+	ValidationErrorInvalidType  ValidationErrorType = "invalid_type"
+	ValidationErrorUnknownType  ValidationErrorType = "unknown_type"
+	ValidationErrorIDPrefix     ValidationErrorType = "id_prefix"
+)
+
+// ValidationError represents a structured validation error with field information.
+type ValidationError struct {
+	Type     ValidationErrorType
+	Property string // The property name that failed validation (empty for entity-level errors)
+	Message  string // Human-readable error message
+}
+
+// Error implements the error interface.
+func (e *ValidationError) Error() string {
+	return e.Message
+}
+
+// ValidateEntity validates an entity against the metamodel.
+// Returns a slice of *ValidationError for structured error handling.
+func (m *Metamodel) ValidateEntity(entity *model.Entity) []*ValidationError {
+	var errs []*ValidationError
 
 	def, ok := m.GetEntityDef(entity.Type)
 	if !ok {
-		errs = append(errs, fmt.Errorf("unknown entity type: %s", entity.Type))
+		errs = append(errs, &ValidationError{
+			Type:    ValidationErrorUnknownType,
+			Message: fmt.Sprintf("unknown entity type: %s", entity.Type),
+		})
 		return errs
 	}
 
@@ -23,7 +50,11 @@ func (m *Metamodel) ValidateEntity(entity *model.Entity) []error {
 		if propDef.Required {
 			val, exists := entity.Properties[propName]
 			if !exists || val == nil || val == "" {
-				errs = append(errs, fmt.Errorf("missing required property: %s", propName))
+				errs = append(errs, &ValidationError{
+					Type:     ValidationErrorRequired,
+					Property: propName,
+					Message:  "This field is required",
+				})
 			}
 		}
 	}
@@ -40,7 +71,7 @@ func (m *Metamodel) ValidateEntity(entity *model.Entity) []error {
 			continue
 		}
 
-		if err := m.ValidatePropertyValue(propName, &propDef, val); err != nil {
+		if err := m.validatePropertyValue(propName, &propDef, val); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -56,8 +87,10 @@ func (m *Metamodel) ValidateEntity(entity *model.Entity) []error {
 			}
 		}
 		if !matched {
-			errs = append(errs, fmt.Errorf("entity ID %s does not match any prefix for type %s: %v",
-				entity.ID, entity.Type, prefixes))
+			errs = append(errs, &ValidationError{
+				Type:    ValidationErrorIDPrefix,
+				Message: fmt.Sprintf("entity ID %s does not match any prefix for type %s: %v", entity.ID, entity.Type, prefixes),
+			})
 		}
 	}
 
@@ -69,23 +102,50 @@ func (m *Metamodel) ValidateRelationEntities(relationType string, from, to *mode
 	return m.ValidateRelation(relationType, from.Type, to.Type)
 }
 
-// ValidatePropertyValue validates a single property value against its definition
+// ValidatePropertyValue validates a single property value against its definition.
+// Returns a plain error for backward compatibility with existing callers.
+//
+// Note: The explicit nil check is required because returning a nil *ValidationError
+// directly as error creates a non-nil interface with nil value (Go interface gotcha).
 func (m *Metamodel) ValidatePropertyValue(propName string, propDef *PropertyDef, val interface{}) error {
+	err := m.validatePropertyValue(propName, propDef, val)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// validatePropertyValue validates a single property value and returns a structured ValidationError.
+//
+//nolint:funlen // large switch for property type validation; splitting would reduce readability
+func (m *Metamodel) validatePropertyValue(propName string, propDef *PropertyDef, val interface{}) *ValidationError {
 	switch propDef.Type {
 	case PropertyTypeString:
 		if _, ok := val.(string); !ok {
-			return fmt.Errorf("property %s must be a string", propName)
+			return &ValidationError{
+				Type:     ValidationErrorInvalidType,
+				Property: propName,
+				Message:  "Must be a string",
+			}
 		}
 
 	case PropertyTypeDate:
 		s, ok := val.(string)
 		if !ok {
-			return fmt.Errorf("property %s must be a date string", propName)
+			return &ValidationError{
+				Type:     ValidationErrorInvalidType,
+				Property: propName,
+				Message:  "Must be a date string",
+			}
 		}
 		// Use ParseDateValue to validate - it accepts the configured format plus common fallbacks
 		if _, err := ParseDateValue(s, propDef); err != nil {
 			format := propDef.GetDateFormat()
-			return fmt.Errorf("invalid date %q for property %s (expected format: %s)", s, propName, format)
+			return &ValidationError{
+				Type:     ValidationErrorInvalidValue,
+				Property: propName,
+				Message:  fmt.Sprintf("Invalid date %q (expected format: %s)", s, format),
+			}
 		}
 
 	case PropertyTypeInteger:
@@ -94,10 +154,18 @@ func (m *Metamodel) ValidatePropertyValue(propName string, propDef *PropertyDef,
 			// OK - YAML may parse integers as these types
 		case string:
 			if _, err := strconv.Atoi(v); err != nil {
-				return fmt.Errorf("invalid integer %q for property %s", v, propName)
+				return &ValidationError{
+					Type:     ValidationErrorInvalidValue,
+					Property: propName,
+					Message:  fmt.Sprintf("Invalid integer %q", v),
+				}
 			}
 		default:
-			return fmt.Errorf("property %s must be an integer", propName)
+			return &ValidationError{
+				Type:     ValidationErrorInvalidType,
+				Property: propName,
+				Message:  "Must be an integer",
+			}
 		}
 
 	case PropertyTypeBoolean:
@@ -106,17 +174,29 @@ func (m *Metamodel) ValidatePropertyValue(propName string, propDef *PropertyDef,
 			// OK
 		case string:
 			if v != "true" && v != "false" {
-				return fmt.Errorf("property %s must be true or false, got %q", propName, v)
+				return &ValidationError{
+					Type:     ValidationErrorInvalidValue,
+					Property: propName,
+					Message:  fmt.Sprintf("Must be true or false, got %q", v),
+				}
 			}
 		default:
-			return fmt.Errorf("property %s must be a boolean", propName)
+			return &ValidationError{
+				Type:     ValidationErrorInvalidType,
+				Property: propName,
+				Message:  "Must be a boolean",
+			}
 		}
 
 	case PropertyTypeEnum:
 		if propDef.Values != nil {
 			s, ok := val.(string)
 			if !ok {
-				return fmt.Errorf("property %s must be a string", propName)
+				return &ValidationError{
+					Type:     ValidationErrorInvalidType,
+					Property: propName,
+					Message:  "Must be a string",
+				}
 			}
 			valid := false
 			for _, v := range propDef.Values {
@@ -126,7 +206,11 @@ func (m *Metamodel) ValidatePropertyValue(propName string, propDef *PropertyDef,
 				}
 			}
 			if !valid {
-				return fmt.Errorf("invalid value for %s: %s (allowed: %v)", propName, s, propDef.Values)
+				return &ValidationError{
+					Type:     ValidationErrorInvalidValue,
+					Property: propName,
+					Message:  fmt.Sprintf("Invalid value %q (allowed: %v)", s, propDef.Values),
+				}
 			}
 		}
 
@@ -134,7 +218,11 @@ func (m *Metamodel) ValidatePropertyValue(propName string, propDef *PropertyDef,
 		// Legacy built-in status type
 		if s, ok := val.(string); ok {
 			if !model.Status(s).IsValid() {
-				return fmt.Errorf("invalid status value: %s", s)
+				return &ValidationError{
+					Type:     ValidationErrorInvalidValue,
+					Property: propName,
+					Message:  fmt.Sprintf("Invalid status value: %s", s),
+				}
 			}
 		}
 
@@ -142,7 +230,11 @@ func (m *Metamodel) ValidatePropertyValue(propName string, propDef *PropertyDef,
 		// Legacy built-in priority type
 		if p, ok := val.(string); ok {
 			if !model.Priority(p).IsValid() {
-				return fmt.Errorf("invalid priority value: %s", p)
+				return &ValidationError{
+					Type:     ValidationErrorInvalidValue,
+					Property: propName,
+					Message:  fmt.Sprintf("Invalid priority value: %s", p),
+				}
 			}
 		}
 
@@ -151,7 +243,11 @@ func (m *Metamodel) ValidatePropertyValue(propName string, propDef *PropertyDef,
 		if customType, ok := m.Types[propDef.Type]; ok {
 			s, ok := val.(string)
 			if !ok {
-				return fmt.Errorf("property %s must be a string", propName)
+				return &ValidationError{
+					Type:     ValidationErrorInvalidType,
+					Property: propName,
+					Message:  "Must be a string",
+				}
 			}
 			valid := false
 			for _, v := range customType.Values {
@@ -161,10 +257,18 @@ func (m *Metamodel) ValidatePropertyValue(propName string, propDef *PropertyDef,
 				}
 			}
 			if !valid {
-				return fmt.Errorf("invalid value for %s: %s (allowed: %v)", propName, s, customType.Values)
+				return &ValidationError{
+					Type:     ValidationErrorInvalidValue,
+					Property: propName,
+					Message:  fmt.Sprintf("Invalid value %q (allowed: %v)", s, customType.Values),
+				}
 			}
 		} else {
-			return fmt.Errorf("property %s has unknown type %q", propName, propDef.Type)
+			return &ValidationError{
+				Type:     ValidationErrorUnknownType,
+				Property: propName,
+				Message:  fmt.Sprintf("Unknown type %q", propDef.Type),
+			}
 		}
 	}
 

--- a/internal/metamodel/validation_test.go
+++ b/internal/metamodel/validation_test.go
@@ -45,9 +45,14 @@ func TestValidateEntity_EmptyRequiredProperty(t *testing.T) {
 		t.Errorf("expected 1 error for empty required property, got %d: %v", len(errs), errs)
 	}
 
-	// Verify it's the "missing required property" error
-	if len(errs) > 0 && errs[0].Error() != "missing required property: title" {
-		t.Errorf("unexpected error message: %v", errs[0])
+	// Verify it's a required field error
+	if len(errs) > 0 {
+		if errs[0].Type != ValidationErrorRequired {
+			t.Errorf("expected ValidationErrorRequired, got %v", errs[0].Type)
+		}
+		if errs[0].Property != "title" {
+			t.Errorf("expected property 'title', got %q", errs[0].Property)
+		}
 	}
 }
 
@@ -447,7 +452,7 @@ func TestValidatePropertyValue_UnknownType(t *testing.T) {
 		t.Fatal("expected error for unknown property type, got nil")
 	}
 
-	if !strings.Contains(err.Error(), "unknown type") {
+	if !strings.Contains(strings.ToLower(err.Error()), "unknown type") {
 		t.Errorf("expected 'unknown type' in error, got: %v", err)
 	}
 	if !strings.Contains(err.Error(), "nonexistent") {


### PR DESCRIPTION
## Summary
- Add server-side validation with inline error display for data entry forms (create and edit)
- Return 422 with re-rendered form showing field-level errors (red borders, error messages, scroll-to-first-error)
- Client-side error clearing on user input with `evt.isTrusted` guard to avoid interference from SlimSelect/HTMX
- Use `novalidate` on forms to let server-side validation handle required fields
- Structured `ValidationError` type replaces raw error strings in metamodel validation

## Test plan
- [x] All existing tests pass with race detection
- [x] New handler tests assert 422 status, HX-Retarget/HX-Reswap headers, and error markup
- [x] Manual testing: create form shows errors, errors clear on input, scroll-to-first-error works
- [x] Lint clean