### PR TITLE
Add interactive markdown checkboxes to data entry UI

### DIFF
--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -1019,6 +1019,44 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func (a *App) handleToggleCheckbox(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	r.ParseForm() //nolint:errcheck // form parse errors are handled by empty values
+
+	entityID := r.FormValue("entity_id")
+	indexStr := r.FormValue("index")
+
+	entity, ok := a.g.GetNode(entityID)
+	if !ok {
+		http.Error(w, "Entity not found", http.StatusNotFound)
+		return
+	}
+
+	idx, err := strconv.Atoi(indexStr)
+	if err != nil {
+		http.Error(w, "Invalid checkbox index", http.StatusBadRequest)
+		return
+	}
+
+	newContent, err := toggleCheckbox(entity.Content, idx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	entity.Content = newContent
+	if err := a.repo.WriteEntity(entity, a.meta); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to write: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = fmt.Fprint(w, simpleMarkdownToHTML(entity.Content))
+}
+
 func (a *App) handleDelete(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -191,6 +192,7 @@ func simpleMarkdownToHTML(md string) template.HTML {
 	}
 
 	inMermaidBlock := false
+	cbIndex := 0
 
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
@@ -250,6 +252,28 @@ func simpleMarkdownToHTML(md string) template.HTML {
 		if strings.HasPrefix(trimmed, "# ") {
 			flushParagraph()
 			out = append(out, "<h3>"+inlineFormat(trimmed[2:])+"</h3>")
+			continue
+		}
+
+		// Task list item (checkbox)
+		if strings.HasPrefix(trimmed, "- [ ] ") || strings.HasPrefix(trimmed, "- [x] ") || strings.HasPrefix(trimmed, "- [X] ") {
+			flushParagraph()
+			if listTag != "" && listTag != "ul" {
+				closeList()
+			}
+			if listTag == "" {
+				out = append(out, `<ul class="task-list">`)
+				listTag = "ul"
+			}
+			checked := trimmed[3] != ' '
+			content := trimmed[6:]
+			checkedAttr := ""
+			if checked {
+				checkedAttr = " checked"
+			}
+			out = append(out, fmt.Sprintf(`<li class="task-item"><label><input type="checkbox" data-cb-idx="%d"%s> %s</label></li>`,
+				cbIndex, checkedAttr, inlineFormat(content)))
+			cbIndex++
 			continue
 		}
 
@@ -343,6 +367,59 @@ func inlineFormat(s string) string {
 		s = s[:start] + "<em>" + s[start+1:end] + "</em>" + s[end+1:]
 	}
 	return s
+}
+
+// checkboxPattern matches markdown task list items: - [ ], - [x], - [X].
+var checkboxPattern = regexp.MustCompile(`^(- \[)([ xX])(\] )`)
+
+// toggleCheckbox flips the checkbox at the given 0-based index in a markdown string.
+// Returns the modified content and an error if the index is out of range.
+func toggleCheckbox(content string, index int) (string, error) {
+	lines := strings.Split(content, "\n")
+	cbIdx := 0
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if checkboxPattern.MatchString(trimmed) {
+			if cbIdx == index {
+				// Find the bracket position in the original (untrimmed) line
+				pos := strings.Index(line, "- [")
+				if pos < 0 {
+					return "", fmt.Errorf("checkbox %d: bracket not found", index)
+				}
+				charPos := pos + 3 // position of the check character
+				if line[charPos] == ' ' {
+					line = line[:charPos] + "x" + line[charPos+1:]
+				} else {
+					line = line[:charPos] + " " + line[charPos+1:]
+				}
+				lines[i] = line
+				return strings.Join(lines, "\n"), nil
+			}
+			cbIdx++
+		}
+	}
+	return "", fmt.Errorf("checkbox index %d out of range (found %d)", index, cbIdx)
+}
+
+// CheckboxStats holds completion counts for task list items.
+type CheckboxStats struct {
+	Checked int
+	Total   int
+}
+
+// checkboxStats counts checked and total task list items in markdown content.
+func checkboxStats(content string) CheckboxStats {
+	var stats CheckboxStats
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if checkboxPattern.MatchString(trimmed) {
+			stats.Total++
+			if trimmed[3] != ' ' {
+				stats.Checked++
+			}
+		}
+	}
+	return stats
 }
 
 // executeQuery parses a search query and returns all matching entities from the graph.
@@ -445,6 +522,7 @@ func templateFuncs(styleMap map[string]map[string]string, styledTypes map[string
 		"add":            func(a, b int) int { return a + b },
 		"boolTrue":       func(b *bool) bool { return b != nil && *b },
 		"renderMarkdown": simpleMarkdownToHTML,
+		"checkboxStats":  checkboxStats,
 		"map": func(pairs ...interface{}) map[string]interface{} {
 			m := make(map[string]interface{}, len(pairs)/2)
 			for i := 0; i+1 < len(pairs); i += 2 {

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -390,6 +390,35 @@ func TestSimpleMarkdownToHTML(t *testing.T) {
 			"```mermaid\ngraph LR\n  A-->B",
 			"<pre class=\"mermaid\">\ngraph LR\n  A--&gt;B\n</pre>",
 		},
+		{
+			"unchecked checkbox",
+			"- [ ] task one",
+			`<ul class="task-list">` + "\n" + `<li class="task-item"><label><input type="checkbox" data-cb-idx="0"> task one</label></li>` + "\n" + `</ul>`,
+		},
+		{
+			"checked checkbox",
+			"- [x] done task",
+			`<ul class="task-list">` + "\n" + `<li class="task-item"><label><input type="checkbox" data-cb-idx="0" checked> done task</label></li>` + "\n" + `</ul>`,
+		},
+		{
+			"checked checkbox uppercase",
+			"- [X] done task",
+			`<ul class="task-list">` + "\n" + `<li class="task-item"><label><input type="checkbox" data-cb-idx="0" checked> done task</label></li>` + "\n" + `</ul>`,
+		},
+		{
+			"multiple checkboxes",
+			"- [ ] first\n- [x] second\n- [ ] third",
+			`<ul class="task-list">` + "\n" +
+				`<li class="task-item"><label><input type="checkbox" data-cb-idx="0"> first</label></li>` + "\n" +
+				`<li class="task-item"><label><input type="checkbox" data-cb-idx="1" checked> second</label></li>` + "\n" +
+				`<li class="task-item"><label><input type="checkbox" data-cb-idx="2"> third</label></li>` + "\n" +
+				`</ul>`,
+		},
+		{
+			"checkbox with bold",
+			"- [x] **bold** task",
+			`<ul class="task-list">` + "\n" + `<li class="task-item"><label><input type="checkbox" data-cb-idx="0" checked> <strong>bold</strong> task</label></li>` + "\n" + `</ul>`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -420,6 +449,103 @@ func TestInlineFormat(t *testing.T) {
 			got := inlineFormat(tt.input)
 			if got != tt.want {
 				t.Errorf("inlineFormat(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToggleCheckbox(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		index   int
+		want    string
+		wantErr bool
+	}{
+		{
+			"check unchecked",
+			"- [ ] task one",
+			0,
+			"- [x] task one",
+			false,
+		},
+		{
+			"uncheck checked",
+			"- [x] task one",
+			0,
+			"- [ ] task one",
+			false,
+		},
+		{
+			"uncheck uppercase",
+			"- [X] task one",
+			0,
+			"- [ ] task one",
+			false,
+		},
+		{
+			"toggle second of three",
+			"- [ ] first\n- [ ] second\n- [x] third",
+			1,
+			"- [ ] first\n- [x] second\n- [x] third",
+			false,
+		},
+		{
+			"index out of range",
+			"- [ ] only one",
+			1,
+			"",
+			true,
+		},
+		{
+			"no checkboxes",
+			"just text",
+			0,
+			"",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toggleCheckbox(tt.content, tt.index)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("toggleCheckbox(%q, %d)\n  got:  %q\n  want: %q", tt.content, tt.index, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckboxStats(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		checked int
+		total   int
+	}{
+		{"empty", "", 0, 0},
+		{"no checkboxes", "just text\n- list item", 0, 0},
+		{"one unchecked", "- [ ] task", 0, 1},
+		{"one checked", "- [x] task", 1, 1},
+		{"mixed", "- [ ] first\n- [x] second\n- [ ] third", 1, 3},
+		{"all checked", "- [x] a\n- [X] b", 2, 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := checkboxStats(tt.content)
+			if stats.Checked != tt.checked || stats.Total != tt.total {
+				t.Errorf("checkboxStats(%q) = {Checked:%d, Total:%d}, want {Checked:%d, Total:%d}",
+					tt.content, stats.Checked, stats.Total, tt.checked, tt.total)
 			}
 		})
 	}

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -33,6 +33,7 @@ func (a *App) NewRouter() http.Handler {
 	inner.HandleFunc("/api/create", a.handleCreate)
 	inner.HandleFunc("/api/update", a.handleUpdate)
 	inner.HandleFunc("/api/delete", a.handleDelete)
+	inner.HandleFunc("/api/toggle-checkbox", a.handleToggleCheckbox)
 	inner.HandleFunc("/api/inline-create", a.handleInlineCreate)
 	inner.HandleFunc("/api/inline-form/", a.handleInlineForm)
 	inner.HandleFunc("/api/link-candidates", a.handleLinkCandidates)

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -94,7 +94,7 @@ tbody tr:last-child td { border-bottom: none; }
 .btn-danger { background: #fff; color: var(--danger); border-color: var(--danger); }
 .btn-danger:hover { background: #fef2f2; }
 
-.form-card { padding: 28px; max-width: 640px; }
+.form-card { padding: 28px; max-width: 820px; }
 .form-desc { color: var(--text-muted); font-size: 13px; margin-bottom: 24px; }
 .form-group { margin-bottom: 20px; }
 .form-group label { display: block; font-size: 13px; font-weight: 600; margin-bottom: 6px; }
@@ -154,6 +154,12 @@ tbody tr:last-child td { border-bottom: none; }
 .EasyMDEContainer { border: 1px solid var(--border); border-radius: 6px; }
 .EasyMDEContainer .CodeMirror { border: none; border-radius: 0 0 6px 6px; font-family: var(--font-mono); font-size: 14px; }
 .EasyMDEContainer .editor-toolbar { border-bottom: 1px solid var(--border); border-radius: 6px 6px 0 0; }
+.EasyMDEContainer .editor-preview { padding: 12px 16px; }
+.EasyMDEContainer .editor-preview ul, .EasyMDEContainer .editor-preview ol { padding-left: 24px; }
+.EasyMDEContainer .editor-preview li { margin: 2px 0; }
+.EasyMDEContainer .editor-preview ul.contains-task-list { list-style: none; padding-left: 4px; }
+.EasyMDEContainer .editor-preview .task-list-item { display: flex; align-items: baseline; gap: 6px; }
+.EasyMDEContainer .editor-preview .task-list-item input[type="checkbox"] { margin: 0; position: relative; top: 1px; }
 
 /* Fullscreen editor mode */
 .editor-fullscreen-overlay { position: fixed; inset: 0; z-index: 300; background: var(--bg); display: flex; flex-direction: column; }
@@ -177,6 +183,11 @@ tbody tr:last-child td { border-bottom: none; }
 .markdown-body pre code { background: none; padding: 0; }
 .markdown-body strong { font-weight: 600; }
 .markdown-body em { font-style: italic; }
+.markdown-body ul.task-list { list-style: none; padding-left: 4px; }
+.markdown-body .task-item { margin: 4px 0; }
+.markdown-body .task-item label { display: flex; align-items: baseline; gap: 6px; cursor: pointer; }
+.markdown-body .task-item input[type="checkbox"] { cursor: pointer; margin: 0; position: relative; top: 1px; }
+.cb-stats { font-size: 13px; font-weight: 400; color: var(--text-muted); margin-left: 6px; }
 
 /* SlimSelect theme overrides */
 :root {
@@ -294,7 +305,7 @@ tbody tr.row-selected { background: #dbeafe; outline: 2px solid var(--primary); 
 
 /* ── Side panel (form context panel) ── */
 .main-with-panel { max-width: none; display: flex; align-items: stretch; min-height: 100vh; padding: 0; }
-.main-with-panel .form-column { flex: 0 1 640px; min-width: 0; padding: 32px; }
+.main-with-panel .form-column { flex: 0 1 820px; min-width: 0; padding: 32px; }
 .main-with-panel .form-column .form-card { max-width: none; }
 .side-panel { flex: 0 0 auto; width: min(420px, 30vw); min-width: 260px; margin-left: auto; background: #f1f5f9; border-left: 1px solid var(--border); padding: 32px 16px; overflow-y: auto; position: sticky; top: 0; height: 100vh; }
 .side-panel-section { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow); overflow: hidden; }
@@ -324,7 +335,7 @@ tbody tr.row-selected { background: #dbeafe; outline: 2px solid var(--primary); 
 .sp-card-meta { font-size: 12px; color: var(--text-muted); margin-top: 2px; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
 @media (max-width: 1100px) {
   .side-panel-edge-bar { display: flex; }
-  .main-with-panel .form-column { flex: 1; max-width: 640px; padding-right: 48px; }
+  .main-with-panel .form-column { flex: 1; max-width: 820px; padding-right: 48px; }
   .side-panel { position: fixed; top: 0; right: 0; bottom: 0; z-index: 200; max-width: 380px; width: 85vw; min-width: 0; border-radius: 0; border: none; border-left: 1px solid var(--border); padding: 0; overflow-y: auto; height: auto; transform: translateX(100%); transition: transform 0.25s ease; box-shadow: -4px 0 20px rgba(0,0,0,0.1); }
   .side-panel.open { transform: translateX(0); }
   .side-panel-header { display: flex; align-items: center; padding: 16px; border-bottom: 1px solid var(--border); background: #f1f5f9; }
@@ -359,6 +370,35 @@ if (typeof mermaid !== 'undefined') {
   document.addEventListener('DOMContentLoaded', function() { renderMermaid(); });
   document.addEventListener('htmx:afterSettle', function(e) { renderMermaid(e.detail.target); });
 }
+
+// Checkbox toggle enhancement
+function enhanceCheckboxes(root) {
+  (root || document).querySelectorAll('.markdown-body input[type="checkbox"][data-cb-idx]').forEach(function(cb) {
+    if (cb.dataset.enhanced) return;
+    cb.dataset.enhanced = 'true';
+    cb.addEventListener('change', function() {
+      var container = cb.closest('[data-entity-id]');
+      if (!container) return;
+      var body = new FormData();
+      body.append('entity_id', container.dataset.entityId);
+      body.append('index', cb.dataset.cbIdx);
+      fetch('/api/toggle-checkbox', { method: 'POST', body: body })
+        .then(function(r) { return r.text(); })
+        .then(function(html) {
+          var target = cb.closest('.markdown-body');
+          if (target) { target.innerHTML = html; enhanceCheckboxes(target); }
+          var stats = container.querySelector('.cb-stats');
+          if (stats) {
+            var checked = target.querySelectorAll('input[type="checkbox"]:checked').length;
+            var total = target.querySelectorAll('input[type="checkbox"][data-cb-idx]').length;
+            stats.textContent = checked + '/' + total;
+          }
+        });
+    });
+  });
+}
+document.addEventListener('DOMContentLoaded', function() { enhanceCheckboxes(); });
+document.addEventListener('htmx:afterSettle', function(e) { enhanceCheckboxes(e.detail.target); });
 
 // SlimSelect progressive enhancement
 function enhanceSelects(root) {
@@ -1953,7 +1993,21 @@ var _editorInstance = null;
       spellChecker: false,
       status: false,
       minHeight: '200px',
-      toolbar: ['bold', 'italic', 'heading', '|', 'unordered-list', 'ordered-list', '|', 'link', 'image', '|', 'preview', 'side-by-side', '|', {
+      toolbar: ['bold', 'italic', 'heading', '|', 'unordered-list', 'ordered-list', {
+        name: 'checklist',
+        action: function(editor) {
+          var cm = editor.codemirror;
+          var sel = cm.getSelection();
+          if (sel) {
+            cm.replaceSelection(sel.split('\n').map(function(l) { return '- [ ] ' + l; }).join('\n'));
+          } else {
+            cm.replaceSelection('- [ ] ');
+          }
+          cm.focus();
+        },
+        className: 'fa fa-check-square-o',
+        title: 'Checklist (Ctrl+Shift+L)',
+      }, '|', 'link', 'image', '|', 'preview', 'side-by-side', '|', {
         name: 'toggle-fullscreen-editor',
         action: toggleFullscreenEditor,
         className: 'fa fa-arrows-alt',
@@ -2180,7 +2234,7 @@ function closeSidePanel() {
 <div class="jump-bar">
   <a href="#properties" class="jump-link">Properties</a>
   {{ if .Relations }}<a href="#relations" class="jump-link">Relations ({{ len .Relations }})</a>{{ end }}
-  {{ if .Entity.Content }}<a href="#content" class="jump-link">Content</a>{{ end }}
+  {{ if .Entity.Content }}<a href="#content" class="jump-link">Content{{ with checkboxStats .Entity.Content }}{{ if gt .Total 0 }} ({{ .Checked }}/{{ .Total }}){{ end }}{{ end }}</a>{{ end }}
 </div>
 
 <div class="card" style="padding:24px;">
@@ -2218,8 +2272,8 @@ function closeSidePanel() {
 
   {{ if .Entity.Content }}
   <div id="entity-content" class="detail-section">
-    <h3>Content</h3>
-    <div class="markdown-body" style="padding:12px;background:#f8fafc;border-radius:6px;font-size:14px;">{{ renderMarkdown .Entity.Content }}</div>
+    <h3>Content{{ with checkboxStats .Entity.Content }}{{ if gt .Total 0 }} <span class="cb-stats">{{ .Checked }}/{{ .Total }}</span>{{ end }}{{ end }}</h3>
+    <div class="markdown-body" data-entity-id="{{ .Entity.ID }}" style="padding:12px;background:#f8fafc;border-radius:6px;font-size:14px;">{{ renderMarkdown .Entity.Content }}</div>
   </div>
   {{ end }}
 </div>


### PR DESCRIPTION
## Summary
- Render markdown task list items (`- [ ]` / `- [x]`) as interactive checkboxes in the data entry web UI
- Toggle checkboxes via `POST /api/toggle-checkbox` endpoint that persists state to markdown files
- Show completion stats (checked/total) in the Content heading and jump bar
- Add checklist toolbar button to EasyMDE editor
- Widen form area (640px → 820px) for better side-by-side preview

## Test plan
- [ ] Create/edit an entity with `- [ ] task` and `- [x] done` in the body
- [ ] Verify checkboxes render on the entity detail page
- [ ] Click checkboxes to toggle — verify state persists after page reload
- [ ] Check completion stats update in heading and jump bar
- [ ] Test the checklist toolbar button in the editor
- [ ] Verify EasyMDE side-by-side preview renders checkboxes