### PR TITLE
Fix fullscreen editor side-by-side preview layout

### DIFF
--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -163,6 +163,10 @@ tbody tr:last-child td { border-bottom: none; }
 .editor-fullscreen-overlay .EasyMDEContainer { flex: 1; display: flex; flex-direction: column; border: 1px solid var(--border); border-radius: 6px; }
 .editor-fullscreen-overlay .EasyMDEContainer .CodeMirror { flex: 1; }
 .editor-fullscreen-overlay .EasyMDEContainer .CodeMirror-scroll { min-height: 0; }
+.editor-fullscreen-overlay .EasyMDEContainer.sided--no-fullscreen { display: grid; grid-template-columns: 1fr 1fr; grid-template-rows: auto 1fr; }
+.editor-fullscreen-overlay .EasyMDEContainer.sided--no-fullscreen .editor-toolbar { grid-column: 1 / -1; }
+.editor-fullscreen-overlay .EasyMDEContainer.sided--no-fullscreen .CodeMirror { min-height: 0; width: 100% !important; }
+.editor-fullscreen-overlay .EasyMDEContainer.sided--no-fullscreen .editor-preview-active-side { overflow: auto; width: 100% !important; }
 
 .view-section-heading { font-size: 15px; font-weight: 700; color: var(--text); margin: 0 0 10px; padding-bottom: 6px; border-bottom: 2px solid var(--border); }
 .view-content-entity .markdown-body { font-size: 14px; line-height: 1.7; color: var(--text); }


### PR DESCRIPTION
## Summary
- Fix the EasyMDE side-by-side preview not working in the custom fullscreen editor overlay
- The overlay CSS forced `flex-direction: column` on the EasyMDE container, overriding the `flex-direction: row` needed for side-by-side layout
- Uses CSS Grid when both fullscreen overlay and side-by-side mode are active, giving the toolbar full width and splitting the editor/preview 50/50 below

## Test plan
- [ ] Open a form with the markdown body editor
- [ ] Enter fullscreen mode via the toolbar button
- [ ] Click the side-by-side button — editor and preview should display side by side
- [ ] Click the preview (eye) button — rendered preview should overlay the editor
- [ ] Exit fullscreen — editor returns to normal inline form
- [ ] Non-fullscreen side-by-side remains unaffected