### PR TITLE
Add natural sorting for human-friendly ID ordering

### DIFF
--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -39,6 +39,7 @@ var analyzeOrphansCmd = &cobra.Command{
 			return nil
 		}
 
+		filter.SortByID(orphans, false)
 		out.WriteWarning("Found %d orphan entities:", len(orphans))
 		return out.WriteEntities(orphans)
 	},

--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 var (
@@ -111,7 +112,7 @@ func exportEntities(entityType string) error {
 
 	// Sort by ID for consistent output
 	sort.Slice(entities, func(i, j int) bool {
-		return entities[i].ID < entities[j].ID
+		return natsort.Less(entities[i].ID, entities[j].ID)
 	})
 
 	if len(entities) == 0 {
@@ -147,20 +148,20 @@ func exportAllData() error {
 	// Sort entities by type, then ID
 	sort.Slice(allEntities, func(i, j int) bool {
 		if allEntities[i].Type != allEntities[j].Type {
-			return allEntities[i].Type < allEntities[j].Type
+			return natsort.Less(allEntities[i].Type, allEntities[j].Type)
 		}
-		return allEntities[i].ID < allEntities[j].ID
+		return natsort.Less(allEntities[i].ID, allEntities[j].ID)
 	})
 
 	// Sort edges by from, relation, to
 	sort.Slice(allEdges, func(i, j int) bool {
 		if allEdges[i].From != allEdges[j].From {
-			return allEdges[i].From < allEdges[j].From
+			return natsort.Less(allEdges[i].From, allEdges[j].From)
 		}
 		if allEdges[i].Type != allEdges[j].Type {
-			return allEdges[i].Type < allEdges[j].Type
+			return natsort.Less(allEdges[i].Type, allEdges[j].Type)
 		}
-		return allEdges[i].To < allEdges[j].To
+		return natsort.Less(allEdges[i].To, allEdges[j].To)
 	})
 
 	exportEntities := make([]ExportEntity, 0, len(allEntities))
@@ -346,7 +347,7 @@ func collectPropertyKeys(entities []*model.Entity) []string {
 	for k := range keySet {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	natsort.Strings(keys)
 
 	// Move common properties to the front
 	priority := []string{"title", "status", "description"}
@@ -392,7 +393,7 @@ func formatRelationsMap(m map[string][]RelationTarget) string {
 	for rt := range m {
 		relTypes = append(relTypes, rt)
 	}
-	sort.Strings(relTypes)
+	natsort.Strings(relTypes)
 
 	for _, rt := range relTypes {
 		targets := m[rt]

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 var (
@@ -643,7 +644,7 @@ func getSortedEntityNames(m *metamodel.Metamodel) []string {
 		names = append(names, name)
 	}
 	sort.Slice(names, func(i, j int) bool {
-		return m.Entities[names[i]].Label < m.Entities[names[j]].Label
+		return natsort.Less(m.Entities[names[i]].Label, m.Entities[names[j]].Label)
 	})
 	return names
 }
@@ -654,7 +655,7 @@ func getSortedRelationNames(m *metamodel.Metamodel) []string {
 		names = append(names, name)
 	}
 	sort.Slice(names, func(i, j int) bool {
-		return m.Relations[names[i]].Label < m.Relations[names[j]].Label
+		return natsort.Less(m.Relations[names[i]].Label, m.Relations[names[j]].Label)
 	})
 	return names
 }
@@ -664,7 +665,7 @@ func getSortedTypeNames(m *metamodel.Metamodel) []string {
 	for name := range m.Types {
 		names = append(names, name)
 	}
-	sort.Strings(names)
+	natsort.Strings(names)
 	return names
 }
 

--- a/internal/cli/template.go
+++ b/internal/cli/template.go
@@ -2,9 +2,10 @@ package cli
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/spf13/cobra"
+
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 var (
@@ -64,12 +65,12 @@ Examples:
 			if !templateRelations {
 				// Include entities (default or --entities flag)
 				entityTypes = meta.EntityTypes()
-				sort.Strings(entityTypes)
+				natsort.Strings(entityTypes)
 			}
 			if !templateEntities {
 				// Include relations (default or --relations flag)
 				relationTypes = meta.RelationTypes()
-				sort.Strings(relationTypes)
+				natsort.Strings(relationTypes)
 			}
 		}
 

--- a/internal/dataentry/analyze.go
+++ b/internal/dataentry/analyze.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // AnalysisIssue represents a single validation issue, optionally linked to an entity.
@@ -132,7 +133,7 @@ func (a *App) analyzeDuplicates() AnalysisSection {
 			titles = append(titles, title)
 		}
 	}
-	sort.Strings(titles)
+	natsort.Strings(titles)
 
 	for _, title := range titles {
 		group := titleGroups[title]
@@ -190,7 +191,7 @@ func (a *App) analyzeGaps() AnalysisSection {
 	for prefix := range prefixGroups {
 		prefixes = append(prefixes, prefix)
 	}
-	sort.Strings(prefixes)
+	natsort.Strings(prefixes)
 
 	for _, prefix := range prefixes {
 		numbers := prefixGroups[prefix]
@@ -227,7 +228,7 @@ func (a *App) analyzeCardinality() AnalysisSection {
 	for name := range a.meta.Relations {
 		relNames = append(relNames, name)
 	}
-	sort.Strings(relNames)
+	natsort.Strings(relNames)
 
 	for _, relName := range relNames {
 		relDef := a.meta.Relations[relName]
@@ -430,10 +431,10 @@ func countEdgesByType(edges []*model.Relation, relType string) int {
 	return n
 }
 
-// sortEntitiesByID sorts entities by their ID for deterministic output.
+// sortEntitiesByID sorts entities by their ID using natural ordering for deterministic output.
 func sortEntitiesByID(entities []*model.Entity) {
 	sort.Slice(entities, func(i, j int) bool {
-		return entities[i].ID < entities[j].ID
+		return natsort.Less(entities[i].ID, entities[j].ID)
 	})
 }
 

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/migration"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
 )
 
@@ -270,7 +270,7 @@ func (a *App) editFormForType(entityType string) string {
 	for id := range a.Cfg.Forms {
 		ids = append(ids, id)
 	}
-	sort.Strings(ids)
+	natsort.Strings(ids)
 	for _, id := range ids {
 		f := a.Cfg.Forms[id]
 		if f.EntityType == entityType && (f.Mode == "edit" || f.Mode == "") {
@@ -288,7 +288,7 @@ func (a *App) createFormForType(entityType string) string {
 	for id := range a.Cfg.Forms {
 		ids = append(ids, id)
 	}
-	sort.Strings(ids)
+	natsort.Strings(ids)
 	fallback := ""
 	for _, id := range ids {
 		f := a.Cfg.Forms[id]

--- a/internal/dataentry/commands.go
+++ b/internal/dataentry/commands.go
@@ -9,13 +9,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // Protocol prefix for structured command output messages.
@@ -44,7 +44,7 @@ func (a *App) resolveCommands(pageType, qualifier, entityType string) []Resolved
 	for id := range a.Cfg.Commands {
 		ids = append(ids, id)
 	}
-	sort.Strings(ids)
+	natsort.Strings(ids)
 
 	var result []ResolvedCommand
 	for _, id := range ids {

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 	"github.com/Sourcehaven-BV/rela/internal/tui/searchparser"
 )
 
@@ -588,7 +589,7 @@ func (a *App) handleEntity(w http.ResponseWriter, r *http.Request) {
 		for k := range e.Properties {
 			propKeys = append(propKeys, k)
 		}
-		sort.Strings(propKeys)
+		natsort.Strings(propKeys)
 		for _, k := range propKeys {
 			rd.Properties = append(rd.Properties, RelPropDisplay{k, fmt.Sprintf("%v", e.Properties[k])})
 		}
@@ -607,7 +608,7 @@ func (a *App) handleEntity(w http.ResponseWriter, r *http.Request) {
 		for k := range e.Properties {
 			propKeys = append(propKeys, k)
 		}
-		sort.Strings(propKeys)
+		natsort.Strings(propKeys)
 		for _, k := range propKeys {
 			rd.Properties = append(rd.Properties, RelPropDisplay{k, fmt.Sprintf("%v", e.Properties[k])})
 		}
@@ -620,7 +621,7 @@ func (a *App) handleEntity(w http.ResponseWriter, r *http.Request) {
 		for propName := range entDef.Properties {
 			propTypeKeys = append(propTypeKeys, propName)
 		}
-		sort.Strings(propTypeKeys)
+		natsort.Strings(propTypeKeys)
 		for _, propName := range propTypeKeys {
 			propTypes[propName] = entDef.Properties[propName].Type
 		}
@@ -1376,7 +1377,7 @@ func (a *App) handleSearch(w http.ResponseWriter, r *http.Request) {
 				for pn := range entDef.Properties {
 					propNames = append(propNames, pn)
 				}
-				sort.Strings(propNames)
+				natsort.Strings(propNames)
 				count := 0
 				for _, propName := range propNames {
 					if count >= 3 {
@@ -1569,8 +1570,8 @@ func (a *App) handleDashboard(w http.ResponseWriter, r *http.Request) {
 				}
 				groups[val]++
 			}
-			// Sort values alphabetically for consistent display
-			sort.Strings(orderedValues)
+			// Sort values in natural order for consistent display
+			natsort.Strings(orderedValues)
 			// Determine property type for badge styling
 			propType := ""
 			if len(entities) > 0 {
@@ -1740,7 +1741,7 @@ func (a *App) handleSettings(w http.ResponseWriter, r *http.Request) {
 	for name := range propMap {
 		propNames = append(propNames, name)
 	}
-	sort.Strings(propNames)
+	natsort.Strings(propNames)
 	allProperties := make([]PropertyInfo, 0, len(propNames))
 	for _, name := range propNames {
 		allProperties = append(allProperties, propMap[name])
@@ -1754,7 +1755,7 @@ func (a *App) handleSettings(w http.ResponseWriter, r *http.Request) {
 		Targets    []struct{ ID, Title string }
 	}
 	relNames := a.meta.RelationTypes()
-	sort.Strings(relNames)
+	natsort.Strings(relNames)
 	allRelations := make([]RelationInfo, 0, len(relNames))
 	for _, relName := range relNames {
 		relDef, ok := a.meta.GetRelationDef(relName)
@@ -1779,7 +1780,7 @@ func (a *App) handleSettings(w http.ResponseWriter, r *http.Request) {
 
 	// Entity types for override type selection.
 	entityTypes := a.meta.EntityTypes()
-	sort.Strings(entityTypes)
+	natsort.Strings(entityTypes)
 
 	activeList := "_settings"
 	data := map[string]interface{}{
@@ -1883,7 +1884,7 @@ func (a *App) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 	for idx := range idxSet {
 		indices = append(indices, idx)
 	}
-	sort.Strings(indices)
+	natsort.Strings(indices)
 
 	for _, idx := range indices {
 		types := overrideTypes[idx]

--- a/internal/dataentry/handlers_graph.go
+++ b/internal/dataentry/handlers_graph.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // handleGraph serves the full-page graph visualization.
@@ -127,7 +128,7 @@ func (a *App) buildContentGraphData() graphDataResponse {
 
 	// Collect entity types
 	entityTypes := a.meta.EntityTypes()
-	sort.Strings(entityTypes)
+	natsort.Strings(entityTypes)
 
 	etList := make([]graphEntityType, 0, len(entityTypes))
 	for i, et := range entityTypes {
@@ -176,7 +177,7 @@ func (a *App) buildContentGraphData() graphDataResponse {
 
 	// Collect relation types
 	relTypes := a.meta.RelationTypes()
-	sort.Strings(relTypes)
+	natsort.Strings(relTypes)
 	rtList := make([]graphRelationType, 0, len(relTypes))
 	for _, rt := range relTypes {
 		label := rt
@@ -200,7 +201,7 @@ func (a *App) buildContentGraphData() graphDataResponse {
 
 func (a *App) buildMetamodelGraphData() graphDataResponse {
 	entityTypes := a.meta.EntityTypes()
-	sort.Strings(entityTypes)
+	natsort.Strings(entityTypes)
 
 	etList := make([]graphEntityType, 0, len(entityTypes))
 	nodes := make([]graphNode, 0, len(entityTypes))
@@ -223,7 +224,7 @@ func (a *App) buildMetamodelGraphData() graphDataResponse {
 			for pn := range entDef.Properties {
 				propNames = append(propNames, pn)
 			}
-			sort.Strings(propNames)
+			natsort.Strings(propNames)
 			for _, pn := range propNames {
 				pd := entDef.Properties[pn]
 				props[pn] = pd.Type
@@ -242,7 +243,7 @@ func (a *App) buildMetamodelGraphData() graphDataResponse {
 
 	// Build edges from relation definitions (from-type → to-type)
 	relTypes := a.meta.RelationTypes()
-	sort.Strings(relTypes)
+	natsort.Strings(relTypes)
 
 	var edges []graphEdge
 	relTypeCounts := make(map[string]int)
@@ -296,7 +297,7 @@ func (a *App) buildMetaInfo(entityTypes, relTypes []string) graphMetaData {
 			for pn := range entDef.Properties {
 				propNames = append(propNames, pn)
 			}
-			sort.Strings(propNames)
+			natsort.Strings(propNames)
 			for _, pn := range propNames {
 				pd := entDef.Properties[pn]
 				me.Properties = append(me.Properties, graphMetaProperty{Name: pn, Type: pd.Type})

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 	"github.com/Sourcehaven-BV/rela/internal/tui/searchparser"
 )
 
@@ -470,7 +471,7 @@ func templateFuncs(styleMap map[string]map[string]string, styledTypes map[string
 			for k := range m {
 				keys = append(keys, k)
 			}
-			sort.Strings(keys)
+			natsort.Strings(keys)
 			return keys
 		},
 	}
@@ -554,7 +555,7 @@ func (a *App) resolveScope(currentEntityID string, r *http.Request) *ScopeNav {
 	case strings.HasPrefix(scope, "search:"):
 		query := strings.TrimPrefix(scope, "search:")
 		entities := a.executeQuery(query)
-		sort.Slice(entities, func(i, j int) bool { return entities[i].ID < entities[j].ID })
+		sort.Slice(entities, func(i, j int) bool { return natsort.Less(entities[i].ID, entities[j].ID) })
 		ids = make([]string, len(entities))
 		for i, e := range entities {
 			ids[i] = e.ID

--- a/internal/dataentry/validate.go
+++ b/internal/dataentry/validate.go
@@ -2,12 +2,12 @@ package dataentry
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // Valid top-level keys in data-entry.yaml
@@ -125,7 +125,7 @@ func ValidateConfig(data []byte, cfg *Config, meta *metamodel.Metamodel) error {
 	errs = append(errs, validateCrossReferences(cfg)...)
 
 	if len(errs) > 0 {
-		sort.Strings(errs)
+		natsort.Strings(errs)
 		return &ConfigValidationError{Errors: errs}
 	}
 	return nil
@@ -803,7 +803,7 @@ func sortedMapKeys[V any](m map[string]V) []string {
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	natsort.Strings(keys)
 	return keys
 }
 
@@ -814,6 +814,6 @@ func joinMapKeys(m map[string]bool) string {
 			keys = append(keys, k)
 		}
 	}
-	sort.Strings(keys)
+	natsort.Strings(keys)
 	return strings.Join(keys, ", ")
 }

--- a/internal/filter/sort.go
+++ b/internal/filter/sort.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // Sort sorts entities by a property with type-aware comparison.
@@ -119,10 +120,10 @@ func compareEnums(valI, valJ interface{}, enumIndex map[string]int) bool {
 	return sI < sJ
 }
 
-// SortByID sorts entities by their ID (default sort)
+// SortByID sorts entities by their ID using natural ordering (default sort)
 func SortByID(entities []*model.Entity, descending bool) {
 	sort.SliceStable(entities, func(i, j int) bool {
-		less := entities[i].ID < entities[j].ID
+		less := natsort.Less(entities[i].ID, entities[j].ID)
 		if descending {
 			return !less
 		}
@@ -130,14 +131,14 @@ func SortByID(entities []*model.Entity, descending bool) {
 	})
 }
 
-// compareStrings compares two values as strings
+// compareStrings compares two values as strings using natural ordering
 func compareStrings(valI, valJ interface{}) bool {
 	sI, okI := valI.(string)
 	sJ, okJ := valJ.(string)
 	if !okI || !okJ {
 		return false
 	}
-	return sI < sJ
+	return natsort.Less(sI, sJ)
 }
 
 // compareDates compares two values as dates.

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // Graph represents an in-memory graph of entities and relations
@@ -215,9 +216,9 @@ func (g *Graph) OutgoingEdges(id string) []*model.Relation {
 	copy(edges, g.outgoing[id])
 	sort.Slice(edges, func(i, j int) bool {
 		if edges[i].Type != edges[j].Type {
-			return edges[i].Type < edges[j].Type
+			return natsort.Less(edges[i].Type, edges[j].Type)
 		}
-		return edges[i].To < edges[j].To
+		return natsort.Less(edges[i].To, edges[j].To)
 	})
 	return edges
 }
@@ -230,9 +231,9 @@ func (g *Graph) IncomingEdges(id string) []*model.Relation {
 	copy(edges, g.incoming[id])
 	sort.Slice(edges, func(i, j int) bool {
 		if edges[i].Type != edges[j].Type {
-			return edges[i].Type < edges[j].Type
+			return natsort.Less(edges[i].Type, edges[j].Type)
 		}
-		return edges[i].From < edges[j].From
+		return natsort.Less(edges[i].From, edges[j].From)
 	})
 	return edges
 }
@@ -247,7 +248,7 @@ func (g *Graph) AllNodes() []*model.Entity {
 		nodes = append(nodes, node)
 	}
 	sort.Slice(nodes, func(i, j int) bool {
-		return nodes[i].ID < nodes[j].ID
+		return natsort.Less(nodes[i].ID, nodes[j].ID)
 	})
 	return nodes
 }
@@ -261,12 +262,12 @@ func (g *Graph) AllEdges() []*model.Relation {
 	copy(edges, g.edges)
 	sort.Slice(edges, func(i, j int) bool {
 		if edges[i].From != edges[j].From {
-			return edges[i].From < edges[j].From
+			return natsort.Less(edges[i].From, edges[j].From)
 		}
 		if edges[i].Type != edges[j].Type {
-			return edges[i].Type < edges[j].Type
+			return natsort.Less(edges[i].Type, edges[j].Type)
 		}
-		return edges[i].To < edges[j].To
+		return natsort.Less(edges[i].To, edges[j].To)
 	})
 	return edges
 }
@@ -283,7 +284,7 @@ func (g *Graph) NodesByType(entityType string) []*model.Entity {
 		}
 	}
 	sort.Slice(nodes, func(i, j int) bool {
-		return nodes[i].ID < nodes[j].ID
+		return natsort.Less(nodes[i].ID, nodes[j].ID)
 	})
 	return nodes
 }
@@ -311,7 +312,7 @@ func (g *Graph) AllIDs() []string {
 	for id := range g.nodes {
 		ids = append(ids, id)
 	}
-	sort.Strings(ids)
+	natsort.Strings(ids)
 	return ids
 }
 
@@ -326,7 +327,7 @@ func (g *Graph) IDsByType(entityType string) []string {
 			ids = append(ids, id)
 		}
 	}
-	sort.Strings(ids)
+	natsort.Strings(ids)
 	return ids
 }
 
@@ -379,16 +380,13 @@ func (g *Graph) GetPropertyValues(propertyName string, limit int) []string {
 		sorted = append(sorted, valueCount{value: val, count: count})
 	}
 
-	// Sort by count descending, then by value alphabetically
-	for i := 0; i < len(sorted); i++ {
-		for j := i + 1; j < len(sorted); j++ {
-			if sorted[j].count > sorted[i].count ||
-				(sorted[j].count == sorted[i].count && sorted[j].value < sorted[i].value) {
-
-				sorted[i], sorted[j] = sorted[j], sorted[i]
-			}
+	// Sort by count descending, then by value in natural order
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].count != sorted[j].count {
+			return sorted[i].count > sorted[j].count
 		}
-	}
+		return natsort.Less(sorted[i].value, sorted[j].value)
+	})
 
 	// Extract values up to limit
 	result := make([]string, 0, limit)

--- a/internal/markdown/template.go
+++ b/internal/markdown/template.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 )
 
@@ -140,7 +140,7 @@ func (f *FileIO) GenerateEntityTemplate(
 	for name := range entityDef.Properties {
 		propNames = append(propNames, name)
 	}
-	sort.Strings(propNames)
+	natsort.Strings(propNames)
 
 	// Add properties with defaults or empty values
 	for _, name := range propNames {

--- a/internal/mcp/convert.go
+++ b/internal/mcp/convert.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // entityJSON represents an entity for JSON output in MCP responses.
@@ -202,23 +203,23 @@ func convertRelationsList(relations []*model.Relation) (string, error) {
 	return marshalJSON(result)
 }
 
-// sortEntitiesByID sorts entities by ID for consistent output.
+// sortEntitiesByID sorts entities by ID using natural ordering for consistent output.
 func sortEntitiesByID(entities []*model.Entity) {
 	sort.Slice(entities, func(i, j int) bool {
-		return entities[i].ID < entities[j].ID
+		return natsort.Less(entities[i].ID, entities[j].ID)
 	})
 }
 
-// sortRelations sorts relations for consistent output.
+// sortRelations sorts relations using natural ordering for consistent output.
 func sortRelations(relations []*model.Relation) {
 	sort.Slice(relations, func(i, j int) bool {
 		if relations[i].From != relations[j].From {
-			return relations[i].From < relations[j].From
+			return natsort.Less(relations[i].From, relations[j].From)
 		}
 		if relations[i].Type != relations[j].Type {
-			return relations[i].Type < relations[j].Type
+			return natsort.Less(relations[i].Type, relations[j].Type)
 		}
-		return relations[i].To < relations[j].To
+		return natsort.Less(relations[i].To, relations[j].To)
 	})
 }
 

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -4,12 +4,12 @@ package mcp
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 func (s *Server) registerPrompts() {
@@ -147,7 +147,7 @@ func (s *Server) handleReviewOrphansPrompt(
 	// Get available relation types
 	meta := s.getMeta()
 	relTypes := meta.RelationTypes()
-	sort.Strings(relTypes)
+	natsort.Strings(relTypes)
 	var relInfo strings.Builder
 	for _, name := range relTypes {
 		def, _ := meta.GetRelationDef(name)
@@ -192,7 +192,7 @@ func (s *Server) handleSummarizeProjectPrompt(
 	// Entity counts by type
 	meta := s.getMeta()
 	entityTypes := meta.EntityTypes()
-	sort.Strings(entityTypes)
+	natsort.Strings(entityTypes)
 	var entityCounts strings.Builder
 	totalEntities := 0
 	for _, t := range entityTypes {
@@ -208,7 +208,7 @@ func (s *Server) handleSummarizeProjectPrompt(
 
 	// Relation counts by type
 	relTypes := meta.RelationTypes()
-	sort.Strings(relTypes)
+	natsort.Strings(relTypes)
 	var relCounts strings.Builder
 	totalRelations := 0
 	for _, t := range relTypes {

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -4,11 +4,11 @@ package mcp
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 	"github.com/Sourcehaven-BV/rela/internal/views"
 )
 
@@ -143,7 +143,7 @@ func (s *Server) handleReadView(
 	viewDef, ok := viewsFile.GetView(viewName)
 	if !ok {
 		names := viewsFile.ViewNames()
-		sort.Strings(names)
+		natsort.Strings(names)
 		return nil, fmt.Errorf("view not found: %s (available: %s)", viewName, strings.Join(names, ", "))
 	}
 

--- a/internal/mcp/tools_export.go
+++ b/internal/mcp/tools_export.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 func (s *Server) handleRefresh(
@@ -181,7 +181,7 @@ func (s *Server) exportCSV(entities []*model.Entity) (*mcp.CallToolResult, error
 	for k := range keySet {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	natsort.Strings(keys)
 
 	// Build CSV
 	var buf strings.Builder

--- a/internal/mcp/tools_schema.go
+++ b/internal/mcp/tools_schema.go
@@ -3,11 +3,11 @@ package mcp
 
 import (
 	"context"
-	"sort"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 func (s *Server) handleGetMetamodel(
@@ -46,7 +46,7 @@ func (s *Server) handleListEntityTypes(
 
 	meta := s.getMeta()
 	types := meta.EntityTypes()
-	sort.Strings(types)
+	natsort.Strings(types)
 
 	result := make([]entityTypeInfo, 0, len(types))
 	for _, name := range types {
@@ -86,7 +86,7 @@ func (s *Server) handleListRelationTypes(
 
 	meta := s.getMeta()
 	types := meta.RelationTypes()
-	sort.Strings(types)
+	natsort.Strings(types)
 
 	result := make([]relationTypeInfo, 0, len(types))
 	for _, name := range types {

--- a/internal/mcp/tools_views.go
+++ b/internal/mcp/tools_views.go
@@ -4,11 +4,11 @@ package mcp
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 	"github.com/Sourcehaven-BV/rela/internal/views"
 )
 
@@ -21,7 +21,7 @@ func (s *Server) handleListViews(
 	}
 
 	names := viewsFile.ViewNames()
-	sort.Strings(names)
+	natsort.Strings(names)
 
 	if len(names) == 0 {
 		return mcp.NewToolResultText("No views defined (views.yaml not found or empty)"), nil
@@ -73,7 +73,7 @@ func (s *Server) handleExecuteView(
 	viewDef, ok := viewsFile.GetView(viewName)
 	if !ok {
 		names := viewsFile.ViewNames()
-		sort.Strings(names)
+		natsort.Strings(names)
 		return mcp.NewToolResultError(
 			fmt.Sprintf("view not found: %s (available: %s)", viewName, strings.Join(names, ", "))), nil
 	}

--- a/internal/natsort/natsort.go
+++ b/internal/natsort/natsort.go
@@ -1,0 +1,166 @@
+// Package natsort provides natural sorting for strings containing numbers.
+// It splits strings into text and numeric chunks and compares them so that
+// embedded numbers are compared numerically rather than lexicographically.
+// For example, "REQ-2" sorts before "REQ-10".
+package natsort
+
+import "sort"
+
+// Compare returns -1, 0, or +1 comparing a and b using natural ordering.
+// Text is compared case-insensitively with case used only as a final tiebreaker.
+func Compare(a, b string) int {
+	ia, ib := 0, 0
+	la, lb := len(a), len(b)
+	caseTiebreak := 0 // first case difference found (used only if otherwise equal)
+
+	for ia < la && ib < lb {
+		ca, cb := a[ia], b[ib]
+		isDigitA := isDigit(ca)
+		isDigitB := isDigit(cb)
+
+		switch {
+		case isDigitA && isDigitB:
+			if c := compareNumChunks(a, b, &ia, &ib, la, lb); c != 0 {
+				return c
+			}
+		case !isDigitA && !isDigitB:
+			if c := compareTextChar(ca, cb); c != 0 {
+				return c
+			}
+			if caseTiebreak == 0 {
+				caseTiebreak = caseDiff(ca, cb)
+			}
+			ia++
+			ib++
+		default:
+			return digitVsText(isDigitA)
+		}
+	}
+
+	return compareRemaining(la-ia, lb-ib, caseTiebreak)
+}
+
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }
+
+// compareTextChar compares two non-digit characters case-insensitively.
+// Returns -1, 0, or 1.
+func compareTextChar(ca, cb byte) int {
+	lowA := toLower(ca)
+	lowB := toLower(cb)
+	if lowA < lowB {
+		return -1
+	}
+	if lowA > lowB {
+		return 1
+	}
+	return 0
+}
+
+// caseDiff returns the case tiebreak for two characters that are equal
+// case-insensitively. Returns -1, 0, or 1.
+func caseDiff(ca, cb byte) int {
+	if ca < cb {
+		return -1
+	}
+	if ca > cb {
+		return 1
+	}
+	return 0
+}
+
+// digitVsText returns -1 if a digit should sort before text, or 1 otherwise.
+func digitVsText(aIsDigit bool) int {
+	if aIsDigit {
+		return -1
+	}
+	return 1
+}
+
+// compareRemaining handles the tail comparison when one or both strings are exhausted.
+func compareRemaining(remA, remB, caseTiebreak int) int {
+	if remA < remB {
+		return -1
+	}
+	if remA > remB {
+		return 1
+	}
+	return caseTiebreak
+}
+
+// compareNumChunks compares two numeric chunks starting at positions ia and ib.
+// It advances both pointers past the numeric chunks.
+func compareNumChunks(a, b string, ia, ib *int, la, lb int) int {
+	leadingZerosA := skipZeros(a, ia, la)
+	leadingZerosB := skipZeros(b, ib, lb)
+
+	// Find end of numeric part (significant digits)
+	sigStartA, sigLenA := scanDigits(a, *ia, la)
+	*ia = sigStartA + sigLenA
+	sigStartB, sigLenB := scanDigits(b, *ib, lb)
+	*ib = sigStartB + sigLenB
+
+	// Different number of significant digits means different magnitude
+	if sigLenA != sigLenB {
+		if sigLenA < sigLenB {
+			return -1
+		}
+		return 1
+	}
+
+	// Same length — compare digit by digit
+	for k := 0; k < sigLenA; k++ {
+		if a[sigStartA+k] != b[sigStartB+k] {
+			if a[sigStartA+k] < b[sigStartB+k] {
+				return -1
+			}
+			return 1
+		}
+	}
+
+	// Numerically equal — fewer leading zeros first
+	if leadingZerosA != leadingZerosB {
+		if leadingZerosA < leadingZerosB {
+			return -1
+		}
+		return 1
+	}
+
+	return 0
+}
+
+// skipZeros advances *pos past leading '0' digits and returns how many were skipped.
+func skipZeros(s string, pos *int, length int) int {
+	start := *pos
+	for *pos < length && s[*pos] == '0' {
+		*pos++
+	}
+	return *pos - start
+}
+
+// scanDigits returns the start position and count of consecutive digit characters.
+func scanDigits(s string, start, length int) (pos, count int) {
+	i := start
+	for i < length && isDigit(s[i]) {
+		i++
+	}
+	return start, i - start
+}
+
+func toLower(c byte) byte {
+	if c >= 'A' && c <= 'Z' {
+		return c + ('a' - 'A')
+	}
+	return c
+}
+
+// Less reports whether a should sort before b using natural ordering.
+func Less(a, b string) bool {
+	return Compare(a, b) < 0
+}
+
+// Strings sorts a slice of strings in natural order.
+func Strings(s []string) {
+	sort.Slice(s, func(i, j int) bool {
+		return Compare(s[i], s[j]) < 0
+	})
+}

--- a/internal/natsort/natsort_test.go
+++ b/internal/natsort/natsort_test.go
@@ -1,0 +1,325 @@
+package natsort
+
+import (
+	"testing"
+)
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		// Equal strings
+		{"", "", 0},
+		{"abc", "abc", 0},
+		{"123", "123", 0},
+
+		// Pure text (case-insensitive)
+		{"abc", "def", -1},
+		{"def", "abc", 1},
+		{"abc", "ABC", 1},  // lowercase after uppercase for same letters
+		{"ABC", "abc", -1}, // uppercase before lowercase
+
+		// Pure numbers
+		{"1", "2", -1},
+		{"2", "1", 1},
+		{"9", "10", -1},
+		{"10", "9", 1},
+		{"100", "99", 1},
+
+		// Prefix with numbers — the core use case
+		{"REQ-1", "REQ-2", -1},
+		{"REQ-2", "REQ-10", -1},
+		{"REQ-10", "REQ-2", 1},
+		{"REQ-9", "REQ-10", -1},
+		{"REQ-10", "REQ-11", -1},
+		{"REQ-1", "REQ-1", 0},
+
+		// Different prefixes
+		{"COMP-1", "REQ-1", -1},
+		{"REQ-1", "COMP-1", 1},
+
+		// Multiple number segments
+		{"a1b2", "a1b10", -1},
+		{"a1b10", "a1b2", 1},
+		{"v1.2.3", "v1.10.1", -1},
+		{"v1.10.1", "v1.2.3", 1},
+		{"v2.0.0", "v10.0.0", -1},
+
+		// Leading zeros
+		{"REQ-01", "REQ-1", 1},  // "01" has a leading zero, "1" does not
+		{"REQ-1", "REQ-01", -1}, // fewer leading zeros first
+		{"REQ-001", "REQ-01", 1},
+		{"REQ-001", "REQ-1", 1},
+
+		// Numerically equal with different zero padding
+		{"001", "1", 1},
+		{"01", "1", 1},
+		{"00", "0", 1},
+
+		// Empty vs non-empty
+		{"", "a", -1},
+		{"a", "", 1},
+		{"", "1", -1},
+
+		// Digits vs text at same position
+		{"a1", "ab", -1}, // digit sorts before text
+		{"ab", "a1", 1},
+
+		// Length differences
+		{"abc", "abcd", -1},
+		{"abcd", "abc", 1},
+
+		// Real-world IDs
+		{"COMP-1", "COMP-2", -1},
+		{"COMP-2", "COMP-10", -1},
+		{"DEC-1", "DEC-100", -1},
+		{"SOL-9", "SOL-10", -1},
+		{"SOL-10", "SOL-100", -1},
+
+		// Case insensitivity for text parts
+		{"req-1", "REQ-2", -1},
+		{"REQ-1", "req-2", -1},
+
+		// All zeros
+		{"0", "0", 0},
+		{"00", "00", 0},
+		{"0", "1", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			got := Compare(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("Compare(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLess(t *testing.T) {
+	if !Less("REQ-2", "REQ-10") {
+		t.Error("Less(REQ-2, REQ-10) should be true")
+	}
+	if Less("REQ-10", "REQ-2") {
+		t.Error("Less(REQ-10, REQ-2) should be false")
+	}
+	if Less("REQ-1", "REQ-1") {
+		t.Error("Less(REQ-1, REQ-1) should be false")
+	}
+}
+
+func TestStrings(t *testing.T) {
+	input := []string{
+		"REQ-1", "REQ-10", "REQ-2", "REQ-20", "REQ-3", "REQ-11",
+	}
+	want := []string{
+		"REQ-1", "REQ-2", "REQ-3", "REQ-10", "REQ-11", "REQ-20",
+	}
+
+	Strings(input)
+
+	for i, got := range input {
+		if got != want[i] {
+			t.Errorf("Strings()[%d] = %q, want %q", i, got, want[i])
+		}
+	}
+}
+
+func TestStrings_MixedTypes(t *testing.T) {
+	input := []string{
+		"COMP-10", "REQ-2", "COMP-2", "REQ-1", "COMP-1", "REQ-10",
+	}
+	want := []string{
+		"COMP-1", "COMP-2", "COMP-10", "REQ-1", "REQ-2", "REQ-10",
+	}
+
+	Strings(input)
+
+	for i, got := range input {
+		if got != want[i] {
+			t.Errorf("Strings()[%d] = %q, want %q", i, got, want[i])
+		}
+	}
+}
+
+func TestStrings_Versions(t *testing.T) {
+	input := []string{"v1.10.0", "v1.2.0", "v1.1.0", "v2.0.0", "v1.9.0"}
+	want := []string{"v1.1.0", "v1.2.0", "v1.9.0", "v1.10.0", "v2.0.0"}
+
+	Strings(input)
+
+	for i, got := range input {
+		if got != want[i] {
+			t.Errorf("Strings()[%d] = %q, want %q", i, got, want[i])
+		}
+	}
+}
+
+func TestStrings_Empty(_ *testing.T) {
+	var input []string
+	Strings(input) // should not panic
+}
+
+func TestStrings_Single(t *testing.T) {
+	input := []string{"one"}
+	Strings(input)
+	if input[0] != "one" {
+		t.Errorf("single element changed: %q", input[0])
+	}
+}
+
+func TestCompare_Symmetry(t *testing.T) {
+	pairs := [][2]string{
+		{"REQ-1", "REQ-2"},
+		{"a", "b"},
+		{"1", "2"},
+		{"v1.2", "v1.10"},
+		{"", "a"},
+	}
+	for _, p := range pairs {
+		ab := Compare(p[0], p[1])
+		ba := Compare(p[1], p[0])
+		if ab != -ba {
+			t.Errorf("Compare(%q,%q)=%d but Compare(%q,%q)=%d (not symmetric)",
+				p[0], p[1], ab, p[1], p[0], ba)
+		}
+	}
+}
+
+func TestCompare_Transitivity(t *testing.T) {
+	// If a < b and b < c, then a < c
+	triples := [][3]string{
+		{"REQ-1", "REQ-2", "REQ-10"},
+		{"a", "b", "c"},
+		{"COMP-1", "COMP-10", "REQ-1"},
+	}
+	for _, tr := range triples {
+		ab := Compare(tr[0], tr[1])
+		bc := Compare(tr[1], tr[2])
+		ac := Compare(tr[0], tr[2])
+		if ab < 0 && bc < 0 && ac >= 0 {
+			t.Errorf("transitivity violated: %q < %q < %q but Compare(%q,%q)=%d",
+				tr[0], tr[1], tr[2], tr[0], tr[2], ac)
+		}
+	}
+}
+
+func FuzzCompare(f *testing.F) {
+	f.Add("REQ-1", "REQ-10")
+	f.Add("", "")
+	f.Add("abc", "def")
+	f.Add("123", "456")
+	f.Add("a1b2c3", "a1b2c4")
+	f.Add("ABC", "abc")
+	f.Add("00", "0")
+	f.Add("a", "1")
+
+	f.Fuzz(func(t *testing.T, a, b string) {
+		ab := Compare(a, b)
+		ba := Compare(b, a)
+
+		// Antisymmetry: Compare(a,b) == -Compare(b,a)
+		if ab != -ba {
+			t.Errorf("antisymmetry: Compare(%q,%q)=%d, Compare(%q,%q)=%d",
+				a, b, ab, b, a, ba)
+		}
+
+		// Reflexivity: Compare(a,a) == 0
+		if Compare(a, a) != 0 {
+			t.Errorf("reflexivity: Compare(%q,%q)=%d", a, a, Compare(a, a))
+		}
+
+		// Consistency: result is always -1, 0, or 1
+		if ab < -1 || ab > 1 {
+			t.Errorf("Compare(%q,%q) = %d, want -1/0/1", a, b, ab)
+		}
+	})
+}
+
+func FuzzTransitivity(f *testing.F) {
+	f.Add("REQ-1", "REQ-2", "REQ-10")
+	f.Add("a", "b", "c")
+	f.Add("1", "2", "10")
+	f.Add("COMP-1", "COMP-10", "REQ-1")
+	f.Add("", "a", "b")
+	f.Add("A", "a", "B")
+	f.Add("01", "1", "2")
+	f.Add("v1.2", "v1.10", "v2.0")
+
+	f.Fuzz(func(t *testing.T, a, b, c string) {
+		ab := Compare(a, b)
+		bc := Compare(b, c)
+		ac := Compare(a, c)
+
+		// Transitivity: if a <= b and b <= c, then a <= c
+		if ab <= 0 && bc <= 0 && ac > 0 {
+			t.Errorf("transitivity violated: Compare(%q,%q)=%d, Compare(%q,%q)=%d, Compare(%q,%q)=%d",
+				a, b, ab, b, c, bc, a, c, ac)
+		}
+
+		// Reverse transitivity: if a >= b and b >= c, then a >= c
+		if ab >= 0 && bc >= 0 && ac < 0 {
+			t.Errorf("reverse transitivity violated: Compare(%q,%q)=%d, Compare(%q,%q)=%d, Compare(%q,%q)=%d",
+				a, b, ab, b, c, bc, a, c, ac)
+		}
+	})
+}
+
+func FuzzSortIdempotent(f *testing.F) {
+	f.Add("REQ-10,REQ-2,REQ-1")
+	f.Add("a,b,c")
+	f.Add("10,2,1,20,3")
+	f.Add("COMP-1,REQ-2,COMP-10,REQ-1")
+	f.Add(",a,")
+	f.Add("ABC,abc,Abc")
+
+	f.Fuzz(func(t *testing.T, csv string) {
+		if len(csv) > 500 {
+			return // bound input size
+		}
+
+		items := splitNonEmpty(csv)
+		if len(items) < 2 {
+			return
+		}
+
+		// Sort once
+		s1 := make([]string, len(items))
+		copy(s1, items)
+		Strings(s1)
+
+		// Verify sorted: every adjacent pair should satisfy Compare <= 0
+		for i := 1; i < len(s1); i++ {
+			if Compare(s1[i-1], s1[i]) > 0 {
+				t.Errorf("not sorted at [%d]: %q > %q (input: %v)", i, s1[i-1], s1[i], items)
+			}
+		}
+
+		// Sort again — should be idempotent
+		s2 := make([]string, len(s1))
+		copy(s2, s1)
+		Strings(s2)
+		for i := range s1 {
+			if s1[i] != s2[i] {
+				t.Errorf("not idempotent at [%d]: %q vs %q", i, s1[i], s2[i])
+			}
+		}
+	})
+}
+
+// splitNonEmpty splits a comma-separated string, keeping empty elements.
+func splitNonEmpty(s string) []string {
+	if s == "" {
+		return nil
+	}
+	result := []string{}
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == ',' {
+			result = append(result, s[start:i])
+			start = i + 1
+		}
+	}
+	return result
+}

--- a/internal/tui/analysis.go
+++ b/internal/tui/analysis.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
@@ -129,6 +130,7 @@ func (a *AnalysisModel) runCheck(app *App, check string) {
 
 func (a *AnalysisModel) runOrphans(app *App) {
 	orphans := app.graph.FindOrphans()
+	filter.SortByID(orphans, false)
 
 	if len(orphans) == 0 {
 		a.results = append(a.results, analysisResult{

--- a/internal/tui/browser.go
+++ b/internal/tui/browser.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // BrowserLevel represents the navigation level in the browser
@@ -59,7 +60,7 @@ func (b *BrowserModel) loadTypes(app *App) {
 	}
 	// Sort by label
 	sort.Slice(b.types, func(i, j int) bool {
-		return b.types[i].label < b.types[j].label
+		return natsort.Less(b.types[i].label, b.types[j].label)
 	})
 }
 
@@ -67,7 +68,7 @@ func (b *BrowserModel) loadEntities(app *App, typeName string) {
 	b.entities = app.graph.NodesByType(typeName)
 	// Sort by ID
 	sort.Slice(b.entities, func(i, j int) bool {
-		return b.entities[i].ID < b.entities[j].ID
+		return natsort.Less(b.entities[i].ID, b.entities[j].ID)
 	})
 	b.selectedType = typeName
 }

--- a/internal/tui/create.go
+++ b/internal/tui/create.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/markdown"
 	mdmodel "github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // propertyInput represents a required property being filled in
@@ -55,7 +56,7 @@ func (c *CreateModel) loadTypes(app *App) {
 		})
 	}
 	sort.Slice(c.types, func(i, j int) bool {
-		return c.types[i].label < c.types[j].label
+		return natsort.Less(c.types[i].label, c.types[j].label)
 	})
 
 	// Preselect type if set

--- a/internal/tui/link.go
+++ b/internal/tui/link.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/markdown"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // LinkStep represents the current step in link creation
@@ -74,7 +75,7 @@ func (l *LinkModel) loadRelations(app *App) {
 	}
 
 	sort.Slice(l.relations, func(i, j int) bool {
-		return l.relations[i].label < l.relations[j].label
+		return natsort.Less(l.relations[i].label, l.relations[j].label)
 	})
 }
 
@@ -99,7 +100,7 @@ func (l *LinkModel) loadTargets(app *App) {
 	}
 
 	sort.Slice(l.targets, func(i, j int) bool {
-		return l.targets[i].ID < l.targets[j].ID
+		return natsort.Less(l.targets[i].ID, l.targets[j].ID)
 	})
 
 	l.filteredList = l.targets

--- a/internal/tui/metamodel.go
+++ b/internal/tui/metamodel.go
@@ -9,6 +9,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // MetamodelTab represents the active tab
@@ -66,7 +68,7 @@ func (m *MetamodelModel) load(app *App) {
 			}
 			props = append(props, fmt.Sprintf("%s%s: %s", propName, required, propDef.Type))
 		}
-		sort.Strings(props)
+		natsort.Strings(props)
 
 		m.entityTypes = append(m.entityTypes, entityTypeInfo{
 			name:       name,
@@ -77,7 +79,7 @@ func (m *MetamodelModel) load(app *App) {
 		})
 	}
 	sort.Slice(m.entityTypes, func(i, j int) bool {
-		return m.entityTypes[i].label < m.entityTypes[j].label
+		return natsort.Less(m.entityTypes[i].label, m.entityTypes[j].label)
 	})
 
 	// Load relations
@@ -98,7 +100,7 @@ func (m *MetamodelModel) load(app *App) {
 		})
 	}
 	sort.Slice(m.relations, func(i, j int) bool {
-		return m.relations[i].label < m.relations[j].label
+		return natsort.Less(m.relations[i].label, m.relations[j].label)
 	})
 }
 

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 	"github.com/Sourcehaven-BV/rela/internal/tui/searchparser"
 )
 
@@ -97,7 +98,7 @@ func (s *SearchModel) getPropertyValueSuggestions(app *App, propertyName, prefix
 			if sorted[i].count != sorted[j].count {
 				return sorted[i].count > sorted[j].count // Higher count first
 			}
-			return sorted[i].val < sorted[j].val // Alphabetical for same count
+			return natsort.Less(sorted[i].val, sorted[j].val) // Natural order for same count
 		})
 
 		// Take top N suggestions
@@ -206,7 +207,7 @@ func (s *SearchModel) updateSuggestions(app *App) {
 				s.suggestions = append(s.suggestions, propName)
 			}
 		}
-		sort.Strings(s.suggestions)
+		natsort.Strings(s.suggestions)
 		s.showSuggestions = len(s.suggestions) > 0
 
 	case "sortdir":

--- a/internal/tui/templates.go
+++ b/internal/tui/templates.go
@@ -10,6 +10,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // TemplatesDir is the directory name for templates
@@ -65,7 +67,7 @@ func (t *TemplatesModel) load(app *App) {
 	for typeName := range app.metamodel.Entities {
 		t.entityTypes = append(t.entityTypes, typeName)
 	}
-	sort.Strings(t.entityTypes)
+	natsort.Strings(t.entityTypes)
 
 	// Load templates
 	t.templates = nil
@@ -116,9 +118,9 @@ func (t *TemplatesModel) load(app *App) {
 	// Sort templates by entity type then name
 	sort.Slice(t.templates, func(i, j int) bool {
 		if t.templates[i].EntityType != t.templates[j].EntityType {
-			return t.templates[i].EntityType < t.templates[j].EntityType
+			return natsort.Less(t.templates[i].EntityType, t.templates[j].EntityType)
 		}
-		return t.templates[i].Name < t.templates[j].Name
+		return natsort.Less(t.templates[i].Name, t.templates[j].Name)
 	})
 }
 

--- a/internal/views/affected.go
+++ b/internal/views/affected.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // AffectedRoots finds which root entities are affected by changes to the given entity IDs.
@@ -38,7 +39,7 @@ func (e *Engine) AffectedRoots(view ViewDef, changedIDs, rootIDs []string) ([]*m
 	}
 
 	sort.Slice(affected, func(i, j int) bool {
-		return affected[i].ID < affected[j].ID
+		return natsort.Less(affected[i].ID, affected[j].ID)
 	})
 
 	return affected, nil

--- a/internal/views/deps.go
+++ b/internal/views/deps.go
@@ -1,7 +1,7 @@
 package views
 
 import (
-	"sort"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // CollectDeps executes a view for each root and returns all unique entity IDs touched.
@@ -48,7 +48,7 @@ func (e *Engine) CollectDeps(view ViewDef, rootIDs []string) ([]string, error) {
 	for id := range seen {
 		ids = append(ids, id)
 	}
-	sort.Strings(ids)
+	natsort.Strings(ids)
 
 	return ids, nil
 }


### PR DESCRIPTION
## Summary
- Introduce `internal/natsort` package with `Compare`, `Less`, and `Strings` functions for natural string sorting (REQ-2 before REQ-10)
- Replace all lexicographic sorting across 29 files (~60 sort sites) with natural sort: graph, CLI, TUI, MCP, data entry, views, export, and markdown templates
- Fix unsorted orphan analysis output in CLI (`analyze orphans`) and TUI by adding `filter.SortByID` calls
- Add comprehensive tests (49 table-driven cases) and 3 fuzz targets (antisymmetry, transitivity, sort idempotency) verified with ~8.5M random inputs

## Test plan
- [x] Unit tests pass (`go test ./...`)
- [x] Fuzz tests pass (30s each, ~8.5M inputs)
- [x] Linter passes (`golangci-lint run`)
- [x] Manual QA: verified `rela list`, `rela export --format json/csv`, `rela analyze orphans/gaps` all produce natural sort order