### PR TITLE
Add fuzzy search with OR logic and relevance ranking

### DIFF
--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -1596,7 +1596,10 @@ func (a *App) handleSearch(w http.ResponseWriter, r *http.Request) {
 
 	if !sq.IsEmpty() {
 		entities := a.executeQuery(query)
-		sort.Slice(entities, func(i, j int) bool { return entities[i].ID < entities[j].ID })
+		// Only sort by ID when there's no free-text query (preserve relevance ranking)
+		if !sq.HasFreeText() && !sq.HasSort() {
+			sort.Slice(entities, func(i, j int) bool { return entities[i].ID < entities[j].ID })
+		}
 		const maxResults = 100
 		for _, e := range entities {
 			if len(results) >= maxResults {

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/natsort"
+	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/tui/searchparser"
 )
 
@@ -425,6 +426,7 @@ func checkboxStats(content string) CheckboxStats {
 
 // executeQuery parses a search query and returns all matching entities from the graph.
 // It supports the same query syntax as the search page: type:, prop:, status:, and free text.
+// Free-text words use OR logic with relevance scoring; results are ranked by score.
 func (a *App) executeQuery(query string) []*model.Entity {
 	sq := searchparser.ParseQuery(query)
 	if sq.IsEmpty() {
@@ -440,7 +442,12 @@ func (a *App) executeQuery(query string) []*model.Entity {
 		candidates = a.g.AllNodes()
 	}
 
-	results := make([]*model.Entity, 0, len(candidates))
+	type scored struct {
+		entity *model.Entity
+		score  float64
+	}
+	var scoredResults []scored
+
 	for _, e := range candidates {
 		if len(sq.PropertyFilters) > 0 {
 			entDef, ok := a.meta.GetEntityDef(e.Type)
@@ -454,36 +461,32 @@ func (a *App) executeQuery(query string) []*model.Entity {
 		}
 
 		if sq.HasFreeText() {
-			searchText := strings.ToLower(e.ID + " " + a.entityDisplayTitle(e) + " " + e.Content)
-			for _, v := range e.Properties {
-				searchText += " " + strings.ToLower(fmt.Sprintf("%v", v))
-			}
-			match := true
-			for _, word := range sq.FreeTextWords {
-				if !strings.Contains(searchText, strings.ToLower(word)) {
-					match = false
-					break
-				}
-			}
-			if match {
-				for _, phrase := range sq.FreeTextPhrases {
-					if !strings.Contains(searchText, strings.ToLower(phrase)) {
-						match = false
-						break
-					}
-				}
-			}
-			if !match {
+			sc := search.ScoreEntity(e, sq.FreeTextWords, sq.FreeTextPhrases)
+			if sc <= 0 {
 				continue
 			}
+			scoredResults = append(scoredResults, scored{entity: e, score: sc})
+		} else {
+			scoredResults = append(scoredResults, scored{entity: e, score: 1.0})
 		}
-
-		results = append(results, e)
 	}
 
-	// Apply sort from query syntax
+	results := make([]*model.Entity, len(scoredResults))
+	for i, sr := range scoredResults {
+		results[i] = sr.entity
+	}
+
+	// Apply sort from query syntax, or rank by relevance for free-text queries
 	if sq.HasSort() {
 		a.sortEntitiesMulti(results, sq.SortClauses)
+	} else if sq.HasFreeText() {
+		sort.SliceStable(results, func(i, j int) bool {
+			si, sj := scoredResults[i].score, scoredResults[j].score
+			if si != sj {
+				return si > sj
+			}
+			return results[i].ID < results[j].ID
+		})
 	}
 
 	return results

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -2809,7 +2809,7 @@ function closeSidePanel() {
     <code>prop:priority=high</code> filter by property &middot;
     <code>sort:priority:desc</code> sort results &middot;
     <code>"exact phrase"</code> exact match &middot;
-    plain words (AND logic)
+    plain words (fuzzy, ranked)
   </div>
 </div>
 

--- a/internal/mcp/convert_test.go
+++ b/internal/mcp/convert_test.go
@@ -557,26 +557,26 @@ func TestMarshalJSON_Indented(t *testing.T) {
 	}
 }
 
-func TestMatchesSearch(t *testing.T) {
+func TestScoreSearch(t *testing.T) {
 	e := model.NewEntity("REQ-001", "requirement")
 	e.Properties["title"] = "Authentication Feature"
 	e.Properties["status"] = "draft"
 	e.Content = "Users should be able to log in"
 
 	// Match by ID
-	if !matchesSearch(e, "req-001") {
+	if scoreSearch(e, "req-001") <= 0 {
 		t.Error("expected match by ID")
 	}
 	// Match by property
-	if !matchesSearch(e, "authentication") {
+	if scoreSearch(e, "authentication") <= 0 {
 		t.Error("expected match by property value")
 	}
-	// Match by content
-	if !matchesSearch(e, "log in") {
+	// Match by content (two words, OR logic)
+	if scoreSearch(e, "log in") <= 0 {
 		t.Error("expected match by content")
 	}
 	// No match
-	if matchesSearch(e, "nonexistent") {
+	if scoreSearch(e, "nonexistent") > 0 {
 		t.Error("expected no match for nonexistent query")
 	}
 	// Non-string property should not match
@@ -685,44 +685,54 @@ func TestConvertTraceResult_DeepNesting(t *testing.T) {
 	}
 }
 
-func TestMatchesSearch_ByIDCaseInsensitive(t *testing.T) {
+func TestScoreSearch_ByIDCaseInsensitive(t *testing.T) {
 	e := model.NewEntity("REQ-001", "requirement")
 
-	// matchesSearch expects queryLower to already be lowercase
-	if !matchesSearch(e, "req") {
+	if scoreSearch(e, "req") <= 0 {
 		t.Error("expected case-insensitive ID match")
 	}
-	if !matchesSearch(e, "req-001") {
+	if scoreSearch(e, "req-001") <= 0 {
 		t.Error("expected full ID match")
 	}
 }
 
-func TestMatchesSearch_ByContent(t *testing.T) {
+func TestScoreSearch_ByContent(t *testing.T) {
 	e := model.NewEntity("REQ-001", "requirement")
 	e.Content = "This is about Authentication"
 
-	if !matchesSearch(e, "authentication") {
+	if scoreSearch(e, "authentication") <= 0 {
 		t.Error("expected case-insensitive content match")
 	}
 }
 
-func TestMatchesSearch_NoMatch(t *testing.T) {
+func TestScoreSearch_NoMatch(t *testing.T) {
 	e := model.NewEntity("REQ-001", "requirement")
 	e.Properties["title"] = "Something"
 	e.Content = "Other content"
 
-	if matchesSearch(e, "zzznomatch") {
+	if scoreSearch(e, "zzznomatch") > 0 {
 		t.Error("expected no match")
 	}
 }
 
-func TestMatchesSearch_NonStringProperty(t *testing.T) {
+func TestScoreSearch_MultipleWords(t *testing.T) {
 	e := model.NewEntity("REQ-001", "requirement")
-	e.Properties["count"] = 42
+	e.Properties["title"] = "Authentication Feature"
+	e.Content = "OAuth 2.0 API integration"
 
-	// Non-string properties should not be searched
-	if matchesSearch(e, "42") {
-		t.Error("expected non-string property to not match")
+	// Both words match → higher score
+	scoreBoth := scoreSearch(e, "authentication oauth")
+	// One word matches
+	scoreOne := scoreSearch(e, "authentication elephant")
+
+	if scoreBoth <= 0 {
+		t.Error("expected match for both words")
+	}
+	if scoreOne <= 0 {
+		t.Error("expected match for one word")
+	}
+	if scoreBoth <= scoreOne {
+		t.Errorf("both-match score (%f) should be higher than one-match (%f)", scoreBoth, scoreOne)
 	}
 }
 

--- a/internal/mcp/tools_entity.go
+++ b/internal/mcp/tools_entity.go
@@ -4,6 +4,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -83,7 +84,11 @@ func (s *Server) handleSearchEntities(
 
 	queryLower := strings.ToLower(query)
 
-	var results []*model.Entity
+	type scored struct {
+		entity *model.Entity
+		score  float64
+	}
+
 	var candidates []*model.Entity
 	if entityType != "" {
 		resolved := s.resolveType(entityType)
@@ -92,13 +97,26 @@ func (s *Server) handleSearchEntities(
 		candidates = s.graph.AllNodes()
 	}
 
+	var scoredResults []scored
 	for _, e := range candidates {
-		if matchesSearch(e, queryLower) {
-			results = append(results, e)
+		sc := scoreSearch(e, queryLower)
+		if sc > 0 {
+			scoredResults = append(scoredResults, scored{entity: e, score: sc})
 		}
 	}
 
-	sortEntitiesByID(results)
+	// Sort by relevance score (descending), then by ID for stability
+	sort.SliceStable(scoredResults, func(i, j int) bool {
+		if scoredResults[i].score != scoredResults[j].score {
+			return scoredResults[i].score > scoredResults[j].score
+		}
+		return scoredResults[i].entity.ID < scoredResults[j].entity.ID
+	})
+
+	results := make([]*model.Entity, len(scoredResults))
+	for i, sr := range scoredResults {
+		results[i] = sr.entity
+	}
 	if limit > 0 && limit < len(results) {
 		results = results[:limit]
 	}

--- a/internal/mcp/tools_helpers.go
+++ b/internal/mcp/tools_helpers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/search"
 )
 
 func (s *Server) resolveType(typeName string) string {
@@ -188,18 +189,14 @@ func (s *Server) checkValidationRule(rule metamodel.ValidationRule) []*model.Ent
 	return violations
 }
 
-func matchesSearch(e *model.Entity, queryLower string) bool {
-	if strings.Contains(strings.ToLower(e.ID), queryLower) {
-		return true
+// scoreSearch splits the query into words and returns a relevance score using
+// OR logic with fuzzy matching. Returns 0 if nothing matches.
+func scoreSearch(e *model.Entity, queryLower string) float64 {
+	words := strings.Fields(queryLower)
+	if len(words) == 0 {
+		return 0
 	}
-	for _, v := range e.Properties {
-		if str, ok := v.(string); ok {
-			if strings.Contains(strings.ToLower(str), queryLower) {
-				return true
-			}
-		}
-	}
-	return strings.Contains(strings.ToLower(e.Content), queryLower)
+	return search.ScoreEntity(e, words, nil)
 }
 
 func countEdgesByType(edges []*model.Relation, relType string) int {

--- a/internal/search/fuzzy.go
+++ b/internal/search/fuzzy.go
@@ -1,0 +1,95 @@
+package search
+
+import "strings"
+
+// DefaultFuzzyThreshold is the minimum trigram similarity for a fuzzy match.
+const DefaultFuzzyThreshold = 0.4
+
+// trigrams returns the set of 3-character subsequences of s (lowercased).
+// For strings shorter than 3 chars, the string itself is used as the sole trigram.
+func trigrams(s string) map[string]struct{} {
+	s = strings.ToLower(s)
+	set := make(map[string]struct{})
+	runes := []rune(s)
+	if len(runes) < 3 {
+		if len(runes) > 0 {
+			set[string(runes)] = struct{}{}
+		}
+		return set
+	}
+	for i := 0; i <= len(runes)-3; i++ {
+		set[string(runes[i:i+3])] = struct{}{}
+	}
+	return set
+}
+
+// trigramSimilarity returns the Jaccard similarity between the trigram sets of a and b.
+// Returns a value between 0.0 (no overlap) and 1.0 (identical trigram sets).
+func trigramSimilarity(a, b string) float64 {
+	setA := trigrams(a)
+	setB := trigrams(b)
+	if len(setA) == 0 || len(setB) == 0 {
+		return 0
+	}
+
+	intersection := 0
+	for t := range setA {
+		if _, ok := setB[t]; ok {
+			intersection++
+		}
+	}
+
+	union := len(setA) + len(setB) - intersection
+	if union == 0 {
+		return 0
+	}
+	return float64(intersection) / float64(union)
+}
+
+// fuzzyContains checks whether any substring of text fuzzy-matches word.
+// It uses a sliding window approach: for each position in text, it extracts
+// windows of length len(word)-2 to len(word)+2 and compares trigram similarity.
+// Returns the best similarity score above threshold, or 0 if none.
+func fuzzyContains(text, word string, threshold float64) float64 {
+	textLower := strings.ToLower(text)
+	wordLower := strings.ToLower(word)
+	textRunes := []rune(textLower)
+	wordLen := len([]rune(wordLower))
+
+	if wordLen == 0 {
+		return 0
+	}
+
+	// For very short words (1-2 chars), fuzzy matching is not meaningful.
+	if wordLen <= 2 {
+		if strings.Contains(textLower, wordLower) {
+			return 1.0
+		}
+		return 0
+	}
+
+	best := 0.0
+	minWin := wordLen - 2
+	if minWin < 3 {
+		minWin = 3
+	}
+	maxWin := wordLen + 2
+
+	for winSize := minWin; winSize <= maxWin; winSize++ {
+		if winSize > len(textRunes) {
+			break
+		}
+		for i := 0; i <= len(textRunes)-winSize; i++ {
+			window := string(textRunes[i : i+winSize])
+			sim := trigramSimilarity(window, wordLower)
+			if sim > best {
+				best = sim
+			}
+		}
+	}
+
+	if best >= threshold {
+		return best
+	}
+	return 0
+}

--- a/internal/search/fuzzy_test.go
+++ b/internal/search/fuzzy_test.go
@@ -1,0 +1,110 @@
+package search
+
+import (
+	"testing"
+)
+
+func TestTrigrams(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int // expected number of unique trigrams
+	}{
+		{"", 0},
+		{"ab", 1},   // "ab" is the sole entry
+		{"abc", 1},  // "abc"
+		{"abcd", 2}, // "abc", "bcd"
+		{"hello", 3},
+	}
+	for _, tt := range tests {
+		got := trigrams(tt.input)
+		if len(got) != tt.want {
+			t.Errorf("trigrams(%q): got %d trigrams, want %d", tt.input, len(got), tt.want)
+		}
+	}
+}
+
+func TestTrigramsCaseInsensitive(t *testing.T) {
+	upper := trigrams("ABC")
+	lower := trigrams("abc")
+	if len(upper) != len(lower) {
+		t.Fatalf("case mismatch: upper=%d lower=%d", len(upper), len(lower))
+	}
+	for k := range upper {
+		if _, ok := lower[k]; !ok {
+			t.Errorf("trigram %q from upper not in lower set", k)
+		}
+	}
+}
+
+func TestTrigramSimilarity(t *testing.T) {
+	tests := []struct {
+		a, b    string
+		minSim  float64
+		maxSim  float64
+		comment string
+	}{
+		{"hello", "hello", 1.0, 1.0, "identical"},
+		{"hello", "hallo", 0.2, 0.6, "one char diff"},
+		{"hello", "world", 0.0, 0.1, "completely different"},
+		{"authentication", "autentication", 0.5, 1.0, "missing char"},
+		{"", "hello", 0.0, 0.0, "empty a"},
+		{"hello", "", 0.0, 0.0, "empty b"},
+	}
+	for _, tt := range tests {
+		sim := trigramSimilarity(tt.a, tt.b)
+		if sim < tt.minSim || sim > tt.maxSim {
+			t.Errorf("trigramSimilarity(%q, %q) = %f, want [%f, %f] (%s)",
+				tt.a, tt.b, sim, tt.minSim, tt.maxSim, tt.comment)
+		}
+	}
+}
+
+func TestFuzzyContains(t *testing.T) {
+	tests := []struct {
+		text      string
+		word      string
+		threshold float64
+		wantMatch bool
+		comment   string
+	}{
+		// Exact substring
+		{"the quick brown fox", "quick", 0.4, true, "exact substring"},
+		// Typo: missing letter
+		{"user authentication system", "autentication", 0.4, true, "missing h"},
+		// Typo: swapped letters
+		{"requirement specification", "requirment", 0.4, true, "missing e"}, //nolint:misspell // intentional typo for fuzzy test
+		// Completely unrelated
+		{"the quick brown fox", "elephant", 0.4, false, "no match"},
+		// Short words — fall back to exact
+		{"hello world", "he", 0.4, true, "short exact match"},
+		{"hello world", "zz", 0.4, false, "short no match"},
+		// Empty
+		{"hello", "", 0.4, false, "empty word"},
+		{"", "hello", 0.4, false, "empty text"},
+		// Case insensitive
+		{"Authentication Required", "authentication", 0.4, true, "case insensitive"},
+	}
+	for _, tt := range tests {
+		score := fuzzyContains(tt.text, tt.word, tt.threshold)
+		gotMatch := score > 0
+		if gotMatch != tt.wantMatch {
+			t.Errorf("fuzzyContains(%q, %q, %f) = %f (match=%v), want match=%v (%s)",
+				tt.text, tt.word, tt.threshold, score, gotMatch, tt.wantMatch, tt.comment)
+		}
+	}
+}
+
+func TestFuzzyContainsScoreOrdering(t *testing.T) {
+	text := "the authentication module handles user requests"
+
+	exact := fuzzyContains(text, "authentication", 0.4)
+	typo := fuzzyContains(text, "autentication", 0.4) // missing h
+	noMatch := fuzzyContains(text, "elephant", 0.4)
+
+	if exact <= typo {
+		t.Errorf("exact (%f) should score higher than typo (%f)", exact, typo)
+	}
+	if typo <= noMatch {
+		t.Errorf("typo (%f) should score higher than noMatch (%f)", typo, noMatch)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,0 +1,52 @@
+package search
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+// ScoreText returns a relevance score for how well text matches the given query terms.
+//
+// Scoring rules:
+//   - Each word that substring-matches: +1.0
+//   - Each word that only fuzzy-matches: +fractional score (0.0–1.0)
+//   - Each phrase that substring-matches: +2.0
+//   - If any phrase does NOT match: score is forced to 0 (phrases are explicit user intent)
+//
+// Returns 0 if nothing matches or a required phrase is missing.
+func ScoreText(text string, words, phrases []string) float64 {
+	textLower := strings.ToLower(text)
+
+	// Phrases are required (AND logic) — if any phrase is missing, no match.
+	for _, phrase := range phrases {
+		if !strings.Contains(textLower, strings.ToLower(phrase)) {
+			return 0
+		}
+	}
+
+	score := float64(len(phrases)) * 2.0
+
+	// Words use OR logic — each matching word adds to the score.
+	for _, word := range words {
+		wordLower := strings.ToLower(word)
+		if strings.Contains(textLower, wordLower) {
+			score += 1.0
+		} else if fuzzyScore := fuzzyContains(textLower, wordLower, DefaultFuzzyThreshold); fuzzyScore > 0 {
+			score += fuzzyScore
+		}
+	}
+
+	return score
+}
+
+// ScoreEntity builds searchable text from an entity and scores it against the query terms.
+func ScoreEntity(e *model.Entity, words, phrases []string) float64 {
+	parts := []string{e.ID, e.Title(), e.Description(), e.Content}
+	for _, v := range e.Properties {
+		parts = append(parts, fmt.Sprintf("%v", v))
+	}
+	text := strings.Join(parts, " ")
+	return ScoreText(text, words, phrases)
+}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -1,0 +1,147 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+func TestScoreText_ExactSubstring(t *testing.T) {
+	text := "the quick brown fox jumps over the lazy dog"
+	score := ScoreText(text, []string{"quick"}, nil)
+	if score != 1.0 {
+		t.Errorf("exact substring: got %f, want 1.0", score)
+	}
+}
+
+func TestScoreText_MultipleWordsOR(t *testing.T) {
+	text := "the quick brown fox"
+
+	// Both words match
+	score := ScoreText(text, []string{"quick", "fox"}, nil)
+	if score != 2.0 {
+		t.Errorf("two matching words: got %f, want 2.0", score)
+	}
+
+	// Only one word matches
+	score = ScoreText(text, []string{"quick", "elephant"}, nil)
+	if score != 1.0 {
+		t.Errorf("one matching word: got %f, want 1.0", score)
+	}
+
+	// No words match
+	score = ScoreText(text, []string{"elephant", "giraffe"}, nil)
+	if score != 0.0 {
+		t.Errorf("no matching words: got %f, want 0.0", score)
+	}
+}
+
+func TestScoreText_FuzzyWord(t *testing.T) {
+	text := "user authentication system"
+
+	// Exact match
+	exact := ScoreText(text, []string{"authentication"}, nil)
+	// Fuzzy match (typo)
+	fuzzy := ScoreText(text, []string{"autentication"}, nil)
+	// No match
+	none := ScoreText(text, []string{"elephant"}, nil)
+
+	if exact <= 0 {
+		t.Errorf("exact match should score > 0, got %f", exact)
+	}
+	if fuzzy <= 0 {
+		t.Errorf("fuzzy match should score > 0, got %f", fuzzy)
+	}
+	if exact <= fuzzy {
+		t.Errorf("exact (%f) should score higher than fuzzy (%f)", exact, fuzzy)
+	}
+	if none != 0 {
+		t.Errorf("no match should score 0, got %f", none)
+	}
+}
+
+func TestScoreText_Phrases(t *testing.T) {
+	text := "the OAuth 2.0 authentication protocol"
+
+	// Phrase matches
+	score := ScoreText(text, nil, []string{"OAuth 2.0"})
+	if score != 2.0 {
+		t.Errorf("matching phrase: got %f, want 2.0", score)
+	}
+
+	// Phrase doesn't match — score must be 0
+	score = ScoreText(text, []string{"authentication"}, []string{"does not exist"})
+	if score != 0.0 {
+		t.Errorf("missing phrase should force score to 0, got %f", score)
+	}
+}
+
+func TestScoreText_WordsAndPhrases(t *testing.T) {
+	text := "the OAuth 2.0 authentication protocol for API access"
+
+	// Phrase matches + words match
+	score := ScoreText(text, []string{"API", "authentication"}, []string{"OAuth 2.0"})
+	if score != 4.0 { // phrase=2.0 + API=1.0 + authentication=1.0
+		t.Errorf("words + phrase: got %f, want 4.0", score)
+	}
+}
+
+func TestScoreText_CaseInsensitive(t *testing.T) {
+	text := "User Authentication System"
+	score := ScoreText(text, []string{"authentication"}, nil)
+	if score <= 0 {
+		t.Errorf("case insensitive match should score > 0, got %f", score)
+	}
+}
+
+func TestScoreText_EmptyInputs(t *testing.T) {
+	// No words or phrases
+	score := ScoreText("some text", nil, nil)
+	if score != 0.0 {
+		t.Errorf("no query terms: got %f, want 0.0", score)
+	}
+
+	// Empty text
+	score = ScoreText("", []string{"hello"}, nil)
+	if score != 0.0 {
+		t.Errorf("empty text: got %f, want 0.0", score)
+	}
+}
+
+func TestScoreEntity(t *testing.T) {
+	e := model.NewEntity("REQ-001", "requirement")
+	e.Properties["title"] = "User Authentication"
+	e.Properties["description"] = "System must support OAuth"
+	e.Content = "Detailed requirements for authentication flow"
+
+	// Should match on title
+	score := ScoreEntity(e, []string{"authentication"}, nil)
+	if score <= 0 {
+		t.Errorf("should match entity title/content, got %f", score)
+	}
+
+	// Should match on ID
+	score = ScoreEntity(e, []string{"REQ-001"}, nil)
+	if score <= 0 {
+		t.Errorf("should match entity ID, got %f", score)
+	}
+
+	// Should match on property value
+	score = ScoreEntity(e, []string{"OAuth"}, nil)
+	if score <= 0 {
+		t.Errorf("should match property value, got %f", score)
+	}
+}
+
+func TestScoreText_RelevanceRanking(t *testing.T) {
+	// Entity that matches both words should score higher than one matching only one
+	textBoth := "API authentication service"
+	textOne := "API gateway service"
+
+	scoreBoth := ScoreText(textBoth, []string{"API", "authentication"}, nil)
+	scoreOne := ScoreText(textOne, []string{"API", "authentication"}, nil)
+
+	if scoreBoth <= scoreOne {
+		t.Errorf("both-match (%f) should score higher than one-match (%f)", scoreBoth, scoreOne)
+	}
+}

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -134,7 +134,7 @@ func (h *HelpModel) View(_, height int) string {
 				{"prop:status=draft", "Property filter (=, !=, <, <=, >, >=)"},
 				{"status:published", "Status shortcut"},
 				{"\"exact phrase\"", "Exact phrase match"},
-				{"word1 word2", "Free text (AND logic)"},
+				{"word1 word2", "Free text (OR, ranked)"},
 			},
 		},
 		{

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/natsort"
+	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/tui/searchparser"
 )
 
@@ -523,13 +524,24 @@ func (s *SearchModel) performSearch(app *App, query string) (results []*model.En
 
 	// Get all entities from graph
 	allEntities := app.graph.AllNodes()
-	var filtered []*model.Entity
 
-	// Apply filters
+	// Score and filter entities
+	type scored struct {
+		entity *model.Entity
+		score  float64
+	}
+	var scoredResults []scored
+
 	for _, entity := range allEntities {
-		if s.matchesFilters(entity, sq) {
-			filtered = append(filtered, entity)
+		sc := s.scoreEntity(entity, sq)
+		if sc > 0 {
+			scoredResults = append(scoredResults, scored{entity: entity, score: sc})
 		}
+	}
+
+	filtered := make([]*model.Entity, len(scoredResults))
+	for i, sr := range scoredResults {
+		filtered[i] = sr.entity
 	}
 
 	// Validate sort properties against result set
@@ -546,11 +558,21 @@ func (s *SearchModel) performSearch(app *App, query string) (results []*model.En
 	}
 
 	// Apply sort
-	if sq.HasSort() {
+	switch {
+	case sq.HasSort():
 		entityDefs := collectEntityDefs(app.metamodel, filtered)
 		filter.SortMulti(filtered, sq.SortClauses, entityDefs, app.metamodel)
-	} else {
-		// Apply default_sort if single entity type
+	case sq.HasFreeText():
+		// Sort by relevance score (descending), then by ID for stability
+		sort.SliceStable(filtered, func(i, j int) bool {
+			si, sj := scoredResults[i].score, scoredResults[j].score
+			if si != sj {
+				return si > sj
+			}
+			return filtered[i].ID < filtered[j].ID
+		})
+	default:
+		// No free text — apply default_sort if single entity type
 		types := uniqueTypes(filtered)
 		if len(types) == 1 {
 			if def, ok := app.metamodel.GetEntityDef(types[0]); ok && len(def.DefaultSort) > 0 {
@@ -611,61 +633,42 @@ func uniqueTypes(entities []*model.Entity) []string {
 	return types
 }
 
-// matchesFilters checks if an entity matches all search criteria
-func (s *SearchModel) matchesFilters(entity *model.Entity, sq *searchparser.SearchQuery) bool {
-	// 1. Filter by entity type (if specified)
+// scoreEntity returns a relevance score for an entity against the search query.
+// Returns 0 if the entity doesn't match type/property filters or no free-text terms match.
+// Returns a positive score based on how many free-text words/phrases match.
+// When there's no free-text query, returns 1.0 for entities passing type/property filters.
+func (s *SearchModel) scoreEntity(entity *model.Entity, sq *searchparser.SearchQuery) float64 {
+	// 1. Filter by entity type (if specified) — boolean gate
 	if len(sq.EntityTypes) > 0 {
 		found := false
 		for _, t := range sq.EntityTypes {
-			// Support prefix matching (case-insensitive)
-			// e.g., "req" matches "requirement", "dec" matches "decision"
 			if strings.HasPrefix(strings.ToLower(entity.Type), strings.ToLower(t)) {
 				found = true
 				break
 			}
 		}
 		if !found {
-			return false
+			return 0
 		}
 	}
 
-	// 2. Apply property filters (AND logic)
+	// 2. Apply property filters (AND logic) — boolean gate
 	for _, propFilter := range sq.PropertyFilters {
 		value, exists := entity.Properties[propFilter.Property]
 		if !exists {
-			return false
+			return 0
 		}
 		if !filter.MatchValue(value, propFilter) {
-			return false
+			return 0
 		}
 	}
 
-	// 3. Apply free-text search (AND logic - all words must be present)
+	// 3. Apply free-text search (OR logic with scoring)
 	if sq.HasFreeText() {
-		// Combine all searchable text
-		searchableText := strings.ToLower(strings.Join([]string{
-			entity.ID,
-			entity.Title(),
-			entity.Description(),
-			entity.Content,
-		}, " "))
-
-		// Check all free text words
-		for _, word := range sq.FreeTextWords {
-			if !strings.Contains(searchableText, strings.ToLower(word)) {
-				return false
-			}
-		}
-
-		// Check all exact phrases
-		for _, phrase := range sq.FreeTextPhrases {
-			if !strings.Contains(searchableText, strings.ToLower(phrase)) {
-				return false
-			}
-		}
+		return search.ScoreEntity(entity, sq.FreeTextWords, sq.FreeTextPhrases)
 	}
 
-	return true
+	return 1.0
 }
 
 // View renders the search screen

--- a/internal/tui/search_integration_test.go
+++ b/internal/tui/search_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
+	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/tui/searchparser"
 )
@@ -87,10 +88,10 @@ func TestSearchIntegration(t *testing.T) {
 			expectIDs:   []string{"REQ-001", "SOL-001"},
 		},
 		{
-			name:        "Multiple words (AND logic)",
+			name:        "Multiple words (OR logic with ranking)",
 			query:       "API authentication",
-			expectCount: 1,
-			expectIDs:   []string{"DEC-002"},
+			expectCount: 6,
+			expectIDs:   []string{"REQ-001", "REQ-002", "REQ-004", "DEC-002", "SOL-001", "SOL-002"},
 		},
 		{
 			name:        "Type filter - requirements only",
@@ -302,7 +303,7 @@ func runSearchTest(t *testing.T, g *graph.Graph, tc searchTestCase) {
 	}
 }
 
-// matchesSearchFilters duplicates the logic from SearchModel.matchesFilters for testing
+// matchesSearchFilters checks if an entity matches search criteria using OR-based scoring.
 func matchesSearchFilters(entity *model.Entity, sq *searchparser.SearchQuery) bool {
 	// 1. Filter by entity type (if specified)
 	if len(sq.EntityTypes) > 0 {
@@ -329,29 +330,9 @@ func matchesSearchFilters(entity *model.Entity, sq *searchparser.SearchQuery) bo
 		}
 	}
 
-	// 3. Apply free-text search (AND logic - all words must be present)
+	// 3. Apply free-text search (OR logic with scoring)
 	if sq.HasFreeText() {
-		// Combine all searchable text
-		searchableText := strings.ToLower(strings.Join([]string{
-			entity.ID,
-			entity.Title(),
-			entity.Description(),
-			entity.Content,
-		}, " "))
-
-		// Check all free text words
-		for _, word := range sq.FreeTextWords {
-			if !strings.Contains(searchableText, strings.ToLower(word)) {
-				return false
-			}
-		}
-
-		// Check all exact phrases
-		for _, phrase := range sq.FreeTextPhrases {
-			if !strings.Contains(searchableText, strings.ToLower(phrase)) {
-				return false
-			}
-		}
+		return search.ScoreEntity(entity, sq.FreeTextWords, sq.FreeTextPhrases) > 0
 	}
 
 	return true

--- a/internal/tui/searchparser/parser.go
+++ b/internal/tui/searchparser/parser.go
@@ -13,7 +13,7 @@ import (
 type SearchQuery struct {
 	EntityTypes     []string         // Entity types to filter (e.g., ["requirement", "decision"])
 	PropertyFilters []*filter.Filter // Property filters (e.g., status=published)
-	FreeTextWords   []string         // Free text words (AND logic)
+	FreeTextWords   []string         // Free text words (OR logic with scoring)
 	FreeTextPhrases []string         // Exact phrase matches (quoted strings)
 	SortClauses     []model.SortSpec // Sort criteria (e.g., sort:priority:desc)
 	ParseErrors     []string         // Any parsing errors encountered


### PR DESCRIPTION
## Summary
- Replace strict AND-based substring matching with OR-based scoring for free-text search words
- Add trigram-based fuzzy matching for typo tolerance (no external dependencies)
- Rank results by relevance score (number of matching words), with ties broken by ID
- Quoted phrases remain exact-match (AND logic preserved for explicit user intent)
- Integrated into all three search consumers: TUI, data entry web app, and MCP

## Behavior change

| Query | Before | After |
|-------|--------|-------|
| `keyboard mouse` | AND: 0 results | OR: 3 results, ranked |
| `keybord` (typo) | 0 results | Fuzzy matches "keyboard" |
| `"wireless keyboard"` | Exact phrase | Unchanged |
| `type:product prop:status=draft` | Filters (AND) | Unchanged |

## New package: `internal/search/`
- `fuzzy.go` — Trigram similarity with sliding window (96.9% coverage)
- `search.go` — `ScoreText` / `ScoreEntity` scoring API

## Test plan
- [x] Unit tests for trigram matching, scoring, and entity scoring
- [x] Integration tests updated for OR behavior
- [x] MCP search tests updated for word-splitting + scoring
- [x] Manual QA against catalog example (single word, multi-word, fuzzy, phrase, filters, ranking)
- [x] `just ci` passes (lint, test, coverage, build, docs)