### PR TITLE
Fix custom type validation for status and priority (#70)

### DIFF
--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -17,6 +17,12 @@ import (
 func testMetamodel() *metamodel.Metamodel {
 	return &metamodel.Metamodel{
 		Version: "1.0",
+		Types: map[string]metamodel.CustomType{
+			"status": {
+				Values:  []string{"draft", "approved", "accepted", "rejected"},
+				Default: "draft",
+			},
+		},
 		Entities: map[string]metamodel.EntityDef{
 			"requirement": {
 				Label:    "Requirement",

--- a/internal/metamodel/validation.go
+++ b/internal/metamodel/validation.go
@@ -130,45 +130,29 @@ func (m *Metamodel) ValidatePropertyValue(propName string, propDef *PropertyDef,
 			}
 		}
 
-	case "status":
-		// Legacy built-in status type
-		if s, ok := val.(string); ok {
-			if !model.Status(s).IsValid() {
-				return fmt.Errorf("invalid status value: %s", s)
-			}
-		}
-
-	case "priority":
-		// Legacy built-in priority type
-		if p, ok := val.(string); ok {
-			if !model.Priority(p).IsValid() {
-				return fmt.Errorf("invalid priority value: %s", p)
-			}
-		}
-
 	default:
-		// Check if it's a custom type (enum defined in types section)
+		// Custom type (enum defined in types section)
 		if customType, ok := m.Types[propDef.Type]; ok {
-			s, ok := val.(string)
-			if !ok {
-				return fmt.Errorf("property %s must be a string", propName)
-			}
-			valid := false
-			for _, v := range customType.Values {
-				if v == s {
-					valid = true
-					break
-				}
-			}
-			if !valid {
-				return fmt.Errorf("invalid value for %s: %s (allowed: %v)", propName, s, customType.Values)
-			}
-		} else {
-			return fmt.Errorf("property %s has unknown type %q", propName, propDef.Type)
+			return validateCustomTypeValue(propName, customType, val)
 		}
+		return fmt.Errorf("property %s has unknown type %q", propName, propDef.Type)
 	}
 
 	return nil
+}
+
+// validateCustomTypeValue validates a value against a custom type's allowed values.
+func validateCustomTypeValue(propName string, customType CustomType, val interface{}) error {
+	s, ok := val.(string)
+	if !ok {
+		return fmt.Errorf("property %s must be a string", propName)
+	}
+	for _, v := range customType.Values {
+		if v == s {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid value for %s: %s (allowed: %v)", propName, s, customType.Values)
 }
 
 // ParseDateValue parses a date string using the property's format.

--- a/internal/metamodel/validation_test.go
+++ b/internal/metamodel/validation_test.go
@@ -10,6 +10,12 @@ import (
 func TestValidateEntity_EmptyRequiredProperty(t *testing.T) {
 	// Bug PROP-002: Empty required property should only show one error, not two
 	meta := &Metamodel{
+		Types: map[string]CustomType{
+			"status": {
+				Values:  []string{"draft", "proposed", "accepted"},
+				Default: "draft",
+			},
+		},
 		Entities: map[string]EntityDef{
 			"requirement": {
 				Label:    "Requirement",
@@ -431,6 +437,74 @@ func TestValidatePropertyValue_CustomType(t *testing.T) {
 	err = meta.ValidatePropertyValue("severity", propDef, 123)
 	if err == nil {
 		t.Error("expected error for non-string custom type")
+	}
+}
+
+func TestValidatePropertyValue_CustomStatusType(t *testing.T) {
+	// Bug #70: Custom type named "status" should override built-in status validation
+	meta := &Metamodel{
+		Types: map[string]CustomType{
+			"status": {
+				Values:  []string{"draft", "review", "approved", "active", "completed", "on_hold", "superseded", "retired"},
+				Default: "draft",
+			},
+		},
+	}
+	propDef := &PropertyDef{Type: "status"}
+
+	// All custom values should be accepted
+	for _, val := range []string{"draft", "review", "approved", "active", "completed", "on_hold", "superseded", "retired"} {
+		err := meta.ValidatePropertyValue("status", propDef, val)
+		if err != nil {
+			t.Errorf("expected custom status value %q to be valid, got: %v", val, err)
+		}
+	}
+
+	// Values not in the custom type should be rejected
+	err := meta.ValidatePropertyValue("status", propDef, "proposed")
+	if err == nil {
+		t.Error("expected error for value not in custom status type")
+	}
+}
+
+func TestValidatePropertyValue_CustomPriorityType(t *testing.T) {
+	// Custom type named "priority" should override built-in priority validation
+	meta := &Metamodel{
+		Types: map[string]CustomType{
+			"priority": {
+				Values:  []string{"p0", "p1", "p2", "p3"},
+				Default: "p2",
+			},
+		},
+	}
+	propDef := &PropertyDef{Type: "priority"}
+
+	// Custom values should be accepted
+	err := meta.ValidatePropertyValue("priority", propDef, "p1")
+	if err != nil {
+		t.Errorf("expected custom priority value to be valid, got: %v", err)
+	}
+
+	// Built-in values not in custom type should be rejected
+	err = meta.ValidatePropertyValue("priority", propDef, "high")
+	if err == nil {
+		t.Error("expected error for value not in custom priority type")
+	}
+}
+
+func TestValidatePropertyValue_UndeclaredStatusType(t *testing.T) {
+	// Using type "status" without declaring it in types section should error
+	meta := &Metamodel{
+		Types: map[string]CustomType{},
+	}
+	propDef := &PropertyDef{Type: "status"}
+
+	err := meta.ValidatePropertyValue("status", propDef, "draft")
+	if err == nil {
+		t.Error("expected error for undeclared status type")
+	}
+	if !strings.Contains(err.Error(), "unknown type") {
+		t.Errorf("expected 'unknown type' in error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Removed hardcoded `case "status":` and `case "priority":` branches from `ValidatePropertyValue` that shadowed custom type definitions with the same name
- Custom types named "status" or "priority" now correctly validate against their declared values instead of built-in constants
- Extracted `validateCustomTypeValue` helper to reduce nesting

Closes #70

## Test plan
- [x] Added `TestValidatePropertyValue_CustomStatusType` — custom status values accepted, non-members rejected
- [x] Added `TestValidatePropertyValue_CustomPriorityType` — same for priority
- [x] Added `TestValidatePropertyValue_UndeclaredStatusType` — using bare "status" without declaring it errors
- [x] Updated importer test fixtures to declare status as a custom type
- [x] `just ci` passes (lint, tests, coverage, build, docs)
- [x] Manual end-to-end test: created entities with custom status values (active, review, approved, on_hold) — all accepted; bogus value correctly rejected