### PR TITLE
Harden MCP server input handling and validation

### DIFF
--- a/internal/filter/match.go
+++ b/internal/filter/match.go
@@ -13,15 +13,15 @@ import (
 func Match(entity *model.Entity, filter *Filter, propDef *metamodel.PropertyDef, m *metamodel.Metamodel) (bool, error) {
 	val := entity.Properties[filter.Property]
 
-	// Handle nil/missing values
-	// Semantic: missing properties do NOT match any filter, except when
+	// Handle nil/missing/empty values
+	// Semantic: missing or empty properties do NOT match any filter, except when
 	// explicitly checking for empty values with "property=" (OpEqual with empty string).
 	// This means:
-	//   - property=value  -> false (missing is not equal to value)
-	//   - property!=value -> false (missing should not match "not equal to value")
-	//   - property=       -> true  (missing matches "is empty")
-	//   - property!=      -> false (missing should not match "is not empty")
-	if val == nil {
+	//   - property=value  -> false (missing/empty is not equal to value)
+	//   - property!=value -> false (missing/empty should not match "not equal to value")
+	//   - property=       -> true  (missing/empty matches "is empty")
+	//   - property!=      -> false (missing/empty should not match "is not empty")
+	if val == nil || val == "" {
 		// Only match if explicitly comparing to empty with = operator
 		if filter.Operator == OpEqual && filter.Value == "" {
 			return true, nil

--- a/internal/filter/match_test.go
+++ b/internal/filter/match_test.go
@@ -433,6 +433,100 @@ func TestMatchMissingProperty(t *testing.T) {
 	}
 }
 
+// TestMatchEmptyStringProperty tests that entities with empty string properties
+// are treated the same as missing properties for filtering purposes.
+// This is important for non-required typed properties (like dates) where an empty
+// string means "no value set" rather than a valid value.
+func TestMatchEmptyStringProperty(t *testing.T) {
+	mm := &metamodel.Metamodel{}
+
+	tests := []struct {
+		name    string
+		propDef *metamodel.PropertyDef
+		filter  string
+		want    bool
+		wantErr bool
+	}{
+		// Date property with empty string
+		{
+			name:    "empty string date should not match =date",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeDate, Format: "2006-01-02"},
+			filter:  "due_date=2025-01-01",
+			want:    false,
+		},
+		{
+			name:    "empty string date should not match !=date",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeDate, Format: "2006-01-02"},
+			filter:  "due_date!=2025-01-01",
+			want:    false,
+		},
+		{
+			name:    "empty string date should match = (empty check)",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeDate, Format: "2006-01-02"},
+			filter:  "due_date=",
+			want:    true,
+		},
+		{
+			name:    "empty string date should not match != (empty check)",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeDate, Format: "2006-01-02"},
+			filter:  "due_date!=",
+			want:    false,
+		},
+		{
+			name:    "empty string date should not match >date",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeDate, Format: "2006-01-02"},
+			filter:  "due_date>2025-01-01",
+			want:    false,
+		},
+		// Integer property with empty string
+		{
+			name:    "empty string integer should not match =value",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeInteger},
+			filter:  "count=10",
+			want:    false,
+		},
+		{
+			name:    "empty string integer should match = (empty check)",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeInteger},
+			filter:  "count=",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Entity with empty string property value
+			entity := &model.Entity{
+				ID:   "TEST-001",
+				Type: "test",
+				Properties: map[string]interface{}{
+					tt.propDef.Type: "", // empty string
+				},
+			}
+			// Use the actual property name from the filter
+			f, err := Parse(tt.filter)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", tt.filter, err)
+			}
+			entity.Properties[f.Property] = ""
+
+			got, err := Match(entity, f, tt.propDef, mm)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Match error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Match = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMatchAllAND(t *testing.T) {
 	mm := &metamodel.Metamodel{}
 	entityDef := &metamodel.EntityDef{

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -95,7 +95,7 @@ func toolDeleteEntity() mcp.Tool {
 	return mcp.NewTool("delete_entity",
 		mcp.WithDescription("Delete an entity and optionally its relations"),
 		mcp.WithString("id", mcp.Required(), mcp.Description("Entity ID to delete")),
-		mcp.WithBoolean("cascade", mcp.Description("Also delete all relations (default true)")),
+		mcp.WithBoolean("cascade", mcp.Description("Also delete all relations (default false)")),
 	)
 }
 

--- a/internal/mcp/tools_entity.go
+++ b/internal/mcp/tools_entity.go
@@ -56,6 +56,7 @@ func (s *Server) handleShowEntity(
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	id = trimID(id)
 
 	entity, ok := s.graph.GetNode(id)
 	if !ok {
@@ -127,6 +128,11 @@ func (s *Server) handleCreateEntity(
 
 	// Parse properties from the request
 	properties := s.extractProperties(request)
+
+	// Validate property names early for better error messages
+	if errResult := s.validatePropertyNames(resolvedType, properties); errResult != nil {
+		return errResult, nil
+	}
 
 	// Generate or validate ID
 	var entityID string
@@ -202,6 +208,7 @@ func (s *Server) handleUpdateEntity(
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	id = trimID(id)
 
 	entity, ok := s.graph.GetNode(id)
 	if !ok {
@@ -213,6 +220,11 @@ func (s *Server) handleUpdateEntity(
 
 	if len(properties) == 0 && content == "" {
 		return mcp.NewToolResultError("no updates specified"), nil
+	}
+
+	// Validate property names early for better error messages
+	if errResult := s.validatePropertyNames(entity.Type, properties); errResult != nil {
+		return errResult, nil
 	}
 
 	// Apply property updates
@@ -250,7 +262,8 @@ func (s *Server) handleDeleteEntity(
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
-	cascade := request.GetBool("cascade", true)
+	id = trimID(id)
+	cascade := request.GetBool("cascade", false)
 
 	entity, ok := s.graph.GetNode(id)
 	if !ok {

--- a/internal/mcp/tools_helpers.go
+++ b/internal/mcp/tools_helpers.go
@@ -13,6 +13,7 @@ import (
 )
 
 func (s *Server) resolveType(typeName string) string {
+	typeName = strings.TrimSpace(typeName)
 	meta := s.getMeta()
 	resolved := meta.ResolveAlias(typeName)
 	if _, ok := meta.GetEntityDef(resolved); ok {
@@ -32,6 +33,11 @@ func (s *Server) resolveType(typeName string) string {
 	return typeName
 }
 
+// trimID trims whitespace from an entity ID
+func trimID(id string) string {
+	return strings.TrimSpace(id)
+}
+
 func (s *Server) resolveEntityType(typeName string) (string, *metamodel.EntityDef, error) {
 	resolved := s.resolveType(typeName)
 	def, ok := s.getMeta().GetEntityDef(resolved)
@@ -48,17 +54,43 @@ func (s *Server) extractProperties(request mcp.CallToolRequest) map[string]inter
 		return nil
 	}
 
+	var props map[string]interface{}
 	switch p := propsRaw.(type) {
 	case map[string]interface{}:
-		return p
+		props = p
 	case string:
 		// Try to parse as JSON
-		var result map[string]interface{}
-		if err := json.Unmarshal([]byte(p), &result); err == nil {
-			return result
+		if err := json.Unmarshal([]byte(p), &props); err != nil {
+			return nil
 		}
+	default:
+		return nil
 	}
-	return nil
+
+	// Filter out nil and empty string values - they represent "no value"
+	return filterNilAndEmpty(props)
+}
+
+// filterNilAndEmpty removes nil and empty string values from a property map.
+// These values are semantically "no value" and should not be stored.
+func filterNilAndEmpty(props map[string]interface{}) map[string]interface{} {
+	if props == nil {
+		return nil
+	}
+	filtered := make(map[string]interface{}, len(props))
+	for k, v := range props {
+		if v == nil {
+			continue
+		}
+		if s, ok := v.(string); ok && s == "" {
+			continue
+		}
+		filtered[k] = v
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
 }
 
 func (s *Server) validateEntity(entity *model.Entity) *mcp.CallToolResult {
@@ -71,6 +103,40 @@ func (s *Server) validateEntity(entity *model.Entity) *mcp.CallToolResult {
 		msgs = append(msgs, e.Error())
 	}
 	return mcp.NewToolResultError(fmt.Sprintf("validation errors:\n  %s", strings.Join(msgs, "\n  ")))
+}
+
+// validatePropertyNames checks if all property names exist in the metamodel for the given entity type.
+// Returns an error result if any unknown properties are found, nil otherwise.
+func (s *Server) validatePropertyNames(entityType string, properties map[string]interface{}) *mcp.CallToolResult {
+	if properties == nil {
+		return nil
+	}
+
+	meta := s.getMeta()
+	entityDef, ok := meta.GetEntityDef(entityType)
+	if !ok {
+		return nil // Type validation will catch this
+	}
+
+	var unknown []string
+	for propName := range properties {
+		if _, exists := entityDef.Properties[propName]; !exists {
+			unknown = append(unknown, propName)
+		}
+	}
+
+	if len(unknown) > 0 {
+		// Get list of valid properties for helpful error message
+		valid := make([]string, 0, len(entityDef.Properties))
+		for name := range entityDef.Properties {
+			valid = append(valid, name)
+		}
+		return mcp.NewToolResultError(fmt.Sprintf(
+			"unknown properties for %s: %s (valid: %s)",
+			entityType, strings.Join(unknown, ", "), strings.Join(valid, ", ")))
+	}
+
+	return nil
 }
 
 func (s *Server) saveCache() {

--- a/internal/mcp/tools_relation.go
+++ b/internal/mcp/tools_relation.go
@@ -4,6 +4,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
@@ -64,14 +65,17 @@ func (s *Server) handleCreateRelation(
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	fromID = trimID(fromID)
 	relType, err := request.RequireString("type")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	relType = strings.TrimSpace(relType)
 	toID, err := request.RequireString("to")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	toID = trimID(toID)
 	content := request.GetString("content", "")
 
 	// Check entities exist
@@ -125,14 +129,17 @@ func (s *Server) handleDeleteRelation(
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	fromID = trimID(fromID)
 	relType, err := request.RequireString("type")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	relType = strings.TrimSpace(relType)
 	toID, err := request.RequireString("to")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	toID = trimID(toID)
 
 	_, exists := s.graph.GetEdge(fromID, relType, toID)
 	if !exists {

--- a/internal/mcp/tools_trace.go
+++ b/internal/mcp/tools_trace.go
@@ -15,6 +15,7 @@ func (s *Server) handleTraceFrom(
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	id = trimID(id)
 	maxDepth := request.GetInt("max_depth", 0)
 
 	if _, ok := s.graph.GetNode(id); !ok {
@@ -40,6 +41,7 @@ func (s *Server) handleTraceTo(
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	id = trimID(id)
 	maxDepth := request.GetInt("max_depth", 0)
 
 	if _, ok := s.graph.GetNode(id); !ok {
@@ -65,10 +67,12 @@ func (s *Server) handleFindPath(
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	from = trimID(from)
 	to, err := request.RequireString("to")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	to = trimID(to)
 
 	if _, ok := s.graph.GetNode(from); !ok {
 		return mcp.NewToolResultError(fmt.Sprintf("source entity not found: %s", from)), nil

--- a/internal/mcp/tools_views.go
+++ b/internal/mcp/tools_views.go
@@ -59,10 +59,12 @@ func (s *Server) handleExecuteView(
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	viewName = strings.TrimSpace(viewName)
 	entryID, err := request.RequireString("id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	entryID = trimID(entryID)
 	format := request.GetString("format", "json")
 
 	viewsFile, loadErr := s.loadViews()

--- a/internal/metamodel/validation.go
+++ b/internal/metamodel/validation.go
@@ -35,8 +35,9 @@ func (m *Metamodel) ValidateEntity(entity *model.Entity) []error {
 			continue
 		}
 
-		// Skip empty strings for required properties - already reported as missing
-		if propDef.Required && val == "" {
+		// Skip empty strings - they represent "no value"
+		// For required properties, this is already reported as missing above
+		if val == "" {
 			continue
 		}
 

--- a/internal/metamodel/validation_test.go
+++ b/internal/metamodel/validation_test.go
@@ -98,6 +98,11 @@ func TestValidateEntity_DateValidation_RFC3339(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name:      "empty string on non-required date",
+			dateValue: "",
+			wantErr:   false,
+		},
+		{
 			name:      "invalid date format",
 			dateValue: "15-03-2026",
 			wantErr:   true,


### PR DESCRIPTION
## Summary
- Skip validation for empty string values on non-required properties (fixes date validation error)
- Treat empty strings as missing in filter matching (prevents parse errors)
- Filter nil/empty values from extracted properties before storing
- Change cascade delete default to false (safer default for destructive op)
- Trim whitespace on entity IDs, types, and relation params
- Validate property names against metamodel before applying (better error messages)

## Test plan
- [x] All existing tests pass
- [x] New test: empty string on non-required date passes validation
- [x] New test: empty string properties treated as missing in filters
- [x] Pre-commit hook passes (lint + test)