### PR TITLE
Add metamodel-aware data-entry cleanup migration

### DIFF
--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Sourcehaven-BV/rela/internal/dataentry"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/migration"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 )
@@ -34,6 +35,9 @@ Examples:
 			return fmt.Errorf("no project found: run 'rela init' to create one")
 		}
 
+		// Load metamodel for context-aware migrations (ignore errors - metamodel may need migration)
+		mm, _ := metamodel.LoadWithoutMigrationCheck(ctx.MetamodelPath, cliFS)
+
 		// Define files to check
 		dataEntryPath := filepath.Join(ctx.Root, dataentry.ConfigFile)
 
@@ -47,10 +51,10 @@ Examples:
 		}
 
 		if migrateCheck {
-			return runMigrateCheck(files)
+			return runMigrateCheck(files, mm)
 		}
 
-		return runMigrate(files)
+		return runMigrate(files, mm)
 	},
 }
 
@@ -58,7 +62,7 @@ func runMigrateCheck(files []struct {
 	path     string
 	fileType migration.FileType
 	name     string
-}) error {
+}, meta *metamodel.Metamodel) error {
 	needsMigration := false
 
 	for _, f := range files {
@@ -67,15 +71,15 @@ func runMigrateCheck(files []struct {
 			continue
 		}
 
-		result, err := migration.CheckOnly(f.path, f.fileType, cliFS)
+		detections, err := migration.DetectWithMetamodel(f.path, f.fileType, cliFS, meta)
 		if err != nil {
 			return fmt.Errorf("checking %s: %w", f.name, err)
 		}
 
-		if result.NeedsMigration() {
+		if len(detections) > 0 {
 			needsMigration = true
 			fmt.Printf("%s needs migration:\n", f.name)
-			for _, d := range result.Detections {
+			for _, d := range detections {
 				fmt.Printf("  - %s\n", d.Description)
 			}
 		}
@@ -94,7 +98,7 @@ func runMigrate(files []struct {
 	path     string
 	fileType migration.FileType
 	name     string
-}) error {
+}, meta *metamodel.Metamodel) error {
 	filesUpdated := 0
 	totalMigrations := 0
 
@@ -104,7 +108,7 @@ func runMigrate(files []struct {
 			continue
 		}
 
-		result, err := migration.Apply(f.path, f.fileType, cliFS)
+		result, err := migration.ApplyWithMetamodel(f.path, f.fileType, cliFS, meta)
 		if err != nil {
 			return fmt.Errorf("migrating %s: %w", f.name, err)
 		}

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -220,7 +220,7 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 	for i, col := range list.Columns {
 		rc := ResolvedColumn{
 			Property: col.Property,
-			Label:    col.Label,
+			Label:    coalesce(col.Label, titleCase(col.Property)),
 			Sortable: col.Sortable,
 			Link:     col.Link,
 		}
@@ -396,7 +396,44 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		targetDef, _ := a.meta.GetEntityDef(rel.TargetType)
+		// Resolve direction from metamodel if not specified.
+		direction := rel.Direction
+		relDef, relDefOK := a.meta.GetRelationDef(rel.Relation)
+		if direction == "" && relDefOK {
+			inFrom := containsString(relDef.From, form.EntityType)
+			inTo := containsString(relDef.To, form.EntityType)
+			if inFrom && !inTo {
+				direction = "outgoing"
+			} else if inTo && !inFrom {
+				direction = "incoming"
+			}
+			// If in both or neither, direction remains empty (caller must specify)
+		}
+
+		// Resolve target type from metamodel if not specified.
+		targetType := rel.TargetType
+		if targetType == "" && relDefOK {
+			if direction == "incoming" {
+				if len(relDef.From) == 1 {
+					targetType = relDef.From[0]
+				}
+			} else {
+				if len(relDef.To) == 1 {
+					targetType = relDef.To[0]
+				}
+			}
+		}
+
+		// Resolve label from metamodel if not specified.
+		label := rel.Label
+		if label == "" && relDefOK {
+			label = relDef.Label
+		}
+		if label == "" {
+			label = titleCase(rel.Relation)
+		}
+
+		targetDef, _ := a.meta.GetEntityDef(targetType)
 		targetLabel := ""
 		if targetDef != nil {
 			targetLabel = targetDef.Label
@@ -404,10 +441,10 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 
 		rr := ResolvedRelation{
 			Relation:      rel.Relation,
-			Label:         rel.Label,
+			Label:         label,
 			Required:      rel.Required,
 			Widget:        coalesce(rel.Widget, "select"),
-			TargetType:    rel.TargetType,
+			TargetType:    targetType,
 			TargetLabel:   targetLabel,
 			AllowCreate:   rel.AllowCreate,
 			CreateForm:    rel.CreateForm,
@@ -415,13 +452,13 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 			SelectedProps: make(map[string]map[string]string),
 		}
 
-		targets := a.g.NodesByType(rel.TargetType)
+		targets := a.g.NodesByType(targetType)
 		for _, t := range targets {
 			rr.Options = append(rr.Options, struct{ ID, Title string }{t.ID, a.entityDisplayTitle(t)})
 		}
 
 		if entity != nil {
-			if rel.Direction == "incoming" {
+			if direction == "incoming" {
 				for _, edge := range a.g.IncomingEdges(entity.ID) {
 					if edge.Type == rel.Relation {
 						rr.Selected = append(rr.Selected, edge.From)

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -119,6 +119,16 @@ func coalesce(vals ...string) string {
 	return ""
 }
 
+// containsString returns true if slice contains the given string.
+func containsString(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
 // slugify converts a string to a URL-safe slug (lowercase, hyphens, no special chars).
 func slugify(s string) string {
 	s = strings.ToLower(s)

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -269,6 +269,30 @@ func TestCoalesce(t *testing.T) {
 	}
 }
 
+func TestContainsString(t *testing.T) {
+	tests := []struct {
+		name  string
+		slice []string
+		s     string
+		want  bool
+	}{
+		{"found", []string{"a", "b", "c"}, "b", true},
+		{"not found", []string{"a", "b", "c"}, "d", false},
+		{"empty slice", []string{}, "a", false},
+		{"nil slice", nil, "a", false},
+		{"empty string found", []string{"", "b"}, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := containsString(tt.slice, tt.s)
+			if got != tt.want {
+				t.Errorf("containsString(%v, %q) = %v, want %v", tt.slice, tt.s, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSlugify(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -81,6 +81,31 @@ func Load(path string, fs storage.FS) (*Metamodel, error) {
 	return m, nil
 }
 
+// LoadWithoutMigrationCheck loads a metamodel without checking for migrations.
+// This is used by the migrate command itself to avoid chicken-and-egg issues.
+// Returns nil if loading fails (caller should handle gracefully).
+func LoadWithoutMigrationCheck(path string, fs storage.FS) (*Metamodel, error) {
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	m, err := parseRaw(data)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(m.Includes) > 0 {
+		rootDir := filepath.Dir(path)
+		if err := loadWithIncludes(m, path, rootDir, fs); err != nil {
+			return nil, err
+		}
+	}
+
+	// Skip validation since metamodel may be in a migration state
+	return m, nil
+}
+
 // Parse parses and validates metamodel YAML content.
 func Parse(data []byte) (*Metamodel, error) {
 	m, err := parseRaw(data)

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -634,6 +634,90 @@ func (m *Metamodel) GetTypes() interface{} {
 	return m.Types
 }
 
+// Methods implementing migration.MetamodelProvider interface
+
+// GetPropertyType returns the type of a property for an entity type (empty if not found).
+func (m *Metamodel) GetPropertyType(entityType, property string) string {
+	entDef, ok := m.GetEntityDef(entityType)
+	if !ok {
+		return ""
+	}
+	propDef, ok := entDef.Properties[property]
+	if !ok {
+		return ""
+	}
+	return propDef.Type
+}
+
+// IsPropertyRequired returns whether a property is required.
+func (m *Metamodel) IsPropertyRequired(entityType, property string) bool {
+	entDef, ok := m.GetEntityDef(entityType)
+	if !ok {
+		return false
+	}
+	propDef, ok := entDef.Properties[property]
+	if !ok {
+		return false
+	}
+	return propDef.Required
+}
+
+// GetPropertyDefault returns the default value for a property.
+func (m *Metamodel) GetPropertyDefault(entityType, property string) string {
+	entDef, ok := m.GetEntityDef(entityType)
+	if !ok {
+		return ""
+	}
+	propDef, ok := entDef.Properties[property]
+	if !ok {
+		return ""
+	}
+	return propDef.Default
+}
+
+// GetTypeDefault returns the default value for a custom type.
+func (m *Metamodel) GetTypeDefault(typeName string) string {
+	if ct, ok := m.Types[typeName]; ok {
+		return ct.Default
+	}
+	return ""
+}
+
+// IsEnumType returns whether a type is an enum-like type (has values).
+func (m *Metamodel) IsEnumType(typeName string) bool {
+	if ct, ok := m.Types[typeName]; ok {
+		return len(ct.Values) > 0
+	}
+	return false
+}
+
+// GetRelationLabel returns the label for a relation (empty if not found).
+func (m *Metamodel) GetRelationLabel(relation string) string {
+	relDef, ok := m.GetRelationDef(relation)
+	if !ok {
+		return ""
+	}
+	return relDef.Label
+}
+
+// GetRelationFrom returns the "from" entity types for a relation.
+func (m *Metamodel) GetRelationFrom(relation string) []string {
+	relDef, ok := m.GetRelationDef(relation)
+	if !ok {
+		return nil
+	}
+	return relDef.From
+}
+
+// GetRelationTo returns the "to" entity types for a relation.
+func (m *Metamodel) GetRelationTo(relation string) []string {
+	relDef, ok := m.GetRelationDef(relation)
+	if !ok {
+		return nil
+	}
+	return relDef.To
+}
+
 // Schema output interface methods for EntityDef
 
 // GetLabel returns the entity label

--- a/internal/migration/dataentry_cleanup.go
+++ b/internal/migration/dataentry_cleanup.go
@@ -1,0 +1,483 @@
+package migration
+
+import (
+	"strings"
+	"unicode"
+
+	"gopkg.in/yaml.v3"
+)
+
+func init() {
+	Register(&DataEntryCleanupMigration{})
+}
+
+// DataEntryCleanupMigration removes redundant properties from data-entry.yaml
+// that can be auto-resolved at runtime. When provided with a metamodel (via
+// SetMetamodel), it can detect and remove:
+//   - label matching titleCase(property)
+//   - widget matching the type→widget mapping
+//   - required matching metamodel property
+//   - default matching metamodel/type default
+//   - direction when unambiguous from metamodel
+//   - target_type when single target in metamodel
+//   - relation label matching metamodel relation label or titleCase
+//
+// Without a metamodel, it only removes labels matching titleCase and widget: select.
+type DataEntryCleanupMigration struct {
+	meta MetamodelProvider
+}
+
+// SetMetamodel implements MetamodelAware.
+func (m *DataEntryCleanupMigration) SetMetamodel(meta MetamodelProvider) {
+	m.meta = meta
+}
+
+func (m *DataEntryCleanupMigration) Name() string {
+	return "dataentry-cleanup"
+}
+
+func (m *DataEntryCleanupMigration) Description() string {
+	if m.meta != nil {
+		return "Remove redundant properties from data-entry.yaml (using metamodel)"
+	}
+	return "Remove redundant labels and default widgets from data-entry.yaml"
+}
+
+func (m *DataEntryCleanupMigration) FileTypes() []FileType {
+	return []FileType{FileTypeDataEntry}
+}
+
+func (m *DataEntryCleanupMigration) Detect(doc *yaml.Node) bool {
+	root := GetDocumentRoot(doc)
+	if root == nil {
+		return false
+	}
+
+	// Check forms section
+	forms := GetMapValue(root, "forms")
+	if forms != nil && forms.Kind == yaml.MappingNode {
+		if m.detectInForms(forms) {
+			return true
+		}
+	}
+
+	// Check lists section
+	lists := GetMapValue(root, "lists")
+	if lists != nil && lists.Kind == yaml.MappingNode {
+		if m.detectInLists(lists) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *DataEntryCleanupMigration) detectInForms(forms *yaml.Node) bool {
+	for i := 1; i < len(forms.Content); i += 2 {
+		formDef := forms.Content[i]
+		if formDef.Kind != yaml.MappingNode {
+			continue
+		}
+
+		entityType := getScalarValue(formDef, "entity_type")
+		if m.detectInFormFields(formDef, entityType) || m.detectInFormRelations(formDef, entityType) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *DataEntryCleanupMigration) detectInFormFields(formDef *yaml.Node, entityType string) bool {
+	fields := GetMapValue(formDef, "fields")
+	if fields == nil || fields.Kind != yaml.SequenceNode {
+		return false
+	}
+	for _, field := range fields.Content {
+		if field.Kind == yaml.MappingNode && m.isRedundantField(field, entityType) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *DataEntryCleanupMigration) detectInFormRelations(formDef *yaml.Node, entityType string) bool {
+	relations := GetMapValue(formDef, "relations")
+	if relations == nil || relations.Kind != yaml.SequenceNode {
+		return false
+	}
+	for _, rel := range relations.Content {
+		if rel.Kind == yaml.MappingNode && m.isRedundantRelation(rel, entityType) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *DataEntryCleanupMigration) detectInLists(lists *yaml.Node) bool {
+	for i := 1; i < len(lists.Content); i += 2 {
+		listDef := lists.Content[i]
+		if listDef.Kind != yaml.MappingNode {
+			continue
+		}
+
+		columns := GetMapValue(listDef, "columns")
+		if columns != nil && columns.Kind == yaml.SequenceNode {
+			for _, col := range columns.Content {
+				if col.Kind == yaml.MappingNode && m.isRedundantLabel(col) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// isRedundantField checks if any property in this field is redundant.
+func (m *DataEntryCleanupMigration) isRedundantField(node *yaml.Node, entityType string) bool {
+	return m.isRedundantLabel(node) ||
+		m.isRedundantWidget(node, entityType) ||
+		m.isRedundantRequired(node, entityType) ||
+		m.isRedundantDefault(node, entityType)
+}
+
+// isRedundantRelation checks if any property in this relation is redundant.
+func (m *DataEntryCleanupMigration) isRedundantRelation(node *yaml.Node, entityType string) bool {
+	return m.isRedundantRelationWidget(node) ||
+		m.isRedundantRelationLabel(node) ||
+		m.isRedundantDirection(node, entityType) ||
+		m.isRedundantTargetType(node, entityType)
+}
+
+// isRedundantLabel checks if label matches titleCase(property).
+func (m *DataEntryCleanupMigration) isRedundantLabel(node *yaml.Node) bool {
+	prop := getScalarValue(node, "property")
+	label := getScalarValue(node, "label")
+	if prop == "" || label == "" {
+		return false
+	}
+	return label == titleCase(prop)
+}
+
+// isRedundantWidget checks if widget matches the type→widget mapping.
+func (m *DataEntryCleanupMigration) isRedundantWidget(node *yaml.Node, entityType string) bool {
+	if m.meta == nil {
+		return false
+	}
+
+	prop := getScalarValue(node, "property")
+	widget := getScalarValue(node, "widget")
+	if prop == "" || widget == "" {
+		return false
+	}
+
+	propType := m.meta.GetPropertyType(entityType, prop)
+	if propType == "" {
+		return false
+	}
+
+	expectedWidget := resolveWidgetFromType(propType, m.meta)
+	return widget == expectedWidget
+}
+
+// isRedundantRequired checks if required matches metamodel.
+func (m *DataEntryCleanupMigration) isRedundantRequired(node *yaml.Node, entityType string) bool {
+	if m.meta == nil {
+		return false
+	}
+
+	prop := getScalarValue(node, "property")
+	requiredVal := getScalarValue(node, "required")
+	if prop == "" || requiredVal == "" {
+		return false
+	}
+
+	// Check if the required value matches metamodel
+	metaRequired := m.meta.IsPropertyRequired(entityType, prop)
+	formRequired := requiredVal == "true"
+	return formRequired == metaRequired
+}
+
+// isRedundantDefault checks if default matches metamodel/type default.
+func (m *DataEntryCleanupMigration) isRedundantDefault(node *yaml.Node, entityType string) bool {
+	if m.meta == nil {
+		return false
+	}
+
+	prop := getScalarValue(node, "property")
+	defaultVal := getScalarValue(node, "default")
+	if prop == "" || defaultVal == "" {
+		return false
+	}
+
+	// Check property default first
+	propDefault := m.meta.GetPropertyDefault(entityType, prop)
+	if propDefault != "" {
+		return defaultVal == propDefault
+	}
+
+	// Check custom type default
+	propType := m.meta.GetPropertyType(entityType, prop)
+	if propType != "" {
+		typeDefault := m.meta.GetTypeDefault(propType)
+		if typeDefault != "" {
+			return defaultVal == typeDefault
+		}
+	}
+
+	return false
+}
+
+// isRedundantRelationWidget checks if widget is "select" (the default).
+func (m *DataEntryCleanupMigration) isRedundantRelationWidget(node *yaml.Node) bool {
+	widget := getScalarValue(node, "widget")
+	return widget == "select"
+}
+
+// isRedundantRelationLabel checks if relation label matches metamodel or titleCase.
+func (m *DataEntryCleanupMigration) isRedundantRelationLabel(node *yaml.Node) bool {
+	rel := getScalarValue(node, "relation")
+	label := getScalarValue(node, "label")
+	if rel == "" || label == "" {
+		return false
+	}
+
+	// Check if matches metamodel label
+	if m.meta != nil {
+		relLabel := m.meta.GetRelationLabel(rel)
+		if relLabel != "" && label == relLabel {
+			return true
+		}
+	}
+
+	// Check if matches titleCase
+	return label == titleCase(rel)
+}
+
+// isRedundantDirection checks if direction can be inferred from metamodel.
+func (m *DataEntryCleanupMigration) isRedundantDirection(node *yaml.Node, entityType string) bool {
+	if m.meta == nil || entityType == "" {
+		return false
+	}
+
+	rel := getScalarValue(node, "relation")
+	direction := getScalarValue(node, "direction")
+	if rel == "" || direction == "" {
+		return false
+	}
+
+	fromTypes := m.meta.GetRelationFrom(rel)
+	toTypes := m.meta.GetRelationTo(rel)
+	if len(fromTypes) == 0 && len(toTypes) == 0 {
+		return false
+	}
+
+	inFrom := containsStr(fromTypes, entityType)
+	inTo := containsStr(toTypes, entityType)
+
+	// Direction is redundant if it can be unambiguously inferred
+	if inFrom && !inTo && direction == "outgoing" {
+		return true
+	}
+	if inTo && !inFrom && direction == "incoming" {
+		return true
+	}
+
+	return false
+}
+
+// isRedundantTargetType checks if target_type can be inferred from metamodel.
+func (m *DataEntryCleanupMigration) isRedundantTargetType(node *yaml.Node, entityType string) bool {
+	if m.meta == nil {
+		return false
+	}
+
+	rel := getScalarValue(node, "relation")
+	targetType := getScalarValue(node, "target_type")
+	direction := getScalarValue(node, "direction")
+	if rel == "" || targetType == "" {
+		return false
+	}
+
+	fromTypes := m.meta.GetRelationFrom(rel)
+	toTypes := m.meta.GetRelationTo(rel)
+	if len(fromTypes) == 0 && len(toTypes) == 0 {
+		return false
+	}
+
+	// Infer direction if not specified
+	if direction == "" && entityType != "" {
+		inFrom := containsStr(fromTypes, entityType)
+		inTo := containsStr(toTypes, entityType)
+		if inFrom && !inTo {
+			direction = "outgoing"
+		} else if inTo && !inFrom {
+			direction = "incoming"
+		}
+	}
+
+	// Check if target_type matches the only possible target
+	if direction == "incoming" && len(fromTypes) == 1 {
+		return targetType == fromTypes[0]
+	}
+	if direction == "outgoing" && len(toTypes) == 1 {
+		return targetType == toTypes[0]
+	}
+
+	return false
+}
+
+func (m *DataEntryCleanupMigration) Apply(doc *yaml.Node) error {
+	root := GetDocumentRoot(doc)
+	if root == nil {
+		return nil
+	}
+
+	forms := GetMapValue(root, "forms")
+	if forms != nil && forms.Kind == yaml.MappingNode {
+		m.cleanupForms(forms)
+	}
+
+	lists := GetMapValue(root, "lists")
+	if lists != nil && lists.Kind == yaml.MappingNode {
+		m.cleanupLists(lists)
+	}
+
+	return nil
+}
+
+func (m *DataEntryCleanupMigration) cleanupForms(forms *yaml.Node) {
+	for i := 1; i < len(forms.Content); i += 2 {
+		formDef := forms.Content[i]
+		if formDef.Kind != yaml.MappingNode {
+			continue
+		}
+		entityType := getScalarValue(formDef, "entity_type")
+		m.cleanupFormFields(formDef, entityType)
+		m.cleanupFormRelations(formDef, entityType)
+	}
+}
+
+func (m *DataEntryCleanupMigration) cleanupFormFields(formDef *yaml.Node, entityType string) {
+	fields := GetMapValue(formDef, "fields")
+	if fields == nil || fields.Kind != yaml.SequenceNode {
+		return
+	}
+	for _, field := range fields.Content {
+		if field.Kind != yaml.MappingNode {
+			continue
+		}
+		if m.isRedundantLabel(field) {
+			DeleteMapKey(field, "label")
+		}
+		if m.isRedundantWidget(field, entityType) {
+			DeleteMapKey(field, "widget")
+		}
+		if m.isRedundantRequired(field, entityType) {
+			DeleteMapKey(field, "required")
+		}
+		if m.isRedundantDefault(field, entityType) {
+			DeleteMapKey(field, "default")
+		}
+	}
+}
+
+func (m *DataEntryCleanupMigration) cleanupFormRelations(formDef *yaml.Node, entityType string) {
+	relations := GetMapValue(formDef, "relations")
+	if relations == nil || relations.Kind != yaml.SequenceNode {
+		return
+	}
+	for _, rel := range relations.Content {
+		if rel.Kind != yaml.MappingNode {
+			continue
+		}
+		if m.isRedundantRelationWidget(rel) {
+			DeleteMapKey(rel, "widget")
+		}
+		if m.isRedundantRelationLabel(rel) {
+			DeleteMapKey(rel, "label")
+		}
+		if m.isRedundantDirection(rel, entityType) {
+			DeleteMapKey(rel, "direction")
+		}
+		if m.isRedundantTargetType(rel, entityType) {
+			DeleteMapKey(rel, "target_type")
+		}
+	}
+}
+
+func (m *DataEntryCleanupMigration) cleanupLists(lists *yaml.Node) {
+	for i := 1; i < len(lists.Content); i += 2 {
+		listDef := lists.Content[i]
+		if listDef.Kind != yaml.MappingNode {
+			continue
+		}
+
+		columns := GetMapValue(listDef, "columns")
+		if columns == nil || columns.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, col := range columns.Content {
+			if col.Kind == yaml.MappingNode && m.isRedundantLabel(col) {
+				DeleteMapKey(col, "label")
+			}
+		}
+	}
+}
+
+// Helper functions
+
+func getScalarValue(node *yaml.Node, key string) string {
+	val := GetMapValue(node, key)
+	if val != nil && val.Kind == yaml.ScalarNode {
+		return val.Value
+	}
+	return ""
+}
+
+func containsStr(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveWidgetFromType returns the expected widget for a property type.
+func resolveWidgetFromType(propType string, meta MetamodelProvider) string {
+	switch propType {
+	case "string":
+		return "text"
+	case "date":
+		return "date"
+	case "integer":
+		return "number"
+	case "boolean":
+		return "checkbox"
+	case "enum":
+		return "select"
+	default:
+		// Check if it's a custom type with values (enum-like)
+		if meta != nil && meta.IsEnumType(propType) {
+			return "select"
+		}
+		return "text"
+	}
+}
+
+// titleCase converts snake_case or kebab-case to Title Case.
+func titleCase(s string) string {
+	s = strings.ReplaceAll(s, "_", " ")
+	s = strings.ReplaceAll(s, "-", " ")
+
+	words := strings.Fields(s)
+	for i, word := range words {
+		if word != "" {
+			runes := []rune(word)
+			runes[0] = unicode.ToUpper(runes[0])
+			words[i] = string(runes)
+		}
+	}
+
+	return strings.Join(words, " ")
+}

--- a/internal/migration/dataentry_cleanup_test.go
+++ b/internal/migration/dataentry_cleanup_test.go
@@ -1,0 +1,710 @@
+package migration
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// mockMetamodel implements MetamodelProvider for testing.
+type mockMetamodel struct {
+	entities  map[string]mockEntityDef
+	relations map[string]mockRelationDef
+	types     map[string]mockCustomType
+}
+
+type mockEntityDef struct {
+	properties map[string]mockPropertyDef
+}
+
+type mockPropertyDef struct {
+	propType string
+	required bool
+	defValue string
+}
+
+type mockRelationDef struct {
+	label string
+	from  []string
+	to    []string
+}
+
+type mockCustomType struct {
+	values   []string
+	defValue string
+}
+
+func (m *mockMetamodel) GetPropertyType(entityType, property string) string {
+	if ent, ok := m.entities[entityType]; ok {
+		if prop, ok := ent.properties[property]; ok {
+			return prop.propType
+		}
+	}
+	return ""
+}
+
+func (m *mockMetamodel) IsPropertyRequired(entityType, property string) bool {
+	if ent, ok := m.entities[entityType]; ok {
+		if prop, ok := ent.properties[property]; ok {
+			return prop.required
+		}
+	}
+	return false
+}
+
+func (m *mockMetamodel) GetPropertyDefault(entityType, property string) string {
+	if ent, ok := m.entities[entityType]; ok {
+		if prop, ok := ent.properties[property]; ok {
+			return prop.defValue
+		}
+	}
+	return ""
+}
+
+func (m *mockMetamodel) GetTypeDefault(typeName string) string {
+	if ct, ok := m.types[typeName]; ok {
+		return ct.defValue
+	}
+	return ""
+}
+
+func (m *mockMetamodel) IsEnumType(typeName string) bool {
+	if ct, ok := m.types[typeName]; ok {
+		return len(ct.values) > 0
+	}
+	return false
+}
+
+func (m *mockMetamodel) GetRelationLabel(relation string) string {
+	if rel, ok := m.relations[relation]; ok {
+		return rel.label
+	}
+	return ""
+}
+
+func (m *mockMetamodel) GetRelationFrom(relation string) []string {
+	if rel, ok := m.relations[relation]; ok {
+		return rel.from
+	}
+	return nil
+}
+
+func (m *mockMetamodel) GetRelationTo(relation string) []string {
+	if rel, ok := m.relations[relation]; ok {
+		return rel.to
+	}
+	return nil
+}
+
+func TestDataEntryCleanupMigration_Detect(t *testing.T) {
+	m := &DataEntryCleanupMigration{}
+
+	tests := []struct {
+		name   string
+		yaml   string
+		expect bool
+	}{
+		{
+			name: "detects redundant label in form field",
+			yaml: `
+forms:
+  create_ticket:
+    fields:
+      - property: title
+        label: "Title"
+`,
+			expect: true,
+		},
+		{
+			name: "detects redundant label in list column",
+			yaml: `
+lists:
+  all_tickets:
+    columns:
+      - property: status
+        label: "Status"
+`,
+			expect: true,
+		},
+		{
+			name: "detects redundant widget: select in relation",
+			yaml: `
+forms:
+  create_ticket:
+    relations:
+      - relation: belongs-to
+        widget: select
+`,
+			expect: true,
+		},
+		{
+			name: "does not detect custom label",
+			yaml: `
+forms:
+  create_ticket:
+    fields:
+      - property: assignee
+        label: "Assign to"
+`,
+			expect: false,
+		},
+		{
+			name: "does not detect non-default widget",
+			yaml: `
+forms:
+  create_ticket:
+    relations:
+      - relation: tagged
+        widget: multi-select
+`,
+			expect: false,
+		},
+		{
+			name: "handles snake_case property correctly",
+			yaml: `
+forms:
+  create_ticket:
+    fields:
+      - property: due_date
+        label: "Due Date"
+`,
+			expect: true,
+		},
+		{
+			name: "does not match partial label",
+			yaml: `
+forms:
+  create_ticket:
+    fields:
+      - property: due_date
+        label: "Due"
+`,
+			expect: false,
+		},
+		{
+			name: "empty config returns false",
+			yaml: `
+version: "1.0"
+`,
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var doc yaml.Node
+			if err := yaml.Unmarshal([]byte(tt.yaml), &doc); err != nil {
+				t.Fatalf("failed to parse YAML: %v", err)
+			}
+
+			got := m.Detect(&doc)
+			if got != tt.expect {
+				t.Errorf("Detect() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestDataEntryCleanupMigration_DetectWithMetamodel(t *testing.T) {
+	meta := &mockMetamodel{
+		types: map[string]mockCustomType{
+			"priority": {values: []string{"low", "medium", "high"}, defValue: "medium"},
+			"status":   {values: []string{"open", "closed"}, defValue: "open"},
+		},
+		entities: map[string]mockEntityDef{
+			"ticket": {
+				properties: map[string]mockPropertyDef{
+					"title":    {propType: "string", required: true},
+					"priority": {propType: "priority", required: true},
+					"status":   {propType: "status"},
+					"due_date": {propType: "date"},
+					"count":    {propType: "integer"},
+					"active":   {propType: "boolean"},
+				},
+			},
+		},
+		relations: map[string]mockRelationDef{
+			"belongs-to": {label: "belongs to", from: []string{"ticket"}, to: []string{"category"}},
+			"blocks":     {label: "blocks", from: []string{"ticket"}, to: []string{"ticket"}},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		yaml   string
+		expect bool
+	}{
+		{
+			name: "detects redundant widget matching type",
+			yaml: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    fields:
+      - property: due_date
+        widget: date
+`,
+			expect: true,
+		},
+		{
+			name: "detects redundant widget for integer",
+			yaml: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    fields:
+      - property: count
+        widget: number
+`,
+			expect: true,
+		},
+		{
+			name: "detects redundant widget for boolean",
+			yaml: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    fields:
+      - property: active
+        widget: checkbox
+`,
+			expect: true,
+		},
+		{
+			name: "detects redundant widget for custom type (select)",
+			yaml: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    fields:
+      - property: priority
+        widget: select
+`,
+			expect: true,
+		},
+		{
+			name: "detects redundant required matching metamodel",
+			yaml: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    fields:
+      - property: title
+        required: true
+`,
+			expect: true,
+		},
+		{
+			name: "detects redundant default matching type default",
+			yaml: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    fields:
+      - property: priority
+        default: medium
+`,
+			expect: true,
+		},
+		{
+			name: "detects redundant direction when unambiguous",
+			yaml: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    relations:
+      - relation: belongs-to
+        direction: outgoing
+`,
+			expect: true,
+		},
+		{
+			name: "detects redundant target_type when single target",
+			yaml: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    relations:
+      - relation: belongs-to
+        target_type: category
+`,
+			expect: true,
+		},
+		{
+			name: "detects redundant relation label matching metamodel",
+			yaml: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    relations:
+      - relation: belongs-to
+        label: "belongs to"
+`,
+			expect: true,
+		},
+		{
+			name: "does not detect non-redundant direction (ambiguous)",
+			yaml: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    relations:
+      - relation: blocks
+        direction: outgoing
+`,
+			expect: false,
+		},
+		{
+			name: "does not detect non-redundant widget (textarea for string)",
+			yaml: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    fields:
+      - property: title
+        widget: textarea
+`,
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &DataEntryCleanupMigration{}
+			m.SetMetamodel(meta)
+
+			var doc yaml.Node
+			if err := yaml.Unmarshal([]byte(tt.yaml), &doc); err != nil {
+				t.Fatalf("failed to parse YAML: %v", err)
+			}
+
+			got := m.Detect(&doc)
+			if got != tt.expect {
+				t.Errorf("Detect() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestDataEntryCleanupMigration_Apply(t *testing.T) {
+	m := &DataEntryCleanupMigration{}
+
+	tests := []struct {
+		name       string
+		input      string
+		wantAbsent []string
+		wantKeep   []string
+	}{
+		{
+			name: "removes redundant label from form field",
+			input: `
+forms:
+  create_ticket:
+    fields:
+      - property: title
+        label: "Title"
+        placeholder: "Enter title"
+`,
+			wantAbsent: []string{`label: "Title"`, `label: Title`},
+			wantKeep:   []string{"property: title", "placeholder:"},
+		},
+		{
+			name: "removes redundant label from list column",
+			input: `
+lists:
+  all_tickets:
+    columns:
+      - property: status
+        label: "Status"
+        sortable: true
+`,
+			wantAbsent: []string{`label: "Status"`, `label: Status`},
+			wantKeep:   []string{"property: status", "sortable: true"},
+		},
+		{
+			name: "removes widget: select from relation",
+			input: `
+forms:
+  create_ticket:
+    relations:
+      - relation: belongs-to
+        widget: select
+        required: true
+`,
+			wantAbsent: []string{"widget: select"},
+			wantKeep:   []string{"relation: belongs-to", "required: true"},
+		},
+		{
+			name: "keeps custom labels",
+			input: `
+forms:
+  create_ticket:
+    fields:
+      - property: assignee
+        label: "Assign to"
+`,
+			wantAbsent: []string{},
+			wantKeep:   []string{"label:", "Assign to", "property: assignee"},
+		},
+		{
+			name: "keeps non-default widgets",
+			input: `
+forms:
+  create_ticket:
+    relations:
+      - relation: tagged
+        widget: multi-select
+`,
+			wantAbsent: []string{},
+			wantKeep:   []string{"widget: multi-select"},
+		},
+		{
+			name: "handles mixed redundant and custom",
+			input: `
+forms:
+  create_ticket:
+    fields:
+      - property: title
+        label: "Title"
+      - property: assignee
+        label: "Assign to"
+    relations:
+      - relation: belongs-to
+        widget: select
+      - relation: tagged
+        widget: multi-select
+`,
+			wantAbsent: []string{`label: "Title"`, `label: Title`},
+			wantKeep:   []string{"Assign to", "widget: multi-select"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var doc yaml.Node
+			if err := yaml.Unmarshal([]byte(tt.input), &doc); err != nil {
+				t.Fatalf("failed to parse YAML: %v", err)
+			}
+
+			if err := m.Apply(&doc); err != nil {
+				t.Fatalf("Apply() error: %v", err)
+			}
+
+			output, err := yaml.Marshal(&doc)
+			if err != nil {
+				t.Fatalf("failed to marshal result: %v", err)
+			}
+			result := string(output)
+
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(result, absent) {
+					t.Errorf("output should not contain %q:\n%s", absent, result)
+				}
+			}
+
+			for _, keep := range tt.wantKeep {
+				if !strings.Contains(result, keep) {
+					t.Errorf("output should contain %q:\n%s", keep, result)
+				}
+			}
+		})
+	}
+}
+
+func TestDataEntryCleanupMigration_ApplyWithMetamodel(t *testing.T) {
+	meta := &mockMetamodel{
+		types: map[string]mockCustomType{
+			"priority": {values: []string{"low", "medium", "high"}, defValue: "medium"},
+		},
+		entities: map[string]mockEntityDef{
+			"ticket": {
+				properties: map[string]mockPropertyDef{
+					"title":    {propType: "string", required: true},
+					"priority": {propType: "priority"},
+					"due_date": {propType: "date"},
+				},
+			},
+		},
+		relations: map[string]mockRelationDef{
+			"belongs-to": {label: "belongs to", from: []string{"ticket"}, to: []string{"category"}},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		input      string
+		wantAbsent []string
+		wantKeep   []string
+	}{
+		{
+			name: "removes redundant widget for date type",
+			input: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    fields:
+      - property: due_date
+        widget: date
+        label: "Due"
+`,
+			wantAbsent: []string{"widget: date"},
+			wantKeep:   []string{"property: due_date", "label: "},
+		},
+		{
+			name: "removes redundant required",
+			input: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    fields:
+      - property: title
+        required: true
+`,
+			wantAbsent: []string{"required: true"},
+			wantKeep:   []string{"property: title"},
+		},
+		{
+			name: "removes redundant default",
+			input: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    fields:
+      - property: priority
+        default: medium
+`,
+			wantAbsent: []string{"default: medium"},
+			wantKeep:   []string{"property: priority"},
+		},
+		{
+			name: "removes redundant direction and target_type",
+			input: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    relations:
+      - relation: belongs-to
+        direction: outgoing
+        target_type: category
+        required: true
+`,
+			wantAbsent: []string{"direction: outgoing", "target_type: category"},
+			wantKeep:   []string{"relation: belongs-to", "required: true"},
+		},
+		{
+			name: "removes redundant relation label",
+			input: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    relations:
+      - relation: belongs-to
+        label: "belongs to"
+`,
+			wantAbsent: []string{"label: belongs to", `label: "belongs to"`},
+			wantKeep:   []string{"relation: belongs-to"},
+		},
+		{
+			name: "keeps custom relation label",
+			input: `
+forms:
+  create_ticket:
+    entity_type: ticket
+    relations:
+      - relation: belongs-to
+        label: "Category"
+`,
+			wantAbsent: []string{},
+			wantKeep:   []string{"label:", "Category"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &DataEntryCleanupMigration{}
+			m.SetMetamodel(meta)
+
+			var doc yaml.Node
+			if err := yaml.Unmarshal([]byte(tt.input), &doc); err != nil {
+				t.Fatalf("failed to parse YAML: %v", err)
+			}
+
+			if err := m.Apply(&doc); err != nil {
+				t.Fatalf("Apply() error: %v", err)
+			}
+
+			output, err := yaml.Marshal(&doc)
+			if err != nil {
+				t.Fatalf("failed to marshal result: %v", err)
+			}
+			result := string(output)
+
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(result, absent) {
+					t.Errorf("output should not contain %q:\n%s", absent, result)
+				}
+			}
+
+			for _, keep := range tt.wantKeep {
+				if !strings.Contains(result, keep) {
+					t.Errorf("output should contain %q:\n%s", keep, result)
+				}
+			}
+		})
+	}
+}
+
+func TestTitleCase(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"title", "Title"},
+		{"due_date", "Due Date"},
+		{"first-name", "First Name"},
+		{"status", "Status"},
+		{"estimated_hours", "Estimated Hours"},
+		{"is_blocked", "Is Blocked"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := titleCase(tt.input)
+			if got != tt.want {
+				t.Errorf("titleCase(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveWidgetFromType(t *testing.T) {
+	meta := &mockMetamodel{
+		types: map[string]mockCustomType{
+			"priority": {values: []string{"low", "high"}},
+		},
+	}
+
+	tests := []struct {
+		propType string
+		want     string
+	}{
+		{"string", "text"},
+		{"date", "date"},
+		{"integer", "number"},
+		{"boolean", "checkbox"},
+		{"enum", "select"},
+		{"priority", "select"},
+		{"unknown", "text"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.propType, func(t *testing.T) {
+			got := resolveWidgetFromType(tt.propType, meta)
+			if got != tt.want {
+				t.Errorf("resolveWidgetFromType(%q) = %q, want %q", tt.propType, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -3,9 +3,28 @@
 // comments and formatting using yaml.Node AST manipulation.
 package migration
 
-import (
-	"gopkg.in/yaml.v3"
-)
+import "gopkg.in/yaml.v3"
+
+// MetamodelProvider provides metamodel data for context-aware migrations.
+// This interface is satisfied by *metamodel.Metamodel.
+type MetamodelProvider interface {
+	// GetPropertyType returns the type of a property for an entity type (empty if not found).
+	GetPropertyType(entityType, property string) string
+	// IsPropertyRequired returns whether a property is required.
+	IsPropertyRequired(entityType, property string) bool
+	// GetPropertyDefault returns the default value for a property.
+	GetPropertyDefault(entityType, property string) string
+	// GetTypeDefault returns the default value for a custom type.
+	GetTypeDefault(typeName string) string
+	// IsEnumType returns whether a type is an enum-like type (has values).
+	IsEnumType(typeName string) bool
+	// GetRelationLabel returns the label for a relation (empty if not found).
+	GetRelationLabel(relation string) string
+	// GetRelationFrom returns the "from" entity types for a relation.
+	GetRelationFrom(relation string) []string
+	// GetRelationTo returns the "to" entity types for a relation.
+	GetRelationTo(relation string) []string
+}
 
 // FileType identifies which project files a migration applies to.
 type FileType string
@@ -35,6 +54,17 @@ type Migration interface {
 	// Apply transforms the YAML document in-place.
 	// It should only be called if Detect returned true.
 	Apply(doc *yaml.Node) error
+}
+
+// MetamodelAware is an optional interface for migrations that need access to the
+// metamodel for context-aware detection and transformation. Migrations implementing
+// this interface will receive the metamodel when processing data-entry.yaml files.
+type MetamodelAware interface {
+	Migration
+
+	// SetMetamodel provides the metamodel to the migration.
+	// Called by the runner before Detect/Apply for data-entry migrations.
+	SetMetamodel(meta MetamodelProvider)
 }
 
 // registry holds all registered migrations in order of application.

--- a/internal/migration/runner.go
+++ b/internal/migration/runner.go
@@ -36,6 +36,12 @@ type FileResult struct {
 // Detect checks a YAML file for migrations that need to be applied
 // using the given filesystem.
 func Detect(path string, ft FileType, fs storage.FS) ([]DetectionResult, error) {
+	return DetectWithMetamodel(path, ft, fs, nil)
+}
+
+// DetectWithMetamodel checks a YAML file for migrations, passing the metamodel
+// to migrations that implement MetamodelAware.
+func DetectWithMetamodel(path string, ft FileType, fs storage.FS, meta MetamodelProvider) ([]DetectionResult, error) {
 	data, err := fs.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading file: %w", err)
@@ -46,7 +52,7 @@ func Detect(path string, ft FileType, fs storage.FS) ([]DetectionResult, error) 
 		return nil, fmt.Errorf("parsing YAML: %w", err)
 	}
 
-	return DetectFromNode(&doc, ft), nil
+	return DetectFromNodeWithMetamodel(&doc, ft, meta), nil
 }
 
 // DetectBytes checks YAML content for migrations that need to be applied.
@@ -61,10 +67,21 @@ func DetectBytes(data []byte, ft FileType) []DetectionResult {
 
 // DetectFromNode checks a parsed YAML document for migrations.
 func DetectFromNode(doc *yaml.Node, ft FileType) []DetectionResult {
+	return DetectFromNodeWithMetamodel(doc, ft, nil)
+}
+
+// DetectFromNodeWithMetamodel checks a parsed YAML document for migrations,
+// passing the metamodel to migrations that implement MetamodelAware.
+func DetectFromNodeWithMetamodel(doc *yaml.Node, ft FileType, meta MetamodelProvider) []DetectionResult {
 	var results []DetectionResult
 	migrations := ForFileType(ft)
 
 	for _, m := range migrations {
+		// Pass metamodel to migrations that need it
+		if ma, ok := m.(MetamodelAware); ok && meta != nil {
+			ma.SetMetamodel(meta)
+		}
+
 		if m.Detect(doc) {
 			results = append(results, DetectionResult{
 				Migration:   m,
@@ -79,6 +96,12 @@ func DetectFromNode(doc *yaml.Node, ft FileType) []DetectionResult {
 // Apply runs all applicable migrations on a file using the given filesystem.
 // Returns results for each migration attempted.
 func Apply(path string, ft FileType, fs storage.FS) (*FileResult, error) {
+	return ApplyWithMetamodel(path, ft, fs, nil)
+}
+
+// ApplyWithMetamodel runs all applicable migrations on a file, passing the metamodel
+// to migrations that implement MetamodelAware.
+func ApplyWithMetamodel(path string, ft FileType, fs storage.FS, meta MetamodelProvider) (*FileResult, error) {
 	data, err := fs.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading file: %w", err)
@@ -95,13 +118,13 @@ func Apply(path string, ft FileType, fs storage.FS) (*FileResult, error) {
 	}
 
 	// First detect what needs migration
-	result.Detections = DetectFromNode(&doc, ft)
+	result.Detections = DetectFromNodeWithMetamodel(&doc, ft, meta)
 
 	if len(result.Detections) == 0 {
 		return result, nil
 	}
 
-	// Apply each detected migration
+	// Apply each detected migration (metamodel already set during detection)
 	for _, detection := range result.Detections {
 		mr := Result{Migration: detection.Migration}
 

--- a/internal/migration/yaml_util.go
+++ b/internal/migration/yaml_util.go
@@ -180,3 +180,19 @@ func GetDocumentRoot(doc *yaml.Node) *yaml.Node {
 	}
 	return doc
 }
+
+// DeleteMapKey removes a key-value pair from a mapping node by key name.
+// Returns true if the key was found and deleted.
+func DeleteMapKey(node *yaml.Node, key string) bool {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			// Remove both key and value (2 elements)
+			node.Content = append(node.Content[:i], node.Content[i+2:]...)
+			return true
+		}
+	}
+	return false
+}

--- a/internal/migration/yaml_util_test.go
+++ b/internal/migration/yaml_util_test.go
@@ -286,3 +286,45 @@ func TestGetDocumentRoot(t *testing.T) {
 		t.Error("GetDocumentRoot(nil) should return nil")
 	}
 }
+
+func TestDeleteMapKey(t *testing.T) {
+	yamlContent := `
+key1: value1
+key2: value2
+key3: value3
+`
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlContent), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+
+	root := GetDocumentRoot(&doc)
+
+	// Delete existing key
+	if !DeleteMapKey(root, "key2") {
+		t.Error("DeleteMapKey() returned false for existing key")
+	}
+
+	// Verify it's gone
+	if GetMapValue(root, "key2") != nil {
+		t.Error("key2 still exists after deletion")
+	}
+
+	// Verify other keys still exist
+	if GetMapValue(root, "key1") == nil {
+		t.Error("key1 should still exist")
+	}
+	if GetMapValue(root, "key3") == nil {
+		t.Error("key3 should still exist")
+	}
+
+	// Delete non-existing key
+	if DeleteMapKey(root, "nonexistent") {
+		t.Error("DeleteMapKey() returned true for non-existing key")
+	}
+
+	// Delete from nil
+	if DeleteMapKey(nil, "key") {
+		t.Error("DeleteMapKey(nil, ...) should return false")
+	}
+}

--- a/prototypes/data-entry/catalog/data-entry.yaml
+++ b/prototypes/data-entry/catalog/data-entry.yaml
@@ -27,56 +27,38 @@ forms:
       - property: name
         label: "Product Name"
         placeholder: "e.g., Wireless Keyboard MK-500"
-        required: true
 
       - property: sku
-        label: "SKU"
         placeholder: "e.g., WK-MK500-BLK"
         help: "Unique stock keeping unit identifier"
 
       - property: description
-        label: "Description"
         widget: textarea
 
       - property: price
         label: "Price (cents)"
-        widget: number
         placeholder: "4999"
         help: "Price in cents, e.g., 4999 = $49.99"
 
       - property: availability
-        label: "Availability"
-        default: in-stock
 
       - property: condition
-        label: "Condition"
-        default: new
 
       - property: weight_grams
         label: "Weight (g)"
-        widget: number
 
       - property: release_date
-        label: "Release Date"
-        widget: date
 
       - property: featured
-        label: "Featured Product"
-        widget: checkbox
 
     relations:
       - relation: made-by
-        direction: outgoing
-        target_type: brand
         label: "Brand"
         required: true
-        widget: select
         allow_create: true
         create_form: add_brand
 
       - relation: tagged
-        direction: outgoing
-        target_type: tag
         label: "Tags"
         widget: multi-select
         allow_create: true
@@ -93,47 +75,32 @@ forms:
         label: "Product Name"
 
       - property: sku
-        label: "SKU"
 
       - property: description
-        label: "Description"
         widget: textarea
 
       - property: price
         label: "Price (cents)"
-        widget: number
 
       - property: availability
-        label: "Availability"
 
       - property: condition
-        label: "Condition"
 
       - property: weight_grams
         label: "Weight (g)"
-        widget: number
 
       - property: release_date
-        label: "Release Date"
-        widget: date
 
       - property: featured
-        label: "Featured Product"
-        widget: checkbox
 
     relations:
       - relation: made-by
-        direction: outgoing
-        target_type: brand
         label: "Brand"
         required: true
-        widget: select
         allow_create: true
         create_form: add_brand
 
       - relation: tagged
-        direction: outgoing
-        target_type: tag
         label: "Tags"
         widget: multi-select
         allow_create: true
@@ -141,8 +108,6 @@ forms:
 
       - relation: accessory-for
         direction: outgoing
-        target_type: product
-        label: "Accessory For"
         widget: search
 
   add_brand:
@@ -152,15 +117,12 @@ forms:
     fields:
       - property: name
         label: "Brand Name"
-        required: true
         placeholder: "e.g., Logitech"
 
       - property: website
-        label: "Website"
         placeholder: "https://..."
 
       - property: country
-        label: "Country"
         placeholder: "e.g., Switzerland"
 
   add_tag:
@@ -170,7 +132,6 @@ forms:
     fields:
       - property: name
         label: "Tag Name"
-        required: true
         placeholder: "e.g., wireless, ergonomic, gaming"
 
 lists:
@@ -186,19 +147,15 @@ lists:
         link: true
 
       - property: sku
-        label: "SKU"
         sortable: true
 
       - property: price
-        label: "Price"
         sortable: true
 
       - property: availability
-        label: "Availability"
         sortable: true
 
       - property: condition
-        label: "Condition"
         sortable: true
 
     sort:
@@ -276,10 +233,8 @@ lists:
         sortable: true
         link: true
       - property: country
-        label: "Country"
         sortable: true
       - property: website
-        label: "Website"
 
     sort:
       property: name

--- a/prototypes/data-entry/project/data-entry.yaml
+++ b/prototypes/data-entry/project/data-entry.yaml
@@ -23,17 +23,12 @@ forms:
     body: true
     fields:
       - property: title
-        label: "Title"
         placeholder: "Brief summary of the issue..."
         help: "A short, descriptive title for the ticket"
-        required: true
       - property: description
-        label: "Description"
         widget: textarea
         help: "Detailed description of the issue"
       - property: priority
-        label: "Priority"
-        default: medium
       - property: reporter
         label: "Reported by"
         placeholder: "your.name"
@@ -41,27 +36,15 @@ forms:
         label: "Assign to"
         placeholder: "assignee.name"
       - property: due_date
-        label: "Due Date"
-        widget: date
       - property: estimated_hours
-        label: "Estimated Hours"
-        widget: number
       - property: status
         hidden: true
-        default: open
     relations:
       - relation: belongs-to
-        direction: outgoing
-        target_type: category
-        label: "Category"
         required: true
-        widget: select
         allow_create: true
         create_form: create_category
       - relation: tagged
-        direction: outgoing
-        target_type: label
-        label: "Labels"
         widget: multi-select
         allow_create: true
         create_form: create_label
@@ -72,14 +55,10 @@ forms:
     body: true
     fields:
       - property: title
-        label: "Title"
       - property: description
-        label: "Description"
         widget: textarea
       - property: priority
-        label: "Priority"
       - property: status
-        label: "Status"
         transitions:
           open: [in-progress, closed]
           in-progress: [open, resolved]
@@ -90,39 +69,23 @@ forms:
       - property: reporter
         label: "Reported by"
       - property: due_date
-        label: "Due Date"
-        widget: date
       - property: estimated_hours
-        label: "Estimated Hours"
-        widget: number
       - property: is_blocked
-        label: "Blocked"
-        widget: checkbox
     relations:
       - relation: belongs-to
-        direction: outgoing
-        target_type: category
-        label: "Category"
         required: true
-        widget: select
         allow_create: true
         create_form: create_category
       - relation: tagged
-        direction: outgoing
-        target_type: label
-        label: "Labels"
         widget: multi-select
         allow_create: true
         create_form: create_label
       - relation: blocks
         direction: outgoing
-        target_type: ticket
-        label: "Blocks"
         widget: search
         properties:
           - property: reason
             label: "Block Reason"
-            widget: text
 
     side_panel:
       traverse:
@@ -162,9 +125,7 @@ forms:
           display: properties
           fields:
             - property: reporter
-              label: "Reporter"
             - property: due_date
-              label: "Due Date"
             - property: estimated_hours
               label: "Est. Hours"
 
@@ -175,13 +136,10 @@ forms:
     fields:
       - property: name
         label: "Category Name"
-        required: true
         placeholder: "e.g., Backend, Frontend, DevOps"
       - property: description
-        label: "Description"
         widget: textarea
       - property: color
-        label: "Color"
         placeholder: "#3b82f6"
         help: "Hex color code for visual identification"
   create_label:
@@ -191,7 +149,6 @@ forms:
     fields:
       - property: name
         label: "Label Name"
-        required: true
         placeholder: "e.g., bug, enhancement, urgent"
 lists:
   all_tickets:
@@ -200,20 +157,15 @@ lists:
     description: "View all tickets"
     columns:
       - property: title
-        label: "Title"
         sortable: true
         link: true
       - property: status
-        label: "Status"
         sortable: true
       - property: priority
-        label: "Priority"
         sortable: true
       - property: assignee
-        label: "Assignee"
         sortable: true
       - property: reporter
-        label: "Reporter"
         sortable: true
       - property: due_date
         label: "Due"
@@ -237,14 +189,11 @@ lists:
     title: "Open Tickets"
     columns:
       - property: title
-        label: "Title"
         sortable: true
         link: true
       - property: priority
-        label: "Priority"
         sortable: true
       - property: assignee
-        label: "Assignee"
         sortable: true
       - property: due_date
         label: "Due"
@@ -288,11 +237,9 @@ lists:
     title: "Categories"
     columns:
       - property: name
-        label: "Name"
         sortable: true
         link: true
       - property: description
-        label: "Description"
     sort:
       - property: name
         direction: asc
@@ -327,9 +274,7 @@ views:
         display: properties
         fields:
           - property: name
-            label: "Name"
           - property: description
-            label: "Description"
       # All tickets as full content cards
       - heading: "Tickets"
         source: tickets
@@ -347,14 +292,10 @@ views:
         display: table
         columns:
           - property: title
-            label: "Title"
             link: true
           - property: status
-            label: "Status"
           - property: priority
-            label: "Priority"
           - property: assignee
-            label: "Assignee"
         empty_message: "No blocking relationships"
       # Labels used by tickets in this category
       - heading: "Labels Used"
@@ -391,9 +332,7 @@ views:
           - property: assignee
           - property: reporter
           - property: due_date
-            label: "Due Date"
           - property: estimated_hours
-            label: "Estimated Hours"
       # Ticket body (markdown content)
       - source: entry
         display: content
@@ -448,12 +387,9 @@ dashboard:
       display: table
       columns:
         - property: title
-          label: "Title"
           link: true
         - property: status
-          label: "Status"
         - property: assignee
-          label: "Assignee"
       sort:
         - property: status
           direction: asc
@@ -463,12 +399,9 @@ dashboard:
       display: table
       columns:
         - property: title
-          label: "Title"
           link: true
         - property: priority
-          label: "Priority"
         - property: assignee
-          label: "Assignee"
       limit: 5
 # ──────────────────────────────────────────────
 # Commands: executable scripts triggered from the UI


### PR DESCRIPTION
## Summary
- Auto-resolve relation `direction`, `target_type`, and `label` from metamodel at runtime
- Add `dataentry-cleanup` migration that removes redundant properties from data-entry.yaml
- Add `MetamodelProvider` interface to avoid import cycle between migration and metamodel packages
- Update `migrate` command to pass metamodel to context-aware migrations

## Migration removes redundant properties
- Labels matching `titleCase(property)` (e.g., `label: "Due Date"` for `due_date`)
- Widgets matching type→widget mapping (`date→date`, `integer→number`, `boolean→checkbox`, custom→`select`)
- `required` matching metamodel property definition
- `default` matching metamodel/type default value
- `direction` when unambiguously inferable (entity only in `from` OR `to`)
- `target_type` when single target exists in metamodel
- `widget: select` (default for relations)
- Relation labels matching metamodel label

## Test plan
- [x] Unit tests for all migration detection and application logic
- [x] Manual QA: Created test project, verified migration reduces config by ~50%
- [x] Verified `rela migrate --check` detects redundant properties
- [x] Verified `rela migrate` removes them correctly
- [x] All existing tests pass
- [x] Lint passes