### PR TITLE
Upgrade Go to 1.24.13 (fix GO-2026-4337)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Sourcehaven-BV/rela
 
-go 1.24.0
+go 1.24.13
 
 require (
 	github.com/charmbracelet/bubbletea v0.25.0
@@ -12,6 +12,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.8.0
 	github.com/wailsapp/wails/v2 v2.11.0
+	github.com/yuin/goldmark v1.7.16
 	golang.org/x/text v0.22.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -59,7 +60,6 @@ require (
 	github.com/wailsapp/mimetype v1.4.1 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	github.com/yuin/goldmark v1.7.16 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect


### PR DESCRIPTION
## Summary
- Upgrade Go from 1.24.0 to 1.24.13 to fix security vulnerability GO-2026-4337 (unexpected session resumption in crypto/tls)

## Test plan
- [x] All tests pass locally
- [x] Lint passes