### PR TITLE
Move vulncheck from PR to release gate + weekly scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,26 +201,10 @@ jobs:
           go test -run='^$' -fuzz='^FuzzValidateID$' -fuzztime=10s ./internal/model/
           go test -run='^$' -fuzz='^FuzzParseRelationFilename$' -fuzztime=10s ./internal/markdown/
 
-  security:
-    name: Security
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.24'
-
-      - name: Run govulncheck
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
-
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [test, lint, lint-markdown, security, fuzz]
+    needs: [test, lint, lint-markdown, fuzz]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,26 @@ jobs:
       - name: Run tests
         run: go test -v -race ./...
 
+  security:
+    name: Security
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, security]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,28 @@
+name: Security Scan
+
+on:
+  schedule:
+    # Run weekly on Monday at 9:00 UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  vulncheck:
+    name: Vulnerability Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...


### PR DESCRIPTION
## Summary
- Remove govulncheck from CI (no longer blocks PRs)
- Add govulncheck as release gate (blocks releases if vulns exist)
- Add weekly scheduled security scan (Monday 9:00 UTC) with manual trigger

## Test plan
- [ ] Verify CI passes without security job
- [ ] Check release.yml syntax is valid
- [ ] Check security.yml syntax is valid