### PR TITLE
Fix --project flag for tui, migrate, mcp, validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ rela show REQ-001
 
 # Launch the interactive TUI
 rela tui
+
+# Work with a project in a different directory
+rela -p /path/to/project list
+export RELA_PROJECT=/path/to/project && rela list
 ```
 
 ## Features

--- a/docs-project/entities/guide/GUIDE-cli-reference.md
+++ b/docs-project/entities/guide/GUIDE-cli-reference.md
@@ -14,21 +14,29 @@ Complete reference for all rela commands.
 
 These options work with any command:
 
-| Option          | Description                                |
-| --------------- | ------------------------------------------ |
-| `-o, --output`  | Output format: `table` (default) or `json` |
-| `-v, --verbose` | Enable verbose output                      |
-| `-q, --quiet`   | Suppress non-essential output              |
-| `-h, --help`    | Show help for any command                  |
+| Option          | Description                                                          |
+| --------------- | -------------------------------------------------------------------- |
+| `-p, --project` | Project directory (default: auto-detect from cwd, or `RELA_PROJECT`) |
+| `-o, --output`  | Output format: `table` (default) or `json`                           |
+| `-v, --verbose` | Enable verbose output                                                |
+| `-q, --quiet`   | Suppress non-essential output                                        |
+| `-h, --help`    | Show help for any command                                            |
+
+## Environment Variables
+
+| Variable       | Description                                                      |
+| -------------- | ---------------------------------------------------------------- |
+| `RELA_PROJECT` | Default project directory when `--project` flag is not specified |
 
 ## Commands
 
 ### rela init
 
-Initialize a new rela project in the current directory.
+Initialize a new rela project.
 
 ```bash
 rela init
+rela init -p /path/to/project
 ```
 
 Creates:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -6,21 +6,29 @@ Complete reference for all rela commands.
 
 These options work with any command:
 
-| Option          | Description                                |
-| --------------- | ------------------------------------------ |
-| `-o, --output`  | Output format: `table` (default) or `json` |
-| `-v, --verbose` | Enable verbose output                      |
-| `-q, --quiet`   | Suppress non-essential output              |
-| `-h, --help`    | Show help for any command                  |
+| Option          | Description                                                          |
+| --------------- | -------------------------------------------------------------------- |
+| `-p, --project` | Project directory (default: auto-detect from cwd, or `RELA_PROJECT`) |
+| `-o, --output`  | Output format: `table` (default) or `json`                           |
+| `-v, --verbose` | Enable verbose output                                                |
+| `-q, --quiet`   | Suppress non-essential output                                        |
+| `-h, --help`    | Show help for any command                                            |
+
+## Environment Variables
+
+| Variable       | Description                                                      |
+| -------------- | ---------------------------------------------------------------- |
+| `RELA_PROJECT` | Default project directory when `--project` flag is not specified |
 
 ## Commands
 
 ### rela init
 
-Initialize a new rela project in the current directory.
+Initialize a new rela project.
 
 ```bash
 rela init
+rela init -p /path/to/project
 ```
 
 Creates:

--- a/docs/templates/readme.md.j2
+++ b/docs/templates/readme.md.j2
@@ -36,6 +36,10 @@ rela show REQ-001
 
 # Launch the interactive TUI
 rela tui
+
+# Work with a project in a different directory
+rela -p /path/to/project list
+export RELA_PROJECT=/path/to/project && rela list
 ```
 
 ## Features

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -15,12 +16,20 @@ var initCmd = &cobra.Command{
 	Short: "Initialize a new rela project",
 	Long:  `Creates a new rela project in the current directory with a default metamodel.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cwd, err := cliFS.Getwd()
-		if err != nil {
-			return err
+		// Determine target directory: flag > env var > cwd
+		targetDir := projectPath
+		if targetDir == "" {
+			targetDir = os.Getenv("RELA_PROJECT")
+		}
+		if targetDir == "" {
+			var err error
+			targetDir, err = cliFS.Getwd()
+			if err != nil {
+				return err
+			}
 		}
 
-		metamodelPath := filepath.Join(cwd, project.MetamodelFile)
+		metamodelPath := filepath.Join(targetDir, project.MetamodelFile)
 
 		// Check if already initialized
 		if _, err := cliFS.Stat(metamodelPath); err == nil {
@@ -29,12 +38,12 @@ var initCmd = &cobra.Command{
 
 		// Create project context
 		ctx := &project.Context{
-			Root:          cwd,
+			Root:          targetDir,
 			MetamodelPath: metamodelPath,
-			CacheDir:      filepath.Join(cwd, project.CacheDir),
-			CachePath:     filepath.Join(cwd, project.CacheDir, project.CacheFile),
-			EntitiesDir:   filepath.Join(cwd, project.EntitiesDir),
-			RelationsDir:  filepath.Join(cwd, project.RelationsDir),
+			CacheDir:      filepath.Join(targetDir, project.CacheDir),
+			CachePath:     filepath.Join(targetDir, project.CacheDir, project.CacheFile),
+			EntitiesDir:   filepath.Join(targetDir, project.EntitiesDir),
+			RelationsDir:  filepath.Join(targetDir, project.RelationsDir),
 		}
 
 		// Create directories
@@ -48,7 +57,7 @@ var initCmd = &cobra.Command{
 		}
 
 		// Add .rela to .gitignore if it exists
-		gitignorePath := filepath.Join(cwd, ".gitignore")
+		gitignorePath := filepath.Join(targetDir, ".gitignore")
 		if _, err := cliFS.Stat(gitignorePath); err == nil {
 			// Read existing content
 			content, err := cliFS.ReadFile(gitignorePath)
@@ -61,7 +70,7 @@ var initCmd = &cobra.Command{
 			}
 		}
 
-		out.WriteSuccess("Initialized rela project in %s", cwd)
+		out.WriteSuccess("Initialized rela project in %s", targetDir)
 		out.WriteMessage("  Created metamodel.yaml")
 		out.WriteMessage("  Created entities/ directory")
 		out.WriteMessage("  Created relations/ directory")

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -46,9 +47,15 @@ Logs are written to stderr.`,
 }
 
 func runMCPServer() error {
+	// Determine start directory: flag > env var > cwd
+	startDir := projectPath
+	if startDir == "" {
+		startDir = os.Getenv("RELA_PROJECT")
+	}
+
 	// Discover project (standalone initialization because mcp is excluded
 	// from the root PersistentPreRunE skip list)
-	ctx, err := project.Discover("", cliFS)
+	ctx, err := project.Discover(startDir, cliFS)
 	if err != nil {
 		return fmt.Errorf("no project found: run 'rela init' to create one")
 	}

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -29,8 +29,14 @@ Examples:
   rela migrate         # Apply all pending migrations
   rela migrate --check # Check for pending migrations (for CI)`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Determine start directory: flag > env var > cwd
+		startDir := projectPath
+		if startDir == "" {
+			startDir = os.Getenv("RELA_PROJECT")
+		}
+
 		// Discover project (we need the paths but not the metamodel)
-		ctx, err := project.Discover("", cliFS)
+		ctx, err := project.Discover(startDir, cliFS)
 		if err != nil {
 			return fmt.Errorf("no project found: run 'rela init' to create one")
 		}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -23,6 +23,7 @@ var (
 	outputFormat string
 	verbose      bool
 	quiet        bool
+	projectPath  string
 
 	// Shared state
 	projectCtx *project.Context
@@ -56,9 +57,15 @@ and maintain semantic relationships between them.`,
 			return nil
 		}
 
+		// Determine project path: flag > env var > cwd
+		startDir := projectPath
+		if startDir == "" {
+			startDir = os.Getenv("RELA_PROJECT")
+		}
+
 		// Discover project
 		var err error
-		projectCtx, err = project.Discover("", cliFS)
+		projectCtx, err = project.Discover(startDir, cliFS)
 		if err != nil {
 			return fmt.Errorf("no project found: run 'rela init' to create one")
 		}
@@ -110,6 +117,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format (table, json)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Quiet output")
+	rootCmd.PersistentFlags().StringVarP(&projectPath, "project", "p", "", "Project directory (default: auto-detect from cwd, or RELA_PROJECT env var)")
 
 	// Add version command
 	rootCmd.AddCommand(&cobra.Command{

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestRootCmdProjectFlag(t *testing.T) {
+	// Verify the project flag is registered
+	flag := rootCmd.PersistentFlags().Lookup("project")
+	if flag == nil {
+		t.Fatal("expected --project flag to be registered")
+	}
+
+	// Verify short flag
+	if flag.Shorthand != "p" {
+		t.Errorf("expected shorthand 'p', got %q", flag.Shorthand)
+	}
+
+	// Verify default value is empty (auto-detect)
+	if flag.DefValue != "" {
+		t.Errorf("expected empty default value, got %q", flag.DefValue)
+	}
+}

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -31,8 +31,14 @@ Keyboard shortcuts:
   q - Quit or go back
   Esc - Go back`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Determine start directory: flag > env var > cwd
+		startDir := projectPath
+		if startDir == "" {
+			startDir = os.Getenv("RELA_PROJECT")
+		}
+
 		// Try to discover project
-		ctx, err := project.Discover("", cliFS)
+		ctx, err := project.Discover(startDir, cliFS)
 		if err != nil {
 			// No project found - launch TUI in init mode
 			cwd, cwdErr := os.Getwd()

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -29,8 +29,14 @@ Checks for:
 Examples:
   rela validate    # Validate all config files`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Determine start directory: flag > env var > cwd
+		startDir := projectPath
+		if startDir == "" {
+			startDir = os.Getenv("RELA_PROJECT")
+		}
+
 		// Discover project (we need the paths)
-		ctx, err := project.Discover("", cliFS)
+		ctx, err := project.Discover(startDir, cliFS)
 		if err != nil {
 			return fmt.Errorf("no project found: run 'rela init' to create one")
 		}


### PR DESCRIPTION
## Summary
- Fix `tui`, `migrate`, `mcp`, and `validate` commands to respect `--project` flag and `RELA_PROJECT` env var
- These commands skipped `PersistentPreRunE` but didn't implement the flag/env resolution themselves

## Test plan
- [x] All tests pass
- [x] Manual verification: `rela -p /path/to/project validate` works