### PR TITLE
Fix -p flag conflict and add issue tracking metamodel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,68 @@ jobs:
           name: rela-linux
           path: bin/rela
 
+  rela-tickets:
+    name: Rela Tickets
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Build rela
+        run: go build -o bin/rela ./cmd/rela
+
+      - name: Check for new bug or feature entity
+        run: |
+          set -euo pipefail
+          BASE_REF="${{ github.event.pull_request.base.sha }}"
+
+          # Get list of added entity files in this PR
+          ADDED_ENTITIES=$(git diff --name-only --diff-filter=A "${BASE_REF}"...HEAD -- \
+            'tickets/entities/bugs/*.md' \
+            'tickets/entities/features/*.md' \
+            'tickets/entities/tickets/*.md' || true)
+
+          if [[ -z "$ADDED_ENTITIES" ]]; then
+            echo ""
+            echo "ERROR: PR must include a new bug, feature, or ticket entity in tickets/entities/"
+            echo ""
+            echo "Create one with:"
+            echo "  rela create bug --project tickets -t 'Title'"
+            echo "  rela create feature --project tickets -t 'Title'"
+            echo "  rela create ticket --project tickets -t 'Title'"
+            exit 1
+          fi
+
+          echo "Found new entities:"
+          echo "$ADDED_ENTITIES"
+
+      - name: Run rela analyze
+        run: |
+          set -euo pipefail
+          cd tickets
+
+          echo "Running cardinality check..."
+          ../bin/rela analyze cardinality
+
+          echo "Running orphans check..."
+          ../bin/rela analyze orphans
+
+          echo "Running properties check..."
+          ../bin/rela analyze properties
+
+          echo "Running validations check..."
+          ../bin/rela analyze validations
+
+          echo ""
+          echo "All rela checks passed!"
+
   docs:
     name: Docs
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ QA-SUMMARY-*.md
 BUG-FIX-*.md
 *-BUGFIXES.md
 test-tui*.sh
-tickets/
 other-ci.yml
 .claude/
 .ignored/

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "rela-docs": {
       "command": "bash",
       "args": ["-c", "cd docs-project && exec rela mcp"]
+    },
+    "rela-issues-and-design-tickets": {
+      "command": "bash",
+      "args": ["-c", "cd tickets && exec rela mcp"]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,3 +340,56 @@ Place temporary working documents in the `.ignored/` directory:
 - Scratch notes
 
 This directory is gitignored. Never commit design docs, tickets, or reports to the repository.
+
+## Rela for Planning & Issue Tracking
+
+This project uses two rela instances via MCP for design and issue tracking:
+
+- **rela-docs**: Documentation entities (concepts, features, guides, tutorials, scenarios)
+- **rela-issues-and-design-tickets**: Issue tracking (tickets, features, decisions, concepts, risks, measures, tests)
+
+### Workflow for Creating Tickets/Entities
+
+When creating or updating entities in `rela-issues-and-design-tickets`:
+
+1. **Create the entity** with required properties
+2. **Run ALL analyze tools** to check for issues:
+   - `analyze_cardinality` - check required relations
+   - `analyze_orphans` - find unlinked entities
+   - `analyze_properties` - validate property values
+   - `analyze_validations` - run custom validation rules
+3. **Fix any violations** (create missing relations, add required properties, etc.)
+4. **Repeat analysis until ALL checks pass** - do not stop after fixing one issue
+
+### Common Required Relations
+
+| Entity Type | Required Relations |
+|-------------|-------------------|
+| ticket | `affects` → concept (min 1), `implements` → feature (min 1) |
+| feature | `requires` → concept (min 1) |
+| test-case/test-suite | `test-covers` → concept (min 1), `verifies` → feature/ticket (min 1) |
+| doc-task | `affects` → concept (min 1), `triggered-by` → ticket/feature/decision (min 1), `updates` → guide/tutorial/scenario (min 1) |
+
+### Validation Rules
+
+The metamodel includes validation rules that enforce:
+- In-progress bugs should have `why1` and `why2` started
+- Done bugs must have full 5-whys analysis (`why1`-`why3` required, `why4`-`why5` recommended) and `prevention`
+- Ready tickets need `effort`, `priority`, and `description`
+- Accepted decisions need `date`, `context`, and `consequences`
+
+Always run `analyze_validations` to catch these issues.
+
+### 5-Whys for Bug Analysis
+
+Bug tickets use the 5-whys method for root cause analysis:
+
+| Property | Purpose |
+|----------|---------|
+| `why1` | What was the immediate cause? |
+| `why2` | Why did that happen? |
+| `why3` | Why did that happen? |
+| `why4` | Why did that happen? |
+| `why5` | What is the systemic root cause? |
+
+Done bugs require at least 3 levels (why1-why3). The goal is to reach systemic causes that can be addressed with process/tooling improvements documented in `prevention`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,8 +373,9 @@ When creating or updating entities in `rela-issues-and-design-tickets`:
 ### Validation Rules
 
 The metamodel includes validation rules that enforce:
+
 - In-progress bugs should have `why1` and `why2` started
-- Done bugs must have full 5-whys analysis (`why1`-`why3` required, `why4`-`why5` recommended) and `prevention`
+- Done bugs must have 5-whys analysis (`why1`-`why3` required) and `prevention`
 - Ready tickets need `effort`, `priority`, and `description`
 - Accepted decisions need `date`, `context`, and `consequences`
 
@@ -392,4 +393,5 @@ Bug tickets use the 5-whys method for root cause analysis:
 | `why4` | Why did that happen? |
 | `why5` | What is the systemic root cause? |
 
-Done bugs require at least 3 levels (why1-why3). The goal is to reach systemic causes that can be addressed with process/tooling improvements documented in `prevention`.
+Done bugs require at least 3 levels (why1-why3). The goal is to reach systemic causes
+that can be addressed with process/tooling improvements documented in `prevention`.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -117,7 +117,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format (table, json)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Quiet output")
-	rootCmd.PersistentFlags().StringVarP(&projectPath, "project", "p", "", "Project directory (default: auto-detect from cwd, or RELA_PROJECT env var)")
+	rootCmd.PersistentFlags().StringVar(&projectPath, "project", "", "Project directory (default: auto-detect from cwd, or RELA_PROJECT env var)")
 
 	// Add version command
 	rootCmd.AddCommand(&cobra.Command{

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -2,7 +2,59 @@ package cli
 
 import (
 	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
+
+// TestNoShorthandConflicts ensures persistent flags don't conflict with local flags.
+// This prevents bugs like -p being used for both --project (persistent) and --priority (local).
+func TestNoShorthandConflicts(t *testing.T) {
+	// Collect all persistent flag shorthands from root
+	persistentShorthands := make(map[string]string) // shorthand -> flag name
+	rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		if f.Shorthand != "" {
+			persistentShorthands[f.Shorthand] = f.Name
+		}
+	})
+
+	// Check each subcommand for conflicts
+	for _, cmd := range rootCmd.Commands() {
+		checkCommandForConflicts(t, cmd, persistentShorthands)
+	}
+}
+
+func checkCommandForConflicts(t *testing.T, cmd *cobra.Command, parentShorthands map[string]string) {
+	t.Helper()
+
+	// Check local flags against parent persistent flags
+	// Same name shadowing is OK (e.g., local --output shadows persistent --output)
+	// Different name with same shorthand is a conflict
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Shorthand != "" {
+			if parentFlag, exists := parentShorthands[f.Shorthand]; exists && parentFlag != f.Name {
+				t.Errorf("command %q: flag --%s uses shorthand -%s which conflicts with persistent flag --%s",
+					cmd.Name(), f.Name, f.Shorthand, parentFlag)
+			}
+		}
+	})
+
+	// Build combined shorthands for checking nested subcommands
+	combinedShorthands := make(map[string]string)
+	for k, v := range parentShorthands {
+		combinedShorthands[k] = v
+	}
+	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		if f.Shorthand != "" {
+			combinedShorthands[f.Shorthand] = f.Name
+		}
+	})
+
+	// Recurse into subcommands
+	for _, subCmd := range cmd.Commands() {
+		checkCommandForConflicts(t, subCmd, combinedShorthands)
+	}
+}
 
 func TestRootCmdProjectFlag(t *testing.T) {
 	// Verify the project flag is registered
@@ -11,9 +63,9 @@ func TestRootCmdProjectFlag(t *testing.T) {
 		t.Fatal("expected --project flag to be registered")
 	}
 
-	// Verify short flag
-	if flag.Shorthand != "p" {
-		t.Errorf("expected shorthand 'p', got %q", flag.Shorthand)
+	// Verify no shorthand (removed to avoid conflict with --priority on create/update)
+	if flag.Shorthand != "" {
+		t.Errorf("expected no shorthand, got %q", flag.Shorthand)
 	}
 
 	// Verify default value is empty (auto-detect)

--- a/tickets/entities/automated-measures/check-flag-shorthands.md
+++ b/tickets/entities/automated-measures/check-flag-shorthands.md
@@ -1,0 +1,9 @@
+---
+id: check-flag-shorthands
+type: automated-measure
+title: Check flag shorthand availability before adding
+kind: test
+location: internal/cli/root_test.go:TestNoShorthandConflicts
+status: active
+description: Test that walks all CLI commands and verifies no local flag shorthand conflicts with a persistent flag shorthand from a parent command. Runs in CI on every PR.
+---

--- a/tickets/entities/bugs/BUG-001.md
+++ b/tickets/entities/bugs/BUG-001.md
@@ -23,7 +23,8 @@ The `-p` shorthand is assigned to multiple flags:
 | `create.go:218` | `--priority` | Local to `create` |
 | `update.go:154` | `--priority` | Local to `update` |
 
-Since `--project` is a persistent flag on the root command, it applies to all subcommands including `create` and `update`, where `--priority` also claims `-p`.
+Since `--project` is a persistent flag on the root command, it applies to all subcommands
+including `create` and `update`, where `--priority` also claims `-p`.
 
 ## Options
 
@@ -34,4 +35,6 @@ Since `--project` is a persistent flag on the root command, it applies to all su
 
 ## Recommendation
 
-Option 3: Remove `-p` shorthand from `--project`. The `--project` flag is typically set once via env var (`RELA_PROJECT`) or used occasionally, while `--priority` is used frequently during entity creation.
+Option 3: Remove `-p` shorthand from `--project`. The `--project` flag is typically set
+once via env var (`RELA_PROJECT`) or used occasionally, while `--priority` is used
+frequently during entity creation.

--- a/tickets/entities/bugs/BUG-001.md
+++ b/tickets/entities/bugs/BUG-001.md
@@ -1,0 +1,37 @@
+---
+id: BUG-001
+type: bug
+title: 'Flag conflict: -p used for both --project and --priority'
+description: The -p shorthand is used by both --project (persistent flag on root) and --priority (local flag on create/update), causing a conflict.
+priority: high
+status: done
+why1: The --project flag uses -p shorthand which conflicts with --priority on create/update commands
+why2: The -p shorthand was assigned without checking existing flag usage across subcommands
+why3: No process exists to verify shorthand availability before adding new flags
+why4: Flag naming conventions and reserved shorthands are not documented
+why5: Missing developer guidelines for CLI flag management
+prevention: 'Before adding shorthand flags, grep for existing uses: `grep -r ''VarP.*"x"'' internal/cli/` where x is the proposed shorthand.'
+---
+
+## Problem
+
+The `-p` shorthand is assigned to multiple flags:
+
+| Location | Flag | Scope |
+|----------|------|-------|
+| `root.go:120` | `--project` | Persistent (all commands) |
+| `create.go:218` | `--priority` | Local to `create` |
+| `update.go:154` | `--priority` | Local to `update` |
+
+Since `--project` is a persistent flag on the root command, it applies to all subcommands including `create` and `update`, where `--priority` also claims `-p`.
+
+## Options
+
+1. **Change `--priority` to `-P`** (uppercase) - minimal impact, priority is less common
+2. **Change `--project` to `-d`** (directory) - but `-d` may conflict elsewhere
+3. **Remove shorthand from `--project`** - it's a new flag, long form is fine
+4. **Remove shorthand from `--priority`** - less convenient for frequent use
+
+## Recommendation
+
+Option 3: Remove `-p` shorthand from `--project`. The `--project` flag is typically set once via env var (`RELA_PROJECT`) or used occasionally, while `--priority` is used frequently during entity creation.

--- a/tickets/entities/concepts/cli-flags.md
+++ b/tickets/entities/concepts/cli-flags.md
@@ -1,0 +1,10 @@
+---
+description: Cobra flag definitions and parsing for all CLI commands
+id: cli-flags
+layer: cli
+package: internal/cli
+status: stable
+summary: Flag definitions using Cobra's persistent and local flags
+title: CLI Flag Handling
+type: concept
+---

--- a/tickets/entities/features/FEAT-001.md
+++ b/tickets/entities/features/FEAT-001.md
@@ -1,0 +1,9 @@
+---
+description: Command-line interface for all rela operations
+id: FEAT-001
+priority: high
+status: implemented
+summary: Cobra-based CLI with commands for entity/relation management, analysis, and export
+title: CLI Interface
+type: feature
+---

--- a/tickets/metamodel.yaml
+++ b/tickets/metamodel.yaml
@@ -1,0 +1,1260 @@
+# Metamodel for rela's own development
+# Dogfooding: using rela to track architecture, features, tickets, QA, and docs
+
+version: "1.0"
+namespace: "https://rela.dev/ontology/development#"
+
+types:
+  # Lifecycle statuses
+  concept_status:
+    values: [draft, stable, deprecated]
+    default: draft
+
+  decision_status:
+    values: [proposed, accepted, superseded, deprecated]
+    default: proposed
+
+  feature_status:
+    values: [proposed, planned, in-progress, implemented, removed]
+    default: proposed
+
+  ticket_status:
+    values: [backlog, ready, in-progress, blocked, done, wont-fix]
+    default: backlog
+
+  risk_status:
+    values: [identified, mitigated, accepted, resolved]
+    default: identified
+
+  test_status:
+    values: [draft, active, skipped, deprecated]
+    default: active
+
+  qa_result:
+    values: [in-progress, passed, failed, blocked]
+    default: in-progress
+
+  doc_status:
+    values: [stub, draft, review, published, outdated]
+    default: stub
+
+  # Enums
+  priority:
+    values: [critical, high, medium, low]
+    default: medium
+
+  layer:
+    values: [core, cli, tui, server, infra]
+
+  ticket_kind:
+    values: [enhancement, refactor, docs, test, chore]
+
+  effort:
+    values: [xs, s, m, l, xl]
+
+  likelihood:
+    values: [low, medium, high]
+
+  impact:
+    values: [low, medium, high]
+
+  test_kind:
+    values: [unit, integration, e2e, manual, fuzz, property]
+
+  automated_measure_kind:
+    values: [test, lint, ci, type-check, monitoring]
+
+  manual_measure_kind:
+    values: [review, docs, process, checklist]
+
+  measure_status:
+    values: [proposed, active, deprecated]
+    default: proposed
+
+  doc_kind:
+    values: [guide, reference, tutorial, howto, explanation, changelog]
+
+  audience:
+    values: [beginner, intermediate, advanced]
+    default: beginner
+
+entities:
+  # ===================
+  # Architecture
+  # ===================
+  concept:
+    label: Concept
+    id_type: manual
+    color: "#E3F2FD"
+    border_color: "#1976D2"
+    properties:
+      title:
+        type: string
+        required: true
+      summary:
+        type: string
+        description: Brief explanation for documentation
+      description:
+        type: string
+      package:
+        type: string
+        description: Go package location (e.g., internal/graph)
+      layer:
+        type: layer
+      status:
+        type: concept_status
+        required: true
+    default_sort:
+      - property: layer
+      - property: title
+
+  decision:
+    label: Decision
+    aliases: [dec, adr]
+    id_prefix: "DEC-"
+    color: "#FFF3E0"
+    border_color: "#F57C00"
+    properties:
+      title:
+        type: string
+        required: true
+      context:
+        type: string
+        description: Why this decision was needed
+      consequences:
+        type: string
+        description: Implications of this decision
+      date:
+        type: date
+      status:
+        type: decision_status
+        required: true
+    default_sort:
+      - property: date
+        direction: desc
+
+  # ===================
+  # Planning
+  # ===================
+  feature:
+    label: Feature
+    id_prefix: "FEAT-"
+    color: "#E8F5E9"
+    border_color: "#388E3C"
+    properties:
+      title:
+        type: string
+        required: true
+      summary:
+        type: string
+        description: Brief explanation for documentation
+      description:
+        type: string
+      priority:
+        type: priority
+      status:
+        type: feature_status
+        required: true
+    default_sort:
+      - property: priority
+      - property: status
+
+  bug:
+    label: Bug
+    aliases: [defect]
+    id_prefix: "BUG-"
+    color: "#FFCDD2"
+    border_color: "#D32F2F"
+    properties:
+      title:
+        type: string
+        required: true
+      description:
+        type: string
+      priority:
+        type: priority
+      effort:
+        type: effort
+      why1:
+        type: string
+        description: "5-Whys level 1: What was the immediate cause?"
+      why2:
+        type: string
+        description: "5-Whys level 2: Why did that happen?"
+      why3:
+        type: string
+        description: "5-Whys level 3: Why did that happen?"
+      why4:
+        type: string
+        description: "5-Whys level 4: Why did that happen?"
+      why5:
+        type: string
+        description: "5-Whys level 5: What is the systemic root cause?"
+      prevention:
+        type: string
+        description: How to prevent similar bugs
+      status:
+        type: ticket_status
+        required: true
+    default_sort:
+      - property: priority
+      - property: status
+
+  ticket:
+    label: Ticket
+    aliases: [task, issue]
+    id_prefix: "TKT-"
+    color: "#FFFDE7"
+    border_color: "#FBC02D"
+    properties:
+      title:
+        type: string
+        required: true
+      description:
+        type: string
+      kind:
+        type: ticket_kind
+        required: true
+      priority:
+        type: priority
+      effort:
+        type: effort
+      status:
+        type: ticket_status
+        required: true
+    default_sort:
+      - property: priority
+      - property: status
+
+  risk:
+    label: Risk
+    id_prefix: "RISK-"
+    color: "#FFEBEE"
+    border_color: "#D32F2F"
+    properties:
+      title:
+        type: string
+        required: true
+      description:
+        type: string
+      likelihood:
+        type: likelihood
+        required: true
+      impact:
+        type: impact
+        required: true
+      mitigation:
+        type: string
+        description: How this risk will be/was addressed
+      status:
+        type: risk_status
+        required: true
+    default_sort:
+      - property: impact
+        direction: desc
+      - property: likelihood
+        direction: desc
+
+  # ===================
+  # QA / Testing
+  # ===================
+  test-case:
+    label: Test Case
+    aliases: [test]
+    id_prefix: "TC-"
+    color: "#F3E5F5"
+    border_color: "#7B1FA2"
+    properties:
+      title:
+        type: string
+        required: true
+      description:
+        type: string
+      kind:
+        type: test_kind
+        required: true
+      automated:
+        type: boolean
+        default: "true"
+      location:
+        type: string
+        description: File path or test function name
+      status:
+        type: test_status
+        required: true
+    default_sort:
+      - property: kind
+      - property: title
+
+  test-suite:
+    label: Test Suite
+    aliases: [suite]
+    id_prefix: "TS-"
+    color: "#EDE7F6"
+    border_color: "#512DA8"
+    properties:
+      title:
+        type: string
+        required: true
+      description:
+        type: string
+      kind:
+        type: test_kind
+      status:
+        type: test_status
+        required: true
+    default_sort:
+      - property: kind
+      - property: title
+
+  qa-report:
+    label: QA Report
+    aliases: [qa]
+    id_prefix: "QA-"
+    color: "#FCE4EC"
+    border_color: "#C2185B"
+    properties:
+      title:
+        type: string
+        required: true
+      date:
+        type: date
+        required: true
+      version:
+        type: string
+        description: Version or commit being tested
+      passed:
+        type: integer
+      failed:
+        type: integer
+      skipped:
+        type: integer
+      notes:
+        type: string
+      status:
+        type: qa_result
+        required: true
+    default_sort:
+      - property: date
+        direction: desc
+
+  # ===================
+  # Preventive Measures
+  # ===================
+  automated-measure:
+    label: Automated Measure
+    aliases: [check, guard]
+    id_type: manual
+    color: "#C8E6C9"
+    border_color: "#388E3C"
+    properties:
+      title:
+        type: string
+        required: true
+      description:
+        type: string
+      kind:
+        type: automated_measure_kind
+        required: true
+      location:
+        type: string
+        required: true
+        description: Where this measure is implemented (file, CI config, etc.)
+      status:
+        type: measure_status
+        required: true
+    default_sort:
+      - property: kind
+      - property: title
+
+  manual-measure:
+    label: Manual Measure
+    aliases: [process, guideline]
+    id_type: manual
+    color: "#E8EAF6"
+    border_color: "#3F51B5"
+    properties:
+      title:
+        type: string
+        required: true
+      description:
+        type: string
+      kind:
+        type: manual_measure_kind
+        required: true
+      location:
+        type: string
+        description: Where this measure is documented (file, wiki, etc.)
+      status:
+        type: measure_status
+        required: true
+    default_sort:
+      - property: kind
+      - property: title
+
+  # ===================
+  # Documentation
+  # ===================
+  guide:
+    label: Guide
+    id_type: manual
+    color: "#E0F7FA"
+    border_color: "#0097A7"
+    properties:
+      title:
+        type: string
+        required: true
+      summary:
+        type: string
+      order:
+        type: integer
+        description: Display order within section
+      audience:
+        type: audience
+      path:
+        type: string
+        description: File path relative to docs/
+      status:
+        type: doc_status
+        required: true
+    default_sort:
+      - property: order
+      - property: title
+
+  tutorial:
+    label: Tutorial
+    id_type: manual
+    color: "#E0F2F1"
+    border_color: "#00796B"
+    properties:
+      title:
+        type: string
+        required: true
+      summary:
+        type: string
+      audience:
+        type: audience
+      path:
+        type: string
+        description: File path relative to docs/
+      status:
+        type: doc_status
+        required: true
+    default_sort:
+      - property: audience
+      - property: title
+
+  scenario:
+    label: Scenario
+    id_type: manual
+    color: "#F1F8E9"
+    border_color: "#689F38"
+    properties:
+      title:
+        type: string
+        required: true
+      summary:
+        type: string
+      domain:
+        type: string
+        description: Domain this scenario applies to (e.g., compliance, architecture)
+      path:
+        type: string
+        description: File path relative to docs/
+      status:
+        type: doc_status
+        required: true
+    default_sort:
+      - property: domain
+      - property: title
+
+  doc-task:
+    label: Doc Task
+    id_prefix: "DOC-"
+    color: "#ECEFF1"
+    border_color: "#546E7A"
+    properties:
+      title:
+        type: string
+        required: true
+      description:
+        type: string
+      priority:
+        type: priority
+      status:
+        type: ticket_status
+        required: true
+    default_sort:
+      - property: priority
+      - property: status
+
+relations:
+  # ===================
+  # Ticket → Work Relations
+  # ===================
+  implements:
+    label: implements
+    description: Ticket delivers this feature
+    from: [ticket]
+    to: [feature]
+    inverse: implementedBy
+    min_outgoing: 1  # Every ticket should implement at least one feature
+
+  fixes:
+    label: fixes
+    description: Bug fixes an issue in this feature
+    from: [bug]
+    to: [feature]
+    inverse: fixedBy
+    min_outgoing: 1  # Every bug must be linked to the feature it fixes
+
+  affects:
+    label: affects
+    description: Work touches this architectural concept
+    from: [ticket, bug, doc-task]
+    to: [concept]
+    inverse: affectedBy
+    min_outgoing: 1  # Work items must specify which concepts they affect
+
+  depends-on:
+    label: depends on
+    description: Requires this to be completed first
+    from: [ticket, bug, feature, doc-task]
+    to: [ticket, bug, feature, doc-task]
+    inverse: blocks
+
+  # ===================
+  # Architecture Relations
+  # ===================
+  decides:
+    label: decides
+    description: Decision governs how this concept works
+    from: [decision]
+    to: [concept]
+    inverse: decidedBy
+    min_outgoing: 1  # Every decision must relate to at least one concept
+
+  supersedes:
+    label: supersedes
+    description: Replaces previous decision
+    from: [decision]
+    to: [decision]
+    inverse: supersededBy
+    max_outgoing: 1  # A decision supersedes at most one other
+
+  refines:
+    label: refines
+    description: More specific version of
+    from: [concept, feature]
+    to: [concept, feature]
+    inverse: refinedBy
+
+  requires:
+    label: requires
+    description: Feature requires this concept to exist
+    from: [feature]
+    to: [concept]
+    inverse: requiredBy
+    min_outgoing: 1  # Features must be grounded in at least one concept
+
+  concept-depends-on:
+    label: depends on
+    description: Concept depends on another concept
+    from: [concept]
+    to: [concept]
+    inverse: dependencyOf
+
+  # ===================
+  # Root Cause Analysis (bugs only)
+  # ===================
+  caused-by:
+    label: caused by
+    description: Bug was caused by this concept, decision, or prior change
+    from: [bug]
+    to: [concept, decision, ticket, bug]
+    inverse: caused
+
+  # ===================
+  # Prevention (bugs only)
+  # ===================
+  prevented-by:
+    label: could be prevented by
+    description: Bug could have been caught by this measure (but wasn't)
+    from: [bug]
+    to: [automated-measure, manual-measure]
+    inverse: shouldPrevent
+
+  detected-by:
+    label: detected by
+    description: Bug was detected by this measure
+    from: [bug]
+    to: [automated-measure, manual-measure, test-case, test-suite, qa-report]
+    inverse: detected
+
+  adds-measure:
+    label: adds measure
+    description: Bug fix must add an automated preventive measure
+    from: [bug]
+    to: [automated-measure]
+    inverse: addedBy
+    min_outgoing: 1  # Every bug must result in an automated preventive measure
+
+  protects:
+    label: protects
+    description: Measure protects this concept from bugs
+    from: [automated-measure, manual-measure]
+    to: [concept]
+    inverse: protectedBy
+
+  # ===================
+  # Risk Relations
+  # ===================
+  mitigates:
+    label: mitigates
+    description: Addresses this risk
+    from: [ticket, bug, decision]
+    to: [risk]
+    inverse: mitigatedBy
+
+  introduces:
+    label: introduces
+    description: This change introduces a risk
+    from: [ticket, bug, decision, feature]
+    to: [risk]
+    inverse: introducedBy
+
+  # ===================
+  # QA Relations (logical verification)
+  # ===================
+  verifies:
+    label: verifies
+    description: Test validates this feature/ticket/bug-fix works correctly
+    from: [test-case, test-suite]
+    to: [feature, ticket, bug]
+    inverse: verifiedBy
+    min_outgoing: 1  # Tests must verify at least one feature/ticket/bug
+
+  test-covers:
+    label: covers
+    description: Test exercises this architectural concept
+    from: [test-case, test-suite]
+    to: [concept]
+    inverse: testedBy
+    min_outgoing: 1  # Tests must cover at least one concept
+
+  contains:
+    label: contains
+    description: Suite contains these test cases
+    from: [test-suite]
+    to: [test-case]
+    inverse: containedIn
+    min_outgoing: 1  # Suites must contain at least one test
+
+  found-by:
+    label: found by
+    description: Bug was discovered by this test or QA session
+    from: [bug]
+    to: [test-case, qa-report]
+    inverse: found
+
+  regression-for:
+    label: regression test for
+    description: Test prevents regression of this fixed bug
+    from: [test-case]
+    to: [bug]
+    inverse: hasRegressionTest
+
+  blocks-release:
+    label: blocks release
+    description: This issue blocks the release
+    from: [ticket, bug, risk]
+    to: [qa-report]
+    inverse: releaseBlockedBy
+
+  tested-in:
+    label: tested in
+    description: Feature/ticket/bug was tested in this QA session
+    from: [feature, ticket, bug]
+    to: [qa-report]
+    inverse: tests
+    min_incoming: 1  # QA reports must test at least one feature/ticket/bug
+
+  # ===================
+  # Documentation Relations
+  # ===================
+  explains:
+    label: explains
+    description: Guide/tutorial explains this concept
+    from: [guide, tutorial]
+    to: [concept]
+    inverse: explainedBy
+
+  covers:
+    label: covers
+    description: Guide/tutorial covers this feature
+    from: [guide, tutorial]
+    to: [feature]
+    inverse: coveredBy
+
+  demonstrates:
+    label: demonstrates
+    description: Scenario/tutorial demonstrates this feature in practice
+    from: [scenario, tutorial]
+    to: [feature]
+    inverse: demonstratedBy
+
+  prerequisite:
+    label: prerequisite
+    description: This guide/tutorial requires reading another first
+    from: [guide, tutorial]
+    to: [guide, concept]
+    inverse: prerequisiteFor
+
+  documents:
+    label: documents
+    description: Documentation describes this decision
+    from: [guide, tutorial, scenario]
+    to: [decision]
+    inverse: documentedBy
+
+  updates:
+    label: updates
+    description: Doc task updates this documentation
+    from: [doc-task]
+    to: [guide, tutorial, scenario]
+    inverse: updatedBy
+    min_outgoing: 1  # Every doc-task must update at least one doc
+
+  triggered-by:
+    label: triggered by
+    description: Doc work triggered by this change
+    from: [doc-task]
+    to: [ticket, bug, feature, decision]
+    inverse: triggers
+    min_outgoing: 1  # Doc tasks must be triggered by something
+
+# ===================
+# Validation Rules
+# ===================
+validations:
+  # --- Ticket completeness (progressive) ---
+  - name: backlog-tickets-should-have-description
+    description: "Backlog tickets should have a description"
+    entity_type: ticket
+    when:
+      - "status=backlog"
+    then:
+      - "description!="
+    severity: warning
+
+  - name: ready-tickets-need-effort
+    description: "Ready tickets must have effort estimated"
+    entity_type: ticket
+    when:
+      - "status=ready"
+    then:
+      - "effort!="
+    severity: error
+
+  - name: ready-tickets-need-priority
+    description: "Ready tickets must have priority set"
+    entity_type: ticket
+    when:
+      - "status=ready"
+    then:
+      - "priority!="
+    severity: error
+
+  - name: ready-tickets-need-description
+    description: "Ready tickets must have a description"
+    entity_type: ticket
+    when:
+      - "status=ready"
+    then:
+      - "description!="
+    severity: error
+
+  - name: in-progress-tickets-need-priority
+    description: "In-progress tickets must have priority set"
+    entity_type: ticket
+    when:
+      - "status=in-progress"
+    then:
+      - "priority!="
+    severity: error
+
+  - name: done-tickets-need-description
+    description: "Done tickets must have a description"
+    entity_type: ticket
+    when:
+      - "status=done"
+    then:
+      - "description!="
+    severity: error
+
+  # --- Bug completeness (progressive) ---
+  - name: bugs-should-have-description
+    description: "Bugs should have a description"
+    entity_type: bug
+    then:
+      - "description!="
+    severity: warning
+
+  - name: ready-bugs-need-effort
+    description: "Ready bugs must have effort estimated"
+    entity_type: bug
+    when:
+      - "status=ready"
+    then:
+      - "effort!="
+    severity: error
+
+  - name: ready-bugs-need-priority
+    description: "Ready bugs must have priority set"
+    entity_type: bug
+    when:
+      - "status=ready"
+    then:
+      - "priority!="
+    severity: error
+
+  - name: ready-bugs-need-description
+    description: "Ready bugs must have a description"
+    entity_type: bug
+    when:
+      - "status=ready"
+    then:
+      - "description!="
+    severity: error
+
+  - name: in-progress-bugs-need-priority
+    description: "In-progress bugs must have priority set"
+    entity_type: bug
+    when:
+      - "status=in-progress"
+    then:
+      - "priority!="
+    severity: error
+
+  - name: in-progress-bugs-should-have-why1
+    description: "In-progress bugs should identify immediate cause"
+    entity_type: bug
+    when:
+      - "status=in-progress"
+    then:
+      - "why1!="
+    severity: warning
+
+  - name: in-progress-bugs-should-have-why2
+    description: "In-progress bugs should start 5-whys analysis"
+    entity_type: bug
+    when:
+      - "status=in-progress"
+    then:
+      - "why2!="
+    severity: warning
+
+  - name: done-bugs-need-5-whys
+    description: "Done bugs must have 5-whys analysis (at least 3 levels)"
+    entity_type: bug
+    when:
+      - "status=done"
+    then:
+      - "why1!="
+      - "why2!="
+      - "why3!="
+    severity: error
+
+  - name: done-bugs-should-have-deep-analysis
+    description: "Done bugs should have full 5-whys analysis"
+    entity_type: bug
+    when:
+      - "status=done"
+    then:
+      - "why4!="
+      - "why5!="
+    severity: warning
+
+  - name: done-bugs-need-prevention
+    description: "Done bugs must document prevention strategy"
+    entity_type: bug
+    when:
+      - "status=done"
+    then:
+      - "prevention!="
+    severity: error
+
+  - name: done-bugs-need-description
+    description: "Done bugs must have a description"
+    entity_type: bug
+    when:
+      - "status=done"
+    then:
+      - "description!="
+    severity: error
+
+  # --- Measure completeness ---
+  # --- Automated measure completeness ---
+  - name: active-automated-measures-need-description
+    description: "Active automated measures must have a description"
+    entity_type: automated-measure
+    when:
+      - "status=active"
+    then:
+      - "description!="
+    severity: error
+
+  - name: proposed-automated-measures-should-have-description
+    description: "Proposed automated measures should have a description"
+    entity_type: automated-measure
+    when:
+      - "status=proposed"
+    then:
+      - "description!="
+    severity: warning
+
+  # --- Manual measure completeness ---
+  - name: active-manual-measures-need-description
+    description: "Active manual measures must have a description"
+    entity_type: manual-measure
+    when:
+      - "status=active"
+    then:
+      - "description!="
+    severity: error
+
+  - name: proposed-manual-measures-should-have-description
+    description: "Proposed manual measures should have a description"
+    entity_type: manual-measure
+    when:
+      - "status=proposed"
+    then:
+      - "description!="
+    severity: warning
+
+  # --- Decision completeness (progressive) ---
+  - name: proposed-decisions-should-have-date
+    description: "Proposed decisions should have a date"
+    entity_type: decision
+    when:
+      - "status=proposed"
+    then:
+      - "date!="
+    severity: warning
+
+  - name: proposed-decisions-should-have-context
+    description: "Proposed decisions should document their context"
+    entity_type: decision
+    when:
+      - "status=proposed"
+    then:
+      - "context!="
+    severity: warning
+
+  - name: accepted-decisions-need-date
+    description: "Accepted decisions must have a date"
+    entity_type: decision
+    when:
+      - "status=accepted"
+    then:
+      - "date!="
+    severity: error
+
+  - name: accepted-decisions-need-context
+    description: "Accepted decisions must document their context"
+    entity_type: decision
+    when:
+      - "status=accepted"
+    then:
+      - "context!="
+    severity: error
+
+  - name: accepted-decisions-need-consequences
+    description: "Accepted decisions must document consequences"
+    entity_type: decision
+    when:
+      - "status=accepted"
+    then:
+      - "consequences!="
+    severity: error
+
+  # --- Feature completeness (progressive) ---
+  - name: proposed-features-should-have-description
+    description: "Proposed features should have a description"
+    entity_type: feature
+    when:
+      - "status=proposed"
+    then:
+      - "description!="
+    severity: warning
+
+  - name: planned-features-need-priority
+    description: "Planned features must have priority assigned"
+    entity_type: feature
+    when:
+      - "status=planned"
+    then:
+      - "priority!="
+    severity: error
+
+  - name: planned-features-need-description
+    description: "Planned features must have a description"
+    entity_type: feature
+    when:
+      - "status=planned"
+    then:
+      - "description!="
+    severity: error
+
+  - name: in-progress-features-need-description
+    description: "In-progress features must have a description"
+    entity_type: feature
+    when:
+      - "status=in-progress"
+    then:
+      - "description!="
+    severity: error
+
+  - name: implemented-features-need-summary
+    description: "Implemented features must have a summary for docs"
+    entity_type: feature
+    when:
+      - "status=implemented"
+    then:
+      - "summary!="
+    severity: error
+
+  - name: implemented-features-need-description
+    description: "Implemented features must have a description"
+    entity_type: feature
+    when:
+      - "status=implemented"
+    then:
+      - "description!="
+    severity: error
+
+  # --- Risk completeness (progressive) ---
+  - name: identified-risks-need-assessment
+    description: "Identified risks must have likelihood and impact"
+    entity_type: risk
+    when:
+      - "status=identified"
+    then:
+      - "likelihood!="
+      - "impact!="
+    severity: error
+
+  - name: identified-risks-should-have-description
+    description: "Identified risks should have a description"
+    entity_type: risk
+    when:
+      - "status=identified"
+    then:
+      - "description!="
+    severity: warning
+
+  - name: mitigated-risks-need-mitigation
+    description: "Mitigated risks must document the mitigation"
+    entity_type: risk
+    when:
+      - "status=mitigated"
+    then:
+      - "mitigation!="
+    severity: error
+
+  - name: mitigated-risks-need-description
+    description: "Mitigated risks must have a description"
+    entity_type: risk
+    when:
+      - "status=mitigated"
+    then:
+      - "description!="
+    severity: error
+
+  - name: resolved-risks-need-mitigation
+    description: "Resolved risks must document how they were addressed"
+    entity_type: risk
+    when:
+      - "status=resolved"
+    then:
+      - "mitigation!="
+    severity: error
+
+  # --- Test completeness ---
+  - name: automated-tests-need-location
+    description: "Automated tests must specify their location"
+    entity_type: test-case
+    when:
+      - "automated=true"
+    then:
+      - "location!="
+    severity: error
+
+  - name: active-tests-should-have-description
+    description: "Active tests should have a description"
+    entity_type: test-case
+    when:
+      - "status=active"
+    then:
+      - "description!="
+    severity: warning
+
+  - name: test-suites-need-kind
+    description: "Test suites must specify their kind"
+    entity_type: test-suite
+    then:
+      - "kind!="
+    severity: error
+
+  - name: active-suites-should-have-description
+    description: "Active test suites should have a description"
+    entity_type: test-suite
+    when:
+      - "status=active"
+    then:
+      - "description!="
+    severity: warning
+
+  # --- QA completeness ---
+  - name: completed-qa-needs-counts
+    description: "Completed QA reports must have test counts"
+    entity_type: qa-report
+    when:
+      - "status=passed"
+    then:
+      - "passed!="
+    severity: warning
+
+  - name: failed-qa-needs-counts
+    description: "Failed QA reports must document failure count"
+    entity_type: qa-report
+    when:
+      - "status=failed"
+    then:
+      - "failed!="
+    severity: error
+
+  # --- Documentation completeness ---
+  - name: published-guides-need-path
+    description: "Published guides must have a file path"
+    entity_type: guide
+    when:
+      - "status=published"
+    then:
+      - "path!="
+    severity: error
+
+  - name: published-tutorials-need-path
+    description: "Published tutorials must have a file path"
+    entity_type: tutorial
+    when:
+      - "status=published"
+    then:
+      - "path!="
+    severity: error
+
+  - name: published-scenarios-need-path
+    description: "Published scenarios must have a file path"
+    entity_type: scenario
+    when:
+      - "status=published"
+    then:
+      - "path!="
+    severity: error
+
+  - name: guides-should-have-audience
+    description: "Guides should specify target audience"
+    entity_type: guide
+    then:
+      - "audience!="
+    severity: warning
+
+  - name: tutorials-should-have-audience
+    description: "Tutorials should specify target audience"
+    entity_type: tutorial
+    then:
+      - "audience!="
+    severity: warning
+
+  # --- Doc task completeness (progressive) ---
+  - name: ready-doc-tasks-need-priority
+    description: "Ready doc tasks must have priority set"
+    entity_type: doc-task
+    when:
+      - "status=ready"
+    then:
+      - "priority!="
+    severity: error
+
+  - name: ready-doc-tasks-need-description
+    description: "Ready doc tasks must have a description"
+    entity_type: doc-task
+    when:
+      - "status=ready"
+    then:
+      - "description!="
+    severity: error
+
+  - name: done-doc-tasks-need-description
+    description: "Done doc tasks must have a description"
+    entity_type: doc-task
+    when:
+      - "status=done"
+    then:
+      - "description!="
+    severity: error
+
+  # --- Concept completeness (progressive) ---
+  - name: draft-concepts-should-have-layer
+    description: "Draft concepts should specify their layer"
+    entity_type: concept
+    when:
+      - "status=draft"
+    then:
+      - "layer!="
+    severity: warning
+
+  - name: draft-concepts-should-have-description
+    description: "Draft concepts should have a description"
+    entity_type: concept
+    when:
+      - "status=draft"
+    then:
+      - "description!="
+    severity: warning
+
+  - name: stable-concepts-need-layer
+    description: "Stable concepts must specify their layer"
+    entity_type: concept
+    when:
+      - "status=stable"
+    then:
+      - "layer!="
+    severity: error
+
+  - name: stable-concepts-need-package
+    description: "Stable concepts must specify their package location"
+    entity_type: concept
+    when:
+      - "status=stable"
+    then:
+      - "package!="
+    severity: error
+
+  - name: stable-concepts-need-description
+    description: "Stable concepts must have a description"
+    entity_type: concept
+    when:
+      - "status=stable"
+    then:
+      - "description!="
+    severity: error
+
+  - name: stable-concepts-need-summary
+    description: "Stable concepts must have a summary for docs"
+    entity_type: concept
+    when:
+      - "status=stable"
+    then:
+      - "summary!="
+    severity: error

--- a/tickets/relations/BUG-001--adds-measure--check-flag-shorthands.md
+++ b/tickets/relations/BUG-001--adds-measure--check-flag-shorthands.md
@@ -1,0 +1,5 @@
+---
+from: BUG-001
+relation: adds-measure
+to: check-flag-shorthands
+---

--- a/tickets/relations/BUG-001--affects--cli-flags.md
+++ b/tickets/relations/BUG-001--affects--cli-flags.md
@@ -1,0 +1,5 @@
+---
+from: BUG-001
+relation: affects
+to: cli-flags
+---

--- a/tickets/relations/BUG-001--fixes--FEAT-001.md
+++ b/tickets/relations/BUG-001--fixes--FEAT-001.md
@@ -1,0 +1,5 @@
+---
+from: BUG-001
+relation: fixes
+to: FEAT-001
+---

--- a/tickets/relations/FEAT-001--requires--cli-flags.md
+++ b/tickets/relations/FEAT-001--requires--cli-flags.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-001
+relation: requires
+to: cli-flags
+---

--- a/tickets/relations/check-flag-shorthands--protects--cli-flags.md
+++ b/tickets/relations/check-flag-shorthands--protects--cli-flags.md
@@ -1,0 +1,5 @@
+---
+from: check-flag-shorthands
+relation: protects
+to: cli-flags
+---


### PR DESCRIPTION
## Summary
- Remove `-p` shorthand from `--project` flag to fix conflict with `--priority` on create/update commands
- Add `TestNoShorthandConflicts` test to prevent future shorthand conflicts
- Set up rela issue tracking metamodel with structured bug/ticket entity types

## Changes
- **Bug fix**: `--project` no longer uses `-p` shorthand
- **Test**: Detects shorthand conflicts between persistent and local flags
- **Metamodel**: Bugs require 5-whys root cause analysis and automated preventive measures
- **Entity types**: Split `measure` into `automated-measure` and `manual-measure`

## Test plan
- [x] `TestNoShorthandConflicts` passes
- [x] `TestRootCmdProjectFlag` verifies no shorthand
- [x] rela analyze passes on tickets project