### PR TITLE
Add template selection UI and variant support for data entry

### DIFF
--- a/internal/cli/template.go
+++ b/internal/cli/template.go
@@ -12,6 +12,7 @@ var (
 	templateForce     bool
 	templateEntities  bool
 	templateRelations bool
+	templateVariant   string
 )
 
 var templateCmd = &cobra.Command{
@@ -36,15 +37,17 @@ Without arguments, generates templates for all entity and relation types.
 With arguments, generates templates only for the specified types.
 
 Use --entities or --relations to filter by kind.
+Use --variant to create a named variant template (e.g., requirement--epic.md).
 Use --force to overwrite existing templates.
 
 Examples:
-  rela template init                    # Generate all templates
-  rela template init requirement        # Generate requirement template
-  rela template init addresses          # Generate addresses relation template
-  rela template init --entities         # Generate all entity templates
-  rela template init --relations        # Generate all relation templates
-  rela template init --force            # Overwrite existing templates`,
+  rela template init                         # Generate all templates
+  rela template init requirement             # Generate requirement template
+  rela template init addresses               # Generate addresses relation template
+  rela template init --entities              # Generate all entity templates
+  rela template init --relations             # Generate all relation templates
+  rela template init --force                 # Overwrite existing templates
+  rela template init requirement --variant epic  # Generate requirement--epic.md variant`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Collect types to generate
 		var entityTypes, relationTypes []string
@@ -86,16 +89,20 @@ Examples:
 
 		// Generate entity templates
 		for _, entityType := range entityTypes {
-			created, err := repo.GenerateEntityTemplate(meta, entityType, templateForce)
+			created, err := repo.GenerateEntityTemplate(meta, entityType, templateVariant, templateForce)
 			if err != nil {
 				return fmt.Errorf("failed to generate template for %s: %w", entityType, err)
 			}
+			filename := entityType + ".md"
+			if templateVariant != "" {
+				filename = entityType + "--" + templateVariant + ".md"
+			}
 			if created {
-				out.WriteSuccess("Created template: templates/entities/%s.md", entityType)
+				out.WriteSuccess("Created template: templates/entities/%s", filename)
 				createdCount++
 			} else {
 				if !quiet {
-					out.WriteInfo("Skipped (exists): templates/entities/%s.md", entityType)
+					out.WriteInfo("Skipped (exists): templates/entities/%s", filename)
 				}
 				skippedCount++
 			}
@@ -135,6 +142,7 @@ func init() {
 	templateInitCmd.Flags().BoolVar(&templateForce, "force", false, "Overwrite existing templates")
 	templateInitCmd.Flags().BoolVar(&templateEntities, "entities", false, "Only generate entity templates")
 	templateInitCmd.Flags().BoolVar(&templateRelations, "relations", false, "Only generate relation templates")
+	templateInitCmd.Flags().StringVar(&templateVariant, "variant", "", "Create a named variant template (e.g., --variant epic)")
 
 	templateCmd.AddCommand(templateInitCmd)
 	rootCmd.AddCommand(templateCmd)

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/graph"
+	"github.com/Sourcehaven-BV/rela/internal/markdown"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/migration"
 	"github.com/Sourcehaven-BV/rela/internal/model"
@@ -433,4 +434,13 @@ func buildStyleMap(cfg *Config, meta *metamodel.Metamodel) (styleMap map[string]
 	}
 
 	return sm, st
+}
+
+// templatesForType returns all entity templates for a type, or nil on error.
+func (a *App) templatesForType(entityType string) []*markdown.EntityTemplate {
+	templates, err := a.repo.DiscoverEntityTemplates(entityType)
+	if err != nil {
+		return nil
+	}
+	return templates
 }

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Sourcehaven-BV/rela/internal/markdown"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/natsort"
@@ -307,6 +308,27 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 
 	entDef, _ := a.meta.GetEntityDef(form.EntityType)
 
+	// Load templates (only relevant for create mode)
+	var templates []*markdown.EntityTemplate
+	var selectedTemplate *markdown.EntityTemplate
+	selectedTemplateName := r.URL.Query().Get("template")
+
+	if entityID == "" { // create mode
+		templates = a.templatesForType(form.EntityType)
+		// Find the selected template
+		for _, t := range templates {
+			if t.Name == selectedTemplateName {
+				selectedTemplate = t
+				break
+			}
+		}
+		// If no template selected and templates exist, use the first (default)
+		if selectedTemplate == nil && len(templates) > 0 {
+			selectedTemplate = templates[0]
+			selectedTemplateName = selectedTemplate.Name
+		}
+	}
+
 	// Resolve fields
 	type ResolvedField struct {
 		Property    string
@@ -336,12 +358,19 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 		if a.userDefaults != nil {
 			userDefault = a.userDefaults.ResolvePropertyDefault(form.EntityType, f.Property)
 		}
+		// Get template default if available
+		templateDefault := ""
+		if selectedTemplate != nil {
+			if val, ok := selectedTemplate.Properties[f.Property]; ok {
+				templateDefault = fmt.Sprintf("%v", val)
+			}
+		}
 		rf := ResolvedField{
 			Property:    f.Property,
 			Label:       coalesce(f.Label, titleCase(f.Property)),
 			Placeholder: f.Placeholder,
 			Help:        f.Help,
-			Default:     coalesce(userDefault, f.Default, prop.Default),
+			Default:     coalesce(userDefault, templateDefault, f.Default, prop.Default),
 			Hidden:      f.Hidden,
 			Widget:      resolveWidget(f.Widget, prop, a.meta),
 			Values:      resolvePropertyValues(prop, a.meta),
@@ -369,8 +398,12 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 	// Resolve body content
 	var bodyContent string
 	showBody := form.Body != nil && *form.Body
-	if showBody && entity != nil {
-		bodyContent = entity.Content
+	if showBody {
+		if entity != nil {
+			bodyContent = entity.Content
+		} else if selectedTemplate != nil && selectedTemplate.Content != "" {
+			bodyContent = selectedTemplate.Content
+		}
 	}
 
 	// Resolve relation fields
@@ -501,9 +534,19 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Prefill relation from user defaults (only when creating and not already selected).
+		// User defaults take precedence over template defaults.
 		if entity == nil && len(rr.Selected) == 0 && a.userDefaults != nil {
 			if defaultTarget := a.userDefaults.ResolveRelationDefault(form.EntityType, rel.Relation); defaultTarget != "" {
 				rr.Selected = append(rr.Selected, defaultTarget)
+			}
+		}
+
+		// Prefill relation from template (only when creating and not already selected).
+		if entity == nil && len(rr.Selected) == 0 && selectedTemplate != nil {
+			for _, tr := range selectedTemplate.Relations {
+				if tr.Relation == rel.Relation && tr.Target != "" {
+					rr.Selected = append(rr.Selected, tr.Target)
+				}
 			}
 		}
 
@@ -536,6 +579,30 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 	default:
 		backURL = "/"
 	}
+
+	// Build template options for the UI
+	type TemplateOption struct {
+		Name     string
+		Label    string
+		Selected bool
+	}
+	templateOptions := make([]TemplateOption, 0, len(templates))
+	for _, t := range templates {
+		label := t.Name
+		if label == "" {
+			label = "Default"
+		} else {
+			label = titleCase(t.Name)
+		}
+		templateOptions = append(templateOptions, TemplateOption{
+			Name:     t.Name,
+			Label:    label,
+			Selected: t.Name == selectedTemplateName,
+		})
+	}
+	showTemplates := len(templates) > 1
+	usePills := len(templates) <= 4
+
 	data := map[string]interface{}{
 		"App":               a.Cfg.App,
 		"Navigation":        a.navElements(activeList),
@@ -556,6 +623,10 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 		"LinkAs":            r.URL.Query().Get("link_as"),
 		"IsHTMX":            r.Header.Get("HX-Request") == "true",
 		"SidePanelSections": sidePanelSections,
+		"Templates":         templateOptions,
+		"ShowTemplates":     showTemplates,
+		"UsePills":          usePills,
+		"SelectedTemplate":  selectedTemplateName,
 	}
 
 	if r.Header.Get("HX-Request") == "true" {
@@ -1133,6 +1204,82 @@ func (a *App) handleCreate(w http.ResponseWriter, r *http.Request) {
 			} else {
 				a.g.AddEdge(relation)
 			}
+		}
+	}
+
+	// Create relations from template (templates apply even without explicit selection)
+	templateName := r.FormValue("_template")
+	templates := a.templatesForType(form.EntityType)
+	var selectedTemplate *markdown.EntityTemplate
+	for _, t := range templates {
+		if t.Name == templateName {
+			selectedTemplate = t
+			break
+		}
+	}
+	// If no specific template selected but templates exist, use default
+	if selectedTemplate == nil && len(templates) > 0 {
+		selectedTemplate = templates[0]
+	}
+
+	if selectedTemplate != nil {
+		// Create relations defined in the template that weren't already created
+		// via form relations (to avoid duplicates)
+		createdRelations := make(map[string]bool)
+		for _, edge := range a.g.OutgoingEdges(entityID) {
+			createdRelations[edge.Type+"->"+edge.To] = true
+		}
+		for _, edge := range a.g.IncomingEdges(entityID) {
+			createdRelations[edge.Type+"<-"+edge.From] = true
+		}
+
+		for _, tr := range selectedTemplate.Relations {
+			if tr.Target == "" {
+				continue
+			}
+			// Check if target entity exists
+			if _, exists := a.g.GetNode(tr.Target); !exists {
+				log.Printf("Template relation target %s not found, skipping", tr.Target)
+				continue
+			}
+
+			// Determine direction from metamodel
+			relDef, relOK := a.meta.GetRelationDef(tr.Relation)
+			if !relOK {
+				log.Printf("Unknown relation type %s in template, skipping", tr.Relation)
+				continue
+			}
+
+			// Determine if this entity is the source or target
+			isFrom := containsString(relDef.From, form.EntityType)
+			isTo := containsString(relDef.To, form.EntityType)
+
+			var fromID, toID, key string
+			switch {
+			case isFrom && !isTo:
+				fromID, toID = entityID, tr.Target
+				key = tr.Relation + "->" + tr.Target
+			case isTo && !isFrom:
+				fromID, toID = tr.Target, entityID
+				key = tr.Relation + "<-" + tr.Target
+			default:
+				// Ambiguous - assume outgoing
+				fromID, toID = entityID, tr.Target
+				key = tr.Relation + "->" + tr.Target
+			}
+
+			// Skip if already created
+			if createdRelations[key] {
+				continue
+			}
+
+			relation := model.NewRelation(fromID, tr.Relation, toID)
+			if err := a.repo.WriteRelation(relation); err != nil {
+				log.Printf("Failed to write template relation: %v", err)
+				continue
+			}
+			a.g.AddEdge(relation)
+			createdRelations[key] = true
 		}
 	}
 

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -95,6 +95,13 @@ tbody tr:last-child td { border-bottom: none; }
 .btn-danger:hover { background: #fef2f2; }
 
 .form-card { padding: 28px; max-width: 820px; }
+.template-selector { margin-bottom: 16px; display: flex; align-items: center; gap: 12px; max-width: 820px; }
+.template-label { font-size: 13px; font-weight: 500; color: var(--text-muted); }
+.template-pills { display: flex; gap: 8px; flex-wrap: wrap; }
+.template-pill { padding: 6px 14px; border: 1px solid var(--border); border-radius: 16px; background: var(--bg-card); font-size: 13px; cursor: pointer; transition: all 0.15s; color: var(--text); }
+.template-pill:hover { border-color: var(--primary); color: var(--primary); }
+.template-pill.active { background: var(--primary); color: white; border-color: var(--primary); }
+.template-dropdown { padding: 6px 12px; border: 1px solid var(--border); border-radius: 6px; font-size: 13px; background: var(--bg-card); color: var(--text); }
 .form-desc { color: var(--text-muted); font-size: 13px; margin-bottom: 24px; }
 .form-group { margin-bottom: 20px; }
 .form-group label { display: block; font-size: 13px; font-weight: 600; margin-bottom: 6px; }
@@ -457,6 +464,16 @@ document.addEventListener('htmx:beforeSwap', function(evt) {
     evt.detail.shouldSwap = true;
     evt.detail.isError = false;
   }
+  // Destroy SlimSelect instances before swap to prevent orphaned elements
+  var target = evt.detail.target;
+  if (target) {
+    target.querySelectorAll('select').forEach(function(sel) {
+      if (sel._slimSelect) {
+        try { sel._slimSelect.destroy(); } catch(e) {}
+        sel._slimSelect = null;
+      }
+    });
+  }
 });
 document.addEventListener('htmx:afterSettle', function(evt) {
   enhanceSelects(evt.detail.target);
@@ -511,6 +528,39 @@ function confirmDelete(entityID, returnTo) {
     overlay.remove();
   });
 }
+
+// --- Template switching ---
+var _formDirty = false;
+document.addEventListener('input', function(e) {
+  if (e.target.closest('form.form-card form, .form-card form, form[hx-post]')) _formDirty = true;
+});
+document.addEventListener('htmx:beforeSwap', function(e) {
+  if (e.detail.target && e.detail.target.id === 'content') _formDirty = false;
+});
+
+function switchTemplate(templateName) {
+  var formID = document.querySelector('input[name="_form_id"]');
+  if (!formID) return;
+  var url = '/form/' + formID.value + '?template=' + encodeURIComponent(templateName);
+  if (_formDirty && !confirm('Discard changes and switch template?')) return;
+  htmx.ajax('GET', url, {target: '#content', swap: 'innerHTML'}).then(function() {
+    history.pushState({}, '', url);
+  });
+}
+
+// Intercept pill button switches for dirty form warning
+document.addEventListener('htmx:confirm', function(e) {
+  var elt = e.detail.elt;
+  if (elt.classList.contains('template-pill') && !elt.classList.contains('active')) {
+    if (_formDirty) {
+      e.preventDefault();
+      if (confirm('Discard changes and switch template?')) {
+        _formDirty = false;
+        htmx.trigger(elt, 'htmx:confirm');
+      }
+    }
+  }
+});
 
 // --- Command execution ---
 var _cmdToasts = {};
@@ -1724,11 +1774,32 @@ document.body.addEventListener('htmx:pushedIntoHistory', function() {
      hx-get="{{ .BackURL }}" hx-target="#content" hx-push-url="true">&larr; Back <kbd>Esc</kbd></a>
 </div>
 
+{{ if .ShowTemplates }}
+<div class="template-selector">
+  {{ if .UsePills }}
+  <div class="template-pills">
+    {{ range .Templates }}
+    <button type="button" class="template-pill{{ if .Selected }} active{{ end }}"
+            {{ if not .Selected }}hx-get="/form/{{ $.FormID }}?template={{ .Name }}" hx-target="#content" hx-push-url="true"{{ end }}>{{ .Label }}</button>
+    {{ end }}
+  </div>
+  {{ else }}
+  <label class="template-label">Template:</label>
+  <select class="template-dropdown" onchange="switchTemplate(this.value)">
+    {{ range .Templates }}
+    <option value="{{ .Name }}"{{ if .Selected }} selected{{ end }}>{{ .Label }}</option>
+    {{ end }}
+  </select>
+  {{ end }}
+</div>
+{{ end }}
+
 <div class="card form-card">
   <form {{ if eq .Mode "edit" }}hx-post="/api/update"{{ else }}hx-post="/api/create"{{ end }}
         hx-swap="none" novalidate>
     <input type="hidden" name="_form_id" value="{{ .FormID }}">
     <input type="hidden" name="_entity_id" value="{{ .EntityID }}">
+    <input type="hidden" name="_template" value="{{ .SelectedTemplate }}">
     {{ if .ReturnTo }}<input type="hidden" name="_return_to" value="{{ .ReturnTo }}">{{ end }}
     {{ if .LinkRelation }}<input type="hidden" name="_link_relation" value="{{ .LinkRelation }}">
     <input type="hidden" name="_link_peer" value="{{ .LinkPeer }}">

--- a/internal/markdown/template.go
+++ b/internal/markdown/template.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -15,6 +16,21 @@ import (
 
 // ErrTemplateNotFound is returned when a template file does not exist.
 var ErrTemplateNotFound = fmt.Errorf("template not found")
+
+// TemplateRelation represents a pre-filled relation in a template.
+type TemplateRelation struct {
+	Relation string `yaml:"relation"`
+	Target   string `yaml:"target"`
+}
+
+// EntityTemplate represents a parsed entity template with optional variant name.
+type EntityTemplate struct {
+	Name       string                 // "" for default, "epic" for --epic variant
+	EntityType string                 // The entity type this template is for
+	Properties map[string]interface{} // Property defaults (excludes _template_relations)
+	Content    string                 // Markdown body content
+	Relations  []TemplateRelation     // Pre-filled relations
+}
 
 // LoadEntityTemplate reads an entity template file and returns the parsed document.
 // Returns nil, nil if the template file does not exist.
@@ -36,6 +52,140 @@ func (f *FileIO) LoadRelationTemplate(ctx *project.Context, relationType string)
 		return nil, nil //nolint:nilnil // nil,nil is intentional when template doesn't exist
 	}
 	return doc, err
+}
+
+// DiscoverEntityTemplates returns all templates for an entity type, including variants.
+// Templates are discovered by looking for files matching:
+//   - <entityType>.md (default template)
+//   - <entityType>--<variant>.md (variant templates)
+//
+// Returns templates sorted by name (default first, then alphabetically).
+// Returns an empty slice if no templates exist (not an error).
+func (f *FileIO) DiscoverEntityTemplates(ctx *project.Context, entityType string) ([]*EntityTemplate, error) {
+	dir := ctx.EntityTemplatesDir
+
+	// Check if templates directory exists
+	if _, err := f.FS.Stat(dir); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	// Read directory entries
+	entries, err := f.FS.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read templates directory: %w", err)
+	}
+
+	templates := make([]*EntityTemplate, 0, len(entries))
+	prefix := entityType + "--"
+	defaultFile := entityType + ".md"
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+
+		var variantName string
+		switch {
+		case name == defaultFile:
+			variantName = "" // default template
+		case strings.HasPrefix(name, prefix):
+			// Extract variant name: requirement--epic.md -> epic
+			variantName = strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".md")
+		default:
+			continue // not a template for this entity type
+		}
+
+		// Load and parse the template
+		path := filepath.Join(dir, name)
+		tmpl, err := f.loadEntityTemplate(path, entityType, variantName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load template %s: %w", name, err)
+		}
+		templates = append(templates, tmpl)
+	}
+
+	// Sort: default first, then alphabetically by variant name
+	sort.Slice(templates, func(i, j int) bool {
+		// Default template (empty name) always comes first
+		if templates[i].Name == "" {
+			return true
+		}
+		if templates[j].Name == "" {
+			return false
+		}
+		return natsort.Less(templates[i].Name, templates[j].Name)
+	})
+
+	return templates, nil
+}
+
+// loadEntityTemplate loads a single entity template file and parses it into an EntityTemplate.
+func (f *FileIO) loadEntityTemplate(path, entityType, variantName string) (*EntityTemplate, error) {
+	content, err := f.FS.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read template: %w", err)
+	}
+
+	doc, err := ParseDocument(string(content))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	// Extract _template_relations from frontmatter
+	relations := extractTemplateRelations(doc.Frontmatter)
+
+	// Remove _template_relations from properties
+	properties := make(map[string]interface{})
+	for k, v := range doc.Frontmatter {
+		if k != "_template_relations" {
+			properties[k] = v
+		}
+	}
+
+	return &EntityTemplate{
+		Name:       variantName,
+		EntityType: entityType,
+		Properties: properties,
+		Content:    doc.Content,
+		Relations:  relations,
+	}, nil
+}
+
+// extractTemplateRelations parses the _template_relations field from frontmatter.
+func extractTemplateRelations(frontmatter map[string]interface{}) []TemplateRelation {
+	raw, ok := frontmatter["_template_relations"]
+	if !ok {
+		return nil
+	}
+
+	// _template_relations should be a list of maps with "relation" and "target" keys
+	list, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	var relations []TemplateRelation
+	for _, item := range list {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		rel := TemplateRelation{}
+		if r, ok := m["relation"].(string); ok {
+			rel.Relation = r
+		}
+		if t, ok := m["target"].(string); ok {
+			rel.Target = t
+		}
+		if rel.Relation != "" && rel.Target != "" {
+			relations = append(relations, rel)
+		}
+	}
+	return relations
 }
 
 // loadTemplate reads and parses a template file.
@@ -111,11 +261,13 @@ func ApplyRelationTemplate(relation *model.Relation, template *Document) {
 }
 
 // GenerateEntityTemplate creates a template file for an entity type.
+// If variant is non-empty, creates a variant template (e.g., type--variant.md).
 // Returns true if the file was created, false if it already existed (and force is false).
 func (f *FileIO) GenerateEntityTemplate(
 	ctx *project.Context,
 	meta *metamodel.Metamodel,
 	entityType string,
+	variant string,
 	force bool,
 ) (bool, error) {
 	entityDef, ok := meta.GetEntityDef(entityType)
@@ -123,7 +275,7 @@ func (f *FileIO) GenerateEntityTemplate(
 		return false, fmt.Errorf("unknown entity type: %s", entityType)
 	}
 
-	path := ctx.EntityTemplatePath(entityType)
+	path := ctx.EntityTemplateVariantPath(entityType, variant)
 
 	// Check if file exists
 	if !force {

--- a/internal/markdown/template_test.go
+++ b/internal/markdown/template_test.go
@@ -223,7 +223,7 @@ func TestGenerateEntityTemplate(t *testing.T) {
 	}
 
 	// Generate template
-	created, err := testIO.GenerateEntityTemplate(ctx, meta, "requirement", false)
+	created, err := testIO.GenerateEntityTemplate(ctx, meta, "requirement", "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -285,7 +285,7 @@ func TestGenerateEntityTemplate_NoOverwrite(t *testing.T) {
 	}
 
 	// Try to generate without force
-	created, err := testIO.GenerateEntityTemplate(ctx, meta, "requirement", false)
+	created, err := testIO.GenerateEntityTemplate(ctx, meta, "requirement", "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -321,7 +321,7 @@ func TestGenerateEntityTemplate_ForceOverwrite(t *testing.T) {
 	}
 
 	// Generate with force
-	created, err := testIO.GenerateEntityTemplate(ctx, meta, "requirement", true)
+	created, err := testIO.GenerateEntityTemplate(ctx, meta, "requirement", "", true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -343,9 +343,60 @@ func TestGenerateEntityTemplate_UnknownType(t *testing.T) {
 		Entities: map[string]metamodel.EntityDef{},
 	}
 
-	_, err := testIO.GenerateEntityTemplate(ctx, meta, "unknown", false)
+	_, err := testIO.GenerateEntityTemplate(ctx, meta, "unknown", "", false)
 	if err == nil {
 		t.Error("expected error for unknown entity type")
+	}
+}
+
+func TestGenerateEntityTemplate_Variant(t *testing.T) {
+	ctx := setupTestContext(t)
+
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"requirement": {
+				Label: "Requirement",
+				Properties: map[string]metamodel.PropertyDef{
+					"status": {Type: "status", Default: "draft"},
+				},
+			},
+		},
+		Types: map[string]metamodel.CustomType{
+			"status": {
+				Values:  []string{"draft", "proposed", "accepted"},
+				Default: "draft",
+			},
+		},
+	}
+
+	// Generate variant template
+	created, err := testIO.GenerateEntityTemplate(ctx, meta, "requirement", "epic", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !created {
+		t.Error("expected variant template to be created")
+	}
+
+	// Verify file exists at correct path (requirement--epic.md)
+	variantPath := ctx.EntityTemplateVariantPath("requirement", "epic")
+	if _, statErr := os.Stat(variantPath); os.IsNotExist(statErr) {
+		t.Error("variant template file should exist")
+	}
+
+	// Default template should NOT exist
+	defaultPath := ctx.EntityTemplatePath("requirement")
+	if _, statErr := os.Stat(defaultPath); !os.IsNotExist(statErr) {
+		t.Error("default template should not be created when generating variant")
+	}
+
+	// Verify content
+	content, err := os.ReadFile(variantPath)
+	if err != nil {
+		t.Fatalf("failed to read variant template: %v", err)
+	}
+	if len(content) == 0 {
+		t.Error("variant template content is empty")
 	}
 }
 
@@ -387,5 +438,219 @@ func TestGenerateRelationTemplate_UnknownType(t *testing.T) {
 	_, err := testIO.GenerateRelationTemplate(ctx, meta, "unknown", false)
 	if err == nil {
 		t.Error("expected error for unknown relation type")
+	}
+}
+
+func TestDiscoverEntityTemplates_NoTemplatesDir(t *testing.T) {
+	ctx := setupTestContext(t)
+
+	templates, err := testIO.DiscoverEntityTemplates(ctx, "requirement")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(templates) != 0 {
+		t.Errorf("expected 0 templates, got %d", len(templates))
+	}
+}
+
+func TestDiscoverEntityTemplates_DefaultOnly(t *testing.T) {
+	ctx := setupTestContext(t)
+
+	// Create templates directory and default template
+	if err := os.MkdirAll(ctx.EntityTemplatesDir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	templateContent := `---
+status: draft
+priority: high
+---
+# Default content
+`
+	if err := os.WriteFile(filepath.Join(ctx.EntityTemplatesDir, "requirement.md"), []byte(templateContent), 0644); err != nil {
+		t.Fatalf("failed to write template: %v", err)
+	}
+
+	templates, err := testIO.DiscoverEntityTemplates(ctx, "requirement")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(templates) != 1 {
+		t.Fatalf("expected 1 template, got %d", len(templates))
+	}
+
+	tmpl := templates[0]
+	if tmpl.Name != "" {
+		t.Errorf("default template Name = %q, want empty string", tmpl.Name)
+	}
+	if tmpl.EntityType != "requirement" {
+		t.Errorf("EntityType = %q, want %q", tmpl.EntityType, "requirement")
+	}
+	if tmpl.Properties["status"] != "draft" {
+		t.Errorf("status = %v, want %q", tmpl.Properties["status"], "draft")
+	}
+}
+
+func TestDiscoverEntityTemplates_WithVariants(t *testing.T) {
+	ctx := setupTestContext(t)
+
+	if err := os.MkdirAll(ctx.EntityTemplatesDir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	// Default template
+	defaultContent := `---
+status: draft
+---
+# Default
+`
+	if err := os.WriteFile(filepath.Join(ctx.EntityTemplatesDir, "requirement.md"), []byte(defaultContent), 0644); err != nil {
+		t.Fatalf("failed to write default template: %v", err)
+	}
+
+	// Epic variant
+	epicContent := `---
+status: proposed
+priority: high
+---
+# Epic template
+`
+	if err := os.WriteFile(filepath.Join(ctx.EntityTemplatesDir, "requirement--epic.md"), []byte(epicContent), 0644); err != nil {
+		t.Fatalf("failed to write epic template: %v", err)
+	}
+
+	// Checklist variant
+	checklistContent := `---
+status: draft
+---
+# Checklist
+- [ ] Item 1
+`
+	if err := os.WriteFile(filepath.Join(ctx.EntityTemplatesDir, "requirement--checklist.md"), []byte(checklistContent), 0644); err != nil {
+		t.Fatalf("failed to write checklist template: %v", err)
+	}
+
+	// Unrelated template (different entity type)
+	if err := os.WriteFile(filepath.Join(ctx.EntityTemplatesDir, "decision.md"), []byte("---\n---\n"), 0644); err != nil {
+		t.Fatalf("failed to write unrelated template: %v", err)
+	}
+
+	templates, err := testIO.DiscoverEntityTemplates(ctx, "requirement")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(templates) != 3 {
+		t.Fatalf("expected 3 templates, got %d", len(templates))
+	}
+
+	// Check order: default first, then alphabetically
+	if templates[0].Name != "" {
+		t.Errorf("first template should be default (empty name), got %q", templates[0].Name)
+	}
+	if templates[1].Name != "checklist" {
+		t.Errorf("second template should be 'checklist', got %q", templates[1].Name)
+	}
+	if templates[2].Name != "epic" {
+		t.Errorf("third template should be 'epic', got %q", templates[2].Name)
+	}
+
+	// Verify epic template properties
+	epic := templates[2]
+	if epic.Properties["priority"] != "high" {
+		t.Errorf("epic priority = %v, want %q", epic.Properties["priority"], "high")
+	}
+}
+
+func TestDiscoverEntityTemplates_WithRelations(t *testing.T) {
+	ctx := setupTestContext(t)
+
+	if err := os.MkdirAll(ctx.EntityTemplatesDir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	templateContent := `---
+status: draft
+_template_relations:
+  - relation: addresses
+    target: COMP-001
+  - relation: assigned-to
+    target: USER-042
+---
+# Template with relations
+`
+	if err := os.WriteFile(filepath.Join(ctx.EntityTemplatesDir, "requirement.md"), []byte(templateContent), 0644); err != nil {
+		t.Fatalf("failed to write template: %v", err)
+	}
+
+	templates, err := testIO.DiscoverEntityTemplates(ctx, "requirement")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(templates) != 1 {
+		t.Fatalf("expected 1 template, got %d", len(templates))
+	}
+
+	tmpl := templates[0]
+
+	// _template_relations should be extracted and removed from Properties
+	if _, exists := tmpl.Properties["_template_relations"]; exists {
+		t.Error("_template_relations should not be in Properties")
+	}
+
+	// Check relations were parsed
+	if len(tmpl.Relations) != 2 {
+		t.Fatalf("expected 2 relations, got %d", len(tmpl.Relations))
+	}
+
+	rel1 := tmpl.Relations[0]
+	if rel1.Relation != "addresses" || rel1.Target != "COMP-001" {
+		t.Errorf("relation 1 = {%q, %q}, want {addresses, COMP-001}", rel1.Relation, rel1.Target)
+	}
+
+	rel2 := tmpl.Relations[1]
+	if rel2.Relation != "assigned-to" || rel2.Target != "USER-042" {
+		t.Errorf("relation 2 = {%q, %q}, want {assigned-to, USER-042}", rel2.Relation, rel2.Target)
+	}
+}
+
+func TestExtractTemplateRelations_Empty(t *testing.T) {
+	frontmatter := map[string]interface{}{
+		"status": "draft",
+	}
+
+	relations := extractTemplateRelations(frontmatter)
+	if len(relations) != 0 {
+		t.Errorf("expected 0 relations, got %d", len(relations))
+	}
+}
+
+func TestExtractTemplateRelations_InvalidFormat(t *testing.T) {
+	// _template_relations is not a list
+	frontmatter := map[string]interface{}{
+		"_template_relations": "invalid",
+	}
+
+	relations := extractTemplateRelations(frontmatter)
+	if len(relations) != 0 {
+		t.Errorf("expected 0 relations for invalid format, got %d", len(relations))
+	}
+}
+
+func TestExtractTemplateRelations_PartialData(t *testing.T) {
+	// Some entries missing required fields
+	frontmatter := map[string]interface{}{
+		"_template_relations": []interface{}{
+			map[string]interface{}{"relation": "addresses"},                       // missing target
+			map[string]interface{}{"target": "COMP-001"},                          // missing relation
+			map[string]interface{}{"relation": "implements", "target": "REQ-001"}, // valid
+		},
+	}
+
+	relations := extractTemplateRelations(frontmatter)
+	if len(relations) != 1 {
+		t.Fatalf("expected 1 valid relation, got %d", len(relations))
+	}
+	if relations[0].Relation != "implements" || relations[0].Target != "REQ-001" {
+		t.Errorf("relation = {%q, %q}, want {implements, REQ-001}", relations[0].Relation, relations[0].Target)
 	}
 }

--- a/internal/project/context.go
+++ b/internal/project/context.go
@@ -141,9 +141,19 @@ func (c *Context) Exists(fs storage.FS) bool {
 	return err == nil
 }
 
-// EntityTemplatePath returns the file path for an entity type template
+// EntityTemplatePath returns the file path for an entity type template.
+// If variant is non-empty, returns the path for that variant (e.g., type--variant.md).
 func (c *Context) EntityTemplatePath(entityType string) string {
 	return filepath.Join(c.EntityTemplatesDir, entityType+".md")
+}
+
+// EntityTemplateVariantPath returns the file path for an entity template variant.
+// Variant templates use the naming convention: <type>--<variant>.md
+func (c *Context) EntityTemplateVariantPath(entityType, variant string) string {
+	if variant == "" {
+		return c.EntityTemplatePath(entityType)
+	}
+	return filepath.Join(c.EntityTemplatesDir, entityType+"--"+variant+".md")
 }
 
 // RelationTemplatePath returns the file path for a relation type template

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -84,8 +84,11 @@ type Store interface {
 
 	LoadEntityTemplate(entityType string) (*markdown.Document, error)
 	LoadRelationTemplate(relationType string) (*markdown.Document, error)
-	GenerateEntityTemplate(meta *metamodel.Metamodel, entityType string, force bool) (bool, error)
+	GenerateEntityTemplate(meta *metamodel.Metamodel, entityType, variant string, force bool) (bool, error)
 	GenerateRelationTemplate(meta *metamodel.Metamodel, relationType string, force bool) (bool, error)
+	// DiscoverEntityTemplates returns all templates (including variants) for an entity type.
+	// Templates are named <type>.md (default) and <type>--<variant>.md (variants).
+	DiscoverEntityTemplates(entityType string) ([]*markdown.EntityTemplate, error)
 
 	// --- Path Helpers ---
 
@@ -280,11 +283,12 @@ func (r *Repository) LoadRelationTemplate(relationType string) (*markdown.Docume
 }
 
 // GenerateEntityTemplate generates a template file for the given entity type.
+// If variant is non-empty, creates a variant template (e.g., type--variant.md).
 // Returns true if a new template was created.
 func (r *Repository) GenerateEntityTemplate(
-	meta *metamodel.Metamodel, entityType string, force bool,
+	meta *metamodel.Metamodel, entityType, variant string, force bool,
 ) (bool, error) {
-	return r.fio.GenerateEntityTemplate(r.paths, meta, entityType, force)
+	return r.fio.GenerateEntityTemplate(r.paths, meta, entityType, variant, force)
 }
 
 // GenerateRelationTemplate generates a template file for the given relation type.
@@ -293,6 +297,11 @@ func (r *Repository) GenerateRelationTemplate(
 	meta *metamodel.Metamodel, relationType string, force bool,
 ) (bool, error) {
 	return r.fio.GenerateRelationTemplate(r.paths, meta, relationType, force)
+}
+
+// DiscoverEntityTemplates returns all templates (including variants) for an entity type.
+func (r *Repository) DiscoverEntityTemplates(entityType string) ([]*markdown.EntityTemplate, error) {
+	return r.fio.DiscoverEntityTemplates(r.paths, entityType)
 }
 
 // --- Change Notification ---

--- a/prototypes/data-entry/project/templates/entities/ticket--bug.md
+++ b/prototypes/data-entry/project/templates/entities/ticket--bug.md
@@ -1,0 +1,31 @@
+---
+status: open
+priority: high
+---
+
+# Bug Report
+
+## Summary
+
+Brief description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+
+A clear description of what you expected to happen.
+
+## Actual Behavior
+
+What actually happens instead.
+
+## Environment
+
+- Browser:
+- OS:
+- Version:

--- a/prototypes/data-entry/project/templates/entities/ticket--feature.md
+++ b/prototypes/data-entry/project/templates/entities/ticket--feature.md
@@ -1,0 +1,22 @@
+---
+status: open
+priority: low
+---
+
+# Feature Request
+
+## Problem Statement
+
+What problem does this feature solve?
+
+## Proposed Solution
+
+Describe your proposed solution.
+
+## Alternatives Considered
+
+What alternatives have you considered?
+
+## Additional Context
+
+Any other context or screenshots about the feature request.

--- a/prototypes/data-entry/project/templates/entities/ticket.md
+++ b/prototypes/data-entry/project/templates/entities/ticket.md
@@ -1,0 +1,21 @@
+---
+status: open
+priority: medium
+---
+
+# Issue Description
+
+Describe the issue here.
+
+## Steps to Reproduce
+
+1. Step 1
+2. Step 2
+
+## Expected Behavior
+
+What should happen.
+
+## Actual Behavior
+
+What actually happens.

--- a/tickets/entities/features/FEAT-002.md
+++ b/tickets/entities/features/FEAT-002.md
@@ -1,0 +1,6 @@
+---
+id: FEAT-002
+status: proposed
+title: Template selection UI and variant support for data entry
+type: feature
+---

--- a/tickets/entities/features/FEAT-003.md
+++ b/tickets/entities/features/FEAT-003.md
@@ -1,5 +1,5 @@
 ---
-id: FEAT-002
+id: FEAT-003
 status: proposed
 title: Template selection UI and variant support for data entry
 type: feature


### PR DESCRIPTION
## Summary
- Add template selector UI (pills for ≤4 templates, dropdown for more) to entity create forms
- Support template variants with `--variant` flag in CLI (`rela template init ticket --variant epic`)
- User defaults now override template values for both properties and relations
- Fix SlimSelect dropdown cleanup on HTMX content swap

## Changes
- **Template Discovery**: `DiscoverEntityTemplates()` finds all templates including variants (`type.md`, `type--variant.md`)
- **Template Relations**: Parse `_template_relations` from template frontmatter for pre-filled relations
- **Priority Chain**: User defaults > Template defaults > Form defaults > Metamodel defaults
- **SlimSelect Fix**: Destroy instances before HTMX swap to prevent orphaned elements

## Test plan
- [x] Template pills display correctly (Default, Bug, Feature)
- [x] Template switch changes field values correctly
- [x] SlimSelect dropdowns render after template switch
- [x] User defaults override template values
- [x] CLI `template init --variant` creates variant templates
- [x] All existing tests pass