### PR TITLE
Add sticky headers to data-entry UI

### DIFF
--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -43,13 +43,15 @@ body { font-family: var(--font); background: var(--bg); color: var(--text); line
 .sidebar nav .nav-group-items a { padding-left: 40px; }
 
 .main { margin-left: 240px; flex: 1; padding: 32px; max-width: 1100px; }
-.page-header { margin-bottom: 24px; display: flex; align-items: center; justify-content: space-between; }
+.page-header { position: sticky; top: 0; z-index: 50; background: var(--bg); padding: 12px 0; margin: -12px 0 16px 0; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; }
 .page-header h2 { font-size: 22px; font-weight: 700; }
 .page-header p { color: var(--text-muted); font-size: 14px; margin-top: 2px; }
 
 .card { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow); }
 
-.filter-bar { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; margin-bottom: 16px; }
+.filter-bar-sentinel { height: 1px; margin: 0; visibility: hidden; }
+.filter-bar { position: sticky; top: 57px; z-index: 40; background: var(--bg); padding: 8px 0 12px 0; display: flex; gap: 12px; align-items: center; flex-wrap: wrap; margin-bottom: 16px; }
+.filter-bar.is-stuck { border-bottom: 1px solid var(--border); box-shadow: 0 2px 4px rgba(0,0,0,0.04); }
 .filter-bar label { font-size: 12px; color: var(--text-muted); font-weight: 500; }
 .filter-bar select, .filter-bar input { padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; font-size: 13px; font-family: var(--font); background: var(--bg-card); min-width: 140px; }
 
@@ -221,7 +223,7 @@ tbody tr:last-child td { border-bottom: none; }
 html { scroll-behavior: smooth; }
 thead th.sortable { user-select: none; }
 .sort-indicator { font-size: 10px; margin-left: 2px; opacity: 0.7; }
-.jump-bar { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 20px; padding: 8px 12px; background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); }
+.jump-bar { position: sticky; top: 57px; z-index: 40; display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 20px; padding: 8px 12px; background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: 0 2px 4px rgba(0,0,0,0.04); }
 .jump-link { font-size: 13px; color: var(--primary); text-decoration: none; padding: 2px 10px; border-radius: 9999px; transition: all 0.15s; }
 .jump-link:hover { background: var(--primary-light); }
 .nav-count { margin-left: auto; font-size: 11px; color: rgba(255,255,255,0.4); font-weight: 400; }
@@ -364,6 +366,19 @@ document.addEventListener('keydown', function(e) {
   if (e.key === 'ArrowLeft') { var btn = nav.querySelector('a.scope-nav-btn'); if (btn) btn.click(); }
   if (e.key === 'ArrowRight') { var btns = nav.querySelectorAll('a.scope-nav-btn'); if (btns.length > 0) btns[btns.length-1].click(); }
 });
+
+// Sticky detection for filter-bar
+(function() {
+  var filterBar = document.querySelector('.filter-bar');
+  if (!filterBar) return;
+  var sentinel = document.createElement('div');
+  sentinel.className = 'filter-bar-sentinel';
+  filterBar.parentNode.insertBefore(sentinel, filterBar);
+  var observer = new IntersectionObserver(function(entries) {
+    filterBar.classList.toggle('is-stuck', !entries[0].isIntersecting);
+  }, { threshold: 0, rootMargin: '-58px 0px 0px 0px' });
+  observer.observe(sentinel);
+})();
 
 // Mermaid diagram rendering
 if (typeof mermaid !== 'undefined') {

--- a/tickets/entities/concepts/data-entry-ui.md
+++ b/tickets/entities/concepts/data-entry-ui.md
@@ -1,0 +1,22 @@
+---
+id: data-entry-ui
+type: concept
+title: Data Entry Web UI
+summary: HTMX-powered web interface for entity/relation management
+description: |
+  Config-driven web application for data entry operations. Built with:
+  - Go HTML templates (internal/dataentry/templates.go)
+  - HTMX for dynamic updates
+  - CSS-in-Go embedded styles
+  - JavaScript enhancements (SlimSelect, sticky detection, etc.)
+
+  Key UI components:
+  - Sidebar navigation (fixed)
+  - Page header with title and actions
+  - Filter bars for list views
+  - Jump bars for entity navigation
+  - Detail views with markdown rendering
+layer: server
+package: internal/dataentry
+status: stable
+---

--- a/tickets/entities/features/FEAT-002.md
+++ b/tickets/entities/features/FEAT-002.md
@@ -1,0 +1,28 @@
+---
+id: FEAT-002
+type: feature
+title: Sticky Headers in Data Entry UI
+summary: Page headers, filter bars, and jump bars stay visible while scrolling
+description: |
+  Sticky positioning for key UI elements in the data-entry web app:
+  - Page header: sticky at top (z-index 50)
+  - Filter bar: sticky below header (z-index 40), with border/shadow appearing only when stuck
+  - Jump bar: sticky below header (z-index 40) with subtle shadow
+
+  Uses IntersectionObserver to detect when filter bar becomes stuck and applies
+  visual feedback (border + shadow) only in that state.
+priority: medium
+status: in-progress
+---
+
+## Implementation
+
+### CSS Changes (templates.go)
+- `.page-header`: `position: sticky; top: 0`
+- `.filter-bar`: `position: sticky; top: 57px`
+- `.filter-bar.is-stuck`: border + shadow styles
+- `.jump-bar`: `position: sticky; top: 57px`
+
+### JavaScript
+- IntersectionObserver watches a sentinel div inserted before filter-bar
+- Toggles `is-stuck` class when sentinel leaves viewport

--- a/tickets/entities/features/FEAT-002.md
+++ b/tickets/entities/features/FEAT-002.md
@@ -18,11 +18,13 @@ status: in-progress
 ## Implementation
 
 ### CSS Changes (templates.go)
+
 - `.page-header`: `position: sticky; top: 0`
 - `.filter-bar`: `position: sticky; top: 57px`
 - `.filter-bar.is-stuck`: border + shadow styles
 - `.jump-bar`: `position: sticky; top: 57px`
 
 ### JavaScript
+
 - IntersectionObserver watches a sentinel div inserted before filter-bar
 - Toggles `is-stuck` class when sentinel leaves viewport

--- a/tickets/relations/FEAT-002--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-002--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-002
+relation: requires
+to: data-entry-ui
+---


### PR DESCRIPTION
## Summary
- Page header stays sticky at top while scrolling
- Filter bar sticks below header with border/shadow appearing only when stuck
- Jump bar sticks below header with subtle shadow

Uses IntersectionObserver to detect stuck state and toggle visual feedback dynamically.

## Test plan
- [ ] Open data-entry demo and scroll on list pages to verify filter bar sticks
- [ ] Verify border/shadow only appears when filter bar is actually stuck
- [ ] Test on entity detail pages with jump bar