### PR TITLE
Add git conflict resolution UI for data entry

### DIFF
--- a/internal/conflict/detect.go
+++ b/internal/conflict/detect.go
@@ -30,8 +30,8 @@ func DetectAll(ctx *project.Context) (*DetectResult, error) {
 	}
 
 	for _, path := range entityFiles {
-		conflicted, err := DetectInFile(path)
-		if err != nil {
+		conflicted, detectErr := DetectInFile(path)
+		if detectErr != nil {
 			continue // Skip files we can't read
 		}
 		if conflicted != nil {
@@ -48,8 +48,8 @@ func DetectAll(ctx *project.Context) (*DetectResult, error) {
 	}
 
 	for _, path := range relationFiles {
-		conflicted, err := DetectInFile(path)
-		if err != nil {
+		conflicted, detectErr := DetectInFile(path)
+		if detectErr != nil {
 			continue // Skip files we can't read
 		}
 		if conflicted != nil {
@@ -61,7 +61,7 @@ func DetectAll(ctx *project.Context) (*DetectResult, error) {
 }
 
 // DetectInFile checks a single file for git conflicts.
-// Returns nil if the file has no conflicts.
+// Returns nil, nil if the file has no conflicts (this is not an error condition).
 func DetectInFile(path string) (*ConflictedFile, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -69,12 +69,12 @@ func DetectInFile(path string) (*ConflictedFile, error) {
 	}
 
 	if !markdown.HasConflictMarkers(content) {
-		return nil, nil
+		return nil, nil //nolint:nilnil // no conflicts is not an error
 	}
 
 	markers := FindMarkers(string(content))
 	if len(markers) == 0 {
-		return nil, nil
+		return nil, nil //nolint:nilnil // no conflicts is not an error
 	}
 
 	return &ConflictedFile{
@@ -84,12 +84,12 @@ func DetectInFile(path string) (*ConflictedFile, error) {
 }
 
 // FindMarkers locates all conflict marker regions in content.
-func FindMarkers(content string) []ConflictMarker {
-	var markers []ConflictMarker
+func FindMarkers(content string) []Marker {
+	var markers []Marker
 
 	scanner := bufio.NewScanner(strings.NewReader(content))
 	lineNum := 0
-	var current *ConflictMarker
+	var current *Marker
 
 	for scanner.Scan() {
 		lineNum++
@@ -98,7 +98,7 @@ func FindMarkers(content string) []ConflictMarker {
 		switch {
 		case strings.HasPrefix(line, markerStart):
 			// Start of new conflict
-			current = &ConflictMarker{
+			current = &Marker{
 				StartLine: lineNum,
 				OursRef:   strings.TrimSpace(strings.TrimPrefix(line, markerStart)),
 			}

--- a/internal/conflict/detect.go
+++ b/internal/conflict/detect.go
@@ -1,0 +1,157 @@
+package conflict
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/markdown"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+)
+
+// Conflict marker prefixes
+const (
+	markerStart = "<<<<<<<"
+	markerMid   = "======="
+	markerEnd   = ">>>>>>>"
+)
+
+// DetectAll scans all entity and relation files for git conflicts.
+func DetectAll(ctx *project.Context) (*DetectResult, error) {
+	result := &DetectResult{
+		Files: make([]ConflictedFile, 0),
+	}
+
+	// Scan entity files
+	entityFiles, err := listMarkdownFiles(ctx.EntitiesDir)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	for _, path := range entityFiles {
+		conflicted, err := DetectInFile(path)
+		if err != nil {
+			continue // Skip files we can't read
+		}
+		if conflicted != nil {
+			// Try to determine entity type from path
+			conflicted.EntityType = inferEntityType(path, ctx.EntitiesDir)
+			result.Files = append(result.Files, *conflicted)
+		}
+	}
+
+	// Scan relation files
+	relationFiles, err := listMarkdownFiles(ctx.RelationsDir)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	for _, path := range relationFiles {
+		conflicted, err := DetectInFile(path)
+		if err != nil {
+			continue // Skip files we can't read
+		}
+		if conflicted != nil {
+			result.Files = append(result.Files, *conflicted)
+		}
+	}
+
+	return result, nil
+}
+
+// DetectInFile checks a single file for git conflicts.
+// Returns nil if the file has no conflicts.
+func DetectInFile(path string) (*ConflictedFile, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if !markdown.HasConflictMarkers(content) {
+		return nil, nil
+	}
+
+	markers := FindMarkers(string(content))
+	if len(markers) == 0 {
+		return nil, nil
+	}
+
+	return &ConflictedFile{
+		Path:    path,
+		Markers: markers,
+	}, nil
+}
+
+// FindMarkers locates all conflict marker regions in content.
+func FindMarkers(content string) []ConflictMarker {
+	var markers []ConflictMarker
+
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	lineNum := 0
+	var current *ConflictMarker
+
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+
+		switch {
+		case strings.HasPrefix(line, markerStart):
+			// Start of new conflict
+			current = &ConflictMarker{
+				StartLine: lineNum,
+				OursRef:   strings.TrimSpace(strings.TrimPrefix(line, markerStart)),
+			}
+
+		case strings.HasPrefix(line, markerMid) && current != nil:
+			// Middle marker
+			current.MidLine = lineNum
+
+		case strings.HasPrefix(line, markerEnd) && current != nil:
+			// End of conflict
+			current.EndLine = lineNum
+			current.TheirsRef = strings.TrimSpace(strings.TrimPrefix(line, markerEnd))
+			markers = append(markers, *current)
+			current = nil
+		}
+	}
+
+	return markers
+}
+
+// HasConflicts checks if content has any conflict markers.
+func HasConflicts(content string) bool {
+	return markdown.HasConflictMarkersString(content)
+}
+
+// listMarkdownFiles returns all .md files in a directory tree.
+func listMarkdownFiles(dir string) ([]string, error) {
+	var files []string
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && strings.HasSuffix(path, ".md") {
+			files = append(files, path)
+		}
+		return nil
+	})
+
+	return files, err
+}
+
+// inferEntityType tries to determine entity type from file path.
+// Entity files are stored as entities/<type>/<id>.md
+func inferEntityType(path, entitiesDir string) string {
+	rel, err := filepath.Rel(entitiesDir, path)
+	if err != nil {
+		return ""
+	}
+
+	parts := strings.Split(rel, string(filepath.Separator))
+	if len(parts) >= 2 {
+		return parts[0]
+	}
+	return ""
+}

--- a/internal/conflict/detect_test.go
+++ b/internal/conflict/detect_test.go
@@ -146,7 +146,7 @@ status: draft
 		t.Fatalf("DetectInFile failed: %v", err)
 	}
 	if cf == nil {
-		t.Error("expected conflict to be detected")
+		t.Fatal("expected conflict to be detected")
 	}
 	if cf.Path != conflictedPath {
 		t.Errorf("Path = %q, want %q", cf.Path, conflictedPath)

--- a/internal/conflict/detect_test.go
+++ b/internal/conflict/detect_test.go
@@ -1,0 +1,266 @@
+package conflict
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/project"
+)
+
+func TestFindMarkers(t *testing.T) {
+	content := `---
+id: REQ-001
+<<<<<<< HEAD
+status: draft
+=======
+status: approved
+>>>>>>> feature-branch
+---
+
+Content here.
+`
+
+	markers := FindMarkers(content)
+
+	if len(markers) != 1 {
+		t.Fatalf("expected 1 marker, got %d", len(markers))
+	}
+
+	m := markers[0]
+	if m.StartLine != 3 {
+		t.Errorf("StartLine = %d, want 3", m.StartLine)
+	}
+	if m.MidLine != 5 {
+		t.Errorf("MidLine = %d, want 5", m.MidLine)
+	}
+	if m.EndLine != 7 {
+		t.Errorf("EndLine = %d, want 7", m.EndLine)
+	}
+	if m.OursRef != "HEAD" {
+		t.Errorf("OursRef = %q, want HEAD", m.OursRef)
+	}
+	if m.TheirsRef != "feature-branch" {
+		t.Errorf("TheirsRef = %q, want feature-branch", m.TheirsRef)
+	}
+}
+
+func TestFindMarkers_Multiple(t *testing.T) {
+	content := `---
+<<<<<<< HEAD
+id: REQ-001
+=======
+id: REQ-002
+>>>>>>> branch
+<<<<<<< HEAD
+status: draft
+=======
+status: done
+>>>>>>> branch
+---
+`
+
+	markers := FindMarkers(content)
+
+	if len(markers) != 2 {
+		t.Fatalf("expected 2 markers, got %d", len(markers))
+	}
+}
+
+func TestFindMarkers_NoConflicts(t *testing.T) {
+	content := `---
+id: REQ-001
+status: draft
+---
+
+Normal content.
+`
+
+	markers := FindMarkers(content)
+
+	if len(markers) != 0 {
+		t.Errorf("expected 0 markers, got %d", len(markers))
+	}
+}
+
+func TestHasConflicts(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name:     "no conflicts",
+			content:  "---\nid: REQ-001\n---\n",
+			expected: false,
+		},
+		{
+			name:     "has conflicts",
+			content:  "---\n<<<<<<< HEAD\nstatus: x\n=======\nstatus: y\n>>>>>>> b\n---\n",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasConflicts(tt.content)
+			if got != tt.expected {
+				t.Errorf("HasConflicts() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDetectInFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a conflicted file
+	conflictedPath := filepath.Join(tmpDir, "conflicted.md")
+	conflictedContent := `---
+id: REQ-001
+<<<<<<< HEAD
+status: draft
+=======
+status: approved
+>>>>>>> feature
+---
+`
+	if err := os.WriteFile(conflictedPath, []byte(conflictedContent), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	// Create a normal file
+	normalPath := filepath.Join(tmpDir, "normal.md")
+	normalContent := `---
+id: REQ-002
+status: draft
+---
+`
+	if err := os.WriteFile(normalPath, []byte(normalContent), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	// Test conflicted file
+	cf, err := DetectInFile(conflictedPath)
+	if err != nil {
+		t.Fatalf("DetectInFile failed: %v", err)
+	}
+	if cf == nil {
+		t.Error("expected conflict to be detected")
+	}
+	if cf.Path != conflictedPath {
+		t.Errorf("Path = %q, want %q", cf.Path, conflictedPath)
+	}
+	if len(cf.Markers) != 1 {
+		t.Errorf("expected 1 marker, got %d", len(cf.Markers))
+	}
+
+	// Test normal file
+	cf, err = DetectInFile(normalPath)
+	if err != nil {
+		t.Fatalf("DetectInFile failed: %v", err)
+	}
+	if cf != nil {
+		t.Error("expected no conflict in normal file")
+	}
+}
+
+func TestDetectAll(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	ctx := &project.Context{
+		Root:         tmpDir,
+		EntitiesDir:  filepath.Join(tmpDir, "entities"),
+		RelationsDir: filepath.Join(tmpDir, "relations"),
+	}
+
+	// Create directories
+	reqDir := filepath.Join(ctx.EntitiesDir, "requirement")
+	if err := os.MkdirAll(reqDir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	if err := os.MkdirAll(ctx.RelationsDir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	// Create a conflicted entity
+	conflictedEntity := `---
+id: REQ-001
+<<<<<<< HEAD
+status: draft
+=======
+status: approved
+>>>>>>> feature
+---
+`
+	if err := os.WriteFile(filepath.Join(reqDir, "REQ-001.md"), []byte(conflictedEntity), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	// Create a normal entity
+	normalEntity := `---
+id: REQ-002
+status: draft
+---
+`
+	if err := os.WriteFile(filepath.Join(reqDir, "REQ-002.md"), []byte(normalEntity), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	// Create a conflicted relation
+	conflictedRelation := `---
+from: REQ-001
+relation: depends-on
+<<<<<<< HEAD
+to: REQ-002
+=======
+to: REQ-003
+>>>>>>> feature
+---
+`
+	if err := os.WriteFile(filepath.Join(ctx.RelationsDir, "conflict.md"), []byte(conflictedRelation), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	result, err := DetectAll(ctx)
+	if err != nil {
+		t.Fatalf("DetectAll failed: %v", err)
+	}
+
+	if len(result.Files) != 2 {
+		t.Errorf("expected 2 conflicted files, got %d", len(result.Files))
+	}
+}
+
+func TestInferEntityType(t *testing.T) {
+	tests := []struct {
+		path        string
+		entitiesDir string
+		expected    string
+	}{
+		{
+			path:        "/project/entities/requirement/REQ-001.md",
+			entitiesDir: "/project/entities",
+			expected:    "requirement",
+		},
+		{
+			path:        "/project/entities/decision/DEC-001.md",
+			entitiesDir: "/project/entities",
+			expected:    "decision",
+		},
+		{
+			path:        "/project/entities/single.md",
+			entitiesDir: "/project/entities",
+			expected:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := inferEntityType(tt.path, tt.entitiesDir)
+			if got != tt.expected {
+				t.Errorf("inferEntityType() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/conflict/parse.go
+++ b/internal/conflict/parse.go
@@ -1,0 +1,267 @@
+package conflict
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/markdown"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// ParseConflictedFile reads and parses both sides of a conflicted file.
+func ParseConflictedFile(path string, meta *metamodel.Metamodel) (*ConflictedFile, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading file: %w", err)
+	}
+
+	return ParseConflictedContent(path, string(content), meta)
+}
+
+// ParseConflictedContent parses conflicted content into structured data.
+func ParseConflictedContent(path, content string, meta *metamodel.Metamodel) (*ConflictedFile, error) {
+	markers := FindMarkers(content)
+	if len(markers) == 0 {
+		return nil, fmt.Errorf("no conflict markers found in %s", path)
+	}
+
+	// Extract ours and theirs content
+	oursContent, theirsContent := ExtractSides(content, markers)
+
+	cf := &ConflictedFile{
+		Path:    path,
+		Markers: markers,
+		Ours:    &ParsedSide{Raw: oursContent},
+		Theirs:  &ParsedSide{Raw: theirsContent},
+	}
+
+	// Try to parse both sides
+	fio := markdown.NewFileIO(storage.NewOsFS())
+
+	// Parse ours side
+	if doc, err := markdown.ParseDocument(oursContent); err == nil {
+		if isRelationFile(path) {
+			cf.Ours.Relation = docToRelation(doc, path)
+		} else {
+			cf.Ours.Entity = docToEntity(doc, path, meta, fio)
+			if cf.Ours.Entity != nil {
+				cf.EntityID = cf.Ours.Entity.ID
+				cf.EntityType = cf.Ours.Entity.Type
+			}
+		}
+	}
+
+	// Parse theirs side
+	if doc, err := markdown.ParseDocument(theirsContent); err == nil {
+		if isRelationFile(path) {
+			cf.Theirs.Relation = docToRelation(doc, path)
+		} else {
+			cf.Theirs.Entity = docToEntity(doc, path, meta, fio)
+			if cf.Theirs.Entity != nil && cf.EntityID == "" {
+				cf.EntityID = cf.Theirs.Entity.ID
+				cf.EntityType = cf.Theirs.Entity.Type
+			}
+		}
+	}
+
+	return cf, nil
+}
+
+// ExtractSides extracts the "ours" and "theirs" versions from conflicted content.
+// It handles multiple conflict regions by merging them appropriately.
+func ExtractSides(content string, markers []ConflictMarker) (ours, theirs string) {
+	lines := strings.Split(content, "\n")
+
+	var oursLines, theirsLines []string
+	inConflict := false
+	inOurs := false
+	conflictIdx := 0
+
+	for i, line := range lines {
+		lineNum := i + 1
+
+		if conflictIdx < len(markers) && lineNum == markers[conflictIdx].StartLine {
+			inConflict = true
+			inOurs = true
+			continue
+		}
+
+		if inConflict && conflictIdx < len(markers) && lineNum == markers[conflictIdx].MidLine {
+			inOurs = false
+			continue
+		}
+
+		if inConflict && conflictIdx < len(markers) && lineNum == markers[conflictIdx].EndLine {
+			inConflict = false
+			inOurs = false
+			conflictIdx++
+			continue
+		}
+
+		if inConflict {
+			if inOurs {
+				oursLines = append(oursLines, line)
+			} else {
+				theirsLines = append(theirsLines, line)
+			}
+		} else {
+			// Outside conflict - add to both sides
+			oursLines = append(oursLines, line)
+			theirsLines = append(theirsLines, line)
+		}
+	}
+
+	return strings.Join(oursLines, "\n"), strings.Join(theirsLines, "\n")
+}
+
+// AnalyzeConflict creates a detailed diff between the two sides.
+func AnalyzeConflict(cf *ConflictedFile) *ConflictInfo {
+	info := &ConflictInfo{
+		File:              cf,
+		PropertyDiffs:     make([]PropertyDiff, 0),
+		ContentDiffOurs:   "",
+		ContentDiffTheirs: "",
+		ContentSame:       true,
+	}
+
+	// Get properties and content from each side
+	var oursProps, theirsProps map[string]interface{}
+	var oursContent, theirsContent string
+
+	if cf.Ours != nil {
+		if cf.Ours.Entity != nil {
+			oursProps = cf.Ours.Entity.Properties
+			oursContent = cf.Ours.Entity.Content
+		} else if cf.Ours.Relation != nil {
+			oursProps = cf.Ours.Relation.Properties
+			oursContent = cf.Ours.Relation.Content
+		}
+	}
+
+	if cf.Theirs != nil {
+		if cf.Theirs.Entity != nil {
+			theirsProps = cf.Theirs.Entity.Properties
+			theirsContent = cf.Theirs.Entity.Content
+		} else if cf.Theirs.Relation != nil {
+			theirsProps = cf.Theirs.Relation.Properties
+			theirsContent = cf.Theirs.Relation.Content
+		}
+	}
+
+	// Collect all property keys
+	allKeys := make(map[string]bool)
+	for k := range oursProps {
+		allKeys[k] = true
+	}
+	for k := range theirsProps {
+		allKeys[k] = true
+	}
+
+	// Sort property keys for stable ordering
+	sortedKeys := make([]string, 0, len(allKeys))
+	for k := range allKeys {
+		sortedKeys = append(sortedKeys, k)
+	}
+	natsort.Strings(sortedKeys)
+
+	// Compare properties (in sorted order)
+	for _, prop := range sortedKeys {
+		oursVal := oursProps[prop]
+		theirsVal := theirsProps[prop]
+		isSame := fmt.Sprintf("%v", oursVal) == fmt.Sprintf("%v", theirsVal)
+
+		info.PropertyDiffs = append(info.PropertyDiffs, PropertyDiff{
+			Property:    prop,
+			OursValue:   oursVal,
+			TheirsValue: theirsVal,
+			IsSame:      isSame,
+		})
+	}
+
+	// Compare content
+	info.ContentDiffOurs = oursContent
+	info.ContentDiffTheirs = theirsContent
+	info.ContentSame = oursContent == theirsContent
+
+	return info
+}
+
+// isRelationFile checks if a path is a relation file based on naming convention.
+func isRelationFile(path string) bool {
+	// Relations are stored as FROM--type--TO.md
+	base := strings.TrimSuffix(path, ".md")
+	parts := strings.Split(base, "--")
+	return len(parts) == 3
+}
+
+// docToEntity converts a parsed document to an entity.
+func docToEntity(doc *markdown.Document, path string, meta *metamodel.Metamodel, fio *markdown.FileIO) *model.Entity {
+	id := doc.GetString("id")
+	entityType := doc.GetString("type")
+
+	if entityType == "" && meta != nil && id != "" {
+		entityType = meta.InferEntityType(id)
+	}
+
+	if meta != nil && entityType != "" {
+		entityType = meta.ResolveAlias(entityType)
+	}
+
+	entity := &model.Entity{
+		ID:         id,
+		Type:       entityType,
+		Properties: make(map[string]interface{}),
+		Content:    doc.Content,
+		FilePath:   path,
+	}
+
+	for key, value := range doc.Frontmatter {
+		if key != "id" && key != "type" {
+			entity.Properties[key] = value
+		}
+	}
+
+	return entity
+}
+
+// docToRelation converts a parsed document to a relation.
+func docToRelation(doc *markdown.Document, path string) *model.Relation {
+	relation := &model.Relation{
+		From:       doc.GetString("from"),
+		Type:       doc.GetString("relation"),
+		To:         doc.GetString("to"),
+		Content:    doc.Content,
+		FilePath:   path,
+		Properties: make(map[string]interface{}),
+	}
+
+	for key, value := range doc.Frontmatter {
+		if key != "from" && key != "relation" && key != "to" {
+			relation.Properties[key] = value
+		}
+	}
+
+	return relation
+}
+
+// readLines reads a file into lines for easier manipulation.
+func readLines(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	return lines, scanner.Err()
+}

--- a/internal/conflict/parse.go
+++ b/internal/conflict/parse.go
@@ -1,7 +1,6 @@
 package conflict
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"strings"
@@ -74,7 +73,7 @@ func ParseConflictedContent(path, content string, meta *metamodel.Metamodel) (*C
 
 // ExtractSides extracts the "ours" and "theirs" versions from conflicted content.
 // It handles multiple conflict regions by merging them appropriately.
-func ExtractSides(content string, markers []ConflictMarker) (ours, theirs string) {
+func ExtractSides(content string, markers []Marker) (ours, theirs string) {
 	lines := strings.Split(content, "\n")
 
 	var oursLines, theirsLines []string
@@ -120,8 +119,8 @@ func ExtractSides(content string, markers []ConflictMarker) (ours, theirs string
 }
 
 // AnalyzeConflict creates a detailed diff between the two sides.
-func AnalyzeConflict(cf *ConflictedFile) *ConflictInfo {
-	info := &ConflictInfo{
+func AnalyzeConflict(cf *ConflictedFile) *Info {
+	info := &Info{
 		File:              cf,
 		PropertyDiffs:     make([]PropertyDiff, 0),
 		ContentDiffOurs:   "",
@@ -200,7 +199,7 @@ func isRelationFile(path string) bool {
 }
 
 // docToEntity converts a parsed document to an entity.
-func docToEntity(doc *markdown.Document, path string, meta *metamodel.Metamodel, fio *markdown.FileIO) *model.Entity {
+func docToEntity(doc *markdown.Document, path string, meta *metamodel.Metamodel, _ *markdown.FileIO) *model.Entity {
 	id := doc.GetString("id")
 	entityType := doc.GetString("type")
 
@@ -247,21 +246,4 @@ func docToRelation(doc *markdown.Document, path string) *model.Relation {
 	}
 
 	return relation
-}
-
-// readLines reads a file into lines for easier manipulation.
-func readLines(path string) ([]string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	var lines []string
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-
-	return lines, scanner.Err()
 }

--- a/internal/conflict/parse_test.go
+++ b/internal/conflict/parse_test.go
@@ -1,0 +1,337 @@
+package conflict
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractSides(t *testing.T) {
+	content := `---
+id: REQ-001
+<<<<<<< HEAD
+status: draft
+priority: high
+=======
+status: approved
+priority: low
+>>>>>>> feature-branch
+title: Test
+---
+
+Content here.
+`
+
+	markers := FindMarkers(content)
+	ours, theirs := ExtractSides(content, markers)
+
+	// Check ours side
+	expectedOurs := `---
+id: REQ-001
+status: draft
+priority: high
+title: Test
+---
+
+Content here.
+`
+	if ours != expectedOurs {
+		t.Errorf("ours =\n%s\nwant:\n%s", ours, expectedOurs)
+	}
+
+	// Check theirs side
+	expectedTheirs := `---
+id: REQ-001
+status: approved
+priority: low
+title: Test
+---
+
+Content here.
+`
+	if theirs != expectedTheirs {
+		t.Errorf("theirs =\n%s\nwant:\n%s", theirs, expectedTheirs)
+	}
+}
+
+func TestExtractSides_MultipleConflicts(t *testing.T) {
+	content := `---
+<<<<<<< HEAD
+id: REQ-001
+=======
+id: REQ-002
+>>>>>>> branch
+type: requirement
+<<<<<<< HEAD
+status: draft
+=======
+status: done
+>>>>>>> branch
+---
+`
+
+	markers := FindMarkers(content)
+	ours, theirs := ExtractSides(content, markers)
+
+	if !contains(ours, "id: REQ-001") {
+		t.Error("ours should contain 'id: REQ-001'")
+	}
+	if !contains(ours, "status: draft") {
+		t.Error("ours should contain 'status: draft'")
+	}
+	if !contains(theirs, "id: REQ-002") {
+		t.Error("theirs should contain 'id: REQ-002'")
+	}
+	if !contains(theirs, "status: done") {
+		t.Error("theirs should contain 'status: done'")
+	}
+}
+
+func TestExtractSides_ConflictInContent(t *testing.T) {
+	content := `---
+id: REQ-001
+status: draft
+---
+
+# Description
+
+<<<<<<< HEAD
+This is the current content.
+=======
+This is the incoming content.
+>>>>>>> feature
+`
+
+	markers := FindMarkers(content)
+	ours, theirs := ExtractSides(content, markers)
+
+	if !contains(ours, "This is the current content.") {
+		t.Error("ours should contain current content")
+	}
+	if contains(ours, "This is the incoming content.") {
+		t.Error("ours should not contain incoming content")
+	}
+	if !contains(theirs, "This is the incoming content.") {
+		t.Error("theirs should contain incoming content")
+	}
+	if contains(theirs, "This is the current content.") {
+		t.Error("theirs should not contain current content")
+	}
+}
+
+func TestParseConflictedFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "REQ-001.md")
+
+	content := `---
+id: REQ-001
+type: requirement
+<<<<<<< HEAD
+status: draft
+priority: high
+=======
+status: approved
+priority: medium
+>>>>>>> feature
+title: Test Requirement
+---
+
+# Description
+
+Test content.
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	cf, err := ParseConflictedFile(path, nil)
+	if err != nil {
+		t.Fatalf("ParseConflictedFile failed: %v", err)
+	}
+
+	if cf.Path != path {
+		t.Errorf("Path = %q, want %q", cf.Path, path)
+	}
+
+	if cf.Ours == nil {
+		t.Fatal("Ours is nil")
+	}
+	if cf.Theirs == nil {
+		t.Fatal("Theirs is nil")
+	}
+
+	// Check ours entity
+	if cf.Ours.Entity == nil {
+		t.Fatal("Ours.Entity is nil")
+	}
+	if cf.Ours.Entity.ID != "REQ-001" {
+		t.Errorf("Ours.Entity.ID = %q, want REQ-001", cf.Ours.Entity.ID)
+	}
+	if cf.Ours.Entity.GetString("status") != "draft" {
+		t.Errorf("Ours status = %q, want draft", cf.Ours.Entity.GetString("status"))
+	}
+	if cf.Ours.Entity.GetString("priority") != "high" {
+		t.Errorf("Ours priority = %q, want high", cf.Ours.Entity.GetString("priority"))
+	}
+
+	// Check theirs entity
+	if cf.Theirs.Entity == nil {
+		t.Fatal("Theirs.Entity is nil")
+	}
+	if cf.Theirs.Entity.GetString("status") != "approved" {
+		t.Errorf("Theirs status = %q, want approved", cf.Theirs.Entity.GetString("status"))
+	}
+	if cf.Theirs.Entity.GetString("priority") != "medium" {
+		t.Errorf("Theirs priority = %q, want medium", cf.Theirs.Entity.GetString("priority"))
+	}
+
+	// Common properties should be the same
+	if cf.Ours.Entity.GetString("title") != cf.Theirs.Entity.GetString("title") {
+		t.Error("title should be the same on both sides")
+	}
+}
+
+func TestParseConflictedContent_Relation(t *testing.T) {
+	content := `---
+from: REQ-001
+relation: depends-on
+<<<<<<< HEAD
+to: REQ-002
+=======
+to: REQ-003
+>>>>>>> feature
+---
+`
+
+	// Use a relation-style path
+	path := "/project/relations/REQ-001--depends-on--conflict.md"
+
+	cf, err := ParseConflictedContent(path, content, nil)
+	if err != nil {
+		t.Fatalf("ParseConflictedContent failed: %v", err)
+	}
+
+	if cf.Ours.Relation == nil {
+		t.Fatal("Ours.Relation is nil")
+	}
+	if cf.Theirs.Relation == nil {
+		t.Fatal("Theirs.Relation is nil")
+	}
+
+	if cf.Ours.Relation.From != "REQ-001" {
+		t.Errorf("Ours.Relation.From = %q, want REQ-001", cf.Ours.Relation.From)
+	}
+	if cf.Ours.Relation.To != "REQ-002" {
+		t.Errorf("Ours.Relation.To = %q, want REQ-002", cf.Ours.Relation.To)
+	}
+	if cf.Theirs.Relation.To != "REQ-003" {
+		t.Errorf("Theirs.Relation.To = %q, want REQ-003", cf.Theirs.Relation.To)
+	}
+}
+
+func TestAnalyzeConflict(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "REQ-001.md")
+
+	content := `---
+id: REQ-001
+type: requirement
+<<<<<<< HEAD
+status: draft
+priority: high
+=======
+status: approved
+priority: high
+>>>>>>> feature
+title: Same Title
+---
+
+<<<<<<< HEAD
+Current content.
+=======
+Different content.
+>>>>>>> feature
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	cf, err := ParseConflictedFile(path, nil)
+	if err != nil {
+		t.Fatalf("ParseConflictedFile failed: %v", err)
+	}
+
+	info := AnalyzeConflict(cf)
+
+	// Check property diffs
+	statusDiff := findPropertyDiff(info.PropertyDiffs, "status")
+	if statusDiff == nil {
+		t.Fatal("status diff not found")
+	}
+	if statusDiff.IsSame {
+		t.Error("status should be different")
+	}
+	if statusDiff.OursValue != "draft" {
+		t.Errorf("status ours = %v, want draft", statusDiff.OursValue)
+	}
+	if statusDiff.TheirsValue != "approved" {
+		t.Errorf("status theirs = %v, want approved", statusDiff.TheirsValue)
+	}
+
+	priorityDiff := findPropertyDiff(info.PropertyDiffs, "priority")
+	if priorityDiff == nil {
+		t.Fatal("priority diff not found")
+	}
+	if !priorityDiff.IsSame {
+		t.Error("priority should be the same")
+	}
+
+	// Check content diff
+	if info.ContentSame {
+		t.Error("content should be different")
+	}
+}
+
+func TestIsRelationFile(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected bool
+	}{
+		{"/project/relations/REQ-001--depends-on--REQ-002.md", true},
+		{"/project/relations/DEC-001--addresses--REQ-001.md", true},
+		{"/project/entities/requirement/REQ-001.md", false},
+		{"/project/relations/invalid.md", false},
+		{"/project/relations/one--two.md", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := isRelationFile(tt.path)
+			if got != tt.expected {
+				t.Errorf("isRelationFile(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func findPropertyDiff(diffs []PropertyDiff, prop string) *PropertyDiff {
+	for i := range diffs {
+		if diffs[i].Property == prop {
+			return &diffs[i]
+		}
+	}
+	return nil
+}

--- a/internal/conflict/parse_test.go
+++ b/internal/conflict/parse_test.go
@@ -315,7 +315,7 @@ func TestIsRelationFile(t *testing.T) {
 }
 
 func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+	return len(s) >= len(substr) && (s == substr || s != "" && containsHelper(s, substr))
 }
 
 func containsHelper(s, substr string) bool {

--- a/internal/conflict/resolve.go
+++ b/internal/conflict/resolve.go
@@ -18,19 +18,13 @@ func Resolve(cf *ConflictedFile, resolution *Resolution) (*model.Entity, *model.
 
 	// Handle entity files
 	if cf.Ours.Entity != nil && cf.Theirs.Entity != nil {
-		entity, err := resolveEntity(cf, resolution)
-		if err != nil {
-			return nil, nil, err
-		}
+		entity := resolveEntity(cf, resolution)
 		return entity, nil, nil
 	}
 
 	// Handle relation files
 	if cf.Ours.Relation != nil && cf.Theirs.Relation != nil {
-		relation, err := resolveRelation(cf, resolution)
-		if err != nil {
-			return nil, nil, err
-		}
+		relation := resolveRelation(cf, resolution)
 		return nil, relation, nil
 	}
 
@@ -38,7 +32,7 @@ func Resolve(cf *ConflictedFile, resolution *Resolution) (*model.Entity, *model.
 }
 
 // resolveEntity merges two entity versions based on the resolution.
-func resolveEntity(cf *ConflictedFile, resolution *Resolution) (*model.Entity, error) {
+func resolveEntity(cf *ConflictedFile, resolution *Resolution) *model.Entity {
 	ours := cf.Ours.Entity
 	theirs := cf.Theirs.Entity
 
@@ -66,8 +60,6 @@ func resolveEntity(cf *ConflictedFile, resolution *Resolution) (*model.Entity, e
 			if val, ok := theirs.Properties[prop]; ok {
 				resolved.Properties[prop] = val
 			}
-		case SideOurs:
-			fallthrough
 		default:
 			// Default to ours
 			if val, ok := ours.Properties[prop]; ok {
@@ -77,19 +69,20 @@ func resolveEntity(cf *ConflictedFile, resolution *Resolution) (*model.Entity, e
 	}
 
 	// Resolve content
-	if resolution.ManualContent != "" {
+	switch {
+	case resolution.ManualContent != "":
 		resolved.Content = resolution.ManualContent
-	} else if resolution.ContentChoice == SideTheirs {
+	case resolution.ContentChoice == SideTheirs:
 		resolved.Content = theirs.Content
-	} else {
+	default:
 		resolved.Content = ours.Content
 	}
 
-	return resolved, nil
+	return resolved
 }
 
 // resolveRelation merges two relation versions based on the resolution.
-func resolveRelation(cf *ConflictedFile, resolution *Resolution) (*model.Relation, error) {
+func resolveRelation(cf *ConflictedFile, resolution *Resolution) *model.Relation {
 	ours := cf.Ours.Relation
 	theirs := cf.Theirs.Relation
 
@@ -121,8 +114,6 @@ func resolveRelation(cf *ConflictedFile, resolution *Resolution) (*model.Relatio
 			if val, ok := theirs.Properties[prop]; ok {
 				resolved.Properties[prop] = val
 			}
-		case SideOurs:
-			fallthrough
 		default:
 			if val, ok := ours.Properties[prop]; ok {
 				resolved.Properties[prop] = val
@@ -131,15 +122,16 @@ func resolveRelation(cf *ConflictedFile, resolution *Resolution) (*model.Relatio
 	}
 
 	// Resolve content
-	if resolution.ManualContent != "" {
+	switch {
+	case resolution.ManualContent != "":
 		resolved.Content = resolution.ManualContent
-	} else if resolution.ContentChoice == SideTheirs {
+	case resolution.ContentChoice == SideTheirs:
 		resolved.Content = theirs.Content
-	} else {
+	default:
 		resolved.Content = ours.Content
 	}
 
-	return resolved, nil
+	return resolved
 }
 
 // ResolveAndWrite resolves a conflict and writes the result to disk.
@@ -155,7 +147,7 @@ func ResolveAndWrite(cf *ConflictedFile, resolution *Resolution, meta *metamodel
 		// Validate entity before writing
 		if meta != nil {
 			if errs := meta.ValidateEntity(entity); len(errs) > 0 {
-				return fmt.Errorf("validation failed: %v", errs[0])
+				return fmt.Errorf("validation failed: %w", errs[0])
 			}
 		}
 		return fio.WriteEntity(entity, cf.Path)

--- a/internal/conflict/resolve.go
+++ b/internal/conflict/resolve.go
@@ -1,0 +1,268 @@
+package conflict
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Sourcehaven-BV/rela/internal/markdown"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// Resolve applies a resolution to a conflicted file and returns the resolved entity or relation.
+func Resolve(cf *ConflictedFile, resolution *Resolution) (*model.Entity, *model.Relation, error) {
+	if cf.Ours == nil || cf.Theirs == nil {
+		return nil, nil, fmt.Errorf("cannot resolve: both sides must be parsed")
+	}
+
+	// Handle entity files
+	if cf.Ours.Entity != nil && cf.Theirs.Entity != nil {
+		entity, err := resolveEntity(cf, resolution)
+		if err != nil {
+			return nil, nil, err
+		}
+		return entity, nil, nil
+	}
+
+	// Handle relation files
+	if cf.Ours.Relation != nil && cf.Theirs.Relation != nil {
+		relation, err := resolveRelation(cf, resolution)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, relation, nil
+	}
+
+	return nil, nil, fmt.Errorf("cannot resolve: mixed or unparseable content")
+}
+
+// resolveEntity merges two entity versions based on the resolution.
+func resolveEntity(cf *ConflictedFile, resolution *Resolution) (*model.Entity, error) {
+	ours := cf.Ours.Entity
+	theirs := cf.Theirs.Entity
+
+	// Start with a copy of one side as the base
+	resolved := &model.Entity{
+		ID:         ours.ID,
+		Type:       ours.Type,
+		Properties: make(map[string]interface{}),
+		FilePath:   cf.Path,
+	}
+
+	// If IDs differ, prefer theirs if explicitly chosen
+	if ours.ID != theirs.ID {
+		if resolution.PropertyChoices["id"] == SideTheirs {
+			resolved.ID = theirs.ID
+		}
+	}
+
+	// Merge properties based on resolution choices
+	allProps := collectPropertyKeys(ours.Properties, theirs.Properties)
+	for _, prop := range allProps {
+		side := resolution.PropertyChoices[prop]
+		switch side {
+		case SideTheirs:
+			if val, ok := theirs.Properties[prop]; ok {
+				resolved.Properties[prop] = val
+			}
+		case SideOurs:
+			fallthrough
+		default:
+			// Default to ours
+			if val, ok := ours.Properties[prop]; ok {
+				resolved.Properties[prop] = val
+			}
+		}
+	}
+
+	// Resolve content
+	if resolution.ManualContent != "" {
+		resolved.Content = resolution.ManualContent
+	} else if resolution.ContentChoice == SideTheirs {
+		resolved.Content = theirs.Content
+	} else {
+		resolved.Content = ours.Content
+	}
+
+	return resolved, nil
+}
+
+// resolveRelation merges two relation versions based on the resolution.
+func resolveRelation(cf *ConflictedFile, resolution *Resolution) (*model.Relation, error) {
+	ours := cf.Ours.Relation
+	theirs := cf.Theirs.Relation
+
+	resolved := &model.Relation{
+		From:       ours.From,
+		Type:       ours.Type,
+		To:         ours.To,
+		Properties: make(map[string]interface{}),
+		FilePath:   cf.Path,
+	}
+
+	// Handle from/to/type differences
+	if resolution.PropertyChoices["from"] == SideTheirs {
+		resolved.From = theirs.From
+	}
+	if resolution.PropertyChoices["to"] == SideTheirs {
+		resolved.To = theirs.To
+	}
+	if resolution.PropertyChoices["relation"] == SideTheirs {
+		resolved.Type = theirs.Type
+	}
+
+	// Merge other properties
+	allProps := collectPropertyKeys(ours.Properties, theirs.Properties)
+	for _, prop := range allProps {
+		side := resolution.PropertyChoices[prop]
+		switch side {
+		case SideTheirs:
+			if val, ok := theirs.Properties[prop]; ok {
+				resolved.Properties[prop] = val
+			}
+		case SideOurs:
+			fallthrough
+		default:
+			if val, ok := ours.Properties[prop]; ok {
+				resolved.Properties[prop] = val
+			}
+		}
+	}
+
+	// Resolve content
+	if resolution.ManualContent != "" {
+		resolved.Content = resolution.ManualContent
+	} else if resolution.ContentChoice == SideTheirs {
+		resolved.Content = theirs.Content
+	} else {
+		resolved.Content = ours.Content
+	}
+
+	return resolved, nil
+}
+
+// ResolveAndWrite resolves a conflict and writes the result to disk.
+func ResolveAndWrite(cf *ConflictedFile, resolution *Resolution, meta *metamodel.Metamodel) error {
+	entity, relation, err := Resolve(cf, resolution)
+	if err != nil {
+		return err
+	}
+
+	fio := markdown.NewFileIO(storage.NewOsFS())
+
+	if entity != nil {
+		// Validate entity before writing
+		if meta != nil {
+			if errs := meta.ValidateEntity(entity); len(errs) > 0 {
+				return fmt.Errorf("validation failed: %v", errs[0])
+			}
+		}
+		return fio.WriteEntity(entity, cf.Path)
+	}
+
+	if relation != nil {
+		return fio.WriteRelation(relation, cf.Path)
+	}
+
+	return fmt.Errorf("nothing to write")
+}
+
+// AcceptOurs resolves a conflict by accepting all values from "ours" (HEAD).
+func AcceptOurs(cf *ConflictedFile) *Resolution {
+	resolution := &Resolution{
+		PropertyChoices: make(map[string]Side),
+		ContentChoice:   SideOurs,
+	}
+
+	// Set all properties to ours
+	if cf.Ours != nil && cf.Ours.Entity != nil {
+		for prop := range cf.Ours.Entity.Properties {
+			resolution.PropertyChoices[prop] = SideOurs
+		}
+	}
+	if cf.Theirs != nil && cf.Theirs.Entity != nil {
+		for prop := range cf.Theirs.Entity.Properties {
+			if _, ok := resolution.PropertyChoices[prop]; !ok {
+				resolution.PropertyChoices[prop] = SideOurs
+			}
+		}
+	}
+
+	return resolution
+}
+
+// AcceptTheirs resolves a conflict by accepting all values from "theirs" (incoming).
+func AcceptTheirs(cf *ConflictedFile) *Resolution {
+	resolution := &Resolution{
+		PropertyChoices: make(map[string]Side),
+		ContentChoice:   SideTheirs,
+	}
+
+	// Set all properties to theirs
+	if cf.Ours != nil && cf.Ours.Entity != nil {
+		for prop := range cf.Ours.Entity.Properties {
+			resolution.PropertyChoices[prop] = SideTheirs
+		}
+	}
+	if cf.Theirs != nil && cf.Theirs.Entity != nil {
+		for prop := range cf.Theirs.Entity.Properties {
+			resolution.PropertyChoices[prop] = SideTheirs
+		}
+	}
+
+	return resolution
+}
+
+// WriteResolved writes a resolved entity or relation to disk.
+func WriteResolved(path string, entity *model.Entity, relation *model.Relation) error {
+	fio := markdown.NewFileIO(storage.NewOsFS())
+
+	if entity != nil {
+		return fio.WriteEntity(entity, path)
+	}
+	if relation != nil {
+		return fio.WriteRelation(relation, path)
+	}
+	return fmt.Errorf("nothing to write")
+}
+
+// RemoveConflictMarkers removes all conflict markers from a file, keeping the "ours" content.
+// This is a simple text-based resolution that doesn't parse the YAML.
+func RemoveConflictMarkers(path string, keepSide Side) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	markers := FindMarkers(string(content))
+	if len(markers) == 0 {
+		return nil // No conflicts to resolve
+	}
+
+	var resolved string
+	if keepSide == SideTheirs {
+		_, resolved = ExtractSides(string(content), markers)
+	} else {
+		resolved, _ = ExtractSides(string(content), markers)
+	}
+
+	return os.WriteFile(path, []byte(resolved), 0644)
+}
+
+// collectPropertyKeys returns all unique property keys from both maps.
+func collectPropertyKeys(a, b map[string]interface{}) []string {
+	keys := make(map[string]bool)
+	for k := range a {
+		keys[k] = true
+	}
+	for k := range b {
+		keys[k] = true
+	}
+
+	result := make([]string, 0, len(keys))
+	for k := range keys {
+		result = append(result, k)
+	}
+	return result
+}

--- a/internal/conflict/resolve_test.go
+++ b/internal/conflict/resolve_test.go
@@ -1,0 +1,363 @@
+package conflict
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolve_Entity(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "REQ-001.md")
+
+	content := `---
+id: REQ-001
+type: requirement
+<<<<<<< HEAD
+status: draft
+priority: high
+=======
+status: approved
+priority: low
+>>>>>>> feature
+title: Test
+---
+
+<<<<<<< HEAD
+Current content.
+=======
+Incoming content.
+>>>>>>> feature
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	cf, err := ParseConflictedFile(path, nil)
+	if err != nil {
+		t.Fatalf("ParseConflictedFile failed: %v", err)
+	}
+
+	// Resolve with mixed choices
+	resolution := &Resolution{
+		PropertyChoices: map[string]Side{
+			"status":   SideTheirs, // Take theirs (approved)
+			"priority": SideOurs,   // Keep ours (high)
+			"title":    SideOurs,   // Keep ours
+		},
+		ContentChoice: SideTheirs, // Take theirs content
+	}
+
+	entity, relation, err := Resolve(cf, resolution)
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	if relation != nil {
+		t.Error("expected nil relation for entity file")
+	}
+	if entity == nil {
+		t.Fatal("expected entity, got nil")
+	}
+
+	if entity.ID != "REQ-001" {
+		t.Errorf("ID = %q, want REQ-001", entity.ID)
+	}
+	if entity.GetString("status") != "approved" {
+		t.Errorf("status = %q, want approved (theirs)", entity.GetString("status"))
+	}
+	if entity.GetString("priority") != "high" {
+		t.Errorf("priority = %q, want high (ours)", entity.GetString("priority"))
+	}
+	if !strings.Contains(entity.Content, "Incoming content") {
+		t.Error("content should be theirs (incoming)")
+	}
+}
+
+func TestResolve_Relation(t *testing.T) {
+	content := `---
+from: REQ-001
+relation: depends-on
+<<<<<<< HEAD
+to: REQ-002
+=======
+to: REQ-003
+>>>>>>> feature
+---
+`
+	path := "/project/relations/REQ-001--depends-on--conflict.md"
+
+	cf, err := ParseConflictedContent(path, content, nil)
+	if err != nil {
+		t.Fatalf("ParseConflictedContent failed: %v", err)
+	}
+
+	resolution := &Resolution{
+		PropertyChoices: map[string]Side{
+			"to": SideTheirs, // Take theirs (REQ-003)
+		},
+		ContentChoice: SideOurs,
+	}
+
+	entity, relation, err := Resolve(cf, resolution)
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	if entity != nil {
+		t.Error("expected nil entity for relation file")
+	}
+	if relation == nil {
+		t.Fatal("expected relation, got nil")
+	}
+
+	if relation.From != "REQ-001" {
+		t.Errorf("From = %q, want REQ-001", relation.From)
+	}
+	if relation.To != "REQ-003" {
+		t.Errorf("To = %q, want REQ-003 (theirs)", relation.To)
+	}
+}
+
+func TestAcceptOurs(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "REQ-001.md")
+
+	content := `---
+id: REQ-001
+type: requirement
+<<<<<<< HEAD
+status: draft
+=======
+status: approved
+>>>>>>> feature
+---
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	cf, err := ParseConflictedFile(path, nil)
+	if err != nil {
+		t.Fatalf("ParseConflictedFile failed: %v", err)
+	}
+
+	resolution := AcceptOurs(cf)
+
+	entity, _, err := Resolve(cf, resolution)
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	if entity.GetString("status") != "draft" {
+		t.Errorf("status = %q, want draft (ours)", entity.GetString("status"))
+	}
+}
+
+func TestAcceptTheirs(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "REQ-001.md")
+
+	content := `---
+id: REQ-001
+type: requirement
+<<<<<<< HEAD
+status: draft
+=======
+status: approved
+>>>>>>> feature
+---
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	cf, err := ParseConflictedFile(path, nil)
+	if err != nil {
+		t.Fatalf("ParseConflictedFile failed: %v", err)
+	}
+
+	resolution := AcceptTheirs(cf)
+
+	entity, _, err := Resolve(cf, resolution)
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	if entity.GetString("status") != "approved" {
+		t.Errorf("status = %q, want approved (theirs)", entity.GetString("status"))
+	}
+}
+
+func TestResolve_ManualContent(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "REQ-001.md")
+
+	content := `---
+id: REQ-001
+type: requirement
+status: draft
+---
+
+<<<<<<< HEAD
+Current content.
+=======
+Incoming content.
+>>>>>>> feature
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	cf, err := ParseConflictedFile(path, nil)
+	if err != nil {
+		t.Fatalf("ParseConflictedFile failed: %v", err)
+	}
+
+	resolution := &Resolution{
+		PropertyChoices: make(map[string]Side),
+		ManualContent:   "Manually edited content.",
+	}
+
+	entity, _, err := Resolve(cf, resolution)
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	if entity.Content != "Manually edited content." {
+		t.Errorf("content = %q, want manual content", entity.Content)
+	}
+}
+
+func TestResolveAndWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "REQ-001.md")
+
+	content := `---
+id: REQ-001
+type: requirement
+<<<<<<< HEAD
+status: draft
+=======
+status: approved
+>>>>>>> feature
+---
+
+Content.
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	cf, err := ParseConflictedFile(path, nil)
+	if err != nil {
+		t.Fatalf("ParseConflictedFile failed: %v", err)
+	}
+
+	resolution := AcceptTheirs(cf)
+
+	err = ResolveAndWrite(cf, resolution, nil)
+	if err != nil {
+		t.Fatalf("ResolveAndWrite failed: %v", err)
+	}
+
+	// Read back and verify
+	newContent, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read resolved file: %v", err)
+	}
+
+	if strings.Contains(string(newContent), "<<<<<<<") {
+		t.Error("resolved file should not contain conflict markers")
+	}
+	if !strings.Contains(string(newContent), "status: approved") {
+		t.Error("resolved file should contain theirs status")
+	}
+}
+
+func TestRemoveConflictMarkers(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name     string
+		content  string
+		keepSide Side
+		expected string
+	}{
+		{
+			name: "keep ours",
+			content: `---
+id: REQ-001
+<<<<<<< HEAD
+status: draft
+=======
+status: approved
+>>>>>>> feature
+---
+`,
+			keepSide: SideOurs,
+			expected: "status: draft",
+		},
+		{
+			name: "keep theirs",
+			content: `---
+id: REQ-001
+<<<<<<< HEAD
+status: draft
+=======
+status: approved
+>>>>>>> feature
+---
+`,
+			keepSide: SideTheirs,
+			expected: "status: approved",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(tmpDir, tt.name+".md")
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("failed to create file: %v", err)
+			}
+
+			err := RemoveConflictMarkers(path, tt.keepSide)
+			if err != nil {
+				t.Fatalf("RemoveConflictMarkers failed: %v", err)
+			}
+
+			newContent, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read file: %v", err)
+			}
+
+			if strings.Contains(string(newContent), "<<<<<<<") {
+				t.Error("should not contain conflict markers")
+			}
+			if !strings.Contains(string(newContent), tt.expected) {
+				t.Errorf("should contain %q", tt.expected)
+			}
+		})
+	}
+}
+
+func TestCollectPropertyKeys(t *testing.T) {
+	a := map[string]interface{}{"foo": 1, "bar": 2}
+	b := map[string]interface{}{"bar": 3, "baz": 4}
+
+	keys := collectPropertyKeys(a, b)
+
+	if len(keys) != 3 {
+		t.Errorf("expected 3 keys, got %d", len(keys))
+	}
+
+	keyMap := make(map[string]bool)
+	for _, k := range keys {
+		keyMap[k] = true
+	}
+
+	if !keyMap["foo"] || !keyMap["bar"] || !keyMap["baz"] {
+		t.Error("missing expected keys")
+	}
+}

--- a/internal/conflict/types.go
+++ b/internal/conflict/types.go
@@ -14,8 +14,8 @@ const (
 	SideTheirs Side = "theirs" // Incoming branch
 )
 
-// ConflictMarker represents a single conflict region in a file.
-type ConflictMarker struct {
+// Marker represents a single conflict region in a file.
+type Marker struct {
 	StartLine int    // Line number of <<<<<<<
 	MidLine   int    // Line number of =======
 	EndLine   int    // Line number of >>>>>>>
@@ -25,12 +25,12 @@ type ConflictMarker struct {
 
 // ConflictedFile represents a file with one or more git conflicts.
 type ConflictedFile struct {
-	Path       string           // Absolute path to the file
-	EntityType string           // Entity type (if known)
-	EntityID   string           // Entity ID (if parseable from either side)
-	Markers    []ConflictMarker // All conflict regions in the file
-	Ours       *ParsedSide      // Parsed content from "ours" side
-	Theirs     *ParsedSide      // Parsed content from "theirs" side
+	Path       string      // Absolute path to the file
+	EntityType string      // Entity type (if known)
+	EntityID   string      // Entity ID (if parseable from either side)
+	Markers    []Marker    // All conflict regions in the file
+	Ours       *ParsedSide // Parsed content from "ours" side
+	Theirs     *ParsedSide // Parsed content from "theirs" side
 }
 
 // ParsedSide represents one side of a conflict, parsed into structured data.
@@ -48,8 +48,8 @@ type PropertyDiff struct {
 	IsSame      bool        // True if both sides have the same value
 }
 
-// ConflictInfo provides a structured view of differences between sides.
-type ConflictInfo struct {
+// Info provides a structured view of differences between sides.
+type Info struct {
 	File              *ConflictedFile
 	PropertyDiffs     []PropertyDiff // Differences in frontmatter properties
 	ContentDiffOurs   string         // Markdown content from ours

--- a/internal/conflict/types.go
+++ b/internal/conflict/types.go
@@ -1,0 +1,70 @@
+// Package conflict provides detection and resolution of git merge conflicts
+// in entity and relation markdown files.
+package conflict
+
+import (
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+// Side represents which side of a conflict to use.
+type Side string
+
+const (
+	SideOurs   Side = "ours"   // Current branch (HEAD)
+	SideTheirs Side = "theirs" // Incoming branch
+)
+
+// ConflictMarker represents a single conflict region in a file.
+type ConflictMarker struct {
+	StartLine int    // Line number of <<<<<<<
+	MidLine   int    // Line number of =======
+	EndLine   int    // Line number of >>>>>>>
+	OursRef   string // Reference after <<<<<<< (e.g., "HEAD")
+	TheirsRef string // Reference after >>>>>>> (e.g., "feature-branch")
+}
+
+// ConflictedFile represents a file with one or more git conflicts.
+type ConflictedFile struct {
+	Path       string           // Absolute path to the file
+	EntityType string           // Entity type (if known)
+	EntityID   string           // Entity ID (if parseable from either side)
+	Markers    []ConflictMarker // All conflict regions in the file
+	Ours       *ParsedSide      // Parsed content from "ours" side
+	Theirs     *ParsedSide      // Parsed content from "theirs" side
+}
+
+// ParsedSide represents one side of a conflict, parsed into structured data.
+type ParsedSide struct {
+	Entity   *model.Entity   // Parsed entity (for entity files)
+	Relation *model.Relation // Parsed relation (for relation files)
+	Raw      string          // Raw content of this side
+}
+
+// PropertyDiff represents the difference in a single property between sides.
+type PropertyDiff struct {
+	Property    string      // Property name
+	OursValue   interface{} // Value on "ours" side (nil if not present)
+	TheirsValue interface{} // Value on "theirs" side (nil if not present)
+	IsSame      bool        // True if both sides have the same value
+}
+
+// ConflictInfo provides a structured view of differences between sides.
+type ConflictInfo struct {
+	File              *ConflictedFile
+	PropertyDiffs     []PropertyDiff // Differences in frontmatter properties
+	ContentDiffOurs   string         // Markdown content from ours
+	ContentDiffTheirs string         // Markdown content from theirs
+	ContentSame       bool           // True if content is identical
+}
+
+// Resolution represents how to resolve a conflict.
+type Resolution struct {
+	PropertyChoices map[string]Side // Which side to use for each property
+	ContentChoice   Side            // Which side to use for content
+	ManualContent   string          // If set, use this instead of either side
+}
+
+// DetectResult contains the results of scanning for conflicts.
+type DetectResult struct {
+	Files []ConflictedFile // All files with conflicts
+}

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -262,6 +262,7 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 
 	data := map[string]interface{}{
 		"App":              a.Cfg.App,
+		"ConflictCount":    a.conflictCount(),
 		"Navigation":       a.navElements(listID),
 		"ActiveList":       listID,
 		"List":             list,
@@ -605,6 +606,7 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 
 	data := map[string]interface{}{
 		"App":               a.Cfg.App,
+		"ConflictCount":     a.conflictCount(),
 		"Navigation":        a.navElements(activeList),
 		"ActiveList":        activeList,
 		"FormID":            formID,
@@ -748,19 +750,20 @@ func (a *App) handleEntity(w http.ResponseWriter, r *http.Request) {
 		backURL = "/list/" + entityActiveList
 	}
 	data := map[string]interface{}{
-		"App":        a.Cfg.App,
-		"Navigation": a.navElements(entityActiveList),
-		"ActiveList": entityActiveList,
-		"Entity":     entity,
-		"EntityDef":  entDef,
-		"EditFormID": editFormID,
-		"Relations":  rels,
-		"PropTypes":  propTypes,
-		"ReturnTo":   returnTo,
-		"Scope":      a.resolveScope(entity.ID, r),
-		"Commands":   a.resolveCommands("entity", "", entity.Type),
-		"BackURL":    backURL,
-		"IsHTMX":     r.Header.Get("HX-Request") == "true",
+		"App":           a.Cfg.App,
+		"ConflictCount": a.conflictCount(),
+		"Navigation":    a.navElements(entityActiveList),
+		"ActiveList":    entityActiveList,
+		"Entity":        entity,
+		"EntityDef":     entDef,
+		"EditFormID":    editFormID,
+		"Relations":     rels,
+		"PropTypes":     propTypes,
+		"ReturnTo":      returnTo,
+		"Scope":         a.resolveScope(entity.ID, r),
+		"Commands":      a.resolveCommands("entity", "", entity.Type),
+		"BackURL":       backURL,
+		"IsHTMX":        r.Header.Get("HX-Request") == "true",
 	}
 
 	if r.Header.Get("HX-Request") == "true" {
@@ -867,21 +870,22 @@ func (a *App) handleView(w http.ResponseWriter, r *http.Request) {
 		backURL = "/list/" + viewActiveList
 	}
 	data := map[string]interface{}{
-		"App":        a.Cfg.App,
-		"Navigation": a.navElements(viewActiveList),
-		"ActiveList": viewActiveList,
-		"View":       view,
-		"ViewID":     viewID,
-		"EntityID":   entityID,
-		"Entry":      result.Entry,
-		"EntryTitle": a.entityDisplayTitle(result.Entry),
-		"EditFormID": a.editFormForType(result.Entry.Type),
-		"ReturnTo":   returnTo,
-		"Sections":   sections,
-		"Scope":      a.resolveScope(entityID, r),
-		"Commands":   a.resolveCommands("view", viewID, result.Entry.Type),
-		"BackURL":    backURL,
-		"IsHTMX":     r.Header.Get("HX-Request") == "true",
+		"App":           a.Cfg.App,
+		"ConflictCount": a.conflictCount(),
+		"Navigation":    a.navElements(viewActiveList),
+		"ActiveList":    viewActiveList,
+		"View":          view,
+		"ViewID":        viewID,
+		"EntityID":      entityID,
+		"Entry":         result.Entry,
+		"EntryTitle":    a.entityDisplayTitle(result.Entry),
+		"EditFormID":    a.editFormForType(result.Entry.Type),
+		"ReturnTo":      returnTo,
+		"Sections":      sections,
+		"Scope":         a.resolveScope(entityID, r),
+		"Commands":      a.resolveCommands("view", viewID, result.Entry.Type),
+		"BackURL":       backURL,
+		"IsHTMX":        r.Header.Get("HX-Request") == "true",
 	}
 
 	if r.Header.Get("HX-Request") == "true" {
@@ -1036,25 +1040,26 @@ func (a *App) renderFormWithErrors(w http.ResponseWriter, r *http.Request, formI
 	}
 
 	data := map[string]interface{}{
-		"App":          a.Cfg.App,
-		"Navigation":   a.navElements(activeList),
-		"ActiveList":   activeList,
-		"FormID":       formID,
-		"Form":         form,
-		"Fields":       fields,
-		"Relations":    relations,
-		"Mode":         mode,
-		"EntityID":     entity.ID,
-		"EntityType":   form.EntityType,
-		"ShowBody":     showBody,
-		"Body":         bodyContent,
-		"ReturnTo":     returnTo,
-		"BackURL":      backURL,
-		"LinkRelation": linkRelation,
-		"LinkPeer":     linkPeer,
-		"LinkAs":       r.FormValue("_link_as"),
-		"IsHTMX":       true, // Always true since this is a form submission response
-		"HasErrors":    len(fieldErrors) > 0,
+		"App":           a.Cfg.App,
+		"ConflictCount": a.conflictCount(),
+		"Navigation":    a.navElements(activeList),
+		"ActiveList":    activeList,
+		"FormID":        formID,
+		"Form":          form,
+		"Fields":        fields,
+		"Relations":     relations,
+		"Mode":          mode,
+		"EntityID":      entity.ID,
+		"EntityType":    form.EntityType,
+		"ShowBody":      showBody,
+		"Body":          bodyContent,
+		"ReturnTo":      returnTo,
+		"BackURL":       backURL,
+		"LinkRelation":  linkRelation,
+		"LinkPeer":      linkPeer,
+		"LinkAs":        r.FormValue("_link_as"),
+		"IsHTMX":        true, // Always true since this is a form submission response
+		"HasErrors":     len(fieldErrors) > 0,
 	}
 
 	// Return 422 Unprocessable Entity for validation errors.
@@ -1894,6 +1899,7 @@ func (a *App) handleSearch(w http.ResponseWriter, r *http.Request) {
 
 	data := map[string]interface{}{
 		"App":             a.Cfg.App,
+		"ConflictCount":   a.conflictCount(),
 		"Navigation":      a.navElements(""),
 		"ActiveList":      "",
 		"Query":           query,
@@ -2057,6 +2063,7 @@ func (a *App) handleDashboard(w http.ResponseWriter, r *http.Request) {
 
 	data := map[string]interface{}{
 		"App":              a.Cfg.App,
+		"ConflictCount":    a.conflictCount(),
 		"Navigation":       a.navElements("_dashboard"),
 		"ActiveList":       "_dashboard",
 		"Dashboard":        dash,
@@ -2079,11 +2086,12 @@ func (a *App) handleAnalyze(w http.ResponseWriter, r *http.Request) {
 	result := a.runAnalysis()
 
 	data := map[string]interface{}{
-		"App":        a.Cfg.App,
-		"Navigation": a.navElements("_analyze"),
-		"ActiveList": "_analyze",
-		"Analysis":   result,
-		"IsHTMX":     r.Header.Get("HX-Request") == "true",
+		"App":           a.Cfg.App,
+		"ConflictCount": a.conflictCount(),
+		"Navigation":    a.navElements("_analyze"),
+		"ActiveList":    "_analyze",
+		"Analysis":      result,
+		"IsHTMX":        r.Header.Get("HX-Request") == "true",
 	}
 
 	if r.Header.Get("HX-Request") == "true" {
@@ -2210,6 +2218,7 @@ func (a *App) handleSettings(w http.ResponseWriter, r *http.Request) {
 	activeList := "_settings"
 	data := map[string]interface{}{
 		"App":           a.Cfg.App,
+		"ConflictCount": a.conflictCount(),
 		"Navigation":    a.navElements(activeList),
 		"ActiveList":    activeList,
 		"UserDefaults":  ud,

--- a/internal/dataentry/handlers_conflict.go
+++ b/internal/dataentry/handlers_conflict.go
@@ -1,0 +1,227 @@
+package dataentry
+
+import (
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/conflict"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+)
+
+// ConflictListItem represents a conflicted file for display.
+type ConflictListItem struct {
+	Path        string
+	RelPath     string
+	EntityType  string
+	EntityID    string
+	MarkerCount int
+}
+
+// ConflictResolutionData contains data for the resolution page.
+type ConflictResolutionData struct {
+	File       *conflict.ConflictedFile
+	Info       *conflict.ConflictInfo
+	RelPath    string
+	IsEntity   bool
+	IsRelation bool
+}
+
+// handleConflicts shows a list of files with git conflicts.
+func (a *App) handleConflicts(w http.ResponseWriter, r *http.Request) {
+	// Check if this is a resolution request (path after /conflicts/)
+	path := strings.TrimPrefix(r.URL.Path, "/conflicts")
+	if path != "" && path != "/" {
+		a.handleConflictResolve(w, r)
+		return
+	}
+
+	ctx := &project.Context{
+		Root:         a.repo.Paths().Root,
+		EntitiesDir:  a.repo.Paths().EntitiesDir,
+		RelationsDir: a.repo.Paths().RelationsDir,
+	}
+
+	result, err := conflict.DetectAll(ctx)
+	if err != nil {
+		http.Error(w, "Failed to detect conflicts: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Build list items
+	items := make([]ConflictListItem, 0, len(result.Files))
+	for _, cf := range result.Files {
+		relPath, _ := filepath.Rel(ctx.Root, cf.Path)
+		items = append(items, ConflictListItem{
+			Path:        cf.Path,
+			RelPath:     relPath,
+			EntityType:  cf.EntityType,
+			EntityID:    cf.EntityID,
+			MarkerCount: len(cf.Markers),
+		})
+	}
+
+	data := map[string]interface{}{
+		"App":           a.Cfg.App,
+		"ConflictCount": len(items),
+		"Navigation":    a.navElements("_conflicts"),
+		"ActiveList":    "_conflicts",
+		"Conflicts":     items,
+		"HasConflicts":  len(items) > 0,
+		"IsHTMX":        r.Header.Get("HX-Request") == "true",
+	}
+
+	if r.Header.Get("HX-Request") == "true" {
+		a.tmpl.ExecuteTemplate(w, "conflicts-content", data) //nolint:errcheck
+	} else {
+		a.tmpl.ExecuteTemplate(w, "conflicts-page", data) //nolint:errcheck
+	}
+}
+
+// handleConflictResolve shows the resolution UI for a specific file.
+func (a *App) handleConflictResolve(w http.ResponseWriter, r *http.Request) {
+	// Extract file path from URL
+	path := strings.TrimPrefix(r.URL.Path, "/conflicts/")
+	if path == "" {
+		http.Error(w, "Missing file path", http.StatusBadRequest)
+		return
+	}
+
+	// Build absolute path
+	ctx := a.repo.Paths()
+	absPath := filepath.Join(ctx.Root, path)
+
+	// Parse the conflicted file
+	cf, err := conflict.ParseConflictedFile(absPath, a.meta)
+	if err != nil {
+		http.Error(w, "Failed to parse conflict: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	info := conflict.AnalyzeConflict(cf)
+
+	resData := &ConflictResolutionData{
+		File:       cf,
+		Info:       info,
+		RelPath:    path,
+		IsEntity:   cf.Ours != nil && cf.Ours.Entity != nil,
+		IsRelation: cf.Ours != nil && cf.Ours.Relation != nil,
+	}
+
+	data := map[string]interface{}{
+		"App":           a.Cfg.App,
+		"ConflictCount": a.conflictCount(),
+		"Navigation":    a.navElements("_conflicts"),
+		"ActiveList":    "_conflicts",
+		"Resolution":    resData,
+		"IsHTMX":        r.Header.Get("HX-Request") == "true",
+	}
+
+	if r.Header.Get("HX-Request") == "true" {
+		a.tmpl.ExecuteTemplate(w, "conflict-resolve-content", data) //nolint:errcheck
+	} else {
+		a.tmpl.ExecuteTemplate(w, "conflict-resolve-page", data) //nolint:errcheck
+	}
+}
+
+// handleConflictApply applies a resolution to a conflicted file.
+func (a *App) handleConflictApply(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "Invalid form data", http.StatusBadRequest)
+		return
+	}
+
+	path := r.FormValue("path")
+	if path == "" {
+		http.Error(w, "Missing path", http.StatusBadRequest)
+		return
+	}
+
+	action := r.FormValue("action")
+	ctx := a.repo.Paths()
+	absPath := filepath.Join(ctx.Root, path)
+
+	// Parse the file again
+	cf, err := conflict.ParseConflictedFile(absPath, a.meta)
+	if err != nil {
+		http.Error(w, "Failed to parse conflict: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var resolution *conflict.Resolution
+
+	switch action {
+	case "ours":
+		resolution = conflict.AcceptOurs(cf)
+	case "theirs":
+		resolution = conflict.AcceptTheirs(cf)
+	case "custom":
+		// Build resolution from form values
+		resolution = &conflict.Resolution{
+			PropertyChoices: make(map[string]conflict.Side),
+		}
+
+		// Get property choices
+		for key := range r.Form {
+			if strings.HasPrefix(key, "prop_") {
+				propName := strings.TrimPrefix(key, "prop_")
+				value := r.FormValue(key)
+				if value == "theirs" {
+					resolution.PropertyChoices[propName] = conflict.SideTheirs
+				} else {
+					resolution.PropertyChoices[propName] = conflict.SideOurs
+				}
+			}
+		}
+
+		// Get content choice
+		contentChoice := r.FormValue("content")
+		if contentChoice == "theirs" {
+			resolution.ContentChoice = conflict.SideTheirs
+		} else if contentChoice == "manual" {
+			resolution.ManualContent = r.FormValue("manual_content")
+		} else {
+			resolution.ContentChoice = conflict.SideOurs
+		}
+	default:
+		http.Error(w, "Invalid action", http.StatusBadRequest)
+		return
+	}
+
+	// Apply the resolution
+	if err := conflict.ResolveAndWrite(cf, resolution, a.meta); err != nil {
+		http.Error(w, "Failed to resolve: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Redirect back to conflicts list
+	if r.Header.Get("HX-Request") == "true" {
+		w.Header().Set("HX-Redirect", "/conflicts")
+		w.WriteHeader(http.StatusOK)
+	} else {
+		http.Redirect(w, r, "/conflicts", http.StatusSeeOther)
+	}
+}
+
+// conflictCount returns the number of conflicted files for nav badge.
+func (a *App) conflictCount() int {
+	if a.repo == nil {
+		return 0
+	}
+	ctx := &project.Context{
+		Root:         a.repo.Paths().Root,
+		EntitiesDir:  a.repo.Paths().EntitiesDir,
+		RelationsDir: a.repo.Paths().RelationsDir,
+	}
+
+	result, err := conflict.DetectAll(ctx)
+	if err != nil {
+		return 0
+	}
+	return len(result.Files)
+}

--- a/internal/dataentry/handlers_conflict.go
+++ b/internal/dataentry/handlers_conflict.go
@@ -21,7 +21,7 @@ type ConflictListItem struct {
 // ConflictResolutionData contains data for the resolution page.
 type ConflictResolutionData struct {
 	File       *conflict.ConflictedFile
-	Info       *conflict.ConflictInfo
+	Info       *conflict.Info
 	RelPath    string
 	IsEntity   bool
 	IsRelation bool
@@ -72,9 +72,9 @@ func (a *App) handleConflicts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Header.Get("HX-Request") == "true" {
-		a.tmpl.ExecuteTemplate(w, "conflicts-content", data) //nolint:errcheck
+		a.tmpl.ExecuteTemplate(w, "conflicts-content", data) //nolint:errcheck // template errors handled by http response
 	} else {
-		a.tmpl.ExecuteTemplate(w, "conflicts-page", data) //nolint:errcheck
+		a.tmpl.ExecuteTemplate(w, "conflicts-page", data) //nolint:errcheck // template errors handled by http response
 	}
 }
 
@@ -118,9 +118,9 @@ func (a *App) handleConflictResolve(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Header.Get("HX-Request") == "true" {
-		a.tmpl.ExecuteTemplate(w, "conflict-resolve-content", data) //nolint:errcheck
+		a.tmpl.ExecuteTemplate(w, "conflict-resolve-content", data) //nolint:errcheck // template errors handled by http response
 	} else {
-		a.tmpl.ExecuteTemplate(w, "conflict-resolve-page", data) //nolint:errcheck
+		a.tmpl.ExecuteTemplate(w, "conflict-resolve-page", data) //nolint:errcheck // template errors handled by http response
 	}
 }
 
@@ -181,11 +181,12 @@ func (a *App) handleConflictApply(w http.ResponseWriter, r *http.Request) {
 
 		// Get content choice
 		contentChoice := r.FormValue("content")
-		if contentChoice == "theirs" {
+		switch contentChoice {
+		case "theirs":
 			resolution.ContentChoice = conflict.SideTheirs
-		} else if contentChoice == "manual" {
+		case "manual":
 			resolution.ManualContent = r.FormValue("manual_content")
-		} else {
+		default:
 			resolution.ContentChoice = conflict.SideOurs
 		}
 	default:

--- a/internal/dataentry/handlers_graph.go
+++ b/internal/dataentry/handlers_graph.go
@@ -11,9 +11,10 @@ import (
 // handleGraph serves the full-page graph visualization.
 func (a *App) handleGraph(w http.ResponseWriter, _ *http.Request) {
 	data := map[string]interface{}{
-		"App":        a.Cfg.App,
-		"Navigation": a.navElements("_graph"),
-		"ActiveList": "_graph",
+		"App":           a.Cfg.App,
+		"ConflictCount": a.conflictCount(),
+		"Navigation":    a.navElements("_graph"),
+		"ActiveList":    "_graph",
 	}
 	a.tmpl.ExecuteTemplate(w, "graph-page", data) //nolint:errcheck // template errors logged by http
 }

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -47,6 +47,9 @@ func (a *App) NewRouter() http.Handler {
 	inner.HandleFunc("/api/open-url", a.handleOpenURL)
 	inner.HandleFunc("/settings", a.handleSettings)
 	inner.HandleFunc("/api/settings", a.handleSaveSettings)
+	inner.HandleFunc("/conflicts", a.handleConflicts)
+	inner.HandleFunc("/conflicts/", a.handleConflicts)
+	inner.HandleFunc("/api/conflict-resolve", a.handleConflictApply)
 
 	locked := a.reloadLockMiddleware(inner)
 	mux.Handle("/", locked)

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -181,6 +181,15 @@ tbody tr:last-child td { border-bottom: none; }
 .toast-error { background: #991b1b; }
 @keyframes toastIn { from { opacity: 0; transform: translateY(-8px); } to { opacity: 1; transform: translateY(0); } }
 
+.conflict-banner { position: fixed; top: 0; left: 240px; right: 0; z-index: 90; background: linear-gradient(90deg, #fef3c7, #fde68a); border-bottom: 1px solid #fcd34d; padding: 8px 20px; display: flex; align-items: center; justify-content: space-between; font-size: 14px; color: #92400e; }
+.conflict-banner-icon { font-size: 16px; margin-right: 8px; }
+.conflict-banner a { color: #92400e; font-weight: 600; text-decoration: underline; }
+.conflict-banner a:hover { color: #78350f; }
+.conflict-banner-close { background: none; border: none; font-size: 18px; cursor: pointer; color: #92400e; opacity: 0.7; padding: 4px 8px; }
+.conflict-banner-close:hover { opacity: 1; }
+.has-conflict-banner .main { padding-top: 56px; }
+.has-conflict-banner .page-header { top: 44px; }
+
 .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 200; display: flex; align-items: center; justify-content: center; animation: fadeIn 0.15s; }
 .modal { background: var(--bg-card); border-radius: 12px; box-shadow: 0 8px 32px rgba(0,0,0,0.2); width: 480px; max-width: 90vw; max-height: 80vh; overflow-y: auto; }
 .modal-header { padding: 16px 20px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; }
@@ -400,6 +409,93 @@ tbody tr.row-selected { background: #dbeafe; outline: 2px solid var(--primary); 
   .side-panel-overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.3); z-index: 199; }
   .side-panel-overlay.open { display: block; }
 }
+
+/* Settings page */
+.settings-row { display: flex; align-items: center; gap: 8px; padding: 8px 0; border-bottom: 1px solid var(--border); }
+.settings-row:first-child { border-top: 1px solid var(--border); }
+.settings-row-label { font-size: 13px; font-weight: 500; font-family: var(--font-mono); color: var(--text); min-width: 140px; flex-shrink: 0; }
+.settings-row-value { flex: 1; }
+.settings-row-value select, .settings-row-value input { width: 100%; padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; font-size: 13px; font-family: var(--font); background: var(--bg-card); color: var(--text); }
+.settings-row-value select:focus, .settings-row-value input:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-light); }
+.settings-row-remove { background: none; border: none; cursor: pointer; color: var(--text-muted); font-size: 18px; padding: 4px; border-radius: 4px; transition: all 0.15s; line-height: 1; flex-shrink: 0; }
+.settings-row-remove:hover { color: var(--danger); background: #fef2f2; }
+.override-group { border: 1px solid var(--border); border-radius: var(--radius); padding: 20px; margin-top: 12px; background: var(--bg); }
+.override-header { display: flex; align-items: start; gap: 12px; }
+.settings-stale-badge { display: inline-block; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; padding: 2px 6px; border-radius: 4px; background: #fef3c7; color: #92400e; border: 1px solid #fcd34d; margin-left: 6px; flex-shrink: 0; white-space: nowrap; }
+.stale-option { color: #92400e; font-style: italic; }
+
+/* Conflicts list page */
+.conflict-summary { margin-bottom: 16px; }
+.conflict-chip { display: inline-flex; align-items: center; gap: 6px; padding: 8px 16px; border-radius: 8px; font-size: 14px; font-weight: 600; }
+.conflict-chip-warning { background: #fef3c7; color: #92400e; border: 1px solid #fcd34d; }
+.conflict-path { font-family: var(--font-mono); font-size: 13px; }
+.conflict-path-link { display: block; text-decoration: none; color: inherit; }
+.conflict-path-link:hover .conflict-path { color: var(--primary); text-decoration: underline; }
+.conflict-id { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+.conflict-empty { text-align: center; padding: 60px 20px; }
+.conflict-empty-icon { font-size: 48px; color: #22c55e; margin-bottom: 16px; }
+.conflict-empty h3 { font-size: 18px; color: var(--text); margin-bottom: 8px; }
+.conflict-empty p { color: var(--text-muted); }
+
+/* Conflict resolution page */
+.resolve-actions-top { display: flex; gap: 12px; margin-bottom: 16px; }
+.resolve-actions-bottom { display: flex; gap: 12px; margin-top: 16px; justify-content: flex-end; }
+.resolve-card { padding: 20px; margin-bottom: 16px; }
+.resolve-card h3 { font-size: 14px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); margin-bottom: 16px; }
+.resolve-table { width: 100%; }
+.resolve-table th { text-align: left; padding: 8px 12px; font-size: 12px; font-weight: 600; color: var(--text-muted); border-bottom: 2px solid var(--border); }
+.resolve-table td { padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+.resolve-prop-name { font-family: var(--font-mono); font-size: 13px; font-weight: 500; }
+.resolve-value { font-size: 13px; max-width: 200px; overflow: hidden; text-overflow: ellipsis; }
+.resolve-value em { color: var(--text-muted); }
+.resolve-choice { white-space: nowrap; }
+.resolve-choice label { display: inline-flex; align-items: center; gap: 4px; margin-right: 12px; font-size: 13px; cursor: pointer; }
+.resolve-same { background: #f0fdf4; }
+.resolve-same-label { font-size: 11px; color: #15803d; font-weight: 500; }
+.resolve-radio-hidden { position: absolute; opacity: 0; pointer-events: none; }
+.resolve-value-selectable { cursor: pointer; transition: all 0.15s ease; position: relative; border-left: 3px solid transparent; }
+.resolve-value-selectable:hover { background: #eff6ff; }
+.resolve-value-selected { background: #eff6ff; border-left-color: #3b82f6; }
+.resolve-value-unselected { color: var(--text-muted); opacity: 0.6; }
+.resolve-value-unselected:hover { opacity: 1; }
+.resolve-value-same { text-align: center; color: var(--text-muted); }
+.resolve-row-focused td { outline: 2px solid #3b82f6; outline-offset: -2px; }
+.resolve-row-focused td:first-child { border-radius: 4px 0 0 4px; }
+.resolve-row-focused td:last-child { border-radius: 0 4px 4px 0; }
+.resolve-content-choice { display: flex; gap: 20px; margin-bottom: 16px; }
+.resolve-content-choice label { display: flex; align-items: center; gap: 6px; font-size: 14px; cursor: pointer; }
+.resolve-content-compare { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.resolve-content-side { border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
+.resolve-content-label { background: var(--bg); padding: 8px 12px; font-size: 12px; font-weight: 600; color: var(--text-muted); border-bottom: 1px solid var(--border); }
+.resolve-content-pre { padding: 12px; margin: 0; font-size: 12px; font-family: var(--font-mono); white-space: pre-wrap; word-break: break-word; max-height: 300px; overflow-y: auto; background: var(--bg-card); }
+.resolve-manual-edit { margin-top: 16px; }
+.resolve-manual-edit label { display: block; font-size: 12px; font-weight: 600; color: var(--text-muted); margin-bottom: 8px; }
+.resolve-manual-edit textarea { width: 100%; padding: 12px; border: 1px solid var(--border); border-radius: 6px; font-size: 13px; font-family: var(--font-mono); resize: vertical; }
+
+/* Diff highlighting */
+.diff-line { display: block; padding: 1px 4px; margin: 0 -4px; border-radius: 2px; }
+.diff-line-add { background: #f0fdf4; }
+.diff-line-remove { background: #fef2f2; }
+.diff-line-change { background: transparent; }
+.diff-word-add { background: #bbf7d0; border-radius: 2px; padding: 0 2px; }
+.diff-word-remove { background: #fecaca; border-radius: 2px; padding: 0 2px; }
+
+/* Dark mode: Conflict resolution */
+[data-theme="dark"] .conflict-banner { background: linear-gradient(90deg, rgba(251,191,36,0.15), rgba(251,191,36,0.1)); border-bottom-color: #92400e; color: #fcd34d; }
+[data-theme="dark"] .conflict-banner a { color: #fcd34d; }
+[data-theme="dark"] .conflict-banner a:hover { color: #fef3c7; }
+[data-theme="dark"] .conflict-banner-close { color: #fcd34d; }
+[data-theme="dark"] .conflict-chip-warning { background: rgba(251,191,36,0.15); color: #fcd34d; border-color: #92400e; }
+[data-theme="dark"] .conflict-empty-icon { color: #4ade80; }
+[data-theme="dark"] .resolve-same { background: rgba(34,197,94,0.1); }
+[data-theme="dark"] .resolve-same-label { color: #4ade80; }
+[data-theme="dark"] .resolve-value-selectable:hover { background: rgba(59,130,246,0.15); }
+[data-theme="dark"] .resolve-value-selected { background: rgba(59,130,246,0.2); border-left-color: #60a5fa; }
+[data-theme="dark"] .resolve-row-focused td { outline-color: #60a5fa; }
+[data-theme="dark"] .diff-line-add { background: rgba(34,197,94,0.15); }
+[data-theme="dark"] .diff-line-remove { background: rgba(239,68,68,0.15); }
+[data-theme="dark"] .diff-word-add { background: rgba(34,197,94,0.3); }
+[data-theme="dark"] .diff-word-remove { background: rgba(239,68,68,0.3); }
 
 </style>
 <script>
@@ -1506,8 +1602,10 @@ document.addEventListener('click', function(e) {
       }
       if ((e.key === 'Enter' || e.key === 'o') && _selectedRow >= 0) {
         var rows = getListRows();
-        var link = rows[_selectedRow] && rows[_selectedRow].querySelector('.cell-link');
-        if (link) link.click();
+        var row = rows[_selectedRow];
+        // Click first link in row (primary action)
+        var link = row && (row.querySelector('.cell-link') || row.querySelector('a[href]'));
+        if (link) { link.click(); return; }
         return;
       }
       if (e.key === 'e' && _selectedRow >= 0) {
@@ -1552,6 +1650,46 @@ document.addEventListener('click', function(e) {
     }
   });
 })();
+
+// Shared EasyMDE factory - creates editor with consistent config
+function createRelaEditor(element, options) {
+  options = options || {};
+  var toolbar = ['bold', 'italic', 'heading', '|', 'unordered-list', 'ordered-list', {
+    name: 'checklist',
+    action: function(editor) {
+      var cm = editor.codemirror;
+      var sel = cm.getSelection();
+      if (sel) {
+        cm.replaceSelection(sel.split('\n').map(function(l) { return '- [ ] ' + l; }).join('\n'));
+      } else {
+        cm.replaceSelection('- [ ] ');
+      }
+      cm.focus();
+    },
+    className: 'fa fa-check-square-o',
+    title: 'Checklist (Ctrl+Shift+L)',
+  }, '|', 'link', 'image', '|', 'preview', 'side-by-side'];
+
+  // Add fullscreen toggle if callback provided
+  if (options.fullscreenToggle) {
+    toolbar.push('|', {
+      name: 'toggle-fullscreen-editor',
+      action: options.fullscreenToggle,
+      className: 'fa fa-arrows-alt',
+      title: 'Toggle Full Screen Editor',
+    });
+  }
+  toolbar.push('|', 'guide');
+
+  return new EasyMDE({
+    element: element,
+    spellChecker: false,
+    status: false,
+    minHeight: options.minHeight || '200px',
+    toolbar: toolbar,
+    sideBySideFullscreen: false,
+  });
+}
 </script>
 {{- end -}}
 
@@ -1571,6 +1709,20 @@ document.addEventListener('click', function(e) {
        hx-get="/list/{{ .List }}" hx-target="#content" hx-push-url="true">
       {{ .Label }}<span class="nav-count">{{ .Count }}</span>
     </a>
+{{ end }}
+{{- end -}}
+
+{{- define "conflict-bar" -}}
+{{ if and .ConflictCount (gt .ConflictCount 0) }}
+<div class="conflict-banner" id="conflict-banner">
+  <div>
+    <span class="conflict-banner-icon">⚠️</span>
+    <strong>{{ .ConflictCount }} file{{ if gt .ConflictCount 1 }}s{{ end }} with merge conflicts</strong> —
+    <a href="/conflicts" hx-get="/conflicts" hx-target="#content" hx-push-url="true">Resolve now</a>
+  </div>
+  <button class="conflict-banner-close" onclick="this.parentElement.remove();document.body.classList.remove('has-conflict-banner');" title="Dismiss">×</button>
+</div>
+<script>document.body.classList.add('has-conflict-banner');</script>
 {{ end }}
 {{- end -}}
 
@@ -1703,6 +1855,7 @@ document.body.addEventListener('htmx:pushedIntoHistory', function() {
 </head>
 <body>
 {{ template "sidebar" . }}
+{{ template "conflict-bar" . }}
 <main class="main" id="content">
 {{ template "list-content" . }}
 </main>
@@ -1827,6 +1980,7 @@ document.body.addEventListener('htmx:pushedIntoHistory', function() {
 </head>
 <body>
 {{ template "sidebar" . }}
+{{ template "conflict-bar" . }}
 <main class="main{{ if .SidePanelSections }} main-with-panel{{ end }}" id="content">
 {{ template "form-content" . }}
 </main>
@@ -2172,32 +2326,8 @@ var _editorInstance = null;
 (function() {
   var el = document.getElementById('body-editor');
   if (el) {
-    _editorInstance = new EasyMDE({
-      element: el,
-      spellChecker: false,
-      status: false,
-      minHeight: '200px',
-      toolbar: ['bold', 'italic', 'heading', '|', 'unordered-list', 'ordered-list', {
-        name: 'checklist',
-        action: function(editor) {
-          var cm = editor.codemirror;
-          var sel = cm.getSelection();
-          if (sel) {
-            cm.replaceSelection(sel.split('\n').map(function(l) { return '- [ ] ' + l; }).join('\n'));
-          } else {
-            cm.replaceSelection('- [ ] ');
-          }
-          cm.focus();
-        },
-        className: 'fa fa-check-square-o',
-        title: 'Checklist (Ctrl+Shift+L)',
-      }, '|', 'link', 'image', '|', 'preview', 'side-by-side', '|', {
-        name: 'toggle-fullscreen-editor',
-        action: toggleFullscreenEditor,
-        className: 'fa fa-arrows-alt',
-        title: 'Toggle Full Screen Editor',
-      }, '|', 'guide'],
-      sideBySideFullscreen: false,
+    _editorInstance = createRelaEditor(el, {
+      fullscreenToggle: toggleFullscreenEditor
     });
   }
 })();
@@ -2362,6 +2492,7 @@ function closeSidePanel() {
 </head>
 <body>
 {{ template "sidebar" . }}
+{{ template "conflict-bar" . }}
 <main class="main" id="content">
 {{ template "entity-content" . }}
 </main>
@@ -2472,6 +2603,7 @@ function closeSidePanel() {
 </head>
 <body>
 {{ template "sidebar" . }}
+{{ template "conflict-bar" . }}
 <main class="main" id="content">
 {{ template "view-content" . }}
 </main>
@@ -2894,6 +3026,7 @@ function closeSidePanel() {
 </head>
 <body>
 {{ template "sidebar" . }}
+{{ template "conflict-bar" . }}
 <main class="main" id="content">
 {{ template "search-content" . }}
 </main>
@@ -3281,6 +3414,7 @@ function closeSidePanel() {
 </head>
 <body>
 {{ template "sidebar" . }}
+{{ template "conflict-bar" . }}
 <main class="main" id="content">
 {{ template "dashboard-content" . }}
 </main>
@@ -3436,6 +3570,7 @@ function closeSidePanel() {
 </head>
 <body>
 {{ template "sidebar" . }}
+{{ template "conflict-bar" . }}
 <main class="main" id="content">
 {{ template "analyze-content" . }}
 </main>
@@ -3531,10 +3666,10 @@ function closeSidePanel() {
 <head>
 <title>{{ .App.Name }} - Settings</title>
 {{ template "head" . }}
-{{ template "settings-head" . }}
 </head>
 <body>
 {{ template "sidebar" . }}
+{{ template "conflict-bar" . }}
 <main class="main" id="content">
 {{ template "settings-content" . }}
 </main>
@@ -3933,4 +4068,439 @@ function addOverrideGroup() {
 .stale-option { color: #92400e; font-style: italic; }
 </style>
 {{- end -}}
+
+{{- define "conflicts-page" -}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>{{ .App.Name }} - Conflicts</title>
+{{ template "head" . }}
+</head>
+<body>
+{{ template "sidebar" . }}
+{{ template "conflict-bar" . }}
+<main class="main" id="content">
+{{ template "conflicts-content" . }}
+</main>
+<div id="command-toast-container"></div>
+</body>
+</html>
+{{- end -}}
+
+{{- define "conflicts-content" -}}
+<div class="page-header">
+  <div>
+    <h2>Merge Conflicts</h2>
+    <p>Files with unresolved git conflicts</p>
+  </div>
+</div>
+
+{{ if .HasConflicts }}
+<div class="conflict-summary">
+  <span class="conflict-chip conflict-chip-warning">⚠ {{ len .Conflicts }} file{{ if gt (len .Conflicts) 1 }}s{{ end }} with conflicts</span>
+</div>
+
+<div class="card" style="margin-top: 16px;">
+  <table>
+    <thead>
+      <tr>
+        <th>File</th>
+        <th>Type</th>
+        <th>Conflicts</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{ range .Conflicts }}
+      <tr>
+        <td>
+          <a href="/conflicts/{{ .RelPath }}" class="conflict-path-link"
+             hx-get="/conflicts/{{ .RelPath }}" hx-target="#content" hx-push-url="true">
+            <div class="conflict-path">{{ .RelPath }}</div>
+            {{ if .EntityID }}<div class="conflict-id">{{ .EntityID }}</div>{{ end }}
+          </a>
+        </td>
+        <td>{{ if .EntityType }}<span class="badge badge-gray">{{ .EntityType }}</span>{{ else }}<span class="badge badge-purple">relation</span>{{ end }}</td>
+        <td><span class="badge badge-orange">{{ .MarkerCount }}</span></td>
+      </tr>
+      {{ end }}
+    </tbody>
+  </table>
+</div>
+{{ else }}
+<div class="conflict-empty">
+  <div class="conflict-empty-icon">✓</div>
+  <h3>No conflicts detected</h3>
+  <p>All entity and relation files are clean.</p>
+</div>
+{{ end }}
+{{- end -}}
+
+
+{{- define "conflict-resolve-page" -}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>{{ .App.Name }} - Resolve Conflict</title>
+{{ template "head" . }}
+</head>
+<body>
+{{ template "sidebar" . }}
+{{ template "conflict-bar" . }}
+<main class="main" id="content">
+{{ template "conflict-resolve-content" . }}
+</main>
+<div id="command-toast-container"></div>
+</body>
+</html>
+{{- end -}}
+
+{{- define "conflict-resolve-content" -}}
+<div class="page-header">
+  <div>
+    <h2>Resolve Conflict</h2>
+    <p>{{ .Resolution.RelPath }}</p>
+  </div>
+  <a href="/conflicts" class="btn btn-secondary" hx-get="/conflicts" hx-target="#content" hx-push-url="true">← Back to Conflicts</a>
+</div>
+
+<form method="POST" action="/api/conflict-resolve" id="resolve-form">
+  <input type="hidden" name="path" value="{{ .Resolution.RelPath }}">
+
+  <div class="resolve-actions-top">
+    <button type="button" class="btn btn-secondary" onclick="selectAllSide('ours')">Select All Ours <kbd>O</kbd></button>
+    <button type="button" class="btn btn-secondary" onclick="selectAllSide('theirs')">Select All Theirs <kbd>T</kbd></button>
+  </div>
+
+  <div class="card resolve-card">
+    <h3>Properties</h3>
+    <table class="resolve-table">
+      <thead>
+        <tr>
+          <th>Property</th>
+          <th>Ours (HEAD)</th>
+          <th>Theirs</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range .Resolution.Info.PropertyDiffs }}
+        <tr class="{{ if .IsSame }}resolve-same{{ else }}resolve-diff{{ end }}" data-prop="{{ .Property }}">
+          <td class="resolve-prop-name">{{ .Property }}</td>
+          {{ if .IsSame }}
+          <td class="resolve-value resolve-value-same" colspan="2">{{ if .OursValue }}{{ .OursValue }}{{ else }}<em>empty</em>{{ end }}</td>
+          <input type="hidden" name="prop_{{ .Property }}" value="ours">
+          {{ else }}
+          <td class="resolve-value resolve-value-selectable resolve-value-selected" data-side="ours" data-prop="{{ .Property }}">
+            <input type="radio" name="prop_{{ .Property }}" value="ours" checked class="resolve-radio-hidden">
+            <span class="resolve-value-text">{{ if .OursValue }}{{ .OursValue }}{{ else }}<em>empty</em>{{ end }}</span>
+          </td>
+          <td class="resolve-value resolve-value-selectable resolve-value-unselected" data-side="theirs" data-prop="{{ .Property }}">
+            <input type="radio" name="prop_{{ .Property }}" value="theirs" class="resolve-radio-hidden">
+            <span class="resolve-value-text">{{ if .TheirsValue }}{{ .TheirsValue }}{{ else }}<em>empty</em>{{ end }}</span>
+          </td>
+          {{ end }}
+        </tr>
+        {{ end }}
+      </tbody>
+    </table>
+  </div>
+
+  {{ if not .Resolution.Info.ContentSame }}
+  <div class="card resolve-card">
+    <h3>Content</h3>
+    <div class="resolve-content-choice">
+      <label><input type="radio" name="content" value="ours" checked> Use Ours</label>
+      <label><input type="radio" name="content" value="theirs"> Use Theirs</label>
+      <label><input type="radio" name="content" value="manual" id="content-manual-radio"> Edit Manually</label>
+    </div>
+    <div class="resolve-content-compare">
+      <div class="resolve-content-side">
+        <div class="resolve-content-label">Ours (HEAD)</div>
+        <pre class="resolve-content-pre" id="diff-ours">{{ .Resolution.Info.ContentDiffOurs }}</pre>
+      </div>
+      <div class="resolve-content-side">
+        <div class="resolve-content-label">Theirs</div>
+        <pre class="resolve-content-pre" id="diff-theirs">{{ .Resolution.Info.ContentDiffTheirs }}</pre>
+      </div>
+    </div>
+    <div class="resolve-manual-edit" id="manual-edit-container" style="display:none;">
+      <label>Manual Content</label>
+      <textarea name="manual_content" id="manual-content-editor" rows="10">{{ .Resolution.Info.ContentDiffOurs }}</textarea>
+    </div>
+  </div>
+  {{ else }}
+  <input type="hidden" name="content" value="ours">
+  {{ end }}
+
+  <div class="resolve-actions-bottom">
+    <button type="submit" name="action" value="custom" class="btn btn-primary">Apply Resolution <kbd>&#8984;&#8629;</kbd></button>
+  </div>
+</form>
+
+<script>
+(function() {
+  var manualRadio = document.getElementById('content-manual-radio');
+  var container = document.getElementById('manual-edit-container');
+  var editorEl = document.getElementById('manual-content-editor');
+  var editorInstance = null;
+
+  function showManualEdit() {
+    container.style.display = 'block';
+    if (!editorInstance && editorEl) {
+      editorInstance = createRelaEditor(editorEl, { minHeight: '250px' });
+    }
+    if (editorInstance) {
+      setTimeout(function() { editorInstance.codemirror.refresh(); }, 10);
+    }
+  }
+
+  function hideManualEdit() {
+    container.style.display = 'none';
+  }
+
+  if (manualRadio) {
+    manualRadio.addEventListener('change', function() {
+      if (this.checked) showManualEdit();
+    });
+  }
+
+  document.querySelectorAll('input[name="content"]').forEach(function(radio) {
+    radio.addEventListener('change', function() {
+      if (manualRadio && manualRadio.checked) {
+        showManualEdit();
+      } else {
+        hideManualEdit();
+      }
+    });
+  });
+
+  // Diff highlighting
+  function escapeHtml(text) {
+    var div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  function computeLineDiff(oursLines, theirsLines) {
+    // Simple LCS-based diff
+    var m = oursLines.length, n = theirsLines.length;
+    var dp = [];
+    for (var i = 0; i <= m; i++) {
+      dp[i] = [];
+      for (var j = 0; j <= n; j++) {
+        if (i === 0 || j === 0) dp[i][j] = 0;
+        else if (oursLines[i-1] === theirsLines[j-1]) dp[i][j] = dp[i-1][j-1] + 1;
+        else dp[i][j] = Math.max(dp[i-1][j], dp[i][j-1]);
+      }
+    }
+    // Backtrack to find diff
+    var oursResult = [], theirsResult = [];
+    var i = m, j = n;
+    while (i > 0 || j > 0) {
+      if (i > 0 && j > 0 && oursLines[i-1] === theirsLines[j-1]) {
+        oursResult.unshift({ text: oursLines[i-1], type: 'same' });
+        theirsResult.unshift({ text: theirsLines[j-1], type: 'same' });
+        i--; j--;
+      } else if (j > 0 && (i === 0 || dp[i][j-1] >= dp[i-1][j])) {
+        theirsResult.unshift({ text: theirsLines[j-1], type: 'add' });
+        j--;
+      } else {
+        oursResult.unshift({ text: oursLines[i-1], type: 'remove' });
+        i--;
+      }
+    }
+    return { ours: oursResult, theirs: theirsResult };
+  }
+
+  function highlightWordDiff(line1, line2, addClass, removeClass) {
+    var words1 = line1.split(/(\s+)/), words2 = line2.split(/(\s+)/);
+    var result1 = '', result2 = '';
+    var i = 0, j = 0;
+    while (i < words1.length || j < words2.length) {
+      if (i < words1.length && j < words2.length && words1[i] === words2[j]) {
+        result1 += escapeHtml(words1[i]);
+        result2 += escapeHtml(words2[j]);
+        i++; j++;
+      } else if (j < words2.length && (i >= words1.length || words1.indexOf(words2[j], i) === -1)) {
+        result2 += '<span class="' + addClass + '">' + escapeHtml(words2[j]) + '</span>';
+        j++;
+      } else {
+        result1 += '<span class="' + removeClass + '">' + escapeHtml(words1[i]) + '</span>';
+        i++;
+      }
+    }
+    return { line1: result1, line2: result2 };
+  }
+
+  function renderDiff() {
+    var oursEl = document.getElementById('diff-ours');
+    var theirsEl = document.getElementById('diff-theirs');
+    if (!oursEl || !theirsEl) return;
+
+    var oursText = oursEl.textContent;
+    var theirsText = theirsEl.textContent;
+    var oursLines = oursText.split('\n');
+    var theirsLines = theirsText.split('\n');
+
+    var diff = computeLineDiff(oursLines, theirsLines);
+
+    var oursHtml = '', theirsHtml = '';
+    var oi = 0, ti = 0;
+    while (oi < diff.ours.length || ti < diff.theirs.length) {
+      var oLine = diff.ours[oi], tLine = diff.theirs[ti];
+      if (oLine && tLine && oLine.type === 'same' && tLine.type === 'same') {
+        oursHtml += '<span class="diff-line">' + escapeHtml(oLine.text) + '</span>\n';
+        theirsHtml += '<span class="diff-line">' + escapeHtml(tLine.text) + '</span>\n';
+        oi++; ti++;
+      } else if (oLine && oLine.type === 'remove' && tLine && tLine.type === 'add') {
+        // Changed line - highlight word differences
+        var wordDiff = highlightWordDiff(oLine.text, tLine.text, 'diff-word-add', 'diff-word-remove');
+        oursHtml += '<span class="diff-line diff-line-change">' + wordDiff.line1 + '</span>\n';
+        theirsHtml += '<span class="diff-line diff-line-change">' + wordDiff.line2 + '</span>\n';
+        oi++; ti++;
+      } else if (oLine && oLine.type === 'remove') {
+        oursHtml += '<span class="diff-line diff-line-remove">' + escapeHtml(oLine.text) + '</span>\n';
+        oi++;
+      } else if (tLine && tLine.type === 'add') {
+        theirsHtml += '<span class="diff-line diff-line-add">' + escapeHtml(tLine.text) + '</span>\n';
+        ti++;
+      } else {
+        oi++; ti++;
+      }
+    }
+
+    oursEl.innerHTML = oursHtml.replace(/\n$/, '');
+    theirsEl.innerHTML = theirsHtml.replace(/\n$/, '');
+  }
+
+  renderDiff();
+
+  // Select all properties and content to one side
+  window.selectAllSide = function(side) {
+    // Select all property values
+    document.querySelectorAll('.resolve-value-selectable[data-side="' + side + '"]').forEach(function(cell) {
+      cell.click();
+    });
+    // Select content radio
+    var contentRadio = document.querySelector('input[name="content"][value="' + side + '"]');
+    if (contentRadio) contentRadio.click();
+  };
+
+  // Click-to-select property values
+  document.querySelectorAll('.resolve-value-selectable').forEach(function(cell) {
+    cell.addEventListener('click', function() {
+      var prop = this.getAttribute('data-prop');
+      var side = this.getAttribute('data-side');
+      var row = this.closest('tr');
+
+      // Check the radio button
+      var radio = this.querySelector('input[type="radio"]');
+      if (radio) radio.checked = true;
+
+      // Update visual states
+      row.querySelectorAll('.resolve-value-selectable').forEach(function(c) {
+        if (c.getAttribute('data-side') === side) {
+          c.classList.add('resolve-value-selected');
+          c.classList.remove('resolve-value-unselected');
+        } else {
+          c.classList.remove('resolve-value-selected');
+          c.classList.add('resolve-value-unselected');
+        }
+      });
+    });
+  });
+
+  // Keyboard navigation for conflict resolution
+  (function() {
+    var rows = Array.from(document.querySelectorAll('.resolve-table tbody tr'));
+    var focusedIndex = -1;
+
+    function setFocusedRow(index) {
+      rows.forEach(function(r) { r.classList.remove('resolve-row-focused'); });
+      if (index >= 0 && index < rows.length) {
+        focusedIndex = index;
+        rows[index].classList.add('resolve-row-focused');
+        rows[index].scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      }
+    }
+
+    function selectSide(side) {
+      if (focusedIndex < 0 || focusedIndex >= rows.length) return;
+      var row = rows[focusedIndex];
+      var cell = row.querySelector('.resolve-value-selectable[data-side="' + side + '"]');
+      if (cell) cell.click();
+    }
+
+    document.addEventListener('keydown', function(e) {
+      // Skip if typing in an input/textarea
+      var tag = e.target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      if (e.target.isContentEditable) return;
+
+      // Only handle if we're on the conflict resolution page
+      var table = document.querySelector('.resolve-table');
+      if (!table) return;
+
+      switch(e.key) {
+        case 'ArrowDown':
+        case 'j':
+          e.preventDefault();
+          if (focusedIndex < 0) {
+            // First press: focus first differing row
+            for (var i = 0; i < rows.length; i++) {
+              if (rows[i].querySelector('.resolve-value-selectable')) {
+                setFocusedRow(i);
+                break;
+              }
+            }
+          } else {
+            setFocusedRow(Math.min(focusedIndex + 1, rows.length - 1));
+          }
+          break;
+        case 'ArrowUp':
+        case 'k':
+          e.preventDefault();
+          if (focusedIndex < 0) {
+            // First press: focus last differing row
+            for (var i = rows.length - 1; i >= 0; i--) {
+              if (rows[i].querySelector('.resolve-value-selectable')) {
+                setFocusedRow(i);
+                break;
+              }
+            }
+          } else {
+            setFocusedRow(Math.max(focusedIndex - 1, 0));
+          }
+          break;
+        case 'ArrowLeft':
+        case 'h':
+        case '1':
+          e.preventDefault();
+          selectSide('ours');
+          break;
+        case 'ArrowRight':
+        case 'l':
+        case '2':
+          e.preventDefault();
+          selectSide('theirs');
+          break;
+        case 'Escape':
+          e.preventDefault();
+          var backLink = document.querySelector('a[href="/conflicts"]');
+          if (backLink) backLink.click();
+          break;
+        case 'O':
+          e.preventDefault();
+          selectAllSide('ours');
+          break;
+        case 'T':
+          e.preventDefault();
+          selectAllSide('theirs');
+          break;
+      }
+    });
+  })();
+})();
+</script>
+{{- end -}}
+
 `

--- a/internal/markdown/entity.go
+++ b/internal/markdown/entity.go
@@ -137,7 +137,9 @@ func (f *FileIO) LoadAllEntities(entitiesDir string, meta *metamodel.Metamodel) 
 }
 
 // LoadAllEntitiesWithConflicts loads all entities and tracks conflicted files.
-func (f *FileIO) LoadAllEntitiesWithConflicts(entitiesDir string, meta *metamodel.Metamodel) (*EntityLoadResult, error) {
+func (f *FileIO) LoadAllEntitiesWithConflicts(
+	entitiesDir string, meta *metamodel.Metamodel,
+) (*EntityLoadResult, error) {
 	files, err := f.ListEntityFiles(entitiesDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/markdown/entity.go
+++ b/internal/markdown/entity.go
@@ -1,6 +1,7 @@
 package markdown
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,6 +12,12 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
+
+// EntityLoadResult contains results from loading entities.
+type EntityLoadResult struct {
+	Entities   []*model.Entity
+	Conflicted []string // Paths of files with git conflicts
+}
 
 // ReadEntity reads an entity from a markdown file.
 func (f *FileIO) ReadEntity(path string, meta *metamodel.Metamodel) (*model.Entity, error) {
@@ -122,16 +129,25 @@ func (f *FileIO) ListEntityFiles(entitiesDir string) ([]string, error) {
 
 // LoadAllEntities loads all entities from the entities directory using parallel I/O.
 func (f *FileIO) LoadAllEntities(entitiesDir string, meta *metamodel.Metamodel) ([]*model.Entity, error) {
+	result, err := f.LoadAllEntitiesWithConflicts(entitiesDir, meta)
+	if err != nil {
+		return nil, err
+	}
+	return result.Entities, nil
+}
+
+// LoadAllEntitiesWithConflicts loads all entities and tracks conflicted files.
+func (f *FileIO) LoadAllEntitiesWithConflicts(entitiesDir string, meta *metamodel.Metamodel) (*EntityLoadResult, error) {
 	files, err := f.ListEntityFiles(entitiesDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return []*model.Entity{}, nil
+			return &EntityLoadResult{Entities: []*model.Entity{}}, nil
 		}
 		return nil, err
 	}
 
 	if len(files) == 0 {
-		return []*model.Entity{}, nil
+		return &EntityLoadResult{Entities: []*model.Entity{}}, nil
 	}
 
 	// Use worker pool for parallel file reading
@@ -140,9 +156,14 @@ func (f *FileIO) LoadAllEntities(entitiesDir string, meta *metamodel.Metamodel) 
 		numWorkers = len(files)
 	}
 
+	type loadResult struct {
+		entity     *model.Entity
+		conflicted string // Non-empty if file has conflicts
+	}
+
 	// Channels for work distribution and result collection
 	fileChan := make(chan string, len(files))
-	resultChan := make(chan *model.Entity, len(files))
+	resultChan := make(chan loadResult, len(files))
 
 	// Start workers
 	var wg sync.WaitGroup
@@ -153,10 +174,13 @@ func (f *FileIO) LoadAllEntities(entitiesDir string, meta *metamodel.Metamodel) 
 			for file := range fileChan {
 				entity, readErr := f.ReadEntity(file, meta)
 				if readErr != nil {
-					// Skip files that can't be parsed
+					if errors.Is(readErr, ErrConflictedFile) {
+						resultChan <- loadResult{conflicted: file}
+					}
+					// Skip other files that can't be parsed
 					continue
 				}
-				resultChan <- entity
+				resultChan <- loadResult{entity: entity}
 			}
 		}()
 	}
@@ -174,12 +198,20 @@ func (f *FileIO) LoadAllEntities(entitiesDir string, meta *metamodel.Metamodel) 
 	}()
 
 	// Collect results
-	entities := make([]*model.Entity, 0, len(files))
-	for entity := range resultChan {
-		entities = append(entities, entity)
+	result := &EntityLoadResult{
+		Entities:   make([]*model.Entity, 0, len(files)),
+		Conflicted: make([]string, 0),
+	}
+	for lr := range resultChan {
+		if lr.entity != nil {
+			result.Entities = append(result.Entities, lr.entity)
+		}
+		if lr.conflicted != "" {
+			result.Conflicted = append(result.Conflicted, lr.conflicted)
+		}
 	}
 
-	return entities, nil
+	return result, nil
 }
 
 // EntityFileModTime returns the modification time of an entity file.

--- a/internal/markdown/entity_test.go
+++ b/internal/markdown/entity_test.go
@@ -1,6 +1,7 @@
 package markdown
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -530,7 +531,7 @@ Content here.
 	_, err := testIO.ReadEntity(entityPath, nil)
 	testutil.AssertError(t, err)
 
-	if err != ErrConflictedFile {
+	if !errors.Is(err, ErrConflictedFile) {
 		t.Errorf("expected ErrConflictedFile, got %v", err)
 	}
 }

--- a/internal/markdown/entity_test.go
+++ b/internal/markdown/entity_test.go
@@ -426,3 +426,111 @@ func TestEntityFileModTime_NonExistent(t *testing.T) {
 		t.Error("expected error for nonexistent file")
 	}
 }
+
+func TestLoadAllEntitiesWithConflicts(t *testing.T) {
+	tmpDir := t.TempDir()
+	entitiesDir := filepath.Join(tmpDir, "entities")
+	if err := os.MkdirAll(entitiesDir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	// Create a valid entity
+	validContent := `---
+id: REQ-001
+type: requirement
+title: Valid Entity
+---
+
+Valid content.
+`
+	if err := os.WriteFile(filepath.Join(entitiesDir, "REQ-001.md"), []byte(validContent), 0644); err != nil {
+		t.Fatalf("failed to create valid entity: %v", err)
+	}
+
+	// Create a conflicted entity
+	conflictedContent := `---
+id: REQ-002
+type: requirement
+<<<<<<< HEAD
+status: draft
+=======
+status: approved
+>>>>>>> feature-branch
+---
+
+Some content.
+`
+	conflictedPath := filepath.Join(entitiesDir, "REQ-002.md")
+	if err := os.WriteFile(conflictedPath, []byte(conflictedContent), 0644); err != nil {
+		t.Fatalf("failed to create conflicted entity: %v", err)
+	}
+
+	// Create another valid entity
+	valid2Content := `---
+id: REQ-003
+type: requirement
+title: Another Valid Entity
+---
+`
+	if err := os.WriteFile(filepath.Join(entitiesDir, "REQ-003.md"), []byte(valid2Content), 0644); err != nil {
+		t.Fatalf("failed to create valid entity: %v", err)
+	}
+
+	result, err := testIO.LoadAllEntitiesWithConflicts(entitiesDir, nil)
+	if err != nil {
+		t.Fatalf("LoadAllEntitiesWithConflicts failed: %v", err)
+	}
+
+	// Should load 2 valid entities
+	if len(result.Entities) != 2 {
+		t.Errorf("got %d entities, want 2", len(result.Entities))
+	}
+
+	// Should track 1 conflicted file
+	if len(result.Conflicted) != 1 {
+		t.Errorf("got %d conflicted files, want 1", len(result.Conflicted))
+	}
+
+	if len(result.Conflicted) > 0 && result.Conflicted[0] != conflictedPath {
+		t.Errorf("conflicted file = %q, want %q", result.Conflicted[0], conflictedPath)
+	}
+
+	// Verify the valid entities are loaded correctly
+	ids := make(map[string]bool)
+	for _, entity := range result.Entities {
+		ids[entity.ID] = true
+	}
+	if !ids["REQ-001"] || !ids["REQ-003"] {
+		t.Error("expected REQ-001 and REQ-003 to be loaded")
+	}
+	if ids["REQ-002"] {
+		t.Error("REQ-002 should not be loaded (conflicted)")
+	}
+}
+
+func TestReadEntity_ConflictedFile(t *testing.T) {
+	tmpDir := testutil.TempDirWithCleanup(t)
+
+	conflictedContent := `---
+id: REQ-001
+type: requirement
+<<<<<<< HEAD
+status: draft
+=======
+status: approved
+>>>>>>> feature-branch
+---
+
+Content here.
+`
+
+	entityPath := filepath.Join(tmpDir, "REQ-001.md")
+	testutil.CreateFile(t, entityPath, conflictedContent)
+
+	_, err := testIO.ReadEntity(entityPath, nil)
+	testutil.AssertError(t, err)
+
+	if err != ErrConflictedFile {
+		t.Errorf("expected ErrConflictedFile, got %v", err)
+	}
+}

--- a/internal/markdown/parser.go
+++ b/internal/markdown/parser.go
@@ -2,13 +2,25 @@ package markdown
 
 import (
 	"bufio"
+	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
+// ErrConflictedFile is returned when a file has unresolved git conflict markers.
+var ErrConflictedFile = errors.New("file has unresolved git conflicts")
+
 const frontmatterDelimiter = "---"
+
+// Git conflict markers
+var (
+	conflictMarkerStart = []byte("<<<<<<<")
+	conflictMarkerMid   = []byte("=======")
+	conflictMarkerEnd   = []byte(">>>>>>>")
+)
 
 // Document represents a parsed markdown document with YAML frontmatter
 type Document struct {
@@ -16,8 +28,23 @@ type Document struct {
 	Content     string
 }
 
-// ParseDocument parses a markdown document with YAML frontmatter
+// HasConflictMarkers checks if content contains git conflict markers.
+func HasConflictMarkers(content []byte) bool {
+	return bytes.Contains(content, conflictMarkerStart)
+}
+
+// HasConflictMarkersString checks if content contains git conflict markers.
+func HasConflictMarkersString(content string) bool {
+	return strings.Contains(content, string(conflictMarkerStart))
+}
+
+// ParseDocument parses a markdown document with YAML frontmatter.
+// Returns ErrConflictedFile if the content contains git conflict markers.
 func ParseDocument(content string) (*Document, error) {
+	if HasConflictMarkersString(content) {
+		return nil, ErrConflictedFile
+	}
+
 	frontmatter, body, err := splitFrontmatter(content)
 	if err != nil {
 		return nil, err

--- a/internal/markdown/parser.go
+++ b/internal/markdown/parser.go
@@ -15,12 +15,8 @@ var ErrConflictedFile = errors.New("file has unresolved git conflicts")
 
 const frontmatterDelimiter = "---"
 
-// Git conflict markers
-var (
-	conflictMarkerStart = []byte("<<<<<<<")
-	conflictMarkerMid   = []byte("=======")
-	conflictMarkerEnd   = []byte(">>>>>>>")
-)
+// Git conflict marker for detecting conflicts.
+var conflictMarkerStart = []byte("<<<<<<<")
 
 // Document represents a parsed markdown document with YAML frontmatter
 type Document struct {

--- a/internal/markdown/parser_test.go
+++ b/internal/markdown/parser_test.go
@@ -1,6 +1,7 @@
 package markdown
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -431,7 +432,7 @@ status: approved
 	_, err := ParseDocument(content)
 	testutil.AssertError(t, err)
 
-	if err != ErrConflictedFile {
+	if !errors.Is(err, ErrConflictedFile) {
 		t.Errorf("expected ErrConflictedFile, got %v", err)
 	}
 }
@@ -454,7 +455,7 @@ This is the incoming content.
 	_, err := ParseDocument(content)
 	testutil.AssertError(t, err)
 
-	if err != ErrConflictedFile {
+	if !errors.Is(err, ErrConflictedFile) {
 		t.Errorf("expected ErrConflictedFile, got %v", err)
 	}
 }

--- a/internal/markdown/parser_test.go
+++ b/internal/markdown/parser_test.go
@@ -355,6 +355,110 @@ id: REQ-001
 	testutil.AssertEqual(t, body, "")
 }
 
+func TestHasConflictMarkers(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name:     "no conflicts",
+			content:  "---\nid: REQ-001\n---\nContent",
+			expected: false,
+		},
+		{
+			name: "has conflicts in frontmatter",
+			content: `---
+id: REQ-001
+<<<<<<< HEAD
+status: draft
+=======
+status: approved
+>>>>>>> feature-branch
+---
+Content`,
+			expected: true,
+		},
+		{
+			name: "has conflicts in content",
+			content: `---
+id: REQ-001
+---
+<<<<<<< HEAD
+Some content
+=======
+Different content
+>>>>>>> feature-branch`,
+			expected: true,
+		},
+		{
+			name:     "partial marker only",
+			content:  "Some text with <<<<<< but not full marker",
+			expected: false,
+		},
+		{
+			name:     "full start marker",
+			content:  "Some text with <<<<<<< HEAD somewhere",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasConflictMarkersString(tt.content)
+			testutil.AssertEqual(t, got, tt.expected)
+
+			// Also test byte version
+			gotBytes := HasConflictMarkers([]byte(tt.content))
+			testutil.AssertEqual(t, gotBytes, tt.expected)
+		})
+	}
+}
+
+func TestParseDocument_ConflictedFile(t *testing.T) {
+	content := `---
+id: REQ-001
+<<<<<<< HEAD
+status: draft
+=======
+status: approved
+>>>>>>> feature-branch
+---
+
+# Description
+`
+
+	_, err := ParseDocument(content)
+	testutil.AssertError(t, err)
+
+	if err != ErrConflictedFile {
+		t.Errorf("expected ErrConflictedFile, got %v", err)
+	}
+}
+
+func TestParseDocument_ConflictedFileInContent(t *testing.T) {
+	content := `---
+id: REQ-001
+status: draft
+---
+
+# Description
+
+<<<<<<< HEAD
+This is the current content.
+=======
+This is the incoming content.
+>>>>>>> feature-branch
+`
+
+	_, err := ParseDocument(content)
+	testutil.AssertError(t, err)
+
+	if err != ErrConflictedFile {
+		t.Errorf("expected ErrConflictedFile, got %v", err)
+	}
+}
+
 func TestRoundTrip(t *testing.T) {
 	// Original content
 	original := `---

--- a/internal/markdown/relation.go
+++ b/internal/markdown/relation.go
@@ -1,6 +1,7 @@
 package markdown
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,12 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
+
+// RelationLoadResult contains results from loading relations.
+type RelationLoadResult struct {
+	Relations  []*model.Relation
+	Conflicted []string // Paths of files with git conflicts
+}
 
 // ReadRelation reads a relation from a markdown file.
 func (f *FileIO) ReadRelation(path string) (*model.Relation, error) {
@@ -103,13 +110,22 @@ func (f *FileIO) ListRelationFiles(relationsDir string) ([]string, error) {
 
 // LoadAllRelations loads all relations from the relations directory using parallel I/O.
 func (f *FileIO) LoadAllRelations(relationsDir string) ([]*model.Relation, error) {
+	result, err := f.LoadAllRelationsWithConflicts(relationsDir)
+	if err != nil {
+		return nil, err
+	}
+	return result.Relations, nil
+}
+
+// LoadAllRelationsWithConflicts loads all relations and tracks conflicted files.
+func (f *FileIO) LoadAllRelationsWithConflicts(relationsDir string) (*RelationLoadResult, error) {
 	files, err := f.ListRelationFiles(relationsDir)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(files) == 0 {
-		return []*model.Relation{}, nil
+		return &RelationLoadResult{Relations: []*model.Relation{}}, nil
 	}
 
 	// Use worker pool for parallel file reading
@@ -118,9 +134,14 @@ func (f *FileIO) LoadAllRelations(relationsDir string) ([]*model.Relation, error
 		numWorkers = len(files)
 	}
 
+	type loadResult struct {
+		relation   *model.Relation
+		conflicted string // Non-empty if file has conflicts
+	}
+
 	// Channels for work distribution and result collection
 	fileChan := make(chan string, len(files))
-	resultChan := make(chan *model.Relation, len(files))
+	resultChan := make(chan loadResult, len(files))
 
 	// Start workers
 	var wg sync.WaitGroup
@@ -131,10 +152,13 @@ func (f *FileIO) LoadAllRelations(relationsDir string) ([]*model.Relation, error
 			for file := range fileChan {
 				relation, readErr := f.ReadRelation(file)
 				if readErr != nil {
-					// Skip files that can't be parsed
+					if errors.Is(readErr, ErrConflictedFile) {
+						resultChan <- loadResult{conflicted: file}
+					}
+					// Skip other files that can't be parsed
 					continue
 				}
-				resultChan <- relation
+				resultChan <- loadResult{relation: relation}
 			}
 		}()
 	}
@@ -152,12 +176,20 @@ func (f *FileIO) LoadAllRelations(relationsDir string) ([]*model.Relation, error
 	}()
 
 	// Collect results
-	relations := make([]*model.Relation, 0, len(files))
-	for relation := range resultChan {
-		relations = append(relations, relation)
+	result := &RelationLoadResult{
+		Relations:  make([]*model.Relation, 0, len(files)),
+		Conflicted: make([]string, 0),
+	}
+	for lr := range resultChan {
+		if lr.relation != nil {
+			result.Relations = append(result.Relations, lr.relation)
+		}
+		if lr.conflicted != "" {
+			result.Conflicted = append(result.Conflicted, lr.conflicted)
+		}
 	}
 
-	return relations, nil
+	return result, nil
 }
 
 // RelationFilename generates a filename for a relation.

--- a/internal/markdown/sync.go
+++ b/internal/markdown/sync.go
@@ -8,6 +8,7 @@ import (
 )
 
 // SyncFromFiles rebuilds the graph from markdown files.
+// Files with git conflict markers are skipped and tracked in result.Conflicted.
 func (f *FileIO) SyncFromFiles(
 	ctx *project.Context, meta *metamodel.Metamodel, g *graph.Graph,
 ) (*model.SyncResult, error) {
@@ -16,24 +17,25 @@ func (f *FileIO) SyncFromFiles(
 	// Clear the graph
 	g.Clear()
 
-	// Load all entities
-	entities, err := f.LoadAllEntities(ctx.EntitiesDir, meta)
+	// Load all entities (with conflict tracking)
+	entityResult, err := f.LoadAllEntitiesWithConflicts(ctx.EntitiesDir, meta)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, entity := range entities {
+	for _, entity := range entityResult.Entities {
 		g.AddNode(entity)
 		result.EntitiesLoaded++
 	}
+	result.Conflicted = append(result.Conflicted, entityResult.Conflicted...)
 
-	// Load all relations
-	relations, err := f.LoadAllRelations(ctx.RelationsDir)
+	// Load all relations (with conflict tracking)
+	relationResult, err := f.LoadAllRelationsWithConflicts(ctx.RelationsDir)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, relation := range relations {
+	for _, relation := range relationResult.Relations {
 		// Validate that both ends exist
 		if _, ok := g.GetNode(relation.From); !ok {
 			result.Errors = append(result.Errors, &model.SyncError{
@@ -53,6 +55,7 @@ func (f *FileIO) SyncFromFiles(
 		g.AddEdge(relation)
 		result.RelationsLoaded++
 	}
+	result.Conflicted = append(result.Conflicted, relationResult.Conflicted...)
 
 	return result, nil
 }

--- a/internal/markdown/sync_test.go
+++ b/internal/markdown/sync_test.go
@@ -342,3 +342,125 @@ func TestSyncFromFiles_LoadEntitiesError(t *testing.T) {
 		t.Errorf("error = %q, want 'permission denied'", err.Error())
 	}
 }
+
+func TestSyncFromFiles_ConflictedFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := &project.Context{
+		Root:         tmpDir,
+		EntitiesDir:  filepath.Join(tmpDir, "entities"),
+		RelationsDir: filepath.Join(tmpDir, "relations"),
+	}
+
+	// Create entity directory
+	reqDir := filepath.Join(ctx.EntitiesDir, "requirement")
+	if err := os.MkdirAll(reqDir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	if err := os.MkdirAll(ctx.RelationsDir, 0755); err != nil {
+		t.Fatalf("failed to create relations dir: %v", err)
+	}
+
+	// Create a valid entity
+	validContent := `---
+id: REQ-001
+type: requirement
+title: Valid Entity
+---
+`
+	if err := os.WriteFile(filepath.Join(reqDir, "REQ-001.md"), []byte(validContent), 0644); err != nil {
+		t.Fatalf("failed to create valid entity: %v", err)
+	}
+
+	// Create a conflicted entity
+	conflictedContent := `---
+id: REQ-002
+type: requirement
+<<<<<<< HEAD
+status: draft
+=======
+status: approved
+>>>>>>> feature-branch
+---
+`
+	conflictedEntityPath := filepath.Join(reqDir, "REQ-002.md")
+	if err := os.WriteFile(conflictedEntityPath, []byte(conflictedContent), 0644); err != nil {
+		t.Fatalf("failed to create conflicted entity: %v", err)
+	}
+
+	// Create a valid relation
+	relationContent := `---
+from: REQ-001
+relation: depends-on
+to: REQ-001
+---
+`
+	if err := os.WriteFile(filepath.Join(ctx.RelationsDir, "REQ-001--depends-on--REQ-001.md"), []byte(relationContent), 0644); err != nil {
+		t.Fatalf("failed to create relation: %v", err)
+	}
+
+	// Create a conflicted relation
+	conflictedRelationContent := `---
+from: REQ-001
+relation: addresses
+<<<<<<< HEAD
+to: REQ-002
+=======
+to: REQ-003
+>>>>>>> feature-branch
+---
+`
+	conflictedRelationPath := filepath.Join(ctx.RelationsDir, "REQ-001--addresses--conflict.md")
+	if err := os.WriteFile(conflictedRelationPath, []byte(conflictedRelationContent), 0644); err != nil {
+		t.Fatalf("failed to create conflicted relation: %v", err)
+	}
+
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"requirement": {Label: "Requirement"},
+		},
+	}
+	g := graph.New()
+
+	result, err := testIO.SyncFromFiles(ctx, meta, g)
+	if err != nil {
+		t.Fatalf("SyncFromFiles failed: %v", err)
+	}
+
+	// Should load 1 valid entity
+	if result.EntitiesLoaded != 1 {
+		t.Errorf("EntitiesLoaded = %d, want 1", result.EntitiesLoaded)
+	}
+
+	// Should load 1 valid relation
+	if result.RelationsLoaded != 1 {
+		t.Errorf("RelationsLoaded = %d, want 1", result.RelationsLoaded)
+	}
+
+	// Should track 2 conflicted files (1 entity + 1 relation)
+	if len(result.Conflicted) != 2 {
+		t.Errorf("got %d conflicted files, want 2", len(result.Conflicted))
+	}
+
+	// Verify the conflicted files are tracked
+	conflictedMap := make(map[string]bool)
+	for _, path := range result.Conflicted {
+		conflictedMap[path] = true
+	}
+	if !conflictedMap[conflictedEntityPath] {
+		t.Errorf("missing conflicted entity: %s", conflictedEntityPath)
+	}
+	if !conflictedMap[conflictedRelationPath] {
+		t.Errorf("missing conflicted relation: %s", conflictedRelationPath)
+	}
+
+	// Verify the graph only contains valid entities
+	if g.NodeCount() != 1 {
+		t.Errorf("graph has %d nodes, want 1", g.NodeCount())
+	}
+	if _, ok := g.GetNode("REQ-001"); !ok {
+		t.Error("REQ-001 should exist in graph")
+	}
+	if _, ok := g.GetNode("REQ-002"); ok {
+		t.Error("REQ-002 should not exist in graph (conflicted)")
+	}
+}

--- a/internal/model/sync.go
+++ b/internal/model/sync.go
@@ -5,6 +5,7 @@ type SyncResult struct {
 	EntitiesLoaded  int
 	RelationsLoaded int
 	Errors          []error
+	Conflicted      []string // Files with unresolved git conflicts
 }
 
 // SyncError represents an error during sync.

--- a/tickets/entities/concepts/data-entry-server.md
+++ b/tickets/entities/concepts/data-entry-server.md
@@ -1,0 +1,6 @@
+---
+id: data-entry-server
+status: draft
+title: Data entry server
+type: concept
+---

--- a/tickets/entities/features/FEAT-001.md
+++ b/tickets/entities/features/FEAT-001.md
@@ -1,9 +1,6 @@
 ---
-description: Command-line interface for all rela operations
 id: FEAT-001
-priority: high
-status: implemented
-summary: Cobra-based CLI with commands for entity/relation management, analysis, and export
-title: CLI Interface
+status: proposed
+title: Git conflict resolution UI
 type: feature
 ---

--- a/tickets/relations/FEAT-001--requires--data-entry-server.md
+++ b/tickets/relations/FEAT-001--requires--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-001
+relation: requires
+to: data-entry-server
+---


### PR DESCRIPTION
## Summary

- Add conflict detection and resolution UI for entity/relation files with git merge conflicts
- Implement side-by-side comparison with property-level resolution choices
- Add skip-conflict sync mode for markdown parsing
- Include dark mode styles for conflict resolution screens

## Test plan

- [ ] Navigate to /conflicts when files have git conflict markers
- [ ] Verify conflict list shows files with marker counts
- [ ] Test property-by-property resolution (clicking ours/theirs values)
- [ ] Test "Accept Ours" and "Accept Theirs" quick actions
- [ ] Verify resolved files are written correctly without conflict markers
- [ ] Test dark mode styling for conflict pages