### PR TITLE
Add favicon to data entry app

### DIFF
--- a/internal/dataentry/static/favicon.svg
+++ b/internal/dataentry/static/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 12.7 12.7">
+  <path style="fill:none;stroke:#fffffe;stroke-width:0.576" d="M 5.668 10.67 L 10.491 6.076"/>
+  <path style="fill:none;stroke:#fffffe;stroke-width:0.576" d="M 2.476 5.469 L 10.491 6.076 L 7.581 2.358 Z"/>
+  <path style="fill:none;stroke:#fffffe;stroke-width:0.576" d="M 5.668 10.67 L 2.476 5.469"/>
+  <circle style="fill:#ff7bdb;stroke:#fffffe;stroke-width:0.569" cx="7.581" cy="2.358" r="1.209"/>
+  <circle style="fill:#9bce00;stroke:#fffffe;stroke-width:0.51" cx="10.491" cy="6.076" r="1.083"/>
+  <circle style="fill:#0b63c4;stroke:#fffffe;stroke-width:0.517" cx="2.476" cy="5.469" r="1.098"/>
+  <circle style="fill:#6c1c9e;stroke:#fffffe;stroke-width:0.569" cx="5.668" cy="10.416" r="1.209"/>
+</svg>

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -6,6 +6,7 @@ const allTemplates = `
 {{- define "head" -}}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
 <script>
 (function(){var t=localStorage.getItem('theme');if(t){document.documentElement.setAttribute('data-theme',t)}else if(matchMedia('(prefers-color-scheme:dark)').matches){document.documentElement.setAttribute('data-theme','dark')}})();
 </script>

--- a/tickets/entities/tickets/TKT-002.md
+++ b/tickets/entities/tickets/TKT-002.md
@@ -1,5 +1,5 @@
 ---
-id: TKT-001
+id: TKT-002
 kind: enhancement
 status: done
 title: Add favicon to data entry app


### PR DESCRIPTION
## Summary
- Add SVG favicon based on the existing logo
- Link favicon in shared head template for all pages

## Test plan
- [x] Verified favicon appears in browser tab