### PR TITLE
Add back button to scope navigation in data entry

### DIFF
--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -744,7 +744,10 @@ func (a *App) handleEntity(w http.ResponseWriter, r *http.Request) {
 
 	entityActiveList := a.resolveActiveList(entity.Type, r)
 	backURL := "/"
-	if entityActiveList != "" {
+	if scope := r.URL.Query().Get("scope"); strings.HasPrefix(scope, "search:") {
+		query := strings.TrimPrefix(scope, "search:")
+		backURL = "/search?q=" + url.QueryEscape(query)
+	} else if entityActiveList != "" {
 		backURL = "/list/" + entityActiveList
 	}
 	data := map[string]interface{}{

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -592,6 +593,7 @@ type ScopeNav struct {
 	NextURL  string // URL for next entity (empty if at last)
 	Progress string // e.g. "[3/12]"
 	Label    string // e.g. "12 tickets" or "5 results for 'auth'"
+	BackURL  string // URL to return to the list/search
 }
 
 // resolveScope parses the "scope" query parameter and reconstructs the ordered
@@ -605,6 +607,7 @@ func (a *App) resolveScope(currentEntityID string, r *http.Request) *ScopeNav {
 
 	var ids []string
 	var label string
+	var backURL string
 
 	switch {
 	case strings.HasPrefix(scope, "list:"):
@@ -642,6 +645,7 @@ func (a *App) resolveScope(currentEntityID string, r *http.Request) *ScopeNav {
 			ids[i] = e.ID
 		}
 		label = fmt.Sprintf("%d %s", len(ids), list.Title)
+		backURL = "/list/" + listID
 
 	case strings.HasPrefix(scope, "search:"):
 		query := strings.TrimPrefix(scope, "search:")
@@ -656,6 +660,7 @@ func (a *App) resolveScope(currentEntityID string, r *http.Request) *ScopeNav {
 			displayQuery = displayQuery[:30] + "..."
 		}
 		label = fmt.Sprintf("%d results for \"%s\"", len(ids), displayQuery)
+		backURL = "/search?q=" + url.QueryEscape(query)
 
 	default:
 		return nil
@@ -676,6 +681,7 @@ func (a *App) resolveScope(currentEntityID string, r *http.Request) *ScopeNav {
 	nav := &ScopeNav{
 		Progress: fmt.Sprintf("[%d/%d]", idx+1, len(ids)),
 		Label:    label,
+		BackURL:  backURL,
 	}
 
 	// Build prev/next URLs by swapping the entity ID in the path

--- a/internal/dataentry/templates.go
+++ b/internal/dataentry/templates.go
@@ -1376,6 +1376,9 @@ document.addEventListener('click', function(e) {
       if (isShortcutsOpen()) { toggleShortcuts(); return; }
       if (hasSearchResultSelected()) { exitSearchResults(); return; }
       if (isInputFocused()) { document.activeElement.blur(); return; }
+      // On scope nav — click the Back button (first link in scope-nav)
+      var scopeBackBtn = document.querySelector('.scope-nav a.scope-nav-btn');
+      if (scopeBackBtn) { scopeBackBtn.click(); return; }
       // On form, entity detail, or view pages — click the Back/Cancel button
       var backBtn = document.querySelector('#content .btn-secondary[hx-get]');
       if (backBtn) backBtn.click();
@@ -2317,10 +2320,11 @@ function closeSidePanel() {
 {{- define "scope-nav" -}}
 {{ if .Scope }}
 <div class="scope-nav">
+  <a href="{{ .Scope.BackURL }}" hx-get="{{ .Scope.BackURL }}" hx-target="#content" hx-push-url="true" class="scope-nav-btn">&larr; Back <kbd>Esc</kbd></a>
   {{ if .Scope.PrevURL }}
-  <a href="{{ .Scope.PrevURL }}" hx-get="{{ .Scope.PrevURL }}" hx-target="#content" hx-push-url="true" class="scope-nav-btn">&larr; Prev</a>
+  <a href="{{ .Scope.PrevURL }}" hx-get="{{ .Scope.PrevURL }}" hx-target="#content" hx-push-url="true" class="scope-nav-btn">Prev</a>
   {{ else }}
-  <span class="scope-nav-disabled">&larr; Prev</span>
+  <span class="scope-nav-disabled">Prev</span>
   {{ end }}
   <span class="scope-nav-progress">{{ .Scope.Progress }}</span>
   <span class="scope-nav-label">{{ .Scope.Label }}</span>

--- a/tickets/entities/features/FEAT-004.md
+++ b/tickets/entities/features/FEAT-004.md
@@ -1,0 +1,6 @@
+---
+id: FEAT-004
+status: proposed
+title: Add back button to search results in data entry
+type: feature
+---


### PR DESCRIPTION
## Summary
- Adds a "← Back Esc" button to the scope navigation bar when viewing entities from search results
- Pressing Esc key navigates back to the search results with the query preserved
- Works for both search scope (`scope=search:query`) and list scope (`scope=list:listID`)

## Test plan
- [ ] Search for entities, click a result, verify Back button appears in scope nav
- [ ] Click Back button, verify it returns to search with query preserved
- [ ] Press Esc key, verify same behavior as clicking Back