### PR TITLE
Harden git tests against repo pollution

### DIFF
--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -9,38 +9,28 @@ import (
 )
 
 // setupTestRepo creates a temporary git repository for testing.
-func setupTestRepo(t *testing.T) (dir string, cleanup func()) {
+// Uses t.TempDir() for automatic cleanup.
+func setupTestRepo(t *testing.T) string {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "git-test-*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-
-	cleanup = func() {
-		os.RemoveAll(dir)
-	}
+	dir := t.TempDir()
 
 	// Initialize git repo
 	if err := runCmd(dir, "init"); err != nil {
-		cleanup()
 		t.Fatalf("git init failed: %v", err)
 	}
 
 	// Configure git user for commits
 	if err := runCmd(dir, "config", "user.email", "test@test.com"); err != nil {
-		cleanup()
 		t.Fatalf("git config email failed: %v", err)
 	}
 	if err := runCmd(dir, "config", "user.name", "Test User"); err != nil {
-		cleanup()
 		t.Fatalf("git config name failed: %v", err)
 	}
 
 	// Create entities directory
 	entitiesDir := filepath.Join(dir, "entities", "tickets")
 	if err := os.MkdirAll(entitiesDir, 0o755); err != nil {
-		cleanup()
 		t.Fatalf("mkdir entities failed: %v", err)
 	}
 
@@ -48,49 +38,37 @@ func setupTestRepo(t *testing.T) (dir string, cleanup func()) {
 	testFile := filepath.Join(entitiesDir, "TKT-001.md")
 	content := "---\nid: TKT-001\ntype: ticket\n---\nTest ticket\n"
 	if err := os.WriteFile(testFile, []byte(content), 0o644); err != nil {
-		cleanup()
 		t.Fatalf("write file failed: %v", err)
 	}
 
 	if err := runCmd(dir, "add", "."); err != nil {
-		cleanup()
 		t.Fatalf("git add failed: %v", err)
 	}
 	if err := runCmd(dir, "commit", "-m", "Initial commit"); err != nil {
-		cleanup()
 		t.Fatalf("git commit failed: %v", err)
 	}
 
-	return dir, cleanup
+	return dir
 }
 
 // setupTestRepoWithRemote creates a test repo with a remote.
+// Uses t.TempDir() for automatic cleanup.
 //
 //nolint:unparam // remoteDir is returned for potential future use
-func setupTestRepoWithRemote(t *testing.T) (localDir, remoteDir string, cleanup func()) {
+func setupTestRepoWithRemote(t *testing.T) (localDir, remoteDir string) {
 	t.Helper()
 
 	// Create "remote" (bare repo)
-	remoteDir, err := os.MkdirTemp("", "git-remote-*")
-	if err != nil {
-		t.Fatalf("failed to create remote dir: %v", err)
-	}
+	remoteDir = t.TempDir()
 	if err := runCmd(remoteDir, "init", "--bare"); err != nil {
-		os.RemoveAll(remoteDir)
 		t.Fatalf("git init bare failed: %v", err)
 	}
 
 	// Create local repo
-	localDir, cleanupLocal := setupTestRepo(t)
-
-	cleanup = func() {
-		cleanupLocal()
-		os.RemoveAll(remoteDir)
-	}
+	localDir = setupTestRepo(t)
 
 	// Add remote
 	if err := runCmd(localDir, "remote", "add", "origin", remoteDir); err != nil {
-		cleanup()
 		t.Fatalf("git remote add failed: %v", err)
 	}
 
@@ -98,30 +76,32 @@ func setupTestRepoWithRemote(t *testing.T) (localDir, remoteDir string, cleanup 
 	if err := runCmd(localDir, "push", "-u", "origin", "master"); err != nil {
 		// Try main branch
 		if err := runCmd(localDir, "branch", "-M", "main"); err != nil {
-			cleanup()
 			t.Fatalf("git branch rename failed: %v", err)
 		}
 		if err := runCmd(localDir, "push", "-u", "origin", "main"); err != nil {
-			cleanup()
 			t.Fatalf("git push failed: %v", err)
 		}
 	}
 
-	return localDir, remoteDir, cleanup
+	return localDir, remoteDir
 }
 
 func runCmd(dir string, args ...string) error {
+	if dir == "" {
+		panic("runCmd: dir is empty")
+	}
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		panic("runCmd: dir does not exist: " + dir)
+	}
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	// Explicitly set GIT_DIR to prevent git from using parent repos
+	cmd.Env = append(os.Environ(), "GIT_DIR="+filepath.Join(dir, ".git"))
 	return cmd.Run()
 }
 
 func TestIsRepo_NotARepo(t *testing.T) {
-	dir, err := os.MkdirTemp("", "not-a-repo-*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if IsRepo(dir) {
 		t.Error("expected IsRepo to return false for non-repo directory")
@@ -129,8 +109,7 @@ func TestIsRepo_NotARepo(t *testing.T) {
 }
 
 func TestIsRepo_NoRemote(t *testing.T) {
-	dir, cleanup := setupTestRepo(t)
-	defer cleanup()
+	dir := setupTestRepo(t)
 
 	// Repo without remote should return false
 	if IsRepo(dir) {
@@ -139,8 +118,7 @@ func TestIsRepo_NoRemote(t *testing.T) {
 }
 
 func TestIsRepo_WithRemote(t *testing.T) {
-	dir, _, cleanup := setupTestRepoWithRemote(t)
-	defer cleanup()
+	dir, _ := setupTestRepoWithRemote(t)
 
 	if !IsRepo(dir) {
 		t.Error("expected IsRepo to return true for repo with remote")
@@ -148,8 +126,7 @@ func TestIsRepo_WithRemote(t *testing.T) {
 }
 
 func TestGetStatus_NoRemote(t *testing.T) {
-	dir, cleanup := setupTestRepo(t)
-	defer cleanup()
+	dir := setupTestRepo(t)
 
 	ops := NewOps(dir, Config{})
 	status, err := ops.GetStatus()
@@ -163,8 +140,7 @@ func TestGetStatus_NoRemote(t *testing.T) {
 }
 
 func TestGetStatus_WithRemote(t *testing.T) {
-	dir, _, cleanup := setupTestRepoWithRemote(t)
-	defer cleanup()
+	dir, _ := setupTestRepoWithRemote(t)
 
 	ops := NewOps(dir, Config{})
 	status, err := ops.GetStatus()
@@ -184,8 +160,7 @@ func TestGetStatus_WithRemote(t *testing.T) {
 }
 
 func TestGetStatus_LocalChanges(t *testing.T) {
-	dir, _, cleanup := setupTestRepoWithRemote(t)
-	defer cleanup()
+	dir, _ := setupTestRepoWithRemote(t)
 
 	// Modify a file in entities/
 	testFile := filepath.Join(dir, "entities", "tickets", "TKT-001.md")
@@ -206,8 +181,7 @@ func TestGetStatus_LocalChanges(t *testing.T) {
 }
 
 func TestGetStatus_IgnoresNonEntityChanges(t *testing.T) {
-	dir, _, cleanup := setupTestRepoWithRemote(t)
-	defer cleanup()
+	dir, _ := setupTestRepoWithRemote(t)
 
 	// Create a file outside entities/
 	testFile := filepath.Join(dir, "README.md")
@@ -228,8 +202,7 @@ func TestGetStatus_IgnoresNonEntityChanges(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
-	dir, _, cleanup := setupTestRepoWithRemote(t)
-	defer cleanup()
+	dir, _ := setupTestRepoWithRemote(t)
 
 	ops := NewOps(dir, Config{})
 	err := ops.Fetch()
@@ -289,8 +262,7 @@ func TestGetBaseBranch(t *testing.T) {
 }
 
 func TestAbortRebase_NoRebaseInProgress(t *testing.T) {
-	dir, _, cleanup := setupTestRepoWithRemote(t)
-	defer cleanup()
+	dir, _ := setupTestRepoWithRemote(t)
 
 	ops := NewOps(dir, Config{})
 	// AbortRebase when no rebase is in progress should fail
@@ -301,8 +273,7 @@ func TestAbortRebase_NoRebaseInProgress(t *testing.T) {
 }
 
 func TestSync_RejectsWhenConflictInProgress(t *testing.T) {
-	dir, _, cleanup := setupTestRepoWithRemote(t)
-	defer cleanup()
+	dir, _ := setupTestRepoWithRemote(t)
 
 	// Simulate a rebase conflict by creating the rebase-merge directory
 	// (this is what git creates during a rebase conflict)
@@ -322,8 +293,7 @@ func TestSync_RejectsWhenConflictInProgress(t *testing.T) {
 }
 
 func TestSync_RejectsWhenRebaseApplyInProgress(t *testing.T) {
-	dir, _, cleanup := setupTestRepoWithRemote(t)
-	defer cleanup()
+	dir, _ := setupTestRepoWithRemote(t)
 
 	// Simulate a rebase by creating the rebase-apply directory
 	rebaseApplyDir := filepath.Join(dir, ".git", "rebase-apply")

--- a/tickets/entities/automated-measures/git-test-dir-assertions.md
+++ b/tickets/entities/automated-measures/git-test-dir-assertions.md
@@ -1,0 +1,15 @@
+---
+description: Assertions in runCmd() that panic if directory is empty or missing, plus explicit GIT_DIR env var
+id: git-test-dir-assertions
+kind: test
+location: internal/git/git_test.go:runCmd()
+status: active
+title: Git test directory assertions
+type: automated-measure
+---
+
+Defensive assertions in git test helper to prevent repo pollution:
+
+- Panic if dir is empty
+- Panic if dir does not exist
+- Set GIT_DIR explicitly to prevent parent repo access

--- a/tickets/entities/bugs/BUG-003.md
+++ b/tickets/entities/bugs/BUG-003.md
@@ -1,0 +1,28 @@
+---
+description: Git tests polluted the main repo .git/config with bare=true and test user credentials
+id: BUG-003
+prevention: Added directory existence assertions and explicit GIT_DIR env var
+priority: high
+status: done
+title: Git tests pollute main repo config
+type: bug
+why1: Git config commands ran against the main repo instead of the temp test repo
+why2: The temp directory didn't exist or was empty when git commands executed
+why3: No assertions verified the directory existed before running git commands
+why4: Test helper runCmd() trusted that the directory always existed
+why5: No defensive programming patterns in test infrastructure
+---
+
+Git tests in `internal/git/git_test.go` were setting `core.bare=true` and test user
+credentials on the main repository's `.git/config`, breaking git operations.
+
+## Root cause
+
+Unknown exact trigger, but likely an interrupted test run or race condition where the
+temp directory was deleted before git commands finished.
+
+## Fix
+
+1. Added assertions in `runCmd()` to panic if dir is empty or doesn't exist
+2. Set `GIT_DIR` environment variable explicitly
+3. Switched from `os.MkdirTemp` to `t.TempDir()` for better lifecycle management

--- a/tickets/entities/concepts/test-isolation.md
+++ b/tickets/entities/concepts/test-isolation.md
@@ -1,0 +1,10 @@
+---
+description: Tests must run in isolated environments to prevent side effects on the host system or interference between tests
+id: test-isolation
+layer: infra
+package: internal/git
+status: stable
+summary: Tests must not affect the host environment or other tests
+title: Test Isolation
+type: concept
+---

--- a/tickets/entities/features/FEAT-008.md
+++ b/tickets/entities/features/FEAT-008.md
@@ -1,0 +1,8 @@
+---
+description: Sync entity changes with git remote repositories
+id: FEAT-008
+status: implemented
+summary: Synchronize entity and relation changes with a remote git repository
+title: Git sync support for data entry
+type: feature
+---

--- a/tickets/relations/BUG-003--adds-measure--git-test-dir-assertions.md
+++ b/tickets/relations/BUG-003--adds-measure--git-test-dir-assertions.md
@@ -1,0 +1,5 @@
+---
+from: BUG-003
+relation: adds-measure
+to: git-test-dir-assertions
+---

--- a/tickets/relations/BUG-003--affects--test-isolation.md
+++ b/tickets/relations/BUG-003--affects--test-isolation.md
@@ -1,0 +1,5 @@
+---
+from: BUG-003
+relation: affects
+to: test-isolation
+---

--- a/tickets/relations/BUG-003--fixes--FEAT-008.md
+++ b/tickets/relations/BUG-003--fixes--FEAT-008.md
@@ -1,0 +1,5 @@
+---
+from: BUG-003
+relation: fixes
+to: FEAT-008
+---

--- a/tickets/relations/FEAT-008--requires--test-isolation.md
+++ b/tickets/relations/FEAT-008--requires--test-isolation.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-008
+relation: requires
+to: test-isolation
+---

--- a/tickets/relations/git-test-dir-assertions--protects--test-isolation.md
+++ b/tickets/relations/git-test-dir-assertions--protects--test-isolation.md
@@ -1,0 +1,5 @@
+---
+from: git-test-dir-assertions
+relation: protects
+to: test-isolation
+---


### PR DESCRIPTION
## Summary
- Add directory existence assertions to `runCmd` to catch invalid state early
- Set `GIT_DIR` explicitly to prevent git from using parent repos
- Switch from `os.MkdirTemp` to `t.TempDir()` for better lifecycle management

## Test plan
- [x] All git tests pass
- [x] Verified no config pollution after test run