### PR TITLE
Fix kanban drag and drop

### DIFF
--- a/internal/dataentry/static/app.css
+++ b/internal/dataentry/static/app.css
@@ -274,7 +274,7 @@ thead th.sortable { user-select: none; }
 .kanban-cards { flex: 1; padding: 8px; display: flex; flex-direction: column; gap: 8px; min-height: 80px; overflow-y: auto; background: var(--bg); }
 .kanban-card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 6px; padding: 10px 12px; cursor: pointer; transition: box-shadow 0.15s, transform 0.15s, opacity 0.15s; border-left: 3px solid var(--border); position: relative; }
 .kanban-card:hover { box-shadow: 0 4px 12px rgba(0,0,0,0.08); transform: translateY(-1px); }
-.kanban-card.dragging { opacity: 0.5; transform: rotate(2deg); }
+.kanban-card.dragging { opacity: 0.5; transform: rotate(2deg); pointer-events: none; }
 .kanban-card-title { font-weight: 500; font-size: 13px; margin-bottom: 8px; line-height: 1.4; color: var(--text); }
 .kanban-card-fields { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
 .kanban-card-fields .badge { font-size: 10px; padding: 2px 6px; }

--- a/internal/dataentry/static/app.js
+++ b/internal/dataentry/static/app.js
@@ -1400,7 +1400,7 @@ function toggleNavGroup(btn) {
 }
 
 // Update active sidebar link after HTMX navigation
-document.body.addEventListener('htmx:pushedIntoHistory', function() {
+document.addEventListener('htmx:pushedIntoHistory', function() {
   var path = window.location.pathname;
   var links = document.querySelectorAll('.sidebar nav a');
   var matched = false;

--- a/tickets/entities/bugs/BUG-004.md
+++ b/tickets/entities/bugs/BUG-004.md
@@ -1,0 +1,12 @@
+---
+description: Cards couldn't be dragged between columns due to missing pointer-events and JS error
+id: BUG-004
+prevention: 'Added pointer-events: none to .kanban-card.dragging and fixed document.body null error'
+priority: high
+status: done
+title: Kanban drag and drop not working
+type: bug
+why1: Drop events were intercepted by the dragged card element
+why2: The .dragging CSS class didn't disable pointer-events
+why3: 'CSS was missing pointer-events: none for dragging state'
+---

--- a/tickets/relations/BUG-004--affects--data-entry-server.md
+++ b/tickets/relations/BUG-004--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: BUG-004
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/BUG-004--fixes--FEAT-004.md
+++ b/tickets/relations/BUG-004--fixes--FEAT-004.md
@@ -1,0 +1,5 @@
+---
+from: BUG-004
+relation: fixes
+to: FEAT-004
+---


### PR DESCRIPTION
## Summary
- Add `pointer-events: none` to `.kanban-card.dragging` so drop events reach the underlying columns
- Use `document` instead of `document.body` for htmx event listener to avoid null error when script loads before body

## Test plan
- [x] Drag cards between columns on kanban board
- [x] Verify no console errors on page load