### PR TITLE
Add helpful error for number/float types suggesting integer

### DIFF
--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -225,9 +225,15 @@ func validateEntitySemantics(m *Metamodel) []string {
 				continue
 			}
 			if !isKnownPropertyType(propDef.Type, m) {
-				errs = append(errs, fmt.Sprintf(
-					"entity %q: property %q has unknown type %q (not a built-in type and not defined in 'types')",
-					name, propName, propDef.Type))
+				if propDef.Type == "number" || propDef.Type == "float" {
+					errs = append(errs, fmt.Sprintf(
+						"entity %q: property %q has type %q which is not supported; use \"integer\" instead",
+						name, propName, propDef.Type))
+				} else {
+					errs = append(errs, fmt.Sprintf(
+						"entity %q: property %q has unknown type %q (not a built-in type and not defined in 'types')",
+						name, propName, propDef.Type))
+				}
 			}
 			if propDef.Type == PropertyTypeEnum && len(propDef.Values) == 0 {
 				errs = append(errs, fmt.Sprintf(

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -2,6 +2,7 @@ package metamodel
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -716,6 +717,42 @@ relations: {}
 	}
 	if !strings.Contains(err.Error(), "mypriority") {
 		t.Errorf("expected 'mypriority' in error, got: %v", err)
+	}
+}
+
+func TestParse_NumberTypeSuggestsInteger(t *testing.T) {
+	tests := []struct {
+		name     string
+		typeName string
+	}{
+		{"number type", "number"},
+		{"float type", "float"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yaml := fmt.Sprintf(`
+version: "1.0"
+entities:
+  phase:
+    label: Phase
+    id_prefix: "PH-"
+    properties:
+      order:
+        type: %s
+types: {}
+relations: {}
+`, tt.typeName)
+			_, err := Parse([]byte(yaml))
+			assertError(t, err)
+
+			if !strings.Contains(err.Error(), tt.typeName) {
+				t.Errorf("expected %q in error, got: %v", tt.typeName, err)
+			}
+			if !strings.Contains(err.Error(), `use "integer" instead`) {
+				t.Errorf("expected suggestion to use integer, got: %v", err)
+			}
+		})
 	}
 }
 

--- a/tickets/entities/concepts/metamodel-types.md
+++ b/tickets/entities/concepts/metamodel-types.md
@@ -1,0 +1,9 @@
+---
+id: metamodel-types
+layer: core
+package: internal/metamodel
+status: stable
+summary: Built-in property types (string, integer, boolean, date, enum) supported by the metamodel
+title: Metamodel Property Types
+type: concept
+---

--- a/tickets/entities/features/FEAT-009.md
+++ b/tickets/entities/features/FEAT-009.md
@@ -1,0 +1,7 @@
+---
+description: 'When users specify type: number or type: float in metamodel properties, emit a helpful error suggesting integer instead'
+id: FEAT-009
+status: implemented
+title: Helpful error for number/float types
+type: feature
+---

--- a/tickets/entities/tickets/TKT-006.md
+++ b/tickets/entities/tickets/TKT-006.md
@@ -1,0 +1,8 @@
+---
+description: 'When users specify type: number or type: float in metamodel properties, emit a helpful error suggesting integer instead. Closes #122'
+id: TKT-006
+kind: enhancement
+status: done
+title: Add number type support for entity properties
+type: ticket
+---

--- a/tickets/relations/FEAT-009--requires--metamodel-types.md
+++ b/tickets/relations/FEAT-009--requires--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-009
+relation: requires
+to: metamodel-types
+---

--- a/tickets/relations/TKT-006--affects--metamodel-types.md
+++ b/tickets/relations/TKT-006--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-006
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-006--implements--FEAT-009.md
+++ b/tickets/relations/TKT-006--implements--FEAT-009.md
@@ -1,0 +1,5 @@
+---
+from: TKT-006
+relation: implements
+to: FEAT-009
+---


### PR DESCRIPTION
## Summary
- When users specify `type: number` or `type: float` in metamodel properties, emit a helpful error suggesting `integer` instead
- Closes #122

## Test plan
- [x] Added test `TestParse_NumberTypeSuggestsInteger` covering both `number` and `float` types
- [x] All existing tests pass