### PR TITLE
Fix EasyMDE editor content not saving on form submit

### DIFF
--- a/internal/dataentry/static/app.js
+++ b/internal/dataentry/static/app.js
@@ -1346,7 +1346,7 @@ function createRelaEditor(element, options) {
   }
   toolbar.push('|', 'guide');
 
-  return new EasyMDE({
+  var editor = new EasyMDE({
     element: element,
     spellChecker: false,
     status: false,
@@ -1354,6 +1354,14 @@ function createRelaEditor(element, options) {
     toolbar: toolbar,
     sideBySideFullscreen: false,
   });
+
+  // Sync CodeMirror content to textarea before form submission
+  // Using 'changes' event (batched) is more efficient than 'change' (per-keystroke)
+  editor.codemirror.on('changes', function() {
+    editor.codemirror.save();
+  });
+
+  return editor;
 }
 
 // Kanban board functions
@@ -1519,7 +1527,6 @@ document.addEventListener('htmx:afterSettle', function(e) {
     _editorInstance = createRelaEditor(el, { fullscreenToggle: toggleFullscreenEditor });
   }
 });
-
 // Inline create modal
 var _inlineRelation = '';
 var _inlineFormID = '';

--- a/tickets/entities/automated-measures/codemirror-textarea-sync.md
+++ b/tickets/entities/automated-measures/codemirror-textarea-sync.md
@@ -1,0 +1,10 @@
+---
+id: codemirror-textarea-sync
+kind: test
+location: internal/dataentry/static/app.js
+status: active
+title: CodeMirror textarea sync on changes
+type: automated-measure
+---
+
+EasyMDE/CodeMirror editor automatically syncs content to the underlying textarea on every change using the batched `changes` event. This ensures HTMX form submissions always include the current editor content.

--- a/tickets/entities/bugs/BUG-005.md
+++ b/tickets/entities/bugs/BUG-005.md
@@ -1,0 +1,22 @@
+---
+effort: xs
+id: BUG-005
+prevention: Added CodeMirror 'changes' event handler to sync content to textarea automatically
+priority: medium
+status: done
+title: EasyMDE editor content not saved on form submit
+type: bug
+why1: HTMX collects form data before its events fire, so the textarea value is stale
+why2: EasyMDE wraps textarea and stores content in CodeMirror, not syncing back automatically
+why3: No explicit sync mechanism was implemented when EasyMDE was added
+---
+
+When editing markdown content in the data-entry forms, changes made in the EasyMDE editor were not being saved when submitting the form.
+
+## Root Cause
+
+EasyMDE wraps the textarea element and stores content in CodeMirror internally. When HTMX submits the form, it collects form data before any HTMX events fire, so the original textarea still has the old content.
+
+## Fix
+
+Added a `changes` event handler to CodeMirror that calls `save()` to sync content back to the textarea. Using the batched `changes` event (not `change`) for efficiency.

--- a/tickets/entities/features/FEAT-014.md
+++ b/tickets/entities/features/FEAT-014.md
@@ -1,0 +1,15 @@
+---
+id: FEAT-014
+status: implemented
+summary: EasyMDE-based markdown editor for entity content in data entry forms
+title: Markdown editor in data entry forms
+type: feature
+---
+
+The data entry forms include an EasyMDE markdown editor for editing entity body content. Features:
+
+- Toolbar with common formatting options (bold, italic, heading, lists)
+- Checklist support
+- Link and image insertion
+- Preview and side-by-side modes
+- Fullscreen editing

--- a/tickets/relations/BUG-005--adds-measure--codemirror-textarea-sync.md
+++ b/tickets/relations/BUG-005--adds-measure--codemirror-textarea-sync.md
@@ -1,0 +1,5 @@
+---
+from: BUG-005
+relation: adds-measure
+to: codemirror-textarea-sync
+---

--- a/tickets/relations/BUG-005--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-005--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-005
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-005--fixes--FEAT-014.md
+++ b/tickets/relations/BUG-005--fixes--FEAT-014.md
@@ -1,0 +1,5 @@
+---
+from: BUG-005
+relation: fixes
+to: FEAT-014
+---

--- a/tickets/relations/FEAT-014--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-014--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-014
+relation: requires
+to: data-entry-ui
+---


### PR DESCRIPTION
## Summary
- Fix bug where markdown editor content wasn't saved when submitting forms in data-entry
- Sync CodeMirror content to textarea using batched 'changes' event

## Test plan
- [x] Verified with Puppeteer that editor content is now saved correctly
- [x] All dataentry tests pass