### PR TITLE
Add automation engine for entity lifecycle events

### DIFF
--- a/internal/automation/engine.go
+++ b/internal/automation/engine.go
@@ -1,0 +1,241 @@
+package automation
+
+import (
+	"github.com/Sourcehaven-BV/rela/internal/filter"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+// Engine evaluates automations against entity events.
+type Engine struct {
+	automations []Automation
+	vars        TemplateVars
+}
+
+// NewEngine creates an automation engine with the given automations.
+func NewEngine(automations []Automation) *Engine {
+	return &Engine{
+		automations: automations,
+		vars:        DefaultTemplateVars(),
+	}
+}
+
+// NewEngineFromMetamodel creates an automation engine from metamodel definitions.
+func NewEngineFromMetamodel(defs []metamodel.AutomationDef) *Engine {
+	automations := make([]Automation, len(defs))
+	for i, def := range defs {
+		automations[i] = convertFromMetamodel(def)
+	}
+	return NewEngine(automations)
+}
+
+// convertFromMetamodel converts a metamodel AutomationDef to the internal Automation type.
+func convertFromMetamodel(def metamodel.AutomationDef) Automation {
+	auto := Automation{
+		Name:        def.Name,
+		Description: def.Description,
+		On: Trigger{
+			Entity:          []string(def.On.Entity),
+			Property:        def.On.Property,
+			Becomes:         def.On.Becomes,
+			From:            def.On.From,
+			Created:         def.On.Created,
+			RelationCreated: def.On.RelationCreated,
+			RelationRemoved: def.On.RelationRemoved,
+		},
+		Do:       make([]Action, len(def.Do)),
+		Validate: make([]Validation, len(def.Validate)),
+	}
+
+	for i, a := range def.Do {
+		action := Action{
+			Set:   a.Set,
+			Value: a.Value,
+		}
+		if a.CreateRelation != nil {
+			action.CreateRelation = &CreateRelationAction{
+				Relation: a.CreateRelation.Relation,
+				To:       a.CreateRelation.To,
+			}
+		}
+		auto.Do[i] = action
+	}
+
+	for i, v := range def.Validate {
+		auto.Validate[i] = Validation{
+			Check:    v.Check,
+			Severity: v.Severity,
+			Message:  v.Message,
+		}
+	}
+
+	return auto
+}
+
+// SetTemplateVars sets the template variables for interpolation.
+func (e *Engine) SetTemplateVars(vars TemplateVars) {
+	e.vars = vars
+}
+
+// Process evaluates all automations against an event and returns the result.
+func (e *Engine) Process(event Event) *Result {
+	result := &Result{
+		PropertiesSet:     make(map[string]string),
+		RelationsToCreate: make([]*model.Relation, 0),
+		Warnings:          make([]string, 0),
+		Errors:            make([]string, 0),
+	}
+
+	for _, auto := range e.automations {
+		if !e.matches(auto.On, event) {
+			continue
+		}
+
+		// Execute actions
+		for _, action := range auto.Do {
+			e.executeAction(action, event, result)
+		}
+
+		// Evaluate validations
+		for _, validation := range auto.Validate {
+			e.evaluateValidation(validation, event, result)
+		}
+	}
+
+	return result
+}
+
+// matches checks if a trigger matches an event.
+func (e *Engine) matches(trigger Trigger, event Event) bool {
+	// Check entity type constraint
+	if len(trigger.Entity) > 0 && event.Entity != nil {
+		matched := false
+		for _, entityType := range trigger.Entity {
+			if event.Entity.Type == entityType {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	switch event.Type {
+	case EventEntityCreated:
+		return trigger.Created
+
+	case EventEntityUpdated:
+		if trigger.Property == "" {
+			return false
+		}
+		return e.matchesPropertyChange(trigger, event)
+
+	case EventRelationCreated:
+		if trigger.RelationCreated == "" {
+			return false
+		}
+		return event.Relation != nil && event.Relation.Type == trigger.RelationCreated
+
+	case EventRelationRemoved:
+		if trigger.RelationRemoved == "" {
+			return false
+		}
+		return event.Relation != nil && event.Relation.Type == trigger.RelationRemoved
+	}
+
+	return false
+}
+
+// matchesPropertyChange checks if a property change event matches the trigger.
+func (e *Engine) matchesPropertyChange(trigger Trigger, event Event) bool {
+	if event.Entity == nil {
+		return false
+	}
+
+	newValue := event.Entity.GetString(trigger.Property)
+	oldValue := ""
+	if event.OldEntity != nil {
+		oldValue = event.OldEntity.GetString(trigger.Property)
+	}
+
+	// No change occurred
+	if newValue == oldValue {
+		return false
+	}
+
+	// Check "from" constraint
+	if trigger.From != "" && oldValue != trigger.From {
+		return false
+	}
+
+	// Check "becomes" constraint
+	if trigger.Becomes != "" && newValue != trigger.Becomes {
+		return false
+	}
+
+	return true
+}
+
+// executeAction performs an action and updates the result.
+func (e *Engine) executeAction(action Action, event Event, result *Result) {
+	if action.Set != "" {
+		value := e.interpolate(action.Value, event)
+		result.PropertiesSet[action.Set] = value
+	}
+
+	if action.CreateRelation != nil {
+		targetID := e.interpolate(action.CreateRelation.To, event)
+		if targetID != "" && event.Entity != nil {
+			rel := model.NewRelation(event.Entity.ID, action.CreateRelation.Relation, targetID)
+			result.RelationsToCreate = append(result.RelationsToCreate, rel)
+		}
+	}
+}
+
+// evaluateValidation checks a validation and adds warnings/errors to the result.
+func (e *Engine) evaluateValidation(validation Validation, event Event, result *Result) {
+	if event.Entity == nil {
+		return
+	}
+
+	// Parse the check expression and evaluate against the entity
+	f, err := filter.Parse(validation.Check)
+	if err != nil {
+		result.Warnings = append(result.Warnings, "Invalid validation check: "+validation.Check)
+		return
+	}
+
+	// Use simple value matching (works without full metamodel context)
+	val := event.Entity.Properties[f.Property]
+	if !matchSimple(val, f) {
+		msg := e.interpolate(validation.Message, event)
+		if validation.GetSeverity() == "error" {
+			result.Errors = append(result.Errors, msg)
+		} else {
+			result.Warnings = append(result.Warnings, msg)
+		}
+	}
+}
+
+// matchSimple does simple value matching without metamodel context.
+// Handles the most common automation validation cases.
+func matchSimple(val interface{}, f *filter.Filter) bool {
+	// Handle nil/missing/empty values
+	if val == nil || val == "" {
+		// Only match if explicitly comparing to empty with = operator
+		if f.Operator == filter.OpEqual && f.Value == "" {
+			return true
+		}
+		// For "!=" with empty value, missing/nil means "is empty", so it should NOT match "is not empty"
+		return false
+	}
+
+	// Use the filter package's MatchValue for the actual comparison
+	return filter.MatchValue(val, f)
+}
+
+// interpolate replaces template variables in a string.
+func (e *Engine) interpolate(template string, event Event) string {
+	return Interpolate(template, e.vars, event.Entity, event.OldEntity)
+}

--- a/internal/automation/engine_test.go
+++ b/internal/automation/engine_test.go
@@ -1,0 +1,377 @@
+package automation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+func TestEngine_EntityCreated(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "set-created-at",
+			On: Trigger{
+				Entity:  []string{"ticket"},
+				Created: true,
+			},
+			Do: []Action{
+				{Set: "created_at", Value: "{{today}}"},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+	engine.SetTemplateVars(TemplateVars{
+		Now: func() time.Time { return time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC) },
+	})
+
+	entity := model.NewEntity("T-001", "ticket")
+	result := engine.Process(Event{
+		Type:   EventEntityCreated,
+		Entity: entity,
+	})
+
+	if result.PropertiesSet["created_at"] != "2025-01-15" {
+		t.Errorf("expected created_at=2025-01-15, got %q", result.PropertiesSet["created_at"])
+	}
+}
+
+func TestEngine_EntityCreated_WrongType(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "set-created-at",
+			On: Trigger{
+				Entity:  []string{"ticket"},
+				Created: true,
+			},
+			Do: []Action{
+				{Set: "created_at", Value: "{{today}}"},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	// Entity of different type - should not trigger
+	entity := model.NewEntity("B-001", "bug")
+	result := engine.Process(Event{
+		Type:   EventEntityCreated,
+		Entity: entity,
+	})
+
+	if len(result.PropertiesSet) > 0 {
+		t.Error("expected no properties to be set for wrong entity type")
+	}
+}
+
+func TestEngine_PropertyChange(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "set-started-at",
+			On: Trigger{
+				Entity:   []string{"ticket"},
+				Property: "status",
+				Becomes:  "in-progress",
+			},
+			Do: []Action{
+				{Set: "started_at", Value: "{{today}}"},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+	engine.SetTemplateVars(TemplateVars{
+		Now: func() time.Time { return time.Date(2025, 2, 10, 10, 0, 0, 0, time.UTC) },
+	})
+
+	oldEntity := model.NewEntity("T-001", "ticket")
+	oldEntity.Properties["status"] = "backlog"
+
+	newEntity := model.NewEntity("T-001", "ticket")
+	newEntity.Properties["status"] = "in-progress"
+
+	result := engine.Process(Event{
+		Type:      EventEntityUpdated,
+		Entity:    newEntity,
+		OldEntity: oldEntity,
+	})
+
+	if result.PropertiesSet["started_at"] != "2025-02-10" {
+		t.Errorf("expected started_at=2025-02-10, got %q", result.PropertiesSet["started_at"])
+	}
+}
+
+func TestEngine_PropertyChange_NoChange(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "set-started-at",
+			On: Trigger{
+				Entity:   []string{"ticket"},
+				Property: "status",
+				Becomes:  "in-progress",
+			},
+			Do: []Action{
+				{Set: "started_at", Value: "{{today}}"},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	// Status already "in-progress" - no change
+	oldEntity := model.NewEntity("T-001", "ticket")
+	oldEntity.Properties["status"] = "in-progress"
+
+	newEntity := model.NewEntity("T-001", "ticket")
+	newEntity.Properties["status"] = "in-progress"
+
+	result := engine.Process(Event{
+		Type:      EventEntityUpdated,
+		Entity:    newEntity,
+		OldEntity: oldEntity,
+	})
+
+	if len(result.PropertiesSet) > 0 {
+		t.Error("expected no properties to be set when value doesn't change")
+	}
+}
+
+func TestEngine_PropertyChange_FromConstraint(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "only-from-backlog",
+			On: Trigger{
+				Entity:   []string{"ticket"},
+				Property: "status",
+				From:     "backlog",
+				Becomes:  "in-progress",
+			},
+			Do: []Action{
+				{Set: "was_backlog", Value: "true"},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	// From "backlog" to "in-progress" - should trigger
+	oldEntity := model.NewEntity("T-001", "ticket")
+	oldEntity.Properties["status"] = "backlog"
+
+	newEntity := model.NewEntity("T-001", "ticket")
+	newEntity.Properties["status"] = "in-progress"
+
+	result := engine.Process(Event{
+		Type:      EventEntityUpdated,
+		Entity:    newEntity,
+		OldEntity: oldEntity,
+	})
+
+	if result.PropertiesSet["was_backlog"] != "true" {
+		t.Error("expected trigger when changing from backlog")
+	}
+
+	// From "ready" to "in-progress" - should NOT trigger
+	oldEntity2 := model.NewEntity("T-002", "ticket")
+	oldEntity2.Properties["status"] = "ready"
+
+	newEntity2 := model.NewEntity("T-002", "ticket")
+	newEntity2.Properties["status"] = "in-progress"
+
+	result2 := engine.Process(Event{
+		Type:      EventEntityUpdated,
+		Entity:    newEntity2,
+		OldEntity: oldEntity2,
+	})
+
+	if len(result2.PropertiesSet) > 0 {
+		t.Error("expected no trigger when not changing from backlog")
+	}
+}
+
+func TestEngine_ValidationWarning(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "require-why1-for-in-progress-bugs",
+			On: Trigger{
+				Entity:   []string{"bug"},
+				Property: "status",
+				Becomes:  "in-progress",
+			},
+			Validate: []Validation{
+				{
+					Check:    "why1!=",
+					Severity: "warning",
+					Message:  "Please add a why1 analysis",
+				},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	oldEntity := model.NewEntity("B-001", "bug")
+	oldEntity.Properties["status"] = "backlog"
+
+	newEntity := model.NewEntity("B-001", "bug")
+	newEntity.Properties["status"] = "in-progress"
+	// why1 is empty
+
+	result := engine.Process(Event{
+		Type:      EventEntityUpdated,
+		Entity:    newEntity,
+		OldEntity: oldEntity,
+	})
+
+	if !result.HasWarnings() {
+		t.Error("expected warning for missing why1")
+	}
+	if len(result.Warnings) != 1 || result.Warnings[0] != "Please add a why1 analysis" {
+		t.Errorf("unexpected warnings: %v", result.Warnings)
+	}
+}
+
+func TestEngine_ValidationPasses(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "require-why1-for-in-progress-bugs",
+			On: Trigger{
+				Entity:   []string{"bug"},
+				Property: "status",
+				Becomes:  "in-progress",
+			},
+			Validate: []Validation{
+				{
+					Check:    "why1!=",
+					Severity: "warning",
+					Message:  "Please add a why1 analysis",
+				},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	oldEntity := model.NewEntity("B-001", "bug")
+	oldEntity.Properties["status"] = "backlog"
+
+	newEntity := model.NewEntity("B-001", "bug")
+	newEntity.Properties["status"] = "in-progress"
+	newEntity.Properties["why1"] = "Database connection timeout"
+
+	result := engine.Process(Event{
+		Type:      EventEntityUpdated,
+		Entity:    newEntity,
+		OldEntity: oldEntity,
+	})
+
+	if result.HasWarnings() {
+		t.Errorf("expected no warnings when why1 is set, got: %v", result.Warnings)
+	}
+}
+
+func TestEngine_CreateRelation(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "link-to-current-sprint",
+			On: Trigger{
+				Entity:  []string{"ticket"},
+				Created: true,
+			},
+			Do: []Action{
+				{
+					CreateRelation: &CreateRelationAction{
+						Relation: "belongs-to",
+						To:       "sprint-current",
+					},
+				},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	entity := model.NewEntity("T-001", "ticket")
+	result := engine.Process(Event{
+		Type:   EventEntityCreated,
+		Entity: entity,
+	})
+
+	if len(result.RelationsToCreate) != 1 {
+		t.Fatalf("expected 1 relation to create, got %d", len(result.RelationsToCreate))
+	}
+	rel := result.RelationsToCreate[0]
+	if rel.From != "T-001" || rel.Type != "belongs-to" || rel.To != "sprint-current" {
+		t.Errorf("unexpected relation: %+v", rel)
+	}
+}
+
+func TestEngine_MultipleEntityTypes(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "mark-created",
+			On: Trigger{
+				Entity:  []string{"ticket", "bug", "feature"},
+				Created: true,
+			},
+			Do: []Action{
+				{Set: "created", Value: "true"},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	for _, entityType := range []string{"ticket", "bug", "feature"} {
+		entity := model.NewEntity("E-001", entityType)
+		result := engine.Process(Event{
+			Type:   EventEntityCreated,
+			Entity: entity,
+		})
+
+		if result.PropertiesSet["created"] != "true" {
+			t.Errorf("expected trigger for entity type %s", entityType)
+		}
+	}
+
+	// Other type should not trigger
+	entity := model.NewEntity("D-001", "decision")
+	result := engine.Process(Event{
+		Type:   EventEntityCreated,
+		Entity: entity,
+	})
+
+	if len(result.PropertiesSet) > 0 {
+		t.Error("expected no trigger for decision type")
+	}
+}
+
+func TestEngine_RelationCreated(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "mark-linked",
+			On: Trigger{
+				RelationCreated: "implements",
+			},
+			Do: []Action{
+				{Set: "has_implementation", Value: "true"},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	entity := model.NewEntity("T-001", "ticket")
+	rel := model.NewRelation("S-001", "implements", "T-001")
+
+	result := engine.Process(Event{
+		Type:     EventRelationCreated,
+		Entity:   entity,
+		Relation: rel,
+	})
+
+	if result.PropertiesSet["has_implementation"] != "true" {
+		t.Error("expected trigger on relation created")
+	}
+}

--- a/internal/automation/template.go
+++ b/internal/automation/template.go
@@ -1,0 +1,140 @@
+package automation
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+// TemplateVars holds variables available for template interpolation.
+type TemplateVars struct {
+	// Now is the current time function (injectable for testing).
+	Now func() time.Time
+
+	// User holds user identity information.
+	User UserVars
+}
+
+// UserVars holds user identity information.
+type UserVars struct {
+	Name  string
+	Email string
+}
+
+// DefaultTemplateVars returns template vars with current time and git user info.
+func DefaultTemplateVars() TemplateVars {
+	return TemplateVars{
+		Now:  time.Now,
+		User: GetGitUser(),
+	}
+}
+
+// GetGitUser retrieves user.name and user.email from git config.
+func GetGitUser() UserVars {
+	vars := UserVars{
+		Name:  os.Getenv("USER"),
+		Email: "",
+	}
+
+	// Try git config user.name
+	if out, err := exec.Command("git", "config", "user.name").Output(); err == nil {
+		vars.Name = strings.TrimSpace(string(out))
+	}
+
+	// Try git config user.email
+	if out, err := exec.Command("git", "config", "user.email").Output(); err == nil {
+		vars.Email = strings.TrimSpace(string(out))
+	}
+
+	return vars
+}
+
+// Interpolate replaces template variables in a string.
+// Supported variables:
+//   - {{now}}         - Current timestamp (ISO 8601)
+//   - {{today}}       - Current date (YYYY-MM-DD)
+//   - {{user.name}}   - Git user name
+//   - {{user.email}}  - Git user email
+//   - {{entity.id}}   - Current entity ID
+//   - {{entity.type}} - Current entity type
+//   - {{old.<prop>}}  - Previous value of a property
+//   - {{new.<prop>}}  - New value of a property
+func Interpolate(template string, vars TemplateVars, entity, oldEntity *model.Entity) string {
+	if !strings.Contains(template, "{{") {
+		return template
+	}
+
+	now := vars.Now()
+	if vars.Now == nil {
+		now = time.Now()
+	}
+
+	replacements := map[string]string{
+		"{{now}}":        now.Format(time.RFC3339),
+		"{{today}}":      now.Format("2006-01-02"),
+		"{{user.name}}":  vars.User.Name,
+		"{{user.email}}": vars.User.Email,
+	}
+
+	if entity != nil {
+		replacements["{{entity.id}}"] = entity.ID
+		replacements["{{entity.type}}"] = entity.Type
+	}
+
+	// Process the template
+	result := template
+
+	// Simple replacements
+	for key, value := range replacements {
+		result = strings.ReplaceAll(result, key, value)
+	}
+
+	// Handle dynamic property references: {{old.prop}} and {{new.prop}}
+	result = interpolatePropertyRefs(result, "old.", oldEntity)
+	result = interpolatePropertyRefs(result, "new.", entity)
+
+	return result
+}
+
+// interpolatePropertyRefs handles {{prefix.property}} patterns.
+func interpolatePropertyRefs(s, prefix string, entity *model.Entity) string {
+	marker := "{{" + prefix
+	if !strings.Contains(s, marker) {
+		return s
+	}
+
+	var buf bytes.Buffer
+	remaining := s
+
+	for {
+		idx := strings.Index(remaining, marker)
+		if idx == -1 {
+			buf.WriteString(remaining)
+			break
+		}
+
+		buf.WriteString(remaining[:idx])
+		remaining = remaining[idx+len(marker):]
+
+		// Find closing }}
+		endIdx := strings.Index(remaining, "}}")
+		if endIdx == -1 {
+			buf.WriteString(marker)
+			continue
+		}
+
+		propName := remaining[:endIdx]
+		remaining = remaining[endIdx+2:]
+
+		if entity != nil {
+			buf.WriteString(entity.GetString(propName))
+		}
+		// If entity is nil, the variable expands to empty string
+	}
+
+	return buf.String()
+}

--- a/internal/automation/template_test.go
+++ b/internal/automation/template_test.go
@@ -1,0 +1,125 @@
+package automation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+func TestInterpolate_SimpleVariables(t *testing.T) {
+	vars := TemplateVars{
+		Now: func() time.Time { return time.Date(2025, 3, 15, 14, 30, 0, 0, time.UTC) },
+		User: UserVars{
+			Name:  "John Doe",
+			Email: "john@example.com",
+		},
+	}
+
+	tests := []struct {
+		template string
+		expected string
+	}{
+		{"{{today}}", "2025-03-15"},
+		{"{{user.name}}", "John Doe"},
+		{"{{user.email}}", "john@example.com"},
+		{"Created by {{user.name}}", "Created by John Doe"},
+		{"No variables here", "No variables here"},
+		{"", ""},
+	}
+
+	for _, tc := range tests {
+		result := Interpolate(tc.template, vars, nil, nil)
+		if result != tc.expected {
+			t.Errorf("Interpolate(%q) = %q, want %q", tc.template, result, tc.expected)
+		}
+	}
+}
+
+func TestInterpolate_EntityVariables(t *testing.T) {
+	vars := DefaultTemplateVars()
+	vars.Now = func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) }
+
+	entity := model.NewEntity("T-123", "ticket")
+	entity.Properties["status"] = "in-progress"
+	entity.Properties["owner"] = "alice"
+
+	tests := []struct {
+		template string
+		expected string
+	}{
+		{"{{entity.id}}", "T-123"},
+		{"{{entity.type}}", "ticket"},
+		{"{{new.status}}", "in-progress"},
+		{"{{new.owner}}", "alice"},
+		{"{{new.missing}}", ""},
+	}
+
+	for _, tc := range tests {
+		result := Interpolate(tc.template, vars, entity, nil)
+		if result != tc.expected {
+			t.Errorf("Interpolate(%q) = %q, want %q", tc.template, result, tc.expected)
+		}
+	}
+}
+
+func TestInterpolate_OldEntityVariables(t *testing.T) {
+	vars := DefaultTemplateVars()
+	vars.Now = func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) }
+
+	oldEntity := model.NewEntity("T-123", "ticket")
+	oldEntity.Properties["status"] = "backlog"
+	oldEntity.Properties["owner"] = "bob"
+
+	newEntity := model.NewEntity("T-123", "ticket")
+	newEntity.Properties["status"] = "in-progress"
+	newEntity.Properties["owner"] = "alice"
+
+	tests := []struct {
+		template string
+		expected string
+	}{
+		{"{{old.status}}", "backlog"},
+		{"{{new.status}}", "in-progress"},
+		{"Changed from {{old.owner}} to {{new.owner}}", "Changed from bob to alice"},
+	}
+
+	for _, tc := range tests {
+		result := Interpolate(tc.template, vars, newEntity, oldEntity)
+		if result != tc.expected {
+			t.Errorf("Interpolate(%q) = %q, want %q", tc.template, result, tc.expected)
+		}
+	}
+}
+
+func TestInterpolate_NowFormat(t *testing.T) {
+	vars := TemplateVars{
+		Now: func() time.Time { return time.Date(2025, 6, 15, 14, 30, 45, 0, time.UTC) },
+	}
+
+	result := Interpolate("{{now}}", vars, nil, nil)
+	// RFC3339 format
+	if result != "2025-06-15T14:30:45Z" {
+		t.Errorf("Interpolate({{now}}) = %q, want RFC3339 format", result)
+	}
+}
+
+func TestInterpolate_MixedTemplate(t *testing.T) {
+	vars := TemplateVars{
+		Now: func() time.Time { return time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC) },
+		User: UserVars{
+			Name: "Alice",
+		},
+	}
+
+	entity := model.NewEntity("T-001", "ticket")
+	entity.Properties["title"] = "Fix bug"
+
+	template := "{{entity.id}}: {{new.title}} - assigned to {{user.name}} on {{today}}"
+	expected := "T-001: Fix bug - assigned to Alice on 2025-01-15"
+
+	result := Interpolate(template, vars, entity, nil)
+	if result != expected {
+		t.Errorf("Interpolate(%q) = %q, want %q", template, result, expected)
+	}
+}

--- a/internal/automation/types.go
+++ b/internal/automation/types.go
@@ -1,0 +1,121 @@
+// Package automation provides a trigger-action engine for entity lifecycle events.
+// It enables automatic property updates, validation warnings, and relation creation
+// when entities change.
+package automation
+
+import (
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+// Automation defines a trigger-action rule (internal representation).
+type Automation struct {
+	Name        string
+	Description string
+	On          Trigger
+	Do          []Action
+	Validate    []Validation
+}
+
+// Trigger specifies conditions that activate an automation.
+type Trigger struct {
+	Entity          []string
+	Property        string
+	Becomes         string
+	From            string
+	Created         bool
+	RelationCreated string
+	RelationRemoved string
+}
+
+// Action specifies an operation to perform.
+type Action struct {
+	Set            string
+	Value          string
+	CreateRelation *CreateRelationAction
+}
+
+// CreateRelationAction specifies parameters for creating a relation.
+type CreateRelationAction struct {
+	Relation string
+	To       string
+}
+
+// Validation specifies a condition to check.
+type Validation struct {
+	Check    string
+	Severity string
+	Message  string
+}
+
+// GetSeverity returns the severity, defaulting to "warning".
+func (v *Validation) GetSeverity() string {
+	if v.Severity == "" {
+		return "warning"
+	}
+	return v.Severity
+}
+
+// Event represents a change that occurred to an entity or relation.
+type Event struct {
+	// Type is the type of event.
+	Type EventType
+
+	// Entity is the affected entity.
+	Entity *model.Entity
+
+	// OldEntity is the previous state (nil for Created events).
+	OldEntity *model.Entity
+
+	// Relation is the affected relation (for RelationCreated/RelationRemoved events).
+	Relation *model.Relation
+}
+
+// EventType identifies the kind of change.
+type EventType int
+
+const (
+	// EventEntityCreated fires when a new entity is created.
+	EventEntityCreated EventType = iota
+
+	// EventEntityUpdated fires when an entity's properties change.
+	EventEntityUpdated
+
+	// EventRelationCreated fires when a new relation is created.
+	EventRelationCreated
+
+	// EventRelationRemoved fires when a relation is removed.
+	EventRelationRemoved
+)
+
+// Result represents the outcome of running automations.
+type Result struct {
+	// PropertiesSet contains properties that were automatically set.
+	PropertiesSet map[string]string
+
+	// RelationsToCreate contains relations that should be created.
+	RelationsToCreate []*model.Relation
+
+	// Warnings contains validation warnings (allow save, show message).
+	Warnings []string
+
+	// Errors contains validation errors (should block save in strict mode).
+	Errors []string
+}
+
+// HasWarnings returns true if there are any warnings.
+func (r *Result) HasWarnings() bool {
+	return len(r.Warnings) > 0
+}
+
+// HasErrors returns true if there are any errors.
+func (r *Result) HasErrors() bool {
+	return len(r.Errors) > 0
+}
+
+// AllMessages returns all warnings and errors combined.
+func (r *Result) AllMessages() []string {
+	msgs := make([]string, 0, len(r.Warnings)+len(r.Errors))
+	msgs = append(msgs, r.Errors...)
+	msgs = append(msgs, r.Warnings...)
+	return msgs
+}

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Sourcehaven-BV/rela/internal/automation"
 	"github.com/Sourcehaven-BV/rela/internal/markdown"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
@@ -141,6 +142,30 @@ Examples:
 			entity.Content = bodyContent
 		}
 
+		// Process automations (entity created event)
+		var autoResult *automation.Result
+		if automationEngine != nil {
+			autoResult = automationEngine.Process(automation.Event{
+				Type:   automation.EventEntityCreated,
+				Entity: entity,
+			})
+
+			// Apply property changes from automations
+			for prop, val := range autoResult.PropertiesSet {
+				entity.SetString(prop, val)
+			}
+
+			// Show warnings (but continue - CLI doesn't block for warnings)
+			for _, warning := range autoResult.Warnings {
+				out.WriteWarning("Automation: %s", warning)
+			}
+
+			// Show errors (but continue - they're not fatal)
+			for _, errMsg := range autoResult.Errors {
+				out.WriteWarning("Automation error: %s", errMsg)
+			}
+		}
+
 		// Validate entity
 		errs := meta.ValidateEntity(entity)
 		if len(errs) > 0 {
@@ -158,6 +183,20 @@ Examples:
 
 		// Add to graph
 		g.AddNode(entity)
+
+		// Create any relations from automations
+		if autoResult != nil && len(autoResult.RelationsToCreate) > 0 {
+			for _, rel := range autoResult.RelationsToCreate {
+				// Update the From field to use the actual entity ID
+				rel.From = entity.ID
+				if err := repo.WriteRelation(rel); err != nil {
+					out.WriteWarning("Failed to create automation relation: %v", err)
+				} else {
+					g.AddEdge(rel)
+					out.WriteInfo("Automation created relation: %s --%s--> %s", rel.From, rel.Type, rel.To)
+				}
+			}
+		}
 
 		// Save cache
 		if err := saveCache(); err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Sourcehaven-BV/rela/internal/automation"
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/output"
@@ -26,12 +27,13 @@ var (
 	projectPath  string
 
 	// Shared state
-	projectCtx *project.Context
-	meta       *metamodel.Metamodel
-	g          *graph.Graph
-	out        *output.Writer
-	cliFS      storage.FS = storage.NewSafeFS(storage.NewOsFS())
-	repo       repository.Store
+	projectCtx       *project.Context
+	meta             *metamodel.Metamodel
+	g                *graph.Graph
+	out              *output.Writer
+	cliFS            storage.FS = storage.NewSafeFS(storage.NewOsFS())
+	repo             repository.Store
+	automationEngine *automation.Engine
 )
 
 // rootCmd represents the base command
@@ -78,6 +80,9 @@ and maintain semantic relationships between them.`,
 		if err != nil {
 			return fmt.Errorf("failed to load metamodel: %w", err)
 		}
+
+		// Initialize automation engine
+		automationEngine = automation.NewEngineFromMetamodel(meta.Automations)
 
 		// Initialize graph
 		g = graph.New()

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/Sourcehaven-BV/rela/internal/automation"
 )
 
 var (
@@ -45,6 +47,9 @@ Examples:
 		if !ok {
 			return &entityNotFoundError{ID: entityID}
 		}
+
+		// Capture old state for automation property change detection
+		oldEntity := entity.Clone()
 
 		// Track if anything changed
 		changed := false
@@ -93,6 +98,31 @@ Examples:
 			return fmt.Errorf("no updates specified")
 		}
 
+		// Process automations (entity updated event)
+		var autoResult *automation.Result
+		if automationEngine != nil {
+			autoResult = automationEngine.Process(automation.Event{
+				Type:      automation.EventEntityUpdated,
+				Entity:    entity,
+				OldEntity: oldEntity,
+			})
+
+			// Apply property changes from automations
+			for prop, val := range autoResult.PropertiesSet {
+				entity.SetString(prop, val)
+			}
+
+			// Show warnings (but continue - CLI doesn't block for warnings)
+			for _, warning := range autoResult.Warnings {
+				out.WriteWarning("Automation: %s", warning)
+			}
+
+			// Show errors (but continue - they're not fatal)
+			for _, errMsg := range autoResult.Errors {
+				out.WriteWarning("Automation error: %s", errMsg)
+			}
+		}
+
 		// Validate entity
 		errs := meta.ValidateEntity(entity)
 		if len(errs) > 0 {
@@ -106,6 +136,20 @@ Examples:
 
 		// Update in graph
 		g.AddNode(entity)
+
+		// Create any relations from automations
+		if autoResult != nil && len(autoResult.RelationsToCreate) > 0 {
+			for _, rel := range autoResult.RelationsToCreate {
+				// Ensure From field uses the entity ID
+				rel.From = entity.ID
+				if err := repo.WriteRelation(rel); err != nil {
+					out.WriteWarning("Failed to create automation relation: %v", err)
+				} else {
+					g.AddEdge(rel)
+					out.WriteInfo("Automation created relation: %s --%s--> %s", rel.From, rel.Type, rel.To)
+				}
+			}
+		}
 
 		// Save cache
 		if err := saveCache(); err != nil {

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -13,6 +13,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/Sourcehaven-BV/rela/internal/automation"
 	"github.com/Sourcehaven-BV/rela/internal/git"
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/markdown"
@@ -47,6 +48,8 @@ type App struct {
 	userDefaults *UserDefaults
 	// gitOps provides git operations when git is enabled.
 	gitOps *git.Ops
+	// automationEngine processes automation rules.
+	automationEngine *automation.Engine
 	// mu protects reloadable state (Cfg, meta, g, tmpl, styleMap, styledTypes)
 	// during live-reload. Handlers acquire RLock; reload acquires Lock.
 	mu sync.RWMutex
@@ -108,14 +111,15 @@ func NewApp(repo repository.Store) (*App, error) {
 		return nil, fmt.Errorf("parsing graph templates: %w", err)
 	}
 	app := &App{
-		Cfg:         &cfg,
-		meta:        meta,
-		g:           g,
-		repo:        repo,
-		tmpl:        tmpl,
-		styleMap:    styleMap,
-		styledTypes: styledTypes,
-		broker:      newEventBroker(),
+		Cfg:              &cfg,
+		meta:             meta,
+		g:                g,
+		repo:             repo,
+		tmpl:             tmpl,
+		styleMap:         styleMap,
+		styledTypes:      styledTypes,
+		automationEngine: automation.NewEngineFromMetamodel(meta.Automations),
+		broker:           newEventBroker(),
 	}
 	app.userDefaults = app.loadUserDefaults()
 

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -20,6 +20,7 @@ var validTopLevelKeys = map[string]bool{
 	"entities":    true,
 	"relations":   true,
 	"validations": true,
+	"automations": true,
 	"includes":    true,
 }
 

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -11,6 +11,7 @@ type Metamodel struct {
 	Entities    map[string]EntityDef   `yaml:"entities"`
 	Relations   map[string]RelationDef `yaml:"relations"`
 	Validations []ValidationRule       `yaml:"validations,omitempty"`
+	Automations []AutomationDef        `yaml:"automations,omitempty"`
 
 	// Computed lookups (not from YAML)
 	aliasMap map[string]string // alias -> canonical name
@@ -228,5 +229,65 @@ func (i *InverseDef) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	*i = InverseDef(objectForm)
+	return nil
+}
+
+// AutomationDef defines a trigger-action automation rule.
+type AutomationDef struct {
+	Name        string             `yaml:"name"`
+	Description string             `yaml:"description,omitempty"`
+	On          AutomationTrigger  `yaml:"on"`
+	Do          []AutomationAction `yaml:"do,omitempty"`
+	Validate    []AutomationCheck  `yaml:"validate,omitempty"`
+}
+
+// AutomationTrigger specifies conditions that activate an automation.
+type AutomationTrigger struct {
+	Entity          StringOrSlice `yaml:"entity,omitempty"`
+	Property        string        `yaml:"property,omitempty"`
+	Becomes         string        `yaml:"becomes,omitempty"`
+	From            string        `yaml:"from,omitempty"`
+	Created         bool          `yaml:"created,omitempty"`
+	RelationCreated string        `yaml:"relation_created,omitempty"`
+	RelationRemoved string        `yaml:"relation_removed,omitempty"`
+}
+
+// AutomationAction specifies an operation to perform.
+type AutomationAction struct {
+	Set            string                `yaml:"set,omitempty"`
+	Value          string                `yaml:"value,omitempty"`
+	CreateRelation *CreateRelationAction `yaml:"create_relation,omitempty"`
+}
+
+// CreateRelationAction specifies parameters for creating a relation.
+type CreateRelationAction struct {
+	Relation string `yaml:"relation"`
+	To       string `yaml:"to"`
+}
+
+// AutomationCheck specifies a validation condition.
+type AutomationCheck struct {
+	Check    string `yaml:"check"`
+	Severity string `yaml:"severity,omitempty"`
+	Message  string `yaml:"message"`
+}
+
+// StringOrSlice is a YAML type that can be unmarshaled from either a string or []string.
+type StringOrSlice []string
+
+// UnmarshalYAML allows StringOrSlice to be unmarshaled from either a string or a slice.
+func (s *StringOrSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// Try string first
+	var single string
+	if err := unmarshal(&single); err == nil {
+		*s = []string{single}
+		return nil
+	}
+	// Try slice
+	var slice []string
+	if err := unmarshal(&slice); err != nil {
+		return err
+	}
+	*s = slice
 	return nil
 }

--- a/internal/model/entity.go
+++ b/internal/model/entity.go
@@ -108,3 +108,19 @@ func NewRelation(from, relationType, to string) *Relation {
 func (r *Relation) Key() string {
 	return r.From + "--" + r.Type + "--" + r.To
 }
+
+// Clone returns a deep copy of the entity.
+func (e *Entity) Clone() *Entity {
+	clone := &Entity{
+		ID:         e.ID,
+		Type:       e.Type,
+		Content:    e.Content,
+		FilePath:   e.FilePath,
+		ModTime:    e.ModTime,
+		Properties: make(map[string]interface{}, len(e.Properties)),
+	}
+	for k, v := range e.Properties {
+		clone.Properties[k] = v
+	}
+	return clone
+}

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -709,6 +709,34 @@ func TestGenerateShortID_CollisionAvoidance(t *testing.T) {
 	}
 }
 
+// TestEntityClone tests the Clone method
+func TestEntityClone(t *testing.T) {
+	original := NewEntity("REQ-001", "requirement")
+	original.SetString("title", "Original Title")
+	original.SetString("status", "accepted")
+	original.Content = "Original content"
+	original.FilePath = "/path/to/file.md"
+
+	clone := original.Clone()
+
+	// Verify clone has same values
+	assertEqual(t, clone.ID, original.ID)
+	assertEqual(t, clone.Type, original.Type)
+	assertEqual(t, clone.Content, original.Content)
+	assertEqual(t, clone.FilePath, original.FilePath)
+	assertEqual(t, clone.GetString("title"), "Original Title")
+	assertEqual(t, clone.GetString("status"), "accepted")
+
+	// Verify clone has independent properties map
+	clone.SetString("title", "Modified Title")
+	assertEqual(t, original.GetString("title"), "Original Title")
+	assertEqual(t, clone.GetString("title"), "Modified Title")
+
+	// Verify modifying original doesn't affect clone
+	original.SetString("status", "rejected")
+	assertEqual(t, clone.GetString("status"), "accepted")
+}
+
 // TestCalculateIDLength tests the ID length calculation
 func TestCalculateIDLength(t *testing.T) {
 	tests := []struct {

--- a/tickets/entities/features/FEAT-013.md
+++ b/tickets/entities/features/FEAT-013.md
@@ -1,7 +1,6 @@
 ---
-description: Add file attachment support with content-addressable storage and asset manager UI
 id: FEAT-013
-status: implemented
-title: File attachment support
+status: proposed
+title: Automation engine for entity lifecycle events
 type: feature
 ---

--- a/tickets/entities/tickets/TKT-008.md
+++ b/tickets/entities/tickets/TKT-008.md
@@ -1,0 +1,8 @@
+---
+description: 'Implements automation engine for entity lifecycle events: property change triggers, validation rules, and automatic property setting.'
+id: TKT-008
+kind: feature
+status: done
+title: Implement automation engine
+type: ticket
+---

--- a/tickets/relations/TKT-008--implements--FEAT-013.md
+++ b/tickets/relations/TKT-008--implements--FEAT-013.md
@@ -1,0 +1,5 @@
+---
+from: TKT-008
+relation: implements
+to: FEAT-013
+---


### PR DESCRIPTION
## Summary
- Adds automation engine with trigger-action pattern for entity lifecycle events
- Supports events: entity created/updated, relation created/removed
- Template variables: `{{today}}`, `{{now}}`, `{{user.name}}`, `{{entity.id}}`, `{{old.prop}}`, `{{new.prop}}`
- Integrates with CLI (create, update commands) and data entry app

## Test plan
- [x] Unit tests for automation engine
- [x] Unit tests for template interpolation
- [ ] Manual testing with example automations in metamodel