### PR TITLE
Add entity ID rename with transactional guarantees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ relations/*.md → Relation ↗      ↓
 The `rela mcp` command starts a Model Context Protocol server over stdio, exposing rela's
 capabilities to AI assistants (Claude Code, Cursor, etc.):
 
-- **22 tools**: Entity/relation CRUD, graph tracing, analysis, schema introspection, export
+- **23 tools**: Entity/relation CRUD, graph tracing, analysis, schema introspection, export
 - **3 resources**: `rela://metamodel`, `rela://entity/{type}/{id}`, `rela://relation/{from}/{type}/{to}`
 - **4 prompts**: `analyze-traceability`, `review-orphans`, `summarize-project`, `review-entity`
 - **File watcher**: Watches entities/, relations/, and metamodel.yaml with 200ms debounce

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -12,6 +12,7 @@ import (
 var (
 	gcDryRun      bool
 	gcAttachments bool
+	gcTempFiles   bool
 )
 
 var gcCmd = &cobra.Command{
@@ -19,19 +20,29 @@ var gcCmd = &cobra.Command{
 	Short: "Garbage collect unreferenced files",
 	Long: `Remove unreferenced files from the project.
 
-Currently supports cleaning up attachments that are no longer referenced
-by any entity.
+Supports cleaning up:
+  --attachments  Remove attachment files no longer referenced by entities
+  --temp-files   Remove orphaned .new files from interrupted transactions
 
 Examples:
   rela gc --attachments           # Remove unreferenced attachment files
+  rela gc --temp-files            # Remove orphaned temp files
   rela gc --attachments --dry-run # Show what would be removed`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if !gcAttachments {
-			return fmt.Errorf("specify --attachments to clean up attachment files")
+		if !gcAttachments && !gcTempFiles {
+			return fmt.Errorf("specify at least one of --attachments or --temp-files")
+		}
+
+		if gcTempFiles {
+			if err := gcOrphanedTempFiles(); err != nil {
+				return err
+			}
 		}
 
 		if gcAttachments {
-			return gcAttachmentFiles()
+			if err := gcAttachmentFiles(); err != nil {
+				return err
+			}
 		}
 
 		return nil
@@ -119,9 +130,38 @@ func extractAttachmentPaths(val interface{}) []string {
 	return nil
 }
 
+func gcOrphanedTempFiles() error {
+	orphaned, err := repo.FindOrphanedTempFiles()
+	if err != nil {
+		return fmt.Errorf("find orphaned files: %w", err)
+	}
+
+	if len(orphaned) == 0 {
+		out.WriteMessage("No orphaned temp files found")
+		return nil
+	}
+
+	if gcDryRun {
+		out.WriteMessage("Would remove %d orphaned temp file(s):", len(orphaned))
+		for _, path := range orphaned {
+			out.WriteMessage("  %s", path)
+		}
+		return nil
+	}
+
+	count, err := repo.CleanupOrphanedTempFiles()
+	if err != nil {
+		return fmt.Errorf("cleanup failed: %w", err)
+	}
+
+	out.WriteSuccess("Removed %d orphaned temp file(s)", count)
+	return nil
+}
+
 func init() {
 	gcCmd.Flags().BoolVar(&gcDryRun, "dry-run", false, "Show what would be removed without actually removing")
 	gcCmd.Flags().BoolVar(&gcAttachments, "attachments", false, "Clean up unreferenced attachment files")
+	gcCmd.Flags().BoolVar(&gcTempFiles, "temp-files", false, "Clean up orphaned .new files from interrupted transactions")
 
 	rootCmd.AddCommand(gcCmd)
 }

--- a/internal/cli/rename.go
+++ b/internal/cli/rename.go
@@ -11,11 +11,13 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/markdown"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/rename"
 )
 
 var (
-	renameForce  bool
-	renamePlural string
+	renameForce    bool
+	renamePlural   string
+	renameIDDryRun bool
 )
 
 var renameCmd = &cobra.Command{
@@ -223,10 +225,72 @@ func validateTypeName(name string) error {
 	return nil
 }
 
+var renameIDCmd = &cobra.Command{
+	Use:   "id <old-id> <new-id>",
+	Short: "Rename an entity's ID",
+	Long: `Renames an entity's ID and updates all relations that reference it.
+
+This updates:
+  - The entity file (renamed and id field updated)
+  - All relation files where this entity is the 'from' or 'to' endpoint
+
+Examples:
+  rela rename id REQ-001 REQ-100
+  rela rename id REQ-001 REQ-100 --dry-run`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runRenameID(args[0], args[1])
+	},
+}
+
+func runRenameID(oldID, newID string) error {
+	// Get entity to find type
+	entity, ok := g.GetNode(oldID)
+	if !ok {
+		return fmt.Errorf("entity not found: %s", oldID)
+	}
+
+	result, err := rename.Rename(repo, meta, g, entity.Type, oldID, newID, rename.Options{DryRun: renameIDDryRun})
+	if err != nil {
+		return err
+	}
+
+	if renameIDDryRun {
+		out.WriteMessage("Dry run - no changes made")
+		out.WriteMessage("")
+	}
+
+	out.WriteMessage("Rename: %s → %s", result.OldID, result.NewID)
+	out.WriteMessage("Entity file: %s", result.EntityFile)
+
+	if len(result.RelationsUpdated) > 0 {
+		out.WriteMessage("\nRelations updated (%d):", len(result.RelationsUpdated))
+		for _, rel := range result.RelationsUpdated {
+			out.WriteMessage("  %s --%s--> %s", rel.From, rel.Type, rel.To)
+		}
+	} else {
+		out.WriteMessage("\nNo relations updated")
+	}
+
+	if !renameIDDryRun {
+		if saveErr := saveCache(); saveErr != nil {
+			out.WriteWarning("Failed to save cache: %v", saveErr)
+		}
+		if len(result.OldFilesDeleted) > 0 {
+			out.WriteMessage("\nOld files deleted (%d)", len(result.OldFilesDeleted))
+		}
+	}
+
+	return nil
+}
+
 func init() {
 	renameEntityCmd.Flags().BoolVarP(&renameForce, "force", "f", false, "Skip confirmation prompt")
 	renameEntityCmd.Flags().StringVar(&renamePlural, "plural", "", "Override plural form for directory name")
 
+	renameIDCmd.Flags().BoolVar(&renameIDDryRun, "dry-run", false, "Preview changes without applying")
+
 	renameCmd.AddCommand(renameEntityCmd)
+	renameCmd.AddCommand(renameIDCmd)
 	rootCmd.AddCommand(renameCmd)
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -12,6 +12,7 @@ func (s *Server) registerTools() {
 	s.mcp.AddTool(toolCreateEntity(), s.handleCreateEntity)
 	s.mcp.AddTool(toolUpdateEntity(), s.handleUpdateEntity)
 	s.mcp.AddTool(toolDeleteEntity(), s.handleDeleteEntity)
+	s.mcp.AddTool(toolRenameEntity(), s.handleRenameEntity)
 
 	// Relation tools
 	s.mcp.AddTool(toolListRelations(), s.handleListRelations)
@@ -96,6 +97,15 @@ func toolDeleteEntity() mcp.Tool {
 		mcp.WithDescription("Delete an entity and optionally its relations"),
 		mcp.WithString("id", mcp.Required(), mcp.Description("Entity ID to delete")),
 		mcp.WithBoolean("cascade", mcp.Description("Also delete all relations (default false)")),
+	)
+}
+
+func toolRenameEntity() mcp.Tool {
+	return mcp.NewTool("rename_entity",
+		mcp.WithDescription("Rename an entity's ID, updating all relations that reference it"),
+		mcp.WithString("id", mcp.Required(), mcp.Description("Current entity ID")),
+		mcp.WithString("new_id", mcp.Required(), mcp.Description("New entity ID")),
+		mcp.WithBoolean("dry_run", mcp.Description("Preview changes without applying (default false)")),
 	)
 }
 

--- a/internal/mcp/tools_entity.go
+++ b/internal/mcp/tools_entity.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/markdown"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/rename"
 )
 
 func (s *Server) handleListEntities(
@@ -321,4 +322,72 @@ func (s *Server) handleDeleteEntity(
 		msg += fmt.Sprintf(" and %d relation(s)", totalRelations)
 	}
 	return mcp.NewToolResultText(msg), nil
+}
+
+func (s *Server) handleRenameEntity(
+	_ context.Context, request mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	oldID, err := request.RequireString("id")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	oldID = trimID(oldID)
+
+	newID, err := request.RequireString("new_id")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	newID = trimID(newID)
+
+	dryRun := request.GetBool("dry_run", false)
+
+	// Get entity to find type
+	entity, ok := s.graph.GetNode(oldID)
+	if !ok {
+		return mcp.NewToolResultError(fmt.Sprintf("entity not found: %s", oldID)), nil
+	}
+
+	// Pause watcher during rename
+	if s.watcher != nil {
+		s.watcher.Pause()
+		defer s.watcher.Resume()
+	}
+
+	opts := rename.Options{DryRun: dryRun}
+	result, renameErr := rename.Rename(s.repo, s.getMeta(), s.graph, entity.Type, oldID, newID, opts)
+	if renameErr != nil {
+		return mcp.NewToolResultError(renameErr.Error()), nil
+	}
+
+	if !dryRun {
+		s.saveCache()
+	}
+
+	return mcp.NewToolResultText(formatRenameResult(result, dryRun)), nil
+}
+
+func formatRenameResult(result *rename.Result, dryRun bool) string {
+	var sb strings.Builder
+
+	if dryRun {
+		sb.WriteString("Dry run - no changes made\n\n")
+	}
+
+	sb.WriteString(fmt.Sprintf("Rename: %s → %s\n", result.OldID, result.NewID))
+	sb.WriteString(fmt.Sprintf("Entity file: %s\n", result.EntityFile))
+
+	if len(result.RelationsUpdated) > 0 {
+		sb.WriteString(fmt.Sprintf("\nRelations updated (%d):\n", len(result.RelationsUpdated)))
+		for _, rel := range result.RelationsUpdated {
+			sb.WriteString(fmt.Sprintf("  %s --%s--> %s\n", rel.From, rel.Type, rel.To))
+		}
+	} else {
+		sb.WriteString("\nNo relations updated\n")
+	}
+
+	if !dryRun && len(result.OldFilesDeleted) > 0 {
+		sb.WriteString(fmt.Sprintf("\nOld files deleted (%d)\n", len(result.OldFilesDeleted)))
+	}
+
+	return sb.String()
 }

--- a/internal/mcp/watcher.go
+++ b/internal/mcp/watcher.go
@@ -12,7 +12,7 @@ import (
 // Watcher watches entity and relation files for changes and notifies MCP clients.
 type Watcher struct {
 	server *Server
-	stop   func()
+	handle *repository.WatchHandle
 }
 
 // NewWatcher creates a new file watcher for the rela project using the
@@ -20,7 +20,7 @@ type Watcher struct {
 func NewWatcher(s *Server) (*Watcher, error) {
 	w := &Watcher{server: s}
 
-	stop, err := s.repo.Watch(repository.WatchOptions{}, func(events []model.ChangeEvent) {
+	handle, err := s.repo.WatchWithHandle(repository.WatchOptions{}, func(events []model.ChangeEvent) {
 		for _, e := range events {
 			s.logger.Printf("File changed: %s (%s)", e.Path, e.Op)
 		}
@@ -30,13 +30,24 @@ func NewWatcher(s *Server) (*Watcher, error) {
 		return nil, err
 	}
 
-	w.stop = stop
+	w.handle = handle
 	return w, nil
 }
 
 // Stop stops the file watcher.
 func (w *Watcher) Stop() {
-	w.stop()
+	w.handle.Stop()
+}
+
+// Pause temporarily stops processing file change events.
+// Events that occur while paused are discarded.
+func (w *Watcher) Pause() {
+	w.handle.Pause()
+}
+
+// Resume re-enables event processing after a Pause.
+func (w *Watcher) Resume() {
+	w.handle.Resume()
 }
 
 func (w *Watcher) syncAndNotify() {

--- a/internal/rename/rename.go
+++ b/internal/rename/rename.go
@@ -1,0 +1,279 @@
+package rename
+
+import (
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/graph"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
+)
+
+// Options configures the rename operation.
+type Options struct {
+	DryRun bool // If true, return what would change without making changes
+}
+
+// RelationRef identifies a relation by its three-part key.
+type RelationRef struct {
+	From string `json:"from"`
+	Type string `json:"type"`
+	To   string `json:"to"`
+}
+
+// Result contains the outcome of a rename operation.
+type Result struct {
+	OldID            string
+	NewID            string
+	EntityType       string
+	EntityFile       string        // Path to new entity file
+	RelationsUpdated []RelationRef // Relations that were updated
+	OldFilesDeleted  []string      // Files that were deleted
+}
+
+// Store defines the repository operations needed for rename.
+type Store interface {
+	EntityFilePath(entityType, id string, meta *metamodel.Metamodel) string
+	Paths() *project.Context
+	Transaction(fn func(tx repository.Tx) error) error
+}
+
+// Rename performs a staged entity ID rename with transaction tracking.
+// It updates the entity file and all relations referencing the old ID.
+func Rename(
+	repo Store,
+	meta *metamodel.Metamodel,
+	g *graph.Graph,
+	entityType, oldID, newID string,
+	opts Options,
+) (*Result, error) {
+	// 1. Validate inputs
+	if err := validate(g, oldID, newID); err != nil {
+		return nil, err
+	}
+
+	// 2. Get the entity
+	entity, ok := g.GetNode(oldID)
+	if !ok {
+		return nil, fmt.Errorf("entity not found: %s", oldID)
+	}
+	if entity.Type != entityType {
+		return nil, fmt.Errorf("entity %s has type %s, not %s", oldID, entity.Type, entityType)
+	}
+
+	// 3. Collect affected relations
+	incoming := g.IncomingEdges(oldID)
+	outgoing := g.OutgoingEdges(oldID)
+
+	// 4. Build result for dry-run or actual execution
+	result := &Result{
+		OldID:            oldID,
+		NewID:            newID,
+		EntityType:       entityType,
+		EntityFile:       repo.EntityFilePath(entityType, newID, meta),
+		RelationsUpdated: make([]RelationRef, 0, len(incoming)+len(outgoing)),
+		OldFilesDeleted:  make([]string, 0),
+	}
+
+	// Collect relation refs
+	for _, rel := range outgoing {
+		result.RelationsUpdated = append(result.RelationsUpdated, RelationRef{
+			From: newID, // Will be renamed
+			Type: rel.Type,
+			To:   rel.To,
+		})
+	}
+	for _, rel := range incoming {
+		result.RelationsUpdated = append(result.RelationsUpdated, RelationRef{
+			From: rel.From,
+			Type: rel.Type,
+			To:   newID, // Will be renamed
+		})
+	}
+
+	// Collect files to delete
+	result.OldFilesDeleted = append(result.OldFilesDeleted, repo.EntityFilePath(entityType, oldID, meta))
+	for _, rel := range outgoing {
+		result.OldFilesDeleted = append(result.OldFilesDeleted,
+			repo.Paths().RelationFilePath(oldID, rel.Type, rel.To))
+	}
+	for _, rel := range incoming {
+		result.OldFilesDeleted = append(result.OldFilesDeleted,
+			repo.Paths().RelationFilePath(rel.From, rel.Type, oldID))
+	}
+
+	if opts.DryRun {
+		return result, nil
+	}
+
+	// 5. Execute the rename with transaction tracking
+	if err := executeRename(repo, meta, g, entity, oldID, newID, incoming, outgoing); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func validate(g *graph.Graph, oldID, newID string) error {
+	// Check old ID exists
+	if _, ok := g.GetNode(oldID); !ok {
+		return fmt.Errorf("entity not found: %s", oldID)
+	}
+
+	// Check new ID doesn't exist
+	if _, ok := g.GetNode(newID); ok {
+		return fmt.Errorf("entity with ID %s already exists", newID)
+	}
+
+	// Validate new ID format
+	if err := model.ValidateID(newID); err != nil {
+		return fmt.Errorf("invalid new ID: %w", err)
+	}
+
+	return nil
+}
+
+func executeRename(
+	repo Store,
+	meta *metamodel.Metamodel,
+	g *graph.Graph,
+	entity *model.Entity,
+	oldID, newID string,
+	incoming, outgoing []*model.Relation,
+) error {
+	err := repo.Transaction(func(tx repository.Tx) error {
+		// Write new entity file
+		newEntity := &model.Entity{
+			ID:         newID,
+			Type:       entity.Type,
+			Properties: entity.Properties,
+			Content:    entity.Content,
+		}
+		if writeErr := tx.WriteEntity(newEntity, meta); writeErr != nil {
+			return fmt.Errorf("write new entity: %w", writeErr)
+		}
+
+		// Write updated relations
+		if relErr := writeUpdatedRelations(tx, oldID, newID, incoming, outgoing); relErr != nil {
+			return relErr
+		}
+
+		// Delete old files
+		if delErr := tx.DeleteEntity(entity.Type, oldID, meta); delErr != nil {
+			return fmt.Errorf("delete old entity: %w", delErr)
+		}
+		for _, rel := range outgoing {
+			if delErr := tx.DeleteRelation(oldID, rel.Type, rel.To); delErr != nil {
+				return fmt.Errorf("delete old relation: %w", delErr)
+			}
+		}
+		for _, rel := range incoming {
+			if delErr := tx.DeleteRelation(rel.From, rel.Type, oldID); delErr != nil {
+				return fmt.Errorf("delete old relation: %w", delErr)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Update graph in-memory (only after successful commit)
+	updateGraph(g, entity, newID, incoming, outgoing)
+
+	return nil
+}
+
+func writeUpdatedRelations(tx repository.Tx, oldID, newID string, incoming, outgoing []*model.Relation) error {
+	// Update outgoing relations (from=oldID -> from=newID)
+	for _, rel := range outgoing {
+		newTo := rel.To
+		if rel.To == oldID { // Self-referential
+			newTo = newID
+		}
+		newRel := &model.Relation{
+			From: newID, Type: rel.Type, To: newTo,
+			Properties: rel.Properties, Content: rel.Content,
+		}
+		if err := tx.WriteRelation(newRel); err != nil {
+			return fmt.Errorf("write relation %s--%s-->%s: %w", newID, rel.Type, newTo, err)
+		}
+	}
+
+	// Update incoming relations (skip self-referential, already handled)
+	for _, rel := range incoming {
+		if rel.From == oldID {
+			continue
+		}
+		newRel := &model.Relation{
+			From: rel.From, Type: rel.Type, To: newID,
+			Properties: rel.Properties, Content: rel.Content,
+		}
+		if err := tx.WriteRelation(newRel); err != nil {
+			return fmt.Errorf("write relation %s--%s-->%s: %w", rel.From, rel.Type, newID, err)
+		}
+	}
+
+	return nil
+}
+
+func updateGraph(
+	g *graph.Graph,
+	entity *model.Entity,
+	newID string,
+	incoming, outgoing []*model.Relation,
+) {
+	oldID := entity.ID
+
+	// Remove old edges
+	for _, rel := range outgoing {
+		g.RemoveEdge(oldID, rel.Type, rel.To)
+	}
+	for _, rel := range incoming {
+		g.RemoveEdge(rel.From, rel.Type, oldID)
+	}
+
+	// Remove old node
+	g.RemoveNode(oldID)
+
+	// Add new node
+	newEntity := &model.Entity{
+		ID:         newID,
+		Type:       entity.Type,
+		Properties: entity.Properties,
+		Content:    entity.Content,
+		FilePath:   entity.FilePath, // Will be updated by WriteEntity
+	}
+	g.AddNode(newEntity)
+
+	// Add new edges
+	for _, rel := range outgoing {
+		// For self-referential relations, update both from and to
+		newTo := rel.To
+		if rel.To == oldID {
+			newTo = newID
+		}
+		g.AddEdge(&model.Relation{
+			From:       newID,
+			Type:       rel.Type,
+			To:         newTo,
+			Properties: rel.Properties,
+			Content:    rel.Content,
+		})
+	}
+	for _, rel := range incoming {
+		// Skip self-referential (already added in outgoing loop)
+		if rel.From == oldID {
+			continue
+		}
+		g.AddEdge(&model.Relation{
+			From:       rel.From,
+			Type:       rel.Type,
+			To:         newID,
+			Properties: rel.Properties,
+			Content:    rel.Content,
+		})
+	}
+}

--- a/internal/rename/rename_test.go
+++ b/internal/rename/rename_test.go
@@ -1,0 +1,512 @@
+package rename
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/graph"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+const testMetamodelYAML = `version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    plural: requirements
+    id_prefix: "REQ-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+        required: true
+      status:
+        type: string
+  decision:
+    label: Decision
+    plural: decisions
+    id_prefix: "DEC-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+        required: true
+relations:
+  addresses:
+    label: Addresses
+    from: [decision]
+    to: [requirement]
+  depends-on:
+    label: Depends On
+    from: [requirement]
+    to: [requirement]
+`
+
+func setupTestEnv(t *testing.T) (*repository.Repository, *metamodel.Metamodel, *graph.Graph, storage.FS) {
+	t.Helper()
+	fs := storage.NewMemFS()
+
+	root := "/project"
+	ctx := &project.Context{
+		Root:                 root,
+		MetamodelPath:        root + "/metamodel.yaml",
+		CacheDir:             root + "/.rela",
+		CachePath:            root + "/.rela/cache.json",
+		EntitiesDir:          root + "/entities",
+		RelationsDir:         root + "/relations",
+		TemplatesDir:         root + "/templates",
+		EntityTemplatesDir:   root + "/templates/entities",
+		RelationTemplatesDir: root + "/templates/relations",
+	}
+
+	// Create directory structure
+	_ = fs.MkdirAll(ctx.EntitiesDir+"/requirements", 0o755)
+	_ = fs.MkdirAll(ctx.EntitiesDir+"/decisions", 0o755)
+	_ = fs.MkdirAll(ctx.RelationsDir, 0o755)
+	_ = fs.MkdirAll(ctx.CacheDir, 0o755)
+
+	// Write metamodel file
+	_ = fs.WriteFile(ctx.MetamodelPath, []byte(testMetamodelYAML), 0o644)
+
+	meta, err := metamodel.Parse([]byte(testMetamodelYAML))
+	if err != nil {
+		t.Fatalf("failed to parse test metamodel: %v", err)
+	}
+
+	repo := repository.New(fs, ctx)
+	g := graph.New()
+
+	return repo, meta, g, fs
+}
+
+func TestRename_NoRelations(t *testing.T) {
+	repo, meta, g, _ := setupTestEnv(t)
+
+	// Create entity
+	entity := model.NewEntity("REQ-001", "requirement")
+	entity.SetString("title", "Test Requirement")
+	if err := repo.WriteEntity(entity, meta); err != nil {
+		t.Fatalf("WriteEntity() error = %v", err)
+	}
+	g.AddNode(entity)
+
+	// Rename
+	result, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-100", Options{})
+	if err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+
+	// Check result
+	if result.OldID != "REQ-001" {
+		t.Errorf("OldID = %q, want %q", result.OldID, "REQ-001")
+	}
+	if result.NewID != "REQ-100" {
+		t.Errorf("NewID = %q, want %q", result.NewID, "REQ-100")
+	}
+	if len(result.RelationsUpdated) != 0 {
+		t.Errorf("RelationsUpdated = %d, want 0", len(result.RelationsUpdated))
+	}
+
+	// Verify graph updated
+	if _, ok := g.GetNode("REQ-001"); ok {
+		t.Error("old ID should not exist in graph")
+	}
+	if _, ok := g.GetNode("REQ-100"); !ok {
+		t.Error("new ID should exist in graph")
+	}
+
+	// Verify files
+	if _, err := repo.ReadEntity("requirement", "REQ-100", meta); err != nil {
+		t.Errorf("new entity file should exist: %v", err)
+	}
+	if _, err := repo.ReadEntity("requirement", "REQ-001", meta); err == nil {
+		t.Error("old entity file should not exist")
+	}
+}
+
+func TestRename_OutgoingRelations(t *testing.T) {
+	repo, meta, g, _ := setupTestEnv(t)
+
+	// Create entities
+	req := model.NewEntity("REQ-001", "requirement")
+	req.SetString("title", "Requirement")
+	dec := model.NewEntity("DEC-001", "decision")
+	dec.SetString("title", "Decision")
+
+	if err := repo.WriteEntity(req, meta); err != nil {
+		t.Fatalf("WriteEntity(req) error = %v", err)
+	}
+	if err := repo.WriteEntity(dec, meta); err != nil {
+		t.Fatalf("WriteEntity(dec) error = %v", err)
+	}
+	g.AddNode(req)
+	g.AddNode(dec)
+
+	// Create outgoing relation from DEC-001
+	rel := model.NewRelation("DEC-001", "addresses", "REQ-001")
+	if err := repo.WriteRelation(rel); err != nil {
+		t.Fatalf("WriteRelation() error = %v", err)
+	}
+	g.AddEdge(rel)
+
+	// Rename DEC-001 -> DEC-100 (entity with outgoing relation)
+	result, err := Rename(repo, meta, g, "decision", "DEC-001", "DEC-100", Options{})
+	if err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+
+	// Check relations updated
+	if len(result.RelationsUpdated) != 1 {
+		t.Errorf("RelationsUpdated = %d, want 1", len(result.RelationsUpdated))
+	}
+
+	// Verify graph
+	outgoing := g.OutgoingEdges("DEC-100")
+	if len(outgoing) != 1 {
+		t.Fatalf("new entity should have 1 outgoing edge, got %d", len(outgoing))
+	}
+	if outgoing[0].From != "DEC-100" || outgoing[0].To != "REQ-001" {
+		t.Errorf("outgoing edge = %s -> %s, want DEC-100 -> REQ-001", outgoing[0].From, outgoing[0].To)
+	}
+
+	// Verify files
+	if _, err := repo.ReadRelation("DEC-100", "addresses", "REQ-001"); err != nil {
+		t.Errorf("new relation file should exist: %v", err)
+	}
+	if _, err := repo.ReadRelation("DEC-001", "addresses", "REQ-001"); err == nil {
+		t.Error("old relation file should not exist")
+	}
+}
+
+func TestRename_IncomingRelations(t *testing.T) {
+	repo, meta, g, _ := setupTestEnv(t)
+
+	// Create entities
+	req := model.NewEntity("REQ-001", "requirement")
+	req.SetString("title", "Requirement")
+	dec := model.NewEntity("DEC-001", "decision")
+	dec.SetString("title", "Decision")
+
+	if err := repo.WriteEntity(req, meta); err != nil {
+		t.Fatalf("WriteEntity(req) error = %v", err)
+	}
+	if err := repo.WriteEntity(dec, meta); err != nil {
+		t.Fatalf("WriteEntity(dec) error = %v", err)
+	}
+	g.AddNode(req)
+	g.AddNode(dec)
+
+	// Create relation to REQ-001
+	rel := model.NewRelation("DEC-001", "addresses", "REQ-001")
+	if err := repo.WriteRelation(rel); err != nil {
+		t.Fatalf("WriteRelation() error = %v", err)
+	}
+	g.AddEdge(rel)
+
+	// Rename REQ-001 -> REQ-100 (entity with incoming relation)
+	result, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-100", Options{})
+	if err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+
+	// Check relations updated
+	if len(result.RelationsUpdated) != 1 {
+		t.Errorf("RelationsUpdated = %d, want 1", len(result.RelationsUpdated))
+	}
+
+	// Verify graph
+	incoming := g.IncomingEdges("REQ-100")
+	if len(incoming) != 1 {
+		t.Fatalf("new entity should have 1 incoming edge, got %d", len(incoming))
+	}
+	if incoming[0].From != "DEC-001" || incoming[0].To != "REQ-100" {
+		t.Errorf("incoming edge = %s -> %s, want DEC-001 -> REQ-100", incoming[0].From, incoming[0].To)
+	}
+
+	// Verify files
+	if _, err := repo.ReadRelation("DEC-001", "addresses", "REQ-100"); err != nil {
+		t.Errorf("new relation file should exist: %v", err)
+	}
+	if _, err := repo.ReadRelation("DEC-001", "addresses", "REQ-001"); err == nil {
+		t.Error("old relation file should not exist")
+	}
+}
+
+func TestRename_BothIncomingAndOutgoing(t *testing.T) {
+	repo, meta, g, _ := setupTestEnv(t)
+
+	// Create entities: REQ-001, REQ-002, REQ-003
+	for _, id := range []string{"REQ-001", "REQ-002", "REQ-003"} {
+		e := model.NewEntity(id, "requirement")
+		e.SetString("title", "Requirement "+id)
+		if err := repo.WriteEntity(e, meta); err != nil {
+			t.Fatalf("WriteEntity(%s) error = %v", id, err)
+		}
+		g.AddNode(e)
+	}
+
+	// REQ-001 depends-on REQ-002 (outgoing from REQ-001)
+	rel1 := model.NewRelation("REQ-001", "depends-on", "REQ-002")
+	if err := repo.WriteRelation(rel1); err != nil {
+		t.Fatalf("WriteRelation(rel1) error = %v", err)
+	}
+	g.AddEdge(rel1)
+
+	// REQ-003 depends-on REQ-001 (incoming to REQ-001)
+	rel2 := model.NewRelation("REQ-003", "depends-on", "REQ-001")
+	if err := repo.WriteRelation(rel2); err != nil {
+		t.Fatalf("WriteRelation(rel2) error = %v", err)
+	}
+	g.AddEdge(rel2)
+
+	// Rename REQ-001 -> REQ-100
+	result, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-100", Options{})
+	if err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+
+	// Should have 2 relations updated
+	if len(result.RelationsUpdated) != 2 {
+		t.Errorf("RelationsUpdated = %d, want 2", len(result.RelationsUpdated))
+	}
+
+	// Verify graph edges
+	outgoing := g.OutgoingEdges("REQ-100")
+	if len(outgoing) != 1 || outgoing[0].To != "REQ-002" {
+		t.Error("REQ-100 should have outgoing edge to REQ-002")
+	}
+
+	incoming := g.IncomingEdges("REQ-100")
+	if len(incoming) != 1 || incoming[0].From != "REQ-003" {
+		t.Error("REQ-100 should have incoming edge from REQ-003")
+	}
+}
+
+func TestRename_SelfReferential(t *testing.T) {
+	repo, meta, g, _ := setupTestEnv(t)
+
+	// Create entity
+	req := model.NewEntity("REQ-001", "requirement")
+	req.SetString("title", "Self-referential")
+	if err := repo.WriteEntity(req, meta); err != nil {
+		t.Fatalf("WriteEntity() error = %v", err)
+	}
+	g.AddNode(req)
+
+	// Create self-referential relation
+	rel := model.NewRelation("REQ-001", "depends-on", "REQ-001")
+	if err := repo.WriteRelation(rel); err != nil {
+		t.Fatalf("WriteRelation() error = %v", err)
+	}
+	g.AddEdge(rel)
+
+	// Rename REQ-001 -> REQ-100
+	result, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-100", Options{})
+	if err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+
+	// Self-referential counts as 2 (incoming + outgoing)
+	if len(result.RelationsUpdated) != 2 {
+		t.Errorf("RelationsUpdated = %d, want 2", len(result.RelationsUpdated))
+	}
+
+	// Verify graph - self-referential edge should now be REQ-100 -> REQ-100
+	outgoing := g.OutgoingEdges("REQ-100")
+	if len(outgoing) != 1 {
+		t.Fatalf("should have 1 outgoing edge, got %d", len(outgoing))
+	}
+	if outgoing[0].From != "REQ-100" || outgoing[0].To != "REQ-100" {
+		t.Errorf("edge = %s -> %s, want REQ-100 -> REQ-100", outgoing[0].From, outgoing[0].To)
+	}
+}
+
+func TestRename_DryRun(t *testing.T) {
+	repo, meta, g, _ := setupTestEnv(t)
+
+	// Create entity with relation
+	req := model.NewEntity("REQ-001", "requirement")
+	req.SetString("title", "Requirement")
+	dec := model.NewEntity("DEC-001", "decision")
+	dec.SetString("title", "Decision")
+
+	if err := repo.WriteEntity(req, meta); err != nil {
+		t.Fatalf("WriteEntity(req) error = %v", err)
+	}
+	if err := repo.WriteEntity(dec, meta); err != nil {
+		t.Fatalf("WriteEntity(dec) error = %v", err)
+	}
+	g.AddNode(req)
+	g.AddNode(dec)
+
+	rel := model.NewRelation("DEC-001", "addresses", "REQ-001")
+	if err := repo.WriteRelation(rel); err != nil {
+		t.Fatalf("WriteRelation() error = %v", err)
+	}
+	g.AddEdge(rel)
+
+	// Dry run
+	result, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-100", Options{DryRun: true})
+	if err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+
+	// Result should show what would change
+	if result.NewID != "REQ-100" {
+		t.Errorf("NewID = %q, want %q", result.NewID, "REQ-100")
+	}
+	if len(result.RelationsUpdated) != 1 {
+		t.Errorf("RelationsUpdated = %d, want 1", len(result.RelationsUpdated))
+	}
+
+	// But nothing should have changed
+	if _, ok := g.GetNode("REQ-001"); !ok {
+		t.Error("old ID should still exist in graph (dry run)")
+	}
+	if _, ok := g.GetNode("REQ-100"); ok {
+		t.Error("new ID should not exist in graph (dry run)")
+	}
+
+	// Files unchanged
+	if _, readErr := repo.ReadEntity("requirement", "REQ-001", meta); readErr != nil {
+		t.Error("old entity file should still exist (dry run)")
+	}
+}
+
+func TestRename_ErrorNewIDExists(t *testing.T) {
+	repo, meta, g, _ := setupTestEnv(t)
+
+	// Create two entities
+	req1 := model.NewEntity("REQ-001", "requirement")
+	req1.SetString("title", "First")
+	req2 := model.NewEntity("REQ-002", "requirement")
+	req2.SetString("title", "Second")
+
+	if err := repo.WriteEntity(req1, meta); err != nil {
+		t.Fatalf("WriteEntity(req1) error = %v", err)
+	}
+	if err := repo.WriteEntity(req2, meta); err != nil {
+		t.Fatalf("WriteEntity(req2) error = %v", err)
+	}
+	g.AddNode(req1)
+	g.AddNode(req2)
+
+	// Try to rename REQ-001 to REQ-002 (already exists)
+	_, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-002", Options{})
+	if err == nil {
+		t.Fatal("Rename() should fail when new ID already exists")
+	}
+	if err.Error() != "entity with ID REQ-002 already exists" {
+		t.Errorf("error = %q, want 'entity with ID REQ-002 already exists'", err.Error())
+	}
+}
+
+func TestRename_ErrorOldIDNotFound(t *testing.T) {
+	repo, meta, g, _ := setupTestEnv(t)
+
+	// Try to rename non-existent entity
+	_, err := Rename(repo, meta, g, "requirement", "REQ-999", "REQ-100", Options{})
+	if err == nil {
+		t.Fatal("Rename() should fail when old ID doesn't exist")
+	}
+}
+
+func TestRename_ErrorInvalidNewID(t *testing.T) {
+	repo, meta, g, _ := setupTestEnv(t)
+
+	// Create entity
+	req := model.NewEntity("REQ-001", "requirement")
+	req.SetString("title", "Test")
+	if err := repo.WriteEntity(req, meta); err != nil {
+		t.Fatalf("WriteEntity() error = %v", err)
+	}
+	g.AddNode(req)
+
+	// Try to rename with invalid ID (path traversal)
+	_, err := Rename(repo, meta, g, "requirement", "REQ-001", "../evil", Options{})
+	if err == nil {
+		t.Fatal("Rename() should fail for invalid new ID")
+	}
+}
+
+func TestRename_ErrorTypeMismatch(t *testing.T) {
+	repo, meta, g, _ := setupTestEnv(t)
+
+	// Create entity
+	req := model.NewEntity("REQ-001", "requirement")
+	req.SetString("title", "Test")
+	if err := repo.WriteEntity(req, meta); err != nil {
+		t.Fatalf("WriteEntity() error = %v", err)
+	}
+	g.AddNode(req)
+
+	// Try to rename with wrong type
+	_, err := Rename(repo, meta, g, "decision", "REQ-001", "REQ-100", Options{})
+	if err == nil {
+		t.Fatal("Rename() should fail when entity type doesn't match")
+	}
+}
+
+func TestRename_PreservesContent(t *testing.T) {
+	repo, meta, g, _ := setupTestEnv(t)
+
+	// Create entity with content
+	req := model.NewEntity("REQ-001", "requirement")
+	req.SetString("title", "With Content")
+	req.SetString("status", "approved")
+	req.Content = "# Description\n\nThis is the detailed description.\n"
+	if err := repo.WriteEntity(req, meta); err != nil {
+		t.Fatalf("WriteEntity() error = %v", err)
+	}
+	g.AddNode(req)
+
+	// Rename
+	_, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-100", Options{})
+	if err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+
+	// Read back and verify content preserved
+	newEntity, err := repo.ReadEntity("requirement", "REQ-100", meta)
+	if err != nil {
+		t.Fatalf("ReadEntity() error = %v", err)
+	}
+
+	if newEntity.GetString("title") != "With Content" {
+		t.Errorf("title = %q, want %q", newEntity.GetString("title"), "With Content")
+	}
+	if newEntity.GetString("status") != "approved" {
+		t.Errorf("status = %q, want %q", newEntity.GetString("status"), "approved")
+	}
+	if newEntity.Content == "" {
+		t.Error("content should be preserved")
+	}
+}
+
+func TestRename_NoTempFilesLeft(t *testing.T) {
+	repo, meta, g, fs := setupTestEnv(t)
+
+	// Create entity
+	req := model.NewEntity("REQ-001", "requirement")
+	req.SetString("title", "Test")
+	if err := repo.WriteEntity(req, meta); err != nil {
+		t.Fatalf("WriteEntity() error = %v", err)
+	}
+	g.AddNode(req)
+
+	// Rename
+	_, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-100", Options{})
+	if err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+
+	// No .new temp files should be left behind
+	entries, _ := fs.ReadDir("/project/entities/requirements")
+	for _, entry := range entries {
+		if name := entry.Name(); len(name) > 4 && name[len(name)-4:] == ".new" {
+			t.Errorf("temp file should not exist: %s", name)
+		}
+	}
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -103,11 +103,29 @@ type Store interface {
 	// filesystem notifications, database triggers, polling, etc.
 	Watch(opts WatchOptions, onChange func(events []model.ChangeEvent)) (stop func(), err error)
 
+	// WatchWithHandle is like Watch but returns a WatchHandle that allows
+	// pausing and resuming the watcher in addition to stopping it.
+	WatchWithHandle(opts WatchOptions, onChange func(events []model.ChangeEvent)) (*WatchHandle, error)
+
 	// --- Filesystem Access ---
 
 	// FS returns the underlying filesystem for direct access when needed
 	// (e.g., for attachment storage that operates on raw files).
 	FS() storage.FS
+
+	// --- Transactions ---
+
+	// Transaction executes a function within a transaction context.
+	// All write/delete operations are batched and applied atomically.
+	// On error, all staged changes are rolled back.
+	Transaction(fn func(tx Tx) error) error
+
+	// FindOrphanedTempFiles scans for leftover .new files from interrupted transactions.
+	FindOrphanedTempFiles() ([]string, error)
+
+	// CleanupOrphanedTempFiles removes all orphaned .new temp files.
+	// Returns the number of files cleaned up.
+	CleanupOrphanedTempFiles() (int, error)
 }
 
 // WatchOptions configures optional parameters for Store.Watch.
@@ -317,12 +335,45 @@ func (r *Repository) DiscoverEntityTemplates(entityType string) ([]*markdown.Ent
 
 // --- Change Notification ---
 
+// WatchHandle provides control over an active file watcher.
+type WatchHandle struct {
+	watcher *storage.Watcher
+}
+
+// Stop stops the file watcher and releases resources.
+func (h *WatchHandle) Stop() {
+	h.watcher.Stop()
+}
+
+// Pause temporarily stops processing file change events.
+// Events that occur while paused are discarded.
+func (h *WatchHandle) Pause() {
+	h.watcher.Pause()
+}
+
+// Resume re-enables event processing after a Pause.
+func (h *WatchHandle) Resume() {
+	h.watcher.Resume()
+}
+
 // Watch starts watching for changes to entities, relations, metamodel, and
 // views files. The onChange callback is called with batched change events.
 // Returns a stop function to shut down the watcher.
 func (r *Repository) Watch(
 	opts WatchOptions, onChange func(events []model.ChangeEvent),
 ) (stop func(), err error) {
+	handle, err := r.WatchWithHandle(opts, onChange)
+	if err != nil {
+		return nil, err
+	}
+	return handle.Stop, nil
+}
+
+// WatchWithHandle is like Watch but returns a WatchHandle that allows
+// pausing and resuming the watcher in addition to stopping it.
+func (r *Repository) WatchWithHandle(
+	opts WatchOptions, onChange func(events []model.ChangeEvent),
+) (*WatchHandle, error) {
 	viewsPath := filepath.Join(r.paths.Root, "views.yaml")
 	files := []string{r.paths.MetamodelPath, viewsPath}
 	files = append(files, opts.ExtraFiles...)
@@ -340,7 +391,7 @@ func (r *Repository) Watch(
 	}
 
 	go w.Start()
-	return w.Stop, nil
+	return &WatchHandle{watcher: w}, nil
 }
 
 // --- Path Helpers ---

--- a/internal/repository/transaction.go
+++ b/internal/repository/transaction.go
@@ -1,0 +1,202 @@
+package repository
+
+import (
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+// Tx represents an active transaction that batches write operations.
+// All writes are staged to temporary files (.new suffix) and only
+// committed atomically when the transaction completes successfully.
+// On error, all staged files are cleaned up automatically.
+type Tx interface {
+	// WriteEntity stages an entity write. The actual file is written
+	// to a temporary location and renamed on commit.
+	WriteEntity(entity *model.Entity, meta *metamodel.Metamodel) error
+
+	// WriteRelation stages a relation write.
+	WriteRelation(relation *model.Relation) error
+
+	// DeleteEntity marks an entity for deletion. The file is removed on commit.
+	DeleteEntity(entityType, id string, meta *metamodel.Metamodel) error
+
+	// DeleteRelation marks a relation for deletion.
+	DeleteRelation(from, relType, to string) error
+}
+
+// Transaction executes a function within a transaction context.
+// All write/delete operations are batched and applied atomically.
+// On error, all staged changes are rolled back.
+func (r *Repository) Transaction(fn func(tx Tx) error) error {
+	tx := &transaction{
+		repo:          r,
+		stagedWrites:  make(map[string]string), // target -> temp path
+		stagedDeletes: make([]string, 0),
+	}
+
+	// Execute the user function
+	if err := fn(tx); err != nil {
+		tx.rollback()
+		return err
+	}
+
+	// Commit all staged operations
+	return tx.commit()
+}
+
+// transaction implements Tx with two-phase commit semantics.
+type transaction struct {
+	repo          *Repository
+	stagedWrites  map[string]string // target path -> temp path
+	stagedDeletes []string          // paths to delete on commit
+}
+
+func (tx *transaction) WriteEntity(entity *model.Entity, meta *metamodel.Metamodel) error {
+	filePath := tx.repo.EntityFilePath(entity.Type, entity.ID, meta)
+	if filePath == "" {
+		return fmt.Errorf("unknown entity type: %s", entity.Type)
+	}
+
+	tempPath := filePath + ".new"
+	entity.FilePath = filePath
+
+	if err := tx.repo.fio.WriteEntity(entity, tempPath); err != nil {
+		return fmt.Errorf("write staged entity: %w", err)
+	}
+
+	tx.stagedWrites[filePath] = tempPath
+	return nil
+}
+
+func (tx *transaction) WriteRelation(relation *model.Relation) error {
+	filePath := tx.repo.paths.RelationFilePath(relation.From, relation.Type, relation.To)
+	tempPath := filePath + ".new"
+	relation.FilePath = filePath
+
+	if err := tx.repo.fio.WriteRelation(relation, tempPath); err != nil {
+		return fmt.Errorf("write staged relation: %w", err)
+	}
+
+	tx.stagedWrites[filePath] = tempPath
+	return nil
+}
+
+func (tx *transaction) DeleteEntity(entityType, id string, meta *metamodel.Metamodel) error {
+	filePath := tx.repo.EntityFilePath(entityType, id, meta)
+	if filePath == "" {
+		return fmt.Errorf("unknown entity type: %s", entityType)
+	}
+
+	tx.stagedDeletes = append(tx.stagedDeletes, filePath)
+	return nil
+}
+
+func (tx *transaction) DeleteRelation(from, relType, to string) error {
+	filePath := tx.repo.paths.RelationFilePath(from, relType, to)
+	tx.stagedDeletes = append(tx.stagedDeletes, filePath)
+	return nil
+}
+
+// commit applies all staged operations atomically.
+// First renames all temp files, then deletes marked files.
+func (tx *transaction) commit() error {
+	// Phase 1: Rename all staged writes
+	renamed := make([]string, 0, len(tx.stagedWrites))
+	for target, temp := range tx.stagedWrites {
+		if err := tx.repo.fs.Rename(temp, target); err != nil {
+			// Rollback already renamed files
+			tx.rollbackRenamed(renamed)
+			// Clean up remaining temp files
+			tx.rollback()
+			return fmt.Errorf("commit rename %s: %w", target, err)
+		}
+		renamed = append(renamed, target)
+	}
+
+	// Clear staged writes (they're committed now)
+	tx.stagedWrites = make(map[string]string)
+
+	// Phase 2: Delete marked files (best effort, ignore errors)
+	for _, path := range tx.stagedDeletes {
+		_ = tx.repo.fs.Remove(path)
+	}
+
+	return nil
+}
+
+// rollback removes all staged temporary files.
+func (tx *transaction) rollback() {
+	for _, temp := range tx.stagedWrites {
+		_ = tx.repo.fs.Remove(temp)
+	}
+	tx.stagedWrites = make(map[string]string)
+}
+
+// rollbackRenamed attempts to restore renamed files.
+// This is best-effort since we can't truly undo an atomic rename.
+func (tx *transaction) rollbackRenamed(renamed []string) {
+	// We can't truly rollback renames, but we can try to clean up
+	// by removing the target files that were just created.
+	// This leaves the system in an inconsistent state, but that's
+	// the nature of two-phase commit without a true transaction log.
+	for _, target := range renamed {
+		_ = tx.repo.fs.Remove(target)
+	}
+}
+
+// FindOrphanedTempFiles scans for leftover .new files from interrupted transactions.
+// Returns a list of paths to orphaned temp files.
+func (r *Repository) FindOrphanedTempFiles() ([]string, error) {
+	var orphaned []string
+
+	// Check entities directory
+	entityOrphans := r.findTempFilesInDir(r.paths.EntitiesDir)
+	orphaned = append(orphaned, entityOrphans...)
+
+	// Check relations directory
+	relationOrphans := r.findTempFilesInDir(r.paths.RelationsDir)
+	orphaned = append(orphaned, relationOrphans...)
+
+	return orphaned, nil
+}
+
+// CleanupOrphanedTempFiles removes all orphaned .new temp files.
+func (r *Repository) CleanupOrphanedTempFiles() (int, error) {
+	orphaned, err := r.FindOrphanedTempFiles()
+	if err != nil {
+		return 0, err
+	}
+
+	for _, path := range orphaned {
+		if removeErr := r.fs.Remove(path); removeErr != nil {
+			return 0, fmt.Errorf("remove %s: %w", path, removeErr)
+		}
+	}
+
+	return len(orphaned), nil
+}
+
+func (r *Repository) findTempFilesInDir(dir string) []string {
+	var result []string
+
+	entries, err := r.fs.ReadDir(dir)
+	if err != nil {
+		return nil // Directory might not exist, that's fine
+	}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		path := dir + "/" + name
+
+		if entry.IsDir() {
+			// Recurse into subdirectories (e.g., entities/tasks/)
+			result = append(result, r.findTempFilesInDir(path)...)
+		} else if len(name) > 4 && name[len(name)-4:] == ".new" {
+			result = append(result, path)
+		}
+	}
+
+	return result
+}

--- a/internal/repository/transaction_test.go
+++ b/internal/repository/transaction_test.go
@@ -1,0 +1,263 @@
+package repository
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+const txTestMetamodelYAML = `version: "1.0"
+entities:
+  task:
+    label: Task
+    plural: tasks
+    id_prefix: "TASK-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+        required: true
+relations:
+  depends-on:
+    label: Depends On
+    from: [task]
+    to: [task]
+`
+
+func setupTxTestEnv(t *testing.T) (*Repository, *metamodel.Metamodel, storage.FS) {
+	t.Helper()
+	fs := storage.NewMemFS()
+
+	root := "/project"
+	ctx := &project.Context{
+		Root:                 root,
+		MetamodelPath:        root + "/metamodel.yaml",
+		CacheDir:             root + "/.rela",
+		CachePath:            root + "/.rela/cache.json",
+		EntitiesDir:          root + "/entities",
+		RelationsDir:         root + "/relations",
+		TemplatesDir:         root + "/templates",
+		EntityTemplatesDir:   root + "/templates/entities",
+		RelationTemplatesDir: root + "/templates/relations",
+	}
+
+	_ = fs.MkdirAll(ctx.EntitiesDir+"/tasks", 0o755)
+	_ = fs.MkdirAll(ctx.RelationsDir, 0o755)
+	_ = fs.MkdirAll(ctx.CacheDir, 0o755)
+	_ = fs.WriteFile(ctx.MetamodelPath, []byte(txTestMetamodelYAML), 0o644)
+
+	meta, err := metamodel.Parse([]byte(txTestMetamodelYAML))
+	if err != nil {
+		t.Fatalf("failed to parse test metamodel: %v", err)
+	}
+
+	repo := New(fs, ctx)
+	return repo, meta, fs
+}
+
+func TestTransaction_CommitsOnSuccess(t *testing.T) {
+	repo, meta, fs := setupTxTestEnv(t)
+
+	entity := model.NewEntity("TASK-001", "task")
+	entity.SetString("title", "Test Task")
+
+	err := repo.Transaction(func(tx Tx) error {
+		return tx.WriteEntity(entity, meta)
+	})
+	if err != nil {
+		t.Fatalf("Transaction() error = %v", err)
+	}
+
+	// Entity should exist after commit
+	if _, readErr := repo.ReadEntity("task", "TASK-001", meta); readErr != nil {
+		t.Errorf("entity should exist after commit: %v", readErr)
+	}
+
+	// No temp files should remain
+	entries, _ := fs.ReadDir("/project/entities/tasks")
+	for _, entry := range entries {
+		if name := entry.Name(); len(name) > 4 && name[len(name)-4:] == ".new" {
+			t.Errorf("temp file should not exist: %s", name)
+		}
+	}
+}
+
+func TestTransaction_RollsBackOnError(t *testing.T) {
+	repo, meta, fs := setupTxTestEnv(t)
+
+	entity := model.NewEntity("TASK-001", "task")
+	entity.SetString("title", "Test Task")
+
+	err := repo.Transaction(func(tx Tx) error {
+		if writeErr := tx.WriteEntity(entity, meta); writeErr != nil {
+			return writeErr
+		}
+		return errors.New("simulated error")
+	})
+	if err == nil {
+		t.Fatal("Transaction() should return error")
+	}
+
+	// Entity should NOT exist after rollback
+	if _, readErr := repo.ReadEntity("task", "TASK-001", meta); readErr == nil {
+		t.Error("entity should not exist after rollback")
+	}
+
+	// No temp files should remain
+	entries, _ := fs.ReadDir("/project/entities/tasks")
+	for _, entry := range entries {
+		if name := entry.Name(); len(name) > 4 && name[len(name)-4:] == ".new" {
+			t.Errorf("temp file should not exist after rollback: %s", name)
+		}
+	}
+}
+
+func TestTransaction_MultipleOperations(t *testing.T) {
+	repo, meta, _ := setupTxTestEnv(t)
+
+	task1 := model.NewEntity("TASK-001", "task")
+	task1.SetString("title", "Task 1")
+	task2 := model.NewEntity("TASK-002", "task")
+	task2.SetString("title", "Task 2")
+
+	err := repo.Transaction(func(tx Tx) error {
+		if err := tx.WriteEntity(task1, meta); err != nil {
+			return err
+		}
+		if err := tx.WriteEntity(task2, meta); err != nil {
+			return err
+		}
+		rel := model.NewRelation("TASK-001", "depends-on", "TASK-002")
+		return tx.WriteRelation(rel)
+	})
+	if err != nil {
+		t.Fatalf("Transaction() error = %v", err)
+	}
+
+	// Both entities should exist
+	if _, readErr := repo.ReadEntity("task", "TASK-001", meta); readErr != nil {
+		t.Errorf("TASK-001 should exist: %v", readErr)
+	}
+	if _, readErr := repo.ReadEntity("task", "TASK-002", meta); readErr != nil {
+		t.Errorf("TASK-002 should exist: %v", readErr)
+	}
+
+	// Relation should exist
+	if _, readErr := repo.ReadRelation("TASK-001", "depends-on", "TASK-002"); readErr != nil {
+		t.Errorf("relation should exist: %v", readErr)
+	}
+}
+
+func TestTransaction_DeleteOperations(t *testing.T) {
+	repo, meta, _ := setupTxTestEnv(t)
+
+	// First create an entity outside transaction
+	entity := model.NewEntity("TASK-001", "task")
+	entity.SetString("title", "To Delete")
+	if err := repo.WriteEntity(entity, meta); err != nil {
+		t.Fatalf("WriteEntity() error = %v", err)
+	}
+
+	// Now delete in a transaction
+	err := repo.Transaction(func(tx Tx) error {
+		return tx.DeleteEntity("task", "TASK-001", meta)
+	})
+	if err != nil {
+		t.Fatalf("Transaction() error = %v", err)
+	}
+
+	// Entity should be deleted
+	if _, readErr := repo.ReadEntity("task", "TASK-001", meta); readErr == nil {
+		t.Error("entity should be deleted after transaction")
+	}
+}
+
+func TestTransaction_WriteAndDeleteInSameTransaction(t *testing.T) {
+	repo, meta, _ := setupTxTestEnv(t)
+
+	// Create an entity outside transaction
+	oldEntity := model.NewEntity("TASK-001", "task")
+	oldEntity.SetString("title", "Old")
+	if err := repo.WriteEntity(oldEntity, meta); err != nil {
+		t.Fatalf("WriteEntity() error = %v", err)
+	}
+
+	// Simulate a rename: write new, delete old
+	newEntity := model.NewEntity("TASK-100", "task")
+	newEntity.SetString("title", "Old") // Same content
+
+	err := repo.Transaction(func(tx Tx) error {
+		if writeErr := tx.WriteEntity(newEntity, meta); writeErr != nil {
+			return writeErr
+		}
+		return tx.DeleteEntity("task", "TASK-001", meta)
+	})
+	if err != nil {
+		t.Fatalf("Transaction() error = %v", err)
+	}
+
+	// Old entity should be gone
+	if _, readErr := repo.ReadEntity("task", "TASK-001", meta); readErr == nil {
+		t.Error("old entity should be deleted")
+	}
+
+	// New entity should exist
+	if _, readErr := repo.ReadEntity("task", "TASK-100", meta); readErr != nil {
+		t.Errorf("new entity should exist: %v", readErr)
+	}
+}
+
+func TestFindOrphanedTempFiles_NoOrphans(t *testing.T) {
+	repo, _, _ := setupTxTestEnv(t)
+
+	orphaned, err := repo.FindOrphanedTempFiles()
+	if err != nil {
+		t.Fatalf("FindOrphanedTempFiles() error = %v", err)
+	}
+
+	if len(orphaned) != 0 {
+		t.Errorf("expected no orphans, got %d", len(orphaned))
+	}
+}
+
+func TestFindOrphanedTempFiles_FindsOrphans(t *testing.T) {
+	repo, _, fs := setupTxTestEnv(t)
+
+	// Create some orphaned .new files
+	_ = fs.WriteFile("/project/entities/tasks/TASK-001.md.new", []byte("orphan1"), 0o644)
+	_ = fs.WriteFile("/project/relations/TASK-001--depends-on--TASK-002.md.new", []byte("orphan2"), 0o644)
+
+	orphaned, err := repo.FindOrphanedTempFiles()
+	if err != nil {
+		t.Fatalf("FindOrphanedTempFiles() error = %v", err)
+	}
+
+	if len(orphaned) != 2 {
+		t.Errorf("expected 2 orphans, got %d: %v", len(orphaned), orphaned)
+	}
+}
+
+func TestCleanupOrphanedTempFiles(t *testing.T) {
+	repo, _, fs := setupTxTestEnv(t)
+
+	// Create orphaned .new files
+	_ = fs.WriteFile("/project/entities/tasks/TASK-001.md.new", []byte("orphan"), 0o644)
+
+	count, err := repo.CleanupOrphanedTempFiles()
+	if err != nil {
+		t.Fatalf("CleanupOrphanedTempFiles() error = %v", err)
+	}
+
+	if count != 1 {
+		t.Errorf("expected 1 cleaned, got %d", count)
+	}
+
+	// Verify file is gone
+	if _, err := fs.ReadFile("/project/entities/tasks/TASK-001.md.new"); err == nil {
+		t.Error("orphaned file should be removed")
+	}
+}

--- a/internal/storage/watcher.go
+++ b/internal/storage/watcher.go
@@ -38,6 +38,7 @@ type Watcher struct {
 	done      chan struct{}
 	mu        sync.Mutex
 	pending   []model.ChangeEvent
+	paused    bool
 }
 
 // NewWatcher creates a file watcher with the given configuration.
@@ -96,12 +97,14 @@ func (w *Watcher) Start() {
 			}
 
 			w.mu.Lock()
-			w.pending = append(w.pending, model.ChangeEvent{
-				Path: event.Name,
-				Op:   toChangeOp(event.Op),
-			})
+			if !w.paused {
+				w.pending = append(w.pending, model.ChangeEvent{
+					Path: event.Name,
+					Op:   toChangeOp(event.Op),
+				})
+				timer.Reset(w.cfg.Debounce)
+			}
 			w.mu.Unlock()
-			timer.Reset(w.cfg.Debounce)
 
 		case <-timer.C:
 			w.mu.Lock()
@@ -134,6 +137,30 @@ func (w *Watcher) Stop() {
 // Useful for testing.
 func (w *Watcher) WatchList() []string {
 	return w.fsWatcher.WatchList()
+}
+
+// Pause temporarily stops processing file change events.
+// Events that occur while paused are discarded.
+// Use Resume to re-enable event processing.
+func (w *Watcher) Pause() {
+	w.mu.Lock()
+	w.paused = true
+	w.pending = nil // Discard any pending events
+	w.mu.Unlock()
+}
+
+// Resume re-enables event processing after a Pause.
+func (w *Watcher) Resume() {
+	w.mu.Lock()
+	w.paused = false
+	w.mu.Unlock()
+}
+
+// IsPaused returns whether the watcher is currently paused.
+func (w *Watcher) IsPaused() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.paused
 }
 
 func (w *Watcher) addRecursive(root string) {

--- a/tickets/entities/features/FEAT-016.md
+++ b/tickets/entities/features/FEAT-016.md
@@ -1,0 +1,6 @@
+---
+id: FEAT-016
+status: proposed
+title: Add entity ID rename with transactional guarantees
+type: feature
+---


### PR DESCRIPTION
## Summary
- Add `rename` package with transaction-based entity ID renaming
- Add repository `Transaction` API with two-phase commit (write to `.new` files, then atomic rename)
- Add MCP `rename_entity` tool with watcher pause/resume to prevent race conditions
- Add CLI: `rela rename id <old> <new>` with `--dry-run` flag
- Add `gc --temp-files` to clean up orphaned `.new` files from interrupted transactions

## Test plan
- [x] Unit tests for rename package (13 tests covering various scenarios)
- [x] Unit tests for transaction API (8 tests)
- [x] CI passes