### PR TITLE
Add JSON output support to all analyze subcommands

### DIFF
--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -28,6 +28,28 @@ Subcommands:
   all         - Run all analyses`,
 }
 
+// writeAnalysisJSON writes an analysis result in JSON format if JSON output is enabled.
+// Returns true if JSON was written (caller should return), false if text output should be used.
+// When count > 0, the status is set to "warning" and issuesFmt is used as the message format.
+func writeAnalysisJSON(count int, details interface{}, successMsg, issuesFmt string) bool {
+	if out.Format != "json" {
+		return false
+	}
+	status := "success"
+	message := successMsg
+	if count > 0 {
+		status = "warning"
+		message = fmt.Sprintf(issuesFmt, count)
+	}
+	_ = out.WriteAnalysisResult(output.AnalysisResult{
+		Status:  status,
+		Message: message,
+		Count:   count,
+		Details: details,
+	})
+	return true
+}
+
 var analyzeOrphansCmd = &cobra.Command{
 	Use:   "orphans",
 	Short: "Find entities with no connections",
@@ -35,28 +57,15 @@ var analyzeOrphansCmd = &cobra.Command{
 		orphans := g.FindOrphans()
 		filter.SortByID(orphans, false)
 
-		// Handle JSON output format
-		if out.Format == "json" {
-			status := "success"
-			message := "No orphan entities found"
-			if len(orphans) > 0 {
-				status = "warning"
-				message = fmt.Sprintf("Found %d orphan entities", len(orphans))
-			}
-			return out.WriteAnalysisResult(output.AnalysisResult{
-				Status:  status,
-				Message: message,
-				Count:   len(orphans),
-				Details: orphans,
-			})
+		if writeAnalysisJSON(len(orphans), orphans,
+			"No orphan entities found", "Found %d orphan entities") {
+			return nil
 		}
 
-		// Text output format
 		if len(orphans) == 0 {
 			out.WriteSuccess("No orphan entities found")
 			return nil
 		}
-
 		out.WriteWarning("Found %d orphan entities:", len(orphans))
 		return out.WriteEntities(orphans)
 	},
@@ -98,22 +107,11 @@ var analyzeDuplicatesCmd = &cobra.Command{
 					Entities: group,
 				})
 			}
-
-			status := "success"
-			message := "No duplicate titles found"
-			if len(duplicates) > 0 {
-				status = "warning"
-				message = fmt.Sprintf("Found %d groups of potential duplicates", len(duplicates))
-			}
-			return out.WriteAnalysisResult(output.AnalysisResult{
-				Status:  status,
-				Message: message,
-				Count:   len(duplicates),
-				Details: details,
-			})
+			writeAnalysisJSON(len(duplicates), details,
+				"No duplicate titles found", "Found %d groups of potential duplicates")
+			return nil
 		}
 
-		// Text output format
 		if len(duplicates) == 0 {
 			out.WriteSuccess("No duplicate titles found")
 			return nil
@@ -200,23 +198,11 @@ since they use manually-specified IDs that are not expected to be sequential.`,
 			}
 		}
 
-		// Handle JSON output format
-		if out.Format == "json" {
-			status := "success"
-			message := "No ID sequence gaps found"
-			if len(allGaps) > 0 {
-				status = "warning"
-				message = fmt.Sprintf("Found gaps in %d ID sequences", len(allGaps))
-			}
-			return out.WriteAnalysisResult(output.AnalysisResult{
-				Status:  status,
-				Message: message,
-				Count:   len(allGaps),
-				Details: allGaps,
-			})
+		if writeAnalysisJSON(len(allGaps), allGaps,
+			"No ID sequence gaps found", "Found gaps in %d ID sequences") {
+			return nil
 		}
 
-		// Text output format
 		if len(allGaps) == 0 {
 			out.WriteSuccess("No ID sequence gaps found")
 		} else {
@@ -353,23 +339,11 @@ var analyzeCardinalityCmd = &cobra.Command{
 			}
 		}
 
-		// Handle JSON output format
-		if out.Format == "json" {
-			status := "success"
-			message := "All cardinality constraints satisfied"
-			if len(allViolations) > 0 {
-				status = "warning"
-				message = fmt.Sprintf("Found %d cardinality violations", len(allViolations))
-			}
-			return out.WriteAnalysisResult(output.AnalysisResult{
-				Status:  status,
-				Message: message,
-				Count:   len(allViolations),
-				Details: allViolations,
-			})
+		if writeAnalysisJSON(len(allViolations), allViolations,
+			"All cardinality constraints satisfied", "Found %d cardinality violations") {
+			return nil
 		}
 
-		// Text output format
 		for _, v := range allViolations {
 			if strings.HasPrefix(v.Constraint, "min_") {
 				out.WriteWarning("%s must have at least %d '%s' relation(s), has %d",

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -33,13 +33,30 @@ var analyzeOrphansCmd = &cobra.Command{
 	Short: "Find entities with no connections",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		orphans := g.FindOrphans()
+		filter.SortByID(orphans, false)
 
+		// Handle JSON output format
+		if out.Format == "json" {
+			status := "success"
+			message := "No orphan entities found"
+			if len(orphans) > 0 {
+				status = "warning"
+				message = fmt.Sprintf("Found %d orphan entities", len(orphans))
+			}
+			return out.WriteAnalysisResult(output.AnalysisResult{
+				Status:  status,
+				Message: message,
+				Count:   len(orphans),
+				Details: orphans,
+			})
+		}
+
+		// Text output format
 		if len(orphans) == 0 {
 			out.WriteSuccess("No orphan entities found")
 			return nil
 		}
 
-		filter.SortByID(orphans, false)
 		out.WriteWarning("Found %d orphan entities:", len(orphans))
 		return out.WriteEntities(orphans)
 	},
@@ -68,6 +85,35 @@ var analyzeDuplicatesCmd = &cobra.Command{
 			}
 		}
 
+		// Handle JSON output format
+		if out.Format == "json" {
+			type duplicateGroup struct {
+				Title    string          `json:"title"`
+				Entities []*model.Entity `json:"entities"`
+			}
+			var details []duplicateGroup
+			for _, group := range duplicates {
+				details = append(details, duplicateGroup{
+					Title:    group[0].Title(),
+					Entities: group,
+				})
+			}
+
+			status := "success"
+			message := "No duplicate titles found"
+			if len(duplicates) > 0 {
+				status = "warning"
+				message = fmt.Sprintf("Found %d groups of potential duplicates", len(duplicates))
+			}
+			return out.WriteAnalysisResult(output.AnalysisResult{
+				Status:  status,
+				Message: message,
+				Count:   len(duplicates),
+				Details: details,
+			})
+		}
+
+		// Text output format
 		if len(duplicates) == 0 {
 			out.WriteSuccess("No duplicate titles found")
 			return nil
@@ -121,7 +167,12 @@ since they use manually-specified IDs that are not expected to be sequential.`,
 			prefixGroups[parsed.Prefix] = append(prefixGroups[parsed.Prefix], parsed.Number)
 		}
 
-		hasGaps := false
+		// Collect all gaps
+		type gapResult struct {
+			Prefix  string   `json:"prefix"`
+			Missing []string `json:"missing"`
+		}
+		var allGaps []gapResult
 
 		for prefix, numbers := range prefixGroups {
 			sort.Ints(numbers)
@@ -138,18 +189,41 @@ since they use manually-specified IDs that are not expected to be sequential.`,
 			}
 
 			if len(gaps) > 0 {
-				hasGaps = true
-				out.WriteWarning("Gaps in %s sequence:", prefix)
 				gapStrs := make([]string, len(gaps))
 				for i, n := range gaps {
 					gapStrs[i] = fmt.Sprintf("%s%03d", prefix, n)
 				}
-				out.WriteMessage("  Missing: %s", strings.Join(gapStrs, ", "))
+				allGaps = append(allGaps, gapResult{
+					Prefix:  prefix,
+					Missing: gapStrs,
+				})
 			}
 		}
 
-		if !hasGaps {
+		// Handle JSON output format
+		if out.Format == "json" {
+			status := "success"
+			message := "No ID sequence gaps found"
+			if len(allGaps) > 0 {
+				status = "warning"
+				message = fmt.Sprintf("Found gaps in %d ID sequences", len(allGaps))
+			}
+			return out.WriteAnalysisResult(output.AnalysisResult{
+				Status:  status,
+				Message: message,
+				Count:   len(allGaps),
+				Details: allGaps,
+			})
+		}
+
+		// Text output format
+		if len(allGaps) == 0 {
 			out.WriteSuccess("No ID sequence gaps found")
+		} else {
+			for _, gap := range allGaps {
+				out.WriteWarning("Gaps in %s sequence:", gap.Prefix)
+				out.WriteMessage("  Missing: %s", strings.Join(gap.Missing, ", "))
+			}
 		}
 
 		return nil
@@ -160,7 +234,14 @@ var analyzeCardinalityCmd = &cobra.Command{
 	Use:   "cardinality",
 	Short: "Check relation cardinality constraints",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		violations := 0
+		type cardinalityViolation struct {
+			EntityID     string `json:"entity_id"`
+			RelationType string `json:"relation_type"`
+			Constraint   string `json:"constraint"`
+			Required     int    `json:"required"`
+			Actual       int    `json:"actual"`
+		}
+		var allViolations []cardinalityViolation
 
 		for relName, relDef := range meta.Relations {
 			// Check min_outgoing constraint
@@ -176,9 +257,13 @@ var analyzeCardinalityCmd = &cobra.Command{
 							}
 						}
 						if count < *relDef.MinOutgoing {
-							out.WriteWarning("%s must have at least %d '%s' relation(s), has %d",
-								e.ID, *relDef.MinOutgoing, relName, count)
-							violations++
+							allViolations = append(allViolations, cardinalityViolation{
+								EntityID:     e.ID,
+								RelationType: relName,
+								Constraint:   "min_outgoing",
+								Required:     *relDef.MinOutgoing,
+								Actual:       count,
+							})
 						}
 					}
 				}
@@ -196,9 +281,13 @@ var analyzeCardinalityCmd = &cobra.Command{
 							}
 						}
 						if count > *relDef.MaxOutgoing {
-							out.WriteWarning("%s has more than %d '%s' relation(s): %d",
-								e.ID, *relDef.MaxOutgoing, relName, count)
-							violations++
+							allViolations = append(allViolations, cardinalityViolation{
+								EntityID:     e.ID,
+								RelationType: relName,
+								Constraint:   "max_outgoing",
+								Required:     *relDef.MaxOutgoing,
+								Actual:       count,
+							})
 						}
 					}
 				}
@@ -222,9 +311,13 @@ var analyzeCardinalityCmd = &cobra.Command{
 							if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
 								relLabel = relDef.Inverse.GetID()
 							}
-							out.WriteWarning("%s must have at least %d '%s' relation(s), has %d",
-								e.ID, *relDef.MinIncoming, relLabel, count)
-							violations++
+							allViolations = append(allViolations, cardinalityViolation{
+								EntityID:     e.ID,
+								RelationType: relLabel,
+								Constraint:   "min_incoming",
+								Required:     *relDef.MinIncoming,
+								Actual:       count,
+							})
 						}
 					}
 				}
@@ -247,19 +340,50 @@ var analyzeCardinalityCmd = &cobra.Command{
 							if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
 								relLabel = relDef.Inverse.GetID()
 							}
-							out.WriteWarning("%s has more than %d '%s' relation(s): %d",
-								e.ID, *relDef.MaxIncoming, relLabel, count)
-							violations++
+							allViolations = append(allViolations, cardinalityViolation{
+								EntityID:     e.ID,
+								RelationType: relLabel,
+								Constraint:   "max_incoming",
+								Required:     *relDef.MaxIncoming,
+								Actual:       count,
+							})
 						}
 					}
 				}
 			}
 		}
 
-		if violations == 0 {
+		// Handle JSON output format
+		if out.Format == "json" {
+			status := "success"
+			message := "All cardinality constraints satisfied"
+			if len(allViolations) > 0 {
+				status = "warning"
+				message = fmt.Sprintf("Found %d cardinality violations", len(allViolations))
+			}
+			return out.WriteAnalysisResult(output.AnalysisResult{
+				Status:  status,
+				Message: message,
+				Count:   len(allViolations),
+				Details: allViolations,
+			})
+		}
+
+		// Text output format
+		for _, v := range allViolations {
+			if strings.HasPrefix(v.Constraint, "min_") {
+				out.WriteWarning("%s must have at least %d '%s' relation(s), has %d",
+					v.EntityID, v.Required, v.RelationType, v.Actual)
+			} else {
+				out.WriteWarning("%s has more than %d '%s' relation(s): %d",
+					v.EntityID, v.Required, v.RelationType, v.Actual)
+			}
+		}
+
+		if len(allViolations) == 0 {
 			out.WriteSuccess("All cardinality constraints satisfied")
 		} else {
-			out.WriteWarning("Found %d cardinality violations", violations)
+			out.WriteWarning("Found %d cardinality violations", len(allViolations))
 		}
 
 		return nil
@@ -389,29 +513,62 @@ Example metamodel configuration:
 }
 
 // runValidations executes custom validation rules and returns error/warning counts
-func runValidations() error {
-	rules := meta.Validations
-	if len(rules) == 0 {
-		out.WriteSuccess("No custom validation rules defined in metamodel")
-		return nil
+// validationViolation represents a single validation rule violation for JSON output
+type validationViolation struct {
+	RuleName    string `json:"rule_name"`
+	Description string `json:"description"`
+	Severity    string `json:"severity"`
+	EntityID    string `json:"entity_id"`
+	EntityTitle string `json:"entity_title"`
+}
+
+// collectValidationViolations collects all validation violations and counts
+func collectValidationViolations(
+	rules []metamodel.ValidationRule,
+) (violations []validationViolation, errorCount, warningCount int) {
+	for _, rule := range rules {
+		ruleViolations := checkValidationRule(rule)
+		severity := rule.GetSeverity()
+		for _, v := range ruleViolations {
+			violations = append(violations, validationViolation{
+				RuleName:    rule.Name,
+				Description: rule.Description,
+				Severity:    severity,
+				EntityID:    v.ID,
+				EntityTitle: v.Title(),
+			})
+			if severity == "error" {
+				errorCount++
+			} else {
+				warningCount++
+			}
+		}
 	}
+	return violations, errorCount, warningCount
+}
 
-	errorCount := 0
-	warningCount := 0
-
+// writeValidationsTextOutput writes validation results in text format
+func writeValidationsTextOutput(
+	rules []metamodel.ValidationRule,
+	errorCount, warningCount int,
+) {
+	// Group violations by rule
+	ruleViolations := make(map[string][]*model.Entity)
 	for _, rule := range rules {
 		violations := checkValidationRule(rule)
 		if len(violations) > 0 {
-			// Determine severity indicator
-			severity := rule.GetSeverity()
-			if severity == "error" {
-				errorCount += len(violations)
+			ruleViolations[rule.Name] = violations
+		}
+	}
+
+	for _, rule := range rules {
+		violations := ruleViolations[rule.Name]
+		if len(violations) > 0 {
+			if rule.GetSeverity() == "error" {
 				out.WriteError("%s (%d):", rule.Description, len(violations))
 			} else {
-				warningCount += len(violations)
 				out.WriteWarning("%s (%d):", rule.Description, len(violations))
 			}
-
 			for _, v := range violations {
 				out.WriteMessage("  %s: %s", v.ID, v.Title())
 			}
@@ -420,14 +577,53 @@ func runValidations() error {
 
 	if errorCount == 0 && warningCount == 0 {
 		out.WriteSuccess("All %d validation rules passed", len(rules))
+		return
+	}
+	if errorCount > 0 {
+		out.WriteError("Found %d errors, %d warnings across %d rules", errorCount, warningCount, len(rules))
 	} else {
-		if errorCount > 0 {
-			out.WriteError("Found %d errors, %d warnings across %d rules", errorCount, warningCount, len(rules))
-		} else {
-			out.WriteWarning("Found %d warnings across %d rules", warningCount, len(rules))
+		out.WriteWarning("Found %d warnings across %d rules", warningCount, len(rules))
+	}
+}
+
+// runValidations executes custom validation rules and returns error/warning counts
+func runValidations() error {
+	rules := meta.Validations
+	if len(rules) == 0 {
+		if out.Format == "json" {
+			return out.WriteAnalysisResult(output.AnalysisResult{
+				Status:  "success",
+				Message: "No custom validation rules defined in metamodel",
+				Count:   0,
+				Details: []interface{}{},
+			})
 		}
+		out.WriteSuccess("No custom validation rules defined in metamodel")
+		return nil
 	}
 
+	allViolations, errorCount, warningCount := collectValidationViolations(rules)
+
+	if out.Format == "json" {
+		status := "success"
+		message := fmt.Sprintf("All %d validation rules passed", len(rules))
+		if errorCount > 0 {
+			status = "error"
+			message = fmt.Sprintf("Found %d errors, %d warnings across %d rules",
+				errorCount, warningCount, len(rules))
+		} else if warningCount > 0 {
+			status = "warning"
+			message = fmt.Sprintf("Found %d warnings across %d rules", warningCount, len(rules))
+		}
+		return out.WriteAnalysisResult(output.AnalysisResult{
+			Status:  status,
+			Message: message,
+			Count:   errorCount + warningCount,
+			Details: allViolations,
+		})
+	}
+
+	writeValidationsTextOutput(rules, errorCount, warningCount)
 	return nil
 }
 
@@ -668,7 +864,49 @@ var analyzeAllCmd = &cobra.Command{
 		// Count validation issues
 		validationErrors, validationWarnings := countValidationIssues()
 
-		// Summary box
+		// Handle JSON output format
+		if out.Format == "json" {
+			type allAnalysisSummary struct {
+				Orphans            int `json:"orphans"`
+				Cardinality        int `json:"cardinality"`
+				Duplicates         int `json:"duplicates"`
+				Gaps               int `json:"gaps"`
+				Properties         int `json:"properties"`
+				ValidationErrors   int `json:"validation_errors"`
+				ValidationWarnings int `json:"validation_warnings"`
+			}
+
+			summary := allAnalysisSummary{
+				Orphans:            orphanCount,
+				Cardinality:        cardinalityCount,
+				Duplicates:         duplicateCount,
+				Gaps:               gapCount,
+				Properties:         propertyErrorCount,
+				ValidationErrors:   validationErrors,
+				ValidationWarnings: validationWarnings,
+			}
+
+			totalIssues := orphanCount + cardinalityCount + duplicateCount +
+				gapCount + propertyErrorCount + validationErrors
+			status := "success"
+			message := "All analyses passed"
+			if validationErrors > 0 || propertyErrorCount > 0 {
+				status = "error"
+				message = fmt.Sprintf("Found %d issues requiring attention", totalIssues)
+			} else if totalIssues > 0 || validationWarnings > 0 {
+				status = "warning"
+				message = fmt.Sprintf("Found %d issues and %d warnings", totalIssues, validationWarnings)
+			}
+
+			return out.WriteAnalysisResult(output.AnalysisResult{
+				Status:  status,
+				Message: message,
+				Count:   totalIssues + validationWarnings,
+				Details: summary,
+			})
+		}
+
+		// Text output format
 		summaryItems := []string{
 			fmt.Sprintf("Orphans: %d", orphanCount),
 			fmt.Sprintf("Cardinality: %d", cardinalityCount),

--- a/internal/cli/analyze_test.go
+++ b/internal/cli/analyze_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/graph"
@@ -638,5 +640,242 @@ func TestCountPropertyErrors(t *testing.T) {
 				t.Errorf("countPropertyErrors() = %d, want 0", got)
 			}
 		})
+	}
+}
+
+// setupJSONTestOutput sets up JSON output writer and returns the buffer
+func setupJSONTestOutput() *bytes.Buffer {
+	var buf bytes.Buffer
+	out = output.NewWithWriter(&buf, output.FormatJSON)
+	return &buf
+}
+
+func TestAnalyzeOrphansJSONOutput(t *testing.T) {
+	setupAnalyzeTestGraph()
+	buf := setupJSONTestOutput()
+
+	// Remove all edges to create orphans
+	g = graph.New()
+	orphan := model.NewEntity("REQ-003", "requirement")
+	orphan.Properties["title"] = "Orphan Requirement"
+	g.AddNode(orphan)
+
+	err := analyzeOrphansCmd.RunE(nil, nil)
+	if err != nil {
+		t.Fatalf("analyzeOrphansCmd.RunE() error = %v", err)
+	}
+
+	var result output.AnalysisResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if result.Status != "warning" {
+		t.Errorf("Expected status 'warning', got %q", result.Status)
+	}
+	if result.Count != 1 {
+		t.Errorf("Expected count 1, got %d", result.Count)
+	}
+}
+
+func TestAnalyzeOrphansJSONOutputEmpty(t *testing.T) {
+	setupAnalyzeTestGraph()
+	buf := setupJSONTestOutput()
+
+	err := analyzeOrphansCmd.RunE(nil, nil)
+	if err != nil {
+		t.Fatalf("analyzeOrphansCmd.RunE() error = %v", err)
+	}
+
+	var result output.AnalysisResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if result.Status != "success" {
+		t.Errorf("Expected status 'success', got %q", result.Status)
+	}
+	if result.Count != 0 {
+		t.Errorf("Expected count 0, got %d", result.Count)
+	}
+}
+
+func TestAnalyzeDuplicatesJSONOutput(t *testing.T) {
+	g = graph.New()
+	meta = &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"requirement": {Label: "Requirement", IDPrefix: "REQ-"},
+		},
+	}
+	buf := setupJSONTestOutput()
+
+	// Create entities with duplicate titles
+	e1 := model.NewEntity("REQ-001", "requirement")
+	e1.Properties["title"] = "Same Title"
+	g.AddNode(e1)
+
+	e2 := model.NewEntity("REQ-002", "requirement")
+	e2.Properties["title"] = "Same Title"
+	g.AddNode(e2)
+
+	err := analyzeDuplicatesCmd.RunE(nil, nil)
+	if err != nil {
+		t.Fatalf("analyzeDuplicatesCmd.RunE() error = %v", err)
+	}
+
+	var result output.AnalysisResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if result.Status != "warning" {
+		t.Errorf("Expected status 'warning', got %q", result.Status)
+	}
+	if result.Count != 1 {
+		t.Errorf("Expected count 1, got %d", result.Count)
+	}
+}
+
+func TestAnalyzeGapsJSONOutput(t *testing.T) {
+	g = graph.New()
+	meta = &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"requirement": {Label: "Requirement", IDPrefix: "REQ-"},
+		},
+	}
+	buf := setupJSONTestOutput()
+
+	// Create entities with a gap in IDs
+	e1 := model.NewEntity("REQ-001", "requirement")
+	g.AddNode(e1)
+	e3 := model.NewEntity("REQ-003", "requirement")
+	g.AddNode(e3)
+
+	err := analyzeGapsCmd.RunE(nil, nil)
+	if err != nil {
+		t.Fatalf("analyzeGapsCmd.RunE() error = %v", err)
+	}
+
+	var result output.AnalysisResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if result.Status != "warning" {
+		t.Errorf("Expected status 'warning', got %q", result.Status)
+	}
+	if result.Count != 1 {
+		t.Errorf("Expected count 1, got %d", result.Count)
+	}
+}
+
+func TestAnalyzeCardinalityJSONOutput(t *testing.T) {
+	setupAnalyzeTestGraph()
+	buf := setupJSONTestOutput()
+
+	// Add cardinality constraint that will be violated
+	minTwo := 2
+	meta.Relations["implements"] = metamodel.RelationDef{
+		Label:       "Implements",
+		From:        []string{"decision"},
+		To:          []string{"requirement"},
+		MinOutgoing: &minTwo,
+	}
+
+	// DEC-001 has 2 implements relations, so no violation with MinOutgoing=2
+	// But let's test with 3 to cause a violation
+	minThree := 3
+	meta.Relations["implements"] = metamodel.RelationDef{
+		Label:       "Implements",
+		From:        []string{"decision"},
+		To:          []string{"requirement"},
+		MinOutgoing: &minThree,
+	}
+
+	err := analyzeCardinalityCmd.RunE(nil, nil)
+	if err != nil {
+		t.Fatalf("analyzeCardinalityCmd.RunE() error = %v", err)
+	}
+
+	var result output.AnalysisResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if result.Status != "warning" {
+		t.Errorf("Expected status 'warning', got %q", result.Status)
+	}
+	if result.Count != 1 {
+		t.Errorf("Expected count 1, got %d", result.Count)
+	}
+}
+
+func TestAnalyzeValidationsJSONOutput(t *testing.T) {
+	g = graph.New()
+	meta = &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"requirement": {
+				Label:    "Requirement",
+				IDPrefix: "REQ-",
+				Properties: map[string]metamodel.PropertyDef{
+					"status":   {Type: "string"},
+					"priority": {Type: "string"},
+				},
+			},
+		},
+		Validations: []metamodel.ValidationRule{
+			{
+				Name:        "accepted-needs-priority",
+				Description: "Accepted requirements must have priority",
+				EntityType:  "requirement",
+				When:        []string{"status=accepted"},
+				Then:        []string{"priority!="},
+				Severity:    "error",
+			},
+		},
+	}
+	buf := setupJSONTestOutput()
+
+	// Create entity that violates the rule
+	e := model.NewEntity("REQ-001", "requirement")
+	e.Properties["status"] = "accepted"
+	// No priority set - will violate the rule
+	g.AddNode(e)
+
+	err := runValidations()
+	if err != nil {
+		t.Fatalf("runValidations() error = %v", err)
+	}
+
+	var result output.AnalysisResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if result.Status != "error" {
+		t.Errorf("Expected status 'error', got %q", result.Status)
+	}
+	if result.Count != 1 {
+		t.Errorf("Expected count 1, got %d", result.Count)
+	}
+}
+
+func TestAnalyzeAllJSONOutput(t *testing.T) {
+	setupAnalyzeTestGraph()
+	buf := setupJSONTestOutput()
+
+	err := analyzeAllCmd.RunE(nil, nil)
+	if err != nil {
+		t.Fatalf("analyzeAllCmd.RunE() error = %v", err)
+	}
+
+	var result output.AnalysisResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	// With the test graph having no violations, should be success
+	if result.Status != "success" {
+		t.Errorf("Expected status 'success', got %q", result.Status)
 	}
 }

--- a/internal/cli/analyze_test.go
+++ b/internal/cli/analyze_test.go
@@ -650,19 +650,14 @@ func setupJSONTestOutput() *bytes.Buffer {
 	return &buf
 }
 
-func TestAnalyzeOrphansJSONOutput(t *testing.T) {
-	setupAnalyzeTestGraph()
+// runJSONTest is a helper that runs an analyze command and verifies the JSON output
+func runJSONTest(t *testing.T, name string, setup func(), run func() error, wantStatus string, wantCount int) {
+	t.Helper()
+	setup()
 	buf := setupJSONTestOutput()
 
-	// Remove all edges to create orphans
-	g = graph.New()
-	orphan := model.NewEntity("REQ-003", "requirement")
-	orphan.Properties["title"] = "Orphan Requirement"
-	g.AddNode(orphan)
-
-	err := analyzeOrphansCmd.RunE(nil, nil)
-	if err != nil {
-		t.Fatalf("analyzeOrphansCmd.RunE() error = %v", err)
+	if err := run(); err != nil {
+		t.Fatalf("%s error = %v", name, err)
 	}
 
 	var result output.AnalysisResult
@@ -670,212 +665,145 @@ func TestAnalyzeOrphansJSONOutput(t *testing.T) {
 		t.Fatalf("Failed to unmarshal JSON: %v", err)
 	}
 
-	if result.Status != "warning" {
-		t.Errorf("Expected status 'warning', got %q", result.Status)
+	if result.Status != wantStatus {
+		t.Errorf("Expected status %q, got %q", wantStatus, result.Status)
 	}
-	if result.Count != 1 {
-		t.Errorf("Expected count 1, got %d", result.Count)
-	}
-}
-
-func TestAnalyzeOrphansJSONOutputEmpty(t *testing.T) {
-	setupAnalyzeTestGraph()
-	buf := setupJSONTestOutput()
-
-	err := analyzeOrphansCmd.RunE(nil, nil)
-	if err != nil {
-		t.Fatalf("analyzeOrphansCmd.RunE() error = %v", err)
-	}
-
-	var result output.AnalysisResult
-	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
-		t.Fatalf("Failed to unmarshal JSON: %v", err)
-	}
-
-	if result.Status != "success" {
-		t.Errorf("Expected status 'success', got %q", result.Status)
-	}
-	if result.Count != 0 {
-		t.Errorf("Expected count 0, got %d", result.Count)
+	if result.Count != wantCount {
+		t.Errorf("Expected count %d, got %d", wantCount, result.Count)
 	}
 }
 
-func TestAnalyzeDuplicatesJSONOutput(t *testing.T) {
-	g = graph.New()
-	meta = &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"requirement": {Label: "Requirement", IDPrefix: "REQ-"},
-		},
-	}
-	buf := setupJSONTestOutput()
-
-	// Create entities with duplicate titles
-	e1 := model.NewEntity("REQ-001", "requirement")
-	e1.Properties["title"] = "Same Title"
-	g.AddNode(e1)
-
-	e2 := model.NewEntity("REQ-002", "requirement")
-	e2.Properties["title"] = "Same Title"
-	g.AddNode(e2)
-
-	err := analyzeDuplicatesCmd.RunE(nil, nil)
-	if err != nil {
-		t.Fatalf("analyzeDuplicatesCmd.RunE() error = %v", err)
-	}
-
-	var result output.AnalysisResult
-	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
-		t.Fatalf("Failed to unmarshal JSON: %v", err)
-	}
-
-	if result.Status != "warning" {
-		t.Errorf("Expected status 'warning', got %q", result.Status)
-	}
-	if result.Count != 1 {
-		t.Errorf("Expected count 1, got %d", result.Count)
-	}
-}
-
-func TestAnalyzeGapsJSONOutput(t *testing.T) {
-	g = graph.New()
-	meta = &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"requirement": {Label: "Requirement", IDPrefix: "REQ-"},
-		},
-	}
-	buf := setupJSONTestOutput()
-
-	// Create entities with a gap in IDs
-	e1 := model.NewEntity("REQ-001", "requirement")
-	g.AddNode(e1)
-	e3 := model.NewEntity("REQ-003", "requirement")
-	g.AddNode(e3)
-
-	err := analyzeGapsCmd.RunE(nil, nil)
-	if err != nil {
-		t.Fatalf("analyzeGapsCmd.RunE() error = %v", err)
-	}
-
-	var result output.AnalysisResult
-	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
-		t.Fatalf("Failed to unmarshal JSON: %v", err)
-	}
-
-	if result.Status != "warning" {
-		t.Errorf("Expected status 'warning', got %q", result.Status)
-	}
-	if result.Count != 1 {
-		t.Errorf("Expected count 1, got %d", result.Count)
-	}
-}
-
-func TestAnalyzeCardinalityJSONOutput(t *testing.T) {
-	setupAnalyzeTestGraph()
-	buf := setupJSONTestOutput()
-
-	// Add cardinality constraint that will be violated
-	minTwo := 2
-	meta.Relations["implements"] = metamodel.RelationDef{
-		Label:       "Implements",
-		From:        []string{"decision"},
-		To:          []string{"requirement"},
-		MinOutgoing: &minTwo,
-	}
-
-	// DEC-001 has 2 implements relations, so no violation with MinOutgoing=2
-	// But let's test with 3 to cause a violation
+func TestAnalyzeJSONOutput(t *testing.T) {
 	minThree := 3
-	meta.Relations["implements"] = metamodel.RelationDef{
-		Label:       "Implements",
-		From:        []string{"decision"},
-		To:          []string{"requirement"},
-		MinOutgoing: &minThree,
-	}
 
-	err := analyzeCardinalityCmd.RunE(nil, nil)
-	if err != nil {
-		t.Fatalf("analyzeCardinalityCmd.RunE() error = %v", err)
-	}
-
-	var result output.AnalysisResult
-	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
-		t.Fatalf("Failed to unmarshal JSON: %v", err)
-	}
-
-	if result.Status != "warning" {
-		t.Errorf("Expected status 'warning', got %q", result.Status)
-	}
-	if result.Count != 1 {
-		t.Errorf("Expected count 1, got %d", result.Count)
-	}
-}
-
-func TestAnalyzeValidationsJSONOutput(t *testing.T) {
-	g = graph.New()
-	meta = &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"requirement": {
-				Label:    "Requirement",
-				IDPrefix: "REQ-",
-				Properties: map[string]metamodel.PropertyDef{
-					"status":   {Type: "string"},
-					"priority": {Type: "string"},
-				},
+	tests := []struct {
+		name       string
+		setup      func()
+		run        func() error
+		wantStatus string
+		wantCount  int
+	}{
+		{
+			name: "orphans with issues",
+			setup: func() {
+				g = graph.New()
+				meta = &metamodel.Metamodel{
+					Entities: map[string]metamodel.EntityDef{
+						"requirement": {Label: "Requirement", IDPrefix: "REQ-"},
+					},
+				}
+				orphan := model.NewEntity("REQ-003", "requirement")
+				orphan.Properties["title"] = "Orphan Requirement"
+				g.AddNode(orphan)
 			},
+			run:        func() error { return analyzeOrphansCmd.RunE(nil, nil) },
+			wantStatus: "warning",
+			wantCount:  1,
 		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:        "accepted-needs-priority",
-				Description: "Accepted requirements must have priority",
-				EntityType:  "requirement",
-				When:        []string{"status=accepted"},
-				Then:        []string{"priority!="},
-				Severity:    "error",
+		{
+			name:       "orphans empty",
+			setup:      setupAnalyzeTestGraph,
+			run:        func() error { return analyzeOrphansCmd.RunE(nil, nil) },
+			wantStatus: "success",
+			wantCount:  0,
+		},
+		{
+			name: "duplicates with issues",
+			setup: func() {
+				g = graph.New()
+				meta = &metamodel.Metamodel{
+					Entities: map[string]metamodel.EntityDef{
+						"requirement": {Label: "Requirement", IDPrefix: "REQ-"},
+					},
+				}
+				e1 := model.NewEntity("REQ-001", "requirement")
+				e1.Properties["title"] = "Same Title"
+				g.AddNode(e1)
+				e2 := model.NewEntity("REQ-002", "requirement")
+				e2.Properties["title"] = "Same Title"
+				g.AddNode(e2)
 			},
+			run:        func() error { return analyzeDuplicatesCmd.RunE(nil, nil) },
+			wantStatus: "warning",
+			wantCount:  1,
+		},
+		{
+			name: "gaps with issues",
+			setup: func() {
+				g = graph.New()
+				meta = &metamodel.Metamodel{
+					Entities: map[string]metamodel.EntityDef{
+						"requirement": {Label: "Requirement", IDPrefix: "REQ-"},
+					},
+				}
+				g.AddNode(model.NewEntity("REQ-001", "requirement"))
+				g.AddNode(model.NewEntity("REQ-003", "requirement"))
+			},
+			run:        func() error { return analyzeGapsCmd.RunE(nil, nil) },
+			wantStatus: "warning",
+			wantCount:  1,
+		},
+		{
+			name: "cardinality with violations",
+			setup: func() {
+				setupAnalyzeTestGraph()
+				meta.Relations["implements"] = metamodel.RelationDef{
+					Label:       "Implements",
+					From:        []string{"decision"},
+					To:          []string{"requirement"},
+					MinOutgoing: &minThree,
+				}
+			},
+			run:        func() error { return analyzeCardinalityCmd.RunE(nil, nil) },
+			wantStatus: "warning",
+			wantCount:  1,
+		},
+		{
+			name: "validations with errors",
+			setup: func() {
+				g = graph.New()
+				meta = &metamodel.Metamodel{
+					Entities: map[string]metamodel.EntityDef{
+						"requirement": {
+							Label:    "Requirement",
+							IDPrefix: "REQ-",
+							Properties: map[string]metamodel.PropertyDef{
+								"status":   {Type: "string"},
+								"priority": {Type: "string"},
+							},
+						},
+					},
+					Validations: []metamodel.ValidationRule{
+						{
+							Name:        "accepted-needs-priority",
+							Description: "Accepted requirements must have priority",
+							EntityType:  "requirement",
+							When:        []string{"status=accepted"},
+							Then:        []string{"priority!="},
+							Severity:    "error",
+						},
+					},
+				}
+				e := model.NewEntity("REQ-001", "requirement")
+				e.Properties["status"] = "accepted"
+				g.AddNode(e)
+			},
+			run:        runValidations,
+			wantStatus: "error",
+			wantCount:  1,
+		},
+		{
+			name:       "all analyses pass",
+			setup:      setupAnalyzeTestGraph,
+			run:        func() error { return analyzeAllCmd.RunE(nil, nil) },
+			wantStatus: "success",
+			wantCount:  0,
 		},
 	}
-	buf := setupJSONTestOutput()
 
-	// Create entity that violates the rule
-	e := model.NewEntity("REQ-001", "requirement")
-	e.Properties["status"] = "accepted"
-	// No priority set - will violate the rule
-	g.AddNode(e)
-
-	err := runValidations()
-	if err != nil {
-		t.Fatalf("runValidations() error = %v", err)
-	}
-
-	var result output.AnalysisResult
-	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
-		t.Fatalf("Failed to unmarshal JSON: %v", err)
-	}
-
-	if result.Status != "error" {
-		t.Errorf("Expected status 'error', got %q", result.Status)
-	}
-	if result.Count != 1 {
-		t.Errorf("Expected count 1, got %d", result.Count)
-	}
-}
-
-func TestAnalyzeAllJSONOutput(t *testing.T) {
-	setupAnalyzeTestGraph()
-	buf := setupJSONTestOutput()
-
-	err := analyzeAllCmd.RunE(nil, nil)
-	if err != nil {
-		t.Fatalf("analyzeAllCmd.RunE() error = %v", err)
-	}
-
-	var result output.AnalysisResult
-	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
-		t.Fatalf("Failed to unmarshal JSON: %v", err)
-	}
-
-	// With the test graph having no violations, should be success
-	if result.Status != "success" {
-		t.Errorf("Expected status 'success', got %q", result.Status)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runJSONTest(t, tt.name, tt.setup, tt.run, tt.wantStatus, tt.wantCount)
+		})
 	}
 }

--- a/tickets/entities/automated-measures/analyze-json-tests.md
+++ b/tickets/entities/automated-measures/analyze-json-tests.md
@@ -1,0 +1,9 @@
+---
+description: Unit tests verify all analyze subcommands produce valid JSON when -o json flag is used
+id: analyze-json-tests
+kind: test
+location: internal/cli/analyze_test.go
+status: active
+title: Unit tests for analyze JSON output
+type: automated-measure
+---

--- a/tickets/entities/bugs/BUG-007.md
+++ b/tickets/entities/bugs/BUG-007.md
@@ -1,0 +1,50 @@
+---
+description: Most analyze subcommands ignored the -o json flag and always output human-readable text format. This broke automation scripts that need to parse analysis results.
+effort: s
+id: BUG-007
+prevention: Added JSON output support using the existing AnalysisResult pattern. Future analyze commands should follow the same pattern of checking out.Format and using WriteAnalysisResult for JSON output.
+priority: medium
+status: done
+title: Analyze subcommands ignore -o json flag
+type: bug
+why1: The analyze subcommands (orphans, duplicates, gaps, cardinality, validations) output text format even when -o json is specified
+why2: Each analyze subcommand was implemented independently and only analyze properties checked out.Format before outputting
+why3: There was no shared pattern or helper function for consistent JSON output across analyze commands
+why4: The AnalysisResult type and WriteAnalysisResult method were added later for analyze properties but not retrofitted to other commands
+why5: Missing code review checklist item to verify all CLI commands respect output format flags consistently
+---
+
+## Problem
+
+The following `rela analyze` subcommands ignored the `-o json` flag:
+
+| Command | `-o json` worked? |
+|---------|------------------|
+| `analyze properties` | Yes |
+| `analyze validations` | No |
+| `analyze orphans` | No (outputs text header + JSON array) |
+| `analyze cardinality` | No |
+| `analyze duplicates` | No |
+| `analyze gaps` | No |
+
+## Root Cause
+
+Each analyze subcommand was implemented at different times. The `analyze properties` command was the first to use the `AnalysisResult` type for consistent JSON output, but this pattern wasn't applied to the other commands.
+
+## Solution
+
+Updated all analyze subcommands to check `out.Format` and use `WriteAnalysisResult` for consistent JSON output matching the format used by `analyze properties`:
+
+```json
+{
+  "status": "error|warning|success",
+  "message": "Found X issues...",
+  "count": X,
+  "details": [...]
+}
+```
+
+## References
+
+- GitHub Issue: #149
+- PR: #150

--- a/tickets/entities/features/FEAT-017.md
+++ b/tickets/entities/features/FEAT-017.md
@@ -1,0 +1,9 @@
+---
+description: All analyze subcommands support -o json flag for consistent JSON output
+id: FEAT-017
+priority: medium
+status: implemented
+summary: Enables automation scripts to parse analysis results programmatically
+title: JSON output for analyze commands
+type: feature
+---

--- a/tickets/relations/BUG-007--adds-measure--analyze-json-tests.md
+++ b/tickets/relations/BUG-007--adds-measure--analyze-json-tests.md
@@ -1,0 +1,5 @@
+---
+from: BUG-007
+relation: adds-measure
+to: analyze-json-tests
+---

--- a/tickets/relations/BUG-007--affects--cli-flags.md
+++ b/tickets/relations/BUG-007--affects--cli-flags.md
@@ -1,0 +1,5 @@
+---
+from: BUG-007
+relation: affects
+to: cli-flags
+---

--- a/tickets/relations/BUG-007--fixes--FEAT-017.md
+++ b/tickets/relations/BUG-007--fixes--FEAT-017.md
@@ -1,0 +1,5 @@
+---
+from: BUG-007
+relation: fixes
+to: FEAT-017
+---

--- a/tickets/relations/FEAT-017--requires--cli-flags.md
+++ b/tickets/relations/FEAT-017--requires--cli-flags.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-017
+relation: requires
+to: cli-flags
+---


### PR DESCRIPTION
## Summary
- All `analyze` subcommands now respect the `-o json` flag
- Output is consistent JSON in the `AnalysisResult` format used by `analyze properties`
- Extracted validation logic to helper functions to reduce cognitive complexity

## Test plan
- [x] Added unit tests for JSON output on all affected commands
- [x] Verified all existing tests still pass
- [x] Verified linter passes

Fixes #149