### PR TITLE
Fix empty filter value coercion for non-string types

### DIFF
--- a/internal/filter/match.go
+++ b/internal/filter/match.go
@@ -29,6 +29,25 @@ func Match(entity *model.Entity, filter *Filter, propDef *metamodel.PropertyDef,
 		return false, nil
 	}
 
+	// Handle empty filter value checks ("property=" or "property!=")
+	// This checks for existence/emptiness and works for all property types.
+	// When filter.Value is empty, we're checking if the property has any value,
+	// not comparing to a specific value. This avoids parse errors for non-string types.
+	if filter.Value == "" {
+		switch filter.Operator {
+		case OpEqual:
+			// property= means "is empty", but we already handled nil/"" above,
+			// so if we reach here the value is not empty
+			return false, nil
+		case OpNotEqual:
+			// property!= means "is not empty" - value exists and is not empty
+			return true, nil
+		case OpLess, OpLessEqual, OpGreater, OpGreaterEqual, OpRegex:
+			// For other operators with empty value, fall through to type-specific matching
+			// which will return an appropriate error
+		}
+	}
+
 	// Validate operator is supported for this property type
 	if err := validateOperatorForType(filter.Operator, propDef, m); err != nil {
 		return false, err

--- a/internal/filter/match_test.go
+++ b/internal/filter/match_test.go
@@ -989,3 +989,146 @@ func TestMatchAllUnknownProperty(t *testing.T) {
 		t.Error("Expected error for unknown property")
 	}
 }
+
+// TestMatchEmptyFilterValueNonStringTypes tests that "property!=" (not empty check)
+// works correctly for non-string types like integers, dates, and booleans.
+// This is issue #152: validation rules with property!="" fail for non-string values
+// because the empty filter value cannot be parsed as the target type.
+func TestMatchEmptyFilterValueNonStringTypes(t *testing.T) {
+	mm := &metamodel.Metamodel{}
+
+	tests := []struct {
+		name    string
+		propDef *metamodel.PropertyDef
+		value   interface{}
+		filter  string
+		want    bool
+		wantErr bool
+	}{
+		// Integer property with native int value (as YAML would parse)
+		{
+			name:    "integer not empty with int value",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeInteger},
+			value:   4, // int, not "4" string
+			filter:  "score!=",
+			want:    true,
+		},
+		{
+			name:    "integer is empty with int value",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeInteger},
+			value:   4,
+			filter:  "score=",
+			want:    false,
+		},
+		{
+			name:    "integer not empty with float64 value",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeInteger},
+			value:   4.0, // float64, as YAML might also parse
+			filter:  "score!=",
+			want:    true,
+		},
+		{
+			name:    "integer not empty with string value",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeInteger},
+			value:   "4", // string representation
+			filter:  "score!=",
+			want:    true,
+		},
+		{
+			name:    "integer not empty with zero value",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeInteger},
+			value:   0, // zero is still a value
+			filter:  "score!=",
+			want:    true,
+		},
+		// Date property
+		{
+			name:    "date not empty with string date",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeDate, Format: "2006-01-02"},
+			value:   "2026-01-13",
+			filter:  "review_date!=",
+			want:    true,
+		},
+		{
+			name:    "date is empty with string date",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeDate, Format: "2006-01-02"},
+			value:   "2026-01-13",
+			filter:  "review_date=",
+			want:    false,
+		},
+		// Boolean property
+		{
+			name:    "boolean not empty with true",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeBoolean},
+			value:   true,
+			filter:  "active!=",
+			want:    true,
+		},
+		{
+			name:    "boolean not empty with false",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeBoolean},
+			value:   false, // false is still a value
+			filter:  "active!=",
+			want:    true,
+		},
+		{
+			name:    "boolean is empty with true",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeBoolean},
+			value:   true,
+			filter:  "active=",
+			want:    false,
+		},
+		// String property (existing behavior should still work)
+		{
+			name:    "string not empty with value",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeString},
+			value:   "hello",
+			filter:  "title!=",
+			want:    true,
+		},
+		{
+			name:    "string is empty with value",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeString},
+			value:   "hello",
+			filter:  "title=",
+			want:    false,
+		},
+		// Quoted string integer (as might appear in YAML)
+		{
+			name:    "integer not empty with quoted string",
+			propDef: &metamodel.PropertyDef{Type: metamodel.PropertyTypeInteger},
+			value:   "1", // quoted in YAML: sequence_position: "1"
+			filter:  "sequence_position!=",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := Parse(tt.filter)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", tt.filter, err)
+			}
+
+			entity := &model.Entity{
+				ID:         "TEST-001",
+				Type:       "test",
+				Properties: map[string]interface{}{f.Property: tt.value},
+			}
+
+			got, err := Match(entity, f, tt.propDef, mm)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Match error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Match = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tickets/entities/automated-measures/empty-filter-coercion-tests.md
+++ b/tickets/entities/automated-measures/empty-filter-coercion-tests.md
@@ -1,0 +1,12 @@
+---
+id: empty-filter-coercion-tests
+kind: test
+location: internal/filter/match_test.go
+status: active
+title: Empty filter value coercion tests
+type: automated-measure
+---
+
+Unit tests in `internal/filter/match_test.go` that verify empty filter value checks (`property=""` and `property!=""`) work correctly for all property types including integers, dates, and booleans stored as native Go types.
+
+Test function: `TestMatchEmptyFilterValueNonStringTypes`

--- a/tickets/entities/bugs/BUG-008.md
+++ b/tickets/entities/bugs/BUG-008.md
@@ -1,0 +1,30 @@
+---
+description: Validation rules checking if non-string properties have values fail with parse errors
+id: BUG-008
+prevention: Added early handling of empty filter checks before type-specific matching
+status: done
+title: Validation rules with property!="" fail for non-string types
+type: bug
+why1: Empty filter value "" was passed to type-specific matching functions
+why2: matchInteger and matchDate tried to parse "" as their target type
+why3: The empty string cannot be parsed as integer or date, causing errors
+why4: Match() did not have early handling for empty filter value existence checks
+why5: Filter logic assumed type-specific matching could handle all cases including existence checks
+---
+
+When validation rules use `property!=""` to check if a property has a value,
+the filter would fail for non-string types (integers, dates, booleans).
+
+The issue was in the `Match()` function in `internal/filter/match.go`. When
+checking `property!=""` with a non-empty value like `4` (int):
+
+1. The nil/empty check passes (value exists)
+2. Code proceeds to `matchInteger()`
+3. `matchInteger()` tries to parse `filter.Value` (empty string) as integer
+4. `strconv.Atoi("")` fails with a parse error
+5. Error is treated as validation violation
+
+Fixed by handling empty filter value checks early in `Match()` before
+type-specific matching. When `filter.Value == ""`:
+- `property=` returns false if value exists (not empty)
+- `property!=` returns true if value exists (is not empty)

--- a/tickets/relations/BUG-008--adds-measure--empty-filter-coercion-tests.md
+++ b/tickets/relations/BUG-008--adds-measure--empty-filter-coercion-tests.md
@@ -1,0 +1,5 @@
+---
+from: BUG-008
+relation: adds-measure
+to: empty-filter-coercion-tests
+---

--- a/tickets/relations/BUG-008--affects--metamodel-types.md
+++ b/tickets/relations/BUG-008--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: BUG-008
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/BUG-008--fixes--FEAT-017.md
+++ b/tickets/relations/BUG-008--fixes--FEAT-017.md
@@ -1,0 +1,5 @@
+---
+from: BUG-008
+relation: fixes
+to: FEAT-017
+---

--- a/tickets/relations/empty-filter-coercion-tests--protects--metamodel-types.md
+++ b/tickets/relations/empty-filter-coercion-tests--protects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: empty-filter-coercion-tests
+relation: protects
+to: metamodel-types
+---


### PR DESCRIPTION
## Summary
- Fix validation rules with `property!=""` failing for non-string property types (integers, dates, booleans)
- Handle empty filter value checks early in `Match()` before type-specific matching

Fixes #152

## Test plan
- [x] Added tests for empty filter value with integer (int, float64, string representations)
- [x] Added tests for empty filter value with date values
- [x] Added tests for empty filter value with boolean values
- [x] Verified existing tests still pass