### PR TITLE
Fix Go toolchain version mismatch in CI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/Sourcehaven-BV/rela
 
-go 1.24.13
+go 1.24
+
+toolchain go1.24.13
 
 require (
 	github.com/charmbracelet/bubbletea v0.25.0

--- a/tickets/entities/concepts/ci-pipeline.md
+++ b/tickets/entities/concepts/ci-pipeline.md
@@ -1,0 +1,8 @@
+---
+id: ci-pipeline
+status: stable
+title: CI Pipeline
+type: concept
+---
+
+GitHub Actions CI pipeline for the rela project. Runs tests, linting, fuzz tests, and builds on PRs.

--- a/tickets/entities/tickets/TKT-012.md
+++ b/tickets/entities/tickets/TKT-012.md
@@ -1,0 +1,15 @@
+---
+effort: xs
+id: TKT-012
+kind: chore
+priority: high
+status: done
+title: Fix Go version mismatch in CI
+type: ticket
+---
+
+CI fails because golangci-lint v1.64.8 was built with Go 1.24, but the go.mod had `go 1.24.13` which triggered Go's toolchain auto-download to fetch 1.25.0.
+
+## Fix
+
+Add explicit `toolchain go1.24.13` directive to go.mod to prevent auto-upgrade beyond 1.24.x.

--- a/tickets/relations/TKT-012--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-012--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-012
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-012--implements--FEAT-015.md
+++ b/tickets/relations/TKT-012--implements--FEAT-015.md
@@ -1,0 +1,5 @@
+---
+from: TKT-012
+relation: implements
+to: FEAT-015
+---


### PR DESCRIPTION
## Summary
- Add explicit `toolchain go1.24.13` directive to go.mod to prevent Go auto-upgrade to 1.25.x
- This fixes the CI failure where golangci-lint v1.64.8 (built with Go 1.24) couldn't lint code targeting Go 1.25.0

## Test plan
- [ ] CI passes (lint, test, fuzz, build)