### PR TITLE
Define widget type and direction constants

### DIFF
--- a/internal/dataentry/config.go
+++ b/internal/dataentry/config.go
@@ -10,6 +10,20 @@ package dataentry
 
 import "github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 
+// Widget and direction constants — re-exported from dataentryconfig.
+const (
+	WidgetText        = dataentryconfig.WidgetText
+	WidgetSelect      = dataentryconfig.WidgetSelect
+	WidgetMultiSelect = dataentryconfig.WidgetMultiSelect
+	WidgetCheckbox    = dataentryconfig.WidgetCheckbox
+	WidgetTextarea    = dataentryconfig.WidgetTextarea
+	WidgetNumber      = dataentryconfig.WidgetNumber
+	WidgetDate        = dataentryconfig.WidgetDate
+
+	DirectionIncoming = dataentryconfig.DirectionIncoming
+	DirectionOutgoing = dataentryconfig.DirectionOutgoing
+)
+
 // Config type aliases — re-exported from dataentryconfig for backward compatibility.
 type (
 	Config           = dataentryconfig.Config

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -453,9 +453,9 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 			inFrom := containsString(relDef.From, form.EntityType)
 			inTo := containsString(relDef.To, form.EntityType)
 			if inFrom && !inTo {
-				direction = "outgoing"
+				direction = DirectionOutgoing
 			} else if inTo && !inFrom {
-				direction = "incoming"
+				direction = DirectionIncoming
 			}
 			// If in both or neither, direction remains empty (caller must specify)
 		}
@@ -463,7 +463,7 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 		// Resolve target type from metamodel if not specified.
 		targetType := rel.TargetType
 		if targetType == "" && relDefOK {
-			if direction == "incoming" {
+			if direction == DirectionIncoming {
 				if len(relDef.From) == 1 {
 					targetType = relDef.From[0]
 				}
@@ -493,7 +493,7 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 			Relation:      rel.Relation,
 			Label:         label,
 			Required:      rel.Required,
-			Widget:        "select",
+			Widget:        WidgetSelect,
 			TargetType:    targetType,
 			TargetLabel:   targetLabel,
 			AllowCreate:   rel.AllowCreate,
@@ -508,7 +508,7 @@ func (a *App) handleForm(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if entity != nil {
-			if direction == "incoming" {
+			if direction == DirectionIncoming {
 				for _, edge := range a.g.IncomingEdges(entity.ID) {
 					if edge.Type == rel.Relation {
 						rr.Selected = append(rr.Selected, edge.From)
@@ -710,7 +710,7 @@ func (a *App) handleEntity(w http.ResponseWriter, r *http.Request) {
 			title = a.entityDisplayTitle(target)
 			targetType = target.Type
 		}
-		rd := RelDisplay{e.Type, e.To, targetType, title, "outgoing", nil}
+		rd := RelDisplay{e.Type, e.To, targetType, title, DirectionOutgoing, nil}
 		propKeys := make([]string, 0, len(e.Properties))
 		for k := range e.Properties {
 			propKeys = append(propKeys, k)
@@ -729,7 +729,7 @@ func (a *App) handleEntity(w http.ResponseWriter, r *http.Request) {
 			title = a.entityDisplayTitle(source)
 			sourceType = source.Type
 		}
-		rd := RelDisplay{e.Type, e.From, sourceType, title, "incoming", nil}
+		rd := RelDisplay{e.Type, e.From, sourceType, title, DirectionIncoming, nil}
 		propKeys := make([]string, 0, len(e.Properties))
 		for k := range e.Properties {
 			propKeys = append(propKeys, k)
@@ -1018,7 +1018,7 @@ func (a *App) renderFormWithErrors(w http.ResponseWriter, r *http.Request, formI
 			Relation:      rel.Relation,
 			Label:         rel.Label,
 			Required:      rel.Required,
-			Widget:        "select",
+			Widget:        WidgetSelect,
 			TargetType:    rel.TargetType,
 			TargetLabel:   targetLabel,
 			AllowCreate:   rel.AllowCreate,
@@ -1134,7 +1134,7 @@ func (a *App) populateProperties(entity *model.Entity, fields []FormField, entDe
 	for _, f := range fields {
 		prop := entDef.Properties[f.Property]
 		widget := resolveWidget(prop, a.meta)
-		if widget == "multi-select" {
+		if widget == WidgetMultiSelect {
 			values := r.Form[f.Property]
 			if len(values) > 0 {
 				entity.Properties[f.Property] = values
@@ -1175,7 +1175,7 @@ func (a *App) createFormRelations(entityID string, relations []FormRelation, ent
 				continue
 			}
 			var relation *model.Relation
-			if rel.Direction == "incoming" {
+			if rel.Direction == DirectionIncoming {
 				relation = model.NewRelation(targetID, rel.Relation, entityID)
 			} else {
 				relation = model.NewRelation(entityID, rel.Relation, targetID)
@@ -1386,7 +1386,7 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	for _, f := range form.Fields {
 		prop := entDef.Properties[f.Property]
 		widget := resolveWidget(prop, a.meta)
-		if widget == "multi-select" {
+		if widget == WidgetMultiSelect {
 			values := r.Form[f.Property]
 			if len(values) > 0 {
 				entity.Properties[f.Property] = values
@@ -1398,7 +1398,7 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 			if val != "" {
 				entity.Properties[f.Property] = val
 			} else {
-				if widget == "checkbox" {
+				if widget == WidgetCheckbox {
 					entity.Properties[f.Property] = "false"
 				} else {
 					delete(entity.Properties, f.Property)
@@ -1426,7 +1426,7 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		if rel.Display != "" {
 			continue
 		}
-		if rel.Direction == "incoming" {
+		if rel.Direction == DirectionIncoming {
 			for _, edge := range a.g.IncomingEdges(entityID) {
 				if edge.Type == rel.Relation {
 					if delErr := a.repo.DeleteRelation(edge.From, edge.Type, edge.To); delErr != nil {
@@ -1451,7 +1451,7 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			var relation *model.Relation
-			if rel.Direction == "incoming" {
+			if rel.Direction == DirectionIncoming {
 				relation = model.NewRelation(targetID, rel.Relation, entityID)
 			} else {
 				relation = model.NewRelation(entityID, rel.Relation, targetID)
@@ -1615,7 +1615,7 @@ func (a *App) handleInlineCreate(w http.ResponseWriter, r *http.Request) {
 	for _, f := range form.Fields {
 		prop := entDef.Properties[f.Property]
 		widget := resolveWidget(prop, a.meta)
-		if widget == "multi-select" {
+		if widget == WidgetMultiSelect {
 			values := r.Form[f.Property]
 			if len(values) > 0 {
 				entity.Properties[f.Property] = values
@@ -1693,12 +1693,12 @@ func (a *App) handleInlineForm(w http.ResponseWriter, r *http.Request) {
 		}
 
 		switch {
-		case widget == "checkbox":
+		case widget == WidgetCheckbox:
 			sb.WriteString(fmt.Sprintf(`<div class="form-row-checkbox"><input type="checkbox" name="%s" value="true" id="ic-%s"><label for="ic-%s">%s</label></div>`, esc(f.Property), esc(f.Property), esc(f.Property), esc(label)))
-		case widget == "textarea":
+		case widget == WidgetTextarea:
 			sb.WriteString(fmt.Sprintf(`<label for="ic-%s">%s%s</label>`, esc(f.Property), esc(label), reqMark))
 			sb.WriteString(fmt.Sprintf(`<textarea name="%s" id="ic-%s" placeholder="%s" style="min-height:60px;"></textarea>`, esc(f.Property), esc(f.Property), esc(f.Placeholder)))
-		case widget == "select" || widget == "multi-select":
+		case widget == WidgetSelect || widget == WidgetMultiSelect:
 			sb.WriteString(fmt.Sprintf(`<label for="ic-%s">%s%s</label>`, esc(f.Property), esc(label), reqMark))
 			vals := resolvePropertyValues(prop, a.meta)
 			defaultVal := coalesce(f.Default, prop.Default)

--- a/internal/dataentry/handlers_api.go
+++ b/internal/dataentry/handlers_api.go
@@ -317,7 +317,7 @@ func (a *App) entityToAPI(e *model.Entity, includeRelations bool) APIEntity {
 				Type:        edge.Type,
 				From:        edge.From,
 				To:          edge.To,
-				Direction:   "outgoing",
+				Direction:   DirectionOutgoing,
 				TargetID:    edge.To,
 				TargetTitle: a.entityDisplayTitle(target),
 				TargetType:  target.Type,
@@ -341,7 +341,7 @@ func (a *App) entityToAPI(e *model.Entity, includeRelations bool) APIEntity {
 				Type:        edge.Type,
 				From:        edge.From,
 				To:          edge.To,
-				Direction:   "incoming",
+				Direction:   DirectionIncoming,
 				TargetID:    edge.From,
 				TargetTitle: a.entityDisplayTitle(source),
 				TargetType:  source.Type,
@@ -738,7 +738,7 @@ func (a *App) listOutgoingRelations(from string) []APIRelation {
 		if !found {
 			continue
 		}
-		rel := a.edgeToAPIRelation(edge, target, "outgoing", edge.To)
+		rel := a.edgeToAPIRelation(edge, target, DirectionOutgoing, edge.To)
 		relations = append(relations, rel)
 	}
 	return relations
@@ -753,7 +753,7 @@ func (a *App) listIncomingRelations(to string) []APIRelation {
 		if !found {
 			continue
 		}
-		rel := a.edgeToAPIRelation(edge, source, "incoming", edge.From)
+		rel := a.edgeToAPIRelation(edge, source, DirectionIncoming, edge.From)
 		relations = append(relations, rel)
 	}
 	return relations
@@ -768,7 +768,7 @@ func (a *App) listAllRelations() []APIRelation {
 		if !found {
 			continue
 		}
-		rel := a.edgeToAPIRelation(edge, target, "outgoing", edge.To)
+		rel := a.edgeToAPIRelation(edge, target, DirectionOutgoing, edge.To)
 		relations = append(relations, rel)
 	}
 	return relations

--- a/internal/dataentry/handlers_api_test.go
+++ b/internal/dataentry/handlers_api_test.go
@@ -92,7 +92,7 @@ func TestEntityToAPI_WithRelations(t *testing.T) {
 
 	hasOutgoing := false
 	for _, r := range result.Relations {
-		if r.Direction == "outgoing" && r.Type == "depends_on" && r.To == "TKT-002" {
+		if r.Direction == DirectionOutgoing && r.Type == "depends_on" && r.To == "TKT-002" {
 			hasOutgoing = true
 		}
 	}
@@ -105,7 +105,7 @@ func TestEntityToAPI_WithRelations(t *testing.T) {
 	result2 := app.entityToAPI(entity2, true)
 	hasIncoming := false
 	for _, r := range result2.Relations {
-		if r.Direction == "incoming" && r.Type == "depends_on" && r.From == "TKT-001" {
+		if r.Direction == DirectionIncoming && r.Type == "depends_on" && r.From == "TKT-001" {
 			hasIncoming = true
 		}
 	}

--- a/internal/dataentry/handlers_test.go
+++ b/internal/dataentry/handlers_test.go
@@ -333,7 +333,7 @@ func TestHandleForm(t *testing.T) {
 			Fields:     []FormField{{Property: "name"}},
 			Relations: []FormRelation{{
 				Relation:   "belongs_to",
-				Direction:  "incoming",
+				Direction:  DirectionIncoming,
 				TargetType: "ticket",
 				Label:      "Tickets",
 			}},
@@ -364,7 +364,7 @@ func TestHandleForm(t *testing.T) {
 			Fields:     []FormField{{Property: "title"}},
 			Relations: []FormRelation{{
 				Relation:   "depends_on",
-				Direction:  "outgoing",
+				Direction:  DirectionOutgoing,
 				TargetType: "ticket",
 				Label:      "Dependencies",
 			}},

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -140,37 +140,37 @@ func resolvePropertyValues(prop metamodel.PropertyDef, meta *metamodel.Metamodel
 func resolveWidget(prop metamodel.PropertyDef, meta *metamodel.Metamodel) string {
 	// Check if property is a list (multi-select) - only applies to enum types
 	_, isCustomType := meta.Types[prop.Type]
-	isEnum := prop.Type == "enum" || isCustomType
+	isEnum := prop.Type == metamodel.PropertyTypeEnum || isCustomType
 	if prop.List && isEnum {
-		return "multi-select"
+		return WidgetMultiSelect
 	}
 
 	switch prop.Type {
-	case "string":
-		return "text"
-	case "date":
-		return "date"
-	case "integer":
-		return "number"
-	case "boolean":
-		return "checkbox"
-	case "enum":
-		return "select"
+	case metamodel.PropertyTypeString:
+		return WidgetText
+	case metamodel.PropertyTypeDate:
+		return WidgetDate
+	case metamodel.PropertyTypeInteger:
+		return WidgetNumber
+	case metamodel.PropertyTypeBoolean:
+		return WidgetCheckbox
+	case metamodel.PropertyTypeEnum:
+		return WidgetSelect
 	default:
 		if _, ok := meta.Types[prop.Type]; ok {
-			return "select"
+			return WidgetSelect
 		}
-		return "text"
+		return WidgetText
 	}
 }
 
 // widgetToInputType maps a widget name to an HTML input type.
 func widgetToInputType(widget string) string {
 	switch widget {
-	case "textarea":
-		return "textarea"
-	case "select", "multi-select":
-		return "select"
+	case WidgetTextarea:
+		return WidgetTextarea
+	case WidgetSelect, WidgetMultiSelect:
+		return WidgetSelect
 	default:
 		return widget
 	}

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -371,16 +371,16 @@ func TestResolveWidget(t *testing.T) {
 		prop metamodel.PropertyDef
 		want string
 	}{
-		{"string type", metamodel.PropertyDef{Type: "string"}, "text"},
-		{"date type", metamodel.PropertyDef{Type: "date"}, "date"},
-		{"integer type", metamodel.PropertyDef{Type: "integer"}, "number"},
-		{"boolean type", metamodel.PropertyDef{Type: "boolean"}, "checkbox"},
-		{"enum type", metamodel.PropertyDef{Type: "enum"}, "select"},
-		{"custom type", metamodel.PropertyDef{Type: "priority_type"}, "select"},
-		{"unknown type", metamodel.PropertyDef{Type: "something_else"}, "text"},
-		{"list enum type", metamodel.PropertyDef{Type: "enum", List: true}, "multi-select"},
-		{"list custom type", metamodel.PropertyDef{Type: "priority_type", List: true}, "multi-select"},
-		{"list string type (not multi-select)", metamodel.PropertyDef{Type: "string", List: true}, "text"},
+		{"string type", metamodel.PropertyDef{Type: metamodel.PropertyTypeString}, WidgetText},
+		{"date type", metamodel.PropertyDef{Type: metamodel.PropertyTypeDate}, WidgetDate},
+		{"integer type", metamodel.PropertyDef{Type: metamodel.PropertyTypeInteger}, WidgetNumber},
+		{"boolean type", metamodel.PropertyDef{Type: metamodel.PropertyTypeBoolean}, WidgetCheckbox},
+		{"enum type", metamodel.PropertyDef{Type: metamodel.PropertyTypeEnum}, WidgetSelect},
+		{"custom type", metamodel.PropertyDef{Type: "priority_type"}, WidgetSelect},
+		{"unknown type", metamodel.PropertyDef{Type: "something_else"}, WidgetText},
+		{"list enum type", metamodel.PropertyDef{Type: metamodel.PropertyTypeEnum, List: true}, WidgetMultiSelect},
+		{"list custom type", metamodel.PropertyDef{Type: "priority_type", List: true}, WidgetMultiSelect},
+		{"list string type (not multi-select)", metamodel.PropertyDef{Type: metamodel.PropertyTypeString, List: true}, WidgetText},
 	}
 
 	for _, tt := range tests {
@@ -398,13 +398,13 @@ func TestWidgetToInputType(t *testing.T) {
 		widget string
 		want   string
 	}{
-		{"textarea", "textarea"},
-		{"select", "select"},
-		{"multi-select", "select"},
-		{"text", "text"},
-		{"date", "date"},
-		{"number", "number"},
-		{"checkbox", "checkbox"},
+		{WidgetTextarea, WidgetTextarea},
+		{WidgetSelect, WidgetSelect},
+		{WidgetMultiSelect, WidgetSelect},
+		{WidgetText, WidgetText},
+		{WidgetDate, WidgetDate},
+		{WidgetNumber, WidgetNumber},
+		{WidgetCheckbox, WidgetCheckbox},
 	}
 
 	for _, tt := range tests {

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -12,6 +12,23 @@ import (
 // ConfigFile is the conventional filename for data-entry configuration within a rela project.
 const ConfigFile = "data-entry.yaml"
 
+// Widget type constants for form fields.
+const (
+	WidgetText        = "text"
+	WidgetSelect      = "select"
+	WidgetMultiSelect = "multi-select"
+	WidgetCheckbox    = "checkbox"
+	WidgetTextarea    = "textarea"
+	WidgetNumber      = "number"
+	WidgetDate        = "date"
+)
+
+// Relation direction constants for form relations.
+const (
+	DirectionIncoming = "incoming"
+	DirectionOutgoing = "outgoing"
+)
+
 // Config is the top-level configuration for a data entry application.
 type Config struct {
 	Version    string                       `yaml:"version"`

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -82,9 +82,9 @@ var validCommandContexts = map[string]bool{
 
 // Valid relation directions
 var validRelationDirections = map[string]bool{
-	"":                 true, // default (outgoing)
-	DirectionOutgoing:  true,
-	DirectionIncoming:  true,
+	"":                true, // default (outgoing)
+	DirectionOutgoing: true,
+	DirectionIncoming: true,
 }
 
 // ValidateConfig performs comprehensive validation of a data-entry config.

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -82,9 +82,9 @@ var validCommandContexts = map[string]bool{
 
 // Valid relation directions
 var validRelationDirections = map[string]bool{
-	"":         true, // default (outgoing)
-	"outgoing": true,
-	"incoming": true,
+	"":                 true, // default (outgoing)
+	DirectionOutgoing:  true,
+	DirectionIncoming:  true,
 }
 
 // ValidateConfig performs comprehensive validation of a data-entry config.

--- a/tickets/entities/tickets/TKT-016.md
+++ b/tickets/entities/tickets/TKT-016.md
@@ -1,0 +1,10 @@
+---
+description: Replace bare widget type and direction string literals with named constants
+effort: xs
+id: TKT-016
+kind: refactor
+priority: low
+status: done
+title: Define widget type and direction constants
+type: ticket
+---

--- a/tickets/relations/TKT-016--affects--data-entry-server.md
+++ b/tickets/relations/TKT-016--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-016
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-016--implements--FEAT-021.md
+++ b/tickets/relations/TKT-016--implements--FEAT-021.md
@@ -1,0 +1,5 @@
+---
+from: TKT-016
+relation: implements
+to: FEAT-021
+---


### PR DESCRIPTION
## Summary
- Define `Widget*` and `Direction*` constants in `dataentryconfig` package
- Replace bare string literals (`"text"`, `"select"`, `"multi-select"`, `"checkbox"`, `"textarea"`, `"number"`, `"date"`, `"incoming"`, `"outgoing"`) with constants across `dataentry` package
- Replace `prop.Type == "enum"` with `metamodel.PropertyTypeEnum` and similar for other property types
- Re-export constants in `dataentry` for package-internal use

## Test plan
- [x] All existing tests pass with constants instead of literals
- [x] Full `go test ./...` passes
- [x] Build succeeds