### PR TITLE
Unify duplicated type-to-widget mapping

### DIFF
--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -145,23 +145,7 @@ func resolveWidget(prop metamodel.PropertyDef, meta *metamodel.Metamodel) string
 		return WidgetMultiSelect
 	}
 
-	switch prop.Type {
-	case metamodel.PropertyTypeString:
-		return WidgetText
-	case metamodel.PropertyTypeDate:
-		return WidgetDate
-	case metamodel.PropertyTypeInteger:
-		return WidgetNumber
-	case metamodel.PropertyTypeBoolean:
-		return WidgetCheckbox
-	case metamodel.PropertyTypeEnum:
-		return WidgetSelect
-	default:
-		if _, ok := meta.Types[prop.Type]; ok {
-			return WidgetSelect
-		}
-		return WidgetText
-	}
+	return meta.ResolveWidgetFromType(prop.Type)
 }
 
 // widgetToInputType maps a widget name to an HTML input type.

--- a/internal/metamodel/schema_output.go
+++ b/internal/metamodel/schema_output.go
@@ -111,6 +111,29 @@ func (m *Metamodel) GetRelationTo(relation string) []string {
 	return relDef.To
 }
 
+// ResolveWidgetFromType returns the canonical widget for a property type.
+// This is the single source of truth for the type→widget mapping used by
+// the data entry app and the migration system.
+func (m *Metamodel) ResolveWidgetFromType(propType string) string {
+	switch propType {
+	case PropertyTypeString:
+		return "text"
+	case PropertyTypeDate:
+		return "date"
+	case PropertyTypeInteger:
+		return "number"
+	case PropertyTypeBoolean:
+		return "checkbox"
+	case PropertyTypeEnum:
+		return "select"
+	default:
+		if ct, ok := m.Types[propType]; ok && len(ct.Values) > 0 {
+			return "select"
+		}
+		return "text"
+	}
+}
+
 // Schema output interface methods for EntityDef
 
 // GetLabel returns the entity label

--- a/internal/migration/dataentry_cleanup.go
+++ b/internal/migration/dataentry_cleanup.go
@@ -175,7 +175,7 @@ func (m *DataEntryCleanupMigration) isRedundantWidget(node *yaml.Node, entityTyp
 		return false
 	}
 
-	expectedWidget := resolveWidgetFromType(propType, m.meta)
+	expectedWidget := m.meta.ResolveWidgetFromType(propType)
 	return widget == expectedWidget
 }
 
@@ -441,28 +441,6 @@ func containsStr(slice []string, s string) bool {
 		}
 	}
 	return false
-}
-
-// resolveWidgetFromType returns the expected widget for a property type.
-func resolveWidgetFromType(propType string, meta MetamodelProvider) string {
-	switch propType {
-	case "string":
-		return "text"
-	case "date":
-		return "date"
-	case "integer":
-		return "number"
-	case "boolean":
-		return "checkbox"
-	case "enum":
-		return "select"
-	default:
-		// Check if it's a custom type with values (enum-like)
-		if meta != nil && meta.IsEnumType(propType) {
-			return "select"
-		}
-		return "text"
-	}
 }
 
 // titleCase converts snake_case or kebab-case to Title Case.

--- a/internal/migration/dataentry_cleanup_test.go
+++ b/internal/migration/dataentry_cleanup_test.go
@@ -97,6 +97,26 @@ func (m *mockMetamodel) GetRelationTo(relation string) []string {
 	return nil
 }
 
+func (m *mockMetamodel) ResolveWidgetFromType(propType string) string {
+	switch propType {
+	case "string":
+		return "text"
+	case "date":
+		return "date"
+	case "integer":
+		return "number"
+	case "boolean":
+		return "checkbox"
+	case "enum":
+		return "select"
+	default:
+		if ct, ok := m.types[propType]; ok && len(ct.values) > 0 {
+			return "select"
+		}
+		return "text"
+	}
+}
+
 func TestDataEntryCleanupMigration_Detect(t *testing.T) {
 	m := &DataEntryCleanupMigration{}
 
@@ -701,9 +721,9 @@ func TestResolveWidgetFromType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.propType, func(t *testing.T) {
-			got := resolveWidgetFromType(tt.propType, meta)
+			got := meta.ResolveWidgetFromType(tt.propType)
 			if got != tt.want {
-				t.Errorf("resolveWidgetFromType(%q) = %q, want %q", tt.propType, got, tt.want)
+				t.Errorf("ResolveWidgetFromType(%q) = %q, want %q", tt.propType, got, tt.want)
 			}
 		})
 	}

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -24,6 +24,8 @@ type MetamodelProvider interface {
 	GetRelationFrom(relation string) []string
 	// GetRelationTo returns the "to" entity types for a relation.
 	GetRelationTo(relation string) []string
+	// ResolveWidgetFromType returns the canonical widget for a property type.
+	ResolveWidgetFromType(propType string) string
 }
 
 // FileType identifies which project files a migration applies to.

--- a/tickets/entities/tickets/TKT-017.md
+++ b/tickets/entities/tickets/TKT-017.md
@@ -1,0 +1,10 @@
+---
+description: Unify duplicated type-to-widget mapping between dataentry and migration packages
+effort: xs
+id: TKT-017
+kind: refactor
+priority: low
+status: done
+title: Unify type-to-widget mapping
+type: ticket
+---

--- a/tickets/relations/TKT-017--affects--data-entry-server.md
+++ b/tickets/relations/TKT-017--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-017
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-017--implements--FEAT-021.md
+++ b/tickets/relations/TKT-017--implements--FEAT-021.md
@@ -1,0 +1,5 @@
+---
+from: TKT-017
+relation: implements
+to: FEAT-021
+---


### PR DESCRIPTION
## Summary
- Move canonical type→widget mapping to `Metamodel.ResolveWidgetFromType()` as single source of truth
- Add `ResolveWidgetFromType` to `MetamodelProvider` interface so migration can use it
- Remove duplicate `resolveWidgetFromType()` from migration package
- Simplify `dataentry/helpers.go:resolveWidget()` to delegate to metamodel

## Test plan
- [x] All existing tests pass (migration, dataentry, metamodel)
- [x] `TestResolveWidgetFromType` updated to call through interface
- [x] gofmt clean