### PR TITLE
Add architecture boundary linting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,23 @@ jobs:
         with:
           version: v1.64.8
 
+  arch-lint:
+    name: Architecture
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Install go-arch-lint
+        run: go install github.com/fe3dback/go-arch-lint@latest
+
+      - name: Check architecture
+        run: go-arch-lint check
+
   lint-markdown:
     name: Lint Markdown
     runs-on: ubuntu-latest
@@ -204,7 +221,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [test, lint, lint-markdown, fuzz]
+    needs: [test, lint, arch-lint, lint-markdown, fuzz]
     steps:
       - uses: actions/checkout@v4
 

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -1,0 +1,268 @@
+version: 3
+
+allow:
+  depOnAnyVendor: false
+  deepScan: false
+
+exclude:
+  - internal/testutil
+
+excludeFiles:
+  - "_test\\.go$"
+
+# -- Components ----------------------------------------------------------
+components:
+  # Entry points
+  cmdCli:           { in: cmd/rela }
+  cmdServer:        { in: cmd/rela-server }
+  cmdDesktop:       { in: cmd/rela-desktop }
+  mobileApi:        { in: pkg/mobileapi }
+
+  # CLI layer
+  cli:              { in: internal/cli }
+
+  # Web / UI layer
+  dataentry:        { in: internal/dataentry }
+  dataentryconfig:  { in: internal/dataentryconfig }
+  desktop:          { in: internal/desktop }
+
+  # Server protocols
+  mcp:              { in: internal/mcp }
+
+  # Domain services
+  automation:       { in: internal/automation }
+  conflict:         { in: internal/conflict }
+  importer:         { in: internal/importer }
+  rename:           { in: internal/rename }
+  repository:       { in: internal/repository }
+  views:            { in: internal/views }
+
+  # Core domain
+  graph:            { in: internal/graph }
+  metamodel:        { in: internal/metamodel }
+  migration:        { in: internal/migration }
+  model:            { in: internal/model }
+  markdown:         { in: internal/markdown }
+  filter:           { in: internal/filter }
+  search:           { in: internal/search/** }
+
+  # Infrastructure
+  attachment:       { in: internal/attachment }
+  git:              { in: internal/git }
+  output:           { in: internal/output }
+  project:          { in: internal/project }
+  storage:          { in: internal/storage }
+
+  # Shared utilities
+  errors:           { in: internal/errors }
+  natsort:          { in: internal/natsort }
+
+# -- Vendors --------------------------------------------------------------
+vendors:
+  cobra:       { in: github.com/spf13/cobra }
+  yaml:        { in: gopkg.in/yaml.v3 }
+  goldmark:
+    in:
+      - github.com/yuin/goldmark
+      - github.com/yuin/goldmark/**
+  gogit:       { in: github.com/go-git/go-git/** }
+  mcpgo:       { in: github.com/mark3labs/mcp-go/** }
+  wails:       { in: github.com/wailsapp/wails/** }
+  tablewriter: { in: github.com/olekukonko/tablewriter }
+  color:       { in: github.com/fatih/color }
+  fsnotify:    { in: github.com/fsnotify/fsnotify }
+
+# -- Common (importable by all) -------------------------------------------
+commonComponents:
+  - model
+  - errors
+  - natsort
+
+commonVendors:
+  - yaml
+
+# -- Dependency rules ------------------------------------------------------
+deps:
+  # Entry points
+  cmdCli:
+    mayDependOn:
+      - cli
+  cmdServer:
+    mayDependOn:
+      - dataentry
+      - project
+      - repository
+      - storage
+  cmdDesktop:
+    mayDependOn:
+      - dataentry
+      - desktop
+      - git
+      - metamodel
+      - project
+      - repository
+      - storage
+    canUse:
+      - wails
+  mobileApi:
+    mayDependOn:
+      - dataentry
+      - project
+      - repository
+      - storage
+    canUse:
+      - gogit
+
+  # CLI layer — orchestrates everything
+  cli:
+    mayDependOn:
+      - attachment
+      - automation
+      - dataentryconfig
+      - filter
+      - graph
+      - importer
+      - markdown
+      - mcp
+      - metamodel
+      - migration
+      - output
+      - project
+      - rename
+      - repository
+      - storage
+      - views
+    canUse:
+      - cobra
+      - color
+      - goldmark
+      - tablewriter
+
+  # Web / UI layer
+  dataentry:
+    mayDependOn:
+      - automation
+      - conflict
+      - dataentryconfig
+      - filter
+      - git
+      - graph
+      - markdown
+      - metamodel
+      - migration
+      - project
+      - repository
+      - search
+    canUse:
+      - goldmark
+      - gogit
+  dataentryconfig:
+    mayDependOn:
+      - git
+      - metamodel
+  desktop:
+    canUse:
+      - wails
+
+  # Server protocols
+  mcp:
+    mayDependOn:
+      - filter
+      - graph
+      - markdown
+      - metamodel
+      - migration
+      - project
+      - rename
+      - repository
+      - search
+      - views
+    canUse:
+      - mcpgo
+      - fsnotify
+
+  # Domain services
+  automation:
+    mayDependOn:
+      - filter
+      - metamodel
+  conflict:
+    mayDependOn:
+      - markdown
+      - metamodel
+      - project
+      - storage
+  importer:
+    mayDependOn:
+      - graph
+      - metamodel
+      - repository
+      - storage
+  rename:
+    mayDependOn:
+      - graph
+      - metamodel
+      - project
+      - repository
+  repository:
+    mayDependOn:
+      - graph
+      - markdown
+      - metamodel
+      - project
+      - storage
+      - views
+    canUse:
+      - gogit
+  views:
+    mayDependOn:
+      - filter
+      - graph
+      - metamodel
+      - storage
+
+  # Core domain
+  graph:
+    mayDependOn:
+      - storage
+  metamodel:
+    mayDependOn:
+      - migration
+      - storage
+  migration:
+    mayDependOn:
+      - storage
+  markdown:
+    mayDependOn:
+      - graph
+      - metamodel
+      - project
+      - storage
+    canUse:
+      - goldmark
+  filter:
+    mayDependOn:
+      - metamodel
+  search:
+    anyProjectDeps: true
+
+  # Infrastructure
+  attachment:
+    mayDependOn:
+      - storage
+  git:
+    canUse:
+      - gogit
+  output:
+    mayDependOn:
+      - graph
+    canUse:
+      - color
+      - tablewriter
+  project:
+    mayDependOn:
+      - storage
+  storage:
+    anyProjectDeps: true
+    canUse:
+      - fsnotify

--- a/justfile
+++ b/justfile
@@ -129,6 +129,11 @@ lint:
     @echo "Running Go linter..."
     golangci-lint run
 
+# Check architecture boundaries
+arch-lint:
+    @echo "Checking architecture boundaries..."
+    go-arch-lint check
+
 # Run linter with auto-fix
 lint-fix:
     @echo "Running linter with auto-fix..."
@@ -162,8 +167,8 @@ vet:
 
 # ── CI & Checks ──
 
-# Run all checks (lint + lint-md + test)
-check: lint lint-md test
+# Run all checks (lint + arch-lint + lint-md + test)
+check: lint arch-lint lint-md test
 
 # Generate docs from rela entities via mdcomp
 docs: build-cli
@@ -192,6 +197,8 @@ install-tools:
     go install golang.org/x/tools/cmd/goimports@latest
     @echo "Installing go-test-coverage..."
     go install github.com/vladopajic/go-test-coverage/v2@latest
+    @echo "Installing go-arch-lint..."
+    go install github.com/fe3dback/go-arch-lint@latest
     @echo "Done!"
 
 # Install git hooks

--- a/tickets/entities/tickets/TKT-018.md
+++ b/tickets/entities/tickets/TKT-018.md
@@ -1,0 +1,10 @@
+---
+description: Add go-arch-lint to CI to enforce package dependency boundaries
+effort: xs
+id: TKT-018
+kind: enhancement
+priority: medium
+status: done
+title: Add architecture boundary linting to CI
+type: ticket
+---

--- a/tickets/relations/TKT-018--affects--ci-cd.md
+++ b/tickets/relations/TKT-018--affects--ci-cd.md
@@ -1,0 +1,5 @@
+---
+from: TKT-018
+relation: affects
+to: ci-cd
+---

--- a/tickets/relations/TKT-018--implements--FEAT-021.md
+++ b/tickets/relations/TKT-018--implements--FEAT-021.md
@@ -1,0 +1,5 @@
+---
+from: TKT-018
+relation: implements
+to: FEAT-021
+---


### PR DESCRIPTION
## Summary
- Add `go-arch-lint` config (`.go-arch-lint.yml`) with all 32 components, 9 vendors, and explicit dependency rules
- Add `Architecture` job to CI workflow (runs in parallel with Lint, Test, etc.)
- Add `just arch-lint` target and include in `just check` / `just ci`
- Add go-arch-lint to `just install-tools`

## Test plan
- [x] `go-arch-lint check` passes locally
- [x] Config covers all packages in cmd/, internal/, pkg/