### PR TITLE
Decouple markdown from project package

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -234,7 +234,6 @@ deps:
   markdown:
     mayDependOn:
       - metamodel
-      - project
       - storage
     canUse:
       - goldmark

--- a/internal/markdown/sync.go
+++ b/internal/markdown/sync.go
@@ -3,7 +3,6 @@ package markdown
 import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
-	"github.com/Sourcehaven-BV/rela/internal/project"
 )
 
 // SyncData holds the raw entities and relations loaded from markdown files,
@@ -19,12 +18,12 @@ type SyncData struct {
 // them as raw data. It does NOT populate a graph — that is left to the caller.
 // Files with git conflict markers are skipped and tracked in Conflicted.
 func (f *FileIO) LoadSyncData(
-	ctx *project.Context, meta *metamodel.Metamodel,
+	entitiesDir, relationsDir string, meta *metamodel.Metamodel,
 ) (*SyncData, error) {
 	data := &SyncData{}
 
 	// Load all entities (with conflict tracking)
-	entityResult, err := f.LoadAllEntitiesWithConflicts(ctx.EntitiesDir, meta)
+	entityResult, err := f.LoadAllEntitiesWithConflicts(entitiesDir, meta)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +31,7 @@ func (f *FileIO) LoadSyncData(
 	data.Conflicted = append(data.Conflicted, entityResult.Conflicted...)
 
 	// Load all relations (with conflict tracking)
-	relationResult, err := f.LoadAllRelationsWithConflicts(ctx.RelationsDir)
+	relationResult, err := f.LoadAllRelationsWithConflicts(relationsDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/markdown/sync_test.go
+++ b/internal/markdown/sync_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
-	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/testutil"
 )
@@ -42,14 +41,7 @@ func TestLoadSyncData(t *testing.T) {
 		WithRelation(rel2).
 		Build()
 
-	ctx := &project.Context{
-		Root:         testCtx.Root,
-		EntitiesDir:  testCtx.EntitiesDir,
-		RelationsDir: testCtx.RelationsDir,
-		CacheDir:     testCtx.CacheDir,
-	}
-
-	data, err := testIO.LoadSyncData(ctx, meta)
+	data, err := testIO.LoadSyncData(testCtx.EntitiesDir, testCtx.RelationsDir, meta)
 	testutil.AssertNoError(t, err)
 
 	if len(data.Entities) != 3 {
@@ -66,14 +58,7 @@ func TestLoadSyncData(t *testing.T) {
 func TestLoadSyncData_EmptyDirectories(t *testing.T) {
 	testCtx, meta, _ := testutil.NewProject(t).Build()
 
-	ctx := &project.Context{
-		Root:         testCtx.Root,
-		EntitiesDir:  testCtx.EntitiesDir,
-		RelationsDir: testCtx.RelationsDir,
-		CacheDir:     testCtx.CacheDir,
-	}
-
-	data, err := testIO.LoadSyncData(ctx, meta)
+	data, err := testIO.LoadSyncData(testCtx.EntitiesDir, testCtx.RelationsDir, meta)
 	testutil.AssertNoError(t, err)
 
 	if len(data.Entities) != 0 {
@@ -94,19 +79,13 @@ func TestLoadSyncData_LoadEntitiesError(t *testing.T) {
 
 	errorIO := NewFileIO(errFS)
 
-	ctx := &project.Context{
-		Root:         "/test",
-		EntitiesDir:  "/test/entities",
-		RelationsDir: "/test/relations",
-	}
-
 	meta := &metamodel.Metamodel{
 		Entities: map[string]metamodel.EntityDef{
 			"requirement": {Label: "Requirement"},
 		},
 	}
 
-	_, err := errorIO.LoadSyncData(ctx, meta)
+	_, err := errorIO.LoadSyncData("/test/entities", "/test/relations", meta)
 	if err == nil {
 		t.Error("expected error from LoadSyncData when LoadAllEntities fails")
 	}
@@ -117,17 +96,14 @@ func TestLoadSyncData_LoadEntitiesError(t *testing.T) {
 
 func TestLoadSyncData_ConflictedFiles(t *testing.T) {
 	tmpDir := t.TempDir()
-	ctx := &project.Context{
-		Root:         tmpDir,
-		EntitiesDir:  filepath.Join(tmpDir, "entities"),
-		RelationsDir: filepath.Join(tmpDir, "relations"),
-	}
+	entitiesDir := filepath.Join(tmpDir, "entities")
+	relationsDir := filepath.Join(tmpDir, "relations")
 
-	reqDir := filepath.Join(ctx.EntitiesDir, "requirement")
+	reqDir := filepath.Join(entitiesDir, "requirement")
 	if err := os.MkdirAll(reqDir, 0755); err != nil {
 		t.Fatalf("failed to create dir: %v", err)
 	}
-	if err := os.MkdirAll(ctx.RelationsDir, 0755); err != nil {
+	if err := os.MkdirAll(relationsDir, 0755); err != nil {
 		t.Fatalf("failed to create relations dir: %v", err)
 	}
 
@@ -165,7 +141,7 @@ relation: depends-on
 to: REQ-001
 ---
 `
-	if err := os.WriteFile(filepath.Join(ctx.RelationsDir, "REQ-001--depends-on--REQ-001.md"), []byte(relationContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(relationsDir, "REQ-001--depends-on--REQ-001.md"), []byte(relationContent), 0644); err != nil {
 		t.Fatalf("failed to create relation: %v", err)
 	}
 
@@ -180,7 +156,7 @@ to: REQ-003
 >>>>>>> feature-branch
 ---
 `
-	conflictedRelationPath := filepath.Join(ctx.RelationsDir, "REQ-001--addresses--conflict.md")
+	conflictedRelationPath := filepath.Join(relationsDir, "REQ-001--addresses--conflict.md")
 	if err := os.WriteFile(conflictedRelationPath, []byte(conflictedRelationContent), 0644); err != nil {
 		t.Fatalf("failed to create conflicted relation: %v", err)
 	}
@@ -191,7 +167,7 @@ to: REQ-003
 		},
 	}
 
-	data, err := testIO.LoadSyncData(ctx, meta)
+	data, err := testIO.LoadSyncData(entitiesDir, relationsDir, meta)
 	if err != nil {
 		t.Fatalf("LoadSyncData failed: %v", err)
 	}

--- a/internal/markdown/template.go
+++ b/internal/markdown/template.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/natsort"
-	"github.com/Sourcehaven-BV/rela/internal/project"
 )
 
 // ErrTemplateNotFound is returned when a template file does not exist.
@@ -34,9 +33,9 @@ type EntityTemplate struct {
 
 // LoadEntityTemplate reads an entity template file and returns the parsed document.
 // Returns nil, nil if the template file does not exist.
-func (f *FileIO) LoadEntityTemplate(ctx *project.Context, entityType string) (*Document, error) {
-	path := ctx.EntityTemplatePath(entityType)
-	doc, err := f.loadTemplate(path)
+// The templatePath should be the full path to the template file.
+func (f *FileIO) LoadEntityTemplate(templatePath string) (*Document, error) {
+	doc, err := f.loadTemplate(templatePath)
 	if errors.Is(err, ErrTemplateNotFound) {
 		return nil, nil //nolint:nilnil // nil,nil is intentional when template doesn't exist
 	}
@@ -45,9 +44,9 @@ func (f *FileIO) LoadEntityTemplate(ctx *project.Context, entityType string) (*D
 
 // LoadRelationTemplate reads a relation template file and returns the parsed document.
 // Returns nil, nil if the template file does not exist.
-func (f *FileIO) LoadRelationTemplate(ctx *project.Context, relationType string) (*Document, error) {
-	path := ctx.RelationTemplatePath(relationType)
-	doc, err := f.loadTemplate(path)
+// The templatePath should be the full path to the template file.
+func (f *FileIO) LoadRelationTemplate(templatePath string) (*Document, error) {
+	doc, err := f.loadTemplate(templatePath)
 	if errors.Is(err, ErrTemplateNotFound) {
 		return nil, nil //nolint:nilnil // nil,nil is intentional when template doesn't exist
 	}
@@ -61,8 +60,9 @@ func (f *FileIO) LoadRelationTemplate(ctx *project.Context, relationType string)
 //
 // Returns templates sorted by name (default first, then alphabetically).
 // Returns an empty slice if no templates exist (not an error).
-func (f *FileIO) DiscoverEntityTemplates(ctx *project.Context, entityType string) ([]*EntityTemplate, error) {
-	dir := ctx.EntityTemplatesDir
+// The templatesDir should be the path to the entity templates directory.
+func (f *FileIO) DiscoverEntityTemplates(templatesDir, entityType string) ([]*EntityTemplate, error) {
+	dir := templatesDir
 
 	// Check if templates directory exists
 	if _, err := f.FS.Stat(dir); os.IsNotExist(err) {
@@ -261,13 +261,12 @@ func ApplyRelationTemplate(relation *model.Relation, template *Document) {
 }
 
 // GenerateEntityTemplate creates a template file for an entity type.
-// If variant is non-empty, creates a variant template (e.g., type--variant.md).
 // Returns true if the file was created, false if it already existed (and force is false).
+// The templatePath should be the full path where the template file will be written.
 func (f *FileIO) GenerateEntityTemplate(
-	ctx *project.Context,
+	templatePath string,
 	meta *metamodel.Metamodel,
 	entityType string,
-	variant string,
 	force bool,
 ) (bool, error) {
 	entityDef, ok := meta.GetEntityDef(entityType)
@@ -275,7 +274,7 @@ func (f *FileIO) GenerateEntityTemplate(
 		return false, fmt.Errorf("unknown entity type: %s", entityType)
 	}
 
-	path := ctx.EntityTemplateVariantPath(entityType, variant)
+	path := templatePath
 
 	// Check if file exists
 	if !force {
@@ -362,8 +361,9 @@ func getPropertyDefault(prop metamodel.PropertyDef, meta *metamodel.Metamodel) i
 
 // GenerateRelationTemplate creates a template file for a relation type.
 // Returns true if the file was created, false if it already existed (and force is false).
+// The templatePath should be the full path where the template file will be written.
 func (f *FileIO) GenerateRelationTemplate(
-	ctx *project.Context,
+	templatePath string,
 	meta *metamodel.Metamodel,
 	relationType string,
 	force bool,
@@ -373,7 +373,7 @@ func (f *FileIO) GenerateRelationTemplate(
 		return false, fmt.Errorf("unknown relation type: %s", relationType)
 	}
 
-	path := ctx.RelationTemplatePath(relationType)
+	path := templatePath
 
 	// Check if file exists
 	if !force {

--- a/internal/markdown/template_test.go
+++ b/internal/markdown/template_test.go
@@ -7,24 +7,43 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
-	"github.com/Sourcehaven-BV/rela/internal/project"
 )
 
-func setupTestContext(t *testing.T) *project.Context {
+type testPaths struct {
+	root                 string
+	entityTemplatesDir   string
+	relationTemplatesDir string
+}
+
+func setupTestPaths(t *testing.T) testPaths {
 	t.Helper()
 	tmpDir := t.TempDir()
-	return &project.Context{
-		Root:                 tmpDir,
-		TemplatesDir:         filepath.Join(tmpDir, "templates"),
-		EntityTemplatesDir:   filepath.Join(tmpDir, "templates", "entities"),
-		RelationTemplatesDir: filepath.Join(tmpDir, "templates", "relations"),
+	return testPaths{
+		root:                 tmpDir,
+		entityTemplatesDir:   filepath.Join(tmpDir, "templates", "entities"),
+		relationTemplatesDir: filepath.Join(tmpDir, "templates", "relations"),
 	}
 }
 
-func TestLoadEntityTemplate_NotFound(t *testing.T) {
-	ctx := setupTestContext(t)
+func (p testPaths) entityTemplatePath(entityType string) string {
+	return filepath.Join(p.entityTemplatesDir, entityType+".md")
+}
 
-	doc, err := testIO.LoadEntityTemplate(ctx, "requirement")
+func (p testPaths) entityTemplateVariantPath(entityType, variant string) string {
+	if variant == "" {
+		return p.entityTemplatePath(entityType)
+	}
+	return filepath.Join(p.entityTemplatesDir, entityType+"--"+variant+".md")
+}
+
+func (p testPaths) relationTemplatePath(relationType string) string {
+	return filepath.Join(p.relationTemplatesDir, relationType+".md")
+}
+
+func TestLoadEntityTemplate_NotFound(t *testing.T) {
+	paths := setupTestPaths(t)
+
+	doc, err := testIO.LoadEntityTemplate(paths.entityTemplatePath("requirement"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -34,10 +53,10 @@ func TestLoadEntityTemplate_NotFound(t *testing.T) {
 }
 
 func TestLoadEntityTemplate_Success(t *testing.T) {
-	ctx := setupTestContext(t)
+	paths := setupTestPaths(t)
 
 	// Create template directory and file
-	if err := os.MkdirAll(ctx.EntityTemplatesDir, 0755); err != nil {
+	if err := os.MkdirAll(paths.entityTemplatesDir, 0755); err != nil {
 		t.Fatalf("failed to create template dir: %v", err)
 	}
 
@@ -51,12 +70,12 @@ priority: high
 
 This is a template description.
 `
-	templatePath := ctx.EntityTemplatePath("requirement")
+	templatePath := paths.entityTemplatePath("requirement")
 	if err := os.WriteFile(templatePath, []byte(templateContent), 0644); err != nil {
 		t.Fatalf("failed to write template: %v", err)
 	}
 
-	doc, err := testIO.LoadEntityTemplate(ctx, "requirement")
+	doc, err := testIO.LoadEntityTemplate(templatePath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -82,9 +101,9 @@ This is a template description.
 }
 
 func TestLoadRelationTemplate_NotFound(t *testing.T) {
-	ctx := setupTestContext(t)
+	paths := setupTestPaths(t)
 
-	doc, err := testIO.LoadRelationTemplate(ctx, "addresses")
+	doc, err := testIO.LoadRelationTemplate(paths.relationTemplatePath("addresses"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -196,7 +215,7 @@ func TestApplyRelationTemplate(t *testing.T) {
 }
 
 func TestGenerateEntityTemplate(t *testing.T) {
-	ctx := setupTestContext(t)
+	paths := setupTestPaths(t)
 
 	meta := &metamodel.Metamodel{
 		Entities: map[string]metamodel.EntityDef{
@@ -223,7 +242,8 @@ func TestGenerateEntityTemplate(t *testing.T) {
 	}
 
 	// Generate template
-	created, err := testIO.GenerateEntityTemplate(ctx, meta, "requirement", "", false)
+	templatePath := paths.entityTemplatePath("requirement")
+	created, err := testIO.GenerateEntityTemplate(templatePath, meta, "requirement", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -232,7 +252,6 @@ func TestGenerateEntityTemplate(t *testing.T) {
 	}
 
 	// Verify file exists and has correct content
-	templatePath := ctx.EntityTemplatePath("requirement")
 	content, err := os.ReadFile(templatePath)
 	if err != nil {
 		t.Fatalf("failed to read template: %v", err)
@@ -264,7 +283,7 @@ func TestGenerateEntityTemplate(t *testing.T) {
 }
 
 func TestGenerateEntityTemplate_NoOverwrite(t *testing.T) {
-	ctx := setupTestContext(t)
+	paths := setupTestPaths(t)
 
 	meta := &metamodel.Metamodel{
 		Entities: map[string]metamodel.EntityDef{
@@ -276,16 +295,17 @@ func TestGenerateEntityTemplate_NoOverwrite(t *testing.T) {
 	}
 
 	// Create existing template
-	if err := os.MkdirAll(ctx.EntityTemplatesDir, 0755); err != nil {
+	if err := os.MkdirAll(paths.entityTemplatesDir, 0755); err != nil {
 		t.Fatalf("failed to create dir: %v", err)
 	}
+	templatePath := paths.entityTemplatePath("requirement")
 	existingContent := "existing content"
-	if err := os.WriteFile(ctx.EntityTemplatePath("requirement"), []byte(existingContent), 0644); err != nil {
+	if err := os.WriteFile(templatePath, []byte(existingContent), 0644); err != nil {
 		t.Fatalf("failed to write existing template: %v", err)
 	}
 
 	// Try to generate without force
-	created, err := testIO.GenerateEntityTemplate(ctx, meta, "requirement", "", false)
+	created, err := testIO.GenerateEntityTemplate(templatePath, meta, "requirement", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -294,14 +314,14 @@ func TestGenerateEntityTemplate_NoOverwrite(t *testing.T) {
 	}
 
 	// Verify content unchanged
-	content, _ := os.ReadFile(ctx.EntityTemplatePath("requirement"))
+	content, _ := os.ReadFile(templatePath)
 	if string(content) != existingContent {
 		t.Errorf("content = %q, want %q (should not be overwritten)", string(content), existingContent)
 	}
 }
 
 func TestGenerateEntityTemplate_ForceOverwrite(t *testing.T) {
-	ctx := setupTestContext(t)
+	paths := setupTestPaths(t)
 
 	meta := &metamodel.Metamodel{
 		Entities: map[string]metamodel.EntityDef{
@@ -313,15 +333,16 @@ func TestGenerateEntityTemplate_ForceOverwrite(t *testing.T) {
 	}
 
 	// Create existing template
-	if err := os.MkdirAll(ctx.EntityTemplatesDir, 0755); err != nil {
+	if err := os.MkdirAll(paths.entityTemplatesDir, 0755); err != nil {
 		t.Fatalf("failed to create dir: %v", err)
 	}
-	if err := os.WriteFile(ctx.EntityTemplatePath("requirement"), []byte("old"), 0644); err != nil {
+	templatePath := paths.entityTemplatePath("requirement")
+	if err := os.WriteFile(templatePath, []byte("old"), 0644); err != nil {
 		t.Fatalf("failed to write existing template: %v", err)
 	}
 
 	// Generate with force
-	created, err := testIO.GenerateEntityTemplate(ctx, meta, "requirement", "", true)
+	created, err := testIO.GenerateEntityTemplate(templatePath, meta, "requirement", true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -330,27 +351,27 @@ func TestGenerateEntityTemplate_ForceOverwrite(t *testing.T) {
 	}
 
 	// Verify content changed
-	content, _ := os.ReadFile(ctx.EntityTemplatePath("requirement"))
+	content, _ := os.ReadFile(templatePath)
 	if string(content) == "old" {
 		t.Error("content should have been overwritten")
 	}
 }
 
 func TestGenerateEntityTemplate_UnknownType(t *testing.T) {
-	ctx := setupTestContext(t)
+	paths := setupTestPaths(t)
 
 	meta := &metamodel.Metamodel{
 		Entities: map[string]metamodel.EntityDef{},
 	}
 
-	_, err := testIO.GenerateEntityTemplate(ctx, meta, "unknown", "", false)
+	_, err := testIO.GenerateEntityTemplate(paths.entityTemplatePath("unknown"), meta, "unknown", false)
 	if err == nil {
 		t.Error("expected error for unknown entity type")
 	}
 }
 
 func TestGenerateEntityTemplate_Variant(t *testing.T) {
-	ctx := setupTestContext(t)
+	paths := setupTestPaths(t)
 
 	meta := &metamodel.Metamodel{
 		Entities: map[string]metamodel.EntityDef{
@@ -370,7 +391,8 @@ func TestGenerateEntityTemplate_Variant(t *testing.T) {
 	}
 
 	// Generate variant template
-	created, err := testIO.GenerateEntityTemplate(ctx, meta, "requirement", "epic", false)
+	variantPath := paths.entityTemplateVariantPath("requirement", "epic")
+	created, err := testIO.GenerateEntityTemplate(variantPath, meta, "requirement", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -379,13 +401,12 @@ func TestGenerateEntityTemplate_Variant(t *testing.T) {
 	}
 
 	// Verify file exists at correct path (requirement--epic.md)
-	variantPath := ctx.EntityTemplateVariantPath("requirement", "epic")
 	if _, statErr := os.Stat(variantPath); os.IsNotExist(statErr) {
 		t.Error("variant template file should exist")
 	}
 
 	// Default template should NOT exist
-	defaultPath := ctx.EntityTemplatePath("requirement")
+	defaultPath := paths.entityTemplatePath("requirement")
 	if _, statErr := os.Stat(defaultPath); !os.IsNotExist(statErr) {
 		t.Error("default template should not be created when generating variant")
 	}
@@ -401,7 +422,7 @@ func TestGenerateEntityTemplate_Variant(t *testing.T) {
 }
 
 func TestGenerateRelationTemplate(t *testing.T) {
-	ctx := setupTestContext(t)
+	paths := setupTestPaths(t)
 
 	meta := &metamodel.Metamodel{
 		Relations: map[string]metamodel.RelationDef{
@@ -413,7 +434,8 @@ func TestGenerateRelationTemplate(t *testing.T) {
 		},
 	}
 
-	created, err := testIO.GenerateRelationTemplate(ctx, meta, "addresses", false)
+	templatePath := paths.relationTemplatePath("addresses")
+	created, err := testIO.GenerateRelationTemplate(templatePath, meta, "addresses", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -422,29 +444,28 @@ func TestGenerateRelationTemplate(t *testing.T) {
 	}
 
 	// Verify file exists
-	templatePath := ctx.RelationTemplatePath("addresses")
 	if _, err := os.Stat(templatePath); os.IsNotExist(err) {
 		t.Error("template file should exist")
 	}
 }
 
 func TestGenerateRelationTemplate_UnknownType(t *testing.T) {
-	ctx := setupTestContext(t)
+	paths := setupTestPaths(t)
 
 	meta := &metamodel.Metamodel{
 		Relations: map[string]metamodel.RelationDef{},
 	}
 
-	_, err := testIO.GenerateRelationTemplate(ctx, meta, "unknown", false)
+	_, err := testIO.GenerateRelationTemplate(paths.relationTemplatePath("unknown"), meta, "unknown", false)
 	if err == nil {
 		t.Error("expected error for unknown relation type")
 	}
 }
 
 func TestDiscoverEntityTemplates_NoTemplatesDir(t *testing.T) {
-	ctx := setupTestContext(t)
+	paths := setupTestPaths(t)
 
-	templates, err := testIO.DiscoverEntityTemplates(ctx, "requirement")
+	templates, err := testIO.DiscoverEntityTemplates(paths.entityTemplatesDir, "requirement")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -454,10 +475,10 @@ func TestDiscoverEntityTemplates_NoTemplatesDir(t *testing.T) {
 }
 
 func TestDiscoverEntityTemplates_DefaultOnly(t *testing.T) {
-	ctx := setupTestContext(t)
+	paths := setupTestPaths(t)
 
 	// Create templates directory and default template
-	if err := os.MkdirAll(ctx.EntityTemplatesDir, 0755); err != nil {
+	if err := os.MkdirAll(paths.entityTemplatesDir, 0755); err != nil {
 		t.Fatalf("failed to create dir: %v", err)
 	}
 
@@ -467,11 +488,11 @@ priority: high
 ---
 # Default content
 `
-	if err := os.WriteFile(filepath.Join(ctx.EntityTemplatesDir, "requirement.md"), []byte(templateContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(paths.entityTemplatesDir, "requirement.md"), []byte(templateContent), 0644); err != nil {
 		t.Fatalf("failed to write template: %v", err)
 	}
 
-	templates, err := testIO.DiscoverEntityTemplates(ctx, "requirement")
+	templates, err := testIO.DiscoverEntityTemplates(paths.entityTemplatesDir, "requirement")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -492,9 +513,9 @@ priority: high
 }
 
 func TestDiscoverEntityTemplates_WithVariants(t *testing.T) {
-	ctx := setupTestContext(t)
+	paths := setupTestPaths(t)
 
-	if err := os.MkdirAll(ctx.EntityTemplatesDir, 0755); err != nil {
+	if err := os.MkdirAll(paths.entityTemplatesDir, 0755); err != nil {
 		t.Fatalf("failed to create dir: %v", err)
 	}
 
@@ -504,7 +525,7 @@ status: draft
 ---
 # Default
 `
-	if err := os.WriteFile(filepath.Join(ctx.EntityTemplatesDir, "requirement.md"), []byte(defaultContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(paths.entityTemplatesDir, "requirement.md"), []byte(defaultContent), 0644); err != nil {
 		t.Fatalf("failed to write default template: %v", err)
 	}
 
@@ -515,7 +536,7 @@ priority: high
 ---
 # Epic template
 `
-	if err := os.WriteFile(filepath.Join(ctx.EntityTemplatesDir, "requirement--epic.md"), []byte(epicContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(paths.entityTemplatesDir, "requirement--epic.md"), []byte(epicContent), 0644); err != nil {
 		t.Fatalf("failed to write epic template: %v", err)
 	}
 
@@ -526,16 +547,16 @@ status: draft
 # Checklist
 - [ ] Item 1
 `
-	if err := os.WriteFile(filepath.Join(ctx.EntityTemplatesDir, "requirement--checklist.md"), []byte(checklistContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(paths.entityTemplatesDir, "requirement--checklist.md"), []byte(checklistContent), 0644); err != nil {
 		t.Fatalf("failed to write checklist template: %v", err)
 	}
 
 	// Unrelated template (different entity type)
-	if err := os.WriteFile(filepath.Join(ctx.EntityTemplatesDir, "decision.md"), []byte("---\n---\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(paths.entityTemplatesDir, "decision.md"), []byte("---\n---\n"), 0644); err != nil {
 		t.Fatalf("failed to write unrelated template: %v", err)
 	}
 
-	templates, err := testIO.DiscoverEntityTemplates(ctx, "requirement")
+	templates, err := testIO.DiscoverEntityTemplates(paths.entityTemplatesDir, "requirement")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -562,9 +583,9 @@ status: draft
 }
 
 func TestDiscoverEntityTemplates_WithRelations(t *testing.T) {
-	ctx := setupTestContext(t)
+	paths := setupTestPaths(t)
 
-	if err := os.MkdirAll(ctx.EntityTemplatesDir, 0755); err != nil {
+	if err := os.MkdirAll(paths.entityTemplatesDir, 0755); err != nil {
 		t.Fatalf("failed to create dir: %v", err)
 	}
 
@@ -578,11 +599,11 @@ _template_relations:
 ---
 # Template with relations
 `
-	if err := os.WriteFile(filepath.Join(ctx.EntityTemplatesDir, "requirement.md"), []byte(templateContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(paths.entityTemplatesDir, "requirement.md"), []byte(templateContent), 0644); err != nil {
 		t.Fatalf("failed to write template: %v", err)
 	}
 
-	templates, err := testIO.DiscoverEntityTemplates(ctx, "requirement")
+	templates, err := testIO.DiscoverEntityTemplates(paths.entityTemplatesDir, "requirement")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -239,7 +239,7 @@ func (r *Repository) ListRelations() ([]*model.Relation, error) {
 
 // Sync rebuilds the graph from all entity and relation files on disk.
 func (r *Repository) Sync(meta *metamodel.Metamodel, g *graph.Graph) (*model.SyncResult, error) {
-	data, err := r.fio.LoadSyncData(r.paths, meta)
+	data, err := r.fio.LoadSyncData(r.paths.EntitiesDir, r.paths.RelationsDir, meta)
 	if err != nil {
 		return nil, err
 	}
@@ -352,13 +352,13 @@ func (r *Repository) WriteCacheFile(filename string, data []byte) error {
 // LoadEntityTemplate loads the template for the given entity type, or
 // returns nil if no template exists.
 func (r *Repository) LoadEntityTemplate(entityType string) (*markdown.Document, error) {
-	return r.fio.LoadEntityTemplate(r.paths, entityType)
+	return r.fio.LoadEntityTemplate(r.paths.EntityTemplatePath(entityType))
 }
 
 // LoadRelationTemplate loads the template for the given relation type, or
 // returns nil if no template exists.
 func (r *Repository) LoadRelationTemplate(relationType string) (*markdown.Document, error) {
-	return r.fio.LoadRelationTemplate(r.paths, relationType)
+	return r.fio.LoadRelationTemplate(r.paths.RelationTemplatePath(relationType))
 }
 
 // GenerateEntityTemplate generates a template file for the given entity type.
@@ -367,7 +367,8 @@ func (r *Repository) LoadRelationTemplate(relationType string) (*markdown.Docume
 func (r *Repository) GenerateEntityTemplate(
 	meta *metamodel.Metamodel, entityType, variant string, force bool,
 ) (bool, error) {
-	return r.fio.GenerateEntityTemplate(r.paths, meta, entityType, variant, force)
+	path := r.paths.EntityTemplateVariantPath(entityType, variant)
+	return r.fio.GenerateEntityTemplate(path, meta, entityType, force)
 }
 
 // GenerateRelationTemplate generates a template file for the given relation type.
@@ -375,12 +376,13 @@ func (r *Repository) GenerateEntityTemplate(
 func (r *Repository) GenerateRelationTemplate(
 	meta *metamodel.Metamodel, relationType string, force bool,
 ) (bool, error) {
-	return r.fio.GenerateRelationTemplate(r.paths, meta, relationType, force)
+	path := r.paths.RelationTemplatePath(relationType)
+	return r.fio.GenerateRelationTemplate(path, meta, relationType, force)
 }
 
 // DiscoverEntityTemplates returns all templates (including variants) for an entity type.
 func (r *Repository) DiscoverEntityTemplates(entityType string) ([]*markdown.EntityTemplate, error) {
-	return r.fio.DiscoverEntityTemplates(r.paths, entityType)
+	return r.fio.DiscoverEntityTemplates(r.paths.EntityTemplatesDir, entityType)
 }
 
 // --- Change Notification ---

--- a/tickets/entities/tickets/TKT-021.md
+++ b/tickets/entities/tickets/TKT-021.md
@@ -1,0 +1,10 @@
+---
+description: Decouple markdown package from project by accepting plain path strings instead of project.Context
+effort: s
+id: TKT-021
+kind: refactor
+priority: medium
+status: done
+title: Remove markdown → project dependency
+type: ticket
+---

--- a/tickets/relations/TKT-021--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-021--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-021
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-021--implements--FEAT-022.md
+++ b/tickets/relations/TKT-021--implements--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: TKT-021
+relation: implements
+to: FEAT-022
+---


### PR DESCRIPTION
## Summary
- Remove the `markdown` → `project` dependency by accepting plain path strings instead of `*project.Context`
- `LoadSyncData`, template load/generate/discover functions now take string paths
- The `repository` layer computes paths from `project.Context` and passes them as strings
- Updated `.go-arch-lint.yml` to remove `project` from markdown's `mayDependOn`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/markdown/ ./internal/repository/` passes
- [x] `go-arch-lint check` reports no violations