### PR TITLE
Decouple graph from storage package

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -222,9 +222,6 @@ deps:
       - storage
 
   # Core domain
-  graph:
-    mayDependOn:
-      - storage
   metamodel:
     mayDependOn:
       - storage

--- a/internal/graph/cache.go
+++ b/internal/graph/cache.go
@@ -1,26 +1,19 @@
 package graph
 
 import (
-	"encoding/json"
-	"path/filepath"
-	"time"
-
 	"github.com/Sourcehaven-BV/rela/internal/model"
-	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
-// CacheData represents the serialized graph cache
+// CacheData holds graph data for serialization. The repository layer
+// decides how (and where) to marshal and persist this data.
 type CacheData struct {
-	Version   string            `json:"version"`
-	Timestamp time.Time         `json:"timestamp"`
-	Nodes     []*model.Entity   `json:"nodes"`
-	Edges     []*model.Relation `json:"edges"`
+	Nodes []*model.Entity
+	Edges []*model.Relation
 }
 
-const CacheVersion = "1.0"
-
-// SaveCache saves the graph to a JSON cache file using the given filesystem.
-func (g *Graph) SaveCache(path string, fs storage.FS) error {
+// Snapshot returns a copy of the graph's nodes and edges for external
+// serialization. The caller owns the returned slices.
+func (g *Graph) Snapshot() *CacheData {
 	g.mu.RLock()
 	nodes := make([]*model.Entity, 0, len(g.nodes))
 	for _, node := range g.nodes {
@@ -30,39 +23,15 @@ func (g *Graph) SaveCache(path string, fs storage.FS) error {
 	copy(edges, g.edges)
 	g.mu.RUnlock()
 
-	data := CacheData{
-		Version:   CacheVersion,
-		Timestamp: time.Now(),
-		Nodes:     nodes,
-		Edges:     edges,
+	return &CacheData{
+		Nodes: nodes,
+		Edges: edges,
 	}
-
-	jsonData, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	// Ensure directory exists
-	dir := filepath.Dir(path)
-	if err := fs.MkdirAll(dir, 0755); err != nil {
-		return err
-	}
-
-	return fs.WriteFile(path, jsonData, 0644)
 }
 
-// LoadCache loads the graph from a JSON cache file using the given filesystem.
-func (g *Graph) LoadCache(path string, fs storage.FS) error {
-	jsonData, err := fs.ReadFile(path)
-	if err != nil {
-		return err
-	}
-
-	var data CacheData
-	if err := json.Unmarshal(jsonData, &data); err != nil {
-		return err
-	}
-
+// Restore replaces the graph contents with the provided cache data.
+// It rebuilds all internal indexes (adjacency maps, property index).
+func (g *Graph) Restore(data *CacheData) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
@@ -89,21 +58,4 @@ func (g *Graph) LoadCache(path string, fs storage.FS) error {
 	for _, node := range g.nodes {
 		g.indexEntityProperties(node)
 	}
-
-	return nil
-}
-
-// CacheExists checks if a cache file exists using the given filesystem.
-func CacheExists(path string, fs storage.FS) bool {
-	_, err := fs.Stat(path)
-	return err == nil
-}
-
-// CacheTimestamp returns the timestamp of the cache file using the given filesystem.
-func CacheTimestamp(path string, fs storage.FS) (time.Time, error) {
-	info, err := fs.Stat(path)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return info.ModTime(), nil
 }

--- a/internal/graph/cache_perf_test.go
+++ b/internal/graph/cache_perf_test.go
@@ -2,94 +2,69 @@ package graph
 
 import (
 	"fmt"
-	"path/filepath"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
-	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
-var testCacheFS = storage.NewOsFS()
-
-// BenchmarkSaveCache benchmarks saving the graph to cache
-func BenchmarkSaveCache(b *testing.B) {
+// BenchmarkSnapshot benchmarks taking a graph snapshot
+func BenchmarkSnapshot(b *testing.B) {
 	for _, size := range []int{100, 1000, 10000} {
 		b.Run(fmt.Sprintf("nodes=%d", size), func(b *testing.B) {
 			g := generateTestGraph(size, 1.0)
-			tmpDir := b.TempDir()
-			cachePath := filepath.Join(tmpDir, "cache.json")
 
 			b.ResetTimer()
 			b.ReportAllocs()
 
 			for i := 0; i < b.N; i++ {
-				err := g.SaveCache(cachePath, testCacheFS)
-				if err != nil {
-					b.Fatal(err)
-				}
+				_ = g.Snapshot()
 			}
 		})
 	}
 }
 
-// BenchmarkLoadCache benchmarks loading the graph from cache
-func BenchmarkLoadCache(b *testing.B) {
+// BenchmarkRestore benchmarks restoring a graph from cache data
+func BenchmarkRestore(b *testing.B) {
 	for _, size := range []int{100, 1000, 10000} {
 		b.Run(fmt.Sprintf("nodes=%d", size), func(b *testing.B) {
-			// Create and save a graph
 			g := generateTestGraph(size, 1.0)
-			tmpDir := b.TempDir()
-			cachePath := filepath.Join(tmpDir, "cache.json")
-
-			if err := g.SaveCache(cachePath, testCacheFS); err != nil {
-				b.Fatal(err)
-			}
+			snap := g.Snapshot()
 
 			b.ResetTimer()
 			b.ReportAllocs()
 
 			for i := 0; i < b.N; i++ {
 				newGraph := New()
-				err := newGraph.LoadCache(cachePath, testCacheFS)
-				if err != nil {
-					b.Fatal(err)
-				}
+				newGraph.Restore(snap)
 			}
 		})
 	}
 }
 
-// BenchmarkSaveCacheVsSyncFromFiles compares cache loading vs full sync
-// This demonstrates the performance benefit of the cache
-func BenchmarkSaveCacheVsSyncFromFiles(b *testing.B) {
+// BenchmarkSnapshotRestore benchmarks a full round-trip
+func BenchmarkSnapshotRestore(b *testing.B) {
 	for _, size := range []int{100, 1000} {
-		b.Run(fmt.Sprintf("nodes=%d/cache", size), func(b *testing.B) {
+		b.Run(fmt.Sprintf("nodes=%d", size), func(b *testing.B) {
 			g := generateTestGraph(size, 1.0)
-			tmpDir := b.TempDir()
-			cachePath := filepath.Join(tmpDir, "cache.json")
-
-			if err := g.SaveCache(cachePath, testCacheFS); err != nil {
-				b.Fatal(err)
-			}
 
 			b.ResetTimer()
 			b.ReportAllocs()
 
 			for i := 0; i < b.N; i++ {
+				snap := g.Snapshot()
 				newGraph := New()
-				_ = newGraph.LoadCache(cachePath, testCacheFS)
+				newGraph.Restore(snap)
 			}
 		})
 	}
 }
 
-// BenchmarkCacheWithLargeProperties tests cache with entities containing many properties
-func BenchmarkCacheWithLargeProperties(b *testing.B) {
+// BenchmarkRestoreWithLargeProperties tests restore with entities containing many properties
+func BenchmarkRestoreWithLargeProperties(b *testing.B) {
 	for _, numProps := range []int{5, 20, 50} {
 		b.Run(fmt.Sprintf("properties=%d", numProps), func(b *testing.B) {
 			g := New()
 
-			// Create entities with many properties
 			for i := 0; i < 1000; i++ {
 				props := make(map[string]interface{})
 				for j := 0; j < numProps; j++ {
@@ -105,28 +80,25 @@ func BenchmarkCacheWithLargeProperties(b *testing.B) {
 				})
 			}
 
-			tmpDir := b.TempDir()
-			cachePath := filepath.Join(tmpDir, "cache.json")
+			snap := g.Snapshot()
 
 			b.ResetTimer()
 			b.ReportAllocs()
 
 			for i := 0; i < b.N; i++ {
-				_ = g.SaveCache(cachePath, testCacheFS)
 				newGraph := New()
-				_ = newGraph.LoadCache(cachePath, testCacheFS)
+				newGraph.Restore(snap)
 			}
 		})
 	}
 }
 
-// BenchmarkCacheRebuildAdjacency benchmarks the adjacency map rebuild during load
-func BenchmarkCacheRebuildAdjacency(b *testing.B) {
+// BenchmarkRestoreRebuildAdjacency benchmarks the adjacency map rebuild during restore
+func BenchmarkRestoreRebuildAdjacency(b *testing.B) {
 	for _, numEdges := range []int{100, 1000, 10000} {
 		b.Run(fmt.Sprintf("edges=%d", numEdges), func(b *testing.B) {
 			g := New()
 
-			// Create nodes
 			for i := 0; i < 100; i++ {
 				g.AddNode(&model.Entity{
 					ID:   fmt.Sprintf("ENT-%03d", i),
@@ -134,7 +106,6 @@ func BenchmarkCacheRebuildAdjacency(b *testing.B) {
 				})
 			}
 
-			// Create edges
 			for i := 0; i < numEdges; i++ {
 				g.AddEdge(&model.Relation{
 					From: fmt.Sprintf("ENT-%03d", i%100),
@@ -143,19 +114,14 @@ func BenchmarkCacheRebuildAdjacency(b *testing.B) {
 				})
 			}
 
-			tmpDir := b.TempDir()
-			cachePath := filepath.Join(tmpDir, "cache.json")
-
-			if err := g.SaveCache(cachePath, testCacheFS); err != nil {
-				b.Fatal(err)
-			}
+			snap := g.Snapshot()
 
 			b.ResetTimer()
 			b.ReportAllocs()
 
 			for i := 0; i < b.N; i++ {
 				newGraph := New()
-				_ = newGraph.LoadCache(cachePath, testCacheFS)
+				newGraph.Restore(snap)
 			}
 		})
 	}

--- a/internal/graph/graph_property_test.go
+++ b/internal/graph/graph_property_test.go
@@ -384,18 +384,11 @@ func TestPropertyIndexCacheSurvival(t *testing.T) {
 				expectedCounts[te.PropName][te.PropValue]++
 			}
 
-			// Save and reload from cache
-			tmpFile := t.TempDir() + "/cache.json"
-			if err := g.SaveCache(tmpFile, testCacheFS); err != nil {
-				t.Logf("Failed to save cache: %v", err)
-				return false
-			}
+			// Snapshot and restore to verify property index rebuild
+			snap := g.Snapshot()
 
 			g2 := New()
-			if err := g2.LoadCache(tmpFile, testCacheFS); err != nil {
-				t.Logf("Failed to load cache: %v", err)
-				return false
-			}
+			g2.Restore(snap)
 
 			// Verify property index was rebuilt correctly
 			for propName, valueCounts := range expectedCounts {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -9,6 +9,7 @@
 package repository
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -279,19 +280,64 @@ func (r *Repository) Sync(meta *metamodel.Metamodel, g *graph.Graph) (*model.Syn
 
 // --- Cache ---
 
-// SaveCache writes the graph cache to the project's cache file.
+// cacheEnvelope is the on-disk JSON format for the graph cache.
+type cacheEnvelope struct {
+	Version   string            `json:"version"`
+	Timestamp time.Time         `json:"timestamp"`
+	Nodes     []*model.Entity   `json:"nodes"`
+	Edges     []*model.Relation `json:"edges"`
+}
+
+const cacheVersion = "1.0"
+
+// SaveCache writes the graph cache to the project's cache file as JSON.
 func (r *Repository) SaveCache(g *graph.Graph) error {
-	return g.SaveCache(r.paths.CachePath, r.fs)
+	snap := g.Snapshot()
+
+	env := cacheEnvelope{
+		Version:   cacheVersion,
+		Timestamp: time.Now(),
+		Nodes:     snap.Nodes,
+		Edges:     snap.Edges,
+	}
+
+	data, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(r.paths.CachePath)
+	if err := r.fs.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	return r.fs.WriteFile(r.paths.CachePath, data, 0644)
 }
 
 // LoadCache reads the graph cache from the project's cache file.
 func (r *Repository) LoadCache(g *graph.Graph) error {
-	return g.LoadCache(r.paths.CachePath, r.fs)
+	data, err := r.fs.ReadFile(r.paths.CachePath)
+	if err != nil {
+		return err
+	}
+
+	var env cacheEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return err
+	}
+
+	g.Restore(&graph.CacheData{
+		Nodes: env.Nodes,
+		Edges: env.Edges,
+	})
+
+	return nil
 }
 
 // CacheExists returns true if the graph cache file exists.
 func (r *Repository) CacheExists() bool {
-	return graph.CacheExists(r.paths.CachePath, r.fs)
+	_, err := r.fs.Stat(r.paths.CachePath)
+	return err == nil
 }
 
 // --- Metamodel ---

--- a/tickets/entities/tickets/TKT-020.md
+++ b/tickets/entities/tickets/TKT-020.md
@@ -1,0 +1,10 @@
+---
+description: Decouple graph package from storage by replacing SaveCache/LoadCache with Snapshot/Restore, moving JSON serialization to repository
+effort: s
+id: TKT-020
+kind: refactor
+priority: medium
+status: done
+title: Remove graph → storage dependency
+type: ticket
+---

--- a/tickets/relations/TKT-020--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-020--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-020
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-020--implements--FEAT-022.md
+++ b/tickets/relations/TKT-020--implements--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: TKT-020
+relation: implements
+to: FEAT-022
+---


### PR DESCRIPTION
## Summary
- Remove the `graph` → `storage` dependency by replacing `SaveCache`/`LoadCache` with `Snapshot()`/`Restore()`
- Graph now exposes pure data (`CacheData` struct) without knowing about serialization or filesystems
- Repository owns JSON marshaling with a private `cacheEnvelope` (version, timestamp, nodes, edges)
- Updated `.go-arch-lint.yml` to remove `graph`'s `mayDependOn: [storage]` entry

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/graph/ ./internal/repository/` passes
- [x] `go-arch-lint check` reports no violations