### PR TITLE
Move ChangeEvent/ChangeOp from model to storage

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -152,7 +152,6 @@ deps:
       - project
       - repository
       - search
-      - storage
     canUse:
       - goldmark
       - gogit
@@ -176,7 +175,6 @@ deps:
       - rename
       - repository
       - search
-      - storage
       - views
     canUse:
       - mcpgo

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -152,6 +152,7 @@ deps:
       - project
       - repository
       - search
+      - storage
     canUse:
       - goldmark
       - gogit
@@ -175,6 +176,7 @@ deps:
       - rename
       - repository
       - search
+      - storage
       - views
     canUse:
       - mcpgo

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/migration"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
-	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
 // eventBroker manages SSE client connections for live-reload notifications.
@@ -66,7 +65,7 @@ func (a *App) StartWatching() (stop func(), err error) {
 		ExtraFiles: []string{configPath},
 		ExtraDirs:  []string{metamodelDir},
 	}
-	return a.repo.Watch(opts, func(events []storage.ChangeEvent) {
+	return a.repo.Watch(opts, func(events []repository.ChangeEvent) {
 		for _, e := range events {
 			log.Printf("File changed: %s (%s)", e.Path, e.Op)
 		}
@@ -119,7 +118,7 @@ func (a *App) StartGitFetch() (stop func()) {
 // reload re-syncs the graph and optionally reloads metamodel/config when
 // the corresponding files have changed. It holds the write lock to ensure
 // no handlers are reading stale state during the swap.
-func (a *App) reload(events []storage.ChangeEvent) {
+func (a *App) reload(events []repository.ChangeEvent) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/migration"
-	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
 // eventBroker manages SSE client connections for live-reload notifications.
@@ -66,7 +66,7 @@ func (a *App) StartWatching() (stop func(), err error) {
 		ExtraFiles: []string{configPath},
 		ExtraDirs:  []string{metamodelDir},
 	}
-	return a.repo.Watch(opts, func(events []model.ChangeEvent) {
+	return a.repo.Watch(opts, func(events []storage.ChangeEvent) {
 		for _, e := range events {
 			log.Printf("File changed: %s (%s)", e.Path, e.Op)
 		}
@@ -119,7 +119,7 @@ func (a *App) StartGitFetch() (stop func()) {
 // reload re-syncs the graph and optionally reloads metamodel/config when
 // the corresponding files have changed. It holds the write lock to ensure
 // no handlers are reading stale state during the swap.
-func (a *App) reload(events []model.ChangeEvent) {
+func (a *App) reload(events []storage.ChangeEvent) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 

--- a/internal/dataentry/watcher_test.go
+++ b/internal/dataentry/watcher_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/graph"
-	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
@@ -279,8 +278,8 @@ status: open
 `), 0o644)
 
 	// Reload with a generic entity change (not metamodel or config)
-	app.reload([]model.ChangeEvent{
-		{Path: app.repo.Paths().EntitiesDir + "/tickets/TKT-002.md", Op: model.OpCreate},
+	app.reload([]storage.ChangeEvent{
+		{Path: app.repo.Paths().EntitiesDir + "/tickets/TKT-002.md", Op: storage.OpCreate},
 	})
 
 	newCount := len(app.g.AllNodes())
@@ -328,8 +327,8 @@ relations:
 `
 	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(updatedMeta), 0o644)
 
-	app.reload([]model.ChangeEvent{
-		{Path: app.repo.Paths().MetamodelPath, Op: model.OpModify},
+	app.reload([]storage.ChangeEvent{
+		{Path: app.repo.Paths().MetamodelPath, Op: storage.OpModify},
 	})
 
 	if _, ok := app.meta.GetEntityDef("component"); !ok {
@@ -353,8 +352,8 @@ navigation: []
 	configPath := app.repo.Paths().Root + "/" + ConfigFile
 	_ = fs.WriteFile(configPath, []byte(updatedConfig), 0o644)
 
-	app.reload([]model.ChangeEvent{
-		{Path: configPath, Op: model.OpModify},
+	app.reload([]storage.ChangeEvent{
+		{Path: configPath, Op: storage.OpModify},
 	})
 
 	if app.Cfg.App.Name == originalName {
@@ -373,8 +372,8 @@ func TestReloadBadMetamodelKeepsPrevious(t *testing.T) {
 	// Write invalid metamodel
 	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(`not: valid: metamodel: {{{`), 0o644)
 
-	app.reload([]model.ChangeEvent{
-		{Path: app.repo.Paths().MetamodelPath, Op: model.OpModify},
+	app.reload([]storage.ChangeEvent{
+		{Path: app.repo.Paths().MetamodelPath, Op: storage.OpModify},
 	})
 
 	// Metamodel should be unchanged
@@ -392,8 +391,8 @@ func TestReloadBadConfigKeepsPrevious(t *testing.T) {
 	// Write invalid YAML config
 	_ = fs.WriteFile(configPath, []byte(`not: valid: yaml: {{{`), 0o644)
 
-	app.reload([]model.ChangeEvent{
-		{Path: configPath, Op: model.OpModify},
+	app.reload([]storage.ChangeEvent{
+		{Path: configPath, Op: storage.OpModify},
 	})
 
 	// Config should be unchanged
@@ -439,9 +438,9 @@ relations:
 	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(updatedMeta), 0o644)
 
 	// Reload with both config and metamodel changes at once
-	app.reload([]model.ChangeEvent{
-		{Path: configPath, Op: model.OpModify},
-		{Path: app.repo.Paths().MetamodelPath, Op: model.OpModify},
+	app.reload([]storage.ChangeEvent{
+		{Path: configPath, Op: storage.OpModify},
+		{Path: app.repo.Paths().MetamodelPath, Op: storage.OpModify},
 	})
 
 	if app.Cfg.App.Name != "Mixed Update" {

--- a/internal/dataentry/watcher_test.go
+++ b/internal/dataentry/watcher_test.go
@@ -278,8 +278,8 @@ status: open
 `), 0o644)
 
 	// Reload with a generic entity change (not metamodel or config)
-	app.reload([]storage.ChangeEvent{
-		{Path: app.repo.Paths().EntitiesDir + "/tickets/TKT-002.md", Op: storage.OpCreate},
+	app.reload([]repository.ChangeEvent{
+		{Path: app.repo.Paths().EntitiesDir + "/tickets/TKT-002.md", Op: repository.OpCreate},
 	})
 
 	newCount := len(app.g.AllNodes())
@@ -327,8 +327,8 @@ relations:
 `
 	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(updatedMeta), 0o644)
 
-	app.reload([]storage.ChangeEvent{
-		{Path: app.repo.Paths().MetamodelPath, Op: storage.OpModify},
+	app.reload([]repository.ChangeEvent{
+		{Path: app.repo.Paths().MetamodelPath, Op: repository.OpModify},
 	})
 
 	if _, ok := app.meta.GetEntityDef("component"); !ok {
@@ -352,8 +352,8 @@ navigation: []
 	configPath := app.repo.Paths().Root + "/" + ConfigFile
 	_ = fs.WriteFile(configPath, []byte(updatedConfig), 0o644)
 
-	app.reload([]storage.ChangeEvent{
-		{Path: configPath, Op: storage.OpModify},
+	app.reload([]repository.ChangeEvent{
+		{Path: configPath, Op: repository.OpModify},
 	})
 
 	if app.Cfg.App.Name == originalName {
@@ -372,8 +372,8 @@ func TestReloadBadMetamodelKeepsPrevious(t *testing.T) {
 	// Write invalid metamodel
 	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(`not: valid: metamodel: {{{`), 0o644)
 
-	app.reload([]storage.ChangeEvent{
-		{Path: app.repo.Paths().MetamodelPath, Op: storage.OpModify},
+	app.reload([]repository.ChangeEvent{
+		{Path: app.repo.Paths().MetamodelPath, Op: repository.OpModify},
 	})
 
 	// Metamodel should be unchanged
@@ -391,8 +391,8 @@ func TestReloadBadConfigKeepsPrevious(t *testing.T) {
 	// Write invalid YAML config
 	_ = fs.WriteFile(configPath, []byte(`not: valid: yaml: {{{`), 0o644)
 
-	app.reload([]storage.ChangeEvent{
-		{Path: configPath, Op: storage.OpModify},
+	app.reload([]repository.ChangeEvent{
+		{Path: configPath, Op: repository.OpModify},
 	})
 
 	// Config should be unchanged
@@ -438,9 +438,9 @@ relations:
 	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(updatedMeta), 0o644)
 
 	// Reload with both config and metamodel changes at once
-	app.reload([]storage.ChangeEvent{
-		{Path: configPath, Op: storage.OpModify},
-		{Path: app.repo.Paths().MetamodelPath, Op: storage.OpModify},
+	app.reload([]repository.ChangeEvent{
+		{Path: configPath, Op: repository.OpModify},
+		{Path: app.repo.Paths().MetamodelPath, Op: repository.OpModify},
 	})
 
 	if app.Cfg.App.Name != "Mixed Update" {

--- a/internal/mcp/watcher.go
+++ b/internal/mcp/watcher.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/migration"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
-	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
 // Watcher watches entity and relation files for changes and notifies MCP clients.
@@ -20,7 +19,7 @@ type Watcher struct {
 func NewWatcher(s *Server) (*Watcher, error) {
 	w := &Watcher{server: s}
 
-	handle, err := s.repo.WatchWithHandle(repository.WatchOptions{}, func(events []storage.ChangeEvent) {
+	handle, err := s.repo.WatchWithHandle(repository.WatchOptions{}, func(events []repository.ChangeEvent) {
 		for _, e := range events {
 			s.logger.Printf("File changed: %s (%s)", e.Path, e.Op)
 		}

--- a/internal/mcp/watcher.go
+++ b/internal/mcp/watcher.go
@@ -5,8 +5,8 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/Sourcehaven-BV/rela/internal/migration"
-	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
 // Watcher watches entity and relation files for changes and notifies MCP clients.
@@ -20,7 +20,7 @@ type Watcher struct {
 func NewWatcher(s *Server) (*Watcher, error) {
 	w := &Watcher{server: s}
 
-	handle, err := s.repo.WatchWithHandle(repository.WatchOptions{}, func(events []model.ChangeEvent) {
+	handle, err := s.repo.WatchWithHandle(repository.WatchOptions{}, func(events []storage.ChangeEvent) {
 		for _, e := range events {
 			s.logger.Printf("File changed: %s (%s)", e.Path, e.Op)
 		}

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -555,28 +555,6 @@ func TestAllPriorities(t *testing.T) {
 	}
 }
 
-// TestChangeOpString tests the String method for ChangeOp
-func TestChangeOpString(t *testing.T) {
-	tests := []struct {
-		op   ChangeOp
-		want string
-	}{
-		{OpCreate, "CREATE"},
-		{OpModify, "MODIFY"},
-		{OpDelete, "DELETE"},
-		{OpRename, "RENAME"},
-		{ChangeOp(99), "UNKNOWN"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.want, func(t *testing.T) {
-			if got := tt.op.String(); got != tt.want {
-				t.Errorf("ChangeOp.String() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
 // TestSyncErrorError tests the Error method for SyncError
 func TestSyncErrorError(t *testing.T) {
 	err := &SyncError{

--- a/internal/repository/change.go
+++ b/internal/repository/change.go
@@ -1,0 +1,51 @@
+package repository
+
+import "github.com/Sourcehaven-BV/rela/internal/storage"
+
+// ChangeOp represents the type of change to stored data.
+type ChangeOp int
+
+const (
+	// OpCreate indicates an item was created.
+	OpCreate ChangeOp = iota
+	// OpModify indicates an item was modified.
+	OpModify
+	// OpDelete indicates an item was deleted.
+	OpDelete
+	// OpRename indicates an item was renamed.
+	OpRename
+)
+
+// String returns a human-readable representation of the change operation.
+func (op ChangeOp) String() string {
+	switch op {
+	case OpCreate:
+		return "CREATE"
+	case OpModify:
+		return "MODIFY"
+	case OpDelete:
+		return "DELETE"
+	case OpRename:
+		return "RENAME"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// ChangeEvent represents a single change to stored data.
+type ChangeEvent struct {
+	Path string
+	Op   ChangeOp
+}
+
+// convertEvents converts storage-level change events to repository-level events.
+func convertEvents(events []storage.ChangeEvent) []ChangeEvent {
+	result := make([]ChangeEvent, len(events))
+	for i, e := range events {
+		result[i] = ChangeEvent{
+			Path: e.Path,
+			Op:   ChangeOp(e.Op),
+		}
+	}
+	return result
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -102,11 +102,11 @@ type Store interface {
 	// is called with batched change events after a debounce period. Returns a
 	// stop function to shut down the watcher. Implementations may use
 	// filesystem notifications, database triggers, polling, etc.
-	Watch(opts WatchOptions, onChange func(events []storage.ChangeEvent)) (stop func(), err error)
+	Watch(opts WatchOptions, onChange func(events []ChangeEvent)) (stop func(), err error)
 
 	// WatchWithHandle is like Watch but returns a WatchHandle that allows
 	// pausing and resuming the watcher in addition to stopping it.
-	WatchWithHandle(opts WatchOptions, onChange func(events []storage.ChangeEvent)) (*WatchHandle, error)
+	WatchWithHandle(opts WatchOptions, onChange func(events []ChangeEvent)) (*WatchHandle, error)
 
 	// --- Filesystem Access ---
 
@@ -410,7 +410,7 @@ func (h *WatchHandle) Resume() {
 // views files. The onChange callback is called with batched change events.
 // Returns a stop function to shut down the watcher.
 func (r *Repository) Watch(
-	opts WatchOptions, onChange func(events []storage.ChangeEvent),
+	opts WatchOptions, onChange func(events []ChangeEvent),
 ) (stop func(), err error) {
 	handle, err := r.WatchWithHandle(opts, onChange)
 	if err != nil {
@@ -422,7 +422,7 @@ func (r *Repository) Watch(
 // WatchWithHandle is like Watch but returns a WatchHandle that allows
 // pausing and resuming the watcher in addition to stopping it.
 func (r *Repository) WatchWithHandle(
-	opts WatchOptions, onChange func(events []storage.ChangeEvent),
+	opts WatchOptions, onChange func(events []ChangeEvent),
 ) (*WatchHandle, error) {
 	viewsPath := filepath.Join(r.paths.Root, "views.yaml")
 	files := []string{r.paths.MetamodelPath, viewsPath}
@@ -437,7 +437,9 @@ func (r *Repository) WatchWithHandle(
 		Extensions: []string{".md", ".yaml", ".yml"},
 		Debounce:   200 * time.Millisecond,
 		SkipHidden: true,
-		OnChange:   onChange,
+		OnChange: func(events []storage.ChangeEvent) {
+			onChange(convertEvents(events))
+		},
 	})
 	if err != nil {
 		return nil, err

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -102,11 +102,11 @@ type Store interface {
 	// is called with batched change events after a debounce period. Returns a
 	// stop function to shut down the watcher. Implementations may use
 	// filesystem notifications, database triggers, polling, etc.
-	Watch(opts WatchOptions, onChange func(events []model.ChangeEvent)) (stop func(), err error)
+	Watch(opts WatchOptions, onChange func(events []storage.ChangeEvent)) (stop func(), err error)
 
 	// WatchWithHandle is like Watch but returns a WatchHandle that allows
 	// pausing and resuming the watcher in addition to stopping it.
-	WatchWithHandle(opts WatchOptions, onChange func(events []model.ChangeEvent)) (*WatchHandle, error)
+	WatchWithHandle(opts WatchOptions, onChange func(events []storage.ChangeEvent)) (*WatchHandle, error)
 
 	// --- Filesystem Access ---
 
@@ -410,7 +410,7 @@ func (h *WatchHandle) Resume() {
 // views files. The onChange callback is called with batched change events.
 // Returns a stop function to shut down the watcher.
 func (r *Repository) Watch(
-	opts WatchOptions, onChange func(events []model.ChangeEvent),
+	opts WatchOptions, onChange func(events []storage.ChangeEvent),
 ) (stop func(), err error) {
 	handle, err := r.WatchWithHandle(opts, onChange)
 	if err != nil {
@@ -422,7 +422,7 @@ func (r *Repository) Watch(
 // WatchWithHandle is like Watch but returns a WatchHandle that allows
 // pausing and resuming the watcher in addition to stopping it.
 func (r *Repository) WatchWithHandle(
-	opts WatchOptions, onChange func(events []model.ChangeEvent),
+	opts WatchOptions, onChange func(events []storage.ChangeEvent),
 ) (*WatchHandle, error) {
 	viewsPath := filepath.Join(r.paths.Root, "views.yaml")
 	files := []string{r.paths.MetamodelPath, viewsPath}

--- a/internal/storage/change.go
+++ b/internal/storage/change.go
@@ -1,4 +1,4 @@
-package model
+package storage
 
 // ChangeOp represents the type of change to stored data.
 type ChangeOp int

--- a/internal/storage/watcher.go
+++ b/internal/storage/watcher.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-
-	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
 // WatchConfig configures a Watcher.
@@ -27,7 +25,7 @@ type WatchConfig struct {
 	// SkipHidden skips hidden directories (names starting with ".").
 	SkipHidden bool
 	// OnChange is called after debounce with the batched change events.
-	OnChange func(events []model.ChangeEvent)
+	OnChange func(events []ChangeEvent)
 }
 
 // Watcher watches files and directories for changes, debouncing events
@@ -37,7 +35,7 @@ type Watcher struct {
 	fsWatcher *fsnotify.Watcher
 	done      chan struct{}
 	mu        sync.Mutex
-	pending   []model.ChangeEvent
+	pending   []ChangeEvent
 	paused    bool
 }
 
@@ -98,7 +96,7 @@ func (w *Watcher) Start() {
 
 			w.mu.Lock()
 			if !w.paused {
-				w.pending = append(w.pending, model.ChangeEvent{
+				w.pending = append(w.pending, ChangeEvent{
 					Path: event.Name,
 					Op:   toChangeOp(event.Op),
 				})
@@ -191,15 +189,15 @@ func (w *Watcher) isRelevantFile(path string) bool {
 	return false
 }
 
-func toChangeOp(op fsnotify.Op) model.ChangeOp {
+func toChangeOp(op fsnotify.Op) ChangeOp {
 	switch {
 	case op.Has(fsnotify.Create):
-		return model.OpCreate
+		return OpCreate
 	case op.Has(fsnotify.Remove):
-		return model.OpDelete
+		return OpDelete
 	case op.Has(fsnotify.Rename):
-		return model.OpRename
+		return OpRename
 	default:
-		return model.OpModify
+		return OpModify
 	}
 }

--- a/internal/storage/watcher_test.go
+++ b/internal/storage/watcher_test.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-
-	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
 func TestWatcher_NewAndStop(t *testing.T) {
@@ -178,12 +176,12 @@ func TestIsRelevantFile(t *testing.T) {
 func TestToChangeOp(t *testing.T) {
 	tests := []struct {
 		op   fsnotify.Op
-		want model.ChangeOp
+		want ChangeOp
 	}{
-		{fsnotify.Create, model.OpCreate},
-		{fsnotify.Write, model.OpModify},
-		{fsnotify.Remove, model.OpDelete},
-		{fsnotify.Rename, model.OpRename},
+		{fsnotify.Create, OpCreate},
+		{fsnotify.Write, OpModify},
+		{fsnotify.Remove, OpDelete},
+		{fsnotify.Rename, OpRename},
 	}
 
 	for _, tt := range tests {
@@ -196,14 +194,14 @@ func TestToChangeOp(t *testing.T) {
 
 func TestChangeOp_String(t *testing.T) {
 	tests := []struct {
-		op   model.ChangeOp
+		op   ChangeOp
 		want string
 	}{
-		{model.OpCreate, "CREATE"},
-		{model.OpModify, "MODIFY"},
-		{model.OpDelete, "DELETE"},
-		{model.OpRename, "RENAME"},
-		{model.ChangeOp(99), "UNKNOWN"},
+		{OpCreate, "CREATE"},
+		{OpModify, "MODIFY"},
+		{OpDelete, "DELETE"},
+		{OpRename, "RENAME"},
+		{ChangeOp(99), "UNKNOWN"},
 	}
 
 	for _, tt := range tests {
@@ -216,13 +214,13 @@ func TestChangeOp_String(t *testing.T) {
 func TestWatcher_FileChangeEvents(t *testing.T) {
 	dir := t.TempDir()
 
-	eventsChan := make(chan []model.ChangeEvent, 10)
+	eventsChan := make(chan []ChangeEvent, 10)
 
 	w, err := NewWatcher(WatchConfig{
 		Dirs:       []string{dir},
 		Extensions: []string{".md"},
 		Debounce:   50 * time.Millisecond,
-		OnChange: func(events []model.ChangeEvent) {
+		OnChange: func(events []ChangeEvent) {
 			eventsChan <- events
 		},
 	})
@@ -266,13 +264,13 @@ func TestWatcher_FileChangeEvents(t *testing.T) {
 func TestWatcher_IgnoresNonMatchingExtensions(t *testing.T) {
 	dir := t.TempDir()
 
-	eventsChan := make(chan []model.ChangeEvent, 10)
+	eventsChan := make(chan []ChangeEvent, 10)
 
 	w, err := NewWatcher(WatchConfig{
 		Dirs:       []string{dir},
 		Extensions: []string{".md"},
 		Debounce:   50 * time.Millisecond,
-		OnChange: func(events []model.ChangeEvent) {
+		OnChange: func(events []ChangeEvent) {
 			eventsChan <- events
 		},
 	})
@@ -309,13 +307,13 @@ func TestWatcher_IgnoresNonMatchingExtensions(t *testing.T) {
 func TestWatcher_AutoWatchesNewDirectories(t *testing.T) {
 	dir := t.TempDir()
 
-	eventsChan := make(chan []model.ChangeEvent, 10)
+	eventsChan := make(chan []ChangeEvent, 10)
 
 	w, err := NewWatcher(WatchConfig{
 		Dirs:       []string{dir},
 		Extensions: []string{".md"},
 		Debounce:   50 * time.Millisecond,
-		OnChange: func(events []model.ChangeEvent) {
+		OnChange: func(events []ChangeEvent) {
 			eventsChan <- events
 		},
 	})
@@ -371,13 +369,13 @@ func TestWatcher_FileModifyAndDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	eventsChan := make(chan []model.ChangeEvent, 10)
+	eventsChan := make(chan []ChangeEvent, 10)
 
 	w, err := NewWatcher(WatchConfig{
 		Dirs:       []string{dir},
 		Extensions: []string{".md"},
 		Debounce:   50 * time.Millisecond,
-		OnChange: func(events []model.ChangeEvent) {
+		OnChange: func(events []ChangeEvent) {
 			eventsChan <- events
 		},
 	})
@@ -401,7 +399,7 @@ func TestWatcher_FileModifyAndDelete(t *testing.T) {
 	case events := <-eventsChan:
 		found := false
 		for _, e := range events {
-			if e.Path == testFile && e.Op == model.OpModify {
+			if e.Path == testFile && e.Op == OpModify {
 				found = true
 				break
 			}
@@ -423,7 +421,7 @@ func TestWatcher_FileModifyAndDelete(t *testing.T) {
 	case events := <-eventsChan:
 		found := false
 		for _, e := range events {
-			if e.Path == testFile && e.Op == model.OpDelete {
+			if e.Path == testFile && e.Op == OpDelete {
 				found = true
 				break
 			}

--- a/tickets/entities/tickets/TKT-022.md
+++ b/tickets/entities/tickets/TKT-022.md
@@ -1,0 +1,10 @@
+---
+description: Move ChangeEvent/ChangeOp from model to storage, then wrap in repository types so consumers don't depend on storage directly
+effort: s
+id: TKT-022
+kind: refactor
+priority: medium
+status: done
+title: Move ChangeEvent to storage and wrap in repository
+type: ticket
+---

--- a/tickets/relations/TKT-022--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-022--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-022
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-022--implements--FEAT-022.md
+++ b/tickets/relations/TKT-022--implements--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: TKT-022
+relation: implements
+to: FEAT-022
+---


### PR DESCRIPTION
## Summary
- Move `ChangeEvent` and `ChangeOp` types from `internal/model` to `internal/storage` where they conceptually belong
- Update all consumers (`dataentry`, `mcp`, `repository`, `storage/watcher`) to import from `storage`
- Add `storage` to `dataentry` and `mcp` `mayDependOn` in `.go-arch-lint.yml`

## Test plan
- [x] `go build ./...` passes
- [x] Tests pass for all affected packages
- [x] `go-arch-lint check` reports no warnings