### PR TITLE
Route dataentry writes through workspace

### DIFF
--- a/internal/dataentry/app_test.go
+++ b/internal/dataentry/app_test.go
@@ -24,7 +24,8 @@ func testMeta() *metamodel.Metamodel {
 		},
 		Entities: map[string]metamodel.EntityDef{
 			"ticket": {
-				Label: "Ticket",
+				Label:    "Ticket",
+				IDPrefix: "TKT",
 				Properties: map[string]metamodel.PropertyDef{
 					"title":    {Type: "string", Required: true},
 					"status":   {Type: "status_type"},
@@ -32,7 +33,8 @@ func testMeta() *metamodel.Metamodel {
 				},
 			},
 			"component": {
-				Label: "Component",
+				Label:    "Component",
+				IDPrefix: "CMP",
 				Properties: map[string]metamodel.PropertyDef{
 					"name": {Type: "string", Required: true},
 				},

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -2,6 +2,7 @@ package dataentry
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html"
 	htmltemplate "html/template"
@@ -11,13 +12,13 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/markdown"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/natsort"
 	"github.com/Sourcehaven-BV/rela/internal/search/searchparser"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 func (a *App) handleIndex(w http.ResponseWriter, r *http.Request) {
@@ -1109,35 +1110,18 @@ func validationErrorsToFieldMap(errs []*metamodel.ValidationError) map[string]st
 }
 
 // generateEntityID returns a new entity ID, either from a manual form field or auto-generated.
-func (a *App) generateEntityID(entDef *metamodel.EntityDef, entityType string, r *http.Request) (string, error) {
-	if entDef.IsManualID() {
-		id := r.FormValue("_entity_id")
-		if id == "" {
-			return "", fmt.Errorf("manual ID required")
-		}
-		return id, nil
-	}
-	prefix := ""
-	prefixes := entDef.GetIDPrefixes()
-	if len(prefixes) > 0 {
-		prefix = prefixes[0]
-	}
-	if entDef.IsShortID() {
-		return model.GenerateShortID(a.g.AllIDs(), prefix, a.g.NodeCount()), nil
-	}
-	return model.GenerateNextID(a.g.IDsByType(entityType), prefix), nil
-}
-
-// populateProperties reads form field values into an entity, applying the default chain
-// (user defaults → form default) for empty values.
-func (a *App) populateProperties(entity *model.Entity, fields []FormField, entDef *metamodel.EntityDef, entityType string, r *http.Request) {
+// buildProperties reads form field values into a properties map, applying the default chain
+// (user defaults → form default) for empty values. Used by create handlers to supply
+// properties to workspace.CreateEntity.
+func (a *App) buildProperties(fields []FormField, entDef *metamodel.EntityDef, entityType string, r *http.Request) map[string]interface{} {
+	props := make(map[string]interface{})
 	for _, f := range fields {
 		prop := entDef.Properties[f.Property]
 		widget := resolveWidget(prop, a.meta)
 		if widget == WidgetMultiSelect {
 			values := r.Form[f.Property]
 			if len(values) > 0 {
-				entity.Properties[f.Property] = values
+				props[f.Property] = values
 			}
 		} else {
 			val := r.FormValue(f.Property)
@@ -1151,10 +1135,11 @@ func (a *App) populateProperties(entity *model.Entity, fields []FormField, entDe
 				val = f.Default
 			}
 			if val != "" {
-				entity.Properties[f.Property] = val
+				props[f.Property] = val
 			}
 		}
 	}
+	return props
 }
 
 // createFormRelations creates relations from form relation fields, applying user-default
@@ -1174,23 +1159,28 @@ func (a *App) createFormRelations(entityID string, relations []FormRelation, ent
 			if targetID == "" {
 				continue
 			}
-			var relation *model.Relation
+			var fromID, toID string
 			if rel.Direction == DirectionIncoming {
-				relation = model.NewRelation(targetID, rel.Relation, entityID)
+				fromID, toID = targetID, entityID
 			} else {
-				relation = model.NewRelation(entityID, rel.Relation, targetID)
+				fromID, toID = entityID, targetID
 			}
+			// Collect relation properties from form.
+			relProps := make(map[string]interface{})
 			for _, rp := range rel.Properties {
 				propKey := fmt.Sprintf("_relprop_%s_%s_%s", rel.Relation, targetID, rp.Property)
 				if pv := r.FormValue(propKey); pv != "" {
-					relation.Properties[rp.Property] = pv
+					relProps[rp.Property] = pv
 				}
 			}
-			if err := a.repo.WriteRelation(relation); err != nil {
+			var opts []workspace.CreateRelationOptions
+			if len(relProps) > 0 {
+				opts = append(opts, workspace.CreateRelationOptions{Properties: relProps})
+			}
+			if _, err := a.ws.CreateRelation(fromID, rel.Relation, toID, opts...); err != nil {
 				log.Printf("Failed to write relation: %v", err)
 				continue
 			}
-			a.g.AddEdge(relation)
 		}
 	}
 }
@@ -1215,11 +1205,8 @@ func (a *App) createLinkRelation(entityID string, r *http.Request) {
 	} else {
 		fromID, toID = linkPeer, entityID
 	}
-	relation := model.NewRelation(fromID, linkRelation, toID)
-	if err := a.repo.WriteRelation(relation); err != nil {
+	if _, err := a.ws.CreateRelation(fromID, linkRelation, toID); err != nil {
 		log.Printf("Failed to write link relation: %v", err)
-	} else {
-		a.g.AddEdge(relation)
 	}
 }
 
@@ -1286,12 +1273,10 @@ func (a *App) createTemplateRelations(entityID, entityType string, r *http.Reque
 			continue
 		}
 
-		relation := model.NewRelation(fromID, tr.Relation, toID)
-		if err := a.repo.WriteRelation(relation); err != nil {
+		if _, err := a.ws.CreateRelation(fromID, tr.Relation, toID); err != nil {
 			log.Printf("Failed to write template relation: %v", err)
 			continue
 		}
-		a.g.AddEdge(relation)
 		createdRelations[key] = true
 	}
 }
@@ -1312,47 +1297,54 @@ func (a *App) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	entDef, _ := a.meta.GetEntityDef(form.EntityType)
 
-	entityID, err := a.generateEntityID(entDef, form.EntityType, r)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	if _, exists := a.g.GetNode(entityID); exists {
-		http.Error(w, fmt.Sprintf("Entity %s already exists", entityID), http.StatusConflict)
-		return
-	}
+	// Build properties from form fields.
+	props := a.buildProperties(form.Fields, entDef, form.EntityType, r)
 
-	entity := model.NewEntity(entityID, form.EntityType)
-	a.populateProperties(entity, form.Fields, entDef, form.EntityType, r)
-
+	var content string
 	if form.Body != nil && *form.Body {
-		entity.Content = r.FormValue("_body")
+		content = r.FormValue("_body")
 	}
 
-	// Validate entity before writing
-	if validationErrs := a.meta.ValidateEntity(entity); len(validationErrs) > 0 {
-		a.renderFormWithErrors(w, r, formID, entity, validationErrorsToFieldMap(validationErrs))
+	opts := workspace.CreateOptions{
+		Properties: props,
+		Content:    content,
+	}
+
+	// Manual-ID types provide the ID directly; auto-ID types let workspace generate.
+	if entDef.IsManualID() {
+		opts.ID = r.FormValue("_entity_id")
+		if opts.ID == "" {
+			http.Error(w, "manual ID required", http.StatusBadRequest)
+			return
+		}
+	}
+
+	entity, _, err := a.ws.CreateEntity(form.EntityType, opts)
+	if err != nil {
+		var ve *workspace.ValidationError
+		if errors.As(err, &ve) {
+			// Re-render the form with validation errors.
+			stub := model.NewEntity(opts.ID, form.EntityType)
+			stub.Properties = props
+			stub.Content = content
+			a.renderFormWithErrors(w, r, formID, stub, validationErrorsToFieldMap(ve.Errors))
+			return
+		}
+		http.Error(w, fmt.Sprintf("Failed to create entity: %v", err), http.StatusInternalServerError)
 		return
 	}
 
-	if err := a.repo.WriteEntity(entity, a.meta); err != nil {
-		http.Error(w, fmt.Sprintf("Failed to write entity: %v", err), http.StatusInternalServerError)
-		return
-	}
-	entity.ModTime = time.Now()
-	a.g.AddNode(entity)
+	a.createFormRelations(entity.ID, form.Relations, form.EntityType, r)
+	a.createLinkRelation(entity.ID, r)
+	a.createTemplateRelations(entity.ID, form.EntityType, r)
 
-	a.createFormRelations(entityID, form.Relations, form.EntityType, r)
-	a.createLinkRelation(entityID, r)
-	a.createTemplateRelations(entityID, form.EntityType, r)
+	log.Printf("Created %s %s", form.EntityType, entity.ID)
 
-	log.Printf("Created %s %s", form.EntityType, entityID)
-
-	redirect := "/entity/" + form.EntityType + "/" + entityID
+	redirect := "/entity/" + form.EntityType + "/" + entity.ID
 	if returnTo := r.FormValue("_return_to"); returnTo != "" && strings.HasPrefix(returnTo, "/") {
 		redirect = returnTo
 	}
-	w.Header().Set("HX-Redirect", appendToastParam(redirect, "Created "+entityID))
+	w.Header().Set("HX-Redirect", appendToastParam(redirect, "Created "+entity.ID))
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -1383,6 +1375,9 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unknown entity type", http.StatusBadRequest)
 		return
 	}
+
+	oldEntity := entity.Clone()
+
 	for _, f := range form.Fields {
 		prop := entDef.Properties[f.Property]
 		widget := resolveWidget(prop, a.meta)
@@ -1411,17 +1406,17 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		entity.Content = r.FormValue("_body")
 	}
 
-	// Validate entity before writing
-	if validationErrs := a.meta.ValidateEntity(entity); len(validationErrs) > 0 {
-		a.renderFormWithErrors(w, r, formID, entity, validationErrorsToFieldMap(validationErrs))
-		return
-	}
-
-	if err := a.repo.WriteEntity(entity, a.meta); err != nil {
+	if _, err := a.ws.UpdateEntity(entity, oldEntity); err != nil {
+		var ve *workspace.ValidationError
+		if errors.As(err, &ve) {
+			a.renderFormWithErrors(w, r, formID, entity, validationErrorsToFieldMap(ve.Errors))
+			return
+		}
 		http.Error(w, fmt.Sprintf("Failed to write: %v", err), http.StatusInternalServerError)
 		return
 	}
 
+	// Reconcile relations: delete existing, recreate from form values.
 	for _, rel := range form.Relations {
 		if rel.Display != "" {
 			continue
@@ -1429,19 +1424,17 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		if rel.Direction == DirectionIncoming {
 			for _, edge := range a.g.IncomingEdges(entityID) {
 				if edge.Type == rel.Relation {
-					if delErr := a.repo.DeleteRelation(edge.From, edge.Type, edge.To); delErr != nil {
-						log.Printf("Failed to delete relation file: %v", delErr)
+					if delErr := a.ws.DeleteRelation(edge.From, edge.Type, edge.To); delErr != nil {
+						log.Printf("Failed to delete relation: %v", delErr)
 					}
-					a.g.RemoveEdge(edge.From, edge.Type, edge.To)
 				}
 			}
 		} else {
 			for _, edge := range a.g.OutgoingEdges(entityID) {
 				if edge.Type == rel.Relation {
-					if delErr := a.repo.DeleteRelation(edge.From, edge.Type, edge.To); delErr != nil {
-						log.Printf("Failed to delete relation file: %v", delErr)
+					if delErr := a.ws.DeleteRelation(edge.From, edge.Type, edge.To); delErr != nil {
+						log.Printf("Failed to delete relation: %v", delErr)
 					}
-					a.g.RemoveEdge(edge.From, edge.Type, edge.To)
 				}
 			}
 		}
@@ -1450,23 +1443,28 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 			if targetID == "" {
 				continue
 			}
-			var relation *model.Relation
+			var fromID, toID string
 			if rel.Direction == DirectionIncoming {
-				relation = model.NewRelation(targetID, rel.Relation, entityID)
+				fromID, toID = targetID, entityID
 			} else {
-				relation = model.NewRelation(entityID, rel.Relation, targetID)
+				fromID, toID = entityID, targetID
 			}
+			// Collect relation properties from form.
+			relProps := make(map[string]interface{})
 			for _, rp := range rel.Properties {
 				propKey := fmt.Sprintf("_relprop_%s_%s_%s", rel.Relation, targetID, rp.Property)
 				if pv := r.FormValue(propKey); pv != "" {
-					relation.Properties[rp.Property] = pv
+					relProps[rp.Property] = pv
 				}
 			}
-			if err := a.repo.WriteRelation(relation); err != nil {
+			var opts []workspace.CreateRelationOptions
+			if len(relProps) > 0 {
+				opts = append(opts, workspace.CreateRelationOptions{Properties: relProps})
+			}
+			if _, err := a.ws.CreateRelation(fromID, rel.Relation, toID, opts...); err != nil {
 				log.Printf("Failed to write relation: %v", err)
 				continue
 			}
-			a.g.AddEdge(relation)
 		}
 	}
 
@@ -1508,8 +1506,9 @@ func (a *App) handleToggleCheckbox(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	oldEntity := entity.Clone()
 	entity.Content = newContent
-	if err := a.repo.WriteEntity(entity, a.meta); err != nil {
+	if _, err := a.ws.UpdateEntity(entity, oldEntity); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to write: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -1532,24 +1531,10 @@ func (a *App) handleDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, edge := range a.g.OutgoingEdges(entityID) {
-		if delErr := a.repo.DeleteRelation(edge.From, edge.Type, edge.To); delErr != nil {
-			log.Printf("Failed to delete relation file: %v", delErr)
-		}
-		a.g.RemoveEdge(edge.From, edge.Type, edge.To)
-	}
-	for _, edge := range a.g.IncomingEdges(entityID) {
-		if delErr := a.repo.DeleteRelation(edge.From, edge.Type, edge.To); delErr != nil {
-			log.Printf("Failed to delete relation file: %v", delErr)
-		}
-		a.g.RemoveEdge(edge.From, edge.Type, edge.To)
-	}
-
-	if err := a.repo.DeleteEntity(entity.Type, entityID, a.meta); err != nil {
+	if _, err := a.ws.DeleteEntity(entity.Type, entityID, true); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to delete: %v", err), http.StatusInternalServerError)
 		return
 	}
-	a.g.RemoveNode(entityID)
 
 	log.Printf("Deleted %s", entityID)
 
@@ -1581,73 +1566,32 @@ func (a *App) handleInlineCreate(w http.ResponseWriter, r *http.Request) {
 
 	entDef, _ := a.meta.GetEntityDef(form.EntityType)
 
-	var entityID string
+	opts := workspace.CreateOptions{
+		Properties: a.buildProperties(form.Fields, entDef, form.EntityType, r),
+	}
 	if entDef.IsManualID() {
-		entityID = r.FormValue("_entity_id")
-		if entityID == "" {
+		opts.ID = r.FormValue("_entity_id")
+		if opts.ID == "" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(map[string]string{"error": "ID is required"}) //nolint:errcheck // best-effort JSON response
 			return
 		}
-	} else {
-		prefix := ""
-		prefixes := entDef.GetIDPrefixes()
-		if len(prefixes) > 0 {
-			prefix = prefixes[0]
-		}
-		if entDef.IsShortID() {
-			entityID = model.GenerateShortID(a.g.AllIDs(), prefix, a.g.NodeCount())
-		} else {
-			entityID = model.GenerateNextID(a.g.IDsByType(form.EntityType), prefix)
-		}
 	}
 
-	if _, exists := a.g.GetNode(entityID); exists {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusConflict)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Entity with this ID already exists"}) //nolint:errcheck // best-effort JSON response
-		return
-	}
-
-	entity := model.NewEntity(entityID, form.EntityType)
-
-	for _, f := range form.Fields {
-		prop := entDef.Properties[f.Property]
-		widget := resolveWidget(prop, a.meta)
-		if widget == WidgetMultiSelect {
-			values := r.Form[f.Property]
-			if len(values) > 0 {
-				entity.Properties[f.Property] = values
-			}
-		} else {
-			val := r.FormValue(f.Property)
-			if val == "" && a.userDefaults != nil {
-				val = a.userDefaults.ResolvePropertyDefault(form.EntityType, f.Property)
-			}
-			if val == "" && f.Default != "" {
-				val = f.Default
-			}
-			if val != "" {
-				entity.Properties[f.Property] = val
-			}
-		}
-	}
-
-	if err := a.repo.WriteEntity(entity, a.meta); err != nil {
+	entity, _, err := a.ws.CreateEntity(form.EntityType, opts)
+	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()}) //nolint:errcheck // best-effort JSON response
 		return
 	}
-	entity.ModTime = time.Now()
-	a.g.AddNode(entity)
 
-	log.Printf("Inline-created %s %s", form.EntityType, entityID)
+	log.Printf("Inline-created %s %s", form.EntityType, entity.ID)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{ //nolint:errcheck // best-effort JSON response
-		"id":    entityID,
+		"id":    entity.ID,
 		"title": a.entityDisplayTitle(entity),
 	})
 }
@@ -1834,14 +1778,12 @@ func (a *App) handleLinkExisting(w http.ResponseWriter, r *http.Request) {
 		fromID, toID = targetID, peerID
 	}
 
-	rel := model.NewRelation(fromID, relation, toID)
-	if err := a.repo.WriteRelation(rel); err != nil {
+	if _, err := a.ws.CreateRelation(fromID, relation, toID); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()}) //nolint:errcheck // best-effort JSON response
 		return
 	}
-	a.g.AddEdge(rel)
 
 	log.Printf("Linked %s --%s--> %s", fromID, relation, toID)
 

--- a/internal/dataentry/handlers_api.go
+++ b/internal/dataentry/handlers_api.go
@@ -2,10 +2,12 @@ package dataentry
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 // --- JSON API Handlers ---
@@ -416,65 +418,23 @@ func (a *App) handleAPICreateEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entDef, ok := a.meta.GetEntityDef(req.Type)
-	if !ok {
-		writeJSONError(w, http.StatusBadRequest, "unknown entity type: "+req.Type)
-		return
-	}
-
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	// Generate or validate ID
-	entityID := req.ID
-	if entityID == "" {
-		if entDef.IsManualID() {
-			writeJSONError(w, http.StatusBadRequest, "ID is required for this entity type")
+	entity, _, err := a.ws.CreateEntity(req.Type, workspace.CreateOptions{
+		ID:         req.ID,
+		Properties: req.Properties,
+		Content:    req.Content,
+	})
+	if err != nil {
+		var valErr *workspace.ValidationError
+		if errors.As(err, &valErr) {
+			writeJSONError(w, http.StatusBadRequest, "validation error: "+valErr.Errors[0].Error())
 			return
 		}
-		prefix := ""
-		prefixes := entDef.GetIDPrefixes()
-		if len(prefixes) > 0 {
-			prefix = prefixes[0]
-		}
-		if entDef.IsShortID() {
-			entityID = model.GenerateShortID(a.g.AllIDs(), prefix, a.g.NodeCount())
-		} else {
-			entityID = model.GenerateNextID(a.g.IDsByType(req.Type), prefix)
-		}
-	}
-
-	if _, exists := a.g.GetNode(entityID); exists {
-		writeJSONError(w, http.StatusConflict, "entity already exists: "+entityID)
+		writeJSONError(w, http.StatusInternalServerError, "failed to create entity: "+err.Error())
 		return
 	}
-
-	// Create entity
-	entity := &model.Entity{
-		ID:         entityID,
-		Type:       req.Type,
-		Properties: make(map[string]interface{}),
-		Content:    req.Content,
-	}
-
-	for k, v := range req.Properties {
-		entity.Properties[k] = v
-	}
-
-	// Validate entity
-	if validationErrs := a.meta.ValidateEntity(entity); len(validationErrs) > 0 {
-		writeJSONError(w, http.StatusBadRequest, "validation error: "+validationErrs[0].Error())
-		return
-	}
-
-	// Write to storage
-	if err := a.repo.WriteEntity(entity, a.meta); err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "failed to write entity: "+err.Error())
-		return
-	}
-
-	// Add to graph
-	a.g.AddNode(entity)
 
 	// Return created entity
 	result := a.entityToAPI(entity, false)
@@ -512,6 +472,8 @@ func (a *App) handleAPIUpdateEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	oldEntity := entity.Clone()
+
 	// Update properties
 	if req.Properties != nil {
 		for k, v := range req.Properties {
@@ -524,15 +486,13 @@ func (a *App) handleAPIUpdateEntity(w http.ResponseWriter, r *http.Request) {
 		entity.Content = *req.Content
 	}
 
-	// Validate entity
-	if validationErrs := a.meta.ValidateEntity(entity); len(validationErrs) > 0 {
-		writeJSONError(w, http.StatusBadRequest, "validation error: "+validationErrs[0].Error())
-		return
-	}
-
-	// Write to storage
-	if err := a.repo.WriteEntity(entity, a.meta); err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "failed to write entity: "+err.Error())
+	if _, err := a.ws.UpdateEntity(entity, oldEntity); err != nil {
+		var valErr *workspace.ValidationError
+		if errors.As(err, &valErr) {
+			writeJSONError(w, http.StatusBadRequest, "validation error: "+valErr.Errors[0].Error())
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, "failed to update entity: "+err.Error())
 		return
 	}
 
@@ -564,29 +524,10 @@ func (a *App) handleAPIDeleteEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Delete relations first
-	for _, edge := range a.g.OutgoingEdges(entity.ID) {
-		if err := a.repo.DeleteRelation(edge.From, edge.Type, edge.To); err != nil {
-			writeJSONError(w, http.StatusInternalServerError, "failed to delete relation: "+err.Error())
-			return
-		}
-		a.g.RemoveEdge(edge.From, edge.Type, edge.To)
-	}
-	for _, edge := range a.g.IncomingEdges(entity.ID) {
-		if err := a.repo.DeleteRelation(edge.From, edge.Type, edge.To); err != nil {
-			writeJSONError(w, http.StatusInternalServerError, "failed to delete relation: "+err.Error())
-			return
-		}
-		a.g.RemoveEdge(edge.From, edge.Type, edge.To)
-	}
-
-	// Delete entity
-	if err := a.repo.DeleteEntity(entity.Type, entity.ID, a.meta); err != nil {
+	if _, err := a.ws.DeleteEntity(entity.Type, entity.ID, true); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to delete entity: "+err.Error())
 		return
 	}
-
-	a.g.RemoveNode(entity.ID)
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -612,43 +553,16 @@ func (a *App) handleAPICreateRelation(w http.ResponseWriter, r *http.Request) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	// Verify source and target exist
-	if _, found := a.g.GetNode(req.From); !found {
-		writeJSONError(w, http.StatusBadRequest, "source entity not found: "+req.From)
+	var opts []workspace.CreateRelationOptions
+	if len(req.Properties) > 0 {
+		opts = append(opts, workspace.CreateRelationOptions{Properties: req.Properties})
+	}
+
+	relation, err := a.ws.CreateRelation(req.From, req.Type, req.To, opts...)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to create relation: "+err.Error())
 		return
 	}
-	if _, found := a.g.GetNode(req.To); !found {
-		writeJSONError(w, http.StatusBadRequest, "target entity not found: "+req.To)
-		return
-	}
-
-	// Check if relation already exists
-	for _, edge := range a.g.OutgoingEdges(req.From) {
-		if edge.Type == req.Type && edge.To == req.To {
-			writeJSONError(w, http.StatusConflict, "relation already exists")
-			return
-		}
-	}
-
-	// Create relation
-	relation := &model.Relation{
-		From:       req.From,
-		Type:       req.Type,
-		To:         req.To,
-		Properties: make(map[string]interface{}),
-	}
-
-	for k, v := range req.Properties {
-		relation.Properties[k] = v
-	}
-
-	// Write to storage
-	if err := a.repo.WriteRelation(relation); err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "failed to write relation: "+err.Error())
-		return
-	}
-
-	a.g.AddEdge(relation)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
@@ -692,13 +606,10 @@ func (a *App) handleAPIDeleteRelation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Delete from storage
-	if err := a.repo.DeleteRelation(from, relType, to); err != nil {
+	if err := a.ws.DeleteRelation(from, relType, to); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to delete relation: "+err.Error())
 		return
 	}
-
-	a.g.RemoveEdge(from, relType, to)
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/dataentry/handlers_kanban.go
+++ b/internal/dataentry/handlers_kanban.go
@@ -295,6 +295,8 @@ func (a *App) handleKanbanMove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	oldEntity := entity.Clone()
+
 	// Update column property
 	entity.Properties[kanban.ColumnProperty] = column
 
@@ -303,8 +305,8 @@ func (a *App) handleKanbanMove(w http.ResponseWriter, r *http.Request) {
 		entity.Properties[kanban.SwimlaneProperty] = swimlane
 	}
 
-	// Write entity to disk
-	if err := a.repo.WriteEntity(entity, a.meta); err != nil {
+	// Write entity through workspace
+	if _, err := a.ws.UpdateEntity(entity, oldEntity); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to write: %v", err), http.StatusInternalServerError)
 		return
 	}

--- a/internal/dataentry/handlers_test.go
+++ b/internal/dataentry/handlers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 // newHandlerTestApp builds a full App (including parsed templates) for handler tests.
@@ -63,6 +64,8 @@ func newHandlerTestApp(t *testing.T) *App {
 	_ = fs.MkdirAll(ctx.CacheDir, 0o755)
 	repo := repository.New(fs, ctx)
 
+	ws := workspace.NewWithGraph(repo, meta, g)
+
 	return &App{
 		Cfg:         cfg,
 		meta:        meta,
@@ -71,6 +74,7 @@ func newHandlerTestApp(t *testing.T) *App {
 		styleMap:    styleMap,
 		styledTypes: styledTypes,
 		repo:        repo,
+		ws:          ws,
 	}
 }
 
@@ -1468,6 +1472,9 @@ func TestHandleCreateWithValidationErrors(t *testing.T) {
 		entDef.Properties["title"] = titleProp
 		app.meta.Entities["ticket"] = entDef
 
+		// Rebuild workspace with updated repo and meta
+		app.ws = workspace.NewWithGraph(app.repo, app.meta, app.g)
+
 		// Submit form without title (required field)
 		form := url.Values{
 			"_form_id":   {"create-ticket"},
@@ -1515,6 +1522,9 @@ func TestHandleUpdateWithValidationErrors(t *testing.T) {
 		titleProp.Required = true
 		entDef.Properties["title"] = titleProp
 		app.meta.Entities["ticket"] = entDef
+
+		// Rebuild workspace with updated repo and meta
+		app.ws = workspace.NewWithGraph(app.repo, app.meta, app.g)
 
 		// Submit form with empty title (required field)
 		form := url.Values{

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -186,8 +186,9 @@ func (w *Workspace) ResolveEntityType(typeName string) (string, *metamodel.Entit
 
 // --- ID generation ---
 
-// GenerateID generates the next ID for the given entity type.
-func (w *Workspace) GenerateID(entityType string) (string, error) {
+// GenerateID generates the next ID for the given entity type. If prefix is
+// non-empty it is used instead of the default prefix from the metamodel.
+func (w *Workspace) GenerateID(entityType, prefix string) (string, error) {
 	meta := w.Meta()
 	entityDef, ok := meta.GetEntityDef(entityType)
 	if !ok {
@@ -196,16 +197,19 @@ func (w *Workspace) GenerateID(entityType string) (string, error) {
 	if entityDef.IsManualID() {
 		return "", fmt.Errorf("entity type %s uses manual IDs", entityType)
 	}
-	prefixes := entityDef.GetIDPrefixes()
-	if len(prefixes) == 0 {
-		return "", fmt.Errorf("no ID prefixes defined for type %s", entityType)
+	if prefix == "" {
+		prefixes := entityDef.GetIDPrefixes()
+		if len(prefixes) == 0 {
+			return "", fmt.Errorf("no ID prefixes defined for type %s", entityType)
+		}
+		prefix = prefixes[0]
 	}
 
 	existingIDs := w.graph.AllIDs()
 	if entityDef.IsShortID() {
-		return model.GenerateShortID(existingIDs, prefixes[0], w.graph.NodeCount()), nil
+		return model.GenerateShortID(existingIDs, prefix, w.graph.NodeCount()), nil
 	}
-	return model.GenerateNextID(existingIDs, prefixes[0]), nil
+	return model.GenerateNextID(existingIDs, prefix), nil
 }
 
 // --- Entity operations ---
@@ -213,6 +217,7 @@ func (w *Workspace) GenerateID(entityType string) (string, error) {
 // CreateOptions configures entity creation.
 type CreateOptions struct {
 	ID         string                 // empty = auto-generate
+	Prefix     string                 // override default ID prefix (ignored when ID is set)
 	Properties map[string]interface{} // property values
 	Content    string                 // markdown body
 }
@@ -237,7 +242,7 @@ func (w *Workspace) CreateEntity(entityType string, opts CreateOptions) (*model.
 	// Resolve ID.
 	entityID := opts.ID
 	if entityID == "" {
-		id, err := w.GenerateID(entityType)
+		id, err := w.GenerateID(entityType, opts.Prefix)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -433,9 +438,14 @@ func (w *Workspace) DeleteEntity(entityType, id string, cascade bool) (*DeleteRe
 
 // --- Relation operations ---
 
+// CreateRelationOptions configures optional settings for relation creation.
+type CreateRelationOptions struct {
+	Properties map[string]interface{} // property values for the relation
+}
+
 // CreateRelation validates both endpoints exist, checks for duplicates,
 // validates against the metamodel, writes to disk, and updates the graph.
-func (w *Workspace) CreateRelation(from, relType, to string) (*model.Relation, error) {
+func (w *Workspace) CreateRelation(from, relType, to string, opts ...CreateRelationOptions) (*model.Relation, error) {
 	meta := w.Meta()
 
 	fromEntity, ok := w.graph.GetNode(from)
@@ -466,6 +476,13 @@ func (w *Workspace) CreateRelation(from, relType, to string) (*model.Relation, e
 	}
 	if template != nil {
 		markdown.ApplyRelationTemplate(rel, template)
+	}
+
+	// Apply caller-provided properties (override template defaults).
+	if len(opts) > 0 {
+		for k, v := range opts[0].Properties {
+			rel.Properties[k] = v
+		}
 	}
 
 	if err := w.repo.WriteRelation(rel); err != nil {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -187,7 +187,7 @@ func TestResolveEntityType(t *testing.T) {
 func TestGenerateID(t *testing.T) {
 	ws := setupTestWorkspace(t)
 
-	id, err := ws.GenerateID("requirement")
+	id, err := ws.GenerateID("requirement", "")
 	if err != nil {
 		t.Fatalf("GenerateID() error = %v", err)
 	}
@@ -199,7 +199,7 @@ func TestGenerateID(t *testing.T) {
 func TestGenerateID_ManualType(t *testing.T) {
 	ws := setupTestWorkspace(t)
 
-	_, err := ws.GenerateID("stakeholder")
+	_, err := ws.GenerateID("stakeholder", "")
 	if err == nil {
 		t.Error("expected error for manual ID type")
 	}
@@ -208,7 +208,7 @@ func TestGenerateID_ManualType(t *testing.T) {
 func TestGenerateID_UnknownType(t *testing.T) {
 	ws := setupTestWorkspace(t)
 
-	_, err := ws.GenerateID("nonexistent")
+	_, err := ws.GenerateID("nonexistent", "")
 	if err == nil {
 		t.Error("expected error for unknown type")
 	}
@@ -220,7 +220,7 @@ func TestGenerateID_Sequential(t *testing.T) {
 	// Add an existing entity so the next ID is REQ-002.
 	ws.graph.AddNode(&model.Entity{ID: "REQ-001", Type: "requirement", Properties: map[string]interface{}{"title": "first"}})
 
-	id, err := ws.GenerateID("requirement")
+	id, err := ws.GenerateID("requirement", "")
 	if err != nil {
 		t.Fatalf("GenerateID() error = %v", err)
 	}

--- a/tickets/entities/tickets/TKT-025.md
+++ b/tickets/entities/tickets/TKT-025.md
@@ -1,0 +1,10 @@
+---
+description: Migrate all dataentry handler writes (create, update, delete, kanban moves, API CRUD, relation CRUD) to use workspace methods instead of direct repository+graph calls.
+effort: s
+id: TKT-025
+kind: refactor
+priority: medium
+status: done
+title: Route dataentry writes through workspace
+type: ticket
+---

--- a/tickets/relations/TKT-025--affects--data-entry.md
+++ b/tickets/relations/TKT-025--affects--data-entry.md
@@ -1,0 +1,5 @@
+---
+from: TKT-025
+to: data-entry
+type: affects
+---

--- a/tickets/relations/TKT-025--affects--workspace.md
+++ b/tickets/relations/TKT-025--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-025
+to: workspace
+type: affects
+---


### PR DESCRIPTION
## Summary
- Migrate all dataentry handler writes (create, update, delete, kanban moves) to use workspace methods
- Add `Prefix` to `CreateOptions` and `CreateRelationOptions` for relation properties
- Remove unused `generateEntityID` and `populateProperties` helpers
- Update test fixtures with ID prefixes and workspace setup

## Test plan
- [x] All tests pass
- [x] Architecture lint passes
- [x] Pre-commit hook passes (format, lint, tests)