### PR TITLE
Unify dataentry watcher with workspace watcher

### DIFF
--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -54,7 +54,7 @@ func main() {
 	// Start file watcher for live-reload.
 	// The watcher goroutine is cleaned up on process exit; no explicit stop
 	// is needed since log.Fatal calls os.Exit.
-	if _, err := app.StartWatching(); err != nil {
+	if err := app.StartWatching(); err != nil {
 		log.Printf("Warning: file watcher not started: %v", err)
 	} else {
 		log.Println("File watcher started for live-reload")

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/repository"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 // eventBroker manages SSE client connections for live-reload notifications.
@@ -51,24 +52,26 @@ func (b *eventBroker) broadcast(event string) {
 }
 
 // StartWatching begins file watching for live-reload of views when project
-// files change. Returns a stop function to shut down the watcher.
+// files change. The workspace handles metamodel + graph reload; this method
+// adds dataentry-specific side-effects (config reload, SSE broadcast).
+// Stop via a.ws.StopWatching().
 //
 // coverage-ignore: requires real filesystem events via fsnotify
-func (a *App) StartWatching() (stop func(), err error) {
-	paths := a.repo.Paths()
+func (a *App) StartWatching() error {
+	paths := a.ws.Repo().Paths()
 	configPath := filepath.Join(paths.Root, ConfigFile)
 	metamodelDir := filepath.Join(paths.Root, "metamodel")
 
-	opts := repository.WatchOptions{
+	return a.ws.StartWatching(workspace.WatchOptions{
 		ExtraFiles: []string{configPath},
 		ExtraDirs:  []string{metamodelDir},
-	}
-	return a.repo.Watch(opts, func(events []repository.ChangeEvent) {
-		for _, e := range events {
-			log.Printf("File changed: %s (%s)", e.Path, e.Op)
-		}
-		a.reload(events)
-		a.broker.broadcast("refresh")
+		OnReload: func(events []repository.ChangeEvent) {
+			for _, e := range events {
+				log.Printf("File changed: %s (%s)", e.Path, e.Op)
+			}
+			a.onReload(events)
+			a.broker.broadcast("refresh")
+		},
 	})
 }
 
@@ -113,14 +116,15 @@ func (a *App) StartGitFetch() (stop func()) {
 	}
 }
 
-// reload re-syncs the graph and optionally reloads metamodel/config when
-// the corresponding files have changed. It holds the write lock to ensure
-// no handlers are reading stale state during the swap.
-func (a *App) reload(events []repository.ChangeEvent) {
+// onReload handles dataentry-specific side-effects after the workspace has
+// already reloaded the metamodel and re-synced the graph. It re-reads the
+// data-entry config if changed, updates convenience aliases, and rebuilds
+// styles/templates.
+func (a *App) onReload(events []repository.ChangeEvent) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	paths := a.repo.Paths()
+	paths := a.ws.Repo().Paths()
 	configPath := filepath.Join(paths.Root, ConfigFile)
 	metamodelDir := filepath.Join(paths.Root, "metamodel") + string(filepath.Separator)
 	needConfigReload := false
@@ -138,7 +142,7 @@ func (a *App) reload(events []repository.ChangeEvent) {
 	}
 
 	if needConfigReload {
-		cfgData, err := a.repo.ReadProjectFile(ConfigFile)
+		cfgData, err := a.ws.Repo().ReadProjectFile(ConfigFile)
 		if err != nil {
 			log.Printf("Config reload error: %v", err)
 		} else {
@@ -152,16 +156,9 @@ func (a *App) reload(events []repository.ChangeEvent) {
 		}
 	}
 
-	// Reload metamodel + graph via workspace
-	result, err := a.ws.Reload()
-	if err != nil {
-		log.Printf("Workspace reload error: %v", err)
-	} else {
-		// Update convenience aliases
-		a.meta = a.ws.Meta()
-		a.g = a.ws.Graph()
-		log.Printf("Graph re-synced: %d entities, %d relations", result.EntitiesLoaded, result.RelationsLoaded)
-	}
+	// Update convenience aliases (workspace already reloaded)
+	a.meta = a.ws.Meta()
+	a.g = a.ws.Graph()
 
 	// Rebuild styles and templates if config or metamodel changed
 	if needConfigReload || needMetamodelReload {

--- a/internal/dataentry/watcher_test.go
+++ b/internal/dataentry/watcher_test.go
@@ -264,6 +264,13 @@ func TestEventBrokerConcurrency(t *testing.T) {
 	}
 }
 
+// simulateReload mimics what workspace.StartWatching does: reload the
+// workspace (metamodel + graph), then call the dataentry onReload callback.
+func (a *App) simulateReload(events []repository.ChangeEvent) {
+	_, _ = a.ws.Reload()
+	a.onReload(events)
+}
+
 // --- reload tests ---
 
 func TestReloadEntityChanges(t *testing.T) {
@@ -282,7 +289,7 @@ status: open
 `), 0o644)
 
 	// Reload with a generic entity change (not metamodel or config)
-	app.reload([]repository.ChangeEvent{
+	app.simulateReload([]repository.ChangeEvent{
 		{Path: app.repo.Paths().EntitiesDir + "/tickets/TKT-002.md", Op: repository.OpCreate},
 	})
 
@@ -331,7 +338,7 @@ relations:
 `
 	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(updatedMeta), 0o644)
 
-	app.reload([]repository.ChangeEvent{
+	app.simulateReload([]repository.ChangeEvent{
 		{Path: app.repo.Paths().MetamodelPath, Op: repository.OpModify},
 	})
 
@@ -356,7 +363,7 @@ navigation: []
 	configPath := app.repo.Paths().Root + "/" + ConfigFile
 	_ = fs.WriteFile(configPath, []byte(updatedConfig), 0o644)
 
-	app.reload([]repository.ChangeEvent{
+	app.simulateReload([]repository.ChangeEvent{
 		{Path: configPath, Op: repository.OpModify},
 	})
 
@@ -376,7 +383,7 @@ func TestReloadBadMetamodelKeepsPrevious(t *testing.T) {
 	// Write invalid metamodel
 	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(`not: valid: metamodel: {{{`), 0o644)
 
-	app.reload([]repository.ChangeEvent{
+	app.simulateReload([]repository.ChangeEvent{
 		{Path: app.repo.Paths().MetamodelPath, Op: repository.OpModify},
 	})
 
@@ -395,7 +402,7 @@ func TestReloadBadConfigKeepsPrevious(t *testing.T) {
 	// Write invalid YAML config
 	_ = fs.WriteFile(configPath, []byte(`not: valid: yaml: {{{`), 0o644)
 
-	app.reload([]repository.ChangeEvent{
+	app.simulateReload([]repository.ChangeEvent{
 		{Path: configPath, Op: repository.OpModify},
 	})
 
@@ -442,7 +449,7 @@ relations:
 	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(updatedMeta), 0o644)
 
 	// Reload with both config and metamodel changes at once
-	app.reload([]repository.ChangeEvent{
+	app.simulateReload([]repository.ChangeEvent{
 		{Path: configPath, Op: repository.OpModify},
 		{Path: app.repo.Paths().MetamodelPath, Op: repository.OpModify},
 	})

--- a/tickets/entities/tickets/TKT-026.md
+++ b/tickets/entities/tickets/TKT-026.md
@@ -1,0 +1,10 @@
+---
+description: Replace dataentry's direct repo.Watch() with ws.StartWatching(), eliminating duplicate watcher and redundant ws.Reload() call.
+effort: s
+id: TKT-026
+kind: refactor
+priority: medium
+status: done
+title: Unify dataentry watcher with workspace watcher
+type: ticket
+---

--- a/tickets/relations/TKT-026--affects--data-entry.md
+++ b/tickets/relations/TKT-026--affects--data-entry.md
@@ -1,0 +1,5 @@
+---
+from: TKT-026
+to: data-entry
+type: affects
+---

--- a/tickets/relations/TKT-026--affects--workspace.md
+++ b/tickets/relations/TKT-026--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-026
+to: workspace
+type: affects
+---


### PR DESCRIPTION
## Summary
- Replace `a.repo.Watch()` with `a.ws.StartWatching()` in dataentry
- Rename `reload()` → `onReload()`, remove redundant `ws.Reload()` call (workspace watcher already reloads before calling OnReload)
- Replace `a.repo.Paths()`/`a.repo.ReadProjectFile()` with `a.ws.Repo().*`
- Update `cmd/rela-server` call site (`StartWatching` now returns `error`)

## Test plan
- [x] All tests pass
- [x] Architecture lint passes
- [x] Pre-commit hook passes (format, lint, tests)