### PR TITLE
Expose project-level accessors on workspace

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -181,6 +181,7 @@ deps:
       - markdown
       - metamodel
       - migration
+      - project
       - rename
       - repository
 

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -131,7 +131,7 @@ func extractAttachmentPaths(val interface{}) []string {
 }
 
 func gcOrphanedTempFiles() error {
-	orphaned, err := repo.FindOrphanedTempFiles()
+	orphaned, err := ws.FindOrphanedTempFiles()
 	if err != nil {
 		return fmt.Errorf("find orphaned files: %w", err)
 	}
@@ -149,7 +149,7 @@ func gcOrphanedTempFiles() error {
 		return nil
 	}
 
-	count, err := repo.CleanupOrphanedTempFiles()
+	count, err := ws.CleanupOrphanedTempFiles()
 	if err != nil {
 		return fmt.Errorf("cleanup failed: %w", err)
 	}

--- a/internal/cli/template.go
+++ b/internal/cli/template.go
@@ -89,7 +89,7 @@ Examples:
 
 		// Generate entity templates
 		for _, entityType := range entityTypes {
-			created, err := repo.GenerateEntityTemplate(meta, entityType, templateVariant, templateForce)
+			created, err := ws.GenerateEntityTemplate(entityType, templateVariant, templateForce)
 			if err != nil {
 				return fmt.Errorf("failed to generate template for %s: %w", entityType, err)
 			}
@@ -110,7 +110,7 @@ Examples:
 
 		// Generate relation templates
 		for _, relationType := range relationTypes {
-			created, err := repo.GenerateRelationTemplate(meta, relationType, templateForce)
+			created, err := ws.GenerateRelationTemplate(relationType, templateForce)
 			if err != nil {
 				return fmt.Errorf("failed to generate template for %s: %w", relationType, err)
 			}

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -21,7 +21,6 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/migration"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/natsort"
-	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
@@ -41,7 +40,6 @@ type App struct {
 	// Convenience aliases set from workspace; avoid method-call overhead in hot paths.
 	meta *metamodel.Metamodel
 	g    *graph.Graph
-	repo repository.Store
 	tmpl *template.Template
 	// styleMap: property type name -> value -> CSS class name
 	styleMap map[string]map[string]string
@@ -60,15 +58,13 @@ type App struct {
 
 // NewApp creates and initializes an App using the given workspace.
 func NewApp(ws *workspace.Workspace) (*App, error) {
-	repo := ws.Repo()
-
 	// Load data-entry config from project root
-	cfgData, err := repo.ReadProjectFile(ConfigFile)
+	cfgData, err := ws.ReadProjectFile(ConfigFile)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", ConfigFile, err)
 	}
 	// Check for deprecated syntax that needs migration
-	configPath := filepath.Join(repo.Paths().Root, ConfigFile)
+	configPath := filepath.Join(ws.Paths().Root, ConfigFile)
 	detections := migration.DetectBytes(cfgData, migration.FileTypeDataEntry)
 	if len(detections) > 0 {
 		return nil, &migration.Error{
@@ -109,7 +105,6 @@ func NewApp(ws *workspace.Workspace) (*App, error) {
 		ws:          ws,
 		meta:        meta,
 		g:           g,
-		repo:        repo,
 		tmpl:        tmpl,
 		styleMap:    styleMap,
 		styledTypes: styledTypes,
@@ -118,8 +113,8 @@ func NewApp(ws *workspace.Workspace) (*App, error) {
 	app.userDefaults = app.loadUserDefaults()
 
 	// Initialize git ops if enabled and repo is a git repository
-	if cfg.Git != nil && cfg.Git.Enabled && git.IsRepo(repo.Paths().Root) {
-		app.gitOps = git.NewOps(repo.Paths().Root, *cfg.Git)
+	if cfg.Git != nil && cfg.Git.Enabled && git.IsRepo(ws.Paths().Root) {
+		app.gitOps = git.NewOps(ws.Paths().Root, *cfg.Git)
 		log.Printf("Git sync enabled (mode: %s)", cfg.Git.Mode)
 	}
 
@@ -221,10 +216,10 @@ func (a *App) navElements(activeList string) []NavElement {
 // Returns an empty UIState if the file doesn't exist or can't be parsed.
 func (a *App) loadUIState() UIState {
 	state := UIState{CollapsedGroups: make(map[string]bool)}
-	if a.repo == nil {
+	if a.ws == nil {
 		return state
 	}
-	data, err := a.repo.ReadCacheFile(uiStateFile)
+	data, err := a.ws.ReadCacheFile(uiStateFile)
 	if err != nil {
 		return state
 	}
@@ -239,23 +234,23 @@ func (a *App) loadUIState() UIState {
 
 // saveUIState writes the UI state to .rela/ui-state.json.
 func (a *App) saveUIState(state UIState) error {
-	if a.repo == nil {
+	if a.ws == nil {
 		return nil
 	}
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return err
 	}
-	return a.repo.WriteCacheFile(uiStateFile, data)
+	return a.ws.WriteCacheFile(uiStateFile, data)
 }
 
 // loadUserDefaults reads .rela/user-defaults.yaml and returns the parsed defaults.
 // Returns nil if the file doesn't exist or can't be parsed.
 func (a *App) loadUserDefaults() *UserDefaults {
-	if a.repo == nil {
+	if a.ws == nil {
 		return nil
 	}
-	data, err := a.repo.ReadCacheFile(userDefaultsFile)
+	data, err := a.ws.ReadCacheFile(userDefaultsFile)
 	if err != nil {
 		return nil
 	}
@@ -268,14 +263,14 @@ func (a *App) loadUserDefaults() *UserDefaults {
 
 // saveUserDefaults writes the user defaults to .rela/user-defaults.yaml.
 func (a *App) saveUserDefaults(ud *UserDefaults) error {
-	if a.repo == nil {
+	if a.ws == nil {
 		return nil
 	}
 	data, err := yaml.Marshal(ud)
 	if err != nil {
 		return err
 	}
-	return a.repo.WriteCacheFile(userDefaultsFile, data)
+	return a.ws.WriteCacheFile(userDefaultsFile, data)
 }
 
 // firstNavTarget returns the first navigable item from the navigation config,
@@ -416,7 +411,7 @@ func (a *App) ProjectName() string {
 
 // ProjectRoot returns the root directory of the loaded project.
 func (a *App) ProjectRoot() string {
-	return a.repo.Paths().Root
+	return a.ws.Paths().Root
 }
 
 // colorToCSSClass maps a color name from config to a CSS class.
@@ -467,7 +462,7 @@ func buildStyleMap(cfg *Config, meta *metamodel.Metamodel) (styleMap map[string]
 
 // templatesForType returns all entity templates for a type, or nil on error.
 func (a *App) templatesForType(entityType string) []*markdown.EntityTemplate {
-	templates, err := a.repo.DiscoverEntityTemplates(entityType)
+	templates, err := a.ws.DiscoverEntityTemplates(entityType)
 	if err != nil {
 		return nil
 	}

--- a/internal/dataentry/app_test.go
+++ b/internal/dataentry/app_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 // testMeta returns a metamodel suitable for testing app-level functions.
@@ -706,7 +707,7 @@ func TestFirstNavTarget(t *testing.T) {
 }
 
 func TestUIStateLoadSave(t *testing.T) {
-	// Create an app with a real repository backed by memfs
+	// Create an app with a workspace backed by memfs
 	fs := storage.NewMemFS()
 	ctx := &project.Context{
 		Root:     "/project",
@@ -716,7 +717,7 @@ func TestUIStateLoadSave(t *testing.T) {
 	repo := repository.New(fs, ctx)
 
 	app := testAppInstance()
-	app.repo = repo
+	app.ws = workspace.NewWithGraph(repo, app.meta, app.g)
 
 	t.Run("load returns defaults when file missing", func(t *testing.T) {
 		state := app.loadUIState()
@@ -738,7 +739,7 @@ func TestUIStateLoadSave(t *testing.T) {
 
 	t.Run("UIState overrides config default", func(t *testing.T) {
 		app2 := testAppInstance()
-		app2.repo = repo
+		app2.ws = workspace.NewWithGraph(repo, app2.meta, app2.g)
 		app2.Cfg.Navigation = []NavigationEntry{
 			{
 				Group:     "Tickets",
@@ -762,9 +763,9 @@ func TestUIStateLoadSave(t *testing.T) {
 		}
 	})
 
-	t.Run("nil repo is safe", func(t *testing.T) {
+	t.Run("nil ws is safe", func(t *testing.T) {
 		app2 := testAppInstance()
-		app2.repo = nil
+		app2.ws = nil
 		state := app2.loadUIState()
 		if len(state.CollapsedGroups) != 0 {
 			t.Error("expected empty state")
@@ -785,7 +786,7 @@ func TestUserDefaultsLoadSave(t *testing.T) {
 	repo := repository.New(fs, ctx)
 
 	app := testAppInstance()
-	app.repo = repo
+	app.ws = workspace.NewWithGraph(repo, app.meta, app.g)
 
 	t.Run("load returns nil when file missing", func(t *testing.T) {
 		ud := app.loadUserDefaults()
@@ -830,9 +831,9 @@ func TestUserDefaultsLoadSave(t *testing.T) {
 		}
 	})
 
-	t.Run("nil repo is safe", func(t *testing.T) {
+	t.Run("nil ws is safe", func(t *testing.T) {
 		app2 := testAppInstance()
-		app2.repo = nil
+		app2.ws = nil
 		ud := app2.loadUserDefaults()
 		if ud != nil {
 			t.Errorf("expected nil, got %+v", ud)

--- a/internal/dataentry/commands_test.go
+++ b/internal/dataentry/commands_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 // --- resolveCommands ---
@@ -254,7 +255,9 @@ func TestParseCommandOutput(t *testing.T) {
 
 func TestBuildEntityInput(t *testing.T) {
 	app := testAppInstance()
-	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"})
+	app.ws = workspace.NewWithGraph(
+		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"}),
+		app.meta, app.g)
 	entity, _ := app.g.GetNode("TKT-001")
 	app.g.AddEdge(model.NewRelation("TKT-001", "depends_on", "TKT-002"))
 
@@ -289,7 +292,9 @@ func TestBuildEntityInput(t *testing.T) {
 
 func TestBuildListInput(t *testing.T) {
 	app := testAppInstance()
-	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"})
+	app.ws = workspace.NewWithGraph(
+		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"}),
+		app.meta, app.g)
 	entities := app.g.NodesByType("ticket")
 
 	input := app.buildListInput("tickets", entities)
@@ -307,7 +312,9 @@ func TestBuildListInput(t *testing.T) {
 
 func TestBuildViewInput(t *testing.T) {
 	app := testAppInstance()
-	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"})
+	app.ws = workspace.NewWithGraph(
+		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"}),
+		app.meta, app.g)
 	app.g.AddEdge(model.NewRelation("TKT-001", "belongs_to", "CMP-001"))
 
 	view := ViewConfig{
@@ -343,7 +350,9 @@ func TestBuildViewInput(t *testing.T) {
 
 func TestBuildGlobalInput(t *testing.T) {
 	app := testAppInstance()
-	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"})
+	app.ws = workspace.NewWithGraph(
+		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"}),
+		app.meta, app.g)
 
 	input := app.buildGlobalInput()
 
@@ -359,7 +368,9 @@ func TestBuildGlobalInput(t *testing.T) {
 
 func TestBuildCommandEnv(t *testing.T) {
 	app := testAppInstance()
-	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"})
+	app.ws = workspace.NewWithGraph(
+		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"}),
+		app.meta, app.g)
 
 	cmd := CommandConfig{
 		Script:  "echo hi",
@@ -390,7 +401,9 @@ func TestBuildCommandEnv(t *testing.T) {
 
 func TestBuildCommandEnvListContext(t *testing.T) {
 	app := testAppInstance()
-	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"})
+	app.ws = workspace.NewWithGraph(
+		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"}),
+		app.meta, app.g)
 
 	cmd := CommandConfig{Script: "echo hi", Context: "list"}
 	input := app.buildListInput("tickets", nil)
@@ -404,7 +417,9 @@ func TestBuildCommandEnvListContext(t *testing.T) {
 
 func TestBuildCommandEnvViewContext(t *testing.T) {
 	app := testAppInstance()
-	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"})
+	app.ws = workspace.NewWithGraph(
+		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"}),
+		app.meta, app.g)
 
 	cmd := CommandConfig{Script: "echo hi", Context: "view"}
 	entity, _ := app.g.GetNode("TKT-001")
@@ -585,7 +600,9 @@ commands:
 
 func TestHandleCommandExec(t *testing.T) {
 	app := newHandlerTestApp(t)
-	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()})
+	app.ws = workspace.NewWithGraph(
+		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()}),
+		app.meta, app.g)
 	app.Cfg.Commands = map[string]CommandConfig{
 		"test-echo": {
 			Label:   "Test Echo",
@@ -666,7 +683,9 @@ func TestHandleCommandExec(t *testing.T) {
 
 func TestHandleCommandExecFailing(t *testing.T) {
 	app := newHandlerTestApp(t)
-	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()})
+	app.ws = workspace.NewWithGraph(
+		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()}),
+		app.meta, app.g)
 	app.Cfg.Commands = map[string]CommandConfig{
 		"fail-cmd": {
 			Label:   "Fail",
@@ -702,7 +721,9 @@ func TestHandleCommandExecFailing(t *testing.T) {
 
 func TestHandleCommandExecGlobalContext(t *testing.T) {
 	app := newHandlerTestApp(t)
-	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()})
+	app.ws = workspace.NewWithGraph(
+		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()}),
+		app.meta, app.g)
 	app.Cfg.Commands = map[string]CommandConfig{
 		"global-cmd": {
 			Label:   "Global",
@@ -732,7 +753,9 @@ func TestHandleCommandExecGlobalContext(t *testing.T) {
 
 func TestHandleCommandExecListContext(t *testing.T) {
 	app := newHandlerTestApp(t)
-	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()})
+	app.ws = workspace.NewWithGraph(
+		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()}),
+		app.meta, app.g)
 	app.Cfg.Commands = map[string]CommandConfig{
 		"list-cmd": {
 			Label:   "List",
@@ -752,7 +775,9 @@ func TestHandleCommandExecListContext(t *testing.T) {
 
 func TestHandleCommandExecViewContext(t *testing.T) {
 	app := newHandlerTestApp(t)
-	app.repo = repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()})
+	app.ws = workspace.NewWithGraph(
+		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()}),
+		app.meta, app.g)
 	app.Cfg.Commands = map[string]CommandConfig{
 		"view-cmd": {
 			Label:   "View",

--- a/internal/dataentry/handlers_conflict.go
+++ b/internal/dataentry/handlers_conflict.go
@@ -37,9 +37,9 @@ func (a *App) handleConflicts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := &project.Context{
-		Root:         a.repo.Paths().Root,
-		EntitiesDir:  a.repo.Paths().EntitiesDir,
-		RelationsDir: a.repo.Paths().RelationsDir,
+		Root:         a.ws.Paths().Root,
+		EntitiesDir:  a.ws.Paths().EntitiesDir,
+		RelationsDir: a.ws.Paths().RelationsDir,
 	}
 
 	result, err := conflict.DetectAll(ctx)
@@ -88,7 +88,7 @@ func (a *App) handleConflictResolve(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build absolute path
-	ctx := a.repo.Paths()
+	ctx := a.ws.Paths()
 	absPath := filepath.Join(ctx.Root, path)
 
 	// Parse the conflicted file
@@ -143,7 +143,7 @@ func (a *App) handleConflictApply(w http.ResponseWriter, r *http.Request) {
 	}
 
 	action := r.FormValue("action")
-	ctx := a.repo.Paths()
+	ctx := a.ws.Paths()
 	absPath := filepath.Join(ctx.Root, path)
 
 	// Parse the file again
@@ -211,13 +211,13 @@ func (a *App) handleConflictApply(w http.ResponseWriter, r *http.Request) {
 
 // conflictCount returns the number of conflicted files for nav badge.
 func (a *App) conflictCount() int {
-	if a.repo == nil {
+	if a.ws == nil {
 		return 0
 	}
 	ctx := &project.Context{
-		Root:         a.repo.Paths().Root,
-		EntitiesDir:  a.repo.Paths().EntitiesDir,
-		RelationsDir: a.repo.Paths().RelationsDir,
+		Root:         a.ws.Paths().Root,
+		EntitiesDir:  a.ws.Paths().EntitiesDir,
+		RelationsDir: a.ws.Paths().RelationsDir,
 	}
 
 	result, err := conflict.DetectAll(ctx)

--- a/internal/dataentry/handlers_test.go
+++ b/internal/dataentry/handlers_test.go
@@ -73,7 +73,6 @@ func newHandlerTestApp(t *testing.T) *App {
 		tmpl:        tmpl,
 		styleMap:    styleMap,
 		styledTypes: styledTypes,
-		repo:        repo,
 		ws:          ws,
 	}
 }
@@ -852,11 +851,11 @@ func TestHandleExecuteQuery(t *testing.T) {
 func TestHandleToggleGroup(t *testing.T) {
 	t.Run("toggles group collapsed state", func(t *testing.T) {
 		app := newHandlerTestApp(t)
-		// Set up a repo for UI state persistence
+		// Set up a workspace with cache dir for UI state persistence
 		fs := storage.NewMemFS()
 		ctx := &project.Context{Root: "/project", CacheDir: "/project/.rela"}
 		_ = fs.MkdirAll(ctx.CacheDir, 0o755)
-		app.repo = repository.New(fs, ctx)
+		app.ws = workspace.NewWithGraph(repository.New(fs, ctx), app.meta, app.g)
 
 		// Toggle "Tickets" group to collapsed
 		body := strings.NewReader("group=Tickets")
@@ -1463,7 +1462,7 @@ func TestHandleCreateWithValidationErrors(t *testing.T) {
 		app := newHandlerTestApp(t)
 		// Configure temp directory for repository to avoid writing to real filesystem
 		tmpDir := t.TempDir()
-		app.repo = newTestRepository(t, tmpDir)
+		repo := newTestRepository(t, tmpDir)
 
 		// Make title required in the metamodel
 		entDef := app.meta.Entities["ticket"]
@@ -1473,7 +1472,7 @@ func TestHandleCreateWithValidationErrors(t *testing.T) {
 		app.meta.Entities["ticket"] = entDef
 
 		// Rebuild workspace with updated repo and meta
-		app.ws = workspace.NewWithGraph(app.repo, app.meta, app.g)
+		app.ws = workspace.NewWithGraph(repo, app.meta, app.g)
 
 		// Submit form without title (required field)
 		form := url.Values{
@@ -1514,7 +1513,7 @@ func TestHandleUpdateWithValidationErrors(t *testing.T) {
 		app := newHandlerTestApp(t)
 		// Configure temp directory for repository to avoid writing to real filesystem
 		tmpDir := t.TempDir()
-		app.repo = newTestRepository(t, tmpDir)
+		repo := newTestRepository(t, tmpDir)
 
 		// Make title required in the metamodel
 		entDef := app.meta.Entities["ticket"]
@@ -1524,7 +1523,7 @@ func TestHandleUpdateWithValidationErrors(t *testing.T) {
 		app.meta.Entities["ticket"] = entDef
 
 		// Rebuild workspace with updated repo and meta
-		app.ws = workspace.NewWithGraph(app.repo, app.meta, app.g)
+		app.ws = workspace.NewWithGraph(repo, app.meta, app.g)
 
 		// Submit form with empty title (required field)
 		form := url.Values{

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -58,7 +58,7 @@ func (b *eventBroker) broadcast(event string) {
 //
 // coverage-ignore: requires real filesystem events via fsnotify
 func (a *App) StartWatching() error {
-	paths := a.ws.Repo().Paths()
+	paths := a.ws.Paths()
 	configPath := filepath.Join(paths.Root, ConfigFile)
 	metamodelDir := filepath.Join(paths.Root, "metamodel")
 
@@ -124,7 +124,7 @@ func (a *App) onReload(events []repository.ChangeEvent) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	paths := a.ws.Repo().Paths()
+	paths := a.ws.Paths()
 	configPath := filepath.Join(paths.Root, ConfigFile)
 	metamodelDir := filepath.Join(paths.Root, "metamodel") + string(filepath.Separator)
 	needConfigReload := false
@@ -142,7 +142,7 @@ func (a *App) onReload(events []repository.ChangeEvent) {
 	}
 
 	if needConfigReload {
-		cfgData, err := a.ws.Repo().ReadProjectFile(ConfigFile)
+		cfgData, err := a.ws.ReadProjectFile(ConfigFile)
 		if err != nil {
 			log.Printf("Config reload error: %v", err)
 		} else {

--- a/internal/dataentry/watcher_test.go
+++ b/internal/dataentry/watcher_test.go
@@ -133,7 +133,6 @@ status: open
 		ws:          ws,
 		meta:        meta,
 		g:           g,
-		repo:        repo,
 		tmpl:        tmpl,
 		styleMap:    styleMap,
 		styledTypes: styledTypes,
@@ -280,7 +279,7 @@ func TestReloadEntityChanges(t *testing.T) {
 	initialCount := len(app.g.AllNodes())
 
 	// Add a new entity file
-	_ = fs.WriteFile(app.repo.Paths().EntitiesDir+"/tickets/TKT-002.md", []byte(`---
+	_ = fs.WriteFile(app.ws.Paths().EntitiesDir+"/tickets/TKT-002.md", []byte(`---
 id: TKT-002
 type: ticket
 title: Second Ticket
@@ -290,7 +289,7 @@ status: open
 
 	// Reload with a generic entity change (not metamodel or config)
 	app.simulateReload([]repository.ChangeEvent{
-		{Path: app.repo.Paths().EntitiesDir + "/tickets/TKT-002.md", Op: repository.OpCreate},
+		{Path: app.ws.Paths().EntitiesDir + "/tickets/TKT-002.md", Op: repository.OpCreate},
 	})
 
 	newCount := len(app.g.AllNodes())
@@ -336,10 +335,10 @@ relations:
     from: [ticket]
     to: [ticket]
 `
-	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(updatedMeta), 0o644)
+	_ = fs.WriteFile(app.ws.Paths().MetamodelPath, []byte(updatedMeta), 0o644)
 
 	app.simulateReload([]repository.ChangeEvent{
-		{Path: app.repo.Paths().MetamodelPath, Op: repository.OpModify},
+		{Path: app.ws.Paths().MetamodelPath, Op: repository.OpModify},
 	})
 
 	if _, ok := app.meta.GetEntityDef("component"); !ok {
@@ -360,7 +359,7 @@ lists: {}
 forms: {}
 navigation: []
 `
-	configPath := app.repo.Paths().Root + "/" + ConfigFile
+	configPath := app.ws.Paths().Root + "/" + ConfigFile
 	_ = fs.WriteFile(configPath, []byte(updatedConfig), 0o644)
 
 	app.simulateReload([]repository.ChangeEvent{
@@ -381,10 +380,10 @@ func TestReloadBadMetamodelKeepsPrevious(t *testing.T) {
 	original := app.meta
 
 	// Write invalid metamodel
-	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(`not: valid: metamodel: {{{`), 0o644)
+	_ = fs.WriteFile(app.ws.Paths().MetamodelPath, []byte(`not: valid: metamodel: {{{`), 0o644)
 
 	app.simulateReload([]repository.ChangeEvent{
-		{Path: app.repo.Paths().MetamodelPath, Op: repository.OpModify},
+		{Path: app.ws.Paths().MetamodelPath, Op: repository.OpModify},
 	})
 
 	// Metamodel should be unchanged
@@ -397,7 +396,7 @@ func TestReloadBadConfigKeepsPrevious(t *testing.T) {
 	app, fs := setupReloadTestApp(t)
 
 	originalName := app.Cfg.App.Name
-	configPath := app.repo.Paths().Root + "/" + ConfigFile
+	configPath := app.ws.Paths().Root + "/" + ConfigFile
 
 	// Write invalid YAML config
 	_ = fs.WriteFile(configPath, []byte(`not: valid: yaml: {{{`), 0o644)
@@ -415,7 +414,7 @@ func TestReloadBadConfigKeepsPrevious(t *testing.T) {
 func TestReloadMixedEvents(t *testing.T) {
 	app, fs := setupReloadTestApp(t)
 
-	configPath := app.repo.Paths().Root + "/" + ConfigFile
+	configPath := app.ws.Paths().Root + "/" + ConfigFile
 	updatedConfig := `version: "1.0"
 app:
   name: "Mixed Update"
@@ -446,12 +445,12 @@ relations:
     from: [ticket]
     to: [ticket]
 `
-	_ = fs.WriteFile(app.repo.Paths().MetamodelPath, []byte(updatedMeta), 0o644)
+	_ = fs.WriteFile(app.ws.Paths().MetamodelPath, []byte(updatedMeta), 0o644)
 
 	// Reload with both config and metamodel changes at once
 	app.simulateReload([]repository.ChangeEvent{
 		{Path: configPath, Op: repository.OpModify},
-		{Path: app.repo.Paths().MetamodelPath, Op: repository.OpModify},
+		{Path: app.ws.Paths().MetamodelPath, Op: repository.OpModify},
 	})
 
 	if app.Cfg.App.Name != "Mixed Update" {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/migration"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/rename"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
 )
@@ -94,9 +95,54 @@ func (w *Workspace) Meta() *metamodel.Metamodel {
 	return w.meta
 }
 
-// Repo returns the underlying repository for operations that Workspace
-// does not wrap (ReadProjectFile, WriteCacheFile, FS, etc.).
+// Repo returns the underlying repository for low-level operations not
+// wrapped by Workspace (e.g., FS access, Watch).
 func (w *Workspace) Repo() repository.Store { return w.repo }
+
+// --- Project accessors ---
+
+// Paths returns the project directory layout.
+func (w *Workspace) Paths() *project.Context { return w.repo.Paths() }
+
+// ReadProjectFile reads a file relative to the project root.
+func (w *Workspace) ReadProjectFile(name string) ([]byte, error) {
+	return w.repo.ReadProjectFile(name)
+}
+
+// ReadCacheFile reads a file from the .rela cache directory.
+func (w *Workspace) ReadCacheFile(name string) ([]byte, error) {
+	return w.repo.ReadCacheFile(name)
+}
+
+// WriteCacheFile writes a file to the .rela cache directory.
+func (w *Workspace) WriteCacheFile(name string, data []byte) error {
+	return w.repo.WriteCacheFile(name, data)
+}
+
+// DiscoverEntityTemplates returns all templates (including variants) for an entity type.
+func (w *Workspace) DiscoverEntityTemplates(entityType string) ([]*markdown.EntityTemplate, error) {
+	return w.repo.DiscoverEntityTemplates(entityType)
+}
+
+// GenerateEntityTemplate generates a template file for the given entity type.
+func (w *Workspace) GenerateEntityTemplate(entityType, variant string, force bool) (bool, error) {
+	return w.repo.GenerateEntityTemplate(w.Meta(), entityType, variant, force)
+}
+
+// GenerateRelationTemplate generates a template file for the given relation type.
+func (w *Workspace) GenerateRelationTemplate(relationType string, force bool) (bool, error) {
+	return w.repo.GenerateRelationTemplate(w.Meta(), relationType, force)
+}
+
+// FindOrphanedTempFiles returns paths of leftover .new temp files.
+func (w *Workspace) FindOrphanedTempFiles() ([]string, error) {
+	return w.repo.FindOrphanedTempFiles()
+}
+
+// CleanupOrphanedTempFiles removes leftover .new temp files.
+func (w *Workspace) CleanupOrphanedTempFiles() (int, error) {
+	return w.repo.CleanupOrphanedTempFiles()
+}
 
 // --- Lifecycle ---
 

--- a/tickets/entities/tickets/TKT-027.md
+++ b/tickets/entities/tickets/TKT-027.md
@@ -1,0 +1,10 @@
+---
+description: Add thin delegate methods to workspace (Paths, ReadProjectFile, ReadCacheFile, etc.), remove repo field from dataentry App, route CLI template/gc through workspace.
+effort: m
+id: TKT-027
+kind: refactor
+priority: medium
+status: done
+title: Expose project-level accessors on workspace
+type: ticket
+---

--- a/tickets/relations/TKT-027--affects--data-entry.md
+++ b/tickets/relations/TKT-027--affects--data-entry.md
@@ -1,0 +1,5 @@
+---
+from: TKT-027
+to: data-entry
+type: affects
+---

--- a/tickets/relations/TKT-027--affects--workspace.md
+++ b/tickets/relations/TKT-027--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-027
+to: workspace
+type: affects
+---


### PR DESCRIPTION
## Summary
- Add 9 thin delegate methods to workspace (`Paths`, `ReadProjectFile`, `ReadCacheFile`, `WriteCacheFile`, `DiscoverEntityTemplates`, `GenerateEntityTemplate`, `GenerateRelationTemplate`, `FindOrphanedTempFiles`, `CleanupOrphanedTempFiles`)
- Remove `repo` field from dataentry `App` struct, route all calls through `a.ws.*`
- Migrate CLI `template.go` and `gc.go` to use `ws.*` instead of `repo.*`
- Update arch-lint config to allow workspace → project dependency

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go-arch-lint check`
- [x] `golangci-lint run`