### PR TITLE
Remove repository imports from dataentry and mcp

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -143,7 +143,6 @@ deps:
       - metamodel
       - migration
       - project
-      - repository
       - search
       - workspace
     canUse:
@@ -165,7 +164,6 @@ deps:
       - markdown
       - metamodel
       - rename
-      - repository
       - search
       - views
       - workspace

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -12,7 +12,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
@@ -65,7 +64,7 @@ func (a *App) StartWatching() error {
 	return a.ws.StartWatching(workspace.WatchOptions{
 		ExtraFiles: []string{configPath},
 		ExtraDirs:  []string{metamodelDir},
-		OnReload: func(events []repository.ChangeEvent) {
+		OnReload: func(events []workspace.ChangeEvent) {
 			for _, e := range events {
 				log.Printf("File changed: %s (%s)", e.Path, e.Op)
 			}
@@ -120,7 +119,7 @@ func (a *App) StartGitFetch() (stop func()) {
 // already reloaded the metamodel and re-synced the graph. It re-reads the
 // data-entry config if changed, updates convenience aliases, and rebuilds
 // styles/templates.
-func (a *App) onReload(events []repository.ChangeEvent) {
+func (a *App) onReload(events []workspace.ChangeEvent) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -8,7 +8,6 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
-	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
@@ -58,7 +57,7 @@ func (s *Server) Serve() error {
 
 	// Start file watcher via workspace
 	if err := s.ws.StartWatching(workspace.WatchOptions{
-		OnReload: func(_ []repository.ChangeEvent) {
+		OnReload: func(_ []workspace.ChangeEvent) {
 			s.logger.Println("Graph re-synced from file changes")
 			if s.mcp != nil {
 				s.mcp.SendNotificationToAllClients(

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -22,6 +22,13 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/repository"
 )
 
+// ChangeEvent is re-exported from repository so consumers don't need to
+// import repository directly for watcher callback signatures.
+type ChangeEvent = repository.ChangeEvent
+
+// ChangeOp is re-exported from repository for the same reason as ChangeEvent.
+type ChangeOp = repository.ChangeOp
+
 // Workspace is a stateful domain session that ties together the repository
 // (persistence), graph (in-memory query), metamodel (schema), and automation
 // engine. All write operations go through Workspace so that disk and memory
@@ -567,7 +574,7 @@ type WatchOptions struct {
 	ExtraDirs []string
 	// OnReload is called after workspace has reloaded metamodel and graph.
 	// Consumers use this for side-effects (SSE broadcast, MCP notifications, etc.).
-	OnReload func(events []repository.ChangeEvent)
+	OnReload func(events []ChangeEvent)
 }
 
 // StartWatching begins watching for file changes. On each change the

--- a/tickets/entities/tickets/TKT-028.md
+++ b/tickets/entities/tickets/TKT-028.md
@@ -1,0 +1,10 @@
+---
+description: Re-export ChangeEvent/ChangeOp from workspace, remove repository imports from dataentry and mcp, enforce boundary in arch-lint.
+effort: s
+id: TKT-028
+kind: refactor
+priority: medium
+status: done
+title: Remove repository imports from dataentry and mcp consumers
+type: ticket
+---

--- a/tickets/relations/TKT-028--affects--data-entry.md
+++ b/tickets/relations/TKT-028--affects--data-entry.md
@@ -1,0 +1,5 @@
+---
+from: TKT-028
+to: data-entry
+type: affects
+---

--- a/tickets/relations/TKT-028--affects--workspace.md
+++ b/tickets/relations/TKT-028--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-028
+to: workspace
+type: affects
+---


### PR DESCRIPTION
## Summary
- Re-export `ChangeEvent`/`ChangeOp` as type aliases from workspace
- Replace `repository.ChangeEvent` with `workspace.ChangeEvent` in dataentry watcher and mcp server
- Remove `repository` from `dataentry` and `mcp` `mayDependOn` in arch-lint

Dataentry and mcp now only depend on workspace for persistence, not repository directly.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go-arch-lint check`
- [x] `golangci-lint run`