### PR TITLE
Remove CLI storage/repository dependencies

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -119,11 +119,8 @@ deps:
       - markdown
       - mcp
       - metamodel
-      - migration
       - output
       - project
-      - repository
-      - storage
       - views
       - workspace
     canUse:
@@ -175,6 +172,7 @@ deps:
   workspace:
     mayDependOn:
       - automation
+      - dataentryconfig
       - graph
       - markdown
       - metamodel
@@ -183,6 +181,7 @@ deps:
       - rename
       - repository
       - storage
+      - views
 
   # Domain services
   automation:

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -171,6 +171,7 @@ deps:
   # Application services
   workspace:
     mayDependOn:
+      - attachment
       - automation
       - dataentryconfig
       - graph

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -111,7 +111,6 @@ deps:
   # CLI layer — orchestrates everything
   cli:
     mayDependOn:
-      - attachment
       - dataentryconfig
       - filter
       - graph

--- a/internal/attachment/store.go
+++ b/internal/attachment/store.go
@@ -359,26 +359,6 @@ func detectContentType(ext string) string {
 	}
 }
 
-// FormatSize formats a byte size as a human-readable string.
-func FormatSize(size int64) string {
-	const (
-		KB = 1024
-		MB = KB * 1024
-		GB = MB * 1024
-	)
-
-	switch {
-	case size >= GB:
-		return fmt.Sprintf("%.1fGB", float64(size)/GB)
-	case size >= MB:
-		return fmt.Sprintf("%.1fMB", float64(size)/MB)
-	case size >= KB:
-		return fmt.Sprintf("%.1fKB", float64(size)/KB)
-	default:
-		return fmt.Sprintf("%dB", size)
-	}
-}
-
 // ValidatePath checks if a path is a valid attachment path.
 func ValidatePath(path string) error {
 	hash, ext, ok := ParsePath(path)

--- a/internal/attachment/store_test.go
+++ b/internal/attachment/store_test.go
@@ -224,28 +224,6 @@ func TestValidatePath(t *testing.T) {
 	}
 }
 
-func TestFormatSize(t *testing.T) {
-	tests := []struct {
-		size int64
-		want string
-	}{
-		{0, "0B"},
-		{100, "100B"},
-		{1024, "1.0KB"},
-		{1536, "1.5KB"},
-		{1048576, "1.0MB"},
-		{1572864, "1.5MB"},
-		{1073741824, "1.0GB"},
-	}
-
-	for _, tt := range tests {
-		got := FormatSize(tt.size)
-		if got != tt.want {
-			t.Errorf("FormatSize(%d) = %q, want %q", tt.size, got, tt.want)
-		}
-	}
-}
-
 func TestStoreNoExtension(t *testing.T) {
 	fs := storage.NewMemFS()
 	store := NewStore(fs, "/project")

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -72,7 +72,7 @@ Examples:
 		}
 
 		// Create attachment store
-		store := attachment.NewStore(cliFS, projectCtx.Root)
+		store := attachment.NewStore(ws.FS(), ws.Paths().Root)
 
 		// Process each file
 		var attachments []*attachment.Attachment

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -2,13 +2,9 @@ package cli
 
 import (
 	"fmt"
-	"os/user"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-
-	"github.com/Sourcehaven-BV/rela/internal/attachment"
-	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
 var attachProperty string
@@ -34,48 +30,7 @@ Examples:
 		entityID := args[0]
 		filePaths := args[1:]
 
-		// Get entity from graph
-		entity, ok := g.GetNode(entityID)
-		if !ok {
-			return fmt.Errorf("entity not found: %s", entityID)
-		}
-
-		// Get entity definition
-		entityDef, ok := meta.GetEntityDef(entity.Type)
-		if !ok {
-			return fmt.Errorf("unknown entity type: %s", entity.Type)
-		}
-
-		// Determine which property to use
-		propName := attachProperty
-		if propName == "" {
-			// Find first file-type property
-			propName = findFileProperty(entityDef)
-			if propName == "" {
-				return fmt.Errorf("no file property defined for entity type %s; use --property to specify", entity.Type)
-			}
-		}
-
-		// Validate property exists and is file type
-		propDef, ok := entityDef.Properties[propName]
-		if !ok {
-			return fmt.Errorf("property %q not defined for entity type %s", propName, entity.Type)
-		}
-		if propDef.Type != metamodel.PropertyTypeFile {
-			return fmt.Errorf("property %q is not a file type (is %s)", propName, propDef.Type)
-		}
-
-		// Get current user for metadata
-		addedBy := ""
-		if u, err := user.Current(); err == nil {
-			addedBy = u.Username
-		}
-
-		// Create attachment store
-		store := attachment.NewStore(ws.FS(), ws.Paths().Root)
-
-		// Process each file
-		var attachments []*attachment.Attachment
+		var attached int
 		for _, filePath := range filePaths {
 			// Expand globs
 			matches, err := filepath.Glob(filePath)
@@ -94,71 +49,21 @@ Examples:
 					return fmt.Errorf("invalid path %q: %w", match, err)
 				}
 
-				// Add to store
-				att, err := store.Add(absPath, addedBy)
+				result, err := ws.AttachFile(entityID, absPath, attachProperty)
 				if err != nil {
 					return fmt.Errorf("failed to attach %q: %w", match, err)
 				}
-				attachments = append(attachments, att)
-				out.WriteSuccess("Attached %s → %s", filepath.Base(match), att.Path)
+				out.WriteSuccess("Attached %s → %s", filepath.Base(match), result.Path)
+				attached++
 			}
 		}
 
-		if len(attachments) == 0 {
+		if attached == 0 {
 			return fmt.Errorf("no files matched")
-		}
-
-		// Clone before mutation so workspace can diff old vs new.
-		oldEntity := entity.Clone()
-
-		// Update entity property
-		// For single file, store as string; for multiple, store as list
-		if len(attachments) == 1 {
-			entity.SetString(propName, attachments[0].Path)
-		} else {
-			// Get existing values if any
-			var paths []string
-			if existing := entity.Properties[propName]; existing != nil {
-				switch v := existing.(type) {
-				case string:
-					if v != "" {
-						paths = append(paths, v)
-					}
-				case []interface{}:
-					for _, item := range v {
-						if s, ok := item.(string); ok {
-							paths = append(paths, s)
-						}
-					}
-				case []string:
-					paths = append(paths, v...)
-				}
-			}
-
-			// Add new paths
-			for _, att := range attachments {
-				paths = append(paths, att.Path)
-			}
-			entity.Properties[propName] = paths
-		}
-
-		// Write through workspace (validates, persists, updates graph+cache).
-		if _, err := ws.UpdateEntity(entity, oldEntity); err != nil {
-			return fmt.Errorf("failed to update entity: %w", err)
 		}
 
 		return nil
 	},
-}
-
-// findFileProperty returns the first file-type property name for an entity definition.
-func findFileProperty(entityDef *metamodel.EntityDef) string {
-	for name, prop := range entityDef.Properties {
-		if prop.Type == metamodel.PropertyTypeFile {
-			return name
-		}
-	}
-	return ""
 }
 
 func init() {

--- a/internal/cli/attachments.go
+++ b/internal/cli/attachments.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Sourcehaven-BV/rela/internal/attachment"
-	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
 var attachmentsCmd = &cobra.Command{
@@ -24,74 +23,9 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		entityID := args[0]
 
-		// Get entity from graph
-		entity, ok := g.GetNode(entityID)
-		if !ok {
-			return fmt.Errorf("entity not found: %s", entityID)
-		}
-
-		// Get entity definition
-		entityDef, ok := meta.GetEntityDef(entity.Type)
-		if !ok {
-			return fmt.Errorf("unknown entity type: %s", entity.Type)
-		}
-
-		// Create attachment store for metadata lookup
-		store := attachment.NewStore(ws.FS(), ws.Paths().Root)
-
-		// Collect attachments from all file properties
-		type attachmentInfo struct {
-			Property string
-			Path     string
-			Original string
-			Size     string
-		}
-
-		var infos []attachmentInfo
-
-		for propName, propDef := range entityDef.Properties {
-			if propDef.Type != metamodel.PropertyTypeFile {
-				continue
-			}
-
-			val, ok := entity.Properties[propName]
-			if !ok || val == nil {
-				continue
-			}
-
-			// Handle single value or list
-			var paths []string
-			switch v := val.(type) {
-			case string:
-				if v != "" {
-					paths = append(paths, v)
-				}
-			case []interface{}:
-				for _, item := range v {
-					if s, ok := item.(string); ok && s != "" {
-						paths = append(paths, s)
-					}
-				}
-			case []string:
-				paths = append(paths, v...)
-			}
-
-			for _, path := range paths {
-				info := attachmentInfo{
-					Property: propName,
-					Path:     path,
-					Original: "-",
-					Size:     "-",
-				}
-
-				// Try to get metadata
-				if meta, err := store.GetMetadata(path); err == nil {
-					info.Original = meta.OriginalName
-					info.Size = attachment.FormatSize(meta.Size)
-				}
-
-				infos = append(infos, info)
-			}
+		infos, err := ws.ListAttachments(entityID)
+		if err != nil {
+			return err
 		}
 
 		if len(infos) == 0 {
@@ -114,8 +48,8 @@ Examples:
 			if len(info.Path) > pathWidth {
 				pathWidth = len(info.Path)
 			}
-			if len(info.Original) > origWidth {
-				origWidth = len(info.Original)
+			if len(info.OriginalName) > origWidth {
+				origWidth = len(info.OriginalName)
 			}
 		}
 
@@ -130,7 +64,15 @@ Examples:
 
 		// Print rows
 		for _, info := range infos {
-			out.WriteMessage(format, info.Property, info.Path, info.Original, info.Size)
+			original := info.OriginalName
+			if original == "" {
+				original = "-"
+			}
+			size := "-"
+			if info.Size > 0 {
+				size = attachment.FormatSize(info.Size)
+			}
+			out.WriteMessage(format, info.Property, info.Path, original, size)
 		}
 
 		return nil

--- a/internal/cli/attachments.go
+++ b/internal/cli/attachments.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Sourcehaven-BV/rela/internal/attachment"
+	"github.com/Sourcehaven-BV/rela/internal/output"
 )
 
 var attachmentsCmd = &cobra.Command{
@@ -70,7 +70,7 @@ Examples:
 			}
 			size := "-"
 			if info.Size > 0 {
-				size = attachment.FormatSize(info.Size)
+				size = output.FormatSize(info.Size)
 			}
 			out.WriteMessage(format, info.Property, info.Path, original, size)
 		}

--- a/internal/cli/attachments.go
+++ b/internal/cli/attachments.go
@@ -37,7 +37,7 @@ Examples:
 		}
 
 		// Create attachment store for metadata lookup
-		store := attachment.NewStore(cliFS, projectCtx.Root)
+		store := attachment.NewStore(ws.FS(), ws.Paths().Root)
 
 		// Collect attachments from all file properties
 		type attachmentInfo struct {

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -132,7 +133,7 @@ func getBodyContent(cmd *cobra.Command) (string, error) {
 		if createBodyFile == "-" {
 			content, err = io.ReadAll(cmd.InOrStdin())
 		} else {
-			content, err = cliFS.ReadFile(createBodyFile)
+			content, err = os.ReadFile(createBodyFile)
 		}
 
 		if err != nil {

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Sourcehaven-BV/rela/internal/attachment"
+	"github.com/Sourcehaven-BV/rela/internal/output"
 )
 
 var (
@@ -61,7 +61,7 @@ func gcAttachmentFiles() error {
 
 	if gcDryRun {
 		out.WriteMessage("Would remove %d unreferenced attachment(s) (%s):",
-			len(result.Removed), attachment.FormatSize(result.Reclaimed))
+			len(result.Removed), output.FormatSize(result.Reclaimed))
 		for _, path := range result.Removed {
 			out.WriteMessage("  %s", path)
 		}
@@ -69,7 +69,7 @@ func gcAttachmentFiles() error {
 	}
 
 	out.WriteSuccess("Removed %d unreferenced attachment(s), reclaimed %s",
-		len(result.Removed), attachment.FormatSize(result.Reclaimed))
+		len(result.Removed), output.FormatSize(result.Reclaimed))
 
 	return nil
 }

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -51,7 +51,7 @@ Examples:
 
 func gcAttachmentFiles() error {
 	referencedPaths := collectReferencedAttachmentPaths()
-	store := attachment.NewStore(cliFS, projectCtx.Root)
+	store := attachment.NewStore(ws.FS(), ws.Paths().Root)
 
 	result, err := store.GC(referencedPaths)
 	if err != nil {

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Sourcehaven-BV/rela/internal/attachment"
-	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
 var (
@@ -50,12 +49,9 @@ Examples:
 }
 
 func gcAttachmentFiles() error {
-	referencedPaths := collectReferencedAttachmentPaths()
-	store := attachment.NewStore(ws.FS(), ws.Paths().Root)
-
-	result, err := store.GC(referencedPaths)
+	result, err := ws.GCAttachments(gcDryRun)
 	if err != nil {
-		return fmt.Errorf("gc failed: %w", err)
+		return err
 	}
 
 	if len(result.Removed) == 0 {
@@ -72,60 +68,8 @@ func gcAttachmentFiles() error {
 		return nil
 	}
 
-	if err := store.RemoveUnreferenced(result); err != nil {
-		return fmt.Errorf("failed to remove files: %w", err)
-	}
-
 	out.WriteSuccess("Removed %d unreferenced attachment(s), reclaimed %s",
 		len(result.Removed), attachment.FormatSize(result.Reclaimed))
-
-	return nil
-}
-
-// collectReferencedAttachmentPaths returns all attachment paths referenced by entities.
-func collectReferencedAttachmentPaths() []string {
-	var paths []string
-
-	for _, entity := range g.AllNodes() {
-		entityDef, ok := meta.GetEntityDef(entity.Type)
-		if !ok {
-			continue
-		}
-
-		for propName, propDef := range entityDef.Properties {
-			if propDef.Type != metamodel.PropertyTypeFile {
-				continue
-			}
-
-			paths = append(paths, extractAttachmentPaths(entity.Properties[propName])...)
-		}
-	}
-
-	return paths
-}
-
-// extractAttachmentPaths extracts attachment paths from a property value.
-func extractAttachmentPaths(val interface{}) []string {
-	if val == nil {
-		return nil
-	}
-
-	switch v := val.(type) {
-	case string:
-		if v != "" {
-			return []string{v}
-		}
-	case []interface{}:
-		var paths []string
-		for _, item := range v {
-			if s, ok := item.(string); ok && s != "" {
-				paths = append(paths, s)
-			}
-		}
-		return paths
-	case []string:
-		return v
-	}
 
 	return nil
 }

--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -83,7 +83,7 @@ Examples:
 		}
 
 		// Write DOT file
-		return cliFS.WriteFile(graphOutput, []byte(dot), 0644)
+		return os.WriteFile(graphOutput, []byte(dot), 0644)
 	},
 }
 

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -79,7 +79,7 @@ CSV format (relations):
 			RelationsFile: importRelationsFile,
 		}
 
-		imp := importer.New(ws.Repo(), meta, g, opts, importer.NewImportSource(cliFS))
+		imp := importer.New(ws.Repo(), meta, g, opts, importer.NewImportSource(ws.FS()))
 
 		if importDryRun {
 			out.WriteInfo("Dry run - validating without creating files...")

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,14 +1,11 @@
 package cli
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
-	"github.com/Sourcehaven-BV/rela/internal/metamodel"
-	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 var initCmd = &cobra.Command{
@@ -21,56 +18,13 @@ var initCmd = &cobra.Command{
 		if targetDir == "" {
 			targetDir = os.Getenv("RELA_PROJECT")
 		}
-		if targetDir == "" {
-			var err error
-			targetDir, err = cliFS.Getwd()
-			if err != nil {
-				return err
-			}
+
+		result, err := workspace.Initialize(targetDir)
+		if err != nil {
+			return err
 		}
 
-		metamodelPath := filepath.Join(targetDir, project.MetamodelFile)
-
-		// Check if already initialized
-		if _, err := cliFS.Stat(metamodelPath); err == nil {
-			return fmt.Errorf("project already initialized (metamodel.yaml exists)")
-		}
-
-		// Create project context
-		ctx := &project.Context{
-			Root:          targetDir,
-			MetamodelPath: metamodelPath,
-			CacheDir:      filepath.Join(targetDir, project.CacheDir),
-			CachePath:     filepath.Join(targetDir, project.CacheDir, project.CacheFile),
-			EntitiesDir:   filepath.Join(targetDir, project.EntitiesDir),
-			RelationsDir:  filepath.Join(targetDir, project.RelationsDir),
-		}
-
-		// Create directories
-		if err := ctx.Initialize(cliFS); err != nil {
-			return fmt.Errorf("failed to create directories: %w", err)
-		}
-
-		// Write default metamodel
-		if err := cliFS.WriteFile(metamodelPath, []byte(metamodel.DefaultMetamodelYAML()), 0644); err != nil {
-			return fmt.Errorf("failed to write metamodel: %w", err)
-		}
-
-		// Add .rela to .gitignore if it exists
-		gitignorePath := filepath.Join(targetDir, ".gitignore")
-		if _, err := cliFS.Stat(gitignorePath); err == nil {
-			// Read existing content
-			content, err := cliFS.ReadFile(gitignorePath)
-			if err == nil {
-				// Check if .rela is already in .gitignore
-				if !contains(string(content), ".rela") {
-					updated := append(content, []byte("\n# rela cache\n.rela/\n")...)
-					_ = cliFS.WriteFile(gitignorePath, updated, 0644)
-				}
-			}
-		}
-
-		out.WriteSuccess("Initialized rela project in %s", targetDir)
+		out.WriteSuccess("Initialized rela project in %s", result.Root)
 		out.WriteMessage("  Created metamodel.yaml")
 		out.WriteMessage("  Created entities/ directory")
 		out.WriteMessage("  Created relations/ directory")
@@ -86,17 +40,4 @@ var initCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(initCmd)
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || s != "" && containsString(s, substr))
-}
-
-func containsString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -3,14 +3,10 @@ package cli
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
-	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
-	"github.com/Sourcehaven-BV/rela/internal/metamodel"
-	"github.com/Sourcehaven-BV/rela/internal/migration"
-	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 var (
@@ -35,63 +31,27 @@ Examples:
 			startDir = os.Getenv("RELA_PROJECT")
 		}
 
-		// Discover project (we need the paths but not the metamodel)
-		ctx, err := project.Discover(startDir, cliFS)
-		if err != nil {
-			return fmt.Errorf("no project found: run 'rela init' to create one")
-		}
-
-		// Load metamodel for context-aware migrations (ignore errors - metamodel may need migration)
-		mm, _ := metamodel.LoadWithoutMigrationCheck(ctx.MetamodelPath, cliFS)
-
-		// Define files to check
-		dataEntryPath := filepath.Join(ctx.Root, dataentryconfig.ConfigFile)
-
-		files := []struct {
-			path     string
-			fileType migration.FileType
-			name     string
-		}{
-			{ctx.MetamodelPath, migration.FileTypeMetamodel, "metamodel.yaml"},
-			{dataEntryPath, migration.FileTypeDataEntry, dataentryconfig.ConfigFile},
-		}
-
 		if migrateCheck {
-			return runMigrateCheck(files, mm)
+			return runMigrateCheck(startDir)
 		}
 
-		return runMigrate(files, mm)
+		return runMigrate(startDir)
 	},
 }
 
-func runMigrateCheck(files []struct {
-	path     string
-	fileType migration.FileType
-	name     string
-}, meta *metamodel.Metamodel) error {
-	needsMigration := false
-
-	for _, f := range files {
-		// Skip files that don't exist
-		if _, err := cliFS.Stat(f.path); os.IsNotExist(err) {
-			continue
-		}
-
-		detections, err := migration.DetectWithMetamodel(f.path, f.fileType, cliFS, meta)
-		if err != nil {
-			return fmt.Errorf("checking %s: %w", f.name, err)
-		}
-
-		if len(detections) > 0 {
-			needsMigration = true
-			fmt.Printf("%s needs migration:\n", f.name)
-			for _, d := range detections {
-				fmt.Printf("  - %s\n", d.Description)
-			}
-		}
+func runMigrateCheck(startDir string) error {
+	detections, err := workspace.DetectMigrations(startDir)
+	if err != nil {
+		return err
 	}
 
-	if needsMigration {
+	if len(detections) > 0 {
+		for _, d := range detections {
+			fmt.Printf("%s needs migration:\n", d.File.Name)
+			for _, m := range d.Migrations {
+				fmt.Printf("  - %s\n", m.Description)
+			}
+		}
 		fmt.Println("\nRun 'rela migrate' to apply these migrations.")
 		os.Exit(1)
 	}
@@ -100,45 +60,32 @@ func runMigrateCheck(files []struct {
 	return nil
 }
 
-func runMigrate(files []struct {
-	path     string
-	fileType migration.FileType
-	name     string
-}, meta *metamodel.Metamodel) error {
-	filesUpdated := 0
-	totalMigrations := 0
+func runMigrate(startDir string) error {
+	result, err := workspace.Migrate(startDir)
+	if err != nil {
+		return err
+	}
 
-	for _, f := range files {
-		// Skip files that don't exist
-		if _, err := cliFS.Stat(f.path); os.IsNotExist(err) {
-			continue
-		}
-
-		result, err := migration.ApplyWithMetamodel(f.path, f.fileType, cliFS, meta)
-		if err != nil {
-			return fmt.Errorf("migrating %s: %w", f.name, err)
-		}
-
-		if result.HasErrors() {
-			return fmt.Errorf("migrating %s: %w", f.name, result.Error)
-		}
-
-		if result.NeedsMigration() {
-			filesUpdated++
-			fmt.Printf("Migrating %s...\n", f.name)
-			for _, mr := range result.Results {
+	if result.FilesUpdated == 0 {
+		fmt.Println("No migrations needed.")
+	} else {
+		for _, fr := range result.FileResults {
+			appliedCount := 0
+			for _, mr := range fr.Results {
 				if mr.Applied {
-					totalMigrations++
-					fmt.Printf("  ✓ %s: %s\n", mr.Migration.Name(), mr.Migration.Description())
+					appliedCount++
+				}
+			}
+			if appliedCount > 0 {
+				fmt.Printf("Migrating %s...\n", fr.File.Name)
+				for _, mr := range fr.Results {
+					if mr.Applied {
+						fmt.Printf("  ✓ %s: %s\n", mr.Migration.Name(), mr.Migration.Description())
+					}
 				}
 			}
 		}
-	}
-
-	if filesUpdated == 0 {
-		fmt.Println("No migrations needed.")
-	} else {
-		fmt.Printf("\nDone. %d file(s) updated with %d migration(s).\n", filesUpdated, totalMigrations)
+		fmt.Printf("\nDone. %d file(s) updated with %d migration(s).\n", result.FilesUpdated, result.TotalMigrations)
 	}
 
 	return nil

--- a/internal/cli/rename.go
+++ b/internal/cli/rename.go
@@ -107,7 +107,7 @@ func resolveRenameEntity(oldType, newType string) (*renameEntityInfo, error) {
 	}
 
 	oldTemplatePath := projectCtx.EntityTemplatePath(resolvedOld)
-	_, statErr := cliFS.Stat(oldTemplatePath)
+	_, statErr := ws.FS().Stat(oldTemplatePath)
 
 	return &renameEntityInfo{
 		resolvedOld:     resolvedOld,
@@ -165,19 +165,20 @@ func confirmRename() (bool, error) {
 }
 
 func applyRenameEntity(info *renameEntityInfo) error {
-	renameErr := metamodel.RenameEntityType(projectCtx.MetamodelPath, info.resolvedOld, info.newType, cliFS)
+	fs := ws.FS()
+	renameErr := metamodel.RenameEntityType(projectCtx.MetamodelPath, info.resolvedOld, info.newType, fs)
 	if renameErr != nil {
 		return fmt.Errorf("failed to update metamodel: %w", renameErr)
 	}
 
-	if _, err := cliFS.Stat(info.oldDir); err == nil {
-		if renameErr := cliFS.Rename(info.oldDir, info.newDir); renameErr != nil {
+	if _, err := fs.Stat(info.oldDir); err == nil {
+		if renameErr := fs.Rename(info.oldDir, info.newDir); renameErr != nil {
 			return fmt.Errorf("failed to rename directory: %w", renameErr)
 		}
 	}
 
-	if _, err := cliFS.Stat(info.newDir); err == nil {
-		count, updateErr := markdown.NewFileIO(cliFS).UpdateEntityTypesInDir(info.newDir, info.newType, meta)
+	if _, err := fs.Stat(info.newDir); err == nil {
+		count, updateErr := markdown.NewFileIO(fs).UpdateEntityTypesInDir(info.newDir, info.newType, meta)
 		if updateErr != nil {
 			return fmt.Errorf("failed to update entity files: %w", updateErr)
 		}
@@ -188,14 +189,14 @@ func applyRenameEntity(info *renameEntityInfo) error {
 
 	if info.hasTemplate {
 		newTemplatePath := projectCtx.EntityTemplatePath(info.newType)
-		if mkdirErr := cliFS.MkdirAll(projectCtx.EntityTemplatesDir, 0755); mkdirErr != nil {
+		if mkdirErr := fs.MkdirAll(projectCtx.EntityTemplatesDir, 0755); mkdirErr != nil {
 			out.WriteWarning("Failed to create templates directory: %v", mkdirErr)
-		} else if renameErr := cliFS.Rename(info.oldTemplatePath, newTemplatePath); renameErr != nil {
+		} else if renameErr := fs.Rename(info.oldTemplatePath, newTemplatePath); renameErr != nil {
 			out.WriteWarning("Failed to rename template: %v", renameErr)
 		}
 	}
 
-	if err := cliFS.Remove(projectCtx.CachePath); err != nil && !os.IsNotExist(err) {
+	if err := fs.Remove(projectCtx.CachePath); err != nil && !os.IsNotExist(err) {
 		out.WriteWarning("Failed to remove cache: %v", err)
 	}
 

--- a/internal/cli/rename_test.go
+++ b/internal/cli/rename_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/output"
 	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 func setupRenameTestEnv(t *testing.T) string {
@@ -20,14 +23,15 @@ func setupRenameTestEnv(t *testing.T) string {
 	g = graph.New()
 	out = output.New(output.FormatTable)
 	projectCtx = &project.Context{
-		Root:               dir,
-		EntitiesDir:        filepath.Join(dir, "entities"),
-		RelationsDir:       filepath.Join(dir, "relations"),
-		CacheDir:           filepath.Join(dir, ".rela"),
-		CachePath:          filepath.Join(dir, ".rela", "cache.json"),
-		MetamodelPath:      filepath.Join(dir, "metamodel.yaml"),
-		TemplatesDir:       filepath.Join(dir, "templates"),
-		EntityTemplatesDir: filepath.Join(dir, "templates", "entities"),
+		Root:                 dir,
+		EntitiesDir:          filepath.Join(dir, "entities"),
+		RelationsDir:         filepath.Join(dir, "relations"),
+		CacheDir:             filepath.Join(dir, ".rela"),
+		CachePath:            filepath.Join(dir, ".rela", "cache.json"),
+		MetamodelPath:        filepath.Join(dir, "metamodel.yaml"),
+		TemplatesDir:         filepath.Join(dir, "templates"),
+		EntityTemplatesDir:   filepath.Join(dir, "templates", "entities"),
+		RelationTemplatesDir: filepath.Join(dir, "templates", "relations"),
 	}
 
 	// Create directories
@@ -68,6 +72,11 @@ relations:
 	if err != nil {
 		t.Fatalf("failed to parse metamodel: %v", err)
 	}
+
+	// Set up workspace for FS access
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	repo := repository.New(fs, projectCtx)
+	ws = workspace.NewWithGraph(repo, meta, g)
 
 	return dir
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/output"
 	"github.com/Sourcehaven-BV/rela/internal/project"
-	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
@@ -30,9 +29,6 @@ var (
 	meta       *metamodel.Metamodel
 	g          *graph.Graph
 	out        *output.Writer
-
-	// Filesystem abstraction for commands that don't use workspace
-	cliFS storage.FS = storage.NewSafeFS(storage.NewOsFS())
 )
 
 // rootCmd represents the base command

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -136,7 +137,7 @@ func getUpdateBodyContent(cmd *cobra.Command) (string, error) {
 		if updateBodyFile == "-" {
 			content, err = io.ReadAll(cmd.InOrStdin())
 		} else {
-			content, err = cliFS.ReadFile(updateBodyFile)
+			content, err = os.ReadFile(updateBodyFile)
 		}
 
 		if err != nil {

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -3,15 +3,11 @@ package cli
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
-	"github.com/Sourcehaven-BV/rela/internal/metamodel"
-	"github.com/Sourcehaven-BV/rela/internal/project"
-	"github.com/Sourcehaven-BV/rela/internal/repository"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 var validateCmd = &cobra.Command{
@@ -35,45 +31,37 @@ Examples:
 			startDir = os.Getenv("RELA_PROJECT")
 		}
 
-		// Discover project (we need the paths)
-		ctx, err := project.Discover(startDir, cliFS)
+		result, err := workspace.Validate(startDir)
 		if err != nil {
-			return fmt.Errorf("no project found: run 'rela init' to create one")
+			return err
 		}
 
 		hasErrors := false
 
-		// Initialize repository
-		repoInstance := repository.New(cliFS, ctx)
-
-		// 1. Validate metamodel
+		// Report metamodel validation
 		fmt.Println("Validating metamodel.yaml...")
-		mm, err := repoInstance.LoadMetamodel()
-		if err != nil {
-			fmt.Printf("  ✗ %v\n", err)
+		if result.MetamodelError != nil {
+			fmt.Printf("  ✗ %v\n", result.MetamodelError)
 			hasErrors = true
-			mm = nil
 		} else {
 			fmt.Println("  ✓ metamodel.yaml is valid")
 		}
 
-		// 2. Validate data-entry.yaml if it exists
-		dataEntryPath := filepath.Join(ctx.Root, dataentryconfig.ConfigFile)
-		if _, statErr := cliFS.Stat(dataEntryPath); statErr == nil {
-			fmt.Printf("Validating %s...\n", dataentryconfig.ConfigFile)
-
-			if mm == nil {
+		// Report data-entry validation
+		if result.DataEntrySkipped {
+			if result.MetamodelError != nil {
 				fmt.Println("  ⚠ Skipping data-entry validation (metamodel has errors)")
 			} else {
-				if err := validateDataEntryConfig(dataEntryPath, mm); err != nil {
-					fmt.Printf("  ✗ %v\n", err)
-					hasErrors = true
-				} else {
-					fmt.Printf("  ✓ %s is valid\n", dataentryconfig.ConfigFile)
-				}
+				fmt.Printf("Skipping %s (file not found)\n", dataentryconfig.ConfigFile)
 			}
 		} else {
-			fmt.Printf("Skipping %s (file not found)\n", dataentryconfig.ConfigFile)
+			fmt.Printf("Validating %s...\n", dataentryconfig.ConfigFile)
+			if result.DataEntryError != nil {
+				fmt.Printf("  ✗ %v\n", result.DataEntryError)
+				hasErrors = true
+			} else {
+				fmt.Printf("  ✓ %s is valid\n", dataentryconfig.ConfigFile)
+			}
 		}
 
 		if hasErrors {
@@ -84,21 +72,6 @@ Examples:
 		fmt.Println("\nAll configuration files are valid.")
 		return nil
 	},
-}
-
-// validateDataEntryConfig validates the data-entry.yaml file.
-func validateDataEntryConfig(path string, mm *metamodel.Metamodel) error {
-	data, err := cliFS.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("reading file: %w", err)
-	}
-
-	var cfg dataentryconfig.Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return fmt.Errorf("parsing YAML: %w", err)
-	}
-
-	return dataentryconfig.ValidateConfig(data, &cfg, mm)
 }
 
 func init() {

--- a/internal/cli/view.go
+++ b/internal/cli/view.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -26,8 +25,7 @@ Examples:
 		entryID := args[1]
 
 		// Load views file
-		viewsPath := filepath.Join(projectCtx.Root, "views.yaml")
-		viewsFile, err := views.Load(viewsPath, cliFS)
+		viewsFile, err := ws.LoadViews()
 		if err != nil {
 			return fmt.Errorf("failed to load views file: %w", err)
 		}

--- a/internal/cli/view_affected.go
+++ b/internal/cli/view_affected.go
@@ -43,8 +43,7 @@ Examples:
 		viewName := args[0]
 
 		// Load views file
-		viewsPath := filepath.Join(projectCtx.Root, "views.yaml")
-		viewsFile, err := views.Load(viewsPath, cliFS)
+		viewsFile, err := ws.LoadViews()
 		if err != nil {
 			return fmt.Errorf("failed to load views file: %w", err)
 		}
@@ -166,7 +165,7 @@ func resolveChangedFiles() ([]string, error) {
 		}
 
 		resolved := false
-		candidates := []string{path, filepath.Join(projectCtx.Root, path)}
+		candidates := []string{path, filepath.Join(ws.Paths().Root, path)}
 		for _, candidate := range candidates {
 			if id, ok := pathToEntityID[candidate]; ok {
 				ids = append(ids, id)

--- a/internal/cli/view_deps.go
+++ b/internal/cli/view_deps.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -36,8 +35,7 @@ Examples:
 		viewName := args[0]
 
 		// Load views file
-		viewsPath := filepath.Join(projectCtx.Root, "views.yaml")
-		viewsFile, err := views.Load(viewsPath, cliFS)
+		viewsFile, err := ws.LoadViews()
 		if err != nil {
 			return fmt.Errorf("failed to load views file: %w", err)
 		}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -386,6 +386,26 @@ func truncate(s string, maxLen int) string {
 	return s[:maxLen-3] + "..."
 }
 
+// FormatSize formats a byte size as a human-readable string.
+func FormatSize(size int64) string {
+	const (
+		KB = 1024
+		MB = KB * 1024
+		GB = MB * 1024
+	)
+
+	switch {
+	case size >= GB:
+		return fmt.Sprintf("%.1fGB", float64(size)/GB)
+	case size >= MB:
+		return fmt.Sprintf("%.1fMB", float64(size)/MB)
+	case size >= KB:
+		return fmt.Sprintf("%.1fKB", float64(size)/KB)
+	default:
+		return fmt.Sprintf("%dB", size)
+	}
+}
+
 // WriteSectionHeader writes a styled section header with box drawing
 func (w *Writer) WriteSectionHeader(title string) {
 	if w.NoColor {

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -635,6 +635,29 @@ func TestColorizeStatus(t *testing.T) {
 	}
 }
 
+// TestFormatSize tests byte size formatting
+func TestFormatSize(t *testing.T) {
+	tests := []struct {
+		size int64
+		want string
+	}{
+		{0, "0B"},
+		{100, "100B"},
+		{1024, "1.0KB"},
+		{1536, "1.5KB"},
+		{1048576, "1.0MB"},
+		{1572864, "1.5MB"},
+		{1073741824, "1.0GB"},
+	}
+
+	for _, tt := range tests {
+		got := FormatSize(tt.size)
+		if got != tt.want {
+			t.Errorf("FormatSize(%d) = %q, want %q", tt.size, got, tt.want)
+		}
+	}
+}
+
 // TestTruncate tests string truncation
 func TestTruncate(t *testing.T) {
 	tests := []struct {

--- a/internal/workspace/attachment.go
+++ b/internal/workspace/attachment.go
@@ -1,0 +1,185 @@
+package workspace
+
+import (
+	"fmt"
+	"os/user"
+
+	"github.com/Sourcehaven-BV/rela/internal/attachment"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// AttachmentInfo contains information about an attachment on an entity.
+type AttachmentInfo struct {
+	Property     string
+	Path         string
+	OriginalName string
+	ContentType  string
+	Size         int64
+}
+
+// AttachResult contains the outcome of attaching a file.
+type AttachResult struct {
+	Path         string
+	OriginalName string
+	Deduplicated bool // true if file already existed in store
+}
+
+// AttachFile attaches a file to an entity's file property.
+// If property is empty, it uses the first file-type property defined for the entity type.
+// The file is stored in the content-addressable attachment store and the entity is updated.
+func (w *Workspace) AttachFile(entityID, filePath, property string) (*AttachResult, error) {
+	// Get entity from graph
+	entity, ok := w.graph.GetNode(entityID)
+	if !ok {
+		return nil, fmt.Errorf("entity not found: %s", entityID)
+	}
+
+	meta := w.Meta()
+
+	// Get entity definition
+	entityDef, ok := meta.GetEntityDef(entity.Type)
+	if !ok {
+		return nil, fmt.Errorf("unknown entity type: %s", entity.Type)
+	}
+
+	// Determine which property to use
+	propName := property
+	if propName == "" {
+		propName = findFileProperty(entityDef)
+		if propName == "" {
+			return nil, fmt.Errorf("no file property defined for entity type %s; specify property explicitly", entity.Type)
+		}
+	}
+
+	// Validate property exists and is file type
+	propDef, ok := entityDef.Properties[propName]
+	if !ok {
+		return nil, fmt.Errorf("property %q not defined for entity type %s", propName, entity.Type)
+	}
+	if propDef.Type != metamodel.PropertyTypeFile {
+		return nil, fmt.Errorf("property %q is not a file type (is %s)", propName, propDef.Type)
+	}
+
+	// Get current user for metadata
+	addedBy := ""
+	if u, err := user.Current(); err == nil {
+		addedBy = u.Username
+	}
+
+	// Create attachment store and add file
+	store := attachment.NewStore(w.FS(), w.Paths().Root)
+	att, err := store.Add(filePath, addedBy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to store attachment: %w", err)
+	}
+
+	// Clone before mutation so we can diff old vs new
+	oldEntity := entity.Clone()
+
+	// Update entity property with the attachment path
+	entity.SetString(propName, att.Path)
+
+	// Write through workspace (validates, persists, updates graph+cache)
+	if _, err := w.UpdateEntity(entity, oldEntity); err != nil {
+		return nil, fmt.Errorf("failed to update entity: %w", err)
+	}
+
+	result := &AttachResult{
+		Path:         att.Path,
+		OriginalName: att.Metadata.OriginalName,
+		Deduplicated: false, // TODO: detect if file was deduplicated
+	}
+
+	return result, nil
+}
+
+// ListAttachments returns all attachments for an entity.
+func (w *Workspace) ListAttachments(entityID string) ([]AttachmentInfo, error) {
+	// Get entity from graph
+	entity, ok := w.graph.GetNode(entityID)
+	if !ok {
+		return nil, fmt.Errorf("entity not found: %s", entityID)
+	}
+
+	meta := w.Meta()
+
+	// Get entity definition
+	entityDef, ok := meta.GetEntityDef(entity.Type)
+	if !ok {
+		return nil, fmt.Errorf("unknown entity type: %s", entity.Type)
+	}
+
+	// Create attachment store for metadata lookup
+	store := attachment.NewStore(w.FS(), w.Paths().Root)
+
+	var infos []AttachmentInfo
+
+	// Iterate over all file-type properties
+	for propName, propDef := range entityDef.Properties {
+		if propDef.Type != metamodel.PropertyTypeFile {
+			continue
+		}
+
+		val, ok := entity.Properties[propName]
+		if !ok || val == nil {
+			continue
+		}
+
+		// Extract paths from property value
+		paths := extractPaths(val)
+
+		for _, path := range paths {
+			info := AttachmentInfo{
+				Property: propName,
+				Path:     path,
+			}
+
+			// Try to get metadata
+			if meta, err := store.GetMetadata(path); err == nil {
+				info.OriginalName = meta.OriginalName
+				info.ContentType = meta.ContentType
+				info.Size = meta.Size
+			}
+
+			infos = append(infos, info)
+		}
+	}
+
+	return infos, nil
+}
+
+// findFileProperty returns the first file-type property name for an entity definition.
+func findFileProperty(entityDef *metamodel.EntityDef) string {
+	for name, prop := range entityDef.Properties {
+		if prop.Type == metamodel.PropertyTypeFile {
+			return name
+		}
+	}
+	return ""
+}
+
+// extractPaths extracts attachment paths from a property value.
+func extractPaths(val interface{}) []string {
+	if val == nil {
+		return nil
+	}
+
+	switch v := val.(type) {
+	case string:
+		if v != "" {
+			return []string{v}
+		}
+	case []interface{}:
+		var paths []string
+		for _, item := range v {
+			if s, ok := item.(string); ok && s != "" {
+				paths = append(paths, s)
+			}
+		}
+		return paths
+	case []string:
+		return v
+	}
+
+	return nil
+}

--- a/internal/workspace/attachment.go
+++ b/internal/workspace/attachment.go
@@ -183,3 +183,57 @@ func extractPaths(val interface{}) []string {
 
 	return nil
 }
+
+// GCAttachmentsResult contains the outcome of garbage collecting attachments.
+type GCAttachmentsResult struct {
+	Removed   []string // Paths that were (or would be) removed
+	Reclaimed int64    // Bytes reclaimed (or that would be reclaimed)
+}
+
+// GCAttachments removes unreferenced attachment files from the store.
+// If dryRun is true, it returns what would be removed without actually removing.
+func (w *Workspace) GCAttachments(dryRun bool) (*GCAttachmentsResult, error) {
+	referencedPaths := w.collectReferencedAttachmentPaths()
+	store := attachment.NewStore(w.FS(), w.Paths().Root)
+
+	gcResult, err := store.GC(referencedPaths)
+	if err != nil {
+		return nil, fmt.Errorf("gc failed: %w", err)
+	}
+
+	result := &GCAttachmentsResult{
+		Removed:   gcResult.Removed,
+		Reclaimed: gcResult.Reclaimed,
+	}
+
+	if !dryRun && len(gcResult.Removed) > 0 {
+		if err := store.RemoveUnreferenced(gcResult); err != nil {
+			return nil, fmt.Errorf("failed to remove files: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+// collectReferencedAttachmentPaths returns all attachment paths referenced by entities.
+func (w *Workspace) collectReferencedAttachmentPaths() []string {
+	var paths []string
+	meta := w.Meta()
+
+	for _, entity := range w.graph.AllNodes() {
+		entityDef, ok := meta.GetEntityDef(entity.Type)
+		if !ok {
+			continue
+		}
+
+		for propName, propDef := range entityDef.Properties {
+			if propDef.Type != metamodel.PropertyTypeFile {
+				continue
+			}
+
+			paths = append(paths, extractPaths(entity.Properties[propName])...)
+		}
+	}
+
+	return paths
+}

--- a/internal/workspace/init.go
+++ b/internal/workspace/init.go
@@ -1,0 +1,102 @@
+package workspace
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// InitResult contains information about what was created during initialization.
+type InitResult struct {
+	Root            string
+	MetamodelPath   string
+	GitignoreUpdate bool
+}
+
+// Initialize creates a new rela project in the given directory.
+// If targetDir is empty, it uses the current working directory.
+// It creates the directory structure, writes a default metamodel, and
+// optionally updates .gitignore.
+func Initialize(targetDir string) (*InitResult, error) {
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	return InitializeWithFS(targetDir, fs)
+}
+
+// InitializeWithFS creates a new rela project using the provided filesystem.
+// This is useful for testing.
+func InitializeWithFS(targetDir string, fs storage.FS) (*InitResult, error) {
+	// Resolve target directory
+	if targetDir == "" {
+		cwd, err := fs.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("get working directory: %w", err)
+		}
+		targetDir = cwd
+	}
+
+	metamodelPath := filepath.Join(targetDir, project.MetamodelFile)
+
+	// Check if already initialized
+	if _, err := fs.Stat(metamodelPath); err == nil {
+		return nil, fmt.Errorf("project already initialized (metamodel.yaml exists)")
+	}
+
+	// Create project context with all paths
+	ctx := &project.Context{
+		Root:                 targetDir,
+		MetamodelPath:        metamodelPath,
+		CacheDir:             filepath.Join(targetDir, project.CacheDir),
+		CachePath:            filepath.Join(targetDir, project.CacheDir, project.CacheFile),
+		EntitiesDir:          filepath.Join(targetDir, project.EntitiesDir),
+		RelationsDir:         filepath.Join(targetDir, project.RelationsDir),
+		TemplatesDir:         filepath.Join(targetDir, project.TemplatesDir),
+		EntityTemplatesDir:   filepath.Join(targetDir, project.TemplatesDir, project.EntityTemplatesDir),
+		RelationTemplatesDir: filepath.Join(targetDir, project.TemplatesDir, project.RelationTemplatesDir),
+	}
+
+	// Create directories
+	if err := ctx.Initialize(fs); err != nil {
+		return nil, fmt.Errorf("create directories: %w", err)
+	}
+
+	// Write default metamodel
+	if err := fs.WriteFile(metamodelPath, []byte(metamodel.DefaultMetamodelYAML()), 0644); err != nil {
+		return nil, fmt.Errorf("write metamodel: %w", err)
+	}
+
+	result := &InitResult{
+		Root:          targetDir,
+		MetamodelPath: metamodelPath,
+	}
+
+	// Add .rela to .gitignore if it exists
+	gitignorePath := filepath.Join(targetDir, ".gitignore")
+	if _, err := fs.Stat(gitignorePath); err == nil {
+		content, err := fs.ReadFile(gitignorePath)
+		if err == nil && !strings.Contains(string(content), ".rela") {
+			content = append(content, []byte("\n# rela cache\n.rela/\n")...)
+			if writeErr := fs.WriteFile(gitignorePath, content, 0644); writeErr == nil {
+				result.GitignoreUpdate = true
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// NewAfterInit creates a workspace for a newly initialized project.
+// Use this after Initialize() when you need a workspace immediately.
+func NewAfterInit(targetDir string) (*Workspace, error) {
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	ctx, err := project.Discover(targetDir, fs)
+	if err != nil {
+		return nil, err
+	}
+	repo := repository.New(fs, ctx)
+	return New(repo)
+}

--- a/internal/workspace/migrate.go
+++ b/internal/workspace/migrate.go
@@ -1,0 +1,154 @@
+package workspace
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/migration"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// MigrateFile represents a file that can be migrated.
+type MigrateFile struct {
+	Path     string
+	Name     string
+	FileType migration.FileType
+}
+
+// MigrateDetection represents a detected migration for a file.
+type MigrateDetection struct {
+	File       MigrateFile
+	Migrations []migration.DetectionResult
+}
+
+// MigrateResult contains the outcome of applying migrations.
+type MigrateResult struct {
+	FilesUpdated    int
+	TotalMigrations int
+	FileResults     []MigrateFileResult
+}
+
+// MigrateFileResult contains the result for a single file.
+type MigrateFileResult struct {
+	File    MigrateFile
+	Results []migration.Result
+	Error   error
+}
+
+// DetectMigrations checks for pending migrations in project files.
+// If startDir is empty, it uses the current working directory.
+func DetectMigrations(startDir string) ([]MigrateDetection, error) {
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	return DetectMigrationsWithFS(startDir, fs)
+}
+
+// DetectMigrationsWithFS checks for pending migrations using the provided filesystem.
+func DetectMigrationsWithFS(startDir string, fs storage.FS) ([]MigrateDetection, error) {
+	ctx, err := project.Discover(startDir, fs)
+	if err != nil {
+		return nil, fmt.Errorf("no project found: run 'rela init' to create one")
+	}
+
+	// Load metamodel for context-aware migrations (ignore errors - may need migration itself)
+	mm, _ := metamodel.LoadWithoutMigrationCheck(ctx.MetamodelPath, fs)
+
+	files := getMigrateFiles(ctx)
+	var detections []MigrateDetection
+
+	for _, f := range files {
+		// Skip files that don't exist
+		if _, statErr := fs.Stat(f.Path); statErr != nil {
+			continue
+		}
+
+		detected, err := migration.DetectWithMetamodel(f.Path, f.FileType, fs, mm)
+		if err != nil {
+			return nil, fmt.Errorf("checking %s: %w", f.Name, err)
+		}
+
+		if len(detected) > 0 {
+			detections = append(detections, MigrateDetection{
+				File:       f,
+				Migrations: detected,
+			})
+		}
+	}
+
+	return detections, nil
+}
+
+// Migrate applies pending migrations to project files.
+// If startDir is empty, it uses the current working directory.
+func Migrate(startDir string) (*MigrateResult, error) {
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	return MigrateWithFS(startDir, fs)
+}
+
+// MigrateWithFS applies migrations using the provided filesystem.
+func MigrateWithFS(startDir string, fs storage.FS) (*MigrateResult, error) {
+	ctx, err := project.Discover(startDir, fs)
+	if err != nil {
+		return nil, fmt.Errorf("no project found: run 'rela init' to create one")
+	}
+
+	// Load metamodel for context-aware migrations (ignore errors - may need migration itself)
+	mm, _ := metamodel.LoadWithoutMigrationCheck(ctx.MetamodelPath, fs)
+
+	files := getMigrateFiles(ctx)
+	result := &MigrateResult{}
+
+	for _, f := range files {
+		// Skip files that don't exist
+		if _, statErr := fs.Stat(f.Path); statErr != nil {
+			continue
+		}
+
+		fileResult, err := migration.ApplyWithMetamodel(f.Path, f.FileType, fs, mm)
+		if err != nil {
+			return result, fmt.Errorf("migrating %s: %w", f.Name, err)
+		}
+
+		if fileResult.HasErrors() {
+			return result, fmt.Errorf("migrating %s: %w", f.Name, fileResult.Error)
+		}
+
+		migrationCount := 0
+		var migrationResults []migration.Result
+		for _, mr := range fileResult.Results {
+			if mr.Applied {
+				migrationCount++
+			}
+			migrationResults = append(migrationResults, mr)
+		}
+
+		if migrationCount > 0 {
+			result.FilesUpdated++
+			result.TotalMigrations += migrationCount
+		}
+
+		result.FileResults = append(result.FileResults, MigrateFileResult{
+			File:    f,
+			Results: migrationResults,
+		})
+	}
+
+	return result, nil
+}
+
+func getMigrateFiles(ctx *project.Context) []MigrateFile {
+	return []MigrateFile{
+		{
+			Path:     ctx.MetamodelPath,
+			Name:     "metamodel.yaml",
+			FileType: migration.FileTypeMetamodel,
+		},
+		{
+			Path:     filepath.Join(ctx.Root, dataentryconfig.ConfigFile),
+			Name:     dataentryconfig.ConfigFile,
+			FileType: migration.FileTypeDataEntry,
+		},
+	}
+}

--- a/internal/workspace/validate.go
+++ b/internal/workspace/validate.go
@@ -1,0 +1,102 @@
+package workspace
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// ValidateResult contains the outcome of validating project configuration.
+type ValidateResult struct {
+	MetamodelValid   bool
+	MetamodelError   error
+	Metamodel        *metamodel.Metamodel // nil if validation failed
+	DataEntryValid   bool
+	DataEntryError   error
+	DataEntrySkipped bool // true if file doesn't exist
+}
+
+// HasErrors returns true if any validation failed.
+func (r *ValidateResult) HasErrors() bool {
+	return r.MetamodelError != nil || r.DataEntryError != nil
+}
+
+// Validate validates project configuration files (metamodel.yaml, data-entry.yaml)
+// without loading the full graph. Use this for the `rela validate` command.
+// If startDir is empty, it uses the current working directory.
+func Validate(startDir string) (*ValidateResult, error) {
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	return ValidateWithFS(startDir, fs)
+}
+
+// ValidateWithFS validates using the provided filesystem.
+func ValidateWithFS(startDir string, fs storage.FS) (*ValidateResult, error) {
+	// Discover project
+	ctx, err := project.Discover(startDir, fs)
+	if err != nil {
+		return nil, fmt.Errorf("no project found: run 'rela init' to create one")
+	}
+
+	result := &ValidateResult{}
+
+	// Validate metamodel
+	mm, err := metamodel.Load(ctx.MetamodelPath, fs)
+	if err != nil {
+		result.MetamodelError = err
+	} else {
+		result.MetamodelValid = true
+		result.Metamodel = mm
+	}
+
+	// Validate data-entry.yaml if it exists
+	dataEntryPath := filepath.Join(ctx.Root, dataentryconfig.ConfigFile)
+	result.DataEntryError = validateDataEntry(dataEntryPath, mm, fs)
+	if result.DataEntryError == nil {
+		if _, statErr := fs.Stat(dataEntryPath); statErr != nil || mm == nil {
+			result.DataEntrySkipped = true
+		} else {
+			result.DataEntryValid = true
+		}
+	}
+
+	return result, nil
+}
+
+// validateDataEntry validates the data-entry.yaml file.
+// Returns nil if file doesn't exist or metamodel is nil (validation skipped).
+func validateDataEntry(path string, mm *metamodel.Metamodel, fs storage.FS) error {
+	if mm == nil {
+		return nil // Can't validate without metamodel
+	}
+
+	exists, _ := fileExists(path, fs)
+	if !exists {
+		return nil
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	var cfg dataentryconfig.Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parsing YAML: %w", err)
+	}
+
+	return dataentryconfig.ValidateConfig(data, &cfg, mm)
+}
+
+func fileExists(path string, fs storage.FS) (bool, error) {
+	_, err := fs.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	return false, err
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/rename"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/views"
 )
 
 // ChangeEvent is re-exported from repository so consumers don't need to
@@ -648,3 +649,18 @@ func (w *Workspace) ResumeWatching() {
 // should hold this lock for the duration of the request.
 func (w *Workspace) RLock()   { w.mu.RLock() }
 func (w *Workspace) RUnlock() { w.mu.RUnlock() }
+
+// --- Views ---
+
+// LoadViews loads and parses the views.yaml file from the project root.
+func (w *Workspace) LoadViews() (*views.File, error) {
+	return w.repo.LoadViews()
+}
+
+// --- Filesystem access ---
+
+// FS returns the underlying filesystem for operations that need direct
+// file access (e.g., attachment store, writing output files).
+func (w *Workspace) FS() storage.FS {
+	return w.repo.FS()
+}

--- a/tickets/entities/tickets/TKT-031.md
+++ b/tickets/entities/tickets/TKT-031.md
@@ -1,0 +1,37 @@
+---
+effort: m
+id: TKT-031
+kind: refactor
+priority: medium
+status: done
+title: Remove CLI storage/repository dependencies
+type: ticket
+---
+
+## Summary
+
+Remove direct `storage` and `repository` imports from the CLI package by routing all
+operations through the workspace façade.
+
+## Changes
+
+1. **New workspace functions** for project lifecycle:
+   - `workspace.Initialize()` - project creation
+   - `workspace.Validate()` - config validation without full sync
+   - `workspace.DetectMigrations()` / `workspace.Migrate()` - schema migrations
+
+2. **New workspace methods**:
+   - `LoadViews()` - load views.yaml through repository
+   - `FS()` - expose filesystem for attachment operations
+
+3. **CLI updates**:
+   - `init.go` uses `workspace.Initialize()`
+   - `validate.go` uses `workspace.Validate()`
+   - `migrate.go` uses `workspace.Migrate()`
+   - `view*.go` uses `ws.LoadViews()`
+   - `attach*.go`, `gc.go` uses `ws.FS()` for attachment store
+   - `rename.go` uses `ws.FS()` for file operations
+
+4. **Arch-lint config**:
+   - Removed `repository`, `storage` from CLI's `mayDependOn`
+   - Added `dataentryconfig`, `views` to workspace's `mayDependOn`

--- a/tickets/relations/TKT-031--affects--workspace.md
+++ b/tickets/relations/TKT-031--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-031
+relation: affects
+to: workspace
+---

--- a/tickets/relations/TKT-031--implements--FEAT-022.md
+++ b/tickets/relations/TKT-031--implements--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: TKT-031
+relation: implements
+to: FEAT-022
+---


### PR DESCRIPTION
## Summary
- Move project lifecycle operations (init, validate, migrate) to workspace package
- Add `LoadViews()` and `FS()` methods to workspace
- Update CLI commands to use workspace methods instead of direct storage/repository access
- Remove `repository` and `storage` from CLI's arch-lint dependencies

## Test plan
- [x] All tests pass
- [x] Arch-lint passes
- [x] Build succeeds