### PR TITLE
Remove CLI dependency on graph package (#TKT-031)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -113,7 +113,6 @@ deps:
     mayDependOn:
       - dataentryconfig
       - filter
-      - graph
       - importer
       - markdown
       - mcp

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -55,7 +55,7 @@ var analyzeOrphansCmd = &cobra.Command{
 	Use:   "orphans",
 	Short: "Find entities with no connections",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		orphans := g.FindOrphans()
+		orphans := ws.FindOrphans()
 		filter.SortByID(orphans, false)
 
 		if writeAnalysisJSON(len(orphans), orphans,
@@ -76,7 +76,7 @@ var analyzeDuplicatesCmd = &cobra.Command{
 	Use:   "duplicates",
 	Short: "Find entities with similar titles",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		entities := g.AllNodes()
+		entities := ws.AllEntities()
 
 		// Group by normalized title
 		titleGroups := make(map[string][]*model.Entity)
@@ -154,7 +154,7 @@ since they use manually-specified IDs that are not expected to be sequential.`,
 		// Group IDs by prefix (only for sequential ID types)
 		prefixGroups := make(map[string][]int)
 
-		for _, id := range g.AllIDs() {
+		for _, id := range ws.EntityIDs() {
 			parsed, err := model.ParseEntityID(id)
 			if err != nil || parsed.Prefix == "" {
 				continue
@@ -235,10 +235,10 @@ var analyzeCardinalityCmd = &cobra.Command{
 			if relDef.MinOutgoing != nil && *relDef.MinOutgoing > 0 {
 				// For each entity type in From, check they have at least MinOutgoing outgoing relations of this type
 				for _, sourceType := range relDef.From {
-					entities := g.NodesByType(sourceType)
+					entities := ws.EntitiesByType(sourceType)
 					for _, e := range entities {
 						count := 0
-						for _, edge := range g.OutgoingEdges(e.ID) {
+						for _, edge := range ws.OutgoingRelations(e.ID) {
 							if edge.Type == relName {
 								count++
 							}
@@ -259,10 +259,10 @@ var analyzeCardinalityCmd = &cobra.Command{
 			// Check max_outgoing constraint
 			if relDef.MaxOutgoing != nil {
 				for _, sourceType := range relDef.From {
-					entities := g.NodesByType(sourceType)
+					entities := ws.EntitiesByType(sourceType)
 					for _, e := range entities {
 						count := 0
-						for _, edge := range g.OutgoingEdges(e.ID) {
+						for _, edge := range ws.OutgoingRelations(e.ID) {
 							if edge.Type == relName {
 								count++
 							}
@@ -284,10 +284,10 @@ var analyzeCardinalityCmd = &cobra.Command{
 			// For each entity type in To, check they have at least MinIncoming incoming relations of this type
 			if relDef.MinIncoming != nil && *relDef.MinIncoming > 0 {
 				for _, targetType := range relDef.To {
-					entities := g.NodesByType(targetType)
+					entities := ws.EntitiesByType(targetType)
 					for _, e := range entities {
 						count := 0
-						for _, edge := range g.IncomingEdges(e.ID) {
+						for _, edge := range ws.IncomingRelations(e.ID) {
 							if edge.Type == relName {
 								count++
 							}
@@ -313,10 +313,10 @@ var analyzeCardinalityCmd = &cobra.Command{
 			// Check max_incoming constraint
 			if relDef.MaxIncoming != nil {
 				for _, targetType := range relDef.To {
-					entities := g.NodesByType(targetType)
+					entities := ws.EntitiesByType(targetType)
 					for _, e := range entities {
 						count := 0
-						for _, edge := range g.IncomingEdges(e.ID) {
+						for _, edge := range ws.IncomingRelations(e.ID) {
 							if edge.Type == relName {
 								count++
 							}
@@ -386,7 +386,7 @@ This catches issues in manually-edited markdown files that bypass CLI validation
 
 // runPropertyValidation validates all entity properties against the metamodel
 func runPropertyValidation() error {
-	entities := g.AllNodes()
+	entities := ws.AllEntities()
 	errorCount := 0
 
 	// Group errors by entity for cleaner output
@@ -455,7 +455,7 @@ func runPropertyValidation() error {
 // countPropertyErrors counts property validation errors across all entities
 func countPropertyErrors() int {
 	count := 0
-	for _, entity := range g.AllNodes() {
+	for _, entity := range ws.AllEntities() {
 		count += len(meta.ValidateEntity(entity))
 	}
 	return count
@@ -623,9 +623,9 @@ func checkValidationRule(rule metamodel.ValidationRule) []*model.Entity {
 	// Get entities to check
 	var entities []*model.Entity
 	if rule.EntityType != "" {
-		entities = g.NodesByType(rule.EntityType)
+		entities = ws.EntitiesByType(rule.EntityType)
 	} else {
-		entities = g.AllNodes()
+		entities = ws.AllEntities()
 	}
 
 	for _, entity := range entities {
@@ -706,7 +706,7 @@ func countMinOutgoingViolations(relName string, relDef metamodel.RelationDef) in
 	}
 	violations := 0
 	for _, sourceType := range relDef.From {
-		for _, e := range g.NodesByType(sourceType) {
+		for _, e := range ws.EntitiesByType(sourceType) {
 			if countOutgoingByType(e.ID, relName) < *relDef.MinOutgoing {
 				violations++
 			}
@@ -722,7 +722,7 @@ func countMaxOutgoingViolations(relName string, relDef metamodel.RelationDef) in
 	}
 	violations := 0
 	for _, sourceType := range relDef.From {
-		for _, e := range g.NodesByType(sourceType) {
+		for _, e := range ws.EntitiesByType(sourceType) {
 			if countOutgoingByType(e.ID, relName) > *relDef.MaxOutgoing {
 				violations++
 			}
@@ -738,7 +738,7 @@ func countMinIncomingViolations(relName string, relDef metamodel.RelationDef) in
 	}
 	violations := 0
 	for _, targetType := range relDef.To {
-		for _, e := range g.NodesByType(targetType) {
+		for _, e := range ws.EntitiesByType(targetType) {
 			if countIncomingByType(e.ID, relName) < *relDef.MinIncoming {
 				violations++
 			}
@@ -754,7 +754,7 @@ func countMaxIncomingViolations(relName string, relDef metamodel.RelationDef) in
 	}
 	violations := 0
 	for _, targetType := range relDef.To {
-		for _, e := range g.NodesByType(targetType) {
+		for _, e := range ws.EntitiesByType(targetType) {
 			if countIncomingByType(e.ID, relName) > *relDef.MaxIncoming {
 				violations++
 			}
@@ -766,7 +766,7 @@ func countMaxIncomingViolations(relName string, relDef metamodel.RelationDef) in
 // countOutgoingByType counts outgoing edges of a specific relation type
 func countOutgoingByType(entityID, relName string) int {
 	count := 0
-	for _, edge := range g.OutgoingEdges(entityID) {
+	for _, edge := range ws.OutgoingRelations(entityID) {
 		if edge.Type == relName {
 			count++
 		}
@@ -777,7 +777,7 @@ func countOutgoingByType(entityID, relName string) int {
 // countIncomingByType counts incoming edges of a specific relation type
 func countIncomingByType(entityID, relName string) int {
 	count := 0
-	for _, edge := range g.IncomingEdges(entityID) {
+	for _, edge := range ws.IncomingRelations(entityID) {
 		if edge.Type == relName {
 			count++
 		}
@@ -790,13 +790,13 @@ var analyzeAllCmd = &cobra.Command{
 	Short: "Run all analyses",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Collect issue counts for summary
-		orphanCount := len(g.FindOrphans())
+		orphanCount := len(ws.FindOrphans())
 
 		// Count cardinality violations
 		cardinalityCount := countCardinalityViolations()
 
 		// Count duplicates
-		entities := g.AllNodes()
+		entities := ws.AllEntities()
 		titleGroups := make(map[string][]*model.Entity)
 		for _, e := range entities {
 			title := normalizeTitle(e.Title())
@@ -823,7 +823,7 @@ var analyzeAllCmd = &cobra.Command{
 			}
 		}
 		prefixGroups := make(map[string][]int)
-		for _, id := range g.AllIDs() {
+		for _, id := range ws.EntityIDs() {
 			parsed, err := model.ParseEntityID(id)
 			if err != nil || parsed.Prefix == "" {
 				continue

--- a/internal/cli/analyze_test.go
+++ b/internal/cli/analyze_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/output"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 func setupAnalyzeTestGraph() {
@@ -41,6 +42,7 @@ func setupAnalyzeTestGraph() {
 			},
 		},
 	}
+	ws = workspace.NewForTest(g, meta)
 	out = output.New(output.FormatTable)
 
 	// Add test entities
@@ -611,6 +613,7 @@ func TestCountPropertyErrors(t *testing.T) {
 						},
 					},
 				}
+				ws = workspace.NewForTest(g, meta)
 				out = output.New(output.FormatTable)
 
 				entity := model.NewEntity("REQ-001", "requirement")
@@ -626,6 +629,7 @@ func TestCountPropertyErrors(t *testing.T) {
 				meta = &metamodel.Metamodel{
 					Entities: map[string]metamodel.EntityDef{},
 				}
+				ws = workspace.NewForTest(g, meta)
 				out = output.New(output.FormatTable)
 			},
 			wantZero: true,
@@ -692,6 +696,7 @@ func TestAnalyzeJSONOutput(t *testing.T) {
 						"requirement": {Label: "Requirement", IDPrefix: "REQ-"},
 					},
 				}
+				ws = workspace.NewForTest(g, meta)
 				orphan := model.NewEntity("REQ-003", "requirement")
 				orphan.Properties["title"] = "Orphan Requirement"
 				g.AddNode(orphan)
@@ -716,6 +721,7 @@ func TestAnalyzeJSONOutput(t *testing.T) {
 						"requirement": {Label: "Requirement", IDPrefix: "REQ-"},
 					},
 				}
+				ws = workspace.NewForTest(g, meta)
 				e1 := model.NewEntity("REQ-001", "requirement")
 				e1.Properties["title"] = "Same Title"
 				g.AddNode(e1)
@@ -736,6 +742,7 @@ func TestAnalyzeJSONOutput(t *testing.T) {
 						"requirement": {Label: "Requirement", IDPrefix: "REQ-"},
 					},
 				}
+				ws = workspace.NewForTest(g, meta)
 				g.AddNode(model.NewEntity("REQ-001", "requirement"))
 				g.AddNode(model.NewEntity("REQ-003", "requirement"))
 			},
@@ -784,6 +791,7 @@ func TestAnalyzeJSONOutput(t *testing.T) {
 						},
 					},
 				}
+				ws = workspace.NewForTest(g, meta)
 				e := model.NewEntity("REQ-001", "requirement")
 				e.Properties["status"] = "accepted"
 				g.AddNode(e)

--- a/internal/cli/create_test.go
+++ b/internal/cli/create_test.go
@@ -13,10 +13,13 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/output"
 	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 func setupCreateTestEnv() {
 	g = graph.New()
+	meta = nil // Will be set by individual tests
+	ws = nil   // Will be set by individual tests after meta is set
 	out = output.New(output.FormatTable)
 	projectCtx = &project.Context{
 		Root:          "/tmp/test-project",
@@ -143,6 +146,7 @@ func TestCreateEntityWithPrimaryPropertyName(t *testing.T) {
 			},
 		},
 	}
+	ws = workspace.NewForTest(g, meta)
 
 	// Test that GetPrimaryProperty returns correct property for each type
 	stakeholderDef, _ := meta.GetEntityDef("stakeholder")
@@ -180,6 +184,7 @@ func TestCreateEntityWithMultipleProperties(t *testing.T) {
 			},
 		},
 	}
+	ws = workspace.NewForTest(g, meta)
 
 	// Test that GetPrimaryProperty returns "title" for control
 	controlDef, _ := meta.GetEntityDef("control")
@@ -204,6 +209,7 @@ func TestCreateEntityTypeWithLabelProperty(t *testing.T) {
 			},
 		},
 	}
+	ws = workspace.NewForTest(g, meta)
 
 	// Test that GetPrimaryProperty returns "label" for tag
 	tagDef, _ := meta.GetEntityDef("tag")
@@ -233,6 +239,7 @@ func TestCreateEntityNoPrimaryProperty(t *testing.T) {
 			},
 		},
 	}
+	ws = workspace.NewForTest(g, meta)
 
 	// Test that GetPrimaryProperty returns empty string
 	markerDef, _ := meta.GetEntityDef("marker")

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -30,14 +30,14 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		entityID := args[0]
 
-		entity, ok := g.GetNode(entityID)
+		entity, ok := ws.GetEntity(entityID)
 		if !ok {
 			return &entityNotFoundError{ID: entityID}
 		}
 
 		// Check for relations
-		incoming := g.IncomingEdges(entityID)
-		outgoing := g.OutgoingEdges(entityID)
+		incoming := ws.IncomingRelations(entityID)
+		outgoing := ws.OutgoingRelations(entityID)
 		totalRelations := len(incoming) + len(outgoing)
 
 		if totalRelations > 0 && !deleteCascade {

--- a/internal/cli/detach.go
+++ b/internal/cli/detach.go
@@ -34,8 +34,8 @@ Examples:
 			hashPrefix = args[2]
 		}
 
-		// Get entity from graph
-		entity, ok := g.GetNode(entityID)
+		// Get entity
+		entity, ok := ws.GetEntity(entityID)
 		if !ok {
 			return fmt.Errorf("entity not found: %s", entityID)
 		}

--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -108,7 +108,7 @@ Examples:
 }
 
 func exportEntities(entityType string) error {
-	entities := g.NodesByType(entityType)
+	entities := ws.EntitiesByType(entityType)
 
 	// Sort by ID for consistent output
 	sort.Slice(entities, func(i, j int) bool {
@@ -142,8 +142,8 @@ func exportEntities(entityType string) error {
 }
 
 func exportAllData() error {
-	allEntities := g.AllNodes()
-	allEdges := g.AllEdges()
+	allEntities := ws.AllEntities()
+	allEdges := ws.AllRelations()
 
 	// Sort entities by type, then ID
 	sort.Slice(allEntities, func(i, j int) bool {
@@ -215,8 +215,8 @@ func entityToExport(e *model.Entity) ExportEntity {
 }
 
 func getEntityRelations(entityID string) *ExportRelations {
-	outgoing := g.OutgoingEdges(entityID)
-	incoming := g.IncomingEdges(entityID)
+	outgoing := ws.OutgoingRelations(entityID)
+	incoming := ws.IncomingRelations(entityID)
 
 	if len(outgoing) == 0 && len(incoming) == 0 {
 		return nil
@@ -229,7 +229,7 @@ func getEntityRelations(entityID string) *ExportRelations {
 
 	for _, rel := range outgoing {
 		target := RelationTarget{ID: rel.To}
-		if node, ok := g.GetNode(rel.To); ok {
+		if node, ok := ws.GetEntity(rel.To); ok {
 			target.Title = node.Title()
 		}
 		relations.Outgoing[rel.Type] = append(relations.Outgoing[rel.Type], target)
@@ -237,7 +237,7 @@ func getEntityRelations(entityID string) *ExportRelations {
 
 	for _, rel := range incoming {
 		source := RelationTarget{ID: rel.From}
-		if node, ok := g.GetNode(rel.From); ok {
+		if node, ok := ws.GetEntity(rel.From); ok {
 			source.Title = node.Title()
 		}
 		relations.Incoming[rel.Type] = append(relations.Incoming[rel.Type], source)

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/output"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 func setupTestGraph() {
@@ -44,6 +45,7 @@ func setupTestGraph() {
 			},
 		},
 	}
+	ws = workspace.NewForTest(g, meta)
 	out = output.New(output.FormatTable)
 
 	// Add test entities

--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -30,8 +30,8 @@ Examples:
   rela graph --types requirement,decision`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get entities and edges
-		entities := g.AllNodes()
-		edges := g.AllEdges()
+		entities := ws.AllEntities()
+		edges := ws.AllRelations()
 
 		// Filter by types if specified
 		if len(graphTypes) > 0 {

--- a/internal/cli/graph_test.go
+++ b/internal/cli/graph_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/output"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 func setupGraphTestGraph() {
@@ -33,6 +34,7 @@ func setupGraphTestGraph() {
 			},
 		},
 	}
+	ws = workspace.NewForTest(g, meta)
 	out = output.New(output.FormatTable)
 
 	// Add test entities
@@ -181,6 +183,7 @@ func TestGenerateDOT_EmptyGraph(t *testing.T) {
 	meta = &metamodel.Metamodel{
 		Entities: map[string]metamodel.EntityDef{},
 	}
+	ws = workspace.NewForTest(g, meta)
 
 	entities := g.AllNodes()
 	edges := g.AllEdges()
@@ -206,6 +209,7 @@ func TestGenerateDOT_EntityWithoutTitle(t *testing.T) {
 			},
 		},
 	}
+	ws = workspace.NewForTest(g, meta)
 
 	// Add entity without title
 	entity := model.NewEntity("CMP-001", "component")

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -79,7 +79,7 @@ CSV format (relations):
 			RelationsFile: importRelationsFile,
 		}
 
-		imp := importer.New(ws.Repo(), meta, g, opts, importer.NewImportSource(ws.FS()))
+		imp := importer.New(ws.Repo(), meta, ws.Graph(), opts, importer.NewImportSource(ws.FS()))
 
 		if importDryRun {
 			out.WriteInfo("Dry run - validating without creating files...")

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -55,10 +55,10 @@ Examples:
 			}
 
 			entityTypeName = resolvedType
-			entities = g.NodesByType(resolvedType)
+			entities = ws.EntitiesByType(resolvedType)
 		} else {
 			// All entities
-			entities = g.AllNodes()
+			entities = ws.AllEntities()
 		}
 
 		// Parse and apply filters

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -16,6 +16,8 @@ import (
 
 func setupListTestEnv() {
 	g = graph.New()
+	meta = nil // Will be set by individual tests
+	ws = nil   // Will be set by individual tests after meta is set
 	out = output.New(output.FormatTable)
 	projectCtx = &project.Context{
 		Root:          "/tmp/test-project",
@@ -170,6 +172,7 @@ types:
 	if err != nil {
 		t.Fatalf("failed to parse metamodel: %v", err)
 	}
+	ws = workspace.NewForTest(g, meta)
 
 	// Add some test entities to the graph
 	g.AddNode(&model.Entity{
@@ -311,6 +314,7 @@ func TestListAllEntities(t *testing.T) {
 	setupListTestEnv()
 
 	meta = metamodel.DefaultMetamodel()
+	ws = workspace.NewForTest(g, meta)
 
 	// Add entities of different types
 	req := model.NewEntity("REQ-001", "requirement")
@@ -331,6 +335,7 @@ func TestListAllEntities(t *testing.T) {
 func TestListEmptyGraph(t *testing.T) {
 	setupListTestEnv()
 	meta = metamodel.DefaultMetamodel()
+	ws = workspace.NewForTest(g, meta)
 
 	// Empty graph
 	entities := g.AllNodes()
@@ -342,6 +347,7 @@ func TestListEmptyGraph(t *testing.T) {
 func TestListByType(t *testing.T) {
 	setupListTestEnv()
 	meta = metamodel.DefaultMetamodel()
+	ws = workspace.NewForTest(g, meta)
 
 	// Add entities
 	req1 := model.NewEntity("REQ-001", "requirement")
@@ -373,6 +379,7 @@ func TestListByType(t *testing.T) {
 func TestListCommandWithUnknownType(t *testing.T) {
 	setupListTestEnv()
 	meta = metamodel.DefaultMetamodel()
+	ws = workspace.NewForTest(g, meta)
 
 	_, _, err := resolveEntityType("nonexistent")
 	if err == nil {

--- a/internal/cli/normalize.go
+++ b/internal/cli/normalize.go
@@ -46,9 +46,9 @@ Examples:
 			if err != nil {
 				return err
 			}
-			entities = g.NodesByType(resolvedType)
+			entities = ws.EntitiesByType(resolvedType)
 		} else {
-			entities = g.AllNodes()
+			entities = ws.AllEntities()
 		}
 
 		if len(entities) == 0 {

--- a/internal/cli/rename.go
+++ b/internal/cli/rename.go
@@ -116,7 +116,7 @@ func resolveRenameEntity(oldType, newType string) (*renameEntityInfo, error) {
 		newPlural:       newPlural,
 		oldDir:          projectCtx.EntityTypeDirWithPlural(oldPlural),
 		newDir:          projectCtx.EntityTypeDirWithPlural(newPlural),
-		entityCount:     len(g.NodesByType(resolvedOld)),
+		entityCount:     len(ws.EntitiesByType(resolvedOld)),
 		relCount:        countAffectedRelations(resolvedOld),
 		oldTemplatePath: oldTemplatePath,
 		hasTemplate:     statErr == nil,
@@ -245,7 +245,7 @@ Examples:
 
 func runRenameID(oldID, newID string) error {
 	// Get entity to find type
-	entity, ok := g.GetNode(oldID)
+	entity, ok := ws.GetEntity(oldID)
 	if !ok {
 		return fmt.Errorf("entity not found: %s", oldID)
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/output"
 	"github.com/Sourcehaven-BV/rela/internal/project"
@@ -27,7 +26,6 @@ var (
 	ws         *workspace.Workspace
 	projectCtx *project.Context // derived from ws.Paths()
 	meta       *metamodel.Metamodel
-	g          *graph.Graph
 	out        *output.Writer
 )
 
@@ -70,7 +68,6 @@ and maintain semantic relationships between them.`,
 		// Convenience aliases for read-only commands
 		projectCtx = ws.Paths()
 		meta = ws.Meta()
-		g = ws.Graph()
 
 		// Set up output writer
 		out = output.New(output.Format(outputFormat))

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -126,12 +126,12 @@ func runSchemaOverview() error {
 	// Entity types with counts
 	entityNames := getSortedEntityNames(meta)
 
-	// Get entity counts from graph if available
+	// Get entity counts from workspace if available
 	entityCounts := make(map[string]int)
 	maxCount := 0
-	if g != nil {
+	if ws != nil {
 		for _, name := range entityNames {
-			count := len(g.NodesByType(name))
+			count := len(ws.EntitiesByType(name))
 			entityCounts[name] = count
 			if count > maxCount {
 				maxCount = count

--- a/internal/cli/schema_test.go
+++ b/internal/cli/schema_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/output"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 // setupSchemaTest sets up the test environment with default metamodel
@@ -19,9 +20,11 @@ func setupSchemaTest(t *testing.T) (buf *bytes.Buffer, cleanup func()) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 
 	meta = metamodel.DefaultMetamodel()
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	buf = new(bytes.Buffer)
 	out = output.NewWithWriter(buf, output.FormatTable)
@@ -30,6 +33,7 @@ func setupSchemaTest(t *testing.T) (buf *bytes.Buffer, cleanup func()) {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}
 
 	return buf, cleanup
@@ -198,10 +202,12 @@ func TestSchemaEntityWithAlias(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}()
 
 	// Parse the default metamodel from YAML to properly build the alias map
@@ -211,6 +217,7 @@ func TestSchemaEntityWithAlias(t *testing.T) {
 		t.Fatalf("failed to parse metamodel: %v", err)
 	}
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatTable)
@@ -289,14 +296,17 @@ func TestSchemaOverviewJSON(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}()
 
 	meta = metamodel.DefaultMetamodel()
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatJSON)
@@ -331,14 +341,17 @@ func TestSchemaEntitiesJSON(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}()
 
 	meta = metamodel.DefaultMetamodel()
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatJSON)
@@ -367,14 +380,17 @@ func TestSchemaEntityJSON(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}()
 
 	meta = metamodel.DefaultMetamodel()
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatJSON)
@@ -406,14 +422,17 @@ func TestSchemaRelationJSON(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}()
 
 	meta = metamodel.DefaultMetamodel()
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatJSON)
@@ -445,10 +464,12 @@ func TestSchemaTypesEmpty(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}()
 
 	// Create metamodel with no custom types
@@ -458,6 +479,7 @@ func TestSchemaTypesEmpty(t *testing.T) {
 		Entities: map[string]metamodel.EntityDef{},
 	}
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatTable)
@@ -478,10 +500,12 @@ func TestSchemaEntitiesEmpty(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}()
 
 	// Create metamodel with no entities
@@ -492,6 +516,7 @@ func TestSchemaEntitiesEmpty(t *testing.T) {
 		Relations: map[string]metamodel.RelationDef{},
 	}
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatTable)
@@ -512,10 +537,12 @@ func TestSchemaRelationsEmpty(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}()
 
 	// Create metamodel with no relations
@@ -526,6 +553,7 @@ func TestSchemaRelationsEmpty(t *testing.T) {
 		Relations: map[string]metamodel.RelationDef{},
 	}
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatTable)
@@ -546,10 +574,12 @@ func TestSchemaWithCardinality(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}()
 
 	sourceMin := 1
@@ -574,6 +604,7 @@ func TestSchemaWithCardinality(t *testing.T) {
 		},
 	}
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatTable)
@@ -600,10 +631,12 @@ func TestSchemaWithSymmetricRelation(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}()
 
 	// Create metamodel with symmetric relation
@@ -623,6 +656,7 @@ func TestSchemaWithSymmetricRelation(t *testing.T) {
 		},
 	}
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatTable)
@@ -664,14 +698,17 @@ func TestSchemaGraphvizOutput(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}()
 
 	meta = metamodel.DefaultMetamodel()
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatTable)
@@ -716,11 +753,13 @@ func TestSchemaGraphvizWithConstraints(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	oldConstraints := schemaConstraints
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 		schemaConstraints = oldConstraints
 	}()
 
@@ -745,6 +784,7 @@ func TestSchemaGraphvizWithConstraints(t *testing.T) {
 		},
 	}
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatTable)
@@ -770,10 +810,12 @@ func TestSchemaGraphvizWithColors(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}()
 
 	meta = &metamodel.Metamodel{
@@ -790,6 +832,7 @@ func TestSchemaGraphvizWithColors(t *testing.T) {
 		Relations: map[string]metamodel.RelationDef{},
 	}
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatTable)
@@ -814,10 +857,12 @@ func TestSchemaGraphvizMultipleFromTo(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}()
 
 	meta = &metamodel.Metamodel{
@@ -837,6 +882,7 @@ func TestSchemaGraphvizMultipleFromTo(t *testing.T) {
 		},
 	}
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatTable)

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -16,13 +16,13 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		entityID := args[0]
 
-		entity, ok := g.GetNode(entityID)
+		entity, ok := ws.GetEntity(entityID)
 		if !ok {
 			return &entityNotFoundError{ID: entityID}
 		}
 
-		incoming := g.IncomingEdges(entityID)
-		outgoing := g.OutgoingEdges(entityID)
+		incoming := ws.IncomingRelations(entityID)
+		outgoing := ws.OutgoingRelations(entityID)
 
 		return out.WriteEntity(entity, incoming, outgoing)
 	},

--- a/internal/cli/show_test.go
+++ b/internal/cli/show_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/output"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 // setupShowTest sets up the test environment for show command tests
@@ -20,9 +21,11 @@ func setupShowTest(t *testing.T) (buf *bytes.Buffer, cleanup func()) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 
 	meta = metamodel.DefaultMetamodel()
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	buf = new(bytes.Buffer)
 	out = output.NewWithWriter(buf, output.FormatTable)
@@ -31,6 +34,7 @@ func setupShowTest(t *testing.T) (buf *bytes.Buffer, cleanup func()) {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}
 
 	return buf, cleanup
@@ -159,14 +163,17 @@ func TestShowEntityJSON(t *testing.T) {
 	oldMeta := meta
 	oldG := g
 	oldOut := out
+	oldWs := ws
 	defer func() {
 		meta = oldMeta
 		g = oldG
 		out = oldOut
+		ws = oldWs
 	}()
 
 	meta = metamodel.DefaultMetamodel()
 	g = graph.New()
+	ws = workspace.NewForTest(g, meta)
 
 	var buf bytes.Buffer
 	out = output.NewWithWriter(&buf, output.FormatJSON)

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -1,0 +1,6 @@
+package cli
+
+import "github.com/Sourcehaven-BV/rela/internal/graph"
+
+// Package-level variables for tests. Tests set these to control CLI behavior.
+var g *graph.Graph

--- a/internal/cli/trace.go
+++ b/internal/cli/trace.go
@@ -34,11 +34,11 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		entityID := args[0]
 
-		if _, ok := g.GetNode(entityID); !ok {
+		if _, ok := ws.GetEntity(entityID); !ok {
 			return &entityNotFoundError{ID: entityID}
 		}
 
-		result := g.TraceFrom(entityID, traceMaxDepth)
+		result := ws.TraceFrom(entityID, traceMaxDepth)
 		if result == nil {
 			out.WriteMessage("No downstream dependencies found")
 			return nil
@@ -61,11 +61,11 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		entityID := args[0]
 
-		if _, ok := g.GetNode(entityID); !ok {
+		if _, ok := ws.GetEntity(entityID); !ok {
 			return &entityNotFoundError{ID: entityID}
 		}
 
-		result := g.TraceTo(entityID, traceMaxDepth)
+		result := ws.TraceTo(entityID, traceMaxDepth)
 		if result == nil {
 			out.WriteMessage("No upstream dependencies found")
 			return nil
@@ -87,14 +87,14 @@ Examples:
 		fromID := args[0]
 		toID := args[1]
 
-		if _, ok := g.GetNode(fromID); !ok {
+		if _, ok := ws.GetEntity(fromID); !ok {
 			return fmt.Errorf("source entity not found: %s", fromID)
 		}
-		if _, ok := g.GetNode(toID); !ok {
+		if _, ok := ws.GetEntity(toID); !ok {
 			return fmt.Errorf("target entity not found: %s", toID)
 		}
 
-		path := g.FindPath(fromID, toID)
+		path := ws.FindPath(fromID, toID)
 		if path == nil {
 			out.WriteMessage("No path found between %s and %s", fromID, toID)
 			return nil

--- a/internal/cli/unlink.go
+++ b/internal/cli/unlink.go
@@ -21,7 +21,7 @@ Examples:
 		toID := args[2]
 
 		// Check if relation exists (for better error message)
-		if _, exists := g.GetEdge(fromID, relationType, toID); !exists {
+		if _, exists := ws.GetRelation(fromID, relationType, toID); !exists {
 			return fmt.Errorf("relation not found: %s --%s--> %s", fromID, relationType, toID)
 		}
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -42,7 +42,7 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		entityID := args[0]
 
-		entity, ok := g.GetNode(entityID)
+		entity, ok := ws.GetEntity(entityID)
 		if !ok {
 			return &entityNotFoundError{ID: entityID}
 		}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/output"
 	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 func setupUpdateTestEnv() {
@@ -52,6 +53,7 @@ func setupUpdateTestEnv() {
 			},
 		},
 	}
+	ws = workspace.NewForTest(g, meta)
 }
 
 func TestUpdateCmd_PropertyFlagExists(t *testing.T) {

--- a/internal/cli/view.go
+++ b/internal/cli/view.go
@@ -42,7 +42,7 @@ Examples:
 		}
 
 		// Create view engine
-		engine := views.NewEngine(g, meta)
+		engine := views.NewEngine(ws.Graph(), meta)
 
 		// Execute the view
 		result, err := engine.Execute(viewDef, entryID)
@@ -56,7 +56,7 @@ Examples:
 			format = "yaml" // Default to yaml for views
 		}
 
-		output, err := views.Format(result, format, g, meta)
+		output, err := views.Format(result, format, ws.Graph(), meta)
 		if err != nil {
 			return fmt.Errorf("failed to format output: %w", err)
 		}

--- a/internal/cli/view_affected.go
+++ b/internal/cli/view_affected.go
@@ -77,13 +77,13 @@ Examples:
 		if viewAffectedRoots != "" {
 			rootIDs = strings.Split(viewAffectedRoots, ",")
 		} else {
-			for _, entity := range g.NodesByType(viewDef.Entry.Type) {
+			for _, entity := range ws.EntitiesByType(viewDef.Entry.Type) {
 				rootIDs = append(rootIDs, entity.ID)
 			}
 		}
 
 		// Find affected roots
-		engine := views.NewEngine(g, meta)
+		engine := views.NewEngine(ws.Graph(), meta)
 		affected, err := engine.AffectedRoots(viewDef, changedIDs, rootIDs)
 		if err != nil {
 			return fmt.Errorf("failed to find affected roots: %w", err)
@@ -143,7 +143,7 @@ func resolveChangedFiles() ([]string, error) {
 
 	// Build reverse lookups from file path to entity/relation IDs
 	pathToEntityID := make(map[string]string)
-	for _, entity := range g.AllNodes() {
+	for _, entity := range ws.AllEntities() {
 		if entity.FilePath != "" {
 			pathToEntityID[entity.FilePath] = entity.ID
 		}
@@ -151,7 +151,7 @@ func resolveChangedFiles() ([]string, error) {
 
 	type relationEndpoints struct{ from, to string }
 	pathToRelation := make(map[string]relationEndpoints)
-	for _, rel := range g.AllEdges() {
+	for _, rel := range ws.AllRelations() {
 		if rel.FilePath != "" {
 			pathToRelation[rel.FilePath] = relationEndpoints{from: rel.From, to: rel.To}
 		}

--- a/internal/cli/view_deps.go
+++ b/internal/cli/view_deps.go
@@ -57,13 +57,13 @@ Examples:
 			rootIDs = strings.Split(viewDepsRoots, ",")
 		} else {
 			// Use all entities of the view's entry type
-			for _, entity := range g.NodesByType(viewDef.Entry.Type) {
+			for _, entity := range ws.EntitiesByType(viewDef.Entry.Type) {
 				rootIDs = append(rootIDs, entity.ID)
 			}
 		}
 
 		// Execute and collect deps
-		engine := views.NewEngine(g, meta)
+		engine := views.NewEngine(ws.Graph(), meta)
 		ids, err := engine.CollectDeps(viewDef, rootIDs)
 		if err != nil {
 			return fmt.Errorf("failed to collect dependencies: %w", err)
@@ -72,7 +72,7 @@ Examples:
 		// Output
 		for _, id := range ids {
 			if viewDepsFiles {
-				entity, ok := g.GetNode(id)
+				entity, ok := ws.GetEntity(id)
 				if !ok || entity.FilePath == "" {
 					fmt.Fprintf(os.Stderr, "warning: entity %s has no file path\n", id)
 					continue

--- a/internal/workspace/query.go
+++ b/internal/workspace/query.go
@@ -1,0 +1,83 @@
+package workspace
+
+import (
+	"github.com/Sourcehaven-BV/rela/internal/graph"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+// --- Entity queries ---
+
+// GetEntity returns an entity by ID.
+func (w *Workspace) GetEntity(id string) (*model.Entity, bool) {
+	return w.graph.GetNode(id)
+}
+
+// AllEntities returns all entities in the workspace.
+func (w *Workspace) AllEntities() []*model.Entity {
+	return w.graph.AllNodes()
+}
+
+// EntitiesByType returns all entities of the given type.
+func (w *Workspace) EntitiesByType(entityType string) []*model.Entity {
+	return w.graph.NodesByType(entityType)
+}
+
+// EntityCount returns the total number of entities.
+func (w *Workspace) EntityCount() int {
+	return w.graph.NodeCount()
+}
+
+// EntityIDs returns all entity IDs.
+func (w *Workspace) EntityIDs() []string {
+	return w.graph.AllIDs()
+}
+
+// --- Relation queries ---
+
+// GetRelation returns a relation by its endpoints and type.
+func (w *Workspace) GetRelation(from, relType, to string) (*model.Relation, bool) {
+	return w.graph.GetEdge(from, relType, to)
+}
+
+// AllRelations returns all relations in the workspace.
+func (w *Workspace) AllRelations() []*model.Relation {
+	return w.graph.AllEdges()
+}
+
+// IncomingRelations returns all relations pointing to the given entity.
+func (w *Workspace) IncomingRelations(entityID string) []*model.Relation {
+	return w.graph.IncomingEdges(entityID)
+}
+
+// OutgoingRelations returns all relations originating from the given entity.
+func (w *Workspace) OutgoingRelations(entityID string) []*model.Relation {
+	return w.graph.OutgoingEdges(entityID)
+}
+
+// --- Graph analysis ---
+
+// FindOrphans returns entities with no incoming or outgoing relations.
+func (w *Workspace) FindOrphans() []*model.Entity {
+	return w.graph.FindOrphans()
+}
+
+// TraceResult is re-exported from graph for consumers.
+type TraceResult = graph.TraceResult
+
+// TraceFrom traces all paths from the given entity (outgoing direction).
+func (w *Workspace) TraceFrom(entityID string, maxDepth int) *TraceResult {
+	return w.graph.TraceFrom(entityID, maxDepth)
+}
+
+// TraceTo traces all paths to the given entity (incoming direction).
+func (w *Workspace) TraceTo(entityID string, maxDepth int) *TraceResult {
+	return w.graph.TraceTo(entityID, maxDepth)
+}
+
+// PathStep is re-exported from graph for consumers.
+type PathStep = graph.PathStep
+
+// FindPath finds the shortest path between two entities.
+func (w *Workspace) FindPath(from, to string) []PathStep {
+	return w.graph.FindPath(from, to)
+}

--- a/internal/workspace/query_test.go
+++ b/internal/workspace/query_test.go
@@ -1,0 +1,151 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/graph"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+func TestEntityQueries(t *testing.T) {
+	g := graph.New()
+	ws := &Workspace{graph: g}
+
+	// Add test entities
+	req := model.NewEntity("REQ-001", "requirement")
+	req.Properties["title"] = "Test Requirement"
+	g.AddNode(req)
+
+	dec := model.NewEntity("DEC-001", "decision")
+	dec.Properties["title"] = "Test Decision"
+	g.AddNode(dec)
+
+	// Test GetEntity
+	entity, ok := ws.GetEntity("REQ-001")
+	if !ok {
+		t.Error("expected to find REQ-001")
+	}
+	if entity.Title() != "Test Requirement" {
+		t.Errorf("got title %q, want %q", entity.Title(), "Test Requirement")
+	}
+
+	// Test GetEntity not found
+	_, ok = ws.GetEntity("NONEXISTENT")
+	if ok {
+		t.Error("expected not to find NONEXISTENT")
+	}
+
+	// Test AllEntities
+	entities := ws.AllEntities()
+	if len(entities) != 2 {
+		t.Errorf("got %d entities, want 2", len(entities))
+	}
+
+	// Test EntitiesByType
+	reqs := ws.EntitiesByType("requirement")
+	if len(reqs) != 1 {
+		t.Errorf("got %d requirements, want 1", len(reqs))
+	}
+
+	// Test EntityCount
+	if ws.EntityCount() != 2 {
+		t.Errorf("got count %d, want 2", ws.EntityCount())
+	}
+
+	// Test EntityIDs
+	ids := ws.EntityIDs()
+	if len(ids) != 2 {
+		t.Errorf("got %d IDs, want 2", len(ids))
+	}
+}
+
+func TestRelationQueries(t *testing.T) {
+	g := graph.New()
+	ws := &Workspace{graph: g}
+
+	// Add entities
+	req := model.NewEntity("REQ-001", "requirement")
+	g.AddNode(req)
+	dec := model.NewEntity("DEC-001", "decision")
+	g.AddNode(dec)
+
+	// Add relation
+	rel := model.NewRelation("DEC-001", "implements", "REQ-001")
+	g.AddEdge(rel)
+
+	// Test GetRelation
+	found, ok := ws.GetRelation("DEC-001", "implements", "REQ-001")
+	if !ok {
+		t.Error("expected to find relation")
+	}
+	if found.From != "DEC-001" || found.To != "REQ-001" {
+		t.Error("relation endpoints don't match")
+	}
+
+	// Test GetRelation not found
+	_, ok = ws.GetRelation("REQ-001", "implements", "DEC-001")
+	if ok {
+		t.Error("expected not to find reverse relation")
+	}
+
+	// Test AllRelations
+	relations := ws.AllRelations()
+	if len(relations) != 1 {
+		t.Errorf("got %d relations, want 1", len(relations))
+	}
+
+	// Test IncomingRelations
+	incoming := ws.IncomingRelations("REQ-001")
+	if len(incoming) != 1 {
+		t.Errorf("got %d incoming, want 1", len(incoming))
+	}
+
+	// Test OutgoingRelations
+	outgoing := ws.OutgoingRelations("DEC-001")
+	if len(outgoing) != 1 {
+		t.Errorf("got %d outgoing, want 1", len(outgoing))
+	}
+}
+
+func TestGraphAnalysis(t *testing.T) {
+	g := graph.New()
+	ws := &Workspace{graph: g}
+
+	// Add entities
+	req := model.NewEntity("REQ-001", "requirement")
+	g.AddNode(req)
+	dec := model.NewEntity("DEC-001", "decision")
+	g.AddNode(dec)
+	orphan := model.NewEntity("ORPHAN-001", "requirement")
+	g.AddNode(orphan)
+
+	// Add relation between req and dec
+	g.AddEdge(model.NewRelation("DEC-001", "implements", "REQ-001"))
+
+	// Test FindOrphans
+	orphans := ws.FindOrphans()
+	if len(orphans) != 1 {
+		t.Errorf("got %d orphans, want 1", len(orphans))
+	}
+	if orphans[0].ID != "ORPHAN-001" {
+		t.Errorf("got orphan %q, want ORPHAN-001", orphans[0].ID)
+	}
+
+	// Test TraceFrom
+	trace := ws.TraceFrom("DEC-001", 0)
+	if trace == nil {
+		t.Error("expected trace result, got nil")
+	}
+
+	// Test TraceTo
+	trace = ws.TraceTo("REQ-001", 0)
+	if trace == nil {
+		t.Error("expected trace result, got nil")
+	}
+
+	// Test FindPath
+	path := ws.FindPath("DEC-001", "REQ-001")
+	if len(path) == 0 {
+		t.Error("expected path, got empty")
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -93,6 +93,16 @@ func NewWithGraph(repo repository.Store, meta *metamodel.Metamodel, g *graph.Gra
 	return newWorkspace(repo, meta, g)
 }
 
+// NewForTest creates a minimal workspace for testing. It has no repository,
+// so write operations will panic. Use this for unit tests that only need
+// to query the graph.
+func NewForTest(g *graph.Graph, meta *metamodel.Metamodel) *Workspace {
+	return &Workspace{
+		graph: g,
+		meta:  meta,
+	}
+}
+
 func newWorkspace(repo repository.Store, meta *metamodel.Metamodel, g *graph.Graph) *Workspace {
 	var autoEngine *automation.Engine
 	if len(meta.Automations) > 0 {

--- a/tickets/entities/tickets/TKT-032.md
+++ b/tickets/entities/tickets/TKT-032.md
@@ -1,0 +1,37 @@
+---
+effort: m
+id: TKT-032
+kind: refactor
+priority: medium
+status: done
+title: Remove CLI graph dependency via workspace façade
+type: ticket
+---
+
+## Summary
+
+Route all CLI graph operations through workspace façade methods, removing the direct
+`graph` package import from CLI production code.
+
+## Changes
+
+1. **New workspace query methods** (`internal/workspace/query.go`):
+   - `GetEntity`, `AllEntities`, `EntitiesByType`, `EntityCount`, `EntityIDs`
+   - `GetRelation`, `AllRelations`, `IncomingRelations`, `OutgoingRelations`
+   - `FindOrphans`, `TraceFrom`, `TraceTo`, `FindPath`
+
+2. **New test constructor** (`internal/workspace/workspace.go`):
+   - `NewForTest(g, meta)` - creates minimal workspace for unit tests
+
+3. **CLI updates**:
+   - All `g.GetNode()` → `ws.GetEntity()`
+   - All `g.AllNodes()` → `ws.AllEntities()`
+   - All `g.NodesByType()` → `ws.EntitiesByType()`
+   - All `g.AllEdges()` → `ws.AllRelations()`
+   - All `g.OutgoingEdges()` → `ws.OutgoingRelations()`
+   - All `g.IncomingEdges()` → `ws.IncomingRelations()`
+   - All graph tracing methods through workspace
+   - Removed `g` variable from production code (moved to test helper)
+
+4. **Arch-lint config**:
+   - Removed `graph` from CLI's `mayDependOn`

--- a/tickets/relations/TKT-032--affects--workspace.md
+++ b/tickets/relations/TKT-032--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-032
+relation: affects
+to: workspace
+---

--- a/tickets/relations/TKT-032--implements--FEAT-022.md
+++ b/tickets/relations/TKT-032--implements--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: TKT-032
+relation: implements
+to: FEAT-022
+---


### PR DESCRIPTION
## Summary

- Route all CLI graph operations through workspace façade methods
- Add `workspace.NewForTest()` constructor for unit tests
- Add workspace query methods: `GetEntity`, `AllEntities`, `EntitiesByType`, `GetRelation`, `AllRelations`, `IncomingRelations`, `OutgoingRelations`, `FindOrphans`, `TraceFrom`, `TraceTo`, `FindPath`
- Remove `graph` import from CLI production code
- Update arch-lint config to disallow CLI→graph dependency

## Test plan

- [x] All existing tests pass
- [x] Arch-lint passes with no warnings
- [x] Build succeeds