### PR TITLE
Move TraceResult/PathStep types from graph to model (#TKT-033)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -250,8 +250,6 @@ deps:
     canUse:
       - gogit
   output:
-    mayDependOn:
-      - graph
     canUse:
       - color
       - tablewriter

--- a/internal/graph/query.go
+++ b/internal/graph/query.go
@@ -4,21 +4,10 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
-// TraceResult represents the result of a trace operation
-type TraceResult struct {
-	ID       string
-	Type     string
-	Title    string
-	Depth    int
-	Relation string // The relation that led to this node
-	Incoming bool   // True if this node was reached via an incoming relation
-	Children []*TraceResult
-}
-
 // TraceFrom traces all dependencies from a node by following both outgoing AND incoming edges.
 // This allows tracing entities that depend on the given entity (via incoming relations)
 // as well as entities the given entity depends on (via outgoing relations).
-func (g *Graph) TraceFrom(id string, maxDepth int) *TraceResult {
+func (g *Graph) TraceFrom(id string, maxDepth int) *model.TraceResult {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
@@ -27,7 +16,7 @@ func (g *Graph) TraceFrom(id string, maxDepth int) *TraceResult {
 }
 
 // TraceTo traces all upstream dependencies to a node (following incoming edges)
-func (g *Graph) TraceTo(id string, maxDepth int) *TraceResult {
+func (g *Graph) TraceTo(id string, maxDepth int) *model.TraceResult {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
@@ -36,7 +25,7 @@ func (g *Graph) TraceTo(id string, maxDepth int) *TraceResult {
 }
 
 // TraceBoth traces both incoming and outgoing relations from a node
-func (g *Graph) TraceBoth(id string, maxDepth int) *TraceResult {
+func (g *Graph) TraceBoth(id string, maxDepth int) *model.TraceResult {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
@@ -48,7 +37,7 @@ func (g *Graph) TraceBoth(id string, maxDepth int) *TraceResult {
 // It follows both outgoing and incoming edges to traverse the full graph.
 func (g *Graph) traceBidirectional(
 	id string, depth, maxDepth int, relation string, incoming bool, visited map[string]bool,
-) *TraceResult {
+) *model.TraceResult {
 	if maxDepth > 0 && depth > maxDepth {
 		return nil
 	}
@@ -58,7 +47,7 @@ func (g *Graph) traceBidirectional(
 		return nil
 	}
 
-	result := &TraceResult{
+	result := &model.TraceResult{
 		ID:       id,
 		Type:     node.Type,
 		Title:    node.Title(),
@@ -91,7 +80,9 @@ func (g *Graph) traceBidirectional(
 	return result
 }
 
-func (g *Graph) traceToInternal(id string, depth, maxDepth int, relation string, visited map[string]bool) *TraceResult {
+func (g *Graph) traceToInternal(
+	id string, depth, maxDepth int, relation string, visited map[string]bool,
+) *model.TraceResult {
 	if maxDepth > 0 && depth > maxDepth {
 		return nil
 	}
@@ -101,7 +92,7 @@ func (g *Graph) traceToInternal(id string, depth, maxDepth int, relation string,
 		return nil
 	}
 
-	result := &TraceResult{
+	result := &model.TraceResult{
 		ID:       id,
 		Type:     node.Type,
 		Title:    node.Title(),
@@ -127,13 +118,13 @@ func (g *Graph) traceToInternal(id string, depth, maxDepth int, relation string,
 // FindPath finds a path between two nodes (BFS), traversing edges in both directions.
 // This treats the graph as undirected for path-finding purposes, allowing paths to be
 // found regardless of edge direction.
-func (g *Graph) FindPath(fromID, toID string) []PathStep {
+func (g *Graph) FindPath(fromID, toID string) []model.PathStep {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
 	if fromID == toID {
 		if node, ok := g.nodes[fromID]; ok {
-			return []PathStep{{ID: fromID, Type: node.Type, Title: node.Title()}}
+			return []model.PathStep{{ID: fromID, Type: node.Type, Title: node.Title()}}
 		}
 		return nil
 	}
@@ -141,7 +132,7 @@ func (g *Graph) FindPath(fromID, toID string) []PathStep {
 	// BFS
 	type queueItem struct {
 		id   string
-		path []PathStep
+		path []model.PathStep
 	}
 
 	visited := make(map[string]bool)
@@ -150,7 +141,7 @@ func (g *Graph) FindPath(fromID, toID string) []PathStep {
 	if node, ok := g.nodes[fromID]; ok {
 		queue = append(queue, queueItem{
 			id:   fromID,
-			path: []PathStep{{ID: fromID, Type: node.Type, Title: node.Title()}},
+			path: []model.PathStep{{ID: fromID, Type: node.Type, Title: node.Title()}},
 		})
 	}
 
@@ -184,9 +175,9 @@ func (g *Graph) FindPath(fromID, toID string) []PathStep {
 			if nb.id == toID {
 				// Found the target
 				if node, ok := g.nodes[toID]; ok {
-					finalPath := make([]PathStep, len(current.path), len(current.path)+1)
+					finalPath := make([]model.PathStep, len(current.path), len(current.path)+1)
 					copy(finalPath, current.path)
-					finalPath = append(finalPath, PathStep{
+					finalPath = append(finalPath, model.PathStep{
 						ID:       toID,
 						Type:     node.Type,
 						Title:    node.Title(),
@@ -198,9 +189,9 @@ func (g *Graph) FindPath(fromID, toID string) []PathStep {
 
 			if !visited[nb.id] {
 				if node, ok := g.nodes[nb.id]; ok {
-					newPath := make([]PathStep, len(current.path), len(current.path)+1)
+					newPath := make([]model.PathStep, len(current.path), len(current.path)+1)
 					copy(newPath, current.path)
-					newPath = append(newPath, PathStep{
+					newPath = append(newPath, model.PathStep{
 						ID:       nb.id,
 						Type:     node.Type,
 						Title:    node.Title(),
@@ -213,14 +204,6 @@ func (g *Graph) FindPath(fromID, toID string) []PathStep {
 	}
 
 	return nil // No path found
-}
-
-// PathStep represents a step in a path between nodes
-type PathStep struct {
-	ID       string
-	Type     string
-	Title    string
-	Relation string // The relation that led to this step
 }
 
 // FindOrphans returns all nodes with no connections

--- a/internal/graph/query_test.go
+++ b/internal/graph/query_test.go
@@ -136,8 +136,8 @@ func TestTraceFromIncludesIncoming(t *testing.T) {
 
 	// Collect all reachable IDs
 	reachable := make(map[string]bool)
-	var collectIDs func(r *TraceResult)
-	collectIDs = func(r *TraceResult) {
+	var collectIDs func(r *model.TraceResult)
+	collectIDs = func(r *model.TraceResult) {
 		reachable[r.ID] = true
 		for _, child := range r.Children {
 			collectIDs(child)

--- a/internal/mcp/convert.go
+++ b/internal/mcp/convert.go
@@ -102,13 +102,13 @@ func convertRelation(r *model.Relation) (string, error) {
 	return marshalJSON(rj)
 }
 
-// convertTraceResult converts a graph.TraceResult to JSON string.
-func convertTraceResult(tr *graph.TraceResult) (string, error) {
+// convertTraceResult converts a model.TraceResult to JSON string.
+func convertTraceResult(tr *model.TraceResult) (string, error) {
 	node := convertTraceNode(tr)
 	return marshalJSON(node)
 }
 
-func convertTraceNode(tr *graph.TraceResult) *traceNodeJSON {
+func convertTraceNode(tr *model.TraceResult) *traceNodeJSON {
 	if tr == nil {
 		return nil
 	}
@@ -126,8 +126,8 @@ func convertTraceNode(tr *graph.TraceResult) *traceNodeJSON {
 	return node
 }
 
-// convertPathSteps converts graph.PathStep slice to JSON string.
-func convertPathSteps(steps []graph.PathStep) (string, error) {
+// convertPathSteps converts model.PathStep slice to JSON string.
+func convertPathSteps(steps []model.PathStep) (string, error) {
 	result := make([]pathStepJSON, len(steps))
 	for i, s := range steps {
 		result[i] = pathStepJSON{

--- a/internal/mcp/convert_test.go
+++ b/internal/mcp/convert_test.go
@@ -189,12 +189,12 @@ func TestConvertRelation(t *testing.T) {
 }
 
 func TestConvertTraceResult(t *testing.T) {
-	tr := &graph.TraceResult{
+	tr := &model.TraceResult{
 		ID:    "REQ-001",
 		Type:  "requirement",
 		Title: "Root Req",
 		Depth: 0,
-		Children: []*graph.TraceResult{
+		Children: []*model.TraceResult{
 			{
 				ID:       "SOL-001",
 				Type:     "solution",
@@ -245,7 +245,7 @@ func TestConvertTraceResult_Nil(t *testing.T) {
 }
 
 func TestConvertPathSteps(t *testing.T) {
-	steps := []graph.PathStep{
+	steps := []model.PathStep{
 		{ID: "REQ-001", Type: "requirement", Title: "Start"},
 		{ID: "SOL-001", Type: "solution", Title: "Middle", Relation: "addresses"},
 		{ID: "CMP-001", Type: "component", Title: "End", Relation: "implements"},
@@ -276,7 +276,7 @@ func TestConvertPathSteps(t *testing.T) {
 }
 
 func TestConvertPathSteps_Empty(t *testing.T) {
-	result, err := convertPathSteps([]graph.PathStep{})
+	result, err := convertPathSteps([]model.PathStep{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -637,19 +637,19 @@ func TestConvertRelation_NoProperties(t *testing.T) {
 }
 
 func TestConvertTraceResult_DeepNesting(t *testing.T) {
-	tr := &graph.TraceResult{
+	tr := &model.TraceResult{
 		ID:    "REQ-001",
 		Type:  "requirement",
 		Title: "Root",
 		Depth: 0,
-		Children: []*graph.TraceResult{
+		Children: []*model.TraceResult{
 			{
 				ID:       "SOL-001",
 				Type:     "solution",
 				Title:    "Level 1",
 				Depth:    1,
 				Relation: "addresses",
-				Children: []*graph.TraceResult{
+				Children: []*model.TraceResult{
 					{
 						ID:       "CMP-001",
 						Type:     "component",

--- a/internal/model/trace.go
+++ b/internal/model/trace.go
@@ -1,0 +1,21 @@
+package model
+
+// TraceResult represents the result of a graph trace operation.
+// It forms a tree structure showing entities reachable from a starting point.
+type TraceResult struct {
+	ID       string
+	Type     string
+	Title    string
+	Depth    int
+	Relation string // The relation that led to this node
+	Incoming bool   // True if this node was reached via an incoming relation
+	Children []*TraceResult
+}
+
+// PathStep represents a step in a path between two entities.
+type PathStep struct {
+	ID       string
+	Type     string
+	Title    string
+	Relation string // The relation that led to this step
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -10,7 +10,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/olekukonko/tablewriter"
 
-	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
@@ -234,7 +233,7 @@ func (w *Writer) WriteRelations(relations []*model.Relation) error {
 }
 
 // WriteTrace outputs a trace result as a tree
-func (w *Writer) WriteTrace(result *graph.TraceResult) error {
+func (w *Writer) WriteTrace(result *model.TraceResult) error {
 	if w.Format == FormatJSON {
 		return w.writeJSON(result)
 	}
@@ -243,7 +242,7 @@ func (w *Writer) WriteTrace(result *graph.TraceResult) error {
 	return nil
 }
 
-func (w *Writer) writeTraceNode(node *graph.TraceResult, prefix string, isLast bool) {
+func (w *Writer) writeTraceNode(node *model.TraceResult, prefix string, isLast bool) {
 	if node == nil {
 		return
 	}
@@ -286,7 +285,7 @@ func (w *Writer) writeTraceNode(node *graph.TraceResult, prefix string, isLast b
 }
 
 // WritePath outputs a path between nodes
-func (w *Writer) WritePath(path []graph.PathStep) error {
+func (w *Writer) WritePath(path []model.PathStep) error {
 	if w.Format == FormatJSON {
 		return w.writeJSON(path)
 	}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
@@ -351,15 +350,15 @@ func TestWriteTrace(t *testing.T) {
 	buf := &bytes.Buffer{}
 	w := NewWithWriter(buf, FormatTable)
 
-	trace := &graph.TraceResult{
+	trace := &model.TraceResult{
 		ID:    "REQ-001",
 		Title: "Root",
-		Children: []*graph.TraceResult{
+		Children: []*model.TraceResult{
 			{
 				ID:       "REQ-002",
 				Title:    "Child 1",
 				Relation: "depends_on",
-				Children: []*graph.TraceResult{
+				Children: []*model.TraceResult{
 					{
 						ID:       "REQ-004",
 						Title:    "Grandchild",
@@ -398,7 +397,7 @@ func TestWriteTrace(t *testing.T) {
 	// Test trace without relation info
 	buf2 := &bytes.Buffer{}
 	w2 := NewWithWriter(buf2, FormatTable)
-	trace2 := &graph.TraceResult{
+	trace2 := &model.TraceResult{
 		ID:    "REQ-005",
 		Title: "No relations",
 	}
@@ -417,7 +416,7 @@ func TestWriteTraceJSON(t *testing.T) {
 	buf := &bytes.Buffer{}
 	w := NewWithWriter(buf, FormatJSON)
 
-	trace := &graph.TraceResult{
+	trace := &model.TraceResult{
 		ID:    "REQ-001",
 		Title: "Root",
 	}
@@ -427,7 +426,7 @@ func TestWriteTraceJSON(t *testing.T) {
 		t.Fatalf("WriteTrace failed: %v", err)
 	}
 
-	var result graph.TraceResult
+	var result model.TraceResult
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
 		t.Fatalf("failed to parse JSON output: %v", err)
 	}
@@ -441,7 +440,7 @@ func TestWritePath(t *testing.T) {
 	buf := &bytes.Buffer{}
 	w := NewWithWriter(buf, FormatTable)
 
-	path := []graph.PathStep{
+	path := []model.PathStep{
 		{ID: "REQ-001", Type: "requirement"},
 		{ID: "REQ-002", Type: "requirement", Relation: "depends_on"},
 		{ID: "DEC-001", Type: "decision", Relation: "implements"},
@@ -478,7 +477,7 @@ func TestWritePath(t *testing.T) {
 	}
 
 	// Test with single hop
-	path1 := []graph.PathStep{
+	path1 := []model.PathStep{
 		{ID: "REQ-001", Type: "requirement"},
 		{ID: "REQ-002", Type: "requirement", Relation: "depends_on"},
 	}
@@ -499,7 +498,7 @@ func TestWritePathEmpty(t *testing.T) {
 	buf := &bytes.Buffer{}
 	w := NewWithWriter(buf, FormatTable)
 
-	err := w.WritePath([]graph.PathStep{})
+	err := w.WritePath([]model.PathStep{})
 	if err != nil {
 		t.Fatalf("WritePath failed: %v", err)
 	}
@@ -515,7 +514,7 @@ func TestWritePathJSON(t *testing.T) {
 	buf := &bytes.Buffer{}
 	w := NewWithWriter(buf, FormatJSON)
 
-	path := []graph.PathStep{
+	path := []model.PathStep{
 		{ID: "REQ-001", Type: "requirement"},
 	}
 
@@ -524,7 +523,7 @@ func TestWritePathJSON(t *testing.T) {
 		t.Fatalf("WritePath failed: %v", err)
 	}
 
-	var result []graph.PathStep
+	var result []model.PathStep
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
 		t.Fatalf("failed to parse JSON output: %v", err)
 	}

--- a/internal/workspace/query.go
+++ b/internal/workspace/query.go
@@ -1,7 +1,6 @@
 package workspace
 
 import (
-	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
@@ -61,8 +60,8 @@ func (w *Workspace) FindOrphans() []*model.Entity {
 	return w.graph.FindOrphans()
 }
 
-// TraceResult is re-exported from graph for consumers.
-type TraceResult = graph.TraceResult
+// TraceResult is re-exported from model for consumers.
+type TraceResult = model.TraceResult
 
 // TraceFrom traces all paths from the given entity (outgoing direction).
 func (w *Workspace) TraceFrom(entityID string, maxDepth int) *TraceResult {
@@ -74,8 +73,8 @@ func (w *Workspace) TraceTo(entityID string, maxDepth int) *TraceResult {
 	return w.graph.TraceTo(entityID, maxDepth)
 }
 
-// PathStep is re-exported from graph for consumers.
-type PathStep = graph.PathStep
+// PathStep is re-exported from model for consumers.
+type PathStep = model.PathStep
 
 // FindPath finds the shortest path between two entities.
 func (w *Workspace) FindPath(from, to string) []PathStep {

--- a/tickets/entities/tickets/TKT-033.md
+++ b/tickets/entities/tickets/TKT-033.md
@@ -1,0 +1,10 @@
+---
+description: Moves TraceResult and PathStep types from graph package to model package to remove output→graph dependency
+effort: xs
+id: TKT-033
+kind: refactor
+priority: medium
+status: done
+title: Move TraceResult/PathStep types from graph to model
+type: ticket
+---

--- a/tickets/relations/TKT-033--affects--workspace.md
+++ b/tickets/relations/TKT-033--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-033
+relation: affects
+to: workspace
+---

--- a/tickets/relations/TKT-033--implements--FEAT-022.md
+++ b/tickets/relations/TKT-033--implements--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: TKT-033
+relation: implements
+to: FEAT-022
+---


### PR DESCRIPTION
## Summary
- Moves `TraceResult` and `PathStep` types from `graph` package to `model` package
- Removes `output→graph` dependency from arch-lint rules
- Updates all consumers (workspace, mcp, output) to use model types

## Test plan
- [x] All tests pass
- [x] Lint passes
- [x] Build succeeds