### PR TITLE
Remove graph import from mcp/convert.go (#TKT-034)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -155,7 +155,6 @@ deps:
   mcp:
     mayDependOn:
       - filter
-      - graph
       - markdown
       - metamodel
       - rename

--- a/internal/mcp/convert.go
+++ b/internal/mcp/convert.go
@@ -5,10 +5,17 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
+
+// relationQuerier provides relation lookup methods for entity conversion.
+// Implemented by workspace.Workspace.
+type relationQuerier interface {
+	GetEntity(id string) (*model.Entity, bool)
+	OutgoingRelations(entityID string) []*model.Relation
+	IncomingRelations(entityID string) []*model.Relation
+}
 
 // entityJSON represents an entity for JSON output in MCP responses.
 type entityJSON struct {
@@ -60,7 +67,7 @@ type pathStepJSON struct {
 }
 
 // convertEntity converts a model.Entity to JSON string with optional relations.
-func convertEntity(e *model.Entity, g *graph.Graph, includeRelations bool) (string, error) {
+func convertEntity(e *model.Entity, rq relationQuerier, includeRelations bool) (string, error) {
 	ej := entityJSON{
 		ID:         e.ID,
 		Type:       e.Type,
@@ -69,7 +76,7 @@ func convertEntity(e *model.Entity, g *graph.Graph, includeRelations bool) (stri
 	}
 
 	if includeRelations {
-		ej.Relations = buildRelations(e.ID, g)
+		ej.Relations = buildRelations(e.ID, rq)
 	}
 
 	return marshalJSON(ej)
@@ -141,9 +148,9 @@ func convertPathSteps(steps []model.PathStep) (string, error) {
 }
 
 // buildRelations builds the relations JSON for an entity.
-func buildRelations(entityID string, g *graph.Graph) *relationsJSON {
-	outgoing := g.OutgoingEdges(entityID)
-	incoming := g.IncomingEdges(entityID)
+func buildRelations(entityID string, rq relationQuerier) *relationsJSON {
+	outgoing := rq.OutgoingRelations(entityID)
+	incoming := rq.IncomingRelations(entityID)
 
 	if len(outgoing) == 0 && len(incoming) == 0 {
 		return nil
@@ -156,7 +163,7 @@ func buildRelations(entityID string, g *graph.Graph) *relationsJSON {
 
 	for _, rel := range outgoing {
 		target := relationTargetJSON{ID: rel.To}
-		if node, ok := g.GetNode(rel.To); ok {
+		if node, ok := rq.GetEntity(rel.To); ok {
 			target.Title = node.Title()
 		}
 		rels.Outgoing[rel.Type] = append(rels.Outgoing[rel.Type], target)
@@ -164,7 +171,7 @@ func buildRelations(entityID string, g *graph.Graph) *relationsJSON {
 
 	for _, rel := range incoming {
 		source := relationTargetJSON{ID: rel.From}
-		if node, ok := g.GetNode(rel.From); ok {
+		if node, ok := rq.GetEntity(rel.From); ok {
 			source.Title = node.Title()
 		}
 		rels.Incoming[rel.Type] = append(rels.Incoming[rel.Type], source)

--- a/internal/mcp/convert_test.go
+++ b/internal/mcp/convert_test.go
@@ -20,6 +20,23 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
+// graphAdapter wraps *graph.Graph to implement relationQuerier for tests.
+type graphAdapter struct {
+	g *graph.Graph
+}
+
+func (a *graphAdapter) GetEntity(id string) (*model.Entity, bool) {
+	return a.g.GetNode(id)
+}
+
+func (a *graphAdapter) OutgoingRelations(entityID string) []*model.Relation {
+	return a.g.OutgoingEdges(entityID)
+}
+
+func (a *graphAdapter) IncomingRelations(entityID string) []*model.Relation {
+	return a.g.IncomingEdges(entityID)
+}
+
 // makeToolRequest creates a CallToolRequest with the given arguments.
 func makeToolRequest(args map[string]interface{}) mcp.CallToolRequest {
 	return mcp.CallToolRequest{
@@ -37,7 +54,7 @@ func TestConvertEntity_WithoutRelations(t *testing.T) {
 	e.Content = "Some content"
 	g.AddNode(e)
 
-	result, err := convertEntity(e, g, false)
+	result, err := convertEntity(e, &graphAdapter{g}, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -76,7 +93,7 @@ func TestConvertEntity_WithRelations(t *testing.T) {
 	rel := model.NewRelation("SOL-001", "addresses", "REQ-001")
 	g.AddEdge(rel)
 
-	result, err := convertEntity(e1, g, true)
+	result, err := convertEntity(e1, &graphAdapter{g}, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -104,7 +121,7 @@ func TestConvertEntity_NoRelationsPresent(t *testing.T) {
 	e := model.NewEntity("REQ-001", "requirement")
 	g.AddNode(e)
 
-	result, err := convertEntity(e, g, true)
+	result, err := convertEntity(e, &graphAdapter{g}, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -290,7 +307,7 @@ func TestBuildRelations_NoEdges(t *testing.T) {
 	e := model.NewEntity("REQ-001", "requirement")
 	g.AddNode(e)
 
-	rels := buildRelations("REQ-001", g)
+	rels := buildRelations("REQ-001", &graphAdapter{g})
 	if rels != nil {
 		t.Error("expected nil relations for entity with no edges")
 	}
@@ -308,7 +325,7 @@ func TestBuildRelations_OutgoingOnly(t *testing.T) {
 	rel := model.NewRelation("SOL-001", "addresses", "REQ-001")
 	g.AddEdge(rel)
 
-	rels := buildRelations("SOL-001", g)
+	rels := buildRelations("SOL-001", &graphAdapter{g})
 	if rels == nil {
 		t.Fatal("expected non-nil relations")
 	}
@@ -338,7 +355,7 @@ func TestBuildRelations_IncomingOnly(t *testing.T) {
 	rel := model.NewRelation("SOL-001", "addresses", "REQ-001")
 	g.AddEdge(rel)
 
-	rels := buildRelations("REQ-001", g)
+	rels := buildRelations("REQ-001", &graphAdapter{g})
 	if rels == nil {
 		t.Fatal("expected non-nil relations")
 	}
@@ -368,7 +385,7 @@ func TestBuildRelations_BothDirections(t *testing.T) {
 	g.AddEdge(model.NewRelation("SOL-001", "addresses", "REQ-001"))
 	g.AddEdge(model.NewRelation("REQ-001", "motivates", "DEC-001"))
 
-	rels := buildRelations("REQ-001", g)
+	rels := buildRelations("REQ-001", &graphAdapter{g})
 	if rels == nil {
 		t.Fatal("expected non-nil relations")
 	}
@@ -746,7 +763,7 @@ func TestConvertEntity_WithProperties(t *testing.T) {
 	e.Properties["priority"] = "high"
 	g.AddNode(e)
 
-	result, err := convertEntity(e, g, false)
+	result, err := convertEntity(e, &graphAdapter{g}, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -64,21 +64,20 @@ func (s *Server) handleAnalyzeTraceabilityPrompt(
 		return nil, fmt.Errorf("id argument is required")
 	}
 
-	g := s.ws.Graph()
-	entity, ok := g.GetNode(id)
+	entity, ok := s.ws.GetEntity(id)
 	if !ok {
 		return nil, fmt.Errorf("entity not found: %s", id)
 	}
 
 	// Get entity details
-	entityText, err := convertEntity(entity, g, true)
+	entityText, err := convertEntity(entity, s.ws, true)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get trace trees
-	traceFrom := g.TraceFrom(id, 0)
-	traceTo := g.TraceTo(id, 0)
+	traceFrom := s.ws.TraceFrom(id, 0)
+	traceTo := s.ws.TraceTo(id, 0)
 
 	var traceFromText, traceToText string
 	if traceFrom != nil {
@@ -269,13 +268,12 @@ func (s *Server) handleReviewEntityPrompt(
 		return nil, fmt.Errorf("id argument is required")
 	}
 
-	g := s.ws.Graph()
-	entity, ok := g.GetNode(id)
+	entity, ok := s.ws.GetEntity(id)
 	if !ok {
 		return nil, fmt.Errorf("entity not found: %s", id)
 	}
 
-	entityText, err := convertEntity(entity, g, true)
+	entityText, err := convertEntity(entity, s.ws, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -100,8 +100,7 @@ func (s *Server) handleReadEntity(
 	}
 	entityType, id := segments[0], segments[1]
 
-	g := s.ws.Graph()
-	entity, ok := g.GetNode(id)
+	entity, ok := s.ws.GetEntity(id)
 	if !ok {
 		return nil, fmt.Errorf("entity not found: %s", id)
 	}
@@ -109,7 +108,7 @@ func (s *Server) handleReadEntity(
 		return nil, fmt.Errorf("entity %s is type %s, not %s", id, entity.Type, entityType)
 	}
 
-	text, err := convertEntity(entity, g, true)
+	text, err := convertEntity(entity, s.ws, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert entity: %w", err)
 	}

--- a/internal/mcp/tools_entity.go
+++ b/internal/mcp/tools_entity.go
@@ -61,13 +61,12 @@ func (s *Server) handleShowEntity(
 	}
 	id = trimID(id)
 
-	g := s.ws.Graph()
-	entity, ok := g.GetNode(id)
+	entity, ok := s.ws.GetEntity(id)
 	if !ok {
 		return mcp.NewToolResultError(fmt.Sprintf("entity not found: %s", id)), nil
 	}
 
-	text, err := convertEntity(entity, g, true)
+	text, err := convertEntity(entity, s.ws, true)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -165,7 +164,7 @@ func (s *Server) handleCreateEntity(
 		return mcp.NewToolResultError(createErr.Error()), nil
 	}
 
-	text, err := convertEntity(entity, s.ws.Graph(), false)
+	text, err := convertEntity(entity, s.ws, false)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -181,8 +180,7 @@ func (s *Server) handleUpdateEntity(
 	}
 	id = trimID(id)
 
-	g := s.ws.Graph()
-	entity, ok := g.GetNode(id)
+	entity, ok := s.ws.GetEntity(id)
 	if !ok {
 		return mcp.NewToolResultError(fmt.Sprintf("entity not found: %s", id)), nil
 	}
@@ -214,7 +212,7 @@ func (s *Server) handleUpdateEntity(
 		return mcp.NewToolResultError(updateErr.Error()), nil
 	}
 
-	text, convertErr := convertEntity(entity, g, true)
+	text, convertErr := convertEntity(entity, s.ws, true)
 	if convertErr != nil {
 		return mcp.NewToolResultError(convertErr.Error()), nil
 	}

--- a/tickets/entities/tickets/TKT-034.md
+++ b/tickets/entities/tickets/TKT-034.md
@@ -1,0 +1,10 @@
+---
+description: Introduces relationQuerier interface for relation lookups, removing direct graph.Graph dependency from mcp/convert.go production code
+effort: xs
+id: TKT-034
+kind: refactor
+priority: medium
+status: done
+title: Remove graph import from mcp/convert.go
+type: ticket
+---

--- a/tickets/relations/TKT-034--affects--mcp-api.md
+++ b/tickets/relations/TKT-034--affects--mcp-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-034
+relation: affects
+to: mcp-api
+---

--- a/tickets/relations/TKT-034--implements--FEAT-022.md
+++ b/tickets/relations/TKT-034--implements--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: TKT-034
+relation: implements
+to: FEAT-022
+---


### PR DESCRIPTION
## Summary
- Introduces `relationQuerier` interface for relation lookups in convert.go
- Changes `convertEntity` and `buildRelations` to accept interface instead of `*graph.Graph`
- Updates all callers to pass `s.ws` (workspace) instead of `s.ws.Graph()`
- Removes graph import from mcp/convert.go production code

## Test plan
- [x] All tests pass
- [x] Lint passes
- [x] Build succeeds