### PR TITLE
Add run action to automation system

### DIFF
--- a/internal/automation/engine.go
+++ b/internal/automation/engine.go
@@ -58,6 +58,12 @@ func convertFromMetamodel(def metamodel.AutomationDef) Automation {
 				To:       a.CreateRelation.To,
 			}
 		}
+		if a.Run != nil {
+			action.Run = &RunAction{
+				Script: a.Run.Script,
+				Args:   a.Run.Args,
+			}
+		}
 		auto.Do[i] = action
 	}
 
@@ -82,6 +88,7 @@ func (e *Engine) Process(event Event) *Result {
 	result := &Result{
 		PropertiesSet:     make(map[string]string),
 		RelationsToCreate: make([]*model.Relation, 0),
+		ScriptsToRun:      make([]ScriptToRun, 0),
 		Warnings:          make([]string, 0),
 		Errors:            make([]string, 0),
 	}
@@ -190,6 +197,17 @@ func (e *Engine) executeAction(action Action, event Event, result *Result) {
 			rel := model.NewRelation(event.Entity.ID, action.CreateRelation.Relation, targetID)
 			result.RelationsToCreate = append(result.RelationsToCreate, rel)
 		}
+	}
+
+	if action.Run != nil {
+		args := make([]string, len(action.Run.Args))
+		for i, arg := range action.Run.Args {
+			args[i] = e.interpolate(arg, event)
+		}
+		result.ScriptsToRun = append(result.ScriptsToRun, ScriptToRun{
+			Script: action.Run.Script,
+			Args:   args,
+		})
 	}
 }
 

--- a/internal/automation/engine_test.go
+++ b/internal/automation/engine_test.go
@@ -375,3 +375,85 @@ func TestEngine_RelationCreated(t *testing.T) {
 		t.Error("expected trigger on relation created")
 	}
 }
+
+func TestEngine_RunScript(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "run-on-complete",
+			On: Trigger{
+				Entity:   []string{"task"},
+				Property: "status",
+				Becomes:  "done",
+			},
+			Do: []Action{
+				{
+					Run: &RunAction{
+						Script: "scripts/on-complete.sh",
+						Args:   []string{"{{entity.id}}", "{{new.status}}"},
+					},
+				},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	oldEntity := model.NewEntity("T-001", "task")
+	oldEntity.Properties["status"] = "in-progress"
+
+	newEntity := model.NewEntity("T-001", "task")
+	newEntity.Properties["status"] = "done"
+
+	result := engine.Process(Event{
+		Type:      EventEntityUpdated,
+		Entity:    newEntity,
+		OldEntity: oldEntity,
+	})
+
+	if len(result.ScriptsToRun) != 1 {
+		t.Fatalf("expected 1 script to run, got %d", len(result.ScriptsToRun))
+	}
+	script := result.ScriptsToRun[0]
+	if script.Script != "scripts/on-complete.sh" {
+		t.Errorf("expected script=scripts/on-complete.sh, got %q", script.Script)
+	}
+	if len(script.Args) != 2 || script.Args[0] != "T-001" || script.Args[1] != "done" {
+		t.Errorf("unexpected args: %v", script.Args)
+	}
+}
+
+func TestEngine_RunScript_OnCreate(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "notify-on-create",
+			On: Trigger{
+				Entity:  []string{"ticket"},
+				Created: true,
+			},
+			Do: []Action{
+				{
+					Run: &RunAction{
+						Script: "scripts/notify.sh",
+						Args:   []string{"{{entity.type}}", "{{entity.id}}"},
+					},
+				},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	entity := model.NewEntity("T-123", "ticket")
+	result := engine.Process(Event{
+		Type:   EventEntityCreated,
+		Entity: entity,
+	})
+
+	if len(result.ScriptsToRun) != 1 {
+		t.Fatalf("expected 1 script to run, got %d", len(result.ScriptsToRun))
+	}
+	script := result.ScriptsToRun[0]
+	if script.Args[0] != "ticket" || script.Args[1] != "T-123" {
+		t.Errorf("unexpected args: %v", script.Args)
+	}
+}

--- a/internal/automation/types.go
+++ b/internal/automation/types.go
@@ -32,12 +32,19 @@ type Action struct {
 	Set            string
 	Value          string
 	CreateRelation *CreateRelationAction
+	Run            *RunAction
 }
 
 // CreateRelationAction specifies parameters for creating a relation.
 type CreateRelationAction struct {
 	Relation string
 	To       string
+}
+
+// RunAction specifies a script to execute.
+type RunAction struct {
+	Script string   // Path to script (relative to project root)
+	Args   []string // Arguments with template interpolation
 }
 
 // Validation specifies a condition to check.
@@ -95,11 +102,20 @@ type Result struct {
 	// RelationsToCreate contains relations that should be created.
 	RelationsToCreate []*model.Relation
 
+	// ScriptsToRun contains scripts that should be executed.
+	ScriptsToRun []ScriptToRun
+
 	// Warnings contains validation warnings (allow save, show message).
 	Warnings []string
 
 	// Errors contains validation errors (should block save in strict mode).
 	Errors []string
+}
+
+// ScriptToRun contains a script to execute after entity operations complete.
+type ScriptToRun struct {
+	Script string   // Path to script (relative to project root)
+	Args   []string // Interpolated arguments
 }
 
 // HasWarnings returns true if there are any warnings.

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -95,30 +95,7 @@ Examples:
 			return err
 		}
 
-		// Show automation feedback
-		for _, warning := range result.AutomationWarnings {
-			out.WriteWarning("Automation: %s", warning)
-		}
-		for _, errMsg := range result.AutomationErrors {
-			out.WriteWarning("Automation error: %s", errMsg)
-		}
-		for _, rel := range result.RelationsCreated {
-			out.WriteInfo("Automation created relation: %s --%s--> %s", rel.From, rel.Type, rel.To)
-		}
-		for _, script := range result.ScriptsRun {
-			if script.ExitCode != 0 || script.Error != "" {
-				if script.Error != "" {
-					out.WriteError("Script %s failed: %s", script.Script, script.Error)
-				} else {
-					out.WriteError("Script %s exited with code %d", script.Script, script.ExitCode)
-				}
-				if script.Output != "" {
-					out.WriteMessage("  Output: %s", script.Output)
-				}
-			} else if verbose {
-				out.WriteInfo("Script %s completed", script.Script)
-			}
-		}
+		showAutomationFeedback(result)
 
 		out.WriteSuccess("Created %s %s", resolvedType, entity.ID)
 		if outputFormat == "json" {

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -105,6 +105,20 @@ Examples:
 		for _, rel := range result.RelationsCreated {
 			out.WriteInfo("Automation created relation: %s --%s--> %s", rel.From, rel.Type, rel.To)
 		}
+		for _, script := range result.ScriptsRun {
+			if script.ExitCode != 0 || script.Error != "" {
+				if script.Error != "" {
+					out.WriteError("Script %s failed: %s", script.Script, script.Error)
+				} else {
+					out.WriteError("Script %s exited with code %d", script.Script, script.ExitCode)
+				}
+				if script.Output != "" {
+					out.WriteMessage("  Output: %s", script.Output)
+				}
+			} else if verbose {
+				out.WriteInfo("Script %s completed", script.Script)
+			}
+		}
 
 		out.WriteSuccess("Created %s %s", resolvedType, entity.ID)
 		if outputFormat == "json" {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -7,10 +7,19 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/output"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
+
+// AutomationResult is implemented by workspace.CreateResult and workspace.UpdateResult.
+type AutomationResult interface {
+	GetAutomationWarnings() []string
+	GetAutomationErrors() []string
+	GetRelationsCreated() []*model.Relation
+	GetScriptsRun() []workspace.ScriptResult
+}
 
 var (
 	// Version is set at build time
@@ -112,4 +121,31 @@ func saveCache() error {
 // resolveEntityType delegates to workspace.
 func resolveEntityType(typeName string) (string, *metamodel.EntityDef, error) {
 	return ws.ResolveEntityType(typeName)
+}
+
+// showAutomationFeedback displays automation warnings, errors, relations, and script results.
+func showAutomationFeedback(result AutomationResult) {
+	for _, warning := range result.GetAutomationWarnings() {
+		out.WriteWarning("Automation: %s", warning)
+	}
+	for _, errMsg := range result.GetAutomationErrors() {
+		out.WriteWarning("Automation error: %s", errMsg)
+	}
+	for _, rel := range result.GetRelationsCreated() {
+		out.WriteInfo("Automation created relation: %s --%s--> %s", rel.From, rel.Type, rel.To)
+	}
+	for _, script := range result.GetScriptsRun() {
+		if script.ExitCode != 0 || script.Error != "" {
+			if script.Error != "" {
+				out.WriteError("Script %s failed: %s", script.Script, script.Error)
+			} else {
+				out.WriteError("Script %s exited with code %d", script.Script, script.ExitCode)
+			}
+			if script.Output != "" {
+				out.WriteMessage("  Output: %s", script.Output)
+			}
+		} else if verbose {
+			out.WriteInfo("Script %s completed", script.Script)
+		}
+	}
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -102,30 +102,7 @@ Examples:
 			return err
 		}
 
-		// Show automation feedback
-		for _, warning := range result.AutomationWarnings {
-			out.WriteWarning("Automation: %s", warning)
-		}
-		for _, errMsg := range result.AutomationErrors {
-			out.WriteWarning("Automation error: %s", errMsg)
-		}
-		for _, rel := range result.RelationsCreated {
-			out.WriteInfo("Automation created relation: %s --%s--> %s", rel.From, rel.Type, rel.To)
-		}
-		for _, script := range result.ScriptsRun {
-			if script.ExitCode != 0 || script.Error != "" {
-				if script.Error != "" {
-					out.WriteError("Script %s failed: %s", script.Script, script.Error)
-				} else {
-					out.WriteError("Script %s exited with code %d", script.Script, script.ExitCode)
-				}
-				if script.Output != "" {
-					out.WriteMessage("  Output: %s", script.Output)
-				}
-			} else if verbose {
-				out.WriteInfo("Script %s completed", script.Script)
-			}
-		}
+		showAutomationFeedback(result)
 
 		out.WriteSuccess("Updated %s", entityID)
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -112,6 +112,20 @@ Examples:
 		for _, rel := range result.RelationsCreated {
 			out.WriteInfo("Automation created relation: %s --%s--> %s", rel.From, rel.Type, rel.To)
 		}
+		for _, script := range result.ScriptsRun {
+			if script.ExitCode != 0 || script.Error != "" {
+				if script.Error != "" {
+					out.WriteError("Script %s failed: %s", script.Script, script.Error)
+				} else {
+					out.WriteError("Script %s exited with code %d", script.Script, script.ExitCode)
+				}
+				if script.Output != "" {
+					out.WriteMessage("  Output: %s", script.Output)
+				}
+			} else if verbose {
+				out.WriteInfo("Script %s completed", script.Script)
+			}
+		}
 
 		out.WriteSuccess("Updated %s", entityID)
 

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -1381,8 +1381,8 @@ func (a *App) handleCreate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	toastMsg := "Created " + entity.ID
-	if scriptErr := formatScriptErrorsForToast(createResult.ScriptsRun); scriptErr != "" {
-		toastMsg += " | " + scriptErr
+	if errMsg := createResult.FormatErrors(); errMsg != "" {
+		toastMsg += " | " + errMsg
 	}
 	w.Header().Set("HX-Redirect", appendToastParam(redirect, toastMsg))
 	w.WriteHeader(http.StatusOK)
@@ -1516,8 +1516,8 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		redirect = returnTo
 	}
 	toastMsg := "Saved " + entityID
-	if scriptErr := formatScriptErrorsForToast(updateResult.ScriptsRun); scriptErr != "" {
-		toastMsg += " | " + scriptErr
+	if errMsg := updateResult.FormatErrors(); errMsg != "" {
+		toastMsg += " | " + errMsg
 	}
 	w.Header().Set("HX-Redirect", appendToastParam(redirect, toastMsg))
 	w.WriteHeader(http.StatusOK)
@@ -1638,8 +1638,8 @@ func (a *App) handleInlineCreate(w http.ResponseWriter, r *http.Request) {
 		"id":    entity.ID,
 		"title": a.entityDisplayTitle(entity),
 	}
-	if scriptErr := formatScriptErrorsForToast(createResult.ScriptsRun); scriptErr != "" {
-		response["scriptError"] = scriptErr
+	if errMsg := createResult.FormatErrors(); errMsg != "" {
+		response["scriptError"] = errMsg
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response) //nolint:errcheck // best-effort JSON response
@@ -2012,25 +2012,6 @@ func appendToastParam(redirectURL, message string) string {
 		base += "#" + fragment
 	}
 	return base
-}
-
-// formatScriptErrorsForToast formats script failures for display in a toast message.
-// Returns empty string if no failures occurred.
-func formatScriptErrorsForToast(scripts []workspace.ScriptResult) string {
-	var failures []string
-	for _, s := range scripts {
-		if s.ExitCode != 0 || s.Error != "" {
-			if s.Error != "" {
-				failures = append(failures, fmt.Sprintf("Script %s: %s", s.Script, s.Error))
-			} else {
-				failures = append(failures, fmt.Sprintf("Script %s exited with code %d", s.Script, s.ExitCode))
-			}
-		}
-	}
-	if len(failures) == 0 {
-		return ""
-	}
-	return strings.Join(failures, "; ")
 }
 
 // coverage-ignore: dashboard handler - tested via integration/manual testing

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -1351,7 +1351,7 @@ func (a *App) handleCreate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	entity, _, err := a.ws.CreateEntity(form.EntityType, opts)
+	entity, createResult, err := a.ws.CreateEntity(form.EntityType, opts)
 	if err != nil {
 		var ve *workspace.ValidationError
 		if errors.As(err, &ve) {
@@ -1380,7 +1380,11 @@ func (a *App) handleCreate(w http.ResponseWriter, r *http.Request) {
 			redirect = redirect + "#" + strings.ToLower(entity.ID)
 		}
 	}
-	w.Header().Set("HX-Redirect", appendToastParam(redirect, "Created "+entity.ID))
+	toastMsg := "Created " + entity.ID
+	if scriptErr := formatScriptErrorsForToast(createResult.ScriptsRun); scriptErr != "" {
+		toastMsg += " | " + scriptErr
+	}
+	w.Header().Set("HX-Redirect", appendToastParam(redirect, toastMsg))
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -1442,7 +1446,8 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		entity.Content = r.FormValue("_body")
 	}
 
-	if _, err := a.ws.UpdateEntity(entity, oldEntity); err != nil {
+	updateResult, err := a.ws.UpdateEntity(entity, oldEntity)
+	if err != nil {
 		var ve *workspace.ValidationError
 		if errors.As(err, &ve) {
 			a.renderFormWithErrors(w, r, formID, entity, validationErrorsToFieldMap(ve.Errors))
@@ -1497,8 +1502,8 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 			if len(relProps) > 0 {
 				opts = append(opts, workspace.CreateRelationOptions{Properties: relProps})
 			}
-			if _, err := a.ws.CreateRelation(fromID, rel.Relation, toID, opts...); err != nil {
-				log.Printf("Failed to write relation: %v", err)
+			if _, relErr := a.ws.CreateRelation(fromID, rel.Relation, toID, opts...); relErr != nil {
+				log.Printf("Failed to write relation: %v", relErr)
 				continue
 			}
 		}
@@ -1510,7 +1515,11 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	if returnTo := r.FormValue("_return_to"); returnTo != "" && strings.HasPrefix(returnTo, "/") {
 		redirect = returnTo
 	}
-	w.Header().Set("HX-Redirect", appendToastParam(redirect, "Saved "+entityID))
+	toastMsg := "Saved " + entityID
+	if scriptErr := formatScriptErrorsForToast(updateResult.ScriptsRun); scriptErr != "" {
+		toastMsg += " | " + scriptErr
+	}
+	w.Header().Set("HX-Redirect", appendToastParam(redirect, toastMsg))
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -1615,7 +1624,7 @@ func (a *App) handleInlineCreate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	entity, _, err := a.ws.CreateEntity(form.EntityType, opts)
+	entity, createResult, err := a.ws.CreateEntity(form.EntityType, opts)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -1625,11 +1634,15 @@ func (a *App) handleInlineCreate(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("Inline-created %s %s", form.EntityType, entity.ID)
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{ //nolint:errcheck // best-effort JSON response
+	response := map[string]interface{}{
 		"id":    entity.ID,
 		"title": a.entityDisplayTitle(entity),
-	})
+	}
+	if scriptErr := formatScriptErrorsForToast(createResult.ScriptsRun); scriptErr != "" {
+		response["scriptError"] = scriptErr
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response) //nolint:errcheck // best-effort JSON response
 }
 
 func (a *App) handleInlineForm(w http.ResponseWriter, r *http.Request) {
@@ -1999,6 +2012,25 @@ func appendToastParam(redirectURL, message string) string {
 		base += "#" + fragment
 	}
 	return base
+}
+
+// formatScriptErrorsForToast formats script failures for display in a toast message.
+// Returns empty string if no failures occurred.
+func formatScriptErrorsForToast(scripts []workspace.ScriptResult) string {
+	var failures []string
+	for _, s := range scripts {
+		if s.ExitCode != 0 || s.Error != "" {
+			if s.Error != "" {
+				failures = append(failures, fmt.Sprintf("Script %s: %s", s.Script, s.Error))
+			} else {
+				failures = append(failures, fmt.Sprintf("Script %s exited with code %d", s.Script, s.ExitCode))
+			}
+		}
+	}
+	if len(failures) == 0 {
+		return ""
+	}
+	return strings.Join(failures, "; ")
 }
 
 // coverage-ignore: dashboard handler - tested via integration/manual testing

--- a/internal/dataentry/handlers_api.go
+++ b/internal/dataentry/handlers_api.go
@@ -400,6 +400,20 @@ type APICreateRelationRequest struct {
 	Properties map[string]interface{} `json:"properties,omitempty"`
 }
 
+// APIScriptError represents a script execution failure.
+type APIScriptError struct {
+	Script   string `json:"script"`
+	ExitCode int    `json:"exitCode,omitempty"`
+	Output   string `json:"output,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+// APIEntityResponse wraps an entity with optional script errors.
+type APIEntityResponse struct {
+	APIEntity
+	ScriptErrors []APIScriptError `json:"scriptErrors,omitempty"`
+}
+
 // handleAPICreateEntity handles POST /api/entities to create a new entity.
 func (a *App) handleAPICreateEntity(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -421,7 +435,7 @@ func (a *App) handleAPICreateEntity(w http.ResponseWriter, r *http.Request) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	entity, _, err := a.ws.CreateEntity(req.Type, workspace.CreateOptions{
+	entity, createResult, err := a.ws.CreateEntity(req.Type, workspace.CreateOptions{
 		ID:         req.ID,
 		Properties: req.Properties,
 		Content:    req.Content,
@@ -436,8 +450,9 @@ func (a *App) handleAPICreateEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Return created entity
-	result := a.entityToAPI(entity, false)
+	// Return created entity with script errors if any
+	result := APIEntityResponse{APIEntity: a.entityToAPI(entity, false)}
+	result.ScriptErrors = collectScriptErrors(createResult.ScriptsRun)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(result)
@@ -486,7 +501,8 @@ func (a *App) handleAPIUpdateEntity(w http.ResponseWriter, r *http.Request) {
 		entity.Content = *req.Content
 	}
 
-	if _, err := a.ws.UpdateEntity(entity, oldEntity); err != nil {
+	updateResult, err := a.ws.UpdateEntity(entity, oldEntity)
+	if err != nil {
 		var valErr *workspace.ValidationError
 		if errors.As(err, &valErr) {
 			writeJSONError(w, http.StatusBadRequest, "validation error: "+valErr.Errors[0].Error())
@@ -496,8 +512,9 @@ func (a *App) handleAPIUpdateEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Return updated entity
-	result := a.entityToAPI(entity, false)
+	// Return updated entity with script errors if any
+	result := APIEntityResponse{APIEntity: a.entityToAPI(entity, false)}
+	result.ScriptErrors = collectScriptErrors(updateResult.ScriptsRun)
 	writeJSON(w, result)
 }
 
@@ -703,4 +720,20 @@ func (a *App) edgeToAPIRelation(edge *model.Relation, relatedEntity *model.Entit
 		}
 	}
 	return rel
+}
+
+// collectScriptErrors converts script results to API errors (only failures).
+func collectScriptErrors(scripts []workspace.ScriptResult) []APIScriptError {
+	var result []APIScriptError
+	for _, s := range scripts {
+		if s.ExitCode != 0 || s.Error != "" {
+			result = append(result, APIScriptError{
+				Script:   s.Script,
+				ExitCode: s.ExitCode,
+				Output:   s.Output,
+				Error:    s.Error,
+			})
+		}
+	}
+	return result
 }

--- a/internal/dataentry/handlers_kanban.go
+++ b/internal/dataentry/handlers_kanban.go
@@ -306,12 +306,20 @@ func (a *App) handleKanbanMove(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Write entity through workspace
-	if _, err := a.ws.UpdateEntity(entity, oldEntity); err != nil {
+	updateResult, err := a.ws.UpdateEntity(entity, oldEntity)
+	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to write: %v", err), http.StatusInternalServerError)
 		return
 	}
 
 	log.Printf("Moved %s to %s=%s", entityID, kanban.ColumnProperty, column)
+
+	// Log script errors if any
+	for _, script := range updateResult.ScriptsRun {
+		if script.ExitCode != 0 || script.Error != "" {
+			log.Printf("Script %s failed: exitCode=%d error=%s", script.Script, script.ExitCode, script.Error)
+		}
+	}
 
 	// Re-render the kanban board
 	r.URL.Path = "/kanban/" + kanbanID

--- a/internal/mcp/tools_entity.go
+++ b/internal/mcp/tools_entity.go
@@ -155,7 +155,7 @@ func (s *Server) handleCreateEntity(
 		return errResult, nil
 	}
 
-	entity, _, createErr := s.ws.CreateEntity(resolvedType, workspace.CreateOptions{
+	entity, result, createErr := s.ws.CreateEntity(resolvedType, workspace.CreateOptions{
 		ID:         customID,
 		Properties: properties,
 		Content:    content,
@@ -168,7 +168,10 @@ func (s *Server) handleCreateEntity(
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
-	return mcp.NewToolResultText(fmt.Sprintf("Created %s %s\n\n%s", resolvedType, entity.ID, text)), nil
+
+	output := fmt.Sprintf("Created %s %s\n\n%s", resolvedType, entity.ID, text)
+	output += formatScriptResults(result.ScriptsRun)
+	return mcp.NewToolResultText(output), nil
 }
 
 func (s *Server) handleUpdateEntity(
@@ -208,7 +211,8 @@ func (s *Server) handleUpdateEntity(
 		entity.Content = content
 	}
 
-	if _, updateErr := s.ws.UpdateEntity(entity, oldEntity); updateErr != nil {
+	result, updateErr := s.ws.UpdateEntity(entity, oldEntity)
+	if updateErr != nil {
 		return mcp.NewToolResultError(updateErr.Error()), nil
 	}
 
@@ -216,7 +220,10 @@ func (s *Server) handleUpdateEntity(
 	if convertErr != nil {
 		return mcp.NewToolResultError(convertErr.Error()), nil
 	}
-	return mcp.NewToolResultText(fmt.Sprintf("Updated %s\n\n%s", id, text)), nil
+
+	output := fmt.Sprintf("Updated %s\n\n%s", id, text)
+	output += formatScriptResults(result.ScriptsRun)
+	return mcp.NewToolResultText(output), nil
 }
 
 func (s *Server) handleDeleteEntity(

--- a/internal/mcp/tools_entity.go
+++ b/internal/mcp/tools_entity.go
@@ -170,7 +170,7 @@ func (s *Server) handleCreateEntity(
 	}
 
 	output := fmt.Sprintf("Created %s %s\n\n%s", resolvedType, entity.ID, text)
-	output += formatScriptResults(result.ScriptsRun)
+	output += formatAutomationFeedback(result)
 	return mcp.NewToolResultText(output), nil
 }
 
@@ -222,7 +222,7 @@ func (s *Server) handleUpdateEntity(
 	}
 
 	output := fmt.Sprintf("Updated %s\n\n%s", id, text)
-	output += formatScriptResults(result.ScriptsRun)
+	output += formatAutomationFeedback(result)
 	return mcp.NewToolResultText(output), nil
 }
 

--- a/internal/mcp/tools_helpers.go
+++ b/internal/mcp/tools_helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 	"github.com/Sourcehaven-BV/rela/internal/search"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 func (s *Server) resolveType(typeName string) string {
@@ -246,4 +247,24 @@ func applyPagination[T any](items []T, offset, limit int) []T {
 		items = items[:limit]
 	}
 	return items
+}
+
+// formatScriptResults formats script execution results for MCP output.
+// Only failed scripts are shown to avoid cluttering successful responses.
+func formatScriptResults(scripts []workspace.ScriptResult) string {
+	var sb strings.Builder
+	for _, script := range scripts {
+		if script.ExitCode != 0 || script.Error != "" {
+			sb.WriteString("\n---\n")
+			if script.Error != "" {
+				sb.WriteString(fmt.Sprintf("Script %s failed: %s\n", script.Script, script.Error))
+			} else {
+				sb.WriteString(fmt.Sprintf("Script %s exited with code %d\n", script.Script, script.ExitCode))
+			}
+			if script.Output != "" {
+				sb.WriteString(fmt.Sprintf("Output: %s\n", script.Output))
+			}
+		}
+	}
+	return sb.String()
 }

--- a/internal/mcp/tools_helpers.go
+++ b/internal/mcp/tools_helpers.go
@@ -249,11 +249,29 @@ func applyPagination[T any](items []T, offset, limit int) []T {
 	return items
 }
 
-// formatScriptResults formats script execution results for MCP output.
-// Only failed scripts are shown to avoid cluttering successful responses.
-func formatScriptResults(scripts []workspace.ScriptResult) string {
+// AutomationResult is implemented by workspace.CreateResult and workspace.UpdateResult.
+type AutomationResult interface {
+	GetAutomationWarnings() []string
+	GetAutomationErrors() []string
+	GetRelationsCreated() []*model.Relation
+	GetScriptsRun() []workspace.ScriptResult
+}
+
+// formatAutomationFeedback formats all automation feedback for MCP output.
+// Only non-empty results are shown to avoid cluttering successful responses.
+func formatAutomationFeedback(result AutomationResult) string {
 	var sb strings.Builder
-	for _, script := range scripts {
+
+	for _, warning := range result.GetAutomationWarnings() {
+		sb.WriteString(fmt.Sprintf("\n⚠️ Automation: %s", warning))
+	}
+	for _, errMsg := range result.GetAutomationErrors() {
+		sb.WriteString(fmt.Sprintf("\n⚠️ Automation error: %s", errMsg))
+	}
+	for _, rel := range result.GetRelationsCreated() {
+		sb.WriteString(fmt.Sprintf("\nAutomation created relation: %s --%s--> %s", rel.From, rel.Type, rel.To))
+	}
+	for _, script := range result.GetScriptsRun() {
 		if script.ExitCode != 0 || script.Error != "" {
 			sb.WriteString("\n---\n")
 			if script.Error != "" {

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -261,12 +261,19 @@ type AutomationAction struct {
 	Set            string                `yaml:"set,omitempty"`
 	Value          string                `yaml:"value,omitempty"`
 	CreateRelation *CreateRelationAction `yaml:"create_relation,omitempty"`
+	Run            *RunAction            `yaml:"run,omitempty"`
 }
 
 // CreateRelationAction specifies parameters for creating a relation.
 type CreateRelationAction struct {
 	Relation string `yaml:"relation"`
 	To       string `yaml:"to"`
+}
+
+// RunAction specifies a script to execute.
+type RunAction struct {
+	Script string   `yaml:"script"`
+	Args   []string `yaml:"args,omitempty"`
 }
 
 // AutomationCheck specifies a validation condition.

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -325,6 +325,12 @@ func (r *CreateResult) GetRelationsCreated() []*model.Relation { return r.Relati
 // GetScriptsRun returns script execution results.
 func (r *CreateResult) GetScriptsRun() []ScriptResult { return r.ScriptsRun }
 
+// FormatErrors returns a concise error summary for display (e.g., in toasts).
+// Returns empty string if no errors occurred.
+func (r *CreateResult) FormatErrors() string {
+	return formatAutomationErrors(r.AutomationErrors, r.ScriptsRun)
+}
+
 // ScriptResult contains the outcome of running an automation script.
 type ScriptResult struct {
 	Script   string // Script that was executed
@@ -457,6 +463,12 @@ func (r *UpdateResult) GetRelationsCreated() []*model.Relation { return r.Relati
 
 // GetScriptsRun returns script execution results.
 func (r *UpdateResult) GetScriptsRun() []ScriptResult { return r.ScriptsRun }
+
+// FormatErrors returns a concise error summary for display (e.g., in toasts).
+// Returns empty string if no errors occurred.
+func (r *UpdateResult) FormatErrors() string {
+	return formatAutomationErrors(r.AutomationErrors, r.ScriptsRun)
+}
 
 // UpdateEntity validates and writes an existing entity, runs automation,
 // and updates the graph.
@@ -783,4 +795,24 @@ func (w *Workspace) runScripts(scripts []automation.ScriptToRun) []ScriptResult 
 // file access (e.g., attachment store, writing output files).
 func (w *Workspace) FS() storage.FS {
 	return w.repo.FS()
+}
+
+// formatAutomationErrors formats automation errors and script failures into
+// a concise string for display in toasts or similar UI elements.
+func formatAutomationErrors(automationErrors []string, scripts []ScriptResult) string {
+	failures := make([]string, 0, len(automationErrors)+len(scripts))
+	failures = append(failures, automationErrors...)
+	for _, s := range scripts {
+		if s.ExitCode != 0 || s.Error != "" {
+			if s.Error != "" {
+				failures = append(failures, fmt.Sprintf("Script %s: %s", s.Script, s.Error))
+			} else {
+				failures = append(failures, fmt.Sprintf("Script %s exited with code %d", s.Script, s.ExitCode))
+			}
+		}
+	}
+	if len(failures) == 0 {
+		return ""
+	}
+	return strings.Join(failures, "; ")
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -313,6 +313,18 @@ type CreateResult struct {
 	ScriptsRun         []ScriptResult
 }
 
+// GetAutomationWarnings returns automation warnings.
+func (r *CreateResult) GetAutomationWarnings() []string { return r.AutomationWarnings }
+
+// GetAutomationErrors returns automation errors.
+func (r *CreateResult) GetAutomationErrors() []string { return r.AutomationErrors }
+
+// GetRelationsCreated returns relations created by automation.
+func (r *CreateResult) GetRelationsCreated() []*model.Relation { return r.RelationsCreated }
+
+// GetScriptsRun returns script execution results.
+func (r *CreateResult) GetScriptsRun() []ScriptResult { return r.ScriptsRun }
+
 // ScriptResult contains the outcome of running an automation script.
 type ScriptResult struct {
 	Script   string // Script that was executed
@@ -433,6 +445,18 @@ type UpdateResult struct {
 	RelationsCreated   []*model.Relation
 	ScriptsRun         []ScriptResult
 }
+
+// GetAutomationWarnings returns automation warnings.
+func (r *UpdateResult) GetAutomationWarnings() []string { return r.AutomationWarnings }
+
+// GetAutomationErrors returns automation errors.
+func (r *UpdateResult) GetAutomationErrors() []string { return r.AutomationErrors }
+
+// GetRelationsCreated returns relations created by automation.
+func (r *UpdateResult) GetRelationsCreated() []*model.Relation { return r.RelationsCreated }
+
+// GetScriptsRun returns script execution results.
+func (r *UpdateResult) GetScriptsRun() []ScriptResult { return r.ScriptsRun }
 
 // UpdateEntity validates and writes an existing entity, runs automation,
 // and updates the graph.

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -6,8 +6,12 @@
 package workspace
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"log"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -306,6 +310,15 @@ type CreateResult struct {
 	AutomationWarnings []string
 	AutomationErrors   []string
 	RelationsCreated   []*model.Relation
+	ScriptsRun         []ScriptResult
+}
+
+// ScriptResult contains the outcome of running an automation script.
+type ScriptResult struct {
+	Script   string // Script that was executed
+	ExitCode int    // Exit code (0 = success)
+	Output   string // Combined stdout/stderr
+	Error    string // Error message if execution failed
 }
 
 // CreateEntity generates an ID (unless provided), applies templates and
@@ -388,8 +401,9 @@ func (w *Workspace) CreateEntity(entityType string, opts CreateOptions) (*model.
 	}
 	w.graph.AddNode(entity)
 
-	// Create automation relations (re-run to pick up RelationsToCreate;
-	// the first run above only captured property changes).
+	// Create automation relations and run scripts (re-run to pick up
+	// RelationsToCreate and ScriptsToRun; the first run above only
+	// captured property changes).
 	if w.automation != nil {
 		autoResult := w.automation.Process(automation.Event{
 			Type:   automation.EventEntityCreated,
@@ -404,6 +418,8 @@ func (w *Workspace) CreateEntity(entityType string, opts CreateOptions) (*model.
 			w.graph.AddEdge(rel)
 			result.RelationsCreated = append(result.RelationsCreated, rel)
 		}
+		// Run scripts after all entity operations complete
+		result.ScriptsRun = w.runScripts(autoResult.ScriptsToRun)
 	}
 
 	w.saveCacheQuietly()
@@ -415,6 +431,7 @@ type UpdateResult struct {
 	AutomationWarnings []string
 	AutomationErrors   []string
 	RelationsCreated   []*model.Relation
+	ScriptsRun         []ScriptResult
 }
 
 // UpdateEntity validates and writes an existing entity, runs automation,
@@ -430,6 +447,7 @@ func (w *Workspace) UpdateEntity(entity, oldEntity *model.Entity) (*UpdateResult
 	result := &UpdateResult{}
 
 	// Run automation.
+	var scriptsToRun []automation.ScriptToRun
 	if w.automation != nil && oldEntity != nil {
 		autoResult := w.automation.Process(automation.Event{
 			Type:      automation.EventEntityUpdated,
@@ -451,6 +469,7 @@ func (w *Workspace) UpdateEntity(entity, oldEntity *model.Entity) (*UpdateResult
 			w.graph.AddEdge(rel)
 			result.RelationsCreated = append(result.RelationsCreated, rel)
 		}
+		scriptsToRun = autoResult.ScriptsToRun
 	}
 
 	// Write to disk + update graph.
@@ -458,6 +477,9 @@ func (w *Workspace) UpdateEntity(entity, oldEntity *model.Entity) (*UpdateResult
 		return nil, fmt.Errorf("write entity: %w", err)
 	}
 	w.graph.AddNode(entity)
+
+	// Run scripts after all entity operations complete
+	result.ScriptsRun = w.runScripts(scriptsToRun)
 
 	w.saveCacheQuietly()
 	return result, nil
@@ -682,6 +704,53 @@ func (w *Workspace) ExecuteView(viewName, entryID string) (*views.ViewResult, er
 
 	engine := views.NewEngine(w.graph, w.meta)
 	return engine.Execute(viewDef, entryID)
+}
+
+// --- Script execution ---
+
+// runScripts executes automation scripts and returns the results.
+func (w *Workspace) runScripts(scripts []automation.ScriptToRun) []ScriptResult {
+	if len(scripts) == 0 {
+		return nil
+	}
+
+	results := make([]ScriptResult, 0, len(scripts))
+	projectRoot := w.Paths().Root
+
+	for _, script := range scripts {
+		result := ScriptResult{Script: script.Script}
+
+		// Resolve script path relative to project root
+		scriptPath := script.Script
+		if !filepath.IsAbs(scriptPath) {
+			scriptPath = filepath.Join(projectRoot, scriptPath)
+		}
+
+		// Execute the script
+		cmd := exec.Command(scriptPath, script.Args...)
+		cmd.Dir = projectRoot
+
+		var output bytes.Buffer
+		cmd.Stdout = &output
+		cmd.Stderr = &output
+
+		err := cmd.Run()
+		result.Output = output.String()
+
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				result.ExitCode = exitErr.ExitCode()
+			} else {
+				result.ExitCode = -1
+				result.Error = err.Error()
+			}
+		}
+
+		results = append(results, result)
+	}
+
+	return results
 }
 
 // --- Filesystem access ---


### PR DESCRIPTION
## Summary
- Adds `run` action type to the automation system for executing external scripts
- Scripts execute synchronously after entity operations complete
- Script errors are displayed to users in CLI, data entry UI, and MCP responses

## Changes
- **Automation engine**: New `RunAction` type with script path and templated arguments
- **Workspace**: `runScripts()` function executes scripts and captures exit codes/output
- **CLI**: Shows script errors via `WriteError()` after create/update
- **Data entry UI**: Appends script errors to toast messages, returns `scriptErrors` in JSON API
- **MCP**: Includes script failure details in tool response text

## Example usage
```yaml
automations:
  - name: notify-on-complete
    trigger:
      event: entity_updated
      entity_type: task
      property: status
      becomes: done
    actions:
      - run:
          script: scripts/notify.sh
          args: ["{{entity.id}}", "{{new.status}}"]
```

## Test plan
- [x] Unit tests for automation engine run action
- [x] Unit tests for template interpolation in script args
- [x] All existing tests pass
- [x] Linter passes