### PR TITLE
ArrowLeft goes to Back instead of Prev; Cmd+Enter does not save form

### DIFF
--- a/internal/dataentry/static/app.js
+++ b/internal/dataentry/static/app.js
@@ -5,8 +5,8 @@ document.addEventListener('keydown', function(e) {
   if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
   var nav = document.querySelector('.scope-nav');
   if (!nav) return;
-  if (e.key === 'ArrowLeft') { var btn = nav.querySelector('a.scope-nav-btn'); if (btn) btn.click(); }
-  if (e.key === 'ArrowRight') { var btns = nav.querySelectorAll('a.scope-nav-btn'); if (btns.length > 0) btns[btns.length-1].click(); }
+  if (e.key === 'ArrowLeft') { var btn = nav.querySelector('a[data-scope-dir="prev"]'); if (btn) btn.click(); }
+  if (e.key === 'ArrowRight') { var btn = nav.querySelector('a[data-scope-dir="next"]'); if (btn) btn.click(); }
 });
 
 // Sticky detection for filter-bar
@@ -1164,9 +1164,9 @@ document.addEventListener('click', function(e) {
     // Cmd/Ctrl+Enter: scan DOM for a matching <kbd> on a submit button
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
       var kbdMap = scanKbdShortcuts();
-      if (kbdMap['meta+enter']) {
+      if (kbdMap['meta+Enter']) {
         e.preventDefault();
-        kbdMap['meta+enter'].click();
+        kbdMap['meta+Enter'].click();
       }
       return;
     }

--- a/internal/dataentry/templates/entity.html
+++ b/internal/dataentry/templates/entity.html
@@ -19,16 +19,16 @@
 {{- define "scope-nav" -}}
 {{ if .Scope }}
 <div class="scope-nav">
-  <a href="{{ .Scope.BackURL }}" hx-get="{{ .Scope.BackURL }}" hx-target="#content" hx-push-url="true" class="scope-nav-btn">&larr; Back <kbd>Esc</kbd></a>
+  <a href="{{ .Scope.BackURL }}" hx-get="{{ .Scope.BackURL }}" hx-target="#content" hx-push-url="true" class="scope-nav-btn">Back <kbd>Esc</kbd></a>
   {{ if .Scope.PrevURL }}
-  <a href="{{ .Scope.PrevURL }}" hx-get="{{ .Scope.PrevURL }}" hx-target="#content" hx-push-url="true" class="scope-nav-btn">Prev</a>
+  <a href="{{ .Scope.PrevURL }}" hx-get="{{ .Scope.PrevURL }}" hx-target="#content" hx-push-url="true" class="scope-nav-btn" data-scope-dir="prev">&larr; Prev</a>
   {{ else }}
   <span class="scope-nav-disabled">Prev</span>
   {{ end }}
   <span class="scope-nav-progress">{{ .Scope.Progress }}</span>
   <span class="scope-nav-label">{{ .Scope.Label }}</span>
   {{ if .Scope.NextURL }}
-  <a href="{{ .Scope.NextURL }}" hx-get="{{ .Scope.NextURL }}" hx-target="#content" hx-push-url="true" class="scope-nav-btn">Next &rarr;</a>
+  <a href="{{ .Scope.NextURL }}" hx-get="{{ .Scope.NextURL }}" hx-target="#content" hx-push-url="true" class="scope-nav-btn" data-scope-dir="next">Next &rarr;</a>
   {{ else }}
   <span class="scope-nav-disabled">Next &rarr;</span>
   {{ end }}

--- a/tickets/entities/bugs/BUG-010.md
+++ b/tickets/entities/bugs/BUG-010.md
@@ -1,0 +1,35 @@
+---
+description: Two keyboard shortcuts in the data entry UI were broken — ArrowLeft navigated Back instead of Prev, and Cmd+Enter did not submit forms despite the shortcut being shown on the Save button.
+effort: xs
+id: BUG-010
+prevention: Add explicit `data-scope-dir` attributes to navigation anchors so JS never relies on DOM order. Define shortcut key strings as shared constants between the normalizer and the lookup to prevent casing drift.
+priority: low
+status: done
+title: ArrowLeft goes to Back instead of Prev; Cmd+Enter does not save form
+type: bug
+why1: ArrowLeft used `querySelector('a.scope-nav-btn')` which always returns the first matching element — the Back button. Cmd+Enter looked up `kbdMap['meta+enter']` (lowercase) while `_normalizeKbdKey` returns `'meta+Enter'` (capital E), so the key was never found.
+why2: Navigation buttons had no distinguishing attributes; the handler assumed positional order was stable. The shortcut key casing between normalization and lookup was never verified to be consistent.
+why3: No tests exist for the keyboard shortcut handlers in the data entry JavaScript layer, so the regressions went undetected.
+why4: Frontend JS in the data entry app is treated as too simple to warrant testing, even though it handles user-facing interactions that are not exercised by the Go test suite.
+why5: There is no E2E or smoke test suite covering keyboard shortcuts in the data entry UI, leaving this class of bug invisible until manually discovered.
+---
+
+# ArrowLeft goes to Back instead of Prev; Cmd+Enter does not save form
+
+## Observed behaviour
+
+- Pressing **ArrowLeft** in the entity view navigated to the **Back** (list) URL instead of the **Prev** entity in the current scope.
+- Pressing **Cmd+Enter** (shown as ⌘↵ on the Save button) in any form did nothing.
+
+## Root cause
+
+**ArrowLeft:** `app.js` used `nav.querySelector('a.scope-nav-btn')` to find the target. This selector always returns the *first* matching anchor, which is the Back button. Prev and Next had no distinguishing attribute.
+
+**Cmd+Enter:** `_normalizeKbdKey` returns `'meta+Enter'` (capital E) but the keydown handler looked up `kbdMap['meta+enter']` (lowercase e). The key was never found in the map.
+
+## Fix
+
+- Added `data-scope-dir="prev"` and `data-scope-dir="next"` to the conditional `<a>` elements in `entity.html`.
+- Updated the ArrowLeft/ArrowRight handlers to use `nav.querySelector('a[data-scope-dir="prev/next"]')`.
+- Changed the Cmd+Enter lookup from `kbdMap['meta+enter']` to `kbdMap['meta+Enter']` to match the normalizer output.
+


### PR DESCRIPTION
## Observed behaviour

- Pressing **ArrowLeft** in the entity view navigated to the **Back** (list) URL instead of the **Prev** entity in the current scope.
- Pressing **Cmd+Enter** (shown as ⌘↵ on the Save button) in any form did nothing.

## Root cause

**ArrowLeft:** `app.js` used `nav.querySelector('a.scope-nav-btn')` to find the target. This selector always returns the *first* matching anchor, which is the Back button. Prev and Next had no distinguishing attribute.

**Cmd+Enter:** `_normalizeKbdKey` returns `'meta+Enter'` (capital E) but the keydown handler looked up `kbdMap['meta+enter']` (lowercase e). The key was never found in the map.

## Fix

- Added `data-scope-dir="prev"` and `data-scope-dir="next"` to the conditional `<a>` elements in `entity.html`.
- Updated the ArrowLeft/ArrowRight handlers to use `nav.querySelector('a[data-scope-dir="prev/next"]')`.
- Changed the Cmd+Enter lookup from `kbdMap['meta+enter']` to `kbdMap['meta+Enter']` to match the normalizer output.

