### PR TITLE
add relation-based filter controls to list views with navigator fix

### DIFF
--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -61,30 +61,26 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 
 	// Apply query param filters
 	for _, fc := range list.FilterControls {
-		if fc.Relation != "" {
-			if val := r.URL.Query().Get("filter_" + fc.Relation); val != "" {
-				entities = a.filterByRelation(entities, fc.Relation, val)
-			}
+		val := r.URL.Query().Get("filter_" + fc.Key())
+		if val == "" {
+			continue
+		}
+		if fc.IsRelation() {
+			entities = a.filterByRelation(entities, fc.Relation, val)
 		} else {
-			if val := r.URL.Query().Get("filter_" + fc.Property); val != "" {
-				entities = applyFilters(entities, []FilterConfig{{
-					Property: fc.Property,
-					Operator: "=",
-					Value:    val,
-				}})
-			}
+			entities = applyFilters(entities, []FilterConfig{{
+				Property: fc.Property,
+				Operator: "=",
+				Value:    val,
+			}})
 		}
 	}
 
 	// Build active filter query params for URL construction
 	var filterParams string
 	for _, fc := range list.FilterControls {
-		key := fc.Property
-		if fc.Relation != "" {
-			key = fc.Relation
-		}
-		if val := r.URL.Query().Get("filter_" + key); val != "" {
-			filterParams += "&filter_" + url.QueryEscape(key) + "=" + url.QueryEscape(val)
+		if val := r.URL.Query().Get("filter_" + fc.Key()); val != "" {
+			filterParams += "&filter_" + url.QueryEscape(fc.Key()) + "=" + url.QueryEscape(val)
 		}
 	}
 
@@ -190,35 +186,25 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 	}
 	filterControls := make([]ResolvedFC, 0, len(list.FilterControls))
 	for _, fc := range list.FilterControls {
-		if fc.Relation != "" {
+		label := fc.Label
+		if label == "" {
+			label = titleCase(fc.Key())
+		}
+		rfc := ResolvedFC{
+			Property: fc.Key(),
+			Label:    label,
+			Current:  r.URL.Query().Get("filter_" + fc.Key()),
+		}
+		if fc.IsRelation() {
 			allEntities := a.g.NodesByType(list.EntityType)
-			vals := a.resolveRelationFilterValues(allEntities, fc.Relation)
-			label := fc.Label
-			if label == "" {
-				label = titleCase(fc.Relation)
-			}
-			filterControls = append(filterControls, ResolvedFC{
-				Property: fc.Relation,
-				Label:    label,
-				Widget:   "select",
-				Values:   vals,
-				Current:  r.URL.Query().Get("filter_" + fc.Relation),
-			})
+			rfc.Values = a.resolveRelationFilterValues(allEntities, fc.Relation)
+			rfc.Widget = "select"
 		} else {
 			prop := entDef.Properties[fc.Property]
-			vals := resolvePropertyValues(prop, a.meta)
-			label := fc.Label
-			if label == "" {
-				label = titleCase(fc.Property)
-			}
-			filterControls = append(filterControls, ResolvedFC{
-				Property: fc.Property,
-				Label:    label,
-				Widget:   resolveWidget(prop, a.meta),
-				Values:   vals,
-				Current:  r.URL.Query().Get("filter_" + fc.Property),
-			})
+			rfc.Values = resolvePropertyValues(prop, a.meta)
+			rfc.Widget = resolveWidget(prop, a.meta)
 		}
+		filterControls = append(filterControls, rfc)
 	}
 
 	// Resolve relation data for display

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -185,6 +185,7 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 		Current  string
 	}
 	filterControls := make([]ResolvedFC, 0, len(list.FilterControls))
+	var allEntities []*model.Entity // lazily initialized for relation filters
 	for _, fc := range list.FilterControls {
 		label := fc.Label
 		if label == "" {
@@ -196,9 +197,11 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 			Current:  r.URL.Query().Get("filter_" + fc.Key()),
 		}
 		if fc.IsRelation() {
-			allEntities := a.g.NodesByType(list.EntityType)
+			if allEntities == nil {
+				allEntities = a.g.NodesByType(list.EntityType)
+			}
 			rfc.Values = a.resolveRelationFilterValues(allEntities, fc.Relation)
-			rfc.Widget = "select"
+			rfc.Widget = WidgetSelect
 		} else {
 			prop := entDef.Properties[fc.Property]
 			rfc.Values = resolvePropertyValues(prop, a.meta)

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -61,21 +61,30 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 
 	// Apply query param filters
 	for _, fc := range list.FilterControls {
-		val := r.URL.Query().Get("filter_" + fc.Property)
-		if val != "" {
-			entities = applyFilters(entities, []FilterConfig{{
-				Property: fc.Property,
-				Operator: "=",
-				Value:    val,
-			}})
+		if fc.Relation != "" {
+			if val := r.URL.Query().Get("filter_" + fc.Relation); val != "" {
+				entities = a.filterByRelation(entities, fc.Relation, val)
+			}
+		} else {
+			if val := r.URL.Query().Get("filter_" + fc.Property); val != "" {
+				entities = applyFilters(entities, []FilterConfig{{
+					Property: fc.Property,
+					Operator: "=",
+					Value:    val,
+				}})
+			}
 		}
 	}
 
 	// Build active filter query params for URL construction
 	var filterParams string
 	for _, fc := range list.FilterControls {
-		if val := r.URL.Query().Get("filter_" + fc.Property); val != "" {
-			filterParams += "&filter_" + url.QueryEscape(fc.Property) + "=" + url.QueryEscape(val)
+		key := fc.Property
+		if fc.Relation != "" {
+			key = fc.Relation
+		}
+		if val := r.URL.Query().Get("filter_" + key); val != "" {
+			filterParams += "&filter_" + url.QueryEscape(key) + "=" + url.QueryEscape(val)
 		}
 	}
 
@@ -181,15 +190,35 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 	}
 	filterControls := make([]ResolvedFC, 0, len(list.FilterControls))
 	for _, fc := range list.FilterControls {
-		prop := entDef.Properties[fc.Property]
-		vals := resolvePropertyValues(prop, a.meta)
-		filterControls = append(filterControls, ResolvedFC{
-			Property: fc.Property,
-			Label:    titleCase(fc.Property),
-			Widget:   resolveWidget(prop, a.meta),
-			Values:   vals,
-			Current:  r.URL.Query().Get("filter_" + fc.Property),
-		})
+		if fc.Relation != "" {
+			allEntities := a.g.NodesByType(list.EntityType)
+			vals := a.resolveRelationFilterValues(allEntities, fc.Relation)
+			label := fc.Label
+			if label == "" {
+				label = titleCase(fc.Relation)
+			}
+			filterControls = append(filterControls, ResolvedFC{
+				Property: fc.Relation,
+				Label:    label,
+				Widget:   "select",
+				Values:   vals,
+				Current:  r.URL.Query().Get("filter_" + fc.Relation),
+			})
+		} else {
+			prop := entDef.Properties[fc.Property]
+			vals := resolvePropertyValues(prop, a.meta)
+			label := fc.Label
+			if label == "" {
+				label = titleCase(fc.Property)
+			}
+			filterControls = append(filterControls, ResolvedFC{
+				Property: fc.Property,
+				Label:    label,
+				Widget:   resolveWidget(prop, a.meta),
+				Values:   vals,
+				Current:  r.URL.Query().Get("filter_" + fc.Property),
+			})
+		}
 	}
 
 	// Resolve relation data for display
@@ -1180,6 +1209,19 @@ func (a *App) createFormRelations(entityID string, relations []FormRelation, ent
 		if rel.Display != "" {
 			continue
 		}
+		// Resolve direction from metamodel if not specified in config (mirrors handleForm logic).
+		direction := rel.Direction
+		if direction == "" {
+			if relDef, ok := a.meta.GetRelationDef(rel.Relation); ok {
+				inFrom := containsString(relDef.From, entityType)
+				inTo := containsString(relDef.To, entityType)
+				if inFrom && !inTo {
+					direction = DirectionOutgoing
+				} else if inTo && !inFrom {
+					direction = DirectionIncoming
+				}
+			}
+		}
 		values := r.Form[rel.Relation]
 		if len(values) == 0 && a.userDefaults != nil {
 			if defaultTarget := a.userDefaults.ResolveRelationDefault(entityType, rel.Relation); defaultTarget != "" {
@@ -1191,7 +1233,7 @@ func (a *App) createFormRelations(entityID string, relations []FormRelation, ent
 				continue
 			}
 			var fromID, toID string
-			if rel.Direction == DirectionIncoming {
+			if direction == DirectionIncoming {
 				fromID, toID = targetID, entityID
 			} else {
 				fromID, toID = entityID, targetID
@@ -1457,7 +1499,20 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		if rel.Display != "" {
 			continue
 		}
-		if rel.Direction == DirectionIncoming {
+		// Resolve direction from metamodel if not specified in config (mirrors handleForm logic).
+		direction := rel.Direction
+		if direction == "" {
+			if relDef, ok := a.meta.GetRelationDef(rel.Relation); ok {
+				inFrom := containsString(relDef.From, form.EntityType)
+				inTo := containsString(relDef.To, form.EntityType)
+				if inFrom && !inTo {
+					direction = DirectionOutgoing
+				} else if inTo && !inFrom {
+					direction = DirectionIncoming
+				}
+			}
+		}
+		if direction == DirectionIncoming {
 			for _, edge := range a.g.IncomingEdges(entityID) {
 				if edge.Type == rel.Relation {
 					if delErr := a.ws.DeleteRelation(edge.From, edge.Type, edge.To); delErr != nil {
@@ -1480,7 +1535,7 @@ func (a *App) handleUpdate(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			var fromID, toID string
-			if rel.Direction == DirectionIncoming {
+			if direction == DirectionIncoming {
 				fromID, toID = targetID, entityID
 			} else {
 				fromID, toID = entityID, targetID

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -59,9 +59,11 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 	entities := a.g.NodesByType(list.EntityType)
 	entities = applyFilters(entities, list.Filters)
 
-	// Apply query param filters
+	// Apply query param filters and build filter params for URL construction
+	query := r.URL.Query()
+	var filterParams string
 	for _, fc := range list.FilterControls {
-		val := r.URL.Query().Get("filter_" + fc.Key())
+		val := fc.CurrentValue(query)
 		if val == "" {
 			continue
 		}
@@ -74,14 +76,7 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 				Value:    val,
 			}})
 		}
-	}
-
-	// Build active filter query params for URL construction
-	var filterParams string
-	for _, fc := range list.FilterControls {
-		if val := r.URL.Query().Get("filter_" + fc.Key()); val != "" {
-			filterParams += "&filter_" + url.QueryEscape(fc.Key()) + "=" + url.QueryEscape(val)
-		}
+		filterParams += "&" + url.QueryEscape(fc.QueryParamKey()) + "=" + url.QueryEscape(val)
 	}
 
 	// Resolve effective sort (query params override config default)
@@ -194,7 +189,7 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 		rfc := ResolvedFC{
 			Property: fc.Key(),
 			Label:    label,
-			Current:  r.URL.Query().Get("filter_" + fc.Key()),
+			Current:  fc.CurrentValue(query),
 		}
 		if fc.IsRelation() {
 			if allEntities == nil {

--- a/internal/dataentry/handlers_test.go
+++ b/internal/dataentry/handlers_test.go
@@ -270,6 +270,169 @@ func TestHandleList(t *testing.T) {
 			t.Error("expected 'feature' in multi-select column")
 		}
 	})
+
+	t.Run("relation-based filter control filters list", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+
+		// Add relation to existing tickets
+		app.g.AddEdge(model.NewRelation("TKT-001", "belongs_to", "CMP-001"))
+
+		// Configure list with relation-based filter
+		app.Cfg.Lists["tickets"] = List{
+			EntityType: "ticket",
+			Title:      "Tickets",
+			Columns: []ListColumn{
+				{Property: "title", Label: "Title"},
+			},
+			FilterControls: []FilterControl{
+				{Relation: "belongs_to"},
+			},
+		}
+
+		// Request with relation filter
+		r := httptest.NewRequest(http.MethodGet, "/list/tickets?filter_belongs_to=Frontend", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleList(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		// TKT-001 belongs to CMP-001 (Frontend), so should be in results
+		if !strings.Contains(body, "TKT-001") {
+			t.Error("expected TKT-001 in filtered results")
+		}
+		// TKT-002 does not belong to Frontend
+		if strings.Contains(body, "TKT-002") {
+			t.Error("TKT-002 should be filtered out")
+		}
+	})
+
+	t.Run("relation-based filter shows select with target titles", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+
+		// Add relation to existing tickets
+		app.g.AddEdge(model.NewRelation("TKT-001", "belongs_to", "CMP-001"))
+
+		// Configure list with relation-based filter
+		app.Cfg.Lists["tickets"] = List{
+			EntityType: "ticket",
+			Title:      "Tickets",
+			Columns: []ListColumn{
+				{Property: "title", Label: "Title"},
+			},
+			FilterControls: []FilterControl{
+				{Relation: "belongs_to"},
+			},
+		}
+
+		r := httptest.NewRequest(http.MethodGet, "/list/tickets", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleList(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		// Should show "Frontend" as a filter option (CMP-001's name)
+		if !strings.Contains(body, "Frontend") {
+			t.Error("expected 'Frontend' as filter option in relation filter control")
+		}
+	})
+
+	t.Run("filter control with custom label", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+
+		// Configure list with property filter and custom label
+		app.Cfg.Lists["tickets"] = List{
+			EntityType: "ticket",
+			Title:      "Tickets",
+			Columns: []ListColumn{
+				{Property: "title", Label: "Title"},
+			},
+			FilterControls: []FilterControl{
+				{Property: "status", Label: "Ticket Status"},
+			},
+		}
+
+		r := httptest.NewRequest(http.MethodGet, "/list/tickets", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleList(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		// Should use custom label
+		if !strings.Contains(body, "Ticket Status") {
+			t.Error("expected custom label 'Ticket Status' in filter control")
+		}
+	})
+
+	t.Run("relation filter control with custom label", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+
+		// Add relation to existing tickets
+		app.g.AddEdge(model.NewRelation("TKT-001", "belongs_to", "CMP-001"))
+
+		// Configure list with relation filter and custom label
+		app.Cfg.Lists["tickets"] = List{
+			EntityType: "ticket",
+			Title:      "Tickets",
+			Columns: []ListColumn{
+				{Property: "title", Label: "Title"},
+			},
+			FilterControls: []FilterControl{
+				{Relation: "belongs_to", Label: "Component"},
+			},
+		}
+
+		r := httptest.NewRequest(http.MethodGet, "/list/tickets", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleList(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		// Should use custom label "Component" instead of "Belongs To"
+		if !strings.Contains(body, "Component") {
+			t.Error("expected custom label 'Component' in relation filter control")
+		}
+	})
+
+	t.Run("filter params preserved in pagination links", func(t *testing.T) {
+		app := newHandlerTestApp(t)
+
+		// Add more tickets for pagination
+		for i := 3; i <= 5; i++ {
+			e := model.NewEntity("TKT-00"+string(rune('0'+i)), "ticket")
+			e.SetString("title", "Ticket "+string(rune('0'+i)))
+			e.SetString("status", "open")
+			app.g.AddNode(e)
+		}
+
+		// Configure list with pagination and filter
+		app.Cfg.Lists["tickets"] = List{
+			EntityType: "ticket",
+			Title:      "Tickets",
+			PageSize:   2,
+			Columns: []ListColumn{
+				{Property: "title", Label: "Title"},
+			},
+			FilterControls: []FilterControl{
+				{Property: "status"},
+			},
+		}
+
+		r := httptest.NewRequest(http.MethodGet, "/list/tickets?filter_status=open", http.NoBody)
+		w := httptest.NewRecorder()
+		app.handleList(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		// Pagination links should preserve filter params
+		if !strings.Contains(body, "filter_status=open") {
+			t.Error("expected filter_status=open in pagination or list links")
+		}
+	})
 }
 
 func TestHandleForm(t *testing.T) {

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -580,18 +580,18 @@ func (a *App) resolveScope(currentEntityID string, r *http.Request) *ScopeNav {
 
 		// Apply dynamic filter params (same as handleList)
 		for _, fc := range list.FilterControls {
-			if fc.Relation != "" {
-				if val := r.URL.Query().Get("filter_" + fc.Relation); val != "" {
-					entities = a.filterByRelation(entities, fc.Relation, val)
-				}
+			val := r.URL.Query().Get("filter_" + fc.Key())
+			if val == "" {
+				continue
+			}
+			if fc.IsRelation() {
+				entities = a.filterByRelation(entities, fc.Relation, val)
 			} else {
-				if val := r.URL.Query().Get("filter_" + fc.Property); val != "" {
-					entities = applyFilters(entities, []FilterConfig{{
-						Property: fc.Property,
-						Operator: "=",
-						Value:    val,
-					}})
-				}
+				entities = applyFilters(entities, []FilterConfig{{
+					Property: fc.Property,
+					Operator: "=",
+					Value:    val,
+				}})
 			}
 		}
 

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -499,6 +499,53 @@ func (a *App) resolveRelationColumnValues(entityID, relationType string) []strin
 	return titles
 }
 
+// filterByRelation filters entities to those that have an outgoing edge of the given
+// relation type pointing to a target whose display title matches value.
+func (a *App) filterByRelation(entities []*model.Entity, relationType, value string) []*model.Entity {
+	var result []*model.Entity
+	for _, e := range entities {
+		for _, edge := range a.g.OutgoingEdges(e.ID) {
+			if edge.Type != relationType {
+				continue
+			}
+			target, ok := a.g.GetNode(edge.To)
+			if !ok {
+				continue
+			}
+			if a.entityDisplayTitle(target) == value {
+				result = append(result, e)
+				break
+			}
+		}
+	}
+	return result
+}
+
+// resolveRelationFilterValues returns sorted, unique display titles of all entities
+// reachable via the given relation type from any of the provided entities.
+func (a *App) resolveRelationFilterValues(entities []*model.Entity, relationType string) []string {
+	seen := make(map[string]bool)
+	var vals []string
+	for _, e := range entities {
+		for _, edge := range a.g.OutgoingEdges(e.ID) {
+			if edge.Type != relationType {
+				continue
+			}
+			target, ok := a.g.GetNode(edge.To)
+			if !ok {
+				continue
+			}
+			title := a.entityDisplayTitle(target)
+			if !seen[title] {
+				seen[title] = true
+				vals = append(vals, title)
+			}
+		}
+	}
+	sort.Strings(vals)
+	return vals
+}
+
 // ScopeNav holds prev/next navigation context for browsing through a list of entities.
 type ScopeNav struct {
 	PrevURL  string // URL for previous entity (empty if at first)
@@ -533,13 +580,18 @@ func (a *App) resolveScope(currentEntityID string, r *http.Request) *ScopeNav {
 
 		// Apply dynamic filter params (same as handleList)
 		for _, fc := range list.FilterControls {
-			val := r.URL.Query().Get("filter_" + fc.Property)
-			if val != "" {
-				entities = applyFilters(entities, []FilterConfig{{
-					Property: fc.Property,
-					Operator: "=",
-					Value:    val,
-				}})
+			if fc.Relation != "" {
+				if val := r.URL.Query().Get("filter_" + fc.Relation); val != "" {
+					entities = a.filterByRelation(entities, fc.Relation, val)
+				}
+			} else {
+				if val := r.URL.Query().Get("filter_" + fc.Property); val != "" {
+					entities = applyFilters(entities, []FilterConfig{{
+						Property: fc.Property,
+						Operator: "=",
+						Value:    val,
+					}})
+				}
 			}
 		}
 

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -1115,6 +1115,211 @@ func TestIsRelationLinked(t *testing.T) {
 	}
 }
 
+func TestFilterByRelation(t *testing.T) {
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string"},
+				},
+			},
+			"component": {
+				Properties: map[string]metamodel.PropertyDef{
+					"name": {Type: "string", Required: true},
+				},
+			},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"belongs_to": {
+				Label: "belongs to",
+				From:  []string{"ticket"},
+				To:    []string{"component"},
+			},
+		},
+	}
+
+	g := graph.New()
+
+	// Create components
+	cmp1 := model.NewEntity("CMP-001", "component")
+	cmp1.SetString("name", "Frontend")
+	g.AddNode(cmp1)
+
+	cmp2 := model.NewEntity("CMP-002", "component")
+	cmp2.SetString("name", "Backend")
+	g.AddNode(cmp2)
+
+	// Create tickets with relations to components
+	t1 := model.NewEntity("TKT-001", "ticket")
+	t1.SetString("title", "Frontend bug")
+	g.AddNode(t1)
+	g.AddEdge(&model.Relation{From: "TKT-001", Type: "belongs_to", To: "CMP-001"})
+
+	t2 := model.NewEntity("TKT-002", "ticket")
+	t2.SetString("title", "Backend bug")
+	g.AddNode(t2)
+	g.AddEdge(&model.Relation{From: "TKT-002", Type: "belongs_to", To: "CMP-002"})
+
+	t3 := model.NewEntity("TKT-003", "ticket")
+	t3.SetString("title", "Another frontend bug")
+	g.AddNode(t3)
+	g.AddEdge(&model.Relation{From: "TKT-003", Type: "belongs_to", To: "CMP-001"})
+
+	t4 := model.NewEntity("TKT-004", "ticket")
+	t4.SetString("title", "No component ticket")
+	g.AddNode(t4)
+	// No relation for t4
+
+	app := &App{meta: meta, g: g}
+	allTickets := g.NodesByType("ticket")
+
+	t.Run("filters by relation target title", func(t *testing.T) {
+		got := app.filterByRelation(allTickets, "belongs_to", "Frontend")
+		gotIDs := collectIDs(got)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 results, got %d: %v", len(got), gotIDs)
+		}
+		if !sliceContainsStr(gotIDs, "TKT-001") || !sliceContainsStr(gotIDs, "TKT-003") {
+			t.Errorf("expected TKT-001 and TKT-003, got %v", gotIDs)
+		}
+	})
+
+	t.Run("filters by different relation target", func(t *testing.T) {
+		got := app.filterByRelation(allTickets, "belongs_to", "Backend")
+		gotIDs := collectIDs(got)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 result, got %d: %v", len(got), gotIDs)
+		}
+		if gotIDs[0] != "TKT-002" {
+			t.Errorf("expected TKT-002, got %v", gotIDs)
+		}
+	})
+
+	t.Run("returns empty for non-matching value", func(t *testing.T) {
+		got := app.filterByRelation(allTickets, "belongs_to", "Nonexistent")
+		if len(got) != 0 {
+			t.Errorf("expected 0 results, got %d", len(got))
+		}
+	})
+
+	t.Run("returns empty for unknown relation type", func(t *testing.T) {
+		got := app.filterByRelation(allTickets, "unknown_relation", "Frontend")
+		if len(got) != 0 {
+			t.Errorf("expected 0 results, got %d", len(got))
+		}
+	})
+
+	t.Run("handles entities without relations", func(t *testing.T) {
+		got := app.filterByRelation(allTickets, "belongs_to", "Frontend")
+		for _, e := range got {
+			if e.ID == "TKT-004" {
+				t.Error("TKT-004 should not be in results (has no belongs_to relation)")
+			}
+		}
+	})
+}
+
+func TestResolveRelationFilterValues(t *testing.T) {
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string"},
+				},
+			},
+			"component": {
+				Properties: map[string]metamodel.PropertyDef{
+					"name": {Type: "string", Required: true},
+				},
+			},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"belongs_to": {
+				Label: "belongs to",
+				From:  []string{"ticket"},
+				To:    []string{"component"},
+			},
+		},
+	}
+
+	g := graph.New()
+
+	// Create components
+	cmp1 := model.NewEntity("CMP-001", "component")
+	cmp1.SetString("name", "Frontend")
+	g.AddNode(cmp1)
+
+	cmp2 := model.NewEntity("CMP-002", "component")
+	cmp2.SetString("name", "Backend")
+	g.AddNode(cmp2)
+
+	cmp3 := model.NewEntity("CMP-003", "component")
+	cmp3.SetString("name", "API")
+	g.AddNode(cmp3)
+
+	// Create tickets with relations
+	t1 := model.NewEntity("TKT-001", "ticket")
+	t1.SetString("title", "Ticket 1")
+	g.AddNode(t1)
+	g.AddEdge(&model.Relation{From: "TKT-001", Type: "belongs_to", To: "CMP-001"})
+
+	t2 := model.NewEntity("TKT-002", "ticket")
+	t2.SetString("title", "Ticket 2")
+	g.AddNode(t2)
+	g.AddEdge(&model.Relation{From: "TKT-002", Type: "belongs_to", To: "CMP-002"})
+
+	t3 := model.NewEntity("TKT-003", "ticket")
+	t3.SetString("title", "Ticket 3")
+	g.AddNode(t3)
+	g.AddEdge(&model.Relation{From: "TKT-003", Type: "belongs_to", To: "CMP-001"}) // duplicate Frontend
+
+	// TKT-004 has no relation
+	t4 := model.NewEntity("TKT-004", "ticket")
+	t4.SetString("title", "Ticket 4")
+	g.AddNode(t4)
+
+	app := &App{meta: meta, g: g}
+	allTickets := g.NodesByType("ticket")
+
+	t.Run("returns unique sorted values", func(t *testing.T) {
+		got := app.resolveRelationFilterValues(allTickets, "belongs_to")
+		// Only Frontend and Backend are referenced, API is not
+		// Should be sorted: Backend, Frontend
+		if len(got) != 2 {
+			t.Fatalf("expected 2 values, got %d: %v", len(got), got)
+		}
+		if got[0] != "Backend" {
+			t.Errorf("expected first value 'Backend', got %q", got[0])
+		}
+		if got[1] != "Frontend" {
+			t.Errorf("expected second value 'Frontend', got %q", got[1])
+		}
+	})
+
+	t.Run("returns empty for unknown relation type", func(t *testing.T) {
+		got := app.resolveRelationFilterValues(allTickets, "unknown_relation")
+		if len(got) != 0 {
+			t.Errorf("expected 0 values, got %d", len(got))
+		}
+	})
+
+	t.Run("returns empty for empty entities list", func(t *testing.T) {
+		got := app.resolveRelationFilterValues([]*model.Entity{}, "belongs_to")
+		if len(got) != 0 {
+			t.Errorf("expected 0 values, got %d", len(got))
+		}
+	})
+}
+
+func sliceContainsStr(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
 func TestResolveScope(t *testing.T) {
 	meta := &metamodel.Metamodel{
 		Entities: map[string]metamodel.EntityDef{
@@ -1321,6 +1526,69 @@ func TestResolveScope(t *testing.T) {
 		got := app.resolveScope("T-002", r)
 		if got != nil {
 			t.Errorf("expected nil for search with no results, got %+v", got)
+		}
+	})
+
+	t.Run("list scope with relation filter narrows results", func(t *testing.T) {
+		// Create an app with relation-based filter
+		relMeta := &metamodel.Metamodel{
+			Entities: map[string]metamodel.EntityDef{
+				"ticket": {
+					Properties: map[string]metamodel.PropertyDef{
+						"title": {Type: "string"},
+					},
+				},
+				"component": {
+					Properties: map[string]metamodel.PropertyDef{
+						"name": {Type: "string", Required: true},
+					},
+				},
+			},
+			Relations: map[string]metamodel.RelationDef{
+				"belongs_to": {From: []string{"ticket"}, To: []string{"component"}},
+			},
+		}
+
+		relGraph := graph.New()
+		cmp := model.NewEntity("CMP-001", "component")
+		cmp.SetString("name", "Frontend")
+		relGraph.AddNode(cmp)
+
+		for _, e := range []*model.Entity{
+			{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{"title": "Ticket 1"}},
+			{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{"title": "Ticket 2"}},
+			{ID: "T-003", Type: "ticket", Properties: map[string]interface{}{"title": "Ticket 3"}},
+		} {
+			relGraph.AddNode(e)
+		}
+		// Only T-001 and T-002 belong to Frontend
+		relGraph.AddEdge(&model.Relation{From: "T-001", Type: "belongs_to", To: "CMP-001"})
+		relGraph.AddEdge(&model.Relation{From: "T-002", Type: "belongs_to", To: "CMP-001"})
+
+		relApp := &App{
+			meta: relMeta,
+			g:    relGraph,
+			Cfg: &Config{
+				Lists: map[string]List{
+					"tickets": {
+						EntityType: "ticket",
+						Title:      "Tickets",
+						FilterControls: []FilterControl{
+							{Relation: "belongs_to"},
+						},
+					},
+				},
+			},
+		}
+
+		r := makeRequest("/entity/ticket/T-001?scope=list:tickets&filter_belongs_to=Frontend")
+		got := relApp.resolveScope("T-001", r)
+		if got == nil {
+			t.Fatal("expected non-nil scope")
+		}
+		// Filter to Frontend should give only T-001 and T-002 (2 tickets)
+		if got.Label != "2 Tickets" {
+			t.Errorf("Label = %q, want %q", got.Label, "2 Tickets")
 		}
 	})
 

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -5,6 +5,8 @@
 package dataentryconfig
 
 import (
+	"net/url"
+
 	"github.com/Sourcehaven-BV/rela/internal/git"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
@@ -160,6 +162,16 @@ func (fc FilterControl) Key() string {
 // IsRelation returns true if this filter control filters by relation.
 func (fc FilterControl) IsRelation() bool {
 	return fc.Relation != ""
+}
+
+// QueryParamKey returns the URL query parameter key for this filter control.
+func (fc FilterControl) QueryParamKey() string {
+	return "filter_" + fc.Key()
+}
+
+// CurrentValue returns the current filter value from the given query parameters.
+func (fc FilterControl) CurrentValue(query url.Values) string {
+	return query.Get(fc.QueryParamKey())
 }
 
 // Kanban defines a kanban board view for an entity type.

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -149,6 +149,19 @@ type FilterControl struct {
 	Label    string `yaml:"label"`    // optional display label override
 }
 
+// Key returns the filter key (Relation if set, otherwise Property).
+func (fc FilterControl) Key() string {
+	if fc.Relation != "" {
+		return fc.Relation
+	}
+	return fc.Property
+}
+
+// IsRelation returns true if this filter control filters by relation.
+func (fc FilterControl) IsRelation() bool {
+	return fc.Relation != ""
+}
+
 // Kanban defines a kanban board view for an entity type.
 type Kanban struct {
 	EntityType       string           `yaml:"entity_type"`

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -145,10 +145,16 @@ type FilterConfig struct {
 }
 
 // FilterControl defines a user-facing filter control in a list.
+// Exactly one of Property or Relation must be set:
+//   - Property: filter on a scalar property of the entity.
+//   - Relation: filter by the target title of an outgoing relation; the
+//     relation name must exist in the metamodel.
+//
+// Label is an optional display label override for the control.
 type FilterControl struct {
-	Property string `yaml:"property"`
-	Relation string `yaml:"relation"` // filter by outgoing relation target title
-	Label    string `yaml:"label"`    // optional display label override
+	Property string `yaml:"property,omitempty"`
+	Relation string `yaml:"relation,omitempty"`
+	Label    string `yaml:"label,omitempty"`
 }
 
 // Key returns the filter key (Relation if set, otherwise Property).

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -145,6 +145,8 @@ type FilterConfig struct {
 // FilterControl defines a user-facing filter control in a list.
 type FilterControl struct {
 	Property string `yaml:"property"`
+	Relation string `yaml:"relation"` // filter by outgoing relation target title
+	Label    string `yaml:"label"`    // optional display label override
 }
 
 // Kanban defines a kanban board view for an entity type.

--- a/internal/dataentryconfig/config_test.go
+++ b/internal/dataentryconfig/config_test.go
@@ -134,3 +134,42 @@ func TestUserDefaultsResolveRelationDefault(t *testing.T) {
 		}
 	})
 }
+
+func TestFilterControlKey(t *testing.T) {
+	t.Run("returns relation when set", func(t *testing.T) {
+		fc := FilterControl{Relation: "belongs_to", Property: "status"}
+		if got := fc.Key(); got != "belongs_to" {
+			t.Errorf("expected 'belongs_to', got %q", got)
+		}
+	})
+
+	t.Run("returns property when relation empty", func(t *testing.T) {
+		fc := FilterControl{Property: "status"}
+		if got := fc.Key(); got != "status" {
+			t.Errorf("expected 'status', got %q", got)
+		}
+	})
+
+	t.Run("returns empty when both empty", func(t *testing.T) {
+		fc := FilterControl{}
+		if got := fc.Key(); got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+}
+
+func TestFilterControlIsRelation(t *testing.T) {
+	t.Run("true when relation set", func(t *testing.T) {
+		fc := FilterControl{Relation: "belongs_to"}
+		if !fc.IsRelation() {
+			t.Error("expected true")
+		}
+	})
+
+	t.Run("false when relation empty", func(t *testing.T) {
+		fc := FilterControl{Property: "status"}
+		if fc.IsRelation() {
+			t.Error("expected false")
+		}
+	})
+}

--- a/internal/dataentryconfig/config_test.go
+++ b/internal/dataentryconfig/config_test.go
@@ -173,3 +173,45 @@ func TestFilterControlIsRelation(t *testing.T) {
 		}
 	})
 }
+
+func TestFilterControlQueryParamKey(t *testing.T) {
+	t.Run("property filter", func(t *testing.T) {
+		fc := FilterControl{Property: "status"}
+		if got := fc.QueryParamKey(); got != "filter_status" {
+			t.Errorf("expected 'filter_status', got %q", got)
+		}
+	})
+
+	t.Run("relation filter", func(t *testing.T) {
+		fc := FilterControl{Relation: "belongs_to"}
+		if got := fc.QueryParamKey(); got != "filter_belongs_to" {
+			t.Errorf("expected 'filter_belongs_to', got %q", got)
+		}
+	})
+}
+
+func TestFilterControlCurrentValue(t *testing.T) {
+	t.Run("returns value when present", func(t *testing.T) {
+		fc := FilterControl{Property: "status"}
+		query := map[string][]string{"filter_status": {"open"}}
+		if got := fc.CurrentValue(query); got != "open" {
+			t.Errorf("expected 'open', got %q", got)
+		}
+	})
+
+	t.Run("returns empty when not present", func(t *testing.T) {
+		fc := FilterControl{Property: "status"}
+		query := map[string][]string{}
+		if got := fc.CurrentValue(query); got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("relation filter", func(t *testing.T) {
+		fc := FilterControl{Relation: "belongs_to"}
+		query := map[string][]string{"filter_belongs_to": {"category-1"}}
+		if got := fc.CurrentValue(query); got != "category-1" {
+			t.Errorf("expected 'category-1', got %q", got)
+		}
+	})
+}

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -353,11 +353,23 @@ func validateLists(cfg *Config, meta *metamodel.Metamodel) []string {
 
 		// Validate filter_controls
 		for i, fc := range list.FilterControls {
+			if fc.Property == "" && fc.Relation == "" {
+				errs = append(errs, fmt.Sprintf(
+					"list %q: filter_controls[%d] must specify either property or relation",
+					listID, i))
+			}
 			if fc.Property != "" {
 				if _, ok := entDef.Properties[fc.Property]; !ok {
 					errs = append(errs, fmt.Sprintf(
 						"list %q: filter_controls[%d] references unknown property %q",
 						listID, i, fc.Property))
+				}
+			}
+			if fc.Relation != "" {
+				if _, ok := meta.GetRelationDef(fc.Relation); !ok {
+					errs = append(errs, fmt.Sprintf(
+						"list %q: filter_controls[%d] references unknown relation %q",
+						listID, i, fc.Relation))
 				}
 			}
 		}
@@ -693,11 +705,23 @@ func validateKanbans(cfg *Config, meta *metamodel.Metamodel) []string {
 
 		// Validate filter_controls
 		for i, fc := range kanban.FilterControls {
+			if fc.Property == "" && fc.Relation == "" {
+				errs = append(errs, fmt.Sprintf(
+					"kanban %q: filter_controls[%d] must specify either property or relation",
+					kanbanID, i))
+			}
 			if fc.Property != "" {
 				if _, ok := entDef.Properties[fc.Property]; !ok {
 					errs = append(errs, fmt.Sprintf(
 						"kanban %q: filter_controls[%d] references unknown property %q",
 						kanbanID, i, fc.Property))
+				}
+			}
+			if fc.Relation != "" {
+				if _, ok := meta.GetRelationDef(fc.Relation); !ok {
+					errs = append(errs, fmt.Sprintf(
+						"kanban %q: filter_controls[%d] references unknown relation %q",
+						kanbanID, i, fc.Relation))
 				}
 			}
 		}

--- a/internal/dataentryconfig/validate_test.go
+++ b/internal/dataentryconfig/validate_test.go
@@ -935,3 +935,102 @@ func TestConfigValidationError_MultipleErrors(t *testing.T) {
 		t.Errorf("expected %q, got %q", expected, err.Error())
 	}
 }
+
+func TestValidateConfig_FilterControlMissingPropertyAndRelation(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Lists: map[string]List{
+			"test": {
+				EntityType:     "ticket",
+				FilterControls: []FilterControl{{}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for filter_control with neither property nor relation")
+	}
+	if !strings.Contains(err.Error(), "must specify either property or relation") {
+		t.Errorf("expected error about missing property or relation, got: %v", err)
+	}
+}
+
+func TestValidateConfig_FilterControlUnknownRelation(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Lists: map[string]List{
+			"test": {
+				EntityType:     "ticket",
+				FilterControls: []FilterControl{{Relation: "unknown_rel"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for filter_control with unknown relation")
+	}
+	if !strings.Contains(err.Error(), `references unknown relation "unknown_rel"`) {
+		t.Errorf("expected error about unknown relation, got: %v", err)
+	}
+}
+
+func TestValidateConfig_FilterControlValidRelation(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Lists: map[string]List{
+			"test": {
+				EntityType:     "ticket",
+				FilterControls: []FilterControl{{Relation: "belongs-to"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err != nil {
+		t.Errorf("expected valid filter_control relation to pass, got: %v", err)
+	}
+}
+
+func TestValidateConfig_KanbanFilterControlMissingPropertyAndRelation(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Kanbans: map[string]Kanban{
+			"test": {
+				EntityType:     "ticket",
+				ColumnProperty: "status",
+				FilterControls: []FilterControl{{}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for kanban filter_control with neither property nor relation")
+	}
+	if !strings.Contains(err.Error(), "must specify either property or relation") {
+		t.Errorf("expected error about missing property or relation, got: %v", err)
+	}
+}
+
+func TestValidateConfig_KanbanFilterControlUnknownRelation(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Kanbans: map[string]Kanban{
+			"test": {
+				EntityType:     "ticket",
+				ColumnProperty: "status",
+				FilterControls: []FilterControl{{Relation: "unknown_rel"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for kanban filter_control with unknown relation")
+	}
+	if !strings.Contains(err.Error(), `references unknown relation "unknown_rel"`) {
+		t.Errorf("expected error about unknown relation, got: %v", err)
+	}
+}

--- a/tickets/entities/features/FEAT-024.md
+++ b/tickets/entities/features/FEAT-024.md
@@ -1,0 +1,44 @@
+---
+description: Add support for relation-based filter controls in data-entry list views, allowing users to filter entities by outgoing relation targets (e.g., filter controls by owner role).
+id: FEAT-024
+priority: medium
+status: implemented
+title: Relation-based filter controls in list views
+type: feature
+---
+
+## Changes
+
+### `internal/dataentryconfig/config.go`
+
+Extended `FilterControl` with two new fields:
+
+- `Relation string` — when set, the filter dropdown is populated from outgoing relation targets rather than a property value
+- `Label string` — optional display label override for both property and relation filter controls
+
+### `internal/dataentry/helpers.go`
+
+Added two new methods on `App`:
+
+- `filterByRelation(entities, relationType, value)` — keeps only entities that have an outgoing relation of the given type whose target title matches `value`
+- `resolveRelationFilterValues(entities, relationType)` — collects and sorts the distinct target titles across all entities for use as dropdown options
+
+Updated `resolveScope` to apply relation-based filters when reconstructing the ordered entity list for scope navigation (prev/next), keeping it in sync with the filter logic in `handleList`.
+
+### `internal/dataentry/handlers.go`
+
+Updated `handleList` in three places:
+
+1. **Filter application loop** — added `fc.Relation != ""` branch calling `filterByRelation`
+2. **filterParams builder** — uses `fc.Relation` as the URL param key when set
+3. **Filter control renderer** — relation controls get their dropdown values from `resolveRelationFilterValues` on all (unfiltered) entities; respects the new `Label` field for both relation and property controls
+
+### `business/data-entry.yaml` (example usage)
+
+```yaml
+filter_controls:
+  - property: implementation_status
+    widget: select
+  - relation: controlOwnedByRole
+    label: Owner
+```

--- a/tickets/entities/tickets/TKT-034.md
+++ b/tickets/entities/tickets/TKT-034.md
@@ -1,5 +1,5 @@
 ---
-description: Introduces relationQuerier interface for relation lookups, removing direct graph.Graph dependency from mcp/convert.go production code
+description: Introduces relationQuerier interface for relation lookups, removing direct graph. Graph dependency from mcp/convert.go production code
 effort: xs
 id: TKT-034
 kind: refactor

--- a/tickets/entities/tickets/TKT-034.md
+++ b/tickets/entities/tickets/TKT-034.md
@@ -1,5 +1,5 @@
 ---
-description: Introduces relationQuerier interface for relation lookups, removing direct graph. Graph dependency from mcp/convert.go production code
+description: Introduces relationQuerier interface for relation lookups, removing direct graph.Graph dependency from mcp/convert.go production code
 effort: xs
 id: TKT-034
 kind: refactor

--- a/tickets/relations/FEAT-024--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-024--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-024
+relation: requires
+to: data-entry-ui
+---


### PR DESCRIPTION
## Description

Add support for relation-based filter controls in data-entry list views, allowing users to filter entities by outgoing relation targets (e.g., filter controls by owner role).

## Changes

#### `internal/dataentryconfig/config.go`

Extended `FilterControl` with two new fields:

- `Relation string` — when set, the filter dropdown is populated from outgoing relation targets rather than a property value
- `Label string` — optional display label override for both property and relation filter controls

#### `internal/dataentry/helpers.go`

Added two new methods on `App`:

- `filterByRelation(entities, relationType, value)` — keeps only entities that have an outgoing relation of the given type whose target title matches `value`
- `resolveRelationFilterValues(entities, relationType)` — collects and sorts the distinct target titles across all entities for use as dropdown options

Updated `resolveScope` to apply relation-based filters when reconstructing the ordered entity list for scope navigation (prev/next), keeping it in sync with the filter logic in `handleList`.

#### `internal/dataentry/handlers.go`

Updated `handleList` in three places:

1. **Filter application loop** — added `fc.Relation != ""` branch calling `filterByRelation`
2. **filterParams builder** — uses `fc.Relation` as the URL param key when set
3. **Filter control renderer** — relation controls get their dropdown values from `resolveRelationFilterValues` on all (unfiltered) entities; respects the new `Label` field for both relation and property controls

#### `business/data-entry.yaml` (example usage)

```yaml
filter_controls:
  - property: implementation_status
    widget: select
  - relation: controlOwnedByRole
    label: Owner
```
