### PR TITLE
Add no-cache headers to API/HTML responses

### DIFF
--- a/internal/dataentry/router_test.go
+++ b/internal/dataentry/router_test.go
@@ -51,6 +51,37 @@ func TestNewRouterStaticFiles(t *testing.T) {
 	}
 }
 
+func TestNewRouterStaticFilesNoCacheHeader(t *testing.T) {
+	app := newHandlerTestApp(t)
+	app.broker = newEventBroker()
+	handler := app.NewRouter()
+
+	// Static files should NOT have no-cache header (they bypass the middleware)
+	r := httptest.NewRequest(http.MethodGet, "/static/htmx.min.js", http.NoBody)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if cc := w.Header().Get("Cache-Control"); cc != "" {
+		t.Errorf("static files should not have Cache-Control header, got %q", cc)
+	}
+}
+
+func TestNewRouterAPIHasNoCacheHeader(t *testing.T) {
+	app := newHandlerTestApp(t)
+	app.broker = newEventBroker()
+	handler := app.NewRouter()
+
+	// API/HTML routes should have no-cache header
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	cc := w.Header().Get("Cache-Control")
+	if cc != "no-cache, no-store, must-revalidate" {
+		t.Errorf("expected Cache-Control header on API routes, got %q", cc)
+	}
+}
+
 func TestNewRouterSSEEndpoint(t *testing.T) {
 	app := newHandlerTestApp(t)
 	app.broker = newEventBroker()

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -210,11 +210,16 @@ func (a *App) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 // reloadLockMiddleware wraps an http.Handler so that every request holds
 // the App's read-lock, preventing concurrent reloads from swapping state
-// mid-request.
+// mid-request. It also sets no-cache headers to ensure browsers always
+// fetch fresh data after file changes trigger a reload.
+//
+// Note: Static files (/static/*) are served separately and bypass this
+// middleware, so they retain normal caching behavior.
 func (a *App) reloadLockMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		a.mu.RLock()
 		defer a.mu.RUnlock()
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/dataentry/watcher_test.go
+++ b/internal/dataentry/watcher_test.go
@@ -596,6 +596,25 @@ func TestReloadLockMiddleware(t *testing.T) {
 	}
 }
 
+func TestReloadLockMiddlewareSetsNoCacheHeader(t *testing.T) {
+	app, _ := setupReloadTestApp(t)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := app.reloadLockMiddleware(inner)
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	cc := w.Header().Get("Cache-Control")
+	if cc != "no-cache, no-store, must-revalidate" {
+		t.Errorf("expected Cache-Control header, got %q", cc)
+	}
+}
+
 func TestReloadLockMiddlewareBlocksDuringReload(t *testing.T) {
 	app, _ := setupReloadTestApp(t)
 

--- a/tickets/entities/features/FEAT-025.md
+++ b/tickets/entities/features/FEAT-025.md
@@ -1,0 +1,8 @@
+---
+description: File watcher monitors entities, relations, and metamodel changes, broadcasting updates via SSE to trigger browser refresh
+id: FEAT-025
+status: implemented
+summary: Automatic browser refresh when project files change
+title: Live reload for data entry server
+type: feature
+---

--- a/tickets/entities/tickets/TKT-035.md
+++ b/tickets/entities/tickets/TKT-035.md
@@ -1,0 +1,8 @@
+---
+description: Ensures browsers always fetch fresh data after file changes trigger a reload via the SSE watcher. Static files bypass the middleware and retain normal caching.
+id: TKT-035
+kind: enhancement
+status: done
+title: Add no-cache headers to API/HTML responses
+type: ticket
+---

--- a/tickets/relations/FEAT-025--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-025--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-025
+relation: requires
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-035--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-035--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-035
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-035--implements--FEAT-025.md
+++ b/tickets/relations/TKT-035--implements--FEAT-025.md
@@ -1,0 +1,5 @@
+---
+from: TKT-035
+relation: implements
+to: FEAT-025
+---


### PR DESCRIPTION
## Summary

- Add `Cache-Control: no-cache, no-store, must-revalidate` header to API/HTML routes
- Static files (`/static/*`) bypass this middleware and retain normal caching behavior

This ensures browsers always fetch fresh data after file changes trigger a reload via the SSE watcher.

## Test plan

- [x] Unit test verifying middleware sets header
- [x] Unit test verifying static files do NOT have the header
- [x] Unit test verifying API routes have the header