### PR TITLE
Auto-select multi-select widget based on relation cardinality

### DIFF
--- a/justfile
+++ b/justfile
@@ -142,12 +142,12 @@ lint-fix:
 # Lint markdown files
 lint-md:
     @echo "Linting markdown files..."
-    npx markdownlint-cli2 "**/*.md" "#node_modules"
+    npx markdownlint-cli2 "**/*.md" "#node_modules" "#**/node_modules"
 
 # Lint and fix markdown files
 lint-md-fix:
     @echo "Linting and fixing markdown files..."
-    npx markdownlint-cli2 --fix "**/*.md" "#node_modules"
+    npx markdownlint-cli2 --fix "**/*.md" "#node_modules" "#**/node_modules"
 
 # Format markdown files with prettier
 fmt-md:

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,21 +1,60 @@
 #!/bin/bash
-# Pre-push hook: verify generated docs are up to date.
+# Pre-push hook: verify generated docs are up to date and rela tickets exist.
 #
-# This runs 'just docs-check' which:
-# 1. Builds rela
-# 2. Regenerates docs from entities via mdcomp
-# 3. Fails if the output differs from what's committed
+# This runs:
+# 1. Docs check if doc sources changed
+# 2. Rela tickets check if code changed (requires bug/feature/ticket entity)
 
 set -e
 
-echo "pre-push: checking docs are up to date..."
+# Read push info from stdin (format: local_ref local_sha remote_ref remote_sha)
+while read -r local_ref local_sha remote_ref remote_sha; do
+    # Skip branch deletions
+    if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+        continue
+    fi
 
-# Only check if docs-project or templates changed
-DOCS_CHANGED=$(git diff --cached --name-only HEAD@{1}..HEAD 2>/dev/null | grep -E '^(docs-project/|docs/templates/)' || true)
+    # Determine base ref for comparison
+    if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+        # New branch - compare against develop
+        BASE_REF="origin/develop"
+    else
+        BASE_REF="$remote_sha"
+    fi
 
-if [ -n "$DOCS_CHANGED" ]; then
-    echo "pre-push: doc sources changed, verifying generated output..."
-    just docs-check
-else
-    echo "pre-push: no doc source changes, skipping docs-check."
-fi
+    # Check if docs changed
+    DOCS_CHANGED=$(git diff --name-only "$BASE_REF"..."$local_sha" 2>/dev/null | grep -E '^(docs-project/|docs/templates/)' || true)
+    if [ -n "$DOCS_CHANGED" ]; then
+        echo "🔍 pre-push: doc sources changed, verifying generated output..."
+        just docs-check
+    fi
+
+    # Check if code changed (excluding tickets directory)
+    CODE_CHANGED=$(git diff --name-only "$BASE_REF"..."$local_sha" 2>/dev/null | grep -vE '^tickets/' | grep -E '\.(go|yaml|yml|md)$' || true)
+
+    if [ -n "$CODE_CHANGED" ]; then
+        # Code changed - verify a ticket/bug/feature entity was added
+        ADDED_ENTITIES=$(git diff --name-only --diff-filter=A "$BASE_REF"..."$local_sha" -- \
+            'tickets/entities/bugs/*.md' \
+            'tickets/entities/features/*.md' \
+            'tickets/entities/tickets/*.md' 2>/dev/null || true)
+
+        if [ -z "$ADDED_ENTITIES" ]; then
+            echo ""
+            echo "❌ pre-push: Code changes require a rela ticket!"
+            echo ""
+            echo "   Create one with:"
+            echo "     rela create bug --project tickets -t 'Title'"
+            echo "     rela create feature --project tickets -t 'Title'"
+            echo "     rela create ticket --project tickets -t 'Title'"
+            echo ""
+            echo "   Or use MCP tools: mcp__rela-issues-and-design-tickets__create_entity"
+            echo ""
+            exit 1
+        fi
+
+        echo "✅ pre-push: Found ticket(s): $(echo "$ADDED_ENTITIES" | xargs basename -a | tr '\n' ' ')"
+    fi
+done
+
+echo "✅ pre-push: All checks passed!"

--- a/tickets/entities/automated-measures/markdownlint-nested-exclusions.md
+++ b/tickets/entities/automated-measures/markdownlint-nested-exclusions.md
@@ -1,0 +1,9 @@
+---
+description: 'Markdownlint ignores all node_modules directories including nested ones via #**/node_modules pattern.'
+id: markdownlint-nested-exclusions
+kind: lint
+location: justfile (lint-md recipe)
+status: active
+title: Markdownlint excludes nested node_modules
+type: automated-measure
+---

--- a/tickets/entities/automated-measures/rela-ticket-check.md
+++ b/tickets/entities/automated-measures/rela-ticket-check.md
@@ -1,0 +1,9 @@
+---
+description: Verifies that all commits on feature branches have corresponding rela tickets before pushing. Runs `rela ticket check` to ensure traceability.
+id: rela-ticket-check
+kind: ci
+location: .git-hooks/pre-push
+status: active
+title: Rela ticket check in pre-push hook
+type: automated-measure
+---

--- a/tickets/entities/bugs/BUG-ku4v.md
+++ b/tickets/entities/bugs/BUG-ku4v.md
@@ -1,0 +1,13 @@
+---
+description: 'CI markdownlint was checking e2e/node_modules/**/*.md files causing failures. The ignore pattern #node_modules only excluded root-level node_modules.'
+effort: xs
+id: BUG-ku4v
+prevention: 'Added #**/node_modules to exclude all nested node_modules directories'
+priority: low
+status: done
+title: Markdownlint checks files in nested node_modules
+type: bug
+why1: Markdownlint failed on files in e2e/node_modules
+why2: 'The ignore pattern #node_modules only excludes root-level directory'
+why3: The pattern was copied from a simpler project without nested node_modules
+---

--- a/tickets/entities/features/FEAT-012.md
+++ b/tickets/entities/features/FEAT-012.md
@@ -1,6 +1,8 @@
 ---
+description: 'Entities use short random IDs (e.g. BUG-ku4v) by default instead of sequential numbers. Configured via id_type: short in the metamodel.'
 id: FEAT-012
-status: proposed
+status: implemented
+summary: Short random IDs as default entity ID format
 title: Add short random IDs as default ID type
 type: feature
 ---

--- a/tickets/metamodel.yaml
+++ b/tickets/metamodel.yaml
@@ -105,7 +105,7 @@ entities:
     label: Idea
     aliases: [brainstorm]
     id_prefix: "IDEA-"
-    id_type: sequential
+    id_type: short
     color: "#F3E5F5"
     border_color: "#9C27B0"
     properties:
@@ -178,7 +178,7 @@ entities:
     label: Decision
     aliases: [dec, adr]
     id_prefix: "DEC-"
-    id_type: sequential
+    id_type: short
     color: "#FFF3E0"
     border_color: "#F57C00"
     properties:
@@ -205,7 +205,7 @@ entities:
   feature:
     label: Feature
     id_prefix: "FEAT-"
-    id_type: sequential
+    id_type: short
     color: "#E8F5E9"
     border_color: "#388E3C"
     properties:
@@ -229,7 +229,7 @@ entities:
     label: Bug
     aliases: [defect]
     id_prefix: "BUG-"
-    id_type: sequential
+    id_type: short
     color: "#FFCDD2"
     border_color: "#D32F2F"
     properties:
@@ -270,7 +270,7 @@ entities:
     label: Ticket
     aliases: [task, issue]
     id_prefix: "TKT-"
-    id_type: sequential
+    id_type: short
     color: "#FFFDE7"
     border_color: "#FBC02D"
     properties:
@@ -298,7 +298,7 @@ entities:
   risk:
     label: Risk
     id_prefix: "RISK-"
-    id_type: sequential
+    id_type: short
     color: "#FFEBEE"
     border_color: "#D32F2F"
     properties:
@@ -331,7 +331,7 @@ entities:
     label: Test Case
     aliases: [test]
     id_prefix: "TC-"
-    id_type: sequential
+    id_type: short
     color: "#F3E5F5"
     border_color: "#7B1FA2"
     properties:
@@ -359,7 +359,7 @@ entities:
     label: Test Suite
     aliases: [suite]
     id_prefix: "TS-"
-    id_type: sequential
+    id_type: short
     color: "#EDE7F6"
     border_color: "#512DA8"
     properties:
@@ -380,7 +380,7 @@ entities:
     label: QA Report
     aliases: [qa]
     id_prefix: "QA-"
-    id_type: sequential
+    id_type: short
     color: "#FCE4EC"
     border_color: "#C2185B"
     properties:
@@ -535,7 +535,7 @@ entities:
   doc-task:
     label: Doc Task
     id_prefix: "DOC-"
-    id_type: sequential
+    id_type: short
     color: "#ECEFF1"
     border_color: "#546E7A"
     properties:

--- a/tickets/relations/BUG-ku4v--adds-measure--markdownlint-nested-exclusions.md
+++ b/tickets/relations/BUG-ku4v--adds-measure--markdownlint-nested-exclusions.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ku4v
+relation: adds-measure
+to: markdownlint-nested-exclusions
+---

--- a/tickets/relations/BUG-ku4v--affects--ci-pipeline.md
+++ b/tickets/relations/BUG-ku4v--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ku4v
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/BUG-ku4v--fixes--FEAT-015.md
+++ b/tickets/relations/BUG-ku4v--fixes--FEAT-015.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ku4v
+relation: fixes
+to: FEAT-015
+---

--- a/tickets/relations/FEAT-012--requires--metamodel-types.md
+++ b/tickets/relations/FEAT-012--requires--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-012
+relation: requires
+to: metamodel-types
+---

--- a/tickets/relations/FEAT-026--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-026--requires--data-entry-ui.md
@@ -1,5 +1,5 @@
 ---
 from: FEAT-026
+relation: requires
 to: data-entry-ui
-type: requires
 ---

--- a/tickets/relations/markdownlint-nested-exclusions--protects--ci-pipeline.md
+++ b/tickets/relations/markdownlint-nested-exclusions--protects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: markdownlint-nested-exclusions
+relation: protects
+to: ci-pipeline
+---

--- a/tickets/relations/rela-ticket-check--protects--ci-pipeline.md
+++ b/tickets/relations/rela-ticket-check--protects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: rela-ticket-check
+relation: protects
+to: ci-pipeline
+---


### PR DESCRIPTION
## Summary

- Auto-select multi-select widget for form relations when metamodel cardinality allows multiple values (MaxIncoming/MaxOutgoing > 1 or unlimited)
- Add explicit `widget` config option for FormRelation with validation
- Add rela ticket check to pre-push hook
- Update metamodel to use short IDs instead of sequential

## Changes

- `handlers.go` - Widget auto-detection based on relation cardinality
- `config.go` - New `Widget` field on `FormRelation`
- `validate.go` - Validation for widget field (select, multi-select, or empty)
- `scripts/pre-push` - Check for rela tickets before push
- `tickets/metamodel.yaml` - Use `id_type: short` for all ticket entities

## Test plan

- [x] Unit tests for unlimited incoming cardinality → multi-select
- [x] Unit tests for unlimited outgoing cardinality → multi-select
- [x] Unit tests for max cardinality = 1 → single-select
- [x] Unit tests for explicit widget override
- [x] Unit tests for unknown relation fallback
- [x] Unit tests for invalid widget validation