### PR TITLE
Support direction: incoming for relation columns in lists

### DIFF
--- a/internal/dataentry/config.go
+++ b/internal/dataentry/config.go
@@ -28,6 +28,7 @@ const (
 type (
 	Config           = dataentryconfig.Config
 	AppConfig        = dataentryconfig.AppConfig
+	Direction        = dataentryconfig.Direction
 	Form             = dataentryconfig.Form
 	SidePanelConfig  = dataentryconfig.SidePanelConfig
 	FormField        = dataentryconfig.FormField

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -149,7 +149,7 @@ func (a *App) handleList(w http.ResponseWriter, r *http.Request) {
 				EntityType: e.Type,
 			}
 			if col.Relation != "" {
-				cell.Values = a.resolveRelationColumnValues(e.ID, col.Relation)
+				cell.Values = a.resolveRelationColumnValues(e.ID, col.Relation, col.Direction)
 			} else {
 				// Get property definition from metamodel
 				var propDef metamodel.PropertyDef
@@ -2149,7 +2149,7 @@ func (a *App) handleDashboard(w http.ResponseWriter, r *http.Request) {
 					var val string
 					var propType string
 					if col.Relation != "" {
-						val = strings.Join(a.resolveRelationColumnValues(e.ID, col.Relation), ", ")
+						val = strings.Join(a.resolveRelationColumnValues(e.ID, col.Relation, col.Direction), ", ")
 					} else {
 						if v := e.Properties[col.Property]; v != nil {
 							val = fmt.Sprintf("%v", v)

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -755,7 +755,7 @@ func (a *App) handleEntity(w http.ResponseWriter, r *http.Request) {
 		TargetID    string
 		TargetType  string
 		TargetTitle string
-		Direction   string
+		Direction   Direction
 		Properties  []RelPropDisplay
 	}
 	rels := make([]RelDisplay, 0, len(outgoing)+len(incoming))

--- a/internal/dataentry/handlers_api.go
+++ b/internal/dataentry/handlers_api.go
@@ -28,7 +28,7 @@ type APIRelation struct {
 	Type        string                 `json:"type"`
 	From        string                 `json:"from"`
 	To          string                 `json:"to"`
-	Direction   string                 `json:"direction"` // "outgoing" or "incoming"
+	Direction   Direction              `json:"direction"` // "outgoing" or "incoming"
 	TargetID    string                 `json:"targetId"`
 	TargetTitle string                 `json:"targetTitle"`
 	TargetType  string                 `json:"targetType"`
@@ -686,7 +686,7 @@ func (a *App) listAllRelations() []APIRelation {
 }
 
 // edgeToAPIRelation converts a graph edge to an APIRelation.
-func (a *App) edgeToAPIRelation(edge *model.Relation, relatedEntity *model.Entity, direction, targetID string) APIRelation {
+func (a *App) edgeToAPIRelation(edge *model.Relation, relatedEntity *model.Entity, direction Direction, targetID string) APIRelation {
 	rel := APIRelation{
 		Type:        edge.Type,
 		From:        edge.From,

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/renderer/html"
 
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/htmlutil"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -482,11 +483,11 @@ func templateFuncs(styleMap map[string]map[string]string, styledTypes map[string
 }
 
 // resolveRelationColumnValues returns display titles for all targets of the given
-// relation type from an entity. Direction can be "incoming" to follow edges pointing
-// to the entity, or "outgoing" (the default) to follow edges from the entity.
-func (a *App) resolveRelationColumnValues(entityID, relationType, direction string) []string {
+// relation type from an entity. Direction controls whether to follow edges pointing
+// to the entity (incoming) or from the entity (outgoing, the default).
+func (a *App) resolveRelationColumnValues(entityID, relationType string, direction dataentryconfig.Direction) []string {
 	var edges []*model.Relation
-	if direction == "incoming" {
+	if direction.IsIncoming() {
 		edges = a.g.IncomingEdges(entityID)
 	} else {
 		edges = a.g.OutgoingEdges(entityID)
@@ -497,7 +498,7 @@ func (a *App) resolveRelationColumnValues(entityID, relationType, direction stri
 			continue
 		}
 		var targetID string
-		if direction == "incoming" {
+		if direction.IsIncoming() {
 			targetID = edge.From
 		} else {
 			targetID = edge.To

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -482,15 +482,27 @@ func templateFuncs(styleMap map[string]map[string]string, styledTypes map[string
 }
 
 // resolveRelationColumnValues returns display titles for all targets of the given
-// relation type from an entity.
-func (a *App) resolveRelationColumnValues(entityID, relationType string) []string {
-	edges := a.g.OutgoingEdges(entityID)
+// relation type from an entity. Direction can be "incoming" to follow edges pointing
+// to the entity, or "outgoing" (the default) to follow edges from the entity.
+func (a *App) resolveRelationColumnValues(entityID, relationType, direction string) []string {
+	var edges []*model.Relation
+	if direction == "incoming" {
+		edges = a.g.IncomingEdges(entityID)
+	} else {
+		edges = a.g.OutgoingEdges(entityID)
+	}
 	titles := make([]string, 0, len(edges))
 	for _, edge := range edges {
 		if edge.Type != relationType {
 			continue
 		}
-		target, ok := a.g.GetNode(edge.To)
+		var targetID string
+		if direction == "incoming" {
+			targetID = edge.From
+		} else {
+			targetID = edge.To
+		}
+		target, ok := a.g.GetNode(targetID)
 		if !ok {
 			continue
 		}

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -1024,7 +1024,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	app := &App{meta: meta, g: g}
 
 	t.Run("resolves multiple targets", func(t *testing.T) {
-		got := app.resolveRelationColumnValues("ASS-001", "assessmentBy")
+		got := app.resolveRelationColumnValues("ASS-001", "assessmentBy", "")
 		want := []string{"Alice", "Bob"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -1032,7 +1032,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	})
 
 	t.Run("filters by relation type", func(t *testing.T) {
-		got := app.resolveRelationColumnValues("ASS-001", "otherRel")
+		got := app.resolveRelationColumnValues("ASS-001", "otherRel", "")
 		want := []string{"Alice"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -1040,14 +1040,48 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	})
 
 	t.Run("returns empty for no matching relations", func(t *testing.T) {
-		got := app.resolveRelationColumnValues("ASS-001", "nonexistent")
+		got := app.resolveRelationColumnValues("ASS-001", "nonexistent", "")
 		if len(got) != 0 {
 			t.Errorf("got %v, want empty slice", got)
 		}
 	})
 
 	t.Run("returns empty for unknown entity", func(t *testing.T) {
-		got := app.resolveRelationColumnValues("UNKNOWN", "assessmentBy")
+		got := app.resolveRelationColumnValues("UNKNOWN", "assessmentBy", "")
+		if len(got) != 0 {
+			t.Errorf("got %v, want empty slice", got)
+		}
+	})
+
+	t.Run("direction outgoing explicit", func(t *testing.T) {
+		got := app.resolveRelationColumnValues("ASS-001", "assessmentBy", "outgoing")
+		want := []string{"Alice", "Bob"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("direction incoming returns sources", func(t *testing.T) {
+		// PER-001 has an incoming edge from ASS-001 via assessmentBy
+		// Assessment title is not required, so falls back to ID
+		got := app.resolveRelationColumnValues("PER-001", "assessmentBy", "incoming")
+		want := []string{"ASS-001"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("direction incoming returns multiple sources", func(t *testing.T) {
+		// PER-001 is target of both assessmentBy and otherRel from ASS-001
+		got := app.resolveRelationColumnValues("PER-001", "otherRel", "incoming")
+		want := []string{"ASS-001"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("direction incoming no matches", func(t *testing.T) {
+		got := app.resolveRelationColumnValues("ASS-001", "assessmentBy", "incoming")
 		if len(got) != 0 {
 			t.Errorf("got %v, want empty slice", got)
 		}

--- a/internal/dataentry/sections.go
+++ b/internal/dataentry/sections.go
@@ -185,7 +185,7 @@ func (a *App) buildSections(sections []ViewSection, result *viewResult) []Sectio
 							Link: a.resolveLinkTarget(col.Link, e.Type, e.ID), EntityID: e.ID, EntityType: e.Type,
 						}
 						if col.Relation != "" {
-							cell.Values = a.resolveRelationColumnValues(e.ID, col.Relation)
+							cell.Values = a.resolveRelationColumnValues(e.ID, col.Relation, col.Direction)
 						} else {
 							var pd metamodel.PropertyDef
 							if eDef != nil {

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -124,13 +124,16 @@ type List struct {
 
 // ListColumn defines a column in a list view.
 // A column references either a Property (entity property) or a Relation
-// (outgoing relation type whose target titles are shown comma-separated).
+// (relation type whose target titles are shown comma-separated).
+// For relation columns, Direction controls whether to show outgoing (default)
+// or incoming edges. Use "incoming" to display entities that point to the current row.
 type ListColumn struct {
-	Property string `yaml:"property"`
-	Relation string `yaml:"relation"`
-	Label    string `yaml:"label"`
-	Sortable bool   `yaml:"sortable"`
-	Link     string `yaml:"link"`
+	Property  string `yaml:"property"`
+	Relation  string `yaml:"relation"`
+	Direction string `yaml:"direction"` // "outgoing" (default) or "incoming"
+	Label     string `yaml:"label"`
+	Sortable  bool   `yaml:"sortable"`
+	Link      string `yaml:"link"`
 }
 
 // SortSpec defines a single sort criterion for a list or dashboard card.

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -5,7 +5,10 @@
 package dataentryconfig
 
 import (
+	"fmt"
 	"net/url"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/git"
 	"github.com/Sourcehaven-BV/rela/internal/model"
@@ -25,11 +28,36 @@ const (
 	WidgetDate        = "date"
 )
 
-// Relation direction constants for form relations.
+// Direction represents the edge direction for relation columns and form relations.
+type Direction string
+
+// Relation direction constants.
 const (
-	DirectionIncoming = "incoming"
-	DirectionOutgoing = "outgoing"
+	DirectionIncoming Direction = "incoming"
+	DirectionOutgoing Direction = "outgoing"
 )
+
+// UnmarshalYAML validates the direction value during YAML parsing.
+func (d *Direction) UnmarshalYAML(value *yaml.Node) error {
+	var s string
+	if err := value.Decode(&s); err != nil {
+		return err
+	}
+	switch s {
+	case "", "outgoing":
+		*d = DirectionOutgoing
+	case "incoming":
+		*d = DirectionIncoming
+	default:
+		return fmt.Errorf("invalid direction %q (must be 'outgoing' or 'incoming')", s)
+	}
+	return nil
+}
+
+// IsIncoming returns true if the direction is incoming.
+func (d Direction) IsIncoming() bool {
+	return d == DirectionIncoming
+}
 
 // Config is the top-level configuration for a data entry application.
 type Config struct {
@@ -87,7 +115,7 @@ type FormField struct {
 // FormRelation defines a relation field in a form.
 type FormRelation struct {
 	Relation     string             `yaml:"relation"`
-	Direction    string             `yaml:"direction"`
+	Direction    Direction          `yaml:"direction"`
 	TargetType   string             `yaml:"target_type"`
 	Label        string             `yaml:"label"`
 	Required     bool               `yaml:"required"`
@@ -128,12 +156,12 @@ type List struct {
 // For relation columns, Direction controls whether to show outgoing (default)
 // or incoming edges. Use "incoming" to display entities that point to the current row.
 type ListColumn struct {
-	Property  string `yaml:"property"`
-	Relation  string `yaml:"relation"`
-	Direction string `yaml:"direction"` // "outgoing" (default) or "incoming"
-	Label     string `yaml:"label"`
-	Sortable  bool   `yaml:"sortable"`
-	Link      string `yaml:"link"`
+	Property  string    `yaml:"property"`
+	Relation  string    `yaml:"relation"`
+	Direction Direction `yaml:"direction"` // "outgoing" (default) or "incoming"
+	Label     string    `yaml:"label"`
+	Sortable  bool      `yaml:"sortable"`
+	Link      string    `yaml:"link"`
 }
 
 // SortSpec defines a single sort criterion for a list or dashboard card.

--- a/internal/dataentryconfig/config_test.go
+++ b/internal/dataentryconfig/config_test.go
@@ -1,6 +1,11 @@
 package dataentryconfig
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
 
 func TestUserDefaultsResolvePropertyDefault(t *testing.T) {
 	ud := &UserDefaults{
@@ -212,6 +217,86 @@ func TestFilterControlCurrentValue(t *testing.T) {
 		query := map[string][]string{"filter_belongs_to": {"category-1"}}
 		if got := fc.CurrentValue(query); got != "category-1" {
 			t.Errorf("expected 'category-1', got %q", got)
+		}
+	})
+}
+
+func TestDirection_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		want    Direction
+		wantErr string
+	}{
+		{
+			name: "empty defaults to outgoing",
+			yaml: `direction: ""`,
+			want: DirectionOutgoing,
+		},
+		{
+			name: "outgoing",
+			yaml: `direction: outgoing`,
+			want: DirectionOutgoing,
+		},
+		{
+			name: "incoming",
+			yaml: `direction: incoming`,
+			want: DirectionIncoming,
+		},
+		{
+			name:    "invalid direction",
+			yaml:    `direction: both`,
+			wantErr: `invalid direction "both"`,
+		},
+		{
+			name:    "invalid direction sideways",
+			yaml:    `direction: sideways`,
+			wantErr: `invalid direction "sideways"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg struct {
+				Direction Direction `yaml:"direction"`
+			}
+			err := yaml.Unmarshal([]byte(tt.yaml), &cfg)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.Direction != tt.want {
+				t.Errorf("got %q, want %q", cfg.Direction, tt.want)
+			}
+		})
+	}
+}
+
+func TestDirection_IsIncoming(t *testing.T) {
+	t.Run("incoming returns true", func(t *testing.T) {
+		if !DirectionIncoming.IsIncoming() {
+			t.Error("expected true")
+		}
+	})
+
+	t.Run("outgoing returns false", func(t *testing.T) {
+		if DirectionOutgoing.IsIncoming() {
+			t.Error("expected false")
+		}
+	})
+
+	t.Run("empty returns false", func(t *testing.T) {
+		var d Direction
+		if d.IsIncoming() {
+			t.Error("expected false")
 		}
 	})
 }

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -82,7 +82,7 @@ var validCommandContexts = map[string]bool{
 }
 
 // Valid relation directions
-var validRelationDirections = map[string]bool{
+var validRelationDirections = map[Direction]bool{
 	"":                true, // default (outgoing)
 	DirectionOutgoing: true,
 	DirectionIncoming: true,

--- a/tickets/entities/features/FEAT-0c9l.md
+++ b/tickets/entities/features/FEAT-0c9l.md
@@ -1,0 +1,32 @@
+---
+description: 'List columns with relation: currently only show outgoing relations. Add direction:incoming support to display entities that point to the current row.'
+id: FEAT-0c9l
+priority: medium
+status: implemented
+title: Support direction:incoming for relation columns in lists
+type: feature
+---
+
+## Use Case
+
+In a roles list, show "Held By" (which persons hold this role) and "Controls" (which controls are owned by this role). The relations are:
+- hasRole: person → role
+- controlOwnedByRole: control → role
+
+Both point to the role, so incoming edges are needed.
+
+## Solution
+
+Add `Direction` field to `ListColumn` struct and update `resolveRelationColumnValues()` to use `IncomingEdges()` when `direction: incoming`.
+
+## Example Config
+
+```yaml
+columns:
+  - relation: hasRole
+    direction: incoming
+    label: 'Held By'
+  - relation: controlOwnedByRole
+    direction: incoming
+    label: 'Controls'
+```

--- a/tickets/entities/features/FEAT-tr9f.md
+++ b/tickets/entities/features/FEAT-tr9f.md
@@ -1,0 +1,28 @@
+---
+description: 'List columns with relation: currently only show outgoing relations. Add support for direction: incoming to display entities that point to the current row.'
+id: FEAT-tr9f
+status: implemented
+title: 'Support direction: incoming for relation columns in lists'
+type: feature
+---
+
+## Use case
+
+In a roles list, showing "Held By" (which persons hold this role) and "Controls" (which controls are owned by this role). The relations are:
+- hasRole: person → role
+- controlOwnedByRole: control → role
+
+Both point to the role, so incoming edges are needed.
+
+## Solution
+
+Add `Direction` field to `ListColumn` struct and update `resolveRelationColumnValues()` to use `IncomingEdges()` when `direction: incoming`.
+
+## Config example
+
+```yaml
+columns:
+  - relation: hasRole
+    direction: incoming
+    label: 'Held By'
+```

--- a/tickets/relations/FEAT-tr9f--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-tr9f--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-tr9f
+relation: requires
+to: data-entry-ui
+---


### PR DESCRIPTION
## Summary

- Add `direction` field to `ListColumn` struct (values: `"outgoing"` (default) or `"incoming"`)
- Update `resolveRelationColumnValues()` to use `IncomingEdges()` when direction is incoming
- Enables showing entities that point to the current row in list columns

Closes FEAT-tr9f

## Test plan

- [x] Existing tests pass
- [x] New tests for incoming direction added
- [ ] Manual test: configure a list column with `direction: incoming` and verify it shows source entities