### PR TITLE
Add help modal for entity documentation in data-entry

### DIFF
--- a/docs-project/entities/guide/GUIDE-data-entry.md
+++ b/docs-project/entities/guide/GUIDE-data-entry.md
@@ -387,6 +387,51 @@ relations:
 | `widget`   | string | Input widget (`text`, `textarea`) |
 | `required` | bool   | Must be filled                    |
 
+### Help Modal
+
+Every form displays a help icon (?) next to the title. Clicking it opens a modal with
+documentation for the entity type, pulled from the metamodel:
+
+- **Entity description**: The `description` field from the entity definition (supports markdown)
+- **Properties**: All properties with their types and descriptions
+- **Outgoing relations**: Relations from this entity to others, with cardinality constraints
+- **Incoming relations**: Relations from other entities to this one, with cardinality constraints
+
+Relations with minimum cardinality >= 1 are marked as "required" in the help modal, indicating
+that at least one relation of that type must be created.
+
+To populate the help modal, add descriptions to your metamodel:
+
+```yaml
+entities:
+  ticket:
+    label: Ticket
+    description: |
+      A ticket represents a unit of work to be completed.
+
+      Use tickets for:
+      - Bug reports
+      - Feature requests
+      - Tasks and chores
+    properties:
+      title:
+        type: string
+        required: true
+        description: "Brief summary of the ticket"
+      priority:
+        type: priority
+        description: "How urgently this ticket needs attention"
+
+relations:
+  blocks:
+    label: blocks
+    description: "Indicates this ticket must be resolved before another can proceed"
+    from: [ticket]
+    to: [ticket]
+    min_outgoing: 0
+    max_outgoing: 10
+```
+
 ## Lists
 
 Lists display entities in a sortable, filterable table with optional create/edit actions.

--- a/docs-project/entities/guide/GUIDE-metamodel.md
+++ b/docs-project/entities/guide/GUIDE-metamodel.md
@@ -189,6 +189,7 @@ Each entity type defines:
 | Field         | Description                                               |
 | ------------- | --------------------------------------------------------- |
 | `label`       | Display name                                              |
+| `description` | Documentation explaining intent and usage (optional)      |
 | `aliases`     | Alternative names for CLI (e.g., `req` for `requirement`) |
 | `id_type`     | `auto` (default) or `manual` - controls ID generation     |
 | `id_patterns` | ID prefixes (e.g., `REQ-`, `ADR-`)                        |
@@ -245,6 +246,32 @@ rela create requirement -t "User authentication"
 rela create component --id auth-service -t "Authentication Service"
 # Creates auth-service
 ```
+
+### Entity Descriptions
+
+Add a `description` field to document the intent and usage of an entity type. Descriptions
+support markdown and are surfaced in the data-entry UI via help modals:
+
+```yaml
+entities:
+  decision:
+    label: Decision
+    description: |
+      A decision records an important architectural choice and its rationale.
+
+      Use decisions when:
+      - Making technology choices (frameworks, databases, etc.)
+      - Defining patterns or conventions
+      - Resolving requirement conflicts
+
+      Each decision should address one or more requirements.
+    properties:
+      # ...
+```
+
+In the data-entry UI, a help icon (?) appears next to the entity form title. Clicking it
+opens a modal showing the entity description, all properties with their descriptions, and
+available relations with cardinality constraints.
 
 ### Example Entity Type
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -379,6 +379,51 @@ relations:
 | `widget`   | string | Input widget (`text`, `textarea`) |
 | `required` | bool   | Must be filled                    |
 
+### Help Modal
+
+Every form displays a help icon (?) next to the title. Clicking it opens a modal with
+documentation for the entity type, pulled from the metamodel:
+
+- **Entity description**: The `description` field from the entity definition (supports markdown)
+- **Properties**: All properties with their types and descriptions
+- **Outgoing relations**: Relations from this entity to others, with cardinality constraints
+- **Incoming relations**: Relations from other entities to this one, with cardinality constraints
+
+Relations with minimum cardinality >= 1 are marked as "required" in the help modal, indicating
+that at least one relation of that type must be created.
+
+To populate the help modal, add descriptions to your metamodel:
+
+```yaml
+entities:
+  ticket:
+    label: Ticket
+    description: |
+      A ticket represents a unit of work to be completed.
+
+      Use tickets for:
+      - Bug reports
+      - Feature requests
+      - Tasks and chores
+    properties:
+      title:
+        type: string
+        required: true
+        description: "Brief summary of the ticket"
+      priority:
+        type: priority
+        description: "How urgently this ticket needs attention"
+
+relations:
+  blocks:
+    label: blocks
+    description: "Indicates this ticket must be resolved before another can proceed"
+    from: [ticket]
+    to: [ticket]
+    min_outgoing: 0
+    max_outgoing: 10
+```
+
 ## Lists
 
 Lists display entities in a sortable, filterable table with optional create/edit actions.

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -181,6 +181,7 @@ Each entity type defines:
 | Field         | Description                                               |
 | ------------- | --------------------------------------------------------- |
 | `label`       | Display name                                              |
+| `description` | Documentation explaining intent and usage (optional)      |
 | `aliases`     | Alternative names for CLI (e.g., `req` for `requirement`) |
 | `id_type`     | `auto` (default) or `manual` - controls ID generation     |
 | `id_patterns` | ID prefixes (e.g., `REQ-`, `ADR-`)                        |
@@ -237,6 +238,32 @@ rela create requirement -t "User authentication"
 rela create component --id auth-service -t "Authentication Service"
 # Creates auth-service
 ```
+
+### Entity Descriptions
+
+Add a `description` field to document the intent and usage of an entity type. Descriptions
+support markdown and are surfaced in the data-entry UI via help modals:
+
+```yaml
+entities:
+  decision:
+    label: Decision
+    description: |
+      A decision records an important architectural choice and its rationale.
+
+      Use decisions when:
+      - Making technology choices (frameworks, databases, etc.)
+      - Defining patterns or conventions
+      - Resolving requirement conflicts
+
+      Each decision should address one or more requirements.
+    properties:
+      # ...
+```
+
+In the data-entry UI, a help icon (?) appears next to the entity form title. Clicking it
+opens a modal showing the entity description, all properties with their descriptions, and
+available relations with cardinality constraints.
 
 ### Example Entity Type
 

--- a/internal/dataentry/app_test.go
+++ b/internal/dataentry/app_test.go
@@ -2,6 +2,7 @@ package dataentry
 
 import (
 	"errors"
+	"html/template"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -136,16 +137,18 @@ func testGraph() *graph.Graph {
 	return g
 }
 
-// testAppInstance creates a minimal App without templates for testing app-level methods.
+// testAppInstance creates a minimal App with templates for testing app-level methods.
 func testAppInstance() *App {
 	cfg := testConfig()
 	meta := testMeta()
 	g := testGraph()
 	styleMap, styledTypes := buildStyleMap(cfg, meta)
+	tmpl, _ := template.New("").Funcs(templateFuncs(styleMap, styledTypes)).Parse(allTemplates())
 	return &App{
 		Cfg:         cfg,
 		meta:        meta,
 		g:           g,
+		tmpl:        tmpl,
 		styleMap:    styleMap,
 		styledTypes: styledTypes,
 	}

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -2508,45 +2508,9 @@ func (a *App) handleEntityHelp(w http.ResponseWriter, r *http.Request) {
 	// Sort properties alphabetically
 	sort.Slice(props, func(i, j int) bool { return props[i].Name < props[j].Name })
 
-	// Gather outgoing relations (where this entity type is in "from")
-	outgoingRels := make([]RelationHelp, 0, len(a.meta.Relations))
-	for name, rel := range a.meta.Relations {
-		if !containsString(rel.From, entityType) {
-			continue
-		}
-		rh := RelationHelp{
-			Name:        name,
-			Label:       rel.Label,
-			TargetType:  strings.Join(rel.To, ", "),
-			Cardinality: formatCardinality(rel.MinOutgoing, rel.MaxOutgoing),
-			Required:    rel.MinOutgoing != nil && *rel.MinOutgoing >= 1,
-		}
-		if rel.Description != "" {
-			rh.Description = simpleMarkdownToHTML(rel.Description)
-		}
-		outgoingRels = append(outgoingRels, rh)
-	}
-	sort.Slice(outgoingRels, func(i, j int) bool { return outgoingRels[i].Name < outgoingRels[j].Name })
-
-	// Gather incoming relations (where this entity type is in "to")
-	incomingRels := make([]RelationHelp, 0, len(a.meta.Relations))
-	for name, rel := range a.meta.Relations {
-		if !containsString(rel.To, entityType) {
-			continue
-		}
-		rh := RelationHelp{
-			Name:        name,
-			Label:       rel.Label,
-			TargetType:  strings.Join(rel.From, ", "),
-			Cardinality: formatCardinality(rel.MinIncoming, rel.MaxIncoming),
-			Required:    rel.MinIncoming != nil && *rel.MinIncoming >= 1,
-		}
-		if rel.Description != "" {
-			rh.Description = simpleMarkdownToHTML(rel.Description)
-		}
-		incomingRels = append(incomingRels, rh)
-	}
-	sort.Slice(incomingRels, func(i, j int) bool { return incomingRels[i].Name < incomingRels[j].Name })
+	// Gather outgoing and incoming relations
+	outgoingRels := a.gatherRelations(entityType, true)
+	incomingRels := a.gatherRelations(entityType, false)
 
 	// Render entity description
 	var entityDesc htmltemplate.HTML
@@ -2564,6 +2528,40 @@ func (a *App) handleEntityHelp(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	a.tmpl.ExecuteTemplate(w, "help-content", data) //nolint:errcheck // template errors logged by http
+}
+
+// gatherRelations collects relation documentation for an entity type.
+// If outgoing is true, gathers relations where entityType is in "from";
+// otherwise gathers relations where entityType is in "to".
+func (a *App) gatherRelations(entityType string, outgoing bool) []RelationHelp {
+	rels := make([]RelationHelp, 0, len(a.meta.Relations))
+	for name, rel := range a.meta.Relations {
+		var matchTypes, targetTypes []string
+		var minCard, maxCard *int
+		if outgoing {
+			matchTypes, targetTypes = rel.From, rel.To
+			minCard, maxCard = rel.MinOutgoing, rel.MaxOutgoing
+		} else {
+			matchTypes, targetTypes = rel.To, rel.From
+			minCard, maxCard = rel.MinIncoming, rel.MaxIncoming
+		}
+		if !containsString(matchTypes, entityType) {
+			continue
+		}
+		rh := RelationHelp{
+			Name:        name,
+			Label:       rel.Label,
+			TargetType:  strings.Join(targetTypes, ", "),
+			Cardinality: formatCardinality(minCard, maxCard),
+			Required:    minCard != nil && *minCard >= 1,
+		}
+		if rel.Description != "" {
+			rh.Description = simpleMarkdownToHTML(rel.Description)
+		}
+		rels = append(rels, rh)
+	}
+	sort.Slice(rels, func(i, j int) bool { return rels[i].Name < rels[j].Name })
+	return rels
 }
 
 // formatCardinality formats min/max constraints as a human-readable string.

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -2458,3 +2458,212 @@ func (a *App) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("HX-Redirect", appendToastParam("/settings", "Settings saved"))
 	w.WriteHeader(http.StatusOK)
 }
+
+// PropertyHelp holds documentation for a single property.
+type PropertyHelp struct {
+	Name        string
+	Type        string
+	Required    bool
+	Description htmltemplate.HTML
+}
+
+// RelationHelp holds documentation for a single relation.
+type RelationHelp struct {
+	Name        string
+	Label       string
+	TargetType  string // target type for outgoing, source type for incoming
+	Cardinality string
+	Description htmltemplate.HTML
+}
+
+// handleEntityHelp returns HTML fragment with documentation for an entity type.
+// GET /api/help/{entityType}
+func (a *App) handleEntityHelp(w http.ResponseWriter, r *http.Request) {
+	entityType := strings.TrimPrefix(r.URL.Path, "/api/help/")
+	if entityType == "" {
+		http.Error(w, "entity type required", http.StatusBadRequest)
+		return
+	}
+
+	entDef, ok := a.meta.GetEntityDef(entityType)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Gather property documentation
+	props := make([]PropertyHelp, 0, len(entDef.Properties))
+	for name, prop := range entDef.Properties {
+		ph := PropertyHelp{
+			Name:     name,
+			Type:     prop.Type,
+			Required: prop.Required,
+		}
+		if prop.Description != "" {
+			ph.Description = simpleMarkdownToHTML(prop.Description)
+		}
+		props = append(props, ph)
+	}
+	// Sort properties alphabetically
+	sort.Slice(props, func(i, j int) bool { return props[i].Name < props[j].Name })
+
+	// Gather outgoing relations (where this entity type is in "from")
+	outgoingRels := make([]RelationHelp, 0, len(a.meta.Relations))
+	for name, rel := range a.meta.Relations {
+		if !containsString(rel.From, entityType) {
+			continue
+		}
+		rh := RelationHelp{
+			Name:        name,
+			Label:       rel.Label,
+			TargetType:  strings.Join(rel.To, ", "),
+			Cardinality: formatCardinality(rel.MinOutgoing, rel.MaxOutgoing),
+		}
+		if rel.Description != "" {
+			rh.Description = simpleMarkdownToHTML(rel.Description)
+		}
+		outgoingRels = append(outgoingRels, rh)
+	}
+	sort.Slice(outgoingRels, func(i, j int) bool { return outgoingRels[i].Name < outgoingRels[j].Name })
+
+	// Gather incoming relations (where this entity type is in "to")
+	incomingRels := make([]RelationHelp, 0, len(a.meta.Relations))
+	for name, rel := range a.meta.Relations {
+		if !containsString(rel.To, entityType) {
+			continue
+		}
+		rh := RelationHelp{
+			Name:        name,
+			Label:       rel.Label,
+			TargetType:  strings.Join(rel.From, ", "),
+			Cardinality: formatCardinality(rel.MinIncoming, rel.MaxIncoming),
+		}
+		if rel.Description != "" {
+			rh.Description = simpleMarkdownToHTML(rel.Description)
+		}
+		incomingRels = append(incomingRels, rh)
+	}
+	sort.Slice(incomingRels, func(i, j int) bool { return incomingRels[i].Name < incomingRels[j].Name })
+
+	// Render entity description
+	var entityDesc htmltemplate.HTML
+	if entDef.Description != "" {
+		entityDesc = simpleMarkdownToHTML(entDef.Description)
+	}
+
+	// Build HTML response
+	var sb strings.Builder
+	sb.WriteString(`<div class="help-content">`)
+
+	// Entity description
+	if entityDesc != "" {
+		sb.WriteString(`<div class="help-section help-entity-desc">`)
+		sb.WriteString(string(entityDesc))
+		sb.WriteString(`</div>`)
+	}
+
+	// Properties section
+	if len(props) > 0 {
+		sb.WriteString(`<div class="help-section"><h4>Properties</h4>`)
+		for _, p := range props {
+			sb.WriteString(`<div class="help-item">`)
+			sb.WriteString(`<div class="help-item-header">`)
+			sb.WriteString(`<code>`)
+			sb.WriteString(html.EscapeString(p.Name))
+			sb.WriteString(`</code>`)
+			sb.WriteString(`<span class="help-item-meta">`)
+			sb.WriteString(html.EscapeString(p.Type))
+			if p.Required {
+				sb.WriteString(` <span class="help-required">required</span>`)
+			}
+			sb.WriteString(`</span>`)
+			sb.WriteString(`</div>`)
+			if p.Description != "" {
+				sb.WriteString(`<div class="help-item-desc">`)
+				sb.WriteString(string(p.Description))
+				sb.WriteString(`</div>`)
+			}
+			sb.WriteString(`</div>`)
+		}
+		sb.WriteString(`</div>`)
+	}
+
+	// Outgoing relations section
+	writeRelationSection(&sb, "Outgoing Relations", "Relations from this entity to others", "→", outgoingRels)
+
+	// Incoming relations section
+	writeRelationSection(&sb, "Incoming Relations", "Relations from other entities to this one", "←", incomingRels)
+
+	// No documentation message
+	if entityDesc == "" && len(props) == 0 && len(outgoingRels) == 0 && len(incomingRels) == 0 {
+		sb.WriteString(`<p class="help-empty">No documentation available for this entity type.</p>`)
+	}
+
+	sb.WriteString(`</div>`)
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte(sb.String()))
+}
+
+// writeRelationSection writes a section of relations to the string builder.
+func writeRelationSection(sb *strings.Builder, title, hint, arrow string, rels []RelationHelp) {
+	if len(rels) == 0 {
+		return
+	}
+	sb.WriteString(`<div class="help-section"><h4>`)
+	sb.WriteString(title)
+	sb.WriteString(`</h4>`)
+	sb.WriteString(`<p class="help-section-hint">`)
+	sb.WriteString(hint)
+	sb.WriteString(`</p>`)
+	for _, r := range rels {
+		sb.WriteString(`<div class="help-item">`)
+		sb.WriteString(`<div class="help-item-header">`)
+		sb.WriteString(`<code>`)
+		sb.WriteString(html.EscapeString(r.Name))
+		sb.WriteString(`</code>`)
+		sb.WriteString(`<span class="help-item-meta">`)
+		sb.WriteString(arrow)
+		sb.WriteString(` `)
+		sb.WriteString(html.EscapeString(r.TargetType))
+		if r.Cardinality != "" {
+			sb.WriteString(` (`)
+			sb.WriteString(html.EscapeString(r.Cardinality))
+			sb.WriteString(`)`)
+		}
+		sb.WriteString(`</span>`)
+		sb.WriteString(`</div>`)
+		if r.Description != "" {
+			sb.WriteString(`<div class="help-item-desc">`)
+			sb.WriteString(string(r.Description))
+			sb.WriteString(`</div>`)
+		}
+		sb.WriteString(`</div>`)
+	}
+	sb.WriteString(`</div>`)
+}
+
+// formatCardinality formats min/max constraints as a human-readable string.
+func formatCardinality(minC, maxC *int) string {
+	if minC == nil && maxC == nil {
+		return ""
+	}
+	minVal := 0
+	if minC != nil {
+		minVal = *minC
+	}
+	if maxC == nil {
+		if minVal == 0 {
+			return ""
+		}
+		return fmt.Sprintf("min %d", minVal)
+	}
+	maxVal := *maxC
+	if minVal == maxVal {
+		return fmt.Sprintf("exactly %d", minVal)
+	}
+	if minVal == 0 {
+		return fmt.Sprintf("max %d", maxVal)
+	}
+	return fmt.Sprintf("%d-%d", minVal, maxVal)
+}

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -2554,99 +2554,16 @@ func (a *App) handleEntityHelp(w http.ResponseWriter, r *http.Request) {
 		entityDesc = simpleMarkdownToHTML(entDef.Description)
 	}
 
-	// Build HTML response
-	var sb strings.Builder
-	sb.WriteString(`<div class="help-content">`)
-
-	// Entity description
-	if entityDesc != "" {
-		sb.WriteString(`<div class="help-section help-entity-desc">`)
-		sb.WriteString(string(entityDesc))
-		sb.WriteString(`</div>`)
+	// Render template
+	data := map[string]interface{}{
+		"EntityDescription": entityDesc,
+		"Properties":        props,
+		"OutgoingRelations": outgoingRels,
+		"IncomingRelations": incomingRels,
 	}
-
-	// Properties section
-	if len(props) > 0 {
-		sb.WriteString(`<div class="help-section"><h4>Properties</h4>`)
-		for _, p := range props {
-			sb.WriteString(`<div class="help-item">`)
-			sb.WriteString(`<div class="help-item-header">`)
-			sb.WriteString(`<code>`)
-			sb.WriteString(html.EscapeString(p.Name))
-			sb.WriteString(`</code>`)
-			sb.WriteString(`<span class="help-item-meta">`)
-			sb.WriteString(html.EscapeString(p.Type))
-			if p.Required {
-				sb.WriteString(` <span class="help-required">required</span>`)
-			}
-			sb.WriteString(`</span>`)
-			sb.WriteString(`</div>`)
-			if p.Description != "" {
-				sb.WriteString(`<div class="help-item-desc">`)
-				sb.WriteString(string(p.Description))
-				sb.WriteString(`</div>`)
-			}
-			sb.WriteString(`</div>`)
-		}
-		sb.WriteString(`</div>`)
-	}
-
-	// Outgoing relations section
-	writeRelationSection(&sb, "Outgoing Relations", "Relations from this entity to others", "→", outgoingRels)
-
-	// Incoming relations section
-	writeRelationSection(&sb, "Incoming Relations", "Relations from other entities to this one", "←", incomingRels)
-
-	// No documentation message
-	if entityDesc == "" && len(props) == 0 && len(outgoingRels) == 0 && len(incomingRels) == 0 {
-		sb.WriteString(`<p class="help-empty">No documentation available for this entity type.</p>`)
-	}
-
-	sb.WriteString(`</div>`)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = w.Write([]byte(sb.String()))
-}
-
-// writeRelationSection writes a section of relations to the string builder.
-func writeRelationSection(sb *strings.Builder, title, hint, arrow string, rels []RelationHelp) {
-	if len(rels) == 0 {
-		return
-	}
-	sb.WriteString(`<div class="help-section"><h4>`)
-	sb.WriteString(title)
-	sb.WriteString(`</h4>`)
-	sb.WriteString(`<p class="help-section-hint">`)
-	sb.WriteString(hint)
-	sb.WriteString(`</p>`)
-	for _, r := range rels {
-		sb.WriteString(`<div class="help-item">`)
-		sb.WriteString(`<div class="help-item-header">`)
-		sb.WriteString(`<code>`)
-		sb.WriteString(html.EscapeString(r.Name))
-		sb.WriteString(`</code>`)
-		if r.Required {
-			sb.WriteString(` <span class="help-required">required</span>`)
-		}
-		sb.WriteString(`<span class="help-item-meta">`)
-		sb.WriteString(arrow)
-		sb.WriteString(` `)
-		sb.WriteString(html.EscapeString(r.TargetType))
-		if r.Cardinality != "" {
-			sb.WriteString(` (`)
-			sb.WriteString(html.EscapeString(r.Cardinality))
-			sb.WriteString(`)`)
-		}
-		sb.WriteString(`</span>`)
-		sb.WriteString(`</div>`)
-		if r.Description != "" {
-			sb.WriteString(`<div class="help-item-desc">`)
-			sb.WriteString(string(r.Description))
-			sb.WriteString(`</div>`)
-		}
-		sb.WriteString(`</div>`)
-	}
-	sb.WriteString(`</div>`)
+	a.tmpl.ExecuteTemplate(w, "help-content", data) //nolint:errcheck // template errors logged by http
 }
 
 // formatCardinality formats min/max constraints as a human-readable string.

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -2473,6 +2473,7 @@ type RelationHelp struct {
 	Label       string
 	TargetType  string // target type for outgoing, source type for incoming
 	Cardinality string
+	Required    bool // true if min cardinality >= 1
 	Description htmltemplate.HTML
 }
 
@@ -2518,6 +2519,7 @@ func (a *App) handleEntityHelp(w http.ResponseWriter, r *http.Request) {
 			Label:       rel.Label,
 			TargetType:  strings.Join(rel.To, ", "),
 			Cardinality: formatCardinality(rel.MinOutgoing, rel.MaxOutgoing),
+			Required:    rel.MinOutgoing != nil && *rel.MinOutgoing >= 1,
 		}
 		if rel.Description != "" {
 			rh.Description = simpleMarkdownToHTML(rel.Description)
@@ -2537,6 +2539,7 @@ func (a *App) handleEntityHelp(w http.ResponseWriter, r *http.Request) {
 			Label:       rel.Label,
 			TargetType:  strings.Join(rel.From, ", "),
 			Cardinality: formatCardinality(rel.MinIncoming, rel.MaxIncoming),
+			Required:    rel.MinIncoming != nil && *rel.MinIncoming >= 1,
 		}
 		if rel.Description != "" {
 			rh.Description = simpleMarkdownToHTML(rel.Description)
@@ -2622,6 +2625,9 @@ func writeRelationSection(sb *strings.Builder, title, hint, arrow string, rels [
 		sb.WriteString(`<code>`)
 		sb.WriteString(html.EscapeString(r.Name))
 		sb.WriteString(`</code>`)
+		if r.Required {
+			sb.WriteString(` <span class="help-required">required</span>`)
+		}
 		sb.WriteString(`<span class="help-item-meta">`)
 		sb.WriteString(arrow)
 		sb.WriteString(` `)

--- a/internal/dataentry/handlers_api_test.go
+++ b/internal/dataentry/handlers_api_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
@@ -285,3 +286,81 @@ func TestHandleAPIRelationsCRUD_MethodNotAllowed(t *testing.T) {
 		t.Errorf("expected 405, got %d", w.Code)
 	}
 }
+
+func TestHandleEntityHelp(t *testing.T) {
+	app := testAppInstance()
+
+	t.Run("valid entity type", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/api/help/ticket", http.NoBody)
+		app.handleEntityHelp(w, r)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+
+		body := w.Body.String()
+		if !strings.Contains(body, "help-content") {
+			t.Error("expected help-content class in response")
+		}
+		// Should contain properties section
+		if !strings.Contains(body, "Properties") {
+			t.Error("expected Properties section in response")
+		}
+		// Should contain title property (required)
+		if !strings.Contains(body, "title") {
+			t.Error("expected title property in response")
+		}
+		// Should contain outgoing relations
+		if !strings.Contains(body, "Outgoing Relations") {
+			t.Error("expected Outgoing Relations section in response")
+		}
+	})
+
+	t.Run("entity not found", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/api/help/nonexistent", http.NoBody)
+		app.handleEntityHelp(w, r)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("missing entity type", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/api/help/", http.NoBody)
+		app.handleEntityHelp(w, r)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+}
+
+func TestFormatCardinality(t *testing.T) {
+	tests := []struct {
+		name     string
+		min, max *int
+		want     string
+	}{
+		{"nil both", nil, nil, ""},
+		{"min only zero", intPtr(0), nil, ""},
+		{"min only nonzero", intPtr(1), nil, "min 1"},
+		{"max only", nil, intPtr(5), "max 5"},
+		{"exact", intPtr(3), intPtr(3), "exactly 3"},
+		{"range", intPtr(1), intPtr(5), "1-5"},
+		{"zero to max", intPtr(0), intPtr(3), "max 3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatCardinality(tt.min, tt.max)
+			if got != tt.want {
+				t.Errorf("formatCardinality(%v, %v) = %q, want %q", tt.min, tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
+func intPtr(i int) *int { return &i }

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -39,6 +39,7 @@ func (a *App) NewRouter() http.Handler {
 	inner.HandleFunc("/api/toggle-checkbox", a.handleToggleCheckbox)
 	inner.HandleFunc("/api/inline-create", a.handleInlineCreate)
 	inner.HandleFunc("/api/inline-form/", a.handleInlineForm)
+	inner.HandleFunc("/api/help/", a.handleEntityHelp)
 	inner.HandleFunc("/api/link-candidates", a.handleLinkCandidates)
 	inner.HandleFunc("/api/link-existing", a.handleLinkExisting)
 	inner.HandleFunc("/graph", a.handleGraph)

--- a/internal/dataentry/static/app.css
+++ b/internal/dataentry/static/app.css
@@ -634,3 +634,28 @@ tbody tr.row-selected { background: #dbeafe; outline: 2px solid var(--primary); 
 .analyze-section thead th { padding: 8px 16px; font-size: 11px; }
 .analyze-section tbody td { padding: 8px 16px; vertical-align: top; }
 .analyze-section-ok { padding: 16px; color: #166534; font-size: 13px; font-weight: 500; border-top: 1px solid var(--border); }
+
+/* Help modal and content */
+.btn-help { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; border-radius: 50%; background: var(--bg); border: 1px solid var(--border); color: var(--text-muted); font-size: 13px; font-weight: 600; cursor: pointer; margin-left: 8px; vertical-align: middle; transition: all 0.15s; }
+.btn-help:hover { background: var(--primary-light); border-color: var(--primary); color: var(--primary); }
+.modal-help { width: 560px; max-height: 80vh; }
+.help-content { font-size: 14px; line-height: 1.6; }
+.help-content p { margin: 0 0 12px; }
+.help-content ul, .help-content ol { margin: 0 0 12px; padding-left: 20px; }
+.help-content li { margin-bottom: 4px; }
+.help-content code { background: var(--bg); padding: 2px 6px; border-radius: 4px; font-size: 13px; font-family: var(--font-mono); }
+.help-content h2 { font-size: 16px; font-weight: 600; margin: 16px 0 8px; }
+.help-content h3 { font-size: 14px; font-weight: 600; margin: 12px 0 6px; }
+.help-entity-desc { padding-bottom: 16px; border-bottom: 1px solid var(--border); margin-bottom: 16px; }
+.help-section { margin-bottom: 20px; }
+.help-section h4 { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); margin: 0 0 12px; }
+.help-section-hint { font-size: 12px; color: var(--text-muted); margin: -8px 0 12px; }
+.help-item { padding: 10px 12px; background: var(--bg); border-radius: 6px; margin-bottom: 8px; }
+.help-item-header { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; }
+.help-item-header code { background: var(--bg-card); font-weight: 600; }
+.help-item-meta { font-size: 12px; color: var(--text-muted); }
+.help-required { background: var(--danger-light); color: var(--danger); padding: 1px 6px; border-radius: 3px; font-size: 10px; font-weight: 600; text-transform: uppercase; }
+.help-item-desc { font-size: 13px; color: var(--text); }
+.help-item-desc p { margin: 0; }
+.help-item-desc p + p { margin-top: 8px; }
+.help-empty { text-align: center; color: var(--text-muted); padding: 24px 0; }

--- a/internal/dataentry/static/app.js
+++ b/internal/dataentry/static/app.js
@@ -1593,6 +1593,45 @@ function submitInlineCreate() {
     .catch(function(e) { alert('Error creating: ' + e); });
 }
 
+// Help modal
+function openHelpModal(entityType) {
+  var modal = document.getElementById('help-modal');
+  var title = document.getElementById('help-modal-title');
+  var body = document.getElementById('help-modal-body');
+  if (!modal || !body) return;
+
+  title.textContent = entityType + ' — Help';
+  body.innerHTML = '<p style="color:var(--text-muted);text-align:center;">Loading...</p>';
+  modal.style.display = 'flex';
+
+  fetch('/api/help/' + encodeURIComponent(entityType))
+    .then(function(r) {
+      if (!r.ok) throw new Error('Not found');
+      return r.text();
+    })
+    .then(function(html) {
+      body.innerHTML = html;
+    })
+    .catch(function() {
+      body.innerHTML = '<p style="color:var(--danger);text-align:center;">Failed to load help.</p>';
+    });
+}
+
+function closeHelpModal() {
+  var modal = document.getElementById('help-modal');
+  if (modal) modal.style.display = 'none';
+}
+
+// Close help modal on Escape key
+document.addEventListener('keydown', function(e) {
+  if (e.key === 'Escape') {
+    var modal = document.getElementById('help-modal');
+    if (modal && modal.style.display === 'flex') {
+      closeHelpModal();
+    }
+  }
+});
+
 // Side panel toggle (mobile)
 function toggleSidePanel(btn) {
   var chevron = btn.querySelector('.sp-chevron');

--- a/internal/dataentry/templates/form.html
+++ b/internal/dataentry/templates/form.html
@@ -19,7 +19,9 @@
 {{ if .SidePanelSections }}<div class="form-column">{{ end }}
 <div class="page-header">
   <div>
-    <h2>{{ .Form.Title }}{{ if .EntityID }} — {{ .EntityID }}{{ end }}</h2>
+    <h2>{{ .Form.Title }}{{ if .EntityID }} — {{ .EntityID }}{{ end }}
+      <button type="button" class="btn-help" onclick="openHelpModal('{{ .EntityType }}')" title="Help for {{ .Form.Title }}">?</button>
+    </h2>
     {{ if .Form.Description }}<p>{{ .Form.Description }}</p>{{ end }}
   </div>
   <a href="{{ .BackURL }}" class="btn btn-secondary btn-sm"
@@ -344,6 +346,18 @@
     <div class="modal-footer">
       <button class="btn btn-secondary btn-sm" onclick="closeInlineCreate()">Cancel</button>
       <button class="btn btn-primary btn-sm" onclick="submitInlineCreate()">Create</button>
+    </div>
+  </div>
+</div>
+
+<div id="help-modal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)closeHelpModal()">
+  <div class="modal modal-help">
+    <div class="modal-header">
+      <h3 id="help-modal-title">Help</h3>
+      <button class="modal-close" onclick="closeHelpModal()">&times;</button>
+    </div>
+    <div class="modal-body" id="help-modal-body">
+      <p style="color:var(--text-muted);">Loading...</p>
     </div>
   </div>
 </div>

--- a/internal/dataentry/templates/help.html
+++ b/internal/dataentry/templates/help.html
@@ -1,3 +1,22 @@
+{{- define "help-relation-section" -}}
+{{ if .Relations }}
+<div class="help-section">
+  <h4>{{ .Title }}</h4>
+  <p class="help-section-hint">{{ .Hint }}</p>
+  {{ range .Relations }}
+  <div class="help-item">
+    <div class="help-item-header">
+      <code>{{ .Name }}</code>
+      {{ if .Required }}<span class="help-required">required</span>{{ end }}
+      <span class="help-item-meta">{{ $.Arrow }} {{ .TargetType }}{{ if .Cardinality }} ({{ .Cardinality }}){{ end }}</span>
+    </div>
+    {{ if .Description }}<div class="help-item-desc">{{ .Description }}</div>{{ end }}
+  </div>
+  {{ end }}
+</div>
+{{ end }}
+{{- end -}}
+
 {{- define "help-content" -}}
 <div class="help-content">
 
@@ -22,39 +41,8 @@
 </div>
 {{ end }}
 
-{{ if .OutgoingRelations }}
-<div class="help-section">
-  <h4>Outgoing Relations</h4>
-  <p class="help-section-hint">Relations from this entity to others</p>
-  {{ range .OutgoingRelations }}
-  <div class="help-item">
-    <div class="help-item-header">
-      <code>{{ .Name }}</code>
-      {{ if .Required }}<span class="help-required">required</span>{{ end }}
-      <span class="help-item-meta">→ {{ .TargetType }}{{ if .Cardinality }} ({{ .Cardinality }}){{ end }}</span>
-    </div>
-    {{ if .Description }}<div class="help-item-desc">{{ .Description }}</div>{{ end }}
-  </div>
-  {{ end }}
-</div>
-{{ end }}
-
-{{ if .IncomingRelations }}
-<div class="help-section">
-  <h4>Incoming Relations</h4>
-  <p class="help-section-hint">Relations from other entities to this one</p>
-  {{ range .IncomingRelations }}
-  <div class="help-item">
-    <div class="help-item-header">
-      <code>{{ .Name }}</code>
-      {{ if .Required }}<span class="help-required">required</span>{{ end }}
-      <span class="help-item-meta">← {{ .TargetType }}{{ if .Cardinality }} ({{ .Cardinality }}){{ end }}</span>
-    </div>
-    {{ if .Description }}<div class="help-item-desc">{{ .Description }}</div>{{ end }}
-  </div>
-  {{ end }}
-</div>
-{{ end }}
+{{ template "help-relation-section" map "Title" "Outgoing Relations" "Hint" "Relations from this entity to others" "Arrow" "→" "Relations" .OutgoingRelations }}
+{{ template "help-relation-section" map "Title" "Incoming Relations" "Hint" "Relations from other entities to this one" "Arrow" "←" "Relations" .IncomingRelations }}
 
 {{ if and (not .EntityDescription) (not .Properties) (not .OutgoingRelations) (not .IncomingRelations) }}
 <p class="help-empty">No documentation available for this entity type.</p>

--- a/internal/dataentry/templates/help.html
+++ b/internal/dataentry/templates/help.html
@@ -1,0 +1,64 @@
+{{- define "help-content" -}}
+<div class="help-content">
+
+{{ if .EntityDescription }}
+<div class="help-section help-entity-desc">
+{{ .EntityDescription }}
+</div>
+{{ end }}
+
+{{ if .Properties }}
+<div class="help-section">
+  <h4>Properties</h4>
+  {{ range .Properties }}
+  <div class="help-item">
+    <div class="help-item-header">
+      <code>{{ .Name }}</code>
+      <span class="help-item-meta">{{ .Type }}{{ if .Required }} <span class="help-required">required</span>{{ end }}</span>
+    </div>
+    {{ if .Description }}<div class="help-item-desc">{{ .Description }}</div>{{ end }}
+  </div>
+  {{ end }}
+</div>
+{{ end }}
+
+{{ if .OutgoingRelations }}
+<div class="help-section">
+  <h4>Outgoing Relations</h4>
+  <p class="help-section-hint">Relations from this entity to others</p>
+  {{ range .OutgoingRelations }}
+  <div class="help-item">
+    <div class="help-item-header">
+      <code>{{ .Name }}</code>
+      {{ if .Required }}<span class="help-required">required</span>{{ end }}
+      <span class="help-item-meta">→ {{ .TargetType }}{{ if .Cardinality }} ({{ .Cardinality }}){{ end }}</span>
+    </div>
+    {{ if .Description }}<div class="help-item-desc">{{ .Description }}</div>{{ end }}
+  </div>
+  {{ end }}
+</div>
+{{ end }}
+
+{{ if .IncomingRelations }}
+<div class="help-section">
+  <h4>Incoming Relations</h4>
+  <p class="help-section-hint">Relations from other entities to this one</p>
+  {{ range .IncomingRelations }}
+  <div class="help-item">
+    <div class="help-item-header">
+      <code>{{ .Name }}</code>
+      {{ if .Required }}<span class="help-required">required</span>{{ end }}
+      <span class="help-item-meta">← {{ .TargetType }}{{ if .Cardinality }} ({{ .Cardinality }}){{ end }}</span>
+    </div>
+    {{ if .Description }}<div class="help-item-desc">{{ .Description }}</div>{{ end }}
+  </div>
+  {{ end }}
+</div>
+{{ end }}
+
+{{ if and (not .EntityDescription) (not .Properties) (not .OutgoingRelations) (not .IncomingRelations) }}
+<p class="help-empty">No documentation available for this entity type.</p>
+{{ end }}
+
+</div>
+{{- end -}}

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -71,7 +71,8 @@ type CustomType struct {
 type EntityDef struct {
 	Label       string                 `yaml:"label"`
 	LabelPlural string                 `yaml:"label_plural,omitempty"`
-	Plural      string                 `yaml:"plural,omitempty"` // Used for directory names (e.g., "policies" for "policy")
+	Description string                 `yaml:"description,omitempty"` // Documentation explaining intent/usage
+	Plural      string                 `yaml:"plural,omitempty"`      // Used for directory names (e.g., "policies" for "policy")
 	Aliases     []string               `yaml:"aliases,omitempty"`
 	IDType      string                 `yaml:"id_type,omitempty"`     // "auto" (default) or "manual"
 	IDPrefix    string                 `yaml:"id_prefix,omitempty"`   // Single ID prefix (sugar for single-element id_prefixes)

--- a/tickets/entities/features/FEAT-8cwr.md
+++ b/tickets/entities/features/FEAT-8cwr.md
@@ -1,0 +1,21 @@
+---
+id: FEAT-8cwr
+status: implemented
+title: Help modal for entity documentation in data-entry
+type: feature
+---
+
+## Summary
+Add optional `description` fields to metamodel entities, properties, and relations. Surface these in data-entry via a help icon (?) that opens a modal showing documentation.
+
+## Features
+- Entity type descriptions explaining when/how to use each type
+- Property descriptions with type info and required indicator  
+- Relation descriptions showing cardinality and required status
+- Markdown rendering for all descriptions
+
+## Implementation
+- Added `description` field to `EntityDef` in metamodel (properties/relations already had it)
+- New `/api/help/{entityType}` endpoint returns rendered HTML
+- Help icon in form header opens modal via JavaScript
+- Template-based rendering with reusable partials

--- a/tickets/relations/FEAT-8cwr--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-8cwr--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-8cwr
+relation: requires
+to: data-entry-ui
+---


### PR DESCRIPTION
## Summary
- Add optional `description` field to entity types in metamodel
- Add help icon (?) button next to entity type in form headers
- Help modal displays entity description, properties with descriptions, and relations (outgoing/incoming) with descriptions
- Descriptions support markdown rendering

## Test plan
- [ ] Add descriptions to metamodel entities/properties/relations
- [ ] Open a form in data-entry and click the help icon
- [ ] Verify modal shows entity description, properties, and relations
- [ ] Verify markdown is rendered correctly
- [ ] Test with entity types that have no descriptions (shows "No documentation" message)