### PR TITLE
feat(metamodel): add regex validations for custom types

### DIFF
--- a/docs-project/entities/guide/GUIDE-metamodel.md
+++ b/docs-project/entities/guide/GUIDE-metamodel.md
@@ -212,20 +212,6 @@ Each validation requires:
 - Patterns are easier to write and maintain
 - No mega-regex with opaque errors
 
-### Combined Enum and Regex
-
-A type can have both enum values and regex validations. The value must be in
-the allowed list AND pass all regex validations:
-
-```yaml
-types:
-  lowercase_status:
-    values: [draft, review, published]
-    validations:
-      - pattern: "^[a-z]+$"
-        error: "Must be lowercase letters only"
-```
-
 ### Empty Values
 
 - **Enum types**: Empty string is not a valid value (fails validation)

--- a/docs-project/entities/guide/GUIDE-metamodel.md
+++ b/docs-project/entities/guide/GUIDE-metamodel.md
@@ -154,7 +154,12 @@ To resolve conflicts, rename one of the definitions or move it to a shared file.
 
 ## Custom Types
 
-Define reusable enum types that can be used in entity properties:
+Define reusable types that can be used in entity properties. Custom types support
+enum values, regex validations, or both.
+
+### Enum Types
+
+Define allowed values for a property:
 
 ```yaml
 types:
@@ -165,6 +170,67 @@ types:
   priority:
     values: [critical, high, medium, low]
 ```
+
+### Regex Validations
+
+Define validation patterns with user-friendly error messages. Multiple patterns
+can be combined—all must pass for a value to be valid:
+
+```yaml
+types:
+  semver:
+    description: "Semantic version number"
+    validations:
+      - pattern: '^\d+\.\d+\.\d+$'
+        error: "Must be valid semver (e.g., 1.2.3)"
+
+  rrule:
+    description: "iCal recurrence rule (RFC 5545)"
+    validations:
+      - pattern: "^FREQ=(YEARLY|MONTHLY|WEEKLY|DAILY)"
+        error: "Must start with valid FREQ"
+      - pattern: "^(?!.*COUNT=.*UNTIL=)"
+        error: "Cannot specify both COUNT and UNTIL"
+
+  email:
+    validations:
+      - pattern: "^[^@]+@[^@]+\\.[^@]+$"
+        error: "Must be a valid email address"
+```
+
+Each validation requires:
+
+| Field     | Description                                        |
+| --------- | -------------------------------------------------- |
+| `pattern` | Regex pattern that values must match               |
+| `error`   | User-friendly error message shown when validation fails |
+
+**Benefits of multiple simple patterns vs one complex regex:**
+
+- Each pattern has its own clear error message
+- Users see exactly which validation failed
+- Patterns are easier to write and maintain
+- No mega-regex with opaque errors
+
+### Combined Enum and Regex
+
+A type can have both enum values and regex validations. The value must be in
+the allowed list AND pass all regex validations:
+
+```yaml
+types:
+  lowercase_status:
+    values: [draft, review, published]
+    validations:
+      - pattern: "^[a-z]+$"
+        error: "Must be lowercase letters only"
+```
+
+### Empty Values
+
+- **Enum types**: Empty string is not a valid value (fails validation)
+- **Regex-only types**: Empty strings skip validation (let `required` handle it)
+- **List properties**: Each item in the list is validated independently
 
 ### Reserved Type Names
 

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -148,7 +148,12 @@ To resolve conflicts, rename one of the definitions or move it to a shared file.
 
 ## Custom Types
 
-Define reusable enum types that can be used in entity properties:
+Define reusable types that can be used in entity properties. Custom types support
+enum values, regex validations, or both.
+
+### Enum Types
+
+Define allowed values for a property:
 
 ```yaml
 types:
@@ -159,6 +164,67 @@ types:
   priority:
     values: [critical, high, medium, low]
 ```
+
+### Regex Validations
+
+Define validation patterns with user-friendly error messages. Multiple patterns
+can be combined—all must pass for a value to be valid:
+
+```yaml
+types:
+  semver:
+    description: "Semantic version number"
+    validations:
+      - pattern: '^\d+\.\d+\.\d+$'
+        error: "Must be valid semver (e.g., 1.2.3)"
+
+  rrule:
+    description: "iCal recurrence rule (RFC 5545)"
+    validations:
+      - pattern: "^FREQ=(YEARLY|MONTHLY|WEEKLY|DAILY)"
+        error: "Must start with valid FREQ"
+      - pattern: "^(?!.*COUNT=.*UNTIL=)"
+        error: "Cannot specify both COUNT and UNTIL"
+
+  email:
+    validations:
+      - pattern: "^[^@]+@[^@]+\\.[^@]+$"
+        error: "Must be a valid email address"
+```
+
+Each validation requires:
+
+| Field     | Description                                        |
+| --------- | -------------------------------------------------- |
+| `pattern` | Regex pattern that values must match               |
+| `error`   | User-friendly error message shown when validation fails |
+
+**Benefits of multiple simple patterns vs one complex regex:**
+
+- Each pattern has its own clear error message
+- Users see exactly which validation failed
+- Patterns are easier to write and maintain
+- No mega-regex with opaque errors
+
+### Combined Enum and Regex
+
+A type can have both enum values and regex validations. The value must be in
+the allowed list AND pass all regex validations:
+
+```yaml
+types:
+  lowercase_status:
+    values: [draft, review, published]
+    validations:
+      - pattern: "^[a-z]+$"
+        error: "Must be lowercase letters only"
+```
+
+### Empty Values
+
+- **Enum types**: Empty string is not a valid value (fails validation)
+- **Regex-only types**: Empty strings skip validation (let `required` handle it)
+- **List properties**: Each item in the list is validated independently
 
 ### Reserved Type Names
 

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -206,20 +206,6 @@ Each validation requires:
 - Patterns are easier to write and maintain
 - No mega-regex with opaque errors
 
-### Combined Enum and Regex
-
-A type can have both enum values and regex validations. The value must be in
-the allowed list AND pass all regex validations:
-
-```yaml
-types:
-  lowercase_status:
-    values: [draft, review, published]
-    validations:
-      - pattern: "^[a-z]+$"
-        error: "Must be lowercase letters only"
-```
-
 ### Empty Values
 
 - **Enum types**: Empty string is not a valid value (fails validation)

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -3,6 +3,7 @@ package metamodel
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -142,6 +143,7 @@ func validate(m *Metamodel) error {
 		validationErrors = append(validationErrors, "metamodel has no entity types defined")
 	}
 
+	validationErrors = append(validationErrors, validateCustomTypes(m)...)
 	validationErrors = append(validationErrors, validateEntitySemantics(m)...)
 	validationErrors = append(validationErrors, validateRelationReferences(m)...)
 
@@ -257,6 +259,46 @@ func validateDefaultSort(entityName string, def EntityDef) []string {
 				entityName, i, ss.Direction))
 		}
 	}
+	return errs
+}
+
+// validateCustomTypes validates custom type definitions, compiles regex patterns,
+// and stores the compiled regexes for use during validation.
+func validateCustomTypes(m *Metamodel) []string {
+	var errs []string
+
+	typeNames := sortedKeys(m.Types)
+	for _, typeName := range typeNames {
+		customType := m.Types[typeName]
+
+		for i := range customType.Validations {
+			validation := &customType.Validations[i]
+
+			if validation.Pattern == "" {
+				errs = append(errs, fmt.Sprintf(
+					"type %q: validation[%d] has empty pattern", typeName, i))
+				continue
+			}
+			if validation.Error == "" {
+				errs = append(errs, fmt.Sprintf(
+					"type %q: validation[%d] has empty error message", typeName, i))
+			}
+
+			re, err := regexp.Compile(validation.Pattern)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf(
+					"type %q: validation[%d] has invalid regex pattern %q: %v",
+					typeName, i, validation.Pattern, err))
+			} else {
+				// Cache the compiled regex for use during validation
+				validation.SetCompiled(re)
+			}
+		}
+
+		// Write back the modified type with compiled regexes
+		m.Types[typeName] = customType
+	}
+
 	return errs
 }
 

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -1036,3 +1036,165 @@ func TestSchemaValidationError_MultipleErrors(t *testing.T) {
 	expected := "metamodel validation errors:\n  - first problem\n  - second problem"
 	assertEqual(t, err.Error(), expected)
 }
+
+func TestParse_CustomTypeWithValidations(t *testing.T) {
+	yaml := `
+version: "1.0"
+namespace: "https://example.org/"
+types:
+  semver:
+    description: "Semantic version"
+    validations:
+      - pattern: '^\d+\.\d+\.\d+$'
+        error: "Must be valid semver (e.g., 1.2.3)"
+entities:
+  component:
+    label: Component
+    id_prefix: "COMP-"
+    properties:
+      name:
+        type: string
+        required: true
+      version:
+        type: semver
+`
+	meta, err := Parse([]byte(yaml))
+	assertNoError(t, err)
+
+	if meta == nil {
+		t.Fatal("expected metamodel, got nil")
+	}
+
+	// Verify the type was loaded
+	semver, ok := meta.Types["semver"]
+	if !ok {
+		t.Fatal("expected semver type to be defined")
+	}
+	if semver.Description != "Semantic version" {
+		t.Errorf("expected description 'Semantic version', got %q", semver.Description)
+	}
+	if len(semver.Validations) != 1 {
+		t.Fatalf("expected 1 validation, got %d", len(semver.Validations))
+	}
+	if semver.Validations[0].Pattern != `^\d+\.\d+\.\d+$` {
+		t.Errorf("unexpected pattern: %s", semver.Validations[0].Pattern)
+	}
+	if semver.Validations[0].Error != "Must be valid semver (e.g., 1.2.3)" {
+		t.Errorf("unexpected error message: %s", semver.Validations[0].Error)
+	}
+}
+
+func TestParse_CustomTypeWithInvalidRegex(t *testing.T) {
+	yaml := `
+version: "1.0"
+namespace: "https://example.org/"
+types:
+  bad_type:
+    validations:
+      - pattern: '[invalid(regex'
+        error: "This won't work"
+entities:
+  item:
+    label: Item
+    id_prefix: "ITEM-"
+    properties:
+      name:
+        type: string
+        required: true
+`
+	_, err := Parse([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for invalid regex pattern")
+	}
+	if !strings.Contains(err.Error(), "invalid regex pattern") {
+		t.Errorf("expected 'invalid regex pattern' in error, got: %v", err)
+	}
+}
+
+func TestParse_CustomTypeWithEmptyPattern(t *testing.T) {
+	yaml := `
+version: "1.0"
+namespace: "https://example.org/"
+types:
+  bad_type:
+    validations:
+      - pattern: ""
+        error: "Empty pattern"
+entities:
+  item:
+    label: Item
+    id_prefix: "ITEM-"
+    properties:
+      name:
+        type: string
+        required: true
+`
+	_, err := Parse([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for empty pattern")
+	}
+	if !strings.Contains(err.Error(), "empty pattern") {
+		t.Errorf("expected 'empty pattern' in error, got: %v", err)
+	}
+}
+
+func TestParse_CustomTypeWithEmptyError(t *testing.T) {
+	yaml := `
+version: "1.0"
+namespace: "https://example.org/"
+types:
+  bad_type:
+    validations:
+      - pattern: "^test$"
+        error: ""
+entities:
+  item:
+    label: Item
+    id_prefix: "ITEM-"
+    properties:
+      name:
+        type: string
+        required: true
+`
+	_, err := Parse([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for empty error message")
+	}
+	if !strings.Contains(err.Error(), "empty error message") {
+		t.Errorf("expected 'empty error message' in error, got: %v", err)
+	}
+}
+
+func TestParse_CustomTypeWithEnumAndValidations(t *testing.T) {
+	// A type can have both enum values AND regex validations
+	yaml := `
+version: "1.0"
+namespace: "https://example.org/"
+types:
+  constrained_status:
+    values: [draft, review, published]
+    validations:
+      - pattern: '^[a-z]+$'
+        error: "Must be lowercase"
+entities:
+  document:
+    label: Document
+    id_prefix: "DOC-"
+    properties:
+      title:
+        type: string
+        required: true
+      status:
+        type: constrained_status
+`
+	meta, err := Parse([]byte(yaml))
+	assertNoError(t, err)
+
+	ct := meta.Types["constrained_status"]
+	if len(ct.Values) != 3 {
+		t.Errorf("expected 3 enum values, got %d", len(ct.Values))
+	}
+	if len(ct.Validations) != 1 {
+		t.Errorf("expected 1 validation, got %d", len(ct.Validations))
+	}
+}

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -1,6 +1,10 @@
 package metamodel
 
-import "github.com/Sourcehaven-BV/rela/internal/model"
+import (
+	"regexp"
+
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
 
 // Metamodel represents the full metamodel configuration
 type Metamodel struct {
@@ -61,10 +65,33 @@ func (v *ValidationRule) IsError() bool {
 	return v.GetSeverity() == "error"
 }
 
-// CustomType defines a reusable enum type
+// TypeValidation defines a regex validation for a custom type.
+type TypeValidation struct {
+	Pattern string `yaml:"pattern"` // Regex pattern that values must match
+	Error   string `yaml:"error"`   // User-friendly error message if pattern doesn't match
+
+	// compiled is the pre-compiled regex, populated during metamodel load.
+	// Not exported to prevent YAML serialization issues.
+	compiled *regexp.Regexp
+}
+
+// Compiled returns the pre-compiled regex pattern.
+// Returns nil if the pattern hasn't been compiled yet.
+func (tv *TypeValidation) Compiled() *regexp.Regexp {
+	return tv.compiled
+}
+
+// SetCompiled sets the pre-compiled regex pattern.
+func (tv *TypeValidation) SetCompiled(re *regexp.Regexp) {
+	tv.compiled = re
+}
+
+// CustomType defines a reusable type with optional enum values and/or regex validations.
 type CustomType struct {
-	Values  []string `yaml:"values"`
-	Default string   `yaml:"default,omitempty"`
+	Values      []string         `yaml:"values,omitempty"`      // Allowed values (makes this an enum type)
+	Default     string           `yaml:"default,omitempty"`     // Default value
+	Description string           `yaml:"description,omitempty"` // Documentation for the type
+	Validations []TypeValidation `yaml:"validations,omitempty"` // Regex validations with error messages
 }
 
 // EntityDef defines an entity type in the metamodel

--- a/internal/metamodel/validation.go
+++ b/internal/metamodel/validation.go
@@ -2,7 +2,9 @@ package metamodel
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/model"
@@ -230,9 +232,28 @@ func (m *Metamodel) validatePropertyValue(propName string, propDef *PropertyDef,
 	return nil
 }
 
-// validateCustomTypeValue validates a value against a custom type's allowed values.
+// validateCustomTypeValue validates a value against a custom type's allowed values and regex validations.
 // Supports both single string values and []string (multi-select).
+// Returns an error combining all validation failures.
+//
+//nolint:funlen // validation logic for multiple cases; splitting would reduce readability
 func validateCustomTypeValue(propName string, customType CustomType, val interface{}) *ValidationError {
+	hasEnumValues := len(customType.Values) > 0
+	hasValidations := len(customType.Validations) > 0
+
+	// If no values and no validations, treat as plain string (no validation needed)
+	if !hasEnumValues && !hasValidations {
+		if _, ok := val.(string); !ok {
+			return &ValidationError{
+				Type:     ValidationErrorInvalidType,
+				Property: propName,
+				Message:  "Must be a string",
+			}
+		}
+		return nil
+	}
+
+	// Build allowed values map for enum validation
 	allowed := make(map[string]bool, len(customType.Values))
 	for _, v := range customType.Values {
 		allowed[v] = true
@@ -240,20 +261,29 @@ func validateCustomTypeValue(propName string, customType CustomType, val interfa
 
 	// Handle []string (multi-select from form submission)
 	if list, ok := val.([]string); ok {
-		if len(list) == 0 {
+		if len(list) == 0 && hasEnumValues {
 			return &ValidationError{
 				Type:     ValidationErrorInvalidValue,
 				Property: propName,
 				Message:  fmt.Sprintf("Empty list (allowed: %v)", customType.Values),
 			}
 		}
-		for _, s := range list {
-			if !allowed[s] {
-				return &ValidationError{
-					Type:     ValidationErrorInvalidValue,
-					Property: propName,
-					Message:  fmt.Sprintf("Invalid value %q (allowed: %v)", s, customType.Values),
-				}
+		// Collect all errors from all list items
+		var allErrors []string
+		for i, s := range list {
+			if hasEnumValues && !allowed[s] {
+				allErrors = append(allErrors, fmt.Sprintf("item[%d]: invalid value %q", i, s))
+			}
+			// Run regex validations on each item
+			if err := validateRegexPatterns(propName, customType.Validations, s); err != nil {
+				allErrors = append(allErrors, fmt.Sprintf("item[%d]: %s", i, err.Message))
+			}
+		}
+		if len(allErrors) > 0 {
+			return &ValidationError{
+				Type:     ValidationErrorInvalidValue,
+				Property: propName,
+				Message:  strings.Join(allErrors, "; "),
 			}
 		}
 		return nil
@@ -261,28 +291,34 @@ func validateCustomTypeValue(propName string, customType CustomType, val interfa
 
 	// Handle []interface{} (from YAML parsing)
 	if list, ok := val.([]interface{}); ok {
-		if len(list) == 0 {
+		if len(list) == 0 && hasEnumValues {
 			return &ValidationError{
 				Type:     ValidationErrorInvalidValue,
 				Property: propName,
 				Message:  fmt.Sprintf("Empty list (allowed: %v)", customType.Values),
 			}
 		}
-		for _, item := range list {
+		// Collect all errors from all list items
+		var allErrors []string
+		for i, item := range list {
 			s, ok := item.(string)
 			if !ok {
-				return &ValidationError{
-					Type:     ValidationErrorInvalidType,
-					Property: propName,
-					Message:  "List values must be strings",
-				}
+				allErrors = append(allErrors, fmt.Sprintf("item[%d]: must be a string", i))
+				continue
 			}
-			if !allowed[s] {
-				return &ValidationError{
-					Type:     ValidationErrorInvalidValue,
-					Property: propName,
-					Message:  fmt.Sprintf("Invalid value %q (allowed: %v)", s, customType.Values),
-				}
+			if hasEnumValues && !allowed[s] {
+				allErrors = append(allErrors, fmt.Sprintf("item[%d]: invalid value %q", i, s))
+			}
+			// Run regex validations on each item
+			if err := validateRegexPatterns(propName, customType.Validations, s); err != nil {
+				allErrors = append(allErrors, fmt.Sprintf("item[%d]: %s", i, err.Message))
+			}
+		}
+		if len(allErrors) > 0 {
+			return &ValidationError{
+				Type:     ValidationErrorInvalidValue,
+				Property: propName,
+				Message:  strings.Join(allErrors, "; "),
 			}
 		}
 		return nil
@@ -297,21 +333,76 @@ func validateCustomTypeValue(propName string, customType CustomType, val interfa
 			Message:  "Must be a string or list of strings",
 		}
 	}
+
+	// Empty string handling:
+	// - For enum types: empty is not a valid value, so fail
+	// - For regex-only types: empty can be skipped (let 'required' handle it)
 	if s == "" {
+		if hasEnumValues {
+			return &ValidationError{
+				Type:     ValidationErrorInvalidValue,
+				Property: propName,
+				Message:  fmt.Sprintf("Invalid value %q (allowed: %v)", s, customType.Values),
+			}
+		}
+		// For regex-only types, skip validation on empty
+		return nil
+	}
+
+	// Validate against enum values if present
+	if hasEnumValues && !allowed[s] {
 		return &ValidationError{
 			Type:     ValidationErrorInvalidValue,
 			Property: propName,
 			Message:  fmt.Sprintf("Invalid value %q (allowed: %v)", s, customType.Values),
 		}
 	}
-	if !allowed[s] {
-		return &ValidationError{
-			Type:     ValidationErrorInvalidValue,
-			Property: propName,
-			Message:  fmt.Sprintf("Invalid value %q (allowed: %v)", s, customType.Values),
+
+	// Run regex validations
+	return validateRegexPatterns(propName, customType.Validations, s)
+}
+
+// validateRegexPatterns validates a string value against a list of regex patterns.
+// Returns an error containing all failing validation messages combined.
+// Uses pre-compiled regexes cached during metamodel load.
+func validateRegexPatterns(propName string, validations []TypeValidation, value string) *ValidationError {
+	if len(validations) == 0 {
+		return nil
+	}
+
+	var failedMessages []string
+
+	for i := range validations {
+		v := &validations[i]
+
+		// Use the pre-compiled regex from metamodel load
+		re := v.Compiled()
+		if re == nil {
+			// Fallback: compile if not cached (shouldn't happen in normal usage)
+			var err error
+			re, err = regexp.Compile(v.Pattern)
+			if err != nil {
+				failedMessages = append(failedMessages, fmt.Sprintf("[internal] invalid pattern: %v", err))
+				continue
+			}
+		}
+
+		if !re.MatchString(value) {
+			failedMessages = append(failedMessages, v.Error)
 		}
 	}
-	return nil
+
+	if len(failedMessages) == 0 {
+		return nil
+	}
+
+	// Combine all error messages
+	message := strings.Join(failedMessages, "; ")
+	return &ValidationError{
+		Type:     ValidationErrorInvalidValue,
+		Property: propName,
+		Message:  message,
+	}
 }
 
 // ParseDateValue parses a date string using the property's format.

--- a/internal/metamodel/validation_test.go
+++ b/internal/metamodel/validation_test.go
@@ -1,6 +1,7 @@
 package metamodel
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -536,5 +537,307 @@ func TestValidatePropertyValue_UnknownType(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "nonexistent") {
 		t.Errorf("expected 'nonexistent' in error, got: %v", err)
+	}
+}
+
+func TestValidatePropertyValue_RegexValidation(t *testing.T) {
+	meta := &Metamodel{
+		Types: map[string]CustomType{
+			"semver": {
+				Validations: []TypeValidation{
+					{
+						Pattern: `^\d+\.\d+\.\d+$`,
+						Error:   "Must be valid semver (e.g., 1.2.3)",
+					},
+				},
+			},
+		},
+	}
+	propDef := &PropertyDef{Type: "semver"}
+
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+		errMsg  string
+	}{
+		{"valid semver", "1.2.3", false, ""},
+		{"valid semver zeros", "0.0.0", false, ""},
+		{"valid semver large", "123.456.789", false, ""},
+		{"invalid no dots", "123", true, "Must be valid semver"},
+		{"invalid one dot", "1.2", true, "Must be valid semver"},
+		{"invalid letters", "1.2.x", true, "Must be valid semver"},
+		{"invalid extra dots", "1.2.3.4", true, "Must be valid semver"},
+		{"empty string skipped", "", false, ""}, // Empty strings skip regex validation
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := meta.ValidatePropertyValue("version", propDef, tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %q, got nil", tt.value)
+				} else if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tt.errMsg, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error for %q: %v", tt.value, err)
+			}
+		})
+	}
+}
+
+func TestValidatePropertyValue_MultipleRegexValidations(t *testing.T) {
+	meta := &Metamodel{
+		Types: map[string]CustomType{
+			"rrule": {
+				Description: "iCal recurrence rule",
+				Validations: []TypeValidation{
+					{
+						Pattern: `^FREQ=`,
+						Error:   "Must start with FREQ=",
+					},
+					{
+						Pattern: `FREQ=(YEARLY|MONTHLY|WEEKLY|DAILY)`,
+						Error:   "FREQ must be YEARLY, MONTHLY, WEEKLY, or DAILY",
+					},
+				},
+			},
+		},
+	}
+	propDef := &PropertyDef{Type: "rrule"}
+
+	tests := []struct {
+		name        string
+		value       string
+		wantErr     bool
+		errCount    int
+		errContains []string
+	}{
+		{
+			name:    "valid weekly",
+			value:   "FREQ=WEEKLY;BYDAY=MO",
+			wantErr: false,
+		},
+		{
+			name:    "valid daily",
+			value:   "FREQ=DAILY",
+			wantErr: false,
+		},
+		{
+			name:        "missing FREQ prefix",
+			value:       "BYDAY=MO",
+			wantErr:     true,
+			errCount:    2,
+			errContains: []string{"Must start with FREQ=", "FREQ must be"},
+		},
+		{
+			name:        "invalid frequency",
+			value:       "FREQ=HOURLY",
+			wantErr:     true,
+			errCount:    1,
+			errContains: []string{"FREQ must be YEARLY, MONTHLY, WEEKLY, or DAILY"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := meta.ValidatePropertyValue("schedule", propDef, tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %q, got nil", tt.value)
+					return
+				}
+				// Check error count
+				errParts := strings.Split(err.Error(), "; ")
+				if tt.errCount > 0 && len(errParts) != tt.errCount {
+					t.Errorf("expected %d error(s), got %d: %q", tt.errCount, len(errParts), err.Error())
+				}
+				// Check error contains expected messages
+				for _, msg := range tt.errContains {
+					if !strings.Contains(err.Error(), msg) {
+						t.Errorf("expected error to contain %q, got %q", msg, err.Error())
+					}
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error for %q: %v", tt.value, err)
+			}
+		})
+	}
+}
+
+func TestValidatePropertyValue_EnumWithRegexValidation(t *testing.T) {
+	// A type can have both enum values AND regex validations
+	meta := &Metamodel{
+		Types: map[string]CustomType{
+			"constrained_status": {
+				Values: []string{"draft", "review", "published"},
+				Validations: []TypeValidation{
+					{
+						Pattern: `^[a-z]+$`,
+						Error:   "Must be lowercase letters only",
+					},
+				},
+			},
+		},
+	}
+	propDef := &PropertyDef{Type: "constrained_status"}
+
+	// Valid enum value that also passes regex
+	err := meta.ValidatePropertyValue("status", propDef, "draft")
+	if err != nil {
+		t.Errorf("expected valid value to pass, got: %v", err)
+	}
+
+	// Invalid enum value (not in list)
+	err = meta.ValidatePropertyValue("status", propDef, "pending")
+	if err == nil {
+		t.Error("expected error for invalid enum value")
+	}
+	if !strings.Contains(err.Error(), "allowed") {
+		t.Errorf("expected enum error, got: %v", err)
+	}
+}
+
+func TestValidatePropertyValue_TypeWithNoValidation(t *testing.T) {
+	// A custom type with no values and no validations should accept any string
+	meta := &Metamodel{
+		Types: map[string]CustomType{
+			"alias_string": {
+				Description: "Just an alias for string",
+				// No Values, no Validations
+			},
+		},
+	}
+	propDef := &PropertyDef{Type: "alias_string"}
+
+	// Any string should be valid
+	err := meta.ValidatePropertyValue("field", propDef, "anything goes here!")
+	if err != nil {
+		t.Errorf("expected any string to be valid, got: %v", err)
+	}
+
+	// But non-strings should fail
+	err = meta.ValidatePropertyValue("field", propDef, 123)
+	if err == nil {
+		t.Error("expected error for non-string value")
+	}
+}
+
+func TestValidatePropertyValue_RegexOnStringList(t *testing.T) {
+	// Compile regexes to populate the cache (normally done by loader)
+	semverType := CustomType{
+		Validations: []TypeValidation{
+			{Pattern: `^\d+\.\d+\.\d+$`, Error: "Must be semver"},
+		},
+	}
+	re, _ := regexp.Compile(semverType.Validations[0].Pattern)
+	semverType.Validations[0].SetCompiled(re)
+
+	meta := &Metamodel{
+		Types: map[string]CustomType{
+			"semver": semverType,
+		},
+	}
+	propDef := &PropertyDef{Type: "semver", List: true}
+
+	// All valid
+	err := meta.ValidatePropertyValue("versions", propDef, []string{"1.0.0", "2.0.0"})
+	if err != nil {
+		t.Errorf("expected valid list, got: %v", err)
+	}
+
+	// One invalid
+	err = meta.ValidatePropertyValue("versions", propDef, []string{"1.0.0", "bad"})
+	if err == nil {
+		t.Fatal("expected error for invalid list item")
+	}
+	if !strings.Contains(err.Error(), "item[1]") {
+		t.Errorf("expected error to mention item index, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Must be semver") {
+		t.Errorf("expected error to mention validation message, got: %v", err)
+	}
+
+	// Multiple invalid - should report all errors
+	err = meta.ValidatePropertyValue("versions", propDef, []string{"bad1", "1.0.0", "bad2"})
+	if err == nil {
+		t.Fatal("expected error for invalid list items")
+	}
+	if !strings.Contains(err.Error(), "item[0]") {
+		t.Errorf("expected error to mention item[0], got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "item[2]") {
+		t.Errorf("expected error to mention item[2], got: %v", err)
+	}
+}
+
+func TestValidatePropertyValue_RegexOnInterfaceList(t *testing.T) {
+	// Compile regexes to populate the cache (normally done by loader)
+	semverType := CustomType{
+		Validations: []TypeValidation{
+			{Pattern: `^\d+\.\d+\.\d+$`, Error: "Must be semver"},
+		},
+	}
+	re, _ := regexp.Compile(semverType.Validations[0].Pattern)
+	semverType.Validations[0].SetCompiled(re)
+
+	meta := &Metamodel{
+		Types: map[string]CustomType{
+			"semver": semverType,
+		},
+	}
+	propDef := &PropertyDef{Type: "semver", List: true}
+
+	// All valid ([]interface{} as from YAML parsing)
+	err := meta.ValidatePropertyValue("versions", propDef, []interface{}{"1.0.0", "2.0.0"})
+	if err != nil {
+		t.Errorf("expected valid list, got: %v", err)
+	}
+
+	// One invalid
+	err = meta.ValidatePropertyValue("versions", propDef, []interface{}{"1.0.0", "bad"})
+	if err == nil {
+		t.Fatal("expected error for invalid list item")
+	}
+	if !strings.Contains(err.Error(), "item[1]") {
+		t.Errorf("expected error to mention item index, got: %v", err)
+	}
+
+	// Non-string item in list
+	err = meta.ValidatePropertyValue("versions", propDef, []interface{}{"1.0.0", 123})
+	if err == nil {
+		t.Fatal("expected error for non-string list item")
+	}
+	if !strings.Contains(err.Error(), "item[1]") {
+		t.Errorf("expected error to mention item index, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "must be a string") {
+		t.Errorf("expected error to mention type issue, got: %v", err)
+	}
+}
+
+func TestValidatePropertyValue_EmptyListWithRegexOnly(t *testing.T) {
+	// A regex-only type (no enum values) with an empty list should pass
+	// (let 'required' handle empty lists if needed)
+	semverType := CustomType{
+		Validations: []TypeValidation{
+			{Pattern: `^\d+\.\d+\.\d+$`, Error: "Must be semver"},
+		},
+	}
+	re, _ := regexp.Compile(semverType.Validations[0].Pattern)
+	semverType.Validations[0].SetCompiled(re)
+
+	meta := &Metamodel{
+		Types: map[string]CustomType{
+			"semver": semverType,
+		},
+	}
+	propDef := &PropertyDef{Type: "semver", List: true}
+
+	// Empty list should pass for regex-only types
+	err := meta.ValidatePropertyValue("versions", propDef, []string{})
+	if err != nil {
+		t.Errorf("expected empty list to pass for regex-only type, got: %v", err)
 	}
 }

--- a/tickets/entities/tickets/TKT-rrule.md
+++ b/tickets/entities/tickets/TKT-rrule.md
@@ -1,0 +1,43 @@
+---
+effort: s
+id: TKT-rrule
+kind: enhancement
+priority: medium
+status: done
+title: Custom type regex validations
+type: ticket
+---
+
+## Description
+
+Extend custom types in metamodel to support regex validations with user-friendly error messages. This enables users to define validated types like RRULE, semver, URLs, etc. without requiring built-in support.
+
+**Feature:**
+
+```yaml
+types:
+  rrule:
+    description: "iCal recurrence rule (RFC 5545)"
+    validations:
+      - pattern: "^FREQ=(YEARLY|MONTHLY|WEEKLY|DAILY)"
+        error: "Must start with valid FREQ"
+      - pattern: "^(?!.*COUNT=.*UNTIL=)"
+        error: "Cannot specify both COUNT and UNTIL"
+
+  semver:
+    validations:
+      - pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+"
+        error: "Must be valid semver (e.g., 1.2.3)"
+```
+
+**Benefits:**
+- Multiple simple patterns > one complex regex with opaque errors
+- User-defined error messages for clear feedback
+- No new built-in types needed - users define what they need
+- Reusable across entity types
+
+**Use cases:**
+- RRULE validation for recurring schedules
+- Semantic version validation
+- URL/email format validation
+- Custom ID format enforcement


### PR DESCRIPTION
## Summary

- Enable custom types to define regex validation patterns with user-friendly error messages
- Multiple patterns can be combined (all must pass)
- Patterns compiled at load time and cached for performance
- Supports single values and lists (validates each item)

Example usage:
```yaml
types:
  semver:
    validations:
      - pattern: '^\d+\.\d+\.\d+$'
        error: "Must be valid semver (e.g., 1.2.3)"

  rrule:
    description: "iCal recurrence rule"
    validations:
      - pattern: "^FREQ=(YEARLY|MONTHLY|WEEKLY|DAILY)"
        error: "Must start with valid FREQ"
```

## Test plan

- [x] Unit tests for single value regex validation
- [x] Unit tests for multiple patterns (all errors combined)
- [x] Unit tests for enum + regex combined
- [x] Unit tests for list validation ([]string and []interface{})
- [x] Loader tests for pattern compilation and error handling
- [x] Empty values skip validation (let `required` handle it)

Closes TKT-rrule