### PR TITLE
feat: add id_caps config for short ID suffix capitalization

### DIFF
--- a/internal/metamodel/entity_def.go
+++ b/internal/metamodel/entity_def.go
@@ -123,6 +123,14 @@ func (e *EntityDef) IsManualID() bool {
 	return e.GetIDType() == IDTypeManual
 }
 
+// GetIDCaps returns the ID capitalization mode for short IDs, defaulting to "upper".
+func (e *EntityDef) GetIDCaps() string {
+	if e.IDCaps == "" {
+		return IDCapsUpper
+	}
+	return e.IDCaps
+}
+
 // GetIDPrefixes returns the effective ID prefixes for this entity type.
 // It normalizes id_prefix (singular) and id_prefixes (plural) into a single list.
 func (e *EntityDef) GetIDPrefixes() []string {

--- a/internal/metamodel/errors.go
+++ b/internal/metamodel/errors.go
@@ -33,6 +33,16 @@ func (e *InvalidIDTypeError) Error() string {
 	return "invalid id_type for entity " + e.EntityType + ": " + e.IDType + " (must be 'short', 'sequential', or 'manual')"
 }
 
+// InvalidIDCapsError is returned when an entity has an invalid id_caps value.
+type InvalidIDCapsError struct {
+	EntityType string
+	IDCaps     string
+}
+
+func (e *InvalidIDCapsError) Error() string {
+	return "invalid id_caps for entity " + e.EntityType + ": " + e.IDCaps + " (must be 'upper' or 'lower')"
+}
+
 // ReservedPropertyError is returned when a property name conflicts with a reserved name.
 type ReservedPropertyError struct {
 	EntityType   string

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -164,6 +164,9 @@ func validateEntityStructure(m *Metamodel) error {
 		if def.IDType != "" && def.IDType != IDTypeShort && def.IDType != IDTypeSequential && def.IDType != IDTypeManual {
 			return &InvalidIDTypeError{EntityType: name, IDType: def.IDType}
 		}
+		if def.IDCaps != "" && def.IDCaps != IDCapsUpper && def.IDCaps != IDCapsLower {
+			return &InvalidIDCapsError{EntityType: name, IDCaps: def.IDCaps}
+		}
 
 		for propName := range def.Properties {
 			trimmedName := strings.TrimSpace(propName)

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -211,6 +211,10 @@ func validateEntitySemantics(m *Metamodel) []string {
 			errs = append(errs, fmt.Sprintf(
 				"entity %q: no ID prefix defined (set 'id_prefix' or 'id_prefixes', or use 'id_type: manual')", name))
 		}
+		if def.IDCaps != "" && def.GetIDType() != IDTypeShort {
+			errs = append(errs, fmt.Sprintf(
+				"entity %q: 'id_caps' has no effect (only applies to 'id_type: short')", name))
+		}
 
 		for propName, propDef := range def.Properties {
 			if propDef.Type == "" {

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -605,6 +605,87 @@ func TestInvalidIDTypeError_Error(t *testing.T) {
 	}
 }
 
+func TestInvalidIDCapsError_Error(t *testing.T) {
+	err := &InvalidIDCapsError{
+		EntityType: "task",
+		IDCaps:     "mixed",
+	}
+
+	expected := `invalid id_caps for entity task: mixed (must be 'upper' or 'lower')`
+	if err.Error() != expected {
+		t.Errorf("expected %q, got %q", expected, err.Error())
+	}
+}
+
+func TestParse_InvalidIDCaps(t *testing.T) {
+	yaml := `version: "1.0"
+entities:
+  task:
+    label: Task
+    id_type: short
+    id_caps: mixed
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+`
+
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+
+	var idCapsErr *InvalidIDCapsError
+	if !errors.As(err, &idCapsErr) {
+		t.Errorf("expected InvalidIDCapsError, got %T: %v", err, err)
+	}
+}
+
+func TestParse_ValidIDCaps(t *testing.T) {
+	tests := []struct {
+		name     string
+		idCaps   string
+		expected string
+	}{
+		{"upper", "upper", "upper"},
+		{"lower", "lower", "lower"},
+		{"empty defaults to upper", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yaml := fmt.Sprintf(`version: "1.0"
+entities:
+  task:
+    label: Task
+    id_type: short
+    id_caps: %s
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+`, tt.idCaps)
+			if tt.idCaps == "" {
+				yaml = `version: "1.0"
+entities:
+  task:
+    label: Task
+    id_type: short
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+`
+			}
+
+			meta, err := Parse([]byte(yaml))
+			assertNoError(t, err)
+
+			if meta.Entities["task"].IDCaps != tt.expected {
+				t.Errorf("expected IDCaps=%q, got %q", tt.expected, meta.Entities["task"].IDCaps)
+			}
+		})
+	}
+}
+
 func TestParse_UnknownTopLevelKeys(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -686,6 +686,94 @@ entities:
 	}
 }
 
+func TestParse_IDCapsOnNonShortType(t *testing.T) {
+	// id_caps should warn when set on non-short ID types
+	tests := []struct {
+		name       string
+		yaml       string
+		wantErr    bool
+		wantErrStr string
+	}{
+		{
+			name: "id_caps on sequential type warns",
+			yaml: `version: "1.0"
+entities:
+  task:
+    label: Task
+    id_type: sequential
+    id_caps: upper
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+`,
+			wantErr:    true,
+			wantErrStr: "'id_caps' has no effect (only applies to 'id_type: short')",
+		},
+		{
+			name: "id_caps on manual type warns",
+			yaml: `version: "1.0"
+entities:
+  task:
+    label: Task
+    id_type: manual
+    id_caps: lower
+    properties:
+      title:
+        type: string
+`,
+			wantErr:    true,
+			wantErrStr: "'id_caps' has no effect (only applies to 'id_type: short')",
+		},
+		{
+			name: "id_caps on default type (short) is valid",
+			yaml: `version: "1.0"
+entities:
+  task:
+    label: Task
+    id_caps: upper
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+`,
+			wantErr: false, // default id_type is "short", so id_caps is valid
+		},
+		{
+			name: "id_caps on short type is valid",
+			yaml: `version: "1.0"
+entities:
+  task:
+    label: Task
+    id_type: short
+    id_caps: upper
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.yaml))
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.wantErrStr)
+					return
+				}
+				if !strings.Contains(err.Error(), tt.wantErrStr) {
+					t.Errorf("expected error containing %q, got: %v", tt.wantErrStr, err)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestParse_UnknownTopLevelKeys(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -102,6 +102,7 @@ type EntityDef struct {
 	Plural      string                 `yaml:"plural,omitempty"`      // Used for directory names (e.g., "policies" for "policy")
 	Aliases     []string               `yaml:"aliases,omitempty"`
 	IDType      string                 `yaml:"id_type,omitempty"`     // "short" (default), "sequential", or "manual"
+	IDCaps      string                 `yaml:"id_caps,omitempty"`     // "upper" (default) or "lower" - capitalization for short ID suffix
 	IDPrefix    string                 `yaml:"id_prefix,omitempty"`   // Single ID prefix (sugar for single-element id_prefixes)
 	IDPrefixes  []string               `yaml:"id_prefixes,omitempty"` // Multiple ID prefixes
 	RDFType     string                 `yaml:"rdf_type,omitempty"`
@@ -140,6 +141,12 @@ const (
 
 	// Deprecated alias (still accepted for backwards compatibility)
 	IDTypeString = "string" // Deprecated: use "manual" instead
+)
+
+// ID capitalization modes for short IDs
+const (
+	IDCapsUpper = "upper" // Random suffix is uppercase (e.g., REQ-A3F8) - default
+	IDCapsLower = "lower" // Random suffix is lowercase (e.g., REQ-a3f8)
 )
 
 // ReservedPropertyNames contains property names that cannot be used in metamodel definitions

--- a/internal/metamodel/types_test.go
+++ b/internal/metamodel/types_test.go
@@ -324,6 +324,39 @@ func TestEntityDef_GetIDType(t *testing.T) {
 	}
 }
 
+func TestEntityDef_GetIDCaps(t *testing.T) {
+	tests := []struct {
+		name string
+		def  EntityDef
+		want string
+	}{
+		{
+			name: "empty defaults to upper",
+			def:  EntityDef{},
+			want: IDCapsUpper,
+		},
+		{
+			name: "explicit upper",
+			def:  EntityDef{IDCaps: IDCapsUpper},
+			want: IDCapsUpper,
+		},
+		{
+			name: "explicit lower",
+			def:  EntityDef{IDCaps: IDCapsLower},
+			want: IDCapsLower,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.def.GetIDCaps()
+			if got != tt.want {
+				t.Errorf("GetIDCaps() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEntityDef_IsShortID(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/model/id.go
+++ b/internal/model/id.go
@@ -158,7 +158,8 @@ const (
 // GenerateShortID generates a random base36 ID with the given prefix.
 // Length is adaptive based on entityCount to minimize collision probability.
 // The function retries with progressively longer IDs if collisions occur.
-func GenerateShortID(existingIDs []string, prefix string, entityCount int) string {
+// The caps parameter controls suffix capitalization: "upper" or "lower".
+func GenerateShortID(existingIDs []string, prefix string, entityCount int, caps string) string {
 	// Build a set for fast lookup
 	existing := make(map[string]struct{}, len(existingIDs))
 	for _, id := range existingIDs {
@@ -168,7 +169,7 @@ func GenerateShortID(existingIDs []string, prefix string, entityCount int) strin
 	length := calculateIDLength(entityCount)
 
 	for attempts := 0; attempts < shortIDMaxAttempts; attempts++ {
-		id := generateRandomBase36(prefix, length)
+		id := generateRandomBase36(prefix, length, caps)
 		if _, exists := existing[id]; !exists {
 			return id
 		}
@@ -179,7 +180,7 @@ func GenerateShortID(existingIDs []string, prefix string, entityCount int) strin
 	}
 
 	// Final fallback: use maximum length
-	return generateRandomBase36(prefix, maxShortIDLength)
+	return generateRandomBase36(prefix, maxShortIDLength, caps)
 }
 
 // calculateIDLength determines the optimal ID length based on entity count.
@@ -200,7 +201,8 @@ func calculateIDLength(entityCount int) int {
 }
 
 // generateRandomBase36 generates a random ID with the given prefix and length.
-func generateRandomBase36(prefix string, length int) string {
+// The caps parameter controls suffix capitalization: "upper" (default) or "lower".
+func generateRandomBase36(prefix string, length int, caps string) string {
 	b := make([]byte, length)
 	if _, err := rand.Read(b); err != nil {
 		// Fallback to less random but functional approach
@@ -216,5 +218,10 @@ func generateRandomBase36(prefix string, length int) string {
 	if !strings.HasSuffix(prefix, "-") {
 		prefix += "-"
 	}
-	return strings.ToUpper(prefix) + string(b)
+
+	suffix := string(b)
+	if caps != "lower" {
+		suffix = strings.ToUpper(suffix)
+	}
+	return prefix + suffix
 }

--- a/internal/model/id_fuzz_test.go
+++ b/internal/model/id_fuzz_test.go
@@ -274,13 +274,13 @@ func FuzzFormatWithPadding(f *testing.F) {
 // FuzzGenerateShortID tests short random ID generation
 func FuzzGenerateShortID(f *testing.F) {
 	// Seed with various prefixes and entity counts
-	f.Add("TKT", "", 0)
-	f.Add("REQ-", "REQ-a1b2", 10)
-	f.Add("DEC", "DEC-xxxx,DEC-yyyy,DEC-zzzz", 100)
-	f.Add("COMP-", "", 1000)
-	f.Add("A", "", 10000)
+	f.Add("TKT", "", 0, "upper")
+	f.Add("REQ-", "REQ-A1B2", 10, "upper")
+	f.Add("DEC", "DEC-xxxx,DEC-yyyy,DEC-zzzz", 100, "lower")
+	f.Add("COMP-", "", 1000, "upper")
+	f.Add("A", "", 10000, "lower")
 
-	f.Fuzz(func(t *testing.T, prefix, existingJoined string, entityCount int) {
+	f.Fuzz(func(t *testing.T, prefix, existingJoined string, entityCount int, caps string) {
 		// Skip very long prefixes
 		if len(prefix) > 50 {
 			return
@@ -304,13 +304,18 @@ func FuzzGenerateShortID(f *testing.F) {
 			entityCount = 100000
 		}
 
+		// Normalize caps to valid values
+		if caps != "lower" {
+			caps = "upper"
+		}
+
 		var existing []string
 		if existingJoined != "" {
 			existing = strings.Split(existingJoined, ",")
 		}
 
 		// Should never panic
-		result := GenerateShortID(existing, prefix, entityCount)
+		result := GenerateShortID(existing, prefix, entityCount, caps)
 
 		// Result should be non-empty
 		if result == "" {
@@ -318,8 +323,8 @@ func FuzzGenerateShortID(f *testing.F) {
 			return
 		}
 
-		// Result should start with uppercased prefix + dash
-		expectedPrefix := strings.ToUpper(strings.TrimSuffix(prefix, "-")) + "-"
+		// Result should start with prefix (as-is) + dash if not already present
+		expectedPrefix := strings.TrimSuffix(prefix, "-") + "-"
 		if !strings.HasPrefix(result, expectedPrefix) {
 			t.Errorf("GenerateShortID result %q doesn't have expected prefix %q",
 				result, expectedPrefix)
@@ -337,12 +342,19 @@ func FuzzGenerateShortID(f *testing.F) {
 			t.Errorf("GenerateShortID returned invalid ID %q: %v", result, err)
 		}
 
-		// Random part should only contain base36 characters
+		// Random part should only contain base36 characters with correct case
 		randomPart := strings.TrimPrefix(result, expectedPrefix)
 		for _, c := range randomPart {
-			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z')) {
-				t.Errorf("GenerateShortID random part %q contains invalid char %q",
-					randomPart, c)
+			if caps == "upper" {
+				if !((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z')) {
+					t.Errorf("GenerateShortID random part %q contains invalid char %q (expected uppercase)",
+						randomPart, c)
+				}
+			} else {
+				if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z')) {
+					t.Errorf("GenerateShortID random part %q contains invalid char %q (expected lowercase)",
+						randomPart, c)
+				}
 			}
 		}
 	})
@@ -350,17 +362,22 @@ func FuzzGenerateShortID(f *testing.F) {
 
 // FuzzGenerateShortIDCollision stress tests collision resistance
 func FuzzGenerateShortIDCollision(f *testing.F) {
-	f.Add("TKT", 100)
-	f.Add("REQ", 500)
-	f.Add("X", 1000)
+	f.Add("TKT", 100, "upper")
+	f.Add("REQ", 500, "lower")
+	f.Add("X", 1000, "upper")
 
-	f.Fuzz(func(t *testing.T, prefix string, count int) {
+	f.Fuzz(func(t *testing.T, prefix string, count int, caps string) {
 		// Skip invalid inputs
 		if prefix == "" || len(prefix) > 20 {
 			return
 		}
 		if count < 1 || count > 1000 {
 			return
+		}
+
+		// Normalize caps to valid values
+		if caps != "lower" {
+			caps = "upper"
 		}
 
 		// Generate many IDs and verify no collisions
@@ -372,7 +389,7 @@ func FuzzGenerateShortIDCollision(f *testing.F) {
 				existing = append(existing, id)
 			}
 
-			id := GenerateShortID(existing, prefix, len(seen))
+			id := GenerateShortID(existing, prefix, len(seen), caps)
 			if _, exists := seen[id]; exists {
 				t.Errorf("GenerateShortID produced collision: %q (iteration %d)", id, i)
 				return

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -597,70 +597,96 @@ func TestGenerateShortID(t *testing.T) {
 		existingIDs []string
 		prefix      string
 		entityCount int
+		caps        string
 		wantPrefix  string
 		wantLength  int
+		wantUpper   bool
 	}{
 		{
-			name:        "first ID with empty prefix",
+			name:        "first ID with empty prefix uppercase",
 			existingIDs: []string{},
 			prefix:      "TKT",
 			entityCount: 0,
+			caps:        "upper",
 			wantPrefix:  "TKT-",
 			wantLength:  4, // 4 chars for small counts
+			wantUpper:   true,
 		},
 		{
 			name:        "prefix with trailing dash",
 			existingIDs: []string{},
 			prefix:      "REQ-",
 			entityCount: 0,
+			caps:        "upper",
 			wantPrefix:  "REQ-",
 			wantLength:  4,
+			wantUpper:   true,
 		},
 		{
-			name:        "length scales with entity count 500",
+			name:        "lowercase suffix",
 			existingIDs: []string{},
-			prefix:      "TKT",
-			entityCount: 500,
+			prefix:      "TKT-",
+			entityCount: 0,
+			caps:        "lower",
 			wantPrefix:  "TKT-",
 			wantLength:  4,
+			wantUpper:   false,
+		},
+		{
+			name:        "prefix case preserved",
+			existingIDs: []string{},
+			prefix:      "MyType-",
+			entityCount: 0,
+			caps:        "upper",
+			wantPrefix:  "MyType-",
+			wantLength:  4,
+			wantUpper:   true,
 		},
 		{
 			name:        "length scales with entity count 501",
 			existingIDs: []string{},
 			prefix:      "TKT",
 			entityCount: 501,
+			caps:        "upper",
 			wantPrefix:  "TKT-",
 			wantLength:  5,
+			wantUpper:   true,
 		},
 		{
 			name:        "length scales with entity count 1501",
 			existingIDs: []string{},
 			prefix:      "TKT",
 			entityCount: 1501,
+			caps:        "upper",
 			wantPrefix:  "TKT-",
 			wantLength:  6,
+			wantUpper:   true,
 		},
 		{
 			name:        "length scales with entity count 10001",
 			existingIDs: []string{},
 			prefix:      "TKT",
 			entityCount: 10001,
+			caps:        "upper",
 			wantPrefix:  "TKT-",
 			wantLength:  7,
+			wantUpper:   true,
 		},
 		{
 			name:        "length scales with entity count 50001",
 			existingIDs: []string{},
 			prefix:      "TKT",
 			entityCount: 50001,
+			caps:        "upper",
 			wantPrefix:  "TKT-",
 			wantLength:  8,
+			wantUpper:   true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GenerateShortID(tt.existingIDs, tt.prefix, tt.entityCount)
+			got := GenerateShortID(tt.existingIDs, tt.prefix, tt.entityCount, tt.caps)
 
 			// Check prefix
 			if len(got) < len(tt.wantPrefix) || got[:len(tt.wantPrefix)] != tt.wantPrefix {
@@ -673,11 +699,17 @@ func TestGenerateShortID(t *testing.T) {
 				t.Errorf("GenerateShortID() length = %d, want %d (got %q)", len(got), wantTotalLen, got)
 			}
 
-			// Check random part contains only valid base36 characters
+			// Check random part contains only valid base36 characters with correct case
 			randomPart := got[len(tt.wantPrefix):]
 			for _, c := range randomPart {
-				if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z')) {
-					t.Errorf("GenerateShortID() random part contains invalid char %q in %q", c, got)
+				if tt.wantUpper {
+					if !((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z')) {
+						t.Errorf("GenerateShortID() random part contains invalid char %q in %q (expected uppercase)", c, got)
+					}
+				} else {
+					if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z')) {
+						t.Errorf("GenerateShortID() random part contains invalid char %q in %q (expected lowercase)", c, got)
+					}
 				}
 			}
 		})
@@ -691,7 +723,7 @@ func TestGenerateShortID_Uniqueness(t *testing.T) {
 
 	// Generate many IDs and check for uniqueness
 	for i := 0; i < 1000; i++ {
-		id := GenerateShortID(existingIDs, "TKT", i)
+		id := GenerateShortID(existingIDs, "TKT", i, "upper")
 		if generated[id] {
 			t.Errorf("Duplicate ID generated: %s", id)
 		}
@@ -703,11 +735,11 @@ func TestGenerateShortID_Uniqueness(t *testing.T) {
 // TestGenerateShortID_CollisionAvoidance tests collision handling
 func TestGenerateShortID_CollisionAvoidance(t *testing.T) {
 	// Pre-populate with some IDs that might collide
-	existingIDs := []string{"TKT-0000", "TKT-1111", "TKT-aaaa"}
+	existingIDs := []string{"TKT-0000", "TKT-1111", "TKT-AAAA"}
 
 	// Generate IDs and ensure none collide with existing
 	for i := 0; i < 100; i++ {
-		id := GenerateShortID(existingIDs, "TKT", len(existingIDs))
+		id := GenerateShortID(existingIDs, "TKT", len(existingIDs), "upper")
 		for _, existing := range existingIDs {
 			if id == existing {
 				t.Errorf("Generated ID %s collides with existing ID", id)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -407,7 +407,7 @@ func (w *Workspace) GenerateID(entityType, prefix string) (string, error) {
 
 	existingIDs := w.graph.AllIDs()
 	if entityDef.IsShortID() {
-		return model.GenerateShortID(existingIDs, prefix, w.graph.NodeCount()), nil
+		return model.GenerateShortID(existingIDs, prefix, w.graph.NodeCount(), entityDef.GetIDCaps()), nil
 	}
 	return model.GenerateNextID(existingIDs, prefix), nil
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -229,6 +229,119 @@ func TestGenerateID_Sequential(t *testing.T) {
 	}
 }
 
+func TestGenerateID_ShortWithIDCaps(t *testing.T) {
+	// Test that id_caps configuration affects short ID generation
+	shortIDMetamodel := `version: "1.0"
+entities:
+  ticket-upper:
+    label: Ticket (Uppercase)
+    plural: tickets-upper
+    id_prefix: "TKT-"
+    id_type: short
+    id_caps: upper
+    properties:
+      title:
+        type: string
+        required: true
+  ticket-lower:
+    label: Ticket (Lowercase)
+    plural: tickets-lower
+    id_prefix: "TKT-"
+    id_type: short
+    id_caps: lower
+    properties:
+      title:
+        type: string
+        required: true
+  ticket-default:
+    label: Ticket (Default)
+    plural: tickets-default
+    id_prefix: "TKT-"
+    id_type: short
+    properties:
+      title:
+        type: string
+        required: true
+relations: {}
+`
+	fs := storage.NewMemFS()
+	root := "/project"
+	ctx := &project.Context{
+		Root:                 root,
+		MetamodelPath:        root + "/metamodel.yaml",
+		CacheDir:             root + "/.rela",
+		CachePath:            root + "/.rela/cache.json",
+		EntitiesDir:          root + "/entities",
+		RelationsDir:         root + "/relations",
+		TemplatesDir:         root + "/templates",
+		EntityTemplatesDir:   root + "/templates/entities",
+		RelationTemplatesDir: root + "/templates/relations",
+	}
+
+	_ = fs.MkdirAll(ctx.EntitiesDir+"/tickets-upper", 0o755)
+	_ = fs.MkdirAll(ctx.EntitiesDir+"/tickets-lower", 0o755)
+	_ = fs.MkdirAll(ctx.EntitiesDir+"/tickets-default", 0o755)
+	_ = fs.MkdirAll(ctx.RelationsDir, 0o755)
+	_ = fs.MkdirAll(ctx.CacheDir, 0o755)
+	_ = fs.WriteFile(ctx.MetamodelPath, []byte(shortIDMetamodel), 0o644)
+
+	meta, err := metamodel.Parse([]byte(shortIDMetamodel))
+	if err != nil {
+		t.Fatalf("failed to parse metamodel: %v", err)
+	}
+
+	repo := repository.New(fs, ctx)
+	g := graph.New()
+	ws := NewWithGraph(repo, meta, g)
+
+	tests := []struct {
+		entityType  string
+		expectUpper bool
+	}{
+		{"ticket-upper", true},
+		{"ticket-lower", false},
+		{"ticket-default", true}, // default is uppercase
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.entityType, func(t *testing.T) {
+			id, err := ws.GenerateID(tt.entityType, "")
+			if err != nil {
+				t.Fatalf("GenerateID() error = %v", err)
+			}
+
+			// ID should start with TKT-
+			if !hasPrefix(id, "TKT-") {
+				t.Errorf("GenerateID() = %q, expected prefix TKT-", id)
+			}
+
+			// Get the random suffix (everything after TKT-)
+			suffix := id[4:]
+			if suffix == "" {
+				t.Fatalf("GenerateID() = %q, no suffix generated", id)
+			}
+
+			// Check case of the random suffix
+			for _, c := range suffix {
+				if c >= 'A' && c <= 'Z' {
+					if !tt.expectUpper {
+						t.Errorf("GenerateID() = %q, expected lowercase suffix but found uppercase char %q", id, c)
+					}
+				} else if c >= 'a' && c <= 'z' {
+					if tt.expectUpper {
+						t.Errorf("GenerateID() = %q, expected uppercase suffix but found lowercase char %q", id, c)
+					}
+				}
+				// digits 0-9 are case-neutral, ignore them
+			}
+		})
+	}
+}
+
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
 // --- CreateEntity ---
 
 func TestCreateEntity(t *testing.T) {

--- a/tickets/entities/implementation-checklists/IMPL-fkzj.md
+++ b/tickets/entities/implementation-checklists/IMPL-fkzj.md
@@ -1,0 +1,32 @@
+---
+id: IMPL-fkzj
+status: in-progress
+title: 'Implementation: Allow configuration of short ID capitalization'
+type: implementation-checklist
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-2o1s.md
+++ b/tickets/entities/planning-checklists/PLAN-2o1s.md
@@ -1,0 +1,116 @@
+---
+id: PLAN-2o1s
+status: done
+title: 'Planning: Allow configuration of short ID capitalization'
+type: planning-checklist
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+- IN SCOPE: Add `id_caps` field to metamodel entity definitions to control suffix capitalization
+- IN SCOPE: Support values: `upper` (default), `lower`
+- IN SCOPE: Change default from lowercase suffix to uppercase suffix
+- IN SCOPE: Prefix always stays as defined in metamodel (not affected by id_caps)
+- OUT OF SCOPE: Migration for existing IDs (they remain as-is)
+
+**Acceptance Criteria:**
+1. `id_caps: upper` produces `TKT-A1B2` (prefix as-is, suffix uppercase) - NEW DEFAULT
+2. `id_caps: lower` produces `TKT-a1b2` (prefix as-is, suffix lowercase - current behavior)
+3. Omitting `id_caps` defaults to `upper`
+4. Invalid values are rejected at metamodel load time
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+- Current logic in `internal/model/id.go:219` uses `strings.ToUpper(prefix) + string(b)` where `b` uses lowercase base36 chars
+- Need to: (1) stop uppercasing prefix, (2) add option to uppercase suffix
+- `EntityDef` struct pattern for optional fields like `id_type`, `id_prefix`
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+1. Add `IDCaps` field to `EntityDef` struct in `internal/metamodel/types.go`
+2. Add `IDCapsUpper`, `IDCapsLower` constants
+3. Add `GetIDCaps()` helper method in `internal/metamodel/entity_def.go`
+4. Modify `GenerateShortID()` to accept capitalization option
+5. Update `generateRandomBase36()`: remove `strings.ToUpper(prefix)`, add suffix case option
+6. Update `Workspace.GenerateID()` to pass capitalization to model
+7. Add validation in metamodel loader
+
+**Files to modify:**
+- `internal/metamodel/types.go` - Add IDCaps field and constants
+- `internal/metamodel/entity_def.go` - Add GetIDCaps() helper
+- `internal/metamodel/loader.go` - Add validation for id_caps values
+- `internal/model/id.go` - Modify GenerateShortID and generateRandomBase36
+- `internal/workspace/workspace.go` - Pass capitalization to model
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+- Source: `id_caps` field in metamodel.yaml
+- Validation: Allowlist (`upper`, `lower`)
+- Invalid input: Error at metamodel load time
+
+**Security-Sensitive Operations:**
+- None - capitalization doesn't affect security
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+1. Unit test `generateRandomBase36()` with upper/lower modes
+2. Unit test `GetIDCaps()` default behavior
+3. Metamodel validation test for invalid `id_caps` values
+
+**Edge Cases:**
+- Empty `id_caps` field → defaults to `upper`
+- Prefix without hyphen → hyphen added, prefix case preserved
+
+**Negative Tests:**
+- `id_caps: mixed` → should error at metamodel load
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+- Breaking change: New default (uppercase suffix) differs from old (lowercase suffix)
+  - Mitigation: Users can use `id_caps: lower` for old behavior
+- Existing tests may assume lowercase suffix
+  - Mitigation: Update fuzz tests
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: simple config change)
+- [x] ~~All critical/significant findings addressed in plan~~ (N/A)
+
+**Design Review Findings:** N/A - straightforward config addition

--- a/tickets/entities/tickets/TKT-o02q.md
+++ b/tickets/entities/tickets/TKT-o02q.md
@@ -1,0 +1,11 @@
+---
+effort: s
+id: TKT-o02q
+kind: enhancement
+priority: medium
+status: in-progress
+title: Allow configuration of short ID capitalization
+type: ticket
+---
+
+Add configuration option to control whether short ID prefixes are uppercase or lowercase. New default should be uppercase (e.g., TKT-abc1 instead of tkt-abc1).

--- a/tickets/relations/TKT-o02q--affects--metamodel-types.md
+++ b/tickets/relations/TKT-o02q--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-o02q
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-o02q--has-implementation--IMPL-fkzj.md
+++ b/tickets/relations/TKT-o02q--has-implementation--IMPL-fkzj.md
@@ -1,0 +1,5 @@
+---
+from: TKT-o02q
+relation: has-implementation
+to: IMPL-fkzj
+---

--- a/tickets/relations/TKT-o02q--has-planning--PLAN-2o1s.md
+++ b/tickets/relations/TKT-o02q--has-planning--PLAN-2o1s.md
@@ -1,0 +1,5 @@
+---
+from: TKT-o02q
+relation: has-planning
+to: PLAN-2o1s
+---

--- a/tickets/relations/TKT-o02q--implements--FEAT-012.md
+++ b/tickets/relations/TKT-o02q--implements--FEAT-012.md
@@ -1,0 +1,5 @@
+---
+from: TKT-o02q
+relation: implements
+to: FEAT-012
+---


### PR DESCRIPTION
## Summary

- Add `id_caps` field to metamodel entity definitions to control short ID suffix case
- New default is uppercase (e.g., `TKT-A3F8` instead of `tkt-a3f8`)
- Options: `upper` (default), `lower`
- Prefix case is preserved as defined in metamodel

## Test plan

- [x] Unit tests for GenerateShortID with caps parameter
- [x] Workspace integration test for id_caps config
- [x] Loader validation test for invalid id_caps values
- [x] Warning test when id_caps set on non-short ID types
- [x] Fuzz tests updated for caps parameter