### PR TITLE
feat(automation): add conditional triggers with when clause

### DIFF
--- a/docs-project/entities/guide/GUIDE-metamodel.md
+++ b/docs-project/entities/guide/GUIDE-metamodel.md
@@ -1113,8 +1113,8 @@ This uses the same filter syntax as validation rules.
 
 ```yaml
 automations:
-  - name: docs-for-enhancements
-    description: Create docs checklist only for enhancement tickets
+  - name: mark-enhancement-for-docs
+    description: Mark enhancement tickets for documentation review
     on:
       entity: ticket
       property: status
@@ -1122,9 +1122,8 @@ automations:
       when:
         - "kind=enhancement"
     do:
-      - create_entity:
-          type: docs-checklist
-          relation: has-docs
+      - set: needs_docs
+        value: "true"
 ```
 
 Multiple conditions use AND logic (all must match):

--- a/docs-project/entities/guide/GUIDE-metamodel.md
+++ b/docs-project/entities/guide/GUIDE-metamodel.md
@@ -1104,6 +1104,45 @@ Automations fire based on entity changes:
 | `created`         | Fires when entity is created                   | `true`                    |
 | `relation_created`| Fires when this relation type is created       | `implements`              |
 | `relation_removed`| Fires when this relation type is removed       | `implements`              |
+| `when`            | Property conditions that must match (AND)      | `["kind=enhancement"]`    |
+
+### Conditional Triggers
+
+Use `when` to add property conditions that must be satisfied for the automation to fire.
+This uses the same filter syntax as validation rules.
+
+```yaml
+automations:
+  - name: docs-for-enhancements
+    description: Create docs checklist only for enhancement tickets
+    on:
+      entity: ticket
+      property: status
+      becomes: review
+      when:
+        - "kind=enhancement"
+    do:
+      - create_entity:
+          type: docs-checklist
+          relation: has-docs
+```
+
+Multiple conditions use AND logic (all must match):
+
+```yaml
+on:
+  entity: ticket
+  property: status
+  becomes: review
+  when:
+    - "kind=enhancement"
+    - "priority=high"
+```
+
+Supported operators: `=`, `!=`, `<`, `<=`, `>`, `>=`, `=~` (regex).
+
+**Note:** Conditions are evaluated against the entity's NEW state (after the change).
+For property change triggers, use `from` to filter on the old value of the changed property.
 
 ### Actions
 

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -1098,6 +1098,45 @@ Automations fire based on entity changes:
 | `created`         | Fires when entity is created                   | `true`                    |
 | `relation_created`| Fires when this relation type is created       | `implements`              |
 | `relation_removed`| Fires when this relation type is removed       | `implements`              |
+| `when`            | Property conditions that must match (AND)      | `["kind=enhancement"]`    |
+
+### Conditional Triggers
+
+Use `when` to add property conditions that must be satisfied for the automation to fire.
+This uses the same filter syntax as validation rules.
+
+```yaml
+automations:
+  - name: docs-for-enhancements
+    description: Create docs checklist only for enhancement tickets
+    on:
+      entity: ticket
+      property: status
+      becomes: review
+      when:
+        - "kind=enhancement"
+    do:
+      - create_entity:
+          type: docs-checklist
+          relation: has-docs
+```
+
+Multiple conditions use AND logic (all must match):
+
+```yaml
+on:
+  entity: ticket
+  property: status
+  becomes: review
+  when:
+    - "kind=enhancement"
+    - "priority=high"
+```
+
+Supported operators: `=`, `!=`, `<`, `<=`, `>`, `>=`, `=~` (regex).
+
+**Note:** Conditions are evaluated against the entity's NEW state (after the change).
+For property change triggers, use `from` to filter on the old value of the changed property.
 
 ### Actions
 

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -1107,8 +1107,8 @@ This uses the same filter syntax as validation rules.
 
 ```yaml
 automations:
-  - name: docs-for-enhancements
-    description: Create docs checklist only for enhancement tickets
+  - name: mark-enhancement-for-docs
+    description: Mark enhancement tickets for documentation review
     on:
       entity: ticket
       property: status
@@ -1116,9 +1116,8 @@ automations:
       when:
         - "kind=enhancement"
     do:
-      - create_entity:
-          type: docs-checklist
-          relation: has-docs
+      - set: needs_docs
+        value: "true"
 ```
 
 Multiple conditions use AND logic (all must match):

--- a/internal/automation/engine.go
+++ b/internal/automation/engine.go
@@ -31,6 +31,20 @@ func NewEngineFromMetamodel(defs []metamodel.AutomationDef) *Engine {
 
 // convertFromMetamodel converts a metamodel AutomationDef to the internal Automation type.
 func convertFromMetamodel(def metamodel.AutomationDef) Automation {
+	// Parse when conditions
+	// Note: Invalid filters are silently skipped. This could be improved by
+	// validating at metamodel load time (requires breaking filter/metamodel import cycle).
+	whenFilters := make([]*filter.Filter, 0, len(def.On.When))
+	for _, w := range def.On.When {
+		f, err := filter.Parse(w)
+		if err != nil {
+			// Skip invalid conditions - this automation will have fewer constraints
+			// than intended, which is safer than having no constraints at all
+			continue
+		}
+		whenFilters = append(whenFilters, f)
+	}
+
 	auto := Automation{
 		Name:        def.Name,
 		Description: def.Description,
@@ -42,6 +56,7 @@ func convertFromMetamodel(def metamodel.AutomationDef) Automation {
 			Created:         def.On.Created,
 			RelationCreated: def.On.RelationCreated,
 			RelationRemoved: def.On.RelationRemoved,
+			When:            whenFilters,
 		},
 		Do:       make([]Action, len(def.Do)),
 		Validate: make([]Validation, len(def.Validate)),
@@ -121,6 +136,11 @@ func (e *Engine) matches(trigger Trigger, event Event) bool {
 		}
 	}
 
+	// Check when conditions (property filters on the entity)
+	if !e.matchesWhenConditions(trigger, event.Entity) {
+		return false
+	}
+
 	switch event.Type {
 	case EventEntityCreated:
 		return trigger.Created
@@ -174,6 +194,25 @@ func (e *Engine) matchesPropertyChange(trigger Trigger, event Event) bool {
 		return false
 	}
 
+	return true
+}
+
+// matchesWhenConditions checks if all when conditions are satisfied.
+// Returns true if no conditions are specified (backward compatible).
+func (e *Engine) matchesWhenConditions(trigger Trigger, entity *model.Entity) bool {
+	if len(trigger.When) == 0 {
+		return true
+	}
+	if entity == nil {
+		return false
+	}
+
+	for _, f := range trigger.When {
+		val := entity.Properties[f.Property]
+		if !matchSimple(val, f) {
+			return false
+		}
+	}
 	return true
 }
 

--- a/internal/automation/engine_test.go
+++ b/internal/automation/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
@@ -374,4 +375,308 @@ func TestEngine_RelationCreated(t *testing.T) {
 	if result.PropertiesSet["has_implementation"] != "true" {
 		t.Error("expected trigger on relation created")
 	}
+}
+
+func TestEngine_WhenConditionMet(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "docs-for-enhancements",
+			On: Trigger{
+				Entity:   []string{"ticket"},
+				Property: "status",
+				Becomes:  "review",
+				When:     parseFilters(t, "kind=enhancement"),
+			},
+			Do: []Action{
+				{Set: "needs_docs", Value: "true"},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	oldEntity := model.NewEntity("T-001", "ticket")
+	oldEntity.Properties["status"] = "in-progress"
+	oldEntity.Properties["kind"] = "enhancement"
+
+	newEntity := model.NewEntity("T-001", "ticket")
+	newEntity.Properties["status"] = "review"
+	newEntity.Properties["kind"] = "enhancement"
+
+	result := engine.Process(Event{
+		Type:      EventEntityUpdated,
+		Entity:    newEntity,
+		OldEntity: oldEntity,
+	})
+
+	if result.PropertiesSet["needs_docs"] != "true" {
+		t.Error("expected trigger to fire when condition is met")
+	}
+}
+
+func TestEngine_WhenConditionNotMet(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "docs-for-enhancements",
+			On: Trigger{
+				Entity:   []string{"ticket"},
+				Property: "status",
+				Becomes:  "review",
+				When:     parseFilters(t, "kind=enhancement"),
+			},
+			Do: []Action{
+				{Set: "needs_docs", Value: "true"},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	oldEntity := model.NewEntity("T-001", "ticket")
+	oldEntity.Properties["status"] = "in-progress"
+	oldEntity.Properties["kind"] = "bug" // Not an enhancement
+
+	newEntity := model.NewEntity("T-001", "ticket")
+	newEntity.Properties["status"] = "review"
+	newEntity.Properties["kind"] = "bug"
+
+	result := engine.Process(Event{
+		Type:      EventEntityUpdated,
+		Entity:    newEntity,
+		OldEntity: oldEntity,
+	})
+
+	if len(result.PropertiesSet) > 0 {
+		t.Error("expected trigger NOT to fire when condition is not met")
+	}
+}
+
+func TestEngine_MultipleWhenConditions(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "high-priority-enhancements",
+			On: Trigger{
+				Entity:   []string{"ticket"},
+				Property: "status",
+				Becomes:  "review",
+				When:     parseFilters(t, "kind=enhancement", "priority=high"),
+			},
+			Do: []Action{
+				{Set: "urgent_review", Value: "true"},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	// Test: both conditions met
+	oldEntity := model.NewEntity("T-001", "ticket")
+	oldEntity.Properties["status"] = "in-progress"
+	oldEntity.Properties["kind"] = "enhancement"
+	oldEntity.Properties["priority"] = "high"
+
+	newEntity := model.NewEntity("T-001", "ticket")
+	newEntity.Properties["status"] = "review"
+	newEntity.Properties["kind"] = "enhancement"
+	newEntity.Properties["priority"] = "high"
+
+	result := engine.Process(Event{
+		Type:      EventEntityUpdated,
+		Entity:    newEntity,
+		OldEntity: oldEntity,
+	})
+
+	if result.PropertiesSet["urgent_review"] != "true" {
+		t.Error("expected trigger when all conditions are met")
+	}
+
+	// Test: only one condition met
+	oldEntity2 := model.NewEntity("T-002", "ticket")
+	oldEntity2.Properties["status"] = "in-progress"
+	oldEntity2.Properties["kind"] = "enhancement"
+	oldEntity2.Properties["priority"] = "low" // Not high
+
+	newEntity2 := model.NewEntity("T-002", "ticket")
+	newEntity2.Properties["status"] = "review"
+	newEntity2.Properties["kind"] = "enhancement"
+	newEntity2.Properties["priority"] = "low"
+
+	result2 := engine.Process(Event{
+		Type:      EventEntityUpdated,
+		Entity:    newEntity2,
+		OldEntity: oldEntity2,
+	})
+
+	if len(result2.PropertiesSet) > 0 {
+		t.Error("expected trigger NOT to fire when only one condition met")
+	}
+}
+
+func TestEngine_NoWhenConditions(t *testing.T) {
+	// Backward compatibility: no when conditions = always match
+	automations := []Automation{
+		{
+			Name: "always-trigger",
+			On: Trigger{
+				Entity:   []string{"ticket"},
+				Property: "status",
+				Becomes:  "review",
+				// No When conditions
+			},
+			Do: []Action{
+				{Set: "reviewed", Value: "true"},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	oldEntity := model.NewEntity("T-001", "ticket")
+	oldEntity.Properties["status"] = "in-progress"
+
+	newEntity := model.NewEntity("T-001", "ticket")
+	newEntity.Properties["status"] = "review"
+
+	result := engine.Process(Event{
+		Type:      EventEntityUpdated,
+		Entity:    newEntity,
+		OldEntity: oldEntity,
+	})
+
+	if result.PropertiesSet["reviewed"] != "true" {
+		t.Error("expected trigger without when conditions to fire")
+	}
+}
+
+func TestEngine_WhenConditionOnCreated(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "init-enhancement",
+			On: Trigger{
+				Entity:  []string{"ticket"},
+				Created: true,
+				When:    parseFilters(t, "kind=enhancement"),
+			},
+			Do: []Action{
+				{Set: "needs_planning", Value: "true"},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	// Enhancement ticket
+	entity := model.NewEntity("T-001", "ticket")
+	entity.Properties["kind"] = "enhancement"
+
+	result := engine.Process(Event{
+		Type:   EventEntityCreated,
+		Entity: entity,
+	})
+
+	if result.PropertiesSet["needs_planning"] != "true" {
+		t.Error("expected trigger on created when condition met")
+	}
+
+	// Bug ticket - should not trigger
+	bugEntity := model.NewEntity("T-002", "ticket")
+	bugEntity.Properties["kind"] = "bug"
+
+	result2 := engine.Process(Event{
+		Type:   EventEntityCreated,
+		Entity: bugEntity,
+	})
+
+	if len(result2.PropertiesSet) > 0 {
+		t.Error("expected no trigger on created when condition not met")
+	}
+}
+
+func TestEngine_WhenConditionOnRelationCreated(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "link-only-enhancements",
+			On: Trigger{
+				RelationCreated: "implements",
+				When:            parseFilters(t, "kind=enhancement"),
+			},
+			Do: []Action{
+				{Set: "has_impl", Value: "true"},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	// Enhancement ticket - should trigger
+	entity := model.NewEntity("T-001", "ticket")
+	entity.Properties["kind"] = "enhancement"
+	rel := model.NewRelation("S-001", "implements", "T-001")
+
+	result := engine.Process(Event{
+		Type:     EventRelationCreated,
+		Entity:   entity,
+		Relation: rel,
+	})
+
+	if result.PropertiesSet["has_impl"] != "true" {
+		t.Error("expected trigger on relation created when condition met")
+	}
+
+	// Bug ticket - should not trigger
+	bugEntity := model.NewEntity("T-002", "ticket")
+	bugEntity.Properties["kind"] = "bug"
+	rel2 := model.NewRelation("S-002", "implements", "T-002")
+
+	result2 := engine.Process(Event{
+		Type:     EventRelationCreated,
+		Entity:   bugEntity,
+		Relation: rel2,
+	})
+
+	if len(result2.PropertiesSet) > 0 {
+		t.Error("expected no trigger on relation created when condition not met")
+	}
+}
+
+func TestEngine_WhenConditionNilEntity(t *testing.T) {
+	automations := []Automation{
+		{
+			Name: "with-when",
+			On: Trigger{
+				Property: "status",
+				Becomes:  "done",
+				When:     parseFilters(t, "kind=enhancement"),
+			},
+			Do: []Action{
+				{Set: "done", Value: "true"},
+			},
+		},
+	}
+
+	engine := NewEngine(automations)
+
+	// Nil entity should not panic and should not fire
+	result := engine.Process(Event{
+		Type:   EventEntityUpdated,
+		Entity: nil,
+	})
+
+	if len(result.PropertiesSet) > 0 {
+		t.Error("expected no trigger when entity is nil")
+	}
+}
+
+// parseFilters is a test helper to parse filter strings.
+func parseFilters(t *testing.T, conditions ...string) []*filter.Filter {
+	t.Helper()
+	filters := make([]*filter.Filter, 0, len(conditions))
+	for _, c := range conditions {
+		f, err := filter.Parse(c)
+		if err != nil {
+			t.Fatalf("failed to parse filter %q: %v", c, err)
+		}
+		filters = append(filters, f)
+	}
+	return filters
 }

--- a/internal/automation/engine_test.go
+++ b/internal/automation/engine_test.go
@@ -399,9 +399,8 @@ func TestEngine_WhenConditionMet(t *testing.T) {
 	oldEntity.Properties["status"] = "in-progress"
 	oldEntity.Properties["kind"] = "enhancement"
 
-	newEntity := model.NewEntity("T-001", "ticket")
+	newEntity := oldEntity.Clone()
 	newEntity.Properties["status"] = "review"
-	newEntity.Properties["kind"] = "enhancement"
 
 	result := engine.Process(Event{
 		Type:      EventEntityUpdated,
@@ -436,9 +435,8 @@ func TestEngine_WhenConditionNotMet(t *testing.T) {
 	oldEntity.Properties["status"] = "in-progress"
 	oldEntity.Properties["kind"] = "bug" // Not an enhancement
 
-	newEntity := model.NewEntity("T-001", "ticket")
+	newEntity := oldEntity.Clone()
 	newEntity.Properties["status"] = "review"
-	newEntity.Properties["kind"] = "bug"
 
 	result := engine.Process(Event{
 		Type:      EventEntityUpdated,
@@ -475,10 +473,8 @@ func TestEngine_MultipleWhenConditions(t *testing.T) {
 	oldEntity.Properties["kind"] = "enhancement"
 	oldEntity.Properties["priority"] = "high"
 
-	newEntity := model.NewEntity("T-001", "ticket")
+	newEntity := oldEntity.Clone()
 	newEntity.Properties["status"] = "review"
-	newEntity.Properties["kind"] = "enhancement"
-	newEntity.Properties["priority"] = "high"
 
 	result := engine.Process(Event{
 		Type:      EventEntityUpdated,
@@ -496,10 +492,8 @@ func TestEngine_MultipleWhenConditions(t *testing.T) {
 	oldEntity2.Properties["kind"] = "enhancement"
 	oldEntity2.Properties["priority"] = "low" // Not high
 
-	newEntity2 := model.NewEntity("T-002", "ticket")
+	newEntity2 := oldEntity2.Clone()
 	newEntity2.Properties["status"] = "review"
-	newEntity2.Properties["kind"] = "enhancement"
-	newEntity2.Properties["priority"] = "low"
 
 	result2 := engine.Process(Event{
 		Type:      EventEntityUpdated,
@@ -534,7 +528,7 @@ func TestEngine_NoWhenConditions(t *testing.T) {
 	oldEntity := model.NewEntity("T-001", "ticket")
 	oldEntity.Properties["status"] = "in-progress"
 
-	newEntity := model.NewEntity("T-001", "ticket")
+	newEntity := oldEntity.Clone()
 	newEntity.Properties["status"] = "review"
 
 	result := engine.Process(Event{

--- a/internal/automation/types.go
+++ b/internal/automation/types.go
@@ -4,6 +4,7 @@
 package automation
 
 import (
+	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
@@ -25,6 +26,7 @@ type Trigger struct {
 	Created         bool
 	RelationCreated string
 	RelationRemoved string
+	When            []*filter.Filter // Property conditions that must all match
 }
 
 // Action specifies an operation to perform.

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -289,6 +289,7 @@ type AutomationTrigger struct {
 	Created         bool          `yaml:"created,omitempty"`
 	RelationCreated string        `yaml:"relation_created,omitempty"`
 	RelationRemoved string        `yaml:"relation_removed,omitempty"`
+	When            []string      `yaml:"when,omitempty"` // Property conditions that must match (AND logic)
 }
 
 // AutomationAction specifies an operation to perform.

--- a/tickets/entities/tickets/TKT-fac0.md
+++ b/tickets/entities/tickets/TKT-fac0.md
@@ -1,0 +1,8 @@
+---
+id: TKT-fac0
+kind: enhancement
+priority: medium
+status: done
+title: Conditional automations based on entity properties
+type: ticket
+---


### PR DESCRIPTION
## Summary

- Add `when` property conditions to automation triggers using filter syntax
- Automations only fire when all `when` conditions match the entity
- Enables conditional workflows like "create docs checklist only for enhancement tickets"

## Example

```yaml
automations:
  - name: docs-for-enhancements
    on:
      entity: ticket
      property: status
      becomes: review
      when:
        - "kind=enhancement"
    do:
      - create_entity:
          type: docs-checklist
          relation: has-docs
```

## Test plan

- [x] Unit tests for conditional trigger matching
- [x] Tests for multiple `when` conditions (AND logic)
- [x] Tests for non-matching conditions (automation skipped)