### PR TITLE
feat(cli): add fmt command and frontmatter ordering

### DIFF
--- a/internal/cli/fmt.go
+++ b/internal/cli/fmt.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Sourcehaven-BV/rela/internal/errors"
+	"github.com/Sourcehaven-BV/rela/internal/markdown"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+)
+
+var (
+	fmtDryRun bool
+	fmtCheck  bool
+)
+
+var fmtCmd = &cobra.Command{
+	Use:   "fmt [type]",
+	Short: "Format entity files",
+	Long: `Formats entity files to ensure consistent formatting.
+
+Currently this command:
+- Orders frontmatter properties according to the metamodel definition
+- Ensures id and type appear first, followed by properties in metamodel order
+- Places any extra properties (not in metamodel) at the end, sorted alphabetically
+
+Exit codes:
+- 0: All files formatted (or already formatted with --check)
+- 1: Files need formatting (with --check)
+
+Examples:
+  rela fmt                # Format all entities
+  rela fmt requirements   # Format only requirements
+  rela fmt --dry-run      # Preview changes without writing
+  rela fmt --check        # Check if files need formatting (for CI)`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var entities []*model.Entity
+
+		if len(args) > 0 {
+			typeName := args[0]
+			resolvedType, _, err := resolveEntityType(typeName)
+			if err != nil {
+				return err
+			}
+			entities = ws.EntitiesByType(resolvedType)
+		} else {
+			entities = ws.AllEntities()
+		}
+
+		if len(entities) == 0 {
+			out.WriteMessage("No entities found")
+			return nil
+		}
+
+		modified := 0
+		for _, entity := range entities {
+			// Get property order from metamodel
+			var propertyOrder []string
+			if entityDef, ok := meta.GetEntityDef(entity.Type); ok {
+				propertyOrder = entityDef.GetPropertyOrder()
+			}
+
+			// Generate formatted content
+			formatted, err := markdown.FormatEntity(entity, propertyOrder)
+			if err != nil {
+				out.WriteWarning("Failed to format %s: %v", entity.ID, err)
+				continue
+			}
+
+			// Read current file content
+			currentContent, err := os.ReadFile(entity.FilePath)
+			if err != nil {
+				out.WriteWarning("Failed to read %s: %v", entity.ID, err)
+				continue
+			}
+
+			// Compare
+			if formatted == string(currentContent) {
+				continue
+			}
+
+			modified++
+
+			if fmtCheck {
+				out.WriteMessage("Needs formatting: %s", entity.ID)
+				continue
+			}
+
+			if fmtDryRun {
+				out.WriteMessage("Would format: %s", entity.ID)
+				continue
+			}
+
+			// Write formatted content
+			if err := os.WriteFile(entity.FilePath, []byte(formatted), 0644); err != nil {
+				out.WriteWarning("Failed to write %s: %v", entity.ID, err)
+				continue
+			}
+
+			if verbose {
+				out.WriteMessage("Formatted: %s", entity.ID)
+			}
+		}
+
+		if fmtCheck {
+			if modified > 0 {
+				out.WriteMessage("%d entities need formatting", modified)
+				return errors.NewExitError(1)
+			}
+			out.WriteSuccess("All entities are properly formatted")
+			return nil
+		}
+
+		if fmtDryRun {
+			out.WriteMessage("Dry run: %d entities would be formatted", modified)
+		} else {
+			out.WriteSuccess("Formatted %d entities", modified)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	fmtCmd.Flags().BoolVar(&fmtDryRun, "dry-run", false, "Preview changes without writing")
+	fmtCmd.Flags().BoolVar(&fmtCheck, "check", false, "Check if files need formatting (exits 1 if they do)")
+
+	rootCmd.AddCommand(fmtCmd)
+}

--- a/internal/cli/fmt.go
+++ b/internal/cli/fmt.go
@@ -1,12 +1,9 @@
 package cli
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/Sourcehaven-BV/rela/internal/errors"
-	"github.com/Sourcehaven-BV/rela/internal/markdown"
 	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
@@ -54,30 +51,18 @@ Examples:
 			return nil
 		}
 
+		// For --check mode, use dry-run behavior internally
+		dryRun := fmtDryRun || fmtCheck
+
 		modified := 0
 		for _, entity := range entities {
-			// Get property order from metamodel
-			var propertyOrder []string
-			if entityDef, ok := meta.GetEntityDef(entity.Type); ok {
-				propertyOrder = entityDef.GetPropertyOrder()
-			}
-
-			// Generate formatted content
-			formatted, err := markdown.FormatEntity(entity, propertyOrder)
+			changed, err := ws.FormatEntity(entity, dryRun)
 			if err != nil {
 				out.WriteWarning("Failed to format %s: %v", entity.ID, err)
 				continue
 			}
 
-			// Read current file content
-			currentContent, err := os.ReadFile(entity.FilePath)
-			if err != nil {
-				out.WriteWarning("Failed to read %s: %v", entity.ID, err)
-				continue
-			}
-
-			// Compare
-			if formatted == string(currentContent) {
+			if !changed {
 				continue
 			}
 
@@ -85,21 +70,9 @@ Examples:
 
 			if fmtCheck {
 				out.WriteMessage("Needs formatting: %s", entity.ID)
-				continue
-			}
-
-			if fmtDryRun {
+			} else if fmtDryRun {
 				out.WriteMessage("Would format: %s", entity.ID)
-				continue
-			}
-
-			// Write formatted content
-			if err := os.WriteFile(entity.FilePath, []byte(formatted), 0644); err != nil {
-				out.WriteWarning("Failed to write %s: %v", entity.ID, err)
-				continue
-			}
-
-			if verbose {
+			} else if verbose {
 				out.WriteMessage("Formatted: %s", entity.ID)
 			}
 		}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	stderrors "errors"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 
+	"github.com/Sourcehaven-BV/rela/internal/errors"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/output"
 	"github.com/Sourcehaven-BV/rela/internal/project"
@@ -80,6 +82,11 @@ and maintain semantic relationships between them.`,
 // coverage-ignore: CLI entry point - tested via integration tests
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		// Check for ExitError to use custom exit code
+		var exitErr *errors.ExitError
+		if stderrors.As(err, &exitErr) {
+			os.Exit(exitErr.Code)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -63,3 +63,19 @@ func (e *ValidationError) Error() string {
 func (e *ValidationError) Unwrap() error {
 	return ErrValidation
 }
+
+// ExitError is an error that indicates the program should exit with a specific code.
+// This allows commands to signal exit codes without calling os.Exit directly,
+// making them testable.
+type ExitError struct {
+	Code int
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("exit status %d", e.Code)
+}
+
+// NewExitError creates a new ExitError with the given exit code.
+func NewExitError(code int) *ExitError {
+	return &ExitError{Code: code}
+}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -52,3 +52,27 @@ func TestValidationError(t *testing.T) {
 		t.Error("ValidationError should wrap ErrValidation")
 	}
 }
+
+func TestExitError(t *testing.T) {
+	err := NewExitError(42)
+
+	if err.Code != 42 {
+		t.Errorf("expected code 42, got %d", err.Code)
+	}
+
+	if err.Error() != "exit status 42" {
+		t.Errorf("unexpected error message: %s", err.Error())
+	}
+}
+
+func TestExitErrorZero(t *testing.T) {
+	err := NewExitError(0)
+
+	if err.Code != 0 {
+		t.Errorf("expected code 0, got %d", err.Code)
+	}
+
+	if err.Error() != "exit status 0" {
+		t.Errorf("unexpected error message: %s", err.Error())
+	}
+}

--- a/internal/markdown/entity.go
+++ b/internal/markdown/entity.go
@@ -67,29 +67,36 @@ func (f *FileIO) ReadEntity(path string, meta *metamodel.Metamodel) (*model.Enti
 	return entity, nil
 }
 
-// WriteEntity writes an entity to a markdown file.
-func (f *FileIO) WriteEntity(entity *model.Entity, path string) error {
+// FormatEntity returns the formatted markdown content for an entity.
+// The optional propertyOrder specifies the order for entity properties (after id and type).
+func FormatEntity(entity *model.Entity, propertyOrder []string) (string, error) {
 	frontmatter := make(map[string]interface{})
 	frontmatter["id"] = entity.ID
 	frontmatter["type"] = entity.Type
 
-	// Add properties in a consistent order
-	// First the common ones
-	if title := entity.GetString("title"); title != "" {
-		frontmatter["title"] = title
-	}
-	if status := entity.GetString("status"); status != "" {
-		frontmatter["status"] = status
-	}
-
-	// Then the rest
+	// Copy all properties
 	for key, value := range entity.Properties {
-		if key != "title" && key != "status" {
-			frontmatter[key] = value
-		}
+		frontmatter[key] = value
 	}
 
-	content, err := FormatDocument(frontmatter, entity.Content)
+	// Build key order: id, type, then property order (or alphabetical for remaining)
+	keyOrder := []string{"id", "type"}
+	if len(propertyOrder) > 0 {
+		keyOrder = append(keyOrder, propertyOrder...)
+	}
+
+	return FormatDocumentOrdered(frontmatter, entity.Content, keyOrder)
+}
+
+// WriteEntity writes an entity to a markdown file.
+// The optional propertyOrder specifies the order for entity properties (after id and type).
+func (f *FileIO) WriteEntity(entity *model.Entity, path string, propertyOrder ...[]string) error {
+	var order []string
+	if len(propertyOrder) > 0 {
+		order = propertyOrder[0]
+	}
+
+	content, err := FormatEntity(entity, order)
 	if err != nil {
 		return err
 	}

--- a/internal/markdown/entity_test.go
+++ b/internal/markdown/entity_test.go
@@ -206,6 +206,71 @@ func TestWriteEntity_PropertyOrdering(t *testing.T) {
 	}
 }
 
+func TestWriteEntity_WithPropertyOrder(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	entity := model.NewEntity("REQ-001", "requirement")
+	entity.SetString("zebra", "last-alphabetically")
+	entity.SetString("alpha", "first-alphabetically")
+	entity.SetString("priority", "high")
+	entity.SetString("title", "Test")
+	entity.SetString("status", "draft")
+	entity.SetString("extra", "not-in-order")
+
+	entityPath := filepath.Join(tmpDir, "REQ-001.md")
+
+	// Write with specific property order: title, priority, status
+	propertyOrder := []string{"title", "priority", "status"}
+	err := testIO.WriteEntity(entity, entityPath, propertyOrder)
+	if err != nil {
+		t.Fatalf("WriteEntity failed: %v", err)
+	}
+
+	content, err := os.ReadFile(entityPath)
+	if err != nil {
+		t.Fatalf("failed to read entity file: %v", err)
+	}
+
+	contentStr := string(content)
+
+	// Verify the order: id, type, then title, priority, status, then remaining alphabetically
+	idIdx := strings.Index(contentStr, "id:")
+	typeIdx := strings.Index(contentStr, "type:")
+	titleIdx := strings.Index(contentStr, "title:")
+	priorityIdx := strings.Index(contentStr, "priority:")
+	statusIdx := strings.Index(contentStr, "status:")
+	alphaIdx := strings.Index(contentStr, "alpha:")
+	extraIdx := strings.Index(contentStr, "extra:")
+	zebraIdx := strings.Index(contentStr, "zebra:")
+
+	// id and type should come first
+	if idIdx > typeIdx {
+		t.Error("id should come before type")
+	}
+
+	// Properties in specified order
+	if typeIdx > titleIdx {
+		t.Error("type should come before title")
+	}
+	if titleIdx > priorityIdx {
+		t.Error("title should come before priority")
+	}
+	if priorityIdx > statusIdx {
+		t.Error("priority should come before status")
+	}
+
+	// Remaining properties should come after and be sorted alphabetically
+	if statusIdx > alphaIdx {
+		t.Error("status should come before remaining properties")
+	}
+	if alphaIdx > extraIdx {
+		t.Error("alpha should come before extra (alphabetical)")
+	}
+	if extraIdx > zebraIdx {
+		t.Error("extra should come before zebra (alphabetical)")
+	}
+}
+
 func TestDeleteEntity(t *testing.T) {
 	tmpDir := testutil.TempDirWithCleanup(t)
 

--- a/internal/markdown/parser.go
+++ b/internal/markdown/parser.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -98,15 +99,30 @@ func splitFrontmatter(content string) (frontmatter, body string, err error) {
 	return frontmatter, body, nil
 }
 
-// FormatDocument formats a document back to markdown with YAML frontmatter
+// FormatDocument formats a document back to markdown with YAML frontmatter.
+// Keys are output in alphabetical order (yaml.Marshal default behavior).
 func FormatDocument(frontmatter map[string]interface{}, content string) (string, error) {
+	return FormatDocumentOrdered(frontmatter, content, nil)
+}
+
+// FormatDocumentOrdered formats a document with YAML frontmatter in a specific key order.
+// If keyOrder is nil or empty, keys are sorted alphabetically.
+// Keys in keyOrder appear first (in that order), followed by any remaining keys alphabetically.
+func FormatDocumentOrdered(frontmatter map[string]interface{}, content string, keyOrder []string) (string, error) {
 	var sb strings.Builder
 
 	if len(frontmatter) > 0 {
 		sb.WriteString(frontmatterDelimiter)
 		sb.WriteString("\n")
 
-		yamlBytes, err := yaml.Marshal(frontmatter)
+		var yamlBytes []byte
+		var err error
+
+		if len(keyOrder) > 0 {
+			yamlBytes, err = marshalOrdered(frontmatter, keyOrder)
+		} else {
+			yamlBytes, err = yaml.Marshal(frontmatter)
+		}
 		if err != nil {
 			return "", err
 		}
@@ -124,6 +140,67 @@ func FormatDocument(frontmatter map[string]interface{}, content string) (string,
 	}
 
 	return sb.String(), nil
+}
+
+// marshalOrdered marshals a map to YAML with keys in the specified order.
+// Keys in keyOrder appear first, followed by remaining keys alphabetically.
+func marshalOrdered(data map[string]interface{}, keyOrder []string) ([]byte, error) {
+	// Build yaml.Node with ordered keys
+	node := &yaml.Node{
+		Kind: yaml.MappingNode,
+	}
+
+	// Track which keys we've added
+	added := make(map[string]bool)
+
+	// Add keys in specified order first
+	for _, key := range keyOrder {
+		val, ok := data[key]
+		if !ok {
+			continue
+		}
+		node.Content = append(node.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: key},
+		)
+		valNode, err := valueToNode(val)
+		if err != nil {
+			return nil, err
+		}
+		node.Content = append(node.Content, valNode)
+		added[key] = true
+	}
+
+	// Collect remaining keys and sort them
+	var remaining []string
+	for key := range data {
+		if !added[key] {
+			remaining = append(remaining, key)
+		}
+	}
+	sort.Strings(remaining)
+
+	// Add remaining keys alphabetically
+	for _, key := range remaining {
+		node.Content = append(node.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: key},
+		)
+		valNode, err := valueToNode(data[key])
+		if err != nil {
+			return nil, err
+		}
+		node.Content = append(node.Content, valNode)
+	}
+
+	return yaml.Marshal(node)
+}
+
+// valueToNode converts a Go value to a yaml.Node.
+func valueToNode(val interface{}) (*yaml.Node, error) {
+	var node yaml.Node
+	if err := node.Encode(val); err != nil {
+		return nil, err
+	}
+	return &node, nil
 }
 
 // GetString extracts a string value from frontmatter

--- a/internal/metamodel/entity_def.go
+++ b/internal/metamodel/entity_def.go
@@ -161,3 +161,15 @@ func (e *EntityDef) MatchesID(id string) bool {
 	}
 	return false
 }
+
+// GetPropertyOrder returns the property names in their definition order.
+// If PropertyOrder was not populated during loading, returns nil.
+// Returns a copy to prevent external modification.
+func (e *EntityDef) GetPropertyOrder() []string {
+	if e.PropertyOrder == nil {
+		return nil
+	}
+	result := make([]string, len(e.PropertyOrder))
+	copy(result, e.PropertyOrder)
+	return result
+}

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -127,7 +127,9 @@ func parseRaw(data []byte) (*Metamodel, error) {
 	}
 
 	// Extract property order from YAML (maps lose key order during unmarshaling)
-	extractPropertyOrder(data, &m)
+	if err := extractPropertyOrder(data, &m); err != nil {
+		return nil, err
+	}
 
 	return &m, nil
 }
@@ -135,19 +137,19 @@ func parseRaw(data []byte) (*Metamodel, error) {
 // extractPropertyOrder parses the YAML using yaml.Node to extract property key order
 // for each entity definition. This allows WriteEntity to output properties in the
 // same order as defined in the metamodel.
-func extractPropertyOrder(data []byte, m *Metamodel) {
+func extractPropertyOrder(data []byte, m *Metamodel) error {
 	var root yaml.Node
 	if err := yaml.Unmarshal(data, &root); err != nil {
-		return // Defensive: shouldn't fail since struct parsing succeeded
+		return fmt.Errorf("parse yaml.Node for property order: %w", err)
 	}
 
 	// root is a document node, get its content
 	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
-		return
+		return nil
 	}
 	doc := root.Content[0]
 	if doc.Kind != yaml.MappingNode {
-		return
+		return nil
 	}
 
 	// Find the "entities" key
@@ -159,6 +161,7 @@ func extractPropertyOrder(data []byte, m *Metamodel) {
 			break
 		}
 	}
+	return nil
 }
 
 // extractEntityPropertyOrder extracts property order from the entities mapping node.

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -135,15 +135,10 @@ func parseRaw(data []byte) (*Metamodel, error) {
 // extractPropertyOrder parses the YAML using yaml.Node to extract property key order
 // for each entity definition. This allows WriteEntity to output properties in the
 // same order as defined in the metamodel.
-//
-// This is a best-effort enhancement: if yaml.Node parsing fails, we silently
-// continue without property ordering. The main struct parsing already succeeded,
-// so the metamodel is valid - we just won't have property order information.
 func extractPropertyOrder(data []byte, m *Metamodel) {
 	var root yaml.Node
 	if err := yaml.Unmarshal(data, &root); err != nil {
-		// Best-effort: property order is nice-to-have, not required
-		return
+		return // Defensive: shouldn't fail since struct parsing succeeded
 	}
 
 	// root is a document node, get its content

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -126,7 +126,76 @@ func parseRaw(data []byte) (*Metamodel, error) {
 		}
 	}
 
+	// Extract property order from YAML (maps lose key order during unmarshaling)
+	extractPropertyOrder(data, &m)
+
 	return &m, nil
+}
+
+// extractPropertyOrder parses the YAML using yaml.Node to extract property key order
+// for each entity definition. This allows WriteEntity to output properties in the
+// same order as defined in the metamodel.
+//
+// This is a best-effort enhancement: if yaml.Node parsing fails, we silently
+// continue without property ordering. The main struct parsing already succeeded,
+// so the metamodel is valid - we just won't have property order information.
+func extractPropertyOrder(data []byte, m *Metamodel) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		// Best-effort: property order is nice-to-have, not required
+		return
+	}
+
+	// root is a document node, get its content
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return
+	}
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return
+	}
+
+	// Find the "entities" key
+	for i := 0; i < len(doc.Content)-1; i += 2 {
+		keyNode := doc.Content[i]
+		valueNode := doc.Content[i+1]
+		if keyNode.Value == "entities" && valueNode.Kind == yaml.MappingNode {
+			extractEntityPropertyOrder(valueNode, m)
+			break
+		}
+	}
+}
+
+// extractEntityPropertyOrder extracts property order from the entities mapping node.
+func extractEntityPropertyOrder(entitiesNode *yaml.Node, m *Metamodel) {
+	// Iterate over entity definitions
+	for i := 0; i < len(entitiesNode.Content)-1; i += 2 {
+		entityNameNode := entitiesNode.Content[i]
+		entityDefNode := entitiesNode.Content[i+1]
+
+		entityName := entityNameNode.Value
+		entityDef, ok := m.Entities[entityName]
+		if !ok || entityDefNode.Kind != yaml.MappingNode {
+			continue
+		}
+
+		// Find the "properties" key within this entity definition
+		for j := 0; j < len(entityDefNode.Content)-1; j += 2 {
+			keyNode := entityDefNode.Content[j]
+			valueNode := entityDefNode.Content[j+1]
+			if keyNode.Value == "properties" && valueNode.Kind == yaml.MappingNode {
+				// Extract property names in order
+				var order []string
+				for k := 0; k < len(valueNode.Content)-1; k += 2 {
+					propNameNode := valueNode.Content[k]
+					order = append(order, propNameNode.Value)
+				}
+				entityDef.PropertyOrder = order
+				m.Entities[entityName] = entityDef
+				break
+			}
+		}
+	}
 }
 
 // validate performs structural and semantic validation on a fully assembled metamodel.

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -1367,3 +1367,48 @@ entities:
 		t.Errorf("expected 1 validation, got %d", len(ct.Validations))
 	}
 }
+
+func TestParse_PropertyOrderExtraction(t *testing.T) {
+	// Property order in YAML should be preserved in PropertyOrder field
+	yaml := `version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+    properties:
+      title:
+        type: string
+        required: true
+      priority:
+        type: string
+      status:
+        type: string
+      assignee:
+        type: string
+      due_date:
+        type: date
+`
+	meta, err := Parse([]byte(yaml))
+	assertNoError(t, err)
+
+	entityDef, ok := meta.Entities["task"]
+	if !ok {
+		t.Fatal("task entity not found")
+	}
+
+	order := entityDef.GetPropertyOrder()
+	if order == nil {
+		t.Fatal("PropertyOrder should not be nil")
+	}
+
+	expected := []string{"title", "priority", "status", "assignee", "due_date"}
+	if len(order) != len(expected) {
+		t.Fatalf("expected %d properties in order, got %d: %v", len(expected), len(order), order)
+	}
+
+	for i, prop := range expected {
+		if order[i] != prop {
+			t.Errorf("property order[%d]: expected %q, got %q", i, prop, order[i])
+		}
+	}
+}

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -96,20 +96,21 @@ type CustomType struct {
 
 // EntityDef defines an entity type in the metamodel
 type EntityDef struct {
-	Label       string                 `yaml:"label"`
-	LabelPlural string                 `yaml:"label_plural,omitempty"`
-	Description string                 `yaml:"description,omitempty"` // Documentation explaining intent/usage
-	Plural      string                 `yaml:"plural,omitempty"`      // Used for directory names (e.g., "policies" for "policy")
-	Aliases     []string               `yaml:"aliases,omitempty"`
-	IDType      string                 `yaml:"id_type,omitempty"`     // "short" (default), "sequential", or "manual"
-	IDCaps      string                 `yaml:"id_caps,omitempty"`     // "upper" (default) or "lower" - capitalization for short ID suffix
-	IDPrefix    string                 `yaml:"id_prefix,omitempty"`   // Single ID prefix (sugar for single-element id_prefixes)
-	IDPrefixes  []string               `yaml:"id_prefixes,omitempty"` // Multiple ID prefixes
-	RDFType     string                 `yaml:"rdf_type,omitempty"`
-	Properties  map[string]PropertyDef `yaml:"properties"`
-	DefaultSort []model.SortSpec       `yaml:"default_sort,omitempty"` // Default sort order for this entity type
-	Color       string                 `yaml:"color,omitempty"`
-	BorderColor string                 `yaml:"border_color,omitempty"`
+	Label         string                 `yaml:"label"`
+	LabelPlural   string                 `yaml:"label_plural,omitempty"`
+	Description   string                 `yaml:"description,omitempty"` // Documentation explaining intent/usage
+	Plural        string                 `yaml:"plural,omitempty"`      // Used for directory names (e.g., "policies" for "policy")
+	Aliases       []string               `yaml:"aliases,omitempty"`
+	IDType        string                 `yaml:"id_type,omitempty"`     // "short" (default), "sequential", or "manual"
+	IDCaps        string                 `yaml:"id_caps,omitempty"`     // "upper" (default) or "lower" - capitalization for short ID suffix
+	IDPrefix      string                 `yaml:"id_prefix,omitempty"`   // Single ID prefix (sugar for single-element id_prefixes)
+	IDPrefixes    []string               `yaml:"id_prefixes,omitempty"` // Multiple ID prefixes
+	RDFType       string                 `yaml:"rdf_type,omitempty"`
+	Properties    map[string]PropertyDef `yaml:"properties"`
+	PropertyOrder []string               `yaml:"-"`                      // Order of properties as defined in YAML (computed at load)
+	DefaultSort   []model.SortSpec       `yaml:"default_sort,omitempty"` // Default sort order for this entity type
+	Color         string                 `yaml:"color,omitempty"`
+	BorderColor   string                 `yaml:"border_color,omitempty"`
 }
 
 // PropertyDef defines a property on an entity

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -193,13 +193,21 @@ func (r *Repository) ReadEntity(entityType, id string, meta *metamodel.Metamodel
 // WriteEntity writes an entity to its canonical file path.
 // The path is computed from the entity's Type and ID using the metamodel's
 // plural directory convention. Sets entity.FilePath before writing.
+// Properties are written in the order defined in the metamodel.
 func (r *Repository) WriteEntity(entity *model.Entity, meta *metamodel.Metamodel) error {
 	filePath := r.EntityFilePath(entity.Type, entity.ID, meta)
 	if filePath == "" {
 		return fmt.Errorf("unknown entity type: %s", entity.Type)
 	}
 	entity.FilePath = filePath
-	return r.fio.WriteEntity(entity, filePath)
+
+	// Get property order from metamodel if available
+	var propertyOrder []string
+	if entityDef, ok := meta.GetEntityDef(entity.Type); ok {
+		propertyOrder = entityDef.GetPropertyOrder()
+	}
+
+	return r.fio.WriteEntity(entity, filePath, propertyOrder)
 }
 
 // DeleteEntity removes the entity file for the given type and ID.

--- a/internal/repository/transaction.go
+++ b/internal/repository/transaction.go
@@ -62,7 +62,13 @@ func (tx *transaction) WriteEntity(entity *model.Entity, meta *metamodel.Metamod
 	tempPath := filePath + ".new"
 	entity.FilePath = filePath
 
-	if err := tx.repo.fio.WriteEntity(entity, tempPath); err != nil {
+	// Get property order from metamodel if available
+	var propertyOrder []string
+	if entityDef, ok := meta.GetEntityDef(entity.Type); ok {
+		propertyOrder = entityDef.GetPropertyOrder()
+	}
+
+	if err := tx.repo.fio.WriteEntity(entity, tempPath, propertyOrder); err != nil {
 		return fmt.Errorf("write staged entity: %w", err)
 	}
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1004,6 +1004,44 @@ func (w *Workspace) RenameEntity(entityType, oldID, newID string, dryRun bool) (
 	return rename.Rename(w.repo, w.Meta(), w.graph, entityType, oldID, newID, rename.Options{DryRun: dryRun})
 }
 
+// --- Formatting ---
+
+// FormatEntity checks if an entity file needs formatting and optionally writes
+// the formatted version. Returns true if the file was (or would be) modified.
+func (w *Workspace) FormatEntity(entity *model.Entity, dryRun bool) (bool, error) {
+	// Get property order from metamodel
+	var propertyOrder []string
+	if entityDef, ok := w.meta.GetEntityDef(entity.Type); ok {
+		propertyOrder = entityDef.GetPropertyOrder()
+	}
+
+	// Generate formatted content
+	formatted, err := markdown.FormatEntity(entity, propertyOrder)
+	if err != nil {
+		return false, fmt.Errorf("format entity: %w", err)
+	}
+
+	// Read current file content
+	current, err := w.repo.FS().ReadFile(entity.FilePath)
+	if err != nil {
+		return false, fmt.Errorf("read entity file: %w", err)
+	}
+
+	// Compare
+	if formatted == string(current) {
+		return false, nil
+	}
+
+	// Write if not dry-run
+	if !dryRun {
+		if err := w.repo.WriteEntity(entity, w.meta); err != nil {
+			return false, fmt.Errorf("write entity: %w", err)
+		}
+	}
+
+	return true, nil
+}
+
 // --- File watching ---
 
 // WatchOptions configures the file watcher.

--- a/tickets/entities/planning-checklists/PLAN-5R3L.md
+++ b/tickets/entities/planning-checklists/PLAN-5R3L.md
@@ -1,0 +1,100 @@
+---
+id: PLAN-5R3L
+status: done
+title: 'Planning: Sort frontmatter by metamodel order'
+type: planning-checklist
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [ ] Problem/requirements clearly understood
+- [ ] Scope defined (what's in/out documented below)
+- [ ] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+<!-- Document explicitly what IS and IS NOT in scope -->
+
+**Acceptance Criteria:**
+<!-- Each criterion must have a concrete test scenario -->
+1. ...
+
+## Research
+
+- [ ] Searched for existing libraries that solve this problem
+- [ ] Checked codebase for similar patterns or reusable code
+- [ ] Looked for reference implementations in other projects
+- [ ] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+<!-- Document what you found:
+- Libraries considered (with pros/cons, why chosen or rejected)
+- Similar patterns in codebase (file:line references)
+- Reference implementations that inspired the approach
+- Relevant concepts from rela-docs or rela-issues-and-design-tickets
+-->
+
+## Approach
+
+- [ ] Technical approach chosen and documented
+- [ ] Approach builds on existing patterns (not reinventing)
+- [ ] Alternatives considered (document why rejected)
+- [ ] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+<!-- Document the approach with enough detail that implementation is mechanical -->
+
+**Files to modify:**
+<!-- List specific files that will change -->
+
+## Security Considerations
+
+- [ ] Input sources identified (user input, config, external APIs)
+- [ ] Input validation approach defined (allowlist preferred over blocklist)
+- [ ] Security-sensitive operations identified (file access, auth, crypto)
+- [ ] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+<!-- For each input: source, validation approach, what happens on invalid input -->
+
+**Security-Sensitive Operations:**
+<!-- List operations and how they're protected -->
+
+## Test Plan
+
+- [ ] Test scenarios documented for each acceptance criterion
+- [ ] Edge cases identified and documented
+- [ ] Negative test cases defined (invalid input, error conditions)
+- [ ] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+<!-- Map each acceptance criterion to how it will be tested -->
+
+**Edge Cases:**
+<!-- List specific edge cases and expected behavior. Consider:
+- Empty/null/missing values
+- Boundary values (0, -1, MAX_INT)
+- Special characters, unicode, null bytes
+- Concurrent access
+- Resource exhaustion
+-->
+
+**Negative Tests:**
+<!-- What should fail? How should it fail? -->
+
+## Risk Assessment
+
+- [ ] Technical risks assessed with mitigations
+- [ ] Security risks assessed (see Security Considerations)
+- [ ] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+<!-- List risks and how they will be mitigated -->
+
+## Design Review
+
+- [ ] Run `/design-review` before starting implementation
+- [ ] All critical/significant findings addressed in plan
+
+**Design Review Findings:** <!-- List review-response IDs, e.g., RR-xxxx -->

--- a/tickets/entities/planning-checklists/PLAN-5R3L.md
+++ b/tickets/entities/planning-checklists/PLAN-5R3L.md
@@ -9,92 +9,125 @@ type: planning-checklist
 
 ## Understanding
 
-- [ ] Problem/requirements clearly understood
-- [ ] Scope defined (what's in/out documented below)
-- [ ] Acceptance criteria documented with specific test scenarios
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
 
 **Scope:**
-<!-- Document explicitly what IS and IS NOT in scope -->
+- IN: Entity frontmatter property ordering based on metamodel definition
+- IN: `rela fmt` CLI command with `--dry-run` and `--check` flags
+- OUT: Relation file formatting (future work)
+- OUT: Automatic formatting on save (would require hooks)
 
 **Acceptance Criteria:**
-<!-- Each criterion must have a concrete test scenario -->
-1. ...
+1. Properties appear in order: `id`, `type`, then metamodel-defined order, then extras alphabetically
+2. `rela fmt` formats all or specific entity types
+3. `rela fmt --dry-run` shows what would change without writing
+4. `rela fmt --check` exits 1 if files need formatting (for CI)
 
 ## Research
 
-- [ ] Searched for existing libraries that solve this problem
-- [ ] Checked codebase for similar patterns or reusable code
-- [ ] Looked for reference implementations in other projects
-- [ ] Reviewed relevant rela concepts for prior art
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
 
 **Existing Solutions:**
-<!-- Document what you found:
-- Libraries considered (with pros/cons, why chosen or rejected)
-- Similar patterns in codebase (file:line references)
-- Reference implementations that inspired the approach
-- Relevant concepts from rela-docs or rela-issues-and-design-tickets
--->
+- gopkg.in/yaml.v3 provides `yaml.Node` for preserving/controlling YAML key order
+- Existing `FormatDocument` in `markdown/parser.go:70` used as base pattern
+- Go maps don't preserve order, so need explicit key order tracking
+- `WriteEntity` already supports property order parameter (added in this work)
 
 ## Approach
 
-- [ ] Technical approach chosen and documented
-- [ ] Approach builds on existing patterns (not reinventing)
-- [ ] Alternatives considered (document why rejected)
-- [ ] Dependencies identified (packages, APIs, types)
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
 
 **Technical Approach:**
-<!-- Document the approach with enough detail that implementation is mechanical -->
+1. Extract property definition order from metamodel YAML using `yaml.Node` during loading
+2. Store order in `EntityDef.PropertyOrder` field
+3. Add `FormatDocumentOrdered` that builds yaml.Node with explicit key order
+4. Update `WriteEntity` to pass property order through the layers
+5. Add `rela fmt` command using workspace.FormatEntity
+
+**Alternatives considered:**
+- Using YAML comments to preserve order: Rejected - comments not semantic
+- Alphabetical order: Rejected - metamodel order is more meaningful
+- Third-party YAML library: Rejected - yaml.v3 Node support is sufficient
 
 **Files to modify:**
-<!-- List specific files that will change -->
+- `internal/metamodel/types.go` - Add PropertyOrder field
+- `internal/metamodel/loader.go` - Extract order via yaml.Node
+- `internal/metamodel/entity_def.go` - GetPropertyOrder method
+- `internal/markdown/parser.go` - FormatDocumentOrdered, marshalOrdered, valueToNode
+- `internal/markdown/entity.go` - FormatEntity, update WriteEntity signature
+- `internal/repository/repository.go` - Pass property order to WriteEntity
+- `internal/repository/transaction.go` - Pass property order to WriteEntity
+- `internal/workspace/workspace.go` - Add FormatEntity method
+- `internal/cli/fmt.go` - New fmt command
+- `internal/cli/root.go` - Handle ExitError
+- `internal/errors/errors.go` - Add ExitError type
 
 ## Security Considerations
 
-- [ ] Input sources identified (user input, config, external APIs)
-- [ ] Input validation approach defined (allowlist preferred over blocklist)
-- [ ] Security-sensitive operations identified (file access, auth, crypto)
-- [ ] Error handling doesn't leak sensitive information
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
 
 **Input Sources & Validation:**
-<!-- For each input: source, validation approach, what happens on invalid input -->
+- Entity files: Already validated by metamodel during load
+- Metamodel YAML: Parsed by existing loader with validation
+- No direct user input - command operates on existing project files
 
 **Security-Sensitive Operations:**
-<!-- List operations and how they're protected -->
+- File reads: Through workspace/repository layers with SafeFS
+- File writes: Through workspace/repository layers, same paths as existing files
+- No network access, no auth, no crypto
 
 ## Test Plan
 
-- [ ] Test scenarios documented for each acceptance criterion
-- [ ] Edge cases identified and documented
-- [ ] Negative test cases defined (invalid input, error conditions)
-- [ ] Integration test approach defined (not just unit tests)
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
 
 **Test Scenarios:**
-<!-- Map each acceptance criterion to how it will be tested -->
+1. FormatDocumentOrdered produces correct key order (unit test)
+2. GetPropertyOrder returns defensive copy (unit test)
+3. ExitError works correctly (unit test)
+4. `rela fmt --check` exits 1 when files need formatting (manual/integration)
+5. `rela fmt` then `--check` exits 0 (manual/integration)
 
 **Edge Cases:**
-<!-- List specific edge cases and expected behavior. Consider:
-- Empty/null/missing values
-- Boundary values (0, -1, MAX_INT)
-- Special characters, unicode, null bytes
-- Concurrent access
-- Resource exhaustion
--->
+- Entity with no properties defined in metamodel: Uses alphabetical order
+- Entity with extra properties not in metamodel: Extras sorted alphabetically at end
+- Empty entity content: Should work (just frontmatter)
+- Metamodel without property order: Falls back gracefully
 
 **Negative Tests:**
-<!-- What should fail? How should it fail? -->
+- Invalid entity type argument: Returns error
+- yaml.Node parse failure: Now returns error (was silent, fixed per RR-XD6H)
 
 ## Risk Assessment
 
-- [ ] Technical risks assessed with mitigations
-- [ ] Security risks assessed (see Security Considerations)
-- [ ] Effort estimated (xs/s/m/l/xl)
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
 
 **Risks:**
-<!-- List risks and how they will be mitigated -->
+- Risk: yaml.Node API complexity → Mitigated by thorough testing
+- Risk: Breaking existing frontmatter → Mitigated by --dry-run flag and idempotent formatting
+- Effort: **S** (small) - Straightforward YAML manipulation with existing patterns
 
 ## Design Review
 
-- [ ] Run `/design-review` before starting implementation
-- [ ] All critical/significant findings addressed in plan
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
 
-**Design Review Findings:** <!-- List review-response IDs, e.g., RR-xxxx -->
+**Design Review Findings:**
+- RR-MWZR (critical): valueToNode marshal/unmarshal inefficiency → Fixed: use yaml.Node.Encode()
+- RR-XD6H (significant): extractPropertyOrder silently swallows errors → Fixed: returns error
+- RR-8B12 (minor): GetPropertyOrder aliasing → Fixed: returns defensive copy

--- a/tickets/entities/review-responses/RR-8B12.md
+++ b/tickets/entities/review-responses/RR-8B12.md
@@ -1,0 +1,8 @@
+---
+finding: GetPropertyOrder returns the slice directly, creating potential aliasing issues. Should return a defensive copy.
+id: RR-8B12
+severity: minor
+status: addressed
+title: GetPropertyOrder should return defensive copy
+type: review-response
+---

--- a/tickets/entities/review-responses/RR-MWZR.md
+++ b/tickets/entities/review-responses/RR-MWZR.md
@@ -1,0 +1,8 @@
+---
+finding: valueToNode has an inefficient marshal/unmarshal round-trip that can corrupt types. Should use yaml.Node.Encode() instead.
+id: RR-MWZR
+severity: critical
+status: addressed
+title: valueToNode uses inefficient marshal/unmarshal
+type: review-response
+---

--- a/tickets/entities/review-responses/RR-XD6H.md
+++ b/tickets/entities/review-responses/RR-XD6H.md
@@ -1,0 +1,8 @@
+---
+finding: extractPropertyOrder silently ignores yaml.Node parsing errors. Should at least log a warning.
+id: RR-XD6H
+severity: significant
+status: addressed
+title: extractPropertyOrder silently swallows errors
+type: review-response
+---

--- a/tickets/entities/tickets/TKT-ORKI.md
+++ b/tickets/entities/tickets/TKT-ORKI.md
@@ -1,0 +1,9 @@
+---
+effort: s
+id: TKT-ORKI
+kind: enhancement
+priority: medium
+status: done
+title: Sort frontmatter properties by metamodel order
+type: ticket
+---

--- a/tickets/relations/TKT-ORKI--affects--workspace.md
+++ b/tickets/relations/TKT-ORKI--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ORKI
+relation: affects
+to: workspace
+---

--- a/tickets/relations/TKT-ORKI--has-planning--PLAN-5R3L.md
+++ b/tickets/relations/TKT-ORKI--has-planning--PLAN-5R3L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ORKI
+relation: has-planning
+to: PLAN-5R3L
+---

--- a/tickets/relations/TKT-ORKI--has-review-response--RR-8B12.md
+++ b/tickets/relations/TKT-ORKI--has-review-response--RR-8B12.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ORKI
+relation: has-review-response
+to: RR-8B12
+---

--- a/tickets/relations/TKT-ORKI--has-review-response--RR-MWZR.md
+++ b/tickets/relations/TKT-ORKI--has-review-response--RR-MWZR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ORKI
+relation: has-review-response
+to: RR-MWZR
+---

--- a/tickets/relations/TKT-ORKI--has-review-response--RR-XD6H.md
+++ b/tickets/relations/TKT-ORKI--has-review-response--RR-XD6H.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ORKI
+relation: has-review-response
+to: RR-XD6H
+---

--- a/tickets/relations/TKT-ORKI--implements--FEAT-013.md
+++ b/tickets/relations/TKT-ORKI--implements--FEAT-013.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ORKI
+relation: implements
+to: FEAT-013
+---


### PR DESCRIPTION
## Summary
- Add `rela fmt` command to format entity files with consistent frontmatter property ordering
- Properties are ordered: id, type, then metamodel-defined order, then extra properties alphabetically  
- Add `--check` flag for CI use (exits 1 if files need formatting)
- Add `--dry-run` flag to preview changes without writing

## Test plan
- [x] Run `rela fmt --help` and verify output
- [x] Run `rela fmt --check` and verify exit code 1 when files need formatting
- [x] Run `rela fmt` on a type, then `rela fmt --check` and verify exit code 0
- [x] Run `just ci` and verify all checks pass