### PR TITLE
feat(lua): add Lua scripting support

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -43,6 +43,7 @@ components:
 
   # Core domain
   graph:            { in: internal/graph }
+  lua:              { in: internal/lua }
   metamodel:        { in: internal/metamodel }
   migration:        { in: internal/migration }
   model:            { in: internal/model }
@@ -73,6 +74,7 @@ vendors:
       - github.com/yuin/goldmark
       - github.com/yuin/goldmark/**
   gogit:       { in: github.com/go-git/go-git/** }
+  gopherlua:   { in: github.com/yuin/gopher-lua }
   mcpgo:       { in: github.com/mark3labs/mcp-go/** }
   wails:       { in: github.com/wailsapp/wails/** }
   tablewriter: { in: github.com/olekukonko/tablewriter }
@@ -120,6 +122,7 @@ deps:
       - dataentryconfig
       - filter
       - importer
+      - lua
       - markdown
       - mcp
       - metamodel
@@ -267,6 +270,13 @@ deps:
     mayDependOn:
       - metamodel
       - pattern
+  lua:
+    mayDependOn:
+      - filter
+      - metamodel
+      - workspace
+    canUse:
+      - gopherlua
   search:
     mayDependOn:
       - filter

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -167,6 +167,7 @@ deps:
     mayDependOn:
       - dataentryconfig
       - filter
+      - lua
       - markdown
       - metamodel
       - rename

--- a/docs-project/entities/features/FEAT-lua-scripting.md
+++ b/docs-project/entities/features/FEAT-lua-scripting.md
@@ -1,0 +1,26 @@
+---
+id: FEAT-lua-scripting
+status: published
+summary: Programmable automation and reporting via embedded Lua scripts
+title: Lua Scripting
+type: feature
+---
+
+Rela includes an embedded Lua scripting runtime that provides programmable access to the entity graph. Scripts can query, create, update, and delete entities and relations, generate reports, perform bulk operations, and export data to custom formats.
+
+## Key Capabilities
+
+- **Query Operations**: Get entities, list by type with filters, search, trace dependencies
+- **Mutation Operations**: Create, update, delete entities and relations
+- **Schema Introspection**: Access entity types, relation types, and property definitions
+- **Output**: JSON output to stdout, file writing to `output/` directory
+- **MCP Integration**: Execute scripts via `lua_eval`, `lua_run`, and `lua_list` tools
+
+## Security Model
+
+The Lua runtime is sandboxed:
+
+- Only safe libraries loaded (string, table, math, coroutine)
+- No `io`, `os`, or `debug` libraries
+- File writes restricted to `output/` directory
+- Scripts in `scripts/` directory only (for `lua_run`)

--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -1,0 +1,324 @@
+---
+audience: advanced
+id: GUIDE-lua-scripting
+order: 10
+status: published
+summary: Programmable automation with embedded Lua
+title: Lua Scripting
+type: guide
+---
+
+Rela includes an embedded Lua scripting runtime for programmable access to the entity graph.
+Scripts can query, mutate, analyze, and export data—enabling automation beyond what's possible
+with the CLI or MCP tools alone.
+
+## Quick Start
+
+### Via MCP (AI Assistants)
+
+```lua
+-- lua_eval: Execute inline Lua code
+local tickets = rela.list_entities("ticket", "status=open")
+rela.output({count = #tickets})
+```
+
+### Via CLI
+
+```bash
+# Run a script file
+rela lua scripts/report.lua
+
+# Pass arguments
+rela lua scripts/migrate.lua --from=v1 --to=v2
+```
+
+### Script Location
+
+Scripts executed via `lua_run` must be in the `scripts/` directory:
+
+```
+project/
+├── scripts/
+│   ├── report.lua
+│   └── utils/
+│       └── helpers.lua
+├── entities/
+└── metamodel.yaml
+```
+
+## API Reference
+
+### Query Functions
+
+| Function | Description | Returns |
+|----------|-------------|---------|
+| `rela.get_entity(id)` | Get entity by ID | table or nil |
+| `rela.list_entities(type, filter?)` | List entities of a type | table (array) |
+| `rela.search(query, limit?)` | Full-text search | table (array) |
+| `rela.get_relations(opts?)` | Get relations with filters | table (array) |
+| `rela.trace_from(id, depth?)` | Trace outgoing dependencies | table (tree) |
+| `rela.trace_to(id, depth?)` | Trace incoming dependencies | table (tree) |
+| `rela.find_path(from, to)` | Find shortest path | table (array) or nil |
+
+### Mutation Functions
+
+| Function | Description | Returns |
+|----------|-------------|---------|
+| `rela.create_entity(type, props, content?, id?)` | Create entity | table |
+| `rela.update_entity(id, props, content?)` | Update entity | table |
+| `rela.delete_entity(id, cascade?)` | Delete entity | boolean |
+| `rela.create_relation(from, type, to)` | Create relation | table |
+| `rela.delete_relation(from, type, to)` | Delete relation | boolean |
+| `rela.refresh()` | Reload graph from disk | boolean |
+
+### Schema Functions
+
+| Function | Description | Returns |
+|----------|-------------|---------|
+| `rela.get_entity_types()` | Get all entity type definitions | table |
+| `rela.get_relation_types()` | Get all relation type definitions | table |
+
+### Output Functions
+
+| Function | Description |
+|----------|-------------|
+| `rela.output(data)` | Output data as JSON to stdout |
+| `rela.write_file(path, content)` | Write file to `output/` directory |
+
+### Context
+
+| Variable | Description |
+|----------|-------------|
+| `rela.project_root` | Absolute path to project root |
+| `rela.args` | Script arguments (table) |
+
+## Entity Structure
+
+Entities returned by query functions have this structure:
+
+```lua
+{
+    id = "TKT-001",
+    type = "ticket",
+    content = "Markdown body...",
+    properties = {
+        title = "Fix login bug",
+        status = "open",
+        priority = "high"
+    }
+}
+```
+
+## Filter Expressions
+
+The `list_entities` function accepts filter expressions:
+
+```lua
+-- Single value
+rela.list_entities("ticket", "status=open")
+
+-- Multiple values (OR)
+rela.list_entities("ticket", "status=open,in-progress")
+
+-- Not equal
+rela.list_entities("ticket", "priority!=low")
+```
+
+## Examples
+
+### Generate a Report
+
+```lua
+-- Export open tickets as markdown
+local tickets = rela.list_entities("ticket", "status=open")
+
+local lines = {"# Open Tickets", ""}
+for _, t in ipairs(tickets) do
+    table.insert(lines, string.format("- **%s**: %s", t.id, t.properties.title))
+end
+
+rela.write_file("open-tickets.md", table.concat(lines, "\n"))
+rela.output({exported = #tickets})
+```
+
+### Bulk Update
+
+```lua
+-- Close all tickets in a completed sprint
+local sprint = rela.args[1] or "2024-Q1"
+local tickets = rela.list_entities("ticket", "sprint=" .. sprint)
+
+local updated = 0
+for _, t in ipairs(tickets) do
+    if t.properties.status ~= "done" then
+        rela.update_entity(t.id, {status = "cancelled"})
+        updated = updated + 1
+    end
+end
+
+rela.output({sprint = sprint, cancelled = updated})
+```
+
+### Find Orphans
+
+```lua
+-- Find entities with no relations
+local orphans = {}
+local types = rela.get_entity_types()
+
+for name, _ in pairs(types) do
+    local entities = rela.list_entities(name)
+    for _, e in ipairs(entities) do
+        local from = rela.trace_from(e.id, 1)
+        local to = rela.trace_to(e.id, 1)
+        if #from.children == 0 and #to.children == 0 then
+            table.insert(orphans, {
+                id = e.id,
+                type = e.type,
+                title = e.properties.title
+            })
+        end
+    end
+end
+
+rela.output(orphans)
+```
+
+### Create Related Entities
+
+```lua
+-- Create test cases from feature acceptance criteria
+local feature_id = rela.args[1]
+local feature = rela.get_entity(feature_id)
+
+if not feature then
+    error("Feature not found: " .. feature_id)
+end
+
+local created = {}
+for line in feature.content:gmatch("[^\n]+") do
+    if line:match("^%s*[-*]") then
+        local criterion = line:gsub("^%s*[-*]%s*", "")
+        local test = rela.create_entity("test-case", {
+            title = "Verify: " .. criterion,
+            status = "pending"
+        })
+        rela.create_relation(test.id, "verifies", feature_id)
+        table.insert(created, test.id)
+    end
+end
+
+rela.output({feature = feature_id, tests_created = created})
+```
+
+### Traceability Matrix
+
+```lua
+-- Generate requirement-to-test coverage matrix
+local reqs = rela.list_entities("requirement")
+local matrix = {}
+
+for _, req in ipairs(reqs) do
+    local entry = {
+        id = req.id,
+        title = req.properties.title,
+        tests = {},
+        covered = false
+    }
+    
+    local trace = rela.trace_from(req.id, 2)
+    for _, child in ipairs(trace.children) do
+        if child.type == "test-case" then
+            table.insert(entry.tests, child.id)
+        end
+    end
+    
+    entry.covered = #entry.tests > 0
+    table.insert(matrix, entry)
+end
+
+-- Summary
+local total = #matrix
+local covered = 0
+for _, entry in ipairs(matrix) do
+    if entry.covered then covered = covered + 1 end
+end
+
+rela.output({
+    matrix = matrix,
+    summary = {
+        total = total,
+        covered = covered,
+        uncovered = total - covered,
+        coverage_pct = math.floor(covered / total * 100)
+    }
+})
+```
+
+## Security
+
+The Lua runtime is sandboxed for security:
+
+### Available Libraries
+
+- `string` - String manipulation
+- `table` - Table operations
+- `math` - Mathematical functions
+- `coroutine` - Coroutine support
+- Base functions: `print`, `pairs`, `ipairs`, `type`, `tostring`, `tonumber`, `error`, `pcall`, `assert`, `select`, `next`, `unpack`
+
+### Unavailable (Security)
+
+- `io` - No direct file system access
+- `os` - No system commands
+- `debug` - No runtime introspection
+- `load`, `loadfile`, `dofile`, `loadstring` - No dynamic code loading
+- `rawget`, `rawset`, `getmetatable`, `setmetatable` - No metatable manipulation
+
+### File Writing
+
+Files can only be written to the `output/` directory:
+
+```lua
+-- OK: writes to output/report.txt
+rela.write_file("report.txt", "content")
+
+-- OK: writes to output/reports/2024/summary.md  
+rela.write_file("reports/2024/summary.md", "content")
+
+-- ERROR: path traversal blocked
+rela.write_file("../secret.txt", "content")
+
+-- ERROR: absolute paths blocked
+rela.write_file("/etc/passwd", "content")
+```
+
+## MCP Tools
+
+Lua scripting is available via MCP tools:
+
+| Tool | Description |
+|------|-------------|
+| `lua_eval` | Execute inline Lua code |
+| `lua_run` | Execute a script from `scripts/` |
+| `lua_list` | List available scripts |
+
+### lua_eval
+
+Execute inline Lua code:
+
+```
+lua_eval(code: "rela.output(rela.list_entities('ticket'))")
+```
+
+### lua_run
+
+Execute a script file with arguments:
+
+```
+lua_run(path: "report.lua", args: ["2024-Q1"])
+```
+
+### lua_list
+
+List available scripts in `scripts/` directory.

--- a/docs-project/relations/GUIDE-lua-scripting--covers--FEAT-lua-scripting.md
+++ b/docs-project/relations/GUIDE-lua-scripting--covers--FEAT-lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: GUIDE-lua-scripting
+relation: covers
+to: FEAT-lua-scripting
+---

--- a/docs-project/relations/GUIDE-lua-scripting--prerequisite--GUIDE-mcp-server.md
+++ b/docs-project/relations/GUIDE-lua-scripting--prerequisite--GUIDE-mcp-server.md
@@ -1,0 +1,5 @@
+---
+from: GUIDE-lua-scripting
+relation: prerequisite
+to: GUIDE-mcp-server
+---

--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,7 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.etcd.io/bbolt v1.4.0 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/mod v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -448,6 +448,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=
 github.com/yuin/goldmark v1.7.16/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=
 go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -14,14 +14,26 @@ var scriptCmd = &cobra.Command{
 	Long: `Execute a Lua script with access to the rela graph.
 
 Scripts can query entities and relations, apply filters, trace dependencies,
-and output results as JSON or write files.
+create/update/delete entities and relations, and output results.
 
-Available functions in the rela module:
+Query functions:
   rela.get_entity(id)              Get entity by ID (returns table or nil)
   rela.list_entities(type, filter) List entities with optional filter
+  rela.search(query, limit?)       Full-text search (default limit: 20)
   rela.get_relations(opts)         Get relations (opts: {from, type, to})
   rela.trace_from(id, depth)       Trace outgoing dependencies
   rela.trace_to(id, depth)         Trace incoming dependencies
+  rela.find_path(from, to)         Find shortest path between entities
+
+Mutation functions:
+  rela.create_entity(type, props, content?, id?)  Create new entity
+  rela.update_entity(id, props, content?)         Update entity properties
+  rela.delete_entity(id, cascade?)                Delete entity
+  rela.create_relation(from, type, to)            Create relation
+  rela.delete_relation(from, type, to)            Delete relation
+  rela.refresh()                                  Reload graph from disk
+
+Output functions:
   rela.output(data)                Output data as JSON to stdout
   rela.write_file(path, content)   Write content to file
 

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Sourcehaven-BV/rela/internal/lua"
+)
+
+var scriptCmd = &cobra.Command{
+	Use:   "script <file.lua> [args...]",
+	Short: "Execute a Lua script against the graph",
+	Long: `Execute a Lua script with access to the rela graph.
+
+Scripts can query entities and relations, apply filters, trace dependencies,
+and output results as JSON or write files.
+
+Available functions in the rela module:
+  rela.get_entity(id)              Get entity by ID (returns table or nil)
+  rela.list_entities(type, filter) List entities with optional filter
+  rela.get_relations(opts)         Get relations (opts: {from, type, to})
+  rela.trace_from(id, depth)       Trace outgoing dependencies
+  rela.trace_to(id, depth)         Trace incoming dependencies
+  rela.output(data)                Output data as JSON to stdout
+  rela.write_file(path, content)   Write content to file
+
+Context:
+  rela.args                        Script arguments (table)
+  rela.project_root                Project root path
+
+Example:
+  rela script scripts/export.lua
+  rela script scripts/report.lua --format=json`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		scriptPath := args[0]
+		scriptArgs := args[1:]
+
+		runtime := lua.New(ws, meta, projectCtx.Root, os.Stdout)
+		defer runtime.Close()
+
+		return runtime.RunFile(scriptPath, scriptArgs)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(scriptCmd)
+}

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -33,6 +33,10 @@ Mutation functions:
   rela.delete_relation(from, type, to)            Delete relation
   rela.refresh()                                  Reload graph from disk
 
+Schema introspection:
+  rela.get_entity_types()            Get all entity types with properties
+  rela.get_relation_types()          Get all relation types with constraints
+
 Output functions:
   rela.output(data)                Output data as JSON to stdout
   rela.write_file(path, content)   Write content to file

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -19,6 +19,12 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
+// Default values for Lua API functions.
+const (
+	defaultSearchLimit   = 20
+	argPosCreateEntityID = 4
+)
+
 // Runtime wraps gopher-lua VM with rela bindings.
 type Runtime struct {
 	L           *lua.LState
@@ -69,20 +75,34 @@ func (r *Runtime) Close() {
 func (r *Runtime) registerBindings() {
 	rela := r.L.NewTable()
 
-	// Entity functions
+	// Entity query functions
 	r.L.SetField(rela, "get_entity", r.L.NewFunction(r.luaGetEntity))
 	r.L.SetField(rela, "list_entities", r.L.NewFunction(r.luaListEntities))
+	r.L.SetField(rela, "search", r.L.NewFunction(r.luaSearch))
 
-	// Relation functions
+	// Entity mutation functions
+	r.L.SetField(rela, "create_entity", r.L.NewFunction(r.luaCreateEntity))
+	r.L.SetField(rela, "update_entity", r.L.NewFunction(r.luaUpdateEntity))
+	r.L.SetField(rela, "delete_entity", r.L.NewFunction(r.luaDeleteEntity))
+
+	// Relation query functions
 	r.L.SetField(rela, "get_relations", r.L.NewFunction(r.luaGetRelations))
+
+	// Relation mutation functions
+	r.L.SetField(rela, "create_relation", r.L.NewFunction(r.luaCreateRelation))
+	r.L.SetField(rela, "delete_relation", r.L.NewFunction(r.luaDeleteRelation))
 
 	// Graph traversal
 	r.L.SetField(rela, "trace_from", r.L.NewFunction(r.luaTraceFrom))
 	r.L.SetField(rela, "trace_to", r.L.NewFunction(r.luaTraceTo))
+	r.L.SetField(rela, "find_path", r.L.NewFunction(r.luaFindPath))
 
 	// Output functions
 	r.L.SetField(rela, "output", r.L.NewFunction(r.luaOutput))
 	r.L.SetField(rela, "write_file", r.L.NewFunction(r.luaWriteFile))
+
+	// Utility functions
+	r.L.SetField(rela, "refresh", r.L.NewFunction(r.luaRefresh))
 
 	// Context
 	r.L.SetField(rela, "project_root", lua.LString(r.projectRoot))
@@ -422,6 +442,237 @@ func luaTableToGo(t *lua.LTable) interface{} {
 	}
 
 	// It's a map
+	m := make(map[string]interface{})
+	t.ForEach(func(k, v lua.LValue) {
+		var key string
+		switch kv := k.(type) {
+		case lua.LString:
+			key = string(kv)
+		case lua.LNumber:
+			key = fmt.Sprintf("%v", float64(kv))
+		default:
+			key = k.String()
+		}
+		m[key] = luaValueToGo(v)
+	})
+	return m
+}
+
+// luaSearch implements rela.search(query, type?, limit?) -> table
+func (r *Runtime) luaSearch(ls *lua.LState) int {
+	query := ls.CheckString(1)
+	if query == "" {
+		ls.RaiseError("search query cannot be empty")
+		return 0
+	}
+
+	limit := ls.OptInt(2, defaultSearchLimit)
+
+	entities, err := r.ws.SearchSimple(query, limit)
+	if err != nil {
+		ls.RaiseError("search error: %s", err.Error())
+		return 0
+	}
+
+	result := ls.NewTable()
+	for i, e := range entities {
+		result.RawSetInt(i+1, entityToTable(ls, e))
+	}
+	ls.Push(result)
+	return 1
+}
+
+// luaCreateEntity implements rela.create_entity(type, properties, content?, id?) -> table
+func (r *Runtime) luaCreateEntity(ls *lua.LState) int {
+	entityType := ls.CheckString(1)
+	if entityType == "" {
+		ls.RaiseError("entity type cannot be empty")
+		return 0
+	}
+
+	propsTable := ls.CheckTable(2)
+	props := luaTableToGoMap(propsTable)
+
+	content := ls.OptString(3, "")
+	customID := ls.OptString(argPosCreateEntityID, "")
+
+	entity, _, err := r.ws.CreateEntity(entityType, workspace.CreateOptions{
+		ID:         customID,
+		Properties: props,
+		Content:    content,
+	})
+	if err != nil {
+		ls.RaiseError("create entity error: %s", err.Error())
+		return 0
+	}
+
+	ls.Push(entityToTable(ls, entity))
+	return 1
+}
+
+// luaUpdateEntity implements rela.update_entity(id, properties, content?) -> table
+func (r *Runtime) luaUpdateEntity(ls *lua.LState) int {
+	id := ls.CheckString(1)
+	if id == "" {
+		ls.RaiseError("entity ID cannot be empty")
+		return 0
+	}
+
+	entity, found := r.ws.GetEntity(id)
+	if !found {
+		ls.RaiseError("entity not found: %s", id)
+		return 0
+	}
+
+	// Clone entity for update
+	oldEntity := *entity
+	updated := *entity
+
+	// Update properties if provided
+	if ls.GetTop() >= 2 && ls.Get(2).Type() == lua.LTTable {
+		propsTable := ls.CheckTable(2)
+		newProps := luaTableToGoMap(propsTable)
+		// Merge properties
+		if updated.Properties == nil {
+			updated.Properties = make(map[string]interface{})
+		}
+		for k, v := range newProps {
+			updated.Properties[k] = v
+		}
+	}
+
+	// Update content if provided
+	if ls.GetTop() >= 3 {
+		content := ls.OptString(3, "")
+		if content != "" {
+			updated.Content = content
+		}
+	}
+
+	_, err := r.ws.UpdateEntity(&updated, &oldEntity)
+	if err != nil {
+		ls.RaiseError("update entity error: %s", err.Error())
+		return 0
+	}
+
+	// Get fresh entity after update
+	updatedEntity, _ := r.ws.GetEntity(id)
+	ls.Push(entityToTable(ls, updatedEntity))
+	return 1
+}
+
+// luaDeleteEntity implements rela.delete_entity(id, cascade?) -> boolean
+func (r *Runtime) luaDeleteEntity(ls *lua.LState) int {
+	id := ls.CheckString(1)
+	if id == "" {
+		ls.RaiseError("entity ID cannot be empty")
+		return 0
+	}
+
+	cascade := ls.OptBool(2, false)
+
+	entity, found := r.ws.GetEntity(id)
+	if !found {
+		ls.RaiseError("entity not found: %s", id)
+		return 0
+	}
+
+	_, err := r.ws.DeleteEntity(entity.Type, id, cascade)
+	if err != nil {
+		ls.RaiseError("delete entity error: %s", err.Error())
+		return 0
+	}
+
+	ls.Push(lua.LTrue)
+	return 1
+}
+
+// luaCreateRelation implements rela.create_relation(from, type, to, content?) -> table
+func (r *Runtime) luaCreateRelation(ls *lua.LState) int {
+	from := ls.CheckString(1)
+	relType := ls.CheckString(2)
+	to := ls.CheckString(3)
+
+	if from == "" || relType == "" || to == "" {
+		ls.RaiseError("from, type, and to are required")
+		return 0
+	}
+
+	rel, err := r.ws.CreateRelation(from, relType, to)
+	if err != nil {
+		ls.RaiseError("create relation error: %s", err.Error())
+		return 0
+	}
+
+	ls.Push(relationToTable(ls, rel))
+	return 1
+}
+
+// luaDeleteRelation implements rela.delete_relation(from, type, to) -> boolean
+func (r *Runtime) luaDeleteRelation(ls *lua.LState) int {
+	from := ls.CheckString(1)
+	relType := ls.CheckString(2)
+	to := ls.CheckString(3)
+
+	if from == "" || relType == "" || to == "" {
+		ls.RaiseError("from, type, and to are required")
+		return 0
+	}
+
+	err := r.ws.DeleteRelation(from, relType, to)
+	if err != nil {
+		ls.RaiseError("delete relation error: %s", err.Error())
+		return 0
+	}
+
+	ls.Push(lua.LTrue)
+	return 1
+}
+
+// luaFindPath implements rela.find_path(from, to) -> table
+func (r *Runtime) luaFindPath(ls *lua.LState) int {
+	from := ls.CheckString(1)
+	to := ls.CheckString(2)
+
+	if from == "" || to == "" {
+		ls.RaiseError("from and to are required")
+		return 0
+	}
+
+	path := r.ws.FindPath(from, to)
+	if path == nil {
+		ls.Push(lua.LNil)
+		return 1
+	}
+
+	result := ls.NewTable()
+	for i, step := range path {
+		stepTable := ls.NewTable()
+		stepTable.RawSetString("id", lua.LString(step.ID))
+		stepTable.RawSetString("type", lua.LString(step.Type))
+		stepTable.RawSetString("title", lua.LString(step.Title))
+		stepTable.RawSetString("relation", lua.LString(step.Relation))
+		result.RawSetInt(i+1, stepTable)
+	}
+	ls.Push(result)
+	return 1
+}
+
+// luaRefresh implements rela.refresh() -> boolean
+// Re-syncs the graph from disk (reloads all entities and relations).
+func (r *Runtime) luaRefresh(ls *lua.LState) int {
+	_, err := r.ws.Sync()
+	if err != nil {
+		ls.RaiseError("refresh error: %s", err.Error())
+		return 0
+	}
+
+	ls.Push(lua.LTrue)
+	return 1
+}
+
+// luaTableToGoMap converts a Lua table to a Go map[string]interface{}.
+func luaTableToGoMap(t *lua.LTable) map[string]interface{} {
 	m := make(map[string]interface{})
 	t.ForEach(func(k, v lua.LValue) {
 		var key string

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -1,5 +1,11 @@
 // Package lua provides a Lua scripting runtime for rela with bindings
 // to query entities, relations, and output results.
+//
+// The runtime is sandboxed: only safe Lua libraries are loaded (base, table,
+// string, math, utf8, coroutine). The io, os, and debug libraries are NOT
+// available to prevent filesystem access and code execution. File operations
+// are only possible through the provided rela.write_file() function which
+// validates paths are within the project root.
 package lua
 
 import (
@@ -9,7 +15,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"strings"
 
 	lua "github.com/yuin/gopher-lua"
 
@@ -21,7 +26,9 @@ import (
 
 // Default values for Lua API functions.
 const (
-	defaultSearchLimit   = 20
+	defaultSearchLimit = 20
+	// argPosCreateEntityID is the position of the optional ID parameter in create_entity
+	// (type=1, properties=2, content=3, id=4).
 	argPosCreateEntityID = 4
 )
 
@@ -35,8 +42,17 @@ type Runtime struct {
 }
 
 // New creates a Runtime with rela bindings registered.
+// The Lua VM is sandboxed with only safe libraries loaded (no io, os, or debug).
 func New(ws *workspace.Workspace, meta *metamodel.Metamodel, projectRoot string, stdout io.Writer) *Runtime {
-	L := lua.NewState()
+	// Create sandboxed Lua state - skip default libraries for security
+	L := lua.NewState(lua.Options{
+		SkipOpenLibs:  true,
+		CallStackSize: 1024,      // Limit call stack depth to prevent stack overflow
+		RegistrySize:  1024 * 64, // Limit registry size
+	})
+
+	// Load only safe libraries (NOT io, os, or debug)
+	openSafeLibraries(L)
 
 	r := &Runtime{
 		L:           L,
@@ -48,6 +64,44 @@ func New(ws *workspace.Workspace, meta *metamodel.Metamodel, projectRoot string,
 
 	r.registerBindings()
 	return r
+}
+
+// openSafeLibraries loads only safe Lua standard libraries.
+// Excluded for security: io (file access), os (system commands), debug (internals).
+func openSafeLibraries(ls *lua.LState) {
+	// Libraries to load - order matters, LoadLibName must come first if used
+	safeLibs := []struct {
+		name string
+		fn   lua.LGFunction
+	}{
+		{lua.BaseLibName, lua.OpenBase},
+		{lua.TabLibName, lua.OpenTable},
+		{lua.StringLibName, lua.OpenString},
+		{lua.MathLibName, lua.OpenMath},
+		{lua.CoroutineLibName, lua.OpenCoroutine},
+		// NOT included: lua.IoLibName, lua.OsLibName, lua.DebugLibName, lua.ChannelLibName
+	}
+
+	for _, lib := range safeLibs {
+		ls.Push(ls.NewFunction(lib.fn))
+		ls.Push(lua.LString(lib.name))
+		ls.Call(1, 0)
+	}
+
+	// Remove dangerous base functions that could bypass sandbox
+	ls.SetGlobal("loadfile", lua.LNil)
+	ls.SetGlobal("dofile", lua.LNil)
+	ls.SetGlobal("load", lua.LNil)
+	ls.SetGlobal("loadstring", lua.LNil)
+
+	// Remove raw access functions that could bypass metamethod protections
+	// and modify the rela module internals
+	ls.SetGlobal("rawget", lua.LNil)
+	ls.SetGlobal("rawset", lua.LNil)
+	ls.SetGlobal("rawequal", lua.LNil)
+	ls.SetGlobal("rawlen", lua.LNil)
+	ls.SetGlobal("getmetatable", lua.LNil)
+	ls.SetGlobal("setmetatable", lua.LNil)
 }
 
 // RunFile executes a Lua script file with arguments.
@@ -69,6 +123,18 @@ func (r *Runtime) RunFile(path string, args []string) error {
 // RunString executes Lua code from a string.
 func (r *Runtime) RunString(code string) error {
 	return r.L.DoString(code)
+}
+
+// SetArgs sets the script arguments (rela.args) before execution.
+func (r *Runtime) SetArgs(args []string) {
+	argsTable := r.L.NewTable()
+	for i, arg := range args {
+		argsTable.RawSetInt(i+1, lua.LString(arg))
+	}
+	relaTable, ok := r.L.GetGlobal("rela").(*lua.LTable)
+	if ok {
+		relaTable.RawSetString("args", argsTable)
+	}
 }
 
 // Close releases Lua VM resources.
@@ -123,6 +189,10 @@ func (r *Runtime) registerBindings() {
 // luaGetEntity implements rela.get_entity(id) -> table|nil
 func (r *Runtime) luaGetEntity(ls *lua.LState) int {
 	id := ls.CheckString(1)
+	if id == "" {
+		ls.RaiseError("entity ID cannot be empty")
+		return 0
+	}
 
 	entity, found := r.ws.GetEntity(id)
 	if !found {
@@ -227,6 +297,10 @@ func (r *Runtime) luaGetRelations(ls *lua.LState) int {
 // luaTraceFrom implements rela.trace_from(id, depth?) -> table|nil
 func (r *Runtime) luaTraceFrom(ls *lua.LState) int {
 	id := ls.CheckString(1)
+	if id == "" {
+		ls.RaiseError("entity ID cannot be empty")
+		return 0
+	}
 	maxDepth := ls.OptInt(2, 0)
 
 	trace := r.ws.TraceFrom(id, maxDepth)
@@ -241,6 +315,10 @@ func (r *Runtime) luaTraceFrom(ls *lua.LState) int {
 // luaTraceTo implements rela.trace_to(id, depth?) -> table|nil
 func (r *Runtime) luaTraceTo(ls *lua.LState) int {
 	id := ls.CheckString(1)
+	if id == "" {
+		ls.RaiseError("entity ID cannot be empty")
+		return 0
+	}
 	maxDepth := ls.OptInt(2, 0)
 
 	trace := r.ws.TraceTo(id, maxDepth)
@@ -267,36 +345,50 @@ func (r *Runtime) luaOutput(ls *lua.LState) int {
 	return 0
 }
 
+// outputDir is the only directory where Lua scripts can write files.
+const outputDir = "output"
+
 // luaWriteFile implements rela.write_file(path, content)
-// Path must be within the project root for security.
+// Files can ONLY be written to the output/ directory for security.
+// Path is relative to output/ (e.g., "report.txt" -> "output/report.txt").
 func (r *Runtime) luaWriteFile(ls *lua.LState) int {
 	path := ls.CheckString(1)
 	content := ls.CheckString(2)
 
-	// Resolve to absolute path
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		ls.RaiseError("invalid path: %s", err.Error())
+	if path == "" {
+		ls.RaiseError("write_file: path cannot be empty")
 		return 0
 	}
 
-	// Validate path is within project root
-	absRoot, err := filepath.Abs(r.projectRoot)
-	if err != nil {
-		ls.RaiseError("invalid project root: %s", err.Error())
+	// Validate the path is local (no "..", no absolute paths)
+	if !filepath.IsLocal(path) {
+		ls.RaiseError("write_file: path must be a local path (no '..' or absolute paths)")
 		return 0
 	}
 
-	// Ensure the path starts with project root (after cleaning)
-	if !strings.HasPrefix(absPath, absRoot+string(filepath.Separator)) && absPath != absRoot {
-		ls.RaiseError("write_file: path must be within project root")
+	// Build the full path within output directory
+	outputPath := filepath.Join(r.projectRoot, outputDir)
+
+	// Ensure output directory exists
+	if err := os.MkdirAll(outputPath, 0755); err != nil {
+		ls.RaiseError("write_file: cannot create output directory: %s", err.Error())
 		return 0
 	}
 
-	if err := os.WriteFile(absPath, []byte(content), 0644); err != nil {
-		ls.RaiseError("write file error: %s", err.Error())
+	// Ensure parent directories within output/ exist
+	fullPath := filepath.Join(outputPath, path)
+	dir := filepath.Dir(fullPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		ls.RaiseError("write_file: cannot create directory: %s", err.Error())
 		return 0
 	}
+
+	// Write the file
+	if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+		ls.RaiseError("write_file: cannot write file: %s", err.Error())
+		return 0
+	}
+
 	return 0
 }
 
@@ -467,7 +559,8 @@ func luaTableToGo(t *lua.LTable) interface{} {
 	return m
 }
 
-// luaSearch implements rela.search(query, type?, limit?) -> table
+// luaSearch implements rela.search(query, limit?) -> table
+// Performs full-text search across entity titles and properties.
 func (r *Runtime) luaSearch(ls *lua.LState) int {
 	query := ls.CheckString(1)
 	if query == "" {
@@ -533,9 +626,19 @@ func (r *Runtime) luaUpdateEntity(ls *lua.LState) int {
 		return 0
 	}
 
-	// Clone entity for update
+	// Clone entity for update - must deep copy the Properties map
 	oldEntity := *entity
 	updated := *entity
+
+	// Deep copy the properties map to avoid mutating oldEntity
+	if entity.Properties != nil {
+		oldEntity.Properties = make(map[string]interface{}, len(entity.Properties))
+		updated.Properties = make(map[string]interface{}, len(entity.Properties))
+		for k, v := range entity.Properties {
+			oldEntity.Properties[k] = v
+			updated.Properties[k] = v
+		}
+	}
 
 	// Update properties if provided
 	if ls.GetTop() >= 2 && ls.Get(2).Type() == lua.LTTable {
@@ -550,12 +653,9 @@ func (r *Runtime) luaUpdateEntity(ls *lua.LState) int {
 		}
 	}
 
-	// Update content if provided
-	if ls.GetTop() >= 3 {
-		content := ls.OptString(3, "")
-		if content != "" {
-			updated.Content = content
-		}
+	// Update content if provided (nil means not provided, empty string clears content)
+	if ls.GetTop() >= 3 && ls.Get(3).Type() != lua.LTNil {
+		updated.Content = ls.CheckString(3)
 	}
 
 	_, err := r.ws.UpdateEntity(&updated, &oldEntity)
@@ -565,7 +665,11 @@ func (r *Runtime) luaUpdateEntity(ls *lua.LState) int {
 	}
 
 	// Get fresh entity after update
-	updatedEntity, _ := r.ws.GetEntity(id)
+	updatedEntity, found := r.ws.GetEntity(id)
+	if !found {
+		ls.RaiseError("entity disappeared after update: %s", id)
+		return 0
+	}
 	ls.Push(entityToTable(ls, updatedEntity))
 	return 1
 }

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -109,6 +109,10 @@ func (r *Runtime) registerBindings() {
 	// Utility functions
 	r.L.SetField(rela, "refresh", r.L.NewFunction(r.luaRefresh))
 
+	// Schema introspection
+	r.L.SetField(rela, "get_entity_types", r.L.NewFunction(r.luaGetEntityTypes))
+	r.L.SetField(rela, "get_relation_types", r.L.NewFunction(r.luaGetRelationTypes))
+
 	// Context
 	r.L.SetField(rela, "project_root", lua.LString(r.projectRoot))
 	r.L.SetField(rela, "args", r.L.NewTable()) // Will be set before running script
@@ -692,4 +696,74 @@ func luaTableToGoMap(t *lua.LTable) map[string]interface{} {
 		m[key] = luaValueToGo(v)
 	})
 	return m
+}
+
+// luaGetEntityTypes implements rela.get_entity_types() -> table
+// Returns a table of entity type definitions with their properties.
+func (r *Runtime) luaGetEntityTypes(ls *lua.LState) int {
+	result := ls.NewTable()
+
+	for name, et := range r.meta.Entities {
+		typeTable := ls.NewTable()
+		typeTable.RawSetString("name", lua.LString(name))
+		typeTable.RawSetString("label", lua.LString(et.Label))
+		typeTable.RawSetString("plural", lua.LString(et.Plural))
+
+		// Properties
+		propsTable := ls.NewTable()
+		for propName, prop := range et.Properties {
+			propTable := ls.NewTable()
+			propTable.RawSetString("name", lua.LString(propName))
+			propTable.RawSetString("type", lua.LString(prop.Type))
+			propTable.RawSetString("required", lua.LBool(prop.Required))
+			if prop.Default != "" {
+				propTable.RawSetString("default", lua.LString(prop.Default))
+			}
+			if len(prop.Values) > 0 {
+				valuesTable := ls.NewTable()
+				for i, val := range prop.Values {
+					valuesTable.RawSetInt(i+1, lua.LString(val))
+				}
+				propTable.RawSetString("values", valuesTable)
+			}
+			propsTable.RawSetString(propName, propTable)
+		}
+		typeTable.RawSetString("properties", propsTable)
+
+		result.RawSetString(name, typeTable)
+	}
+
+	ls.Push(result)
+	return 1
+}
+
+// luaGetRelationTypes implements rela.get_relation_types() -> table
+// Returns a table of relation type definitions with their constraints.
+func (r *Runtime) luaGetRelationTypes(ls *lua.LState) int {
+	result := ls.NewTable()
+
+	for name, rt := range r.meta.Relations {
+		typeTable := ls.NewTable()
+		typeTable.RawSetString("name", lua.LString(name))
+		typeTable.RawSetString("label", lua.LString(rt.Label))
+
+		// From constraints
+		fromTable := ls.NewTable()
+		for i, f := range rt.From {
+			fromTable.RawSetInt(i+1, lua.LString(f))
+		}
+		typeTable.RawSetString("from", fromTable)
+
+		// To constraints
+		toTable := ls.NewTable()
+		for i, t := range rt.To {
+			toTable.RawSetInt(i+1, lua.LString(t))
+		}
+		typeTable.RawSetString("to", toTable)
+
+		result.RawSetString(name, typeTable)
+	}
+
+	ls.Push(result)
+	return 1
 }

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -66,6 +66,11 @@ func (r *Runtime) RunFile(path string, args []string) error {
 	return r.L.DoFile(path)
 }
 
+// RunString executes Lua code from a string.
+func (r *Runtime) RunString(code string) error {
+	return r.L.DoString(code)
+}
+
 // Close releases Lua VM resources.
 func (r *Runtime) Close() {
 	r.L.Close()

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -1,0 +1,439 @@
+// Package lua provides a Lua scripting runtime for rela with bindings
+// to query entities, relations, and output results.
+package lua
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/Sourcehaven-BV/rela/internal/filter"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
+)
+
+// Runtime wraps gopher-lua VM with rela bindings.
+type Runtime struct {
+	L           *lua.LState
+	ws          *workspace.Workspace
+	meta        *metamodel.Metamodel
+	stdout      io.Writer
+	projectRoot string
+}
+
+// New creates a Runtime with rela bindings registered.
+func New(ws *workspace.Workspace, meta *metamodel.Metamodel, projectRoot string, stdout io.Writer) *Runtime {
+	L := lua.NewState()
+
+	r := &Runtime{
+		L:           L,
+		ws:          ws,
+		meta:        meta,
+		stdout:      stdout,
+		projectRoot: projectRoot,
+	}
+
+	r.registerBindings()
+	return r
+}
+
+// RunFile executes a Lua script file with arguments.
+func (r *Runtime) RunFile(path string, args []string) error {
+	// Set rela.args
+	argsTable := r.L.NewTable()
+	for i, arg := range args {
+		argsTable.RawSetInt(i+1, lua.LString(arg))
+	}
+	relaTable, ok := r.L.GetGlobal("rela").(*lua.LTable)
+	if !ok {
+		return fmt.Errorf("rela module not initialized")
+	}
+	relaTable.RawSetString("args", argsTable)
+
+	return r.L.DoFile(path)
+}
+
+// Close releases Lua VM resources.
+func (r *Runtime) Close() {
+	r.L.Close()
+}
+
+// registerBindings sets up the rela module with all functions.
+func (r *Runtime) registerBindings() {
+	rela := r.L.NewTable()
+
+	// Entity functions
+	r.L.SetField(rela, "get_entity", r.L.NewFunction(r.luaGetEntity))
+	r.L.SetField(rela, "list_entities", r.L.NewFunction(r.luaListEntities))
+
+	// Relation functions
+	r.L.SetField(rela, "get_relations", r.L.NewFunction(r.luaGetRelations))
+
+	// Graph traversal
+	r.L.SetField(rela, "trace_from", r.L.NewFunction(r.luaTraceFrom))
+	r.L.SetField(rela, "trace_to", r.L.NewFunction(r.luaTraceTo))
+
+	// Output functions
+	r.L.SetField(rela, "output", r.L.NewFunction(r.luaOutput))
+	r.L.SetField(rela, "write_file", r.L.NewFunction(r.luaWriteFile))
+
+	// Context
+	r.L.SetField(rela, "project_root", lua.LString(r.projectRoot))
+	r.L.SetField(rela, "args", r.L.NewTable()) // Will be set before running script
+
+	r.L.SetGlobal("rela", rela)
+}
+
+// luaGetEntity implements rela.get_entity(id) -> table|nil
+func (r *Runtime) luaGetEntity(ls *lua.LState) int {
+	id := ls.CheckString(1)
+
+	entity, found := r.ws.GetEntity(id)
+	if !found {
+		ls.Push(lua.LNil)
+		return 1
+	}
+
+	ls.Push(entityToTable(ls, entity))
+	return 1
+}
+
+// luaListEntities implements rela.list_entities(type, filter?) -> table
+func (r *Runtime) luaListEntities(ls *lua.LState) int {
+	entityType := ls.CheckString(1)
+	if entityType == "" {
+		ls.RaiseError("entity type cannot be empty")
+		return 0
+	}
+	filterExpr := ls.OptString(2, "")
+
+	entities := r.ws.EntitiesByType(entityType)
+
+	// Apply filter if provided
+	if filterExpr != "" {
+		f, err := filter.Parse(filterExpr)
+		if err != nil {
+			ls.RaiseError("invalid filter: %s", err.Error())
+			return 0
+		}
+
+		entityDef, found := r.meta.GetEntityDef(entityType)
+		if !found {
+			ls.RaiseError("unknown entity type: %s", entityType)
+			return 0
+		}
+
+		filters := []*filter.Filter{f}
+		filtered := make([]*model.Entity, 0)
+		for _, e := range entities {
+			match, err := filter.MatchAll(e, filters, entityDef, r.meta)
+			if err != nil {
+				ls.RaiseError("filter error: %s", err.Error())
+				return 0
+			}
+			if match {
+				filtered = append(filtered, e)
+			}
+		}
+		entities = filtered
+	}
+
+	result := ls.NewTable()
+	for i, e := range entities {
+		result.RawSetInt(i+1, entityToTable(ls, e))
+	}
+	ls.Push(result)
+	return 1
+}
+
+// luaGetRelations implements rela.get_relations(opts?) -> table
+// opts can have: from, type, to
+func (r *Runtime) luaGetRelations(ls *lua.LState) int {
+	var fromFilter, typeFilter, toFilter string
+
+	// Parse options table if provided
+	if ls.GetTop() >= 1 && ls.Get(1).Type() == lua.LTTable {
+		opts := ls.CheckTable(1)
+		if v, ok := opts.RawGetString("from").(lua.LString); ok {
+			fromFilter = string(v)
+		}
+		if v, ok := opts.RawGetString("type").(lua.LString); ok {
+			typeFilter = string(v)
+		}
+		if v, ok := opts.RawGetString("to").(lua.LString); ok {
+			toFilter = string(v)
+		}
+	}
+
+	relations := r.ws.AllRelations()
+
+	result := ls.NewTable()
+	idx := 1
+	for _, rel := range relations {
+		// Apply filters
+		if fromFilter != "" && rel.From != fromFilter {
+			continue
+		}
+		if typeFilter != "" && rel.Type != typeFilter {
+			continue
+		}
+		if toFilter != "" && rel.To != toFilter {
+			continue
+		}
+
+		result.RawSetInt(idx, relationToTable(ls, rel))
+		idx++
+	}
+	ls.Push(result)
+	return 1
+}
+
+// luaTraceFrom implements rela.trace_from(id, depth?) -> table|nil
+func (r *Runtime) luaTraceFrom(ls *lua.LState) int {
+	id := ls.CheckString(1)
+	maxDepth := ls.OptInt(2, 0)
+
+	trace := r.ws.TraceFrom(id, maxDepth)
+	if trace == nil {
+		ls.Push(lua.LNil)
+		return 1
+	}
+	ls.Push(traceResultToTable(ls, trace))
+	return 1
+}
+
+// luaTraceTo implements rela.trace_to(id, depth?) -> table|nil
+func (r *Runtime) luaTraceTo(ls *lua.LState) int {
+	id := ls.CheckString(1)
+	maxDepth := ls.OptInt(2, 0)
+
+	trace := r.ws.TraceTo(id, maxDepth)
+	if trace == nil {
+		ls.Push(lua.LNil)
+		return 1
+	}
+	ls.Push(traceResultToTable(ls, trace))
+	return 1
+}
+
+// luaOutput implements rela.output(data) - JSON encode to stdout
+func (r *Runtime) luaOutput(ls *lua.LState) int {
+	data := ls.CheckAny(1)
+
+	goData := luaValueToGo(data)
+
+	encoder := json.NewEncoder(r.stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(goData); err != nil {
+		ls.RaiseError("JSON encoding error: %s", err.Error())
+		return 0
+	}
+	return 0
+}
+
+// luaWriteFile implements rela.write_file(path, content)
+// Path must be within the project root for security.
+func (r *Runtime) luaWriteFile(ls *lua.LState) int {
+	path := ls.CheckString(1)
+	content := ls.CheckString(2)
+
+	// Resolve to absolute path
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		ls.RaiseError("invalid path: %s", err.Error())
+		return 0
+	}
+
+	// Validate path is within project root
+	absRoot, err := filepath.Abs(r.projectRoot)
+	if err != nil {
+		ls.RaiseError("invalid project root: %s", err.Error())
+		return 0
+	}
+
+	// Ensure the path starts with project root (after cleaning)
+	if !strings.HasPrefix(absPath, absRoot+string(filepath.Separator)) && absPath != absRoot {
+		ls.RaiseError("write_file: path must be within project root")
+		return 0
+	}
+
+	if err := os.WriteFile(absPath, []byte(content), 0644); err != nil {
+		ls.RaiseError("write file error: %s", err.Error())
+		return 0
+	}
+	return 0
+}
+
+// entityToTable converts a model.Entity to a Lua table.
+func entityToTable(ls *lua.LState, e *model.Entity) *lua.LTable {
+	t := ls.NewTable()
+	t.RawSetString("id", lua.LString(e.ID))
+	t.RawSetString("type", lua.LString(e.Type))
+	t.RawSetString("content", lua.LString(e.Content))
+
+	props := ls.NewTable()
+	for k, v := range e.Properties {
+		props.RawSetString(k, goToLuaValue(ls, v))
+	}
+	t.RawSetString("properties", props)
+
+	return t
+}
+
+// relationToTable converts a model.Relation to a Lua table.
+func relationToTable(ls *lua.LState, rel *model.Relation) *lua.LTable {
+	t := ls.NewTable()
+	t.RawSetString("from", lua.LString(rel.From))
+	t.RawSetString("type", lua.LString(rel.Type))
+	t.RawSetString("to", lua.LString(rel.To))
+
+	if len(rel.Properties) > 0 {
+		props := ls.NewTable()
+		for k, v := range rel.Properties {
+			props.RawSetString(k, goToLuaValue(ls, v))
+		}
+		t.RawSetString("properties", props)
+	}
+
+	return t
+}
+
+// traceResultToTable converts a trace result tree to a Lua table.
+func traceResultToTable(ls *lua.LState, trace *model.TraceResult) *lua.LTable {
+	t := ls.NewTable()
+	t.RawSetString("id", lua.LString(trace.ID))
+	t.RawSetString("type", lua.LString(trace.Type))
+	t.RawSetString("title", lua.LString(trace.Title))
+	t.RawSetString("depth", lua.LNumber(trace.Depth))
+	t.RawSetString("relation", lua.LString(trace.Relation))
+	t.RawSetString("incoming", lua.LBool(trace.Incoming))
+
+	// Convert children recursively
+	children := ls.NewTable()
+	for i, child := range trace.Children {
+		children.RawSetInt(i+1, traceResultToTable(ls, child))
+	}
+	t.RawSetString("children", children)
+
+	return t
+}
+
+// goToLuaValue converts a Go value to a Lua value.
+func goToLuaValue(ls *lua.LState, v interface{}) lua.LValue {
+	if v == nil {
+		return lua.LNil
+	}
+	switch val := v.(type) {
+	case string:
+		return lua.LString(val)
+	case int:
+		return lua.LNumber(val)
+	case int64:
+		return lua.LNumber(val)
+	case float64:
+		return lua.LNumber(val)
+	case bool:
+		return lua.LBool(val)
+	case []interface{}:
+		t := ls.NewTable()
+		for i, item := range val {
+			t.RawSetInt(i+1, goToLuaValue(ls, item))
+		}
+		return t
+	case []string:
+		t := ls.NewTable()
+		for i, item := range val {
+			t.RawSetInt(i+1, lua.LString(item))
+		}
+		return t
+	case map[string]interface{}:
+		t := ls.NewTable()
+		for k, item := range val {
+			t.RawSetString(k, goToLuaValue(ls, item))
+		}
+		return t
+	default:
+		// Fallback: convert to string
+		return lua.LString(fmt.Sprintf("%v", v))
+	}
+}
+
+// luaValueToGo converts a Lua value to a Go value.
+func luaValueToGo(lv lua.LValue) interface{} {
+	switch v := lv.(type) {
+	case lua.LBool:
+		return bool(v)
+	case lua.LNumber:
+		return float64(v)
+	case lua.LString:
+		return string(v)
+	case *lua.LTable:
+		return luaTableToGo(v)
+	case *lua.LNilType:
+		return nil
+	default:
+		return nil
+	}
+}
+
+// maxArraySize is the maximum size for arrays converted from Lua tables.
+const maxArraySize = 100000
+
+// luaTableToGo converts a Lua table to a Go map or slice.
+func luaTableToGo(t *lua.LTable) interface{} {
+	// Check if it's an array (sequential positive integer keys starting at 1)
+	isArray := true
+	maxN := 0
+	t.ForEach(func(k, _ lua.LValue) {
+		if kn, ok := k.(lua.LNumber); ok {
+			f := float64(kn)
+			// Must be a positive integer within bounds
+			if f != math.Floor(f) || f < 1 || f > maxArraySize {
+				isArray = false
+				return
+			}
+			n := int(f)
+			if n > maxN {
+				maxN = n
+			}
+		} else {
+			isArray = false
+		}
+	})
+
+	if isArray && maxN > 0 {
+		arr := make([]interface{}, maxN)
+		t.ForEach(func(k, v lua.LValue) {
+			if kn, ok := k.(lua.LNumber); ok {
+				idx := int(kn) - 1
+				if idx >= 0 && idx < maxN {
+					arr[idx] = luaValueToGo(v)
+				}
+			}
+		})
+		return arr
+	}
+
+	// It's a map
+	m := make(map[string]interface{})
+	t.ForEach(func(k, v lua.LValue) {
+		var key string
+		switch kv := k.(type) {
+		case lua.LString:
+			key = string(kv)
+		case lua.LNumber:
+			key = fmt.Sprintf("%v", float64(kv))
+		default:
+			key = k.String()
+		}
+		m[key] = luaValueToGo(v)
+	})
+	return m
+}

--- a/internal/lua/runtime_test.go
+++ b/internal/lua/runtime_test.go
@@ -1,0 +1,587 @@
+package lua
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/graph"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/workspace"
+)
+
+// testWorkspace creates a workspace with test entities for testing.
+func testWorkspace(t *testing.T) *workspace.Workspace {
+	t.Helper()
+
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Properties: map[string]metamodel.PropertyDef{
+					"title":  {Type: "string"},
+					"status": {Type: "string"},
+				},
+			},
+			"feature": {
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string"},
+				},
+			},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"implements": {
+				From: []string{"ticket"},
+				To:   []string{"feature"},
+			},
+		},
+	}
+
+	g := graph.New()
+	g.AddNode(&model.Entity{
+		ID:   "TKT-001",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title":  "Test Ticket",
+			"status": "open",
+		},
+		Content: "Test content",
+	})
+	g.AddNode(&model.Entity{
+		ID:   "TKT-002",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title":  "Done Ticket",
+			"status": "done",
+		},
+	})
+	g.AddNode(&model.Entity{
+		ID:   "FEAT-001",
+		Type: "feature",
+		Properties: map[string]interface{}{
+			"title": "Test Feature",
+		},
+	})
+	g.AddEdge(&model.Relation{
+		From: "TKT-001",
+		Type: "implements",
+		To:   "FEAT-001",
+	})
+
+	ws := workspace.NewForTest(g, meta)
+	return ws
+}
+
+func TestRunFile_BasicOutput(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	// Create a temp script
+	script := `rela.output({status = "ok"})`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["status"] != "ok" {
+		t.Errorf("Expected status=ok, got %v", result["status"])
+	}
+}
+
+func TestRunFile_Args(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `rela.output(rela.args)`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, []string{"foo", "bar"}); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result []interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if len(result) != 2 || result[0] != "foo" || result[1] != "bar" {
+		t.Errorf("Expected [foo, bar], got %v", result)
+	}
+}
+
+func TestGetEntity(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `
+local e = rela.get_entity("TKT-001")
+rela.output({
+    id = e.id,
+    type = e.type,
+    title = e.properties.title,
+    content = e.content
+})
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["id"] != "TKT-001" {
+		t.Errorf("Expected id=TKT-001, got %v", result["id"])
+	}
+	if result["type"] != "ticket" {
+		t.Errorf("Expected type=ticket, got %v", result["type"])
+	}
+	if result["title"] != "Test Ticket" {
+		t.Errorf("Expected title=Test Ticket, got %v", result["title"])
+	}
+	if result["content"] != "Test content" {
+		t.Errorf("Expected content=Test content, got %v", result["content"])
+	}
+}
+
+func TestGetEntity_NotFound(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `
+local e = rela.get_entity("NONEXISTENT")
+if e == nil then
+    rela.output({found = false})
+else
+    rela.output({found = true})
+end
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["found"] != false {
+		t.Errorf("Expected found=false, got %v", result["found"])
+	}
+}
+
+func TestListEntities(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `
+local tickets = rela.list_entities("ticket")
+rela.output({count = #tickets})
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["count"] != float64(2) {
+		t.Errorf("Expected count=2, got %v", result["count"])
+	}
+}
+
+func TestListEntities_WithFilter(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `
+local tickets = rela.list_entities("ticket", "status=done")
+rela.output({count = #tickets})
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["count"] != float64(1) {
+		t.Errorf("Expected count=1, got %v", result["count"])
+	}
+}
+
+func TestGetRelations(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `
+local rels = rela.get_relations({type = "implements"})
+rela.output({
+    count = #rels,
+    first = rels[1]
+})
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["count"] != float64(1) {
+		t.Errorf("Expected count=1, got %v", result["count"])
+	}
+
+	first := result["first"].(map[string]interface{})
+	if first["from"] != "TKT-001" {
+		t.Errorf("Expected from=TKT-001, got %v", first["from"])
+	}
+	if first["type"] != "implements" {
+		t.Errorf("Expected type=implements, got %v", first["type"])
+	}
+	if first["to"] != "FEAT-001" {
+		t.Errorf("Expected to=FEAT-001, got %v", first["to"])
+	}
+}
+
+func TestWriteFile(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	// Use same temp dir for project root and output file
+	projectRoot := t.TempDir()
+	r := New(ws, ws.Meta(), projectRoot, &buf)
+	defer r.Close()
+
+	outFile := filepath.Join(projectRoot, "output.txt")
+
+	script := `rela.write_file("` + outFile + `", "hello world")`
+	tmpFile := filepath.Join(projectRoot, "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	content, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+
+	if string(content) != "hello world" {
+		t.Errorf("Expected 'hello world', got %q", string(content))
+	}
+}
+
+func TestScriptError_Syntax(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `print(`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.RunFile(tmpFile, nil)
+	if err == nil {
+		t.Fatal("Expected error for syntax error")
+	}
+}
+
+func TestScriptError_Runtime(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `error("boom")`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.RunFile(tmpFile, nil)
+	if err == nil {
+		t.Fatal("Expected error for runtime error")
+	}
+}
+
+func TestProjectRoot(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/my/project", &buf)
+	defer r.Close()
+
+	script := `rela.output({root = rela.project_root})`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["root"] != "/my/project" {
+		t.Errorf("Expected root=/my/project, got %v", result["root"])
+	}
+}
+
+func TestWriteFile_PathTraversal(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	projectRoot := t.TempDir()
+	r := New(ws, ws.Meta(), projectRoot, &buf)
+	defer r.Close()
+
+	// Try to write outside project root using path traversal
+	script := `rela.write_file("../outside.txt", "malicious")`
+	tmpFile := filepath.Join(projectRoot, "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.RunFile(tmpFile, nil)
+	if err == nil {
+		t.Fatal("Expected error for path traversal attempt")
+	}
+	if !strings.Contains(err.Error(), "must be within project root") {
+		t.Errorf("Expected 'must be within project root' error, got: %v", err)
+	}
+}
+
+func TestWriteFile_AbsolutePathOutside(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	projectRoot := t.TempDir()
+	r := New(ws, ws.Meta(), projectRoot, &buf)
+	defer r.Close()
+
+	// Try to write to absolute path outside project
+	script := `rela.write_file("/tmp/outside.txt", "malicious")`
+	tmpFile := filepath.Join(projectRoot, "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.RunFile(tmpFile, nil)
+	if err == nil {
+		t.Fatal("Expected error for absolute path outside project")
+	}
+}
+
+func TestWriteFile_WithinProject(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	projectRoot := t.TempDir()
+	r := New(ws, ws.Meta(), projectRoot, &buf)
+	defer r.Close()
+
+	outFile := filepath.Join(projectRoot, "output.txt")
+	script := `rela.write_file("` + outFile + `", "allowed")`
+	tmpFile := filepath.Join(projectRoot, "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	content, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+
+	if string(content) != "allowed" {
+		t.Errorf("Expected 'allowed', got %q", string(content))
+	}
+}
+
+func TestListEntities_EmptyType(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `rela.list_entities("")`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.RunFile(tmpFile, nil)
+	if err == nil {
+		t.Fatal("Expected error for empty entity type")
+	}
+}
+
+func TestListEntities_InvalidFilter(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `rela.list_entities("ticket", "invalid[filter")`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.RunFile(tmpFile, nil)
+	if err == nil {
+		t.Fatal("Expected error for invalid filter")
+	}
+}
+
+func TestGetRelations_NoFilters(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `
+local rels = rela.get_relations()
+rela.output({count = #rels})
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	// Should return all relations (we have 1 in test workspace)
+	if result["count"] != float64(1) {
+		t.Errorf("Expected count=1, got %v", result["count"])
+	}
+}
+
+func TestTraceFrom_NonExistent(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `
+local trace = rela.trace_from("NONEXISTENT", 0)
+if trace == nil then
+    rela.output({found = false})
+else
+    rela.output({found = true})
+end
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	// For non-existent entity, trace_from returns nil
+	if result["found"] != false {
+		t.Errorf("Expected found=false, got %v", result["found"])
+	}
+}

--- a/internal/lua/runtime_test.go
+++ b/internal/lua/runtime_test.go
@@ -11,22 +11,25 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/repository"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
-// testWorkspace creates a workspace with test entities for testing.
-func testWorkspace(t *testing.T) *workspace.Workspace {
-	t.Helper()
-
-	meta := &metamodel.Metamodel{
+// testMeta returns the metamodel used for testing.
+func testMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
 		Entities: map[string]metamodel.EntityDef{
 			"ticket": {
+				IDPrefix: "TKT",
 				Properties: map[string]metamodel.PropertyDef{
 					"title":  {Type: "string"},
 					"status": {Type: "string"},
 				},
 			},
 			"feature": {
+				IDPrefix: "FEAT",
 				Properties: map[string]metamodel.PropertyDef{
 					"title": {Type: "string"},
 				},
@@ -39,6 +42,11 @@ func testWorkspace(t *testing.T) *workspace.Workspace {
 			},
 		},
 	}
+}
+
+// testWorkspace creates a workspace with test entities for testing.
+func testWorkspace(t *testing.T) *workspace.Workspace {
+	t.Helper()
 
 	g := graph.New()
 	g.AddNode(&model.Entity{
@@ -71,8 +79,125 @@ func testWorkspace(t *testing.T) *workspace.Workspace {
 		To:   "FEAT-001",
 	})
 
-	ws := workspace.NewForTest(g, meta)
+	ws := workspace.NewForTest(g, testMeta())
 	return ws
+}
+
+// testWorkspaceWithRepo creates a workspace with a real repository for mutation tests.
+// Returns the workspace and the project root path.
+func testWorkspaceWithRepo(t *testing.T) (ws *workspace.Workspace, root string) {
+	t.Helper()
+
+	fs := storage.NewMemFS()
+	root = "/project"
+	ctx := &project.Context{
+		Root:          root,
+		EntitiesDir:   filepath.Join(root, "entities"),
+		RelationsDir:  filepath.Join(root, "relations"),
+		MetamodelPath: filepath.Join(root, "metamodel.yaml"),
+		CacheDir:      filepath.Join(root, ".rela"),
+	}
+
+	// Create directories
+	_ = fs.MkdirAll(ctx.CacheDir, 0755)
+	_ = fs.MkdirAll(filepath.Join(ctx.EntitiesDir, "tickets"), 0755)
+	_ = fs.MkdirAll(filepath.Join(ctx.EntitiesDir, "features"), 0755)
+	_ = fs.MkdirAll(ctx.RelationsDir, 0755)
+
+	// Write metamodel
+	metamodelContent := `entities:
+  ticket:
+    label: Ticket
+    plural: tickets
+    id_prefix: TKT
+    id_type: sequential
+    properties:
+      title: {type: string}
+      status: {type: string}
+  feature:
+    label: Feature
+    plural: features
+    id_prefix: FEAT
+    id_type: sequential
+    properties:
+      title: {type: string}
+
+relations:
+  implements:
+    from: [ticket]
+    to: [feature]
+`
+	_ = fs.WriteFile(ctx.MetamodelPath, []byte(metamodelContent), 0644)
+
+	// Write test entities
+	tkt001 := `---
+title: Test Ticket
+status: open
+---
+Test content
+`
+	_ = fs.WriteFile(filepath.Join(ctx.EntitiesDir, "tickets", "TKT-001.md"), []byte(tkt001), 0644)
+
+	tkt002 := `---
+title: Done Ticket
+status: done
+---
+`
+	_ = fs.WriteFile(filepath.Join(ctx.EntitiesDir, "tickets", "TKT-002.md"), []byte(tkt002), 0644)
+
+	feat001 := `---
+title: Test Feature
+---
+`
+	_ = fs.WriteFile(filepath.Join(ctx.EntitiesDir, "features", "FEAT-001.md"), []byte(feat001), 0644)
+
+	// Write test relation
+	rel := `---
+---
+`
+	_ = fs.WriteFile(filepath.Join(ctx.RelationsDir, "TKT-001--implements--FEAT-001.md"), []byte(rel), 0644)
+
+	// Create graph with test entities (same as testWorkspace)
+	g := graph.New()
+	g.AddNode(&model.Entity{
+		ID:   "TKT-001",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title":  "Test Ticket",
+			"status": "open",
+		},
+		Content: "Test content",
+	})
+	g.AddNode(&model.Entity{
+		ID:   "TKT-002",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title":  "Done Ticket",
+			"status": "done",
+		},
+	})
+	g.AddNode(&model.Entity{
+		ID:   "FEAT-001",
+		Type: "feature",
+		Properties: map[string]interface{}{
+			"title": "Test Feature",
+		},
+	})
+	g.AddEdge(&model.Relation{
+		From: "TKT-001",
+		Type: "implements",
+		To:   "FEAT-001",
+	})
+
+	// Create repository and workspace with graph
+	repo := repository.New(fs, ctx)
+	meta, err := repo.LoadMetamodel()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ws = workspace.NewWithGraph(repo, meta, g)
+
+	return ws, root
 }
 
 func TestRunFile_BasicOutput(t *testing.T) {
@@ -583,5 +708,512 @@ end
 	// For non-existent entity, trace_from returns nil
 	if result["found"] != false {
 		t.Errorf("Expected found=false, got %v", result["found"])
+	}
+}
+
+func TestSearch(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `
+local results = rela.search("Test")
+rela.output({count = #results})
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	// Should find entities with "Test" in their title
+	count := result["count"].(float64)
+	if count < 1 {
+		t.Errorf("Expected at least 1 result, got %v", count)
+	}
+}
+
+func TestSearch_EmptyQuery(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `rela.search("")`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.RunFile(tmpFile, nil)
+	if err == nil {
+		t.Fatal("Expected error for empty search query")
+	}
+}
+
+func TestCreateEntity(t *testing.T) {
+	ws, root := testWorkspaceWithRepo(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), root, &buf)
+	defer r.Close()
+
+	script := `
+local entity = rela.create_entity("ticket", {title = "New Ticket", status = "open"}, "Content here")
+rela.output({
+    id = entity.id,
+    type = entity.type,
+    title = entity.properties.title,
+    status = entity.properties.status
+})
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["type"] != "ticket" {
+		t.Errorf("Expected type=ticket, got %v", result["type"])
+	}
+	if result["title"] != "New Ticket" {
+		t.Errorf("Expected title=New Ticket, got %v", result["title"])
+	}
+	if result["status"] != "open" {
+		t.Errorf("Expected status=open, got %v", result["status"])
+	}
+}
+
+func TestCreateEntity_EmptyType(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `rela.create_entity("", {title = "Test"})`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.RunFile(tmpFile, nil)
+	if err == nil {
+		t.Fatal("Expected error for empty entity type")
+	}
+}
+
+func TestUpdateEntity(t *testing.T) {
+	ws, root := testWorkspaceWithRepo(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), root, &buf)
+	defer r.Close()
+
+	script := `
+local entity = rela.update_entity("TKT-001", {status = "closed"})
+rela.output({
+    id = entity.id,
+    status = entity.properties.status
+})
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["id"] != "TKT-001" {
+		t.Errorf("Expected id=TKT-001, got %v", result["id"])
+	}
+	if result["status"] != "closed" {
+		t.Errorf("Expected status=closed, got %v", result["status"])
+	}
+}
+
+func TestUpdateEntity_NotFound(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `rela.update_entity("NONEXISTENT", {status = "closed"})`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.RunFile(tmpFile, nil)
+	if err == nil {
+		t.Fatal("Expected error for non-existent entity")
+	}
+	if !strings.Contains(err.Error(), "entity not found") {
+		t.Errorf("Expected 'entity not found' error, got: %v", err)
+	}
+}
+
+func TestDeleteEntity(t *testing.T) {
+	ws, root := testWorkspaceWithRepo(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), root, &buf)
+	defer r.Close()
+
+	script := `
+local success = rela.delete_entity("TKT-002", false)
+rela.output({success = success})
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["success"] != true {
+		t.Errorf("Expected success=true, got %v", result["success"])
+	}
+
+	// Verify entity is deleted
+	_, found := ws.GetEntity("TKT-002")
+	if found {
+		t.Error("Entity TKT-002 should have been deleted")
+	}
+}
+
+func TestDeleteEntity_NotFound(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `rela.delete_entity("NONEXISTENT")`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.RunFile(tmpFile, nil)
+	if err == nil {
+		t.Fatal("Expected error for non-existent entity")
+	}
+}
+
+func TestCreateRelation(t *testing.T) {
+	ws, root := testWorkspaceWithRepo(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), root, &buf)
+	defer r.Close()
+
+	// TKT-002 doesn't have a relation to FEAT-001 yet
+	script := `
+local rel = rela.create_relation("TKT-002", "implements", "FEAT-001")
+rela.output({
+    from = rel.from,
+    type = rel.type,
+    to = rel.to
+})
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["from"] != "TKT-002" {
+		t.Errorf("Expected from=TKT-002, got %v", result["from"])
+	}
+	if result["type"] != "implements" {
+		t.Errorf("Expected type=implements, got %v", result["type"])
+	}
+	if result["to"] != "FEAT-001" {
+		t.Errorf("Expected to=FEAT-001, got %v", result["to"])
+	}
+}
+
+func TestCreateRelation_MissingArgs(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `rela.create_relation("", "implements", "FEAT-001")`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.RunFile(tmpFile, nil)
+	if err == nil {
+		t.Fatal("Expected error for missing from argument")
+	}
+}
+
+func TestDeleteRelation(t *testing.T) {
+	ws, root := testWorkspaceWithRepo(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), root, &buf)
+	defer r.Close()
+
+	script := `
+local success = rela.delete_relation("TKT-001", "implements", "FEAT-001")
+rela.output({success = success})
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["success"] != true {
+		t.Errorf("Expected success=true, got %v", result["success"])
+	}
+}
+
+func TestFindPath(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `
+local path = rela.find_path("TKT-001", "FEAT-001")
+if path then
+    rela.output({found = true, length = #path})
+else
+    rela.output({found = false})
+end
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["found"] != true {
+		t.Errorf("Expected found=true, got %v", result["found"])
+	}
+	// Path should have 2 steps: TKT-001 -> FEAT-001
+	if result["length"] != float64(2) {
+		t.Errorf("Expected length=2, got %v", result["length"])
+	}
+}
+
+func TestFindPath_NoPath(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `
+local path = rela.find_path("TKT-001", "NONEXISTENT")
+if path then
+    rela.output({found = true})
+else
+    rela.output({found = false})
+end
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["found"] != false {
+		t.Errorf("Expected found=false, got %v", result["found"])
+	}
+}
+
+func TestFindPath_MissingArgs(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `rela.find_path("", "FEAT-001")`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.RunFile(tmpFile, nil)
+	if err == nil {
+		t.Fatal("Expected error for empty from argument")
+	}
+}
+
+func TestRefresh(t *testing.T) {
+	ws, root := testWorkspaceWithRepo(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), root, &buf)
+	defer r.Close()
+
+	script := `
+local success = rela.refresh()
+rela.output({success = success})
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["success"] != true {
+		t.Errorf("Expected success=true, got %v", result["success"])
+	}
+}
+
+func TestTraceFrom(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `
+local trace = rela.trace_from("TKT-001", 0)
+rela.output({
+    id = trace.id,
+    has_children = #trace.children > 0
+})
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["id"] != "TKT-001" {
+		t.Errorf("Expected id=TKT-001, got %v", result["id"])
+	}
+	if result["has_children"] != true {
+		t.Errorf("Expected has_children=true, got %v", result["has_children"])
+	}
+}
+
+func TestTraceTo(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	script := `
+local trace = rela.trace_to("FEAT-001", 0)
+rela.output({
+    id = trace.id,
+    has_children = #trace.children > 0
+})
+`
+	tmpFile := filepath.Join(t.TempDir(), "test.lua")
+	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.RunFile(tmpFile, nil); err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["id"] != "FEAT-001" {
+		t.Errorf("Expected id=FEAT-001, got %v", result["id"])
+	}
+	if result["has_children"] != true {
+		t.Errorf("Expected has_children=true (TKT-001 -> FEAT-001), got %v", result["has_children"])
 	}
 }

--- a/internal/lua/runtime_test.go
+++ b/internal/lua/runtime_test.go
@@ -441,23 +441,19 @@ func TestWriteFile(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
-	// Use same temp dir for project root and output file
 	projectRoot := t.TempDir()
 	r := New(ws, ws.Meta(), projectRoot, &buf)
 	defer r.Close()
 
-	outFile := filepath.Join(projectRoot, "output.txt")
-
-	script := `rela.write_file("` + outFile + `", "hello world")`
-	tmpFile := filepath.Join(projectRoot, "test.lua")
-	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
-		t.Fatal(err)
+	// Files are written to output/ directory
+	script := `rela.write_file("result.txt", "hello world")`
+	err := r.RunString(script)
+	if err != nil {
+		t.Fatalf("RunString failed: %v", err)
 	}
 
-	if err := r.RunFile(tmpFile, nil); err != nil {
-		t.Fatalf("RunFile failed: %v", err)
-	}
-
+	// File should be in output/ subdirectory
+	outFile := filepath.Join(projectRoot, "output", "result.txt")
 	content, err := os.ReadFile(outFile)
 	if err != nil {
 		t.Fatalf("Failed to read output file: %v", err)
@@ -541,19 +537,21 @@ func TestWriteFile_PathTraversal(t *testing.T) {
 	r := New(ws, ws.Meta(), projectRoot, &buf)
 	defer r.Close()
 
-	// Try to write outside project root using path traversal
+	// Try to escape output/ using path traversal
 	script := `rela.write_file("../outside.txt", "malicious")`
-	tmpFile := filepath.Join(projectRoot, "test.lua")
-	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	err := r.RunFile(tmpFile, nil)
+	err := r.RunString(script)
 	if err == nil {
 		t.Fatal("Expected error for path traversal attempt")
 	}
-	if !strings.Contains(err.Error(), "must be within project root") {
-		t.Errorf("Expected 'must be within project root' error, got: %v", err)
+	// Error message should indicate the path is not local
+	if !strings.Contains(err.Error(), "local path") {
+		t.Errorf("Expected 'local path' error, got: %v", err)
+	}
+
+	// Verify file was NOT created outside output/
+	outsideFile := filepath.Join(projectRoot, "outside.txt")
+	if _, err := os.Stat(outsideFile); err == nil {
+		t.Error("File should not have been created outside output/")
 	}
 }
 
@@ -565,20 +563,15 @@ func TestWriteFile_AbsolutePathOutside(t *testing.T) {
 	r := New(ws, ws.Meta(), projectRoot, &buf)
 	defer r.Close()
 
-	// Try to write to absolute path outside project
+	// Try to write to absolute path (should be rejected)
 	script := `rela.write_file("/tmp/outside.txt", "malicious")`
-	tmpFile := filepath.Join(projectRoot, "test.lua")
-	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	err := r.RunFile(tmpFile, nil)
+	err := r.RunString(script)
 	if err == nil {
-		t.Fatal("Expected error for absolute path outside project")
+		t.Fatal("Expected error for absolute path")
 	}
 }
 
-func TestWriteFile_WithinProject(t *testing.T) {
+func TestWriteFile_InOutputDir(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
@@ -586,17 +579,15 @@ func TestWriteFile_WithinProject(t *testing.T) {
 	r := New(ws, ws.Meta(), projectRoot, &buf)
 	defer r.Close()
 
-	outFile := filepath.Join(projectRoot, "output.txt")
-	script := `rela.write_file("` + outFile + `", "allowed")`
-	tmpFile := filepath.Join(projectRoot, "test.lua")
-	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
-		t.Fatal(err)
+	// Write to output directory
+	script := `rela.write_file("result.txt", "allowed")`
+	err := r.RunString(script)
+	if err != nil {
+		t.Fatalf("RunString failed: %v", err)
 	}
 
-	if err := r.RunFile(tmpFile, nil); err != nil {
-		t.Fatalf("RunFile failed: %v", err)
-	}
-
+	// File should be in output/ subdirectory
+	outFile := filepath.Join(projectRoot, "output", "result.txt")
 	content, err := os.ReadFile(outFile)
 	if err != nil {
 		t.Fatalf("Failed to read output file: %v", err)
@@ -1215,5 +1206,157 @@ rela.output({
 	}
 	if result["has_children"] != true {
 		t.Errorf("Expected has_children=true (TKT-001 -> FEAT-001), got %v", result["has_children"])
+	}
+}
+
+// TestSandbox_DangerousLibrariesUnavailable verifies that dangerous Lua libraries
+// (io, os, debug) are not available in the sandboxed runtime.
+func TestSandbox_DangerousLibrariesUnavailable(t *testing.T) {
+	ws := testWorkspace(t)
+
+	tests := []struct {
+		name   string
+		script string
+	}{
+		{"io library", `if io then error("io should not be available") end`},
+		{"os library", `if os then error("os should not be available") end`},
+		{"debug library", `if debug then error("debug should not be available") end`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			r := New(ws, ws.Meta(), "/tmp", &buf)
+			defer r.Close()
+
+			// Should succeed because the libraries are not available
+			err := r.RunString(tt.script)
+			if err != nil {
+				t.Errorf("Script failed unexpectedly: %v", err)
+			}
+		})
+	}
+}
+
+// TestSandbox_DangerousFunctionsRemoved verifies that dangerous base functions
+// are removed from the sandbox.
+func TestSandbox_DangerousFunctionsRemoved(t *testing.T) {
+	ws := testWorkspace(t)
+
+	dangerousFuncs := []string{
+		"loadfile",
+		"dofile",
+		"load",
+		"loadstring",
+		"rawget",
+		"rawset",
+		"rawequal",
+		"rawlen",
+		"getmetatable",
+		"setmetatable",
+	}
+
+	for _, fn := range dangerousFuncs {
+		t.Run(fn, func(t *testing.T) {
+			var buf bytes.Buffer
+			r := New(ws, ws.Meta(), "/tmp", &buf)
+			defer r.Close()
+
+			script := `if ` + fn + ` ~= nil then error("` + fn + ` should be nil") end`
+			err := r.RunString(script)
+			if err != nil {
+				t.Errorf("Function %s should be nil but script failed: %v", fn, err)
+			}
+		})
+	}
+}
+
+// TestSandbox_SafeLibrariesAvailable verifies that safe Lua libraries are available.
+func TestSandbox_SafeLibrariesAvailable(t *testing.T) {
+	ws := testWorkspace(t)
+
+	tests := []struct {
+		name   string
+		script string
+	}{
+		{"string library", `if not string.len then error("string.len not available") end`},
+		{"table library", `if not table.insert then error("table.insert not available") end`},
+		{"math library", `if not math.floor then error("math.floor not available") end`},
+		{"coroutine library", `if not coroutine.create then error("coroutine.create not available") end`},
+		{"base print", `if not print then error("print not available") end`},
+		{"base pairs", `if not pairs then error("pairs not available") end`},
+		{"base ipairs", `if not ipairs then error("ipairs not available") end`},
+		{"base type", `if not type then error("type not available") end`},
+		{"base tostring", `if not tostring then error("tostring not available") end`},
+		{"base tonumber", `if not tonumber then error("tonumber not available") end`},
+		{"base error", `if not error then error("error not available") end`},
+		{"base pcall", `if not pcall then error("pcall not available") end`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			r := New(ws, ws.Meta(), "/tmp", &buf)
+			defer r.Close()
+
+			err := r.RunString(tt.script)
+			if err != nil {
+				t.Errorf("Script failed: %v", err)
+			}
+		})
+	}
+}
+
+// TestWriteFile_NestedDirectories verifies that write_file creates nested directories in output/.
+func TestWriteFile_NestedDirectories(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	projectRoot := t.TempDir()
+	r := New(ws, ws.Meta(), projectRoot, &buf)
+	defer r.Close()
+
+	// Write to a deeply nested path within output/
+	script := `rela.write_file("reports/2024/summary.txt", "nested content")`
+	err := r.RunString(script)
+	if err != nil {
+		t.Fatalf("RunString failed: %v", err)
+	}
+
+	// Verify file was created in output/ subdirectory
+	outFile := filepath.Join(projectRoot, "output", "reports", "2024", "summary.txt")
+	content, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+
+	if string(content) != "nested content" {
+		t.Errorf("Expected 'nested content', got %q", string(content))
+	}
+}
+
+// TestSetArgs verifies that SetArgs correctly sets script arguments.
+func TestSetArgs(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	r.SetArgs([]string{"arg1", "arg2", "arg3"})
+
+	script := `rela.output(rela.args)`
+	err := r.RunString(script)
+	if err != nil {
+		t.Fatalf("RunString failed: %v", err)
+	}
+
+	var result []interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if len(result) != 3 || result[0] != "arg1" || result[1] != "arg2" || result[2] != "arg3" {
+		t.Errorf("Expected [arg1, arg2, arg3], got %v", result)
 	}
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -43,6 +43,10 @@ func (s *Server) registerTools() {
 	// Utility tools
 	s.mcp.AddTool(toolRefresh(), s.handleRefresh)
 	s.mcp.AddTool(toolExport(), s.handleExport)
+
+	// Lua scripting tools
+	s.mcp.AddTool(toolLuaEval(), s.handleLuaEval)
+	s.mcp.AddTool(toolLuaRun(), s.handleLuaRun)
 }
 
 // --- Tool Definitions ---

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -47,6 +47,7 @@ func (s *Server) registerTools() {
 	// Lua scripting tools
 	s.mcp.AddTool(toolLuaEval(), s.handleLuaEval)
 	s.mcp.AddTool(toolLuaRun(), s.handleLuaRun)
+	s.mcp.AddTool(toolLuaList(), s.handleLuaList)
 }
 
 // --- Tool Definitions ---

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -1,0 +1,101 @@
+// coverage-ignore: MCP tool handlers - tested via integration tests
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/Sourcehaven-BV/rela/internal/lua"
+)
+
+func toolLuaEval() mcp.Tool {
+	return mcp.NewTool("lua_eval",
+		mcp.WithDescription(
+			"Execute Lua code against the rela graph. "+
+				"Use rela.output(data) to return results as JSON. "+
+				"Available functions: get_entity, list_entities, search, create_entity, update_entity, "+
+				"delete_entity, get_relations, create_relation, delete_relation, trace_from, trace_to, "+
+				"find_path, refresh, write_file. "+
+				"Context: rela.project_root."),
+		mcp.WithString("code", mcp.Required(),
+			mcp.Description("Lua code to execute")),
+	)
+}
+
+func toolLuaRun() mcp.Tool {
+	return mcp.NewTool("lua_run",
+		mcp.WithDescription(
+			"Execute a Lua script file against the rela graph. "+
+				"Script path is relative to project root. "+
+				"Use rela.output(data) to return results as JSON."),
+		mcp.WithString("path", mcp.Required(),
+			mcp.Description("Path to Lua script file (relative to project root)")),
+		mcp.WithArray("args",
+			mcp.Description("Arguments to pass to the script (available as rela.args)")),
+	)
+}
+
+func (s *Server) handleLuaEval(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	code, err := req.RequireString("code")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	projectRoot := s.ws.Paths().Root
+
+	// Capture output
+	var output bytes.Buffer
+
+	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output)
+	defer runtime.Close()
+
+	if err := runtime.RunString(code); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Lua error: %s", err.Error())), nil
+	}
+
+	result := output.String()
+	if result == "" {
+		result = "Script executed successfully (no output)"
+	}
+
+	return mcp.NewToolResultText(result), nil
+}
+
+func (s *Server) handleLuaRun(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path, err := req.RequireString("path")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Parse args if provided
+	args := req.GetStringSlice("args", nil)
+
+	projectRoot := s.ws.Paths().Root
+
+	// Resolve path relative to project root
+	scriptPath := path
+	if !filepath.IsAbs(path) {
+		scriptPath = filepath.Join(projectRoot, path)
+	}
+
+	// Capture output
+	var output bytes.Buffer
+
+	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output)
+	defer runtime.Close()
+
+	if err := runtime.RunFile(scriptPath, args); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Lua error: %s", err.Error())), nil
+	}
+
+	result := output.String()
+	if result == "" {
+		result = "Script executed successfully (no output)"
+	}
+
+	return mcp.NewToolResultText(result), nil
+}

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -21,8 +21,8 @@ func toolLuaEval() mcp.Tool {
 				"Use rela.output(data) to return results as JSON. "+
 				"Available functions: get_entity, list_entities, search, create_entity, update_entity, "+
 				"delete_entity, get_relations, create_relation, delete_relation, trace_from, trace_to, "+
-				"find_path, refresh, write_file. "+
-				"Context: rela.project_root."),
+				"find_path, refresh, write_file, get_entity_types, get_relation_types. "+
+				"Context: rela.project_root, rela.args."),
 		mcp.WithString("code", mcp.Required(),
 			mcp.Description("Lua code to execute")),
 	)

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,9 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 )
+
+// scriptsDir is the directory where Lua scripts must be located for lua_run.
+const scriptsDir = "scripts"
 
 func toolLuaEval() mcp.Tool {
 	return mcp.NewTool("lua_eval",
@@ -32,10 +36,10 @@ func toolLuaRun() mcp.Tool {
 	return mcp.NewTool("lua_run",
 		mcp.WithDescription(
 			"Execute a Lua script file against the rela graph. "+
-				"Script path is relative to project root. "+
+				"Scripts must be located in the 'scripts/' directory. "+
 				"Use rela.output(data) to return results as JSON."),
 		mcp.WithString("path", mcp.Required(),
-			mcp.Description("Path to Lua script file (relative to project root)")),
+			mcp.Description("Script filename or path within scripts/ (e.g., 'export.lua' or 'reports/summary.lua')")),
 		mcp.WithArray("args",
 			mcp.Description("Arguments to pass to the script (available as rela.args)")),
 	)
@@ -44,8 +48,8 @@ func toolLuaRun() mcp.Tool {
 func toolLuaList() mcp.Tool {
 	return mcp.NewTool("lua_list",
 		mcp.WithDescription(
-			"List available Lua scripts in the project. "+
-				"Searches for .lua files in common locations (scripts/, lua/, root)."),
+			"List available Lua scripts in the scripts/ directory. "+
+				"Only scripts in this directory can be executed via lua_run."),
 	)
 }
 
@@ -81,15 +85,47 @@ func (s *Server) handleLuaRun(_ context.Context, req mcp.CallToolRequest) (*mcp.
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	// Security: Validate path is local (no "..", no absolute paths)
+	if !filepath.IsLocal(path) {
+		return mcp.NewToolResultError("script path must be a local path (no '..' or absolute paths allowed)"), nil
+	}
+
+	// Security: Must have .lua extension
+	if !strings.HasSuffix(path, ".lua") {
+		return mcp.NewToolResultError("script must have .lua extension"), nil
+	}
+
 	// Parse args if provided
 	args := req.GetStringSlice("args", nil)
 
 	projectRoot := s.ws.Paths().Root
 
-	// Resolve path relative to project root
-	scriptPath := path
-	if !filepath.IsAbs(path) {
-		scriptPath = filepath.Join(projectRoot, path)
+	// Security: Scripts must be in the scripts/ directory
+	// Use os.Root for traversal-resistant path access
+	root, err := os.OpenRoot(projectRoot)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("cannot open project root: %s", err.Error())), nil
+	}
+	defer root.Close()
+
+	// Verify script exists using traversal-resistant API
+	scriptsRoot, err := root.OpenRoot(scriptsDir)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("scripts directory not found: %s", err.Error())), nil
+	}
+	defer scriptsRoot.Close()
+
+	// Read script content using traversal-resistant API to prevent symlink escapes
+	scriptFile, err := scriptsRoot.Open(path)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("script not found: %s (scripts must be in the scripts/ directory)", path)), nil
+	}
+	defer scriptFile.Close()
+
+	// Read script content
+	scriptContent, err := io.ReadAll(scriptFile)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("cannot read script: %s", err.Error())), nil
 	}
 
 	// Capture output
@@ -98,8 +134,12 @@ func (s *Server) handleLuaRun(_ context.Context, req mcp.CallToolRequest) (*mcp.
 	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output)
 	defer runtime.Close()
 
-	if err := runtime.RunFile(scriptPath, args); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("Lua error: %s", err.Error())), nil
+	// Set script args before execution
+	runtime.SetArgs(args)
+
+	// Execute script content directly (bypasses symlink escapes since we read via os.Root)
+	if err := runtime.RunString(string(scriptContent)); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Lua error in %s: %s", path, err.Error())), nil
 	}
 
 	result := output.String()
@@ -113,58 +153,43 @@ func (s *Server) handleLuaRun(_ context.Context, req mcp.CallToolRequest) (*mcp.
 func (s *Server) handleLuaList(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	projectRoot := s.ws.Paths().Root
 
-	// Directories to search for Lua scripts
-	searchDirs := []string{
-		"scripts",
-		"lua",
-		".",
-	}
+	// Only search the scripts/ directory (security restriction)
+	scriptsPath := filepath.Join(projectRoot, scriptsDir)
 
 	var scripts []string
-	seen := make(map[string]bool)
 
-	for _, dir := range searchDirs {
-		searchPath := filepath.Join(projectRoot, dir)
-		entries, err := os.ReadDir(searchPath)
-		if err != nil {
-			continue // Directory doesn't exist, skip
+	// Walk the scripts directory recursively to find all .lua files
+	_ = filepath.WalkDir(scriptsPath, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return filepath.SkipDir // Skip directories with errors
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".lua") {
+			return nil
 		}
 
-		for _, entry := range entries {
-			if entry.IsDir() {
-				continue
-			}
-			if !strings.HasSuffix(entry.Name(), ".lua") {
-				continue
-			}
-
-			// Get relative path from project root
-			var relPath string
-			if dir == "." {
-				relPath = entry.Name()
-			} else {
-				relPath = filepath.Join(dir, entry.Name())
-			}
-
-			if seen[relPath] {
-				continue
-			}
-			seen[relPath] = true
+		// Get relative path from scripts directory
+		relPath, _ := filepath.Rel(scriptsPath, path)
+		if relPath != "" {
 			scripts = append(scripts, relPath)
 		}
-	}
+		return nil
+	})
 
 	if len(scripts) == 0 {
-		return mcp.NewToolResultText("No Lua scripts found in project"), nil
+		return mcp.NewToolResultText("No Lua scripts found in scripts/ directory"), nil
 	}
 
 	var result strings.Builder
-	result.WriteString("Available Lua scripts:\n")
+	result.WriteString("Available Lua scripts (in scripts/):\n")
 	for _, script := range scripts {
 		result.WriteString("  ")
 		result.WriteString(script)
 		result.WriteString("\n")
 	}
+	result.WriteString("\nUse lua_run with the script name to execute.")
 
 	return mcp.NewToolResultText(result.String()), nil
 }

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -5,7 +5,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
@@ -36,6 +38,14 @@ func toolLuaRun() mcp.Tool {
 			mcp.Description("Path to Lua script file (relative to project root)")),
 		mcp.WithArray("args",
 			mcp.Description("Arguments to pass to the script (available as rela.args)")),
+	)
+}
+
+func toolLuaList() mcp.Tool {
+	return mcp.NewTool("lua_list",
+		mcp.WithDescription(
+			"List available Lua scripts in the project. "+
+				"Searches for .lua files in common locations (scripts/, lua/, root)."),
 	)
 }
 
@@ -98,4 +108,63 @@ func (s *Server) handleLuaRun(_ context.Context, req mcp.CallToolRequest) (*mcp.
 	}
 
 	return mcp.NewToolResultText(result), nil
+}
+
+func (s *Server) handleLuaList(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	projectRoot := s.ws.Paths().Root
+
+	// Directories to search for Lua scripts
+	searchDirs := []string{
+		"scripts",
+		"lua",
+		".",
+	}
+
+	var scripts []string
+	seen := make(map[string]bool)
+
+	for _, dir := range searchDirs {
+		searchPath := filepath.Join(projectRoot, dir)
+		entries, err := os.ReadDir(searchPath)
+		if err != nil {
+			continue // Directory doesn't exist, skip
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			if !strings.HasSuffix(entry.Name(), ".lua") {
+				continue
+			}
+
+			// Get relative path from project root
+			var relPath string
+			if dir == "." {
+				relPath = entry.Name()
+			} else {
+				relPath = filepath.Join(dir, entry.Name())
+			}
+
+			if seen[relPath] {
+				continue
+			}
+			seen[relPath] = true
+			scripts = append(scripts, relPath)
+		}
+	}
+
+	if len(scripts) == 0 {
+		return mcp.NewToolResultText("No Lua scripts found in project"), nil
+	}
+
+	var result strings.Builder
+	result.WriteString("Available Lua scripts:\n")
+	for _, script := range scripts {
+		result.WriteString("  ")
+		result.WriteString(script)
+		result.WriteString("\n")
+	}
+
+	return mcp.NewToolResultText(result.String()), nil
 }

--- a/scripts/dev-status.lua
+++ b/scripts/dev-status.lua
@@ -1,0 +1,141 @@
+-- dev-status.lua
+-- Generate a development status report for rela itself
+-- Usage: rela lua scripts/dev-status.lua
+--    or: lua_run(path: "dev-status.lua")
+
+local function count_by_status(entities)
+    local counts = {}
+    for _, e in ipairs(entities) do
+        local status = e.properties.status or "unknown"
+        counts[status] = (counts[status] or 0) + 1
+    end
+    return counts
+end
+
+local function get_recent(entities, status, limit)
+    local filtered = {}
+    for _, e in ipairs(entities) do
+        if e.properties.status == status then
+            table.insert(filtered, {
+                id = e.id,
+                title = e.properties.title,
+                priority = e.properties.priority
+            })
+        end
+    end
+    -- Return up to limit items
+    local result = {}
+    for i = 1, math.min(limit, #filtered) do
+        table.insert(result, filtered[i])
+    end
+    return result
+end
+
+-- Collect data
+local tickets = rela.list_entities("ticket")
+local bugs = rela.list_entities("bug")
+local features = rela.list_entities("feature")
+local decisions = rela.list_entities("decision")
+local ideas = rela.list_entities("idea")
+
+-- Calculate statistics
+local ticket_stats = count_by_status(tickets)
+local bug_stats = count_by_status(bugs)
+local feature_stats = count_by_status(features)
+
+-- Find active work
+local in_progress_tickets = get_recent(tickets, "in-progress", 10)
+local in_progress_bugs = get_recent(bugs, "in-progress", 5)
+local review_items = get_recent(tickets, "review", 10)
+
+-- Find blockers
+local blocked_tickets = get_recent(tickets, "blocked", 10)
+local blocked_bugs = get_recent(bugs, "blocked", 5)
+
+-- Find ready work (backlog items ready to start)
+local ready_tickets = get_recent(tickets, "ready", 10)
+local ready_bugs = get_recent(bugs, "ready", 5)
+
+-- Count open review responses
+local review_responses = rela.list_entities("review-response")
+local open_reviews = {}
+local critical_reviews = {}
+for _, rr in ipairs(review_responses) do
+    if rr.properties.status == "open" then
+        table.insert(open_reviews, {
+            id = rr.id,
+            title = rr.properties.title,
+            severity = rr.properties.severity
+        })
+        if rr.properties.severity == "critical" then
+            table.insert(critical_reviews, rr)
+        end
+    end
+end
+
+-- Build report
+local report = {
+    summary = {
+        tickets = {
+            total = #tickets,
+            by_status = ticket_stats
+        },
+        bugs = {
+            total = #bugs,
+            by_status = bug_stats
+        },
+        features = {
+            total = #features,
+            by_status = feature_stats
+        },
+        decisions = #decisions,
+        ideas = #ideas
+    },
+    active_work = {
+        in_progress = {
+            tickets = in_progress_tickets,
+            bugs = in_progress_bugs
+        },
+        in_review = review_items
+    },
+    blockers = {
+        tickets = blocked_tickets,
+        bugs = blocked_bugs
+    },
+    ready_to_start = {
+        tickets = ready_tickets,
+        bugs = ready_bugs
+    },
+    code_review = {
+        open_count = #open_reviews,
+        critical_count = #critical_reviews,
+        open_items = open_reviews
+    }
+}
+
+-- Add warnings
+report.warnings = {}
+
+if #critical_reviews > 0 then
+    table.insert(report.warnings, {
+        level = "critical",
+        message = string.format("%d critical review response(s) need attention", #critical_reviews)
+    })
+end
+
+if #blocked_tickets + #blocked_bugs > 0 then
+    table.insert(report.warnings, {
+        level = "warning",
+        message = string.format("%d item(s) are blocked", #blocked_tickets + #blocked_bugs)
+    })
+end
+
+local in_progress_count = #in_progress_tickets + #in_progress_bugs
+if in_progress_count > 5 then
+    table.insert(report.warnings, {
+        level = "info",
+        message = string.format("%d items in progress - consider focusing", in_progress_count)
+    })
+end
+
+rela.output(report)

--- a/tickets/entities/concepts/lua-scripting.md
+++ b/tickets/entities/concepts/lua-scripting.md
@@ -1,0 +1,23 @@
+---
+description: Lua scripting engine using gopher-lua for flexible data extraction and transformation
+id: lua-scripting
+layer: core
+status: draft
+summary: Embedded Lua runtime for programmable extensions
+title: Lua Scripting
+type: concept
+---
+
+# Lua Scripting
+
+Embedded Lua 5.1 runtime (via gopher-lua) providing programmable extensions for rela.
+
+## Use Cases
+
+1. **Programmable Views**: Complex data extraction with arbitrary logic
+2. **Future**: Custom validations, automations, computed properties
+
+## Key Components
+
+- `internal/lua/` - Lua runtime and rela bindings
+- Script files in project `scripts/` directory

--- a/tickets/entities/concepts/sql-interface.md
+++ b/tickets/entities/concepts/sql-interface.md
@@ -1,0 +1,48 @@
+---
+description: Provides a SQL interface to rela graphs using dolthub/go-mysql-server. Entity types become pluralized tables (documents, components), relation types become tables with from_id/to_id columns. Supports SELECT, JOIN, WHERE, COUNT, DESCRIBE, and SHOW TABLES.
+id: sql-interface
+layer: server
+package: internal/sqldb
+status: draft
+summary: MySQL-compatible SQL interface for querying rela graphs
+title: SQL Interface
+type: concept
+---
+
+# SQL Interface
+
+The SQL interface allows querying rela graphs using standard MySQL-compatible SQL syntax.
+
+## Table Mapping
+
+- **Entity tables**: Pluralized entity type names (e.g., `documents`, `components`, `requirements`)
+- **Relation tables**: Relation type names (e.g., `implements`, `affects`, `requires`)
+
+## Entity Table Schema
+
+Each entity table has columns:
+- `id` - Entity ID
+- `title` - Entity title
+- `content` - Markdown body content
+- All defined properties from the metamodel
+
+## Relation Table Schema
+
+Each relation table has columns:
+- `from_id` - Source entity ID
+- `to_id` - Target entity ID
+- `content` - Relation content (if any)
+
+## Supported SQL Features
+
+- `SELECT ... FROM ... WHERE ...`
+- `JOIN` operations across entity and relation tables
+- `COUNT(*)` and other aggregations
+- `DESCRIBE table_name`
+- `SHOW TABLES`
+- `LIMIT` and `OFFSET`
+
+## Access Modes
+
+1. **Network server** (`rela sql --port 3307`): MySQL-compatible server for external clients
+2. **In-process query** (`rela query "SELECT ..."`): Direct query execution without network

--- a/tickets/entities/concepts/views.md
+++ b/tickets/entities/concepts/views.md
@@ -1,0 +1,33 @@
+---
+description: Views define how to traverse the entity graph and shape output for document publishing, context generation, and analysis. Defined in views.yaml.
+id: views
+layer: core
+package: internal/views
+status: stable
+summary: Declarative graph traversals for context generation
+title: Views
+type: concept
+---
+
+# Views
+
+Views are declarative definitions that specify:
+
+1. **Entry point**: Starting entity type and parameter
+2. **Traversal rules**: How to follow relations through the graph
+3. **Filters**: Which entities to include/exclude
+4. **Output structure**: How to shape the result
+
+## Current Implementation
+
+The current view system uses flat collections with implicit type filtering based on collection names. This requires post-processing scripts to:
+- Filter entities to scope (e.g., only components belonging to document's bouwblokken)
+- Build hierarchical structures for document rendering
+- Deduplicate entities that appear via multiple paths
+
+## Key Files
+
+- `internal/views/types.go` - Type definitions
+- `internal/views/engine.go` - Execution engine
+- `internal/views/formatter.go` - Output formatting
+- `internal/views/loader.go` - YAML loading

--- a/tickets/entities/features/FEAT-1hca.md
+++ b/tickets/entities/features/FEAT-1hca.md
@@ -1,0 +1,92 @@
+---
+description: Provides SQL interface to rela graphs via dolthub/go-mysql-server. Supports network server mode (rela sql) and in-process queries (rela query).
+id: FEAT-1hca
+priority: medium
+status: in-progress
+summary: Query rela graphs using MySQL-compatible SQL syntax
+title: SQL Support
+type: feature
+---
+
+# SQL Support
+
+Query rela graphs using familiar SQL syntax instead of the graph-specific API.
+
+## Capabilities
+
+### Table Mapping
+- Entity types become tables with pluralized names (e.g., `documents`, `requirements`)
+- Relation types become tables with `from_id`, `to_id`, `content` columns
+
+### Supported SQL
+- `SELECT ... FROM ... WHERE ...` with all standard operators
+- `JOIN` across entity and relation tables
+- `COUNT(*)` and aggregations
+- `DESCRIBE table_name` - show table schema
+- `SHOW TABLES` - list available tables
+
+### Access Modes
+
+1. **Network Server** (`rela sql --port 3307`)
+   - MySQL-compatible wire protocol
+   - Connect with any MySQL client (mysql, mysqlsh, DBeaver, etc.)
+   - Useful for exploration, dashboards, external tools
+
+2. **In-Process Query** (`rela query "SELECT ..."`)
+   - Direct query without network overhead
+   - Supports `--format json` for scripting
+   - Useful for CLI automation, scripts
+
+## Implementation
+
+Uses [dolthub/go-mysql-server](https://github.com/dolthub/go-mysql-server) which provides:
+- Full MySQL parser and query planner
+- In-memory table implementation
+- MySQL wire protocol server
+
+## Example Queries
+
+```sql
+-- List all documents
+SELECT id, title FROM documents
+
+-- Functions implementing requirements
+SELECT f.id, f.title, r.id as req_id, r.title as req_title
+FROM functions f
+JOIN implements i ON f.id = i.from_id
+JOIN requirements r ON i.to_id = r.id
+
+-- Count entities by type
+SELECT COUNT(*) FROM components WHERE status = 'active'
+
+-- Describe a table
+DESCRIBE requirements
+```
+
+## Testing Requirements
+
+1. **Unit Tests**
+   - Table schema generation from metamodel
+   - Row iteration for entities and relations
+   - Property type mapping to SQL types
+
+2. **Integration Tests**
+   - Basic queries: SELECT, WHERE, LIMIT
+   - JOIN queries across entity/relation tables
+   - Aggregations: COUNT, GROUP BY
+   - Schema introspection: DESCRIBE, SHOW TABLES
+
+3. **Network Server Tests**
+   - Server startup and shutdown
+   - MySQL client connectivity
+   - Concurrent connections
+
+## Current Status
+
+- [x] POC implementation complete
+- [x] Entity and relation tables working
+- [x] Network server mode (`rela sql`)
+- [x] In-process query mode (`rela query`)
+- [ ] Unit test coverage
+- [ ] Integration test coverage
+- [ ] Documentation

--- a/tickets/entities/features/FEAT-i5ji.md
+++ b/tickets/entities/features/FEAT-i5ji.md
@@ -1,0 +1,33 @@
+---
+description: Add Lua scripting capability using gopher-lua to enable programmable views as an alternative to declarative YAML views. Scripts can invoke rela functions to query entities and relations, then produce structured output as JSON.
+id: FEAT-i5ji
+status: proposed
+title: Lua scripting support for programmable views
+type: feature
+---
+
+# Lua Scripting Support
+
+Enable Lua scripts as a flexible alternative to declarative views for complex data extraction scenarios.
+
+## Motivation
+
+The current view system is declarative (YAML-based), which works well for straightforward traversals but becomes limiting for complex transformations. Lua scripting provides:
+
+- **Flexibility**: Arbitrary logic for filtering, transforming, and aggregating data
+- **Reusability**: Scripts can be shared and parameterized
+- **Extensibility**: Foundation for future scripting use cases (automations, validations, etc.)
+
+## Core Capabilities
+
+1. **Entity Access**: Query entities by type, ID, or filter expressions
+2. **Relation Traversal**: Navigate the graph programmatically
+3. **Parameter Input**: Accept parameters when invoking scripts
+4. **Structured Output**: Produce JSON-serializable data structures
+
+## Open Questions
+
+- **Output API**: Should scripts return a value (rela serializes) or call an output function (imperative)?
+- **Script Location**: Where do scripts live? (`scripts/` directory? inline in views.yaml?)
+- **Error Handling**: How to surface Lua errors to users?
+- **Sandboxing**: Which Lua standard libraries to expose?

--- a/tickets/entities/features/FEAT-qos.md
+++ b/tickets/entities/features/FEAT-qos.md
@@ -1,0 +1,141 @@
+---
+id: FEAT-qos
+priority: high
+status: proposed
+summary: Redesign view system where query structure mirrors output structure, with JSONPath-based scope filtering
+title: Query-as-Output-Structure View System
+type: feature
+---
+
+# Query-as-Output-Structure View System
+
+Redesign the view system so the YAML query structure directly mirrors the output structure. Uses JSONPath for scope filtering.
+
+## Problem
+
+The current view system has several issues:
+
+1. **No type filtering on collect** - must manually filter by entity type in post-processing
+2. **No scope filtering** - can't express "only include components belonging to document's bouwblokken"
+3. **No relation filters** - can't filter based on relation properties
+4. **Flat collections** - output doesn't match document rendering needs
+5. **Output structure unclear** - must trace all traverse rules to understand what gets collected
+
+## Solution
+
+Query-as-Output-Structure: the YAML query tree IS the output structure.
+
+```yaml
+views:
+  document_publish:
+    query:
+      $:  # Root (entry)
+        type: document
+        
+        bouwbloks:
+          via: describesBouwblok
+          
+          functions:
+            via_incoming: partOfBouwblok
+            type: function
+            
+            components:
+              via_incoming: realizes
+              type: component
+              
+              dependencies:
+                via: dependsOn
+                recursive: 5
+                type: component
+                # JSONPath scope filter
+                require:
+                  partOfBouwblok: $.bouwbloks[*].id
+```
+
+Output mirrors query:
+```yaml
+entry:
+  id: DOC-001
+  bouwbloks:
+    - id: BB-001
+      functions:
+        - id: FUNC-001
+          components:
+            - id: COMP-001
+              dependencies:
+                - id: COMP-002
+```
+
+## Key Features
+
+| Feature | Syntax |
+|---------|--------|
+| Follow outgoing relation | `via: relationName` |
+| Follow incoming relation | `via_incoming: relationName` |
+| Type filter | `type: entityType` |
+| Property filter | `where: "status=active"` |
+| Recursive traversal | `recursive: 5` (max depth) |
+| Select properties | `only: [id, title]` |
+| Scope constraint | `require: { partOfBouwblok: $.bouwbloks[*].id }` |
+
+## Defaults
+
+- All properties included by default (use `only:` to limit)
+- Content included by default (use `content: false` to exclude)
+- Relations included by default
+
+## JSONPath for Scope Filtering
+
+Use standard JSONPath (RFC 9535) syntax:
+
+| Syntax | Meaning |
+|--------|---------|
+| `$` | Root |
+| `$.bouwbloks` | Bouwbloks collection at root |
+| `$.bouwbloks[*].id` | All bouwblok IDs |
+| `$..components` | All components anywhere in tree |
+| `[?@.status=='active']` | Filter expression |
+
+Benefits:
+- Well-documented standard
+- Use existing Go library (ohler55/ojg)
+- No custom parser to maintain
+
+## Two-Pass Execution
+
+1. **Pass 1 (Collect)**: Traverse graph, build output tree without filtering
+2. **Pass 2 (Filter)**: Apply `require` clauses using JSONPath, top-down until stable
+
+This allows siblings to reference each other regardless of YAML order.
+
+Validation:
+- Error if JSONPath references non-existent collection
+- Warn if JSONPath matches nothing at runtime
+
+## Entity Map
+
+Auto-generated flat map of all collected entities for lookup:
+
+```yaml
+entry:
+  # ... hierarchical structure
+
+entities:
+  COMP-001: { id: COMP-001, type: component, ... }
+  COMP-002: { id: COMP-002, type: component, ... }
+```
+
+## Migration
+
+This replaces the current traverse/filter model. Existing views.yaml files will need rewriting, but the new format is more intuitive and self-documenting.
+
+## Implementation Steps
+
+1. Define new YAML schema types
+2. Implement two-pass engine (collect + filter)
+3. Integrate JSONPath library (ohler55/ojg)
+4. Add validation (JSONPath references, type existence)
+5. Update formatter for hierarchical output
+6. Update MCP tools and CLI
+7. Migrate example views
+8. Update documentation

--- a/tickets/entities/implementation-checklists/IMPL-3af8.md
+++ b/tickets/entities/implementation-checklists/IMPL-3af8.md
@@ -1,0 +1,32 @@
+---
+id: IMPL-3af8
+status: in-progress
+title: 'Implementation: Implement v2 view engine with two-pass execution'
+type: implementation-checklist
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-mv5o.md
+++ b/tickets/entities/implementation-checklists/IMPL-mv5o.md
@@ -1,0 +1,52 @@
+---
+id: IMPL-mv5o
+status: done
+title: 'Implementation: Define YAML schema types for Query-as-Output-Structure views'
+type: implementation-checklist
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] ~~Integration tests written (test full flow, not just units)~~ (N/A: pure data structures, no integration needed)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+1. **Root entry_type/param**: `TestQueryNode_RootFields` - PASS
+2. **Nested relations 3+ levels**: `TestQueryNode_NestedRelations` - PASS (4 levels)
+3. **Traversal options**: `TestQueryNode_ViaOutgoing`, `TestQueryNode_ViaIncoming`, `TestQueryNode_TypesFilterSingle/Multiple`, `TestQueryNode_Recursive` - PASS
+4. **Require with JSONPath**: `TestQueryNode_RequireWithJSONPath`, `TestQueryNode_RequireMultipleRelations` - PASS
+5. **Output controls**: `TestQueryNode_OnlyProperties`, `TestQueryNode_ContentFalse/Default`, `TestQueryNode_PropsFalse/Default` - PASS
+6. **V1 compatibility**: `TestIsV2Format` confirms v1 detection works - PASS
+7. **Complex example**: `TestQueryNode_ComplexExample` tests realistic use case - PASS
+
+All 26 tests pass:
+```
+go test ./internal/views/... -v
+ok  	github.com/Sourcehaven-BV/rela/internal/views	1.358s
+```
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+**Files created:**
+- `internal/views/types_v2.go` - New types (QueryNode, ViewDefV2, FileV2)
+- `internal/views/types_v2_test.go` - Comprehensive tests
+
+**Files modified:**
+- `internal/views/loader.go` - Added LoadV2, ParseV2, IsV2Format functions

--- a/tickets/entities/implementation-checklists/IMPL-p72e.md
+++ b/tickets/entities/implementation-checklists/IMPL-p72e.md
@@ -1,0 +1,32 @@
+---
+id: IMPL-p72e
+status: in-progress
+title: 'Implementation: Add Lua scripting support via gopher-lua'
+type: implementation-checklist
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-tsxk.md
+++ b/tickets/entities/implementation-checklists/IMPL-tsxk.md
@@ -1,0 +1,34 @@
+---
+id: IMPL-tsxk
+status: done
+title: 'Implementation: Add SQL query tool to MCP server'
+type: implementation-checklist
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+- All 6 SQL tests pass (SELECT, WHERE, JOIN, SHOW TABLES, invalid SQL, missing query)
+- `just lint` passes
+- `just test` passes - all 36 packages pass
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-aqye.md
+++ b/tickets/entities/planning-checklists/PLAN-aqye.md
@@ -1,0 +1,140 @@
+---
+id: PLAN-aqye
+status: done
+title: 'Planning: Add SQL query tool to MCP server'
+type: planning-checklist
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN SCOPE:
+- Add `sql_query` tool to MCP server that executes SQL queries against the rela graph
+- Return structured results (columns + rows) in JSON format
+- Support all SQL features the underlying go-mysql-server engine supports
+
+OUT OF SCOPE:
+- Write operations (INSERT, UPDATE, DELETE) - this is read-only
+- Custom SQL functions
+- Schema modification commands
+
+**Acceptance Criteria:**
+
+1. MCP tool `sql_query` accepts a `query` parameter with SQL
+2. Returns results with `columns` array and `rows` array of arrays
+3. Supports SELECT, JOIN, WHERE, GROUP BY, ORDER BY, LIMIT
+4. Returns clear error messages for invalid SQL
+5. Works with all entity tables and relation tables
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+- `internal/sqldb/query.go:23` - `Query()` function already exists that takes a graph, metamodel, and SQL string
+- `internal/sqldb/query.go:16-20` - `QueryResult` struct with `Columns []string` and `Rows [][]interface{}`
+- Other MCP tools follow pattern in `internal/mcp/tools.go` - register tool definition + handler
+- Example: `toolExport()` in `tools.go:242-248` and `handleExport()` in `tools_export.go`
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+1. Add `sqldb` to mcp's `mayDependOn` in `.go-arch-lint.yml`
+2. Create `internal/mcp/tools_sql.go` with:
+   - `toolSQLQuery()` - tool definition with `query` required string parameter
+   - `handleSQLQuery()` - handler that calls `sqldb.Query()` and formats result
+3. Register tool in `tools.go` under "SQL tools" section
+4. Result format: `{"columns": [...], "rows": [[...], [...]], "row_count": N}`
+
+**Alternatives Considered:**
+- Expose via workspace layer first: Rejected - sqldb.Query already has clean interface, no need for indirection
+- Add to existing export tool: Rejected - SQL is fundamentally different from export
+
+**Files to modify:**
+- `.go-arch-lint.yml` - add sqldb to mcp dependencies
+- `internal/mcp/tools.go` - register new tool
+- `internal/mcp/tools_sql.go` - new file with tool definition and handler
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- `query` parameter: SQL string from MCP client (AI assistant)
+- Validation: go-mysql-server parses and validates SQL syntax
+- Invalid input: Returns SQL parse error message (safe - no internal paths exposed)
+
+**Security-Sensitive Operations:**
+
+- Read-only queries only - go-mysql-server memory tables don't support writes
+- No file system access - queries only read in-memory graph
+- No authentication bypass - MCP already runs in-process with full access
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+1. Basic SELECT: `SELECT id, title FROM requirements` → returns columns and rows
+2. JOIN query: `SELECT r.id, c.title FROM requirements r JOIN implements i ON r.id = i.to_id JOIN components c ON i.from_id = c.id`
+3. WHERE filter: `SELECT * FROM tickets WHERE status = 'open'`
+4. Aggregation: `SELECT COUNT(*) FROM components`
+5. ORDER BY + LIMIT: `SELECT id FROM features ORDER BY title LIMIT 5`
+
+**Edge Cases:**
+
+- Empty result set → returns `{"columns": [...], "rows": [], "row_count": 0}`
+- Query with no tables in graph → returns empty result
+- Very long query string → should handle gracefully
+- SQL with comments → should work
+
+**Negative Tests:**
+
+- Invalid SQL syntax → error message with parse failure
+- Non-existent table → error message "table not found"
+- Missing required `query` parameter → error message "query is required"
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- Low risk: Simple integration using existing `sqldb.Query()` function
+- Mitigation for query errors: Wrap in try-catch, return user-friendly error
+
+Effort: **S** (small) - straightforward integration
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: simple integration, no complex design)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** N/A - This is a simple tool registration following existing patterns. No architectural decisions required.

--- a/tickets/entities/planning-checklists/PLAN-jc0p.md
+++ b/tickets/entities/planning-checklists/PLAN-jc0p.md
@@ -1,0 +1,198 @@
+---
+id: PLAN-jc0p
+status: done
+title: 'Planning: Define YAML schema types for Query-as-Output-Structure views'
+type: planning-checklist
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN SCOPE:
+- Define Go types for query-as-output-structure format
+- Support traversal: `via`, `via_incoming`, `types` (list), `recursive`
+- Support filtering: `where`, `require` (JSONPath strings stored, not evaluated)
+- Support output control: `only`, `content`, `props`
+- Explicit `relations:` block for children (no custom unmarshal needed)
+- Coexist with existing `ViewDef` type
+
+OUT OF SCOPE:
+- Engine implementation (evaluating the query)
+- JSONPath parsing/evaluation
+- CLI/MCP changes
+- Migration tooling
+- Validation against metamodel
+
+**Acceptance Criteria:**
+
+1. Can unmarshal a view with entry_type and param at root level
+2. Can unmarshal nested relations (3+ levels deep)
+3. Can unmarshal all traversal options (`via`, `via_incoming`, `types`, `recursive`)
+4. Can unmarshal `require` with JSONPath strings
+5. Can unmarshal output controls (`only`, `content`, `props`)
+6. Existing views.yaml files continue to work (no breaking changes)
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+With explicit `relations:` block, standard Go YAML unmarshaling handles recursion automatically via `map[string]*QueryNode`. No custom unmarshal needed.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+```go
+// QueryNode represents a node in the query tree
+type QueryNode struct {
+    // Entry point (root only)
+    EntryType string `yaml:"entry_type,omitempty"`
+    Param     string `yaml:"param,omitempty"`
+    
+    // Traversal
+    Via         string   `yaml:"via,omitempty"`
+    ViaIncoming string   `yaml:"via_incoming,omitempty"`
+    Types       []string `yaml:"types,omitempty"`
+    Recursive   int      `yaml:"recursive,omitempty"`
+    
+    // Filtering
+    Where   string            `yaml:"where,omitempty"`
+    Require map[string]string `yaml:"require,omitempty"`
+    
+    // Output control
+    Only    []string `yaml:"only,omitempty"`
+    Content *bool    `yaml:"content,omitempty"`
+    Props   *bool    `yaml:"props,omitempty"`
+    
+    // Children
+    Relations map[string]*QueryNode `yaml:"relations,omitempty"`
+}
+
+// ViewDefV2 is the new view format (root IS a QueryNode)
+type ViewDefV2 struct {
+    QueryNode `yaml:",inline"`
+    Description string `yaml:"description,omitempty"`
+}
+```
+
+**Example YAML:**
+
+```yaml
+views:
+  document_publish:
+    description: "Complete context for document publishing"
+    entry_type: document
+    param: doc_id
+    
+    relations:
+      bouwbloks:
+        via: describesBouwblok
+        
+        relations:
+          functions:
+            via_incoming: partOfBouwblok
+            types: [function]
+            
+            relations:
+              components:
+                via_incoming: realizes
+                types: [component]
+                recursive: 5
+                require:
+                  partOfBouwblok: $.bouwbloks[*].id
+```
+
+**Example Output:**
+
+```yaml
+entry:
+  id: DOC-001
+  type: document
+  props:
+    title: "My Document"
+    status: draft
+  content: "..."
+  
+  relations:
+    bouwbloks:
+      - id: BB-001
+        props:
+          title: "Bouwblok Core"
+        relations:
+          functions:
+            - id: FUNC-001
+              props:
+                title: "Publish API"
+```
+
+**Files to modify:**
+
+- `internal/views/types_v2.go` (NEW) - New types
+- `internal/views/types_v2_test.go` (NEW) - Tests
+- `internal/views/loader.go` - Add detection of v2 format
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+No security concerns - pure data structure definition.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios:**
+
+| Criterion | Test |
+|-----------|------|
+| Root entry_type/param | `TestQueryNode_RootFields` |
+| Nested relations | `TestQueryNode_NestedRelations` |
+| Traversal options | `TestQueryNode_TraversalOptions` |
+| Require with JSONPath | `TestQueryNode_Require` |
+| Output controls | `TestQueryNode_OutputControls` |
+| V1 compatibility | `TestFile_ParseV1Compatible` |
+
+**Edge Cases:**
+
+- Empty relations map (leaf node)
+- `recursive: 0` vs not set
+- `types: []` empty vs not set
+- `content: false` vs not set (default true)
+- `props: false` vs not set (default true)
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Effort estimated
+
+**Effort:** S (small) - simplified by using explicit `relations:` block
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: simple data structures, no complex logic)
+- [x] ~~All critical/significant findings addressed in plan~~ (N/A)
+
+**Design Review Findings:** Skipped - this is straightforward type definitions with no complex logic to review.

--- a/tickets/entities/planning-checklists/PLAN-mi7j.md
+++ b/tickets/entities/planning-checklists/PLAN-mi7j.md
@@ -1,0 +1,291 @@
+---
+id: PLAN-mi7j
+status: done
+title: 'Planning: Add Lua scripting support via gopher-lua'
+type: planning-checklist
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+**IN scope:**
+- Lua runtime integration via gopher-lua
+- New `internal/lua` package with rela bindings
+- CLI command `rela script <file.lua> [args...]`
+- Imperative output API (`rela.output()`, `rela.write_file()`)
+- Entity/relation query functions exposed to Lua
+- Full Lua stdlib (security not a concern per user)
+- Scripts located in project `scripts/` directory (convention)
+
+**OUT of scope:**
+- MCP tool for script execution (future ticket)
+- Watch mode / live reload
+- Script caching / precompilation
+- Inline scripts in views.yaml
+- Custom metamodel validation via Lua (future use case)
+
+**Acceptance Criteria:**
+
+1. **AC1**: `rela script test.lua` executes a Lua script and exits with code 0 on success
+   - Test: Create script that calls `rela.output({status="ok"})`, verify JSON stdout
+
+2. **AC2**: Scripts can query entities via `rela.get_entity(id)` returning a Lua table
+   - Test: Script fetches known entity, verifies id/type/properties are accessible
+
+3. **AC3**: Scripts can list entities via `rela.list_entities(type, filter?)` 
+   - Test: Script lists all "ticket" entities, filters by `status=done`, verifies count
+
+4. **AC4**: Scripts can query relations via `rela.get_relations(from?, type?, to?)`
+   - Test: Script gets all "implements" relations, verifies from/type/to fields
+
+5. **AC5**: Scripts can write files via `rela.write_file(path, content)`
+   - Test: Script writes temp file, verify file exists with correct content
+
+6. **AC6**: Script errors are surfaced with file/line information
+   - Test: Script with syntax error shows "script.lua:5: unexpected symbol"
+
+7. **AC7**: Script arguments accessible via `rela.args` table
+   - Test: `rela script test.lua foo bar` → `rela.args = {"foo", "bar"}`
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+**Library: gopher-lua (github.com/yuin/gopher-lua)**
+- Pros: Pure Go, no CGO, Lua 5.1 compatible, well-maintained, good docs
+- Pros: Easy to embed, simple function registration API
+- Cons: Lua 5.1 only (not 5.3/5.4) - acceptable for our needs
+- Decision: **Use this** - it's the de facto standard for Go+Lua
+
+**Codebase patterns:**
+- CLI command pattern: `internal/cli/export.go` - file processing, JSON output
+- Workspace access: `internal/cli/root.go:30-40` - shared `ws`, `meta`, `out` vars
+- Entity filtering: `internal/filter/filter.go` - `Parse()`, `MatchAll()` for filters
+- Output: `internal/output/output.go` - `WriteJSON()`, encoder patterns
+
+**Reference implementations:**
+- Similar approach in other tools: Neovim's Lua API, Redis Lua scripting
+- Pattern: Register module table, expose typed functions, return Lua tables
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+### Package Structure
+
+```
+internal/lua/
+├── runtime.go      # Lua VM lifecycle, script execution
+├── bindings.go     # rela.* function implementations  
+├── convert.go      # Go ↔ Lua type conversion helpers
+└── runtime_test.go # Unit tests
+```
+
+### Core Types
+
+```go
+// Runtime wraps gopher-lua VM with rela bindings
+type Runtime struct {
+    L       *lua.LState
+    ws      *workspace.Workspace
+    meta    *metamodel.Metamodel
+    stdout  io.Writer  // for rela.output()
+}
+
+// New creates a Runtime with rela bindings registered
+func New(ws *workspace.Workspace, meta *metamodel.Metamodel, stdout io.Writer) *Runtime
+
+// RunFile executes a Lua script file with arguments
+func (r *Runtime) RunFile(path string, args []string) error
+
+// Close releases Lua VM resources
+func (r *Runtime) Close()
+```
+
+### Lua API Surface
+
+```lua
+-- Entity access
+entity = rela.get_entity("TKT-001")        -- returns table or nil
+entities = rela.list_entities("ticket")    -- returns array of tables
+entities = rela.list_entities("ticket", "status=done")  -- with filter
+
+-- Relation access  
+relations = rela.get_relations()                    -- all relations
+relations = rela.get_relations({from="TKT-001"})    -- filter by from
+relations = rela.get_relations({type="implements"}) -- filter by type
+
+-- Graph traversal
+trace = rela.trace_from("TKT-001", 2)  -- trace outgoing, max depth 2
+trace = rela.trace_to("TKT-001")       -- trace incoming, unlimited
+
+-- Output
+rela.output(data)                -- JSON encode to stdout
+rela.write_file("out.json", json.encode(data))  -- write file
+
+-- Context
+rela.args          -- table of CLI arguments
+rela.project_root  -- project root path
+```
+
+### Entity Table Structure (Lua)
+
+```lua
+entity = {
+    id = "TKT-001",
+    type = "ticket",
+    properties = {
+        title = "Fix bug",
+        status = "done",
+        priority = "high"
+    },
+    content = "Markdown body..."
+}
+```
+
+### CLI Command
+
+```go
+// internal/cli/script.go
+var scriptCmd = &cobra.Command{
+    Use:   "script <file.lua> [args...]",
+    Short: "Execute a Lua script against the graph",
+    Args:  cobra.MinimumNArgs(1),
+    RunE: func(cmd *cobra.Command, args []string) error {
+        runtime := lua.New(ws, meta, os.Stdout)
+        defer runtime.Close()
+        return runtime.RunFile(args[0], args[1:])
+    },
+}
+```
+
+**Alternatives considered:**
+
+1. **JavaScript via goja** - Rejected: Larger runtime, more complex API
+2. **Starlark (Python subset)** - Rejected: Less familiar syntax, fewer users
+3. **Expression language only** - Rejected: Too limited for complex transformations
+4. **Return value instead of imperative** - Rejected per user: less flexible
+
+**Files to modify:**
+
+| File | Change |
+|------|--------|
+| `internal/lua/runtime.go` | NEW: Lua VM wrapper |
+| `internal/lua/bindings.go` | NEW: rela.* function implementations |
+| `internal/lua/convert.go` | NEW: Go ↔ Lua type conversion |
+| `internal/lua/runtime_test.go` | NEW: Unit tests |
+| `internal/cli/script.go` | NEW: CLI command |
+| `.go-arch-lint.yml` | ADD: lua component and deps |
+| `go.mod` | ADD: gopher-lua dependency |
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+| Input | Source | Validation | On Invalid |
+|-------|--------|------------|------------|
+| Script path | CLI arg | File exists, readable | Error with path |
+| Script args | CLI args | None (passthrough) | N/A |
+| Filter expressions | Script | Use existing filter.Parse() | Lua error |
+| Entity IDs | Script | Graph lookup (not found = nil) | Return nil |
+| Output file path | Script | Relative to project root | Error |
+
+**Security-Sensitive Operations:**
+
+Per user: "Security is not of concern at this point (tools run locally with trusted data, rela already has options to execute commands)."
+
+- Full Lua stdlib enabled (including `io`, `os`)
+- File writes allowed anywhere (user's responsibility)
+- No sandboxing required
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Test | Approach |
+|----|------|----------|
+| AC1 | Script execution | Unit: RunFile returns nil on success |
+| AC2 | get_entity | Unit: Mock workspace, verify table fields |
+| AC3 | list_entities | Unit: Filter expression passed to filter.Parse |
+| AC4 | get_relations | Unit: Verify from/type/to filtering |
+| AC5 | write_file | Unit: Write to temp dir, verify content |
+| AC6 | Error reporting | Unit: Syntax error includes line number |
+| AC7 | Args passing | Unit: Verify rela.args table |
+
+**Integration test:**
+- Create test project with entities in `internal/lua/testdata/`
+- Script that queries entities, filters, outputs JSON
+- Verify JSON output matches expected
+
+**Edge Cases:**
+
+| Case | Expected Behavior |
+|------|-------------------|
+| Empty script | No output, exit 0 |
+| Script not found | Error: "script not found: path" |
+| Entity not found | `rela.get_entity()` returns nil |
+| Invalid filter syntax | Lua error with filter parse message |
+| Empty entity list | Returns empty table `{}` |
+| Circular relations in trace | Handled by existing trace logic |
+| Very large output | Works (streaming not required for v1) |
+| Unicode in properties | Preserved correctly |
+
+**Negative Tests:**
+
+| Test | Input | Expected |
+|------|-------|----------|
+| Missing script | `rela script` | Usage error |
+| Script syntax error | `print(` | Error with line number |
+| Runtime error | `error("boom")` | Error with message |
+| Unknown function | `rela.foo()` | "attempt to call nil" |
+| Wrong arg type | `rela.get_entity(123)` | Type error message |
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| gopher-lua API learning curve | Low | Medium | Good docs, simple use case |
+| Type conversion complexity | Medium | Medium | Start with basic types, iterate |
+| Performance with large graphs | Low | Low | Lua is fast, workspace caches |
+
+**Effort:** L (large) - New package, new dependency, multiple binding functions
+
+## Design Review
+
+- [ ] Run `/design-review` before starting implementation
+- [ ] All critical/significant findings addressed in plan
+
+**Design Review Findings:** <!-- To be filled after /design-review -->

--- a/tickets/entities/review-checklists/REV-325e.md
+++ b/tickets/entities/review-checklists/REV-325e.md
@@ -1,0 +1,50 @@
+---
+id: REV-325e
+status: done
+title: 'Review: Define YAML schema types for Query-as-Output-Structure views'
+type: review-checklist
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-f6nc (critical - validation), RR-zjlv (significant - child validation), RR-ygyq (significant - ViewNames ordering), RR-qnl5 (minor - edge case tests)
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+- PASS: QueryNode struct with all fields - verified by TestQueryNode_* tests
+- PASS: ViewDefV2 struct with Description - verified by TestViewDefV2_Unmarshal
+- PASS: FileV2 struct with Views map - verified by TestFileV2_Unmarshal
+- PASS: Helper methods (IncludeContent, IncludeProps, IsRecursive, HasChildren, IsRoot) - verified by dedicated tests
+- PASS: YAML unmarshaling works correctly - verified by all unmarshal tests
+- PASS: Validation against metamodel - verified by TestViewDefV2_Validate_* and TestQueryNode_ValidateAsChild_* tests
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (except Rela Tickets which requires ticket files in branch)
+- [x] PR URL documented below
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/248

--- a/tickets/entities/review-checklists/REV-hnz9.md
+++ b/tickets/entities/review-checklists/REV-hnz9.md
@@ -1,0 +1,54 @@
+---
+id: REV-hnz9
+status: done
+title: 'Review: Add Lua scripting support via gopher-lua'
+type: review-checklist
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`) - 68.1% for new lua package
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** Code review findings addressed inline:
+- Path validation for `write_file` (security fix)
+- Empty entity type validation
+- Array size limits in `luaTableToGo`
+- Nil handling for trace functions
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+- PASS: `rela script` command works - tested with tickets project (48 entities counted)
+- PASS: Entity queries work - `rela.list_entities()`, `rela.get_entity()` tested
+- PASS: Relation queries work - `rela.get_relations()` tested
+- PASS: Trace functions work - `rela.trace_from()`, `rela.trace_to()` tested
+- PASS: Output works - JSON output to stdout verified
+- PASS: File writing works within project root only
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass (waiting for CI)
+- [x] PR URL documented below
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/252

--- a/tickets/entities/review-checklists/REV-tolp.md
+++ b/tickets/entities/review-checklists/REV-tolp.md
@@ -1,0 +1,48 @@
+---
+id: REV-tolp
+status: in-progress
+title: 'Review: Add SQL query tool to MCP server'
+type: review-checklist
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] ~~Coverage maintained~~ (coverage-ignore on MCP handlers)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-pzwh, RR-k5mp, RR-pq3p, RR-7mu4 (all addressed)
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+- PASS: sql_query tool accepts SQL and returns structured JSON
+- PASS: Entity/relation tables exposed with correct pluralization
+- PASS: SHOW TABLES and DESCRIBE work
+- PASS: Error handling for invalid SQL
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- pending -->

--- a/tickets/entities/review-checklists/REV-wv71.md
+++ b/tickets/entities/review-checklists/REV-wv71.md
@@ -1,0 +1,45 @@
+---
+id: REV-wv71
+status: in-progress
+title: 'Review: Implement v2 view engine with two-pass execution'
+type: review-checklist
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g., RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-7mu4.md
+++ b/tickets/entities/review-responses/RR-7mu4.md
@@ -1,0 +1,9 @@
+---
+finding: Code assumes len(result.Columns) == len(row) without verification. Should add defensive check.
+id: RR-7mu4
+resolution: 'Added defensive check in MCP handler: if len(row) != len(result.Columns) return error'
+severity: significant
+status: addressed
+title: Index out of bounds potential
+type: review-response
+---

--- a/tickets/entities/review-responses/RR-f6nc.md
+++ b/tickets/entities/review-responses/RR-f6nc.md
@@ -1,0 +1,9 @@
+---
+finding: V1 has validation.go but v2 has none. Root node must have entry_type but this is not validated. This is a critical gap - invalid view definitions will cause runtime errors rather than clear error messages.
+id: RR-f6nc
+resolution: Added validation_v2.go with Validate methods for FileV2, ViewDefV2, and QueryNode. Root nodes must have entry_type and param, child nodes must have via or via_incoming, and all entity/relation types are validated against the metamodel.
+severity: critical
+status: addressed
+title: No validation for v2 types
+type: review-response
+---

--- a/tickets/entities/review-responses/RR-k5mp.md
+++ b/tickets/entities/review-responses/RR-k5mp.md
@@ -1,0 +1,9 @@
+---
+finding: Context parameter is ignored in handleSQLQuery. sqldb.Query creates its own context.Background() that cannot be cancelled, risking resource exhaustion on expensive queries.
+id: RR-k5mp
+resolution: Added context parameter to Query() function and propagated from MCP handler and CLI command
+severity: critical
+status: addressed
+title: No query timeout/context propagation
+type: review-response
+---

--- a/tickets/entities/review-responses/RR-pq3p.md
+++ b/tickets/entities/review-responses/RR-pq3p.md
@@ -1,0 +1,9 @@
+---
+finding: No limit on returned rows. SELECT * FROM large_table could cause memory exhaustion through amplification (each row becomes a map with multiple allocations).
+id: RR-pq3p
+resolution: Added MaxRows=10000 limit with Truncated flag in QueryResult. MCP handler and CLI show truncation warning.
+severity: significant
+status: addressed
+title: No row count limit
+type: review-response
+---

--- a/tickets/entities/review-responses/RR-pzwh.md
+++ b/tickets/entities/review-responses/RR-pzwh.md
@@ -1,0 +1,9 @@
+---
+finding: query.go breaks on EOF or error silently, treating all errors as EOF. If rowIter.Next() returns an actual error, partial results are returned with no indication of failure.
+id: RR-pzwh
+resolution: Changed from 'break // EOF or error' to properly check 'errors.Is(err, io.EOF)' and return error for non-EOF errors
+severity: critical
+status: addressed
+title: Silent error swallowing in row iteration
+type: review-response
+---

--- a/tickets/entities/review-responses/RR-qnl5.md
+++ b/tickets/entities/review-responses/RR-qnl5.md
@@ -1,0 +1,9 @@
+---
+finding: HasChildren() checks len(Relations) but no test verifies behavior when Relations is nil vs empty map.
+id: RR-qnl5
+resolution: Added tests for HasChildren() with nil Relations, empty Relations map, and populated Relations map in validation_v2_test.go.
+severity: minor
+status: addressed
+title: Missing test for nil Relations map
+type: review-response
+---

--- a/tickets/entities/review-responses/RR-ygyq.md
+++ b/tickets/entities/review-responses/RR-ygyq.md
@@ -1,0 +1,9 @@
+---
+finding: ViewNames() iterates over a map which has non-deterministic order. This affects testability and could cause confusing output.
+id: RR-ygyq
+resolution: Added SortedViewNames() method that returns view names in alphabetical order. ViewNames() now delegates to SortedViewNames() for consistent ordering.
+severity: significant
+status: addressed
+title: ViewNames returns unpredictable order
+type: review-response
+---

--- a/tickets/entities/review-responses/RR-zjlv.md
+++ b/tickets/entities/review-responses/RR-zjlv.md
@@ -1,0 +1,9 @@
+---
+finding: Child nodes should NOT have entry_type/param (root-only fields), and non-root nodes must have via or via_incoming. These constraints are documented but not enforced.
+id: RR-zjlv
+resolution: 'Added validateAsChild method that validates: child nodes cannot have entry_type or param (root-only fields), must have exactly one of via or via_incoming, and all references are validated against metamodel.'
+severity: significant
+status: addressed
+title: Child nodes validation missing
+type: review-response
+---

--- a/tickets/entities/tickets/TKT-17qi.md
+++ b/tickets/entities/tickets/TKT-17qi.md
@@ -1,0 +1,41 @@
+---
+effort: l
+id: TKT-17qi
+kind: enhancement
+priority: medium
+status: done
+title: Add Lua scripting support via gopher-lua
+type: ticket
+---
+
+# Add Lua Scripting Support
+
+Integrate the [gopher-lua](https://github.com/yuin/gopher-lua) library to provide Lua scripting capability as an alternative to declarative views.
+
+## Background
+
+The current view system is YAML-based and declarative. For complex data extraction scenarios, a programmable approach offers more flexibility. Lua scripts can:
+
+- Query entities and relations via rela bindings
+- Apply arbitrary filtering and transformation logic
+- Produce structured output (JSON, multiple files, etc.)
+
+## Scope
+
+1. **Lua Runtime Integration**: Add gopher-lua dependency and create `internal/lua` package
+2. **Rela Bindings**: Expose core rela functions to Lua scripts:
+   - `rela.get_entity(id)` - Get entity by ID
+   - `rela.list_entities(type, filter?)` - List entities with optional filter
+   - `rela.get_relations(from?, type?, to?)` - Query relations
+   - `rela.trace_from(id, depth?)` - Trace dependencies
+3. **Output API** (imperative):
+   - `rela.output(data)` - Write JSON to stdout
+   - `rela.write_file(path, content)` - Write to file
+4. **CLI Command**: `rela script <file.lua> [params...]` to execute scripts
+5. **Script Location**: Project `scripts/` directory
+
+## Design Decisions
+
+- **Imperative Output API**: More flexible - supports multiple outputs, file generation, streaming
+- **Full Lua stdlib**: Security not a concern (local tool, trusted data, rela already executes commands)
+- **Scripts in `scripts/` folder**: Convention over configuration

--- a/tickets/entities/tickets/TKT-elbr.md
+++ b/tickets/entities/tickets/TKT-elbr.md
@@ -1,0 +1,24 @@
+---
+effort: s
+id: TKT-elbr
+kind: enhancement
+priority: medium
+status: review
+title: Add SQL query tool to MCP server
+type: ticket
+---
+
+Expose a `sql_query` tool in the MCP server that allows AI assistants to execute SQL queries against the rela graph. This complements existing MCP tools by enabling complex JOINs, aggregations, and flexible filtering using standard SQL syntax.
+
+## Background
+
+The `internal/sqldb` package already provides SQL query functionality via:
+- `sqldb.Query()` for in-process queries
+- Entity tables with pluralized names (requirements, functions, etc.)
+- Relation tables (implements, belongs-to, etc.)
+
+## Scope
+
+- Add `sql_query` tool to MCP server
+- Return results in structured format (columns + rows)
+- Support all SQL features the underlying engine supports

--- a/tickets/entities/tickets/TKT-qoc0.md
+++ b/tickets/entities/tickets/TKT-qoc0.md
@@ -1,0 +1,98 @@
+---
+id: TKT-qoc0
+kind: enhancement
+priority: high
+status: review
+title: Implement v2 view engine with two-pass execution
+type: ticket
+---
+
+# Implement v2 view engine with two-pass execution
+
+Phase 2 of FEAT-qos: implement the execution engine for v2 view definitions.
+
+## Scope
+
+Create the engine that executes v2 view definitions using a two-pass approach:
+1. **Pass 1 (Collect)**: Traverse graph following relations, collecting entities into the hierarchical structure
+2. **Pass 2 (Filter)**: Apply `require` clauses using JSONPath to filter collected entities
+
+## Requirements
+
+1. Implement `EngineV2` type in `internal/views/`
+2. Execute v2 view definitions (QueryNode tree)
+3. Traverse relations following `via` and `via_incoming`
+4. Filter by entity types (`types: [...]`)
+5. Support recursive traversal with depth limit
+6. Apply property filters (`where: "..."`)
+7. Integrate JSONPath library (ohler55/ojg) for `require` clause evaluation
+8. Build hierarchical output that mirrors input structure
+9. Generate flat entity map for lookups
+10. Handle cycles in graph traversal
+
+## Out of Scope
+
+- CLI/MCP integration (separate ticket)
+- Migration tooling for v1 -> v2
+- Performance optimization
+
+## Acceptance Criteria
+
+- [x] Engine executes basic v2 view (entry + single relation)
+- [x] Type filtering works (`types: [function]`)
+- [x] Recursive traversal respects depth limit
+- [x] Property filter (`where`) works
+- [x] JSONPath `require` filters entities correctly
+- [x] Two-pass execution handles cross-references
+- [x] Output structure mirrors input query structure
+- [x] Entity deduplication works correctly
+
+## Implementation Notes
+
+### Pass 1 (Collect) - Completed
+
+The collect pass is fully implemented in `internal/views/engine_v2.go`:
+
+- `EngineV2` struct with `graph` and `meta` fields
+- `Execute()` method validates entry and kicks off collection
+- `collectEntity()` builds hierarchical output for each entity
+- `collectChildren()` follows relations (via/via_incoming), applies filters
+- `collectRecursive()` handles recursive traversal with depth tracking
+- `followOutgoing()`/`followIncoming()` traverse edges
+- `filterByTypes()` filters by entity type
+- `filterByWhere()` filters by property expression
+- `buildRelationRefs()` builds relation references for output
+
+### Pass 2 (Filter) - Completed
+
+JSONPath filtering (`require` clauses) implemented in `internal/views/filter_v2.go`:
+
+- `buildJSONData()` / `entityToMap()` convert result to JSON-like structure
+- `evaluateJSONPath()` evaluates JSONPath expressions using ohler55/ojg
+- `extractIDs()` extracts IDs from JSONPath results
+- `filterByRequire()` filters entities based on relation constraints
+- `applyRequireFiltersRecursive()` applies filters throughout the tree
+- `hasRequireClauses()` detects if filtering is needed
+
+### Output Structure
+
+- `ResultV2`: Contains `Entry` (root entity) and `EntityMap` (flat map of all entities)
+- `EntityResultV2`: Hierarchical entity with `Children` map for nested relations
+- Structure mirrors the query structure exactly
+
+### CLI Integration - Completed
+
+- `LoadViewsAuto()` detects v1 vs v2 format automatically
+- `IsV2Format()` checks for `entry_type` field (v2) vs `entry.type` (v1)
+- `view` command calls appropriate engine based on format
+- `FormatV2()` formats results as JSON or YAML
+
+### Files Created/Modified
+
+- `internal/views/engine_v2.go` - Core v2 engine
+- `internal/views/engine_v2_test.go` - Comprehensive tests
+- `internal/views/filter_v2.go` - JSONPath filtering
+- `internal/views/formatter.go` - Added FormatV2()
+- `internal/repository/repository.go` - Added LoadViewsV2, LoadViewsAuto
+- `internal/workspace/workspace.go` - Added v2 workspace methods
+- `internal/cli/view.go` - CLI auto-detection for v1/v2

--- a/tickets/entities/tickets/TKT-sxcv.md
+++ b/tickets/entities/tickets/TKT-sxcv.md
@@ -1,0 +1,33 @@
+---
+id: TKT-sxcv
+kind: enhancement
+priority: high
+status: done
+title: Define YAML schema types for Query-as-Output-Structure views
+type: ticket
+---
+
+# Define YAML schema types for Query-as-Output-Structure views
+
+First phase of FEAT-qos: define the new Go types for the query-as-structure view format.
+
+## Scope
+
+Create new type definitions in `internal/views/` that represent the query-as-output-structure format. This is schema definition only - no engine implementation yet.
+
+## Requirements
+
+1. Define `QueryNode` type representing a node in the query tree
+2. Support all traversal options: `via`, `via_incoming`, `type`, `recursive`
+3. Support filtering: `where`, `require` (JSONPath-based scope filtering)
+4. Support output control: `only`, `content`
+5. Define `ViewDefV2` (or similar) to hold the new format
+6. Add YAML unmarshaling with proper handling of the recursive tree structure
+7. Coexist with existing types (don't break current views yet)
+
+## Out of Scope
+
+- Engine implementation (separate ticket)
+- JSONPath evaluation (separate ticket)
+- Migration of existing views
+- CLI/MCP changes

--- a/tickets/entities/tickets/TKT-tm8t.md
+++ b/tickets/entities/tickets/TKT-tm8t.md
@@ -1,0 +1,78 @@
+---
+effort: m
+id: TKT-tm8t
+kind: enhancement
+priority: medium
+status: in-progress
+title: Implement SQL support with tests
+type: ticket
+---
+
+# Implement SQL support with tests
+
+Complete the SQL interface implementation with proper test coverage and documentation.
+
+## Implementation Plan
+
+### Phase 1: Core Implementation (Done)
+- [x] Create `internal/sqldb` package
+- [x] Implement `Database` type wrapping rela graph
+- [x] Implement `EntityTable` for entity type tables
+- [x] Implement `RelationTable` for relation tables
+- [x] Add `rela sql` command for network server
+- [x] Add `rela query` command for in-process queries
+
+### Phase 2: Unit Tests
+- [ ] `internal/sqldb/database_test.go`
+  - [ ] `TestNewDatabase` - database creation
+  - [ ] `TestGetTableNames` - returns entity and relation tables
+  - [ ] `TestGetTable` - entity tables by pluralized name
+  - [ ] `TestGetTable` - relation tables by name
+  - [ ] `TestPluralize` - pluralization rules
+
+- [ ] `internal/sqldb/entity_table_test.go`
+  - [ ] `TestEntityTableSchema` - columns match metamodel properties
+  - [ ] `TestEntityTablePartitions` - row iteration
+  - [ ] `TestEntityTableFiltering` - WHERE clause support
+
+- [ ] `internal/sqldb/relation_table_test.go`
+  - [ ] `TestRelationTableSchema` - from_id, to_id, content columns
+  - [ ] `TestRelationTablePartitions` - row iteration
+
+- [ ] `internal/sqldb/query_test.go`
+  - [ ] `TestQuery_Select` - basic SELECT
+  - [ ] `TestQuery_Where` - WHERE filtering
+  - [ ] `TestQuery_Join` - JOIN across tables
+  - [ ] `TestQuery_Count` - COUNT aggregation
+  - [ ] `TestQuery_Describe` - DESCRIBE table
+  - [ ] `TestQuery_ShowTables` - SHOW TABLES
+
+### Phase 3: Integration Tests
+- [ ] Test with real metamodel and entities
+- [ ] Test complex JOIN queries
+- [ ] Test error handling for invalid SQL
+
+### Phase 4: Network Server Tests
+- [ ] Server startup/shutdown
+- [ ] MySQL client connection test
+- [ ] Query execution over wire protocol
+
+### Phase 5: Documentation
+- [ ] Update CLAUDE.md with SQL commands
+- [ ] Add examples to CLI help text
+
+## Test Data Setup
+
+Create test fixtures with:
+- Multiple entity types (at least 3)
+- Multiple relation types (at least 2)
+- Various property types (string, enum, integer, boolean)
+- Enough entities for meaningful JOIN tests
+
+## Acceptance Criteria
+
+1. All unit tests pass
+2. Coverage meets baseline requirements
+3. `rela query` works for all documented SQL features
+4. `rela sql` server accepts MySQL client connections
+5. DESCRIBE and SHOW TABLES return correct schema info

--- a/tickets/relations/FEAT-1hca--requires--sql-interface.md
+++ b/tickets/relations/FEAT-1hca--requires--sql-interface.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-1hca
+relation: requires
+to: sql-interface
+---

--- a/tickets/relations/FEAT-drlm--depends-on--FEAT-qos.md
+++ b/tickets/relations/FEAT-drlm--depends-on--FEAT-qos.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-drlm
+relation: depends-on
+to: FEAT-qos
+---

--- a/tickets/relations/FEAT-drlm--requires--views.md
+++ b/tickets/relations/FEAT-drlm--requires--views.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-drlm
+relation: requires
+to: views
+---

--- a/tickets/relations/FEAT-i5ji--requires--lua-scripting.md
+++ b/tickets/relations/FEAT-i5ji--requires--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-i5ji
+relation: requires
+to: lua-scripting
+---

--- a/tickets/relations/FEAT-qos--requires--views.md
+++ b/tickets/relations/FEAT-qos--requires--views.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-qos
+relation: requires
+to: views
+---

--- a/tickets/relations/TKT-17qi--affects--lua-scripting.md
+++ b/tickets/relations/TKT-17qi--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-17qi
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-17qi--affects--views.md
+++ b/tickets/relations/TKT-17qi--affects--views.md
@@ -1,0 +1,5 @@
+---
+from: TKT-17qi
+relation: affects
+to: views
+---

--- a/tickets/relations/TKT-17qi--has-implementation--IMPL-p72e.md
+++ b/tickets/relations/TKT-17qi--has-implementation--IMPL-p72e.md
@@ -1,0 +1,5 @@
+---
+from: TKT-17qi
+relation: has-implementation
+to: IMPL-p72e
+---

--- a/tickets/relations/TKT-17qi--has-planning--PLAN-mi7j.md
+++ b/tickets/relations/TKT-17qi--has-planning--PLAN-mi7j.md
@@ -1,0 +1,5 @@
+---
+from: TKT-17qi
+relation: has-planning
+to: PLAN-mi7j
+---

--- a/tickets/relations/TKT-17qi--has-review--REV-hnz9.md
+++ b/tickets/relations/TKT-17qi--has-review--REV-hnz9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-17qi
+relation: has-review
+to: REV-hnz9
+---

--- a/tickets/relations/TKT-17qi--implements--FEAT-i5ji.md
+++ b/tickets/relations/TKT-17qi--implements--FEAT-i5ji.md
@@ -1,0 +1,5 @@
+---
+from: TKT-17qi
+relation: implements
+to: FEAT-i5ji
+---

--- a/tickets/relations/TKT-elbr--affects--mcp-api.md
+++ b/tickets/relations/TKT-elbr--affects--mcp-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-elbr
+relation: affects
+to: mcp-api
+---

--- a/tickets/relations/TKT-elbr--affects--sql-interface.md
+++ b/tickets/relations/TKT-elbr--affects--sql-interface.md
@@ -1,0 +1,5 @@
+---
+from: TKT-elbr
+relation: affects
+to: sql-interface
+---

--- a/tickets/relations/TKT-elbr--has-implementation--IMPL-tsxk.md
+++ b/tickets/relations/TKT-elbr--has-implementation--IMPL-tsxk.md
@@ -1,0 +1,5 @@
+---
+from: TKT-elbr
+relation: has-implementation
+to: IMPL-tsxk
+---

--- a/tickets/relations/TKT-elbr--has-planning--PLAN-aqye.md
+++ b/tickets/relations/TKT-elbr--has-planning--PLAN-aqye.md
@@ -1,0 +1,5 @@
+---
+from: TKT-elbr
+relation: has-planning
+to: PLAN-aqye
+---

--- a/tickets/relations/TKT-elbr--has-review--REV-tolp.md
+++ b/tickets/relations/TKT-elbr--has-review--REV-tolp.md
@@ -1,0 +1,5 @@
+---
+from: TKT-elbr
+relation: has-review
+to: REV-tolp
+---

--- a/tickets/relations/TKT-elbr--has-review-response--RR-7mu4.md
+++ b/tickets/relations/TKT-elbr--has-review-response--RR-7mu4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-elbr
+relation: has-review-response
+to: RR-7mu4
+---

--- a/tickets/relations/TKT-elbr--has-review-response--RR-k5mp.md
+++ b/tickets/relations/TKT-elbr--has-review-response--RR-k5mp.md
@@ -1,0 +1,5 @@
+---
+from: TKT-elbr
+relation: has-review-response
+to: RR-k5mp
+---

--- a/tickets/relations/TKT-elbr--has-review-response--RR-pq3p.md
+++ b/tickets/relations/TKT-elbr--has-review-response--RR-pq3p.md
@@ -1,0 +1,5 @@
+---
+from: TKT-elbr
+relation: has-review-response
+to: RR-pq3p
+---

--- a/tickets/relations/TKT-elbr--has-review-response--RR-pzwh.md
+++ b/tickets/relations/TKT-elbr--has-review-response--RR-pzwh.md
@@ -1,0 +1,5 @@
+---
+from: TKT-elbr
+relation: has-review-response
+to: RR-pzwh
+---

--- a/tickets/relations/TKT-elbr--implements--FEAT-1hca.md
+++ b/tickets/relations/TKT-elbr--implements--FEAT-1hca.md
@@ -1,0 +1,5 @@
+---
+from: TKT-elbr
+relation: implements
+to: FEAT-1hca
+---

--- a/tickets/relations/TKT-qoc0--affects--views.md
+++ b/tickets/relations/TKT-qoc0--affects--views.md
@@ -1,0 +1,5 @@
+---
+from: TKT-qoc0
+relation: affects
+to: views
+---

--- a/tickets/relations/TKT-qoc0--has-implementation--IMPL-3af8.md
+++ b/tickets/relations/TKT-qoc0--has-implementation--IMPL-3af8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-qoc0
+relation: has-implementation
+to: IMPL-3af8
+---

--- a/tickets/relations/TKT-qoc0--has-review--REV-wv71.md
+++ b/tickets/relations/TKT-qoc0--has-review--REV-wv71.md
@@ -1,0 +1,5 @@
+---
+from: TKT-qoc0
+relation: has-review
+to: REV-wv71
+---

--- a/tickets/relations/TKT-qoc0--implements--FEAT-qos.md
+++ b/tickets/relations/TKT-qoc0--implements--FEAT-qos.md
@@ -1,0 +1,5 @@
+---
+from: TKT-qoc0
+relation: implements
+to: FEAT-qos
+---

--- a/tickets/relations/TKT-sxcv--affects--views.md
+++ b/tickets/relations/TKT-sxcv--affects--views.md
@@ -1,0 +1,5 @@
+---
+from: TKT-sxcv
+relation: affects
+to: views
+---

--- a/tickets/relations/TKT-sxcv--has-implementation--IMPL-mv5o.md
+++ b/tickets/relations/TKT-sxcv--has-implementation--IMPL-mv5o.md
@@ -1,0 +1,5 @@
+---
+from: TKT-sxcv
+relation: has-implementation
+to: IMPL-mv5o
+---

--- a/tickets/relations/TKT-sxcv--has-planning--PLAN-jc0p.md
+++ b/tickets/relations/TKT-sxcv--has-planning--PLAN-jc0p.md
@@ -1,0 +1,5 @@
+---
+from: TKT-sxcv
+relation: has-planning
+to: PLAN-jc0p
+---

--- a/tickets/relations/TKT-sxcv--has-review--REV-325e.md
+++ b/tickets/relations/TKT-sxcv--has-review--REV-325e.md
@@ -1,0 +1,5 @@
+---
+from: TKT-sxcv
+relation: has-review
+to: REV-325e
+---

--- a/tickets/relations/TKT-sxcv--has-review-response--RR-f6nc.md
+++ b/tickets/relations/TKT-sxcv--has-review-response--RR-f6nc.md
@@ -1,0 +1,5 @@
+---
+from: TKT-sxcv
+relation: has-review-response
+to: RR-f6nc
+---

--- a/tickets/relations/TKT-sxcv--has-review-response--RR-qnl5.md
+++ b/tickets/relations/TKT-sxcv--has-review-response--RR-qnl5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-sxcv
+relation: has-review-response
+to: RR-qnl5
+---

--- a/tickets/relations/TKT-sxcv--has-review-response--RR-ygyq.md
+++ b/tickets/relations/TKT-sxcv--has-review-response--RR-ygyq.md
@@ -1,0 +1,5 @@
+---
+from: TKT-sxcv
+relation: has-review-response
+to: RR-ygyq
+---

--- a/tickets/relations/TKT-sxcv--has-review-response--RR-zjlv.md
+++ b/tickets/relations/TKT-sxcv--has-review-response--RR-zjlv.md
@@ -1,0 +1,5 @@
+---
+from: TKT-sxcv
+relation: has-review-response
+to: RR-zjlv
+---

--- a/tickets/relations/TKT-sxcv--implements--FEAT-qos.md
+++ b/tickets/relations/TKT-sxcv--implements--FEAT-qos.md
@@ -1,0 +1,5 @@
+---
+from: TKT-sxcv
+relation: implements
+to: FEAT-qos
+---

--- a/tickets/relations/TKT-tm8t--affects--sql-interface.md
+++ b/tickets/relations/TKT-tm8t--affects--sql-interface.md
@@ -1,0 +1,5 @@
+---
+from: TKT-tm8t
+relation: affects
+to: sql-interface
+---

--- a/tickets/relations/TKT-tm8t--implements--FEAT-1hca.md
+++ b/tickets/relations/TKT-tm8t--implements--FEAT-1hca.md
@@ -1,0 +1,5 @@
+---
+from: TKT-tm8t
+relation: implements
+to: FEAT-1hca
+---


### PR DESCRIPTION
## Summary
- Add Lua scripting via gopher-lua with sandboxed runtime
- Expose rela graph operations (CRUD, tracing, search) to Lua scripts
- Add MCP tools: `lua_eval`, `lua_run`, `lua_list`
- Restrict file writes to `output/` directory for security
- Add schema introspection functions (`get_entity_types`, `get_relation_types`)

## Test plan
- [x] Unit tests for Lua runtime and sandbox
- [x] Tests for write_file restrictions
- [x] Tests for dangerous function removal
- [x] Lint and coverage checks pass