### PR TITLE
fix(lua): harden sandbox and add docs

### DIFF
--- a/docs-project/entities/features/FEAT-lua-scripting.md
+++ b/docs-project/entities/features/FEAT-lua-scripting.md
@@ -1,0 +1,28 @@
+---
+id: FEAT-lua-scripting
+status: published
+summary: Programmable automation and reporting via embedded Lua scripts
+title: Lua Scripting
+type: feature
+---
+
+Rela includes an embedded Lua scripting runtime that provides programmable access to the
+entity graph. Scripts can query, create, update, and delete entities and relations,
+generate reports, perform bulk operations, and export data to custom formats.
+
+## Key Capabilities
+
+- **Query Operations**: Get entities, list by type with filters, search, trace dependencies
+- **Mutation Operations**: Create, update, delete entities and relations
+- **Schema Introspection**: Access entity types, relation types, and property definitions
+- **Output**: JSON output to stdout, file writing to `output/` directory
+- **MCP Integration**: Execute scripts via `lua_eval`, `lua_run`, and `lua_list` tools
+
+## Security Model
+
+The Lua runtime is sandboxed:
+
+- Only safe libraries loaded (string, table, math, coroutine)
+- No `io`, `os`, or `debug` libraries
+- File writes restricted to `output/` directory
+- Scripts in `scripts/` directory only (for `lua_run`)

--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -1,0 +1,325 @@
+---
+audience: advanced
+id: GUIDE-lua-scripting
+order: 10
+status: published
+summary: Programmable automation with embedded Lua
+title: Lua Scripting
+type: guide
+---
+
+Rela includes an embedded Lua scripting runtime for programmable access to the entity graph.
+Scripts can query, mutate, analyze, and export data—enabling automation beyond what's possible
+with the CLI or MCP tools alone.
+
+## Quick Start
+
+### Via MCP (AI Assistants)
+
+```lua
+-- lua_eval: Execute inline Lua code
+local tickets = rela.list_entities("ticket", "status=open")
+rela.output({count = #tickets})
+```
+
+### Via CLI
+
+```bash
+# Run a script file
+rela lua scripts/report.lua
+
+# Pass arguments
+rela lua scripts/migrate.lua --from=v1 --to=v2
+```
+
+### Script Location
+
+Scripts executed via `lua_run` must be in the `scripts/` directory:
+
+```text
+project/
+├── scripts/
+│   ├── report.lua
+│   └── utils/
+│       └── helpers.lua
+├── entities/
+└── metamodel.yaml
+```
+
+## API Reference
+
+### Query Functions
+
+| Function | Description | Returns |
+|----------|-------------|---------|
+| `rela.get_entity(id)` | Get entity by ID | table or nil |
+| `rela.list_entities(type, filter?)` | List entities of a type | table (array) |
+| `rela.search(query, limit?)` | Full-text search | table (array) |
+| `rela.get_relations(opts?)` | Get relations with filters | table (array) |
+| `rela.trace_from(id, depth?)` | Trace outgoing dependencies | table (tree) |
+| `rela.trace_to(id, depth?)` | Trace incoming dependencies | table (tree) |
+| `rela.find_path(from, to)` | Find shortest path | table (array) or nil |
+
+### Mutation Functions
+
+| Function | Description | Returns |
+|----------|-------------|---------|
+| `rela.create_entity(type, props, content?, id?)` | Create entity | table |
+| `rela.update_entity(id, props, content?)` | Update entity | table |
+| `rela.delete_entity(id, cascade?)` | Delete entity | boolean |
+| `rela.create_relation(from, type, to)` | Create relation | table |
+| `rela.delete_relation(from, type, to)` | Delete relation | boolean |
+| `rela.refresh()` | Reload graph from disk | boolean |
+
+### Schema Functions
+
+| Function | Description | Returns |
+|----------|-------------|---------|
+| `rela.get_entity_types()` | Get all entity type definitions | table |
+| `rela.get_relation_types()` | Get all relation type definitions | table |
+
+### Output Functions
+
+| Function | Description |
+|----------|-------------|
+| `rela.output(data)` | Output data as JSON to stdout |
+| `rela.write_file(path, content)` | Write file to `output/` directory |
+
+### Context
+
+| Variable | Description |
+|----------|-------------|
+| `rela.project_root` | Absolute path to project root |
+| `rela.args` | Script arguments (table) |
+
+## Entity Structure
+
+Entities returned by query functions have this structure:
+
+```lua
+{
+    id = "TKT-001",
+    type = "ticket",
+    content = "Markdown body...",
+    properties = {
+        title = "Fix login bug",
+        status = "open",
+        priority = "high"
+    }
+}
+```
+
+## Filter Expressions
+
+The `list_entities` function accepts filter expressions:
+
+```lua
+-- Single value
+rela.list_entities("ticket", "status=open")
+
+-- Multiple values (OR)
+rela.list_entities("ticket", "status=open,in-progress")
+
+-- Not equal
+rela.list_entities("ticket", "priority!=low")
+```
+
+## Examples
+
+### Generate a Report
+
+```lua
+-- Export open tickets as markdown
+local tickets = rela.list_entities("ticket", "status=open")
+
+local lines = {"# Open Tickets", ""}
+for _, t in ipairs(tickets) do
+    table.insert(lines, string.format("- **%s**: %s", t.id, t.properties.title))
+end
+
+rela.write_file("open-tickets.md", table.concat(lines, "\n"))
+rela.output({exported = #tickets})
+```
+
+### Bulk Update
+
+```lua
+-- Close all tickets in a completed sprint
+local sprint = rela.args[1] or "2024-Q1"
+local tickets = rela.list_entities("ticket", "sprint=" .. sprint)
+
+local updated = 0
+for _, t in ipairs(tickets) do
+    if t.properties.status ~= "done" then
+        rela.update_entity(t.id, {status = "cancelled"})
+        updated = updated + 1
+    end
+end
+
+rela.output({sprint = sprint, cancelled = updated})
+```
+
+### Find Orphans
+
+```lua
+-- Find entities with no relations
+local orphans = {}
+local types = rela.get_entity_types()
+
+for name, _ in pairs(types) do
+    local entities = rela.list_entities(name)
+    for _, e in ipairs(entities) do
+        local from = rela.trace_from(e.id, 1)
+        local to = rela.trace_to(e.id, 1)
+        if #from.children == 0 and #to.children == 0 then
+            table.insert(orphans, {
+                id = e.id,
+                type = e.type,
+                title = e.properties.title
+            })
+        end
+    end
+end
+
+rela.output(orphans)
+```
+
+### Create Related Entities
+
+```lua
+-- Create test cases from feature acceptance criteria
+local feature_id = rela.args[1]
+local feature = rela.get_entity(feature_id)
+
+if not feature then
+    error("Feature not found: " .. feature_id)
+end
+
+local created = {}
+for line in feature.content:gmatch("[^\n]+") do
+    if line:match("^%s*[-*]") then
+        local criterion = line:gsub("^%s*[-*]%s*", "")
+        local test = rela.create_entity("test-case", {
+            title = "Verify: " .. criterion,
+            status = "pending"
+        })
+        rela.create_relation(test.id, "verifies", feature_id)
+        table.insert(created, test.id)
+    end
+end
+
+rela.output({feature = feature_id, tests_created = created})
+```
+
+### Traceability Matrix
+
+```lua
+-- Generate requirement-to-test coverage matrix
+local reqs = rela.list_entities("requirement")
+local matrix = {}
+
+for _, req in ipairs(reqs) do
+    local entry = {
+        id = req.id,
+        title = req.properties.title,
+        tests = {},
+        covered = false
+    }
+    
+    local trace = rela.trace_from(req.id, 2)
+    for _, child in ipairs(trace.children) do
+        if child.type == "test-case" then
+            table.insert(entry.tests, child.id)
+        end
+    end
+    
+    entry.covered = #entry.tests > 0
+    table.insert(matrix, entry)
+end
+
+-- Summary
+local total = #matrix
+local covered = 0
+for _, entry in ipairs(matrix) do
+    if entry.covered then covered = covered + 1 end
+end
+
+rela.output({
+    matrix = matrix,
+    summary = {
+        total = total,
+        covered = covered,
+        uncovered = total - covered,
+        coverage_pct = math.floor(covered / total * 100)
+    }
+})
+```
+
+## Security
+
+The Lua runtime is sandboxed for security:
+
+### Available Libraries
+
+- `string` - String manipulation
+- `table` - Table operations
+- `math` - Mathematical functions
+- `coroutine` - Coroutine support
+- Base functions: `print`, `pairs`, `ipairs`, `type`, `tostring`, `tonumber`, `error`, `pcall`,
+  `assert`, `select`, `next`, `unpack`
+
+### Unavailable (Security)
+
+- `io` - No direct file system access
+- `os` - No system commands
+- `debug` - No runtime introspection
+- `load`, `loadfile`, `dofile`, `loadstring` - No dynamic code loading
+- `rawget`, `rawset`, `getmetatable`, `setmetatable` - No metatable manipulation
+
+### File Writing
+
+Files can only be written to the `output/` directory:
+
+```lua
+-- OK: writes to output/report.txt
+rela.write_file("report.txt", "content")
+
+-- OK: writes to output/reports/2024/summary.md  
+rela.write_file("reports/2024/summary.md", "content")
+
+-- ERROR: path traversal blocked
+rela.write_file("../secret.txt", "content")
+
+-- ERROR: absolute paths blocked
+rela.write_file("/etc/passwd", "content")
+```
+
+## MCP Tools
+
+Lua scripting is available via MCP tools:
+
+| Tool | Description |
+|------|-------------|
+| `lua_eval` | Execute inline Lua code |
+| `lua_run` | Execute a script from `scripts/` |
+| `lua_list` | List available scripts |
+
+### lua_eval
+
+Execute inline Lua code:
+
+```text
+lua_eval(code: "rela.output(rela.list_entities('ticket'))")
+```
+
+### lua_run
+
+Execute a script file with arguments:
+
+```text
+lua_run(path: "report.lua", args: ["2024-Q1"])
+```
+
+### lua_list
+
+List available scripts in `scripts/` directory.

--- a/docs-project/relations/GUIDE-lua-scripting--covers--FEAT-lua-scripting.md
+++ b/docs-project/relations/GUIDE-lua-scripting--covers--FEAT-lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: GUIDE-lua-scripting
+relation: covers
+to: FEAT-lua-scripting
+---

--- a/docs-project/relations/GUIDE-lua-scripting--prerequisite--GUIDE-mcp-server.md
+++ b/docs-project/relations/GUIDE-lua-scripting--prerequisite--GUIDE-mcp-server.md
@@ -1,0 +1,5 @@
+---
+from: GUIDE-lua-scripting
+relation: prerequisite
+to: GUIDE-mcp-server
+---

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -1,5 +1,11 @@
 // Package lua provides a Lua scripting runtime for rela with bindings
 // to query entities, relations, and output results.
+//
+// The runtime is sandboxed: only safe Lua libraries are loaded (base, table,
+// string, math, utf8, coroutine). The io, os, and debug libraries are NOT
+// available to prevent filesystem access and code execution. File operations
+// are only possible through the provided rela.write_file() function which
+// validates paths are within the project root.
 package lua
 
 import (
@@ -9,7 +15,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"strings"
 
 	lua "github.com/yuin/gopher-lua"
 
@@ -21,7 +26,9 @@ import (
 
 // Default values for Lua API functions.
 const (
-	defaultSearchLimit   = 20
+	defaultSearchLimit = 20
+	// argPosCreateEntityID is the position of the optional ID parameter in create_entity
+	// (type=1, properties=2, content=3, id=4).
 	argPosCreateEntityID = 4
 )
 
@@ -35,8 +42,17 @@ type Runtime struct {
 }
 
 // New creates a Runtime with rela bindings registered.
+// The Lua VM is sandboxed with only safe libraries loaded (no io, os, or debug).
 func New(ws *workspace.Workspace, meta *metamodel.Metamodel, projectRoot string, stdout io.Writer) *Runtime {
-	L := lua.NewState()
+	// Create sandboxed Lua state - skip default libraries for security
+	L := lua.NewState(lua.Options{
+		SkipOpenLibs:  true,
+		CallStackSize: 1024,      // Limit call stack depth to prevent stack overflow
+		RegistrySize:  1024 * 64, // Limit registry size
+	})
+
+	// Load only safe libraries (NOT io, os, or debug)
+	openSafeLibraries(L)
 
 	r := &Runtime{
 		L:           L,
@@ -48,6 +64,44 @@ func New(ws *workspace.Workspace, meta *metamodel.Metamodel, projectRoot string,
 
 	r.registerBindings()
 	return r
+}
+
+// openSafeLibraries loads only safe Lua standard libraries.
+// Excluded for security: io (file access), os (system commands), debug (internals).
+func openSafeLibraries(ls *lua.LState) {
+	// Libraries to load - order matters, LoadLibName must come first if used
+	safeLibs := []struct {
+		name string
+		fn   lua.LGFunction
+	}{
+		{lua.BaseLibName, lua.OpenBase},
+		{lua.TabLibName, lua.OpenTable},
+		{lua.StringLibName, lua.OpenString},
+		{lua.MathLibName, lua.OpenMath},
+		{lua.CoroutineLibName, lua.OpenCoroutine},
+		// NOT included: lua.IoLibName, lua.OsLibName, lua.DebugLibName, lua.ChannelLibName
+	}
+
+	for _, lib := range safeLibs {
+		ls.Push(ls.NewFunction(lib.fn))
+		ls.Push(lua.LString(lib.name))
+		ls.Call(1, 0)
+	}
+
+	// Remove dangerous base functions that could bypass sandbox
+	ls.SetGlobal("loadfile", lua.LNil)
+	ls.SetGlobal("dofile", lua.LNil)
+	ls.SetGlobal("load", lua.LNil)
+	ls.SetGlobal("loadstring", lua.LNil)
+
+	// Remove raw access functions that could bypass metamethod protections
+	// and modify the rela module internals
+	ls.SetGlobal("rawget", lua.LNil)
+	ls.SetGlobal("rawset", lua.LNil)
+	ls.SetGlobal("rawequal", lua.LNil)
+	ls.SetGlobal("rawlen", lua.LNil)
+	ls.SetGlobal("getmetatable", lua.LNil)
+	ls.SetGlobal("setmetatable", lua.LNil)
 }
 
 // RunFile executes a Lua script file with arguments.
@@ -69,6 +123,18 @@ func (r *Runtime) RunFile(path string, args []string) error {
 // RunString executes Lua code from a string.
 func (r *Runtime) RunString(code string) error {
 	return r.L.DoString(code)
+}
+
+// SetArgs sets the script arguments (rela.args) before execution.
+func (r *Runtime) SetArgs(args []string) {
+	argsTable := r.L.NewTable()
+	for i, arg := range args {
+		argsTable.RawSetInt(i+1, lua.LString(arg))
+	}
+	relaTable, ok := r.L.GetGlobal("rela").(*lua.LTable)
+	if ok {
+		relaTable.RawSetString("args", argsTable)
+	}
 }
 
 // Close releases Lua VM resources.
@@ -123,6 +189,10 @@ func (r *Runtime) registerBindings() {
 // luaGetEntity implements rela.get_entity(id) -> table|nil
 func (r *Runtime) luaGetEntity(ls *lua.LState) int {
 	id := ls.CheckString(1)
+	if id == "" {
+		ls.RaiseError("entity ID cannot be empty")
+		return 0
+	}
 
 	entity, found := r.ws.GetEntity(id)
 	if !found {
@@ -227,6 +297,10 @@ func (r *Runtime) luaGetRelations(ls *lua.LState) int {
 // luaTraceFrom implements rela.trace_from(id, depth?) -> table|nil
 func (r *Runtime) luaTraceFrom(ls *lua.LState) int {
 	id := ls.CheckString(1)
+	if id == "" {
+		ls.RaiseError("entity ID cannot be empty")
+		return 0
+	}
 	maxDepth := ls.OptInt(2, 0)
 
 	trace := r.ws.TraceFrom(id, maxDepth)
@@ -241,6 +315,10 @@ func (r *Runtime) luaTraceFrom(ls *lua.LState) int {
 // luaTraceTo implements rela.trace_to(id, depth?) -> table|nil
 func (r *Runtime) luaTraceTo(ls *lua.LState) int {
 	id := ls.CheckString(1)
+	if id == "" {
+		ls.RaiseError("entity ID cannot be empty")
+		return 0
+	}
 	maxDepth := ls.OptInt(2, 0)
 
 	trace := r.ws.TraceTo(id, maxDepth)
@@ -267,36 +345,50 @@ func (r *Runtime) luaOutput(ls *lua.LState) int {
 	return 0
 }
 
+// outputDir is the only directory where Lua scripts can write files.
+const outputDir = "output"
+
 // luaWriteFile implements rela.write_file(path, content)
-// Path must be within the project root for security.
+// Files can ONLY be written to the output/ directory for security.
+// Path is relative to output/ (e.g., "report.txt" -> "output/report.txt").
 func (r *Runtime) luaWriteFile(ls *lua.LState) int {
 	path := ls.CheckString(1)
 	content := ls.CheckString(2)
 
-	// Resolve to absolute path
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		ls.RaiseError("invalid path: %s", err.Error())
+	if path == "" {
+		ls.RaiseError("write_file: path cannot be empty")
 		return 0
 	}
 
-	// Validate path is within project root
-	absRoot, err := filepath.Abs(r.projectRoot)
-	if err != nil {
-		ls.RaiseError("invalid project root: %s", err.Error())
+	// Validate the path is local (no "..", no absolute paths)
+	if !filepath.IsLocal(path) {
+		ls.RaiseError("write_file: path must be a local path (no '..' or absolute paths)")
 		return 0
 	}
 
-	// Ensure the path starts with project root (after cleaning)
-	if !strings.HasPrefix(absPath, absRoot+string(filepath.Separator)) && absPath != absRoot {
-		ls.RaiseError("write_file: path must be within project root")
+	// Build the full path within output directory
+	outputPath := filepath.Join(r.projectRoot, outputDir)
+
+	// Ensure output directory exists
+	if err := os.MkdirAll(outputPath, 0755); err != nil {
+		ls.RaiseError("write_file: cannot create output directory: %s", err.Error())
 		return 0
 	}
 
-	if err := os.WriteFile(absPath, []byte(content), 0644); err != nil {
-		ls.RaiseError("write file error: %s", err.Error())
+	// Ensure parent directories within output/ exist
+	fullPath := filepath.Join(outputPath, path)
+	dir := filepath.Dir(fullPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		ls.RaiseError("write_file: cannot create directory: %s", err.Error())
 		return 0
 	}
+
+	// Write the file
+	if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+		ls.RaiseError("write_file: cannot write file: %s", err.Error())
+		return 0
+	}
+
 	return 0
 }
 
@@ -467,7 +559,8 @@ func luaTableToGo(t *lua.LTable) interface{} {
 	return m
 }
 
-// luaSearch implements rela.search(query, type?, limit?) -> table
+// luaSearch implements rela.search(query, limit?) -> table
+// Performs full-text search across entity titles and properties.
 func (r *Runtime) luaSearch(ls *lua.LState) int {
 	query := ls.CheckString(1)
 	if query == "" {
@@ -533,9 +626,19 @@ func (r *Runtime) luaUpdateEntity(ls *lua.LState) int {
 		return 0
 	}
 
-	// Clone entity for update
+	// Clone entity for update - must deep copy the Properties map
 	oldEntity := *entity
 	updated := *entity
+
+	// Deep copy the properties map to avoid mutating oldEntity
+	if entity.Properties != nil {
+		oldEntity.Properties = make(map[string]interface{}, len(entity.Properties))
+		updated.Properties = make(map[string]interface{}, len(entity.Properties))
+		for k, v := range entity.Properties {
+			oldEntity.Properties[k] = v
+			updated.Properties[k] = v
+		}
+	}
 
 	// Update properties if provided
 	if ls.GetTop() >= 2 && ls.Get(2).Type() == lua.LTTable {
@@ -550,12 +653,9 @@ func (r *Runtime) luaUpdateEntity(ls *lua.LState) int {
 		}
 	}
 
-	// Update content if provided
-	if ls.GetTop() >= 3 {
-		content := ls.OptString(3, "")
-		if content != "" {
-			updated.Content = content
-		}
+	// Update content if provided (nil means not provided, empty string clears content)
+	if ls.GetTop() >= 3 && ls.Get(3).Type() != lua.LTNil {
+		updated.Content = ls.CheckString(3)
 	}
 
 	_, err := r.ws.UpdateEntity(&updated, &oldEntity)
@@ -565,7 +665,11 @@ func (r *Runtime) luaUpdateEntity(ls *lua.LState) int {
 	}
 
 	// Get fresh entity after update
-	updatedEntity, _ := r.ws.GetEntity(id)
+	updatedEntity, found := r.ws.GetEntity(id)
+	if !found {
+		ls.RaiseError("entity disappeared after update: %s", id)
+		return 0
+	}
 	ls.Push(entityToTable(ls, updatedEntity))
 	return 1
 }

--- a/internal/lua/runtime_test.go
+++ b/internal/lua/runtime_test.go
@@ -441,23 +441,19 @@ func TestWriteFile(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
-	// Use same temp dir for project root and output file
 	projectRoot := t.TempDir()
 	r := New(ws, ws.Meta(), projectRoot, &buf)
 	defer r.Close()
 
-	outFile := filepath.Join(projectRoot, "output.txt")
-
-	script := `rela.write_file("` + outFile + `", "hello world")`
-	tmpFile := filepath.Join(projectRoot, "test.lua")
-	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
-		t.Fatal(err)
+	// Files are written to output/ directory
+	script := `rela.write_file("result.txt", "hello world")`
+	err := r.RunString(script)
+	if err != nil {
+		t.Fatalf("RunString failed: %v", err)
 	}
 
-	if err := r.RunFile(tmpFile, nil); err != nil {
-		t.Fatalf("RunFile failed: %v", err)
-	}
-
+	// File should be in output/ subdirectory
+	outFile := filepath.Join(projectRoot, "output", "result.txt")
 	content, err := os.ReadFile(outFile)
 	if err != nil {
 		t.Fatalf("Failed to read output file: %v", err)
@@ -541,19 +537,21 @@ func TestWriteFile_PathTraversal(t *testing.T) {
 	r := New(ws, ws.Meta(), projectRoot, &buf)
 	defer r.Close()
 
-	// Try to write outside project root using path traversal
+	// Try to escape output/ using path traversal
 	script := `rela.write_file("../outside.txt", "malicious")`
-	tmpFile := filepath.Join(projectRoot, "test.lua")
-	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	err := r.RunFile(tmpFile, nil)
+	err := r.RunString(script)
 	if err == nil {
 		t.Fatal("Expected error for path traversal attempt")
 	}
-	if !strings.Contains(err.Error(), "must be within project root") {
-		t.Errorf("Expected 'must be within project root' error, got: %v", err)
+	// Error message should indicate the path is not local
+	if !strings.Contains(err.Error(), "local path") {
+		t.Errorf("Expected 'local path' error, got: %v", err)
+	}
+
+	// Verify file was NOT created outside output/
+	outsideFile := filepath.Join(projectRoot, "outside.txt")
+	if _, err := os.Stat(outsideFile); err == nil {
+		t.Error("File should not have been created outside output/")
 	}
 }
 
@@ -565,20 +563,15 @@ func TestWriteFile_AbsolutePathOutside(t *testing.T) {
 	r := New(ws, ws.Meta(), projectRoot, &buf)
 	defer r.Close()
 
-	// Try to write to absolute path outside project
+	// Try to write to absolute path (should be rejected)
 	script := `rela.write_file("/tmp/outside.txt", "malicious")`
-	tmpFile := filepath.Join(projectRoot, "test.lua")
-	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	err := r.RunFile(tmpFile, nil)
+	err := r.RunString(script)
 	if err == nil {
-		t.Fatal("Expected error for absolute path outside project")
+		t.Fatal("Expected error for absolute path")
 	}
 }
 
-func TestWriteFile_WithinProject(t *testing.T) {
+func TestWriteFile_InOutputDir(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
@@ -586,17 +579,15 @@ func TestWriteFile_WithinProject(t *testing.T) {
 	r := New(ws, ws.Meta(), projectRoot, &buf)
 	defer r.Close()
 
-	outFile := filepath.Join(projectRoot, "output.txt")
-	script := `rela.write_file("` + outFile + `", "allowed")`
-	tmpFile := filepath.Join(projectRoot, "test.lua")
-	if err := os.WriteFile(tmpFile, []byte(script), 0644); err != nil {
-		t.Fatal(err)
+	// Write to output directory
+	script := `rela.write_file("result.txt", "allowed")`
+	err := r.RunString(script)
+	if err != nil {
+		t.Fatalf("RunString failed: %v", err)
 	}
 
-	if err := r.RunFile(tmpFile, nil); err != nil {
-		t.Fatalf("RunFile failed: %v", err)
-	}
-
+	// File should be in output/ subdirectory
+	outFile := filepath.Join(projectRoot, "output", "result.txt")
 	content, err := os.ReadFile(outFile)
 	if err != nil {
 		t.Fatalf("Failed to read output file: %v", err)
@@ -1215,5 +1206,157 @@ rela.output({
 	}
 	if result["has_children"] != true {
 		t.Errorf("Expected has_children=true (TKT-001 -> FEAT-001), got %v", result["has_children"])
+	}
+}
+
+// TestSandbox_DangerousLibrariesUnavailable verifies that dangerous Lua libraries
+// (io, os, debug) are not available in the sandboxed runtime.
+func TestSandbox_DangerousLibrariesUnavailable(t *testing.T) {
+	ws := testWorkspace(t)
+
+	tests := []struct {
+		name   string
+		script string
+	}{
+		{"io library", `if io then error("io should not be available") end`},
+		{"os library", `if os then error("os should not be available") end`},
+		{"debug library", `if debug then error("debug should not be available") end`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			r := New(ws, ws.Meta(), "/tmp", &buf)
+			defer r.Close()
+
+			// Should succeed because the libraries are not available
+			err := r.RunString(tt.script)
+			if err != nil {
+				t.Errorf("Script failed unexpectedly: %v", err)
+			}
+		})
+	}
+}
+
+// TestSandbox_DangerousFunctionsRemoved verifies that dangerous base functions
+// are removed from the sandbox.
+func TestSandbox_DangerousFunctionsRemoved(t *testing.T) {
+	ws := testWorkspace(t)
+
+	dangerousFuncs := []string{
+		"loadfile",
+		"dofile",
+		"load",
+		"loadstring",
+		"rawget",
+		"rawset",
+		"rawequal",
+		"rawlen",
+		"getmetatable",
+		"setmetatable",
+	}
+
+	for _, fn := range dangerousFuncs {
+		t.Run(fn, func(t *testing.T) {
+			var buf bytes.Buffer
+			r := New(ws, ws.Meta(), "/tmp", &buf)
+			defer r.Close()
+
+			script := `if ` + fn + ` ~= nil then error("` + fn + ` should be nil") end`
+			err := r.RunString(script)
+			if err != nil {
+				t.Errorf("Function %s should be nil but script failed: %v", fn, err)
+			}
+		})
+	}
+}
+
+// TestSandbox_SafeLibrariesAvailable verifies that safe Lua libraries are available.
+func TestSandbox_SafeLibrariesAvailable(t *testing.T) {
+	ws := testWorkspace(t)
+
+	tests := []struct {
+		name   string
+		script string
+	}{
+		{"string library", `if not string.len then error("string.len not available") end`},
+		{"table library", `if not table.insert then error("table.insert not available") end`},
+		{"math library", `if not math.floor then error("math.floor not available") end`},
+		{"coroutine library", `if not coroutine.create then error("coroutine.create not available") end`},
+		{"base print", `if not print then error("print not available") end`},
+		{"base pairs", `if not pairs then error("pairs not available") end`},
+		{"base ipairs", `if not ipairs then error("ipairs not available") end`},
+		{"base type", `if not type then error("type not available") end`},
+		{"base tostring", `if not tostring then error("tostring not available") end`},
+		{"base tonumber", `if not tonumber then error("tonumber not available") end`},
+		{"base error", `if not error then error("error not available") end`},
+		{"base pcall", `if not pcall then error("pcall not available") end`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			r := New(ws, ws.Meta(), "/tmp", &buf)
+			defer r.Close()
+
+			err := r.RunString(tt.script)
+			if err != nil {
+				t.Errorf("Script failed: %v", err)
+			}
+		})
+	}
+}
+
+// TestWriteFile_NestedDirectories verifies that write_file creates nested directories in output/.
+func TestWriteFile_NestedDirectories(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	projectRoot := t.TempDir()
+	r := New(ws, ws.Meta(), projectRoot, &buf)
+	defer r.Close()
+
+	// Write to a deeply nested path within output/
+	script := `rela.write_file("reports/2024/summary.txt", "nested content")`
+	err := r.RunString(script)
+	if err != nil {
+		t.Fatalf("RunString failed: %v", err)
+	}
+
+	// Verify file was created in output/ subdirectory
+	outFile := filepath.Join(projectRoot, "output", "reports", "2024", "summary.txt")
+	content, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+
+	if string(content) != "nested content" {
+		t.Errorf("Expected 'nested content', got %q", string(content))
+	}
+}
+
+// TestSetArgs verifies that SetArgs correctly sets script arguments.
+func TestSetArgs(t *testing.T) {
+	ws := testWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	r.SetArgs([]string{"arg1", "arg2", "arg3"})
+
+	script := `rela.output(rela.args)`
+	err := r.RunString(script)
+	if err != nil {
+		t.Fatalf("RunString failed: %v", err)
+	}
+
+	var result []interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if len(result) != 3 || result[0] != "arg1" || result[1] != "arg2" || result[2] != "arg3" {
+		t.Errorf("Expected [arg1, arg2, arg3], got %v", result)
 	}
 }

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,9 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 )
+
+// scriptsDir is the directory where Lua scripts must be located for lua_run.
+const scriptsDir = "scripts"
 
 func toolLuaEval() mcp.Tool {
 	return mcp.NewTool("lua_eval",
@@ -32,10 +36,10 @@ func toolLuaRun() mcp.Tool {
 	return mcp.NewTool("lua_run",
 		mcp.WithDescription(
 			"Execute a Lua script file against the rela graph. "+
-				"Script path is relative to project root. "+
+				"Scripts must be located in the 'scripts/' directory. "+
 				"Use rela.output(data) to return results as JSON."),
 		mcp.WithString("path", mcp.Required(),
-			mcp.Description("Path to Lua script file (relative to project root)")),
+			mcp.Description("Script filename or path within scripts/ (e.g., 'export.lua' or 'reports/summary.lua')")),
 		mcp.WithArray("args",
 			mcp.Description("Arguments to pass to the script (available as rela.args)")),
 	)
@@ -44,8 +48,8 @@ func toolLuaRun() mcp.Tool {
 func toolLuaList() mcp.Tool {
 	return mcp.NewTool("lua_list",
 		mcp.WithDescription(
-			"List available Lua scripts in the project. "+
-				"Searches for .lua files in common locations (scripts/, lua/, root)."),
+			"List available Lua scripts in the scripts/ directory. "+
+				"Only scripts in this directory can be executed via lua_run."),
 	)
 }
 
@@ -81,15 +85,47 @@ func (s *Server) handleLuaRun(_ context.Context, req mcp.CallToolRequest) (*mcp.
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	// Security: Validate path is local (no "..", no absolute paths)
+	if !filepath.IsLocal(path) {
+		return mcp.NewToolResultError("script path must be a local path (no '..' or absolute paths allowed)"), nil
+	}
+
+	// Security: Must have .lua extension
+	if !strings.HasSuffix(path, ".lua") {
+		return mcp.NewToolResultError("script must have .lua extension"), nil
+	}
+
 	// Parse args if provided
 	args := req.GetStringSlice("args", nil)
 
 	projectRoot := s.ws.Paths().Root
 
-	// Resolve path relative to project root
-	scriptPath := path
-	if !filepath.IsAbs(path) {
-		scriptPath = filepath.Join(projectRoot, path)
+	// Security: Scripts must be in the scripts/ directory
+	// Use os.Root for traversal-resistant path access
+	root, err := os.OpenRoot(projectRoot)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("cannot open project root: %s", err.Error())), nil
+	}
+	defer root.Close()
+
+	// Verify script exists using traversal-resistant API
+	scriptsRoot, err := root.OpenRoot(scriptsDir)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("scripts directory not found: %s", err.Error())), nil
+	}
+	defer scriptsRoot.Close()
+
+	// Read script content using traversal-resistant API to prevent symlink escapes
+	scriptFile, err := scriptsRoot.Open(path)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("script not found: %s (scripts must be in the scripts/ directory)", path)), nil
+	}
+	defer scriptFile.Close()
+
+	// Read script content
+	scriptContent, err := io.ReadAll(scriptFile)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("cannot read script: %s", err.Error())), nil
 	}
 
 	// Capture output
@@ -98,8 +134,12 @@ func (s *Server) handleLuaRun(_ context.Context, req mcp.CallToolRequest) (*mcp.
 	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output)
 	defer runtime.Close()
 
-	if err := runtime.RunFile(scriptPath, args); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("Lua error: %s", err.Error())), nil
+	// Set script args before execution
+	runtime.SetArgs(args)
+
+	// Execute script content directly (bypasses symlink escapes since we read via os.Root)
+	if err := runtime.RunString(string(scriptContent)); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Lua error in %s: %s", path, err.Error())), nil
 	}
 
 	result := output.String()
@@ -113,58 +153,43 @@ func (s *Server) handleLuaRun(_ context.Context, req mcp.CallToolRequest) (*mcp.
 func (s *Server) handleLuaList(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	projectRoot := s.ws.Paths().Root
 
-	// Directories to search for Lua scripts
-	searchDirs := []string{
-		"scripts",
-		"lua",
-		".",
-	}
+	// Only search the scripts/ directory (security restriction)
+	scriptsPath := filepath.Join(projectRoot, scriptsDir)
 
 	var scripts []string
-	seen := make(map[string]bool)
 
-	for _, dir := range searchDirs {
-		searchPath := filepath.Join(projectRoot, dir)
-		entries, err := os.ReadDir(searchPath)
-		if err != nil {
-			continue // Directory doesn't exist, skip
+	// Walk the scripts directory recursively to find all .lua files
+	_ = filepath.WalkDir(scriptsPath, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return filepath.SkipDir // Skip directories with errors
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".lua") {
+			return nil
 		}
 
-		for _, entry := range entries {
-			if entry.IsDir() {
-				continue
-			}
-			if !strings.HasSuffix(entry.Name(), ".lua") {
-				continue
-			}
-
-			// Get relative path from project root
-			var relPath string
-			if dir == "." {
-				relPath = entry.Name()
-			} else {
-				relPath = filepath.Join(dir, entry.Name())
-			}
-
-			if seen[relPath] {
-				continue
-			}
-			seen[relPath] = true
+		// Get relative path from scripts directory
+		relPath, _ := filepath.Rel(scriptsPath, path)
+		if relPath != "" {
 			scripts = append(scripts, relPath)
 		}
-	}
+		return nil
+	})
 
 	if len(scripts) == 0 {
-		return mcp.NewToolResultText("No Lua scripts found in project"), nil
+		return mcp.NewToolResultText("No Lua scripts found in scripts/ directory"), nil
 	}
 
 	var result strings.Builder
-	result.WriteString("Available Lua scripts:\n")
+	result.WriteString("Available Lua scripts (in scripts/):\n")
 	for _, script := range scripts {
 		result.WriteString("  ")
 		result.WriteString(script)
 		result.WriteString("\n")
 	}
+	result.WriteString("\nUse lua_run with the script name to execute.")
 
 	return mcp.NewToolResultText(result.String()), nil
 }

--- a/scripts/dev-status.lua
+++ b/scripts/dev-status.lua
@@ -1,0 +1,141 @@
+-- dev-status.lua
+-- Generate a development status report for rela itself
+-- Usage: rela lua scripts/dev-status.lua
+--    or: lua_run(path: "dev-status.lua")
+
+local function count_by_status(entities)
+    local counts = {}
+    for _, e in ipairs(entities) do
+        local status = e.properties.status or "unknown"
+        counts[status] = (counts[status] or 0) + 1
+    end
+    return counts
+end
+
+local function get_recent(entities, status, limit)
+    local filtered = {}
+    for _, e in ipairs(entities) do
+        if e.properties.status == status then
+            table.insert(filtered, {
+                id = e.id,
+                title = e.properties.title,
+                priority = e.properties.priority
+            })
+        end
+    end
+    -- Return up to limit items
+    local result = {}
+    for i = 1, math.min(limit, #filtered) do
+        table.insert(result, filtered[i])
+    end
+    return result
+end
+
+-- Collect data
+local tickets = rela.list_entities("ticket")
+local bugs = rela.list_entities("bug")
+local features = rela.list_entities("feature")
+local decisions = rela.list_entities("decision")
+local ideas = rela.list_entities("idea")
+
+-- Calculate statistics
+local ticket_stats = count_by_status(tickets)
+local bug_stats = count_by_status(bugs)
+local feature_stats = count_by_status(features)
+
+-- Find active work
+local in_progress_tickets = get_recent(tickets, "in-progress", 10)
+local in_progress_bugs = get_recent(bugs, "in-progress", 5)
+local review_items = get_recent(tickets, "review", 10)
+
+-- Find blockers
+local blocked_tickets = get_recent(tickets, "blocked", 10)
+local blocked_bugs = get_recent(bugs, "blocked", 5)
+
+-- Find ready work (backlog items ready to start)
+local ready_tickets = get_recent(tickets, "ready", 10)
+local ready_bugs = get_recent(bugs, "ready", 5)
+
+-- Count open review responses
+local review_responses = rela.list_entities("review-response")
+local open_reviews = {}
+local critical_reviews = {}
+for _, rr in ipairs(review_responses) do
+    if rr.properties.status == "open" then
+        table.insert(open_reviews, {
+            id = rr.id,
+            title = rr.properties.title,
+            severity = rr.properties.severity
+        })
+        if rr.properties.severity == "critical" then
+            table.insert(critical_reviews, rr)
+        end
+    end
+end
+
+-- Build report
+local report = {
+    summary = {
+        tickets = {
+            total = #tickets,
+            by_status = ticket_stats
+        },
+        bugs = {
+            total = #bugs,
+            by_status = bug_stats
+        },
+        features = {
+            total = #features,
+            by_status = feature_stats
+        },
+        decisions = #decisions,
+        ideas = #ideas
+    },
+    active_work = {
+        in_progress = {
+            tickets = in_progress_tickets,
+            bugs = in_progress_bugs
+        },
+        in_review = review_items
+    },
+    blockers = {
+        tickets = blocked_tickets,
+        bugs = blocked_bugs
+    },
+    ready_to_start = {
+        tickets = ready_tickets,
+        bugs = ready_bugs
+    },
+    code_review = {
+        open_count = #open_reviews,
+        critical_count = #critical_reviews,
+        open_items = open_reviews
+    }
+}
+
+-- Add warnings
+report.warnings = {}
+
+if #critical_reviews > 0 then
+    table.insert(report.warnings, {
+        level = "critical",
+        message = string.format("%d critical review response(s) need attention", #critical_reviews)
+    })
+end
+
+if #blocked_tickets + #blocked_bugs > 0 then
+    table.insert(report.warnings, {
+        level = "warning",
+        message = string.format("%d item(s) are blocked", #blocked_tickets + #blocked_bugs)
+    })
+end
+
+local in_progress_count = #in_progress_tickets + #in_progress_bugs
+if in_progress_count > 5 then
+    table.insert(report.warnings, {
+        level = "info",
+        message = string.format("%d items in progress - consider focusing", in_progress_count)
+    })
+end
+
+rela.output(report)

--- a/tickets/entities/bugs/BUG-AH67.md
+++ b/tickets/entities/bugs/BUG-AH67.md
@@ -1,0 +1,24 @@
+---
+id: BUG-AH67
+status: done
+title: Harden Lua sandbox security
+type: bug
+priority: high
+description: |
+  The Lua runtime sandbox needs hardening to prevent potential security issues.
+why1: |
+  The initial Lua implementation loaded all standard libraries including io, os, debug
+why2: |
+  Scripts could use raw* functions to bypass protections on the rela module
+why3: |
+  File writes were allowed anywhere in the project root
+prevention: |
+  Added sandbox tests, restricted file writes to output/, removed dangerous functions
+---
+
+Security hardening for the Lua scripting feature:
+
+- Remove dangerous libraries (io, os, debug)
+- Remove dangerous functions (load, loadfile, dofile, rawget, rawset, etc.)
+- Restrict file writes to `output/` directory only
+- Use os.Root for traversal-resistant script loading


### PR DESCRIPTION
## Summary
- Harden Lua sandbox: remove dangerous functions (loadfile, dofile, rawget, rawset, etc.)
- Restrict file writes to `output/` directory only
- Add Lua scripting guide and feature documentation
- Add dev-status.lua example script

## Test plan
- [x] Sandbox tests verify dangerous functions are removed
- [x] Write tests verify output-only restriction
- [x] All tests pass, lint clean