### PR TITLE
feat(fmt): add markdown content formatting

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -72,6 +72,7 @@ vendors:
     in:
       - github.com/yuin/goldmark
       - github.com/yuin/goldmark/**
+      - github.com/teekennedy/goldmark-markdown
   gogit:       { in: github.com/go-git/go-git/** }
   mcpgo:       { in: github.com/mark3labs/mcp-go/** }
   wails:       { in: github.com/wailsapp/wails/** }

--- a/go.mod
+++ b/go.mod
@@ -95,6 +95,7 @@ require (
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
+	github.com/teekennedy/goldmark-markdown v0.5.1 // indirect
 	github.com/tkrajina/go-reflector v0.5.8 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -422,6 +422,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/teekennedy/goldmark-markdown v0.5.1 h1:2lIlJ3AcIwaD1wFl4dflJSJFMhRTKEsEj+asVsu6M/0=
+github.com/teekennedy/goldmark-markdown v0.5.1/go.mod h1:so260mNSPELuRyynZY18719dRYlD+OSnAovqsyrOMOM=
 github.com/tkrajina/go-reflector v0.5.8 h1:yPADHrwmUbMq4RGEyaOUpz2H90sRsETNVpjzo3DLVQQ=
 github.com/tkrajina/go-reflector v0.5.8/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/internal/cli/fmt.go
+++ b/internal/cli/fmt.go
@@ -14,27 +14,32 @@ var (
 
 var fmtCmd = &cobra.Command{
 	Use:   "fmt [type]",
-	Short: "Format entity files",
-	Long: `Formats entity files to ensure consistent formatting.
+	Short: "Format entity and relation files",
+	Long: `Formats entity and relation files to ensure consistent formatting.
 
-Currently this command:
-- Orders frontmatter properties according to the metamodel definition
-- Ensures id and type appear first, followed by properties in metamodel order
-- Places any extra properties (not in metamodel) at the end, sorted alphabetically
+This command normalizes:
+- Frontmatter property ordering (id/type first for entities, from/relation/to for relations)
+- Markdown content formatting (headings, lists, whitespace)
 
 Exit codes:
 - 0: All files formatted (or already formatted with --check)
 - 1: Files need formatting (with --check)
 
 Examples:
-  rela fmt                # Format all entities
-  rela fmt requirements   # Format only requirements
+  rela fmt                # Format all entities and relations
+  rela fmt requirements   # Format only requirements (entities)
   rela fmt --dry-run      # Preview changes without writing
   rela fmt --check        # Check if files need formatting (for CI)`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var entities []*model.Entity
+		// For --check mode, use dry-run behavior internally
+		dryRun := fmtDryRun || fmtCheck
 
+		modifiedEntities := 0
+		modifiedRelations := 0
+
+		// Format entities
+		var entities []*model.Entity
 		if len(args) > 0 {
 			typeName := args[0]
 			resolvedType, _, err := resolveEntityType(typeName)
@@ -46,15 +51,6 @@ Examples:
 			entities = ws.AllEntities()
 		}
 
-		if len(entities) == 0 {
-			out.WriteMessage("No entities found")
-			return nil
-		}
-
-		// For --check mode, use dry-run behavior internally
-		dryRun := fmtDryRun || fmtCheck
-
-		modified := 0
 		for _, entity := range entities {
 			changed, err := ws.FormatEntity(entity, dryRun)
 			if err != nil {
@@ -66,7 +62,7 @@ Examples:
 				continue
 			}
 
-			modified++
+			modifiedEntities++
 
 			if fmtCheck {
 				out.WriteMessage("Needs formatting: %s", entity.ID)
@@ -77,19 +73,52 @@ Examples:
 			}
 		}
 
+		// Format relations (only when no specific type is specified)
+		if len(args) == 0 {
+			relations := ws.AllRelations()
+			for _, relation := range relations {
+				changed, err := ws.FormatRelation(relation, dryRun)
+				if err != nil {
+					out.WriteWarning("Failed to format relation %s--%s--%s: %v",
+						relation.From, relation.Type, relation.To, err)
+					continue
+				}
+
+				if !changed {
+					continue
+				}
+
+				modifiedRelations++
+
+				relationID := relation.From + "--" + relation.Type + "--" + relation.To
+				if fmtCheck {
+					out.WriteMessage("Needs formatting: %s", relationID)
+				} else if fmtDryRun {
+					out.WriteMessage("Would format: %s", relationID)
+				} else if verbose {
+					out.WriteMessage("Formatted: %s", relationID)
+				}
+			}
+		}
+
+		totalModified := modifiedEntities + modifiedRelations
+
 		if fmtCheck {
-			if modified > 0 {
-				out.WriteMessage("%d entities need formatting", modified)
+			if totalModified > 0 {
+				out.WriteMessage("%d files need formatting (%d entities, %d relations)",
+					totalModified, modifiedEntities, modifiedRelations)
 				return errors.NewExitError(1)
 			}
-			out.WriteSuccess("All entities are properly formatted")
+			out.WriteSuccess("All files are properly formatted")
 			return nil
 		}
 
 		if fmtDryRun {
-			out.WriteMessage("Dry run: %d entities would be formatted", modified)
+			out.WriteMessage("Dry run: %d files would be formatted (%d entities, %d relations)",
+				totalModified, modifiedEntities, modifiedRelations)
 		} else {
-			out.WriteSuccess("Formatted %d entities", modified)
+			out.WriteSuccess("Formatted %d files (%d entities, %d relations)",
+				totalModified, modifiedEntities, modifiedRelations)
 		}
 
 		return nil

--- a/internal/markdown/entity.go
+++ b/internal/markdown/entity.go
@@ -69,6 +69,7 @@ func (f *FileIO) ReadEntity(path string, meta *metamodel.Metamodel) (*model.Enti
 
 // FormatEntity returns the formatted markdown content for an entity.
 // The optional propertyOrder specifies the order for entity properties (after id and type).
+// Both frontmatter ordering and markdown content formatting are applied.
 func FormatEntity(entity *model.Entity, propertyOrder []string) (string, error) {
 	frontmatter := make(map[string]interface{})
 	frontmatter["id"] = entity.ID
@@ -85,7 +86,13 @@ func FormatEntity(entity *model.Entity, propertyOrder []string) (string, error) 
 		keyOrder = append(keyOrder, propertyOrder...)
 	}
 
-	return FormatDocumentOrdered(frontmatter, entity.Content, keyOrder)
+	// Format markdown content
+	content := entity.Content
+	if content != "" {
+		content = FormatMarkdown(content)
+	}
+
+	return FormatDocumentOrdered(frontmatter, content, keyOrder)
 }
 
 // WriteEntity writes an entity to a markdown file.

--- a/internal/markdown/format.go
+++ b/internal/markdown/format.go
@@ -1,0 +1,44 @@
+package markdown
+
+import (
+	"bytes"
+	"strings"
+
+	markdown "github.com/teekennedy/goldmark-markdown"
+	"github.com/yuin/goldmark"
+)
+
+// FormatMarkdown normalizes markdown content using consistent formatting rules:
+// - ATX-style headings (#)
+// - Consistent list markers
+// - Normalized whitespace and indentation
+// - Consistent code fence style
+//
+// Returns the formatted content, or the original content if formatting fails.
+func FormatMarkdown(content string) string {
+	if content == "" {
+		return ""
+	}
+
+	// Trim trailing whitespace but preserve structure
+	content = strings.TrimRight(content, " \t")
+
+	renderer := markdown.NewRenderer(
+		markdown.WithHeadingStyle(markdown.HeadingStyleATX),
+		markdown.WithIndentStyle(markdown.IndentStyleSpaces),
+	)
+	md := goldmark.New(goldmark.WithRenderer(renderer))
+
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(content), &buf); err != nil {
+		// If formatting fails, return original content
+		return content
+	}
+
+	result := buf.String()
+
+	// Ensure single trailing newline
+	result = strings.TrimRight(result, "\n") + "\n"
+
+	return result
+}

--- a/internal/markdown/format_test.go
+++ b/internal/markdown/format_test.go
@@ -1,0 +1,120 @@
+package markdown
+
+import (
+	"testing"
+)
+
+func TestFormatMarkdown(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty content",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "plain text",
+			input:    "Hello world",
+			expected: "Hello world\n",
+		},
+		{
+			name:     "ATX heading preserved",
+			input:    "## Heading",
+			expected: "## Heading\n",
+		},
+		{
+			name:     "setext h1 converted to ATX",
+			input:    "Heading\n=======",
+			expected: "# Heading\n",
+		},
+		{
+			name:     "setext h2 converted to ATX",
+			input:    "Heading\n-------",
+			expected: "## Heading\n",
+		},
+		{
+			name:     "trailing whitespace removed",
+			input:    "Hello world   \t",
+			expected: "Hello world\n",
+		},
+		{
+			name:     "multiple trailing newlines normalized",
+			input:    "Hello world\n\n\n",
+			expected: "Hello world\n",
+		},
+		{
+			name:     "unordered list normalized",
+			input:    "- item 1\n- item 2",
+			expected: "- item 1\n- item 2\n",
+		},
+		{
+			name:     "ordered list normalized",
+			input:    "1. item 1\n2. item 2",
+			expected: "1. item 1\n2. item 2\n",
+		},
+		{
+			name:     "code block preserved",
+			input:    "```go\nfunc main() {}\n```",
+			expected: "```go\nfunc main() {}\n```\n",
+		},
+		{
+			name:     "inline code preserved",
+			input:    "Use `code` here",
+			expected: "Use `code` here\n",
+		},
+		{
+			name:     "link preserved",
+			input:    "[text](http://example.com)",
+			expected: "[text](http://example.com)\n",
+		},
+		{
+			name:     "emphasis preserved",
+			input:    "*italic* and **bold**",
+			expected: "*italic* and **bold**\n",
+		},
+		{
+			name:     "blockquote preserved",
+			input:    "> quoted text",
+			expected: "> quoted text\n",
+		},
+		{
+			name:     "paragraph separation preserved",
+			input:    "Paragraph 1\n\nParagraph 2",
+			expected: "Paragraph 1\n\nParagraph 2\n",
+		},
+		{
+			name:     "complex document",
+			input:    "## Description\n\nSome text here.\n\n- Item 1\n- Item 2\n\n## Notes\n\n> A quote",
+			expected: "## Description\n\nSome text here.\n\n- Item 1\n- Item 2\n\n## Notes\n\n> A quote\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatMarkdown(tt.input)
+			if result != tt.expected {
+				t.Errorf("FormatMarkdown() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFormatMarkdown_Idempotent(t *testing.T) {
+	// Formatting the same content twice should give identical results
+	inputs := []string{
+		"## Heading\n\nSome content.\n\n- List item\n",
+		"Heading\n=======\n\nParagraph",
+		"> Quote\n\n```\ncode\n```\n",
+	}
+
+	for _, input := range inputs {
+		first := FormatMarkdown(input)
+		second := FormatMarkdown(first)
+		if first != second {
+			t.Errorf("FormatMarkdown is not idempotent:\nFirst:  %q\nSecond: %q", first, second)
+		}
+	}
+}

--- a/internal/markdown/relation.go
+++ b/internal/markdown/relation.go
@@ -56,18 +56,7 @@ func (f *FileIO) ReadRelation(path string) (*model.Relation, error) {
 
 // WriteRelation writes a relation to a markdown file.
 func (f *FileIO) WriteRelation(relation *model.Relation, path string) error {
-	frontmatter := map[string]interface{}{
-		"from":     relation.From,
-		"relation": relation.Type,
-		"to":       relation.To,
-	}
-
-	// Add any additional properties
-	for key, value := range relation.Properties {
-		frontmatter[key] = value
-	}
-
-	content, err := FormatDocument(frontmatter, relation.Content)
+	content, err := FormatRelation(relation)
 	if err != nil {
 		return err
 	}
@@ -79,6 +68,33 @@ func (f *FileIO) WriteRelation(relation *model.Relation, path string) error {
 	}
 
 	return f.FS.WriteFile(path, []byte(content), 0644)
+}
+
+// FormatRelation returns the formatted markdown content for a relation.
+// Frontmatter keys are ordered: from, relation, to, then extras alphabetically.
+// Markdown content is also formatted.
+func FormatRelation(relation *model.Relation) (string, error) {
+	frontmatter := map[string]interface{}{
+		"from":     relation.From,
+		"relation": relation.Type,
+		"to":       relation.To,
+	}
+
+	// Add any additional properties
+	for key, value := range relation.Properties {
+		frontmatter[key] = value
+	}
+
+	// Key order: from, relation, to, then extras alphabetically
+	keyOrder := []string{"from", "relation", "to"}
+
+	// Format markdown content
+	content := relation.Content
+	if content != "" {
+		content = FormatMarkdown(content)
+	}
+
+	return FormatDocumentOrdered(frontmatter, content, keyOrder)
 }
 
 // DeleteRelation removes a relation file.

--- a/internal/markdown/relation_test.go
+++ b/internal/markdown/relation_test.go
@@ -123,6 +123,92 @@ func TestWriteRelation(t *testing.T) {
 	}
 }
 
+func TestFormatRelation(t *testing.T) {
+	tests := []struct {
+		name     string
+		relation *model.Relation
+		contains []string
+	}{
+		{
+			name: "basic relation",
+			relation: &model.Relation{
+				From: "DEC-001",
+				Type: "addresses",
+				To:   "REQ-001",
+			},
+			contains: []string{"from: DEC-001", "relation: addresses", "to: REQ-001"},
+		},
+		{
+			name: "relation with properties",
+			relation: &model.Relation{
+				From: "DEC-001",
+				Type: "addresses",
+				To:   "REQ-001",
+				Properties: map[string]interface{}{
+					"rationale": "Because it makes sense",
+				},
+			},
+			contains: []string{"from: DEC-001", "rationale: Because it makes sense"},
+		},
+		{
+			name: "relation with content",
+			relation: &model.Relation{
+				From:    "DEC-001",
+				Type:    "addresses",
+				To:      "REQ-001",
+				Content: "## Notes\n\nSome notes here.",
+			},
+			contains: []string{"## Notes", "Some notes here."},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatted, err := FormatRelation(tt.relation)
+			if err != nil {
+				t.Fatalf("FormatRelation failed: %v", err)
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(formatted, want) {
+					t.Errorf("formatted output missing %q:\n%s", want, formatted)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatRelation_KeyOrder(t *testing.T) {
+	relation := &model.Relation{
+		From: "DEC-001",
+		Type: "addresses",
+		To:   "REQ-001",
+		Properties: map[string]interface{}{
+			"alpha": "first",
+			"zebra": "last",
+		},
+	}
+
+	formatted, err := FormatRelation(relation)
+	if err != nil {
+		t.Fatalf("FormatRelation failed: %v", err)
+	}
+
+	// Check that from, relation, to appear before properties
+	fromIdx := strings.Index(formatted, "from:")
+	relationIdx := strings.Index(formatted, "relation:")
+	toIdx := strings.Index(formatted, "to:")
+	alphaIdx := strings.Index(formatted, "alpha:")
+	zebraIdx := strings.Index(formatted, "zebra:")
+
+	if fromIdx >= relationIdx || relationIdx >= toIdx {
+		t.Errorf("key order should be from, relation, to; got indices %d, %d, %d", fromIdx, relationIdx, toIdx)
+	}
+	if toIdx >= alphaIdx || toIdx >= zebraIdx {
+		t.Errorf("properties should come after from/relation/to; to=%d, alpha=%d, zebra=%d", toIdx, alphaIdx, zebraIdx)
+	}
+}
+
 func TestDeleteRelation(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1042,6 +1042,36 @@ func (w *Workspace) FormatEntity(entity *model.Entity, dryRun bool) (bool, error
 	return true, nil
 }
 
+// FormatRelation checks if a relation file needs formatting and optionally writes
+// the formatted version. Returns true if the file was (or would be) modified.
+func (w *Workspace) FormatRelation(relation *model.Relation, dryRun bool) (bool, error) {
+	// Generate formatted content
+	formatted, err := markdown.FormatRelation(relation)
+	if err != nil {
+		return false, fmt.Errorf("format relation: %w", err)
+	}
+
+	// Read current file content
+	current, err := w.repo.FS().ReadFile(relation.FilePath)
+	if err != nil {
+		return false, fmt.Errorf("read relation file: %w", err)
+	}
+
+	// Compare
+	if formatted == string(current) {
+		return false, nil
+	}
+
+	// Write if not dry-run
+	if !dryRun {
+		if err := w.repo.WriteRelation(relation); err != nil {
+			return false, fmt.Errorf("write relation: %w", err)
+		}
+	}
+
+	return true, nil
+}
+
 // --- File watching ---
 
 // WatchOptions configures the file watcher.

--- a/tickets/entities/tickets/TKT-9RZB.md
+++ b/tickets/entities/tickets/TKT-9RZB.md
@@ -1,0 +1,11 @@
+---
+id: TKT-9RZB
+type: ticket
+title: Add markdown content formatting to rela fmt
+kind: enhancement
+priority: medium
+effort: s
+status: in-progress
+---
+
+The markdown content (body) of entity files can be formatted differently by different editors, causing unnecessary git diffs. Extend the rela fmt command to also normalize markdown content, not just frontmatter property order.

--- a/tickets/relations/TKT-9RZB--affects--workspace.md
+++ b/tickets/relations/TKT-9RZB--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9RZB
+relation: affects
+to: workspace
+---

--- a/tickets/relations/TKT-9RZB--has-implementation--IMPL-B545.md
+++ b/tickets/relations/TKT-9RZB--has-implementation--IMPL-B545.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9RZB
+relation: has-implementation
+to: IMPL-B545
+---

--- a/tickets/relations/TKT-9RZB--has-planning--PLAN-604S.md
+++ b/tickets/relations/TKT-9RZB--has-planning--PLAN-604S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9RZB
+relation: has-planning
+to: PLAN-604S
+---

--- a/tickets/relations/TKT-9RZB--implements--FEAT-013.md
+++ b/tickets/relations/TKT-9RZB--implements--FEAT-013.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9RZB
+relation: implements
+to: FEAT-013
+---


### PR DESCRIPTION
## Summary
- Extend `rela fmt` to normalize markdown content in addition to frontmatter ordering
- Add goldmark-markdown dependency for AST-based markdown rendering
- Add relation formatting with proper key ordering (from, relation, to)

## Changes
- Convert setext headings to ATX style (#)
- Normalize list markers and indentation
- Remove trailing whitespace
- Ensure consistent trailing newlines

## Test plan
- [x] Unit tests for FormatMarkdown function
- [x] Unit tests for FormatRelation function
- [x] `just ci` passes locally
- [x] Manual test: `rela fmt --check` detects unformatted files