### PR TITLE
refactor(test): improve test patterns with entity references and EntityFor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,7 +388,7 @@ Each phase has a dedicated checklist entity with standard items from templates.
 
 **Ticket Workflow:**
 
-```
+```text
 backlog → ready → planning → in-progress → review → done
                      │            │           │
                      ▼            ▼           ▼
@@ -402,7 +402,7 @@ backlog → ready → planning → in-progress → review → done
 
 **Bug Workflow:**
 
-```
+```text
 backlog → ready → analyzing → in-progress → review → done
                      │            │           │
                      ▼            ▼           ▼
@@ -490,6 +490,7 @@ Alternatively, invoke the cranky-code-reviewer agent directly for ad-hoc reviews
 **Creating Review Responses:**
 
 For each finding from code review:
+
 1. Create a `review-response` entity with:
    - `title`: Brief description of the finding
    - `finding`: Full description of the issue
@@ -507,17 +508,20 @@ For each finding from code review:
 | nit | Optional, can wont-fix with reason |
 
 When addressing a finding:
+
 - Fix the issue in code
 - Update status to `addressed`
 - Document the `resolution` (how it was fixed)
 
 When not addressing:
+
 - Set status to `wont-fix` or `deferred`
 - Document the `reason` (justification required)
 
 **Validation Gates:**
 
 Tickets/bugs cannot be marked `done` if they have:
+
 - Open critical review responses
 - Open significant review responses
 
@@ -604,39 +608,41 @@ Follow these patterns to make tests clearer and more maintainable.
 
 **Use Test Fixture Builders:**
 
-Use builder patterns or factory functions to create test data. Only specify values that matter for the specific test - let fixtures handle defaults and generate random values for everything else.
+Use builder patterns or factory functions to create test data. Only specify values that matter
+for the specific test - let fixtures handle defaults and generate random values for everything
+else.
 
 **Avoid Hardcoded Values in Assertions:**
 
 Don't compare against hardcoded strings when the object is in scope:
 
-```
-// BAD - couples test to specific value
+```python
+# BAD - couples test to specific value
 entity = createEntity(id="T-001")
 assert relation.from == "T-001"
 
-// GOOD - uses object reference
+# GOOD - uses object reference
 entity = createEntity()
 assert relation.from == entity.id
 ```
 
 For interpolated values, construct the expected value from the object:
 
-```
-// BAD
+```python
+# BAD
 assert result.title == "Checklist for T-001"
 
-// GOOD
+# GOOD
 assert result.title == "Checklist for " + entity.id
 ```
 
 For preserved properties, compare against the original object:
 
-```
-// BAD
+```python
+# BAD
 assert updated.title == "Original Title"
 
-// GOOD
+# GOOD
 assert updated.title == original.title
 ```
 
@@ -650,12 +656,12 @@ assert updated.title == original.title
 
 When values are passed to helpers and then asserted, extract to variables:
 
-```
-// BAD - duplicated string
+```python
+# BAD - duplicated string
 createEntity(id="REQ-001")
 assert relation.from == "REQ-001"
 
-// GOOD - single source of truth
+# GOOD - single source of truth
 reqId = "REQ-001"
 createEntity(id=reqId)
 assert relation.from == reqId

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,7 +388,7 @@ Each phase has a dedicated checklist entity with standard items from templates.
 
 **Ticket Workflow:**
 
-```text
+```
 backlog → ready → planning → in-progress → review → done
                      │            │           │
                      ▼            ▼           ▼
@@ -402,7 +402,7 @@ backlog → ready → planning → in-progress → review → done
 
 **Bug Workflow:**
 
-```text
+```
 backlog → ready → analyzing → in-progress → review → done
                      │            │           │
                      ▼            ▼           ▼
@@ -490,7 +490,6 @@ Alternatively, invoke the cranky-code-reviewer agent directly for ad-hoc reviews
 **Creating Review Responses:**
 
 For each finding from code review:
-
 1. Create a `review-response` entity with:
    - `title`: Brief description of the finding
    - `finding`: Full description of the issue
@@ -508,20 +507,17 @@ For each finding from code review:
 | nit | Optional, can wont-fix with reason |
 
 When addressing a finding:
-
 - Fix the issue in code
 - Update status to `addressed`
 - Document the `resolution` (how it was fixed)
 
 When not addressing:
-
 - Set status to `wont-fix` or `deferred`
 - Document the `reason` (justification required)
 
 **Validation Gates:**
 
 Tickets/bugs cannot be marked `done` if they have:
-
 - Open critical review responses
 - Open significant review responses
 
@@ -608,40 +604,39 @@ Follow these patterns to make tests clearer and more maintainable.
 
 **Use Test Fixture Builders:**
 
-Use builder patterns or factory functions to create test data. Only specify values that matter for
-the specific test - let fixtures handle defaults and generate random values for everything else.
+Use builder patterns or factory functions to create test data. Only specify values that matter for the specific test - let fixtures handle defaults and generate random values for everything else.
 
 **Avoid Hardcoded Values in Assertions:**
 
 Don't compare against hardcoded strings when the object is in scope:
 
-```python
-# BAD - couples test to specific value
+```
+// BAD - couples test to specific value
 entity = createEntity(id="T-001")
 assert relation.from == "T-001"
 
-# GOOD - uses object reference
+// GOOD - uses object reference
 entity = createEntity()
 assert relation.from == entity.id
 ```
 
 For interpolated values, construct the expected value from the object:
 
-```python
-# BAD
+```
+// BAD
 assert result.title == "Checklist for T-001"
 
-# GOOD
+// GOOD
 assert result.title == "Checklist for " + entity.id
 ```
 
 For preserved properties, compare against the original object:
 
-```python
-# BAD
+```
+// BAD
 assert updated.title == "Original Title"
 
-# GOOD
+// GOOD
 assert updated.title == original.title
 ```
 
@@ -655,12 +650,12 @@ assert updated.title == original.title
 
 When values are passed to helpers and then asserted, extract to variables:
 
-```python
-# BAD - duplicated string
+```
+// BAD - duplicated string
 createEntity(id="REQ-001")
 assert relation.from == "REQ-001"
 
-# GOOD - single source of truth
+// GOOD - single source of truth
 reqId = "REQ-001"
 createEntity(id=reqId)
 assert relation.from == reqId

--- a/internal/automation/engine_test.go
+++ b/internal/automation/engine_test.go
@@ -283,7 +283,7 @@ func TestEngine_CreateRelation(t *testing.T) {
 		t.Fatalf("expected 1 relation to create, got %d", len(result.RelationsToCreate))
 	}
 	rel := result.RelationsToCreate[0]
-	if rel.From != "T-001" || rel.Type != "belongs-to" || rel.To != "sprint-current" {
+	if rel.From != entity.ID || rel.Type != "belongs-to" || rel.To != "sprint-current" {
 		t.Errorf("unexpected relation: %+v", rel)
 	}
 }

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -127,10 +127,8 @@ func TestListCommandWithAliases(t *testing.T) {
 	ws = workspace.NewForTest(g, meta)
 
 	// Add some test entities to the graph
-	g.AddNode(testutil.Entity("requirement").
+	g.AddNode(testutil.EntityFor(meta, "requirement").
 		ID("REQ-001").
-		With("title", "Test requirement").
-		With("status", "draft").
 		Build())
 
 	// Test using alias directly
@@ -249,8 +247,8 @@ func TestListAllEntities(t *testing.T) {
 	ws = workspace.NewForTest(g, meta)
 
 	// Add entities of different types
-	g.AddNode(testutil.Entity("requirement").ID("REQ-001").With("title", "Test Requirement").Build())
-	g.AddNode(testutil.Entity("decision").ID("DEC-001").With("title", "Test Decision").Build())
+	g.AddNode(testutil.EntityFor(meta, "requirement").ID("REQ-001").Build())
+	g.AddNode(testutil.EntityFor(meta, "decision").ID("DEC-001").Build())
 
 	// List all entities (no type filter)
 	entities := g.AllNodes()
@@ -277,9 +275,9 @@ func TestListByType(t *testing.T) {
 	ws = workspace.NewForTest(g, meta)
 
 	// Add entities
-	g.AddNode(testutil.Entity("requirement").ID("REQ-001").With("title", "Req 1").Build())
-	g.AddNode(testutil.Entity("requirement").ID("REQ-002").With("title", "Req 2").Build())
-	g.AddNode(testutil.Entity("decision").ID("DEC-001").With("title", "Dec 1").Build())
+	g.AddNode(testutil.EntityFor(meta, "requirement").ID("REQ-001").Build())
+	g.AddNode(testutil.EntityFor(meta, "requirement").ID("REQ-002").Build())
+	g.AddNode(testutil.EntityFor(meta, "decision").ID("DEC-001").Build())
 
 	// List only requirements
 	entities := g.NodesByType("requirement")

--- a/internal/dataentry/app_test.go
+++ b/internal/dataentry/app_test.go
@@ -116,11 +116,11 @@ func testConfig() *Config {
 }
 
 // testGraph returns a graph with some test entities.
-func testGraph() *graph.Graph {
+func testGraph(meta *metamodel.Metamodel) *graph.Graph {
 	g := graph.New()
-	g.AddNode(testutil.Entity("ticket").ID("TKT-001").With("title", "First Ticket").With("status", "open").With("priority", "high").Build())
-	g.AddNode(testutil.Entity("ticket").ID("TKT-002").With("title", "Second Ticket").With("status", "closed").With("priority", "low").Build())
-	g.AddNode(testutil.Entity("component").ID("CMP-001").With("name", "Frontend").Build())
+	g.AddNode(testutil.EntityFor(meta, "ticket").ID("TKT-001").With("title", "First Ticket").With("status", "open").With("priority", "high").Build())
+	g.AddNode(testutil.EntityFor(meta, "ticket").ID("TKT-002").With("title", "Second Ticket").With("status", "closed").With("priority", "low").Build())
+	g.AddNode(testutil.EntityFor(meta, "component").ID("CMP-001").With("name", "Frontend").Build())
 	return g
 }
 
@@ -128,7 +128,7 @@ func testGraph() *graph.Graph {
 func testAppInstance() *App {
 	cfg := testConfig()
 	meta := testMeta()
-	g := testGraph()
+	g := testGraph(meta)
 	styleMap, styledTypes := buildStyleMap(cfg, meta)
 	tmpl, _ := template.New("").Funcs(templateFuncs(styleMap, styledTypes)).Parse(allTemplates())
 	return &App{

--- a/internal/dataentry/handlers_graph_test.go
+++ b/internal/dataentry/handlers_graph_test.go
@@ -16,7 +16,7 @@ func newGraphTestApp(t *testing.T) *App {
 	t.Helper()
 	meta := testMeta()
 	cfg := testConfig()
-	g := testGraph()
+	g := testGraph(meta)
 
 	// Add a relation edge for testing
 	g.AddEdge(model.NewRelation("TKT-001", "depends_on", "TKT-002"))
@@ -419,7 +419,7 @@ func TestNavElementsGraphSkipsCount(t *testing.T) {
 func TestBuildContentGraphDataEmptyGraph(t *testing.T) {
 	meta := testMeta()
 	cfg := testConfig()
-	g := testGraph()
+	g := testGraph(meta)
 
 	// Remove all nodes
 	for _, n := range g.AllNodes() {

--- a/internal/dataentry/handlers_test.go
+++ b/internal/dataentry/handlers_test.go
@@ -23,7 +23,7 @@ func newHandlerTestApp(t *testing.T) *App {
 	t.Helper()
 	meta := testMeta()
 	cfg := testConfig()
-	g := testGraph()
+	g := testGraph(meta)
 
 	// Add a relation for testing edge display
 	g.AddEdge(testutil.NewRelation("TKT-001", "depends_on", "TKT-002").Build())

--- a/internal/dataentry/handlers_test.go
+++ b/internal/dataentry/handlers_test.go
@@ -1146,9 +1146,11 @@ func TestHandleExecuteQuery(t *testing.T) {
 	})
 
 	t.Run("free text query", func(t *testing.T) {
+		// testGraph creates TKT-001 with title "First Ticket"
+		firstTicket, _ := app.g.GetNode("TKT-001")
 		results := app.executeQuery("First")
-		if len(results) != 1 || results[0].ID != "TKT-001" {
-			t.Errorf("expected [TKT-001], got %v", collectIDs(results))
+		if len(results) != 1 || results[0].ID != firstTicket.ID {
+			t.Errorf("expected [%s], got %v", firstTicket.ID, collectIDs(results))
 		}
 	})
 
@@ -1160,9 +1162,11 @@ func TestHandleExecuteQuery(t *testing.T) {
 	})
 
 	t.Run("property filter query", func(t *testing.T) {
+		// testGraph creates TKT-001 with status "open"
+		openTicket, _ := app.g.GetNode("TKT-001")
 		results := app.executeQuery("type:ticket status:open")
-		if len(results) != 1 || results[0].ID != "TKT-001" {
-			t.Errorf("expected [TKT-001], got %v", collectIDs(results))
+		if len(results) != 1 || results[0].ID != openTicket.ID {
+			t.Errorf("expected [%s], got %v", openTicket.ID, collectIDs(results))
 		}
 	})
 }
@@ -1301,9 +1305,10 @@ func TestHandleSaveSettings(t *testing.T) {
 
 	t.Run("saves global relation defaults", func(t *testing.T) {
 		app := newHandlerTestApp(t)
+		component, _ := app.g.GetNode("CMP-001")
 
 		form := url.Values{
-			"default_rel[belongs_to]": {"CMP-001"},
+			"default_rel[belongs_to]": {component.ID},
 		}
 		r := httptest.NewRequest(http.MethodPost, "/api/settings", strings.NewReader(form.Encode()))
 		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -1312,18 +1317,19 @@ func TestHandleSaveSettings(t *testing.T) {
 		if w.Code != http.StatusOK {
 			t.Errorf("expected 200, got %d", w.Code)
 		}
-		if app.userDefaults.RelationDefaults["belongs_to"] != "CMP-001" {
-			t.Errorf("expected belongs_to=CMP-001, got %q", app.userDefaults.RelationDefaults["belongs_to"])
+		if app.userDefaults.RelationDefaults["belongs_to"] != component.ID {
+			t.Errorf("expected belongs_to=%s, got %q", component.ID, app.userDefaults.RelationDefaults["belongs_to"])
 		}
 	})
 
 	t.Run("saves override groups", func(t *testing.T) {
 		app := newHandlerTestApp(t)
+		ticket2, _ := app.g.GetNode("TKT-002")
 
 		form := url.Values{
 			"override[0][types]":           {"ticket"},
 			"override[0][prop][priority]":  {"high"},
-			"override[0][rel][depends_on]": {"TKT-002"},
+			"override[0][rel][depends_on]": {ticket2.ID},
 		}
 		r := httptest.NewRequest(http.MethodPost, "/api/settings", strings.NewReader(form.Encode()))
 		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -1342,8 +1348,8 @@ func TestHandleSaveSettings(t *testing.T) {
 		if o.Defaults["priority"] != "high" {
 			t.Errorf("expected priority=high, got %q", o.Defaults["priority"])
 		}
-		if o.RelationDefaults["depends_on"] != "TKT-002" {
-			t.Errorf("expected depends_on=TKT-002, got %q", o.RelationDefaults["depends_on"])
+		if o.RelationDefaults["depends_on"] != ticket2.ID {
+			t.Errorf("expected depends_on=%s, got %q", ticket2.ID, o.RelationDefaults["depends_on"])
 		}
 	})
 
@@ -1452,8 +1458,9 @@ func TestHandleFormWithUserDefaults(t *testing.T) {
 
 	t.Run("create form uses user defaults for relation", func(t *testing.T) {
 		app := newHandlerTestApp(t)
+		component, _ := app.g.GetNode("CMP-001")
 		app.userDefaults = &UserDefaults{
-			RelationDefaults: map[string]string{"belongs_to": "CMP-001"},
+			RelationDefaults: map[string]string{"belongs_to": component.ID},
 		}
 		// Need a form with a relation field
 		app.Cfg.Forms["create-ticket-rel"] = Form{
@@ -1473,9 +1480,10 @@ func TestHandleFormWithUserDefaults(t *testing.T) {
 			t.Errorf("expected 200, got %d", w.Code)
 		}
 		body := w.Body.String()
-		// CMP-001 should be pre-selected as the default relation target
-		if !strings.Contains(body, `value="CMP-001" selected`) {
-			t.Error("expected CMP-001 to be pre-selected as user default relation")
+		// Component should be pre-selected as the default relation target
+		expectedAttr := `value="` + component.ID + `" selected`
+		if !strings.Contains(body, expectedAttr) {
+			t.Errorf("expected %s to be pre-selected as user default relation", component.ID)
 		}
 	})
 
@@ -1571,6 +1579,9 @@ func TestHandleLinkCandidates(t *testing.T) {
 	t.Run("returns candidates excluding already linked", func(t *testing.T) {
 		app := newHandlerTestApp(t)
 		// TKT-001 depends_on TKT-002 (added in newHandlerTestApp)
+		ticket1, _ := app.g.GetNode("TKT-001")
+		ticket2, _ := app.g.GetNode("TKT-002")
+
 		r := httptest.NewRequest(http.MethodGet,
 			"/api/link-candidates?relation=depends_on&link_as=to&peer=TKT-001&entity_types=ticket",
 			http.NoBody)
@@ -1589,11 +1600,11 @@ func TestHandleLinkCandidates(t *testing.T) {
 		}
 		// TKT-002 is already linked, TKT-001 is self — expect empty
 		for _, c := range candidates {
-			if c.ID == "TKT-002" {
-				t.Error("TKT-002 should be excluded (already linked)")
+			if c.ID == ticket2.ID {
+				t.Errorf("%s should be excluded (already linked)", ticket2.ID)
 			}
-			if c.ID == "TKT-001" {
-				t.Error("TKT-001 should be excluded (self)")
+			if c.ID == ticket1.ID {
+				t.Errorf("%s should be excluded (self)", ticket1.ID)
 			}
 		}
 	})
@@ -1601,7 +1612,8 @@ func TestHandleLinkCandidates(t *testing.T) {
 	t.Run("filters by search query", func(t *testing.T) {
 		app := newHandlerTestApp(t)
 		// Add a third ticket
-		app.g.AddNode(testutil.EntityFor(app.meta, "ticket").ID("TKT-003").With("title", "Third Ticket").Build())
+		thirdTicket := testutil.EntityFor(app.meta, "ticket").ID("TKT-003").With("title", "Third Ticket").Build()
+		app.g.AddNode(thirdTicket)
 
 		r := httptest.NewRequest(http.MethodGet,
 			"/api/link-candidates?relation=depends_on&link_as=to&peer=TKT-001&entity_types=ticket&q=Third",
@@ -1620,8 +1632,8 @@ func TestHandleLinkCandidates(t *testing.T) {
 		if len(candidates) != 1 {
 			t.Fatalf("expected 1 candidate, got %d", len(candidates))
 		}
-		if candidates[0].ID != "TKT-003" {
-			t.Errorf("expected TKT-003, got %s", candidates[0].ID)
+		if candidates[0].ID != thirdTicket.ID {
+			t.Errorf("expected %s, got %s", thirdTicket.ID, candidates[0].ID)
 		}
 	})
 

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -128,10 +128,11 @@ func TestPropertyIsEmpty(t *testing.T) {
 }
 
 func TestApplyFilters(t *testing.T) {
+	meta := testMeta()
 	entities := []*model.Entity{
-		testutil.Entity("ticket").ID("E-001").With("status", "open").With("priority", "high").Build(),
-		testutil.Entity("ticket").ID("E-002").With("status", "closed").With("priority", "low").Build(),
-		testutil.Entity("ticket").ID("E-003").With("status", "open").With("priority", "low").Build(),
+		testutil.EntityFor(meta, "ticket").ID("E-001").With("status", "open").With("priority", "high").Build(),
+		testutil.EntityFor(meta, "ticket").ID("E-002").With("status", "closed").With("priority", "low").Build(),
+		testutil.EntityFor(meta, "ticket").ID("E-003").With("status", "open").With("priority", "low").Build(),
 	}
 
 	tests := []struct {
@@ -199,6 +200,8 @@ func TestApplyFilters(t *testing.T) {
 }
 
 func TestApplyFiltersMultiSelect(t *testing.T) {
+	// Note: Using Entity() here because "clause" type is not in testMeta()
+	// and the test is specifically testing multi-select property filtering logic
 	entities := []*model.Entity{
 		testutil.Entity("clause").ID("E-001").With("applies_to", "client").Build(),
 		testutil.Entity("clause").ID("E-002").WithList("applies_to", "client", "provider").Build(),
@@ -265,6 +268,8 @@ func TestSortEntitiesMulti(t *testing.T) {
 	}
 
 	makeEntities := func() []*model.Entity {
+		// Note: Using Entity() here because "item" type is not in testMeta()
+		// and the test is specifically testing sorting logic, not entity creation
 		return []*model.Entity{
 			testutil.Entity("item").ID("E-003").With("name", "Charlie").Build(),
 			testutil.Entity("item").ID("E-001").With("name", "Alice").Build(),
@@ -309,6 +314,7 @@ func TestSortEntitiesMulti(t *testing.T) {
 	})
 
 	t.Run("nil property values sort to end", func(t *testing.T) {
+		// Note: Using Entity() here because "item" type is not in testMeta()
 		entities := []*model.Entity{
 			testutil.Entity("item").ID("E-001").With("name", "Bob").Build(),
 			testutil.Entity("item").ID("E-002").Build(),
@@ -1006,9 +1012,9 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	}
 
 	g := graph.New()
-	assessment := testutil.Entity("assessment").ID("ASS-001").With("title", "Q1 Review").Build()
-	person1 := testutil.Entity("person").ID("PER-001").With("name", "Alice").Build()
-	person2 := testutil.Entity("person").ID("PER-002").With("name", "Bob").Build()
+	assessment := testutil.EntityFor(meta, "assessment").ID("ASS-001").With("title", "Q1 Review").Build()
+	person1 := testutil.EntityFor(meta, "person").ID("PER-001").With("name", "Alice").Build()
+	person2 := testutil.EntityFor(meta, "person").ID("PER-002").With("name", "Bob").Build()
 	g.AddNode(assessment)
 	g.AddNode(person1)
 	g.AddNode(person2)
@@ -1150,7 +1156,7 @@ func TestFilterByRelation(t *testing.T) {
 		Entities: map[string]metamodel.EntityDef{
 			"ticket": {
 				Properties: map[string]metamodel.PropertyDef{
-					"title": {Type: "string"},
+					"title": {Type: "string", Required: true},
 				},
 			},
 			"component": {
@@ -1171,25 +1177,25 @@ func TestFilterByRelation(t *testing.T) {
 	g := graph.New()
 
 	// Create components
-	cmpFrontend := testutil.Entity("component").ID("CMP-001").With("name", "Frontend").Build()
-	cmpBackend := testutil.Entity("component").ID("CMP-002").With("name", "Backend").Build()
+	cmpFrontend := testutil.EntityFor(meta, "component").ID("CMP-001").With("name", "Frontend").Build()
+	cmpBackend := testutil.EntityFor(meta, "component").ID("CMP-002").With("name", "Backend").Build()
 	g.AddNode(cmpFrontend)
 	g.AddNode(cmpBackend)
 
 	// Create tickets with relations to components
-	tkt1 := testutil.Entity("ticket").ID("TKT-001").With("title", "Frontend bug").Build()
+	tkt1 := testutil.EntityFor(meta, "ticket").ID("TKT-001").With("title", "Frontend bug").Build()
 	g.AddNode(tkt1)
 	g.AddEdge(testutil.NewRelation(tkt1.ID, "belongs_to", cmpFrontend.ID).Build())
 
-	tkt2 := testutil.Entity("ticket").ID("TKT-002").With("title", "Backend bug").Build()
+	tkt2 := testutil.EntityFor(meta, "ticket").ID("TKT-002").With("title", "Backend bug").Build()
 	g.AddNode(tkt2)
 	g.AddEdge(testutil.NewRelation(tkt2.ID, "belongs_to", cmpBackend.ID).Build())
 
-	tkt3 := testutil.Entity("ticket").ID("TKT-003").With("title", "Another frontend bug").Build()
+	tkt3 := testutil.EntityFor(meta, "ticket").ID("TKT-003").With("title", "Another frontend bug").Build()
 	g.AddNode(tkt3)
 	g.AddEdge(testutil.NewRelation(tkt3.ID, "belongs_to", cmpFrontend.ID).Build())
 
-	tkt4 := testutil.Entity("ticket").ID("TKT-004").With("title", "No component ticket").Build()
+	tkt4 := testutil.EntityFor(meta, "ticket").ID("TKT-004").With("title", "No component ticket").Build()
 	g.AddNode(tkt4)
 	// No relation for TKT-004
 
@@ -1247,7 +1253,7 @@ func TestResolveRelationFilterValues(t *testing.T) {
 		Entities: map[string]metamodel.EntityDef{
 			"ticket": {
 				Properties: map[string]metamodel.PropertyDef{
-					"title": {Type: "string"},
+					"title": {Type: "string", Required: true},
 				},
 			},
 			"component": {
@@ -1268,28 +1274,28 @@ func TestResolveRelationFilterValues(t *testing.T) {
 	g := graph.New()
 
 	// Create components
-	cmpFrontend := testutil.Entity("component").ID("CMP-001").With("name", "Frontend").Build()
-	cmpBackend := testutil.Entity("component").ID("CMP-002").With("name", "Backend").Build()
-	cmpAPI := testutil.Entity("component").ID("CMP-003").With("name", "API").Build()
+	cmpFrontend := testutil.EntityFor(meta, "component").ID("CMP-001").With("name", "Frontend").Build()
+	cmpBackend := testutil.EntityFor(meta, "component").ID("CMP-002").With("name", "Backend").Build()
+	cmpAPI := testutil.EntityFor(meta, "component").ID("CMP-003").With("name", "API").Build()
 	g.AddNode(cmpFrontend)
 	g.AddNode(cmpBackend)
 	g.AddNode(cmpAPI)
 
 	// Create tickets with relations
-	tkt1 := testutil.Entity("ticket").ID("TKT-001").With("title", "Ticket 1").Build()
+	tkt1 := testutil.EntityFor(meta, "ticket").ID("TKT-001").With("title", "Ticket 1").Build()
 	g.AddNode(tkt1)
 	g.AddEdge(testutil.NewRelation(tkt1.ID, "belongs_to", cmpFrontend.ID).Build())
 
-	tkt2 := testutil.Entity("ticket").ID("TKT-002").With("title", "Ticket 2").Build()
+	tkt2 := testutil.EntityFor(meta, "ticket").ID("TKT-002").With("title", "Ticket 2").Build()
 	g.AddNode(tkt2)
 	g.AddEdge(testutil.NewRelation(tkt2.ID, "belongs_to", cmpBackend.ID).Build())
 
-	tkt3 := testutil.Entity("ticket").ID("TKT-003").With("title", "Ticket 3").Build()
+	tkt3 := testutil.EntityFor(meta, "ticket").ID("TKT-003").With("title", "Ticket 3").Build()
 	g.AddNode(tkt3)
 	g.AddEdge(testutil.NewRelation(tkt3.ID, "belongs_to", cmpFrontend.ID).Build()) // duplicate Frontend
 
 	// TKT-004 has no relation
-	tkt4 := testutil.Entity("ticket").ID("TKT-004").With("title", "Ticket 4").Build()
+	tkt4 := testutil.EntityFor(meta, "ticket").ID("TKT-004").With("title", "Ticket 4").Build()
 	g.AddNode(tkt4)
 
 	app := &App{meta: meta, g: g}
@@ -1348,10 +1354,10 @@ func TestResolveScope(t *testing.T) {
 
 	makeGraph := func() *graph.Graph {
 		g := graph.New()
-		g.AddNode(testutil.Entity("ticket").ID("T-001").With("status", "open").With("priority", "high").Build())
-		g.AddNode(testutil.Entity("ticket").ID("T-002").With("status", "closed").With("priority", "low").Build())
-		g.AddNode(testutil.Entity("ticket").ID("T-003").With("status", "open").With("priority", "medium").Build())
-		g.AddNode(testutil.Entity("ticket").ID("T-004").With("status", "open").With("priority", "low").Build())
+		g.AddNode(testutil.EntityFor(meta, "ticket").ID("T-001").With("status", "open").With("priority", "high").Build())
+		g.AddNode(testutil.EntityFor(meta, "ticket").ID("T-002").With("status", "closed").With("priority", "low").Build())
+		g.AddNode(testutil.EntityFor(meta, "ticket").ID("T-003").With("status", "open").With("priority", "medium").Build())
+		g.AddNode(testutil.EntityFor(meta, "ticket").ID("T-004").With("status", "open").With("priority", "low").Build())
 		return g
 	}
 
@@ -1545,7 +1551,7 @@ func TestResolveScope(t *testing.T) {
 			Entities: map[string]metamodel.EntityDef{
 				"ticket": {
 					Properties: map[string]metamodel.PropertyDef{
-						"title": {Type: "string"},
+						"title": {Type: "string", Required: true},
 					},
 				},
 				"component": {
@@ -1560,12 +1566,12 @@ func TestResolveScope(t *testing.T) {
 		}
 
 		relGraph := graph.New()
-		cmp := testutil.Entity("component").ID("CMP-001").With("name", "Frontend").Build()
+		cmp := testutil.EntityFor(relMeta, "component").ID("CMP-001").With("name", "Frontend").Build()
 		relGraph.AddNode(cmp)
 
-		t1 := testutil.Entity("ticket").ID("T-001").With("title", "Ticket 1").Build()
-		t2 := testutil.Entity("ticket").ID("T-002").With("title", "Ticket 2").Build()
-		t3 := testutil.Entity("ticket").ID("T-003").With("title", "Ticket 3").Build()
+		t1 := testutil.EntityFor(relMeta, "ticket").ID("T-001").With("title", "Ticket 1").Build()
+		t2 := testutil.EntityFor(relMeta, "ticket").ID("T-002").With("title", "Ticket 2").Build()
+		t3 := testutil.EntityFor(relMeta, "ticket").ID("T-003").With("title", "Ticket 3").Build()
 		relGraph.AddNode(t1)
 		relGraph.AddNode(t2)
 		relGraph.AddNode(t3)

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -1006,18 +1006,21 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	}
 
 	g := graph.New()
-	g.AddNode(testutil.Entity("assessment").ID("ASS-001").With("title", "Q1 Review").Build())
-	g.AddNode(testutil.Entity("person").ID("PER-001").With("name", "Alice").Build())
-	g.AddNode(testutil.Entity("person").ID("PER-002").With("name", "Bob").Build())
+	assessment := testutil.Entity("assessment").ID("ASS-001").With("title", "Q1 Review").Build()
+	person1 := testutil.Entity("person").ID("PER-001").With("name", "Alice").Build()
+	person2 := testutil.Entity("person").ID("PER-002").With("name", "Bob").Build()
+	g.AddNode(assessment)
+	g.AddNode(person1)
+	g.AddNode(person2)
 
-	g.AddEdge(testutil.NewRelation("ASS-001", "assessmentBy", "PER-001").Build())
-	g.AddEdge(testutil.NewRelation("ASS-001", "assessmentBy", "PER-002").Build())
-	g.AddEdge(testutil.NewRelation("ASS-001", "otherRel", "PER-001").Build())
+	g.AddEdge(testutil.NewRelation(assessment.ID, "assessmentBy", person1.ID).Build())
+	g.AddEdge(testutil.NewRelation(assessment.ID, "assessmentBy", person2.ID).Build())
+	g.AddEdge(testutil.NewRelation(assessment.ID, "otherRel", person1.ID).Build())
 
 	app := &App{meta: meta, g: g}
 
 	t.Run("resolves multiple targets", func(t *testing.T) {
-		got := app.resolveRelationColumnValues("ASS-001", "assessmentBy", "")
+		got := app.resolveRelationColumnValues(assessment.ID, "assessmentBy", "")
 		want := []string{"Alice", "Bob"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -1025,7 +1028,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	})
 
 	t.Run("filters by relation type", func(t *testing.T) {
-		got := app.resolveRelationColumnValues("ASS-001", "otherRel", "")
+		got := app.resolveRelationColumnValues(assessment.ID, "otherRel", "")
 		want := []string{"Alice"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -1033,7 +1036,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	})
 
 	t.Run("returns empty for no matching relations", func(t *testing.T) {
-		got := app.resolveRelationColumnValues("ASS-001", "nonexistent", "")
+		got := app.resolveRelationColumnValues(assessment.ID, "nonexistent", "")
 		if len(got) != 0 {
 			t.Errorf("got %v, want empty slice", got)
 		}
@@ -1047,7 +1050,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	})
 
 	t.Run("direction outgoing explicit", func(t *testing.T) {
-		got := app.resolveRelationColumnValues("ASS-001", "assessmentBy", "outgoing")
+		got := app.resolveRelationColumnValues(assessment.ID, "assessmentBy", "outgoing")
 		want := []string{"Alice", "Bob"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -1057,8 +1060,8 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	t.Run("direction incoming returns sources", func(t *testing.T) {
 		// PER-001 has an incoming edge from ASS-001 via assessmentBy
 		// Assessment title is not required, so falls back to ID
-		got := app.resolveRelationColumnValues("PER-001", "assessmentBy", "incoming")
-		want := []string{"ASS-001"}
+		got := app.resolveRelationColumnValues(person1.ID, "assessmentBy", "incoming")
+		want := []string{assessment.ID}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
 		}
@@ -1066,15 +1069,15 @@ func TestResolveRelationColumnValue(t *testing.T) {
 
 	t.Run("direction incoming returns multiple sources", func(t *testing.T) {
 		// PER-001 is target of both assessmentBy and otherRel from ASS-001
-		got := app.resolveRelationColumnValues("PER-001", "otherRel", "incoming")
-		want := []string{"ASS-001"}
+		got := app.resolveRelationColumnValues(person1.ID, "otherRel", "incoming")
+		want := []string{assessment.ID}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
 		}
 	})
 
 	t.Run("direction incoming no matches", func(t *testing.T) {
-		got := app.resolveRelationColumnValues("ASS-001", "assessmentBy", "incoming")
+		got := app.resolveRelationColumnValues(assessment.ID, "assessmentBy", "incoming")
 		if len(got) != 0 {
 			t.Errorf("got %v, want empty slice", got)
 		}
@@ -1168,20 +1171,26 @@ func TestFilterByRelation(t *testing.T) {
 	g := graph.New()
 
 	// Create components
-	g.AddNode(testutil.Entity("component").ID("CMP-001").With("name", "Frontend").Build())
-	g.AddNode(testutil.Entity("component").ID("CMP-002").With("name", "Backend").Build())
+	cmpFrontend := testutil.Entity("component").ID("CMP-001").With("name", "Frontend").Build()
+	cmpBackend := testutil.Entity("component").ID("CMP-002").With("name", "Backend").Build()
+	g.AddNode(cmpFrontend)
+	g.AddNode(cmpBackend)
 
 	// Create tickets with relations to components
-	g.AddNode(testutil.Entity("ticket").ID("TKT-001").With("title", "Frontend bug").Build())
-	g.AddEdge(testutil.NewRelation("TKT-001", "belongs_to", "CMP-001").Build())
+	tkt1 := testutil.Entity("ticket").ID("TKT-001").With("title", "Frontend bug").Build()
+	g.AddNode(tkt1)
+	g.AddEdge(testutil.NewRelation(tkt1.ID, "belongs_to", cmpFrontend.ID).Build())
 
-	g.AddNode(testutil.Entity("ticket").ID("TKT-002").With("title", "Backend bug").Build())
-	g.AddEdge(testutil.NewRelation("TKT-002", "belongs_to", "CMP-002").Build())
+	tkt2 := testutil.Entity("ticket").ID("TKT-002").With("title", "Backend bug").Build()
+	g.AddNode(tkt2)
+	g.AddEdge(testutil.NewRelation(tkt2.ID, "belongs_to", cmpBackend.ID).Build())
 
-	g.AddNode(testutil.Entity("ticket").ID("TKT-003").With("title", "Another frontend bug").Build())
-	g.AddEdge(testutil.NewRelation("TKT-003", "belongs_to", "CMP-001").Build())
+	tkt3 := testutil.Entity("ticket").ID("TKT-003").With("title", "Another frontend bug").Build()
+	g.AddNode(tkt3)
+	g.AddEdge(testutil.NewRelation(tkt3.ID, "belongs_to", cmpFrontend.ID).Build())
 
-	g.AddNode(testutil.Entity("ticket").ID("TKT-004").With("title", "No component ticket").Build())
+	tkt4 := testutil.Entity("ticket").ID("TKT-004").With("title", "No component ticket").Build()
+	g.AddNode(tkt4)
 	// No relation for TKT-004
 
 	app := &App{meta: meta, g: g}
@@ -1193,8 +1202,8 @@ func TestFilterByRelation(t *testing.T) {
 		if len(got) != 2 {
 			t.Fatalf("expected 2 results, got %d: %v", len(got), gotIDs)
 		}
-		if !sliceContainsStr(gotIDs, "TKT-001") || !sliceContainsStr(gotIDs, "TKT-003") {
-			t.Errorf("expected TKT-001 and TKT-003, got %v", gotIDs)
+		if !sliceContainsStr(gotIDs, tkt1.ID) || !sliceContainsStr(gotIDs, tkt3.ID) {
+			t.Errorf("expected %s and %s, got %v", tkt1.ID, tkt3.ID, gotIDs)
 		}
 	})
 
@@ -1204,8 +1213,8 @@ func TestFilterByRelation(t *testing.T) {
 		if len(got) != 1 {
 			t.Fatalf("expected 1 result, got %d: %v", len(got), gotIDs)
 		}
-		if gotIDs[0] != "TKT-002" {
-			t.Errorf("expected TKT-002, got %v", gotIDs)
+		if gotIDs[0] != tkt2.ID {
+			t.Errorf("expected %s, got %v", tkt2.ID, gotIDs)
 		}
 	})
 
@@ -1226,8 +1235,8 @@ func TestFilterByRelation(t *testing.T) {
 	t.Run("handles entities without relations", func(t *testing.T) {
 		got := app.filterByRelation(allTickets, "belongs_to", "Frontend")
 		for _, e := range got {
-			if e.ID == "TKT-004" {
-				t.Error("TKT-004 should not be in results (has no belongs_to relation)")
+			if e.ID == tkt4.ID {
+				t.Errorf("%s should not be in results (has no belongs_to relation)", tkt4.ID)
 			}
 		}
 	})
@@ -1259,22 +1268,29 @@ func TestResolveRelationFilterValues(t *testing.T) {
 	g := graph.New()
 
 	// Create components
-	g.AddNode(testutil.Entity("component").ID("CMP-001").With("name", "Frontend").Build())
-	g.AddNode(testutil.Entity("component").ID("CMP-002").With("name", "Backend").Build())
-	g.AddNode(testutil.Entity("component").ID("CMP-003").With("name", "API").Build())
+	cmpFrontend := testutil.Entity("component").ID("CMP-001").With("name", "Frontend").Build()
+	cmpBackend := testutil.Entity("component").ID("CMP-002").With("name", "Backend").Build()
+	cmpAPI := testutil.Entity("component").ID("CMP-003").With("name", "API").Build()
+	g.AddNode(cmpFrontend)
+	g.AddNode(cmpBackend)
+	g.AddNode(cmpAPI)
 
 	// Create tickets with relations
-	g.AddNode(testutil.Entity("ticket").ID("TKT-001").With("title", "Ticket 1").Build())
-	g.AddEdge(testutil.NewRelation("TKT-001", "belongs_to", "CMP-001").Build())
+	tkt1 := testutil.Entity("ticket").ID("TKT-001").With("title", "Ticket 1").Build()
+	g.AddNode(tkt1)
+	g.AddEdge(testutil.NewRelation(tkt1.ID, "belongs_to", cmpFrontend.ID).Build())
 
-	g.AddNode(testutil.Entity("ticket").ID("TKT-002").With("title", "Ticket 2").Build())
-	g.AddEdge(testutil.NewRelation("TKT-002", "belongs_to", "CMP-002").Build())
+	tkt2 := testutil.Entity("ticket").ID("TKT-002").With("title", "Ticket 2").Build()
+	g.AddNode(tkt2)
+	g.AddEdge(testutil.NewRelation(tkt2.ID, "belongs_to", cmpBackend.ID).Build())
 
-	g.AddNode(testutil.Entity("ticket").ID("TKT-003").With("title", "Ticket 3").Build())
-	g.AddEdge(testutil.NewRelation("TKT-003", "belongs_to", "CMP-001").Build()) // duplicate Frontend
+	tkt3 := testutil.Entity("ticket").ID("TKT-003").With("title", "Ticket 3").Build()
+	g.AddNode(tkt3)
+	g.AddEdge(testutil.NewRelation(tkt3.ID, "belongs_to", cmpFrontend.ID).Build()) // duplicate Frontend
 
 	// TKT-004 has no relation
-	g.AddNode(testutil.Entity("ticket").ID("TKT-004").With("title", "Ticket 4").Build())
+	tkt4 := testutil.Entity("ticket").ID("TKT-004").With("title", "Ticket 4").Build()
+	g.AddNode(tkt4)
 
 	app := &App{meta: meta, g: g}
 	allTickets := g.NodesByType("ticket")
@@ -1544,15 +1560,19 @@ func TestResolveScope(t *testing.T) {
 		}
 
 		relGraph := graph.New()
-		relGraph.AddNode(testutil.Entity("component").ID("CMP-001").With("name", "Frontend").Build())
+		cmp := testutil.Entity("component").ID("CMP-001").With("name", "Frontend").Build()
+		relGraph.AddNode(cmp)
 
-		relGraph.AddNode(testutil.Entity("ticket").ID("T-001").With("title", "Ticket 1").Build())
-		relGraph.AddNode(testutil.Entity("ticket").ID("T-002").With("title", "Ticket 2").Build())
-		relGraph.AddNode(testutil.Entity("ticket").ID("T-003").With("title", "Ticket 3").Build())
+		t1 := testutil.Entity("ticket").ID("T-001").With("title", "Ticket 1").Build()
+		t2 := testutil.Entity("ticket").ID("T-002").With("title", "Ticket 2").Build()
+		t3 := testutil.Entity("ticket").ID("T-003").With("title", "Ticket 3").Build()
+		relGraph.AddNode(t1)
+		relGraph.AddNode(t2)
+		relGraph.AddNode(t3)
 
 		// Only T-001 and T-002 belong to Frontend
-		relGraph.AddEdge(testutil.NewRelation("T-001", "belongs_to", "CMP-001").Build())
-		relGraph.AddEdge(testutil.NewRelation("T-002", "belongs_to", "CMP-001").Build())
+		relGraph.AddEdge(testutil.NewRelation(t1.ID, "belongs_to", cmp.ID).Build())
+		relGraph.AddEdge(testutil.NewRelation(t2.ID, "belongs_to", cmp.ID).Build())
 
 		relApp := &App{
 			meta: relMeta,
@@ -1570,8 +1590,8 @@ func TestResolveScope(t *testing.T) {
 			},
 		}
 
-		r := makeRequest("/entity/ticket/T-001?scope=list:tickets&filter_belongs_to=Frontend")
-		got := relApp.resolveScope("T-001", r)
+		r := makeRequest("/entity/ticket/" + t1.ID + "?scope=list:tickets&filter_belongs_to=Frontend")
+		got := relApp.resolveScope(t1.ID, r)
 		if got == nil {
 			t.Fatal("expected non-nil scope")
 		}

--- a/internal/dataentry/views_test.go
+++ b/internal/dataentry/views_test.go
@@ -44,10 +44,10 @@ func testViewApp() *App {
 	}
 
 	g := graph.New()
-	g.AddNode(testutil.Entity("ticket").ID("TKT-001").With("title", "First").With("status", "open").Build())
-	g.AddNode(testutil.Entity("ticket").ID("TKT-002").With("title", "Second").With("status", "closed").Build())
-	g.AddNode(testutil.Entity("ticket").ID("TKT-003").With("title", "Third").Build())
-	g.AddNode(testutil.Entity("component").ID("CMP-001").With("name", "Frontend").Build())
+	g.AddNode(testutil.EntityFor(meta, "ticket").ID("TKT-001").With("title", "First").With("status", "open").Build())
+	g.AddNode(testutil.EntityFor(meta, "ticket").ID("TKT-002").With("title", "Second").With("status", "closed").Build())
+	g.AddNode(testutil.EntityFor(meta, "ticket").ID("TKT-003").With("title", "Third").Build())
+	g.AddNode(testutil.EntityFor(meta, "component").ID("CMP-001").With("name", "Frontend").Build())
 
 	g.AddEdge(testutil.NewRelation("TKT-001", "depends_on", "TKT-002").Build())
 	g.AddEdge(testutil.NewRelation("TKT-002", "depends_on", "TKT-003").Build())
@@ -319,17 +319,17 @@ func testViewAppWithMixedTypes() *App {
 	g := graph.New()
 
 	// Bouwblok
-	g.AddNode(testutil.Entity("bouwblok").ID("BOUWBLOK-001").With("title", "Main Bouwblok").Build())
+	g.AddNode(testutil.EntityFor(meta, "bouwblok").ID("BOUWBLOK-001").With("title", "Main Bouwblok").Build())
 
 	// Functions
-	g.AddNode(testutil.Entity("function").ID("FUNC-001").With("title", "Function One").With("status", "active").Build())
-	g.AddNode(testutil.Entity("function").ID("FUNC-002").With("title", "Function Two").With("status", "draft").Build())
+	g.AddNode(testutil.EntityFor(meta, "function").ID("FUNC-001").With("title", "Function One").With("status", "active").Build())
+	g.AddNode(testutil.EntityFor(meta, "function").ID("FUNC-002").With("title", "Function Two").With("status", "draft").Build())
 
 	// Use case
-	g.AddNode(testutil.Entity("usecase").ID("UC-001").With("title", "Use Case One").With("status", "active").Build())
+	g.AddNode(testutil.EntityFor(meta, "usecase").ID("UC-001").With("title", "Use Case One").With("status", "active").Build())
 
 	// Scenario
-	g.AddNode(testutil.Entity("scenario").ID("SCEN-001").With("title", "Scenario One").Build())
+	g.AddNode(testutil.EntityFor(meta, "scenario").ID("SCEN-001").With("title", "Scenario One").Build())
 
 	// Relations: all point to bouwblok
 	g.AddEdge(testutil.NewRelation("FUNC-001", "partOfBouwblok", "BOUWBLOK-001").Build())
@@ -522,10 +522,10 @@ func TestFilterEntities(t *testing.T) {
 	app := testViewAppWithMixedTypes()
 
 	entities := []*model.Entity{
-		testutil.Entity("function").ID("FUNC-001").With("status", "active").Build(),
-		testutil.Entity("function").ID("FUNC-002").With("status", "draft").Build(),
-		testutil.Entity("usecase").ID("UC-001").With("status", "active").Build(),
-		testutil.Entity("scenario").ID("SCEN-001").Build(),
+		testutil.EntityFor(app.meta, "function").ID("FUNC-001").With("status", "active").Build(),
+		testutil.EntityFor(app.meta, "function").ID("FUNC-002").With("status", "draft").Build(),
+		testutil.EntityFor(app.meta, "usecase").ID("UC-001").With("status", "active").Build(),
+		testutil.EntityFor(app.meta, "scenario").ID("SCEN-001").Build(),
 	}
 
 	t.Run("filter by type", func(t *testing.T) {

--- a/internal/lua/runtime_test.go
+++ b/internal/lua/runtime_test.go
@@ -259,6 +259,9 @@ func TestGetEntity(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
+	// Get reference entity for assertions
+	entity, _ := ws.GetEntity("TKT-001")
+
 	r := New(ws, ws.Meta(), "/tmp", &buf)
 	defer r.Close()
 
@@ -285,17 +288,17 @@ rela.output({
 		t.Fatalf("Failed to parse output: %v", err)
 	}
 
-	if result["id"] != "TKT-001" {
-		t.Errorf("Expected id=TKT-001, got %v", result["id"])
+	if result["id"] != entity.ID {
+		t.Errorf("Expected id=%s, got %v", entity.ID, result["id"])
 	}
-	if result["type"] != "ticket" {
-		t.Errorf("Expected type=ticket, got %v", result["type"])
+	if result["type"] != entity.Type {
+		t.Errorf("Expected type=%s, got %v", entity.Type, result["type"])
 	}
-	if result["title"] != "Test Ticket" {
-		t.Errorf("Expected title=Test Ticket, got %v", result["title"])
+	if result["title"] != entity.Properties["title"] {
+		t.Errorf("Expected title=%v, got %v", entity.Properties["title"], result["title"])
 	}
-	if result["content"] != "Test content" {
-		t.Errorf("Expected content=Test content, got %v", result["content"])
+	if result["content"] != entity.Content {
+		t.Errorf("Expected content=%s, got %v", entity.Content, result["content"])
 	}
 }
 
@@ -397,6 +400,13 @@ func TestGetRelations(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
+	// Get reference relation for assertions
+	rels := ws.Graph().RelationsOfType("implements")
+	if len(rels) == 0 {
+		t.Fatal("Expected at least one implements relation in test workspace")
+	}
+	testRel := rels[0]
+
 	r := New(ws, ws.Meta(), "/tmp", &buf)
 	defer r.Close()
 
@@ -426,14 +436,14 @@ rela.output({
 	}
 
 	first := result["first"].(map[string]interface{})
-	if first["from"] != "TKT-001" {
-		t.Errorf("Expected from=TKT-001, got %v", first["from"])
+	if first["from"] != testRel.From {
+		t.Errorf("Expected from=%s, got %v", testRel.From, first["from"])
 	}
-	if first["type"] != "implements" {
-		t.Errorf("Expected type=implements, got %v", first["type"])
+	if first["type"] != testRel.Type {
+		t.Errorf("Expected type=%s, got %v", testRel.Type, first["type"])
 	}
-	if first["to"] != "FEAT-001" {
-		t.Errorf("Expected to=FEAT-001, got %v", first["to"])
+	if first["to"] != testRel.To {
+		t.Errorf("Expected to=%s, got %v", testRel.To, first["to"])
 	}
 }
 
@@ -817,6 +827,10 @@ func TestUpdateEntity(t *testing.T) {
 	ws, root := testWorkspaceWithRepo(t)
 	var buf bytes.Buffer
 
+	// Get reference entity for assertions
+	entity, _ := ws.GetEntity("TKT-001")
+	entityID := entity.ID
+
 	r := New(ws, ws.Meta(), root, &buf)
 	defer r.Close()
 
@@ -841,8 +855,8 @@ rela.output({
 		t.Fatalf("Failed to parse output: %v", err)
 	}
 
-	if result["id"] != "TKT-001" {
-		t.Errorf("Expected id=TKT-001, got %v", result["id"])
+	if result["id"] != entityID {
+		t.Errorf("Expected id=%s, got %v", entityID, result["id"])
 	}
 	if result["status"] != "closed" {
 		t.Errorf("Expected status=closed, got %v", result["status"])
@@ -930,6 +944,11 @@ func TestCreateRelation(t *testing.T) {
 	ws, root := testWorkspaceWithRepo(t)
 	var buf bytes.Buffer
 
+	// Get reference entities for assertions
+	fromEntity, _ := ws.GetEntity("TKT-002")
+	toEntity, _ := ws.GetEntity("FEAT-001")
+	relType := "implements"
+
 	r := New(ws, ws.Meta(), root, &buf)
 	defer r.Close()
 
@@ -956,14 +975,14 @@ rela.output({
 		t.Fatalf("Failed to parse output: %v", err)
 	}
 
-	if result["from"] != "TKT-002" {
-		t.Errorf("Expected from=TKT-002, got %v", result["from"])
+	if result["from"] != fromEntity.ID {
+		t.Errorf("Expected from=%s, got %v", fromEntity.ID, result["from"])
 	}
-	if result["type"] != "implements" {
-		t.Errorf("Expected type=implements, got %v", result["type"])
+	if result["type"] != relType {
+		t.Errorf("Expected type=%s, got %v", relType, result["type"])
 	}
-	if result["to"] != "FEAT-001" {
-		t.Errorf("Expected to=FEAT-001, got %v", result["to"])
+	if result["to"] != toEntity.ID {
+		t.Errorf("Expected to=%s, got %v", toEntity.ID, result["to"])
 	}
 }
 
@@ -1141,6 +1160,9 @@ func TestTraceFrom(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
+	// Get reference entity for assertions
+	entity, _ := ws.GetEntity("TKT-001")
+
 	r := New(ws, ws.Meta(), "/tmp", &buf)
 	defer r.Close()
 
@@ -1165,8 +1187,8 @@ rela.output({
 		t.Fatalf("Failed to parse output: %v", err)
 	}
 
-	if result["id"] != "TKT-001" {
-		t.Errorf("Expected id=TKT-001, got %v", result["id"])
+	if result["id"] != entity.ID {
+		t.Errorf("Expected id=%s, got %v", entity.ID, result["id"])
 	}
 	if result["has_children"] != true {
 		t.Errorf("Expected has_children=true, got %v", result["has_children"])
@@ -1176,6 +1198,9 @@ rela.output({
 func TestTraceTo(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
+
+	// Get reference entity for assertions
+	entity, _ := ws.GetEntity("FEAT-001")
 
 	r := New(ws, ws.Meta(), "/tmp", &buf)
 	defer r.Close()
@@ -1201,8 +1226,8 @@ rela.output({
 		t.Fatalf("Failed to parse output: %v", err)
 	}
 
-	if result["id"] != "FEAT-001" {
-		t.Errorf("Expected id=FEAT-001, got %v", result["id"])
+	if result["id"] != entity.ID {
+		t.Errorf("Expected id=%s, got %v", entity.ID, result["id"])
 	}
 	if result["has_children"] != true {
 		t.Errorf("Expected has_children=true (TKT-001 -> FEAT-001), got %v", result["has_children"])

--- a/internal/mcp/convert_test.go
+++ b/internal/mcp/convert_test.go
@@ -62,8 +62,8 @@ func TestConvertEntity_WithoutRelations(t *testing.T) {
 		t.Fatalf("failed to parse JSON: %v", err)
 	}
 
-	if parsed.ID != "REQ-001" {
-		t.Errorf("expected ID REQ-001, got %s", parsed.ID)
+	if parsed.ID != e.ID {
+		t.Errorf("expected ID %s, got %s", e.ID, parsed.ID)
 	}
 	if parsed.Type != "requirement" {
 		t.Errorf("expected type requirement, got %s", parsed.Type)
@@ -86,7 +86,7 @@ func TestConvertEntity_WithRelations(t *testing.T) {
 	g.AddNode(e1)
 	g.AddNode(e2)
 
-	g.AddEdge(testutil.NewRelation("SOL-001", "addresses", "REQ-001").Build())
+	g.AddEdge(testutil.NewRelation(e2.ID, "addresses", e1.ID).Build())
 
 	result, err := convertEntity(e1, &graphAdapter{g}, true)
 	if err != nil {
@@ -105,9 +105,9 @@ func TestConvertEntity_WithRelations(t *testing.T) {
 		t.Errorf("expected 1 incoming 'addresses' relation, got %d",
 			len(parsed.Relations.Incoming["addresses"]))
 	}
-	if parsed.Relations.Incoming["addresses"][0].ID != "SOL-001" {
-		t.Errorf("expected incoming from SOL-001, got %s",
-			parsed.Relations.Incoming["addresses"][0].ID)
+	if parsed.Relations.Incoming["addresses"][0].ID != e2.ID {
+		t.Errorf("expected incoming from %s, got %s",
+			e2.ID, parsed.Relations.Incoming["addresses"][0].ID)
 	}
 }
 
@@ -136,17 +136,17 @@ func TestConvertEntitySummary(t *testing.T) {
 
 	result := convertEntitySummary(e)
 
-	if result["id"] != "REQ-001" {
-		t.Errorf("expected id REQ-001, got %v", result["id"])
+	if result["id"] != e.ID {
+		t.Errorf("expected id %s, got %v", e.ID, result["id"])
 	}
-	if result["type"] != "requirement" {
-		t.Errorf("expected type requirement, got %v", result["type"])
+	if result["type"] != e.Type {
+		t.Errorf("expected type %s, got %v", e.Type, result["type"])
 	}
-	if result["title"] != "My Title" {
-		t.Errorf("expected title 'My Title', got %v", result["title"])
+	if result["title"] != e.Properties["title"] {
+		t.Errorf("expected title '%v', got %v", e.Properties["title"], result["title"])
 	}
-	if result["status"] != "accepted" {
-		t.Errorf("expected status 'accepted', got %v", result["status"])
+	if result["status"] != e.Properties["status"] {
+		t.Errorf("expected status '%v', got %v", e.Properties["status"], result["status"])
 	}
 }
 
@@ -155,8 +155,8 @@ func TestConvertEntitySummary_NoTitleNoStatus(t *testing.T) {
 
 	result := convertEntitySummary(e)
 
-	if result["id"] != "REQ-002" {
-		t.Errorf("expected id REQ-002, got %v", result["id"])
+	if result["id"] != e.ID {
+		t.Errorf("expected id %s, got %v", e.ID, result["id"])
 	}
 	if _, ok := result["title"]; ok {
 		t.Error("expected no title key when title is empty")
@@ -179,20 +179,20 @@ func TestConvertRelation(t *testing.T) {
 		t.Fatalf("failed to parse JSON: %v", err)
 	}
 
-	if parsed.From != "SOL-001" {
-		t.Errorf("expected from SOL-001, got %s", parsed.From)
+	if parsed.From != r.From {
+		t.Errorf("expected from %s, got %s", r.From, parsed.From)
 	}
-	if parsed.Type != "addresses" {
-		t.Errorf("expected type addresses, got %s", parsed.Type)
+	if parsed.Type != r.Type {
+		t.Errorf("expected type %s, got %s", r.Type, parsed.Type)
 	}
-	if parsed.To != "REQ-001" {
-		t.Errorf("expected to REQ-001, got %s", parsed.To)
+	if parsed.To != r.To {
+		t.Errorf("expected to %s, got %s", r.To, parsed.To)
 	}
-	if parsed.Content != "Relation content" {
-		t.Errorf("expected content 'Relation content', got %s", parsed.Content)
+	if parsed.Content != r.Content {
+		t.Errorf("expected content '%s', got %s", r.Content, parsed.Content)
 	}
-	if parsed.Properties["rationale"] != "because" {
-		t.Errorf("expected property rationale=because, got %v", parsed.Properties["rationale"])
+	if parsed.Properties["rationale"] != r.Properties["rationale"] {
+		t.Errorf("expected property rationale=%v, got %v", r.Properties["rationale"], parsed.Properties["rationale"])
 	}
 }
 
@@ -305,23 +305,25 @@ func TestBuildRelations_NoEdges(t *testing.T) {
 
 func TestBuildRelations_OutgoingOnly(t *testing.T) {
 	g := graph.New()
-	g.AddNode(testutil.Entity("solution").ID("SOL-001").With("title", "Solution").Build())
-	g.AddNode(testutil.Entity("requirement").ID("REQ-001").With("title", "Requirement").Build())
+	sol := testutil.Entity("solution").ID("SOL-001").With("title", "Solution").Build()
+	req := testutil.Entity("requirement").ID("REQ-001").With("title", "Requirement").Build()
+	g.AddNode(sol)
+	g.AddNode(req)
 
-	g.AddEdge(testutil.NewRelation("SOL-001", "addresses", "REQ-001").Build())
+	g.AddEdge(testutil.NewRelation(sol.ID, "addresses", req.ID).Build())
 
-	rels := buildRelations("SOL-001", &graphAdapter{g})
+	rels := buildRelations(sol.ID, &graphAdapter{g})
 	if rels == nil {
 		t.Fatal("expected non-nil relations")
 	}
 	if len(rels.Outgoing["addresses"]) != 1 {
 		t.Errorf("expected 1 outgoing addresses relation, got %d", len(rels.Outgoing["addresses"]))
 	}
-	if rels.Outgoing["addresses"][0].ID != "REQ-001" {
-		t.Errorf("expected target REQ-001, got %s", rels.Outgoing["addresses"][0].ID)
+	if rels.Outgoing["addresses"][0].ID != req.ID {
+		t.Errorf("expected target %s, got %s", req.ID, rels.Outgoing["addresses"][0].ID)
 	}
-	if rels.Outgoing["addresses"][0].Title != "Requirement" {
-		t.Errorf("expected title 'Requirement', got %s", rels.Outgoing["addresses"][0].Title)
+	if rels.Outgoing["addresses"][0].Title != req.Properties["title"] {
+		t.Errorf("expected title '%v', got %s", req.Properties["title"], rels.Outgoing["addresses"][0].Title)
 	}
 	if rels.Incoming != nil {
 		t.Error("expected no incoming relations")
@@ -330,12 +332,14 @@ func TestBuildRelations_OutgoingOnly(t *testing.T) {
 
 func TestBuildRelations_IncomingOnly(t *testing.T) {
 	g := graph.New()
-	g.AddNode(testutil.Entity("requirement").ID("REQ-001").With("title", "Requirement").Build())
-	g.AddNode(testutil.Entity("solution").ID("SOL-001").With("title", "Solution").Build())
+	req := testutil.Entity("requirement").ID("REQ-001").With("title", "Requirement").Build()
+	sol := testutil.Entity("solution").ID("SOL-001").With("title", "Solution").Build()
+	g.AddNode(req)
+	g.AddNode(sol)
 
-	g.AddEdge(testutil.NewRelation("SOL-001", "addresses", "REQ-001").Build())
+	g.AddEdge(testutil.NewRelation(sol.ID, "addresses", req.ID).Build())
 
-	rels := buildRelations("REQ-001", &graphAdapter{g})
+	rels := buildRelations(req.ID, &graphAdapter{g})
 	if rels == nil {
 		t.Fatal("expected non-nil relations")
 	}
@@ -345,8 +349,8 @@ func TestBuildRelations_IncomingOnly(t *testing.T) {
 	if len(rels.Incoming["addresses"]) != 1 {
 		t.Errorf("expected 1 incoming addresses relation, got %d", len(rels.Incoming["addresses"]))
 	}
-	if rels.Incoming["addresses"][0].ID != "SOL-001" {
-		t.Errorf("expected source SOL-001, got %s", rels.Incoming["addresses"][0].ID)
+	if rels.Incoming["addresses"][0].ID != sol.ID {
+		t.Errorf("expected source %s, got %s", sol.ID, rels.Incoming["addresses"][0].ID)
 	}
 }
 
@@ -580,8 +584,8 @@ func TestConvertRelation_NoProperties(t *testing.T) {
 		t.Fatalf("failed to parse JSON: %v", err)
 	}
 
-	if parsed.From != "SOL-001" {
-		t.Errorf("expected from SOL-001, got %s", parsed.From)
+	if parsed.From != r.From {
+		t.Errorf("expected from %s, got %s", r.From, parsed.From)
 	}
 	if parsed.Content != "" {
 		t.Errorf("expected empty content, got %s", parsed.Content)

--- a/internal/mcp/convert_test.go
+++ b/internal/mcp/convert_test.go
@@ -21,6 +21,43 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
+// testMeta returns a shared metamodel for convert tests with all needed entity types.
+func testMeta() *metamodel.Metamodel {
+	return testutil.NewMetamodel().
+		DefineEntity("requirement").
+		Label("Requirement").
+		IDPrefix("REQ-").
+		Prop("title", metamodel.PropertyTypeString, true).
+		Prop("status", "status", false).
+		End().
+		DefineEntity("decision").
+		Label("Decision").
+		IDPrefix("DEC-").
+		Prop("title", metamodel.PropertyTypeString, true).
+		Prop("status", "status", false).
+		Prop("priority", metamodel.PropertyTypeString, false).
+		End().
+		DefineEntity("solution").
+		Label("Solution").
+		IDPrefix("SOL-").
+		Prop("title", metamodel.PropertyTypeString, true).
+		End().
+		DefineEntity("component").
+		Label("Component").
+		IDPrefix("CMP-").
+		Prop("title", metamodel.PropertyTypeString, false).
+		End().
+		DefineEntity("test").
+		Label("Test").
+		Prop("title", metamodel.PropertyTypeString, false).
+		End().
+		WithRelation("addresses", "Addresses", []string{"solution"}, []string{"requirement"}).
+		WithRelation("implements", "Implements", []string{"component"}, []string{"solution"}).
+		WithRelation("motivates", "Motivates", []string{"requirement"}, []string{"decision"}).
+		WithCustomType("status", []string{"draft", "proposed", "accepted", "rejected"}).
+		Build()
+}
+
 // graphAdapter wraps *graph.Graph to implement relationQuerier for tests.
 type graphAdapter struct {
 	g *graph.Graph
@@ -48,8 +85,9 @@ func makeToolRequest(args map[string]interface{}) mcp.CallToolRequest {
 }
 
 func TestConvertEntity_WithoutRelations(t *testing.T) {
+	meta := testMeta()
 	g := graph.New()
-	e := testutil.Entity("requirement").ID("REQ-001").With("title", "Test requirement").With("status", "draft").WithContent("Some content").Build()
+	e := testutil.EntityFor(meta, "requirement").ID("REQ-001").With("title", "Test requirement").WithContent("Some content").Build()
 	g.AddNode(e)
 
 	result, err := convertEntity(e, &graphAdapter{g}, false)
@@ -80,9 +118,10 @@ func TestConvertEntity_WithoutRelations(t *testing.T) {
 }
 
 func TestConvertEntity_WithRelations(t *testing.T) {
+	meta := testMeta()
 	g := graph.New()
-	e1 := testutil.Entity("requirement").ID("REQ-001").With("title", "Requirement 1").Build()
-	e2 := testutil.Entity("solution").ID("SOL-001").With("title", "Solution 1").Build()
+	e1 := testutil.EntityFor(meta, "requirement").ID("REQ-001").Build()
+	e2 := testutil.EntityFor(meta, "solution").ID("SOL-001").Build()
 	g.AddNode(e1)
 	g.AddNode(e2)
 
@@ -112,8 +151,9 @@ func TestConvertEntity_WithRelations(t *testing.T) {
 }
 
 func TestConvertEntity_NoRelationsPresent(t *testing.T) {
+	meta := testMeta()
 	g := graph.New()
-	e := testutil.Entity("requirement").ID("REQ-001").Build()
+	e := testutil.EntityFor(meta, "requirement").ID("REQ-001").Build()
 	g.AddNode(e)
 
 	result, err := convertEntity(e, &graphAdapter{g}, true)
@@ -132,7 +172,8 @@ func TestConvertEntity_NoRelationsPresent(t *testing.T) {
 }
 
 func TestConvertEntitySummary(t *testing.T) {
-	e := testutil.Entity("requirement").ID("REQ-001").With("title", "My Title").With("status", "accepted").Build()
+	meta := testMeta()
+	e := testutil.EntityFor(meta, "requirement").ID("REQ-001").With("title", "My Title").With("status", "accepted").Build()
 
 	result := convertEntitySummary(e)
 
@@ -151,7 +192,8 @@ func TestConvertEntitySummary(t *testing.T) {
 }
 
 func TestConvertEntitySummary_NoTitleNoStatus(t *testing.T) {
-	e := testutil.Entity("requirement").ID("REQ-002").Build()
+	meta := testMeta()
+	e := testutil.EntityFor(meta, "requirement").ID("REQ-002").Without("title").Without("status").Build()
 
 	result := convertEntitySummary(e)
 
@@ -294,8 +336,9 @@ func TestConvertPathSteps_Empty(t *testing.T) {
 }
 
 func TestBuildRelations_NoEdges(t *testing.T) {
+	meta := testMeta()
 	g := graph.New()
-	g.AddNode(testutil.Entity("requirement").ID("REQ-001").Build())
+	g.AddNode(testutil.EntityFor(meta, "requirement").ID("REQ-001").Build())
 
 	rels := buildRelations("REQ-001", &graphAdapter{g})
 	if rels != nil {
@@ -304,9 +347,10 @@ func TestBuildRelations_NoEdges(t *testing.T) {
 }
 
 func TestBuildRelations_OutgoingOnly(t *testing.T) {
+	meta := testMeta()
 	g := graph.New()
-	sol := testutil.Entity("solution").ID("SOL-001").With("title", "Solution").Build()
-	req := testutil.Entity("requirement").ID("REQ-001").With("title", "Requirement").Build()
+	sol := testutil.EntityFor(meta, "solution").ID("SOL-001").With("title", "Solution").Build()
+	req := testutil.EntityFor(meta, "requirement").ID("REQ-001").With("title", "Requirement").Build()
 	g.AddNode(sol)
 	g.AddNode(req)
 
@@ -331,9 +375,10 @@ func TestBuildRelations_OutgoingOnly(t *testing.T) {
 }
 
 func TestBuildRelations_IncomingOnly(t *testing.T) {
+	meta := testMeta()
 	g := graph.New()
-	req := testutil.Entity("requirement").ID("REQ-001").With("title", "Requirement").Build()
-	sol := testutil.Entity("solution").ID("SOL-001").With("title", "Solution").Build()
+	req := testutil.EntityFor(meta, "requirement").ID("REQ-001").With("title", "Requirement").Build()
+	sol := testutil.EntityFor(meta, "solution").ID("SOL-001").With("title", "Solution").Build()
 	g.AddNode(req)
 	g.AddNode(sol)
 
@@ -355,10 +400,11 @@ func TestBuildRelations_IncomingOnly(t *testing.T) {
 }
 
 func TestBuildRelations_BothDirections(t *testing.T) {
+	meta := testMeta()
 	g := graph.New()
-	g.AddNode(testutil.Entity("requirement").ID("REQ-001").With("title", "Req").Build())
-	g.AddNode(testutil.Entity("solution").ID("SOL-001").With("title", "Sol").Build())
-	g.AddNode(testutil.Entity("decision").ID("DEC-001").With("title", "Dec").Build())
+	g.AddNode(testutil.EntityFor(meta, "requirement").ID("REQ-001").With("title", "Req").Build())
+	g.AddNode(testutil.EntityFor(meta, "solution").ID("SOL-001").With("title", "Sol").Build())
+	g.AddNode(testutil.EntityFor(meta, "decision").ID("DEC-001").With("title", "Dec").Build())
 
 	g.AddEdge(testutil.NewRelation("SOL-001", "addresses", "REQ-001").Build())
 	g.AddEdge(testutil.NewRelation("REQ-001", "motivates", "DEC-001").Build())
@@ -382,9 +428,10 @@ func TestBuildRelations_BothDirections(t *testing.T) {
 }
 
 func TestConvertEntitiesList(t *testing.T) {
+	meta := testMeta()
 	entities := []*model.Entity{
-		testutil.Entity("requirement").ID("REQ-001").With("title", "First").With("status", "draft").Build(),
-		testutil.Entity("requirement").ID("REQ-002").With("title", "Second").Build(),
+		testutil.EntityFor(meta, "requirement").ID("REQ-001").With("title", "First").With("status", "draft").Build(),
+		testutil.EntityFor(meta, "requirement").ID("REQ-002").With("title", "Second").Build(),
 	}
 
 	result, err := convertEntitiesList(entities)
@@ -459,10 +506,11 @@ func TestConvertRelationsList_Empty(t *testing.T) {
 }
 
 func TestSortEntitiesByID(t *testing.T) {
+	meta := testMeta()
 	entities := []*model.Entity{
-		testutil.Entity("requirement").ID("REQ-003").Build(),
-		testutil.Entity("requirement").ID("REQ-001").Build(),
-		testutil.Entity("requirement").ID("REQ-002").Build(),
+		testutil.EntityFor(meta, "requirement").ID("REQ-003").Build(),
+		testutil.EntityFor(meta, "requirement").ID("REQ-001").Build(),
+		testutil.EntityFor(meta, "requirement").ID("REQ-002").Build(),
 	}
 
 	sortEntitiesByID(entities)
@@ -644,8 +692,9 @@ func TestConvertTraceResult_DeepNesting(t *testing.T) {
 }
 
 func TestConvertEntity_WithProperties(t *testing.T) {
+	meta := testMeta()
 	g := graph.New()
-	e := testutil.Entity("decision").ID("DEC-001").With("title", "Use Go").With("status", "accepted").With("priority", "high").Build()
+	e := testutil.EntityFor(meta, "decision").ID("DEC-001").With("title", "Use Go").With("status", "accepted").With("priority", "high").Build()
 	g.AddNode(e)
 
 	result, err := convertEntity(e, &graphAdapter{g}, false)
@@ -665,10 +714,11 @@ func TestConvertEntity_WithProperties(t *testing.T) {
 }
 
 func TestSortEntitiesByID_AlreadySorted(t *testing.T) {
+	meta := testMeta()
 	entities := []*model.Entity{
-		testutil.Entity("test").ID("A-001").Build(),
-		testutil.Entity("test").ID("B-001").Build(),
-		testutil.Entity("test").ID("C-001").Build(),
+		testutil.EntityFor(meta, "test").ID("A-001").Build(),
+		testutil.EntityFor(meta, "test").ID("B-001").Build(),
+		testutil.EntityFor(meta, "test").ID("C-001").Build(),
 	}
 
 	sortEntitiesByID(entities)

--- a/internal/rename/rename_test.go
+++ b/internal/rename/rename_test.go
@@ -55,42 +55,44 @@ func TestRename_NoRelations(t *testing.T) {
 	repo, meta, g, _ := setupTestEnv(t)
 
 	// Create entity
-	entity := testutil.NewEntity("REQ-001", "requirement").With("title", "Test Requirement").Build()
+	oldID := "REQ-001"
+	newID := "REQ-100"
+	entity := testutil.NewEntity(oldID, "requirement").With("title", "Test Requirement").Build()
 	if err := repo.WriteEntity(entity, meta); err != nil {
 		t.Fatalf("WriteEntity() error = %v", err)
 	}
 	g.AddNode(entity)
 
 	// Rename
-	result, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-100", Options{})
+	result, err := Rename(repo, meta, g, "requirement", oldID, newID, Options{})
 	if err != nil {
 		t.Fatalf("Rename() error = %v", err)
 	}
 
 	// Check result
-	if result.OldID != "REQ-001" {
-		t.Errorf("OldID = %q, want %q", result.OldID, "REQ-001")
+	if result.OldID != oldID {
+		t.Errorf("OldID = %q, want %q", result.OldID, oldID)
 	}
-	if result.NewID != "REQ-100" {
-		t.Errorf("NewID = %q, want %q", result.NewID, "REQ-100")
+	if result.NewID != newID {
+		t.Errorf("NewID = %q, want %q", result.NewID, newID)
 	}
 	if len(result.RelationsUpdated) != 0 {
 		t.Errorf("RelationsUpdated = %d, want 0", len(result.RelationsUpdated))
 	}
 
 	// Verify graph updated
-	if _, ok := g.GetNode("REQ-001"); ok {
+	if _, ok := g.GetNode(oldID); ok {
 		t.Error("old ID should not exist in graph")
 	}
-	if _, ok := g.GetNode("REQ-100"); !ok {
+	if _, ok := g.GetNode(newID); !ok {
 		t.Error("new ID should exist in graph")
 	}
 
 	// Verify files
-	if _, err := repo.ReadEntity("requirement", "REQ-100", meta); err != nil {
+	if _, err := repo.ReadEntity("requirement", newID, meta); err != nil {
 		t.Errorf("new entity file should exist: %v", err)
 	}
-	if _, err := repo.ReadEntity("requirement", "REQ-001", meta); err == nil {
+	if _, err := repo.ReadEntity("requirement", oldID, meta); err == nil {
 		t.Error("old entity file should not exist")
 	}
 }
@@ -99,8 +101,10 @@ func TestRename_OutgoingRelations(t *testing.T) {
 	repo, meta, g, _ := setupTestEnv(t)
 
 	// Create entities
+	oldDecID := "DEC-001"
+	newDecID := "DEC-100"
 	req := testutil.NewEntity("REQ-001", "requirement").With("title", "Requirement").Build()
-	dec := testutil.NewEntity("DEC-001", "decision").With("title", "Decision").Build()
+	dec := testutil.NewEntity(oldDecID, "decision").With("title", "Decision").Build()
 
 	if err := repo.WriteEntity(req, meta); err != nil {
 		t.Fatalf("WriteEntity(req) error = %v", err)
@@ -112,14 +116,14 @@ func TestRename_OutgoingRelations(t *testing.T) {
 	g.AddNode(dec)
 
 	// Create outgoing relation from DEC-001
-	rel := testutil.NewRelation("DEC-001", "addresses", "REQ-001").Build()
+	rel := testutil.NewRelation(dec.ID, "addresses", req.ID).Build()
 	if err := repo.WriteRelation(rel); err != nil {
 		t.Fatalf("WriteRelation() error = %v", err)
 	}
 	g.AddEdge(rel)
 
 	// Rename DEC-001 -> DEC-100 (entity with outgoing relation)
-	result, err := Rename(repo, meta, g, "decision", "DEC-001", "DEC-100", Options{})
+	result, err := Rename(repo, meta, g, "decision", oldDecID, newDecID, Options{})
 	if err != nil {
 		t.Fatalf("Rename() error = %v", err)
 	}
@@ -130,19 +134,19 @@ func TestRename_OutgoingRelations(t *testing.T) {
 	}
 
 	// Verify graph
-	outgoing := g.OutgoingEdges("DEC-100")
+	outgoing := g.OutgoingEdges(newDecID)
 	if len(outgoing) != 1 {
 		t.Fatalf("new entity should have 1 outgoing edge, got %d", len(outgoing))
 	}
-	if outgoing[0].From != "DEC-100" || outgoing[0].To != "REQ-001" {
-		t.Errorf("outgoing edge = %s -> %s, want DEC-100 -> REQ-001", outgoing[0].From, outgoing[0].To)
+	if outgoing[0].From != newDecID || outgoing[0].To != req.ID {
+		t.Errorf("outgoing edge = %s -> %s, want %s -> %s", outgoing[0].From, outgoing[0].To, newDecID, req.ID)
 	}
 
 	// Verify files
-	if _, err := repo.ReadRelation("DEC-100", "addresses", "REQ-001"); err != nil {
+	if _, err := repo.ReadRelation(newDecID, "addresses", req.ID); err != nil {
 		t.Errorf("new relation file should exist: %v", err)
 	}
-	if _, err := repo.ReadRelation("DEC-001", "addresses", "REQ-001"); err == nil {
+	if _, err := repo.ReadRelation(oldDecID, "addresses", req.ID); err == nil {
 		t.Error("old relation file should not exist")
 	}
 }
@@ -151,7 +155,9 @@ func TestRename_IncomingRelations(t *testing.T) {
 	repo, meta, g, _ := setupTestEnv(t)
 
 	// Create entities
-	req := testutil.NewEntity("REQ-001", "requirement").With("title", "Requirement").Build()
+	oldReqID := "REQ-001"
+	newReqID := "REQ-100"
+	req := testutil.NewEntity(oldReqID, "requirement").With("title", "Requirement").Build()
 	dec := testutil.NewEntity("DEC-001", "decision").With("title", "Decision").Build()
 
 	if err := repo.WriteEntity(req, meta); err != nil {
@@ -164,14 +170,14 @@ func TestRename_IncomingRelations(t *testing.T) {
 	g.AddNode(dec)
 
 	// Create relation to REQ-001
-	rel := testutil.NewRelation("DEC-001", "addresses", "REQ-001").Build()
+	rel := testutil.NewRelation(dec.ID, "addresses", req.ID).Build()
 	if err := repo.WriteRelation(rel); err != nil {
 		t.Fatalf("WriteRelation() error = %v", err)
 	}
 	g.AddEdge(rel)
 
 	// Rename REQ-001 -> REQ-100 (entity with incoming relation)
-	result, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-100", Options{})
+	result, err := Rename(repo, meta, g, "requirement", oldReqID, newReqID, Options{})
 	if err != nil {
 		t.Fatalf("Rename() error = %v", err)
 	}
@@ -182,19 +188,19 @@ func TestRename_IncomingRelations(t *testing.T) {
 	}
 
 	// Verify graph
-	incoming := g.IncomingEdges("REQ-100")
+	incoming := g.IncomingEdges(newReqID)
 	if len(incoming) != 1 {
 		t.Fatalf("new entity should have 1 incoming edge, got %d", len(incoming))
 	}
-	if incoming[0].From != "DEC-001" || incoming[0].To != "REQ-100" {
-		t.Errorf("incoming edge = %s -> %s, want DEC-001 -> REQ-100", incoming[0].From, incoming[0].To)
+	if incoming[0].From != dec.ID || incoming[0].To != newReqID {
+		t.Errorf("incoming edge = %s -> %s, want %s -> %s", incoming[0].From, incoming[0].To, dec.ID, newReqID)
 	}
 
 	// Verify files
-	if _, err := repo.ReadRelation("DEC-001", "addresses", "REQ-100"); err != nil {
+	if _, err := repo.ReadRelation(dec.ID, "addresses", newReqID); err != nil {
 		t.Errorf("new relation file should exist: %v", err)
 	}
-	if _, err := repo.ReadRelation("DEC-001", "addresses", "REQ-001"); err == nil {
+	if _, err := repo.ReadRelation(dec.ID, "addresses", oldReqID); err == nil {
 		t.Error("old relation file should not exist")
 	}
 }
@@ -203,7 +209,12 @@ func TestRename_BothIncomingAndOutgoing(t *testing.T) {
 	repo, meta, g, _ := setupTestEnv(t)
 
 	// Create entities: REQ-001, REQ-002, REQ-003
-	for _, id := range []string{"REQ-001", "REQ-002", "REQ-003"} {
+	oldID := "REQ-001"
+	newID := "REQ-100"
+	req2ID := "REQ-002"
+	req3ID := "REQ-003"
+
+	for _, id := range []string{oldID, req2ID, req3ID} {
 		e := testutil.NewEntity(id, "requirement").With("title", "Requirement "+id).Build()
 		if err := repo.WriteEntity(e, meta); err != nil {
 			t.Fatalf("WriteEntity(%s) error = %v", id, err)
@@ -212,21 +223,21 @@ func TestRename_BothIncomingAndOutgoing(t *testing.T) {
 	}
 
 	// REQ-001 depends-on REQ-002 (outgoing from REQ-001)
-	rel1 := testutil.NewRelation("REQ-001", "depends-on", "REQ-002").Build()
+	rel1 := testutil.NewRelation(oldID, "depends-on", req2ID).Build()
 	if err := repo.WriteRelation(rel1); err != nil {
 		t.Fatalf("WriteRelation(rel1) error = %v", err)
 	}
 	g.AddEdge(rel1)
 
 	// REQ-003 depends-on REQ-001 (incoming to REQ-001)
-	rel2 := testutil.NewRelation("REQ-003", "depends-on", "REQ-001").Build()
+	rel2 := testutil.NewRelation(req3ID, "depends-on", oldID).Build()
 	if err := repo.WriteRelation(rel2); err != nil {
 		t.Fatalf("WriteRelation(rel2) error = %v", err)
 	}
 	g.AddEdge(rel2)
 
 	// Rename REQ-001 -> REQ-100
-	result, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-100", Options{})
+	result, err := Rename(repo, meta, g, "requirement", oldID, newID, Options{})
 	if err != nil {
 		t.Fatalf("Rename() error = %v", err)
 	}
@@ -237,14 +248,14 @@ func TestRename_BothIncomingAndOutgoing(t *testing.T) {
 	}
 
 	// Verify graph edges
-	outgoing := g.OutgoingEdges("REQ-100")
-	if len(outgoing) != 1 || outgoing[0].To != "REQ-002" {
-		t.Error("REQ-100 should have outgoing edge to REQ-002")
+	outgoing := g.OutgoingEdges(newID)
+	if len(outgoing) != 1 || outgoing[0].To != req2ID {
+		t.Errorf("%s should have outgoing edge to %s", newID, req2ID)
 	}
 
-	incoming := g.IncomingEdges("REQ-100")
-	if len(incoming) != 1 || incoming[0].From != "REQ-003" {
-		t.Error("REQ-100 should have incoming edge from REQ-003")
+	incoming := g.IncomingEdges(newID)
+	if len(incoming) != 1 || incoming[0].From != req3ID {
+		t.Errorf("%s should have incoming edge from %s", newID, req3ID)
 	}
 }
 
@@ -252,21 +263,23 @@ func TestRename_SelfReferential(t *testing.T) {
 	repo, meta, g, _ := setupTestEnv(t)
 
 	// Create entity
-	req := testutil.NewEntity("REQ-001", "requirement").With("title", "Self-referential").Build()
+	oldID := "REQ-001"
+	newID := "REQ-100"
+	req := testutil.NewEntity(oldID, "requirement").With("title", "Self-referential").Build()
 	if err := repo.WriteEntity(req, meta); err != nil {
 		t.Fatalf("WriteEntity() error = %v", err)
 	}
 	g.AddNode(req)
 
 	// Create self-referential relation
-	rel := testutil.NewRelation("REQ-001", "depends-on", "REQ-001").Build()
+	rel := testutil.NewRelation(req.ID, "depends-on", req.ID).Build()
 	if err := repo.WriteRelation(rel); err != nil {
 		t.Fatalf("WriteRelation() error = %v", err)
 	}
 	g.AddEdge(rel)
 
 	// Rename REQ-001 -> REQ-100
-	result, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-100", Options{})
+	result, err := Rename(repo, meta, g, "requirement", oldID, newID, Options{})
 	if err != nil {
 		t.Fatalf("Rename() error = %v", err)
 	}
@@ -277,12 +290,12 @@ func TestRename_SelfReferential(t *testing.T) {
 	}
 
 	// Verify graph - self-referential edge should now be REQ-100 -> REQ-100
-	outgoing := g.OutgoingEdges("REQ-100")
+	outgoing := g.OutgoingEdges(newID)
 	if len(outgoing) != 1 {
 		t.Fatalf("should have 1 outgoing edge, got %d", len(outgoing))
 	}
-	if outgoing[0].From != "REQ-100" || outgoing[0].To != "REQ-100" {
-		t.Errorf("edge = %s -> %s, want REQ-100 -> REQ-100", outgoing[0].From, outgoing[0].To)
+	if outgoing[0].From != newID || outgoing[0].To != newID {
+		t.Errorf("edge = %s -> %s, want %s -> %s", outgoing[0].From, outgoing[0].To, newID, newID)
 	}
 }
 
@@ -290,7 +303,9 @@ func TestRename_DryRun(t *testing.T) {
 	repo, meta, g, _ := setupTestEnv(t)
 
 	// Create entity with relation
-	req := testutil.NewEntity("REQ-001", "requirement").With("title", "Requirement").Build()
+	oldReqID := "REQ-001"
+	newReqID := "REQ-100"
+	req := testutil.NewEntity(oldReqID, "requirement").With("title", "Requirement").Build()
 	dec := testutil.NewEntity("DEC-001", "decision").With("title", "Decision").Build()
 
 	if err := repo.WriteEntity(req, meta); err != nil {
@@ -302,36 +317,36 @@ func TestRename_DryRun(t *testing.T) {
 	g.AddNode(req)
 	g.AddNode(dec)
 
-	rel := testutil.NewRelation("DEC-001", "addresses", "REQ-001").Build()
+	rel := testutil.NewRelation(dec.ID, "addresses", req.ID).Build()
 	if err := repo.WriteRelation(rel); err != nil {
 		t.Fatalf("WriteRelation() error = %v", err)
 	}
 	g.AddEdge(rel)
 
 	// Dry run
-	result, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-100", Options{DryRun: true})
+	result, err := Rename(repo, meta, g, "requirement", oldReqID, newReqID, Options{DryRun: true})
 	if err != nil {
 		t.Fatalf("Rename() error = %v", err)
 	}
 
 	// Result should show what would change
-	if result.NewID != "REQ-100" {
-		t.Errorf("NewID = %q, want %q", result.NewID, "REQ-100")
+	if result.NewID != newReqID {
+		t.Errorf("NewID = %q, want %q", result.NewID, newReqID)
 	}
 	if len(result.RelationsUpdated) != 1 {
 		t.Errorf("RelationsUpdated = %d, want 1", len(result.RelationsUpdated))
 	}
 
 	// But nothing should have changed
-	if _, ok := g.GetNode("REQ-001"); !ok {
+	if _, ok := g.GetNode(oldReqID); !ok {
 		t.Error("old ID should still exist in graph (dry run)")
 	}
-	if _, ok := g.GetNode("REQ-100"); ok {
+	if _, ok := g.GetNode(newReqID); ok {
 		t.Error("new ID should not exist in graph (dry run)")
 	}
 
 	// Files unchanged
-	if _, readErr := repo.ReadEntity("requirement", "REQ-001", meta); readErr != nil {
+	if _, readErr := repo.ReadEntity("requirement", oldReqID, meta); readErr != nil {
 		t.Error("old entity file should still exist (dry run)")
 	}
 }
@@ -353,12 +368,13 @@ func TestRename_ErrorNewIDExists(t *testing.T) {
 	g.AddNode(req2)
 
 	// Try to rename REQ-001 to REQ-002 (already exists)
-	_, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-002", Options{})
+	_, err := Rename(repo, meta, g, "requirement", req1.ID, req2.ID, Options{})
 	if err == nil {
 		t.Fatal("Rename() should fail when new ID already exists")
 	}
-	if err.Error() != "entity with ID REQ-002 already exists" {
-		t.Errorf("error = %q, want 'entity with ID REQ-002 already exists'", err.Error())
+	expectedErr := "entity with ID " + req2.ID + " already exists"
+	if err.Error() != expectedErr {
+		t.Errorf("error = %q, want %q", err.Error(), expectedErr)
 	}
 }
 
@@ -410,9 +426,13 @@ func TestRename_PreservesContent(t *testing.T) {
 	repo, meta, g, _ := setupTestEnv(t)
 
 	// Create entity with content
-	req := testutil.NewEntity("REQ-001", "requirement").
-		With("title", "With Content").
-		With("status", "approved").
+	oldID := "REQ-001"
+	newID := "REQ-100"
+	expectedTitle := "With Content"
+	expectedStatus := "approved"
+	req := testutil.NewEntity(oldID, "requirement").
+		With("title", expectedTitle).
+		With("status", expectedStatus).
 		WithContent("# Description\n\nThis is the detailed description.\n").
 		Build()
 	if err := repo.WriteEntity(req, meta); err != nil {
@@ -421,22 +441,22 @@ func TestRename_PreservesContent(t *testing.T) {
 	g.AddNode(req)
 
 	// Rename
-	_, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-100", Options{})
+	_, err := Rename(repo, meta, g, "requirement", oldID, newID, Options{})
 	if err != nil {
 		t.Fatalf("Rename() error = %v", err)
 	}
 
 	// Read back and verify content preserved
-	newEntity, err := repo.ReadEntity("requirement", "REQ-100", meta)
+	newEntity, err := repo.ReadEntity("requirement", newID, meta)
 	if err != nil {
 		t.Fatalf("ReadEntity() error = %v", err)
 	}
 
-	if newEntity.GetString("title") != "With Content" {
-		t.Errorf("title = %q, want %q", newEntity.GetString("title"), "With Content")
+	if newEntity.GetString("title") != expectedTitle {
+		t.Errorf("title = %q, want %q", newEntity.GetString("title"), expectedTitle)
 	}
-	if newEntity.GetString("status") != "approved" {
-		t.Errorf("status = %q, want %q", newEntity.GetString("status"), "approved")
+	if newEntity.GetString("status") != expectedStatus {
+		t.Errorf("status = %q, want %q", newEntity.GetString("status"), expectedStatus)
 	}
 	if newEntity.Content == "" {
 		t.Error("content should be preserved")
@@ -447,14 +467,16 @@ func TestRename_NoTempFilesLeft(t *testing.T) {
 	repo, meta, g, fs := setupTestEnv(t)
 
 	// Create entity
-	req := testutil.NewEntity("REQ-001", "requirement").With("title", "Test").Build()
+	oldID := "REQ-001"
+	newID := "REQ-100"
+	req := testutil.NewEntity(oldID, "requirement").With("title", "Test").Build()
 	if err := repo.WriteEntity(req, meta); err != nil {
 		t.Fatalf("WriteEntity() error = %v", err)
 	}
 	g.AddNode(req)
 
 	// Rename
-	_, err := Rename(repo, meta, g, "requirement", "REQ-001", "REQ-100", Options{})
+	_, err := Rename(repo, meta, g, "requirement", oldID, newID, Options{})
 	if err != nil {
 		t.Fatalf("Rename() error = %v", err)
 	}

--- a/internal/views/engine_test.go
+++ b/internal/views/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/testutil"
 )
 
 func TestEngineExecute(t *testing.T) {
@@ -39,49 +40,34 @@ func TestEngineExecute(t *testing.T) {
 	// Create a graph with test data
 	g := graph.New()
 
-	doc := &model.Entity{
-		ID:   "DOC-001",
-		Type: "document",
-		Properties: map[string]interface{}{
-			"title": "Test Document",
-		},
-		Content: "Document content",
-	}
+	doc := testutil.EntityFor(meta, "document").
+		ID("DOC-001").
+		With("title", "Test Document").
+		WithContent("Document content").
+		Build()
 	g.AddNode(doc)
 
-	sec1 := &model.Entity{
-		ID:   "SEC-001",
-		Type: "section",
-		Properties: map[string]interface{}{
-			"title": "Section 1",
-		},
-		Content: "Section 1 content",
-	}
+	sec1 := testutil.EntityFor(meta, "section").
+		ID("SEC-001").
+		With("title", "Section 1").
+		WithContent("Section 1 content").
+		Build()
 	g.AddNode(sec1)
 
-	sec2 := &model.Entity{
-		ID:   "SEC-002",
-		Type: "section",
-		Properties: map[string]interface{}{
-			"title": "Section 2",
-		},
-		Content: "Section 2 content",
-	}
+	sec2 := testutil.EntityFor(meta, "section").
+		ID("SEC-002").
+		With("title", "Section 2").
+		WithContent("Section 2 content").
+		Build()
 	g.AddNode(sec2)
 
 	// Add relations
-	g.AddEdge(&model.Relation{
-		From:    "DOC-001",
-		Type:    "contains",
-		To:      "SEC-001",
-		Content: "Relation content 1",
-	})
-	g.AddEdge(&model.Relation{
-		From:    "DOC-001",
-		Type:    "contains",
-		To:      "SEC-002",
-		Content: "Relation content 2",
-	})
+	g.AddEdge(testutil.NewRelation("DOC-001", "contains", "SEC-001").
+		WithContent("Relation content 1").
+		Build())
+	g.AddEdge(testutil.NewRelation("DOC-001", "contains", "SEC-002").
+		WithContent("Relation content 2").
+		Build())
 
 	// Create a view definition
 	view := ViewDef{
@@ -156,36 +142,27 @@ func TestEngineTraverseRecursive(t *testing.T) {
 	// Create a graph with dependencies
 	g := graph.New()
 
-	comp1 := &model.Entity{
-		ID:   "COMP-001",
-		Type: "component",
-		Properties: map[string]interface{}{
-			"title": "Component 1",
-		},
-	}
+	comp1 := testutil.EntityFor(meta, "component").
+		ID("COMP-001").
+		With("title", "Component 1").
+		Build()
 	g.AddNode(comp1)
 
-	comp2 := &model.Entity{
-		ID:   "COMP-002",
-		Type: "component",
-		Properties: map[string]interface{}{
-			"title": "Component 2",
-		},
-	}
+	comp2 := testutil.EntityFor(meta, "component").
+		ID("COMP-002").
+		With("title", "Component 2").
+		Build()
 	g.AddNode(comp2)
 
-	comp3 := &model.Entity{
-		ID:   "COMP-003",
-		Type: "component",
-		Properties: map[string]interface{}{
-			"title": "Component 3",
-		},
-	}
+	comp3 := testutil.EntityFor(meta, "component").
+		ID("COMP-003").
+		With("title", "Component 3").
+		Build()
 	g.AddNode(comp3)
 
 	// COMP-001 -> COMP-002 -> COMP-003 (chain)
-	g.AddEdge(&model.Relation{From: "COMP-001", Type: "dependsOn", To: "COMP-002"})
-	g.AddEdge(&model.Relation{From: "COMP-002", Type: "dependsOn", To: "COMP-003"})
+	g.AddEdge(testutil.NewRelation("COMP-001", "dependsOn", "COMP-002").Build())
+	g.AddEdge(testutil.NewRelation("COMP-002", "dependsOn", "COMP-003").Build())
 
 	// Create a view with recursive traversal
 	view := ViewDef{
@@ -295,9 +272,9 @@ func TestViewDefValidation(t *testing.T) {
 }
 
 func TestViewResultEntities(t *testing.T) {
-	entry := &model.Entity{ID: "DOC-001", Type: "document"}
-	sec1 := &model.Entity{ID: "SEC-001", Type: "section"}
-	sec2 := &model.Entity{ID: "SEC-002", Type: "section"}
+	entry := testutil.NewEntity("DOC-001", "document").Build()
+	sec1 := testutil.NewEntity("SEC-001", "section").Build()
+	sec2 := testutil.NewEntity("SEC-002", "section").Build()
 
 	tests := []struct {
 		name    string
@@ -388,8 +365,8 @@ func TestViewResultEntities(t *testing.T) {
 }
 
 func TestViewResultEntityIDs(t *testing.T) {
-	entry := &model.Entity{ID: "DOC-001", Type: "document"}
-	sec1 := &model.Entity{ID: "SEC-001", Type: "section"}
+	entry := testutil.NewEntity("DOC-001", "document").Build()
+	sec1 := testutil.NewEntity("SEC-001", "section").Build()
 
 	result := &ViewResult{
 		Entry: entry,

--- a/internal/workspace/query_test.go
+++ b/internal/workspace/query_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 func TestEntityQueries(t *testing.T) {
+	meta := testutil.WorkspaceMetamodel()
 	g := graph.New()
-	ws := &Workspace{graph: g}
+	ws := &Workspace{graph: g, meta: meta}
 
 	// Add test entities
-	g.AddNode(testutil.Entity("requirement").ID("REQ-001").With("title", "Test Requirement").Build())
-	g.AddNode(testutil.Entity("decision").ID("DEC-001").With("title", "Test Decision").Build())
+	g.AddNode(testutil.EntityFor(meta, "requirement").ID("REQ-001").With("title", "Test Requirement").Build())
+	g.AddNode(testutil.EntityFor(meta, "decision").ID("DEC-001").With("title", "Test Decision").Build())
 
 	// Test GetEntity
 	entity, ok := ws.GetEntity("REQ-001")
@@ -55,12 +56,13 @@ func TestEntityQueries(t *testing.T) {
 }
 
 func TestRelationQueries(t *testing.T) {
+	meta := testutil.WorkspaceMetamodel()
 	g := graph.New()
-	ws := &Workspace{graph: g}
+	ws := &Workspace{graph: g, meta: meta}
 
 	// Add entities
-	g.AddNode(testutil.Entity("requirement").ID("REQ-001").Build())
-	g.AddNode(testutil.Entity("decision").ID("DEC-001").Build())
+	g.AddNode(testutil.EntityFor(meta, "requirement").ID("REQ-001").Build())
+	g.AddNode(testutil.EntityFor(meta, "decision").ID("DEC-001").Build())
 
 	// Add relation
 	g.AddEdge(testutil.NewRelation("DEC-001", "implements", "REQ-001").Build())
@@ -100,13 +102,14 @@ func TestRelationQueries(t *testing.T) {
 }
 
 func TestGraphAnalysis(t *testing.T) {
+	meta := testutil.WorkspaceMetamodel()
 	g := graph.New()
-	ws := &Workspace{graph: g}
+	ws := &Workspace{graph: g, meta: meta}
 
 	// Add entities
-	g.AddNode(testutil.Entity("requirement").ID("REQ-001").Build())
-	g.AddNode(testutil.Entity("decision").ID("DEC-001").Build())
-	g.AddNode(testutil.Entity("requirement").ID("ORPHAN-001").Build())
+	g.AddNode(testutil.EntityFor(meta, "requirement").ID("REQ-001").Build())
+	g.AddNode(testutil.EntityFor(meta, "decision").ID("DEC-001").Build())
+	g.AddNode(testutil.EntityFor(meta, "requirement").ID("ORPHAN-001").Build())
 
 	// Add relation between req and dec
 	g.AddEdge(testutil.NewRelation("DEC-001", "implements", "REQ-001").Build())

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -517,20 +517,22 @@ func TestDeleteEntity_NotFound(t *testing.T) {
 func TestCreateRelation(t *testing.T) {
 	ws := setupTestWorkspace(t)
 
+	reqID := "REQ-001"
+	decID := "DEC-001"
 	mustCreate(t, ws, "requirement", CreateOptions{
-		ID:         "REQ-001",
+		ID:         reqID,
 		Properties: map[string]interface{}{"title": "Req"},
 	})
 	mustCreate(t, ws, "decision", CreateOptions{
-		ID:         "DEC-001",
+		ID:         decID,
 		Properties: map[string]interface{}{"title": "Dec"},
 	})
 
-	rel, err := ws.CreateRelation("DEC-001", "addresses", "REQ-001")
+	rel, err := ws.CreateRelation(decID, "addresses", reqID)
 	if err != nil {
 		t.Fatalf("CreateRelation() error = %v", err)
 	}
-	if rel.From != "DEC-001" || rel.Type != "addresses" || rel.To != "REQ-001" {
+	if rel.From != decID || rel.Type != "addresses" || rel.To != reqID {
 		t.Errorf("unexpected relation: %+v", rel)
 	}
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -177,7 +177,7 @@ func TestGenerateID_Sequential(t *testing.T) {
 	ws := setupTestWorkspace(t)
 
 	// Add an existing entity so the next ID is REQ-002.
-	ws.graph.AddNode(testutil.Entity("requirement").ID("REQ-001").With("title", "first").Build())
+	ws.graph.AddNode(testutil.EntityFor(ws.Meta(), "requirement").ID("REQ-001").Build())
 
 	id, err := ws.GenerateID("requirement", "")
 	if err != nil {

--- a/tickets/entities/tickets/TKT-7g7x.md
+++ b/tickets/entities/tickets/TKT-7g7x.md
@@ -1,0 +1,100 @@
+---
+effort: m
+id: TKT-7g7x
+kind: refactor
+priority: low
+status: ready
+title: Replace hardcoded ID comparisons in test assertions
+type: ticket
+---
+
+## Problem
+
+Many test files compare against hardcoded ID strings and property values in assertions, which couples the test to specific values rather than referencing the entity being tested. This also prevents the use of randomized test data.
+
+Example of problematic patterns:
+```go
+entity := testutil.Entity("ticket").ID("T-001").Build()
+// ... later ...
+if rel.From != "T-001" {  // hardcoded - should use entity.ID
+
+// Also:
+if toCreate.Properties["title"] != "Checklist for T-001" {  // should use entity.ID
+```
+
+## Goals
+
+1. **Enable random test data**: By removing hardcoded value assertions, tests can use `EntityFor()` with auto-generated random IDs and properties
+2. **Clarify test intent**: Only specify values that are actually being tested
+3. **Reduce boilerplate**: Let the test fixtures handle default values
+
+## Scope
+
+~130+ instances across the codebase fall into these categories:
+
+### 1. Can use entity reference (IN SCOPE)
+Where entity is in scope, use `entity.ID` instead of hardcoded string:
+```go
+// Before
+if rel.From != "T-001" { ... }
+// After  
+if rel.From != entity.ID { ... }
+```
+
+### 2. Needs local constants (IN SCOPE)
+Where IDs are passed to helper functions, extract to local variables:
+```go
+// Before
+mustCreate(t, ws, "requirement", CreateOptions{ID: "REQ-001", ...})
+if rel.From != "REQ-001" { ... }
+// After
+reqID := "REQ-001"
+mustCreate(t, ws, "requirement", CreateOptions{ID: reqID, ...})
+if rel.From != reqID { ... }
+```
+
+### 3. Interpolated property values (IN SCOPE)
+Where assertions check interpolated values, construct expected value from entity:
+```go
+// Before
+if toCreate.Properties["title"] != "Checklist for T-001" { ... }
+// After
+if toCreate.Properties["title"] != "Checklist for "+entity.ID { ... }
+```
+
+### 4. Preserved property assertions (IN SCOPE)
+Where tests verify a property wasn't changed, compare against original entity:
+```go
+// Before
+if updated.Properties["title"] != "Original Title" { ... }
+// After
+if updated.Properties["title"] != original.Properties["title"] { ... }
+```
+
+### 5. Ordering tests (OUT OF SCOPE)
+Where specific IDs are used to verify sort order, hardcoded strings are appropriate since the test is verifying deterministic ordering.
+
+### 6. Parse/read tests (OUT OF SCOPE)
+Where the ID comes from parsed content (files, fixtures), hardcoded strings are appropriate since the test is verifying the parser reads specific values.
+
+### 7. Automation trigger values (OUT OF SCOPE)
+Where specific values trigger automation rules (e.g., status="in-progress"), hardcoded values are appropriate since that's what's being tested.
+
+## Files with most instances
+
+From grep analysis:
+- `internal/mcp/convert_test.go` (~25 instances)
+- `internal/dataentry/helpers_test.go` (~15 instances)
+- `internal/dataentry/handlers_test.go` (~10 instances)
+- `internal/workspace/workspace_test.go` (~5 instances)
+- `internal/rename/rename_test.go` (~10 instances)
+- `internal/automation/engine_test.go` (~10 instances)
+- `internal/lua/runtime_test.go` (~15 instances)
+
+## Acceptance Criteria
+
+- [ ] Category 1-4 instances use entity/property references where applicable
+- [ ] Tests that don't need specific IDs can use `EntityFor()` with random IDs
+- [ ] All tests pass after refactoring
+- [ ] No new test failures introduced
+- [ ] Test intent is clearer (only explicitly set values that matter for the test)

--- a/tickets/relations/TKT-7g7x--affects--test-fixtures.md
+++ b/tickets/relations/TKT-7g7x--affects--test-fixtures.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7g7x
+relation: affects
+to: test-fixtures
+---

--- a/tickets/relations/TKT-7g7x--implements--FEAT-testutil.md
+++ b/tickets/relations/TKT-7g7x--implements--FEAT-testutil.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7g7x
+relation: implements
+to: FEAT-testutil
+---


### PR DESCRIPTION
## Summary

- Replace hardcoded ID/property assertions with entity references
- Use `EntityFor` with metamodel for automatic property auto-fill
- Use builder pattern instead of inline struct creation
- Add test writing best practices to claude-workflow templates

## Changes

### 1. Replace hardcoded assertions (~140+ instances)
Use entity references instead of hardcoded strings in test assertions:
```go
// Before
if rel.From != "T-001" { ... }
// After
if rel.From != entity.ID { ... }
```

### 2. Use EntityFor with metamodel (10 files)
Let EntityFor auto-fill required properties from the metamodel:
```go
// Before
testutil.Entity("ticket").With("title", "...").With("status", "...").Build()
// After
testutil.EntityFor(meta, "ticket").Build()  // auto-fills required props
```

### 3. Use builder pattern for entities
Replace inline struct creation with fluent builders:
```go
// Before
&model.Entity{ID: "DOC-001", Type: "document", ...}
// After
testutil.EntityFor(meta, "document").ID("DOC-001").Build()
```

## Test plan

- [x] All tests pass locally
- [x] Local CI checks pass (`just ci`)