### PR TITLE
feat(validation): add checklist validation for markdown content

### DIFF
--- a/internal/dataentry/analyze_test.go
+++ b/internal/dataentry/analyze_test.go
@@ -605,3 +605,116 @@ func TestAnalyzeValidationsWithCombinedRules(t *testing.T) {
 		t.Error("expected violation on DEC-002")
 	}
 }
+
+func TestAnalyzeValidationsWithChecklistRule(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"checklist": {Properties: map[string]metamodel.PropertyDef{
+				"title":  {Type: "string"},
+				"status": {Type: "string"},
+			}},
+		},
+		Validations: []metamodel.ValidationRule{
+			{
+				Name:        "done-checklist-complete",
+				Description: "Done checklists must have all items checked",
+				EntityType:  "checklist",
+				When:        []string{"status=done"},
+				Content: &metamodel.ContentRule{
+					Checklist: &metamodel.ChecklistRule{
+						AllChecked: true,
+					},
+				},
+				Severity: "error",
+			},
+		},
+	}
+
+	// Done with unchecked items — violation
+	g.AddNode(&model.Entity{
+		ID:         "CHK-001",
+		Type:       "checklist",
+		Properties: map[string]interface{}{"title": "Incomplete", "status": "done"},
+		Content:    "- [x] Done item\n- [ ] Not done item",
+	})
+	// Done with all checked — OK
+	g.AddNode(&model.Entity{
+		ID:         "CHK-002",
+		Type:       "checklist",
+		Properties: map[string]interface{}{"title": "Complete", "status": "done"},
+		Content:    "- [x] Done 1\n- [x] Done 2",
+	})
+	// In-progress — rule doesn't apply
+	g.AddNode(&model.Entity{
+		ID:         "CHK-003",
+		Type:       "checklist",
+		Properties: map[string]interface{}{"title": "WIP", "status": "in-progress"},
+		Content:    "- [ ] Not started",
+	})
+
+	app := newTestApp(g, meta)
+	section := app.analyzeValidations()
+
+	if len(section.Issues) != 1 {
+		t.Fatalf("expected 1 checklist validation issue, got %d", len(section.Issues))
+	}
+	if section.Issues[0].EntityID != "CHK-001" {
+		t.Errorf("expected violation on CHK-001, got %s", section.Issues[0].EntityID)
+	}
+	if section.Issues[0].Severity != "error" {
+		t.Errorf("expected severity 'error', got %q", section.Issues[0].Severity)
+	}
+}
+
+func TestAnalyzeValidationsWithChecklistAllowSkipped(t *testing.T) {
+	g := graph.New()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"checklist": {Properties: map[string]metamodel.PropertyDef{
+				"title":  {Type: "string"},
+				"status": {Type: "string"},
+			}},
+		},
+		Validations: []metamodel.ValidationRule{
+			{
+				Name:        "done-checklist-allow-skipped",
+				Description: "Done checklists must have all items checked or skipped",
+				EntityType:  "checklist",
+				When:        []string{"status=done"},
+				Content: &metamodel.ContentRule{
+					Checklist: &metamodel.ChecklistRule{
+						AllChecked:   true,
+						AllowSkipped: true,
+					},
+				},
+				Severity: "error",
+			},
+		},
+	}
+
+	// Done with skipped item — OK
+	g.AddNode(&model.Entity{
+		ID:         "CHK-001",
+		Type:       "checklist",
+		Properties: map[string]interface{}{"title": "Skipped", "status": "done"},
+		Content:    "- [x] Done item\n- [x] ~~Skipped item~~ (N/A: reason)",
+	})
+	// Done with unchecked non-skipped — violation
+	g.AddNode(&model.Entity{
+		ID:         "CHK-002",
+		Type:       "checklist",
+		Properties: map[string]interface{}{"title": "Incomplete", "status": "done"},
+		Content:    "- [x] Done item\n- [ ] Not done, not skipped",
+	})
+
+	app := newTestApp(g, meta)
+	section := app.analyzeValidations()
+
+	if len(section.Issues) != 1 {
+		t.Fatalf("expected 1 checklist validation issue, got %d", len(section.Issues))
+	}
+	if section.Issues[0].EntityID != "CHK-002" {
+		t.Errorf("expected violation on CHK-002, got %s", section.Issues[0].EntityID)
+	}
+}

--- a/internal/markdown/content.go
+++ b/internal/markdown/content.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	extast "github.com/yuin/goldmark/extension/ast"
 	"github.com/yuin/goldmark/text"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -21,8 +23,8 @@ func ExtractHeaders(content string) []string {
 
 	source := []byte(content)
 	reader := text.NewReader(source)
-	parser := goldmark.DefaultParser()
-	doc := parser.Parse(reader)
+	p := goldmark.DefaultParser()
+	doc := p.Parse(reader)
 
 	var headers []string
 	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
@@ -85,6 +87,148 @@ func CheckContentRule(entity *model.Entity, rule *metamodel.ContentRule) bool {
 
 	for _, headerCheck := range rule.RequiredHeaders {
 		if !MatchHeader(headers, headerCheck) {
+			return false
+		}
+	}
+
+	// Check checklist rules
+	if rule.Checklist != nil {
+		items := ExtractChecklistItems(entity.Content)
+		if !CheckChecklistRule(items, rule.Checklist) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// ChecklistItem represents a task list item in markdown.
+type ChecklistItem struct {
+	Checked bool   // Whether the checkbox is checked (- [x])
+	Skipped bool   // Whether the item is strikethrough (~~text~~)
+	Text    string // The text content of the item
+}
+
+// ExtractChecklistItems extracts all markdown checklist items from content using goldmark's AST parser.
+// This properly handles task lists and detects strikethrough items.
+func ExtractChecklistItems(content string) []ChecklistItem {
+	if content == "" {
+		return nil
+	}
+
+	source := []byte(content)
+	reader := text.NewReader(source)
+
+	// Create parser with TaskList and Strikethrough extensions enabled
+	md := goldmark.New(
+		goldmark.WithExtensions(extension.TaskList, extension.Strikethrough),
+	)
+	mdParser := md.Parser()
+	doc := mdParser.Parse(reader)
+
+	var items []ChecklistItem
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		// Look for TaskCheckBox nodes
+		if checkbox, ok := n.(*extast.TaskCheckBox); ok {
+			// Get the parent list item to extract text
+			listItem := findParentListItem(n)
+			if listItem == nil {
+				return ast.WalkContinue, nil
+			}
+
+			// Extract text content and check for strikethrough
+			itemText, hasStrikethrough := extractListItemText(listItem, source)
+
+			items = append(items, ChecklistItem{
+				Checked: checkbox.IsChecked,
+				Skipped: hasStrikethrough,
+				Text:    itemText,
+			})
+		}
+		return ast.WalkContinue, nil
+	})
+
+	return items
+}
+
+// findParentListItem walks up the AST to find the parent ListItem node.
+func findParentListItem(n ast.Node) *ast.ListItem {
+	for p := n.Parent(); p != nil; p = p.Parent() {
+		if li, ok := p.(*ast.ListItem); ok {
+			return li
+		}
+	}
+	return nil
+}
+
+// extractListItemText extracts the text content of a list item and detects strikethrough.
+// Processes all direct children except nested lists to get the item's main text content.
+func extractListItemText(li *ast.ListItem, source []byte) (string, bool) {
+	var textContent strings.Builder
+	hasStrikethrough := false
+
+	// Process all direct children except nested lists
+	for c := li.FirstChild(); c != nil; c = c.NextSibling() {
+		// Skip nested lists
+		if _, ok := c.(*ast.List); ok {
+			continue
+		}
+
+		_ = ast.Walk(c, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+			if !entering {
+				return ast.WalkContinue, nil
+			}
+
+			// Skip the checkbox itself
+			if _, ok := n.(*extast.TaskCheckBox); ok {
+				return ast.WalkContinue, nil
+			}
+
+			// Check for strikethrough
+			if _, ok := n.(*extast.Strikethrough); ok {
+				hasStrikethrough = true
+				return ast.WalkContinue, nil
+			}
+
+			// Collect text content
+			if t, ok := n.(*ast.Text); ok {
+				textContent.Write(t.Segment.Value(source))
+			}
+
+			return ast.WalkContinue, nil
+		})
+	}
+
+	return strings.TrimSpace(textContent.String()), hasStrikethrough
+}
+
+// CheckChecklistRule validates checklist items against a checklist rule.
+func CheckChecklistRule(items []ChecklistItem, rule *metamodel.ChecklistRule) bool {
+	if rule == nil {
+		return true
+	}
+
+	// If no checklist items, nothing to validate
+	if len(items) == 0 {
+		return true
+	}
+
+	if rule.AllChecked {
+		for _, item := range items {
+			// Item passes if:
+			// - It's checked, OR
+			// - It's skipped (strikethrough) AND allow-skipped is true
+			if item.Checked {
+				continue
+			}
+			if rule.AllowSkipped && item.Skipped {
+				continue
+			}
+			// Found an unchecked item that isn't skipped
 			return false
 		}
 	}

--- a/internal/markdown/content_test.go
+++ b/internal/markdown/content_test.go
@@ -209,3 +209,268 @@ func TestCheckContentRule(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractChecklistItems(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []ChecklistItem
+	}{
+		{
+			name:    "empty content",
+			content: "",
+			want:    nil,
+		},
+		{
+			name:    "no checklists",
+			content: "Just some text\n- Regular list item\n- Another item",
+			want:    nil,
+		},
+		{
+			name:    "single unchecked item",
+			content: "- [ ] Task to do",
+			want: []ChecklistItem{
+				{Checked: false, Skipped: false, Text: "Task to do"},
+			},
+		},
+		{
+			name:    "single checked item",
+			content: "- [x] Completed task",
+			want: []ChecklistItem{
+				{Checked: true, Skipped: false, Text: "Completed task"},
+			},
+		},
+		{
+			name:    "uppercase X",
+			content: "- [X] Also checked",
+			want: []ChecklistItem{
+				{Checked: true, Skipped: false, Text: "Also checked"},
+			},
+		},
+		{
+			name:    "multiple items",
+			content: "- [x] Done\n- [ ] Not done\n- [x] Also done",
+			want: []ChecklistItem{
+				{Checked: true, Skipped: false, Text: "Done"},
+				{Checked: false, Skipped: false, Text: "Not done"},
+				{Checked: true, Skipped: false, Text: "Also done"},
+			},
+		},
+		{
+			name:    "strikethrough item",
+			content: "- [x] ~~Skipped task~~ (N/A: reason)",
+			want: []ChecklistItem{
+				{Checked: true, Skipped: true, Text: "Skipped task (N/A: reason)"},
+			},
+		},
+		{
+			name:    "unchecked strikethrough",
+			content: "- [ ] ~~This was skipped~~",
+			want: []ChecklistItem{
+				{Checked: false, Skipped: true, Text: "This was skipped"},
+			},
+		},
+		{
+			name:    "mixed checked unchecked and skipped",
+			content: "- [x] Done task\n- [ ] Pending\n- [x] ~~Skipped~~ (N/A)",
+			want: []ChecklistItem{
+				{Checked: true, Skipped: false, Text: "Done task"},
+				{Checked: false, Skipped: false, Text: "Pending"},
+				{Checked: true, Skipped: true, Text: "Skipped (N/A)"},
+			},
+		},
+		{
+			name:    "nested checklist",
+			content: "- [x] Parent\n  - [ ] Child 1\n  - [x] Child 2",
+			want: []ChecklistItem{
+				{Checked: true, Skipped: false, Text: "Parent"},
+				{Checked: false, Skipped: false, Text: "Child 1"},
+				{Checked: true, Skipped: false, Text: "Child 2"},
+			},
+		},
+		{
+			name:    "checkbox in code block ignored",
+			content: "- [x] Real item\n```\n- [ ] Not a real item\n```",
+			want: []ChecklistItem{
+				{Checked: true, Skipped: false, Text: "Real item"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractChecklistItems(tt.content)
+			if len(got) != len(tt.want) {
+				t.Errorf("ExtractChecklistItems() got %d items, want %d", len(got), len(tt.want))
+				for i, item := range got {
+					t.Logf("  got[%d]: checked=%v, skipped=%v, text=%q", i, item.Checked, item.Skipped, item.Text)
+				}
+				return
+			}
+			for i := range got {
+				if got[i].Checked != tt.want[i].Checked {
+					t.Errorf("item[%d].Checked = %v, want %v", i, got[i].Checked, tt.want[i].Checked)
+				}
+				if got[i].Skipped != tt.want[i].Skipped {
+					t.Errorf("item[%d].Skipped = %v, want %v", i, got[i].Skipped, tt.want[i].Skipped)
+				}
+				if got[i].Text != tt.want[i].Text {
+					t.Errorf("item[%d].Text = %q, want %q", i, got[i].Text, tt.want[i].Text)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckChecklistRule(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []ChecklistItem
+		rule  *metamodel.ChecklistRule
+		want  bool
+	}{
+		{
+			name:  "nil rule passes",
+			items: []ChecklistItem{{Checked: false}},
+			rule:  nil,
+			want:  true,
+		},
+		{
+			name:  "empty items passes",
+			items: []ChecklistItem{},
+			rule:  &metamodel.ChecklistRule{AllChecked: true},
+			want:  true,
+		},
+		{
+			name: "all checked passes",
+			items: []ChecklistItem{
+				{Checked: true, Text: "Item 1"},
+				{Checked: true, Text: "Item 2"},
+			},
+			rule: &metamodel.ChecklistRule{AllChecked: true},
+			want: true,
+		},
+		{
+			name: "unchecked item fails",
+			items: []ChecklistItem{
+				{Checked: true, Text: "Item 1"},
+				{Checked: false, Text: "Item 2"},
+			},
+			rule: &metamodel.ChecklistRule{AllChecked: true},
+			want: false,
+		},
+		{
+			name: "skipped item passes with allow-skipped",
+			items: []ChecklistItem{
+				{Checked: true, Text: "Item 1"},
+				{Checked: false, Skipped: true, Text: "Skipped item"},
+			},
+			rule: &metamodel.ChecklistRule{AllChecked: true, AllowSkipped: true},
+			want: true,
+		},
+		{
+			name: "skipped item fails without allow-skipped",
+			items: []ChecklistItem{
+				{Checked: true, Text: "Item 1"},
+				{Checked: false, Skipped: true, Text: "Skipped item"},
+			},
+			rule: &metamodel.ChecklistRule{AllChecked: true, AllowSkipped: false},
+			want: false,
+		},
+		{
+			name: "checked skipped item passes",
+			items: []ChecklistItem{
+				{Checked: true, Skipped: true, Text: "Item 1"},
+			},
+			rule: &metamodel.ChecklistRule{AllChecked: true},
+			want: true,
+		},
+		{
+			name: "no all-checked rule passes with unchecked",
+			items: []ChecklistItem{
+				{Checked: false, Text: "Unchecked"},
+			},
+			rule: &metamodel.ChecklistRule{AllChecked: false},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CheckChecklistRule(tt.items, tt.rule)
+			if got != tt.want {
+				t.Errorf("CheckChecklistRule() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckContentRuleWithChecklist(t *testing.T) {
+	tests := []struct {
+		name   string
+		entity *model.Entity
+		rule   *metamodel.ContentRule
+		want   bool
+	}{
+		{
+			name:   "all checked passes",
+			entity: &model.Entity{Content: "- [x] Task 1\n- [x] Task 2"},
+			rule: &metamodel.ContentRule{
+				Checklist: &metamodel.ChecklistRule{AllChecked: true},
+			},
+			want: true,
+		},
+		{
+			name:   "unchecked item fails",
+			entity: &model.Entity{Content: "- [x] Task 1\n- [ ] Task 2"},
+			rule: &metamodel.ContentRule{
+				Checklist: &metamodel.ChecklistRule{AllChecked: true},
+			},
+			want: false,
+		},
+		{
+			name:   "skipped item passes with allow-skipped",
+			entity: &model.Entity{Content: "- [x] Task 1\n- [x] ~~Task 2~~ (N/A)"},
+			rule: &metamodel.ContentRule{
+				Checklist: &metamodel.ChecklistRule{AllChecked: true, AllowSkipped: true},
+			},
+			want: true,
+		},
+		{
+			name:   "combined headers and checklist both pass",
+			entity: &model.Entity{Content: "## Summary\n- [x] Done\n## Details"},
+			rule: &metamodel.ContentRule{
+				RequiredHeaders: []metamodel.HeaderCheck{{Header: "## Summary"}},
+				Checklist:       &metamodel.ChecklistRule{AllChecked: true},
+			},
+			want: true,
+		},
+		{
+			name:   "combined headers pass checklist fails",
+			entity: &model.Entity{Content: "## Summary\n- [ ] Not done"},
+			rule: &metamodel.ContentRule{
+				RequiredHeaders: []metamodel.HeaderCheck{{Header: "## Summary"}},
+				Checklist:       &metamodel.ChecklistRule{AllChecked: true},
+			},
+			want: false,
+		},
+		{
+			name:   "combined headers fail checklist passes",
+			entity: &model.Entity{Content: "## Other\n- [x] Done"},
+			rule: &metamodel.ContentRule{
+				RequiredHeaders: []metamodel.HeaderCheck{{Header: "## Summary"}},
+				Checklist:       &metamodel.ChecklistRule{AllChecked: true},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CheckContentRule(tt.entity, tt.rule)
+			if got != tt.want {
+				t.Errorf("CheckContentRule() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -327,6 +327,18 @@ type AutomationCheck struct {
 type ContentRule struct {
 	// RequiredHeaders specifies headers that must appear in the content
 	RequiredHeaders []HeaderCheck `yaml:"required-headers,omitempty"`
+
+	// Checklist specifies validation rules for markdown checklists (task lists)
+	Checklist *ChecklistRule `yaml:"checklist,omitempty"`
+}
+
+// ChecklistRule defines validation rules for markdown checklists.
+type ChecklistRule struct {
+	// AllChecked requires all checklist items to be checked
+	AllChecked bool `yaml:"all-checked,omitempty"`
+
+	// AllowSkipped treats strikethrough items as complete (e.g., "- [x] ~~task~~ (N/A: reason)")
+	AllowSkipped bool `yaml:"allow-skipped,omitempty"`
 }
 
 // HeaderCheck specifies a header to check for in markdown content.

--- a/tickets/entities/features/FEAT-GM14.md
+++ b/tickets/entities/features/FEAT-GM14.md
@@ -1,0 +1,80 @@
+---
+id: FEAT-GM14
+type: feature
+title: Checklist validation for markdown content
+description: Add validation rules for markdown checklists (task lists) within entity bodies, enabling CI gates that require all tasks to be completed
+status: proposed
+---
+
+# Checklist Validation for Markdown Content
+
+Add validation rules for markdown checklists (task lists) within entity bodies. This enables enforcing completeness of checklists, which is useful for:
+
+- **CI gates**: Ensuring all tasks in a planning/implementation checklist are completed before status transitions
+- **Quality gates**: Verifying review checklists are finished before marking tickets done
+- **Compliance**: Ensuring all required steps in a process have been acknowledged
+
+## Design
+
+### Syntax
+
+Extend validation rules with checklist validation:
+
+```yaml
+validations:
+  - name: done-tickets-need-complete-checklist
+    entity_type: ticket
+    when:
+      - "status=done"
+    content:
+      checklist:
+        all-checked: true
+    severity: error
+
+  - name: planning-checklists-complete
+    entity_type: planning-checklist
+    when:
+      - "status=done"
+    content:
+      checklist:
+        all-checked: true
+        allow-skipped: true  # Allow strikethrough items with reason
+    severity: error
+```
+
+### Checklist Options
+
+| Option | Description |
+|--------|-------------|
+| `all-checked: true` | All `- [ ]` must be `- [x]` |
+| `allow-skipped: true` | Strikethrough items (~~item~~) count as complete |
+| `min-checked: N` | At least N items must be checked |
+| `min-percentage: N` | At least N% of items must be checked |
+
+### Skipped Items
+
+Items can be marked as skipped using strikethrough with a reason:
+
+```markdown
+- [x] ~~API docs updated~~ (N/A: no API changes)
+```
+
+When `allow-skipped: true`, these count as complete. When false (default), only `- [x]` items count.
+
+## Implementation
+
+1. Add `ChecklistRule` type to `internal/metamodel/types.go`
+2. Extend `ContentRule` with `Checklist *ChecklistRule` field
+3. Add checklist parsing in `internal/markdown/` to extract task items
+4. Add checklist validation logic in `internal/dataentry/analyze.go`
+5. Count checked vs unchecked items, handle strikethrough detection
+6. Report violations through existing `analyze_validations` flow
+
+## Acceptance Criteria
+
+- [ ] Can define `checklist.all-checked` in validation rules
+- [ ] Counts `- [ ]` and `- [x]` items correctly
+- [ ] `allow-skipped` handles strikethrough items
+- [ ] `min-checked` and `min-percentage` work correctly
+- [ ] Violations appear in `analyze_validations` output
+- [ ] Works with `when:` conditions

--- a/tickets/entities/tickets/TKT-Y2JW.md
+++ b/tickets/entities/tickets/TKT-Y2JW.md
@@ -1,0 +1,30 @@
+---
+id: TKT-Y2JW
+type: ticket
+title: Add checklist validation for markdown content
+kind: enhancement
+priority: medium
+effort: m
+status: done
+---
+
+# Add Checklist Validation for Markdown Content
+
+## Summary
+
+Implement validation rules for markdown checklists (task lists) within entity bodies. This enables CI gates that require all tasks to be completed before status transitions.
+
+## Use Cases
+
+1. **CI gates**: Block status transitions when checklists are incomplete
+2. **Workflow enforcement**: Ensure planning/implementation checklists are finished
+3. **Quality assurance**: Verify all review items have been addressed
+
+## Acceptance Criteria
+
+- [ ] Can define `checklist.all-checked` validation rule
+- [ ] Counts `- [ ]` and `- [x]` items correctly
+- [ ] `allow-skipped` option handles strikethrough items with reasons
+- [ ] Violations appear in `analyze_validations` output
+- [ ] Works with `when:` conditions for status-based requirements
+- [ ] Integration tests verify checklist parsing edge cases

--- a/tickets/relations/FEAT-GM14--requires--metamodel-types.md
+++ b/tickets/relations/FEAT-GM14--requires--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-GM14
+relation: requires
+to: metamodel-types
+---

--- a/tickets/relations/TKT-Y2JW--affects--metamodel-types.md
+++ b/tickets/relations/TKT-Y2JW--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y2JW
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-Y2JW--implements--FEAT-GM14.md
+++ b/tickets/relations/TKT-Y2JW--implements--FEAT-GM14.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y2JW
+relation: implements
+to: FEAT-GM14
+---


### PR DESCRIPTION
## Summary

- Add checklist validation for markdown content, enabling CI gates that require all tasks to be completed before status transitions
- Improve workflow docs and checklist templates

## Changes

### Checklist Validation Feature

New metamodel validation syntax for markdown checklists:

```yaml
validations:
  - name: done-checklists-complete
    entity_type: checklist
    when: ["status=done"]
    content:
      checklist:
        all-checked: true      # All - [ ] must be - [x]
        allow-skipped: true    # Strikethrough items count as complete
    severity: error
```

**Features:**
- `all-checked`: requires all `- [ ]` items to be `- [x]`
- `allow-skipped`: strikethrough items (`~~text~~`) count as complete
- Works with `when` conditions for status-based requirements
- Properly ignores checkboxes in code blocks (goldmark AST parsing)

**Files changed:**
- `internal/metamodel/types.go` - Added `ChecklistRule` struct
- `internal/markdown/content.go` - Added extraction and validation logic
- `internal/markdown/content_test.go` - Unit tests
- `internal/dataentry/analyze_test.go` - Integration tests

### Workflow Improvements

- Improved checklist templates for planning, implementation, and review phases
- Added test writing best practices section

## Test plan

- [x] Unit tests for `ExtractChecklistItems()` function
- [x] Unit tests for `CheckChecklistRule()` function
- [x] Integration tests with metamodel validation rules
- [x] Manual end-to-end testing with test project
- [x] All local CI checks pass (`just ci`)