### PR TITLE
feat(fmt): add configurable line width for paragraph wrapping

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -74,6 +74,7 @@ vendors:
       - github.com/yuin/goldmark
       - github.com/yuin/goldmark/**
       - github.com/teekennedy/goldmark-markdown
+      - github.com/mitchellh/go-wordwrap
   gogit:       { in: github.com/go-git/go-git/** }
   gopherlua:   { in: github.com/yuin/gopher-lua }
   mcpgo:       { in: github.com/mark3labs/mcp-go/** }

--- a/docs-project/entities/guide/GUIDE-cli-reference.md
+++ b/docs-project/entities/guide/GUIDE-cli-reference.md
@@ -28,6 +28,20 @@ These options work with any command:
 | -------------- | ---------------------------------------------------------------- |
 | `RELA_PROJECT` | Default project directory when `--project` flag is not specified |
 
+## Project Configuration
+
+Project-level settings are stored in `.rela/config.yaml`. This file is optional; defaults are used
+when it doesn't exist.
+
+```yaml
+formatting:
+  line_width: 80  # Maximum line width for paragraph wrapping (default: 80)
+```
+
+| Setting                  | Description                                      | Default |
+| ------------------------ | ------------------------------------------------ | ------- |
+| `formatting.line_width`  | Maximum line width for paragraph wrapping        | 80      |
+
 ## Commands
 
 ### rela init
@@ -663,6 +677,66 @@ When using `--all`, the output includes both entities and relations:
   ]
 }
 ```
+
+---
+
+### rela fmt
+
+Format entity and relation files for consistent styling.
+
+```bash
+rela fmt [type] [flags]
+```
+
+**Arguments:**
+
+- `type` - Optional: specific entity type to format
+
+**Flags:**
+
+| Flag        | Description                                          |
+| ----------- | ---------------------------------------------------- |
+| `--dry-run` | Preview changes without writing                      |
+| `--check`   | Check if files need formatting (exits 1 if they do)  |
+
+This command normalizes:
+
+- Frontmatter property ordering (id/type first for entities, from/relation/to for relations)
+- Markdown content formatting (headings, lists, whitespace)
+- Paragraph wrapping to configured line width (default: 80 characters)
+
+**Configuration:**
+
+Line width can be configured in `.rela/config.yaml`:
+
+```yaml
+formatting:
+  line_width: 100  # default: 80
+```
+
+**What gets wrapped:**
+
+- Paragraph text is wrapped to the configured line width
+- Code blocks, headings, lists, and blockquotes are NOT wrapped (preserved as-is)
+
+**Examples:**
+
+```bash
+rela fmt                # Format all entities and relations
+rela fmt requirements   # Format only requirements (entities)
+rela fmt --dry-run      # Preview changes without writing
+rela fmt --check        # Check if files need formatting (for CI)
+```
+
+**CI Integration:**
+
+Add to your CI pipeline to ensure consistent formatting:
+
+```yaml
+- run: rela fmt --check
+```
+
+This will exit with code 1 if any files need formatting.
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -22,6 +22,20 @@ These options work with any command:
 | -------------- | ---------------------------------------------------------------- |
 | `RELA_PROJECT` | Default project directory when `--project` flag is not specified |
 
+## Project Configuration
+
+Project-level settings are stored in `.rela/config.yaml`. This file is optional; defaults are used
+when it doesn't exist.
+
+```yaml
+formatting:
+  line_width: 80  # Maximum line width for paragraph wrapping (default: 80)
+```
+
+| Setting                  | Description                                      | Default |
+| ------------------------ | ------------------------------------------------ | ------- |
+| `formatting.line_width`  | Maximum line width for paragraph wrapping        | 80      |
+
 ## Commands
 
 ### rela init
@@ -657,6 +671,66 @@ When using `--all`, the output includes both entities and relations:
   ]
 }
 ```
+
+---
+
+### rela fmt
+
+Format entity and relation files for consistent styling.
+
+```bash
+rela fmt [type] [flags]
+```
+
+**Arguments:**
+
+- `type` - Optional: specific entity type to format
+
+**Flags:**
+
+| Flag        | Description                                          |
+| ----------- | ---------------------------------------------------- |
+| `--dry-run` | Preview changes without writing                      |
+| `--check`   | Check if files need formatting (exits 1 if they do)  |
+
+This command normalizes:
+
+- Frontmatter property ordering (id/type first for entities, from/relation/to for relations)
+- Markdown content formatting (headings, lists, whitespace)
+- Paragraph wrapping to configured line width (default: 80 characters)
+
+**Configuration:**
+
+Line width can be configured in `.rela/config.yaml`:
+
+```yaml
+formatting:
+  line_width: 100  # default: 80
+```
+
+**What gets wrapped:**
+
+- Paragraph text is wrapped to the configured line width
+- Code blocks, headings, lists, and blockquotes are NOT wrapped (preserved as-is)
+
+**Examples:**
+
+```bash
+rela fmt                # Format all entities and relations
+rela fmt requirements   # Format only requirements (entities)
+rela fmt --dry-run      # Preview changes without writing
+rela fmt --check        # Check if files need formatting (for CI)
+```
+
+**CI Integration:**
+
+Add to your CI pipeline to ensure consistent formatting:
+
+```yaml
+- run: rela fmt --check
+```
+
+This will exit with code 1 if any files need formatting.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,8 @@ github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3N
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
+github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/internal/markdown/entity.go
+++ b/internal/markdown/entity.go
@@ -70,7 +70,14 @@ func (f *FileIO) ReadEntity(path string, meta *metamodel.Metamodel) (*model.Enti
 // FormatEntity returns the formatted markdown content for an entity.
 // The optional propertyOrder specifies the order for entity properties (after id and type).
 // Both frontmatter ordering and markdown content formatting are applied.
+// Uses default line width (80) for paragraph wrapping.
 func FormatEntity(entity *model.Entity, propertyOrder []string) (string, error) {
+	return FormatEntityWithWidth(entity, propertyOrder, DefaultLineWidth)
+}
+
+// FormatEntityWithWidth returns the formatted markdown content for an entity
+// with a specific line width for paragraph wrapping.
+func FormatEntityWithWidth(entity *model.Entity, propertyOrder []string, lineWidth int) (string, error) {
 	frontmatter := make(map[string]interface{})
 	frontmatter["id"] = entity.ID
 	frontmatter["type"] = entity.Type
@@ -89,7 +96,7 @@ func FormatEntity(entity *model.Entity, propertyOrder []string) (string, error) 
 	// Format markdown content
 	content := entity.Content
 	if content != "" {
-		content = FormatMarkdown(content)
+		content = FormatMarkdownWithWidth(content, lineWidth)
 	}
 
 	return FormatDocumentOrdered(frontmatter, content, keyOrder)

--- a/internal/markdown/format.go
+++ b/internal/markdown/format.go
@@ -2,20 +2,34 @@ package markdown
 
 import (
 	"bytes"
+	"regexp"
 	"strings"
 
+	wordwrap "github.com/mitchellh/go-wordwrap"
 	markdown "github.com/teekennedy/goldmark-markdown"
 	"github.com/yuin/goldmark"
 )
+
+// orderedListPattern matches ordered list items (e.g., "1. ", "2. ").
+var orderedListPattern = regexp.MustCompile(`^\d+\.\s`)
+
+// DefaultLineWidth is the default line width for paragraph wrapping.
+const DefaultLineWidth = 80
 
 // FormatMarkdown normalizes markdown content using consistent formatting rules:
 // - ATX-style headings (#)
 // - Consistent list markers
 // - Normalized whitespace and indentation
 // - Consistent code fence style
+// - Paragraph text wrapped at 80 characters
 //
 // Returns the formatted content, or the original content if formatting fails.
 func FormatMarkdown(content string) string {
+	return FormatMarkdownWithWidth(content, DefaultLineWidth)
+}
+
+// FormatMarkdownWithWidth normalizes markdown content with a specific line width.
+func FormatMarkdownWithWidth(content string, lineWidth int) string {
 	if content == "" {
 		return ""
 	}
@@ -23,11 +37,12 @@ func FormatMarkdown(content string) string {
 	// Trim trailing whitespace but preserve structure
 	content = strings.TrimRight(content, " \t")
 
-	renderer := markdown.NewRenderer(
+	r := markdown.NewRenderer(
 		markdown.WithHeadingStyle(markdown.HeadingStyleATX),
 		markdown.WithIndentStyle(markdown.IndentStyleSpaces),
 	)
-	md := goldmark.New(goldmark.WithRenderer(renderer))
+
+	md := goldmark.New(goldmark.WithRenderer(r))
 
 	var buf bytes.Buffer
 	if err := md.Convert([]byte(content), &buf); err != nil {
@@ -37,8 +52,136 @@ func FormatMarkdown(content string) string {
 
 	result := buf.String()
 
+	// Post-process: wrap paragraphs at line width
+	result = wrapParagraphs(result, lineWidth)
+
 	// Ensure single trailing newline
 	result = strings.TrimRight(result, "\n") + "\n"
 
 	return result
+}
+
+// wrapParagraphs wraps paragraph text while preserving code blocks, lists, headings, etc.
+func wrapParagraphs(content string, lineWidth int) string {
+	lines := strings.Split(content, "\n")
+	var result []string
+	paragraphLines := make([]string, 0, 10)
+	inCodeBlock := false
+	codeBlockMarker := ""
+
+	// Ensure lineWidth is positive to avoid overflow
+	if lineWidth <= 0 {
+		lineWidth = DefaultLineWidth
+	}
+
+	flushParagraph := func() {
+		if len(paragraphLines) > 0 {
+			// Join lines and wrap
+			text := strings.Join(paragraphLines, " ")
+			text = strings.TrimSpace(text)
+			if text != "" {
+				wrapped := wordwrap.WrapString(text, uint(lineWidth)) //nolint:gosec // lineWidth is validated positive
+				result = append(result, wrapped)
+			}
+			paragraphLines = paragraphLines[:0]
+		}
+	}
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Check for code block markers
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			flushParagraph()
+			switch {
+			case !inCodeBlock:
+				inCodeBlock = true
+				codeBlockMarker = trimmed[:3]
+				result = append(result, line)
+			case strings.HasPrefix(trimmed, codeBlockMarker):
+				inCodeBlock = false
+				codeBlockMarker = ""
+				result = append(result, line)
+			default:
+				result = append(result, line)
+			}
+			continue
+		}
+
+		// Inside code block - preserve exactly
+		if inCodeBlock {
+			result = append(result, line)
+			continue
+		}
+
+		// Check for special lines that shouldn't be wrapped
+		if isSpecialLine(trimmed) {
+			flushParagraph()
+			result = append(result, line)
+			continue
+		}
+
+		// Empty line - end of paragraph
+		if trimmed == "" {
+			flushParagraph()
+			result = append(result, "")
+			continue
+		}
+
+		// Regular paragraph content
+		paragraphLines = append(paragraphLines, trimmed)
+	}
+
+	flushParagraph()
+
+	return strings.Join(result, "\n")
+}
+
+// isSpecialLine returns true for lines that shouldn't be wrapped.
+func isSpecialLine(line string) bool {
+	if line == "" {
+		return true
+	}
+
+	// Headings
+	if strings.HasPrefix(line, "#") {
+		return true
+	}
+
+	// List items (unordered)
+	if strings.HasPrefix(line, "- ") || strings.HasPrefix(line, "* ") || strings.HasPrefix(line, "+ ") {
+		return true
+	}
+
+	// List items (ordered) - matches "1. ", "2. ", etc.
+	if orderedListPattern.MatchString(line) {
+		return true
+	}
+
+	// Blockquotes
+	if strings.HasPrefix(line, ">") {
+		return true
+	}
+
+	// Thematic breaks
+	if line == "---" || line == "***" || line == "___" {
+		return true
+	}
+
+	// Indented code (4+ spaces or tab)
+	if strings.HasPrefix(line, "    ") || strings.HasPrefix(line, "\t") {
+		return true
+	}
+
+	// HTML-style comments
+	if strings.HasPrefix(line, "<!--") {
+		return true
+	}
+
+	// Tables (pipe-delimited)
+	if strings.HasPrefix(line, "|") {
+		return true
+	}
+
+	return false
 }

--- a/internal/markdown/format_test.go
+++ b/internal/markdown/format_test.go
@@ -108,6 +108,7 @@ func TestFormatMarkdown_Idempotent(t *testing.T) {
 		"## Heading\n\nSome content.\n\n- List item\n",
 		"Heading\n=======\n\nParagraph",
 		"> Quote\n\n```\ncode\n```\n",
+		"This is a very long paragraph that should be wrapped at the default line width of eighty characters.",
 	}
 
 	for _, input := range inputs {
@@ -117,4 +118,153 @@ func TestFormatMarkdown_Idempotent(t *testing.T) {
 			t.Errorf("FormatMarkdown is not idempotent:\nFirst:  %q\nSecond: %q", first, second)
 		}
 	}
+}
+
+func TestFormatMarkdown_LineWrapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		width    int
+		expected string
+	}{
+		{
+			name:     "short paragraph not wrapped",
+			input:    "Short text.",
+			width:    80,
+			expected: "Short text.\n",
+		},
+		{
+			name:     "long paragraph wrapped",
+			input:    "This is a very long paragraph that exceeds the line width and should be wrapped at word boundaries.",
+			width:    40,
+			expected: "This is a very long paragraph that\nexceeds the line width and should be\nwrapped at word boundaries.\n",
+		},
+		{
+			name:     "code block not wrapped",
+			input:    "```\nThis is a very long line of code that should not be wrapped even if it exceeds the line width.\n```",
+			width:    40,
+			expected: "```\nThis is a very long line of code that should not be wrapped even if it exceeds the line width.\n```\n",
+		},
+		{
+			name:     "heading not wrapped",
+			input:    "## This is a very long heading that should not be wrapped even if it exceeds the line width",
+			width:    40,
+			expected: "## This is a very long heading that should not be wrapped even if it exceeds the line width\n",
+		},
+		{
+			name:     "inline code preserved in wrapped text",
+			input:    "Use the `FormatMarkdown` function to format your content and make it look nice.",
+			width:    40,
+			expected: "Use the `FormatMarkdown` function to\nformat your content and make it look\nnice.\n",
+		},
+		{
+			name:     "link preserved in wrapped text",
+			input:    "Visit the [documentation](https://example.com/docs) for more information about this feature.",
+			width:    40,
+			expected: "Visit the\n[documentation](https://example.com/docs)\nfor more information about this feature.\n",
+		},
+		{
+			name:     "emphasis preserved in wrapped text",
+			input:    "This is *important* and this is **very important** information that you should read.",
+			width:    40,
+			expected: "This is *important* and this is **very\nimportant** information that you should\nread.\n",
+		},
+		{
+			name:     "multiple paragraphs wrapped independently",
+			input:    "First paragraph with some text that should be wrapped.\n\nSecond paragraph with different text that also needs wrapping.",
+			width:    40,
+			expected: "First paragraph with some text that\nshould be wrapped.\n\nSecond paragraph with different text\nthat also needs wrapping.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatMarkdownWithWidth(tt.input, tt.width)
+			if result != tt.expected {
+				t.Errorf("FormatMarkdownWithWidth() =\n%q\nwant:\n%q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFormatMarkdownWithWidth_DefaultWidth(t *testing.T) {
+	// Test that FormatMarkdown uses 80 char width
+	longText := "This is a paragraph that is exactly one hundred characters long and should wrap."
+	result := FormatMarkdown(longText)
+
+	// Should be wrapped since it exceeds 80 chars
+	if result != "" && result[0] != '\n' {
+		lines := splitLines(result)
+		for _, line := range lines {
+			if len(line) > 80 {
+				t.Errorf("Line exceeds 80 chars: %q (len=%d)", line, len(line))
+			}
+		}
+	}
+}
+
+func TestFormatMarkdownWithWidth_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		width    int
+		expected string
+	}{
+		{
+			name:     "zero width falls back to default",
+			input:    "Short text.",
+			width:    0,
+			expected: "Short text.\n",
+		},
+		{
+			name:     "negative width falls back to default",
+			input:    "Short text.",
+			width:    -10,
+			expected: "Short text.\n",
+		},
+		{
+			name:     "unclosed code block handled gracefully",
+			input:    "```\ncode here\nmore code",
+			width:    40,
+			expected: "```\ncode here\nmore code\n```\n", // goldmark auto-closes
+		},
+		{
+			name:     "long list item not wrapped (intentional limitation)",
+			input:    "- This is a very long list item that exceeds the line width significantly.",
+			width:    40,
+			expected: "- This is a very long list item that exceeds the line width significantly.\n",
+		},
+		{
+			name:     "long blockquote not wrapped (intentional limitation)",
+			input:    "> This is a very long blockquote that exceeds the line width significantly.",
+			width:    40,
+			expected: "> This is a very long blockquote that exceeds the line width significantly.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatMarkdownWithWidth(tt.input, tt.width)
+			if result != tt.expected {
+				t.Errorf("FormatMarkdownWithWidth() =\n%q\nwant:\n%q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	var current string
+	for _, r := range s {
+		if r == '\n' {
+			lines = append(lines, current)
+			current = ""
+		} else {
+			current += string(r)
+		}
+	}
+	if current != "" {
+		lines = append(lines, current)
+	}
+	return lines
 }

--- a/internal/markdown/relation.go
+++ b/internal/markdown/relation.go
@@ -72,8 +72,14 @@ func (f *FileIO) WriteRelation(relation *model.Relation, path string) error {
 
 // FormatRelation returns the formatted markdown content for a relation.
 // Frontmatter keys are ordered: from, relation, to, then extras alphabetically.
-// Markdown content is also formatted.
+// Markdown content is also formatted. Uses default line width (80).
 func FormatRelation(relation *model.Relation) (string, error) {
+	return FormatRelationWithWidth(relation, DefaultLineWidth)
+}
+
+// FormatRelationWithWidth returns the formatted markdown content for a relation
+// with a specific line width for paragraph wrapping.
+func FormatRelationWithWidth(relation *model.Relation, lineWidth int) (string, error) {
 	frontmatter := map[string]interface{}{
 		"from":     relation.From,
 		"relation": relation.Type,
@@ -91,7 +97,7 @@ func FormatRelation(relation *model.Relation) (string, error) {
 	// Format markdown content
 	content := relation.Content
 	if content != "" {
-		content = FormatMarkdown(content)
+		content = FormatMarkdownWithWidth(content, lineWidth)
 	}
 
 	return FormatDocumentOrdered(frontmatter, content, keyOrder)

--- a/internal/project/config.go
+++ b/internal/project/config.go
@@ -1,0 +1,67 @@
+package project
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigFile is the conventional filename for project configuration.
+const ConfigFile = "config.yaml"
+
+// Config holds project-level settings stored in .rela/config.yaml.
+type Config struct {
+	// Formatting configures how markdown content is formatted.
+	Formatting FormattingConfig `yaml:"formatting,omitempty"`
+}
+
+// FormattingConfig holds settings for markdown formatting.
+type FormattingConfig struct {
+	// LineWidth is the maximum line width for paragraph wrapping.
+	// Default is 80 if not specified.
+	LineWidth int `yaml:"line_width,omitempty"`
+}
+
+// DefaultConfig returns a Config with default values.
+func DefaultConfig() *Config {
+	return &Config{
+		Formatting: FormattingConfig{
+			LineWidth: 80,
+		},
+	}
+}
+
+// LoadConfig loads the project configuration from .rela/config.yaml.
+// If the file doesn't exist, returns default configuration.
+func LoadConfig(ctx *Context) (*Config, error) {
+	return LoadConfigFromPath(ctx.ConfigPath())
+}
+
+// LoadConfigFromPath loads project configuration from a specific path.
+// If the file doesn't exist, returns default configuration.
+func LoadConfigFromPath(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultConfig(), nil
+		}
+		return nil, err
+	}
+
+	cfg := DefaultConfig()
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, err
+	}
+
+	// Apply defaults for zero values
+	if cfg.Formatting.LineWidth <= 0 {
+		cfg.Formatting.LineWidth = 80
+	}
+
+	return cfg, nil
+}
+
+// ConfigPath returns the path to the project configuration file.
+func (c *Context) ConfigPath() string {
+	return c.CacheDir + "/" + ConfigFile
+}

--- a/internal/project/config_test.go
+++ b/internal/project/config_test.go
@@ -1,0 +1,114 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Formatting.LineWidth != 80 {
+		t.Errorf("DefaultConfig().Formatting.LineWidth = %d, want 80", cfg.Formatting.LineWidth)
+	}
+}
+
+func TestLoadConfig_NotExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "config.yaml")
+
+	cfg, err := LoadConfigFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadConfigFromPath() error = %v", err)
+	}
+
+	if cfg.Formatting.LineWidth != 80 {
+		t.Errorf("LineWidth = %d, want 80 (default)", cfg.Formatting.LineWidth)
+	}
+}
+
+func TestLoadConfig_CustomLineWidth(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "config.yaml")
+
+	content := `formatting:
+  line_width: 100
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadConfigFromPath() error = %v", err)
+	}
+
+	if cfg.Formatting.LineWidth != 100 {
+		t.Errorf("LineWidth = %d, want 100", cfg.Formatting.LineWidth)
+	}
+}
+
+func TestLoadConfig_ZeroLineWidthUsesDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "config.yaml")
+
+	content := `formatting:
+  line_width: 0
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadConfigFromPath() error = %v", err)
+	}
+
+	if cfg.Formatting.LineWidth != 80 {
+		t.Errorf("LineWidth = %d, want 80 (default for zero)", cfg.Formatting.LineWidth)
+	}
+}
+
+func TestLoadConfig_InvalidYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "config.yaml")
+
+	content := `formatting: [invalid`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	_, err := LoadConfigFromPath(path)
+	if err == nil {
+		t.Error("LoadConfigFromPath() should return error for invalid YAML")
+	}
+}
+
+func TestLoadConfig_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "config.yaml")
+
+	if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadConfigFromPath() error = %v", err)
+	}
+
+	// Empty file should use defaults
+	if cfg.Formatting.LineWidth != 80 {
+		t.Errorf("LineWidth = %d, want 80 (default)", cfg.Formatting.LineWidth)
+	}
+}
+
+func TestContext_ConfigPath(t *testing.T) {
+	ctx := newContext("/project")
+	expected := "/project/.rela/config.yaml"
+
+	if ctx.ConfigPath() != expected {
+		t.Errorf("ConfigPath() = %q, want %q", ctx.ConfigPath(), expected)
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -44,6 +44,7 @@ type Workspace struct {
 	meta       *metamodel.Metamodel
 	automation *automation.Engine
 	searchIdx  *search.Index
+	config     *project.Config
 	mu         sync.RWMutex
 
 	// Watcher state (nil when not watching).
@@ -116,8 +117,9 @@ func NewWithGraph(repo repository.Store, meta *metamodel.Metamodel, g *graph.Gra
 // to query the graph. It initializes a search index with all entities.
 func NewForTest(g *graph.Graph, meta *metamodel.Metamodel) *Workspace {
 	ws := &Workspace{
-		graph: g,
-		meta:  meta,
+		graph:  g,
+		meta:   meta,
+		config: project.DefaultConfig(),
 	}
 
 	// Initialize search index for test workspaces.
@@ -152,12 +154,26 @@ func newWorkspace(repo repository.Store, meta *metamodel.Metamodel, g *graph.Gra
 		}
 	}
 
+	// Load project config (use defaults if not found or repo is nil).
+	var cfg *project.Config
+	if repo != nil {
+		var err error
+		cfg, err = project.LoadConfig(repo.Paths())
+		if err != nil {
+			log.Printf("Warning: failed to load config: %v", err)
+			cfg = project.DefaultConfig()
+		}
+	} else {
+		cfg = project.DefaultConfig()
+	}
+
 	return &Workspace{
 		repo:       repo,
 		graph:      g,
 		meta:       meta,
 		automation: autoEngine,
 		searchIdx:  searchIdx,
+		config:     cfg,
 	}
 }
 
@@ -1015,8 +1031,8 @@ func (w *Workspace) FormatEntity(entity *model.Entity, dryRun bool) (bool, error
 		propertyOrder = entityDef.GetPropertyOrder()
 	}
 
-	// Generate formatted content
-	formatted, err := markdown.FormatEntity(entity, propertyOrder)
+	// Generate formatted content with configured line width
+	formatted, err := markdown.FormatEntityWithWidth(entity, propertyOrder, w.config.Formatting.LineWidth)
 	if err != nil {
 		return false, fmt.Errorf("format entity: %w", err)
 	}
@@ -1045,8 +1061,8 @@ func (w *Workspace) FormatEntity(entity *model.Entity, dryRun bool) (bool, error
 // FormatRelation checks if a relation file needs formatting and optionally writes
 // the formatted version. Returns true if the file was (or would be) modified.
 func (w *Workspace) FormatRelation(relation *model.Relation, dryRun bool) (bool, error) {
-	// Generate formatted content
-	formatted, err := markdown.FormatRelation(relation)
+	// Generate formatted content with configured line width
+	formatted, err := markdown.FormatRelationWithWidth(relation, w.config.Formatting.LineWidth)
 	if err != nil {
 		return false, fmt.Errorf("format relation: %w", err)
 	}

--- a/tickets/entities/tickets/TKT-QK9H.md
+++ b/tickets/entities/tickets/TKT-QK9H.md
@@ -1,0 +1,16 @@
+---
+id: TKT-QK9H
+type: ticket
+title: Add line length wrapping to markdown formatting
+kind: enhancement
+priority: medium
+status: done
+effort: s
+---
+
+Add line length wrapping to markdown content formatting. When entities or relations
+are saved/updated (via data entry UI or workspace operations), wrap paragraph text
+to a configurable line length (e.g., 80 or 100 characters) to improve readability
+and reduce git diffs from editors with different wrapping behavior.
+
+This extends the markdown formatting added in TKT-9RZB.


### PR DESCRIPTION
## Summary

- Add `.rela/config.yaml` support for project-level configuration
- Add `formatting.line_width` setting (default: 80) for paragraph wrapping
- Paragraphs are wrapped when formatting entities/relations via `rela fmt` or workspace operations
- Code blocks, headings, lists, and blockquotes are preserved (not wrapped)

## Changes

- Add `internal/project/config.go` with `Config` struct and loading functions
- Add `FormatEntityWithWidth` and `FormatRelationWithWidth` functions
- Integrate config loading into workspace
- Document `rela fmt` command and `formatting.line_width` in CLI reference

## Test plan

- [x] Unit tests for config loading (missing file, custom value, zero value, invalid YAML)
- [x] Unit tests for paragraph wrapping (short/long text, code blocks, headings, lists)
- [x] Integration: workspace uses configured line width for formatting
- [x] Local CI passes (`just ci`)