### PR TITLE
fix(arch): decouple workspace from script package

### DIFF
--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
+	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
@@ -125,7 +126,7 @@ func (d *Desktop) LoadProject(dir string) string {
 		return "needs_setup"
 	}
 
-	ws, wsErr := workspace.New(repo)
+	ws, wsErr := workspace.New(repo, script.NewEngine())
 	if wsErr != nil {
 		d.mu.Lock()
 		d.loadErr = wsErr.Error()

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/dataentry"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
+	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
@@ -33,7 +34,7 @@ func main() {
 		log.Fatalf("Failed to initialize repository: %v", err)
 	}
 
-	ws, err := workspace.New(repo)
+	ws, err := workspace.New(repo, script.NewEngine())
 	if err != nil {
 		log.Fatalf("Failed to initialize workspace: %v", err)
 	}

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	relamcp "github.com/Sourcehaven-BV/rela/internal/mcp"
+	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
@@ -52,7 +53,7 @@ func runMCPServer() error {
 	}
 
 	// Discover project and initialize workspace
-	mcpWs, err := workspace.Discover(startDir)
+	mcpWs, err := workspace.Discover(startDir, script.NewEngine())
 	if err != nil {
 		return fmt.Errorf("no project found: run 'rela init' to create one")
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/output"
 	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
@@ -62,7 +63,7 @@ and maintain semantic relationships between them.`,
 
 		// Discover project and initialize workspace
 		var err error
-		ws, err = workspace.Discover(startDir)
+		ws, err = workspace.Discover(startDir, script.NewEngine())
 		if err != nil {
 			return fmt.Errorf("no project found: run 'rela init' to create one")
 		}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -111,7 +111,7 @@ func runValidate(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Initialize workspace for entity checks (no Lua executor needed for validation)
-	checkWs, err := workspace.DiscoverAndNew(startDir, nil)
+	checkWs, err := workspace.Discover(startDir, workspace.NopScriptExecutor)
 	if err != nil {
 		return fmt.Errorf("failed to initialize workspace: %w", err)
 	}

--- a/internal/dataentry/e2e_test.go
+++ b/internal/dataentry/e2e_test.go
@@ -63,7 +63,7 @@ func newE2ETestApp(t *testing.T) (*App, string, func()) {
 
 	fs := storage.NewSafeFS(storage.NewOsFS())
 	repo := repository.New(fs, ctx)
-	ws, err := workspace.New(repo)
+	ws, err := workspace.New(repo, workspace.NopScriptExecutor)
 	if err != nil {
 		t.Fatalf("creating workspace: %v", err)
 	}

--- a/internal/mcp/watcher_test.go
+++ b/internal/mcp/watcher_test.go
@@ -41,7 +41,7 @@ func TestWatcherStop(t *testing.T) {
 		CachePath:     filepath.Join(cacheDir, "cache.json"),
 	}
 	repo := repository.New(storage.NewOsFS(), ctx)
-	ws, err := workspace.New(repo)
+	ws, err := workspace.New(repo, workspace.NopScriptExecutor)
 	if err != nil {
 		t.Fatalf("workspace.New failed: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestWatcherFileChange(t *testing.T) {
 		CachePath:     filepath.Join(cacheDir, "cache.json"),
 	}
 	repo := repository.New(storage.NewOsFS(), ctx)
-	ws, err := workspace.New(repo)
+	ws, err := workspace.New(repo, workspace.NopScriptExecutor)
 	if err != nil {
 		t.Fatalf("workspace.New failed: %v", err)
 	}

--- a/internal/metamodel/script_context.go
+++ b/internal/metamodel/script_context.go
@@ -1,0 +1,24 @@
+package metamodel
+
+import "github.com/Sourcehaven-BV/rela/internal/model"
+
+// ScriptContext provides everything a script executor needs to execute.
+// This interface is defined here (instead of the script package) to allow
+// workspace to implement it without importing script, avoiding import cycles.
+//
+// The GetWorkspace() method returns an interface{} which must satisfy
+// lua.WorkspaceInterface. This avoids workspace needing to import lua
+// just to declare the return type.
+type ScriptContext interface {
+	// GetWorkspace returns the workspace for Lua callbacks.
+	// The returned value must satisfy lua.WorkspaceInterface.
+	GetWorkspace() interface{}
+	// GetMeta returns the current metamodel.
+	GetMeta() *Metamodel
+	// GetProjectRoot returns the absolute project path.
+	GetProjectRoot() string
+	// GetEntity returns the triggering entity (may be nil).
+	GetEntity() *model.Entity
+	// GetOldEntity returns the previous entity state (may be nil).
+	GetOldEntity() *model.Entity
+}

--- a/internal/script/executor.go
+++ b/internal/script/executor.go
@@ -19,32 +19,10 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
-	"github.com/Sourcehaven-BV/rela/internal/model"
 )
 
 // scriptsDir is the directory where script files must be located.
 const scriptsDir = "scripts"
-
-// Context provides everything a script needs to execute.
-// This interface is satisfied by workspace's internal context type,
-// allowing workspace to pass context without import cycles.
-//
-// The GetWorkspace() method returns an interface{} which must satisfy
-// lua.WorkspaceInterface. This avoids workspace needing to import lua
-// just to declare the return type.
-type Context interface {
-	// GetWorkspace returns the workspace for Lua callbacks.
-	// The returned value must satisfy lua.WorkspaceInterface.
-	GetWorkspace() interface{}
-	// GetMeta returns the current metamodel.
-	GetMeta() *metamodel.Metamodel
-	// GetProjectRoot returns the absolute project path.
-	GetProjectRoot() string
-	// GetEntity returns the triggering entity (may be nil).
-	GetEntity() *model.Entity
-	// GetOldEntity returns the previous entity state (may be nil).
-	GetOldEntity() *model.Entity
-}
 
 // Engine runs scripts with provided context. It is stateless - all dependencies
 // are passed at execution time via Context. This centralizes script execution
@@ -59,13 +37,13 @@ func NewEngine() *Engine {
 }
 
 // ExecuteCode runs inline script code with the given context.
-func (e *Engine) ExecuteCode(code string, ctx Context) error {
+func (e *Engine) ExecuteCode(code string, ctx metamodel.ScriptContext) error {
 	return e.execute(code, ctx)
 }
 
 // ExecuteFile loads and runs a script file from the scripts/ directory.
 // The path must be a local path (no ".." or absolute paths) with .lua extension.
-func (e *Engine) ExecuteFile(path string, ctx Context) error {
+func (e *Engine) ExecuteFile(path string, ctx metamodel.ScriptContext) error {
 	scriptCode, err := loadScript(ctx.GetProjectRoot(), path)
 	if err != nil {
 		return err
@@ -75,7 +53,7 @@ func (e *Engine) ExecuteFile(path string, ctx Context) error {
 
 // execute runs Lua code with entity context.
 // Timeout is handled by lua.Runtime (default 30s).
-func (e *Engine) execute(code string, ctx Context) error {
+func (e *Engine) execute(code string, ctx metamodel.ScriptContext) error {
 	// Type assert workspace to lua.WorkspaceInterface
 	ws, ok := ctx.GetWorkspace().(lua.WorkspaceInterface)
 	if !ok {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -22,7 +22,6 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/rename"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
-	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/views"
@@ -40,19 +39,19 @@ type ChangeOp = repository.ChangeOp
 // This keeps workspace independent of specific script languages (Lua, etc.).
 //
 // The executor is stateless - all context is passed at execution time via
-// script.Context. This avoids circular dependencies: workspace can be created
-// with a script engine, and the engine receives workspace access only when
-// executing scripts.
+// metamodel.ScriptContext. This avoids circular dependencies: workspace can be
+// created with a script engine, and the engine receives workspace access only
+// when executing scripts.
 //
 // For production, pass script.NewEngine(). For tests, pass NopScriptExecutor.
 type ScriptExecutor interface {
 	// ExecuteCode runs inline script code with entity context.
-	ExecuteCode(code string, ctx script.Context) error
+	ExecuteCode(code string, ctx metamodel.ScriptContext) error
 	// ExecuteFile runs a script file from the scripts/ directory.
-	ExecuteFile(path string, ctx script.Context) error
+	ExecuteFile(path string, ctx metamodel.ScriptContext) error
 }
 
-// scriptContextImpl implements script.Context for passing to ScriptExecutor.
+// scriptContextImpl implements metamodel.ScriptContext for passing to ScriptExecutor.
 // The workspace field satisfies lua.WorkspaceInterface (verified at runtime
 // by the script package).
 type scriptContextImpl struct {
@@ -76,11 +75,11 @@ var NopScriptExecutor ScriptExecutor = nopScriptExecutor{}
 
 type nopScriptExecutor struct{}
 
-func (nopScriptExecutor) ExecuteCode(string, script.Context) error {
+func (nopScriptExecutor) ExecuteCode(string, metamodel.ScriptContext) error {
 	panic("NopScriptExecutor: Lua execution not expected in this context")
 }
 
-func (nopScriptExecutor) ExecuteFile(string, script.Context) error {
+func (nopScriptExecutor) ExecuteFile(string, metamodel.ScriptContext) error {
 	panic("NopScriptExecutor: Lua execution not expected in this context")
 }
 
@@ -110,22 +109,12 @@ type Workspace struct {
 const maxAutomationDepth = 50
 
 // Discover discovers a project from the given start directory and creates
-// a production workspace with script execution enabled. If startDir is empty,
-// it uses the current working directory.
+// a workspace with the given script executor. If startDir is empty, it uses
+// the current working directory.
 //
-// This is the standard way to create a workspace for CLI and server use.
-// For tests, use DiscoverAndNew with NopScriptExecutor instead.
-func Discover(startDir string) (*Workspace, error) {
-	return DiscoverAndNew(startDir, script.NewEngine())
-}
-
-// DiscoverAndNew discovers a project from the given start directory and
-// creates a workspace with a custom script executor. If startDir is empty,
-// it uses the current working directory.
-//
-// For production use, prefer Discover() which uses script.NewEngine().
-// This function is mainly for tests that need NopScriptExecutor.
-func DiscoverAndNew(startDir string, scriptExec ScriptExecutor) (*Workspace, error) {
+// For production use, pass script.NewEngine() for Lua support.
+// For tests, pass NopScriptExecutor.
+func Discover(startDir string, scriptExec ScriptExecutor) (*Workspace, error) {
 	fs := storage.NewSafeFS(storage.NewOsFS())
 	ctx, err := project.Discover(startDir, fs)
 	if err != nil {
@@ -135,16 +124,16 @@ func DiscoverAndNew(startDir string, scriptExec ScriptExecutor) (*Workspace, err
 	return New(repo, scriptExec)
 }
 
-// New creates a workspace from a repository with an optional script executor.
+// New creates a workspace from a repository with a script executor.
 // It loads the metamodel, initializes the graph (from cache or by syncing
 // from disk), and sets up the automation engine.
 //
-// If scriptExec is not provided, defaults to script.NewEngine() for Lua support.
-// Open() is equivalent to New(repo) - both enable script execution.
-func New(repo repository.Store, scriptExec ...ScriptExecutor) (*Workspace, error) {
-	exec := ScriptExecutor(script.NewEngine())
-	if len(scriptExec) > 0 && scriptExec[0] != nil {
-		exec = scriptExec[0]
+// For production use, pass script.NewEngine() for Lua support.
+// For tests, pass NopScriptExecutor.
+func New(repo repository.Store, scriptExec ScriptExecutor) (*Workspace, error) {
+	exec := scriptExec
+	if exec == nil {
+		exec = NopScriptExecutor
 	}
 
 	meta, err := repo.LoadMetamodel()

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -92,7 +92,7 @@ func TestNew(t *testing.T) {
 	fs := setupWorkspaceFS(ctx, meta, testMetamodelYAML)
 	repo := repository.New(fs, ctx)
 
-	ws, err := New(repo)
+	ws, err := New(repo, NopScriptExecutor)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}

--- a/tickets/entities/automated-measures/go-arch-lint-ci.md
+++ b/tickets/entities/automated-measures/go-arch-lint-ci.md
@@ -1,0 +1,9 @@
+---
+id: go-arch-lint-ci
+type: automated-measure
+title: go-arch-lint CI check
+description: Architecture boundary enforcement via go-arch-lint in CI pipeline
+kind: ci
+location: .github/workflows/ci.yml
+status: active
+---

--- a/tickets/entities/bugs/BUG-WQ7Y.md
+++ b/tickets/entities/bugs/BUG-WQ7Y.md
@@ -1,0 +1,21 @@
+---
+id: BUG-WQ7Y
+type: bug
+title: 'Architecture boundary violation: workspace depends on script'
+status: done
+---
+
+The `workspace` package imports `script` package, violating the architecture
+boundary defined in `.go-arch-lint.yml`. The `workspace` component is not
+allowed to depend on `script`.
+
+## Root Cause
+
+The `workspace` package defined a `ScriptExecutor` interface that used
+`script.Context` as a parameter type, creating an import dependency.
+
+## Fix
+
+Moved `ScriptContext` interface from `script` to `metamodel` package (which
+`workspace` is allowed to depend on). Updated all call sites to explicitly
+pass the script executor.

--- a/tickets/entities/bugs/BUG-WQ7Y.md
+++ b/tickets/entities/bugs/BUG-WQ7Y.md
@@ -2,6 +2,11 @@
 id: BUG-WQ7Y
 type: bug
 title: 'Architecture boundary violation: workspace depends on script'
+description: The workspace package imports script package, violating go-arch-lint rules
+why1: ScriptExecutor interface used script.Context as parameter type
+why2: Context interface was defined in script package for convenience
+why3: No separate interface package existed for shared types
+prevention: Moved interface to metamodel package to follow architecture boundaries
 status: done
 ---
 

--- a/tickets/relations/BUG-WQ7Y--adds-measure--go-arch-lint-ci.md
+++ b/tickets/relations/BUG-WQ7Y--adds-measure--go-arch-lint-ci.md
@@ -1,0 +1,5 @@
+---
+from: BUG-WQ7Y
+relation: adds-measure
+to: go-arch-lint-ci
+---

--- a/tickets/relations/BUG-WQ7Y--affects--workspace.md
+++ b/tickets/relations/BUG-WQ7Y--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: BUG-WQ7Y
+relation: affects
+to: workspace
+---

--- a/tickets/relations/BUG-WQ7Y--detected-by--go-arch-lint-ci.md
+++ b/tickets/relations/BUG-WQ7Y--detected-by--go-arch-lint-ci.md
@@ -1,0 +1,5 @@
+---
+from: BUG-WQ7Y
+relation: detected-by
+to: go-arch-lint-ci
+---

--- a/tickets/relations/BUG-WQ7Y--fixes--FEAT-022.md
+++ b/tickets/relations/BUG-WQ7Y--fixes--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: BUG-WQ7Y
+relation: fixes
+to: FEAT-022
+---


### PR DESCRIPTION
## Summary
- Move `ScriptContext` interface from `script` to `metamodel` package to fix architecture boundary violation
- Workspace package now uses `metamodel.ScriptContext` instead of `script.Context`
- Entry points (CLI, server, desktop) explicitly pass `script.NewEngine()` to workspace constructors
- Tests pass `workspace.NopScriptExecutor` or `script.NewEngine()` depending on Lua requirements

## Test plan
- [x] All CI checks pass locally (`just ci`)
- [x] Architecture lint (`go-arch-lint check`) reports no violations
- [x] All tests pass including Lua automation tests