### PR TITLE
Add npm install step to frontend build

### DIFF
--- a/justfile
+++ b/justfile
@@ -306,8 +306,12 @@ dev-catalog port="8282":
 dev-frontend:
     cd frontend && npm run dev
 
+# Install frontend dependencies
+install-frontend:
+    cd frontend && npm install
+
 # Build Vue frontend for production
-build-frontend:
+build-frontend: install-frontend
     cd frontend && npm run build
 
 # Type-check Vue frontend

--- a/tickets/entities/tickets/TKT-CCUG.md
+++ b/tickets/entities/tickets/TKT-CCUG.md
@@ -1,0 +1,13 @@
+---
+id: TKT-CCUG
+type: ticket
+title: Add npm install step to frontend build
+kind: chore
+priority: low
+effort: xs
+status: done
+---
+
+The justfile `build-frontend` recipe assumed `node_modules` was already
+installed. Added an `install-frontend` recipe as a dependency so `npm install`
+runs automatically before building.

--- a/tickets/relations/TKT-CCUG--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-CCUG--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CCUG
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-CCUG--implements--FEAT-021.md
+++ b/tickets/relations/TKT-CCUG--implements--FEAT-021.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CCUG
+relation: implements
+to: FEAT-021
+---


### PR DESCRIPTION
## Summary
- Adds `install-frontend` recipe that runs `npm install` in the frontend directory
- Makes `build-frontend` depend on `install-frontend` so dependencies are always available
- `npm install` is a no-op when `node_modules` is already up to date

## Test plan
- [x] `just ci` passes locally
- [x] `just install` works from clean state (no node_modules)