### PR TITLE
fix(arch): allow lua component to use runewidth vendor

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -82,6 +82,7 @@ vendors:
       - github.com/mitchellh/go-wordwrap
   gogit:       { in: github.com/go-git/go-git/** }
   gopherlua:   { in: github.com/yuin/gopher-lua }
+  runewidth:   { in: github.com/mattn/go-runewidth }
   mcpgo:       { in: github.com/mark3labs/mcp-go/** }
   wails:       { in: github.com/wailsapp/wails/** }
   tablewriter: { in: github.com/olekukonko/tablewriter }
@@ -299,6 +300,7 @@ deps:
     canUse:
       - goldmark
       - gopherlua
+      - runewidth
   script:
     mayDependOn:
       - lua

--- a/tickets/entities/bugs/BUG-0F0K.md
+++ b/tickets/entities/bugs/BUG-0F0K.md
@@ -1,0 +1,27 @@
+---
+id: BUG-0F0K
+type: bug
+title: 'Architecture lint fails: lua component missing runewidth vendor'
+description: 'Architecture lint fails after PR #291 merged: lua component imports go-runewidth but .go-arch-lint.yml doesn''t declare it as an allowed vendor.'
+priority: high
+effort: s
+why1: go-runewidth was added as a direct import in lua/markdown.go but not declared in .go-arch-lint.yml
+why2: The arch config was not updated in the same PR that added the import
+why3: The PR was auto-merged before the arch fix could be pushed
+prevention: Run just arch-lint locally before pushing
+status: done
+---
+
+# Architecture lint fails: lua component missing runewidth vendor
+
+## Problem
+
+After merging PR #291 (GFM table parsing), the architecture lint check fails
+because `internal/lua/markdown.go` imports `github.com/mattn/go-runewidth` but
+the `.go-arch-lint.yml` config doesn't declare it as an allowed vendor for the
+`lua` component.
+
+## Fix
+
+1. Add `runewidth` vendor entry in `.go-arch-lint.yml`
+2. Add `runewidth` to `lua` component's `canUse` list

--- a/tickets/relations/BUG-0F0K--adds-measure--go-arch-lint-ci.md
+++ b/tickets/relations/BUG-0F0K--adds-measure--go-arch-lint-ci.md
@@ -1,0 +1,5 @@
+---
+from: BUG-0F0K
+relation: adds-measure
+to: go-arch-lint-ci
+---

--- a/tickets/relations/BUG-0F0K--affects--lua-scripting.md
+++ b/tickets/relations/BUG-0F0K--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: BUG-0F0K
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/BUG-0F0K--fixes--FEAT-022.md
+++ b/tickets/relations/BUG-0F0K--fixes--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: BUG-0F0K
+relation: fixes
+to: FEAT-022
+---


### PR DESCRIPTION
## Summary

- Add `runewidth` vendor declaration and allow `lua` component to use it in `.go-arch-lint.yml`
- Fixes architecture lint failure introduced by PR #291 which added `go-runewidth` import for display-width-aware table padding

## Test plan

- [x] `just arch-lint` passes locally