### PR TITLE
feat(lua): add date arithmetic and RRULE helpers

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -83,6 +83,7 @@ vendors:
   gogit:       { in: github.com/go-git/go-git/** }
   gopherlua:   { in: github.com/yuin/gopher-lua }
   runewidth:   { in: github.com/mattn/go-runewidth }
+  rrulego:     { in: github.com/teambition/rrule-go }
   mcpgo:       { in: github.com/mark3labs/mcp-go/** }
   wails:       { in: github.com/wailsapp/wails/** }
   tablewriter: { in: github.com/olekukonko/tablewriter }
@@ -301,6 +302,7 @@ deps:
       - goldmark
       - gopherlua
       - runewidth
+      - rrulego
   script:
     mayDependOn:
       - lua

--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -326,6 +326,73 @@ See [Interactive Flows](#interactive-flows) for detailed documentation.
 | `rela.days_since(date)` | Days between date and today | number (-1 if invalid) |
 | `rela.sort_entities(list, prop, dir?)` | Sort entities by property | sorted table |
 
+### Date Functions
+
+| Function | Description | Returns |
+|----------|-------------|---------|
+| `rela.date_add(date, offset)` | Add offset to date | date string |
+| `rela.date_weekday(date)` | Get weekday name | lowercase string |
+| `rela.date_next_weekday(date, day)` | Next occurrence of weekday after date | date string |
+| `rela.rrule_next(rrule, after?)` | Next RRULE occurrence (default: after today) | date string or nil |
+
+#### date_add
+
+Add a duration offset to a date. Offsets use `Nd`, `Nw`, `Nm`, `Ny` format. Negative values
+are supported.
+
+```lua
+rela.date_add("2025-01-15", "7d")   -- "2025-01-22"
+rela.date_add("2025-01-15", "2w")   -- "2025-01-29"
+rela.date_add("2025-01-15", "1m")   -- "2025-02-15"
+rela.date_add("2025-01-15", "1y")   -- "2026-01-15"
+rela.date_add("2025-01-15", "-3d")  -- "2025-01-12"
+```
+
+#### date_weekday
+
+Returns the lowercase weekday name for a date.
+
+```lua
+rela.date_weekday("2025-01-06")  -- "monday"
+```
+
+#### date_next_weekday
+
+Returns the next occurrence of the given weekday strictly after the date. If the date is
+already that weekday, it advances to the following week.
+
+```lua
+rela.date_next_weekday("2025-01-06", "friday")  -- "2025-01-10"
+rela.date_next_weekday("2025-01-06", "monday")  -- "2025-01-13" (not same day)
+```
+
+#### rrule_next
+
+Computes the next occurrence of an iCal RRULE (RFC 5545) after a given date. If no `after`
+date is provided, uses today. Returns `nil` if the rule has no more occurrences.
+
+Accepts both `RRULE:FREQ=...` and bare `FREQ=...` formats.
+
+```lua
+-- Next Saturday
+rela.rrule_next("FREQ=WEEKLY;BYDAY=SA", "2025-01-06")       -- "2025-01-11"
+
+-- 1st of each month
+rela.rrule_next("FREQ=MONTHLY;BYMONTHDAY=1", "2025-01-15")  -- "2025-02-01"
+
+-- Last day of each month
+rela.rrule_next("FREQ=MONTHLY;BYMONTHDAY=-1", "2025-01-15") -- "2025-01-31"
+
+-- Every 2 weeks
+rela.rrule_next("FREQ=WEEKLY;INTERVAL=2", "2025-01-06")     -- "2025-01-20"
+
+-- 1st Saturday every 3 months
+rela.rrule_next("FREQ=MONTHLY;INTERVAL=3;BYDAY=1SA", "2025-01-06") -- "2025-04-05"
+
+-- Uses today if no after date
+rela.rrule_next("FREQ=DAILY")  -- tomorrow's date
+```
+
 ### Context
 
 | Variable | Description |

--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -373,21 +373,29 @@ date is provided, uses today. Returns `nil` if the rule has no more occurrences.
 
 Accepts both `RRULE:FREQ=...` and bare `FREQ=...` formats.
 
+**Important:** Rules with `INTERVAL` > 1 must include `DTSTART` to anchor the interval
+cadence. Without it, the function raises an error.
+
 ```lua
 -- Next Saturday
-rela.rrule_next("FREQ=WEEKLY;BYDAY=SA", "2025-01-06")       -- "2025-01-11"
+rela.rrule_next("FREQ=WEEKLY;BYDAY=SA;DTSTART=20250101T000000Z", "2025-01-06")
+-- "2025-01-11"
 
 -- 1st of each month
-rela.rrule_next("FREQ=MONTHLY;BYMONTHDAY=1", "2025-01-15")  -- "2025-02-01"
+rela.rrule_next("FREQ=MONTHLY;BYMONTHDAY=1;DTSTART=20250101T000000Z", "2025-01-15")
+-- "2025-02-01"
 
 -- Last day of each month
-rela.rrule_next("FREQ=MONTHLY;BYMONTHDAY=-1", "2025-01-15") -- "2025-01-31"
+rela.rrule_next("FREQ=MONTHLY;BYMONTHDAY=-1;DTSTART=20250101T000000Z", "2025-01-15")
+-- "2025-01-31"
 
--- Every 2 weeks
-rela.rrule_next("FREQ=WEEKLY;INTERVAL=2", "2025-01-06")     -- "2025-01-20"
+-- Every 2 weeks (INTERVAL > 1 requires DTSTART)
+rela.rrule_next("FREQ=WEEKLY;INTERVAL=2;DTSTART=20250106T000000Z", "2025-01-06")
+-- "2025-01-20"
 
--- 1st Saturday every 3 months
-rela.rrule_next("FREQ=MONTHLY;INTERVAL=3;BYDAY=1SA", "2025-01-06") -- "2025-04-05"
+-- 1st Saturday every 3 months (INTERVAL > 1 requires DTSTART)
+rela.rrule_next("FREQ=MONTHLY;INTERVAL=3;BYDAY=1SA;DTSTART=20250101T000000Z", "2025-01-06")
+-- "2025-04-05"
 
 -- Uses today if no after date
 rela.rrule_next("FREQ=DAILY")  -- tomorrow's date

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -367,21 +367,29 @@ date is provided, uses today. Returns `nil` if the rule has no more occurrences.
 
 Accepts both `RRULE:FREQ=...` and bare `FREQ=...` formats.
 
+**Important:** Rules with `INTERVAL` > 1 must include `DTSTART` to anchor the interval
+cadence. Without it, the function raises an error.
+
 ```lua
 -- Next Saturday
-rela.rrule_next("FREQ=WEEKLY;BYDAY=SA", "2025-01-06")       -- "2025-01-11"
+rela.rrule_next("FREQ=WEEKLY;BYDAY=SA;DTSTART=20250101T000000Z", "2025-01-06")
+-- "2025-01-11"
 
 -- 1st of each month
-rela.rrule_next("FREQ=MONTHLY;BYMONTHDAY=1", "2025-01-15")  -- "2025-02-01"
+rela.rrule_next("FREQ=MONTHLY;BYMONTHDAY=1;DTSTART=20250101T000000Z", "2025-01-15")
+-- "2025-02-01"
 
 -- Last day of each month
-rela.rrule_next("FREQ=MONTHLY;BYMONTHDAY=-1", "2025-01-15") -- "2025-01-31"
+rela.rrule_next("FREQ=MONTHLY;BYMONTHDAY=-1;DTSTART=20250101T000000Z", "2025-01-15")
+-- "2025-01-31"
 
--- Every 2 weeks
-rela.rrule_next("FREQ=WEEKLY;INTERVAL=2", "2025-01-06")     -- "2025-01-20"
+-- Every 2 weeks (INTERVAL > 1 requires DTSTART)
+rela.rrule_next("FREQ=WEEKLY;INTERVAL=2;DTSTART=20250106T000000Z", "2025-01-06")
+-- "2025-01-20"
 
--- 1st Saturday every 3 months
-rela.rrule_next("FREQ=MONTHLY;INTERVAL=3;BYDAY=1SA", "2025-01-06") -- "2025-04-05"
+-- 1st Saturday every 3 months (INTERVAL > 1 requires DTSTART)
+rela.rrule_next("FREQ=MONTHLY;INTERVAL=3;BYDAY=1SA;DTSTART=20250101T000000Z", "2025-01-06")
+-- "2025-04-05"
 
 -- Uses today if no after date
 rela.rrule_next("FREQ=DAILY")  -- tomorrow's date

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -320,6 +320,73 @@ See [Interactive Flows](#interactive-flows) for detailed documentation.
 | `rela.days_since(date)` | Days between date and today | number (-1 if invalid) |
 | `rela.sort_entities(list, prop, dir?)` | Sort entities by property | sorted table |
 
+### Date Functions
+
+| Function | Description | Returns |
+|----------|-------------|---------|
+| `rela.date_add(date, offset)` | Add offset to date | date string |
+| `rela.date_weekday(date)` | Get weekday name | lowercase string |
+| `rela.date_next_weekday(date, day)` | Next occurrence of weekday after date | date string |
+| `rela.rrule_next(rrule, after?)` | Next RRULE occurrence (default: after today) | date string or nil |
+
+#### date_add
+
+Add a duration offset to a date. Offsets use `Nd`, `Nw`, `Nm`, `Ny` format. Negative values
+are supported.
+
+```lua
+rela.date_add("2025-01-15", "7d")   -- "2025-01-22"
+rela.date_add("2025-01-15", "2w")   -- "2025-01-29"
+rela.date_add("2025-01-15", "1m")   -- "2025-02-15"
+rela.date_add("2025-01-15", "1y")   -- "2026-01-15"
+rela.date_add("2025-01-15", "-3d")  -- "2025-01-12"
+```
+
+#### date_weekday
+
+Returns the lowercase weekday name for a date.
+
+```lua
+rela.date_weekday("2025-01-06")  -- "monday"
+```
+
+#### date_next_weekday
+
+Returns the next occurrence of the given weekday strictly after the date. If the date is
+already that weekday, it advances to the following week.
+
+```lua
+rela.date_next_weekday("2025-01-06", "friday")  -- "2025-01-10"
+rela.date_next_weekday("2025-01-06", "monday")  -- "2025-01-13" (not same day)
+```
+
+#### rrule_next
+
+Computes the next occurrence of an iCal RRULE (RFC 5545) after a given date. If no `after`
+date is provided, uses today. Returns `nil` if the rule has no more occurrences.
+
+Accepts both `RRULE:FREQ=...` and bare `FREQ=...` formats.
+
+```lua
+-- Next Saturday
+rela.rrule_next("FREQ=WEEKLY;BYDAY=SA", "2025-01-06")       -- "2025-01-11"
+
+-- 1st of each month
+rela.rrule_next("FREQ=MONTHLY;BYMONTHDAY=1", "2025-01-15")  -- "2025-02-01"
+
+-- Last day of each month
+rela.rrule_next("FREQ=MONTHLY;BYMONTHDAY=-1", "2025-01-15") -- "2025-01-31"
+
+-- Every 2 weeks
+rela.rrule_next("FREQ=WEEKLY;INTERVAL=2", "2025-01-06")     -- "2025-01-20"
+
+-- 1st Saturday every 3 months
+rela.rrule_next("FREQ=MONTHLY;INTERVAL=3;BYDAY=1SA", "2025-01-06") -- "2025-04-05"
+
+-- Uses today if no after date
+rela.rrule_next("FREQ=DAILY")  -- tomorrow's date
+```
+
 ### Context
 
 | Variable | Description |

--- a/go.mod
+++ b/go.mod
@@ -126,6 +126,7 @@ require (
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
+	github.com/teambition/rrule-go v1.8.2 // indirect
 	github.com/tkrajina/go-reflector v0.5.8 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -506,6 +506,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/teambition/rrule-go v1.8.2 h1:lIjpjvWTj9fFUZCmuoVDrKVOtdiyzbzc93qTmRVe/J8=
+github.com/teambition/rrule-go v1.8.2/go.mod h1:Ieq5AbrKGciP1V//Wq8ktsTXwSwJHDD5mD/wLBGl3p4=
 github.com/teekennedy/goldmark-markdown v0.5.1 h1:2lIlJ3AcIwaD1wFl4dflJSJFMhRTKEsEj+asVsu6M/0=
 github.com/teekennedy/goldmark-markdown v0.5.1/go.mod h1:so260mNSPELuRyynZY18719dRYlD+OSnAovqsyrOMOM=
 github.com/tkrajina/go-reflector v0.5.8 h1:yPADHrwmUbMq4RGEyaOUpz2H90sRsETNVpjzo3DLVQQ=

--- a/internal/lua/date.go
+++ b/internal/lua/date.go
@@ -1,0 +1,187 @@
+package lua
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	rrule "github.com/teambition/rrule-go"
+	lua "github.com/yuin/gopher-lua"
+)
+
+const daysPerWeek = 7
+
+// weekdayNames maps lowercase weekday names to time.Weekday values.
+var weekdayNames = map[string]time.Weekday{
+	"sunday":    time.Sunday,
+	"monday":    time.Monday,
+	"tuesday":   time.Tuesday,
+	"wednesday": time.Wednesday,
+	"thursday":  time.Thursday,
+	"friday":    time.Friday,
+	"saturday":  time.Saturday,
+}
+
+// registerDateHelpers adds date and RRULE utility functions to the rela table.
+func registerDateHelpers(ls *lua.LState, rela *lua.LTable) {
+	ls.SetField(rela, "date_add", ls.NewFunction(luaDateAdd))
+	ls.SetField(rela, "date_weekday", ls.NewFunction(luaDateWeekday))
+	ls.SetField(rela, "date_next_weekday", ls.NewFunction(luaDateNextWeekday))
+	ls.SetField(rela, "rrule_next", ls.NewFunction(luaRruleNext))
+}
+
+// parseDate parses a date string in RFC3339 or date-only format.
+func parseDate(s string) (time.Time, error) {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t, err = time.Parse("2006-01-02", s)
+	}
+	return t, err
+}
+
+// luaDateAdd implements rela.date_add(date, offset) -> string
+// Adds an offset like "7d", "2w", "1m", "1y" to a date. Negative offsets
+// are supported with a leading minus: "-3d", "-1m".
+func luaDateAdd(ls *lua.LState) int {
+	dateStr := ls.CheckString(1)
+	offsetStr := ls.CheckString(2)
+
+	t, err := parseDate(dateStr)
+	if err != nil {
+		ls.RaiseError("date_add: invalid date %q", dateStr)
+		return 0
+	}
+
+	years, months, days, err := parseOffset(offsetStr)
+	if err != nil {
+		ls.RaiseError("date_add: invalid offset %q: %s", offsetStr, err)
+		return 0
+	}
+
+	result := t.AddDate(years, months, days)
+	ls.Push(lua.LString(result.Format("2006-01-02")))
+	return 1
+}
+
+// luaDateWeekday implements rela.date_weekday(date) -> string
+// Returns the lowercase weekday name for a date.
+func luaDateWeekday(ls *lua.LState) int {
+	dateStr := ls.CheckString(1)
+
+	t, err := parseDate(dateStr)
+	if err != nil {
+		ls.RaiseError("date_weekday: invalid date %q", dateStr)
+		return 0
+	}
+
+	ls.Push(lua.LString(strings.ToLower(t.Weekday().String())))
+	return 1
+}
+
+// luaDateNextWeekday implements rela.date_next_weekday(date, weekday) -> string
+// Returns the next occurrence of the given weekday strictly after the given date.
+func luaDateNextWeekday(ls *lua.LState) int {
+	dateStr := ls.CheckString(1)
+	dayName := ls.CheckString(2)
+
+	t, err := parseDate(dateStr)
+	if err != nil {
+		ls.RaiseError("date_next_weekday: invalid date %q", dateStr)
+		return 0
+	}
+
+	target, ok := weekdayNames[strings.ToLower(dayName)]
+	if !ok {
+		ls.RaiseError("date_next_weekday: invalid weekday %q", dayName)
+		return 0
+	}
+
+	daysAhead := int(target-t.Weekday()+daysPerWeek) % daysPerWeek
+	if daysAhead == 0 {
+		daysAhead = daysPerWeek // always advance, never same day
+	}
+
+	result := t.AddDate(0, 0, daysAhead)
+	ls.Push(lua.LString(result.Format("2006-01-02")))
+	return 1
+}
+
+// luaRruleNext implements rela.rrule_next(rrule_string, after?) -> string|nil
+// Computes the next occurrence of an RRULE after the given date (or today).
+// Accepts both "RRULE:FREQ=..." and bare "FREQ=..." formats.
+func luaRruleNext(ls *lua.LState) int {
+	rruleStr := ls.CheckString(1)
+	afterStr := ls.OptString(2, "")
+
+	var after time.Time
+	if afterStr == "" {
+		after = time.Now()
+	} else {
+		var err error
+		after, err = parseDate(afterStr)
+		if err != nil {
+			ls.RaiseError("rrule_next: invalid after date %q", afterStr)
+			return 0
+		}
+	}
+
+	// Strip RRULE: prefix if present
+	rruleStr = strings.TrimPrefix(rruleStr, "RRULE:")
+
+	// Parse the rule. teambition/rrule-go expects the option string without
+	// the RRULE: prefix, but with DTSTART if you want a specific start.
+	// We set DTStart to after so the rule generates from there.
+	opt, err := rrule.StrToROption(rruleStr)
+	if err != nil {
+		ls.RaiseError("rrule_next: invalid RRULE %q: %s", rruleStr, err)
+		return 0
+	}
+
+	// Use the after date as DTSTART so the rule generates occurrences from there.
+	opt.Dtstart = after
+	rule, err := rrule.NewRRule(*opt)
+	if err != nil {
+		ls.RaiseError("rrule_next: failed to create rule: %s", err)
+		return 0
+	}
+
+	// Get the next occurrence strictly after the after date.
+	next := rule.After(after, false)
+	if next.IsZero() {
+		ls.Push(lua.LNil)
+		return 1
+	}
+
+	ls.Push(lua.LString(next.Format("2006-01-02")))
+	return 1
+}
+
+// parseOffset parses an offset string like "7d", "2w", "1m", "1y", "-3d"
+// and returns (years, months, days).
+func parseOffset(s string) (years, months, days int, err error) {
+	if len(s) < 2 {
+		return 0, 0, 0, fmt.Errorf("too short")
+	}
+
+	unit := s[len(s)-1]
+	numStr := s[:len(s)-1]
+
+	n, err := strconv.Atoi(numStr)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("invalid number %q", numStr)
+	}
+
+	switch unit {
+	case 'd':
+		return 0, 0, n, nil
+	case 'w':
+		return 0, 0, n * daysPerWeek, nil
+	case 'm':
+		return 0, n, 0, nil
+	case 'y':
+		return n, 0, 0, nil
+	default:
+		return 0, 0, 0, fmt.Errorf("unknown unit %q (use d, w, m, y)", string(unit))
+	}
+}

--- a/internal/lua/date.go
+++ b/internal/lua/date.go
@@ -32,7 +32,19 @@ func registerDateHelpers(ls *lua.LState, rela *lua.LTable) {
 }
 
 // parseDate parses a date string in RFC3339 or date-only format.
+// Date-only strings are parsed in local time to avoid off-by-one errors
+// when comparing with time.Now() near midnight.
 func parseDate(s string) (time.Time, error) {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t, err = time.ParseInLocation("2006-01-02", s, time.Local)
+	}
+	return t, err
+}
+
+// parseDateUTC parses a date string in RFC3339 or date-only format, always in UTC.
+// Used by rrule_next where all date comparisons happen in UTC.
+func parseDateUTC(s string) (time.Time, error) {
 	t, err := time.Parse(time.RFC3339, s)
 	if err != nil {
 		t, err = time.Parse("2006-01-02", s)
@@ -110,16 +122,22 @@ func luaDateNextWeekday(ls *lua.LState) int {
 // luaRruleNext implements rela.rrule_next(rrule_string, after?) -> string|nil
 // Computes the next occurrence of an RRULE after the given date (or today).
 // Accepts both "RRULE:FREQ=..." and bare "FREQ=..." formats.
+//
+// Rules with INTERVAL > 1 require an explicit DTSTART in the RRULE string
+// to anchor the interval counting. Without it, the interval cadence would
+// drift on every invocation.
 func luaRruleNext(ls *lua.LState) int {
 	rruleStr := ls.CheckString(1)
 	afterStr := ls.OptString(2, "")
 
 	var after time.Time
 	if afterStr == "" {
-		after = time.Now()
+		// Use today at midnight UTC for consistency with RRULE dates.
+		now := time.Now()
+		after = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 	} else {
 		var err error
-		after, err = parseDate(afterStr)
+		after, err = parseDateUTC(afterStr)
 		if err != nil {
 			ls.RaiseError("rrule_next: invalid after date %q", afterStr)
 			return 0
@@ -129,17 +147,20 @@ func luaRruleNext(ls *lua.LState) int {
 	// Strip RRULE: prefix if present
 	rruleStr = strings.TrimPrefix(rruleStr, "RRULE:")
 
-	// Parse the rule. teambition/rrule-go expects the option string without
-	// the RRULE: prefix, but with DTSTART if you want a specific start.
-	// We set DTStart to after so the rule generates from there.
+	// Parse in UTC — RRULE deals with dates, not times.
 	opt, err := rrule.StrToROption(rruleStr)
 	if err != nil {
 		ls.RaiseError("rrule_next: invalid RRULE %q: %s", rruleStr, err)
 		return 0
 	}
 
-	// Use the after date as DTSTART so the rule generates occurrences from there.
-	opt.Dtstart = after
+	// Reject INTERVAL > 1 without DTSTART — the interval cadence needs a
+	// stable anchor point, otherwise it drifts on every invocation.
+	if opt.Interval > 1 && opt.Dtstart.IsZero() {
+		ls.RaiseError("rrule_next: INTERVAL > 1 requires DTSTART in the RRULE string")
+		return 0
+	}
+
 	rule, err := rrule.NewRRule(*opt)
 	if err != nil {
 		ls.RaiseError("rrule_next: failed to create rule: %s", err)

--- a/internal/lua/date_test.go
+++ b/internal/lua/date_test.go
@@ -1,0 +1,275 @@
+package lua
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newDateTestRuntime(t *testing.T) (*Runtime, *strings.Builder) {
+	t.Helper()
+	var sb strings.Builder
+	rt := New(nil, nil, "", &sb)
+	return rt, &sb
+}
+
+func TestDateAdd(t *testing.T) {
+	tests := []struct {
+		name   string
+		date   string
+		offset string
+		want   string
+	}{
+		{"add days", "2025-01-15", "7d", "2025-01-22"},
+		{"add weeks", "2025-01-15", "2w", "2025-01-29"},
+		{"add months", "2025-01-15", "1m", "2025-02-15"},
+		{"add years", "2025-01-15", "1y", "2026-01-15"},
+		{"negative days", "2025-01-15", "-3d", "2025-01-12"},
+		{"negative months", "2025-03-15", "-1m", "2025-02-15"},
+		{"month overflow jan31 plus 1m", "2025-01-31", "1m", "2025-03-03"},
+		{"leap year", "2024-02-29", "1y", "2025-03-01"},
+		{"rfc3339 input", "2025-01-15T10:00:00Z", "3d", "2025-01-18"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt, buf := newDateTestRuntime(t)
+			defer rt.Close()
+
+			script := `rela.output(rela.date_add("` + tt.date + `", "` + tt.offset + `"))`
+			err := rt.RunString(script)
+			require.NoError(t, err)
+
+			var result string
+			require.NoError(t, json.Unmarshal([]byte(buf.String()), &result))
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestDateAddError(t *testing.T) {
+	tests := []struct {
+		name   string
+		script string
+	}{
+		{"invalid date", `rela.date_add("not-a-date", "1d")`},
+		{"invalid offset", `rela.date_add("2025-01-15", "abc")`},
+		{"empty offset", `rela.date_add("2025-01-15", "x")`},
+		{"bad unit", `rela.date_add("2025-01-15", "3z")`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt, _ := newDateTestRuntime(t)
+			defer rt.Close()
+
+			err := rt.RunString(tt.script)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestDateWeekday(t *testing.T) {
+	tests := []struct {
+		date string
+		want string
+	}{
+		{"2025-01-06", "monday"},
+		{"2025-01-07", "tuesday"},
+		{"2025-01-08", "wednesday"},
+		{"2025-01-09", "thursday"},
+		{"2025-01-10", "friday"},
+		{"2025-01-11", "saturday"},
+		{"2025-01-12", "sunday"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			rt, buf := newDateTestRuntime(t)
+			defer rt.Close()
+
+			script := `rela.output(rela.date_weekday("` + tt.date + `"))`
+			err := rt.RunString(script)
+			require.NoError(t, err)
+
+			var result string
+			require.NoError(t, json.Unmarshal([]byte(buf.String()), &result))
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestDateNextWeekday(t *testing.T) {
+	tests := []struct {
+		name string
+		date string
+		day  string
+		want string
+	}{
+		{"monday to friday", "2025-01-06", "friday", "2025-01-10"},
+		{"friday to monday", "2025-01-10", "monday", "2025-01-13"},
+		{"same day advances 7", "2025-01-06", "monday", "2025-01-13"},
+		{"saturday to saturday", "2025-01-11", "saturday", "2025-01-18"},
+		{"case insensitive", "2025-01-06", "Friday", "2025-01-10"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt, buf := newDateTestRuntime(t)
+			defer rt.Close()
+
+			script := `rela.output(rela.date_next_weekday("` + tt.date + `", "` + tt.day + `"))`
+			err := rt.RunString(script)
+			require.NoError(t, err)
+
+			var result string
+			require.NoError(t, json.Unmarshal([]byte(buf.String()), &result))
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestDateNextWeekdayError(t *testing.T) {
+	rt, _ := newDateTestRuntime(t)
+	defer rt.Close()
+
+	err := rt.RunString(`rela.date_next_weekday("2025-01-06", "notaday")`)
+	require.Error(t, err)
+}
+
+func TestRruleNext(t *testing.T) {
+	tests := []struct {
+		name  string
+		rrule string
+		after string
+		want  string
+	}{
+		{
+			"weekly saturday",
+			"FREQ=WEEKLY;BYDAY=SA",
+			"2025-01-06",
+			"2025-01-11",
+		},
+		{
+			"monthly first day",
+			"FREQ=MONTHLY;BYMONTHDAY=1",
+			"2025-01-15",
+			"2025-02-01",
+		},
+		{
+			"monthly last day",
+			"FREQ=MONTHLY;BYMONTHDAY=-1",
+			"2025-01-15",
+			"2025-01-31",
+		},
+		{
+			"quarterly first saturday",
+			"FREQ=MONTHLY;INTERVAL=3;BYDAY=1SA",
+			"2025-01-06",
+			"2025-04-05",
+		},
+		{
+			"with RRULE prefix",
+			"RRULE:FREQ=WEEKLY;BYDAY=MO",
+			"2025-01-07",
+			"2025-01-13",
+		},
+		{
+			"every 2 weeks",
+			"FREQ=WEEKLY;INTERVAL=2",
+			"2025-01-06",
+			"2025-01-20",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt, buf := newDateTestRuntime(t)
+			defer rt.Close()
+
+			script := `rela.output(rela.rrule_next("` + tt.rrule + `", "` + tt.after + `"))`
+			err := rt.RunString(script)
+			require.NoError(t, err)
+
+			var result string
+			require.NoError(t, json.Unmarshal([]byte(buf.String()), &result))
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestRruleNextDefaultsToToday(t *testing.T) {
+	rt, buf := newDateTestRuntime(t)
+	defer rt.Close()
+
+	// Without after date, should use today and return a future date
+	script := `rela.output(rela.rrule_next("FREQ=DAILY"))`
+	err := rt.RunString(script)
+	require.NoError(t, err)
+
+	var result string
+	require.NoError(t, json.Unmarshal([]byte(buf.String()), &result))
+	assert.NotEmpty(t, result)
+	// Result should be a valid date string
+	assert.Regexp(t, `^\d{4}-\d{2}-\d{2}$`, result)
+}
+
+func TestRruleNextExhausted(t *testing.T) {
+	rt, buf := newDateTestRuntime(t)
+	defer rt.Close()
+
+	// Rule with COUNT=1 starting at after date — next after that is nil
+	script := `rela.output(rela.rrule_next("FREQ=DAILY;COUNT=1", "2025-01-01"))`
+	err := rt.RunString(script)
+	require.NoError(t, err)
+
+	assert.Equal(t, "null", strings.TrimSpace(buf.String()))
+}
+
+func TestRruleNextError(t *testing.T) {
+	rt, _ := newDateTestRuntime(t)
+	defer rt.Close()
+
+	err := rt.RunString(`rela.rrule_next("INVALID_RRULE")`)
+	require.Error(t, err)
+}
+
+func TestParseOffset(t *testing.T) {
+	tests := []struct {
+		input  string
+		years  int
+		months int
+		days   int
+	}{
+		{"7d", 0, 0, 7},
+		{"2w", 0, 0, 14},
+		{"3m", 0, 3, 0},
+		{"1y", 1, 0, 0},
+		{"-5d", 0, 0, -5},
+		{"-2m", 0, -2, 0},
+		{"10d", 0, 0, 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			y, m, d, err := parseOffset(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.years, y)
+			assert.Equal(t, tt.months, m)
+			assert.Equal(t, tt.days, d)
+		})
+	}
+}
+
+func TestParseOffsetError(t *testing.T) {
+	tests := []string{"", "x", "abc", "3z", "d"}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, _, _, err := parseOffset(input)
+			require.Error(t, err)
+		})
+	}
+}

--- a/internal/lua/date_test.go
+++ b/internal/lua/date_test.go
@@ -149,37 +149,37 @@ func TestRruleNext(t *testing.T) {
 	}{
 		{
 			"weekly saturday",
-			"FREQ=WEEKLY;BYDAY=SA",
+			"FREQ=WEEKLY;BYDAY=SA;DTSTART=20250101T000000Z",
 			"2025-01-06",
 			"2025-01-11",
 		},
 		{
 			"monthly first day",
-			"FREQ=MONTHLY;BYMONTHDAY=1",
+			"FREQ=MONTHLY;BYMONTHDAY=1;DTSTART=20250101T000000Z",
 			"2025-01-15",
 			"2025-02-01",
 		},
 		{
 			"monthly last day",
-			"FREQ=MONTHLY;BYMONTHDAY=-1",
+			"FREQ=MONTHLY;BYMONTHDAY=-1;DTSTART=20250101T000000Z",
 			"2025-01-15",
 			"2025-01-31",
 		},
 		{
 			"quarterly first saturday",
-			"FREQ=MONTHLY;INTERVAL=3;BYDAY=1SA",
+			"FREQ=MONTHLY;INTERVAL=3;BYDAY=1SA;DTSTART=20250101T000000Z",
 			"2025-01-06",
 			"2025-04-05",
 		},
 		{
 			"with RRULE prefix",
-			"RRULE:FREQ=WEEKLY;BYDAY=MO",
+			"RRULE:FREQ=WEEKLY;BYDAY=MO;DTSTART=20250101T000000Z",
 			"2025-01-07",
 			"2025-01-13",
 		},
 		{
 			"every 2 weeks",
-			"FREQ=WEEKLY;INTERVAL=2",
+			"FREQ=WEEKLY;INTERVAL=2;DTSTART=20250106T000000Z",
 			"2025-01-06",
 			"2025-01-20",
 		},
@@ -221,8 +221,9 @@ func TestRruleNextExhausted(t *testing.T) {
 	rt, buf := newDateTestRuntime(t)
 	defer rt.Close()
 
-	// Rule with COUNT=1 starting at after date — next after that is nil
-	script := `rela.output(rela.rrule_next("FREQ=DAILY;COUNT=1", "2025-01-01"))`
+	// Rule with COUNT=1 and DTSTART in the past — only occurrence is Jan 1,
+	// so asking for next after Jan 1 returns nil.
+	script := `rela.output(rela.rrule_next("FREQ=DAILY;COUNT=1;DTSTART=20250101T000000Z", "2025-01-01"))`
 	err := rt.RunString(script)
 	require.NoError(t, err)
 
@@ -230,11 +231,24 @@ func TestRruleNextExhausted(t *testing.T) {
 }
 
 func TestRruleNextError(t *testing.T) {
-	rt, _ := newDateTestRuntime(t)
-	defer rt.Close()
+	tests := []struct {
+		name   string
+		script string
+	}{
+		{"invalid rrule", `rela.rrule_next("INVALID_RRULE")`},
+		{"interval without dtstart", `rela.rrule_next("FREQ=WEEKLY;INTERVAL=2", "2025-01-06")`},
+		{"interval 3 without dtstart", `rela.rrule_next("FREQ=MONTHLY;INTERVAL=3", "2025-01-06")`},
+	}
 
-	err := rt.RunString(`rela.rrule_next("INVALID_RRULE")`)
-	require.Error(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt, _ := newDateTestRuntime(t)
+			defer rt.Close()
+
+			err := rt.RunString(tt.script)
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestParseOffset(t *testing.T) {

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -294,6 +294,9 @@ func (r *Runtime) registerBindings() {
 	r.L.SetField(rela, "project_root", lua.LString(r.projectRoot))
 	r.L.SetField(rela, "args", r.L.NewTable()) // Will be set before running script
 
+	// Date and RRULE utility functions
+	registerDateHelpers(r.L, rela)
+
 	// Markdown AST and generation helpers module (rela.md.*)
 	r.registerMarkdownModule(rela)
 
@@ -1195,16 +1198,7 @@ func luaDaysSince(ls *lua.LState) int {
 		return 1
 	}
 
-	var t time.Time
-	var err error
-
-	// Try RFC3339 first (includes timezone)
-	t, err = time.Parse(time.RFC3339, dateStr)
-	if err != nil {
-		// Fall back to date-only format
-		t, err = time.Parse("2006-01-02", dateStr)
-	}
-
+	t, err := parseDate(dateStr)
 	if err != nil {
 		ls.Push(lua.LNumber(-1))
 		return 1

--- a/tickets/entities/bugs/BUG-002.md
+++ b/tickets/entities/bugs/BUG-002.md
@@ -9,5 +9,5 @@ description: |
 why1: Sync() attempts git operations without checking for conflict state
 why2: No pre-flight check for .git/rebase-merge or .git/rebase-apply directories
 why3: Original implementation focused on happy path
-prevention: Added ErrConflictInProgress check at start of Sync()
+prevention: Added ErrConflictInProgress sentinel error and pre-flight check at the start of Sync() that detects active rebase/merge conflicts by checking for .git/rebase-merge and .git/rebase-apply directories. When detected, returns a clear user-facing error message instead of proceeding with git operations that would fail with confusing refspec errors.
 ---

--- a/tickets/entities/implementation-checklists/IMPL-ITQT.md
+++ b/tickets/entities/implementation-checklists/IMPL-ITQT.md
@@ -1,0 +1,51 @@
+---
+id: IMPL-ITQT
+type: implementation-checklist
+title: 'Implementation: Add shebang support to Lua scripts'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+1. **AC1 - Scripts with shebang execute**: Tested with `scripts/test-shebang.lua` containing `#!/usr/bin/env -S rela script` - executed successfully with output `{"args":["arg1","arg2"],"message":"Hello from shebang script!"}`
+
+2. **AC2 - Shebang only stripped from first line**: Unit test `TestStripShebang_ShebangInMiddle` verifies shebang-like content in middle of file is NOT stripped
+
+3. **AC3 - Scripts without shebang work**: All existing tests pass (78.8% coverage), no regressions
+
+4. **AC4 - All entry points covered**: `RunString()` now calls `StripShebang()` - all paths (MCP, validation, automation) funnel through it
+
+5. **AC5 - Error line numbers accurate**: Test `TestRunFile_ErrorLineNumbers_WithShebang` verifies error on line 2 reports as `line:2`
+
+6. **Filename in errors**: Test `TestRunFile_ErrorIncludesFilename` verifies filename appears in error messages
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-54LN.md
+++ b/tickets/entities/planning-checklists/PLAN-54LN.md
@@ -1,0 +1,169 @@
+---
+id: PLAN-54LN
+type: planning-checklist
+title: 'Planning: Add shebang support to Lua scripts'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN SCOPE:
+- Strip shebang lines (`#!...`) from Lua scripts before execution
+- Support shebang in scripts loaded from `scripts/` directory (CLI, MCP lua_run)
+- Support shebang in validation scripts loaded from `validations/` directory
+- Support shebang in automation Lua file actions
+
+OUT OF SCOPE:
+- Actually making scripts executable via shebang (that's a shell/OS concern)
+- Modifying the `rela script` CLI to accept scripts from stdin
+- Adding a `rela-lua` binary/symlink for direct script execution
+
+**Acceptance Criteria:**
+1. Scripts starting with `#!/...` execute successfully (shebang line stripped)
+2. Scripts starting with `#!` on first line only (not in middle of file) are handled
+3. Scripts without shebang continue to work unchanged
+4. Shebang stripping works for all entry points: `rela script`, MCP `lua_run`, automation engine, validation engine
+5. Error line numbers in Lua errors remain accurate (shebang line should not shift line numbers)
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+- Standard Lua interpreter handles shebangs natively by ignoring lines starting with `#`
+- gopher-lua (the library used) does NOT handle shebangs - it will fail on `#!`
+- The fix is simple: strip the first line if it starts with `#!` before passing to the Lua VM
+- No existing pattern in codebase for this - this is new functionality
+
+**Entry points that load Lua scripts:**
+1. `internal/lua/runtime.go:147-162` - `RunFile()` uses `L.DoFile(path)` directly
+2. `internal/script/executor.go:81-119` - `loadScript()` reads file, returns string
+3. `internal/mcp/tools_lua.go:118-141` - `handleLuaRun()` reads file, calls `RunString()`
+4. `internal/validation/lua.go:207-245` - `loadScript()` reads file, returns string
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Add a `StripShebang(code string) string` function in `internal/lua/runtime.go`
+that:
+1. Checks if the string starts with `#!`
+2. If so, finds the first newline position
+3. Returns the substring starting FROM (including) the newline - this preserves line numbers
+4. If no newline found (single-line shebang), returns empty string
+5. If doesn't start with `#!`, returns the string unchanged
+
+Example: `#!/bin/rela\ncode` becomes `\ncode` where line 1 is blank and line 2
+is `code`.
+
+Call this function in `RunString()` - this covers all entry points since MCP,
+validation, and automation all funnel through `RunString()`.
+
+For `RunFile()`: read the file, strip shebang, use `L.LoadString()` with chunk
+name set to the filename (preserves filename in error messages), then call the
+loaded function.
+
+**Alternatives considered:**
+1. **Strip in each loader separately** - Rejected: duplicates logic in 4 places
+2. **Modify gopher-lua** - Rejected: external dependency, unnecessary
+3. **Strip in RunString only** - Chosen: single point of change, all paths go through RunString
+
+**Dependencies:**
+- No new packages needed
+- Only modifies `internal/lua/runtime.go`
+
+**Files to modify:**
+- `internal/lua/runtime.go` - Add `StripShebang()` function, modify `RunString()` to call it, modify `RunFile()` to read file, strip shebang, use `LoadString()` with chunk name
+- `internal/lua/runtime_test.go` - Add tests for shebang handling
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+- Input: Lua script content (string) from files in `scripts/` or `validations/` directories
+- Validation: Only strip `#!` from the very first characters of the string - this is safe
+- Invalid input: If script doesn't start with `#!`, return unchanged - no error
+
+**Security-Sensitive Operations:**
+- None added - this is a simple string manipulation before existing secure execution
+- File access is already secured via `os.OpenRoot` in the loaders
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+1. AC1: Test script with `#!/usr/bin/env rela script` shebang executes correctly
+2. AC2: Test script with shebang-like content in middle of file (not stripped)
+3. AC3: Test script without shebang continues to work
+4. AC4: Test `RunFile()` with shebang script executes correctly
+5. AC5: Test error in line 2 of shebang script reports as line 2 (not line 1)
+6. Test `RunFile()` error messages include filename (not `<string>`)
+
+**Edge Cases:**
+- Empty script (just shebang, no code) → returns empty string, executes as no-op
+- Shebang with no newline → returns empty string
+- Script starting with `#` but not `#!` (e.g., Lua comment) → not stripped (Lua comments use `--`)
+- Windows line endings (`\r\n`) → find `\n`, let `\r` be part of blank line (harmless)
+- Very long shebang line → handled correctly
+
+**Negative Tests:**
+- Script with syntax error after shebang → error with correct line number
+- No negative tests for shebang itself - invalid shebangs just get stripped
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+1. **Line number accuracy in errors** - Risk: stripping line shifts line numbers
+   - Mitigation: Return substring starting FROM the newline (include it) so line count is preserved
+
+2. **Performance** - Risk: checking every script
+   - Mitigation: Single string prefix check, negligible overhead
+
+**Effort: xs** (extra small) - Simple string manipulation, ~20 lines of code +
+tests
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] N/A - Internal change, no user-facing docs needed
+- Scripts with shebangs will "just work" - no documentation required
+- Could optionally add a note to CLI help for `rela script` but not required
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** RR-X4B5, RR-UWZW, RR-V824 (all minor, addressed in
+updated plan)

--- a/tickets/entities/review-checklists/REV-LX4I.md
+++ b/tickets/entities/review-checklists/REV-LX4I.md
@@ -56,8 +56,8 @@ status: done
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
 
-**PR:** <!-- Pending -->
+**PR:** #287

--- a/tickets/entities/review-checklists/REV-LX4I.md
+++ b/tickets/entities/review-checklists/REV-LX4I.md
@@ -1,0 +1,63 @@
+---
+id: REV-LX4I
+type: review-checklist
+title: 'Review: Add shebang support to Lua scripts'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:**
+- RR-X4B5: Clarify line number preservation (minor, design review) - addressed
+- RR-UWZW: RunFile error messages lose filename context (minor, design review) - addressed
+- RR-V824: Add explicit test for RunFile with shebang (minor, design review) - addressed
+- RR-Z9TR: RunFile did not preserve filename in chunk name (significant, code review) - addressed
+- RR-VPXU: Missing test for Windows-style line endings (significant, code review) - addressed
+- RR-300X: Documentation lacked context (nit, code review) - addressed
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+1. AC1 - Scripts with shebang execute: PASS - TestRunFile_WithShebang, TestRunString_WithShebang
+2. AC2 - Shebang only stripped from first line: PASS - TestStripShebang_ShebangInMiddle
+3. AC3 - Scripts without shebang work: PASS - All existing tests pass
+4. AC4 - All entry points covered: PASS - RunString calls StripShebang, all paths funnel through it
+5. AC5 - Error line numbers accurate: PASS - TestRunFile_ErrorLineNumbers_WithShebang
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A - internal change)
+- [x] ~~User-facing documentation updated~~ (N/A - scripts "just work")
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+**Docs Checklist:** N/A - Internal enhancement, no user-facing docs needed
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- Pending -->

--- a/tickets/entities/review-responses/RR-300X.md
+++ b/tickets/entities/review-responses/RR-300X.md
@@ -1,0 +1,9 @@
+---
+id: RR-300X
+type: review-response
+title: Documentation lacked context on why shebangs are stripped
+finding: Comments explained WHAT but not WHY shebangs are stripped.
+severity: nit
+resolution: Updated StripShebang documentation to explain this allows scripts to be directly executable from the command line.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-704E.md
+++ b/tickets/entities/review-responses/RR-704E.md
@@ -1,0 +1,9 @@
+---
+id: RR-704E
+type: review-response
+title: Fixed-mode recurrence skips missed periods
+finding: 'If cron hasn''t run for 3 weeks with a weekly rule, only one task is created. Missed periods are silently swallowed. Need explicit design decision: catch-up vs skip mode.'
+severity: critical
+reason: 'Intentional design: skip mode, not catch-up. For PIM tasks like watering plants, creating missed instances would pile up meaningless tasks. Documented in script header.'
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-704E.md
+++ b/tickets/entities/review-responses/RR-704E.md
@@ -4,6 +4,6 @@ type: review-response
 title: Fixed-mode recurrence skips missed periods
 finding: 'If cron hasn''t run for 3 weeks with a weekly rule, only one task is created. Missed periods are silently swallowed. Need explicit design decision: catch-up vs skip mode.'
 severity: critical
-reason: 'Intentional design: skip mode, not catch-up. For PIM tasks like watering plants, creating missed instances would pile up meaningless tasks. Documented in script header.'
+reason: 'Intentional design decision: skip mode, not catch-up. For personal PIM tasks like watering plants or cleaning, creating multiple missed instances would pile up meaningless tasks that the user would have to dismiss one by one. The script creates only the current period task and advances next_due. This behavior is documented in the recurrence.lua script header comments.'
 status: wont-fix
 ---

--- a/tickets/entities/review-responses/RR-CRM1.md
+++ b/tickets/entities/review-responses/RR-CRM1.md
@@ -1,0 +1,9 @@
+---
+id: RR-CRM1
+type: review-response
+title: RRULE DTSTART override destroys rule semantics
+finding: Setting opt.Dtstart = after means interval-based rules count from the wrong epoch. FREQ=WEEKLY;INTERVAL=2 fires on wrong weeks. BYMONTHDAY rules may also misbehave. Should preserve original DTSTART and only use After() to find next occurrence.
+severity: critical
+resolution: Don't override DTSTART. Reject INTERVAL > 1 without explicit DTSTART in the RRULE string. Users must anchor interval cadence explicitly.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-D8NA.md
+++ b/tickets/entities/review-responses/RR-D8NA.md
@@ -1,0 +1,9 @@
+---
+id: RR-D8NA
+type: review-response
+title: Timezone inconsistency between time.Now() and date-only parsing
+finding: time.Now() returns local time, time.Parse date-only returns UTC. days_since can be off by one day near midnight. Parse date-only strings in local time or truncate to midnight.
+severity: significant
+resolution: parseDate now uses time.ParseInLocation with time.Local for date-only strings. rrule_next uses UTC internally for RRULE comparisons via parseDateUTC.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GCHX.md
+++ b/tickets/entities/review-responses/RR-GCHX.md
@@ -1,0 +1,9 @@
+---
+id: RR-GCHX
+type: review-response
+title: 'after mode recurrence: first run creates immediately'
+finding: When recurring entity is first created with after mode, empty spawns list means task is immediately created. Also deleted tasks (not done) trigger re-creation.
+severity: significant
+reason: Immediate creation on first run is the intended behavior for after mode — the user just created a recurring template and wants the first task. Deleted-task re-creation is acceptable; if you don't want a task, set mode to exhausted or remove the recurring entity.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-HHPP.md
+++ b/tickets/entities/review-responses/RR-HHPP.md
@@ -1,0 +1,9 @@
+---
+id: RR-HHPP
+type: review-response
+title: contact-remind duplicate detection too broad
+finding: Any task with about relation to person blocks reminders, even non-reminder tasks. Need to distinguish reminder tasks from regular tasks linked to a person.
+severity: significant
+reason: Current duplicate detection works for the initial use case. Will revisit if non-reminder tasks get about relations to people, potentially adding a tags-based filter.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-II0B.md
+++ b/tickets/entities/review-responses/RR-II0B.md
@@ -1,0 +1,9 @@
+---
+id: RR-II0B
+type: review-response
+title: daily-parse regex fragile for real-world markdown
+finding: Pattern requires exact '- [ ] ' format. Won't match asterisk lists or double spaces. Inline markdown in text becomes part of task title. Fine for v1 but should strip formatting.
+severity: significant
+reason: Needs proper GFM task list support in rela's markdown package. Will create separate ticket for goldmark tasklist extension. Current regex is adequate for v1.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-O003.md
+++ b/tickets/entities/review-responses/RR-O003.md
@@ -1,0 +1,9 @@
+---
+id: RR-O003
+type: review-response
+title: Exhausted RRULE sets next_due to empty string
+finding: 'When rrule_next returns nil, next_due becomes empty. The recurring entity becomes a zombie: looks active but never fires. Should set a status or log a message.'
+severity: critical
+resolution: Added recurring-status type (active/exhausted) to PIM metamodel. recurrence.lua now sets status=exhausted when rrule_next returns nil and reports count in output.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-UWZW.md
+++ b/tickets/entities/review-responses/RR-UWZW.md
@@ -1,0 +1,9 @@
+---
+id: RR-UWZW
+type: review-response
+title: RunFile error messages will lose filename context
+finding: The plan proposes modifying RunFile() to read the file and call RunString(). However, L.DoFile() provides filename context in error messages. After the change, errors will show '<string>' instead of the filename. Consider using L.LoadString() with a chunk name parameter to preserve filename in errors, or accept this as a minor trade-off.
+severity: minor
+resolution: 'Updated plan: RunFile() will use L.LoadString() with chunk name set to filename to preserve error context.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-V824.md
+++ b/tickets/entities/review-responses/RR-V824.md
@@ -1,0 +1,9 @@
+---
+id: RR-V824
+type: review-response
+title: Add explicit test for RunFile with shebang
+finding: 'Test plan says ''Integration covered by existing tests'' but RunFile() uses DoFile() directly which will need modification. Add explicit test: ''RunFile() with shebang script executes correctly and reports errors with correct line numbers and filename.'''
+severity: minor
+resolution: 'Added explicit test scenarios to test plan: AC4 tests RunFile() with shebang, plus test that error messages include filename.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-VPXU.md
+++ b/tickets/entities/review-responses/RR-VPXU.md
@@ -1,0 +1,9 @@
+---
+id: RR-VPXU
+type: review-response
+title: Missing test for Windows-style line endings
+finding: All shebang tests used Unix-style line endings (\n). CRLF handling was not tested.
+severity: significant
+resolution: Added TestStripShebang_WindowsLineEndings test. The \r is stripped along with shebang content since it comes before \n, which is correct behavior.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-WBSU.md
+++ b/tickets/entities/review-responses/RR-WBSU.md
@@ -1,0 +1,9 @@
+---
+id: RR-WBSU
+type: review-response
+title: 'daily-parse TOCTOU: crash between create and annotate causes duplicates'
+finding: If script crashes between create_entity and update_entity, task exists but annotation is never written. Next run creates duplicate. Should write annotation immediately or check spawned relations.
+severity: significant
+reason: TOCTOU window is very small (between create_entity and update_entity in same script run). Proper fix requires GFM task list support to check spawned relations instead of annotations. Acceptable risk for personal PIM.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-X4B5.md
+++ b/tickets/entities/review-responses/RR-X4B5.md
@@ -1,0 +1,9 @@
+---
+id: RR-X4B5
+type: review-response
+title: Clarify line number preservation implementation
+finding: 'The plan states to ''prepend a blank line'' but the wording is confusing. The correct implementation is: find the first newline in the shebang, and return the substring starting FROM (including) that newline position. This preserves the line count. Example: ''#!/bin/rela\ncode'' becomes ''\ncode'' where line 1 is now blank and line 2 is ''code''. The plan''s intent is correct but implementation details should be explicit.'
+severity: minor
+resolution: 'Updated plan to clarify: return substring starting FROM (including) the newline position. Example added to plan.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Z9TR.md
+++ b/tickets/entities/review-responses/RR-Z9TR.md
@@ -1,0 +1,9 @@
+---
+id: RR-Z9TR
+type: review-response
+title: RunFile did not preserve filename in chunk name
+finding: LoadString does not accept a chunk name parameter. Error messages showed '<string>' instead of the filename. The code comment was misleading.
+severity: significant
+resolution: Changed to use L.Load(strings.NewReader(code), path) which accepts the filename as chunk name.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-Y0M1.md
+++ b/tickets/entities/tickets/TKT-Y0M1.md
@@ -1,0 +1,11 @@
+---
+id: TKT-Y0M1
+type: ticket
+title: Add date arithmetic and RRULE helpers to Lua runtime
+kind: enhancement
+priority: medium
+effort: s
+status: ready
+---
+
+## Description\n\nAdd four Lua date helper functions for recurrence scheduling:\n\n- `rela.date_add(date, offset)` — add d/w/m/y offsets (negative supported)\n- `rela.date_weekday(date)` — get lowercase weekday name\n- `rela.date_next_weekday(date, day)` — next occurrence of weekday\n- `rela.rrule_next(rrule, after?)` — next RRULE occurrence using teambition/rrule-go\n\nUses RFC 5545 RRULE syntax for iCal recurrence rules.\n\n## Implementation\n\n- New file: `internal/lua/date.go` with four standalone functions + `registerDateHelpers`\n- New file: `internal/lua/date_test.go` with comprehensive tests\n- Modified: `internal/lua/runtime.go` — register helpers, refactor `luaDaysSince` to use shared `parseDate()`\n- New dependency: `github.com/teambition/rrule-go v1.8.2`\n- Updated: `.go-arch-lint.yml` — allow rrule-go in lua component\n\nPR: #297"

--- a/tickets/relations/TKT-Q3KQ--has-implementation--IMPL-ITQT.md
+++ b/tickets/relations/TKT-Q3KQ--has-implementation--IMPL-ITQT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q3KQ
+relation: has-implementation
+to: IMPL-ITQT
+---

--- a/tickets/relations/TKT-Q3KQ--has-planning--PLAN-54LN.md
+++ b/tickets/relations/TKT-Q3KQ--has-planning--PLAN-54LN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q3KQ
+relation: has-planning
+to: PLAN-54LN
+---

--- a/tickets/relations/TKT-Q3KQ--has-review--REV-LX4I.md
+++ b/tickets/relations/TKT-Q3KQ--has-review--REV-LX4I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q3KQ
+relation: has-review
+to: REV-LX4I
+---

--- a/tickets/relations/TKT-Q3KQ--has-review-response--RR-300X.md
+++ b/tickets/relations/TKT-Q3KQ--has-review-response--RR-300X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q3KQ
+relation: has-review-response
+to: RR-300X
+---

--- a/tickets/relations/TKT-Q3KQ--has-review-response--RR-UWZW.md
+++ b/tickets/relations/TKT-Q3KQ--has-review-response--RR-UWZW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q3KQ
+relation: has-review-response
+to: RR-UWZW
+---

--- a/tickets/relations/TKT-Q3KQ--has-review-response--RR-V824.md
+++ b/tickets/relations/TKT-Q3KQ--has-review-response--RR-V824.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q3KQ
+relation: has-review-response
+to: RR-V824
+---

--- a/tickets/relations/TKT-Q3KQ--has-review-response--RR-VPXU.md
+++ b/tickets/relations/TKT-Q3KQ--has-review-response--RR-VPXU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q3KQ
+relation: has-review-response
+to: RR-VPXU
+---

--- a/tickets/relations/TKT-Q3KQ--has-review-response--RR-X4B5.md
+++ b/tickets/relations/TKT-Q3KQ--has-review-response--RR-X4B5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q3KQ
+relation: has-review-response
+to: RR-X4B5
+---

--- a/tickets/relations/TKT-Q3KQ--has-review-response--RR-Z9TR.md
+++ b/tickets/relations/TKT-Q3KQ--has-review-response--RR-Z9TR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q3KQ
+relation: has-review-response
+to: RR-Z9TR
+---

--- a/tickets/relations/TKT-Y0M1--affects--lua-scripting.md
+++ b/tickets/relations/TKT-Y0M1--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y0M1
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-Y0M1--has-review-response--RR-704E.md
+++ b/tickets/relations/TKT-Y0M1--has-review-response--RR-704E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y0M1
+relation: has-review-response
+to: RR-704E
+---

--- a/tickets/relations/TKT-Y0M1--has-review-response--RR-CRM1.md
+++ b/tickets/relations/TKT-Y0M1--has-review-response--RR-CRM1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y0M1
+relation: has-review-response
+to: RR-CRM1
+---

--- a/tickets/relations/TKT-Y0M1--has-review-response--RR-D8NA.md
+++ b/tickets/relations/TKT-Y0M1--has-review-response--RR-D8NA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y0M1
+relation: has-review-response
+to: RR-D8NA
+---

--- a/tickets/relations/TKT-Y0M1--has-review-response--RR-GCHX.md
+++ b/tickets/relations/TKT-Y0M1--has-review-response--RR-GCHX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y0M1
+relation: has-review-response
+to: RR-GCHX
+---

--- a/tickets/relations/TKT-Y0M1--has-review-response--RR-HHPP.md
+++ b/tickets/relations/TKT-Y0M1--has-review-response--RR-HHPP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y0M1
+relation: has-review-response
+to: RR-HHPP
+---

--- a/tickets/relations/TKT-Y0M1--has-review-response--RR-II0B.md
+++ b/tickets/relations/TKT-Y0M1--has-review-response--RR-II0B.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y0M1
+relation: has-review-response
+to: RR-II0B
+---

--- a/tickets/relations/TKT-Y0M1--has-review-response--RR-O003.md
+++ b/tickets/relations/TKT-Y0M1--has-review-response--RR-O003.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y0M1
+relation: has-review-response
+to: RR-O003
+---

--- a/tickets/relations/TKT-Y0M1--has-review-response--RR-WBSU.md
+++ b/tickets/relations/TKT-Y0M1--has-review-response--RR-WBSU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y0M1
+relation: has-review-response
+to: RR-WBSU
+---

--- a/tickets/relations/TKT-Y0M1--implements--FEAT-i5ji.md
+++ b/tickets/relations/TKT-Y0M1--implements--FEAT-i5ji.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y0M1
+relation: implements
+to: FEAT-i5ji
+---


### PR DESCRIPTION
## Summary
- Add four Lua date helper functions: `rela.date_add`, `rela.date_weekday`, `rela.date_next_weekday`, `rela.rrule_next`
- Uses `teambition/rrule-go` for RFC 5545 RRULE parsing (iCal recurrence rules)
- Enables Lua scripts to do date arithmetic and compute next occurrences for recurring schedules

## Test plan
- [x] Unit tests for all four helpers including edge cases (month overflow, leap year, negative offsets, exhausted rules)
- [x] Tests for `parseOffset` helper
- [x] Error path tests (invalid dates, bad RRULE strings)
- [x] Full test suite passes
- [x] Lint passes
- [x] Architecture lint updated to allow rrule-go dependency in lua component