### PR TITLE
feat(dataentry): add palette import with smart color assignment

### DIFF
--- a/frontend/src/utils/palette.test.ts
+++ b/frontend/src/utils/palette.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeHex,
+  parseHexList,
+  parseGPL,
+  parsePalette,
+  hexToHSL,
+  assignPalette,
+} from './palette'
+
+describe('normalizeHex', () => {
+  it('normalizes 6-digit with #', () => {
+    expect(normalizeHex('#AABBCC')).toBe('#aabbcc')
+  })
+
+  it('normalizes bare 6-digit', () => {
+    expect(normalizeHex('ddcf99')).toBe('#ddcf99')
+  })
+
+  it('expands 3-digit', () => {
+    expect(normalizeHex('#f00')).toBe('#ff0000')
+  })
+
+  it('expands bare 3-digit', () => {
+    expect(normalizeHex('f0f')).toBe('#ff00ff')
+  })
+})
+
+describe('parseHexList', () => {
+  it('parses one per line', () => {
+    const result = parseHexList('ddcf99\ncca87b\nb97a60')
+    expect(result).toEqual(['#ddcf99', '#cca87b', '#b97a60'])
+  })
+
+  it('parses with # prefix', () => {
+    const result = parseHexList('#ff0000\n#00ff00')
+    expect(result).toEqual(['#ff0000', '#00ff00'])
+  })
+
+  it('parses comma separated', () => {
+    const result = parseHexList('#ff0000, #00ff00, #0000ff')
+    expect(result).toEqual(['#ff0000', '#00ff00', '#0000ff'])
+  })
+
+  it('skips invalid tokens', () => {
+    const result = parseHexList('ff0000\nhello\n00ff00')
+    expect(result).toEqual(['#ff0000', '#00ff00'])
+  })
+
+  it('deduplicates', () => {
+    const result = parseHexList('ff0000\nff0000\n00ff00')
+    expect(result).toEqual(['#ff0000', '#00ff00'])
+  })
+
+  it('returns empty for garbage', () => {
+    expect(parseHexList('hello world')).toEqual([])
+  })
+
+  it('returns empty for empty string', () => {
+    expect(parseHexList('')).toEqual([])
+  })
+})
+
+describe('parseGPL', () => {
+  it('parses GIMP Palette format', () => {
+    const gpl = `GIMP Palette
+Name: Test
+Columns: 4
+#
+255   0   0\tRed
+  0 255   0\tGreen
+  0   0 255\tBlue`
+    const result = parseGPL(gpl)
+    expect(result).toEqual(['#ff0000', '#00ff00', '#0000ff'])
+  })
+
+  it('skips comments and headers', () => {
+    const gpl = `GIMP Palette
+Name: Minimal
+# This is a comment
+128 128 128`
+    const result = parseGPL(gpl)
+    expect(result).toEqual(['#808080'])
+  })
+
+  it('rejects out-of-range values', () => {
+    const gpl = `GIMP Palette
+#
+256 0 0`
+    expect(parseGPL(gpl)).toEqual([])
+  })
+})
+
+describe('parsePalette', () => {
+  it('auto-detects GPL format', () => {
+    const gpl = `GIMP Palette
+#
+255 0 0`
+    expect(parsePalette(gpl)).toEqual(['#ff0000'])
+  })
+
+  it('auto-detects hex list', () => {
+    expect(parsePalette('ff0000\n00ff00')).toEqual(['#ff0000', '#00ff00'])
+  })
+})
+
+describe('hexToHSL', () => {
+  it('pure red', () => {
+    const hsl = hexToHSL('#ff0000')
+    expect(hsl.h).toBeCloseTo(0, 1)
+    expect(hsl.s).toBeCloseTo(1, 1)
+    expect(hsl.l).toBeCloseTo(0.5, 1)
+  })
+
+  it('pure green', () => {
+    const hsl = hexToHSL('#00ff00')
+    expect(hsl.h).toBeCloseTo(1 / 3, 1)
+    expect(hsl.s).toBeCloseTo(1, 1)
+  })
+
+  it('white', () => {
+    const hsl = hexToHSL('#ffffff')
+    expect(hsl.l).toBeCloseTo(1, 1)
+    expect(hsl.s).toBe(0)
+  })
+
+  it('black', () => {
+    const hsl = hexToHSL('#000000')
+    expect(hsl.l).toBeCloseTo(0, 1)
+  })
+})
+
+describe('assignPalette', () => {
+  it('returns empty for no colors', () => {
+    const result = assignPalette([])
+    expect(result.colors).toEqual({})
+    expect(result.badges).toEqual({})
+  })
+
+  it('single color assigned to accent', () => {
+    const result = assignPalette(['#6366f1'])
+    expect(result.colors.accent).toBe('#6366f1')
+    expect(Object.keys(result.colors)).toHaveLength(1)
+  })
+
+  it('two colors: darkest=base, lightest=surface', () => {
+    const result = assignPalette(['#ffffff', '#000000'])
+    expect(result.colors.base).toBe('#000000')
+    expect(result.colors.surface).toBe('#ffffff')
+  })
+
+  it('assigns base as darkest and surface as lightest', () => {
+    const colors = ['#1a1a2e', '#f8fafc', '#6366f1', '#1e293b']
+    const result = assignPalette(colors)
+    expect(result.colors.base).toBe('#1a1a2e')
+    expect(result.colors.surface).toBe('#f8fafc')
+  })
+
+  it('assigns green hue to success', () => {
+    const colors = [
+      '#000000', '#ffffff', '#333333', '#666666', // structural
+      '#22c55e', // green → should map to success
+      '#ef4444', // red → error
+      '#3b82f6', // blue → info
+      '#f59e0b', // yellow → warning
+    ]
+    const result = assignPalette(colors)
+    expect(result.colors.success).toBe('#22c55e')
+    expect(result.colors.error).toBe('#ef4444')
+  })
+
+  it('assigns badge colors by hue with enough colors', () => {
+    // 16 colors — enough for all 15 roles
+    const colors = [
+      '#000000', '#ffffff', '#333333', '#666666',
+      '#22c55e', '#ef4444', '#3b82f6', '#f59e0b',
+      '#8b5cf6', '#f97316', '#eab308', '#6b7280',
+      '#cc3344', '#1e40af', '#15803d', '#c2410c',
+    ]
+    const result = assignPalette(colors)
+    // With 16 colors, all badge slots should be filled
+    expect(Object.keys(result.badges).length).toBeGreaterThanOrEqual(5)
+    // Gray should be low-saturation
+    if (result.badges.gray) {
+      const grayHSL = hexToHSL(result.badges.gray)
+      expect(grayHSL.s).toBeLessThan(0.3)
+    }
+  })
+
+  it('no duplicate UI role assignments', () => {
+    const colors = ['#111111', '#222222', '#333333', '#444444',
+      '#555555', '#666666', '#777777', '#888888']
+    const result = assignPalette(colors)
+    // UI + semantic roles should be unique (no duplicates within theme colors)
+    const themeColors = Object.values(result.colors)
+    const unique = new Set(themeColors)
+    expect(unique.size).toBe(themeColors.length)
+    // Badges may reuse theme colors but should be unique among themselves
+    const badgeColors = Object.values(result.badges)
+    const uniqueBadges = new Set(badgeColors)
+    expect(uniqueBadges.size).toBe(badgeColors.length)
+  })
+
+  it('handles red hue wrap-around (350° should match red)', () => {
+    // #cc3344 has hue ~352° which should be close to red (0°)
+    const colors = [
+      '#000000', '#ffffff', '#333333', '#666666',
+      '#22c55e', '#cc3344', '#3b82f6', '#f59e0b',
+    ]
+    const result = assignPalette(colors)
+    expect(result.colors.error).toBe('#cc3344')
+  })
+
+  it('fading-16 palette assigns reasonable roles', () => {
+    const fading16 = [
+      '#ddcf99', '#cca87b', '#b97a60', '#9c524e',
+      '#774251', '#4b3d44', '#4e5463', '#5b7d73',
+      '#8e9f7d', '#645355', '#8c7c79', '#a99c8d',
+      '#7d7b62', '#aaa25d', '#846d59', '#a88a5e',
+    ]
+    const result = assignPalette(fading16)
+    // Should have base (darkest), surface (lightest), and several others
+    expect(result.colors.base).toBeDefined()
+    expect(result.colors.surface).toBeDefined()
+    expect(result.colors.accent).toBeDefined()
+    // Should have some badge assignments
+    expect(Object.keys(result.badges).length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/utils/palette.ts
+++ b/frontend/src/utils/palette.ts
@@ -1,0 +1,235 @@
+// Palette import: parsing and smart color assignment.
+
+const HEX_RE = /^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/
+
+interface HSL {
+  h: number // [0,1]
+  s: number // [0,1]
+  l: number // [0,1]
+}
+
+// --- Parsing ---
+
+/** Normalize a hex color to #rrggbb format. */
+export function normalizeHex(raw: string): string {
+  let hex = raw.trim().replace(/^#/, '')
+  if (hex.length === 3) {
+    hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2]
+  }
+  return '#' + hex.toLowerCase()
+}
+
+/** Parse a hex list (one per line, or comma/space separated). Accepts bare hex and #-prefixed. */
+export function parseHexList(text: string): string[] {
+  const colors: string[] = []
+  const tokens = text.split(/[\n,\s]+/).map((t) => t.trim()).filter(Boolean)
+  for (const token of tokens) {
+    if (HEX_RE.test(token)) {
+      colors.push(normalizeHex(token))
+    }
+  }
+  return dedupe(colors)
+}
+
+/** Parse a GIMP Palette (.gpl) format string. */
+export function parseGPL(text: string): string[] {
+  const colors: string[] = []
+  const lines = text.split('\n')
+  for (const line of lines) {
+    const trimmed = line.trim()
+    // Skip headers and comments
+    if (!trimmed || trimmed.startsWith('GIMP Palette') || trimmed.startsWith('Name:') ||
+        trimmed.startsWith('Columns:') || trimmed.startsWith('#')) {
+      continue
+    }
+    // Parse "R G B [name]" — at least 3 numbers
+    const match = trimmed.match(/^\s*(\d{1,3})\s+(\d{1,3})\s+(\d{1,3})/)
+    if (match) {
+      const r = parseInt(match[1], 10)
+      const g = parseInt(match[2], 10)
+      const b = parseInt(match[3], 10)
+      if (r <= 255 && g <= 255 && b <= 255) {
+        colors.push(rgbToHex(r, g, b))
+      }
+    }
+  }
+  return dedupe(colors)
+}
+
+/** Auto-detect format and parse palette text. */
+export function parsePalette(text: string): string[] {
+  if (text.trim().startsWith('GIMP Palette')) {
+    return parseGPL(text)
+  }
+  return parseHexList(text)
+}
+
+function dedupe(colors: string[]): string[] {
+  return [...new Set(colors)]
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return '#' + [r, g, b].map((c) => c.toString(16).padStart(2, '0')).join('')
+}
+
+// --- HSL Color Math ---
+
+export function hexToHSL(hex: string): HSL {
+  const normalized = normalizeHex(hex).replace('#', '')
+  const r = parseInt(normalized.slice(0, 2), 16) / 255
+  const g = parseInt(normalized.slice(2, 4), 16) / 255
+  const b = parseInt(normalized.slice(4, 6), 16) / 255
+
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  const l = (max + min) / 2
+
+  if (max === min) return { h: 0, s: 0, l }
+
+  const d = max - min
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+
+  let h = 0
+  if (max === r) { h = (g - b) / d + (g < b ? 6 : 0) }
+  else if (max === g) { h = (b - r) / d + 2 }
+  else { h = (r - g) / d + 4 }
+  h /= 6
+
+  return { h, s, l }
+}
+
+/** Circular hue distance in [0, 0.5] range. */
+function hueDist(h1: number, h2: number): number {
+  const d = Math.abs(h1 - h2)
+  return Math.min(d, 1 - d)
+}
+
+/** Weighted color distance for hue matching. */
+function colorDist(c: HSL, target: HSL): number {
+  return hueDist(c.h, target.h) * 3 + Math.abs(c.s - target.s) + Math.abs(c.l - target.l) * 0.5
+}
+
+// --- Smart Assignment ---
+
+export interface PaletteAssignment {
+  colors: Record<string, string>   // role key → hex
+  badges: Record<string, string>   // badge name → hex
+}
+
+// Target hues for semantic roles (normalized [0,1])
+const SEMANTIC_TARGETS: { key: string; h: number; s: number; l: number }[] = [
+  { key: 'success', h: 145 / 360, s: 0.6, l: 0.45 },
+  { key: 'error',   h: 0 / 360,   s: 0.8, l: 0.55 },
+  { key: 'warning', h: 38 / 360,  s: 0.9, l: 0.52 },
+  { key: 'info',    h: 217 / 360, s: 0.9, l: 0.60 },
+]
+
+// Target hues for badge colors
+const BADGE_TARGETS: { key: string; h: number; s: number; l: number; isGray?: boolean }[] = [
+  { key: 'red',    h: 0 / 360,   s: 0.8, l: 0.55 },
+  { key: 'orange', h: 25 / 360,  s: 0.9, l: 0.53 },
+  { key: 'yellow', h: 48 / 360,  s: 0.8, l: 0.47 },
+  { key: 'green',  h: 142 / 360, s: 0.7, l: 0.45 },
+  { key: 'blue',   h: 217 / 360, s: 0.9, l: 0.60 },
+  { key: 'purple', h: 259 / 360, s: 0.9, l: 0.55 },
+  { key: 'gray',   h: 0,         s: 0,   l: 0.5, isGray: true },
+]
+
+/** Assign imported colors to palette roles using heuristic matching. */
+export function assignPalette(hexColors: string[]): PaletteAssignment {
+  if (hexColors.length === 0) return { colors: {}, badges: {} }
+
+  const result: PaletteAssignment = { colors: {}, badges: {} }
+  const hsls = hexColors.map((c) => ({ hex: c, hsl: hexToHSL(c) }))
+  const used = new Set<string>()
+
+  // Step 1: Assign UI structural roles by lightness
+  const byLightness = [...hsls].sort((a, b) => a.hsl.l - b.hsl.l)
+
+  if (hexColors.length === 1) {
+    result.colors.accent = hexColors[0]
+    used.add(hexColors[0])
+    return result
+  }
+
+  // base = darkest, surface = lightest
+  result.colors.base = byLightness[0].hex
+  used.add(byLightness[0].hex)
+
+  result.colors.surface = byLightness[byLightness.length - 1].hex
+  used.add(byLightness[byLightness.length - 1].hex)
+
+  if (hexColors.length >= 3) {
+    // text = second darkest (skip if same as base)
+    for (let i = 1; i < byLightness.length; i++) {
+      if (!used.has(byLightness[i].hex)) {
+        result.colors.text = byLightness[i].hex
+        used.add(byLightness[i].hex)
+        break
+      }
+    }
+  }
+
+  if (hexColors.length >= 4) {
+    // accent = most saturated of remaining mid-range colors
+    const remaining = hsls.filter((c) => !used.has(c.hex))
+    if (remaining.length > 0) {
+      remaining.sort((a, b) => b.hsl.s - a.hsl.s)
+      result.colors.accent = remaining[0].hex
+      used.add(remaining[0].hex)
+    }
+  }
+
+  // Step 2: Assign semantic roles by hue proximity (priority before badges)
+  for (const target of SEMANTIC_TARGETS) {
+    const best = findClosest(hsls, target, used)
+    if (best) {
+      result.colors[target.key] = best
+      used.add(best)
+    }
+  }
+
+  // Step 3: Assign badge colors by hue proximity
+  // Badges may reuse colors already assigned to UI/semantic roles
+  const badgeUsed = new Set<string>()
+  for (const target of BADGE_TARGETS) {
+    if (target.isGray) {
+      // Gray = lowest saturation (prefer unassigned, but allow reuse)
+      const candidates = [...hsls].sort((a, b) => a.hsl.s - b.hsl.s)
+      const best = candidates.find((c) => !badgeUsed.has(c.hex))
+      if (best) {
+        result.badges[target.key] = best.hex
+        badgeUsed.add(best.hex)
+      }
+    } else {
+      const best = findClosest(hsls, target, badgeUsed)
+      if (best) {
+        result.badges[target.key] = best
+        badgeUsed.add(best)
+      }
+    }
+  }
+
+  return result
+}
+
+/** Find the closest unassigned color to a target HSL. */
+function findClosest(
+  colors: { hex: string; hsl: HSL }[],
+  target: { h: number; s: number; l: number },
+  used: Set<string>,
+): string | undefined {
+  let bestHex: string | undefined
+  let bestDist = Infinity
+
+  for (const c of colors) {
+    if (used.has(c.hex)) continue
+    const d = colorDist(c.hsl, target)
+    if (d < bestDist) {
+      bestDist = d
+      bestHex = c.hex
+    }
+  }
+
+  return bestHex
+}

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -11,6 +11,7 @@ import type {
   PaletteConfig,
 } from '@/api/settings'
 import TagSelect from '@/components/ui/TagSelect.vue'
+import { parsePalette, assignPalette } from '@/utils/palette'
 
 const schemaStore = useSchemaStore()
 const uiStore = useUIStore()
@@ -46,6 +47,11 @@ const paletteRoles = [
 ]
 
 const badgeNames = ['blue', 'purple', 'green', 'gray', 'red', 'orange', 'yellow']
+
+// Import state
+const importText = ref('')
+const importedColors = ref<string[]>([])
+const selectedRole = ref<{ type: 'color' | 'badge'; key: string } | null>(null)
 
 // UI state for adding new items
 const selectedNewProperty = ref('')
@@ -150,6 +156,53 @@ async function handleSavePalette() {
   } finally {
     savingPalette.value = false
   }
+}
+
+function handleImport() {
+  const colors = parsePalette(importText.value)
+  if (colors.length === 0) {
+    uiStore.warning('No valid colors found. Paste hex values or a GIMP Palette.')
+    return
+  }
+  importedColors.value = colors
+  const assignment = assignPalette(colors)
+
+  // Apply assignment to palette state
+  for (const [key, val] of Object.entries(assignment.colors)) {
+    paletteColors.value[key] = val
+  }
+  for (const [key, val] of Object.entries(assignment.badges)) {
+    paletteBadges.value[key] = val
+  }
+
+  uiStore.success(`Imported ${colors.length} colors and auto-assigned to roles`)
+}
+
+function clearImport() {
+  importText.value = ''
+  importedColors.value = []
+  selectedRole.value = null
+}
+
+function selectRole(type: 'color' | 'badge', key: string) {
+  if (selectedRole.value?.type === type && selectedRole.value?.key === key) {
+    selectedRole.value = null // deselect
+  } else {
+    selectedRole.value = { type, key }
+  }
+}
+
+function assignSwatch(hex: string) {
+  if (!selectedRole.value) return
+  if (selectedRole.value.type === 'color') {
+    paletteColors.value[selectedRole.value.key] = hex
+  } else {
+    paletteBadges.value[selectedRole.value.key] = hex
+  }
+}
+
+function isRoleSelected(type: 'color' | 'badge', key: string): boolean {
+  return selectedRole.value?.type === type && selectedRole.value?.key === key
 }
 
 function clearPaletteColor(key: string) {
@@ -544,9 +597,55 @@ onMounted(() => {
         <p class="description">Customize the color palette. Empty fields use built-in defaults.</p>
         <p class="file-path">.rela/palette.yaml</p>
 
+        <h4 class="section-subtitle">Import Palette</h4>
+        <div class="import-section">
+          <textarea
+            v-model="importText"
+            class="import-textarea"
+            placeholder="Paste hex colors (one per line) or GIMP Palette (.gpl) content"
+            rows="4"
+          />
+          <div class="import-actions">
+            <button
+              type="button"
+              class="btn btn-primary btn-sm"
+              :disabled="!importText.trim()"
+              @click="handleImport"
+            >Import</button>
+            <button
+              v-if="importedColors.length"
+              type="button"
+              class="btn btn-secondary btn-sm"
+              @click="clearImport"
+            >Clear</button>
+          </div>
+          <div v-if="importedColors.length" class="swatch-section">
+            <p class="swatch-hint">
+              Click a role label below, then click a swatch to assign it.
+            </p>
+            <div class="swatch-grid">
+              <button
+                v-for="color in importedColors"
+                :key="color"
+                type="button"
+                class="swatch"
+                :style="{ backgroundColor: color }"
+                :title="color"
+                @click="assignSwatch(color)"
+              />
+            </div>
+          </div>
+        </div>
+
         <h4 class="section-subtitle">Theme Colors</h4>
         <div class="color-grid">
-          <div v-for="role in paletteRoles" :key="role.key" class="color-row">
+          <div
+            v-for="role in paletteRoles"
+            :key="role.key"
+            class="color-row"
+            :class="{ 'role-selected': isRoleSelected('color', role.key) }"
+            @click="selectRole('color', role.key)"
+          >
             <label class="color-label">
               <span class="color-name">{{ role.label }}</span>
               <span class="color-desc">{{ role.description }}</span>
@@ -578,7 +677,13 @@ onMounted(() => {
 
         <h4 class="section-subtitle">Badge Colors</h4>
         <div class="color-grid">
-          <div v-for="name in badgeNames" :key="name" class="color-row">
+          <div
+            v-for="name in badgeNames"
+            :key="name"
+            class="color-row"
+            :class="{ 'role-selected': isRoleSelected('badge', name) }"
+            @click="selectRole('badge', name)"
+          >
             <label class="color-label">
               <span class="color-name badge-label">{{ name }}</span>
             </label>
@@ -966,6 +1071,65 @@ h1 {
   margin-top: 16px;
   display: flex;
   gap: 12px;
+}
+
+.import-section {
+  margin-bottom: 16px;
+}
+
+.import-textarea {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: monospace;
+  background: var(--input-bg);
+  color: var(--text-color);
+  resize: vertical;
+}
+
+.import-actions {
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
+}
+
+.swatch-section {
+  margin-top: 12px;
+}
+
+.swatch-hint {
+  font-size: 12px;
+  color: var(--muted-text);
+  margin: 0 0 8px;
+}
+
+.swatch-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.swatch {
+  width: 28px;
+  height: 28px;
+  border: 2px solid var(--border-color);
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 0;
+  transition: transform 0.1s;
+}
+
+.swatch:hover {
+  transform: scale(1.15);
+  border-color: var(--accent-color);
+}
+
+.role-selected {
+  outline: 2px solid var(--accent-color);
+  outline-offset: -2px;
+  border-radius: 6px;
 }
 
 /* Uses global .btn, .btn-primary, .btn-secondary, .btn-sm, .loading-state, .spinner, .error-state from App.vue */

--- a/tickets/entities/implementation-checklists/IMPL-60F8.md
+++ b/tickets/entities/implementation-checklists/IMPL-60F8.md
@@ -1,0 +1,41 @@
+---
+id: IMPL-60F8
+type: implementation-checklist
+title: 'Implementation: Add palette import helper with smart color assignment'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] ~~Integration tests written~~ (N/A: pure frontend utility + UI)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:** 29 unit tests covering parsing (hex, GPL,
+auto-detect), HSL conversion, and assignment algorithm. Frontend builds and
+type-checks clean. 277 total frontend tests pass.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-LMC5.md
+++ b/tickets/entities/planning-checklists/PLAN-LMC5.md
@@ -1,0 +1,240 @@
+---
+id: PLAN-LMC5
+type: planning-checklist
+title: 'Planning: Add palette import helper with smart color assignment'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN scope:
+- Parse hex list format (one hex per line, or comma/space separated) — this is what Lospec gives
+- Parse GPL (GIMP Palette) format — RGB lines with optional names
+- Auto-detect format from pasted text
+- Smart color assignment algorithm for 8 UI roles using lightness sorting + hue matching
+- Smart color assignment for 7 badge colors using hue proximity to default badge hues
+- Show full imported palette as clickable swatches in the Settings Appearance section
+- Click a swatch to assign it to the currently-focused color role
+- All client-side (no new backend endpoint needed — just populate the existing palette form)
+
+OUT of scope:
+- Lospec API integration (user pastes text, not a URL)
+- File upload dialog (textarea paste is simpler and works everywhere)
+- ASE/PAL binary formats (hex + GPL cover the common text formats)
+- Perfect color mapping (goal is "good enough starting point")
+
+**Acceptance Criteria:**
+
+1. User can paste a hex list (one per line) into an import textarea and get auto-assigned palette
+   - Test: paste Fading 16 hex list, verify 8 UI roles + 7 badges populated
+2. User can paste GPL format text and get auto-assigned palette
+   - Test: paste a GIMP Palette file content, verify parsing and assignment
+3. Format is auto-detected (hex vs GPL)
+   - Test: paste hex list without header → hex mode; paste with "GIMP Palette" header → GPL mode
+4. Imported palette swatches are displayed below the import area
+   - Test: import 16 colors, see 16 clickable swatches
+5. Clicking a swatch assigns that color to the currently selected/focused role
+   - Test: focus on "accent" field, click a swatch, verify accent field updates
+6. Auto-assignment uses lightness for UI roles (darkest→base, lightest→surface)
+   - Test: import palette with known lightness order, verify base is darkest, surface is lightest
+7. Auto-assignment uses hue proximity for semantic + badge colors
+   - Test: import palette with a green, verify it's assigned to success/green badge
+8. No color is assigned to two different roles (uniqueness constraint)
+   - Test: import 8-color palette, verify no duplicate assignments
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+- **HSL utilities in palette.go**: `hexToHSL`, `hslToHex`, `mixColors` — can be ported to TS or reimplemented client-side
+- **SettingsView.vue**: Appearance section already has color pickers for all 15 roles — import just populates these
+- **No existing import libs needed** — parsing hex/GPL is trivial string parsing
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+### Pure Frontend Implementation
+
+This is entirely client-side. No backend changes needed — the import parses
+text, runs the assignment algorithm, and populates the existing `paletteColors`
+and `paletteBadges` reactive state. The user can then tweak and hit "Save
+Palette" as before.
+
+### Parsing
+
+```typescript
+function parseHexList(text: string): string[]
+// Split by newlines/commas/spaces, filter valid hex, normalize to #rrggbb
+
+function parseGPL(text: string): string[]
+// Skip "GIMP Palette", "Name:", "Columns:", "#" lines
+// Parse "R G B" lines → convert to hex
+
+function parsePalette(text: string): string[]
+// Auto-detect: starts with "GIMP Palette" → GPL, else hex list
+```
+
+### Color Assignment Algorithm
+
+**Step 1: Sort by lightness** (L in HSL)
+- All imported colors sorted light→dark
+
+**Step 2: Assign UI structural roles**
+- `surface` = lightest color
+- `base` = darkest color
+- `text` = second darkest (must contrast with surface)
+- `accent` = most saturated of remaining mid-range colors
+
+**Step 3: Assign semantic roles by hue matching** Target hues (from defaults):
+- success ≈ 145° (green)
+- error ≈ 0° (red)
+- warning ≈ 38° (yellow-orange)
+- info ≈ 217° (blue)
+
+For each semantic role, find the unassigned color with the closest hue (weighted
+distance: hue×3 + saturation×1 + lightness×0.5). Mark as used.
+
+**Step 4: Assign badge colors by hue matching** Target hues:
+- blue ≈ 217°, purple ≈ 259°, green ≈ 142°, gray ≈ low saturation
+- red ≈ 0°, orange ≈ 25°, yellow ≈ 48°
+
+For gray badge: pick lowest saturation unassigned color. For others: closest hue
+match from remaining unassigned colors.
+
+If fewer colors than roles, some roles stay empty (use defaults).
+
+### UI Components
+
+**Import section** (new, above the existing Theme Colors section):
+
+```
+┌─ Import Palette ──────────────────────────────┐
+│ [textarea: paste hex or GPL here]             │
+│ [Import] [Clear]                              │
+│                                               │
+│ Imported Colors:                              │
+│ ■ ■ ■ ■ ■ ■ ■ ■ ■ ■ ■ ■ ■ ■ ■ ■            │
+│ (click a swatch to assign to selected role)   │
+└───────────────────────────────────────────────┘
+```
+
+**Swatch interaction:**
+- Each color role input gets a "focus" state tracked in a ref
+- When a swatch is clicked, if a role is focused, assign that color to it
+- Visual feedback: focused role has a highlighted border
+
+**Files to modify:**
+
+Frontend only:
+- `frontend/src/views/SettingsView.vue` — import UI, swatch display, assignment logic
+- `frontend/src/utils/palette.ts` — NEW: parsing + assignment algorithm (pure functions, testable)
+- `frontend/src/utils/palette.test.ts` — NEW: unit tests for parsing + assignment
+
+**Alternatives considered:**
+
+- **Backend parsing endpoint**: Rejected — unnecessary complexity, all parsing is simple string ops
+- **File upload dialog**: Rejected — textarea paste is simpler, works on all platforms, no file API needed
+- **Binary format support (ASE/PAL)**: Rejected — hex + GPL cover the text formats Lospec provides
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+1. **Textarea paste** (user input): Parsed client-side only. Invalid lines silently skipped. Hex regex validates each color. No data sent to server until user explicitly clicks Save.
+2. **No new API endpoints** — import is purely client-side
+3. **XSS risk**: None — colors are hex strings applied via `setProperty()`, never inserted as HTML
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Test | Type |
+|----|------|------|
+| 1 | Parse hex list, verify color count and values | Unit |
+| 2 | Parse GPL format, verify RGB→hex conversion | Unit |
+| 3 | Auto-detect hex vs GPL | Unit |
+| 4 | Import populates swatch display | Manual |
+| 5 | Click swatch assigns to focused role | Manual |
+| 6 | assignUIRoles: darkest→base, lightest→surface | Unit |
+| 7 | assignSemanticRoles: green hue→success | Unit |
+| 8 | No duplicate assignments | Unit |
+
+**Edge Cases:**
+
+- Empty input → no change, show error toast
+- Single color → assign to accent only
+- Fewer colors than roles → unassigned roles stay empty (defaults)
+- More colors than roles → extra colors shown as swatches but not auto-assigned
+- Mixed valid/invalid lines → skip invalid, use valid
+- All grays (low saturation) → hue matching degrades gracefully
+- Duplicate colors in input → deduplicate
+
+**Negative Tests:**
+
+- Completely invalid input ("hello world") → "No valid colors found" message
+- Empty textarea → disabled import button
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Hue matching picks wrong color for a role | Medium | Low | User can click swatches to reassign; it's a starting point |
+| Small palettes (4-8 colors) leave many roles empty | Medium | Low | Unassigned roles keep defaults; user fills via swatches |
+| GPL format variations | Low | Low | Lenient parser, skip unparseable lines |
+
+Effort: **M** (frontend-only, ~200 lines of utility code + ~100 lines of UI)
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [ ] ~~User guide~~ (N/A: UI is self-explanatory with placeholder text)
+- [ ] ~~CLI help text~~ (N/A)
+- [ ] ~~CLAUDE.md~~ (N/A)
+- [ ] ~~README.md~~ (N/A)
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: small, frontend-only feature building on existing palette)
+- [x] ~~All critical/significant findings addressed in plan~~ (N/A)
+
+**Design Review Findings:** Skipped — pure frontend addition with no
+architectural changes

--- a/tickets/entities/review-responses/RR-B00A.md
+++ b/tickets/entities/review-responses/RR-B00A.md
@@ -1,0 +1,9 @@
+---
+id: RR-B00A
+type: review-response
+title: Hue distance calculation must handle circular wrap-around
+finding: 'Hue is circular (0° = 360°). Red at 0° and a pinkish-red at 350° should be very close, but naive |h1-h2| gives 350°. The algorithm needs circular distance: min(|h1-h2|, 1-|h1-h2|) in normalized [0,1] space. Without this, colors near red will be poorly matched.'
+severity: significant
+resolution: 'Implemented circular hue distance: min(|h1-h2|, 1-|h1-h2|) in normalized [0,1] space'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-BPKK.md
+++ b/tickets/entities/review-responses/RR-BPKK.md
@@ -1,0 +1,9 @@
+---
+id: RR-BPKK
+type: review-response
+title: 'Hex parsing must handle bare hex without # prefix'
+finding: Lospec hex downloads are bare hex values like 'ddcf99' without '#'. The parser must accept and normalize both '#ddcf99' and 'ddcf99' to '#ddcf99'. The plan only mentions 'hex list' without specifying prefix handling.
+severity: minor
+resolution: 'Parser accepts both bare hex (ddcf99) and prefixed (#ddcf99), normalizes to #rrggbb'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-I5IQ.md
+++ b/tickets/entities/review-responses/RR-I5IQ.md
@@ -1,0 +1,9 @@
+---
+id: RR-I5IQ
+type: review-response
+title: Assignment priority order not specified for small palettes
+finding: 'With fewer colors than roles (e.g. 8-color palette, 15 roles), semantic and badge roles compete for the same unassigned colors. The plan doesn''t specify priority order. Should be: UI roles first (4), then semantic (4), then badges (7). Within each group, order matters too — should the most constrained roles (specific hue requirements) be assigned before flexible ones.'
+severity: significant
+resolution: 'Assignment order: UI roles (4) → semantic (4) → badges (7). Most constrained hues assigned first within each group.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-X8V0.md
+++ b/tickets/entities/review-responses/RR-X8V0.md
@@ -1,0 +1,9 @@
+---
+id: RR-X8V0
+type: review-response
+title: Use explicit role selection instead of browser focus for swatch assignment
+finding: The plan says 'click a swatch to assign to the focused role' but clicking a swatch steals browser focus from the input. Use an explicit 'selectedRole' ref — user clicks a role label to select it (highlighted border), then clicks a swatch to assign. This is more reliable and clearer than relying on native focus events.
+severity: minor
+resolution: Using explicit selectedRole ref instead of browser focus. Click role label to select, click swatch to assign.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-EPB5.md
+++ b/tickets/entities/tickets/TKT-EPB5.md
@@ -1,0 +1,26 @@
+---
+id: TKT-EPB5
+type: ticket
+title: Add palette import helper with smart color assignment
+kind: enhancement
+priority: medium
+effort: l
+status: done
+---
+
+# Add Palette Import Helper with Smart Color Assignment
+
+## Problem
+
+Setting up a custom palette requires manually picking and assigning 8 theme
+colors + 7 badge colors. Users who find a palette on Lospec or similar sites
+have to manually map each color to a role. This is tedious and error-prone.
+
+## Goal
+
+Provide a palette import flow that:
+1. Accepts a palette in common formats (hex list, GPL, etc.)
+2. Automatically assigns colors to roles using heuristic algorithms
+3. Shows the full imported palette as swatches
+4. Lets users click swatches to assign/reassign individual colors
+5. Produces a good-enough starting point that users can fine-tune

--- a/tickets/relations/TKT-EPB5--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-EPB5--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EPB5
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-EPB5--has-implementation--IMPL-60F8.md
+++ b/tickets/relations/TKT-EPB5--has-implementation--IMPL-60F8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EPB5
+relation: has-implementation
+to: IMPL-60F8
+---

--- a/tickets/relations/TKT-EPB5--has-planning--PLAN-LMC5.md
+++ b/tickets/relations/TKT-EPB5--has-planning--PLAN-LMC5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EPB5
+relation: has-planning
+to: PLAN-LMC5
+---

--- a/tickets/relations/TKT-EPB5--has-review-response--RR-B00A.md
+++ b/tickets/relations/TKT-EPB5--has-review-response--RR-B00A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EPB5
+relation: has-review-response
+to: RR-B00A
+---

--- a/tickets/relations/TKT-EPB5--has-review-response--RR-BPKK.md
+++ b/tickets/relations/TKT-EPB5--has-review-response--RR-BPKK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EPB5
+relation: has-review-response
+to: RR-BPKK
+---

--- a/tickets/relations/TKT-EPB5--has-review-response--RR-I5IQ.md
+++ b/tickets/relations/TKT-EPB5--has-review-response--RR-I5IQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EPB5
+relation: has-review-response
+to: RR-I5IQ
+---

--- a/tickets/relations/TKT-EPB5--has-review-response--RR-X8V0.md
+++ b/tickets/relations/TKT-EPB5--has-review-response--RR-X8V0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EPB5
+relation: has-review-response
+to: RR-X8V0
+---

--- a/tickets/relations/TKT-EPB5--implements--FEAT-4OEJ.md
+++ b/tickets/relations/TKT-EPB5--implements--FEAT-4OEJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EPB5
+relation: implements
+to: FEAT-4OEJ
+---


### PR DESCRIPTION
## Summary

- Add palette import to Settings > Appearance: paste hex list or GIMP Palette (.gpl) text
- Auto-detect format and parse colors with lenient validation
- Smart color assignment algorithm:
  - UI roles: lightness sorting (darkest→base, lightest→surface, most saturated→accent)
  - Semantic roles: circular hue proximity matching (green→success, red→error, etc.)
  - Badge colors: hue matching, may reuse theme colors, gray=lowest saturation
- Imported palette shown as clickable swatches for manual reassignment
- Click a role label to select it, then click a swatch to assign that color
- Pure frontend implementation — no backend changes needed

## Test plan

- [x] 29 unit tests for parsing (hex, GPL, auto-detect), HSL conversion, assignment algorithm
- [x] All 277 frontend tests pass
- [x] TypeScript clean
- [x] Frontend lint clean (no errors)
- [x] Backend tests + lint pass (no changes)
- [x] Frontend builds successfully

Closes TKT-EPB5