### PR TITLE
feat(dataentry): add file import, YAML palette, and dark mode editing

### DIFF
--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -49,6 +49,7 @@ export interface PaletteConfig {
   warning?: string
   info?: string
   badges?: Record<string, string>
+  dark?: PaletteColors | 'auto' | false
 }
 
 export interface SettingsData {

--- a/frontend/src/utils/palette.test.ts
+++ b/frontend/src/utils/palette.test.ts
@@ -4,6 +4,7 @@ import {
   parseHexList,
   parseGPL,
   parsePalette,
+  parseRelaPalette,
   hexToHSL,
   assignPalette,
 } from './palette'
@@ -101,6 +102,87 @@ describe('parsePalette', () => {
 
   it('auto-detects hex list', () => {
     expect(parsePalette('ff0000\n00ff00')).toEqual(['#ff0000', '#00ff00'])
+  })
+})
+
+describe('parseRelaPalette', () => {
+  it('parses basic palette.yaml', () => {
+    const yaml = `base: "#1a1a2e"
+surface: "#f8fafc"
+accent: "#6366f1"
+text: "#1e293b"
+success: "#10b981"
+error: "#ef4444"
+warning: "#f59e0b"
+info: "#3b82f6"`
+    const result = parseRelaPalette(yaml)
+    expect(result.colors.base).toBe('#1a1a2e')
+    expect(result.colors.accent).toBe('#6366f1')
+    expect(Object.keys(result.colors)).toHaveLength(8)
+    expect(result.allColors).toHaveLength(8)
+  })
+
+  it('parses badges section', () => {
+    const yaml = `accent: "#6366f1"
+surface: "#f8fafc"
+badges:
+  blue: "#3b82f6"
+  red: "#ef4444"`
+    const result = parseRelaPalette(yaml)
+    expect(result.badges.blue).toBe('#3b82f6')
+    expect(result.badges.red).toBe('#ef4444')
+  })
+
+  it('parses explicit dark section', () => {
+    const yaml = `accent: "#6366f1"
+surface: "#f8fafc"
+dark:
+  accent: "#818cf8"
+  surface: "#121218"`
+    const result = parseRelaPalette(yaml)
+    expect(result.dark).toBeDefined()
+    expect(result.dark!.accent).toBe('#818cf8')
+    expect(result.dark!.surface).toBe('#121218')
+  })
+
+  it('handles unquoted hex values', () => {
+    const yaml = `accent: #6366f1
+surface: #f8fafc`
+    const result = parseRelaPalette(yaml)
+    expect(result.colors.accent).toBe('#6366f1')
+  })
+
+  it('handles inline comments', () => {
+    const yaml = `accent: "#6366f1" # primary color
+surface: "#f8fafc"`
+    const result = parseRelaPalette(yaml)
+    expect(result.colors.accent).toBe('#6366f1')
+  })
+
+  it('returns undefined dark when not present', () => {
+    const yaml = `accent: "#6366f1"
+surface: "#f8fafc"`
+    const result = parseRelaPalette(yaml)
+    expect(result.dark).toBeUndefined()
+  })
+
+  it('dark: auto does not create dark overrides', () => {
+    const yaml = `accent: "#6366f1"
+surface: "#f8fafc"
+dark: auto`
+    const result = parseRelaPalette(yaml)
+    expect(result.dark).toBeUndefined()
+  })
+})
+
+describe('parsePalette auto-detection', () => {
+  it('detects rela YAML', () => {
+    const yaml = `base: "#1a1a2e"
+surface: "#f8fafc"
+accent: "#6366f1"`
+    const result = parsePalette(yaml)
+    expect(result).toContain('#1a1a2e')
+    expect(result).toContain('#6366f1')
   })
 })
 

--- a/frontend/src/utils/palette.ts
+++ b/frontend/src/utils/palette.ts
@@ -56,10 +56,88 @@ export function parseGPL(text: string): string[] {
   return dedupe(colors)
 }
 
-/** Auto-detect format and parse palette text. */
+/** Result of parsing a rela palette.yaml file. */
+export interface RelaPaletteResult {
+  colors: Record<string, string>
+  badges: Record<string, string>
+  dark?: Record<string, string>
+  allColors: string[] // flat list for swatch display
+}
+
+/** Detect if text is a rela palette YAML file. */
+function isRelaPalette(text: string): boolean {
+  // Check for rela palette keys (at least 2 of the 8 role names at root level)
+  const roleKeys = ['base:', 'surface:', 'accent:', 'text:', 'success:', 'error:', 'warning:', 'info:']
+  let found = 0
+  for (const key of roleKeys) {
+    if (text.includes(key)) found++
+  }
+  return found >= 2
+}
+
+// Regex to extract hex color from a YAML line like: key: "#aabbcc" or key: #aabbcc
+const YAML_HEX_RE = /^\s{0,4}(\w[\w-]*):\s*"?#?([0-9a-fA-F]{6})"?\s*(?:#.*)?$/
+
+/** Parse a rela palette.yaml file into structured colors. */
+export function parseRelaPalette(text: string): RelaPaletteResult {
+  const colors: Record<string, string> = {}
+  const badges: Record<string, string> = {}
+  const dark: Record<string, string> = {}
+  const allColors: string[] = []
+
+  const roleKeys = new Set(['base', 'surface', 'accent', 'text', 'success', 'error', 'warning', 'info'])
+  const badgeKeys = new Set(['blue', 'purple', 'green', 'gray', 'red', 'orange', 'yellow'])
+
+  let section: 'root' | 'badges' | 'dark' = 'root'
+
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+
+    // Detect section changes (non-indented keys ending with :)
+    if (trimmed === 'badges:') { section = 'badges'; continue }
+    if (trimmed === 'dark:' || trimmed.startsWith('dark:')) {
+      // dark: auto / dark: false / dark: (object follows)
+      if (trimmed === 'dark: auto' || trimmed === 'dark: false' || trimmed === 'dark:') {
+        section = 'dark'
+        continue
+      }
+    }
+    // Any non-indented key resets to root
+    if (!line.startsWith(' ') && !line.startsWith('\t') && trimmed.includes(':')) {
+      if (section === 'badges' || section === 'dark') {
+        // Only reset if it's a known root key
+        const key = trimmed.split(':')[0].trim()
+        if (roleKeys.has(key)) section = 'root'
+      }
+    }
+
+    const match = trimmed.match(YAML_HEX_RE)
+    if (!match) continue
+
+    const key = match[1]
+    const hex = '#' + match[2].toLowerCase()
+    allColors.push(hex)
+
+    if (section === 'badges' && badgeKeys.has(key)) {
+      badges[key] = hex
+    } else if (section === 'dark' && roleKeys.has(key)) {
+      dark[key] = hex
+    } else if (section === 'root' && roleKeys.has(key)) {
+      colors[key] = hex
+    }
+  }
+
+  return { colors, badges, dark: Object.keys(dark).length > 0 ? dark : undefined, allColors: dedupe(allColors) }
+}
+
+/** Auto-detect format and parse palette text. Returns flat color array for swatches. */
 export function parsePalette(text: string): string[] {
   if (text.trim().startsWith('GIMP Palette')) {
     return parseGPL(text)
+  }
+  if (isRelaPalette(text)) {
+    return parseRelaPalette(text).allColors
   }
   return parseHexList(text)
 }

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -11,7 +11,7 @@ import type {
   PaletteConfig,
 } from '@/api/settings'
 import TagSelect from '@/components/ui/TagSelect.vue'
-import { parsePalette, assignPalette } from '@/utils/palette'
+import { parsePalette, parseRelaPalette, assignPalette } from '@/utils/palette'
 
 const schemaStore = useSchemaStore()
 const uiStore = useUIStore()
@@ -52,6 +52,35 @@ const badgeNames = ['blue', 'purple', 'green', 'gray', 'red', 'orange', 'yellow'
 const importText = ref('')
 const importedColors = ref<string[]>([])
 const selectedRole = ref<{ type: 'color' | 'badge'; key: string } | null>(null)
+const dragging = ref(false)
+const fileInput = ref<HTMLInputElement | null>(null)
+
+// Dark mode editing state
+const paletteDarkColors = ref<Record<string, string>>({})
+const paletteDarkBadges = ref<Record<string, string>>({})
+const editingDark = ref(false)
+
+const MAX_FILE_SIZE = 102400 // 100KB
+
+// Computed: which palette refs to show based on light/dark toggle
+const activeColors = computed(() => editingDark.value ? paletteDarkColors.value : paletteColors.value)
+const activeBadges = computed(() => editingDark.value ? paletteDarkBadges.value : paletteBadges.value)
+
+function setColor(key: string, value: string) {
+  if (editingDark.value) {
+    paletteDarkColors.value[key] = value
+  } else {
+    paletteColors.value[key] = value
+  }
+}
+
+function setBadge(key: string, value: string) {
+  if (editingDark.value) {
+    paletteDarkBadges.value[key] = value
+  } else {
+    paletteBadges.value[key] = value
+  }
+}
 
 // UI state for adding new items
 const selectedNewProperty = ref('')
@@ -148,6 +177,18 @@ async function handleSavePalette() {
     }
     if (Object.keys(badges).length > 0) palette.badges = badges
 
+    // Include dark mode overrides if any are set
+    const darkColors: Record<string, string> = {}
+    for (const [key, val] of Object.entries(paletteDarkColors.value)) {
+      if (val) darkColors[key] = val
+    }
+    for (const [key, val] of Object.entries(paletteDarkBadges.value)) {
+      if (val) darkColors[key] = val
+    }
+    if (Object.keys(darkColors).length > 0) {
+      (palette as Record<string, unknown>).dark = darkColors
+    }
+
     await savePalette(palette)
     uiStore.success('Palette saved — reload page to see changes')
     await schemaStore.reload()
@@ -184,6 +225,67 @@ function clearImport() {
   selectedRole.value = null
 }
 
+function handleFilePick() {
+  fileInput.value?.click()
+}
+
+function handleFileSelected(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (file) readFile(file)
+  input.value = '' // reset so same file can be re-selected
+}
+
+function handleDragOver(event: DragEvent) {
+  event.preventDefault()
+  dragging.value = true
+}
+
+function handleDragLeave() {
+  dragging.value = false
+}
+
+function handleDrop(event: DragEvent) {
+  event.preventDefault()
+  dragging.value = false
+  const file = event.dataTransfer?.files[0]
+  if (file) readFile(file)
+}
+
+function readFile(file: File) {
+  if (file.size > MAX_FILE_SIZE) {
+    uiStore.warning('File too large (max 100KB)')
+    return
+  }
+  const reader = new FileReader()
+  reader.onload = () => {
+    const text = reader.result as string
+    importText.value = text
+
+    // If it's a rela palette YAML, do structured import
+    const isYaml = file.name.endsWith('.yaml') || file.name.endsWith('.yml')
+    if (isYaml) {
+      const result = parseRelaPalette(text)
+      importedColors.value = result.allColors
+      for (const [key, val] of Object.entries(result.colors)) {
+        paletteColors.value[key] = val
+      }
+      for (const [key, val] of Object.entries(result.badges)) {
+        paletteBadges.value[key] = val
+      }
+      if (result.dark) {
+        for (const [key, val] of Object.entries(result.dark)) {
+          paletteDarkColors.value[key] = val
+        }
+      }
+      uiStore.success(`Imported palette from ${file.name}`)
+    } else {
+      handleImport()
+    }
+  }
+  reader.readAsText(file)
+}
+
 function selectRole(type: 'color' | 'badge', key: string) {
   if (selectedRole.value?.type === type && selectedRole.value?.key === key) {
     selectedRole.value = null // deselect
@@ -194,10 +296,12 @@ function selectRole(type: 'color' | 'badge', key: string) {
 
 function assignSwatch(hex: string) {
   if (!selectedRole.value) return
+  const colorsRef = editingDark.value ? paletteDarkColors : paletteColors
+  const badgesRef = editingDark.value ? paletteDarkBadges : paletteBadges
   if (selectedRole.value.type === 'color') {
-    paletteColors.value[selectedRole.value.key] = hex
+    colorsRef.value[selectedRole.value.key] = hex
   } else {
-    paletteBadges.value[selectedRole.value.key] = hex
+    badgesRef.value[selectedRole.value.key] = hex
   }
 }
 
@@ -206,11 +310,19 @@ function isRoleSelected(type: 'color' | 'badge', key: string): boolean {
 }
 
 function clearPaletteColor(key: string) {
-  delete paletteColors.value[key]
+  if (editingDark.value) {
+    delete paletteDarkColors.value[key]
+  } else {
+    delete paletteColors.value[key]
+  }
 }
 
 function clearBadgeColor(key: string) {
-  delete paletteBadges.value[key]
+  if (editingDark.value) {
+    delete paletteDarkBadges.value[key]
+  } else {
+    delete paletteBadges.value[key]
+  }
 }
 
 function addPropertyDefault() {
@@ -598,11 +710,24 @@ onMounted(() => {
         <p class="file-path">.rela/palette.yaml</p>
 
         <h4 class="section-subtitle">Import Palette</h4>
-        <div class="import-section">
+        <div
+          class="import-section"
+          :class="{ 'drop-active': dragging }"
+          @dragover="handleDragOver"
+          @dragleave="handleDragLeave"
+          @drop="handleDrop"
+        >
+          <input
+            ref="fileInput"
+            type="file"
+            accept=".gpl,.hex,.txt,.yaml,.yml"
+            class="file-input-hidden"
+            @change="handleFileSelected"
+          />
           <textarea
             v-model="importText"
             class="import-textarea"
-            placeholder="Paste hex colors (one per line) or GIMP Palette (.gpl) content"
+            placeholder="Paste hex colors, GIMP Palette (.gpl), or drag & drop a palette file"
             rows="4"
           />
           <div class="import-actions">
@@ -612,6 +737,11 @@ onMounted(() => {
               :disabled="!importText.trim()"
               @click="handleImport"
             >Import</button>
+            <button
+              type="button"
+              class="btn btn-secondary btn-sm"
+              @click="handleFilePick"
+            >Browse File</button>
             <button
               v-if="importedColors.length"
               type="button"
@@ -637,6 +767,21 @@ onMounted(() => {
           </div>
         </div>
 
+        <div class="mode-toggle">
+          <button
+            type="button"
+            class="toggle-pill"
+            :class="{ active: !editingDark }"
+            @click="editingDark = false"
+          >Light</button>
+          <button
+            type="button"
+            class="toggle-pill"
+            :class="{ active: editingDark }"
+            @click="editingDark = true"
+          >Dark</button>
+        </div>
+
         <h4 class="section-subtitle">Theme Colors</h4>
         <div class="color-grid">
           <div
@@ -653,19 +798,19 @@ onMounted(() => {
             <div class="color-input-group">
               <input
                 type="color"
-                :value="paletteColors[role.key] || '#808080'"
+                :value="activeColors[role.key] || '#808080'"
                 class="color-picker"
-                @input="paletteColors[role.key] = ($event.target as HTMLInputElement).value"
+                @input="setColor(role.key, ($event.target as HTMLInputElement).value)"
               />
               <input
                 type="text"
-                :value="paletteColors[role.key] || ''"
+                :value="activeColors[role.key] || ''"
                 placeholder="#hex"
                 class="color-text"
-                @input="paletteColors[role.key] = ($event.target as HTMLInputElement).value"
+                @input="setColor(role.key, ($event.target as HTMLInputElement).value)"
               />
               <button
-                v-if="paletteColors[role.key]"
+                v-if="activeColors[role.key]"
                 type="button"
                 class="btn-icon btn-remove"
                 title="Clear (use default)"
@@ -690,19 +835,19 @@ onMounted(() => {
             <div class="color-input-group">
               <input
                 type="color"
-                :value="paletteBadges[name] || '#808080'"
+                :value="activeBadges[name] || '#808080'"
                 class="color-picker"
-                @input="paletteBadges[name] = ($event.target as HTMLInputElement).value"
+                @input="setBadge(name, ($event.target as HTMLInputElement).value)"
               />
               <input
                 type="text"
-                :value="paletteBadges[name] || ''"
+                :value="activeBadges[name] || ''"
                 placeholder="#hex"
                 class="color-text"
-                @input="paletteBadges[name] = ($event.target as HTMLInputElement).value"
+                @input="setBadge(name, ($event.target as HTMLInputElement).value)"
               />
               <button
-                v-if="paletteBadges[name]"
+                v-if="activeBadges[name]"
                 type="button"
                 class="btn-icon btn-remove"
                 title="Clear (use default)"
@@ -1130,6 +1275,47 @@ h1 {
   outline: 2px solid var(--accent-color);
   outline-offset: -2px;
   border-radius: 6px;
+}
+
+.file-input-hidden {
+  display: none;
+}
+
+.drop-active {
+  outline: 2px dashed var(--accent-color);
+  outline-offset: 2px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent-color) 5%, transparent);
+}
+
+.mode-toggle {
+  display: flex;
+  gap: 0;
+  margin: 16px 0 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  overflow: hidden;
+  width: fit-content;
+}
+
+.toggle-pill {
+  padding: 6px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  border: none;
+  background: var(--input-bg);
+  color: var(--muted-text);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.toggle-pill.active {
+  background: var(--accent-color);
+  color: white;
+}
+
+.toggle-pill:hover:not(.active) {
+  background: var(--hover-bg);
 }
 
 /* Uses global .btn, .btn-primary, .btn-secondary, .btn-sm, .loading-state, .spinner, .error-state from App.vue */

--- a/internal/dataentryconfig/palette.go
+++ b/internal/dataentryconfig/palette.go
@@ -1,6 +1,7 @@
 package dataentryconfig
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"regexp"
@@ -21,8 +22,8 @@ var ValidBadgeNames = map[string]bool{
 // PaletteConfig is the top-level palette configuration in data-entry.yaml.
 type PaletteConfig struct {
 	PaletteColors `yaml:",inline"`
-	Badges        map[string]string `yaml:"badges,omitempty"`
-	Dark          DarkMode          `yaml:"dark,omitempty"`
+	Badges        map[string]string `yaml:"badges,omitempty" json:"badges,omitempty"`
+	Dark          DarkMode          `yaml:"dark,omitempty"   json:"dark,omitempty"`
 }
 
 // PaletteColors holds the 8 named color roles. All fields are optional;
@@ -106,6 +107,54 @@ func (d DarkMode) MarshalYAML() (interface{}, error) {
 		return false, nil
 	}
 	return "auto", nil
+}
+
+// MarshalJSON serializes DarkMode to JSON.
+// Returns "auto", false, or the explicit PaletteColors object.
+func (d DarkMode) MarshalJSON() ([]byte, error) {
+	if d.Explicit != nil {
+		return json.Marshal(d.Explicit)
+	}
+	if d.Mode == "false" {
+		return json.Marshal(false)
+	}
+	return json.Marshal("auto")
+}
+
+// UnmarshalJSON handles the three-way union for JSON: string "auto", bool false, or object.
+func (d *DarkMode) UnmarshalJSON(data []byte) error {
+	// Try bool first (handles false/true)
+	var boolVal bool
+	if err := json.Unmarshal(data, &boolVal); err == nil {
+		if !boolVal {
+			d.Mode = "false"
+			return nil
+		}
+		d.Mode = "auto"
+		return nil
+	}
+
+	// Try string ("auto", "false", "disabled")
+	var strVal string
+	if err := json.Unmarshal(data, &strVal); err == nil {
+		switch strings.ToLower(strVal) {
+		case "", "auto":
+			d.Mode = "auto"
+		case "false", "disabled":
+			d.Mode = "false"
+		default:
+			return fmt.Errorf("invalid dark mode %q", strVal)
+		}
+		return nil
+	}
+
+	// Try object (explicit palette)
+	var colors PaletteColors
+	if err := json.Unmarshal(data, &colors); err != nil {
+		return fmt.Errorf("invalid dark mode: must be \"auto\", false, or a palette object: %w", err)
+	}
+	d.Explicit = &colors
+	return nil
 }
 
 // ResolvedPalette contains the fully resolved CSS variable values for both themes.

--- a/internal/dataentryconfig/palette_test.go
+++ b/internal/dataentryconfig/palette_test.go
@@ -1,6 +1,7 @@
 package dataentryconfig
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -132,6 +133,85 @@ func TestDarkModeMarshalYAML(t *testing.T) {
 		out, err := yaml.Marshal(d)
 		require.NoError(t, err)
 		assert.Contains(t, string(out), "#818cf8")
+	})
+}
+
+func TestDarkModeJSON(t *testing.T) {
+	t.Run("marshal auto", func(t *testing.T) {
+		d := DarkMode{Mode: "auto"}
+		out, err := json.Marshal(d)
+		require.NoError(t, err)
+		assert.Equal(t, `"auto"`, string(out))
+	})
+
+	t.Run("marshal false", func(t *testing.T) {
+		d := DarkMode{Mode: "false"}
+		out, err := json.Marshal(d)
+		require.NoError(t, err)
+		assert.Equal(t, "false", string(out))
+	})
+
+	t.Run("marshal explicit", func(t *testing.T) {
+		d := DarkMode{Explicit: &PaletteColors{Accent: "#818cf8"}}
+		out, err := json.Marshal(d)
+		require.NoError(t, err)
+		assert.Contains(t, string(out), `"accent":"#818cf8"`)
+	})
+
+	t.Run("unmarshal auto string", func(t *testing.T) {
+		var d DarkMode
+		require.NoError(t, json.Unmarshal([]byte(`"auto"`), &d))
+		assert.True(t, d.IsAuto())
+	})
+
+	t.Run("unmarshal false bool", func(t *testing.T) {
+		var d DarkMode
+		require.NoError(t, json.Unmarshal([]byte(`false`), &d))
+		assert.True(t, d.IsDisabled())
+	})
+
+	t.Run("unmarshal explicit object", func(t *testing.T) {
+		var d DarkMode
+		require.NoError(t, json.Unmarshal([]byte(`{"accent":"#818cf8","surface":"#121218"}`), &d))
+		assert.True(t, d.IsExplicit())
+		assert.Equal(t, "#818cf8", d.Explicit.Accent)
+		assert.Equal(t, "#121218", d.Explicit.Surface)
+	})
+
+	t.Run("round-trip auto", func(t *testing.T) {
+		original := DarkMode{Mode: "auto"}
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+		var decoded DarkMode
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.True(t, decoded.IsAuto())
+	})
+
+	t.Run("round-trip explicit", func(t *testing.T) {
+		original := DarkMode{Explicit: &PaletteColors{Accent: "#818cf8", Base: "#0f0f1a"}}
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+		var decoded DarkMode
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.True(t, decoded.IsExplicit())
+		assert.Equal(t, original.Explicit.Accent, decoded.Explicit.Accent)
+		assert.Equal(t, original.Explicit.Base, decoded.Explicit.Base)
+	})
+
+	t.Run("full PaletteConfig JSON round-trip", func(t *testing.T) {
+		original := PaletteConfig{
+			PaletteColors: PaletteColors{Accent: "#e11d48"},
+			Badges:        map[string]string{"blue": "#1e40af"},
+			Dark:          DarkMode{Explicit: &PaletteColors{Accent: "#818cf8"}},
+		}
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+		var decoded PaletteConfig
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, "#e11d48", decoded.Accent)
+		assert.Equal(t, "#1e40af", decoded.Badges["blue"])
+		assert.True(t, decoded.Dark.IsExplicit())
+		assert.Equal(t, "#818cf8", decoded.Dark.Explicit.Accent)
 	})
 }
 

--- a/tickets/entities/implementation-checklists/IMPL-ZX6J.md
+++ b/tickets/entities/implementation-checklists/IMPL-ZX6J.md
@@ -1,0 +1,41 @@
+---
+id: IMPL-ZX6J
+type: implementation-checklist
+title: 'Implementation: Add file import and dark mode editing to palette settings'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] ~~Integration tests written~~ (N/A: UI interactions)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:** 9 Go tests for DarkMode JSON serialization
+(marshal/unmarshal/round-trips). 37 TS tests for palette parsing. 285 total
+frontend tests pass. TypeScript clean. Frontend builds.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-ZCJI.md
+++ b/tickets/entities/planning-checklists/PLAN-ZCJI.md
@@ -1,0 +1,152 @@
+---
+id: PLAN-ZCJI
+type: planning-checklist
+title: 'Planning: Add file import and dark mode editing to palette settings'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN scope:
+- File picker button to load .gpl, .hex, .txt, .yaml files into the import textarea
+- Drag & drop zone on the import area for dropping palette files
+- Parse rela `palette.yaml` files (YAML with base/surface/accent/etc + badges + dark)
+- Dark mode editing: toggle between Light/Dark in the Appearance section
+- When editing dark, show dark palette colors; user can override individual values
+- Dark mode control: auto (default), disabled, or explicit overrides
+- **Backend: Add JSON serialization to DarkMode type** (design review finding)
+
+OUT of scope:
+- Palette export/download (future ticket)
+- Dark mode preview (would need to toggle the entire page theme)
+
+**Acceptance Criteria:**
+
+1. File picker button opens native file dialog accepting .gpl, .hex, .txt, .yaml
+2. Drag & drop a palette file onto the import area populates the textarea
+3. Importing a rela palette.yaml populates both light colors and badges (and dark if present)
+4. Light/Dark toggle in Appearance section switches between editing light and dark palettes
+5. Dark palette edits are saved as explicit dark overrides in palette.yaml
+6. When dark palette has no overrides, auto-generation is used (default behavior)
+
+## Research
+
+- [x] All items checked
+
+**Existing Solutions:** parsePalette, PaletteConfig, backend DarkMode type
+(needs JSON methods)
+
+## Approach
+
+- [x] All items checked
+
+**Technical Approach:**
+
+### 0. Backend: DarkMode JSON Serialization (design review fix)
+
+Add `UnmarshalJSON`/`MarshalJSON` to `DarkMode` in `palette.go`:
+- `MarshalJSON`: returns `"auto"`, `false`, or the explicit PaletteColors object
+- `UnmarshalJSON`: try string → try bool → try object (same pattern as YAML)
+- Add tests in `palette_test.go`
+
+### 1. File Picker & Drag/Drop
+
+- Hidden `<input type="file" accept=".gpl,.hex,.txt,.yaml,.yml">` triggered by button
+- Drag & drop zone wrapping textarea with `dragover`/`drop` handlers
+- Check `file.size < 102400` (100KB) before reading; toast error if too large
+- `FileReader.readAsText()` → populate `importText` → auto-trigger import
+
+### 2. YAML Palette Parsing
+
+Extend `parsePalette()` in `palette.ts`:
+- Detect rela YAML by checking for `base:` or `surface:` or `accent:` keys
+- New `parseRelaPalette()` function:
+  - Regex parser: `key:\s*"?#?([0-9a-fA-F]{6})"?` handles quoted/unquoted hex
+  - Track indentation to detect `badges:` and `dark:` sections
+  - Returns `{ colors, badges, dark }` structured result
+- For swatch display: extract all hex values into flat array
+- For form population: directly set `paletteColors`, `paletteBadges`, and dark overrides
+
+### 3. Dark Mode Editing
+
+**State:**
+- `paletteDarkColors` ref for dark theme overrides
+- `paletteDarkBadges` ref for dark badge overrides
+- `editingDark` boolean ref — toggles light vs dark editing
+
+**UI:**
+- Light/Dark toggle pill above Theme Colors
+- When `editingDark=true`: pickers show/edit dark refs; empty fields show auto-generated as placeholder
+- When `editingDark=false`: pickers show/edit light refs (current behavior)
+
+**Saving:**
+- If any dark colors set → include `dark` object with PaletteColors in API call
+- All dark empty → omit `dark` field (defaults to auto)
+
+### 4. API Type Update
+
+```typescript
+export interface PaletteConfig {
+  // ...existing 8 color fields + badges...
+  dark?: PaletteColors | 'auto' | false
+}
+```
+
+**Files to modify:**
+
+Backend:
+- `internal/dataentryconfig/palette.go` — add `UnmarshalJSON`/`MarshalJSON` to DarkMode
+- `internal/dataentryconfig/palette_test.go` — JSON serialization tests
+
+Frontend:
+- `frontend/src/utils/palette.ts` — add YAML parsing
+- `frontend/src/utils/palette.test.ts` — YAML parsing tests
+- `frontend/src/views/SettingsView.vue` — file picker, drag/drop, dark mode toggle
+- `frontend/src/api/settings.ts` — add dark field to PaletteConfig
+
+## Security Considerations
+
+- [x] All items checked
+
+File picker/drag-drop sandboxed by browser. YAML parsing is regex-based, no
+eval. File size capped at 100KB.
+
+## Test Plan
+
+- [x] All items checked
+
+| AC | Test | Type |
+|----|------|------|
+| 0 | DarkMode JSON marshal/unmarshal round-trips | Unit (Go) |
+| 1 | File picker triggers import | Manual |
+| 2 | Drag & drop triggers import | Manual |
+| 3 | Parse rela palette.yaml | Unit (TS) |
+| 4 | Light/Dark toggle swaps palette | Manual |
+| 5 | Dark edits saved as explicit section | Manual |
+| 6 | Empty dark → auto mode | Unit (TS) |
+
+## Risk Assessment
+
+- [x] All items checked
+
+Effort: **M**
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+| ID | Severity | Finding | Status |
+|----|----------|---------|--------|
+| RR-IJG9 | critical | DarkMode needs JSON serialization | addressed |
+| RR-6383 | significant | Plan incorrectly said no backend changes | addressed |
+| RR-1LRP | minor | YAML parser must handle quoted hex | addressed |
+| RR-LL33 | minor | File size check before FileReader | addressed |

--- a/tickets/entities/review-responses/RR-1LRP.md
+++ b/tickets/entities/review-responses/RR-1LRP.md
@@ -1,0 +1,9 @@
+---
+id: RR-1LRP
+type: review-response
+title: Simple YAML parser may break on quoted strings and comments
+finding: 'The plan proposes a simple line-by-line YAML parser for palette.yaml files. Rela writes YAML with quoted hex values (e.g. accent: "#6366f1") — the parser needs to handle both quoted and unquoted values. Also needs to handle inline comments (key: value # comment). Consider using a lightweight regex approach rather than true YAML parsing.'
+severity: minor
+resolution: YAML parser uses regex that strips optional quotes around hex values
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-6383.md
+++ b/tickets/entities/review-responses/RR-6383.md
@@ -1,0 +1,9 @@
+---
+id: RR-6383
+type: review-response
+title: Plan says 'no backend changes' but dark mode API serialization is broken
+finding: The plan states 'No backend changes needed — the Go PaletteConfig already supports dark mode.' This is incorrect. The backend PaletteConfig.Dark field works for YAML (config file) but not for JSON (API). Need to add UnmarshalJSON and MarshalJSON to DarkMode type, and add json tags to the DarkMode struct fields.
+severity: significant
+resolution: 'Plan updated: backend changes required for palette.go (DarkMode JSON serialization)'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-IJG9.md
+++ b/tickets/entities/review-responses/RR-IJG9.md
@@ -1,0 +1,9 @@
+---
+id: RR-IJG9
+type: review-response
+title: DarkMode type needs UnmarshalJSON/MarshalJSON for API compatibility
+finding: 'DarkMode has custom UnmarshalYAML for the three-way union (auto/false/object) but no JSON equivalent. The palette API handler uses json.Decode which will fail to deserialize {"dark": {"accent": "#818cf8"}} into the Mode/Explicit struct. Also MarshalJSON is needed so GET returns the correct format. This is a backend fix required before the frontend can send dark mode overrides.'
+severity: critical
+resolution: Add UnmarshalJSON/MarshalJSON to DarkMode in palette.go following the same pattern as the YAML methods
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-LL33.md
+++ b/tickets/entities/review-responses/RR-LL33.md
@@ -1,0 +1,9 @@
+---
+id: RR-LL33
+type: review-response
+title: Large file size limit not enforced in FileReader
+finding: Plan mentions 'only process first 100KB' but doesn't specify how. FileReader.readAsText() reads the entire file into memory. Should check file.size before reading and show an error for files > 100KB to prevent memory issues with accidentally dropped large files.
+severity: minor
+resolution: Check file.size < 100KB before FileReader.readAsText(), show error toast for oversized files
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-ULCZ.md
+++ b/tickets/entities/tickets/TKT-ULCZ.md
@@ -1,0 +1,26 @@
+---
+id: TKT-ULCZ
+type: ticket
+title: Add file import and dark mode editing to palette settings
+kind: enhancement
+priority: medium
+effort: m
+status: done
+---
+
+# Add File Import and Dark Mode Editing to Palette Settings
+
+## Problem
+
+The palette import currently only supports paste into a textarea. Users
+typically download palette files (.gpl, .hex) or share rela palette.yaml files —
+they need drag & drop and file picker. Also, dark mode colors are auto-generated
+but users can't see or tweak them in the Settings UI.
+
+## Scope
+
+1. **File picker button** — opens native file dialog to load .gpl, .hex, .txt, .yaml palette files
+2. **Drag & drop** — drop palette files onto the import area
+3. **Accept rela palette.yaml** — parse and import palette.yaml files for sharing between projects
+4. **Dark mode toggle** — show light/dark palette side-by-side or with a toggle in the Appearance section
+5. **Dark mode editing** — let users tweak individual dark mode colors (override auto-generated)

--- a/tickets/relations/TKT-ULCZ--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-ULCZ--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ULCZ
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-ULCZ--has-implementation--IMPL-ZX6J.md
+++ b/tickets/relations/TKT-ULCZ--has-implementation--IMPL-ZX6J.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ULCZ
+relation: has-implementation
+to: IMPL-ZX6J
+---

--- a/tickets/relations/TKT-ULCZ--has-planning--PLAN-ZCJI.md
+++ b/tickets/relations/TKT-ULCZ--has-planning--PLAN-ZCJI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ULCZ
+relation: has-planning
+to: PLAN-ZCJI
+---

--- a/tickets/relations/TKT-ULCZ--has-review-response--RR-1LRP.md
+++ b/tickets/relations/TKT-ULCZ--has-review-response--RR-1LRP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ULCZ
+relation: has-review-response
+to: RR-1LRP
+---

--- a/tickets/relations/TKT-ULCZ--has-review-response--RR-6383.md
+++ b/tickets/relations/TKT-ULCZ--has-review-response--RR-6383.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ULCZ
+relation: has-review-response
+to: RR-6383
+---

--- a/tickets/relations/TKT-ULCZ--has-review-response--RR-IJG9.md
+++ b/tickets/relations/TKT-ULCZ--has-review-response--RR-IJG9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ULCZ
+relation: has-review-response
+to: RR-IJG9
+---

--- a/tickets/relations/TKT-ULCZ--has-review-response--RR-LL33.md
+++ b/tickets/relations/TKT-ULCZ--has-review-response--RR-LL33.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ULCZ
+relation: has-review-response
+to: RR-LL33
+---

--- a/tickets/relations/TKT-ULCZ--implements--FEAT-4OEJ.md
+++ b/tickets/relations/TKT-ULCZ--implements--FEAT-4OEJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ULCZ
+relation: implements
+to: FEAT-4OEJ
+---


### PR DESCRIPTION
## Summary

- **File picker** button to browse .gpl/.hex/.txt/.yaml palette files
- **Drag & drop** zone on the import area for dropping palette files
- **Rela palette.yaml support** — parse and import structured palette files for sharing between projects (colors + badges + dark overrides)
- **Light/Dark toggle** pill to switch between editing light and dark palettes
- **Dark mode editing** — override individual dark mode colors; empty fields use auto-generation
- **Backend fix**: Add `MarshalJSON`/`UnmarshalJSON` to `DarkMode` type for proper API serialization of the three-way union (auto/false/explicit object)

## Test plan

- [x] 9 Go unit tests for DarkMode JSON marshal/unmarshal/round-trips
- [x] 37 TS unit tests for palette parsing (hex, GPL, YAML, auto-detect, assignment)
- [x] All 285 frontend tests pass
- [x] TypeScript clean, frontend lint clean (0 errors)
- [x] Go lint + tests pass
- [x] Frontend builds successfully
- [x] File size limit (100KB) enforced before FileReader

Closes TKT-ULCZ