### PR TITLE
feat(dataentry): add live palette preview and reset button

### DIFF
--- a/frontend/src/utils/palette.ts
+++ b/frontend/src/utils/palette.ts
@@ -176,6 +176,105 @@ export function hexToHSL(hex: string): HSL {
   return { h, s, l }
 }
 
+function hslToHex(h: number, s: number, l: number): string {
+  if (s === 0) {
+    const v = Math.round(l * 255)
+    return rgbToHex(v, v, v)
+  }
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s
+  const p = 2 * l - q
+  const hueToRgb = (t: number) => {
+    const tt = t < 0 ? t + 1 : t > 1 ? t - 1 : t
+    if (tt < 1 / 6) return p + (q - p) * 6 * tt
+    if (tt < 1 / 2) return q
+    if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6
+    return p
+  }
+  return rgbToHex(
+    Math.round(hueToRgb(h + 1 / 3) * 255),
+    Math.round(hueToRgb(h) * 255),
+    Math.round(hueToRgb(h - 1 / 3) * 255),
+  )
+}
+
+function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v))
+}
+
+function mixColors(hex1: string, hex2: string, ratio: number): string {
+  const n1 = normalizeHex(hex1).replace('#', '')
+  const n2 = normalizeHex(hex2).replace('#', '')
+  const r = Math.round(parseInt(n1.slice(0, 2), 16) * (1 - ratio) + parseInt(n2.slice(0, 2), 16) * ratio)
+  const g = Math.round(parseInt(n1.slice(2, 4), 16) * (1 - ratio) + parseInt(n2.slice(2, 4), 16) * ratio)
+  const b = Math.round(parseInt(n1.slice(4, 6), 16) * (1 - ratio) + parseInt(n2.slice(4, 6), 16) * ratio)
+  return rgbToHex(r, g, b)
+}
+
+// Default light colors (must match backend defaults)
+const DEFAULTS = {
+  base: '#1a1a2e', surface: '#f8fafc', accent: '#6366f1', text: '#1e293b',
+  success: '#10b981', error: '#ef4444', warning: '#f59e0b', info: '#3b82f6',
+}
+const DEFAULT_BADGES: Record<string, string> = {
+  blue: '#3b82f6', purple: '#8b5cf6', green: '#22c55e', gray: '#6b7280',
+  red: '#ef4444', orange: '#f97316', yellow: '#eab308',
+}
+
+/**
+ * Derive the full 21-variable CSS map from 8 base colors + 7 badges.
+ * Mirrors the Go deriveTheme() in palette.go.
+ */
+export function deriveTheme(
+  colors: Record<string, string>,
+  badges: Record<string, string>,
+): Record<string, string> {
+  // Fill gaps with defaults
+  const c = { ...DEFAULTS, ...colors }
+  const b = { ...DEFAULT_BADGES, ...badges }
+
+  const surfaceHSL = hexToHSL(c.surface)
+  const textHSL = hexToHSL(c.text)
+  const baseHSL = hexToHSL(c.base)
+
+  const m: Record<string, string> = {
+    '--sidebar-bg': c.base,
+    '--bg-color': c.surface,
+    '--accent-color': c.accent,
+    '--text-color': c.text,
+    '--success-color': c.success,
+    '--error-color': c.error,
+    '--warning-color': c.warning,
+    '--info-color': c.info,
+  }
+
+  // card-bg: lighten surface ~2%
+  m['--card-bg'] = surfaceHSL.l >= 0.98
+    ? c.surface
+    : hslToHex(surfaceHSL.h, surfaceHSL.s, clamp01(surfaceHSL.l + 0.02))
+  m['--input-bg'] = m['--card-bg']
+
+  // hover-bg: darken surface ~3%
+  m['--hover-bg'] = surfaceHSL.l <= 0.03
+    ? c.surface
+    : hslToHex(surfaceHSL.h, surfaceHSL.s, clamp01(surfaceHSL.l - 0.03))
+
+  // border-color: mix surface and text at 15%
+  m['--border-color'] = mixColors(c.surface, c.text, 0.15)
+
+  // muted-text: lighten text 30%
+  m['--muted-text'] = hslToHex(textHSL.h, textHSL.s, clamp01(textHSL.l + 0.30))
+
+  // sidebar-text: high contrast against base
+  m['--sidebar-text'] = baseHSL.l < 0.5 ? '#e8e8e8' : '#1e293b'
+
+  // Badge colors
+  for (const [name, color] of Object.entries(b)) {
+    m[`--badge-${name}`] = color
+  }
+
+  return m
+}
+
 /** Circular hue distance in [0, 0.5] range. */
 function hueDist(h1: number, h2: number): number {
   const d = Math.abs(h1 - h2)

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useSchemaStore, useUIStore } from '@/stores'
 import { getSettings, saveSettings, savePalette } from '@/api'
 import type {
@@ -11,7 +11,7 @@ import type {
   PaletteConfig,
 } from '@/api/settings'
 import TagSelect from '@/components/ui/TagSelect.vue'
-import { parsePalette, parseRelaPalette, assignPalette } from '@/utils/palette'
+import { parsePalette, parseRelaPalette, assignPalette, deriveTheme } from '@/utils/palette'
 
 const schemaStore = useSchemaStore()
 const uiStore = useUIStore()
@@ -65,6 +65,23 @@ const MAX_FILE_SIZE = 102400 // 100KB
 // Computed: which palette refs to show based on light/dark toggle
 const activeColors = computed(() => editingDark.value ? paletteDarkColors.value : paletteColors.value)
 const activeBadges = computed(() => editingDark.value ? paletteDarkBadges.value : paletteBadges.value)
+
+// Map role keys to CSS variable names for looking up auto-generated dark values
+const roleToCSSVar: Record<string, string> = {
+  base: '--sidebar-bg', surface: '--bg-color', accent: '--accent-color', text: '--text-color',
+  success: '--success-color', error: '--error-color', warning: '--warning-color', info: '--info-color',
+}
+const badgeToCSSVar = (name: string) => `--badge-${name}`
+
+/** Get the auto-generated dark value for a role (from resolved palette). */
+function autoDarkColor(key: string): string {
+  const cssVar = roleToCSSVar[key]
+  return cssVar ? (schemaStore.paletteDark[cssVar] || '') : ''
+}
+
+function autoDarkBadge(name: string): string {
+  return schemaStore.paletteDark[badgeToCSSVar(name)] || ''
+}
 
 function setColor(key: string, value: string) {
   if (editingDark.value) {
@@ -190,7 +207,7 @@ async function handleSavePalette() {
     }
 
     await savePalette(palette)
-    uiStore.success('Palette saved — reload page to see changes')
+    uiStore.success('Palette saved')
     await schemaStore.reload()
   } catch (err) {
     uiStore.error(err instanceof Error ? err.message : 'Failed to save palette')
@@ -198,6 +215,57 @@ async function handleSavePalette() {
     savingPalette.value = false
   }
 }
+
+async function handleResetPalette() {
+  // Reload from disk — discard unsaved edits
+  await loadSettings()
+  // Reapply the saved palette from schema store
+  const palette = uiStore.isDark ? schemaStore.paletteDark : schemaStore.paletteLight
+  if (Object.keys(palette).length > 0) {
+    uiStore.applyPalette(palette)
+  } else {
+    uiStore.clearPalette()
+  }
+  uiStore.info('Palette reset to saved state')
+}
+
+/** Build a full CSS variable map from current editing state for live preview.
+ *  Uses deriveTheme to compute all 21 variables including derived ones. */
+function buildPreviewPalette(): Record<string, string> {
+  const src = editingDark.value ? paletteDarkColors.value : paletteColors.value
+  const badgeSrc = editingDark.value ? paletteDarkBadges.value : paletteBadges.value
+
+  // Only build preview if at least one color is set
+  const hasColors = Object.values(src).some(Boolean)
+  const hasBadges = Object.values(badgeSrc).some(Boolean)
+  if (!hasColors && !hasBadges) return {}
+
+  // Derive all 21 CSS variables (8 base + 6 computed + 7 badges)
+  return deriveTheme(src, badgeSrc)
+}
+
+// Live preview: apply palette as user edits colors
+const stopPreviewWatch = watch(
+  [paletteColors, paletteBadges, paletteDarkColors, paletteDarkBadges, editingDark],
+  () => {
+    const preview = buildPreviewPalette()
+    if (Object.keys(preview).length > 0) {
+      uiStore.applyPalette(preview)
+    }
+  },
+  { deep: true },
+)
+
+// On unmount, reapply the saved palette (discard unsaved preview)
+onUnmounted(() => {
+  stopPreviewWatch()
+  const palette = uiStore.isDark ? schemaStore.paletteDark : schemaStore.paletteLight
+  if (Object.keys(palette).length > 0) {
+    uiStore.applyPalette(palette)
+  } else {
+    uiStore.clearPalette()
+  }
+})
 
 function handleImport() {
   const colors = parsePalette(importText.value)
@@ -798,14 +866,14 @@ onMounted(() => {
             <div class="color-input-group">
               <input
                 type="color"
-                :value="activeColors[role.key] || '#808080'"
+                :value="activeColors[role.key] || (editingDark ? autoDarkColor(role.key) : '') || '#808080'"
                 class="color-picker"
                 @input="setColor(role.key, ($event.target as HTMLInputElement).value)"
               />
               <input
                 type="text"
                 :value="activeColors[role.key] || ''"
-                placeholder="#hex"
+                :placeholder="editingDark ? (autoDarkColor(role.key) || 'auto') : '#hex'"
                 class="color-text"
                 @input="setColor(role.key, ($event.target as HTMLInputElement).value)"
               />
@@ -835,14 +903,14 @@ onMounted(() => {
             <div class="color-input-group">
               <input
                 type="color"
-                :value="activeBadges[name] || '#808080'"
+                :value="activeBadges[name] || (editingDark ? autoDarkBadge(name) : '') || '#808080'"
                 class="color-picker"
                 @input="setBadge(name, ($event.target as HTMLInputElement).value)"
               />
               <input
                 type="text"
                 :value="activeBadges[name] || ''"
-                placeholder="#hex"
+                :placeholder="editingDark ? (autoDarkBadge(name) || 'auto') : '#hex'"
                 class="color-text"
                 @input="setBadge(name, ($event.target as HTMLInputElement).value)"
               />
@@ -866,6 +934,11 @@ onMounted(() => {
           >
             {{ savingPalette ? 'Saving...' : 'Save Palette' }}
           </button>
+          <button
+            type="button"
+            class="btn btn-secondary btn-sm"
+            @click="handleResetPalette"
+          >Reset</button>
         </div>
       </div>
 

--- a/tickets/entities/tickets/TKT-BFWP.md
+++ b/tickets/entities/tickets/TKT-BFWP.md
@@ -1,0 +1,16 @@
+---
+id: TKT-BFWP
+type: ticket
+title: Fix palette live preview for derived CSS variables
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+# Fix Palette Live Preview for Derived CSS Variables
+
+Live preview only applied the 8 direct role colors, not the 6 derived variables
+(card-bg, input-bg, hover-bg, border-color, muted-text, sidebar-text). Ported
+deriveTheme() to TypeScript so the preview computes all 21 CSS variables
+client-side. Also added reset button and auto-revert on navigation.

--- a/tickets/relations/TKT-BFWP--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-BFWP--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BFWP
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-BFWP--implements--FEAT-4OEJ.md
+++ b/tickets/relations/TKT-BFWP--implements--FEAT-4OEJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BFWP
+relation: implements
+to: FEAT-4OEJ
+---


### PR DESCRIPTION
## Summary

- **Live preview**: palette colors apply instantly as user edits them in Settings (no save needed to see effect)
- **Reset button**: discards unsaved edits and reloads palette from disk
- **Auto-revert on navigation**: leaving Settings page reverts any unsaved preview changes
- **Dark mode placeholders**: show auto-generated dark values in empty fields when editing dark palette

## Test plan

- [x] Verified via Playwright: accent, surface, base, badge colors all update CSS variables immediately on edit
- [x] Verified: navigating away reverts unsaved changes
- [x] All 285 frontend tests pass
- [x] TypeScript clean, lint clean
- [x] Go lint + tests pass