### PR TITLE
fix(frontend): use configured list after entity delete

### DIFF
--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -195,7 +195,7 @@ async function deleteEntity() {
   try {
     await entitiesStore.remove(props.entityType, props.entityId)
     uiStore.success('Entity deleted successfully')
-    router.push(`/list/${props.entityType}s`)
+    router.push(backTargetAfterDelete())
   } catch (err) {
     uiStore.error('Failed to delete entity')
     console.error(err)
@@ -203,6 +203,18 @@ async function deleteEntity() {
     deleting.value = false
     showDeleteConfirm.value = false
   }
+}
+
+// Determine where to navigate after deleting this entity.
+// Priority:
+//   1. The list we came from (scope navigation)
+//   2. A list configured for this entity type
+//   3. The dashboard
+function backTargetAfterDelete(): string {
+  if (scopeNav.value?.backUrl) return scopeNav.value.backUrl
+  const listId = schemaStore.findListIdForEntityType(props.entityType)
+  if (listId) return `/list/${listId}`
+  return '/'
 }
 
 // Commands
@@ -408,7 +420,7 @@ onMounted(() => loadEntity())
     <div v-else class="error-state">
       <h2>Entity not found</h2>
       <p>{{ entityType }} "{{ entityId }}" could not be found.</p>
-      <router-link :to="`/list/${entityType}s`" class="btn btn-secondary">
+      <router-link :to="backTargetAfterDelete()" class="btn btn-secondary">
         Back to list
       </router-link>
     </div>

--- a/frontend/src/stores/schema.test.ts
+++ b/frontend/src/stores/schema.test.ts
@@ -256,6 +256,14 @@ describe('Schema Store', () => {
       expect(store.getList('nonexistent')).toBeUndefined()
     })
 
+    it('findListIdForEntityType returns the list ID for a given entity type', async () => {
+      const store = useSchemaStore()
+      await store.load()
+
+      expect(store.findListIdForEntityType('task')).toBe('tasks')
+      expect(store.findListIdForEntityType('nonexistent-type')).toBeUndefined()
+    })
+
     it('getView returns view config', async () => {
       const store = useSchemaStore()
       await store.load()

--- a/frontend/src/stores/schema.ts
+++ b/frontend/src/stores/schema.ts
@@ -41,6 +41,14 @@ export const useSchemaStore = defineStore('schema', () => {
   const getRelationType = computed(() => (name: string) => relationTypes.value.get(name))
   const getForm = computed(() => (id: string) => forms.value.get(id))
   const getList = computed(() => (id: string) => lists.value.get(id))
+  // Find the first list ID that shows entities of the given type.
+  // Returns undefined if no list is configured for that type.
+  const findListIdForEntityType = computed(() => (entityType: string) => {
+    for (const [id, cfg] of lists.value.entries()) {
+      if (cfg.entity === entityType) return id
+    }
+    return undefined
+  })
   const getView = computed(() => (id: string) => views.value.get(id))
   const getKanban = computed(() => (id: string) => kanbans.value.get(id))
 
@@ -124,6 +132,7 @@ export const useSchemaStore = defineStore('schema', () => {
     getRelationType,
     getForm,
     getList,
+    findListIdForEntityType,
     getView,
     getKanban,
     entityTypeList,

--- a/tickets/entities/automated-measures/findListIdForEntityType-test.md
+++ b/tickets/entities/automated-measures/findListIdForEntityType-test.md
@@ -1,0 +1,9 @@
+---
+id: findListIdForEntityType-test
+type: automated-measure
+title: findListIdForEntityType getter has unit test
+description: Unit test for the schema store getter used by EntityDetail for post-delete navigation. Guards against regressions that would reintroduce the broken /list/{entityType}s assumption.
+kind: test
+location: frontend/src/stores/schema.test.ts
+status: active
+---

--- a/tickets/entities/bugs/BUG-ZZ84.md
+++ b/tickets/entities/bugs/BUG-ZZ84.md
@@ -1,0 +1,20 @@
+---
+id: BUG-ZZ84
+type: bug
+title: Entity delete navigates to broken /list/{type}s URL
+description: When deleting the last entity of a given type in the data-entry UI, the frontend redirected to /list/${entityType}s which assumes the list ID is the entity type plural. For any project where lists have different names (e.g. PIM uses all_daily_notes for daily-note entities), this shows 'List not found' instead of the expected empty list view.
+priority: medium
+why1: After deleting an entity, EntityDetail.deleteEntity pushed /list/${entityType}s which assumes the list ID matches the entity type plural.
+why2: PIM (and any project where lists are named differently) has lists like all_daily_notes for daily-note entities, so the URL /list/daily-notes doesn't exist and the frontend shows 'List not found'.
+why3: The delete navigation was hardcoded instead of reusing scope navigation info or the schema's list-to-entity-type mapping that was already available via the schema store.
+why4: Frontend components were allowed to hardcode list URLs based on entity type assumptions instead of consulting the schema store, which had no API for that lookup.
+why5: The schema store API grew organically without a clear principle that all cross-references should go through typed getters that would catch missing configurations at lookup time.
+prevention: Added findListIdForEntityType getter to the schema store so any component can look up a list for an entity type. EntityDetail now uses scopeNav.backUrl if available, falls back to the configured list for this entity type, and finally the dashboard. Same fallback applied to the 'entity not found' back link.
+status: done
+---
+
+When deleting the last entity of a given type in the data-entry UI, the frontend
+redirected to `/list/${entityType}s` which assumes the list ID is the entity
+type plural. For any project where lists have different names (e.g. PIM uses
+`all_daily_notes` for `daily-note` entities), this shows "List not found"
+instead of the expected empty list view.

--- a/tickets/relations/BUG-ZZ84--adds-measure--findListIdForEntityType-test.md
+++ b/tickets/relations/BUG-ZZ84--adds-measure--findListIdForEntityType-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZZ84
+relation: adds-measure
+to: findListIdForEntityType-test
+---

--- a/tickets/relations/BUG-ZZ84--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-ZZ84--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZZ84
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-ZZ84--fixes--FEAT-24hp.md
+++ b/tickets/relations/BUG-ZZ84--fixes--FEAT-24hp.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZZ84
+relation: fixes
+to: FEAT-24hp
+---


### PR DESCRIPTION
## Summary
- After deleting an entity, the frontend navigated to \`/list/\${entityType}s\` which assumes the list ID matches the entity type plural. This shows "List not found" in any project where lists are named differently (e.g. PIM uses \`all_daily_notes\` for \`daily-note\` entities).
- Added \`findListIdForEntityType\` getter to the schema store that looks up a list by entity type via the config.
- \`EntityDetail.deleteEntity\` now uses \`scopeNav.backUrl\` if available, falls back to the configured list for this entity type, and finally the dashboard. Same fallback applied to the "entity not found" back link.

## Test plan
- [x] Unit test for \`findListIdForEntityType\` in \`schema.test.ts\`
- [x] Manual puppeteer verification: delete last daily-note in PIM → lands on \`/list/all_daily_notes\` with "No daily-notes found" instead of "List not found"
- [x] BUG-ZZ84 with 5-whys + measure link

## Related
- BUG-ZZ84