### PR TITLE
fix(ci): pin WiX to v6 to avoid OSMF EULA prompt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Install WiX Toolset
         if: matrix.os_name == 'windows'
-        run: dotnet tool install --global wix
+        run: dotnet tool install --global wix --version 6.0.1
 
       - name: Copy icon for MSI
         if: matrix.os_name == 'windows'

--- a/tickets/entities/automated-measures/pin-dotnet-tool-versions.md
+++ b/tickets/entities/automated-measures/pin-dotnet-tool-versions.md
@@ -1,0 +1,9 @@
+---
+id: pin-dotnet-tool-versions
+type: automated-measure
+title: Pin dotnet/global tool versions in release workflow
+description: All `dotnet tool install --global` invocations in the release workflow must pass an explicit `--version` so a silent upstream major bump cannot break a release. WiX is currently pinned to 6.0.1.
+kind: ci
+location: .github/workflows/release.yml
+status: active
+---

--- a/tickets/entities/bugs/BUG-GGSY.md
+++ b/tickets/entities/bugs/BUG-GGSY.md
@@ -1,0 +1,15 @@
+---
+id: BUG-GGSY
+type: bug
+title: v0.9 release blocked by WiX v7 OSMF EULA prompt
+description: 'The v0.9 release pipeline failed at the Windows MSI step with `error WIX7015: You must accept the Open Source Maintenance Fee (OSMF) EULA to use WiX Toolset v7`. The release.yml workflow installed wix as `dotnet tool install --global wix` (unpinned), which now resolves to WiX v7 and refuses to build without an interactive EULA acceptance.'
+priority: high
+effort: xs
+why1: The release workflow installed `wix` as a dotnet tool without a version pin, so a fresh runner picked up WiX v7.
+why2: WiX v7 introduced a new OSMF EULA gate (WIX7015) that blocks `wix build` until the user accepts the license, which is not possible in headless CI.
+why3: We pinned neither the WiX major version nor the dotnet tool version, so any breaking change in the upstream tool reaches release builds immediately.
+why4: There is no policy/convention requiring explicit pinning of build-time toolchain dependencies installed by the release workflow.
+why5: Release-only tooling (only exercised when cutting a tag) lacks the same supply-chain hygiene we apply to compile-time dependencies in go.mod.
+prevention: Pinned `wix` to v6.0.1 in .github/workflows/release.yml so the existing `wix build` invocation keeps working without an EULA prompt. Going forward, all dotnet/global tool installs in workflows should pass an explicit `--version` to avoid silent major-version upgrades.
+status: done
+---

--- a/tickets/relations/BUG-GGSY--adds-measure--pin-dotnet-tool-versions.md
+++ b/tickets/relations/BUG-GGSY--adds-measure--pin-dotnet-tool-versions.md
@@ -1,0 +1,5 @@
+---
+from: BUG-GGSY
+relation: adds-measure
+to: pin-dotnet-tool-versions
+---

--- a/tickets/relations/BUG-GGSY--affects--ci-pipeline.md
+++ b/tickets/relations/BUG-GGSY--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: BUG-GGSY
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/BUG-GGSY--fixes--FEAT-021.md
+++ b/tickets/relations/BUG-GGSY--fixes--FEAT-021.md
@@ -1,0 +1,5 @@
+---
+from: BUG-GGSY
+relation: fixes
+to: FEAT-021
+---


### PR DESCRIPTION
## Summary
- WiX v7 (released recently) requires accepting the Open Source Maintenance Fee (OSMF) EULA, which broke the v0.9 Windows release build with `error WIX7015`.
- Pin `wix` dotnet tool to `6.0.1` so the existing `wix build` command keeps working without prompting.

Failing run: https://github.com/sourcehaven-bv/rela/actions/runs/24079508801/job/70237063805

## Test plan
- [ ] Release workflow Windows MSI step succeeds after retagging v0.9