### PR TITLE
fix(desktop): build Vue frontend before desktop binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,18 @@ jobs:
         with:
           go-version: "1.25"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Build Vue frontend
+        shell: bash
+        run: |
+          cd frontend
+          npm ci
+          npm run build
+
       - name: Install Linux dependencies
         if: matrix.os_name == 'linux'
         run: |

--- a/justfile
+++ b/justfile
@@ -23,13 +23,13 @@ build-server: build-frontend
     CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o {{build_dir}}/rela-server ./cmd/rela-server
 
 # Build the desktop app
-build-desktop:
+build-desktop: build-frontend
     @echo "Building rela-desktop..."
     @mkdir -p {{build_dir}}
     CGO_ENABLED=1 CGO_LDFLAGS="-framework UniformTypeIdentifiers" go build -tags desktop,production -trimpath -ldflags "-s -w" -o {{build_dir}}/rela-desktop ./cmd/rela-desktop
 
 # Build the desktop app with debug/devtools support for E2E testing
-build-desktop-debug:
+build-desktop-debug: build-frontend
     @echo "Building rela-desktop (debug)..."
     @mkdir -p {{build_dir}}
     CGO_ENABLED=1 CGO_LDFLAGS="-framework UniformTypeIdentifiers" go build -tags desktop -o {{build_dir}}/rela-desktop ./cmd/rela-desktop

--- a/tickets/entities/automated-measures/build-desktop-frontend-dep.md
+++ b/tickets/entities/automated-measures/build-desktop-frontend-dep.md
@@ -1,0 +1,9 @@
+---
+id: build-desktop-frontend-dep
+type: automated-measure
+title: build-desktop depends on build-frontend
+description: The just build-desktop and build-desktop-debug recipes depend on build-frontend, and the desktop CI release job builds the Vue SPA before compiling the binary, so the embedded static/v2 directory always contains the SPA.
+kind: ci
+location: justfile, .github/workflows/release.yml
+status: active
+---

--- a/tickets/entities/bugs/BUG-W144.md
+++ b/tickets/entities/bugs/BUG-W144.md
@@ -1,0 +1,14 @@
+---
+id: BUG-W144
+type: bug
+title: Desktop binary ships without Vue SPA assets
+description: rela-desktop showed a directory listing instead of the SPA after picking a project, because the embedded static/v2 directory was missing index.html.
+priority: high
+why1: The desktop binary embeds internal/dataentry/static/v2/ via go:embed, but the directory was empty (or only contained leftover v1 files), so the asset server fell through to a directory listing after a project was loaded.
+why2: The Vue SPA was never built before compiling the desktop binary — the build-desktop just recipe (and the desktop CI release job) did not depend on build-frontend.
+why3: When the desktop build target was added, it was patterned after build-cli (no frontend) instead of build-server (which already depends on build-frontend), so the embed dependency was silently omitted.
+why4: There is no compile-time check that //go:embed targets are non-empty or contain expected files, and no integration test that exercises a packaged desktop binary against a real project.
+why5: Embedded asset pipelines have an implicit dependency from Go code on a sibling build system (npm/vite), and our build orchestration does not encode that dependency consistently across all targets that share the same embed.
+prevention: Any go:embed of a generated directory must be matched by an explicit build-system dependency on the generator. When adding a new build target that imports a package using //go:embed of generated assets, audit existing recipes that embed the same path and copy their generator dependencies. Consider a smoke test that packages and launches the desktop binary against a fixture project.
+status: done
+---

--- a/tickets/relations/BUG-W144--adds-measure--build-desktop-frontend-dep.md
+++ b/tickets/relations/BUG-W144--adds-measure--build-desktop-frontend-dep.md
@@ -1,0 +1,5 @@
+---
+from: BUG-W144
+relation: adds-measure
+to: build-desktop-frontend-dep
+---

--- a/tickets/relations/BUG-W144--affects--ci-pipeline.md
+++ b/tickets/relations/BUG-W144--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: BUG-W144
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/BUG-W144--affects--desktop-app.md
+++ b/tickets/relations/BUG-W144--affects--desktop-app.md
@@ -1,0 +1,5 @@
+---
+from: BUG-W144
+relation: affects
+to: desktop-app
+---

--- a/tickets/relations/BUG-W144--fixes--FEAT-018.md
+++ b/tickets/relations/BUG-W144--fixes--FEAT-018.md
@@ -1,0 +1,5 @@
+---
+from: BUG-W144
+relation: fixes
+to: FEAT-018
+---


### PR DESCRIPTION
## Summary
- `build-desktop` did not depend on `build-frontend`, so the embedded `internal/dataentry/static/v2/` was missing `index.html`. After picking a project, the asset server fell through to a directory listing ("html barf").
- Apply the same fix to `.github/workflows/release.yml` so released DMG/MSI/deb/rpm packages include the Vue SPA.

## Test plan
- [x] `just build-frontend && just build-desktop` produces a 28M binary with assets embedded
- [x] `./bin/rela-desktop` launches and loads a project without showing the directory listing
- [ ] CI green