### PR TITLE
fix(cli): surface real project-discovery errors

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -65,7 +65,7 @@ and maintain semantic relationships between them.`,
 		var err error
 		ws, err = workspace.Discover(startDir, script.NewEngine())
 		if err != nil {
-			return fmt.Errorf("no project found: run 'rela init' to create one")
+			return wrapDiscoverError(err)
 		}
 
 		// Convenience aliases for read-only commands
@@ -107,6 +107,18 @@ func init() {
 			fmt.Printf("rela version %s\n", Version)
 		},
 	})
+}
+
+// wrapDiscoverError translates errors from workspace.Discover into user-facing
+// messages. Only the "no metamodel.yaml found" case (errors.ErrNoProject) gets
+// the "run 'rela init'" hint; all other failures (parse errors, permission
+// denied, corrupt cache, pending migration, etc.) are surfaced verbatim so the
+// user can see what actually went wrong.
+func wrapDiscoverError(err error) error {
+	if stderrors.Is(err, errors.ErrNoProject) {
+		return fmt.Errorf("no project found: run 'rela init' to create one")
+	}
+	return err
 }
 
 // saveCache saves the graph to the cache file.

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,10 +1,15 @@
 package cli
 
 import (
+	stderrors "errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/Sourcehaven-BV/rela/internal/errors"
 )
 
 // TestNoShorthandConflicts ensures persistent flags don't conflict with local flags.
@@ -54,6 +59,38 @@ func checkCommandForConflicts(t *testing.T, cmd *cobra.Command, parentShorthands
 	for _, subCmd := range cmd.Commands() {
 		checkCommandForConflicts(t, subCmd, combinedShorthands)
 	}
+}
+
+func TestWrapDiscoverError(t *testing.T) {
+	t.Run("no project returns init hint", func(t *testing.T) {
+		wrapped := fmt.Errorf("discover: %w", errors.ErrNoProject)
+		got := wrapDiscoverError(wrapped)
+		if got == nil {
+			t.Fatal("expected error, got nil")
+		}
+		msg := got.Error()
+		if !strings.Contains(msg, "run 'rela init'") {
+			t.Errorf("expected init hint, got: %q", msg)
+		}
+	})
+
+	t.Run("other errors are surfaced verbatim", func(t *testing.T) {
+		underlying := stderrors.New("load metamodel: yaml: line 3: mapping values are not allowed in this context")
+		got := wrapDiscoverError(underlying)
+		if got == nil {
+			t.Fatal("expected error, got nil")
+		}
+		msg := got.Error()
+		if strings.Contains(msg, "run 'rela init'") {
+			t.Errorf("should not suggest init for load failures, got: %q", msg)
+		}
+		if !strings.Contains(msg, "yaml: line 3") {
+			t.Errorf("expected underlying error to be surfaced, got: %q", msg)
+		}
+		if !stderrors.Is(got, underlying) && got.Error() != underlying.Error() {
+			t.Errorf("expected underlying error preserved, got: %v", got)
+		}
+	})
 }
 
 func TestRootCmdProjectFlag(t *testing.T) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -95,8 +96,19 @@ func runCmd(dir string, args ...string) error {
 	}
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	// Strip inherited GIT_* env vars (e.g., GIT_INDEX_FILE set when these
+	// tests run inside a parent `git commit` pre-commit hook) so subprocess
+	// git commands operate on the test repo instead of the parent repo.
+	env := make([]string, 0, len(os.Environ()))
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "GIT_") {
+			continue
+		}
+		env = append(env, e)
+	}
 	// Explicitly set GIT_DIR to prevent git from using parent repos
-	cmd.Env = append(os.Environ(), "GIT_DIR="+filepath.Join(dir, ".git"))
+	env = append(env, "GIT_DIR="+filepath.Join(dir, ".git"))
+	cmd.Env = env
 	return cmd.Run()
 }
 

--- a/tickets/entities/automated-measures/cli-root-error-mapping-tests.md
+++ b/tickets/entities/automated-measures/cli-root-error-mapping-tests.md
@@ -1,0 +1,9 @@
+---
+id: cli-root-error-mapping-tests
+type: automated-measure
+title: Test wrapDiscoverError preserves underlying errors
+description: Unit test verifying that wrapDiscoverError returns the 'run rela init' hint only for errors.ErrNoProject, and surfaces all other errors (e.g. metamodel parse failures) verbatim.
+kind: test
+location: internal/cli/root_test.go:TestWrapDiscoverError
+status: active
+---

--- a/tickets/entities/bugs/BUG-HN0I.md
+++ b/tickets/entities/bugs/BUG-HN0I.md
@@ -1,0 +1,14 @@
+---
+id: BUG-HN0I
+type: bug
+title: CLI hides real project-discovery errors behind generic 'no project found' message
+description: 'The PersistentPreRunE hook in internal/cli/root.go wrapped every error from workspace.Discover as ''no project found: run rela init to create one'', hiding real failures like metamodel parse errors, permission errors, or pending migrations. Fixed by distinguishing errors.ErrNoProject (shows init hint) from other errors (surfaced verbatim).'
+priority: medium
+why1: Every discovery error was mapped to a single hardcoded user-facing string, discarding the underlying cause.
+why2: The hook did not distinguish between genuinely missing projects and other failures.
+why3: No sentinel check was used; the code chose a friendly hint over correctness without fallback for other cases.
+why4: Error messages were treated as a nice-to-have polish item rather than a debugging surface, so helpful hints were added without preserving the underlying cause.
+why5: No coding guideline in the project requires that user-facing error translations fall through to the wrapped error for unexpected failure modes.
+prevention: When translating internal errors to user-facing messages, always check a sentinel with errors.Is before swapping in a generic hint, and fall through to the wrapped error for any other case.
+status: done
+---

--- a/tickets/relations/BUG-HN0I--adds-measure--cli-root-error-mapping-tests.md
+++ b/tickets/relations/BUG-HN0I--adds-measure--cli-root-error-mapping-tests.md
@@ -1,0 +1,5 @@
+---
+from: BUG-HN0I
+relation: adds-measure
+to: cli-root-error-mapping-tests
+---

--- a/tickets/relations/BUG-HN0I--affects--cli-flags.md
+++ b/tickets/relations/BUG-HN0I--affects--cli-flags.md
@@ -1,0 +1,5 @@
+---
+from: BUG-HN0I
+relation: affects
+to: cli-flags
+---

--- a/tickets/relations/BUG-HN0I--fixes--FEAT-001.md
+++ b/tickets/relations/BUG-HN0I--fixes--FEAT-001.md
@@ -1,0 +1,5 @@
+---
+from: BUG-HN0I
+relation: fixes
+to: FEAT-001
+---


### PR DESCRIPTION
## Summary

- `internal/cli/root.go` wrapped every error from `workspace.Discover` as `"no project found: run 'rela init' to create one"`, hiding real failures such as metamodel parse errors, permission denials, or pending migrations.
- Extracted the translation into `wrapDiscoverError`, which only shows the `rela init` hint when the underlying error is `errors.ErrNoProject` (the sentinel returned by `project.Discover` when no `metamodel.yaml` is found walking up the tree). All other errors are surfaced verbatim.
- Added `TestWrapDiscoverError` covering both paths: the sentinel produces the init hint, any other error is passed through unchanged.

## Incidental fix

While running the pre-commit hook, pre-existing tests in `internal/git/git_test.go` failed because `runCmd` inherited `GIT_INDEX_FILE` from the parent `git commit` invocation, causing subprocess `git` commands in test setup to operate on the parent repo's index. The helper now strips inherited `GIT_*` env vars before setting `GIT_DIR`. This was the only way to get the hook green without `--no-verify`.

## Test plan

- [x] `go test ./internal/cli/...`
- [x] `go test ./...`
- [x] `just lint`
- [x] Pre-commit hook passes
- [ ] CI green