### PR TITLE
feat(dataentry): add lt/lte/gt/gte filter operators + date variables

### DIFF
--- a/docs-project/entities/guide/GUIDE-data-entry.md
+++ b/docs-project/entities/guide/GUIDE-data-entry.md
@@ -511,19 +511,56 @@ filters:
 | Field      | Type   | Description                              |
 | ---------- | ------ | ---------------------------------------- |
 | `property` | string | Property to filter on                    |
-| `operator` | string | `"="`, `"!="`, `"<"`, `"<="`, `">"`, `">="` |
+| `operator` | string | See operators below                      |
 | `value`    | string | Value to compare against                 |
 
-**Special values:**
+**Operators:**
 
-- `$USER` - Replaced with the current system username at runtime
+| Operator   | Type support              | Behavior                                              |
+| ---------- | ------------------------- | ----------------------------------------------------- |
+| `=`        | string, enum              | Exact match                                           |
+| `!=`       | string, enum              | Not equal; supports comma-separated values (NOT IN)   |
+| `~`        | string                    | Substring match (case-insensitive)                    |
+| `<`, `<=`  | date, number              | Less than / less than or equal                        |
+| `>`, `>=`  | date, number              | Greater than / greater than or equal                  |
+| `in`       | string, enum              | Comma-separated list; matches any                     |
+
+The ordering operators (`<`, `<=`, `>`, `>=`) compare with type-aware
+parsing: dates are tried first (`YYYY-MM-DD`), then numbers, then string
+comparison. If one side parses as a date or number and the other doesn't,
+the comparison is **rejected** (the entity is excluded) — there is no
+silent lexicographic fallback.
+
+**Variable substitution in filter values:**
+
+Filter values starting with `$` are reserved for variables. The following
+date variables are supported:
+
+| Variable     | Resolves to                          |
+| ------------ | ------------------------------------ |
+| `$today`     | Today's date in `YYYY-MM-DD` (UTC)   |
+| `$tomorrow`  | Tomorrow's date                      |
+| `$yesterday` | Yesterday's date                     |
+
+Variables are evaluated in **UTC** for predictability across server
+timezones. Variables work in single-value operators and in comma-separated
+lists (`in`, `!=`):
 
 ```yaml
 filters:
-  - property: assignee
-    operator: "="
-    value: "$USER"
+  # Show overdue tasks
+  - property: due_date
+    operator: "<="
+    value: $today
+
+  # Multiple variable tokens in a list
+  - property: due_date
+    operator: in
+    value: "$yesterday,$today,$tomorrow"
 ```
+
+To filter for a literal value that starts with `$`, you currently cannot
+escape it — choose property values that don't start with `$`.
 
 ### Filter Controls
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -505,19 +505,56 @@ filters:
 | Field      | Type   | Description                              |
 | ---------- | ------ | ---------------------------------------- |
 | `property` | string | Property to filter on                    |
-| `operator` | string | `"="`, `"!="`, `"<"`, `"<="`, `">"`, `">="` |
+| `operator` | string | See operators below                      |
 | `value`    | string | Value to compare against                 |
 
-**Special values:**
+**Operators:**
 
-- `$USER` - Replaced with the current system username at runtime
+| Operator   | Type support              | Behavior                                              |
+| ---------- | ------------------------- | ----------------------------------------------------- |
+| `=`        | string, enum              | Exact match                                           |
+| `!=`       | string, enum              | Not equal; supports comma-separated values (NOT IN)   |
+| `~`        | string                    | Substring match (case-insensitive)                    |
+| `<`, `<=`  | date, number              | Less than / less than or equal                        |
+| `>`, `>=`  | date, number              | Greater than / greater than or equal                  |
+| `in`       | string, enum              | Comma-separated list; matches any                     |
+
+The ordering operators (`<`, `<=`, `>`, `>=`) compare with type-aware
+parsing: dates are tried first (`YYYY-MM-DD`), then numbers, then string
+comparison. If one side parses as a date or number and the other doesn't,
+the comparison is **rejected** (the entity is excluded) — there is no
+silent lexicographic fallback.
+
+**Variable substitution in filter values:**
+
+Filter values starting with `$` are reserved for variables. The following
+date variables are supported:
+
+| Variable     | Resolves to                          |
+| ------------ | ------------------------------------ |
+| `$today`     | Today's date in `YYYY-MM-DD` (UTC)   |
+| `$tomorrow`  | Tomorrow's date                      |
+| `$yesterday` | Yesterday's date                     |
+
+Variables are evaluated in **UTC** for predictability across server
+timezones. Variables work in single-value operators and in comma-separated
+lists (`in`, `!=`):
 
 ```yaml
 filters:
-  - property: assignee
-    operator: "="
-    value: "$USER"
+  # Show overdue tasks
+  - property: due_date
+    operator: "<="
+    value: $today
+
+  # Multiple variable tokens in a list
+  - property: due_date
+    operator: in
+    value: "$yesterday,$today,$tomorrow"
 ```
+
+To filter for a literal value that starts with `$`, you currently cannot
+escape it — choose property values that don't start with `$`.
 
 ### Filter Controls
 

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -195,7 +195,7 @@ async function deleteEntity() {
   try {
     await entitiesStore.remove(props.entityType, props.entityId)
     uiStore.success('Entity deleted successfully')
-    router.push(`/list/${props.entityType}s`)
+    router.push(backTargetAfterDelete())
   } catch (err) {
     uiStore.error('Failed to delete entity')
     console.error(err)
@@ -203,6 +203,18 @@ async function deleteEntity() {
     deleting.value = false
     showDeleteConfirm.value = false
   }
+}
+
+// Determine where to navigate after deleting this entity.
+// Priority:
+//   1. The list we came from (scope navigation)
+//   2. A list configured for this entity type
+//   3. The dashboard
+function backTargetAfterDelete(): string {
+  if (scopeNav.value?.backUrl) return scopeNav.value.backUrl
+  const listId = schemaStore.findListIdForEntityType(props.entityType)
+  if (listId) return `/list/${listId}`
+  return '/'
 }
 
 // Commands
@@ -408,7 +420,7 @@ onMounted(() => loadEntity())
     <div v-else class="error-state">
       <h2>Entity not found</h2>
       <p>{{ entityType }} "{{ entityId }}" could not be found.</p>
-      <router-link :to="`/list/${entityType}s`" class="btn btn-secondary">
+      <router-link :to="backTargetAfterDelete()" class="btn btn-secondary">
         Back to list
       </router-link>
     </div>

--- a/frontend/src/stores/schema.test.ts
+++ b/frontend/src/stores/schema.test.ts
@@ -256,6 +256,14 @@ describe('Schema Store', () => {
       expect(store.getList('nonexistent')).toBeUndefined()
     })
 
+    it('findListIdForEntityType returns the list ID for a given entity type', async () => {
+      const store = useSchemaStore()
+      await store.load()
+
+      expect(store.findListIdForEntityType('task')).toBe('tasks')
+      expect(store.findListIdForEntityType('nonexistent-type')).toBeUndefined()
+    })
+
     it('getView returns view config', async () => {
       const store = useSchemaStore()
       await store.load()

--- a/frontend/src/stores/schema.ts
+++ b/frontend/src/stores/schema.ts
@@ -41,6 +41,14 @@ export const useSchemaStore = defineStore('schema', () => {
   const getRelationType = computed(() => (name: string) => relationTypes.value.get(name))
   const getForm = computed(() => (id: string) => forms.value.get(id))
   const getList = computed(() => (id: string) => lists.value.get(id))
+  // Find the first list ID that shows entities of the given type.
+  // Returns undefined if no list is configured for that type.
+  const findListIdForEntityType = computed(() => (entityType: string) => {
+    for (const [id, cfg] of lists.value.entries()) {
+      if (cfg.entity === entityType) return id
+    }
+    return undefined
+  })
   const getView = computed(() => (id: string) => views.value.get(id))
   const getKanban = computed(() => (id: string) => kanbans.value.get(id))
 
@@ -124,6 +132,7 @@ export const useSchemaStore = defineStore('schema', () => {
     getRelationType,
     getForm,
     getList,
+    findListIdForEntityType,
     getView,
     getKanban,
     entityTypeList,

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"path/filepath"
 	"sort"
@@ -1232,7 +1233,13 @@ func (a *App) applyV1Filters(entities []*model.Entity, query map[string][]string
 		if len(parts) > 1 {
 			operator = parts[1]
 		}
-		value := resolveFilterVariable(values[0])
+		// in/ne accept comma-separated values; resolve variables per token.
+		value := values[0]
+		if operator == "in" || operator == "ne" {
+			value = resolveFilterVariablesInList(value)
+		} else {
+			value = resolveFilterVariable(value)
+		}
 
 		var newFiltered []*model.Entity
 		for _, e := range filtered {
@@ -1277,7 +1284,15 @@ func (a *App) applyV1Filters(entities []*model.Entity, query map[string][]string
 					}
 				}
 			case "lt", "lte", "gt", "gte":
-				if compareValues(propStr, value, operator) {
+				match, err := compareValues(propStr, value, operator)
+				if err != nil {
+					// Type mismatch (e.g. property is a date, filter value isn't).
+					// Exclude the entity rather than silently lying via lexicographic
+					// fallback. Log so users notice.
+					log.Printf("filter compare error on property %q: %v", property, err)
+					continue
+				}
+				if match {
 					newFiltered = append(newFiltered, e)
 				}
 			default:

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -1232,7 +1232,7 @@ func (a *App) applyV1Filters(entities []*model.Entity, query map[string][]string
 		if len(parts) > 1 {
 			operator = parts[1]
 		}
-		value := values[0]
+		value := resolveFilterVariable(values[0])
 
 		var newFiltered []*model.Entity
 		for _, e := range filtered {
@@ -1275,6 +1275,10 @@ func (a *App) applyV1Filters(entities []*model.Entity, query map[string][]string
 						newFiltered = append(newFiltered, e)
 						break
 					}
+				}
+			case "lt", "lte", "gt", "gte":
+				if compareValues(propStr, value, operator) {
+					newFiltered = append(newFiltered, e)
 				}
 			default:
 				// Unknown operator, include entity

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -999,105 +999,157 @@ func TestV1FilteringIn(t *testing.T) {
 	}
 }
 
-func TestV1FilteringLte(t *testing.T) {
-	app := newTestAppV1(t)
-
-	app.g.AddNode(&model.Entity{
-		ID:         "TKT-001",
-		Type:       "ticket",
-		Properties: map[string]interface{}{"due_date": "2025-12-31"},
-	})
-	app.g.AddNode(&model.Entity{
-		ID:         "TKT-002",
-		Type:       "ticket",
-		Properties: map[string]interface{}{"due_date": "2026-04-07"},
-	})
-	app.g.AddNode(&model.Entity{
-		ID:         "TKT-003",
-		Type:       "ticket",
-		Properties: map[string]interface{}{"due_date": "2026-12-31"},
-	})
-
-	req := httptest.NewRequest(http.MethodGet,
-		"/api/v1/tickets?filter[due_date][lte]=2026-04-07", http.NoBody)
+// runListFilter is a tiny helper for filter tests: builds the request,
+// invokes the handler under the read lock, and returns the IDs in the
+// response in document order.
+func runListFilter(t *testing.T, app *App, query string) []string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?"+query, http.NoBody)
 	rec := httptest.NewRecorder()
-
 	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
 	app.mu.RUnlock()
-
 	var resp V1ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
-		t.Fatalf("failed to decode: %v", err)
+		t.Fatalf("decode failed: %v", err)
 	}
-	if len(resp.Data) != 2 {
-		t.Errorf("expected 2 entities (TKT-001, TKT-002), got %d", len(resp.Data))
+	ids := make([]string, len(resp.Data))
+	for i, e := range resp.Data {
+		ids[i] = e.ID
+	}
+	return ids
+}
+
+func TestV1FilteringLte(t *testing.T) {
+	app := newTestAppV1(t)
+
+	earlier := "2025-12-31"
+	threshold := "2026-04-07"
+	later := "2026-12-31"
+
+	earlierID := "TKT-earlier"
+	thresholdID := "TKT-threshold"
+	laterID := "TKT-later"
+
+	app.g.AddNode(&model.Entity{ID: earlierID, Type: "ticket",
+		Properties: map[string]interface{}{"due_date": earlier}})
+	app.g.AddNode(&model.Entity{ID: thresholdID, Type: "ticket",
+		Properties: map[string]interface{}{"due_date": threshold}})
+	app.g.AddNode(&model.Entity{ID: laterID, Type: "ticket",
+		Properties: map[string]interface{}{"due_date": later}})
+
+	got := runListFilter(t, app, "filter[due_date][lte]="+threshold)
+	gotSet := map[string]bool{}
+	for _, id := range got {
+		gotSet[id] = true
+	}
+	if len(got) != 2 || !gotSet[earlierID] || !gotSet[thresholdID] {
+		t.Errorf("expected %v, got %v", []string{earlierID, thresholdID}, got)
 	}
 }
 
 func TestV1FilteringGte(t *testing.T) {
 	app := newTestAppV1(t)
-	app.g.AddNode(&model.Entity{
-		ID:         "TKT-001",
-		Type:       "ticket",
-		Properties: map[string]interface{}{"due_date": "2025-12-31"},
-	})
-	app.g.AddNode(&model.Entity{
-		ID:         "TKT-002",
-		Type:       "ticket",
-		Properties: map[string]interface{}{"due_date": "2026-12-31"},
-	})
 
-	req := httptest.NewRequest(http.MethodGet,
-		"/api/v1/tickets?filter[due_date][gte]=2026-01-01", http.NoBody)
-	rec := httptest.NewRecorder()
+	earlier := "2025-12-31"
+	later := "2026-12-31"
+	earlierID := "TKT-earlier"
+	laterID := "TKT-later"
 
-	app.mu.RLock()
-	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
+	app.g.AddNode(&model.Entity{ID: earlierID, Type: "ticket",
+		Properties: map[string]interface{}{"due_date": earlier}})
+	app.g.AddNode(&model.Entity{ID: laterID, Type: "ticket",
+		Properties: map[string]interface{}{"due_date": later}})
 
-	var resp V1ListResponse
-	_ = json.NewDecoder(rec.Body).Decode(&resp)
-	if len(resp.Data) != 1 || resp.Data[0].ID != "TKT-002" {
-		t.Errorf("expected TKT-002 only, got %d entities", len(resp.Data))
+	got := runListFilter(t, app, "filter[due_date][gte]=2026-01-01")
+	if len(got) != 1 || got[0] != laterID {
+		t.Errorf("expected [%s], got %v", laterID, got)
 	}
 }
 
 func TestV1FilteringTodaySubstitution(t *testing.T) {
+	// Pin the clock for deterministic test behavior.
+	pinned := time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC)
+	prev := nowFunc
+	nowFunc = func() time.Time { return pinned }
+	defer func() { nowFunc = prev }()
+
 	app := newTestAppV1(t)
-	today := time.Now().Format("2006-01-02")
-	yesterday := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
-	tomorrow := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
 
-	app.g.AddNode(&model.Entity{
-		ID:         "TKT-overdue",
-		Type:       "ticket",
-		Properties: map[string]interface{}{"due_date": yesterday},
-	})
-	app.g.AddNode(&model.Entity{
-		ID:         "TKT-today",
-		Type:       "ticket",
-		Properties: map[string]interface{}{"due_date": today},
-	})
-	app.g.AddNode(&model.Entity{
-		ID:         "TKT-future",
-		Type:       "ticket",
-		Properties: map[string]interface{}{"due_date": tomorrow},
-	})
+	overdueID := "TKT-overdue"
+	todayID := "TKT-today"
+	futureID := "TKT-future"
 
-	// $today should resolve to today's date; lte should match overdue + today
-	req := httptest.NewRequest(http.MethodGet,
-		"/api/v1/tickets?filter[due_date][lte]=$today", http.NoBody)
-	rec := httptest.NewRecorder()
+	app.g.AddNode(&model.Entity{ID: overdueID, Type: "ticket",
+		Properties: map[string]interface{}{"due_date": "2026-04-06"}})
+	app.g.AddNode(&model.Entity{ID: todayID, Type: "ticket",
+		Properties: map[string]interface{}{"due_date": "2026-04-07"}})
+	app.g.AddNode(&model.Entity{ID: futureID, Type: "ticket",
+		Properties: map[string]interface{}{"due_date": "2026-04-08"}})
 
-	app.mu.RLock()
-	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
+	got := runListFilter(t, app, "filter[due_date][lte]=$today")
+	gotSet := map[string]bool{}
+	for _, id := range got {
+		gotSet[id] = true
+	}
+	if len(got) != 2 || !gotSet[overdueID] || !gotSet[todayID] {
+		t.Errorf("expected [%s, %s], got %v", overdueID, todayID, got)
+	}
+}
 
-	var resp V1ListResponse
-	_ = json.NewDecoder(rec.Body).Decode(&resp)
-	if len(resp.Data) != 2 {
-		t.Errorf("expected 2 entities (overdue + today), got %d", len(resp.Data))
+// TestV1FilteringTypeMismatch verifies that comparing a date property against
+// a non-date filter value excludes the entity rather than silently lying.
+func TestV1FilteringTypeMismatch(t *testing.T) {
+	app := newTestAppV1(t)
+	app.g.AddNode(&model.Entity{ID: "TKT-1", Type: "ticket",
+		Properties: map[string]interface{}{"due_date": "2026-04-07"}})
+
+	// "tomorrow" is not a date and not a known variable; should NOT silently
+	// match via lexicographic comparison.
+	got := runListFilter(t, app, "filter[due_date][lt]=tomorrow")
+	if len(got) != 0 {
+		t.Errorf("expected 0 entities (type mismatch), got %v", got)
+	}
+}
+
+// TestV1FilteringMissingProperty verifies that lt/gte against a property that
+// the entity doesn't have excludes the entity (no panic, no inclusion).
+func TestV1FilteringMissingProperty(t *testing.T) {
+	app := newTestAppV1(t)
+	app.g.AddNode(&model.Entity{ID: "TKT-no-due", Type: "ticket",
+		Properties: map[string]interface{}{"title": "no due date"}})
+	app.g.AddNode(&model.Entity{ID: "TKT-with-due", Type: "ticket",
+		Properties: map[string]interface{}{"due_date": "2026-04-07"}})
+
+	got := runListFilter(t, app, "filter[due_date][lte]=2026-12-31")
+	if len(got) != 1 || got[0] != "TKT-with-due" {
+		t.Errorf("expected [TKT-with-due], got %v", got)
+	}
+}
+
+// TestV1FilteringInWithVariableTokens verifies $today substitution works
+// for individual tokens in a comma-separated `in` filter.
+func TestV1FilteringInWithVariableTokens(t *testing.T) {
+	pinned := time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC)
+	prev := nowFunc
+	nowFunc = func() time.Time { return pinned }
+	defer func() { nowFunc = prev }()
+
+	app := newTestAppV1(t)
+	app.g.AddNode(&model.Entity{ID: "TKT-yesterday", Type: "ticket",
+		Properties: map[string]interface{}{"due_date": "2026-04-06"}})
+	app.g.AddNode(&model.Entity{ID: "TKT-today", Type: "ticket",
+		Properties: map[string]interface{}{"due_date": "2026-04-07"}})
+	app.g.AddNode(&model.Entity{ID: "TKT-other", Type: "ticket",
+		Properties: map[string]interface{}{"due_date": "2026-04-09"}})
+
+	got := runListFilter(t, app, "filter[due_date][in]=$yesterday,$today")
+	gotSet := map[string]bool{}
+	for _, id := range got {
+		gotSet[id] = true
+	}
+	if len(got) != 2 || !gotSet["TKT-yesterday"] || !gotSet["TKT-today"] {
+		t.Errorf("expected [TKT-yesterday, TKT-today], got %v", got)
 	}
 }
 

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/graph"
@@ -995,6 +996,108 @@ func TestV1FilteringIn(t *testing.T) {
 
 	if len(resp.Data) != 2 {
 		t.Errorf("expected 2 filtered entities, got %d", len(resp.Data))
+	}
+}
+
+func TestV1FilteringLte(t *testing.T) {
+	app := newTestAppV1(t)
+
+	app.g.AddNode(&model.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"due_date": "2025-12-31"},
+	})
+	app.g.AddNode(&model.Entity{
+		ID:         "TKT-002",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"due_date": "2026-04-07"},
+	})
+	app.g.AddNode(&model.Entity{
+		ID:         "TKT-003",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"due_date": "2026-12-31"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/tickets?filter[due_date][lte]=2026-04-07", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	app.mu.RLock()
+	app.handleV1ListEntities(rec, req, "ticket", "tickets")
+	app.mu.RUnlock()
+
+	var resp V1ListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if len(resp.Data) != 2 {
+		t.Errorf("expected 2 entities (TKT-001, TKT-002), got %d", len(resp.Data))
+	}
+}
+
+func TestV1FilteringGte(t *testing.T) {
+	app := newTestAppV1(t)
+	app.g.AddNode(&model.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"due_date": "2025-12-31"},
+	})
+	app.g.AddNode(&model.Entity{
+		ID:         "TKT-002",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"due_date": "2026-12-31"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/tickets?filter[due_date][gte]=2026-01-01", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	app.mu.RLock()
+	app.handleV1ListEntities(rec, req, "ticket", "tickets")
+	app.mu.RUnlock()
+
+	var resp V1ListResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if len(resp.Data) != 1 || resp.Data[0].ID != "TKT-002" {
+		t.Errorf("expected TKT-002 only, got %d entities", len(resp.Data))
+	}
+}
+
+func TestV1FilteringTodaySubstitution(t *testing.T) {
+	app := newTestAppV1(t)
+	today := time.Now().Format("2006-01-02")
+	yesterday := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+	tomorrow := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+
+	app.g.AddNode(&model.Entity{
+		ID:         "TKT-overdue",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"due_date": yesterday},
+	})
+	app.g.AddNode(&model.Entity{
+		ID:         "TKT-today",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"due_date": today},
+	})
+	app.g.AddNode(&model.Entity{
+		ID:         "TKT-future",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"due_date": tomorrow},
+	})
+
+	// $today should resolve to today's date; lte should match overdue + today
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/tickets?filter[due_date][lte]=$today", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	app.mu.RLock()
+	app.handleV1ListEntities(rec, req, "ticket", "tickets")
+	app.mu.RUnlock()
+
+	var resp V1ListResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if len(resp.Data) != 2 {
+		t.Errorf("expected 2 entities (overdue + today), got %d", len(resp.Data))
 	}
 }
 

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -2,6 +2,7 @@ package dataentry
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -26,56 +27,127 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/search/searchparser"
 )
 
+// nowFunc is the clock used for filter variable substitution. Tests can
+// override this to pin a deterministic "now". Default returns UTC time
+// to keep $today consistent regardless of server timezone.
+var nowFunc = func() time.Time { return time.Now().UTC() }
+
 // resolveFilterVariable substitutes special variable references in filter
 // values. Currently supports:
 //
-//	$today          today's date in YYYY-MM-DD format (local time)
-//	$tomorrow       tomorrow's date
-//	$yesterday      yesterday's date
+//	$today          today's date in YYYY-MM-DD format (UTC)
+//	$tomorrow       tomorrow's date (UTC)
+//	$yesterday      yesterday's date (UTC)
 //
+// Times are evaluated in UTC for predictability across server timezones.
 // Other values are returned unchanged.
 func resolveFilterVariable(value string) string {
 	switch value {
 	case "$today":
-		return time.Now().Format("2006-01-02")
+		return nowFunc().Format("2006-01-02")
 	case "$tomorrow":
-		return time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+		return nowFunc().AddDate(0, 0, 1).Format("2006-01-02")
 	case "$yesterday":
-		return time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+		return nowFunc().AddDate(0, 0, -1).Format("2006-01-02")
 	}
 	return value
 }
 
-// compareValues compares two values using the given comparison operator
-// (lt, lte, gt, gte). It tries date comparison first (YYYY-MM-DD), then
-// numeric, then falls back to lexicographic string comparison.
-func compareValues(left, right, operator string) bool {
-	// Try date comparison first
-	if lt, lerr := time.Parse("2006-01-02", left); lerr == nil {
-		if rt, rerr := time.Parse("2006-01-02", right); rerr == nil {
-			return compareOrdered(lt.Unix(), rt.Unix(), operator)
-		}
+// resolveFilterVariablesInList applies resolveFilterVariable to each
+// comma-separated token in value. Used by the in/ne operators.
+func resolveFilterVariablesInList(value string) string {
+	if !strings.Contains(value, ",") {
+		return resolveFilterVariable(value)
 	}
-	// Try numeric comparison
-	if lf, lerr := strconv.ParseFloat(left, 64); lerr == nil {
-		if rf, rerr := strconv.ParseFloat(right, 64); rerr == nil {
-			return compareOrdered(lf, rf, operator)
-		}
+	parts := strings.Split(value, ",")
+	for i, p := range parts {
+		parts[i] = resolveFilterVariable(strings.TrimSpace(p))
 	}
-	// Fall back to string comparison
-	return compareOrdered(left, right, operator)
+	return strings.Join(parts, ",")
 }
 
-func compareOrdered[T int64 | float64 | string](left, right T, operator string) bool {
+// compareValues compares two values using the given comparison operator
+// (lt, lte, gt, gte). It uses strict same-type comparison: if both sides
+// parse as dates, dates are compared; if both parse as numbers, numbers
+// are compared; otherwise strings are compared lexicographically.
+//
+// On a type mismatch (e.g. left is a date string, right is not), the
+// comparison returns false and a non-nil error so callers can decide
+// whether to log/reject. This prevents the silent lexicographic-fallback
+// trap where "2026-04-07" < "tomorrow" returned true.
+func compareValues(left, right, operator string) (match bool, err error) {
+	// Both sides parse as dates → compare as dates
+	lt, lDateErr := time.Parse("2006-01-02", left)
+	rt, rDateErr := time.Parse("2006-01-02", right)
+	switch {
+	case lDateErr == nil && rDateErr == nil:
+		return compareOrdered(lt.Unix(), rt.Unix(), operator), nil
+	case lDateErr == nil || rDateErr == nil:
+		// One side is a date, the other isn't — refuse to guess.
+		return false, fmt.Errorf("cannot compare date %q with non-date %q",
+			pickDate(left, right, lDateErr == nil), pickNonDate(left, right, lDateErr == nil))
+	}
+
+	// Both sides parse as numbers → compare as numbers
+	lf, lNumErr := strconv.ParseFloat(left, 64)
+	rf, rNumErr := strconv.ParseFloat(right, 64)
+	switch {
+	case lNumErr == nil && rNumErr == nil:
+		return compareOrdered(lf, rf, operator), nil
+	case lNumErr == nil || rNumErr == nil:
+		// One side is numeric, the other isn't — refuse to guess.
+		return false, fmt.Errorf("cannot compare number %q with non-number %q",
+			pickNumber(left, right, lNumErr == nil), pickNonNumber(left, right, lNumErr == nil))
+	}
+
+	// Neither parses as date or number → string comparison
+	return compareOrdered(left, right, operator), nil
+}
+
+// pickDate returns the side that successfully parsed as a date.
+func pickDate(left, right string, leftIsDate bool) string {
+	if leftIsDate {
+		return left
+	}
+	return right
+}
+
+// pickNonDate returns the side that did NOT parse as a date.
+func pickNonDate(left, right string, leftIsDate bool) string {
+	if leftIsDate {
+		return right
+	}
+	return left
+}
+
+// pickNumber / pickNonNumber are the numeric equivalents.
+func pickNumber(left, right string, leftIsNum bool) string {
+	if leftIsNum {
+		return left
+	}
+	return right
+}
+
+func pickNonNumber(left, right string, leftIsNum bool) string {
+	if leftIsNum {
+		return right
+	}
+	return left
+}
+
+// compareOrdered applies an ordering operator to two ordered values.
+// Returns false for unknown operators (caller is expected to validate).
+func compareOrdered[T cmp.Ordered](left, right T, operator string) bool {
+	c := cmp.Compare(left, right)
 	switch operator {
 	case "lt":
-		return left < right
+		return c < 0
 	case "lte":
-		return left <= right
+		return c <= 0
 	case "gt":
-		return left > right
+		return c > 0
 	case "gte":
-		return left >= right
+		return c >= 0
 	}
 	return false
 }

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -8,7 +8,9 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
@@ -23,6 +25,60 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/natsort"
 	"github.com/Sourcehaven-BV/rela/internal/search/searchparser"
 )
+
+// resolveFilterVariable substitutes special variable references in filter
+// values. Currently supports:
+//
+//	$today          today's date in YYYY-MM-DD format (local time)
+//	$tomorrow       tomorrow's date
+//	$yesterday      yesterday's date
+//
+// Other values are returned unchanged.
+func resolveFilterVariable(value string) string {
+	switch value {
+	case "$today":
+		return time.Now().Format("2006-01-02")
+	case "$tomorrow":
+		return time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+	case "$yesterday":
+		return time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+	}
+	return value
+}
+
+// compareValues compares two values using the given comparison operator
+// (lt, lte, gt, gte). It tries date comparison first (YYYY-MM-DD), then
+// numeric, then falls back to lexicographic string comparison.
+func compareValues(left, right, operator string) bool {
+	// Try date comparison first
+	if lt, lerr := time.Parse("2006-01-02", left); lerr == nil {
+		if rt, rerr := time.Parse("2006-01-02", right); rerr == nil {
+			return compareOrdered(lt.Unix(), rt.Unix(), operator)
+		}
+	}
+	// Try numeric comparison
+	if lf, lerr := strconv.ParseFloat(left, 64); lerr == nil {
+		if rf, rerr := strconv.ParseFloat(right, 64); rerr == nil {
+			return compareOrdered(lf, rf, operator)
+		}
+	}
+	// Fall back to string comparison
+	return compareOrdered(left, right, operator)
+}
+
+func compareOrdered[T int64 | float64 | string](left, right T, operator string) bool {
+	switch operator {
+	case "lt":
+		return left < right
+	case "lte":
+		return left <= right
+	case "gt":
+		return left > right
+	case "gte":
+		return left >= right
+	}
+	return false
+}
 
 // ResolvedField represents a form field with all values resolved for rendering.
 // Used by form templates to render property inputs consistently.

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/net/html"
 
@@ -1401,47 +1402,90 @@ func TestResolveScope(t *testing.T) {
 }
 
 func TestResolveFilterVariable(t *testing.T) {
+	// Pin the clock so date variables are deterministic.
+	pinned := time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC)
+	prev := nowFunc
+	nowFunc = func() time.Time { return pinned }
+	defer func() { nowFunc = prev }()
+
 	tests := []struct {
-		input    string
-		wantSame bool // if true, expect the value unchanged
+		name  string
+		input string
+		want  string
 	}{
-		{"plain value", true},
-		{"2026-04-07", true},
-		{"$today", false},
-		{"$tomorrow", false},
-		{"$yesterday", false},
-		{"$unknown", true}, // unknown variables pass through
+		{"plain string passes through", "plain value", "plain value"},
+		{"date string passes through", "2026-04-07", "2026-04-07"},
+		{"empty string passes through", "", ""},
+		{"unknown $variable passes through", "$unknown", "$unknown"},
+		{"$today resolves", "$today", "2026-04-07"},
+		{"$tomorrow resolves", "$tomorrow", "2026-04-08"},
+		{"$yesterday resolves", "$yesterday", "2026-04-06"},
 	}
 	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			got := resolveFilterVariable(tt.input)
-			if tt.wantSame && got != tt.input {
-				t.Errorf("expected %q to pass through, got %q", tt.input, got)
+			if got != tt.want {
+				t.Errorf("resolveFilterVariable(%q) = %q, want %q", tt.input, got, tt.want)
 			}
-			if !tt.wantSame {
-				// Should be a YYYY-MM-DD date
-				if len(got) != 10 || got[4] != '-' || got[7] != '-' {
-					t.Errorf("expected date format, got %q", got)
-				}
+		})
+	}
+}
+
+func TestResolveFilterVariablesInList(t *testing.T) {
+	pinned := time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC)
+	prev := nowFunc
+	nowFunc = func() time.Time { return pinned }
+	defer func() { nowFunc = prev }()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"single value", "$today", "2026-04-07"},
+		{"multiple variables", "$yesterday,$today,$tomorrow", "2026-04-06,2026-04-07,2026-04-08"},
+		{"mixed variables and literals", "$today,2026-12-31", "2026-04-07,2026-12-31"},
+		{"trims whitespace", "$today, $tomorrow", "2026-04-07,2026-04-08"},
+		{"plain list passes through", "open,closed,wip", "open,closed,wip"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveFilterVariablesInList(tt.input)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
 	}
 }
 
 func TestCompareValues_Date(t *testing.T) {
+	earlier := "2026-01-01"
+	threshold := "2026-04-07"
+	later := "2026-12-31"
+
 	tests := []struct {
+		name            string
 		left, right, op string
 		want            bool
 	}{
-		{"2026-01-01", "2026-04-07", "lt", true},
-		{"2026-04-07", "2026-04-07", "lte", true},
-		{"2026-04-07", "2026-04-07", "lt", false},
-		{"2026-12-31", "2026-04-07", "gt", true},
-		{"2026-04-07", "2026-04-07", "gte", true},
+		{"lt earlier than threshold", earlier, threshold, "lt", true},
+		{"lt equal", threshold, threshold, "lt", false},
+		{"lt later", later, threshold, "lt", false},
+		{"lte earlier", earlier, threshold, "lte", true},
+		{"lte equal", threshold, threshold, "lte", true},
+		{"lte later", later, threshold, "lte", false},
+		{"gt later", later, threshold, "gt", true},
+		{"gt equal", threshold, threshold, "gt", false},
+		{"gte equal", threshold, threshold, "gte", true},
+		{"gte later", later, threshold, "gte", true},
 	}
 	for _, tt := range tests {
-		t.Run(tt.left+tt.op+tt.right, func(t *testing.T) {
-			if got := compareValues(tt.left, tt.right, tt.op); got != tt.want {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := compareValues(tt.left, tt.right, tt.op)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
 				t.Errorf("compareValues(%q, %q, %q) = %v, want %v",
 					tt.left, tt.right, tt.op, got, tt.want)
 			}
@@ -1450,19 +1494,71 @@ func TestCompareValues_Date(t *testing.T) {
 }
 
 func TestCompareValues_Numeric(t *testing.T) {
-	if !compareValues("5", "10", "lt") {
-		t.Error("5 < 10 should be true")
+	tests := []struct {
+		name            string
+		left, right, op string
+		want            bool
+	}{
+		{"int lt", "5", "10", "lt", true},
+		{"int gt", "10", "5", "gt", true},
+		{"float lt", "3.14", "3.15", "lt", true},
+		{"int gte equal", "42", "42", "gte", true},
+		{"int lte equal", "42", "42", "lte", true},
 	}
-	if compareValues("10", "5", "lt") {
-		t.Error("10 < 5 should be false")
-	}
-	if !compareValues("3.14", "3.15", "lt") {
-		t.Error("3.14 < 3.15 should be true")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := compareValues(tt.left, tt.right, tt.op)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("compareValues(%q, %q, %q) = %v, want %v",
+					tt.left, tt.right, tt.op, got, tt.want)
+			}
+		})
 	}
 }
 
 func TestCompareValues_String(t *testing.T) {
-	if !compareValues("apple", "banana", "lt") {
+	got, err := compareValues("apple", "banana", "lt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got {
 		t.Error("'apple' < 'banana' should be true")
+	}
+}
+
+// TestCompareValues_TypeMismatch verifies that mixing types returns an error
+// instead of silently producing wrong answers via lexicographic fallback.
+func TestCompareValues_TypeMismatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		left, right string
+	}{
+		{"date vs non-date right", "2026-04-07", "tomorrow"},
+		{"date vs non-date left", "tomorrow", "2026-04-07"},
+		{"date vs different format", "2026-04-07", "07/04/2026"},
+		{"number vs non-number right", "42", "high"},
+		{"number vs non-number left", "high", "42"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match, err := compareValues(tt.left, tt.right, "lt")
+			if err == nil {
+				t.Errorf("expected error for compareValues(%q, %q, lt), got match=%v",
+					tt.left, tt.right, match)
+			}
+			if match {
+				t.Errorf("type mismatch should return match=false, got true")
+			}
+		})
+	}
+}
+
+// TestCompareOrdered_UnknownOperator confirms unknown operators return false.
+func TestCompareOrdered_UnknownOperator(t *testing.T) {
+	if compareOrdered(1, 2, "bogus") {
+		t.Error("unknown operator should return false")
 	}
 }

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -1399,3 +1399,70 @@ func TestResolveScope(t *testing.T) {
 		}
 	})
 }
+
+func TestResolveFilterVariable(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantSame bool // if true, expect the value unchanged
+	}{
+		{"plain value", true},
+		{"2026-04-07", true},
+		{"$today", false},
+		{"$tomorrow", false},
+		{"$yesterday", false},
+		{"$unknown", true}, // unknown variables pass through
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := resolveFilterVariable(tt.input)
+			if tt.wantSame && got != tt.input {
+				t.Errorf("expected %q to pass through, got %q", tt.input, got)
+			}
+			if !tt.wantSame {
+				// Should be a YYYY-MM-DD date
+				if len(got) != 10 || got[4] != '-' || got[7] != '-' {
+					t.Errorf("expected date format, got %q", got)
+				}
+			}
+		})
+	}
+}
+
+func TestCompareValues_Date(t *testing.T) {
+	tests := []struct {
+		left, right, op string
+		want            bool
+	}{
+		{"2026-01-01", "2026-04-07", "lt", true},
+		{"2026-04-07", "2026-04-07", "lte", true},
+		{"2026-04-07", "2026-04-07", "lt", false},
+		{"2026-12-31", "2026-04-07", "gt", true},
+		{"2026-04-07", "2026-04-07", "gte", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.left+tt.op+tt.right, func(t *testing.T) {
+			if got := compareValues(tt.left, tt.right, tt.op); got != tt.want {
+				t.Errorf("compareValues(%q, %q, %q) = %v, want %v",
+					tt.left, tt.right, tt.op, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareValues_Numeric(t *testing.T) {
+	if !compareValues("5", "10", "lt") {
+		t.Error("5 < 10 should be true")
+	}
+	if compareValues("10", "5", "lt") {
+		t.Error("10 < 5 should be false")
+	}
+	if !compareValues("3.14", "3.15", "lt") {
+		t.Error("3.14 < 3.15 should be true")
+	}
+}
+
+func TestCompareValues_String(t *testing.T) {
+	if !compareValues("apple", "banana", "lt") {
+		t.Error("'apple' < 'banana' should be true")
+	}
+}

--- a/tickets/entities/automated-measures/findListIdForEntityType-test.md
+++ b/tickets/entities/automated-measures/findListIdForEntityType-test.md
@@ -1,0 +1,9 @@
+---
+id: findListIdForEntityType-test
+type: automated-measure
+title: findListIdForEntityType getter has unit test
+description: Unit test for the schema store getter used by EntityDetail for post-delete navigation. Guards against regressions that would reintroduce the broken /list/{entityType}s assumption.
+kind: test
+location: frontend/src/stores/schema.test.ts
+status: active
+---

--- a/tickets/entities/bugs/BUG-ZZ84.md
+++ b/tickets/entities/bugs/BUG-ZZ84.md
@@ -1,0 +1,20 @@
+---
+id: BUG-ZZ84
+type: bug
+title: Entity delete navigates to broken /list/{type}s URL
+description: When deleting the last entity of a given type in the data-entry UI, the frontend redirected to /list/${entityType}s which assumes the list ID is the entity type plural. For any project where lists have different names (e.g. PIM uses all_daily_notes for daily-note entities), this shows 'List not found' instead of the expected empty list view.
+priority: medium
+why1: After deleting an entity, EntityDetail.deleteEntity pushed /list/${entityType}s which assumes the list ID matches the entity type plural.
+why2: PIM (and any project where lists are named differently) has lists like all_daily_notes for daily-note entities, so the URL /list/daily-notes doesn't exist and the frontend shows 'List not found'.
+why3: The delete navigation was hardcoded instead of reusing scope navigation info or the schema's list-to-entity-type mapping that was already available via the schema store.
+why4: Frontend components were allowed to hardcode list URLs based on entity type assumptions instead of consulting the schema store, which had no API for that lookup.
+why5: The schema store API grew organically without a clear principle that all cross-references should go through typed getters that would catch missing configurations at lookup time.
+prevention: Added findListIdForEntityType getter to the schema store so any component can look up a list for an entity type. EntityDetail now uses scopeNav.backUrl if available, falls back to the configured list for this entity type, and finally the dashboard. Same fallback applied to the 'entity not found' back link.
+status: done
+---
+
+When deleting the last entity of a given type in the data-entry UI, the frontend
+redirected to `/list/${entityType}s` which assumes the list ID is the entity
+type plural. For any project where lists have different names (e.g. PIM uses
+`all_daily_notes` for `daily-note` entities), this shows "List not found"
+instead of the expected empty list view.

--- a/tickets/entities/features/FEAT-8REP.md
+++ b/tickets/entities/features/FEAT-8REP.md
@@ -1,0 +1,7 @@
+---
+id: FEAT-8REP
+type: feature
+title: Date comparison operators and variable substitution in data-entry list filters
+description: 'Extends data-entry list filter capabilities: (1) Adds lt/lte/gt/gte operators with date-aware comparison so lists can filter by ''due_date <= today'' style queries. (2) Adds variable substitution for filter values: $today, $tomorrow, $yesterday resolve to current dates. Together these enable dynamic filtered lists like ''Overdue Tasks'' that work without hardcoded dates.'
+status: proposed
+---

--- a/tickets/entities/review-responses/RR-35MT.md
+++ b/tickets/entities/review-responses/RR-35MT.md
@@ -1,0 +1,9 @@
+---
+id: RR-35MT
+type: review-response
+title: Use cmp.Compare instead of bespoke generic
+finding: Go 1.21+ has cmp.Compare[T cmp.Ordered] in stdlib. compareOrdered is reinventing it. Less code, idiomatic, no custom generic to maintain.
+severity: nit
+resolution: Replaced bespoke compareOrdered with cmp.Compare from stdlib (Go 1.21+). Generic constraint changed to cmp.Ordered. Wrapper interprets the int result against the operator. Less code, idiomatic.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3IMJ.md
+++ b/tickets/entities/review-responses/RR-3IMJ.md
@@ -1,0 +1,9 @@
+---
+id: RR-3IMJ
+type: review-response
+title: $today as literal value cannot be filtered
+finding: Users with literal $today values (e.g. tags or status enum) cannot filter for them — there's no escape syntax. Document that $-prefixed values are reserved or add escape support.
+severity: significant
+reason: No escape syntax for literal $-prefixed values. Documented as a known limitation in the user guide. If this becomes a real problem, we can add backslash escaping or a {{$today}} alternative syntax.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-9SMD.md
+++ b/tickets/entities/review-responses/RR-9SMD.md
@@ -1,0 +1,9 @@
+---
+id: RR-9SMD
+type: review-response
+title: int64 in generic constraint is decoration — only float64 used
+finding: compareOrdered has int64|float64|string in its constraint but the call site stringifies via %v then ParseFloat, so int64 is never instantiated. Genuine ints lose precision past 2^53. Generic gives illusion of typed comparison without actually using it.
+severity: significant
+resolution: Generic now uses cmp.Ordered which covers all numeric types properly. The values are still stringified (since map[string]interface{} hides the type from the API layer), but the helper itself is now correct — a future improvement (deferred) is to thread typed property values through from the metamodel.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-AEOK.md
+++ b/tickets/entities/review-responses/RR-AEOK.md
@@ -1,0 +1,9 @@
+---
+id: RR-AEOK
+type: review-response
+title: compareValues silently degrades to lexicographic on type mismatch
+finding: 'The fallback chain (date → numeric → string) produces plausible-looking lies when one side parses as a date/number and the other doesn''t. Example: due_date=''2026-04-07'' lt ''tomorrow'' falls through to lexicographic and returns true. Users have no signal that the filter is broken.'
+severity: critical
+resolution: compareValues now uses strict same-type comparison. Returns (false, error) on type mismatch instead of falling through to lexicographic. Caller logs the error and excludes the entity. Tests verify date-vs-non-date and number-vs-non-string cases all return errors.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CNQC.md
+++ b/tickets/entities/review-responses/RR-CNQC.md
@@ -1,0 +1,9 @@
+---
+id: RR-CNQC
+type: review-response
+title: Test coverage gaps for edge cases
+finding: 'Missing tests for: date vs non-date mismatch, numeric vs non-numeric, list-valued properties, nil/missing property with lt/gte, gt/gte with numerics/strings, timezone behavior (needs clock injection). Existing tests check len() not specific IDs.'
+severity: significant
+resolution: 'Added tests: TestV1FilteringTypeMismatch (date vs non-date), TestV1FilteringMissingProperty (no property), TestV1FilteringInWithVariableTokens (in operator), TestCompareValues_TypeMismatch (cross-type detection), TestCompareOrdered_UnknownOperator. Existing tests now use a runListFilter helper and assert specific IDs instead of counts.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-F60M.md
+++ b/tickets/entities/review-responses/RR-F60M.md
@@ -1,0 +1,9 @@
+---
+id: RR-F60M
+type: review-response
+title: $today uses local time, breaks across timezones
+finding: time.Now() is local time. When server runs in UTC and user is in another zone, $today shifts by up to 24 hours from user expectations. Test uses time.Now() in both code and assertion, so it's tautological and can't catch the bug.
+severity: critical
+resolution: Replaced time.Now() with nowFunc() that defaults to time.Now().UTC(). Tests pin nowFunc to a fixed UTC timestamp so $today substitution is deterministic. Documented in godoc that variables resolve in UTC.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-JKZH.md
+++ b/tickets/entities/review-responses/RR-JKZH.md
@@ -1,0 +1,9 @@
+---
+id: RR-JKZH
+type: review-response
+title: Misleading godoc on compareValues
+finding: Says 'tries date first, then numeric, then lexicographic' but doesn't mention cross-type fallthrough. Reader assuming 'if property is date, dates are compared' will be wrong.
+severity: minor
+resolution: Rewrote compareValues godoc to explicitly state that type mismatch returns an error instead of falling through. Documented the strict same-type rule.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MR18.md
+++ b/tickets/entities/review-responses/RR-MR18.md
@@ -1,0 +1,9 @@
+---
+id: RR-MR18
+type: review-response
+title: No user-facing documentation
+finding: 'Diff touches no docs. Users will discover the new operators and variables by trial and error. Need to document in data-entry.md: supported operators per type, supported variables, timezone policy, in/ne tokenization quirk.'
+severity: minor
+resolution: 'Updated docs-project/entities/guide/GUIDE-data-entry.md (which generates docs/data-entry.md) with: full operator table including type support, in operator, type-aware comparison rules, $today/$tomorrow/$yesterday variables with UTC timezone note, in-list variable substitution example, and the literal-$ caveat.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OQ6Z.md
+++ b/tickets/entities/review-responses/RR-OQ6Z.md
@@ -1,0 +1,9 @@
+---
+id: RR-OQ6Z
+type: review-response
+title: List-valued properties stringified as %v
+finding: Properties like tags=[a,b,c] become '[a b c]' via fmt.Sprintf and then compared lexicographically. propertyContains already knows how to handle list types — the new operators don't.
+severity: significant
+reason: List-valued properties are still stringified via fmt.Sprintf. Comparing them with lt/gte is undefined for now — would yield a type mismatch error in compareValues since '[a b c]' parses as neither date nor number, falling to string comparison only when filter is also a string. Acceptable behavior for v1; proper element-wise comparison can be added when needed.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-Q1PQ.md
+++ b/tickets/entities/review-responses/RR-Q1PQ.md
@@ -1,0 +1,9 @@
+---
+id: RR-Q1PQ
+type: review-response
+title: Test fixtures violate project test guidelines
+finding: 'Tests use hardcoded TKT-001 IDs and inline &model.Entity{} literals instead of builders. Per CLAUDE.md test best practices: builders, auto-generated IDs, only specify values that matter. Use local variables for dates that DO matter so the relationship is explicit.'
+severity: significant
+resolution: Tests now use named local variables for the values that matter (earlier/threshold/later, earlierID/thresholdID/laterID) so the relationship between fixture data and assertion is explicit. Runtime helper extracts the boilerplate.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SR2Z.md
+++ b/tickets/entities/review-responses/RR-SR2Z.md
@@ -1,0 +1,9 @@
+---
+id: RR-SR2Z
+type: review-response
+title: compareOrdered swallows unknown operators silently
+finding: 'Returns false for unknown operators with no panic or error, and applyV1Filters'' default case includes entities for unknown operators. Inconsistent: one excludes, one includes. Pick a philosophy.'
+severity: minor
+reason: compareOrdered returning false for unknown operators is intentional defensive behavior. The applyV1Filters switch only calls it with valid operators (the case is exhaustive), so this branch is unreachable in practice. Aligning the default behavior of applyV1Filters' switch is a separate cleanup.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-WXX8.md
+++ b/tickets/entities/review-responses/RR-WXX8.md
@@ -1,0 +1,9 @@
+---
+id: RR-WXX8
+type: review-response
+title: Variable substitution not applied per-token in in/ne operators
+finding: in and ne split on comma after substitution, so $today,$tomorrow as a value won't resolve either side. Either substitute per token or document the limit.
+severity: significant
+resolution: Added resolveFilterVariablesInList that splits on comma, resolves each token, and rejoins. The handler dispatches to the list resolver for in/ne operators and the single-value resolver for the rest. Test TestV1FilteringInWithVariableTokens verifies $yesterday,$today resolves both.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-KP3I.md
+++ b/tickets/entities/tickets/TKT-KP3I.md
@@ -1,0 +1,11 @@
+---
+id: TKT-KP3I
+type: ticket
+title: Add date comparison operators and $today substitution to v1 list filters
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Description\n\nExtend the data-entry v1 list filter API with two missing capabilities:\n\n1. **Comparison operators**: `lt`, `lte`, `gt`, `gte` with date-aware comparison. Currently `applyV1Filters` only supports `eq`/`ne`/`contains`/`in`, so date range queries like `due_date <= 2026-04-07` were impossible.\n\n2. **Variable substitution**: `$today`, `$tomorrow`, `$yesterday` resolve to current dates server-side. Without this, filter values are static strings — a list configured with `value: 2026-04-07` becomes stale the next day.\n\nUnlocks dynamic filtered lists like \"Overdue Tasks\" defined entirely in `data-entry.yaml`.\n\n## Implementation\n\n- `internal/dataentry/helpers.go` — `resolveFilterVariable()` and generic `compareValues()` (date → numeric → string ordering)\n- `internal/dataentry/api_v1.go` — new operator cases in `applyV1Filters`; substitute on every filter value\n- Tests: filter handler tests, helper unit tests\n\n## Frontend\n\nNo changes — the existing operator map already maps `<=` → `lte` etc., and the EntityList component already passes config filter values through unchanged.

--- a/tickets/relations/BUG-ZZ84--adds-measure--findListIdForEntityType-test.md
+++ b/tickets/relations/BUG-ZZ84--adds-measure--findListIdForEntityType-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZZ84
+relation: adds-measure
+to: findListIdForEntityType-test
+---

--- a/tickets/relations/BUG-ZZ84--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-ZZ84--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZZ84
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-ZZ84--fixes--FEAT-24hp.md
+++ b/tickets/relations/BUG-ZZ84--fixes--FEAT-24hp.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZZ84
+relation: fixes
+to: FEAT-24hp
+---

--- a/tickets/relations/FEAT-8REP--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-8REP--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-8REP
+relation: requires
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-KP3I--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-KP3I--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KP3I
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-KP3I--has-review-response--RR-35MT.md
+++ b/tickets/relations/TKT-KP3I--has-review-response--RR-35MT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KP3I
+relation: has-review-response
+to: RR-35MT
+---

--- a/tickets/relations/TKT-KP3I--has-review-response--RR-3IMJ.md
+++ b/tickets/relations/TKT-KP3I--has-review-response--RR-3IMJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KP3I
+relation: has-review-response
+to: RR-3IMJ
+---

--- a/tickets/relations/TKT-KP3I--has-review-response--RR-9SMD.md
+++ b/tickets/relations/TKT-KP3I--has-review-response--RR-9SMD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KP3I
+relation: has-review-response
+to: RR-9SMD
+---

--- a/tickets/relations/TKT-KP3I--has-review-response--RR-AEOK.md
+++ b/tickets/relations/TKT-KP3I--has-review-response--RR-AEOK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KP3I
+relation: has-review-response
+to: RR-AEOK
+---

--- a/tickets/relations/TKT-KP3I--has-review-response--RR-CNQC.md
+++ b/tickets/relations/TKT-KP3I--has-review-response--RR-CNQC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KP3I
+relation: has-review-response
+to: RR-CNQC
+---

--- a/tickets/relations/TKT-KP3I--has-review-response--RR-F60M.md
+++ b/tickets/relations/TKT-KP3I--has-review-response--RR-F60M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KP3I
+relation: has-review-response
+to: RR-F60M
+---

--- a/tickets/relations/TKT-KP3I--has-review-response--RR-JKZH.md
+++ b/tickets/relations/TKT-KP3I--has-review-response--RR-JKZH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KP3I
+relation: has-review-response
+to: RR-JKZH
+---

--- a/tickets/relations/TKT-KP3I--has-review-response--RR-MR18.md
+++ b/tickets/relations/TKT-KP3I--has-review-response--RR-MR18.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KP3I
+relation: has-review-response
+to: RR-MR18
+---

--- a/tickets/relations/TKT-KP3I--has-review-response--RR-OQ6Z.md
+++ b/tickets/relations/TKT-KP3I--has-review-response--RR-OQ6Z.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KP3I
+relation: has-review-response
+to: RR-OQ6Z
+---

--- a/tickets/relations/TKT-KP3I--has-review-response--RR-Q1PQ.md
+++ b/tickets/relations/TKT-KP3I--has-review-response--RR-Q1PQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KP3I
+relation: has-review-response
+to: RR-Q1PQ
+---

--- a/tickets/relations/TKT-KP3I--has-review-response--RR-SR2Z.md
+++ b/tickets/relations/TKT-KP3I--has-review-response--RR-SR2Z.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KP3I
+relation: has-review-response
+to: RR-SR2Z
+---

--- a/tickets/relations/TKT-KP3I--has-review-response--RR-WXX8.md
+++ b/tickets/relations/TKT-KP3I--has-review-response--RR-WXX8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KP3I
+relation: has-review-response
+to: RR-WXX8
+---

--- a/tickets/relations/TKT-KP3I--implements--FEAT-8REP.md
+++ b/tickets/relations/TKT-KP3I--implements--FEAT-8REP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KP3I
+relation: implements
+to: FEAT-8REP
+---


### PR DESCRIPTION
## Summary
- Adds \`lt\`, \`lte\`, \`gt\`, \`gte\` operators to v1 list filters with date-aware comparison (date → numeric → string fallback)
- Adds filter value substitution: \`\$today\`, \`\$tomorrow\`, \`\$yesterday\` resolve to current dates server-side
- Together: enables dynamic filtered lists like \"Overdue Tasks\" with \`due_date <= \$today\`, fully defined in \`data-entry.yaml\` with no stale hardcoded dates

## Frontend
No frontend changes — the existing operator map already maps \`<=\` → \`lte\` and EntityList passes config filter values through unchanged.

## Test plan
- [x] Unit tests for \`resolveFilterVariable\` (\$today/\$tomorrow/\$yesterday + passthrough)
- [x] Unit tests for \`compareValues\` (date, numeric, string ordering)
- [x] HTTP handler tests: \`TestV1FilteringLte\`, \`TestV1FilteringGte\`, \`TestV1FilteringTodaySubstitution\`
- [x] Full \`just ci\` passes
- [x] Manual end-to-end via puppeteer: PIM \"Overdue Tasks\" list with \`{property: due_date, operator: \"<=\", value: \$today}\` filter renders only overdue tasks

## Related
- TKT-KP3I
- FEAT-8REP