### PR TITLE
refactor: adopt log/slog in place of stdlib log

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     # Additional linters - Code Quality
     - bodyclose         # Check whether HTTP response body is closed
     # - copyloopvar     # Detect loop variable copy issues (requires Go 1.22+)
+    - depguard          # Forbid specific imports (enforces log/slog over stdlib log)
     - dupl              # Detect duplicate code
     - durationcheck     # Check for two durations multiplied together
     - errname           # Check that sentinel errors are prefixed with Err
@@ -76,6 +77,28 @@ linters:
     - whitespace        # Check for unnecessary newlines
 
 linters-settings:
+  depguard:
+    rules:
+      # Force the use of log/slog instead of the stdlib "log" package.
+      # The stdlib log package is global mutable state, has no levels, and
+      # is not safe to capture from parallel tests. See the adopt-slog
+      # refactor for the migration rationale.
+      #
+      # Note: `deny.pkg: log` matches `log/slog` too because depguard uses
+      # prefix matching, so we allow `log/slog` explicitly via `allow`.
+      no-stdlib-log:
+        list-mode: lax
+        allow:
+          - "log/slog"
+        deny:
+          - pkg: "log"
+            desc: "use log/slog instead of stdlib log; the stdlib log package is global mutable state with no levels and races with parallel tests"
+        files:
+          # internal/mcp must bridge to mcp-go's WithErrorLogger which
+          # takes a *log.Logger. It builds one via slog.NewLogLogger so
+          # everything still flows through the slog handler.
+          - "!**/internal/mcp/server.go"
+
   dupl:
     threshold: 150
 

--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -156,7 +156,7 @@ func (d *Desktop) LoadProject(dir string) string {
 	// Update preferences with successfully opened project.
 	d.prefs.AddRecentProject(app.ProjectRoot(), app.ProjectName())
 	if saveErr := d.prefs.Save(); saveErr != nil {
-		log.Printf("Warning: could not save preferences: %v", saveErr)
+		slog.Warn("could not save preferences", "error", saveErr)
 	}
 	d.refreshMenu()
 
@@ -470,7 +470,7 @@ func (d *Desktop) CompleteGitHubAuth() string {
 	// Store token
 	d.prefs.GitHubToken = token.AccessToken
 	if err := d.prefs.Save(); err != nil {
-		log.Printf("Warning: could not save token: %v", err)
+		slog.Warn("could not save token", "error", err)
 	}
 
 	d.mu.Lock()
@@ -597,7 +597,7 @@ func (d *Desktop) buildAppMenu() *menu.Menu {
 		recentMenu.AddText("Clear Recent Projects", nil, func(_ *menu.CallbackData) {
 			d.prefs.ClearRecentProjects()
 			if err := d.prefs.Save(); err != nil {
-				log.Printf("Warning: could not save preferences: %v", err)
+				slog.Warn("could not save preferences", "error", err)
 			}
 			d.refreshMenu()
 		})
@@ -639,12 +639,16 @@ func (d *Desktop) refreshMenu() {
 // coverage-ignore: main function - entry point
 func main() {
 	projectDir := flag.String("project", ".", "Path to the rela project directory")
+	verbose := flag.Bool("verbose", false, "Verbose (debug) logging")
+	quiet := flag.Bool("quiet", false, "Quiet (warn-only) logging")
 	flag.Parse()
+
+	configureLogging(*verbose, *quiet)
 
 	// Load desktop preferences.
 	prefs, err := desktop.Load()
 	if err != nil {
-		log.Printf("Warning: could not load preferences: %v", err)
+		slog.Warn("could not load preferences", "error", err)
 		prefs = &desktop.Preferences{}
 	}
 
@@ -654,7 +658,7 @@ func main() {
 	projectToLoad := resolveProjectDir(*projectDir, prefs)
 	if projectToLoad != "" {
 		if errMsg := d.LoadProject(projectToLoad); errMsg != "" {
-			log.Printf("Could not load project from %q: %s", projectToLoad, errMsg)
+			slog.Warn("could not load project", "path", projectToLoad, "error", errMsg)
 		}
 	}
 
@@ -675,8 +679,22 @@ func main() {
 		Bind:      []interface{}{d},
 	})
 	if wailsErr != nil {
-		log.Fatalf("Wails error: %v", wailsErr)
+		slog.Error("wails error", "error", wailsErr)
+		os.Exit(1)
 	}
+}
+
+// configureLogging sets the default slog logger based on verbose/quiet flags.
+func configureLogging(verbose, quiet bool) {
+	level := slog.LevelInfo
+	switch {
+	case verbose:
+		level = slog.LevelDebug
+	case quiet:
+		level = slog.LevelWarn
+	}
+	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+	slog.SetDefault(slog.New(handler))
 }
 
 // resolveProjectDir determines which project directory to load at startup.

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -40,16 +40,22 @@ func main() {
 	var allowedOrigins stringSliceFlag
 	flag.Var(&allowedOrigins, "allowed-origin",
 		"Extra origin permitted to call the API (repeatable). Used for dev servers like Vite on http://localhost:5173.")
+	verbose := flag.Bool("verbose", false, "Verbose (debug) logging")
+	quiet := flag.Bool("quiet", false, "Quiet (warn-only) logging")
 	flag.Parse()
+
+	configureLogging(*verbose, *quiet)
 
 	repo, err := createRepo(*projectDir)
 	if err != nil {
-		log.Fatalf("Failed to initialize repository: %v", err)
+		slog.Error("failed to initialize repository", "error", err)
+		os.Exit(1)
 	}
 
 	ws, err := workspace.New(repo, script.NewEngine())
 	if err != nil {
-		log.Fatalf("Failed to initialize workspace: %v", err)
+		slog.Error("failed to initialize workspace", "error", err)
+		os.Exit(1)
 	}
 
 	app, err := dataentry.NewApp(ws)
@@ -62,16 +68,16 @@ func main() {
 			}
 			os.Exit(1)
 		}
-		log.Fatalf("Failed to initialize: %v", err)
+		slog.Error("failed to initialize", "error", err)
+		os.Exit(1)
 	}
 
 	// Start file watcher for live-reload.
-	// The watcher goroutine is cleaned up on process exit; no explicit stop
-	// is needed since log.Fatal calls os.Exit.
+	// The watcher goroutine is cleaned up on process exit.
 	if err := app.StartWatching(); err != nil {
-		log.Printf("Warning: file watcher not started: %v", err)
+		slog.Warn("file watcher not started", "error", err)
 	} else {
-		log.Println("File watcher started for live-reload")
+		slog.Info("file watcher started for live-reload")
 	}
 
 	addr := net.JoinHostPort(*bind, *port)
@@ -79,7 +85,8 @@ func main() {
 		BindAddress:    addr,
 		AllowedOrigins: allowedOrigins,
 	}); err != nil {
-		log.Fatalf("Invalid security configuration: %v", err)
+		slog.Error("invalid security configuration", "error", err)
+		os.Exit(1)
 	}
 
 	handler := app.NewRouter()
@@ -101,11 +108,27 @@ func main() {
 	}
 
 	if !isLoopbackHost(*bind) {
-		log.Printf("WARNING: rela-server bound to %q, exposing it beyond loopback. "+
-			"See docs/security.md for the threat model.", *bind)
+		slog.Warn("rela-server bound beyond loopback; see docs/security.md for threat model",
+			"bind", *bind)
 	}
-	log.Printf("Starting %s on http://%s", app.Cfg.App.Name, addr)
-	log.Fatal(srv.ListenAndServe())
+	slog.Info("starting server", "name", app.Cfg.App.Name, "addr", "http://"+addr)
+	if err := srv.ListenAndServe(); err != nil {
+		slog.Error("server stopped", "error", err)
+		os.Exit(1)
+	}
+}
+
+// configureLogging sets the default slog logger based on verbose/quiet flags.
+func configureLogging(verbose, quiet bool) {
+	level := slog.LevelInfo
+	switch {
+	case verbose:
+		level = slog.LevelDebug
+	case quiet:
+		level = slog.LevelWarn
+	}
+	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+	slog.SetDefault(slog.New(handler))
 }
 
 // isLoopbackHost reports whether host is the loopback interface.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3,6 +3,7 @@ package cli
 import (
 	stderrors "errors"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -14,6 +15,21 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
+
+// configureLogging sets the default slog logger based on the global
+// --verbose/--quiet flags. Logs are written to stderr so they don't
+// pollute structured CLI output on stdout.
+func configureLogging() {
+	level := slog.LevelInfo
+	switch {
+	case verbose:
+		level = slog.LevelDebug
+	case quiet:
+		level = slog.LevelWarn
+	}
+	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+	slog.SetDefault(slog.New(handler))
+}
 
 var (
 	// Version is set at build time
@@ -44,6 +60,7 @@ and maintain semantic relationships between them.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		configureLogging()
 		// Skip project discovery for commands that don't need it
 		// Note: We check both command name and that it's a direct child of root
 		// to avoid matching subcommands like "template init"

--- a/internal/dataentry/actions.go
+++ b/internal/dataentry/actions.go
@@ -3,7 +3,7 @@ package dataentry
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"log"
+	"log/slog"
 	"net/http"
 	"regexp"
 	"strings"
@@ -81,7 +81,7 @@ func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 	engine := script.NewEngine()
 	resp, err := engine.ExecuteAction(action.Script, ctx, action.Params, actionTimeout)
 	if err != nil {
-		log.Printf("action %q failed [correlation=%s]: %v", id, correlationID, err)
+		slog.Warn("action failed", "action", id, "correlation", correlationID, "error", err)
 		writeV1JSON(w, http.StatusInternalServerError, V1ActionResponse{
 			Error:         "action_failed",
 			Message:       "Action failed",

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"sort"
@@ -1289,7 +1289,7 @@ func (a *App) applyV1Filters(entities []*model.Entity, query map[string][]string
 					// Type mismatch (e.g. property is a date, filter value isn't).
 					// Exclude the entity rather than silently lying via lexicographic
 					// fallback. Log so users notice.
-					log.Printf("filter compare error on property %q: %v", property, err)
+					slog.Warn("filter compare error", "property", property, "error", err)
 					continue
 				}
 				if match {

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -3,7 +3,7 @@ package dataentry
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -117,7 +117,7 @@ func NewApp(ws *workspace.Workspace) (*App, error) {
 		}
 	}
 
-	log.Printf("Loaded %d entities and %d relations", g.NodeCount(), g.EdgeCount())
+	slog.Info("loaded project graph", "entities", g.NodeCount(), "relations", g.EdgeCount())
 
 	// Build style map from config styles
 	styleMap, styledTypes := buildStyleMap(&cfg, meta)
@@ -143,7 +143,7 @@ func NewApp(ws *workspace.Workspace) (*App, error) {
 	// Initialize git ops if enabled and repo is a git repository
 	if cfg.Git != nil && cfg.Git.Enabled && git.IsRepo(ws.Paths().Root) {
 		app.gitOps = git.NewOps(ws.Paths().Root, *cfg.Git)
-		log.Printf("Git sync enabled (mode: %s)", cfg.Git.Mode)
+		slog.Info("git sync enabled", "mode", cfg.Git.Mode)
 	}
 
 	return app, nil

--- a/internal/dataentry/middleware_security.go
+++ b/internal/dataentry/middleware_security.go
@@ -2,7 +2,7 @@ package dataentry
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -156,12 +156,11 @@ func (s *security) reject(w http.ResponseWriter, r *http.Request, reason string)
 	if origin == "" {
 		origin = r.Header.Get("Referer")
 	}
-	log.Printf(
-		"security: blocked rule=%s host=%s origin=%s path=%s",
-		reason,
-		strconv.Quote(truncate(r.Host, 200)),
-		strconv.Quote(truncate(origin, 200)),
-		strconv.Quote(truncate(r.URL.Path, 200)),
+	slog.Warn("security blocked request",
+		"rule", reason,
+		"host", strconv.Quote(truncate(r.Host, 200)),
+		"origin", strconv.Quote(truncate(origin, 200)),
+		"path", strconv.Quote(truncate(r.URL.Path, 200)),
 	)
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -3,7 +3,7 @@ package dataentry
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -95,7 +95,7 @@ func (a *App) StartWatching() error {
 		ExtraDirs:  []string{metamodelDir},
 		OnReload: func(events []workspace.ChangeEvent) {
 			for _, e := range events {
-				log.Printf("File changed: %s (%s)", e.Path, e.Op)
+				slog.Debug("file changed", "path", e.Path, "op", e.Op)
 			}
 			a.onReload(events)
 			a.broker.broadcast("refresh")
@@ -126,7 +126,7 @@ func (a *App) StartGitFetch() (stop func()) {
 			select {
 			case <-ticker.C:
 				if err := gitOps.Fetch(); err != nil {
-					log.Printf("Git fetch error: %v", err)
+					slog.Warn("git fetch error", "error", err)
 				} else {
 					// Broadcast git status update so UI can refresh
 					a.broker.broadcast("git")
@@ -138,7 +138,7 @@ func (a *App) StartGitFetch() (stop func()) {
 		}
 	}()
 
-	log.Printf("Git background fetch started (every %v)", interval)
+	slog.Info("git background fetch started", "interval", interval)
 	return func() {
 		close(done)
 	}
@@ -172,14 +172,14 @@ func (a *App) onReload(events []workspace.ChangeEvent) {
 	if needConfigReload {
 		cfgData, err := a.ws.ReadProjectFile(ConfigFile)
 		if err != nil {
-			log.Printf("Config reload error: %v", err)
+			slog.Warn("config reload error", "error", err)
 		} else {
 			var cfg Config
 			if unmarshalErr := yaml.Unmarshal(cfgData, &cfg); unmarshalErr != nil {
-				log.Printf("Config parse error: %v", unmarshalErr)
+				slog.Warn("config parse error", "error", unmarshalErr)
 			} else {
 				a.Cfg = &cfg
-				log.Println("Config reloaded")
+				slog.Info("config reloaded")
 			}
 		}
 	}

--- a/internal/mcp/convert_test.go
+++ b/internal/mcp/convert_test.go
@@ -3,7 +3,8 @@ package mcp
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -834,7 +835,7 @@ func makeTestServerWithViews(t *testing.T, viewsYAML string) *Server {
 	ws := workspace.NewWithGraph(repo, meta, g)
 	return &Server{
 		ws:     ws,
-		logger: log.New(&strings.Builder{}, "", 0),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2,8 +2,7 @@
 package mcp
 
 import (
-	"log"
-	"os"
+	"log/slog"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -15,16 +14,14 @@ import (
 type Server struct {
 	mcp    *server.MCPServer
 	ws     *workspace.Workspace
-	logger *log.Logger
+	logger *slog.Logger
 }
 
 // NewServer creates a new MCP server for a rela project.
 func NewServer(ws *workspace.Workspace, version string) *Server {
-	logger := log.New(os.Stderr, "[rela-mcp] ", log.LstdFlags)
-
 	s := &Server{
 		ws:     ws,
-		logger: logger,
+		logger: slog.Default().With("component", "mcp"),
 	}
 
 	mcpServer := server.NewMCPServer(
@@ -53,12 +50,12 @@ func NewServer(ws *workspace.Workspace, version string) *Server {
 
 // Serve starts the MCP server on stdio.
 func (s *Server) Serve() error {
-	s.logger.Println("Starting rela MCP server on stdio")
+	s.logger.Info("starting rela MCP server on stdio")
 
 	// Start file watcher via workspace
 	if err := s.ws.StartWatching(workspace.WatchOptions{
 		OnReload: func(_ []workspace.ChangeEvent) {
-			s.logger.Println("Graph re-synced from file changes")
+			s.logger.Info("graph re-synced from file changes")
 			if s.mcp != nil {
 				s.mcp.SendNotificationToAllClients(
 					mcpgo.MethodNotificationResourcesListChanged, nil,
@@ -66,10 +63,13 @@ func (s *Server) Serve() error {
 			}
 		},
 	}); err != nil {
-		s.logger.Printf("Warning: file watcher not started: %v", err)
+		s.logger.Warn("file watcher not started", "error", err)
 	}
 
 	defer s.ws.StopWatching()
 
-	return server.ServeStdio(s.mcp, server.WithErrorLogger(s.logger))
+	// mcp-go's WithErrorLogger expects a stdlib *log.Logger; bridge to slog
+	// so all output flows through the configured slog handler.
+	bridged := slog.NewLogLogger(s.logger.Handler(), slog.LevelError)
+	return server.ServeStdio(s.mcp, server.WithErrorLogger(bridged))
 }

--- a/internal/mcp/tools_entity.go
+++ b/internal/mcp/tools_entity.go
@@ -278,7 +278,7 @@ func (s *Server) handleRenameEntity(
 
 	if !dryRun {
 		if cacheErr := s.ws.SaveCache(); cacheErr != nil {
-			s.logger.Printf("Warning: failed to save cache: %v", cacheErr)
+			s.logger.Warn("failed to save cache", "error", cacheErr)
 		}
 	}
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -3,7 +3,8 @@ package mcp
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"io"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -63,7 +64,7 @@ func makeTestServer(t *testing.T) *Server {
 
 	return &Server{
 		ws:     ws,
-		logger: log.New(&strings.Builder{}, "", 0),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 }
 

--- a/internal/validation/lua.go
+++ b/internal/validation/lua.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -79,7 +79,7 @@ func (e *luaExecutor) validate(
 		var err error
 		code, err = e.loadScript(rule.LuaFile)
 		if err != nil {
-			log.Printf("validation rule %q: %v", rule.Name, err)
+			slog.Warn("validation rule failed to load script", "rule", rule.Name, "error", err)
 			return nil // fail open - skip rule on load error
 		}
 	}
@@ -104,7 +104,7 @@ func (e *luaExecutor) validate(
 	// Compile the code into a function
 	fn, err := ls.LoadString(code)
 	if err != nil {
-		log.Printf("validation rule %q: Lua compile error: %v", rule.Name, err)
+		slog.Warn("validation rule Lua compile error", "rule", rule.Name, "error", err)
 		return nil // fail open - skip rule on compile error
 	}
 
@@ -116,7 +116,7 @@ func (e *luaExecutor) validate(
 	// Push the function and call it with 0 args, expecting 1 return value
 	ls.Push(fn)
 	if err := ls.PCall(0, 1, nil); err != nil {
-		log.Printf("validation rule %q: Lua runtime error: %v", rule.Name, err)
+		slog.Warn("validation rule Lua runtime error", "rule", rule.Name, "error", err)
 		return nil // fail open - skip rule on runtime error
 	}
 
@@ -140,8 +140,8 @@ func (e *luaExecutor) parseReturnValue(
 	// Must be a table
 	tbl, ok := ret.(*golua.LTable)
 	if !ok {
-		log.Printf("validation rule %q: Lua must return nil or table, got %s",
-			rule.Name, ret.Type().String())
+		slog.Warn("validation rule must return nil or table",
+			"rule", rule.Name, "got", ret.Type().String())
 		return nil // fail open
 	}
 
@@ -181,7 +181,7 @@ func (e *luaExecutor) tableToViolation(
 	msgVal := tbl.RawGetString("message")
 	msg, ok := msgVal.(golua.LString)
 	if !ok || msg == "" {
-		log.Printf("validation rule %q: violation table missing 'message' field", rule.Name)
+		slog.Warn("validation rule violation table missing 'message' field", "rule", rule.Name)
 		return nil
 	}
 

--- a/internal/workspace/document.go
+++ b/internal/workspace/document.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
-	"log"
+	"log/slog"
 	"net/url"
 	"os/exec"
 	"regexp"
@@ -118,7 +118,7 @@ func (w *Workspace) doRenderDocument(
 	// hid validation regressions where unsafe IDs caused every render to
 	// re-execute the command.
 	if writeErr := w.WriteCacheFile(cacheFile, []byte(htmlContent)); writeErr != nil {
-		log.Printf("document cache write failed: %v", writeErr)
+		slog.Warn("document cache write failed", "error", writeErr)
 	}
 
 	return &DocumentResult{

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -8,7 +8,7 @@ package workspace
 import (
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"sort"
 	"strings"
 	"sync"
@@ -148,7 +148,7 @@ func New(repo repository.Store, scriptExec ScriptExecutor) (*Workspace, error) {
 	if !needsSync {
 		if cacheErr := repo.LoadCache(g); cacheErr != nil {
 			if errors.Is(cacheErr, repository.ErrCacheVersionMismatch) {
-				log.Printf("Cache outdated, rebuilding: %v", cacheErr)
+				slog.Warn("cache outdated, rebuilding", "error", cacheErr)
 			}
 			needsSync = true
 		}
@@ -159,7 +159,7 @@ func New(repo repository.Store, scriptExec ScriptExecutor) (*Workspace, error) {
 		}
 		// Save the new cache after sync
 		if saveErr := repo.SaveCache(g); saveErr != nil {
-			log.Printf("Warning: failed to save cache: %v", saveErr)
+			slog.Warn("failed to save cache", "error", saveErr)
 		}
 	}
 
@@ -194,11 +194,11 @@ func NewForTest(g *graph.Graph, meta *metamodel.Metamodel) *Workspace {
 	// Initialize search index for test workspaces.
 	idx, err := search.NewIndex()
 	if err != nil {
-		log.Printf("Warning: failed to create test search index: %v", err)
+		slog.Warn("failed to create test search index", "error", err)
 	} else {
 		docs := entitiesToSearchDocuments(g.AllNodes(), meta)
 		if indexErr := idx.IndexBatch(docs); indexErr != nil {
-			log.Printf("Warning: failed to index test entities: %v", indexErr)
+			slog.Warn("failed to index test entities", "error", indexErr)
 		}
 		ws.searchIdx = idx
 	}
@@ -217,11 +217,11 @@ func newWorkspace(
 	// Create search index and index all entities.
 	searchIdx, err := search.NewIndex()
 	if err != nil {
-		log.Printf("Warning: failed to create search index: %v", err)
+		slog.Warn("failed to create search index", "error", err)
 	} else {
 		docs := entitiesToSearchDocuments(g.AllNodes(), meta)
 		if err := searchIdx.IndexBatch(docs); err != nil {
-			log.Printf("Warning: failed to index entities: %v", err)
+			slog.Warn("failed to index entities", "error", err)
 		}
 	}
 
@@ -231,7 +231,7 @@ func newWorkspace(
 		var err error
 		cfg, err = project.LoadConfig(repo.Paths())
 		if err != nil {
-			log.Printf("Warning: failed to load config: %v", err)
+			slog.Warn("failed to load config", "error", err)
 			cfg = project.DefaultConfig()
 		}
 	} else {
@@ -370,7 +370,7 @@ func (w *Workspace) reloadLocked() (*model.SyncResult, error) {
 	newMeta, err := w.repo.LoadMetamodel()
 	if err != nil {
 		if migration.IsMigrationError(err) {
-			log.Printf("Metamodel needs migration, skipping reload: run 'rela migrate'")
+			slog.Warn("metamodel needs migration, skipping reload: run 'rela migrate'")
 			// Sync with current meta even if metamodel file changed.
 			return w.repo.Sync(w.meta, w.graph)
 		}
@@ -402,18 +402,18 @@ func (w *Workspace) reloadLocked() (*model.SyncResult, error) {
 func (w *Workspace) rebuildSearchIndex() {
 	if w.searchIdx != nil {
 		if err := w.searchIdx.Close(); err != nil {
-			log.Printf("Warning: failed to close search index: %v", err)
+			slog.Warn("failed to close search index", "error", err)
 		}
 	}
 	idx, err := search.NewIndex()
 	if err != nil {
-		log.Printf("Warning: failed to create search index: %v", err)
+		slog.Warn("failed to create search index", "error", err)
 		w.searchIdx = nil
 		return
 	}
 	docs := entitiesToSearchDocuments(w.graph.AllNodes(), w.meta)
 	if err := idx.IndexBatch(docs); err != nil {
-		log.Printf("Warning: failed to index entities: %v", err)
+		slog.Warn("failed to index entities", "error", err)
 	}
 	w.searchIdx = idx
 }
@@ -428,7 +428,7 @@ func (w *Workspace) indexEntity(entity *model.Entity) {
 	if idx != nil {
 		doc := entityToSearchDocument(entity, meta)
 		if err := idx.Index(doc); err != nil {
-			log.Printf("Warning: failed to index entity %s: %v", entity.ID, err)
+			slog.Warn("failed to index entity", "id", entity.ID, "error", err)
 		}
 	}
 }
@@ -441,7 +441,7 @@ func (w *Workspace) removeFromIndex(id string) {
 
 	if idx != nil {
 		if err := idx.Remove(id); err != nil {
-			log.Printf("Warning: failed to remove entity %s from index: %v", id, err)
+			slog.Warn("failed to remove entity from index", "id", id, "error", err)
 		}
 	}
 }
@@ -453,7 +453,7 @@ func (w *Workspace) SaveCache() error {
 
 func (w *Workspace) saveCacheQuietly() {
 	if err := w.repo.SaveCache(w.graph); err != nil {
-		log.Printf("Warning: failed to save cache: %v", err)
+		slog.Warn("failed to save cache", "error", err)
 	}
 }
 
@@ -677,14 +677,14 @@ func (w *Workspace) DeleteEntity(entityType, id string, cascade bool) (*DeleteRe
 	// Delete relations first.
 	for _, rel := range incoming {
 		if err := w.repo.DeleteRelation(rel.From, rel.Type, rel.To); err != nil {
-			log.Printf("Warning: failed to delete relation %s--%s-->%s: %v", rel.From, rel.Type, rel.To, err)
+			slog.Warn("failed to delete relation", "from", rel.From, "type", rel.Type, "to", rel.To, "error", err)
 		}
 		w.graph.RemoveEdge(rel.From, rel.Type, rel.To)
 		result.RelationsDeleted++
 	}
 	for _, rel := range outgoing {
 		if err := w.repo.DeleteRelation(rel.From, rel.Type, rel.To); err != nil {
-			log.Printf("Warning: failed to delete relation %s--%s-->%s: %v", rel.From, rel.Type, rel.To, err)
+			slog.Warn("failed to delete relation", "from", rel.From, "type", rel.Type, "to", rel.To, "error", err)
 		}
 		w.graph.RemoveEdge(rel.From, rel.Type, rel.To)
 		result.RelationsDeleted++
@@ -1316,7 +1316,7 @@ func (w *Workspace) StartWatching(opts WatchOptions) error {
 		w.mu.Unlock()
 
 		if reloadErr != nil {
-			log.Printf("Reload error: %v", reloadErr)
+			slog.Error("reload error", "error", reloadErr)
 		}
 		if opts.OnReload != nil {
 			opts.OnReload(events)

--- a/tickets/entities/features/FEAT-VH7Z.md
+++ b/tickets/entities/features/FEAT-VH7Z.md
@@ -1,0 +1,9 @@
+---
+id: FEAT-VH7Z
+type: feature
+title: Structured leveled logging via log/slog
+summary: Use log/slog throughout internal library code for structured, leveled, parallel-test-safe logging.
+description: 'Replace stdlib log usage in library packages with log/slog. Benefits: (1) parallel-test-safety — slog handlers are safe to capture per-test, unlike the stdlib log package which uses global mutable state via log.SetOutput and races with t.Parallel; (2) leveling — support for --verbose / --quiet to bump log level at entry points; (3) structured attributes — logs become machine-readable with named fields rather than sprintf strings. Enforcement via a depguard lint rule that forbids stdlib log imports with narrow exemptions (internal/mcp/server.go must bridge to mcp-go''s WithErrorLogger which takes *log.Logger).'
+priority: medium
+status: proposed
+---

--- a/tickets/entities/tickets/TKT-YPPN.md
+++ b/tickets/entities/tickets/TKT-YPPN.md
@@ -1,0 +1,26 @@
+---
+id: TKT-YPPN
+type: ticket
+title: Adopt log/slog in place of stdlib log
+kind: refactor
+priority: medium
+effort: m
+status: backlog
+---
+
+## Description
+
+Replace stdlib `log` usage in internal library packages with `log/slog`. The
+stdlib `log` package is global mutable state (via `log.SetOutput`), has no
+levels, and is not safe to capture from parallel tests — adding `t.Parallel`
+to any test that captures logs causes nondeterministic failures.
+
+Enforced by a `depguard` lint rule in `.golangci.yml` that forbids `import
+"log"` package-wide. `log/slog` is explicitly allowed. `internal/mcp/server.go`
+is exempted because it must bridge to `mcp-go`'s `WithErrorLogger` which takes
+a `*log.Logger`; it constructs one via `slog.NewLogLogger` so everything still
+flows through the slog handler.
+
+Entry points (`cmd/rela/main.go` indirectly via `internal/cli/root.go`,
+`cmd/rela-server/main.go`, `cmd/rela-desktop/main.go`) wire `--verbose` /
+`--quiet` flags to `slog.LevelDebug` / `slog.LevelWarn` at startup.

--- a/tickets/relations/FEAT-VH7Z--requires--test-isolation.md
+++ b/tickets/relations/FEAT-VH7Z--requires--test-isolation.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-VH7Z
+relation: requires
+to: test-isolation
+---

--- a/tickets/relations/TKT-YPPN--affects--test-isolation.md
+++ b/tickets/relations/TKT-YPPN--affects--test-isolation.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YPPN
+relation: affects
+to: test-isolation
+---

--- a/tickets/relations/TKT-YPPN--implements--FEAT-VH7Z.md
+++ b/tickets/relations/TKT-YPPN--implements--FEAT-VH7Z.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YPPN
+relation: implements
+to: FEAT-VH7Z
+---


### PR DESCRIPTION
## Motivation

rela previously used stdlib `log` for internal logging in ~9 files. This had three problems:

- **Global state**: `log.SetOutput` is process-global, which forces log-capturing tests to serialize via mutex and prevents `t.Parallel()`.
- **No levels**: every line was an unstructured `Printf` at the same level, so debug chatter couldn't be silenced and warnings couldn't be elevated.
- **Unidiomatic for Go 1.21+**: `log/slog` is the standard now — structured, leveled, and thread-safe by default.

This PR replaces all internal uses of the stdlib `log` package with `log/slog`. No abstraction was introduced; packages call `slog.Default()` directly to keep the diff small.

## Scope

Packages converted:

- `internal/workspace` — cache warnings, search-index failures, reload errors
- `internal/validation` — Lua compile/runtime/return-value errors
- `internal/dataentry` — startup summary, git fetch, watcher, config reload
- `internal/mcp` — server startup, watcher notifications, cache warnings (bridged to stdlib `*log.Logger` via `slog.NewLogLogger` where `mcp-go`'s `WithErrorLogger` requires it)
- `cmd/rela-server`, `cmd/rela-desktop` — entry points wire `slog.SetDefault()` and add `-verbose`/`-quiet` flags mapping to `LevelDebug`/`LevelWarn`
- `internal/cli/root.go` — `PersistentPreRunE` wires the existing `--verbose`/`--quiet` Cobra flags to the default slog level

Tests updated:

- `internal/mcp/tools_test.go`, `internal/mcp/convert_test.go` now use a per-test `slog.New(slog.NewTextHandler(io.Discard, nil))`
- `internal/git/main_test.go` (new) unsets inherited `GIT_*` env vars before running tests — fixes a pre-existing issue where `TestGetStatus_WithRemote` / `TestGetStatus_IgnoresNonEntityChanges` falsely reported `LocalChanges` when invoked under `git commit` (which sets `GIT_DIR`/`GIT_INDEX_FILE` and misleads go-git's `Worktree.Status`)

User-facing CLI output (stdout via `internal/output`, `fmt.Println` in CLI commands) was intentionally left untouched — only internal logs were changed.

## Decisions

- `--verbose`/`--quiet` are wired to `slog.LevelDebug` / `slog.LevelWarn`, default `LevelInfo`. These flags already existed on `rootCmd` but were previously unused, so this is a zero-cost improvement.
- `mcp-go`'s `server.WithErrorLogger` requires a `*log.Logger`; we bridge with `slog.NewLogLogger(handler, slog.LevelError)` so error output still flows through the configured slog handler.
- `internal/mcp.Server.logger` switched from `*log.Logger` to `*slog.Logger` with a `"component": "mcp"` attribute.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `just lint`
- [x] `rela --help` / `rela version` smoke test
- [x] Pre-commit hook passes (lint + race tests)