### PR TITLE
fix(lua): propagate caller cancellation into runtime

### DIFF
--- a/internal/cli/flow.go
+++ b/internal/cli/flow.go
@@ -66,7 +66,7 @@ Example:
 			return fmt.Errorf("no project found for script %s", scriptPath)
 		}
 
-		var opts []lua.Option
+		opts := []lua.Option{lua.WithContext(cmd.Context())}
 		if flowOutputDir != "" {
 			opts = append(opts, lua.WithOutputDir(flowOutputDir))
 		}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,10 +1,13 @@
 package cli
 
 import (
+	"context"
 	stderrors "errors"
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -99,15 +102,30 @@ and maintain semantic relationships between them.`,
 // Execute runs the root command
 // coverage-ignore: CLI entry point - tested via integration tests
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		// Check for ExitError to use custom exit code
-		var exitErr *errors.ExitError
-		if stderrors.As(err, &exitErr) {
-			os.Exit(exitErr.Code)
-		}
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+	os.Exit(run())
+}
+
+// run executes the root command with a signal-aware context and returns the
+// process exit code. It is split out from Execute so that signal.NotifyContext
+// cleanup runs before os.Exit.
+// coverage-ignore: CLI entry point - tested via integration tests
+func run() int {
+	// Set up a signal-aware context so Ctrl+C (SIGINT) and SIGTERM cancel
+	// in-flight operations, including embedded Lua execution.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	err := rootCmd.ExecuteContext(ctx)
+	if err == nil {
+		return 0
 	}
+	// Check for ExitError to use custom exit code
+	var exitErr *errors.ExitError
+	if stderrors.As(err, &exitErr) {
+		return exitErr.Code
+	}
+	fmt.Fprintln(os.Stderr, err)
+	return 1
 }
 
 func init() {

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -59,7 +59,7 @@ Example:
 		scriptPath := args[0]
 		scriptArgs := args[1:]
 
-		var opts []lua.Option
+		opts := []lua.Option{lua.WithContext(cmd.Context())}
 		if scriptOutputDir != "" {
 			opts = append(opts, lua.WithOutputDir(scriptOutputDir))
 		}

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -60,8 +60,9 @@ type Runtime struct {
 	meta          *metamodel.Metamodel
 	stdout        io.Writer
 	projectRoot   string
-	outputDir     string        // Directory where write_file can write (defaults to "output")
-	timeout       time.Duration // Execution timeout (0 = no timeout)
+	outputDir     string          // Directory where write_file can write (defaults to "output")
+	timeout       time.Duration   // Execution timeout (0 = no timeout)
+	parentCtx     context.Context // Parent context for cancellation propagation (nil = Background)
 	cancelTimeout context.CancelFunc
 	params        map[string]string // rela.params values (used by action scripts)
 	isAction      bool              // true when running as an action (changes rela.output behavior)
@@ -79,6 +80,20 @@ const DefaultTimeout = 30 * time.Second
 func WithTimeout(d time.Duration) Option {
 	return func(r *Runtime) {
 		r.timeout = d
+	}
+}
+
+// WithContext sets a parent context for the runtime. Cancellation of this
+// context propagates into in-flight Lua operations (e.g. long-running loops
+// or blocking calls from bindings). When combined with WithTimeout, the
+// timeout is derived from this parent so canceling the parent also cancels
+// the timeout-bound context.
+//
+// Typical usage: pass cmd.Context() from a cobra RunE so that Ctrl+C
+// interrupts script execution.
+func WithContext(ctx context.Context) Option {
+	return func(r *Runtime) {
+		r.parentCtx = ctx
 	}
 }
 
@@ -264,12 +279,25 @@ func (r *Runtime) RunActionString(code, name string) (interface{}, error) {
 
 // applyTimeout sets the execution timeout on the Lua state.
 // Must be called before executing any Lua code.
+//
+// The derived context is rooted at r.parentCtx (if set) so that canceling
+// the caller's context (e.g. Ctrl+C via a cobra command context) interrupts
+// in-flight Lua execution. When no timeout is configured but a parent context
+// is set, the parent is attached directly so cancellation still propagates.
 func (r *Runtime) applyTimeout() {
 	r.clearTimeout()
+	parent := r.parentCtx
+	if parent == nil {
+		parent = context.Background()
+	}
 	if r.timeout > 0 {
-		ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+		ctx, cancel := context.WithTimeout(parent, r.timeout)
 		r.cancelTimeout = cancel
 		r.L.SetContext(ctx)
+		return
+	}
+	if r.parentCtx != nil {
+		r.L.SetContext(r.parentCtx)
 	}
 }
 

--- a/internal/lua/runtime_test.go
+++ b/internal/lua/runtime_test.go
@@ -2,6 +2,7 @@ package lua
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/graph"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -2242,5 +2244,69 @@ func TestActionMode_OutputIsWarning(t *testing.T) {
 	}
 	if strings.Contains(out, `"foo"`) {
 		t.Errorf("expected output to be dropped in action mode, got %q", out)
+	}
+}
+
+// TestWithContext_CancellationInterruptsBusyLoop verifies that canceling the
+// parent context passed via WithContext interrupts an in-flight Lua busy loop,
+// rather than waiting for the internal timeout to fire.
+func TestWithContext_CancellationInterruptsBusyLoop(t *testing.T) {
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+
+	// Parent context with a tight deadline. The internal Lua timeout is left
+	// at its default (30s) so that any cancellation we observe must come from
+	// the parent context, not the timeout fallback.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	r := New(ws, ws.Meta(), "/tmp", &buf, WithContext(ctx))
+	defer r.Close()
+
+	start := time.Now()
+	err := r.RunString(`while true do end`)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected busy loop to be interrupted, got nil error")
+	}
+	// Must finish well before the default 30s timeout would fire.
+	if elapsed > 5*time.Second {
+		t.Fatalf("busy loop ran for %v; expected parent context to interrupt quickly", elapsed)
+	}
+	// gopher-lua surfaces context cancellation as "context deadline exceeded"
+	// or "context canceled" embedded in the error message.
+	msg := err.Error()
+	if !strings.Contains(msg, "context") {
+		t.Errorf("expected context-related error, got: %v", err)
+	}
+}
+
+// TestWithContext_NoTimeoutStillCancels verifies that even with the internal
+// timeout disabled, a cancelled parent context interrupts execution.
+func TestWithContext_NoTimeoutStillCancels(t *testing.T) {
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	r := New(ws, ws.Meta(), "/tmp", &buf, WithContext(ctx), WithTimeout(0))
+	defer r.Close()
+
+	// Cancel shortly after starting.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := r.RunString(`while true do end`)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected busy loop to be interrupted, got nil error")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("busy loop ran for %v; expected parent cancel to interrupt", elapsed)
 	}
 }

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -53,7 +53,7 @@ func toolLuaList() mcp.Tool {
 	)
 }
 
-func (s *Server) handleLuaEval(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (s *Server) handleLuaEval(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	code, err := req.RequireString("code")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -64,7 +64,7 @@ func (s *Server) handleLuaEval(_ context.Context, req mcp.CallToolRequest) (*mcp
 	// Capture output
 	var output bytes.Buffer
 
-	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output)
+	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output, lua.WithContext(ctx))
 	defer runtime.Close()
 
 	if err := runtime.RunString(code); err != nil {
@@ -79,7 +79,7 @@ func (s *Server) handleLuaEval(_ context.Context, req mcp.CallToolRequest) (*mcp
 	return mcp.NewToolResultText(result), nil
 }
 
-func (s *Server) handleLuaRun(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (s *Server) handleLuaRun(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	path, err := req.RequireString("path")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -131,7 +131,7 @@ func (s *Server) handleLuaRun(_ context.Context, req mcp.CallToolRequest) (*mcp.
 	// Capture output
 	var output bytes.Buffer
 
-	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output)
+	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output, lua.WithContext(ctx))
 	defer runtime.Close()
 
 	// Set script args before execution

--- a/tickets/entities/automated-measures/lua-cancellation-tests.md
+++ b/tickets/entities/automated-measures/lua-cancellation-tests.md
@@ -1,0 +1,9 @@
+---
+id: lua-cancellation-tests
+type: automated-measure
+title: Lua runtime cancellation tests
+description: Tests that verify a parent context.Context cancellation propagates into the gopher-lua LState and interrupts execution well before the internal timeout fires. Covers WithContext option and busy-loop interruption.
+kind: test
+location: internal/lua/runtime_test.go
+status: active
+---

--- a/tickets/entities/bugs/BUG-AD4X.md
+++ b/tickets/entities/bugs/BUG-AD4X.md
@@ -1,0 +1,14 @@
+---
+id: BUG-AD4X
+type: bug
+title: Ctrl+C does not interrupt in-flight Lua operations
+description: The Lua runtime's applyTimeout() rooted its LState context at context.Background, so caller cancellation (e.g. Ctrl+C via cobra) did not propagate. Any rela script, rela flow, or MCP lua_eval/lua_run call would run to completion (or hit the 30s internal timeout) regardless of SIGINT.
+priority: high
+why1: applyTimeout() always used context.Background() as the parent, ignoring any caller context.
+why2: The runtime API had no way for callers to pass their context in (only WithTimeout).
+why3: The original design treated the Lua timeout as the only cancellation mechanism, since scripts were pure/CPU-bound and Ctrl+C was not considered.
+why4: Scripts have since grown network-calling bindings that can block for up to 30s, making the lack of caller-driven cancellation user-visible.
+why5: No systemic hook in CLI startup ever wired a signal-aware context down to embedded runtimes.
+prevention: Added lua.WithContext option plus signal.NotifyContext at cli.Execute so cancellation flows from SIGINT/SIGTERM into the Lua LState.
+status: done
+---

--- a/tickets/relations/BUG-AD4X--adds-measure--lua-cancellation-tests.md
+++ b/tickets/relations/BUG-AD4X--adds-measure--lua-cancellation-tests.md
@@ -1,0 +1,5 @@
+---
+from: BUG-AD4X
+relation: adds-measure
+to: lua-cancellation-tests
+---

--- a/tickets/relations/BUG-AD4X--affects--lua-scripting.md
+++ b/tickets/relations/BUG-AD4X--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: BUG-AD4X
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/BUG-AD4X--fixes--FEAT-i5ji.md
+++ b/tickets/relations/BUG-AD4X--fixes--FEAT-i5ji.md
@@ -1,0 +1,5 @@
+---
+from: BUG-AD4X
+relation: fixes
+to: FEAT-i5ji
+---


### PR DESCRIPTION
## Summary

Fixes a latent issue where Ctrl+C on `rela script`, `rela flow`, or any MCP `lua_eval`/`lua_run` invocation did not interrupt in-flight Lua execution. The script would run to completion (or hit the 30s internal timeout) regardless of SIGINT.

## Root cause

`internal/lua/runtime.go`'s `applyTimeout()` built the LState context via:

```go
ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
```

The LState was therefore rooted at `context.Background()` and knew nothing about the caller's signal-aware context.

## Fix

- Add a new `lua.WithContext(ctx)` option so callers can pass a parent context into the runtime.
- `applyTimeout()` now derives its timeout from `r.parentCtx` (defaulting to `Background`). When `r.timeout == 0` but a parent is set, the parent is attached directly so cancellation still propagates.
- `cli.Execute` now builds a signal-aware context via `signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)` and runs cobra via `rootCmd.ExecuteContext`. The `Execute`/`run` split keeps `defer stop()` valid around `os.Exit`.
- Wire `cmd.Context()` into `lua.New` from `internal/cli/script.go` and `internal/cli/flow.go`.
- Forward the request context into `lua.New` from MCP `handleLuaEval` and `handleLuaRun` in `internal/mcp/tools_lua.go`.

`internal/script/executor.go` (automations invoked inside workspace CRUD) and `internal/validation/lua.go` (validation rules) still use `context.Background` behavior; plumbing a context through the `metamodel.ScriptContext` interface and every workspace write call site would cascade well beyond the scope of this fix. Their pre-existing 30s (Lua) and 5s (validation) timeouts remain in place.

## Drive-by fix

`internal/git` tests inherit `GIT_INDEX_FILE` when `go test` is invoked from a git hook, which contaminates their throwaway repositories and fails `TestGetStatus_WithRemote` / `TestGetStatus_IgnoresNonEntityChanges`. Added a `TestMain` in that package that unsets `GIT_*` env vars. This bug surfaced while running the pre-commit hook in a worktree with staged changes.

## Test plan

- [x] New `TestWithContext_CancellationInterruptsBusyLoop`: parent ctx with a 50ms deadline cancels a `while true do end` Lua loop well before the default 30s timeout
- [x] New `TestWithContext_NoTimeoutStillCancels`: with `WithTimeout(0)`, a later `cancel()` on the parent still interrupts a busy loop
- [x] Existing `internal/lua` tests still pass
- [x] `just lint` clean
- [x] `go test -race ./...` clean
- [ ] Manual: `rela script` against a long-running script and hit Ctrl+C (should exit immediately)