### PR TITLE
feat(ai): add OpenAI-compatible AI client and Lua bindings (TKT-YBKB)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -7,6 +7,7 @@ allow:
 exclude:
   - internal/testutil
   - frontend
+  - .claude
 
 excludeFiles:
   - "_test\\.go$"
@@ -56,6 +57,7 @@ components:
   search:           { in: internal/search/** }
 
   # Infrastructure
+  ai:               { in: internal/ai }
   attachment:       { in: internal/attachment }
   git:              { in: internal/git }
   output:           { in: internal/output }
@@ -130,6 +132,7 @@ deps:
   # CLI layer — orchestrates everything
   cli:
     mayDependOn:
+      - ai
       - dataentryconfig
       - filter
       - importer
@@ -181,6 +184,7 @@ deps:
   # Server protocols
   mcp:
     mayDependOn:
+      - ai
       - dataentryconfig
       - filter
       - lua
@@ -298,6 +302,7 @@ deps:
       - pattern
   lua:
     mayDependOn:
+      - ai
       - filter
       - metamodel
       - workspace
@@ -308,8 +313,10 @@ deps:
       - rrulego
   script:
     mayDependOn:
+      - ai
       - lua
       - metamodel
+      - project
   search:
     mayDependOn:
       - filter
@@ -317,6 +324,10 @@ deps:
       - bleve
 
   # Infrastructure
+  # ai: pure leaf — only stdlib (net/http, log/slog, encoding/json) plus
+  # yaml (already in commonVendors). The Provider interface is consumed
+  # by lua, script, cli, and mcp. No mayDependOn/canUse entry needed
+  # because the component is component-only with no internal deps.
   attachment:
     mayDependOn:
       - storage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,134 @@ sync) independently from the standard CLI state setup in `PersistentPreRunE`.
 
 All commands share `projectCtx`, `meta`, `g` (graph), and `out` (output writer).
 
+## AI Integration
+
+The `internal/ai` package provides LLM access via OpenAI-compatible providers
+(OpenAI, Anthropic via compat layer, Ollama, LM Studio, Groq, apfel, etc.).
+It is exposed to Lua scripts as a top-level `ai` global.
+
+### Configuration
+
+User config lives in `.rela/ai.yaml` (gitignored, per-user):
+
+```yaml
+base_url: http://127.0.0.1:11434/v1   # required, must include scheme
+model: gemma3:12b                      # required, default model
+api_key_env: OPENAI_API_KEY            # optional; absent = no auth header
+timeout_seconds: 60                    # optional, default 30
+```
+
+`api_key_env` is **optional**. When absent, no `Authorization` header is sent —
+this supports local providers like ollama, apfel, and LM Studio that run without
+authentication. When set, the named env var is read at request time (not at
+startup), so commands that don't use AI never fail because the env var is unset.
+
+### Lua API
+
+```lua
+-- Full form
+local result, err = ai.chat({
+  messages = {
+    {role = "system", content = "You are concise."},
+    {role = "user",   content = "What is 2+2?"},
+  },
+  model = "gemma3:12b",   -- optional, falls back to .rela/ai.yaml
+  temperature = 0,        -- optional; 0 is sent distinctly from "unset"
+  max_tokens = 50,        -- optional
+})
+
+-- Convenience: single user message, returns just the content string
+local text, err = ai.complete("Summarize: " .. content)
+```
+
+On success: `result` is a table `{content, model, finish_reason, usage}` with
+flat fields. `usage` is a sub-table `{prompt_tokens, completion_tokens, total_tokens}`.
+
+On failure: `err` is a typed table `{kind, status, message, retry_after}` with
+stable `kind` values:
+
+| `err.kind` | When |
+|---|---|
+| `not_configured` | No `.rela/ai.yaml` or it failed to load |
+| `auth` | API key missing/invalid; HTTP 401/403 |
+| `bad_request` | HTTP 400/4xx; unknown model, unsupported parameter |
+| `rate_limited` | HTTP 429; `err.retry_after` populated when server provides Retry-After |
+| `server_error` | HTTP 5xx |
+| `timeout` | Request exceeded its deadline |
+| `network` | DNS, connection refused, TLS, etc. |
+| `bad_response` | Non-JSON, malformed JSON, missing choices, unrecognized content shape |
+| `streaming_unsupported` | Provider returned SSE despite `stream: false` |
+
+**Convention deviation**: `ai.chat` and `ai.complete` are the *only* rela Lua
+bindings that return `(nil, err_table)` for runtime failures. All other rela
+bindings raise via `RaiseError`. The deviation is deliberate — AI calls are
+network-bound, failure is expected, and scripts should handle it inline rather
+than wrap every call in `pcall`. Programming errors (wrong arg type, empty
+messages list) still raise. See `internal/lua/ai.go` top-of-file comment for
+the full rationale.
+
+### Security: New threat surface
+
+Adding AI to the Lua sandbox introduces a **new threat class**: a malicious or
+compromised Lua script can now silently exfiltrate every entity in the project
+to the user's *own* legitimate provider via
+`ai.chat({messages = {{role="user", content=entity_dump}}})`. The data lands in
+the provider's logs, possibly in training data, possibly readable by junior
+staff, possibly billed to the user. The script needs no malicious config and no
+filesystem write — it uses the user's own working setup.
+
+**Mitigations in place:**
+
+- Operational logging (debug/info/warn) makes unusual call patterns visible
+- API is opt-in: requires `.rela/ai.yaml` to exist
+- API key is read at call time and never logged or echoed in errors (`redactKey` helper + table-driven leak test)
+- Config rejects URLs with embedded credentials (`https://user:pass@host`)
+- Response body is capped at 10 MiB to prevent OOM
+
+**Treat Lua scripts as trusted code.** The `rela.write_file` and `ai.chat`
+capabilities together mean a malicious script can do real damage. Don't run
+Lua scripts you don't trust.
+
+### Operational logging
+
+Every AI request emits structured log lines via the stdlib `log` package:
+
+- `ai: request start base_url=... model=... messages=N` (debug-equivalent)
+- `ai: request ok status=200 model=... latency_ms=... prompt_tokens=... completion_tokens=... total_tokens=...`
+- `ai: request failed kind=... status=... latency_ms=... message=...`
+
+No headers, no API keys, no message content are ever logged.
+
+### Architecture
+
+```text
+internal/ai/
+  config.go     Config struct, LoadConfig (ErrConfigNotFound on missing file)
+  errors.go     ErrKind enum, *Error type, classify(), redaction
+  provider.go   Provider interface, ChatRequest, ChatResponse
+  openai.go     OpenAICompatProvider implementation (HTTP, no SDK)
+  loader.go     LoadProvider helper for entry-point wiring
+  redact.go     redactKey(s, key) helper
+```
+
+The `Provider` interface is intentionally an aggregate (currently only `Chat`,
+will gain `Embed` in a future ticket). The Lua runtime takes a single
+`ai.Provider` via `lua.WithAIProvider(p)`, so embeddings will not require
+parallel wiring paths.
+
+Four entry points wire AI into the Lua runtime: `internal/cli/script.go`,
+`internal/cli/flow.go`, `internal/script/executor.go`, `internal/mcp/tools_lua.go`.
+Each calls `ai.LoadProvider(.rela_dir)` and passes the result to `lua.New` via
+`WithAIProvider`. Missing or malformed config silently disables AI for that
+runtime; the Lua bindings return `not_configured` at call time.
+
+**`internal/validation/lua.go` is intentionally NOT wired with AI.** A validation
+rule that calls `ai.chat` would hit the provider on every entity on every
+`analyze` run with no quota, no kill switch, and no cost warning. The 5-second
+validation timeout would also silently clip slow calls. AI-powered validation
+rules need their own design (per-rule opt-in, cost guardrails, longer per-rule
+budget) and are tracked as a follow-up.
+
 ## Test Coverage
 
 The project uses [go-test-coverage](https://github.com/vladopajic/go-test-coverage) with a

--- a/internal/ai/config.go
+++ b/internal/ai/config.go
@@ -97,6 +97,18 @@ func (c *Config) Validate() error {
 	if u.User != nil {
 		return errors.New("base_url must not contain credentials (use api_key_env instead)")
 	}
+	if u.RawQuery != "" {
+		// Some legacy providers (notably old Azure) carry the API key
+		// in a query parameter like ?api_key=... or ?token=.... If we
+		// allowed that the key would be embedded in every log line via
+		// logRequestStart and never redacted (the redactKey helper only
+		// knows about env-var-sourced keys). Force users to authenticate
+		// via api_key_env so the key never lands in the URL.
+		return errors.New("base_url must not contain a query string (use api_key_env for authentication)")
+	}
+	if u.Fragment != "" {
+		return errors.New("base_url must not contain a fragment")
+	}
 
 	if c.Provider != "" && c.Provider != "openai-compatible" {
 		return fmt.Errorf("provider %q is not supported (only openai-compatible)", c.Provider)

--- a/internal/ai/config.go
+++ b/internal/ai/config.go
@@ -1,0 +1,119 @@
+// Package ai provides LLM access for rela via OpenAI-compatible providers.
+//
+// The package exposes a Provider interface, an OpenAI-compatible HTTP
+// implementation, a typed error taxonomy, and a config loader for
+// .rela/ai.yaml. It is designed to be the foundation for AI-powered
+// features throughout rela: Lua bindings, validations, CLI commands,
+// MCP tools, and the data entry UI.
+//
+// The Provider interface intentionally aggregates capabilities (Chat
+// today, Embed in a future ticket) so that consumers — particularly the
+// Lua runtime — only have one wiring point.
+package ai
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigFile is the name of the AI config file inside .rela/.
+const ConfigFile = "ai.yaml"
+
+// DefaultTimeoutSeconds is the default request timeout when none is set.
+const DefaultTimeoutSeconds = 30
+
+// ErrConfigNotFound indicates that .rela/ai.yaml does not exist. This
+// is the "AI not configured" state and is returned by LoadConfig so
+// callers can use errors.Is(err, ErrConfigNotFound) to handle it as a
+// normal absence rather than a failure.
+var ErrConfigNotFound = errors.New("ai: not configured (no .rela/ai.yaml)")
+
+// Config is the contents of .rela/ai.yaml.
+//
+// APIKeyEnv is OPTIONAL. When empty, the provider sends no Authorization
+// header at all (supports auth-free local providers like ollama, apfel,
+// LM Studio). When non-empty, the named environment variable must be set
+// to a non-empty value at Chat() call time.
+type Config struct {
+	Provider       string `yaml:"provider"`
+	BaseURL        string `yaml:"base_url"`
+	Model          string `yaml:"model"`
+	APIKeyEnv      string `yaml:"api_key_env"`
+	TimeoutSeconds int    `yaml:"timeout_seconds"`
+}
+
+// LoadConfig reads .rela/ai.yaml from the given .rela directory.
+//
+// Returns ErrConfigNotFound (wrapped) if the file does not exist — this
+// is the "AI not configured" state. Callers can use
+// errors.Is(err, ErrConfigNotFound) to distinguish it from real errors.
+//
+// Returns other errors on read failure, parse failure, or invalid
+// required fields.
+func LoadConfig(relaDir string) (*Config, error) {
+	path := filepath.Join(relaDir, ConfigFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrConfigNotFound
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", path, err)
+	}
+
+	return &cfg, nil
+}
+
+// Validate checks required fields and rejects unsafe values.
+func (c *Config) Validate() error {
+	if strings.TrimSpace(c.BaseURL) == "" {
+		return errors.New("base_url is required")
+	}
+	if strings.TrimSpace(c.Model) == "" {
+		return errors.New("model is required")
+	}
+
+	u, err := url.Parse(c.BaseURL)
+	if err != nil {
+		return fmt.Errorf("base_url is not a valid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("base_url must use http:// or https://, got %q", c.BaseURL)
+	}
+	if u.User != nil {
+		return errors.New("base_url must not contain credentials (use api_key_env instead)")
+	}
+
+	if c.Provider != "" && c.Provider != "openai-compatible" {
+		return fmt.Errorf("provider %q is not supported (only openai-compatible)", c.Provider)
+	}
+
+	if c.TimeoutSeconds < 0 {
+		return fmt.Errorf("timeout_seconds must be >= 0, got %d", c.TimeoutSeconds)
+	}
+
+	return nil
+}
+
+// Timeout returns the request timeout in seconds, applying the default
+// when TimeoutSeconds is zero.
+func (c *Config) Timeout() int {
+	if c.TimeoutSeconds <= 0 {
+		return DefaultTimeoutSeconds
+	}
+	return c.TimeoutSeconds
+}

--- a/internal/ai/config_test.go
+++ b/internal/ai/config_test.go
@@ -118,6 +118,34 @@ model: gpt-4
 	}
 }
 
+// Some legacy providers use ?api_key=... in the URL. We reject this
+// because the key would land in every request log line via
+// logRequestStart and never be redacted (the redactKey helper only
+// knows about env-var-sourced keys). Review finding F6.
+func TestLoadConfig_BaseURLWithQueryString(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `
+base_url: "https://api.example.com/v1?api_key=secret"
+model: gpt-4
+`)
+	_, err := LoadConfig(dir)
+	if err == nil || !strings.Contains(err.Error(), "query") {
+		t.Fatalf("expected query string error, got %v", err)
+	}
+}
+
+func TestLoadConfig_BaseURLWithFragment(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `
+base_url: "https://api.example.com/v1#frag"
+model: gpt-4
+`)
+	_, err := LoadConfig(dir)
+	if err == nil || !strings.Contains(err.Error(), "fragment") {
+		t.Fatalf("expected fragment error, got %v", err)
+	}
+}
+
 func TestLoadConfig_UnsupportedProvider(t *testing.T) {
 	dir := t.TempDir()
 	writeConfig(t, dir, `

--- a/internal/ai/config_test.go
+++ b/internal/ai/config_test.go
@@ -1,0 +1,193 @@
+package ai
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadConfig_Missing(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := LoadConfig(dir)
+	if !errors.Is(err, ErrConfigNotFound) {
+		t.Fatalf("expected ErrConfigNotFound, got err=%v", err)
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil config for missing file, got %+v", cfg)
+	}
+}
+
+func TestLoadConfig_Valid(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `
+provider: openai-compatible
+base_url: https://api.openai.com/v1
+model: gpt-4o-mini
+api_key_env: OPENAI_API_KEY
+timeout_seconds: 60
+`)
+	cfg, err := LoadConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if cfg.BaseURL != "https://api.openai.com/v1" {
+		t.Errorf("BaseURL = %q", cfg.BaseURL)
+	}
+	if cfg.Model != "gpt-4o-mini" {
+		t.Errorf("Model = %q", cfg.Model)
+	}
+	if cfg.APIKeyEnv != "OPENAI_API_KEY" {
+		t.Errorf("APIKeyEnv = %q", cfg.APIKeyEnv)
+	}
+	if cfg.Timeout() != 60 {
+		t.Errorf("Timeout() = %d", cfg.Timeout())
+	}
+}
+
+func TestLoadConfig_NoAPIKeyEnv(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `
+base_url: http://localhost:11434/v1
+model: gemma3:12b
+`)
+	cfg, err := LoadConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.APIKeyEnv != "" {
+		t.Errorf("expected empty APIKeyEnv, got %q", cfg.APIKeyEnv)
+	}
+	if cfg.Timeout() != DefaultTimeoutSeconds {
+		t.Errorf("expected default timeout, got %d", cfg.Timeout())
+	}
+}
+
+func TestLoadConfig_Malformed(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `not: valid: yaml: at: all`)
+	_, err := LoadConfig(dir)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML")
+	}
+}
+
+func TestLoadConfig_MissingBaseURL(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `model: gpt-4`)
+	_, err := LoadConfig(dir)
+	if err == nil || !strings.Contains(err.Error(), "base_url") {
+		t.Fatalf("expected base_url error, got %v", err)
+	}
+}
+
+func TestLoadConfig_MissingModel(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `base_url: https://example.com/v1`)
+	_, err := LoadConfig(dir)
+	if err == nil || !strings.Contains(err.Error(), "model") {
+		t.Fatalf("expected model error, got %v", err)
+	}
+}
+
+func TestLoadConfig_BaseURLNoScheme(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `
+base_url: api.openai.com/v1
+model: gpt-4
+`)
+	_, err := LoadConfig(dir)
+	if err == nil || !strings.Contains(err.Error(), "http") {
+		t.Fatalf("expected scheme error, got %v", err)
+	}
+}
+
+func TestLoadConfig_BaseURLWithCredentials(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `
+base_url: https://user:secret@api.example.com/v1
+model: gpt-4
+`)
+	_, err := LoadConfig(dir)
+	if err == nil || !strings.Contains(err.Error(), "credentials") {
+		t.Fatalf("expected credentials error, got %v", err)
+	}
+}
+
+func TestLoadConfig_UnsupportedProvider(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `
+provider: anthropic-native
+base_url: https://api.anthropic.com/v1
+model: claude
+`)
+	_, err := LoadConfig(dir)
+	if err == nil || !strings.Contains(err.Error(), "openai-compatible") {
+		t.Fatalf("expected provider error, got %v", err)
+	}
+}
+
+func TestLoadConfig_NegativeTimeout(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `
+base_url: https://example.com/v1
+model: gpt-4
+timeout_seconds: -1
+`)
+	_, err := LoadConfig(dir)
+	if err == nil {
+		t.Fatal("expected error for negative timeout")
+	}
+}
+
+func TestLoadConfig_DirectoryDoesNotExist(t *testing.T) {
+	cfg, err := LoadConfig("/definitely/does/not/exist/anywhere")
+	if !errors.Is(err, ErrConfigNotFound) {
+		t.Fatalf("expected ErrConfigNotFound for missing dir, got %v", err)
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil cfg, got %+v", cfg)
+	}
+}
+
+func TestConfig_Timeout_Default(t *testing.T) {
+	c := &Config{}
+	if c.Timeout() != DefaultTimeoutSeconds {
+		t.Errorf("Timeout() = %d, want default %d", c.Timeout(), DefaultTimeoutSeconds)
+	}
+}
+
+func writeConfig(t *testing.T, dir, content string) {
+	t.Helper()
+	path := filepath.Join(dir, ConfigFile)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Sanity check that LoadConfig returns nil when the directory exists
+// but the file is permission-denied. Skipped on Windows / when running
+// as root since chmod 000 doesn't reliably block root.
+func TestLoadConfig_ReadError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can read 000 files")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, ConfigFile)
+	if err := os.WriteFile(path, []byte("base_url: https://x/y\nmodel: m\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+	_, err := LoadConfig(dir)
+	if err == nil {
+		t.Fatal("expected error for unreadable file")
+	}
+	// Should be a wrapped read error, not os.ErrNotExist.
+	if errors.Is(err, os.ErrNotExist) {
+		t.Errorf("unexpectedly got ErrNotExist: %v", err)
+	}
+}

--- a/internal/ai/errors.go
+++ b/internal/ai/errors.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -79,10 +80,8 @@ func (e *Error) Unwrap() error {
 	return e.cause
 }
 
-// errBodySnippetBytes is how much of an unrecognized response body is
-// included in error messages for diagnostics. Must be kept in sync with
-// the openai.go snippetBytes constant; both exist so the package
-// compiles even if files are reorganized.
+// errBodySnippetBytes caps how much of an unrecognized response body is
+// included in error messages for diagnostics.
 const errBodySnippetBytes = 200
 
 // wrapNetworkError converts a network/transport-level error from
@@ -185,7 +184,7 @@ func parseErrorEnvelope(body []byte) (errType, message string) {
 			Message string `json:"message"`
 		} `json:"error"`
 	}
-	if err := jsonUnmarshal(body, &env); err != nil {
+	if err := json.Unmarshal(body, &env); err != nil {
 		return "", ""
 	}
 	return env.Error.Type, env.Error.Message

--- a/internal/ai/errors.go
+++ b/internal/ai/errors.go
@@ -1,0 +1,231 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ErrKind classifies an AI error so callers (and Lua scripts) can branch
+// on the kind of failure without parsing prose error messages.
+type ErrKind string
+
+const (
+	// ErrNotConfigured indicates the runtime has no AI provider wired
+	// (no .rela/ai.yaml or it failed to load).
+	ErrNotConfigured ErrKind = "not_configured"
+
+	// ErrAuth indicates the request was rejected for authentication
+	// reasons: missing API key, wrong key, expired key, etc.
+	ErrAuth ErrKind = "auth"
+
+	// ErrBadRequest indicates the upstream provider rejected the
+	// request as invalid: unknown model, unsupported parameter,
+	// malformed body, etc.
+	ErrBadRequest ErrKind = "bad_request"
+
+	// ErrRateLimited indicates the upstream provider returned 429.
+	// RetryAfter is populated when the response includes a usable
+	// Retry-After header.
+	ErrRateLimited ErrKind = "rate_limited"
+
+	// ErrServerError indicates an upstream 5xx response.
+	ErrServerError ErrKind = "server_error"
+
+	// ErrTimeout indicates the request exceeded its deadline.
+	ErrTimeout ErrKind = "timeout"
+
+	// ErrNetwork indicates a network-level failure (DNS, connection
+	// refused, TLS handshake, etc.) — anything that prevented the
+	// HTTP exchange from completing.
+	ErrNetwork ErrKind = "network"
+
+	// ErrBadResponse indicates the upstream returned a response we
+	// could not understand: wrong Content-Type, malformed JSON,
+	// missing required fields, unrecognized content shape.
+	ErrBadResponse ErrKind = "bad_response"
+
+	// ErrStreamingUnsupported indicates the upstream returned a
+	// streaming response when we requested non-streamed.
+	ErrStreamingUnsupported ErrKind = "streaming_unsupported"
+)
+
+// Error is the typed error returned by Provider implementations.
+//
+// Message is human-readable and is safe to display to users — it never
+// contains API keys (callers must use redactKey for any text derived
+// from secrets-adjacent sources).
+type Error struct {
+	Kind       ErrKind
+	Status     int           // HTTP status code, 0 if not applicable
+	Message    string        // human-readable, never contains secrets
+	RetryAfter time.Duration // 0 if unknown; populated for ErrRateLimited
+	cause      error
+}
+
+func (e *Error) Error() string {
+	if e.Status > 0 {
+		return fmt.Sprintf("%s (status %d): %s", e.Kind, e.Status, e.Message)
+	}
+	return fmt.Sprintf("%s: %s", e.Kind, e.Message)
+}
+
+func (e *Error) Unwrap() error {
+	return e.cause
+}
+
+// errBodySnippetBytes is how much of an unrecognized response body is
+// included in error messages for diagnostics. Must be kept in sync with
+// the openai.go snippetBytes constant; both exist so the package
+// compiles even if files are reorganized.
+const errBodySnippetBytes = 200
+
+// wrapNetworkError converts a network/transport-level error from
+// http.Client.Do into a typed Error. It distinguishes between deadline
+// exceeded (timeout) and other network failures.
+func wrapNetworkError(err error, apiKey string) *Error {
+	if err == nil {
+		return nil
+	}
+	msg := redactKey(err.Error(), apiKey)
+	if errors.Is(err, context.DeadlineExceeded) {
+		return &Error{Kind: ErrTimeout, Message: msg, cause: err}
+	}
+	if errors.Is(err, context.Canceled) {
+		return &Error{Kind: ErrTimeout, Message: msg, cause: err}
+	}
+	// net.Error timeout (e.g., dial timeout)
+	var nerr net.Error
+	if errors.As(err, &nerr) && nerr.Timeout() {
+		return &Error{Kind: ErrTimeout, Message: msg, cause: err}
+	}
+	return &Error{Kind: ErrNetwork, Message: msg, cause: err}
+}
+
+// classify maps an HTTP response (and its already-read body) to a
+// typed Error. It prefers the upstream error envelope's "type" field
+// when present, falling back to HTTP status.
+//
+// apiKey is used solely for redaction of any body snippet included in
+// the error message — pass an empty string when no key is in scope.
+func classify(status int, headers http.Header, body []byte, apiKey string) *Error {
+	envType, envMessage := parseErrorEnvelope(body)
+
+	kind := kindFromEnvelopeType(envType)
+	if kind == "" {
+		kind = kindFromStatus(status)
+	}
+
+	message := envMessage
+	if message == "" {
+		message = fmt.Sprintf("upstream returned status %d: %s", status, snippet(body))
+	}
+	message = redactKey(message, apiKey)
+
+	out := &Error{Kind: kind, Status: status, Message: message}
+	if kind == ErrRateLimited {
+		out.RetryAfter = parseRetryAfter(headers.Get("Retry-After"))
+	}
+	return out
+}
+
+// kindFromEnvelopeType maps OpenAI-style error.type strings to ErrKind.
+// Returns "" when the type is unknown or absent.
+func kindFromEnvelopeType(t string) ErrKind {
+	switch t {
+	case "":
+		return ""
+	case "invalid_request_error":
+		return ErrBadRequest
+	case "authentication_error", "permission_error", "unauthorized":
+		return ErrAuth
+	case "rate_limit_error", "rate_limit_exceeded":
+		return ErrRateLimited
+	case "server_error", "api_error", "internal_server_error":
+		return ErrServerError
+	}
+	// Unknown type — fall through to status-based classification.
+	return ""
+}
+
+// kindFromStatus maps HTTP status codes to ErrKind.
+func kindFromStatus(status int) ErrKind {
+	switch {
+	case status == http.StatusUnauthorized, status == http.StatusForbidden:
+		return ErrAuth
+	case status == http.StatusTooManyRequests:
+		return ErrRateLimited
+	case status == http.StatusRequestTimeout, status == http.StatusGatewayTimeout:
+		return ErrTimeout
+	case status >= 400 && status < 500:
+		return ErrBadRequest
+	case status >= 500 && status < 600:
+		return ErrServerError
+	}
+	return ErrBadResponse
+}
+
+// parseErrorEnvelope extracts (type, message) from an OpenAI-style
+// error envelope. It does not use encoding/json to avoid pulling errors
+// when the body is malformed; it does a tolerant scan instead.
+func parseErrorEnvelope(body []byte) (errType, message string) {
+	if len(body) == 0 {
+		return "", ""
+	}
+	// Tolerant approach: try a strict JSON decode first; on failure
+	// return empty so the classifier falls back to status.
+	var env struct {
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := jsonUnmarshal(body, &env); err != nil {
+		return "", ""
+	}
+	return env.Error.Type, env.Error.Message
+}
+
+// parseRetryAfter parses an HTTP Retry-After header value, supporting
+// both delta-seconds and HTTP-date forms. Returns 0 on any parse error.
+func parseRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	// delta-seconds
+	if secs, err := strconv.Atoi(value); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	// HTTP-date
+	if t, err := http.ParseTime(value); err == nil {
+		d := time.Until(t)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+	return 0
+}
+
+// snippet returns up to errBodySnippetBytes of body, truncated on a
+// UTF-8 rune boundary so the result is always valid UTF-8.
+func snippet(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	if len(body) <= errBodySnippetBytes {
+		return string(body)
+	}
+	// Walk back from errBodySnippetBytes to find the last rune boundary.
+	end := errBodySnippetBytes
+	for end > 0 && (body[end]&0xC0) == 0x80 {
+		end--
+	}
+	return string(body[:end])
+}

--- a/internal/ai/errors_test.go
+++ b/internal/ai/errors_test.go
@@ -1,0 +1,173 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestError_Error(t *testing.T) {
+	withStatus := &Error{Kind: ErrAuth, Status: 401, Message: "bad key"}
+	if got := withStatus.Error(); !strings.Contains(got, "auth") || !strings.Contains(got, "401") {
+		t.Errorf("Error() = %q", got)
+	}
+
+	noStatus := &Error{Kind: ErrNotConfigured, Message: "missing config"}
+	if got := noStatus.Error(); !strings.Contains(got, "not_configured") || strings.Contains(got, "0") {
+		t.Errorf("Error() = %q", got)
+	}
+}
+
+func TestError_Unwrap(t *testing.T) {
+	cause := errors.New("inner")
+	e := &Error{Kind: ErrNetwork, Message: "wrapped", cause: cause}
+	if !errors.Is(e, cause) {
+		t.Error("errors.Is should find the cause through Unwrap")
+	}
+	noCause := &Error{Kind: ErrNetwork}
+	if errors.Unwrap(noCause) != nil {
+		t.Error("Unwrap should return nil when no cause")
+	}
+}
+
+func TestWrapNetworkError_Nil(t *testing.T) {
+	if got := wrapNetworkError(nil, ""); got != nil {
+		t.Errorf("wrapNetworkError(nil) = %v", got)
+	}
+}
+
+func TestWrapNetworkError_DeadlineExceeded(t *testing.T) {
+	got := wrapNetworkError(context.DeadlineExceeded, "")
+	if got.Kind != ErrTimeout {
+		t.Errorf("Kind = %q", got.Kind)
+	}
+}
+
+func TestWrapNetworkError_Canceled(t *testing.T) {
+	got := wrapNetworkError(context.Canceled, "")
+	if got.Kind != ErrTimeout {
+		t.Errorf("Kind = %q", got.Kind)
+	}
+}
+
+func TestWrapNetworkError_Generic(t *testing.T) {
+	got := wrapNetworkError(errors.New("dns failed"), "")
+	if got.Kind != ErrNetwork {
+		t.Errorf("Kind = %q", got.Kind)
+	}
+}
+
+func TestKindFromEnvelopeType(t *testing.T) {
+	cases := map[string]ErrKind{
+		"":                      "",
+		"unknown_thing":         "",
+		"invalid_request_error": ErrBadRequest,
+		"authentication_error":  ErrAuth,
+		"permission_error":      ErrAuth,
+		"unauthorized":          ErrAuth,
+		"rate_limit_error":      ErrRateLimited,
+		"rate_limit_exceeded":   ErrRateLimited,
+		"server_error":          ErrServerError,
+		"api_error":             ErrServerError,
+		"internal_server_error": ErrServerError,
+	}
+	for input, want := range cases {
+		if got := kindFromEnvelopeType(input); got != want {
+			t.Errorf("kindFromEnvelopeType(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestKindFromStatus(t *testing.T) {
+	cases := map[int]ErrKind{
+		401: ErrAuth,
+		403: ErrAuth,
+		429: ErrRateLimited,
+		408: ErrTimeout,
+		504: ErrTimeout,
+		400: ErrBadRequest,
+		404: ErrBadRequest,
+		500: ErrServerError,
+		502: ErrServerError,
+		200: ErrBadResponse, // unexpected; classify never called for 2xx
+	}
+	for status, want := range cases {
+		if got := kindFromStatus(status); got != want {
+			t.Errorf("kindFromStatus(%d) = %q, want %q", status, got, want)
+		}
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	if d := parseRetryAfter(""); d != 0 {
+		t.Errorf("empty = %v", d)
+	}
+	if d := parseRetryAfter("30"); d != 30*time.Second {
+		t.Errorf("30 = %v", d)
+	}
+	if d := parseRetryAfter("0"); d != 0 {
+		t.Errorf("0 = %v", d)
+	}
+	if d := parseRetryAfter("garbage"); d != 0 {
+		t.Errorf("garbage = %v", d)
+	}
+	// HTTP-date in the past → 0
+	if d := parseRetryAfter("Wed, 21 Oct 2015 07:28:00 GMT"); d != 0 {
+		t.Errorf("past date = %v", d)
+	}
+}
+
+func TestParseErrorEnvelope(t *testing.T) {
+	cases := []struct {
+		name        string
+		body        string
+		wantType    string
+		wantMessage string
+	}{
+		{"empty", "", "", ""},
+		{"valid", `{"error":{"type":"x","message":"y"}}`, "x", "y"},
+		{"no_error", `{"choices":[]}`, "", ""},
+		{"malformed", `{not json`, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotType, gotMsg := parseErrorEnvelope([]byte(tc.body))
+			if gotType != tc.wantType {
+				t.Errorf("type = %q, want %q", gotType, tc.wantType)
+			}
+			if gotMsg != tc.wantMessage {
+				t.Errorf("message = %q, want %q", gotMsg, tc.wantMessage)
+			}
+		})
+	}
+}
+
+func TestSnippet(t *testing.T) {
+	if got := snippet(nil); got != "" {
+		t.Errorf("nil = %q", got)
+	}
+	if got := snippet([]byte("short")); got != "short" {
+		t.Errorf("short = %q", got)
+	}
+	long := strings.Repeat("a", errBodySnippetBytes+50)
+	got := snippet([]byte(long))
+	if len(got) > errBodySnippetBytes {
+		t.Errorf("long snippet too long: %d", len(got))
+	}
+}
+
+func TestClassify_FallsBackToStatus(t *testing.T) {
+	// No error envelope → status fallback
+	headers := http.Header{}
+	headers.Set("Retry-After", "5")
+	got := classify(http.StatusTooManyRequests, headers, []byte(""), "")
+	if got.Kind != ErrRateLimited {
+		t.Errorf("Kind = %q", got.Kind)
+	}
+	if got.RetryAfter != 5*time.Second {
+		t.Errorf("RetryAfter = %v", got.RetryAfter)
+	}
+}

--- a/internal/ai/loader.go
+++ b/internal/ai/loader.go
@@ -1,0 +1,33 @@
+package ai
+
+import (
+	"errors"
+	"log/slog"
+)
+
+// LoadProvider is a convenience for entry points: load .rela/ai.yaml
+// from the given directory and build a Provider if it exists. Returns
+// nil when no AI config is present, so callers can pass the returned
+// Provider directly to lua.WithAIProvider — the Lua bindings will
+// surface a typed not_configured error at call time.
+//
+// On config-load errors (malformed YAML, invalid fields), this logs a
+// warning and returns nil. The rationale: a misconfigured ai.yaml
+// should not prevent unrelated rela commands from running. The user
+// will see the warning the next time they invoke an AI script and the
+// not_configured error message will direct them to fix the config.
+func LoadProvider(relaDir string) Provider {
+	cfg, err := LoadConfig(relaDir)
+	if err != nil {
+		if !errors.Is(err, ErrConfigNotFound) {
+			slog.Warn("ai: failed to load config", "rela_dir", relaDir, "error", err)
+		}
+		return nil
+	}
+	provider, err := NewOpenAICompatProvider(cfg)
+	if err != nil {
+		slog.Warn("ai: failed to build provider", "error", err)
+		return nil
+	}
+	return provider
+}

--- a/internal/ai/loader.go
+++ b/internal/ai/loader.go
@@ -1,33 +1,27 @@
 package ai
 
-import (
-	"errors"
-	"log/slog"
-)
-
 // LoadProvider is a convenience for entry points: load .rela/ai.yaml
-// from the given directory and build a Provider if it exists. Returns
-// nil when no AI config is present, so callers can pass the returned
-// Provider directly to lua.WithAIProvider — the Lua bindings will
-// surface a typed not_configured error at call time.
+// from the given directory and build a Provider if it exists.
 //
-// On config-load errors (malformed YAML, invalid fields), this logs a
-// warning and returns nil. The rationale: a misconfigured ai.yaml
-// should not prevent unrelated rela commands from running. The user
-// will see the warning the next time they invoke an AI script and the
-// not_configured error message will direct them to fix the config.
-func LoadProvider(relaDir string) Provider {
+// Returns:
+//   - (provider, nil) when the config loaded successfully
+//   - (nil, ErrConfigNotFound) when no config exists (AI is "not
+//     configured" — this is a normal state, not an error). Callers
+//     check via errors.Is(err, ErrConfigNotFound).
+//   - (nil, err) when the config exists but cannot be loaded or
+//     validated, or when provider construction fails
+//
+// Callers decide policy: interactive entry points like `rela script`
+// and `rela flow` should surface non-ErrConfigNotFound errors to the
+// user (AI may be the whole point of the command). Background contexts
+// (automation script executor, MCP tool handlers) typically log + ignore
+// so a misconfigured ai.yaml doesn't break the host process.
+func LoadProvider(relaDir string) (Provider, error) {
 	cfg, err := LoadConfig(relaDir)
 	if err != nil {
-		if !errors.Is(err, ErrConfigNotFound) {
-			slog.Warn("ai: failed to load config", "rela_dir", relaDir, "error", err)
-		}
-		return nil
+		// LoadConfig already returns ErrConfigNotFound (wrapped) for
+		// the missing-file case, so we just propagate.
+		return nil, err
 	}
-	provider, err := NewOpenAICompatProvider(cfg)
-	if err != nil {
-		slog.Warn("ai: failed to build provider", "error", err)
-		return nil
-	}
-	return provider
+	return NewOpenAICompatProvider(cfg)
 }

--- a/internal/ai/loader_test.go
+++ b/internal/ai/loader_test.go
@@ -1,0 +1,49 @@
+package ai
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadProvider_Missing(t *testing.T) {
+	dir := t.TempDir()
+	if p := LoadProvider(dir); p != nil {
+		t.Errorf("expected nil provider when config missing, got %T", p)
+	}
+}
+
+func TestLoadProvider_Valid(t *testing.T) {
+	dir := t.TempDir()
+	writeAIYaml(t, dir, `
+base_url: https://example.com/v1
+model: test-model
+`)
+	p := LoadProvider(dir)
+	if p == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestLoadProvider_Malformed(t *testing.T) {
+	dir := t.TempDir()
+	writeAIYaml(t, dir, `not: valid: yaml: at: all`)
+	if p := LoadProvider(dir); p != nil {
+		t.Errorf("expected nil provider on malformed config, got %T", p)
+	}
+}
+
+func TestLoadProvider_InvalidConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeAIYaml(t, dir, `model: only-model-no-url`)
+	if p := LoadProvider(dir); p != nil {
+		t.Errorf("expected nil provider on invalid config, got %T", p)
+	}
+}
+
+func writeAIYaml(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, ConfigFile), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/ai/loader_test.go
+++ b/internal/ai/loader_test.go
@@ -1,14 +1,20 @@
 package ai
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestLoadProvider_Missing(t *testing.T) {
 	dir := t.TempDir()
-	if p := LoadProvider(dir); p != nil {
+	p, err := LoadProvider(dir)
+	if !errors.Is(err, ErrConfigNotFound) {
+		t.Errorf("expected ErrConfigNotFound, got %v", err)
+	}
+	if p != nil {
 		t.Errorf("expected nil provider when config missing, got %T", p)
 	}
 }
@@ -19,7 +25,10 @@ func TestLoadProvider_Valid(t *testing.T) {
 base_url: https://example.com/v1
 model: test-model
 `)
-	p := LoadProvider(dir)
+	p, err := LoadProvider(dir)
+	if err != nil {
+		t.Fatalf("LoadProvider: %v", err)
+	}
 	if p == nil {
 		t.Fatal("expected non-nil provider")
 	}
@@ -28,7 +37,11 @@ model: test-model
 func TestLoadProvider_Malformed(t *testing.T) {
 	dir := t.TempDir()
 	writeAIYaml(t, dir, `not: valid: yaml: at: all`)
-	if p := LoadProvider(dir); p != nil {
+	p, err := LoadProvider(dir)
+	if err == nil {
+		t.Fatal("expected error on malformed config")
+	}
+	if p != nil {
 		t.Errorf("expected nil provider on malformed config, got %T", p)
 	}
 }
@@ -36,7 +49,14 @@ func TestLoadProvider_Malformed(t *testing.T) {
 func TestLoadProvider_InvalidConfig(t *testing.T) {
 	dir := t.TempDir()
 	writeAIYaml(t, dir, `model: only-model-no-url`)
-	if p := LoadProvider(dir); p != nil {
+	p, err := LoadProvider(dir)
+	if err == nil {
+		t.Fatal("expected error on invalid config")
+	}
+	if !strings.Contains(err.Error(), "base_url") {
+		t.Errorf("expected base_url error, got %v", err)
+	}
+	if p != nil {
 		t.Errorf("expected nil provider on invalid config, got %T", p)
 	}
 }

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -43,6 +43,16 @@ func NewOpenAICompatProvider(cfg *Config) (Provider, error) {
 		cfg: cfg,
 		httpClient: &http.Client{
 			Timeout: time.Duration(cfg.Timeout()) * time.Second,
+			// Disable redirect-following. None of the OpenAI-compat
+			// providers we target use redirects in their normal flow.
+			// Following them would let a misconfigured proxy or DNS
+			// cache redirect a request to a path the user did not
+			// authorize, and Go's stdlib only strips Authorization
+			// on cross-host redirects (not same-host), which is a
+			// thinner defense than just refusing to follow.
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
 		},
 	}, nil
 }
@@ -74,8 +84,13 @@ type chatResponseWire struct {
 }
 
 type choiceWire struct {
-	Message      messageRawWire `json:"message"`
-	FinishReason string         `json:"finish_reason"`
+	// Message is a pointer so we can tell when the upstream omitted it
+	// entirely (vs. sending an empty message object). Some providers
+	// have been observed to return choices without a message under
+	// edge conditions; that should be ErrBadResponse, not silently
+	// produce empty content.
+	Message      *messageRawWire `json:"message"`
+	FinishReason string          `json:"finish_reason"`
 }
 
 type messageRawWire struct {
@@ -119,9 +134,19 @@ func (p *openAICompatProvider) Chat(ctx context.Context, req ChatRequest) (*Chat
 
 	respBody, readErr := readLimitedBody(resp.Body)
 	if readErr != nil {
-		netErr := wrapNetworkError(readErr, apiKey)
-		logRequestFailure(string(netErr.Kind), resp.StatusCode, time.Since(start), netErr.Message)
-		return nil, netErr
+		var aiErr *Error
+		if errors.Is(readErr, errBodyTooLarge) {
+			aiErr = &Error{
+				Kind:    ErrBadResponse,
+				Status:  resp.StatusCode,
+				Message: fmt.Sprintf("upstream response exceeded %d bytes", maxResponseBytes),
+				cause:   readErr,
+			}
+		} else {
+			aiErr = wrapNetworkError(readErr, apiKey)
+		}
+		logRequestFailure(string(aiErr.Kind), resp.StatusCode, time.Since(start), aiErr.Message)
+		return nil, aiErr
 	}
 
 	return p.parseResponse(resp, respBody, apiKey, start)
@@ -235,6 +260,10 @@ func decodeChatResponse(respBody []byte, apiKey string) (*ChatResponse, *Error) 
 		return nil, &Error{Kind: ErrBadResponse, Message: "upstream returned no choices"}
 	}
 
+	if parsed.Choices[0].Message == nil {
+		return nil, &Error{Kind: ErrBadResponse, Message: "upstream returned choice with no message"}
+	}
+
 	content, contentErr := decodeContent(parsed.Choices[0].Message.Content)
 	if contentErr != nil {
 		return nil, &Error{Kind: ErrBadResponse, Message: contentErr.Error(), cause: contentErr}
@@ -272,8 +301,15 @@ func (p *openAICompatProvider) resolveAPIKey() (string, *Error) {
 	return key, nil
 }
 
+// errBodyTooLarge is returned by readLimitedBody when the upstream
+// response exceeds maxResponseBytes. Distinguished as a sentinel so
+// Chat() can classify it as ErrBadResponse (an upstream protocol
+// violation) rather than ErrNetwork (a transport failure).
+var errBodyTooLarge = errors.New("response body exceeded size limit")
+
 // readLimitedBody reads up to maxResponseBytes from r. If the limit is
-// hit it returns an error so the caller can surface ErrBadResponse.
+// hit it returns errBodyTooLarge so the caller can surface
+// ErrBadResponse.
 func readLimitedBody(r io.Reader) ([]byte, error) {
 	limited := io.LimitReader(r, maxResponseBytes+1)
 	body, err := io.ReadAll(limited)
@@ -281,7 +317,7 @@ func readLimitedBody(r io.Reader) ([]byte, error) {
 		return nil, err
 	}
 	if int64(len(body)) > maxResponseBytes {
-		return nil, fmt.Errorf("response body exceeded %d bytes", maxResponseBytes)
+		return nil, errBodyTooLarge
 	}
 	return body, nil
 }

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -1,0 +1,378 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// maxResponseBytes caps the response body to prevent OOM from a
+// malicious or misconfigured server.
+const maxResponseBytes = 10 * 1024 * 1024 // 10 MiB
+
+// openAICompatProvider implements Provider using the OpenAI Chat
+// Completions HTTP wire format. It works against any provider that
+// honors the OpenAI shape, including OpenAI itself, ollama, apfel, LM
+// Studio, Groq, and Anthropic-compat layers.
+type openAICompatProvider struct {
+	cfg        *Config
+	httpClient *http.Client
+}
+
+// NewOpenAICompatProvider builds a Provider from a Config.
+//
+// It does NOT read the API key. The key (if any) is read at Chat() call
+// time so commands that never use AI can still start when the env var
+// is unset.
+func NewOpenAICompatProvider(cfg *Config) (Provider, error) {
+	if cfg == nil {
+		return nil, errors.New("ai: nil config")
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &openAICompatProvider{
+		cfg: cfg,
+		httpClient: &http.Client{
+			Timeout: time.Duration(cfg.Timeout()) * time.Second,
+		},
+	}, nil
+}
+
+// chatRequestWire is the JSON shape sent to the upstream. We deliberately
+// keep this minimal: only the parameters we explicitly set. omitempty on
+// the pointer fields means temperature=0 is sent (pointer is non-nil)
+// while absent temperature is omitted entirely.
+type chatRequestWire struct {
+	Model       string        `json:"model"`
+	Messages    []messageWire `json:"messages"`
+	Stream      bool          `json:"stream"`
+	Temperature *float64      `json:"temperature,omitempty"`
+	MaxTokens   *int          `json:"max_tokens,omitempty"`
+}
+
+type messageWire struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// chatResponseWire mirrors the OpenAI response. Content is read as
+// json.RawMessage so we can tolerate providers that return either a
+// string or an array of content parts.
+type chatResponseWire struct {
+	Model   string       `json:"model"`
+	Choices []choiceWire `json:"choices"`
+	Usage   *usageWire   `json:"usage"`
+}
+
+type choiceWire struct {
+	Message      messageRawWire `json:"message"`
+	FinishReason string         `json:"finish_reason"`
+}
+
+type messageRawWire struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+type usageWire struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// Chat sends a chat completion request and returns the response.
+func (p *openAICompatProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	apiKey, authErr := p.resolveAPIKey()
+	if authErr != nil {
+		return nil, authErr
+	}
+
+	model := req.Model
+	if model == "" {
+		model = p.cfg.Model
+	}
+
+	httpReq, err := p.buildHTTPRequest(ctx, model, req, apiKey)
+	if err != nil {
+		return nil, err
+	}
+
+	logRequestStart(p.cfg.BaseURL, model, len(req.Messages))
+	start := time.Now()
+
+	resp, doErr := p.httpClient.Do(httpReq)
+	if doErr != nil {
+		netErr := wrapNetworkError(doErr, apiKey)
+		logRequestFailure(string(netErr.Kind), 0, time.Since(start), netErr.Message)
+		return nil, netErr
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, readErr := readLimitedBody(resp.Body)
+	if readErr != nil {
+		netErr := wrapNetworkError(readErr, apiKey)
+		logRequestFailure(string(netErr.Kind), resp.StatusCode, time.Since(start), netErr.Message)
+		return nil, netErr
+	}
+
+	return p.parseResponse(resp, respBody, apiKey, start)
+}
+
+// buildHTTPRequest constructs the *http.Request including headers and
+// JSON body. Returns a typed *Error on any failure.
+func (p *openAICompatProvider) buildHTTPRequest(
+	ctx context.Context, model string, req ChatRequest, apiKey string,
+) (*http.Request, error) {
+	wire := chatRequestWire{
+		Model:       model,
+		Messages:    toMessageWire(req.Messages),
+		Stream:      false,
+		Temperature: req.Temperature,
+		MaxTokens:   req.MaxTokens,
+	}
+	body, err := json.Marshal(wire)
+	if err != nil {
+		// Unreachable in practice; chatRequestWire has no fields that fail to marshal.
+		return nil, &Error{Kind: ErrBadRequest, Message: "marshal request: " + redactKey(err.Error(), apiKey), cause: err}
+	}
+
+	endpoint := strings.TrimRight(p.cfg.BaseURL, "/") + "/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, &Error{Kind: ErrNetwork, Message: redactKey(err.Error(), apiKey), cause: err}
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	if apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	return httpReq, nil
+}
+
+// parseResponse handles all post-HTTP response processing: Content-Type
+// validation, status classification, error envelope detection, JSON
+// decoding, and content shape handling. Returns a typed *Error on any
+// failure path.
+func (p *openAICompatProvider) parseResponse(
+	resp *http.Response, respBody []byte, apiKey string, start time.Time,
+) (*ChatResponse, error) {
+	// Validate Content-Type before doing anything with the body.
+	contentType := resp.Header.Get("Content-Type")
+	if isStreamContentType(contentType) {
+		streamErr := &Error{
+			Kind:    ErrStreamingUnsupported,
+			Status:  resp.StatusCode,
+			Message: fmt.Sprintf("upstream returned streaming response (Content-Type %q) but stream=false was requested", contentType),
+		}
+		logRequestFailure(string(streamErr.Kind), resp.StatusCode, time.Since(start), streamErr.Message)
+		return nil, streamErr
+	}
+	if !isJSONContentType(contentType) {
+		badResp := &Error{
+			Kind:    ErrBadResponse,
+			Status:  resp.StatusCode,
+			Message: fmt.Sprintf("upstream returned non-JSON response (Content-Type %q, status %d): %s", contentType, resp.StatusCode, redactKey(snippet(respBody), apiKey)),
+		}
+		logRequestFailure(string(badResp.Kind), resp.StatusCode, time.Since(start), badResp.Message)
+		return nil, badResp
+	}
+
+	// Non-2xx → classify and return.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		classified := classify(resp.StatusCode, resp.Header, respBody, apiKey)
+		logRequestFailure(string(classified.Kind), resp.StatusCode, time.Since(start), classified.Message)
+		return nil, classified
+	}
+
+	// 2xx with JSON body — error envelope masquerading as success?
+	if envType, envMessage := parseErrorEnvelope(respBody); envType != "" || envMessage != "" {
+		classified := classify(resp.StatusCode, resp.Header, respBody, apiKey)
+		if envType != "" {
+			if k := kindFromEnvelopeType(envType); k != "" {
+				classified.Kind = k
+			}
+		}
+		if envMessage != "" {
+			classified.Message = redactKey(envMessage, apiKey)
+		}
+		logRequestFailure(string(classified.Kind), resp.StatusCode, time.Since(start), classified.Message)
+		return nil, classified
+	}
+
+	out, parseErr := decodeChatResponse(respBody, apiKey)
+	if parseErr != nil {
+		parseErr.Status = resp.StatusCode
+		logRequestFailure(string(parseErr.Kind), resp.StatusCode, time.Since(start), parseErr.Message)
+		return nil, parseErr
+	}
+
+	logRequestSuccess(resp.StatusCode, out.Model, time.Since(start), out.Usage)
+	return out, nil
+}
+
+// decodeChatResponse parses a successful 2xx JSON body into a
+// *ChatResponse. Returns a typed *Error on any decode failure.
+func decodeChatResponse(respBody []byte, apiKey string) (*ChatResponse, *Error) {
+	var parsed chatResponseWire
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, &Error{
+			Kind:    ErrBadResponse,
+			Message: fmt.Sprintf("decode response: %v: %s", err, redactKey(snippet(respBody), apiKey)),
+			cause:   err,
+		}
+	}
+
+	if len(parsed.Choices) == 0 {
+		return nil, &Error{Kind: ErrBadResponse, Message: "upstream returned no choices"}
+	}
+
+	content, contentErr := decodeContent(parsed.Choices[0].Message.Content)
+	if contentErr != nil {
+		return nil, &Error{Kind: ErrBadResponse, Message: contentErr.Error(), cause: contentErr}
+	}
+
+	out := &ChatResponse{
+		Content:      content,
+		Model:        parsed.Model,
+		FinishReason: parsed.Choices[0].FinishReason,
+	}
+	if parsed.Usage != nil {
+		out.Usage = Usage{
+			PromptTokens:     parsed.Usage.PromptTokens,
+			CompletionTokens: parsed.Usage.CompletionTokens,
+			TotalTokens:      parsed.Usage.TotalTokens,
+		}
+	}
+	return out, nil
+}
+
+// resolveAPIKey reads the API key from the configured env var. Returns
+// ("", nil) when no auth is configured. Returns ("", *Error) when auth
+// is configured but the env var is missing/empty.
+func (p *openAICompatProvider) resolveAPIKey() (string, *Error) {
+	if p.cfg.APIKeyEnv == "" {
+		return "", nil
+	}
+	key := os.Getenv(p.cfg.APIKeyEnv)
+	if key == "" {
+		return "", &Error{
+			Kind:    ErrAuth,
+			Message: fmt.Sprintf("environment variable %s is unset or empty", p.cfg.APIKeyEnv),
+		}
+	}
+	return key, nil
+}
+
+// readLimitedBody reads up to maxResponseBytes from r. If the limit is
+// hit it returns an error so the caller can surface ErrBadResponse.
+func readLimitedBody(r io.Reader) ([]byte, error) {
+	limited := io.LimitReader(r, maxResponseBytes+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxResponseBytes {
+		return nil, fmt.Errorf("response body exceeded %d bytes", maxResponseBytes)
+	}
+	return body, nil
+}
+
+// decodeContent parses the message.content field which can be either a
+// string or an array of content parts ({"type":"text","text":"..."}).
+func decodeContent(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "", nil
+	}
+	// Try string first.
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s, nil
+	}
+	// Try array of parts.
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &parts); err == nil {
+		var b strings.Builder
+		for _, p := range parts {
+			if p.Type == "" || p.Type == "text" {
+				b.WriteString(p.Text)
+			}
+		}
+		return b.String(), nil
+	}
+	return "", fmt.Errorf("unrecognized content shape: %s", snippet(raw))
+}
+
+// toMessageWire converts the public Message slice to the wire form.
+func toMessageWire(in []Message) []messageWire {
+	out := make([]messageWire, len(in))
+	for i, m := range in {
+		out[i] = messageWire(m)
+	}
+	return out
+}
+
+// isJSONContentType returns true if the Content-Type header indicates a
+// JSON body. Tolerant: matches application/json, application/vnd...+json, etc.
+func isJSONContentType(ct string) bool {
+	ct = strings.ToLower(ct)
+	if ct == "" {
+		return false
+	}
+	// Strip parameters.
+	if i := strings.Index(ct, ";"); i >= 0 {
+		ct = strings.TrimSpace(ct[:i])
+	}
+	return strings.Contains(ct, "json")
+}
+
+// isStreamContentType returns true for SSE responses.
+func isStreamContentType(ct string) bool {
+	ct = strings.ToLower(ct)
+	if i := strings.Index(ct, ";"); i >= 0 {
+		ct = strings.TrimSpace(ct[:i])
+	}
+	return ct == "text/event-stream"
+}
+
+// logRequestStart emits a debug log when an AI request begins.
+// We log the base URL (which has no path), model, and message count —
+// never headers, content, or the API key.
+func logRequestStart(baseURL, model string, messageCount int) {
+	slog.Debug("ai request start",
+		"base_url", baseURL,
+		"model", model,
+		"messages", messageCount)
+}
+
+// logRequestSuccess emits an info log on successful response.
+func logRequestSuccess(status int, model string, latency time.Duration, usage Usage) {
+	slog.Info("ai request ok",
+		"status", status,
+		"model", model,
+		"latency_ms", latency.Milliseconds(),
+		"prompt_tokens", usage.PromptTokens,
+		"completion_tokens", usage.CompletionTokens,
+		"total_tokens", usage.TotalTokens)
+}
+
+// logRequestFailure emits a warn log on any error path. The message has
+// already been redacted.
+func logRequestFailure(kind string, status int, latency time.Duration, message string) {
+	slog.Warn("ai request failed",
+		"kind", kind,
+		"status", status,
+		"latency_ms", latency.Milliseconds(),
+		"message", message)
+}

--- a/internal/ai/openai_test.go
+++ b/internal/ai/openai_test.go
@@ -1,0 +1,776 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// sentinelKey is a unique string we set as the API key in tests so we
+// can assert it never appears in any error or log message.
+const sentinelKey = "SENTINEL_KEY_ZZZZZ_DO_NOT_LEAK"
+
+// canonicalSuccessBody is the canonical OpenAI response shape, taken
+// from a real ollama gemma3:12b round trip.
+const canonicalSuccessBody = `{
+  "id":"chatcmpl-366",
+  "object":"chat.completion",
+  "created":1775560657,
+  "model":"gemma3:12b",
+  "system_fingerprint":"fp_ollama",
+  "choices":[
+    {"index":0,"message":{"role":"assistant","content":"hello from gemma"},"finish_reason":"stop"}
+  ],
+  "usage":{"prompt_tokens":20,"completion_tokens":5,"total_tokens":25}
+}`
+
+// newTestProvider builds a Provider pointing at the given test server.
+// Sets the env var to sentinelKey unless apiKeyEnv is empty.
+func newTestProvider(t *testing.T, server *httptest.Server, apiKeyEnv string) Provider {
+	t.Helper()
+	if apiKeyEnv != "" {
+		t.Setenv(apiKeyEnv, sentinelKey)
+	}
+	cfg := &Config{
+		BaseURL:        server.URL + "/v1",
+		Model:          "test-model",
+		APIKeyEnv:      apiKeyEnv,
+		TimeoutSeconds: 5,
+	}
+	p, err := NewOpenAICompatProvider(cfg)
+	if err != nil {
+		t.Fatalf("NewOpenAICompatProvider: %v", err)
+	}
+	return p
+}
+
+// hiMessages returns a single user message with content "hi". Used by
+// tests that exercise transport behavior and don't care about the
+// prompt content.
+func hiMessages() []Message {
+	return []Message{{Role: "user", Content: "hi"}}
+}
+
+func TestProvider_Chat_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(canonicalSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	resp, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Content != "hello from gemma" {
+		t.Errorf("Content = %q", resp.Content)
+	}
+	if resp.Model != "gemma3:12b" {
+		t.Errorf("Model = %q", resp.Model)
+	}
+	if resp.FinishReason != "stop" {
+		t.Errorf("FinishReason = %q", resp.FinishReason)
+	}
+	if resp.Usage.PromptTokens != 20 || resp.Usage.CompletionTokens != 5 || resp.Usage.TotalTokens != 25 {
+		t.Errorf("Usage = %+v", resp.Usage)
+	}
+}
+
+func TestProvider_Chat_AuthHeaderSent(t *testing.T) {
+	var receivedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(canonicalSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	if _, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	want := "Bearer " + sentinelKey
+	if receivedAuth != want {
+		t.Errorf("Authorization = %q, want %q", receivedAuth, want)
+	}
+}
+
+func TestProvider_Chat_NoAuthHeaderWhenAPIKeyEnvEmpty(t *testing.T) {
+	var receivedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(canonicalSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "")
+	if _, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if receivedAuth != "" {
+		t.Errorf("expected no Authorization header, got %q", receivedAuth)
+	}
+}
+
+func TestProvider_Chat_AuthErrorWhenEnvVarMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Errorf("server should not be called when env var missing")
+	}))
+	t.Cleanup(server.Close)
+
+	// Provider construction must succeed even with missing env var.
+	cfg := &Config{
+		BaseURL:   server.URL + "/v1",
+		Model:     "test-model",
+		APIKeyEnv: "DEFINITELY_NOT_SET_VAR_ZZZ",
+	}
+	// Make sure it really isn't set.
+	t.Setenv("DEFINITELY_NOT_SET_VAR_ZZZ", "")
+
+	p, err := NewOpenAICompatProvider(cfg)
+	if err != nil {
+		t.Fatalf("NewOpenAICompatProvider should succeed even with unset env var: %v", err)
+	}
+
+	_, chatErr := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	if chatErr == nil {
+		t.Fatal("expected ErrAuth")
+	}
+	var aiErr *Error
+	if !errors.As(chatErr, &aiErr) {
+		t.Fatalf("expected *Error, got %T: %v", chatErr, chatErr)
+	}
+	if aiErr.Kind != ErrAuth {
+		t.Errorf("Kind = %q, want %q", aiErr.Kind, ErrAuth)
+	}
+	if !strings.Contains(aiErr.Message, "DEFINITELY_NOT_SET_VAR_ZZZ") {
+		t.Errorf("error should name the env var, got %q", aiErr.Message)
+	}
+}
+
+func TestProvider_Chat_TemperatureZeroSentDistinctly(t *testing.T) {
+	var bodySeen []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodySeen, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(canonicalSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+
+	// temperature=0 should be sent.
+	zero := 0.0
+	if _, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages(), Temperature: &zero}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if !strings.Contains(string(bodySeen), `"temperature":0`) {
+		t.Errorf("expected temperature:0 in body, got %s", bodySeen)
+	}
+
+	// temperature absent should NOT be sent.
+	bodySeen = nil
+	if _, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if strings.Contains(string(bodySeen), `"temperature"`) {
+		t.Errorf("expected no temperature key in body, got %s", bodySeen)
+	}
+}
+
+func TestProvider_Chat_StreamFalseAlwaysSent(t *testing.T) {
+	var bodySeen []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodySeen, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(canonicalSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	if _, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if !strings.Contains(string(bodySeen), `"stream":false`) {
+		t.Errorf("expected stream:false in body, got %s", bodySeen)
+	}
+}
+
+func TestProvider_Chat_NoUnsupportedParameters(t *testing.T) {
+	var bodySeen []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodySeen, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(canonicalSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	temp := 0.5
+	maxTok := 100
+	if _, err := p.Chat(context.Background(), ChatRequest{
+		Messages: hiMessages(), Temperature: &temp, MaxTokens: &maxTok,
+	}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	body := string(bodySeen)
+	for _, banned := range []string{"logprobs", `"n":`, "presence_penalty", "frequency_penalty", `"stop":`} {
+		if strings.Contains(body, banned) {
+			t.Errorf("body contains unsupported parameter %q: %s", banned, body)
+		}
+	}
+}
+
+func TestProvider_Chat_RateLimited(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"type":"rate_limit_error","message":"slow down"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, err)
+	if aiErr.Kind != ErrRateLimited {
+		t.Errorf("Kind = %q", aiErr.Kind)
+	}
+	if aiErr.Status != 429 {
+		t.Errorf("Status = %d", aiErr.Status)
+	}
+	if aiErr.RetryAfter != 30*time.Second {
+		t.Errorf("RetryAfter = %v", aiErr.RetryAfter)
+	}
+}
+
+func TestProvider_Chat_AuthFailed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"type":"authentication_error","message":"bad key"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, err)
+	if aiErr.Kind != ErrAuth {
+		t.Errorf("Kind = %q", aiErr.Kind)
+	}
+}
+
+func TestProvider_Chat_BadRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"type":"invalid_request_error","message":"unknown model"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, err)
+	if aiErr.Kind != ErrBadRequest {
+		t.Errorf("Kind = %q", aiErr.Kind)
+	}
+	if !strings.Contains(aiErr.Message, "unknown model") {
+		t.Errorf("expected upstream message in error, got %q", aiErr.Message)
+	}
+}
+
+func TestProvider_Chat_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"type":"server_error","message":"oops"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, err)
+	if aiErr.Kind != ErrServerError {
+		t.Errorf("Kind = %q", aiErr.Kind)
+	}
+	if aiErr.Status != 500 {
+		t.Errorf("Status = %d", aiErr.Status)
+	}
+}
+
+func TestProvider_Chat_NetworkError(t *testing.T) {
+	// Point at a port that's almost certainly closed.
+	cfg := &Config{
+		BaseURL:        "http://127.0.0.1:1/v1",
+		Model:          "x",
+		TimeoutSeconds: 2,
+	}
+	p, err := NewOpenAICompatProvider(cfg)
+	if err != nil {
+		t.Fatalf("NewOpenAICompatProvider: %v", err)
+	}
+	_, chatErr := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, chatErr)
+	if aiErr.Kind != ErrNetwork {
+		t.Errorf("Kind = %q, want %q", aiErr.Kind, ErrNetwork)
+	}
+}
+
+func TestProvider_Chat_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(canonicalSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := &Config{
+		BaseURL:        server.URL + "/v1",
+		Model:          "test-model",
+		TimeoutSeconds: 1,
+	}
+	p, _ := NewOpenAICompatProvider(cfg)
+	// Use a context with a tight deadline so we don't wait the full
+	// 1-second client timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := p.Chat(ctx, ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, err)
+	if aiErr.Kind != ErrTimeout {
+		t.Errorf("Kind = %q", aiErr.Kind)
+	}
+}
+
+func TestProvider_Chat_StreamingResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\ndata: [DONE]\n\n"))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, err)
+	if aiErr.Kind != ErrStreamingUnsupported {
+		t.Errorf("Kind = %q", aiErr.Kind)
+	}
+}
+
+func TestProvider_Chat_HTMLResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body>proxy error</body></html>"))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, err)
+	if aiErr.Kind != ErrBadResponse {
+		t.Errorf("Kind = %q", aiErr.Kind)
+	}
+	if !strings.Contains(aiErr.Message, "proxy error") {
+		t.Errorf("expected body snippet in error, got %q", aiErr.Message)
+	}
+}
+
+func TestProvider_Chat_MalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{not valid json`))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, err)
+	if aiErr.Kind != ErrBadResponse {
+		t.Errorf("Kind = %q", aiErr.Kind)
+	}
+}
+
+func TestProvider_Chat_EmptyChoices(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"x","choices":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, err)
+	if aiErr.Kind != ErrBadResponse {
+		t.Errorf("Kind = %q", aiErr.Kind)
+	}
+}
+
+func TestProvider_Chat_ContentAsArray(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "model":"x",
+  "choices":[{"message":{"role":"assistant","content":[{"type":"text","text":"hello "},{"type":"text","text":"world"}]},"finish_reason":"stop"}]
+}`))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	resp, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Content != "hello world" {
+		t.Errorf("Content = %q", resp.Content)
+	}
+}
+
+func TestProvider_Chat_ContentUnrecognizedShape(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"x","choices":[{"message":{"role":"assistant","content":42},"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, err)
+	if aiErr.Kind != ErrBadResponse {
+		t.Errorf("Kind = %q", aiErr.Kind)
+	}
+}
+
+func TestProvider_Chat_OptionalFieldsMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hi"}}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	resp, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Content != "hi" {
+		t.Errorf("Content = %q", resp.Content)
+	}
+	if resp.Usage != (Usage{}) {
+		t.Errorf("expected zero usage, got %+v", resp.Usage)
+	}
+	if resp.FinishReason != "" {
+		t.Errorf("FinishReason = %q", resp.FinishReason)
+	}
+}
+
+func TestProvider_Chat_ErrorEnvelopeOn200(t *testing.T) {
+	// apfel quirk: streaming endpoint returns 200 + SSE body containing
+	// {"error":...}. We catch this via the Content-Type check.
+	// This test covers a different quirk: 200 + JSON body that is an
+	// error envelope (some compat layers do this).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"error":{"type":"invalid_request_error","message":"weird"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, err)
+	if aiErr.Kind != ErrBadRequest {
+		t.Errorf("Kind = %q", aiErr.Kind)
+	}
+	if !strings.Contains(aiErr.Message, "weird") {
+		t.Errorf("expected upstream message, got %q", aiErr.Message)
+	}
+}
+
+func TestProvider_Chat_BaseURLTrailingSlash(t *testing.T) {
+	var path string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(canonicalSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := &Config{
+		BaseURL:        server.URL + "/v1/",
+		Model:          "test-model",
+		TimeoutSeconds: 5,
+	}
+	p, _ := NewOpenAICompatProvider(cfg)
+	if _, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if path != "/v1/chat/completions" {
+		t.Errorf("path = %q, want /v1/chat/completions", path)
+	}
+}
+
+// TestProvider_Chat_KeyNeverLeaks is the table-driven sentinel test that
+// exercises every error path and asserts the API key sentinel string
+// appears in NO returned error message and NO captured log line.
+func TestProvider_Chat_KeyNeverLeaks(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			"401_auth",
+			func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = fmt.Fprintf(w, `{"error":{"type":"authentication_error","message":"received key %s"}}`, sentinelKey)
+			},
+		},
+		{
+			"429_rate_limited",
+			func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = fmt.Fprintf(w, `{"error":{"type":"rate_limit_error","message":"key %s rate limited"}}`, sentinelKey)
+			},
+		},
+		{
+			"500_server_error",
+			func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = fmt.Fprintf(w, `{"error":{"type":"server_error","message":"failure with key %s"}}`, sentinelKey)
+			},
+		},
+		{
+			"400_bad_request",
+			func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = fmt.Fprintf(w, `{"error":{"type":"invalid_request_error","message":"key %s is unknown"}}`, sentinelKey)
+			},
+		},
+		{
+			"html_proxy_error",
+			func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/html")
+				_, _ = fmt.Fprintf(w, "<html>received key: %s</html>", sentinelKey)
+			},
+		},
+		{
+			"malformed_json_with_key_in_body",
+			func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{not json key=%s`, sentinelKey)
+			},
+		},
+		{
+			"sse_stream",
+			func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = fmt.Fprintf(w, "data: {\"error\":{\"message\":\"key %s\"}}\n\n", sentinelKey)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(tc.handler)
+			t.Cleanup(server.Close)
+
+			var logBuf strings.Builder
+			restore := captureLog(&logBuf)
+			t.Cleanup(restore)
+
+			p := newTestProvider(t, server, "LEAK_TEST_KEY")
+			_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if strings.Contains(err.Error(), sentinelKey) {
+				t.Errorf("API key leaked into error: %q", err.Error())
+			}
+			if strings.Contains(logBuf.String(), sentinelKey) {
+				t.Errorf("API key leaked into log: %q", logBuf.String())
+			}
+		})
+	}
+}
+
+func TestProvider_Chat_BodySnippetUTF8Safe(t *testing.T) {
+	// Build a body where a multi-byte rune (’ = U+2019, 3 bytes in
+	// UTF-8) starts before byte 200 but ends after.
+	prefix := strings.Repeat("a", 199)
+	bodyText := prefix + "’" + " trailing"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(bodyText))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, err)
+	// The snippet should be valid UTF-8 — it must not contain a half rune.
+	for i, r := range aiErr.Message {
+		if r == '\uFFFD' {
+			t.Errorf("snippet contains replacement char at byte %d: %q", i, aiErr.Message)
+			break
+		}
+	}
+}
+
+func TestProvider_Chat_LogsSuccessAndFailure(t *testing.T) {
+	// Success path
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(canonicalSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	var logBuf strings.Builder
+	restore := captureLog(&logBuf)
+	t.Cleanup(restore)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	if _, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, `msg="ai request ok"`) {
+		t.Errorf("expected success log line, got %q", logs)
+	}
+	if !strings.Contains(logs, "level=INFO") {
+		t.Errorf("expected INFO level in log, got %q", logs)
+	}
+	if !strings.Contains(logs, "status=200") {
+		t.Errorf("expected status=200 in log, got %q", logs)
+	}
+	if !strings.Contains(logs, "prompt_tokens=20") {
+		t.Errorf("expected prompt_tokens=20 in log, got %q", logs)
+	}
+}
+
+func TestProvider_Chat_LogsFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"type":"server_error","message":"oops"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var logBuf strings.Builder
+	restore := captureLog(&logBuf)
+	t.Cleanup(restore)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, _ = p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	logs := logBuf.String()
+	if !strings.Contains(logs, `msg="ai request failed"`) {
+		t.Errorf("expected failure log, got %q", logs)
+	}
+	if !strings.Contains(logs, "level=WARN") {
+		t.Errorf("expected WARN level in log, got %q", logs)
+	}
+	if !strings.Contains(logs, "status=500") {
+		t.Errorf("expected status=500 in log, got %q", logs)
+	}
+}
+
+func TestProvider_Chat_ResponseTooLarge(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Write > 10 MiB
+		big := make([]byte, maxResponseBytes+10)
+		for i := range big {
+			big[i] = 'a'
+		}
+		_, _ = w.Write(big)
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, err)
+	// Either ErrBadResponse (truncation hit) or ErrNetwork (depending on
+	// whether the limit error trips at read time).
+	if aiErr.Kind != ErrBadResponse && aiErr.Kind != ErrNetwork {
+		t.Errorf("Kind = %q, want bad_response or network", aiErr.Kind)
+	}
+}
+
+// --- helpers ---
+
+func assertAIError(t *testing.T, err error) *Error {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var aiErr *Error
+	if !errors.As(err, &aiErr) {
+		t.Fatalf("expected *Error, got %T: %v", err, err)
+	}
+	return aiErr
+}
+
+// captureLog redirects the slog default logger output to a buffer and
+// returns a function that restores it. We have to serialize through a
+// global mutex because slog.SetDefault is process-global state.
+//
+// IMPORTANT: do not call t.Parallel() in tests that use captureLog —
+// they will race against each other and against any other test that
+// emits a log line via slog.
+var logMu sync.Mutex
+
+func captureLog(buf io.Writer) func() {
+	logMu.Lock()
+	prev := slog.Default()
+	// Use LevelDebug so we capture every level the production code emits.
+	handler := slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	slog.SetDefault(slog.New(handler))
+	return func() {
+		slog.SetDefault(prev)
+		logMu.Unlock()
+	}
+}
+
+// Static check: chatRequestWire should round-trip with omitempty for
+// pointer fields. This is a regression guard against accidentally
+// changing the field types.
+func TestChatRequestWire_OmitEmpty(t *testing.T) {
+	body, err := json.Marshal(chatRequestWire{
+		Model:    "x",
+		Messages: []messageWire{{Role: "user", Content: "hi"}},
+		Stream:   false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(body)
+	if strings.Contains(s, "temperature") {
+		t.Errorf("temperature should be omitted when nil, got %s", s)
+	}
+	if strings.Contains(s, "max_tokens") {
+		t.Errorf("max_tokens should be omitted when nil, got %s", s)
+	}
+
+	zero := 0.0
+	body2, _ := json.Marshal(chatRequestWire{
+		Messages:    []messageWire{{Role: "user", Content: "hi"}},
+		Temperature: &zero,
+	})
+	if !strings.Contains(string(body2), `"temperature":0`) {
+		t.Errorf("temperature=0 should be sent as 0, got %s", body2)
+	}
+}

--- a/internal/ai/openai_test.go
+++ b/internal/ai/openai_test.go
@@ -475,6 +475,62 @@ func TestProvider_Chat_OptionalFieldsMissing(t *testing.T) {
 	}
 }
 
+// TestProvider_Chat_ChoiceWithoutMessage covers the edge case where the
+// upstream returns a 2xx JSON body containing a choice that omits the
+// "message" object entirely. Some providers have been observed to do
+// this under load. Without explicit handling we would silently surface
+// empty content as success — see review finding F5.
+func TestProvider_Chat_ChoiceWithoutMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"x","choices":[{"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	aiErr := assertAIError(t, err)
+	if aiErr.Kind != ErrBadResponse {
+		t.Errorf("Kind = %q, want %q", aiErr.Kind, ErrBadResponse)
+	}
+	if !strings.Contains(aiErr.Message, "no message") {
+		t.Errorf("expected 'no message' in error, got %q", aiErr.Message)
+	}
+}
+
+// TestProvider_Chat_NoRedirectFollow verifies that the provider does
+// not follow HTTP redirects. None of the OpenAI-compat providers we
+// target use redirects in their normal flow; following them would let
+// a misconfigured proxy or DNS cache redirect a request to a path the
+// user did not authorize. Review finding F7.
+func TestProvider_Chat_NoRedirectFollow(t *testing.T) {
+	var followed bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/elsewhere" {
+			followed = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(canonicalSuccessBody))
+			return
+		}
+		http.Redirect(w, r, "/elsewhere", http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(server.Close)
+
+	p := newTestProvider(t, server, "TEST_KEY")
+	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	if err == nil {
+		t.Fatal("expected error when upstream returns a redirect")
+	}
+	if followed {
+		t.Error("client followed the redirect; CheckRedirect should have refused")
+	}
+	// The 307 has no Content-Type, so we surface it as ErrBadResponse.
+	aiErr := assertAIError(t, err)
+	if aiErr.Kind != ErrBadResponse {
+		t.Errorf("Kind = %q, want %q", aiErr.Kind, ErrBadResponse)
+	}
+}
+
 func TestProvider_Chat_ErrorEnvelopeOn200(t *testing.T) {
 	// apfel quirk: streaming endpoint returns 200 + SSE body containing
 	// {"error":...}. We catch this via the Content-Type check.
@@ -608,6 +664,71 @@ func TestProvider_Chat_KeyNeverLeaks(t *testing.T) {
 	}
 }
 
+// TestProvider_Chat_KeyNeverLeaks_SuccessPath complements the
+// error-path leak test by exercising the happy path: logRequestStart
+// and logRequestSuccess must not embed the API key in their structured
+// log fields, even though they have access to base_url and model.
+func TestProvider_Chat_KeyNeverLeaks_SuccessPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(canonicalSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	var logBuf strings.Builder
+	restore := captureLog(&logBuf)
+	t.Cleanup(restore)
+
+	p := newTestProvider(t, server, "LEAK_TEST_KEY")
+	if _, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if strings.Contains(logBuf.String(), sentinelKey) {
+		t.Errorf("API key leaked into log on success path: %q", logBuf.String())
+	}
+	// Sanity check: we should at least have logged something on the
+	// success path, otherwise the leak check is meaningless.
+	if !strings.Contains(logBuf.String(), "ai request ok") {
+		t.Errorf("expected success log line, got %q", logBuf.String())
+	}
+}
+
+// TestProvider_Chat_KeyNeverLeaks_NetworkError covers the network-failure
+// log/error path. wrapNetworkError pulls the underlying error string into
+// the typed *Error.Message field; that string could in principle contain
+// the URL, which on a misconfigured base_url could embed credentials.
+// Defense in depth: assert the sentinel never appears even when the
+// transport itself fails.
+func TestProvider_Chat_KeyNeverLeaks_NetworkError(t *testing.T) {
+	cfg := &Config{
+		BaseURL:        "http://127.0.0.1:1/v1",
+		Model:          "x",
+		APIKeyEnv:      "LEAK_TEST_KEY",
+		TimeoutSeconds: 2,
+	}
+	t.Setenv("LEAK_TEST_KEY", sentinelKey)
+
+	p, err := NewOpenAICompatProvider(cfg)
+	if err != nil {
+		t.Fatalf("NewOpenAICompatProvider: %v", err)
+	}
+
+	var logBuf strings.Builder
+	restore := captureLog(&logBuf)
+	t.Cleanup(restore)
+
+	_, chatErr := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
+	if chatErr == nil {
+		t.Fatal("expected network error")
+	}
+	if strings.Contains(chatErr.Error(), sentinelKey) {
+		t.Errorf("API key leaked into network error: %q", chatErr.Error())
+	}
+	if strings.Contains(logBuf.String(), sentinelKey) {
+		t.Errorf("API key leaked into network failure log: %q", logBuf.String())
+	}
+}
+
 func TestProvider_Chat_BodySnippetUTF8Safe(t *testing.T) {
 	// Build a body where a multi-byte rune (’ = U+2019, 3 bytes in
 	// UTF-8) starts before byte 200 but ends after.
@@ -703,10 +824,11 @@ func TestProvider_Chat_ResponseTooLarge(t *testing.T) {
 	p := newTestProvider(t, server, "TEST_KEY")
 	_, err := p.Chat(context.Background(), ChatRequest{Messages: hiMessages()})
 	aiErr := assertAIError(t, err)
-	// Either ErrBadResponse (truncation hit) or ErrNetwork (depending on
-	// whether the limit error trips at read time).
-	if aiErr.Kind != ErrBadResponse && aiErr.Kind != ErrNetwork {
-		t.Errorf("Kind = %q, want bad_response or network", aiErr.Kind)
+	if aiErr.Kind != ErrBadResponse {
+		t.Errorf("Kind = %q, want %q", aiErr.Kind, ErrBadResponse)
+	}
+	if !strings.Contains(aiErr.Message, "exceeded") {
+		t.Errorf("expected size limit message, got %q", aiErr.Message)
 	}
 }
 

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -1,0 +1,65 @@
+package ai
+
+import "context"
+
+// Provider is the unified interface for AI capabilities.
+//
+// Today it has only Chat. A future ticket will add Embed for embeddings,
+// at which point implementations grow a method and test fakes need a
+// stub. The Lua runtime field and option are deliberately named after
+// Provider (not Client) so adding capabilities does not require a
+// parallel wiring path.
+//
+// Implementations must be safe to share across goroutines. Concurrency
+// at the Lua-binding layer is constrained: gopher-lua *lua.LState is
+// not safe for concurrent use, so callers should ensure ai.chat is
+// called serially per LState. The same Provider instance can serve any
+// number of LStates concurrently as long as the implementation itself
+// is thread-safe (the OpenAI-compat provider is, because http.Client
+// is).
+type Provider interface {
+	// Chat sends a chat completion request and returns the response.
+	// On failure it returns a *Error (typed via ErrKind) — callers
+	// can use errors.As(err, &aiErr) to inspect the kind.
+	Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error)
+}
+
+// Message is one entry in a chat conversation.
+type Message struct {
+	Role    string // "system", "user", "assistant"
+	Content string
+}
+
+// ChatRequest is the input to Provider.Chat.
+//
+// Temperature and MaxTokens are pointers so callers can distinguish
+// "explicitly set to zero" from "unset" — temperature=0 is the most
+// common deterministic-sampling setting and must round-trip correctly.
+// Nil pointers are omitted from the wire JSON; non-nil pointers are
+// always sent.
+type ChatRequest struct {
+	Messages    []Message
+	Model       string   // optional; provider falls back to Config.Model
+	Temperature *float64 // optional
+	MaxTokens   *int     // optional
+}
+
+// ChatResponse is the response from Provider.Chat.
+//
+// Optional upstream fields (Usage, FinishReason, Model) are zero-valued
+// when the upstream provider omits them. Implementations tolerate
+// providers that diverge from the canonical OpenAI shape.
+type ChatResponse struct {
+	Content      string
+	Model        string
+	FinishReason string
+	Usage        Usage
+}
+
+// Usage is the token accounting block. Zero values mean the provider
+// did not report usage.
+type Usage struct {
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+}

--- a/internal/ai/redact.go
+++ b/internal/ai/redact.go
@@ -1,0 +1,32 @@
+package ai
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// redactKey returns s with all occurrences of key (and "Bearer <key>")
+// replaced with "<REDACTED>". When key is empty, s is returned unchanged.
+//
+// This is a defense-in-depth helper used at error and log construction
+// sites that *could* see the API key. The key should never be passed
+// into error messages in the first place; this is the safety net.
+func redactKey(s, key string) string {
+	if key == "" {
+		return s
+	}
+	out := s
+	// Order matters: replace the longer "Bearer <key>" form first so
+	// the literal substring is fully removed before we touch the key
+	// itself.
+	out = strings.ReplaceAll(out, "Bearer "+key, "<REDACTED>")
+	out = strings.ReplaceAll(out, key, "<REDACTED>")
+	return out
+}
+
+// jsonUnmarshal is a thin wrapper that exists so errors.go can call into
+// encoding/json without an import cycle when we eventually move helpers
+// around. Today it is just json.Unmarshal.
+func jsonUnmarshal(data []byte, v any) error {
+	return json.Unmarshal(data, v)
+}

--- a/internal/ai/redact.go
+++ b/internal/ai/redact.go
@@ -1,7 +1,6 @@
 package ai
 
 import (
-	"encoding/json"
 	"strings"
 )
 
@@ -22,11 +21,4 @@ func redactKey(s, key string) string {
 	out = strings.ReplaceAll(out, "Bearer "+key, "<REDACTED>")
 	out = strings.ReplaceAll(out, key, "<REDACTED>")
 	return out
-}
-
-// jsonUnmarshal is a thin wrapper that exists so errors.go can call into
-// encoding/json without an import cycle when we eventually move helpers
-// around. Today it is just json.Unmarshal.
-func jsonUnmarshal(data []byte, v any) error {
-	return json.Unmarshal(data, v)
 }

--- a/internal/ai/redact_test.go
+++ b/internal/ai/redact_test.go
@@ -1,0 +1,37 @@
+package ai
+
+import "testing"
+
+func TestRedactKey_Empty(t *testing.T) {
+	if got := redactKey("hello sk-secret world", ""); got != "hello sk-secret world" {
+		t.Errorf("empty key should pass through, got %q", got)
+	}
+}
+
+func TestRedactKey_Simple(t *testing.T) {
+	got := redactKey("auth failed for sk-abc123", "sk-abc123")
+	if got != "auth failed for <REDACTED>" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRedactKey_Bearer(t *testing.T) {
+	got := redactKey("header was: Bearer sk-abc123 (rejected)", "sk-abc123")
+	if got != "header was: <REDACTED> (rejected)" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRedactKey_MultipleOccurrences(t *testing.T) {
+	got := redactKey("sk-abc and again sk-abc", "sk-abc")
+	if got != "<REDACTED> and again <REDACTED>" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRedactKey_NotPresent(t *testing.T) {
+	got := redactKey("nothing to redact", "sk-secret")
+	if got != "nothing to redact" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/internal/cli/flow.go
+++ b/internal/cli/flow.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 
+	"github.com/Sourcehaven-BV/rela/internal/ai"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
@@ -69,6 +70,9 @@ Example:
 		opts := []lua.Option{lua.WithContext(cmd.Context())}
 		if flowOutputDir != "" {
 			opts = append(opts, lua.WithOutputDir(flowOutputDir))
+		}
+		if provider := ai.LoadProvider(flowWs.Paths().CacheDir); provider != nil {
+			opts = append(opts, lua.WithAIProvider(provider))
 		}
 
 		runtime := lua.New(flowWs, flowWs.Meta(), flowWs.Paths().Root, os.Stdout, opts...)

--- a/internal/cli/flow.go
+++ b/internal/cli/flow.go
@@ -71,7 +71,17 @@ Example:
 		if flowOutputDir != "" {
 			opts = append(opts, lua.WithOutputDir(flowOutputDir))
 		}
-		if provider := ai.LoadProvider(flowWs.Paths().CacheDir); provider != nil {
+		// AI is often the whole point of running a flow script, so a
+		// misconfigured ai.yaml should surface immediately rather
+		// than silently disable AI. ErrConfigNotFound is the normal
+		// "no AI" state and is not propagated.
+		provider, providerErr := ai.LoadProvider(flowWs.Paths().CacheDir)
+		switch {
+		case errors.Is(providerErr, ai.ErrConfigNotFound):
+			// no AI configured
+		case providerErr != nil:
+			return fmt.Errorf("ai: %w", providerErr)
+		default:
 			opts = append(opts, lua.WithAIProvider(provider))
 		}
 

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Sourcehaven-BV/rela/internal/ai"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 )
 
@@ -62,6 +63,9 @@ Example:
 		opts := []lua.Option{lua.WithContext(cmd.Context())}
 		if scriptOutputDir != "" {
 			opts = append(opts, lua.WithOutputDir(scriptOutputDir))
+		}
+		if provider := ai.LoadProvider(projectCtx.CacheDir); provider != nil {
+			opts = append(opts, lua.WithAIProvider(provider))
 		}
 
 		runtime := lua.New(ws, meta, projectCtx.Root, os.Stdout, opts...)

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -64,7 +66,19 @@ Example:
 		if scriptOutputDir != "" {
 			opts = append(opts, lua.WithOutputDir(scriptOutputDir))
 		}
-		if provider := ai.LoadProvider(projectCtx.CacheDir); provider != nil {
+		// AI is often the whole point of running a script, so a
+		// misconfigured ai.yaml should surface immediately rather
+		// than silently disable AI and let the script blow up later
+		// with a not_configured error. ErrConfigNotFound is the
+		// normal "no AI" state and is not propagated.
+		provider, err := ai.LoadProvider(projectCtx.CacheDir)
+		switch {
+		case errors.Is(err, ai.ErrConfigNotFound):
+			// no AI configured; the Lua bindings will return
+			// not_configured if the script tries to call ai.*
+		case err != nil:
+			return fmt.Errorf("ai: %w", err)
+		default:
 			opts = append(opts, lua.WithAIProvider(provider))
 		}
 

--- a/internal/lua/ai.go
+++ b/internal/lua/ai.go
@@ -160,10 +160,12 @@ func parseChatRequest(opts *lua.LTable) (ai.ChatRequest, error) {
 	}
 
 	// model (optional)
-	if v, ok := opts.RawGetString("model").(lua.LString); ok {
-		req.Model = string(v)
-	} else if opts.RawGetString("model") != lua.LNil {
-		return req, errors.New("model must be a string")
+	if v := opts.RawGetString("model"); v != lua.LNil {
+		s, ok := v.(lua.LString)
+		if !ok {
+			return req, errors.New("model must be a string")
+		}
+		req.Model = string(s)
 	}
 
 	// temperature (optional)
@@ -214,11 +216,21 @@ func pushAIError(ls *lua.LState, e *ai.Error) int {
 }
 
 // aiErrorToTable converts a *ai.Error to a Lua table with stable fields.
+//
+// The "details" field exposes the wrapped underlying error (if any) so
+// scripts can surface low-level transport detail (TLS cert issue, DNS
+// record, etc.) when the top-level Message isn't enough to diagnose a
+// failure. Empty when there is no cause.
 func aiErrorToTable(ls *lua.LState, e *ai.Error) *lua.LTable {
 	tbl := ls.NewTable()
 	tbl.RawSetString("kind", lua.LString(e.Kind))
 	tbl.RawSetString("status", lua.LNumber(e.Status))
 	tbl.RawSetString("message", lua.LString(e.Message))
 	tbl.RawSetString("retry_after", lua.LNumber(e.RetryAfter.Seconds()))
+	if cause := errors.Unwrap(e); cause != nil {
+		tbl.RawSetString("details", lua.LString(cause.Error()))
+	} else {
+		tbl.RawSetString("details", lua.LString(""))
+	}
 	return tbl
 }

--- a/internal/lua/ai.go
+++ b/internal/lua/ai.go
@@ -1,0 +1,224 @@
+// Lua bindings for the ai.* module.
+//
+// DELIBERATE CONVENTION DEVIATION:
+//
+// All other rela Lua bindings raise errors via ls.RaiseError. The ai.*
+// bindings instead return (nil, err_table) for *expected runtime
+// failures* — network errors, HTTP errors, missing config, rate limits,
+// upstream 5xx, etc. — because AI calls are inherently network-bound and
+// scripts should be able to handle failure inline rather than wrap every
+// call in pcall.
+//
+// PROGRAMMING ERRORS still raise via RaiseError (wrong argument type,
+// empty messages list, malformed messages entry). The taxonomy is:
+//
+//	expected runtime failure  -> (nil, err_table)
+//	programming error         -> RaiseError
+//
+// The error table has stable fields: kind (string), status (number),
+// message (string), retry_after (number, seconds). Scripts branch on
+// err.kind (e.g. "rate_limited", "auth", "server_error", ...) without
+// parsing prose error messages.
+//
+// CONCURRENCY: ai.chat assumes single-threaded LState use. gopher-lua
+// *lua.LState is NOT safe for concurrent goroutine use. ai.Provider
+// implementations must be safe to share across runtimes (the default
+// OpenAICompatProvider is, because http.Client is).
+//
+// Do not "fix" this convention without reading the planning document
+// for TKT-YBKB. The string-error alternative was deliberately rejected.
+package lua
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/Sourcehaven-BV/rela/internal/ai"
+)
+
+// registerAIModule installs the top-level `ai` global with `chat` and
+// `complete` functions. The global is registered unconditionally; if no
+// provider is wired into the Runtime, the functions return a typed
+// not_configured error so scripts can feature-detect uniformly.
+func (r *Runtime) registerAIModule() {
+	tbl := r.L.NewTable()
+	r.L.SetField(tbl, "chat", r.L.NewFunction(r.luaAIChat))
+	r.L.SetField(tbl, "complete", r.L.NewFunction(r.luaAIComplete))
+	r.L.SetGlobal("ai", tbl)
+}
+
+// luaAIChat implements ai.chat({messages, model?, temperature?, max_tokens?})
+// -> (result_table, nil) on success, (nil, err_table) on failure.
+func (r *Runtime) luaAIChat(ls *lua.LState) int {
+	if r.aiProvider == nil {
+		return pushAIError(ls, &ai.Error{
+			Kind:    ai.ErrNotConfigured,
+			Message: "AI is not configured: create .rela/ai.yaml with base_url and model",
+		})
+	}
+
+	opts := ls.CheckTable(1)
+
+	req, parseErr := parseChatRequest(opts)
+	if parseErr != nil {
+		ls.RaiseError("ai.chat: %s", parseErr.Error())
+		return 0
+	}
+
+	resp, err := r.aiProvider.Chat(chatContext(r), req)
+	if err != nil {
+		var aiErr *ai.Error
+		if !errors.As(err, &aiErr) {
+			// Should not happen — every ai package error is *ai.Error.
+			// Treat as a programming bug and raise loudly.
+			ls.RaiseError("ai.chat: unexpected error type %T: %v", err, err)
+			return 0
+		}
+		return pushAIError(ls, aiErr)
+	}
+
+	ls.Push(chatResponseToTable(ls, resp))
+	ls.Push(lua.LNil)
+	return 2
+}
+
+// luaAIComplete implements ai.complete(prompt) -> (string, nil) or
+// (nil, err_table). Convenience wrapper around ai.chat for the common
+// single-user-message case.
+func (r *Runtime) luaAIComplete(ls *lua.LState) int {
+	if r.aiProvider == nil {
+		return pushAIError(ls, &ai.Error{
+			Kind:    ai.ErrNotConfigured,
+			Message: "AI is not configured: create .rela/ai.yaml with base_url and model",
+		})
+	}
+
+	prompt := ls.CheckString(1)
+
+	resp, err := r.aiProvider.Chat(chatContext(r), ai.ChatRequest{
+		Messages: []ai.Message{{Role: "user", Content: prompt}},
+	})
+	if err != nil {
+		var aiErr *ai.Error
+		if !errors.As(err, &aiErr) {
+			ls.RaiseError("ai.complete: unexpected error type %T: %v", err, err)
+			return 0
+		}
+		return pushAIError(ls, aiErr)
+	}
+
+	ls.Push(lua.LString(resp.Content))
+	ls.Push(lua.LNil)
+	return 2
+}
+
+// chatContext returns the context to use for AI calls. If the runtime
+// has a Lua-state context (set by applyTimeout), use that so timeouts
+// propagate; otherwise fall back to context.Background().
+func chatContext(r *Runtime) context.Context {
+	if ctx := r.L.Context(); ctx != nil {
+		return ctx
+	}
+	return context.Background()
+}
+
+// parseChatRequest converts a Lua options table into an ai.ChatRequest.
+// Returns an error for programming mistakes (wrong types, missing
+// messages, etc.) — callers raise these as Lua errors.
+func parseChatRequest(opts *lua.LTable) (ai.ChatRequest, error) {
+	var req ai.ChatRequest
+
+	// messages (required)
+	messagesVal := opts.RawGetString("messages")
+	messagesTbl, ok := messagesVal.(*lua.LTable)
+	if !ok {
+		return req, errors.New("messages must be a table")
+	}
+	count := messagesTbl.Len()
+	if count == 0 {
+		return req, errors.New("messages must not be empty")
+	}
+	req.Messages = make([]ai.Message, 0, count)
+	for i := 1; i <= count; i++ {
+		entryVal := messagesTbl.RawGetInt(i)
+		entryTbl, ok := entryVal.(*lua.LTable)
+		if !ok {
+			return req, fmt.Errorf("messages[%d] must be a table", i)
+		}
+		role, ok := entryTbl.RawGetString("role").(lua.LString)
+		if !ok || role == "" {
+			return req, fmt.Errorf("messages[%d].role must be a non-empty string", i)
+		}
+		content, ok := entryTbl.RawGetString("content").(lua.LString)
+		if !ok {
+			return req, fmt.Errorf("messages[%d].content must be a string", i)
+		}
+		req.Messages = append(req.Messages, ai.Message{Role: string(role), Content: string(content)})
+	}
+
+	// model (optional)
+	if v, ok := opts.RawGetString("model").(lua.LString); ok {
+		req.Model = string(v)
+	} else if opts.RawGetString("model") != lua.LNil {
+		return req, errors.New("model must be a string")
+	}
+
+	// temperature (optional)
+	if tempVal := opts.RawGetString("temperature"); tempVal != lua.LNil {
+		num, ok := tempVal.(lua.LNumber)
+		if !ok {
+			return req, errors.New("temperature must be a number")
+		}
+		t := float64(num)
+		req.Temperature = &t
+	}
+
+	// max_tokens (optional)
+	if maxVal := opts.RawGetString("max_tokens"); maxVal != lua.LNil {
+		num, ok := maxVal.(lua.LNumber)
+		if !ok {
+			return req, errors.New("max_tokens must be a number")
+		}
+		mt := int(num)
+		req.MaxTokens = &mt
+	}
+
+	return req, nil
+}
+
+// chatResponseToTable converts a *ai.ChatResponse to a flat Lua table.
+func chatResponseToTable(ls *lua.LState, resp *ai.ChatResponse) *lua.LTable {
+	tbl := ls.NewTable()
+	tbl.RawSetString("content", lua.LString(resp.Content))
+	tbl.RawSetString("model", lua.LString(resp.Model))
+	tbl.RawSetString("finish_reason", lua.LString(resp.FinishReason))
+
+	usage := ls.NewTable()
+	usage.RawSetString("prompt_tokens", lua.LNumber(resp.Usage.PromptTokens))
+	usage.RawSetString("completion_tokens", lua.LNumber(resp.Usage.CompletionTokens))
+	usage.RawSetString("total_tokens", lua.LNumber(resp.Usage.TotalTokens))
+	tbl.RawSetString("usage", usage)
+
+	return tbl
+}
+
+// pushAIError pushes (nil, err_table) onto the Lua stack and returns 2.
+// The err_table has fields: kind, status, message, retry_after.
+func pushAIError(ls *lua.LState, e *ai.Error) int {
+	ls.Push(lua.LNil)
+	ls.Push(aiErrorToTable(ls, e))
+	return 2
+}
+
+// aiErrorToTable converts a *ai.Error to a Lua table with stable fields.
+func aiErrorToTable(ls *lua.LState, e *ai.Error) *lua.LTable {
+	tbl := ls.NewTable()
+	tbl.RawSetString("kind", lua.LString(e.Kind))
+	tbl.RawSetString("status", lua.LNumber(e.Status))
+	tbl.RawSetString("message", lua.LString(e.Message))
+	tbl.RawSetString("retry_after", lua.LNumber(e.RetryAfter.Seconds()))
+	return tbl
+}

--- a/internal/lua/ai_test.go
+++ b/internal/lua/ai_test.go
@@ -263,6 +263,13 @@ func TestLuaAI_CompleteRejectsNonString(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected Lua error")
 	}
+	// gopher-lua's CheckString reports the type mismatch like
+	// "string expected, got table". Assert a specific substring so a
+	// regression that breaks ai.complete entirely (e.g. global no longer
+	// registered) doesn't accidentally satisfy this test.
+	if !strings.Contains(err.Error(), "string expected") {
+		t.Errorf("expected 'string expected' in error, got: %v", err)
+	}
 }
 
 func TestLuaAI_NoAuthHeaderWhenAPIKeyEnvEmpty(t *testing.T) {

--- a/internal/lua/ai_test.go
+++ b/internal/lua/ai_test.go
@@ -1,0 +1,316 @@
+package lua
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/ai"
+)
+
+const aiSuccessBody = `{
+  "id":"chatcmpl-1",
+  "object":"chat.completion",
+  "model":"gemma3:12b",
+  "choices":[{"index":0,"message":{"role":"assistant","content":"hello from gemma"},"finish_reason":"stop"}],
+  "usage":{"prompt_tokens":20,"completion_tokens":5,"total_tokens":25}
+}`
+
+// newAIRuntime builds a Runtime wired to a fake AI provider pointed at
+// the given test server. apiKeyEnv may be empty for no-auth providers.
+func newAIRuntime(t *testing.T, server *httptest.Server, apiKeyEnv string) *Runtime {
+	t.Helper()
+	if apiKeyEnv != "" {
+		t.Setenv(apiKeyEnv, "test-key-value")
+	}
+	cfg := &ai.Config{
+		BaseURL:        server.URL + "/v1",
+		Model:          "test-model",
+		APIKeyEnv:      apiKeyEnv,
+		TimeoutSeconds: 5,
+	}
+	provider, err := ai.NewOpenAICompatProvider(cfg)
+	if err != nil {
+		t.Fatalf("NewOpenAICompatProvider: %v", err)
+	}
+
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+	rt := New(ws, ws.Meta(), t.TempDir(), &buf, WithAIProvider(provider))
+	t.Cleanup(rt.Close)
+	return rt
+}
+
+// newAIRuntimeNoProvider builds a Runtime with no AI provider wired.
+func newAIRuntimeNoProvider(t *testing.T) *Runtime {
+	t.Helper()
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+	rt := New(ws, ws.Meta(), t.TempDir(), &buf)
+	t.Cleanup(rt.Close)
+	return rt
+}
+
+func TestLuaAI_GlobalAlwaysRegistered(t *testing.T) {
+	rt := newAIRuntimeNoProvider(t)
+	if err := rt.RunString(`
+		assert(type(ai) == "table", "ai global must be a table, got " .. type(ai))
+		assert(type(ai.chat) == "function", "ai.chat must be a function")
+		assert(type(ai.complete) == "function", "ai.complete must be a function")
+	`); err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+}
+
+func TestLuaAI_NotConfiguredError(t *testing.T) {
+	rt := newAIRuntimeNoProvider(t)
+	if err := rt.RunString(`
+		local result, err = ai.chat({messages = {{role="user", content="hi"}}})
+		assert(result == nil, "result should be nil")
+		assert(type(err) == "table", "err should be a table, got " .. type(err))
+		assert(err.kind == "not_configured", "err.kind = " .. tostring(err.kind))
+		assert(string.find(err.message, ".rela/ai.yaml"), "message should mention .rela/ai.yaml, got: " .. err.message)
+	`); err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+}
+
+func TestLuaAI_NotConfiguredError_Complete(t *testing.T) {
+	rt := newAIRuntimeNoProvider(t)
+	if err := rt.RunString(`
+		local result, err = ai.complete("hi")
+		assert(result == nil)
+		assert(err.kind == "not_configured")
+	`); err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+}
+
+func TestLuaAI_ChatSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(aiSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	rt := newAIRuntime(t, server, "TEST_KEY")
+	if err := rt.RunString(`
+		local result, err = ai.chat({messages = {{role="user", content="hi"}}})
+		assert(err == nil, "expected nil err, got " .. tostring(err))
+		assert(type(result) == "table", "result should be a table")
+		assert(result.content == "hello from gemma", "content = " .. tostring(result.content))
+		assert(result.model == "gemma3:12b", "model = " .. tostring(result.model))
+		assert(result.finish_reason == "stop", "finish_reason = " .. tostring(result.finish_reason))
+		assert(type(result.usage) == "table", "usage should be a table")
+		assert(result.usage.prompt_tokens == 20, "prompt_tokens = " .. tostring(result.usage.prompt_tokens))
+		assert(result.usage.completion_tokens == 5)
+		assert(result.usage.total_tokens == 25)
+	`); err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+}
+
+func TestLuaAI_CompleteSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(aiSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	rt := newAIRuntime(t, server, "TEST_KEY")
+	if err := rt.RunString(`
+		local text, err = ai.complete("hi")
+		assert(err == nil)
+		assert(text == "hello from gemma", "text = " .. tostring(text))
+	`); err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+}
+
+func TestLuaAI_HTTPErrorReturnsTypedTable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"type":"server_error","message":"oops"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	rt := newAIRuntime(t, server, "TEST_KEY")
+	if err := rt.RunString(`
+		local result, err = ai.chat({messages = {{role="user", content="hi"}}})
+		assert(result == nil)
+		assert(type(err) == "table")
+		assert(err.kind == "server_error", "kind = " .. tostring(err.kind))
+		assert(err.status == 500, "status = " .. tostring(err.status))
+		assert(string.find(err.message, "oops"), "message = " .. tostring(err.message))
+	`); err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+}
+
+func TestLuaAI_RateLimitedHasRetryAfter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"type":"rate_limit_error","message":"slow down"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	rt := newAIRuntime(t, server, "TEST_KEY")
+	if err := rt.RunString(`
+		local result, err = ai.chat({messages = {{role="user", content="hi"}}})
+		assert(err.kind == "rate_limited")
+		assert(err.status == 429)
+		assert(err.retry_after == 60, "retry_after = " .. tostring(err.retry_after))
+	`); err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+}
+
+func TestLuaAI_TemperatureZeroPropagated(t *testing.T) {
+	var bodyWithTemp, bodyWithoutTemp []byte
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if calls == 0 {
+			bodyWithTemp = body
+		} else {
+			bodyWithoutTemp = body
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(aiSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	rt := newAIRuntime(t, server, "TEST_KEY")
+
+	if err := rt.RunString(`
+		ai.chat({messages={{role="user",content="hi"}}, temperature=0})
+		ai.chat({messages={{role="user",content="hi"}}})
+	`); err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+
+	if !strings.Contains(string(bodyWithTemp), `"temperature":0`) {
+		t.Errorf("first call should have temperature:0, got %s", bodyWithTemp)
+	}
+	if strings.Contains(string(bodyWithoutTemp), `"temperature"`) {
+		t.Errorf("second call should not have temperature key, got %s", bodyWithoutTemp)
+	}
+}
+
+func TestLuaAI_EmptyMessagesRaisesProgrammingError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Errorf("server should not be called for programming error")
+	}))
+	t.Cleanup(server.Close)
+
+	rt := newAIRuntime(t, server, "TEST_KEY")
+	err := rt.RunString(`ai.chat({messages={}})`)
+	if err == nil {
+		t.Fatal("expected Lua error")
+	}
+	if !strings.Contains(err.Error(), "messages must not be empty") {
+		t.Errorf("error = %v", err)
+	}
+}
+
+func TestLuaAI_MessagesNotTableRaises(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Errorf("server should not be called")
+	}))
+	t.Cleanup(server.Close)
+
+	rt := newAIRuntime(t, server, "TEST_KEY")
+	err := rt.RunString(`ai.chat({messages="not a table"})`)
+	if err == nil {
+		t.Fatal("expected Lua error")
+	}
+	if !strings.Contains(err.Error(), "messages must be a table") {
+		t.Errorf("error = %v", err)
+	}
+}
+
+func TestLuaAI_MessageMissingRoleRaises(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Errorf("server should not be called")
+	}))
+	t.Cleanup(server.Close)
+
+	rt := newAIRuntime(t, server, "TEST_KEY")
+	err := rt.RunString(`ai.chat({messages={{content="hi"}}})`)
+	if err == nil {
+		t.Fatal("expected Lua error")
+	}
+	if !strings.Contains(err.Error(), "role") {
+		t.Errorf("error should mention role, got: %v", err)
+	}
+}
+
+func TestLuaAI_CompleteRejectsNonString(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Errorf("server should not be called")
+	}))
+	t.Cleanup(server.Close)
+
+	rt := newAIRuntime(t, server, "TEST_KEY")
+	err := rt.RunString(`ai.complete({})`)
+	if err == nil {
+		t.Fatal("expected Lua error")
+	}
+}
+
+func TestLuaAI_NoAuthHeaderWhenAPIKeyEnvEmpty(t *testing.T) {
+	var receivedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(aiSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	rt := newAIRuntime(t, server, "")
+	if err := rt.RunString(`ai.chat({messages={{role="user",content="hi"}}})`); err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+	if receivedAuth != "" {
+		t.Errorf("expected no Authorization header, got %q", receivedAuth)
+	}
+}
+
+func TestLuaAI_AdditionalParametersPassthrough(t *testing.T) {
+	var bodySeen []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodySeen, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(aiSuccessBody))
+	}))
+	t.Cleanup(server.Close)
+
+	rt := newAIRuntime(t, server, "TEST_KEY")
+	if err := rt.RunString(`
+		ai.chat({
+			messages = {{role="user", content="hi"}},
+			model = "override-model",
+			temperature = 0.5,
+			max_tokens = 100,
+		})
+	`); err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+	body := string(bodySeen)
+	if !strings.Contains(body, `"model":"override-model"`) {
+		t.Errorf("expected override-model in body, got %s", body)
+	}
+	if !strings.Contains(body, `"temperature":0.5`) {
+		t.Errorf("expected temperature:0.5, got %s", body)
+	}
+	if !strings.Contains(body, `"max_tokens":100`) {
+		t.Errorf("expected max_tokens:100, got %s", body)
+	}
+}

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -22,6 +22,7 @@ import (
 
 	lua "github.com/yuin/gopher-lua"
 
+	"github.com/Sourcehaven-BV/rela/internal/ai"
 	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
@@ -66,6 +67,7 @@ type Runtime struct {
 	cancelTimeout context.CancelFunc
 	params        map[string]string // rela.params values (used by action scripts)
 	isAction      bool              // true when running as an action (changes rela.output behavior)
+	aiProvider    ai.Provider       // nil means AI is not configured
 }
 
 // Option configures a Runtime.
@@ -119,6 +121,15 @@ func WithParams(params map[string]string) Option {
 func WithActionMode() Option {
 	return func(r *Runtime) {
 		r.isAction = true
+	}
+}
+
+// WithAIProvider wires an AI provider into the runtime so the ai.* Lua
+// bindings are functional. When omitted, ai.chat and ai.complete return
+// a typed not_configured error.
+func WithAIProvider(p ai.Provider) Option {
+	return func(r *Runtime) {
+		r.aiProvider = p
 	}
 }
 
@@ -393,6 +404,10 @@ func (r *Runtime) registerBindings() {
 	r.registerMarkdownModule(rela)
 
 	r.L.SetGlobal("rela", rela)
+
+	// Top-level ai.* module (always registered; functions return a
+	// typed not_configured error when no provider is wired).
+	r.registerAIModule()
 }
 
 // luaGetEntity implements rela.get_entity(id) -> table|nil

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -4,8 +4,10 @@ package mcp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,7 +68,17 @@ func (s *Server) handleLuaEval(ctx context.Context, req mcp.CallToolRequest) (*m
 	var output bytes.Buffer
 
 	opts := []lua.Option{lua.WithContext(ctx)}
-	if provider := ai.LoadProvider(filepath.Join(projectRoot, ".rela")); provider != nil {
+	// Soft-fail on misconfigured ai.yaml: log + continue without AI
+	// rather than crashing every Lua tool call. The MCP client will
+	// see the not_configured error if their script tries to call ai.*.
+	// ErrConfigNotFound is the normal "no AI" state and is silent.
+	provider, providerErr := ai.LoadProvider(s.ws.Paths().CacheDir)
+	switch {
+	case errors.Is(providerErr, ai.ErrConfigNotFound):
+		// no AI configured
+	case providerErr != nil:
+		slog.Warn("ai: failed to load config; AI bindings disabled", "error", providerErr)
+	default:
 		opts = append(opts, lua.WithAIProvider(provider))
 	}
 	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output, opts...)
@@ -137,7 +149,11 @@ func (s *Server) handleLuaRun(ctx context.Context, req mcp.CallToolRequest) (*mc
 	var output bytes.Buffer
 
 	opts := []lua.Option{lua.WithContext(ctx)}
-	if provider := ai.LoadProvider(filepath.Join(projectRoot, ".rela")); provider != nil {
+	// Soft-fail on misconfigured ai.yaml: log + continue without AI
+	// rather than crashing every Lua tool call.
+	if provider, providerErr := ai.LoadProvider(s.ws.Paths().CacheDir); providerErr != nil {
+		slog.Warn("ai: failed to load config; AI bindings disabled", "error", providerErr)
+	} else if provider != nil {
 		opts = append(opts, lua.WithAIProvider(provider))
 	}
 	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output, opts...)

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 
+	"github.com/Sourcehaven-BV/rela/internal/ai"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 )
 
@@ -64,7 +65,11 @@ func (s *Server) handleLuaEval(ctx context.Context, req mcp.CallToolRequest) (*m
 	// Capture output
 	var output bytes.Buffer
 
-	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output, lua.WithContext(ctx))
+	opts := []lua.Option{lua.WithContext(ctx)}
+	if provider := ai.LoadProvider(filepath.Join(projectRoot, ".rela")); provider != nil {
+		opts = append(opts, lua.WithAIProvider(provider))
+	}
+	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output, opts...)
 	defer runtime.Close()
 
 	if err := runtime.RunString(code); err != nil {
@@ -131,7 +136,11 @@ func (s *Server) handleLuaRun(ctx context.Context, req mcp.CallToolRequest) (*mc
 	// Capture output
 	var output bytes.Buffer
 
-	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output, lua.WithContext(ctx))
+	opts := []lua.Option{lua.WithContext(ctx)}
+	if provider := ai.LoadProvider(filepath.Join(projectRoot, ".rela")); provider != nil {
+		opts = append(opts, lua.WithAIProvider(provider))
+	}
+	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output, opts...)
 	defer runtime.Close()
 
 	// Set script args before execution

--- a/internal/script/executor.go
+++ b/internal/script/executor.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/ai"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/project"
 )
 
 // scriptsDir is the directory where script files must be located.
@@ -63,7 +65,17 @@ func (e *Engine) execute(code string, ctx metamodel.ScriptContext) error {
 
 	var output bytes.Buffer
 	var opts []lua.Option
-	if provider := ai.LoadProvider(filepath.Join(ctx.GetProjectRoot(), ".rela")); provider != nil {
+	// Soft-fail on misconfigured ai.yaml: an automation script firing
+	// on every entity write must not crash the host because the user
+	// has a typo in their AI config. Log it so the user notices.
+	// ErrConfigNotFound is the normal "no AI" state and is silent.
+	provider, providerErr := ai.LoadProvider(filepath.Join(ctx.GetProjectRoot(), project.CacheDir))
+	switch {
+	case errors.Is(providerErr, ai.ErrConfigNotFound):
+		// no AI configured; nothing to log
+	case providerErr != nil:
+		slog.Warn("ai: failed to load config; AI bindings disabled for this run", "error", providerErr)
+	default:
 		opts = append(opts, lua.WithAIProvider(provider))
 	}
 	runtime := lua.New(ws, ctx.GetMeta(), ctx.GetProjectRoot(), &output, opts...)

--- a/internal/script/executor.go
+++ b/internal/script/executor.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Sourcehaven-BV/rela/internal/ai"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
@@ -61,7 +62,11 @@ func (e *Engine) execute(code string, ctx metamodel.ScriptContext) error {
 	}
 
 	var output bytes.Buffer
-	runtime := lua.New(ws, ctx.GetMeta(), ctx.GetProjectRoot(), &output)
+	var opts []lua.Option
+	if provider := ai.LoadProvider(filepath.Join(ctx.GetProjectRoot(), ".rela")); provider != nil {
+		opts = append(opts, lua.WithAIProvider(provider))
+	}
+	runtime := lua.New(ws, ctx.GetMeta(), ctx.GetProjectRoot(), &output, opts...)
 	defer runtime.Close()
 
 	// Set entity context as Lua globals

--- a/internal/validation/lua.go
+++ b/internal/validation/lua.go
@@ -88,7 +88,14 @@ func (e *luaExecutor) validate(
 		return nil // no Lua validation
 	}
 
-	// Create runtime with read-only workspace and discarded stdout
+	// Create runtime with read-only workspace and discarded stdout.
+	//
+	// AI is intentionally NOT wired into validation rules: an AI-powered
+	// rule would call out to a provider on every entity on every analyze
+	// run, with no quota or kill switch. The 5s validation timeout would
+	// also silently clip slow calls. AI-in-validations is tracked as a
+	// follow-up that needs its own design (cost guardrails, opt-in
+	// per rule, longer per-rule budget).
 	runtime := lua.New(e.ws, e.meta, e.projectRoot, io.Discard)
 	defer runtime.Close()
 

--- a/tickets/entities/concepts/ai-integration.md
+++ b/tickets/entities/concepts/ai-integration.md
@@ -1,0 +1,85 @@
+---
+id: ai-integration
+type: concept
+title: AI Integration
+summary: Integration with LLM providers via OpenAI-compatible APIs, exposed to scripts and tooling for content generation, analysis, and transformation.
+description: Unified surface for invoking LLMs from rela. Provides configuration (.rela/ai.yaml) targeting any OpenAI-compatible provider (OpenAI, Anthropic, Ollama, LM Studio, Groq, etc.) and exposes LLM access to scripts (Lua), CLI commands, MCP tools, and the data entry UI in successive slices. Designed to be local-first, human-in-the-loop, auditable, and cost-aware.
+layer: core
+status: draft
+---
+
+## Purpose
+
+A unified surface for invoking large language models from within rela. Enables
+scripts, validations, and (eventually) CLI/UI features to call LLMs for tasks
+like:
+
+- Drafting and improving entity descriptions
+- Suggesting missing relations
+- Detecting duplicates and inconsistencies
+- Generating documentation from structured entities
+- Analyzing content for quality, completeness, and risk
+
+## Provider Strategy
+
+rela targets the **OpenAI Chat Completions API** as the lingua franca. Most LLM
+providers (Anthropic, Groq, Together, Mistral, local runtimes like Ollama and LM
+Studio, etc.) either expose this API natively or have well-maintained
+compatibility layers. Targeting one wire format keeps the integration small
+while supporting the entire ecosystem.
+
+## Configuration
+
+Provider configuration lives in `.rela/ai.yaml` (gitignored, per-user) so
+credentials never enter the project repository. The config specifies the base
+URL, default model, and (optionally) the environment variable holding the API
+key. When `api_key_env` is omitted, no `Authorization` header is sent — this
+supports local providers like Ollama and LM Studio that run without
+authentication.
+
+## Security: Network Egress as a New Threat Class
+
+Adding AI to the Lua sandbox is **not** a no-op against the existing threat
+model. Before AI integration, a malicious Lua script could only damage the
+local project (read entities, write files within project root). After AI
+integration, a malicious script can additionally call `ai.chat` to silently
+exfiltrate every entity in the project to **the user's own legitimate
+provider**. The data lands in the provider's logs — possibly in training data,
+possibly readable by junior staff, possibly billed to the user. The script
+needs no malicious config, no filesystem write, no separate compromise. It
+uses the user's own working setup.
+
+This is a meaningful escalation, not a no-op. Mitigations in the foundation
+slice (TKT-YBKB):
+
+- Operational logging makes unusual call patterns visible (DEBUG/INFO/WARN with structured fields)
+- API is opt-in: requires `.rela/ai.yaml` to exist
+- API key never logged or echoed in errors (`redactKey` helper + table-driven leak test)
+- Config rejects URLs with embedded credentials (`https://user:pass@host`)
+- Response body capped at 10 MiB
+
+Mitigations deferred to follow-up tickets:
+
+- One-time warning on first AI invocation per script or session (needs UX design)
+- Allowlist of script files permitted to use `ai.*`
+- Per-script token / call budgets
+- Network egress audit log
+
+**Treat Lua scripts as trusted code.** The combination of `rela.write_file`
+and `ai.chat` means a malicious script can exfiltrate or corrupt project data.
+
+## Surface Areas
+
+The integration is built up in slices:
+
+1. **Lua bindings** (first slice): `ai.chat()` and `ai.complete()` available inside Lua scripts. Enables user-written automations, validations, and views to call LLMs.
+2. **CLI commands** (future): `rela ai ...` for ad-hoc tasks like description improvement and link suggestion.
+3. **MCP tools** (future): expose AI helpers to AI assistants like Claude Code.
+4. **Data entry UI** (future): inline "✨ Suggest" buttons for property completion and relation discovery.
+
+## Design Principles
+
+- **Local-first option**: Ollama and LM Studio support out of the box — no data leaves the machine unless the user opts into a hosted provider.
+- **Human-in-the-loop**: AI output is always a *proposal*, never a silent edit. Destructive actions remain explicit.
+- **Auditability**: AI calls should be loggable so users can trace why a suggestion was made.
+- **Cost-aware**: Cache where possible; prefer cheaper models by default.

--- a/tickets/entities/features/FEAT-ER3Y.md
+++ b/tickets/entities/features/FEAT-ER3Y.md
@@ -1,0 +1,56 @@
+---
+id: FEAT-ER3Y
+type: feature
+title: AI integration via OpenAI-compatible API
+summary: LLM access throughout rela via configurable OpenAI-compatible providers, starting with Lua bindings.
+description: 'Add a unified AI layer that lets rela call any OpenAI-compatible LLM provider. Configuration lives in .rela/ai.yaml. The integration is built up in slices: first as Lua bindings (ai.chat, ai.complete) so users can write scripts that invoke LLMs, then expanded to CLI commands, MCP tools, and UI features as concrete use cases emerge.'
+priority: medium
+status: proposed
+---
+
+## Motivation
+
+LLMs are well-suited to tasks rela users perform constantly: drafting
+descriptions, suggesting missing relations, detecting duplicates, generating
+documentation, validating content quality. Rather than hardcoding any one of
+these as a feature, expose LLM access as a primitive that users (and future rela
+features) can compose.
+
+## Strategy
+
+**One wire format, many providers.** Target the OpenAI Chat Completions API.
+This gives access to OpenAI, Anthropic (via compatibility layer), Groq,
+Together, Mistral, Ollama, LM Studio, and most other providers without writing
+per-provider code.
+
+**Build up in slices.** Each slice ships independently and proves the design
+before the next one is built.
+
+## Slices
+
+1. **Lua bindings** (this feature's first ticket)
+   - `.rela/ai.yaml` config loader
+   - `internal/ai` package with OpenAI-compatible chat client
+   - `ai.chat({messages, model?, temperature?, max_tokens?})` Lua function
+   - `ai.complete(string)` convenience wrapper
+2. **Embeddings** — `ai.embed(...)` for semantic similarity (relation suggestion, duplicate detection)
+3. **CLI commands** — `rela ai suggest-links`, `rela ai improve`, `rela ai ask`
+4. **MCP tools** — wrap AI helpers as MCP tools so external agents can invoke them
+5. **Caching layer** — content-hash-keyed cache to control cost
+6. **Data entry UI integration** — inline AI affordances in the web UI
+7. **AI-powered validation rules** — Lua validations that use `ai.chat` to flag quality issues
+
+## Design Principles
+
+- **Human-in-the-loop**: AI output is a proposal, never a silent edit
+- **Local-first option**: Ollama / LM Studio work out of the box
+- **Auditability**: Calls should be loggable for traceability
+- **Cost-aware**: Cache aggressively, prefer cheaper models by default
+- **Prompt-injection aware**: Entity content is user-controlled; never auto-execute destructive AI suggestions
+
+## Open Questions
+
+- Embedding model selection (text-embedding-3-small vs local alternatives)
+- How to surface AI call cost / token usage to users
+- Streaming API shape for long generations
+- Whether to support tool use / function calling in the Lua binding

--- a/tickets/entities/implementation-checklists/IMPL-SI2E.md
+++ b/tickets/entities/implementation-checklists/IMPL-SI2E.md
@@ -1,0 +1,155 @@
+---
+id: IMPL-SI2E
+type: implementation-checklist
+title: 'Implementation: Add OpenAI-compatible AI client config and Lua bindings'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+### Unit and integration test results
+
+```
+$ go test ./... 2>&1 | grep -E "FAIL|^ok " | wc -l
+37
+$ go test ./... 2>&1 | grep FAIL
+(empty)
+```
+
+All 37 packages pass. Zero regressions across the entire project after wiring AI
+into 5 entry points (`internal/cli/script.go`, `internal/cli/flow.go`,
+`internal/script/executor.go`, `internal/validation/lua.go`,
+`internal/mcp/tools_lua.go`).
+
+**Coverage:**
+
+```
+$ go test -cover ./internal/ai/
+ok  github.com/Sourcehaven-BV/rela/internal/ai  0.959s  coverage: 93.8% of statements
+$ just coverage-check
+Coverage difference threshold (0.00%) satisfied: PASS
+```
+
+93.8% coverage on `internal/ai`. Coverage ratchet passes.
+
+**Lint:**
+
+```
+$ just lint
+golangci-lint run
+(clean — no output, exit 0)
+```
+
+### Live end-to-end smoke test against real ollama gemma3:12b
+
+```
+$ rela --project=/tmp/rela-ai-smoke script scripts/ai_smoke.lua
+
+=== ai global type ===
+table
+
+=== ai.complete (single-string convenience) ===
+ai: request start base_url=http://127.0.0.1:11434/v1 model=gemma3:12b messages=1
+ai: request ok status=200 model=gemma3:12b latency_ms=8538 prompt_tokens=20 completion_tokens=6 total_tokens=26
+complete result: hello from gemma
+
+=== ai.chat (full form with system prompt, temperature=0) ===
+ai: request start base_url=http://127.0.0.1:11434/v1 model=gemma3:12b messages=2
+ai: request ok status=200 model=gemma3:12b latency_ms=611 prompt_tokens=36 completion_tokens=3 total_tokens=39
+chat content: Four.
+chat model: gemma3:12b
+chat finish_reason: stop
+chat usage prompt_tokens: 36
+chat usage completion_tokens: 3
+chat usage total_tokens: 39
+
+=== Error path: explicit unknown model ===
+ai: request failed kind=bad_request status=404 latency_ms=0 message=model 'definitely-not-a-real-model' not found
+expected error: r3= nil err3.kind= bad_request err3.status= 404
+
+=== ALL SMOKE TESTS PASSED ===
+```
+
+**What was verified end-to-end:**
+
+1. **AC #1 (config loads)**: `.rela/ai.yaml` with `base_url`, `model`, no `api_key_env` — loads, provider builds, requests succeed against ollama with no Authorization header. Optional auth works.
+2. **AC #2 (ai.chat success)**: Lua script calling `ai.chat` against real gemma3:12b returns a populated result table with `content`, `model`, `finish_reason`, `usage.*`. All token counts populated.
+3. **AC #3 (ai.complete success)**: Returns the flat content string "hello from gemma".
+4. **AC #15 (temperature=0)**: Sent distinctly from absent. The "Four." response is from `temperature=0` — verified by both unit test and live test.
+5. **AC #29 (not_configured)**: Verified via `TestLuaAI_NotConfiguredError` (unit) and the always-registered `ai` global behavior.
+6. **Error path (bad_request)**: Real ollama returns 404 for unknown models (not 400 — provider divergence). Our `kindFromStatus` correctly maps it to `bad_request` via the `>=400 && <500` fallback. The typed error table has `kind="bad_request", status=404, message="model '...' not found"`.
+7. **Operational logging**: Every request emits structured log lines with no API key and no message content, exactly as the plan specified.
+8. **API key never leaked**: Sentinel test (`TestProvider_Chat_KeyNeverLeaks`) exercises 7 error scenarios with a poisoned key — passes.
+9. **Provider divergence handling**: Verified via tests for content-as-array, missing usage, missing finish_reason, content-as-integer, etc.
+10. **Stream defense**: Test verifies `stream: false` is always sent and SSE responses are rejected with `ErrStreamingUnsupported`.
+11. **Content-Type validation**: HTML responses produce `ErrBadResponse` with body snippet, not a JSON parse error.
+
+### Files created (10)
+
+- `internal/ai/config.go` — Config struct + LoadConfig + Validate (sentinel `ErrConfigNotFound`)
+- `internal/ai/config_test.go` — config loader tests
+- `internal/ai/provider.go` — Provider interface + ChatRequest/Response/Message/Usage
+- `internal/ai/errors.go` — ErrKind enum, *Error type, classify(), parseRetryAfter, snippet
+- `internal/ai/errors_test.go` — error classifier tests
+- `internal/ai/openai.go` — OpenAICompatProvider HTTP implementation
+- `internal/ai/openai_test.go` — httptest.Server-based provider tests including key-leak sentinel
+- `internal/ai/loader.go` — LoadProvider helper for entry points
+- `internal/ai/loader_test.go` — loader tests
+- `internal/ai/redact.go` — redactKey helper
+- `internal/ai/redact_test.go` — redact tests
+- `internal/lua/ai.go` — Lua bindings (with top-of-file convention deviation comment)
+- `internal/lua/ai_test.go` — Lua-level integration tests
+
+### Files edited (7)
+
+- `internal/lua/runtime.go` — added `aiProvider` field, `WithAIProvider` option, `registerAIModule()` call
+- `internal/cli/script.go` — wire AI provider via `LoadProvider`
+- `internal/cli/flow.go` — same
+- `internal/script/executor.go` — same
+- `internal/validation/lua.go` — same (validation rules can use AI; opt-in by writing rules that call ai.*)
+- `internal/mcp/tools_lua.go` — same (MCP lua_run / lua_eval)
+- `internal/cli/root.go` — improved error message: now wraps the underlying error so users see the real reason (e.g., migration needed) instead of just "no project found"
+- `CLAUDE.md` — added AI Integration section: config schema, Lua API, error taxonomy, security notes
+- `tickets/entities/concepts/ai-integration.md` — added explicit script-level exfiltration threat section
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+**Quality notes:**
+
+- Followed `internal/lua/markdown.go` registration pattern for the AI module
+- Followed `internal/lua/runtime.go` Option pattern (`WithTimeout`, `WithOutputDir`, now `WithAIProvider`)
+- Used stdlib `log` package matching `internal/workspace/workspace.go` (codebase doesn't use slog)
+- API key handling defense-in-depth: never read at construction (commands without AI start fine), `redactKey` helper at every error/log site, sentinel test asserts no leak across 7 error paths, base_url validation rejects user:pass@host
+- All error paths return typed `*ai.Error` (not raw error strings) — Lua scripts get a stable `{kind, status, message, retry_after}` table
+- Provider divergence handled tolerantly: missing usage/finish_reason/model are zero values, content-as-array decodes correctly, error envelopes promoted from HTTP 200 are caught
+- Operational logging emits zero secrets, zero PII, zero message content
+- The `(nil, err_table)` Lua convention split is documented at the top of `internal/lua/ai.go` with the rationale and the LState concurrency invariant

--- a/tickets/entities/planning-checklists/PLAN-FOOU.md
+++ b/tickets/entities/planning-checklists/PLAN-FOOU.md
@@ -1,0 +1,816 @@
+---
+id: PLAN-FOOU
+type: planning-checklist
+title: 'Planning: Add OpenAI-compatible AI client config and Lua bindings'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Addendum — real-world findings from apfel and ollama
+
+After completing the design review, we probed two real OpenAI-compatible
+endpoints (apfel v0.9.1 on Apple FoundationModels, ollama 0.20.3 with gemma3:12b)
+to validate assumptions before implementation. Findings supersede the original
+plan where they conflict.
+
+### Confirmed assumptions
+
+- OpenAI error envelope shape: `{"error": {"message": "...", "type": "..."}}`
+- HTTP 503 with `type: server_error` for transient unavailability
+- HTTP 400 with `type: invalid_request_error` for client errors
+- `Content-Type: application/json` on errors (always)
+- `/v1/chat/completions` and `/v1/models` paths are standard
+- Default port 11434 collides between apfel and ollama (not our problem, but worth noting in docs)
+
+### New findings that change the design
+
+**Finding A — Optional authentication (was a real design hole).**
+Most local providers (ollama, apfel, LM Studio) ship with NO authentication by
+default. The original plan made `api_key_env` required, which would force users
+to invent a fake env var. **Fix:** `api_key_env` is now optional in
+`.rela/ai.yaml`. When absent, no `Authorization` header is sent. When present,
+the env var must be set to a non-empty value at `Chat()` call time or `ErrAuth`
+is returned. New ACs #42-#44 below.
+
+**Finding B — `error.type` is more reliable than HTTP status for classification.**
+SSE responses return HTTP 200 even when the body contains `data: {"error":...}`.
+Some providers return 503 for both transient unavailability AND model loading.
+The plan's `classify()` should prefer `error.type` over HTTP status when present:
+`invalid_request_error` → `ErrBadRequest`, `server_error` → `ErrServerError`,
+`authentication_error` → `ErrAuth`, etc. Falls back to status code when `type` is
+absent or unrecognized.
+
+**Finding C — Provider may publish unsupported parameters in `/v1/models`.**
+apfel's model metadata includes an `unsupported_parameters` array. We deliberately
+send only `model`, `messages`, `stream`, `temperature?`, `max_tokens?` — but
+adding a **negative test** asserting we never accidentally send `logprobs`, `n`,
+`presence_penalty`, `frequency_penalty`, `stop` (the common offenders) would
+catch regression. Added as AC #45.
+
+**Finding D — Streamed error responses arrive on HTTP 200 + SSE.**
+When apfel was probed with `stream: true` while the model was loading, it
+returned `HTTP 200 OK` with `Content-Type: text/event-stream` and the SSE body
+contained `data: {"error": {...}}` followed by `data: [DONE]`. The plan's
+Content-Type check correctly catches this as `ErrStreamingUnsupported` because
+we never request streaming, but the test for AC #17 should use exactly this
+shape (200 + SSE + error chunk + DONE) since it's what real providers do under
+edge conditions.
+
+**Finding E — Error messages may contain non-ASCII (smart quotes).**
+apfel returned `isn't` as `isn’t` (U+2019). Our string operations and the
+`redactKey` helper must be UTF-8 safe (Go's are by default), and the body-snippet
+truncation must not split mid-rune. Added as AC #46.
+
+### Findings deferred to future tickets
+
+- **`/health` endpoint with model availability** — apfel exposes rich diagnostics. A future `ai.health()` Lua function could probe this. Out of scope.
+- **`unsupported_parameters` discovery via `/v1/models`** — could let scripts feature-detect, but adds complexity. Defer until a use case appears.
+- **JSON pretty-printing tolerance** — stdlib `json.Decoder` already handles it; nothing to change.
+
+### Effort impact
+
+The optional-auth change is one config field + one branch in the request
+builder + 3 new ACs. The negative-parameter test is one table-driven test. Total
+~1 hour of additional work. Effort stays at `l`.
+
+---
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem:** rela has no way to invoke LLMs from scripts. Users want to write
+Lua scripts that call out to OpenAI-compatible providers (OpenAI, Ollama, LM
+Studio, Anthropic compat layer, Groq, etc.) for content generation, analysis,
+and transformation. This ticket lays the foundation: config + provider + Lua
+bindings + typed errors + operational logging. Future tickets layer embeddings,
+CLI commands, MCP tools, caching, and UI integration on top.
+
+**Scope (in):**
+
+- `internal/ai` package owning `Config`, `Provider` interface, `OpenAICompatProvider` impl
+- `.rela/ai.yaml` config file: `provider`, `base_url`, `model`, `api_key_env?`, `timeout_seconds?`
+- **`api_key_env` is OPTIONAL.** When absent, no `Authorization` header is sent (supports local auth-free providers like ollama, apfel, LM Studio). When present, the named env var must be set at `Chat()` call time or `ErrAuth` is returned.
+- API key sourced from env var named in config; **read at call time**, not at construction
+- Lua bindings: `ai.chat({messages, model?, temperature?, max_tokens?})` and `ai.complete(string)`
+- Both bindings return `(result, nil)` on success, `(nil, err_table)` on failure
+- **Typed error table** with stable `kind` enum: `not_configured`, `bad_request`, `auth`, `rate_limited`, `server_error`, `timeout`, `network`, `bad_response`, `streaming_unsupported`. Plus `message`, `status`, `retry_after` fields.
+- Optional types for `temperature` and `max_tokens` so `0` is distinguishable from "unset"
+- Wired into the Lua runtime via a new `lua.WithAIProvider` option
+- Operational logging (debug/info/warn) using stdlib `log` to match codebase
+- Provider-divergence handling: tolerate missing `usage`, `finish_reason`; handle `content` as string OR array of content parts
+- Stream defense: send `"stream": false`; reject `text/event-stream` responses with a typed error
+- Content-Type validation before JSON decoding
+- API key redaction helper used at every error and log construction site
+- Unit tests for `internal/ai` using `httptest.Server`
+- Integration test for the Lua binding (sandbox + fake HTTP server)
+- Document network-egress + provider-side exfiltration in CLAUDE.md and the `ai-integration` concept
+
+**Scope (out):**
+
+- Embeddings (`ai.embed`) — separate ticket; the `Provider` interface design supports adding a method without breaking the wiring
+- Caching layer — separate ticket
+- CLI commands (`rela ai ...`) — separate ticket
+- MCP tool wrappers — separate ticket
+- Web UI integration — separate ticket
+- Streaming responses (just rejected as unsupported) — separate ticket
+- Tool use / function calling
+- Multi-provider abstraction beyond OpenAI-compat
+- Pre-built example scripts (suggest-links, validate-with-ai, etc.)
+- Audit logging (every prompt/response stored) — separate ticket
+- Per-call timeout argument (`ai.chat({..., timeout=60})`) — defer
+- Record-and-replay test mode — defer
+- HTTP retries with backoff — defer (the typed `rate_limited` error gives scripts the data to do this themselves)
+- CI precommit hook scanning for API key prefixes — separate ticket; generic secret-scanning concern, not AI-specific
+- Opt-in `--enable-ai` flag — explicitly rejected; AI is always available when configured
+- One-time warning on first AI invocation from a script — deferred to follow-up if it needs UX design
+
+**Acceptance Criteria:**
+
+1. **Config loads from `.rela/ai.yaml`** — Test: write a fixture YAML file in a temp dir, call `ai.LoadConfig`, assert all fields parse correctly.
+2. **Missing config returns a sentinel `nil` config without error** — Test: call `ai.LoadConfig` on a temp dir with no `ai.yaml`, assert `(nil, nil)`.
+3. **Malformed config returns an error** — Test: write invalid YAML, assert `LoadConfig` returns a wrapped error.
+4. **Required config fields validated** — Test: missing `base_url` / `model` / `api_key_env` each return a clear error naming the missing field.
+5. **`base_url` must include scheme** — Test: `base_url: api.openai.com` returns an error; `https://...` and `http://...` accepted.
+6. **`Provider.Chat` succeeds against an OpenAI-compatible endpoint** — Test: `httptest.Server` returning a canned OpenAI response, assert `Response.Content` non-empty and `Response.Usage` populated.
+7. **`Provider.Chat` returns typed `auth` error when API key env var unset** — Test: unset env var, call `Chat`, assert error has `Kind == ErrAuth` and message names the env var. **Construction does NOT read the env var.** Construction succeeds even with unset env var.
+8. **`Provider.Chat` returns typed `auth` error when API key env var empty string** — Same handling as unset.
+9. **`Provider.Chat` returns typed `rate_limited` error on HTTP 429 with `Retry-After`** — Test: fake server returns 429 with `Retry-After: 30`, assert error `Kind == ErrRateLimited`, `Status == 429`, `RetryAfter == 30 * time.Second`.
+10. **`Provider.Chat` returns typed `auth` error on HTTP 401/403** — Test asserts `Kind == ErrAuth`.
+11. **`Provider.Chat` returns typed `bad_request` error on HTTP 400** — Test asserts `Kind == ErrBadRequest`, message includes upstream error envelope.
+12. **`Provider.Chat` returns typed `server_error` on HTTP 5xx** — Test asserts `Kind == ErrServerError`, status preserved.
+13. **`Provider.Chat` returns typed `network` error on connection refused** — Test: client points at `127.0.0.1:1`, assert `Kind == ErrNetwork`.
+14. **`Provider.Chat` returns typed `timeout` error when context deadline exceeded** — Test: fake server sleeps longer than `timeout_seconds`, assert `Kind == ErrTimeout`.
+15. **`Provider.Chat` honors `temperature=0` distinctly from unset** — Test: pass `Temperature: ptr(0.0)`, assert request body contains `"temperature": 0`. Pass nil, assert key absent. Same for `MaxTokens`.
+16. **`Provider.Chat` explicitly sends `"stream": false`** — Test: assert request body contains `"stream": false`.
+17. **`Provider.Chat` rejects `text/event-stream` responses** — Test: fake server responds with `Content-Type: text/event-stream`, assert `Kind == ErrStreamingUnsupported`.
+18. **`Provider.Chat` validates Content-Type before decoding** — Test: fake server returns HTML with `Content-Type: text/html`, assert error `Kind == ErrBadResponse`, message includes status and snippet of body (first 200 bytes).
+19. **`Provider.Chat` handles missing optional response fields** — Tests: missing `usage`, missing `finish_reason`, missing `model` — all succeed with zero values, no error.
+20. **`Provider.Chat` handles `content` as a JSON array of parts** — Test: response has `"content": [{"type":"text","text":"hi"}]`, assert `Response.Content == "hi"`.
+21. **`Provider.Chat` returns `bad_response` for unrecognized content shape** — Test: response has `"content": 42`, assert `Kind == ErrBadResponse` with a clear message.
+22. **`Provider.Chat` returns `bad_response` for empty `choices`** — Test asserts the same.
+23. **`Provider.Chat` returns `bad_response` for malformed JSON** — Test asserts the same; message includes first 200 bytes of body.
+24. **API key never appears in any error message** — **Table-driven test**: poison the env var with a unique sentinel string (`SENTINEL_KEY_ZZZZZ`), exercise *every* error path (auth, rate_limited, network, timeout, bad_response, server_error, streaming_unsupported, bad content-type), assert the sentinel appears in NO returned error's `.Error()` or `.Message`.
+25. **`base_url` with trailing slash works** — Test: `https://api.openai.com/v1/`, assert request goes to `.../v1/chat/completions` (no double slash).
+26. **`base_url` with `user:pass@host` is rejected** — Test asserts config validation error (defends against URL credential leakage).
+27. **Lua: `ai.chat` returns a result table on success** — Test: spin up fake server, build provider, run Lua script `local r, err = ai.chat({messages={{role="user", content="hi"}}}); rela.output(r)`, assert output has `content`, `model`, `finish_reason`, `usage.prompt_tokens`, `usage.completion_tokens`, `usage.total_tokens`.
+28. **Lua: `ai.chat` returns `(nil, err_table)` on HTTP error** — Test: fake server returns 500, assert `r == nil`, `type(err) == "table"`, `err.kind == "server_error"`, `err.status == 500`, `err.message ~= ""`.
+29. **Lua: `ai.chat` returns typed `not_configured` error when no provider wired** — Test: construct runtime *without* `WithAIProvider`, call `ai.chat`, assert `err.kind == "not_configured"`, message mentions `.rela/ai.yaml`.
+30. **Lua: `ai.chat` propagates `temperature=0` distinctly from absent** — Test: Lua `ai.chat({messages=..., temperature=0})` produces a request body with `"temperature": 0`. Lua `ai.chat({messages=...})` (no temperature key) produces a request body without the `temperature` field. Verify by having the fake server echo the received body.
+31. **Lua: empty `messages` list raises a Lua error** — Test: `ai.chat({messages={}})` raises (programming error, uses `RaiseError`).
+32. **Lua: `messages` not a table raises a Lua error** — Test: `ai.chat({messages="hi"})` raises.
+33. **Lua: `messages[i]` missing `role` or `content` raises a Lua error** — Test asserts.
+34. **Lua: `ai.complete(string)` returns a string on success** — Test: fake server returns canned content, assert `text == "<canned>"`.
+35. **Lua: `ai.complete` returns `(nil, err_table)` on failure** — Test: fake server returns 429, assert `err.kind == "rate_limited"`.
+36. **Lua: `ai.complete` rejects non-string argument** — Test: `ai.complete({})` raises a Lua type error (programming error).
+37. **The `ai` global is always registered** — Test: with no `WithAIProvider`, assert `type(ai) == "table"` and `type(ai.chat) == "function"`.
+38. **Operational logging on success** — Test: capture log output, run `Provider.Chat`, assert one info-level line contains `status=200`, `model=...`, `latency_ms=...`, `tokens=...`. Assert NO log line contains the API key sentinel or any message content.
+39. **Operational logging on failure** — Test: capture log output, run failing `Provider.Chat`, assert one warn-level line contains the status code and a body snippet. Assert no API key in log.
+40. **Existing Lua tests pass unchanged** — `go test ./internal/lua/...` passes.
+41. **Coverage ratchet passes** — `just coverage-check` passes.
+42. **Config without `api_key_env` loads successfully** — Test: `.rela/ai.yaml` with only `base_url` and `model`, assert `LoadConfig` succeeds and `Config.APIKeyEnv == ""`.
+43. **`Provider.Chat` sends NO `Authorization` header when `api_key_env` is empty** — Test: fake server records request headers, build provider with `Config.APIKeyEnv == ""`, call `Chat`, assert no `Authorization` header was received.
+44. **`Provider.Chat` sends `Authorization: Bearer <env value>` when `api_key_env` is set** — Test: fake server records request headers, set env var to a sentinel, call `Chat`, assert `Authorization == "Bearer <sentinel>"`.
+45. **`Provider.Chat` never sends unsupported parameters** — Table-driven test: capture the request body sent to a fake server across all `ChatRequest` configurations (with/without temperature, with/without max_tokens), assert the JSON body contains NO keys named `logprobs`, `n`, `presence_penalty`, `frequency_penalty`, `stop`. Locks in our minimal-payload promise.
+46. **Body snippet truncation is UTF-8 safe** — Test: fake server returns an error body containing multi-byte runes (e.g., `isn’t` with U+2019) at byte position 199. Assert the resulting `Error.Message` snippet does not contain a half-rune and decodes as valid UTF-8.
+47. **`error.type` from response body is preferred over HTTP status for classification** — Test: fake server returns HTTP 200 with `{"error": {"type": "invalid_request_error", "message": "..."}}` (a real apfel quirk), assert `Kind == ErrBadRequest`. Test: fake server returns HTTP 503 with `{"error": {"type": "server_error", ...}}`, assert `Kind == ErrServerError`. Test: fake server returns HTTP 401 with no error envelope, assert `Kind == ErrAuth` (status fallback).
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+- **OpenAI Go SDK (`github.com/sashabaranov/go-openai`)**: mature, but heavy dependency tree, opinionated request shape, won't bend gracefully for compat-layer divergences. **Rejected** — the OpenAI Chat Completions API is one POST endpoint; hand-rolling with `net/http` is cleaner, lighter, and lets us tolerate provider quirks.
+- **`github.com/anthropics/anthropic-sdk-go`**: locks us into one provider; defeats the OpenAI-compat strategy. **Rejected.**
+- **`langchaingo`**: massive surface area for "POST a JSON payload, parse the response." **Rejected.**
+
+**Codebase patterns reused:**
+
+- **Lua submodule registration**: `internal/lua/markdown.go:41` (`registerMarkdownModule`). The new `internal/lua/ai.go` follows the same shape: a `registerAIModule()` method on `*Runtime` that builds a table and assigns it.
+- **Lua runtime options**: `internal/lua/runtime.go:67` (`Option func(*Runtime)`) plus `WithTimeout`, `WithOutputDir`. New `WithAIProvider(ai.Provider) Option` follows the same shape.
+- **Lua test helpers**: `internal/lua/runtime_test.go:206` (`TestRunFile_BasicOutput`). Pattern: build mock workspace, construct runtime, run script via `RunString`, parse `rela.output` JSON, assert.
+- **`.rela/` lifecycle**: `.rela/` is gitignored as a whole (`.gitignore` line 14). No new gitignore entry needed.
+- **YAML config loading**: `internal/dataentry/app.go:234` (`loadUserDefaults`) shows the silent-on-missing pattern. We're slightly stricter — `LoadConfig` returns `(nil, nil)` on missing file but errors on malformed YAML or missing required fields.
+- **Logging**: codebase uses stdlib `log` (`internal/workspace/workspace.go:11`), not `slog`. Match that.
+
+**Convention deviation — error handling (deliberate):**
+
+All existing rela Lua bindings raise errors via `ls.RaiseError(...)`. The new
+`ai.*` bindings will instead return `(nil, err_table)` as a deliberate
+exception. **Rationale:** AI calls are network-bound; failure is expected as
+normal operation (transient network errors, rate limits, upstream 500s).
+Wrapping every call in `pcall(function() ... end)` is verbose and obscures
+intent. The two-return pattern lets scripts write idiomatic Lua: `local result,
+err = ai.chat({...}); if not result then ... end`.
+
+**Programming errors still raise** (wrong arg type, empty messages list,
+malformed messages entry). The convention is: "expected runtime failures return
+`nil, err_table`; programming errors raise."
+
+This deviation will be documented in `internal/lua/ai.go` with a top-of-file
+comment so future maintainers don't "fix" it.
+
+**Relevant concepts:**
+
+- `ai-integration` (new) — this ticket is the first slice
+- `lua-scripting` — this ticket extends the Lua surface
+- `FEAT-i5ji` — Lua scripting feature, history of incremental Lua API additions
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+### Package layout
+
+```text
+internal/ai/
+  config.go         Config struct, LoadConfig
+  config_test.go
+  provider.go       Provider interface, types, errors
+  errors.go         ErrKind enum, Error struct, error classifier
+  errors_test.go
+  openai.go         OpenAICompatProvider implementation
+  openai_test.go    httptest.Server-based unit tests
+  redact.go         redactKey helper (used by errors and logging)
+```
+
+### Provider interface (forward-compatible for embeddings)
+
+```go
+// internal/ai/provider.go
+type Provider interface {
+    Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error)
+    // Embed(...) will be added in a future ticket without breaking the
+    // wiring — implementations grow a method, the interface widens, and
+    // every existing test that uses a fake Provider will need to add a
+    // stub. Since fakes are constrained to internal/lua/ai_test.go and
+    // internal/ai/*_test.go, this is acceptable. The alternative
+    // (composition via Chatter + Embedder small interfaces) was
+    // considered and rejected: it forces every consumer to know about
+    // both interfaces and parameterize on the right one.
+}
+
+type ChatRequest struct {
+    Messages    []Message
+    Model       string   // optional; defaults to Config.Model
+    Temperature *float64 // nil = unset; explicit 0 sent as 0
+    MaxTokens   *int     // nil = unset
+}
+
+type Message struct {
+    Role    string // "system" | "user" | "assistant"
+    Content string
+}
+
+type ChatResponse struct {
+    Content      string
+    Model        string
+    FinishReason string
+    Usage        Usage
+}
+
+type Usage struct {
+    PromptTokens     int
+    CompletionTokens int
+    TotalTokens      int
+}
+```
+
+### Typed errors
+
+```go
+// internal/ai/errors.go
+type ErrKind string
+
+const (
+    ErrNotConfigured       ErrKind = "not_configured"
+    ErrAuth                ErrKind = "auth"
+    ErrBadRequest          ErrKind = "bad_request"
+    ErrRateLimited         ErrKind = "rate_limited"
+    ErrServerError         ErrKind = "server_error"
+    ErrTimeout             ErrKind = "timeout"
+    ErrNetwork             ErrKind = "network"
+    ErrBadResponse         ErrKind = "bad_response"
+    ErrStreamingUnsupported ErrKind = "streaming_unsupported"
+)
+
+type Error struct {
+    Kind       ErrKind
+    Status     int           // HTTP status, 0 if not applicable
+    Message    string        // human-readable; never contains secrets
+    RetryAfter time.Duration // 0 if unknown; populated for ErrRateLimited
+    cause      error         // wrapped underlying error, optional
+}
+
+func (e *Error) Error() string  // human-readable, never includes API key
+func (e *Error) Unwrap() error  // returns cause
+```
+
+A package-level `classify(resp *http.Response, body []byte) *Error` function
+maps HTTP responses to typed errors. Used by `OpenAICompatProvider.Chat`.
+
+### Config
+
+```go
+// internal/ai/config.go
+type Config struct {
+    Provider       string `yaml:"provider"`        // optional, informational; if set, must be "openai-compatible"
+    BaseURL        string `yaml:"base_url"`        // required, must include scheme, no userinfo
+    Model          string `yaml:"model"`           // required
+    APIKeyEnv      string `yaml:"api_key_env"`     // OPTIONAL — name of env var holding API key; absent = no auth
+    TimeoutSeconds int    `yaml:"timeout_seconds"` // optional, default 30
+}
+
+// LoadConfig reads .rela/ai.yaml from the given .rela directory.
+// Returns (nil, nil) if the file does not exist (treated as "AI not configured").
+// Returns (nil, err) on parse failure or invalid required fields.
+func LoadConfig(relaDir string) (*Config, error)
+
+// Validate checks required fields and rejects URL credentials, missing scheme, etc.
+func (c *Config) Validate() error
+```
+
+### Provider construction (no env var read)
+
+```go
+// NewOpenAICompatProvider constructs a provider from a Config.
+// It does NOT read the API key. The key is read at Chat() call time
+// from os.Getenv(cfg.APIKeyEnv). This means commands that don't use AI
+// will not fail to start when the env var is unset.
+func NewOpenAICompatProvider(cfg *Config) (Provider, error)
+```
+
+### Wire format
+
+POST `{base_url}/chat/completions`:
+
+```json
+{
+  "model": "gpt-4o-mini",
+  "messages": [{"role": "user", "content": "hi"}],
+  "stream": false,
+  "temperature": 0.2,
+  "max_tokens": 500
+}
+```
+
+`stream: false` is **always** sent. `temperature` and `max_tokens` are omitted
+from the JSON (using `omitempty` on pointer fields) when nil.
+
+Headers: `Content-Type: application/json`. `Authorization: Bearer <key>` is sent ONLY if `Config.APIKeyEnv` is non-empty AND the named env var is set to a non-empty value at call time. If `Config.APIKeyEnv` is set but the env var is unset/empty, return `ErrAuth` before making the HTTP call. If `Config.APIKeyEnv` is empty, no Authorization header is sent at all (supports auth-free local providers).
+
+Response handling:
+
+1. Read up to 10 MiB via `io.LimitReader`. If reader hits the limit, return `ErrBadResponse`.
+2. Validate `Content-Type` includes `json`. If `text/event-stream`, return `ErrStreamingUnsupported`. Otherwise return `ErrBadResponse` with status + first 200 bytes of body.
+3. If status is non-2xx, classify via `classify()` → typed error.
+4. Decode JSON into a tolerant response struct that uses `json.RawMessage` for `choices[0].message.content`.
+5. Parse `content`: try string first, then array of `{type, text}` parts (concatenate `text` fields), else `ErrBadResponse`.
+6. `usage`, `finish_reason`, `model` are all optional — missing → zero values.
+7. If `choices` is empty, return `ErrBadResponse`.
+
+### API key redaction
+
+`redactKey(s string, key string) string` replaces all occurrences of `key` (and
+the substring `Bearer <key>`) with `<REDACTED>`. Used at every error
+construction site that *could* see the key, and in logging. Belt and braces —
+the key shouldn't be passed to error construction in the first place, but the
+helper is the safety net.
+
+### Operational logging
+
+Use stdlib `log` (matching `internal/workspace/workspace.go`). Logger is the
+package-level default; no DI in this slice.
+
+| Event | Level | Fields | NOT logged |
+|---|---|---|---|
+| Request start | DEBUG | base_url (no path), model, message_count | headers, content, key |
+| Success | INFO | status, model, latency_ms, prompt_tokens, completion_tokens | content, key |
+| HTTP error | WARN | status, kind, latency_ms, body snippet (200 bytes, key-redacted) | content, key |
+| Network error | WARN | kind, latency_ms, error message (key-redacted) | content, key |
+
+Tests assert: API key sentinel never appears in captured log output.
+
+### Lua binding
+
+```text
+internal/lua/
+  ai.go       registerAIModule, luaAIChat, luaAIComplete, errorToLuaTable
+  ai_test.go  Integration tests with httptest.Server
+```
+
+Top-of-file comment in `internal/lua/ai.go`:
+
+```go
+// Package lua bindings for ai.* — DELIBERATE CONVENTION DEVIATION.
+//
+// All other rela Lua bindings raise errors via ls.RaiseError. The ai.*
+// bindings instead return (nil, err_table) for *expected runtime failures*
+// (network errors, HTTP errors, missing config, rate limits) because AI
+// calls are inherently network-bound and scripts should be able to handle
+// failure inline rather than wrap every call in pcall.
+//
+// PROGRAMMING ERRORS still raise via RaiseError (wrong argument type,
+// empty messages list, malformed messages entry). The taxonomy is:
+//   - expected runtime failure  -> (nil, err_table)
+//   - programming error         -> RaiseError
+//
+// CONCURRENCY: ai.chat assumes single-threaded LState use. gopher-lua
+// *lua.LState is NOT safe for concurrent goroutine use. ai.Provider
+// implementations must be safe to share across runtimes (the default
+// OpenAICompatProvider is, because http.Client is safe).
+//
+// Do not "fix" this convention without reading the planning document.
+```
+
+```go
+type Runtime struct {
+    // ... existing fields ...
+    aiProvider ai.Provider  // nil means AI is not configured
+}
+
+func WithAIProvider(p ai.Provider) Option {
+    return func(r *Runtime) { r.aiProvider = p }
+}
+
+func (r *Runtime) registerAIModule() {
+    aiTable := r.L.NewTable()
+    r.L.SetField(aiTable, "chat", r.L.NewFunction(r.luaAIChat))
+    r.L.SetField(aiTable, "complete", r.L.NewFunction(r.luaAIComplete))
+    r.L.SetGlobal("ai", aiTable)
+}
+```
+
+`luaAIChat`:
+
+1. If `r.aiProvider == nil`, push `(nil, errorTable(ErrNotConfigured, "AI is not configured: create .rela/ai.yaml"))`, return 2.
+2. Type-check the argument is a table. If not, `RaiseError`.
+3. Type-check `messages` is a non-empty table-of-tables. Each entry must have `role` (string) and `content` (string). On any failure, `RaiseError` with a clear message.
+4. Read optional `model` (string), `temperature` (number), `max_tokens` (integer). **Use `LGetField + LNil check`** to distinguish "key absent" from "key set to 0". Build `*float64` / `*int` accordingly.
+5. Call `r.aiProvider.Chat(r.ctx, req)`.
+6. On error: type-assert to `*ai.Error`, build a Lua table `{kind=..., status=..., message=..., retry_after=...}`, push `(nil, err_table)`, return 2. If the error is somehow not `*ai.Error` (programming bug), `RaiseError` (we want a loud failure during dev).
+7. On success: build a Lua result table with flat fields (`content`, `model`, `finish_reason`, `usage` sub-table), push `(result, nil)`, return 2.
+
+`luaAIComplete`:
+
+1. Type-check argument is a string. If not, `RaiseError`.
+2. Build a `ChatRequest` with one user message.
+3. Call `r.aiProvider.Chat(...)`.
+4. On error: same error-table marshaling as `luaAIChat`. Note: `complete` returns `(nil, err_table)`, NOT `(nil, "string err")` — consistent with `chat`.
+5. On success: push `(content_string, nil)`, return 2.
+
+### Wiring into entry points (concrete)
+
+`grep "lua.New("` finds 5 sites. **AI is wired into 4 of the 5**, deliberately
+excluding `internal/validation/lua.go`:
+
+| File | AI wired? | Notes |
+|---|---|---|
+| `internal/cli/script.go` | YES | `rela script` command — has project context, load AI config |
+| `internal/cli/flow.go` | YES | `rela flow` command — has project context, load AI config |
+| `internal/script/executor.go` | YES | shared script executor for automation Lua actions |
+| `internal/mcp/tools_lua.go` | YES | MCP `lua_run` / `lua_eval` tools — has project context, load AI config |
+| `internal/validation/lua.go` | **NO** | Lua validation rules — see "Why not validation" below |
+
+**Why not validation:** an AI-powered validation rule would call out to a
+provider on **every entity on every analyze run** with no quota, no kill
+switch, and no cost warning. The 5-second validation timeout would also
+silently clip slow AI calls without informing the rule author. Wiring
+AI into validations responsibly needs its own design (per-rule opt-in,
+cost guardrails, longer per-rule budget) — tracked as a follow-up
+ticket.
+
+Each AI-wired site loads `.rela/ai.yaml` via `ai.LoadConfig(ctx.CacheDir)`. If
+`ErrConfigNotFound`, no provider wired (Lua functions return `not_configured`).
+If a `*Config` is returned, build provider via
+`ai.NewOpenAICompatProvider(cfg)` and pass `lua.WithAIProvider(p)`. If config
+load fails for any other reason, log a warning and continue without a provider
+(don't fail the whole command for a malformed AI config).
+
+**Files to modify/create:**
+
+| File | Action | Purpose |
+|---|---|---|
+| `internal/ai/config.go` | new | Config struct + LoadConfig + Validate |
+| `internal/ai/config_test.go` | new | Loader tests (missing/present/malformed/required-field/url-creds) |
+| `internal/ai/provider.go` | new | Provider interface + ChatRequest/Response/Message/Usage types |
+| `internal/ai/errors.go` | new | ErrKind constants, Error struct, classify() |
+| `internal/ai/errors_test.go` | new | Classifier tests |
+| `internal/ai/openai.go` | new | OpenAICompatProvider implementation |
+| `internal/ai/openai_test.go` | new | httptest.Server tests covering all AC scenarios |
+| `internal/ai/redact.go` | new | redactKey helper |
+| `internal/ai/redact_test.go` | new | Redaction tests including edge cases (empty key, key in URL) |
+| `internal/lua/ai.go` | new | registerAIModule + luaAIChat + luaAIComplete + errorToLuaTable + top-of-file convention doc |
+| `internal/lua/ai_test.go` | new | Integration tests through Lua sandbox |
+| `internal/lua/runtime.go` | edit | Add `aiProvider` field, `WithAIProvider` option, call `registerAIModule()` from `registerBindings` |
+| `internal/cli/script.go` | edit | Load AI config + wire into runtime |
+| `internal/cli/flow.go` | edit | Same |
+| `internal/script/executor.go` | edit | Same |
+| `internal/validation/lua.go` | (no edit) | AI deliberately not wired — see Wiring section |
+| `internal/mcp/tools_lua.go` | edit | Same |
+| `CLAUDE.md` | edit | Document AI integration: config, Lua API, network egress + provider exfiltration risk |
+| `tickets/entities/concepts/ai-integration.md` | edit | Add explicit network-egress + exfiltration section |
+
+**Alternatives considered:**
+
+| Alternative | Why rejected |
+|---|---|
+| Use `go-openai` SDK | Heavy dependency, opinionated, fragile across compat layers |
+| `RaiseError` for AI errors | Forces `pcall` for every call; AI failures are expected, not exceptional |
+| String error returns to Lua | Locks API into prose-parsing forever; typed errors are a one-way improvement |
+| `ai.Client` instead of `ai.Provider` (single-purpose) | Forces parallel `aiClient` + `aiEmbedder` Lua plumbing later |
+| Keep `Temperature float64` and document `0` ambiguity | Ships a known correctness footgun; pointers are 30 minutes of work |
+| Read API key at construction (fail fast at startup) | Breaks unrelated commands when env var unset; conflicts with AC #7 |
+| Hang AI config off `project.Context` | Pollutes Context with AI concerns; harder to test |
+| Conditional `ai.*` registration (only if provider configured) | Scripts can't feature-detect cleanly; better to always register |
+| `rela.ai.*` namespace | Less ergonomic; AI calls are conceptually independent of rela |
+| Streaming responses | Out of scope; requires coroutine API design |
+| Caching | Out of scope; needs its own design |
+| HTTP retries with backoff | Out of scope; the typed `rate_limited` error gives scripts what they need to do this themselves |
+| Per-call timeout argument | Out of scope; runtime context handles common case |
+| Linter rule enforcing `(nil, err_table)` for AI bindings | Brittle; top-of-file comment + code review is sufficient |
+| Composition interfaces (`Chatter` + `Embedder`) instead of `Provider` aggregate | More flexible but forces every consumer to parameterize on the right small interface; aggregate is simpler for this codebase |
+| `ai.complete(prompt, opts?)` with system prompt support | Defeats the purpose of the helper; if you need a system prompt, use `ai.chat` |
+
+**Dependencies:**
+
+- `gopkg.in/yaml.v3` (already in go.mod)
+- `net/http`, `encoding/json`, `context`, `log`, `strings`, `time`, `io`, `errors`, `net/url`, `os` (stdlib)
+- No new third-party dependencies
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+| Source | Validation | On Invalid |
+|---|---|---|
+| `.rela/ai.yaml` (file content) | YAML parse + required field check (`base_url`, `model`) + URL scheme + reject userinfo. `api_key_env` is OPTIONAL. | `LoadConfig` returns wrapped error |
+| API key (env var) | Non-empty check at `Chat()` call time IFF `api_key_env` is set in config | Return `ErrAuth` referencing the env var name (NOT the key) |
+| Lua `messages` arg | Type-check non-empty table-of-tables; each entry has `role` (string) and `content` (string) | `RaiseError` (programming error) |
+| Lua `model`, `temperature`, `max_tokens` | Optional; type-check if present | `RaiseError` |
+| Lua `complete(string)` arg | Type-check string | `RaiseError` |
+| Upstream HTTP response | Status code, Content-Type, JSON shape, response size | Return typed `Error` (`ErrBadResponse`, `ErrStreamingUnsupported`, etc.) |
+
+**Security-Sensitive Operations:**
+
+### 1. API key handling
+
+- Key is read from env var, never from a file
+- Key is **read at call time**, never stored long-term in the provider
+- Key is never logged, never echoed in errors, never written to disk
+- Error messages reference the env var *name*, not the value
+- **Optional**: when `api_key_env` is absent from config, no auth is used at all (local providers like ollama, apfel, LM Studio)
+- **`redactKey` helper** is used at every error construction and log site as a belt-and-braces measure (no-op when key is empty)
+- **Table-driven leak test** (AC #24): poison the env var with a sentinel string and assert it appears in NO error or log line across every code path
+
+**Key leak surface considered:**
+
+- Error wrapping (`fmt.Errorf("%w", err)`) — `redactKey` wraps any error message we construct from upstream data
+- Stack traces / panics — we don't `recover` and log request objects; if a panic happens, gopher-lua's recover wraps it but doesn't have the key in scope
+- URL credentials (`https://user:key@host`) — config validation **rejects** any `base_url` with userinfo
+- Test fixtures — addressed by AC #24 (any committed fixture using the sentinel will fail tests if it leaks)
+- CI precommit hook for `sk-` prefix scanning — **deferred** to a separate ticket, generic concern
+
+### 2. Network egress (NEW capability for the Lua sandbox)
+
+- The Lua sandbox previously had no outbound network access (io/os/debug blocked)
+- `ai.chat` is the first sanctioned outbound network call from the sandbox
+- This is a **genuine new capability**, not a no-op against the existing threat model
+
+### 3. Script-level data exfiltration (NEW threat class)
+
+This was undersold in the first draft of the plan. Reframing:
+
+**Before AI integration:** A malicious Lua script can read all entities
+(`rela.list_entities`) and write files (`rela.write_file` within the project
+root). The damage is contained to your local filesystem.
+
+**After AI integration:** A malicious script can additionally call
+`ai.chat({messages={{role="user", content=<entire project dump>}}})`, sending
+project content to **the user's own legitimate provider**. The data lands in the
+provider's logs, possibly in training data, possibly readable by junior staff,
+possibly billed to the user. The script needs no malicious config — it uses the
+user's own working setup. This is a meaningful escalation: contained-to-local
+damage becomes silent third-party data egress.
+
+**Mitigations in this slice:**
+
+- Documentation in CLAUDE.md and the `ai-integration` concept explicitly calling out this threat
+- Operational logging makes it visible *if anyone looks* — scripts that suddenly start hammering the AI endpoint will show up
+- Users are advised: treat Lua scripts as trusted code, the same way you'd treat any code that runs in your project
+- AI is opt-in by virtue of requiring `.rela/ai.yaml` to exist and an API key to be set
+
+**Mitigations deferred:**
+
+- One-time warning on first AI invocation per-script or per-session (needs UX design)
+- Allowlist of script files permitted to use `ai.*`
+- Per-script token / call budgets
+- Network egress audit log
+
+### 4. URL validation
+
+- `base_url` is used as-is for HTTP POST after stripping trailing slash
+- Required: scheme is `http://` or `https://`
+- Required: no userinfo (no `user:pass@host`)
+- **Not** restricted to specific hosts — users want to point at internal endpoints, Ollama on localhost, etc.
+
+### 5. Prompt injection
+
+- Entity content passed into AI prompts is user-controlled
+- **Out of scope** for this ticket: the `internal/ai` layer is just a transport
+- Future tickets that build AI-powered features (suggest-links, etc.) must address this in their own designs
+
+### 6. Response size
+
+- Cap upstream body read at **10 MiB** via `io.LimitReader`
+- If the limit is hit, return `ErrBadResponse` rather than truncating silently
+
+### 7. TLS
+
+- Use the default `http.Client` TLS config (system roots)
+- No `insecure_skip_verify` option in this slice
+
+### 8. SSRF considerations
+
+- Users configure `base_url` themselves; SSRF in the traditional sense (attacker-controlled URL) requires the attacker to first control the config file, which requires filesystem access
+- We do not protect against `base_url: http://169.254.169.254/...` (cloud metadata) because that would prevent legitimate use of `localhost` and internal endpoints
+- Documented as user responsibility
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** see Acceptance Criteria above — each criterion has a
+concrete test.
+
+**Edge Cases:**
+
+| Case | Expected Behavior |
+|---|---|
+| Empty `.rela/ai.yaml` | `LoadConfig` returns error (required fields missing) |
+| `.rela/ai.yaml` missing | `LoadConfig` returns `(nil, nil)`; runtime gets nil provider; Lua returns `not_configured` |
+| Env var named in `api_key_env` is unset | `Chat()` returns `ErrAuth` (NOT construction failure) |
+| Env var is set but empty string | Same — treat empty as unset |
+| `base_url` with trailing slash | Normalize: strip trailing slash before joining `/chat/completions` |
+| `base_url` missing scheme | `Validate()` returns error (require `http://` or `https://`) |
+| `base_url` with `user:pass@host` | `Validate()` returns error |
+| `temperature=0` from Lua | Sent as `"temperature": 0` (pointer is non-nil) |
+| `temperature` absent from Lua | Field omitted from JSON (pointer is nil) |
+| `max_tokens=0` from Lua | Sent as `"max_tokens": 0` |
+| `max_tokens` absent | Field omitted |
+| Empty `messages` | `RaiseError` (programming error) |
+| `messages` not a table | `RaiseError` |
+| `messages` entry missing `role` or `content` | `RaiseError` |
+| Upstream returns SSE stream | `ErrStreamingUnsupported` |
+| Upstream returns HTML error page | `ErrBadResponse` with status + body snippet |
+| Upstream returns 200 with empty `choices` | `ErrBadResponse` |
+| Upstream returns 200 with `content` as string | Success, normal path |
+| Upstream returns 200 with `content` as `[{type, text}]` array | Success, parts concatenated |
+| Upstream returns 200 with `content` as integer | `ErrBadResponse` |
+| Upstream returns 200 with malformed JSON | `ErrBadResponse` with snippet |
+| Upstream returns 200 missing `usage` | Success, `Usage{}` zero values |
+| Upstream returns 200 missing `finish_reason` | Success, empty string |
+| Upstream returns 401 with OpenAI envelope | `ErrAuth`, message includes upstream `error.message` |
+| Upstream returns 403 | `ErrAuth` |
+| Upstream returns 400 with envelope | `ErrBadRequest`, includes upstream message |
+| Upstream returns 429 with `Retry-After: 30` | `ErrRateLimited`, `RetryAfter == 30s` |
+| Upstream returns 429 without `Retry-After` | `ErrRateLimited`, `RetryAfter == 0` |
+| Upstream returns 5xx | `ErrServerError` |
+| Network error (DNS, connection refused) | `ErrNetwork` |
+| Timeout exceeded | `ErrTimeout` |
+| Response body > 10 MiB | `ErrBadResponse` |
+| API key sentinel test | Sentinel never appears in any error or log |
+| Concurrent providers across runtimes | Safe; `http.Client` is safe to share |
+| Single LState used from one goroutine at a time | Safe; documented invariant |
+| Two runtimes constructed without `WithAIProvider` | Both have `ai` global; both `chat` and `complete` return `not_configured` |
+
+**Negative Tests:**
+
+- Invalid YAML → loader returns wrapped error
+- Missing required config field → loader returns error naming the field
+- Missing API key env var → `Chat()` returns `ErrAuth` naming the env var
+- HTTP 401 → `ErrAuth` to Lua
+- HTTP 429 → `ErrRateLimited` with `RetryAfter`
+- HTTP 500 → `ErrServerError`
+- Network unreachable → `ErrNetwork`
+- Timeout → `ErrTimeout`
+- SSE response → `ErrStreamingUnsupported`
+- HTML response → `ErrBadResponse`
+- Lua arg type errors → `RaiseError`
+- `ai.chat` with no provider wired → `ErrNotConfigured`
+
+**Integration Test Approach:**
+
+`internal/lua/ai_test.go` runs the full stack end-to-end:
+
+1. Spin up `httptest.NewServer` returning canned OpenAI-compatible JSON
+2. Build `*ai.Config` pointing at the test server's URL
+3. Set the API key env var via `t.Setenv` to a known value
+4. Build `Provider` via `ai.NewOpenAICompatProvider(cfg)`
+5. Construct `lua.Runtime` with `WithAIProvider(p)`
+6. Run a Lua script via `Runtime.RunString(...)` that calls `ai.chat` and writes to `rela.output`
+7. Parse the output JSON, assert all fields
+
+Plus a parallel suite that exercises every error path through the Lua surface to
+confirm the error tables marshal correctly.
+
+We do NOT mock at the `Provider` interface level for the Lua integration tests —
+the whole point is to verify the wire format, HTTP plumbing, and error
+marshaling.
+
+Provider-level unit tests (`internal/ai/openai_test.go`) DO use
+`httptest.Server` directly without involving Lua, for finer-grained coverage of
+HTTP edge cases.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| OpenAI-compat providers diverge in response shape | High | Medium | Tests for: missing usage, missing finish_reason, content-as-array, content-as-string. Tolerant `json.RawMessage` decoding. |
+| The `(nil, err_table)` convention split causes confusion | Medium | Low | Top-of-file comment + this planning doc as the durable rationale |
+| Network egress + script-level exfiltration is a real new risk class | Medium | Medium | Documented honestly in CLAUDE.md and `ai-integration` concept; operational logging makes it visible |
+| API key leaks via some path we didn't think of | Low | High | `redactKey` helper used everywhere + table-driven sentinel test across all error paths + reject `user:pass@host` URLs |
+| Test flakiness from `httptest.Server` race conditions | Low | Low | `t.Cleanup(server.Close)` |
+| `gopher-lua` LState concurrent use bug | Low | High | Documented invariant; existing rela code does not use Lua coroutines across goroutines |
+| Five wiring sites mean one is missed | Medium | Low | Concrete list in plan; grep `lua.New(` during impl as a final check |
+| Embeddings ticket forces interface refactor | Low | Low | `ai.Provider` aggregate interface is forward-compatible; only test fakes need a stub method |
+| Operational log volume is too high in scripts that call AI in a loop | Low | Low | Default level is INFO; DEBUG-level events are off by default |
+
+**Effort:** **m+** (slightly larger than the original `m` estimate). Roughly:
+
+- `internal/ai/config.go` + tests: small
+- `internal/ai/provider.go`: small (interface only)
+- `internal/ai/errors.go` + tests: small
+- `internal/ai/redact.go` + tests: small
+- `internal/ai/openai.go` + tests: medium-large (the bulk of the work — HTTP plumbing, content-shape handling, error classification, edge cases)
+- `internal/lua/ai.go` + tests: medium (error table marshaling, table-key-presence checks for optional fields)
+- `internal/lua/runtime.go` edit: trivial
+- 5 entry-point wirings: small (one line each, plus error handling)
+- CLAUDE.md update + concept update: small
+- Total: **~1 day** of focused work, larger than the original `m` estimate but justified by the design review fixes.
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] CLAUDE.md — new section: `.rela/ai.yaml` config, Lua `ai.*` API, error taxonomy table, **network egress + script-level exfiltration security note**
+- [x] `ai-integration` concept — add explicit script-level exfiltration threat
+- [x] Top-of-file comment in `internal/lua/ai.go` documenting the `(nil, err_table)` convention split, the programming-error vs runtime-error taxonomy, AND the LState concurrency invariant
+- [x] ~~User guide / reference docs~~ (N/A: no Lua API reference docs exist yet; TKT-CVG6 covers documenting them)
+- [x] ~~CLI help text~~ (N/A: no CLI commands added in this slice)
+- [x] ~~README.md~~ (N/A: project-level readme is unaffected)
+- [x] ~~API docs~~ (N/A: no public API docs to update)
+- Optional: a small example script (deferred unless a natural home appears)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+
+| RR | Severity | Title | Status |
+|---|---|---|---|
+| RR-JV6M | significant | AC #15 contains unfinished editing residue | addressed (AC list rewritten) |
+| RR-Z5XJ | critical | temperature=0 cannot be distinguished from unset | addressed (`*float64` / `*int` end-to-end) |
+| RR-8HSQ | critical | No typed errors or rate-limit handling | addressed (error taxonomy with stable `kind` enum, marshaled as Lua table) |
+| RR-U833 | critical | API key read at construction | addressed (env var read deferred to `Chat()` call) |
+| RR-SNJ8 | significant | Client interface too narrow for embeddings | addressed (renamed to `Provider`, single wiring point) |
+| RR-LUXQ | significant | Lua sandbox concurrency invariants unstated | addressed (top-of-file comment in `internal/lua/ai.go`) |
+| RR-6FMU | significant | Provider-divergence handling hand-waved | addressed (tolerant `json.RawMessage`, content-as-array, missing fields) |
+| RR-TH21 | significant | Streamed response confusion | addressed (`stream: false` always sent, SSE rejected with typed error) |
+| RR-GIK4 | significant | Content-Type validation missing | addressed (validated before decode) |
+| RR-LQ1R | significant | Threat model dismissively framed | addressed (security section rewritten with script-level exfiltration as distinct threat) |
+| RR-N3OU | significant | API key leak surface broader than one test | addressed (`redactKey` helper + table-driven sentinel test; CI scanning deferred) |
+| RR-QIEC | significant | No operational logging | addressed (debug/info/warn requirements added) |

--- a/tickets/entities/review-checklists/REV-DKF9.md
+++ b/tickets/entities/review-checklists/REV-DKF9.md
@@ -2,55 +2,105 @@
 id: REV-DKF9
 type: review-checklist
 title: 'Review: Add OpenAI-compatible AI client config and Lua bindings'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:**
+
+12 design-review RRs from the planning phase (all `addressed`): RR-JV6M (AC #15
+cleanup), RR-Z5XJ (temperature=0), RR-8HSQ (typed errors), RR-U833 (API key
+construction timing), RR-SNJ8 (Provider interface naming), RR-LUXQ (LState
+concurrency invariant), RR-6FMU (provider divergence), RR-TH21 (stream defense),
+RR-GIK4 (Content-Type validation), RR-LQ1R (threat model reframing), RR-N3OU
+(key leak surface), RR-QIEC (operational logging).
+
+19 code-review RRs from the cranky-code-reviewer pass after implementation:
+
+| RR | F# | Title | Status |
+|----|----|-------|--------|
+| RR-ZUPC | F1 | Provider rebuilt per validation rule per entity | addressed (un-wired AI from validation) |
+| RR-T96M | F2 | 5s validation timeout silently caps AI calls | addressed (un-wired) |
+| RR-IA4B | F3 | Unbounded AI spend from validations | addressed (un-wired) |
+| RR-RA9I | F4 | Body-cap returns ErrNetwork not ErrBadResponse | addressed (errBodyTooLarge sentinel) |
+| RR-GK2Z | F5 | Missing choices[0].message silently empty content | addressed (Message pointer + reject) |
+| RR-8VL3 | F6 | base_url allows query-string credentials | addressed (Validate rejects RawQuery) |
+| RR-UQ5H | F7 | No HTTP redirect policy | addressed (CheckRedirect: ErrUseLastResponse) |
+| RR-U20G | F8 | LoadProvider fail-soft wrong for script/flow | addressed ((Provider, error) signature) |
+| RR-9L8P | F9 | Lua error table drops cause | addressed (added details field) |
+| RR-QH8C | F10 | captureLog global mutex | **deferred** (architectural; needs logger DI refactor) |
+| RR-TDHV | F11 | Entry points copy-paste .rela magic string | addressed (Paths().CacheDir / project.CacheDir) |
+| RR-SRCH | F12 | errBodySnippetBytes stale comment | addressed (cleaned) |
+| RR-HWUO | F13 | Pointless jsonUnmarshal wrapper | addressed (deleted, inlined json.Unmarshal) |
+| RR-57JZ | F14 | root.go drive-by | addressed (reverted by rebase; develop has wrapDiscoverError) |
+| RR-2RJW | F15 | Body-cap test accepts two classifications | addressed (asserts exactly ErrBadResponse) |
+| RR-0Z1M | F16 | Weak TestLuaAI_CompleteRejectsNonString | addressed (asserts "string expected") |
+| RR-W876 | F17 | Sentinel leak test gaps | addressed (added _SuccessPath, _NetworkError) |
+| RR-OD1W | F18 | parseChatRequest double-reads model | addressed (single-read style) |
+| RR-GLT3 | F19 | Lua context cancellation pre-existing | addressed (resolved by PR #329 merge) |
+
+**Summary**: 30 of 31 review-responses `addressed`. 1 `deferred` (F10/RR-QH8C —
+captureLog global mutex; documented as a follow-up to inject `*slog.Logger` into
+`ai.Provider`). All critical and significant findings closed.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+| AC | Status | Evidence |
+|----|--------|----------|
+| 1. Config loads from .rela/ai.yaml | PASS | TestLoadConfig_Valid + TestLoadConfig_NoAPIKeyEnv. Live: smoke test against ollama. |
+| 2. ai.chat returns populated result | PASS | TestLuaAI_ChatSuccess. Live: gemma3:12b returned "Four." for "What is 2+2?" |
+| 3. ai.complete returns string | PASS | TestLuaAI_CompleteSuccess. Live: returned "hello from gemma" |
+| 4. Missing config returns not_configured err | PASS | TestLuaAI_NotConfiguredError + TestLuaAI_NotConfiguredError_Complete |
+| 5. Malformed config: script/flow fail at startup | PASS | Verified end-to-end: writing 'not: valid: yaml' to .rela/ai.yaml and running `rela script` printed "ai: parse /path/to/ai.yaml: yaml: mapping values are not allowed in this context" |
+| 6. Network/HTTP errors return typed err | PASS | TestProvider_Chat_RateLimited, _AuthFailed, _BadRequest, _ServerError, _NetworkError, _Timeout, _StreamingResponse, _HTMLResponse, _MalformedJSON, _EmptyChoices, _ChoiceWithoutMessage |
+| 7. temperature=0 distinct from unset | PASS | TestProvider_Chat_TemperatureZeroSentDistinctly + TestLuaAI_TemperatureZeroPropagated (request body capture) |
+| 8. Lua sandbox does not regress | PASS | go test ./internal/lua/... clean |
+| 9. Coverage ratchet | PASS | internal/ai 93.8%; coverage-check passes |
+| 10. Smoke-tested end-to-end | PASS | Real ollama gemma3:12b round-trip + apfel error-path divergence checks |
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: documentation is in CLAUDE.md and the ai-integration concept entity, not in user-facing guides which don't exist for the Lua API yet — TKT-CVG6 covers that)
+- [x] User-facing documentation updated (CLAUDE.md AI Integration section)
+- [x] ~~Docs-checklist marked as done~~ (N/A: no separate docs-checklist created)
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** N/A — see above. CLAUDE.md and the `ai-integration` concept
+entity carry the user-facing reference; the Lua API reference docs are tracked
+separately under TKT-CVG6.
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/336
+
+All 12 CI checks green: Architecture, Build, Coverage Baseline Guard, Docs,
+Frontend, Frontend Coverage Baseline Guard, Fuzz, Lint, Lint Markdown, Rela
+Tickets, Test (+ auto-merge skipping).

--- a/tickets/entities/review-checklists/REV-DKF9.md
+++ b/tickets/entities/review-checklists/REV-DKF9.md
@@ -1,0 +1,56 @@
+---
+id: REV-DKF9
+type: review-checklist
+title: 'Review: Add OpenAI-compatible AI client config and Lua bindings'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-0Z1M.md
+++ b/tickets/entities/review-responses/RR-0Z1M.md
@@ -1,0 +1,9 @@
+---
+id: RR-0Z1M
+type: review-response
+title: 'F16: TestLuaAI_CompleteRejectsNonString asserts only that *some* error occurred'
+finding: 'The test would pass if ai.complete({}) raised ''bad argument #1'' OR ''ai.complete is not defined'' OR ''undefined variable ai'' OR any other Lua error. A future refactor that accidentally broke type checking would slip past.'
+severity: nit
+resolution: Test now also asserts strings.Contains(err.Error(), 'string expected') so a regression that breaks the binding entirely (e.g. ai global no longer registered) cannot accidentally satisfy the assertion.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-2RJW.md
+++ b/tickets/entities/review-responses/RR-2RJW.md
@@ -1,0 +1,9 @@
+---
+id: RR-2RJW
+type: review-response
+title: 'F15: TestProvider_Chat_ResponseTooLarge encodes the bug instead of testing the fix'
+finding: The test asserted aiErr.Kind != ErrBadResponse && aiErr.Kind != ErrNetwork — accepting either classification. 'Either is fine' tests pass even if the implementation is broken in one of the two directions.
+severity: minor
+resolution: Tightened the test (folded into the F4 fix) to assert exactly ErrBadResponse and to verify the message contains 'exceeded'. The dual-classification escape hatch is gone.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-57JZ.md
+++ b/tickets/entities/review-responses/RR-57JZ.md
@@ -1,0 +1,9 @@
+---
+id: RR-57JZ
+type: review-response
+title: 'F14: root.go error wrap is scope creep and can produce misleading messages'
+finding: 'TKT-YBKB included a drive-by edit to internal/cli/root.go that wrapped the workspace.Discover error unconditionally with ''no project found: %w (run rela init to create one)''. The hint was attached even when the underlying error was a permission denied or a corrupt-metamodel parse failure, which is actively misleading.'
+severity: nit
+resolution: 'Resolved by the rebase onto develop: PR #326 (fix(cli): surface real project-discovery errors) landed a proper wrapDiscoverError that uses errors.Is(err, errors.ErrNoProject) to attach the hint only when the project is genuinely absent. My drive-by edit was dropped during conflict resolution; develop''s version is now in place.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-6FMU.md
+++ b/tickets/entities/review-responses/RR-6FMU.md
@@ -1,0 +1,9 @@
+---
+id: RR-6FMU
+type: review-response
+title: Provider-divergence handling is hand-waved; concrete shapes not addressed
+finding: 'Plan says ''treat optional fields as optional'' but only addresses missing usage. Real divergences in OpenAI-compat providers: (1) Ollama returns prompt_eval_count/eval_count instead of usage in some versions, omits both in others; (2) finish_reason may be absent or named done_reason; (3) LM Studio has returned choices[0].text instead of choices[0].message.content for some loaders; (4) some compat layers (Anthropic-style) return content as an array of content parts ({type:text, text:...}) — your string deserialize will fail at JSON unmarshal time or silently produce empty content. Fix: deserialize content as json.RawMessage, then handle both string and array-of-parts shapes. Add tests for: missing usage, missing finish_reason, content-as-array, alternative usage field names. If we cannot reasonably handle a shape, return a clear error naming the shape.'
+severity: significant
+resolution: 'Response decoding now uses json.RawMessage for choices[0].message.content. The decoder tries string first, then array of {type, text} parts (concatenating text fields), else returns ErrBadResponse with a clear message. usage, finish_reason, model are all optional — missing fields produce zero values, not errors. ACs #19 (missing optional fields), #20 (content-as-array), #21 (unrecognized content shape) cover this. Empty choices returns ErrBadResponse (AC #22).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-8HSQ.md
+++ b/tickets/entities/review-responses/RR-8HSQ.md
@@ -1,0 +1,9 @@
+---
+id: RR-8HSQ
+type: review-response
+title: No typed errors or rate-limit handling; scripts must string-match
+finding: 'Plan returns raw err.Error() to Lua as a string. There is no special-casing of HTTP 429, no Retry-After parsing, no error taxonomy. Real OpenAI-compat endpoints return 429 constantly; scripts have no clean way to retry without parsing prose error messages. Even if retries are deferred, the typed error surface must exist now — once strings are returned, the API is locked in. Fix: define an error taxonomy with stable kinds (rate_limit, auth, timeout, upstream, network, bad_response, bad_request, server_error). Surface to Lua as a table {kind, status, message, retry_after} via the second return. This is the leverage opportunity #18 reframed as a critical: the cost of NOT doing this now is much higher than the cost of doing it.'
+severity: critical
+resolution: 'Introduced internal/ai/errors.go with ErrKind enum (not_configured, auth, bad_request, rate_limited, server_error, timeout, network, bad_response, streaming_unsupported) and Error struct {Kind, Status, Message, RetryAfter, cause}. classify() maps HTTP responses to typed errors. Lua binding marshals to a table {kind, status, message, retry_after} as the second return. ACs #9-14, #28, #35 cover the typed error surface. Retries themselves are deferred but the rate_limited error includes RetryAfter so scripts can implement backoff.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-8VL3.md
+++ b/tickets/entities/review-responses/RR-8VL3.md
@@ -1,0 +1,9 @@
+---
+id: RR-8VL3
+type: review-response
+title: 'F6: BaseURL validation allows credentials via query string'
+finding: Validator correctly rejected https://user:secret@host but did NOT reject https://host/v1?api_key=secret or ?token=secret, which some legacy providers (notably old Azure and some compat layers) actually use. That URL would then end up in every logRequestStart line via base_url=, leaking the API key in plaintext to logs. The redactKey path didn't cover this because resolveAPIKey only knows about env-var keys, not embedded query-string ones.
+severity: significant
+resolution: Config.Validate now rejects any base_url with a non-empty RawQuery or Fragment. New TestLoadConfig_BaseURLWithQueryString and TestLoadConfig_BaseURLWithFragment lock it in. Documented inline that auth must come through api_key_env only.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-9L8P.md
+++ b/tickets/entities/review-responses/RR-9L8P.md
@@ -1,0 +1,9 @@
+---
+id: RR-9L8P
+type: review-response
+title: 'F9: aiErrorToTable drops cause, making Lua-side debugging painful'
+finding: The Lua error table exposed kind, status, message, retry_after. The wrapped cause error chain was discarded. For rare/flaky failures where the Go-level error wrapping includes helpful transport detail (TLS cert issue, DNS record, etc.), the script author only saw the top-level Message.
+severity: minor
+resolution: Added a 'details' field to the Lua error table via errors.Unwrap(e). Empty when there is no cause; otherwise contains the unwrapped error string. Documented the field in aiErrorToTable's doc comment so future maintainers understand its purpose.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GIK4.md
+++ b/tickets/entities/review-responses/RR-GIK4.md
@@ -1,0 +1,9 @@
+---
+id: RR-GIK4
+type: review-response
+title: Content-Type validation missing; HTML error pages decode to confusing JSON errors
+finding: 'Plan caps response body at 10 MiB (good for OOM) but does not validate Content-Type before decoding. An HTML error page from a misconfigured corporate proxy decodes to ''unexpected character <'' and the user has no idea their proxy is intercepting traffic. Fix: check Content-Type is application/json (or includes ''json'') before decoding. On mismatch, return an error including upstream status + first 200 bytes of body so the user can diagnose. Apply this to all decode error paths, not just JSON-parse failures.'
+severity: significant
+resolution: 'Provider.Chat now validates Content-Type before JSON decoding. text/event-stream → ErrStreamingUnsupported. Anything else not containing ''json'' → ErrBadResponse with status + first 200 bytes of body. AC #18 tests HTML responses; AC #23 covers malformed JSON with body snippet. Body snippet is key-redacted via redactKey.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GK2Z.md
+++ b/tickets/entities/review-responses/RR-GK2Z.md
@@ -1,0 +1,9 @@
+---
+id: RR-GK2Z
+type: review-response
+title: 'F5: Missing choices[0].message silently swallowed as empty content'
+finding: chatResponseWire.Choices[i].Message was a value type. If the upstream returned {choices:[{finish_reason:stop}]} with no message, Message was zero-valued, Content was a nil json.RawMessage, and decodeContent(nil) returned ('', nil). The caller got a successful *ChatResponse with Content=='' and no error at all. Scripts checking err==nil would happily use the empty string.
+severity: significant
+resolution: 'Made choiceWire.Message a *messageRawWire pointer so absence is detectable. decodeChatResponse now rejects parsed.Choices[0].Message == nil with &Error{Kind: ErrBadResponse, Message: ''upstream returned choice with no message''}. New TestProvider_Chat_ChoiceWithoutMessage covers the path.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GLT3.md
+++ b/tickets/entities/review-responses/RR-GLT3.md
@@ -1,0 +1,9 @@
+---
+id: RR-GLT3
+type: review-response
+title: 'F19: Runtime AI calls don''t propagate the caller''s cancellation context (pre-existing)'
+finding: applyTimeout built the Lua-state context from context.Background(), never from a parent. So Ctrl+C to rela script wouldn't interrupt an in-flight AI HTTP call — only the 30-second HTTP client timeout would. Pre-existing issue but became user-visible once Lua scripts could make 30-second network calls.
+severity: minor
+resolution: 'Resolved upstream by PR #329 (fix(lua): propagate caller cancellation into runtime), which landed in develop as 0f76c4a before TKT-YBKB''s rebase. The Lua runtime now accepts a parent context via lua.WithContext(ctx), and rela script / rela flow / MCP lua_eval+lua_run all wire cmd.Context() through a signal-aware context built via signal.NotifyContext at cli.Execute. Ctrl+C to rela script now interrupts both pure-CPU Lua loops AND in-flight ai.chat calls.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-HWUO.md
+++ b/tickets/entities/review-responses/RR-HWUO.md
@@ -1,0 +1,9 @@
+---
+id: RR-HWUO
+type: review-response
+title: 'F13: jsonUnmarshal wrapper is pointless indirection with a false rationale'
+finding: redact.go contained a jsonUnmarshal wrapper around json.Unmarshal with a comment claiming it 'exists so errors.go can call into encoding/json without an import cycle'. Files in the same Go package cannot have an import cycle with each other; the wrapper was zero-value indirection.
+severity: nit
+resolution: Wrapper deleted from redact.go. errors.go now imports encoding/json directly and calls json.Unmarshal at the call site. redact.go no longer needs the json import.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-IA4B.md
+++ b/tickets/entities/review-responses/RR-IA4B.md
@@ -1,0 +1,9 @@
+---
+id: RR-IA4B
+type: review-response
+title: 'F3: Unbounded AI spend from validation rules — no opt-in, no guardrail'
+finding: Wiring AI into the validation runtime means any validation rule can ai.chat(...) on every entity on every analyze run. No quota, no cost warning, no opt-in flag, no per-project kill switch. A user who innocently drops ai.chat into a rule will wake up to an OpenAI bill or an ollama box at 100% CPU.
+severity: significant
+resolution: Resolved by un-wiring AI from internal/validation/lua.go. Documented in CLAUDE.md, PLAN-FOOU, and inline in validation/lua.go. AI-powered validations need their own design that addresses cost guardrails, per-rule opt-in, and per-rule budget — tracked as a follow-up ticket.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-JV6M.md
+++ b/tickets/entities/review-responses/RR-JV6M.md
@@ -1,0 +1,9 @@
+---
+id: RR-JV6M
+type: review-response
+title: 'AC #15 contains unfinished editing residue'
+finding: 'Acceptance criterion #15 in PLAN-FOOU starts with ''The ai global does not exist when no client is configured...'' and then immediately self-corrects with ''Wait, no: per decision 4, ai global is *always* registered''. The criterion title and body now contradict each other; an automated check or future reader will assert the wrong invariant. This is unfinished editing left in the document and is also a tell that other parts may be sloppy.'
+severity: significant
+resolution: 'Acceptance criteria list completely rewritten in PLAN-FOOU. The contradicting AC is now AC #37: ''The ai global is always registered''. No more ''Wait, no'' residue.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-LQ1R.md
+++ b/tickets/entities/review-responses/RR-LQ1R.md
@@ -1,0 +1,9 @@
+---
+id: RR-LQ1R
+type: review-response
+title: Threat model dismissively framed; script-level exfiltration via legitimate provider is a real new risk
+finding: 'Plan says ''anyone running an untrusted Lua script in their rela project is already compromised'' to dismiss the network-egress addition. This is half right and dangerously framed. Before AI: malicious script can damage your local project (contained). After AI: malicious script can silently exfiltrate every entity to *your own* legitimate provider via ai.chat({messages = {{role=''user'', content=entire_project_dump}}}). The data lands in your provider''s logs (potentially in training data, billing logs, or readable by junior staff). The script needs no malicious config, no filesystem write, no separate compromise. This is a genuine new risk class. Fix: rewrite the security section to acknowledge script-level data exfiltration via the user''s own provider as a distinct threat. Document it honestly in CLAUDE.md and the ai-integration concept. Consider whether `rela script` should print a one-time warning the first time AI is invoked from a script (deferred to a follow-up if the warning needs UX design).'
+severity: significant
+resolution: 'Security section completely rewritten. New ''Script-level data exfiltration (NEW threat class)'' subsection explicitly distinguishes the before-state (contained-to-local damage) from the after-state (silent data egress to user''s own legitimate provider, lands in provider logs / training data / billing logs). CLAUDE.md and the ai-integration concept will document this honestly as part of the implementation. Mitigations listed as deferred: one-time warning, allowlist, per-script budgets, audit log.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-LUXQ.md
+++ b/tickets/entities/review-responses/RR-LUXQ.md
@@ -1,0 +1,9 @@
+---
+id: RR-LUXQ
+type: review-response
+title: Lua sandbox concurrency invariants for ai.chat are unstated
+finding: 'Plan asserts http.Client is safe (true) but never addresses the gopher-lua concurrency model. *lua.LState is NOT safe for concurrent use. If anyone calls ai.chat from a coroutine resumed from a different goroutine, data races. Fix: state the explicit invariant in design and in the top-of-file comment of internal/lua/ai.go: ''one ai.chat call per LState at a time; clients are safe to share across runtimes because the only shared state is http.Client''. Verify test coverage of the single-LState single-goroutine path.'
+severity: significant
+resolution: 'Top-of-file comment in internal/lua/ai.go now explicitly documents the LState concurrency invariant: ''ai.chat assumes single-threaded LState use. gopher-lua *lua.LState is NOT safe for concurrent goroutine use. ai.Provider implementations must be safe to share across runtimes.'' OpenAICompatProvider is safe because http.Client is. Plan''s risk table also lists LState concurrent use as a documented invariant.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-N3OU.md
+++ b/tickets/entities/review-responses/RR-N3OU.md
@@ -1,0 +1,9 @@
+---
+id: RR-N3OU
+type: review-response
+title: API key leak surface broader than the one planned test covers
+finding: 'Plan has one test that an HTTP failure error string does not contain the API key. Other leak sites unaddressed: (1) httputil.DumpRequest used for diagnostics will dump Authorization header; (2) panics with the request object on the stack will print headers in a recover''d %+v log; (3) developers will copy real .rela/ai.yaml into test fixtures; (4) error wrapping that includes a URL with embedded user:key@host. Fix: (a) introduce a redactKey helper used at every error construction and log site; (b) add a table-driven test that uses a poisoned API key string and asserts it appears in NO error returned from any code path across all error scenarios; (c) add a CI check or precommit hook scanning for real API key prefixes (sk-, etc.) in committed files; (d) never log Authorization headers.'
+severity: significant
+resolution: 'Three layers: (1) redactKey helper used at every error and log construction site that could see the key; (2) base_url validation rejects user:pass@host URLs (AC #26); (3) AC #24 is a table-driven test that poisons the env var with a sentinel string (SENTINEL_KEY_ZZZZZ) and asserts it appears in NO error or log line across every code path (auth, rate_limited, network, timeout, bad_response, server_error, streaming_unsupported, bad content-type). Operational logging explicitly excludes Authorization headers. CI precommit hook for sk- prefix scanning is deferred to a separate ticket as a generic secret-scanning concern.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OD1W.md
+++ b/tickets/entities/review-responses/RR-OD1W.md
@@ -1,0 +1,9 @@
+---
+id: RR-OD1W
+type: review-response
+title: 'F18: parseChatRequest double-reads opts.RawGetString(model)'
+finding: Code path called RawGetString('model') twice and used a different style from the temperature/max_tokens optional parsers directly below it.
+severity: nit
+resolution: 'Refactored to match the temperature/max_tokens style: read the value once into a local, check against lua.LNil, then type-assert. Single read, consistent with the rest of the function.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QH8C.md
+++ b/tickets/entities/review-responses/RR-QH8C.md
@@ -1,0 +1,9 @@
+---
+id: RR-QH8C
+type: review-response
+title: 'F10: captureLog test helper races with non-capturing tests via global log.SetOutput'
+finding: log.SetOutput is process-global mutable state. logMu only serializes tests that opt into capture, so if another test in the same package runs in parallel via t.Parallel() and emits a log line while a captureLog-using test holds the lock, the line lands in the captured buffer. Today no tests in this package call t.Parallel() so it's latent, but the moment someone adds it the KeyNeverLeaks test becomes non-deterministic. The right long-term fix is to stop using log.Printf from library code entirely and inject a logger dependency.
+severity: minor
+reason: 'Architectural — slog.Default() is also process-global, so just rewriting captureLog for slog (which we did during the rebase) does not actually fix the race, only renames it. The real fix is to inject a *slog.Logger into the provider via dependency injection so tests can use a per-test instance instead of swapping the global. That requires changing NewOpenAICompatProvider''s signature plus all the entry-point construction sites and is a refactor in its own right. Today no tests in the internal/ai package call t.Parallel() so the race is latent, not active. Documented as a follow-up: ''Inject slog.Logger into ai.Provider to remove global-state race in tests''.'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-QIEC.md
+++ b/tickets/entities/review-responses/RR-QIEC.md
@@ -1,0 +1,9 @@
+---
+id: RR-QIEC
+type: review-response
+title: No operational logging at all; debugging will be miserable
+finding: 'Plan defers ''audit logging'' (every prompt/response stored — fine to defer) but adds zero operational logging. When users report ''AI calls don''t work'', there is nothing to look at — no request URL, no status code, no latency, no token count. This is table-stakes operational visibility, not an audit feature. Fix: add operational logging requirements to the plan. At minimum, using whatever logger the rest of the codebase uses (find during impl): debug log on request start (URL + model + message count, no headers, no content); info log on success (status + latency + token count); warn log on non-2xx with status + truncated body. Explicitly: zero PII, zero secrets, zero prompt content.'
+severity: significant
+resolution: 'Added operational logging requirements using stdlib log (matching internal/workspace/workspace.go). Levels: DEBUG (request start with base_url + model + message_count, no headers/content/key), INFO (success with status + model + latency_ms + token counts), WARN (HTTP/network errors with status + kind + redacted body snippet). ACs #38 and #39 verify log lines and that the API key sentinel never appears in captured log output. Audit logging (storing prompts/responses) remains deferred.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-RA9I.md
+++ b/tickets/entities/review-responses/RR-RA9I.md
@@ -1,0 +1,9 @@
+---
+id: RR-RA9I
+type: review-response
+title: 'F4: Response body size cap returns ErrNetwork instead of ErrBadResponse'
+finding: readLimitedBody returned a plain error when the body exceeded maxResponseBytes. That flowed through wrapNetworkError and got classified as ErrNetwork. A 12 MiB upstream response is an upstream protocol violation, not a network failure; classifying it as network misleads automated retry logic (retrying a misbehaving upstream is pointless) and the test even accepted *either* classification, which was a smell.
+severity: significant
+resolution: 'Introduced an errBodyTooLarge sentinel in openai.go. Chat() now branches on errors.Is(readErr, errBodyTooLarge) and constructs a typed *Error{Kind: ErrBadResponse, Status: resp.StatusCode, Message: ...} directly. TestProvider_Chat_ResponseTooLarge tightened to assert exactly ErrBadResponse with the size-limit message in the error string.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SNJ8.md
+++ b/tickets/entities/review-responses/RR-SNJ8.md
@@ -1,0 +1,9 @@
+---
+id: RR-SNJ8
+type: review-response
+title: Client interface too narrow; embeddings will force breaking changes to Lua plumbing
+finding: 'Plan rationalizes embeddings as ''package shape supports this'' but the *Lua runtime field* is aiClient ai.Client. When embeddings land, you either add a parallel field (aiEmbedder) and a parallel option (WithAIEmbedder) — two wirings to keep in sync — or you widen the Client interface and break every test double. Fix: introduce ai.Provider (or ai.Service) aggregate now with only Chat() defined. Lua takes WithAIProvider. Embeddings just add a method to the implementation. One wiring point forever.'
+severity: significant
+resolution: Renamed Client to Provider throughout. Lua runtime field is aiProvider ai.Provider, option is WithAIProvider. When embeddings land, the Provider interface widens with Embed(...) and only test fakes need a stub method — no parallel wiring. Documented the rationale and the alternative (Chatter+Embedder small interfaces) in the plan.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SRCH.md
+++ b/tickets/entities/review-responses/RR-SRCH.md
@@ -1,0 +1,9 @@
+---
+id: RR-SRCH
+type: review-response
+title: 'F12: errBodySnippetBytes comment references a phantom constant'
+finding: The comment claimed errBodySnippetBytes had to be 'kept in sync with the openai.go snippetBytes constant' and that 'both exist so the package compiles even if files are reorganized'. There was no snippetBytes constant in openai.go (it was deleted in an earlier refactor) and the import-cycle rationale was nonsense — files in the same Go package cannot have an import cycle.
+severity: nit
+resolution: Comment cleaned up to a single sentence describing what the constant does. The phantom reference and the false language-constraint claim are gone.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-T96M.md
+++ b/tickets/entities/review-responses/RR-T96M.md
@@ -1,0 +1,9 @@
+---
+id: RR-T96M
+type: review-response
+title: 'F2: Validation 5s timeout silently caps AI calls'
+finding: validationTimeout = 5 seconds, enforced via ls.SetContext(ctx). chatContext(r) reads r.L.Context(), so AI requests from validation rules inherit the validation's 5-second deadline. The OpenAI-compat provider has a 30-second default client timeout that becomes dead code inside validation. Worse, a rule that legitimately needs AI will appear to 'usually work in dev, randomly fail in CI' as soon as provider latency drifts up. The failure mode is an opaque ErrTimeout with no hint that a validation deadline, not the network, caused it.
+severity: significant
+resolution: 'Resolved by un-wiring AI from validation entirely (see F1). The 5s validation timeout no longer interacts with AI calls because AI is unreachable from validation rules. Tracked as a follow-up: AI in validations must come with longer per-rule budgets and explicit opt-in.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-TDHV.md
+++ b/tickets/entities/review-responses/RR-TDHV.md
@@ -1,0 +1,9 @@
+---
+id: RR-TDHV
+type: review-response
+title: 'F11: Five entry points copy-paste filepath.Join(projectRoot, .rela)'
+finding: Four of five Lua-construction sites hand-built the .rela path with the literal string, duplicating the project.CacheDir constant and re-inventing a path that already exists on every Paths struct.
+severity: minor
+resolution: 'Partial cleanup as part of F8: internal/mcp/tools_lua.go now uses s.ws.Paths().CacheDir directly (both call sites). internal/script/executor.go uses filepath.Join(ctx.GetProjectRoot(), project.CacheDir) — the project.CacheDir constant instead of the literal ''.rela''. The two cli sites already used Paths().CacheDir from the start. The literal magic string is gone from the codebase. A proper LoadProviderForWorkspace helper was considered but deemed overkill for a one-liner that varies slightly per call site (cli has projectCtx, mcp has s.ws, script has ctx.GetProjectRoot).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-TH21.md
+++ b/tickets/entities/review-responses/RR-TH21.md
@@ -1,0 +1,9 @@
+---
+id: RR-TH21
+type: review-response
+title: Streamed response from server expecting non-streamed produces confusing error
+finding: 'Plan does not explicitly send ''stream: false'' in the request body. Some compat servers (older Ollama, some gateways) SSE-stream by default. The JSON decoder will see ''data: {...}'' and produce a confusing parse error. Fix: explicitly set stream: false in the request body. If response Content-Type is text/event-stream, return a clear typed error like ''streaming responses are not supported in this slice'' rather than a JSON parse error.'
+severity: significant
+resolution: 'Request body now always sends ''stream'': false (AC #16). Response Content-Type validation rejects text/event-stream with ErrStreamingUnsupported (AC #17). Users who want streaming get a clear typed error rather than a confusing JSON parse failure.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-U20G.md
+++ b/tickets/entities/review-responses/RR-U20G.md
@@ -1,0 +1,9 @@
+---
+id: RR-U20G
+type: review-response
+title: 'F8: LoadProvider fail-soft default is wrong for script/flow entry points'
+finding: For rela script and rela flow, AI is often the entire point of running the command. Silently downgrading a malformed ai.yaml to 'no provider' and logging a warning to stderr (which competes with any other output the command produces) means the user's script blows up with a not_configured error downstream and they have to dig through earlier log lines to discover the actual parse error.
+severity: significant
+resolution: 'Changed LoadProvider signature to (Provider, error). ErrConfigNotFound is propagated as-is for the normal ''no AI'' state. Each entry point picks its own policy: rela script and rela flow now surface non-ErrConfigNotFound errors via fmt.Errorf(''ai: %w'', err) so a malformed ai.yaml prints the parse error at startup instead of mid-script. The shared script executor and MCP lua_eval/lua_run tools keep soft-fail with slog.Warn since they run in automation/server contexts where crashing the host would be worse. Verified end-to-end: writing ''not: valid: yaml'' to /tmp/rela-ai-smoke/.rela/ai.yaml and running rela script now prints ''ai: parse /path/to/ai.yaml: yaml: mapping values are not allowed in this context''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-U833.md
+++ b/tickets/entities/review-responses/RR-U833.md
@@ -1,0 +1,9 @@
+---
+id: RR-U833
+type: review-response
+title: 'API key read at construction conflicts with AC #7 and breaks unrelated commands'
+finding: 'Plan says ''NewOpenAICompatClient reads the API key at construction time so a missing key fails fast at startup''. AC #7 says ''Client.Chat surfaces missing API key as an error before making any HTTP call''. These describe two different error sites. Worse, fail-fast at startup means any rela command that constructs a Lua runtime will refuse to start if the env var is unset, including commands that never use AI — that''s a regression for users who only set the env var when they actually want AI. Fix: defer the env var read to call time inside Chat(), drop fail-fast language, AC #7 becomes the source of truth. Construction validates only the config struct itself.'
+severity: critical
+resolution: 'NewOpenAICompatProvider no longer reads the API key. Construction validates only the Config struct. API key is read inside Chat() via os.Getenv at call time. AC #7 explicitly tests that construction succeeds with unset env var, and that Chat() returns ErrAuth referencing the env var name. AC #8 covers empty-string env var. Commands that don''t use AI no longer fail to start when the env var is unset.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-UQ5H.md
+++ b/tickets/entities/review-responses/RR-UQ5H.md
@@ -1,0 +1,9 @@
+---
+id: RR-UQ5H
+type: review-response
+title: 'F7: http.Client redirect policy not locked down'
+finding: No CheckRedirect set on http.Client. Go's default follows up to 10 redirects. Stdlib does strip Authorization on cross-host redirects since Go 1.8, but same-host redirects preserve the header, and a misconfigured proxy or DNS cache poisoning could still cause surprises. A provider following a 302 to a different path means the request the user authorized and the request the server answered can diverge.
+severity: significant
+resolution: 'Added CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse } to the http.Client. None of the OpenAI-compat providers we target use redirects in their normal flow, so disabling them is the safer default. New TestProvider_Chat_NoRedirectFollow verifies a 307 Temporary Redirect is rejected rather than followed.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-W876.md
+++ b/tickets/entities/review-responses/RR-W876.md
@@ -1,0 +1,9 @@
+---
+id: RR-W876
+type: review-response
+title: 'F17: Sentinel leak test does not cover the start log path or the marshal error path'
+finding: 'The KeyNeverLeaks test exercised 7 server-response shapes and asserted the sentinel did not appear in err.Error() or captured logs. Missing paths: logRequestStart on the success path (which logs base_url), the network-error log path, and edge cases where the URL itself could embed credentials.'
+severity: minor
+resolution: 'Added two new tests: TestProvider_Chat_KeyNeverLeaks_SuccessPath verifies logRequestStart and logRequestSuccess do not leak the API key on the happy path, and TestProvider_Chat_KeyNeverLeaks_NetworkError verifies the network-failure log path does not leak. Both serialize through the same global captureLog mutex as the original.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Z5XJ.md
+++ b/tickets/entities/review-responses/RR-Z5XJ.md
@@ -1,0 +1,9 @@
+---
+id: RR-Z5XJ
+type: review-response
+title: temperature=0 cannot be distinguished from unset; ships a known correctness bug
+finding: 'Plan accepts that ChatRequest.Temperature float64 zero-value collides with ''unset'', so temperature=0.0 will not be sent upstream. Documents ''use 0.0001 as workaround''. This is a real correctness bug — temperature=0 is the most common deterministic-sampling setting (golden tests, evals, reproducible runs). Users will silently get non-deterministic output that looks deterministic. Fix: use *float64 (or equivalent optional type) end-to-end, including for MaxTokens (where 0 is also semantically distinct). The Lua side already knows whether the key was present in the table — propagate that. ~30 minutes of extra work; removes a footgun forever.'
+severity: critical
+resolution: 'ChatRequest.Temperature is now *float64, MaxTokens is *int. JSON tags use omitempty so nil pointers are absent from the wire. Lua binding uses LGetField + LNil check to distinguish ''key absent'' from ''key set to 0''. AC #15 and AC #30 verify temperature=0 is sent distinctly from absent at both Provider and Lua layers.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ZUPC.md
+++ b/tickets/entities/review-responses/RR-ZUPC.md
@@ -1,0 +1,9 @@
+---
+id: RR-ZUPC
+type: review-response
+title: 'F1: Validation runtime builds a fresh AI provider per rule per entity'
+finding: validate() is called once per entity per rule. LoadProvider re-reads and re-parses .rela/ai.yaml from disk every single call, re-runs URL validation, and re-constructs an http.Client. On a project with 200 entities and 10 rules, that's 2000 file reads and 2000 http.Client allocations per analyze run.
+severity: significant
+resolution: Resolved by un-wiring AI from internal/validation/lua.go entirely. AI in validation rules needs its own design (per-rule opt-in, cost guardrails, longer per-rule budget) and is tracked as a follow-up ticket.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-YBKB.md
+++ b/tickets/entities/tickets/TKT-YBKB.md
@@ -1,0 +1,60 @@
+---
+id: TKT-YBKB
+type: ticket
+title: Add OpenAI-compatible AI client config and Lua bindings
+kind: enhancement
+priority: medium
+effort: l
+status: review
+---
+
+## Goal
+
+Land the foundation for AI integration in rela: a config loader for
+`.rela/ai.yaml`, an `internal/ai` package with an OpenAI-compatible chat client,
+and Lua bindings that expose `ai.chat()` and `ai.complete()` to scripts.
+
+This is the first slice of `FEAT-ER3Y` (AI integration via OpenAI-compatible
+API). It deliberately ships only the chat primitive — embeddings, CLI commands,
+MCP tools, caching, and UI integration are explicitly out of scope and will
+follow as separate tickets once this foundation proves out.
+
+## In Scope
+
+- **Config**: load `.rela/ai.yaml` with `provider`, `base_url`, `model`, `api_key_env` fields. Gitignored. Missing config = AI disabled (Lua functions error clearly).
+- **Package**: `internal/ai` with a `Client` interface and one OpenAI-compatible chat completions implementation. HTTP-based, no SDK dependency.
+- **Lua bindings**: top-level `ai` table in the Lua sandbox exposing:
+  - `ai.chat({messages, model?, temperature?, max_tokens?})` → `(result_table, nil)` on success, `(nil, err_string)` on failure. Result table has flat fields: `content`, `model`, `finish_reason`, `usage = {prompt_tokens, completion_tokens, total_tokens}`.
+  - `ai.complete(string)` → `(string, nil)` / `(nil, err)`. Convenience that wraps `ai.chat` with a single user message and returns just the content.
+- **Errors**: surface clearly to Lua via `nil, err` pattern (no silent failures, no panics).
+- **Tests**: unit tests with a fake HTTP server (httptest); one Lua-level integration test that exercises both functions through the sandbox; tests for config loading edge cases.
+
+## Out of Scope
+
+- Embeddings API (`ai.embed`)
+- Caching layer
+- CLI commands (`rela ai ...`)
+- MCP tool wrappers
+- Web UI integration
+- Streaming responses
+- Tool use / function calling
+- Multi-provider abstraction beyond OpenAI-compat
+- Pre-built AI-powered example scripts (suggest-links, validate-with-ai, etc.)
+- Logging / audit trail of AI calls (deferred to a dedicated ticket)
+
+## Acceptance Criteria
+
+1. A user can create `.rela/ai.yaml` pointing at any OpenAI-compatible endpoint (OpenAI, Ollama, LM Studio, Groq, etc.) and the config loads without error.
+2. With config present and API key set, a Lua script calling `ai.chat({messages={{role="user", content="hi"}}})` returns a non-empty result table with `.content` populated.
+3. With config present, `ai.complete("hi")` returns a non-empty string.
+4. With config absent or invalid, both functions return `nil, err` with a clear, actionable error message — no panic, no silent failure.
+5. With a network/HTTP error, both functions return `nil, err` with the underlying error surfaced.
+6. The Lua sandbox does not regress: existing scripts and tests continue to pass.
+7. Coverage ratchet passes — new code in `internal/ai` is unit-tested with a fake HTTP server.
+
+## Notes
+
+- Config file is gitignored (consistent with `.rela/user-defaults.yaml`).
+- API key must come from an env var, not the config file, so config can be safely shared.
+- Use Go's `net/http` directly; do not pull in an OpenAI SDK.
+- The `ai` Lua global must not collide with existing sandbox names — verify during planning.

--- a/tickets/entities/tickets/TKT-YBKB.md
+++ b/tickets/entities/tickets/TKT-YBKB.md
@@ -5,7 +5,7 @@ title: Add OpenAI-compatible AI client config and Lua bindings
 kind: enhancement
 priority: medium
 effort: l
-status: review
+status: done
 ---
 
 ## Goal
@@ -21,40 +21,58 @@ follow as separate tickets once this foundation proves out.
 
 ## In Scope
 
-- **Config**: load `.rela/ai.yaml` with `provider`, `base_url`, `model`, `api_key_env` fields. Gitignored. Missing config = AI disabled (Lua functions error clearly).
-- **Package**: `internal/ai` with a `Client` interface and one OpenAI-compatible chat completions implementation. HTTP-based, no SDK dependency.
+- **Config**: load `.rela/ai.yaml` with `provider`, `base_url`, `model`, `api_key_env?`, `timeout_seconds?` fields. Gitignored. `api_key_env` is optional — when absent, no `Authorization` header is sent (supports local providers like ollama, apfel, LM Studio). Missing config = AI disabled (Lua functions return a typed `not_configured` error table).
+- **Package**: `internal/ai` with a `Provider` interface (named `Provider` so embeddings can be added later without parallel wiring) and one OpenAI-compatible chat completions implementation. HTTP-based, no SDK dependency.
+- **Typed errors**: stable `ErrKind` enum (`not_configured`, `auth`, `bad_request`, `rate_limited`, `server_error`, `timeout`, `network`, `bad_response`, `streaming_unsupported`) classified by upstream `error.type` first with HTTP status fallback. `RetryAfter` populated for rate-limit responses.
 - **Lua bindings**: top-level `ai` table in the Lua sandbox exposing:
-  - `ai.chat({messages, model?, temperature?, max_tokens?})` → `(result_table, nil)` on success, `(nil, err_string)` on failure. Result table has flat fields: `content`, `model`, `finish_reason`, `usage = {prompt_tokens, completion_tokens, total_tokens}`.
-  - `ai.complete(string)` → `(string, nil)` / `(nil, err)`. Convenience that wraps `ai.chat` with a single user message and returns just the content.
-- **Errors**: surface clearly to Lua via `nil, err` pattern (no silent failures, no panics).
-- **Tests**: unit tests with a fake HTTP server (httptest); one Lua-level integration test that exercises both functions through the sandbox; tests for config loading edge cases.
+  - `ai.chat({messages, model?, temperature?, max_tokens?})` → `(result_table, nil)` on success, `(nil, err_table)` on failure. Result table has flat fields: `content`, `model`, `finish_reason`, `usage = {prompt_tokens, completion_tokens, total_tokens}`. Error table has `kind`, `status`, `message`, `retry_after`, `details`.
+  - `ai.complete(string)` → `(string, nil)` / `(nil, err_table)`. Convenience that wraps `ai.chat` with a single user message and returns just the content.
+- **Optional pointer types** for `temperature` and `max_tokens` so 0 round-trips distinctly from "unset".
+- **Operational logging** via `log/slog`: `slog.Debug` on request start, `slog.Info` on success with token counts, `slog.Warn` on any failure. Zero secrets, zero PII, zero message content.
+- **API key safety**: read at `Chat()` call time (not construction), `redactKey` defense-in-depth at every error and log site, table-driven sentinel test that asserts the key never appears in any error or log line across success path, every error path, and the network-error path.
+- **Provider divergence handling**: tolerate missing `usage`, `finish_reason`, `model`. Decode `content` as either a string or an array of `{type, text}` parts. Reject `text/event-stream` with `ErrStreamingUnsupported`. Validate `Content-Type` before JSON decoding so HTML proxy errors produce `ErrBadResponse` with a body snippet, not a confusing JSON parse error.
+- **Body cap**: 10 MiB via `io.LimitReader`; exceeding it returns `ErrBadResponse` (not `ErrNetwork`) via the `errBodyTooLarge` sentinel.
+- **HTTP redirect policy**: `CheckRedirect: ErrUseLastResponse` so the client refuses to follow upstream redirects.
+- **`base_url` validation**: must include scheme, must not contain credentials, must not contain a query string or fragment (so query-string `api_key=...` parameters can never end up in logs).
+- **`LoadProvider` returns `(Provider, error)`** so each entry point picks its own policy: interactive commands surface errors immediately, background contexts soft-fail with a log warning.
+- **Wired into 4 of 5 Lua entry points**: `internal/cli/script.go`, `internal/cli/flow.go`, `internal/script/executor.go`, `internal/mcp/tools_lua.go`. Validation rules (`internal/validation/lua.go`) deliberately do NOT get AI access — see Out of Scope.
+- **Tests**: unit tests for `internal/ai` using `httptest.Server` covering all error paths, the success path, content-shape variants, redirect rejection, body-cap, sentinel leak (across success + error + network paths). Lua-level integration tests through the sandbox. Coverage 93%+.
+- **Documentation**: `CLAUDE.md` AI Integration section (config, Lua API, error taxonomy, network egress + script-level exfiltration security note). `ai-integration` concept entity. Top-of-file comment in `internal/lua/ai.go` documenting the `(nil, err_table)` convention split, the programming-error vs runtime-error taxonomy, and the LState concurrency invariant.
 
 ## Out of Scope
 
 - Embeddings API (`ai.embed`)
 - Caching layer
 - CLI commands (`rela ai ...`)
-- MCP tool wrappers
+- MCP tool wrappers (other than the existing `lua_eval` / `lua_run` carrying AI through Lua)
 - Web UI integration
 - Streaming responses
 - Tool use / function calling
 - Multi-provider abstraction beyond OpenAI-compat
 - Pre-built AI-powered example scripts (suggest-links, validate-with-ai, etc.)
-- Logging / audit trail of AI calls (deferred to a dedicated ticket)
+- **AI in validation rules**: a validation rule that calls `ai.chat` would hit the provider on every entity on every analyze run with no quota, no kill switch, and no cost warning. The 5-second validation timeout would also silently clip slow calls. This needs its own design (per-rule opt-in, cost guardrails, longer per-rule budget) and is a follow-up ticket.
+- **Audit logging** (storing every prompt/response for compliance) — operational logging via slog ships with this ticket; full audit trail is a separate ticket.
+- HTTP retries with backoff — the typed `rate_limited` error with `retry_after` gives scripts what they need to implement their own retry policy.
+- Per-call timeout argument (`ai.chat({..., timeout=60})`).
+- Logger dependency injection — currently uses `slog.Default()`, which means tests that capture log output must serialize through a global mutex. Tracked as a follow-up.
 
 ## Acceptance Criteria
 
-1. A user can create `.rela/ai.yaml` pointing at any OpenAI-compatible endpoint (OpenAI, Ollama, LM Studio, Groq, etc.) and the config loads without error.
-2. With config present and API key set, a Lua script calling `ai.chat({messages={{role="user", content="hi"}}})` returns a non-empty result table with `.content` populated.
+1. A user can create `.rela/ai.yaml` pointing at any OpenAI-compatible endpoint (OpenAI, Ollama, LM Studio, apfel, Groq, etc.) and the config loads without error. `api_key_env` is optional.
+2. With config present and API key set (or absent for no-auth providers), a Lua script calling `ai.chat({messages={{role="user", content="hi"}}})` returns a non-empty result table with `.content` populated.
 3. With config present, `ai.complete("hi")` returns a non-empty string.
-4. With config absent or invalid, both functions return `nil, err` with a clear, actionable error message — no panic, no silent failure.
-5. With a network/HTTP error, both functions return `nil, err` with the underlying error surfaced.
-6. The Lua sandbox does not regress: existing scripts and tests continue to pass.
-7. Coverage ratchet passes — new code in `internal/ai` is unit-tested with a fake HTTP server.
+4. With config absent, both functions return `(nil, err_table)` with `err.kind == "not_configured"`.
+5. With config present but malformed, `rela script` and `rela flow` fail at startup with the parse error in the message; background contexts (executor, MCP) log a warning and continue without AI.
+6. With a network/HTTP error, both functions return `(nil, err_table)` with the appropriate `err.kind` (`network`, `timeout`, `auth`, `rate_limited`, `server_error`, `bad_request`, `bad_response`, `streaming_unsupported`).
+7. `temperature=0` is sent distinctly from `temperature` absent (verified by request-body capture).
+8. The Lua sandbox does not regress: existing scripts and tests continue to pass.
+9. Coverage ratchet passes — `internal/ai` is at 93%+ with `httptest.Server`-based unit tests.
+10. Smoke-tested end-to-end against real ollama `gemma3:12b` and against apfel for error-path divergences.
 
 ## Notes
 
 - Config file is gitignored (consistent with `.rela/user-defaults.yaml`).
 - API key must come from an env var, not the config file, so config can be safely shared.
-- Use Go's `net/http` directly; do not pull in an OpenAI SDK.
-- The `ai` Lua global must not collide with existing sandbox names — verify during planning.
+- Use Go's `net/http` directly; no OpenAI SDK dependency.
+- The `ai` Lua global is registered unconditionally at the top level (verified not to collide with the existing `rela` global or any other global).
+- The `ai.*` Lua bindings deliberately use `(nil, err_table)` for runtime failures while every other rela Lua binding raises via `RaiseError`. This convention split is documented in `internal/lua/ai.go` top-of-file.

--- a/tickets/relations/FEAT-ER3Y--requires--ai-integration.md
+++ b/tickets/relations/FEAT-ER3Y--requires--ai-integration.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-ER3Y
+relation: requires
+to: ai-integration
+---

--- a/tickets/relations/TKT-YBKB--affects--ai-integration.md
+++ b/tickets/relations/TKT-YBKB--affects--ai-integration.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: affects
+to: ai-integration
+---

--- a/tickets/relations/TKT-YBKB--affects--lua-scripting.md
+++ b/tickets/relations/TKT-YBKB--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-YBKB--has-implementation--IMPL-SI2E.md
+++ b/tickets/relations/TKT-YBKB--has-implementation--IMPL-SI2E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-implementation
+to: IMPL-SI2E
+---

--- a/tickets/relations/TKT-YBKB--has-planning--PLAN-FOOU.md
+++ b/tickets/relations/TKT-YBKB--has-planning--PLAN-FOOU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-planning
+to: PLAN-FOOU
+---

--- a/tickets/relations/TKT-YBKB--has-review--REV-DKF9.md
+++ b/tickets/relations/TKT-YBKB--has-review--REV-DKF9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review
+to: REV-DKF9
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-0Z1M.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-0Z1M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-0Z1M
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-2RJW.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-2RJW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-2RJW
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-57JZ.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-57JZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-57JZ
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-6FMU.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-6FMU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-6FMU
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-8HSQ.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-8HSQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-8HSQ
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-8VL3.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-8VL3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-8VL3
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-9L8P.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-9L8P.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-9L8P
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-GIK4.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-GIK4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-GIK4
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-GK2Z.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-GK2Z.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-GK2Z
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-GLT3.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-GLT3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-GLT3
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-HWUO.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-HWUO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-HWUO
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-IA4B.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-IA4B.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-IA4B
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-JV6M.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-JV6M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-JV6M
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-LQ1R.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-LQ1R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-LQ1R
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-LUXQ.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-LUXQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-LUXQ
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-N3OU.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-N3OU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-N3OU
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-OD1W.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-OD1W.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-OD1W
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-QH8C.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-QH8C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-QH8C
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-QIEC.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-QIEC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-QIEC
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-RA9I.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-RA9I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-RA9I
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-SNJ8.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-SNJ8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-SNJ8
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-SRCH.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-SRCH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-SRCH
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-T96M.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-T96M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-T96M
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-TDHV.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-TDHV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-TDHV
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-TH21.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-TH21.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-TH21
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-U20G.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-U20G.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-U20G
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-U833.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-U833.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-U833
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-UQ5H.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-UQ5H.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-UQ5H
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-W876.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-W876.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-W876
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-Z5XJ.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-Z5XJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-Z5XJ
+---

--- a/tickets/relations/TKT-YBKB--has-review-response--RR-ZUPC.md
+++ b/tickets/relations/TKT-YBKB--has-review-response--RR-ZUPC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: has-review-response
+to: RR-ZUPC
+---

--- a/tickets/relations/TKT-YBKB--implements--FEAT-ER3Y.md
+++ b/tickets/relations/TKT-YBKB--implements--FEAT-ER3Y.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YBKB
+relation: implements
+to: FEAT-ER3Y
+---


### PR DESCRIPTION
First slice of `FEAT-ER3Y` (AI integration via OpenAI-compatible API).
Adds an `internal/ai` package with a `Provider` interface, an
OpenAI-compatible HTTP implementation, typed errors, optional auth, and
Lua bindings (`ai.chat`, `ai.complete`) wired into four entry points.
Tracks: `TKT-YBKB`.

## Summary

- **`internal/ai` package** with `Provider` interface (named for forward
  compatibility with embeddings), `OpenAICompatProvider` HTTP impl,
  typed `Error` with stable `ErrKind` enum, `LoadProvider(relaDir)
  (Provider, error)`, `redactKey` defense-in-depth helper, operational
  logging via `log/slog`. **93.8 % coverage.**
- **Lua bindings** (`internal/lua/ai.go`) exposing top-level `ai.chat` and
  `ai.complete`. Returns `(result, nil)` on success or `(nil, err_table)`
  on runtime failure (network, HTTP, rate limit, config, etc.).
  Programming errors still raise via `RaiseError` — see the top-of-file
  comment for the convention split rationale.
- **Wired into four entry points**: `cli/script.go`, `cli/flow.go`,
  `script/executor.go`, `mcp/tools_lua.go`. **Validation rules
  intentionally excluded** (would hammer providers on every analyze
  run with no quota — needs its own design).
- **Config**: `.rela/ai.yaml` with `base_url`, `model`, `api_key_env?`,
  `timeout_seconds?`. `api_key_env` is optional so local providers
  (ollama, apfel, LM Studio) work out of the box with no auth header.
  Validation rejects URL credentials, query strings, and fragments so
  the key never lands in logs.
- **Hardening**: HTTP redirect refusal, 10 MiB body cap (typed
  `ErrBadResponse`), Content-Type validation before JSON decoding,
  `stream: false` always sent, SSE responses rejected with
  `ErrStreamingUnsupported`, content-as-string OR content-as-array
  parsing, missing optional fields tolerated, missing `choices[0].message`
  rejected explicitly.
- **API key safety**: read at `Chat()` call time (not construction),
  redacted at every error and log site, table-driven sentinel test
  asserts the key never appears in any error or log line across
  success path, every error path, AND the network-error path.
- **Operational logging**: `slog.Debug` on request start, `slog.Info`
  on success with token counts, `slog.Warn` on any failure. Zero
  secrets, zero PII, zero message content.
- **Documentation**: `CLAUDE.md` AI Integration section, `ai-integration`
  concept entity, top-of-file comment in `internal/lua/ai.go` covering
  the convention deviation and the LState concurrency invariant.

## Process trail

- Planning checklist `PLAN-FOOU` with full design doc, including a
  `/design-review` round that produced 12 RRs (all addressed).
- Implementation checklist `IMPL-SI2E` with verification evidence.
- Review checklist `REV-DKF9` with a `/code-review` round that produced
  19 RRs (18 addressed, 1 deferred — F10/RR-QH8C: captureLog global
  mutex needs `*slog.Logger` dependency injection, refactor in its
  own ticket).

## Testing

```
$ go test ./...
ok 37 packages, 0 failures
$ go test -cover ./internal/ai/
ok  github.com/Sourcehaven-BV/rela/internal/ai  coverage: 93.8% of statements
$ just lint
golangci-lint run  (clean)
$ just coverage-check
PASS
```

**Live smoke test against real ollama gemma3:12b:**

```
$ rela --project=/tmp/rela-ai-smoke script scripts/ai_smoke.lua
=== ai.complete (single-string convenience) ===
level=INFO msg="ai request ok" status=200 model=gemma3:12b latency_ms=8447 prompt_tokens=20 completion_tokens=5
complete result: hello from gemma

=== ai.chat (full form with system prompt, temperature=0) ===
level=INFO msg="ai request ok" status=200 model=gemma3:12b latency_ms=617 prompt_tokens=36 completion_tokens=3
chat content: Four.

=== Error path: explicit unknown model ===
level=WARN msg="ai request failed" kind=bad_request status=404 latency_ms=1 message="model 'definitely-not-a-real-model' not found"
expected error: r3=nil err3.kind=bad_request err3.status=404

=== ALL SMOKE TESTS PASSED ===
```

**Strict-mode error path verified end-to-end:** writing `not: valid: yaml`
to `.rela/ai.yaml` and running `rela script` now prints `ai: parse
/tmp/rela-ai-smoke/.rela/ai.yaml: yaml: mapping values are not allowed
in this context` at startup, instead of silently disabling AI and
letting the script blow up later.

## Test plan

- [x] `go test ./...` — 37 packages, 0 failures
- [x] `go test -race ./...` — clean
- [x] `just lint` — clean (depguard rule from #328 enforced)
- [x] `just coverage-check` — passes; `internal/ai` at 93.8 %
- [x] Live smoke test against ollama `gemma3:12b` (success path + error path)
- [x] Live error-path probe against apfel (error envelope shapes)
- [x] Strict-mode malformed-config error surfacing verified manually
- [x] `rela validate` on `tickets/` passes (all 118 rules)

## Out of scope (deferred to follow-up tickets)

- Embeddings API
- AI in validation rules (cost guardrails + opt-in design needed)
- Audit logging (every prompt/response stored)
- HTTP retries with backoff (scripts can use the typed `rate_limited` error)
- Per-call timeout argument
- CLI commands (`rela ai ...`)
- MCP tool wrappers (other than carrying AI through Lua)
- Web UI integration
- Logger dependency injection (F10 in the code review — `slog.Default()` is process-global, blocks parallel-test capture)