### PR TITLE
docs(tickets): file three follow-up tickets for AI integration

### DIFF
--- a/tickets/entities/tickets/TKT-135Q.md
+++ b/tickets/entities/tickets/TKT-135Q.md
@@ -1,0 +1,188 @@
+---
+id: TKT-135Q
+type: ticket
+title: Add content-hash-keyed cache for AI responses
+kind: enhancement
+priority: high
+effort: m
+status: ready
+---
+
+## Goal
+
+Add a content-hash-keyed disk cache for AI responses (chat and embeddings) so
+repeated runs against the same input don't burn tokens or wait on the network.
+Implemented as a decorator over `ai.Provider` so it composes cleanly without
+touching the underlying transport code.
+
+## Background
+
+Once embeddings (`TKT-5FYM`) ship, every analyze run that uses semantic search
+will re-embed every entity unless we cache. For a 200-entity project that's
+potentially thousands of API calls per run — too expensive to use casually, even
+against a local Ollama instance, where the bottleneck is GPU latency rather than
+dollars.
+
+Chat completions also benefit, especially for deterministic prompts
+(`temperature=0`) used in golden tests, evals, or "improve this entity
+description" workflows where the same input will be retried multiple times
+during iteration.
+
+## Strategy
+
+**Decorator over `ai.Provider`.** A new `internal/ai/cache` subpackage exposes:
+
+```go
+type CachingProvider struct {
+    inner ai.Provider
+    store CacheStore
+}
+
+func NewCachingProvider(inner ai.Provider, dir string) (*CachingProvider, error)
+
+func (c *CachingProvider) Chat(ctx, req) (*ai.ChatResponse, error)
+func (c *CachingProvider) Embed(ctx, req) (*ai.EmbedResponse, error)
+```
+
+`CachingProvider` implements `ai.Provider`, so callers see no API change. Wire
+it into `ai.LoadProvider` so every entry point gets caching for free.
+
+## Cache key
+
+For chat:
+
+sha256(provider_id || model || temperature || max_tokens || canonical(messages))
+
+For embed:
+
+sha256(provider_id || model || canonical(input))
+
+`canonical(messages)` and `canonical(input)` are JSON marshals with sorted map
+keys. `provider_id` is a stable string derived from `Config.BaseURL` (so a cache
+built against `localhost:11434` doesn't get reused when the user switches to
+OpenAI). `temperature=0` is explicit, `nil` is `"unset"`, so the same key only
+matches truly identical requests.
+
+## Cache layout
+
+```
+.rela/ai-cache/
+  chat/
+    <sha256-prefix>/<sha256>.json    # serialized ChatResponse + metadata
+  embed/
+    <sha256-prefix>/<sha256>.json    # serialized EmbedResponse + metadata
+```
+
+Two-level fan-out (`<sha256-prefix>/<sha256>`) so directories don't get
+hot-spotted with thousands of entries.
+
+`.rela/ai-cache/` is gitignored (`.rela/` is already gitignored as a whole —
+verified).
+
+## Cache entry format
+
+```json
+{
+  "version": 1,
+  "created_at": "2026-04-08T...",
+  "request_summary": {
+    "model": "gemma3:12b",
+    "kind": "chat",
+    "prompt_tokens": 20
+  },
+  "response": { /* ChatResponse or EmbedResponse */ }
+}
+```
+
+The `request_summary` is *not* the cache key (the key is the sha256 in the
+filename) — it's just human-readable metadata for debugging ("what's in this
+cache entry?").
+
+The cache file contains the **response** (model output) but not the **request**
+(prompt). The hash-only filename means you can't enumerate the prompts from the
+cache, but the response payload itself is stored in cleartext. Privacy story is
+the same as `.rela/cache.json`: gitignored, local to the user, treat as you
+would any local-only project state.
+
+## Invalidation
+
+**TTL-less by default** — responses to deterministic prompts (`temperature=0`)
+don't go stale. Users can `rm -rf .rela/ai-cache/` to invalidate manually.
+
+A future ticket may add an optional `cache.ttl_days` config field for users who
+want time-based eviction. **Out of scope for v1.**
+
+## Bypass
+
+Users sometimes need to force a fresh call (e.g. after switching models or to
+refresh stale embeddings). Two mechanisms:
+
+1. **Global**: `.rela/ai.yaml` has `cache: false` to disable entirely.
+2. **Per-call**: Lua scripts can pass `bypass_cache = true` in the
+options table for `ai.chat` and `ai.embed`. Defaults to false.
+
+## Out of Scope
+
+- LRU eviction or size limits — this is a leaf-fanout disk cache, not
+an in-memory LRU. Users who care can `du -sh .rela/ai-cache/` and `rm -rf` if it
+gets big. Add eviction in v2 if it becomes a real problem.
+- Distributed cache (Redis, S3, etc.). Local disk only.
+- Cache hit/miss metrics — operational logging emits `cache=hit` /
+`cache=miss` fields in the existing `slog.Info` line so users can grep, but no
+Prometheus-style counters.
+- Cache warming (precomputing embeddings for the whole graph). Useful
+but a separate ticket.
+- Sharing cache between projects — keyed by `provider_id` which is per
+`BaseURL`, not per-project. If two projects use the same provider, they share
+cache entries. That's a feature, not a bug.
+
+## Acceptance Criteria
+
+1. New `internal/ai/cache` package with a `CachingProvider` that
+implements `ai.Provider` (decorator over an inner provider).
+2. `Chat` and `Embed` first check the cache, then fall through to the
+inner provider on miss, then write the response back to disk.
+3. Cache key is sha256 over (provider_id, model, temperature,
+max_tokens, canonical-JSON of input). Different providers/models/ parameters
+never collide.
+4. Cache directory is `.rela/ai-cache/{chat,embed}/<prefix>/<sha>.json`
+with two-level fan-out.
+5. `ai.LoadProvider` wraps the underlying provider in
+`CachingProvider` by default. Disabled if `.rela/ai.yaml` has `cache: false`.
+6. Lua bindings accept an optional `bypass_cache = true` in the
+options table for both `ai.chat` and `ai.embed`. When set, the cache layer is
+skipped for that one call (no read, no write).
+7. Operational logging includes `cache=hit` / `cache=miss` fields in
+the existing `slog.Info` line for AI requests.
+8. Cache hits still produce a log line at `slog.Debug` so users can
+verify caching is working without enabling full debug.
+9. Cache misses are written atomically (write to `.tmp` then rename)
+so a crash mid-write doesn't leave a half-file that fails to parse on next read.
+10. Tests cover: cache miss + write, cache hit, bypass_cache,
+concurrent reads/writes don't corrupt entries, atomic writes, cache disabled via
+config, key collision avoidance across parameters.
+11. Live smoke test against ollama: first call to a deterministic
+prompt is slow (~1s gemma3 inference); second call with the same prompt is <50ms
+(cache hit) and produces a `cache=hit` log line.
+12. `internal/ai` coverage stays at 90 %+ including the new cache
+package.
+
+## Notes
+
+- Implement the cache as `internal/ai/cache.New(ai.Provider, dir) ai.Provider`
+rather than a method on `ai.Config` so the decorator pattern is obvious and
+tests can stub the inner provider with a fake.
+- The `provider_id` derivation should be `sha256(BaseURL)[:16]` rather
+than the raw URL to avoid pathological filenames if a user has a weird
+`BaseURL`.
+- Use `os.WriteFile` to a `.tmp` sibling then `os.Rename` for atomicity.
+POSIX guarantees rename is atomic on the same filesystem.
+- Cache reads should be `io.LimitReader` capped to 100 MiB per entry.
+An attacker who can drop a giant file into the cache dir already owns your
+machine, but the cap prevents accidental OOM if a future bug writes a malformed
+huge entry.
+- The `request_summary` metadata field is for `rela ai cache inspect`
+in some future ticket, not for runtime use. Keep it lightweight.
+- This ticket explicitly **depends on** `TKT-5FYM` (embeddings) for
+the Embed code path. The Chat caching can ship first if needed, but the whole
+point is making embeddings affordable, so don't split unless required.

--- a/tickets/entities/tickets/TKT-5FYM.md
+++ b/tickets/entities/tickets/TKT-5FYM.md
@@ -1,0 +1,189 @@
+---
+id: TKT-5FYM
+type: ticket
+title: 'Add embeddings support: ai.embed Lua binding and Provider.Embed'
+kind: enhancement
+priority: high
+effort: m
+status: ready
+---
+
+## Goal
+
+Add an `Embed` method to the `ai.Provider` interface, an OpenAI-compatible HTTP
+implementation, and a Lua binding `ai.embed()` that lets scripts compute vector
+embeddings for text. This is the second slice of `FEAT-ER3Y` (AI integration via
+OpenAI-compatible API) and the foundation for everything in Tier 3
+(suggest-links, semantic search, duplicate detection, ask).
+
+## Background
+
+`TKT-YBKB` deliberately named the interface `Provider` (not `Client`) so
+embeddings could be added later without parallel wiring. The Lua runtime takes a
+single `ai.Provider` via `WithAIProvider`, so adding `Embed` to the interface is
+a one-method change at the consumer side plus a new test stub. The 4 entry
+points (cli/script, cli/flow, script/executor, mcp/tools_lua) need no wiring
+changes.
+
+Embeddings are also genuinely valuable on their own: combined with the `rela`
+graph, they unlock "find entities semantically similar to this one" — a
+differentiating capability for a traceability tool.
+
+## In Scope
+
+### Provider interface
+
+Add `Embed` to `ai.Provider`:
+
+```go
+type Provider interface {
+    Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error)
+    Embed(ctx context.Context, req EmbedRequest) (*EmbedResponse, error)
+}
+
+type EmbedRequest struct {
+    Input []string  // batch input — embeddings APIs are per-text but accept arrays
+    Model string    // optional; defaults to Config.EmbeddingModel (or Config.Model if unset)
+}
+
+type EmbedResponse struct {
+    Embeddings [][]float32  // one vector per input, in the same order
+    Model      string
+    Usage      Usage         // reuses the existing Usage struct (prompt_tokens, total_tokens)
+}
+```
+
+### OpenAI-compat HTTP implementation
+
+POST to `{base_url}/embeddings` with body:
+
+```json
+{
+  "model": "text-embedding-3-small",
+  "input": ["first text", "second text"]
+}
+```
+
+Response shape:
+
+```json
+{
+  "object": "list",
+  "data": [
+    {"object": "embedding", "index": 0, "embedding": [0.123, ...]},
+    {"object": "embedding", "index": 1, "embedding": [0.456, ...]}
+  ],
+  "model": "text-embedding-3-small",
+  "usage": {"prompt_tokens": 10, "total_tokens": 10}
+}
+```
+
+Same hardening as Chat:
+
+- Read API key at call time, not construction
+- Same redirect-refusal policy
+- Same Content-Type validation
+- Same body cap
+- Same error taxonomy (`ErrAuth`, `ErrRateLimited`, `ErrServerError`,
+`ErrTimeout`, `ErrNetwork`, `ErrBadResponse`)
+- Same `redactKey` defense in depth
+- Same operational logging via `slog`
+- Same sentinel-key leak test extended to cover the new code paths
+
+### Config
+
+Add an optional `embedding_model` field to `.rela/ai.yaml`. If unset, `Embed`
+falls back to `model`. Most providers use a *different* default for chat vs
+embeddings (e.g. OpenAI uses `gpt-4o-mini` for chat but `text-embedding-3-small`
+for embeddings), so a single `model` field isn't enough.
+
+```yaml
+base_url: https://api.openai.com/v1
+model: gpt-4o-mini
+embedding_model: text-embedding-3-small
+api_key_env: OPENAI_API_KEY
+```
+
+### Lua binding
+
+```lua
+-- Single text
+local vec, err = ai.embed("hello world")
+-- vec is a Lua table of numbers (the embedding vector)
+
+-- Batch (more efficient — one HTTP call for many texts)
+local vecs, err = ai.embed({"first", "second", "third"})
+-- vecs is a Lua table of tables (one inner table per input)
+
+-- Optional model override
+local vec, err = ai.embed("text", {model = "text-embedding-3-large"})
+```
+
+Returns `(result, nil)` on success or `(nil, err_table)` on failure (same
+convention split as `ai.chat`). The result is either a flat array of numbers
+(single input) or an array of arrays (batch input).
+
+### Tests
+
+- `httptest.Server` based unit tests in `internal/ai/openai_test.go` for
+every error path (auth, rate-limited, server, network, timeout, malformed JSON,
+missing data, content-type validation, redirect refusal, body cap)
+- Extend the sentinel-key leak test to cover Embed
+- Lua-level integration tests in `internal/lua/ai_test.go` for both
+single and batch input, success and error paths
+- Live smoke test against ollama with `nomic-embed-text:latest` (already
+pulled in the dev environment)
+
+## Out of Scope
+
+- **Caching layer** — strongly recommended as a follow-up (without it,
+every analyze run that uses semantic search re-embeds everything). Tracked
+separately as `Add content-hash-keyed cache for AI responses`.
+- **Vector store / similarity index** — `ai.embed` is the primitive;
+building a persistent vector index for the rela graph is its own ticket.
+- **Suggest-links / improve / ask CLI commands** — these consume
+embeddings but are separate user-facing tickets.
+- **Embedding-powered validation rules** — same reasoning as
+`AI in validation rules` follow-up: needs cost guardrails first.
+
+## Acceptance Criteria
+
+1. `ai.Provider` interface has both `Chat` and `Embed` methods.
+2. `OpenAICompatProvider.Embed` POSTs to `{base_url}/embeddings` with
+the OpenAI-compatible request shape and parses the response.
+3. `Embed` honors the configured timeout, redirect-refusal, body cap,
+and Content-Type validation, identical to `Chat`.
+4. `Embed` returns typed errors via the existing `Error` / `ErrKind`
+taxonomy.
+5. `Config.EmbeddingModel` is optional. When unset, `Embed` uses
+`Config.Model`.
+6. Lua binding `ai.embed(string)` returns `({float, ...}, nil)` on
+success.
+7. Lua binding `ai.embed({string, string, ...})` returns
+`({{float, ...}, {float, ...}}, nil)` on success — one vector per input in
+order.
+8. Lua binding `ai.embed(input, {model = "..."})` accepts an optional
+options table for model override.
+9. Sentinel-key leak test extended: poisoned API key never appears in
+error or log output across all Embed code paths.
+10. Live smoke test against ollama `nomic-embed-text` returns a vector
+of the expected dimensionality (384 for nomic) for both single and batch input.
+11. `internal/ai` coverage stays at 90 %+ after the changes.
+12. The `lua.WithAIProvider` wiring at the 4 entry points needs zero
+changes — the `Embed` method is automatically available via the same
+`ai.Provider` instance.
+
+## Notes
+
+- Use the existing `chatRequestWire` / `chatResponseWire` pattern for
+the embed wire types (`embedRequestWire`, `embedResponseWire`).
+- Ollama's OpenAI-compat `/v1/embeddings` endpoint is well-tested with
+`nomic-embed-text` and should work out of the box.
+- The OpenAI embedding response shape has `data: [{embedding: [...]}]`
+not `embeddings: [...]` directly. The wire type needs to flatten this to
+`[][]float32`.
+- Float32 (not float64) for vectors — that's what every embedding
+provider returns and it halves the memory cost.
+- This unblocks `TKT-LK1J` (logger DI) being applied to the new methods
+too — do `TKT-LK1J` first if possible so Embed inherits the cleaner test
+pattern.

--- a/tickets/entities/tickets/TKT-LK1J.md
+++ b/tickets/entities/tickets/TKT-LK1J.md
@@ -1,0 +1,97 @@
+---
+id: TKT-LK1J
+type: ticket
+title: Inject *slog.Logger into ai.Provider for parallel-test-safe log capture
+kind: refactor
+priority: low
+effort: s
+status: ready
+---
+
+## Goal
+
+Replace `slog.Default()` calls inside `internal/ai` with an injectable
+`*slog.Logger` field on `OpenAICompatProvider` so tests can capture log output
+from a per-test logger instead of swapping the process-global default via
+`slog.SetDefault`.
+
+Resolves the deferred finding `RR-QH8C` (code review F10) from `TKT-YBKB`.
+
+## Background
+
+The `internal/ai` package emits structured logs via `slog.Debug`, `slog.Info`,
+and `slog.Warn` from `logRequestStart`, `logRequestSuccess`, and
+`logRequestFailure`. These all call into the process-global `slog.Default()`.
+
+Tests that want to assert on log output (`TestProvider_Chat_LogsSuccess
+AndFailure`, `TestProvider_Chat_LogsFailure`, the entire
+`TestProvider_Chat_KeyNeverLeaks*` family) capture logs via the `captureLog`
+helper, which swaps `slog.Default()` to a buffered handler and serializes
+through a package-level mutex `logMu`.
+
+This works today only because no test in the package calls `t.Parallel()`. The
+moment someone adds it, the global mutex won't help — another test running in
+parallel can emit a log line via `slog.Default()` while a `captureLog`-using
+test holds the lock, contaminating the captured buffer with unrelated output.
+The `KeyNeverLeaks` family is especially fragile: a stray log line from another
+test could either accidentally satisfy or accidentally fail the leak assertion.
+
+The cranky-code-reviewer flagged this as F10 in the TKT-YBKB code review
+(`RR-QH8C`). It was deferred because the captureLog rewrite for slog (during the
+develop rebase) does not actually fix the race — it only renames it. The real
+fix is dependency injection.
+
+## In Scope
+
+- Add a `*slog.Logger` field to `openAICompatProvider` (default to
+`slog.Default()` if not set so existing callers don't break)
+- Add a `WithLogger(*slog.Logger) Option` mirroring the existing
+options pattern, OR add a `Logger` field on `Config`/the constructor signature —
+pick whichever is least invasive at the call sites
+- Replace the three `logRequest*` package-level functions with methods
+on `*openAICompatProvider` so they can use `p.logger` directly
+- Rewrite `captureLog` in `openai_test.go` to construct a per-test
+`*slog.Logger` and pass it to the provider via `WithLogger`. The `logMu` global
+serialization disappears.
+- Once the global mutex is gone, opt the noisier tests into
+`t.Parallel()` to demonstrate the fix is real
+
+## Out of Scope
+
+- Changing the format of any log lines (the existing `slog.TextHandler`
+output is fine)
+- Wiring a custom logger from CLI/MCP entry points — they continue to
+use `slog.Default()` via the constructor default. Logger DI here is about
+test-isolation, not about making production loggers configurable per-call.
+(That's a separate concern, see below.)
+- Removing the `--verbose`/`--quiet` Cobra flag wiring from
+`internal/cli/root.go` (added by FEAT-VH7Z / PR #328)
+
+## Acceptance Criteria
+
+1. `OpenAICompatProvider` has a `logger *slog.Logger` field that
+defaults to `slog.Default()` when not set.
+2. `WithLogger(*slog.Logger) Option` (or equivalent) lets callers
+inject a logger.
+3. The three `logRequest*` functions become methods on the provider
+and use `p.logger` instead of `slog.Default()`.
+4. `captureLog` no longer swaps the process-global default and no
+longer uses `logMu`. Each test that wants log capture constructs its own
+`*slog.Logger` over a `*bytes.Buffer`.
+5. At least one log-capturing test (e.g.
+`TestProvider_Chat_KeyNeverLeaks_SuccessPath`) opts into `t.Parallel()` and
+still passes deterministically.
+6. `go test -race ./internal/ai/...` passes.
+7. No production behavior change: CLI/MCP entry points still emit
+logs via `slog.Default()` as today (no entry-point wiring change).
+
+## Notes
+
+- This is a small mechanical refactor. The whole change should be under
+~150 lines of Go.
+- The `ai.LoadProvider` convenience helper does not need to change —
+it builds a default-logger provider, and entry points that want a custom logger
+can still use `NewOpenAICompatProvider(cfg, WithLogger(...))` directly.
+- A future ticket could thread a per-call `*slog.Logger` through the CLI
+for `--verbose` runs that want richer AI-specific logging, but that is not this
+ticket.

--- a/tickets/relations/TKT-135Q--affects--ai-integration.md
+++ b/tickets/relations/TKT-135Q--affects--ai-integration.md
@@ -1,0 +1,5 @@
+---
+from: TKT-135Q
+relation: affects
+to: ai-integration
+---

--- a/tickets/relations/TKT-135Q--implements--FEAT-ER3Y.md
+++ b/tickets/relations/TKT-135Q--implements--FEAT-ER3Y.md
@@ -1,0 +1,5 @@
+---
+from: TKT-135Q
+relation: implements
+to: FEAT-ER3Y
+---

--- a/tickets/relations/TKT-5FYM--affects--ai-integration.md
+++ b/tickets/relations/TKT-5FYM--affects--ai-integration.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5FYM
+relation: affects
+to: ai-integration
+---

--- a/tickets/relations/TKT-5FYM--affects--lua-scripting.md
+++ b/tickets/relations/TKT-5FYM--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5FYM
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-5FYM--implements--FEAT-ER3Y.md
+++ b/tickets/relations/TKT-5FYM--implements--FEAT-ER3Y.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5FYM
+relation: implements
+to: FEAT-ER3Y
+---

--- a/tickets/relations/TKT-LK1J--affects--ai-integration.md
+++ b/tickets/relations/TKT-LK1J--affects--ai-integration.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LK1J
+relation: affects
+to: ai-integration
+---

--- a/tickets/relations/TKT-LK1J--affects--test-isolation.md
+++ b/tickets/relations/TKT-LK1J--affects--test-isolation.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LK1J
+relation: affects
+to: test-isolation
+---

--- a/tickets/relations/TKT-LK1J--implements--FEAT-ER3Y.md
+++ b/tickets/relations/TKT-LK1J--implements--FEAT-ER3Y.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LK1J
+relation: implements
+to: FEAT-ER3Y
+---


### PR DESCRIPTION
Three ready tickets layered on top of TKT-YBKB / PR #336 (now merged) to continue building out FEAT-ER3Y. Ordered by dependency and value.

| ID | Title | Effort | Priority | Depends on |
|---|---|---|---|---|
| TKT-LK1J | Inject \`*slog.Logger\` into \`ai.Provider\` for parallel-test-safe log capture | s | low | — |
| TKT-5FYM | Add embeddings support: \`ai.embed\` Lua binding and \`Provider.Embed\` | m | high | — |
| TKT-135Q | Add content-hash-keyed cache for AI responses | m | high | TKT-5FYM |

## Why these three, in this order

**TKT-LK1J** closes the only deferred finding from the TKT-YBKB code review (\`RR-QH8C\` / F10). Today \`internal/ai\` tests can't use \`t.Parallel()\` because \`captureLog\` swaps \`slog.Default()\`, which is process-global. Injecting a per-provider logger removes the need for the global mutex. Small mechanical refactor — could be done in a single agent pass.

**TKT-5FYM** is the foundation for everything user-facing in the AI roadmap (suggest-links, semantic search, duplicate detection, ask). The \`Provider\` interface was named "Provider" specifically so this would slot in without parallel wiring. Same hardening as Chat: typed errors, redirect refusal, body cap, Content-Type validation, sentinel-key leak prevention. Smoke-tested against ollama \`nomic-embed-text\` (already pulled in dev).

**TKT-135Q** is the cost-control layer that makes embeddings affordable to use casually. Without caching, every \`analyze\` run that touches semantic search re-embeds every entity in the project. Implemented as a decorator over \`ai.Provider\` so it composes cleanly. Strongly recommended to land alongside or right after TKT-5FYM.

## Doc-only PR

This PR contains **only ticket markdown files** — no code changes. Each ticket has detailed acceptance criteria, scope decisions, and notes on dependencies and test plans. They're scoped tightly enough that an agent could pick one up and start.

## Test plan

- [x] \`rela validate\` passes (cardinality, properties, custom validations) — verified locally against the new develop state
- [x] All tickets link to \`FEAT-ER3Y\` via \`implements\` and \`ai-integration\` via \`affects\`
- [x] TKT-5FYM also \`affects\` \`lua-scripting\`; TKT-LK1J also \`affects\` \`test-isolation\`
- [x] All 118 rela validation rules pass

## Other follow-ups (filed later)

The full followup list from the planning round is documented in this PR's parent thread but not yet filed as tickets:

- AI in validation rules (cost guardrails design)
- CLI commands (\`rela ai suggest-links\`, \`rela ai improve\`, \`rela ai ask\`)
- MCP tool wrappers for AI helpers
- Web UI inline AI affordances
- Audit logging
- HTTP retries with backoff
- Per-call timeout argument
- One-time exfiltration warning