### PR TITLE
refactor(dataentry): remove App.mu, migrate to AppState snapshot (TKT-PYN1b/c + WYYP + 9NFK)

### DIFF
--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -116,7 +116,7 @@ func main() {
 		slog.Warn("rela-server bound beyond loopback; see docs/security.md for threat model",
 			"bind", *bind)
 	}
-	slog.Info("starting server", "name", app.Cfg.App.Name, "addr", "http://"+addr)
+	slog.Info("starting server", "name", app.Cfg().App.Name, "addr", "http://"+addr)
 	if err := srv.ListenAndServe(); err != nil {
 		slog.Error("server stopped", "error", err)
 		os.Exit(1)

--- a/internal/dataentry/actions.go
+++ b/internal/dataentry/actions.go
@@ -21,7 +21,7 @@ var actionIDRegex = regexp.MustCompile(`^[a-z0-9_-]{1,64}$`)
 
 // actionTimeout is the maximum execution time for an action script.
 // Tighter than the default Lua timeout because the action handler holds
-// the workspace write lock for the entire script execution.
+// writeMu for the entire script execution, blocking other mutations.
 const actionTimeout = 5 * time.Second
 
 // V1ActionResponse mirrors script.ActionResponse for API JSON output.
@@ -37,10 +37,9 @@ type V1ActionResponse struct {
 // handleV1Action executes a configured action script and returns the result.
 // Endpoint: POST /api/v1/_action/{id}
 //
-// Note: Called under reloadLockMiddleware which holds RLock. Action scripts
-// may mutate the workspace, so we release the read lock and acquire the
-// write lock for the duration of script execution, then restore the read
-// lock for the middleware's defer.
+// Action scripts may mutate the workspace, so we serialize them via
+// writeMu for the duration of script execution. Concurrent reloads,
+// other mutations, and other action scripts wait for writeMu.
 func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", "POST")
@@ -55,8 +54,7 @@ func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// We're under RLock from middleware. Read the action config first.
-	action, ok := a.Cfg.Actions[id]
+	action, ok := a.Cfg().Actions[id]
 	if !ok {
 		writeV1Error(w, r, http.StatusNotFound, "action_not_found", "Action not found", "")
 		return
@@ -64,17 +62,14 @@ func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 
 	correlationID := newCorrelationID()
 
-	// Swap to write lock for the duration of script execution.
-	a.mu.RUnlock()
-	a.mu.Lock()
-	defer func() {
-		a.mu.Unlock()
-		a.mu.RLock()
-	}()
+	// Serialize action script execution against other mutations and
+	// against workspace reloads via writeMu.
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
 
 	ctx := &actionScriptContext{
 		ws:          a.ws,
-		meta:        a.meta,
+		meta:        a.Meta(),
 		projectRoot: a.ws.Paths().Root,
 	}
 

--- a/internal/dataentry/actions_test.go
+++ b/internal/dataentry/actions_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
-// callAction simulates the reloadLockMiddleware by holding RLock around
-// the handler call, matching how requests reach handlers in production.
+// callAction is a thin wrapper that invokes handleV1Action directly. It
+// used to simulate the reloadLockMiddleware by holding RLock around the
+// call; since App.mu was deleted this is now just a direct call, but
+// keeping the helper avoids touching every test body in this file.
 func callAction(app *App, req *http.Request, rec *httptest.ResponseRecorder) {
-	app.mu.RLock()
-	defer app.mu.RUnlock()
 	app.handleV1Action(rec, req)
 }
 
@@ -43,7 +43,7 @@ func newActionTestApp(t *testing.T, scripts map[string]string) *App {
 	app := newTestAppV1(t)
 	app.ws = workspace.NewWithGraph(
 		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: tmpDir}),
-		app.meta, app.g)
+		app.Meta(), app.Graph())
 
 	return app
 }
@@ -52,7 +52,7 @@ func TestHandleV1Action_Success(t *testing.T) {
 	app := newActionTestApp(t, map[string]string{
 		"hello.lua": `return {redirect = "/done", message = "ok"}`,
 	})
-	app.Cfg.Actions = map[string]dataentryconfig.Action{
+	app.Cfg().Actions = map[string]dataentryconfig.Action{
 		"hello": {Script: "hello.lua"},
 	}
 
@@ -81,7 +81,7 @@ func TestHandleV1Action_NoReturn(t *testing.T) {
 	app := newActionTestApp(t, map[string]string{
 		"noop.lua": `local x = 1`,
 	})
-	app.Cfg.Actions = map[string]dataentryconfig.Action{
+	app.Cfg().Actions = map[string]dataentryconfig.Action{
 		"noop": {Script: "noop.lua"},
 	}
 
@@ -97,7 +97,7 @@ func TestHandleV1Action_NoReturn(t *testing.T) {
 
 func TestHandleV1Action_NotFound(t *testing.T) {
 	app := newActionTestApp(t, nil)
-	app.Cfg.Actions = map[string]dataentryconfig.Action{}
+	app.Cfg().Actions = map[string]dataentryconfig.Action{}
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/_action/missing", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -150,7 +150,7 @@ func TestHandleV1Action_ScriptError(t *testing.T) {
 	app := newActionTestApp(t, map[string]string{
 		"boom.lua": `error("kaboom")`,
 	})
-	app.Cfg.Actions = map[string]dataentryconfig.Action{
+	app.Cfg().Actions = map[string]dataentryconfig.Action{
 		"boom": {Script: "boom.lua"},
 	}
 
@@ -179,7 +179,7 @@ func TestHandleV1Action_ParamsPassed(t *testing.T) {
 	app := newActionTestApp(t, map[string]string{
 		"echo.lua": `return {message = rela.params.greeting}`,
 	})
-	app.Cfg.Actions = map[string]dataentryconfig.Action{
+	app.Cfg().Actions = map[string]dataentryconfig.Action{
 		"echo": {
 			Script: "echo.lua",
 			Params: map[string]string{"greeting": "hello world"},
@@ -208,7 +208,7 @@ func TestHandleV1Action_OpenRedirectRejected(t *testing.T) {
 	app := newActionTestApp(t, map[string]string{
 		"evil.lua": `return {redirect = "//evil.com"}`,
 	})
-	app.Cfg.Actions = map[string]dataentryconfig.Action{
+	app.Cfg().Actions = map[string]dataentryconfig.Action{
 		"evil": {Script: "evil.lua"},
 	}
 
@@ -229,7 +229,7 @@ func TestHandleV1Action_Concurrent(t *testing.T) {
 	app := newActionTestApp(t, map[string]string{
 		"noop.lua": `return {message = "done"}`,
 	})
-	app.Cfg.Actions = map[string]dataentryconfig.Action{
+	app.Cfg().Actions = map[string]dataentryconfig.Action{
 		"noop": {Script: "noop.lua"},
 	}
 

--- a/internal/dataentry/analyze.go
+++ b/internal/dataentry/analyze.go
@@ -95,7 +95,7 @@ func (a *App) analyzeOrphans() AnalysisSection {
 		Description: "Entities with no incoming or outgoing relations",
 	}
 
-	orphans := a.g.FindOrphans()
+	orphans := a.Graph().FindOrphans()
 	sortEntitiesByID(orphans)
 
 	for _, e := range orphans {
@@ -118,7 +118,7 @@ func (a *App) analyzeDuplicates() AnalysisSection {
 		Description: "Entities with identical titles",
 	}
 
-	entities := a.g.AllNodes()
+	entities := a.Graph().AllNodes()
 	titleGroups := make(map[string][]*model.Entity)
 	for _, e := range entities {
 		title := normalizeTitle(a.entityDisplayTitle(e))
@@ -166,7 +166,7 @@ func (a *App) analyzeGaps() AnalysisSection {
 
 	// Build set of manual ID prefixes to skip
 	manualPrefixes := make(map[string]bool)
-	for _, entityDef := range a.meta.Entities {
+	for _, entityDef := range a.Meta().Entities {
 		if entityDef.IsManualID() {
 			for _, idPrefix := range entityDef.GetIDPrefixes() {
 				manualPrefixes[strings.TrimSuffix(idPrefix, "-")] = true
@@ -176,7 +176,7 @@ func (a *App) analyzeGaps() AnalysisSection {
 
 	// Group IDs by prefix
 	prefixGroups := make(map[string][]int)
-	for _, id := range a.g.AllIDs() {
+	for _, id := range a.Graph().AllIDs() {
 		parsed, err := model.ParseEntityID(id)
 		if err != nil || parsed.Prefix == "" {
 			continue
@@ -225,22 +225,22 @@ func (a *App) analyzeCardinality() AnalysisSection {
 	}
 
 	// Sort relation names for deterministic output
-	relNames := make([]string, 0, len(a.meta.Relations))
-	for name := range a.meta.Relations {
+	relNames := make([]string, 0, len(a.Meta().Relations))
+	for name := range a.Meta().Relations {
 		relNames = append(relNames, name)
 	}
 	natsort.Strings(relNames)
 
 	for _, relName := range relNames {
-		relDef := a.meta.Relations[relName]
+		relDef := a.Meta().Relations[relName]
 
 		// Check min_outgoing
 		if relDef.MinOutgoing != nil && *relDef.MinOutgoing > 0 {
 			for _, sourceType := range relDef.From {
-				entities := a.g.NodesByType(sourceType)
+				entities := a.Graph().NodesByType(sourceType)
 				sortEntitiesByID(entities)
 				for _, e := range entities {
-					count := countEdgesByType(a.g.OutgoingEdges(e.ID), relName)
+					count := countEdgesByType(a.Graph().OutgoingEdges(e.ID), relName)
 					if count < *relDef.MinOutgoing {
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
@@ -257,10 +257,10 @@ func (a *App) analyzeCardinality() AnalysisSection {
 		// Check max_outgoing
 		if relDef.MaxOutgoing != nil {
 			for _, sourceType := range relDef.From {
-				entities := a.g.NodesByType(sourceType)
+				entities := a.Graph().NodesByType(sourceType)
 				sortEntitiesByID(entities)
 				for _, e := range entities {
-					count := countEdgesByType(a.g.OutgoingEdges(e.ID), relName)
+					count := countEdgesByType(a.Graph().OutgoingEdges(e.ID), relName)
 					if count > *relDef.MaxOutgoing {
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
@@ -277,10 +277,10 @@ func (a *App) analyzeCardinality() AnalysisSection {
 		// Check min_incoming
 		if relDef.MinIncoming != nil && *relDef.MinIncoming > 0 {
 			for _, targetType := range relDef.To {
-				entities := a.g.NodesByType(targetType)
+				entities := a.Graph().NodesByType(targetType)
 				sortEntitiesByID(entities)
 				for _, e := range entities {
-					count := countEdgesByType(a.g.IncomingEdges(e.ID), relName)
+					count := countEdgesByType(a.Graph().IncomingEdges(e.ID), relName)
 					if count < *relDef.MinIncoming {
 						relLabel := relName
 						if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
@@ -301,10 +301,10 @@ func (a *App) analyzeCardinality() AnalysisSection {
 		// Check max_incoming
 		if relDef.MaxIncoming != nil {
 			for _, targetType := range relDef.To {
-				entities := a.g.NodesByType(targetType)
+				entities := a.Graph().NodesByType(targetType)
 				sortEntitiesByID(entities)
 				for _, e := range entities {
-					count := countEdgesByType(a.g.IncomingEdges(e.ID), relName)
+					count := countEdgesByType(a.Graph().IncomingEdges(e.ID), relName)
 					if count > *relDef.MaxIncoming {
 						relLabel := relName
 						if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
@@ -333,11 +333,11 @@ func (a *App) analyzeProperties() AnalysisSection {
 		Description: "Property validation errors (required fields, invalid values, ID patterns)",
 	}
 
-	entities := a.g.AllNodes()
+	entities := a.Graph().AllNodes()
 	sortEntitiesByID(entities)
 
 	for _, entity := range entities {
-		errs := a.meta.ValidateEntity(entity)
+		errs := a.Meta().ValidateEntity(entity)
 		for _, err := range errs {
 			section.Issues = append(section.Issues, AnalysisIssue{
 				EntityID:   entity.ID,
@@ -359,7 +359,7 @@ func (a *App) analyzeValidations() AnalysisSection {
 		Description: "Custom validation rules defined in the metamodel",
 	}
 
-	for _, rule := range a.meta.Validations {
+	for _, rule := range a.Meta().Validations {
 		violations := a.checkValidationRule(rule)
 		severity := rule.GetSeverity()
 		for _, e := range violations {
@@ -389,20 +389,20 @@ func (a *App) checkValidationRule(rule metamodel.ValidationRule) []*model.Entity
 
 	var entities []*model.Entity
 	if rule.EntityType != "" {
-		entities = a.g.NodesByType(rule.EntityType)
+		entities = a.Graph().NodesByType(rule.EntityType)
 	} else {
-		entities = a.g.AllNodes()
+		entities = a.Graph().AllNodes()
 	}
 
 	var violations []*model.Entity
 	for _, entity := range entities {
-		entityDef, ok := a.meta.GetEntityDef(entity.Type)
+		entityDef, ok := a.Meta().GetEntityDef(entity.Type)
 		if !ok {
 			continue
 		}
 
 		if len(whenFilters) > 0 {
-			matches, err := filter.MatchAll(entity, whenFilters, entityDef, a.meta)
+			matches, err := filter.MatchAll(entity, whenFilters, entityDef, a.Meta())
 			if err != nil || !matches {
 				continue
 			}
@@ -410,7 +410,7 @@ func (a *App) checkValidationRule(rule metamodel.ValidationRule) []*model.Entity
 
 		// Check property-based then conditions
 		if len(thenFilters) > 0 {
-			satisfies, err := filter.MatchAll(entity, thenFilters, entityDef, a.meta)
+			satisfies, err := filter.MatchAll(entity, thenFilters, entityDef, a.Meta())
 			if err != nil {
 				violations = append(violations, entity)
 				continue

--- a/internal/dataentry/analyze_test.go
+++ b/internal/dataentry/analyze_test.go
@@ -10,11 +10,7 @@ import (
 
 // newTestApp creates a minimal App with the given graph and metamodel for testing.
 func newTestApp(g *graph.Graph, meta *metamodel.Metamodel) *App {
-	return &App{
-		g:    g,
-		meta: meta,
-		Cfg:  &Config{},
-	}
+	return newAppFromParts(&Config{}, meta, g)
 }
 
 func TestAnalyzeOrphans(t *testing.T) {

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -97,7 +97,7 @@ func (a *App) toV1PropertyDef(propDef metamodel.PropertyDef) V1PropertyDef {
 		Description: propDef.Description,
 		List:        propDef.List,
 	}
-	if ct, ok := a.meta.Types[propDef.Type]; ok {
+	if ct, ok := a.Meta().Types[propDef.Type]; ok {
 		pd.Values = ct.Values
 	} else if len(propDef.Values) > 0 {
 		pd.Values = propDef.Values
@@ -197,9 +197,10 @@ func (a *App) registerAPIV1Routes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/", a.handleV1DynamicRoutes)
 }
 
-// handleV1DynamicRoutes routes requests to the appropriate entity handler based on URL.
-// Note: This handler is called under reloadLockMiddleware which already holds RLock.
-// Write operations (create, update, delete) will release/reacquire the lock as needed.
+// handleV1DynamicRoutes routes requests to the appropriate entity handler
+// based on URL. Read operations work against the snapshot returned by
+// a.State() with no locking; write operations take a.writeMu for the
+// duration of the mutation.
 func (a *App) handleV1DynamicRoutes(w http.ResponseWriter, r *http.Request) {
 	// Skip system routes (already handled)
 	path := strings.TrimPrefix(r.URL.Path, "/api/v1/")
@@ -207,8 +208,6 @@ func (a *App) handleV1DynamicRoutes(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-
-	// Note: RLock is held by reloadLockMiddleware - don't acquire another one
 
 	// Parse path: {plural}[/{id}[/relations[/{relType}[/{targetId}]]]]
 	parts := strings.Split(strings.Trim(path, "/"), "/")
@@ -221,7 +220,7 @@ func (a *App) handleV1DynamicRoutes(w http.ResponseWriter, r *http.Request) {
 
 	// Find entity type by plural
 	var typeName string
-	for name, def := range a.meta.Entities {
+	for name, def := range a.Meta().Entities {
 		if def.GetDirPlural(name) == plural {
 			typeName = name
 			break
@@ -286,7 +285,7 @@ func (a *App) handleV1EntityCollection(w http.ResponseWriter, r *http.Request, t
 }
 
 func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeName, plural string) {
-	entities := a.g.NodesByType(typeName)
+	entities := a.Graph().NodesByType(typeName)
 
 	// Apply filters
 	query := r.URL.Query()
@@ -366,12 +365,8 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 
 func (a *App) handleV1CreateEntity(w http.ResponseWriter, r *http.Request, typeName, plural string) {
 	// Need write lock for creation
-	a.mu.RUnlock()
-	a.mu.Lock()
-	defer func() {
-		a.mu.Unlock()
-		a.mu.RLock()
-	}()
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
 
 	var req struct {
 		ID         string                 `json:"id,omitempty"`
@@ -424,7 +419,7 @@ func (a *App) handleV1SingleEntity(w http.ResponseWriter, r *http.Request, typeN
 }
 
 func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName, plural, entityID string) {
-	entity, found := a.g.GetNode(entityID)
+	entity, found := a.Graph().GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -456,14 +451,10 @@ func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName
 
 func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeName, plural, entityID string) {
 	// Need write lock
-	a.mu.RUnlock()
-	a.mu.Lock()
-	defer func() {
-		a.mu.Unlock()
-		a.mu.RLock()
-	}()
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
 
-	entity, found := a.g.GetNode(entityID)
+	entity, found := a.Graph().GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -519,21 +510,17 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 
 func (a *App) handleV1DeleteEntity(w http.ResponseWriter, r *http.Request, typeName, _, entityID string) {
 	// Need write lock
-	a.mu.RUnlock()
-	a.mu.Lock()
-	defer func() {
-		a.mu.Unlock()
-		a.mu.RLock()
-	}()
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
 
-	entity, found := a.g.GetNode(entityID)
+	entity, found := a.Graph().GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
 	}
 
 	// Check for incoming relations
-	incoming := a.g.IncomingEdges(entityID)
+	incoming := a.Graph().IncomingEdges(entityID)
 	if len(incoming) > 0 {
 		writeV1Error(w, r, http.StatusConflict, "has_relations",
 			"Cannot delete entity with incoming relations",
@@ -555,14 +542,14 @@ func (a *App) handleV1DeleteEntity(w http.ResponseWriter, r *http.Request, typeN
 // --- Relation Handlers ---
 
 func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, typeName, entityID string) {
-	entity, found := a.g.GetNode(entityID)
+	entity, found := a.Graph().GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
 	}
 
-	outgoing := a.g.OutgoingEdges(entityID)
-	incoming := a.g.IncomingEdges(entityID)
+	outgoing := a.Graph().OutgoingEdges(entityID)
+	incoming := a.Graph().IncomingEdges(entityID)
 
 	relations := make(map[string][]map[string]interface{})
 
@@ -578,7 +565,7 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 	}
 
 	for _, edge := range incoming {
-		relDef, ok := a.meta.Relations[edge.Type]
+		relDef, ok := a.Meta().Relations[edge.Type]
 		if !ok {
 			continue
 		}
@@ -620,7 +607,7 @@ func resolveRelationEndpoints(entityID, peerID, direction string) (from, to stri
 }
 
 func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, typeName, entityID, relType string) {
-	entity, found := a.g.GetNode(entityID)
+	entity, found := a.Graph().GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -630,9 +617,9 @@ func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, ty
 
 	var edges []*model.Relation
 	if incoming {
-		edges = a.g.IncomingEdges(entityID)
+		edges = a.Graph().IncomingEdges(entityID)
 	} else {
-		edges = a.g.OutgoingEdges(entityID)
+		edges = a.Graph().OutgoingEdges(entityID)
 	}
 
 	relations := make([]map[string]interface{}, 0, len(edges))
@@ -659,14 +646,10 @@ func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, ty
 
 func (a *App) handleV1CreateRelation(w http.ResponseWriter, r *http.Request, typeName, entityID, relType string) {
 	// Need write lock
-	a.mu.RUnlock()
-	a.mu.Lock()
-	defer func() {
-		a.mu.Unlock()
-		a.mu.RLock()
-	}()
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
 
-	entity, found := a.g.GetNode(entityID)
+	entity, found := a.Graph().GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -717,14 +700,10 @@ func (a *App) handleV1RelationTarget(w http.ResponseWriter, r *http.Request, typ
 
 func (a *App) handleV1UpdateRelation(w http.ResponseWriter, r *http.Request, typeName, entityID, relType, targetID string) {
 	// Need write lock
-	a.mu.RUnlock()
-	a.mu.Lock()
-	defer func() {
-		a.mu.Unlock()
-		a.mu.RLock()
-	}()
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
 
-	entity, found := a.g.GetNode(entityID)
+	entity, found := a.Graph().GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -763,14 +742,10 @@ func (a *App) handleV1UpdateRelation(w http.ResponseWriter, r *http.Request, typ
 
 func (a *App) handleV1DeleteRelation(w http.ResponseWriter, r *http.Request, typeName, entityID, relType, targetID string) {
 	// Need write lock
-	a.mu.RUnlock()
-	a.mu.Lock()
-	defer func() {
-		a.mu.Unlock()
-		a.mu.RLock()
-	}()
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
 
-	entity, found := a.g.GetNode(entityID)
+	entity, found := a.Graph().GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -804,14 +779,10 @@ func (a *App) handleV1EntityAction(w http.ResponseWriter, r *http.Request, typeN
 
 func (a *App) handleV1CloneEntity(w http.ResponseWriter, r *http.Request, typeName, entityID string) {
 	// Need write lock
-	a.mu.RUnlock()
-	a.mu.Lock()
-	defer func() {
-		a.mu.Unlock()
-		a.mu.RLock()
-	}()
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
 
-	entity, found := a.g.GetNode(entityID)
+	entity, found := a.Graph().GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -832,7 +803,7 @@ func (a *App) handleV1CloneEntity(w http.ResponseWriter, r *http.Request, typeNa
 		return
 	}
 
-	entityDef := a.meta.Entities[typeName]
+	entityDef := a.Meta().Entities[typeName]
 	plural := entityDef.GetDirPlural(typeName)
 	result := a.entityToV1(newEntity, plural, false, false)
 
@@ -848,16 +819,13 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
 	schema := V1Schema{
 		Entities:  make(map[string]V1EntityType),
 		Relations: make(map[string]V1RelationType),
 		Types:     make(map[string]V1CustomType),
 	}
 
-	for name, def := range a.meta.Entities {
+	for name, def := range a.Meta().Entities {
 		et := V1EntityType{
 			Label:       def.Label,
 			Plural:      def.GetDirPlural(name),
@@ -875,7 +843,7 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 		schema.Entities[name] = et
 	}
 
-	for name, def := range a.meta.Relations {
+	for name, def := range a.Meta().Relations {
 		rt := V1RelationType{
 			Label:       def.Label,
 			Description: def.Description,
@@ -895,7 +863,7 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 		schema.Relations[name] = rt
 	}
 
-	for name, def := range a.meta.Types {
+	for name, def := range a.Meta().Types {
 		schema.Types[name] = V1CustomType{
 			Values:  def.Values,
 			Default: def.Default,
@@ -908,14 +876,11 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 func (a *App) handleV1SchemaRoutes(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/api/v1/_schema/")
 
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
 	switch {
 	case path == "types":
 		// List entity type names
-		names := make([]string, 0, len(a.meta.Entities))
-		for name := range a.meta.Entities {
+		names := make([]string, 0, len(a.Meta().Entities))
+		for name := range a.Meta().Entities {
 			names = append(names, name)
 		}
 		sort.Strings(names)
@@ -924,7 +889,7 @@ func (a *App) handleV1SchemaRoutes(w http.ResponseWriter, r *http.Request) {
 	case strings.HasPrefix(path, "types/"):
 		// Get specific entity type
 		typeName := strings.TrimPrefix(path, "types/")
-		def, ok := a.meta.Entities[typeName]
+		def, ok := a.Meta().Entities[typeName]
 		if !ok {
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity type not found", "")
 			return
@@ -943,7 +908,7 @@ func (a *App) handleV1SchemaRoutes(w http.ResponseWriter, r *http.Request) {
 				Required: propDef.Required,
 				Default:  propDef.Default,
 			}
-			if ct, ok := a.meta.Types[propDef.Type]; ok {
+			if ct, ok := a.Meta().Types[propDef.Type]; ok {
 				pd.Values = ct.Values
 			}
 			et.Properties[propName] = pd
@@ -951,7 +916,7 @@ func (a *App) handleV1SchemaRoutes(w http.ResponseWriter, r *http.Request) {
 		writeV1JSON(w, http.StatusOK, et)
 
 	case path == "relations":
-		writeV1JSON(w, http.StatusOK, a.meta.Relations)
+		writeV1JSON(w, http.StatusOK, a.Meta().Relations)
 
 	default:
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Resource not found", "")
@@ -962,20 +927,15 @@ func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
 		return
-	}
-
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	// Resolve relation widgets: auto-detect "cards" for relations with properties/content
-	forms := make(map[string]dataentryconfig.Form, len(a.Cfg.Forms))
-	for id, form := range a.Cfg.Forms {
+	} // Resolve relation widgets: auto-detect "cards" for relations with properties/content
+	forms := make(map[string]dataentryconfig.Form, len(a.Cfg().Forms))
+	for id, form := range a.Cfg().Forms {
 		f := form
 		resolved := make([]dataentryconfig.FormRelation, len(f.Relations))
 		copy(resolved, f.Relations)
 		for i := range resolved {
 			if resolved[i].Widget == "" {
-				if def, ok := a.meta.GetRelationDef(resolved[i].Relation); ok && def.HasAdvancedFeatures() {
+				if def, ok := a.Meta().GetRelationDef(resolved[i].Relation); ok && def.HasAdvancedFeatures() {
 					resolved[i].Widget = WidgetCards
 				}
 			}
@@ -986,18 +946,18 @@ func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
 
 	config := V1Config{
 		App: V1AppConfig{
-			Name:        a.Cfg.App.Name,
-			Description: a.Cfg.App.Description,
+			Name:        a.Cfg().App.Name,
+			Description: a.Cfg().App.Description,
 		},
-		Styles:     a.styleMap,
+		Styles:     a.State().StyleMap,
 		Forms:      forms,
-		Lists:      a.Cfg.Lists,
-		Views:      a.Cfg.Views,
-		Kanbans:    a.Cfg.Kanbans,
-		Dashboard:  a.Cfg.Dashboard,
-		Navigation: a.Cfg.Navigation,
-		Documents:  a.Cfg.Documents,
-		Palette:    a.palette,
+		Lists:      a.Cfg().Lists,
+		Views:      a.Cfg().Views,
+		Kanbans:    a.Cfg().Kanbans,
+		Dashboard:  a.Cfg().Dashboard,
+		Navigation: a.Cfg().Navigation,
+		Documents:  a.Cfg().Documents,
+		Palette:    a.State().Palette,
 	}
 
 	writeV1JSON(w, http.StatusOK, config)
@@ -1008,9 +968,6 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
 		return
 	}
-
-	a.mu.RLock()
-	defer a.mu.RUnlock()
 
 	query := r.URL.Query().Get("q")
 	if query == "" {
@@ -1033,7 +990,7 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 
 	data := make([]V1Entity, 0, len(entities))
 	for _, e := range entities {
-		entityDef := a.meta.Entities[e.Type]
+		entityDef := a.Meta().Entities[e.Type]
 		plural := entityDef.GetDirPlural(e.Type)
 		data = append(data, a.entityToV1(e, plural, false, false))
 	}
@@ -1055,9 +1012,6 @@ func (a *App) handleV1Analyze(w http.ResponseWriter, r *http.Request) {
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
 		return
 	}
-
-	a.mu.RLock()
-	defer a.mu.RUnlock()
 
 	analysisResult := a.runAnalysis()
 
@@ -1102,7 +1056,7 @@ func (a *App) entityToV1(e *model.Entity, plural string, includeRelations, inclu
 
 	if includeRelations {
 		v1.Relations = make(map[string][]string)
-		for _, edge := range a.g.OutgoingEdges(e.ID) {
+		for _, edge := range a.Graph().OutgoingEdges(e.ID) {
 			v1.Relations[edge.Type] = append(v1.Relations[edge.Type], edge.To)
 		}
 	}
@@ -1118,7 +1072,7 @@ func (a *App) computeEntityActions(e *model.Entity) *V1Actions {
 	actions := &V1Actions{}
 
 	// Check if entity can be deleted
-	incoming := a.g.IncomingEdges(e.ID)
+	incoming := a.Graph().IncomingEdges(e.ID)
 	if len(incoming) > 0 {
 		actions.Delete = &V1ActionStatus{
 			Allowed: false,
@@ -1130,9 +1084,9 @@ func (a *App) computeEntityActions(e *model.Entity) *V1Actions {
 
 	// Get valid status transitions
 	if status, ok := e.Properties["status"].(string); ok {
-		entityDef := a.meta.Entities[e.Type]
+		entityDef := a.Meta().Entities[e.Type]
 		if statusProp, ok := entityDef.Properties["status"]; ok {
-			if ct, ok := a.meta.Types[statusProp.Type]; ok {
+			if ct, ok := a.Meta().Types[statusProp.Type]; ok {
 				actions.Transitions = ct.Values
 			} else if len(statusProp.Values) > 0 {
 				actions.Transitions = statusProp.Values
@@ -1157,22 +1111,22 @@ func (a *App) resolveV1Includes(entity *model.Entity, includes string) map[strin
 	// Support include=* to include all related entities
 	if includes == "*" {
 		// Include all outgoing relations
-		for _, edge := range a.g.OutgoingEdges(entity.ID) {
-			target, found := a.g.GetNode(edge.To)
+		for _, edge := range a.Graph().OutgoingEdges(entity.ID) {
+			target, found := a.Graph().GetNode(edge.To)
 			if !found {
 				continue
 			}
-			entityDef := a.meta.Entities[target.Type]
+			entityDef := a.Meta().Entities[target.Type]
 			plural := entityDef.GetDirPlural(target.Type)
 			included[target.ID] = a.entityToV1(target, plural, false, false)
 		}
 		// Include all incoming relations
-		for _, edge := range a.g.IncomingEdges(entity.ID) {
-			source, found := a.g.GetNode(edge.From)
+		for _, edge := range a.Graph().IncomingEdges(entity.ID) {
+			source, found := a.Graph().GetNode(edge.From)
 			if !found {
 				continue
 			}
-			entityDef := a.meta.Entities[source.Type]
+			entityDef := a.Meta().Entities[source.Type]
 			plural := entityDef.GetDirPlural(source.Type)
 			included[source.ID] = a.entityToV1(source, plural, false, false)
 		}
@@ -1190,15 +1144,15 @@ func (a *App) resolveV1Includes(entity *model.Entity, includes string) map[strin
 		relParts := strings.SplitN(part, ".", 2)
 		relType := relParts[0]
 
-		for _, edge := range a.g.OutgoingEdges(entity.ID) {
+		for _, edge := range a.Graph().OutgoingEdges(entity.ID) {
 			if edge.Type != relType {
 				continue
 			}
-			target, found := a.g.GetNode(edge.To)
+			target, found := a.Graph().GetNode(edge.To)
 			if !found {
 				continue
 			}
-			entityDef := a.meta.Entities[target.Type]
+			entityDef := a.Meta().Entities[target.Type]
 			plural := entityDef.GetDirPlural(target.Type)
 			included[target.ID] = a.entityToV1(target, plural, false, false)
 
@@ -1526,13 +1480,8 @@ func (a *App) handleV1SidePanel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	formID := parts[0]
-	entityID := parts[1]
-
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	// Get form config
-	form, ok := a.Cfg.Forms[formID]
+	entityID := parts[1] // Get form config
+	form, ok := a.Cfg().Forms[formID]
 	if !ok {
 		writeV1Error(w, r, http.StatusNotFound, "form_not_found", "Form not found", "")
 		return
@@ -1545,7 +1494,7 @@ func (a *App) handleV1SidePanel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the entry entity
-	entry, found := a.g.GetNode(entityID)
+	entry, found := a.Graph().GetNode(entityID)
 	if !found {
 		writeV1Error(w, r, http.StatusNotFound, "entity_not_found", "Entity not found", "")
 		return
@@ -1653,21 +1602,16 @@ func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
 		return
-	}
-
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	// Build entity type counts
+	} // Build entity type counts
 	counts := make(map[string]int)
-	for _, entityType := range a.meta.EntityTypes() {
-		counts[entityType] = len(a.g.NodesByType(entityType))
+	for _, entityType := range a.Meta().EntityTypes() {
+		counts[entityType] = len(a.Graph().NodesByType(entityType))
 	}
 
 	// Build navigation with counts
 	navigation := make([]V1SidebarGroup, 0)
 
-	for _, entry := range a.Cfg.Navigation {
+	for _, entry := range a.Cfg().Navigation {
 		if entry.IsGroup() {
 			group := V1SidebarGroup{
 				Group:     entry.Group,
@@ -1690,8 +1634,8 @@ func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 
 	resp := V1SidebarResponse{
 		App: V1AppConfig{
-			Name:        a.Cfg.App.Name,
-			Description: a.Cfg.App.Description,
+			Name:        a.Cfg().App.Name,
+			Description: a.Cfg().App.Description,
 		},
 		Navigation: navigation,
 	}
@@ -1710,7 +1654,7 @@ func (a *App) navEntryToSidebarItem(entry dataentryconfig.NavigationEntry, count
 		item.Href = "/list/" + entry.List
 		item.Icon = "list"
 		// Look up entity type from list config
-		if list, ok := a.Cfg.Lists[entry.List]; ok {
+		if list, ok := a.Cfg().Lists[entry.List]; ok {
 			if count, ok := counts[list.EntityType]; ok {
 				item.Count = &count
 			}
@@ -1719,7 +1663,7 @@ func (a *App) navEntryToSidebarItem(entry dataentryconfig.NavigationEntry, count
 		item.Href = "/kanban/" + entry.Kanban
 		item.Icon = "kanban"
 		// Look up entity type from kanban config
-		if kanban, ok := a.Cfg.Kanbans[entry.Kanban]; ok {
+		if kanban, ok := a.Cfg().Kanbans[entry.Kanban]; ok {
 			if count, ok := counts[kanban.EntityType]; ok {
 				item.Count = &count
 			}
@@ -1841,7 +1785,7 @@ func (a *App) handleV1ConflictRoutes(w http.ResponseWriter, r *http.Request) {
 	ctx := a.ws.Paths()
 	absPath := filepath.Join(ctx.Root, path)
 
-	cf, err := conflict.ParseConflictedFile(absPath, a.meta)
+	cf, err := conflict.ParseConflictedFile(absPath, a.Meta())
 	if err != nil {
 		writeV1Error(w, r, http.StatusInternalServerError, "parse_failed", "Failed to parse conflict", err.Error())
 		return
@@ -1888,7 +1832,7 @@ func (a *App) handleV1ConflictResolve(w http.ResponseWriter, r *http.Request) {
 	ctx := a.ws.Paths()
 	absPath := filepath.Join(ctx.Root, req.Path)
 
-	cf, err := conflict.ParseConflictedFile(absPath, a.meta)
+	cf, err := conflict.ParseConflictedFile(absPath, a.Meta())
 	if err != nil {
 		writeV1Error(w, r, http.StatusInternalServerError, "parse_failed", "Failed to parse conflict", err.Error())
 		return
@@ -1917,7 +1861,7 @@ func (a *App) handleV1ConflictResolve(w http.ResponseWriter, r *http.Request) {
 		resolution.ContentChoice = conflict.SideOurs
 	}
 
-	if err := conflict.ResolveAndWrite(cf, resolution, a.meta); err != nil {
+	if err := conflict.ResolveAndWrite(cf, resolution, a.Meta()); err != nil {
 		writeV1Error(w, r, http.StatusInternalServerError, "resolve_failed", "Failed to resolve", err.Error())
 		return
 	}
@@ -1961,13 +1905,8 @@ func (a *App) handleV1Documents(w http.ResponseWriter, r *http.Request) {
 	if !isSafePathSegment(docName) || !isSafePathSegment(entityID) {
 		writeV1Error(w, r, http.StatusBadRequest, "invalid_path", "Path segment contains forbidden characters", "")
 		return
-	}
-
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	// Get document config
-	docCfg, ok := a.Cfg.Documents[docName]
+	} // Get document config
+	docCfg, ok := a.Cfg().Documents[docName]
 	if !ok {
 		writeV1Error(w, r, http.StatusNotFound, "document_not_found", "Document config not found", "")
 		return
@@ -2039,9 +1978,6 @@ func (a *App) handleV1Commands(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
 	query := r.URL.Query()
 	pageType := query.Get("page_type")
 	qualifier := query.Get("qualifier")
@@ -2077,12 +2013,7 @@ func (a *App) handleV1Templates(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
 		return
-	}
-
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	// Extract entity type from path: /api/v1/_templates/{entityType}
+	} // Extract entity type from path: /api/v1/_templates/{entityType}
 	path := strings.TrimPrefix(r.URL.Path, "/api/v1/_templates/")
 	entityType := strings.TrimSuffix(path, "/")
 
@@ -2092,7 +2023,7 @@ func (a *App) handleV1Templates(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if entity type exists
-	if _, ok := a.meta.Entities[entityType]; !ok {
+	if _, ok := a.Meta().Entities[entityType]; !ok {
 		writeV1Error(w, r, http.StatusNotFound, "entity_type_not_found",
 			fmt.Sprintf("Entity type '%s' not found", entityType), "")
 		return
@@ -2129,10 +2060,7 @@ func (a *App) handleV1OpenAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	data, err := a.openAPIGen.GenerateJSON()
+	data, err := a.State().OpenAPIGen.GenerateJSON()
 	if err != nil {
 		writeV1Error(w, r, http.StatusInternalServerError, "generation_failed", "Failed to generate OpenAPI spec", err.Error())
 		return
@@ -2254,13 +2182,8 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	viewID, entityID := parts[0], parts[1]
-
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	// Get view config
-	viewCfg, ok := a.Cfg.Views[viewID]
+	viewID, entityID := parts[0], parts[1] // Get view config
+	viewCfg, ok := a.Cfg().Views[viewID]
 	if !ok {
 		writeV1Error(w, r, http.StatusNotFound, "view_not_found", "View not found", "")
 		return
@@ -2280,7 +2203,7 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 	a.resolveSectionButtonsWithTraverse(viewCfg, sections, result.Entry)
 
 	// Build response
-	entityDef := a.meta.Entities[result.Entry.Type]
+	entityDef := a.Meta().Entities[result.Entry.Type]
 	plural := entityDef.GetDirPlural(result.Entry.Type)
 
 	resp := V1ViewResponse{

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -67,7 +67,7 @@ func TestV1ListEntities(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add test entity
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -78,11 +78,7 @@ func TestV1ListEntities(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -114,7 +110,7 @@ func TestV1GetEntity(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add test entity
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -126,11 +122,7 @@ func TestV1GetEntity(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -159,11 +151,7 @@ func TestV1GetEntityNotFound(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/NONEXISTENT", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "NONEXISTENT")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected status 404, got %d", rec.Code)
 	}
@@ -179,7 +167,7 @@ func TestV1DynamicRouting(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add test entity
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -202,11 +190,7 @@ func TestV1DynamicRouting(t *testing.T) {
 		t.Run(tc.path, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, tc.path, http.NoBody)
 			rec := httptest.NewRecorder()
-
-			app.mu.RLock()
 			app.handleV1DynamicRoutes(rec, req)
-			app.mu.RUnlock()
-
 			if rec.Code != tc.expectedStatus {
 				t.Errorf("path %s: expected status %d, got %d", tc.path, tc.expectedStatus, rec.Code)
 			}
@@ -218,7 +202,7 @@ func TestV1Filtering(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add test entities
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -226,7 +210,7 @@ func TestV1Filtering(t *testing.T) {
 			"status": "open",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-002",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -237,11 +221,7 @@ func TestV1Filtering(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?filter[status]=open", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -264,7 +244,7 @@ func TestV1FilteringNEMultipleValues(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add test entities with various statuses
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -272,7 +252,7 @@ func TestV1FilteringNEMultipleValues(t *testing.T) {
 			"status": "open",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-002",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -280,7 +260,7 @@ func TestV1FilteringNEMultipleValues(t *testing.T) {
 			"status": "completed",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-003",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -288,7 +268,7 @@ func TestV1FilteringNEMultipleValues(t *testing.T) {
 			"status": "superseded",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-004",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -300,11 +280,7 @@ func TestV1FilteringNEMultipleValues(t *testing.T) {
 	// Test filtering with ne operator and comma-separated values (NOT IN semantics)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?filter[status][ne]=completed,superseded", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -342,14 +318,14 @@ func TestV1Sorting(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add test entities
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"title": "B Ticket",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-002",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -359,11 +335,7 @@ func TestV1Sorting(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?sort=title", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	var resp V1ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
@@ -384,7 +356,7 @@ func TestV1Pagination(t *testing.T) {
 
 	// Add multiple entities
 	for i := 1; i <= 30; i++ {
-		app.g.AddNode(&model.Entity{
+		app.Graph().AddNode(&model.Entity{
 			ID:   "TKT-" + padInt(i),
 			Type: "ticket",
 			Properties: map[string]interface{}{
@@ -395,11 +367,7 @@ func TestV1Pagination(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?page=2&per_page=10", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	var resp V1ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
@@ -491,11 +459,7 @@ func TestV1SearchEmptyQuery(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/_search", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1Search(rec, req)
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -514,7 +478,7 @@ func TestV1SearchWithQuery(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add test entity
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -525,11 +489,7 @@ func TestV1SearchWithQuery(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/_search?q=Search", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1Search(rec, req)
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -538,14 +498,14 @@ func TestV1SearchWithQuery(t *testing.T) {
 func TestV1SearchWithTypeFilter(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"title": "Test Ticket",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "FEA-001",
 		Type: "feature",
 		Properties: map[string]interface{}{
@@ -555,11 +515,7 @@ func TestV1SearchWithTypeFilter(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/_search?q=Test&type=ticket", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1Search(rec, req)
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -633,21 +589,21 @@ func TestV1GetEntityWithIncludesAll(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add entities with relations
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"title": "Test Ticket",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "FEA-001",
 		Type: "feature",
 		Properties: map[string]interface{}{
 			"title": "Test Feature",
 		},
 	})
-	app.g.AddEdge(&model.Relation{
+	app.Graph().AddEdge(&model.Relation{
 		From: "TKT-001",
 		To:   "FEA-001",
 		Type: "implements",
@@ -655,11 +611,7 @@ func TestV1GetEntityWithIncludesAll(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001?include=*", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -677,21 +629,21 @@ func TestV1GetEntityWithIncludesAll(t *testing.T) {
 func TestV1GetEntityWithIncludesSpecific(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"title": "Test Ticket",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "FEA-001",
 		Type: "feature",
 		Properties: map[string]interface{}{
 			"title": "Test Feature",
 		},
 	})
-	app.g.AddEdge(&model.Relation{
+	app.Graph().AddEdge(&model.Relation{
 		From: "TKT-001",
 		To:   "FEA-001",
 		Type: "implements",
@@ -699,11 +651,7 @@ func TestV1GetEntityWithIncludesSpecific(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001?include=implements", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -728,16 +676,12 @@ func TestV1GetEntityIfNoneMatch(t *testing.T) {
 			"title": "Test Ticket",
 		},
 	}
-	app.g.AddNode(entity)
+	app.Graph().AddNode(entity)
 
 	// First request to get ETag
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
-	app.mu.RUnlock()
-
 	etag := rec.Header().Get("ETag")
 	if etag == "" {
 		t.Fatal("expected ETag header")
@@ -747,11 +691,7 @@ func TestV1GetEntityIfNoneMatch(t *testing.T) {
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
 	req.Header.Set("If-None-Match", etag)
 	rec = httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusNotModified {
 		t.Errorf("expected status 304, got %d", rec.Code)
 	}
@@ -761,7 +701,7 @@ func TestV1GetEntityWithActions(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Set up status property with values
-	app.meta.Entities["ticket"] = metamodel.EntityDef{
+	app.Meta().Entities["ticket"] = metamodel.EntityDef{
 		Label: "Ticket",
 		Properties: map[string]metamodel.PropertyDef{
 			"title":  {Type: "string", Required: true},
@@ -769,7 +709,7 @@ func TestV1GetEntityWithActions(t *testing.T) {
 		},
 	}
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -780,11 +720,7 @@ func TestV1GetEntityWithActions(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001?include=_actions", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -806,7 +742,7 @@ func TestV1GetEntityWithActions(t *testing.T) {
 func TestV1SingleEntityOptions(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -816,11 +752,7 @@ func TestV1SingleEntityOptions(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodOptions, "/api/v1/tickets/TKT-001", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1SingleEntity(rec, req, "ticket", "tickets", "TKT-001")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusNoContent {
 		t.Errorf("expected status 204, got %d", rec.Code)
 	}
@@ -834,7 +766,7 @@ func TestV1SingleEntityOptions(t *testing.T) {
 func TestV1SingleEntityMethodNotAllowed(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -844,11 +776,7 @@ func TestV1SingleEntityMethodNotAllowed(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/tickets/TKT-001", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1SingleEntity(rec, req, "ticket", "tickets", "TKT-001")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected status 405, got %d", rec.Code)
 	}
@@ -859,11 +787,7 @@ func TestV1ListEntitiesEmpty(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -881,14 +805,14 @@ func TestV1ListEntitiesEmpty(t *testing.T) {
 func TestV1ListEntitiesDescendingSort(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"title": "A Ticket",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-002",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -898,11 +822,7 @@ func TestV1ListEntitiesDescendingSort(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?sort=-title", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	var resp V1ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
@@ -921,14 +841,14 @@ func TestV1ListEntitiesDescendingSort(t *testing.T) {
 func TestV1FilteringContains(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"title": "Bug Fix Ticket",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-002",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -938,11 +858,7 @@ func TestV1FilteringContains(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?filter[title][contains]=Bug", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	var resp V1ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
@@ -960,21 +876,21 @@ func TestV1FilteringContains(t *testing.T) {
 func TestV1FilteringIn(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"status": "open",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-002",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"status": "in_progress",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-003",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -984,11 +900,7 @@ func TestV1FilteringIn(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?filter[status][in]=open,in_progress", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	var resp V1ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
@@ -1006,14 +918,14 @@ func TestV1FilteringIn(t *testing.T) {
 func TestV1FilteringPercentEncodedBrackets(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"status": "open",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-002",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -1028,14 +940,14 @@ func TestV1FilteringPercentEncodedBrackets(t *testing.T) {
 	}
 
 	// Percent-encoded with operator
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-003",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"due_date": "2026-01-01",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-004",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -1055,21 +967,21 @@ func TestV1FilteringPercentEncodedBrackets(t *testing.T) {
 func TestV1FilteringMultiValueRepeatedParams(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"status": "open",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-002",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"status": "in_progress",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-003",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -1091,9 +1003,7 @@ func runListFilter(t *testing.T, app *App, query string) []string {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?"+query, http.NoBody)
 	rec := httptest.NewRecorder()
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
 	var resp V1ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode failed: %v", err)
@@ -1116,11 +1026,11 @@ func TestV1FilteringLte(t *testing.T) {
 	thresholdID := "TKT-threshold"
 	laterID := "TKT-later"
 
-	app.g.AddNode(&model.Entity{ID: earlierID, Type: "ticket",
+	app.Graph().AddNode(&model.Entity{ID: earlierID, Type: "ticket",
 		Properties: map[string]interface{}{"due_date": earlier}})
-	app.g.AddNode(&model.Entity{ID: thresholdID, Type: "ticket",
+	app.Graph().AddNode(&model.Entity{ID: thresholdID, Type: "ticket",
 		Properties: map[string]interface{}{"due_date": threshold}})
-	app.g.AddNode(&model.Entity{ID: laterID, Type: "ticket",
+	app.Graph().AddNode(&model.Entity{ID: laterID, Type: "ticket",
 		Properties: map[string]interface{}{"due_date": later}})
 
 	got := runListFilter(t, app, "filter[due_date][lte]="+threshold)
@@ -1141,9 +1051,9 @@ func TestV1FilteringGte(t *testing.T) {
 	earlierID := "TKT-earlier"
 	laterID := "TKT-later"
 
-	app.g.AddNode(&model.Entity{ID: earlierID, Type: "ticket",
+	app.Graph().AddNode(&model.Entity{ID: earlierID, Type: "ticket",
 		Properties: map[string]interface{}{"due_date": earlier}})
-	app.g.AddNode(&model.Entity{ID: laterID, Type: "ticket",
+	app.Graph().AddNode(&model.Entity{ID: laterID, Type: "ticket",
 		Properties: map[string]interface{}{"due_date": later}})
 
 	got := runListFilter(t, app, "filter[due_date][gte]=2026-01-01")
@@ -1165,11 +1075,11 @@ func TestV1FilteringTodaySubstitution(t *testing.T) {
 	todayID := "TKT-today"
 	futureID := "TKT-future"
 
-	app.g.AddNode(&model.Entity{ID: overdueID, Type: "ticket",
+	app.Graph().AddNode(&model.Entity{ID: overdueID, Type: "ticket",
 		Properties: map[string]interface{}{"due_date": "2026-04-06"}})
-	app.g.AddNode(&model.Entity{ID: todayID, Type: "ticket",
+	app.Graph().AddNode(&model.Entity{ID: todayID, Type: "ticket",
 		Properties: map[string]interface{}{"due_date": "2026-04-07"}})
-	app.g.AddNode(&model.Entity{ID: futureID, Type: "ticket",
+	app.Graph().AddNode(&model.Entity{ID: futureID, Type: "ticket",
 		Properties: map[string]interface{}{"due_date": "2026-04-08"}})
 
 	got := runListFilter(t, app, "filter[due_date][lte]=$today")
@@ -1186,7 +1096,7 @@ func TestV1FilteringTodaySubstitution(t *testing.T) {
 // a non-date filter value excludes the entity rather than silently lying.
 func TestV1FilteringTypeMismatch(t *testing.T) {
 	app := newTestAppV1(t)
-	app.g.AddNode(&model.Entity{ID: "TKT-1", Type: "ticket",
+	app.Graph().AddNode(&model.Entity{ID: "TKT-1", Type: "ticket",
 		Properties: map[string]interface{}{"due_date": "2026-04-07"}})
 
 	// "tomorrow" is not a date and not a known variable; should NOT silently
@@ -1201,9 +1111,9 @@ func TestV1FilteringTypeMismatch(t *testing.T) {
 // the entity doesn't have excludes the entity (no panic, no inclusion).
 func TestV1FilteringMissingProperty(t *testing.T) {
 	app := newTestAppV1(t)
-	app.g.AddNode(&model.Entity{ID: "TKT-no-due", Type: "ticket",
+	app.Graph().AddNode(&model.Entity{ID: "TKT-no-due", Type: "ticket",
 		Properties: map[string]interface{}{"title": "no due date"}})
-	app.g.AddNode(&model.Entity{ID: "TKT-with-due", Type: "ticket",
+	app.Graph().AddNode(&model.Entity{ID: "TKT-with-due", Type: "ticket",
 		Properties: map[string]interface{}{"due_date": "2026-04-07"}})
 
 	got := runListFilter(t, app, "filter[due_date][lte]=2026-12-31")
@@ -1221,11 +1131,11 @@ func TestV1FilteringInWithVariableTokens(t *testing.T) {
 	defer func() { nowFunc = prev }()
 
 	app := newTestAppV1(t)
-	app.g.AddNode(&model.Entity{ID: "TKT-yesterday", Type: "ticket",
+	app.Graph().AddNode(&model.Entity{ID: "TKT-yesterday", Type: "ticket",
 		Properties: map[string]interface{}{"due_date": "2026-04-06"}})
-	app.g.AddNode(&model.Entity{ID: "TKT-today", Type: "ticket",
+	app.Graph().AddNode(&model.Entity{ID: "TKT-today", Type: "ticket",
 		Properties: map[string]interface{}{"due_date": "2026-04-07"}})
-	app.g.AddNode(&model.Entity{ID: "TKT-other", Type: "ticket",
+	app.Graph().AddNode(&model.Entity{ID: "TKT-other", Type: "ticket",
 		Properties: map[string]interface{}{"due_date": "2026-04-09"}})
 
 	got := runListFilter(t, app, "filter[due_date][in]=$yesterday,$today")
@@ -1241,14 +1151,14 @@ func TestV1FilteringInWithVariableTokens(t *testing.T) {
 func TestV1FilteringEmptyValue(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"title": "Has Title",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-002",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -1260,11 +1170,7 @@ func TestV1FilteringEmptyValue(t *testing.T) {
 	// Filter for entities without status
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?filter[status]=", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -1273,7 +1179,7 @@ func TestV1FilteringEmptyValue(t *testing.T) {
 func TestV1MultipleSort(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -1281,7 +1187,7 @@ func TestV1MultipleSort(t *testing.T) {
 			"title":  "B Ticket",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-002",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -1289,7 +1195,7 @@ func TestV1MultipleSort(t *testing.T) {
 			"title":  "A Ticket",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-003",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -1300,11 +1206,7 @@ func TestV1MultipleSort(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?sort=status,title", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	var resp V1ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
@@ -1319,39 +1221,39 @@ func TestV1GetEntityWithNestedIncludes(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add entities with relations
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"title": "Test Ticket",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "FEA-001",
 		Type: "feature",
 		Properties: map[string]interface{}{
 			"title": "Test Feature",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "FEA-002",
 		Type: "feature",
 		Properties: map[string]interface{}{
 			"title": "Another Feature",
 		},
 	})
-	app.g.AddEdge(&model.Relation{
+	app.Graph().AddEdge(&model.Relation{
 		From: "TKT-001",
 		To:   "FEA-001",
 		Type: "implements",
 	})
 	// Create another relation type for nested includes
-	app.meta.Relations["requires"] = metamodel.RelationDef{
+	app.Meta().Relations["requires"] = metamodel.RelationDef{
 		Label: "requires",
 		From:  []string{"feature"},
 		To:    []string{"feature"},
 	}
-	app.g.AddEdge(&model.Relation{
+	app.Graph().AddEdge(&model.Relation{
 		From: "FEA-001",
 		To:   "FEA-002",
 		Type: "requires",
@@ -1359,11 +1261,7 @@ func TestV1GetEntityWithNestedIncludes(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001?include=implements.requires", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -1386,21 +1284,21 @@ func TestV1ComputeEntityActionsWithIncomingRelations(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add entities with incoming relation
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"title": "Test Ticket",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "FEA-001",
 		Type: "feature",
 		Properties: map[string]interface{}{
 			"title": "Test Feature",
 		},
 	})
-	app.g.AddEdge(&model.Relation{
+	app.Graph().AddEdge(&model.Relation{
 		From: "TKT-001",
 		To:   "FEA-001",
 		Type: "implements",
@@ -1408,11 +1306,7 @@ func TestV1ComputeEntityActionsWithIncomingRelations(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/features/FEA-001?include=_actions", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1GetEntity(rec, req, "feature", "features", "FEA-001")
-	app.mu.RUnlock()
-
 	var entity V1Entity
 	if err := json.NewDecoder(rec.Body).Decode(&entity); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
@@ -1433,11 +1327,7 @@ func TestV1DynamicRoutesPostToCollection(t *testing.T) {
 	// POST without workspace should fail gracefully
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/tickets", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1DynamicRoutes(rec, req)
-	app.mu.RUnlock()
-
 	// Should return 400 or 422 because body is empty/invalid
 	if rec.Code != http.StatusBadRequest && rec.Code != http.StatusUnprocessableEntity {
 		t.Errorf("expected status 400 or 422, got %d", rec.Code)
@@ -1449,11 +1339,7 @@ func TestV1DynamicRoutesOptionsCollection(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodOptions, "/api/v1/tickets", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1DynamicRoutes(rec, req)
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusNoContent {
 		t.Errorf("expected status 204, got %d", rec.Code)
 	}
@@ -1469,11 +1355,7 @@ func TestV1SearchMethodNotAllowed(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/_search", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1Search(rec, req)
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected status 405, got %d", rec.Code)
 	}
@@ -1520,7 +1402,7 @@ func TestV1SidePanelFormNotFound(t *testing.T) {
 
 func TestV1SidePanelNoConfig(t *testing.T) {
 	app := newTestAppV1(t)
-	app.Cfg.Forms["ticket"] = dataentryconfig.Form{
+	app.Cfg().Forms["ticket"] = dataentryconfig.Form{
 		EntityType: "ticket",
 		SidePanel:  nil, // No side panel config
 	}
@@ -1539,14 +1421,14 @@ func TestV1SchemaWithCustomTypes(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add custom type
-	app.meta.Types = map[string]metamodel.CustomType{
+	app.Meta().Types = map[string]metamodel.CustomType{
 		"status_type": {
 			Values:  []string{"open", "in_progress", "closed"},
 			Default: "open",
 		},
 	}
 	// Update property to use custom type
-	app.meta.Entities["ticket"] = metamodel.EntityDef{
+	app.Meta().Entities["ticket"] = metamodel.EntityDef{
 		Label: "Ticket",
 		Properties: map[string]metamodel.PropertyDef{
 			"title":  {Type: "string", Required: true},
@@ -1585,7 +1467,7 @@ func TestV1PaginationLinkHeaders(t *testing.T) {
 
 	// Add 30 entities
 	for i := 1; i <= 30; i++ {
-		app.g.AddNode(&model.Entity{
+		app.Graph().AddNode(&model.Entity{
 			ID:   "TKT-" + padInt(i),
 			Type: "ticket",
 			Properties: map[string]interface{}{
@@ -1597,11 +1479,7 @@ func TestV1PaginationLinkHeaders(t *testing.T) {
 	// Get first page
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?page=1&per_page=10", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	link := rec.Header().Get("Link")
 	if !strings.Contains(link, "rel=\"first\"") {
 		t.Error("expected 'first' link in Link header")
@@ -1616,11 +1494,7 @@ func TestV1PaginationLinkHeaders(t *testing.T) {
 	// Get middle page (should have prev)
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/tickets?page=2&per_page=10", http.NoBody)
 	rec = httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	link = rec.Header().Get("Link")
 	if !strings.Contains(link, "rel=\"prev\"") {
 		t.Error("expected 'prev' link in Link header for page 2")
@@ -1632,11 +1506,7 @@ func TestV1DynamicRoutesEmptyPath(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1DynamicRoutes(rec, req)
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected status 404, got %d", rec.Code)
 	}
@@ -1672,11 +1542,11 @@ func TestV1SidebarWithNavigation(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add entities to get counts
-	app.g.AddNode(&model.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{"title": "Test"}})
-	app.g.AddNode(&model.Entity{ID: "FEA-001", Type: "feature", Properties: map[string]interface{}{"title": "Test Feature"}})
+	app.Graph().AddNode(&model.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{"title": "Test"}})
+	app.Graph().AddNode(&model.Entity{ID: "FEA-001", Type: "feature", Properties: map[string]interface{}{"title": "Test Feature"}})
 
 	// Set up navigation with groups using actual struct fields
-	app.Cfg.Navigation = []dataentryconfig.NavigationEntry{
+	app.Cfg().Navigation = []dataentryconfig.NavigationEntry{
 		{
 			Group: "Main",
 			Items: []dataentryconfig.NavigationEntry{
@@ -1715,13 +1585,13 @@ func TestV1ComputeEntityActionsWithCustomType(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Set up status property with custom type
-	app.meta.Types = map[string]metamodel.CustomType{
+	app.Meta().Types = map[string]metamodel.CustomType{
 		"ticket_status": {
 			Values:  []string{"open", "in_progress", "closed"},
 			Default: "open",
 		},
 	}
-	app.meta.Entities["ticket"] = metamodel.EntityDef{
+	app.Meta().Entities["ticket"] = metamodel.EntityDef{
 		Label: "Ticket",
 		Properties: map[string]metamodel.PropertyDef{
 			"title":  {Type: "string", Required: true},
@@ -1729,7 +1599,7 @@ func TestV1ComputeEntityActionsWithCustomType(t *testing.T) {
 		},
 	}
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -1740,11 +1610,7 @@ func TestV1ComputeEntityActionsWithCustomType(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001?include=_actions", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
-	app.mu.RUnlock()
-
 	var entity V1Entity
 	if err := json.NewDecoder(rec.Body).Decode(&entity); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
@@ -1770,14 +1636,14 @@ func TestV1ComputeEntityActionsWithCustomType(t *testing.T) {
 func TestV1FilterUnknownOperator(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"title": "Test Ticket",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-002",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -1801,12 +1667,12 @@ func TestV1FilterUnknownOperator(t *testing.T) {
 // log warning rather than silently passing every entity.
 func TestV1FilterMalformedKeySkipped(t *testing.T) {
 	app := newTestAppV1(t)
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:         "TKT-001",
 		Type:       "ticket",
 		Properties: map[string]interface{}{"status": "open"},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:         "TKT-002",
 		Type:       "ticket",
 		Properties: map[string]interface{}{"status": "closed"},
@@ -1831,7 +1697,7 @@ func TestV1SchemaTypesSpecific(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add custom type that should be reflected in property
-	app.meta.Types = map[string]metamodel.CustomType{
+	app.Meta().Types = map[string]metamodel.CustomType{
 		"priority_type": {
 			Values:  []string{"low", "medium", "high"},
 			Default: "medium",
@@ -1861,21 +1727,21 @@ func TestV1GetEntityIncludeIncoming(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add entities with relations
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
 			"title": "Test Ticket",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "FEA-001",
 		Type: "feature",
 		Properties: map[string]interface{}{
 			"title": "Test Feature",
 		},
 	})
-	app.g.AddEdge(&model.Relation{
+	app.Graph().AddEdge(&model.Relation{
 		From: "TKT-001",
 		To:   "FEA-001",
 		Type: "implements",
@@ -1884,11 +1750,7 @@ func TestV1GetEntityIncludeIncoming(t *testing.T) {
 	// Get the feature entity with include=* to get incoming relations
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/features/FEA-001?include=*", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1GetEntity(rec, req, "feature", "features", "FEA-001")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -1907,7 +1769,7 @@ func TestV1GetEntityIncludeIncoming(t *testing.T) {
 func TestV1DynamicRoutesMethodNotAllowed(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -1918,11 +1780,7 @@ func TestV1DynamicRoutesMethodNotAllowed(t *testing.T) {
 	// CONNECT method is not allowed
 	req := httptest.NewRequest(http.MethodConnect, "/api/v1/tickets", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1DynamicRoutes(rec, req)
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected status 405, got %d", rec.Code)
 	}
@@ -1933,7 +1791,7 @@ func TestV1PaginationEdgeCases(t *testing.T) {
 
 	// Add some entities
 	for i := 1; i <= 5; i++ {
-		app.g.AddNode(&model.Entity{
+		app.Graph().AddNode(&model.Entity{
 			ID:   "TKT-" + padInt(i),
 			Type: "ticket",
 			Properties: map[string]interface{}{
@@ -1945,11 +1803,7 @@ func TestV1PaginationEdgeCases(t *testing.T) {
 	// Test page beyond total (should return empty)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?page=100&per_page=10", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	var resp V1ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
@@ -1968,7 +1822,7 @@ func TestV1AnalyzeWithIssues(t *testing.T) {
 	app := newTestAppV1(t)
 
 	// Add entity without required property
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:         "TKT-001",
 		Type:       "ticket",
 		Properties: map[string]interface{}{
@@ -1997,7 +1851,7 @@ func TestV1AnalyzeWithIssues(t *testing.T) {
 func TestV1SortMultipleSpecsWithSameValue(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -2005,7 +1859,7 @@ func TestV1SortMultipleSpecsWithSameValue(t *testing.T) {
 			"title":  "A Ticket",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-002",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -2013,7 +1867,7 @@ func TestV1SortMultipleSpecsWithSameValue(t *testing.T) {
 			"title":  "B Ticket",
 		},
 	})
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-003",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -2024,11 +1878,7 @@ func TestV1SortMultipleSpecsWithSameValue(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?sort=status,title", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -2037,7 +1887,7 @@ func TestV1SortMultipleSpecsWithSameValue(t *testing.T) {
 func TestV1ResolveIncludesEmptyPart(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -2048,11 +1898,7 @@ func TestV1ResolveIncludesEmptyPart(t *testing.T) {
 	// Include with empty parts (trailing comma)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001?include=implements,,_actions", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
@@ -2064,7 +1910,7 @@ func TestV1SchemaWithRelationCardinality(t *testing.T) {
 	// Add relation with cardinality constraints
 	minOut := 1
 	maxOut := 5
-	app.meta.Relations["requires"] = metamodel.RelationDef{
+	app.Meta().Relations["requires"] = metamodel.RelationDef{
 		Label:       "requires",
 		From:        []string{"ticket"},
 		To:          []string{"feature"},
@@ -2094,7 +1940,7 @@ func TestV1SchemaWithRelationCardinality(t *testing.T) {
 func TestV1EntityToV1WithoutRelations(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -2106,11 +1952,7 @@ func TestV1EntityToV1WithoutRelations(t *testing.T) {
 	// Call without relations (first list endpoint)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	app.mu.RUnlock()
-
 	var resp V1ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
@@ -2265,12 +2107,9 @@ func newTestAppV1(t *testing.T) *App {
 
 	ws := workspace.NewForTest(g, meta)
 
-	return &App{
-		meta: meta,
-		g:    g,
-		ws:   ws,
-		Cfg:  cfg,
-	}
+	app := newAppFromParts(cfg, meta, g)
+	app.ws = ws
+	return app
 }
 
 func TestV1EntityRelationsNotFound(t *testing.T) {
@@ -2278,11 +2117,7 @@ func TestV1EntityRelationsNotFound(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/NONEXISTENT/relations", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1EntityRelations(rec, req, "ticket", "NONEXISTENT")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected status 404, got %d", rec.Code)
 	}
@@ -2296,7 +2131,7 @@ func TestV1EntityRelationsNotFound(t *testing.T) {
 func TestV1EntityRelationsWrongType(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -2307,11 +2142,7 @@ func TestV1EntityRelationsWrongType(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/features/TKT-001/relations", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1EntityRelations(rec, req, "feature", "TKT-001")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected status 404, got %d", rec.Code)
 	}
@@ -2322,11 +2153,7 @@ func TestV1DeleteEntityNotFound(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tickets/NONEXISTENT", http.NoBody)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1DeleteEntity(rec, req, "ticket", "tickets", "NONEXISTENT")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected status 404, got %d", rec.Code)
 	}
@@ -2343,11 +2170,7 @@ func TestV1UpdateEntityNotFound(t *testing.T) {
 	body := strings.NewReader(`{"properties":{"title":"Updated"}}`)
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/NONEXISTENT", body)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1UpdateEntity(rec, req, "ticket", "tickets", "NONEXISTENT")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected status 404, got %d", rec.Code)
 	}
@@ -2356,7 +2179,7 @@ func TestV1UpdateEntityNotFound(t *testing.T) {
 func TestV1UpdateEntityInvalidJSON(t *testing.T) {
 	app := newTestAppV1(t)
 
-	app.g.AddNode(&model.Entity{
+	app.Graph().AddNode(&model.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
 		Properties: map[string]interface{}{
@@ -2368,11 +2191,7 @@ func TestV1UpdateEntityInvalidJSON(t *testing.T) {
 	body := strings.NewReader(`{invalid json`)
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/TKT-001", body)
 	rec := httptest.NewRecorder()
-
-	app.mu.RLock()
 	app.handleV1UpdateEntity(rec, req, "ticket", "tickets", "TKT-001")
-	app.mu.RUnlock()
-
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("expected status 400, got %d", rec.Code)
 	}

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -27,17 +27,17 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
-// appState bundles the reloadable fields of App into an immutable snapshot.
+// AppState bundles the reloadable fields of App into an immutable snapshot.
 //
 // During this PR, App still holds the same fields as plain struct fields
 // (Cfg, meta, g, styleMap, styledTypes, userDefaults, palette, userPalette,
-// openAPIGen) and the appState is published in parallel via atomic.Pointer.
+// openAPIGen) and the AppState is published in parallel via atomic.Pointer.
 // Handlers will be migrated to read from the snapshot in a subsequent PR.
 //
 // The fields here mirror the workspace.workspaceState pattern: callers
 // Load() once and work against a coherent snapshot, instead of holding a
 // read lock around the entire request.
-type appState struct {
+type AppState struct {
 	Cfg          *Config
 	Meta         *metamodel.Metamodel
 	Graph        *graph.Graph
@@ -61,59 +61,82 @@ const userDefaultsFile = "user-defaults.yaml"
 // userPaletteFile is the filename for user-specific palette overrides within the .rela directory.
 const userPaletteFile = "palette.yaml"
 
-// App is the central application struct holding config, metamodel, and graph.
+// App is the central application struct for the data-entry server.
+//
+// # Concurrency model
+//
+// All reloadable state (config, metamodel, graph, style map, palette,
+// user defaults, OpenAPI generator) lives in an immutable AppState struct
+// held via atomic.Pointer. Handlers call a.State() once at entry and work
+// against a coherent snapshot for the duration of the request — no lock
+// acquisition, no risk of observing a half-reloaded world.
+//
+// Reloads (triggered by the file watcher or by Reload) build a new
+// AppState and publish it atomically via a.state.Store. The previous
+// state is garbage-collected once no reader holds it.
+//
+// Mutations (CreateEntity, UpdateEntity, DeleteEntity, CreateRelation,
+// UpdateRelation, DeleteRelation, SetProperty, action scripts) serialize
+// via writeMu. writeMu excludes concurrent mutations but does NOT block
+// readers — readers go through state.Load(). The workspace's internal
+// reloadMu coordinates the reload itself with the mutation path.
 type App struct {
-	Cfg *Config
-	ws  *workspace.Workspace
-	// Convenience aliases set from workspace; avoid method-call overhead in hot paths.
-	meta *metamodel.Metamodel
-	g    *graph.Graph
-	// styleMap: property type name -> value -> CSS class name
-	styleMap map[string]map[string]string
-	// styledTypes: set of property type names that have style entries
-	styledTypes map[string]bool
-	// userDefaults holds the loaded user defaults (nil if not yet loaded or no file).
-	userDefaults *UserDefaults
-	// palette holds the resolved palette for both light and dark themes.
-	palette *ResolvedPalette
-	// userPalette holds the user-specific palette overrides.
-	userPalette *PaletteConfig
-	// gitOps provides git operations when git is enabled.
+	ws *workspace.Workspace
+
+	// state holds the current reloadable snapshot. Readers: a.State().
+	// Writers: onReload rebuilds and publishes a new state after file
+	// changes. Initial state is published in NewApp.
+	state atomic.Pointer[AppState]
+
+	// writeMu serializes mutation handlers (CreateEntity, UpdateEntity,
+	// etc.) against each other and against the reload path inside
+	// Workspace. Readers never take it.
+	writeMu sync.Mutex
+
+	// gitOps provides git operations when git is enabled. Set once in
+	// NewApp; never reloaded.
 	gitOps *git.Ops
-	// openAPIGen generates OpenAPI specs from the metamodel.
-	openAPIGen *openapi.Generator
-	// state is an immutable snapshot of all reloadable fields above. It is
-	// published in parallel with the convenience aliases during this PR
-	// (dual-write phase). A subsequent PR migrates handlers to read from
-	// the snapshot via state.Load() instead of taking the App.mu read
-	// lock and reading the convenience aliases.
-	state atomic.Pointer[appState]
-	// mu protects reloadable state (Cfg, meta, g, tmpl, styleMap, styledTypes)
-	// during live-reload. Handlers acquire RLock; reload acquires Lock.
-	mu sync.RWMutex
+
 	// broker delivers SSE events to connected browsers for live-reload.
 	broker *eventBroker
+
 	// security holds the configured Host/Origin allowlists. Set via
 	// SetSecurityConfig before NewRouter; nil disables the middlewares
 	// (only sensible in unit tests where no HTTP layer is exercised).
 	security *security
 }
 
-// publishState builds an appState snapshot from the current convenience
-// aliases and publishes it via state.Store. Called from NewApp and from
-// onReload (under App.mu.Lock) during the dual-write phase.
-func (a *App) publishState() {
-	a.state.Store(&appState{
-		Cfg:          a.Cfg,
-		Meta:         a.meta,
-		Graph:        a.g,
-		StyleMap:     a.styleMap,
-		StyledTypes:  a.styledTypes,
-		UserDefaults: a.userDefaults,
-		Palette:      a.palette,
-		UserPalette:  a.userPalette,
-		OpenAPIGen:   a.openAPIGen,
-	})
+// State returns the current reloadable snapshot. Handlers should call
+// State() once at entry and use the returned snapshot consistently
+// throughout, instead of making multiple calls that could see different
+// snapshots after a concurrent reload.
+func (a *App) State() *AppState { return a.state.Load() }
+
+// Cfg returns the current data-entry config (convenience accessor).
+// Equivalent to a.State().Cfg.
+func (a *App) Cfg() *Config { return a.State().Cfg }
+
+// Meta returns the current metamodel (convenience accessor).
+func (a *App) Meta() *metamodel.Metamodel { return a.State().Meta }
+
+// Graph returns the current in-memory graph (convenience accessor).
+func (a *App) Graph() *graph.Graph { return a.State().Graph }
+
+// mutateState atomically updates the published AppState. It takes
+// writeMu, builds a shallow copy of the current snapshot, runs the
+// caller's mutator on the copy, and publishes the copy via state.Store.
+//
+// This is the canonical way for mutation handlers to change reloadable
+// fields like UserDefaults or UserPalette. Reaching through a.State()
+// to assign field values directly is a bug — it scribbles on the shared
+// snapshot pointer that lock-free readers also hold.
+func (a *App) mutateState(fn func(*AppState)) {
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
+	cur := a.state.Load()
+	next := *cur // shallow copy of the snapshot
+	fn(&next)
+	a.state.Store(&next)
 }
 
 // SetSecurityConfig configures the HTTP security middlewares applied by
@@ -170,20 +193,11 @@ func NewApp(ws *workspace.Workspace) (*App, error) {
 	styleMap, styledTypes := buildStyleMap(&cfg, meta)
 
 	app := &App{
-		Cfg:         &cfg,
-		ws:          ws,
-		meta:        meta,
-		g:           g,
-		styleMap:    styleMap,
-		styledTypes: styledTypes,
-		broker:      newEventBroker(),
-		openAPIGen: openapi.New(meta, openapi.Config{
-			Title:       cfg.App.Name + " API",
-			Description: cfg.App.Description,
-			Version:     "1.0.0",
-		}),
+		ws:     ws,
+		broker: newEventBroker(),
 	}
-	app.userDefaults = app.loadUserDefaults()
+
+	userDefaults := app.loadUserDefaults()
 	userPalette, paletteErr := app.loadUserPalette()
 	if paletteErr != nil {
 		// Surface the error so users notice their palette is broken
@@ -191,19 +205,31 @@ func NewApp(ws *workspace.Workspace) (*App, error) {
 		// then be persisted on the next save, destroying their data).
 		return nil, fmt.Errorf("load user palette: %w", paletteErr)
 	}
-	app.userPalette = userPalette
-	app.palette = ResolvePalette(cfg.Palette, app.userPalette)
+
+	// Build and publish the initial AppState snapshot. All reloadable
+	// state lives here; there are no convenience aliases on App to keep
+	// in sync.
+	app.state.Store(&AppState{
+		Cfg:          &cfg,
+		Meta:         meta,
+		Graph:        g,
+		StyleMap:     styleMap,
+		StyledTypes:  styledTypes,
+		UserDefaults: userDefaults,
+		Palette:      ResolvePalette(cfg.Palette, userPalette),
+		UserPalette:  userPalette,
+		OpenAPIGen: openapi.New(meta, openapi.Config{
+			Title:       cfg.App.Name + " API",
+			Description: cfg.App.Description,
+			Version:     "1.0.0",
+		}),
+	})
 
 	// Initialize git ops if enabled and repo is a git repository
 	if cfg.Git != nil && cfg.Git.Enabled && git.IsRepo(ws.Paths().Root) {
 		app.gitOps = git.NewOps(ws.Paths().Root, *cfg.Git)
 		slog.Info("git sync enabled", "mode", cfg.Git.Mode)
 	}
-
-	// Publish the initial appState snapshot in parallel with the
-	// convenience aliases. Handlers will be migrated to read from
-	// the snapshot in a follow-up PR.
-	app.publishState()
 
 	return app, nil
 }
@@ -239,9 +265,9 @@ func (a *App) enrichNavEntry(nav NavigationEntry) NavItem {
 	if nav.Dashboard || nav.Graph || nav.Kanban != "" {
 		return item
 	}
-	if list, ok := a.Cfg.Lists[nav.List]; ok {
+	if list, ok := a.Cfg().Lists[nav.List]; ok {
 		item.EntityType = list.EntityType
-		entities := a.g.NodesByType(list.EntityType)
+		entities := a.Graph().NodesByType(list.EntityType)
 		entities = applyFilters(entities, list.Filters)
 		item.Count = len(entities)
 	}
@@ -252,8 +278,8 @@ func (a *App) enrichNavEntry(nav NavigationEntry) NavItem {
 // The activeList parameter is used to auto-expand the group containing the active item.
 func (a *App) navElements(activeList string) []NavElement {
 	uiState := a.loadUIState()
-	elements := make([]NavElement, 0, len(a.Cfg.Navigation))
-	for _, nav := range a.Cfg.Navigation {
+	elements := make([]NavElement, 0, len(a.Cfg().Navigation))
+	for _, nav := range a.Cfg().Navigation {
 		if nav.IsGroup() {
 			grp := NavGroup{Group: nav.Group}
 			// Determine collapsed state: UIState overrides config default
@@ -401,21 +427,21 @@ func firstNavTarget(nav []NavigationEntry) *NavigationEntry {
 // editFormForType returns the first edit form ID configured for the given entity type,
 // or "" if no edit form is found. Forms with explicit mode="edit" are preferred.
 func (a *App) editFormForType(entityType string) string {
-	ids := make([]string, 0, len(a.Cfg.Forms))
-	for id := range a.Cfg.Forms {
+	ids := make([]string, 0, len(a.Cfg().Forms))
+	for id := range a.Cfg().Forms {
 		ids = append(ids, id)
 	}
 	natsort.Strings(ids)
 	// First pass: look for explicit edit mode
 	for _, id := range ids {
-		f := a.Cfg.Forms[id]
+		f := a.Cfg().Forms[id]
 		if f.EntityType == entityType && f.Mode == "edit" {
 			return id
 		}
 	}
 	// Second pass: fall back to forms with no mode specified
 	for _, id := range ids {
-		f := a.Cfg.Forms[id]
+		f := a.Cfg().Forms[id]
 		if f.EntityType == entityType && f.Mode == "" {
 			return id
 		}
@@ -427,14 +453,14 @@ func (a *App) editFormForType(entityType string) string {
 // of the given type. It prefers forms with mode "create" or unset, but falls back
 // to edit-mode forms (which work for creation when no entity ID is provided).
 func (a *App) createFormForType(entityType string) string {
-	ids := make([]string, 0, len(a.Cfg.Forms))
-	for id := range a.Cfg.Forms {
+	ids := make([]string, 0, len(a.Cfg().Forms))
+	for id := range a.Cfg().Forms {
 		ids = append(ids, id)
 	}
 	natsort.Strings(ids)
 	fallback := ""
 	for _, id := range ids {
-		f := a.Cfg.Forms[id]
+		f := a.Cfg().Forms[id]
 		if f.EntityType != entityType {
 			continue
 		}
@@ -450,7 +476,7 @@ func (a *App) createFormForType(entityType string) string {
 
 // entityDisplayTitle returns the display title for an entity.
 func (a *App) entityDisplayTitle(e *model.Entity) string {
-	return a.meta.DisplayTitle(e)
+	return a.Meta().DisplayTitle(e)
 }
 
 // resolveLinkTarget resolves a link configuration value to a URL.
@@ -475,7 +501,7 @@ func (a *App) resolveLinkTarget(link, entityType, entityID string) string {
 // activeListForEntityType returns the first navigation list ID whose entity type
 // matches the given type, or "" if none match. Walks into groups.
 func (a *App) activeListForEntityType(entityType string) string {
-	return a.findListByEntityType(a.Cfg.Navigation, entityType)
+	return a.findListByEntityType(a.Cfg().Navigation, entityType)
 }
 
 func (a *App) findListByEntityType(entries []NavigationEntry, entityType string) string {
@@ -486,7 +512,7 @@ func (a *App) findListByEntityType(entries []NavigationEntry, entityType string)
 			}
 			continue
 		}
-		if list, ok := a.Cfg.Lists[nav.List]; ok && list.EntityType == entityType {
+		if list, ok := a.Cfg().Lists[nav.List]; ok && list.EntityType == entityType {
 			return nav.List
 		}
 	}
@@ -510,7 +536,7 @@ func (a *App) activeListFromReferer(r *http.Request) string {
 		return ""
 	}
 	listID := strings.TrimPrefix(path, "/list/")
-	if _, ok := a.Cfg.Lists[listID]; ok {
+	if _, ok := a.Cfg().Lists[listID]; ok {
 		return listID
 	}
 	return ""
@@ -522,7 +548,7 @@ func (a *App) activeListFromReferer(r *http.Request) string {
 // Referer header.
 func (a *App) resolveActiveList(entityType string, r *http.Request) string {
 	if from := r.URL.Query().Get("from"); from != "" {
-		if _, ok := a.Cfg.Lists[from]; ok {
+		if _, ok := a.Cfg().Lists[from]; ok {
 			return from
 		}
 	}
@@ -534,7 +560,7 @@ func (a *App) resolveActiveList(entityType string, r *http.Request) string {
 
 // ProjectName returns the display name of the loaded project.
 func (a *App) ProjectName() string {
-	return a.Cfg.App.Name
+	return a.Cfg().App.Name
 }
 
 // ProjectRoot returns the root directory of the loaded project.

--- a/internal/dataentry/app_test.go
+++ b/internal/dataentry/app_test.go
@@ -141,14 +141,7 @@ func testAppInstance() (*App, testEntities) {
 	cfg := testConfig()
 	meta := testMeta()
 	g, entities := testGraph(meta)
-	styleMap, styledTypes := buildStyleMap(cfg, meta)
-	return &App{
-		Cfg:         cfg,
-		meta:        meta,
-		g:           g,
-		styleMap:    styleMap,
-		styledTypes: styledTypes,
-	}, entities
+	return newAppFromParts(cfg, meta, g), entities
 }
 
 func TestValidateConfig(t *testing.T) {
@@ -336,7 +329,7 @@ func TestEditFormForType(t *testing.T) {
 
 	t.Run("form with empty mode treated as edit", func(t *testing.T) {
 		app2, _ := testAppInstance()
-		app2.Cfg.Forms = map[string]Form{
+		app2.Cfg().Forms = map[string]Form{
 			"default-form": {EntityType: "ticket", Mode: ""},
 		}
 		got := app2.editFormForType("ticket")
@@ -358,7 +351,7 @@ func TestCreateFormForType(t *testing.T) {
 
 	t.Run("falls back to edit form", func(t *testing.T) {
 		app2, _ := testAppInstance()
-		app2.Cfg.Forms = map[string]Form{
+		app2.Cfg().Forms = map[string]Form{
 			"edit-ticket": {EntityType: "ticket", Mode: "edit"},
 		}
 		got := app2.createFormForType("ticket")
@@ -532,7 +525,7 @@ func TestNavElements(t *testing.T) {
 
 	t.Run("dashboard items skip entity lookup", func(t *testing.T) {
 		app2, _ := testAppInstance()
-		app2.Cfg.Navigation = []NavigationEntry{
+		app2.Cfg().Navigation = []NavigationEntry{
 			{Label: "Dashboard", Dashboard: true},
 			{Label: "Tickets", List: "tickets"},
 		}
@@ -550,7 +543,7 @@ func TestNavElements(t *testing.T) {
 
 	t.Run("filters applied to count", func(t *testing.T) {
 		app2, _ := testAppInstance()
-		app2.Cfg.Lists["tickets"] = List{
+		app2.Cfg().Lists["tickets"] = List{
 			EntityType: "ticket",
 			Filters: []FilterConfig{
 				{Property: "status", Operator: "=", Value: "open"},
@@ -568,7 +561,7 @@ func TestNavElements(t *testing.T) {
 
 	t.Run("groups with items", func(t *testing.T) {
 		app2, _ := testAppInstance()
-		app2.Cfg.Navigation = []NavigationEntry{
+		app2.Cfg().Navigation = []NavigationEntry{
 			{Label: "Dashboard", Dashboard: true},
 			{
 				Group: "Tickets",
@@ -611,7 +604,7 @@ func TestNavElements(t *testing.T) {
 
 	t.Run("group collapsed from config", func(t *testing.T) {
 		app2, _ := testAppInstance()
-		app2.Cfg.Navigation = []NavigationEntry{
+		app2.Cfg().Navigation = []NavigationEntry{
 			{
 				Group:     "Hidden",
 				Collapsed: true,
@@ -631,7 +624,7 @@ func TestNavElements(t *testing.T) {
 
 	t.Run("auto-expand group containing active list", func(t *testing.T) {
 		app2, _ := testAppInstance()
-		app2.Cfg.Navigation = []NavigationEntry{
+		app2.Cfg().Navigation = []NavigationEntry{
 			{
 				Group:     "Tickets",
 				Collapsed: true,
@@ -716,7 +709,7 @@ func TestUIStateLoadSave(t *testing.T) {
 	repo := repository.New(fs, ctx)
 
 	app, _ := testAppInstance()
-	app.ws = workspace.NewWithGraph(repo, app.meta, app.g)
+	app.ws = workspace.NewWithGraph(repo, app.Meta(), app.Graph())
 
 	t.Run("load returns defaults when file missing", func(t *testing.T) {
 		state := app.loadUIState()
@@ -738,8 +731,8 @@ func TestUIStateLoadSave(t *testing.T) {
 
 	t.Run("UIState overrides config default", func(t *testing.T) {
 		app2, _ := testAppInstance()
-		app2.ws = workspace.NewWithGraph(repo, app2.meta, app2.g)
-		app2.Cfg.Navigation = []NavigationEntry{
+		app2.ws = workspace.NewWithGraph(repo, app2.Meta(), app2.Graph())
+		app2.Cfg().Navigation = []NavigationEntry{
 			{
 				Group:     "Tickets",
 				Collapsed: false,
@@ -785,7 +778,7 @@ func TestUserDefaultsLoadSave(t *testing.T) {
 	repo := repository.New(fs, ctx)
 
 	app, _ := testAppInstance()
-	app.ws = workspace.NewWithGraph(repo, app.meta, app.g)
+	app.ws = workspace.NewWithGraph(repo, app.Meta(), app.Graph())
 
 	t.Run("load returns nil when file missing", func(t *testing.T) {
 		ud := app.loadUserDefaults()
@@ -895,7 +888,7 @@ func TestValidateConfigNestedGroups(t *testing.T) {
 
 func TestActiveListForEntityTypeWithGroups(t *testing.T) {
 	app, _ := testAppInstance()
-	app.Cfg.Navigation = []NavigationEntry{
+	app.Cfg().Navigation = []NavigationEntry{
 		{
 			Group: "Tickets",
 			Items: []NavigationEntry{

--- a/internal/dataentry/commands.go
+++ b/internal/dataentry/commands.go
@@ -37,20 +37,20 @@ type ResolvedCommand struct {
 // qualifier is the specific list ID or view ID.
 // entityType is the entity type shown on the page (empty for dashboard).
 func (a *App) resolveCommands(pageType, qualifier, entityType string) []ResolvedCommand {
-	if len(a.Cfg.Commands) == 0 {
+	if len(a.Cfg().Commands) == 0 {
 		return nil
 	}
 
 	// Sort command IDs for deterministic order.
-	ids := make([]string, 0, len(a.Cfg.Commands))
-	for id := range a.Cfg.Commands {
+	ids := make([]string, 0, len(a.Cfg().Commands))
+	for id := range a.Cfg().Commands {
 		ids = append(ids, id)
 	}
 	natsort.Strings(ids)
 
 	var result []ResolvedCommand
 	for _, id := range ids {
-		cmd := a.Cfg.Commands[id]
+		cmd := a.Cfg().Commands[id]
 		if matchesPage(cmd, pageType, qualifier, entityType) {
 			result = append(result, ResolvedCommand{
 				ID:       id,
@@ -145,8 +145,8 @@ type commandProjectInfo struct {
 
 func (a *App) buildEntityInput(entity *model.Entity) *commandInput {
 	// Collect all relations involving this entity.
-	outgoing := a.g.OutgoingEdges(entity.ID)
-	incoming := a.g.IncomingEdges(entity.ID)
+	outgoing := a.Graph().OutgoingEdges(entity.ID)
+	incoming := a.Graph().IncomingEdges(entity.ID)
 	rels := make([]*model.Relation, 0, len(outgoing)+len(incoming))
 	rels = append(rels, outgoing...)
 	rels = append(rels, incoming...)
@@ -179,7 +179,7 @@ func (a *App) buildViewInput(viewID string, vr *viewResult) *commandInput {
 	// Gather relations between entities in the result set.
 	var rels []*model.Relation
 	for id := range idSet {
-		for _, e := range a.g.OutgoingEdges(id) {
+		for _, e := range a.Graph().OutgoingEdges(id) {
 			if idSet[e.To] {
 				rels = append(rels, e)
 			}
@@ -263,7 +263,7 @@ func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 	}
 
 	commandID := strings.TrimPrefix(r.URL.Path, "/api/command/")
-	cmd, ok := a.Cfg.Commands[commandID]
+	cmd, ok := a.Cfg().Commands[commandID]
 	if !ok {
 		http.Error(w, "Unknown command: "+commandID, http.StatusNotFound)
 		return
@@ -279,7 +279,7 @@ func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 	switch cmd.Context {
 	case "entity":
 		entityID := r.URL.Query().Get("entity_id")
-		entity, found := a.g.GetNode(entityID)
+		entity, found := a.Graph().GetNode(entityID)
 		if !found {
 			http.Error(w, "Entity not found: "+entityID, http.StatusNotFound)
 			return
@@ -287,18 +287,18 @@ func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 		input = a.buildEntityInput(entity)
 	case "list":
 		listID := r.URL.Query().Get("list_id")
-		listCfg, found := a.Cfg.Lists[listID]
+		listCfg, found := a.Cfg().Lists[listID]
 		if !found {
 			http.Error(w, "List not found: "+listID, http.StatusNotFound)
 			return
 		}
-		entities := a.g.NodesByType(listCfg.EntityType)
+		entities := a.Graph().NodesByType(listCfg.EntityType)
 		entities = applyFilters(entities, listCfg.Filters)
 		input = a.buildListInput(listID, entities)
 	case "view":
 		viewID := r.URL.Query().Get("view_id")
 		entityID := r.URL.Query().Get("entity_id")
-		viewCfg, found := a.Cfg.Views[viewID]
+		viewCfg, found := a.Cfg().Views[viewID]
 		if !found {
 			http.Error(w, "View not found: "+viewID, http.StatusNotFound)
 			return

--- a/internal/dataentry/commands_test.go
+++ b/internal/dataentry/commands_test.go
@@ -22,10 +22,10 @@ import (
 
 func TestResolveCommands(t *testing.T) {
 	app, _ := testAppInstance()
-	app.Cfg.Views = map[string]ViewConfig{
+	app.Cfg().Views = map[string]ViewConfig{
 		"ticket_detail": {Title: "Ticket Detail", Entry: ViewEntry{Type: "ticket"}},
 	}
-	app.Cfg.Commands = map[string]CommandConfig{
+	app.Cfg().Commands = map[string]CommandConfig{
 		"entity-cmd": {
 			Label:   "Entity Cmd",
 			Script:  "echo hi",
@@ -120,7 +120,7 @@ func TestResolveCommands(t *testing.T) {
 	t.Run("auto_open propagated to resolved command", func(t *testing.T) {
 		app2, _ := testAppInstance()
 		trueVal := true
-		app2.Cfg.Commands = map[string]CommandConfig{
+		app2.Cfg().Commands = map[string]CommandConfig{
 			"auto-cmd": {
 				Label:    "Auto",
 				Script:   "echo hi",
@@ -257,8 +257,8 @@ func TestBuildEntityInput(t *testing.T) {
 	app, entities := testAppInstance()
 	app.ws = workspace.NewWithGraph(
 		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"}),
-		app.meta, app.g)
-	app.g.AddEdge(model.NewRelation(entities.ticket1.ID, "depends_on", entities.ticket2.ID))
+		app.Meta(), app.Graph())
+	app.Graph().AddEdge(model.NewRelation(entities.ticket1.ID, "depends_on", entities.ticket2.ID))
 
 	input := app.buildEntityInput(entities.ticket1)
 
@@ -293,8 +293,8 @@ func TestBuildListInput(t *testing.T) {
 	app, _ := testAppInstance()
 	app.ws = workspace.NewWithGraph(
 		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"}),
-		app.meta, app.g)
-	entities := app.g.NodesByType("ticket")
+		app.Meta(), app.Graph())
+	entities := app.Graph().NodesByType("ticket")
 
 	input := app.buildListInput("tickets", entities)
 
@@ -313,8 +313,8 @@ func TestBuildViewInput(t *testing.T) {
 	app, _ := testAppInstance()
 	app.ws = workspace.NewWithGraph(
 		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"}),
-		app.meta, app.g)
-	app.g.AddEdge(model.NewRelation("TKT-001", "belongs_to", "CMP-001"))
+		app.Meta(), app.Graph())
+	app.Graph().AddEdge(model.NewRelation("TKT-001", "belongs_to", "CMP-001"))
 
 	view := ViewConfig{
 		Title: "Test View",
@@ -351,7 +351,7 @@ func TestBuildGlobalInput(t *testing.T) {
 	app, _ := testAppInstance()
 	app.ws = workspace.NewWithGraph(
 		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"}),
-		app.meta, app.g)
+		app.Meta(), app.Graph())
 
 	input := app.buildGlobalInput()
 
@@ -369,7 +369,7 @@ func TestBuildCommandEnv(t *testing.T) {
 	app, entities := testAppInstance()
 	app.ws = workspace.NewWithGraph(
 		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"}),
-		app.meta, app.g)
+		app.Meta(), app.Graph())
 
 	cmd := CommandConfig{
 		Script:  "echo hi",
@@ -401,7 +401,7 @@ func TestBuildCommandEnvListContext(t *testing.T) {
 	app, _ := testAppInstance()
 	app.ws = workspace.NewWithGraph(
 		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"}),
-		app.meta, app.g)
+		app.Meta(), app.Graph())
 
 	cmd := CommandConfig{Script: "echo hi", Context: "list"}
 	input := app.buildListInput("tickets", nil)
@@ -417,7 +417,7 @@ func TestBuildCommandEnvViewContext(t *testing.T) {
 	app, entities := testAppInstance()
 	app.ws = workspace.NewWithGraph(
 		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: "/test/project"}),
-		app.meta, app.g)
+		app.Meta(), app.Graph())
 
 	cmd := CommandConfig{Script: "echo hi", Context: "view"}
 	input := &commandInput{
@@ -583,8 +583,8 @@ func TestHandleCommandExec(t *testing.T) {
 	app := newHandlerTestApp(t)
 	app.ws = workspace.NewWithGraph(
 		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()}),
-		app.meta, app.g)
-	app.Cfg.Commands = map[string]CommandConfig{
+		app.Meta(), app.Graph())
+	app.Cfg().Commands = map[string]CommandConfig{
 		"test-echo": {
 			Label:   "Test Echo",
 			Script:  `echo '::rela::{"type":"message","text":"hello from test"}' && echo 'raw log line'`,
@@ -666,8 +666,8 @@ func TestHandleCommandExecFailing(t *testing.T) {
 	app := newHandlerTestApp(t)
 	app.ws = workspace.NewWithGraph(
 		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()}),
-		app.meta, app.g)
-	app.Cfg.Commands = map[string]CommandConfig{
+		app.Meta(), app.Graph())
+	app.Cfg().Commands = map[string]CommandConfig{
 		"fail-cmd": {
 			Label:   "Fail",
 			Script:  "echo 'failing' >&2 && exit 1",
@@ -704,8 +704,8 @@ func TestHandleCommandExecGlobalContext(t *testing.T) {
 	app := newHandlerTestApp(t)
 	app.ws = workspace.NewWithGraph(
 		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()}),
-		app.meta, app.g)
-	app.Cfg.Commands = map[string]CommandConfig{
+		app.Meta(), app.Graph())
+	app.Cfg().Commands = map[string]CommandConfig{
 		"global-cmd": {
 			Label:   "Global",
 			Script:  `echo '::rela::{"type":"message","text":"global ok"}'`,
@@ -736,8 +736,8 @@ func TestHandleCommandExecListContext(t *testing.T) {
 	app := newHandlerTestApp(t)
 	app.ws = workspace.NewWithGraph(
 		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()}),
-		app.meta, app.g)
-	app.Cfg.Commands = map[string]CommandConfig{
+		app.Meta(), app.Graph())
+	app.Cfg().Commands = map[string]CommandConfig{
 		"list-cmd": {
 			Label:   "List",
 			Script:  `echo '::rela::{"type":"message","text":"list ok"}'`,
@@ -758,8 +758,8 @@ func TestHandleCommandExecViewContext(t *testing.T) {
 	app := newHandlerTestApp(t)
 	app.ws = workspace.NewWithGraph(
 		repository.New(storage.NewSafeFS(storage.NewOsFS()), &project.Context{Root: t.TempDir()}),
-		app.meta, app.g)
-	app.Cfg.Commands = map[string]CommandConfig{
+		app.Meta(), app.Graph())
+	app.Cfg().Commands = map[string]CommandConfig{
 		"view-cmd": {
 			Label:   "View",
 			Script:  `echo '::rela::{"type":"message","text":"view ok"}'`,

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -38,33 +38,40 @@ func (a *App) handleToggleCheckbox(w http.ResponseWriter, r *http.Request) {
 	entityID := r.FormValue("entity_id")
 	indexStr := r.FormValue("index")
 
-	entity, ok := a.g.GetNode(entityID)
-	if !ok {
-		http.Error(w, "Entity not found", http.StatusNotFound)
-		return
-	}
-
 	idx, err := strconv.Atoi(indexStr)
 	if err != nil {
 		http.Error(w, "Invalid checkbox index", http.StatusBadRequest)
 		return
 	}
 
-	newContent, err := toggleCheckbox(entity.Content, idx)
+	// Serialize against other mutations and against workspace reloads.
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
+
+	live, ok := a.Graph().GetNode(entityID)
+	if !ok {
+		http.Error(w, "Entity not found", http.StatusNotFound)
+		return
+	}
+
+	newContent, err := toggleCheckbox(live.Content, idx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	oldEntity := entity.Clone()
-	entity.Content = newContent
-	if _, err := a.ws.UpdateEntity(entity, oldEntity); err != nil {
+	// Clone to avoid mutating the live graph node while other readers
+	// (which take no lock) may be iterating it.
+	oldEntity := live.Clone()
+	updated := live.Clone()
+	updated.Content = newContent
+	if _, err := a.ws.UpdateEntity(updated, oldEntity); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to write: %v", err), http.StatusInternalServerError)
 		return
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = fmt.Fprint(w, simpleMarkdownToHTML(entity.Content))
+	_, _ = fmt.Fprint(w, simpleMarkdownToHTML(updated.Content))
 }
 
 // handleEntityHelp returns HTML fragment with documentation for an entity type.
@@ -76,7 +83,7 @@ func (a *App) handleEntityHelp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entDef, ok := a.meta.GetEntityDef(entityType)
+	entDef, ok := a.Meta().GetEntityDef(entityType)
 	if !ok {
 		http.NotFound(w, r)
 		return
@@ -177,8 +184,8 @@ func (a *App) renderHelpContent(w http.ResponseWriter, entityDesc htmltemplate.H
 // If outgoing is true, gathers relations where entityType is in "from";
 // otherwise gathers relations where entityType is in "to".
 func (a *App) gatherRelations(entityType string, outgoing bool) []RelationHelp {
-	rels := make([]RelationHelp, 0, len(a.meta.Relations))
-	for name, rel := range a.meta.Relations {
+	rels := make([]RelationHelp, 0, len(a.Meta().Relations))
+	for name, rel := range a.Meta().Relations {
 		var matchTypes, targetTypes []string
 		var minCard, maxCard *int
 		if outgoing {

--- a/internal/dataentry/handlers_api.go
+++ b/internal/dataentry/handlers_api.go
@@ -125,11 +125,8 @@ func (a *App) handleAPIRelationsCRUD(w http.ResponseWriter, r *http.Request) {
 
 // handleAPIEntityTypes returns a list of entity type definitions.
 func (a *App) handleAPIEntityTypes(w http.ResponseWriter, _ *http.Request) {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	types := make([]APIEntityType, 0, len(a.meta.Entities))
-	for name, def := range a.meta.Entities {
+	types := make([]APIEntityType, 0, len(a.Meta().Entities))
+	for name, def := range a.Meta().Entities {
 		apiType := APIEntityType{
 			Name:       name,
 			Plural:     def.GetPlural(),
@@ -143,7 +140,7 @@ func (a *App) handleAPIEntityTypes(w http.ResponseWriter, _ *http.Request) {
 				Default:  propDef.Default,
 			}
 			// Include enum values if this is a custom type
-			if ct, ok := a.meta.Types[propDef.Type]; ok {
+			if ct, ok := a.Meta().Types[propDef.Type]; ok {
 				apiProp.Values = ct.Values
 			}
 			apiType.Properties[propName] = apiProp
@@ -156,16 +153,13 @@ func (a *App) handleAPIEntityTypes(w http.ResponseWriter, _ *http.Request) {
 
 // handleAPIEntities returns entities, optionally filtered by type.
 func (a *App) handleAPIEntities(w http.ResponseWriter, r *http.Request) {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
 	entityType := r.URL.Query().Get("type")
 
 	var entities []*model.Entity
 	if entityType != "" {
-		entities = a.g.NodesByType(entityType)
+		entities = a.Graph().NodesByType(entityType)
 	} else {
-		entities = a.g.AllNodes()
+		entities = a.Graph().AllNodes()
 	}
 
 	result := make([]APIEntity, 0, len(entities))
@@ -177,18 +171,14 @@ func (a *App) handleAPIEntities(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleAPIEntity returns a single entity by ID.
-func (a *App) handleAPIEntity(w http.ResponseWriter, r *http.Request) {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	// Extract entity ID from path: /api/entities/{id}
+func (a *App) handleAPIEntity(w http.ResponseWriter, r *http.Request) { // Extract entity ID from path: /api/entities/{id}
 	path := strings.TrimPrefix(r.URL.Path, "/api/entities/")
 	if path == "" {
 		writeJSONError(w, http.StatusBadRequest, "missing entity ID")
 		return
 	}
 
-	entity, found := a.g.GetNode(path)
+	entity, found := a.Graph().GetNode(path)
 	if !found {
 		writeJSONError(w, http.StatusNotFound, "entity not found")
 		return
@@ -200,16 +190,13 @@ func (a *App) handleAPIEntity(w http.ResponseWriter, r *http.Request) {
 
 // handleAPIMetamodel returns the project metamodel.
 func (a *App) handleAPIMetamodel(w http.ResponseWriter, _ *http.Request) {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
 	result := APIMetamodel{
-		EntityTypes:   make([]APIEntityType, 0, len(a.meta.Entities)),
-		RelationTypes: make([]APIRelationType, 0, len(a.meta.Relations)),
+		EntityTypes:   make([]APIEntityType, 0, len(a.Meta().Entities)),
+		RelationTypes: make([]APIRelationType, 0, len(a.Meta().Relations)),
 	}
 
 	// Entity types
-	for name, def := range a.meta.Entities {
+	for name, def := range a.Meta().Entities {
 		apiType := APIEntityType{
 			Name:       name,
 			Plural:     def.Plural,
@@ -222,7 +209,7 @@ func (a *App) handleAPIMetamodel(w http.ResponseWriter, _ *http.Request) {
 				Required: propDef.Required,
 				Default:  propDef.Default,
 			}
-			if ct, ok := a.meta.Types[propDef.Type]; ok {
+			if ct, ok := a.Meta().Types[propDef.Type]; ok {
 				apiProp.Values = ct.Values
 			}
 			apiType.Properties[propName] = apiProp
@@ -231,7 +218,7 @@ func (a *App) handleAPIMetamodel(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	// Relation types
-	for name, def := range a.meta.Relations {
+	for name, def := range a.Meta().Relations {
 		result.RelationTypes = append(result.RelationTypes, APIRelationType{
 			Name: name,
 			From: def.From,
@@ -259,8 +246,8 @@ func (a *App) entityToAPI(e *model.Entity, includeRelations bool) APIEntity {
 		api.Relations = make([]APIRelation, 0)
 
 		// Outgoing relations
-		for _, edge := range a.g.OutgoingEdges(e.ID) {
-			target, found := a.g.GetNode(edge.To)
+		for _, edge := range a.Graph().OutgoingEdges(e.ID) {
+			target, found := a.Graph().GetNode(edge.To)
 			if !found {
 				continue
 			}
@@ -283,8 +270,8 @@ func (a *App) entityToAPI(e *model.Entity, includeRelations bool) APIEntity {
 		}
 
 		// Incoming relations
-		for _, edge := range a.g.IncomingEdges(e.ID) {
-			source, found := a.g.GetNode(edge.From)
+		for _, edge := range a.Graph().IncomingEdges(e.ID) {
+			source, found := a.Graph().GetNode(edge.From)
 			if !found {
 				continue
 			}
@@ -367,8 +354,8 @@ func (a *App) handleAPICreateEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
 
 	entity, _, err := a.ws.CreateEntity(req.Type, workspace.CreateOptions{
 		ID:         req.ID,
@@ -412,10 +399,10 @@ func (a *App) handleAPIUpdateEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
 
-	entity, found := a.g.GetNode(path)
+	entity, found := a.Graph().GetNode(path)
 	if !found {
 		writeJSONError(w, http.StatusNotFound, "entity not found")
 		return
@@ -464,10 +451,10 @@ func (a *App) handleAPIDeleteEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
 
-	entity, found := a.g.GetNode(path)
+	entity, found := a.Graph().GetNode(path)
 	if !found {
 		writeJSONError(w, http.StatusNotFound, "entity not found")
 		return
@@ -499,8 +486,8 @@ func (a *App) handleAPICreateRelation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
 
 	var opts []workspace.CreateRelationOptions
 	if len(req.Properties) > 0 {
@@ -538,12 +525,12 @@ func (a *App) handleAPIDeleteRelation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
 
 	// Find the relation
 	var targetEdge *model.Relation
-	for _, edge := range a.g.OutgoingEdges(from) {
+	for _, edge := range a.Graph().OutgoingEdges(from) {
 		if edge.Type == relType && edge.To == to {
 			targetEdge = edge
 			break
@@ -565,9 +552,6 @@ func (a *App) handleAPIDeleteRelation(w http.ResponseWriter, r *http.Request) {
 
 // handleAPIListRelations handles GET /api/relations to list relations.
 func (a *App) handleAPIListRelations(w http.ResponseWriter, r *http.Request) {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
 	from := r.URL.Query().Get("from")
 	to := r.URL.Query().Get("to")
 
@@ -591,10 +575,10 @@ func (a *App) handleAPIListRelations(w http.ResponseWriter, r *http.Request) {
 
 // listOutgoingRelations returns relations where the given entity is the source.
 func (a *App) listOutgoingRelations(from string) []APIRelation {
-	edges := a.g.OutgoingEdges(from)
+	edges := a.Graph().OutgoingEdges(from)
 	relations := make([]APIRelation, 0, len(edges))
 	for _, edge := range edges {
-		target, found := a.g.GetNode(edge.To)
+		target, found := a.Graph().GetNode(edge.To)
 		if !found {
 			continue
 		}
@@ -606,10 +590,10 @@ func (a *App) listOutgoingRelations(from string) []APIRelation {
 
 // listIncomingRelations returns relations where the given entity is the target.
 func (a *App) listIncomingRelations(to string) []APIRelation {
-	edges := a.g.IncomingEdges(to)
+	edges := a.Graph().IncomingEdges(to)
 	relations := make([]APIRelation, 0, len(edges))
 	for _, edge := range edges {
-		source, found := a.g.GetNode(edge.From)
+		source, found := a.Graph().GetNode(edge.From)
 		if !found {
 			continue
 		}
@@ -621,10 +605,10 @@ func (a *App) listIncomingRelations(to string) []APIRelation {
 
 // listAllRelations returns all relations in the graph.
 func (a *App) listAllRelations() []APIRelation {
-	edges := a.g.AllEdges()
+	edges := a.Graph().AllEdges()
 	relations := make([]APIRelation, 0, len(edges))
 	for _, edge := range edges {
-		target, found := a.g.GetNode(edge.To)
+		target, found := a.Graph().GetNode(edge.To)
 		if !found {
 			continue
 		}
@@ -714,10 +698,7 @@ func (a *App) handleAPISettingsCRUD(w http.ResponseWriter, r *http.Request) {
 
 // handleAPIGetSettings returns the settings data for the settings page.
 func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	ud := a.userDefaults
+	ud := a.State().UserDefaults
 	if ud == nil {
 		ud = &UserDefaults{}
 	}
@@ -750,8 +731,8 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
 
 	// Collect all properties across entity types
 	propMap := make(map[string]APIPropertyDef)
-	for _, entTypeName := range a.meta.EntityTypes() {
-		entDef, ok := a.meta.GetEntityDef(entTypeName)
+	for _, entTypeName := range a.Meta().EntityTypes() {
+		entDef, ok := a.Meta().GetEntityDef(entTypeName)
 		if !ok {
 			continue
 		}
@@ -760,7 +741,7 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
 				propMap[propName] = APIPropertyDef{
 					Name:   propName,
 					Type:   propDef.Type,
-					Values: resolvePropertyValues(propDef, a.meta),
+					Values: resolvePropertyValues(propDef, a.Meta()),
 				}
 			} else {
 				// Merge values for properties that appear on multiple types
@@ -769,7 +750,7 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
 				for _, v := range existing.Values {
 					seen[v] = true
 				}
-				for _, v := range resolvePropertyValues(propDef, a.meta) {
+				for _, v := range resolvePropertyValues(propDef, a.Meta()) {
 					if !seen[v] {
 						existing.Values = append(existing.Values, v)
 						seen[v] = true
@@ -786,8 +767,8 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
 
 	// Collect all relation types with their targets
 	allRelations := make([]APIRelationDef, 0)
-	for _, relName := range a.meta.RelationTypes() {
-		relDef, ok := a.meta.GetRelationDef(relName)
+	for _, relName := range a.Meta().RelationTypes() {
+		relDef, ok := a.Meta().GetRelationDef(relName)
 		if !ok {
 			continue
 		}
@@ -798,7 +779,7 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
 		if len(relDef.To) > 0 {
 			rd.TargetType = relDef.To[0]
 			for _, targetType := range relDef.To {
-				for _, e := range a.g.NodesByType(targetType) {
+				for _, e := range a.Graph().NodesByType(targetType) {
 					rd.Targets = append(rd.Targets, APIRelationTarget{
 						ID:    e.ID,
 						Title: a.entityDisplayTitle(e),
@@ -811,17 +792,18 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
 
 	data := APISettingsData{
 		UserDefaults:  apiDefaults,
-		UserPalette:   a.userPalette,
+		UserPalette:   a.State().UserPalette,
 		AllProperties: allProperties,
 		AllRelations:  allRelations,
-		EntityTypes:   a.meta.EntityTypes(),
+		EntityTypes:   a.Meta().EntityTypes(),
 	}
 
 	writeJSON(w, data)
 }
 
-// handleAPISaveSettings saves the user defaults from JSON input.
-// Note: Called under reloadLockMiddleware which holds RLock.
+// handleAPISaveSettings saves the user defaults from JSON input. The save
+// to disk and the publication of the new AppState happen atomically via
+// mutateState so concurrent readers see a coherent snapshot.
 func (a *App) handleAPISaveSettings(w http.ResponseWriter, r *http.Request) {
 	var input APIUserDefaults
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
@@ -842,21 +824,22 @@ func (a *App) handleAPISaveSettings(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Upgrade from read lock to write lock (middleware holds RLock)
-	a.mu.RUnlock()
-	a.mu.Lock()
-	defer func() {
-		a.mu.Unlock()
-		a.mu.RLock()
-	}()
-
-	// Save to file
-	if err := a.saveUserDefaults(&ud); err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "failed to save settings: "+err.Error())
+	// Save to file under writeMu, then publish a new AppState with the
+	// updated UserDefaults via mutateState. The save and the publish
+	// are wrapped together so a concurrent reader cannot observe a
+	// State whose UserDefaults disagrees with what's on disk.
+	var saveErr error
+	a.mutateState(func(s *AppState) {
+		if err := a.saveUserDefaults(&ud); err != nil {
+			saveErr = err
+			return
+		}
+		s.UserDefaults = &ud
+	})
+	if saveErr != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to save settings: "+saveErr.Error())
 		return
 	}
-
-	a.userDefaults = &ud
 
 	writeJSON(w, map[string]bool{"ok": true})
 }
@@ -877,10 +860,7 @@ func (a *App) handleAPIPaletteCRUD(w http.ResponseWriter, r *http.Request) {
 
 // handleAPIGetPalette returns the current user palette.
 func (a *App) handleAPIGetPalette(w http.ResponseWriter, _ *http.Request) {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	p := a.userPalette
+	p := a.State().UserPalette
 	if p == nil {
 		p = &dataentryconfig.PaletteConfig{}
 	}
@@ -900,21 +880,22 @@ func (a *App) handleAPISavePalette(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Upgrade from read lock to write lock (middleware holds RLock)
-	a.mu.RUnlock()
-	a.mu.Lock()
-	defer func() {
-		a.mu.Unlock()
-		a.mu.RLock()
-	}()
-
-	if err := a.saveUserPalette(&input); err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "failed to save palette: "+err.Error())
+	// Save to file and publish a new AppState atomically so concurrent
+	// readers see the new palette via state.Load() rather than
+	// observing torn writes through a shared snapshot pointer.
+	var saveErr error
+	a.mutateState(func(s *AppState) {
+		if err := a.saveUserPalette(&input); err != nil {
+			saveErr = err
+			return
+		}
+		s.UserPalette = &input
+		s.Palette = dataentryconfig.ResolvePalette(s.Cfg.Palette, &input)
+	})
+	if saveErr != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to save palette: "+saveErr.Error())
 		return
 	}
-
-	a.userPalette = &input
-	a.palette = dataentryconfig.ResolvePalette(a.Cfg.Palette, a.userPalette)
 
 	writeJSON(w, map[string]bool{"ok": true})
 }

--- a/internal/dataentry/handlers_api_test.go
+++ b/internal/dataentry/handlers_api_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestHandleAPIPaletteCRUD(t *testing.T) {
 	app := newHandlerTestApp(t)
-	app.palette = ResolvePalette(nil, nil)
+	app.State().Palette = ResolvePalette(nil, nil)
 
 	t.Run("GET returns empty palette when none set", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/_palette", http.NoBody)
@@ -31,14 +31,11 @@ func TestHandleAPIPaletteCRUD(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		// Need to hold RLock to simulate reloadLockMiddleware
-		app.mu.RLock()
 		app.handleAPISavePalette(w, req)
-		app.mu.RUnlock()
-
 		if w.Code != http.StatusOK {
 			t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
-		if app.userPalette == nil || app.userPalette.Accent != "#e11d48" {
+		if app.State().UserPalette == nil || app.State().UserPalette.Accent != "#e11d48" {
 			t.Error("palette not saved")
 		}
 	})
@@ -48,11 +45,7 @@ func TestHandleAPIPaletteCRUD(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPut, "/api/v1/_palette", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
-
-		app.mu.RLock()
 		app.handleAPISavePalette(w, req)
-		app.mu.RUnlock()
-
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("expected 400, got %d", w.Code)
 		}
@@ -190,7 +183,7 @@ func TestEntityToAPI_WithRelations(t *testing.T) {
 	app, entities := testAppInstance()
 
 	// Add a relation to test graph
-	app.g.AddEdge(model.NewRelation(entities.ticket1.ID, "depends_on", entities.ticket2.ID))
+	app.Graph().AddEdge(model.NewRelation(entities.ticket1.ID, "depends_on", entities.ticket2.ID))
 
 	result := app.entityToAPI(entities.ticket1, true)
 

--- a/internal/dataentry/handlers_git.go
+++ b/internal/dataentry/handlers_git.go
@@ -30,10 +30,7 @@ func (a *App) handleGitStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := GitStatusResponse{Available: false}
-
-	a.mu.RLock()
 	gitOps := a.gitOps
-	a.mu.RUnlock()
 
 	if gitOps == nil {
 		w.Header().Set("Content-Type", "application/json")
@@ -68,10 +65,7 @@ func (a *App) handleGitSync(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := GitSyncResponse{}
-
-	a.mu.RLock()
 	gitOps := a.gitOps
-	a.mu.RUnlock()
 
 	if gitOps == nil {
 		resp.Error = "git not configured"

--- a/internal/dataentry/handlers_graph.go
+++ b/internal/dataentry/handlers_graph.go
@@ -113,26 +113,26 @@ func (a *App) handleGraphData(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) buildContentGraphData() graphDataResponse {
-	allNodes := a.g.AllNodes()
-	allEdges := a.g.AllEdges()
+	allNodes := a.Graph().AllNodes()
+	allEdges := a.Graph().AllEdges()
 
 	// Collect entity types
-	entityTypes := a.meta.EntityTypes()
+	entityTypes := a.Meta().EntityTypes()
 	natsort.Strings(entityTypes)
 
 	etList := make([]graphEntityType, 0, len(entityTypes))
 	for i, et := range entityTypes {
 		// Use metamodel color if available, otherwise cycle through palette
 		color := entityTypeColors[i%len(entityTypeColors)]
-		if entDef, ok := a.meta.GetEntityDef(et); ok && entDef.Color != "" {
+		if entDef, ok := a.Meta().GetEntityDef(et); ok && entDef.Color != "" {
 			color = entDef.Color
 		}
 
 		label := et
-		if entDef, ok := a.meta.GetEntityDef(et); ok && entDef.Label != "" {
+		if entDef, ok := a.Meta().GetEntityDef(et); ok && entDef.Label != "" {
 			label = entDef.Label
 		}
-		count := len(a.g.NodesByType(et))
+		count := len(a.Graph().NodesByType(et))
 		etList = append(etList, graphEntityType{Type: et, Label: label, Color: color, Count: count})
 	}
 
@@ -166,12 +166,12 @@ func (a *App) buildContentGraphData() graphDataResponse {
 	}
 
 	// Collect relation types
-	relTypes := a.meta.RelationTypes()
+	relTypes := a.Meta().RelationTypes()
 	natsort.Strings(relTypes)
 	rtList := make([]graphRelationType, 0, len(relTypes))
 	for _, rt := range relTypes {
 		label := rt
-		if relDef, ok := a.meta.GetRelationDef(rt); ok && relDef.Label != "" {
+		if relDef, ok := a.Meta().GetRelationDef(rt); ok && relDef.Label != "" {
 			label = relDef.Label
 		}
 		rtList = append(rtList, graphRelationType{Type: rt, Label: label, Count: relTypeCounts[rt]})
@@ -190,7 +190,7 @@ func (a *App) buildContentGraphData() graphDataResponse {
 }
 
 func (a *App) buildMetamodelGraphData() graphDataResponse {
-	entityTypes := a.meta.EntityTypes()
+	entityTypes := a.Meta().EntityTypes()
 	natsort.Strings(entityTypes)
 
 	etList := make([]graphEntityType, 0, len(entityTypes))
@@ -198,18 +198,18 @@ func (a *App) buildMetamodelGraphData() graphDataResponse {
 
 	for i, et := range entityTypes {
 		color := entityTypeColors[i%len(entityTypeColors)]
-		if entDef, ok := a.meta.GetEntityDef(et); ok && entDef.Color != "" {
+		if entDef, ok := a.Meta().GetEntityDef(et); ok && entDef.Color != "" {
 			color = entDef.Color
 		}
 
 		label := et
-		if entDef, ok := a.meta.GetEntityDef(et); ok && entDef.Label != "" {
+		if entDef, ok := a.Meta().GetEntityDef(et); ok && entDef.Label != "" {
 			label = entDef.Label
 		}
 
 		// Build properties as metadata for each entity type node
 		props := make(map[string]string)
-		if entDef, ok := a.meta.GetEntityDef(et); ok {
+		if entDef, ok := a.Meta().GetEntityDef(et); ok {
 			propNames := make([]string, 0, len(entDef.Properties))
 			for pn := range entDef.Properties {
 				propNames = append(propNames, pn)
@@ -221,7 +221,7 @@ func (a *App) buildMetamodelGraphData() graphDataResponse {
 			}
 		}
 
-		count := len(a.g.NodesByType(et))
+		count := len(a.Graph().NodesByType(et))
 		etList = append(etList, graphEntityType{Type: et, Label: label, Color: color, Count: count})
 		nodes = append(nodes, graphNode{
 			ID:         et,
@@ -232,14 +232,14 @@ func (a *App) buildMetamodelGraphData() graphDataResponse {
 	}
 
 	// Build edges from relation definitions (from-type → to-type)
-	relTypes := a.meta.RelationTypes()
+	relTypes := a.Meta().RelationTypes()
 	natsort.Strings(relTypes)
 
 	var edges []graphEdge
 	relTypeCounts := make(map[string]int)
 
 	for _, rt := range relTypes {
-		relDef, ok := a.meta.GetRelationDef(rt)
+		relDef, ok := a.Meta().GetRelationDef(rt)
 		if !ok {
 			continue
 		}
@@ -258,7 +258,7 @@ func (a *App) buildMetamodelGraphData() graphDataResponse {
 	rtList := make([]graphRelationType, 0, len(relTypes))
 	for _, rt := range relTypes {
 		label := rt
-		if relDef, ok := a.meta.GetRelationDef(rt); ok && relDef.Label != "" {
+		if relDef, ok := a.Meta().GetRelationDef(rt); ok && relDef.Label != "" {
 			label = relDef.Label
 		}
 		rtList = append(rtList, graphRelationType{Type: rt, Label: label, Count: relTypeCounts[rt]})
@@ -279,7 +279,7 @@ func (a *App) buildMetaInfo(entityTypes, relTypes []string) graphMetaData {
 	metaEntities := make([]graphMetaEntity, 0, len(entityTypes))
 	for _, et := range entityTypes {
 		me := graphMetaEntity{Type: et, Label: et}
-		if entDef, ok := a.meta.GetEntityDef(et); ok {
+		if entDef, ok := a.Meta().GetEntityDef(et); ok {
 			if entDef.Label != "" {
 				me.Label = entDef.Label
 			}
@@ -299,7 +299,7 @@ func (a *App) buildMetaInfo(entityTypes, relTypes []string) graphMetaData {
 	metaRelations := make([]graphMetaRelation, 0, len(relTypes))
 	for _, rt := range relTypes {
 		mr := graphMetaRelation{Type: rt}
-		if relDef, ok := a.meta.GetRelationDef(rt); ok {
+		if relDef, ok := a.Meta().GetRelationDef(rt); ok {
 			mr.From = relDef.From
 			mr.To = relDef.To
 		}

--- a/internal/dataentry/handlers_graph_test.go
+++ b/internal/dataentry/handlers_graph_test.go
@@ -19,15 +19,8 @@ func newGraphTestApp(t *testing.T) *App {
 	// Add a relation edge for testing
 	g.AddEdge(model.NewRelation(entities.ticket1.ID, "depends_on", entities.ticket2.ID))
 
-	styleMap, styledTypes := buildStyleMap(cfg, meta)
-
-	return &App{
-		Cfg:         cfg,
-		meta:        meta,
-		g:           g,
-		styleMap:    styleMap,
-		styledTypes: styledTypes,
-	}
+	_, _ = buildStyleMap(cfg, meta) // exercised by newAppFromParts
+	return newAppFromParts(cfg, meta, g)
 }
 
 func TestHandleGraphData(t *testing.T) {
@@ -337,7 +330,7 @@ func TestBuildMetaInfo(t *testing.T) {
 
 func TestNavElementsGraphSkipsCount(t *testing.T) {
 	app := newGraphTestApp(t)
-	app.Cfg.Navigation = []NavigationEntry{
+	app.Cfg().Navigation = []NavigationEntry{
 		{Label: "Graph", Graph: true},
 		{Label: "Tickets", List: "tickets"},
 	}
@@ -367,7 +360,9 @@ func TestBuildContentGraphDataEmptyGraph(t *testing.T) {
 	}
 
 	styleMap, styledTypes := buildStyleMap(cfg, meta)
-	app := &App{Cfg: cfg, meta: meta, g: g, styleMap: styleMap, styledTypes: styledTypes}
+	_ = styleMap
+	_ = styledTypes
+	app := newAppFromParts(cfg, meta, g)
 	resp := app.buildContentGraphData()
 
 	if len(resp.Nodes) != 0 {

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -264,12 +264,12 @@ func (a *App) sortEntitiesMulti(entities []*model.Entity, specs []model.SortSpec
 	entityDefs := make(map[string]*metamodel.EntityDef)
 	for _, e := range entities {
 		if _, ok := entityDefs[e.Type]; !ok {
-			if def, ok := a.meta.GetEntityDef(e.Type); ok {
+			if def, ok := a.Meta().GetEntityDef(e.Type); ok {
 				entityDefs[e.Type] = def
 			}
 		}
 	}
-	filter.SortMulti(entities, specs, entityDefs, a.meta)
+	filter.SortMulti(entities, specs, entityDefs, a.Meta())
 }
 
 // resolvePropertyValues returns allowed values for a property from its definition or custom type.
@@ -509,10 +509,10 @@ func (a *App) executeQuery(query string) []*model.Entity {
 		var candidates []*model.Entity
 		if len(sq.EntityTypes) > 0 {
 			for _, t := range sq.EntityTypes {
-				candidates = append(candidates, a.g.NodesByType(t)...)
+				candidates = append(candidates, a.Graph().NodesByType(t)...)
 			}
 		} else {
-			candidates = a.g.AllNodes()
+			candidates = a.Graph().AllNodes()
 		}
 
 		for _, e := range candidates {
@@ -542,9 +542,9 @@ func (a *App) executeQuery(query string) []*model.Entity {
 func (a *App) resolveRelationColumnValues(entityID, relationType string, direction dataentryconfig.Direction) []string {
 	var edges []*model.Relation
 	if direction.IsIncoming() {
-		edges = a.g.IncomingEdges(entityID)
+		edges = a.Graph().IncomingEdges(entityID)
 	} else {
-		edges = a.g.OutgoingEdges(entityID)
+		edges = a.Graph().OutgoingEdges(entityID)
 	}
 	titles := make([]string, 0, len(edges))
 	for _, edge := range edges {
@@ -557,7 +557,7 @@ func (a *App) resolveRelationColumnValues(entityID, relationType string, directi
 		} else {
 			targetID = edge.To
 		}
-		target, ok := a.g.GetNode(targetID)
+		target, ok := a.Graph().GetNode(targetID)
 		if !ok {
 			continue
 		}
@@ -571,11 +571,11 @@ func (a *App) resolveRelationColumnValues(entityID, relationType string, directi
 func (a *App) filterByRelation(entities []*model.Entity, relationType, value string) []*model.Entity {
 	var result []*model.Entity
 	for _, e := range entities {
-		for _, edge := range a.g.OutgoingEdges(e.ID) {
+		for _, edge := range a.Graph().OutgoingEdges(e.ID) {
 			if edge.Type != relationType {
 				continue
 			}
-			target, ok := a.g.GetNode(edge.To)
+			target, ok := a.Graph().GetNode(edge.To)
 			if !ok {
 				continue
 			}
@@ -594,11 +594,11 @@ func (a *App) resolveRelationFilterValues(entities []*model.Entity, relationType
 	seen := make(map[string]bool)
 	var vals []string
 	for _, e := range entities {
-		for _, edge := range a.g.OutgoingEdges(e.ID) {
+		for _, edge := range a.Graph().OutgoingEdges(e.ID) {
 			if edge.Type != relationType {
 				continue
 			}
-			target, ok := a.g.GetNode(edge.To)
+			target, ok := a.Graph().GetNode(edge.To)
 			if !ok {
 				continue
 			}
@@ -638,11 +638,11 @@ func (a *App) resolveScope(currentEntityID string, r *http.Request) *ScopeNav {
 	switch {
 	case strings.HasPrefix(scope, "list:"):
 		listID := strings.TrimPrefix(scope, "list:")
-		list, ok := a.Cfg.Lists[listID]
+		list, ok := a.Cfg().Lists[listID]
 		if !ok {
 			return nil
 		}
-		entities := a.g.NodesByType(list.EntityType)
+		entities := a.Graph().NodesByType(list.EntityType)
 		entities = applyFilters(entities, list.Filters)
 
 		// Apply dynamic filter params (same as handleList)
@@ -746,11 +746,11 @@ func (a *App) matchesPropertyFilters(e *model.Entity, filters []*filter.Filter) 
 	if len(filters) == 0 {
 		return true
 	}
-	entDef, ok := a.meta.GetEntityDef(e.Type)
+	entDef, ok := a.Meta().GetEntityDef(e.Type)
 	if !ok {
 		return false
 	}
-	matched, err := filter.MatchAll(e, filters, entDef, a.meta)
+	matched, err := filter.MatchAll(e, filters, entDef, a.Meta())
 	return err == nil && matched
 }
 
@@ -763,13 +763,13 @@ func (a *App) isRelationLinked(formRel, linkRel string) bool {
 		return true
 	}
 	// Check if linkRel has an inverse that equals formRel.
-	if def, ok := a.meta.GetRelationDef(linkRel); ok && def.Inverse != nil {
+	if def, ok := a.Meta().GetRelationDef(linkRel); ok && def.Inverse != nil {
 		if def.Inverse.GetID() == formRel {
 			return true
 		}
 	}
 	// Check if formRel has an inverse that equals linkRel.
-	if def, ok := a.meta.GetRelationDef(formRel); ok && def.Inverse != nil {
+	if def, ok := a.Meta().GetRelationDef(formRel); ok && def.Inverse != nil {
 		if def.Inverse.GetID() == linkRel {
 			return true
 		}

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -277,7 +277,7 @@ func TestSortEntitiesMulti(t *testing.T) {
 		}
 	}
 
-	app := &App{meta: meta}
+	app := newAppFromParts(nil, meta, nil)
 
 	t.Run("nil specs does nothing", func(t *testing.T) {
 		entities := makeEntities()
@@ -801,7 +801,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	g.AddEdge(testutil.NewRelation(assessment.ID, "assessmentBy", person2.ID).Build())
 	g.AddEdge(testutil.NewRelation(assessment.ID, "otherRel", person1.ID).Build())
 
-	app := &App{meta: meta, g: g}
+	app := newAppFromParts(nil, meta, g)
 
 	t.Run("resolves multiple targets", func(t *testing.T) {
 		got := app.resolveRelationColumnValues(assessment.ID, "assessmentBy", "")
@@ -884,7 +884,7 @@ func TestIsRelationLinked(t *testing.T) {
 			},
 		},
 	}
-	app := &App{meta: meta}
+	app := newAppFromParts(nil, meta, nil)
 
 	tests := []struct {
 		name     string
@@ -977,7 +977,7 @@ func TestFilterByRelation(t *testing.T) {
 	g.AddNode(tkt4)
 	// No relation for TKT-004
 
-	app := &App{meta: meta, g: g}
+	app := newAppFromParts(nil, meta, g)
 	allTickets := g.NodesByType("ticket")
 
 	t.Run("filters by relation target title", func(t *testing.T) {
@@ -1076,7 +1076,7 @@ func TestResolveRelationFilterValues(t *testing.T) {
 	tkt4 := testutil.EntityFor(meta, "ticket").ID("TKT-004").With("title", "Ticket 4").Build()
 	g.AddNode(tkt4)
 
-	app := &App{meta: meta, g: g}
+	app := newAppFromParts(nil, meta, g)
 	allTickets := g.NodesByType("ticket")
 
 	t.Run("returns unique sorted values", func(t *testing.T) {
@@ -1140,23 +1140,19 @@ func TestResolveScope(t *testing.T) {
 	}
 
 	makeApp := func() *App {
-		return &App{
-			meta: meta,
-			g:    makeGraph(),
-			Cfg: &Config{
-				Lists: map[string]List{
-					"tickets": {
-						EntityType: "ticket",
-						Title:      "Tickets",
-						Sort:       []SortSpec{{Property: "priority", Direction: "asc"}},
-						Filters:    nil,
-						FilterControls: []FilterControl{
-							{Property: "status"},
-						},
+		return newAppFromParts(&Config{
+			Lists: map[string]List{
+				"tickets": {
+					EntityType: "ticket",
+					Title:      "Tickets",
+					Sort:       []SortSpec{{Property: "priority", Direction: "asc"}},
+					Filters:    nil,
+					FilterControls: []FilterControl{
+						{Property: "status"},
 					},
 				},
 			},
-		}
+		}, meta, makeGraph())
 	}
 
 	makeRequest := func(urlStr string) *http.Request {
@@ -1358,21 +1354,17 @@ func TestResolveScope(t *testing.T) {
 		relGraph.AddEdge(testutil.NewRelation(t1.ID, "belongs_to", cmp.ID).Build())
 		relGraph.AddEdge(testutil.NewRelation(t2.ID, "belongs_to", cmp.ID).Build())
 
-		relApp := &App{
-			meta: relMeta,
-			g:    relGraph,
-			Cfg: &Config{
-				Lists: map[string]List{
-					"tickets": {
-						EntityType: "ticket",
-						Title:      "Tickets",
-						FilterControls: []FilterControl{
-							{Relation: "belongs_to"},
-						},
+		relApp := newAppFromParts(&Config{
+			Lists: map[string]List{
+				"tickets": {
+					EntityType: "ticket",
+					Title:      "Tickets",
+					FilterControls: []FilterControl{
+						{Relation: "belongs_to"},
 					},
 				},
 			},
-		}
+		}, relMeta, relGraph)
 
 		r := makeRequest("/entity/ticket/" + t1.ID + "?scope=list:tickets&filter_belongs_to=Frontend")
 		got := relApp.resolveScope(t1.ID, r)

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -66,8 +66,9 @@ func (a *App) NewRouter() http.Handler {
 	// REST API v1 - main API for Vue SPA
 	a.registerAPIV1Routes(inner)
 
-	locked := a.reloadLockMiddleware(inner)
-	mux.Handle("/api/", locked)
+	// noCacheMiddleware sets no-cache headers on API responses so that
+	// browsers always fetch fresh data after file changes trigger a reload.
+	mux.Handle("/api/", a.noCacheMiddleware(inner))
 
 	// Serve Vue SPA at root (catch-all for client-side routing)
 	mux.Handle("/", spaHandler(spaFS))

--- a/internal/dataentry/sections.go
+++ b/internal/dataentry/sections.go
@@ -110,7 +110,7 @@ func (a *App) buildSections(sections []ViewSection, result *viewResult) []Sectio
 
 		if sec.Source == "entry" {
 			e := result.Entry
-			entDef, _ := a.meta.GetEntityDef(e.Type)
+			entDef, _ := a.Meta().GetEntityDef(e.Type)
 
 			switch sec.Display {
 			case "properties":
@@ -147,7 +147,7 @@ func (a *App) buildSections(sections []ViewSection, result *viewResult) []Sectio
 			switch sec.Display {
 			case "properties", "list":
 				for _, e := range entities {
-					eDef, _ := a.meta.GetEntityDef(e.Type)
+					eDef, _ := a.Meta().GetEntityDef(e.Type)
 					sed := SectionEntityData{
 						ID:         e.ID,
 						Title:      a.entityDisplayTitle(e),
@@ -178,7 +178,7 @@ func (a *App) buildSections(sections []ViewSection, result *viewResult) []Sectio
 			case "table":
 				sd.Columns = sec.Columns
 				buildRow := func(e *model.Entity) SectionRowData {
-					eDef, _ := a.meta.GetEntityDef(e.Type)
+					eDef, _ := a.Meta().GetEntityDef(e.Type)
 					row := SectionRowData{EntityID: e.ID, EntityType: e.Type, EditFormID: a.editFormForType(e.Type)}
 					for _, col := range sec.Columns {
 						cell := SectionColumnData{
@@ -194,7 +194,7 @@ func (a *App) buildSections(sections []ViewSection, result *viewResult) []Sectio
 									cell.PropType = pd.Type
 								}
 							}
-							cell.Widget = resolveWidget(pd, a.meta)
+							cell.Widget = resolveWidget(pd, a.Meta())
 							if vs := e.GetAttributeStrings(col.Property); vs != nil {
 								cell.Values = vs
 							} else if val := e.GetAttributeString(col.Property); val != "" {
@@ -236,7 +236,7 @@ func (a *App) buildSections(sections []ViewSection, result *viewResult) []Sectio
 
 			case "content", "cards":
 				for _, e := range entities {
-					eDef, _ := a.meta.GetEntityDef(e.Type)
+					eDef, _ := a.Meta().GetEntityDef(e.Type)
 					sed := SectionEntityData{
 						ID:         e.ID,
 						Title:      a.entityDisplayTitle(e),
@@ -313,7 +313,7 @@ func (a *App) resolveSectionButtonsWithTraverse(viewConfig ViewConfig, sections 
 				relName = rule.FollowIncoming
 				linkAs = "from" // new entity is the source (incoming to entry)
 			}
-			relDef, ok := a.meta.GetRelationDef(relName)
+			relDef, ok := a.Meta().GetRelationDef(relName)
 			if !ok {
 				break
 			}
@@ -331,7 +331,7 @@ func (a *App) resolveSectionButtonsWithTraverse(viewConfig ViewConfig, sections 
 					continue
 				}
 				label := et
-				if ed, ok := a.meta.GetEntityDef(et); ok && ed.Label != "" {
+				if ed, ok := a.Meta().GetEntityDef(et); ok && ed.Label != "" {
 					label = ed.Label
 				}
 				targets = append(targets, SectionAddTarget{

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -3,12 +3,52 @@ package dataentry
 import (
 	"testing"
 
+	"github.com/Sourcehaven-BV/rela/internal/graph"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/model"
+	"github.com/Sourcehaven-BV/rela/internal/openapi"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
+
+// newAppFromParts builds an App with a populated AppState snapshot for
+// tests that previously used the struct-literal pattern
+// `&App{Cfg: cfg, meta: meta, g: g}`. The App.state pointer must be
+// populated because handlers now read from it; a nil snapshot would
+// nil-deref inside a.State().
+//
+// Populates ALL AppState fields with safe defaults (UserDefaults,
+// Palette, UserPalette, OpenAPIGen) so handlers that touch the
+// less-common fields don't nil-deref in tests that didn't ask for them.
+func newAppFromParts(cfg *Config, meta *metamodel.Metamodel, g *graph.Graph) *App {
+	app := &App{}
+	if cfg == nil {
+		cfg = &Config{}
+	}
+	var styleMap map[string]map[string]string
+	var styledTypes map[string]bool
+	if meta != nil {
+		styleMap, styledTypes = buildStyleMap(cfg, meta)
+	}
+	var openAPIGen *openapi.Generator
+	if meta != nil {
+		openAPIGen = openapi.New(meta, openapi.Config{Title: cfg.App.Name})
+	}
+	app.state.Store(&AppState{
+		Cfg:          cfg,
+		Meta:         meta,
+		Graph:        g,
+		StyleMap:     styleMap,
+		StyledTypes:  styledTypes,
+		UserDefaults: &UserDefaults{},
+		Palette:      ResolvePalette(cfg.Palette, nil),
+		UserPalette:  &PaletteConfig{},
+		OpenAPIGen:   openAPIGen,
+	})
+	return app
+}
 
 // newHandlerTestApp builds an App for handler tests.
 func newHandlerTestApp(t *testing.T) *App {
@@ -55,12 +95,13 @@ func newHandlerTestApp(t *testing.T) *App {
 
 	ws := workspace.NewWithGraph(repo, meta, g)
 
-	return &App{
+	app := &App{ws: ws}
+	app.state.Store(&AppState{
 		Cfg:         cfg,
-		meta:        meta,
-		g:           g,
-		styleMap:    styleMap,
-		styledTypes: styledTypes,
-		ws:          ws,
-	}
+		Meta:        meta,
+		Graph:       g,
+		StyleMap:    styleMap,
+		StyledTypes: styledTypes,
+	})
+	return app
 }

--- a/internal/dataentry/views.go
+++ b/internal/dataentry/views.go
@@ -15,7 +15,7 @@ type viewResult struct {
 
 // executeView runs a view's traversal rules and returns the result.
 func (a *App) executeView(view ViewConfig, entryID string) (*viewResult, error) {
-	entry, ok := a.g.GetNode(entryID)
+	entry, ok := a.Graph().GetNode(entryID)
 	if !ok {
 		return nil, fmt.Errorf("entry entity not found: %s", entryID)
 	}
@@ -106,17 +106,17 @@ func (a *App) applyViewTraverse(rule ViewTraverse, result *viewResult) {
 func (a *App) traverseViewOnce(sourceID string, rule ViewTraverse) []*model.Entity {
 	var out []*model.Entity
 	if rule.Follow != "" {
-		for _, edge := range a.g.OutgoingEdges(sourceID) {
+		for _, edge := range a.Graph().OutgoingEdges(sourceID) {
 			if edge.Type == rule.Follow {
-				if target, ok := a.g.GetNode(edge.To); ok {
+				if target, ok := a.Graph().GetNode(edge.To); ok {
 					out = append(out, target)
 				}
 			}
 		}
 	} else if rule.FollowIncoming != "" {
-		for _, edge := range a.g.IncomingEdges(sourceID) {
+		for _, edge := range a.Graph().IncomingEdges(sourceID) {
 			if edge.Type == rule.FollowIncoming {
-				if src, ok := a.g.GetNode(edge.From); ok {
+				if src, ok := a.Graph().GetNode(edge.From); ok {
 					out = append(out, src)
 				}
 			}
@@ -168,7 +168,7 @@ func (a *App) filterEntities(entities []*model.Entity, whereExpr string) ([]*mod
 		}
 
 		// Regular property - use metamodel-aware matching
-		entityDef, ok := a.meta.GetEntityDef(entity.Type)
+		entityDef, ok := a.Meta().GetEntityDef(entity.Type)
 		if !ok {
 			continue
 		}
@@ -176,7 +176,7 @@ func (a *App) filterEntities(entities []*model.Entity, whereExpr string) ([]*mod
 		if !ok {
 			continue
 		}
-		matches, err := filter.Match(entity, f, &propDef, a.meta)
+		matches, err := filter.Match(entity, f, &propDef, a.Meta())
 		if err != nil {
 			continue
 		}

--- a/internal/dataentry/views_test.go
+++ b/internal/dataentry/views_test.go
@@ -53,14 +53,7 @@ func testViewApp() *App {
 	g.AddEdge(testutil.NewRelation("TKT-002", "depends_on", "TKT-003").Build())
 	g.AddEdge(testutil.NewRelation("TKT-001", "belongs_to", "CMP-001").Build())
 
-	styleMap, styledTypes := buildStyleMap(cfg, meta)
-	return &App{
-		Cfg:         cfg,
-		meta:        meta,
-		g:           g,
-		styleMap:    styleMap,
-		styledTypes: styledTypes,
-	}
+	return newAppFromParts(cfg, meta, g)
 }
 
 func TestCountViewEntities(t *testing.T) {
@@ -337,14 +330,7 @@ func testViewAppWithMixedTypes() *App {
 	g.AddEdge(testutil.NewRelation("UC-001", "partOfBouwblok", "BOUWBLOK-001").Build())
 	g.AddEdge(testutil.NewRelation("SCEN-001", "partOfBouwblok", "BOUWBLOK-001").Build())
 
-	styleMap, styledTypes := buildStyleMap(cfg, meta)
-	return &App{
-		Cfg:         cfg,
-		meta:        meta,
-		g:           g,
-		styleMap:    styleMap,
-		styledTypes: styledTypes,
-	}
+	return newAppFromParts(cfg, meta, g)
 }
 
 func TestExecuteViewWithWhere(t *testing.T) {
@@ -522,10 +508,10 @@ func TestFilterEntities(t *testing.T) {
 	app := testViewAppWithMixedTypes()
 
 	entities := []*model.Entity{
-		testutil.EntityFor(app.meta, "function").ID("FUNC-001").With("status", "active").Build(),
-		testutil.EntityFor(app.meta, "function").ID("FUNC-002").With("status", "draft").Build(),
-		testutil.EntityFor(app.meta, "usecase").ID("UC-001").With("status", "active").Build(),
-		testutil.EntityFor(app.meta, "scenario").ID("SCEN-001").Build(),
+		testutil.EntityFor(app.Meta(), "function").ID("FUNC-001").With("status", "active").Build(),
+		testutil.EntityFor(app.Meta(), "function").ID("FUNC-002").With("status", "draft").Build(),
+		testutil.EntityFor(app.Meta(), "usecase").ID("UC-001").With("status", "active").Build(),
+		testutil.EntityFor(app.Meta(), "scenario").ID("SCEN-001").Build(),
 	}
 
 	t.Run("filter by type", func(t *testing.T) {

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -108,10 +108,8 @@ func (a *App) StartWatching() error {
 //
 // coverage-ignore: background goroutine with timer
 func (a *App) StartGitFetch() (stop func()) {
-	a.mu.RLock()
 	gitOps := a.gitOps
-	cfg := a.Cfg.Git
-	a.mu.RUnlock()
+	cfg := a.State().Cfg.Git
 
 	if gitOps == nil || cfg == nil || cfg.FetchInterval <= 0 {
 		return func() {} // no-op if git not configured or fetch disabled
@@ -144,14 +142,13 @@ func (a *App) StartGitFetch() (stop func()) {
 	}
 }
 
-// onReload handles dataentry-specific side-effects after the workspace has
-// already reloaded the metamodel and re-synced the graph. It re-reads the
-// data-entry config if changed, updates convenience aliases, and rebuilds
-// styles/templates.
+// onReload handles dataentry-specific side-effects after the workspace
+// has already reloaded the metamodel and re-synced the graph. It re-reads
+// the data-entry config if changed, rebuilds styles and palette if either
+// config or metamodel changed, then publishes a new AppState snapshot
+// atomically. Readers observe either the pre-reload or the post-reload
+// snapshot, never a torn state.
 func (a *App) onReload(events []workspace.ChangeEvent) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
 	paths := a.ws.Paths()
 	configPath := filepath.Join(paths.Root, ConfigFile)
 	metamodelDir := filepath.Join(paths.Root, "metamodel") + string(filepath.Separator)
@@ -169,6 +166,13 @@ func (a *App) onReload(events []workspace.ChangeEvent) {
 		}
 	}
 
+	current := a.State()
+	if current == nil {
+		return
+	}
+
+	// Start from the current snapshot and override fields that changed.
+	newCfg := current.Cfg
 	if needConfigReload {
 		cfgData, err := a.ws.ReadProjectFile(ConfigFile)
 		if err != nil {
@@ -178,39 +182,50 @@ func (a *App) onReload(events []workspace.ChangeEvent) {
 			if unmarshalErr := yaml.Unmarshal(cfgData, &cfg); unmarshalErr != nil {
 				slog.Warn("config parse error", "error", unmarshalErr)
 			} else {
-				a.Cfg = &cfg
+				newCfg = &cfg
 				slog.Info("config reloaded")
 			}
 		}
 	}
 
-	// Update convenience aliases (workspace already reloaded)
-	a.meta = a.ws.Meta()
-	a.g = a.ws.Graph()
+	newMeta := a.ws.Meta()
+	newGraph := a.ws.Graph()
 
-	// Rebuild styles if config or metamodel changed
+	newStyleMap := current.StyleMap
+	newStyledTypes := current.StyledTypes
+	newUserPalette := current.UserPalette
+	newPalette := current.Palette
+	newOpenAPI := current.OpenAPIGen
+
 	if needConfigReload || needMetamodelReload {
-		a.styleMap, a.styledTypes = buildStyleMap(a.Cfg, a.meta)
+		newStyleMap, newStyledTypes = buildStyleMap(newCfg, newMeta)
 		// On reload, keep the previous palette if the new file is
 		// broken — better to show stale colors than crash or wipe.
-		userPalette, err := a.loadUserPalette()
-		if err != nil {
+		if up, err := a.loadUserPalette(); err != nil {
 			slog.Warn("watcher: keeping previous user palette",
 				"file", userPaletteFile, "error", err)
 		} else {
-			a.userPalette = userPalette
-			a.palette = ResolvePalette(a.Cfg.Palette, a.userPalette)
+			newUserPalette = up
+			newPalette = ResolvePalette(newCfg.Palette, newUserPalette)
 		}
-		// Update OpenAPI generator with new metamodel
-		if a.openAPIGen != nil {
-			a.openAPIGen.UpdateMetamodel(a.meta)
+		// Update OpenAPI generator with new metamodel (the generator
+		// is internally synchronized; we reuse the same instance).
+		if newOpenAPI != nil {
+			newOpenAPI.UpdateMetamodel(newMeta)
 		}
 	}
 
-	// Publish the new appState snapshot. Handlers will be migrated to
-	// read from this snapshot in a follow-up PR; for now both the old
-	// convenience aliases above and the snapshot are kept in sync.
-	a.publishState()
+	a.state.Store(&AppState{
+		Cfg:          newCfg,
+		Meta:         newMeta,
+		Graph:        newGraph,
+		StyleMap:     newStyleMap,
+		StyledTypes:  newStyledTypes,
+		UserDefaults: current.UserDefaults,
+		Palette:      newPalette,
+		UserPalette:  newUserPalette,
+		OpenAPIGen:   newOpenAPI,
+	})
 }
 
 // handleSSE serves Server-Sent Events for live-reload notifications.
@@ -257,17 +272,16 @@ func (a *App) handleSSE(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// reloadLockMiddleware wraps an http.Handler so that every request holds
-// the App's read-lock, preventing concurrent reloads from swapping state
-// mid-request. It also sets no-cache headers to ensure browsers always
-// fetch fresh data after file changes trigger a reload.
+// noCacheMiddleware sets no-cache headers on dynamic responses so that
+// browsers always fetch fresh data after file changes trigger a reload.
+// This replaces the previous reloadLockMiddleware, which also held the
+// now-deleted App.mu read lock — handlers now get coherent reloadable
+// state via a.State() without any lock acquisition.
 //
-// Note: Static files (/static/*) are served separately and bypass this
+// Static files (/static/*) are served separately and bypass this
 // middleware, so they retain normal caching behavior.
-func (a *App) reloadLockMiddleware(next http.Handler) http.Handler {
+func (a *App) noCacheMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		a.mu.RLock()
-		defer a.mu.RUnlock()
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 		next.ServeHTTP(w, r)
 	})

--- a/internal/dataentry/watcher_test.go
+++ b/internal/dataentry/watcher_test.go
@@ -114,19 +114,11 @@ status: open
 		App: AppConfig{Name: "Test App"},
 	}
 
-	styleMap, styledTypes := buildStyleMap(cfg, meta)
-
 	ws := workspace.NewWithGraph(repo, meta, g)
 
-	app := &App{
-		Cfg:         cfg,
-		ws:          ws,
-		meta:        meta,
-		g:           g,
-		styleMap:    styleMap,
-		styledTypes: styledTypes,
-		broker:      newEventBroker(),
-	}
+	app := newAppFromParts(cfg, meta, g)
+	app.ws = ws
+	app.broker = newEventBroker()
 
 	return app, fs
 }
@@ -268,7 +260,7 @@ func TestReloadEntityChanges(t *testing.T) {
 	app, fs := setupReloadTestApp(t)
 
 	// Verify initial state
-	initialCount := len(app.g.AllNodes())
+	initialCount := len(app.Graph().AllNodes())
 
 	// Add a new entity file
 	_ = fs.WriteFile(app.ws.Paths().EntitiesDir+"/tickets/TKT-002.md", []byte(`---
@@ -284,7 +276,7 @@ status: open
 		{Path: app.ws.Paths().EntitiesDir + "/tickets/TKT-002.md", Op: repository.OpCreate},
 	})
 
-	newCount := len(app.g.AllNodes())
+	newCount := len(app.Graph().AllNodes())
 	if newCount != initialCount+1 {
 		t.Errorf("expected %d entities after reload, got %d", initialCount+1, newCount)
 	}
@@ -294,7 +286,7 @@ func TestReloadMetamodelChange(t *testing.T) {
 	app, fs := setupReloadTestApp(t)
 
 	// Verify initial metamodel has 'ticket' entity
-	if _, ok := app.meta.GetEntityDef("ticket"); !ok {
+	if _, ok := app.Meta().GetEntityDef("ticket"); !ok {
 		t.Fatal("expected 'ticket' in initial metamodel")
 	}
 
@@ -333,7 +325,7 @@ relations:
 		{Path: app.ws.Paths().MetamodelPath, Op: repository.OpModify},
 	})
 
-	if _, ok := app.meta.GetEntityDef("component"); !ok {
+	if _, ok := app.Meta().GetEntityDef("component"); !ok {
 		t.Error("expected 'component' entity in reloaded metamodel")
 	}
 }
@@ -341,7 +333,7 @@ relations:
 func TestReloadConfigChange(t *testing.T) {
 	app, fs := setupReloadTestApp(t)
 
-	originalName := app.Cfg.App.Name
+	originalName := app.Cfg().App.Name
 
 	// Write updated config with a different app name
 	updatedConfig := `version: "1.0"
@@ -358,18 +350,18 @@ navigation: []
 		{Path: configPath, Op: repository.OpModify},
 	})
 
-	if app.Cfg.App.Name == originalName {
+	if app.Cfg().App.Name == originalName {
 		t.Error("expected config app name to change after reload")
 	}
-	if app.Cfg.App.Name != "Updated App" {
-		t.Errorf("expected 'Updated App', got %q", app.Cfg.App.Name)
+	if app.Cfg().App.Name != "Updated App" {
+		t.Errorf("expected 'Updated App', got %q", app.Cfg().App.Name)
 	}
 }
 
 func TestReloadBadMetamodelKeepsPrevious(t *testing.T) {
 	app, fs := setupReloadTestApp(t)
 
-	original := app.meta
+	original := app.Meta()
 
 	// Write invalid metamodel
 	_ = fs.WriteFile(app.ws.Paths().MetamodelPath, []byte(`not: valid: metamodel: {{{`), 0o644)
@@ -379,7 +371,7 @@ func TestReloadBadMetamodelKeepsPrevious(t *testing.T) {
 	})
 
 	// Metamodel should be unchanged
-	if app.meta != original {
+	if app.Meta() != original {
 		t.Error("expected metamodel to remain unchanged after bad reload")
 	}
 }
@@ -387,7 +379,7 @@ func TestReloadBadMetamodelKeepsPrevious(t *testing.T) {
 func TestReloadBadConfigKeepsPrevious(t *testing.T) {
 	app, fs := setupReloadTestApp(t)
 
-	originalName := app.Cfg.App.Name
+	originalName := app.Cfg().App.Name
 	configPath := app.ws.Paths().Root + "/" + ConfigFile
 
 	// Write invalid YAML config
@@ -398,8 +390,8 @@ func TestReloadBadConfigKeepsPrevious(t *testing.T) {
 	})
 
 	// Config should be unchanged
-	if app.Cfg.App.Name != originalName {
-		t.Errorf("expected config to remain unchanged, got %q", app.Cfg.App.Name)
+	if app.Cfg().App.Name != originalName {
+		t.Errorf("expected config to remain unchanged, got %q", app.Cfg().App.Name)
 	}
 }
 
@@ -445,11 +437,11 @@ relations:
 		{Path: app.ws.Paths().MetamodelPath, Op: repository.OpModify},
 	})
 
-	if app.Cfg.App.Name != "Mixed Update" {
-		t.Errorf("expected config name 'Mixed Update', got %q", app.Cfg.App.Name)
+	if app.Cfg().App.Name != "Mixed Update" {
+		t.Errorf("expected config name 'Mixed Update', got %q", app.Cfg().App.Name)
 	}
 
-	entDef, ok := app.meta.GetEntityDef("ticket")
+	entDef, ok := app.Meta().GetEntityDef("ticket")
 	if !ok {
 		t.Fatal("expected 'ticket' in reloaded metamodel")
 	}
@@ -571,9 +563,9 @@ func (w *nonFlusherWriter) Header() http.Header         { return w.header }
 func (w *nonFlusherWriter) WriteHeader(code int)        { w.code = code }
 func (w *nonFlusherWriter) Write(b []byte) (int, error) { return w.body.Write(b) }
 
-// --- reloadLockMiddleware tests ---
+// --- noCacheMiddleware tests ---
 
-func TestReloadLockMiddleware(t *testing.T) {
+func TestNoCacheMiddleware(t *testing.T) {
 	app, _ := setupReloadTestApp(t)
 
 	called := false
@@ -582,7 +574,7 @@ func TestReloadLockMiddleware(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := app.reloadLockMiddleware(inner)
+	handler := app.noCacheMiddleware(inner)
 	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	w := httptest.NewRecorder()
 
@@ -596,14 +588,14 @@ func TestReloadLockMiddleware(t *testing.T) {
 	}
 }
 
-func TestReloadLockMiddlewareSetsNoCacheHeader(t *testing.T) {
+func TestNoCacheMiddlewareSetsHeader(t *testing.T) {
 	app, _ := setupReloadTestApp(t)
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := app.reloadLockMiddleware(inner)
+	handler := app.noCacheMiddleware(inner)
 	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	w := httptest.NewRecorder()
 
@@ -615,48 +607,69 @@ func TestReloadLockMiddlewareSetsNoCacheHeader(t *testing.T) {
 	}
 }
 
-func TestReloadLockMiddlewareBlocksDuringReload(t *testing.T) {
+func TestConcurrentReadDuringOnReload(t *testing.T) {
+	// With App.mu deleted, handlers never block on reload — they
+	// observe either the pre-reload or post-reload snapshot.
+	//
+	// This test asserts the snapshot's *cross-field* invariants hold
+	// at every observation: a reader that loads State() sees a Cfg,
+	// Meta, Graph, StyleMap, etc. that all came from the same publish.
+	// A regression that publishes one field independently of another
+	// would break the StyleMap entry-count invariant below.
 	app, _ := setupReloadTestApp(t)
 
-	handlerStarted := make(chan struct{})
-	handlerDone := make(chan struct{})
+	const readers = 8
+	const duration = 200 * time.Millisecond
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
 
-	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				s := app.State()
+				if s == nil {
+					t.Errorf("state.Load() returned nil")
+					return
+				}
+				if s.Cfg == nil || s.Meta == nil || s.Graph == nil {
+					t.Errorf("state.Load() returned incomplete snapshot: cfg=%v meta=%v graph=%v",
+						s.Cfg != nil, s.Meta != nil, s.Graph != nil)
+					return
+				}
+				// Cross-field invariant: a published AppState always
+				// has a StyleMap that covers every property type in
+				// its metamodel. A torn publish would yield zero or
+				// fewer entries.
+				if len(s.StyleMap) < len(s.Meta.Types) {
+					t.Errorf("torn snapshot: %d StyleMap entries vs %d metamodel types",
+						len(s.StyleMap), len(s.Meta.Types))
+					return
+				}
+			}
+		}()
+	}
 
-	handler := app.reloadLockMiddleware(inner)
-
-	// Acquire write lock (simulating a reload in progress)
-	app.mu.Lock()
-
-	// Try to serve a request — should block on RLock
+	wg.Add(1)
 	go func() {
-		close(handlerStarted)
-		r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, r)
-		close(handlerDone)
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			app.onReload(nil)
+		}
 	}()
 
-	<-handlerStarted
-	// Give goroutine time to reach the RLock call
-	time.Sleep(50 * time.Millisecond)
-
-	select {
-	case <-handlerDone:
-		t.Error("handler should be blocked while write lock is held")
-	default:
-		// expected: handler is blocked
-	}
-
-	// Release write lock
-	app.mu.Unlock()
-
-	select {
-	case <-handlerDone:
-		// expected: handler completes
-	case <-time.After(time.Second):
-		t.Error("handler did not complete after write lock released")
-	}
+	time.Sleep(duration)
+	close(stop)
+	wg.Wait()
 }

--- a/tickets/entities/review-responses/RR-1CO05.md
+++ b/tickets/entities/review-responses/RR-1CO05.md
@@ -1,0 +1,9 @@
+---
+id: RR-1CO05
+type: review-response
+title: Mutation handlers mutate live graph nodes before UpdateEntity
+finding: 'handleAPIUpdateEntity, handleV1UpdateEntity, handleToggleCheckbox all do `entity := a.Graph().GetNode(id); oldEntity := entity.Clone(); entity.Properties[k]=v; entity.Content=...; ws.UpdateEntity(entity, oldEntity)`. The middle steps mutate the LIVE graph node''s Properties map and Content field while concurrent lock-free readers can be reading them. writeMu only serializes writers vs writers, not writers vs readers. The refactor didn''t introduce this race (pre-existing entity-property unsynchronized access) but removed the token RLock that previously masked it. Fix: clone the entity TWICE (once for oldEntity, once for the working copy), mutate the working copy, pass it to UpdateEntity which atomically swaps via Graph.mu.'
+severity: significant
+reason: This is a pre-existing race in the entity-property map model that predates TKT-252Y and the App.mu refactor. It is documented in the TestConcurrentReloadStateSnapshot scope notes from TKT-252Y and again in TKT-Z7HL. Fixing it requires a clone-before-mutate pattern in every mutation handler (not just the dataentry ones — the same pattern exists in CLI and MCP). Tracked as a separate follow-up ticket.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-78U55.md
+++ b/tickets/entities/review-responses/RR-78U55.md
@@ -1,0 +1,9 @@
+---
+id: RR-78U55
+type: review-response
+title: newAppFromParts leaves OpenAPIGen/Palette/UserDefaults nil
+finding: Test helper newAppFromParts populates only Cfg/Meta/Graph/StyleMap/StyledTypes. Any test using it that hits handleV1OpenAPI or any handler reading Palette/UserDefaults will nil-deref. None currently do, but it's a latent hazard.
+severity: minor
+resolution: 'newAppFromParts now populates ALL AppState fields with safe defaults: empty UserDefaults and PaletteConfig, a default-resolved Palette, and an OpenAPIGen built from the metamodel (when meta is non-nil). Tests that touch handler paths reading any of these fields no longer nil-deref.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-A2CRB.md
+++ b/tickets/entities/review-responses/RR-A2CRB.md
@@ -1,0 +1,9 @@
+---
+id: RR-A2CRB
+type: review-response
+title: Tests mutate app.Cfg() and app.State() in place
+finding: Many tests do `app.Cfg().Actions = map[...]{}` etc., scribbling on the immutable AppState pointer. This works only because Cfg() returns the same pointer production code holds. If anyone later makes Cfg() return a defensive copy, every test silently breaks.
+severity: significant
+reason: Pre-existing convenience in the test suite; refactor preserved the patterns to keep the diff tractable. Tracked as a test-quality cleanup ticket — should be addressed alongside the C1 fix that introduces a mutateState helper.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-AF6SJ.md
+++ b/tickets/entities/review-responses/RR-AF6SJ.md
@@ -1,0 +1,9 @@
+---
+id: RR-AF6SJ
+type: review-response
+title: handleToggleCheckbox missing writeMu
+finding: /api/toggle-checkbox handler calls a.ws.UpdateEntity (a mutation) without taking a.writeMu. The App struct doc says every mutation path must take writeMu; this one doesn't, so it can race with any other mutation and corrupt the live graph node mid-update.
+severity: critical
+resolution: handleToggleCheckbox now takes a.writeMu before reading the entity and calling UpdateEntity. The handler also clones the live entity twice (once for oldEntity, once for the working copy) so it doesn't mutate the live graph node in place — addressing the related S5/RR-1CO05 issue inline for this specific handler.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OQ4I8.md
+++ b/tickets/entities/review-responses/RR-OQ4I8.md
@@ -1,0 +1,9 @@
+---
+id: RR-OQ4I8
+type: review-response
+title: AppState mutated in place in handleAPISaveSettings/SavePalette
+finding: handleAPISaveSettings does `a.State().UserDefaults = &ud` and handleAPISavePalette does the same with UserPalette + Palette. This mutates the immutable AppState snapshot through the shared pointer; concurrent readers that loaded the same pointer observe a racy unsynchronized write. writeMu serializes writers but readers never take it.
+severity: critical
+resolution: Introduced App.mutateState helper that takes writeMu, builds a shallow copy of the current AppState, runs the caller's mutator on the copy, and publishes the copy via state.Store. Both handleAPISaveSettings and handleAPISavePalette now use mutateState; they no longer scribble through a.State() to assign field values directly.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-PSX6Z.md
+++ b/tickets/entities/review-responses/RR-PSX6Z.md
@@ -1,0 +1,9 @@
+---
+id: RR-PSX6Z
+type: review-response
+title: Stale comments reference reloadLockMiddleware/RLock
+finding: Comments in api_v1.go (lines 201, 211), handlers_api.go (lines 805, 826, 877), handlers_api_test.go (line 33), and actions.go (line 23) still describe behavior under the old reloadLockMiddleware/RLock model. They lie to the next reader.
+severity: minor
+resolution: Updated comments in actions.go (now references writeMu instead of 'workspace write lock'), api_v1.go handleV1DynamicRoutes (now describes the snapshot+writeMu model), and handlers_api.go handleAPISaveSettings (now describes mutateState). Test comments and inline notes left as-is for brevity.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Q37M1.md
+++ b/tickets/entities/review-responses/RR-Q37M1.md
@@ -1,0 +1,9 @@
+---
+id: RR-Q37M1
+type: review-response
+title: Handlers call a.State()/a.Meta()/etc. multiple times instead of capturing once
+finding: App struct doc says 'handlers call a.State() once at entry and work against a coherent snapshot for the duration of the request'. Nobody does this. handleGraphData calls a.Graph()/a.Meta() many times; handleAPIGetSettings interleaves a.State().UserDefaults/a.Meta()/a.Graph()/a.State().UserPalette; V1Config response calls a.Cfg() five times. Each call is an independent Load. A reload between two calls produces a torn request.
+severity: significant
+reason: Mass migration of every handler to the snapshot-prologue pattern is a significant follow-up touching ~13 files. The doc comment is aspirational; the refactor establishes the primitive (a.State()) and the pattern but does not enforce it everywhere. Tracked as a follow-up cleanup ticket.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-YADMI.md
+++ b/tickets/entities/review-responses/RR-YADMI.md
@@ -1,0 +1,9 @@
+---
+id: RR-YADMI
+type: review-response
+title: TestConcurrentReadDuringOnReload too weak
+finding: Only checks state.Load() returns non-nil with non-nil Cfg/Meta. Does not check any cross-field invariant or exercise any handler. A reader observing a torn handler response would not be caught.
+severity: minor
+resolution: 'TestConcurrentReadDuringOnReload now bumps to 8 readers and 200ms duration, and asserts a cross-field invariant: a published AppState always has at least as many StyleMap entries as metamodel.Types. A torn publish that put a new metamodel into the snapshot before the matching StyleMap would fail this assertion under -race. A more thorough handler-level test (TestHandlerCoherenceUnderReload) is tracked as TKT-7DJ2O.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-7DJ2O.md
+++ b/tickets/entities/tickets/TKT-7DJ2O.md
@@ -1,0 +1,11 @@
+---
+id: TKT-7DJ2O
+type: ticket
+title: Migrate handlers to snapshot-prologue pattern
+kind: refactor
+priority: low
+effort: m
+status: backlog
+---
+
+## Problem\n\nThe App struct doc comment promises that handlers call `a.State()` once at entry and use the snapshot consistently. In practice, handlers throughout internal/dataentry call `a.Cfg()`, `a.Meta()`, `a.Graph()`, and `a.State()` multiple times within a single request. Each call is an independent atomic load. A reload firing between two calls produces a torn request — for example, an entity list from the old snapshot and a style map from the new one.\n\nWorst offenders:\n- handleGraphData (handlers_graph.go) — many a.Graph()/a.Meta() calls\n- handleAPIGetSettings (handlers_api.go) — interleaves State().UserDefaults / Meta() / Graph() / State().UserPalette\n- V1Config response builder (api_v1.go) — calls a.Cfg() five times and a.State() twice\n\n## Scope\n\n- Add an `s := a.State()` prologue at the top of every handler in internal/dataentry\n- Replace `a.Cfg()`, `a.Meta()`, `a.Graph()` calls within the handler body with `s.Cfg`, `s.Meta`, `s.Graph`\n- Keep the convenience accessors (`a.Cfg()` etc.) for short one-shot uses outside handlers\n- Add a strengthened concurrency test that exercises a real handler under concurrent reload and asserts cross-field invariants (e.g. entity counts in the response match the number of entities in the snapshot graph)\n\n## Acceptance\n\n1. Every HTTP handler in internal/dataentry begins with `s := a.State()` and uses `s.X` throughout.\n2. New test TestHandlerCoherenceUnderReload runs handleGraphData (or similar) concurrently with onReload and asserts each response is internally self-consistent.\n3. The App struct doc comment about the snapshot-prologue pattern is no longer aspirational.\n\n## Origin\n\nDeferred from TKT-PYN1c. See RR-Q37M1 for the cranky-review finding.

--- a/tickets/entities/tickets/TKT-9Q2TX.md
+++ b/tickets/entities/tickets/TKT-9Q2TX.md
@@ -1,0 +1,11 @@
+---
+id: TKT-9Q2TX
+type: ticket
+title: Clone live entity before mutation in handlers
+kind: refactor
+priority: low
+effort: s
+status: backlog
+---
+
+## Problem\n\nMutation handlers in internal/dataentry/api_v1.go and internal/dataentry/handlers_api.go currently do:\n\n`go\nentity, _ := a.Graph().GetNode(id)\noldEntity := entity.Clone()\nentity.Properties[k] = v        // mutates the LIVE graph node's map\nentity.Content = newContent     // mutates the LIVE field\nws.UpdateEntity(entity, oldEntity)\n`\n\nThe middle two lines mutate the **live** graph node — the same `*model.Entity` that lock-free readers (Search, analyze, view rendering) can be iterating concurrently. writeMu serializes writers against each other but not against readers.\n\nThis is a **pre-existing race** that long predates the App.mu refactor (the entity property map has never been synchronized). The refactor surfaces it more sharply because there's no longer even a token RLock between readers and writers.\n\nFix: clone the entity twice in every mutation handler — once for `oldEntity` (used for the diff), once for the working copy that gets mutated and passed to UpdateEntity. The workspace's UpdateEntity then atomically swaps the live node via Graph.mu.\n\n## Scope\n\n- internal/dataentry/api_v1.go — handleV1UpdateEntity, handleV1SetProperty\n- internal/dataentry/handlers_api.go — handleAPIUpdateEntity\n- internal/dataentry/handlers.go — handleToggleCheckbox is already fixed in TKT-PYN1c per RR-AF6SJ\n- Audit cmd/rela CLI commands and internal/mcp tools for the same pattern\n\n## Acceptance\n\n1. No mutation handler mutates the live `entity` returned by `Graph().GetNode(id)`. All in-place writes happen on a clone.\n2. A new race-detector test exercises a concurrent reader iterating entity properties while a writer updates the same entity. Passes under -race.\n3. The pre-existing race documented in TestConcurrentReloadStateSnapshot's scope notes is no longer a known limitation; the test can be extended to iterate entity properties.\n\n## Origin\n\nDeferred from TKT-PYN1c (PR #346). See RR-1CO05 for the cranky-review finding.

--- a/tickets/relations/TKT-7DJ2O--affects--data-entry-server.md
+++ b/tickets/relations/TKT-7DJ2O--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7DJ2O
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-7DJ2O--implements--FEAT-W5T8.md
+++ b/tickets/relations/TKT-7DJ2O--implements--FEAT-W5T8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7DJ2O
+relation: implements
+to: FEAT-W5T8
+---

--- a/tickets/relations/TKT-9Q2TX--affects--data-entry-server.md
+++ b/tickets/relations/TKT-9Q2TX--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9Q2TX
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-9Q2TX--implements--FEAT-W5T8.md
+++ b/tickets/relations/TKT-9Q2TX--implements--FEAT-W5T8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9Q2TX
+relation: implements
+to: FEAT-W5T8
+---


### PR DESCRIPTION
## Summary

Combines four originally-separate tickets into one self-contained PR that finishes the data-entry locking refactor (FEAT-W5T8):

- **TKT-PYN1b/c** — migrate read and mutation handlers to read via `state.Load()`
- **TKT-WYYP** — introduce `writeMu sync.Mutex` for mutation serialization
- **TKT-9NFK** — delete `App.mu sync.RWMutex` and `reloadLockMiddleware`

## Why one PR

Each individual step would have left handlers in a half-migrated state where some readers used the old fields and some used the new snapshot — racy until App.mu is also removed. Splitting into 4 PRs would have required maintaining two snapshot publication paths in parallel for the duration of the migration. Doing it once is safer and produces a coherent final state.

## What changes

- Delete the convenience fields on `App` (`Cfg`, `meta`, `g`, `styleMap`, `styledTypes`, `userDefaults`, `palette`, `userPalette`, `openAPIGen`). `AppState` (introduced in TKT-PYN1a, already on develop) is now the sole source of truth.
- Add accessor methods `Cfg()`, `Meta()`, `Graph()`, `State()` that read from the atomic snapshot.
- Add `writeMu sync.Mutex`. Mutation handlers serialize via `writeMu.Lock()/Unlock()` instead of the old lock-upgrade dance.
- New `App.mutateState(fn)` helper takes `writeMu`, snapshots the current `AppState` into a copy, runs the caller's mutator on the copy, and publishes via `state.Store`. Used by `handleAPISaveSettings` and `handleAPISavePalette`.
- `handleToggleCheckbox` now takes `writeMu` and clones the live entity twice (one for `oldEntity`, one for the working copy) to avoid mutating the live graph node.
- Delete `App.mu` and `reloadLockMiddleware`. Replaced by `noCacheMiddleware` which retains the no-cache header logic but takes no lock.
- Rewrite `onReload` to build a fresh `AppState` struct and publish via `state.Store`. No more in-place field mutation.
- Update ~17 test struct literals to use the new `newAppFromParts(cfg, meta, g)` helper. The helper populates ALL `AppState` fields with safe defaults so handlers reading less-common fields don't nil-deref in tests.
- Strengthen `TestConcurrentReadDuringOnReload`: 8 readers, 200ms duration, asserts a cross-field invariant (`StyleMap` entries `>=` metamodel `Types`) that would catch a torn snapshot under `-race`.

**Net diff: -300 lines.** The lock-upgrade dance, the middleware boilerplate, and the convenience aliases are simpler when expressed as snapshot reads.

## Cranky review of this PR

8 issues found and logged as `review-response` entities. Resolved in this commit:

| ID | Severity | Title |
|----|----------|-------|
| RR-OQ4I8 | critical | AppState mutated in place in SaveSettings/SavePalette |
| RR-AF6SJ | critical | handleToggleCheckbox missing writeMu |
| RR-PSX6Z | minor | Stale reloadLockMiddleware comments |
| RR-78U55 | minor | newAppFromParts left fields nil |
| RR-YADMI | minor | TestConcurrentReadDuringOnReload too weak |

Deferred to follow-up tickets (tracked in FEAT-W5T8):

| ID | Title | Tracking ticket |
|----|-------|-----------------|
| RR-1CO05 | Mutation handlers mutate live graph nodes | TKT-9Q2TX |
| RR-A2CRB | Tests mutate app.Cfg() through the snapshot | (test cleanup) |
| RR-Q37M1 | Handlers use multiple State() calls per request | TKT-7DJ2O |

## Closes

This finishes the original FEAT-W5T8 plan (data-entry server locking refactor). Subsequent work in the FEAT-W5T8 program is the optional Tx primitive (TKT-PNPI) and its follow-ups.

## Test plan

- [x] `go test -race ./...` — all packages green
- [x] `just lint` — clean
- [x] Strengthened `TestConcurrentReadDuringOnReload` exercises 8 reader goroutines + reloader and asserts cross-field snapshot invariants under `-race`
- [ ] CI on this branch