### PR TITLE
arch: allow cli to depend on rename

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -142,6 +142,7 @@ deps:
       - metamodel
       - output
       - project
+      - rename
       - schema
       - script
       - views

--- a/tickets/entities/tickets/TKT-YJ251.md
+++ b/tickets/entities/tickets/TKT-YJ251.md
@@ -1,0 +1,15 @@
+---
+id: TKT-YJ251
+type: ticket
+title: Allow cli to depend on rename in arch config
+kind: chore
+priority: low
+effort: xs
+status: done
+---
+
+After PR #353 migrated rename orchestration into workspace, the rename package
+became a types-only DTO package. `internal/cli/rename.go` imports rename for
+`rename.Options` when calling `ws.Rename`, but the `.go-arch-lint.yml` allowlist
+was missed in that PR. This adds `rename` to `cli.mayDependOn`, matching the
+existing `mcp→rename` dependency.

--- a/tickets/relations/TKT-YJ251--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-YJ251--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YJ251
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-YJ251--implements--FEAT-022.md
+++ b/tickets/relations/TKT-YJ251--implements--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YJ251
+relation: implements
+to: FEAT-022
+---


### PR DESCRIPTION
## Summary
- The `rename` package is now a types-only DTO package (`Options`, `Result`, `RelationRef`) after #353 moved orchestration into `workspace`.
- `internal/cli/rename.go` imports `rename` for `rename.Options` when calling `ws.Rename`, but the arch allowlist was missed.
- Adds `rename` to `cli.mayDependOn`, matching the existing `mcp → rename` dependency.

## Test plan
- [x] `go-arch-lint check` passes locally