### PR TITLE
refactor: migrate CLI to workspace.Snapshot (Phase 3)

### DIFF
--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -601,7 +601,7 @@ Examples:
 		viewsFile := loadViewsFile()
 
 		// Run analysis
-		analysis := schema.Analyze(meta, ws.Graph(), dataEntry, viewsFile, schemaThreshold)
+		analysis := schema.Analyze(meta, ws.Snapshot().Graph(), dataEntry, viewsFile, schemaThreshold)
 
 		// Handle cleanup mode
 		if schemaCleanup {

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -79,7 +79,7 @@ CSV format (relations):
 			RelationsFile: importRelationsFile,
 		}
 
-		imp := importer.New(ws.Repo(), meta, ws.Graph(), opts, importer.NewImportSource(ws.FS()))
+		imp := importer.New(ws.Repo(), meta, ws.Snapshot().Graph(), opts, importer.NewImportSource(ws.FS()))
 
 		if importDryRun {
 			out.WriteInfo("Dry run - validating without creating files...")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -90,7 +90,7 @@ and maintain semantic relationships between them.`,
 
 		// Convenience aliases for read-only commands
 		projectCtx = ws.Paths()
-		meta = ws.Meta()
+		meta = ws.Snapshot().Meta()
 
 		// Set up output writer
 		out = output.New(output.Format(outputFormat))

--- a/internal/cli/view.go
+++ b/internal/cli/view.go
@@ -41,8 +41,11 @@ Examples:
 			return fmt.Errorf("view validation failed: %w", validationErr)
 		}
 
+		snap := ws.Snapshot()
+		g := snap.Graph()
+
 		// Create view engine
-		engine := views.NewEngine(ws.Graph(), meta)
+		engine := views.NewEngine(g, meta)
 
 		// Execute the view
 		result, err := engine.Execute(viewDef, entryID)
@@ -56,7 +59,7 @@ Examples:
 			format = "yaml" // Default to yaml for views
 		}
 
-		output, err := views.Format(result, format, ws.Graph(), meta)
+		output, err := views.Format(result, format, g, meta)
 		if err != nil {
 			return fmt.Errorf("failed to format output: %w", err)
 		}

--- a/internal/cli/view_affected.go
+++ b/internal/cli/view_affected.go
@@ -83,7 +83,7 @@ Examples:
 		}
 
 		// Find affected roots
-		engine := views.NewEngine(ws.Graph(), meta)
+		engine := views.NewEngine(ws.Snapshot().Graph(), meta)
 		affected, err := engine.AffectedRoots(viewDef, changedIDs, rootIDs)
 		if err != nil {
 			return fmt.Errorf("failed to find affected roots: %w", err)

--- a/internal/cli/view_deps.go
+++ b/internal/cli/view_deps.go
@@ -63,7 +63,7 @@ Examples:
 		}
 
 		// Execute and collect deps
-		engine := views.NewEngine(ws.Graph(), meta)
+		engine := views.NewEngine(ws.Snapshot().Graph(), meta)
 		ids, err := engine.CollectDeps(viewDef, rootIDs)
 		if err != nil {
 			return fmt.Errorf("failed to collect dependencies: %w", err)

--- a/tickets/entities/tickets/TKT-910WC.md
+++ b/tickets/entities/tickets/TKT-910WC.md
@@ -6,6 +6,7 @@ kind: refactor
 priority: high
 effort: l
 status: done
+tags: phase3-cli-done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-910WC.md
+++ b/tickets/entities/tickets/TKT-910WC.md
@@ -6,7 +6,6 @@ kind: refactor
 priority: high
 effort: l
 status: done
-tags: phase3-cli-done
 ---
 
 ## Problem
@@ -91,3 +90,9 @@ CLI is trivial — 7 call sites.
 3. All MCP handlers use snapshot instead of direct `ws.Graph()` / `ws.Meta()`
 4. All existing MCP tests pass
 5. `go test -race ./...`, `just lint`, `go-arch-lint check` all pass
+
+## Completion
+
+- Phase 1 (MCP): PR #368, merged
+- Phase 3 (CLI): PR #372, merged
+- Phase 2 (dataentry): deferred — separate follow-up


### PR DESCRIPTION
## Summary
- Replace all `ws.Graph()` and `ws.Meta()` calls in CLI with `ws.Snapshot()`
- 6 files changed, +10/-7 lines
- Completes Snapshot migration for CLI (Phase 3 of TKT-910WC)

Phases 1 (MCP, #368) and 3 (CLI, this PR) are done. Phase 2 (dataentry) is the remaining consumer.

## Test plan
- [x] `go test -race ./...` — all pass
- [x] `golangci-lint run ./internal/cli/` — clean
- [x] Zero `ws.Graph()` / `ws.Meta()` calls in CLI (verified via grep)