### PR TITLE
refactor: separate metamodel reload from data reload in watcher (TKT-7WKTZ)

### DIFF
--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -179,7 +179,7 @@ func (d *Desktop) GetSetupInfo() map[string]interface{} {
 		return map[string]interface{}{"error": "No project pending setup"}
 	}
 
-	meta, err := d.pendingSetupRepo.LoadMetamodel()
+	meta, _, err := d.pendingSetupRepo.LoadMetamodel()
 	if err != nil {
 		return map[string]interface{}{"error": fmt.Sprintf("Failed to load metamodel: %v", err)}
 	}
@@ -206,7 +206,7 @@ func (d *Desktop) GenerateDataEntryConfig(appName string) string {
 		return "No project pending setup"
 	}
 
-	meta, err := repo.LoadMetamodel()
+	meta, _, err := repo.LoadMetamodel()
 	if err != nil {
 		return fmt.Sprintf("Failed to load metamodel: %v", err)
 	}

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -93,7 +93,7 @@ func (a *App) StartWatching() error {
 	return a.ws.StartWatching(workspace.WatchOptions{
 		ExtraFiles: []string{configPath},
 		ExtraDirs:  []string{metamodelDir},
-		OnReload: func(events []workspace.ChangeEvent) {
+		OnChange: func(events []workspace.ChangeEvent) {
 			for _, e := range events {
 				slog.Debug("file changed", "path", e.Path, "op", e.Op)
 			}

--- a/internal/dataentry/watcher_test.go
+++ b/internal/dataentry/watcher_test.go
@@ -100,7 +100,7 @@ status: open
 
 	repo := repository.New(fs, ctx)
 
-	meta, err := repo.LoadMetamodel()
+	meta, _, err := repo.LoadMetamodel()
 	if err != nil {
 		t.Fatalf("failed to load metamodel: %v", err)
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -54,7 +54,7 @@ func (s *Server) Serve() error {
 
 	// Start file watcher via workspace
 	if err := s.ws.StartWatching(workspace.WatchOptions{
-		OnReload: func(_ []workspace.ChangeEvent) {
+		OnChange: func(_ []workspace.ChangeEvent) {
 			s.logger.Info("graph re-synced from file changes")
 			if s.mcp != nil {
 				s.mcp.SendNotificationToAllClients(

--- a/internal/metamodel/include.go
+++ b/internal/metamodel/include.go
@@ -36,14 +36,17 @@ type includeState struct {
 // loadWithIncludes loads a metamodel and recursively resolves all includes.
 // rootDir is the project root directory (where the root metamodel.yaml lives).
 // All include paths are resolved relative to rootDir.
-func loadWithIncludes(root *Metamodel, rootPath, rootDir string, fs storage.FS) error {
+//
+// Returns the absolute paths of all include files that were read (not including
+// the root metamodel path itself).
+func loadWithIncludes(root *Metamodel, rootPath, rootDir string, fs storage.FS) ([]string, error) {
 	if len(root.Includes) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	absRoot, err := filepath.Abs(rootPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	state := &includeState{
@@ -56,20 +59,26 @@ func loadWithIncludes(root *Metamodel, rootPath, rootDir string, fs storage.FS) 
 	for _, inc := range root.Includes {
 		collected, err := resolveIncludes(rootDir, inc, rootPath, state, []string{rootPath}, fs)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		partials = append(partials, collected...)
 	}
 
 	// Merge all partials into the root metamodel
 	if err := mergeIncludes(root, rootPath, partials); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Rebuild the alias map to include entities from all files
 	root.rebuildAliasMap()
 
-	return nil
+	// Collect resolved include paths from the processed set (excludes root)
+	includePaths := make([]string, 0, len(state.processed))
+	for absPath := range state.processed {
+		includePaths = append(includePaths, absPath)
+	}
+
+	return includePaths, nil
 }
 
 // resolveIncludes recursively resolves an include file and all its nested includes.

--- a/internal/metamodel/include_test.go
+++ b/internal/metamodel/include_test.go
@@ -37,7 +37,7 @@ entities:
         required: true
 `)
 
-	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	meta, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertNoError(t, err)
 
 	if _, ok := meta.Entities["requirement"]; !ok {
@@ -100,7 +100,7 @@ relations:
     inverse: mitigatedBy
 `)
 
-	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	meta, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertNoError(t, err)
 
 	// Types from types.yaml
@@ -163,7 +163,7 @@ entities:
         type: string
 `)
 
-	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	meta, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertNoError(t, err)
 
 	if _, ok := meta.Entities["root_entity"]; !ok {
@@ -212,7 +212,7 @@ entities:
         type: string
 `)
 
-	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	_, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertError(t, err)
 
 	var circularErr *CircularIncludeError
@@ -230,7 +230,7 @@ includes:
   - metamodel.yaml
 `)
 
-	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	_, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertError(t, err)
 
 	var circularErr *CircularIncludeError
@@ -271,7 +271,7 @@ entities:
         type: string
 `)
 
-	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	_, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertError(t, err)
 
 	var dupErr *DuplicateDefinitionError
@@ -302,7 +302,7 @@ types:
     values: [low, high, critical]
 `)
 
-	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	_, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertError(t, err)
 
 	var dupErr *DuplicateDefinitionError
@@ -339,7 +339,7 @@ relations:
     to: [risk]
 `)
 
-	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	_, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertError(t, err)
 
 	var dupErr *DuplicateDefinitionError
@@ -372,7 +372,7 @@ validations:
       - "title!="
 `)
 
-	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	_, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertError(t, err)
 
 	var dupErr *DuplicateDefinitionError
@@ -392,7 +392,7 @@ includes:
   - nonexistent.yaml
 `)
 
-	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	_, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertError(t, err)
 
 	var notFoundErr *IncludeNotFoundError
@@ -423,7 +423,7 @@ entities:
         type: string
 `)
 
-	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	_, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertError(t, err)
 
 	var rootFieldErr *IncludeHasRootFieldError
@@ -454,7 +454,7 @@ entities:
         type: string
 `)
 
-	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	_, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertError(t, err)
 
 	var rootFieldErr *IncludeHasRootFieldError
@@ -481,7 +481,7 @@ entities:
         required: true
 `)
 
-	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	meta, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertNoError(t, err)
 
 	if _, ok := meta.Entities["requirement"]; !ok {
@@ -516,7 +516,7 @@ types:
     values: [low, medium, high, critical]
 `)
 
-	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	meta, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertNoError(t, err)
 
 	// Verify cross-file reference works: entity uses type from included file
@@ -573,7 +573,7 @@ relations:
     inverse: mitigatedBy
 `)
 
-	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	meta, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertNoError(t, err)
 
 	// Verify relation references entities from another included file
@@ -633,7 +633,7 @@ types:
     values: [a, b, c]
 `)
 
-	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	meta, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertNoError(t, err)
 
 	// All entities should be present
@@ -679,7 +679,7 @@ entities:
         required: true
 `)
 
-	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	meta, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertNoError(t, err)
 
 	if _, ok := meta.Entities["control"]; !ok {
@@ -717,7 +717,7 @@ entities:
         type: string
 `)
 
-	_, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	_, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertError(t, err)
 
 	var dupErr *DuplicateDefinitionError
@@ -763,7 +763,7 @@ validations:
     severity: warning
 `)
 
-	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	meta, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertNoError(t, err)
 
 	if len(meta.Validations) != 2 {
@@ -814,7 +814,7 @@ entities:
         required: true
 `)
 
-	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	meta, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertNoError(t, err)
 
 	// Aliases from root
@@ -842,7 +842,7 @@ entities:
         required: true
 `)
 
-	meta, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	meta, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
 	assertNoError(t, err)
 
 	if _, ok := meta.Entities["requirement"]; !ok {

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -36,62 +36,83 @@ var knownTypos = map[string]string{
 // If the metamodel contains an `includes:` key, included files are recursively
 // loaded and merged. Include paths are resolved relative to the directory
 // containing the metamodel file.
-func Load(path string, fs storage.FS) (*Metamodel, error) {
+//
+// The returned []string contains the absolute paths of all files that were
+// read: the main metamodel.yaml path plus all include files.
+func Load(path string, fs storage.FS) (*Metamodel, []string, error) {
 	data, err := fs.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// When includes are present, parse without full validation first,
 	// resolve includes, then validate the merged result.
 	m, err := parseRaw(data)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if len(m.Includes) > 0 {
 		rootDir := filepath.Dir(path)
-		if err := loadWithIncludes(m, path, rootDir, fs); err != nil {
-			return nil, err
+		includePaths, err := loadWithIncludes(m, path, rootDir, fs)
+		if err != nil {
+			return nil, nil, err
 		}
 		// Validate the fully merged metamodel
 		if err := validate(m); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return m, nil
+		sourceFiles := append([]string{absPath}, includePaths...)
+		return m, sourceFiles, nil
 	}
 
 	// No includes: validate immediately
 	if err := validate(m); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return m, nil
+	return m, []string{absPath}, nil
 }
 
 // LoadWithoutMigrationCheck loads a metamodel without checking for migrations.
 // This is used by the migrate command itself to avoid chicken-and-egg issues.
 // Returns nil if loading fails (caller should handle gracefully).
-func LoadWithoutMigrationCheck(path string, fs storage.FS) (*Metamodel, error) {
+//
+// The returned []string contains the absolute paths of all files that were read.
+func LoadWithoutMigrationCheck(path string, fs storage.FS) (*Metamodel, []string, error) {
 	data, err := fs.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	m, err := parseRaw(data)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if len(m.Includes) > 0 {
 		rootDir := filepath.Dir(path)
-		if err := loadWithIncludes(m, path, rootDir, fs); err != nil {
-			return nil, err
+		includePaths, err := loadWithIncludes(m, path, rootDir, fs)
+		if err != nil {
+			return nil, nil, err
 		}
+		sourceFiles := append([]string{absPath}, includePaths...)
+		// Skip validation since metamodel may be in a migration state
+		return m, sourceFiles, nil
 	}
 
 	// Skip validation since metamodel may be in a migration state
-	return m, nil
+	return m, []string{absPath}, nil
 }
 
 // Parse parses and validates metamodel YAML content.

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -415,7 +415,7 @@ entities:
 	createFile(t, tmpFile, validYAML)
 
 	// Test successful load
-	meta, err := Load(tmpFile, testMetaFS)
+	meta, _, err := Load(tmpFile, testMetaFS)
 	assertNoError(t, err)
 
 	if meta == nil {
@@ -430,7 +430,7 @@ entities:
 }
 
 func TestLoad_NonExistentFile(t *testing.T) {
-	_, err := Load("/nonexistent/metamodel.yaml", testMetaFS)
+	_, _, err := Load("/nonexistent/metamodel.yaml", testMetaFS)
 	assertError(t, err)
 }
 
@@ -445,7 +445,7 @@ entities:
 
 	createFile(t, tmpFile, invalidYAML)
 
-	_, err := Load(tmpFile, testMetaFS)
+	_, _, err := Load(tmpFile, testMetaFS)
 	assertError(t, err)
 }
 

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -60,7 +60,10 @@ type Store interface {
 
 	// --- Metamodel ---
 
-	LoadMetamodel() (*metamodel.Metamodel, error)
+	// LoadMetamodel loads and parses the metamodel from the project's metamodel file.
+	// The returned []string contains the absolute paths of all files that were read
+	// (metamodel.yaml plus any include files).
+	LoadMetamodel() (*metamodel.Metamodel, []string, error)
 
 	// --- Views ---
 
@@ -379,13 +382,15 @@ func (r *Repository) CacheExists() bool {
 
 // LoadMetamodel loads and parses the metamodel from the project's metamodel file.
 // Returns a migration.Error if the file contains deprecated syntax that needs migration.
-func (r *Repository) LoadMetamodel() (*metamodel.Metamodel, error) {
+// The returned []string contains the absolute paths of all files that were read
+// (metamodel.yaml plus any include files).
+func (r *Repository) LoadMetamodel() (*metamodel.Metamodel, []string, error) {
 	detections, err := migration.Detect(r.paths.MetamodelPath, migration.FileTypeMetamodel, r.fs)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if len(detections) > 0 {
-		return nil, &migration.Error{
+		return nil, nil, &migration.Error{
 			FilePath:   r.paths.MetamodelPath,
 			Detections: detections,
 		}
@@ -526,6 +531,11 @@ type WatchHandle struct {
 // Stop stops the file watcher and releases resources.
 func (h *WatchHandle) Stop() {
 	h.watcher.Stop()
+}
+
+// AddFile adds an individual file to the watch list at runtime.
+func (h *WatchHandle) AddFile(path string) error {
+	return h.watcher.AddFile(path)
 }
 
 // Pause temporarily stops processing file change events.

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -444,7 +444,7 @@ func TestRepository_CacheSaveAndLoad(t *testing.T) {
 func TestRepository_LoadMetamodel(t *testing.T) {
 	repo, _, _ := setupTestRepo(t)
 
-	meta, err := repo.LoadMetamodel()
+	meta, _, err := repo.LoadMetamodel()
 	if err != nil {
 		t.Fatalf("LoadMetamodel() error = %v", err)
 	}

--- a/internal/storage/watcher.go
+++ b/internal/storage/watcher.go
@@ -131,6 +131,11 @@ func (w *Watcher) Stop() {
 	_ = w.fsWatcher.Close()
 }
 
+// AddFile adds an individual file to the watch list at runtime.
+func (w *Watcher) AddFile(path string) error {
+	return w.fsWatcher.Add(path)
+}
+
 // WatchList returns the list of currently watched paths.
 // Useful for testing.
 func (w *Watcher) WatchList() []string {

--- a/internal/workspace/migrate.go
+++ b/internal/workspace/migrate.go
@@ -53,7 +53,7 @@ func DetectMigrationsWithFS(startDir string, fs storage.FS) ([]MigrateDetection,
 	}
 
 	// Load metamodel for context-aware migrations (ignore errors - may need migration itself)
-	mm, _ := metamodel.LoadWithoutMigrationCheck(ctx.MetamodelPath, fs)
+	mm, _, _ := metamodel.LoadWithoutMigrationCheck(ctx.MetamodelPath, fs)
 
 	files := getMigrateFiles(ctx)
 	var detections []MigrateDetection
@@ -95,7 +95,7 @@ func MigrateWithFS(startDir string, fs storage.FS) (*MigrateResult, error) {
 	}
 
 	// Load metamodel for context-aware migrations (ignore errors - may need migration itself)
-	mm, _ := metamodel.LoadWithoutMigrationCheck(ctx.MetamodelPath, fs)
+	mm, _, _ := metamodel.LoadWithoutMigrationCheck(ctx.MetamodelPath, fs)
 
 	files := getMigrateFiles(ctx)
 	result := &MigrateResult{}

--- a/internal/workspace/validate.go
+++ b/internal/workspace/validate.go
@@ -46,7 +46,7 @@ func ValidateWithFS(startDir string, fs storage.FS) (*ValidateResult, error) {
 	result := &ValidateResult{}
 
 	// Validate metamodel
-	mm, err := metamodel.Load(ctx.MetamodelPath, fs)
+	mm, _, err := metamodel.Load(ctx.MetamodelPath, fs)
 	if err != nil {
 		result.MetamodelError = err
 	} else {

--- a/internal/workspace/watcher_classify.go
+++ b/internal/workspace/watcher_classify.go
@@ -1,0 +1,74 @@
+package workspace
+
+import (
+	"path/filepath"
+
+	"github.com/Sourcehaven-BV/rela/internal/repository"
+)
+
+// reloadAction describes what the workspace should do in response to file changes.
+type reloadAction int
+
+const (
+	// actionReload means the metamodel changed — full reload needed.
+	actionReload reloadAction = iota
+	// actionSync means only entity/relation data changed — graph re-sync only.
+	actionSync
+	// actionNotify means non-data files changed (views, config) — just notify consumers.
+	actionNotify
+)
+
+// classifyEvents inspects a batch of file change events and determines what
+// action the workspace should take. If ANY event touches a schema file,
+// the result is actionReload. If no schema files but entity/relation files
+// changed, the result is actionSync. Otherwise actionNotify.
+//
+// schemaFiles must contain absolute, cleaned paths. viewsPath must also be
+// absolute and cleaned.
+func classifyEvents(
+	events []repository.ChangeEvent,
+	schemaFiles []string,
+	viewsPath string,
+	entitiesDir string,
+	relationsDir string,
+) reloadAction {
+	schemaSet := make(map[string]bool, len(schemaFiles))
+	for _, f := range schemaFiles {
+		schemaSet[filepath.Clean(f)] = true
+	}
+	cleanViews := filepath.Clean(viewsPath)
+	cleanEntities := filepath.Clean(entitiesDir)
+	cleanRelations := filepath.Clean(relationsDir)
+
+	hasData := false
+	for _, e := range events {
+		p := filepath.Clean(e.Path)
+
+		// Schema file?
+		if schemaSet[p] {
+			return actionReload
+		}
+
+		// Views file? Treat as notify-only (views are loaded on demand)
+		if p == cleanViews {
+			continue
+		}
+
+		// Entity or relation file?
+		if isUnder(p, cleanEntities) || isUnder(p, cleanRelations) {
+			hasData = true
+		}
+	}
+
+	if hasData {
+		return actionSync
+	}
+	return actionNotify
+}
+
+// isUnder checks if path is under dir (using cleaned paths).
+func isUnder(path, dir string) bool {
+	// Add trailing separator so "/entities" doesn't match "/entities-extra"
+	dirPrefix := dir + string(filepath.Separator)
+	return len(path) > len(dirPrefix) && path[:len(dirPrefix)] == dirPrefix
+}

--- a/internal/workspace/watcher_classify_test.go
+++ b/internal/workspace/watcher_classify_test.go
@@ -1,0 +1,85 @@
+package workspace
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/repository"
+)
+
+func TestClassifyEvents(t *testing.T) {
+	schemaFiles := []string{
+		filepath.Clean("/project/metamodel.yaml"),
+		filepath.Clean("/project/types.yaml"),
+	}
+	viewsPath := filepath.Clean("/project/views.yaml")
+	entitiesDir := filepath.Clean("/project/entities")
+	relationsDir := filepath.Clean("/project/relations")
+
+	tests := []struct {
+		name   string
+		events []repository.ChangeEvent
+		want   reloadAction
+	}{
+		{
+			name:   "metamodel change triggers reload",
+			events: []repository.ChangeEvent{{Path: "/project/metamodel.yaml", Op: repository.OpModify}},
+			want:   actionReload,
+		},
+		{
+			name:   "include file change triggers reload",
+			events: []repository.ChangeEvent{{Path: "/project/types.yaml", Op: repository.OpModify}},
+			want:   actionReload,
+		},
+		{
+			name:   "entity change triggers sync",
+			events: []repository.ChangeEvent{{Path: "/project/entities/requirement/REQ-001.md", Op: repository.OpModify}},
+			want:   actionSync,
+		},
+		{
+			name:   "relation change triggers sync",
+			events: []repository.ChangeEvent{{Path: "/project/relations/REQ-001--implements--FEAT-001.md", Op: repository.OpModify}},
+			want:   actionSync,
+		},
+		{
+			name:   "views change triggers notify only",
+			events: []repository.ChangeEvent{{Path: "/project/views.yaml", Op: repository.OpModify}},
+			want:   actionNotify,
+		},
+		{
+			name: "mixed metamodel and entity triggers reload",
+			events: []repository.ChangeEvent{
+				{Path: "/project/entities/requirement/REQ-001.md", Op: repository.OpModify},
+				{Path: "/project/metamodel.yaml", Op: repository.OpModify},
+			},
+			want: actionReload,
+		},
+		{
+			name: "mixed entity and views triggers sync",
+			events: []repository.ChangeEvent{
+				{Path: "/project/entities/requirement/REQ-001.md", Op: repository.OpModify},
+				{Path: "/project/views.yaml", Op: repository.OpModify},
+			},
+			want: actionSync,
+		},
+		{
+			name:   "unknown file triggers notify",
+			events: []repository.ChangeEvent{{Path: "/project/something-else.yaml", Op: repository.OpModify}},
+			want:   actionNotify,
+		},
+		{
+			name:   "empty events triggers notify",
+			events: []repository.ChangeEvent{},
+			want:   actionNotify,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyEvents(tt.events, schemaFiles, viewsPath, entitiesDir, relationsDir)
+			if got != tt.want {
+				t.Errorf("classifyEvents() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -143,6 +144,12 @@ type Workspace struct {
 
 	// Watcher state (nil when not watching).
 	watchHandle *repository.WatchHandle
+
+	// schemaFiles holds the absolute paths of all files that make up the
+	// current metamodel (metamodel.yaml + includes). Updated after each
+	// successful Reload. Used by the watcher to distinguish schema changes
+	// from data changes.
+	schemaFiles []string
 }
 
 // maxAutomationDepth limits recursive automation triggering. When an entity
@@ -180,7 +187,7 @@ func New(repo repository.Store, scriptExec ScriptExecutor) (*Workspace, error) {
 		exec = NopScriptExecutor
 	}
 
-	meta, err := repo.LoadMetamodel()
+	meta, schemaFiles, err := repo.LoadMetamodel()
 	if err != nil {
 		return nil, fmt.Errorf("load metamodel: %w", err)
 	}
@@ -209,7 +216,9 @@ func New(repo repository.Store, scriptExec ScriptExecutor) (*Workspace, error) {
 		}
 	}
 
-	return newWorkspace(repo, meta, g, exec), nil
+	ws := newWorkspace(repo, meta, g, exec)
+	ws.schemaFiles = schemaFiles
+	return ws, nil
 }
 
 // NewWithGraph creates a workspace with a pre-populated graph. Use this
@@ -590,7 +599,7 @@ func (w *Workspace) Reload() (*model.SyncResult, error) {
 
 	oldState := w.state.Load()
 
-	newMeta, err := w.repo.LoadMetamodel()
+	newMeta, newSchemaFiles, err := w.repo.LoadMetamodel()
 	if err != nil {
 		if migration.IsMigrationError(err) {
 			return w.reloadKeepingOldMetamodel(oldState)
@@ -627,6 +636,9 @@ func (w *Workspace) Reload() (*model.SyncResult, error) {
 		automation: newAuto,
 		searchIdx:  newIdx,
 	})
+
+	// Watch any new schema include files that appeared after reload.
+	w.updateSchemaFiles(newSchemaFiles)
 
 	// Close the old search index if it was replaced (not carried over).
 	if oldState != nil && oldState.searchIdx != nil && oldState.searchIdx != newIdx {
@@ -1629,25 +1641,49 @@ type WatchOptions struct {
 	ExtraFiles []string
 	// ExtraDirs lists additional directories to watch (e.g., metamodel/).
 	ExtraDirs []string
-	// OnReload is called after workspace has reloaded metamodel and graph.
-	// Consumers use this for side-effects (SSE broadcast, MCP notifications, etc.).
-	OnReload func(events []ChangeEvent)
+	// OnChange is called after the workspace has handled file changes
+	// (reload, sync, or notify-only). Consumers use this for side-effects
+	// (SSE broadcast, MCP notifications, etc.).
+	OnChange func(events []ChangeEvent)
 }
 
-// StartWatching begins watching for file changes. On each change the
-// workspace reloads the metamodel, re-syncs the graph, saves the cache,
-// and then calls OnReload.
+// StartWatching begins watching for file changes. On each batch of changes
+// the workspace classifies the events and either reloads the metamodel and
+// graph, re-syncs only the graph, or skips reloading (notify-only). Then it
+// calls OnChange with the raw events.
 func (w *Workspace) StartWatching(opts WatchOptions) error {
+	// Include schema include files in the initial watch list so changes to
+	// them are detected immediately.
+	extraFiles := make([]string, 0, len(opts.ExtraFiles)+len(w.schemaFiles))
+	extraFiles = append(extraFiles, opts.ExtraFiles...)
+	extraFiles = append(extraFiles, w.schemaFiles...)
+
 	repoOpts := repository.WatchOptions{
-		ExtraFiles: opts.ExtraFiles,
+		ExtraFiles: extraFiles,
 		ExtraDirs:  opts.ExtraDirs,
 	}
+
+	paths := w.Paths()
+	viewsPath := filepath.Join(paths.Root, "views.yaml")
+
 	handle, err := w.repo.WatchWithHandle(repoOpts, func(events []repository.ChangeEvent) {
-		if _, reloadErr := w.Reload(); reloadErr != nil {
-			slog.Error("reload error", "error", reloadErr)
+		action := classifyEvents(events, w.schemaFiles, viewsPath, paths.EntitiesDir, paths.RelationsDir)
+
+		switch action {
+		case actionReload:
+			if _, reloadErr := w.Reload(); reloadErr != nil {
+				slog.Error("reload error", "error", reloadErr)
+			}
+		case actionSync:
+			if _, syncErr := w.Sync(); syncErr != nil {
+				slog.Error("sync error", "error", syncErr)
+			}
+		case actionNotify:
+			// No data changes — just notify consumers
 		}
-		if opts.OnReload != nil {
-			opts.OnReload(events)
+
+		if opts.OnChange != nil {
+			opts.OnChange(events)
 		}
 	})
 	if err != nil {
@@ -1657,8 +1693,38 @@ func (w *Workspace) StartWatching(opts WatchOptions) error {
 	return nil
 }
 
-// StopWatching stops the file watcher.
+// updateSchemaFiles compares newSchemaFiles against the current w.schemaFiles,
+// adds any newly-seen files to the active watcher, and updates w.schemaFiles.
+// Caller must hold reloadMu.
+func (w *Workspace) updateSchemaFiles(newSchemaFiles []string) {
+	oldSet := make(map[string]bool, len(w.schemaFiles))
+	for _, f := range w.schemaFiles {
+		oldSet[filepath.Clean(f)] = true
+	}
+
+	if w.watchHandle != nil {
+		for _, f := range newSchemaFiles {
+			if !oldSet[filepath.Clean(f)] {
+				if addErr := w.watchHandle.AddFile(f); addErr != nil {
+					slog.Warn("failed to watch new schema file", "path", f, "error", addErr)
+				}
+			}
+		}
+	}
+
+	w.schemaFiles = newSchemaFiles
+}
+
+// StopWatching stops the file watcher. Serialized against Reload/Sync
+// via reloadMu to prevent races with updateSchemaFiles.
 func (w *Workspace) StopWatching() {
+	w.reloadMu.Lock()
+	defer w.reloadMu.Unlock()
+	w.stopWatchingLocked()
+}
+
+// stopWatchingLocked stops the watcher. Caller must hold reloadMu.
+func (w *Workspace) stopWatchingLocked() {
 	if w.watchHandle != nil {
 		w.watchHandle.Stop()
 		w.watchHandle = nil
@@ -1670,9 +1736,9 @@ func (w *Workspace) StopWatching() {
 // reloadMu; the closed flag prevents any Reload that arrives after Close
 // from resurrecting the workspace.
 func (w *Workspace) Close() error {
-	w.StopWatching()
 	w.reloadMu.Lock()
 	defer w.reloadMu.Unlock()
+	w.stopWatchingLocked()
 	if w.closed.Swap(true) {
 		return nil // already closed
 	}

--- a/tickets/entities/tickets/TKT-7WKTZ.md
+++ b/tickets/entities/tickets/TKT-7WKTZ.md
@@ -1,0 +1,54 @@
+---
+id: TKT-7WKTZ
+type: ticket
+title: Separate metamodel reload from data reload in watcher
+kind: refactor
+priority: high
+effort: m
+status: ready
+---
+
+## Problem
+
+The file watcher calls `Reload()` on every file change, which re-reads the
+metamodel AND re-syncs all entities/relations from disk. This is wasteful:
+entity/relation changes (the common case) don't need a metamodel reload, and
+metamodel changes don't need the full entity parse if nothing else changed.
+
+More importantly, the metamodel's `includes:` files (e.g., `types.yaml`,
+`entities.yaml`) are not in the watcher's file list, so changes to include
+files don't trigger any reload at all.
+
+See `.ignored/database-lessons.md` proposal #2 ("Catalog vs. Data Lifecycle").
+
+## Approach
+
+1. **In the watcher callback**, inspect event paths to determine what changed:
+   - If metamodel.yaml (or an include file) changed → full `Reload()` (meta + graph)
+   - If only entities/relations changed → `Sync()` (graph only, keep current meta)
+2. **Add include files to the watch list** so changes to `types.yaml` etc. trigger reloads
+3. The metamodel's `Includes` field (post-parse) lists the include paths. After initial
+   load, pass these to the watcher as extra files.
+
+## Scope
+
+**In scope:**
+1. Modify `StartWatching` callback to inspect event paths
+2. Add metamodel include files to the watcher's file list
+3. Call `Sync()` for data-only changes, `Reload()` for metamodel changes
+4. Test that both paths work correctly
+
+**Out of scope:**
+- Removing metamodel from `workspaceState` (catalog lifecycle proposal #2 full version)
+- Making metamodel restart-only (the user explicitly chose option 3 — smart reload)
+- Snapshot API Phase 2 (dataentry migration)
+
+## Acceptance Criteria
+
+1. Entity/relation file changes trigger `Sync()`, not `Reload()`
+2. `metamodel.yaml` changes still trigger full `Reload()`
+3. Metamodel include file changes trigger full `Reload()`
+4. `views.yaml` changes trigger full `Reload()` (it affects view definitions)
+5. Mixed changes (metamodel + entities in same batch) trigger `Reload()`
+6. All existing tests pass
+7. `go test -race ./...`, `just lint`, `go-arch-lint check` all pass

--- a/tickets/relations/TKT-7WKTZ--affects--workspace.md
+++ b/tickets/relations/TKT-7WKTZ--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7WKTZ
+relation: affects
+to: workspace
+---

--- a/tickets/relations/TKT-7WKTZ--implements--FEAT-workspace.md
+++ b/tickets/relations/TKT-7WKTZ--implements--FEAT-workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7WKTZ
+relation: implements
+to: FEAT-workspace
+---


### PR DESCRIPTION
## Summary
- File watcher now classifies events and dispatches to the right reload path:
  - Schema files (metamodel.yaml + includes) → `Reload()` (full)
  - Entity/relation files → `Sync()` (graph only, skip metamodel)
  - Views/other → notify-only (no reload at all)
- `metamodel.Load()` returns source file paths so the watcher knows which files are schema
- Include files are dynamically added to the watch list when discovered during reload
- `WatchOptions.OnReload` renamed to `OnChange`
- `classifyEvents()` extracted as a testable pure function (9 test cases)

## Design review findings (all addressed)
- C1: Stale watcher when includes change → dynamic `AddFile()` after Reload
- S2: Path normalization → `filepath.Clean()` in classifyEvents
- S3: SourceFiles on Metamodel → returned separately from Load(), stored in Workspace
- S4: views.yaml Reload is wasteful → three-way dispatch, views = notify-only
- M5: OnReload naming → renamed to OnChange
- M6: Testability → `classifyEvents()` pure function with table-driven tests

## Test plan
- [x] `go test -race ./...` — 36/36 pass
- [x] `golangci-lint run ./...` — clean
- [x] `go-arch-lint check` — no warnings
- [x] 9 table-driven tests for `classifyEvents()`