### PR TITLE
refactor: enforce State() snapshot discipline in dataentry (TKT-910WC Phase 2)

### DIFF
--- a/internal/dataentry/actions.go
+++ b/internal/dataentry/actions.go
@@ -66,7 +66,8 @@ func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	action, ok := a.Cfg().Actions[id]
+	s := a.State()
+	action, ok := s.Cfg.Actions[id]
 	if !ok {
 		writeV1Error(w, r, http.StatusNotFound, "action_not_found", "Action not found", "")
 		return
@@ -92,14 +93,14 @@ func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 	// Resolve entity if provided in the request.
 	var entity *model.Entity
 	if req.EntityID != "" {
-		if e, ok := a.Graph().GetNode(req.EntityID); ok {
+		if e, ok := s.Graph.GetNode(req.EntityID); ok {
 			entity = e
 		}
 	}
 
 	ctx := &actionScriptContext{
 		ws:          a.ws,
-		meta:        a.Meta(),
+		meta:        s.Meta,
 		projectRoot: a.ws.Paths().Root,
 		entity:      entity,
 	}

--- a/internal/dataentry/analyze.go
+++ b/internal/dataentry/analyze.go
@@ -89,19 +89,20 @@ func (a *App) analysisIssueCounts() (errors, warnings int) {
 
 // analyzeOrphans finds entities with no connections.
 func (a *App) analyzeOrphans() AnalysisSection {
+	s := a.State()
 	section := AnalysisSection{
 		Name:        "Orphans",
 		Description: "Entities with no incoming or outgoing relations",
 	}
 
-	orphans := a.Graph().FindOrphans()
+	orphans := s.Graph.FindOrphans()
 	sortEntitiesByID(orphans)
 
 	for _, e := range orphans {
 		section.Issues = append(section.Issues, AnalysisIssue{
 			EntityID:   e.ID,
 			EntityType: e.Type,
-			Title:      a.entityDisplayTitle(e),
+			Title:      s.Meta.DisplayTitle(e),
 			Message:    "No relations",
 			Severity:   "warning",
 		})
@@ -112,15 +113,16 @@ func (a *App) analyzeOrphans() AnalysisSection {
 
 // analyzeDuplicates finds entities with identical normalized titles.
 func (a *App) analyzeDuplicates() AnalysisSection {
+	s := a.State()
 	section := AnalysisSection{
 		Name:        "Duplicates",
 		Description: "Entities with identical titles",
 	}
 
-	entities := a.Graph().AllNodes()
+	entities := s.Graph.AllNodes()
 	titleGroups := make(map[string][]*model.Entity)
 	for _, e := range entities {
-		title := normalizeTitle(a.entityDisplayTitle(e))
+		title := normalizeTitle(s.Meta.DisplayTitle(e))
 		if title != "" {
 			titleGroups[title] = append(titleGroups[title], e)
 		}
@@ -146,7 +148,7 @@ func (a *App) analyzeDuplicates() AnalysisSection {
 			section.Issues = append(section.Issues, AnalysisIssue{
 				EntityID:   e.ID,
 				EntityType: e.Type,
-				Title:      a.entityDisplayTitle(e),
+				Title:      s.Meta.DisplayTitle(e),
 				Message:    fmt.Sprintf("Duplicate title (shared by %s)", strings.Join(ids, ", ")),
 				Severity:   "warning",
 			})
@@ -158,6 +160,7 @@ func (a *App) analyzeDuplicates() AnalysisSection {
 
 // analyzeGaps finds gaps in ID sequences for auto-numbered entity types.
 func (a *App) analyzeGaps() AnalysisSection {
+	s := a.State()
 	section := AnalysisSection{
 		Name:        "ID Gaps",
 		Description: "Missing numbers in auto-generated ID sequences",
@@ -165,7 +168,7 @@ func (a *App) analyzeGaps() AnalysisSection {
 
 	// Build set of manual ID prefixes to skip
 	manualPrefixes := make(map[string]bool)
-	for _, entityDef := range a.Meta().Entities {
+	for _, entityDef := range s.Meta.Entities {
 		if entityDef.IsManualID() {
 			for _, idPrefix := range entityDef.GetIDPrefixes() {
 				manualPrefixes[strings.TrimSuffix(idPrefix, "-")] = true
@@ -175,7 +178,7 @@ func (a *App) analyzeGaps() AnalysisSection {
 
 	// Group IDs by prefix
 	prefixGroups := make(map[string][]int)
-	for _, id := range a.Graph().AllIDs() {
+	for _, id := range s.Graph.AllIDs() {
 		parsed, err := model.ParseEntityID(id)
 		if err != nil || parsed.Prefix == "" {
 			continue
@@ -218,33 +221,34 @@ func (a *App) analyzeGaps() AnalysisSection {
 
 // analyzeCardinality checks relation cardinality constraints.
 func (a *App) analyzeCardinality() AnalysisSection {
+	s := a.State()
 	section := AnalysisSection{
 		Name:        "Cardinality",
 		Description: "Relation cardinality constraint violations",
 	}
 
 	// Sort relation names for deterministic output
-	relNames := make([]string, 0, len(a.Meta().Relations))
-	for name := range a.Meta().Relations {
+	relNames := make([]string, 0, len(s.Meta.Relations))
+	for name := range s.Meta.Relations {
 		relNames = append(relNames, name)
 	}
 	natsort.Strings(relNames)
 
 	for _, relName := range relNames {
-		relDef := a.Meta().Relations[relName]
+		relDef := s.Meta.Relations[relName]
 
 		// Check min_outgoing
 		if relDef.MinOutgoing != nil && *relDef.MinOutgoing > 0 {
 			for _, sourceType := range relDef.From {
-				entities := a.Graph().NodesByType(sourceType)
+				entities := s.Graph.NodesByType(sourceType)
 				sortEntitiesByID(entities)
 				for _, e := range entities {
-					count := countEdgesByType(a.Graph().OutgoingEdges(e.ID), relName)
+					count := countEdgesByType(s.Graph.OutgoingEdges(e.ID), relName)
 					if count < *relDef.MinOutgoing {
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      a.entityDisplayTitle(e),
+							Title:      s.Meta.DisplayTitle(e),
 							Message:    fmt.Sprintf("Must have at least %d '%s' relation(s), has %d", *relDef.MinOutgoing, relName, count),
 							Severity:   "error",
 						})
@@ -256,15 +260,15 @@ func (a *App) analyzeCardinality() AnalysisSection {
 		// Check max_outgoing
 		if relDef.MaxOutgoing != nil {
 			for _, sourceType := range relDef.From {
-				entities := a.Graph().NodesByType(sourceType)
+				entities := s.Graph.NodesByType(sourceType)
 				sortEntitiesByID(entities)
 				for _, e := range entities {
-					count := countEdgesByType(a.Graph().OutgoingEdges(e.ID), relName)
+					count := countEdgesByType(s.Graph.OutgoingEdges(e.ID), relName)
 					if count > *relDef.MaxOutgoing {
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      a.entityDisplayTitle(e),
+							Title:      s.Meta.DisplayTitle(e),
 							Message:    fmt.Sprintf("Has more than %d '%s' relation(s): %d", *relDef.MaxOutgoing, relName, count),
 							Severity:   "error",
 						})
@@ -276,10 +280,10 @@ func (a *App) analyzeCardinality() AnalysisSection {
 		// Check min_incoming
 		if relDef.MinIncoming != nil && *relDef.MinIncoming > 0 {
 			for _, targetType := range relDef.To {
-				entities := a.Graph().NodesByType(targetType)
+				entities := s.Graph.NodesByType(targetType)
 				sortEntitiesByID(entities)
 				for _, e := range entities {
-					count := countEdgesByType(a.Graph().IncomingEdges(e.ID), relName)
+					count := countEdgesByType(s.Graph.IncomingEdges(e.ID), relName)
 					if count < *relDef.MinIncoming {
 						relLabel := relName
 						if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
@@ -288,7 +292,7 @@ func (a *App) analyzeCardinality() AnalysisSection {
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      a.entityDisplayTitle(e),
+							Title:      s.Meta.DisplayTitle(e),
 							Message:    fmt.Sprintf("Must have at least %d '%s' relation(s), has %d", *relDef.MinIncoming, relLabel, count),
 							Severity:   "error",
 						})
@@ -300,10 +304,10 @@ func (a *App) analyzeCardinality() AnalysisSection {
 		// Check max_incoming
 		if relDef.MaxIncoming != nil {
 			for _, targetType := range relDef.To {
-				entities := a.Graph().NodesByType(targetType)
+				entities := s.Graph.NodesByType(targetType)
 				sortEntitiesByID(entities)
 				for _, e := range entities {
-					count := countEdgesByType(a.Graph().IncomingEdges(e.ID), relName)
+					count := countEdgesByType(s.Graph.IncomingEdges(e.ID), relName)
 					if count > *relDef.MaxIncoming {
 						relLabel := relName
 						if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
@@ -312,7 +316,7 @@ func (a *App) analyzeCardinality() AnalysisSection {
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      a.entityDisplayTitle(e),
+							Title:      s.Meta.DisplayTitle(e),
 							Message:    fmt.Sprintf("Has more than %d '%s' relation(s): %d", *relDef.MaxIncoming, relLabel, count),
 							Severity:   "error",
 						})
@@ -327,21 +331,22 @@ func (a *App) analyzeCardinality() AnalysisSection {
 
 // analyzeProperties validates all entity properties against the metamodel.
 func (a *App) analyzeProperties() AnalysisSection {
+	s := a.State()
 	section := AnalysisSection{
 		Name:        "Properties",
 		Description: "Property validation errors (required fields, invalid values, ID patterns)",
 	}
 
-	entities := a.Graph().AllNodes()
+	entities := s.Graph.AllNodes()
 	sortEntitiesByID(entities)
 
 	for _, entity := range entities {
-		errs := a.Meta().ValidateEntity(entity)
+		errs := s.Meta.ValidateEntity(entity)
 		for _, err := range errs {
 			section.Issues = append(section.Issues, AnalysisIssue{
 				EntityID:   entity.ID,
 				EntityType: entity.Type,
-				Title:      a.entityDisplayTitle(entity),
+				Title:      s.Meta.DisplayTitle(entity),
 				Message:    err.Error(),
 				Severity:   "error",
 			})
@@ -353,19 +358,20 @@ func (a *App) analyzeProperties() AnalysisSection {
 
 // analyzeValidations runs custom validation rules from the metamodel.
 func (a *App) analyzeValidations() AnalysisSection {
+	s := a.State()
 	section := AnalysisSection{
 		Name:        "Validations",
 		Description: "Custom validation rules defined in the metamodel",
 	}
 
-	for _, rule := range a.Meta().Validations {
-		violations := a.checkValidationRule(rule)
+	for _, rule := range s.Meta.Validations {
+		violations := a.checkValidationRule(s, rule)
 		severity := rule.GetSeverity()
 		for _, e := range violations {
 			section.Issues = append(section.Issues, AnalysisIssue{
 				EntityID:   e.ID,
 				EntityType: e.Type,
-				Title:      a.entityDisplayTitle(e),
+				Title:      s.Meta.DisplayTitle(e),
 				Message:    rule.Description,
 				Severity:   severity,
 			})
@@ -376,14 +382,14 @@ func (a *App) analyzeValidations() AnalysisSection {
 }
 
 // checkValidationRule checks a single validation rule against applicable entities.
-func (a *App) checkValidationRule(rule metamodel.ValidationRule) []*model.Entity {
+func (a *App) checkValidationRule(s *AppState, rule metamodel.ValidationRule) []*model.Entity {
 	var entities []*model.Entity
 	if rule.EntityType != "" {
-		entities = a.Graph().NodesByType(rule.EntityType)
+		entities = s.Graph.NodesByType(rule.EntityType)
 	} else {
-		entities = a.Graph().AllNodes()
+		entities = s.Graph.AllNodes()
 	}
-	return workspace.CheckValidationRule(a.Meta(), rule, entities)
+	return workspace.CheckValidationRule(s.Meta, rule, entities)
 }
 
 // countEdgesByType counts relations of a specific type in a slice.

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -89,7 +89,7 @@ type V1PropertyDef struct {
 	List        bool     `json:"list,omitempty"`
 }
 
-func (a *App) toV1PropertyDef(propDef metamodel.PropertyDef) V1PropertyDef {
+func (a *App) toV1PropertyDef(meta *metamodel.Metamodel, propDef metamodel.PropertyDef) V1PropertyDef {
 	pd := V1PropertyDef{
 		Type:        propDef.Type,
 		Required:    propDef.Required,
@@ -97,7 +97,7 @@ func (a *App) toV1PropertyDef(propDef metamodel.PropertyDef) V1PropertyDef {
 		Description: propDef.Description,
 		List:        propDef.List,
 	}
-	if ct, ok := a.Meta().Types[propDef.Type]; ok {
+	if ct, ok := meta.Types[propDef.Type]; ok {
 		pd.Values = ct.Values
 	} else if len(propDef.Values) > 0 {
 		pd.Values = propDef.Values
@@ -221,7 +221,7 @@ func (a *App) handleV1DynamicRoutes(w http.ResponseWriter, r *http.Request) {
 
 	// Find entity type by plural
 	var typeName string
-	for name, def := range a.Meta().Entities {
+	for name, def := range a.State().Meta.Entities {
 		if def.GetDirPlural(name) == plural {
 			typeName = name
 			break
@@ -286,7 +286,7 @@ func (a *App) handleV1EntityCollection(w http.ResponseWriter, r *http.Request, t
 }
 
 func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeName, plural string) {
-	entities := a.Graph().NodesByType(typeName)
+	entities := a.State().Graph.NodesByType(typeName)
 
 	// Apply filters
 	query := r.URL.Query()
@@ -420,7 +420,7 @@ func (a *App) handleV1SingleEntity(w http.ResponseWriter, r *http.Request, typeN
 }
 
 func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName, plural, entityID string) {
-	entity, found := a.Graph().GetNode(entityID)
+	entity, found := a.State().Graph.GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -455,7 +455,7 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
-	entity, found := a.Graph().GetNode(entityID)
+	entity, found := a.State().Graph.GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -514,7 +514,7 @@ func (a *App) handleV1DeleteEntity(w http.ResponseWriter, r *http.Request, typeN
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
-	entity, found := a.Graph().GetNode(entityID)
+	entity, found := a.State().Graph.GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -534,14 +534,15 @@ func (a *App) handleV1DeleteEntity(w http.ResponseWriter, r *http.Request, typeN
 // --- Relation Handlers ---
 
 func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, typeName, entityID string) {
-	entity, found := a.Graph().GetNode(entityID)
+	s := a.State()
+	entity, found := s.Graph.GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
 	}
 
-	outgoing := a.Graph().OutgoingEdges(entityID)
-	incoming := a.Graph().IncomingEdges(entityID)
+	outgoing := s.Graph.OutgoingEdges(entityID)
+	incoming := s.Graph.IncomingEdges(entityID)
 
 	relations := make(map[string][]map[string]interface{})
 
@@ -557,7 +558,7 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 	}
 
 	for _, edge := range incoming {
-		relDef, ok := a.Meta().Relations[edge.Type]
+		relDef, ok := s.Meta.Relations[edge.Type]
 		if !ok {
 			continue
 		}
@@ -599,7 +600,8 @@ func resolveRelationEndpoints(entityID, peerID, direction string) (from, to stri
 }
 
 func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, typeName, entityID, relType string) {
-	entity, found := a.Graph().GetNode(entityID)
+	s := a.State()
+	entity, found := s.Graph.GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -609,9 +611,9 @@ func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, ty
 
 	var edges []*model.Relation
 	if incoming {
-		edges = a.Graph().IncomingEdges(entityID)
+		edges = s.Graph.IncomingEdges(entityID)
 	} else {
-		edges = a.Graph().OutgoingEdges(entityID)
+		edges = s.Graph.OutgoingEdges(entityID)
 	}
 
 	relations := make([]map[string]interface{}, 0, len(edges))
@@ -641,7 +643,7 @@ func (a *App) handleV1CreateRelation(w http.ResponseWriter, r *http.Request, typ
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
-	entity, found := a.Graph().GetNode(entityID)
+	entity, found := a.State().Graph.GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -695,7 +697,7 @@ func (a *App) handleV1UpdateRelation(w http.ResponseWriter, r *http.Request, typ
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
-	entity, found := a.Graph().GetNode(entityID)
+	entity, found := a.State().Graph.GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -737,7 +739,7 @@ func (a *App) handleV1DeleteRelation(w http.ResponseWriter, r *http.Request, typ
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
-	entity, found := a.Graph().GetNode(entityID)
+	entity, found := a.State().Graph.GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -774,7 +776,8 @@ func (a *App) handleV1CloneEntity(w http.ResponseWriter, r *http.Request, typeNa
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
-	entity, found := a.Graph().GetNode(entityID)
+	s := a.State()
+	entity, found := s.Graph.GetNode(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -795,7 +798,7 @@ func (a *App) handleV1CloneEntity(w http.ResponseWriter, r *http.Request, typeNa
 		return
 	}
 
-	entityDef := a.Meta().Entities[typeName]
+	entityDef := s.Meta.Entities[typeName]
 	plural := entityDef.GetDirPlural(typeName)
 	result := a.entityToV1(newEntity, plural, false, false)
 
@@ -811,13 +814,14 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s := a.State()
 	schema := V1Schema{
 		Entities:  make(map[string]V1EntityType),
 		Relations: make(map[string]V1RelationType),
 		Types:     make(map[string]V1CustomType),
 	}
 
-	for name, def := range a.Meta().Entities {
+	for name, def := range s.Meta.Entities {
 		et := V1EntityType{
 			Label:       def.Label,
 			Plural:      def.GetDirPlural(name),
@@ -830,12 +834,12 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 			et.IDPrefix = def.GetIDPrefixes()[0]
 		}
 		for propName, propDef := range def.Properties {
-			et.Properties[propName] = a.toV1PropertyDef(propDef)
+			et.Properties[propName] = a.toV1PropertyDef(s.Meta, propDef)
 		}
 		schema.Entities[name] = et
 	}
 
-	for name, def := range a.Meta().Relations {
+	for name, def := range s.Meta.Relations {
 		rt := V1RelationType{
 			Label:       def.Label,
 			Description: def.Description,
@@ -849,13 +853,13 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 		if len(def.Properties) > 0 {
 			rt.Properties = make(map[string]V1PropertyDef, len(def.Properties))
 			for propName, propDef := range def.Properties {
-				rt.Properties[propName] = a.toV1PropertyDef(propDef)
+				rt.Properties[propName] = a.toV1PropertyDef(s.Meta, propDef)
 			}
 		}
 		schema.Relations[name] = rt
 	}
 
-	for name, def := range a.Meta().Types {
+	for name, def := range s.Meta.Types {
 		schema.Types[name] = V1CustomType{
 			Values:  def.Values,
 			Default: def.Default,
@@ -866,13 +870,14 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleV1SchemaRoutes(w http.ResponseWriter, r *http.Request) {
+	s := a.State()
 	path := strings.TrimPrefix(r.URL.Path, "/api/v1/_schema/")
 
 	switch {
 	case path == "types":
 		// List entity type names
-		names := make([]string, 0, len(a.Meta().Entities))
-		for name := range a.Meta().Entities {
+		names := make([]string, 0, len(s.Meta.Entities))
+		for name := range s.Meta.Entities {
 			names = append(names, name)
 		}
 		sort.Strings(names)
@@ -881,7 +886,7 @@ func (a *App) handleV1SchemaRoutes(w http.ResponseWriter, r *http.Request) {
 	case strings.HasPrefix(path, "types/"):
 		// Get specific entity type
 		typeName := strings.TrimPrefix(path, "types/")
-		def, ok := a.Meta().Entities[typeName]
+		def, ok := s.Meta.Entities[typeName]
 		if !ok {
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity type not found", "")
 			return
@@ -900,7 +905,7 @@ func (a *App) handleV1SchemaRoutes(w http.ResponseWriter, r *http.Request) {
 				Required: propDef.Required,
 				Default:  propDef.Default,
 			}
-			if ct, ok := a.Meta().Types[propDef.Type]; ok {
+			if ct, ok := s.Meta.Types[propDef.Type]; ok {
 				pd.Values = ct.Values
 			}
 			et.Properties[propName] = pd
@@ -908,7 +913,7 @@ func (a *App) handleV1SchemaRoutes(w http.ResponseWriter, r *http.Request) {
 		writeV1JSON(w, http.StatusOK, et)
 
 	case path == "relations":
-		writeV1JSON(w, http.StatusOK, a.Meta().Relations)
+		writeV1JSON(w, http.StatusOK, s.Meta.Relations)
 
 	default:
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Resource not found", "")
@@ -919,15 +924,17 @@ func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
 		return
-	} // Resolve relation widgets: auto-detect "cards" for relations with properties/content
-	forms := make(map[string]dataentryconfig.Form, len(a.Cfg().Forms))
-	for id, form := range a.Cfg().Forms {
+	}
+	s := a.State()
+	// Resolve relation widgets: auto-detect "cards" for relations with properties/content
+	forms := make(map[string]dataentryconfig.Form, len(s.Cfg.Forms))
+	for id, form := range s.Cfg.Forms {
 		f := form
 		resolved := make([]dataentryconfig.FormRelation, len(f.Relations))
 		copy(resolved, f.Relations)
 		for i := range resolved {
 			if resolved[i].Widget == "" {
-				if def, ok := a.Meta().GetRelationDef(resolved[i].Relation); ok && def.HasAdvancedFeatures() {
+				if def, ok := s.Meta.GetRelationDef(resolved[i].Relation); ok && def.HasAdvancedFeatures() {
 					resolved[i].Widget = WidgetCards
 				}
 			}
@@ -938,19 +945,19 @@ func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
 
 	config := V1Config{
 		App: V1AppConfig{
-			Name:        a.Cfg().App.Name,
-			Description: a.Cfg().App.Description,
+			Name:        s.Cfg.App.Name,
+			Description: s.Cfg.App.Description,
 		},
-		Styles:     a.State().StyleMap,
+		Styles:     s.StyleMap,
 		Forms:      forms,
-		Lists:      a.Cfg().Lists,
-		Views:      a.Cfg().Views,
-		Kanbans:    a.Cfg().Kanbans,
-		Dashboard:  a.Cfg().Dashboard,
-		Actions:    a.Cfg().Actions,
-		Navigation: a.Cfg().Navigation,
-		Documents:  a.Cfg().Documents,
-		Palette:    a.State().Palette,
+		Lists:      s.Cfg.Lists,
+		Views:      s.Cfg.Views,
+		Kanbans:    s.Cfg.Kanbans,
+		Dashboard:  s.Cfg.Dashboard,
+		Actions:    s.Cfg.Actions,
+		Navigation: s.Cfg.Navigation,
+		Documents:  s.Cfg.Documents,
+		Palette:    s.Palette,
 	}
 
 	writeV1JSON(w, http.StatusOK, config)
@@ -981,9 +988,10 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 		entities = filtered
 	}
 
+	meta := a.State().Meta
 	data := make([]V1Entity, 0, len(entities))
 	for _, e := range entities {
-		entityDef := a.Meta().Entities[e.Type]
+		entityDef := meta.Entities[e.Type]
 		plural := entityDef.GetDirPlural(e.Type)
 		data = append(data, a.entityToV1(e, plural, false, false))
 	}
@@ -1034,10 +1042,11 @@ func (a *App) handleV1Analyze(w http.ResponseWriter, r *http.Request) {
 // --- Helper Functions ---
 
 func (a *App) entityToV1(e *model.Entity, plural string, includeRelations, includeActions bool) V1Entity {
+	s := a.State()
 	v1 := V1Entity{
 		ID:         e.ID,
 		Type:       e.Type,
-		Title:      a.entityDisplayTitle(e),
+		Title:      s.Meta.DisplayTitle(e),
 		Properties: make(map[string]interface{}),
 		Content:    e.Content,
 		Self:       fmt.Sprintf("/api/v1/%s/%s", plural, e.ID),
@@ -1049,19 +1058,19 @@ func (a *App) entityToV1(e *model.Entity, plural string, includeRelations, inclu
 
 	if includeRelations {
 		v1.Relations = make(map[string][]string)
-		for _, edge := range a.Graph().OutgoingEdges(e.ID) {
+		for _, edge := range s.Graph.OutgoingEdges(e.ID) {
 			v1.Relations[edge.Type] = append(v1.Relations[edge.Type], edge.To)
 		}
 	}
 
 	if includeActions {
-		v1.Actions = a.computeEntityActions(e)
+		v1.Actions = a.computeEntityActions(s, e)
 	}
 
 	return v1
 }
 
-func (a *App) computeEntityActions(e *model.Entity) *V1Actions {
+func (a *App) computeEntityActions(s *AppState, e *model.Entity) *V1Actions {
 	actions := &V1Actions{}
 
 	// Delete is always allowed; cascade removes associated relations.
@@ -1069,9 +1078,9 @@ func (a *App) computeEntityActions(e *model.Entity) *V1Actions {
 
 	// Get valid status transitions
 	if status, ok := e.Properties["status"].(string); ok {
-		entityDef := a.Meta().Entities[e.Type]
+		entityDef := s.Meta.Entities[e.Type]
 		if statusProp, ok := entityDef.Properties["status"]; ok {
-			if ct, ok := a.Meta().Types[statusProp.Type]; ok {
+			if ct, ok := s.Meta.Types[statusProp.Type]; ok {
 				actions.Transitions = ct.Values
 			} else if len(statusProp.Values) > 0 {
 				actions.Transitions = statusProp.Values
@@ -1091,27 +1100,28 @@ func (a *App) computeEntityActions(e *model.Entity) *V1Actions {
 }
 
 func (a *App) resolveV1Includes(entity *model.Entity, includes string) map[string]V1Entity {
+	s := a.State()
 	included := make(map[string]V1Entity)
 
 	// Support include=* to include all related entities
 	if includes == "*" {
 		// Include all outgoing relations
-		for _, edge := range a.Graph().OutgoingEdges(entity.ID) {
-			target, found := a.Graph().GetNode(edge.To)
+		for _, edge := range s.Graph.OutgoingEdges(entity.ID) {
+			target, found := s.Graph.GetNode(edge.To)
 			if !found {
 				continue
 			}
-			entityDef := a.Meta().Entities[target.Type]
+			entityDef := s.Meta.Entities[target.Type]
 			plural := entityDef.GetDirPlural(target.Type)
 			included[target.ID] = a.entityToV1(target, plural, false, false)
 		}
 		// Include all incoming relations
-		for _, edge := range a.Graph().IncomingEdges(entity.ID) {
-			source, found := a.Graph().GetNode(edge.From)
+		for _, edge := range s.Graph.IncomingEdges(entity.ID) {
+			source, found := s.Graph.GetNode(edge.From)
 			if !found {
 				continue
 			}
-			entityDef := a.Meta().Entities[source.Type]
+			entityDef := s.Meta.Entities[source.Type]
 			plural := entityDef.GetDirPlural(source.Type)
 			included[source.ID] = a.entityToV1(source, plural, false, false)
 		}
@@ -1129,15 +1139,15 @@ func (a *App) resolveV1Includes(entity *model.Entity, includes string) map[strin
 		relParts := strings.SplitN(part, ".", 2)
 		relType := relParts[0]
 
-		for _, edge := range a.Graph().OutgoingEdges(entity.ID) {
+		for _, edge := range s.Graph.OutgoingEdges(entity.ID) {
 			if edge.Type != relType {
 				continue
 			}
-			target, found := a.Graph().GetNode(edge.To)
+			target, found := s.Graph.GetNode(edge.To)
 			if !found {
 				continue
 			}
-			entityDef := a.Meta().Entities[target.Type]
+			entityDef := s.Meta.Entities[target.Type]
 			plural := entityDef.GetDirPlural(target.Type)
 			included[target.ID] = a.entityToV1(target, plural, false, false)
 
@@ -1466,7 +1476,8 @@ func (a *App) handleV1SidePanel(w http.ResponseWriter, r *http.Request) {
 
 	formID := parts[0]
 	entityID := parts[1] // Get form config
-	form, ok := a.Cfg().Forms[formID]
+	s := a.State()
+	form, ok := s.Cfg.Forms[formID]
 	if !ok {
 		writeV1Error(w, r, http.StatusNotFound, "form_not_found", "Form not found", "")
 		return
@@ -1479,7 +1490,7 @@ func (a *App) handleV1SidePanel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the entry entity
-	entry, found := a.Graph().GetNode(entityID)
+	entry, found := s.Graph.GetNode(entityID)
 	if !found {
 		writeV1Error(w, r, http.StatusNotFound, "entity_not_found", "Entity not found", "")
 		return
@@ -1587,16 +1598,18 @@ func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
 		return
-	} // Build entity type counts
+	}
+	s := a.State()
+	// Build entity type counts
 	counts := make(map[string]int)
-	for _, entityType := range a.Meta().EntityTypes() {
-		counts[entityType] = len(a.Graph().NodesByType(entityType))
+	for _, entityType := range s.Meta.EntityTypes() {
+		counts[entityType] = len(s.Graph.NodesByType(entityType))
 	}
 
 	// Build navigation with counts
 	navigation := make([]V1SidebarGroup, 0)
 
-	for _, entry := range a.Cfg().Navigation {
+	for _, entry := range s.Cfg.Navigation {
 		if entry.IsGroup() {
 			group := V1SidebarGroup{
 				Group:     entry.Group,
@@ -1619,8 +1632,8 @@ func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 
 	resp := V1SidebarResponse{
 		App: V1AppConfig{
-			Name:        a.Cfg().App.Name,
-			Description: a.Cfg().App.Description,
+			Name:        s.Cfg.App.Name,
+			Description: s.Cfg.App.Description,
 		},
 		Navigation: navigation,
 	}
@@ -1630,6 +1643,7 @@ func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 
 // navEntryToSidebarItem converts a navigation entry to a sidebar item with count.
 func (a *App) navEntryToSidebarItem(entry dataentryconfig.NavigationEntry, counts map[string]int) V1SidebarItem {
+	s := a.State()
 	item := V1SidebarItem{
 		Label: entry.Label,
 	}
@@ -1639,7 +1653,7 @@ func (a *App) navEntryToSidebarItem(entry dataentryconfig.NavigationEntry, count
 		item.Href = "/list/" + entry.List
 		item.Icon = "list"
 		// Look up entity type from list config
-		if list, ok := a.Cfg().Lists[entry.List]; ok {
+		if list, ok := s.Cfg.Lists[entry.List]; ok {
 			if count, ok := counts[list.EntityType]; ok {
 				item.Count = &count
 			}
@@ -1648,7 +1662,7 @@ func (a *App) navEntryToSidebarItem(entry dataentryconfig.NavigationEntry, count
 		item.Href = "/kanban/" + entry.Kanban
 		item.Icon = "kanban"
 		// Look up entity type from kanban config
-		if kanban, ok := a.Cfg().Kanbans[entry.Kanban]; ok {
+		if kanban, ok := s.Cfg.Kanbans[entry.Kanban]; ok {
 			if count, ok := counts[kanban.EntityType]; ok {
 				item.Count = &count
 			}
@@ -1770,7 +1784,7 @@ func (a *App) handleV1ConflictRoutes(w http.ResponseWriter, r *http.Request) {
 	ctx := a.ws.Paths()
 	absPath := filepath.Join(ctx.Root, path)
 
-	cf, err := conflict.ParseConflictedFile(absPath, a.Meta())
+	cf, err := conflict.ParseConflictedFile(absPath, a.State().Meta)
 	if err != nil {
 		writeV1Error(w, r, http.StatusInternalServerError, "parse_failed", "Failed to parse conflict", err.Error())
 		return
@@ -1817,7 +1831,7 @@ func (a *App) handleV1ConflictResolve(w http.ResponseWriter, r *http.Request) {
 	ctx := a.ws.Paths()
 	absPath := filepath.Join(ctx.Root, req.Path)
 
-	cf, err := conflict.ParseConflictedFile(absPath, a.Meta())
+	cf, err := conflict.ParseConflictedFile(absPath, a.State().Meta)
 	if err != nil {
 		writeV1Error(w, r, http.StatusInternalServerError, "parse_failed", "Failed to parse conflict", err.Error())
 		return
@@ -1846,7 +1860,7 @@ func (a *App) handleV1ConflictResolve(w http.ResponseWriter, r *http.Request) {
 		resolution.ContentChoice = conflict.SideOurs
 	}
 
-	if err := conflict.ResolveAndWrite(cf, resolution, a.Meta()); err != nil {
+	if err := conflict.ResolveAndWrite(cf, resolution, a.State().Meta); err != nil {
 		writeV1Error(w, r, http.StatusInternalServerError, "resolve_failed", "Failed to resolve", err.Error())
 		return
 	}
@@ -1891,7 +1905,7 @@ func (a *App) handleV1Documents(w http.ResponseWriter, r *http.Request) {
 		writeV1Error(w, r, http.StatusBadRequest, "invalid_path", "Path segment contains forbidden characters", "")
 		return
 	} // Get document config
-	docCfg, ok := a.Cfg().Documents[docName]
+	docCfg, ok := a.State().Cfg.Documents[docName]
 	if !ok {
 		writeV1Error(w, r, http.StatusNotFound, "document_not_found", "Document config not found", "")
 		return
@@ -2008,7 +2022,7 @@ func (a *App) handleV1Templates(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if entity type exists
-	if _, ok := a.Meta().Entities[entityType]; !ok {
+	if _, ok := a.State().Meta.Entities[entityType]; !ok {
 		writeV1Error(w, r, http.StatusNotFound, "entity_type_not_found",
 			fmt.Sprintf("Entity type '%s' not found", entityType), "")
 		return
@@ -2168,7 +2182,8 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 	}
 
 	viewID, entityID := parts[0], parts[1] // Get view config
-	viewCfg, ok := a.Cfg().Views[viewID]
+	s := a.State()
+	viewCfg, ok := s.Cfg.Views[viewID]
 	if !ok {
 		writeV1Error(w, r, http.StatusNotFound, "view_not_found", "View not found", "")
 		return
@@ -2188,7 +2203,7 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 	a.resolveSectionButtonsWithTraverse(viewCfg, sections, result.Entry)
 
 	// Build response
-	entityDef := a.Meta().Entities[result.Entry.Type]
+	entityDef := s.Meta.Entities[result.Entry.Type]
 	plural := entityDef.GetDirPlural(result.Entry.Type)
 
 	resp := V1ViewResponse{

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -268,9 +268,10 @@ func (a *App) enrichNavEntry(nav NavigationEntry) NavItem {
 	if nav.Dashboard || nav.Graph || nav.Kanban != "" {
 		return item
 	}
-	if list, ok := a.Cfg().Lists[nav.List]; ok {
+	s := a.State()
+	if list, ok := s.Cfg.Lists[nav.List]; ok {
 		item.EntityType = list.EntityType
-		entities := a.Graph().NodesByType(list.EntityType)
+		entities := s.Graph.NodesByType(list.EntityType)
 		entities = applyFilters(entities, list.Filters)
 		item.Count = len(entities)
 	}
@@ -281,8 +282,9 @@ func (a *App) enrichNavEntry(nav NavigationEntry) NavItem {
 // The activeList parameter is used to auto-expand the group containing the active item.
 func (a *App) navElements(activeList string) []NavElement {
 	uiState := a.loadUIState()
-	elements := make([]NavElement, 0, len(a.Cfg().Navigation))
-	for _, nav := range a.Cfg().Navigation {
+	cfgNav := a.State().Cfg.Navigation
+	elements := make([]NavElement, 0, len(cfgNav))
+	for _, nav := range cfgNav {
 		if nav.IsGroup() {
 			grp := NavGroup{Group: nav.Group}
 			// Determine collapsed state: UIState overrides config default
@@ -430,21 +432,22 @@ func firstNavTarget(nav []NavigationEntry) *NavigationEntry {
 // editFormForType returns the first edit form ID configured for the given entity type,
 // or "" if no edit form is found. Forms with explicit mode="edit" are preferred.
 func (a *App) editFormForType(entityType string) string {
-	ids := make([]string, 0, len(a.Cfg().Forms))
-	for id := range a.Cfg().Forms {
+	s := a.State()
+	ids := make([]string, 0, len(s.Cfg.Forms))
+	for id := range s.Cfg.Forms {
 		ids = append(ids, id)
 	}
 	natsort.Strings(ids)
 	// First pass: look for explicit edit mode
 	for _, id := range ids {
-		f := a.Cfg().Forms[id]
+		f := s.Cfg.Forms[id]
 		if f.EntityType == entityType && f.Mode == "edit" {
 			return id
 		}
 	}
 	// Second pass: fall back to forms with no mode specified
 	for _, id := range ids {
-		f := a.Cfg().Forms[id]
+		f := s.Cfg.Forms[id]
 		if f.EntityType == entityType && f.Mode == "" {
 			return id
 		}
@@ -456,14 +459,15 @@ func (a *App) editFormForType(entityType string) string {
 // of the given type. It prefers forms with mode "create" or unset, but falls back
 // to edit-mode forms (which work for creation when no entity ID is provided).
 func (a *App) createFormForType(entityType string) string {
-	ids := make([]string, 0, len(a.Cfg().Forms))
-	for id := range a.Cfg().Forms {
+	s := a.State()
+	ids := make([]string, 0, len(s.Cfg.Forms))
+	for id := range s.Cfg.Forms {
 		ids = append(ids, id)
 	}
 	natsort.Strings(ids)
 	fallback := ""
 	for _, id := range ids {
-		f := a.Cfg().Forms[id]
+		f := s.Cfg.Forms[id]
 		if f.EntityType != entityType {
 			continue
 		}
@@ -479,7 +483,7 @@ func (a *App) createFormForType(entityType string) string {
 
 // entityDisplayTitle returns the display title for an entity.
 func (a *App) entityDisplayTitle(e *model.Entity) string {
-	return a.Meta().DisplayTitle(e)
+	return a.State().Meta.DisplayTitle(e)
 }
 
 // resolveLinkTarget resolves a link configuration value to a URL.
@@ -504,18 +508,19 @@ func (a *App) resolveLinkTarget(link, entityType, entityID string) string {
 // activeListForEntityType returns the first navigation list ID whose entity type
 // matches the given type, or "" if none match. Walks into groups.
 func (a *App) activeListForEntityType(entityType string) string {
-	return a.findListByEntityType(a.Cfg().Navigation, entityType)
+	s := a.State()
+	return a.findListByEntityType(s, s.Cfg.Navigation, entityType)
 }
 
-func (a *App) findListByEntityType(entries []NavigationEntry, entityType string) string {
+func (a *App) findListByEntityType(s *AppState, entries []NavigationEntry, entityType string) string {
 	for _, nav := range entries {
 		if nav.IsGroup() {
-			if found := a.findListByEntityType(nav.Items, entityType); found != "" {
+			if found := a.findListByEntityType(s, nav.Items, entityType); found != "" {
 				return found
 			}
 			continue
 		}
-		if list, ok := a.Cfg().Lists[nav.List]; ok && list.EntityType == entityType {
+		if list, ok := s.Cfg.Lists[nav.List]; ok && list.EntityType == entityType {
 			return nav.List
 		}
 	}
@@ -539,7 +544,7 @@ func (a *App) activeListFromReferer(r *http.Request) string {
 		return ""
 	}
 	listID := strings.TrimPrefix(path, "/list/")
-	if _, ok := a.Cfg().Lists[listID]; ok {
+	if _, ok := a.State().Cfg.Lists[listID]; ok {
 		return listID
 	}
 	return ""
@@ -551,7 +556,7 @@ func (a *App) activeListFromReferer(r *http.Request) string {
 // Referer header.
 func (a *App) resolveActiveList(entityType string, r *http.Request) string {
 	if from := r.URL.Query().Get("from"); from != "" {
-		if _, ok := a.Cfg().Lists[from]; ok {
+		if _, ok := a.State().Cfg.Lists[from]; ok {
 			return from
 		}
 	}
@@ -563,7 +568,7 @@ func (a *App) resolveActiveList(entityType string, r *http.Request) string {
 
 // ProjectName returns the display name of the loaded project.
 func (a *App) ProjectName() string {
-	return a.Cfg().App.Name
+	return a.State().Cfg.App.Name
 }
 
 // ProjectRoot returns the root directory of the loaded project.

--- a/internal/dataentry/commands.go
+++ b/internal/dataentry/commands.go
@@ -37,20 +37,21 @@ type ResolvedCommand struct {
 // qualifier is the specific list ID or view ID.
 // entityType is the entity type shown on the page (empty for dashboard).
 func (a *App) resolveCommands(pageType, qualifier, entityType string) []ResolvedCommand {
-	if len(a.Cfg().Commands) == 0 {
+	s := a.State()
+	if len(s.Cfg.Commands) == 0 {
 		return nil
 	}
 
 	// Sort command IDs for deterministic order.
-	ids := make([]string, 0, len(a.Cfg().Commands))
-	for id := range a.Cfg().Commands {
+	ids := make([]string, 0, len(s.Cfg.Commands))
+	for id := range s.Cfg.Commands {
 		ids = append(ids, id)
 	}
 	natsort.Strings(ids)
 
 	var result []ResolvedCommand
 	for _, id := range ids {
-		cmd := a.Cfg().Commands[id]
+		cmd := s.Cfg.Commands[id]
 		if matchesPage(cmd, pageType, qualifier, entityType) {
 			result = append(result, ResolvedCommand{
 				ID:       id,
@@ -144,9 +145,10 @@ type commandProjectInfo struct {
 }
 
 func (a *App) buildEntityInput(entity *model.Entity) *commandInput {
+	s := a.State()
 	// Collect all relations involving this entity.
-	outgoing := a.Graph().OutgoingEdges(entity.ID)
-	incoming := a.Graph().IncomingEdges(entity.ID)
+	outgoing := s.Graph.OutgoingEdges(entity.ID)
+	incoming := s.Graph.IncomingEdges(entity.ID)
 	rels := make([]*model.Relation, 0, len(outgoing)+len(incoming))
 	rels = append(rels, outgoing...)
 	rels = append(rels, incoming...)
@@ -177,9 +179,10 @@ func (a *App) buildViewInput(viewID string, vr *viewResult) *commandInput {
 	}
 
 	// Gather relations between entities in the result set.
+	g := a.State().Graph
 	var rels []*model.Relation
 	for id := range idSet {
-		for _, e := range a.Graph().OutgoingEdges(id) {
+		for _, e := range g.OutgoingEdges(id) {
 			if idSet[e.To] {
 				rels = append(rels, e)
 			}
@@ -263,7 +266,8 @@ func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 	}
 
 	commandID := strings.TrimPrefix(r.URL.Path, "/api/command/")
-	cmd, ok := a.Cfg().Commands[commandID]
+	s := a.State()
+	cmd, ok := s.Cfg.Commands[commandID]
 	if !ok {
 		http.Error(w, "Unknown command: "+commandID, http.StatusNotFound)
 		return
@@ -279,7 +283,7 @@ func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 	switch cmd.Context {
 	case "entity":
 		entityID := r.URL.Query().Get("entity_id")
-		entity, found := a.Graph().GetNode(entityID)
+		entity, found := s.Graph.GetNode(entityID)
 		if !found {
 			http.Error(w, "Entity not found: "+entityID, http.StatusNotFound)
 			return
@@ -287,18 +291,18 @@ func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 		input = a.buildEntityInput(entity)
 	case "list":
 		listID := r.URL.Query().Get("list_id")
-		listCfg, found := a.Cfg().Lists[listID]
+		listCfg, found := s.Cfg.Lists[listID]
 		if !found {
 			http.Error(w, "List not found: "+listID, http.StatusNotFound)
 			return
 		}
-		entities := a.Graph().NodesByType(listCfg.EntityType)
+		entities := s.Graph.NodesByType(listCfg.EntityType)
 		entities = applyFilters(entities, listCfg.Filters)
 		input = a.buildListInput(listID, entities)
 	case "view":
 		viewID := r.URL.Query().Get("view_id")
 		entityID := r.URL.Query().Get("entity_id")
-		viewCfg, found := a.Cfg().Views[viewID]
+		viewCfg, found := s.Cfg.Views[viewID]
 		if !found {
 			http.Error(w, "View not found: "+viewID, http.StatusNotFound)
 			return

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
 // PropertyHelp holds documentation for a single property.
@@ -48,7 +50,7 @@ func (a *App) handleToggleCheckbox(w http.ResponseWriter, r *http.Request) {
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
-	live, ok := a.Graph().GetNode(entityID)
+	live, ok := a.State().Graph.GetNode(entityID)
 	if !ok {
 		http.Error(w, "Entity not found", http.StatusNotFound)
 		return
@@ -83,7 +85,8 @@ func (a *App) handleEntityHelp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entDef, ok := a.Meta().GetEntityDef(entityType)
+	s := a.State()
+	entDef, ok := s.Meta.GetEntityDef(entityType)
 	if !ok {
 		http.NotFound(w, r)
 		return
@@ -106,8 +109,8 @@ func (a *App) handleEntityHelp(w http.ResponseWriter, r *http.Request) {
 	sort.Slice(props, func(i, j int) bool { return props[i].Name < props[j].Name })
 
 	// Gather outgoing and incoming relations
-	outgoingRels := a.gatherRelations(entityType, true)
-	incomingRels := a.gatherRelations(entityType, false)
+	outgoingRels := a.gatherRelations(s.Meta, entityType, true)
+	incomingRels := a.gatherRelations(s.Meta, entityType, false)
 
 	// Render entity description
 	var entityDesc htmltemplate.HTML
@@ -183,9 +186,9 @@ func (a *App) renderHelpContent(w http.ResponseWriter, entityDesc htmltemplate.H
 // gatherRelations collects relation documentation for an entity type.
 // If outgoing is true, gathers relations where entityType is in "from";
 // otherwise gathers relations where entityType is in "to".
-func (a *App) gatherRelations(entityType string, outgoing bool) []RelationHelp {
-	rels := make([]RelationHelp, 0, len(a.Meta().Relations))
-	for name, rel := range a.Meta().Relations {
+func (a *App) gatherRelations(meta *metamodel.Metamodel, entityType string, outgoing bool) []RelationHelp {
+	rels := make([]RelationHelp, 0, len(meta.Relations))
+	for name, rel := range meta.Relations {
 		var matchTypes, targetTypes []string
 		var minCard, maxCard *int
 		if outgoing {

--- a/internal/dataentry/handlers_api.go
+++ b/internal/dataentry/handlers_api.go
@@ -125,8 +125,9 @@ func (a *App) handleAPIRelationsCRUD(w http.ResponseWriter, r *http.Request) {
 
 // handleAPIEntityTypes returns a list of entity type definitions.
 func (a *App) handleAPIEntityTypes(w http.ResponseWriter, _ *http.Request) {
-	types := make([]APIEntityType, 0, len(a.Meta().Entities))
-	for name, def := range a.Meta().Entities {
+	s := a.State()
+	types := make([]APIEntityType, 0, len(s.Meta.Entities))
+	for name, def := range s.Meta.Entities {
 		apiType := APIEntityType{
 			Name:       name,
 			Plural:     def.GetPlural(),
@@ -140,7 +141,7 @@ func (a *App) handleAPIEntityTypes(w http.ResponseWriter, _ *http.Request) {
 				Default:  propDef.Default,
 			}
 			// Include enum values if this is a custom type
-			if ct, ok := a.Meta().Types[propDef.Type]; ok {
+			if ct, ok := s.Meta.Types[propDef.Type]; ok {
 				apiProp.Values = ct.Values
 			}
 			apiType.Properties[propName] = apiProp
@@ -153,13 +154,14 @@ func (a *App) handleAPIEntityTypes(w http.ResponseWriter, _ *http.Request) {
 
 // handleAPIEntities returns entities, optionally filtered by type.
 func (a *App) handleAPIEntities(w http.ResponseWriter, r *http.Request) {
+	s := a.State()
 	entityType := r.URL.Query().Get("type")
 
 	var entities []*model.Entity
 	if entityType != "" {
-		entities = a.Graph().NodesByType(entityType)
+		entities = s.Graph.NodesByType(entityType)
 	} else {
-		entities = a.Graph().AllNodes()
+		entities = s.Graph.AllNodes()
 	}
 
 	result := make([]APIEntity, 0, len(entities))
@@ -178,7 +180,7 @@ func (a *App) handleAPIEntity(w http.ResponseWriter, r *http.Request) { // Extra
 		return
 	}
 
-	entity, found := a.Graph().GetNode(path)
+	entity, found := a.State().Graph.GetNode(path)
 	if !found {
 		writeJSONError(w, http.StatusNotFound, "entity not found")
 		return
@@ -190,13 +192,14 @@ func (a *App) handleAPIEntity(w http.ResponseWriter, r *http.Request) { // Extra
 
 // handleAPIMetamodel returns the project metamodel.
 func (a *App) handleAPIMetamodel(w http.ResponseWriter, _ *http.Request) {
+	s := a.State()
 	result := APIMetamodel{
-		EntityTypes:   make([]APIEntityType, 0, len(a.Meta().Entities)),
-		RelationTypes: make([]APIRelationType, 0, len(a.Meta().Relations)),
+		EntityTypes:   make([]APIEntityType, 0, len(s.Meta.Entities)),
+		RelationTypes: make([]APIRelationType, 0, len(s.Meta.Relations)),
 	}
 
 	// Entity types
-	for name, def := range a.Meta().Entities {
+	for name, def := range s.Meta.Entities {
 		apiType := APIEntityType{
 			Name:       name,
 			Plural:     def.Plural,
@@ -209,7 +212,7 @@ func (a *App) handleAPIMetamodel(w http.ResponseWriter, _ *http.Request) {
 				Required: propDef.Required,
 				Default:  propDef.Default,
 			}
-			if ct, ok := a.Meta().Types[propDef.Type]; ok {
+			if ct, ok := s.Meta.Types[propDef.Type]; ok {
 				apiProp.Values = ct.Values
 			}
 			apiType.Properties[propName] = apiProp
@@ -218,7 +221,7 @@ func (a *App) handleAPIMetamodel(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	// Relation types
-	for name, def := range a.Meta().Relations {
+	for name, def := range s.Meta.Relations {
 		result.RelationTypes = append(result.RelationTypes, APIRelationType{
 			Name: name,
 			From: def.From,
@@ -231,6 +234,7 @@ func (a *App) handleAPIMetamodel(w http.ResponseWriter, _ *http.Request) {
 
 // entityToAPI converts a model.Entity to APIEntity.
 func (a *App) entityToAPI(e *model.Entity, includeRelations bool) APIEntity {
+	s := a.State()
 	api := APIEntity{
 		ID:         e.ID,
 		Type:       e.Type,
@@ -246,8 +250,8 @@ func (a *App) entityToAPI(e *model.Entity, includeRelations bool) APIEntity {
 		api.Relations = make([]APIRelation, 0)
 
 		// Outgoing relations
-		for _, edge := range a.Graph().OutgoingEdges(e.ID) {
-			target, found := a.Graph().GetNode(edge.To)
+		for _, edge := range s.Graph.OutgoingEdges(e.ID) {
+			target, found := s.Graph.GetNode(edge.To)
 			if !found {
 				continue
 			}
@@ -257,7 +261,7 @@ func (a *App) entityToAPI(e *model.Entity, includeRelations bool) APIEntity {
 				To:          edge.To,
 				Direction:   DirectionOutgoing,
 				TargetID:    edge.To,
-				TargetTitle: a.entityDisplayTitle(target),
+				TargetTitle: s.Meta.DisplayTitle(target),
 				TargetType:  target.Type,
 			}
 			if edge.Properties != nil {
@@ -270,8 +274,8 @@ func (a *App) entityToAPI(e *model.Entity, includeRelations bool) APIEntity {
 		}
 
 		// Incoming relations
-		for _, edge := range a.Graph().IncomingEdges(e.ID) {
-			source, found := a.Graph().GetNode(edge.From)
+		for _, edge := range s.Graph.IncomingEdges(e.ID) {
+			source, found := s.Graph.GetNode(edge.From)
 			if !found {
 				continue
 			}
@@ -281,7 +285,7 @@ func (a *App) entityToAPI(e *model.Entity, includeRelations bool) APIEntity {
 				To:          edge.To,
 				Direction:   DirectionIncoming,
 				TargetID:    edge.From,
-				TargetTitle: a.entityDisplayTitle(source),
+				TargetTitle: s.Meta.DisplayTitle(source),
 				TargetType:  source.Type,
 			}
 			if edge.Properties != nil {
@@ -402,7 +406,7 @@ func (a *App) handleAPIUpdateEntity(w http.ResponseWriter, r *http.Request) {
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
-	entity, found := a.Graph().GetNode(path)
+	entity, found := a.State().Graph.GetNode(path)
 	if !found {
 		writeJSONError(w, http.StatusNotFound, "entity not found")
 		return
@@ -454,7 +458,7 @@ func (a *App) handleAPIDeleteEntity(w http.ResponseWriter, r *http.Request) {
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
-	entity, found := a.Graph().GetNode(path)
+	entity, found := a.State().Graph.GetNode(path)
 	if !found {
 		writeJSONError(w, http.StatusNotFound, "entity not found")
 		return
@@ -530,7 +534,7 @@ func (a *App) handleAPIDeleteRelation(w http.ResponseWriter, r *http.Request) {
 
 	// Find the relation
 	var targetEdge *model.Relation
-	for _, edge := range a.Graph().OutgoingEdges(from) {
+	for _, edge := range a.State().Graph.OutgoingEdges(from) {
 		if edge.Type == relType && edge.To == to {
 			targetEdge = edge
 			break
@@ -575,10 +579,11 @@ func (a *App) handleAPIListRelations(w http.ResponseWriter, r *http.Request) {
 
 // listOutgoingRelations returns relations where the given entity is the source.
 func (a *App) listOutgoingRelations(from string) []APIRelation {
-	edges := a.Graph().OutgoingEdges(from)
+	s := a.State()
+	edges := s.Graph.OutgoingEdges(from)
 	relations := make([]APIRelation, 0, len(edges))
 	for _, edge := range edges {
-		target, found := a.Graph().GetNode(edge.To)
+		target, found := s.Graph.GetNode(edge.To)
 		if !found {
 			continue
 		}
@@ -590,10 +595,11 @@ func (a *App) listOutgoingRelations(from string) []APIRelation {
 
 // listIncomingRelations returns relations where the given entity is the target.
 func (a *App) listIncomingRelations(to string) []APIRelation {
-	edges := a.Graph().IncomingEdges(to)
+	s := a.State()
+	edges := s.Graph.IncomingEdges(to)
 	relations := make([]APIRelation, 0, len(edges))
 	for _, edge := range edges {
-		source, found := a.Graph().GetNode(edge.From)
+		source, found := s.Graph.GetNode(edge.From)
 		if !found {
 			continue
 		}
@@ -605,10 +611,11 @@ func (a *App) listIncomingRelations(to string) []APIRelation {
 
 // listAllRelations returns all relations in the graph.
 func (a *App) listAllRelations() []APIRelation {
-	edges := a.Graph().AllEdges()
+	s := a.State()
+	edges := s.Graph.AllEdges()
 	relations := make([]APIRelation, 0, len(edges))
 	for _, edge := range edges {
-		target, found := a.Graph().GetNode(edge.To)
+		target, found := s.Graph.GetNode(edge.To)
 		if !found {
 			continue
 		}
@@ -698,7 +705,8 @@ func (a *App) handleAPISettingsCRUD(w http.ResponseWriter, r *http.Request) {
 
 // handleAPIGetSettings returns the settings data for the settings page.
 func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
-	ud := a.State().UserDefaults
+	s := a.State()
+	ud := s.UserDefaults
 	if ud == nil {
 		ud = &UserDefaults{}
 	}
@@ -731,8 +739,8 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
 
 	// Collect all properties across entity types
 	propMap := make(map[string]APIPropertyDef)
-	for _, entTypeName := range a.Meta().EntityTypes() {
-		entDef, ok := a.Meta().GetEntityDef(entTypeName)
+	for _, entTypeName := range s.Meta.EntityTypes() {
+		entDef, ok := s.Meta.GetEntityDef(entTypeName)
 		if !ok {
 			continue
 		}
@@ -741,7 +749,7 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
 				propMap[propName] = APIPropertyDef{
 					Name:   propName,
 					Type:   propDef.Type,
-					Values: resolvePropertyValues(propDef, a.Meta()),
+					Values: resolvePropertyValues(propDef, s.Meta),
 				}
 			} else {
 				// Merge values for properties that appear on multiple types
@@ -750,7 +758,7 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
 				for _, v := range existing.Values {
 					seen[v] = true
 				}
-				for _, v := range resolvePropertyValues(propDef, a.Meta()) {
+				for _, v := range resolvePropertyValues(propDef, s.Meta) {
 					if !seen[v] {
 						existing.Values = append(existing.Values, v)
 						seen[v] = true
@@ -767,8 +775,8 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
 
 	// Collect all relation types with their targets
 	allRelations := make([]APIRelationDef, 0)
-	for _, relName := range a.Meta().RelationTypes() {
-		relDef, ok := a.Meta().GetRelationDef(relName)
+	for _, relName := range s.Meta.RelationTypes() {
+		relDef, ok := s.Meta.GetRelationDef(relName)
 		if !ok {
 			continue
 		}
@@ -779,10 +787,10 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
 		if len(relDef.To) > 0 {
 			rd.TargetType = relDef.To[0]
 			for _, targetType := range relDef.To {
-				for _, e := range a.Graph().NodesByType(targetType) {
+				for _, e := range s.Graph.NodesByType(targetType) {
 					rd.Targets = append(rd.Targets, APIRelationTarget{
 						ID:    e.ID,
-						Title: a.entityDisplayTitle(e),
+						Title: s.Meta.DisplayTitle(e),
 					})
 				}
 			}
@@ -792,10 +800,10 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
 
 	data := APISettingsData{
 		UserDefaults:  apiDefaults,
-		UserPalette:   a.State().UserPalette,
+		UserPalette:   s.UserPalette,
 		AllProperties: allProperties,
 		AllRelations:  allRelations,
-		EntityTypes:   a.Meta().EntityTypes(),
+		EntityTypes:   s.Meta.EntityTypes(),
 	}
 
 	writeJSON(w, data)

--- a/internal/dataentry/handlers_graph.go
+++ b/internal/dataentry/handlers_graph.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
@@ -113,26 +114,27 @@ func (a *App) handleGraphData(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) buildContentGraphData() graphDataResponse {
-	allNodes := a.Graph().AllNodes()
-	allEdges := a.Graph().AllEdges()
+	s := a.State()
+	allNodes := s.Graph.AllNodes()
+	allEdges := s.Graph.AllEdges()
 
 	// Collect entity types
-	entityTypes := a.Meta().EntityTypes()
+	entityTypes := s.Meta.EntityTypes()
 	natsort.Strings(entityTypes)
 
 	etList := make([]graphEntityType, 0, len(entityTypes))
 	for i, et := range entityTypes {
 		// Use metamodel color if available, otherwise cycle through palette
 		color := entityTypeColors[i%len(entityTypeColors)]
-		if entDef, ok := a.Meta().GetEntityDef(et); ok && entDef.Color != "" {
+		if entDef, ok := s.Meta.GetEntityDef(et); ok && entDef.Color != "" {
 			color = entDef.Color
 		}
 
 		label := et
-		if entDef, ok := a.Meta().GetEntityDef(et); ok && entDef.Label != "" {
+		if entDef, ok := s.Meta.GetEntityDef(et); ok && entDef.Label != "" {
 			label = entDef.Label
 		}
-		count := len(a.Graph().NodesByType(et))
+		count := len(s.Graph.NodesByType(et))
 		etList = append(etList, graphEntityType{Type: et, Label: label, Color: color, Count: count})
 	}
 
@@ -148,7 +150,7 @@ func (a *App) buildContentGraphData() graphDataResponse {
 		nodes = append(nodes, graphNode{
 			ID:         e.ID,
 			Type:       e.Type,
-			Title:      a.entityDisplayTitle(e),
+			Title:      s.Meta.DisplayTitle(e),
 			Properties: props,
 		})
 	}
@@ -166,19 +168,19 @@ func (a *App) buildContentGraphData() graphDataResponse {
 	}
 
 	// Collect relation types
-	relTypes := a.Meta().RelationTypes()
+	relTypes := s.Meta.RelationTypes()
 	natsort.Strings(relTypes)
 	rtList := make([]graphRelationType, 0, len(relTypes))
 	for _, rt := range relTypes {
 		label := rt
-		if relDef, ok := a.Meta().GetRelationDef(rt); ok && relDef.Label != "" {
+		if relDef, ok := s.Meta.GetRelationDef(rt); ok && relDef.Label != "" {
 			label = relDef.Label
 		}
 		rtList = append(rtList, graphRelationType{Type: rt, Label: label, Count: relTypeCounts[rt]})
 	}
 
 	// Build meta info
-	metaData := a.buildMetaInfo(entityTypes, relTypes)
+	metaData := a.buildMetaInfo(s.Meta, entityTypes, relTypes)
 
 	return graphDataResponse{
 		Nodes:         nodes,
@@ -190,7 +192,8 @@ func (a *App) buildContentGraphData() graphDataResponse {
 }
 
 func (a *App) buildMetamodelGraphData() graphDataResponse {
-	entityTypes := a.Meta().EntityTypes()
+	s := a.State()
+	entityTypes := s.Meta.EntityTypes()
 	natsort.Strings(entityTypes)
 
 	etList := make([]graphEntityType, 0, len(entityTypes))
@@ -198,18 +201,18 @@ func (a *App) buildMetamodelGraphData() graphDataResponse {
 
 	for i, et := range entityTypes {
 		color := entityTypeColors[i%len(entityTypeColors)]
-		if entDef, ok := a.Meta().GetEntityDef(et); ok && entDef.Color != "" {
+		if entDef, ok := s.Meta.GetEntityDef(et); ok && entDef.Color != "" {
 			color = entDef.Color
 		}
 
 		label := et
-		if entDef, ok := a.Meta().GetEntityDef(et); ok && entDef.Label != "" {
+		if entDef, ok := s.Meta.GetEntityDef(et); ok && entDef.Label != "" {
 			label = entDef.Label
 		}
 
 		// Build properties as metadata for each entity type node
 		props := make(map[string]string)
-		if entDef, ok := a.Meta().GetEntityDef(et); ok {
+		if entDef, ok := s.Meta.GetEntityDef(et); ok {
 			propNames := make([]string, 0, len(entDef.Properties))
 			for pn := range entDef.Properties {
 				propNames = append(propNames, pn)
@@ -221,7 +224,7 @@ func (a *App) buildMetamodelGraphData() graphDataResponse {
 			}
 		}
 
-		count := len(a.Graph().NodesByType(et))
+		count := len(s.Graph.NodesByType(et))
 		etList = append(etList, graphEntityType{Type: et, Label: label, Color: color, Count: count})
 		nodes = append(nodes, graphNode{
 			ID:         et,
@@ -232,14 +235,14 @@ func (a *App) buildMetamodelGraphData() graphDataResponse {
 	}
 
 	// Build edges from relation definitions (from-type → to-type)
-	relTypes := a.Meta().RelationTypes()
+	relTypes := s.Meta.RelationTypes()
 	natsort.Strings(relTypes)
 
 	var edges []graphEdge
 	relTypeCounts := make(map[string]int)
 
 	for _, rt := range relTypes {
-		relDef, ok := a.Meta().GetRelationDef(rt)
+		relDef, ok := s.Meta.GetRelationDef(rt)
 		if !ok {
 			continue
 		}
@@ -258,13 +261,13 @@ func (a *App) buildMetamodelGraphData() graphDataResponse {
 	rtList := make([]graphRelationType, 0, len(relTypes))
 	for _, rt := range relTypes {
 		label := rt
-		if relDef, ok := a.Meta().GetRelationDef(rt); ok && relDef.Label != "" {
+		if relDef, ok := s.Meta.GetRelationDef(rt); ok && relDef.Label != "" {
 			label = relDef.Label
 		}
 		rtList = append(rtList, graphRelationType{Type: rt, Label: label, Count: relTypeCounts[rt]})
 	}
 
-	metaData := a.buildMetaInfo(entityTypes, relTypes)
+	metaData := a.buildMetaInfo(s.Meta, entityTypes, relTypes)
 
 	return graphDataResponse{
 		Nodes:         nodes,
@@ -275,11 +278,11 @@ func (a *App) buildMetamodelGraphData() graphDataResponse {
 	}
 }
 
-func (a *App) buildMetaInfo(entityTypes, relTypes []string) graphMetaData {
+func (a *App) buildMetaInfo(meta *metamodel.Metamodel, entityTypes, relTypes []string) graphMetaData {
 	metaEntities := make([]graphMetaEntity, 0, len(entityTypes))
 	for _, et := range entityTypes {
 		me := graphMetaEntity{Type: et, Label: et}
-		if entDef, ok := a.Meta().GetEntityDef(et); ok {
+		if entDef, ok := meta.GetEntityDef(et); ok {
 			if entDef.Label != "" {
 				me.Label = entDef.Label
 			}
@@ -299,7 +302,7 @@ func (a *App) buildMetaInfo(entityTypes, relTypes []string) graphMetaData {
 	metaRelations := make([]graphMetaRelation, 0, len(relTypes))
 	for _, rt := range relTypes {
 		mr := graphMetaRelation{Type: rt}
-		if relDef, ok := a.Meta().GetRelationDef(rt); ok {
+		if relDef, ok := meta.GetRelationDef(rt); ok {
 			mr.From = relDef.From
 			mr.To = relDef.To
 		}

--- a/internal/dataentry/handlers_graph_test.go
+++ b/internal/dataentry/handlers_graph_test.go
@@ -275,7 +275,7 @@ func TestBuildMetamodelGraphData(t *testing.T) {
 
 func TestBuildMetaInfo(t *testing.T) {
 	app := newGraphTestApp(t)
-	metaData := app.buildMetaInfo([]string{"component", "ticket"}, []string{"belongs_to", "depends_on"})
+	metaData := app.buildMetaInfo(app.State().Meta, []string{"component", "ticket"}, []string{"belongs_to", "depends_on"})
 
 	t.Run("meta entities have properties", func(t *testing.T) {
 		if len(metaData.Entities) != 2 {

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -261,15 +261,16 @@ func (a *App) sortEntitiesMulti(entities []*model.Entity, specs []model.SortSpec
 	if len(specs) == 0 {
 		return
 	}
+	s := a.State()
 	entityDefs := make(map[string]*metamodel.EntityDef)
 	for _, e := range entities {
 		if _, ok := entityDefs[e.Type]; !ok {
-			if def, ok := a.Meta().GetEntityDef(e.Type); ok {
+			if def, ok := s.Meta.GetEntityDef(e.Type); ok {
 				entityDefs[e.Type] = def
 			}
 		}
 	}
-	filter.SortMulti(entities, specs, entityDefs, a.Meta())
+	filter.SortMulti(entities, specs, entityDefs, s.Meta)
 }
 
 // resolvePropertyValues returns allowed values for a property from its definition or custom type.
@@ -506,13 +507,14 @@ func (a *App) executeQuery(query string) []*model.Entity {
 		}
 	} else {
 		// No free text - get candidates from graph and filter
+		g := a.State().Graph
 		var candidates []*model.Entity
 		if len(sq.EntityTypes) > 0 {
 			for _, t := range sq.EntityTypes {
-				candidates = append(candidates, a.Graph().NodesByType(t)...)
+				candidates = append(candidates, g.NodesByType(t)...)
 			}
 		} else {
-			candidates = a.Graph().AllNodes()
+			candidates = g.AllNodes()
 		}
 
 		for _, e := range candidates {
@@ -540,11 +542,12 @@ func (a *App) executeQuery(query string) []*model.Entity {
 // relation type from an entity. Direction controls whether to follow edges pointing
 // to the entity (incoming) or from the entity (outgoing, the default).
 func (a *App) resolveRelationColumnValues(entityID, relationType string, direction dataentryconfig.Direction) []string {
+	s := a.State()
 	var edges []*model.Relation
 	if direction.IsIncoming() {
-		edges = a.Graph().IncomingEdges(entityID)
+		edges = s.Graph.IncomingEdges(entityID)
 	} else {
-		edges = a.Graph().OutgoingEdges(entityID)
+		edges = s.Graph.OutgoingEdges(entityID)
 	}
 	titles := make([]string, 0, len(edges))
 	for _, edge := range edges {
@@ -557,11 +560,11 @@ func (a *App) resolveRelationColumnValues(entityID, relationType string, directi
 		} else {
 			targetID = edge.To
 		}
-		target, ok := a.Graph().GetNode(targetID)
+		target, ok := s.Graph.GetNode(targetID)
 		if !ok {
 			continue
 		}
-		titles = append(titles, a.entityDisplayTitle(target))
+		titles = append(titles, s.Meta.DisplayTitle(target))
 	}
 	return titles
 }
@@ -569,17 +572,18 @@ func (a *App) resolveRelationColumnValues(entityID, relationType string, directi
 // filterByRelation filters entities to those that have an outgoing edge of the given
 // relation type pointing to a target whose display title matches value.
 func (a *App) filterByRelation(entities []*model.Entity, relationType, value string) []*model.Entity {
+	s := a.State()
 	var result []*model.Entity
 	for _, e := range entities {
-		for _, edge := range a.Graph().OutgoingEdges(e.ID) {
+		for _, edge := range s.Graph.OutgoingEdges(e.ID) {
 			if edge.Type != relationType {
 				continue
 			}
-			target, ok := a.Graph().GetNode(edge.To)
+			target, ok := s.Graph.GetNode(edge.To)
 			if !ok {
 				continue
 			}
-			if a.entityDisplayTitle(target) == value {
+			if s.Meta.DisplayTitle(target) == value {
 				result = append(result, e)
 				break
 			}
@@ -591,18 +595,19 @@ func (a *App) filterByRelation(entities []*model.Entity, relationType, value str
 // resolveRelationFilterValues returns sorted, unique display titles of all entities
 // reachable via the given relation type from any of the provided entities.
 func (a *App) resolveRelationFilterValues(entities []*model.Entity, relationType string) []string {
+	s := a.State()
 	seen := make(map[string]bool)
 	var vals []string
 	for _, e := range entities {
-		for _, edge := range a.Graph().OutgoingEdges(e.ID) {
+		for _, edge := range s.Graph.OutgoingEdges(e.ID) {
 			if edge.Type != relationType {
 				continue
 			}
-			target, ok := a.Graph().GetNode(edge.To)
+			target, ok := s.Graph.GetNode(edge.To)
 			if !ok {
 				continue
 			}
-			title := a.entityDisplayTitle(target)
+			title := s.Meta.DisplayTitle(target)
 			if !seen[title] {
 				seen[title] = true
 				vals = append(vals, title)
@@ -631,6 +636,7 @@ func (a *App) resolveScope(currentEntityID string, r *http.Request) *ScopeNav {
 		return nil
 	}
 
+	s := a.State()
 	var ids []string
 	var label string
 	var backURL string
@@ -638,11 +644,11 @@ func (a *App) resolveScope(currentEntityID string, r *http.Request) *ScopeNav {
 	switch {
 	case strings.HasPrefix(scope, "list:"):
 		listID := strings.TrimPrefix(scope, "list:")
-		list, ok := a.Cfg().Lists[listID]
+		list, ok := s.Cfg.Lists[listID]
 		if !ok {
 			return nil
 		}
-		entities := a.Graph().NodesByType(list.EntityType)
+		entities := s.Graph.NodesByType(list.EntityType)
 		entities = applyFilters(entities, list.Filters)
 
 		// Apply dynamic filter params (same as handleList)
@@ -746,11 +752,12 @@ func (a *App) matchesPropertyFilters(e *model.Entity, filters []*filter.Filter) 
 	if len(filters) == 0 {
 		return true
 	}
-	entDef, ok := a.Meta().GetEntityDef(e.Type)
+	s := a.State()
+	entDef, ok := s.Meta.GetEntityDef(e.Type)
 	if !ok {
 		return false
 	}
-	matched, err := filter.MatchAll(e, filters, entDef, a.Meta())
+	matched, err := filter.MatchAll(e, filters, entDef, s.Meta)
 	return err == nil && matched
 }
 
@@ -762,14 +769,15 @@ func (a *App) isRelationLinked(formRel, linkRel string) bool {
 	if formRel == linkRel {
 		return true
 	}
+	s := a.State()
 	// Check if linkRel has an inverse that equals formRel.
-	if def, ok := a.Meta().GetRelationDef(linkRel); ok && def.Inverse != nil {
+	if def, ok := s.Meta.GetRelationDef(linkRel); ok && def.Inverse != nil {
 		if def.Inverse.GetID() == formRel {
 			return true
 		}
 	}
 	// Check if formRel has an inverse that equals linkRel.
-	if def, ok := a.Meta().GetRelationDef(formRel); ok && def.Inverse != nil {
+	if def, ok := s.Meta.GetRelationDef(formRel); ok && def.Inverse != nil {
 		if def.Inverse.GetID() == linkRel {
 			return true
 		}

--- a/internal/dataentry/sections.go
+++ b/internal/dataentry/sections.go
@@ -97,6 +97,7 @@ type SectionData struct {
 
 // buildSections builds template-ready section data from view sections and a view result.
 func (a *App) buildSections(sections []ViewSection, result *viewResult) []SectionData {
+	s := a.State()
 	out := make([]SectionData, 0, len(sections))
 
 	for _, sec := range sections {
@@ -110,7 +111,7 @@ func (a *App) buildSections(sections []ViewSection, result *viewResult) []Sectio
 
 		if sec.Source == "entry" {
 			e := result.Entry
-			entDef, _ := a.Meta().GetEntityDef(e.Type)
+			entDef, _ := s.Meta.GetEntityDef(e.Type)
 
 			switch sec.Display {
 			case "properties":
@@ -147,10 +148,10 @@ func (a *App) buildSections(sections []ViewSection, result *viewResult) []Sectio
 			switch sec.Display {
 			case "properties", "list":
 				for _, e := range entities {
-					eDef, _ := a.Meta().GetEntityDef(e.Type)
+					eDef, _ := s.Meta.GetEntityDef(e.Type)
 					sed := SectionEntityData{
 						ID:         e.ID,
-						Title:      a.entityDisplayTitle(e),
+						Title:      s.Meta.DisplayTitle(e),
 						Type:       e.Type,
 						EditFormID: a.editFormForType(e.Type),
 					}
@@ -178,7 +179,7 @@ func (a *App) buildSections(sections []ViewSection, result *viewResult) []Sectio
 			case "table":
 				sd.Columns = sec.Columns
 				buildRow := func(e *model.Entity) SectionRowData {
-					eDef, _ := a.Meta().GetEntityDef(e.Type)
+					eDef, _ := s.Meta.GetEntityDef(e.Type)
 					row := SectionRowData{EntityID: e.ID, EntityType: e.Type, EditFormID: a.editFormForType(e.Type)}
 					for _, col := range sec.Columns {
 						cell := SectionColumnData{
@@ -194,7 +195,7 @@ func (a *App) buildSections(sections []ViewSection, result *viewResult) []Sectio
 									cell.PropType = pd.Type
 								}
 							}
-							cell.Widget = resolveWidget(pd, a.Meta())
+							cell.Widget = resolveWidget(pd, s.Meta)
 							if vs := e.GetAttributeStrings(col.Property); vs != nil {
 								cell.Values = vs
 							} else if val := e.GetAttributeString(col.Property); val != "" {
@@ -236,10 +237,10 @@ func (a *App) buildSections(sections []ViewSection, result *viewResult) []Sectio
 
 			case "content", "cards":
 				for _, e := range entities {
-					eDef, _ := a.Meta().GetEntityDef(e.Type)
+					eDef, _ := s.Meta.GetEntityDef(e.Type)
 					sed := SectionEntityData{
 						ID:         e.ID,
-						Title:      a.entityDisplayTitle(e),
+						Title:      s.Meta.DisplayTitle(e),
 						Type:       e.Type,
 						EditFormID: a.editFormForType(e.Type),
 						Content:    e.Content,
@@ -299,6 +300,7 @@ func (a *App) executeSidePanel(panel *SidePanelConfig, entityID, entityType stri
 
 // resolveSectionButtonsWithTraverse populates AddInfo and LinkInfo using full view config.
 func (a *App) resolveSectionButtonsWithTraverse(viewConfig ViewConfig, sections []SectionData, entry *model.Entity) {
+	s := a.State()
 	for i, sec := range viewConfig.Sections {
 		if sec.Source == "entry" {
 			continue
@@ -313,7 +315,7 @@ func (a *App) resolveSectionButtonsWithTraverse(viewConfig ViewConfig, sections 
 				relName = rule.FollowIncoming
 				linkAs = "from" // new entity is the source (incoming to entry)
 			}
-			relDef, ok := a.Meta().GetRelationDef(relName)
+			relDef, ok := s.Meta.GetRelationDef(relName)
 			if !ok {
 				break
 			}
@@ -331,7 +333,7 @@ func (a *App) resolveSectionButtonsWithTraverse(viewConfig ViewConfig, sections 
 					continue
 				}
 				label := et
-				if ed, ok := a.Meta().GetEntityDef(et); ok && ed.Label != "" {
+				if ed, ok := s.Meta.GetEntityDef(et); ok && ed.Label != "" {
 					label = ed.Label
 				}
 				targets = append(targets, SectionAddTarget{

--- a/internal/dataentry/views.go
+++ b/internal/dataentry/views.go
@@ -15,7 +15,7 @@ type viewResult struct {
 
 // executeView runs a view's traversal rules and returns the result.
 func (a *App) executeView(view ViewConfig, entryID string) (*viewResult, error) {
-	entry, ok := a.Graph().GetNode(entryID)
+	entry, ok := a.State().Graph.GetNode(entryID)
 	if !ok {
 		return nil, fmt.Errorf("entry entity not found: %s", entryID)
 	}
@@ -104,19 +104,20 @@ func (a *App) applyViewTraverse(rule ViewTraverse, result *viewResult) {
 }
 
 func (a *App) traverseViewOnce(sourceID string, rule ViewTraverse) []*model.Entity {
+	g := a.State().Graph
 	var out []*model.Entity
 	if rule.Follow != "" {
-		for _, edge := range a.Graph().OutgoingEdges(sourceID) {
+		for _, edge := range g.OutgoingEdges(sourceID) {
 			if edge.Type == rule.Follow {
-				if target, ok := a.Graph().GetNode(edge.To); ok {
+				if target, ok := g.GetNode(edge.To); ok {
 					out = append(out, target)
 				}
 			}
 		}
 	} else if rule.FollowIncoming != "" {
-		for _, edge := range a.Graph().IncomingEdges(sourceID) {
+		for _, edge := range g.IncomingEdges(sourceID) {
 			if edge.Type == rule.FollowIncoming {
-				if src, ok := a.Graph().GetNode(edge.From); ok {
+				if src, ok := g.GetNode(edge.From); ok {
 					out = append(out, src)
 				}
 			}
@@ -157,6 +158,7 @@ func (a *App) filterEntities(entities []*model.Entity, whereExpr string) ([]*mod
 		return nil, fmt.Errorf("invalid where expression: %w", err)
 	}
 
+	s := a.State()
 	var result []*model.Entity
 	for _, entity := range entities {
 		// Special handling for "type" pseudo-property
@@ -168,7 +170,7 @@ func (a *App) filterEntities(entities []*model.Entity, whereExpr string) ([]*mod
 		}
 
 		// Regular property - use metamodel-aware matching
-		entityDef, ok := a.Meta().GetEntityDef(entity.Type)
+		entityDef, ok := s.Meta.GetEntityDef(entity.Type)
 		if !ok {
 			continue
 		}
@@ -176,7 +178,7 @@ func (a *App) filterEntities(entities []*model.Entity, whereExpr string) ([]*mod
 		if !ok {
 			continue
 		}
-		matches, err := filter.Match(entity, f, &propDef, a.Meta())
+		matches, err := filter.Match(entity, f, &propDef, s.Meta)
 		if err != nil {
 			continue
 		}

--- a/tickets/entities/tickets/TKT-910WC.md
+++ b/tickets/entities/tickets/TKT-910WC.md
@@ -95,4 +95,4 @@ CLI is trivial — 7 call sites.
 
 - Phase 1 (MCP): PR #368, merged
 - Phase 3 (CLI): PR #372, merged
-- Phase 2 (dataentry): deferred — separate follow-up
+- Phase 2 (dataentry): PR #378 — enforce State() snapshot discipline (151+ calls migrated)


### PR DESCRIPTION
## Summary
- Migrate all dataentry handlers to call `a.State()` once at entry
- Replace 151+ separate `a.Graph()` / `a.Meta()` / `a.Cfg()` calls with `s := a.State()` + field access
- Enforces the pattern documented in AppState: "call State() once, use snapshot consistently"
- Prevents handlers from observing different reload epochs across multiple accessor calls
- 12 files, +303/-246 lines, no behavioral changes

Completes Snapshot Phase 2 (TKT-910WC). All three consumer packages now use snapshot discipline:
- Phase 1: MCP (#368)
- Phase 2: dataentry (this PR)
- Phase 3: CLI (#372)

## Test plan
- [x] `go test -race ./...` — all pass
- [x] `golangci-lint run ./internal/dataentry/` — clean