### PR TITLE
refactor: remove Workspace.Graph() and Workspace.Meta() public methods

### DIFF
--- a/internal/cli/flow.go
+++ b/internal/cli/flow.go
@@ -85,7 +85,7 @@ Example:
 			opts = append(opts, lua.WithAIProvider(provider))
 		}
 
-		runtime := lua.New(flowWs, flowWs.Meta(), flowWs.Paths().Root, os.Stdout, opts...)
+		runtime := lua.New(flowWs, flowWs.Snapshot().Meta(), flowWs.Paths().Root, os.Stdout, opts...)
 		defer runtime.Close()
 
 		transport := &TerminalTransport{}

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -171,8 +171,9 @@ func NewApp(ws *workspace.Workspace) (*App, error) {
 		return nil, fmt.Errorf("parsing %s: %w", ConfigFile, unmarshalErr)
 	}
 
-	meta := ws.Meta()
-	g := ws.Graph()
+	snap := ws.Snapshot()
+	meta := snap.Meta()
+	g := snap.Graph()
 
 	// Validate config against metamodel
 	if validationErr := ValidateConfig(cfgData, &cfg, meta); validationErr != nil {

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -188,8 +188,9 @@ func (a *App) onReload(events []workspace.ChangeEvent) {
 		}
 	}
 
-	newMeta := a.ws.Meta()
-	newGraph := a.ws.Graph()
+	snap := a.ws.Snapshot()
+	newMeta := snap.Meta()
+	newGraph := snap.Graph()
 
 	newStyleMap := current.StyleMap
 	newStyledTypes := current.StyledTypes

--- a/internal/lua/ai_test.go
+++ b/internal/lua/ai_test.go
@@ -39,7 +39,7 @@ func newAIRuntime(t *testing.T, server *httptest.Server, apiKeyEnv string) *Runt
 
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
-	rt := New(ws, ws.Meta(), t.TempDir(), &buf, WithAIProvider(provider))
+	rt := New(ws, ws.meta, t.TempDir(), &buf, WithAIProvider(provider))
 	t.Cleanup(rt.Close)
 	return rt
 }
@@ -49,7 +49,7 @@ func newAIRuntimeNoProvider(t *testing.T) *Runtime {
 	t.Helper()
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
-	rt := New(ws, ws.Meta(), t.TempDir(), &buf)
+	rt := New(ws, ws.meta, t.TempDir(), &buf)
 	t.Cleanup(rt.Close)
 	return rt
 }

--- a/internal/lua/runtime_test.go
+++ b/internal/lua/runtime_test.go
@@ -210,7 +210,7 @@ func TestRunFile_BasicOutput(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	// Create a temp script
@@ -238,7 +238,7 @@ func TestRunFile_Args(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `rela.output(rela.args)`
@@ -268,7 +268,7 @@ func TestGetEntity(t *testing.T) {
 	// Get reference entity for assertions
 	entity, _ := ws.GetEntity("TKT-001")
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -312,7 +312,7 @@ func TestGetEntity_NotFound(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -346,7 +346,7 @@ func TestListEntities(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -376,7 +376,7 @@ func TestListEntities_WithFilter(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -407,13 +407,13 @@ func TestGetRelations(t *testing.T) {
 	var buf bytes.Buffer
 
 	// Get reference relation for assertions
-	rels := ws.Graph().RelationsOfType("implements")
+	rels := ws.graph.RelationsOfType("implements")
 	if len(rels) == 0 {
 		t.Fatal("Expected at least one implements relation in test workspace")
 	}
 	testRel := rels[0]
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -458,7 +458,7 @@ func TestWriteFile(t *testing.T) {
 	var buf bytes.Buffer
 
 	projectRoot := t.TempDir()
-	r := New(ws, ws.Meta(), projectRoot, &buf)
+	r := New(ws, ws.meta, projectRoot, &buf)
 	defer r.Close()
 
 	// Files are written to output/ directory
@@ -484,7 +484,7 @@ func TestScriptError_Syntax(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `print(`
@@ -503,7 +503,7 @@ func TestScriptError_Runtime(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `error("boom")`
@@ -522,7 +522,7 @@ func TestProjectRoot(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/my/project", &buf)
+	r := New(ws, ws.meta, "/my/project", &buf)
 	defer r.Close()
 
 	script := `rela.output({root = rela.project_root})`
@@ -550,7 +550,7 @@ func TestWriteFile_PathTraversal(t *testing.T) {
 	var buf bytes.Buffer
 
 	projectRoot := t.TempDir()
-	r := New(ws, ws.Meta(), projectRoot, &buf)
+	r := New(ws, ws.meta, projectRoot, &buf)
 	defer r.Close()
 
 	// Try to escape output/ using path traversal
@@ -576,7 +576,7 @@ func TestWriteFile_AbsolutePathOutside(t *testing.T) {
 	var buf bytes.Buffer
 
 	projectRoot := t.TempDir()
-	r := New(ws, ws.Meta(), projectRoot, &buf)
+	r := New(ws, ws.meta, projectRoot, &buf)
 	defer r.Close()
 
 	// Try to write to absolute path (should be rejected)
@@ -592,7 +592,7 @@ func TestWriteFile_InOutputDir(t *testing.T) {
 	var buf bytes.Buffer
 
 	projectRoot := t.TempDir()
-	r := New(ws, ws.Meta(), projectRoot, &buf)
+	r := New(ws, ws.meta, projectRoot, &buf)
 	defer r.Close()
 
 	// Write to output directory
@@ -618,7 +618,7 @@ func TestListEntities_EmptyType(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `rela.list_entities("")`
@@ -637,7 +637,7 @@ func TestListEntities_InvalidFilter(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `rela.list_entities("ticket", "invalid[filter")`
@@ -656,7 +656,7 @@ func TestGetRelations_NoFilters(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -687,7 +687,7 @@ func TestTraceFrom_NonExistent(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -722,7 +722,7 @@ func TestSearch(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -754,7 +754,7 @@ func TestSearch_EmptyQuery(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `rela.search("")`
@@ -773,7 +773,7 @@ func TestCreateEntity(t *testing.T) {
 	ws, root := newMockWorkspace(t), t.TempDir()
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), root, &buf)
+	r := New(ws, ws.meta, root, &buf)
 	defer r.Close()
 
 	script := `
@@ -814,7 +814,7 @@ func TestCreateEntity_EmptyType(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `rela.create_entity("", {title = "Test"})`
@@ -837,7 +837,7 @@ func TestUpdateEntity(t *testing.T) {
 	entity, _ := ws.GetEntity("TKT-001")
 	entityID := entity.ID
 
-	r := New(ws, ws.Meta(), root, &buf)
+	r := New(ws, ws.meta, root, &buf)
 	defer r.Close()
 
 	script := `
@@ -873,7 +873,7 @@ func TestUpdateEntity_NotFound(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `rela.update_entity("NONEXISTENT", {status = "closed"})`
@@ -895,7 +895,7 @@ func TestDeleteEntity(t *testing.T) {
 	ws, root := newMockWorkspace(t), t.TempDir()
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), root, &buf)
+	r := New(ws, ws.meta, root, &buf)
 	defer r.Close()
 
 	script := `
@@ -931,7 +931,7 @@ func TestDeleteEntity_NotFound(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `rela.delete_entity("NONEXISTENT")`
@@ -955,7 +955,7 @@ func TestCreateRelation(t *testing.T) {
 	toEntity, _ := ws.GetEntity("FEAT-001")
 	relType := "implements"
 
-	r := New(ws, ws.Meta(), root, &buf)
+	r := New(ws, ws.meta, root, &buf)
 	defer r.Close()
 
 	// TKT-002 doesn't have a relation to FEAT-001 yet
@@ -996,7 +996,7 @@ func TestCreateRelation_MissingArgs(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `rela.create_relation("", "implements", "FEAT-001")`
@@ -1015,7 +1015,7 @@ func TestDeleteRelation(t *testing.T) {
 	ws, root := newMockWorkspace(t), t.TempDir()
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), root, &buf)
+	r := New(ws, ws.meta, root, &buf)
 	defer r.Close()
 
 	script := `
@@ -1045,7 +1045,7 @@ func TestFindPath(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -1083,7 +1083,7 @@ func TestFindPath_NoPath(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -1117,7 +1117,7 @@ func TestFindPath_MissingArgs(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `rela.find_path("", "FEAT-001")`
@@ -1136,7 +1136,7 @@ func TestRefresh(t *testing.T) {
 	ws, root := newMockWorkspace(t), t.TempDir()
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), root, &buf)
+	r := New(ws, ws.meta, root, &buf)
 	defer r.Close()
 
 	script := `
@@ -1169,7 +1169,7 @@ func TestTraceFrom(t *testing.T) {
 	// Get reference entity for assertions
 	entity, _ := ws.GetEntity("TKT-001")
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -1208,7 +1208,7 @@ func TestTraceTo(t *testing.T) {
 	// Get reference entity for assertions
 	entity, _ := ws.GetEntity("FEAT-001")
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -1257,7 +1257,7 @@ func TestSandbox_DangerousLibrariesUnavailable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			r := New(ws, ws.Meta(), "/tmp", &buf)
+			r := New(ws, ws.meta, "/tmp", &buf)
 			defer r.Close()
 
 			// Should succeed because the libraries are not available
@@ -1290,7 +1290,7 @@ func TestSandbox_DangerousFunctionsRemoved(t *testing.T) {
 	for _, fn := range dangerousFuncs {
 		t.Run(fn, func(t *testing.T) {
 			var buf bytes.Buffer
-			r := New(ws, ws.Meta(), "/tmp", &buf)
+			r := New(ws, ws.meta, "/tmp", &buf)
 			defer r.Close()
 
 			script := `if ` + fn + ` ~= nil then error("` + fn + ` should be nil") end`
@@ -1327,7 +1327,7 @@ func TestSandbox_SafeLibrariesAvailable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			r := New(ws, ws.Meta(), "/tmp", &buf)
+			r := New(ws, ws.meta, "/tmp", &buf)
 			defer r.Close()
 
 			err := r.RunString(tt.script)
@@ -1344,7 +1344,7 @@ func TestWriteFile_NestedDirectories(t *testing.T) {
 	var buf bytes.Buffer
 
 	projectRoot := t.TempDir()
-	r := New(ws, ws.Meta(), projectRoot, &buf)
+	r := New(ws, ws.meta, projectRoot, &buf)
 	defer r.Close()
 
 	// Write to a deeply nested path within output/
@@ -1371,7 +1371,7 @@ func TestSetArgs(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	r.SetArgs([]string{"arg1", "arg2", "arg3"})
@@ -1396,7 +1396,7 @@ func TestSortEntities_ByStringProperty(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	// Tickets have statuses "open" and "done" - sort by status
@@ -1513,7 +1513,7 @@ func TestSortEntities_Descending(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -1545,7 +1545,7 @@ func TestSortEntities_EmptyProperty(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `rela.sort_entities({}, "")`
@@ -1562,7 +1562,7 @@ func TestEntityProp(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -1650,7 +1650,7 @@ func TestWriteFile_EnsureNewline(t *testing.T) {
 	var buf bytes.Buffer
 
 	projectRoot := t.TempDir()
-	r := New(ws, ws.Meta(), projectRoot, &buf)
+	r := New(ws, ws.meta, projectRoot, &buf)
 	defer r.Close()
 
 	// Write without trailing newline, but with ensure_newline option
@@ -1676,7 +1676,7 @@ func TestWriteFile_EnsureNewline_AlreadyHasNewline(t *testing.T) {
 	var buf bytes.Buffer
 
 	projectRoot := t.TempDir()
-	r := New(ws, ws.Meta(), projectRoot, &buf)
+	r := New(ws, ws.meta, projectRoot, &buf)
 	defer r.Close()
 
 	// Write with trailing newline and ensure_newline option - should not double
@@ -1702,7 +1702,7 @@ func TestWriteFile_EnsureNewline_EmptyContent(t *testing.T) {
 	var buf bytes.Buffer
 
 	projectRoot := t.TempDir()
-	r := New(ws, ws.Meta(), projectRoot, &buf)
+	r := New(ws, ws.meta, projectRoot, &buf)
 	defer r.Close()
 
 	// Empty content should stay empty even with ensure_newline
@@ -1727,7 +1727,7 @@ func TestEntityStripPrefix(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -1793,7 +1793,7 @@ func TestMdLink(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `rela.output({link = rela.md.link("Guide", "docs/guide.md")})`
@@ -1817,7 +1817,7 @@ func TestMdRef(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `rela.output({ref = rela.md.ref("GUIDE-001", "the guide")})`
@@ -1841,7 +1841,7 @@ func TestMdTable(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -1874,7 +1874,7 @@ func TestMdEntityTable_PropertyColumns(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -1913,7 +1913,7 @@ func TestMdEntityTable_FunctionColumn(t *testing.T) {
 	ws := testWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	script := `
@@ -2030,7 +2030,7 @@ func TestShebangExecution(t *testing.T) {
 	t.Run("RunString", func(t *testing.T) {
 		ws := testWorkspace(t)
 		var buf bytes.Buffer
-		r := New(ws, ws.Meta(), "/tmp", &buf)
+		r := New(ws, ws.meta, "/tmp", &buf)
 		defer r.Close()
 
 		if err := r.RunString(script); err != nil {
@@ -2049,7 +2049,7 @@ func TestShebangExecution(t *testing.T) {
 	t.Run("RunFile", func(t *testing.T) {
 		ws := testWorkspace(t)
 		var buf bytes.Buffer
-		r := New(ws, ws.Meta(), "/tmp", &buf)
+		r := New(ws, ws.meta, "/tmp", &buf)
 		defer r.Close()
 
 		tmpFile := filepath.Join(t.TempDir(), "test.lua")
@@ -2075,7 +2075,7 @@ func TestRunFile_Errors(t *testing.T) {
 	t.Run("line numbers preserved with shebang", func(t *testing.T) {
 		ws := testWorkspace(t)
 		var buf bytes.Buffer
-		r := New(ws, ws.Meta(), "/tmp", &buf)
+		r := New(ws, ws.meta, "/tmp", &buf)
 		defer r.Close()
 
 		tmpFile := filepath.Join(t.TempDir(), "test.lua")
@@ -2097,7 +2097,7 @@ func TestRunFile_Errors(t *testing.T) {
 	t.Run("includes filename", func(t *testing.T) {
 		ws := testWorkspace(t)
 		var buf bytes.Buffer
-		r := New(ws, ws.Meta(), "/tmp", &buf)
+		r := New(ws, ws.meta, "/tmp", &buf)
 		defer r.Close()
 
 		tmpFile := filepath.Join(t.TempDir(), "mytest.lua")
@@ -2124,7 +2124,7 @@ func TestWithParams(t *testing.T) {
 		"entity_type":  "ticket",
 		"key_property": "date",
 	}
-	r := New(ws, ws.Meta(), "/tmp", &buf, WithParams(params))
+	r := New(ws, ws.meta, "/tmp", &buf, WithParams(params))
 	defer r.Close()
 
 	script := `rela.output({et = rela.params.entity_type, kp = rela.params.key_property})`
@@ -2146,7 +2146,7 @@ func TestWithParams_Empty(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf)
+	r := New(ws, ws.meta, "/tmp", &buf)
 	defer r.Close()
 
 	// rela.params should exist as an empty table
@@ -2173,7 +2173,7 @@ func TestRunActionString_ReturnTable(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf, WithActionMode())
+	r := New(ws, ws.meta, "/tmp", &buf, WithActionMode())
 	defer r.Close()
 
 	script := `return {redirect = "/foo", message = "hi"}`
@@ -2198,7 +2198,7 @@ func TestRunActionString_NoReturn(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf, WithActionMode())
+	r := New(ws, ws.meta, "/tmp", &buf, WithActionMode())
 	defer r.Close()
 
 	script := `local x = 1` // no return statement
@@ -2212,7 +2212,7 @@ func TestRunActionString_Error(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf, WithActionMode())
+	r := New(ws, ws.meta, "/tmp", &buf, WithActionMode())
 	defer r.Close()
 
 	script := `error("boom")`
@@ -2229,7 +2229,7 @@ func TestActionMode_OutputIsWarning(t *testing.T) {
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
 
-	r := New(ws, ws.Meta(), "/tmp", &buf, WithActionMode())
+	r := New(ws, ws.meta, "/tmp", &buf, WithActionMode())
 	defer r.Close()
 
 	// rela.output in action mode should not write JSON, just a warning
@@ -2260,7 +2260,7 @@ func TestWithContext_CancellationInterruptsBusyLoop(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	r := New(ws, ws.Meta(), "/tmp", &buf, WithContext(ctx))
+	r := New(ws, ws.meta, "/tmp", &buf, WithContext(ctx))
 	defer r.Close()
 
 	start := time.Now()
@@ -2290,7 +2290,7 @@ func TestWithContext_NoTimeoutStillCancels(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	r := New(ws, ws.Meta(), "/tmp", &buf, WithContext(ctx), WithTimeout(0))
+	r := New(ws, ws.meta, "/tmp", &buf, WithContext(ctx), WithTimeout(0))
 	defer r.Close()
 
 	// Cancel shortly after starting.

--- a/internal/mcp/tools_helpers.go
+++ b/internal/mcp/tools_helpers.go
@@ -15,7 +15,7 @@ import (
 
 func (s *Server) resolveType(typeName string) string {
 	typeName = strings.TrimSpace(typeName)
-	meta := s.ws.Meta()
+	meta := s.ws.Snapshot().Meta()
 	resolved := meta.ResolveAlias(typeName)
 	if _, ok := meta.GetEntityDef(resolved); ok {
 		return resolved
@@ -41,7 +41,7 @@ func trimID(id string) string {
 
 func (s *Server) resolveEntityType(typeName string) (string, *metamodel.EntityDef, error) {
 	resolved := s.resolveType(typeName)
-	def, ok := s.ws.Meta().GetEntityDef(resolved)
+	def, ok := s.ws.Snapshot().Meta().GetEntityDef(resolved)
 	if !ok {
 		return "", nil, fmt.Errorf("unknown entity type: %s", typeName)
 	}

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -81,7 +81,7 @@ func (s *Server) handleLuaEval(ctx context.Context, req mcp.CallToolRequest) (*m
 	default:
 		opts = append(opts, lua.WithAIProvider(provider))
 	}
-	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output, opts...)
+	runtime := lua.New(s.ws, s.ws.Snapshot().Meta(), projectRoot, &output, opts...)
 	defer runtime.Close()
 
 	if err := runtime.RunString(code); err != nil {
@@ -156,7 +156,7 @@ func (s *Server) handleLuaRun(ctx context.Context, req mcp.CallToolRequest) (*mc
 	} else if provider != nil {
 		opts = append(opts, lua.WithAIProvider(provider))
 	}
-	runtime := lua.New(s.ws, s.ws.Meta(), projectRoot, &output, opts...)
+	runtime := lua.New(s.ws, s.ws.Snapshot().Meta(), projectRoot, &output, opts...)
 	defer runtime.Close()
 
 	// Set script args before execution

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -351,7 +351,7 @@ func TestHandleListRelations_NoMatch(t *testing.T) {
 func TestHandleListRelations_Pagination(t *testing.T) {
 	s := makeTestServer(t)
 	// Add another relation for pagination testing
-	s.ws.Graph().AddEdge(testutil.NewRelation("DEC-001", "addresses", "REQ-002").Build())
+	s.ws.Snapshot().Graph().AddEdge(testutil.NewRelation("DEC-001", "addresses", "REQ-002").Build())
 
 	req := makeToolRequest(map[string]interface{}{"limit": float64(1)})
 	result, err := s.handleListRelations(context.Background(), req)
@@ -507,7 +507,7 @@ func TestHandleAnalyzeCardinality_WithViolation(t *testing.T) {
 	s := makeTestServer(t)
 	// Set a minimum cardinality that won't be met
 	minVal := 5
-	meta := s.ws.Meta()
+	meta := s.ws.Snapshot().Meta()
 	meta.Relations["addresses"] = metamodel.RelationDef{
 		From:        []string{"decision"},
 		To:          []string{"requirement"},
@@ -726,7 +726,7 @@ func TestResolveEntityType_Unknown(t *testing.T) {
 
 func TestValidateEntity(t *testing.T) {
 	s := makeTestServer(t)
-	entity := testutil.EntityFor(s.ws.Meta(), "requirement").ID("REQ-001").Build()
+	entity := testutil.EntityFor(s.ws.Snapshot().Meta(), "requirement").ID("REQ-001").Build()
 	result := s.validateEntity(entity)
 	if result != nil {
 		t.Error("expected no validation error for valid entity")

--- a/internal/workspace/analysis.go
+++ b/internal/workspace/analysis.go
@@ -49,7 +49,7 @@ func (w *Workspace) ResolveViewScope(viewName, entryID string) (map[string]bool,
 
 // FindOrphansWithScope returns entities with no relations, filtered by scope.
 func (w *Workspace) FindOrphansWithScope(opts AnalyzeOptions) []*model.Entity {
-	orphans := w.Graph().FindOrphans()
+	orphans := w.graph().FindOrphans()
 	return filterByScope(orphans, opts.Scope)
 }
 
@@ -63,7 +63,7 @@ type DuplicateGroup struct {
 
 // FindDuplicates returns groups of entities with similar titles, filtered by scope.
 func (w *Workspace) FindDuplicates(opts AnalyzeOptions) []DuplicateGroup {
-	entities := filterByScope(w.Graph().AllNodes(), opts.Scope)
+	entities := filterByScope(w.graph().AllNodes(), opts.Scope)
 
 	// Group by normalized title
 	titleGroups := make(map[string][]*model.Entity)
@@ -99,7 +99,7 @@ type GapResult struct {
 // FindGaps returns gaps in ID sequences, filtered by scope.
 // Excludes entity types with manual (string) IDs.
 func (w *Workspace) FindGaps(opts AnalyzeOptions) []GapResult {
-	meta := w.Meta()
+	meta := w.meta()
 	// Build a set of prefixes that belong to manual ID types (should be skipped)
 	stringIDPrefixes := make(map[string]bool)
 	for _, entityDef := range meta.Entities {
@@ -113,7 +113,7 @@ func (w *Workspace) FindGaps(opts AnalyzeOptions) []GapResult {
 
 	// Group IDs by prefix (only for sequential ID types)
 	prefixGroups := make(map[string][]int)
-	for _, id := range w.Graph().AllIDs() {
+	for _, id := range w.graph().AllIDs() {
 		if !inScope(id, opts.Scope) {
 			continue
 		}
@@ -172,7 +172,7 @@ type CardinalityViolation struct {
 func (w *Workspace) CheckCardinality(opts AnalyzeOptions) []CardinalityViolation {
 	var violations []CardinalityViolation
 
-	for relName, relDef := range w.Meta().Relations {
+	for relName, relDef := range w.meta().Relations {
 		violations = append(violations, w.checkMinOutgoing(relName, relDef, opts.Scope)...)
 		violations = append(violations, w.checkMaxOutgoing(relName, relDef, opts.Scope)...)
 		violations = append(violations, w.checkMinIncoming(relName, relDef, opts.Scope)...)
@@ -190,7 +190,7 @@ func (w *Workspace) checkMinOutgoing(
 	}
 	var violations []CardinalityViolation
 	for _, sourceType := range relDef.From {
-		for _, e := range filterByScope(w.Graph().NodesByType(sourceType), scope) {
+		for _, e := range filterByScope(w.graph().NodesByType(sourceType), scope) {
 			count := w.countOutgoingByType(e.ID, relName)
 			if count < *relDef.MinOutgoing {
 				violations = append(violations, CardinalityViolation{
@@ -214,7 +214,7 @@ func (w *Workspace) checkMaxOutgoing(
 	}
 	var violations []CardinalityViolation
 	for _, sourceType := range relDef.From {
-		for _, e := range filterByScope(w.Graph().NodesByType(sourceType), scope) {
+		for _, e := range filterByScope(w.graph().NodesByType(sourceType), scope) {
 			count := w.countOutgoingByType(e.ID, relName)
 			if count > *relDef.MaxOutgoing {
 				violations = append(violations, CardinalityViolation{
@@ -238,7 +238,7 @@ func (w *Workspace) checkMinIncoming(
 	}
 	var violations []CardinalityViolation
 	for _, targetType := range relDef.To {
-		for _, e := range filterByScope(w.Graph().NodesByType(targetType), scope) {
+		for _, e := range filterByScope(w.graph().NodesByType(targetType), scope) {
 			count := w.countIncomingByType(e.ID, relName)
 			if count < *relDef.MinIncoming {
 				// Use inverse relation name for the message if available
@@ -267,7 +267,7 @@ func (w *Workspace) checkMaxIncoming(
 	}
 	var violations []CardinalityViolation
 	for _, targetType := range relDef.To {
-		for _, e := range filterByScope(w.Graph().NodesByType(targetType), scope) {
+		for _, e := range filterByScope(w.graph().NodesByType(targetType), scope) {
 			count := w.countIncomingByType(e.ID, relName)
 			if count > *relDef.MaxIncoming {
 				// Use inverse relation name for the message if available
@@ -290,7 +290,7 @@ func (w *Workspace) checkMaxIncoming(
 
 func (w *Workspace) countOutgoingByType(entityID, relName string) int {
 	count := 0
-	for _, edge := range w.Graph().OutgoingEdges(entityID) {
+	for _, edge := range w.graph().OutgoingEdges(entityID) {
 		if edge.Type == relName {
 			count++
 		}
@@ -300,7 +300,7 @@ func (w *Workspace) countOutgoingByType(entityID, relName string) int {
 
 func (w *Workspace) countIncomingByType(entityID, relName string) int {
 	count := 0
-	for _, edge := range w.Graph().IncomingEdges(entityID) {
+	for _, edge := range w.graph().IncomingEdges(entityID) {
 		if edge.Type == relName {
 			count++
 		}
@@ -319,8 +319,8 @@ type PropertyError struct {
 
 // ValidateProperties validates entity properties against the metamodel, filtered by scope.
 func (w *Workspace) ValidateProperties(opts AnalyzeOptions) []PropertyError {
-	meta := w.Meta()
-	entities := filterByScope(w.Graph().AllNodes(), opts.Scope)
+	meta := w.meta()
+	entities := filterByScope(w.graph().AllNodes(), opts.Scope)
 
 	var allErrors []PropertyError
 	for _, entity := range entities {
@@ -346,9 +346,9 @@ type RelationPropertyError struct {
 
 // ValidateRelationProperties validates relation properties against the metamodel.
 func (w *Workspace) ValidateRelationProperties() []RelationPropertyError {
-	meta := w.Meta()
+	meta := w.meta()
 	var allErrors []RelationPropertyError
-	for _, rel := range w.Graph().AllEdges() {
+	for _, rel := range w.graph().AllEdges() {
 		errs := meta.ValidateRelationProperties(rel)
 		if len(errs) > 0 {
 			allErrors = append(allErrors, RelationPropertyError{
@@ -374,12 +374,12 @@ func (w *Workspace) newValidationService() *validation.Service {
 	if w.repo != nil {
 		opts = append(opts, validation.WithProjectRoot(w.repo.Paths().Root))
 	}
-	return validation.New(w.Meta(), opts...)
+	return validation.New(w.meta(), opts...)
 }
 
 // RunValidations executes all custom validation rules from the metamodel, filtered by scope.
 func (w *Workspace) RunValidations(opts AnalyzeOptions) []ValidationViolation {
-	return w.newValidationService().Check(w.Graph().AllNodes(), opts.Scope)
+	return w.newValidationService().Check(w.graph().AllNodes(), opts.Scope)
 }
 
 // RunValidationsFiltered executes custom validation rules matching the given filters.
@@ -399,7 +399,7 @@ func (w *Workspace) RunValidationsFiltered(opts AnalyzeOptions, filters []Valida
 	}
 
 	// Run only matching rules
-	return svc.CheckRules(w.Graph().AllNodes(), opts.Scope, ruleNames)
+	return svc.CheckRules(w.graph().AllNodes(), opts.Scope, ruleNames)
 }
 
 // matchesFilter returns true if the rule matches the filter criteria.

--- a/internal/workspace/attachment.go
+++ b/internal/workspace/attachment.go
@@ -29,12 +29,12 @@ type AttachResult struct {
 // The file is stored in the content-addressable attachment store and the entity is updated.
 func (w *Workspace) AttachFile(entityID, filePath, property string) (*AttachResult, error) {
 	// Get entity from graph
-	entity, ok := w.Graph().GetNode(entityID)
+	entity, ok := w.graph().GetNode(entityID)
 	if !ok {
 		return nil, fmt.Errorf("entity not found: %s", entityID)
 	}
 
-	meta := w.Meta()
+	meta := w.meta()
 
 	// Get entity definition
 	entityDef, ok := meta.GetEntityDef(entity.Type)
@@ -96,12 +96,12 @@ func (w *Workspace) AttachFile(entityID, filePath, property string) (*AttachResu
 // ListAttachments returns all attachments for an entity.
 func (w *Workspace) ListAttachments(entityID string) ([]AttachmentInfo, error) {
 	// Get entity from graph
-	entity, ok := w.Graph().GetNode(entityID)
+	entity, ok := w.graph().GetNode(entityID)
 	if !ok {
 		return nil, fmt.Errorf("entity not found: %s", entityID)
 	}
 
-	meta := w.Meta()
+	meta := w.meta()
 
 	// Get entity definition
 	entityDef, ok := meta.GetEntityDef(entity.Type)
@@ -218,9 +218,9 @@ func (w *Workspace) GCAttachments(dryRun bool) (*GCAttachmentsResult, error) {
 // collectReferencedAttachmentPaths returns all attachment paths referenced by entities.
 func (w *Workspace) collectReferencedAttachmentPaths() []string {
 	var paths []string
-	meta := w.Meta()
+	meta := w.meta()
 
-	for _, entity := range w.Graph().AllNodes() {
+	for _, entity := range w.graph().AllNodes() {
 		entityDef, ok := meta.GetEntityDef(entity.Type)
 		if !ok {
 			continue

--- a/internal/workspace/document.go
+++ b/internal/workspace/document.go
@@ -149,7 +149,7 @@ func (w *Workspace) computeDocumentHash(entryID, viewName string) ([]*model.Enti
 		}
 	} else {
 		// No view specified, just use the entry entity
-		entity, ok := w.Graph().GetNode(entryID)
+		entity, ok := w.graph().GetNode(entryID)
 		if !ok {
 			return nil, "", fmt.Errorf("entity %q not found", entryID)
 		}

--- a/internal/workspace/query.go
+++ b/internal/workspace/query.go
@@ -8,56 +8,56 @@ import (
 
 // GetEntity returns an entity by ID.
 func (w *Workspace) GetEntity(id string) (*model.Entity, bool) {
-	return w.Graph().GetNode(id)
+	return w.graph().GetNode(id)
 }
 
 // AllEntities returns all entities in the workspace.
 func (w *Workspace) AllEntities() []*model.Entity {
-	return w.Graph().AllNodes()
+	return w.graph().AllNodes()
 }
 
 // EntitiesByType returns all entities of the given type.
 func (w *Workspace) EntitiesByType(entityType string) []*model.Entity {
-	return w.Graph().NodesByType(entityType)
+	return w.graph().NodesByType(entityType)
 }
 
 // EntityCount returns the total number of entities.
 func (w *Workspace) EntityCount() int {
-	return w.Graph().NodeCount()
+	return w.graph().NodeCount()
 }
 
 // EntityIDs returns all entity IDs.
 func (w *Workspace) EntityIDs() []string {
-	return w.Graph().AllIDs()
+	return w.graph().AllIDs()
 }
 
 // --- Relation queries ---
 
 // GetRelation returns a relation by its endpoints and type.
 func (w *Workspace) GetRelation(from, relType, to string) (*model.Relation, bool) {
-	return w.Graph().GetEdge(from, relType, to)
+	return w.graph().GetEdge(from, relType, to)
 }
 
 // AllRelations returns all relations in the workspace.
 func (w *Workspace) AllRelations() []*model.Relation {
-	return w.Graph().AllEdges()
+	return w.graph().AllEdges()
 }
 
 // IncomingRelations returns all relations pointing to the given entity.
 func (w *Workspace) IncomingRelations(entityID string) []*model.Relation {
-	return w.Graph().IncomingEdges(entityID)
+	return w.graph().IncomingEdges(entityID)
 }
 
 // OutgoingRelations returns all relations originating from the given entity.
 func (w *Workspace) OutgoingRelations(entityID string) []*model.Relation {
-	return w.Graph().OutgoingEdges(entityID)
+	return w.graph().OutgoingEdges(entityID)
 }
 
 // --- Graph analysis ---
 
 // FindOrphans returns entities with no incoming or outgoing relations.
 func (w *Workspace) FindOrphans() []*model.Entity {
-	return w.Graph().FindOrphans()
+	return w.graph().FindOrphans()
 }
 
 // TraceResult is re-exported from model for consumers.
@@ -65,12 +65,12 @@ type TraceResult = model.TraceResult
 
 // TraceFrom traces all paths from the given entity (outgoing direction).
 func (w *Workspace) TraceFrom(entityID string, maxDepth int) *TraceResult {
-	return w.Graph().TraceFrom(entityID, maxDepth)
+	return w.graph().TraceFrom(entityID, maxDepth)
 }
 
 // TraceTo traces all paths to the given entity (incoming direction).
 func (w *Workspace) TraceTo(entityID string, maxDepth int) *TraceResult {
-	return w.Graph().TraceTo(entityID, maxDepth)
+	return w.graph().TraceTo(entityID, maxDepth)
 }
 
 // PathStep is re-exported from model for consumers.
@@ -78,5 +78,5 @@ type PathStep = model.PathStep
 
 // FindPath finds the shortest path between two entities.
 func (w *Workspace) FindPath(from, to string) []PathStep {
-	return w.Graph().FindPath(from, to)
+	return w.graph().FindPath(from, to)
 }

--- a/internal/workspace/rename_type.go
+++ b/internal/workspace/rename_type.go
@@ -12,7 +12,7 @@ import (
 // Returns the number of entity files updated.
 func (w *Workspace) RenameEntityType(oldType, newType, newPlural string) (int, error) {
 	fs := w.FS()
-	meta := w.Meta()
+	meta := w.meta()
 	paths := w.Paths()
 
 	oldDef, ok := meta.GetEntityDef(oldType)

--- a/internal/workspace/tx_test.go
+++ b/internal/workspace/tx_test.go
@@ -15,7 +15,7 @@ func TestWithTxCommit(t *testing.T) {
 	ws := setupTestWorkspace(t)
 
 	wantTitle := "tx commit test"
-	entity := testutil.EntityFor(ws.Meta(), "requirement").
+	entity := testutil.EntityFor(ws.Snapshot().Meta(), "requirement").
 		ID("REQ-001").
 		With("title", wantTitle).
 		Build()
@@ -28,7 +28,7 @@ func TestWithTxCommit(t *testing.T) {
 	}
 
 	// Graph mutation applied.
-	got, ok := ws.Graph().GetNode("REQ-001")
+	got, ok := ws.Snapshot().Graph().GetNode("REQ-001")
 	if !ok {
 		t.Fatal("entity not in graph after successful tx")
 	}
@@ -37,7 +37,7 @@ func TestWithTxCommit(t *testing.T) {
 	}
 
 	// On-disk file present (verified by re-reading via the repo).
-	read, err := ws.Repo().ReadEntity("requirement", "REQ-001", ws.Meta())
+	read, err := ws.Repo().ReadEntity("requirement", "REQ-001", ws.Snapshot().Meta())
 	if err != nil {
 		t.Fatalf("ReadEntity failed: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestWithTxCommit(t *testing.T) {
 func TestWithTxRollback(t *testing.T) {
 	ws := setupTestWorkspace(t)
 
-	entity := testutil.EntityFor(ws.Meta(), "requirement").
+	entity := testutil.EntityFor(ws.Snapshot().Meta(), "requirement").
 		ID("REQ-002").
 		With("title", "rollback test").
 		Build()
@@ -69,13 +69,13 @@ func TestWithTxRollback(t *testing.T) {
 	}
 
 	// Graph must NOT contain the entity.
-	if _, ok := ws.Graph().GetNode("REQ-002"); ok {
+	if _, ok := ws.Snapshot().Graph().GetNode("REQ-002"); ok {
 		t.Error("entity present in graph after rolled-back tx")
 	}
 
 	// On-disk file must NOT exist. ReadEntity returns an error or nil
 	// when the entity doesn't exist; either is acceptable here.
-	read, err := ws.Repo().ReadEntity("requirement", "REQ-002", ws.Meta())
+	read, err := ws.Repo().ReadEntity("requirement", "REQ-002", ws.Snapshot().Meta())
 	if err == nil && read != nil {
 		t.Error("entity present on disk after rolled-back tx")
 	}
@@ -110,7 +110,7 @@ func TestWithTxMixedOps(t *testing.T) {
 	// delete REQ-A (which has an outgoing edge to REQ-B).
 	// Expected: REQ-A gone, REQ-A's edge gone, REQ-B and REQ-C present,
 	// REQ-C --depends-on--> REQ-B present.
-	thirdEntity := testutil.EntityFor(ws.Meta(), "requirement").
+	thirdEntity := testutil.EntityFor(ws.Snapshot().Meta(), "requirement").
 		ID("REQ-C").
 		With("title", "third").
 		Build()
@@ -132,7 +132,7 @@ func TestWithTxMixedOps(t *testing.T) {
 		t.Fatalf("WithTx returned error: %v", err)
 	}
 
-	g := ws.Graph()
+	g := ws.Snapshot().Graph()
 	if _, ok := g.GetNode("REQ-A"); ok {
 		t.Error("REQ-A should be deleted")
 	}
@@ -166,8 +166,8 @@ func TestWithTxRollbackMultiOp(t *testing.T) {
 
 	// In one tx: write two new entities and a relation, then return
 	// an error. Expected: nothing committed, REQ-A unchanged.
-	e1 := testutil.EntityFor(ws.Meta(), "requirement").ID("REQ-X").With("title", "x").Build()
-	e2 := testutil.EntityFor(ws.Meta(), "requirement").ID("REQ-Y").With("title", "y").Build()
+	e1 := testutil.EntityFor(ws.Snapshot().Meta(), "requirement").ID("REQ-X").With("title", "x").Build()
+	e2 := testutil.EntityFor(ws.Snapshot().Meta(), "requirement").ID("REQ-Y").With("title", "y").Build()
 	rel := model.NewRelation("REQ-X", "depends-on", "REQ-Y")
 
 	wantErr := errors.New("forced rollback in multi-op tx")
@@ -187,7 +187,7 @@ func TestWithTxRollbackMultiOp(t *testing.T) {
 		t.Fatalf("WithTx returned %v, want %v", err, wantErr)
 	}
 
-	g := ws.Graph()
+	g := ws.Snapshot().Graph()
 	if _, ok := g.GetNode("REQ-X"); ok {
 		t.Error("REQ-X must not be in graph after rolled-back tx")
 	}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -332,26 +332,18 @@ func (w *Workspace) Snapshot() *Snapshot {
 	return &Snapshot{s: s}
 }
 
-// Graph returns the in-memory graph from the current workspace state
-// snapshot. The returned pointer reflects the state at the time of the
-// call; a concurrent Reload that publishes a new state will not affect
-// the returned graph (the old graph is never mutated by Reload).
-//
-// Operations that perform multiple reads or that mix graph reads with
-// other state reads should call w.state.Load() once and use the snapshot
-// fields directly, to guarantee a coherent view across the operation.
-func (w *Workspace) Graph() *graph.Graph {
+// graph returns the in-memory graph from the current workspace state.
+// Internal to workspace; external consumers must use Snapshot().
+func (w *Workspace) graph() *graph.Graph {
 	if s := w.state.Load(); s != nil {
 		return s.graph
 	}
 	return nil
 }
 
-// Meta returns the current metamodel. The returned pointer is a snapshot:
-// callers should not hold it across operations that could trigger a reload
-// (file watcher, explicit Reload call), because a newer metamodel may have
-// been published in the meantime.
-func (w *Workspace) Meta() *metamodel.Metamodel {
+// meta returns the current metamodel.
+// Internal to workspace; external consumers must use Snapshot().
+func (w *Workspace) meta() *metamodel.Metamodel {
 	if s := w.state.Load(); s != nil {
 		return s.meta
 	}
@@ -421,12 +413,12 @@ func (w *Workspace) DiscoverEntityTemplates(entityType string) ([]*model.EntityT
 
 // GenerateEntityTemplate generates a template file for the given entity type.
 func (w *Workspace) GenerateEntityTemplate(entityType, variant string, force bool) (bool, error) {
-	return w.repo.GenerateEntityTemplate(w.Meta(), entityType, variant, force)
+	return w.repo.GenerateEntityTemplate(w.meta(), entityType, variant, force)
 }
 
 // GenerateRelationTemplate generates a template file for the given relation type.
 func (w *Workspace) GenerateRelationTemplate(relationType string, force bool) (bool, error) {
-	return w.repo.GenerateRelationTemplate(w.Meta(), relationType, force)
+	return w.repo.GenerateRelationTemplate(w.meta(), relationType, force)
 }
 
 // FindOrphanedTempFiles returns paths of leftover .new temp files.
@@ -751,14 +743,14 @@ func (w *Workspace) removeFromIndex(id string) {
 
 // SaveCache persists the current graph to the cache file.
 func (w *Workspace) SaveCache() error {
-	if g := w.Graph(); g != nil {
+	if g := w.graph(); g != nil {
 		return w.repo.SaveCache(g)
 	}
 	return nil
 }
 
 func (w *Workspace) saveCacheQuietly() {
-	if g := w.Graph(); g != nil {
+	if g := w.graph(); g != nil {
 		w.saveCacheQuietlyFor(g)
 	}
 }
@@ -778,7 +770,7 @@ func (w *Workspace) saveCacheQuietlyFor(g *graph.Graph) {
 // ResolveEntityType resolves a type name (alias, plural) to its canonical
 // name and definition.
 func (w *Workspace) ResolveEntityType(typeName string) (string, *metamodel.EntityDef, error) {
-	meta := w.Meta()
+	meta := w.meta()
 
 	// Exact match or alias.
 	resolved := meta.ResolveAlias(strings.TrimSpace(typeName))
@@ -1094,7 +1086,7 @@ type createEntityCoreOpts struct {
 // createEntityCore creates an entity without running automations.
 // This is the shared creation logic used by CreateEntity and automation processing.
 func (w *Workspace) createEntityCore(entityType string, opts createEntityCoreOpts) (*model.Entity, error) {
-	meta := w.Meta()
+	meta := w.meta()
 	entityDef, ok := meta.GetEntityDef(entityType)
 	if !ok {
 		return nil, fmt.Errorf("unknown entity type: %s", entityType)
@@ -1153,7 +1145,7 @@ func (w *Workspace) createEntityCore(entityType string, opts createEntityCoreOpt
 	if err := w.repo.WriteEntity(entity, meta); err != nil {
 		return nil, fmt.Errorf("write entity: %w", err)
 	}
-	w.Graph().AddNode(entity)
+	w.graph().AddNode(entity)
 
 	return entity, nil
 }
@@ -1170,9 +1162,9 @@ type automationSideEffects struct {
 // the target of a relation from the source entity with the given relation type.
 // Returns nil if no such entity exists.
 func (w *Workspace) findExistingRelationTarget(sourceID, relationType, targetType string) *model.Entity {
-	for _, rel := range w.Graph().OutgoingEdges(sourceID) {
+	for _, rel := range w.graph().OutgoingEdges(sourceID) {
 		if rel.Type == relationType {
-			if target, ok := w.Graph().GetNode(rel.To); ok && target.Type == targetType {
+			if target, ok := w.graph().GetNode(rel.To); ok && target.Type == targetType {
 				return target
 			}
 		}
@@ -1237,7 +1229,7 @@ func (w *Workspace) processEntityCreations(
 	effects *automationSideEffects,
 ) []automationQueueItem {
 	var newItems []automationQueueItem
-	meta := w.Meta()
+	meta := w.meta()
 
 	for _, toCreate := range toCreateList {
 		if skip := w.handleIfExists(trigger, toCreate, effects); skip {
@@ -1317,12 +1309,12 @@ func (w *Workspace) applyRelationCreations(
 	relations []*model.Relation,
 	effects *automationSideEffects,
 ) {
-	meta := w.Meta()
+	meta := w.meta()
 
 	for _, rel := range relations {
 		rel.From = triggerEntity.ID
 
-		targetEntity, ok := w.Graph().GetNode(rel.To)
+		targetEntity, ok := w.graph().GetNode(rel.To)
 		if !ok {
 			effects.Errors = append(effects.Errors,
 				fmt.Sprintf("automation relation target not found: %s", rel.To))
@@ -1357,7 +1349,7 @@ func (w *Workspace) executeLuaActions(
 	// Build script context once for all actions
 	ctx := &scriptContextImpl{
 		workspace:   w,
-		meta:        w.Meta(),
+		meta:        w.meta(),
 		projectRoot: w.repo.Paths().Root,
 		entity:      entity,
 		oldEntity:   oldEntity,
@@ -1432,7 +1424,7 @@ func (w *Workspace) createTriggerRelation(
 	relationType string,
 	effects *automationSideEffects,
 ) {
-	meta := w.Meta()
+	meta := w.meta()
 
 	if err := meta.ValidateRelation(relationType, triggerEntity.Type, created.Type); err != nil {
 		effects.Errors = append(effects.Errors,
@@ -1457,7 +1449,7 @@ func (w *Workspace) writeRelationCore(rel *model.Relation) error {
 	if err := w.repo.WriteRelation(rel); err != nil {
 		return fmt.Errorf("write relation: %w", err)
 	}
-	w.Graph().AddEdge(rel)
+	w.graph().AddEdge(rel)
 	return nil
 }
 
@@ -1528,7 +1520,7 @@ func (w *Workspace) CreateRelation(from, relType, to string, opts ...CreateRelat
 
 // UpdateRelation updates properties on an existing relation.
 func (w *Workspace) UpdateRelation(from, relType, to string, opts CreateRelationOptions) (*model.Relation, error) {
-	rel, exists := w.Graph().GetEdge(from, relType, to)
+	rel, exists := w.graph().GetEdge(from, relType, to)
 	if !exists {
 		return nil, fmt.Errorf("relation not found: %s --%s--> %s", from, relType, to)
 	}
@@ -1557,7 +1549,7 @@ func (w *Workspace) DeleteRelation(from, relType, to string) error {
 	if err := w.repo.DeleteRelation(from, relType, to); err != nil {
 		return fmt.Errorf("delete relation: %w", err)
 	}
-	w.Graph().RemoveEdge(from, relType, to)
+	w.graph().RemoveEdge(from, relType, to)
 	w.saveCacheQuietly()
 	return nil
 }
@@ -1569,7 +1561,7 @@ func (w *Workspace) DeleteRelation(from, relType, to string) error {
 // FormatEntity checks if an entity file needs formatting and optionally writes
 // the formatted version. Returns true if the file was (or would be) modified.
 func (w *Workspace) FormatEntity(entity *model.Entity, dryRun bool) (bool, error) {
-	meta := w.Meta()
+	meta := w.meta()
 	// Get property order from metamodel
 	var propertyOrder []string
 	if entityDef, ok := meta.GetEntityDef(entity.Type); ok {
@@ -1795,7 +1787,7 @@ func (w *Workspace) ExecuteView(viewName, entryID string) (*views.ViewResult, er
 		return nil, fmt.Errorf("view %q not found in views.yaml", viewName)
 	}
 
-	engine := views.NewEngine(w.Graph(), w.Meta())
+	engine := views.NewEngine(w.graph(), w.meta())
 	return engine.Execute(viewDef, entryID)
 }
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -99,10 +99,10 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
-	if ws.Graph() == nil {
+	if ws.Snapshot().Graph() == nil {
 		t.Error("expected graph to be initialized")
 	}
-	if ws.Meta() == nil {
+	if ws.Snapshot().Meta() == nil {
 		t.Error("expected meta to be initialized")
 	}
 	if ws.Repo() == nil {
@@ -112,10 +112,10 @@ func TestNew(t *testing.T) {
 
 func TestNewWithGraph(t *testing.T) {
 	ws := setupTestWorkspace(t)
-	if ws.Graph() == nil {
+	if ws.Snapshot().Graph() == nil {
 		t.Error("expected graph")
 	}
-	if ws.Meta() == nil {
+	if ws.Snapshot().Meta() == nil {
 		t.Error("expected meta")
 	}
 }
@@ -185,7 +185,7 @@ func TestGenerateID_Sequential(t *testing.T) {
 	ws := setupTestWorkspace(t)
 
 	// Add an existing entity so the next ID is REQ-002.
-	ws.Graph().AddNode(testutil.EntityFor(ws.Meta(), "requirement").ID("REQ-001").Build())
+	ws.Snapshot().Graph().AddNode(testutil.EntityFor(ws.Snapshot().Meta(), "requirement").ID("REQ-001").Build())
 
 	id, err := ws.GenerateID("requirement", "")
 	if err != nil {
@@ -309,7 +309,7 @@ func TestCreateEntity(t *testing.T) {
 	}
 
 	// Verify entity is in graph.
-	if _, ok := ws.Graph().GetNode("REQ-001"); !ok {
+	if _, ok := ws.Snapshot().Graph().GetNode("REQ-001"); !ok {
 		t.Error("entity not found in graph after create")
 	}
 }
@@ -416,7 +416,7 @@ func TestUpdateEntity(t *testing.T) {
 	}
 
 	// Verify update in graph.
-	updated, ok := ws.Graph().GetNode(entity.ID)
+	updated, ok := ws.Snapshot().Graph().GetNode(entity.ID)
 	if !ok {
 		t.Fatal("entity not found in graph")
 	}
@@ -444,7 +444,7 @@ func TestDeleteEntity_NoCascade_NoRelations(t *testing.T) {
 	if result.RelationsDeleted != 0 {
 		t.Errorf("relations deleted = %d, want 0", result.RelationsDeleted)
 	}
-	if _, ok := ws.Graph().GetNode("REQ-001"); ok {
+	if _, ok := ws.Snapshot().Graph().GetNode("REQ-001"); ok {
 		t.Error("entity still in graph after delete")
 	}
 }
@@ -516,7 +516,7 @@ func TestCreateRelation(t *testing.T) {
 	}
 
 	// Verify in graph.
-	if _, ok := ws.Graph().GetEdge("DEC-001", "addresses", "REQ-001"); !ok {
+	if _, ok := ws.Snapshot().Graph().GetEdge("DEC-001", "addresses", "REQ-001"); !ok {
 		t.Error("relation not found in graph")
 	}
 }
@@ -569,7 +569,7 @@ func TestDeleteRelation(t *testing.T) {
 		t.Fatalf("DeleteRelation() error = %v", err)
 	}
 
-	if _, ok := ws.Graph().GetEdge("DEC-001", "addresses", "REQ-001"); ok {
+	if _, ok := ws.Snapshot().Graph().GetEdge("DEC-001", "addresses", "REQ-001"); ok {
 		t.Error("relation still in graph after delete")
 	}
 }
@@ -669,7 +669,7 @@ func TestConcurrentReloadStateSnapshot(t *testing.T) {
 					return
 				default:
 				}
-				m := ws.Meta()
+				m := ws.Snapshot().Meta()
 				if m == nil {
 					t.Errorf("Meta() returned nil during concurrent reload")
 					return
@@ -682,7 +682,7 @@ func TestConcurrentReloadStateSnapshot(t *testing.T) {
 				// and walks its nodes. If repo.Sync were still mutating
 				// a shared graph in place, this would see transiently
 				// empty results during a reload.
-				g := ws.Graph()
+				g := ws.Snapshot().Graph()
 				if g == nil {
 					t.Errorf("Graph() returned nil during concurrent reload")
 					return
@@ -926,7 +926,7 @@ func TestCreateEntity_AutomationWithIfExistsReplace(t *testing.T) {
 	}
 
 	// Old checklist should be gone from graph.
-	if _, ok := ws.Graph().GetNode(checklist1.ID); ok {
+	if _, ok := ws.Snapshot().Graph().GetNode(checklist1.ID); ok {
 		t.Errorf("old checklist %s should be deleted from graph", checklist1.ID)
 	}
 }
@@ -1262,7 +1262,7 @@ automations:
             title: "Chain from chain"
 `
 	ws := setupWorkspaceWithMetamodel(t, metamodelYAML)
-	g := ws.Graph()
+	g := ws.Snapshot().Graph()
 
 	// Create starter entity - this should trigger a chain of automations.
 	_, result, err := ws.CreateEntity("starter", CreateOptions{
@@ -1367,7 +1367,7 @@ automations:
             title: "Gamma from Beta"
 `
 	ws := setupWorkspaceWithMetamodel(t, metamodelYAML)
-	g := ws.Graph()
+	g := ws.Snapshot().Graph()
 
 	// Create alpha - should trigger beta creation, which triggers gamma creation.
 	_, result, err := ws.CreateEntity("alpha", CreateOptions{
@@ -1431,7 +1431,7 @@ func TestLuaAutomation_InlineCode(t *testing.T) {
 
 	// Lua automation updates the entity via rela.update_entity.
 	// Check the graph for the updated state.
-	updated, _ := ws.Graph().GetNode(entity.ID)
+	updated, _ := ws.Snapshot().Graph().GetNode(entity.ID)
 	if updated.GetString("status") != "processed" {
 		t.Errorf("expected status 'processed' from Lua, got %q", updated.GetString("status"))
 	}
@@ -1480,7 +1480,7 @@ automations:
 	}
 
 	// Verify lua_result was set by Lua code using entity global.
-	updated, _ := ws.Graph().GetNode(entity.ID)
+	updated, _ := ws.Snapshot().Graph().GetNode(entity.ID)
 	expectedResult := "entity_id:" + entity.ID
 	if updated.GetString("lua_result") != expectedResult {
 		t.Errorf("expected lua_result %q, got %q", expectedResult, updated.GetString("lua_result"))
@@ -1527,7 +1527,7 @@ automations:
 	entityID := entity.ID
 
 	// Get fresh entity from graph (may have been modified by creation automations).
-	entity, _ = ws.Graph().GetNode(entityID)
+	entity, _ = ws.Snapshot().Graph().GetNode(entityID)
 
 	// Update to trigger automation.
 	oldEntity := entity.Clone()
@@ -1544,7 +1544,7 @@ automations:
 	}
 
 	// Verify old_status was captured from old_entity.
-	finalEntity, _ := ws.Graph().GetNode(entityID)
+	finalEntity, _ := ws.Snapshot().Graph().GetNode(entityID)
 	oldStatusVal := finalEntity.GetString("old_status")
 	switch oldStatusVal {
 	case "":

--- a/tickets/entities/tickets/TKT-910WC.md
+++ b/tickets/entities/tickets/TKT-910WC.md
@@ -96,3 +96,4 @@ CLI is trivial — 7 call sites.
 - Phase 1 (MCP): PR #368, merged
 - Phase 3 (CLI): PR #372, merged
 - Phase 2 (dataentry): PR #378 — enforce State() snapshot discipline (151+ calls migrated)
+- Phase 4 (seal boundary): PR #382 — remove Workspace.Graph()/Meta(), all consumers through Snapshot()


### PR DESCRIPTION
## Summary

- Remove `Workspace.Graph()` and `Workspace.Meta()` public methods, replacing them with private `graph()`/`meta()` helpers for workspace-internal use
- All external consumers now access graph and metamodel through `Workspace.Snapshot()`, enforcing the snapshot discipline from Proposal #1 (database-lessons.md)
- `Snapshot.Graph()` and `Snapshot.Meta()` remain as escape hatches for cross-package functions (`views.NewEngine`, `schema.Analyze`, `importer.New`) that take `*graph.Graph` params — removing those is a follow-up

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` passes (all 35 packages)
- [x] No remaining external callers of `Workspace.Graph()` or `Workspace.Meta()`