### PR TITLE
fix: adapt scheduler to workspace.Snapshot API

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -112,6 +112,7 @@ deps:
   cmdServer:
     mayDependOn:
       - dataentry
+      - metamodel
       - project
       - repository
       - scheduler

--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -159,7 +159,8 @@ func (d *Desktop) LoadProject(dir string) string {
 	d.stopScheduler = schedCancel
 	d.mu.Unlock()
 
-	scheduler.StartBackground(schedCtx, ws, ws, slog.Default())
+	metaFn := func() *metamodel.Metamodel { return ws.Snapshot().Meta() }
+	scheduler.StartBackground(schedCtx, ws, ws, metaFn, slog.Default())
 
 	if d.ctx != nil {
 		runtime.WindowSetTitle(d.ctx, app.ProjectName())

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/dataentry"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/repository"
 	"github.com/Sourcehaven-BV/rela/internal/scheduler"
@@ -120,7 +121,8 @@ func main() {
 	}
 	// Start background scheduler if schedules.yaml exists.
 	// The goroutine is cleaned up on process exit.
-	scheduler.StartBackground(context.Background(), ws, ws, slog.Default())
+	metaFn := func() *metamodel.Metamodel { return ws.Snapshot().Meta() }
+	scheduler.StartBackground(context.Background(), ws, ws, metaFn, slog.Default())
 
 	slog.Info("starting server", "name", app.Cfg().App.Name, "addr", "http://"+addr)
 	if err := srv.ListenAndServe(); err != nil {

--- a/internal/cli/scheduler.go
+++ b/internal/cli/scheduler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/scheduler"
 	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
@@ -78,7 +79,8 @@ func runScheduler(cmd *cobra.Command) error {
 		Level: slog.LevelInfo,
 	}))
 
-	s := scheduler.New(cfg, engine, schedWs, schedWs, logger)
+	metaFn := func() *metamodel.Metamodel { return schedWs.Snapshot().Meta() }
+	s := scheduler.New(cfg, engine, schedWs, schedWs, metaFn, logger)
 	return s.Run(cmd.Context())
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -26,7 +26,13 @@ type WorkspaceProvider interface {
 // StartBackground starts the scheduler in a background goroutine if
 // schedules.yaml exists. It is a no-op if the file is missing. The scheduler
 // runs until ctx is cancelled. Errors are logged, not returned.
-func StartBackground(ctx context.Context, ws WorkspaceProvider, wsRaw interface{}, metaFn func() *metamodel.Metamodel, logger *slog.Logger) {
+func StartBackground(
+	ctx context.Context,
+	ws WorkspaceProvider,
+	wsRaw interface{},
+	metaFn func() *metamodel.Metamodel,
+	logger *slog.Logger,
+) {
 	data, err := ws.ReadProjectFile(ConfigFile)
 	if err != nil {
 		// No schedules.yaml — nothing to do.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -17,7 +17,6 @@ const tickInterval = 60 * time.Second
 // WorkspaceProvider is the subset of workspace.Workspace the scheduler needs.
 type WorkspaceProvider interface {
 	Sync() (*model.SyncResult, error)
-	Meta() *metamodel.Metamodel
 	Paths() *project.Context
 	ReadProjectFile(name string) ([]byte, error)
 	ReadCacheFile(name string) ([]byte, error)
@@ -27,7 +26,7 @@ type WorkspaceProvider interface {
 // StartBackground starts the scheduler in a background goroutine if
 // schedules.yaml exists. It is a no-op if the file is missing. The scheduler
 // runs until ctx is cancelled. Errors are logged, not returned.
-func StartBackground(ctx context.Context, ws WorkspaceProvider, wsRaw interface{}, logger *slog.Logger) {
+func StartBackground(ctx context.Context, ws WorkspaceProvider, wsRaw interface{}, metaFn func() *metamodel.Metamodel, logger *slog.Logger) {
 	data, err := ws.ReadProjectFile(ConfigFile)
 	if err != nil {
 		// No schedules.yaml — nothing to do.
@@ -45,7 +44,7 @@ func StartBackground(ctx context.Context, ws WorkspaceProvider, wsRaw interface{
 	}
 
 	engine := script.NewEngine()
-	s := New(cfg, engine, ws, wsRaw, logger)
+	s := New(cfg, engine, ws, wsRaw, metaFn, logger)
 
 	go func() {
 		logger.Info("background scheduler starting", "tasks", len(cfg.Tasks))
@@ -63,6 +62,7 @@ type Scheduler struct {
 	// wsRaw is the workspace as interface{} for passing to ScriptContext.
 	// It must satisfy lua.WorkspaceInterface.
 	wsRaw  interface{}
+	metaFn func() *metamodel.Metamodel
 	state  *State
 	logger *slog.Logger
 	now    func() time.Time // for testing
@@ -72,12 +72,14 @@ type Scheduler struct {
 	executeTaskFunc func(ctx context.Context, task TaskConfig)
 }
 
-// New creates a Scheduler.
+// New creates a Scheduler. The metaFn returns the current metamodel; callers
+// typically pass ws.Snapshot().Meta from a workspace.Workspace.
 func New(
 	cfg *Config,
 	engine *script.Engine,
 	ws WorkspaceProvider,
 	wsRaw interface{},
+	metaFn func() *metamodel.Metamodel,
 	logger *slog.Logger,
 ) *Scheduler {
 	return &Scheduler{
@@ -85,6 +87,7 @@ func New(
 		engine: engine,
 		ws:     ws,
 		wsRaw:  wsRaw,
+		metaFn: metaFn,
 		logger: logger,
 		now:    time.Now,
 	}
@@ -173,7 +176,7 @@ func (s *Scheduler) doExecuteTask(ctx context.Context, task TaskConfig) {
 
 	sctx := &schedulerScriptContext{
 		ws:          s.wsRaw,
-		meta:        s.ws.Meta(),
+		meta:        s.metaFn(),
 		projectRoot: s.ws.Paths().Root,
 	}
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -39,8 +39,7 @@ func (m *mockWorkspace) Sync() (*model.SyncResult, error) {
 	return &model.SyncResult{}, nil
 }
 
-func (m *mockWorkspace) Meta() *metamodel.Metamodel { return m.meta }
-func (m *mockWorkspace) Paths() *project.Context    { return m.paths }
+func (m *mockWorkspace) Paths() *project.Context { return m.paths }
 
 func (m *mockWorkspace) ReadProjectFile(name string) ([]byte, error) {
 	m.mu.Lock()
@@ -108,6 +107,7 @@ func newTestScheduler(
 		config: cfg,
 		ws:     ws,
 		wsRaw:  ws,
+		metaFn: func() *metamodel.Metamodel { return ws.meta },
 		state:  newState(),
 		logger: discardLogger(),
 		now:    func() time.Time { return now },
@@ -319,6 +319,7 @@ func TestScheduler_Run_emptyConfig(t *testing.T) {
 		config: &Config{Tasks: nil},
 		ws:     ws,
 		wsRaw:  ws,
+		metaFn: func() *metamodel.Metamodel { return ws.meta },
 		logger: discardLogger(),
 		now:    time.Now,
 	}
@@ -360,6 +361,7 @@ func TestScheduler_doExecuteTask_skipsOnCancelledContext(t *testing.T) {
 	s := &Scheduler{
 		ws:     ws,
 		wsRaw:  ws,
+		metaFn: func() *metamodel.Metamodel { return ws.meta },
 		state:  newState(),
 		logger: discardLogger(),
 		now:    time.Now,

--- a/tickets/entities/automated-measures/ci-build-check.md
+++ b/tickets/entities/automated-measures/ci-build-check.md
@@ -1,0 +1,9 @@
+---
+id: ci-build-check
+type: automated-measure
+title: CI build check catches interface mismatches
+description: go build in CI catches interface satisfaction failures
+kind: ci
+location: .github/workflows/ci.yml
+status: active
+---

--- a/tickets/entities/bugs/BUG-7OMLX.md
+++ b/tickets/entities/bugs/BUG-7OMLX.md
@@ -5,7 +5,10 @@ title: Scheduler uses unexported workspace.Meta() after Snapshot refactor
 why1: workspace.Meta() was made unexported to meta() in the Snapshot refactor (#372)
 why2: The scheduler PR was developed against the pre-refactor API
 why3: Squash merge resolved the conflict textually but not semantically
+why4: No integration test verifies the scheduler compiles against the real workspace type
+why5: Interface-based decoupling hides compile errors until the caller wires them together
 prevention: CI catches the build failure; this fix resolves it
+description: Scheduler WorkspaceProvider interface declared Meta() but workspace.Workspace only exports meta() after the Snapshot refactor
 status: done
 severity: high
 ---

--- a/tickets/entities/bugs/BUG-7OMLX.md
+++ b/tickets/entities/bugs/BUG-7OMLX.md
@@ -1,0 +1,11 @@
+---
+id: BUG-7OMLX
+type: bug
+title: Scheduler uses unexported workspace.Meta() after Snapshot refactor
+why1: workspace.Meta() was made unexported to meta() in the Snapshot refactor (#372)
+why2: The scheduler PR was developed against the pre-refactor API
+why3: Squash merge resolved the conflict textually but not semantically
+prevention: CI catches the build failure; this fix resolves it
+status: done
+severity: high
+---

--- a/tickets/relations/BUG-7OMLX--adds-measure--ci-build-check.md
+++ b/tickets/relations/BUG-7OMLX--adds-measure--ci-build-check.md
@@ -1,0 +1,5 @@
+---
+from: BUG-7OMLX
+relation: adds-measure
+to: ci-build-check
+---

--- a/tickets/relations/BUG-7OMLX--affects--lua-scripting.md
+++ b/tickets/relations/BUG-7OMLX--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: BUG-7OMLX
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/BUG-7OMLX--fixes--FEAT-QAOV6.md
+++ b/tickets/relations/BUG-7OMLX--fixes--FEAT-QAOV6.md
@@ -1,0 +1,5 @@
+---
+from: BUG-7OMLX
+relation: fixes
+to: FEAT-QAOV6
+---


### PR DESCRIPTION
## Summary

- Workspace.Meta() was made unexported in the Snapshot refactor (#372)
- Scheduler now takes a `metaFn` callback instead of calling `ws.Meta()` directly
- Callers pass `func() { return ws.Snapshot().Meta() }`

## Test plan

- [x] All scheduler tests pass with `-race`
- [x] `just install` succeeds
- [x] pim server restarts with scheduler active