### PR TITLE
feat: secrets/settings system for Lua scripts

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -154,7 +154,7 @@ deps:
       - scheduler
       - schema
       - script
-      - secrets
+
       - workspace
     canUse:
       - cobra
@@ -202,7 +202,7 @@ deps:
       - schema
       - script
       - search
-      - secrets
+
       - workspace
     canUse:
       - mcpgo
@@ -306,6 +306,7 @@ deps:
       - ai
       - filter
       - metamodel
+      - secrets
       - workspace
     canUse:
       - goldmark
@@ -323,7 +324,6 @@ deps:
       - lua
       - metamodel
       - project
-      - secrets
   search:
     mayDependOn:
       - filter

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -57,6 +57,7 @@ components:
 
   # Infrastructure
   ai:               { in: internal/ai }
+  secrets:          { in: internal/secrets }
   attachment:       { in: internal/attachment }
   git:              { in: internal/git }
   output:           { in: internal/output }
@@ -153,7 +154,7 @@ deps:
       - scheduler
       - schema
       - script
-
+      - secrets
       - workspace
     canUse:
       - cobra
@@ -201,7 +202,7 @@ deps:
       - schema
       - script
       - search
-
+      - secrets
       - workspace
     canUse:
       - mcpgo
@@ -322,6 +323,7 @@ deps:
       - lua
       - metamodel
       - project
+      - secrets
   search:
     mayDependOn:
       - filter

--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -525,6 +525,63 @@ end
 | `rela.project_root` | Absolute path to project root |
 | `rela.args` | Script arguments (table) |
 | `rela.today` | Current date as "YYYY-MM-DD" |
+| `rela.params` | Action script parameters (table, from data-entry config) |
+| `rela.secrets` | Per-script secrets (table, from `.rela/secrets.yaml`) |
+
+### Secrets
+
+Scripts can access secrets (API keys, tokens, passwords) via the `rela.secrets` table.
+Secrets are loaded from `.rela/secrets.yaml`, which lives inside the gitignored `.rela/`
+directory.
+
+#### Configuration
+
+Create `.rela/secrets.yaml` in your project:
+
+```yaml
+# Global secrets — available to all scripts
+jira_api_key: sk-abc123
+deploy_endpoint: https://deploy.example.com
+
+# Per-script overrides (merged on top of global)
+overrides:
+  reports/sync.lua:
+    jira_api_key: sk-different-key
+    extra_token: tok-xyz
+```
+
+- Top-level keys are **global** and available to every script
+- Keys under `overrides.<script-path>` apply only to that script and override globals
+- All values are plain strings
+
+#### Usage in Lua
+
+```lua
+-- Access a secret
+local key = rela.secrets.api_key
+
+-- Check if a secret is configured
+if rela.secrets.api_key then
+    -- use it
+else
+    error("api_key not configured in .rela/secrets.yaml")
+end
+```
+
+#### Resolution order
+
+When a script runs, its `rela.secrets` table is built by:
+
+1. Starting with all global (top-level) values
+2. Merging any per-script overrides on top
+
+If `.rela/secrets.yaml` does not exist, `rela.secrets` is an empty table (no error).
+
+#### Security notes
+
+- `.rela/` is gitignored by convention — secrets are not committed to version control
+- Treat Lua scripts as trusted code: any script can read all secrets available to it
+- For shared projects, each contributor maintains their own `.rela/secrets.yaml`
 
 ### Markdown AST: Task Lists
 

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -519,6 +519,63 @@ end
 | `rela.project_root` | Absolute path to project root |
 | `rela.args` | Script arguments (table) |
 | `rela.today` | Current date as "YYYY-MM-DD" |
+| `rela.params` | Action script parameters (table, from data-entry config) |
+| `rela.secrets` | Per-script secrets (table, from `.rela/secrets.yaml`) |
+
+### Secrets
+
+Scripts can access secrets (API keys, tokens, passwords) via the `rela.secrets` table.
+Secrets are loaded from `.rela/secrets.yaml`, which lives inside the gitignored `.rela/`
+directory.
+
+#### Configuration
+
+Create `.rela/secrets.yaml` in your project:
+
+```yaml
+# Global secrets — available to all scripts
+jira_api_key: sk-abc123
+deploy_endpoint: https://deploy.example.com
+
+# Per-script overrides (merged on top of global)
+overrides:
+  reports/sync.lua:
+    jira_api_key: sk-different-key
+    extra_token: tok-xyz
+```
+
+- Top-level keys are **global** and available to every script
+- Keys under `overrides.<script-path>` apply only to that script and override globals
+- All values are plain strings
+
+#### Usage in Lua
+
+```lua
+-- Access a secret
+local key = rela.secrets.api_key
+
+-- Check if a secret is configured
+if rela.secrets.api_key then
+    -- use it
+else
+    error("api_key not configured in .rela/secrets.yaml")
+end
+```
+
+#### Resolution order
+
+When a script runs, its `rela.secrets` table is built by:
+
+1. Starting with all global (top-level) values
+2. Merging any per-script overrides on top
+
+If `.rela/secrets.yaml` does not exist, `rela.secrets` is an empty table (no error).
+
+#### Security notes
+
+- `.rela/` is gitignored by convention — secrets are not committed to version control
+- Treat Lua scripts as trusted code: any script can read all secrets available to it
+- For shared projects, each contributor maintains their own `.rela/secrets.yaml`
 
 ### Markdown AST: Task Lists
 

--- a/internal/cli/flow.go
+++ b/internal/cli/flow.go
@@ -14,10 +14,8 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 
-	"github.com/Sourcehaven-BV/rela/internal/ai"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/script"
-	"github.com/Sourcehaven-BV/rela/internal/secrets"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
@@ -73,27 +71,11 @@ Example:
 		if flowOutputDir != "" {
 			opts = append(opts, lua.WithOutputDir(flowOutputDir))
 		}
-		// AI is often the whole point of running a flow script, so a
-		// misconfigured ai.yaml should surface immediately rather
-		// than silently disable AI. ErrConfigNotFound is the normal
-		// "no AI" state and is not propagated.
-		provider, providerErr := ai.LoadProvider(flowWs.Paths().CacheDir)
-		switch {
-		case errors.Is(providerErr, ai.ErrConfigNotFound):
-			// no AI configured
-		case providerErr != nil:
-			return fmt.Errorf("ai: %w", providerErr)
-		default:
-			opts = append(opts, lua.WithAIProvider(provider))
+		scriptOpts, optErr := loadScriptOptions(flowWs.Paths().CacheDir, scriptPath)
+		if optErr != nil {
+			return optErr
 		}
-
-		sec, secErr := secrets.Load(flowWs.Paths().CacheDir, scriptPath)
-		if secErr != nil && !errors.Is(secErr, secrets.ErrNotFound) {
-			return fmt.Errorf("secrets: %w", secErr)
-		}
-		if len(sec) > 0 {
-			opts = append(opts, lua.WithSecrets(sec))
-		}
+		opts = append(opts, scriptOpts...)
 
 		runtime := lua.New(flowWs, flowWs.Snapshot().Meta(), flowWs.Paths().Root, os.Stdout, opts...)
 		defer runtime.Close()

--- a/internal/cli/flow.go
+++ b/internal/cli/flow.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/ai"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/script"
+	"github.com/Sourcehaven-BV/rela/internal/secrets"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
@@ -84,6 +85,14 @@ Example:
 			return fmt.Errorf("ai: %w", providerErr)
 		default:
 			opts = append(opts, lua.WithAIProvider(provider))
+		}
+
+		sec, secErr := secrets.Load(flowWs.Paths().CacheDir, scriptPath)
+		if secErr != nil && !errors.Is(secErr, secrets.ErrNotFound) {
+			return fmt.Errorf("secrets: %w", secErr)
+		}
+		if len(sec) > 0 {
+			opts = append(opts, lua.WithSecrets(sec))
 		}
 
 		runtime := lua.New(flowWs, flowWs.Snapshot().Meta(), flowWs.Paths().Root, os.Stdout, opts...)

--- a/internal/cli/flow.go
+++ b/internal/cli/flow.go
@@ -71,11 +71,11 @@ Example:
 		if flowOutputDir != "" {
 			opts = append(opts, lua.WithOutputDir(flowOutputDir))
 		}
-		scriptOpts, optErr := loadScriptOptions(flowWs.Paths().CacheDir, scriptPath)
+		ctxOpts, optErr := lua.LoadContextOptions(flowWs.Paths().CacheDir, scriptPath)
 		if optErr != nil {
 			return optErr
 		}
-		opts = append(opts, scriptOpts...)
+		opts = append(opts, ctxOpts...)
 
 		runtime := lua.New(flowWs, flowWs.Snapshot().Meta(), flowWs.Paths().Root, os.Stdout, opts...)
 		defer runtime.Close()

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -67,29 +67,11 @@ Example:
 		if scriptOutputDir != "" {
 			opts = append(opts, lua.WithOutputDir(scriptOutputDir))
 		}
-		// AI is often the whole point of running a script, so a
-		// misconfigured ai.yaml should surface immediately rather
-		// than silently disable AI and let the script blow up later
-		// with a not_configured error. ErrConfigNotFound is the
-		// normal "no AI" state and is not propagated.
-		provider, err := ai.LoadProvider(projectCtx.CacheDir)
-		switch {
-		case errors.Is(err, ai.ErrConfigNotFound):
-			// no AI configured; the Lua bindings will return
-			// not_configured if the script tries to call ai.*
-		case err != nil:
-			return fmt.Errorf("ai: %w", err)
-		default:
-			opts = append(opts, lua.WithAIProvider(provider))
+		scriptOpts, err := loadScriptOptions(projectCtx.CacheDir, scriptPath)
+		if err != nil {
+			return err
 		}
-
-		sec, secErr := secrets.Load(projectCtx.CacheDir, scriptPath)
-		if secErr != nil && !errors.Is(secErr, secrets.ErrNotFound) {
-			return fmt.Errorf("secrets: %w", secErr)
-		}
-		if len(sec) > 0 {
-			opts = append(opts, lua.WithSecrets(sec))
-		}
+		opts = append(opts, scriptOpts...)
 
 		runtime := lua.New(ws, meta, projectCtx.Root, os.Stdout, opts...)
 		defer runtime.Close()
@@ -102,4 +84,30 @@ func init() {
 	scriptCmd.Flags().StringVar(&scriptOutputDir, "output-dir", "",
 		"Directory for write_file output (default: {project}/output)")
 	rootCmd.AddCommand(scriptCmd)
+}
+
+// loadScriptOptions returns lua.Options for AI and secrets, loaded from the
+// given .rela directory. Used by both script and flow commands.
+func loadScriptOptions(cacheDir, scriptPath string) ([]lua.Option, error) {
+	var opts []lua.Option
+
+	provider, err := ai.LoadProvider(cacheDir)
+	switch {
+	case errors.Is(err, ai.ErrConfigNotFound):
+		// no AI configured
+	case err != nil:
+		return nil, fmt.Errorf("ai: %w", err)
+	default:
+		opts = append(opts, lua.WithAIProvider(provider))
+	}
+
+	sec, secErr := secrets.Load(cacheDir, scriptPath)
+	if secErr != nil && !errors.Is(secErr, secrets.ErrNotFound) {
+		return nil, fmt.Errorf("secrets: %w", secErr)
+	}
+	if len(sec) > 0 {
+		opts = append(opts, lua.WithSecrets(sec))
+	}
+
+	return opts, nil
 }

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -1,15 +1,11 @@
 package cli
 
 import (
-	"errors"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 
-	"github.com/Sourcehaven-BV/rela/internal/ai"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
-	"github.com/Sourcehaven-BV/rela/internal/secrets"
 )
 
 var scriptOutputDir string
@@ -67,11 +63,11 @@ Example:
 		if scriptOutputDir != "" {
 			opts = append(opts, lua.WithOutputDir(scriptOutputDir))
 		}
-		scriptOpts, err := loadScriptOptions(projectCtx.CacheDir, scriptPath)
+		ctxOpts, err := lua.LoadContextOptions(projectCtx.CacheDir, scriptPath)
 		if err != nil {
 			return err
 		}
-		opts = append(opts, scriptOpts...)
+		opts = append(opts, ctxOpts...)
 
 		runtime := lua.New(ws, meta, projectCtx.Root, os.Stdout, opts...)
 		defer runtime.Close()
@@ -86,28 +82,3 @@ func init() {
 	rootCmd.AddCommand(scriptCmd)
 }
 
-// loadScriptOptions returns lua.Options for AI and secrets, loaded from the
-// given .rela directory. Used by both script and flow commands.
-func loadScriptOptions(cacheDir, scriptPath string) ([]lua.Option, error) {
-	var opts []lua.Option
-
-	provider, err := ai.LoadProvider(cacheDir)
-	switch {
-	case errors.Is(err, ai.ErrConfigNotFound):
-		// no AI configured
-	case err != nil:
-		return nil, fmt.Errorf("ai: %w", err)
-	default:
-		opts = append(opts, lua.WithAIProvider(provider))
-	}
-
-	sec, secErr := secrets.Load(cacheDir, scriptPath)
-	if secErr != nil && !errors.Is(secErr, secrets.ErrNotFound) {
-		return nil, fmt.Errorf("secrets: %w", secErr)
-	}
-	if len(sec) > 0 {
-		opts = append(opts, lua.WithSecrets(sec))
-	}
-
-	return opts, nil
-}

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -81,4 +81,3 @@ func init() {
 		"Directory for write_file output (default: {project}/output)")
 	rootCmd.AddCommand(scriptCmd)
 }
-

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/ai"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/secrets"
 )
 
 var scriptOutputDir string
@@ -80,6 +81,14 @@ Example:
 			return fmt.Errorf("ai: %w", err)
 		default:
 			opts = append(opts, lua.WithAIProvider(provider))
+		}
+
+		sec, secErr := secrets.Load(projectCtx.CacheDir, scriptPath)
+		if secErr != nil && !errors.Is(secErr, secrets.ErrNotFound) {
+			return fmt.Errorf("secrets: %w", secErr)
+		}
+		if len(sec) > 0 {
+			opts = append(opts, lua.WithSecrets(sec))
 		}
 
 		runtime := lua.New(ws, meta, projectCtx.Root, os.Stdout, opts...)

--- a/internal/lua/context.go
+++ b/internal/lua/context.go
@@ -1,0 +1,49 @@
+package lua
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/ai"
+	"github.com/Sourcehaven-BV/rela/internal/secrets"
+)
+
+// LoadContextOptions loads AI provider and secrets from the .rela directory
+// and returns them as runtime options. This is the single entry point for
+// all Lua callers (CLI, MCP, automation, actions) to load project-level
+// context into a runtime.
+//
+// scriptPath is the script being executed (used to resolve per-script
+// secrets). Pass "" for inline code (skips secrets loading).
+//
+// Returns ai.ErrConfigNotFound (via errors.Is) when AI is not configured —
+// callers that want to silently ignore missing AI can check for it.
+func LoadContextOptions(cacheDir, scriptPath string) ([]Option, error) {
+	var opts []Option
+
+	provider, err := ai.LoadProvider(cacheDir)
+	switch {
+	case errors.Is(err, ai.ErrConfigNotFound):
+		// no AI configured
+	case err != nil:
+		return nil, fmt.Errorf("ai: %w", err)
+	default:
+		opts = append(opts, WithAIProvider(provider))
+	}
+
+	if scriptPath != "" {
+		sec, secErr := secrets.Load(cacheDir, scriptPath)
+		switch {
+		case errors.Is(secErr, secrets.ErrNotFound):
+			// no secrets configured
+		case secErr != nil:
+			return nil, fmt.Errorf("secrets: %w", secErr)
+		default:
+			if len(sec) > 0 {
+				opts = append(opts, WithSecrets(sec))
+			}
+		}
+	}
+
+	return opts, nil
+}

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -66,6 +66,7 @@ type Runtime struct {
 	parentCtx     context.Context // Parent context for cancellation propagation (nil = Background)
 	cancelTimeout context.CancelFunc
 	params        map[string]string // rela.params values (used by action scripts)
+	secrets       map[string]string // rela.secrets values (from .rela/secrets.yaml)
 	isAction      bool              // true when running as an action (changes rela.output behavior)
 	aiProvider    ai.Provider       // nil means AI is not configured
 }
@@ -121,6 +122,14 @@ func WithParams(params map[string]string) Option {
 func WithActionMode() Option {
 	return func(r *Runtime) {
 		r.isAction = true
+	}
+}
+
+// WithSecrets sets the rela.secrets table contents.
+// Secrets are loaded from .rela/secrets.yaml by the caller.
+func WithSecrets(secrets map[string]string) Option {
+	return func(r *Runtime) {
+		r.secrets = secrets
 	}
 }
 
@@ -396,6 +405,13 @@ func (r *Runtime) registerBindings() {
 		r.L.SetField(paramsTable, k, lua.LString(v))
 	}
 	r.L.SetField(rela, "params", paramsTable)
+
+	// Secrets table (populated from WithSecrets option, loaded from .rela/secrets.yaml)
+	secretsTable := r.L.NewTable()
+	for k, v := range r.secrets {
+		r.L.SetField(secretsTable, k, lua.LString(v))
+	}
+	r.L.SetField(rela, "secrets", secretsTable)
 
 	// Date and RRULE utility functions
 	registerDateHelpers(r.L, rela)

--- a/internal/lua/runtime_test.go
+++ b/internal/lua/runtime_test.go
@@ -2310,3 +2310,56 @@ func TestWithContext_NoTimeoutStillCancels(t *testing.T) {
 		t.Fatalf("busy loop ran for %v; expected parent cancel to interrupt", elapsed)
 	}
 }
+
+func TestWithSecrets(t *testing.T) {
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+
+	sec := map[string]string{
+		"api_key":  "sk-secret",
+		"base_url": "https://example.com",
+	}
+	r := New(ws, ws.Meta(), "/tmp", &buf, WithSecrets(sec))
+	defer r.Close()
+
+	script := `rela.output({k = rela.secrets.api_key, u = rela.secrets.base_url})`
+	if err := r.RunString(script); err != nil {
+		t.Fatalf("RunString failed: %v", err)
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["k"] != "sk-secret" || result["u"] != "https://example.com" {
+		t.Errorf("expected sk-secret/https://example.com, got %v", result)
+	}
+}
+
+func TestWithSecrets_Empty(t *testing.T) {
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+
+	r := New(ws, ws.Meta(), "/tmp", &buf)
+	defer r.Close()
+
+	// rela.secrets should exist as an empty table
+	script := `
+		local count = 0
+		for _ in pairs(rela.secrets) do count = count + 1 end
+		rela.output({count = count})
+	`
+	if err := r.RunString(script); err != nil {
+		t.Fatalf("RunString failed: %v", err)
+	}
+
+	var result map[string]float64
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if result["count"] != 0 {
+		t.Errorf("Expected empty secrets, got count=%v", result["count"])
+	}
+}

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/ai"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/secrets"
 )
 
 // scriptsDir is the directory where Lua scripts must be located for lua_run.
@@ -155,6 +156,12 @@ func (s *Server) handleLuaRun(ctx context.Context, req mcp.CallToolRequest) (*mc
 		slog.Warn("ai: failed to load config; AI bindings disabled", "error", providerErr)
 	} else if provider != nil {
 		opts = append(opts, lua.WithAIProvider(provider))
+	}
+	sec, secErr := secrets.Load(s.ws.Paths().CacheDir, path)
+	if secErr != nil && !errors.Is(secErr, secrets.ErrNotFound) {
+		slog.Warn("secrets: failed to load", "error", secErr)
+	} else if len(sec) > 0 {
+		opts = append(opts, lua.WithSecrets(sec))
 	}
 	runtime := lua.New(s.ws, s.ws.Snapshot().Meta(), projectRoot, &output, opts...)
 	defer runtime.Close()

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -4,19 +4,15 @@ package mcp
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
-	"github.com/Sourcehaven-BV/rela/internal/ai"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
-	"github.com/Sourcehaven-BV/rela/internal/secrets"
 )
 
 // scriptsDir is the directory where Lua scripts must be located for lua_run.
@@ -69,19 +65,11 @@ func (s *Server) handleLuaEval(ctx context.Context, req mcp.CallToolRequest) (*m
 	var output bytes.Buffer
 
 	opts := []lua.Option{lua.WithContext(ctx)}
-	// Soft-fail on misconfigured ai.yaml: log + continue without AI
-	// rather than crashing every Lua tool call. The MCP client will
-	// see the not_configured error if their script tries to call ai.*.
-	// ErrConfigNotFound is the normal "no AI" state and is silent.
-	provider, providerErr := ai.LoadProvider(s.ws.Paths().CacheDir)
-	switch {
-	case errors.Is(providerErr, ai.ErrConfigNotFound):
-		// no AI configured
-	case providerErr != nil:
-		slog.Warn("ai: failed to load config; AI bindings disabled", "error", providerErr)
-	default:
-		opts = append(opts, lua.WithAIProvider(provider))
+	ctxOpts, ctxErr := lua.LoadContextOptions(s.ws.Paths().CacheDir, "")
+	if ctxErr != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("config error: %s", ctxErr.Error())), nil
 	}
+	opts = append(opts, ctxOpts...)
 	runtime := lua.New(s.ws, s.ws.Snapshot().Meta(), projectRoot, &output, opts...)
 	defer runtime.Close()
 
@@ -150,19 +138,11 @@ func (s *Server) handleLuaRun(ctx context.Context, req mcp.CallToolRequest) (*mc
 	var output bytes.Buffer
 
 	opts := []lua.Option{lua.WithContext(ctx)}
-	// Soft-fail on misconfigured ai.yaml: log + continue without AI
-	// rather than crashing every Lua tool call.
-	if provider, providerErr := ai.LoadProvider(s.ws.Paths().CacheDir); providerErr != nil {
-		slog.Warn("ai: failed to load config; AI bindings disabled", "error", providerErr)
-	} else if provider != nil {
-		opts = append(opts, lua.WithAIProvider(provider))
+	ctxOpts, ctxErr := lua.LoadContextOptions(s.ws.Paths().CacheDir, path)
+	if ctxErr != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("config error: %s", ctxErr.Error())), nil
 	}
-	sec, secErr := secrets.Load(s.ws.Paths().CacheDir, path)
-	if secErr != nil && !errors.Is(secErr, secrets.ErrNotFound) {
-		slog.Warn("secrets: failed to load", "error", secErr)
-	} else if len(sec) > 0 {
-		opts = append(opts, lua.WithSecrets(sec))
-	}
+	opts = append(opts, ctxOpts...)
 	runtime := lua.New(s.ws, s.ws.Snapshot().Meta(), projectRoot, &output, opts...)
 	defer runtime.Close()
 

--- a/internal/script/action.go
+++ b/internal/script/action.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/secrets"
 )
 
 // actionsDir is the directory where action scripts must be located.
@@ -58,11 +60,24 @@ func (e *Engine) ExecuteAction(
 	}
 
 	var output bytes.Buffer
-	runtime := lua.New(
-		ws, ctx.GetMeta(), ctx.GetProjectRoot(), &output,
+	luaOpts := []lua.Option{
 		lua.WithParams(params),
 		lua.WithActionMode(),
 		lua.WithTimeout(timeout),
+	}
+
+	relaDir := filepath.Join(ctx.GetProjectRoot(), project.CacheDir)
+	sec, secErr := secrets.Load(relaDir, scriptPath)
+	if secErr != nil && !errors.Is(secErr, secrets.ErrNotFound) {
+		return nil, fmt.Errorf("secrets: %w", secErr)
+	}
+	if len(sec) > 0 {
+		luaOpts = append(luaOpts, lua.WithSecrets(sec))
+	}
+
+	runtime := lua.New(
+		ws, ctx.GetMeta(), ctx.GetProjectRoot(), &output,
+		luaOpts...,
 	)
 	defer runtime.Close()
 

--- a/internal/script/action.go
+++ b/internal/script/action.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/project"
-	"github.com/Sourcehaven-BV/rela/internal/secrets"
 )
 
 // actionsDir is the directory where action scripts must be located.
@@ -60,20 +59,16 @@ func (e *Engine) ExecuteAction(
 	}
 
 	var output bytes.Buffer
-	luaOpts := []lua.Option{
+	relaDir := filepath.Join(ctx.GetProjectRoot(), project.CacheDir)
+	ctxOpts, ctxErr := lua.LoadContextOptions(relaDir, scriptPath)
+	if ctxErr != nil {
+		return nil, ctxErr
+	}
+	luaOpts := append([]lua.Option{
 		lua.WithParams(params),
 		lua.WithActionMode(),
 		lua.WithTimeout(timeout),
-	}
-
-	relaDir := filepath.Join(ctx.GetProjectRoot(), project.CacheDir)
-	sec, secErr := secrets.Load(relaDir, scriptPath)
-	if secErr != nil && !errors.Is(secErr, secrets.ErrNotFound) {
-		return nil, fmt.Errorf("secrets: %w", secErr)
-	}
-	if len(sec) > 0 {
-		luaOpts = append(luaOpts, lua.WithSecrets(sec))
-	}
+	}, ctxOpts...)
 
 	runtime := lua.New(
 		ws, ctx.GetMeta(), ctx.GetProjectRoot(), &output,

--- a/internal/script/executor.go
+++ b/internal/script/executor.go
@@ -13,16 +13,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/Sourcehaven-BV/rela/internal/ai"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/project"
-	"github.com/Sourcehaven-BV/rela/internal/secrets"
 )
 
 // scriptsDir is the directory where script files must be located.
@@ -66,28 +63,10 @@ func (e *Engine) execute(code string, ctx metamodel.ScriptContext, scriptPath st
 	}
 
 	var output bytes.Buffer
-	var opts []lua.Option
-	// Soft-fail on misconfigured ai.yaml: an automation script firing
-	// on every entity write must not crash the host because the user
-	// has a typo in their AI config. Log it so the user notices.
-	// ErrConfigNotFound is the normal "no AI" state and is silent.
-	provider, providerErr := ai.LoadProvider(filepath.Join(ctx.GetProjectRoot(), project.CacheDir))
-	switch {
-	case errors.Is(providerErr, ai.ErrConfigNotFound):
-		// no AI configured; nothing to log
-	case providerErr != nil:
-		slog.Warn("ai: failed to load config; AI bindings disabled for this run", "error", providerErr)
-	default:
-		opts = append(opts, lua.WithAIProvider(provider))
-	}
-	if scriptPath != "" {
-		relaDir := filepath.Join(ctx.GetProjectRoot(), project.CacheDir)
-		sec, secErr := secrets.Load(relaDir, scriptPath)
-		if secErr != nil && !errors.Is(secErr, secrets.ErrNotFound) {
-			slog.Warn("secrets: failed to load", "error", secErr)
-		} else if len(sec) > 0 {
-			opts = append(opts, lua.WithSecrets(sec))
-		}
+	relaDir := filepath.Join(ctx.GetProjectRoot(), project.CacheDir)
+	opts, optErr := lua.LoadContextOptions(relaDir, scriptPath)
+	if optErr != nil {
+		return fmt.Errorf("lua context: %w", optErr)
 	}
 	runtime := lua.New(ws, ctx.GetMeta(), ctx.GetProjectRoot(), &output, opts...)
 	defer runtime.Close()

--- a/internal/script/executor.go
+++ b/internal/script/executor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/secrets"
 )
 
 // scriptsDir is the directory where script files must be located.
@@ -41,7 +42,7 @@ func NewEngine() *Engine {
 
 // ExecuteCode runs inline script code with the given context.
 func (e *Engine) ExecuteCode(code string, ctx metamodel.ScriptContext) error {
-	return e.execute(code, ctx)
+	return e.execute(code, ctx, "")
 }
 
 // ExecuteFile loads and runs a script file from the scripts/ directory.
@@ -51,12 +52,13 @@ func (e *Engine) ExecuteFile(path string, ctx metamodel.ScriptContext) error {
 	if err != nil {
 		return err
 	}
-	return e.execute(scriptCode, ctx)
+	return e.execute(scriptCode, ctx, path)
 }
 
-// execute runs Lua code with entity context.
+// execute runs Lua code with entity context. scriptPath is used to resolve
+// per-script secrets; pass "" for inline code (no secrets loaded).
 // Timeout is handled by lua.Runtime (default 30s).
-func (e *Engine) execute(code string, ctx metamodel.ScriptContext) error {
+func (e *Engine) execute(code string, ctx metamodel.ScriptContext, scriptPath string) error {
 	// Type assert workspace to lua.WorkspaceInterface
 	ws, ok := ctx.GetWorkspace().(lua.WorkspaceInterface)
 	if !ok {
@@ -77,6 +79,15 @@ func (e *Engine) execute(code string, ctx metamodel.ScriptContext) error {
 		slog.Warn("ai: failed to load config; AI bindings disabled for this run", "error", providerErr)
 	default:
 		opts = append(opts, lua.WithAIProvider(provider))
+	}
+	if scriptPath != "" {
+		relaDir := filepath.Join(ctx.GetProjectRoot(), project.CacheDir)
+		sec, secErr := secrets.Load(relaDir, scriptPath)
+		if secErr != nil && !errors.Is(secErr, secrets.ErrNotFound) {
+			slog.Warn("secrets: failed to load", "error", secErr)
+		} else if len(sec) > 0 {
+			opts = append(opts, lua.WithSecrets(sec))
+		}
 	}
 	runtime := lua.New(ws, ctx.GetMeta(), ctx.GetProjectRoot(), &output, opts...)
 	defer runtime.Close()

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -1,0 +1,88 @@
+// Package secrets loads per-script secret values from .rela/secrets.yaml.
+//
+// The file has a flat global section (available to all scripts) and an
+// optional "overrides" map keyed by script path. When a script is loaded
+// its effective secrets are: global values merged with any per-script
+// overrides (overrides win).
+//
+// Example .rela/secrets.yaml:
+//
+//	jira_api_key: sk-abc123
+//	base_url: https://jira.example.com
+//
+//	overrides:
+//	  reports/sync.lua:
+//	    jira_api_key: sk-different-key
+//
+// The file lives in .rela/ which is gitignored by convention.
+package secrets
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigFile is the name of the secrets file inside .rela/.
+const ConfigFile = "secrets.yaml"
+
+// ErrNotFound indicates that .rela/secrets.yaml does not exist.
+var ErrNotFound = errors.New("secrets: no .rela/secrets.yaml")
+
+// Load reads .rela/secrets.yaml and returns the resolved secrets for
+// the given script path. Global values are merged with per-script
+// overrides (overrides take precedence).
+//
+// Returns ErrNotFound (wrapped) when the file does not exist — callers
+// should treat this as "no secrets configured" and pass an empty map.
+func Load(relaDir, scriptPath string) (map[string]string, error) {
+	raw, err := readFile(relaDir)
+	if err != nil {
+		return nil, err
+	}
+	return resolve(raw, scriptPath), nil
+}
+
+// rawConfig is the on-disk YAML structure. Top-level keys (except
+// "overrides") are global secrets. The "overrides" key maps script
+// paths to per-script secret maps.
+type rawConfig struct {
+	Global    map[string]string            `yaml:",inline"`
+	Overrides map[string]map[string]string `yaml:"overrides"`
+}
+
+func readFile(relaDir string) (*rawConfig, error) {
+	path := filepath.Join(relaDir, ConfigFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%w", ErrNotFound)
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var raw rawConfig
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &raw, nil
+}
+
+// resolve merges global secrets with per-script overrides.
+func resolve(raw *rawConfig, scriptPath string) map[string]string {
+	result := make(map[string]string, len(raw.Global))
+	for k, v := range raw.Global {
+		result[k] = v
+	}
+
+	if overrides, ok := raw.Overrides[scriptPath]; ok {
+		for k, v := range overrides {
+			result[k] = v
+		}
+	}
+
+	return result
+}

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -1,0 +1,131 @@
+package secrets
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad_FileNotFound(t *testing.T) {
+	dir := t.TempDir()
+	_, err := Load(dir, "test.lua")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestLoad_GlobalOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, `
+api_key: sk-abc123
+base_url: https://example.com
+`)
+
+	sec, err := Load(dir, "any-script.lua")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sec["api_key"] != "sk-abc123" {
+		t.Errorf("expected sk-abc123, got %q", sec["api_key"])
+	}
+	if sec["base_url"] != "https://example.com" {
+		t.Errorf("expected https://example.com, got %q", sec["base_url"])
+	}
+}
+
+func TestLoad_OverrideMerge(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, `
+api_key: global-key
+shared: shared-value
+overrides:
+  special.lua:
+    api_key: special-key
+    extra: extra-value
+`)
+
+	// Script with override
+	sec, err := Load(dir, "special.lua")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sec["api_key"] != "special-key" {
+		t.Errorf("expected override key, got %q", sec["api_key"])
+	}
+	if sec["shared"] != "shared-value" {
+		t.Errorf("expected global shared value, got %q", sec["shared"])
+	}
+	if sec["extra"] != "extra-value" {
+		t.Errorf("expected override extra, got %q", sec["extra"])
+	}
+
+	// Script without override gets globals only
+	sec2, err := Load(dir, "other.lua")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sec2["api_key"] != "global-key" {
+		t.Errorf("expected global key, got %q", sec2["api_key"])
+	}
+	if _, ok := sec2["extra"]; ok {
+		t.Error("other.lua should not have extra key")
+	}
+}
+
+func TestLoad_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, "")
+
+	sec, err := Load(dir, "test.lua")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sec) != 0 {
+		t.Errorf("expected empty map, got %v", sec)
+	}
+}
+
+func TestLoad_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, "{{invalid")
+
+	_, err := Load(dir, "test.lua")
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestLoad_OverridesOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, `
+overrides:
+  my-script.lua:
+    token: secret
+`)
+
+	sec, err := Load(dir, "my-script.lua")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sec["token"] != "secret" {
+		t.Errorf("expected secret, got %q", sec["token"])
+	}
+
+	// Script not in overrides gets empty map
+	sec2, err := Load(dir, "other.lua")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sec2) != 0 {
+		t.Errorf("expected empty map, got %v", sec2)
+	}
+}
+
+func writeYAML(t *testing.T, dir, content string) {
+	t.Helper()
+	err := os.WriteFile(filepath.Join(dir, ConfigFile), []byte(content), 0600)
+	if err != nil {
+		t.Fatalf("write secrets.yaml: %v", err)
+	}
+}

--- a/tickets/entities/tickets/TKT-P1M7C.md
+++ b/tickets/entities/tickets/TKT-P1M7C.md
@@ -4,6 +4,7 @@ type: ticket
 title: Secrets/settings system for Lua scripts
 kind: enhancement
 priority: medium
+effort: s
 status: ready
 ---
 

--- a/tickets/entities/tickets/TKT-P1M7C.md
+++ b/tickets/entities/tickets/TKT-P1M7C.md
@@ -1,0 +1,11 @@
+---
+id: TKT-P1M7C
+type: ticket
+title: Secrets/settings system for Lua scripts
+kind: enhancement
+priority: medium
+status: ready
+---
+
+Allow Lua scripts to access secrets (API keys, tokens) via rela.secrets table,
+loaded from .rela/secrets.yaml with global and per-script overrides.

--- a/tickets/relations/TKT-P1M7C--affects--lua-scripting.md
+++ b/tickets/relations/TKT-P1M7C--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P1M7C
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-P1M7C--implements--FEAT-i5ji.md
+++ b/tickets/relations/TKT-P1M7C--implements--FEAT-i5ji.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P1M7C
+relation: implements
+to: FEAT-i5ji
+---


### PR DESCRIPTION
## Summary

- Add `internal/secrets` package that loads `.rela/secrets.yaml` with global secrets and per-script overrides
- Expose secrets to Lua scripts via `rela.secrets` table (read-only, empty when unconfigured)
- Wire secrets loading into all 5 Lua entry points: `rela script`, `rela flow`, action scripts, automation scripts, MCP `lua_run`

## Test plan

- [x] Unit tests for secrets loading: missing file, global-only, override merge, empty file, invalid YAML, overrides-only
- [x] Lua integration tests: `rela.secrets` with values, empty table when no secrets
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build ./...` passes