### PR TITLE
feat: add month/day picker for yearly rrules

### DIFF
--- a/frontend/src/components/forms/RruleBuilder.test.ts
+++ b/frontend/src/components/forms/RruleBuilder.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import RruleBuilder from './RruleBuilder.vue'
+
+function mountBuilder(modelValue = '', readonly = false) {
+  return mount(RruleBuilder, {
+    props: { modelValue, readonly },
+  })
+}
+
+function getEmittedRrule(wrapper: ReturnType<typeof mount>) {
+  const events = wrapper.emitted('update:modelValue') as string[][]
+  return events?.[events.length - 1]?.[0] ?? ''
+}
+
+describe('RruleBuilder', () => {
+  describe('yearly frequency with month/day picker', () => {
+    it('shows month and day inputs when yearly is selected', async () => {
+      const wrapper = mountBuilder('FREQ=YEARLY')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('.rrule-builder__month').exists()).toBe(true)
+      expect(wrapper.find('.rrule-builder__day-input').exists()).toBe(true)
+    })
+
+    it('hides month and day inputs for non-yearly frequencies', async () => {
+      const wrapper = mountBuilder('FREQ=WEEKLY')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('.rrule-builder__month').exists()).toBe(false)
+      expect(wrapper.find('.rrule-builder__day-input').exists()).toBe(false)
+    })
+
+    it('emits BYMONTH and BYMONTHDAY when both are set', async () => {
+      const wrapper = mountBuilder('FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=15')
+      await wrapper.vm.$nextTick()
+
+      const rrule = getEmittedRrule(wrapper)
+      expect(rrule).toContain('FREQ=YEARLY')
+      expect(rrule).toContain('BYMONTH=3')
+      expect(rrule).toContain('BYMONTHDAY=15')
+    })
+
+    it('emits plain YEARLY when neither month nor day is set', async () => {
+      const wrapper = mountBuilder('FREQ=YEARLY')
+      await wrapper.vm.$nextTick()
+
+      const rrule = getEmittedRrule(wrapper)
+      expect(rrule).toContain('FREQ=YEARLY')
+      expect(rrule).not.toContain('BYMONTH')
+      expect(rrule).not.toContain('BYMONTHDAY')
+    })
+
+    it('shows human-readable preview for yearly with month/day', async () => {
+      const wrapper = mountBuilder('FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=15')
+      await wrapper.vm.$nextTick()
+
+      const preview = wrapper.find('.rrule-builder__preview')
+      expect(preview.exists()).toBe(true)
+      expect(preview.text()).toContain('March')
+      expect(preview.text()).toContain('15')
+    })
+  })
+
+  describe('parsing yearly rules', () => {
+    it('parses BYMONTH and BYMONTHDAY from existing rule', async () => {
+      const wrapper = mountBuilder('FREQ=YEARLY;BYMONTH=7;BYMONTHDAY=4')
+      await wrapper.vm.$nextTick()
+
+      const monthSelect = wrapper.find('.rrule-builder__month')
+        .element as HTMLSelectElement
+      const dayInput = wrapper.find('.rrule-builder__day-input')
+        .element as HTMLInputElement
+
+      expect(monthSelect.value).toBe('7')
+      expect(dayInput.value).toBe('4')
+    })
+
+    it('parses rule with RRULE: prefix', async () => {
+      const wrapper = mountBuilder('RRULE:FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=25')
+      await wrapper.vm.$nextTick()
+
+      const monthSelect = wrapper.find('.rrule-builder__month')
+        .element as HTMLSelectElement
+      const dayInput = wrapper.find('.rrule-builder__day-input')
+        .element as HTMLInputElement
+
+      expect(monthSelect.value).toBe('12')
+      expect(dayInput.value).toBe('25')
+    })
+
+    it('round-trips a yearly birthday rule', async () => {
+      const input = 'FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=15'
+      const wrapper = mountBuilder(input)
+      await wrapper.vm.$nextTick()
+
+      const rrule = getEmittedRrule(wrapper)
+      expect(rrule).toContain('FREQ=YEARLY')
+      expect(rrule).toContain('BYMONTH=3')
+      expect(rrule).toContain('BYMONTHDAY=15')
+    })
+  })
+
+  describe('day clamping per month', () => {
+    it('clamps day when switching to a month with fewer days', async () => {
+      const wrapper = mountBuilder('FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=31')
+      await wrapper.vm.$nextTick()
+
+      // Verify initial state
+      expect(getEmittedRrule(wrapper)).toContain('BYMONTHDAY=31')
+
+      // Switch month to February via change event
+      const monthSelect = wrapper.find('.rrule-builder__month')
+      await monthSelect.setValue('2')
+      await monthSelect.trigger('change')
+      await wrapper.vm.$nextTick()
+
+      const rrule = getEmittedRrule(wrapper)
+      expect(rrule).toContain('BYMONTH=2')
+      expect(rrule).toContain('BYMONTHDAY=28')
+    })
+  })
+
+  describe('readonly mode', () => {
+    it('disables month and day inputs when readonly', async () => {
+      const wrapper = mountBuilder('FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=15', true)
+      await wrapper.vm.$nextTick()
+
+      expect(
+        (wrapper.find('.rrule-builder__month').element as HTMLSelectElement).disabled,
+      ).toBe(true)
+      expect(
+        (wrapper.find('.rrule-builder__day-input').element as HTMLInputElement).disabled,
+      ).toBe(true)
+    })
+  })
+
+  describe('frequency-specific UI', () => {
+    it('shows weekday buttons for weekly frequency', async () => {
+      const wrapper = mountBuilder('FREQ=WEEKLY')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('.rrule-builder__weekdays').exists()).toBe(true)
+      expect(wrapper.find('.rrule-builder__yearly').exists()).toBe(false)
+    })
+
+    it('shows yearly picker, not weekdays, for yearly frequency', async () => {
+      const wrapper = mountBuilder('FREQ=YEARLY')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('.rrule-builder__yearly').exists()).toBe(true)
+      expect(wrapper.find('.rrule-builder__weekdays').exists()).toBe(false)
+    })
+  })
+})

--- a/frontend/src/components/forms/RruleBuilder.vue
+++ b/frontend/src/components/forms/RruleBuilder.vue
@@ -34,6 +34,34 @@ const freq = ref(RRule.WEEKLY)
 const interval = ref(1)
 const selectedDays = ref<Weekday[]>([])
 const dtstart = ref('')
+const selectedMonth = ref<number | null>(null)
+const selectedDay = ref<number | null>(null)
+
+const months = [
+  { value: 1, label: 'January' },
+  { value: 2, label: 'February' },
+  { value: 3, label: 'March' },
+  { value: 4, label: 'April' },
+  { value: 5, label: 'May' },
+  { value: 6, label: 'June' },
+  { value: 7, label: 'July' },
+  { value: 8, label: 'August' },
+  { value: 9, label: 'September' },
+  { value: 10, label: 'October' },
+  { value: 11, label: 'November' },
+  { value: 12, label: 'December' },
+]
+
+const maxDay = computed(() => {
+  if (!selectedMonth.value) return 31
+  return new Date(2023, selectedMonth.value, 0).getDate()
+})
+
+watch(selectedMonth, () => {
+  if (selectedDay.value && selectedDay.value > maxDay.value) {
+    selectedDay.value = maxDay.value
+  }
+})
 
 // Parse existing RRULE string on mount
 function parseRrule(value: string) {
@@ -53,6 +81,14 @@ function parseRrule(value: string) {
       selectedDays.value = (Array.isArray(opts.byweekday) ? opts.byweekday : [opts.byweekday]).map(
         (d) => (d instanceof Weekday ? d : new Weekday(d as number)),
       )
+    }
+    if (opts.bymonth) {
+      const m = Array.isArray(opts.bymonth) ? opts.bymonth[0] : opts.bymonth
+      if (m) selectedMonth.value = m
+    }
+    if (opts.bymonthday) {
+      const d = Array.isArray(opts.bymonthday) ? opts.bymonthday[0] : opts.bymonthday
+      if (d) selectedDay.value = d
     }
     if (opts.dtstart) {
       const d = opts.dtstart
@@ -89,6 +125,11 @@ const rruleString = computed(() => {
 
   if (freq.value === RRule.WEEKLY && selectedDays.value.length > 0) {
     opts.byweekday = selectedDays.value
+  }
+
+  if (freq.value === RRule.YEARLY && selectedMonth.value && selectedDay.value) {
+    opts.bymonth = [selectedMonth.value]
+    opts.bymonthday = [selectedDay.value]
   }
 
   const rule = new RRule(opts)
@@ -166,6 +207,33 @@ function isDaySelected(day: Weekday): boolean {
       >
         {{ day.label }}
       </button>
+    </div>
+
+    <div v-if="freq === RRule.YEARLY" class="rrule-builder__yearly">
+      <div class="rrule-builder__row">
+        <label class="rrule-builder__field-label">On</label>
+        <select
+          :value="selectedMonth ?? ''"
+          class="rrule-builder__month"
+          :disabled="readonly"
+          @change="selectedMonth = ($event.target as HTMLSelectElement).value ? Number(($event.target as HTMLSelectElement).value) : null"
+        >
+          <option value="">Month...</option>
+          <option v-for="m in months" :key="m.value" :value="m.value">
+            {{ m.label }}
+          </option>
+        </select>
+        <input
+          :value="selectedDay ?? ''"
+          type="number"
+          min="1"
+          :max="maxDay"
+          placeholder="Day"
+          class="rrule-builder__day-input"
+          :disabled="readonly"
+          @input="selectedDay = (() => { const v = Number(($event.target as HTMLInputElement).value); return Number.isFinite(v) && v >= 1 ? Math.min(v, maxDay) : null })()"
+        />
+      </div>
     </div>
 
     <div v-if="interval > 1" class="rrule-builder__dtstart">
@@ -283,6 +351,38 @@ function isDaySelected(day: Weekday): boolean {
 
 .rrule-builder__day--selected:hover {
   opacity: 0.9;
+}
+
+.rrule-builder__yearly {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.rrule-builder__month {
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 14px;
+  background: var(--input-bg);
+  color: var(--text-color);
+}
+
+.rrule-builder__day-input {
+  width: 5rem;
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 14px;
+  background: var(--input-bg);
+  color: var(--text-color);
+}
+
+.rrule-builder__month:focus,
+.rrule-builder__day-input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
 }
 
 .rrule-builder__dtstart {

--- a/tickets/entities/planning-checklists/PLAN-YRLY.md
+++ b/tickets/entities/planning-checklists/PLAN-YRLY.md
@@ -1,0 +1,53 @@
+---
+id: PLAN-YRLY
+type: planning-checklist
+title: "Planning: Add month/day picker for yearly rrules"
+status: done
+---
+
+## Understanding
+
+- [x] Problem: RruleBuilder widget has no month/day picker when YEARLY frequency is selected
+- [x] Use case: birthdays, anniversaries — "every year on March 15"
+- [x] RRULE syntax needed: `FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=15`
+- [x] Scope: frontend-only change to `RruleBuilder.vue` — no backend/Go changes needed
+
+## What's NOT in scope
+
+- Monthly BYMONTHDAY picker (separate ticket if needed)
+- BYDAY positional rules (e.g., "2nd Monday of March")
+- COUNT/UNTIL support
+
+## Acceptance Criteria
+
+1. When YEARLY frequency is selected, a month dropdown (Jan-Dec) and day input (1-31) appear
+2. Selecting month+day generates correct BYMONTH and BYMONTHDAY in the rrule string
+3. Parsing an existing `FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=15` populates the month/day fields
+4. Human-readable preview shows e.g. "every year in March on the 15th"
+5. Fields are disabled in readonly mode
+6. Day input clamps to 1-31
+
+## Approach
+
+Modify `frontend/src/components/forms/RruleBuilder.vue`:
+
+1. Add `selectedMonth` ref (1-12, default empty) and `selectedDay` ref (1-31, default empty)
+2. Add a conditional section `v-if="freq === RRule.YEARLY"` with:
+   - Month dropdown (`<select>`) with Jan-Dec options (values 1-12)
+   - Day-of-month number input (1-31)
+3. In `parseRrule()`: extract `opts.bymonth` and `opts.bymonthday` to populate the new refs
+4. In `rruleString` computed: when freq is YEARLY and **both** month and day are set, include `bymonth` and `bymonthday` in the RRule options. If only one is set, omit both (partial selection = plain YEARLY)
+5. Style using existing BEM classes (`.rrule-builder__row`, etc.)
+
+## Test Plan
+
+- Unit: verify rrule string generation with month+day set
+- Unit: verify parsing of existing yearly+month+day rules
+- Manual: test in data-entry UI with a real rrule property
+- Edge cases: no month/day selected (plain YEARLY), month without day (should not emit BYMONTH), day without month (should not emit BYMONTHDAY) — both must be set or neither is emitted
+
+## Risk Assessment
+
+- Low risk: isolated frontend change, additive only
+- The rrule npm library already supports BYMONTH/BYMONTHDAY natively
+- Go backend validation passes through to rrule-go which also supports these params

--- a/tickets/entities/review-responses/RR-YRLY1.md
+++ b/tickets/entities/review-responses/RR-YRLY1.md
@@ -1,0 +1,12 @@
+---
+id: RR-YRLY1
+type: review-response
+title: "Partial selection behavior unspecified"
+finding: |
+  Plan lists "month without day, day without month" as an edge case to test but doesn't specify
+  the expected behavior. FREQ=YEARLY;BYMONTH=3 without BYMONTHDAY means "every day in March"
+  which is almost certainly wrong. Plan should specify: require both month AND day, or emit neither.
+severity: significant
+status: addressed
+resolution: Updated plan to require both month and day to be set before emitting BYMONTH/BYMONTHDAY.
+---

--- a/tickets/entities/review-responses/RR-YRLY2.md
+++ b/tickets/entities/review-responses/RR-YRLY2.md
@@ -1,0 +1,11 @@
+---
+id: RR-YRLY2
+type: review-response
+title: "Day-of-month not validated against selected month"
+finding: |
+  Max=31 on the input allows invalid dates like Feb 31. The rrule library silently produces
+  zero occurrences for impossible dates, so the recurrence would never fire.
+severity: critical
+status: addressed
+resolution: Added maxDay computed that returns days-in-month. Day input uses dynamic :max and clamps value. Month change watcher auto-clamps day.
+---

--- a/tickets/entities/review-responses/RR-YRLY3.md
+++ b/tickets/entities/review-responses/RR-YRLY3.md
@@ -1,0 +1,11 @@
+---
+id: RR-YRLY3
+type: review-response
+title: "Stale state when switching away from YEARLY frequency"
+finding: |
+  selectedMonth and selectedDay retain values when switching to another frequency. If user
+  switches back to YEARLY, stale values reappear.
+severity: critical
+status: wont-fix
+reason: Matches existing weekday behavior — selectedDays is not cleared when switching away from WEEKLY. Keeping state prevents accidental data loss if user briefly switches frequency. The v-if guard prevents stale values from affecting the emitted rrule string.
+---

--- a/tickets/entities/review-responses/RR-YRLY4.md
+++ b/tickets/entities/review-responses/RR-YRLY4.md
@@ -1,0 +1,11 @@
+---
+id: RR-YRLY4
+type: review-response
+title: "NaN from non-numeric day input"
+finding: |
+  Number() on non-numeric input returns NaN which sits in the reactive ref. Currently harmless
+  due to falsy guard but a landmine for future refactors.
+severity: significant
+status: addressed
+resolution: Day input handler now uses Number.isFinite() check and falls back to null for invalid values.
+---

--- a/tickets/entities/review-responses/RR-YRLY5.md
+++ b/tickets/entities/review-responses/RR-YRLY5.md
@@ -1,0 +1,11 @@
+---
+id: RR-YRLY5
+type: review-response
+title: "v-model null coercion risk on month select"
+finding: |
+  v-model on native select with :value="null" can serialize to string "null" in some browsers,
+  bypassing the truthiness guard.
+severity: significant
+status: addressed
+resolution: Replaced v-model with explicit :value and @change handler using empty string as sentinel.
+---

--- a/tickets/entities/review-responses/RR-YRLY6.md
+++ b/tickets/entities/review-responses/RR-YRLY6.md
@@ -1,0 +1,11 @@
+---
+id: RR-YRLY6
+type: review-response
+title: "dtstart not shown for YEARLY frequency"
+finding: |
+  Without dtstart, the rrule library defaults to current moment for first occurrence. User has
+  no control over which year the first occurrence happens.
+severity: significant
+status: wont-fix
+reason: Pre-existing behavior that applies to all frequencies, not specific to this change. The rrule library handles this correctly by defaulting to now. Out of scope for this ticket.
+---

--- a/tickets/entities/tickets/TKT-YRLY.md
+++ b/tickets/entities/tickets/TKT-YRLY.md
@@ -1,0 +1,18 @@
+---
+id: TKT-YRLY
+type: ticket
+title: Add month/day picker for yearly rrules in data-entry widget
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+The RruleBuilder widget supports yearly frequency but provides no UI for selecting which month and day the event occurs on. For use cases like birthdays or anniversaries, users need to express "every year on [month] [day]" (BYMONTH + BYMONTHDAY in RRULE terms).
+
+Currently: selecting "Yearly" only generates `FREQ=YEARLY` with no date specificity.
+Expected: when yearly is selected, show a month dropdown and day-of-month input so the widget generates e.g. `FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=15` for "every year on March 15th".
+
+The monthly frequency already has BYMONTHDAY support in the backend, so this extends the same pattern to the frontend widget.

--- a/tickets/relations/TKT-YRLY--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-YRLY--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YRLY
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-YRLY--has-planning--PLAN-YRLY.md
+++ b/tickets/relations/TKT-YRLY--has-planning--PLAN-YRLY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YRLY
+relation: has-planning
+to: PLAN-YRLY
+---

--- a/tickets/relations/TKT-YRLY--has-review-response--RR-YRLY1.md
+++ b/tickets/relations/TKT-YRLY--has-review-response--RR-YRLY1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YRLY
+relation: has-review-response
+to: RR-YRLY1
+---

--- a/tickets/relations/TKT-YRLY--has-review-response--RR-YRLY2.md
+++ b/tickets/relations/TKT-YRLY--has-review-response--RR-YRLY2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YRLY
+relation: has-review-response
+to: RR-YRLY2
+---

--- a/tickets/relations/TKT-YRLY--has-review-response--RR-YRLY3.md
+++ b/tickets/relations/TKT-YRLY--has-review-response--RR-YRLY3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YRLY
+relation: has-review-response
+to: RR-YRLY3
+---

--- a/tickets/relations/TKT-YRLY--has-review-response--RR-YRLY4.md
+++ b/tickets/relations/TKT-YRLY--has-review-response--RR-YRLY4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YRLY
+relation: has-review-response
+to: RR-YRLY4
+---

--- a/tickets/relations/TKT-YRLY--has-review-response--RR-YRLY5.md
+++ b/tickets/relations/TKT-YRLY--has-review-response--RR-YRLY5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YRLY
+relation: has-review-response
+to: RR-YRLY5
+---

--- a/tickets/relations/TKT-YRLY--has-review-response--RR-YRLY6.md
+++ b/tickets/relations/TKT-YRLY--has-review-response--RR-YRLY6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YRLY
+relation: has-review-response
+to: RR-YRLY6
+---

--- a/tickets/relations/TKT-YRLY--implements--FEAT-DUW9.md
+++ b/tickets/relations/TKT-YRLY--implements--FEAT-DUW9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YRLY
+relation: implements
+to: FEAT-DUW9
+---


### PR DESCRIPTION
## Summary

- Adds month dropdown and day-of-month input to the RruleBuilder widget when YEARLY frequency is selected
- Enables expressing yearly events like birthdays (e.g., "every year on March 15")
- Generates proper RRULE syntax: `FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=15`

## Changes

- `frontend/src/components/forms/RruleBuilder.vue`: month/day picker UI, parsing, and rrule string generation
- Day input clamps to valid range per selected month (e.g., max 28 for February)
- Both month and day must be set before BYMONTH/BYMONTHDAY are emitted (partial selection = plain YEARLY)
- No backend changes needed — Go rrule validation already supports these parameters

## Test plan

- [x] Typecheck passes (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Go tests pass (`just test`)
- [x] Manual verification via data-entry UI with puppeteer