### PR TITLE
tighten storeutil.ValidateID and add storetest.Capabilities

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -35,9 +35,10 @@ override:
 # Exclude packages that are not meaningful to coverage-check
 exclude:
   paths:
-    - ^cmd/rela              # main entry point
-    - ^internal/testutil     # test helpers
-    - ^frontend/node_modules # Go files in npm dependencies
+    - ^cmd/rela                # main entry point
+    - ^internal/testutil       # test helpers
+    - ^internal/store/storetest # shared conformance test kit (exercised via backends)
+    - ^frontend/node_modules   # Go files in npm dependencies
 
 # Require coverage-ignore annotations to have explanatory comments
 force-annotation-comment: true

--- a/internal/store/fsstore/conformance_test.go
+++ b/internal/store/fsstore/conformance_test.go
@@ -58,7 +58,7 @@ func searchFactory(t *testing.T) (store.Store, search.Searcher) {
 }
 
 func TestConformance(t *testing.T) {
-	storetest.RunAll(t, factory, searchFactory)
+	storetest.RunAll(t, factory, searchFactory, storetest.Capabilities{Attachments: true})
 }
 
 func FuzzRelationKeyCollision(f *testing.F) {

--- a/internal/store/memstore/conformance_test.go
+++ b/internal/store/memstore/conformance_test.go
@@ -26,7 +26,7 @@ func fuzzFactory() store.Store {
 }
 
 func TestConformance(t *testing.T) {
-	storetest.RunAll(t, factory, searchFactory)
+	storetest.RunAll(t, factory, searchFactory, storetest.Capabilities{Attachments: true})
 }
 
 func FuzzRelationKeyCollision(f *testing.F) {

--- a/internal/store/storetest/attachment.go
+++ b/internal/store/storetest/attachment.go
@@ -109,6 +109,18 @@ func RunAttachmentTests(t *testing.T, f Factory) {
 		assert.Contains(t, err.Error(), "empty property")
 	})
 
+	t.Run("RejectsSlashInProperty", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("E-1", "t")))
+
+		err := s.AttachFile(ctx(), "E-1", "some/prop", "f.txt", strings.NewReader("data"))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "slash")
+
+		err = s.AttachFile(ctx(), "E-1", "screenshot", "f.png", strings.NewReader("data"))
+		require.NoError(t, err)
+	})
+
 	t.Run("ReaderError", func(t *testing.T) {
 		s := f(t)
 		require.NoError(t, s.CreateEntity(ctx(), entity.New("T-1", "ticket")))

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -22,6 +22,17 @@ type Factory func(t *testing.T) store.Store
 // The store is used for seeding data; the searcher is used for queries.
 type SearchFactory func(t *testing.T) (store.Store, search.Searcher)
 
+// Capabilities declares which optional Store features an implementation
+// supports. Conformance tests gate optional sections on these flags so
+// implementations that omit a feature (e.g. attachments) can still run
+// the rest of the suite.
+type Capabilities struct {
+	// Attachments indicates whether the store implements
+	// AttachmentManager. When false, attachment-related conformance
+	// tests are skipped.
+	Attachments bool
+}
+
 func ctx() context.Context { return context.Background() }
 
 // seedEntities populates a store with a standard set of entities.
@@ -122,7 +133,8 @@ func countRelations(t *testing.T, s store.Store) int {
 
 // RunAll runs the full conformance suite.
 // The optional SearchFactory is used for search tests; if nil, search tests are skipped.
-func RunAll(t *testing.T, f Factory, sf SearchFactory) {
+// Capabilities gates optional feature tests (e.g. attachments).
+func RunAll(t *testing.T, f Factory, sf SearchFactory, caps Capabilities) {
 	t.Run("Entity", func(t *testing.T) { RunEntityTests(t, f) })
 	t.Run("Relation", func(t *testing.T) { RunRelationTests(t, f) })
 	t.Run("Query", func(t *testing.T) { RunQueryTests(t, f) })
@@ -130,7 +142,9 @@ func RunAll(t *testing.T, f Factory, sf SearchFactory) {
 	if sf != nil {
 		t.Run("Search", func(t *testing.T) { RunSearchTests(t, sf) })
 	}
-	t.Run("Attachment", func(t *testing.T) { RunAttachmentTests(t, f) })
+	if caps.Attachments {
+		t.Run("Attachment", func(t *testing.T) { RunAttachmentTests(t, f) })
+	}
 	t.Run("Watcher", func(t *testing.T) { RunWatcherTests(t, f) })
 	t.Run("Validation", func(t *testing.T) { RunValidationTests(t, f) })
 }

--- a/internal/store/storetest/validation.go
+++ b/internal/store/storetest/validation.go
@@ -1,7 +1,6 @@
 package storetest
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +12,32 @@ import (
 
 // RunValidationTests runs input validation conformance tests.
 func RunValidationTests(t *testing.T, f Factory) {
+	t.Run("CreateEntityRejectsInvalidIDs", func(t *testing.T) {
+		s := f(t)
+
+		invalid := []struct {
+			id   string
+			want string
+		}{
+			{"", "empty"},
+			{"foo/bar", "path separator"},
+			{"foo\\bar", "path separator"},
+			{"foo\x00bar", "control character"},
+			{"foo\nbar", "control character"},
+			{"foo\tbar", "control character"},
+			{"foo\x7fbar", "control character"},
+			{"a--b", "consecutive dashes"},
+		}
+		for _, tc := range invalid {
+			err := s.CreateEntity(ctx(), entity.New(tc.id, "t"))
+			assert.Errorf(t, err, "id %q should be rejected", tc.id)
+			if err != nil {
+				assert.Containsf(t, err.Error(), tc.want,
+					"error for id %q should mention %q", tc.id, tc.want)
+			}
+		}
+	})
+
 	t.Run("RelationKeyRejectsDoubleDash", func(t *testing.T) {
 		s := f(t)
 
@@ -28,18 +53,6 @@ func RunValidationTests(t *testing.T, f Factory) {
 		assert.Contains(t, err.Error(), "consecutive dashes")
 
 		_, err = s.CreateRelation(ctx(), "A-B", "requires", "C-D", nil)
-		require.NoError(t, err)
-	})
-
-	t.Run("AttachmentKeyRejectsSlash", func(t *testing.T) {
-		s := f(t)
-		require.NoError(t, s.CreateEntity(ctx(), entity.New("E-1", "t")))
-
-		err := s.AttachFile(ctx(), "E-1", "some/prop", "f.txt", strings.NewReader("data"))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "slash")
-
-		err = s.AttachFile(ctx(), "E-1", "screenshot", "f.png", strings.NewReader("data"))
 		require.NoError(t, err)
 	})
 

--- a/internal/store/storeutil/storeutil.go
+++ b/internal/store/storeutil/storeutil.go
@@ -15,14 +15,30 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
-// ValidateID rejects IDs that would cause key collisions in the
-// from--type--to relation key format.
+// ValidateID rejects IDs that would cause key collisions or bucket-key
+// corruption across store backends.
+//
+// In addition to the `--` separator rule (which collides with the
+// from--type--to relation key format), IDs cannot contain path
+// separators, NUL, or ASCII control characters. Those would break
+// nested-bucket range scans in backends that key on bucket hierarchy
+// (see internal/store/boltstore) and have always been latent hazards
+// in fsstore (NUL crashes file creation on POSIX; `/` silently creates
+// nested directories).
 func ValidateID(id string) error {
 	if id == "" {
 		return errors.New("store: empty ID")
 	}
 	if strings.Contains(id, "--") {
 		return fmt.Errorf("store: ID %q contains consecutive dashes", id)
+	}
+	if strings.ContainsAny(id, "/\\") {
+		return fmt.Errorf("store: ID %q contains path separator", id)
+	}
+	for i := 0; i < len(id); i++ {
+		if id[i] < 0x20 || id[i] == 0x7f {
+			return fmt.Errorf("store: ID %q contains control character", id)
+		}
 	}
 	return nil
 }

--- a/internal/store/storeutil/storeutil.go
+++ b/internal/store/storeutil/storeutil.go
@@ -35,7 +35,7 @@ func ValidateID(id string) error {
 	if strings.ContainsAny(id, "/\\") {
 		return fmt.Errorf("store: ID %q contains path separator", id)
 	}
-	for i := 0; i < len(id); i++ {
+	for i := range len(id) {
 		if id[i] < 0x20 || id[i] == 0x7f {
 			return fmt.Errorf("store: ID %q contains control character", id)
 		}

--- a/internal/store/storeutil/storeutil_test.go
+++ b/internal/store/storeutil/storeutil_test.go
@@ -1,7 +1,6 @@
 package storeutil_test
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
@@ -122,7 +121,7 @@ func TestCursorRoundTrip(t *testing.T) {
 	t.Run("empty cursor decodes to empty", func(t *testing.T) {
 		got, err := storeutil.DecodeCursor("")
 		require.NoError(t, err)
-		assert.Equal(t, "", got)
+		assert.Empty(t, got)
 	})
 
 	t.Run("invalid cursor errors", func(t *testing.T) {
@@ -168,7 +167,7 @@ func TestPaginateSortedKeys(t *testing.T) {
 	})
 
 	t.Run("filters via match", func(t *testing.T) {
-		vowels := func(k string) bool { return strings.Contains("aeiou", k) }
+		vowels := func(k string) bool { return strings.Contains(k, "a") || strings.Contains(k, "e") }
 		page := storeutil.PaginateSortedKeys(keys, "", 0, vowels)
 		assert.Equal(t, []string{"a", "e"}, page.Keys)
 	})
@@ -216,6 +215,6 @@ func TestMatchRelation(t *testing.T) {
 func TestValidateIDErrorShape(t *testing.T) {
 	err := storeutil.ValidateID("")
 	require.Error(t, err)
-	assert.False(t, errors.Is(err, store.ErrNotFound),
+	assert.NotErrorIs(t, err, store.ErrNotFound,
 		"ValidateID errors must not collide with store sentinels")
 }

--- a/internal/store/storeutil/storeutil_test.go
+++ b/internal/store/storeutil/storeutil_test.go
@@ -1,0 +1,221 @@
+package storeutil_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/storeutil"
+)
+
+func TestValidateID(t *testing.T) {
+	cases := []struct {
+		name    string
+		id      string
+		wantErr string
+	}{
+		{"empty", "", "empty ID"},
+		{"consecutive dashes", "FOO--BAR", "consecutive dashes"},
+		{"forward slash", "FOO/BAR", "path separator"},
+		{"backslash", "FOO\\BAR", "path separator"},
+		{"NUL byte", "FOO\x00BAR", "control character"},
+		{"tab", "FOO\tBAR", "control character"},
+		{"newline", "FOO\nBAR", "control character"},
+		{"DEL", "FOO\x7fBAR", "control character"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := storeutil.ValidateID(tc.id)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+
+	t.Run("accepts plain ASCII", func(t *testing.T) {
+		assert.NoError(t, storeutil.ValidateID("FOO-BAR"))
+		assert.NoError(t, storeutil.ValidateID("TKT-001"))
+		assert.NoError(t, storeutil.ValidateID("a"))
+	})
+
+	t.Run("accepts multi-byte UTF-8", func(t *testing.T) {
+		// Continuation bytes are 0x80+ so they never register as control chars.
+		assert.NoError(t, storeutil.ValidateID("café"))
+		assert.NoError(t, storeutil.ValidateID("日本語"))
+	})
+}
+
+func TestValidateProperty(t *testing.T) {
+	t.Run("rejects empty", func(t *testing.T) {
+		err := storeutil.ValidateProperty("")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty property name")
+	})
+
+	t.Run("rejects slash", func(t *testing.T) {
+		err := storeutil.ValidateProperty("foo/bar")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "slash")
+	})
+
+	t.Run("accepts normal names", func(t *testing.T) {
+		assert.NoError(t, storeutil.ValidateProperty("screenshot"))
+		assert.NoError(t, storeutil.ValidateProperty("spec-sheet"))
+	})
+}
+
+func TestSortedInsert(t *testing.T) {
+	t.Run("into empty", func(t *testing.T) {
+		got := storeutil.SortedInsert(nil, "b")
+		assert.Equal(t, []string{"b"}, got)
+	})
+
+	t.Run("at start", func(t *testing.T) {
+		got := storeutil.SortedInsert([]string{"b", "c"}, "a")
+		assert.Equal(t, []string{"a", "b", "c"}, got)
+	})
+
+	t.Run("in middle", func(t *testing.T) {
+		got := storeutil.SortedInsert([]string{"a", "c"}, "b")
+		assert.Equal(t, []string{"a", "b", "c"}, got)
+	})
+
+	t.Run("at end", func(t *testing.T) {
+		got := storeutil.SortedInsert([]string{"a", "b"}, "c")
+		assert.Equal(t, []string{"a", "b", "c"}, got)
+	})
+}
+
+func TestSortedRemove(t *testing.T) {
+	t.Run("from middle", func(t *testing.T) {
+		got := storeutil.SortedRemove([]string{"a", "b", "c"}, "b")
+		assert.Equal(t, []string{"a", "c"}, got)
+	})
+
+	t.Run("only element", func(t *testing.T) {
+		got := storeutil.SortedRemove([]string{"x"}, "x")
+		assert.Empty(t, got)
+	})
+
+	t.Run("panics on missing key", func(t *testing.T) {
+		assert.PanicsWithValue(t,
+			"storeutil: SortedRemove called with missing key: z",
+			func() { storeutil.SortedRemove([]string{"a", "b"}, "z") })
+	})
+}
+
+func TestCursorRoundTrip(t *testing.T) {
+	cases := []string{"", "key", "TKT-001", "with spaces", "日本語", "a/b\\c"}
+	for _, key := range cases {
+		t.Run(key, func(t *testing.T) {
+			cursor := storeutil.EncodeCursor(key)
+			got, err := storeutil.DecodeCursor(cursor)
+			require.NoError(t, err)
+			assert.Equal(t, key, got)
+		})
+	}
+
+	t.Run("empty cursor decodes to empty", func(t *testing.T) {
+		got, err := storeutil.DecodeCursor("")
+		require.NoError(t, err)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("invalid cursor errors", func(t *testing.T) {
+		_, err := storeutil.DecodeCursor("!!not-base64!!")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid cursor")
+	})
+}
+
+func TestPaginateSortedKeys(t *testing.T) {
+	keys := []string{"a", "b", "c", "d", "e"}
+	matchAll := func(string) bool { return true }
+
+	t.Run("no limit returns all", func(t *testing.T) {
+		page := storeutil.PaginateSortedKeys(keys, "", 0, matchAll)
+		assert.Equal(t, keys, page.Keys)
+		assert.Empty(t, page.NextCursor)
+	})
+
+	t.Run("limit with more results sets cursor", func(t *testing.T) {
+		page := storeutil.PaginateSortedKeys(keys, "", 2, matchAll)
+		assert.Equal(t, []string{"a", "b"}, page.Keys)
+		got, err := storeutil.DecodeCursor(page.NextCursor)
+		require.NoError(t, err)
+		assert.Equal(t, "b", got)
+	})
+
+	t.Run("limit on exact last page leaves cursor empty", func(t *testing.T) {
+		page := storeutil.PaginateSortedKeys(keys, "", 5, matchAll)
+		assert.Equal(t, keys, page.Keys)
+		assert.Empty(t, page.NextCursor)
+	})
+
+	t.Run("cursor skips emitted key", func(t *testing.T) {
+		page := storeutil.PaginateSortedKeys(keys, "b", 2, matchAll)
+		assert.Equal(t, []string{"c", "d"}, page.Keys)
+	})
+
+	t.Run("cursor past end yields empty page", func(t *testing.T) {
+		page := storeutil.PaginateSortedKeys(keys, "z", 10, matchAll)
+		assert.Empty(t, page.Keys)
+		assert.Empty(t, page.NextCursor)
+	})
+
+	t.Run("filters via match", func(t *testing.T) {
+		vowels := func(k string) bool { return strings.Contains("aeiou", k) }
+		page := storeutil.PaginateSortedKeys(keys, "", 0, vowels)
+		assert.Equal(t, []string{"a", "e"}, page.Keys)
+	})
+
+	t.Run("non-present cursor resumes at next key", func(t *testing.T) {
+		// "bb" isn't in keys but sorts between "b" and "c"; resume from "c".
+		page := storeutil.PaginateSortedKeys(keys, "bb", 2, matchAll)
+		assert.Equal(t, []string{"c", "d"}, page.Keys)
+	})
+}
+
+func TestMatchRelation(t *testing.T) {
+	rel := &entity.Relation{From: "A", Type: "links", To: "B"}
+
+	cases := []struct {
+		name  string
+		query store.RelationQuery
+		want  bool
+	}{
+		{"empty query matches", store.RelationQuery{}, true},
+		{"type match", store.RelationQuery{Type: "links"}, true},
+		{"type mismatch", store.RelationQuery{Type: "other"}, false},
+		{"from match", store.RelationQuery{From: "A"}, true},
+		{"from mismatch", store.RelationQuery{From: "X"}, false},
+		{"to match", store.RelationQuery{To: "B"}, true},
+		{"to mismatch", store.RelationQuery{To: "X"}, false},
+		{"entity outgoing match", store.RelationQuery{EntityID: "A", Direction: store.DirectionOutgoing}, true},
+		{"entity outgoing mismatch", store.RelationQuery{EntityID: "B", Direction: store.DirectionOutgoing}, false},
+		{"entity incoming match", store.RelationQuery{EntityID: "B", Direction: store.DirectionIncoming}, true},
+		{"entity incoming mismatch", store.RelationQuery{EntityID: "A", Direction: store.DirectionIncoming}, false},
+		{"entity both (from)", store.RelationQuery{EntityID: "A", Direction: store.DirectionBoth}, true},
+		{"entity both (to)", store.RelationQuery{EntityID: "B", Direction: store.DirectionBoth}, true},
+		{"entity both mismatch", store.RelationQuery{EntityID: "Z", Direction: store.DirectionBoth}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, storeutil.MatchRelation(rel, tc.query))
+		})
+	}
+}
+
+// Sanity check that ValidateID errors compose with errors.Is-style wrapping
+// if a caller ever needs it — the function returns plain fmt.Errorf errors,
+// so equality by message is the current contract.
+func TestValidateIDErrorShape(t *testing.T) {
+	err := storeutil.ValidateID("")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, store.ErrNotFound),
+		"ValidateID errors must not collide with store sentinels")
+}

--- a/tickets/entities/concepts/store-backends.md
+++ b/tickets/entities/concepts/store-backends.md
@@ -1,0 +1,10 @@
+---
+description: "Pluggable persistence layer behind a single `store.Store` interface. Current backends: `fsstore` (markdown files on disk) and `memstore` (in-memory, for tests and scripts); a `boltstore` backend is planned. Backend-independent invariants — ID validation, attachment-key rules, query semantics, relation integrity — live in `internal/store/storeutil` and `internal/store/storetest` so every backend runs the same conformance suite. A `Capabilities` struct lets backends opt in or out of optional features (e.g. attachments)."
+id: store-backends
+layer: core
+package: internal/store
+status: draft
+summary: Pluggable store.Store backends with shared conformance test-kit
+title: Store Backends
+type: concept
+---

--- a/tickets/entities/features/FEAT-CO4YP.md
+++ b/tickets/entities/features/FEAT-CO4YP.md
@@ -1,0 +1,8 @@
+---
+id: FEAT-CO4YP
+type: feature
+title: Pluggable store backends with conformance test-kit
+summary: Unify entity and relation access behind `store.Store` with multiple backends (fsstore, memstore, future boltstore) sharing a single conformance test suite.
+description: Pluggable store backends sit behind a single `store.Store` interface. Backend-independent invariants (ID validation, attachment keys, query semantics) live in `internal/store/storeutil` and `internal/store/storetest` so every backend runs the same conformance tests. A `Capabilities` struct lets backends opt in or out of optional features like attachments.
+status: in-progress
+---

--- a/tickets/entities/tickets/TKT-CO4YP.md
+++ b/tickets/entities/tickets/TKT-CO4YP.md
@@ -1,0 +1,34 @@
+---
+id: TKT-CO4YP
+type: ticket
+title: Tighten storeutil.ValidateID and add storetest.Capabilities
+kind: refactor
+priority: medium
+effort: xs
+status: ready
+---
+
+## Description
+
+Preparatory work for an upcoming boltstore backend. Two changes to the shared
+store test-kit so that conformance tests run cleanly across backends with
+different capabilities, and so backend-independent invariants live in one place.
+
+## Scope
+
+- `storeutil.ValidateID` additionally rejects path separators (`/`, `\`), NUL,
+  and ASCII control characters. These were always latent hazards in fsstore
+  (NUL crashes file creation on POSIX; `/` silently nests directories) and
+  will be correctness requirements for any nested-bucket backend.
+- New conformance test `CreateEntityRejectsInvalidIDs` enforces the rules
+  uniformly across fsstore and memstore.
+- `storetest.RunAll` takes a `Capabilities` struct; attachment tests are gated
+  on `Capabilities.Attachments`. The attachment-key slash check moves from
+  `validation.go` into `attachment.go` where it belongs.
+
+## Acceptance criteria
+
+- `go test ./internal/store/...` passes for fsstore, memstore, and storetest.
+- `CreateEntityRejectsInvalidIDs` runs on both fsstore and memstore.
+- No existing conformance tests regress.
+- Zero violations of the tightened rules in committed entity IDs in this repo.

--- a/tickets/entities/tickets/TKT-SUREF.md
+++ b/tickets/entities/tickets/TKT-SUREF.md
@@ -1,0 +1,65 @@
+---
+id: TKT-SUREF
+type: ticket
+title: Refactor storeutil — decompose ValidateID, return bool from SortedRemove, move MatchRelation to RelationQuery
+kind: refactor
+priority: medium
+effort: s
+status: backlog
+---
+
+## Description
+
+Three improvements to `internal/store/storeutil/storeutil.go` identified during
+the architecture review of PR #403 (TKT-CO4YP). Each is a small API-shape change
+with callers in `fsstore`, `memstore`, and the planned `boltstore`.
+
+### 1. Decompose `ValidateID`
+
+Today `ValidateID` conflates three distinct rule sets:
+
+- `--` sequence → collides with the `from--type--to` relation key format
+  (a `store` package concern)
+- Path separators + NUL → filesystem safety (fsstore concern)
+- Control characters → bucket-key safety (boltstore concern)
+
+Split into composable primitives:
+
+```go
+func ValidateIDChars(id string) error       // NUL, control, separators
+func ValidateIDRelationKey(id string) error // also rejects "--"
+func ValidateID(id string) error            // calls both (common path)
+```
+
+This makes each rule's rationale visible per-backend and lets a hypothetical
+pure-KV backend opt out of relation-key rules honestly.
+
+### 2. `SortedRemove` should not panic
+
+Current contract panics when the key is missing ("callers confirm presence
+first"). A bug in any backend panics the whole process. Change to:
+
+```go
+func SortedRemove(s []string, key string) (result []string, removed bool)
+```
+
+Mirrors `sync.Map.LoadAndDelete`. Call sites that truly must-exist can wrap
+with their own assertion.
+
+### 3. Move `MatchRelation` to `RelationQuery.Matches`
+
+`storeutil.MatchRelation(r, q)` has zero overlap with ID/cursor/sort
+concerns and depends entirely on `store.RelationQuery` / `store.Direction`.
+Natural home is `internal/store/store.go`:
+
+```go
+func (q RelationQuery) Matches(r *entity.Relation) bool
+```
+
+Discoverable next to the type definition and removes the
+`store → storeutil → store` conceptual round-trip.
+
+## Motivation
+
+From architect review in PR #403. None of these block the PR, but they are
+real improvements worth landing as a follow-up.

--- a/tickets/relations/FEAT-CO4YP--requires--store-backends.md
+++ b/tickets/relations/FEAT-CO4YP--requires--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-CO4YP
+relation: requires
+to: store-backends
+---

--- a/tickets/relations/TKT-CO4YP--affects--store-backends.md
+++ b/tickets/relations/TKT-CO4YP--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CO4YP
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-CO4YP--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-CO4YP--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CO4YP
+relation: implements
+to: FEAT-CO4YP
+---

--- a/tickets/relations/TKT-SUREF--affects--store-backends.md
+++ b/tickets/relations/TKT-SUREF--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SUREF
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-SUREF--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-SUREF--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SUREF
+relation: implements
+to: FEAT-CO4YP
+---


### PR DESCRIPTION
## Summary

Preparatory work for the upcoming boltstore backend ([TKT-CO4YP](../tickets/entities/tickets/TKT-CO4YP.md) / [FEAT-CO4YP](../tickets/entities/features/FEAT-CO4YP.md), [store-backends](../tickets/entities/concepts/store-backends.md)).

- `storeutil.ValidateID` now also rejects path separators (`/`, `\`), NUL, and ASCII control chars.
- New storetest conformance test `CreateEntityRejectsInvalidIDs` enforces the rules uniformly across backends.
- `storetest.RunAll` takes a `Capabilities` struct; attachment tests are gated on `Capabilities.Attachments`. The attachment-key slash check moves from validation.go into attachment.go where it belongs.

Path separators and NUL were always latent hazards in fsstore (NUL crashes file creation on POSIX; `/` silently nests directories). The tightening is a latent safety fix today and a correctness requirement for a future nested-bucket boltstore.

## Test plan

- [x] `go test ./internal/store/...` passes (fsstore, memstore, storetest)
- [x] `just test` (full suite with race detection) passes
- [x] New `CreateEntityRejectsInvalidIDs` test runs on both fsstore and memstore
- [x] No existing conformance tests regress
- [x] Audit of committed entity IDs in this repo: zero violations of the tightened rules