### PR TITLE
ci: use GitHub App token for coverage ratchet PRs

### DIFF
--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -14,7 +14,16 @@ jobs:
     name: Update Coverage Baseline
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -54,7 +63,7 @@ jobs:
 
       - name: Create PR for updated baseline
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if git diff --quiet .coverage-baseline frontend/.coverage-baseline; then
             echo "No coverage baseline changes"


### PR DESCRIPTION
## Summary
- Swap the default `GITHUB_TOKEN` for a short-lived GitHub App token in `coverage-ratchet.yml`
- Fixes the root cause behind #402: PRs opened with `GITHUB_TOKEN` don't trigger downstream workflows (anti-recursion guard), so `ci.yml` never runs on auto-generated baseline PRs
- Baseline PRs created by the app will now fire CI normally and auto-merge once green

## Test plan
- [ ] Merge this PR
- [ ] Next merge to `develop` triggers `coverage-ratchet.yml`
- [ ] Resulting baseline PR shows CI checks running (not empty)