### PR TITLE
ci: skip baseline guards on ratchet PR; drop stale rela sync call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
   baseline-guard:
     name: Coverage Baseline Guard
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.head_ref != 'chore/coverage-baseline-update'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -152,7 +152,7 @@ jobs:
 
   frontend-baseline-guard:
     name: Frontend Coverage Baseline Guard
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.head_ref != 'chore/coverage-baseline-update'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -2,9 +2,8 @@
 # Generate documentation from rela entities using Lua scripts.
 #
 # This script:
-# 1. Syncs the docs-project graph (validates entities/relations)
-# 2. Runs the Lua script to generate docs from entities
-# 3. Creates directories and ensures proper file endings
+# 1. Runs the Lua script to generate docs from entities
+# 2. Creates directories and ensures proper file endings
 #
 # Prerequisites:
 #   - bin/rela must exist (run 'just build-cli' first)
@@ -23,10 +22,6 @@ if [[ ! -x "$RELA" ]]; then
     exit 1
 fi
 
-echo "==> Syncing docs-project graph..."
-(cd "$DOCS_PROJECT" && "$RELA" sync)
-
-echo ""
 echo "==> Validating docs-project..."
 (cd "$DOCS_PROJECT" && "$RELA" analyze orphans) || true
 


### PR DESCRIPTION
## Summary
- **Baseline guards**: skip `Coverage Baseline Guard` and `Frontend Coverage Baseline Guard` when the PR branch is `chore/coverage-baseline-update`. The guards exist to stop humans from hand-editing the baseline down to dodge the ratchet — but they shouldn't fire on the ratchet's own regeneration PR, where a legitimately lower baseline can occur after a big refactor.
- **Docs script**: drop the `rela sync` call in `scripts/generate-docs.sh` — that command was removed in #400. Graph sync is now implicit on any command that touches the graph.

Unblocks PR #407 and fixes the `Docs` CI job failure.

## Test plan
- [ ] Merge
- [ ] Trigger coverage-ratchet (next merge to develop) — resulting baseline PR skips both guards and goes green
- [ ] Docs job on this PR passes