### PR TITLE
docs: regenerate README.md from docs-project entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,31 +69,16 @@ go build -o rela ./cmd/rela
 
 | Document | Description |
 | -------- | -------- |
-| [Getting Started](docs/getting-started.md) | Installation, first project, core workflow |
-| [Concepts](docs/concepts.md) | Architecture traceability fundamentals |
-| [CLI Reference](docs/cli-reference.md) | Complete command reference |
-| [Metamodel Reference](docs/metamodel.md) | Configure entity types and relations |
-| [Export Guide](docs/export.md) | Export, import, and data integration |
-| [Best Practices](docs/best-practices.md) | Maintenance tips and team workflows |
-| [MCP Server](docs/mcp-server.md) | AI assistant integration via MCP |
-| [Data Entry Web App](docs/data-entry.md) | Config-driven web UI for entity management |
-| [Lua Scripting](docs/lua-scripting.md) | Programmable automation with embedded Lua |
-| [Scheduled Tasks](docs/scheduled-tasks.md) | Run Lua scripts on recurring schedules |
 
 ### Tutorials
 
 | Tutorial | Description |
 | -------- | -------- |
-| [Tutorial: Building an ISO 27001 ISMS with Rela](docs/tutorials/iso27001-isms-tutorial.md) | Build a complete Information Security Management System |
-| [Tutorial: Hybrid Project Management with Rela](docs/tutorials/project-management-tutorial.md) | Build a hybrid project management system |
 
 ### Scenarios
 
 | Scenario | Description |
 | -------- | -------- |
-| [Scenario: DevOps/SRE Runbooks & Infrastructure Operations](docs/scenarios/devops-runbooks.md) | DevOps/SRE runbooks and infrastructure operations |
-| [Scenario: ISO 27001 Information Security Management System](docs/scenarios/iso27001-isms.md) | ISO 27001 Information Security Management System |
-| [Scenario: Hybrid Project Management](docs/scenarios/project-management.md) | Hybrid project management documentation |
 
 ## Project Structure
 


### PR DESCRIPTION
Regenerated README.md via `./scripts/generate-docs.sh`. Unblocks the Docs CI check that was failing on every PR (including the post-merge-sync auto-PRs).