### PR TITLE
fix(desktop): marshal data-entry.yaml via yaml.v3 (BUG-F9I2Z)

### DIFF
--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
+	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/dataentry"
 	"github.com/Sourcehaven-BV/rela/internal/desktop"
@@ -761,82 +762,96 @@ func discoverProject(projectDir string) (storage.FS, *project.Context, error) {
 }
 
 // generateDataEntryConfig creates a minimal data-entry.yaml from the metamodel.
+// Builds a typed structure and marshals via yaml.v3 so every string value is
+// correctly escaped regardless of the characters a user's metamodel contains.
 func generateDataEntryConfig(appName string, meta *metamodel.Metamodel) string {
-	var sb strings.Builder
-	sb.WriteString("version: \"1\"\n\n")
-	sb.WriteString("app:\n")
-	fmt.Fprintf(&sb, "  name: %q\n", appName)
-	sb.WriteString("  description: \"Generated data entry configuration\"\n\n")
-
-	// Get sorted entity types
 	entityTypes := make([]string, 0, len(meta.Entities))
 	for name := range meta.Entities {
 		entityTypes = append(entityTypes, name)
 	}
 	sort.Strings(entityTypes)
 
-	// Generate forms
-	sb.WriteString("forms:\n")
+	forms := yaml.Node{Kind: yaml.MappingNode}
+	lists := yaml.Node{Kind: yaml.MappingNode}
+	navigation := yaml.Node{Kind: yaml.SequenceNode}
+
+	const maxColumns = 4
 	for _, typeName := range entityTypes {
 		entDef := meta.Entities[typeName]
 		formID := strings.ReplaceAll(typeName, "-", "_")
-		fmt.Fprintf(&sb, "  %s:\n", formID)
-		fmt.Fprintf(&sb, "    entity_type: %s\n", typeName)
-		fmt.Fprintf(&sb, "    title: \"%s\"\n", titleCase(typeName))
-		sb.WriteString("    fields:\n")
+		listID := formID + "s"
 
-		// Add fields for each property
 		propNames := make([]string, 0, len(entDef.Properties))
 		for name := range entDef.Properties {
 			propNames = append(propNames, name)
 		}
 		sort.Strings(propNames)
+
+		fields := make([]map[string]string, 0, len(propNames))
 		for _, propName := range propNames {
-			fmt.Fprintf(&sb, "      - property: %s\n", propName)
-			fmt.Fprintf(&sb, "        label: \"%s\"\n", titleCase(propName))
+			fields = append(fields, map[string]string{"property": propName, "label": titleCase(propName)})
 		}
-	}
-	sb.WriteString("\n")
+		appendMapEntry(&forms, formID, map[string]any{
+			"entity_type": typeName,
+			"title":       titleCase(typeName),
+			"fields":      fields,
+		})
 
-	// Generate lists
-	sb.WriteString("lists:\n")
-	for _, typeName := range entityTypes {
-		entDef := meta.Entities[typeName]
-		listID := strings.ReplaceAll(typeName, "-", "_") + "s"
-		fmt.Fprintf(&sb, "  %s:\n", listID)
-		fmt.Fprintf(&sb, "    entity_type: %s\n", typeName)
-		fmt.Fprintf(&sb, "    title: \"%s\"\n", titleCase(typeName)+"s")
-		sb.WriteString("    columns:\n")
-
-		// Add first few properties as columns
-		colPropNames := make([]string, 0, len(entDef.Properties))
-		for name := range entDef.Properties {
-			colPropNames = append(colPropNames, name)
-		}
-		sort.Strings(colPropNames)
-		const maxColumns = 4
-		for i, propName := range colPropNames {
+		columns := make([]map[string]string, 0, maxColumns)
+		for i, propName := range propNames {
 			if i >= maxColumns {
 				break
 			}
-			fmt.Fprintf(&sb, "      - property: %s\n", propName)
-			fmt.Fprintf(&sb, "        label: \"%s\"\n", titleCase(propName))
+			columns = append(columns, map[string]string{"property": propName, "label": titleCase(propName)})
 		}
-		formID := strings.ReplaceAll(typeName, "-", "_")
-		fmt.Fprintf(&sb, "    create_form: %s\n", formID)
-		fmt.Fprintf(&sb, "    edit_form: %s\n", formID)
-	}
-	sb.WriteString("\n")
+		appendMapEntry(&lists, listID, map[string]any{
+			"entity_type": typeName,
+			"title":       titleCase(typeName) + "s",
+			"columns":     columns,
+			"create_form": formID,
+			"edit_form":   formID,
+		})
 
-	// Generate navigation
-	sb.WriteString("navigation:\n")
-	for _, typeName := range entityTypes {
-		listID := strings.ReplaceAll(typeName, "-", "_") + "s"
-		fmt.Fprintf(&sb, "  - label: \"%s\"\n", titleCase(typeName)+"s")
-		fmt.Fprintf(&sb, "    list: %s\n", listID)
+		navItem := yaml.Node{Kind: yaml.MappingNode}
+		appendMapEntry(&navItem, "label", titleCase(typeName)+"s")
+		appendMapEntry(&navItem, "list", listID)
+		navigation.Content = append(navigation.Content, &navItem)
 	}
 
-	return sb.String()
+	root := yaml.Node{Kind: yaml.MappingNode}
+	appendMapEntry(&root, "version", "1")
+	appendMapEntry(&root, "app", map[string]any{
+		"name":        appName,
+		"description": "Generated data entry configuration",
+	})
+	root.Content = append(root.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "forms"}, &forms,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "lists"}, &lists,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "navigation"}, &navigation,
+	)
+
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		// yaml.Marshal on a manually-built node graph shouldn't fail; surface
+		// as a comment so the generated file is still valid YAML.
+		return fmt.Sprintf("# failed to generate config: %v\n", err)
+	}
+	return string(out)
+}
+
+// appendMapEntry adds a key/value pair to a yaml MappingNode. Value may be any
+// Go value yaml.Marshal accepts (string, map, slice, etc.) or a pre-built
+// *yaml.Node.
+func appendMapEntry(m *yaml.Node, key string, value any) {
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: key}
+	var valNode *yaml.Node
+	if n, ok := value.(*yaml.Node); ok {
+		valNode = n
+	} else {
+		valNode = &yaml.Node{}
+		_ = valNode.Encode(value)
+	}
+	m.Content = append(m.Content, keyNode, valNode)
 }
 
 // titleCase converts a-kebab-case or snake_case to Title Case.

--- a/cmd/rela-desktop/main_test.go
+++ b/cmd/rela-desktop/main_test.go
@@ -3,14 +3,24 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
+
+// decodeConfig parses the string returned by generateDataEntryConfig into a
+// generic map. Tests use this rather than substring matching so they stay
+// independent of yaml.v3 formatting choices (when it quotes vs doesn't).
+func decodeConfig(t *testing.T, config string) map[string]any {
+	t.Helper()
+	var out map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(config), &out), "generated config must be valid YAML")
+	return out
+}
 
 func TestTitleCase(t *testing.T) {
 	tests := []struct {
@@ -100,38 +110,40 @@ func TestGenerateDataEntryConfig(t *testing.T) {
 		},
 	}
 
-	config := generateDataEntryConfig("Test App", meta)
+	cfg := decodeConfig(t, generateDataEntryConfig("Test App", meta))
 
-	// Check app name (new format uses app.name)
-	assert.Contains(t, config, "name: \"Test App\"")
+	app := cfg["app"].(map[string]any)
+	assert.Equal(t, "Test App", app["name"])
 
-	// Check forms section
-	assert.Contains(t, config, "forms:")
-	assert.Contains(t, config, "  feature:")
-	assert.Contains(t, config, "    entity_type: feature")
-	assert.Contains(t, config, "    title: \"Feature\"")
-	assert.Contains(t, config, "  bug:")
-	assert.Contains(t, config, "    entity_type: bug")
-	assert.Contains(t, config, "    title: \"Bug\"")
+	forms := cfg["forms"].(map[string]any)
+	feature := forms["feature"].(map[string]any)
+	assert.Equal(t, "feature", feature["entity_type"])
+	assert.Equal(t, "Feature", feature["title"])
+	bug := forms["bug"].(map[string]any)
+	assert.Equal(t, "bug", bug["entity_type"])
+	assert.Equal(t, "Bug", bug["title"])
 
-	// Check lists section
-	assert.Contains(t, config, "lists:")
-	assert.Contains(t, config, "  features:")
-	assert.Contains(t, config, "    entity_type: feature")
-	assert.Contains(t, config, "  bugs:")
-	assert.Contains(t, config, "    entity_type: bug")
+	lists := cfg["lists"].(map[string]any)
+	featuresList := lists["features"].(map[string]any)
+	assert.Equal(t, "feature", featuresList["entity_type"])
+	bugsList := lists["bugs"].(map[string]any)
+	assert.Equal(t, "bug", bugsList["entity_type"])
 
-	// Check navigation section
-	assert.Contains(t, config, "navigation:")
-	assert.Contains(t, config, "  - label: \"Features\"")
-	assert.Contains(t, config, "    list: features")
-	assert.Contains(t, config, "  - label: \"Bugs\"")
-	assert.Contains(t, config, "    list: bugs")
+	navigation := cfg["navigation"].([]any)
+	navLabels := make([]string, 0, len(navigation))
+	for _, item := range navigation {
+		navLabels = append(navLabels, item.(map[string]any)["label"].(string))
+	}
+	assert.Contains(t, navLabels, "Features")
+	assert.Contains(t, navLabels, "Bugs")
 
-	// Check properties exist (they're sorted alphabetically)
-	assert.Contains(t, config, "property: priority")
-	assert.Contains(t, config, "property: status")
-	assert.Contains(t, config, "property: title")
+	// Properties are sorted alphabetically
+	featureFields := feature["fields"].([]any)
+	propNames := make([]string, 0, len(featureFields))
+	for _, f := range featureFields {
+		propNames = append(propNames, f.(map[string]any)["property"].(string))
+	}
+	assert.Equal(t, []string{"priority", "status", "title"}, propNames)
 }
 
 func TestGenerateDataEntryConfig_EmptyMetamodel(t *testing.T) {
@@ -139,12 +151,12 @@ func TestGenerateDataEntryConfig_EmptyMetamodel(t *testing.T) {
 		Entities: map[string]metamodel.EntityDef{},
 	}
 
-	config := generateDataEntryConfig("Empty App", meta)
-
-	assert.Contains(t, config, "name: \"Empty App\"")
-	assert.Contains(t, config, "forms:")
-	assert.Contains(t, config, "lists:")
-	assert.Contains(t, config, "navigation:")
+	cfg := decodeConfig(t, generateDataEntryConfig("Empty App", meta))
+	app := cfg["app"].(map[string]any)
+	assert.Equal(t, "Empty App", app["name"])
+	assert.Contains(t, cfg, "forms")
+	assert.Contains(t, cfg, "lists")
+	assert.Contains(t, cfg, "navigation")
 }
 
 func TestGenerateDataEntryConfig_KebabCaseEntityType(t *testing.T) {
@@ -158,15 +170,21 @@ func TestGenerateDataEntryConfig_KebabCaseEntityType(t *testing.T) {
 		},
 	}
 
-	config := generateDataEntryConfig("Test App", meta)
+	cfg := decodeConfig(t, generateDataEntryConfig("Test App", meta))
 
-	// Kebab-case should be converted to underscore for form/list IDs
-	assert.Contains(t, config, "  test_case:")
-	assert.Contains(t, config, "    entity_type: test-case")
-	assert.Contains(t, config, "    title: \"Test Case\"")
-	assert.Contains(t, config, "  test_cases:")
-	assert.Contains(t, config, "  - label: \"Test Cases\"")
-	assert.Contains(t, config, "    list: test_cases")
+	forms := cfg["forms"].(map[string]any)
+	testCase := forms["test_case"].(map[string]any) // hyphen -> underscore for the key
+	assert.Equal(t, "test-case", testCase["entity_type"])
+	assert.Equal(t, "Test Case", testCase["title"])
+
+	lists := cfg["lists"].(map[string]any)
+	require.Contains(t, lists, "test_cases")
+
+	navigation := cfg["navigation"].([]any)
+	require.Len(t, navigation, 1)
+	nav := navigation[0].(map[string]any)
+	assert.Equal(t, "Test Cases", nav["label"])
+	assert.Equal(t, "test_cases", nav["list"])
 }
 
 func TestGenerateDataEntryConfig_MaxColumns(t *testing.T) {
@@ -185,25 +203,50 @@ func TestGenerateDataEntryConfig_MaxColumns(t *testing.T) {
 		},
 	}
 
-	config := generateDataEntryConfig("Test App", meta)
+	cfg := decodeConfig(t, generateDataEntryConfig("Test App", meta))
+	entitys := cfg["lists"].(map[string]any)["entitys"].(map[string]any)
+	columns := entitys["columns"].([]any)
+	assert.Len(t, columns, 4, "lists should cap at 4 columns")
+}
 
-	// Lists should have max 4 columns
-	// Find the entitys list section between "  entitys:" and "create_form:"
-	listsIdx := strings.Index(config, "lists:")
-	require.NotEqual(t, -1, listsIdx, "should have lists section")
+// TestGenerateDataEntryConfig_YAMLSpecialChars is the regression test for
+// BUG-F9I2Z: titles derived from entity/property names that contain YAML-special
+// characters must still produce valid YAML. The previous Fprintf-based
+// implementation would embed the raw string inside double quotes without
+// escaping, producing unparseable output for names like `foo"bar` or `a\nb`.
+func TestGenerateDataEntryConfig_YAMLSpecialChars(t *testing.T) {
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			`quote"type`: {
+				Properties: map[string]metamodel.PropertyDef{
+					`back\slash`:    {Type: "string"},
+					"newline\nprop": {Type: "string"},
+					"tab\tprop":     {Type: "string"},
+				},
+			},
+		},
+	}
 
-	entitysIdx := strings.Index(config[listsIdx:], "  entitys:")
-	require.NotEqual(t, -1, entitysIdx, "should have entitys list")
+	appName := `App with "quotes" and \backslash`
+	cfg := decodeConfig(t, generateDataEntryConfig(appName, meta))
 
-	columnsIdx := strings.Index(config[listsIdx+entitysIdx:], "columns:")
-	require.NotEqual(t, -1, columnsIdx, "should have columns")
+	// Round-tripping proves the YAML parsed; spot-check that values survived
+	// unmangled.
+	assert.Equal(t, appName, cfg["app"].(map[string]any)["name"])
 
-	createFormIdx := strings.Index(config[listsIdx+entitysIdx+columnsIdx:], "    create_form:")
-	require.NotEqual(t, -1, createFormIdx, "should have create_form")
-
-	columnsSection := config[listsIdx+entitysIdx+columnsIdx : listsIdx+entitysIdx+columnsIdx+createFormIdx]
-
-	// Count property occurrences in columns section
-	propertyCount := strings.Count(columnsSection, "- property:")
-	assert.Equal(t, 4, propertyCount, "should have max 4 columns")
+	forms := cfg["forms"].(map[string]any)
+	// The form key goes through hyphen→underscore, but the entity_type value is
+	// the raw string. Exactly one form was generated; find it.
+	require.Len(t, forms, 1)
+	for _, v := range forms {
+		form := v.(map[string]any)
+		assert.Equal(t, `quote"type`, form["entity_type"])
+		fields := form["fields"].([]any)
+		propNames := make([]string, 0, len(fields))
+		for _, f := range fields {
+			propNames = append(propNames, f.(map[string]any)["property"].(string))
+		}
+		// Sorted alphabetically by the generator.
+		assert.ElementsMatch(t, []string{`back\slash`, "newline\nprop", "tab\tprop"}, propNames)
+	}
 }

--- a/tickets/entities/automated-measures/generate-dataentry-yaml-roundtrip-test.md
+++ b/tickets/entities/automated-measures/generate-dataentry-yaml-roundtrip-test.md
@@ -1,0 +1,9 @@
+---
+id: generate-dataentry-yaml-roundtrip-test
+type: automated-measure
+title: 'Roundtrip test: generateDataEntryConfig output is valid YAML for all metamodels'
+description: 'Feed generateDataEntryConfig a metamodel containing names with YAML-special chars (double quotes, backslashes, newlines in descriptions). Assert the returned string is valid YAML by round-tripping through yaml.Unmarshal and checking the decoded structure round-trips cleanly. This is the preventive measure for BUG-F9I2Z: any future change to the scaffold generator that re-introduces hand-built YAML will fail this test.'
+kind: test
+location: cmd/rela-desktop/main_test.go (TestGenerateDataEntryConfig_RoundTrip)
+status: active
+---

--- a/tickets/entities/bugs/BUG-F9I2Z.md
+++ b/tickets/entities/bugs/BUG-F9I2Z.md
@@ -1,0 +1,56 @@
+---
+id: BUG-F9I2Z
+type: bug
+title: generateDataEntryConfig produces invalid YAML when titles contain quotes
+description: generateDataEntryConfig in cmd/rela-desktop/main.go builds the first-run data-entry.yaml by string-concatenating YAML fragments. Titles derived from entity/property names are embedded inside double-quoted scalars with no escaping, so names containing a double-quote, backslash, or YAML-special char produce invalid or silently-rewritten YAML. Desktop first-run scaffolding is the user's entry point, so a corrupt file here is disproportionately painful.
+priority: low
+effort: s
+why1: generateDataEntryConfig built YAML by string-concatenating fragments with %q/"%s" embedding
+why2: Hand-built YAML was expedient when the function only handled simple identifiers
+why3: No roundtrip test existed to prove the output was valid for all possible inputs
+why4: Test-writing culture favored substring assertions over structural/parseability checks
+why5: The scaffold generator was treated as a one-off, not a production YAML emitter with user-derived strings
+prevention: Always use yaml.Marshal or a documented tested encoder for YAML/JSON emission; reject PRs that build structured formats with fmt.Fprintf. New automated-measure 'generate-dataentry-yaml-roundtrip-test' enforces this for the scaffold specifically.
+status: done
+---
+
+## Description
+
+`cmd/rela-desktop/main.go:generateDataEntryConfig` builds a `data-entry.yaml`
+scaffold by string-concatenating YAML fragments with `fmt.Fprintf(&sb, " title:
+\"%s\"\n", titleCase(propName))`. The title value is embedded inside double
+quotes but only runs through `titleCase()` — no YAML escaping.
+
+If a metamodel defines an entity-type or property name that contains a
+double-quote, backslash, or any unicode character that YAML treats as special in
+a double-quoted scalar (e.g. `\n`, `\t`, `\"`), the generated YAML either
+becomes invalid or silently rewrites the value.
+
+## Impact
+
+- Low: rare in practice — typical entity/property names are `snake_case` or `kebab-case` identifiers without quotes.
+- But: the desktop app's first-run config scaffolding is the user's introduction to the product. A corrupt `data-entry.yaml` at this point leaves the user stuck with no good error message.
+- Related: this is a latent class of bug — any future metamodel feature that allows e.g. `description` values in the scaffold would surface it.
+
+## Reproduction
+
+1. Create a metamodel with an entity type named (hypothetically) `foo"bar`.
+2. Run the desktop app's "new project" flow.
+3. Observe the generated `data-entry.yaml` — the title field breaks parsing.
+
+## Fix
+
+Replace the hand-built YAML with `yaml.Marshal` of a typed or `map[string]any`
+representation. The project already depends on `gopkg.in/yaml.v3`. The helpers
+`titleCase`, the entity-type sort, and the column-limit constants stay; only the
+Fprintf/string-concat block is replaced.
+
+**Estimated effort:** s (small). ~80 lines swapped for ~40 lines of struct
+construction + one `yaml.Marshal` call.
+
+## Origin
+
+Flagged by the cranky-code-reviewer agent during TKT-AWX7V review as RR-V7SIR
+(severity: minor, status: deferred). Deferred from that ticket because the scope
+was a tooling/version chore, not a refactor of `generateDataEntryConfig`. Filing
+as its own bug here.

--- a/tickets/relations/BUG-F9I2Z--adds-measure--generate-dataentry-yaml-roundtrip-test.md
+++ b/tickets/relations/BUG-F9I2Z--adds-measure--generate-dataentry-yaml-roundtrip-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-F9I2Z
+relation: adds-measure
+to: generate-dataentry-yaml-roundtrip-test
+---

--- a/tickets/relations/BUG-F9I2Z--affects--desktop-app.md
+++ b/tickets/relations/BUG-F9I2Z--affects--desktop-app.md
@@ -1,0 +1,5 @@
+---
+from: BUG-F9I2Z
+relation: affects
+to: desktop-app
+---

--- a/tickets/relations/BUG-F9I2Z--fixes--FEAT-025.md
+++ b/tickets/relations/BUG-F9I2Z--fixes--FEAT-025.md
@@ -1,0 +1,5 @@
+---
+from: BUG-F9I2Z
+relation: fixes
+to: FEAT-025
+---

--- a/tickets/relations/generate-dataentry-yaml-roundtrip-test--protects--desktop-app.md
+++ b/tickets/relations/generate-dataentry-yaml-roundtrip-test--protects--desktop-app.md
@@ -1,0 +1,5 @@
+---
+from: generate-dataentry-yaml-roundtrip-test
+relation: protects
+to: desktop-app
+---


### PR DESCRIPTION
## Summary

- **Fix**: rewrite `generateDataEntryConfig` in `cmd/rela-desktop/main.go` to build a `yaml.Node` graph and call `yaml.Marshal` once, instead of string-concatenating YAML fragments. yaml.v3 handles escaping for all user-derived string values.
- **Test**: rewrite existing tests to decode the YAML and assert on structure (more robust than substring matching). Add `TestGenerateDataEntryConfig_YAMLSpecialChars` regression test that feeds in names with quote/backslash/newline/tab and round-trips through `yaml.Unmarshal`.

## Why

The previous implementation embedded values like `titleCase(propName)` inside double-quoted YAML scalars via `fmt.Fprintf(&sb, "    title: \"%s\"\n", ...)` with no escaping. A metamodel with an entity-type or property name containing `"`, `\`, `\n`, or `\t` would produce invalid YAML. Low-likelihood but high-impact: the desktop app's first-run scaffolding is the user's entry point.

Flagged as RR-V7SIR during TKT-AWX7V review; filed as BUG-F9I2Z and fixed here.

## Test plan

- [x] `just lint` passes
- [x] `just test` passes (5 scaffold tests including new regression test)
- [x] `just coverage-check` passes
- [x] `just ci` exits 0 end-to-end
- [ ] CI on this PR is green

## Tracking

Bug: BUG-F9I2Z (status: done). Preventive measure: `generate-dataentry-yaml-roundtrip-test` (status: active, protects: desktop-app concept).