### PR TITLE
ci: enable dependabot for npm (frontend, e2e) with 7-day auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,55 @@ updates:
       interval: weekly
     commit-message:
       prefix: "ci"
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+    groups:
+      vue-ecosystem:
+        patterns:
+          - "vue"
+          - "vue-*"
+          - "@vue/*"
+          - "@vitejs/*"
+          - "pinia"
+          - "@pinia/*"
+      build-tooling:
+        patterns:
+          - "vite"
+          - "vite-*"
+          - "typescript"
+          - "typescript-*"
+          - "tsx"
+          - "vue-tsc"
+      lint-and-format:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "prettier"
+          - "prettier-*"
+          - "jscpd"
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "@testing-library/*"
+          - "happy-dom"
+          - "fast-check"
+          - "@playwright/*"
+    commit-message:
+      prefix: "deps(frontend)"
+
+  - package-ecosystem: npm
+    directory: /e2e
+    schedule:
+      interval: weekly
+    groups:
+      playwright:
+        patterns:
+          - "@playwright/*"
+          - "playwright"
+    commit-message:
+      prefix: "deps(e2e)"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -91,3 +91,17 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # npm updates (frontend/, e2e/) — defer 7 days for supply-chain safety.
+      # npm packages have more maintainers and higher churn than Go modules,
+      # so the 7-day soak window catches post-publish retractions / malicious
+      # versions before merge. Same pattern as Go packages above.
+      - name: Approve npm updates (merge deferred 7 days)
+        if: steps.metadata.outputs.package-ecosystem == 'npm_and_yarn'
+        run: |
+          gh pr review --approve "$PR_URL" \
+            --body "Auto-approved. Merge deferred 7 days from PR creation for supply chain safety."
+          gh pr edit "$PR_URL" --add-label "dependabot-deferred"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Extends the existing Go + GitHub Actions dependabot auto-merge policy to cover
npm dependencies in `/frontend` and `/e2e`. Today those packages are never
updated automatically — this closes that gap while staying conservative about
npm supply-chain risk.

## Changes

**`.github/dependabot.yml`** — adds two `npm` ecosystem entries (weekly).

Updates are grouped by concern so one PR per group covers related changes:

| Group | Directory | Includes |
|---|---|---|
| vue-ecosystem | frontend | vue, vue-router, @vue/*, @vitejs/*, pinia, @pinia/* |
| build-tooling | frontend | vite, typescript, tsx, vue-tsc |
| lint-and-format | frontend | eslint, @eslint/*, prettier, jscpd |
| testing | frontend | vitest, @vitest/*, @testing-library/*, happy-dom, fast-check, @playwright/* |
| playwright | e2e | @playwright/*, playwright |

**`.github/workflows/dependabot-auto-merge.yml`** — adds an npm-defer step that
mirrors the existing Go-packages pattern:

1. Dependabot opens PR
2. This workflow auto-approves + applies `dependabot-deferred` label
3. CI runs (tests, typecheck, lint, build, e2e)
4. `dependabot-deferred-merge.yml` enables auto-squash-merge after 7 days

npm isn't merged immediately (unlike trusted GitHub Actions) because the
npm registry has a larger maintainer surface and higher churn; the soak
window catches post-publish retractions before we merge.

## Test plan

- [x] YAML lints cleanly (`python3 -c 'yaml.safe_load(...)'` on both files)
- [x] Ecosystem id `npm_and_yarn` matches `dependabot/dependabot-core`'s constant
- [x] Branch `chore/` prefix exempts PR from `rela-tickets` check — no ticket required
- [ ] First dependabot npm PR (next Monday) lands, gets approved + labeled
- [ ] `dependabot-deferred-merge.yml` merges it ~7 days later once CI passed

Separate PR from #483 (govulncheck/coverage) to keep review scope tight.