### PR TITLE
fix(ci): use App token for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,6 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      # App token is used for approve / auto-merge so the eventual merge
+      # commit can trigger downstream workflows. GITHUB_TOKEN-authored
+      # approvals are also silently ignored by branch protection's
+      # "require approving review" rule, so the App token future-proofs
+      # against that being enabled later.
+      - name: Generate app token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2
@@ -25,7 +37,7 @@ jobs:
           gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # GitHub Actions — check if all updated actions are from trusted orgs
       - name: Check if Actions are from trusted orgs
@@ -64,7 +76,7 @@ jobs:
           gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # Third-party GitHub Actions — defer 7 days
       - name: Approve third-party Actions updates (merge deferred 7 days)
@@ -77,7 +89,7 @@ jobs:
           gh pr edit "$PR_URL" --add-label "dependabot-deferred"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # Go package updates — defer 7 days
       - name: Approve package updates (merge deferred 7 days)
@@ -90,7 +102,7 @@ jobs:
           gh pr edit "$PR_URL" --add-label "dependabot-deferred"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # npm updates (frontend/, e2e/) — defer 7 days for supply-chain safety.
       # npm packages have more maintainers and higher churn than Go modules,
@@ -104,4 +116,4 @@ jobs:
           gh pr edit "$PR_URL" --add-label "dependabot-deferred"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Problem

Follow-up to #486. The dependabot auto-merge workflow uses `GITHUB_TOKEN` for
`gh pr review --approve` and `gh pr merge --auto --squash`. Two issues:

1. **Approvals by `GITHUB_TOKEN` are silently ignored** by GitHub's branch-protection
   "require approving review" rule. If we ever enable that rule for dependabot branches,
   auto-merge will silently stop working — PRs will linger approved-but-unmerged.

2. **Merges authored by `GITHUB_TOKEN` don't trigger downstream workflows.** The merge
   commit lands, but any `on: push` workflows that should fire (e.g., `post-merge-sync`)
   get skipped.

Both failure modes are silent. The App token (already configured via `APP_ID` /
`APP_PRIVATE_KEY` secrets and used by `post-merge-sync.yml` / `security.yml`) bypasses
both.

## Changes

- Add `actions/create-github-app-token@v1` step at the top of the job
- Switch all 5 `GH_TOKEN: secrets.GITHUB_TOKEN` references to `steps.app-token.outputs.token`
- Keep `dependabot/fetch-metadata@v2` on `GITHUB_TOKEN` — read-only metadata fetch

## Test plan

- [x] YAML validates
- [ ] First dependabot PR after merge gets approved + (for trusted Actions) merged as
  expected; merge commit triggers `post-merge-sync.yml`