### PR TITLE
fix: sanitize DOT cluster ID for hyphenated entity types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,6 +473,39 @@ jobs:
           echo ""
           echo "All rela checks passed!"
 
+  demos:
+    name: Demos
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Install graphviz
+        run: sudo apt-get update && sudo apt-get install -y graphviz
+
+      - name: Build rela
+        run: go build -o bin/rela ./cmd/rela
+
+      - name: Run demo scripts
+        run: |
+          set -euo pipefail
+          # Skyward demos chain off setup; run it first if present.
+          if [ -x scripts/setup-skyward-demo.sh ]; then
+            echo "==> scripts/setup-skyward-demo.sh"
+            scripts/setup-skyward-demo.sh
+          fi
+          shopt -s nullglob
+          for demo in scripts/demo-*.sh; do
+            echo ""
+            echo "==> ${demo}"
+            "${demo}"
+          done
+
   docs:
     name: Docs
     runs-on: ubuntu-latest

--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -125,9 +125,12 @@ func generateDOT(entities []*entity.Entity, edges []*entity.Relation) string {
 		typeGroups[e.Type] = append(typeGroups[e.Type], e)
 	}
 
-	// Write nodes grouped by type (as subgraphs for clustering)
+	// Write nodes grouped by type (as subgraphs for clustering).
+	// DOT unquoted IDs must match [_A-Za-z][_A-Za-z0-9]*, so entity
+	// types with hyphens (e.g. `review-response`) need sanitization
+	// to keep the cluster ID valid.
 	for entityType, group := range typeGroups {
-		fmt.Fprintf(&sb, "  subgraph cluster_%s {\n", entityType)
+		fmt.Fprintf(&sb, "  subgraph cluster_%s {\n", sanitizeDOTID(entityType))
 		fmt.Fprintf(&sb, "    label=\"%ss\";\n", strings.ToUpper(entityType[:1])+entityType[1:])
 
 		// Get color from metamodel
@@ -162,6 +165,24 @@ func generateDOT(entities []*entity.Entity, edges []*entity.Relation) string {
 }
 
 const maxLabelLen = 40
+
+// sanitizeDOTID converts a string into a valid unquoted DOT identifier
+// by replacing any character outside [A-Za-z0-9_] with '_'. Used for
+// subgraph cluster IDs, where entity types containing hyphens would
+// otherwise produce invalid DOT.
+func sanitizeDOTID(s string) string {
+	var sb strings.Builder
+	sb.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
+			sb.WriteRune(r)
+		default:
+			sb.WriteByte('_')
+		}
+	}
+	return sb.String()
+}
 
 func escapeLabel(s string) string {
 	s = strings.ReplaceAll(s, "\"", "\\\"")

--- a/internal/cli/graph_test.go
+++ b/internal/cli/graph_test.go
@@ -144,6 +144,59 @@ func TestGenerateDOT_EntityWithoutTitle(t *testing.T) {
 	}
 }
 
+// TestGenerateDOT_HyphenatedEntityType verifies that entity types
+// containing hyphens produce DOT with a valid (sanitized) cluster ID.
+// DOT unquoted identifiers reject '-', so `cluster_review-response`
+// would be rejected by graphviz with a syntax error.
+func TestGenerateDOT_HyphenatedEntityType(t *testing.T) {
+	meta = &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"review-response": {
+				Label:    "Review response",
+				IDPrefix: "RR-",
+				Color:    "#FFEBEE",
+			},
+		},
+	}
+	seeder := newStoreSeeder(meta)
+	seeder.addEntity(testutil.EntityFor(meta, "review-response").
+		ID("RR-001").With("title", "Finding"))
+	applySeeder(seeder)
+
+	dot := generateDOT(fixtureAllEntities(), fixtureAllRelations())
+
+	if !strings.Contains(dot, "subgraph cluster_review_response") {
+		t.Errorf("expected sanitized cluster ID 'cluster_review_response', got:\n%s", dot)
+	}
+	if strings.Contains(dot, "cluster_review-response") {
+		t.Errorf("DOT must not contain unsanitized hyphenated cluster ID, got:\n%s", dot)
+	}
+}
+
+func TestSanitizeDOTID(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain alphanumeric unchanged", "requirement", "requirement"},
+		{"hyphens replaced with underscore", "review-response", "review_response"},
+		{"multiple hyphens", "bug-analysis-checklist", "bug_analysis_checklist"},
+		{"digits preserved", "type42", "type42"},
+		{"underscore preserved", "my_type", "my_type"},
+		{"dots and spaces replaced", "a.b c", "a_b_c"},
+		{"empty string", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeDOTID(tt.input); got != tt.want {
+				t.Errorf("sanitizeDOTID(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEscapeLabel(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/scripts/demo-graph.sh
+++ b/scripts/demo-graph.sh
@@ -18,7 +18,7 @@ step() { printf '    %s\n' "$*"; }
 say "Building rela → ${BIN}"
 (cd "${REPO}" && go build -o "${BIN}" ./cmd/rela)
 
-say "Seeding demo project at ${DEMO}"
+say "Seeding metamodel at ${DEMO}"
 cat > "${DEMO}/metamodel.yaml" <<'YAML'
 version: "1.0"
 namespace: "https://example.com/demo#"
@@ -60,58 +60,20 @@ relations:
     to: [review-response]
 YAML
 
-mkdir -p \
-  "${DEMO}/entities/features" \
-  "${DEMO}/entities/tickets" \
-  "${DEMO}/entities/review-responses" \
-  "${DEMO}/relations"
-
-cat > "${DEMO}/entities/features/FEAT-001.md" <<'MD'
----
-id: FEAT-001
-type: feature
-title: Graph DOT export
----
-MD
-
-cat > "${DEMO}/entities/tickets/TKT-001.md" <<'MD'
----
-id: TKT-001
-type: ticket
-title: Render DOT with subgraph clusters per type
----
-MD
-
-cat > "${DEMO}/entities/review-responses/RR-001.md" <<'MD'
----
-id: RR-001
-type: review-response
-title: Sanitize cluster IDs for hyphenated types
-status: addressed
----
-MD
-
-cat > "${DEMO}/relations/TKT-001--implements--FEAT-001.md" <<'MD'
----
-from: TKT-001
-relation: implements
-to: FEAT-001
----
-MD
-
-cat > "${DEMO}/relations/TKT-001--has-review-response--RR-001.md" <<'MD'
----
-from: TKT-001
-relation: has-review-response
-to: RR-001
----
-MD
-
 cd "${DEMO}"
 
-say "rela graph → stdout (DOT)"
+say "Creating entities with rela create"
+"${BIN}" create feature         --id FEAT-001 -t "Graph DOT export" -q
+"${BIN}" create ticket          --id TKT-001  -t "Render DOT with subgraph clusters per type" -q
+"${BIN}" create review-response --id RR-001   -t "Sanitize cluster IDs for hyphenated types" -P status=addressed -q
+
+say "Creating relations with rela link"
+"${BIN}" link TKT-001 implements          FEAT-001 -q
+"${BIN}" link TKT-001 has-review-response RR-001   -q
+
+say "rela graph → stdout (DOT, first 12 lines)"
 "${BIN}" graph | sed -n '1,12p'
-step "(truncated — first 12 lines shown)"
+step "(truncated)"
 
 say "rela graph -o graph.dot  (write DOT to file)"
 "${BIN}" graph -o graph.dot

--- a/scripts/demo-graph.sh
+++ b/scripts/demo-graph.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# End-to-end demo of `rela graph`: build a tiny project with a mix of
+# simple and hyphenated entity types, export DOT, and render to SVG via
+# graphviz. Also demonstrates the filtered and LR-direction variants.
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="${REPO}/bin/rela"
+DEMO="$(mktemp -d -t rela-graph-demo.XXXXXX)"
+
+cleanup() { rm -rf "${DEMO}"; }
+trap cleanup EXIT
+
+say() { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+step() { printf '    %s\n' "$*"; }
+
+say "Building rela → ${BIN}"
+(cd "${REPO}" && go build -o "${BIN}" ./cmd/rela)
+
+say "Seeding demo project at ${DEMO}"
+cat > "${DEMO}/metamodel.yaml" <<'YAML'
+version: "1.0"
+namespace: "https://example.com/demo#"
+types:
+  review_response_status:
+    values: [open, addressed]
+    default: open
+entities:
+  feature:
+    label: Feature
+    id_prefix: "FEAT-"
+    id_type: sequential
+    color: "#E8F5E9"
+    properties:
+      title: {type: string, required: true}
+  ticket:
+    label: Ticket
+    id_prefix: "TKT-"
+    id_type: sequential
+    color: "#FFFDE7"
+    properties:
+      title: {type: string, required: true}
+  review-response:
+    label: Review response
+    id_prefix: "RR-"
+    id_type: sequential
+    color: "#FFEBEE"
+    properties:
+      title: {type: string, required: true}
+      status: {type: review_response_status}
+relations:
+  implements:
+    label: implements
+    from: [ticket]
+    to: [feature]
+  has-review-response:
+    label: has review response
+    from: [ticket]
+    to: [review-response]
+YAML
+
+mkdir -p \
+  "${DEMO}/entities/features" \
+  "${DEMO}/entities/tickets" \
+  "${DEMO}/entities/review-responses" \
+  "${DEMO}/relations"
+
+cat > "${DEMO}/entities/features/FEAT-001.md" <<'MD'
+---
+id: FEAT-001
+type: feature
+title: Graph DOT export
+---
+MD
+
+cat > "${DEMO}/entities/tickets/TKT-001.md" <<'MD'
+---
+id: TKT-001
+type: ticket
+title: Render DOT with subgraph clusters per type
+---
+MD
+
+cat > "${DEMO}/entities/review-responses/RR-001.md" <<'MD'
+---
+id: RR-001
+type: review-response
+title: Sanitize cluster IDs for hyphenated types
+status: addressed
+---
+MD
+
+cat > "${DEMO}/relations/TKT-001--implements--FEAT-001.md" <<'MD'
+---
+from: TKT-001
+relation: implements
+to: FEAT-001
+---
+MD
+
+cat > "${DEMO}/relations/TKT-001--has-review-response--RR-001.md" <<'MD'
+---
+from: TKT-001
+relation: has-review-response
+to: RR-001
+---
+MD
+
+cd "${DEMO}"
+
+say "rela graph → stdout (DOT)"
+"${BIN}" graph | sed -n '1,12p'
+step "(truncated — first 12 lines shown)"
+
+say "rela graph -o graph.dot  (write DOT to file)"
+"${BIN}" graph -o graph.dot
+step "wrote $(wc -l < graph.dot | tr -d ' ') lines to graph.dot"
+
+if command -v dot >/dev/null 2>&1; then
+    say "rela graph -o graph.svg -f svg  (render via graphviz)"
+    "${BIN}" graph -o graph.svg -f svg
+    step "SVG size: $(wc -c < graph.svg | tr -d ' ') bytes"
+
+    say "rela graph -o graph-lr.png -f png --direction lr"
+    "${BIN}" graph -o graph-lr.png -f png --direction lr
+    step "PNG size: $(wc -c < graph-lr.png | tr -d ' ') bytes"
+
+    say "rela graph --types ticket,feature -o tf.svg -f svg  (filtered)"
+    "${BIN}" graph --types ticket,feature -o tf.svg -f svg
+    step "filtered SVG size: $(wc -c < tf.svg | tr -d ' ') bytes"
+
+    cp graph.svg graph-lr.png tf.svg /tmp/ 2>/dev/null || true
+    say "Outputs copied to /tmp/graph.svg /tmp/graph-lr.png /tmp/tf.svg"
+else
+    say "graphviz 'dot' not found — skipping render steps"
+    step "install with: brew install graphviz"
+fi
+
+say "Done."

--- a/tickets/entities/automated-measures/graph-dot-hyphen-sanitization-test.md
+++ b/tickets/entities/automated-measures/graph-dot-hyphen-sanitization-test.md
@@ -1,0 +1,9 @@
+---
+id: graph-dot-hyphen-sanitization-test
+type: automated-measure
+title: 'Test: DOT subgraph cluster IDs are sanitized for hyphenated entity types'
+description: Unit test `TestGenerateDOT_HyphenatedEntityType` asserts that when the metamodel contains an entity type with a hyphen (e.g. `review-response`), `generateDOT` emits `subgraph cluster_review_response` and never `cluster_review-response`. Paired with `TestSanitizeDOTID` (table) that pins the sanitization rules. Prevents BUG-graph-hyphen from recurring.
+kind: test
+location: internal/cli/graph_test.go
+status: active
+---

--- a/tickets/entities/bugs/BUG-ULFDB.md
+++ b/tickets/entities/bugs/BUG-ULFDB.md
@@ -1,0 +1,15 @@
+---
+id: BUG-ULFDB
+type: bug
+title: '`rela graph -f svg` fails for entity types containing hyphens'
+description: 'Running `rela graph -f svg` (or any non-`dot` format) fails with `<stdin>: syntax error in line N near ''-''` whenever the metamodel has an entity type whose name contains a hyphen (e.g. `review-response`, `planning-checklist`, `bug-analysis-checklist`). `rela graph` to stdout emits invalid DOT that graphviz rejects. Reproduces on the dogfood `tickets/` project.'
+priority: high
+effort: xs
+why1: graphviz rejects the DOT emitted by `rela graph` with `syntax error near '-'`
+why2: the DOT contains `subgraph cluster_review-response { ... }` — an unquoted identifier containing `-`
+why3: '`generateDOT` interpolates the entity type directly into `cluster_%s`, assuming it is a valid DOT identifier'
+why4: DOT unquoted identifiers are restricted to `[_A-Za-z][_A-Za-z0-9]*`; no sanitization was applied before interpolation
+why5: there was no end-to-end test that rendered DOT through graphviz against a real-shaped metamodel, and unit tests only used hyphen-free type names (`requirement`, `decision`, `component`)
+prevention: Sanitize any metamodel-derived string before embedding it as an unquoted DOT identifier. `sanitizeDOTID` replaces non-[A-Za-z0-9_] with `_`. Unit tests pin the rule; a shell verification script exercises the full pipeline through `dot`.
+status: done
+---

--- a/tickets/entities/concepts/graph-export.md
+++ b/tickets/entities/concepts/graph-export.md
@@ -1,0 +1,10 @@
+---
+id: graph-export
+type: concept
+title: Graph DOT Export
+summary: Rendering the entity graph to Graphviz DOT for visualization, optionally piped through `dot` for SVG/PNG/PDF.
+description: The `rela graph` command serializes nodes (grouped by entity type into DOT subgraph clusters) and edges (relations) into a Graphviz DOT document. With `-f <format>` it invokes the external `dot` binary to render to SVG/PNG/PDF. DOT has specific lexical rules — unquoted identifiers must match [_A-Za-z][_A-Za-z0-9]* — so any component of the DOT produced from user-defined metamodel identifiers must either quote or sanitize those strings.
+package: internal/cli
+layer: cli
+status: stable
+---

--- a/tickets/entities/features/FEAT-F5KJ5.md
+++ b/tickets/entities/features/FEAT-F5KJ5.md
@@ -1,0 +1,9 @@
+---
+id: FEAT-F5KJ5
+type: feature
+title: Graph DOT export and rendering
+summary: '`rela graph` exports the entity/relation graph as Graphviz DOT and optionally renders it to SVG/PNG/PDF via the external `dot` binary.'
+description: 'Implemented in internal/cli/graph.go. Supports: stdout DOT, writing DOT to a file, rendering to image formats via Graphviz, rankdir TB/LR, and filtering by entity type.'
+priority: medium
+status: implemented
+---

--- a/tickets/relations/BUG-ULFDB--adds-measure--graph-dot-hyphen-sanitization-test.md
+++ b/tickets/relations/BUG-ULFDB--adds-measure--graph-dot-hyphen-sanitization-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ULFDB
+relation: adds-measure
+to: graph-dot-hyphen-sanitization-test
+---

--- a/tickets/relations/BUG-ULFDB--affects--graph-export.md
+++ b/tickets/relations/BUG-ULFDB--affects--graph-export.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ULFDB
+relation: affects
+to: graph-export
+---

--- a/tickets/relations/BUG-ULFDB--fixes--FEAT-F5KJ5.md
+++ b/tickets/relations/BUG-ULFDB--fixes--FEAT-F5KJ5.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ULFDB
+relation: fixes
+to: FEAT-F5KJ5
+---

--- a/tickets/relations/FEAT-F5KJ5--requires--graph-export.md
+++ b/tickets/relations/FEAT-F5KJ5--requires--graph-export.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-F5KJ5
+relation: requires
+to: graph-export
+---

--- a/tickets/relations/graph-dot-hyphen-sanitization-test--protects--graph-export.md
+++ b/tickets/relations/graph-dot-hyphen-sanitization-test--protects--graph-export.md
@@ -1,0 +1,5 @@
+---
+from: graph-dot-hyphen-sanitization-test
+relation: protects
+to: graph-export
+---


### PR DESCRIPTION
## Summary

- `rela graph -f svg|png|pdf` was failing with `<stdin>: syntax error near '-'` whenever the metamodel contained an entity type with a hyphen (`review-response`, `planning-checklist`, `bug-analysis-checklist`, …). `generateDOT` interpolated the type name directly into `cluster_%s`, and DOT unquoted identifiers can't contain `-`.
- Fix: `sanitizeDOTID` replaces every non-`[A-Za-z0-9_]` rune with `_` before use as a cluster ID. Node IDs are already quoted, so entity IDs with hyphens are unaffected.
- Tracked as `BUG-ULFDB` (done) with `FEAT-F5KJ5`, `graph-export` concept, and `graph-dot-hyphen-sanitization-test` measure in `tickets/`.
- Added `scripts/demo-graph.sh`: a self-contained end-to-end demo that builds rela, scaffolds a tiny project with a hyphenated type via `rela create` / `rela link`, and exercises stdout DOT, file DOT, SVG render, PNG + LR direction, and `--types` filtering.
- New `Demos` CI job runs every `scripts/demo-*.sh` on each PR (graphviz installed, skyward setup chained first) so future demos get end-to-end PR coverage automatically.

## Test plan

- [x] `go test ./internal/cli/...` — new `TestSanitizeDOTID` (table) and `TestGenerateDOT_HyphenatedEntityType` pass alongside existing tests
- [x] `go test ./...` — full suite passes
- [x] `golangci-lint run` — 0 issues
- [x] `scripts/demo-graph.sh` runs clean locally: DOT, SVG, PNG, filtered SVG all produced
- [x] `setup-skyward-demo.sh` + `demo-conflict.sh` + `demo-remote-changes.sh` + `demo-graph.sh` all succeed in sequence (mirrors what CI will run)
- [x] End-to-end against real project: `(cd tickets && rela graph -o /tmp/tickets-graph.svg -f svg)` renders cleanly