### PR TITLE
feat: schema --graphviz filtering, hub bundling, and legend

### DIFF
--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -519,10 +519,56 @@ const (
 	renderLegend = "legend"
 )
 
-// legendTargetThreshold is the target count at which a many-target relation
-// unconditionally collapses into the legend (instead of a hub-bundle, which is
-// only used for 3-4 targets with at least one otherwise-isolated node).
-const legendTargetThreshold = 5
+// Thresholds for the (source, relation) classifier:
+//   - fewer than minHubTargets targets always render as plain edges
+//   - minHubTargets..legendTargetThreshold-1 may hub-bundle when at least one
+//     target is otherwise isolated; otherwise they collapse into the legend
+//   - legendTargetThreshold or more unconditionally collapse into the legend
+const (
+	minHubTargets         = 3
+	legendTargetThreshold = 5
+)
+
+// legendNodeID and hubIDPrefix are reserved identifiers used for synthetic
+// nodes in the generated DOT. They are intentionally underscore-prefixed and
+// the classifier assumes no user-defined entity type uses these names.
+const (
+	legendNodeID = "__legend"
+	hubIDPrefix  = "__hub_"
+)
+
+// dotID returns a DOT-safe identifier for an arbitrary string. DOT accepts
+// unquoted identifiers only when they match [_A-Za-z][_0-9A-Za-z]*. Anything
+// else — including hyphens, dots, spaces, or an empty string — must be
+// double-quoted. The function always emits the quoted form when the input
+// needs it, otherwise returns the raw identifier untouched.
+func dotID(s string) string {
+	if s == "" {
+		return `""`
+	}
+	for i, r := range s {
+		first := i == 0
+		valid := r == '_' ||
+			(r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(!first && r >= '0' && r <= '9')
+		if !valid {
+			// Escape backslashes and quotes per DOT's quoted-string syntax.
+			var sb strings.Builder
+			sb.Grow(len(s) + 2)
+			sb.WriteByte('"')
+			for _, c := range s {
+				if c == '\\' || c == '"' {
+					sb.WriteByte('\\')
+				}
+				sb.WriteRune(c)
+			}
+			sb.WriteByte('"')
+			return sb.String()
+		}
+	}
+	return s
+}
 
 // relPair is a classified pair with its effective (post-exclude) target list.
 type relPair struct {
@@ -567,7 +613,7 @@ func runSchemaGraphviz() error {
 			borderColor = darkenColor(fillColor)
 		}
 		fmt.Fprintf(&sb, "  %s [label=%q, fillcolor=%q, color=%q];\n",
-			name, def.Label, fillColor, borderColor)
+			dotID(name), def.Label, fillColor, borderColor)
 	}
 	sb.WriteString("\n")
 
@@ -585,16 +631,16 @@ func runSchemaGraphviz() error {
 		case renderPlain:
 			for _, to := range p.to {
 				fmt.Fprintf(&sb, "  %s -> %s [label=%q, color=%q, fontcolor=%q];\n",
-					p.source, to, edgeLabel, edgeColor, edgeColor)
+					dotID(p.source), dotID(to), edgeLabel, edgeColor, edgeColor)
 			}
 		case renderHub:
-			hub := fmt.Sprintf("__hub_%d", hubIdx)
+			hub := fmt.Sprintf("%s%d", hubIDPrefix, hubIdx)
 			hubIdx++
 			fmt.Fprintf(&sb, "  %s [shape=point, width=0.05, height=0.05, label=\"\"];\n", hub)
 			fmt.Fprintf(&sb, "  %s -> %s [label=%q, color=%q, fontcolor=%q, arrowhead=none];\n",
-				p.source, hub, edgeLabel, edgeColor, edgeColor)
+				dotID(p.source), hub, edgeLabel, edgeColor, edgeColor)
 			for _, to := range p.to {
-				fmt.Fprintf(&sb, "  %s -> %s [color=%q];\n", hub, to, edgeColor)
+				fmt.Fprintf(&sb, "  %s -> %s [color=%q];\n", hub, dotID(to), edgeColor)
 			}
 		case renderLegend:
 			legendEntries = append(legendEntries, p)
@@ -662,60 +708,83 @@ func prepareSchemaGraph(m *metamodel.Metamodel) ([]string, []relPair) {
 	return entityNames, pairs
 }
 
-// classifyRenderings assigns a render bucket to each pair using the
-// total-degree snapshot (computed assuming all pairs are plain) to decide
-// whether a target is "otherwise connected".
+// classifyRenderings assigns a render bucket to each pair. The "otherwise
+// connected" check — whether a target has any edge to non-legend pairs — is
+// computed in two passes to avoid a snapshot-based lie: if pair A targets T
+// and pair B (≥5 targets) also targets T, classifying A as plain or hub
+// against a snapshot that assumed B was plain would be wrong, because B will
+// actually collapse into the legend and contribute nothing to T's connectedness.
+//
+//  1. Unconditional-legend pairs (n ≥ legendTargetThreshold) are classified
+//     first and contribute 0 edges.
+//  2. The incoming-degree is computed from the remaining pairs, modeling the
+//     final diagram before the ambiguous 3-4 pairs are classified.
+//  3. Each 3-4 pair is classified against that degree, then if it ends up as
+//     legend its targets' degrees are decremented (because its edges also
+//     disappear) so later pairs see the true reduced degree.
 func classifyRenderings(entityNames []string, pairs []relPair) {
-	// Count potential edges per entity across every pair. For each pair we
-	// count +1 for the source (one outgoing edge per target) and +1 for each
-	// target (one incoming edge from the source). The snapshot is frozen —
-	// reclassifying a pair later doesn't change the counts.
-	degree := make(map[string]int, len(entityNames))
-	for _, p := range pairs {
-		degree[p.source] += len(p.to)
-		for _, t := range p.to {
-			degree[t]++
-		}
-	}
-
+	// Pass 1: handle the always-legend / always-plain buckets.
 	for i := range pairs {
 		p := &pairs[i]
 		n := len(p.to)
-
-		if schemaNoLegend && schemaNoBundle {
+		switch {
+		case n < minHubTargets:
 			p.render = renderPlain
+		case n >= legendTargetThreshold && !schemaNoLegend:
+			p.render = renderLegend
+		case n >= legendTargetThreshold && schemaNoLegend:
+			p.render = renderPlain
+		default:
+			p.render = "" // deferred to pass 2
+		}
+	}
+
+	// Pass 2: incoming-degree for every target, counting only pairs whose edges
+	// will actually be drawn (plain + deferred). Legend-classified pairs are
+	// excluded because their edges never appear.
+	inDegree := make(map[string]int, len(entityNames))
+	for _, p := range pairs {
+		if p.render == renderLegend {
 			continue
 		}
-		if n >= legendTargetThreshold {
-			if !schemaNoLegend {
-				p.render = renderLegend
+		for _, t := range p.to {
+			inDegree[t]++
+		}
+	}
+
+	// Pass 3: classify the deferred pairs, adjusting inDegree on-the-fly when
+	// a deferred pair collapses (so downstream classifications see the true
+	// connectedness).
+	for i := range pairs {
+		p := &pairs[i]
+		if p.render != "" {
+			continue
+		}
+		// Count "other" incoming edges for each target: inDegree[t] counts
+		// this pair's own edge plus edges from other non-legend pairs, so
+		// subtract 1 to get the "otherwise connected" signal.
+		anyIsolated := false
+		for _, t := range p.to {
+			if inDegree[t]-1 <= 0 {
+				anyIsolated = true
+				break
 			}
-			continue
 		}
-		if n >= 3 {
-			// Count the "other" connections each target has: total minus the
-			// contribution this pair makes (one incoming edge from source).
-			anyIsolated := false
+		// Prefer hub for isolated targets, legend otherwise. Respect --no-*
+		// fallbacks: when the preferred collapse is disabled, fall back to
+		// the other collapse mode before giving up and drawing plain edges.
+		switch {
+		case anyIsolated && !schemaNoBundle:
+			p.render = renderHub
+		case !schemaNoLegend:
+			p.render = renderLegend
+			// Legend collapse makes this pair's edges disappear too — keep
+			// inDegree honest so later deferred pairs see reality.
 			for _, t := range p.to {
-				if degree[t]-1 <= 0 {
-					anyIsolated = true
-					break
-				}
+				inDegree[t]--
 			}
-			// Choose the best available rendering given flag overrides.
-			// Preferred: hub when any target is isolated, legend otherwise.
-			// When the preferred mode is disabled, fall back to the other
-			// collapse mode before giving up and drawing plain edges.
-			switch {
-			case anyIsolated && !schemaNoBundle:
-				p.render = renderHub
-			case anyIsolated && !schemaNoLegend:
-				p.render = renderLegend
-			case !anyIsolated && !schemaNoLegend:
-				p.render = renderLegend
-			default:
-				p.render = renderPlain
-			}
+		default:
+			p.render = renderPlain
 		}
 	}
 }
@@ -726,46 +795,28 @@ func classifyRenderings(entityNames []string, pairs []relPair) {
 // would produce a disconnected node. Entities that belong to no pair at all
 // (e.g. leaf types in a tiny metamodel) stay visible.
 func visibleEntities(entityNames []string, pairs []relPair) map[string]bool {
-	visible := make(map[string]bool, len(entityNames))
-	participates := make(map[string]bool, len(entityNames))
-	for _, name := range entityNames {
-		visible[name] = true
-	}
+	// Two sets: every entity that appears in any pair, and every entity that
+	// appears in a pair whose edges will actually be drawn. The final decision
+	// is: hidden iff in seenAny but not in seenDrawn.
+	seenAny := make(map[string]bool, len(entityNames))
+	seenDrawn := make(map[string]bool, len(entityNames))
 	for _, p := range pairs {
-		participates[p.source] = true
+		seenAny[p.source] = true
 		for _, t := range p.to {
-			participates[t] = true
+			seenAny[t] = true
 		}
 		if p.render == renderLegend {
 			continue
 		}
-		visible[p.source] = true
+		seenDrawn[p.source] = true
 		for _, t := range p.to {
-			visible[t] = true
+			seenDrawn[t] = true
 		}
 	}
-	// For every entity that participates in pairs but only via legend-collapsed
-	// ones, mark it hidden.
-	for name := range participates {
-		onlyLegend := true
-		for _, p := range pairs {
-			involved := p.source == name
-			if !involved {
-				for _, t := range p.to {
-					if t == name {
-						involved = true
-						break
-					}
-				}
-			}
-			if involved && p.render != renderLegend {
-				onlyLegend = false
-				break
-			}
-		}
-		if onlyLegend {
-			visible[name] = false
-		}
+
+	visible := make(map[string]bool, len(entityNames))
+	for _, name := range entityNames {
+		visible[name] = !seenAny[name] || seenDrawn[name]
 	}
 	return visible
 }
@@ -781,50 +832,77 @@ func renderLegendNode(entries []relPair, entityNames []string) string {
 
 	var tbl strings.Builder
 	tbl.WriteString(`<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4">`)
-	tbl.WriteString(`<TR><TD ALIGN="LEFT"><B>Universal relations</B></TD></TR>`)
+	tbl.WriteString(`<TR><TD ALIGN="LEFT"><B>Collapsed relations</B></TD></TR>`)
 	for _, e := range entries {
 		src := html.EscapeString(meta.Entities[e.source].Label)
 		rel := html.EscapeString(e.relDef.Label)
 		fmt.Fprintf(&tbl,
 			`<TR><TD ALIGN="LEFT" SIDES="LTR"><B>%s</B> <I>%s</I></TD></TR>`,
 			src, rel)
+		// Effective total excludes the source itself when it's not in its own
+		// target set — otherwise the legend would read "any entity except Src",
+		// listing Src as an exception against its own row.
+		effTotal := total
+		srcInTargets := false
+		for _, t := range e.to {
+			if t == e.source {
+				srcInTargets = true
+				break
+			}
+		}
+		if !srcInTargets {
+			effTotal--
+		}
 		fmt.Fprintf(&tbl,
 			`<TR><TD ALIGN="LEFT" SIDES="LBR"><I>%s</I></TD></TR>`,
-			formatTargets(e.to, labelOf, total))
+			formatTargets(e.to, labelOf, effTotal, e.source, srcInTargets))
 	}
 	tbl.WriteString(`</TABLE>>`)
 
 	var sb strings.Builder
 	sb.WriteString("  // Legend\n")
 	fmt.Fprintf(&sb,
-		"  __legend [shape=plaintext, margin=0, style=solid, fillcolor=white, label=%s];\n",
-		tbl.String())
+		"  %s [shape=plaintext, margin=0, style=solid, fillcolor=white, label=%s];\n",
+		legendNodeID, tbl.String())
 	return sb.String()
 }
 
 // formatTargets picks one of three rendering modes based on how close the
-// target set size is to the total number of entity types:
-//   - all entities (after the legend can exclude self): "any entity"
-//   - at least total-2: "any entity except X, Y"
+// target set size is to the effective total number of targetable entity types:
+//   - equals effectiveTotal: "any entity"
+//   - at least effectiveTotal-2: "any entity except X, Y"
 //   - otherwise: sorted labels, 2 per line, left-aligned with <BR ALIGN="LEFT"/>.
-func formatTargets(to []string, labelOf map[string]string, total int) string {
-	if total == 0 {
+//
+// When `srcInTargets` is false, the source entity is not a valid target and
+// must be excluded from the "except" complement. `source` is the id of that
+// entity so the complement iteration can skip it.
+func formatTargets(
+	to []string,
+	labelOf map[string]string,
+	effectiveTotal int,
+	source string,
+	srcInTargets bool,
+) string {
+	if effectiveTotal <= 0 {
 		return ""
 	}
 	switch {
-	case len(to) == total:
+	case len(to) == effectiveTotal:
 		return "any entity"
-	case len(to) >= total-2:
+	case len(to) >= effectiveTotal-2:
 		included := make(map[string]bool, len(to))
 		for _, t := range to {
 			included[t] = true
 		}
-		missing := make([]string, 0, total-len(to))
-		names := make([]string, 0, total)
+		names := make([]string, 0, len(labelOf))
 		for n := range labelOf {
+			if !srcInTargets && n == source {
+				continue
+			}
 			names = append(names, n)
 		}
 		sort.Strings(names)
+		missing := make([]string, 0, effectiveTotal-len(to))
 		for _, n := range names {
 			if !included[n] {
 				missing = append(missing, html.EscapeString(labelOf[n]))

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"html"
 	"sort"
 	"strconv"
 	"strings"
@@ -17,6 +18,9 @@ import (
 var (
 	schemaGraphviz    bool
 	schemaConstraints bool
+	schemaExclude     []string
+	schemaNoBundle    bool
+	schemaNoLegend    bool
 )
 
 var schemaCmd = &cobra.Command{
@@ -40,6 +44,9 @@ Subcommands:
 Flags:
   --graphviz      Output metamodel as GraphViz DOT format
   --constraints   Include cardinality constraints in GraphViz output
+  --exclude       Hide an entity type (repeatable; only affects --graphviz)
+  --no-bundle     Disable the hub bundle for 3-4 targets with an isolated node
+  --no-legend     Disable the legend table for many-target / fully-connected relations
 
 Examples:
   rela schema                    # Overview
@@ -49,7 +56,8 @@ Examples:
   rela schema entity service     # Detail for one entity type
   rela schema relation addresses # Detail for one relation type
   rela schema --graphviz         # Output as DOT format
-  rela schema --graphviz --constraints  # DOT with cardinality`,
+  rela schema --graphviz --constraints  # DOT with cardinality
+  rela schema --graphviz --exclude referentie  # hide an entity type`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if schemaGraphviz {
 			return runSchemaGraphviz()
@@ -504,69 +512,343 @@ var defaultEdgeColors = []string{
 	"#5d4037", // brown
 }
 
-func runSchemaGraphviz() error {
-	var sb strings.Builder
+// Classification buckets for each (sourceEntity, relation) pair.
+const (
+	renderPlain  = "plain"
+	renderHub    = "hub"
+	renderLegend = "legend"
+)
 
+// legendTargetThreshold is the target count at which a many-target relation
+// unconditionally collapses into the legend (instead of a hub-bundle, which is
+// only used for 3-4 targets with at least one otherwise-isolated node).
+const legendTargetThreshold = 5
+
+// relPair is a classified pair with its effective (post-exclude) target list.
+type relPair struct {
+	source string
+	rel    string
+	to     []string
+	render string
+	relDef metamodel.RelationDef
+	srcIdx int // color index of the source in the entity palette
+}
+
+func runSchemaGraphviz() error {
+	entityNames, relPairs := prepareSchemaGraph(meta)
+	classifyRenderings(entityNames, relPairs)
+
+	var sb strings.Builder
 	sb.WriteString("digraph metamodel {\n")
 	sb.WriteString("  rankdir=LR;\n")
 	sb.WriteString("  node [shape=box, style=\"filled,rounded\", fontname=\"Helvetica\"];\n")
 	sb.WriteString("  edge [fontsize=10, fontname=\"Helvetica\"];\n")
 	sb.WriteString("\n")
 
-	// Entity types as nodes
+	// Determine which entity types are visible in the final diagram. An entity
+	// is omitted when the exclude filter dropped it, or when it has no edges
+	// remaining (including hub-bundled edges) and no incoming edges.
+	visible := visibleEntities(entityNames, relPairs)
+
 	sb.WriteString("  // Entity types\n")
-	entityNames := getSortedEntityNames(meta)
+	entityColorIndex := make(map[string]int)
 	for i, name := range entityNames {
+		entityColorIndex[name] = i
+		if !visible[name] {
+			continue
+		}
 		def := meta.Entities[name]
-		// Use color from metamodel if defined, otherwise use default palette
 		fillColor := def.Color
 		if fillColor == "" {
 			fillColor = defaultEntityColors[i%len(defaultEntityColors)]
 		}
 		borderColor := def.BorderColor
 		if borderColor == "" {
-			// Derive border color from fill (darker shade)
 			borderColor = darkenColor(fillColor)
 		}
-		fmt.Fprintf(&sb, "  %s [label=\"%s\", fillcolor=\"%s\", color=\"%s\"];\n",
+		fmt.Fprintf(&sb, "  %s [label=%q, fillcolor=%q, color=%q];\n",
 			name, def.Label, fillColor, borderColor)
 	}
 	sb.WriteString("\n")
 
-	// Build a map of entity type -> color index for edge coloring
-	entityColorIndex := make(map[string]int)
-	for i, name := range entityNames {
-		entityColorIndex[name] = i
+	sb.WriteString("  // Relations\n")
+	var legendEntries []relPair
+	hubIdx := 0
+	for _, p := range relPairs {
+		edgeLabel := p.relDef.Label
+		if schemaConstraints {
+			edgeLabel = buildConstraintLabel(p.relDef)
+		}
+		edgeColor := defaultEdgeColors[entityColorIndex[p.source]%len(defaultEdgeColors)]
+
+		switch p.render {
+		case renderPlain:
+			for _, to := range p.to {
+				fmt.Fprintf(&sb, "  %s -> %s [label=%q, color=%q, fontcolor=%q];\n",
+					p.source, to, edgeLabel, edgeColor, edgeColor)
+			}
+		case renderHub:
+			hub := fmt.Sprintf("__hub_%d", hubIdx)
+			hubIdx++
+			fmt.Fprintf(&sb, "  %s [shape=point, width=0.05, height=0.05, label=\"\"];\n", hub)
+			fmt.Fprintf(&sb, "  %s -> %s [label=%q, color=%q, fontcolor=%q, arrowhead=none];\n",
+				p.source, hub, edgeLabel, edgeColor, edgeColor)
+			for _, to := range p.to {
+				fmt.Fprintf(&sb, "  %s -> %s [color=%q];\n", hub, to, edgeColor)
+			}
+		case renderLegend:
+			legendEntries = append(legendEntries, p)
+		}
 	}
 
-	// Relations as edges
-	sb.WriteString("  // Relations\n")
-	relationNames := getSortedRelationNames(meta)
-	for _, relName := range relationNames {
-		relDef := meta.Relations[relName]
-
-		// Build edge label
-		edgeLabel := relDef.Label
-		if schemaConstraints {
-			edgeLabel = buildConstraintLabel(relDef)
-		}
-
-		// Create edges for all from->to combinations
-		for _, from := range relDef.From {
-			// Edge color based on source entity type
-			edgeColor := defaultEdgeColors[entityColorIndex[from]%len(defaultEdgeColors)]
-
-			for _, to := range relDef.To {
-				fmt.Fprintf(&sb, "  %s -> %s [label=\"%s\", color=\"%s\", fontcolor=\"%s\"];\n",
-					from, to, edgeLabel, edgeColor, edgeColor)
-			}
-		}
+	if len(legendEntries) > 0 {
+		sb.WriteString("\n")
+		sb.WriteString(renderLegendNode(legendEntries, entityNames))
 	}
 
 	sb.WriteString("}\n")
 
 	fmt.Print(sb.String())
 	return nil
+}
+
+// prepareSchemaGraph applies --exclude filtering and returns the visible entity
+// list plus one relPair per (source, relation) in the post-exclude metamodel.
+func prepareSchemaGraph(m *metamodel.Metamodel) ([]string, []relPair) {
+	excluded := make(map[string]bool, len(schemaExclude))
+	for _, name := range schemaExclude {
+		excluded[name] = true
+	}
+
+	allNames := getSortedEntityNames(m)
+	entityNames := make([]string, 0, len(allNames))
+	for _, name := range allNames {
+		if !excluded[name] {
+			entityNames = append(entityNames, name)
+		}
+	}
+
+	colorIndex := make(map[string]int, len(allNames))
+	for i, name := range allNames {
+		colorIndex[name] = i
+	}
+
+	var pairs []relPair
+	for _, relName := range getSortedRelationNames(m) {
+		relDef := m.Relations[relName]
+		for _, from := range relDef.From {
+			if excluded[from] {
+				continue
+			}
+			targets := make([]string, 0, len(relDef.To))
+			for _, to := range relDef.To {
+				if !excluded[to] {
+					targets = append(targets, to)
+				}
+			}
+			if len(targets) == 0 {
+				continue
+			}
+			pairs = append(pairs, relPair{
+				source: from,
+				rel:    relName,
+				to:     targets,
+				render: renderPlain,
+				relDef: relDef,
+				srcIdx: colorIndex[from],
+			})
+		}
+	}
+	return entityNames, pairs
+}
+
+// classifyRenderings assigns a render bucket to each pair using the
+// total-degree snapshot (computed assuming all pairs are plain) to decide
+// whether a target is "otherwise connected".
+func classifyRenderings(entityNames []string, pairs []relPair) {
+	// Count potential edges per entity across every pair. For each pair we
+	// count +1 for the source (one outgoing edge per target) and +1 for each
+	// target (one incoming edge from the source). The snapshot is frozen —
+	// reclassifying a pair later doesn't change the counts.
+	degree := make(map[string]int, len(entityNames))
+	for _, p := range pairs {
+		degree[p.source] += len(p.to)
+		for _, t := range p.to {
+			degree[t]++
+		}
+	}
+
+	for i := range pairs {
+		p := &pairs[i]
+		n := len(p.to)
+
+		if schemaNoLegend && schemaNoBundle {
+			p.render = renderPlain
+			continue
+		}
+		if n >= legendTargetThreshold {
+			if !schemaNoLegend {
+				p.render = renderLegend
+			}
+			continue
+		}
+		if n >= 3 {
+			// Count the "other" connections each target has: total minus the
+			// contribution this pair makes (one incoming edge from source).
+			anyIsolated := false
+			for _, t := range p.to {
+				if degree[t]-1 <= 0 {
+					anyIsolated = true
+					break
+				}
+			}
+			// Choose the best available rendering given flag overrides.
+			// Preferred: hub when any target is isolated, legend otherwise.
+			// When the preferred mode is disabled, fall back to the other
+			// collapse mode before giving up and drawing plain edges.
+			switch {
+			case anyIsolated && !schemaNoBundle:
+				p.render = renderHub
+			case anyIsolated && !schemaNoLegend:
+				p.render = renderLegend
+			case !anyIsolated && !schemaNoLegend:
+				p.render = renderLegend
+			default:
+				p.render = renderPlain
+			}
+		}
+	}
+}
+
+// visibleEntities returns the set of entity types that should appear in the
+// DOT body. An entity is hidden only when it participates in one or more pairs
+// and every such pair is collapsed into the legend — keeping it in the body
+// would produce a disconnected node. Entities that belong to no pair at all
+// (e.g. leaf types in a tiny metamodel) stay visible.
+func visibleEntities(entityNames []string, pairs []relPair) map[string]bool {
+	visible := make(map[string]bool, len(entityNames))
+	participates := make(map[string]bool, len(entityNames))
+	for _, name := range entityNames {
+		visible[name] = true
+	}
+	for _, p := range pairs {
+		participates[p.source] = true
+		for _, t := range p.to {
+			participates[t] = true
+		}
+		if p.render == renderLegend {
+			continue
+		}
+		visible[p.source] = true
+		for _, t := range p.to {
+			visible[t] = true
+		}
+	}
+	// For every entity that participates in pairs but only via legend-collapsed
+	// ones, mark it hidden.
+	for name := range participates {
+		onlyLegend := true
+		for _, p := range pairs {
+			involved := p.source == name
+			if !involved {
+				for _, t := range p.to {
+					if t == name {
+						involved = true
+						break
+					}
+				}
+			}
+			if involved && p.render != renderLegend {
+				onlyLegend = false
+				break
+			}
+		}
+		if onlyLegend {
+			visible[name] = false
+		}
+	}
+	return visible
+}
+
+// renderLegendNode emits the __legend plaintext node containing an HTML-like
+// TABLE with one two-row block per legend entry.
+func renderLegendNode(entries []relPair, entityNames []string) string {
+	total := len(entityNames)
+	labelOf := make(map[string]string, total)
+	for _, name := range entityNames {
+		labelOf[name] = meta.Entities[name].Label
+	}
+
+	var tbl strings.Builder
+	tbl.WriteString(`<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4">`)
+	tbl.WriteString(`<TR><TD ALIGN="LEFT"><B>Universal relations</B></TD></TR>`)
+	for _, e := range entries {
+		src := html.EscapeString(meta.Entities[e.source].Label)
+		rel := html.EscapeString(e.relDef.Label)
+		fmt.Fprintf(&tbl,
+			`<TR><TD ALIGN="LEFT" SIDES="LTR"><B>%s</B> <I>%s</I></TD></TR>`,
+			src, rel)
+		fmt.Fprintf(&tbl,
+			`<TR><TD ALIGN="LEFT" SIDES="LBR"><I>%s</I></TD></TR>`,
+			formatTargets(e.to, labelOf, total))
+	}
+	tbl.WriteString(`</TABLE>>`)
+
+	var sb strings.Builder
+	sb.WriteString("  // Legend\n")
+	fmt.Fprintf(&sb,
+		"  __legend [shape=plaintext, margin=0, style=solid, fillcolor=white, label=%s];\n",
+		tbl.String())
+	return sb.String()
+}
+
+// formatTargets picks one of three rendering modes based on how close the
+// target set size is to the total number of entity types:
+//   - all entities (after the legend can exclude self): "any entity"
+//   - at least total-2: "any entity except X, Y"
+//   - otherwise: sorted labels, 2 per line, left-aligned with <BR ALIGN="LEFT"/>.
+func formatTargets(to []string, labelOf map[string]string, total int) string {
+	if total == 0 {
+		return ""
+	}
+	switch {
+	case len(to) == total:
+		return "any entity"
+	case len(to) >= total-2:
+		included := make(map[string]bool, len(to))
+		for _, t := range to {
+			included[t] = true
+		}
+		missing := make([]string, 0, total-len(to))
+		names := make([]string, 0, total)
+		for n := range labelOf {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			if !included[n] {
+				missing = append(missing, html.EscapeString(labelOf[n]))
+			}
+		}
+		return fmt.Sprintf(`any entity<BR ALIGN="LEFT"/>except %s<BR ALIGN="LEFT"/>`,
+			strings.Join(missing, ", "))
+	default:
+		labels := make([]string, 0, len(to))
+		for _, t := range to {
+			labels = append(labels, html.EscapeString(labelOf[t]))
+		}
+		sort.Strings(labels)
+		const perLine = 2
+		var lines []string
+		for i := 0; i < len(labels); i += perLine {
+			end := i + perLine
+			if end > len(labels) {
+				end = len(labels)
+			}
+			lines = append(lines, strings.Join(labels[i:end], ", "))
+		}
+		return strings.Join(lines, `<BR ALIGN="LEFT"/>`) + `<BR ALIGN="LEFT"/>`
+	}
 }
 
 // darkenColor takes a hex color and returns a darker version for borders
@@ -692,6 +974,12 @@ func init() {
 
 	schemaCmd.Flags().BoolVar(&schemaGraphviz, "graphviz", false, "Output metamodel as GraphViz DOT format")
 	schemaCmd.Flags().BoolVar(&schemaConstraints, "constraints", false, "Include cardinality constraints in GraphViz output")
+	schemaCmd.Flags().StringSliceVar(&schemaExclude, "exclude", nil,
+		"Hide an entity type in --graphviz output (repeatable)")
+	schemaCmd.Flags().BoolVar(&schemaNoBundle, "no-bundle", false,
+		"Disable the hub bundle for 3-4 targets with an isolated node")
+	schemaCmd.Flags().BoolVar(&schemaNoLegend, "no-legend", false,
+		"Disable the legend table for many-target / fully-connected relations")
 
 	rootCmd.AddCommand(schemaCmd)
 }

--- a/internal/cli/schema_test.go
+++ b/internal/cli/schema_test.go
@@ -950,3 +950,362 @@ func captureStdout(t *testing.T, fn func()) string {
 
 	return buf.String()
 }
+
+// --- graphviz rendering-pipeline tests -------------------------------------
+//
+// These cover the --exclude flag and the classification rule that renders
+// many-target relations as a hub bundle or a legend table rather than a
+// fan of edges.
+
+// schemaGraphvizFixture builds a bare metamodel with the given entities and
+// relations, applies it, and restores the previous state on cleanup.
+// Pass bs as nil to keep all rendering flags at their default.
+func schemaGraphvizFixture(
+	t *testing.T,
+	ents map[string]metamodel.EntityDef,
+	rels map[string]metamodel.RelationDef,
+) {
+	t.Helper()
+	oldMeta := meta
+	oldOut := out
+	oldWs := ws
+	oldGraphviz := schemaGraphviz
+	oldExclude := schemaExclude
+	oldNoBundle := schemaNoBundle
+	oldNoLegend := schemaNoLegend
+	t.Cleanup(func() {
+		meta = oldMeta
+		out = oldOut
+		ws = oldWs
+		schemaGraphviz = oldGraphviz
+		schemaExclude = oldExclude
+		schemaNoBundle = oldNoBundle
+		schemaNoLegend = oldNoLegend
+	})
+
+	meta = &metamodel.Metamodel{
+		Version:   "1.0",
+		Types:     map[string]metamodel.CustomType{},
+		Entities:  ents,
+		Relations: rels,
+	}
+	applySeeder(newStoreSeeder(meta))
+
+	var buf bytes.Buffer
+	out = output.NewWithWriter(&buf, output.FormatTable)
+	schemaGraphviz = true
+	schemaExclude = nil
+	schemaNoBundle = false
+	schemaNoLegend = false
+}
+
+func TestSchemaGraphvizExclude(t *testing.T) {
+	schemaGraphvizFixture(t,
+		map[string]metamodel.EntityDef{
+			"a": {Label: "A", IDPrefix: "A-"},
+			"b": {Label: "B", IDPrefix: "B-"},
+			"c": {Label: "C", IDPrefix: "C-"},
+		},
+		map[string]metamodel.RelationDef{
+			"ab": {Label: "ab", From: []string{"a"}, To: []string{"b"}},
+			"ac": {Label: "ac", From: []string{"a"}, To: []string{"c"}},
+		},
+	)
+	schemaExclude = []string{"c"}
+
+	result := captureStdout(t, func() {
+		if err := runSchemaGraphviz(); err != nil {
+			t.Fatalf("runSchemaGraphviz: %v", err)
+		}
+	})
+
+	if strings.Contains(result, "  c [label") {
+		t.Errorf("excluded node c should not appear:\n%s", result)
+	}
+	if strings.Contains(result, `a -> c `) || strings.Contains(result, `-> c [`) {
+		t.Errorf("edges to c should not appear:\n%s", result)
+	}
+	if !strings.Contains(result, `a -> b `) {
+		t.Errorf("non-excluded edge a->b should appear:\n%s", result)
+	}
+}
+
+func TestSchemaGraphvizLegendFiveTargets(t *testing.T) {
+	ents := map[string]metamodel.EntityDef{
+		"src": {Label: "Src", IDPrefix: "S-"},
+	}
+	// 5 unconnected leaf targets -> relation with 5 targets -> legend bucket.
+	targets := []string{"t1", "t2", "t3", "t4", "t5"}
+	for _, t := range targets {
+		ents[t] = metamodel.EntityDef{Label: strings.ToUpper(t), IDPrefix: t + "-"}
+	}
+	schemaGraphvizFixture(t, ents,
+		map[string]metamodel.RelationDef{
+			"fans": {Label: "fans", From: []string{"src"}, To: targets},
+		},
+	)
+
+	result := captureStdout(t, func() {
+		if err := runSchemaGraphviz(); err != nil {
+			t.Fatalf("runSchemaGraphviz: %v", err)
+		}
+	})
+
+	if !strings.Contains(result, "__legend [") {
+		t.Errorf("expected __legend node:\n%s", result)
+	}
+	if strings.Contains(result, `src -> t1`) || strings.Contains(result, `src -> t5`) {
+		t.Errorf("5-target relation should not emit direct edges:\n%s", result)
+	}
+	if !strings.Contains(result, "<B>Src</B> <I>fans</I>") {
+		t.Errorf("legend should contain source + relation label:\n%s", result)
+	}
+}
+
+func TestSchemaGraphvizHubIsolatedTargets(t *testing.T) {
+	ents := map[string]metamodel.EntityDef{
+		"src": {Label: "Src", IDPrefix: "S-"},
+		"t1":  {Label: "T1", IDPrefix: "T1-"},
+		"t2":  {Label: "T2", IDPrefix: "T2-"},
+		"t3":  {Label: "T3", IDPrefix: "T3-"},
+	}
+	// 3 isolated targets -> hub bundle.
+	schemaGraphvizFixture(t, ents,
+		map[string]metamodel.RelationDef{
+			"fans": {Label: "fans", From: []string{"src"}, To: []string{"t1", "t2", "t3"}},
+		},
+	)
+
+	result := captureStdout(t, func() {
+		if err := runSchemaGraphviz(); err != nil {
+			t.Fatalf("runSchemaGraphviz: %v", err)
+		}
+	})
+
+	if !strings.Contains(result, "__hub_0 [shape=point") {
+		t.Errorf("expected __hub_0 point node:\n%s", result)
+	}
+	if !strings.Contains(result, `src -> __hub_0 [label="fans"`) {
+		t.Errorf("expected labeled source->hub edge:\n%s", result)
+	}
+	if !strings.Contains(result, `__hub_0 -> t1 [color=`) {
+		t.Errorf("expected hub->target edges (unlabeled):\n%s", result)
+	}
+	if strings.Contains(result, "__legend [") {
+		t.Errorf("3 isolated targets should use hub, not legend:\n%s", result)
+	}
+}
+
+func TestSchemaGraphvizLegendConnectedTargets(t *testing.T) {
+	// 4 targets, each with another incoming edge -> all otherwise-connected
+	// -> legend (not hub).
+	ents := map[string]metamodel.EntityDef{
+		"src":    {Label: "Src", IDPrefix: "S-"},
+		"anchor": {Label: "Anchor", IDPrefix: "A-"},
+		"t1":     {Label: "T1", IDPrefix: "T1-"},
+		"t2":     {Label: "T2", IDPrefix: "T2-"},
+		"t3":     {Label: "T3", IDPrefix: "T3-"},
+		"t4":     {Label: "T4", IDPrefix: "T4-"},
+	}
+	schemaGraphvizFixture(t, ents,
+		map[string]metamodel.RelationDef{
+			"fans": {Label: "fans", From: []string{"src"}, To: []string{"t1", "t2", "t3", "t4"}},
+			// Each target additionally has an incoming edge from anchor,
+			// giving every target "otherwise connected" status.
+			"anchors": {Label: "anchors", From: []string{"anchor"}, To: []string{"t1", "t2", "t3", "t4"}},
+		},
+	)
+
+	result := captureStdout(t, func() {
+		if err := runSchemaGraphviz(); err != nil {
+			t.Fatalf("runSchemaGraphviz: %v", err)
+		}
+	})
+
+	if !strings.Contains(result, "__legend [") {
+		t.Errorf("4 connected targets should collapse to legend:\n%s", result)
+	}
+	if strings.Contains(result, "__hub_") {
+		t.Errorf("should not emit hub when all targets are otherwise connected:\n%s", result)
+	}
+	// anchors relation also has 4 targets all connected -> also legend,
+	// but self-check: no direct src->tN edges for the 'fans' relation.
+	if strings.Contains(result, `src -> t1 [label="fans"`) {
+		t.Errorf("fans edges should be suppressed:\n%s", result)
+	}
+}
+
+func TestSchemaGraphvizFewTargetsPlain(t *testing.T) {
+	schemaGraphvizFixture(t,
+		map[string]metamodel.EntityDef{
+			"a": {Label: "A", IDPrefix: "A-"},
+			"b": {Label: "B", IDPrefix: "B-"},
+			"c": {Label: "C", IDPrefix: "C-"},
+		},
+		map[string]metamodel.RelationDef{
+			"r": {Label: "r", From: []string{"a"}, To: []string{"b", "c"}},
+		},
+	)
+
+	result := captureStdout(t, func() {
+		if err := runSchemaGraphviz(); err != nil {
+			t.Fatalf("runSchemaGraphviz: %v", err)
+		}
+	})
+
+	if !strings.Contains(result, `a -> b [label="r"`) ||
+		!strings.Contains(result, `a -> c [label="r"`) {
+
+		t.Errorf("2-target relation should emit plain edges:\n%s", result)
+	}
+	if strings.Contains(result, "__hub_") || strings.Contains(result, "__legend [") {
+		t.Errorf("≤2 targets should never hub/legend:\n%s", result)
+	}
+}
+
+func TestSchemaGraphvizDropsEmptyNode(t *testing.T) {
+	// 'island' participates only in a legend-collapsed relation (≥5 targets),
+	// and has no other edges, so it must be dropped from the body.
+	ents := map[string]metamodel.EntityDef{
+		"island": {Label: "Island", IDPrefix: "I-"},
+	}
+	targets := []string{"t1", "t2", "t3", "t4", "t5"}
+	for _, t := range targets {
+		ents[t] = metamodel.EntityDef{Label: strings.ToUpper(t), IDPrefix: t + "-"}
+	}
+	schemaGraphvizFixture(t, ents,
+		map[string]metamodel.RelationDef{
+			"fans": {Label: "fans", From: []string{"island"}, To: targets},
+			// each target has another connection so they stay visible.
+			"link": {Label: "link", From: []string{"t1"}, To: []string{"t2"}},
+		},
+	)
+
+	result := captureStdout(t, func() {
+		if err := runSchemaGraphviz(); err != nil {
+			t.Fatalf("runSchemaGraphviz: %v", err)
+		}
+	})
+
+	if strings.Contains(result, `island [label`) {
+		t.Errorf("legend-only entity 'island' should be hidden:\n%s", result)
+	}
+	if !strings.Contains(result, `t1 [label="T1"`) {
+		t.Errorf("connected target t1 should remain visible:\n%s", result)
+	}
+}
+
+func TestSchemaGraphvizNoLegendFlag(t *testing.T) {
+	ents := map[string]metamodel.EntityDef{
+		"src": {Label: "Src", IDPrefix: "S-"},
+	}
+	targets := []string{"t1", "t2", "t3", "t4", "t5"}
+	for _, t := range targets {
+		ents[t] = metamodel.EntityDef{Label: strings.ToUpper(t), IDPrefix: t + "-"}
+	}
+	schemaGraphvizFixture(t, ents,
+		map[string]metamodel.RelationDef{
+			"fans": {Label: "fans", From: []string{"src"}, To: targets},
+		},
+	)
+	schemaNoLegend = true
+
+	result := captureStdout(t, func() {
+		if err := runSchemaGraphviz(); err != nil {
+			t.Fatalf("runSchemaGraphviz: %v", err)
+		}
+	})
+
+	if strings.Contains(result, "__legend [") {
+		t.Errorf("--no-legend should suppress the legend:\n%s", result)
+	}
+}
+
+func TestSchemaGraphvizNoBundleFlag(t *testing.T) {
+	ents := map[string]metamodel.EntityDef{
+		"src": {Label: "Src", IDPrefix: "S-"},
+		"t1":  {Label: "T1", IDPrefix: "T1-"},
+		"t2":  {Label: "T2", IDPrefix: "T2-"},
+		"t3":  {Label: "T3", IDPrefix: "T3-"},
+	}
+	schemaGraphvizFixture(t, ents,
+		map[string]metamodel.RelationDef{
+			"fans": {Label: "fans", From: []string{"src"}, To: []string{"t1", "t2", "t3"}},
+		},
+	)
+	schemaNoBundle = true
+
+	result := captureStdout(t, func() {
+		if err := runSchemaGraphviz(); err != nil {
+			t.Fatalf("runSchemaGraphviz: %v", err)
+		}
+	})
+
+	if strings.Contains(result, "__hub_") {
+		t.Errorf("--no-bundle should suppress hub even when targets are isolated:\n%s", result)
+	}
+	// With no bundle and isolated targets, the classification falls back to
+	// legend — which is the correct remaining collapse path.
+	if !strings.Contains(result, "__legend [") {
+		t.Errorf("with --no-bundle the pair should fall back to legend:\n%s", result)
+	}
+}
+
+func TestFormatTargets(t *testing.T) {
+	labels := map[string]string{
+		"a": "A", "b": "B", "c": "C", "d": "D", "e": "E",
+	}
+	tests := []struct {
+		name    string
+		to      []string
+		total   int
+		want    string
+		wantSub string
+	}{
+		{name: "empty total returns empty", total: 0, want: ""},
+		{name: "exactly all", to: []string{"a", "b", "c", "d", "e"}, total: 5, want: "any entity"},
+		{name: "minus one", to: []string{"a", "c", "d", "e"}, total: 5, wantSub: "except B"},
+		{name: "minus two", to: []string{"c", "d", "e"}, total: 5, wantSub: "except A, B"},
+		{name: "small list", to: []string{"c", "a"}, total: 5, wantSub: "A, C"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatTargets(tc.to, labels, tc.total)
+			if tc.want != "" && got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+			if tc.wantSub != "" && !strings.Contains(got, tc.wantSub) {
+				t.Errorf("got %q, want substring %q", got, tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestSchemaGraphvizEscapesHTML(t *testing.T) {
+	ents := map[string]metamodel.EntityDef{
+		"src": {Label: "Src<&>", IDPrefix: "S-"},
+	}
+	targets := []string{"t1", "t2", "t3", "t4", "t5"}
+	for _, t := range targets {
+		ents[t] = metamodel.EntityDef{Label: strings.ToUpper(t), IDPrefix: t + "-"}
+	}
+	schemaGraphvizFixture(t, ents,
+		map[string]metamodel.RelationDef{
+			"rel": {Label: `has "quote"`, From: []string{"src"}, To: targets},
+		},
+	)
+
+	result := captureStdout(t, func() {
+		if err := runSchemaGraphviz(); err != nil {
+			t.Fatalf("runSchemaGraphviz: %v", err)
+		}
+	})
+
+	// The legend uses HTML-like labels, so the unsafe characters must be escaped.
+	if !strings.Contains(result, "Src&lt;&amp;&gt;") {
+		t.Errorf("legend should HTML-escape source label:\n%s", result)
+	}
+	if !strings.Contains(result, "has &#34;quote&#34;") {
+		t.Errorf("legend should HTML-escape relation label:\n%s", result)
+	}
+}

--- a/internal/cli/schema_test.go
+++ b/internal/cli/schema_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -958,8 +959,9 @@ func captureStdout(t *testing.T, fn func()) string {
 // fan of edges.
 
 // schemaGraphvizFixture builds a bare metamodel with the given entities and
-// relations, applies it, and restores the previous state on cleanup.
-// Pass bs as nil to keep all rendering flags at their default.
+// relations, applies it, and restores the previous state on cleanup. All
+// rendering flags start at their defaults — tests can override them after
+// calling this helper.
 func schemaGraphvizFixture(
 	t *testing.T,
 	ents map[string]metamodel.EntityDef,
@@ -1097,22 +1099,25 @@ func TestSchemaGraphvizHubIsolatedTargets(t *testing.T) {
 }
 
 func TestSchemaGraphvizLegendConnectedTargets(t *testing.T) {
-	// 4 targets, each with another incoming edge -> all otherwise-connected
-	// -> legend (not hub).
+	// 4 targets each have a non-collapsing incoming edge from a separate
+	// anchor -> all otherwise-connected -> legend (not hub). The anchor's
+	// edges must NOT themselves collapse, or the whole body ends up empty.
 	ents := map[string]metamodel.EntityDef{
-		"src":    {Label: "Src", IDPrefix: "S-"},
-		"anchor": {Label: "Anchor", IDPrefix: "A-"},
-		"t1":     {Label: "T1", IDPrefix: "T1-"},
-		"t2":     {Label: "T2", IDPrefix: "T2-"},
-		"t3":     {Label: "T3", IDPrefix: "T3-"},
-		"t4":     {Label: "T4", IDPrefix: "T4-"},
+		"src": {Label: "Src", IDPrefix: "S-"},
+		"a1":  {Label: "A1", IDPrefix: "A1-"},
+		"a2":  {Label: "A2", IDPrefix: "A2-"},
+		"t1":  {Label: "T1", IDPrefix: "T1-"},
+		"t2":  {Label: "T2", IDPrefix: "T2-"},
+		"t3":  {Label: "T3", IDPrefix: "T3-"},
+		"t4":  {Label: "T4", IDPrefix: "T4-"},
 	}
 	schemaGraphvizFixture(t, ents,
 		map[string]metamodel.RelationDef{
 			"fans": {Label: "fans", From: []string{"src"}, To: []string{"t1", "t2", "t3", "t4"}},
-			// Each target additionally has an incoming edge from anchor,
-			// giving every target "otherwise connected" status.
-			"anchors": {Label: "anchors", From: []string{"anchor"}, To: []string{"t1", "t2", "t3", "t4"}},
+			// Two small (≤2 target) anchor relations keep every target
+			// otherwise-connected without themselves collapsing.
+			"a1r": {Label: "a1r", From: []string{"a1"}, To: []string{"t1", "t2"}},
+			"a2r": {Label: "a2r", From: []string{"a2"}, To: []string{"t3", "t4"}},
 		},
 	)
 
@@ -1128,10 +1133,66 @@ func TestSchemaGraphvizLegendConnectedTargets(t *testing.T) {
 	if strings.Contains(result, "__hub_") {
 		t.Errorf("should not emit hub when all targets are otherwise connected:\n%s", result)
 	}
-	// anchors relation also has 4 targets all connected -> also legend,
-	// but self-check: no direct src->tN edges for the 'fans' relation.
 	if strings.Contains(result, `src -> t1 [label="fans"`) {
 		t.Errorf("fans edges should be suppressed:\n%s", result)
+	}
+	// The anchors and targets must still be rendered — the snapshot-lie bug
+	// would hide all of them behind an empty-body legend.
+	for _, id := range []string{"a1", "a2", "t1", "t2", "t3", "t4"} {
+		wantLine := id + ` [label="` + strings.ToUpper(id) + `"`
+		if !strings.Contains(result, wantLine) {
+			t.Errorf("expected %s node in body:\n%s", id, result)
+		}
+	}
+	// src's only relation is legend-collapsed and it has no incoming edges,
+	// so it must be hidden (AC 6).
+	if strings.Contains(result, `src [label`) {
+		t.Errorf("src should be hidden when its only pair is legend-collapsed:\n%s", result)
+	}
+	if !strings.Contains(result, `a1 -> t1 [label="a1r"`) {
+		t.Errorf("a1 -> t1 plain edge missing:\n%s", result)
+	}
+}
+
+// TestSchemaGraphvizFivePairStarvesThreePair covers the "snapshot lies" case:
+// a ≥5-target relation will legend-collapse, and its targets' connectedness
+// from that relation should NOT be counted when classifying an adjacent 3-4
+// target relation. Before the two-pass classifier, both relations ended up in
+// the legend and the body was empty.
+func TestSchemaGraphvizFivePairStarvesThreePair(t *testing.T) {
+	ents := map[string]metamodel.EntityDef{
+		"big":   {Label: "Big", IDPrefix: "B-"},
+		"small": {Label: "Small", IDPrefix: "S-"},
+		"t1":    {Label: "T1", IDPrefix: "T1-"},
+		"t2":    {Label: "T2", IDPrefix: "T2-"},
+		"t3":    {Label: "T3", IDPrefix: "T3-"},
+		"t4":    {Label: "T4", IDPrefix: "T4-"},
+		"t5":    {Label: "T5", IDPrefix: "T5-"},
+	}
+	schemaGraphvizFixture(t, ents,
+		map[string]metamodel.RelationDef{
+			"many":  {Label: "many", From: []string{"big"}, To: []string{"t1", "t2", "t3", "t4", "t5"}},
+			"three": {Label: "three", From: []string{"small"}, To: []string{"t1", "t2", "t3"}},
+		},
+	)
+
+	result := captureStdout(t, func() {
+		if err := runSchemaGraphviz(); err != nil {
+			t.Fatalf("runSchemaGraphviz: %v", err)
+		}
+	})
+
+	// The 5-target relation unconditionally legend-collapses.
+	if !strings.Contains(result, `<B>Big</B> <I>many</I>`) {
+		t.Errorf("expected Big/many in legend:\n%s", result)
+	}
+	// The 3-target 'three' relation must NOT also legend-collapse — after
+	// 'many' collapses, t1/t2/t3 are isolated and 'three' should hub-bundle.
+	if !strings.Contains(result, "__hub_") {
+		t.Errorf("3-target relation should hub-bundle when its co-targets lose their only other edge:\n%s", result)
+	}
+	if strings.Contains(result, `<B>Small</B> <I>three</I>`) {
+		t.Errorf("Small/three must not legend-collapse:\n%s", result)
 	}
 }
 
@@ -1256,28 +1317,132 @@ func TestFormatTargets(t *testing.T) {
 		"a": "A", "b": "B", "c": "C", "d": "D", "e": "E",
 	}
 	tests := []struct {
-		name    string
-		to      []string
-		total   int
-		want    string
-		wantSub string
+		name           string
+		to             []string
+		effectiveTotal int
+		source         string
+		srcInTargets   bool
+		want           string
+		wantSub        string
+		wantNotSub     string
 	}{
-		{name: "empty total returns empty", total: 0, want: ""},
-		{name: "exactly all", to: []string{"a", "b", "c", "d", "e"}, total: 5, want: "any entity"},
-		{name: "minus one", to: []string{"a", "c", "d", "e"}, total: 5, wantSub: "except B"},
-		{name: "minus two", to: []string{"c", "d", "e"}, total: 5, wantSub: "except A, B"},
-		{name: "small list", to: []string{"c", "a"}, total: 5, wantSub: "A, C"},
+		{name: "empty total returns empty", effectiveTotal: 0, source: "a", want: ""},
+		{name: "exactly all", to: []string{"a", "b", "c", "d", "e"}, effectiveTotal: 5, source: "z", srcInTargets: false, want: "any entity"},
+		{name: "minus one", to: []string{"a", "c", "d", "e"}, effectiveTotal: 5, source: "z", srcInTargets: false, wantSub: "except B"},
+		{name: "minus two", to: []string{"c", "d", "e"}, effectiveTotal: 5, source: "z", srcInTargets: false, wantSub: "except A, B"},
+		{name: "small list", to: []string{"c", "a"}, effectiveTotal: 5, source: "z", srcInTargets: false, wantSub: "A, C"},
+		{name: "src excluded from complement", to: []string{"a", "c", "d", "e"}, effectiveTotal: 4, source: "b", srcInTargets: false, want: "any entity", wantNotSub: "except"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := formatTargets(tc.to, labels, tc.total)
+			got := formatTargets(tc.to, labels, tc.effectiveTotal, tc.source, tc.srcInTargets)
 			if tc.want != "" && got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 			if tc.wantSub != "" && !strings.Contains(got, tc.wantSub) {
 				t.Errorf("got %q, want substring %q", got, tc.wantSub)
 			}
+			if tc.wantNotSub != "" && strings.Contains(got, tc.wantNotSub) {
+				t.Errorf("got %q, must not contain %q", got, tc.wantNotSub)
+			}
 		})
+	}
+}
+
+func TestDotID(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"simple", "simple"},
+		{"with_underscore", "with_underscore"},
+		{"camelCase", "camelCase"},
+		{"type42", "type42"},
+		{"bug-analysis-checklist", `"bug-analysis-checklist"`},
+		{"has.dot", `"has.dot"`},
+		{"has space", `"has space"`},
+		{"1leading", `"1leading"`},
+		{"", `""`},
+		{`"quoted"`, `"\"quoted\""`},
+		{`back\slash`, `"back\\slash"`},
+	}
+	for _, tc := range tests {
+		if got := dotID(tc.in); got != tc.want {
+			t.Errorf("dotID(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestSchemaGraphvizHyphenatedIDs is a regression test for the class of bug
+// where entity identifiers containing hyphens (or any other non-[_A-Za-z0-9]
+// characters) are emitted unquoted and break DOT parsing. Exercises the full
+// pipeline: plain edge, hub, and legend — each with hyphenated names.
+func TestSchemaGraphvizHyphenatedIDs(t *testing.T) {
+	ents := map[string]metamodel.EntityDef{
+		"review-response":          {Label: "Review Response", IDPrefix: "RR-"},
+		"planning-checklist":       {Label: "Planning Checklist", IDPrefix: "PL-"},
+		"bug-analysis-checklist":   {Label: "Bug Analysis", IDPrefix: "BA-"},
+		"implementation-checklist": {Label: "Implementation Checklist", IDPrefix: "IM-"},
+		"review-checklist":         {Label: "Review Checklist", IDPrefix: "RV-"},
+		"docs-checklist":           {Label: "Docs Checklist", IDPrefix: "DC-"},
+	}
+	schemaGraphvizFixture(t, ents,
+		map[string]metamodel.RelationDef{
+			"touches": {
+				Label: "touches",
+				From:  []string{"review-response"},
+				To:    []string{"planning-checklist"},
+			},
+			// 3 isolated targets to force a hub bundle with hyphenated dsts.
+			"hub-rel": {
+				Label: "hub-rel",
+				From:  []string{"review-response"},
+				To:    []string{"bug-analysis-checklist", "implementation-checklist", "review-checklist"},
+			},
+		},
+	)
+
+	result := captureStdout(t, func() {
+		if err := runSchemaGraphviz(); err != nil {
+			t.Fatalf("runSchemaGraphviz: %v", err)
+		}
+	})
+
+	// All hyphenated identifiers must be emitted quoted.
+	mustNot := []string{
+		"  review-response [",
+		"  planning-checklist [",
+		"review-response -> planning-checklist",
+		"__hub_0 -> bug-analysis-checklist",
+	}
+	for _, bad := range mustNot {
+		if strings.Contains(result, bad) {
+			t.Errorf("unquoted hyphenated identifier leaked: %q\n%s", bad, result)
+		}
+	}
+	mustHave := []string{
+		`"review-response" [label="Review Response"`,
+		`"planning-checklist" [label="Planning Checklist"`,
+		`"review-response" -> "planning-checklist" [label="touches"`,
+		`__hub_0 -> "bug-analysis-checklist"`,
+	}
+	for _, good := range mustHave {
+		if !strings.Contains(result, good) {
+			t.Errorf("expected quoted line %q\n%s", good, result)
+		}
+	}
+
+	// If graphviz is available, round-trip through `dot -Tdot` as a parse
+	// check — the ultimate validation that the DOT is well-formed.
+	if _, err := exec.LookPath("dot"); err != nil {
+		t.Skip("graphviz 'dot' not in PATH; skipping parse round-trip")
+	}
+	cmd := exec.Command("dot", "-Tdot")
+	cmd.Stdin = strings.NewReader(result)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("dot rejected the DOT output: %v\nstderr: %s\nDOT:\n%s",
+			err, stderr.String(), result)
 	}
 }
 

--- a/scripts/demo-schema-render.sh
+++ b/scripts/demo-schema-render.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# End-to-end demo of `rela schema --graphviz`: build a metamodel covering every
+# classification bucket (plain, hub, legend-via-count, legend-via-connectedness),
+# render through graphviz, and assert the PNG is non-empty. Also exercises
+# --exclude.
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="${REPO}/bin/rela"
+DEMO="$(mktemp -d -t rela-schema-demo.XXXXXX)"
+
+cleanup() { rm -rf "${DEMO}"; }
+trap cleanup EXIT
+
+say() { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+step() { printf '    %s\n' "$*"; }
+
+say "Building rela → ${BIN}"
+(cd "${REPO}" && go build -o "${BIN}" ./cmd/rela)
+
+say "Seeding a metamodel that hits every classification bucket"
+# Buckets exercised:
+#   plain:    core  → leaf  via "describes" (1 target)
+#   hub:      hub   → {t1,t2,t3}, targets otherwise isolated (3 isolated)
+#   legend-connected:  webber → {c1,c2,c3,c4}, targets also linked via anchor
+#   legend-many:       catch  → {any..} (≥5 targets)
+cat > "${DEMO}/metamodel.yaml" <<'YAML'
+version: "1.0"
+namespace: "https://example.com/demo#"
+entities:
+  core:
+    label: Core
+    id_prefix: "CORE-"
+    id_type: sequential
+    color: "#E3F2FD"
+    properties:
+      title: {type: string, required: true}
+  leaf:
+    label: Leaf
+    id_prefix: "LEAF-"
+    id_type: sequential
+    color: "#E8F5E9"
+    properties:
+      title: {type: string, required: true}
+  hub:
+    label: Hub
+    id_prefix: "HUB-"
+    id_type: sequential
+    color: "#FFF3E0"
+    properties:
+      title: {type: string, required: true}
+  t1: {label: T1, id_prefix: "T1-", id_type: sequential, color: "#F3E5F5", properties: {title: {type: string, required: true}}}
+  t2: {label: T2, id_prefix: "T2-", id_type: sequential, color: "#E0F7FA", properties: {title: {type: string, required: true}}}
+  t3: {label: T3, id_prefix: "T3-", id_type: sequential, color: "#FCE4EC", properties: {title: {type: string, required: true}}}
+  webber:
+    label: Webber
+    id_prefix: "WEB-"
+    id_type: sequential
+    color: "#FFFDE7"
+    properties:
+      title: {type: string, required: true}
+  anchor:
+    label: Anchor
+    id_prefix: "ANC-"
+    id_type: sequential
+    color: "#EFEBE9"
+    properties:
+      title: {type: string, required: true}
+  c1: {label: C1, id_prefix: "C1-", id_type: sequential, color: "#E3F2FD", properties: {title: {type: string, required: true}}}
+  c2: {label: C2, id_prefix: "C2-", id_type: sequential, color: "#E8F5E9", properties: {title: {type: string, required: true}}}
+  c3: {label: C3, id_prefix: "C3-", id_type: sequential, color: "#FFF3E0", properties: {title: {type: string, required: true}}}
+  c4: {label: C4, id_prefix: "C4-", id_type: sequential, color: "#F3E5F5", properties: {title: {type: string, required: true}}}
+  catch:
+    label: Catch
+    id_prefix: "CATCH-"
+    id_type: sequential
+    color: "#FFEBEE"
+    properties:
+      title: {type: string, required: true}
+  u1: {label: U1, id_prefix: "U1-", id_type: sequential, color: "#E3F2FD", properties: {title: {type: string, required: true}}}
+  u2: {label: U2, id_prefix: "U2-", id_type: sequential, color: "#E8F5E9", properties: {title: {type: string, required: true}}}
+  u3: {label: U3, id_prefix: "U3-", id_type: sequential, color: "#FFF3E0", properties: {title: {type: string, required: true}}}
+  u4: {label: U4, id_prefix: "U4-", id_type: sequential, color: "#F3E5F5", properties: {title: {type: string, required: true}}}
+  u5: {label: U5, id_prefix: "U5-", id_type: sequential, color: "#E0F7FA", properties: {title: {type: string, required: true}}}
+  excluded:
+    label: Excluded
+    id_prefix: "EX-"
+    id_type: sequential
+    color: "#F5F5F5"
+    properties:
+      title: {type: string, required: true}
+relations:
+  describes:
+    label: describes
+    from: [core]
+    to: [leaf]
+  fans:
+    label: fans
+    from: [hub]
+    to: [t1, t2, t3]
+  web:
+    label: web
+    from: [webber]
+    to: [c1, c2, c3, c4]
+  anchors:
+    label: anchors
+    from: [anchor]
+    to: [c1, c2, c3, c4]
+  catches:
+    label: catches
+    from: [catch]
+    to: [u1, u2, u3, u4, u5]
+  lost:
+    label: lost
+    from: [excluded]
+    to: [leaf]
+YAML
+
+cd "${DEMO}"
+
+say "rela schema --graphviz (DOT to stdout, first 20 lines)"
+"${BIN}" schema --graphviz | sed -n '1,20p'
+step "(truncated)"
+
+check() {
+    local label="$1"
+    local out="$2"
+    local pattern="$3"
+    if printf '%s' "$out" | grep -qE "$pattern"; then
+        step "✓ ${label}"
+    else
+        step "✗ ${label} (missing pattern: ${pattern})"
+        echo "--- full DOT ---"
+        printf '%s\n' "$out"
+        exit 1
+    fi
+}
+refute() {
+    local label="$1"
+    local out="$2"
+    local pattern="$3"
+    if printf '%s' "$out" | grep -qE "$pattern"; then
+        step "✗ ${label} (unexpected pattern: ${pattern})"
+        echo "--- full DOT ---"
+        printf '%s\n' "$out"
+        exit 1
+    else
+        step "✓ ${label}"
+    fi
+}
+
+say "Structural assertions on the DOT output"
+DOT="$("${BIN}" schema --graphviz)"
+check "plain edge for 1-target relation" "$DOT" 'core -> leaf \[label="describes"'
+check "hub bundle for 3 isolated targets" "$DOT" '__hub_[0-9]+ \[shape=point'
+check "hub source edge labeled" "$DOT" 'hub -> __hub_[0-9]+ \[label="fans"'
+check "legend node present" "$DOT" '__legend \[shape=plaintext'
+check "legend mentions 'catches' (>=5 targets)" "$DOT" 'catches</I>'
+check "legend mentions 'web' (3-4 connected)" "$DOT" 'web</I>'
+refute "no direct edges for 'web' relation" "$DOT" 'webber -> c[0-9]+ \[label="web"'
+refute "no direct edges for 'catches' relation" "$DOT" 'catch -> u[0-9]+ \[label="catches"'
+
+say "Excluding an entity type"
+EX_DOT="$("${BIN}" schema --graphviz --exclude excluded)"
+refute "excluded node absent" "$EX_DOT" '  excluded \[label'
+refute "no edges from excluded" "$EX_DOT" 'excluded -> '
+
+say "Rendering to PNG via graphviz"
+if ! command -v dot >/dev/null 2>&1; then
+    say "graphviz 'dot' not found — skipping PNG render"
+    step "install with: brew install graphviz  (or: apt-get install graphviz)"
+    exit 0
+fi
+
+printf '%s\n' "$DOT" | dot -Tpng -o graph.png
+SIZE=$(wc -c < graph.png | tr -d ' ')
+if [ "$SIZE" -lt 1000 ]; then
+    step "✗ PNG suspiciously small (${SIZE} bytes) — probably a render error"
+    exit 1
+fi
+step "✓ PNG rendered (${SIZE} bytes)"
+
+cp graph.png /tmp/rela-schema-demo.png 2>/dev/null || true
+say "Output copied to /tmp/rela-schema-demo.png"
+
+say "Done."

--- a/scripts/demo-schema-render.sh
+++ b/scripts/demo-schema-render.sh
@@ -60,9 +60,18 @@ entities:
     color: "#FFFDE7"
     properties:
       title: {type: string, required: true}
-  anchor:
-    label: Anchor
-    id_prefix: "ANC-"
+  # Two anchors, each with a ≤2-target relation, keep every c-node otherwise
+  # connected without themselves collapsing.
+  anchor1:
+    label: Anchor1
+    id_prefix: "A1-"
+    id_type: sequential
+    color: "#EFEBE9"
+    properties:
+      title: {type: string, required: true}
+  anchor2:
+    label: Anchor2
+    id_prefix: "A2-"
     id_type: sequential
     color: "#EFEBE9"
     properties:
@@ -74,6 +83,14 @@ entities:
   catch:
     label: Catch
     id_prefix: "CATCH-"
+    id_type: sequential
+    color: "#FFEBEE"
+    properties:
+      title: {type: string, required: true}
+  # Hyphenated type — exercises DOT identifier quoting.
+  review-response:
+    label: Review Response
+    id_prefix: "RR-"
     id_type: sequential
     color: "#FFEBEE"
     properties:
@@ -103,10 +120,14 @@ relations:
     label: web
     from: [webber]
     to: [c1, c2, c3, c4]
-  anchors:
-    label: anchors
-    from: [anchor]
-    to: [c1, c2, c3, c4]
+  anchors1:
+    label: anchors1
+    from: [anchor1]
+    to: [c1, c2]
+  anchors2:
+    label: anchors2
+    from: [anchor2]
+    to: [c3, c4]
   catches:
     label: catches
     from: [catch]
@@ -115,6 +136,10 @@ relations:
     label: lost
     from: [excluded]
     to: [leaf]
+  responds-to:
+    label: responds to
+    from: [review-response]
+    to: [core]
 YAML
 
 cd "${DEMO}"
@@ -166,12 +191,29 @@ EX_DOT="$("${BIN}" schema --graphviz --exclude excluded)"
 refute "excluded node absent" "$EX_DOT" '  excluded \[label'
 refute "no edges from excluded" "$EX_DOT" 'excluded -> '
 
-say "Rendering to PNG via graphviz"
+say "Parse-checking DOT + rendering to PNG via graphviz"
 if ! command -v dot >/dev/null 2>&1; then
     say "graphviz 'dot' not found — skipping PNG render"
     step "install with: brew install graphviz  (or: apt-get install graphviz)"
     exit 0
 fi
+
+# First: pipe through `dot -Tdot` as a pure syntax check. This catches bugs
+# where DOT is accepted by `dot -Tpng` in lenient mode but is actually malformed.
+if ! printf '%s\n' "$DOT" | dot -Tdot > /dev/null 2>dot.err; then
+    step "✗ dot rejected the generated DOT"
+    cat dot.err
+    exit 1
+fi
+step "✓ DOT parses cleanly"
+
+# Same for the --exclude variant.
+if ! printf '%s\n' "$EX_DOT" | dot -Tdot > /dev/null 2>dot.err; then
+    step "✗ dot rejected the --exclude DOT"
+    cat dot.err
+    exit 1
+fi
+step "✓ --exclude DOT parses cleanly"
 
 printf '%s\n' "$DOT" | dot -Tpng -o graph.png
 SIZE=$(wc -c < graph.png | tr -d ' ')

--- a/tickets/entities/concepts/schema-visualization.md
+++ b/tickets/entities/concepts/schema-visualization.md
@@ -1,0 +1,10 @@
+---
+id: schema-visualization
+type: concept
+title: Metamodel Schema Visualization
+summary: Rendering the metamodel itself (entity types and relation types) as a Graphviz DOT diagram via `rela schema --graphviz`.
+description: Distinct from `rela graph` (which renders actual entities/relations). `rela schema --graphviz` produces a DOT document describing entity types as nodes and relation types as edges. Used for architecture reviews and documentation. Current output becomes unreadable for schemas with polymorphic relations (many-target `to:` lists) and for entity types that act as structural catch-alls (e.g. a `referentie` type that links to every other type).
+package: internal/cli
+layer: cli
+status: stable
+---

--- a/tickets/entities/features/FEAT-HIWW4.md
+++ b/tickets/entities/features/FEAT-HIWW4.md
@@ -1,0 +1,9 @@
+---
+id: FEAT-HIWW4
+type: feature
+title: Readable schema diagrams via filtering and legend bundling
+summary: '`rela schema --graphviz` produces readable diagrams for large/polymorphic metamodels by excluding entity types on request and auto-collapsing universal relations into a compact legend table.'
+description: 'Enhances `rela schema --graphviz` with: (a) `--exclude <type>` flag to omit entity types and their edges; (b) auto-detection of ''universal'' relations (target count exceeds a ratio of total entity types) which get rendered as a legend table rather than as a fan of edges; (c) smart target-list rendering in the legend (full list for small N, complement phrasing ''any entity except X'' when nearly all, plain ''any entity'' when exactly all).'
+priority: medium
+status: proposed
+---

--- a/tickets/entities/implementation-checklists/IMPL-FARVJ.md
+++ b/tickets/entities/implementation-checklists/IMPL-FARVJ.md
@@ -1,0 +1,62 @@
+---
+id: IMPL-FARVJ
+type: implementation-checklist
+title: 'Implementation: Make `rela schema --graphviz` readable for large/polymorphic metamodels'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units) — `scripts/demo-schema-render.sh` runs the full pipeline through graphviz
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place — there are no new error paths; no file I/O, no external calls
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data — new `schemaGraphvizFixture` helper.
+- [x] No hardcoded values in assertions when object is in scope — assertions use identifiers directly from fixtures.
+- [x] Only specifying values that matter for the test — the fixture helper accepts minimal `map[string]EntityDef` / `map[string]RelationDef`, no boilerplate.
+- [x] Interpolated values constructed from objects, not hardcoded — N/A here (no interpolation scenarios).
+- [x] Property comparisons use original object, not hardcoded strings — N/A (tests assert structural DOT output, which is the primary artifact).
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end — ran `scripts/demo-schema-render.sh`, rendered `/tmp/rela-schema-demo.png` through graphviz.
+- [x] Each acceptance criterion verified with a test scenario from planning.
+- [x] Edge cases manually verified — zero relations, single entity, mixed isolation, `--exclude nonexistent`, HTML-escape on labels.
+
+**Verification Evidence:**
+
+Local runs:
+```
+go test ./internal/cli/ -run TestSchemaGraphviz -v   # all pass
+go test ./internal/cli/ -run TestFormatTargets -v    # all pass
+just lint                                             # 0 issues
+scripts/demo-schema-render.sh                         # all assertions ✓, PNG 43175 bytes
+```
+
+Acceptance criteria map to tests:
+
+| AC | Test |
+|----|------|
+| 1 | `TestSchemaGraphvizExclude` ✓ |
+| 2 | `TestSchemaGraphvizLegendFiveTargets` ✓ |
+| 3 | `TestSchemaGraphvizHubIsolatedTargets` ✓ |
+| 4 | `TestSchemaGraphvizLegendConnectedTargets` ✓ |
+| 5 | `TestSchemaGraphvizFewTargetsPlain` ✓ |
+| 6 | `TestSchemaGraphvizDropsEmptyNode` ✓ |
+| 7 | `TestSchemaGraphvizNoLegendFlag` + `TestSchemaGraphvizNoBundleFlag` ✓ |
+| 8 | `scripts/demo-schema-render.sh` ✓ — assertions + valid PNG |
+| 9 | Existing `TestSchemaGraphviz*` suite ✓ — 5 tests unchanged |
+| extras | `TestFormatTargets` (table) + `TestSchemaGraphvizEscapesHTML` ✓ |
+
+## Quality
+
+- [x] Code follows project patterns — reuses existing `getSortedEntityNames`, `getSortedRelationNames`, `darkenColor`, `defaultEntityColors`, `defaultEdgeColors`, `buildConstraintLabel`.
+- [x] No security issues introduced — HTML-escape for user-provided labels in the legend's HTML-like TABLE; no file / subprocess / network operations.
+- [x] No silent failures — classification is deterministic; the renderer either emits edges, hub, or legend based on flag-and-structure rules.
+- [x] No debug code left behind.

--- a/tickets/entities/planning-checklists/PLAN-6T4SN.md
+++ b/tickets/entities/planning-checklists/PLAN-6T4SN.md
@@ -1,0 +1,186 @@
+---
+id: PLAN-6T4SN
+type: planning-checklist
+title: 'Planning: Make `rela schema --graphviz` readable for large/polymorphic metamodels'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+*In scope:*
+- `--exclude <type>` (repeatable) — drop entity type and associated edges.
+- `--no-bundle` / `--no-legend` flags to disable the two rendering features.
+- Classification per `(source, relation)` pair:
+  - ≤ 2 targets → plain edges (unchanged)
+  - 3 or 4 targets, **at least one target otherwise isolated** → hub-bundle
+  - 3 or 4 targets, **all targets otherwise connected** → legend
+  - ≥ 5 targets → legend
+- "Otherwise connected" is computed on the post-exclude graph: a target is connected if it has ≥ 1 other edge besides the one being classified.
+- Legend: single `__legend` plaintext node, HTML-like TABLE with per-entry 2-row block (header `LTR` + target list `LBR`), left-aligned.
+- Smart target-list formatting: full list / "any entity except X, Y" / "any entity".
+- Empty entity nodes (fully collapsed with no other edges) are dropped.
+- Generic demo script exercising all four classification buckets, validated end-to-end through graphviz.
+
+*Out of scope:*
+- `-o` / `-f` rendering flags on `schema --graphviz`.
+- Layout engine changes.
+- `rela graph` changes.
+
+**Acceptance Criteria:** see ticket body — 9 specific criteria, one per test.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions explored:**
+- Graphviz `concentrate=true` — didn't improve readability when tested.
+- Force-directed layouts (`fdp`/`sfdp`/`neato`) — sacrifice hierarchical flow.
+- Hub synthesis with `minlen` — over-constrains layout; default hub placement reads better.
+- HTML-like TABLE labels — stable across `dot` versions, chosen for the legend.
+
+**Codebase:**
+- Flag/dispatch pattern: `internal/cli/schema.go:54-55`, registration: `schema.go:693-694`.
+- Entity/relation iteration: `getSortedEntityNames`, `getSortedRelationNames`.
+- Existing generator: `runSchemaGraphviz` in `schema.go:507` (~60 lines).
+- Test fixture pattern: `internal/cli/schema_test.go:641+`.
+
+**Prior art:** the PR-522 DOT sanitization fix — informs safe identifiers for
+the `__legend` and `__hub_N` nodes.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Extend `runSchemaGraphviz` with four passes before DOT emission:
+
+1. **Apply excludes.** Filter `entityNames` to drop excluded types. For each relation, strip excluded types from `From` / `To`; drop the relation entirely if either side becomes empty.
+
+2. **Build the adjacency index.** For each entity type, precompute an *all-edge count* across every `(source, relation)` pair after excludes — counting edges that would be emitted if every pair were plain. This is the "otherwise connected" snapshot and must be built before classification to avoid feedback.
+
+3. **Classify each (source, relation) pair** into one of three outputs:
+   - `plain` — ≤ 2 targets, OR 3-4 targets with at least one otherwise-isolated → wait, opposite: classification by target count:
+     - **≤ 2 targets:** plain.
+     - **3 or 4 targets:** check each target's other-edge count in the adjacency index (subtracting the edge being classified). If every target has ≥ 1 other edge → `legend`. Else `hub`.
+     - **≥ 5 targets:** `legend`.
+   - `hub` — emit `__hub_N [shape=point, width=0.05, height=0.05, label=""]`, `source → __hub_N [label="rel", arrowhead=none]`, and one `__hub_N → target` per target (no label on the inner edges).
+   - `legend` — accumulate `(source-label, relation-label, targets)` into a slice; emit no edges.
+
+Two-pass ordering prevents chicken-and-egg: the adjacency count is computed
+assuming *all* pairs plain, so classifying A→B as legend doesn't retroactively
+make A→B look different.
+
+4. **Emit.** Entities first (skipping those with zero final attachments). Plain edges and hubs next. Legend node last.
+
+**Files to modify:**
+- `internal/cli/schema.go` — flags, extend `runSchemaGraphviz`. New helpers: `filterExcluded`, `countOtherEdges`, `classifyPair`, `renderHub`, `renderLegend`, `formatTargets`.
+- `internal/cli/schema_test.go` — table tests for each classification bucket, `--exclude`, `--no-*` flags, empty-node drop, HTML escape.
+- `scripts/demo-schema-render.sh` — synthetic metamodel covering all four buckets; runs through `dot -Tpng`; fails on empty PNG.
+
+**Alternatives rejected:**
+- Ratio-based universal threshold: user chose the bucket-based rule (≤2 / 3-4+isolated → hub / 3-4+connected → legend / ≥5 → legend) over a ratio because it's structural, not heuristic.
+- Tiered legend sections: start simple, add later if needed.
+- Post-processing DOT in a separate binary: less convenient.
+
+**Dependencies:** no new Go packages. `html.EscapeString` for label escaping in
+TABLE content.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+- `--exclude <type>` — string equality against `meta.Entities` keys; no DOT interpolation beyond already-sanitized identifiers.
+- Entity / relation labels embedded in the legend TABLE — HTML-escape via `html.EscapeString`.
+
+**Security-Sensitive Operations:** none. No file writes, no subprocess, no
+network.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Test |
+|----|------|
+| 1 | `TestSchemaGraphvizExclude` — 3-type metamodel, `--exclude` one, assert absence. |
+| 2 | `TestSchemaGraphvizLegendFiveTargets` — 5 targets; assert `__legend` row + zero edges for that relation. |
+| 3 | `TestSchemaGraphvizHubIsolatedTargets` — 3 targets, each with no other edges; assert `__hub_` node + correct edges. |
+| 4 | `TestSchemaGraphvizLegendConnectedTargets` — 4 targets each with other edges; assert `__legend` row + zero edges for that relation. |
+| 5 | `TestSchemaGraphvizFewTargetsPlain` — 2 targets; plain edges. |
+| 6 | `TestSchemaGraphvizDropsEmptyNode` — entity whose only outgoing relation goes to legend and has no incoming; assert node absent. |
+| 7 | `TestSchemaGraphvizNoBundle` / `NoLegend` — flags disable; output reverts. |
+| 8 | `scripts/demo-schema-render.sh` — end-to-end graphviz, exit 0, non-empty PNG. |
+| 9 | Existing `TestSchemaGraphviz*` suite — unchanged. |
+| extra | `TestFormatTargets` — table test over (targets, total): exactly-all / total-1 / total-2 / else. |
+| extra | `TestSchemaGraphvizEscapesHTML` — entity label contains `<>&"`; escaped in legend. |
+
+**Edge Cases:**
+- Zero relations → no hubs, no legend.
+- Relation with multiple `from` types — each `(from, relation)` classified independently.
+- `--exclude` of a non-existent type — silently ignored.
+- Target count exactly at boundary (= 2, = 5) — `> 2`, `>= 5` tested.
+- Mixed isolation in the same target set (e.g. 3 targets: 2 connected, 1 isolated) — falls into the "hub" branch because *at least one* is isolated.
+
+**Negative Tests:** none required beyond argument parsing (no numeric input to
+validate).
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Mitigation |
+|------|------------|
+| Classification ordering (A reclassifies B reclassifies A) | Two-pass: build adjacency index assuming all-plain; classify from that frozen snapshot. |
+| Graphviz versions render HTML-like labels differently | End-to-end demo through `dot` in CI (graphviz already installed from PR-522). |
+| Hub positioning suboptimal | Accept graphviz defaults; revisit if users hit problems. |
+| HTML-escape bugs in labels | `html.EscapeString`; explicit test. |
+
+**Effort:** s (~150 LOC Go incl. helpers, ~200 LOC tests, ~60 LOC shell demo;
+2-3h).
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] CLI help text updated in `schema.go`'s Long description.
+- [x] ~~User guide / reference~~ (N/A).
+- [x] ~~CLAUDE.md~~ (N/A).
+- [x] ~~README.md~~ (N/A).
+- [x] ~~API docs~~ (N/A: CLI-only).
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: design validated iteratively in chat via working prototype; user signed off on bucket-based rule).
+- [x] ~~All critical/significant findings addressed in plan~~ (N/A: no formal review run).
+
+**Design Review Findings:** none — design validated through working prototype +
+user-directed rule refinement in chat.

--- a/tickets/entities/review-checklists/REV-OJY1P.md
+++ b/tickets/entities/review-checklists/REV-OJY1P.md
@@ -2,55 +2,73 @@
 id: REV-OJY1P
 type: review-checklist
 title: 'Review: Make `rela schema --graphviz` readable for large/polymorphic metamodels'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`just test`) — `go test ./...` is green.
+- [x] Lint clean (`just lint`) — 0 issues.
+- [x] Coverage maintained (`just coverage-check`) — local coverage ratchet check deferred to CI.
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent) — completed; 11 findings.
+- [x] All critical review-responses addressed — RR-6OSEE (hyphenated IDs) and RR-RDILO (snapshot-lie classifier) both addressed with code fixes + targeted tests.
+- [x] All significant review-responses addressed — RR-OJEIH (empty-body test) and RR-CY4X9 (demo parse-check) both addressed.
+- [x] Self-reviewed the diff for unrelated changes — diff is confined to `internal/cli/schema.go`, `internal/cli/schema_test.go`, `scripts/demo-schema-render.sh`, and the ticket files.
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:**
+- RR-6OSEE (critical, addressed) — hyphenated entity IDs
+- RR-RDILO (critical, addressed) — snapshot classifier
+- RR-OJEIH (significant, addressed) — empty-body test
+- RR-CY4X9 (significant, addressed) — demo parse-check
+- RR-I4KUA (minor, addressed) — self in except list
+- RR-IP8EW (minor, addressed) — visibleEntities simplification
+- RR-1IGO1 (nit, addressed) — stale doc comment
+- RR-OFM44 (nit, addressed) — reserved ID constants
+- RR-BUJU2 (nit, addressed) — dead degree[source]
+- RR-A1DIS (nit, addressed) — named minHubTargets
+- RR-Y8ICV (nit, addressed) — "Collapsed relations" header
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested.
+- [x] Test evidence documented in implementation checklist (IMPL-FARVJ).
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+1. `--exclude` drops entity + edges — **PASS** via `TestSchemaGraphvizExclude`.
+2. ≥5 targets → legend — **PASS** via `TestSchemaGraphvizLegendFiveTargets`.
+3. 3-4 targets, some isolated → hub — **PASS** via `TestSchemaGraphvizHubIsolatedTargets`.
+4. 3-4 targets, all connected → legend — **PASS** via `TestSchemaGraphvizLegendConnectedTargets` (rewritten to also catch empty-body bug).
+5. ≤2 targets → plain — **PASS** via `TestSchemaGraphvizFewTargetsPlain`.
+6. Entities with only legend pairs hidden — **PASS** via `TestSchemaGraphvizDropsEmptyNode` + re-asserted in `TestSchemaGraphvizLegendConnectedTargets`.
+7. `--no-bundle` / `--no-legend` disable features — **PASS** via `TestSchemaGraphvizNoLegendFlag` + `TestSchemaGraphvizNoBundleFlag`.
+8. Generic demo script — **PASS** via `scripts/demo-schema-render.sh` (now includes hyphenated entity + `dot -Tdot` parse check; produced 60757-byte PNG).
+9. Existing tests unchanged — **PASS** (all 5 pre-existing `TestSchemaGraphviz*` tests still green).
+
+Real-world validation: rendered `tickets/metamodel.yaml` through `dot -Tpng` →
+892 KB PNG (was broken at start of review with the hyphenated-ID bug).
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
-
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: only change is CLI help text, which is updated in the `schemaCmd` Long description).
+- [x] User-facing documentation updated — `rela schema --help` lists `--exclude`, `--no-bundle`, `--no-legend`.
+- [x] ~~Docs-checklist marked as done~~ (N/A).
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why — review-response fixes to be committed with a message referencing the addressed RRs.
+- [x] No TODOs or FIXMEs left unaddressed.
+- [x] Ready for another developer to use.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (deferred: PR will be created outside the review-checklist lifecycle; tracked in branch `feat/schema-graphviz-legend-bundle`).
+- [x] ~~All CI checks pass~~ (deferred to PR creation).
+- [x] ~~PR URL documented below~~ (deferred to PR creation).
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** *to be created via `/pr` — current branch
+`feat/schema-graphviz-legend-bundle`*

--- a/tickets/entities/review-checklists/REV-OJY1P.md
+++ b/tickets/entities/review-checklists/REV-OJY1P.md
@@ -1,0 +1,56 @@
+---
+id: REV-OJY1P
+type: review-checklist
+title: 'Review: Make `rela schema --graphviz` readable for large/polymorphic metamodels'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-1IGO1.md
+++ b/tickets/entities/review-responses/RR-1IGO1.md
@@ -1,0 +1,9 @@
+---
+id: RR-1IGO1
+type: review-response
+title: schemaGraphvizFixture doc comment references nonexistent `bs` parameter
+finding: Comment says 'Pass bs as nil to keep all rendering flags at their default' but the signature is `(t, ents, rels)`. Stale from an earlier iteration.
+severity: nit
+resolution: 'Rewrote the doc comment to describe current behavior: ''All rendering flags start at their defaults — tests can override them after calling this helper.'''
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-6OSEE.md
+++ b/tickets/entities/review-responses/RR-6OSEE.md
@@ -1,0 +1,9 @@
+---
+id: RR-6OSEE
+type: review-response
+title: Hyphenated entity IDs emitted unquoted in schema DOT output
+finding: '`runSchemaGraphviz` emits `%s [label=...]` and `%s -> %s [...]` with unquoted entity identifiers. DOT''s unquoted identifier grammar forbids hyphens; the tickets metamodel has many hyphenated types (automated-measure, bug-analysis-checklist, planning-checklist, review-response, etc.). Reproduced: `RELA_PROJECT=./tickets rela schema --graphviz | dot -Tpng` → `syntax error in line 7 near ''-''`. This is the same class of bug as PR-522 (cluster IDs in `rela graph`) but in the sibling `rela schema` codepath. No test catches it because every fixture uses synthetic non-hyphenated names.'
+severity: critical
+resolution: 'Added `dotID()` helper in internal/cli/schema.go that quotes identifiers when they aren''t safe for DOT''s unquoted grammar. Every entity ID emission in runSchemaGraphviz now goes through dotID. Added TestDotID (table test) + TestSchemaGraphvizHyphenatedIDs which builds a metamodel with hyphenated types, asserts no unquoted hyphens leak, and — when graphviz is in PATH — pipes the output through `dot -Tdot` for a true parse-validity check. Manually verified against tickets/metamodel.yaml: `RELA_PROJECT=./tickets rela schema --graphviz | dot -Tpng` now renders cleanly (892 KB PNG).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-A1DIS.md
+++ b/tickets/entities/review-responses/RR-A1DIS.md
@@ -1,0 +1,9 @@
+---
+id: RR-A1DIS
+type: review-response
+title: Magic numbers 3 and 4 for hub bucket are inline
+finding: '`legendTargetThreshold = 5` is named; `3` and `4` for the hub bucket are inline as `n >= 3` and the implicit `< 5`. Inconsistent. Name `minHubTargets = 3`.'
+severity: nit
+resolution: Added `minHubTargets = 3` as a named constant alongside `legendTargetThreshold = 5`. Both thresholds are now documented in a block comment describing the classifier's buckets.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-BUJU2.md
+++ b/tickets/entities/review-responses/RR-BUJU2.md
@@ -1,0 +1,9 @@
+---
+id: RR-BUJU2
+type: review-response
+title: degree[source] accumulated but never read
+finding: '`classifyRenderings` writes `degree[p.source] += len(p.to)` but only reads `degree[t]` for targets. Dead store.'
+severity: nit
+resolution: Classifier rewrite removed the dead source-accumulation entirely. New inDegree map only counts target-side edges (the only direction ever read).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CY4X9.md
+++ b/tickets/entities/review-responses/RR-CY4X9.md
@@ -1,0 +1,9 @@
+---
+id: RR-CY4X9
+type: review-response
+title: demo-schema-render.sh does not parse-check DOT and has no hyphenated entity
+finding: 'The `check` function uses `grep -qE` against the DOT text — purely lexical. It does not run `dot -Tdot` as a parse check. Combined with no hyphenated entity in the fixture, this lets the critical hyphenation bug slip through. Fix: add a hyphenated entity to the demo''s metamodel, and pipe DOT through `dot -Tdot -o /dev/null` as an explicit parse-validity check before the PNG render.'
+severity: significant
+resolution: 'demo-schema-render.sh now (a) includes `review-response` as a hyphenated entity type with a `responds-to` relation, (b) pipes both the main DOT and the --exclude DOT through `dot -Tdot` as a pure parse check before any render. Verified locally: demo runs green with all assertions passing and both parse checks succeed.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-I4KUA.md
+++ b/tickets/entities/review-responses/RR-I4KUA.md
@@ -1,0 +1,9 @@
+---
+id: RR-I4KUA
+type: review-response
+title: Legend 'except' clause may list the source as an exception
+finding: '`formatTargets` takes `total = len(entityNames)`. For self-excluding relations (source not in its own target list), the complement size is `total - 1`, which triggers the ''any entity except Src'' branch — listing the source itself as an exception. Semantic noise. Fix: when the caller knows which entity is the source, pass `effectiveTotal` that excludes self.'
+severity: minor
+resolution: 'renderLegendNode now computes effTotal per entry: if source is not in its own target list, effTotal = total - 1 and formatTargets receives (source, srcInTargets=false) so the complement iteration skips self. Added TestFormatTargets/src_excluded_from_complement case: with source=''b'' (not in targets), 4 targets out of effectiveTotal=4 → ''any entity'', no ''except'' list.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-IP8EW.md
+++ b/tickets/entities/review-responses/RR-IP8EW.md
@@ -1,0 +1,9 @@
+---
+id: RR-IP8EW
+type: review-response
+title: visibleEntities has dead assignments and an O(P^2 T) rescan
+finding: Inner loop reassigns `visible[name] = true` for entities already true from the outer loop. Then a third pass re-scans every pair for every entity to check 'only-legend participation'. Can be a single pass maintaining seenAny and seenNonLegend sets. Code quality, not correctness.
+severity: minor
+resolution: 'Replaced with a single-pass implementation using two sets (seenAny, seenDrawn) and a final derivation: `visible = !seenAny || seenDrawn`. Drops the dead assignments and the O(P^2 T) rescan.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OFM44.md
+++ b/tickets/entities/review-responses/RR-OFM44.md
@@ -1,0 +1,9 @@
+---
+id: RR-OFM44
+type: review-response
+title: __legend and __hub_N identifiers collide if metamodel defines an entity with that name
+finding: The reserved identifiers are hard-coded with no collision detection. A user metamodel with an entity literally named `__legend` (improbable but not forbidden by schema validation) would silently overwrite. Low-probability, cheap to defend against (check for collision, adjust prefix) or at minimum document the reservation.
+severity: nit
+resolution: Extracted the reserved identifiers to named constants `legendNodeID = "__legend"` and `hubIDPrefix = "__hub_"` with a comment documenting the reservation. The full collision-detection approach is kept out of this PR — a user metamodel literally naming an entity `__legend` would silently overwrite, but the probability is negligible and the fix would add complexity disproportionate to the risk.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OJEIH.md
+++ b/tickets/entities/review-responses/RR-OJEIH.md
@@ -1,0 +1,9 @@
+---
+id: RR-OJEIH
+type: review-response
+title: TestSchemaGraphvizLegendConnectedTargets asserts a broken render
+finding: 'The test builds `fans` (4 targets) and `anchors` (4 targets, same targets). Both collapse to legend under the current classifier, so every entity participates only in legend-pairs and `visibleEntities` hides them all. The graph body ends up empty. The test passes because it only checks that `__legend [` appears and `__hub_` does not — neither assertion notices the empty body. This is an instance of critical #2 masquerading as a passing test. Fix: add a non-collapsing edge to keep the body populated and assert on entity labels appearing in node lines.'
+severity: significant
+resolution: 'Rewrote TestSchemaGraphvizLegendConnectedTargets: two small anchor relations (a1r: 2 targets, a2r: 2 targets) keep every t-node otherwise-connected without themselves collapsing. Assertions now require each of a1/a2/t1..t4 to appear as rendered nodes in the body (catches the empty-body regression) and explicitly verify that src IS hidden (AC 6) since its only pair is legend-collapsed.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-RDILO.md
+++ b/tickets/entities/review-responses/RR-RDILO.md
@@ -1,0 +1,9 @@
+---
+id: RR-RDILO
+type: review-response
+title: classifyRenderings degree snapshot lies when co-targets also collapse
+finding: '`classifyRenderings` builds the degree map assuming every pair is plain, then classifies. When two relations share targets and both want to collapse, the snapshot reports each target as degree 2 (connected) even though in the final diagram both edges vanish and the target is actually isolated. Case A: `srcA -> {t1..t4}` and `srcB -> {t1..t4}` both classify as legend → graph body empty. Case B: `srcA -> {t1..t3}` and `srcB -> {t1..t5}`: srcB forces legend (>=5), but with the snapshot t1..t3 still look connected, so srcA also goes legend instead of the correct hub-bundle. Fix: two-pass classification — handle >=5 pairs first (unconditional legend), decrement their targets'' degree, then classify 3-4 pairs against the settled degree.'
+severity: critical
+resolution: 'Rewrote classifyRenderings with a three-pass approach: (1) unconditional buckets (plain for <3, legend for >=5) assigned first; (2) inDegree computed ONLY over non-legend pairs, reflecting what edges will actually be drawn; (3) 3-4 pairs classified against that honest degree, and when a deferred pair ends up as legend its targets'' inDegree is decremented so later pairs see reality. Added TestSchemaGraphvizFivePairStarvesThreePair which creates a 5-target ''many'' relation (forced legend) plus a 3-target ''three'' relation sharing targets. With the old snapshot, both went legend and the body was empty. With the fix, ''three'' correctly hub-bundles because its co-targets are revealed as isolated after ''many'' collapses.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Y8ICV.md
+++ b/tickets/entities/review-responses/RR-Y8ICV.md
@@ -1,0 +1,9 @@
+---
+id: RR-Y8ICV
+type: review-response
+title: '''Universal relations'' header is misleading when legend entries are specific sources'
+finding: 'The table header reads ''Universal relations'' but entries can be any legend-classified (source, relation) pair, not strictly universal ones. Suggestion: ''Collapsed relations'' or ''Fan-out relations''.'
+severity: nit
+resolution: Renamed the legend table header from 'Universal relations' to 'Collapsed relations', which accurately describes what goes into it (both many-target pairs AND 3-4 pairs that would otherwise draw an edge fan).
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-8E4Z6.md
+++ b/tickets/entities/tickets/TKT-8E4Z6.md
@@ -1,0 +1,60 @@
+---
+id: TKT-8E4Z6
+type: ticket
+title: Make `rela schema --graphviz` readable for large/polymorphic metamodels
+kind: enhancement
+priority: medium
+effort: s
+status: review
+---
+
+Large or polymorphic metamodels render poorly with `rela schema --graphviz |
+dot`: a relation whose source has many targets produces a fan of edges that
+dominates the layout and obscures the rest.
+
+## Scope
+
+Two independent enhancements to `rela schema --graphviz`:
+
+1. **`--exclude <type>` (repeatable)** — drop an entity type and its edges from the diagram.
+2. **Auto-rendering of many-target relations**, applied per `(source-type, relation)` pair based on the size of the effective `to` set and whether those targets are otherwise connected:
+
+   | Target count | Targets otherwise connected? | Rendering |
+   |:--:|:--:|:--|
+   | ≤ 2 | — | plain edges (unchanged) |
+   | 3 or 4 | at least one target otherwise isolated | hub-bundle: `source → • → targets` |
+   | 3 or 4 | all targets otherwise connected | legend entry (no edges) |
+   | ≥ 5 | — | legend entry (no edges) |
+
+"Otherwise connected" = the target has ≥ 1 edge in the final diagram other than
+the edge under consideration.
+
+## Legend format
+
+Single `__legend` node (shape=plaintext, white fill), HTML-like TABLE:
+- Header row: `Universal relations`.
+- Per collapsed `(source, relation)`, two rows forming one visual block:
+  1. `SIDES="LTR"`: bold source + italic relation label.
+  2. `SIDES="LBR"`: italic target list, left-aligned via `<BR ALIGN="LEFT"/>`.
+- Target list, auto-selected:
+  - Exactly all entity types: `any entity`
+  - At least `total - 2`: `any entity except X, Y`
+  - Otherwise: sorted, comma-separated labels, ~2 per line.
+
+## Acceptance criteria
+
+1. `--exclude` drops the entity and any edges touching it; relations that still have non-excluded targets keep only those.
+2. A (source, relation) pair with ≥ 5 targets produces a `__legend` row, no edges.
+3. A (source, relation) pair with 3-4 targets where at least one is otherwise-isolated renders as `source → __hub_N → targets`.
+4. A (source, relation) pair with 3-4 targets where all are otherwise-connected produces a `__legend` row, no edges.
+5. A (source, relation) pair with ≤ 2 targets renders as plain edges.
+6. Entity types whose only connections are legend-collapsed AND have no remaining edges are omitted from the DOT.
+7. `--no-legend` / `--no-bundle` flags turn off the respective features; output reverts to today's.
+8. A generic demo script under `scripts/` constructs a synthetic metamodel exercising all four classification buckets, runs through `| dot -Tpng`, and asserts the PNG is non-empty.
+9. Existing `TestSchemaGraphviz*` tests pass unchanged.
+
+## Out of scope
+
+- `-o` / `-f` rendering parity with `rela graph` (separate ticket).
+- Alternative layout engines, cluster attributes, `concentrate=true`.
+- Changes to `rela graph`.

--- a/tickets/entities/tickets/TKT-8E4Z6.md
+++ b/tickets/entities/tickets/TKT-8E4Z6.md
@@ -5,7 +5,7 @@ title: Make `rela schema --graphviz` readable for large/polymorphic metamodels
 kind: enhancement
 priority: medium
 effort: s
-status: review
+status: done
 ---
 
 Large or polymorphic metamodels render poorly with `rela schema --graphviz |

--- a/tickets/relations/FEAT-HIWW4--requires--schema-visualization.md
+++ b/tickets/relations/FEAT-HIWW4--requires--schema-visualization.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-HIWW4
+relation: requires
+to: schema-visualization
+---

--- a/tickets/relations/TKT-8E4Z6--affects--schema-visualization.md
+++ b/tickets/relations/TKT-8E4Z6--affects--schema-visualization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: affects
+to: schema-visualization
+---

--- a/tickets/relations/TKT-8E4Z6--has-implementation--IMPL-FARVJ.md
+++ b/tickets/relations/TKT-8E4Z6--has-implementation--IMPL-FARVJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: has-implementation
+to: IMPL-FARVJ
+---

--- a/tickets/relations/TKT-8E4Z6--has-planning--PLAN-6T4SN.md
+++ b/tickets/relations/TKT-8E4Z6--has-planning--PLAN-6T4SN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: has-planning
+to: PLAN-6T4SN
+---

--- a/tickets/relations/TKT-8E4Z6--has-review--REV-OJY1P.md
+++ b/tickets/relations/TKT-8E4Z6--has-review--REV-OJY1P.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: has-review
+to: REV-OJY1P
+---

--- a/tickets/relations/TKT-8E4Z6--has-review-response--RR-1IGO1.md
+++ b/tickets/relations/TKT-8E4Z6--has-review-response--RR-1IGO1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: has-review-response
+to: RR-1IGO1
+---

--- a/tickets/relations/TKT-8E4Z6--has-review-response--RR-6OSEE.md
+++ b/tickets/relations/TKT-8E4Z6--has-review-response--RR-6OSEE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: has-review-response
+to: RR-6OSEE
+---

--- a/tickets/relations/TKT-8E4Z6--has-review-response--RR-A1DIS.md
+++ b/tickets/relations/TKT-8E4Z6--has-review-response--RR-A1DIS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: has-review-response
+to: RR-A1DIS
+---

--- a/tickets/relations/TKT-8E4Z6--has-review-response--RR-BUJU2.md
+++ b/tickets/relations/TKT-8E4Z6--has-review-response--RR-BUJU2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: has-review-response
+to: RR-BUJU2
+---

--- a/tickets/relations/TKT-8E4Z6--has-review-response--RR-CY4X9.md
+++ b/tickets/relations/TKT-8E4Z6--has-review-response--RR-CY4X9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: has-review-response
+to: RR-CY4X9
+---

--- a/tickets/relations/TKT-8E4Z6--has-review-response--RR-I4KUA.md
+++ b/tickets/relations/TKT-8E4Z6--has-review-response--RR-I4KUA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: has-review-response
+to: RR-I4KUA
+---

--- a/tickets/relations/TKT-8E4Z6--has-review-response--RR-IP8EW.md
+++ b/tickets/relations/TKT-8E4Z6--has-review-response--RR-IP8EW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: has-review-response
+to: RR-IP8EW
+---

--- a/tickets/relations/TKT-8E4Z6--has-review-response--RR-OFM44.md
+++ b/tickets/relations/TKT-8E4Z6--has-review-response--RR-OFM44.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: has-review-response
+to: RR-OFM44
+---

--- a/tickets/relations/TKT-8E4Z6--has-review-response--RR-OJEIH.md
+++ b/tickets/relations/TKT-8E4Z6--has-review-response--RR-OJEIH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: has-review-response
+to: RR-OJEIH
+---

--- a/tickets/relations/TKT-8E4Z6--has-review-response--RR-RDILO.md
+++ b/tickets/relations/TKT-8E4Z6--has-review-response--RR-RDILO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: has-review-response
+to: RR-RDILO
+---

--- a/tickets/relations/TKT-8E4Z6--has-review-response--RR-Y8ICV.md
+++ b/tickets/relations/TKT-8E4Z6--has-review-response--RR-Y8ICV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: has-review-response
+to: RR-Y8ICV
+---

--- a/tickets/relations/TKT-8E4Z6--implements--FEAT-HIWW4.md
+++ b/tickets/relations/TKT-8E4Z6--implements--FEAT-HIWW4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8E4Z6
+relation: implements
+to: FEAT-HIWW4
+---


### PR DESCRIPTION
## Summary

- `rela schema --graphviz` was hard to read for large/polymorphic metamodels — a relation with many targets produced a fan of edges that dominated the layout.
- New `--exclude <type>` flag (repeatable) drops an entity type and its edges.
- New auto-classifier per `(source, relation)` pair:

  | Target count | Targets otherwise connected? | Rendering |
  |:--:|:--:|:--|
  | ≤ 2 | — | plain edges (unchanged) |
  | 3 or 4 | ≥1 target otherwise isolated | hub-bundle `source → • → targets` |
  | 3 or 4 | all targets otherwise connected | legend entry |
  | ≥ 5 | — | legend entry |

- Legend is a single `__legend` plaintext node containing an HTML-like TABLE: header `Collapsed relations`, per-entry 2-row block (bold source + italic relation, then italic left-aligned target list). Targets auto-formatted as full list / `any entity except X, Y` / `any entity` based on size.
- `--no-bundle` / `--no-legend` opt out of the respective features.
- Entities whose only pairs are all legend-collapsed (and have no incoming edges) are hidden from the body.

## Implementation notes

- Classifier uses a **three-pass** approach to avoid a "snapshot lies" bug: first the unconditional buckets (plain `<3`, legend `≥5`), then `inDegree` is computed counting only non-legend pairs, finally 3-4 pairs are classified and their targets' `inDegree` decremented on-the-fly when they collapse. Ensures that a 3-target relation sharing targets with a 5-target relation correctly hub-bundles after the 5-target collapses.
- New `dotID()` helper quotes identifiers not matching `[_A-Za-z][_0-9A-Za-z]*`. Fixes a regression of the same-class bug as PR #522 (hyphenated cluster IDs in `rela graph`). Verified against `tickets/metamodel.yaml`, which renders cleanly now.
- User-provided labels embedded in the legend's HTML-like TABLE are `html.EscapeString`-escaped.

## Tests

- 9 new tests in `internal/cli/schema_test.go` cover each acceptance criterion, classification bucket, flag override, HTML escape, and a `dot -Tdot` round-trip against hyphenated entity IDs (when graphviz is in PATH).
- `TestSchemaGraphvizFivePairStarvesThreePair` pins the three-pass classifier against the "snapshot lies" regression.
- Existing `TestSchemaGraphviz*` suite unchanged and still green.

## Demo

- `scripts/demo-schema-render.sh` constructs a synthetic metamodel hitting all four buckets, pipes through `dot -Tdot` (parse check) and `dot -Tpng` (render check), and asserts the PNG is non-empty. Includes a hyphenated entity type to regression-guard the dotID fix.

## Test plan

- [x] `go test ./...` passes
- [x] `just lint` clean
- [x] `scripts/demo-schema-render.sh` produces a valid PNG end-to-end
- [x] `RELA_PROJECT=./tickets rela schema --graphviz | dot -Tpng` renders (previously `syntax error in line 7 near '-'`)
- [x] Cranky code review run: 11 findings addressed (2 critical + 2 significant + 7 minor/nit)

Closes TKT-8E4Z6.