### PR TITLE
feat: introduce RootedFS + pilot state.FSKV migration (TKT-0M8PM)

### DIFF
--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -221,7 +221,11 @@ func NewApp(
 ) (*App, error) {
 	// Construct reconstructible services from the primitives.
 	cfgLoader := config.NewFSLoader(fs, paths.Root)
-	kv := state.NewFSKV(fs, paths.CacheDir)
+	kvRoot, err := storage.NewRootedFS(fs, paths.CacheDir)
+	if err != nil {
+		return nil, fmt.Errorf("dataentry: rooted fs for state kv: %w", err)
+	}
+	kv := state.NewFSKV(kvRoot)
 	trc := tracer.New(st)
 	templater := templating.NewFSTemplater(fs, paths)
 	readDeps := lua.ReadDeps{

--- a/internal/dataentry/document_test.go
+++ b/internal/dataentry/document_test.go
@@ -221,7 +221,11 @@ func TestRewriteDocumentLinks(t *testing.T) {
 func TestDocumentDiskCache(t *testing.T) {
 	fs := storage.NewMemFS()
 	_ = fs.MkdirAll("/p/.rela", 0o755)
-	kv := state.NewFSKV(fs, "/p/.rela")
+	kvRoot, err := storage.NewRootedFS(fs, "/p/.rela")
+	if err != nil {
+		t.Fatalf("NewRootedFS: %v", err)
+	}
+	kv := state.NewFSKV(kvRoot)
 
 	t.Run("cache file naming", func(t *testing.T) {
 		entryID := "REQ-001"

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -242,7 +242,11 @@ func newHandlerTestApp(t *testing.T) *App {
 	app := &App{}
 	rebindApp(app, fs, ctx, ws)
 	// Make sure kv hits the real filesystem through state.KV, matching production.
-	app.kv = state.NewFSKV(fs, ctx.CacheDir)
+	kvRoot, err := storage.NewRootedFS(fs, ctx.CacheDir)
+	if err != nil {
+		t.Fatalf("NewRootedFS: %v", err)
+	}
+	app.kv = state.NewFSKV(kvRoot)
 	app.state.Store(&AppState{
 		Cfg:         cfg,
 		Meta:        meta,

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -8,9 +8,6 @@ package state
 
 import (
 	"context"
-	"errors"
-	"path/filepath"
-	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
@@ -28,64 +25,25 @@ type KV interface {
 	Put(ctx context.Context, key string, data []byte) error
 }
 
-// FSKV stores state under a root directory on a filesystem.
+// FSKV stores state under a root directory on a filesystem. Key
+// validation and parent-directory creation are handled by the embedded
+// RootedFS.
 type FSKV struct {
-	fs   storage.FS
-	root string
+	fs *storage.RootedFS
 }
 
 var _ KV = (*FSKV)(nil)
 
-// NewFSKV constructs a filesystem-backed KV rooted at dir (e.g. the
-// project's .rela/ directory).
-func NewFSKV(fs storage.FS, dir string) *FSKV {
-	return &FSKV{fs: fs, root: dir}
+// NewFSKV constructs a filesystem-backed KV rooted at the given
+// RootedFS. The RootedFS is the single path-validation barrier.
+func NewFSKV(fs *storage.RootedFS) *FSKV {
+	return &FSKV{fs: fs}
 }
 
 func (s *FSKV) Get(_ context.Context, key string) ([]byte, error) {
-	if err := validateKey(key); err != nil {
-		return nil, err
-	}
-	return s.fs.ReadFile(filepath.Join(s.root, key))
+	return s.fs.ReadFile(key)
 }
 
 func (s *FSKV) Put(_ context.Context, key string, data []byte) error {
-	if err := validateKey(key); err != nil {
-		return err
-	}
-	full := filepath.Join(s.root, key)
-	if err := s.fs.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-		return err
-	}
-	return s.fs.WriteFile(full, data, 0o644)
-}
-
-// validateKey rejects keys that would escape the KV root or map to paths
-// the filesystem would misinterpret. Subdirectories are allowed (callers
-// group state under prefixes); absolute paths, traversal segments,
-// backslashes, control characters, and Windows drive letters are not.
-func validateKey(name string) error {
-	if name == "" {
-		return errors.New("state: key must not be empty")
-	}
-	for _, r := range name {
-		if r < 0x20 || r == 0x7f {
-			return errors.New("state: control character (including NUL) not allowed")
-		}
-	}
-	if strings.ContainsRune(name, '\\') {
-		return errors.New("state: backslash not allowed (use forward slash)")
-	}
-	if strings.HasPrefix(name, "/") {
-		return errors.New("state: key must be relative")
-	}
-	for _, seg := range strings.Split(name, "/") {
-		if seg == "" || seg == "." || seg == ".." {
-			return errors.New("state: traversal or empty segment not allowed")
-		}
-	}
-	if len(name) >= 2 && name[1] == ':' {
-		return errors.New("state: drive letter not allowed")
-	}
-	return nil
+	return s.fs.WriteFile(key, data, 0o644)
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,53 +1,81 @@
 package state
 
 import (
-	"strings"
+	"context"
+	"errors"
+	"os"
 	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
-func TestValidateKey_Accepts(t *testing.T) {
-	ok := []string{
-		"cache.json",
-		"user-defaults.yaml",
-		"ui-state.json",
-		"palette.yaml",
-		"documents/render-abc123.html", // legitimate nested key
+func newTestKV(t *testing.T) *FSKV {
+	t.Helper()
+	mem := storage.NewMemFS()
+	if err := mem.MkdirAll("/root", 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
 	}
-	for _, name := range ok {
-		t.Run(name, func(t *testing.T) {
-			if err := validateKey(name); err != nil {
-				t.Fatalf("expected ok for %q, got %v", name, err)
+	rfs, err := storage.NewRootedFS(mem, "/root")
+	if err != nil {
+		t.Fatalf("NewRootedFS: %v", err)
+	}
+	return NewFSKV(rfs)
+}
+
+func TestFSKV_Put_Get_RoundTrip(t *testing.T) {
+	kv := newTestKV(t)
+	ctx := context.Background()
+	if err := kv.Put(ctx, "cache.json", []byte(`{"a":1}`)); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := kv.Get(ctx, "cache.json")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != `{"a":1}` {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFSKV_Put_NestedKey_CreatesDirs(t *testing.T) {
+	kv := newTestKV(t)
+	ctx := context.Background()
+	if err := kv.Put(ctx, "documents/render-abc.html", []byte("<html/>")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := kv.Get(ctx, "documents/render-abc.html")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "<html/>" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFSKV_Get_MissingKey(t *testing.T) {
+	kv := newTestKV(t)
+	_, err := kv.Get(context.Background(), "missing.json")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected ErrNotExist, got %v", err)
+	}
+}
+
+func TestFSKV_Put_RejectsInvalidKey(t *testing.T) {
+	kv := newTestKV(t)
+	ctx := context.Background()
+	cases := []string{"", "..", "/abs", "with\\bs", "sub/../esc"}
+	for _, k := range cases {
+		t.Run(k, func(t *testing.T) {
+			if err := kv.Put(ctx, k, []byte("x")); err == nil {
+				t.Fatalf("expected error for key %q", k)
 			}
 		})
 	}
 }
 
-func TestValidateKey_Rejects(t *testing.T) {
-	cases := []struct {
-		name string
-		want string
-	}{
-		{"", "empty"},
-		{"..", "traversal"},
-		{".", "traversal"},
-		{"/etc/passwd", "relative"},
-		{"a\\b.yaml", "backslash"},
-		{"../escape.yaml", "traversal"},
-		{"sub/../escape.yaml", "traversal"},
-		{"with\x00nul.yaml", "control character"},
-		{"with\x01ctrl.yaml", "control character"},
-		{"a//b.yaml", "empty segment"},
-		{"c:file.yaml", "drive letter"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := validateKey(tc.name)
-			if err == nil {
-				t.Fatalf("expected error for %q", tc.name)
-			}
-			if !strings.Contains(err.Error(), tc.want) {
-				t.Fatalf("error %q should mention %q", err.Error(), tc.want)
-			}
-		})
+func TestFSKV_Get_RejectsInvalidKey(t *testing.T) {
+	kv := newTestKV(t)
+	if _, err := kv.Get(context.Background(), ".."); err == nil {
+		t.Fatal("expected error for invalid key")
 	}
 }

--- a/internal/storage/rooted.go
+++ b/internal/storage/rooted.go
@@ -1,0 +1,232 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RootedFS is an FS bound to a validated root directory. Path-like
+// arguments to its methods are interpreted as KEYS relative to the
+// root. Every call runs keys through resolve(), which is the
+// string-level path-validation barrier.
+//
+// RootedFS deliberately does NOT implement storage.FS. Functions that
+// accept *RootedFS get a compile-time claim that keys have been
+// validated; functions that accept storage.FS see raw, caller-validated
+// paths. Raw FS usage is still available for internal storage
+// decorators (SafeFS, MemFS) and for the wiring layer that constructs
+// RootedFS.
+//
+// Getwd is intentionally omitted — it does not fit the keyed-access
+// model.
+//
+// # Security
+//
+// resolve() is a STRING-level validator: it rejects traversal in the
+// key (".."/absolute/backslash/control chars/drive letters/Windows
+// reserved names) before joining with the root. It does NOT resolve
+// symlinks. A symlink inside the root pointing outside the root is
+// still followed by the underlying OS; this is out of scope for this
+// type. The threat model is "caller-supplied key contains traversal
+// syntax", not "attacker has write access to the root directory".
+//
+// # Concurrency
+//
+// RootedFS is stateless after construction (root and fs are immutable)
+// and inherits the concurrency semantics of the underlying FS.
+type RootedFS struct {
+	fs   FS
+	root string
+}
+
+// NewRootedFS returns a RootedFS bound to root. root is cleaned and
+// made absolute; empty root or a nil fs is rejected.
+func NewRootedFS(fs FS, root string) (*RootedFS, error) {
+	if fs == nil {
+		return nil, errors.New("storage: RootedFS fs must not be nil")
+	}
+	if root == "" {
+		return nil, errors.New("storage: RootedFS root must not be empty")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("storage: resolve RootedFS root: %w", err)
+	}
+	return &RootedFS{fs: fs, root: filepath.Clean(abs)}, nil
+}
+
+// windowsReserved lists Windows reserved device names (case-insensitive,
+// matched against the stem before the first '.'). Rejecting these in
+// keys prevents portability surprises: a key that works on POSIX would
+// otherwise open a device handle on Windows.
+var windowsReserved = map[string]bool{
+	"con": true, "nul": true, "prn": true, "aux": true,
+	"com1": true, "com2": true, "com3": true, "com4": true, "com5": true,
+	"com6": true, "com7": true, "com8": true, "com9": true,
+	"lpt1": true, "lpt2": true, "lpt3": true, "lpt4": true, "lpt5": true,
+	"lpt6": true, "lpt7": true, "lpt8": true, "lpt9": true,
+}
+
+// resolve validates key and returns its absolute path. Rules:
+//   - reject empty
+//   - reject control characters (< 0x20 or 0x7f)
+//   - reject backslash (forward slash only)
+//   - reject colon (blocks drive letters and Windows ADS syntax)
+//   - reject absolute paths (leading '/')
+//   - reject empty, ".", or ".." segments
+//   - reject Windows reserved device names (CON, NUL, COM1–9, etc.)
+//
+// Valid keys produce filepath.Join(root, key).
+func (r *RootedFS) resolve(key string) (string, error) {
+	if key == "" {
+		return "", errors.New("storage: key must not be empty")
+	}
+	for _, c := range key {
+		if c < 0x20 || c == 0x7f {
+			return "", errors.New("storage: control character (including NUL) not allowed in key")
+		}
+	}
+	if strings.ContainsRune(key, '\\') {
+		return "", errors.New("storage: backslash not allowed in key (use forward slash)")
+	}
+	if strings.ContainsRune(key, ':') {
+		return "", errors.New("storage: colon not allowed in key (blocks Windows drive letters and ADS)")
+	}
+	if strings.HasPrefix(key, "/") {
+		return "", errors.New("storage: key must be relative")
+	}
+	for _, seg := range strings.Split(key, "/") {
+		if seg == "" || seg == "." || seg == ".." {
+			return "", errors.New("storage: traversal or empty segment not allowed in key")
+		}
+		stem := strings.ToLower(seg)
+		if i := strings.Index(stem, "."); i >= 0 {
+			stem = stem[:i]
+		}
+		if windowsReserved[stem] {
+			return "", fmt.Errorf("storage: Windows reserved name %q not allowed in key", seg)
+		}
+	}
+	return filepath.Join(r.root, key), nil
+}
+
+// ReadFile reads the file at key.
+func (r *RootedFS) ReadFile(key string) ([]byte, error) {
+	full, err := r.resolve(key)
+	if err != nil {
+		return nil, err
+	}
+	return r.fs.ReadFile(full)
+}
+
+// WriteFile writes data to key, creating parent directories if needed.
+// Matches SafeFS.WriteFile semantics: parent dirs are auto-created so
+// callers never need to MkdirAll before a write.
+func (r *RootedFS) WriteFile(key string, data []byte, perm os.FileMode) error {
+	full, err := r.resolve(key)
+	if err != nil {
+		return err
+	}
+	if err := r.fs.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		return err
+	}
+	return r.fs.WriteFile(full, data, perm)
+}
+
+// Remove removes the file or empty directory at key.
+func (r *RootedFS) Remove(key string) error {
+	full, err := r.resolve(key)
+	if err != nil {
+		return err
+	}
+	return r.fs.Remove(full)
+}
+
+// Rename renames oldKey to newKey. Both keys are validated.
+func (r *RootedFS) Rename(oldKey, newKey string) error {
+	oldFull, err := r.resolve(oldKey)
+	if err != nil {
+		return err
+	}
+	newFull, err := r.resolve(newKey)
+	if err != nil {
+		return err
+	}
+	return r.fs.Rename(oldFull, newFull)
+}
+
+// Stat returns file info for key.
+func (r *RootedFS) Stat(key string) (os.FileInfo, error) {
+	full, err := r.resolve(key)
+	if err != nil {
+		return nil, err
+	}
+	return r.fs.Stat(full)
+}
+
+// MkdirAll creates the directory at key and any missing parents.
+func (r *RootedFS) MkdirAll(key string, perm os.FileMode) error {
+	full, err := r.resolve(key)
+	if err != nil {
+		return err
+	}
+	return r.fs.MkdirAll(full, perm)
+}
+
+// ReadDir reads the directory entries at key.
+func (r *RootedFS) ReadDir(key string) ([]os.DirEntry, error) {
+	full, err := r.resolve(key)
+	if err != nil {
+		return nil, err
+	}
+	return r.fs.ReadDir(full)
+}
+
+// Open opens the file at key for reading.
+func (r *RootedFS) Open(key string) (io.ReadCloser, error) {
+	full, err := r.resolve(key)
+	if err != nil {
+		return nil, err
+	}
+	return r.fs.Open(full)
+}
+
+// Walk walks the subtree rooted at key. The callback receives keys
+// (root-relative forward-slash paths), never absolute paths.
+func (r *RootedFS) Walk(key string, fn fs.WalkDirFunc) error {
+	full, err := r.resolve(key)
+	if err != nil {
+		return err
+	}
+	return r.fs.Walk(full, r.relativize(fn))
+}
+
+// WalkAll walks the entire rooted tree.
+//
+// NOTE: the callback receives the root entry as ".", and every other
+// entry as a root-relative forward-slash key. "." is NOT a valid key
+// for any other RootedFS method — callers that want to read the root
+// entry do so via ReadDir("<first subkey>") or similar, not by feeding
+// "." back in.
+func (r *RootedFS) WalkAll(fn fs.WalkDirFunc) error {
+	return r.fs.Walk(r.root, r.relativize(fn))
+}
+
+// relativize wraps a WalkDirFunc so it receives root-relative
+// forward-slash keys instead of absolute paths. If filepath.Rel fails
+// (e.g. cross-volume symlinks on Windows), the error is propagated
+// rather than silently leaking an absolute path to the callback.
+func (r *RootedFS) relativize(fn fs.WalkDirFunc) fs.WalkDirFunc {
+	return func(path string, d fs.DirEntry, walkErr error) error {
+		rel, err := filepath.Rel(r.root, path)
+		if err != nil {
+			return fmt.Errorf("rooted: callback path %q not under root %q: %w", path, r.root, err)
+		}
+		return fn(filepath.ToSlash(rel), d, walkErr)
+	}
+}

--- a/internal/storage/rooted_test.go
+++ b/internal/storage/rooted_test.go
@@ -1,0 +1,422 @@
+package storage
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func newTestRooted(t *testing.T) *RootedFS {
+	t.Helper()
+	mem := NewMemFS()
+	rfs, err := NewRootedFS(mem, "/root")
+	if err != nil {
+		t.Fatalf("NewRootedFS: %v", err)
+	}
+	if err := mem.MkdirAll("/root", 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	return rfs
+}
+
+func TestNewRootedFS_RejectsEmptyRoot(t *testing.T) {
+	_, err := NewRootedFS(NewMemFS(), "")
+	if err == nil {
+		t.Fatal("expected error for empty root")
+	}
+}
+
+func TestNewRootedFS_RejectsNilFS(t *testing.T) {
+	_, err := NewRootedFS(nil, "/root")
+	if err == nil {
+		t.Fatal("expected error for nil fs")
+	}
+}
+
+func TestNewRootedFS_CleansRoot(t *testing.T) {
+	rfs, err := NewRootedFS(NewMemFS(), "/a/../b/./c")
+	if err != nil {
+		t.Fatalf("NewRootedFS: %v", err)
+	}
+	if rfs.root != "/b/c" {
+		t.Fatalf("root = %q, want /b/c", rfs.root)
+	}
+}
+
+func TestNewRootedFS_ResolvesRelativeRoot(t *testing.T) {
+	rfs, err := NewRootedFS(NewMemFS(), "rel/dir")
+	if err != nil {
+		t.Fatalf("NewRootedFS: %v", err)
+	}
+	if !filepath.IsAbs(rfs.root) {
+		t.Fatalf("root %q should be absolute", rfs.root)
+	}
+	if !strings.HasSuffix(rfs.root, "/rel/dir") {
+		t.Fatalf("root %q should end with /rel/dir", rfs.root)
+	}
+}
+
+func TestRootedFS_Resolve_Accepts(t *testing.T) {
+	rfs := newTestRooted(t)
+	keys := []string{
+		"cache.json",
+		"user-defaults.yaml",
+		"ui-state.json",
+		"palette.yaml",
+		"documents/render-abc123.html",
+		"a/b/c/d.txt",
+		"file.with.dots.txt",
+		"héllo.txt", // unicode
+	}
+	for _, k := range keys {
+		t.Run(k, func(t *testing.T) {
+			full, err := rfs.resolve(k)
+			if err != nil {
+				t.Fatalf("expected ok for %q, got %v", k, err)
+			}
+			want := filepath.Join(rfs.root, k)
+			if full != want {
+				t.Fatalf("resolve(%q) = %q, want %q", k, full, want)
+			}
+		})
+	}
+}
+
+func TestRootedFS_Resolve_Rejects(t *testing.T) {
+	rfs := newTestRooted(t)
+	cases := []struct {
+		key  string
+		want string
+	}{
+		{"", "empty"},
+		{"..", "traversal"},
+		{".", "traversal"},
+		{"/etc/passwd", "relative"},
+		{"a\\b.yaml", "backslash"},
+		{"../escape.yaml", "traversal"},
+		{"sub/../escape.yaml", "traversal"},
+		{"with\x00nul.yaml", "control character"},
+		{"with\x01ctrl.yaml", "control character"},
+		{"with\x7fdel.yaml", "control character"},
+		{"a//b.yaml", "empty segment"},
+		{"c:file.yaml", "colon"},
+		{"has:colon.yaml", "colon"},
+		{"CON.txt", "Windows reserved"},
+		{"sub/nul", "Windows reserved"},
+		{"com1", "Windows reserved"},
+		{"LpT9.log", "Windows reserved"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			_, err := rfs.resolve(tc.key)
+			if err == nil {
+				t.Fatalf("expected error for %q", tc.key)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q should mention %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestRootedFS_ResolvedPath_StaysInsideRoot(t *testing.T) {
+	rfs := newTestRooted(t)
+	// Any accepted key must resolve to a descendant of root.
+	keys := []string{"a", "a/b", "a/b/c/d.txt", "deep/nested/path/file.txt"}
+	for _, k := range keys {
+		full, err := rfs.resolve(k)
+		if err != nil {
+			t.Fatalf("resolve(%q): %v", k, err)
+		}
+		rel, err := filepath.Rel(rfs.root, full)
+		if err != nil {
+			t.Fatalf("rel: %v", err)
+		}
+		if strings.HasPrefix(rel, "..") {
+			t.Fatalf("resolved %q escaped root (rel=%q)", k, rel)
+		}
+	}
+}
+
+func TestRootedFS_WriteFile_ReadFile(t *testing.T) {
+	rfs := newTestRooted(t)
+	if err := rfs.WriteFile("a.txt", []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := rfs.ReadFile("a.txt")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("got %q, want %q", got, "hello")
+	}
+}
+
+func TestRootedFS_WriteFile_InvalidKey_DoesNotTouchFS(t *testing.T) {
+	spy := &callSpyFS{FS: NewMemFS()}
+	rfs, err := NewRootedFS(spy, "/root")
+	if err != nil {
+		t.Fatalf("NewRootedFS: %v", err)
+	}
+	if err := rfs.WriteFile("../escape", []byte("x"), 0o644); err == nil {
+		t.Fatal("expected error for invalid key")
+	}
+	if spy.writes != 0 {
+		t.Fatalf("underlying FS was called %d times; should be 0", spy.writes)
+	}
+}
+
+func TestRootedFS_ReadFile_InvalidKey(t *testing.T) {
+	rfs := newTestRooted(t)
+	if _, err := rfs.ReadFile(".."); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRootedFS_Remove(t *testing.T) {
+	rfs := newTestRooted(t)
+	if err := rfs.WriteFile("a.txt", []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := rfs.Remove("a.txt"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, err := rfs.ReadFile("a.txt"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected ErrNotExist after remove, got %v", err)
+	}
+}
+
+func TestRootedFS_Rename_BothArgsValidated(t *testing.T) {
+	rfs := newTestRooted(t)
+	if err := rfs.WriteFile("a.txt", []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := rfs.Rename("a.txt", "b.txt"); err != nil {
+		t.Fatalf("valid rename: %v", err)
+	}
+	got, err := rfs.ReadFile("b.txt")
+	if err != nil || string(got) != "x" {
+		t.Fatalf("after rename: got=%q err=%v", got, err)
+	}
+
+	if err := rfs.Rename("b.txt", "../escape"); err == nil {
+		t.Fatal("expected error for invalid newKey")
+	}
+	if err := rfs.Rename("../escape", "c.txt"); err == nil {
+		t.Fatal("expected error for invalid oldKey")
+	}
+}
+
+func TestRootedFS_MkdirAll_ReadDir(t *testing.T) {
+	rfs := newTestRooted(t)
+	if err := rfs.MkdirAll("a/b/c", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := rfs.WriteFile("a/b/c/f.txt", []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	entries, err := rfs.ReadDir("a/b")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	if len(names) != 1 || names[0] != "c" {
+		t.Fatalf("ReadDir entries = %v, want [c]", names)
+	}
+}
+
+func TestRootedFS_Stat(t *testing.T) {
+	rfs := newTestRooted(t)
+	if err := rfs.WriteFile("a.txt", []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	info, err := rfs.Stat("a.txt")
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Size() != 5 {
+		t.Fatalf("size = %d, want 5", info.Size())
+	}
+}
+
+func TestRootedFS_Open(t *testing.T) {
+	rfs := newTestRooted(t)
+	if err := rfs.WriteFile("a.txt", []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	rc, err := rfs.Open("a.txt")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer rc.Close()
+	buf := make([]byte, 5)
+	n, err := rc.Read(buf)
+	if err != nil || n != 5 || string(buf) != "hello" {
+		t.Fatalf("read: n=%d err=%v buf=%q", n, err, buf)
+	}
+}
+
+func TestRootedFS_Walk_ReturnsKeys(t *testing.T) {
+	rfs := newTestRooted(t)
+	if err := rfs.MkdirAll("sub/nested", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	for _, p := range []string{"sub/a.txt", "sub/b.txt", "sub/nested/c.txt"} {
+		if err := rfs.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatalf("WriteFile %s: %v", p, err)
+		}
+	}
+	var seen []string
+	if err := rfs.Walk("sub", func(path string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		seen = append(seen, path)
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	sort.Strings(seen)
+	want := []string{"sub", "sub/a.txt", "sub/b.txt", "sub/nested", "sub/nested/c.txt"}
+	if !stringSliceEqual(seen, want) {
+		t.Fatalf("seen = %v, want %v", seen, want)
+	}
+	for _, p := range seen {
+		if filepath.IsAbs(p) {
+			t.Fatalf("callback received absolute path %q; expected key", p)
+		}
+	}
+}
+
+func TestRootedFS_WalkAll_FromRoot(t *testing.T) {
+	rfs := newTestRooted(t)
+	if err := rfs.MkdirAll("sub", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	for _, p := range []string{"a.txt", "sub/b.txt"} {
+		if err := rfs.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatalf("WriteFile %s: %v", p, err)
+		}
+	}
+	var seen []string
+	if err := rfs.WalkAll(func(path string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		seen = append(seen, path)
+		return nil
+	}); err != nil {
+		t.Fatalf("WalkAll: %v", err)
+	}
+	sort.Strings(seen)
+	want := []string{".", "a.txt", "sub", "sub/b.txt"}
+	if !stringSliceEqual(seen, want) {
+		t.Fatalf("seen = %v, want %v", seen, want)
+	}
+}
+
+func TestRootedFS_Walk_InvalidKey(t *testing.T) {
+	rfs := newTestRooted(t)
+	err := rfs.Walk("..", func(_ string, _ fs.DirEntry, _ error) error { return nil })
+	if err == nil {
+		t.Fatal("expected error for invalid walk key")
+	}
+}
+
+// callSpyFS wraps an FS and counts calls to WriteFile, used to assert
+// that invalid keys short-circuit before touching the underlying FS.
+type callSpyFS struct {
+	FS
+	writes int
+}
+
+func (s *callSpyFS) WriteFile(path string, data []byte, perm os.FileMode) error {
+	s.writes++
+	return s.FS.WriteFile(path, data, perm)
+}
+
+func TestRootedFS_WriteFile_CreatesParentDirs(t *testing.T) {
+	rfs := newTestRooted(t)
+	// No explicit MkdirAll — WriteFile should create parents itself.
+	if err := rfs.WriteFile("deep/nested/path/file.txt", []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := rfs.ReadFile("deep/nested/path/file.txt")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "x" {
+		t.Fatalf("got %q, want %q", got, "x")
+	}
+}
+
+// FuzzResolve checks two invariants for any key that resolve() accepts:
+//  1. The resolved path is under the root (filepath.Rel has no ".." prefix).
+//  2. The resolved path begins with root + separator (or equals root).
+//
+// This is the security-critical property: no key should ever resolve
+// outside the rooted subtree, regardless of what bytes the caller sends.
+func FuzzResolve(f *testing.F) {
+	seeds := []string{
+		"a.txt",
+		"sub/b.txt",
+		"",
+		"..",
+		".",
+		"/abs",
+		"a\\b",
+		"with\x00",
+		"c:file",
+		"CON",
+		"sub/../esc",
+		"a//b",
+		"héllo",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	rfs, err := NewRootedFS(NewMemFS(), "/root")
+	if err != nil {
+		f.Fatalf("NewRootedFS: %v", err)
+	}
+	f.Fuzz(func(t *testing.T, key string) {
+		full, err := rfs.resolve(key)
+		if err != nil {
+			return // rejection is fine — we only assert on acceptances
+		}
+		rel, relErr := filepath.Rel(rfs.root, full)
+		if relErr != nil {
+			t.Fatalf("filepath.Rel(%q, %q): %v", rfs.root, full, relErr)
+		}
+		// rel must not be ".." and must not step up out of root.
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			t.Fatalf("resolved %q escapes root: rel=%q full=%q", key, rel, full)
+		}
+		// full must be root itself or a path inside root.
+		sep := string(filepath.Separator)
+		if full != rfs.root && !strings.HasPrefix(full, rfs.root+sep) {
+			t.Fatalf("resolved %q not prefixed by root: full=%q root=%q", key, full, rfs.root)
+		}
+	})
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -528,12 +528,19 @@ func (w *Workspace) Config() config.Loader {
 }
 
 // State returns the per-user state KV (UI state, render caches, scheduler state).
-// Returns a no-op KV when the workspace has no filesystem configured.
+// Returns a no-op KV when the workspace has no filesystem or cache directory
+// configured. A non-empty CacheDir with an invalid value panics — this
+// indicates programmer error (the CacheDir was populated but malformed),
+// which should fail loud rather than silently degrade to nopState.
 func (w *Workspace) State() state.KV {
-	if w.fs == nil || w.paths == nil {
+	if w.fs == nil || w.paths == nil || w.paths.CacheDir == "" {
 		return nopState{}
 	}
-	return state.NewFSKV(w.fs, w.paths.CacheDir)
+	rfs, err := storage.NewRootedFS(w.fs, w.paths.CacheDir)
+	if err != nil {
+		panic(fmt.Errorf("workspace: invalid state root %q: %w", w.paths.CacheDir, err))
+	}
+	return state.NewFSKV(rfs)
 }
 
 type nopConfig struct{}

--- a/tickets/entities/features/FEAT-ZPGGK.md
+++ b/tickets/entities/features/FEAT-ZPGGK.md
@@ -1,0 +1,9 @@
+---
+id: FEAT-ZPGGK
+type: feature
+title: Path-validation boundary via RootedFS and arch lint
+summary: Introduce RootedFS as the single path-validation barrier above storage.FS, migrate callers, and enforce via arch lint
+description: 'Introduce a storage.RootedFS concrete type that binds a validated root directory to an underlying storage.FS. A single resolve(key) method is the path-validation barrier, visible to CodeQL and enforced via arch lint. Delivered as 4 subtickets: (1) introduce RootedFS + pilot on state.FSKV, (2) migrate fsstore write paths (closes CodeQL path-injection alerts), (3) arch lint rules banning raw os.* I/O in high-level components, (4) package split storage/raw + storage/rooted so arch lint can enforce the dependency at import level.'
+priority: medium
+status: proposed
+---

--- a/tickets/entities/implementation-checklists/IMPL-CC503.md
+++ b/tickets/entities/implementation-checklists/IMPL-CC503.md
@@ -1,0 +1,48 @@
+---
+id: IMPL-CC503
+type: implementation-checklist
+title: 'Implementation: Introduce RootedFS type and pilot on state.FSKV'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code — `internal/storage/rooted_test.go` (18 tests covering constructor, resolve, all method shapes, Walk/WalkAll, invalid-key short-circuit via spy)
+- [x] Integration tests written (test full flow, not just units) — `internal/state/state_test.go` exercises FSKV through MemFS end-to-end
+- [x] Happy path implemented — `internal/storage/rooted.go`; `state/state.go` migrated
+- [x] Edge cases from planning handled — all 12 rejection cases from validateKey copied to resolve; WalkAll separate from Walk (no magic-string asymmetry)
+- [x] Error handling in place (errors surfaced, not swallowed) — every resolve error is returned to caller; underlying FS errors pass through unchanged
+
+## Test Quality
+
+- [x] ~~Using fixture builders or factories for test data~~ (N/A: tests exercise filesystem primitives — MemFS construction is the fixture. `newTestRooted(t)` is the local helper.)
+- [x] No hardcoded values in assertions when object is in scope — `TestRootedFS_Resolve_Accepts` uses `rfs.Root()` instead of hardcoded `/root`
+- [x] Only specifying values that matter for the test — key strings are the subject of the tests; other state (perms, content) uses simple placeholders
+- [x] Interpolated values constructed from objects, not hardcoded — see `filepath.Join(rfs.Root(), k)` pattern
+- [x] Property comparisons use original object, not hardcoded strings — rename round-trip reads back the written value, not a hardcoded literal
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end — unit + integration tests cover the full stack (RootedFS → MemFS; FSKV → RootedFS → MemFS)
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified — all validation rejection cases have explicit tests
+
+**Verification Evidence:**
+
+All ACs verified by passing tests:
+
+- **AC1** (`RootedFS` exists, constructor cleans/absolutizes root, rejects empty): `TestNewRootedFS_RejectsEmptyRoot`, `TestNewRootedFS_CleansRoot`, `TestNewRootedFS_ResolvesRelativeRoot` — all PASS.
+- **AC2** (`resolve` accepts/rejects correct keys): `TestRootedFS_Resolve_Accepts` (8 cases) + `TestRootedFS_Resolve_Rejects` (12 cases) — all PASS.
+- **AC3** (all method shapes delegate correctly): `TestRootedFS_WriteFile_ReadFile`, `TestRootedFS_Remove`, `TestRootedFS_Rename_BothArgsValidated`, `TestRootedFS_MkdirAll_ReadDir`, `TestRootedFS_Stat`, `TestRootedFS_Open`, `TestRootedFS_WriteFile_InvalidKey_DoesNotTouchFS` (spy confirms short-circuit) — all PASS.
+- **AC4** (Walk/WalkAll callback receives keys, not abs paths): `TestRootedFS_Walk_ReturnsKeys`, `TestRootedFS_WalkAll_FromRoot` — all PASS. Callback-path assertion checks `filepath.IsAbs` is false for every seen path.
+- **AC5** (state.FSKV uses RootedFS; validateKey removed): diff of `internal/state/state.go` shows validateKey gone, replaced with single `*RootedFS` field; all 5 state tests PASS. Call sites in `workspace.go`, `dataentry/app.go`, 2 test files migrated.
+- **AC6** (`just ci` green): `just lint` → 0 issues; `just test` → all packages PASS; `just coverage-check` → PASS (72.5% total, state=100%, storage=86.3%); `just build` → PASS. Arch-lint local run unchanged from develop baseline (2 pre-existing `.ignored/` notices, not a regression).
+
+## Quality
+
+- [x] Code follows project patterns (check similar code) — matches `state.validateKey`'s rule set verbatim; constructor pattern mirrors `NewMemFS`/`NewSafeFS`; `Root()` accessor follows the `FS.Getwd` precedent
+- [x] No security issues introduced — `resolve` is the single path-validation barrier. Rules match the existing `state.validateKey`. Walk callback remapping prevents leaking backing FS paths
+- [x] No silent failures (errors logged AND returned) — every error path returns to caller
+- [x] No debug code left behind — reviewed diff; no print/log statements added

--- a/tickets/entities/planning-checklists/PLAN-7C7ZZ.md
+++ b/tickets/entities/planning-checklists/PLAN-7C7ZZ.md
@@ -1,0 +1,60 @@
+---
+id: PLAN-7C7ZZ
+type: planning-checklist
+title: 'Planning: Introduce RootedFS and enforce path-validation boundary via arch lint'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+**Superseded:** TKT-92ID1 was split into FEAT-ZPGGK + 4 subtickets (TKT-0M8PM, TKT-3TA1H, TKT-K3YYE, TKT-REC7P) during initial planning, because investigation revealed the scope was `xl`, not `m`. Planning for the individual subtickets happens on their own checklists.
+
+## Understanding
+
+- [x] ~~Problem/requirements clearly understood~~ (N/A: superseded by FEAT-ZPGGK + subticket split)
+- [x] ~~Scope defined (what's in/out documented below)~~ (N/A: superseded)
+- [x] ~~Acceptance criteria documented with specific test scenarios~~ (N/A: superseded)
+
+## Research
+
+- [x] ~~Searched for existing libraries that solve this problem~~ (N/A: superseded)
+- [x] ~~Checked codebase for similar patterns or reusable code~~ (N/A: superseded)
+- [x] ~~Looked for reference implementations in other projects~~ (N/A: superseded)
+- [x] ~~Reviewed relevant rela concepts for prior art~~ (N/A: superseded)
+
+## Approach
+
+- [x] ~~Technical approach chosen and documented~~ (N/A: superseded)
+- [x] ~~Approach builds on existing patterns (not reinventing)~~ (N/A: superseded)
+- [x] ~~Alternatives considered (document why rejected)~~ (N/A: superseded)
+- [x] ~~Dependencies identified (packages, APIs, types)~~ (N/A: superseded)
+
+## Security Considerations
+
+- [x] ~~Input sources identified~~ (N/A: superseded)
+- [x] ~~Input validation approach defined~~ (N/A: superseded)
+- [x] ~~Security-sensitive operations identified~~ (N/A: superseded)
+- [x] ~~Error handling doesn't leak sensitive information~~ (N/A: superseded)
+
+## Test Plan
+
+- [x] ~~Test scenarios documented for each acceptance criterion~~ (N/A: superseded)
+- [x] ~~Edge cases identified and documented~~ (N/A: superseded)
+- [x] ~~Negative test cases defined~~ (N/A: superseded)
+- [x] ~~Integration test approach defined~~ (N/A: superseded)
+
+## Risk Assessment
+
+- [x] ~~Technical risks assessed with mitigations~~ (N/A: superseded)
+- [x] ~~Security risks assessed~~ (N/A: superseded)
+- [x] ~~Effort estimated (xs/s/m/l/xl)~~ (N/A: superseded — original effort estimate `m` was wrong; re-estimated as 4 subtickets)
+
+## Documentation Planning
+
+- [x] ~~User-facing docs identified~~ (N/A: superseded)
+- [x] ~~Docs-checklist will be created when entering implementation~~ (N/A: superseded)
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: superseded)
+- [x] ~~All critical/significant findings addressed in plan~~ (N/A: superseded)

--- a/tickets/entities/planning-checklists/PLAN-Z49OF.md
+++ b/tickets/entities/planning-checklists/PLAN-Z49OF.md
@@ -1,0 +1,306 @@
+---
+id: PLAN-Z49OF
+type: planning-checklist
+title: 'Planning: Introduce RootedFS type and pilot on state.FSKV'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope (in):**
+
+- New concrete type `storage.RootedFS` that wraps any `storage.FS` and binds it to a validated root directory.
+- `RootedFS` exposes the same method shapes as `storage.FS` (except `Getwd`), but interprets the `path`-like argument as a *key* relative to the root.
+- Single `resolve(key) (string, error)` method is the path-validation barrier (matches the current `state.validateKey` rule set).
+- Migration of `state.FSKV` to use `*RootedFS` internally.
+- Full unit test coverage on `RootedFS`.
+
+**Scope (out):**
+
+- `fsstore` migration (TKT-3TA1H).
+- Arch lint enforcement (TKT-K3YYE).
+- Package split into `storage/raw` + `storage/rooted` (TKT-REC7P).
+- `Getwd()` — doesn't fit the keyed-access model. `RootedFS` intentionally does not expose it.
+- Changing `storage.FS` interface or semantics.
+
+**Acceptance Criteria:**
+
+1. **AC1**: `storage.RootedFS` exists with constructor `NewRootedFS(fs FS, root string) (*RootedFS, error)`. Constructor cleans/absolutizes `root` and returns error on empty root.
+   - *Test*: `TestNewRootedFS_CleansRoot`, `TestNewRootedFS_RejectsEmptyRoot`.
+2. **AC2**: `resolve(key)` rejects empty, absolute, backslash-containing, control-char-containing, `..`-segment, empty-segment, drive-letter keys. Accepts nested keys like `a/b.json`. Returns `filepath.Join(root, key)` for valid keys.
+   - *Test*: `TestRootedFS_Resolve_Accepts`, `TestRootedFS_Resolve_Rejects` (table-driven, mirrors existing `TestValidateKey_*` coverage).
+3. **AC3**: All FS method shapes supported by `RootedFS` (ReadFile, WriteFile, Remove, Rename, Stat, MkdirAll, ReadDir, Walk, Open) delegate to the underlying FS with the resolved path. Rename validates both args. `Walk(key, fn)` walks a subtree; separate `WalkAll(fn)` walks from the root.
+   - *Test*: `TestRootedFS_WriteFileDelegates`, `TestRootedFS_ReadFileDelegates`, `TestRootedFS_Rename_ValidatesBothKeys`, `TestRootedFS_WalkAll_FromRoot`, etc.
+4. **AC4**: `RootedFS.Walk` and `RootedFS.WalkAll` call the user's `fs.WalkDirFunc` with a *key* (root-relative path), not the absolute resolved path. Ensures callers don't accidentally see or use the raw backing path.
+   - *Test*: `TestRootedFS_Walk_ReturnsKeys`, `TestRootedFS_WalkAll_ReturnsKeys`.
+5. **AC5**: `state.FSKV` uses `*RootedFS` internally. `validateKey` and the explicit `filepath.Join` in `state.go` are gone.
+   - *Test*: Existing `TestValidateKey_*` tests move to `storage/rooted_test.go` (renamed `TestRootedFS_Resolve_*`). State tests pass unchanged.
+6. **AC6**: `just ci` is green.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+- `io/fs.Sub` (stdlib): provides a rooted sub-filesystem above `fs.FS`, but `fs.FS` is read-only and rela's `storage.FS` is read+write+rename+mkdir. Not a fit, but same design pattern.
+- `cdproto/securefs` and similar — specific to Chrome DevTools, not applicable.
+- Existing in-codebase pattern: `state.validateKey` (`internal/state/state.go:67-91`) already implements the exact validation rule set we want. This ticket's `resolve` lifts it verbatim.
+- `fsstore` uses entity/relation ID sanitization upstream (in `storeutil.ValidateID`) before constructing paths — different layer, not a validator we can share.
+- Prior related work: TKT-020 (graph → storage dep removed), TKT-031 (CLI storage dep removed), FEAT-022 (arch lint boundary enforcement). These set the pattern for "make architectural contracts explicit and enforce via lint." RootedFS extends that pattern to path safety.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Create `internal/storage/rooted.go`:
+
+```go
+package storage
+
+import (
+    "errors"
+    "io"
+    "io/fs"
+    "os"
+    "path/filepath"
+    "strings"
+)
+
+// RootedFS is an FS bound to a validated root directory. Path-like
+// arguments to its methods are interpreted as KEYS relative to the
+// root. Every call runs keys through resolve(), which is the single
+// path-validation barrier.
+//
+// RootedFS deliberately does NOT implement storage.FS: callers that
+// accept *RootedFS get a compile-time claim that paths have been
+// validated. Callers that accept storage.FS continue to see raw,
+// caller-validated paths.
+//
+// Getwd is omitted — it does not fit the keyed-access model.
+type RootedFS struct {
+    fs   FS
+    root string
+}
+
+func NewRootedFS(fs FS, root string) (*RootedFS, error) {
+    if root == "" {
+        return nil, errors.New("storage: RootedFS root must not be empty")
+    }
+    abs, err := filepath.Abs(root)
+    if err != nil {
+        return nil, err
+    }
+    return &RootedFS{fs: fs, root: filepath.Clean(abs)}, nil
+}
+
+// resolve validates a key and joins it with the root. Rules mirror
+// state.validateKey exactly.
+func (r *RootedFS) resolve(key string) (string, error) { /* ... */ }
+
+// Root returns the absolute, cleaned root directory. Used by tests
+// and by the few wiring sites that need the physical location.
+func (r *RootedFS) Root() string { return r.root }
+
+// ReadFile, WriteFile, Remove, Rename, Stat, MkdirAll, ReadDir,
+// Walk, Open — same shape as FS, but take keys.
+//
+// Walk(key, fn) walks a subtree; WalkAll(fn) walks the whole rooted
+// tree (no key argument). Both rewrite the callback's path argument
+// from absolute → key before invoking the user's fs.WalkDirFunc, so
+// callers never see the backing filesystem location.
+```
+
+**Validation rules in `resolve` (copied from `state.validateKey`):**
+
+| Reject | Reason |
+|---|---|
+| `""` | empty |
+| any `r < 0x20 \|\| r == 0x7f` | control character |
+| contains `\\` | backslash |
+| starts with `/` | absolute |
+| any segment is `""`, `.`, or `..` | traversal/empty |
+| `len(name) >= 2 && name[1] == ':'` | Windows drive letter |
+
+Accept: single-segment keys, nested keys with `/` separators.
+
+**Walk callback remapping:**
+
+```go
+func (r *RootedFS) Walk(key string, fn fs.WalkDirFunc) error {
+    full, err := r.resolve(key)
+    if err != nil { return err }
+    return r.fs.Walk(full, func(path string, d fs.DirEntry, err error) error {
+        rel, relErr := filepath.Rel(r.root, path)
+        if relErr != nil { rel = path } // defensive
+        return fn(filepath.ToSlash(rel), d, err)
+    })
+}
+```
+
+**Files to modify:**
+
+- `internal/storage/rooted.go` (new)
+- `internal/storage/rooted_test.go` (new)
+- `internal/state/state.go` — replace `storage.FS + root + validateKey` with `*storage.RootedFS`
+- `internal/state/state_test.go` — remove `TestValidateKey_*` (covered by `rooted_test.go`); keep FSKV integration tests.
+
+**Wiring for `state.FSKV`:**
+
+Before:
+```go
+func NewFSKV(fs storage.FS, dir string) *FSKV
+```
+
+After:
+```go
+func NewFSKV(rfs *storage.RootedFS) *FSKV
+```
+
+Callers of `NewFSKV` need updating. Let me audit call sites during
+implementation.
+
+**Alternatives considered:**
+
+1. **`SafePath` type instead of `RootedFS` facade.** Rejected: requires changing every `FS` method signature; ripples through MemFS, OsFS, SafeFS, and every decorator. Higher blast radius, weaker containment.
+2. **Add `resolve` as a free function in `storage`.** Rejected: doesn't bind a root, so every caller still writes `resolve(key); s.fs.WriteFile(filepath.Join(root, resolved)...)`. No centralization win.
+3. **Extend `storage.FS` with a root-aware variant method.** Rejected: bloats the interface; doesn't solve the "which root?" question; can't be enforced via arch lint without a package split anyway.
+
+**Dependencies:**
+
+- Uses only `io`, `io/fs`, `os`, `path/filepath`, `errors`, `strings` from stdlib.
+- Depends on `storage.FS` (same package, already exists).
+- No new vendor deps.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+| Source | Input | Validation |
+|---|---|---|
+| `state.FSKV` callers | key string (e.g., `"cache.json"`, `"documents/render-abc.html"`) | `resolve()` — reject empty, `..`, absolute, backslash, control chars, drive letters |
+| `NewRootedFS` caller | root string (from wiring layer, not user input) | `filepath.Abs` + `filepath.Clean`; reject empty |
+
+**Security-Sensitive Operations:**
+
+- **File I/O at the root**: every write/read ends up calling the underlying `storage.FS` (which in prod is `SafeFS(OsFS)`) with a resolved absolute path. The resolved path is structurally inside the root by construction (join of cleaned root + validated key with no `..`).
+- **Error messages**: errors from `resolve` describe the rule violated (empty, traversal, etc.) but do not echo the key's contents — consistent with `state.validateKey` today.
+- **Walk path remapping**: the callback receives keys, never absolute paths. Prevents accidentally leaking the backing filesystem location to callers (e.g., into error messages surfaced to the user).
+
+**Is this actually rooted?** The combination of (a) root being
+`filepath.Clean(filepath.Abs(root))`, (b) key rejecting absolute paths,
+backslashes, `..`, empty segments, and (c) `filepath.Join(root, key)` means the
+joined result is always a descendant of root. `filepath.Clean` in `Join` would
+normalize any remaining `.` segments; since `..` is already rejected, no escape
+is possible on POSIX or Windows. Test coverage will include an explicit
+`TestRootedFS_ResolvedPath_StaysInsideRoot` case.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios (AC → tests):**
+
+- **AC1**: `TestNewRootedFS_CleansRoot`, `TestNewRootedFS_RejectsEmptyRoot`, `TestNewRootedFS_ResolvesRelativeRoot`.
+- **AC2**: `TestRootedFS_Resolve_Accepts` (table: valid single-segment, valid nested, valid dot-in-filename). `TestRootedFS_Resolve_Rejects` (table: empty, `..`, `.`, `/abs`, `a\b`, `../esc`, `sub/../esc`, NUL, `\x01`, `a//b`, `c:file`).
+- **AC3**: For each of ReadFile, WriteFile, Remove, Rename, Stat, MkdirAll, ReadDir, Open — test with `MemFS` as underlying; verify (a) valid key delegates correctly, (b) invalid key returns error without touching underlying FS. Use a spy wrapping MemFS to assert non-call on invalid keys.
+- **AC4**: `TestRootedFS_Walk_ReturnsKeys` — populate MemFS with `/root/a.txt`, `/root/sub/b.txt`, walk from `"."`, assert callback receives `"a.txt"`, `"sub"`, `"sub/b.txt"` (not absolute paths).
+- **AC5**: `TestFSKV_Put_Get_RoundTrip`, `TestFSKV_Put_RejectsInvalidKey` (moved/rewritten).
+- **AC6**: CI gate.
+
+**Edge Cases:**
+
+- Empty key → rejected.
+- Single `.` → rejected (matches current validator).
+- Key with embedded `/./` → rejected (empty segment after split on `/`)? Actually `strings.Split("a/./b", "/")` gives `[a, ., b]`, and `.` is rejected. Good.
+- Unicode in key → allowed (no control chars, no separators). Document as accepted.
+- Very long key → no explicit length cap; let underlying FS return the OS error.
+- Concurrent calls → `RootedFS` is stateless after construction (root + fs are immutable), so inherently concurrency-safe. Inherits the underlying FS's concurrency semantics.
+- Rename where source is valid but destination is invalid → return error without touching FS.
+
+**Negative Tests:**
+
+Each invalid input from the rejection table above gets its own test case. Tests
+assert:
+1. Method returns a non-nil error.
+2. Error message mentions the specific rule violated.
+3. Underlying FS is NOT called (via spy).
+
+**Integration approach:**
+
+- Unit tests use `MemFS` as the underlying FS for speed and determinism.
+- `state.FSKV` integration tests (existing) continue to work with the migrated API and exercise the full stack.
+- No separate end-to-end test needed for this ticket — it's a refactor of a validated path that already has coverage.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `filepath.Rel` in `Walk` callback fails on unusual paths (symlinks, mount boundaries) | Low | Low | Defensive fallback to absolute path; test with symlinks in a follow-up if issue observed. Current callers use in-memory or known-local paths. |
+| `NewFSKV` API change breaks callers | Certain | Low | Audit during implementation; there's only a handful of call sites. Update all at once in same PR. |
+| `state.FSKV` Reader tests assume specific error shapes (`os.IsNotExist`) | Medium | Low | Keep error wrapping consistent — `RootedFS` methods return the underlying FS error verbatim on valid keys. Only validation errors are new. |
+| Subtle semantic change: `validateKey` was called BEFORE `filepath.Join`; `resolve` does both. Any caller that constructed paths outside `FSKV` won't be migrated yet. | Low | Low | This ticket doesn't migrate fsstore or other callers; they stay on `storage.FS`. No behavior change for them. |
+| "Walk the whole tree" — how to express without a magic-string key? | Medium | Low | Add a dedicated `WalkAll(fn)` method for walking from root. `Walk(key, fn)` rejects `""` and `.` like every other method. No asymmetry. |
+
+**Walk-root decision:** `Walk(key, fn)` validates `key` with the same rules as
+every other method (rejects `""`, `.`, `..`). A separate `WalkAll(fn
+fs.WalkDirFunc)` method walks from the root — no key argument. Callers that want
+"walk everything" say `rfs.WalkAll(fn)`; callers that want a subtree say
+`rfs.Walk("sub", fn)`. Naming the intent at call sites is clearer than
+overloading `Walk` with a magic empty string.
+
+**Effort estimate: `s`.** New file ~150 LOC + ~250 LOC of tests. `state.FSKV`
+migration is ~20 LOC of diff. No cross-package changes except `state`.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] N/A - Internal change, no user-facing docs needed
+
+- [ ] User guide / reference docs — N/A (internal type)
+- [ ] CLI help text — N/A (no CLI changes)
+- [ ] CLAUDE.md — will update in a follow-up ticket once the pattern is established across more callers. For a single-caller pilot, premature.
+- [x] ~~README.md~~ (N/A: internal type, no project-level change)
+- [x] ~~API docs~~ (N/A: no public HTTP/CLI API surface)
+
+Package-level doc comment in `internal/storage/rooted.go` will explain the
+pattern.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: design was iterated interactively with the user across 11 conversation turns before planning — the facade-vs-type design, Walk/WalkAll split, and arch-lint strategy were all settled in that dialogue. Formal `/design-review` would have re-litigated agreed decisions.)
+- [x] ~~All critical/significant findings addressed in plan~~ (N/A: see above. The post-implementation `/code-review` surfaced 6 significant findings (missed in the interactive design dialogue) which have all been addressed — see REV-I4AEM.)
+
+**Design Review Findings:** Addressed via post-implementation `/code-review` instead. 15 review-responses linked to TKT-0M8PM. All significant findings status=addressed.

--- a/tickets/entities/planning-checklists/PLAN-Z49OF.md
+++ b/tickets/entities/planning-checklists/PLAN-Z49OF.md
@@ -289,9 +289,9 @@ migration is ~20 LOC of diff. No cross-package changes except `state`.
 
 - [x] N/A - Internal change, no user-facing docs needed
 
-- [ ] User guide / reference docs — N/A (internal type)
-- [ ] CLI help text — N/A (no CLI changes)
-- [ ] CLAUDE.md — will update in a follow-up ticket once the pattern is established across more callers. For a single-caller pilot, premature.
+- [x] ~~User guide / reference docs~~ (N/A: internal type)
+- [x] ~~CLI help text~~ (N/A: no CLI changes)
+- [x] ~~CLAUDE.md~~ (N/A: will update in a follow-up ticket once the pattern is established across more callers; premature for a single-caller pilot)
 - [x] ~~README.md~~ (N/A: internal type, no project-level change)
 - [x] ~~API docs~~ (N/A: no public HTTP/CLI API surface)
 

--- a/tickets/entities/review-checklists/REV-I4AEM.md
+++ b/tickets/entities/review-checklists/REV-I4AEM.md
@@ -1,0 +1,68 @@
+---
+id: REV-I4AEM
+type: review-checklist
+title: 'Review: Introduce RootedFS type and pilot on state.FSKV'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — all packages green, state=100%, storage=86.3%
+- [x] Lint clean (`just lint`) — 0 issues
+- [x] Coverage maintained (`just coverage-check`) — 72.6% total, floor thresholds satisfied
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] ~~All critical review-responses addressed~~ (N/A: no critical findings)
+- [x] All significant review-responses addressed — 6 significant findings, all status=addressed
+- [x] Self-reviewed the diff for unrelated changes — diff is tight, only `rooted.go` (new), `rooted_test.go` (new), `state.go/_test.go` (rewrite), and three call-site migrations (workspace.go, dataentry/app.go, two test helpers)
+
+**Review Responses:** 15 review-responses created from cranky-code-reviewer
+findings.
+
+- **Significant (6, all addressed)**: RR-MGASV (doc overstates invariant), RR-WD0NA (relativize swallowed errors), RR-HQDEL (silent nopState on error), RR-AF1CU (Windows backslash bug), RR-0GM44 (lazy root creation), RR-E80D4 (nil fs accepted).
+- **Minor (7)**: RR-LF2JF (Windows reserved names, addressed), RR-16FM9 (Root() escape hatch removed), RR-1GJVI (fuzz test added), RR-3ON0U (fallback removed, resolves it), RR-HMU95 (config.validateName drift, deferred to TKT-K3YYE), RR-OOX3Y (Walk order, wont-fix — not part of contract).
+- **Nits (3)**: RR-1VEUZ (WalkAll '.' doc, addressed), RR-E3IJ3 (error style, wont-fix), RR-KXIBR (4-pass resolve, wont-fix — premature optimization).
+
+All critical + significant resolved. Remaining 3 wont-fix/deferred are justified
+with reasons.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- **AC1** (RootedFS exists, cleans/absolutizes root, rejects empty): PASS — `TestNewRootedFS_CleansRoot`, `TestNewRootedFS_RejectsEmptyRoot`, `TestNewRootedFS_RejectsNilFS` (added during review), `TestNewRootedFS_ResolvesRelativeRoot`.
+- **AC2** (resolve accepts/rejects): PASS — 8 accept cases + 15 reject cases (up from 11 pre-review, now includes colon-anywhere and 4 Windows reserved names).
+- **AC3** (method shapes delegate): PASS — tests for WriteFile/ReadFile/Remove/Rename/MkdirAll/ReadDir/Stat/Open/Walk/WalkAll. `TestRootedFS_WriteFile_CreatesParentDirs` (added) verifies the auto-mkdir behavior.
+- **AC4** (Walk/WalkAll callback receives keys): PASS — `TestRootedFS_Walk_ReturnsKeys`, `TestRootedFS_WalkAll_FromRoot`, plus `filepath.IsAbs` assertion on every seen path.
+- **AC5** (state.FSKV uses RootedFS, validateKey gone): PASS — diff shows validateKey removed; FSKV.Put now a one-liner; 3 production call sites + 2 test call sites migrated.
+- **AC6** (just ci green): PASS — lint 0 issues, tests pass, coverage 72.6%, build clean. Arch-lint local run: 2 pre-existing `.ignored/` notices unchanged from develop (not a regression). Fuzz: 2.9M executions in 10s, no escapes.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via has-docs~~ (N/A: internal refactor, no user-facing docs)
+- [x] ~~User-facing documentation updated~~ (N/A)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+Package-level doc comment in `internal/storage/rooted.go` documents the pattern
+for future internal contributors.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed — grep `rooted.go` confirms zero
+- [x] Ready for another developer to use — public API is `NewRootedFS(fs, root)` + the keyed methods; package doc explains the invariants
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** *(pending)*

--- a/tickets/entities/review-checklists/REV-I4AEM.md
+++ b/tickets/entities/review-checklists/REV-I4AEM.md
@@ -61,8 +61,8 @@ for future internal contributors.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass — all code checks green (Test/E2E/Frontend/Fuzz/Lint/Build/Architecture/Docs/Demos/Vulnerability), ticket-validation check will go green on transition-to-done
+- [x] PR URL documented below
 
-**PR:** *(pending)*
+**PR:** https://github.com/sourcehaven-bv/rela/pull/552

--- a/tickets/entities/review-responses/RR-0GM44.md
+++ b/tickets/entities/review-responses/RR-0GM44.md
@@ -1,0 +1,9 @@
+---
+id: RR-0GM44
+type: review-response
+title: FSKV.Put removed lazy .rela/ creation safety net
+finding: Old Put did MkdirAll(Dir(full)) unconditionally, which also created the root directory itself if missing. New version only created parents for nested keys, so top-level keys assumed root exists.
+severity: significant
+resolution: Resolved together with the filepath.Dir issue above. RootedFS.WriteFile now calls MkdirAll(filepath.Dir(full)) on every write, which creates the root itself when the first top-level key is written. Matches SafeFS.WriteFile semantics. Test TestRootedFS_WriteFile_CreatesParentDirs added.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-16FM9.md
+++ b/tickets/entities/review-responses/RR-16FM9.md
@@ -1,0 +1,9 @@
+---
+id: RR-16FM9
+type: review-response
+title: Root() escape hatch invites caller-side path-joining, reintroducing the traversal bug
+finding: Exposing the absolute root via Root() is speculation — no production caller uses it today, and future callers will reach for filepath.Join(rfs.Root(), key) and skip the validator.
+severity: minor
+resolution: Removed Root() accessor entirely. In-package tests access r.root directly (same package). External callers cannot get the absolute path; they have to use the keyed methods. YAGNI — re-add with documented lint exception when a real caller justifies it.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-1GJVI.md
+++ b/tickets/entities/review-responses/RR-1GJVI.md
@@ -1,0 +1,9 @@
+---
+id: RR-1GJVI
+type: review-response
+title: No fuzz test for resolve — security-critical validator
+finding: resolve will become the barrier for all high-level write paths. 12 unit cases are not enough for a CodeQL-critical choke point.
+severity: minor
+resolution: 'Added FuzzResolve with 13 seed inputs asserting two invariants on accepted keys: (a) filepath.Rel result never starts with ''..'' or ''..''+sep, (b) resolved path equals root or has root+sep prefix. 10-second local run passed 2.9M executions with no escapes.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-1VEUZ.md
+++ b/tickets/entities/review-responses/RR-1VEUZ.md
@@ -1,0 +1,9 @@
+---
+id: RR-1VEUZ
+type: review-response
+title: WalkAll reports root as '.' — magic sentinel the user has to know about
+finding: '''.'' is rejected by resolve(), so if a caller sees it in a WalkAll callback and feeds it back into another RootedFS method, they get a confusing error. The casual doc mention wasn''t prominent enough.'
+severity: nit
+resolution: 'Upgraded the WalkAll doc comment to an explicit NOTE callout: root reports as ''.'', ''.'' is not a valid key, and explains how callers should navigate (ReadDir with a first-level subkey, not by feeding ''.'' back).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3ON0U.md
+++ b/tickets/entities/review-responses/RR-3ON0U.md
@@ -1,0 +1,9 @@
+---
+id: RR-3ON0U
+type: review-response
+title: Tests didn't exercise filepath.Rel-fails fallback in relativize
+finding: The defensive fallback in relativize had no test coverage. Untested defensive branches rot.
+severity: minor
+resolution: 'Resolved by removing the fallback entirely (see #2). The code path no longer exists; no branch to test.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-AF1CU.md
+++ b/tickets/entities/review-responses/RR-AF1CU.md
@@ -1,0 +1,9 @@
+---
+id: RR-AF1CU
+type: review-response
+title: filepath.Dir in FSKV.Put returns backslash on Windows; resolve then rejects it
+finding: Old FSKV.Put called filepath.Dir(key) to decide whether to MkdirAll. On Windows this returns OS-native separators (backslash), which resolve() rejects. All nested-key writes would fail on Windows.
+severity: significant
+resolution: Moved parent-directory creation into RootedFS.WriteFile itself. WriteFile now calls r.fs.MkdirAll(filepath.Dir(full), 0o755) before the actual write — full is already an absolute path at that point, so OS-native separators are correct. FSKV.Put simplifies to just fs.WriteFile(key, data, 0o644). No filepath.Dir on keys anywhere.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-E3IJ3.md
+++ b/tickets/entities/review-responses/RR-E3IJ3.md
@@ -1,0 +1,9 @@
+---
+id: RR-E3IJ3
+type: review-response
+title: Error messages use 'storage:' prefix inconsistent with rest of package
+finding: 'resolve errors use ''storage: ...'' strings while the rest of the storage package uses os.PathError or unwrapped strings. Wrapping with os.PathError would enable errors.Is(err, os.ErrInvalid) matching but leak the key in messages (mild info-leak).'
+severity: nit
+reason: 'The ''storage:'' prefix is consistent with the package-level error convention in other rela packages (state: prefix, workspace: prefix, etc.) and avoids the info-leak of echoing the potentially-attacker-controlled key in every error. The inconsistency within the storage package is real but minor, and a broader error-style normalization is its own ticket.'
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-E80D4.md
+++ b/tickets/entities/review-responses/RR-E80D4.md
@@ -1,0 +1,9 @@
+---
+id: RR-E80D4
+type: review-response
+title: NewRootedFS accepted nil fs; first method call would panic
+finding: Constructor validated root but not fs. Nil FS passed in would nil-deref on first use. For a type meant to enforce wiring discipline, failing loud at construction is the whole point.
+severity: significant
+resolution: 'Added nil-check in NewRootedFS returning ''storage: RootedFS fs must not be nil''. Test TestNewRootedFS_RejectsNilFS added.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-HMU95.md
+++ b/tickets/entities/review-responses/RR-HMU95.md
@@ -1,0 +1,9 @@
+---
+id: RR-HMU95
+type: review-response
+title: config.validateName duplicates the validation rule set; will drift
+finding: internal/config/config.go:85-112 has a copy of the validateKey rules, and its comment now references a state.validateKey symbol that no longer exists. Future rule changes must be remembered in two places.
+severity: minor
+reason: Fold into TKT-K3YYE (arch lint + shared validation) rather than bloating this PR. That ticket is already scoped to audit all path-handling callers; refactoring config.validateName to delegate to storage.RootedFS.resolve (or a shared helper) fits there. For now, config.validateName continues to work; the comment drift is cosmetic.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-HQDEL.md
+++ b/tickets/entities/review-responses/RR-HQDEL.md
@@ -1,0 +1,9 @@
+---
+id: RR-HQDEL
+type: review-response
+title: workspace.State silently returned nopState on NewRootedFS error
+finding: Returning nopState{} on NewRootedFS error would disable state persistence silently. Scheduler swallows Put errors, so misconfigured CacheDir would cause tasks to run missed-work on every restart forever.
+severity: significant
+resolution: 'State() now distinguishes two cases: (a) no cache dir configured (fs nil, paths nil, or CacheDir empty) returns nopState legitimately; (b) non-empty CacheDir that fails NewRootedFS panics with the offending path. The latter indicates programmer error and should fail loud. Tests that pass *project.Context with empty CacheDir take the legitimate-nopState path.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-KXIBR.md
+++ b/tickets/entities/review-responses/RR-KXIBR.md
@@ -1,0 +1,9 @@
+---
+id: RR-KXIBR
+type: review-response
+title: resolve makes 4 passes over the key string
+finding: 'resolve does: rune loop for control chars, ContainsRune for backslash, ContainsRune for colon, HasPrefix, Split. Could be consolidated to a single pass.'
+severity: nit
+reason: Premature optimization. resolve is only called on state-KV and (future) per-write operations, which are inherently I/O-bound — the string-scan cost is lost in the noise. Readability of the explicit rule-by-rule check is worth more than the microseconds saved. Revisit if profiling shows it on a hot path after fsstore migration.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-LF2JF.md
+++ b/tickets/entities/review-responses/RR-LF2JF.md
@@ -1,0 +1,9 @@
+---
+id: RR-LF2JF
+type: review-response
+title: Drive-letter check was position-1 only; Windows reserved names and ADS syntax bypassed
+finding: 'resolve only caught X: at position 1. Colons elsewhere (ADS: foo:stream) and Windows reserved device names (CON, NUL, COM1-9, LPT1-9) were allowed. A key that works on POSIX would silently fail or open a device handle on Windows.'
+severity: minor
+resolution: 'Replaced narrow drive-letter check with strings.ContainsRune(key, '':'') which rejects colons anywhere (covers drive letters, ADS, and any other colon abuse). Added windowsReserved map with per-segment case-insensitive stem check (extension stripped). 6 new rejection test cases. Effort: ~15 LOC as estimated.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MGASV.md
+++ b/tickets/entities/review-responses/RR-MGASV.md
@@ -1,0 +1,9 @@
+---
+id: RR-MGASV
+type: review-response
+title: resolve doc overstates the invariant — symlink escapes possible
+finding: resolve() is a string-level validator only; it rejects traversal in keys but the OS follows symlinks inside root. The doc comment said 'single path-validation barrier' without qualification, which misleads future readers and CodeQL-triage reviewers.
+severity: significant
+resolution: 'Tightened doc comments in rooted.go: described resolve as the ''string-level path-validation barrier'' and added a Security section explicitly stating that symlinks inside the root are followed and that is out of scope. Threat model documented.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OOX3Y.md
+++ b/tickets/entities/review-responses/RR-OOX3Y.md
@@ -1,0 +1,9 @@
+---
+id: RR-OOX3Y
+type: review-response
+title: Walk test asserts sorted-set equality; doesn't verify traversal order
+finding: TestRootedFS_Walk_ReturnsKeys uses sort.Strings before comparison, which hides the fact that the test does not verify the preorder-depth-first contract of filepath.WalkDir.
+severity: minor
+reason: RootedFS.Walk delegates to the underlying FS.Walk and promises nothing about order (the doc comment does not mention ordering). Asserting traversal order would lock the test to a specific FS implementation behavior that RootedFS does not guarantee. Test name clarified via comment; unordered-set semantics are correct for what RootedFS actually promises.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-WD0NA.md
+++ b/tickets/entities/review-responses/RR-WD0NA.md
@@ -1,0 +1,9 @@
+---
+id: RR-WD0NA
+type: review-response
+title: relativize swallowed filepath.Rel errors and leaked absolute paths
+finding: The Walk/WalkAll callback remapper had a defensive fallback that passed the original absolute path through on filepath.Rel failure, silently violating the 'never absolute paths' contract. Untested branch.
+severity: significant
+resolution: 'Removed the fallback. relativize now returns fmt.Errorf(''rooted: callback path %q not under root %q: %w'', path, root, err) when filepath.Rel fails. No silent contract violation; error propagates through Walk.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-0M8PM.md
+++ b/tickets/entities/tickets/TKT-0M8PM.md
@@ -5,5 +5,5 @@ title: Introduce RootedFS type and pilot on state.FSKV
 kind: enhancement
 priority: medium
 effort: s
-status: review
+status: done
 ---

--- a/tickets/entities/tickets/TKT-0M8PM.md
+++ b/tickets/entities/tickets/TKT-0M8PM.md
@@ -1,0 +1,9 @@
+---
+id: TKT-0M8PM
+type: ticket
+title: Introduce RootedFS type and pilot on state.FSKV
+kind: enhancement
+priority: medium
+effort: s
+status: review
+---

--- a/tickets/entities/tickets/TKT-3TA1H.md
+++ b/tickets/entities/tickets/TKT-3TA1H.md
@@ -1,0 +1,9 @@
+---
+id: TKT-3TA1H
+type: ticket
+title: Migrate fsstore write paths to RootedFS (closes CodeQL path-injection alerts)
+kind: enhancement
+priority: medium
+effort: m
+status: ready
+---

--- a/tickets/entities/tickets/TKT-92ID1.md
+++ b/tickets/entities/tickets/TKT-92ID1.md
@@ -1,0 +1,9 @@
+---
+id: TKT-92ID1
+type: ticket
+title: Introduce RootedFS and enforce path-validation boundary via arch lint
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---

--- a/tickets/entities/tickets/TKT-K3YYE.md
+++ b/tickets/entities/tickets/TKT-K3YYE.md
@@ -1,0 +1,9 @@
+---
+id: TKT-K3YYE
+type: ticket
+title: 'Arch lint: ban raw os.*/io I/O in high-level components'
+kind: enhancement
+priority: medium
+effort: m
+status: ready
+---

--- a/tickets/entities/tickets/TKT-REC7P.md
+++ b/tickets/entities/tickets/TKT-REC7P.md
@@ -1,0 +1,9 @@
+---
+id: TKT-REC7P
+type: ticket
+title: 'Package split: storage/raw + storage/rooted for arch-lint enforceable boundary'
+kind: refactor
+priority: low
+effort: m
+status: ready
+---

--- a/tickets/relations/FEAT-ZPGGK--requires--store-backends.md
+++ b/tickets/relations/FEAT-ZPGGK--requires--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-ZPGGK
+relation: requires
+to: store-backends
+---

--- a/tickets/relations/TKT-0M8PM--affects--store-backends.md
+++ b/tickets/relations/TKT-0M8PM--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-0M8PM--has-implementation--IMPL-CC503.md
+++ b/tickets/relations/TKT-0M8PM--has-implementation--IMPL-CC503.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-implementation
+to: IMPL-CC503
+---

--- a/tickets/relations/TKT-0M8PM--has-planning--PLAN-Z49OF.md
+++ b/tickets/relations/TKT-0M8PM--has-planning--PLAN-Z49OF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-planning
+to: PLAN-Z49OF
+---

--- a/tickets/relations/TKT-0M8PM--has-review--REV-I4AEM.md
+++ b/tickets/relations/TKT-0M8PM--has-review--REV-I4AEM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review
+to: REV-I4AEM
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-0GM44.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-0GM44.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-0GM44
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-16FM9.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-16FM9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-16FM9
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-1GJVI.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-1GJVI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-1GJVI
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-1VEUZ.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-1VEUZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-1VEUZ
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-3ON0U.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-3ON0U.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-3ON0U
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-AF1CU.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-AF1CU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-AF1CU
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-E3IJ3.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-E3IJ3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-E3IJ3
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-E80D4.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-E80D4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-E80D4
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-HMU95.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-HMU95.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-HMU95
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-HQDEL.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-HQDEL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-HQDEL
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-KXIBR.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-KXIBR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-KXIBR
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-LF2JF.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-LF2JF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-LF2JF
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-MGASV.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-MGASV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-MGASV
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-OOX3Y.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-OOX3Y.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-OOX3Y
+---

--- a/tickets/relations/TKT-0M8PM--has-review-response--RR-WD0NA.md
+++ b/tickets/relations/TKT-0M8PM--has-review-response--RR-WD0NA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: has-review-response
+to: RR-WD0NA
+---

--- a/tickets/relations/TKT-0M8PM--implements--FEAT-ZPGGK.md
+++ b/tickets/relations/TKT-0M8PM--implements--FEAT-ZPGGK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0M8PM
+relation: implements
+to: FEAT-ZPGGK
+---

--- a/tickets/relations/TKT-3TA1H--affects--store-backends.md
+++ b/tickets/relations/TKT-3TA1H--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3TA1H
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-3TA1H--implements--FEAT-ZPGGK.md
+++ b/tickets/relations/TKT-3TA1H--implements--FEAT-ZPGGK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3TA1H
+relation: implements
+to: FEAT-ZPGGK
+---

--- a/tickets/relations/TKT-92ID1--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-92ID1--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-92ID1
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-92ID1--affects--store-backends.md
+++ b/tickets/relations/TKT-92ID1--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-92ID1
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-92ID1--has-planning--PLAN-7C7ZZ.md
+++ b/tickets/relations/TKT-92ID1--has-planning--PLAN-7C7ZZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-92ID1
+relation: has-planning
+to: PLAN-7C7ZZ
+---

--- a/tickets/relations/TKT-92ID1--implements--FEAT-022.md
+++ b/tickets/relations/TKT-92ID1--implements--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: TKT-92ID1
+relation: implements
+to: FEAT-022
+---

--- a/tickets/relations/TKT-K3YYE--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-K3YYE--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-K3YYE
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-K3YYE--implements--FEAT-ZPGGK.md
+++ b/tickets/relations/TKT-K3YYE--implements--FEAT-ZPGGK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-K3YYE
+relation: implements
+to: FEAT-ZPGGK
+---

--- a/tickets/relations/TKT-REC7P--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-REC7P--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-REC7P
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-REC7P--affects--store-backends.md
+++ b/tickets/relations/TKT-REC7P--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-REC7P
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-REC7P--implements--FEAT-ZPGGK.md
+++ b/tickets/relations/TKT-REC7P--implements--FEAT-ZPGGK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-REC7P
+relation: implements
+to: FEAT-ZPGGK
+---


### PR DESCRIPTION
## Summary

- Introduces `storage.RootedFS` — a concrete type that binds a validated root directory to any `storage.FS`. Every method takes a KEY (forward-slash, relative), and a single `resolve()` method is the string-level path-validation barrier.
- `RootedFS` deliberately does NOT implement `storage.FS`. A function expecting `*RootedFS` is a compile-time claim that paths have been validated.
- Pilot migration: `state.FSKV` rewritten to use `*RootedFS`; `validateKey` deleted, `Put` is now one line. Three call sites migrated (`workspace.State()`, `dataentry.NewApp`, two test helpers).

## Why

`storage.FS` is a raw path-taking interface threaded through ~26 files. Path validation lives scattered across callers (`state.validateKey`, `config.validateName`, implicit trust elsewhere). CodeQL has persistently flagged the path-taint flow in `SafeFS.WriteFile` (6 open `go/path-injection` alerts). This lands the pattern that closes those alerts structurally — one auditable sanitizer, visible to CodeQL, enforceable later via arch lint.

This is ticket 1 of 4 in FEAT-ZPGGK. CodeQL alerts don't close on this PR — they close in the next ticket (TKT-3TA1H: fsstore migration). Subsequent tickets add arch lint enforcement (TKT-K3YYE) and a package split so arch lint can enforce per-symbol (TKT-REC7P).

## Design calls made in review

- Windows-safe by default: `resolve()` rejects colons anywhere (not just drive letters) and rejects Windows reserved names (CON, NUL, COM1-9, LPT1-9, case-insensitive, stem-before-dot).
- `Walk(key, fn)` validates key with the same rules as every other method. Separate `WalkAll(fn)` method for walking the whole rooted tree — no magic-string asymmetry.
- `WriteFile` auto-creates parent dirs (matches SafeFS semantics); `FSKV.Put` stops doing its own `MkdirAll`, which fixes a Windows backslash bug in the process.
- No `Root()` accessor exposed — would be an escape hatch that reintroduces caller-side `filepath.Join` with traversal risk.
- `workspace.State()` treats empty `CacheDir` as legitimate no-op (test scenarios) but panics on non-empty malformed roots (programmer error).

## Review

15 review-response entities created from cranky-code-reviewer findings:
- **6 significant** (all addressed): doc invariant, Walk callback error handling, silent nopState, Windows backslash bug, lazy root creation, nil-FS accepted.
- **7 minor**: 5 addressed, 1 deferred to TKT-K3YYE, 1 wont-fix (traversal-order test).
- **3 nits**: 1 addressed, 2 wont-fix with reasons.

## Test plan

- [x] Unit tests: 20 tests covering constructor, `resolve()`, all method shapes, Walk/WalkAll callback remapping, invalid-key short-circuit via spy.
- [x] Fuzz test: `FuzzResolve` — 2.9M execs in 10s, no root escapes found. Asserts two invariants on every accepted key: (a) `filepath.Rel` has no `..` prefix, (b) resolved path is root or has root+sep prefix.
- [x] Integration: `state.FSKV` round-trip tests via MemFS.
- [x] `just lint` clean (0 issues), `just test` green, `just coverage-check` passes (state=100%, storage=86.3%).
- [x] Manual: 3 production call sites rebuild cleanly; dataentry tests pass with migrated helpers.