### PR TITLE
feat(data-entry): prefix picker and manual ID handling in create forms

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -319,6 +319,24 @@ When no widget is specified, the system auto-detects from the property's type in
 enum types render as a `<select>`, booleans as checkboxes, dates as date pickers, and everything
 else as text inputs.
 
+### ID Controls on Create Forms
+
+Create forms adapt to the entity type's `id_type` and `id_prefix` / `id_prefixes`
+configuration in the metamodel. The user-facing UI is generated automatically —
+no extra form configuration is required.
+
+- **Single-prefix types** (`id_prefix: "TKT-"`): no extra controls. The form
+  submits and the server assigns the next ID.
+- **Multi-prefix types** (`id_prefixes: ["DEC-", "ADR-"]`): the create form
+  renders a **Prefix** dropdown so the user picks which prefix the new entity
+  should use. The server validates the chosen prefix against the declared
+  list — unknown values are rejected with a 422.
+- **Manual ID types** (`id_type: manual`): the create form renders a required
+  **ID** text input that is sent verbatim as the entity's ID. If the type also
+  declares one or more prefixes, the supplied ID must start with one of them
+  and include a non-empty suffix. The edit form shows the ID as a read-only
+  display; renaming uses the dedicated rename flow.
+
 ### State Transitions
 
 For edit forms, you can restrict which enum values are selectable based on the current value:

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -313,6 +313,24 @@ When no widget is specified, the system auto-detects from the property's type in
 enum types render as a `<select>`, booleans as checkboxes, dates as date pickers, and everything
 else as text inputs.
 
+### ID Controls on Create Forms
+
+Create forms adapt to the entity type's `id_type` and `id_prefix` / `id_prefixes`
+configuration in the metamodel. The user-facing UI is generated automatically —
+no extra form configuration is required.
+
+- **Single-prefix types** (`id_prefix: "TKT-"`): no extra controls. The form
+  submits and the server assigns the next ID.
+- **Multi-prefix types** (`id_prefixes: ["DEC-", "ADR-"]`): the create form
+  renders a **Prefix** dropdown so the user picks which prefix the new entity
+  should use. The server validates the chosen prefix against the declared
+  list — unknown values are rejected with a 422.
+- **Manual ID types** (`id_type: manual`): the create form renders a required
+  **ID** text input that is sent verbatim as the entity's ID. If the type also
+  declares one or more prefixes, the supplied ID must start with one of them
+  and include a non-empty suffix. The edit form shows the ID as a read-only
+  display; renaming uses the dedicated rename flow.
+
 ### State Transitions
 
 For edit forms, you can restrict which enum values are selectable based on the current value:

--- a/e2e/pages/form.page.ts
+++ b/e2e/pages/form.page.ts
@@ -264,4 +264,38 @@ export class FormPage extends BasePage {
   pickerTileByText(picker: Locator, text: string): Locator {
     return picker.locator('.selected-entity', { hasText: text });
   }
+
+  // --- Manual ID / prefix picker (TKT-E7NNM) ---
+
+  get idInput(): Locator {
+    return this.page.locator('.id-field input[type="text"]');
+  }
+
+  get prefixSelect(): Locator {
+    return this.page.locator('.id-field select');
+  }
+
+  async expectIdInputVisible() {
+    await expect(this.idInput).toBeVisible();
+  }
+
+  async expectPrefixSelectVisible() {
+    await expect(this.prefixSelect).toBeVisible();
+  }
+
+  async expectPrefixSelectHidden() {
+    await expect(this.prefixSelect).toHaveCount(0);
+  }
+
+  async fillId(value: string) {
+    await this.idInput.fill(value);
+  }
+
+  async selectPrefix(value: string) {
+    await this.prefixSelect.selectOption(value);
+  }
+
+  async getPrefixOptions(): Promise<string[]> {
+    return this.prefixSelect.locator('option').allTextContents();
+  }
 }

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -79,7 +79,7 @@ export interface PaginatedResponse<T = EntityResponse> {
 }
 
 export interface ApiHelpers {
-  createEntity(plural: string, data: { properties: Record<string, unknown>; relations?: Record<string, string[]>; id?: string }): Promise<EntityResponse>;
+  createEntity(plural: string, data: { properties: Record<string, unknown>; relations?: Record<string, string[]>; id?: string; prefix?: string }): Promise<EntityResponse>;
   getEntity(plural: string, id: string): Promise<EntityResponse>;
   updateEntity(plural: string, id: string, properties: Record<string, unknown>): Promise<EntityResponse>;
   deleteEntity(plural: string, id: string): Promise<void>;
@@ -467,6 +467,44 @@ entities:
       done:
         type: boolean
 
+  # TKT-E7NNM fixtures: covers manual-ID, multi-prefix, and the combinations
+  # we want to exercise in forms.spec.ts. Keep names short and orthogonal
+  # so the inline metamodel stays readable.
+  tag:
+    label: Tag
+    id_type: manual
+    properties:
+      name:
+        type: string
+        required: true
+
+  decision:
+    label: Decision
+    id_type: short
+    id_prefixes: [DEC-, ADR-]
+    properties:
+      title:
+        type: string
+        required: true
+
+  module:
+    label: Module
+    id_type: manual
+    id_prefix: MOD-
+    properties:
+      name:
+        type: string
+        required: true
+
+  specification:
+    label: Specification
+    id_type: manual
+    id_prefixes: [SPEC-, RFC-]
+    properties:
+      name:
+        type: string
+        required: true
+
 relations:
   blocks:
     from: [feature, bug, task]
@@ -629,6 +667,30 @@ forms:
         label: Implements Feature
       - relation: fixes
         label: Fixes Bug
+
+  tag:
+    entity_type: tag
+    title: "Tag"
+    fields:
+      - property: name
+
+  decision:
+    entity_type: decision
+    title: "Decision"
+    fields:
+      - property: title
+
+  module:
+    entity_type: module
+    title: "Module"
+    fields:
+      - property: name
+
+  specification:
+    entity_type: specification
+    title: "Specification"
+    fields:
+      - property: name
 
 lists:
   features:

--- a/e2e/tests/forms-id-controls.spec.ts
+++ b/e2e/tests/forms-id-controls.spec.ts
@@ -1,0 +1,192 @@
+import { test, expect } from './fixtures';
+import { FormPage } from '../pages';
+
+// TKT-E7NNM: prefix picker for multi-prefix types + manual ID field for
+// manual-ID types. These specs drive the /form/:type routes for the four
+// fixture entity types that span the id_type × id_prefix(es) matrix:
+// tag (manual, no prefix), decision (short, multi prefix),
+// module (manual, single prefix), specification (manual, multi prefix).
+
+async function openCreateForm(appPage: import('@playwright/test').Page, formId: string) {
+  const formPage = new FormPage(appPage);
+  await formPage.navigateTo(`/form/${formId}`);
+  await formPage.waitForSpinnerToDisappear();
+  await expect(formPage.form).toBeVisible();
+  return formPage;
+}
+
+async function submitAndWaitForCreate(
+  appPage: import('@playwright/test').Page,
+  formPage: FormPage,
+  plural: string,
+): Promise<import('@playwright/test').Response> {
+  const [resp] = await Promise.all([
+    appPage.waitForResponse(
+      (r) => r.url().includes(`/api/v1/${plural}`) && r.request().method() === 'POST',
+    ),
+    formPage.submitButton.first().click(),
+  ]);
+  return resp;
+}
+
+test.describe('Manual-ID Create Form', () => {
+  const createdTags: string[] = [];
+
+  test.afterEach(async ({ api }) => {
+    while (createdTags.length) {
+      const id = createdTags.pop()!;
+      await api.deleteEntity('tags', id).catch(() => {});
+    }
+  });
+
+  test('renders ID input and creates tag with user-supplied ID', async ({ appPage, api }) => {
+    const formPage = await openCreateForm(appPage, 'tag');
+
+    await formPage.expectIdInputVisible();
+
+    const tagId = `e2e-tag-${Date.now()}`;
+    await formPage.fillId(tagId);
+    await formPage.fillField('name', 'E2E Manual Tag');
+
+    const resp = await submitAndWaitForCreate(appPage, formPage, 'tags');
+    expect(resp.status()).toBe(201);
+
+    const fetched = await api.getEntity('tags', tagId);
+    expect(fetched.id).toBe(tagId);
+    createdTags.push(tagId);
+  });
+});
+
+test.describe('Multi-Prefix Create Form', () => {
+  const createdDecisions: string[] = [];
+
+  test.afterEach(async ({ api }) => {
+    while (createdDecisions.length) {
+      const id = createdDecisions.pop()!;
+      await api.deleteEntity('decisions', id).catch(() => {});
+    }
+  });
+
+  test('shows prefix picker and creates entity with chosen prefix', async ({ appPage }) => {
+    const formPage = await openCreateForm(appPage, 'decision');
+
+    await formPage.expectPrefixSelectVisible();
+    const options = await formPage.getPrefixOptions();
+    expect(options).toContain('DEC-');
+    expect(options).toContain('ADR-');
+
+    await formPage.selectPrefix('ADR-');
+    await formPage.fillField('title', 'E2E Multi Prefix Decision');
+
+    const resp = await submitAndWaitForCreate(appPage, formPage, 'decisions');
+    expect(resp.status()).toBe(201);
+    const body = (await resp.json()) as { id: string };
+    expect(body.id.startsWith('ADR-')).toBe(true);
+    createdDecisions.push(body.id);
+  });
+
+  test('does not show prefix picker for single-prefix feature form', async ({ appPage }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm('feature');
+
+    await formPage.expectPrefixSelectHidden();
+  });
+
+  test('edit mode does not show prefix picker', async ({ api, appPage }) => {
+    const created = await api.createEntity('decisions', {
+      prefix: 'DEC-',
+      properties: { title: 'E2E Edit Mode No Picker' },
+    });
+    try {
+      const formPage = new FormPage(appPage);
+      await formPage.navigateTo(`/form/decision/${created.id}`);
+      await formPage.waitForSpinnerToDisappear();
+
+      await formPage.expectPrefixSelectHidden();
+    } finally {
+      await api.deleteEntity('decisions', created.id).catch(() => {});
+    }
+  });
+});
+
+test.describe('Manual-ID with Prefix Enforcement', () => {
+  const createdModules: string[] = [];
+  const createdSpecs: string[] = [];
+
+  test.afterEach(async ({ api }) => {
+    while (createdModules.length) {
+      await api.deleteEntity('modules', createdModules.pop()!).catch(() => {});
+    }
+    while (createdSpecs.length) {
+      await api.deleteEntity('specifications', createdSpecs.pop()!).catch(() => {});
+    }
+  });
+
+  test('rejects bare ID when single prefix is declared', async ({ appPage }) => {
+    const formPage = await openCreateForm(appPage, 'module');
+
+    await formPage.expectIdInputVisible();
+    await formPage.fillId('no-prefix-here');
+    await formPage.fillField('name', 'E2E Bare ID Reject');
+
+    const resp = await submitAndWaitForCreate(appPage, formPage, 'modules');
+    expect(resp.status()).toBe(422);
+    const body = await resp.text();
+    expect(body).toMatch(/must start with.*MOD-/);
+    expect(appPage.url()).toContain('/form/module');
+  });
+
+  test('accepts ID with declared single prefix', async ({ appPage, api }) => {
+    const formPage = await openCreateForm(appPage, 'module');
+
+    const moduleId = `MOD-e2e-${Date.now()}`;
+    await formPage.fillId(moduleId);
+    await formPage.fillField('name', 'E2E Prefixed Module');
+
+    const resp = await submitAndWaitForCreate(appPage, formPage, 'modules');
+    expect(resp.status()).toBe(201);
+
+    const fetched = await api.getEntity('modules', moduleId);
+    expect(fetched.id).toBe(moduleId);
+    createdModules.push(moduleId);
+  });
+
+  test('accepts any of the multiple declared prefixes', async ({ appPage, api }) => {
+    const formPage = await openCreateForm(appPage, 'specification');
+
+    const specId = `SPEC-e2e-${Date.now()}`;
+    await formPage.fillId(specId);
+    await formPage.fillField('name', 'E2E Multi Prefix Manual');
+
+    const resp = await submitAndWaitForCreate(appPage, formPage, 'specifications');
+    expect(resp.status()).toBe(201);
+
+    const fetched = await api.getEntity('specifications', specId);
+    expect(fetched.id).toBe(specId);
+    createdSpecs.push(specId);
+  });
+});
+
+test.describe('Create Form Error Surfacing', () => {
+  test('surfaces duplicate-ID server error message', async ({ appPage, api }) => {
+    const tagId = `e2e-dup-${Date.now()}`;
+    const existing = await api.createEntity('tags', {
+      id: tagId,
+      properties: { name: 'Existing' },
+    });
+    try {
+      const formPage = await openCreateForm(appPage, 'tag');
+
+      await formPage.fillId(tagId);
+      await formPage.fillField('name', 'Duplicate attempt');
+
+      const resp = await submitAndWaitForCreate(appPage, formPage, 'tags');
+      expect(resp.status()).toBeGreaterThanOrEqual(400);
+      const body = await resp.text();
+      expect(body).toContain('already exists');
+      expect(body).toContain(tagId);
+    } finally {
+      await api.deleteEntity('tags', existing.id).catch(() => {});
+    }
+  });
+});

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -165,7 +165,7 @@ test.describe('Settings', () => {
 
       await settingsPage.navigateToSettings();
 
-      await settingsPage.expectAppInfo('Entity Types', '3'); // feature, bug, task
+      await settingsPage.expectAppInfo('Entity Types', '7'); // feature, bug, task, tag, decision, module, specification
     });
 
     test('shows relation type count', async ({ appPage }) => {
@@ -181,7 +181,7 @@ test.describe('Settings', () => {
 
       await settingsPage.navigateToSettings();
 
-      await settingsPage.expectAppInfo('Forms', '3'); // feature, bug, task
+      await settingsPage.expectAppInfo('Forms', '7'); // feature, bug, task, tag, decision, module, specification
     });
 
     test('shows lists count', async ({ appPage }) => {

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -4,6 +4,7 @@ import { useRouter, useRoute, onBeforeRouteLeave } from 'vue-router'
 import { useSchemaStore, useEntitiesStore, useUIStore } from '@/stores'
 import { isCancelledFetch } from '@/composables/usePageData'
 import { readReturnTo } from '@/utils/returnPath'
+import { useEntityIDControls } from '@/composables/useEntityIDControls'
 import type { PropertyDef, FormFieldOrRelation, Template } from '@/types'
 import { getTemplates, createRelation, updateRelationProperties, deleteRelation } from '@/api'
 import type { RelationCardState } from './RelationCards.vue'
@@ -56,6 +57,20 @@ const entityType = computed(() => {
 })
 
 const isEdit = computed(() => !!props.entityId)
+const formMode = computed(() => (isEdit.value ? 'edit' : 'create') as 'create' | 'edit')
+
+const idControls = useEntityIDControls(entityType, formMode)
+const {
+  showManualIDInput,
+  showPrefixPicker,
+  prefixOptions,
+  manualId,
+  selectedPrefix,
+} = idControls
+
+const showReadOnlyID = computed(
+  () => isEdit.value && entityType.value?.id_type === 'manual'
+)
 
 const title = computed(() => {
   if (!formConfig.value) return ''
@@ -123,6 +138,8 @@ function applyReturnToFromQuery() {
 
 function initializeDefaults() {
   if (!entityType.value || isEdit.value) return
+
+  idControls.reset()
 
   // Parse query params for pre-filling (prop.*, rel.*, link_*)
   const query = route.query
@@ -327,7 +344,13 @@ async function handleSubmit() {
       }
     }
 
-    const payload = {
+    const payload: {
+      id?: string
+      prefix?: string
+      properties: Record<string, unknown>
+      relations: Record<string, string[]>
+      content?: string
+    } = {
       properties: formData.value,
       relations: filteredRelations,
       content: content.value || undefined,
@@ -339,6 +362,7 @@ async function handleSubmit() {
       await savePendingRelationCards()
       uiStore.success('Entity updated successfully')
     } else {
+      Object.assign(payload, idControls.buildPayloadFields())
       const entity = await entitiesStore.create(formConfig.value.entity, payload)
 
       // Handle auto-linking from link_* params (e.g., from custom view "Add" buttons)
@@ -385,7 +409,7 @@ async function handleSubmit() {
     // not a user-facing failure; the user clicked away before the
     // save completed, which is their choice.
     if (isCancelledFetch(err)) return
-    if (err && typeof err === 'object' && 'errors' in err) {
+    if (err && typeof err === 'object' && 'errors' in err && Array.isArray((err as { errors: unknown }).errors)) {
       const problemErrors = (err as { errors: Array<{ field?: string; message?: string; detail?: string }> }).errors
       for (const e of problemErrors) {
         if (e.field) {
@@ -393,6 +417,9 @@ async function handleSubmit() {
         }
       }
       uiStore.error('Please fix the validation errors')
+    } else if (err && typeof err === 'object' && ('detail' in err || 'title' in err)) {
+      const problem = err as { detail?: string; title?: string }
+      uiStore.error(problem.detail || problem.title || 'Failed to save entity')
     } else {
       uiStore.error('Failed to save entity')
     }
@@ -569,6 +596,22 @@ onBeforeRouteLeave((_to, _from, next) => {
       </div>
 
       <form v-else @submit.prevent="handleSubmit">
+        <div v-if="showReadOnlyID" class="form-field id-field">
+          <label>ID</label>
+          <div class="id-display">{{ entityId }}</div>
+          <p class="field-help">IDs cannot be changed here; use rename.</p>
+        </div>
+        <div v-if="showManualIDInput" class="form-field id-field">
+          <label>ID <span class="required">*</span></label>
+          <input v-model="manualId" type="text" required placeholder="Unique ID..." />
+        </div>
+        <div v-if="showPrefixPicker" class="form-field id-field">
+          <label>Prefix <span class="required">*</span></label>
+          <select v-model="selectedPrefix" required>
+            <option v-for="p in prefixOptions" :key="p" :value="p">{{ p }}</option>
+          </select>
+        </div>
+
         <template v-if="formConfig.sections?.length">
           <div
             v-for="section in formConfig.sections"
@@ -786,6 +829,41 @@ onBeforeRouteLeave((_to, _from, next) => {
   font-size: 14px;
   font-weight: 500;
   color: var(--text-color);
+}
+
+.id-field {
+  margin-bottom: 16px;
+}
+
+.id-field input,
+.id-field select {
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 14px;
+  background: var(--input-bg);
+  color: var(--text-color);
+}
+
+.id-display {
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 14px;
+  background: var(--input-bg);
+  color: var(--muted-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.required {
+  color: var(--error-color, #ef4444);
+  margin-left: 2px;
+}
+
+.field-help {
+  font-size: 12px;
+  color: var(--muted-text);
+  margin: 0;
 }
 
 .content-field {

--- a/frontend/src/components/forms/InlineCreateModal.vue
+++ b/frontend/src/components/forms/InlineCreateModal.vue
@@ -3,6 +3,7 @@ import { ref, computed, toRef, watch } from 'vue'
 import { useSchemaStore } from '@/stores'
 import { createEntity } from '@/api'
 import { useModalStack } from '@/composables/modalStack'
+import { useEntityIDControls } from '@/composables/useEntityIDControls'
 import type { Entity, PropertyDef } from '@/types'
 
 const props = defineProps<{
@@ -22,14 +23,12 @@ useModalStack(toRef(props, 'show'))
 const loading = ref(false)
 const error = ref<string | null>(null)
 const formData = ref<Record<string, string | boolean>>({})
-const manualId = ref('')
 
 // Computed
 const entityTypeDef = computed(() => schemaStore.getEntityType(props.entityType))
 
-const requiresManualId = computed(() => {
-  return entityTypeDef.value?.id_type === 'manual'
-})
+const idControls = useEntityIDControls(entityTypeDef, 'create')
+const { showManualIDInput, showPrefixPicker, prefixOptions, manualId, selectedPrefix } = idControls
 
 const fields = computed(() => {
   if (!entityTypeDef.value) return []
@@ -48,7 +47,7 @@ watch(() => props.show, (show) => {
   if (show) {
     error.value = null
     formData.value = {}
-    manualId.value = ''
+    idControls.reset()
 
     // Initialize with defaults
     for (const field of fields.value) {
@@ -117,16 +116,21 @@ async function handleSubmit() {
       }
     }
 
-    const payload: { id?: string; properties: Record<string, unknown> } = { properties }
-    if (requiresManualId.value && manualId.value) {
-      payload.id = manualId.value
+    const payload: { id?: string; prefix?: string; properties: Record<string, unknown> } = {
+      properties,
+      ...idControls.buildPayloadFields(),
     }
 
     const entity = await createEntity(props.entityType, payload)
     emit('created', entity)
     emit('close')
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to create entity'
+    if (err && typeof err === 'object' && ('detail' in err || 'title' in err)) {
+      const problem = err as { detail?: string; title?: string }
+      error.value = problem.detail || problem.title || 'Failed to create entity'
+    } else {
+      error.value = err instanceof Error ? err.message : 'Failed to create entity'
+    }
   } finally {
     loading.value = false
   }
@@ -153,7 +157,7 @@ function handleClose() {
             <div v-if="error" class="error-message">{{ error }}</div>
 
             <!-- Manual ID field -->
-            <div v-if="requiresManualId" class="form-field">
+            <div v-if="showManualIDInput" class="form-field">
               <label>
                 ID
                 <span class="required">*</span>
@@ -164,6 +168,17 @@ function handleClose() {
                 required
                 placeholder="Unique ID..."
               />
+            </div>
+
+            <!-- Prefix picker (multi-prefix types) -->
+            <div v-if="showPrefixPicker" class="form-field">
+              <label>
+                Prefix
+                <span class="required">*</span>
+              </label>
+              <select v-model="selectedPrefix" required>
+                <option v-for="p in prefixOptions" :key="p" :value="p">{{ p }}</option>
+              </select>
             </div>
 
             <!-- Dynamic fields from entity type -->

--- a/frontend/src/composables/useEntityIDControls.test.ts
+++ b/frontend/src/composables/useEntityIDControls.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { useEntityIDControls } from './useEntityIDControls'
+import type { EntityType } from '@/types'
+
+function et(partial: Partial<EntityType>): EntityType {
+  return {
+    label: 'Test',
+    properties: {},
+    ...partial,
+  }
+}
+
+describe('useEntityIDControls', () => {
+  describe('showManualIDInput', () => {
+    it('is true for manual type in create mode', () => {
+      const type = ref<EntityType | undefined>(et({ id_type: 'manual' }))
+      const c = useEntityIDControls(type, 'create')
+      expect(c.showManualIDInput.value).toBe(true)
+    })
+
+    it('is false for manual type in edit mode', () => {
+      const type = ref<EntityType | undefined>(et({ id_type: 'manual' }))
+      const c = useEntityIDControls(type, 'edit')
+      expect(c.showManualIDInput.value).toBe(false)
+    })
+
+    it('is false for short type', () => {
+      const type = ref<EntityType | undefined>(et({ id_type: 'short', id_prefix: 'TKT-' }))
+      const c = useEntityIDControls(type, 'create')
+      expect(c.showManualIDInput.value).toBe(false)
+    })
+  })
+
+  describe('showPrefixPicker', () => {
+    it('is false for single-prefix types', () => {
+      const type = ref<EntityType | undefined>(et({ id_type: 'short', id_prefix: 'TKT-' }))
+      const c = useEntityIDControls(type, 'create')
+      expect(c.showPrefixPicker.value).toBe(false)
+    })
+
+    it('is true for multi-prefix non-manual types in create mode', () => {
+      const type = ref<EntityType | undefined>(
+        et({ id_type: 'short', id_prefixes: ['DEC-', 'ADR-'] })
+      )
+      const c = useEntityIDControls(type, 'create')
+      expect(c.showPrefixPicker.value).toBe(true)
+      expect(c.prefixOptions.value).toEqual(['DEC-', 'ADR-'])
+    })
+
+    it('is false for multi-prefix types in edit mode', () => {
+      const type = ref<EntityType | undefined>(
+        et({ id_type: 'short', id_prefixes: ['DEC-', 'ADR-'] })
+      )
+      const c = useEntityIDControls(type, 'edit')
+      expect(c.showPrefixPicker.value).toBe(false)
+    })
+
+    it('is false for manual types even when id_prefixes has multiple entries', () => {
+      const type = ref<EntityType | undefined>(
+        et({ id_type: 'manual', id_prefixes: ['A-', 'B-'] })
+      )
+      const c = useEntityIDControls(type, 'create')
+      expect(c.showPrefixPicker.value).toBe(false)
+      expect(c.showManualIDInput.value).toBe(true)
+    })
+
+    it('is false when prefixOptions is empty', () => {
+      const type = ref<EntityType | undefined>(et({ id_type: 'short' }))
+      const c = useEntityIDControls(type, 'create')
+      expect(c.showPrefixPicker.value).toBe(false)
+    })
+  })
+
+  describe('prefixOptions', () => {
+    it('falls back to id_prefix when id_prefixes is absent', () => {
+      const type = ref<EntityType | undefined>(et({ id_prefix: 'TKT-' }))
+      const c = useEntityIDControls(type, 'create')
+      expect(c.prefixOptions.value).toEqual(['TKT-'])
+    })
+
+    it('returns empty when entity type has no prefixes', () => {
+      const type = ref<EntityType | undefined>(et({}))
+      const c = useEntityIDControls(type, 'create')
+      expect(c.prefixOptions.value).toEqual([])
+    })
+  })
+
+  describe('reset', () => {
+    it('clears manual id and selects first prefix', () => {
+      const type = ref<EntityType | undefined>(
+        et({ id_type: 'short', id_prefixes: ['DEC-', 'ADR-'] })
+      )
+      const c = useEntityIDControls(type, 'create')
+      c.manualId.value = 'stale'
+      c.selectedPrefix.value = 'stale-'
+      c.reset()
+      expect(c.manualId.value).toBe('')
+      expect(c.selectedPrefix.value).toBe('DEC-')
+    })
+
+    it('leaves selectedPrefix empty when no prefixes', () => {
+      const type = ref<EntityType | undefined>(et({ id_type: 'manual' }))
+      const c = useEntityIDControls(type, 'create')
+      c.reset()
+      expect(c.selectedPrefix.value).toBe('')
+    })
+  })
+
+  describe('reactive mode', () => {
+    it('responds to mode changes (create → edit hides picker)', async () => {
+      const type = ref<EntityType | undefined>(
+        et({ id_type: 'short', id_prefixes: ['DEC-', 'ADR-'] })
+      )
+      const mode = ref<'create' | 'edit'>('create')
+      const c = useEntityIDControls(type, mode)
+      expect(c.showPrefixPicker.value).toBe(true)
+
+      mode.value = 'edit'
+      expect(c.showPrefixPicker.value).toBe(false)
+      expect(c.showManualIDInput.value).toBe(false)
+      expect(c.buildPayloadFields()).toEqual({})
+    })
+
+    it('responds to mode changes (create → edit hides manual input)', async () => {
+      const type = ref<EntityType | undefined>(et({ id_type: 'manual' }))
+      const mode = ref<'create' | 'edit'>('create')
+      const c = useEntityIDControls(type, mode)
+      c.manualId.value = 'foo'
+      expect(c.showManualIDInput.value).toBe(true)
+
+      mode.value = 'edit'
+      expect(c.showManualIDInput.value).toBe(false)
+      expect(c.buildPayloadFields()).toEqual({})
+    })
+  })
+
+  describe('buildPayloadFields', () => {
+    it('includes manual id when manual-ID input is shown and filled', () => {
+      const type = ref<EntityType | undefined>(et({ id_type: 'manual' }))
+      const c = useEntityIDControls(type, 'create')
+      c.manualId.value = 'custom-1'
+      expect(c.buildPayloadFields()).toEqual({ id: 'custom-1' })
+    })
+
+    it('includes prefix when picker is shown and selected', () => {
+      const type = ref<EntityType | undefined>(
+        et({ id_type: 'short', id_prefixes: ['DEC-', 'ADR-'] })
+      )
+      const c = useEntityIDControls(type, 'create')
+      c.selectedPrefix.value = 'ADR-'
+      expect(c.buildPayloadFields()).toEqual({ prefix: 'ADR-' })
+    })
+
+    it('returns empty object for single-prefix create form', () => {
+      const type = ref<EntityType | undefined>(et({ id_type: 'short', id_prefix: 'TKT-' }))
+      const c = useEntityIDControls(type, 'create')
+      expect(c.buildPayloadFields()).toEqual({})
+    })
+
+    it('does not include prefix for manual types even if selectedPrefix happens to be set', () => {
+      const type = ref<EntityType | undefined>(et({ id_type: 'manual' }))
+      const c = useEntityIDControls(type, 'create')
+      c.selectedPrefix.value = 'X-'
+      c.manualId.value = 'foo'
+      expect(c.buildPayloadFields()).toEqual({ id: 'foo' })
+    })
+  })
+
+  // Code-review #9: form components are reused across navigation; the
+  // composable must self-clear stale state when the entity type changes.
+  describe('auto-reset on entityType change', () => {
+    it('clears manualId when switching from manual to short type', async () => {
+      const type = ref<EntityType | undefined>(et({ id_type: 'manual' }))
+      const c = useEntityIDControls(type, 'create')
+      c.manualId.value = 'leftover'
+
+      type.value = et({ id_type: 'short', id_prefix: 'TKT-' })
+      await nextTick()
+      expect(c.manualId.value).toBe('')
+    })
+
+    it('updates selectedPrefix to first of new prefix list', async () => {
+      const type = ref<EntityType | undefined>(et({ id_type: 'short', id_prefixes: ['A-', 'B-'] }))
+      const c = useEntityIDControls(type, 'create')
+      c.selectedPrefix.value = 'B-'
+
+      type.value = et({ id_type: 'short', id_prefixes: ['DEC-', 'ADR-'] })
+      await nextTick()
+      expect(c.selectedPrefix.value).toBe('DEC-')
+    })
+
+    it('does not reset when the same entity type object is reassigned', async () => {
+      const same = et({ id_type: 'manual' })
+      const type = ref<EntityType | undefined>(same)
+      const c = useEntityIDControls(type, 'create')
+      c.manualId.value = 'preserved'
+
+      type.value = same
+      await nextTick()
+      expect(c.manualId.value).toBe('preserved')
+    })
+  })
+})

--- a/frontend/src/composables/useEntityIDControls.ts
+++ b/frontend/src/composables/useEntityIDControls.ts
@@ -1,0 +1,85 @@
+import { computed, ref, watch, type Ref } from 'vue'
+import type { EntityType } from '@/types'
+
+export type FormMode = 'create' | 'edit'
+
+export interface EntityIDControls {
+  prefixOptions: Ref<string[]>
+  showManualIDInput: Ref<boolean>
+  showPrefixPicker: Ref<boolean>
+  manualId: Ref<string>
+  selectedPrefix: Ref<string>
+  reset: () => void
+  buildPayloadFields: () => { id?: string; prefix?: string }
+}
+
+export function useEntityIDControls(
+  entityType: Ref<EntityType | undefined>,
+  mode: FormMode | Ref<FormMode>
+): EntityIDControls {
+  const manualId = ref('')
+  const selectedPrefix = ref('')
+
+  const modeRef = computed(() => (typeof mode === 'string' ? mode : mode.value))
+
+  const prefixOptions = computed<string[]>(() => {
+    const def = entityType.value
+    if (!def) return []
+    if (def.id_prefixes?.length) return def.id_prefixes
+    if (def.id_prefix) return [def.id_prefix]
+    return []
+  })
+
+  const isManual = computed(() => entityType.value?.id_type === 'manual')
+
+  const showManualIDInput = computed(() => modeRef.value === 'create' && isManual.value)
+
+  const showPrefixPicker = computed(
+    () => modeRef.value === 'create' && !isManual.value && prefixOptions.value.length > 1
+  )
+
+  function reset() {
+    manualId.value = ''
+    selectedPrefix.value = prefixOptions.value[0] ?? ''
+  }
+
+  // Auto-reset when the entity type identity changes — DynamicForm and
+  // InlineCreateModal can be reused across form-id navigations without
+  // remounting, which would otherwise leave stale manualId/selectedPrefix
+  // visible against the new type. See code-review #9 (RR-…).
+  watch(
+    () => entityType.value,
+    (next, prev) => {
+      if (next === prev) return
+      if (!prev || !next || prev.id_type !== next.id_type) {
+        reset()
+        return
+      }
+      const prevPrefixes = (prev.id_prefixes ?? (prev.id_prefix ? [prev.id_prefix] : [])).join('|')
+      const nextPrefixes = (next.id_prefixes ?? (next.id_prefix ? [next.id_prefix] : [])).join('|')
+      if (prevPrefixes !== nextPrefixes) reset()
+    }
+  )
+
+  function buildPayloadFields(): { id?: string; prefix?: string } {
+    if (modeRef.value !== 'create') return {}
+    const out: { id?: string; prefix?: string } = {}
+    if (showManualIDInput.value && manualId.value) {
+      out.id = manualId.value
+    }
+    if (showPrefixPicker.value && selectedPrefix.value) {
+      out.prefix = selectedPrefix.value
+    }
+    return out
+  }
+
+  return {
+    prefixOptions,
+    showManualIDInput,
+    showPrefixPicker,
+    manualId,
+    selectedPrefix,
+    reset,
+    buildPayloadFields,
+  }
+}

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -20,6 +20,7 @@ export interface EntityActions {
 
 export interface CreateEntity {
   id?: string
+  prefix?: string
   properties: Record<string, unknown>
   content?: string
   relations?: Record<string, string[]>

--- a/frontend/src/types/schema.ts
+++ b/frontend/src/types/schema.ts
@@ -11,6 +11,7 @@ export interface EntityType {
   description?: string
   id_type?: 'short' | 'sequential' | 'manual'
   id_prefix?: string
+  id_prefixes?: string[]
   properties: Record<string, PropertyDef>
   default_sort?: SortSpec[]
   color?: string

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -79,6 +79,7 @@ type V1EntityType struct {
 	Primary     string                   `json:"primary,omitempty"`
 	IDType      string                   `json:"id_type,omitempty"`
 	IDPrefix    string                   `json:"id_prefix,omitempty"`
+	IDPrefixes  []string                 `json:"id_prefixes,omitempty"`
 	Properties  map[string]V1PropertyDef `json:"properties"`
 }
 
@@ -374,6 +375,7 @@ func (a *App) handleV1CreateEntity(w http.ResponseWriter, r *http.Request, typeN
 
 	var req struct {
 		ID         string                 `json:"id,omitempty"`
+		Prefix     string                 `json:"prefix,omitempty"`
 		Properties map[string]interface{} `json:"properties"`
 		Content    string                 `json:"content,omitempty"`
 		Relations  map[string][]string    `json:"relations,omitempty"`
@@ -384,13 +386,26 @@ func (a *App) handleV1CreateEntity(w http.ResponseWriter, r *http.Request, typeN
 		return
 	}
 
+	entityDef, defOK := a.State().Meta.Entities[typeName]
+	if !defOK {
+		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity type not found", typeName)
+		return
+	}
+
+	req.ID = strings.TrimSpace(req.ID)
+	req.Prefix = strings.TrimSpace(req.Prefix)
+	if msg := validateCreateIDOpts(&entityDef, req.ID, req.Prefix); msg != "" {
+		writeV1Error(w, r, http.StatusUnprocessableEntity, "validation_failed", msg, "")
+		return
+	}
+
 	createResult, err := a.entityManager.CreateEntity(r.Context(),
 		&entityPkg.Entity{
 			Type:       typeName,
 			Properties: req.Properties,
 			Content:    req.Content,
 		},
-		entitymanager.CreateOptions{ID: req.ID},
+		entitymanager.CreateOptions{ID: req.ID, Prefix: req.Prefix},
 	)
 	if err != nil {
 		writeV1Error(w, r, http.StatusUnprocessableEntity, "validation_failed", "Validation failed", err.Error())
@@ -852,8 +867,10 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 			IDType:      def.GetIDType(),
 			Properties:  make(map[string]V1PropertyDef),
 		}
-		if len(def.GetIDPrefixes()) > 0 {
-			et.IDPrefix = def.GetIDPrefixes()[0]
+		prefixes := def.GetIDPrefixes()
+		if len(prefixes) > 0 {
+			et.IDPrefix = prefixes[0]
+			et.IDPrefixes = prefixes
 		}
 		for propName, propDef := range def.Properties {
 			et.Properties[propName] = a.toV1PropertyDef(s.Meta, propDef)
@@ -920,6 +937,10 @@ func (a *App) handleV1SchemaRoutes(w http.ResponseWriter, r *http.Request) {
 			Primary:     def.GetPrimaryProperty(),
 			IDType:      def.GetIDType(),
 			Properties:  make(map[string]V1PropertyDef),
+		}
+		if prefixes := def.GetIDPrefixes(); len(prefixes) > 0 {
+			et.IDPrefix = prefixes[0]
+			et.IDPrefixes = prefixes
 		}
 		for propName, propDef := range def.Properties {
 			pd := V1PropertyDef{
@@ -1446,6 +1467,50 @@ func (a *App) computeEntityETag(e *entityPkg.Entity) string {
 
 	sum := h.Sum(nil)
 	return fmt.Sprintf("\"%s\"", base64.StdEncoding.EncodeToString(sum[:8]))
+}
+
+// validateCreateIDOpts enforces that `id` is only accepted for manual-ID types
+// and that `prefix` is only accepted for non-manual types with a known prefix.
+// For manual-ID types that declare one or more prefixes, the `id` must start
+// with one of them AND include a non-empty suffix. Surrounding whitespace on
+// the inputs is trimmed at the boundary so the error message lines up with
+// what the user actually typed. Returns an empty string when valid.
+func validateCreateIDOpts(def *metamodel.EntityDef, id, prefix string) string {
+	id = strings.TrimSpace(id)
+	prefix = strings.TrimSpace(prefix)
+
+	if id != "" && !def.IsManualID() {
+		return "id not accepted for non-manual ID type; use 'prefix' instead"
+	}
+	if id != "" && def.IsManualID() {
+		if prefixes := def.GetIDPrefixes(); len(prefixes) > 0 {
+			matched := false
+			for _, p := range prefixes {
+				// Reject the bare prefix (id == p) — the entity needs a
+				// distinguishing suffix or it conflicts with the prefix
+				// concept itself. (RR-…)
+				if strings.HasPrefix(id, p) && len(id) > len(p) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return fmt.Sprintf("id %q must start with one of %v and include a suffix", id, prefixes)
+			}
+		}
+	}
+	if prefix == "" {
+		return ""
+	}
+	if def.IsManualID() {
+		return "prefix not applicable to manual ID type"
+	}
+	for _, p := range def.GetIDPrefixes() {
+		if p == prefix {
+			return ""
+		}
+	}
+	return fmt.Sprintf("prefix %q is not valid; allowed: %v", prefix, def.GetIDPrefixes())
 }
 
 func writeV1JSON(w http.ResponseWriter, status int, data interface{}) {

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -3032,3 +3032,321 @@ func TestHandleV1Documents_EntityNotFound(t *testing.T) {
 		t.Errorf("expected 404 for missing entity, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
+
+// newPrefixTestApp builds an app whose schema includes a multi-prefix type, a
+// manual-ID type, and a single-prefix short-ID type for TKT-E7NNM tests.
+// Wires in an in-memory FS so the create path can load (absent) entity templates.
+func newPrefixTestApp(t *testing.T) *App {
+	t.Helper()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Label:    "Ticket",
+				IDType:   "short",
+				IDPrefix: "TKT-",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
+			},
+			"decision": {
+				Label:      "Decision",
+				IDType:     "short",
+				IDPrefixes: []string{"DEC-", "ADR-"},
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
+			},
+			"category": {
+				Label:  "Category",
+				IDType: "manual",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
+			},
+		},
+	}
+	cfg := &dataentryconfig.Config{
+		App:        dataentryconfig.AppConfig{Name: "Test App"},
+		Forms:      make(map[string]dataentryconfig.Form),
+		Lists:      make(map[string]dataentryconfig.List),
+		Views:      make(map[string]dataentryconfig.ViewConfig),
+		Kanbans:    make(map[string]dataentryconfig.Kanban),
+		Navigation: []dataentryconfig.NavigationEntry{},
+	}
+	app := newAppFromParts(cfg, meta, newFixture())
+	fs := storage.NewMemFS()
+	ctx := &project.Context{
+		Root:                 "/project",
+		CacheDir:             "/project/.rela",
+		EntitiesDir:          "/project/entities",
+		RelationsDir:         "/project/relations",
+		TemplatesDir:         "/project/templates",
+		EntityTemplatesDir:   "/project/templates/entities",
+		RelationTemplatesDir: "/project/templates/relations",
+	}
+	_ = fs.MkdirAll(ctx.EntitiesDir, 0o755)
+	_ = fs.MkdirAll(ctx.RelationsDir, 0o755)
+	_ = fs.MkdirAll(ctx.EntityTemplatesDir, 0o755)
+	_ = fs.MkdirAll(ctx.RelationTemplatesDir, 0o755)
+	bindRepoWithFS(app, fs, ctx)
+	app.broker = newEventBroker()
+	return app
+}
+
+// newManualPrefixedTestApp builds an app whose schema includes a manual-ID type
+// that declares a required prefix (TAG-), used to test prefix enforcement on
+// manual IDs.
+func newManualPrefixedTestApp(t *testing.T) *App {
+	t.Helper()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"tag": {
+				Label:    "Tag",
+				IDType:   "manual",
+				IDPrefix: "TAG-",
+				Properties: map[string]metamodel.PropertyDef{
+					"name": {Type: "string", Required: true},
+				},
+			},
+		},
+	}
+	cfg := &dataentryconfig.Config{
+		App:        dataentryconfig.AppConfig{Name: "Test App"},
+		Forms:      make(map[string]dataentryconfig.Form),
+		Lists:      make(map[string]dataentryconfig.List),
+		Views:      make(map[string]dataentryconfig.ViewConfig),
+		Kanbans:    make(map[string]dataentryconfig.Kanban),
+		Navigation: []dataentryconfig.NavigationEntry{},
+	}
+	app := newAppFromParts(cfg, meta, newFixture())
+	fs := storage.NewMemFS()
+	ctx := &project.Context{
+		Root:                 "/project",
+		CacheDir:             "/project/.rela",
+		EntitiesDir:          "/project/entities",
+		RelationsDir:         "/project/relations",
+		TemplatesDir:         "/project/templates",
+		EntityTemplatesDir:   "/project/templates/entities",
+		RelationTemplatesDir: "/project/templates/relations",
+	}
+	_ = fs.MkdirAll(ctx.EntitiesDir, 0o755)
+	_ = fs.MkdirAll(ctx.RelationsDir, 0o755)
+	_ = fs.MkdirAll(ctx.EntityTemplatesDir, 0o755)
+	_ = fs.MkdirAll(ctx.RelationTemplatesDir, 0o755)
+	bindRepoWithFS(app, fs, ctx)
+	app.broker = newEventBroker()
+	return app
+}
+
+func TestV1Schema_MultiPrefix(t *testing.T) {
+	app := newPrefixTestApp(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_schema", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1Schema(rec, req)
+
+	var schema V1Schema
+	if err := json.NewDecoder(rec.Body).Decode(&schema); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	dec, ok := schema.Entities["decision"]
+	if !ok {
+		t.Fatalf("decision entity missing from schema")
+	}
+	want := []string{"DEC-", "ADR-"}
+	if len(dec.IDPrefixes) != len(want) {
+		t.Fatalf("IDPrefixes = %v, want %v", dec.IDPrefixes, want)
+	}
+	for i, p := range want {
+		if dec.IDPrefixes[i] != p {
+			t.Errorf("IDPrefixes[%d] = %q, want %q", i, dec.IDPrefixes[i], p)
+		}
+	}
+}
+
+func TestV1Schema_SinglePrefix_Compat(t *testing.T) {
+	app := newPrefixTestApp(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_schema", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1Schema(rec, req)
+
+	var schema V1Schema
+	if err := json.NewDecoder(rec.Body).Decode(&schema); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	tkt, ok := schema.Entities["ticket"]
+	if !ok {
+		t.Fatalf("ticket entity missing from schema")
+	}
+	if tkt.IDPrefix != "TKT-" {
+		t.Errorf("IDPrefix = %q, want %q", tkt.IDPrefix, "TKT-")
+	}
+	if len(tkt.IDPrefixes) != 1 || tkt.IDPrefixes[0] != "TKT-" {
+		t.Errorf("IDPrefixes = %v, want [TKT-]", tkt.IDPrefixes)
+	}
+}
+
+func postCreate(t *testing.T, app *App, plural, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/"+plural, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	typeName := strings.TrimSuffix(plural, "s")
+	app.handleV1CreateEntity(rec, req, typeName, plural)
+	return rec
+}
+
+func TestV1CreateEntity_PrefixOverride(t *testing.T) {
+	app := newPrefixTestApp(t)
+
+	rec := postCreate(t, app, "decisions", `{"prefix":"ADR-","properties":{"title":"use Redis"}}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var got V1Entity
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.HasPrefix(got.ID, "ADR-") {
+		t.Errorf("ID = %q, want prefix ADR-", got.ID)
+	}
+}
+
+func TestV1CreateEntity_EmptyPrefixUsesFirst(t *testing.T) {
+	app := newPrefixTestApp(t)
+
+	rec := postCreate(t, app, "decisions", `{"properties":{"title":"use Postgres"}}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var got V1Entity
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.HasPrefix(got.ID, "DEC-") {
+		t.Errorf("ID = %q, want first prefix DEC-", got.ID)
+	}
+}
+
+func TestV1CreateEntity_UnknownPrefix(t *testing.T) {
+	app := newPrefixTestApp(t)
+
+	rec := postCreate(t, app, "decisions", `{"prefix":"XXX-","properties":{"title":"x"}}`)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "XXX-") {
+		t.Errorf("body does not mention rejected prefix: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "DEC-") {
+		t.Errorf("body does not list allowed prefixes: %s", rec.Body.String())
+	}
+}
+
+func TestV1CreateEntity_IDRejectedForNonManual(t *testing.T) {
+	app := newPrefixTestApp(t)
+
+	rec := postCreate(t, app, "tickets", `{"id":"TKT-HACKED","properties":{"title":"x"}}`)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "non-manual") {
+		t.Errorf("expected 'non-manual' in error, got: %s", rec.Body.String())
+	}
+}
+
+func TestV1CreateEntity_ManualTypeRejectsPrefix(t *testing.T) {
+	app := newPrefixTestApp(t)
+
+	rec := postCreate(t, app, "categorys", `{"id":"books","prefix":"CAT-","properties":{"title":"Books"}}`)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "prefix not applicable") {
+		t.Errorf("expected 'prefix not applicable' in error, got: %s", rec.Body.String())
+	}
+}
+
+func TestV1CreateEntity_ManualAcceptsID(t *testing.T) {
+	app := newPrefixTestApp(t)
+
+	rec := postCreate(t, app, "categorys", `{"id":"books","properties":{"title":"Books"}}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var got V1Entity
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ID != "books" {
+		t.Errorf("ID = %q, want books", got.ID)
+	}
+}
+
+// Manual-ID types with declared prefixes must reject IDs outside the allowlist.
+func TestV1CreateEntity_ManualWithPrefix_RejectsBareID(t *testing.T) {
+	app := newManualPrefixedTestApp(t)
+
+	rec := postCreate(t, app, "tags", `{"id":"books","properties":{"name":"Books"}}`)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "must start with") {
+		t.Errorf("expected 'must start with' in error, got: %s", rec.Body.String())
+	}
+}
+
+func TestV1CreateEntity_ManualWithPrefix_AcceptsPrefixedID(t *testing.T) {
+	app := newManualPrefixedTestApp(t)
+
+	rec := postCreate(t, app, "tags", `{"id":"TAG-books","properties":{"name":"Books"}}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestValidateCreateIDOpts(t *testing.T) {
+	short := &metamodel.EntityDef{IDType: "short", IDPrefixes: []string{"DEC-", "ADR-"}}
+	manual := &metamodel.EntityDef{IDType: "manual"}
+	manualPrefixed := &metamodel.EntityDef{IDType: "manual", IDPrefix: "TAG-"}
+	manualMulti := &metamodel.EntityDef{IDType: "manual", IDPrefixes: []string{"A-", "B-"}}
+
+	tests := []struct {
+		name    string
+		def     *metamodel.EntityDef
+		id      string
+		prefix  string
+		wantErr string
+	}{
+		{"short, no id/prefix", short, "", "", ""},
+		{"short, valid prefix", short, "", "ADR-", ""},
+		{"short, id set", short, "DEC-X", "", "id not accepted"},
+		{"short, unknown prefix", short, "", "X-", "not valid"},
+		{"manual, id only", manual, "custom", "", ""},
+		{"manual, prefix set", manual, "custom", "X-", "prefix not applicable"},
+		{"manual prefixed, matching id", manualPrefixed, "TAG-books", "", ""},
+		{"manual prefixed, missing prefix", manualPrefixed, "books", "", "must start with"},
+		{"manual prefixed, wrong prefix", manualPrefixed, "CAT-books", "", "must start with"},
+		{"manual multi, matches A-", manualMulti, "A-foo", "", ""},
+		{"manual multi, matches B-", manualMulti, "B-foo", "", ""},
+		{"manual multi, no match", manualMulti, "C-foo", "", "must start with"},
+		// Coverage gaps closed per code-review #10.
+		{"short, both id and prefix set — id rejection wins", short, "DEC-X", "DEC-", "id not accepted"},
+		{"manual prefixed, id matches AND prefix also set", manualPrefixed, "TAG-x", "TAG-", "prefix not applicable"},
+		{"manual prefixed, bare prefix as id", manualPrefixed, "TAG-", "", "must start with"},
+		{"manual prefixed, whitespace-only id treated as empty", manualPrefixed, "   ", "", ""},
+		{"short, whitespace prefix treated as empty", short, "", "  ", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validateCreateIDOpts(tt.def, tt.id, tt.prefix)
+			if tt.wantErr == "" && got != "" {
+				t.Errorf("got error %q, want none", got)
+			}
+			if tt.wantErr != "" && !strings.Contains(got, tt.wantErr) {
+				t.Errorf("got error %q, want containing %q", got, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/dataentry/handlers_api.go
+++ b/internal/dataentry/handlers_api.go
@@ -336,7 +336,8 @@ func writeJSONError(w http.ResponseWriter, status int, message string) {
 
 // APICreateEntityRequest is the request body for creating an entity.
 type APICreateEntityRequest struct {
-	ID         string                 `json:"id,omitempty"` // Optional, auto-generated if empty
+	ID         string                 `json:"id,omitempty"`     // Optional, auto-generated unless type uses manual IDs
+	Prefix     string                 `json:"prefix,omitempty"` // Optional prefix override for multi-prefix types
 	Type       string                 `json:"type"`
 	Properties map[string]interface{} `json:"properties"`
 	Content    string                 `json:"content,omitempty"`
@@ -377,13 +378,27 @@ func (a *App) handleAPICreateEntity(w http.ResponseWriter, r *http.Request) {
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
+	entityDef, defOK := a.State().Meta.Entities[req.Type]
+	if !defOK {
+		writeJSONError(w, http.StatusBadRequest, "unknown entity type: "+req.Type)
+		return
+	}
+	req.ID = strings.TrimSpace(req.ID)
+	req.Prefix = strings.TrimSpace(req.Prefix)
+	// Use 422 — body parsed cleanly but failed a semantic rule. Matches the
+	// v1 handler's choice and the new validateCreateIDOpts contract.
+	if msg := validateCreateIDOpts(&entityDef, req.ID, req.Prefix); msg != "" {
+		writeJSONError(w, http.StatusUnprocessableEntity, msg)
+		return
+	}
+
 	newEntity := &entity.Entity{
 		ID:         req.ID,
 		Type:       req.Type,
 		Properties: req.Properties,
 		Content:    req.Content,
 	}
-	result, err := a.entityManager.CreateEntity(r.Context(), newEntity, entitymanager.CreateOptions{ID: req.ID})
+	result, err := a.entityManager.CreateEntity(r.Context(), newEntity, entitymanager.CreateOptions{ID: req.ID, Prefix: req.Prefix})
 	if err != nil {
 		var valErr *workspace.ValidationError
 		if errors.As(err, &valErr) {

--- a/internal/dataentry/handlers_api_test.go
+++ b/internal/dataentry/handlers_api_test.go
@@ -286,6 +286,63 @@ func TestHandleAPIEntities(t *testing.T) {
 	})
 }
 
+// TestHandleAPICreateEntity_IDValidation pins down the legacy /api/entities
+// POST validation behavior so it can't silently drift away from the v1
+// handler. Mirrors validateCreateIDOpts but at the HTTP boundary, since the
+// legacy path used to silently honor `id` for any entity type. (RR-…)
+func TestHandleAPICreateEntity_IDValidation(t *testing.T) {
+	app, _ := testAppInstance()
+
+	t.Run("rejects id for non-manual type with 422", func(t *testing.T) {
+		body := `{"type":"ticket","id":"TKT-CUSTOM","properties":{"title":"x"}}`
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/api/entities", strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+		app.handleAPICreateEntity(w, r)
+
+		if w.Code != http.StatusUnprocessableEntity {
+			t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "id not accepted") {
+			t.Errorf("expected 'id not accepted' in body, got: %s", w.Body.String())
+		}
+	})
+
+	t.Run("rejects unknown prefix for non-manual type with 422", func(t *testing.T) {
+		body := `{"type":"ticket","prefix":"XYZ-","properties":{"title":"x"}}`
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/api/entities", strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+		app.handleAPICreateEntity(w, r)
+
+		if w.Code != http.StatusUnprocessableEntity {
+			t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "is not valid") {
+			t.Errorf("expected 'is not valid' in body, got: %s", w.Body.String())
+		}
+	})
+
+	t.Run("trims whitespace before validating", func(t *testing.T) {
+		body := `{"type":"ticket","id":"  TKT-X  ","properties":{"title":"x"}}`
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/api/entities", strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+		app.handleAPICreateEntity(w, r)
+
+		// After trim, "TKT-X" is rejected because ticket is non-manual.
+		// The point of this test is that whitespace doesn't change the
+		// rejection — pre-trim it would also reject, but with a misleading
+		// error referencing the leading-space form.
+		if w.Code != http.StatusUnprocessableEntity {
+			t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
+		}
+		if strings.Contains(w.Body.String(), `  TKT-X  `) {
+			t.Errorf("error message should not echo the untrimmed input: %s", w.Body.String())
+		}
+	})
+}
+
 func TestHandleAPIEntity(t *testing.T) {
 	app, _ := testAppInstance()
 

--- a/internal/entitymanager/entitymanager.go
+++ b/internal/entitymanager/entitymanager.go
@@ -20,6 +20,10 @@ import (
 type CreateOptions struct {
 	// ID is an optional explicit ID. If empty, the manager generates one.
 	ID string
+	// Prefix overrides the default ID prefix when the entity type declares
+	// multiple via `id_prefixes`. Ignored when ID is set or when the entity
+	// type uses manual IDs.
+	Prefix string
 	// Variant selects an entity template variant (empty = default).
 	Variant string
 	// SkipAutomation suppresses on-create automations. Defaults to false.

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -30,6 +30,7 @@ func (m *wsEntityManager) CreateEntity(
 
 	createOpts := CreateOptions{
 		ID:         opts.ID,
+		Prefix:     opts.Prefix,
 		Properties: e.Properties,
 		Content:    e.Content,
 	}

--- a/prototypes/data-entry/project/data-entry.yaml
+++ b/prototypes/data-entry/project/data-entry.yaml
@@ -210,6 +210,31 @@ forms:
       - property: name
         label: "Label Name"
         placeholder: "e.g., bug, enhancement, urgent"
+  create_tag:
+    entity_type: tag
+    title: "New Tag"
+    description: "Create a tag with a manual ID"
+    fields:
+      - property: name
+        label: "Tag Name"
+  create_decision:
+    entity_type: decision
+    title: "New Decision"
+    description: "Record a design decision (DEC-) or architecture decision record (ADR-)"
+    fields:
+      - property: title
+  create_module:
+    entity_type: module
+    title: "New Module"
+    description: "Create a module with a manual ID. IDs must start with MOD-."
+    fields:
+      - property: name
+  create_specification:
+    entity_type: specification
+    title: "New Specification"
+    description: "Create a spec with a manual ID. IDs must start with RFC- or SPEC-."
+    fields:
+      - property: name
 actions:
   resolve-ticket:
     label: "Resolve"

--- a/prototypes/data-entry/project/metamodel.yaml
+++ b/prototypes/data-entry/project/metamodel.yaml
@@ -55,6 +55,37 @@ entities:
       name:
         type: string
         required: true
+  tag:
+    label: Tag
+    id_type: manual
+    properties:
+      name:
+        type: string
+        required: true
+  decision:
+    label: Decision
+    id_prefixes: ["DEC-", "ADR-"]
+    id_type: sequential
+    properties:
+      title:
+        type: string
+        required: true
+  module:
+    label: Module
+    id_type: manual
+    id_prefix: "MOD-"
+    properties:
+      name:
+        type: string
+        required: true
+  specification:
+    label: Specification
+    id_type: manual
+    id_prefixes: ["RFC-", "SPEC-"]
+    properties:
+      name:
+        type: string
+        required: true
 relations:
   belongs-to:
     label: belongs to

--- a/tickets/entities/implementation-checklists/IMPL-4J1YO.md
+++ b/tickets/entities/implementation-checklists/IMPL-4J1YO.md
@@ -1,0 +1,70 @@
+---
+id: IMPL-4J1YO
+type: implementation-checklist
+title: 'Implementation: Data-entry create form: prefix picker for multi-prefix types and manual ID field'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Backend (Go):
+- `go test ./internal/dataentry/` — all 164 tests pass including 8 new tests covering schema exposure of `id_prefixes`, prefix override, empty prefix fallback, unknown-prefix 422 (with message listing allowed prefixes), manual-ID accept, manual-type rejects prefix, non-manual rejects id, and `validateCreateIDOpts` table-driven.
+- `go test ./internal/workspace/` + `./internal/entitymanager/` — all pass; the new `Prefix` field on `entitymanager.CreateOptions` is wired through `wsEntityManager.CreateEntity` into `workspace.CreateOptions.Prefix`.
+- `just lint` — clean.
+- `go test -cover ./internal/dataentry/` — 61.5% (well above 55% floor); `validateCreateIDOpts` at 100%, `handleV1CreateEntity` at 81.8%.
+
+Frontend (TS/Vue):
+- `npm run typecheck` — clean.
+- `npm run lint` — clean (only pre-existing warnings).
+- `npm run test:run` — all 434 tests pass including 16 new tests for `useEntityIDControls` covering all mode/id_type/prefix combinations.
+
+Acceptance criteria verified:
+- AC1 (multi-prefix picker shown): component-tested in `useEntityIDControls.test.ts` `is true for multi-prefix non-manual types in create mode`; E2E added as `Multi-Prefix Create Form › shows prefix picker and creates entity with chosen prefix`.
+- AC2 (single-prefix no picker): component-tested in `useEntityIDControls.test.ts` `is false for single-prefix types`; E2E `does not show prefix picker for single-prefix ticket form`.
+- AC3 (manual-ID create + edit read-only): E2E added as `Manual-ID Create Form › renders ID input and creates tag with user-supplied ID`; `showReadOnlyID` computed in DynamicForm.vue guarded by `isEdit && id_type === 'manual'` — verified via code inspection since no manual-ID edit fixture entity exists in E2E suite.
+- AC4 (id_prefixes exposed; id_prefix preserved): `TestV1Schema_MultiPrefix` + `TestV1Schema_SinglePrefix_Compat` both pass.
+- AC5 (prefix validation): `TestV1CreateEntity_PrefixOverride`, `TestV1CreateEntity_UnknownPrefix`, `TestV1CreateEntity_IDRejectedForNonManual`, `TestV1CreateEntity_EmptyPrefixUsesFirst`, `TestV1CreateEntity_ManualTypeRejectsPrefix`, `TestV1CreateEntity_ManualAcceptsID` — all pass.
+
+Edge cases:
+- Manual-ID + declared id_prefixes → picker NOT shown, server rejects prefix: tested in both unit (`is false for manual types even when id_prefixes has multiple entries`) and handler (`TestV1CreateEntity_ManualTypeRejectsPrefix`).
+- Empty prefix falls back to first: `TestV1CreateEntity_EmptyPrefixUsesFirst`.
+- ID rejected for non-manual: `TestV1CreateEntity_IDRejectedForNonManual`.
+- Error message lists allowed prefixes: assertion in `TestV1CreateEntity_UnknownPrefix`.
+
+Known E2E caveat: the shared `frontend/e2e/fixtures.ts` has a pre-existing
+broken import (`GraphPage` not exported since #397 removed the graph
+visualizer). This prevents ALL e2e tests from running locally, not just the new
+ones. The new e2e test code is syntactically valid and uses the existing
+`pages.form()` / `api.*` fixtures; it will run once the pre-existing `GraphPage`
+import is cleaned up (separate ticket).
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-TFQC4.md
+++ b/tickets/entities/planning-checklists/PLAN-TFQC4.md
@@ -1,0 +1,236 @@
+---
+id: PLAN-TFQC4
+type: planning-checklist
+title: 'Planning: Data-entry create form: prefix picker for multi-prefix types and manual ID field'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+In scope:
+- `entitymanager.CreateOptions`: add `Prefix string` field (RR-8D8X3).
+- `workspace/manager.go wsEntityManager.CreateEntity`: forward `opts.Prefix` to `workspace.CreateOptions.Prefix` (RR-8D8X3).
+- `V1EntityType` JSON: expose full `id_prefixes` list (not just first).
+- `handleV1CreateEntity`: accept optional `prefix` field in request body; validate it (see Security Considerations); reject `id` for non-manual types (RR-BJW16).
+- `frontend/src/types/schema.ts`: add `id_prefixes?: string[]` to `EntityType`.
+- `InlineCreateModal.vue`: show prefix picker when `id_type !== 'manual' && id_prefixes.length > 1` (RR-2R1HG).
+- `DynamicForm.vue`: show manual-ID text field (create mode only) when `id_type === 'manual'`; show prefix picker when `id_type !== 'manual' && id_prefixes.length > 1` (RR-6GPR4, RR-2R1HG).
+- Unit tests for the Go handler + Vue components.
+- One E2E test covering manual ID and multi-prefix flows (requires extending the e2e fixture metamodel).
+
+Out of scope:
+- Server-side rendering / HTMX legacy templates in `internal/dataentry/templates/` — v2 Vue SPA is the only path.
+- Changes to `workspace.Workspace.GenerateID` (already supports prefix override).
+- Manual-ID validation beyond "required, non-empty" (pattern validation is a separate feature via custom types; surfacing the metamodel-defined pattern as a form hint is deferred — see RR-M1TIC).
+- Changing how existing single-prefix types render (must stay the same).
+- Rename-in-edit-mode for manual-ID types (covered by FEAT-016; edit form shows ID as read-only display, no input, no rename support here — RR-6GPR4).
+
+**Acceptance Criteria:**
+
+1. Multi-prefix, non-manual types show picker in `DynamicForm.vue` and `InlineCreateModal.vue`.
+   - Test: e2e metamodel has a type with `id_prefixes: ["A-", "B-"]`; the form shows a `<select>` with two options; selecting "B-" then submitting creates an ID starting with `B-`.
+2. Single-prefix types do NOT show a picker.
+   - Test: unit/component test against the existing `ticket` type (`id_prefix: "TKT-"`) asserts the picker element is absent.
+3. Manual-ID types: show editable ID field in CREATE mode; show read-only ID display in EDIT mode; never show prefix picker (RR-6GPR4, RR-2R1HG).
+   - Test: e2e visits a create form whose entity type has `id_type: manual`, types "custom-123", submits, verifies entity is created at `/entity/<type>/custom-123`. Component test for `DynamicForm` in edit mode asserts ID is rendered as `<div class="id-display">` or similar (not `<input>`).
+4. Backend exposes `id_prefixes`; single-prefix types still expose `id_prefix` for back-compat (RR-M0LIU).
+   - Test: `TestV1Schema_MultiPrefix` asserts `id_prefixes: ["A-", "B-"]` for multi-prefix type; `TestV1Schema_SinglePrefix_Compat` asserts a single-prefix type returns BOTH `id_prefix: "TKT-"` AND `id_prefixes: ["TKT-"]`.
+5. Backend create handler validates `prefix` and `id` against entity type (RR-3GURO, RR-BJW16).
+   - Test: `TestV1CreateEntity_PrefixOverride` posts `{prefix: "B-"}` against a multi-prefix type, asserts response ID starts with `B-`.
+   - Test: `TestV1CreateEntity_UnknownPrefix` posts `{prefix: "UNKNOWN-"}`, asserts 422 with message listing allowed prefixes.
+   - Test: `TestV1CreateEntity_IDRejectedForNonManual` posts `{id: "TKT-HACKED"}` against a short-ID type, asserts 422.
+   - Test: `TestV1CreateEntity_EmptyPrefixUsesFirst` posts without `prefix`, asserts ID uses first prefix.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+- No external library — this is project-specific form UX.
+- `workspace.Workspace.GenerateID(entityType, prefix)` (`internal/workspace/workspace.go:675-698`) accepts a prefix override; `workspace.CreateOptions.Prefix` exists and is plumbed through `createEntity` → `createEntityCore`. But no caller currently sets it — it's dead code today.
+- `entitymanager.CreateOptions` (`internal/entitymanager/entitymanager.go:20-27`) does NOT have `Prefix`; the workspace adapter (`internal/workspace/manager.go:31-36`) does NOT forward it. **Both must be added** (RR-8D8X3).
+- `metamodel.EntityDef.GetIDPrefixes()` (`internal/metamodel/entity_def.go:134`) returns the normalized list of prefixes. `EntityDef.IsManualID()` (`:122`) is the gate for manual ID.
+- `InlineCreateModal.vue:30-32, 121-123, 156-167` already handles `id_type === 'manual'`: conditional `<input>` + sets `payload.id`. Pattern reusable in `DynamicForm.vue`.
+- `InlineCreateModal.vue` is invoked from `RelationPicker.vue` (inline-create-from-picker flow). The prefix picker makes sense there too — the user is creating a new target entity and still needs to pick which prefix (RR-KY4RI).
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Backend (Go):
+
+1. `internal/entitymanager/entitymanager.go`: add `Prefix string` to `CreateOptions`, documented as "Overrides default ID prefix (ignored when ID is set or type is manual)".
+2. `internal/workspace/manager.go` `wsEntityManager.CreateEntity`: set `createOpts.Prefix = opts.Prefix`.
+3. `internal/dataentry/api_v1.go`:
+   - Add `IDPrefixes []string \`json:"id_prefixes,omitempty"\``to`V1EntityType`; keep `IDPrefix` (populated with first prefix for compat).
+   - In `handleV1Schema`, populate `et.IDPrefixes = def.GetIDPrefixes()` always.
+   - In `handleV1CreateEntity`:
+     - Decode `req.Prefix string \`json:"prefix,omitempty"\``.
+     - Look up `entityDef, ok := s.Meta.GetEntityDef(typeName)` (already in scope via `a.State()`).
+     - Validation (RR-3GURO, RR-BJW16), BEFORE calling entityManager.CreateEntity:
+       - If `req.ID != ""` and `!entityDef.IsManualID()`: 422 `"id not accepted for non-manual ID type; use 'prefix' instead"`.
+       - If `req.Prefix != ""`:
+         - If `entityDef.IsManualID()`: 422 `"prefix not applicable to manual ID type"`.
+         - If `req.Prefix` not in `entityDef.GetIDPrefixes()`: 422 `"prefix '<x>' is not valid for type <type>; allowed: [...]"`.
+     - Pass `entitymanager.CreateOptions{ID: req.ID, Prefix: req.Prefix}`.
+4. `internal/dataentry/handlers_api.go` (legacy `handleAPICreateEntity` at `:359`): apply the same `req.ID` rejection for non-manual types for consistency (already-existing pre-existing risk; mention in commit, small blast radius).
+
+Frontend (TS/Vue):
+
+1. `frontend/src/types/schema.ts`: add `id_prefixes?: string[]` to `EntityType`.
+2. `frontend/src/types/entity.ts`: add `prefix?: string` to `CreateEntity`.
+3. Extract shared composable `useEntityIDControls(entityType, mode)` in `frontend/src/composables/useEntityIDControls.ts`:
+   - Returns `{ showManualIDInput, showPrefixPicker, prefixOptions, manualId, selectedPrefix, buildPayloadFields() }`.
+   - `showManualIDInput = mode === 'create' && entityType.id_type === 'manual'`.
+   - `showPrefixPicker = mode === 'create' && entityType.id_type !== 'manual' && prefixOptions.length > 1`.
+   - `prefixOptions = entityType.id_prefixes ?? (entityType.id_prefix ? [entityType.id_prefix] : [])`.
+4. `InlineCreateModal.vue`: use the composable; replace existing manualId ref; render `<select>` under "Prefix" label when `showPrefixPicker`.
+5. `DynamicForm.vue`: use the composable; in create mode render manual-ID input OR prefix picker; in edit mode for manual-ID types render a read-only `<div class="id-display">{{ props.entityId }}</div>` under the "ID" label, with a small helper note "IDs cannot be changed here; use rename." (RR-6GPR4).
+6. API wiring: `entitiesStore.create` already accepts the payload; just pass `prefix` and `id` through.
+
+Alternatives considered:
+- Radio buttons vs `<select>`: `<select>` matches existing enum-field UX, less visual noise. Rejected radio.
+- Letting the client compute the generated ID and sending the full ID: violates single-source-of-truth. Rejected.
+- Adding prefix validation to `workspace.GenerateID` instead of the handler: would leak workspace errors with less context. Handler-level validation gives clearer 422 messages. Rejected.
+- Duplicating the computed logic in each component (not extracting a composable): would diverge over time. Rejected.
+
+**Files to modify:**
+
+- `internal/entitymanager/entitymanager.go` (add Prefix to CreateOptions)
+- `internal/workspace/manager.go` (forward Prefix)
+- `internal/dataentry/api_v1.go` (V1EntityType + handleV1CreateEntity validation)
+- `internal/dataentry/api_v1_test.go` (new tests)
+- `internal/dataentry/handlers_api.go` (apply same id-rejection rule)
+- `frontend/src/types/schema.ts` (add id_prefixes)
+- `frontend/src/types/entity.ts` (add prefix? to CreateEntity)
+- `frontend/src/composables/useEntityIDControls.ts` (NEW)
+- `frontend/src/components/forms/InlineCreateModal.vue` (use composable, prefix picker)
+- `frontend/src/components/forms/DynamicForm.vue` (use composable, manual ID + prefix picker)
+- `frontend/src/components/forms/__tests__/InlineCreateModal.test.ts` (new or extend)
+- `frontend/src/components/forms/__tests__/DynamicForm.test.ts` (new or extend)
+- `prototypes/data-entry/project/metamodel.yaml` (add manual-ID and multi-prefix type for E2E)
+- `prototypes/data-entry/project/data-entry.yaml` (add forms for the new types)
+- `frontend/e2e/forms.spec.ts` (new tests)
+- `docs/metamodel.md` (note about multi-prefix picker in data-entry UI)
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- `req.prefix`: user-submitted string. **Allowlist validation in the HTTP handler** against `entityDef.GetIDPrefixes()` (RR-3GURO). Empty string is allowed and falls back to the first prefix. For manual-ID types, any non-empty prefix is a 422. Unknown prefix is a 422 with a specific message listing allowed prefixes.
+- `req.id`: user-submitted string. **Only accepted when `entityDef.IsManualID()`** (RR-BJW16). For non-manual types, any non-empty `id` is a 422 `"id not accepted for non-manual ID type"`. For manual types, workspace's duplicate check (`workspace.go:737`) and any custom-type pattern validation take over. Empty ID for manual types remains 422 from workspace.
+- Schema fetch/entity create race: acceptable. If the metamodel changes between schema fetch and create, the user sees a clean 422 on submit. No defensive fetch needed (RR-6HR8S).
+
+**Security-Sensitive Operations:**
+
+- Entity file writes: already handled by workspace under `a.writeMu`. No new file-system surface.
+- No auth changes; same-origin local server — existing `FEAT-ESLP` posture still applies.
+- Prefix/ID allowlist prevents writing entities outside the schema's declared prefixes.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Test |
+|----|------|
+| 1  | E2E: multi-prefix type in project fixture, form shows `<select>`, submit with prefix "B-", assert created ID starts with `B-`. |
+| 2  | Component test: render `InlineCreateModal` with a single-prefix type, assert prefix `<select>` is absent. |
+| 3  | E2E: manual-ID type form, fill ID, submit, redirected to entity page. Component test for `DynamicForm` in edit mode asserts ID is read-only `<div>`, not input. |
+| 4  | Go: `TestV1Schema_MultiPrefix` + `TestV1Schema_SinglePrefix_Compat` (RR-M0LIU). |
+| 5  | Go: `TestV1CreateEntity_PrefixOverride`, `TestV1CreateEntity_UnknownPrefix`, `TestV1CreateEntity_IDRejectedForNonManual`, `TestV1CreateEntity_EmptyPrefixUsesFirst`, `TestV1CreateEntity_ManualIDEmpty`, `TestV1CreateEntity_ManualTypeRejectsPrefix`. |
+
+**Edge Cases:**
+
+- Empty `id_prefixes` at metamodel level (caught at metamodel load; not a runtime concern).
+- Manual-ID types that ALSO declare `id_prefixes`: prefix picker must NOT render (RR-2R1HG); backend rejects `prefix` (RR-BJW16).
+- Whitespace-only manual ID: browser `required` + server check; stays 422.
+- Empty `prefix` for multi-prefix types: fall back to first prefix (legacy-client compatible).
+- Unknown prefix: 422 listing allowed prefixes.
+- Edit-mode for manual-ID types: read-only display, no input, no rename (RR-6GPR4).
+- Race: metamodel changed on disk → stale select options → submit → clean 422 (RR-6HR8S).
+
+**Negative Tests:**
+
+- Go: `TestV1CreateEntity_UnknownPrefix` — POST `{prefix: "UNKNOWN-"}` → 422.
+- Go: `TestV1CreateEntity_IDRejectedForNonManual` — POST `{id: "TKT-X"}` for short-ID type → 422.
+- Go: `TestV1CreateEntity_ManualTypeRejectsPrefix` — POST `{prefix: "X-"}` for manual-ID type → 422.
+- Go: `TestV1CreateEntity_ManualIDEmpty` — POST without `id` for manual-ID type → 422 from workspace.
+- Component: submitting manual-ID form with empty ID is blocked by `required` attribute.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Mitigation |
+|------|------------|
+| Breaking existing single-prefix forms. | Picker only renders when `> 1` prefix AND non-manual. All existing fixtures keep singular `id_prefix`; back-compat test verifies both JSON fields populated (RR-M0LIU). |
+| Data-entry E2E fixture requires adding a manual-ID and multi-prefix type; risk of breaking unrelated e2e tests that depend on the fixture shape. | Add new types alongside existing `ticket`/`category`/`label`; don't modify them. |
+| Frontend reactivity: selectedPrefix default must re-initialize when the modal reopens for a different type. | Extracted composable resets state on `onMounted` / watch on entityType; unit-tested. |
+| `handleAPICreateEntity` (legacy endpoint) pre-existing issue of accepting `id` for non-manual types. | Fix in same PR for consistency; small behaviour change, documented in commit message. |
+| Adding `Prefix` to `entitymanager.CreateOptions` breaks other callers that construct zero-value. | Zero value is "no override" → same as today. No call sites need changes except the two we update. Compiler would catch any issue. |
+
+Effort: **m** (~1 day backend incl. entitymanager plumbing + ~1 day frontend
+incl. composable extraction + tests).
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] User guide / reference docs — `docs/metamodel.md` add a short note that the data-entry UI now supports picking among declared prefixes.
+- [x] ~~CLI help text~~ (N/A: no CLI changes)
+- [x] ~~CLAUDE.md~~ (N/A: no new patterns worth noting at project level)
+- [x] ~~README.md~~ (N/A: no README-level changes)
+- [x] API docs — `id_prefixes` and `prefix` request field are new schema surface; verify OpenAPI (if auto-generated) reflects them during implementation.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+
+- RR-8D8X3 (critical, addressed): entitymanager.CreateOptions.Prefix added + forwarded in wsEntityManager.
+- RR-3GURO (critical, addressed): explicit allowlist validation in `handleV1CreateEntity` with specific 422 message.
+- RR-BJW16 (significant, addressed): `req.id` rejected for non-manual types; `req.prefix` rejected for manual types.
+- RR-6GPR4 (significant, addressed): edit-mode renders read-only ID display; no rename implied.
+- RR-M1TIC (minor, deferred): ID pattern hint deferred as separate work; not blocking here. Noted in scope.
+- RR-6HR8S (minor, addressed): stale-prefix handling documented as "accept clean 422 on submit".
+- RR-2R1HG (minor, addressed): picker suppressed for manual-ID types in AC 3 and scope.
+- RR-M0LIU (minor, addressed): explicit back-compat test added.
+- RR-KY4RI (nit, addressed): InlineCreateModal invocation via RelationPicker confirmed; picker UX applies uniformly.

--- a/tickets/entities/review-checklists/REV-Y4YC3.md
+++ b/tickets/entities/review-checklists/REV-Y4YC3.md
@@ -1,0 +1,66 @@
+---
+id: REV-Y4YC3
+type: review-checklist
+title: 'Review: Data-entry create form: prefix picker for multi-prefix types and manual ID field'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — Go `go test ./...` green; frontend `npm run test:run` 498/498 passing.
+- [x] Lint clean (`just lint`) — Go lint passes; e2e ESLint passes (POP-enforcement rule satisfied via new `FormPage` methods).
+- [x] Coverage maintained (`just coverage-check`) — `internal/dataentry` package floor still ≥55% after additions.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent) — produced 24 findings on 2026-04-25.
+- [x] ~~All critical review-responses addressed~~ (N/A: zero critical findings)
+- [x] All significant review-responses addressed — 6 of 10 fixed in code; 4 deferred with documented reasons (see RR-GQ5S8, RR-R8W1A, RR-SAIFO, RR-O1UMW).
+- [x] Self-reviewed the diff for unrelated changes — diff is scoped to TKT-E7NNM acceptance criteria.
+
+**Review Responses:**
+
+Original design-review (pre-implementation, from PLAN-TFQC4):
+RR-2R1HG, RR-3GURO, RR-6GPR4, RR-6HR8S, RR-8D8X3, RR-BJW16, RR-KY4RI, RR-M0LIU, RR-M1TIC.
+
+Code-review (post-implementation, 2026-04-25):
+RR-T0H90, RR-15SU1, RR-764AR, RR-O0ZGM, RR-GQ5S8, RR-R8W1A, RR-SAIFO, RR-O1UMW, RR-8EVKJ, RR-V6IVL,
+RR-ODPMN, RR-7505O, RR-WI06C, RR-V6WV6, RR-1G4EK, RR-87ICD, RR-CH13R,
+RR-4J6HA, RR-RQVPW, RR-RYW1R, RR-8G6D7, RR-PROV0, RR-8T3VM, RR-RN5D5.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist) — see status block below.
+- [x] Test evidence documented in implementation checklist — IMPL-4J1YO covers each AC with the corresponding test.
+
+**Acceptance Status:**
+
+1. Multi-prefix non-manual types show picker — PASS. Pinned by `TestV1Schema_MultiPrefix`, `TestV1CreateEntity_PrefixOverride`, and e2e `Multi-Prefix Create Form > shows prefix picker and creates entity with chosen prefix`.
+2. Single-prefix types do NOT show a picker — PASS. Pinned by composable test `is false for single-prefix types` and e2e `does not show prefix picker for single-prefix feature form`.
+3. Manual-ID types: editable ID field in CREATE, read-only in EDIT — PASS. Composable tests `is true for manual type in create mode` / `is false for manual type in edit mode`; e2e `Manual-ID Create Form > renders ID input and creates tag with user-supplied ID` and `edit mode does not show prefix picker`.
+4. Backend exposes `id_prefixes`; single-prefix types still expose `id_prefix` for back-compat — PASS. `TestV1Schema_SinglePrefix_Compat` asserts both fields populated.
+5. Backend create handler validates `prefix` and `id` against entity type — PASS. 17-row `TestValidateCreateIDOpts` covers the matrix; `TestV1CreateEntity_*` covers the HTTP boundary; `TestHandleAPICreateEntity_IDValidation` (added per RR-T0H90) covers the legacy `/api/entities` path.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: documentation impact is one paragraph in `docs/metamodel.md`; no DOCS-xxxx warranted)
+- [x] User-facing documentation updated — `docs/metamodel.md` notes the new prefix-picker UX.
+- [x] ~~Docs-checklist marked as done~~ (N/A: no docs-checklist created)
+
+**Docs Checklist:** N/A
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what — main commit body covers prefix-picker and manual-ID rationale; follow-up commits cover the rebase merge fixes and code-review responses.
+- [x] No TODOs or FIXMEs left unaddressed — `grep -rn 'TODO\|FIXME' frontend/src/composables/useEntityIDControls* internal/dataentry/api_v1.go internal/dataentry/handlers_api.go` returns nothing in changed code.
+- [x] Ready for another developer to use — the composable is self-contained and the page-object methods on `FormPage` are reusable for future ID/prefix UI tests.
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI — PR #555 already open, CI being walked to green.
+- [x] All CI checks pass — Lint, Lint Markdown, Test, Frontend, Architecture, E2E, Fuzz, Vulnerability Check, CodeQL all green; Rela Tickets becomes green when this checklist + ticket flip to `done`.
+- [x] PR URL documented below
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/555

--- a/tickets/entities/review-responses/RR-15SU1.md
+++ b/tickets/entities/review-responses/RR-15SU1.md
@@ -1,0 +1,9 @@
+---
+id: RR-15SU1
+type: review-response
+title: Legacy handler used 400 instead of 422 for the same validation failure
+finding: handleAPICreateEntity (handlers_api.go:387) returned http.StatusBadRequest (400) for validateCreateIDOpts failures, while the v1 handler returns 422. 400 means malformed request; the body here is well-formed JSON failing a semantic rule. The two endpoints disagreed on status for identical inputs.
+severity: significant
+resolution: Switched legacy handler to http.StatusUnprocessableEntity (422) at handlers_api.go to align with the v1 handler. Documented the choice in a code comment.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-1G4EK.md
+++ b/tickets/entities/review-responses/RR-1G4EK.md
@@ -1,0 +1,9 @@
+---
+id: RR-1G4EK
+type: review-response
+title: 'No composable test for id_type: sequential'
+finding: 'useEntityIDControls has no unit test for id_type: sequential combined with multi-prefix. The composable handles it correctly via the !isManual branch, but the case isn''t pinned by a test.'
+severity: minor
+reason: showPrefixPicker is gated by `mode === 'create' && !isManual.value && prefixOptions.value.length > 1`. The 'short, multi-prefix' tests in the same file already cover the !isManual + multi-prefix path, since the composable's logic does not branch on short vs sequential. Adding a row that only differs by id_type string would be testing string equality rather than behavior. The prototype-only sequential+multi-prefix question is tracked in RR-R8W1A.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-2R1HG.md
+++ b/tickets/entities/review-responses/RR-2R1HG.md
@@ -1,0 +1,9 @@
+---
+id: RR-2R1HG
+type: review-response
+title: Acceptance criteria don't cover read-only 'prefix picker' state for single-prefix
+finding: 'Criterion 1 says ''multi-prefix types show picker''. Criterion 2 says ''single-prefix types do NOT show a picker''. But there''s a third state — types with `id_type: manual` (which have prefixes too, per the validate test at metamodel/validation_test.go). Should the picker show for manual-ID types? Answer is no (the ID is fully user-supplied), but the plan doesn''t state that explicitly. Add to plan: ''prefix picker is only shown when id_type != manual AND id_prefixes.length > 1.'''
+severity: minor
+resolution: Plan's acceptance criteria and composable spec now guard picker with `id_type !== 'manual' && id_prefixes.length > 1`. Edge cases section covers the manual-with-declared-prefixes case.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3GURO.md
+++ b/tickets/entities/review-responses/RR-3GURO.md
@@ -1,0 +1,9 @@
+---
+id: RR-3GURO
+type: review-response
+title: 'Prefix validation: plan says ''allowlist'' but handler never sees entityDef'
+finding: 'The plan mandates validating `req.prefix` against `entityDef.GetIDPrefixes()` as an allowlist. However, `handleV1CreateEntity` in api_v1.go:370 is called via the single-type route dispatch and does not currently load the EntityDef. The plan must specify WHERE validation happens: either (a) in the handler before calling entityManager.CreateEntity (explicit 422 with clear message), or (b) add validation inside `workspace.GenerateID` which errors on unknown prefix for known types. Option (a) is cleaner because the error message can be specific (`''{prefix}'' is not a valid prefix for type {type}; allowed: [...]`). If we only rely on `GenerateID`, it will happily generate `UNKNOWN-abc` IDs because it just prepends the string. Specify which path is taken.'
+severity: critical
+resolution: 'Plan now specifies option (a): validation in `handleV1CreateEntity` BEFORE calling entityManager.CreateEntity. Validation uses `entityDef.GetIDPrefixes()` as allowlist; 422 with explicit message listing allowed prefixes.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-4J6HA.md
+++ b/tickets/entities/review-responses/RR-4J6HA.md
@@ -1,0 +1,9 @@
+---
+id: RR-4J6HA
+type: review-response
+title: CreateOptions.Prefix comment reads awkwardly across layers
+finding: 'internal/entitymanager/entitymanager.go: comment says ''Ignored when ID is set or when the entity type uses manual IDs'' — the second clause is the opposite of what validateCreateIDOpts now does (it rejects, not ignores). The comment is accurate for the workspace layer it lives in but inconsistent with API-layer behavior above.'
+severity: nit
+reason: 'The comment describes the workspace-layer contract honestly: at that layer, prefix IS ignored for manual IDs (the workspace doesn''t run validateCreateIDOpts). Adding a cross-reference to API-layer rejection would couple the two layers in documentation. The reader expected to know about the validator is the API handler author, not consumers of CreateOptions — they get the rejection at the HTTP boundary.'
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-6GPR4.md
+++ b/tickets/entities/review-responses/RR-6GPR4.md
@@ -1,0 +1,9 @@
+---
+id: RR-6GPR4
+type: review-response
+title: Manual-ID edit-mode behavior for DynamicForm not fully specified
+finding: 'The plan says ''Manual-ID field is read-only in edit mode'' but DynamicForm currently renders nothing for ID in either create or edit. The plan needs to specify: (a) in edit mode, show the ID as a disabled/read-only text display (for visual consistency with create), OR (b) don''t render it at all. Just saying ''read-only'' is ambiguous. Also: DynamicForm is instantiated by `/form/:id/:entityId?`—if entityId is present (edit mode) AND the type is manual, we should NOT show an editable input because that would imply rename, which is a separate feature (FEAT-016).'
+severity: significant
+resolution: 'Plan now specifies: create mode = editable input; edit mode = read-only `<div class="id-display">` with helper text pointing to rename feature. Rename behavior explicitly out of scope (deferred to FEAT-016). AC3 updated with matching component test.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-6HR8S.md
+++ b/tickets/entities/review-responses/RR-6HR8S.md
@@ -1,0 +1,9 @@
+---
+id: RR-6HR8S
+type: review-response
+title: 'Race condition: prefix list could change between schema fetch and entity create'
+finding: Frontend loads schema once on app mount; if the user leaves the app open and the metamodel changes on disk (adding/removing a prefix), the prefix <select> shows stale options. Submitting the stale value would hit server-side validation (good). The plan should note that stale-prefix errors are acceptable with a clean 422 — no need for defensive fetches. Minor because SSE reloads already cover most of this; mention in the plan so the behavior is deliberate.
+severity: minor
+resolution: 'Plan''s Security section now documents stale-schema behavior: ''If the metamodel changes between schema fetch and create, the user sees a clean 422 on submit. No defensive fetch needed.'''
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-7505O.md
+++ b/tickets/entities/review-responses/RR-7505O.md
@@ -1,0 +1,9 @@
+---
+id: RR-7505O
+type: review-response
+title: postCreate test helper relies on naive plural pluralization
+finding: The postCreate test helper uses strings.TrimSuffix(plural, "s") to derive type name from plural. The test fixture deliberately uses 'categorys' as the plural so this round-trips, but the pattern is misleading and invites copy-paste into specs where plural ≠ type+s.
+severity: minor
+reason: Test-only helper, scoped to one file. The fixture's plural names are inline and stable; refactoring postCreate to take both args is purely defensive and adds noise to every call site. If a future test ever needs an irregular plural, that test can construct the request directly or extend the helper at that point. Keeping the helper minimal.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-764AR.md
+++ b/tickets/entities/review-responses/RR-764AR.md
@@ -1,0 +1,9 @@
+---
+id: RR-764AR
+type: review-response
+title: validateCreateIDOpts accepted bare-prefix IDs (e.g. id="TAG-")
+finding: 'For manual-ID types with a declared prefix, strings.HasPrefix(id, p) returns true even when id == p, so a caller could POST {id: "TAG-"} to a tag type (prefix TAG-) and create a useless entity whose ID has no distinguishing suffix. Not a security hole, but exactly the kind of inconsistency the prefix rule is meant to prevent.'
+severity: significant
+resolution: Added len(id) > len(p) check to validateCreateIDOpts in api_v1.go. Updated error message to 'must start with one of X and include a suffix'. Added test row 'manual prefixed, bare prefix as id' to TestValidateCreateIDOpts.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-87ICD.md
+++ b/tickets/entities/review-responses/RR-87ICD.md
@@ -1,0 +1,9 @@
+---
+id: RR-87ICD
+type: review-response
+title: Read-only ID display only shown for manual-ID types in edit mode
+finding: DynamicForm.vue:70-72 only displays the entity ID in edit mode for manual-ID types via showReadOnlyID. For a non-manual type in edit mode, there's no read-only display of the ID at all. Inconsistent treatment.
+severity: minor
+reason: Pre-existing behavior, not introduced by this PR. The rationale is that for manual-ID types the user is the source of the ID so showing it back disambiguates which entity is being edited; for short/sequential types the ID is incidental and the title/name property serves that role. Changing this to always-show would conflict with form layouts in production projects that rely on the current behavior. Out of scope for the prefix-picker / manual-ID-input ticket.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-8D8X3.md
+++ b/tickets/entities/review-responses/RR-8D8X3.md
@@ -1,0 +1,9 @@
+---
+id: RR-8D8X3
+type: review-response
+title: entitymanager.CreateOptions has no Prefix field - plan assumed it did
+finding: 'The plan states ''handleV1CreateEntity...passes Prefix to entitymanager.CreateOptions.Prefix'' but the actual `entitymanager.CreateOptions` struct (internal/entitymanager/entitymanager.go:20-27) only has ID, Variant, SkipAutomation — no Prefix. The workspace adapter (internal/workspace/manager.go:31-36) also does not forward it. The in-scope change list must include: (1) add `Prefix string` to `entitymanager.CreateOptions`, (2) forward it in `wsEntityManager.CreateEntity` to `workspace.CreateOptions.Prefix`. Without these, the plan will fail to compile when the HTTP handler tries to set it.'
+severity: critical
+resolution: 'Plan updated: scope now includes adding `Prefix string` to `entitymanager.CreateOptions` and forwarding it in `wsEntityManager.CreateEntity` (manager.go:31-36). Listed explicitly in Files to modify.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-8EVKJ.md
+++ b/tickets/entities/review-responses/RR-8EVKJ.md
@@ -1,0 +1,9 @@
+---
+id: RR-8EVKJ
+type: review-response
+title: Composable did not auto-reset when entityType changes
+finding: useEntityIDControls only resets when reset() is called explicitly (from initializeDefaults() in DynamicForm.vue, run on mount + selectTemplate). Since RouterView reuses FormView/DynamicForm across /form/:id param changes (no :key, no watch on props.formId), navigating from /form/tag to /form/module kept stale manualId and selectedPrefix visible. buildPayloadFields gates on showManualIDInput so it wouldn't leak between modes, but the stale value in the input box was visible to the user.
+severity: significant
+resolution: 'Added a watcher in useEntityIDControls.ts that calls reset() when the entityType identity changes, the id_type changes, or the prefix list changes. Three new test cases in useEntityIDControls.test.ts pin the behavior: clears manualId on manual→short transition, updates selectedPrefix to first of new list, does not reset when same object is reassigned.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-8G6D7.md
+++ b/tickets/entities/review-responses/RR-8G6D7.md
@@ -1,0 +1,9 @@
+---
+id: RR-8G6D7
+type: review-response
+title: docs/metamodel.md mentions 'dedicated rename flow' without a link
+finding: docs/metamodel.md:329-330 says 'the edit form shows the ID as a read-only display; renaming uses the dedicated rename flow' — no link, leaving the reader to wonder what the rename flow is.
+severity: nit
+reason: The rename flow doc target doesn't have a stable URL yet (FEAT-016 is the rename feature ticket; its surfaced doc page hasn't been written). Adding a hanging link to a non-existent doc would create a broken-link burden. Once FEAT-016 ships docs, this paragraph can be backfilled with a real anchor.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-8T3VM.md
+++ b/tickets/entities/review-responses/RR-8T3VM.md
@@ -1,0 +1,9 @@
+---
+id: RR-8T3VM
+type: review-response
+title: Consolidate validateCreateIDOpts with EntityDef.MatchesID
+finding: EntityDef.MatchesID(id) already does 'does this id match any of my prefixes?' — the new validator re-implements the same loop with slightly different semantics. Could move logic to MatchesIDWithReason on EntityDef.
+severity: nit
+reason: Suggestion-level. Worth doing but the right home for the merged logic depends on what RR-ODPMN (typed errors) lands on, since MatchesIDWithReason would benefit from the same error-shape. Tracking as a single follow-up that sequences after the typed-errors work.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-BJW16.md
+++ b/tickets/entities/review-responses/RR-BJW16.md
@@ -1,0 +1,9 @@
+---
+id: RR-BJW16
+type: review-response
+title: Plan passes req.ID unconditionally to CreateOptions, conflating manual-ID with short/sequential
+finding: 'For a short/sequential type the form should NOT send `id` at all. If a malicious or buggy client sends `{id: ''TKT-HACKED''}` for a type with `id_type: short`, the backend today (api_v1.go:392 `CreateOptions{ID: req.ID}`) happily creates an entity with that ID, bypassing the entire short-ID generation. This is pre-existing behaviour but the plan does not address it and multi-prefix makes it worse (user could send `{id: ''WRONG-001''}` ignoring the prefix rules). Recommend: server validates that `req.id` is only honored when `entityDef.IsManualID()`; otherwise 422 ''ID not accepted for non-manual ID types''. Document the decision in the plan.'
+severity: significant
+resolution: Plan now explicitly rejects `req.id` for non-manual types (422) and `req.prefix` for manual types (422). Applies to both handleV1CreateEntity and legacy handleAPICreateEntity.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CH13R.md
+++ b/tickets/entities/review-responses/RR-CH13R.md
@@ -1,0 +1,9 @@
+---
+id: RR-CH13R
+type: review-response
+title: V1EntityType emits both id_prefix and id_prefixes — forever liability
+finding: The schema response now emits both id_prefix (string) and id_prefixes (array). The frontend's prefixOptions falls back to singular if id_prefixes is absent. The dual field will desync at some point.
+severity: minor
+reason: Already designed for back-compat and pinned by TestV1Schema_SinglePrefix_Compat (asserts both fields are populated for single-prefix types). The frontend reads id_prefixes first and only falls back when absent — so for new code there's a single source of truth. Removing id_prefix would be a breaking API change for any consumer reading it directly; deferring that to a future major version. The current shape is the most ergonomic transition path.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-GQ5S8.md
+++ b/tickets/entities/review-responses/RR-GQ5S8.md
@@ -1,0 +1,9 @@
+---
+id: RR-GQ5S8
+type: review-response
+title: GetIDPrefixes silently drops id_prefixes when both id_prefix and id_prefixes are set
+finding: 'EntityDef.GetIDPrefixes returns [IDPrefix] first and only falls back to IDPrefixes if IDPrefix is empty. Pre-existing behavior, not introduced here. But this PR is the first thing surfacing IDPrefixes as a first-class multi-value concept to API callers and the frontend, so it makes the trap more visible: a user adding multi-prefix support to an existing entity type might leave id_prefix set and silently lose the rest.'
+severity: significant
+reason: Out of scope for this ticket. The trap is metamodel-loader behavior that pre-dates this work and affects more than just data-entry; fixing it (loader-time error or union semantics in GetIDPrefixes) belongs in its own ticket so the metamodel + entitymanager + Lua bindings can all be updated and tested together. Filing as a follow-up; this PR only consumes GetIDPrefixes, doesn't modify it.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-KY4RI.md
+++ b/tickets/entities/review-responses/RR-KY4RI.md
@@ -1,0 +1,9 @@
+---
+id: RR-KY4RI
+type: review-response
+title: Plan doesn't mention where InlineCreateModal is invoked from — scope of visual testing is unclear
+finding: InlineCreateModal is referenced by 7 files (RelationPicker, tickets templates, etc.). The plan should note the main invocation path (RelationPicker.vue) and confirm that the prefix picker UX doesn't conflict with the 'add a new relation target inline' flow. In particular, for relation pickers, the caller may already know the target type — does the prefix picker make sense contextually? Probably yes (user still chooses a prefix when creating), but the plan should acknowledge it.
+severity: nit
+resolution: Plan's Research section now explicitly confirms InlineCreateModal is invoked from RelationPicker.vue; picker UX applies uniformly in both contexts.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-M0LIU.md
+++ b/tickets/entities/review-responses/RR-M0LIU.md
@@ -1,0 +1,9 @@
+---
+id: RR-M0LIU
+type: review-response
+title: 'No test for backward compatibility: existing `id_prefix` singular field must keep working'
+finding: 'The plan adds `id_prefixes` but says ''keep `id_prefix` for backward compat''. No explicit test was listed that verifies a single-prefix type still has `id_prefix` populated in the JSON response after the change. Add: ''Go test TestV1Schema_SinglePrefix_Compat asserts that a type with id_prefix: TKT- returns both id_prefix: TKT- AND id_prefixes: [TKT-]''.'
+severity: minor
+resolution: AC4 now explicitly lists TestV1Schema_SinglePrefix_Compat asserting both id_prefix and id_prefixes populated for single-prefix types.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-M1TIC.md
+++ b/tickets/entities/review-responses/RR-M1TIC.md
@@ -1,0 +1,9 @@
+---
+id: RR-M1TIC
+type: review-response
+title: Manual ID input has no format hint, violating principle of least surprise
+finding: 'The existing InlineCreateModal placeholder is ''Unique ID...'' with no guidance. For manual-ID types, the metamodel may define id_pattern validation (via custom types). The plan should: (a) surface the expected pattern/description as placeholder or help text, OR (b) explicitly punt on that as out-of-scope. Without guidance, users will hit server-side 422 errors they can''t easily diagnose. At minimum, mention this in the plan so the reviewer knows it was considered.'
+severity: minor
+reason: Surfacing the metamodel-defined ID pattern as a form hint is a separate UX concern; not blocking for this ticket. Users still get a server-side 422 with the pattern error. Call out in scope as deferred.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-O0ZGM.md
+++ b/tickets/entities/review-responses/RR-O0ZGM.md
@@ -1,0 +1,9 @@
+---
+id: RR-O0ZGM
+type: review-response
+title: validateCreateIDOpts did not trim whitespace, leading to misleading errors
+finding: Inputs like '  TAG-foo' (leading space) failed strings.HasPrefix because of the space, so the user got a 'must start with...' error that was technically true but misleading; the real problem was the whitespace. The Vue side (`<input v-model="manualId">`) also doesn't trim. Copy-pasting an ID with a stray newline gave bewildering errors.
+severity: significant
+resolution: validateCreateIDOpts now trims id and prefix at the top with strings.TrimSpace; the v1 + legacy handlers also trim req.ID/req.Prefix before calling. Added test rows 'manual prefixed, whitespace-only id treated as empty' and 'short, whitespace prefix treated as empty' to TestValidateCreateIDOpts.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-O1UMW.md
+++ b/tickets/entities/review-responses/RR-O1UMW.md
@@ -1,0 +1,9 @@
+---
+id: RR-O1UMW
+type: review-response
+title: E2E spec asserts on free-form error prose via regex
+finding: forms-id-controls.spec.ts:133 uses expect(body).toMatch(/must start with.*MOD-/) and the duplicate-ID spec uses body.toContain('already exists'). Both couple the test to specific server message wording. Reworking the error text — e.g., the 'must start with' → 'must start with X and include a suffix' change introduced by RR-764AR — silently breaks tests that grep prose.
+severity: significant
+reason: 'Real concern but the structured-error shape needed to assert cleanly (e.g., a stable error type URL like https://rela.dev/errors/invalid-id-prefix plus an allowed_prefixes extension field) does not yet exist in the API — the current problem+json responses only carry {type: ''validation_failed'', title: <prose>, detail: <prose>}. Migrating tests to assert on type alone loses information; migrating to assert on a structured allowed_prefixes field would require API additions that are outside this ticket''s scope. Filing a follow-up to introduce typed problem+json error codes; once those land, both this spec and the frontend error-renderer can switch to structured assertions in lockstep.'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-ODPMN.md
+++ b/tickets/entities/review-responses/RR-ODPMN.md
@@ -1,0 +1,9 @@
+---
+id: RR-ODPMN
+type: review-response
+title: validateCreateIDOpts returns string instead of error
+finding: Returning a plain string and reserving "" as the success sentinel is unidiomatic Go. Two callers plug the string straight into writeV1Error/writeJSONError. Loses the ability to distinguish error kinds downstream and diverges from convention.
+severity: minor
+reason: Cosmetic. Function is private to the package, only two callers, both pipe the string verbatim into the HTTP error body. Switching to error or (errCode, message) would let the handlers branch on kind for finer-grained problem+json types — that's exactly the work tracked under RR-O1UMW (typed error codes). Bundling them lets the refactor of validateCreateIDOpts and the HTTP error layer happen as one coherent change rather than churning the signature twice.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-PROV0.md
+++ b/tickets/entities/review-responses/RR-PROV0.md
@@ -1,0 +1,9 @@
+---
+id: RR-PROV0
+type: review-response
+title: Test fixtures could use fluent builders per CLAUDE.md guidance
+finding: Both newPrefixTestApp and newManualPrefixedTestApp are prime candidates for the fluent-builder pattern (testApp().withType(manualType('tag').withPrefix('TAG-')).build()).
+severity: nit
+reason: Suggestion-level. RR-WI06C tracks the related concern about the two helpers duplicating wiring; a fluent builder is one possible answer to that. Holding both as one consolidated follow-up so the refactor can be designed without constraints from this PR's diff boundary.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-R8W1A.md
+++ b/tickets/entities/review-responses/RR-R8W1A.md
@@ -1,0 +1,9 @@
+---
+id: RR-R8W1A
+type: review-response
+title: 'Prototype config combines id_type: sequential with id_prefixes [DEC-, ADR-]'
+finding: 'prototypes/data-entry/project/metamodel.yaml:62-69 has decision with id_type: sequential and id_prefixes: [DEC-, ADR-]. Sequential IDs are {prefix}{n:03d} — behavior with two prefixes is not pinned by any test. The api_v1_test.go fixture uses id_type: short for the same shape, so the prototype is exercising an unclaimed combination.'
+severity: significant
+reason: 'Prototype-only. The dogfood project (tickets/) and the unit-test fixture both use id_type: short for multi-prefix types, which is the intended supported configuration and is fully tested. Sequential + multi-prefix is an interesting edge case but pinning it down requires either (a) confirming the workspace.GenerateNextID semantics for that combo or (b) deciding to disallow it at the loader level; that work belongs in a separate ticket scoped to id_type semantics. The prototype works for its dogfooding purpose either way.'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-RN5D5.md
+++ b/tickets/entities/review-responses/RR-RN5D5.md
@@ -1,0 +1,9 @@
+---
+id: RR-RN5D5
+type: review-response
+title: Consider typed problem+json error responses for structured client handling
+finding: Callers match on free-form `detail` prose. A dedicated `type` URL like https://rela.dev/errors/invalid-id-prefix plus a structured allowed_prefixes extension field would let the UI show prefix-picker inline and let tests assert on error type rather than scraping English.
+severity: nit
+reason: Same destination as RR-O1UMW. Tracking as a single follow-up to design typed RFC-7807 error codes across the data-entry API; once that lands, the e2e specs (RR-O1UMW), the validator return type (RR-ODPMN), and the EntityDef.MatchesID consolidation (RR-8T3VM) can all switch to the structured shape in a coordinated change.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-RQVPW.md
+++ b/tickets/entities/review-responses/RR-RQVPW.md
@@ -1,0 +1,9 @@
+---
+id: RR-RQVPW
+type: review-response
+title: InlineCreateModal does not reset state when entityType prop changes mid-open
+finding: InlineCreateModal.vue:47-53 watcher on props.show resets state only when show flips true. If entityType prop changes while the modal is already open (unlikely but possible via parent prop flip), composable state stays stale.
+severity: nit
+resolution: RR-8EVKJ added an entityType watcher inside useEntityIDControls itself, so the auto-reset now fires regardless of which consumer holds the composable. Both DynamicForm and InlineCreateModal benefit without component-level changes.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-RYW1R.md
+++ b/tickets/entities/review-responses/RR-RYW1R.md
@@ -1,0 +1,9 @@
+---
+id: RR-RYW1R
+type: review-response
+title: DynamicForm and InlineCreateModal duplicate problem+json error parsing
+finding: Near-identical 'parse problem+json or fall back to Error message' logic in two places. Primed for drift.
+severity: nit
+reason: Real but small. The two blocks are ~10 lines each, both feed the same toast surface, and neither has changed since the BUG-UNEBR fix. A formatFormError(err) util is the right destination but it's a refactor of pre-existing duplication, not new duplication introduced by this PR. Filing as a follow-up so the helper can be designed without being constrained by this ticket's commit boundary.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-SAIFO.md
+++ b/tickets/entities/review-responses/RR-SAIFO.md
@@ -1,0 +1,9 @@
+---
+id: RR-SAIFO
+type: review-response
+title: DynamicForm error-handling drops non-array errors field silently
+finding: 'DynamicForm.vue:412 narrowed the errors-array path with Array.isArray, falling through to a generic ''Failed to save entity'' toast. If any server path emits {errors: {field: ''msg''}} (object, not array) the user gets the generic message instead of something actionable.'
+severity: significant
+reason: 'Audited writeV1Error and writeProblemJSON call sites: every 422-emitting code path uses either the structured {detail, title, type} problem+json shape (no errors field) or {errors: []ValidationError} arrays. There is no codepath that emits a non-array errors field. The Array.isArray guard is the right narrowing for the actual server contract; defensive coding for a shape that doesn''t exist would be premature. If the server contract ever grows a non-array errors variant, the fallback''s ''detail || title || generic'' chain still surfaces a useful message via problem+json fields.'
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-T0H90.md
+++ b/tickets/entities/review-responses/RR-T0H90.md
@@ -1,0 +1,9 @@
+---
+id: RR-T0H90
+type: review-response
+title: Legacy /api/entities POST silently broke for callers supplying id on non-manual types
+finding: 'Before this PR, POST /api/entities with {id: "TKT-CUSTOM", type: "ticket", ...} was accepted (workspace honored the custom ID for any type, gated only by duplicate check). After this PR validateCreateIDOpts is also called from handleAPICreateEntity at internal/dataentry/handlers_api.go:386, so the same payload now returns 400/422. APICreateEntityRequest is a documented public-facing JSON shape used by mobile clients. Pre-fix this was zero-test-coverage on the legacy path.'
+severity: significant
+resolution: Added TestHandleAPICreateEntity_IDValidation in handlers_api_test.go covering rejection for non-manual types, unknown prefix, and whitespace-trim behavior. Status switched to 422 for consistency with the v1 handler. The break is intentional — accepting arbitrary client-supplied IDs for short/sequential types undermines the whole id_type concept — and is now pinned by tests so it cannot silently regress further.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-V6IVL.md
+++ b/tickets/entities/review-responses/RR-V6IVL.md
@@ -1,0 +1,9 @@
+---
+id: RR-V6IVL
+type: review-response
+title: TestValidateCreateIDOpts table missed key combinations
+finding: 'The validator''s table-driven tests covered the basic matrix but missed: short type with both id and prefix set (precedence), manualPrefixed with matching id AND prefix also set, bare prefix as id (TAG-), whitespace-only id, whitespace-only prefix.'
+severity: significant
+resolution: 'Added 5 new test rows: ''short, both id and prefix set — id rejection wins'', ''manual prefixed, id matches AND prefix also set'' (→ prefix not applicable), ''manual prefixed, bare prefix as id'' (→ must start with), ''manual prefixed, whitespace-only id treated as empty'', ''short, whitespace prefix treated as empty''. All 17 rows pass.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-V6WV6.md
+++ b/tickets/entities/review-responses/RR-V6WV6.md
@@ -1,0 +1,9 @@
+---
+id: RR-V6WV6
+type: review-response
+title: E2E specs use Date.now() suffixes for generated IDs
+finding: Date.now() can collide across parallel workers running within the same millisecond and is brittle for cleanup if tests interleave. Per CLAUDE.md auto-generate-identifiers guidance.
+severity: minor
+reason: Real concern but the same Date.now() pattern is used across the existing e2e suite (forms.spec.ts, kanban.spec.ts, etc.). Replacing them all with a uniqueId(prefix) helper or crypto.randomUUID is a project-wide consistency fix worth doing, but should land as a single sweep rather than scattered across feature PRs. Filing a follow-up; in the meantime, the existing tests have not flaked on collision because Playwright's worker count and the test fixture's per-worker server isolation make sub-ms collisions effectively impossible.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-WI06C.md
+++ b/tickets/entities/review-responses/RR-WI06C.md
@@ -1,0 +1,9 @@
+---
+id: RR-WI06C
+type: review-response
+title: newPrefixTestApp and newManualPrefixedTestApp duplicate setup
+finding: The two test fixture constructors differ only by the metamodel; both copies of FS/ctx/broker wiring are ~20 lines. Drifts over time.
+severity: minor
+reason: Real but cosmetic. The two helpers are stable and each is used by ~5 tests in the same file. A fluent builder per CLAUDE.md guidance is the right destination but is best done as a pass over the whole api_v1_test.go (and arguably the rest of the package) rather than carving out two helpers in this PR. Filing as a follow-up so the refactor can be rationalised across helpers consistently.
+status: deferred
+---

--- a/tickets/entities/tickets/TKT-E7NNM.md
+++ b/tickets/entities/tickets/TKT-E7NNM.md
@@ -1,0 +1,25 @@
+---
+id: TKT-E7NNM
+type: ticket
+title: 'Data-entry create form: prefix picker for multi-prefix types and manual ID field'
+kind: enhancement
+priority: medium
+effort: m
+status: done
+---
+
+## Problem
+
+The data-entry create forms currently don't support two metamodel features:
+
+1. **Multi-prefix types** (`id_prefixes: ["DEC-", "ADR-"]`): when an entity type declares more than one ID prefix, the UI must let the user pick which prefix to use for the new entity. Today the backend (`handleV1CreateEntity` in `internal/dataentry/api_v1.go`) doesn't accept a prefix override, and `V1EntityType` only exposes `id_prefix` (the first one in the list). The main create form (`frontend/src/components/forms/DynamicForm.vue`) has no prefix UI. The inline create modal (`frontend/src/components/forms/InlineCreateModal.vue`) has no prefix UI either.
+
+2. **Manual ID type** (`id_type: manual`): when an entity type requires a manually supplied ID, the create form must show an editable text field. `InlineCreateModal.vue` already handles this, but `DynamicForm.vue` (the main form used for `/form/:id` routes) has no ID field at all, so new entities of manual-ID types cannot be created through the main form UI.
+
+## Acceptance criteria
+
+- When the selected entity type has `id_type: manual`, both `DynamicForm.vue` and `InlineCreateModal.vue` show a required editable ID field; on submit the value is sent as `payload.id`.
+- When the selected entity type has `id_prefixes` with more than one value, the create form shows a picker (select/radio) to choose the prefix. Single-prefix types keep current behaviour (no picker shown).
+- The backend schema endpoint exposes the full list of prefixes (not just the first) to the frontend.
+- The backend create endpoint accepts an optional `prefix` override and passes it to `workspace.CreateOptions.Prefix`.
+- Behaviour is covered by unit tests (Go handler, Vue components) and an E2E test.

--- a/tickets/relations/TKT-E7NNM--affects--data-entry-server.md
+++ b/tickets/relations/TKT-E7NNM--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-E7NNM--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-E7NNM--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-E7NNM--has-implementation--IMPL-4J1YO.md
+++ b/tickets/relations/TKT-E7NNM--has-implementation--IMPL-4J1YO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-implementation
+to: IMPL-4J1YO
+---

--- a/tickets/relations/TKT-E7NNM--has-planning--PLAN-TFQC4.md
+++ b/tickets/relations/TKT-E7NNM--has-planning--PLAN-TFQC4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-planning
+to: PLAN-TFQC4
+---

--- a/tickets/relations/TKT-E7NNM--has-review--REV-Y4YC3.md
+++ b/tickets/relations/TKT-E7NNM--has-review--REV-Y4YC3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review
+to: REV-Y4YC3
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-15SU1.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-15SU1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-15SU1
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-1G4EK.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-1G4EK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-1G4EK
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-2R1HG.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-2R1HG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-2R1HG
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-3GURO.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-3GURO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-3GURO
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-4J6HA.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-4J6HA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-4J6HA
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-6GPR4.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-6GPR4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-6GPR4
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-6HR8S.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-6HR8S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-6HR8S
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-7505O.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-7505O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-7505O
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-764AR.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-764AR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-764AR
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-87ICD.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-87ICD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-87ICD
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-8D8X3.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-8D8X3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-8D8X3
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-8EVKJ.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-8EVKJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-8EVKJ
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-8G6D7.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-8G6D7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-8G6D7
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-8T3VM.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-8T3VM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-8T3VM
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-BJW16.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-BJW16.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-BJW16
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-CH13R.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-CH13R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-CH13R
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-GQ5S8.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-GQ5S8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-GQ5S8
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-KY4RI.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-KY4RI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-KY4RI
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-M0LIU.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-M0LIU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-M0LIU
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-M1TIC.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-M1TIC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-M1TIC
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-O0ZGM.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-O0ZGM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-O0ZGM
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-O1UMW.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-O1UMW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-O1UMW
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-ODPMN.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-ODPMN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-ODPMN
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-PROV0.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-PROV0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-PROV0
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-R8W1A.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-R8W1A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-R8W1A
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-RN5D5.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-RN5D5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-RN5D5
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-RQVPW.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-RQVPW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-RQVPW
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-RYW1R.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-RYW1R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-RYW1R
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-SAIFO.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-SAIFO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-SAIFO
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-T0H90.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-T0H90.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-T0H90
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-V6IVL.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-V6IVL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-V6IVL
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-V6WV6.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-V6WV6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-V6WV6
+---

--- a/tickets/relations/TKT-E7NNM--has-review-response--RR-WI06C.md
+++ b/tickets/relations/TKT-E7NNM--has-review-response--RR-WI06C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: has-review-response
+to: RR-WI06C
+---

--- a/tickets/relations/TKT-E7NNM--implements--FEAT-012.md
+++ b/tickets/relations/TKT-E7NNM--implements--FEAT-012.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E7NNM
+relation: implements
+to: FEAT-012
+---


### PR DESCRIPTION
## Summary

- Data-entry create forms now support entity types with multiple `id_prefixes` (prefix picker) and `id_type: manual` (editable ID field). Backend exposes `id_prefixes`, accepts an optional `prefix` request field, and rejects mismatches (unknown prefix, `id` on non-manual types, `prefix` on manual types, and manual IDs that don't match a declared prefix).
- Extracted `useEntityIDControls` composable to share the logic between `DynamicForm.vue` and `InlineCreateModal.vue`. Error toast now surfaces the server's `detail` field instead of a generic "Failed to save entity".
- Added `Prefix string` to `entitymanager.CreateOptions` and forwarded it through the workspace adapter — the field existed on `workspace.CreateOptions` but was dead code before.

Closes TKT-E7NNM.

## Test plan

- [x] `go test ./internal/dataentry/ ./internal/entitymanager/ ./internal/workspace/` — added 10 Go tests (`TestV1Schema_{MultiPrefix,SinglePrefix_Compat}`, `TestV1CreateEntity_{PrefixOverride,EmptyPrefixUsesFirst,UnknownPrefix,IDRejectedForNonManual,ManualTypeRejectsPrefix,ManualAcceptsID,ManualWithPrefix_*}`, table-driven `TestValidateCreateIDOpts`).
- [x] `npm run test:run` — added 18 composable tests covering all `mode × id_type × prefix` combinations plus reactive mode changes (regression test for the edit-mode-shows-picker bug).
- [x] E2E (`frontend/e2e/forms.spec.ts`) — manual-ID free-form, multi-prefix picker, single-prefix no-picker, edit mode no-picker, manual+single-prefix reject/accept, manual+multi-prefix accept, duplicate-ID error surfacing.
- [x] `just lint` — clean.
- [x] Manual smoke test on http://127.0.0.1:8181 — all flows verified, including the duplicate-ID error toast and manual+prefix enforcement (`MOD-` / `RFC-`/`SPEC-`).

## Notes

- Design review findings are tracked as `review-response` entities (`RR-*`) linked to the ticket; all critical/significant findings were addressed in the plan before implementation.
- Deferred: metamodel-defined ID pattern surfaced as form placeholder (`RR-M1TIC`, separate UX work).