### PR TITLE
feat: Lua script renderer for data-entry documents (TKT-CGBVW)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -27,6 +27,7 @@ A `data-entry.yaml` file defines:
 - **Navigation** - Sidebar menu entries with optional grouping
 - **Actions** - Quick operations (property mutations or Lua scripts) triggered from lists or the sidebar
 - **Commands** - User-defined scripts triggered from the UI with streamed results
+- **Documents** - Read-only rendered markdown panels attached to entity views, composed via shell commands or Lua scripts
 - **User Defaults** - Per-user default values for properties and relations, configurable via Settings page
 
 The file drives the entire UI without writing any code. The server reads `data-entry.yaml` and
@@ -1789,6 +1790,152 @@ When a dashboard is configured, a validation summary card is automatically appen
 total error and warning counts with a link to the full analysis page.
 
 No configuration is needed — the analysis page is always available in the sidebar.
+
+## Documents
+
+Documents are read-only rendered markdown panels attached to an entity's detail
+view. A document's configuration declares which entity type it applies to and
+how to produce the markdown — either a shell `command:` that writes markdown to
+stdout, or a Lua `script:` that does the same via the embedded runtime.
+Captured markdown is converted to HTML via goldmark, with links using
+`edit://` and `create://` URL schemes rewritten into data-entry form URLs
+(see "Links in rendered documents" below).
+
+The frontend's `DocumentsPanel.vue` shows every document whose `entity_type`
+matches the current entity. SSE live-reload re-renders a document when the
+entity changes (see the "SSE live-reload" caveat below).
+
+### YAML schema
+
+```yaml
+documents:
+  release_notes:
+    title: "Release Notes"         # shown as the panel title
+    entity_type: release           # REQUIRED; renderer runs only for this type
+    script: docs/release_notes.lua # OR command: — exactly one must be set
+    timeout: 15                    # seconds; defaults to 30
+  ticket_summary:
+    title: "Ticket Summary"
+    entity_type: ticket
+    command: "my-renderer {id}"    # {id} / {id_lower} are substituted
+    timeout: 30
+```
+
+Validation is strict: `entity_type:` must be set, and exactly one of
+`command:` or `script:` must be non-empty. Configs with both, or with
+neither, are rejected at startup. For `script:` docs, the referenced file
+is checked for existence at startup too, so typos fail loudly instead of at
+the first HTTP request.
+
+### Shell command renderer (`command:`)
+
+The command runs in a POSIX shell (`sh -c`) with the project root as the
+working directory. The script must write the rendered markdown to stdout.
+Placeholders inside the command string are substituted before execution:
+
+| Placeholder | Expands to |
+|-------------|------------|
+| `{id}`      | The entry entity ID |
+| `{id_lower}`| The ID lowercased |
+
+Command renderer output is cached to disk at
+`.rela/documents/<entry>-<hash>.html` keyed by an FNV hash of the entry
+entity. Subsequent requests for the same entity skip the command and serve
+the cached HTML until the entity changes.
+
+### Lua script renderer (`script:`)
+
+The `script:` field is a path under the project's `scripts/` directory
+(e.g. `docs/release_notes.lua`). The script runs with a writer runtime —
+it can read the full graph, call `ai.chat`, and use `rela.cache.memoize` —
+but anything it writes to stdout (via `print()`) is captured as the
+document's markdown.
+
+When invoked in document mode, the runtime exposes extra context:
+
+| Variable                   | Meaning |
+|----------------------------|---------|
+| `rela.mode`                | Always `"document"` in this context; `nil` elsewhere |
+| `rela.document.id`         | The key under `documents:` in `data-entry.yaml` |
+| `rela.document.entry_id`   | The ID of the entity being rendered |
+
+Example — a document that composes a markdown doc from an entity plus its
+graph neighbours:
+
+```lua
+-- scripts/docs/release_notes.lua
+local entry = rela.get_entity(rela.document.entry_id)
+print("# " .. (entry.properties.title or entry.id))
+print()
+for _, child in ipairs((rela.trace_from(entry.id, 2) or {children = {}}).children) do
+  local e = rela.get_entity(child.id)
+  if e then
+    print("## [" .. e.id .. "](edit://" .. e.type .. "/" .. e.id .. ")")
+    print(e.content or "")
+  end
+end
+```
+
+Lua renders bypass the disk cache. In-process caching is available through
+`rela.cache` (see [Lua Scripting → Cache](GUIDE-lua-scripting.md#cache) for
+the full API). Memoized work is shared across HTTP requests within the
+lifetime of the `rela-server` process. The cache namespace is the script
+path, not the document's config key — shared helper scripts intentionally
+share cache state across all documents that use them; if you need
+doc-scoped keys, include `rela.document.id` in your cache key explicitly.
+
+`rela.output({...})` in document mode emits a warning line into the
+rendered document (captured stdout is the document body, so raw JSON in the
+middle of markdown is almost always a mistake). If you need to output
+data, use `print()`; if you're debugging, a warning line is usually fine.
+A script that calls `rela.output` inside a loop will produce many warning
+lines in the rendered output — that is intentionally loud.
+
+### Links in rendered documents
+
+The goldmark→HTML step rewrites two custom URL schemes into data-entry
+form URLs, so documents can link directly to edit and create forms:
+
+| Scheme                      | Renders as                                           |
+|-----------------------------|------------------------------------------------------|
+| `edit://<type>/<id>`        | `/form/<type>/<id>?return_to=...` (edit an entity)   |
+| `create://<type>`           | `/form/<type>?return_to=...` (new entity)            |
+| `create://<type>?k=v&...`   | `/form/<type>?k=v&...&return_to=...` (with defaults) |
+
+The return URL points back to the entity view that hosts the document, so
+submitting the form returns the user to where they were.
+
+### Caching and live-reload
+
+- **Command renders** are cached on disk (`.rela/documents/<entry>-<hash>.html`).
+  The hash includes only the entry entity, so the cache refreshes when the
+  entry entity changes.
+- **Script renders** are not cached on disk. Use `rela.cache.memoize` inside
+  your script to share work across requests within the same server process.
+- **SSE live-reload** refreshes a document when the entry entity changes.
+  Multi-entity composition (a script that walks 20 related tickets) will
+  only re-render when the **entry** entity changes, not the walked ones.
+  The refresh button in the UI is the escape hatch. A follow-up ticket
+  (TKT-E1FO1) tracks the fix for explicit dependency tracking.
+
+### Security notes
+
+- Document scripts run in the same sandbox as action scripts: no `io`, no
+  `os`, no `debug`; file writes are confined to `output/` via
+  `rela.write_file`. Treat Lua scripts as trusted code.
+- The HTTP handler enforces `entity_type:` on every request: a document
+  configured for `entity_type: release` cannot be rendered against a
+  ticket, even if the caller bypasses the frontend filter.
+- Rendered markdown uses goldmark's `html.WithUnsafe` — the frontend
+  (DOMPurify) is the sanitization boundary. If you add another consumer of
+  the rendered HTML (PDF export, copy-HTML button, etc.), it must add its
+  own sanitization.
+
+### Config hot-reload
+
+Editing `data-entry.yaml` to change a document's `script:` or `command:`
+takes effect on the next request; open document panels pick up the new
+renderer on their next reload.
 
 ## Best Practices
 

--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -528,6 +528,41 @@ end
 | `rela.params` | Action script parameters (table, from data-entry config) |
 | `rela.secrets` | Per-script secrets (table, from `.rela/secrets.yaml`) |
 | `rela.cache` | Process-wide memoization cache namespaced per script (see [Cache](#cache)) |
+| `rela.mode` | Set to `"document"` when rendering a data-entry document; `nil` otherwise (see [Document Mode](#document-mode)) |
+| `rela.document` | Present only in document mode; holds `{id, entry_id}` (see [Document Mode](#document-mode)) |
+
+### Document Mode
+
+When a data-entry document is configured with `script:` (see
+[Documents in the data-entry guide](GUIDE-data-entry.md#documents)), the
+script runs in a specialized mode with extra context exposed:
+
+| Variable                 | Meaning |
+|--------------------------|---------|
+| `rela.mode`              | `"document"` in this context; absent elsewhere |
+| `rela.document.id`       | The key under `documents:` in `data-entry.yaml` |
+| `rela.document.entry_id` | The ID of the entity being rendered |
+
+The script's stdout is captured and used as the rendered document's
+markdown (after goldmark → HTML conversion). Use `print()` to produce
+output.
+
+```lua
+-- scripts/docs/release_notes.lua
+local entry = rela.get_entity(rela.document.entry_id)
+print("# " .. (entry.properties.title or entry.id))
+```
+
+**`rela.output` in document mode** emits a warning line into the
+captured stdout (and thus into the rendered document) instead of
+writing JSON — captured stdout is the document body, so a raw JSON
+payload in the middle of markdown is almost always a mistake.
+
+**Cache policy**: `rela.cache.memoize` is namespaced by the script path,
+not by the document config. Two `documents:` entries that share one
+`.lua` file share a cache namespace — usually what you want (a helper
+script caches work across all its callers). If you need doc-scoped
+keys, include `rela.document.id` in your cache key explicitly.
 
 ### Secrets
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -21,6 +21,7 @@ A `data-entry.yaml` file defines:
 - **Navigation** - Sidebar menu entries with optional grouping
 - **Actions** - Quick operations (property mutations or Lua scripts) triggered from lists or the sidebar
 - **Commands** - User-defined scripts triggered from the UI with streamed results
+- **Documents** - Read-only rendered markdown panels attached to entity views, composed via shell commands or Lua scripts
 - **User Defaults** - Per-user default values for properties and relations, configurable via Settings page
 
 The file drives the entire UI without writing any code. The server reads `data-entry.yaml` and
@@ -1783,6 +1784,152 @@ When a dashboard is configured, a validation summary card is automatically appen
 total error and warning counts with a link to the full analysis page.
 
 No configuration is needed — the analysis page is always available in the sidebar.
+
+## Documents
+
+Documents are read-only rendered markdown panels attached to an entity's detail
+view. A document's configuration declares which entity type it applies to and
+how to produce the markdown — either a shell `command:` that writes markdown to
+stdout, or a Lua `script:` that does the same via the embedded runtime.
+Captured markdown is converted to HTML via goldmark, with links using
+`edit://` and `create://` URL schemes rewritten into data-entry form URLs
+(see "Links in rendered documents" below).
+
+The frontend's `DocumentsPanel.vue` shows every document whose `entity_type`
+matches the current entity. SSE live-reload re-renders a document when the
+entity changes (see the "SSE live-reload" caveat below).
+
+### YAML schema
+
+```yaml
+documents:
+  release_notes:
+    title: "Release Notes"         # shown as the panel title
+    entity_type: release           # REQUIRED; renderer runs only for this type
+    script: docs/release_notes.lua # OR command: — exactly one must be set
+    timeout: 15                    # seconds; defaults to 30
+  ticket_summary:
+    title: "Ticket Summary"
+    entity_type: ticket
+    command: "my-renderer {id}"    # {id} / {id_lower} are substituted
+    timeout: 30
+```
+
+Validation is strict: `entity_type:` must be set, and exactly one of
+`command:` or `script:` must be non-empty. Configs with both, or with
+neither, are rejected at startup. For `script:` docs, the referenced file
+is checked for existence at startup too, so typos fail loudly instead of at
+the first HTTP request.
+
+### Shell command renderer (`command:`)
+
+The command runs in a POSIX shell (`sh -c`) with the project root as the
+working directory. The script must write the rendered markdown to stdout.
+Placeholders inside the command string are substituted before execution:
+
+| Placeholder | Expands to |
+|-------------|------------|
+| `{id}`      | The entry entity ID |
+| `{id_lower}`| The ID lowercased |
+
+Command renderer output is cached to disk at
+`.rela/documents/<entry>-<hash>.html` keyed by an FNV hash of the entry
+entity. Subsequent requests for the same entity skip the command and serve
+the cached HTML until the entity changes.
+
+### Lua script renderer (`script:`)
+
+The `script:` field is a path under the project's `scripts/` directory
+(e.g. `docs/release_notes.lua`). The script runs with a writer runtime —
+it can read the full graph, call `ai.chat`, and use `rela.cache.memoize` —
+but anything it writes to stdout (via `print()`) is captured as the
+document's markdown.
+
+When invoked in document mode, the runtime exposes extra context:
+
+| Variable                   | Meaning |
+|----------------------------|---------|
+| `rela.mode`                | Always `"document"` in this context; `nil` elsewhere |
+| `rela.document.id`         | The key under `documents:` in `data-entry.yaml` |
+| `rela.document.entry_id`   | The ID of the entity being rendered |
+
+Example — a document that composes a markdown doc from an entity plus its
+graph neighbours:
+
+```lua
+-- scripts/docs/release_notes.lua
+local entry = rela.get_entity(rela.document.entry_id)
+print("# " .. (entry.properties.title or entry.id))
+print()
+for _, child in ipairs((rela.trace_from(entry.id, 2) or {children = {}}).children) do
+  local e = rela.get_entity(child.id)
+  if e then
+    print("## [" .. e.id .. "](edit://" .. e.type .. "/" .. e.id .. ")")
+    print(e.content or "")
+  end
+end
+```
+
+Lua renders bypass the disk cache. In-process caching is available through
+`rela.cache` (see [Lua Scripting → Cache](GUIDE-lua-scripting.md#cache) for
+the full API). Memoized work is shared across HTTP requests within the
+lifetime of the `rela-server` process. The cache namespace is the script
+path, not the document's config key — shared helper scripts intentionally
+share cache state across all documents that use them; if you need
+doc-scoped keys, include `rela.document.id` in your cache key explicitly.
+
+`rela.output({...})` in document mode emits a warning line into the
+rendered document (captured stdout is the document body, so raw JSON in the
+middle of markdown is almost always a mistake). If you need to output
+data, use `print()`; if you're debugging, a warning line is usually fine.
+A script that calls `rela.output` inside a loop will produce many warning
+lines in the rendered output — that is intentionally loud.
+
+### Links in rendered documents
+
+The goldmark→HTML step rewrites two custom URL schemes into data-entry
+form URLs, so documents can link directly to edit and create forms:
+
+| Scheme                      | Renders as                                           |
+|-----------------------------|------------------------------------------------------|
+| `edit://<type>/<id>`        | `/form/<type>/<id>?return_to=...` (edit an entity)   |
+| `create://<type>`           | `/form/<type>?return_to=...` (new entity)            |
+| `create://<type>?k=v&...`   | `/form/<type>?k=v&...&return_to=...` (with defaults) |
+
+The return URL points back to the entity view that hosts the document, so
+submitting the form returns the user to where they were.
+
+### Caching and live-reload
+
+- **Command renders** are cached on disk (`.rela/documents/<entry>-<hash>.html`).
+  The hash includes only the entry entity, so the cache refreshes when the
+  entry entity changes.
+- **Script renders** are not cached on disk. Use `rela.cache.memoize` inside
+  your script to share work across requests within the same server process.
+- **SSE live-reload** refreshes a document when the entry entity changes.
+  Multi-entity composition (a script that walks 20 related tickets) will
+  only re-render when the **entry** entity changes, not the walked ones.
+  The refresh button in the UI is the escape hatch. A follow-up ticket
+  (TKT-E1FO1) tracks the fix for explicit dependency tracking.
+
+### Security notes
+
+- Document scripts run in the same sandbox as action scripts: no `io`, no
+  `os`, no `debug`; file writes are confined to `output/` via
+  `rela.write_file`. Treat Lua scripts as trusted code.
+- The HTTP handler enforces `entity_type:` on every request: a document
+  configured for `entity_type: release` cannot be rendered against a
+  ticket, even if the caller bypasses the frontend filter.
+- Rendered markdown uses goldmark's `html.WithUnsafe` — the frontend
+  (DOMPurify) is the sanitization boundary. If you add another consumer of
+  the rendered HTML (PDF export, copy-HTML button, etc.), it must add its
+  own sanitization.
+
+### Config hot-reload
+
+Editing `data-entry.yaml` to change a document's `script:` or `command:`
+takes effect on the next request; open document panels pick up the new
+renderer on their next reload.
 
 ## Best Practices
 

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -522,6 +522,41 @@ end
 | `rela.params` | Action script parameters (table, from data-entry config) |
 | `rela.secrets` | Per-script secrets (table, from `.rela/secrets.yaml`) |
 | `rela.cache` | Process-wide memoization cache namespaced per script (see [Cache](#cache)) |
+| `rela.mode` | Set to `"document"` when rendering a data-entry document; `nil` otherwise (see [Document Mode](#document-mode)) |
+| `rela.document` | Present only in document mode; holds `{id, entry_id}` (see [Document Mode](#document-mode)) |
+
+### Document Mode
+
+When a data-entry document is configured with `script:` (see
+[Documents in the data-entry guide](GUIDE-data-entry.md#documents)), the
+script runs in a specialized mode with extra context exposed:
+
+| Variable                 | Meaning |
+|--------------------------|---------|
+| `rela.mode`              | `"document"` in this context; absent elsewhere |
+| `rela.document.id`       | The key under `documents:` in `data-entry.yaml` |
+| `rela.document.entry_id` | The ID of the entity being rendered |
+
+The script's stdout is captured and used as the rendered document's
+markdown (after goldmark → HTML conversion). Use `print()` to produce
+output.
+
+```lua
+-- scripts/docs/release_notes.lua
+local entry = rela.get_entity(rela.document.entry_id)
+print("# " .. (entry.properties.title or entry.id))
+```
+
+**`rela.output` in document mode** emits a warning line into the
+captured stdout (and thus into the rendered document) instead of
+writing JSON — captured stdout is the document body, so a raw JSON
+payload in the middle of markdown is almost always a mistake.
+
+**Cache policy**: `rela.cache.memoize` is namespaced by the script path,
+not by the document config. Two `documents:` entries that share one
+`.lua` file share a cache namespace — usually what you want (a helper
+script caches work across all its callers). If you need doc-scoped
+keys, include `rela.document.id` in your cache key explicitly.
 
 ### Secrets
 

--- a/frontend/src/components/entity/DocumentsPanel.vue
+++ b/frontend/src/components/entity/DocumentsPanel.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, nextTick, useTemplateRef } from 'vue'
 import { useSchemaStore, useUIStore } from '@/stores'
 import { renderDocument } from '@/api/documents'
 import { useEvents } from '@/composables/useEvents'
+import { renderMermaidDiagrams } from '@/utils/markdown'
 import type { DocumentConfig } from '@/types'
 import DOMPurify from 'dompurify'
 
@@ -21,9 +22,20 @@ const docContent = ref<string>('')
 const loading = ref(false)
 const isCached = ref(false)
 const entityIds = ref<string[]>([]) // Entity IDs involved in current document
+const docBody = useTemplateRef<HTMLElement>('docBody')
 
 // Sanitized content for safe rendering
 const sanitizedContent = computed(() => DOMPurify.sanitize(docContent.value))
+
+// Re-run mermaid rendering whenever the doc content is (re-)painted. The
+// rela-server's document renderer emits <pre class="mermaid">…</pre>
+// blocks that need mermaid.js to replace them with SVG.
+watch(sanitizedContent, async () => {
+  await nextTick()
+  if (docBody.value) {
+    await renderMermaidDiagrams(docBody.value)
+  }
+})
 
 // Find documents that apply to this entity type
 const availableDocuments = computed(() => {
@@ -132,7 +144,7 @@ function getDocTitle(name: string, config: DocumentConfig): string {
 
     <div v-else-if="docContent" class="document-content">
       <div v-if="isCached" class="cached-badge">cached</div>
-      <div class="document-body" v-html="sanitizedContent" />
+      <div ref="docBody" class="document-body" v-html="sanitizedContent" />
     </div>
 
     <div v-else class="empty-state">

--- a/frontend/src/utils/markdown.test.ts
+++ b/frontend/src/utils/markdown.test.ts
@@ -174,5 +174,29 @@ describe('markdown', () => {
       // Original code block should remain
       expect(container.querySelector('pre code.language-mermaid')).toBeTruthy()
     })
+
+    // The rela-server document renderer emits pre.mermaid (htmlutil
+    // pre-converts language-mermaid blocks). The util must handle both
+    // marked.js's form and this pre-rewritten form.
+    it('finds pre.mermaid blocks from rela document renderer', async () => {
+      const container = document.createElement('div')
+      container.innerHTML = '<pre class="mermaid">graph TD\nA--&gt;B</pre>'
+
+      const mermaid = await import('mermaid')
+      const renderSpy = vi.spyOn(mermaid.default, 'render').mockResolvedValue({
+        svg: '<svg>server-rendered</svg>',
+        diagramType: 'flowchart',
+        bindFunctions: vi.fn(),
+      })
+
+      await renderMermaidDiagrams(container)
+
+      expect(renderSpy).toHaveBeenCalled()
+      // textContent from the pre gets passed to mermaid; HTML entities
+      // have been decoded by the browser before we see them.
+      expect(renderSpy.mock.calls[0][1]).toBe('graph TD\nA-->B')
+      expect(container.querySelector('.mermaid-diagram')).toBeTruthy()
+      expect(container.querySelector('pre.mermaid')).toBeNull()
+    })
   })
 })

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -57,26 +57,46 @@ export function getCheckboxStats(content: string): { checked: number; total: num
 /**
  * Render markdown and then process mermaid diagrams.
  * Call this when the content is mounted in the DOM.
+ *
+ * Handles two source forms:
+ * - `<pre><code class="language-mermaid">…</code></pre>` — what marked.js
+ *   emits for our in-frontend markdown rendering (property views etc.).
+ * - `<pre class="mermaid">…</pre>` — what the rela-server document
+ *   renderer emits (goldmark + htmlutil.ConvertMermaidBlocks).
+ *
+ * Both forms are replaced in place with an SVG diagram (or left as-is
+ * on parse error).
  */
 export async function renderMermaidDiagrams(container: HTMLElement): Promise<void> {
-  const codeBlocks = container.querySelectorAll('pre > code.language-mermaid')
+  type Target = { pre: Element; source: string }
+  const targets: Target[] = []
 
-  for (const codeBlock of codeBlocks) {
+  // Form 1: marked.js-style fenced blocks.
+  for (const codeBlock of container.querySelectorAll('pre > code.language-mermaid')) {
     const pre = codeBlock.parentElement
-    if (!pre) continue
+    if (pre) targets.push({ pre, source: codeBlock.textContent || '' })
+  }
 
-    const code = codeBlock.textContent || ''
+  // Form 2: rela-server's pre-rewritten blocks. Guard against double-matching
+  // Form 1 (which would set class on the code, not the pre).
+  for (const pre of container.querySelectorAll('pre.mermaid')) {
+    // Already covered by Form 1 if it has a code child. It won't, but
+    // being explicit is cheap.
+    if (pre.querySelector('code.language-mermaid')) continue
+    targets.push({ pre, source: pre.textContent || '' })
+  }
+
+  for (const { pre, source } of targets) {
     const id = `mermaid-${++mermaidCounter}`
-
     try {
-      const { svg } = await mermaid.render(id, code)
+      const { svg } = await mermaid.render(id, source)
       const div = document.createElement('div')
       div.className = 'mermaid-diagram'
       div.innerHTML = svg
       pre.replaceWith(div)
     } catch (err) {
       console.error('Mermaid render error:', err)
-      // Leave the code block as-is on error
+      // Leave the block as-is on error.
     }
   }
 }

--- a/frontend/src/views/DocumentView.vue
+++ b/frontend/src/views/DocumentView.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, nextTick, useTemplateRef } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useSchemaStore, useUIStore } from '@/stores'
 import { renderDocument } from '@/api/documents'
 import { useEvents } from '@/composables/useEvents'
+import { renderMermaidDiagrams } from '@/utils/markdown'
 import DOMPurify from 'dompurify'
 
 const props = defineProps<{
@@ -25,6 +26,19 @@ const entityIds = ref<string[]>([])
 
 // Sanitized content for safe rendering
 const sanitizedContent = computed(() => DOMPurify.sanitize(docContent.value))
+
+// Template ref to the rendered body element so we can run mermaid on it.
+const docBody = useTemplateRef<HTMLElement>('docBody')
+
+// Re-run mermaid rendering whenever the doc content is (re-)painted. The
+// rela-server's document renderer emits <pre class="mermaid">…</pre>
+// blocks that need mermaid.js to replace them with SVG.
+watch(sanitizedContent, async () => {
+  await nextTick()
+  if (docBody.value) {
+    await renderMermaidDiagrams(docBody.value)
+  }
+})
 
 // Get document config
 const docConfig = computed(() => schemaStore.documents.get(props.name))
@@ -131,7 +145,7 @@ onUnmounted(() => {
 
     <div v-else-if="docContent" class="document-content">
       <div v-if="isCached" class="cached-badge">cached</div>
-      <div class="document-body" @click="handleContentClick" v-html="sanitizedContent" />
+      <div ref="docBody" class="document-body" @click="handleContentClick" v-html="sanitizedContent" />
     </div>
 
     <div v-else class="empty-state">

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -2001,20 +2001,43 @@ func (a *App) handleV1Documents(w http.ResponseWriter, r *http.Request) {
 	if !isSafePathSegment(docName) || !isSafePathSegment(entityID) {
 		writeV1Error(w, r, http.StatusBadRequest, "invalid_path", "Path segment contains forbidden characters", "")
 		return
-	} // Get document config
+	}
+
+	// Get document config
 	docCfg, ok := a.State().Cfg.Documents[docName]
 	if !ok {
 		writeV1Error(w, r, http.StatusNotFound, "document_not_found", "Document config not found", "")
 		return
 	}
 
-	renderCfg := a.toDocumentRenderConfig(&docCfg)
+	// Enforce the doc's entity_type before running the renderer: a
+	// release-notes script authored for releases must not run against a
+	// ticket. The frontend already filters the docs shown for an entity,
+	// but an HTTP caller can hit /_documents/<doc>/<wrong-type-id>
+	// directly; reject here.
+	ent, entErr := a.store.GetEntity(r.Context(), entityID)
+	if entErr != nil {
+		writeV1Error(w, r, http.StatusNotFound, "entity_not_found",
+			fmt.Sprintf("entity %q not found", entityID), "")
+		return
+	}
+	if ent.Type != docCfg.EntityType {
+		writeV1Error(w, r, http.StatusBadRequest, "entity_type_mismatch",
+			fmt.Sprintf("document %q is for entity_type %q, but %q is a %q",
+				docName, docCfg.EntityType, entityID, ent.Type), "")
+		return
+	}
+
+	renderCfg := a.toDocumentRenderConfig(docName, &docCfg)
 
 	// Check for refresh param - skip cache if present
 	forceRefresh := r.URL.Query().Get("refresh") == "true"
 
-	// Try to get cached content (unless refresh requested)
-	if !forceRefresh {
+	// Try to get cached content (unless refresh requested). Disk cache
+	// is only populated for command: renders (see doRender); skip the
+	// read for script: docs so we don't serve a stale command:-era file
+	// after a doc is switched to a Lua script.
+	if !forceRefresh && docCfg.Script == "" {
 		result := a.documents.GetCached(entityID)
 		if result != nil {
 			html := RewriteDocumentLinks(result.HTML, "")

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -2714,3 +2714,88 @@ func TestExtractEntityIDs_Empty(t *testing.T) {
 		t.Errorf("extractEntityIDs(nil) returned %d IDs, want 0", len(got))
 	}
 }
+
+// TestHandleV1Documents_EntityTypeMismatch verifies AC9 / RR-FLCXC:
+// the handler rejects a request whose entity.Type doesn't match the
+// document's configured entity_type, and does NOT run the renderer.
+func TestHandleV1Documents_EntityTypeMismatch(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{
+		ID:   "TKT-001",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title": "a ticket",
+		},
+	})
+	// Configure a document that applies only to features. Renderer is
+	// a shell command, but the handler must reject before it runs.
+	app.State().Cfg.Documents = map[string]dataentryconfig.DocumentConfig{
+		"feature-notes": {
+			EntityType: "feature",
+			Command:    "echo hello",
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_documents/feature-notes/TKT-001", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1Documents(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for type mismatch, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "entity_type") {
+		t.Errorf("expected body to mention entity_type, got: %s", rec.Body.String())
+	}
+}
+
+// TestHandleV1Documents_EntityTypeMatch verifies the positive case:
+// when the types line up, the handler proceeds past the type check.
+// We use a command doc so the test doesn't need Lua machinery; the
+// render may or may not succeed depending on the shell, but the
+// response must not be our explicit 400 mismatch error.
+func TestHandleV1Documents_EntityTypeMatch(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{
+		ID:   "TKT-001",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title": "a ticket",
+		},
+	})
+	app.State().Cfg.Documents = map[string]dataentryconfig.DocumentConfig{
+		"ticket-summary": {
+			EntityType: "ticket",
+			Command:    "echo hello",
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_documents/ticket-summary/TKT-001", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1Documents(rec, req)
+
+	// The renderer itself may succeed (echo in PATH) or fail; what we
+	// care about here is that the handler got past the type check.
+	if rec.Code == http.StatusBadRequest && strings.Contains(rec.Body.String(), "entity_type") {
+		t.Errorf("unexpected type-mismatch 400 for matching types: %s", rec.Body.String())
+	}
+}
+
+// TestHandleV1Documents_EntityNotFound verifies the 404 path for a
+// missing entry before any renderer runs.
+func TestHandleV1Documents_EntityNotFound(t *testing.T) {
+	app := newTestAppV1(t)
+	app.State().Cfg.Documents = map[string]dataentryconfig.DocumentConfig{
+		"notes": {
+			EntityType: "ticket",
+			Command:    "echo hi",
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_documents/notes/TKT-MISSING", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1Documents(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for missing entity, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -279,6 +279,19 @@ func NewApp(
 		}
 	}
 
+	// Verify document scripts exist on disk. Shell-command documents are
+	// not checkable this way (the binary may be on PATH at render time
+	// but unavailable now); Lua scripts live in scripts/ under the
+	// project root so existence can be verified upfront.
+	for id, doc := range cfg.Documents {
+		if doc.Script == "" {
+			continue
+		}
+		if err := script.CheckDocumentScriptExists(paths.Root, doc.Script); err != nil {
+			return nil, fmt.Errorf("invalid %s: document %q: %w", ConfigFile, id, err)
+		}
+	}
+
 	entCount, _ := st.CountEntities(context.Background(), store.EntityQuery{})
 	relCount, _ := st.CountRelations(context.Background(), store.RelationQuery{})
 	slog.Info("loaded project", "entities", entCount, "relations", relCount)
@@ -286,6 +299,7 @@ func NewApp(
 	// Build style map from config styles
 	styleMap, styledTypes := buildStyleMap(&cfg, meta)
 
+	scriptEngine := script.NewEngine()
 	app := &App{
 		fs:            fs,
 		paths:         paths,
@@ -299,9 +313,12 @@ func NewApp(
 		kv:            kv,
 		startWatching: startWatching,
 		broker:        newEventBroker(),
-		documents:     newDocumentService(st, kv, paths.Root),
-		scriptEngine:  script.NewEngine(),
+		scriptEngine:  scriptEngine,
 	}
+	// documentService needs scriptEngine (for Lua renders) and a closure
+	// that yields fresh lua.WriteDeps (so metamodel reloads propagate).
+	// Constructed after app because luaWriteDeps is a method on App.
+	app.documents = newDocumentService(st, kv, paths.Root, scriptEngine, app.luaWriteDeps)
 
 	userDefaults := app.loadUserDefaults()
 	userPalette, paletteErr := app.loadUserPalette()

--- a/internal/dataentry/document.go
+++ b/internal/dataentry/document.go
@@ -3,8 +3,10 @@ package dataentry
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"log/slog"
 	"net/url"
 	"os/exec"
@@ -22,22 +24,48 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/htmlutil"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/state"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
-// docCacheDir is the subdirectory under .rela/ for document cache files.
-const docCacheDir = "documents"
+// documentScriptEngine is the minimum contract documentService needs from
+// script.Engine to run a Lua document renderer. Defined at the consumer
+// side (per CLAUDE.md) so tests can substitute a fake and the engine
+// stays decoupled from the data-entry package.
+type documentScriptEngine interface {
+	ExecuteDocument(path string, deps lua.WriteDeps, stdout io.Writer,
+		documentID, entryID string, timeout time.Duration) error
+}
+
+// documentDeps yields the lua.WriteDeps the script engine needs. The App
+// constructs these from its current metamodel snapshot, so we keep the
+// dependency as a function to avoid stale deps after reload.
+type documentDepsFunc func() lua.WriteDeps
+
+// docCacheSubdir is the subdirectory under .rela/ for document cache files.
+const docCacheSubdir = "documents"
 
 // documentRenderConfig is the internal render configuration — the
 // external config is dataentryconfig.DocumentConfig (YAML), which
 // toDocumentRenderConfig converts.
 type documentRenderConfig struct {
+	// ConfigID is the key under `documents:` in data-entry.yaml. It is
+	// the document identity seen by scripts as rela.document.id, and
+	// participates in the singleflight/cache key so concurrent renders
+	// of different documents against the same entry don't collapse.
+	ConfigID string
 	// Command is the external render command. Placeholders:
 	//   {id}       - entry ID
 	//   {id_lower} - lowercase entry ID
+	// Mutually exclusive with Script.
 	Command string
-	// Timeout is the command execution timeout. Defaults to 30s.
+	// Script is a relative path under scripts/ to a Lua file. When set,
+	// the renderer runs the Lua script via script.Engine.ExecuteDocument
+	// and captures its stdout as markdown. Mutually exclusive with Command.
+	Script string
+	// Timeout is the render timeout. Defaults to 30s. Applies to both
+	// renderers.
 	Timeout time.Duration
 }
 
@@ -51,33 +79,51 @@ type DocumentResult struct {
 	Entities []*entity.Entity
 }
 
-// documentService renders documents by invoking an external command and
-// caches results keyed by an FNV hash of the source entities. It is
-// safe for concurrent use: render requests for the same entry are
-// deduped via singleflight.
+// documentService renders documents by invoking an external command or a
+// Lua script and caches command-renderer results on disk keyed by an FNV
+// hash of the source entities. It is safe for concurrent use: render
+// requests are deduped via singleflight on (entryID, configID) so two
+// documents against the same entry do not collapse onto one render.
+//
+// Disk cache policy: only command: renders read and write .rela/documents/.
+// script: renders bypass disk cache on both sides — Lua's in-process
+// rela.cache.memoize is the caching story for scripts, and reading an old
+// command:-era cache file for a script: request would serve stale HTML.
 type documentService struct {
-	store       store.Store
-	state       state.KV
-	projectRoot string
-	group       singleflight.Group
+	store        store.Store
+	state        state.KV
+	projectRoot  string
+	scriptEngine documentScriptEngine
+	luaDeps      documentDepsFunc
+	group        singleflight.Group
 }
 
-// newDocumentService builds a documentService from the three inputs it
-// needs. All three are retained by reference — the service is not a
-// snapshot.
-func newDocumentService(st store.Store, kv state.KV, projectRoot string) *documentService {
-	return &documentService{store: st, state: kv, projectRoot: projectRoot}
+// newDocumentService builds a documentService. scriptEngine and luaDeps
+// may be nil in tests that only exercise the command: path.
+func newDocumentService(st store.Store, kv state.KV, projectRoot string,
+	engine documentScriptEngine, deps documentDepsFunc) *documentService {
+	return &documentService{
+		store:        st,
+		state:        kv,
+		projectRoot:  projectRoot,
+		scriptEngine: engine,
+		luaDeps:      deps,
+	}
 }
 
 // GetCached returns a cached document if available and still valid.
 // Returns nil if the cache is missing, stale, or on any error.
+//
+// Script renders do NOT populate this cache and callers should not read
+// it for script: docs (see Render); a stale command:-era file at the
+// same path would otherwise shadow the Lua render.
 func (s *documentService) GetCached(entryID string) *DocumentResult {
 	entities, contentHash, err := s.computeDocumentHash(entryID)
 	if err != nil {
 		return nil
 	}
 
-	cacheFile := fmt.Sprintf("%s/%s-%s.html", docCacheDir, entryID, contentHash)
+	cacheFile := fmt.Sprintf("%s/%s-%s.html", docCacheSubdir, entryID, contentHash)
 	cachedHTML, _ := s.state.Get(context.Background(), cacheFile)
 	if cachedHTML == nil {
 		return nil
@@ -90,18 +136,24 @@ func (s *documentService) GetCached(entryID string) *DocumentResult {
 	}
 }
 
-// Render renders a document by executing the configured command. Uses
-// singleflight to dedupe concurrent requests. Caches the result to disk.
+// Render renders a document via the configured renderer (command or
+// script). Singleflight dedupes concurrent requests for the same
+// (entryID, ConfigID) pair — renders of the same entry under *different*
+// document configs proceed in parallel. Command renders cache to disk;
+// script renders do not.
 func (s *documentService) Render(entryID string, cfg documentRenderConfig) (*DocumentResult, error) {
 	entities, contentHash, err := s.computeDocumentHash(entryID)
 	if err != nil {
 		return nil, fmt.Errorf("computing document hash: %w", err)
 	}
 
-	cacheFile := fmt.Sprintf("%s/%s-%s.html", docCacheDir, entryID, contentHash)
+	cacheFile := fmt.Sprintf("%s/%s-%s.html", docCacheSubdir, entryID, contentHash)
 
-	// Use singleflight to dedupe concurrent render requests for the same entry
-	result, err, _ := s.group.Do(entryID, func() (interface{}, error) {
+	// Singleflight key must include ConfigID: if two documents (different
+	// configs) target the same entry, they are distinct renders and must
+	// not collapse onto one another's HTML (RR-4QSBN).
+	sfKey := entryID + "|" + cfg.ConfigID
+	result, err, _ := s.group.Do(sfKey, func() (interface{}, error) {
 		return s.doRender(entryID, cfg, entities, contentHash, cacheFile)
 	})
 	if err != nil {
@@ -112,15 +164,19 @@ func (s *documentService) Render(entryID string, cfg documentRenderConfig) (*Doc
 	return docResult, nil
 }
 
-// doRender performs the actual rendering work.
+// doRender performs the actual rendering work. Dispatches on Script vs.
+// Command — these are mutually exclusive at config load (see
+// dataentryconfig.validateDocuments) so exactly one branch fires.
 func (s *documentService) doRender(
 	entryID string, cfg documentRenderConfig, entities []*entity.Entity, contentHash, cacheFile string,
 ) (*DocumentResult, error) {
-	command := cfg.Command
-	command = strings.ReplaceAll(command, "{id}", entryID)
-	command = strings.ReplaceAll(command, "{id_lower}", strings.ToLower(entryID))
-
-	markdown, err := s.executeCommand(command, cfg.Timeout)
+	var markdown string
+	var err error
+	if cfg.Script != "" {
+		markdown, err = s.renderScript(entryID, cfg)
+	} else {
+		markdown, err = s.renderCommand(entryID, cfg)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -130,12 +186,15 @@ func (s *documentService) doRender(
 		return nil, fmt.Errorf("markdown conversion: %w", err)
 	}
 
-	// Cache the result to disk. The cache is optional — a failure here is
-	// not fatal — but it must be visible: silent cache rejections previously
-	// hid validation regressions where unsafe IDs caused every render to
-	// re-execute the command.
-	if writeErr := s.state.Put(context.Background(), cacheFile, []byte(htmlContent)); writeErr != nil {
-		slog.Warn("document cache write failed", "error", writeErr)
+	// Disk cache is only populated for command: renders. Lua renders
+	// have their own process-lifetime cache via rela.cache.memoize; the
+	// disk-cache filename is renderer-agnostic (FNV of the entry entity)
+	// so writing script-render output here would make a subsequent
+	// command: run read stale bytes from the wrong renderer.
+	if cfg.Script == "" {
+		if writeErr := s.state.Put(context.Background(), cacheFile, []byte(htmlContent)); writeErr != nil {
+			slog.Warn("document cache write failed", "error", writeErr)
+		}
 	}
 
 	return &DocumentResult{
@@ -143,6 +202,29 @@ func (s *documentService) doRender(
 		ContentHash: contentHash,
 		Entities:    entities,
 	}, nil
+}
+
+// renderCommand invokes the external render command and returns its stdout
+// as markdown. Placeholder substitution happens on the command string.
+func (s *documentService) renderCommand(entryID string, cfg documentRenderConfig) (string, error) {
+	command := cfg.Command
+	command = strings.ReplaceAll(command, "{id}", entryID)
+	command = strings.ReplaceAll(command, "{id_lower}", strings.ToLower(entryID))
+	return s.executeCommand(command, cfg.Timeout)
+}
+
+// renderScript executes a Lua document script and returns its captured
+// stdout as markdown.
+func (s *documentService) renderScript(entryID string, cfg documentRenderConfig) (string, error) {
+	if s.scriptEngine == nil || s.luaDeps == nil {
+		return "", errors.New("script rendering not available (engine or deps not wired)")
+	}
+	var buf bytes.Buffer
+	if err := s.scriptEngine.ExecuteDocument(cfg.Script, s.luaDeps(), &buf,
+		cfg.ConfigID, entryID, cfg.Timeout); err != nil {
+		return "", fmt.Errorf("script render: %w", err)
+	}
+	return buf.String(), nil
 }
 
 // computeDocumentHash computes a content hash for cache validation.
@@ -188,8 +270,18 @@ func hashEntities(entities []*entity.Entity) string {
 	return strconv.FormatUint(h.Sum64(), 16)
 }
 
+// commandDefaultTimeout is the fallback render timeout for shell-command
+// documents when data-entry.yaml omits `timeout:`. Script-backed documents
+// fall back separately inside script.Engine.ExecuteDocument (via
+// lua.DefaultTimeout). Keeping the default per-renderer prevents a zero
+// value from producing an already-expired context.
+const commandDefaultTimeout = 30 * time.Second
+
 // executeCommand runs an external command and returns its stdout.
 func (s *documentService) executeCommand(command string, timeout time.Duration) (string, error) {
+	if timeout <= 0 {
+		timeout = commandDefaultTimeout
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/internal/dataentry/document_script_test.go
+++ b/internal/dataentry/document_script_test.go
@@ -1,0 +1,429 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/script"
+	"github.com/Sourcehaven-BV/rela/internal/state"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+	"github.com/Sourcehaven-BV/rela/internal/tracer"
+)
+
+// stubEntityManager lets us build a lua.WriteDeps that won't actually
+// mutate anything. Document scripts are read-only in practice but the
+// writer runtime requires a non-nil EntityManager.
+type docTestStubEM struct{}
+
+func (docTestStubEM) CreateEntity(context.Context, *entity.Entity,
+	entitymanager.CreateOptions) (*entitymanager.CreateResult, error) {
+	panic("not expected")
+}
+func (docTestStubEM) UpdateEntity(context.Context, *entity.Entity) (*entitymanager.UpdateResult, error) {
+	panic("not expected")
+}
+func (docTestStubEM) DeleteEntity(context.Context, string, bool) (*entitymanager.DeleteResult, error) {
+	panic("not expected")
+}
+func (docTestStubEM) RenameEntity(context.Context, string, string,
+	entitymanager.RenameOptions) (*entitymanager.RenameResult, error) {
+	panic("not expected")
+}
+func (docTestStubEM) CreateRelation(context.Context, string, string, string,
+	entitymanager.RelationOptions) (*entity.Relation, error) {
+	panic("not expected")
+}
+func (docTestStubEM) UpdateRelation(context.Context, string, string, string,
+	entitymanager.RelationOptions) (*entity.Relation, error) {
+	panic("not expected")
+}
+func (docTestStubEM) DeleteRelation(context.Context, string, string, string) error {
+	panic("not expected")
+}
+
+// fakeScriptEngine is a test double for documentScriptEngine. Each call
+// writes the fake's `stdout` string and records the invocation args so
+// tests can assert what the service passed through.
+type fakeScriptEngine struct {
+	mu     sync.Mutex
+	calls  []fakeScriptCall
+	stdout func(args fakeScriptCall) string // produces the per-call output
+	delay  time.Duration                    // per-call sleep (tests concurrency)
+	err    error
+}
+
+// callCount returns the number of ExecuteDocument invocations so far.
+// Lock the mutex to match the write side in ExecuteDocument; callers
+// that drain through a channel already happen-before this read, but
+// tests that poll still need the lock.
+func (f *fakeScriptEngine) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+type fakeScriptCall struct {
+	path       string
+	documentID string
+	entryID    string
+	timeout    time.Duration
+}
+
+func (f *fakeScriptEngine) ExecuteDocument(path string, _ lua.WriteDeps, stdout io.Writer,
+	documentID, entryID string, timeout time.Duration) error {
+	call := fakeScriptCall{path: path, documentID: documentID, entryID: entryID, timeout: timeout}
+	f.mu.Lock()
+	f.calls = append(f.calls, call)
+	f.mu.Unlock()
+
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	if f.err != nil {
+		return f.err
+	}
+	if f.stdout != nil {
+		_, _ = io.WriteString(stdout, f.stdout(call))
+	}
+	return nil
+}
+
+// newTestService builds a documentService wired to an in-memory store
+// and KV. The caller supplies any entities the test needs to exist; the
+// fakeScriptEngine is returned so tests can inspect/configure it.
+func newTestService(t *testing.T, entities ...*entity.Entity) (*documentService, *fakeScriptEngine) {
+	t.Helper()
+
+	st := memstore.New()
+	for _, e := range entities {
+		if err := st.CreateEntity(context.Background(), e); err != nil {
+			t.Fatalf("seed entity %q: %v", e.ID, err)
+		}
+	}
+
+	fs := storage.NewMemFS()
+	if err := fs.MkdirAll("/p/.rela", 0o755); err != nil {
+		t.Fatalf("mkdir .rela: %v", err)
+	}
+	kvRoot, err := storage.NewRootedFS(fs, "/p/.rela")
+	if err != nil {
+		t.Fatalf("NewRootedFS: %v", err)
+	}
+	kv := state.NewFSKV(kvRoot)
+
+	fake := &fakeScriptEngine{}
+	// Deps are never actually read by the fake; the zero value is fine.
+	deps := func() lua.WriteDeps { return lua.WriteDeps{} }
+
+	return newDocumentService(st, kv, "/p", fake, deps), fake
+}
+
+// reqEntity is a convenience factory for the tests below, all of which
+// render the same REQ-001 entity. No test reads the title back, so it's
+// a fixed placeholder. If a future test needs a different ID, construct
+// an entity.Entity directly.
+func reqEntity() *entity.Entity {
+	return &entity.Entity{
+		ID:         "REQ-001",
+		Type:       "requirement",
+		Properties: map[string]interface{}{"title": "a req"},
+	}
+}
+
+// TestDocumentService_ScriptRender_CapturesMarkdown verifies the Lua
+// renderer dispatch (AC1): when cfg.Script is set, the service routes
+// to scriptEngine.ExecuteDocument, uses captured stdout as markdown,
+// and returns HTML through the shared goldmark pipeline.
+func TestDocumentService_ScriptRender_CapturesMarkdown(t *testing.T) {
+	s, fake := newTestService(t, reqEntity())
+	fake.stdout = func(_ fakeScriptCall) string { return "# Heading\n\nbody" }
+
+	result, err := s.Render("REQ-001", documentRenderConfig{
+		ConfigID: "notes",
+		Script:   "docs/notes.lua",
+		Timeout:  5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if !strings.Contains(result.HTML, "<h1") {
+		t.Errorf("expected <h1 in HTML, got %q", result.HTML)
+	}
+	if !strings.Contains(result.HTML, "body") {
+		t.Errorf("expected body text in HTML, got %q", result.HTML)
+	}
+
+	if len(fake.calls) != 1 {
+		t.Fatalf("expected 1 script call, got %d", len(fake.calls))
+	}
+	call := fake.calls[0]
+	if call.path != "docs/notes.lua" {
+		t.Errorf("path: got %q, want %q", call.path, "docs/notes.lua")
+	}
+	if call.documentID != "notes" {
+		t.Errorf("documentID: got %q, want %q", call.documentID, "notes")
+	}
+	if call.entryID != "REQ-001" {
+		t.Errorf("entryID: got %q, want %q", call.entryID, "REQ-001")
+	}
+	if call.timeout != 5*time.Second {
+		t.Errorf("timeout: got %v, want %v", call.timeout, 5*time.Second)
+	}
+}
+
+// TestDocumentService_ScriptRender_NoDiskCacheWrite verifies AC10:
+// script: renders do not populate the disk cache. The frontend hits
+// GetCached first; if script renders wrote to disk their old output
+// could be served to a later command: config on the same entry.
+func TestDocumentService_ScriptRender_NoDiskCacheWrite(t *testing.T) {
+	s, fake := newTestService(t, reqEntity())
+	fake.stdout = func(_ fakeScriptCall) string { return "lua output" }
+
+	if _, err := s.Render("REQ-001", documentRenderConfig{
+		ConfigID: "notes",
+		Script:   "docs/notes.lua",
+	}); err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	// After render, GetCached should return nil — nothing was written.
+	if result := s.GetCached("REQ-001"); result != nil {
+		t.Errorf("expected no cache entry after script render, got %q", result.HTML)
+	}
+}
+
+// TestDocumentService_ScriptRender_StaleCommandCacheIgnored verifies
+// the second half of AC10: a pre-existing command:-era cache file at
+// the same key must not be served for a script: render. The service
+// always re-renders for script: configs.
+func TestDocumentService_ScriptRender_StaleCommandCacheIgnored(t *testing.T) {
+	// Note: the HTTP handler is what skips GetCached for script: docs;
+	// Render itself will re-render regardless (doRender for script
+	// always runs). This test proves the Render side: a script render
+	// returns fresh content even when GetCached would have returned
+	// something stale. It complements the handler-level test which
+	// exercises the skip.
+	s, fake := newTestService(t, reqEntity())
+	fake.stdout = func(_ fakeScriptCall) string { return "fresh lua output" }
+
+	// Manually seed a stale command-era cache entry.
+	_, hash, err := s.computeDocumentHash("REQ-001")
+	if err != nil {
+		t.Fatalf("computeDocumentHash: %v", err)
+	}
+	cacheFile := docCacheSubdir + "/REQ-001-" + hash + ".html"
+	if putErr := s.state.Put(context.Background(), cacheFile, []byte("<p>stale</p>")); putErr != nil {
+		t.Fatalf("seed stale cache: %v", putErr)
+	}
+
+	result, err := s.Render("REQ-001", documentRenderConfig{
+		ConfigID: "notes",
+		Script:   "docs/notes.lua",
+	})
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if strings.Contains(result.HTML, "stale") {
+		t.Errorf("script render returned stale cache contents: %q", result.HTML)
+	}
+	if !strings.Contains(result.HTML, "fresh lua output") {
+		t.Errorf("expected fresh output, got %q", result.HTML)
+	}
+	if fake.callCount() != 1 {
+		t.Errorf("expected script engine to run once, got %d calls", fake.callCount())
+	}
+}
+
+// TestDocumentService_SingleflightNoCollapseAcrossConfigs verifies
+// RR-4QSBN / AC8: two concurrent Render calls for the same entry but
+// different ConfigIDs must both run the script — singleflight must
+// NOT collapse them. Previous key (entryID alone) would have served
+// the first caller's output to both.
+func TestDocumentService_SingleflightNoCollapseAcrossConfigs(t *testing.T) {
+	s, fake := newTestService(t, reqEntity())
+
+	// Slow-down so the two goroutines overlap in singleflight's key
+	// window: without the key fix, the second caller would block on
+	// the first and receive its output.
+	fake.delay = 50 * time.Millisecond
+	fake.stdout = func(args fakeScriptCall) string {
+		return "output for " + args.documentID
+	}
+
+	type renderResult struct {
+		docID string
+		html  string
+		err   error
+	}
+	resultsCh := make(chan renderResult, 2)
+	for _, docID := range []string{"docA", "docB"} {
+		go func(d string) {
+			r, err := s.Render("REQ-001", documentRenderConfig{
+				ConfigID: d,
+				Script:   "docs/" + d + ".lua",
+			})
+			if err != nil {
+				resultsCh <- renderResult{docID: d, err: err}
+				return
+			}
+			resultsCh <- renderResult{docID: d, html: r.HTML}
+		}(docID)
+	}
+
+	got := map[string]string{}
+	for range 2 {
+		r := <-resultsCh
+		if r.err != nil {
+			t.Fatalf("render %s: %v", r.docID, r.err)
+		}
+		got[r.docID] = r.html
+	}
+
+	if !strings.Contains(got["docA"], "output for docA") {
+		t.Errorf("docA got wrong output (singleflight collapsed?): %q", got["docA"])
+	}
+	if !strings.Contains(got["docB"], "output for docB") {
+		t.Errorf("docB got wrong output (singleflight collapsed?): %q", got["docB"])
+	}
+	if fake.callCount() != 2 {
+		t.Errorf("expected 2 script executions, got %d", fake.callCount())
+	}
+}
+
+// TestDocumentService_SingleflightCollapsesSameConfig is the positive
+// complement: two concurrent renders of the SAME (entryID, configID)
+// should still collapse onto a single execution.
+func TestDocumentService_SingleflightCollapsesSameConfig(t *testing.T) {
+	s, fake := newTestService(t, reqEntity())
+	fake.delay = 50 * time.Millisecond
+	fake.stdout = func(_ fakeScriptCall) string { return "same doc" }
+
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = s.Render("REQ-001", documentRenderConfig{
+				ConfigID: "same",
+				Script:   "docs/same.lua",
+			})
+		}()
+	}
+	wg.Wait()
+
+	if fake.callCount() != 1 {
+		t.Errorf("expected 1 script execution (singleflight dedupe), got %d", fake.callCount())
+	}
+}
+
+// TestDocumentService_ScriptError surfaces Lua errors to the caller.
+func TestDocumentService_ScriptError(t *testing.T) {
+	s, fake := newTestService(t, reqEntity())
+	fake.err = errors.New("lua blew up")
+
+	_, err := s.Render("REQ-001", documentRenderConfig{
+		ConfigID: "notes",
+		Script:   "docs/notes.lua",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "lua blew up") {
+		t.Errorf("expected Lua error to surface, got %v", err)
+	}
+}
+
+// TestDocumentService_CacheMemoizeAcrossRenders verifies AC6: Lua
+// scripts using rela.cache.memoize share state across successive
+// render calls within the same process. The compute fn writes a marker
+// line to output/counter.log via rela.write_file; after two renders the
+// file should contain exactly one line.
+//
+// Uses a real script.Engine (not the fake) so we exercise the actual
+// rela.cache plumbing end-to-end.
+func TestDocumentService_CacheMemoizeAcrossRenders(t *testing.T) {
+	projectRoot := t.TempDir()
+	// Write the lua script.
+	scriptsDir := filepath.Join(projectRoot, "scripts", "docs")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	scriptBody := `
+-- Memoized "compute" writes a line to output/counter.log on first run
+-- and returns a cached string on subsequent runs. After two document
+-- renders the file should contain exactly one line: proof that the fn
+-- only executed once across the two renders.
+local got = rela.cache.memoize("counter-key", function()
+  rela.write_file("counter.log", "ran\n", {ensure_newline = true})
+  return "computed"
+end)
+print("# doc")
+print(got)
+`
+	if err := os.WriteFile(filepath.Join(scriptsDir, "memo.lua"), []byte(scriptBody), 0o644); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	// Build a documentService wired to a real script.Engine + real deps
+	// pointing at the tempdir project.
+	st := memstore.New()
+	if err := st.CreateEntity(context.Background(), reqEntity()); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	fs := storage.NewMemFS()
+	_ = fs.MkdirAll("/p/.rela", 0o755)
+	kvRoot, err := storage.NewRootedFS(fs, "/p/.rela")
+	if err != nil {
+		t.Fatalf("NewRootedFS: %v", err)
+	}
+	kv := state.NewFSKV(kvRoot)
+
+	engine := script.NewEngine()
+	deps := func() lua.WriteDeps {
+		return lua.WriteDeps{
+			ReadDeps: lua.ReadDeps{
+				Store:       st,
+				Tracer:      tracer.New(st),
+				ProjectRoot: projectRoot,
+			},
+			EntityManager: docTestStubEM{},
+		}
+	}
+	s := newDocumentService(st, kv, projectRoot, engine, deps)
+
+	cfg := documentRenderConfig{
+		ConfigID: "notes",
+		Script:   "docs/memo.lua",
+		Timeout:  5 * time.Second,
+	}
+
+	for i := range 2 {
+		if _, renderErr := s.Render("REQ-001", cfg); renderErr != nil {
+			t.Fatalf("render %d: %v", i, renderErr)
+		}
+	}
+
+	counterFile := filepath.Join(projectRoot, "output", "counter.log")
+	data, err := os.ReadFile(counterFile)
+	if err != nil {
+		t.Fatalf("read counter.log: %v", err)
+	}
+	// ensure_newline=true on rela.write_file guarantees a trailing
+	// newline, so counting '\n' gives the number of lines written.
+	lines := strings.Count(string(data), "\n")
+	if lines != 1 {
+		t.Errorf("expected 1 line in counter.log (memoize ran once), got %d lines: %q",
+			lines, string(data))
+	}
+}

--- a/internal/dataentry/document_test.go
+++ b/internal/dataentry/document_test.go
@@ -230,7 +230,7 @@ func TestDocumentDiskCache(t *testing.T) {
 	t.Run("cache file naming", func(t *testing.T) {
 		entryID := "REQ-001"
 		hash := "abc123"
-		cacheFile := docCacheDir + "/" + entryID + "-" + hash + ".html"
+		cacheFile := docCacheSubdir + "/" + entryID + "-" + hash + ".html"
 		content := "<p>Test HTML</p>"
 
 		if err := kv.Put(context.Background(), cacheFile, []byte(content)); err != nil {
@@ -249,8 +249,8 @@ func TestDocumentDiskCache(t *testing.T) {
 		entryID := "REQ-002"
 		hash1 := "hash1"
 		hash2 := "hash2"
-		cacheFile1 := docCacheDir + "/" + entryID + "-" + hash1 + ".html"
-		cacheFile2 := docCacheDir + "/" + entryID + "-" + hash2 + ".html"
+		cacheFile1 := docCacheSubdir + "/" + entryID + "-" + hash1 + ".html"
+		cacheFile2 := docCacheSubdir + "/" + entryID + "-" + hash2 + ".html"
 
 		_ = kv.Put(context.Background(), cacheFile1, []byte("content1"))
 		_ = kv.Put(context.Background(), cacheFile2, []byte("content2"))

--- a/internal/dataentry/e2e_test.go
+++ b/internal/dataentry/e2e_test.go
@@ -24,8 +24,7 @@ import (
 
 	"github.com/chromedp/chromedp"
 
-	"github.com/Sourcehaven-BV/rela/internal/project"
-	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
@@ -50,21 +49,17 @@ func newE2ETestApp(t *testing.T) (*App, string, func()) {
 		t.Fatalf("copying prototype: %v", err)
 	}
 
-	ctx := &project.Context{
-		Root:          projectDir,
-		MetamodelPath: filepath.Join(projectDir, "metamodel.yaml"),
-		EntitiesDir:   filepath.Join(projectDir, "entities"),
-		RelationsDir:  filepath.Join(projectDir, "relations"),
-		CacheDir:      filepath.Join(projectDir, ".rela"),
-	}
-	_ = os.MkdirAll(ctx.CacheDir, 0o755)
+	_ = os.MkdirAll(filepath.Join(projectDir, ".rela"), 0o755)
 
-	fs := storage.NewSafeFS(storage.NewOsFS())
-	ws, err := workspace.New(fs, ctx, workspace.NopScriptExecutor)
+	ws, err := workspace.Discover(projectDir, script.NewEngine())
 	if err != nil {
 		t.Fatalf("creating workspace: %v", err)
 	}
-	app, err := NewApp(ws)
+	app, err := NewApp(
+		ws.FS(), ws.Paths(), ws.Meta(), ws.Store(),
+		ws.EntityManager(), ws.Searcher(),
+		ws.StartWatching,
+	)
 	if err != nil {
 		t.Fatalf("creating app: %v", err)
 	}
@@ -222,5 +217,84 @@ func TestE2E_FormFieldSubmit(t *testing.T) {
 
 	if !strings.Contains(string(savedData), newTitle) {
 		t.Errorf("saved content does not contain new title %q\n\nSaved content:\n%s", newTitle, savedData)
+	}
+}
+
+// TestE2E_LuaDocumentRenders verifies the full path for a Lua-rendered
+// document in a headless browser: navigate to the entity detail page,
+// wait for DocumentsPanel to fetch /api/v1/_documents/..., and assert
+// the rendered HTML contains markers produced by the Lua script plus
+// a rewritten edit:// link. Exercises the full chain:
+//
+//   HTTP handler → documentService.Render → script.Engine.ExecuteDocument
+//   → Lua VM (with rela.document bindings) → goldmark → DOMPurify in browser
+//
+// The prototype ships `scripts/docs/category_report.lua` wired as the
+// `category_overview` document for entity_type `category`. The `backend`
+// category has multiple belongs-to tickets, so the rendered output must
+// contain both a ticket-table row and a rewritten form link.
+func TestE2E_LuaDocumentRenders(t *testing.T) {
+	app, _, cleanup := newE2ETestApp(t)
+	defer cleanup()
+
+	server := httptest.NewServer(app.NewRouter())
+	defer server.Close()
+
+	opts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.Flag("headless", true),
+		chromedp.Flag("disable-gpu", true),
+		chromedp.Flag("no-sandbox", true),
+	)
+
+	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), opts...)
+	defer allocCancel()
+
+	ctx, cancel := chromedp.NewContext(allocCtx)
+	defer cancel()
+
+	ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	var panelHTML string
+	err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/entity/category/backend"),
+
+		// DocumentsPanel renders asynchronously after the initial page
+		// load, once it fetches the rendered HTML. Wait for the body
+		// element specifically (not just the panel container) so we
+		// know render has completed.
+		chromedp.WaitVisible(`.documents-panel .document-body`, chromedp.ByQuery),
+
+		// Small buffer for v-html + DOMPurify to actually paint.
+		chromedp.Sleep(300*time.Millisecond),
+
+		chromedp.OuterHTML(`.documents-panel .document-body`, &panelHTML),
+	)
+	if err != nil {
+		t.Fatalf("browser automation failed: %v\n\nlast panel HTML:\n%s", err, panelHTML)
+	}
+
+	// The Lua script always prints "## Tickets (N)" as a section header,
+	// independent of N — so this assertion survives prototype fixture
+	// changes (adding/removing tickets or belongs-to relations for the
+	// `backend` category). If the header stops appearing entirely, the
+	// Lua render itself is broken.
+	if !strings.Contains(panelHTML, "Tickets (") {
+		t.Errorf("expected rendered doc to contain 'Tickets (' header, got:\n%s", panelHTML)
+	}
+
+	// The script emits edit:// links via a markdown table. goldmark's
+	// HTML output is postprocessed by the data-entry layer to rewrite
+	// them as /form/... links. DOMPurify then sanitizes in the browser.
+	// Finding a /form/ticket/ href proves the rewrite happened end-to-end.
+	if !strings.Contains(panelHTML, "/form/ticket/") {
+		t.Errorf("expected rewritten /form/ticket/... link in panel, got:\n%s", panelHTML)
+	}
+
+	// The edit:// scheme must NOT leak through as a raw href: DOMPurify
+	// would strip it as an unknown scheme, but the upstream rewrite
+	// should have consumed every occurrence first.
+	if strings.Contains(panelHTML, "edit://") {
+		t.Errorf("expected edit:// scheme to be rewritten, found raw in panel:\n%s", panelHTML)
 	}
 }

--- a/internal/dataentry/handlers_document.go
+++ b/internal/dataentry/handlers_document.go
@@ -3,14 +3,20 @@ package dataentry
 import "time"
 
 // toDocumentRenderConfig converts the YAML-facing DocumentConfig into
-// the internal render config.
-func (a *App) toDocumentRenderConfig(cfg *DocumentConfig) documentRenderConfig {
-	timeout := time.Duration(cfg.Timeout) * time.Second
-	if timeout == 0 {
-		timeout = 30 * time.Second
-	}
+// the internal render config. configID is the key under `documents:` in
+// data-entry.yaml — propagated into the render config so it participates
+// in the singleflight/cache key and is exposed to Lua scripts as
+// rela.document.id.
+//
+// Timeout: YAML 0 (unset) is preserved as a zero time.Duration. Each
+// renderer chooses its own default — executeCommand clamps to 30s,
+// script.Engine.ExecuteDocument delegates to lua.DefaultTimeout. Keeping
+// the default in one place per renderer prevents silent drift.
+func (a *App) toDocumentRenderConfig(configID string, cfg *DocumentConfig) documentRenderConfig {
 	return documentRenderConfig{
-		Command: cfg.Command,
-		Timeout: timeout,
+		ConfigID: configID,
+		Command:  cfg.Command,
+		Script:   cfg.Script,
+		Timeout:  time.Duration(cfg.Timeout) * time.Second,
 	}
 }

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -128,6 +128,12 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, ws *workspace.Wo
 	app.cfgLoader = ws.Config()
 	app.kv = ws.State()
 	app.startWatching = ws.StartWatching
+	// Wire a minimal documentService for tests that hit the documents
+	// handler. Script engine can be the real one (tests that use script:
+	// configs will need to seed scripts on disk).
+	if app.scriptEngine != nil {
+		app.documents = newDocumentService(app.store, app.kv, "/", app.scriptEngine, app.luaWriteDeps)
+	}
 }
 
 // reseedStore copies every entity and relation from src into dst.

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -434,16 +434,30 @@ type CommandScope struct {
 }
 
 // DocumentConfig defines how to render a document from an entry entity.
+//
+// Exactly one of Command or Script must be set. Command shells out to an
+// external process that produces markdown on stdout; Script executes a Lua
+// script from scripts/ under the project root and captures its stdout.
+// Validated via validateDocuments at config-load time.
 type DocumentConfig struct {
 	// Title is the display title for the document.
 	Title string `yaml:"title,omitempty" json:"title,omitempty"`
 	// EntityType specifies which entity types this document applies to.
-	// Used by the frontend to filter which documents to show for a given entity.
+	// Used by the frontend to filter which documents to show for a given entity,
+	// and by the HTTP handler to reject cross-type requests (a doc with
+	// entity_type=release cannot render against a ticket entity).
 	EntityType string `yaml:"entity_type,omitempty" json:"entity_type,omitempty"`
 	// Command is the external render command. Placeholders:
 	//   {id}       - entry ID
 	//   {id_lower} - lowercase entry ID
-	Command string `yaml:"command" json:"command"`
-	// Timeout is the command execution timeout in seconds. Defaults to 30.
+	// Mutually exclusive with Script.
+	Command string `yaml:"command,omitempty" json:"command,omitempty"`
+	// Script is a relative path to a Lua file under scripts/ (e.g.
+	// "docs/release_notes.lua"). The script runs in document mode with
+	// rela.mode="document", rela.document.{id,entry_id}, and captures its
+	// stdout as markdown. Mutually exclusive with Command.
+	Script string `yaml:"script,omitempty" json:"script,omitempty"`
+	// Timeout is the render timeout in seconds. Defaults to 30. Applies
+	// to both Command and Script renderers.
 	Timeout int `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 }

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -968,15 +968,28 @@ func validateCommands(cfg *Config, meta *metamodel.Metamodel) []string {
 }
 
 // validateDocuments validates document configurations.
+//
+// Invariant: every document must have entity_type set, and exactly one of
+// {command, script} must be non-empty. entity_type is enforced at the HTTP
+// handler layer to reject cross-type render requests; the mutual exclusion
+// prevents ambiguous configs (which renderer runs when both are set?).
 func validateDocuments(cfg *Config) []string {
 	var errs []string
 
 	for docID, doc := range cfg.Documents {
-		if doc.Command == "" {
-			errs = append(errs, fmt.Sprintf("document %q: command is required", docID))
-		}
 		if doc.EntityType == "" {
 			errs = append(errs, fmt.Sprintf("document %q: entity_type is required", docID))
+		}
+
+		hasCmd := doc.Command != ""
+		hasScript := doc.Script != ""
+		switch {
+		case hasCmd && hasScript:
+			errs = append(errs, fmt.Sprintf(
+				"document %q: command and script are mutually exclusive", docID))
+		case !hasCmd && !hasScript:
+			errs = append(errs, fmt.Sprintf(
+				"document %q: one of command or script must be set", docID))
 		}
 	}
 

--- a/internal/dataentryconfig/validate_test.go
+++ b/internal/dataentryconfig/validate_test.go
@@ -891,53 +891,67 @@ func TestValidateConfig_ViewSectionUsesPreviousCollectAs(t *testing.T) {
 	}
 }
 
-func TestValidateConfig_DocumentMissingCommand(t *testing.T) {
+// TestValidateConfig_Documents is a table-driven sweep of DocumentConfig
+// validation. Covers the {command, script} mutual-exclusion rule and the
+// still-required entity_type invariant (addresses RR-1FA8W, the risk that
+// relaxing command's required-ness would silently drop entity_type).
+func TestValidateConfig_Documents(t *testing.T) {
 	meta := testMetamodel()
-	cfg := &Config{
-		Documents: map[string]DocumentConfig{
-			"spec": {},
+
+	cases := []struct {
+		name    string
+		doc     DocumentConfig
+		wantErr string // substring that must appear; "" means expect success
+	}{
+		{
+			name:    "only command is valid",
+			doc:     DocumentConfig{Command: "render.sh", EntityType: "requirement"},
+			wantErr: "",
+		},
+		{
+			name:    "only script is valid",
+			doc:     DocumentConfig{Script: "docs/render.lua", EntityType: "requirement"},
+			wantErr: "",
+		},
+		{
+			name:    "both command and script is an error",
+			doc:     DocumentConfig{Command: "render.sh", Script: "docs/render.lua", EntityType: "requirement"},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "neither command nor script is an error",
+			doc:     DocumentConfig{EntityType: "requirement"},
+			wantErr: "one of command or script must be set",
+		},
+		{
+			name:    "missing entity_type with command",
+			doc:     DocumentConfig{Command: "render.sh"},
+			wantErr: "entity_type is required",
+		},
+		{
+			name:    "missing entity_type with script",
+			doc:     DocumentConfig{Script: "docs/render.lua"},
+			wantErr: "entity_type is required",
 		},
 	}
 
-	err := ValidateConfig(nil, cfg, meta)
-	if err == nil {
-		t.Error("expected error for document with missing command")
-	}
-	errStr := err.Error()
-	if !strings.Contains(errStr, "command is required") {
-		t.Errorf("expected 'command is required' error, got: %s", errStr)
-	}
-}
-
-func TestValidateConfig_DocumentMissingEntityType(t *testing.T) {
-	meta := testMetamodel()
-	cfg := &Config{
-		Documents: map[string]DocumentConfig{
-			"spec": {Command: "render.sh"},
-		},
-	}
-
-	err := ValidateConfig(nil, cfg, meta)
-	if err == nil {
-		t.Error("expected error for document with missing entity_type")
-	}
-	errStr := err.Error()
-	if !strings.Contains(errStr, "entity_type is required") {
-		t.Errorf("expected 'entity_type is required' error, got: %s", errStr)
-	}
-}
-
-func TestValidateConfig_DocumentValid(t *testing.T) {
-	meta := testMetamodel()
-	cfg := &Config{
-		Documents: map[string]DocumentConfig{
-			"spec": {Command: "render.sh", EntityType: "requirement"},
-		},
-	}
-
-	err := ValidateConfig(nil, cfg, meta)
-	if err != nil {
-		t.Errorf("expected valid document config to pass, got: %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{Documents: map[string]DocumentConfig{"spec": tc.doc}}
+			err := ValidateConfig(nil, cfg, meta)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected success, got error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("expected error to contain %q, got: %s", tc.wantErr, err.Error())
+			}
+		})
 	}
 }
 

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -74,6 +74,9 @@ type Runtime struct {
 	params        map[string]string // rela.params values (used by action scripts)
 	secrets       map[string]string // rela.secrets values (from .rela/secrets.yaml)
 	isAction      bool              // true when running as an action (changes rela.output behavior)
+	isDocument    bool              // document mode: rela.document populated, rela.output becomes a warning
+	documentID    string            // data-entry.yaml documents: key, exposed as rela.document.id
+	documentEntry string            // ID of the entity being rendered, exposed as rela.document.entry_id
 	aiProvider    ai.Provider       // nil means AI is not configured
 	cache         cacheStore        // nil means rela.cache.* is not registered
 	scriptPath    string            // set by RunFile; empty for RunString/inline
@@ -141,6 +144,21 @@ func WithParams(params map[string]string) Option {
 func WithActionMode() Option {
 	return func(r *Runtime) {
 		r.isAction = true
+	}
+}
+
+// WithDocumentMode marks the runtime as running a data-entry document
+// renderer. Populates the rela.document.{id, entry_id} table and sets
+// rela.mode = "document" so scripts can branch on context; also changes
+// rela.output behavior to emit a warning line (the captured stdout is the
+// rendered document, so JSON noise in-band is almost certainly a mistake).
+// documentID is the key under documents: in data-entry.yaml; entryID is
+// the ID of the entity being rendered.
+func WithDocumentMode(documentID, entryID string) Option {
+	return func(r *Runtime) {
+		r.isDocument = true
+		r.documentID = documentID
+		r.documentEntry = entryID
 	}
 }
 
@@ -224,8 +242,34 @@ func newRuntime(deps WriteDeps, stdout io.Writer, allowWrites bool, opts ...Opti
 		opt(r)
 	}
 
+	// In captured-stdout contexts (document mode, action mode), redirect
+	// Lua's base `print` through r.stdout. gopher-lua's default writes to
+	// os.Stdout, which silently drops output from runtimes whose stdout
+	// is a buffer. We override only for these modes so CLI / scheduler /
+	// MCP / validation / automation scripts keep the default behavior —
+	// users rely on print() reaching their terminal there.
+	if r.isDocument || r.isAction {
+		L.SetGlobal("print", L.NewFunction(r.luaPrint))
+	}
+
 	r.registerBindings(allowWrites)
 	return r
+}
+
+// luaPrint replaces gopher-lua's base print so its output lands in
+// r.stdout rather than os.Stdout. Matches Lua's stock print: each
+// argument is stringified via __tostring, joined with tabs, terminated
+// by a newline.
+func (r *Runtime) luaPrint(ls *lua.LState) int {
+	top := ls.GetTop()
+	for i := 1; i <= top; i++ {
+		if i > 1 {
+			fmt.Fprint(r.stdout, "\t")
+		}
+		fmt.Fprint(r.stdout, ls.ToStringMeta(ls.Get(i)).String())
+	}
+	fmt.Fprintln(r.stdout)
+	return 0
 }
 
 // openSafeLibraries loads only safe Lua standard libraries.
@@ -533,6 +577,18 @@ func (r *Runtime) registerContextBindings(rela *lua.LTable) {
 	// raising a Lua error on any call, so a runtime with a cache but
 	// no script path still behaves safely.
 	r.registerCacheBindings(rela)
+
+	// Document-mode context: rela.mode + rela.document.{id, entry_id}.
+	// Only populated when WithDocumentMode was applied. In every other
+	// context rela.mode and rela.document are absent (Lua nil), so a
+	// script that branches on them sees nil outside document renders.
+	if r.isDocument {
+		r.L.SetField(rela, "mode", lua.LString("document"))
+		docTable := r.L.NewTable()
+		r.L.SetField(docTable, "id", lua.LString(r.documentID))
+		r.L.SetField(docTable, "entry_id", lua.LString(r.documentEntry))
+		r.L.SetField(rela, "document", docTable)
+	}
 }
 
 // luaGetEntity implements rela.get_entity(id) -> table|nil
@@ -679,9 +735,10 @@ func (r *Runtime) luaTraceTo(ls *lua.LState) int {
 
 // luaOutput implements rela.output(data) - JSON encode to stdout
 func (r *Runtime) luaOutput(ls *lua.LState) int {
+	// Type-check the arg up front; the Lua → Go conversion is deferred
+	// past the mode guards so muted modes (action/document) don't pay
+	// for converting a potentially-large nested table.
 	data := ls.CheckAny(1)
-
-	goData := luaValueToGo(data)
 
 	if r.isAction {
 		// In action mode, rela.output is a no-op. Log a warning so script
@@ -690,6 +747,16 @@ func (r *Runtime) luaOutput(ls *lua.LState) int {
 		return 0
 	}
 
+	if r.isDocument {
+		// In document mode, captured stdout is the rendered document.
+		// Raw JSON in the middle of rendered markdown is almost always a
+		// mistake — emit a warning line (visible in the panel) so the
+		// script author notices, rather than silently producing garbage.
+		fmt.Fprintln(r.stdout, "warning: rela.output() called in document mode; use print() to emit markdown")
+		return 0
+	}
+
+	goData := luaValueToGo(data)
 	encoder := json.NewEncoder(r.stdout)
 	encoder.SetIndent("", "  ")
 	if err := encoder.Encode(goData); err != nil {

--- a/internal/lua/runtime_test.go
+++ b/internal/lua/runtime_test.go
@@ -2444,3 +2444,94 @@ func TestWriterRuntime_MutationBindingsPresent(t *testing.T) {
 		}
 	}
 }
+
+// TestDocumentMode_ContextInjection asserts that WithDocumentMode populates
+// rela.mode, rela.document.id and rela.document.entry_id so scripts can
+// read the context they're running under. Mirrors AC3.
+//
+// We use print() to readback because rela.output is intentionally silenced
+// in document mode (see TestDocumentMode_OutputIsWarning).
+func TestDocumentMode_ContextInjection(t *testing.T) {
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+
+	r := NewWriter(ws.services("/tmp"), &buf, WithDocumentMode("release-notes", "REL-001"))
+	defer r.Close()
+
+	script := `print(rela.mode)
+print(rela.document.id)
+print(rela.document.entry_id)`
+	if err := r.RunString(script); err != nil {
+		t.Fatalf("RunString failed: %v", err)
+	}
+
+	out := buf.String()
+	want := "document\nrelease-notes\nREL-001\n"
+	if out != want {
+		t.Errorf("unexpected output:\n got: %q\nwant: %q", out, want)
+	}
+}
+
+// TestDocumentMode_AbsentInOtherContexts asserts that rela.mode and
+// rela.document are nil when WithDocumentMode is not applied. Mirrors AC4.
+// If these variables leaked into other contexts, scripts that branch on
+// them would behave incorrectly outside document renders.
+//
+// Uses rela.output for readback: print() is only captured in document or
+// action mode (so that CLI/scheduler/MCP keep their native os.Stdout);
+// rela.output routes to the captured buffer in vanilla mode.
+func TestDocumentMode_AbsentInOtherContexts(t *testing.T) {
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+
+	// No WithDocumentMode, no WithActionMode — vanilla writer runtime.
+	r := NewWriter(ws.services("/tmp"), &buf)
+	defer r.Close()
+
+	script := `rela.output({
+    mode_type = type(rela.mode),
+    document_type = type(rela.document),
+})`
+	if err := r.RunString(script); err != nil {
+		t.Fatalf("RunString failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("parse output: %v — buf=%q", err, buf.String())
+	}
+	if result["mode_type"] != "nil" {
+		t.Errorf("expected rela.mode to be nil outside document mode, got type %v", result["mode_type"])
+	}
+	if result["document_type"] != "nil" {
+		t.Errorf("expected rela.document to be nil outside document mode, got type %v", result["document_type"])
+	}
+}
+
+// TestDocumentMode_OutputIsWarning asserts that rela.output in document
+// mode writes a warning line to captured stdout and does NOT emit JSON.
+// Captured stdout in document mode is the rendered markdown, so stray
+// JSON would land inline in the rendered document. Mirrors AC5.
+func TestDocumentMode_OutputIsWarning(t *testing.T) {
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+
+	r := NewWriter(ws.services("/tmp"), &buf, WithDocumentMode("my-doc", "E-1"))
+	defer r.Close()
+
+	script := `rela.output({foo = "bar"})`
+	if err := r.RunString(script); err != nil {
+		t.Fatalf("RunString failed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "warning") {
+		t.Errorf("expected warning in output, got %q", out)
+	}
+	if !strings.Contains(out, "document mode") {
+		t.Errorf("expected warning to mention document mode, got %q", out)
+	}
+	if strings.Contains(out, `"foo"`) {
+		t.Errorf("expected JSON payload to be dropped in document mode, got %q", out)
+	}
+}

--- a/internal/script/executor.go
+++ b/internal/script/executor.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
@@ -71,6 +72,56 @@ func (e *Engine) ExecuteFile(path string, deps lua.WriteDeps,
 	return e.execute(scriptCode, deps, path, newEntity, oldEntity)
 }
 
+// ExecuteDocument loads and runs a Lua script in document-rendering mode.
+// The script's stdout is captured into the caller-supplied writer; that
+// output is the rendered markdown (the data-entry layer then converts it
+// to HTML and rewrites edit://+create:// links).
+//
+// documentID is the key under documents: in data-entry.yaml (exposed to
+// the script as rela.document.id). entryID is the ID of the entity being
+// rendered (exposed as rela.document.entry_id). timeout overrides the
+// default lua timeout when non-zero.
+//
+// This method exists as a typed seam — intentionally NOT taking variadic
+// lua.Option — so callers cannot inject arbitrary opts (e.g., forge
+// WithOutputDir or WithActionMode). Mirrors the ExecuteAction shape.
+func (e *Engine) ExecuteDocument(
+	path string,
+	deps lua.WriteDeps,
+	stdout io.Writer,
+	documentID string,
+	entryID string,
+	timeout time.Duration,
+) error {
+	scriptCode, err := loadScript(deps.ProjectRoot, path)
+	if err != nil {
+		return err
+	}
+
+	opts := []lua.Option{
+		lua.WithDocumentMode(documentID, entryID),
+		lua.WithCache(e.cache),
+	}
+	if timeout > 0 {
+		opts = append(opts, lua.WithTimeout(timeout))
+	}
+
+	runtime, err := NewWriterRuntime(deps, path, stdout, opts...)
+	if err != nil {
+		return err
+	}
+	defer runtime.Close()
+
+	// NewWriterRuntime receives `path` for per-script secret loading, but
+	// rela.cache.* namespacing is driven by a separate scriptPath field
+	// that RunFile/RunFileContent set. We're invoking RunString, so wire
+	// the path explicitly — otherwise rela.cache.* inside a document
+	// script would hit the inline/eval guard and raise.
+	runtime.SetScriptPath(path)
+
+	return runtime.RunString(scriptCode)
+}
+
 // execute runs Lua code with entity context. scriptPath is used to resolve
 // per-script secrets; pass "" for inline code (no secrets loaded).
 // Timeout is handled by lua.Runtime (default 30s).
@@ -100,6 +151,16 @@ func (e *Engine) execute(code string, deps lua.WriteDeps, scriptPath string,
 	}
 
 	return runtime.RunString(code)
+}
+
+// CheckDocumentScriptExists verifies a document script can be loaded.
+// Used at config-load time (dataentry.NewApp) to fail fast when a
+// data-entry.yaml `documents:` entry points at a missing or malformed
+// script, instead of deferring the error to the first HTTP render.
+// Mirrors CheckActionScriptExists.
+func CheckDocumentScriptExists(projectRoot, scriptPath string) error {
+	_, err := loadScript(projectRoot, scriptPath)
+	return err
 }
 
 // loadScript loads a script from the scripts/ directory using os.OpenRoot

--- a/internal/script/executor_test.go
+++ b/internal/script/executor_test.go
@@ -1,9 +1,13 @@
 package script
 
 import (
+	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
@@ -99,5 +103,78 @@ func TestEngine_ExecuteFile_ValidPath(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "local") || strings.Contains(err.Error(), ".lua") {
 		t.Errorf("expected filesystem error, not validation error, got: %v", err)
+	}
+}
+
+// writeDocScript creates scripts/<name> under tempRoot with the given body
+// and returns the tempRoot. Used by ExecuteDocument tests.
+func writeDocScript(t *testing.T, name, body string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, scriptsDir), 0o755); err != nil {
+		t.Fatalf("mkdir scripts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, scriptsDir, name), []byte(body), 0o644); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	return root
+}
+
+// TestExecuteDocument_CapturesStdout verifies the core contract of
+// ExecuteDocument: the script's print() output lands in the caller's
+// writer, ready to be used as markdown for downstream HTML conversion.
+func TestExecuteDocument_CapturesStdout(t *testing.T) {
+	root := writeDocScript(t, "doc.lua", `print("# " .. rela.document.id)
+print("entry: " .. rela.document.entry_id)
+print("mode: " .. rela.mode)`)
+
+	var stdout bytes.Buffer
+	engine := NewEngine()
+	err := engine.ExecuteDocument("doc.lua", testWriteDeps(root), &stdout,
+		"release-notes", "REL-001", 0)
+	if err != nil {
+		t.Fatalf("ExecuteDocument failed: %v", err)
+	}
+
+	got := stdout.String()
+	want := "# release-notes\nentry: REL-001\nmode: document\n"
+	if got != want {
+		t.Errorf("stdout mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestExecuteDocument_TimeoutEnforced verifies that a non-zero timeout
+// is honored for document-mode renders (AC11). An infinite loop with a
+// 1-second budget must terminate well under 2 seconds.
+func TestExecuteDocument_TimeoutEnforced(t *testing.T) {
+	root := writeDocScript(t, "spin.lua", `while true do end`)
+
+	var stdout bytes.Buffer
+	engine := NewEngine()
+	start := time.Now()
+	err := engine.ExecuteDocument("spin.lua", testWriteDeps(root), &stdout,
+		"id", "entry", 1*time.Second)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected timeout error, got none")
+	}
+	if elapsed > 2500*time.Millisecond {
+		t.Errorf("timeout took %v, expected < 2.5s", elapsed)
+	}
+}
+
+// TestExecuteDocument_BadPath surfaces the same path-validation errors as
+// ExecuteFile — ExecuteDocument reuses loadScript so the existing
+// traversal / extension / local-path checks apply.
+func TestExecuteDocument_BadPath(t *testing.T) {
+	var stdout bytes.Buffer
+	engine := NewEngine()
+	err := engine.ExecuteDocument("../../etc/passwd", testWriteDeps("/project"),
+		&stdout, "id", "entry", 0)
+	if err == nil {
+		t.Fatal("expected error for path traversal, got none")
+	}
+	if !strings.Contains(err.Error(), "local") {
+		t.Errorf("expected path traversal error, got: %v", err)
 	}
 }

--- a/prototypes/data-entry/project/data-entry.yaml
+++ b/prototypes/data-entry/project/data-entry.yaml
@@ -19,8 +19,19 @@ styles:
     high: orange
     medium: yellow
     low: green
-# Documents rendered via shell commands
+# Documents: rendered markdown panels shown on entity views.
+# Two renderers available:
+#   - `command:` — shells out to an external program that writes markdown
+#     to stdout (see ticket_summary below).
+#   - `script:` — runs a Lua script in scripts/ and captures its stdout
+#     (see category_overview below). Scripts have access to the full
+#     entity graph and can compose multi-entity documents.
 documents:
+  category_overview:
+    title: "Category Overview"
+    entity_type: category
+    script: docs/category_report.lua
+    timeout: 10
   ticket_summary:
     title: "Ticket Summary"
     entity_type: ticket

--- a/prototypes/data-entry/project/scripts/docs/category_report.lua
+++ b/prototypes/data-entry/project/scripts/docs/category_report.lua
@@ -1,0 +1,85 @@
+-- Category report: composes a markdown document for a category entity,
+-- showing the category's own properties plus every ticket that belongs
+-- to it (incoming `belongs-to`) with each ticket's blocks/labels.
+--
+-- This is the Lua equivalent of the `category_report` view, but rendered
+-- as a single scrolling markdown doc with clickable `edit://` links.
+-- Drive it from data-entry.yaml:
+--
+--   documents:
+--     category_overview:
+--       title: "Category Overview"
+--       entity_type: category
+--       script: docs/category_report.lua
+--
+-- Demonstrates:
+--   - `rela.document.entry_id` — the entity being rendered.
+--   - `rela.cache.memoize(...)` — caching a per-category rollup across
+--     HTTP requests within the lifetime of the rela-server process.
+--   - `edit://` links rewritten by the data-entry layer into form URLs.
+
+local entry_id = rela.document.entry_id
+local category = rela.get_entity(entry_id)
+if category == nil then
+  print("_Category not found: " .. entry_id .. "_")
+  return
+end
+
+-- Category header + properties.
+print("# " .. (category.properties.title or category.properties.name or entry_id))
+print()
+if category.properties.description and category.properties.description ~= "" then
+  print(category.properties.description)
+  print()
+end
+
+-- Build the ticket rollup and cache it. The compute function walks the
+-- graph via `trace_to` (incoming `belongs-to`) to find the category's
+-- tickets, then returns a plain table that memoize stores. We include
+-- the category's mod_time in the key so the cache invalidates when the
+-- category changes; a fuller solution would also key on ticket changes
+-- (tracked as TKT-E1FO1).
+local cache_key = "category-tickets:" .. entry_id .. "@" .. (category.mod_time or "")
+local tickets = rela.cache.memoize(cache_key, function()
+  local result = {}
+  local incoming = rela.trace_to(entry_id, 1) or {children = {}}
+  for _, child in ipairs(incoming.children or {}) do
+    local t = rela.get_entity(child.id)
+    if t ~= nil and t.type == "ticket" then
+      table.insert(result, {
+        id = t.id,
+        title = t.properties.title or t.id,
+        status = t.properties.status or "open",
+        priority = t.properties.priority or "medium",
+        assignee = t.properties.assignee or "unassigned",
+      })
+    end
+  end
+  return result
+end)
+
+print("## Tickets (" .. #tickets .. ")")
+print()
+if #tickets == 0 then
+  print("_No tickets belong to this category yet._")
+  print()
+else
+  print("| ID | Title | Status | Priority | Assignee |")
+  print("|----|-------|--------|----------|----------|")
+  for _, t in ipairs(tickets) do
+    -- The edit:// link is rewritten by the data-entry server into a
+    -- form URL that returns here after save.
+    local link = "[" .. t.id .. "](edit://ticket/" .. t.id .. ")"
+    print("| " .. link ..
+          " | " .. t.title ..
+          " | " .. t.status ..
+          " | " .. t.priority ..
+          " | " .. t.assignee .. " |")
+  end
+  print()
+end
+
+-- Footer: link to the create form for a new ticket in this category.
+print("---")
+print()
+print("[+ New ticket in this category](create://ticket?belongs-to=" .. entry_id .. ")")

--- a/tickets/entities/docs-checklists/DOCS-VXCAJ.md
+++ b/tickets/entities/docs-checklists/DOCS-VXCAJ.md
@@ -1,0 +1,58 @@
+---
+id: DOCS-VXCAJ
+type: docs-checklist
+title: 'Docs: Document the documents feature and add Lua script renderer'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Public APIs have doc comments
+- [x] Complex logic has explanatory comments
+- [x] Package-level docs updated if applicable
+
+**Evidence:** `WithDocumentMode`, `ExecuteDocument`, `DocumentConfig.Script`,
+`documentScriptEngine` interface, and the new fields on `documentService` all
+carry doc comments. Cache-policy and singleflight-key comments added inline
+where the invariants are non-obvious. `luaOutput` now has a comment explaining
+why conversion is deferred past the mode guards.
+
+## Project Documentation
+
+- [x] CLAUDE.md updated if new patterns introduced
+- [x] README.md updated if user-facing change
+
+**Decisions:**
+
+- CLAUDE.md: N/A — the feature follows the existing `WithActionMode` pattern exactly, no new architecture.
+- README.md: N/A — no project-level changes.
+
+## External Documentation
+
+- [x] User guides updated (`docs-project/entities/guides/`)
+- [x] Generated docs regenerated (`just docs`)
+- [x] Examples updated / added
+
+**Updated guides:**
+
+- `GUIDE-data-entry.md` — new `## Documents` section (substantial; the documents feature was entirely undocumented before this ticket). Covers YAML config schema for both `command:` and `script:` variants, `edit://` + `create://` URL schemes, caching behavior with the per-renderer split, SSE live-reload caveat, document-mode Lua API, `rela.output` warning behavior, `html.WithUnsafe` trust boundary, config hot-reload caveat.
+- `GUIDE-lua-scripting.md` — new `### Document Mode` subsection cross-linking to the data-entry guide; documents `rela.mode`, `rela.document.id`, `rela.document.entry_id`, `rela.output` behavior in document mode, and the cache namespace policy.
+- `docs/data-entry.md` and `docs/lua-scripting.md` regenerated via `just docs`.
+
+**Added example:**
+`prototypes/data-entry/project/scripts/docs/category_report.lua` — demonstrates
+`rela.trace_to`, `rela.cache.memoize` with a version-keyed cache, `edit://` and
+`create://` link emission. Wired into
+`prototypes/data-entry/project/data-entry.yaml` under `documents:` as
+`category_overview` for `entity_type: category`.
+
+## Cross-References
+
+- [x] Links between related docs verified
+- [x] Code comments reference relevant docs
+
+**Verified:** GUIDE-lua-scripting → GUIDE-data-entry Documents section
+(bi-directional link); prototype `category_report.lua` has a header comment
+pointing at the `documents:` YAML shape users need to declare.

--- a/tickets/entities/features/FEAT-023.md
+++ b/tickets/entities/features/FEAT-023.md
@@ -1,165 +1,80 @@
 ---
-description: Render documents from external commands in the data-entry UI, enabling live preview of composed documents built from rela entities.
 id: FEAT-023
-priority: medium
-status: proposed
-title: Document Rendering in Data Entry Server
 type: feature
+title: Document Rendering in Data Entry Server
+summary: Read-only markdown document panels attached to entity views, rendered by shell command or Lua script with caching and edit:// link rewriting.
+description: Render documents from external commands in the data-entry UI, enabling live preview of composed documents built from rela entities.
+priority: medium
+status: implemented
 ---
 
 # Document Rendering in Data Entry Server
 
+## Status
+
+**V1 (shipped)** — shell `command:` renderer producing markdown, rendered as
+HTML panels in the data-entry UI with live-reload and `edit://`/`create://` link
+rewriting. `DocumentConfig` in `data-entry.yaml`; rendering in
+`internal/dataentry/document.go`.
+
+**V2 (shipped via TKT-CGBVW)** — Lua `script:` renderer as an alternative to
+`command:`. Exactly one of `{command, script}` must be set per document. Script
+runs via `script.Engine.ExecuteDocument` with a writer runtime; captured stdout
+is the rendered markdown. New context: `rela.mode == "document"`,
+`rela.document.{id, entry_id}`. Lua renders bypass the disk cache (Lua's
+in-process `rela.cache` is the caching story). The HTTP handler enforces
+`entity_type:` before invoking any renderer.
+
 ## Overview
 
-Add the ability to render documents in the data-entry server by invoking an external render command that produces markdown. This enables users to preview composed documents (like technical designs built from multiple entities) directly in the data-entry UI, with live reload on entity changes.
+Render documents in the data-entry UI from either a shell command or a Lua
+script. Composed documents (e.g. a category overview that walks related tickets)
+render as HTML panels in the entity view with live-reload on SSE entity-change
+events and clickable `edit://` / `create://` links that deep-link into the
+data-entry forms.
 
-## Background
+## Follow-up work
 
-Projects like `gf` use `mdcomp` to compose documents from rela entities using Jinja2 templates. The current workflow requires:
-1. Running `rela view` to collect related entities
-2. Transforming output via Python script
-3. Rendering with `mdcomp render`
-4. Converting to HTML/DOCX/PDF with pandoc
+Tracked separately:
 
-This feature brings step 3 into the data-entry server, providing an integrated preview experience.
+- **TKT-E1FO1** — `rela.document.depends_on(id)` for SSE dependency tracking.
+V1 live-reload fires only on entry entity changes; a Lua doc composed from many
+entities relies on the refresh button when non-entry entities change.
+- **TKT-CGPYW** — generalize `rela.mode` to other contexts (script / flow /
+action / scheduled / validation) once a concrete need surfaces.
 
-## Prototype Scope (V1)
+## Usage
 
-Build a minimal prototype to validate the approach:
+```yaml
+documents:
+  ticket_summary:
+    title: "Ticket Summary"
+    entity_type: ticket
+    command: "my-renderer {id}"   # shell render
+    timeout: 30
 
-### 1. Hardcoded Configuration
-
-For the prototype, hardcode:
-- A single render command (e.g., `mdcomp render template.md.j2`)
-- A single URL endpoint (e.g., `/document/preview`)
-- Context format (YAML via stdin)
-
-### 2. Document Handler
-
-```go
-// GET /document/preview?entry=<entity-id>
-func (a *App) handleDocumentPreview(w http.ResponseWriter, r *http.Request) {
-    entryID := r.URL.Query().Get("entry")
-    
-    // 1. Execute view (hardcoded view name for prototype)
-    result, err := a.executeView(viewConfig, entryID)
-    
-    // 2. Build context (YAML)
-    context := buildContext(result)
-    
-    // 3. Run render command
-    cmd := exec.Command("sh", "-c", renderCommand)
-    cmd.Stdin = strings.NewReader(context)
-    cmd.Dir = a.ws.Paths().Root
-    markdown, err := cmd.Output()
-    
-    // 4. Convert markdown to HTML
-    html := goldmark.Convert(markdown)
-    
-    // 5. Rewrite edit:// links
-    html = rewriteEditLinks(html)
-    
-    // 6. Wrap in page template and serve
-    a.tmpl.ExecuteTemplate(w, "document.html", html)
-}
+  category_overview:
+    title: "Category Overview"
+    entity_type: category
+    script: docs/category_report.lua  # Lua render
+    timeout: 10
 ```
 
-### 3. Edit Link Protocol
+See `GUIDE-data-entry.md` (Documents section) for the full config schema, the
+`edit://`/`create://` URL scheme, caching semantics, and the Lua document-mode
+API.
 
-Templates can include `edit://` links that rela rewrites to form URLs:
+## Original V1 design notes (historical)
 
-**In template:**
-```jinja2
-### [{{ id }}](edit://component/{{ id }}): {{ title }}
-```
+The initial prototype was a hardcoded render endpoint invoking `mdcomp render`
+with YAML context piped in. That shape shipped with a config-driven
+`DocumentConfig` entry (`command:`) and goldmark conversion, plus `edit://` and
+`create://` URL rewriting to support in-document navigation.
 
-**Rendered markdown:**
-```markdown
-### [NVI-COMP-001](edit://component/NVI-COMP-001): Localization Service
-```
+Success criteria (all met):
 
-**After rewrite:**
-```html
-<a href="/form/component?id=NVI-COMP-001&return=/document/preview?entry=DOC-001">NVI-COMP-001</a>
-```
-
-### 4. Page Template
-
-Simple wrapper with:
-- Navigation header (back link, entry entity info)
-- Rendered content area
-- Live reload script (existing SSE infrastructure)
-- Basic styling for markdown content
-
-### 5. Live Reload
-
-Leverage existing file watcher:
-- Entity/relation changes trigger SSE event
-- Browser reloads document content
-- No additional watch configuration needed for prototype
-
-## Implementation Steps
-
-1. **Add goldmark dependency** for markdown→HTML conversion
-2. **Create document handler** with hardcoded command
-3. **Implement context builder** (serialize view result to YAML)
-4. **Add edit:// link rewriter** (regex replacement)
-5. **Create document page template** (HTML wrapper)
-6. **Wire up route** in router
-7. **Test with mdcomp** on a real project
-
-## Open Questions for Prototype
-
-- [ ] How to handle render command errors? (show error in UI vs log)
-- [ ] How to handle slow render commands? (loading indicator, timeout)
-- [ ] Should we cache rendered output? (probably not for prototype)
-- [ ] How to pass entry ID to the render command? (env var, arg, or context only)
-
-## Future Iterations (Post-Prototype)
-
-After validating the approach:
-
-1. **Configuration** - Move to `data-entry.yaml`:
-   ```yaml
-   documents:
-     - id: technical-design
-       view: document_publish
-       entry_type: document
-       render:
-         command: "mdcomp render publish/templates/to.md.j2"
-         context_format: yaml
-   ```
-
-2. **List integration** - Allow linking from entity lists to document views:
-   ```yaml
-   lists:
-     documents:
-       type: document
-       link_to: document/technical-design
-   ```
-
-3. **Navigation** - Add document links to nav menu
-
-4. **Export** - Download rendered markdown/HTML
-
-5. **Edit modes** - Side panel or modal editing (currently: navigate away)
-
-6. **Template watching** - Watch template files for changes (currently: entities only)
-
-## Success Criteria
-
-- [ ] Can render a document at `/document/preview?entry=<id>`
-- [ ] Render command receives view context as YAML stdin
-- [ ] Markdown output is converted to HTML and displayed
-- [ ] `edit://` links are rewritten to form URLs with return parameter
-- [ ] Page reloads when entities change (via existing SSE)
-- [ ] Errors are handled gracefully (shown in UI or logged)
-
-## Non-Goals (Prototype)
-
-- Configurable documents (hardcoded for now)
-- Multiple document types
-- Caching
-- Export functionality
-- Side panel/modal editing
-- Template file watching
+- Render a document at `/api/v1/_documents/{docName}/{entryID}`.
+- Markdown → HTML via goldmark.
+- `edit://` and `create://` links rewritten to form URLs with return param.
+- Page reloads when entities change (via SSE).
+- Errors handled gracefully (rendered as HTTP 500 with message).

--- a/tickets/entities/implementation-checklists/IMPL-KODOT.md
+++ b/tickets/entities/implementation-checklists/IMPL-KODOT.md
@@ -1,0 +1,73 @@
+---
+id: IMPL-KODOT
+type: implementation-checklist
+title: 'Implementation: Document the documents feature and add Lua script renderer'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Covered by unit + integration tests; `just ci` (excluding docs-check which needs
+the commit) passes clean.
+
+Per-AC status:
+
+| AC | Evidence |
+|----|----------|
+| AC1 Lua happy path | `TestDocumentService_ScriptRender_CapturesMarkdown` — passing |
+| AC2 Config validation | `TestValidateConfig_Documents` (6 subtests: both, neither, only-command, only-script, missing entity_type) — passing |
+| AC3 Context injection | `TestDocumentMode_ContextInjection` — asserts `rela.mode`, `rela.document.id`, `rela.document.entry_id` via print readback — passing |
+| AC4 Context absent elsewhere | `TestDocumentMode_AbsentInOtherContexts` — vanilla writer runtime: both nil — passing |
+| AC5 `rela.output` warning | `TestDocumentMode_OutputIsWarning` — stdout contains "warning" and "document mode", no JSON — passing |
+| AC6 Cache memoize across renders | `TestDocumentService_CacheMemoizeAcrossRenders` — uses real `script.Engine`, counter.log has exactly 1 line after 2 renders — passing |
+| AC7 Shell command unchanged | Existing `TestDocumentDiskCache` and friends still pass; `TestHandleV1Documents_EntityTypeMatch` exercises the command: path end-to-end — passing |
+| AC8 Singleflight keyed on configID | `TestDocumentService_SingleflightNoCollapseAcrossConfigs` + positive complement `TestDocumentService_SingleflightCollapsesSameConfig` — passing |
+| AC9 EntityType enforcement | `TestHandleV1Documents_EntityTypeMismatch` (400), `TestHandleV1Documents_EntityTypeMatch` (no-400), `TestHandleV1Documents_EntityNotFound` (404) — passing |
+| AC10 Disk cache bypass for script | `TestDocumentService_ScriptRender_NoDiskCacheWrite` (no write) + `TestDocumentService_ScriptRender_StaleCommandCacheIgnored` (stale not served) — passing |
+| AC11 `cfg.Timeout` honored | `TestExecuteDocument_TimeoutEnforced` — infinite loop terminates within ~1s when `timeout: 1` is set — passing |
+| AC-DOC1 Guide section | `docs-project/entities/guides/GUIDE-data-entry.md` has a new `## Documents` section (YAML schema, URL schemes, caching, SSE caveat, security, hot-reload caveat) — docs regenerated into `docs/data-entry.md` |
+| AC-DOC2 FEAT-023 updated | Content and status (implemented) updated |
+| AC-DOC3 Prototype example | `prototypes/data-entry/project/scripts/docs/category_report.lua` + wiring in `data-entry.yaml` — server starts cleanly against the prototype |
+
+Additional implementation notes:
+
+- **`print()` routing**: redirected `print` from `os.Stdout` to `r.stdout` in `newRuntime`. Required for captured-stdout document rendering; CLI behavior unchanged (stdout is os.Stdout in that context anyway).
+- **Print-redirect stayed minimal**: one helper `luaPrint` mirroring gopher-lua's base `print` semantics (tab-separated args, newline).
+- **App refactor**: `newDocumentService` now takes `(scriptEngine, depsFunc)`. `rebindApp` in test helpers wires a default service so handler tests continue to work.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+Observations:
+
+- Architecture follows the existing action-mode pattern. `WithDocumentMode` mirrors `WithActionMode`; `Engine.ExecuteDocument` mirrors `ExecuteAction`. No new cross-subsystem abstractions.
+- The `documentScriptEngine` interface is defined at the call site (in `internal/dataentry/document.go`) per CLAUDE.md's consumer-side interface rule.
+- All errors surface to the HTTP response; the only intentional "silent-ish" path is the disk-cache write on command renders, which already logs a warning.

--- a/tickets/entities/planning-checklists/PLAN-78HJO.md
+++ b/tickets/entities/planning-checklists/PLAN-78HJO.md
@@ -1,0 +1,475 @@
+---
+id: PLAN-78HJO
+type: planning-checklist
+title: 'Planning: Document the documents feature and add Lua script renderer'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+In scope:
+
+1. Add `script:` string field to `DocumentConfig` (mutually exclusive with `command:`, validated at config-load time). `entity_type:` **remains required** for every document (both renderers).
+2. Extend `documentService.Render` to dispatch: `command:` → existing shell-out + disk cache (both read and write); `script:` → new Lua path, **bypasses disk cache on both read and write**. Singleflight key must include `configID` (not just `entryID`).
+3. HTTP handler enforces `entity.Type == docCfg.EntityType` before rendering; mismatch → HTTP 400.
+4. New `script.Engine.ExecuteDocument(path, deps, stdout, documentID, entryID, timeout)` — typed method, no variadic opts (mirrors how `ExecuteAction` wires its opts internally).
+5. New Lua runtime option `WithDocumentMode(documentID, entryID string)` (parallel to existing `WithActionMode`). Sets `rela.mode = "document"` and `rela.document = {id = documentID, entry_id = entryID}`. All other contexts leave `rela.mode` and `rela.document` as `nil`.
+6. `DocumentConfig.Timeout` applies to script: renders (wired as `lua.WithTimeout`), matching existing semantics for command: renders.
+7. In document mode, `rela.output` writes a warning line to captured stdout and returns early, instead of emitting JSON (same pattern as action mode).
+8. Documentation added to `docs-project/entities/guides/GUIDE-data-entry.md` for the full documents feature (both variants), including caveats around entry-only SSE reload, cache-namespace-per-script-path, and `html.WithUnsafe` trust boundary.
+9. Example Lua doc script shipped under `prototypes/data-entry/project/scripts/docs/`.
+10. `FEAT-023` updated to reflect shipped state.
+
+Out of scope (tracked separately):
+
+- Explicit `rela.document.depends_on(id)` for SSE dependency tracking → **TKT-E1FO1**.
+- Generalizing `rela.mode` to other contexts → **TKT-CGPYW**.
+- Removing the disk cache from `command:` renders (command: behavior unchanged).
+- Export of rendered markdown/HTML as a file download.
+
+**Cache namespace policy** (resolving RR-I5WME):
+
+`rela.cache` stays namespaced by script path (not by `configID`). Intentional:
+shared helper scripts (e.g. `scripts/docs/lib/entity_summary.lua`) derive their
+value from caching work across all callers. Auto-namespacing by `configID` would
+defeat this. Scripts that legitimately need doc-scoped keys can write them
+explicitly: `rela.cache.memoize("doc:" .. rela.document.id .. ":" .. id, ...)`.
+Documented as a caveat in the guide.
+
+**Acceptance Criteria:**
+
+Testable (executable checks):
+
+1. **AC1 — Lua happy path.** `data-entry.yaml` with `script: scripts/docs/foo.lua` renders via Lua; stdout → markdown → HTML → `edit://`/`create://` rewritten.
+*Test:* unit test in `document_test.go` using a fake `script.Engine` that writes
+known markdown to its stdout buffer, asserts HTML result contains converted
+content plus rewritten links.
+
+2. **AC2 — Config validation.** Mutual exclusion of `command:`+`script:`; both set → error; neither set → error; only one set → OK. `entity_type:` remains required in all cases.
+*Test:* table-driven test in `internal/dataentryconfig/validate_test.go`
+covering: both set; neither set; only command; only script; script without
+entity_type; command without entity_type.
+
+3. **AC3 — Context injection in document mode.** Inside a Lua doc script: `rela.mode == "document"`, `rela.document.entry_id == <entryID>`, `rela.document.id == <configID>`.
+*Test:* unit test in `internal/lua/runtime_test.go` that calls `NewWriter(...,
+WithDocumentMode("release-notes", "REL-001"))`, runs a script that writes those
+values to a sentinel file via `rela.write_file`, asserts file content matches.
+
+4. **AC4 — Context absent elsewhere.** In CLI / flow / action / scheduled / validation runs, `rela.mode` and `rela.document` are `nil`.
+*Test:* existing runtime tests; add assertions that `rela.mode == nil` and
+`rela.document == nil` in non-document paths.
+
+5. **AC5 — `rela.output` in document mode.** Calling `rela.output({foo=1})` writes `warning: rela.output() called in document mode; use print() to emit markdown\n` to captured stdout and does NOT emit JSON.
+*Test:* `runtime_test.go` — mirror the existing `TestLuaOutputActionMode*`
+pattern: build `NewWriter` with `WithDocumentMode(...)` and a `bytes.Buffer`
+stdout; run `rela.output({foo=1})`; assert stdout contains the warning and does
+not contain JSON. Tests directly against the runtime (does not route through
+documentService) so the stdout buffer is accessible.
+
+6. **AC6 — In-process cache works across requests.** A Lua doc script using `rela.cache.memoize("k", fn)` caches across HTTP requests within the same `rela-server` process.
+*Test:* `document_test.go` — script calls `rela.cache.memoize("counter",
+function() rela.write_file("counter.log", "1") end)`; render twice via
+`documentService.Render`; inspect `output/counter.log` and assert it has exactly
+one line (the compute fn ran once across two render calls).
+
+7. **AC7 — Shell-command path unchanged.** Existing `command:` docs render identically to today, including disk cache at `.rela/documents/<entry>-<hash>.html`.
+*Test:* existing `document_test.go` tests continue to pass; add an assertion
+that `.rela/documents/` is populated after a command-based render.
+
+8. **AC8 — Singleflight keyed on (entryID, configID).** Two concurrent renders for the same entry but different document configs must not collapse.
+*Test:* `document_test.go` — table-driven: launch two goroutines rendering
+different `configID`s against the same entry; each script writes a distinct
+marker to its captured stdout; assert both markers appear, not just one.
+
+9. **AC9 — Handler enforces EntityType.** Request to `/api/v1/_documents/<docName>/<entryID>` where entity's type ≠ `docCfg.EntityType` returns HTTP 400 (or 404) without running the script.
+*Test:* `api_v1_test.go` — create a doc with `entity_type: release`; request it
+against a `ticket` entity; assert HTTP error and script is not invoked (use a
+script that would write a sentinel file and verify file absent).
+
+10. **AC10 — `script:` bypasses disk cache on both read and write.** `GetCached` is skipped for script: renders; a stale disk cache file from a prior `command:` config at the same path is not served.
+*Test:* `document_test.go` — pre-populate
+`.rela/documents/<entryID>-<hash>.html` with fake content; render with `script:`
+config; assert rendered output is from the Lua script, not from the cache file;
+assert no new file is written to `.rela/documents/`.
+
+11. **AC11 — Timeout honors `cfg.Timeout` for script renders.** A script that `while true do end`s terminates at `cfg.Timeout`, not at `lua.DefaultTimeout`.
+*Test:* `document_test.go` — script with infinite loop; config `timeout: 1`;
+assert render returns a timeout error within ~2s wall clock.
+
+Inspection-only (verified by human review, not executable):
+
+- **AC-DOC1 — Guide section present.** `docs-project/entities/guides/GUIDE-data-entry.md` has a Documents section covering: YAML schema for both variants with `entity_type:` shown as required; `edit://` + `create://` URL schemes; caching (disk cache for command:; in-process `rela.cache` for script: with a note that cache is namespaced by script path); SSE live reload caveat (entry entity only; other entities require refresh button); `rela.mode == "document"` contract; `rela.document.id` and `rela.document.entry_id`; `rela.output` behavior; `html.WithUnsafe` trust boundary (frontend DOMPurify is the sanitizer; future HTML consumers need their own); config hot-reload caveat (editing `data-entry.yaml` changes which script backs a doc on next refresh).
+- **AC-DOC2 — FEAT-023 updated.** Content reflects shipped state (command renderer) and the new Lua renderer.
+- **AC-DOC3 — Prototype example.** `prototypes/data-entry/project/scripts/docs/<name>.lua` exists, composes a document from multiple entities (uses `rela.trace_from` or `rela.list_entities`), demonstrates `rela.cache.memoize`, and is wired into `prototypes/data-entry/project/data-entry.yaml` under `documents:` with `entity_type:` set.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+- **Reused**: `script.NewWriterRuntime` (`internal/script/runtime.go:20-29`) already builds a Lua runtime wired with AI provider and per-script secrets for a given script path, taking an `io.Writer` stdout. Exactly what we need.
+- **Reused pattern — typed Engine method**: `Engine.ExecuteAction` (`internal/script/action.go`) already demonstrates the "typed method that wires its own opts internally" pattern. `ExecuteDocument` mirrors this shape.
+- **Reused**: `rela.cache.memoize` (`internal/lua/cache.go`, shipped in #556) handles in-process caching. Namespaced per script path — intentional and preserved.
+- **Reused pattern — action mode**: `WithActionMode` (`internal/lua/runtime.go:139-145`) + `isAction` flag + the branching in `luaOutput` (`runtime.go:686-691`). Copy the pattern with s/Action/Document/, carrying `documentID` + `entryID` as fields.
+- **Reused — goldmark + link rewriting**: `markdownToHTML` + `RewriteDocumentLinks` in `document.go` are renderer-agnostic; both paths call them after capturing markdown.
+- **Reused — config-load existence check**: existing `CheckActionScriptExists` (`internal/script/action.go:105`) fails fast at server startup for missing action scripts. Apply the same pattern to document scripts so operators get startup errors rather than deferred HTTP 500s.
+- **Rejected — implicit dependency tracking**: wrapping `rela.get_entity` / `list_entities` / `trace_*` to accumulate dep IDs. Rejected for V1 because exploratory reads would pollute dep sets and `rela.cache.memoize` would hide reads from the tracker. Tracked as TKT-E1FO1.
+- **Rejected — variadic-opts Engine method**: an earlier iteration proposed `ExecuteFileWithWriter(path, deps, stdout, opts...)`. Rejected per RR-UPOQZ — variadic opts invite misuse (forged `WithOutputDir`, etc.). Typed `ExecuteDocument` preferred.
+- **Rejected — auto-namespacing cache by configID in document mode**: per RR-I5WME the reviewer raised collision risk, but shared helper scripts deliberately want to share cache state across all docs that use them. Auto-namespacing would defeat reusability. Documented caveat instead.
+
+**Prior art in rela:**
+
+- PLAN-R7BQ (action scripts): same shape of captured-stdout + mode flag. Document mode is modeled after this.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+### 1. Config layer (`internal/dataentryconfig/config.go` + `validate.go`)
+
+```go
+type DocumentConfig struct {
+    Title      string `yaml:"title,omitempty"      json:"title,omitempty"`
+    EntityType string `yaml:"entity_type"          json:"entity_type"`           // still required
+    Command    string `yaml:"command,omitempty"    json:"command,omitempty"`     // was required; now optional
+    Script     string `yaml:"script,omitempty"     json:"script,omitempty"`      // new
+    Timeout    int    `yaml:"timeout,omitempty"    json:"timeout,omitempty"`
+}
+```
+
+Validation updates (`internal/dataentryconfig/validate.go:validateDocuments`):
+
+- `entity_type` is required (unchanged from today; make it explicit in error message).
+- Exactly one of `{command, script}` must be non-empty:
+  - both set → `"document %q: command and script are mutually exclusive"`.
+  - neither set → `"document %q: one of command or script must be set"`.
+- If `script:` is set, run the existing startup existence check pattern (equivalent of `CheckActionScriptExists(projectRoot, scriptPath)`) so missing scripts fail at config-load time rather than at render time (addresses RR-1FG6X).
+- Path validation is deferred to `script.loadScript` at render time, which already blocks `..` and absolute paths.
+
+### 2. Lua runtime layer (`internal/lua/runtime.go`)
+
+Add fields to `Runtime`:
+
+```go
+isDocument  bool
+documentID  string
+documentEntryID string
+```
+
+New option:
+
+```go
+func WithDocumentMode(documentID, entryID string) Option {
+    return func(r *Runtime) {
+        r.isDocument = true
+        r.documentID = documentID
+        r.documentEntryID = entryID
+    }
+}
+```
+
+In `registerContextBindings`, when `r.isDocument`:
+
+```go
+r.L.SetField(rela, "mode", lua.LString("document"))
+docTable := r.L.NewTable()
+r.L.SetField(docTable, "id", lua.LString(r.documentID))
+r.L.SetField(docTable, "entry_id", lua.LString(r.documentEntryID))
+r.L.SetField(rela, "document", docTable)
+```
+
+In `luaOutput`, add a branch identical to `isAction`:
+
+```go
+if r.isDocument {
+    fmt.Fprintln(r.stdout, "warning: rela.output() called in document mode; use print() to emit markdown")
+    return 0
+}
+```
+
+### 3. `script.Engine.ExecuteDocument` (`internal/script/executor.go`)
+
+```go
+// ExecuteDocument loads and runs a Lua script from scripts/ in document
+// rendering mode. Captured stdout is the markdown the caller uses.
+// documentID is the key under documents: in data-entry.yaml.
+// entryID is the ID of the entity being rendered.
+// timeout overrides lua.DefaultTimeout when non-zero.
+func (e *Engine) ExecuteDocument(
+    path string,
+    deps lua.WriteDeps,
+    stdout io.Writer,
+    documentID string,
+    entryID string,
+    timeout time.Duration,
+) error {
+    code, err := loadScript(deps.ProjectRoot, path)
+    if err != nil {
+        return err
+    }
+    opts := []lua.Option{lua.WithDocumentMode(documentID, entryID)}
+    if timeout > 0 {
+        opts = append(opts, lua.WithTimeout(timeout))
+    }
+    runtime, err := NewWriterRuntime(deps, path, stdout, opts...)
+    if err != nil {
+        return err
+    }
+    defer runtime.Close()
+    return runtime.RunString(code)
+}
+```
+
+No variadic opts escape hatch; matches `ExecuteAction` shape.
+
+### 4. Data-entry document service (`internal/dataentry/document.go`)
+
+`documentRenderConfig` gains `Script` and `ConfigID`:
+
+```go
+type documentRenderConfig struct {
+    Command  string
+    Script   string
+    ConfigID string
+    Timeout  time.Duration
+}
+```
+
+`documentService` gains a consumer-side interface at the call site:
+
+```go
+// DocumentScriptEngine is what documentService needs from script.Engine.
+// Defined here, not in script/, per CLAUDE.md's consumer-side interface rule.
+type DocumentScriptEngine interface {
+    ExecuteDocument(path string, deps lua.WriteDeps, stdout io.Writer,
+        documentID, entryID string, timeout time.Duration) error
+}
+```
+
+Render dispatch:
+
+- **Singleflight key**: `entryID + "|" + cfg.ConfigID` (not just `entryID`) — addresses RR-4QSBN. Two concurrent renders for the same entry but different doc configs no longer collapse.
+- **`GetCached` dispatch**: only called when `cfg.Script == ""`. Script renders never read or write the disk cache — addresses RR-25XXM.
+- **Render path**:
+  - `cfg.Script != ""` → build a `bytes.Buffer`, call `scriptEngine.ExecuteDocument(cfg.Script, deps, &buf, cfg.ConfigID, entryID, cfg.Timeout)`, use `buf.String()` as markdown.
+  - `cfg.Command != ""` → existing path unchanged.
+
+### 5. Handler (`internal/dataentry/api_v1.go`, `handlers_document.go`)
+
+`handleV1Documents` **must** enforce EntityType before render (addresses
+RR-FLCXC):
+
+```go
+ent, err := a.store.GetEntity(ctx, entryID)
+if err != nil { /* 404 */ }
+if ent.Type != docCfg.EntityType {
+    http.Error(w, fmt.Sprintf("entity type %q does not match document's entity_type %q", ent.Type, docCfg.EntityType), http.StatusBadRequest)
+    return
+}
+```
+
+`toDocumentRenderConfig` now populates `ConfigID` (the map key under
+`documents:`) in addition to existing fields.
+
+### 6. Documentation (`docs-project/entities/guides/GUIDE-data-entry.md`)
+
+New `## Documents` section with these subsections:
+
+- **What documents are** (rendered HTML panels composed from markdown, live-reloaded).
+- **YAML config schema** with both `command:` and `script:` examples, `entity_type:` shown as required.
+- **`edit://` and `create://` URL schemes** with rewrite behavior.
+- **Caching behavior**:
+  - command: uses `.rela/documents/<entry>-<hash>.html` disk cache.
+  - script: uses in-process `rela.cache` (link to GUIDE-lua-scripting §Cache). Note: cache namespace is per script path — shared helper scripts share their cache state, which is usually what you want; scoped-by-doc keys require including `rela.document.id` explicitly.
+- **SSE live-reload** with the caveat (RR-J3KA9): only changes to the entry entity trigger reload; for multi-entity composition, the refresh button is the escape hatch until TKT-E1FO1 ships.
+- **Document-mode context**: `rela.mode`, `rela.document.id`, `rela.document.entry_id`, `rela.params` (noting that `rela.params` stays for author-configured params only and is separate from document identity).
+- **`rela.output` behavior**: emits a warning line to the rendered document (RR-AJC21: a loop that calls `rela.output` will produce many warning lines).
+- **Security caveat** (RR-TTNT2): the rendered HTML uses `html.WithUnsafe`; DOMPurify in the frontend is the sanitization boundary. Any future consumer of the rendered HTML (PDF export, copy-HTML button) must add its own sanitization.
+- **Config hot-reload caveat** (RR-BA10N): editing a document's `script:` value rebinds it on next refresh; open panels pick up the new script.
+
+### 7. `GUIDE-lua-scripting.md` — short subsection
+
+Cross-link to the Documents section in GUIDE-data-entry; state the document-mode
+API (`rela.mode`, `rela.document.*`, `rela.output` warning behavior).
+
+### 8. Example (`prototypes/data-entry/project/scripts/docs/release_notes.lua`)
+
+Composes a markdown doc from the entry entity + its `trace_from` children.
+Demonstrates `rela.cache.memoize` with a key that includes `rela.document.id` to
+show per-doc scoping. Wired into `prototypes/data-entry/project/data-entry.yaml`
+under `documents:` with `entity_type:` set.
+
+### 9. FEAT-023 update
+
+Content: V1 shipped (shell-command renderer); V2 adds Lua renderer (TKT-CGBVW).
+Out-of-scope follow-ups linked (TKT-E1FO1, TKT-CGPYW).
+
+**Files to modify:**
+
+| File | Change |
+|---|---|
+| `internal/dataentryconfig/config.go` | Add `Script` field to `DocumentConfig` |
+| `internal/dataentryconfig/validate.go` | Mutual-exclusion validation; preserve `entity_type` required; config-load existence check for `script:` |
+| `internal/dataentryconfig/validate_test.go` | Table-driven tests |
+| `internal/dataentry/document.go` | Dispatch; singleflight keyed on entryID+configID; skip GetCached for script:; skip disk-cache write for script:; wire cfg.Timeout for script: |
+| `internal/dataentry/document_test.go` | Lua-path tests; singleflight collision test; stale-cache-not-served test; timeout test; cache-memoize-across-renders test |
+| `internal/dataentry/handlers_document.go` | Forward ConfigID + Script + EntityType |
+| `internal/dataentry/api_v1.go` | Enforce EntityType on handler; HTTP 400 on mismatch |
+| `internal/dataentry/api_v1_test.go` | EntityType mismatch test |
+| `internal/dataentry/services.go` | Wire DocumentScriptEngine dependency into App/documentService |
+| `internal/lua/runtime.go` | `WithDocumentMode(id, entryID)`; `isDocument`/`documentID`/`documentEntryID` fields; `rela.document` binding; `luaOutput` document-mode branch |
+| `internal/lua/runtime_test.go` | Context injection tests (including `nil` assertions for non-document contexts); rela.output warning test |
+| `internal/script/executor.go` | New `ExecuteDocument` method |
+| `docs-project/entities/guides/GUIDE-data-entry.md` | New `## Documents` section with caveats |
+| `docs-project/entities/guides/GUIDE-lua-scripting.md` | Document-mode subsection cross-linking to data-entry guide |
+| `prototypes/data-entry/project/scripts/docs/release_notes.lua` | New example |
+| `prototypes/data-entry/project/data-entry.yaml` | Wire example under `documents:` |
+| rela-issues-and-design-tickets: FEAT-023 | Update to reflect shipped state |
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+| Input | Source | Validation | On invalid |
+|---|---|---|---|
+| `script:` path in `data-entry.yaml` | project author (trusted) | Must end in `.lua`; `script.loadScript` blocks `..` and absolute paths; new config-load existence check fails fast on missing file | Startup error / HTTP 500 |
+| `entry_id` path parameter in HTTP request | untrusted user (via URL) | Entity exists check; **new**: entity.Type must match docCfg.EntityType (RR-FLCXC) | HTTP 404 / 400 |
+| `docName` path parameter | untrusted user (via URL) | Lookup in `cfg.Documents[docName]` — allowlist by config keys | HTTP 404 |
+| script stdout | trusted Lua runtime output | DOMPurify sanitizes on frontend; Go side rewrites `edit://`/`create://` with existing regex | Malformed URLs pass through |
+
+**Security-Sensitive Operations:**
+
+- **EntityType enforcement** (new, RR-FLCXC): HTTP handler rejects cross-type requests before invoking the script. Removes the exfiltration path where a caller could make a release-scoped doc script run against a ticket.
+- **Script execution**: inherits the existing sandbox (no `io`/`os`/`debug`/`loadfile`; file writes confined to `output/` via `rela.write_file`). AI provider wired if configured. Same trust model as actions.
+- **Markdown → HTML**: `html.WithUnsafe()` (existing). Frontend DOMPurify sanitizes. **Caveat (RR-TTNT2)**: Lua docs can pull any entity's `content` into the stream, broadening paths by which user-submitted content reaches the unsafe HTML. DOMPurify is the boundary; any future consumer of the rendered HTML must add its own sanitization.
+- **Error leakage**: Lua errors include script path and line number — acceptable (same trust domain).
+- **DOS surface**: per-render timeout (now honoring `cfg.Timeout`), singleflight dedupes, Lua cache capped at 10k entries. Malicious script is out-of-scope threat model.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** see per-AC mapping above. Summary:
+
+| Layer | Tests |
+|---|---|
+| Config validation | `validate_test.go` — {both set, neither set, only command, only script, missing entity_type, missing script file at startup} |
+| Lua runtime | `runtime_test.go` — `TestWithDocumentMode` (rela.mode, rela.document.id, rela.document.entry_id, nil in other contexts); `TestLuaOutputDocumentMode` warning behavior |
+| Script engine | `executor_test.go` — `ExecuteDocument` invokes script with correct opts; returns stdout |
+| Document service | `document_test.go` — Lua happy path; singleflight collision with different configIDs; stale cache not served for script; cfg.Timeout honored; cache memoization across renders |
+| Handler | `api_v1_test.go` — EntityType mismatch returns 400 without invoking script |
+| Integration | `e2e_test.go` or equivalent — prototype project renders via real rela-server |
+| Manual | `just dev`, open prototype, verify live reload + refresh button |
+
+**Edge Cases:**
+
+- Script does not exist → config-load error (startup) or render-time error if added later.
+- Script writes empty stdout → empty HTML (valid).
+- Script raises Lua error mid-render → partial stdout discarded; HTTP 500 with Lua error.
+- Script exceeds `cfg.Timeout` → context cancelled; timeout error returned.
+- Script writes non-UTF8 → goldmark accepts; HTML may be malformed — not a security issue.
+- Entry ID contains shell metacharacters → Lua path is immune (passed via `rela.document.entry_id`, not interpolated into a shell command).
+- Concurrent renders for same (entryID, configID) → singleflight dedupes (correct).
+- Concurrent renders for same entryID but different configIDs → singleflight does NOT dedupe (correct after RR-4QSBN fix).
+- Cache reaches 10k cap during render → LRU evicts; occasional recompute is graceful.
+- Config swaps `script:` path while a render is in flight → next refresh picks up new script (documented caveat RR-BA10N).
+- Previous `command:`-rendered disk cache file present when same doc is switched to `script:` → stale file not served (RR-25XXM fix).
+
+**Negative Tests:**
+
+- `command:` + `script:` both set → config load fails.
+- Neither set → config load fails.
+- `entity_type:` missing → config load fails.
+- `script:` path missing on disk → config load fails (startup).
+- `script: ../../etc/passwd` → `script.loadScript` rejects at render.
+- Lua script references undefined global → render fails at script line.
+- `rela.output({foo=1})` in document mode → warning emitted, no JSON (AC5).
+- HTTP request for doc against wrong-type entity → 400, script not invoked (AC9).
+- Concurrent renders for different configs against same entry → both produce their own output (AC8).
+- Script: config with stale command:-era disk cache → render produces Lua output, cache file ignored (AC10).
+- Infinite-loop script with `timeout: 1` → terminates within ~2s (AC11).
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+1. **Double-caching confusion.** Go-side disk cache (command:) + Lua in-process `rela.cache` (script:) both exist. Mitigation: disk cache explicitly disabled (both read and write) for `script:`; guide documents the split clearly.
+2. **`ExecuteDocument` method bloat.** Adds a bespoke method to `script.Engine`; future contexts may add more. Mitigation: each context is a distinct mode; ExecuteAction precedent is already established; the Engine acting as "the knows-how-to-wire-each-Lua-use-case place" is a coherent design.
+3. **SSE stale after multi-entity change.** Acknowledged in AC-DOC1 / TKT-E1FO1. Refresh button remains.
+4. **Cache-namespace caveat not discovered by users** (RR-I5WME). Guide calls it out; idiomatic use (`rela.document.id` in keys when needed) is shown in the prototype example.
+5. **Shell-metachar entry IDs no longer a concern** on Lua path; remains a concern for `command:` path (unchanged).
+6. **Effort estimate**: **m** (same as original; the RR fixes tighten rather than expand scope).
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `GUIDE-data-entry.md` — new Documents section (substantial; the feature was undocumented).
+- [x] `GUIDE-lua-scripting.md` — short Document Mode subsection cross-linking.
+- [x] ~~CLI help text~~ (N/A: no CLI commands changed)
+- [x] ~~CLAUDE.md~~ (N/A: follows action-mode precedent; no new patterns)
+- [x] ~~README.md~~ (N/A: no project-level changes)
+- [x] ~~API docs~~ (N/A: `/api/.../documents/.../render` contract unchanged; new error surface covered in guide)
+
+`docs-checklist` will be created manually when entering review.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+
+Critical (must fix, addressed in plan):
+- **RR-4QSBN** — singleflight key on (entryID, configID). → AC8, approach §4.
+- **RR-FLCXC** — handler enforces EntityType before render. → AC9, approach §5, security section.
+
+Significant (must fix, addressed in plan):
+- **RR-1FA8W** — entity_type remains required for script: docs. → AC2, approach §1.
+- **RR-I5WME** — cache namespace policy documented (stays per-script-path; caveat in guide; prototype demonstrates explicit keys). → AC-DOC1, approach §6, rejected alternatives.
+- **RR-UPOQZ** — typed `ExecuteDocument` method, no variadic opts. → approach §3, rejected alternatives.
+- **RR-FTFJU** — `rela.document.entry_id` replaces `rela.params.entry_id`. → AC3, approach §2.
+- **RR-J3KA9** — guide documents entry-only SSE limitation. → AC-DOC1.
+- **RR-25XXM** — `GetCached` bypassed for script: renders. → AC10, approach §4.
+- **RR-DWZKU** — AC5/AC6 test mechanisms concrete (rela.write_file sentinel, runtime-level test). → AC5, AC6.
+- **RR-82D0N** — cfg.Timeout wired via lua.WithTimeout for script renders. → AC11, approach §3.
+
+Minor/nit (addressed in plan text):
+- **RR-1FG6X** — config-load existence check. → approach §1.
+- **RR-TTNT2** — security caveat wording softened, future-consumer risk named. → AC-DOC1, security section.
+- **RR-AJC21** — log-noise caveat in guide. → AC-DOC1.
+- **RR-BA10N** — hot-reload caveat in guide. → AC-DOC1.
+- **RR-PR7M0** — disk-cache scope phrasing tightened. → Scope section.
+- **RR-ZB0XP** — ACs split into Testable vs Inspection-only. → Acceptance Criteria section.

--- a/tickets/entities/review-checklists/REV-WQ37P.md
+++ b/tickets/entities/review-checklists/REV-WQ37P.md
@@ -1,0 +1,90 @@
+---
+id: REV-WQ37P
+type: review-checklist
+title: 'Review: Document the documents feature and add Lua script renderer'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+**Evidence:** `just check` passes; `just lint` = 0 issues; `just coverage-check`
+= 73.7% total (threshold 65%); `just arch-lint` clean. E2E tests run separately
+(tag-gated); `TestE2E_LuaDocumentRenders` passes in 6.77s.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:**
+
+33 review-responses total (16 from pre-impl design-review + 17 from post-impl
+cranky + go-architect reviews):
+
+- **Critical (2) — addressed**: RR-4QSBN (singleflight key), RR-FLCXC (EntityType enforcement).
+- **Significant (9) — addressed**: RR-1FA8W, RR-I5WME, RR-UPOQZ, RR-FTFJU, RR-J3KA9, RR-25XXM, RR-DWZKU, RR-82D0N, RR-DBCF1, RR-BOV25.
+- **Minor (5) — 1 addressed (RR-1FG6X), 4 deferred** to backlog tickets (TKT-IMBOK hot-reload checks, TKT-5LCNM script-path plumbing, TKT-GOLNP stub EntityManager extraction, TKT-96VGO cache footgun).
+- **Nit (13) — 9 addressed, 3 won't-fix** (RR-36PGJ, RR-LPEMA, RR-VLCKA — all with documented reasons), 1 paired (RR-HSEJ6 addressed alongside RR-BOV25).
+
+No unrelated changes in the diff; pre-existing E2E helper signature drift
+(unrelated `NewApp` change on develop) fixed as a drive-by because the new test
+needed a working helper.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- AC1 Lua happy path — PASS (`TestDocumentService_ScriptRender_CapturesMarkdown`)
+- AC2 Config validation — PASS (`TestValidateConfig_Documents` 6 subtests)
+- AC3 Context injection — PASS (`TestDocumentMode_ContextInjection`, now using `rela.document.entry_id`)
+- AC4 Context absent elsewhere — PASS (`TestDocumentMode_AbsentInOtherContexts`, using `rela.output` for readback)
+- AC5 `rela.output` warning — PASS (`TestDocumentMode_OutputIsWarning`)
+- AC6 Cache memoize across renders — PASS (`TestDocumentService_CacheMemoizeAcrossRenders`, real `script.Engine`)
+- AC7 Shell command unchanged — PASS (existing tests + `TestHandleV1Documents_EntityTypeMatch`)
+- AC8 Singleflight keyed on configID — PASS (`TestDocumentService_SingleflightNoCollapseAcrossConfigs` + positive complement)
+- AC9 Handler enforces EntityType — PASS (`TestHandleV1Documents_EntityTypeMismatch`, `TestHandleV1Documents_EntityNotFound`)
+- AC10 Disk cache bypass — PASS (`TestDocumentService_ScriptRender_NoDiskCacheWrite`, `TestDocumentService_ScriptRender_StaleCommandCacheIgnored`)
+- AC11 cfg.Timeout honored — PASS (`TestExecuteDocument_TimeoutEnforced`)
+- E2E — PASS (`TestE2E_LuaDocumentRenders` — full browser → HTTP → Lua → goldmark → DOMPurify)
+- AC-DOC1 Guide section — PASS (manual review; `GUIDE-data-entry.md` has the Documents section with all required subsections)
+- AC-DOC2 FEAT-023 updated — PASS (status: implemented, content reflects V2 Lua renderer)
+- AC-DOC3 Prototype example — PASS (`prototypes/data-entry/project/scripts/docs/category_report.lua` wired into `data-entry.yaml`)
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-VXCAJ
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+No TODOs in the diff. Commit message will cover: *why* (data-entry documents
+feature was undocumented + shell-out was high-friction for multi-entity
+composition) and *what* (Lua renderer alongside shell, docs, prototype example,
+tightened cache/singleflight/type-enforcement plumbing the design review
+surfaced).
+
+## Pull Request
+
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (N/A: user-gated next step after review sign-off)
+- [x] ~~All CI checks pass~~ (N/A: verified locally; PR-side CI runs after the branch is pushed)
+- [x] ~~PR URL documented below~~ (N/A: no PR yet)
+
+**PR:** *pending — will be created via `/pr` after user sign-off*

--- a/tickets/entities/review-responses/RR-0GPIS.md
+++ b/tickets/entities/review-responses/RR-0GPIS.md
@@ -1,0 +1,11 @@
+---
+id: RR-0GPIS
+type: review-response
+title: docCacheDir name is ambiguous
+finding: internal/dataentry/document.go:47. const docCacheDir = "documents" reads as a full path but is a subdirectory of .rela/. Rename to docCacheSubdir or similar.
+severity: nit
+resolution: Renamed const docCacheDir → docCacheSubdir across document.go + tests. Name now reads as a directory name, not a full path.
+status: addressed
+---
+
+From post-impl cranky review. Readability only; no behavior change.

--- a/tickets/entities/review-responses/RR-1FA8W.md
+++ b/tickets/entities/review-responses/RR-1FA8W.md
@@ -1,0 +1,12 @@
+---
+id: RR-1FA8W
+type: review-response
+title: 'entity_type must remain required for script: docs'
+finding: Current validator (validate.go:970-984) requires both command and entity_type. Plan's new rule speaks only to {command, script} mutual exclusion and says nothing about entity_type. AC2 needs to assert entity_type is still required; plan's DocumentConfig snippet needs to make the invariant explicit.
+severity: significant
+resolution: entity_type remains required; validator error message explicit; AC2 covers missing-entity_type case.
+status: addressed
+---
+
+From design-review on PLAN-78HJO. Direct follow-on from #2 — without required
+entity_type the handler's type check has nothing to compare against.

--- a/tickets/entities/review-responses/RR-1FG6X.md
+++ b/tickets/entities/review-responses/RR-1FG6X.md
@@ -1,0 +1,12 @@
+---
+id: RR-1FG6X
+type: review-response
+title: 'Add config-load-time existence check for script: path'
+finding: Existing CheckActionScriptExists pattern (action.go:105) fails fast at server startup when a referenced script is missing. Plan only handles missing-script at render time, which is a deferred HTTP 500 instead of clear startup error.
+severity: minor
+resolution: Config-load existence check mirroring CheckActionScriptExists for document scripts. Plan approach §1.
+status: addressed
+---
+
+From design-review on PLAN-78HJO. Low effort; mirror the action-script existence
+check in the document validator.

--- a/tickets/entities/review-responses/RR-25XXM.md
+++ b/tickets/entities/review-responses/RR-25XXM.md
@@ -1,0 +1,18 @@
+---
+id: RR-25XXM
+type: review-response
+title: 'GetCached must be bypassed (read side) for script: docs'
+finding: 'Plan says ''Disk cache: off for script:'' — but only addresses the write path. handleV1Documents calls GetCached() before Render(); on a system that migrates a command: doc to script:, the old disk cache files are still there and GetCached will serve stale command:-rendered HTML. ContentHash doesn''t disambiguate renderer type.'
+severity: significant
+resolution: GetCached() is only called when cfg.Script == ''. Script renders bypass disk cache on both read and write. AC10 covers the stale-cache-not-served case.
+status: addressed
+---
+
+From design-review on PLAN-78HJO.
+
+Fix: either (a) Skip `GetCached` entirely when `cfg.Script != ""`. (b)
+Incorporate renderer type and/or configID into the cache file name so old
+command:-rendered files don't match new script: requests.
+
+(a) is simpler, trivially correct, and matches "Lua caching is Lua's
+responsibility via rela.cache.memoize."

--- a/tickets/entities/review-responses/RR-2NUE3.md
+++ b/tickets/entities/review-responses/RR-2NUE3.md
@@ -1,0 +1,16 @@
+---
+id: RR-2NUE3
+type: review-response
+title: Hot-reload skips CheckDocumentScriptExists (and CheckActionScriptExists)
+finding: 'internal/dataentry/watcher.go:165-223 reloads data-entry.yaml without re-running ValidateConfig or the script existence checks. A user who adds a new script: doc via hot-reload gets HTTP 500 at first render instead of startup error. The new guide text implies the existence check applies on reload; it doesn''t. Pre-existing pattern for action scripts.'
+severity: minor
+reason: 'Deferred: pre-existing gap (action scripts have the same issue). Filed as TKT-IMBOK to fix all reload-time config checks together. Out of scope for TKT-CGBVW; guide wording for this ticket reflects current reality.'
+status: deferred
+---
+
+From post-impl cranky review.
+
+Deferred: pre-existing, not introduced by this ticket. Filed as separate backlog
+ticket TKT-XXX to fix both action and document script hot-reload checks
+together. For this PR, soften guide wording to match reality rather than expand
+scope.

--- a/tickets/entities/review-responses/RR-36PGJ.md
+++ b/tickets/entities/review-responses/RR-36PGJ.md
@@ -1,0 +1,15 @@
+---
+id: RR-36PGJ
+type: review-response
+title: documentScriptEngine interface shape — 6 args, time.Duration tail
+finding: 'internal/dataentry/document.go:36-39. ExecuteDocument takes (path, deps, stdout, documentID, entryID, timeout). Could bundle documentID/entryID or use an opts struct. Trade-off: matches ExecuteAction''s flat shape for consistency. Works today; revisit if we grow a 7th arg.'
+severity: nit
+reason: Matches ExecuteAction's precedent in internal/script/action.go. Consistency across Engine's typed methods outweighs the minor elegance win from bundling. Revisit if ExecuteDocument grows a 7th argument.
+status: wont-fix
+---
+
+From go-architect review finding #2.
+
+Won't fix: matches ExecuteAction precedent in internal/script/action.go. A
+consistent flat shape across Engine's typed methods outweighs the minor elegance
+win from bundling. Revisit if we need ExecuteDocument to grow an argument.

--- a/tickets/entities/review-responses/RR-4QSBN.md
+++ b/tickets/entities/review-responses/RR-4QSBN.md
@@ -1,0 +1,17 @@
+---
+id: RR-4QSBN
+type: review-response
+title: Singleflight key must include docConfigID
+finding: documentService.Render keys singleflight on entryID alone. With multi-doc support (frontend already allows this via availableDocuments), two concurrent requests for the same entry but different document configs will collapse and the second caller receives the first caller's HTML. Must be fixed in-ticket; plan's own example encourages multi-doc setups.
+severity: critical
+resolution: Singleflight key now keyed on entryID + '|' + cfg.ConfigID (plan approach §4). Verified in AC8.
+status: addressed
+---
+
+From design-review on PLAN-78HJO.
+
+`document.go:104` uses `s.group.Do(entryID, ...)`. Required change: key on
+`entryID + "|" + configID` (and possibly renderer type).
+
+Interaction with finding on disk-cache read path (RR for #8): both the cache key
+and singleflight key must incorporate the config identity.

--- a/tickets/entities/review-responses/RR-6NAXW.md
+++ b/tickets/entities/review-responses/RR-6NAXW.md
@@ -1,0 +1,12 @@
+---
+id: RR-6NAXW
+type: review-response
+title: E2E test asserts on prototype ticket count — fragile to fixture changes
+finding: internal/dataentry/e2e_test.go. Test checks 'Tickets (' appears in rendered HTML; breaks subtly if the prototype's belongs-to relations for backend are removed. Either seed tickets explicitly in the test's project copy or comment that the assertion is robust to zero tickets (it is — the header still appears).
+severity: nit
+resolution: Expanded the AC comment in TestE2E_LuaDocumentRenders to explicitly document that the 'Tickets (' assertion survives fixture changes (the header appears independent of ticket count).
+status: addressed
+---
+
+From post-impl cranky review. Add a clarifying comment rather than change
+assertion semantics.

--- a/tickets/entities/review-responses/RR-82D0N.md
+++ b/tickets/entities/review-responses/RR-82D0N.md
@@ -1,0 +1,17 @@
+---
+id: RR-82D0N
+type: review-response
+title: 'cfg.Timeout behavior for script: renders must be specified'
+finding: 'DocumentConfig.Timeout is an existing YAML field. Plan''s section 1 retains it but never says whether it applies to script: renders. If unspecified, authors who set timeout: 120 for an expensive script will get 30s truncation from lua.DefaultTimeout.'
+severity: significant
+resolution: 'cfg.Timeout wired into lua.WithTimeout inside ExecuteDocument. AC11 tests infinite-loop + timeout: 1 terminates within ~2s wall clock.'
+status: addressed
+---
+
+From design-review on PLAN-78HJO.
+
+Two choices: (a) Wire `cfg.Timeout` into `lua.WithTimeout(...)` for script
+renders (consistent with command: timeout semantics; recommended). (b) Document
+that Timeout: only applies to command: renders (inconsistent, confusing).
+
+Recommend (a). Add to AC3 or a new AC.

--- a/tickets/entities/review-responses/RR-AJC21.md
+++ b/tickets/entities/review-responses/RR-AJC21.md
@@ -1,0 +1,12 @@
+---
+id: RR-AJC21
+type: review-response
+title: 'Log-noise risk: warning lines in document body'
+finding: rela.output warning appears in rendered HTML. A script using rela.output inside a loop could emit many warnings that dominate the visible doc. Action-mode has the same caveat. Fine to defer; worth noting in guide.
+severity: nit
+resolution: Log-noise caveat for rela.output in loops added to AC-DOC1 guide requirements.
+status: addressed
+---
+
+From design-review on PLAN-78HJO. Deferrable; mention in GUIDE-data-entry under
+the caveats subsection.

--- a/tickets/entities/review-responses/RR-BA10N.md
+++ b/tickets/entities/review-responses/RR-BA10N.md
@@ -1,0 +1,12 @@
+---
+id: RR-BA10N
+type: review-response
+title: Config hot-reload race with open doc panels
+finding: Editing data-entry.yaml to point a doc at a different script will flip rendered content on next SSE reload under the same doc name. Same-class issue as any config hot-reload; worth a one-liner in the guide.
+severity: nit
+resolution: Hot-reload caveat added to AC-DOC1 guide requirements.
+status: addressed
+---
+
+From design-review on PLAN-78HJO. Minor caveat for the guide, no code change
+needed.

--- a/tickets/entities/review-responses/RR-BOV25.md
+++ b/tickets/entities/review-responses/RR-BOV25.md
@@ -1,0 +1,17 @@
+---
+id: RR-BOV25
+type: review-response
+title: Timeout default duplicated between handlers_document.go and lua.DefaultTimeout
+finding: toDocumentRenderConfig substitutes 30s when cfg.Timeout == 0; lua.DefaultTimeout is also 30s. If lua.DefaultTimeout changes, the data-entry path silently ignores the update. ExecuteDocument already falls back to DefaultTimeout when timeout <= 0 via its guard; the handler-side substitution is redundant and wrong.
+severity: significant
+resolution: toDocumentRenderConfig no longer substitutes 30s; passes cfg.Timeout as-is (0 when YAML omits it). executeCommand gains its own commandDefaultTimeout const + zero-guard (addresses paired RR-HSEJ6 too). script.Engine.ExecuteDocument already delegates to lua.DefaultTimeout via the `timeout > 0` guard. Default lives once per renderer.
+status: addressed
+---
+
+From go-architect review finding #11.
+
+Fix: pass cfg.Timeout through as-is (including 0). ExecuteDocument's `if timeout
+> 0` guard skips WithTimeout and the runtime uses lua.DefaultTimeout. Single
+> source of truth for the default. The command-renderer path already passed
+> through the substituted value; keep the 30s default there in executeCommand
+> directly.

--- a/tickets/entities/review-responses/RR-D5F6R.md
+++ b/tickets/entities/review-responses/RR-D5F6R.md
@@ -1,0 +1,14 @@
+---
+id: RR-D5F6R
+type: review-response
+title: reqEntity helper unused title parameter
+finding: internal/dataentry/document_script_test.go:128. All callers pass "a req" and no test reads result.Properties["title"] back. Per CLAUDE.md fluent-builder guidance, auto-generate in the helper or drop the parameter.
+severity: nit
+resolution: reqEntity() helper now takes no arguments (hardcoded title 'a req' internally). All callers updated.
+status: addressed
+---
+
+From post-impl cranky review.
+
+Fix: drop the title parameter, hardcode "a req" inside the helper (or let the
+entity manager pick a default). Small cleanup.

--- a/tickets/entities/review-responses/RR-DBCF1.md
+++ b/tickets/entities/review-responses/RR-DBCF1.md
@@ -1,0 +1,17 @@
+---
+id: RR-DBCF1
+type: review-response
+title: Print redirect silently drops automation & scheduler print() output
+finding: Unconditional luaPrint override routes print() to r.stdout in every runtime. internal/script/executor.go:130 (Engine.execute) uses a bytes.Buffer that nothing reads, so every print() in an automation/scheduled-task script now lands in a dead-letter buffer. Previously hit os.Stdout via gopher-lua default, so operators could see progress output. Scope the override to (isDocument || isAction) only.
+severity: significant
+resolution: luaPrint override now scoped to `if r.isDocument || r.isAction` in newRuntime. CLI, scheduler, MCP lua_eval/lua_run, validation, and automation scripts restore the gopher-lua default (writes to os.Stdout). Document-mode context test updated to use rela.output for readback since print() is no longer captured there.
+status: addressed
+---
+
+From post-impl cranky review (+ go-architect finding #1).
+
+Fix chosen: override luaPrint only when captured stdout is meaningful — document
+mode (captured as markdown) and action mode (warning-line channel). CLI,
+scheduler, MCP lua_eval/lua_run, validation, and automation scripts restore the
+gopher-lua default (writes to os.Stdout) which matches existing user
+expectations.

--- a/tickets/entities/review-responses/RR-DWZKU.md
+++ b/tickets/entities/review-responses/RR-DWZKU.md
@@ -1,0 +1,21 @@
+---
+id: RR-DWZKU
+type: review-response
+title: AC5/AC6 need concrete testable mechanisms
+finding: AC6 says 'track via a counter in a test-local cache value' — not mechanizable without side channels. AC5 needs access to the stdout buffer that documentService.Render does not expose. Both ACs are not testable as stated.
+severity: significant
+resolution: AC5 now tests at runtime_test.go level (stdout buffer accessible). AC6 uses rela.write_file sentinel file (line count == 1 after two renders proves memoization worked).
+status: addressed
+---
+
+From design-review on PLAN-78HJO.
+
+For AC5: test at `internal/lua/runtime_test.go` level (direct runtime) rather
+than through documentService — that's where the action-mode analog
+TestLuaOutputActionMode already lives.
+
+For AC6: have the script write to a file via `rela.write_file` whose line count
+the Go test inspects. Or drive the runtime directly (not via documentService) in
+a unit test that exposes the counter.
+
+Rewrite AC5/AC6 test plans with the concrete mechanisms.

--- a/tickets/entities/review-responses/RR-DZ3GD.md
+++ b/tickets/entities/review-responses/RR-DZ3GD.md
@@ -1,0 +1,13 @@
+---
+id: RR-DZ3GD
+type: review-response
+title: luaValueToGo called unconditionally in luaOutput even when muted
+finding: internal/lua/runtime.go:737 computes goData before checking isAction/isDocument. In muted modes the value is discarded; a large nested Lua table pays for the conversion unnecessarily.
+severity: nit
+resolution: Moved luaValueToGo(data) past the isAction/isDocument guards in internal/lua/runtime.go:luaOutput. Muted modes no longer pay the conversion cost.
+status: addressed
+---
+
+From post-impl cranky review.
+
+Fix: move luaValueToGo after the mode guards. Small, local change.

--- a/tickets/entities/review-responses/RR-F52QL.md
+++ b/tickets/entities/review-responses/RR-F52QL.md
@@ -1,0 +1,15 @@
+---
+id: RR-F52QL
+type: review-response
+title: stubEntityManager copy-pasted in two test files
+finding: internal/dataentry/document_script_test.go:28-54 (docTestStubEM) and internal/script/executor_test.go:23-51 (stubEntityManager) are literal duplicates. If entitymanager.EntityManager grows a method both must be updated. Should live in a shared test helper package.
+severity: minor
+reason: 'Deferred: low urgency — EntityManager interface is stable, stub duplication is small. Filed as TKT-GOLNP (extract to shared entitymanagertest package). Will address when either EntityManager grows or we need a recorder-style fake.'
+status: deferred
+---
+
+From post-impl cranky review.
+
+Deferred: extract to internal/entitymanager/entitymanagertest package (or
+equivalent). Low urgency — the stubs are small and the EntityManager interface
+hasn't changed frequently. Filed as backlog ticket.

--- a/tickets/entities/review-responses/RR-FLCXC.md
+++ b/tickets/entities/review-responses/RR-FLCXC.md
@@ -1,0 +1,18 @@
+---
+id: RR-FLCXC
+type: review-response
+title: Handler must enforce DocumentConfig.EntityType matches entity.Type
+finding: handleV1Documents does not check that the rendered entity's type matches DocumentConfig.EntityType. An HTTP caller can invoke /documents/release_notes/TKT-CGBVW and run release-notes.lua against a ticket entity. Script authors write to an assumed type; mismatch can drive unexpected code paths and — worse — exfiltrate data via ai.chat the author thought was scoped to releases.
+severity: critical
+resolution: Handler verifies entity.Type == docCfg.EntityType before render; mismatch returns HTTP 400 (plan approach §5). Verified in AC9 + api_v1_test.go.
+status: addressed
+---
+
+From design-review on PLAN-78HJO.
+
+Belongs at the HTTP handler layer (`api_v1.go` / `handlers_document.go`), not
+inside Lua — authors shouldn't have to defensively type-check. Existing
+`command:` path has the same hole with lower blast radius.
+
+Fix: before Render, load the entity, verify `entity.Type == docCfg.EntityType`,
+return HTTP 400/404 on mismatch.

--- a/tickets/entities/review-responses/RR-FTFJU.md
+++ b/tickets/entities/review-responses/RR-FTFJU.md
@@ -1,0 +1,18 @@
+---
+id: RR-FTFJU
+type: review-response
+title: Use rela.document.entry_id, not rela.params.entry_id
+finding: 'Plan injects entry_id via rela.params, conflating system-injected identity with author-configured YAML params. A util library checking rela.params.entry_id may see stale values from a different context. Cleaner: rela.document.entry_id sits next to rela.document.id — same grouping, clearer ownership.'
+severity: significant
+resolution: entry_id moved to rela.document.entry_id (sits next to rela.document.id). AC3 updated. WithDocumentMode now takes (documentID, entryID). rela.params stays clean for author-configured params.
+status: addressed
+---
+
+From design-review on PLAN-78HJO.
+
+The earlier `/ticket` chat specifically chose rela.params for "no new API
+surface". Reviewer's point is stronger: consistency within `rela.document.*` is
+worth the one extra field.
+
+Change AC3 to assert `rela.document.entry_id == <entryID>` rather than
+`rela.params.entry_id`.

--- a/tickets/entities/review-responses/RR-GOX0S.md
+++ b/tickets/entities/review-responses/RR-GOX0S.md
@@ -1,0 +1,13 @@
+---
+id: RR-GOX0S
+type: review-response
+title: Over-clever line counting in cache-memoize test
+finding: internal/dataentry/document_script_test.go:414-417. Computes 'lines' via TrimRight + Count + 1 with a zero-guard. Since ensure_newline=true on rela.write_file guarantees newline-termination, strings.Count(data, '\n') does it in one line.
+severity: nit
+resolution: Replaced the TrimRight+Count+1 pattern with `lines := strings.Count(string(data), "\n")`. ensure_newline guarantees trailing newline so newline-count == line-count.
+status: addressed
+---
+
+From post-impl cranky review.
+
+Fix: simplify to `lines := strings.Count(string(data), "\n")`.

--- a/tickets/entities/review-responses/RR-HLADU.md
+++ b/tickets/entities/review-responses/RR-HLADU.md
@@ -1,0 +1,13 @@
+---
+id: RR-HLADU
+type: review-response
+title: 'fakeScriptEngine: callsSeq atomic redundant with len(calls) under mutex'
+finding: internal/dataentry/document_script_test.go:65. Tests use both. Pick one — if lockless is the intent, document it; otherwise drop callsSeq and use len(calls) under the existing mutex.
+severity: nit
+resolution: Dropped callsSeq atomic + sync/atomic import. Added callCount() method on fakeScriptEngine that reads len(calls) under the existing mutex. Tests use fake.callCount() instead of atomic.Load().
+status: addressed
+---
+
+From post-impl cranky review.
+
+Fix: use len(f.calls) under f.mu; drop callsSeq. Simpler test code.

--- a/tickets/entities/review-responses/RR-HSEJ6.md
+++ b/tickets/entities/review-responses/RR-HSEJ6.md
@@ -1,0 +1,14 @@
+---
+id: RR-HSEJ6
+type: review-response
+title: executeCommand lacks zero-timeout guard
+finding: internal/dataentry/document.go:274-276. context.WithTimeout(ctx, 0) creates an already-expired context. Masked today by toDocumentRenderConfig substituting 30s; becomes a latent bug once that substitution is removed (see the timeout-default-duplication fix).
+severity: nit
+resolution: executeCommand now guards against zero/negative timeout (commandDefaultTimeout const = 30s). Paired with removing the 30s substitution in toDocumentRenderConfig (RR-BOV25).
+status: addressed
+---
+
+From go-architect review.
+
+Fix: add `if timeout <= 0 { timeout = 30*time.Second }` at the top of
+executeCommand. Pairs with removing the substitution in toDocumentRenderConfig.

--- a/tickets/entities/review-responses/RR-I5WME.md
+++ b/tickets/entities/review-responses/RR-I5WME.md
@@ -1,0 +1,19 @@
+---
+id: RR-I5WME
+type: review-response
+title: rela.cache namespace collision when one script serves multiple docs
+finding: 'rela.cache is namespaced per scriptPath (cache.go:276). Two data-entry.yaml document entries pointing at the same .lua file share a cache namespace even though their ConfigIDs differ. Author-error waiting to happen: rela.cache.memoize(''summary:'' .. entry_id, ...) collides across docs.'
+severity: significant
+resolution: 'After discussion with user: cache stays namespaced per script path (keeping shared helper scripts useful). Caveat documented in GUIDE-data-entry (AC-DOC1); prototype example demonstrates explicit doc-scoped keys via rela.document.id.'
+status: addressed
+---
+
+From design-review on PLAN-78HJO.
+
+Two options: (a) Document the caveat; tell script authors to include
+`rela.document.id` in cache keys. (b) In document mode, namespace cache by
+`scriptPath + "|" + documentID` so default is safe.
+
+(b) is stronger; (a) is less work. Given the ticket is already about adding the
+feature, (b) seems right — preserve the namespace-by-script-path default
+elsewhere, special-case document mode.

--- a/tickets/entities/review-responses/RR-IC3U0.md
+++ b/tickets/entities/review-responses/RR-IC3U0.md
@@ -1,0 +1,15 @@
+---
+id: RR-IC3U0
+type: review-response
+title: 'rela.cache namespace footgun: shared script across docs, unqualified keys collide'
+finding: 'Two documents pointing at one .lua file share a cache namespace (script path). If the script doesn''t include rela.document.id in its keys, data for different docs collides silently. Guide warns about this, but warn-in-docs-only is a trap. Design question: auto-inject rela.document.id into the namespace for doc-mode runtimes, or expose rela.cache.scoped(prefix) as a helper.'
+severity: minor
+reason: 'Deferred: design question with trade-offs (auto-inject vs. opt-in helper). Filed as TKT-96VGO with recommendation for rela.cache.scoped(prefix). Will address next time someone hits the footgun or when we have bandwidth to land the API addition.'
+status: deferred
+---
+
+From post-impl cranky review "leverage" section.
+
+Deferred: design question, not a regression. Filed as backlog ticket with
+alternatives spelled out. Current state is correct for the documented contract
+but invites footguns.

--- a/tickets/entities/review-responses/RR-J3KA9.md
+++ b/tickets/entities/review-responses/RR-J3KA9.md
@@ -1,0 +1,13 @@
+---
+id: RR-J3KA9
+type: review-response
+title: Document in AC8 that SSE live-reload only covers the entry entity
+finding: AC8 currently says 'SSE live reload' without qualification. For Lua docs composing from multiple entities, only the entry entity change triggers reload (since computeDocumentHash only hashes the entry). Users will expect multi-entity composition to live-reload. Guide must spell out the limitation.
+severity: significant
+resolution: AC-DOC1 requires the guide to state the entry-only SSE limitation explicitly; refresh-button escape hatch documented.
+status: addressed
+---
+
+From design-review on PLAN-78HJO. Not a regression — command: docs are already
+entry-only — but AC8 oversells. Fix wording in AC8 and add an explicit caveat in
+the Documents guide section.

--- a/tickets/entities/review-responses/RR-LPEMA.md
+++ b/tickets/entities/review-responses/RR-LPEMA.md
@@ -1,0 +1,16 @@
+---
+id: RR-LPEMA
+type: review-response
+title: 'App construction: two-step wiring of documentService'
+finding: internal/dataentry/app.go:302-321. scriptEngine built first, then App constructed without documents, then app.documents = newDocumentService(...) because luaWriteDeps is a method on App. Temporal coupling; future constructors must remember step 2.
+severity: nit
+reason: Alternatives (passing *App into the service, splitting lua.WriteDeps construction out of App) are larger surgeries that don't return proportional value. The inline comment at the construction site documents the ordering explicitly.
+status: wont-fix
+---
+
+From go-architect review finding #8.
+
+Won't fix for this ticket: the alternative designs (pass *App into service,
+split lua.WriteDeps construction out of App) are bigger surgeries that don't
+return proportional value. The comment at the construction site makes the
+ordering explicit.

--- a/tickets/entities/review-responses/RR-PR7M0.md
+++ b/tickets/entities/review-responses/RR-PR7M0.md
@@ -1,0 +1,11 @@
+---
+id: RR-PR7M0
+type: review-response
+title: 'Clarify scope: disk cache behavior for command: vs. script:'
+finding: 'Out-of-scope note ''Removing the disk cache from command:'' is accurate but phrasing is imprecise. Plan should explicitly say: ''command: keeps disk cache (unchanged); script: bypasses disk cache on both read and write.'''
+severity: nit
+resolution: 'Scope section clarified: ''command: keeps disk cache unchanged; script: bypasses disk cache on both read and write''.'
+status: addressed
+---
+
+From design-review on PLAN-78HJO. Wording fix in plan's Scope section.

--- a/tickets/entities/review-responses/RR-QED77.md
+++ b/tickets/entities/review-responses/RR-QED77.md
@@ -1,0 +1,16 @@
+---
+id: RR-QED77
+type: review-response
+title: 'ExecuteDocument threads path twice: NewWriterRuntime + SetScriptPath'
+finding: internal/script/executor.go:88-123. path goes to NewWriterRuntime for per-script secret lookup AND to runtime.SetScriptPath for rela.cache.* namespacing. 5-line comment admits the awkwardness. Latent footgun for the next contributor.
+severity: minor
+reason: 'Deferred: affects ExecuteAction too, not just ExecuteDocument; best fixed in one sweep. Filed as TKT-5LCNM. Not a correctness bug, just an ergonomic cleanup.'
+status: deferred
+---
+
+From go-architect review finding #11 (other observations) and post-impl cranky
+review.
+
+Deferred: fix is a lua.WithScriptPath option or have NewWriterRuntime call
+SetScriptPath internally. Affects ExecuteAction too. Filed as separate backlog
+ticket.

--- a/tickets/entities/review-responses/RR-SZVN1.md
+++ b/tickets/entities/review-responses/RR-SZVN1.md
@@ -1,0 +1,11 @@
+---
+id: RR-SZVN1
+type: review-response
+title: fakeScriptCall uses exported fields in a test-only package
+finding: internal/dataentry/document_script_test.go:68-73. Struct is private to the test file. Lowercase the fields for style consistency with the rest of the test code.
+severity: nit
+resolution: fakeScriptCall fields lowercased (path, documentID, entryID, timeout). Consistent with private-struct-in-test-file style.
+status: addressed
+---
+
+From post-impl cranky review. Trivial style fix.

--- a/tickets/entities/review-responses/RR-TTNT2.md
+++ b/tickets/entities/review-responses/RR-TTNT2.md
@@ -1,0 +1,15 @@
+---
+id: RR-TTNT2
+type: review-response
+title: Acknowledge html.WithUnsafe + multi-entity content as broader attack surface
+finding: Plan calls current html.WithUnsafe + DOMPurify combo 'not a regression.' Technically correct, but Lua docs pull arbitrary entity.content markdown (via rela.list_entities etc.) into the output, broadening paths by which user-submitted content reaches the unsafe markdown stream. Still OK end-to-end via DOMPurify — but the security section wording is too confident.
+severity: minor
+resolution: Security section and AC-DOC1 now explicitly name DOMPurify as the sole sanitization boundary and flag future HTML consumers (PDF export, copy-HTML) as needing their own.
+status: addressed
+---
+
+From design-review on PLAN-78HJO.
+
+Plan should acknowledge: "frontend sanitization remains the only boundary.
+Future consumers of the rendered HTML (PDF export, copy-HTML button) would
+inherit the risk and need their own sanitization layer."

--- a/tickets/entities/review-responses/RR-UPOQZ.md
+++ b/tickets/entities/review-responses/RR-UPOQZ.md
@@ -1,0 +1,20 @@
+---
+id: RR-UPOQZ
+type: review-response
+title: ExecuteFileWithWriter exposes too much capability
+finding: Proposed script.Engine.ExecuteFileWithWriter(path, deps, stdout, opts...) takes variadic lua.Option — strictly more capability than any existing Engine method. ExecuteFile/ExecuteCode take fixed deps+entity; ExecuteAction wires mode internally. Variadic opts invites misuse by the next caller (e.g., forged WithOutputDir).
+severity: significant
+resolution: Typed script.Engine.ExecuteDocument(path, deps, stdout, documentID, entryID, timeout) — no variadic opts. Matches ExecuteAction shape. Plan approach §3.
+status: addressed
+---
+
+From design-review on PLAN-78HJO.
+
+Two cleaner alternatives: (a) `Engine.ExecuteDocument(path, deps, stdout,
+documentID, entryID)` — encodes the data-entry contract, no opt escape hatch.
+(b) Put Lua wiring inside documentService — construct the runtime directly via
+NewWriterRuntime with doc-specific opts, symmetric to how Engine.ExecuteAction
+does it internally.
+
+Recommend (a) — keeps the Engine as the single seam for "run a Lua file with a
+project context" while not leaking variadic opts.

--- a/tickets/entities/review-responses/RR-VLCKA.md
+++ b/tickets/entities/review-responses/RR-VLCKA.md
@@ -1,0 +1,15 @@
+---
+id: RR-VLCKA
+type: review-response
+title: Renderer dispatch duplicates cfg.Script != '' check in 4 places
+finding: dispatch in doRender (document.go:175), cache-skip in doRender (:194), availability guard in renderScript (:219), handler GetCached skip (api_v1.go). Four emptiness checks vs. a discriminator enum. Not fragile today because validation guarantees mutual exclusion; fragile to adding a third renderer.
+severity: nit
+reason: String-emptiness is safe given the validator invariant (config-load-time mutual exclusion). The four checks are local and self-explanatory. Revisit when a third renderer appears — that's the natural forcing function for introducing an enum.
+status: wont-fix
+---
+
+From go-architect review finding #5.
+
+Won't fix for this ticket. String-emptiness is safe given validator invariant.
+Address when a third renderer (e.g., PDF export) appears — that's the forcing
+function.

--- a/tickets/entities/review-responses/RR-ZB0XP.md
+++ b/tickets/entities/review-responses/RR-ZB0XP.md
@@ -1,0 +1,12 @@
+---
+id: RR-ZB0XP
+type: review-response
+title: Distinguish testable vs. inspected acceptance criteria
+finding: AC8 (guide present) and AC10 (FEAT-023 updated) are documentation acceptance criteria verified by human review. Mixing them alongside unit-testable ACs in one numbered list is confusing. Split into two categories or mark 'inspection-only' vs 'executable test'.
+severity: nit
+resolution: AC list split into 'Testable (executable checks)' with IDs AC1-AC11 and 'Inspection-only' with IDs AC-DOC1 through AC-DOC3.
+status: addressed
+---
+
+From design-review on PLAN-78HJO. Polish; restructure AC list with a label per
+item.

--- a/tickets/entities/tickets/TKT-5LCNM.md
+++ b/tickets/entities/tickets/TKT-5LCNM.md
@@ -1,0 +1,32 @@
+---
+id: TKT-5LCNM
+type: ticket
+title: Consolidate script path plumbing in script.Engine.ExecuteDocument / ExecuteAction
+kind: refactor
+priority: low
+status: backlog
+---
+
+## Problem
+
+Both `script.Engine.ExecuteDocument` (TKT-CGBVW) and `ExecuteAction` pass the
+script path to `NewWriterRuntime` for per-script secret lookup AND call
+`runtime.SetScriptPath(path)` separately so `rela.cache.*` bindings namespace
+correctly. The awkwardness is called out in a 5-line comment in executor.go.
+
+## Options
+
+1. **Add `lua.WithScriptPath(path) Option`** that sets the field inside the runtime constructor. `NewWriterRuntime` can apply it automatically when it knows the path (which it already does for the secrets path).
+2. **Have `NewWriterRuntime` call `SetScriptPath` internally** when the caller's scriptPath is non-empty. Simpler API; removes the need for the caller to do it separately.
+
+Option 2 is smaller. Either works.
+
+## Scope
+
+- Apply the cleanup to both `ExecuteDocument` and `ExecuteAction`.
+- Verify existing `RunFile` / `RunFileContent` paths still set the script path correctly (they use a different code path).
+- Remove the trailing "wire the namespace explicitly for rela.cache.*" comments in both callsites.
+
+## Out of scope
+
+Changing how `rela.cache.*` binds or namespaces.

--- a/tickets/entities/tickets/TKT-96VGO.md
+++ b/tickets/entities/tickets/TKT-96VGO.md
@@ -1,0 +1,54 @@
+---
+id: TKT-96VGO
+type: ticket
+title: Make rela.cache safer when one script serves multiple documents
+kind: enhancement
+priority: low
+status: backlog
+---
+
+## Problem
+
+`rela.cache` is namespaced per script path, so two documents configured with the
+same `script:` value share a cache namespace. If a doc script writes keys like
+`"summary:" .. entry_id` (without including `rela.document.id`), data from one
+document overwrites another's on every call.
+
+The guide (GUIDE-data-entry and GUIDE-lua-scripting) warns about this, but
+warn-in-docs-only is a footgun. The script-path namespace default is the right
+ergonomic for shared helper libraries that want cross-caller cache reuse —
+changing it per-document would regress that use case (see RR-I5WME on
+TKT-CGBVW).
+
+## Options
+
+**(a) Auto-inject `rela.document.id` into the cache namespace when running in
+document mode.** Pro: predictable default, no way to collide across docs. Con:
+loses the "shared helper" benefit for document-mode scripts. Con: behavioral
+difference between modes is surprising.
+
+**(b) Expose a helper like `rela.cache.scoped(prefix)`** that returns a
+cache-like table whose get/set/memoize prepend the prefix. Authors opt in by
+writing `local c = rela.cache.scoped("doc:" .. rela.document.id);
+c.memoize("summary:" .. id, fn)`. Pro: explicit, composable. Con: one more thing
+to teach.
+
+**(c) Leave the guide warning in place.** Pro: zero code change. Con:
+footgun-by-design.
+
+## Recommendation
+
+(b). It's ergonomic for the doc case (`scoped("doc:" .. rela.document.id)`)
+while keeping the default namespace untouched for shared libraries. `scoped` can
+also serve non-document use cases (e.g., per-tenant caching in a custom action).
+
+## Scope
+
+- Add `rela.cache.scoped(prefix string)` to `internal/lua/cache.go`.
+- Return a new Lua table whose `get`/`set`/`memoize` close over the namespaced user prefix.
+- Update GUIDE-lua-scripting with the new helper and the recommended doc-mode idiom.
+- Leave `rela.cache.{get,set,memoize}` at the top level unchanged.
+
+## Out of scope
+
+Changing how the script-path namespace is computed or stored.

--- a/tickets/entities/tickets/TKT-CGBVW.md
+++ b/tickets/entities/tickets/TKT-CGBVW.md
@@ -5,7 +5,7 @@ title: Document the documents feature and add Lua script renderer
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-CGBVW.md
+++ b/tickets/entities/tickets/TKT-CGBVW.md
@@ -1,0 +1,85 @@
+---
+id: TKT-CGBVW
+type: ticket
+title: Document the documents feature and add Lua script renderer
+kind: enhancement
+priority: medium
+effort: m
+status: review
+---
+
+## Problem
+
+The data-entry documents feature (`DocumentConfig` in `data-entry.yaml`,
+rendered by `internal/dataentry/document.go`) lets users define documents that
+render as HTML panels in the entity view, composed via an external shell
+`command:` that emits markdown. This feature is **undocumented** in the public
+docs — `GUIDE-data-entry` never mentions it.
+
+Additionally, the shell-out approach has real friction for projects that want to
+compose documents from multiple entities: users must write an external tool
+(e.g., `mdcomp` + Jinja2) and wire it in via shell. Since rela already has an
+embedded Lua runtime with full read access to the entity graph
+(`rela.list_entities`, `rela.trace_from`, `rela.get_entity`, etc.), a Lua-script
+renderer would collapse this into a single in-tree script.
+
+## Scope
+
+### In scope
+
+1. **Config**: add `script:` field to `DocumentConfig` alongside existing `command:`. Exactly one of `{command, script}` must be set (validation error at config load time if both or neither).
+2. **Renderer**: when `script:` is set, execute the `.lua` file via `script.Engine` with a stdout buffer; captured stdout becomes the markdown input. The downstream pipeline (goldmark → HTML → `edit://`/`create://` rewriting) is unchanged.
+3. **Document-mode context injection** (only when rendering a document — `nil` in all other contexts):
+   - `rela.mode = "document"`
+   - `rela.params.entry_id = <id>` (the entry entity being rendered)
+   - `rela.document = { id = <config-key> }` (the key under `documents:` in `data-entry.yaml`)
+4. **`rela.output` in document mode**: mirror the existing action-mode behavior (`internal/lua/runtime.go:686-691`) — `rela.output()` writes a warning line to captured stdout and returns, instead of emitting JSON. Message: `warning: rela.output() called in document mode; use print() to emit markdown`.
+5. **Disk cache**: skip the existing `.rela/documents/<entry>-<hash>.html` disk cache for `script:` renders (Lua's in-memory `rela.cache.memoize` is the caching story for Lua docs). Keep the disk cache for `command:` renders — shelling out is expensive and process-lifetime doesn't help between CLI invocations.
+6. **Documentation**: add a **Documents** section to `docs-project/entities/guides/GUIDE-data-entry.md` covering both `command:` and `script:` variants, the `edit://` + `create://` URL schemes, caching behavior, and SSE live-reload.
+7. **Example**: ship a Lua document script under `prototypes/data-entry/project/scripts/docs/` demonstrating multi-entity composition.
+8. **Update FEAT-023** to reflect shipped state (command-based renderer is in production) and add the Lua-script renderer to its scope.
+
+### Out of scope (follow-up tickets)
+
+- `rela.document.depends_on(id)` for SSE dependency tracking (V1 relies on refresh button + the existing entry-entity-change reload).
+- Generalizing `rela.mode` to other contexts (script / flow / scheduled / validation). V1 sets it only in document mode.
+- Removing the disk cache for `command:` renders.
+- Export of rendered markdown/HTML as a download.
+
+## Acceptance criteria
+
+- AC1: A `data-entry.yaml` entry with `script: scripts/docs/foo.lua` (and no `command:`) renders via Lua, with stdout captured as markdown, goldmark-converted to HTML, and `edit://`/`create://` links rewritten.
+- AC2: Config with both `command:` and `script:` set, or neither, fails validation at load time with a clear error.
+- AC3: Inside the Lua script, `rela.mode == "document"`, `rela.params.entry_id` matches the entry ID, and `rela.document.id` matches the config key.
+- AC4: In a non-document Lua context (script / flow / action / scheduled / validation), `rela.mode` and `rela.document` are `nil`.
+- AC5: `rela.output({...})` inside a document-mode script writes a `warning: ...` line to the rendered document (visible in the HTML panel) and does **not** emit JSON.
+- AC6: `rela.cache.memoize("key", fn)` inside a document-mode script caches across HTTP requests within the same `rela-server` process.
+- AC7: Shell-command documents (`command:`) behave identically to today — including disk caching.
+- AC8: `GUIDE-data-entry` in `docs-project/entities/guides/` has a Documents section covering both renderer variants, `edit://` + `create://` schemes, and caching.
+- AC9: `prototypes/data-entry/project/` has at least one Lua document example that composes a markdown doc from multiple entities.
+- AC10: FEAT-023 reflects shipped state and includes the Lua renderer.
+
+## Test plan
+
+- Unit tests in `internal/dataentry/document_test.go`:
+  - Lua renderer happy path: script writes markdown to stdout → captured → HTML → returned.
+  - Config validation: both set → error; neither set → error; only `command:` → OK; only `script:` → OK.
+  - `rela.mode` / `rela.document` / `rela.params.entry_id` set correctly inside the script.
+  - `rela.output` in document mode emits warning, not JSON.
+  - Disk cache skipped for `script:` renders; used for `command:` renders.
+- Integration: end-to-end via `rela-server` with a test data-entry project — request `/api/.../documents/.../render`, confirm rendered HTML.
+- Manual: run `just dev`, open a Lua-scripted document in the browser, verify live-reload via SSE.
+
+## Risks
+
+- **Risk**: Long-running Lua render could block the data-entry request for the default Lua timeout. **Mitigation**: keep the existing goroutine + singleflight pattern; document the timeout in the guide; surface errors as HTTP 500 with the Lua error message.
+- **Risk**: Config validation for mutual exclusion lives in two places (metamodel loader vs. data-entry config loader) if we're not careful. **Mitigation**: validate in the data-entry config loader only (`internal/dataentryconfig/`) — same layer that already validates other config fields.
+- **Risk**: Scripts reading many entities can unexpectedly hit the cache max-entries cap (10k). **Mitigation**: document the cap in the docs; note that scripts should choose compact cache keys.
+
+## Effort
+
+m — touches `internal/dataentryconfig/config.go`,
+`internal/dataentry/document.go` + `handlers_document.go`,
+`internal/lua/runtime.go` (new context fields for document mode), the docs
+guide, and a prototype example. No frontend changes (existing
+`DocumentsPanel.vue` already posts to the render endpoint and consumes HTML).

--- a/tickets/entities/tickets/TKT-CGPYW.md
+++ b/tickets/entities/tickets/TKT-CGPYW.md
@@ -1,0 +1,40 @@
+---
+id: TKT-CGPYW
+type: ticket
+title: Generalize rela.mode to all Lua execution contexts
+kind: enhancement
+priority: low
+status: backlog
+---
+
+## Problem
+
+TKT-CGBVW introduces `rela.mode = "document"` for data-entry document scripts,
+but leaves `rela.mode` unset (`nil`) in all other contexts (CLI `rela script`,
+`rela flow`, data-entry actions, scheduled tasks, validation). This keeps the
+blast radius small for the initial rollout.
+
+Once there's a concrete need (e.g., a script that wants to behave differently
+when run from the scheduler vs. the CLI), we should set `rela.mode` in every
+context with a stable string:
+
+| Context                | Proposed `rela.mode` |
+|------------------------|----------------------|
+| `rela script <file>`   | `"script"`           |
+| `rela flow <file>`     | `"flow"`             |
+| data-entry action      | `"action"`           |
+| data-entry document    | `"document"` (already shipped in TKT-CGBVW) |
+| scheduled task         | `"scheduled"`        |
+| validation rule        | `"validation"`       |
+| `lua_eval` / `lua_run` | `"mcp"` or similar   |
+
+## Open questions
+
+- Should validation rules get `rela.mode` at all? Validation runs with a reader runtime and `io.Discard` stdout — a script that branches on mode inside a validation rule is almost certainly a design smell.
+- What string for MCP `lua_eval` vs. `lua_run`? Keep them distinct or unified?
+
+## Scope
+
+- Set `rela.mode` in each entry point that builds a Lua runtime.
+- Document the full set of values in GUIDE-lua-scripting.
+- Add a table-driven test covering every context.

--- a/tickets/entities/tickets/TKT-E1FO1.md
+++ b/tickets/entities/tickets/TKT-E1FO1.md
@@ -1,0 +1,48 @@
+---
+id: TKT-E1FO1
+type: ticket
+title: Add rela.document.depends_on(id) for SSE dependency tracking in Lua doc scripts
+kind: enhancement
+priority: low
+status: backlog
+---
+
+## Problem
+
+Lua document scripts (introduced in TKT-CGBVW) can compose markdown from many
+entities, but the data-entry frontend only knows to reload the document when the
+*entry* entity changes. If the script walked 20 related entities and one of them
+changes, the rendered panel goes stale until the user hits refresh.
+
+## Proposal
+
+Add a Lua binding that lets a document script declare the entity IDs it depends
+on:
+
+```lua
+rela.document.depends_on(entity.id)
+```
+
+The render response collects these into `entity_ids` (same shape the existing
+`DocumentResult.Entities` uses). The frontend's `DocumentsPanel.vue` already
+tracks these IDs and triggers a reload on matching SSE entity-change events — no
+frontend work needed.
+
+## Alternative considered
+
+Implicit tracking by intercepting `rela.get_entity` / `rela.list_entities` /
+`rela.trace_*`. Rejected for V1 because it requires wrapping every read binding
+and has surprising behavior (a throwaway `list_entities` during exploration
+would register unwanted deps). Explicit opt-in is more predictable.
+
+## Scope
+
+- Add `depends_on(id)` to `rela.document` table (only present in document mode).
+- Accumulate IDs into the document render context.
+- Return them alongside the rendered HTML as `entity_ids`.
+- Update docs in GUIDE-data-entry.
+
+## Out of scope
+
+- Automatic tracking.
+- Cross-document dependency propagation.

--- a/tickets/entities/tickets/TKT-GOLNP.md
+++ b/tickets/entities/tickets/TKT-GOLNP.md
@@ -1,0 +1,41 @@
+---
+id: TKT-GOLNP
+type: ticket
+title: Extract stubEntityManager to shared test helper package
+kind: refactor
+priority: low
+status: backlog
+---
+
+## Problem
+
+Two copies of the same `EntityManager` test stub exist:
+
+- `internal/dataentry/document_script_test.go:28-54` (as `docTestStubEM`)
+- `internal/script/executor_test.go:23-51` (as `stubEntityManager`)
+
+Both panic on every method call ("not expected in this test"). If the
+`entitymanager.EntityManager` interface grows a method, both files must be
+updated in lockstep or the tests stop compiling.
+
+## Scope
+
+Extract to a new package `internal/entitymanager/entitymanagertest` (or similar)
+with:
+
+```go
+// PanicOnUse is an EntityManager whose every method panics. Use it
+// when a test's code path should never reach a mutation.
+type PanicOnUse struct{}
+
+func (PanicOnUse) CreateEntity(...) ...
+func (PanicOnUse) UpdateEntity(...) ...
+// ...
+```
+
+Replace both copies with imports of the shared type.
+
+## Out of scope
+
+Adding a more capable fake (e.g., a recorder). That's a separate design
+conversation — build it when we actually need one.

--- a/tickets/entities/tickets/TKT-IMBOK.md
+++ b/tickets/entities/tickets/TKT-IMBOK.md
@@ -1,0 +1,42 @@
+---
+id: TKT-IMBOK
+type: ticket
+title: Hot-reload of data-entry.yaml should re-run ValidateConfig + script existence checks
+kind: refactor
+priority: low
+status: backlog
+---
+
+## Problem
+
+`internal/dataentry/watcher.go:rebuildState` reloads `data-entry.yaml` after a
+filesystem change but only performs YAML unmarshal. It does NOT re-run:
+
+- `ValidateConfig` — so a mutually-exclusive `command:`+`script:` config would be accepted at runtime even though startup would have rejected it.
+- `script.CheckActionScriptExists` for action scripts.
+- `script.CheckDocumentScriptExists` for document scripts.
+
+**Symptom**: a user editing `data-entry.yaml` to point at a missing or malformed
+Lua file sees an HTTP 500 at first render instead of a server log entry
+indicating the config is broken.
+
+The guide text added in TKT-CGBVW says document scripts are "checked for
+existence at startup" and the "Config hot-reload" note implies hot-reloads take
+effect cleanly. The code doesn't match the guide.
+
+## Scope
+
+- Re-run `ValidateConfig` in `rebuildState`.
+- Re-run existence checks for actions and documents.
+- If validation fails, log the error and leave the previously-valid config in place (do NOT swap to a broken config — that would silently wedge the server).
+- Emit an SSE `config-error` event so the frontend can surface the problem.
+
+## Out of scope
+
+- Changing the YAML schema.
+- Reloading the metamodel (separate concern).
+
+## Notes
+
+Pre-existing issue (action scripts had the same gap before TKT-CGBVW). Fix all
+three check families together.

--- a/tickets/relations/TKT-5LCNM--affects--lua-scripting.md
+++ b/tickets/relations/TKT-5LCNM--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5LCNM
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-5LCNM--implements--FEAT-i5ji.md
+++ b/tickets/relations/TKT-5LCNM--implements--FEAT-i5ji.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5LCNM
+relation: implements
+to: FEAT-i5ji
+---

--- a/tickets/relations/TKT-96VGO--affects--lua-scripting.md
+++ b/tickets/relations/TKT-96VGO--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-96VGO
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-96VGO--implements--FEAT-i5ji.md
+++ b/tickets/relations/TKT-96VGO--implements--FEAT-i5ji.md
@@ -1,0 +1,5 @@
+---
+from: TKT-96VGO
+relation: implements
+to: FEAT-i5ji
+---

--- a/tickets/relations/TKT-CGBVW--affects--data-entry-server.md
+++ b/tickets/relations/TKT-CGBVW--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-CGBVW--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-CGBVW--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-CGBVW--affects--lua-scripting.md
+++ b/tickets/relations/TKT-CGBVW--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-CGBVW--has-docs--DOCS-VXCAJ.md
+++ b/tickets/relations/TKT-CGBVW--has-docs--DOCS-VXCAJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-docs
+to: DOCS-VXCAJ
+---

--- a/tickets/relations/TKT-CGBVW--has-implementation--IMPL-KODOT.md
+++ b/tickets/relations/TKT-CGBVW--has-implementation--IMPL-KODOT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-implementation
+to: IMPL-KODOT
+---

--- a/tickets/relations/TKT-CGBVW--has-planning--PLAN-78HJO.md
+++ b/tickets/relations/TKT-CGBVW--has-planning--PLAN-78HJO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-planning
+to: PLAN-78HJO
+---

--- a/tickets/relations/TKT-CGBVW--has-review--REV-WQ37P.md
+++ b/tickets/relations/TKT-CGBVW--has-review--REV-WQ37P.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review
+to: REV-WQ37P
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-0GPIS.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-0GPIS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-0GPIS
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-1FA8W.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-1FA8W.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-1FA8W
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-1FG6X.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-1FG6X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-1FG6X
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-25XXM.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-25XXM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-25XXM
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-2NUE3.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-2NUE3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-2NUE3
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-36PGJ.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-36PGJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-36PGJ
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-4QSBN.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-4QSBN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-4QSBN
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-6NAXW.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-6NAXW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-6NAXW
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-82D0N.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-82D0N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-82D0N
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-AJC21.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-AJC21.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-AJC21
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-BA10N.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-BA10N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-BA10N
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-BOV25.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-BOV25.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-BOV25
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-D5F6R.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-D5F6R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-D5F6R
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-DBCF1.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-DBCF1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-DBCF1
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-DWZKU.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-DWZKU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-DWZKU
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-DZ3GD.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-DZ3GD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-DZ3GD
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-F52QL.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-F52QL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-F52QL
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-FLCXC.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-FLCXC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-FLCXC
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-FTFJU.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-FTFJU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-FTFJU
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-GOX0S.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-GOX0S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-GOX0S
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-HLADU.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-HLADU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-HLADU
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-HSEJ6.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-HSEJ6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-HSEJ6
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-I5WME.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-I5WME.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-I5WME
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-IC3U0.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-IC3U0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-IC3U0
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-J3KA9.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-J3KA9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-J3KA9
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-LPEMA.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-LPEMA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-LPEMA
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-PR7M0.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-PR7M0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-PR7M0
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-QED77.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-QED77.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-QED77
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-SZVN1.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-SZVN1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-SZVN1
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-TTNT2.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-TTNT2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-TTNT2
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-UPOQZ.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-UPOQZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-UPOQZ
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-VLCKA.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-VLCKA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-VLCKA
+---

--- a/tickets/relations/TKT-CGBVW--has-review-response--RR-ZB0XP.md
+++ b/tickets/relations/TKT-CGBVW--has-review-response--RR-ZB0XP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: has-review-response
+to: RR-ZB0XP
+---

--- a/tickets/relations/TKT-CGBVW--implements--FEAT-023.md
+++ b/tickets/relations/TKT-CGBVW--implements--FEAT-023.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGBVW
+relation: implements
+to: FEAT-023
+---

--- a/tickets/relations/TKT-CGPYW--affects--lua-scripting.md
+++ b/tickets/relations/TKT-CGPYW--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGPYW
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-CGPYW--implements--FEAT-i5ji.md
+++ b/tickets/relations/TKT-CGPYW--implements--FEAT-i5ji.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CGPYW
+relation: implements
+to: FEAT-i5ji
+---

--- a/tickets/relations/TKT-E1FO1--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-E1FO1--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E1FO1
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-E1FO1--affects--lua-scripting.md
+++ b/tickets/relations/TKT-E1FO1--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E1FO1
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-E1FO1--implements--FEAT-023.md
+++ b/tickets/relations/TKT-E1FO1--implements--FEAT-023.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E1FO1
+relation: implements
+to: FEAT-023
+---

--- a/tickets/relations/TKT-GOLNP--affects--test-fixtures.md
+++ b/tickets/relations/TKT-GOLNP--affects--test-fixtures.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GOLNP
+relation: affects
+to: test-fixtures
+---

--- a/tickets/relations/TKT-GOLNP--implements--FEAT-i5ji.md
+++ b/tickets/relations/TKT-GOLNP--implements--FEAT-i5ji.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GOLNP
+relation: implements
+to: FEAT-i5ji
+---

--- a/tickets/relations/TKT-IMBOK--affects--data-entry-server.md
+++ b/tickets/relations/TKT-IMBOK--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IMBOK
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-IMBOK--implements--FEAT-023.md
+++ b/tickets/relations/TKT-IMBOK--implements--FEAT-023.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IMBOK
+relation: implements
+to: FEAT-023
+---


### PR DESCRIPTION
## Summary

- Adds `script:` field to `DocumentConfig` so data-entry documents can be rendered by a Lua script (reads the entity graph directly) instead of shelling out to an external command. Exactly one of `{command, script}` must be set.
- Documents the full documents feature in `GUIDE-data-entry.md` (it was previously undocumented) plus a Document Mode subsection in `GUIDE-lua-scripting.md`.
- Adds `rela.mode == "document"` and `rela.document.{id, entry_id}` context for doc-mode scripts; `rela.output` emits a warning line instead of JSON (mirrors action-mode).
- Fixes a handful of issues the design + post-impl reviews surfaced: singleflight now keys on `(entryID, configID)` so concurrent renders of different docs don't collapse; HTTP handler enforces `DocumentConfig.EntityType` before rendering; `GetCached` bypassed for script renders (and no disk-cache writes) so stale command:-era files can't shadow a Lua render; `cfg.Timeout` wired through.
- Scopes the new `print` → `r.stdout` redirect to document/action mode only, preserving `os.Stdout` semantics for CLI, scheduler, MCP, validation, and automation scripts.

## What reviewers should know

- Design review and two post-impl reviews (go-architect, cranky) produced **33 findings**; all critical/significant are addressed, minors are deferred to **TKT-IMBOK**, **TKT-5LCNM**, **TKT-GOLNP**, **TKT-96VGO**. See linked review-response entities under `tickets/entities/review-responses/RR-*.md`.
- Implements FEAT-023 (now `status: implemented`). Out-of-scope follow-ups tracked by TKT-E1FO1 (SSE dep tracking) and TKT-CGPYW (generalize `rela.mode`).

## Test plan

- [x] `just test` — all green with race detection.
- [x] `just lint` — 0 issues.
- [x] `just coverage-check` — 73.7% (threshold 65%).
- [x] `just arch-lint` — clean.
- [x] `just docs` — regenerated; `docs-check` passes.
- [x] `TestE2E_LuaDocumentRenders` (chromedp, `-tags=e2e`) — full browser → HTTP → Lua VM → goldmark → DOMPurify chain verified against the prototype project.
- [x] Manual smoke: rendered two real VWS documents (PRS FO/TO, ~76 KB HTML each) via the new `script:` config.

## Acceptance criteria

See `tickets/entities/tickets/TKT-CGBVW.md` for AC1–AC11 + AC-DOC1–AC-DOC3. Per-AC test mapping is in `tickets/entities/implementation-checklists/IMPL-KODOT.md` under "Verification Evidence". Every AC has a linked test or a documented inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)