### PR TITLE
chore: file deferred tickets from learnings cleanup

### DIFF
--- a/tickets/entities/tickets/TKT-5843C.md
+++ b/tickets/entities/tickets/TKT-5843C.md
@@ -1,0 +1,50 @@
+---
+id: TKT-5843C
+type: ticket
+title: Strict JSON / OpenAPI contract tests for dataentry write endpoints
+kind: test
+priority: medium
+effort: m
+status: backlog
+---
+
+## Problem
+
+BUG-UNEBR (PATCH endpoint silently dropped `relations` payload) was the
+canonical example of a class of bugs where the backend Go struct doesn't match
+what the frontend sends. The bug fix added the missing field, but nothing
+prevents the next field-drift.
+
+Initial PR plan was to add `DisallowUnknownFields` on every dataentry write
+decoder. Investigation showed the frontend sends `Partial<Entity>` on PATCH,
+including `id`, `type`, `_title`, `included`, `_self`, `_actions` — strict
+decoding would reject these and break the UI.
+
+The cleaner fix is a typed contract: derive a Go request struct from the OpenAPI
+spec (already in-progress under FEAT-vfxz) and have the frontend build payloads
+from the same source. Then strict decoding is safe because both sides agree on
+the shape.
+
+## Scope
+
+**In scope**
+
+- Audit every JSON decoder in `internal/dataentry/` for shape drift risk.
+- Derive request structs from `internal/openapi/` spec where feasible.
+- Add `DisallowUnknownFields` decoder helper for endpoints whose spec is
+authoritative.
+- Add Go integration tests that POST/PATCH against each write endpoint
+with the *exact* JSON the frontend sends today, asserting all fields round-trip.
+
+**Out of scope**
+
+- Generating TS types from the OpenAPI spec on the frontend side
+(separate, larger ticket — likely belongs under FEAT-vfxz).
+- Migrating the frontend to send curated payloads instead of `Partial<Entity>`.
+
+## Acceptance criteria
+
+- Each dataentry write endpoint has a contract test that decodes the
+current frontend payload without `unknown field` errors.
+- New endpoint scaffolding (e.g. via `openapi/codegen`) uses
+`DisallowUnknownFields` by default.

--- a/tickets/entities/tickets/TKT-9PJOS.md
+++ b/tickets/entities/tickets/TKT-9PJOS.md
@@ -1,0 +1,44 @@
+---
+id: TKT-9PJOS
+type: ticket
+title: Reload-during-write conformance test in storetest
+kind: test
+priority: medium
+effort: s
+status: backlog
+---
+
+## Problem
+
+`storetest` already has `TestConcurrentReloadDuringRead`, but ~24 review
+findings flag concurrency hazards specifically around *writes* during reload:
+rebuilding the search index from a stale snapshot, validation reading outside
+`WithTx` racing against reload, two-phase `Load()` calls observing different
+snapshots, etc.
+
+RR-EI58 (addressed) explicitly noted "TestConcurrentReloadDuringRead does not
+exercise concurrent writers". RR-065O2 (deferred) asked for the conformance test
+to also run against `SafeFS`-wrapped `OsFS`.
+
+## Scope
+
+**In scope**
+
+- Add `TestConcurrentReloadDuringWrite` to
+`internal/store/storetest/conformance.go`. Goroutine A repeatedly calls
+`Reload()`; goroutine B repeatedly creates/updates entities; assert no data race
+(under `-race`) and no intermediate broken state.
+- Add a writers-and-readers variant.
+- Run the harness against `SafeFS`-wrapped `OsFS` as well as the existing
+fsstore/memstore implementations (closes RR-065O2).
+
+**Out of scope**
+
+- Migrating callers to a new reload contract — that is several other tickets.
+
+## Acceptance criteria
+
+- New conformance tests pass on `develop` under `-race`.
+- They fail when a regression reintroduces a torn-snapshot read or a
+goroutine-leak path.
+- Documented in `internal/store/doc.go` "Reload contract" section.

--- a/tickets/entities/tickets/TKT-NEUH2.md
+++ b/tickets/entities/tickets/TKT-NEUH2.md
@@ -1,0 +1,45 @@
+---
+id: TKT-NEUH2
+type: ticket
+title: Frontend test fixture builders + ESLint rule banning hardcoded ID literals
+kind: test
+priority: low
+effort: s
+status: backlog
+---
+
+## Problem
+
+Review-response pattern analysis surfaced ~10 distinct findings about hardcoded
+entity IDs (`FEAT-001`, `BUG-001`, `TASK-001`) embedded in Vue components, e2e
+specs, and TS fixtures. The Go side has fluent builders
+(`internal/testutil/fixtures.go`); the frontend does not, and there is no ESLint
+rule preventing the pattern from spreading.
+
+CLAUDE.md already mandates fluent builders / no-hardcoded-IDs; the gap is
+*enforcement* on the frontend.
+
+## Scope
+
+**In scope**
+
+- Add a TS fluent builder (entity, relation) under `frontend/src/test/` or
+similar, mirroring `internal/testutil/fixtures.go` semantics (auto-generated IDs
+unless explicitly set).
+- Add an ESLint rule to `eslint.config.js` that flags string literals
+matching `/^[A-Z]+-\d{3,}$/` outside fixture loaders / test data directories.
+Same rule for the `e2e/` workspace.
+- Migrate one or two example test files to use the new builder so the
+pattern is visible to future contributors.
+
+**Out of scope**
+
+- Bulk-migrating all ~50+ hardcoded-ID test sites in one PR. Migrate the
+most-touched files; the lint rule does the rest of the work over time.
+
+## Acceptance criteria
+
+- New ESLint rule fails on a hardcoded `BUG-001`-style literal in a
+non-fixture file.
+- Builder API documented in `frontend/CLAUDE.md` Test section.
+- At least one existing test migrated as the canonical example.

--- a/tickets/entities/tickets/TKT-O03TB.md
+++ b/tickets/entities/tickets/TKT-O03TB.md
@@ -1,0 +1,44 @@
+---
+id: TKT-O03TB
+type: ticket
+title: Packaged-binary smoke test (//go:embed assets non-empty + served)
+kind: test
+priority: medium
+effort: s
+status: backlog
+---
+
+## Problem
+
+BUG-W144 shipped a desktop binary with no Vue SPA assets — the `//go:embed`
+directive resolved to an empty directory because the build pipeline didn't
+declare the SPA generator as a dependency. Caught manually after a release
+candidate test. Nothing prevents recurrence.
+
+A small smoke test that runs after `just build` and asserts that the packaged
+binaries serve a non-empty asset set would close this regression class for
+`rela-server`, `rela-desktop`, and any future packaged binary.
+
+## Scope
+
+**In scope**
+
+- Add a smoke test (Go test or shell script under `scripts/`) that:
+  1. Spawns the built `rela-server` binary against a fixture project.
+  2. Issues a GET to `/index.html` and verifies non-empty body + status 200.
+  3. Issues a GET to one bundled JS asset path and verifies non-empty body.
+  4. Tears down.
+- Wire the test into `just smoke` and into the CI release pipeline.
+- Audit `//go:embed` declarations: each one whose target is generated
+must have its generator declared as a `just` recipe dependency.
+
+**Out of scope**
+
+- Full e2e coverage (already in `/e2e/`).
+- Wails/desktop-binary smoke (harder, separate ticket if needed).
+
+## Acceptance criteria
+
+- `just smoke` builds, runs the binary against a fixture, and exits 0.
+- Smoke test fails (and PR is blocked) if the embedded SPA is empty.
+- Documented in `justfile` and `CLAUDE.md` Commands section.

--- a/tickets/entities/tickets/TKT-R2BAU.md
+++ b/tickets/entities/tickets/TKT-R2BAU.md
@@ -1,0 +1,52 @@
+---
+id: TKT-R2BAU
+type: ticket
+title: Custom analyzer or /code-review checklist for silent default returns
+kind: test
+priority: low
+effort: m
+status: backlog
+---
+
+## Problem
+
+Cross-cutting analysis of 659 review-responses found ~91 findings tagged
+"silently swallows", "fails open", "silent semantic conversion" — the single
+largest category of significant/critical findings. Patterns:
+
+- `return "", nil` or `return nil, nil` in `default:` and `case error:`
+branches with no prior log call.
+- Type-mismatch fallthrough to lexicographic compare or `[foo bar]` rendering.
+- Cleanup goroutines that swallow `Walk` errors.
+
+Two complementary mitigations are possible; this ticket scopes both for
+discussion before committing to either.
+
+**Option A — custom golangci-lint analyzer.** Pattern-match `return ""` /
+`return nil` from default/error branches with no preceding `slog.*` call in the
+same function. Risk: high false-positive rate; analyzer maintenance.
+
+**Option B — `/code-review` checklist line.** Add a bullet: "Grep the diff for
+default returns on error/unknown branches. Each must log+propagate or carry an
+explicit `// intentional fallback: <reason>` comment." Lower ceiling, but no
+false-positive cost and immediate effect.
+
+## Scope
+
+**In scope**
+
+- Decide between A, B, or both.
+- If B: edit `.claude/commands/code-review.md` and the cranky-code-reviewer
+agent prompt to include the new check.
+- If A: spike a ruleguard or custom analyzer; benchmark FP rate on
+develop's diff history; decide whether to enable.
+
+**Out of scope**
+
+- Bulk-fixing existing silent-default sites (the 91 already addressed are
+the corpus that motivated this).
+
+## Acceptance criteria
+
+- Either an analyzer is enabled with measured FP rate on a sample, or the
+/code-review checklist explicitly asks reviewers to grep for silent defaults.

--- a/tickets/relations/TKT-5843C--affects--rest-api.md
+++ b/tickets/relations/TKT-5843C--affects--rest-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5843C
+relation: affects
+to: rest-api
+---

--- a/tickets/relations/TKT-5843C--implements--FEAT-vfxz.md
+++ b/tickets/relations/TKT-5843C--implements--FEAT-vfxz.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5843C
+relation: implements
+to: FEAT-vfxz
+---

--- a/tickets/relations/TKT-9PJOS--affects--store-backends.md
+++ b/tickets/relations/TKT-9PJOS--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9PJOS
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-9PJOS--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-9PJOS--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9PJOS
+relation: implements
+to: FEAT-CO4YP
+---

--- a/tickets/relations/TKT-NEUH2--affects--test-fixtures.md
+++ b/tickets/relations/TKT-NEUH2--affects--test-fixtures.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NEUH2
+relation: affects
+to: test-fixtures
+---

--- a/tickets/relations/TKT-NEUH2--implements--FEAT-022.md
+++ b/tickets/relations/TKT-NEUH2--implements--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NEUH2
+relation: implements
+to: FEAT-022
+---

--- a/tickets/relations/TKT-O03TB--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-O03TB--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-O03TB
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-O03TB--implements--FEAT-022.md
+++ b/tickets/relations/TKT-O03TB--implements--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: TKT-O03TB
+relation: implements
+to: FEAT-022
+---

--- a/tickets/relations/TKT-R2BAU--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-R2BAU--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R2BAU
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-R2BAU--implements--FEAT-022.md
+++ b/tickets/relations/TKT-R2BAU--implements--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R2BAU
+relation: implements
+to: FEAT-022
+---


### PR DESCRIPTION
## Summary

Five new backlog tickets capturing the deferred items from the learnings retrospective:

- **TKT-NEUH2** — Frontend test fixture builders + ESLint rule banning hardcoded ID literals
- **TKT-O03TB** — Packaged-binary smoke test (`//go:embed` assets non-empty + served)
- **TKT-R2BAU** — Custom analyzer or `/code-review` checklist for silent default returns
- **TKT-5843C** — Strict JSON / OpenAPI contract tests for dataentry write endpoints (replaces the abandoned `DisallowUnknownFields` PR — strict decode would break frontend's `Partial<Entity>` payloads)
- **TKT-9PJOS** — Reload-during-write conformance test in storetest

These are tracked but not implemented in this session. See `.ignored/tickets-learnings.md` for the full retrospective.

## Test plan

- [x] `analyze_cardinality` — clean
- [x] `analyze_validations` — 118 rules pass
- [x] `analyze_properties` — clean
- [x] All five tickets have `affects` and `implements` relations