### PR TITLE
ci: skip rela-tickets job on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
 
   rela-tickets:
     name: Rela Tickets
-    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'chore/')
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'chore/') && !startsWith(github.head_ref, 'dependabot/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Dependabot PRs can't include a ticket entity, so the `rela-tickets` CI job fails on every one of them.
- Extend the existing `chore/*` skip to also cover `dependabot/*` branches.

## Test plan
- [ ] After merge, confirm new Dependabot PRs no longer run the `Rela Tickets` job