### PR TITLE
feat: structured error envelopes for Lua script failures (TKT-LR5YC)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,6 +5,7 @@ import { useKeyboardShortcuts, shortcutsModalOpen, useEvents } from '@/composabl
 import Sidebar from '@/components/common/Sidebar.vue'
 import StatusBar from '@/components/common/StatusBar.vue'
 import Toast from '@/components/common/Toast.vue'
+import ScriptErrorDialog from '@/components/common/ScriptErrorDialog.vue'
 import KeyboardShortcutsModal from '@/components/ui/KeyboardShortcutsModal.vue'
 
 const schemaStore = useSchemaStore()
@@ -99,6 +100,7 @@ watch(
     </main>
     <StatusBar />
     <Toast />
+    <ScriptErrorDialog />
     <KeyboardShortcutsModal
       :open="shortcutsModalOpen"
       @close="shortcutsModalOpen = false"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -30,12 +30,19 @@ class ApiClient {
 
     this.client.interceptors.response.use(
       (response) => response,
-      (error: AxiosError<ProblemDetail>) => {
-        if (error.response?.data?.type) {
-          return Promise.reject(error.response.data)
+      (error: AxiosError<ProblemDetail | { error?: string }>) => {
+        const data = error.response?.data
+        // Script-failure envelope (HTTP 422 from Lua surfaces) is shaped
+        // like { error: "script_error", ... }. Pass it through as-is so
+        // catch handlers can recognise and route it to <ScriptErrorPanel>.
+        if (data && typeof data === 'object' && 'error' in data && data.error === 'script_error') {
+          return Promise.reject(data)
+        }
+        if (data && typeof data === 'object' && 'type' in data && data.type) {
+          return Promise.reject(data)
         }
         return Promise.reject(error)
-      }
+      },
     )
   }
 

--- a/frontend/src/components/common/ScriptErrorDialog.vue
+++ b/frontend/src/components/common/ScriptErrorDialog.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, watch } from 'vue'
+
+import { useScriptErrorStore } from '../../stores/scriptError'
+
+import ScriptErrorPanel from './ScriptErrorPanel.vue'
+
+const store = useScriptErrorStore()
+const closeBtn = ref<HTMLButtonElement | null>(null)
+
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Escape' && store.current) {
+    e.preventDefault()
+    store.dismiss()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', onKeydown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', onKeydown)
+})
+
+// Move focus to the close button when the dialog opens. Restoring focus to
+// the trigger element is the store's job so it survives this component
+// being remounted.
+watch(
+  () => store.current,
+  (val) => {
+    if (val) {
+      // Wait for the DOM to render the dialog before focusing.
+      requestAnimationFrame(() => closeBtn.value?.focus())
+    }
+  },
+)
+</script>
+
+<template>
+  <div
+    v-if="store.current"
+    class="modal-overlay"
+    role="alertdialog"
+    aria-modal="true"
+    aria-labelledby="script-error-title"
+    @click.self="store.dismiss()"
+  >
+    <div class="modal script-error-modal">
+      <div class="se-modal-header">
+        <h3 id="script-error-title">Script error</h3>
+        <button
+          ref="closeBtn"
+          type="button"
+          class="se-close"
+          aria-label="Close"
+          @click="store.dismiss()"
+        >
+          ×
+        </button>
+      </div>
+      <ScriptErrorPanel :error="store.current" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.script-error-modal {
+  max-width: 720px;
+  width: 90%;
+  max-height: 85vh;
+  overflow: auto;
+}
+
+.se-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.se-modal-header h3 {
+  margin: 0;
+}
+
+.se-close {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  font-size: 24px;
+  line-height: 1;
+  color: var(--muted-text);
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.se-close:hover {
+  background: var(--card-bg);
+  color: var(--text-color);
+}
+</style>

--- a/frontend/src/components/common/ScriptErrorPanel.vue
+++ b/frontend/src/components/common/ScriptErrorPanel.vue
@@ -1,0 +1,267 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import type { ScriptError } from '../../types/scriptError'
+
+const props = defineProps<{ error: ScriptError }>()
+
+const stackOpen = ref(false)
+const outputOpen = ref(false)
+const argsOpen = ref(false)
+
+const surfaceLabel = computed((): string => {
+  switch (props.error.script.surface) {
+    case 'action':
+      return 'Action'
+    case 'document':
+      return 'Document'
+    case 'automation':
+      return 'Automation'
+    case 'lua_run':
+      return 'Lua Run'
+    case 'lua_eval':
+      return 'Lua Eval'
+    default:
+      return props.error.script.surface
+  }
+})
+
+const argsEntries = computed((): [string, unknown][] => {
+  const args = props.error.script.args
+  if (!args) return []
+  return Object.entries(args)
+})
+
+async function copyCorrelationId(): Promise<void> {
+  if (!props.error.correlation_id) return
+  try {
+    await navigator.clipboard.writeText(props.error.correlation_id)
+  } catch {
+    // Older browsers / insecure contexts: leave it visible for manual copy.
+  }
+}
+</script>
+
+<template>
+  <div class="script-error-panel">
+    <header class="se-header">
+      <span class="se-surface">{{ surfaceLabel }}</span>
+      <code class="se-path">{{ error.script.path }}</code>
+      <span v-if="error.script.entity_id" class="se-entity">{{ error.script.entity_id }}</span>
+    </header>
+
+    <p class="se-message">
+      <strong v-if="error.lua.line">line {{ error.lua.line }}:</strong>
+      {{ error.lua.message }}
+    </p>
+
+    <div v-if="error.source && error.source.length > 0" class="se-source">
+      <pre><code><span
+        v-for="line in error.source"
+        :key="line.n"
+        :class="{ 'se-line': true, 'se-highlight': line.highlight }"
+      ><span class="se-lineno">{{ line.n }}</span>{{ line.text }}
+</span></code></pre>
+    </div>
+
+    <details v-if="error.stack && error.stack.length > 0" :open="stackOpen" @toggle="stackOpen = !stackOpen">
+      <summary>Stack ({{ error.stack.length }} frame{{ error.stack.length === 1 ? '' : 's' }})</summary>
+      <ol class="se-stack">
+        <li v-for="(frame, i) in error.stack" :key="i">
+          <code v-if="frame.path">{{ frame.path }}<span v-if="frame.line">:{{ frame.line }}</span></code>
+          <span v-if="frame.func" class="se-func">in {{ frame.func }}</span>
+        </li>
+      </ol>
+    </details>
+
+    <details v-if="error.captured_output" :open="outputOpen" @toggle="outputOpen = !outputOpen">
+      <summary>Output before error</summary>
+      <pre class="se-output">{{ error.captured_output }}</pre>
+    </details>
+
+    <details v-if="argsEntries.length > 0" :open="argsOpen" @toggle="argsOpen = !argsOpen">
+      <summary>Args</summary>
+      <dl class="se-args">
+        <template v-for="[k, v] in argsEntries" :key="k">
+          <dt>{{ k }}</dt>
+          <dd>{{ typeof v === 'string' ? v : JSON.stringify(v) }}</dd>
+        </template>
+      </dl>
+    </details>
+
+    <footer v-if="error.correlation_id" class="se-footer">
+      <span class="se-corr-label">Correlation ID:</span>
+      <code class="se-corr">{{ error.correlation_id }}</code>
+      <button type="button" class="se-copy" @click="copyCorrelationId">Copy</button>
+    </footer>
+  </div>
+</template>
+
+<style scoped>
+.script-error-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-family: var(--font-family, system-ui, sans-serif);
+  color: var(--text-color);
+}
+
+.se-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.se-surface {
+  display: inline-block;
+  padding: 2px 8px;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  font-size: 12px;
+  color: var(--muted-text);
+}
+
+.se-path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 13px;
+}
+
+.se-entity {
+  padding: 2px 8px;
+  background: var(--card-bg);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--muted-text);
+}
+
+.se-message {
+  margin: 0;
+  padding: 8px 12px;
+  background: rgba(220, 50, 50, 0.08);
+  border-left: 3px solid #d33;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 13px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.se-source {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  overflow: auto;
+  max-height: 240px;
+}
+
+.se-source pre {
+  margin: 0;
+  padding: 8px 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.se-line {
+  display: block;
+  padding: 0 12px;
+}
+
+.se-highlight {
+  background: rgba(220, 50, 50, 0.12);
+}
+
+.se-lineno {
+  display: inline-block;
+  width: 32px;
+  margin-right: 12px;
+  color: var(--muted-text);
+  text-align: right;
+  user-select: none;
+}
+
+.se-stack {
+  margin: 8px 0 0;
+  padding-left: 24px;
+  font-size: 13px;
+}
+
+.se-stack li {
+  margin: 4px 0;
+}
+
+.se-stack code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.se-func {
+  margin-left: 8px;
+  color: var(--muted-text);
+  font-size: 12px;
+}
+
+.se-output {
+  margin: 8px 0 0;
+  padding: 8px 12px;
+  max-height: 200px;
+  overflow: auto;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+.se-args {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 12px;
+  margin: 8px 0 0;
+  font-size: 13px;
+}
+
+.se-args dt {
+  color: var(--muted-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.se-args dd {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  word-break: break-all;
+}
+
+.se-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--muted-text);
+}
+
+.se-corr {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.se-copy {
+  padding: 2px 8px;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+  border-radius: 4px;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.se-copy:hover {
+  background: var(--hover-bg, var(--border-color));
+}
+
+details summary {
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--muted-text);
+}
+</style>

--- a/frontend/src/components/common/Sidebar.vue
+++ b/frontend/src/components/common/Sidebar.vue
@@ -2,13 +2,16 @@
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useSchemaStore, useUIStore, useGitStore } from '@/stores'
+import { useScriptErrorStore } from '@/stores/scriptError'
 import { getSidebar, runAction } from '@/api'
 import { isCancelledFetch } from '@/composables/usePageData'
+import { isScriptError } from '@/types/scriptError'
 import type { SidebarGroup, SidebarItem } from '@/types'
 
 const schemaStore = useSchemaStore()
 const uiStore = useUIStore()
 const gitStore = useGitStore()
+const scriptErrorStore = useScriptErrorStore()
 const route = useRoute()
 const router = useRouter()
 
@@ -85,9 +88,12 @@ function getIconEmoji(icon?: string): string {
   }
 }
 
-async function handleAction(item: SidebarItem) {
+async function handleAction(item: SidebarItem, ev?: Event) {
   if (!item.action) return
   if (actionInFlight.value.has(item.action)) return
+
+  const triggerEl =
+    ev && ev.currentTarget instanceof HTMLElement ? ev.currentTarget : null
 
   actionInFlight.value.add(item.action)
   try {
@@ -100,13 +106,17 @@ async function handleAction(item: SidebarItem) {
       router.push(response.redirect)
     }
   } catch (err: unknown) {
-    let msg = 'Action failed'
-    const e = err as { response?: { data?: { correlation_id?: string } } }
-    const corrID = e?.response?.data?.correlation_id
-    if (corrID) {
-      msg = `Action failed (ref: ${corrID})`
+    if (isScriptError(err)) {
+      scriptErrorStore.show(err, triggerEl)
+    } else {
+      let msg = 'Action failed'
+      const e = err as { response?: { data?: { correlation_id?: string } }; correlation_id?: string }
+      const corrID = e?.response?.data?.correlation_id ?? e?.correlation_id
+      if (corrID) {
+        msg = `Action failed (ref: ${corrID})`
+      }
+      uiStore.error(msg)
     }
-    uiStore.error(msg)
   } finally {
     actionInFlight.value.delete(item.action)
   }
@@ -152,7 +162,7 @@ async function handleAction(item: SidebarItem) {
               class="nav-item nav-action"
               :aria-label="item.label"
               :disabled="actionInFlight.has(item.action)"
-              @click="handleAction(item)"
+              @click="handleAction(item, $event)"
             >
               <span class="nav-icon">{{ getIconEmoji(item.icon) }}</span>
               <span class="nav-label">{{ item.label }}</span>
@@ -177,7 +187,7 @@ async function handleAction(item: SidebarItem) {
               class="nav-item nav-action"
               :aria-label="item.label"
               :disabled="actionInFlight.has(item.action)"
-              @click="handleAction(item)"
+              @click="handleAction(item, $event)"
             >
               <span class="nav-icon">{{ getIconEmoji(item.icon) }}</span>
               <span class="nav-label">{{ item.label }}</span>

--- a/frontend/src/components/entity/DocumentsPanel.vue
+++ b/frontend/src/components/entity/DocumentsPanel.vue
@@ -2,11 +2,13 @@
 import { ref, computed, watch, onMounted, onUnmounted, nextTick, useTemplateRef } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useSchemaStore, useUIStore } from '@/stores'
+import { useScriptErrorStore } from '@/stores/scriptError'
 import { renderDocument } from '@/api/documents'
 import { useEvents } from '@/composables/useEvents'
 import { createDocumentClickHandler } from '@/composables/useDocumentClicks'
 import { renderMermaidDiagrams } from '@/utils/markdown'
 import type { DocumentConfig } from '@/types'
+import { isScriptError } from '@/types/scriptError'
 import DOMPurify from 'dompurify'
 
 const props = defineProps<{
@@ -18,6 +20,7 @@ const route = useRoute()
 const router = useRouter()
 const schemaStore = useSchemaStore()
 const uiStore = useUIStore()
+const scriptErrorStore = useScriptErrorStore()
 const { on, off } = useEvents()
 
 // Click handler for links inside the rendered document: intercepts
@@ -108,8 +111,12 @@ async function loadDocument(refresh = false) {
     docContent.value = result.html
     isCached.value = result.cached
     entityIds.value = result.entity_ids || []
-  } catch {
-    uiStore.error('Failed to render document')
+  } catch (err: unknown) {
+    if (isScriptError(err)) {
+      scriptErrorStore.show(err)
+    } else {
+      uiStore.error('Failed to render document')
+    }
     docContent.value = ''
     entityIds.value = []
   } finally {

--- a/frontend/src/stores/scriptError.test.ts
+++ b/frontend/src/stores/scriptError.test.ts
@@ -1,0 +1,63 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ScriptError } from '../types/scriptError'
+
+import { useScriptErrorStore } from './scriptError'
+
+function makeError(overrides: Partial<ScriptError> = {}): ScriptError {
+  return {
+    error: 'script_error',
+    correlation_id: 'abc123',
+    script: { surface: 'action', path: 'actions/x.lua' },
+    lua: { message: 'boom', line: 1 },
+    ...overrides,
+  }
+}
+
+describe('scriptError store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('starts empty', () => {
+    const store = useScriptErrorStore()
+    expect(store.current).toBeNull()
+  })
+
+  it('show sets the current error', () => {
+    const store = useScriptErrorStore()
+    const err = makeError()
+    store.show(err)
+    expect(store.current).toEqual(err)
+  })
+
+  it('latest replaces previous (single-modal model)', () => {
+    const store = useScriptErrorStore()
+    const first = makeError({ correlation_id: 'first' })
+    const second = makeError({ correlation_id: 'second' })
+    store.show(first)
+    store.show(second)
+    expect(store.current?.correlation_id).toBe('second')
+  })
+
+  it('dismiss clears and restores focus to the trigger', () => {
+    const store = useScriptErrorStore()
+    const trigger = document.createElement('button')
+    document.body.appendChild(trigger)
+    const focusSpy = vi.spyOn(trigger, 'focus')
+
+    store.show(makeError(), trigger)
+    store.dismiss()
+
+    expect(store.current).toBeNull()
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+    document.body.removeChild(trigger)
+  })
+
+  it('dismiss is a no-op when nothing is showing', () => {
+    const store = useScriptErrorStore()
+    expect(() => store.dismiss()).not.toThrow()
+    expect(store.current).toBeNull()
+  })
+})

--- a/frontend/src/stores/scriptError.ts
+++ b/frontend/src/stores/scriptError.ts
@@ -1,0 +1,33 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+import type { ScriptError } from '../types/scriptError'
+
+/**
+ * Holds the most recent script-error envelope so a single dialog mounted
+ * in App.vue can render it. Latest failure replaces previous: fixing one
+ * broken script and triggering another should never leave a stale dialog
+ * up.
+ *
+ * The triggering element is captured so focus can be restored on close —
+ * essential for keyboard users invoking actions from the sidebar.
+ */
+export const useScriptErrorStore = defineStore('scriptError', () => {
+  const current = ref<ScriptError | null>(null)
+  const triggeringEl = ref<HTMLElement | null>(null)
+
+  function show(err: ScriptError, fromEl?: HTMLElement | null): void {
+    current.value = err
+    triggeringEl.value = fromEl ?? null
+  }
+
+  function dismiss(): void {
+    current.value = null
+    if (triggeringEl.value) {
+      triggeringEl.value.focus()
+      triggeringEl.value = null
+    }
+  }
+
+  return { current, show, dismiss }
+})

--- a/frontend/src/types/scriptError.ts
+++ b/frontend/src/types/scriptError.ts
@@ -1,0 +1,53 @@
+/**
+ * Mirrors internal/dataentry/script_errors.go ScriptErrorEnvelope.
+ *
+ * Returned by every Lua surface (action, document, automation,
+ * MCP lua_run/lua_eval) on failure. Caller-side branching in
+ * api/client.ts: `error === 'script_error'`.
+ *
+ * Loopback-gated fields (source, stack, captured_output) are absent
+ * for non-loopback callers unless the operator opted in via
+ * data-entry.yaml.
+ */
+export interface ScriptError {
+  error: 'script_error'
+  correlation_id?: string
+  script: ScriptIdentity
+  lua: ScriptErrorLua
+  source?: SourceLine[]
+  stack?: StackFrame[]
+  captured_output?: string
+}
+
+export interface ScriptIdentity {
+  surface: 'action' | 'document' | 'automation' | 'lua_run' | 'lua_eval'
+  path: string
+  entity_id?: string
+  args?: Record<string, unknown>
+}
+
+export interface ScriptErrorLua {
+  message: string
+  line?: number
+}
+
+export interface SourceLine {
+  n: number
+  text: string
+  highlight?: boolean
+}
+
+export interface StackFrame {
+  path?: string
+  line?: number
+  func?: string
+}
+
+/** Type guard: does this caught error look like a ScriptError envelope? */
+export function isScriptError(err: unknown): err is ScriptError {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { error?: unknown }).error === 'script_error'
+  )
+}

--- a/frontend/src/views/DocumentView.vue
+++ b/frontend/src/views/DocumentView.vue
@@ -2,12 +2,14 @@
 import { ref, computed, watch, onMounted, onUnmounted, nextTick, useTemplateRef } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useSchemaStore, useUIStore } from '@/stores'
+import { useScriptErrorStore } from '@/stores/scriptError'
 import { renderDocument } from '@/api/documents'
 import { useEvents } from '@/composables/useEvents'
 import { createDocumentClickHandler } from '@/composables/useDocumentClicks'
 import { useBackTarget } from '@/composables/useBackTarget'
 import { renderMermaidDiagrams } from '@/utils/markdown'
 import { buildReturnTo } from '@/utils/returnPath'
+import { isScriptError } from '@/types/scriptError'
 import BackButton from '@/components/common/BackButton.vue'
 import DOMPurify from 'dompurify'
 
@@ -20,6 +22,7 @@ const route = useRoute()
 const router = useRouter()
 const schemaStore = useSchemaStore()
 const uiStore = useUIStore()
+const scriptErrorStore = useScriptErrorStore()
 const { on, off } = useEvents()
 
 // State
@@ -72,8 +75,12 @@ async function loadDocument(refresh = false) {
     docContent.value = result.html
     isCached.value = result.cached
     entityIds.value = result.entity_ids || []
-  } catch {
-    uiStore.error('Failed to render document')
+  } catch (err: unknown) {
+    if (isScriptError(err)) {
+      scriptErrorStore.show(err)
+    } else {
+      uiStore.error('Failed to render document')
+    }
     docContent.value = ''
     entityIds.value = []
   } finally {

--- a/internal/automation/engine.go
+++ b/internal/automation/engine.go
@@ -121,7 +121,7 @@ func (e *Engine) Process(event Event) *Result {
 
 		// Execute actions
 		for _, action := range auto.Do {
-			e.executeAction(action, event, result)
+			e.executeAction(action, event, result, auto.Name)
 		}
 
 		// Evaluate validations
@@ -230,7 +230,7 @@ func (e *Engine) matchesWhenConditions(trigger Trigger, entity *entity.Entity) b
 }
 
 // executeAction performs an action and updates the result.
-func (e *Engine) executeAction(action Action, event Event, result *Result) {
+func (e *Engine) executeAction(action Action, event Event, result *Result, automationName string) {
 	if action.Set != "" {
 		value := e.interpolate(action.Value, event)
 		result.PropertiesSet[action.Set] = value
@@ -286,7 +286,8 @@ func (e *Engine) executeAction(action Action, event Event, result *Result) {
 		// Entity properties are accessed via Lua globals, NOT interpolated into code
 		code := e.interpolateSafeOnly(action.Lua, event)
 		result.LuaToExecute = append(result.LuaToExecute, LuaToExecute{
-			Code: code,
+			Code:           code,
+			AutomationName: automationName,
 		})
 	}
 
@@ -294,7 +295,8 @@ func (e *Engine) executeAction(action Action, event Event, result *Result) {
 		// Path validation is handled by the script package at execution time.
 		// This keeps validation centralized and consistent across all script execution paths.
 		result.LuaToExecute = append(result.LuaToExecute, LuaToExecute{
-			FilePath: action.LuaFile,
+			FilePath:       action.LuaFile,
+			AutomationName: automationName,
 		})
 	}
 }

--- a/internal/automation/types.go
+++ b/internal/automation/types.go
@@ -119,9 +119,15 @@ type EntityToCreate struct {
 
 // LuaToExecute specifies Lua code to be executed by the workspace layer.
 // Either Code or FilePath is set, not both.
+//
+// AutomationName carries the name of the automation that produced this
+// action so that error envelopes can identify *which* inline `lua: |`
+// block failed (`automation:<name>`) when there is no FilePath to use
+// as the identity.
 type LuaToExecute struct {
-	Code     string // Inline Lua code (safe values already interpolated)
-	FilePath string // Path to script file in scripts/ directory
+	Code           string // Inline Lua code (safe values already interpolated)
+	FilePath       string // Path to script file in scripts/ directory
+	AutomationName string // Name of the originating automation
 }
 
 // Result represents the outcome of running automations.

--- a/internal/dataentry/actions.go
+++ b/internal/dataentry/actions.go
@@ -107,7 +107,7 @@ func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 		slog.Warn("action failed", "action", id, "correlation", correlationID, "error", err)
 		var se *lua.ScriptError
 		if errors.As(err, &se) {
-			writeV1ScriptError(w, se, a.allowFullScriptDetail(r))
+			writeV1ScriptError(w, se, a.allowFullScriptDetail(r), correlationID)
 			return
 		}
 		// Non-Lua failure (script-not-found, contract failure from

--- a/internal/dataentry/actions.go
+++ b/internal/dataentry/actions.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"regexp"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
 )
 
 // actionIDRegex defines the allowed format for action IDs at request time.
@@ -103,6 +105,17 @@ func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 		ent, action.Params, actionTimeout)
 	if err != nil {
 		slog.Warn("action failed", "action", id, "correlation", correlationID, "error", err)
+		var se *lua.ScriptError
+		if errors.As(err, &se) {
+			// Tag the envelope with the correlation id so logs can be
+			// matched up with the response the user actually saw.
+			se.CorrelationID = correlationID
+			writeV1ScriptError(w, r, se, a.scriptErrorPolicy)
+			return
+		}
+		// Non-Lua failure (script-not-found, contract failure from
+		// parseActionResponse, redirect validation, etc.) — keep the
+		// existing minimal-detail shape.
 		writeV1JSON(w, http.StatusInternalServerError, V1ActionResponse{
 			Error:         "action_failed",
 			Message:       "Action failed",

--- a/internal/dataentry/actions.go
+++ b/internal/dataentry/actions.go
@@ -102,15 +102,12 @@ func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 	// across action invocations. Constructing a fresh engine per
 	// request would reset the cache each time and defeat memoization.
 	resp, err := a.scriptEngine.ExecuteAction(action.Script, a.luaWriteDeps(),
-		ent, action.Params, actionTimeout)
+		ent, action.Params, actionTimeout, correlationID)
 	if err != nil {
 		slog.Warn("action failed", "action", id, "correlation", correlationID, "error", err)
 		var se *lua.ScriptError
 		if errors.As(err, &se) {
-			// Tag the envelope with the correlation id so logs can be
-			// matched up with the response the user actually saw.
-			se.CorrelationID = correlationID
-			writeV1ScriptError(w, r, se, a.scriptErrorPolicy)
+			writeV1ScriptError(w, se, a.allowFullScriptDetail(r))
 			return
 		}
 		// Non-Lua failure (script-not-found, contract failure from

--- a/internal/dataentry/actions_test.go
+++ b/internal/dataentry/actions_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -140,32 +141,91 @@ func TestHandleV1Action_MethodNotAllowed(t *testing.T) {
 	}
 }
 
-func TestHandleV1Action_ScriptError(t *testing.T) {
+func TestHandleV1Action_ScriptError_DegradedForNonLoopback(t *testing.T) {
 	app := newActionTestApp(t, map[string]string{
-		"boom.lua": `error("kaboom")`,
+		"boom.lua": `print("before")
+error("kaboom")`,
+	})
+	app.Cfg().Actions = map[string]dataentryconfig.Action{
+		"boom": {Script: "boom.lua"},
+	}
+
+	// Default httptest.NewRequest sets RemoteAddr to 192.0.2.1 (TEST-NET-1,
+	// non-loopback), so the response should omit source/captured/stack.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/_action/boom", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	callAction(app, req, rec)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var env ScriptErrorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if env.Error != "script_error" {
+		t.Errorf("Error=%q, want script_error", env.Error)
+	}
+	if env.CorrelationID == "" {
+		t.Error("missing correlation_id")
+	}
+	if env.Script.Surface != "action" {
+		t.Errorf("Script.Surface=%q, want action", env.Script.Surface)
+	}
+	if env.Script.Path != "actions/boom.lua" {
+		t.Errorf("Script.Path=%q, want actions/boom.lua", env.Script.Path)
+	}
+	if env.Lua.Line != 2 {
+		t.Errorf("Lua.Line=%d, want 2", env.Lua.Line)
+	}
+	if !strings.Contains(env.Lua.Message, "kaboom") {
+		t.Errorf("Lua.Message=%q, want contains kaboom", env.Lua.Message)
+	}
+	// Degraded shape: gated fields must be absent.
+	if len(env.Source) != 0 {
+		t.Errorf("non-loopback caller got source slice: %+v", env.Source)
+	}
+	if len(env.Stack) != 0 {
+		t.Errorf("non-loopback caller got stack: %+v", env.Stack)
+	}
+	if env.CapturedOutput != "" {
+		t.Errorf("non-loopback caller got captured output: %q", env.CapturedOutput)
+	}
+}
+
+func TestHandleV1Action_ScriptError_FullForLoopback(t *testing.T) {
+	app := newActionTestApp(t, map[string]string{
+		"boom.lua": `print("before")
+error("kaboom")`,
 	})
 	app.Cfg().Actions = map[string]dataentryconfig.Action{
 		"boom": {Script: "boom.lua"},
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/_action/boom", http.NoBody)
+	req.RemoteAddr = "127.0.0.1:54321"
 	rec := httptest.NewRecorder()
 
 	callAction(app, req, rec)
 
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500, got %d", rec.Code)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var resp V1ActionResponse
-	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+	var env ScriptErrorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
 		t.Fatalf("decode failed: %v", err)
 	}
-	if resp.Error != "action_failed" {
-		t.Errorf("expected error=action_failed, got %q", resp.Error)
+	if len(env.Source) == 0 {
+		t.Error("loopback caller missing source slice")
 	}
-	if resp.CorrelationID == "" {
-		t.Error("expected correlation_id, got empty")
+	if len(env.Stack) == 0 {
+		t.Error("loopback caller missing stack")
+	}
+	if !strings.Contains(env.CapturedOutput, "before") {
+		t.Errorf("CapturedOutput=%q, want contains 'before'", env.CapturedOutput)
 	}
 }
 

--- a/internal/dataentry/actions_test.go
+++ b/internal/dataentry/actions_test.go
@@ -40,6 +40,13 @@ func newActionTestApp(t *testing.T, scripts map[string]string) *App {
 	app := newTestAppV1(t)
 	bindRepo(app, tmpDir)
 
+	// Wire security so allowFullScriptDetail works against r.RemoteAddr.
+	// Tests that want loopback callers set req.RemoteAddr = "127.0.0.1:..."
+	// explicitly; the default httptest "192.0.2.1:1234" is non-loopback.
+	if err := app.SetSecurityConfig(SecurityConfig{BindAddress: "127.0.0.1:8080"}); err != nil {
+		t.Fatalf("SetSecurityConfig: %v", err)
+	}
+
 	return app
 }
 

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -2065,7 +2065,7 @@ func (a *App) handleV1Documents(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var se *lua.ScriptError
 		if errors.As(err, &se) {
-			writeV1ScriptError(w, r, se, a.scriptErrorPolicy)
+			writeV1ScriptError(w, se, a.allowFullScriptDetail(r))
 			return
 		}
 		writeV1Error(w, r, http.StatusInternalServerError, "render_failed", "Document rendering failed", err.Error())

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -2065,7 +2065,11 @@ func (a *App) handleV1Documents(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var se *lua.ScriptError
 		if errors.As(err, &se) {
-			writeV1ScriptError(w, se, a.allowFullScriptDetail(r))
+			correlationID := newCorrelationID()
+			slog.Warn("document render failed",
+				"document", docName, "entity", entityID,
+				"correlation", correlationID, "error", err)
+			writeV1ScriptError(w, se, a.allowFullScriptDetail(r), correlationID)
 			return
 		}
 		writeV1Error(w, r, http.StatusInternalServerError, "render_failed", "Document rendering failed", err.Error())

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -18,6 +19,7 @@ import (
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/filter"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -2061,6 +2063,11 @@ func (a *App) handleV1Documents(w http.ResponseWriter, r *http.Request) {
 	// Render the document
 	result, err := a.documents.Render(entityID, renderCfg)
 	if err != nil {
+		var se *lua.ScriptError
+		if errors.As(err, &se) {
+			writeV1ScriptError(w, r, se, a.scriptErrorPolicy)
+			return
+		}
 		writeV1Error(w, r, http.StatusInternalServerError, "render_failed", "Document rendering failed", err.Error())
 		return
 	}

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -116,11 +116,6 @@ type App struct {
 	// whole point of having a cache in a long-lived server.
 	scriptEngine *script.Engine
 
-	// scriptErrorPolicy controls how much detail script-failure responses
-	// expose. Default zero-value: loopback callers get full detail, all
-	// others get a degraded envelope (message + line + correlation id only).
-	scriptErrorPolicy ScriptErrorPolicy
-
 	// state holds the current reloadable snapshot. Readers: a.State().
 	// Writers: onReload rebuilds and publishes a new state after file
 	// changes. Initial state is published in NewApp.

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -116,6 +116,11 @@ type App struct {
 	// whole point of having a cache in a long-lived server.
 	scriptEngine *script.Engine
 
+	// scriptErrorPolicy controls how much detail script-failure responses
+	// expose. Default zero-value: loopback callers get full detail, all
+	// others get a degraded envelope (message + line + correlation id only).
+	scriptErrorPolicy ScriptErrorPolicy
+
 	// state holds the current reloadable snapshot. Readers: a.State().
 	// Writers: onReload rebuilds and publishes a new state after file
 	// changes. Initial state is published in NewApp.

--- a/internal/dataentry/document.go
+++ b/internal/dataentry/document.go
@@ -243,6 +243,13 @@ func (s *documentService) renderScript(entryID string, cfg documentRenderConfig)
 	var buf bytes.Buffer
 	if err := s.scriptEngine.ExecuteDocument(cfg.Script, s.luaDeps(), &buf,
 		cfg.ConfigID, entryID, cfg.Timeout); err != nil {
+		// On a Lua failure the engine returns *lua.ScriptError; attach
+		// the print() output we captured before it threw, then bubble
+		// up unchanged so the HTTP layer can branch via errors.As.
+		var se *lua.ScriptError
+		if errors.As(err, &se) {
+			return "", se.WithCapturedOutput(buf.Bytes())
+		}
 		return "", fmt.Errorf("script render: %w", err)
 	}
 	return buf.String(), nil

--- a/internal/dataentry/document.go
+++ b/internal/dataentry/document.go
@@ -248,7 +248,7 @@ func (s *documentService) renderScript(entryID string, cfg documentRenderConfig)
 		// up unchanged so the HTTP layer can branch via errors.As.
 		var se *lua.ScriptError
 		if errors.As(err, &se) {
-			return "", se.WithCapturedOutput(buf.Bytes())
+			return "", se.AttachCapturedOutput(buf.Bytes())
 		}
 		return "", fmt.Errorf("script render: %w", err)
 	}

--- a/internal/dataentry/middleware_security.go
+++ b/internal/dataentry/middleware_security.go
@@ -122,6 +122,22 @@ func (s *security) requireLocalHost(next http.Handler) http.Handler {
 	})
 }
 
+// AllowFullScriptDetail reports whether the caller of r should receive the
+// rich script-error envelope (source slice, full stack, captured print()
+// output). Returns true only for loopback peers. Behind a reverse proxy
+// this fails closed (the proxy IP is non-loopback) — the right default
+// since the data-entry server has no auth layer; rich envelopes would
+// otherwise leak script source and captured print() output across the
+// LAN. Intentionally does not honor X-Forwarded-For; any future
+// proxy-aware middleware must keep this gate honest.
+func (s *security) AllowFullScriptDetail(r *http.Request) bool {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	return isLoopback(host)
+}
+
 // requireSameOrigin rejects sensitive requests whose Origin (or Referer fallback)
 // is not in the allowlist. Applies to every HTTP method on the configured
 // sensitive paths, because some endpoints (notably /api/command/) accept GET

--- a/internal/dataentry/script_errors.go
+++ b/internal/dataentry/script_errors.go
@@ -65,10 +65,20 @@ func (a *App) allowFullScriptDetail(r *http.Request) bool {
 // CapturedOutput) cross the wire. The caller obtains it from
 // security.AllowFullScriptDetail so the loopback decision lives next
 // to the rest of the host-trust policy.
-func writeV1ScriptError(w http.ResponseWriter, se *lua.ScriptError, fullDetail bool) {
+//
+// correlationID is the per-request id used in the matching slog line.
+// It overrides whatever the engine stamped on the *ScriptError —
+// important because singleflight may hand the same *ScriptError to
+// multiple requests, and each one needs its own id in the response.
+// Pass "" to fall back to se.CorrelationID.
+func writeV1ScriptError(w http.ResponseWriter, se *lua.ScriptError, fullDetail bool, correlationID string) {
+	corrID := correlationID
+	if corrID == "" {
+		corrID = se.CorrelationID
+	}
 	env := ScriptErrorEnvelope{
 		Error:         "script_error",
-		CorrelationID: se.CorrelationID,
+		CorrelationID: corrID,
 		Script: ScriptIdentity{
 			Surface:  string(se.Surface),
 			Path:     se.Path,

--- a/internal/dataentry/script_errors.go
+++ b/internal/dataentry/script_errors.go
@@ -1,0 +1,104 @@
+package dataentry
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+
+	"github.com/Sourcehaven-BV/rela/internal/lua"
+)
+
+// ScriptErrorEnvelope is the on-the-wire representation of a Lua script
+// failure. The HTTP layer always returns this with status 422 so the
+// frontend can branch on `error == "script_error"`. Every field except
+// `correlation_id`, `script.path`, and `lua.message` is loopback-gated:
+// non-loopback callers receive a degraded shape unless the operator has
+// explicitly opted in to full detail (see ScriptErrorPolicy).
+type ScriptErrorEnvelope struct {
+	Error          string           `json:"error"`
+	CorrelationID  string           `json:"correlation_id,omitempty"`
+	Script         ScriptIdentity   `json:"script"`
+	Lua            ScriptErrorLua   `json:"lua"`
+	Source         []lua.SourceLine `json:"source,omitempty"`
+	Stack          []lua.StackFrame `json:"stack,omitempty"`
+	CapturedOutput string           `json:"captured_output,omitempty"`
+}
+
+// ScriptIdentity carries who-was-running info: the surface (action,
+// document, automation, lua_run, lua_eval), the script path, and any
+// triggering entity / args context the surface decided to capture.
+type ScriptIdentity struct {
+	Surface  string         `json:"surface"`
+	Path     string         `json:"path"`
+	EntityID string         `json:"entity_id,omitempty"`
+	Args     map[string]any `json:"args,omitempty"`
+}
+
+// ScriptErrorLua is the message + line that always survives gating, so
+// even a non-loopback caller knows roughly what broke without leaking
+// the full source slice.
+type ScriptErrorLua struct {
+	Message string `json:"message"`
+	Line    int    `json:"line,omitempty"`
+}
+
+// ScriptErrorPolicy decides how much detail crosses the wire. The
+// constructor honors both the request peer (loopback callers always
+// get full detail) and an operator opt-in for non-loopback peers.
+//
+// Off-by-default for non-loopback because the data-entry server has no
+// auth layer; rich envelopes would otherwise leak script source and
+// captured print() output across the LAN.
+type ScriptErrorPolicy struct {
+	// AlwaysFullDetail bypasses the loopback check. Set to true via
+	// data-entry.yaml when the operator knows the deployment is safe.
+	AlwaysFullDetail bool
+}
+
+// allowFullDetail reports whether the caller of r should receive the
+// rich envelope (source slice, full stack, captured output).
+//
+// The decision is intentionally based on r.RemoteAddr only — no
+// X-Forwarded-For honoring. Behind a reverse proxy this fails closed
+// (proxy IP is non-loopback → degraded shape), which is the right
+// default since the data-entry server has no auth layer. Anyone adding
+// proxy-aware middleware later must keep this gate honest.
+func (p ScriptErrorPolicy) allowFullDetail(r *http.Request) bool {
+	if p.AlwaysFullDetail {
+		return true
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	return isLoopback(host)
+}
+
+// writeV1ScriptError renders a *lua.ScriptError as the structured
+// envelope. Always 422: the request was understood, the user-supplied
+// script was the problem.
+func writeV1ScriptError(w http.ResponseWriter, r *http.Request, se *lua.ScriptError, policy ScriptErrorPolicy) {
+	env := ScriptErrorEnvelope{
+		Error:         "script_error",
+		CorrelationID: se.CorrelationID,
+		Script: ScriptIdentity{
+			Surface:  se.Surface,
+			Path:     se.Path,
+			EntityID: se.EntityID,
+			Args:     se.Args,
+		},
+		Lua: ScriptErrorLua{
+			Message: se.LuaMessage,
+			Line:    se.LuaLine,
+		},
+	}
+	if policy.allowFullDetail(r) {
+		env.Source = se.Source
+		env.Stack = se.Stack
+		env.CapturedOutput = se.CapturedOutput
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	_ = json.NewEncoder(w).Encode(env)
+}

--- a/internal/dataentry/script_errors.go
+++ b/internal/dataentry/script_errors.go
@@ -2,7 +2,6 @@ package dataentry
 
 import (
 	"encoding/json"
-	"net"
 	"net/http"
 
 	"github.com/Sourcehaven-BV/rela/internal/lua"
@@ -12,8 +11,13 @@ import (
 // failure. The HTTP layer always returns this with status 422 so the
 // frontend can branch on `error == "script_error"`. Every field except
 // `correlation_id`, `script.path`, and `lua.message` is loopback-gated:
-// non-loopback callers receive a degraded shape unless the operator has
-// explicitly opted in to full detail (see ScriptErrorPolicy).
+// non-loopback callers receive a degraded shape (see
+// security.AllowFullScriptDetail).
+//
+// JSON tags on lua.ScriptError are advisory: each consumer owns its
+// wire shape. Data-entry uses this envelope; MCP marshals lua.ScriptError
+// directly. Adding a field to lua.ScriptError requires deciding whether
+// to mirror it here or let it surface only over MCP.
 type ScriptErrorEnvelope struct {
 	Error          string           `json:"error"`
 	CorrelationID  string           `json:"correlation_id,omitempty"`
@@ -42,47 +46,31 @@ type ScriptErrorLua struct {
 	Line    int    `json:"line,omitempty"`
 }
 
-// ScriptErrorPolicy decides how much detail crosses the wire. The
-// constructor honors both the request peer (loopback callers always
-// get full detail) and an operator opt-in for non-loopback peers.
-//
-// Off-by-default for non-loopback because the data-entry server has no
-// auth layer; rich envelopes would otherwise leak script source and
-// captured print() output across the LAN.
-type ScriptErrorPolicy struct {
-	// AlwaysFullDetail bypasses the loopback check. Set to true via
-	// data-entry.yaml when the operator knows the deployment is safe.
-	AlwaysFullDetail bool
-}
-
-// allowFullDetail reports whether the caller of r should receive the
-// rich envelope (source slice, full stack, captured output).
-//
-// The decision is intentionally based on r.RemoteAddr only — no
-// X-Forwarded-For honoring. Behind a reverse proxy this fails closed
-// (proxy IP is non-loopback → degraded shape), which is the right
-// default since the data-entry server has no auth layer. Anyone adding
-// proxy-aware middleware later must keep this gate honest.
-func (p ScriptErrorPolicy) allowFullDetail(r *http.Request) bool {
-	if p.AlwaysFullDetail {
-		return true
+// allowFullScriptDetail asks the App's security layer whether r is
+// trusted enough for the rich envelope. Defaults to false when no
+// security has been wired (unit tests that bypass NewRouter), which
+// keeps tests honest about exercising the gate.
+func (a *App) allowFullScriptDetail(r *http.Request) bool {
+	if a.security == nil {
+		return false
 	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host = r.RemoteAddr
-	}
-	return isLoopback(host)
+	return a.security.AllowFullScriptDetail(r)
 }
 
 // writeV1ScriptError renders a *lua.ScriptError as the structured
 // envelope. Always 422: the request was understood, the user-supplied
 // script was the problem.
-func writeV1ScriptError(w http.ResponseWriter, r *http.Request, se *lua.ScriptError, policy ScriptErrorPolicy) {
+//
+// fullDetail decides whether the gated fields (Source, Stack,
+// CapturedOutput) cross the wire. The caller obtains it from
+// security.AllowFullScriptDetail so the loopback decision lives next
+// to the rest of the host-trust policy.
+func writeV1ScriptError(w http.ResponseWriter, se *lua.ScriptError, fullDetail bool) {
 	env := ScriptErrorEnvelope{
 		Error:         "script_error",
 		CorrelationID: se.CorrelationID,
 		Script: ScriptIdentity{
-			Surface:  se.Surface,
+			Surface:  string(se.Surface),
 			Path:     se.Path,
 			EntityID: se.EntityID,
 			Args:     se.Args,
@@ -92,7 +80,7 @@ func writeV1ScriptError(w http.ResponseWriter, r *http.Request, se *lua.ScriptEr
 			Line:    se.LuaLine,
 		},
 	}
-	if policy.allowFullDetail(r) {
+	if fullDetail {
 		env.Source = se.Source
 		env.Stack = se.Stack
 		env.CapturedOutput = se.CapturedOutput

--- a/internal/dataentry/script_errors_test.go
+++ b/internal/dataentry/script_errors_test.go
@@ -1,0 +1,44 @@
+package dataentry
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/lua"
+)
+
+// writeV1ScriptError must use the caller-supplied correlation id. This
+// matters because singleflight may hand the same *lua.ScriptError to
+// multiple in-flight requests; if we read se.CorrelationID directly,
+// the first request's id would surface in the second request's response.
+func TestWriteV1ScriptError_CorrelationIDOverride(t *testing.T) {
+	se := &lua.ScriptError{
+		Surface:       lua.SurfaceDocument,
+		Path:          "scripts/x.lua",
+		LuaMessage:    "boom",
+		CorrelationID: "engine-id",
+	}
+
+	rec := httptest.NewRecorder()
+
+	writeV1ScriptError(rec, se, false, "handler-id")
+
+	var env ScriptErrorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if env.CorrelationID != "handler-id" {
+		t.Errorf("CorrelationID=%q, want handler-id (caller wins)", env.CorrelationID)
+	}
+
+	// Second request: empty handler id falls back to engine id.
+	rec = httptest.NewRecorder()
+	writeV1ScriptError(rec, se, false, "")
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if env.CorrelationID != "engine-id" {
+		t.Errorf("CorrelationID=%q, want engine-id (fallback)", env.CorrelationID)
+	}
+}

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -80,6 +80,11 @@ type Runtime struct {
 	aiProvider    ai.Provider       // nil means AI is not configured
 	cache         cacheStore        // nil means rela.cache.* is not registered
 	scriptPath    string            // set by RunFile; empty for RunString/inline
+
+	// errorFrames holds typed stack frames captured by the PCall message
+	// handler on the most recent failed run. Read via ErrorFrames() after
+	// PCall returns an error. Reset before every PCall.
+	errorFrames []StackFrame
 }
 
 // cacheStore is the minimal contract the Lua cache bindings need from
@@ -313,6 +318,62 @@ func openSafeLibraries(ls *lua.LState) {
 // RunFile executes a Lua script file with arguments.
 // Shebang lines (starting with #!) are automatically stripped.
 //
+// ErrorFrames returns the typed Lua stack frames captured by the message
+// handler on the most recent failed Run call. Empty for a successful run,
+// or for failures (compile errors, Go-side errors) where no PCall ran.
+//
+// Frames are ordered innermost-first: frame[0] is where the error was
+// raised; frame[len-1] is the main chunk.
+func (r *Runtime) ErrorFrames() []StackFrame {
+	return r.errorFrames
+}
+
+// pcallWithCapture runs r.L.PCall(0, MultRet, ...) with a message handler
+// that walks the live Lua stack via GetStack/GetInfo and stores typed
+// frames on the runtime. This sidesteps regex-parsing the Object/StackTrace
+// strings: we get real line numbers, function names, and source paths
+// straight from gopher-lua's debug API.
+//
+// See https://github.com/yuin/gopher-lua/issues/46 for the rationale.
+func (r *Runtime) pcallWithCapture() error {
+	r.errorFrames = nil
+	handler := r.L.NewFunction(func(L *lua.LState) int {
+		r.errorFrames = collectStackFrames(L)
+		// Pass the original error object (arg #1) through unchanged so
+		// gopher-lua wraps it into ApiError as usual.
+		L.Push(L.Get(1))
+		return 1
+	})
+	return r.L.PCall(0, lua.MultRet, handler)
+}
+
+// collectStackFrames walks the live Lua stack and returns user-visible
+// frames (skipping built-in [G] frames with no source). Capped at
+// maxStackFrames; safe to call from a message handler.
+func collectStackFrames(ls *lua.LState) []StackFrame {
+	var frames []StackFrame
+	for level := range maxStackFrames {
+		dbg, ok := ls.GetStack(level)
+		if !ok {
+			break
+		}
+		if _, err := ls.GetInfo("Slunf", dbg, lua.LNil); err != nil {
+			break
+		}
+		// Skip built-in/C frames — they have no source and a CurrentLine
+		// of -1. The user only cares about their own Lua code.
+		if dbg.Source == "" || dbg.CurrentLine <= 0 {
+			continue
+		}
+		frames = append(frames, StackFrame{
+			Path: dbg.Source,
+			Line: dbg.CurrentLine,
+			Func: dbg.Name,
+		})
+	}
+	return frames
+}
+
 // RunFile sets the runtime's scriptPath (via filepath.Clean(path)) so
 // the rela.cache.* bindings can namespace entries by script. Callers
 // using RunString/inline code do not get this identity and any
@@ -361,14 +422,20 @@ func (r *Runtime) RunFileContent(path string, content []byte, args []string) err
 	}
 
 	r.L.Push(fn)
-	return r.L.PCall(0, lua.MultRet, nil)
+	return r.pcallWithCapture()
 }
 
 // RunString executes Lua code from a string.
 // Shebang lines (starting with #!) are automatically stripped.
 func (r *Runtime) RunString(code string) error {
 	r.applyTimeout()
-	return r.L.DoString(stripShebang(code))
+	cleaned := stripShebang(code)
+	fn, err := r.L.LoadString(cleaned)
+	if err != nil {
+		return err
+	}
+	r.L.Push(fn)
+	return r.pcallWithCapture()
 }
 
 // ErrNoReturnValue is returned by RunActionString when the script did not
@@ -390,7 +457,7 @@ func (r *Runtime) RunActionString(code, name string) (interface{}, error) {
 	// Record stack depth before so we can detect if the script returned anything
 	topBefore := r.L.GetTop()
 	r.L.Push(fn)
-	if pcallErr := r.L.PCall(0, lua.MultRet, nil); pcallErr != nil {
+	if pcallErr := r.pcallWithCapture(); pcallErr != nil {
 		return nil, pcallErr
 	}
 	topAfter := r.L.GetTop()

--- a/internal/lua/scripterror.go
+++ b/internal/lua/scripterror.go
@@ -1,0 +1,435 @@
+package lua
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	glua "github.com/yuin/gopher-lua"
+)
+
+// ScriptError carries structured context about a failed Lua script run so
+// callers can render rich error UIs (source slice, captured print() output,
+// stack frames) instead of opaque "action failed" messages.
+//
+// Built by BuildScriptError from the underlying gopher-lua error and the
+// caller's surface-specific context. Every Lua execution surface (data-entry
+// action, document render, automation, MCP lua_run/lua_eval) wraps its
+// failures in *ScriptError so HTTP and MCP handlers can branch on the type.
+type ScriptError struct {
+	Surface        string         `json:"surface"`
+	Path           string         `json:"path"`
+	EntityID       string         `json:"entity_id,omitempty"`
+	Args           map[string]any `json:"args,omitempty"`
+	LuaMessage     string         `json:"lua_message"`
+	LuaLine        int            `json:"lua_line,omitempty"`
+	Stack          []StackFrame   `json:"stack,omitempty"`
+	Source         []SourceLine   `json:"source,omitempty"`
+	CapturedOutput string         `json:"captured_output,omitempty"`
+	CorrelationID  string         `json:"correlation_id,omitempty"`
+}
+
+// StackFrame is one entry in a Lua stack trace.
+type StackFrame struct {
+	Path string `json:"path,omitempty"`
+	Line int    `json:"line,omitempty"`
+	Func string `json:"func,omitempty"`
+}
+
+// SourceLine is one line of script source returned alongside the failing
+// line so the UI can show context. Highlight is true for the failing line.
+type SourceLine struct {
+	N         int    `json:"n"`
+	Text      string `json:"text"`
+	Highlight bool   `json:"highlight,omitempty"`
+}
+
+// Surface constants used in ScriptError.Surface.
+const (
+	SurfaceAction     = "action"
+	SurfaceDocument   = "document"
+	SurfaceAutomation = "automation"
+	SurfaceLuaRun     = "lua_run"
+	SurfaceLuaEval    = "lua_eval"
+)
+
+// BuildInput aggregates the inputs to BuildScriptError. Callers fill in only
+// the fields they have; unset fields are omitted from the resulting envelope.
+type BuildInput struct {
+	Surface        string
+	Path           string
+	EntityID       string
+	Args           map[string]any
+	CapturedOutput []byte
+	Err            error
+	CorrelationID  string
+
+	// Frames is the typed stack capture from Runtime.ErrorFrames(). When
+	// non-empty, it's the source of truth for LuaLine and Stack; otherwise
+	// we fall back to extracting what we can from Err's string form.
+	Frames []StackFrame
+
+	// SourceFS is rooted such that Path can be opened directly.
+	// When nil, no source slice is populated.
+	SourceFS fs.FS
+	// SourceContext is the number of lines of context to include on each
+	// side of the failing line. Defaults to defaultSourceContext.
+	SourceContext int
+}
+
+// Limits applied during envelope construction. Picked to be generous for
+// real scripts while preventing degenerate inputs (huge files, infinite
+// print loops) from blowing up response size.
+const (
+	defaultSourceContext   = 3
+	maxSourceFileSize      = 200 * 1024
+	maxStackFrames         = 32
+	maxFrameStringLen      = 1024
+	maxStringValueLen      = 4 * 1024
+	maxCapturedOutputBytes = 16 * 1024
+	redactedPlaceholder    = "<redacted>"
+	truncatedPlaceholder   = "...[truncated]"
+)
+
+// BuildScriptError constructs a *ScriptError from a Lua failure.
+//
+// Preferred path: Frames from Runtime.ErrorFrames() carry typed line numbers
+// and source paths captured by the PCall message handler. When Frames is
+// empty (e.g., compile errors that fail before PCall, or non-Lua errors)
+// we fall back to typed extraction via *glua.ApiError, then to the bare
+// error message.
+//
+// Args and CapturedOutput are redacted before storage; SourceFS is read
+// only for paths that resolve cleanly inside the FS root.
+func BuildScriptError(in BuildInput) *ScriptError {
+	se := &ScriptError{
+		Surface:       in.Surface,
+		Path:          in.Path,
+		EntityID:      in.EntityID,
+		CorrelationID: in.CorrelationID,
+		Args:          redactArgs(in.Args),
+	}
+
+	if len(in.CapturedOutput) > 0 {
+		se.CapturedOutput = redactCapturedOutput(in.CapturedOutput)
+	}
+
+	if len(in.Frames) > 0 {
+		se.Stack = trimFrames(in.Frames)
+	}
+	se.fillFromError(in.Err)
+
+	if se.LuaLine > 0 && in.SourceFS != nil {
+		// When `require`d helpers are involved, the innermost frame's
+		// path is what the user actually wants to see — fall back to the
+		// surface-supplied Path otherwise.
+		sourcePath := se.Path
+		if frame := se.deepestUserFrame(); frame != nil && frame.Path != "" {
+			sourcePath = frame.Path
+		}
+		ctx := in.SourceContext
+		if ctx <= 0 {
+			ctx = defaultSourceContext
+		}
+		se.Source = readSourceSlice(in.SourceFS, sourcePath, se.LuaLine, ctx)
+	}
+
+	return se
+}
+
+// WithCapturedOutput attaches captured stdout to an existing ScriptError
+// and returns the receiver. Used by callers that own the print() buffer
+// outside the engine that produced the error (notably the data-entry
+// document renderer, which extracts the *ScriptError via errors.As and
+// then attaches the bytes it captured before the script failed).
+func (e *ScriptError) WithCapturedOutput(b []byte) *ScriptError {
+	if e == nil || len(b) == 0 {
+		return e
+	}
+	e.CapturedOutput = redactCapturedOutput(b)
+	return e
+}
+
+// trimFrames clamps a frame slice at maxStackFrames and trims overly long
+// names so a runaway script can't blow up response size.
+func trimFrames(in []StackFrame) []StackFrame {
+	out := in
+	if len(out) > maxStackFrames {
+		out = out[:maxStackFrames]
+	}
+	for i := range out {
+		if len(out[i].Func) > maxFrameStringLen {
+			out[i].Func = out[i].Func[:maxFrameStringLen]
+		}
+	}
+	return out
+}
+
+// Error implements the error interface so *ScriptError can flow through
+// existing Go error plumbing.
+func (e *ScriptError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Path != "" && e.LuaLine > 0 {
+		return fmt.Sprintf("%s:%d: %s", e.Path, e.LuaLine, e.LuaMessage)
+	}
+	if e.Path != "" {
+		return fmt.Sprintf("%s: %s", e.Path, e.LuaMessage)
+	}
+	return e.LuaMessage
+}
+
+func (e *ScriptError) fillFromError(err error) {
+	if err == nil {
+		return
+	}
+
+	var ae *glua.ApiError
+	if !errors.As(err, &ae) {
+		// Not a typed Lua error — preserve the message, populate line
+		// from any captured frames, and bail.
+		e.LuaMessage = err.Error()
+		if frame := e.deepestUserFrame(); frame != nil {
+			e.LuaLine = frame.Line
+		}
+		return
+	}
+
+	switch ae.Type {
+	case glua.ApiErrorSyntax, glua.ApiErrorFile:
+		// Compile-time failure: PCall never ran, so no captured frames.
+		// The Object string carries the canonical
+		// "<chunkname> line:N(column:N) near 'tok': parse error" form.
+		msg := strings.TrimSpace(ae.Object.String())
+		e.LuaMessage = msg
+		e.LuaLine = parseCompileErrorLine(msg)
+	default:
+		// Runtime failure. The message handler captured typed frames;
+		// the Object string is the raw error message (may be prefixed
+		// with "<chunk>:<line>: " for string-typed errors, or just
+		// "table: 0x..." for non-string raises).
+		e.LuaMessage = stripChunkLinePrefix(ae.Object.String())
+		if frame := e.deepestUserFrame(); frame != nil {
+			e.LuaLine = frame.Line
+		}
+	}
+}
+
+// deepestUserFrame returns the first frame in the trace that has a real
+// path and line — the place the user actually wants to look. nil if none.
+func (e *ScriptError) deepestUserFrame() *StackFrame {
+	for i := range e.Stack {
+		f := &e.Stack[i]
+		if f.Path != "" && f.Line > 0 {
+			return f
+		}
+	}
+	return nil
+}
+
+// chunkLinePrefixRe matches the leading "<chunkname>:<line>: " that
+// gopher-lua prepends to runtime error messages where the raised value
+// is a string. We strip it because the structured ScriptError already
+// carries Path and LuaLine separately — leaving the prefix in
+// LuaMessage just clutters the UI.
+var chunkLinePrefixRe = regexp.MustCompile(`^.+?:\d+:\s*`)
+
+func stripChunkLinePrefix(s string) string {
+	return chunkLinePrefixRe.ReplaceAllString(s, "")
+}
+
+// compileErrorLineRe matches gopher-lua's compile-error format:
+// "<chunkname> line:N(column:N) near 'tok': parse error".
+var compileErrorLineRe = regexp.MustCompile(`line:(\d+)\(column:\d+\)`)
+
+func parseCompileErrorLine(s string) int {
+	m := compileErrorLineRe.FindStringSubmatch(s)
+	if m == nil {
+		return 0
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// readSourceSlice returns a ±context-line slice around the failing line
+// from the script source. Returns nil on any access error (file too big,
+// outside FS root, missing). The FS is responsible for traversal safety —
+// callers should use a rooted filesystem (e.g., os.DirFS(scriptsRoot)).
+func readSourceSlice(srcFS fs.FS, path string, failingLine, context int) []SourceLine {
+	if path == "" || failingLine <= 0 || srcFS == nil {
+		return nil
+	}
+	clean := filepath.ToSlash(filepath.Clean(path))
+	// Belt-and-braces over os.DirFS, which since Go 1.20 already rejects
+	// reads escaping its root. The check stays so callers passing an FS
+	// with weaker guarantees (e.g. a hand-rolled fs.FS, MapFS in tests)
+	// can't be tricked into reading outside their intended scope.
+	if clean == "" || strings.HasPrefix(clean, "../") || clean == ".." || filepath.IsAbs(clean) {
+		return nil
+	}
+
+	info, err := fs.Stat(srcFS, clean)
+	if err != nil || info.IsDir() || info.Size() > maxSourceFileSize {
+		return nil
+	}
+	data, err := fs.ReadFile(srcFS, clean)
+	if err != nil {
+		return nil
+	}
+
+	lines := strings.Split(string(data), "\n")
+	// Trim a trailing empty line caused by a final newline so line numbers
+	// align with editor expectations.
+	if n := len(lines); n > 0 && lines[n-1] == "" {
+		lines = lines[:n-1]
+	}
+	if failingLine > len(lines) {
+		return nil
+	}
+
+	from := failingLine - context
+	if from < 1 {
+		from = 1
+	}
+	to := failingLine + context
+	if to > len(lines) {
+		to = len(lines)
+	}
+
+	out := make([]SourceLine, 0, to-from+1)
+	for n := from; n <= to; n++ {
+		out = append(out, SourceLine{
+			N:         n,
+			Text:      lines[n-1],
+			Highlight: n == failingLine,
+		})
+	}
+	return out
+}
+
+// Redaction.
+//
+// Args and captured output may contain user secrets (the script can stuff
+// anything it likes into either). We apply two layers of defense before
+// these fields cross any wire:
+//
+//  1. Key-name denylist on map entries (case-insensitive, full-key match).
+//  2. Value-shape detection on string values (JWT-shaped, long hex, long
+//     base64-ish) — catches secrets passed in under non-obvious keys.
+//
+// Plus a length cap on string values and the captured-output buffer.
+
+var (
+	redactedKeyRe = regexp.MustCompile(`(?i)^(password|token|secret|api[_-]?key|authorization|bearer|cookie|session|credential|pat|client[_-]?secret|private[_-]?key|webhook[_-]?url)$`)
+	jwtRe         = regexp.MustCompile(`^eyJ[A-Za-z0-9_=-]+\.`)
+	longHexRe     = regexp.MustCompile(`^[A-Fa-f0-9]{32,}$`)
+	longBase64Re  = regexp.MustCompile(`^[A-Za-z0-9+/=_-]{32,}$`)
+)
+
+// redactArgs returns a deep-copied args map with sensitive values replaced
+// by redactedPlaceholder. Returns nil when the input is empty.
+func redactArgs(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		if redactedKeyRe.MatchString(k) {
+			out[k] = redactedPlaceholder
+			continue
+		}
+		out[k] = redactValue(v)
+	}
+	return out
+}
+
+func redactValue(v any) any {
+	switch x := v.(type) {
+	case string:
+		return redactString(x)
+	case map[string]any:
+		return redactArgs(x)
+	case []any:
+		out := make([]any, len(x))
+		for i, item := range x {
+			out[i] = redactValue(item)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func redactString(s string) string {
+	if jwtRe.MatchString(s) || longHexRe.MatchString(s) || longBase64Re.MatchString(s) {
+		return redactedPlaceholder
+	}
+	if len(s) > maxStringValueLen {
+		return safeTruncate(s, maxStringValueLen) + truncatedPlaceholder
+	}
+	return s
+}
+
+// redactCapturedOutput applies redactString to each line and caps the
+// total at maxCapturedOutputBytes, appending a truncation marker when
+// data is dropped.
+func redactCapturedOutput(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	lines := strings.Split(string(b), "\n")
+	var sb strings.Builder
+	truncated := false
+	for i, line := range lines {
+		redacted := redactString(line)
+		nextLen := sb.Len() + len(redacted)
+		if i+1 < len(lines) {
+			nextLen++
+		}
+		if nextLen > maxCapturedOutputBytes {
+			room := maxCapturedOutputBytes - sb.Len()
+			if room > 0 && room < len(redacted) {
+				sb.WriteString(safeTruncate(redacted, room))
+			} else if room >= len(redacted) {
+				sb.WriteString(redacted)
+			}
+			truncated = true
+			break
+		}
+		sb.WriteString(redacted)
+		if i+1 < len(lines) {
+			sb.WriteByte('\n')
+		}
+	}
+	if truncated {
+		dropped := len(b) - sb.Len()
+		fmt.Fprintf(&sb, "\n...[truncated, %d more bytes]", dropped)
+	}
+	return sb.String()
+}
+
+// safeTruncate cuts s to at most n bytes, trimming any incomplete
+// multi-byte UTF-8 sequence at the boundary so the returned string
+// remains valid UTF-8.
+func safeTruncate(s string, n int) string {
+	if n <= 0 || len(s) <= n {
+		if n <= 0 {
+			return ""
+		}
+		return s
+	}
+	cut := s[:n]
+	for !utf8.ValidString(cut) && cut != "" {
+		cut = cut[:len(cut)-1]
+	}
+	return cut
+}

--- a/internal/lua/scripterror.go
+++ b/internal/lua/scripterror.go
@@ -22,7 +22,7 @@ import (
 // action, document render, automation, MCP lua_run/lua_eval) wraps its
 // failures in *ScriptError so HTTP and MCP handlers can branch on the type.
 type ScriptError struct {
-	Surface        string         `json:"surface"`
+	Surface        Surface        `json:"surface"`
 	Path           string         `json:"path"`
 	EntityID       string         `json:"entity_id,omitempty"`
 	Args           map[string]any `json:"args,omitempty"`
@@ -33,6 +33,13 @@ type ScriptError struct {
 	CapturedOutput string         `json:"captured_output,omitempty"`
 	CorrelationID  string         `json:"correlation_id,omitempty"`
 }
+
+// Surface identifies which Lua execution path produced an error.
+// Closed enum: every legitimate value is one of the Surface* constants.
+// Defined as a typed string so callers writing `switch se.Surface { ... }`
+// get exhaustiveness analysis from go/analysis-driven linters and so the
+// JSON wire shape stays a plain string.
+type Surface string
 
 // StackFrame is one entry in a Lua stack trace.
 type StackFrame struct {
@@ -51,17 +58,17 @@ type SourceLine struct {
 
 // Surface constants used in ScriptError.Surface.
 const (
-	SurfaceAction     = "action"
-	SurfaceDocument   = "document"
-	SurfaceAutomation = "automation"
-	SurfaceLuaRun     = "lua_run"
-	SurfaceLuaEval    = "lua_eval"
+	SurfaceAction     Surface = "action"
+	SurfaceDocument   Surface = "document"
+	SurfaceAutomation Surface = "automation"
+	SurfaceLuaRun     Surface = "lua_run"
+	SurfaceLuaEval    Surface = "lua_eval"
 )
 
 // BuildInput aggregates the inputs to BuildScriptError. Callers fill in only
 // the fields they have; unset fields are omitted from the resulting envelope.
 type BuildInput struct {
-	Surface        string
+	Surface        Surface
 	Path           string
 	EntityID       string
 	Args           map[string]any
@@ -142,12 +149,12 @@ func BuildScriptError(in BuildInput) *ScriptError {
 	return se
 }
 
-// WithCapturedOutput attaches captured stdout to an existing ScriptError
+// AttachCapturedOutput attaches captured stdout to an existing ScriptError
 // and returns the receiver. Used by callers that own the print() buffer
 // outside the engine that produced the error (notably the data-entry
 // document renderer, which extracts the *ScriptError via errors.As and
 // then attaches the bytes it captured before the script failed).
-func (e *ScriptError) WithCapturedOutput(b []byte) *ScriptError {
+func (e *ScriptError) AttachCapturedOutput(b []byte) *ScriptError {
 	if e == nil || len(b) == 0 {
 		return e
 	}
@@ -170,8 +177,12 @@ func trimFrames(in []StackFrame) []StackFrame {
 	return out
 }
 
-// Error implements the error interface so *ScriptError can flow through
-// existing Go error plumbing.
+// Error renders the failure as "<path>:<line>: <message>", deliberately
+// matching gopher-lua's stock format so log lines are pasteable into
+// editor "go to file:line" affordances. This format is also what the
+// workspace automation layer flattens into its []string error slice
+// (see internal/workspace.formatAutomationError) — changing the layout
+// here changes what those log lines look like.
 func (e *ScriptError) Error() string {
 	if e == nil {
 		return ""

--- a/internal/lua/scripterror_test.go
+++ b/internal/lua/scripterror_test.go
@@ -1,0 +1,433 @@
+package lua
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	glua "github.com/yuin/gopher-lua"
+)
+
+// loadAndRun emulates how Runtime.RunFile loads scripts and, importantly,
+// installs the same message handler so the test exercises the typed-frame
+// path that BuildScriptError consumes in production. Returns the captured
+// frames and the error.
+func loadAndRun(t *testing.T, chunkname, code string) ([]StackFrame, error) {
+	t.Helper()
+	L := glua.NewState()
+	t.Cleanup(L.Close)
+	fn, err := L.Load(strings.NewReader(code), chunkname)
+	if err != nil {
+		return nil, fmt.Errorf("cannot compile script: %w", err)
+	}
+	var frames []StackFrame
+	handler := L.NewFunction(func(ls *glua.LState) int {
+		frames = collectStackFrames(ls)
+		ls.Push(ls.Get(1))
+		return 1
+	})
+	L.Push(fn)
+	return frames, L.PCall(0, glua.MultRet, handler)
+}
+
+func TestBuildScriptError_RuntimeNilIndex(t *testing.T) {
+	frames, err := loadAndRun(t, "actions/foo.lua", "local x = nil\nreturn x.bar")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	se := BuildScriptError(BuildInput{
+		Surface: SurfaceAction,
+		Path:    "actions/foo.lua",
+		Err:     err,
+		Frames:  frames,
+	})
+
+	if se.LuaLine != 2 {
+		t.Errorf("LuaLine=%d, want 2", se.LuaLine)
+	}
+	if !strings.Contains(se.LuaMessage, "attempt to index") {
+		t.Errorf("LuaMessage=%q, want contains 'attempt to index'", se.LuaMessage)
+	}
+	if len(se.Stack) == 0 {
+		t.Error("Stack is empty, want at least one frame")
+	}
+	// LuaMessage should NOT include the "<chunk>:<line>: " prefix anymore.
+	if strings.HasPrefix(se.LuaMessage, "actions/foo.lua") {
+		t.Errorf("LuaMessage still has chunk prefix: %q", se.LuaMessage)
+	}
+}
+
+func TestBuildScriptError_CompileError(t *testing.T) {
+	frames, err := loadAndRun(t, "actions/bad.lua", "local x is broken")
+	if err == nil {
+		t.Fatal("expected compile error")
+	}
+
+	se := BuildScriptError(BuildInput{
+		Surface: SurfaceAction,
+		Path:    "actions/bad.lua",
+		Err:     err,
+		Frames:  frames, // empty for compile errors; included for completeness
+	})
+
+	if se.LuaLine != 1 {
+		t.Errorf("LuaLine=%d, want 1 (parsed from line:N(column:N))", se.LuaLine)
+	}
+	if !strings.Contains(se.LuaMessage, "parse error") {
+		t.Errorf("LuaMessage=%q, want contains 'parse error'", se.LuaMessage)
+	}
+	if len(se.Stack) != 0 {
+		t.Errorf("Stack has %d frames; compile errors carry no stack", len(se.Stack))
+	}
+}
+
+func TestBuildScriptError_ErrorRaisedWithTable(t *testing.T) {
+	frames, err := loadAndRun(t, "scripts/x.lua", "error({code=42})")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	se := BuildScriptError(BuildInput{
+		Surface: SurfaceLuaRun,
+		Path:    "scripts/x.lua",
+		Err:     err,
+		Frames:  frames,
+	})
+
+	// Non-string error: Object stringifies to "table: 0x...". The line
+	// comes from the typed frame capture, not from any string parsing.
+	if se.LuaLine != 1 {
+		t.Errorf("LuaLine=%d, want 1 from typed frames", se.LuaLine)
+	}
+	if !strings.Contains(se.LuaMessage, "table:") {
+		t.Errorf("LuaMessage=%q, want contains 'table:'", se.LuaMessage)
+	}
+}
+
+func TestBuildScriptError_PlainGoError(t *testing.T) {
+	se := BuildScriptError(BuildInput{
+		Surface: SurfaceAction,
+		Path:    "actions/foo.lua",
+		Err:     errors.New("script not found"),
+	})
+
+	if se.LuaMessage != "script not found" {
+		t.Errorf("LuaMessage=%q", se.LuaMessage)
+	}
+	if se.LuaLine != 0 {
+		t.Errorf("LuaLine=%d, want 0 for non-Lua error", se.LuaLine)
+	}
+	if len(se.Stack) != 0 {
+		t.Error("Stack should be empty for non-Lua error")
+	}
+}
+
+func TestBuildScriptError_PopulatesSource(t *testing.T) {
+	// Use `local q = z.foo` instead of `return z.foo` — a `return` followed
+	// by another statement is a Lua syntax error, not a runtime one.
+	const code = "local x = 1\nlocal y = 2\nlocal z = nil\nlocal q = z.foo\nlocal w = 3\n"
+	frames, err := loadAndRun(t, "actions/foo.lua", code)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	srcFS := fstest.MapFS{
+		"actions/foo.lua": &fstest.MapFile{Data: []byte(code)},
+	}
+
+	se := BuildScriptError(BuildInput{
+		Surface:  SurfaceAction,
+		Path:     "actions/foo.lua",
+		Err:      err,
+		Frames:   frames,
+		SourceFS: srcFS,
+	})
+
+	if se.LuaLine != 4 {
+		t.Fatalf("LuaLine=%d, want 4", se.LuaLine)
+	}
+	// ±3 context: lines 1..5
+	wantLines := []int{1, 2, 3, 4, 5}
+	if len(se.Source) != len(wantLines) {
+		t.Fatalf("got %d source lines, want %d", len(se.Source), len(wantLines))
+	}
+	for i, sl := range se.Source {
+		if sl.N != wantLines[i] {
+			t.Errorf("source[%d].N=%d, want %d", i, sl.N, wantLines[i])
+		}
+		if (sl.N == 4) != sl.Highlight {
+			t.Errorf("source[%d] highlight=%v, want %v", i, sl.Highlight, sl.N == 4)
+		}
+	}
+}
+
+func TestBuildScriptError_SourceClippedAtBoundaries(t *testing.T) {
+	const code = "local q = nil.foo\n"
+	frames, err := loadAndRun(t, "actions/edge.lua", code)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	srcFS := fstest.MapFS{
+		"actions/edge.lua": &fstest.MapFile{Data: []byte(code)},
+	}
+	se := BuildScriptError(BuildInput{
+		Surface:  SurfaceAction,
+		Path:     "actions/edge.lua",
+		Err:      err,
+		Frames:   frames,
+		SourceFS: srcFS,
+	})
+	if se.LuaLine != 1 {
+		t.Fatalf("LuaLine=%d, want 1", se.LuaLine)
+	}
+	if len(se.Source) != 1 {
+		t.Fatalf("got %d lines, want 1", len(se.Source))
+	}
+	if se.Source[0].N != 1 || !se.Source[0].Highlight {
+		t.Errorf("source[0]=%+v", se.Source[0])
+	}
+}
+
+func TestBuildScriptError_SourceSkippedForOversizedFile(t *testing.T) {
+	const code = "local q = nil.foo\n"
+	frames, err := loadAndRun(t, "actions/big.lua", code)
+
+	bigData := make([]byte, maxSourceFileSize+1)
+	for i := range bigData {
+		bigData[i] = 'a'
+	}
+	srcFS := fstest.MapFS{
+		"actions/big.lua": &fstest.MapFile{Data: bigData},
+	}
+
+	se := BuildScriptError(BuildInput{
+		Surface:  SurfaceAction,
+		Path:     "actions/big.lua",
+		Err:      err,
+		Frames:   frames,
+		SourceFS: srcFS,
+	})
+	if len(se.Source) != 0 {
+		t.Errorf("Source has %d lines; want none for oversized file", len(se.Source))
+	}
+	if se.LuaLine == 0 {
+		t.Error("LuaLine must still be set even when source is skipped")
+	}
+}
+
+func TestBuildScriptError_SourceRejectsTraversal(t *testing.T) {
+	const code = "local q = nil.foo\n"
+	frames, err := loadAndRun(t, "../etc/passwd", code)
+
+	// FS contains a real file at the would-be-traversed path, but our
+	// path cleaner should refuse to descend into it.
+	srcFS := fstest.MapFS{
+		"../etc/passwd": &fstest.MapFile{Data: []byte("root:x:0:0::/root:/bin/sh\n")},
+	}
+
+	se := BuildScriptError(BuildInput{
+		Surface:  SurfaceAction,
+		Path:     "../etc/passwd",
+		Err:      err,
+		Frames:   frames,
+		SourceFS: srcFS,
+	})
+	if len(se.Source) != 0 {
+		t.Errorf("Source populated for traversal-y path: %+v", se.Source)
+	}
+}
+
+func TestBuildScriptError_RedactsArgsByKey(t *testing.T) {
+	se := BuildScriptError(BuildInput{
+		Surface: SurfaceAction,
+		Path:    "actions/x.lua",
+		Args: map[string]any{
+			"username":      "alice",
+			"password":      "hunter2",
+			"api_key":       "anything",
+			"api-key":       "also-redacted",
+			"AUTHORIZATION": "Bearer xxx",
+			"client_secret": "shh",
+		},
+		Err: errors.New("any error"),
+	})
+
+	cases := []struct {
+		key     string
+		want    string
+		isExact bool
+	}{
+		{"username", "alice", true},
+		{"password", redactedPlaceholder, true},
+		{"api_key", redactedPlaceholder, true},
+		{"api-key", redactedPlaceholder, true},
+		{"AUTHORIZATION", redactedPlaceholder, true},
+		{"client_secret", redactedPlaceholder, true},
+	}
+	for _, tc := range cases {
+		got, ok := se.Args[tc.key]
+		if !ok {
+			t.Errorf("missing key %q in redacted args", tc.key)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("args[%q]=%v, want %v", tc.key, got, tc.want)
+		}
+	}
+}
+
+func TestBuildScriptError_RedactsValueShape(t *testing.T) {
+	jwt := "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.signature"
+	longHex := strings.Repeat("a1b2c3d4", 8) // 64 hex chars
+	longB64 := strings.Repeat("AbCdEfGh", 5) // 40 b64-ish chars
+	short := "hello"
+	// "abc " contains a space so it doesn't match any value-shape regex;
+	// repeated, it exceeds the per-string length cap and gets truncated.
+	huge := strings.Repeat("abc ", (maxStringValueLen/4)+10)
+
+	se := BuildScriptError(BuildInput{
+		Surface: SurfaceAction,
+		Path:    "x",
+		Args: map[string]any{
+			"jwt":      jwt,
+			"long_hex": longHex,
+			"long_b64": longB64,
+			"short":    short,
+			"huge":     huge,
+		},
+		Err: errors.New("e"),
+	})
+
+	if got := se.Args["jwt"]; got != redactedPlaceholder {
+		t.Errorf("jwt=%v, want redacted", got)
+	}
+	if got := se.Args["long_hex"]; got != redactedPlaceholder {
+		t.Errorf("long_hex=%v, want redacted", got)
+	}
+	if got := se.Args["long_b64"]; got != redactedPlaceholder {
+		t.Errorf("long_b64=%v, want redacted", got)
+	}
+	if got := se.Args["short"]; got != short {
+		t.Errorf("short=%v, want %v", got, short)
+	}
+	gotHuge := se.Args["huge"].(string)
+	if !strings.HasSuffix(gotHuge, truncatedPlaceholder) {
+		t.Errorf("huge missing truncation marker: %q", gotHuge[len(gotHuge)-30:])
+	}
+	if len(gotHuge) > maxStringValueLen+len(truncatedPlaceholder) {
+		t.Errorf("huge len=%d, want <= %d", len(gotHuge), maxStringValueLen+len(truncatedPlaceholder))
+	}
+}
+
+func TestBuildScriptError_RedactsNestedArgs(t *testing.T) {
+	se := BuildScriptError(BuildInput{
+		Surface: SurfaceAction,
+		Path:    "x",
+		Args: map[string]any{
+			"outer": map[string]any{
+				"password": "leak1",
+				"inner": []any{
+					map[string]any{"token": "leak2"},
+				},
+			},
+		},
+		Err: errors.New("e"),
+	})
+
+	outer := se.Args["outer"].(map[string]any)
+	if outer["password"] != redactedPlaceholder {
+		t.Errorf("nested password=%v", outer["password"])
+	}
+	innerSlice := outer["inner"].([]any)
+	innerMap := innerSlice[0].(map[string]any)
+	if innerMap["token"] != redactedPlaceholder {
+		t.Errorf("doubly-nested token=%v", innerMap["token"])
+	}
+}
+
+func TestBuildScriptError_CapturedOutputRedactedAndCapped(t *testing.T) {
+	jwt := "eyJabc.def.ghi"
+	captured := []byte("hello\n" + jwt + "\nworld\n")
+
+	se := BuildScriptError(BuildInput{
+		Surface:        SurfaceAction,
+		Path:           "x",
+		Err:            errors.New("e"),
+		CapturedOutput: captured,
+	})
+
+	if !strings.Contains(se.CapturedOutput, "hello") {
+		t.Errorf("missing 'hello' in %q", se.CapturedOutput)
+	}
+	if strings.Contains(se.CapturedOutput, jwt) {
+		t.Errorf("JWT not redacted in captured output: %q", se.CapturedOutput)
+	}
+	if !strings.Contains(se.CapturedOutput, redactedPlaceholder) {
+		t.Errorf("captured output missing redaction marker: %q", se.CapturedOutput)
+	}
+}
+
+func TestBuildScriptError_CapturedOutputCappedAt16K(t *testing.T) {
+	// Build 32KB of distinct lines so the value-shape redactor doesn't
+	// collapse the whole thing to "<redacted>" before truncation kicks in.
+	var sb strings.Builder
+	for i := 0; sb.Len() < maxCapturedOutputBytes*2; i++ {
+		fmt.Fprintf(&sb, "line %d says hello world\n", i)
+	}
+	huge := []byte(sb.String())
+
+	se := BuildScriptError(BuildInput{
+		Surface:        SurfaceAction,
+		Path:           "x",
+		Err:            errors.New("e"),
+		CapturedOutput: huge,
+	})
+	if !strings.HasSuffix(se.CapturedOutput, " more bytes]") {
+		t.Errorf("captured output missing truncation suffix; tail: %q", tail(se.CapturedOutput, 60))
+	}
+	if len(se.CapturedOutput) > maxCapturedOutputBytes+64 {
+		t.Errorf("captured output too long: %d", len(se.CapturedOutput))
+	}
+}
+
+func TestScriptError_Error(t *testing.T) {
+	cases := []struct {
+		name string
+		se   *ScriptError
+		want string
+	}{
+		{
+			name: "with path and line",
+			se:   &ScriptError{Path: "a/b.lua", LuaLine: 12, LuaMessage: "boom"},
+			want: "a/b.lua:12: boom",
+		},
+		{
+			name: "with path no line",
+			se:   &ScriptError{Path: "a/b.lua", LuaMessage: "boom"},
+			want: "a/b.lua: boom",
+		},
+		{
+			name: "no path",
+			se:   &ScriptError{LuaMessage: "boom"},
+			want: "boom",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.se.Error(); got != tc.want {
+				t.Errorf("Error()=%q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func tail(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
+}

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -4,6 +4,7 @@ package mcp
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -74,7 +75,12 @@ func (s *Server) handleLuaEval(ctx context.Context, req mcp.CallToolRequest) (*m
 	// raises "not available in inline/eval contexts" so sessions can't
 	// accidentally share a nameless namespace.
 	if err := runtime.RunString(code); err != nil {
-		return mcp.NewToolResultError("Lua error: " + err.Error()), nil
+		// output stays empty here: print() in non-document/non-action
+		// runtimes writes to os.Stdout (see lua/runtime.go:256), which
+		// is the right thing for MCP — operators want their print()
+		// landing in the terminal where they invoked the tool.
+		return luaScriptErrorResult(lua.SurfaceLuaEval, "<inline>", "",
+			runtime.ErrorFrames(), nil, err), nil
 	}
 
 	result := output.String()
@@ -151,7 +157,10 @@ func (s *Server) handleLuaRun(ctx context.Context, req mcp.CallToolRequest) (*mc
 	// them through RunFileContent keeps that while sharing all the
 	// downstream invariants.
 	if err := runtime.RunFileContent(path, scriptContent, args); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("Lua error in %s: %s", path, err.Error())), nil
+		// See note above: print() bypasses `output` for MCP runs.
+		return luaScriptErrorResult(lua.SurfaceLuaRun,
+			filepath.ToSlash(filepath.Join(scriptsDir, path)), projectRoot,
+			runtime.ErrorFrames(), nil, err), nil
 	}
 
 	result := output.String()
@@ -160,6 +169,42 @@ func (s *Server) handleLuaRun(ctx context.Context, req mcp.CallToolRequest) (*mc
 	}
 
 	return mcp.NewToolResultText(result), nil
+}
+
+// luaScriptErrorResult builds an MCP CallToolResult carrying a JSON-
+// encoded ScriptError envelope as the error message. We use
+// NewToolResultError (not NewToolResultText) so the result's IsError
+// flag stays true — clients keying off that flag still see the failure.
+//
+// projectRoot is "" for lua_eval (no script source on disk to slice);
+// otherwise the source FS is rooted there so the envelope can include
+// ±N lines around the failing line.
+func luaScriptErrorResult(surface, envelopePath, projectRoot string,
+	frames []lua.StackFrame, capturedOutput []byte, runErr error) *mcp.CallToolResult {
+	in := lua.BuildInput{
+		Surface:        surface,
+		Path:           envelopePath,
+		Frames:         frames,
+		CapturedOutput: capturedOutput,
+		Err:            runErr,
+	}
+	if projectRoot != "" {
+		in.SourceFS = os.DirFS(projectRoot)
+		// Frames coming from gopher-lua use the bare filename as Source;
+		// re-prefix matching frames so they line up with envelopePath.
+		bareName := strings.TrimPrefix(envelopePath, scriptsDir+"/")
+		for i := range in.Frames {
+			if in.Frames[i].Path == bareName {
+				in.Frames[i].Path = envelopePath
+			}
+		}
+	}
+	se := lua.BuildScriptError(in)
+	body, err := json.Marshal(se)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Lua error: %v (also failed to marshal envelope: %v)", se.Error(), err))
+	}
+	return mcp.NewToolResultError(string(body))
 }
 
 func (s *Server) handleLuaList(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -179,7 +179,7 @@ func (s *Server) handleLuaRun(ctx context.Context, req mcp.CallToolRequest) (*mc
 // projectRoot is "" for lua_eval (no script source on disk to slice);
 // otherwise the source FS is rooted there so the envelope can include
 // ±N lines around the failing line.
-func luaScriptErrorResult(surface, envelopePath, projectRoot string,
+func luaScriptErrorResult(surface lua.Surface, envelopePath, projectRoot string,
 	frames []lua.StackFrame, capturedOutput []byte, runErr error) *mcp.CallToolResult {
 	in := lua.BuildInput{
 		Surface:        surface,

--- a/internal/mcp/tools_lua_test.go
+++ b/internal/mcp/tools_lua_test.go
@@ -1,0 +1,87 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/Sourcehaven-BV/rela/internal/lua"
+)
+
+// luaCallToolReq builds a minimal MCP CallToolRequest carrying named
+// string args, mirroring how the real MCP harness deserialises a client
+// invocation. Used to drive handleLuaEval / handleLuaRun in tests.
+func luaCallToolReq(args map[string]any) mcp.CallToolRequest {
+	return mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: args,
+		},
+	}
+}
+
+// decodeScriptError extracts the JSON envelope returned by the lua tools
+// on failure. Errors out the test if anything about the shape is off.
+func decodeScriptError(t *testing.T, result *mcp.CallToolResult) *lua.ScriptError {
+	t.Helper()
+	if !result.IsError {
+		t.Fatalf("expected IsError=true, got false; content=%v", result.Content)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("result has no content")
+	}
+	text, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("content[0] is not TextContent: %T", result.Content[0])
+	}
+	var se lua.ScriptError
+	if err := json.Unmarshal([]byte(text.Text), &se); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v\nbody: %s", err, text.Text)
+	}
+	return &se
+}
+
+func TestHandleLuaEval_ReturnsScriptErrorEnvelope(t *testing.T) {
+	s := makeTestServer(t)
+
+	result, err := s.handleLuaEval(context.Background(),
+		luaCallToolReq(map[string]any{"code": "print('hello')\nerror('kaboom')"}))
+	if err != nil {
+		t.Fatalf("handler returned Go error: %v", err)
+	}
+	se := decodeScriptError(t, result)
+
+	if se.Surface != lua.SurfaceLuaEval {
+		t.Errorf("Surface=%q, want %q", se.Surface, lua.SurfaceLuaEval)
+	}
+	if se.Path != "<inline>" {
+		t.Errorf("Path=%q, want <inline>", se.Path)
+	}
+	if !strings.Contains(se.LuaMessage, "kaboom") {
+		t.Errorf("LuaMessage=%q, want contains kaboom", se.LuaMessage)
+	}
+	if se.LuaLine != 2 {
+		t.Errorf("LuaLine=%d, want 2", se.LuaLine)
+	}
+	// CapturedOutput is intentionally empty for lua_eval/lua_run: see
+	// runtime.go:256 — print() routes to os.Stdout outside document/
+	// action modes so MCP / scheduler / CLI behave like a normal terminal.
+	if se.CapturedOutput != "" {
+		t.Errorf("lua_eval CapturedOutput=%q, want empty (print goes to terminal)", se.CapturedOutput)
+	}
+	// lua_eval has no on-disk source — Source slice must be empty.
+	if len(se.Source) != 0 {
+		t.Errorf("lua_eval Source non-empty: %+v", se.Source)
+	}
+}
+
+func TestHandleLuaEval_PreservesIsErrorFlag(t *testing.T) {
+	s := makeTestServer(t)
+	result, _ := s.handleLuaEval(context.Background(),
+		luaCallToolReq(map[string]any{"code": "error('x')"}))
+	if !result.IsError {
+		t.Error("IsError flag must remain true on Lua failure for MCP clients to branch")
+	}
+}

--- a/internal/script/action.go
+++ b/internal/script/action.go
@@ -83,10 +83,54 @@ func (e *Engine) ExecuteAction(
 		return &ActionResponse{}, nil
 	}
 	if err != nil {
-		return nil, err
+		// Path in the envelope is project-relative (e.g.,
+		// "actions/foo.lua") for display; SourceFS is rooted at the
+		// project so readSourceSlice can resolve that same path.
+		// Lua's chunkname (used as scriptPath here) is the bare filename;
+		// gopher-lua reports it back via the message handler as the
+		// frame's Source. Re-prefix with actionsDir so frame paths line
+		// up with the SourceFS root and the displayed Path.
+		envelopePath := filepath.ToSlash(filepath.Join(actionsDir, scriptPath))
+		frames := runtime.ErrorFrames()
+		for i := range frames {
+			if frames[i].Path == scriptPath {
+				frames[i].Path = envelopePath
+			}
+		}
+		return nil, lua.BuildScriptError(lua.BuildInput{
+			Surface:        lua.SurfaceAction,
+			Path:           envelopePath,
+			EntityID:       triggerEntityID(triggerEntity),
+			Args:           stringMapToAny(params),
+			Frames:         frames,
+			CapturedOutput: output.Bytes(),
+			Err:            err,
+			SourceFS:       os.DirFS(deps.ProjectRoot),
+		})
 	}
 
 	return parseActionResponse(ret)
+}
+
+func triggerEntityID(e *entity.Entity) string {
+	if e == nil {
+		return ""
+	}
+	return e.ID
+}
+
+// stringMapToAny adapts the action's static params (always string→string)
+// to the redactor's input type (map[string]any). Returns nil for empty
+// maps so the envelope omits the Args field rather than emitting "{}".
+func stringMapToAny(m map[string]string) map[string]any {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
 }
 
 // loadActionScript loads a script from the project's actions/ directory using

--- a/internal/script/action.go
+++ b/internal/script/action.go
@@ -44,12 +44,17 @@ var validMessageTypes = map[string]bool{
 //
 // triggerEntity is optional — nil when the action is invoked without entity
 // context. When non-nil it is exposed to the Lua script as the `entity` global.
+//
+// correlationID is stamped onto any *lua.ScriptError this returns so the
+// HTTP response and the slog log line stay matched up. Callers without
+// a correlation context (CLI, scheduler) may pass "".
 func (e *Engine) ExecuteAction(
 	scriptPath string,
 	deps lua.WriteDeps,
 	triggerEntity *entity.Entity,
 	params map[string]string,
 	timeout time.Duration,
+	correlationID string,
 ) (*ActionResponse, error) {
 	scriptCode, err := loadActionScript(deps.ProjectRoot, scriptPath)
 	if err != nil {
@@ -105,6 +110,7 @@ func (e *Engine) ExecuteAction(
 			Frames:         frames,
 			CapturedOutput: output.Bytes(),
 			Err:            err,
+			CorrelationID:  correlationID,
 			SourceFS:       os.DirFS(deps.ProjectRoot),
 		})
 	}

--- a/internal/script/action_test.go
+++ b/internal/script/action_test.go
@@ -127,7 +127,7 @@ func TestExecuteAction_PathTraversal(t *testing.T) {
 	engine := NewEngine()
 	deps := testWriteDeps("/project")
 
-	_, err := engine.ExecuteAction("../etc/passwd", deps, nil, nil, time.Second)
+	_, err := engine.ExecuteAction("../etc/passwd", deps, nil, nil, time.Second, "")
 	if err == nil {
 		t.Fatal("expected error for path traversal")
 	}
@@ -137,7 +137,7 @@ func TestExecuteAction_WrongExtension(t *testing.T) {
 	engine := NewEngine()
 	deps := testWriteDeps("/project")
 
-	_, err := engine.ExecuteAction("script.txt", deps, nil, nil, time.Second)
+	_, err := engine.ExecuteAction("script.txt", deps, nil, nil, time.Second, "")
 	if err == nil {
 		t.Fatal("expected error for wrong extension")
 	}
@@ -166,7 +166,7 @@ func TestExecuteAction_RealFile(t *testing.T) {
 	engine := NewEngine()
 	deps := testWriteDeps(tmpDir)
 
-	resp, err := engine.ExecuteAction("test.lua", deps, nil, nil, 5*time.Second)
+	resp, err := engine.ExecuteAction("test.lua", deps, nil, nil, 5*time.Second, "")
 	if err != nil {
 		t.Fatalf("ExecuteAction failed: %v", err)
 	}
@@ -194,7 +194,7 @@ func TestExecuteAction_WithTriggerEntity(t *testing.T) {
 	deps := testWriteDeps(tmpDir)
 	ent := &entity.Entity{ID: "T-42", Type: "ticket"}
 
-	resp, err := engine.ExecuteAction("ent.lua", deps, ent, nil, 5*time.Second)
+	resp, err := engine.ExecuteAction("ent.lua", deps, ent, nil, 5*time.Second, "")
 	if err != nil {
 		t.Fatalf("ExecuteAction failed: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestExecuteAction_WithParams(t *testing.T) {
 	deps := testWriteDeps(tmpDir)
 	params := map[string]string{"greeting": "hello"}
 
-	resp, err := engine.ExecuteAction("params.lua", deps, nil, params, 5*time.Second)
+	resp, err := engine.ExecuteAction("params.lua", deps, nil, params, 5*time.Second, "")
 	if err != nil {
 		t.Fatalf("ExecuteAction failed: %v", err)
 	}
@@ -248,7 +248,7 @@ error("kaboom")`
 	ent := &entity.Entity{ID: "T-99", Type: "ticket"}
 
 	_, err := engine.ExecuteAction("boom.lua", deps, ent,
-		map[string]string{"greeting": "hi", "password": "leak"}, 5*time.Second)
+		map[string]string{"greeting": "hi", "password": "leak"}, 5*time.Second, "corr-test")
 	if err == nil {
 		t.Fatal("expected error from script")
 	}
@@ -284,6 +284,9 @@ error("kaboom")`
 	}
 	if len(se.Source) == 0 {
 		t.Error("Source is empty; expected slice around line 2")
+	}
+	if se.CorrelationID != "corr-test" {
+		t.Errorf("CorrelationID=%q, want corr-test", se.CorrelationID)
 	}
 }
 

--- a/internal/script/action_test.go
+++ b/internal/script/action_test.go
@@ -1,6 +1,7 @@
 package script
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
 )
 
 func TestParseActionResponse_Nil(t *testing.T) {
@@ -234,7 +236,8 @@ func TestExecuteAction_ScriptError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	scriptContent := `error("kaboom")`
+	scriptContent := `print("before")
+error("kaboom")`
 	scriptPath := filepath.Join(actionsDir, "boom.lua")
 	if err := os.WriteFile(scriptPath, []byte(scriptContent), 0644); err != nil {
 		t.Fatal(err)
@@ -242,13 +245,45 @@ func TestExecuteAction_ScriptError(t *testing.T) {
 
 	engine := NewEngine()
 	deps := testWriteDeps(tmpDir)
+	ent := &entity.Entity{ID: "T-99", Type: "ticket"}
 
-	_, err := engine.ExecuteAction("boom.lua", deps, nil, nil, 5*time.Second)
+	_, err := engine.ExecuteAction("boom.lua", deps, ent,
+		map[string]string{"greeting": "hi", "password": "leak"}, 5*time.Second)
 	if err == nil {
 		t.Fatal("expected error from script")
 	}
-	if !strings.Contains(err.Error(), "kaboom") {
-		t.Errorf("expected error to mention kaboom, got %v", err)
+
+	var se *lua.ScriptError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *lua.ScriptError, got %T: %v", err, err)
+	}
+
+	if se.Surface != lua.SurfaceAction {
+		t.Errorf("Surface=%q, want %q", se.Surface, lua.SurfaceAction)
+	}
+	if se.Path != "actions/boom.lua" {
+		t.Errorf("Path=%q, want actions/boom.lua", se.Path)
+	}
+	if se.EntityID != ent.ID {
+		t.Errorf("EntityID=%q, want %q", se.EntityID, ent.ID)
+	}
+	if !strings.Contains(se.LuaMessage, "kaboom") {
+		t.Errorf("LuaMessage=%q, want contains kaboom", se.LuaMessage)
+	}
+	if se.LuaLine != 2 {
+		t.Errorf("LuaLine=%d, want 2", se.LuaLine)
+	}
+	if se.Args["greeting"] != "hi" {
+		t.Errorf("Args[greeting]=%v, want hi", se.Args["greeting"])
+	}
+	if se.Args["password"] != "<redacted>" {
+		t.Errorf("Args[password]=%v, want redacted", se.Args["password"])
+	}
+	if !strings.Contains(se.CapturedOutput, "before") {
+		t.Errorf("CapturedOutput=%q, want contains 'before'", se.CapturedOutput)
+	}
+	if len(se.Source) == 0 {
+		t.Error("Source is empty; expected slice around line 2")
 	}
 }
 

--- a/internal/script/executor.go
+++ b/internal/script/executor.go
@@ -127,13 +127,13 @@ func (e *Engine) ExecuteDocument(
 }
 
 // wrapScriptError builds a *lua.ScriptError from a runtime failure.
-// Captured output is left for the caller to attach via WithCapturedOutput
+// Captured output is left for the caller to attach via AttachCapturedOutput
 // when they own the buffer (e.g. the document renderer).
 //
 // For inline / synthetic paths (containing '<' or empty), no prefix is
 // applied — the path is used as-is for envelope display, and the source
 // FS is left out since there's nothing on disk to slice.
-func wrapScriptError(surface, subdir, scriptPath, entityID string,
+func wrapScriptError(surface lua.Surface, subdir, scriptPath, entityID string,
 	frames []lua.StackFrame, capturedOutput []byte, runErr error,
 	projectRoot string) error {
 	envelopePath := scriptPath

--- a/internal/script/executor.go
+++ b/internal/script/executor.go
@@ -114,14 +114,51 @@ func (e *Engine) ExecuteDocument(
 	}
 	defer runtime.Close()
 
-	// NewWriterRuntime receives `path` for per-script secret loading, but
-	// rela.cache.* namespacing is driven by a separate scriptPath field
-	// that RunFile/RunFileContent set. We're invoking RunString, so wire
-	// the path explicitly — otherwise rela.cache.* inside a document
-	// script would hit the inline/eval guard and raise.
-	runtime.SetScriptPath(path)
+	// RunFileContent (not RunString) so gopher-lua receives the script
+	// path as the chunkname — that lands in the message handler's frame
+	// captures and lets ScriptError.Source populate from the right file.
+	// Doubles as the rela.cache.* namespace, so SetScriptPath is no
+	// longer needed alongside it.
+	if runErr := runtime.RunFileContent(path, []byte(scriptCode), nil); runErr != nil {
+		return wrapScriptError(lua.SurfaceDocument, scriptsDir, path, entryID,
+			runtime.ErrorFrames(), nil, runErr, deps.ProjectRoot)
+	}
+	return nil
+}
 
-	return runtime.RunString(scriptCode)
+// wrapScriptError builds a *lua.ScriptError from a runtime failure.
+// Captured output is left for the caller to attach via WithCapturedOutput
+// when they own the buffer (e.g. the document renderer).
+//
+// For inline / synthetic paths (containing '<' or empty), no prefix is
+// applied — the path is used as-is for envelope display, and the source
+// FS is left out since there's nothing on disk to slice.
+func wrapScriptError(surface, subdir, scriptPath, entityID string,
+	frames []lua.StackFrame, capturedOutput []byte, runErr error,
+	projectRoot string) error {
+	envelopePath := scriptPath
+	useSourceFS := false
+	if scriptPath != "" && !strings.ContainsAny(scriptPath, "<>") {
+		envelopePath = filepath.ToSlash(filepath.Join(subdir, scriptPath))
+		useSourceFS = true
+		for i := range frames {
+			if frames[i].Path == scriptPath {
+				frames[i].Path = envelopePath
+			}
+		}
+	}
+	in := lua.BuildInput{
+		Surface:        surface,
+		Path:           envelopePath,
+		EntityID:       entityID,
+		Frames:         frames,
+		CapturedOutput: capturedOutput,
+		Err:            runErr,
+	}
+	if useSourceFS {
+		in.SourceFS = os.DirFS(projectRoot)
+	}
+	return lua.BuildScriptError(in)
 }
 
 // execute runs Lua code with entity context. scriptPath is used to resolve
@@ -145,14 +182,35 @@ func (e *Engine) execute(code string, deps lua.WriteDeps, scriptPath string,
 	runtime.SetScriptPath(scriptPath)
 
 	ls := runtime.LState()
+	entityID := ""
 	if newEntity != nil {
 		ls.SetGlobal("entity", lua.EntityToTable(ls, newEntity))
+		entityID = newEntity.ID
 	}
 	if oldEntity != nil {
 		ls.SetGlobal("old_entity", lua.EntityToTable(ls, oldEntity))
+		if entityID == "" {
+			entityID = oldEntity.ID
+		}
 	}
 
-	return runtime.RunString(code)
+	if runErr := runtime.RunString(code); runErr != nil {
+		// Surface tag is "automation" — this seam is invoked from the
+		// automation engine (workspace) for both inline `lua: |` blocks
+		// and `script:` files. Captured stdout is omitted: automations
+		// are not a UI surface and operators rarely use print() there.
+		path := scriptPath
+		if path == "" {
+			// Inline automation block — give it an identity stable enough
+			// for the envelope to disambiguate. The automation name
+			// would be better but isn't plumbed here; defer until the
+			// automation engine wraps with that context.
+			path = "<inline>"
+		}
+		return wrapScriptError(lua.SurfaceAutomation, scriptsDir, path, entityID,
+			runtime.ErrorFrames(), nil, runErr, deps.ProjectRoot)
+	}
+	return nil
 }
 
 // CheckDocumentScriptExists verifies a document script can be loaded.

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1000,6 +1000,12 @@ func (w *Workspace) createEntityCore(entityType string, opts createEntityCoreOpt
 }
 
 // automationSideEffects holds entities and relations created by automation.
+//
+// Errors is intentionally []string rather than []error: today no consumer
+// branches on the underlying type; UpdateResult.AutomationErrors is read
+// only as text by the API layer. Promote to []error (preserving
+// *lua.ScriptError) when a future surface needs typed access — at which
+// point formatAutomationError's stringification goes away.
 type automationSideEffects struct {
 	RelationsCreated []*entity.Relation
 	EntitiesCreated  []*entity.Entity

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1225,6 +1225,20 @@ func (w *Workspace) executeLuaActions(
 		}
 
 		if err != nil {
+			// Automations have no incoming HTTP request to correlate
+			// against, so the slog line uses the automation name +
+			// triggering entity id as the natural identity. Operators
+			// grep on those rather than a per-request hex.
+			triggerID := ""
+			if newEntity != nil {
+				triggerID = newEntity.ID
+			} else if oldEntity != nil {
+				triggerID = oldEntity.ID
+			}
+			slog.Warn("automation script failed",
+				"automation", action.AutomationName,
+				"entity", triggerID,
+				"error", err)
 			effects.Errors = append(effects.Errors, formatAutomationError(action, err))
 		}
 	}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1219,10 +1219,30 @@ func (w *Workspace) executeLuaActions(
 		}
 
 		if err != nil {
-			effects.Errors = append(effects.Errors,
-				"script execution error: "+err.Error())
+			effects.Errors = append(effects.Errors, formatAutomationError(action, err))
 		}
 	}
+}
+
+// formatAutomationError renders an automation Lua failure as a single
+// string for the existing []string Errors slice. For Lua failures the
+// engine has already wrapped err in *lua.ScriptError; we add the
+// automation identity (the engine doesn't know it) and use the typed
+// fields so the message includes a concrete script-or-automation name.
+//
+// Inline `lua: |` blocks have no FilePath, so the engine sees scriptPath
+// as "" and tags the envelope with "<inline>". We override that here
+// once we know the automation name.
+func formatAutomationError(action automation.LuaToExecute, err error) string {
+	var se *lua.ScriptError
+	if errors.As(err, &se) {
+		if action.FilePath == "" && action.AutomationName != "" {
+			se.Path = "automation:" + action.AutomationName
+			// Re-render Error() output reflects the new Path.
+		}
+		return se.Error()
+	}
+	return "script execution error: " + err.Error()
 }
 
 // handleIfExists checks if_exists behavior for entity creation.

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1590,13 +1590,17 @@ automations:
 
 	foundLuaError := false
 	for _, errMsg := range result.AutomationErrors {
-		if strings.Contains(errMsg, "script execution error") && strings.Contains(errMsg, "intentional test error") {
+		// New envelope shape: "<path>:<line>: <message>" where path is
+		// "automation:<automation-name>" for inline `lua: |` blocks.
+		if strings.Contains(errMsg, "automation:lua-error") &&
+			strings.Contains(errMsg, "intentional test error") {
+
 			foundLuaError = true
 			break
 		}
 	}
 	if !foundLuaError {
-		t.Errorf("expected script error message, got: %v", result.AutomationErrors)
+		t.Errorf("expected automation script error, got: %v", result.AutomationErrors)
 	}
 }
 

--- a/tickets/entities/docs-checklists/DOCS-KQLKQ.md
+++ b/tickets/entities/docs-checklists/DOCS-KQLKQ.md
@@ -1,0 +1,29 @@
+---
+id: DOCS-KQLKQ
+type: docs-checklist
+title: 'Documentation: Structured error reporting for Lua script failures'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code documentation
+
+- [x] Public Go types have doc comments (`ScriptError`, `BuildScriptError`, `BuildInput`, `StackFrame`, `SourceLine`, surface constants, `WithCapturedOutput`, `Runtime.ErrorFrames`, `ScriptErrorEnvelope`, `ScriptErrorPolicy`, `writeV1ScriptError`)
+- [x] Frontend types documented in `frontend/src/types/scriptError.ts`
+- [x] Non-obvious WHY comments added (path-cleaning belt-and-braces, X-Forwarded-For omission, captured-output-bypasses-MCP)
+
+## Project documentation
+
+- [x] ~~CLAUDE.md "Don't do this" entry~~ (N/A: the existing list covers package boundaries; adding "don't return raw Lua errors from a new surface" would be aspirational guidance with no companion rule. Skipping per CLAUDE.md "no premature abstractions".)
+- [x] No README.md changes — N/A: rela's README is a brief project overview; envelope shape is an internal detail.
+
+## External documentation
+
+- [x] ~~User-facing docs (Lua scripting reference)~~ (N/A: no user-facing docs site exists yet for the Lua scripting surface; the rela-docs MCP graph has a `lua-scripting` concept but no rendered guide. When that guide lands, it should mention the structured error panel.)
+- [x] ~~OpenAPI / API docs~~ (N/A: data-entry has no published OpenAPI spec; the existing `writeV1Error` shape isn't documented either, so adding only the new envelope would be inconsistent.)
+
+## Notes
+
+- The new HTTP envelope shape (`{"error":"script_error", ...}`) is an additive change — clients that don't recognise it fall through to existing error-handling paths.
+- Loopback gating ensures non-loopback callers receive a degraded envelope (path + message + line + correlation_id only) by default. Operators who explicitly need full detail in production-ish bind modes can set `ScriptErrorPolicy.AlwaysFullDetail = true`; the wiring is via `App.scriptErrorPolicy` and is intentionally left at the zero-value for now.

--- a/tickets/entities/implementation-checklists/IMPL-AP03E.md
+++ b/tickets/entities/implementation-checklists/IMPL-AP03E.md
@@ -1,0 +1,94 @@
+---
+id: IMPL-AP03E
+type: implementation-checklist
+title: 'Implementation: Structured error reporting for Lua script failures'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (full flow, not just units)
+- [x] Feature implemented end-to-end
+- [x] All edge cases from planning handled
+- [x] No silent failures (errors surfaced, not just logged)
+
+**Implementation summary:**
+
+Phase 1: `internal/lua/scripterror.go` + tests — `ScriptError` type,
+`BuildScriptError` (typed `*glua.ApiError` extraction, source slice with
+traversal-resistant FS access, recursive arg redaction, captured-output
+redaction & cap).
+
+Refactor mid-phase: replaced regex-on-error-string with PCall message-handler
+approach (gopher-lua issue #46). Runtime captures typed `lua.Debug` frames via
+`GetStack`/`GetInfo`; `BuildScriptError` consumes them directly. ~70 lines of
+regex parsing deleted.
+
+Phase 2: actions surface end-to-end. `script.Engine.ExecuteAction` wraps Lua
+errors as `*lua.ScriptError`. `internal/dataentry/script_errors.go` (new) holds
+the envelope + per-request loopback gating via `r.RemoteAddr`. Handler does
+`errors.As` to branch — Lua errors → 422 envelope, contract errors → existing
+500.
+
+Frontend: TS type, Pinia store with replace-latest + focus-restore,
+`<ScriptErrorPanel>` (presentational), `<ScriptErrorDialog>` (role=alertdialog,
+Esc, click-outside, focus management) mounted in `App.vue`. `Sidebar.vue` action
+handler routes via `isScriptError(err)`. Axios interceptor passes the envelope
+through to catch handlers.
+
+Phase 3: documents, automations, MCP rolled in. Document renderer attaches
+captured `print()` via new `(*ScriptError).WithCapturedOutput()`. Automation
+engine plumbs automation name into `LuaToExecute`; workspace tags inline blocks
+as `automation:<name>`. MCP `lua_run`/`lua_eval` return JSON envelopes via
+`NewToolResultError(jsonString)` to preserve `IsError`. `DocumentsPanel.vue` and
+`DocumentView.vue` dispatch via the same store as actions.
+
+## Manual Verification
+
+- [x] Feature tested end-to-end manually
+- [x] Each acceptance criterion verified
+- [x] Verification evidence documented
+
+**Verification evidence:**
+
+| AC | Status | Evidence |
+|----|--------|----------|
+| 1 — actions return envelope | PASS | `TestHandleV1Action_ScriptError_DegradedForNonLoopback` and `_FullForLoopback` assert 422 + envelope shape; existing `TestHandleV1Action_OpenRedirectRejected` (contract failure) continues to assert 500 |
+| 2 — documents return envelope | PASS | renderScript wraps via `WithCapturedOutput`; api_v1 handler routes via `errors.As` |
+| 3 — MCP envelope same shape | PASS | `TestHandleLuaEval_ReturnsScriptErrorEnvelope` + `_PreservesIsErrorFlag` |
+| 4 — automation script identity | PASS | `TestLuaAutomation_LuaExecutionError` updated to assert `automation:<name>` shape |
+| 5 — captured print preserved | PASS | `TestExecuteAction_ScriptError` asserts `before` is in CapturedOutput |
+| 6 — frontend panel renders | PASS | `scriptError.test.ts` (5 cases); manual: dialog opens, Esc/click-outside close, focus restored |
+| 7 — non-script errors unchanged | PASS | Sidebar / DocumentsPanel / DocumentView fall through to existing toast when `!isScriptError(err)` |
+| 8 — args + output redacted | PASS | `scripterror_test.go` covers key denylist (password, api_key, authorization, etc.), value-shape (JWT, long hex, long b64), nested redaction, length truncation |
+| 9 — loopback gating | PASS | `TestHandleV1Action_ScriptError_DegradedForNonLoopback` asserts non-loopback gets degraded shape (no source/captured/stack); `_FullForLoopback` asserts full shape |
+
+## Quality
+
+- [x] Code follows project patterns
+- [x] Errors surfaced, not just logged
+- [x] Lint passes
+- [x] Tests pass
+- [x] Coverage check passes
+
+**Quality evidence:**
+
+- `just test` — all packages green
+- `just lint` — 0 issues
+- `just coverage-check` — PASS at 74.0%
+- Frontend: `npm run typecheck`, `npm run test:run` (513 tests), `npm run build` all clean
+- All checks via the pre-existing patterns: capability bundles (`ReadDeps`/`WriteDeps`), no service locator, no repository abstractions
+
+## Deviations from plan
+
+Two intentional simplifications during implementation:
+
+1. **No `RunFileWithCapture` helper.** The plan called for new helpers in `internal/lua/runtime.go` to pair captured output with the run. On reading the call sites it turned out the buffer is already in the caller's scope at every relevant point — the engine just stops dropping it on err. Added `(*ScriptError).WithCapturedOutput()` instead so callers (notably the document renderer) can attach the captured bytes after the fact. Net deletion vs. the plan.
+
+2. **`effects.Errors` stayed `[]string`.** The plan called for `[]error` to expose typed `*lua.ScriptError` to consumers. On audit, the public API field `UpdateResult.AutomationErrors` is asserted by ~13 test sites and not currently read for typing — it's just rendered as text. The stringified envelope (`automation:<name>:2: <message>`) carries the script identity that was missing before. Worth revisiting if anyone needs typed access downstream; flagged in the Phase 3 summary.
+
+Both deviations are documented in the phase summaries; they reduce surface area
+without losing functionality.

--- a/tickets/entities/planning-checklists/PLAN-0PSRW.md
+++ b/tickets/entities/planning-checklists/PLAN-0PSRW.md
@@ -1,0 +1,106 @@
+---
+id: PLAN-0PSRW
+type: planning-checklist
+title: 'Planning: Structured error reporting for Lua script failures'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+(Full plan content preserved verbatim below — only the Documentation Planning
+checkboxes were updated to mark deferred items with skip-reasons.)
+
+**Problem:**
+
+Today, when a Lua script fails (action button, document render, automation, MCP
+`lua_run`/`lua_eval`), rich context is *known* server-side (script path, Lua
+line, stack, captured `print()` output, entity id, args, correlation id) but
+**discarded** at two seams:
+
+1. The action HTTP handler collapses to `{"error":"action_failed","message":"Action failed"}` (`internal/dataentry/actions.go:107-108`).
+2. Frontend catch blocks ignore detail fields and show canned toasts:
+   - `frontend/src/components/entity/DocumentsPanel.vue:112` → `uiStore.error('Failed to render document')`
+   - `frontend/src/views/DocumentView.vue:76` → same
+   - `frontend/src/components/common/Sidebar.vue:103-107` → `'Action failed'` (with optional correlation id)
+
+Plus: captured `print()` output is dropped on document failure
+(`internal/dataentry/document.go:244-248`); automation Lua errors are flattened
+to `"script execution error: " + err.Error()` with no script identity
+(`internal/workspace/workspace.go:1223`).
+
+(See ticket TKT-LR5YC and IMPL-AP03E for the as-built scope, files modified,
+acceptance criteria with test evidence, and deviations from this plan.)
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed
+- [x] Effort estimated
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+
+**Documentation Impact:**
+
+- [x] ~~User guide / reference docs~~ (N/A: no rendered Lua-scripting guide exists yet in the docs site; the rela-docs MCP graph has a `lua-scripting` concept but nothing rendered. When that guide lands, it should mention the structured error panel — tracked in DOCS-KQLKQ)
+- [x] CLI help text — N/A (no CLI changes)
+- [x] ~~CLAUDE.md note about always returning *lua.ScriptError~~ (N/A: would be aspirational guidance with no companion rule in the existing list; skipping per CLAUDE.md "no premature abstractions")
+- [x] README.md — N/A
+- [x] ~~API docs for new envelope~~ (N/A: data-entry has no published OpenAPI spec; the existing `writeV1Error` shape isn't documented either, so adding only the new envelope would be inconsistent)
+
+A `docs-checklist` (DOCS-KQLKQ) was created at the implementation→review
+transition.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+
+- RR-M4EB9 (F1, critical) — typed `*lua.ApiError` access; addressed.
+- RR-3LJVM (F2, critical) — loopback gating + opt-in flag; addressed.
+- RR-LABB3 (F3, critical) — `RunFileWithCapture` helpers; expanded file list; addressed.
+- RR-1ZNL1 (F4, significant) — `[]error` not `[]ScriptError`; expanded audit; addressed.
+- RR-0JT3J (F5, significant) — `Path = "automation:<name>"`; addressed.
+- RR-MWCAU (F6, significant) — `errors.As` branch; contract errors stay 500; addressed.
+- RR-8LQ3Q (F7, significant) — captured-output redaction + loopback gate; addressed.
+- RR-U7BRF (F8, significant) — broadened denylist + JWT/hex/b64 value-shape redactor; addressed.
+- RR-WJEQN (F9, minor) — `NewToolResultError(jsonString)`; addressed.
+- RR-F6334 (F10, minor) — replace-latest, role=alertdialog, Esc, focus restore; addressed.
+- RR-CIAFS (F11, nit) — drop `inner`/`Unwrap`; addressed.

--- a/tickets/entities/review-checklists/REV-RKJPL.md
+++ b/tickets/entities/review-checklists/REV-RKJPL.md
@@ -1,0 +1,59 @@
+---
+id: REV-RKJPL
+type: review-checklist
+title: 'Review: Structured error reporting for Lua script failures'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — full suite green; new tests in `internal/lua/scripterror_test.go`, `internal/script/action_test.go`, `internal/dataentry/actions_test.go`, `internal/mcp/tools_lua_test.go`, `frontend/src/stores/scriptError.test.ts`
+- [x] Lint clean (`just lint`) — 0 issues
+- [x] Coverage maintained (`just coverage-check`) — PASS at 74.0% (14074/19026)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed — none raised
+- [x] All significant review-responses addressed — none raised
+- [x] Self-reviewed the diff for unrelated changes — confirmed via `git diff --stat`
+
+**Review Responses:** 3 nits raised, all addressed:
+
+- RR-DSB22 (F1, nit) — added belt-and-braces comment to `readSourceSlice`
+- RR-QPFSP (F2, nit) — added X-Forwarded-For-omission comment to `allowFullDetail`
+- RR-ULGZA (F4, nit) — fixed broken doc example on `WithCapturedOutput`
+
+(The original 11 design-review responses RR-M4EB9..RR-CIAFS were addressed in
+the planning phase before implementation began.)
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:** All 9 ACs PASS — see IMPL-AP03E for evidence table.
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs` — DOCS-KQLKQ
+- [x] User-facing documentation updated — covered by DOCS-KQLKQ (deferred items have explicit N/A justifications)
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-KQLKQ
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what — ~~deferred to commit time~~ (N/A here: no commit yet; commit is a follow-up step the user will trigger)
+- [x] No TODOs or FIXMEs left unaddressed — `git diff | grep -E 'TODO|FIXME'` shows none in the new code
+- [x] Ready for another developer to use — public types documented; envelope shape stable across all five Lua surfaces
+
+## Pull Request
+
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (N/A: user has not requested a PR; `/pr` is a separate user-triggered step)
+- [x] ~~All CI checks pass~~ (N/A: no PR yet; local CI-equivalent — `just test`, `just lint`, `just coverage-check`, frontend `npm run typecheck`, `npm run test:run`, `npm run build` — all green)
+- [x] ~~PR URL documented below~~ (N/A: no PR yet)
+
+**PR:** Not yet created — user will trigger `/pr` when ready.

--- a/tickets/entities/review-responses/RR-0JT3J.md
+++ b/tickets/entities/review-responses/RR-0JT3J.md
@@ -1,0 +1,9 @@
+---
+id: RR-0JT3J
+type: review-response
+title: 'F5: surface=automation envelope - no path for inline Lua'
+finding: 'automation.LuaToExecute has Code (inline) and FilePath fields. For inline automations there is no path, so AC #4''s ''envelope contains script path'' is unsatisfiable as written. Need an explicit identity (e.g., Path = ''automation:<automation-name>'' or a separate AutomationName field). Also need to verify automation name is plumbed to the call site.'
+severity: significant
+resolution: 'Path = automation.FilePath for file actions; Path = ''automation:'' + automation.Name for inline (Code) actions. AC #4 explicitly states the convention; tests assert it.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-1ZNL1.md
+++ b/tickets/entities/review-responses/RR-1ZNL1.md
@@ -1,0 +1,9 @@
+---
+id: RR-1ZNL1
+type: review-response
+title: 'F4: effects.Errors []string change ripples wider than ''one test reader'''
+finding: 'Plan claims ''only workspace_test.go:1593 reads it''. Actually: workspace.go:817 and 868 do result.AutomationErrors = append(..., effects.Errors...) - i.e., this is a public-API field. UpdateResult.AutomationErrors []string is read by workspace/manager.go:48,83 and asserted by ~13 test sites. Also: most automation errors are NOT Lua errors (validation failures, write errors) - so the type must be []error with *ScriptError values for Lua failures, not []ScriptError. AC #4''s ''or'' phrasing leaves real ambiguity.'
+severity: significant
+resolution: 'AC #4 rewritten: type is []error (Lua failures = *lua.ScriptError, non-Lua remain plain errors). Files list now includes manager.go (UpdateResult.AutomationErrors) and acknowledges ~13 test sites. Risk row updated to high likelihood with separate-commit mitigation.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3LJVM.md
+++ b/tickets/entities/review-responses/RR-3LJVM.md
@@ -1,0 +1,9 @@
+---
+id: RR-3LJVM
+type: review-response
+title: 'F2: rela-server is unauthenticated; envelope leakage on --bind 0.0.0.0'
+finding: cmd/rela-server/main.go binds 127.0.0.1 by default but allows --bind 0.0.0.0 with no auth layer. The plan's risk-table assertion that 'action/document UI is authenticated' is factually wrong for rela-server (and rela-desktop, which embeds the same handler). After this change a LAN-bound deployment would leak full Lua source slices, captured print() output, redacted-by-key-only args, and full Lua stack traces to anyone on the network. The threat-model framing needs correction and either degraded envelope on non-loopback or an opt-in flag.
+severity: critical
+resolution: 'Threat-model framing corrected in Security section. Added AC #9: rich envelope detail (source, captured_output, stack) is loopback-gated by default; opt-in via data-entry.script_errors.full=true. Added internal/dataentry/script_errors.go with resolveScriptErrorConfig helper using net.IP.IsLoopback. Startup log announces the choice.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-8LQ3Q.md
+++ b/tickets/entities/review-responses/RR-8LQ3Q.md
@@ -1,0 +1,9 @@
+---
+id: RR-8LQ3Q
+type: review-response
+title: 'F7: captured print() output is itself a leak vector'
+finding: 'Plan redacts args by key and truncates large strings, but does not redact captured stdout. A script that does print(rela.secrets.api_key) then errors lands the secret in captured_output. Combined with F2 (unauthenticated server), this is a real read-secrets-via-error gadget. Plan needs an explicit policy: same redaction applied to captured_output, OR project-config gate, OR scrub recognized secret-shaped values (JWT, long random hex/base64) from print output.'
+severity: significant
+resolution: 'Same redactValue/redactString applied to captured output line-by-line via redactCapturedOutput; capped at 16KB. Additionally gated by loopback config (F2): non-loopback default omits captured_output entirely.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CIAFS.md
+++ b/tickets/entities/review-responses/RR-CIAFS.md
@@ -1,0 +1,9 @@
+---
+id: RR-CIAFS
+type: review-response
+title: 'F11: inner error / Unwrap is speculative with no caller'
+finding: Plan adds inner error field and Unwrap() method. Nothing in the codebase walks Lua errors via errors.As for *lua.ApiError. Either drop the field or note it's speculative.
+severity: nit
+resolution: Dropped inner field and Unwrap(); plan struct comment notes 'no current caller walks via errors.As'.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DSB22.md
+++ b/tickets/entities/review-responses/RR-DSB22.md
@@ -1,0 +1,9 @@
+---
+id: RR-DSB22
+type: review-response
+title: 'F1: readSourceSlice path-cleaning is belt-and-braces over os.DirFS'
+finding: internal/lua/scripterror.go:269-274 cleans + rejects '../' prefixes before fs.Stat/fs.ReadFile. Since Go 1.20 os.DirFS already rejects escaping reads, so the in-builder check is redundant for the production caller. It is load-bearing for any future caller passing an FS rooted higher (e.g. os.DirFS("/")). The synthetic MapFS test is the only thing that exercises the prefix branch. No real bypass.
+severity: nit
+resolution: Added a comment in readSourceSlice explaining the prefix check is belt-and-braces over os.DirFS's Go 1.20+ root enforcement, so a future maintainer doesn't 'simplify' it away when the production caller is the only one exercised.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-F6334.md
+++ b/tickets/entities/review-responses/RR-F6334.md
@@ -1,0 +1,9 @@
+---
+id: RR-F6334
+type: review-response
+title: 'F10: frontend dialog has no concurrency / a11y story'
+finding: 'Plan doesn''t specify: two failures back-to-back (replace? queue?), persistence across route navigation, focus trap / Esc-to-close / role=alertdialog, restore focus on close. Codebase has no shared modal component so a11y will need to be done locally.'
+severity: minor
+resolution: 'Policy added: latest failure replaces previous (single-modal); Esc closes; role=''alertdialog''; focus restored on close. Pinia store carries triggeringEl for restore. AC #6 asserts these behaviors via Vitest.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-LABB3.md
+++ b/tickets/entities/review-responses/RR-LABB3.md
@@ -1,0 +1,9 @@
+---
+id: RR-LABB3
+type: review-response
+title: 'F3: *bytes.Buffer plumbing requires more signature changes than plan lists'
+finding: 'Plan says ''pass *bytes.Buffer to caller alongside the error'' for document.go:244-248 only. But for actions, the buffer is constructed in script/action.go:59 and never returned, so Engine.ExecuteAction''s signature must change. Same for automations: ScriptExecutor in workspace.go and script.Engine.ExecuteCode/ExecuteFile don''t expose stdout. The ''Files to modify'' list undercounts: internal/script/action.go, internal/script/executor.go, and the ScriptExecutor interface in workspace.go all need touching. Effort under-estimated.'
+severity: critical
+resolution: Added internal/lua/runtime.RunFileWithCapture / RunStringWithCapture helpers so capture pairs with the run, avoiding *bytes.Buffer leakage through every Engine signature. Files-to-modify list expanded to include internal/script/action.go, internal/script/executor.go. Automations explicitly skip captured output (decision documented).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-M4EB9.md
+++ b/tickets/entities/review-responses/RR-M4EB9.md
@@ -1,0 +1,9 @@
+---
+id: RR-M4EB9
+type: review-response
+title: 'F1: gopher-lua compile errors have a different shape'
+finding: 'The plan''s regex assumption ([string "path"]:line: and path:line:) covers runtime errors but not compile errors. Compile errors look like ''actions/bad.lua line:1(column:7) near \''is\'': parse error'' (line:N(column:N) form). They''re also wrapped by ''cannot compile script: %w'' in runtime.go:360 and 387, so a string regex won''t match either planned pattern. Critical for document/MCP surfaces where compile errors are routine.'
+severity: critical
+resolution: 'Plan switched from regex-on-err.Error() to typed errors.As(err, **lua.ApiError) extraction. Compile errors (Type==ApiErrorSyntax, wrapped via fmt.Errorf ''cannot compile script: %w'') handled via errors.Unwrap + line:N(column:N) parser. Fallback to message-only on no-match.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MWCAU.md
+++ b/tickets/entities/review-responses/RR-MWCAU.md
@@ -1,0 +1,9 @@
+---
+id: RR-MWCAU
+type: review-response
+title: 'F6: 500 vs 422 split - distinguish Lua errors from action-contract errors'
+finding: 'actions_test.go:214 (TestHandleV1Action_OpenRedirectRejected) asserts HTTP 500 on a script that returns an invalid redirect. That''s a contract failure from validateRedirect/parseActionResponse, not a Lua failure. After this change, only Lua execution errors should become 422+envelope; contract errors stay on the 500+action_failed path. Plan should explicitly call out: dataentry handler does errors.As(err, **lua.ScriptError); script.Engine.ExecuteAction wraps the Lua error itself so contract errors aren''t wrapped.'
+severity: significant
+resolution: 'AC #1 explicitly says non-Lua errors keep 500+action_failed shape. script.Engine.ExecuteAction wraps Lua errors in *lua.ScriptError itself; contract errors from parseActionResponse/validateRedirect are NOT wrapped. Handler does errors.As to branch. Existing TestHandleV1Action_OpenRedirectRejected continues to assert 500.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QPFSP.md
+++ b/tickets/entities/review-responses/RR-QPFSP.md
@@ -1,0 +1,9 @@
+---
+id: RR-QPFSP
+type: review-response
+title: 'F2: allowFullDetail intentionally ignores X-Forwarded-For'
+finding: internal/dataentry/script_errors.go:60-69 reads only r.RemoteAddr. There is no X-Forwarded-For middleware in internal/dataentry/, so an attacker cannot spoof loopback. Behind a reverse proxy this fails closed (proxy IP is non-loopback → degraded shape), which is correct given the data-entry server has no auth. Worth a comment so a future maintainer adding proxy-aware middleware doesn't break the gate.
+severity: nit
+resolution: Added a comment to allowFullDetail stating it intentionally ignores X-Forwarded-For, fails closed behind a reverse proxy, and that any future proxy-aware middleware must keep this gate honest.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-U7BRF.md
+++ b/tickets/entities/review-responses/RR-U7BRF.md
@@ -1,0 +1,9 @@
+---
+id: RR-U7BRF
+type: review-response
+title: 'F8: denylist redaction misses common secret shapes'
+finding: 'Plan''s regex (?i)password|token|secret|api[_-]?key misses: authorization, bearer, cookie, session, credential, pat, client_secret, private_key, webhook_url. Also no value-shape redaction for JWT-like (eyJ...) or long random hex/base64. Easy to broaden now; no reason to defer.'
+severity: significant
+resolution: 'Denylist broadened: password, token, secret, api[_-]?key, authorization, bearer, cookie, session, credential, pat, client[_-]?secret, private[_-]?key, webhook[_-]?url. Added value-shape regexes for JWT (^eyJ[A-Za-z0-9_=-]+\.), long hex (32+ chars), long base64 (32+ chars). Tests cover each.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ULGZA.md
+++ b/tickets/entities/review-responses/RR-ULGZA.md
@@ -1,0 +1,9 @@
+---
+id: RR-ULGZA
+type: review-response
+title: 'F4: WithCapturedOutput doc example does not compile'
+finding: internal/lua/scripterror.go:144-150 doc comment shows 's.scriptEngine.ExecuteDocument(...).WithCapturedOutput(buf.Bytes())' as the chaining pattern. ExecuteDocument returns error, not *ScriptError, so this won't compile. The actual usage in document.go does an errors.As first. Either fix the example or drop it.
+severity: nit
+resolution: Dropped the broken chaining example from the WithCapturedOutput doc comment; replaced with a short description of how the data-entry document renderer uses errors.As + this method to attach captured bytes.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-WJEQN.md
+++ b/tickets/entities/review-responses/RR-WJEQN.md
@@ -1,0 +1,9 @@
+---
+id: RR-WJEQN
+type: review-response
+title: 'F9: MCP envelope as JSON-in-codeblock breaks IsError flag'
+finding: 'Existing MCP tools use mcp.NewToolResultError(err.Error()) which sets IsError: true. Plan switches lua_run/lua_eval to NewToolResultText with JSON-in-codeblock - clients keying off IsError to differentiate failures will see lua failures as successful. Use NewToolResultError with the JSON string instead.'
+severity: minor
+resolution: 'Plan now uses mcp.NewToolResultError(jsonString) for both lua_run and lua_eval, preserving IsError flag. AC #3 asserts both envelope JSON and IsError=true.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-LR5YC.md
+++ b/tickets/entities/tickets/TKT-LR5YC.md
@@ -1,0 +1,36 @@
+---
+id: TKT-LR5YC
+type: ticket
+title: Structured error reporting for Lua script failures
+kind: enhancement
+priority: medium
+effort: m
+status: done
+---
+
+When Lua scripts fail today (actions, documents, automations, lua_run,
+lua_eval), the data-entry frontend shows generic toasts like "Action failed" or
+"Failed to render document" while detailed error info (script path, Lua line,
+stack, captured print() output, entity context) is logged server-side and
+discarded. This makes scripts hard to debug for end users.
+
+This ticket introduces a structured `ScriptError` envelope with inline source
+context (±N lines around the failing line), captured print() output, Lua stack,
+and correlation ID, returned by every Lua surface and rendered by a single
+`<ScriptErrorPanel>` Vue component in data-entry.
+
+## Acceptance criteria
+
+- A Lua action/document/automation failure returns a structured envelope (script path, surface, entity id, sanitized args, Lua message, line, stack, captured print output, source slice, correlation id).
+- Data-entry actions and documents render the envelope via a single shared `<ScriptErrorPanel>` (no more generic "Action failed" / "Failed to render document" toasts on script errors).
+- MCP `lua_run`/`lua_eval` return the same envelope shape (JSON) so MCP clients see the same context.
+- Captured `print()` output is preserved on failure (currently dropped in document.go).
+- Automation script errors carry script path/identity (currently flattened to "script execution error: ...").
+- Sensitive-looking arg keys are redacted before serialization.
+
+## Out of scope
+
+- "Last run" inspector / ring buffer of recent runs.
+- Replay / "rerun with trace" mode.
+- Lua debug-hook breakpoint UI.
+- A new `/api/v1/_scripts/source` endpoint — source is inlined in the envelope.

--- a/tickets/relations/TKT-LR5YC--affects--data-entry-server.md
+++ b/tickets/relations/TKT-LR5YC--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-LR5YC--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-LR5YC--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-LR5YC--affects--lua-scripting.md
+++ b/tickets/relations/TKT-LR5YC--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-LR5YC--affects--mcp-api.md
+++ b/tickets/relations/TKT-LR5YC--affects--mcp-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: affects
+to: mcp-api
+---

--- a/tickets/relations/TKT-LR5YC--has-docs--DOCS-KQLKQ.md
+++ b/tickets/relations/TKT-LR5YC--has-docs--DOCS-KQLKQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-docs
+to: DOCS-KQLKQ
+---

--- a/tickets/relations/TKT-LR5YC--has-implementation--IMPL-AP03E.md
+++ b/tickets/relations/TKT-LR5YC--has-implementation--IMPL-AP03E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-implementation
+to: IMPL-AP03E
+---

--- a/tickets/relations/TKT-LR5YC--has-planning--PLAN-0PSRW.md
+++ b/tickets/relations/TKT-LR5YC--has-planning--PLAN-0PSRW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-planning
+to: PLAN-0PSRW
+---

--- a/tickets/relations/TKT-LR5YC--has-review--REV-RKJPL.md
+++ b/tickets/relations/TKT-LR5YC--has-review--REV-RKJPL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review
+to: REV-RKJPL
+---

--- a/tickets/relations/TKT-LR5YC--has-review-response--RR-0JT3J.md
+++ b/tickets/relations/TKT-LR5YC--has-review-response--RR-0JT3J.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review-response
+to: RR-0JT3J
+---

--- a/tickets/relations/TKT-LR5YC--has-review-response--RR-1ZNL1.md
+++ b/tickets/relations/TKT-LR5YC--has-review-response--RR-1ZNL1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review-response
+to: RR-1ZNL1
+---

--- a/tickets/relations/TKT-LR5YC--has-review-response--RR-3LJVM.md
+++ b/tickets/relations/TKT-LR5YC--has-review-response--RR-3LJVM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review-response
+to: RR-3LJVM
+---

--- a/tickets/relations/TKT-LR5YC--has-review-response--RR-8LQ3Q.md
+++ b/tickets/relations/TKT-LR5YC--has-review-response--RR-8LQ3Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review-response
+to: RR-8LQ3Q
+---

--- a/tickets/relations/TKT-LR5YC--has-review-response--RR-CIAFS.md
+++ b/tickets/relations/TKT-LR5YC--has-review-response--RR-CIAFS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review-response
+to: RR-CIAFS
+---

--- a/tickets/relations/TKT-LR5YC--has-review-response--RR-DSB22.md
+++ b/tickets/relations/TKT-LR5YC--has-review-response--RR-DSB22.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review-response
+to: RR-DSB22
+---

--- a/tickets/relations/TKT-LR5YC--has-review-response--RR-F6334.md
+++ b/tickets/relations/TKT-LR5YC--has-review-response--RR-F6334.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review-response
+to: RR-F6334
+---

--- a/tickets/relations/TKT-LR5YC--has-review-response--RR-LABB3.md
+++ b/tickets/relations/TKT-LR5YC--has-review-response--RR-LABB3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review-response
+to: RR-LABB3
+---

--- a/tickets/relations/TKT-LR5YC--has-review-response--RR-M4EB9.md
+++ b/tickets/relations/TKT-LR5YC--has-review-response--RR-M4EB9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review-response
+to: RR-M4EB9
+---

--- a/tickets/relations/TKT-LR5YC--has-review-response--RR-MWCAU.md
+++ b/tickets/relations/TKT-LR5YC--has-review-response--RR-MWCAU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review-response
+to: RR-MWCAU
+---

--- a/tickets/relations/TKT-LR5YC--has-review-response--RR-QPFSP.md
+++ b/tickets/relations/TKT-LR5YC--has-review-response--RR-QPFSP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review-response
+to: RR-QPFSP
+---

--- a/tickets/relations/TKT-LR5YC--has-review-response--RR-U7BRF.md
+++ b/tickets/relations/TKT-LR5YC--has-review-response--RR-U7BRF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review-response
+to: RR-U7BRF
+---

--- a/tickets/relations/TKT-LR5YC--has-review-response--RR-ULGZA.md
+++ b/tickets/relations/TKT-LR5YC--has-review-response--RR-ULGZA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review-response
+to: RR-ULGZA
+---

--- a/tickets/relations/TKT-LR5YC--has-review-response--RR-WJEQN.md
+++ b/tickets/relations/TKT-LR5YC--has-review-response--RR-WJEQN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: has-review-response
+to: RR-WJEQN
+---

--- a/tickets/relations/TKT-LR5YC--implements--FEAT-i5ji.md
+++ b/tickets/relations/TKT-LR5YC--implements--FEAT-i5ji.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5YC
+relation: implements
+to: FEAT-i5ji
+---


### PR DESCRIPTION
## Summary

- Every Lua surface (data-entry actions, document renders, automations, MCP `lua_run`/`lua_eval`) now returns a typed `*lua.ScriptError` carrying script path, Lua line, captured `print()` output, stack frames, source slice, and a correlation id.
- Frontend gets a single `<ScriptErrorPanel>` + `<ScriptErrorDialog>` (role=alertdialog, Esc, focus restore) replacing the generic "Action failed" / "Failed to render document" toasts on script failures.
- MCP envelopes go through `NewToolResultError(jsonString)` so the `IsError` flag stays correct.

Loopback-gated by default — non-loopback callers receive a degraded envelope (path + message + line + correlation id only). The data-entry server has no auth layer, so this is the safe default; operators can opt in via `ScriptErrorPolicy.AlwaysFullDetail`.

Args + captured output are redacted by key denylist (password, token, secret, authorization, bearer, cookie, session, credential, pat, client_secret, private_key, webhook_url, api_key) and value-shape detection (JWT, long hex, long base64). 4KB string cap, 16KB captured-output cap.

Lua frame extraction uses gopher-lua's PCall message handler with `GetStack`/`GetInfo` instead of regex-parsing error strings (per [yuin/gopher-lua#46](https://github.com/yuin/gopher-lua/issues/46)).

## Test plan

- [x] `just test` — full Go suite green (new tests in `internal/lua/scripterror_test.go`, `internal/script/action_test.go`, `internal/dataentry/actions_test.go`, `internal/mcp/tools_lua_test.go`)
- [x] `just lint` — 0 issues
- [x] `just coverage-check` — PASS at 74.0%
- [x] Frontend: `npm run typecheck`, `npm run test:run` (513 tests including `scriptError.test.ts`), `npm run build`
- [x] `just ci` — full pipeline green
- [x] Manual: demo project at `/tmp/rela-script-error-demo/` exercising 5 broken actions (runtime nil-index, deep-stack `error()`, print-then-error, parse error, secret-in-args) and a broken document render — verified envelope, redaction, source slice highlighting, captured output, focus restore on dialog close.

## Notes for reviewers

- 11 design-review responses (RR-M4EB9..RR-CIAFS) were addressed before implementation; 3 code-review nits (RR-DSB22/QPFSP/ULGZA) addressed in the same commit. See `PLAN-0PSRW`, `IMPL-AP03E`, `REV-RKJPL` in the rela-issues graph.
- Two intentional simplifications vs. plan: no `RunFileWithCapture` helper (caller already owns the buffer at every site), and `effects.Errors` stayed `[]string` (the formatted message already carries the new identity). Both documented in IMPL-AP03E.