### PR TITLE
ci(dependabot): exclude majors from groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,15 @@ updates:
         patterns:
           - "github.com/charmbracelet/*"
           - "github.com/muesli/*"
+        update-types:
+          - "minor"
+          - "patch"
       golang-org:
         patterns:
           - "golang.org/x/*"
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "deps"
 
@@ -46,6 +52,10 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 14
+    # Groups bundle minor+patch only. Majors fall out as individual PRs
+    # so a single breaking upgrade can't block the safe ones in its group.
+    # Auto-merge is unconditional on green CI, so each PR (group or
+    # singleton) merges itself the moment its checks pass.
     groups:
       vue-ecosystem:
         patterns:
@@ -55,6 +65,9 @@ updates:
           - "@vitejs/*"
           - "pinia"
           - "@pinia/*"
+        update-types:
+          - "minor"
+          - "patch"
       build-tooling:
         patterns:
           - "vite"
@@ -63,6 +76,9 @@ updates:
           - "typescript-*"
           - "tsx"
           - "vue-tsc"
+        update-types:
+          - "minor"
+          - "patch"
       lint-and-format:
         patterns:
           - "eslint"
@@ -71,6 +87,9 @@ updates:
           - "prettier"
           - "prettier-*"
           - "jscpd"
+        update-types:
+          - "minor"
+          - "patch"
       testing:
         patterns:
           - "vitest"
@@ -79,6 +98,9 @@ updates:
           - "happy-dom"
           - "fast-check"
           - "@playwright/*"
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "deps(frontend)"
 
@@ -94,5 +116,8 @@ updates:
         patterns:
           - "@playwright/*"
           - "playwright"
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "deps(e2e)"


### PR DESCRIPTION
## Summary

- Adds `update-types: ["minor", "patch"]` to every group in `.github/dependabot.yml`.
- Group PRs now bundle only minor/patch bumps; majors come as individual per-package PRs.

## Why

A single breaking major in a group (e.g. `@vue/tsconfig` 0.5→0.9 in `vue-ecosystem`, or `typescript` 5→6 in `build-tooling`) currently fails `npm ci` for the whole group, blocking the safe minor/patch bumps bundled with it. Splitting majors out lets each PR pass or fail CI on its own merits. Auto-merge is already unconditional on green CI, so every PR that goes green merges itself — no human approval needed.

## Effect on backlog

After the next Dependabot run, the seven currently-failing PRs (#580, #582, #584, #591, #597, #604, #606) will be superseded:
- minor/patch group PRs will go green and auto-merge
- each major bump becomes its own PR — passes that work merge themselves; the genuinely breaking ones (tablewriter v1, typescript 5→6, eslint 9→10) remain visible for migration

## Test plan

- [ ] Dependabot recreates open PRs at the next scheduled run, with majors split out
- [ ] At least one minor/patch group PR auto-merges without intervention