### PR TITLE
feat(data-entry): show ScriptErrorDialog for list-action failures (TKT-P0B8C)

### DIFF
--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -48,7 +48,7 @@ const deleting = ref(false)
 // Selection and actions
 const { selectedIds, toggle: toggleSelection, clear: clearActionSelection, isSelected, selectAll } = useListSelection()
 const hasSelection = computed(() => selectedIds.value.size > 0)
-const pendingAction = ref<{ id: string; config: ActionConfig } | null>(null)
+const pendingAction = ref<{ id: string; config: ActionConfig; triggerEl: HTMLElement | null } | null>(null)
 
 const listIdRef = computed(() => props.listId)
 
@@ -57,8 +57,8 @@ const { resolvedActions, processing: actionProcessing, executeAction, triggerAct
   selectedIds,
   entities,
   onClearSelection: () => clearActionSelection(),
-  onRequestConfirm: (action, actionId) => {
-    pendingAction.value = { id: actionId, config: action }
+  onRequestConfirm: (action, actionId, triggerEl) => {
+    pendingAction.value = { id: actionId, config: action, triggerEl }
   },
   onComplete: () => scheduleFetch(),
 })
@@ -568,7 +568,7 @@ onMounted(() => {
                 :key="id"
                 class="action-header-btn"
                 :disabled="actionProcessing"
-                @click="triggerAction(id, config)"
+                @click="(e) => triggerAction(id, config, e)"
               >
                 <kbd>{{ config.key }}</kbd>
                 {{ config.label }}
@@ -681,7 +681,7 @@ onMounted(() => {
       :title="`${pendingAction?.config.label}?`"
       :confirm-label="pendingAction?.config.label || 'Confirm'"
       :busy="actionProcessing"
-      @confirm="() => { if (pendingAction) { executeAction(pendingAction.id, pendingAction.config); pendingAction = null } }"
+      @confirm="() => { if (pendingAction) { executeAction(pendingAction.id, pendingAction.config, pendingAction.triggerEl); pendingAction = null } }"
       @cancel="pendingAction = null"
     >
       Apply <strong>{{ pendingAction?.config.label }}</strong> to {{ selectedIds.size }} selected entities?

--- a/frontend/src/composables/useListActions.test.ts
+++ b/frontend/src/composables/useListActions.test.ts
@@ -1,0 +1,267 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
+
+import type { ActionConfig, Entity } from '@/types'
+import type { ScriptError } from '@/types/scriptError'
+
+import { useListActions } from './useListActions'
+import { useScriptErrorStore } from '@/stores/scriptError'
+import { useSchemaStore, useUIStore } from '@/stores'
+import { runAction } from '@/api/actions'
+import { updateEntity } from '@/api/entities'
+
+vi.mock('@/api/actions', () => ({ runAction: vi.fn() }))
+vi.mock('@/api/entities', () => ({ updateEntity: vi.fn() }))
+
+function makeScriptError(overrides: Partial<ScriptError> = {}): ScriptError {
+  return {
+    error: 'script_error',
+    correlation_id: 'abc123',
+    script: { surface: 'action', path: 'actions/x.lua' },
+    lua: { message: 'boom', line: 1 },
+    ...overrides,
+  }
+}
+
+interface HarnessOptions {
+  selectedIds?: Set<string>
+  entities?: Entity[]
+  action?: ActionConfig
+  onClearSelection?: () => void
+  onComplete?: () => void
+  onRequestConfirm?: (action: ActionConfig, actionId: string) => void
+}
+
+function mountHarness(opts: HarnessOptions = {}) {
+  const selectedIds = ref(opts.selectedIds ?? new Set<string>())
+  const entities = ref<Entity[]>(opts.entities ?? [])
+  const listId = ref('list-1')
+
+  const Harness = defineComponent({
+    setup() {
+      return useListActions({
+        listId,
+        selectedIds,
+        entities,
+        onClearSelection: opts.onClearSelection ?? (() => {}),
+        onRequestConfirm: opts.onRequestConfirm ?? (() => {}),
+        onComplete: opts.onComplete ?? (() => {}),
+      })
+    },
+    template: '<div/>',
+  })
+
+  const wrapper = mount(Harness)
+  return { wrapper, selectedIds, entities }
+}
+
+function configureSchema(action: ActionConfig, actionId = 'act-1') {
+  const schemaStore = useSchemaStore()
+  // Cast through unknown: the test only uses `entity` and `actions`; the
+  // production ListConfig type pulls in many required column fields we
+  // don't need to populate for these unit tests.
+  schemaStore.lists.set('list-1', {
+    id: 'list-1',
+    entity: 'task',
+    actions: [actionId],
+    columns: [],
+  } as unknown as Parameters<typeof schemaStore.lists.set>[1])
+  schemaStore.actions.set(actionId, action)
+}
+
+function ent(id: string): Entity {
+  return { id, type: 'task', properties: {} }
+}
+
+describe('useListActions — script error dispatch', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    // resetAllMocks (not clearAllMocks) drops queued mockReturn-/Resolved-/RejectedValue
+    // setups too, so a default added by a future test can't bleed across cases.
+    vi.resetAllMocks()
+  })
+
+  it('opens the script-error dialog when one rejection is a ScriptError', async () => {
+    const action: ActionConfig = { label: 'Run', key: 'r' }
+    configureSchema(action)
+
+    const err = makeScriptError({ correlation_id: 'first' })
+    vi.mocked(runAction).mockRejectedValueOnce(err).mockResolvedValueOnce(null)
+
+    const { wrapper } = mountHarness({
+      selectedIds: new Set(['t1', 't2']),
+      entities: [
+        ent('t1'),
+        ent('t2'),
+      ],
+    })
+
+    const showSpy = vi.spyOn(useScriptErrorStore(), 'show')
+    const errorSpy = vi.spyOn(useUIStore(), 'error')
+
+    const { executeAction } = wrapper.vm as unknown as ReturnType<typeof useListActions>
+    await executeAction('act-1', action)
+
+    expect(showSpy).toHaveBeenCalledTimes(1)
+    expect(showSpy.mock.calls[0]?.[0]).toBe(err)
+    // No triggerEl supplied → store is called with explicit null, never
+    // undefined. The store guards against undefined too, but the wire
+    // contract is null and tests should pin it down.
+    expect(showSpy.mock.calls[0]?.[1]).toBeNull()
+    expect(errorSpy).toHaveBeenCalledWith('Run: 1 failed, 1 succeeded')
+  })
+
+  it('shows only the first ScriptError when multiple rejections are script errors', async () => {
+    const action: ActionConfig = { label: 'Run', key: 'r' }
+    configureSchema(action)
+
+    const first = makeScriptError({ correlation_id: 'first' })
+    const second = makeScriptError({ correlation_id: 'second' })
+    vi.mocked(runAction).mockRejectedValueOnce(first).mockRejectedValueOnce(second)
+
+    const { wrapper } = mountHarness({
+      selectedIds: new Set(['t1', 't2']),
+      entities: [
+        ent('t1'),
+        ent('t2'),
+      ],
+    })
+
+    const showSpy = vi.spyOn(useScriptErrorStore(), 'show')
+
+    const { executeAction } = wrapper.vm as unknown as ReturnType<typeof useListActions>
+    await executeAction('act-1', action)
+
+    expect(showSpy).toHaveBeenCalledTimes(1)
+    expect(showSpy.mock.calls[0]?.[0]).toBe(first)
+  })
+
+  it('does not open the dialog when rejections are not ScriptErrors', async () => {
+    const action: ActionConfig = { label: 'Run', key: 'r' }
+    configureSchema(action)
+
+    vi.mocked(runAction).mockRejectedValueOnce(new Error('network')).mockResolvedValueOnce(null)
+
+    const { wrapper } = mountHarness({
+      selectedIds: new Set(['t1', 't2']),
+      entities: [
+        ent('t1'),
+        ent('t2'),
+      ],
+    })
+
+    const showSpy = vi.spyOn(useScriptErrorStore(), 'show')
+    const errorSpy = vi.spyOn(useUIStore(), 'error')
+
+    const { executeAction } = wrapper.vm as unknown as ReturnType<typeof useListActions>
+    await executeAction('act-1', action)
+
+    expect(showSpy).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledWith('Run: 1 failed, 1 succeeded')
+  })
+
+  it('passes triggerEl through to the dialog store for focus restore', async () => {
+    const action: ActionConfig = { label: 'Run', key: 'r' }
+    configureSchema(action)
+
+    const err = makeScriptError()
+    vi.mocked(runAction).mockRejectedValueOnce(err)
+
+    const trigger = document.createElement('button')
+
+    const { wrapper } = mountHarness({
+      selectedIds: new Set(['t1']),
+      entities: [ent('t1')],
+    })
+
+    const showSpy = vi.spyOn(useScriptErrorStore(), 'show')
+
+    const { executeAction } = wrapper.vm as unknown as ReturnType<typeof useListActions>
+    await executeAction('act-1', action, trigger)
+
+    expect(showSpy).toHaveBeenCalledTimes(1)
+    expect(showSpy.mock.calls[0]?.[1]).toBe(trigger)
+  })
+
+  it('skips ScriptError dispatch for set-only actions that fail via updateEntity', async () => {
+    const action: ActionConfig = { label: 'Done', key: 'd', set: { status: 'done' } }
+    configureSchema(action)
+
+    vi.mocked(updateEntity).mockRejectedValueOnce(new Error('500'))
+
+    const { wrapper } = mountHarness({
+      selectedIds: new Set(['t1']),
+      entities: [ent('t1')],
+    })
+
+    const showSpy = vi.spyOn(useScriptErrorStore(), 'show')
+    const errorSpy = vi.spyOn(useUIStore(), 'error')
+
+    const { executeAction } = wrapper.vm as unknown as ReturnType<typeof useListActions>
+    await executeAction('act-1', action)
+
+    expect(showSpy).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledWith('Done: 1 failed, 0 succeeded')
+  })
+
+  it('does not open the dialog on the all-success path', async () => {
+    const action: ActionConfig = { label: 'Run', key: 'r' }
+    configureSchema(action)
+
+    vi.mocked(runAction).mockResolvedValueOnce(null).mockResolvedValueOnce(null)
+
+    const { wrapper } = mountHarness({
+      selectedIds: new Set(['t1', 't2']),
+      entities: [
+        ent('t1'),
+        ent('t2'),
+      ],
+    })
+
+    const showSpy = vi.spyOn(useScriptErrorStore(), 'show')
+    const successSpy = vi.spyOn(useUIStore(), 'success')
+
+    const { executeAction } = wrapper.vm as unknown as ReturnType<typeof useListActions>
+    await executeAction('act-1', action)
+
+    expect(showSpy).not.toHaveBeenCalled()
+    expect(successSpy).toHaveBeenCalledWith('Run: 2 updated')
+  })
+
+  it('forwards triggerEl through onRequestConfirm for confirm-required actions', () => {
+    const action: ActionConfig = { label: 'Run', key: 'r', confirm: true }
+    configureSchema(action)
+
+    const onRequestConfirm = vi.fn()
+    const trigger = document.createElement('button')
+
+    const selectedIds = ref(new Set(['t1']))
+    const entities = ref<Entity[]>([ent('t1')])
+    const listId = ref('list-1')
+
+    const Harness = defineComponent({
+      setup() {
+        return useListActions({
+          listId,
+          selectedIds,
+          entities,
+          onClearSelection: () => {},
+          onRequestConfirm,
+          onComplete: () => {},
+        })
+      },
+      template: '<div/>',
+    })
+    const wrapper = mount(Harness)
+
+    const { triggerAction } = wrapper.vm as unknown as ReturnType<typeof useListActions>
+    triggerAction('act-1', action, trigger)
+
+    expect(onRequestConfirm).toHaveBeenCalledTimes(1)
+    expect(onRequestConfirm.mock.calls[0]?.[0]).toBe(action)
+    expect(onRequestConfirm.mock.calls[0]?.[1]).toBe('act-1')
+    expect(onRequestConfirm.mock.calls[0]?.[2]).toBe(trigger)
+  })
+})

--- a/frontend/src/composables/useListActions.ts
+++ b/frontend/src/composables/useListActions.ts
@@ -1,8 +1,10 @@
 import { ref, onMounted, onBeforeUnmount, computed, type Ref } from 'vue'
 import { useSchemaStore, useEntitiesStore, useUIStore } from '@/stores'
+import { useScriptErrorStore } from '@/stores/scriptError'
 import { updateEntity } from '@/api/entities'
 import { runAction } from '@/api/actions'
 import { isInputFocused } from '@/utils/dom'
+import { isScriptError } from '@/types/scriptError'
 import { isAnyModalOpen } from './modalStack'
 import type { ActionConfig, Entity } from '@/types'
 
@@ -14,7 +16,11 @@ interface UseListActionsOptions {
   selectedIds: Ref<Set<string>>
   entities: Ref<Entity[]>
   onClearSelection: () => void
-  onRequestConfirm: (action: ActionConfig, actionId: string) => void
+  onRequestConfirm: (
+    action: ActionConfig,
+    actionId: string,
+    triggerEl: HTMLElement | null,
+  ) => void
   onComplete: () => void
 }
 
@@ -27,6 +33,7 @@ export function useListActions(options: UseListActionsOptions) {
   const schemaStore = useSchemaStore()
   const entitiesStore = useEntitiesStore()
   const uiStore = useUIStore()
+  const scriptErrorStore = useScriptErrorStore()
   const processing = ref(false)
 
   const resolvedActions = computed(() => {
@@ -46,7 +53,11 @@ export function useListActions(options: UseListActionsOptions) {
     return value.replace(/\{\{today\}\}/g, new Date().toISOString().slice(0, 10))
   }
 
-  async function executeAction(actionId: string, action: ActionConfig) {
+  async function executeAction(
+    actionId: string,
+    action: ActionConfig,
+    triggerEl?: HTMLElement | null,
+  ) {
     const ids = Array.from(options.selectedIds.value)
     if (ids.length === 0) return
 
@@ -73,6 +84,18 @@ export function useListActions(options: UseListActionsOptions) {
 
     processing.value = false
 
+    // Surface the first script-error rejection in the shared dialog so the
+    // user gets file:line, source snippet, stack and correlation ID. Other
+    // rejections (script or otherwise) are still summarised in the toast
+    // below; viewing more than one error is a follow-up.
+    const firstScriptError = results
+      .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+      .map((r) => r.reason)
+      .find(isScriptError)
+    if (firstScriptError) {
+      scriptErrorStore.show(firstScriptError, triggerEl ?? null)
+    }
+
     if (errorCount > 0) {
       uiStore.error(`${action.label}: ${errorCount} failed, ${successCount} succeeded`)
     } else {
@@ -96,14 +119,30 @@ export function useListActions(options: UseListActionsOptions) {
     }
   }
 
-  function triggerAction(actionId: string, action: ActionConfig) {
+  // Resolve a ScriptError focus-restore target from any of the kinds the
+  // call sites have lying around (a captured DOM node, a click event, a
+  // keydown event, or nothing). Centralised so the instanceof narrowing
+  // lives in exactly one place.
+  function resolveTriggerEl(source: Event | HTMLElement | null | undefined): HTMLElement | null {
+    if (!source) return null
+    if (source instanceof HTMLElement) return source
+    const candidate = (source as Event).currentTarget ?? (source as Event).target
+    return candidate instanceof HTMLElement ? candidate : null
+  }
+
+  function triggerAction(
+    actionId: string,
+    action: ActionConfig,
+    source?: Event | HTMLElement | null,
+  ) {
     if (options.selectedIds.value.size === 0) return
     if (processing.value) return
 
+    const triggerEl = resolveTriggerEl(source)
     if (action.confirm) {
-      options.onRequestConfirm(action, actionId)
+      options.onRequestConfirm(action, actionId, triggerEl)
     } else {
-      executeAction(actionId, action)
+      executeAction(actionId, action, triggerEl)
     }
   }
 
@@ -116,7 +155,7 @@ export function useListActions(options: UseListActionsOptions) {
     for (const { id, config } of resolvedActions.value) {
       if (config.key === e.key) {
         e.preventDefault()
-        triggerAction(id, config)
+        triggerAction(id, config, e)
         return
       }
     }

--- a/frontend/src/stores/scriptError.test.ts
+++ b/frontend/src/stores/scriptError.test.ts
@@ -60,4 +60,22 @@ describe('scriptError store', () => {
     expect(() => store.dismiss()).not.toThrow()
     expect(store.current).toBeNull()
   })
+
+  it('dismiss skips focus restore when the trigger has been detached', () => {
+    // List actions can detach the trigger before dismiss runs (the
+    // optimistic row removal in useListActions unmounts the action
+    // header alongside the focused row). The store must not call
+    // .focus() on a detached node — that silently lands focus on body.
+    const store = useScriptErrorStore()
+    const trigger = document.createElement('button')
+    document.body.appendChild(trigger)
+    const focusSpy = vi.spyOn(trigger, 'focus')
+
+    store.show(makeError(), trigger)
+    document.body.removeChild(trigger)
+    store.dismiss()
+
+    expect(store.current).toBeNull()
+    expect(focusSpy).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/stores/scriptError.ts
+++ b/frontend/src/stores/scriptError.ts
@@ -23,10 +23,15 @@ export const useScriptErrorStore = defineStore('scriptError', () => {
 
   function dismiss(): void {
     current.value = null
-    if (triggeringEl.value) {
+    // List actions can detach the trigger before dismiss runs (the
+    // optimistic row-removal in useListActions.executeAction unmounts
+    // the action header alongside the focused row). Calling .focus() on
+    // a detached node silently no-ops and focus falls to <body>; the
+    // contains() check makes that explicit.
+    if (triggeringEl.value && document.contains(triggeringEl.value)) {
       triggeringEl.value.focus()
-      triggeringEl.value = null
     }
+    triggeringEl.value = null
   }
 
   return { current, show, dismiss }

--- a/tickets/entities/implementation-checklists/IMPL-68WSY.md
+++ b/tickets/entities/implementation-checklists/IMPL-68WSY.md
@@ -1,0 +1,97 @@
+---
+id: IMPL-68WSY
+type: implementation-checklist
+title: 'Implementation: Show Lua error details for data-entry action failures'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+**Changes:**
+
+- `frontend/src/composables/useListActions.ts`: scan `Promise.allSettled`
+rejections for the first `ScriptError` and surface it via
+`useScriptErrorStore().show(...)`. Plumbed an optional `triggerEl?: HTMLElement
+| null` parameter through `triggerAction` and `executeAction`, captured from
+`e.target` in the keyboard handler.
+- `frontend/src/components/lists/EntityList.vue`: added a small
+`triggerActionFromClick` helper to capture `event.currentTarget` and hand it to
+`triggerAction`, so click-driven and keyboard-driven flows both restore focus
+when the dialog dismisses. Confirm-modal flow passes `null` (acceptable v1 —
+focus simply not restored to the underlying row).
+- `frontend/src/composables/useListActions.test.ts`: 6 new test cases.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+Tests assert against the *same* `ScriptError` object reference that was rejected
+(`expect(showSpy.mock.calls[0]?.[0]).toBe(err)`) — no string duplication. The
+`makeScriptError` factory matches the pattern used in `scriptError.test.ts`.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Unit-test coverage substitutes for the manual end-to-end check because the
+sample project at `prototypes/data-entry/project/` has only `set:` actions, no
+Lua-script list actions. Adding a script-action fixture purely for manual
+verification would be added scope. The dispatch logic is fully covered by:
+
+- AC1 (single failure → dialog opens with the envelope reference):
+test "opens the script-error dialog when one rejection is a ScriptError" asserts
+`showSpy.mock.calls[0]?.[0] === err` and that the count toast still fires with
+the expected text.
+- AC2 (summary toast still fires):
+asserted in the same test (`expect(errorSpy).toHaveBeenCalledWith(...)`).
+- AC3 (multiple → first only):
+test "shows only the first ScriptError when multiple rejections are script
+errors" asserts `showSpy` called exactly once, with the *first* rejected
+envelope reference.
+- AC4 (non-script rejections → no dialog):
+test "does not open the dialog when rejections are not ScriptErrors" asserts
+`showSpy` not called; toast still shows. Plus "skips ScriptError dispatch for
+set-only actions" covers the `updateEntity`-rejection path.
+- AC5 (focus-restore plumbing):
+test "passes triggerEl through to the dialog store for focus restore" asserts
+`showSpy.mock.calls[0]?.[1] === trigger`. The store's actual focus-restore
+behaviour is covered by `scriptError.test.ts`.
+- AC6 (no regression):
+test "does not open the dialog on the all-success path" asserts the success
+toast fires and the dialog stays closed. All 540 existing frontend tests pass;
+`internal/dataentry/...` Go tests pass.
+
+A follow-up ticket can add a Lua list action to the sample project for
+operator-led smoke testing if/when desired; this is small and out-of-scope for
+v1.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+- Wiring mirrors `Sidebar.vue:108-119` (the existing single-action path).
+- `npm run test:run` → 540/540 pass.
+- `npm run lint` → 0 errors (67 pre-existing warnings unchanged).
+- `npm run typecheck` → clean.
+- `npm run build` → builds cleanly into
+`internal/dataentry/static/v2/`.
+- `go test ./internal/dataentry/...` → ok.

--- a/tickets/entities/planning-checklists/PLAN-OGKVX.md
+++ b/tickets/entities/planning-checklists/PLAN-OGKVX.md
@@ -1,0 +1,156 @@
+---
+id: PLAN-OGKVX
+type: planning-checklist
+title: 'Planning: Show Lua error details for data-entry action failures'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem:** When a list-action runs over multiple selected entities and the Lua
+script fails on one or more of them, the user sees only a counts-based error
+toast. The structured `ScriptError` envelopes — which contain `script.path`,
+`lua.line`, `lua.message`, source snippet, stack frames, and correlation IDs —
+are received from the API but dropped on the floor by
+`useListActions.executeAction`.
+
+**Already in place (do not rebuild):** Backend produces the envelope; frontend
+has `ScriptErrorDialog`/`ScriptErrorPanel`/`useScriptErrorStore`/`isScriptError`
+guard, mounted in `App.vue`. Sidebar single-action flow already wired. Axios
+interceptor surfaces the envelope as the rejection reason.
+
+**Scope (IN):** Update `useListActions.executeAction` to inspect rejections,
+dispatch first `ScriptError` to the dialog, capture `triggerEl` for focus
+restore. Tests cover all branches.
+
+**Scope (OUT):** Backend changes (already there); new components/stores;
+multi-error timeline; bulk_set error handling; sidebar (already wired).
+
+**Acceptance Criteria:**
+
+1. List-action script failure → `ScriptErrorDialog` opens with envelope.
+2. Summary toast continues to show `N failed, M succeeded`.
+3. Multiple failures → first envelope only (v1 limitation).
+4. Non-script rejections → no dialog, only summary toast.
+5. Keyboard focus restored to a sensible element after dismiss.
+6. No regression in successful list-action flow.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:** TKT-LR5YC (commit `055961cc`) added structured
+`ScriptError` envelopes across all Lua surfaces and the frontend infrastructure.
+Sidebar single-action flow at `Sidebar.vue:108-119` is the reference wiring to
+mirror. Axios interceptor at `client.ts:36-44` re-rejects `script_error`
+envelopes as the rejection reason directly, so `Promise.allSettled` rejections
+carry the envelope unwrapped.
+
+**Conclusion:** Single-file edit to `useListActions.ts`, plus tests.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+- `useListActions.executeAction`: after `Promise.allSettled`, scan
+rejections for the first matching `isScriptError` and call
+`scriptErrorStore.show(...)`. Keep the existing summary toast.
+- Plumb `triggerEl?: HTMLElement | null` through `triggerAction` →
+`executeAction`, and through `onRequestConfirm` to support the confirm-modal
+flow.
+- Show first script error only (v1).
+
+**Files modified:**
+
+- `frontend/src/composables/useListActions.ts`
+- `frontend/src/components/lists/EntityList.vue`
+- `frontend/src/stores/scriptError.ts` (detach guard for focus restore)
+- New: `frontend/src/composables/useListActions.test.ts`
+- New regression: `frontend/src/stores/scriptError.test.ts`
+
+**Alternatives considered:**
+
+- Show all script errors stacked: rejected (UI is single-error).
+- Server-side parse of error string into structured fields: rejected
+(envelope already provides structure).
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** `ScriptError` envelope is produced by trusted
+backend, structurally validated client-side via `isScriptError`. Rendered with
+text interpolation in `<pre>` (no `v-html`) — XSS-safe. Loopback-gating of
+`source`/`stack`/`captured_output` enforced server-side; frontend untouched.
+
+**Security-Sensitive Operations:** None new. Same data already exposed via the
+sidebar single-action flow.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** unit tests cover ACs 1–4 and 6; AC5 covered by the new
+detach-guard regression test in `scriptError.test.ts`. Manual e2e deferred —
+sample project has only `set:` actions; unit-test coverage substitutes.
+
+**Edge Cases:** mixed rejections; all-non-script rejections; many script-error
+rejections; confirm-modal flow; trigger-element detached after row removal.
+
+**Negative Tests:** non-`ScriptError` rejection reason, empty selection.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:** trigger element detachment (mitigated by `document.contains` guard in
+`dismiss`); first-only error UX surprise (toast still shows count); extending
+optional-param composable API (backward compatible).
+
+**Effort:** xs.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] ~~User guide / reference docs~~ (N/A: TKT-LR5YC docs already describe ScriptErrorDialog UX; this ticket extends it)
+- [x] ~~CLI help text~~ (N/A: no CLI change)
+- [x] ~~CLAUDE.md~~ (N/A: no new patterns)
+- [x] ~~README.md~~ (N/A: no project-level change)
+- [x] ~~API docs~~ (N/A: no API change)
+- [x] N/A — internal wiring fix; user-facing behaviour documented by existing dialog.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: xs-effort wiring fix, no architectural decisions; cranky-code-review run during review phase covered design concerns)
+- [x] ~~All critical/significant findings addressed in plan~~ (N/A: no design review run; code-review findings tracked as review-responses)
+
+**Design Review Findings:** N/A — see code review (`/code-review`) findings in
+the linked review-response entities (RR-7HDS3, RR-1EY20, RR-1CE17, RR-OGRML,
+RR-0RLYP, RR-YXX7C, RR-CDK7C addressed; RR-CJ41O, RR-VZA4X, RR-THTVI marked
+won't-fix/deferred with reasons).

--- a/tickets/entities/review-checklists/REV-4J4GJ.md
+++ b/tickets/entities/review-checklists/REV-4J4GJ.md
@@ -1,0 +1,70 @@
+---
+id: REV-4J4GJ
+type: review-checklist
+title: 'Review: Show Lua error details for data-entry action failures'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — 542 frontend + Go suite green
+- [x] Lint clean (`just lint`) — 0 errors (67+ pre-existing warnings unchanged)
+- [x] Coverage maintained (`just coverage-check`) — 74.1% (package floors satisfied)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed (none flagged)
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:**
+
+- RR-7HDS3 (significant): Confirm-modal flow drops trigger element — addressed
+- RR-1EY20 (significant): Trigger element detached by row removal — addressed
+- RR-1CE17 (significant): Test gap: confirm-modal flow — addressed
+- RR-OGRML (significant): Test gap: triggerEl null vs undefined — addressed
+- RR-0RLYP (nit): clearAllMocks vs resetAllMocks — addressed
+- RR-YXX7C (nit): Inert vi.useFakeTimers in success-path test — addressed
+- RR-CDK7C (nit): Triple HTMLElement narrowing — addressed
+- RR-CJ41O (minor): Cancelled fetches counted as failed — deferred (pre-existing)
+- RR-VZA4X (nit): executeAction has too many responsibilities — deferred (inherited)
+- RR-THTVI (nit): Multiple ScriptErrors discarded — deferred (explicit v1 decision)
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+| AC | Status | Evidence |
+|----|--------|----------|
+| 1 | PASS | unit test "opens the script-error dialog when one rejection is a ScriptError" |
+| 2 | PASS | same test asserts the count toast still fires |
+| 3 | PASS | unit test "shows only the first ScriptError when multiple rejections are script errors" |
+| 4 | PASS | unit tests "does not open the dialog when rejections are not ScriptErrors" + "skips ScriptError dispatch for set-only actions" |
+| 5 | PASS | unit test "passes triggerEl through to the dialog store for focus restore"; detach guard verified by scriptError.test.ts "dismiss skips focus restore when the trigger has been detached"; confirm-flow plumbing covered by "forwards triggerEl through onRequestConfirm" |
+| 6 | PASS | unit test "does not open the dialog on the all-success path"; full test suite green (542/542) |
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: TKT-LR5YC docs already describe ScriptErrorDialog UX; this ticket extends the existing surface)
+- [x] ~~User-facing documentation updated~~ (N/A as above)
+- [x] ~~Docs-checklist marked as done~~ (N/A as above)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/619

--- a/tickets/entities/review-responses/RR-0RLYP.md
+++ b/tickets/entities/review-responses/RR-0RLYP.md
@@ -1,0 +1,9 @@
+---
+id: RR-0RLYP
+type: review-response
+title: 'Mock leakage risk: clearAllMocks vs resetAllMocks'
+finding: vi.clearAllMocks() resets call history but not mockRejectedValueOnce/mockResolvedValueOnce queues or future mockReturnValue defaults. Tests are safe today, but switching to vi.resetAllMocks() in beforeEach is cheap forward-compat insurance.
+severity: nit
+resolution: Switched useListActions.test.ts beforeEach from vi.clearAllMocks() to vi.resetAllMocks() so future mockReturnValue defaults can't bleed across cases. Added a brief comment explaining the rationale.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-1CE17.md
+++ b/tickets/entities/review-responses/RR-1CE17.md
@@ -1,0 +1,9 @@
+---
+id: RR-1CE17
+type: review-response
+title: 'Test coverage gap: confirm-modal flow'
+finding: No test asserts that triggerEl is forwarded (or not forwarded) through the confirmation flow. Given the bug above, this is the path most likely to regress silently. Add a test exercising triggerAction with action.confirm=true and verifying onRequestConfirm carries the right element through to executeAction.
+severity: significant
+resolution: Added test 'forwards triggerEl through onRequestConfirm for confirm-required actions' in useListActions.test.ts. Asserts onRequestConfirm receives the trigger element as the third argument when triggerAction is invoked with action.confirm=true.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-1EY20.md
+++ b/tickets/entities/review-responses/RR-1EY20.md
@@ -1,0 +1,13 @@
+---
+id: RR-1EY20
+type: review-response
+title: Trigger element gets detached by optimistic row removal
+finding: 'Click path: ev.currentTarget is the .action-header-btn in a row that is v-if="hasSelection". After onClearSelection() runs, hasSelection flips to false and the button unmounts. Keyboard path: e.target may be a row removed by the optimistic filter at executeAction line 107. Either way, triggeringEl.focus() in scriptError.ts runs against a detached node and silently no-ops. Focus falls to <body>. User-visible consequence: keyboard user has to Tab from the top of the page to recover. Fix: in scriptError.ts dismiss(), guard with document.contains(triggeringEl) before focusing; fall back to a sensible target or document the limitation.'
+severity: significant
+resolution: Added document.contains(triggeringEl) guard in scriptError.ts dismiss() before calling .focus(). When the trigger element has been detached (e.g. by useListActions optimistic row removal), focus restore is skipped so it falls through to <body> as expected, instead of being silently no-opped. Inline comment documents the reason.
+status: addressed
+---
+
+Also added regression test 'dismiss skips focus restore when the trigger has
+been detached' to scriptError.test.ts, asserting focus is NOT called on a
+detached node and the store still clears its current state.

--- a/tickets/entities/review-responses/RR-7HDS3.md
+++ b/tickets/entities/review-responses/RR-7HDS3.md
@@ -1,0 +1,9 @@
+---
+id: RR-7HDS3
+type: review-response
+title: Confirm-modal flow drops the trigger element
+finding: 'When an action has confirm: true, EntityList.vue:689 calls executeAction(pendingAction.id, pendingAction.config) from @confirm with no third argument. A confirmed action that throws a ScriptError opens the dialog with triggerEl = null and focus restoration falls to document.body. The plumbing exists for keyboard accessibility, and the confirm path is the one users with screen readers are most likely to traverse. Fix: either widen pendingAction to {id, config, triggerEl} or capture the modal''s confirm button as the focus target.'
+severity: significant
+resolution: Widened pendingAction in EntityList.vue to {id, config, triggerEl}. Updated useListActions onRequestConfirm signature to (action, actionId, triggerEl). triggerAction passes triggerEl to onRequestConfirm. The @confirm handler now forwards pendingAction.triggerEl to executeAction. Confirmed-action script errors now restore focus to the original trigger button.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CDK7C.md
+++ b/tickets/entities/review-responses/RR-CDK7C.md
@@ -1,0 +1,9 @@
+---
+id: RR-CDK7C
+type: review-response
+title: Triple HTMLElement narrowing
+finding: The instanceof HTMLElement check is duplicated in triggerActionFromClick, handleKeydown, and the executeAction caller chain. Could be DRY'd by widening triggerAction's parameter to Event | HTMLElement | null and narrowing once. Three lines, not blocking.
+severity: nit
+resolution: 'Consolidated HTMLElement narrowing into a single resolveTriggerEl(source: Event | HTMLElement | null | undefined) helper in useListActions.ts. triggerAction now accepts the wider Event | HTMLElement | null type and narrows once. EntityList.vue dropped its triggerActionFromClick wrapper and now does @click="(e) => triggerAction(id, config, e)" directly. Keyboard handler passes the keydown event in the same way.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CJ41O.md
+++ b/tickets/entities/review-responses/RR-CJ41O.md
@@ -1,0 +1,10 @@
+---
+id: RR-CJ41O
+type: review-response
+title: Cancelled fetches counted as failures
+finding: If a list-action is cancelled (route navigation mid-action), the rejection is a CanceledError. isScriptError correctly returns false so the dialog stays closed, but the toast still says '1 failed' which is misleading. Pre-existing behaviour but worth a TODO or follow-up ticket.
+severity: minor
+resolution: Pre-existing behaviour, not introduced by this branch. Cancelled-fetch handling spans more than just useListActions and warrants its own ticket. Tracked as a follow-up rather than blocking this v1 ship.
+reason: Pre-existing behaviour, not introduced by this branch. Cancelled-fetch handling spans more than just useListActions and warrants its own ticket. Tracked as a follow-up rather than blocking this v1 ship.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-OGRML.md
+++ b/tickets/entities/review-responses/RR-OGRML.md
@@ -1,0 +1,9 @@
+---
+id: RR-OGRML
+type: review-response
+title: 'Test coverage gap: triggerEl defaults to null when omitted'
+finding: useListActions.ts:92 does scriptErrorStore.show(firstScriptError, triggerEl ?? null). Tests assert positive cases but never assert that calling executeAction without a triggerEl argument calls show(err, null). Easy to regress to undefined silently because fromEl ?? null in the store catches it. Add expect(showSpy.mock.calls[0]?.[1]).toBeNull() to one of the no-trigger tests.
+severity: significant
+resolution: 'Added expect(showSpy.mock.calls[0]?.[1]).toBeNull() to the ''opens the script-error dialog when one rejection is a ScriptError'' test, where executeAction is called without a triggerEl. Pins down the wire contract: omitted triggerEl becomes explicit null, never undefined.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-THTVI.md
+++ b/tickets/entities/review-responses/RR-THTVI.md
@@ -1,0 +1,10 @@
+---
+id: RR-THTVI
+type: review-response
+title: Multiple ScriptErrors are discarded
+finding: 'v1 deliberately shows only the first error, but the data for N-1 more is right there in the rejection list. Trivial leverage: append ''(and N-1 more)'' to the toast or expose a ''Next error'' button in the dialog. Out of scope for v1 per ticket plan, but track as a follow-up.'
+severity: nit
+resolution: Explicit v1 design decision per planning checklist (approved by user before implementation). Multi-error stacking would require UI work in ScriptErrorPanel which is out of scope. Worth revisiting if N>1 list-action failures become a common operator complaint.
+reason: Explicit v1 design decision per planning checklist (approved by user before implementation). Multi-error stacking would require UI work in ScriptErrorPanel which is out of scope. Worth revisiting if N>1 list-action failures become a common operator complaint.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-VZA4X.md
+++ b/tickets/entities/review-responses/RR-VZA4X.md
@@ -1,0 +1,10 @@
+---
+id: RR-VZA4X
+type: review-response
+title: executeAction has too many responsibilities
+finding: 'Inherited issue: executeAction now runs the action, counts results, dispatches the dialog, shows a toast, clears selection, optimistically updates entities, and schedules a refetch. Future refactor: extract dispatchScriptError and summarizeAndToast. Not blocking.'
+severity: nit
+resolution: Inherited god-function. Refactoring executeAction's six responsibilities is scope creep for a one-line wiring fix. Track as a follow-up cleanup ticket if/when this composable next needs substantive change.
+reason: Inherited god-function. Refactoring executeAction's six responsibilities is scope creep for a one-line wiring fix. Track as a follow-up cleanup ticket if/when this composable next needs substantive change.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-YXX7C.md
+++ b/tickets/entities/review-responses/RR-YXX7C.md
@@ -1,0 +1,9 @@
+---
+id: RR-YXX7C
+type: review-response
+title: Inert vi.useFakeTimers() in success-path test
+finding: The all-success test enables fake timers but never advances them. setTimeout(..., 350) is scheduled but its effects (invalidateAll, onComplete) are not asserted. Either drop the fake timer or actually exercise the timer with vi.advanceTimersByTime(350).
+severity: nit
+resolution: Removed the inert vi.useFakeTimers() call from the all-success test and the now-dead afterEach(vi.useRealTimers). The test asserts the dialog is not opened and the success toast fires; both happen synchronously after Promise.allSettled, before the 350ms setTimeout. The setTimeout-scheduled invalidateAll/onComplete are not the contract under test here.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-P0B8C.md
+++ b/tickets/entities/tickets/TKT-P0B8C.md
@@ -1,0 +1,29 @@
+---
+id: TKT-P0B8C
+type: ticket
+title: Show Lua error details for data-entry action failures
+kind: enhancement
+priority: medium
+effort: xs
+status: done
+---
+
+## Problem
+
+When a data-entry action's Lua script fails, the user currently sees only a
+generic message ("Action failed" or "3 failed, 2 succeeded") with a correlation
+ID. The actual gopher-lua error — which already includes file:line and stack
+traceback — is logged server-side but never reaches the UI.
+
+## Goal
+
+Surface the Lua error details to the user. Show a short error indicator
+(preserving the existing UX), and on click open the existing Lua error modal
+dialog with the full message, line number, and stack traceback for debugging.
+
+## Notes
+
+- The error is already produced by `RunActionString` in `internal/lua/runtime.go` and contains `file:line` + stack traceback.
+- Currently dropped at `internal/dataentry/actions.go` `handleV1Action` — only `"action_failed"` + correlation ID are returned.
+- Frontend display points: `frontend/src/composables/useListActions.ts`, `frontend/src/components/common/Sidebar.vue`.
+- A modal dialog already exists for Lua errors elsewhere — reuse it.

--- a/tickets/relations/TKT-P0B8C--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-P0B8C--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-P0B8C--affects--lua-scripting.md
+++ b/tickets/relations/TKT-P0B8C--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-P0B8C--has-implementation--IMPL-68WSY.md
+++ b/tickets/relations/TKT-P0B8C--has-implementation--IMPL-68WSY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: has-implementation
+to: IMPL-68WSY
+---

--- a/tickets/relations/TKT-P0B8C--has-planning--PLAN-OGKVX.md
+++ b/tickets/relations/TKT-P0B8C--has-planning--PLAN-OGKVX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: has-planning
+to: PLAN-OGKVX
+---

--- a/tickets/relations/TKT-P0B8C--has-review--REV-4J4GJ.md
+++ b/tickets/relations/TKT-P0B8C--has-review--REV-4J4GJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: has-review
+to: REV-4J4GJ
+---

--- a/tickets/relations/TKT-P0B8C--has-review-response--RR-0RLYP.md
+++ b/tickets/relations/TKT-P0B8C--has-review-response--RR-0RLYP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: has-review-response
+to: RR-0RLYP
+---

--- a/tickets/relations/TKT-P0B8C--has-review-response--RR-1CE17.md
+++ b/tickets/relations/TKT-P0B8C--has-review-response--RR-1CE17.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: has-review-response
+to: RR-1CE17
+---

--- a/tickets/relations/TKT-P0B8C--has-review-response--RR-1EY20.md
+++ b/tickets/relations/TKT-P0B8C--has-review-response--RR-1EY20.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: has-review-response
+to: RR-1EY20
+---

--- a/tickets/relations/TKT-P0B8C--has-review-response--RR-7HDS3.md
+++ b/tickets/relations/TKT-P0B8C--has-review-response--RR-7HDS3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: has-review-response
+to: RR-7HDS3
+---

--- a/tickets/relations/TKT-P0B8C--has-review-response--RR-CDK7C.md
+++ b/tickets/relations/TKT-P0B8C--has-review-response--RR-CDK7C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: has-review-response
+to: RR-CDK7C
+---

--- a/tickets/relations/TKT-P0B8C--has-review-response--RR-CJ41O.md
+++ b/tickets/relations/TKT-P0B8C--has-review-response--RR-CJ41O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: has-review-response
+to: RR-CJ41O
+---

--- a/tickets/relations/TKT-P0B8C--has-review-response--RR-OGRML.md
+++ b/tickets/relations/TKT-P0B8C--has-review-response--RR-OGRML.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: has-review-response
+to: RR-OGRML
+---

--- a/tickets/relations/TKT-P0B8C--has-review-response--RR-THTVI.md
+++ b/tickets/relations/TKT-P0B8C--has-review-response--RR-THTVI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: has-review-response
+to: RR-THTVI
+---

--- a/tickets/relations/TKT-P0B8C--has-review-response--RR-VZA4X.md
+++ b/tickets/relations/TKT-P0B8C--has-review-response--RR-VZA4X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: has-review-response
+to: RR-VZA4X
+---

--- a/tickets/relations/TKT-P0B8C--has-review-response--RR-YXX7C.md
+++ b/tickets/relations/TKT-P0B8C--has-review-response--RR-YXX7C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: has-review-response
+to: RR-YXX7C
+---

--- a/tickets/relations/TKT-P0B8C--implements--FEAT-DO57.md
+++ b/tickets/relations/TKT-P0B8C--implements--FEAT-DO57.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P0B8C
+relation: implements
+to: FEAT-DO57
+---


### PR DESCRIPTION
## Summary

- When a data-entry list-action's Lua script fails on one or more selected
  entities, surface the structured `ScriptError` envelope in the existing
  `ScriptErrorDialog` instead of showing only a counts-based toast.
- Backend already produced the envelope (TKT-LR5YC); this fixes the
  frontend gap in `useListActions.ts` where `Promise.allSettled` rejection
  reasons were being discarded.
- Per ticket plan, v1 shows the **first** script-error rejection only;
  the count-summary toast still fires so the user sees the aggregate
  result.

## Changes

- `frontend/src/composables/useListActions.ts`: scan rejections for the
  first `ScriptError` and call `useScriptErrorStore().show(...)`. Plumbed
  an optional `triggerEl` through `triggerAction` / `executeAction` and
  `onRequestConfirm` so focus is restored to the original button after
  dismiss — confirm-modal flow included.
- `frontend/src/components/lists/EntityList.vue`: widened `pendingAction`
  to carry the trigger element and forward it through the confirm-modal
  `@confirm` handler.
- `frontend/src/stores/scriptError.ts`: added a `document.contains()`
  guard in `dismiss()` so detached trigger elements (the optimistic
  row-removal in `useListActions.executeAction` unmounts the action
  header) don't silently no-op `.focus()`.
- Tests: 7 new cases in `useListActions.test.ts` (single failure → dialog;
  multiple → first only; non-script rejection → no dialog; triggerEl
  plumbing including the explicit-null contract; confirm-flow plumbing;
  set-only updateEntity rejection → no dialog; all-success → no dialog).
  One regression test added to `scriptError.test.ts` for the detach guard.

## Test plan

- [ ] `just test` — Go suite
- [ ] `npm run test:run` (frontend) — 542/542
- [ ] `npm run typecheck` clean
- [ ] `npm run build` clean
- [ ] `npm run lint` — 0 errors
- [ ] `just coverage-check` — 74.1% (package floors satisfied)
- [ ] Manual end-to-end deferred: sample project has only `set:` actions,
      not script actions. Unit-test coverage substitutes; see
      `IMPL-68WSY` for evidence mapping.