### PR TITLE
docs: clarify action params vs entity global

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -1338,10 +1338,15 @@ actions:
 | `description` | string | Optional description                                            |
 | `set`         | map    | Property key-value pairs to set on the entity (mutually exclusive with `script`) |
 | `script`      | string | Lua script path, relative to the `actions/` directory (mutually exclusive with `set`) |
-| `params`      | map    | Key-value parameters passed to the script                       |
+| `params`      | map    | Static key-value parameters from config, exposed as `rela.params` (values must be strings — quote them in YAML) |
 | `confirm`     | bool   | Show a confirmation dialog before executing (default: `false`)  |
 
 Each action must have either `set` or `script`, not both.
+
+`params` is **static config**, not runtime context: the values come from
+`data-entry.yaml` and are the same for every invocation. The selected
+entity (for list actions) is exposed separately via the `entity` global —
+see [Lua Action Scripts](#lua-action-scripts).
 
 ### Using Actions in Lists
 
@@ -1380,14 +1385,29 @@ to that path. If it returns a `message`, a toast notification is shown.
 
 Action scripts live in the `actions/` directory at the project root. They have full access
 to the rela Lua API (entity CRUD, graph queries, AI). A script can optionally return a table
-to control the UI response:
+to control the UI response.
+
+#### Inputs available to the script
+
+| Source        | Where           | Populated when                                                              |
+| ------------- | --------------- | --------------------------------------------------------------------------- |
+| Static config | `rela.params`   | Always — values from the action's `params:` map in `data-entry.yaml`        |
+| Selected row  | `entity` global | Only when invoked from a list against a selected row (one call per entity). The table has `id`, `type`, `properties`, `content`, `mod_time`, plus `prop(name, default)` and `strip_prefix()` methods |
+
+When invoked from a navigation sidebar button, no entity is selected — the
+`entity` global is `nil`. Always nil-check it.
 
 ```lua
 -- actions/validate-ticket.lua
-local entity_id = rela.params["entity_id"]
-local entity_type = rela.params["entity_type"]
+-- Selected row from the list (nil for sidebar/nav invocations).
+if entity == nil then
+    return { message = "Select a ticket first", message_type = "warning" }
+end
 
--- ... perform validation ...
+-- Static parameter from data-entry.yaml — values are always strings.
+local strict = rela.params.strict == "true"
+
+-- ... perform validation against entity.id, entity.properties, ... ...
 
 return {
     message = "Validation passed",
@@ -1396,8 +1416,10 @@ return {
 }
 ```
 
-Scripts have a 5-second execution timeout. Returning nothing (or `nil`) produces a silent
-success response.
+Scripts have a 5-second execution timeout (tighter than the default Lua
+timeout because the action handler holds a global write lock for the
+duration — concurrent mutations and other actions wait). Returning
+nothing (or `nil`) produces a silent success response.
 
 ### Reserved Keyboard Shortcuts
 

--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -649,7 +649,7 @@ error-handling branches work unchanged.
 | `rela.project_root` | Absolute path to project root |
 | `rela.args` | Script arguments (table) |
 | `rela.today` | Current date as "YYYY-MM-DD" |
-| `rela.params` | Action script parameters (table, from data-entry config) |
+| `rela.params` | Action script parameters (table, static string-valued map from data-entry config) |
 | `rela.secrets` | Per-script secrets (table, from `.rela/secrets.yaml`) |
 | `rela.cache` | Process-wide memoization cache namespaced per script (see [Cache](#cache)) |
 | `rela.mode` | Set to `"document"` when rendering a data-entry document; `nil` otherwise (see [Document Mode](#document-mode)) |

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1332,10 +1332,15 @@ actions:
 | `description` | string | Optional description                                            |
 | `set`         | map    | Property key-value pairs to set on the entity (mutually exclusive with `script`) |
 | `script`      | string | Lua script path, relative to the `actions/` directory (mutually exclusive with `set`) |
-| `params`      | map    | Key-value parameters passed to the script                       |
+| `params`      | map    | Static key-value parameters from config, exposed as `rela.params` (values must be strings — quote them in YAML) |
 | `confirm`     | bool   | Show a confirmation dialog before executing (default: `false`)  |
 
 Each action must have either `set` or `script`, not both.
+
+`params` is **static config**, not runtime context: the values come from
+`data-entry.yaml` and are the same for every invocation. The selected
+entity (for list actions) is exposed separately via the `entity` global —
+see [Lua Action Scripts](#lua-action-scripts).
 
 ### Using Actions in Lists
 
@@ -1374,14 +1379,29 @@ to that path. If it returns a `message`, a toast notification is shown.
 
 Action scripts live in the `actions/` directory at the project root. They have full access
 to the rela Lua API (entity CRUD, graph queries, AI). A script can optionally return a table
-to control the UI response:
+to control the UI response.
+
+#### Inputs available to the script
+
+| Source        | Where           | Populated when                                                              |
+| ------------- | --------------- | --------------------------------------------------------------------------- |
+| Static config | `rela.params`   | Always — values from the action's `params:` map in `data-entry.yaml`        |
+| Selected row  | `entity` global | Only when invoked from a list against a selected row (one call per entity). The table has `id`, `type`, `properties`, `content`, `mod_time`, plus `prop(name, default)` and `strip_prefix()` methods |
+
+When invoked from a navigation sidebar button, no entity is selected — the
+`entity` global is `nil`. Always nil-check it.
 
 ```lua
 -- actions/validate-ticket.lua
-local entity_id = rela.params["entity_id"]
-local entity_type = rela.params["entity_type"]
+-- Selected row from the list (nil for sidebar/nav invocations).
+if entity == nil then
+    return { message = "Select a ticket first", message_type = "warning" }
+end
 
--- ... perform validation ...
+-- Static parameter from data-entry.yaml — values are always strings.
+local strict = rela.params.strict == "true"
+
+-- ... perform validation against entity.id, entity.properties, ... ...
 
 return {
     message = "Validation passed",
@@ -1390,8 +1410,10 @@ return {
 }
 ```
 
-Scripts have a 5-second execution timeout. Returning nothing (or `nil`) produces a silent
-success response.
+Scripts have a 5-second execution timeout (tighter than the default Lua
+timeout because the action handler holds a global write lock for the
+duration — concurrent mutations and other actions wait). Returning
+nothing (or `nil`) produces a silent success response.
 
 ### Reserved Keyboard Shortcuts
 

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -643,7 +643,7 @@ error-handling branches work unchanged.
 | `rela.project_root` | Absolute path to project root |
 | `rela.args` | Script arguments (table) |
 | `rela.today` | Current date as "YYYY-MM-DD" |
-| `rela.params` | Action script parameters (table, from data-entry config) |
+| `rela.params` | Action script parameters (table, static string-valued map from data-entry config) |
 | `rela.secrets` | Per-script secrets (table, from `.rela/secrets.yaml`) |
 | `rela.cache` | Process-wide memoization cache namespaced per script (see [Cache](#cache)) |
 | `rela.mode` | Set to `"document"` when rendering a data-entry document; `nil` otherwise (see [Document Mode](#document-mode)) |

--- a/tickets/entities/tickets/TKT-U51OV.md
+++ b/tickets/entities/tickets/TKT-U51OV.md
@@ -1,0 +1,31 @@
+---
+id: TKT-U51OV
+type: ticket
+title: Clarify action params vs entity global in data-entry docs
+kind: docs
+priority: low
+status: done
+---
+
+## Description
+
+The data-entry actions documentation showed a misleading example using
+`rela.params["entity_id"]` and `rela.params["entity_type"]` to read the selected
+row. In reality `rela.params` only holds the static `params:` map from
+`data-entry.yaml`; the runtime selected entity is exposed as the Lua global
+`entity` (set by the action handler when the request body provides `entity_id`).
+A user copying the example would get `nil` for `entity_id`/`entity_type` and
+silent failures.
+
+## Changes
+
+- Replaced the misleading example in `GUIDE-data-entry.md` with one that nil-checks the `entity` global and reads a real static param.
+- Added an "Inputs available to the script" table distinguishing static config (`rela.params`) from the runtime selected-row entity (`entity` global, list-only).
+- Documented the `entity` table shape (`id`, `type`, `properties`, `content`, `mod_time`, plus `prop()` and `strip_prefix()` methods).
+- Clarified that `params` values must be strings (quote them in YAML).
+- Noted the global write lock held during the 5-second action timeout window.
+- Tightened the `rela.params` row in `GUIDE-lua-scripting.md`.
+
+## PR
+
+https://github.com/sourcehaven-bv/rela/pull/622

--- a/tickets/relations/TKT-U51OV--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-U51OV--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-U51OV
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-U51OV--implements--FEAT-DO57.md
+++ b/tickets/relations/TKT-U51OV--implements--FEAT-DO57.md
@@ -1,0 +1,5 @@
+---
+from: TKT-U51OV
+relation: implements
+to: FEAT-DO57
+---


### PR DESCRIPTION
## Summary

- Action docs incorrectly showed `rela.params["entity_id"]` / `rela.params["entity_type"]` to read the selected row. `rela.params` only holds the static `params:` map from `data-entry.yaml`; the runtime selected entity is exposed as the Lua global `entity` (set by the action handler when the request body provides `entity_id`).
- Replaced the misleading example with one that nil-checks `entity` and reads a real static param, and added a table distinguishing the two input sources.
- Noted that `params` values must be strings (quote them in YAML), and that the action handler holds a global write lock for the 5-second timeout window.

## Test plan

- [x] `just ci` passes locally (coverage, build, docs-check)
- [x] Verified `docs/data-entry.md` and `docs/lua-scripting.md` regenerate cleanly from `docs-project/`