### PR TITLE
refactor(test): extract panicking EntityManager stub (TKT-GOLNP)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -7,6 +7,7 @@ allow:
 exclude:
   - internal/testutil
   - internal/store/storetest
+  - internal/entitymanager/entitymanagertest
   - frontend
   - e2e
   - .claude

--- a/internal/dataentry/document_script_test.go
+++ b/internal/dataentry/document_script_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
-	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager/entitymanagertest"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/state"
@@ -20,37 +20,6 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 	"github.com/Sourcehaven-BV/rela/internal/tracer"
 )
-
-// stubEntityManager lets us build a lua.WriteDeps that won't actually
-// mutate anything. Document scripts are read-only in practice but the
-// writer runtime requires a non-nil EntityManager.
-type docTestStubEM struct{}
-
-func (docTestStubEM) CreateEntity(context.Context, *entity.Entity,
-	entitymanager.CreateOptions) (*entitymanager.CreateResult, error) {
-	panic("not expected")
-}
-func (docTestStubEM) UpdateEntity(context.Context, *entity.Entity) (*entitymanager.UpdateResult, error) {
-	panic("not expected")
-}
-func (docTestStubEM) DeleteEntity(context.Context, string, bool) (*entitymanager.DeleteResult, error) {
-	panic("not expected")
-}
-func (docTestStubEM) RenameEntity(context.Context, string, string,
-	entitymanager.RenameOptions) (*entitymanager.RenameResult, error) {
-	panic("not expected")
-}
-func (docTestStubEM) CreateRelation(context.Context, string, string, string,
-	entitymanager.RelationOptions) (*entity.Relation, error) {
-	panic("not expected")
-}
-func (docTestStubEM) UpdateRelation(context.Context, string, string, string,
-	entitymanager.RelationOptions) (*entity.Relation, error) {
-	panic("not expected")
-}
-func (docTestStubEM) DeleteRelation(context.Context, string, string, string) error {
-	panic("not expected")
-}
 
 // fakeScriptEngine is a test double for documentScriptEngine. Each call
 // writes the fake's `stdout` string and records the invocation args so
@@ -397,7 +366,7 @@ print(got)
 				Tracer:      tracer.New(st),
 				ProjectRoot: projectRoot,
 			},
-			EntityManager: docTestStubEM{},
+			EntityManager: entitymanagertest.PanicOnUse{},
 		}
 	}
 	s := newDocumentService(st, kv, projectRoot, engine, deps)

--- a/internal/entitymanager/entitymanagertest/panic.go
+++ b/internal/entitymanager/entitymanagertest/panic.go
@@ -1,0 +1,55 @@
+// Package entitymanagertest provides test doubles for the
+// entitymanager.EntityManager interface.
+//
+// PanicOnUse satisfies the interface but panics from every method. Wire it
+// into tests that need to construct a writer runtime (which requires a
+// non-nil EntityManager) but exercise only read paths — an accidental
+// mutation will fail loudly instead of silently no-oping.
+package entitymanagertest
+
+import (
+	"context"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+)
+
+// PanicOnUse is an entitymanager.EntityManager whose every method panics.
+// Use it when a test's code path should never reach a mutation.
+type PanicOnUse struct{}
+
+var _ entitymanager.EntityManager = PanicOnUse{}
+
+func (PanicOnUse) CreateEntity(context.Context, *entity.Entity,
+	entitymanager.CreateOptions) (*entitymanager.CreateResult, error) {
+	panic("entitymanagertest.PanicOnUse.CreateEntity: not expected in this test")
+}
+
+func (PanicOnUse) UpdateEntity(context.Context,
+	*entity.Entity) (*entitymanager.UpdateResult, error) {
+	panic("entitymanagertest.PanicOnUse.UpdateEntity: not expected in this test")
+}
+
+func (PanicOnUse) DeleteEntity(context.Context, string,
+	bool) (*entitymanager.DeleteResult, error) {
+	panic("entitymanagertest.PanicOnUse.DeleteEntity: not expected in this test")
+}
+
+func (PanicOnUse) RenameEntity(context.Context, string, string,
+	entitymanager.RenameOptions) (*entitymanager.RenameResult, error) {
+	panic("entitymanagertest.PanicOnUse.RenameEntity: not expected in this test")
+}
+
+func (PanicOnUse) CreateRelation(context.Context, string, string, string,
+	entitymanager.RelationOptions) (*entity.Relation, error) {
+	panic("entitymanagertest.PanicOnUse.CreateRelation: not expected in this test")
+}
+
+func (PanicOnUse) UpdateRelation(context.Context, string, string, string,
+	entitymanager.RelationOptions) (*entity.Relation, error) {
+	panic("entitymanagertest.PanicOnUse.UpdateRelation: not expected in this test")
+}
+
+func (PanicOnUse) DeleteRelation(context.Context, string, string, string) error {
+	panic("entitymanagertest.PanicOnUse.DeleteRelation: not expected in this test")
+}

--- a/internal/script/executor_test.go
+++ b/internal/script/executor_test.go
@@ -2,53 +2,17 @@ package script
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/Sourcehaven-BV/rela/internal/entity"
-	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager/entitymanagertest"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 	"github.com/Sourcehaven-BV/rela/internal/tracer"
 )
-
-// stubEntityManager is a no-op EntityManager for tests that exercise the
-// script runtime wiring but never reach a mutation binding. It exists only
-// to satisfy lua.NewWriter's construction-time non-nil check; every method
-// panics so an accidental test reaching a mutation path fails loudly.
-type stubEntityManager struct{}
-
-func (stubEntityManager) CreateEntity(context.Context, *entity.Entity,
-	entitymanager.CreateOptions) (*entitymanager.CreateResult, error) {
-	panic("stubEntityManager.CreateEntity: not expected in this test")
-}
-func (stubEntityManager) UpdateEntity(context.Context,
-	*entity.Entity) (*entitymanager.UpdateResult, error) {
-	panic("stubEntityManager.UpdateEntity: not expected in this test")
-}
-func (stubEntityManager) DeleteEntity(context.Context, string,
-	bool) (*entitymanager.DeleteResult, error) {
-	panic("stubEntityManager.DeleteEntity: not expected in this test")
-}
-func (stubEntityManager) RenameEntity(context.Context, string, string,
-	entitymanager.RenameOptions) (*entitymanager.RenameResult, error) {
-	panic("stubEntityManager.RenameEntity: not expected in this test")
-}
-func (stubEntityManager) CreateRelation(context.Context, string, string, string,
-	entitymanager.RelationOptions) (*entity.Relation, error) {
-	panic("stubEntityManager.CreateRelation: not expected in this test")
-}
-func (stubEntityManager) UpdateRelation(context.Context, string, string, string,
-	entitymanager.RelationOptions) (*entity.Relation, error) {
-	panic("stubEntityManager.UpdateRelation: not expected in this test")
-}
-func (stubEntityManager) DeleteRelation(context.Context, string, string, string) error {
-	panic("stubEntityManager.DeleteRelation: not expected in this test")
-}
 
 func testWriteDeps(projectRoot string) lua.WriteDeps {
 	st := memstore.New()
@@ -58,7 +22,7 @@ func testWriteDeps(projectRoot string) lua.WriteDeps {
 			Tracer:      tracer.New(st),
 			ProjectRoot: projectRoot,
 		},
-		EntityManager: stubEntityManager{},
+		EntityManager: entitymanagertest.PanicOnUse{},
 	}
 }
 

--- a/tickets/entities/implementation-checklists/IMPL-NM5UK.md
+++ b/tickets/entities/implementation-checklists/IMPL-NM5UK.md
@@ -1,0 +1,43 @@
+---
+id: IMPL-NM5UK
+type: implementation-checklist
+title: 'Implementation: Extract stubEntityManager to shared test helper package'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] ~~Unit tests written for new code~~ (N/A: PanicOnUse contract is "every method panics" — exercised by absence of panics in existing test suites)
+- [x] ~~Integration tests written~~ (N/A: helper has no behaviour beyond panicking; exercised via existing dataentry/script tests)
+- [x] Happy path implemented (PanicOnUse satisfies entitymanager.EntityManager via compile-time assertion)
+- [x] Edge cases from planning handled (interface evolution caught by `var _ entitymanager.EntityManager = PanicOnUse{}`)
+- [x] ~~Error handling in place~~ (N/A: panicking is the contract)
+
+## Test Quality
+
+- [x] ~~Using fixture builders or factories for test data~~ (N/A: no test data introduced; only stub replacement)
+- [x] ~~No hardcoded values in assertions when object is in scope~~ (N/A: no new assertions)
+- [x] ~~Only specifying values that matter for the test~~ (N/A: mechanical refactor)
+- [x] ~~Interpolated values constructed from objects, not hardcoded~~ (N/A: no interpolation)
+- [x] ~~Property comparisons use original object, not hardcoded strings~~ (N/A: no new comparisons)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] ~~Edge cases manually verified~~ (covered by compile-time interface assertion + existing test runs)
+
+**Verification Evidence:**
+- `go build ./...` clean.
+- `go test -race ./...` — entire repo passes; `internal/dataentry` and `internal/script` (the two consumers) pass without changes to test logic.
+- `just lint` — 0 issues.
+- `just arch-lint` — only pre-existing `.ignored/` notices on develop; new `entitymanagertest` is properly excluded.
+
+## Quality
+
+- [x] Code follows project patterns (mirrors `internal/store/storetest` layout and arch-lint exclusion)
+- [x] No security issues introduced (test-only helper)
+- [x] No silent failures (panic on use is the explicit contract — opposite of silent)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-T0WFR.md
+++ b/tickets/entities/planning-checklists/PLAN-T0WFR.md
@@ -1,0 +1,101 @@
+---
+id: PLAN-T0WFR
+type: planning-checklist
+title: 'Planning: Extract stubEntityManager to shared test helper package'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+- IN: New `internal/entitymanager/entitymanagertest` package exporting `PanicOnUse` (struct value, panicking method bodies for every method on `entitymanager.EntityManager`).
+- IN: Replace `docTestStubEM` (`internal/dataentry/document_script_test.go`) and `stubEntityManager` (`internal/script/executor_test.go`) with the shared type.
+- IN: Add the new package to the arch-lint `exclude` list (mirroring `internal/store/storetest`).
+- OUT: A more capable fake (recorder, scripted responses) — separate ticket if/when needed.
+
+**Acceptance Criteria:**
+1. New package compiles and is consumed by both test files. Verified by `just test`.
+2. Existing tests in `internal/dataentry` and `internal/script` still pass unchanged.
+3. `just arch-lint` passes.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+- `internal/store/storetest` is the closest analogue: a test-only sibling package next to the production package. Same naming convention applied: `internal/entitymanager/entitymanagertest`.
+- No external library — the interface lives in this repo, so a hand-rolled stub is correct.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+- Create `internal/entitymanager/entitymanagertest/panic.go` with `type PanicOnUse struct{}` and one method per interface entry, each calling `panic("entitymanagertest.PanicOnUse.<Method>: not expected in this test")`.
+- Compile-time assertion: `var _ entitymanager.EntityManager = PanicOnUse{}` so adding a method to the interface fails to build the helper, surfacing the gap once instead of in every consumer.
+- Update both test files to import the new package and replace the stub type references.
+
+**Files to modify:**
+- (new) `internal/entitymanager/entitymanagertest/panic.go`
+- `internal/dataentry/document_script_test.go`
+- `internal/script/executor_test.go`
+- `.go-arch-lint.yml`
+
+## Security Considerations
+
+- [x] ~~Input sources identified~~ (N/A: test-only helper, no inputs)
+- [x] ~~Input validation approach defined~~ (N/A: test-only helper)
+- [x] ~~Security-sensitive operations identified~~ (N/A: test-only helper)
+- [x] ~~Error handling doesn't leak sensitive information~~ (N/A: panics in tests only)
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+- Existing tests in `internal/dataentry` and `internal/script` exercise the call sites where `PanicOnUse` is wired into `lua.WriteDeps`. They cover the read-path; if any test accidentally reaches a mutation method, it panics — the desired behaviour.
+
+**Edge Cases:**
+- Interface evolution: covered by `var _ entitymanager.EntityManager = PanicOnUse{}` compile-time assertion.
+
+**Negative Tests:**
+- Not introducing new tests for the helper itself; its contract (panic on use) is exercised by the absence of panics in the existing suites.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl): **s**
+
+**Risks:**
+- Low. Mechanical extraction of a duplicated test fixture. Mitigated by the compile-time interface assertion and existing test coverage.
+
+## Documentation Planning
+
+- [x] ~~User-facing docs identified~~ (N/A: internal refactor, test-only)
+- [x] ~~Docs-checklist will be created when entering implementation~~ (N/A: refactor, not enhancement)
+
+**Documentation Impact:**
+- N/A — Internal change, no user-facing docs needed.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: trivial mechanical extraction; scope and approach already specified in the ticket)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** None.

--- a/tickets/entities/review-checklists/REV-ZHEXO.md
+++ b/tickets/entities/review-checklists/REV-ZHEXO.md
@@ -1,0 +1,55 @@
+---
+id: REV-ZHEXO
+type: review-checklist
+title: 'Review: Extract stubEntityManager to shared test helper package'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test` — full `go test -race ./...` clean)
+- [x] Lint clean (`just lint` — 0 issues)
+- [x] Coverage maintained (`just coverage-check` — 74.2% total, all package floors satisfied)
+
+## Code Review
+
+- [x] ~~Run `/code-review` command~~ (N/A: trivial mechanical extraction of a duplicated test stub — 7 panic methods + a compile-time interface assertion. No reviewable logic.)
+- [x] ~~All critical review-responses addressed~~ (N/A: none generated)
+- [x] ~~All significant review-responses addressed~~ (N/A: none generated)
+- [x] Self-reviewed the diff for unrelated changes — diff is exactly 4 files: new helper, two test files updated, arch-lint exclude line.
+
+**Review Responses:** None.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+1. New package compiles and is consumed by both test files — **PASS** (`go build ./...` clean; both consumers compile and test green).
+2. Existing tests still pass unchanged in behaviour — **PASS** (`go test -race ./internal/dataentry ./internal/script` ok).
+3. `just arch-lint` passes — **PASS** for this change (only pre-existing `.ignored/` notices remain on develop, unrelated).
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: internal refactor, no user-facing surface)
+- [x] ~~User-facing documentation updated~~ (N/A: internal refactor)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+**Docs Checklist:** N/A.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use (compile-time interface assertion guides future maintainers when the interface evolves)
+
+## Pull Request
+
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (Deferred: user requested implementation only; PR creation will happen when user runs `/pr`.)
+- [x] ~~All CI checks pass~~ (Deferred: depends on PR creation.)
+- [x] ~~PR URL documented below~~ (Deferred: depends on PR creation.)
+
+**PR:** Pending — user has not requested `/pr` yet.

--- a/tickets/entities/tickets/TKT-GOLNP.md
+++ b/tickets/entities/tickets/TKT-GOLNP.md
@@ -5,7 +5,7 @@ title: Extract stubEntityManager to shared test helper package
 kind: refactor
 priority: low
 effort: s
-status: review
+status: done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-GOLNP.md
+++ b/tickets/entities/tickets/TKT-GOLNP.md
@@ -4,7 +4,8 @@ type: ticket
 title: Extract stubEntityManager to shared test helper package
 kind: refactor
 priority: low
-status: backlog
+effort: s
+status: review
 ---
 
 ## Problem

--- a/tickets/relations/TKT-GOLNP--has-implementation--IMPL-NM5UK.md
+++ b/tickets/relations/TKT-GOLNP--has-implementation--IMPL-NM5UK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GOLNP
+relation: has-implementation
+to: IMPL-NM5UK
+---

--- a/tickets/relations/TKT-GOLNP--has-planning--PLAN-T0WFR.md
+++ b/tickets/relations/TKT-GOLNP--has-planning--PLAN-T0WFR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GOLNP
+relation: has-planning
+to: PLAN-T0WFR
+---

--- a/tickets/relations/TKT-GOLNP--has-review--REV-ZHEXO.md
+++ b/tickets/relations/TKT-GOLNP--has-review--REV-ZHEXO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GOLNP
+relation: has-review
+to: REV-ZHEXO
+---


### PR DESCRIPTION
## Summary

- New `internal/entitymanager/entitymanagertest` package with `PanicOnUse` — a single source of truth for the "no-mutation expected" test stub.
- Replaces duplicated `docTestStubEM` / `stubEntityManager` in `internal/dataentry` and `internal/script`. A compile-time `var _ entitymanager.EntityManager = PanicOnUse{}` makes future interface changes break the helper once instead of every consumer.
- `.go-arch-lint.yml` excludes the new test-only package, mirroring `internal/store/storetest`.

Closes TKT-GOLNP.

## Test plan

- [x] `go test -race ./...`
- [x] `just lint`
- [x] `just coverage-check`
- [x] `just lint-md`, `just build`, `just docs-check`