### PR TITLE
fix(data-entry): make custom-view list-section items clickable (#647)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -564,9 +564,14 @@ lists:
 
     create_form: create_ticket
     edit_form: edit_ticket
-    detail_view: ticket_report
     page_size: 25
 ```
+
+> **Where does a click on a row go?** That's configured at entity-type
+> granularity in the top-level `entity_views:` block — see
+> [Entity Views](#entity-views) below. Per-list `detail_view` is no longer
+> used; if you have one in an existing config, run `rela migrate` and it
+> will be moved automatically.
 
 ### List Fields
 
@@ -581,7 +586,6 @@ lists:
 | `filter_controls` | list   | Interactive filter controls shown to the user               |
 | `create_form`     | string | Form name for the "New" button                              |
 | `edit_form`       | string | Form name for the row edit action                           |
-| `detail_view`     | string | View name for the row detail action                         |
 | `page_size`       | int    | Rows per page (default: 25)                                 |
 | `actions`         | list   | Action IDs available as keyboard shortcuts on selected rows |
 
@@ -822,8 +826,8 @@ entry:
 ```
 
 When a user opens a view, the entry entity is determined by the URL. For example,
-clicking a list row that references `detail_view: ticket_report` opens the view for that
-specific ticket entity.
+clicking a list row whose `entity_type` has `entity_views.ticket.detail_view: ticket_report`
+opens the view for that specific ticket entity.
 
 ### Traverse Rules
 
@@ -956,6 +960,51 @@ sections:
 **`properties`** is best for the entry entity's metadata. **`content`** renders the markdown body.
 **`table`** works well for collections with many items. **`cards`** provides a visual layout for
 smaller collections. **`list`** is the most compact.
+
+## Entity Views
+
+`entity_views` declares the canonical detail view for each entity type — the
+view that opens when a user clicks on an entity reference anywhere in the
+data-entry app (a list row, a custom view's `display: list` section, a card,
+a table cell). Without an entry, the SPA falls back to a generic
+`/entity/<type>/<id>` page.
+
+```yaml
+entity_views:
+  ticket:
+    detail_view: ticket_detail
+  decision:
+    detail_view: decision_detail
+```
+
+### Fields
+
+| Field         | Type   | Description                                                       |
+| ------------- | ------ | ----------------------------------------------------------------- |
+| `detail_view` | string | View name (must reference a key under `views:`) used for entities of this type |
+
+### How navigation resolves
+
+For each clickable entity reference, the SPA picks the destination URL using
+the following priority:
+
+1. A column-level `link:` on a list (server-resolved, e.g. `link: detail` or
+   `link: document/<name>`).
+2. `entity_views.<type>.detail_view` (the canonical detail view for the
+   type) → `/view/<viewId>/<id>`.
+3. Fallback: `/entity/<type>/<id>` (a generic detail page).
+
+This means you only configure the destination *once* per entity type, and
+every consumer (lists, view sections, table rows) routes consistently.
+
+### Migration from list-level `detail_view`
+
+Earlier versions accepted `detail_view` directly on each list. That field is
+now deprecated; the canonical home is `entity_views.<type>.detail_view`. Run
+`rela migrate` to lift existing list-level values into the new section
+automatically. If two lists for the same entity type set conflicting
+`detail_view` values, the migration leaves them in place — resolve the
+conflict by hand and run `rela migrate` again.
 
 ## Dashboard
 
@@ -1763,7 +1812,6 @@ lists:
         widget: select
     create_form: create_ticket
     edit_form: edit_ticket
-    detail_view: ticket_detail
     actions: [resolve-ticket, close-ticket]
     page_size: 25
 
@@ -1803,6 +1851,10 @@ lists:
     create_form: create_ticket
     edit_form: edit_ticket
     page_size: 25
+
+entity_views:
+  ticket:
+    detail_view: ticket_detail
 
 views:
   ticket_detail:

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -558,9 +558,14 @@ lists:
 
     create_form: create_ticket
     edit_form: edit_ticket
-    detail_view: ticket_report
     page_size: 25
 ```
+
+> **Where does a click on a row go?** That's configured at entity-type
+> granularity in the top-level `entity_views:` block — see
+> [Entity Views](#entity-views) below. Per-list `detail_view` is no longer
+> used; if you have one in an existing config, run `rela migrate` and it
+> will be moved automatically.
 
 ### List Fields
 
@@ -575,7 +580,6 @@ lists:
 | `filter_controls` | list   | Interactive filter controls shown to the user               |
 | `create_form`     | string | Form name for the "New" button                              |
 | `edit_form`       | string | Form name for the row edit action                           |
-| `detail_view`     | string | View name for the row detail action                         |
 | `page_size`       | int    | Rows per page (default: 25)                                 |
 | `actions`         | list   | Action IDs available as keyboard shortcuts on selected rows |
 
@@ -816,8 +820,8 @@ entry:
 ```
 
 When a user opens a view, the entry entity is determined by the URL. For example,
-clicking a list row that references `detail_view: ticket_report` opens the view for that
-specific ticket entity.
+clicking a list row whose `entity_type` has `entity_views.ticket.detail_view: ticket_report`
+opens the view for that specific ticket entity.
 
 ### Traverse Rules
 
@@ -950,6 +954,51 @@ sections:
 **`properties`** is best for the entry entity's metadata. **`content`** renders the markdown body.
 **`table`** works well for collections with many items. **`cards`** provides a visual layout for
 smaller collections. **`list`** is the most compact.
+
+## Entity Views
+
+`entity_views` declares the canonical detail view for each entity type — the
+view that opens when a user clicks on an entity reference anywhere in the
+data-entry app (a list row, a custom view's `display: list` section, a card,
+a table cell). Without an entry, the SPA falls back to a generic
+`/entity/<type>/<id>` page.
+
+```yaml
+entity_views:
+  ticket:
+    detail_view: ticket_detail
+  decision:
+    detail_view: decision_detail
+```
+
+### Fields
+
+| Field         | Type   | Description                                                       |
+| ------------- | ------ | ----------------------------------------------------------------- |
+| `detail_view` | string | View name (must reference a key under `views:`) used for entities of this type |
+
+### How navigation resolves
+
+For each clickable entity reference, the SPA picks the destination URL using
+the following priority:
+
+1. A column-level `link:` on a list (server-resolved, e.g. `link: detail` or
+   `link: document/<name>`).
+2. `entity_views.<type>.detail_view` (the canonical detail view for the
+   type) → `/view/<viewId>/<id>`.
+3. Fallback: `/entity/<type>/<id>` (a generic detail page).
+
+This means you only configure the destination *once* per entity type, and
+every consumer (lists, view sections, table rows) routes consistently.
+
+### Migration from list-level `detail_view`
+
+Earlier versions accepted `detail_view` directly on each list. That field is
+now deprecated; the canonical home is `entity_views.<type>.detail_view`. Run
+`rela migrate` to lift existing list-level values into the new section
+automatically. If two lists for the same entity type set conflicting
+`detail_view` values, the migration leaves them in place — resolve the
+conflict by hand and run `rela migrate` again.
 
 ## Dashboard
 
@@ -1757,7 +1806,6 @@ lists:
         widget: select
     create_form: create_ticket
     edit_form: edit_ticket
-    detail_view: ticket_detail
     actions: [resolve-ticket, close-ticket]
     page_size: 25
 
@@ -1797,6 +1845,10 @@ lists:
     create_form: create_ticket
     edit_form: edit_ticket
     page_size: 25
+
+entity_views:
+  ticket:
+    detail_view: ticket_detail
 
 views:
   ticket_detail:

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -8,6 +8,7 @@ import { useListActions } from '@/composables/useListActions'
 import { useUrlFilterSync } from '@/composables/useUrlFilterSync'
 import { isCancelledFetch } from '@/composables/usePageData'
 import { toApiOperator, filterStateToApiParams } from '@/utils/filters'
+import { entityDetailHref } from '@/utils/entityRoute'
 import { getCellValue, formatCellValue, isEnumPropertyDef, asArray } from '@/utils/format'
 import type { Entity, ListMeta, ListParams, FilterState } from '@/types'
 import FilterBar from './FilterBar.vue'
@@ -442,16 +443,15 @@ function navigateToEntity(entity: Entity) {
     ? resolveLinkTarget(columnWithLink.link, entity.type, entity.id)
     : ''
 
-  // Priority: column link > detail_view > entity detail page
-  let path: string
-  if (columnLink) {
-    path = columnLink
-  } else if (listConfig.value?.detail_view) {
-    path = `/view/${listConfig.value.detail_view}/${entity.id}`
-  } else {
-    path = `/entity/${entity.type}/${entity.id}`
-  }
-
+  // Priority: column link > entity_views.<type>.detail_view > /entity/:type/:id
+  // Source of truth is the entity_views config; per-list detail_view was
+  // migrated to that location (see internal/migration/detail_view_to_entity_views.go).
+  const path = entityDetailHref(
+    { id: entity.id, type: entity.type },
+    schemaStore.getEntityDetailView,
+    { cellLink: columnLink },
+  )
+  if (!path) return
   router.push({ path, query })
 }
 

--- a/frontend/src/stores/schema.ts
+++ b/frontend/src/stores/schema.ts
@@ -8,6 +8,7 @@ import type {
   FormConfig,
   ListConfig,
   ViewConfig,
+  EntityViewConfig,
   KanbanConfig,
   DashboardConfig,
   NavigationEntry,
@@ -24,6 +25,10 @@ export const useSchemaStore = defineStore('schema', () => {
   const forms = ref<Map<string, FormConfig>>(new Map())
   const lists = ref<Map<string, ListConfig>>(new Map())
   const views = ref<Map<string, ViewConfig>>(new Map())
+  // entityViewConfigs is the data-entry config's entity_views section: a
+  // per-type binding of "the canonical detail view for entities of this type".
+  // Distinct from `entityTypes` above, which is the metamodel definition.
+  const entityViewConfigs = ref<Map<string, EntityViewConfig>>(new Map())
   const kanbans = ref<Map<string, KanbanConfig>>(new Map())
   const documents = ref<Map<string, DocumentConfig>>(new Map())
   const actions = ref<Map<string, ActionConfig>>(new Map())
@@ -59,6 +64,12 @@ export const useSchemaStore = defineStore('schema', () => {
     return undefined
   })
   const getView = computed(() => (id: string) => views.value.get(id))
+  // getEntityDetailView returns the canonical detail view id for an entity
+  // type, or undefined if none is configured. Consumers building entity
+  // links should fall back to /entity/:type/:id when undefined.
+  const getEntityDetailView = computed(
+    () => (type: string) => entityViewConfigs.value.get(type)?.detail_view
+  )
   const getKanban = computed(() => (id: string) => kanbans.value.get(id))
   const getAction = computed(() => (id: string) => actions.value.get(id))
 
@@ -97,6 +108,7 @@ export const useSchemaStore = defineStore('schema', () => {
       forms.value = new Map(Object.entries(configData.forms || {}))
       lists.value = new Map(Object.entries(configData.lists || {}))
       views.value = new Map(Object.entries(configData.views || {}))
+      entityViewConfigs.value = new Map(Object.entries(configData.entity_views || {}))
       kanbans.value = new Map(Object.entries(configData.kanbans || {}))
       documents.value = new Map(Object.entries(configData.documents || {}))
       actions.value = new Map(Object.entries(configData.actions || {}))
@@ -136,6 +148,7 @@ export const useSchemaStore = defineStore('schema', () => {
     forms,
     lists,
     views,
+    entityViewConfigs,
     kanbans,
     documents,
     actions,
@@ -157,6 +170,7 @@ export const useSchemaStore = defineStore('schema', () => {
     getList,
     findListIdForEntityType,
     getView,
+    getEntityDetailView,
     getKanban,
     getAction,
     entityTypeList,

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -14,11 +14,21 @@ export interface Config {
   forms: Record<string, FormConfig>
   lists: Record<string, ListConfig>
   views: Record<string, ViewConfig>
+  entity_views?: Record<string, EntityViewConfig>
   kanbans: Record<string, KanbanConfig>
   dashboard?: DashboardConfig
   actions?: Record<string, ActionConfig>
   navigation: NavigationEntry[]
   documents?: Record<string, DocumentConfig>
+}
+
+// EntityViewConfig declares UX bindings for a metamodel entity type.
+// detail_view names the canonical view used to display an entity of this type
+// — consumed by the SPA when an entity link needs to be rendered (entity-list
+// rows, custom-view sections). Missing detail_view falls back to
+// /entity/:type/:id.
+export interface EntityViewConfig {
+  detail_view?: string
 }
 
 export interface ActionConfig {
@@ -121,7 +131,10 @@ export interface ListConfig {
 }
 
 // Helper to get edit form for an entity type
-export function getEditFormId(schemaStore: { forms: Map<string, FormConfig> }, entityType: string): string | undefined {
+export function getEditFormId(
+  schemaStore: { forms: Map<string, FormConfig> },
+  entityType: string
+): string | undefined {
   for (const [formId, config] of schemaStore.forms) {
     if (config.entity === entityType && config.mode === 'edit') {
       return formId

--- a/frontend/src/utils/entityRoute.test.ts
+++ b/frontend/src/utils/entityRoute.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { entityDetailHref } from './entityRoute'
+
+describe('entityDetailHref', () => {
+  const noDetailViews = () => undefined
+
+  it('returns the configured detail_view path when present', () => {
+    const getDetailView = (type: string) => (type === 'idea' ? 'idea_detail' : undefined)
+    const href = entityDetailHref({ id: 'IDEA-001', type: 'idea' }, getDetailView)
+    expect(href).toBe('/view/idea_detail/IDEA-001')
+  })
+
+  it('falls back to /entity/:type/:id when no detail_view configured', () => {
+    const href = entityDetailHref({ id: 'TKT-9', type: 'ticket' }, noDetailViews)
+    expect(href).toBe('/entity/ticket/TKT-9')
+  })
+
+  it('returns cellLink verbatim when provided (table per-column links win)', () => {
+    const href = entityDetailHref({ id: 'TKT-9', type: 'ticket' }, () => 'ticket_detail', {
+      cellLink: '/document/spec/TKT-9',
+    })
+    expect(href).toBe('/document/spec/TKT-9')
+  })
+
+  it('returns empty string when entity.type is empty (avoids /entity//id)', () => {
+    const href = entityDetailHref({ id: 'X', type: '' }, () => 'unused')
+    expect(href).toBe('')
+  })
+
+  it('returns empty string when entity.id is empty (avoids /entity/type/)', () => {
+    const href = entityDetailHref({ id: '', type: 'ticket' }, () => 'ticket_detail')
+    expect(href).toBe('')
+  })
+
+  it('cellLink wins even when type is empty', () => {
+    const href = entityDetailHref({ id: 'X', type: '' }, noDetailViews, { cellLink: '/somewhere' })
+    expect(href).toBe('/somewhere')
+  })
+})

--- a/frontend/src/utils/entityRoute.ts
+++ b/frontend/src/utils/entityRoute.ts
@@ -1,0 +1,42 @@
+// Helper for computing the canonical SPA path for an entity link.
+//
+// Priority chain:
+//   1. opts.cellLink (server-resolved per-column link, e.g. table cells)
+//   2. /view/<detailView>/<entity.id> when a detail_view is configured
+//      for the entity's type via entity_views.<type>.detail_view
+//   3. /entity/<entity.type>/<entity.id> floor (always non-empty when type is)
+//
+// Returns an empty string when entity.type is empty — templates must guard
+// with v-if="href" and skip rendering an anchor in that case (otherwise we
+// would emit /entity//<id>, which 404s).
+//
+// The helper takes a getDetailView callback rather than the schema store so
+// it stays testable without Pinia. Consumers in components import the store
+// and pass `(type) => schemaStore.getEntityDetailView(type)`.
+//
+// TODO: a future iteration could move this resolution server-side, having the
+// API emit `entity.detailHref` per item so the SPA renders <a :href> with no
+// client-side lookup. Tracked separately.
+
+export interface EntityRef {
+  id: string
+  type: string
+}
+
+export interface EntityDetailHrefOpts {
+  cellLink?: string
+}
+
+export type GetDetailView = (type: string) => string | undefined
+
+export function entityDetailHref(
+  entity: EntityRef,
+  getDetailView: GetDetailView,
+  opts: EntityDetailHrefOpts = {}
+): string {
+  if (opts.cellLink) return opts.cellLink
+  if (!entity.type || !entity.id) return ''
+  const detailView = getDetailView(entity.type)
+  if (detailView) return `/view/${detailView}/${entity.id}`
+  return `/entity/${entity.type}/${entity.id}`
+}

--- a/frontend/src/views/CustomView.test.ts
+++ b/frontend/src/views/CustomView.test.ts
@@ -1,0 +1,150 @@
+// CustomView regression tests for issue #647.
+//
+// The bug: clicking an item in a `display: list` section does nothing
+// because the click handler called router.push({ name: 'entity', params:
+// { id } }) against a route that requires :type/:id. The fix renders the
+// item as a real <a :href> so right-click / cmd-click work, and the
+// click handler now resolves a valid path through entityDetailHref.
+//
+// These tests assert both contracts: rendered href is the right path,
+// and a left-click pushes the same path with return_to context.
+
+import { setActivePinia, createPinia } from 'pinia'
+import { mount, flushPromises } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createRouter, createMemoryHistory } from 'vue-router'
+
+import CustomView from './CustomView.vue'
+import { useSchemaStore } from '@/stores'
+import { fetchView } from '@/api'
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api')
+  return { ...actual, fetchView: vi.fn() }
+})
+
+// useScopeNavigation makes its own GET; stub it so the mounted component
+// doesn't reach for the network and its watch settles cleanly.
+vi.mock('@/composables', async () => {
+  const actual = await vi.importActual<typeof import('@/composables')>('@/composables')
+  return {
+    ...actual,
+    useScopeNavigation: () => ({
+      scopeNav: ref(null),
+      loadScopeNav: vi.fn().mockResolvedValue(undefined),
+      navigateScope: vi.fn(),
+    }),
+  }
+})
+
+function makeRouter() {
+  // Routes match the real router at the destinations we navigate to so
+  // router.push doesn't reject with MISSING_REQUIRED_PARAMS.
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: { template: '<div/>' } },
+      {
+        path: '/view/:id/:entityId',
+        name: 'view',
+        component: { template: '<div/>' },
+      },
+      {
+        path: '/entity/:type/:id',
+        name: 'entity',
+        component: { template: '<div/>' },
+      },
+    ],
+  })
+}
+
+async function mountWithSection(
+  section: Record<string, unknown>,
+  opts: { detailView?: string } = {}
+) {
+  const router = makeRouter()
+  // Land on a /view/... route so route.params reflects the CustomView context.
+  await router.push('/view/policy_detail/POLICY-001')
+  await router.isReady()
+
+  const fetchViewMock = vi.mocked(fetchView)
+  fetchViewMock.mockResolvedValue({
+    entry: {
+      id: 'POLICY-001',
+      type: 'policy',
+      properties: { title: 'A policy' },
+    },
+    sections: [section],
+  } as unknown as Awaited<ReturnType<typeof fetchView>>)
+
+  const wrapper = mount(CustomView, {
+    props: { id: 'policy_detail', entityId: 'POLICY-001' },
+    global: { plugins: [router] },
+  })
+
+  // Seed the schema store after Pinia is active.
+  const schemaStore = useSchemaStore()
+  if (opts.detailView) {
+    schemaStore.entityViewConfigs.set('procedure', { detail_view: opts.detailView })
+  }
+
+  await flushPromises()
+  return { wrapper, router }
+}
+
+describe('CustomView — list section navigation (issue #647)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders list items as real <a href> elements', async () => {
+    const { wrapper } = await mountWithSection({
+      sectionId: 'related',
+      heading: 'Related',
+      display: 'list',
+      entities: [{ id: 'PROC-1', type: 'procedure', title: 'First' }],
+      isEmpty: false,
+    })
+
+    const link = wrapper.find('a.list-link')
+    expect(link.exists()).toBe(true)
+    // No detail_view configured → /entity/:type/:id floor.
+    expect(link.attributes('href')).toBe('/entity/procedure/PROC-1')
+  })
+
+  it('uses entity_views detail_view when configured', async () => {
+    const { wrapper } = await mountWithSection(
+      {
+        sectionId: 'related',
+        heading: 'Related',
+        display: 'list',
+        entities: [{ id: 'PROC-2', type: 'procedure', title: 'Second' }],
+        isEmpty: false,
+      },
+      { detailView: 'detail_procedure' }
+    )
+
+    const link = wrapper.find('a.list-link')
+    expect(link.attributes('href')).toBe('/view/detail_procedure/PROC-2')
+  })
+
+  it('clicking a list item routes to the entity with return_to query', async () => {
+    const { wrapper, router } = await mountWithSection({
+      sectionId: 'related',
+      heading: 'Related',
+      display: 'list',
+      entities: [{ id: 'PROC-3', type: 'procedure', title: 'Third' }],
+      isEmpty: false,
+    })
+
+    const link = wrapper.find('a.list-link')
+    expect(link.exists()).toBe(true)
+
+    await link.trigger('click')
+    await flushPromises()
+
+    expect(router.currentRoute.value.path).toBe('/entity/procedure/PROC-3')
+    expect(router.currentRoute.value.query.return_to).toBe('/view/policy_detail/POLICY-001')
+  })
+})

--- a/frontend/src/views/CustomView.vue
+++ b/frontend/src/views/CustomView.vue
@@ -12,6 +12,7 @@ import { getEditFormId } from '@/types'
 import { isInputFocused } from '@/utils/dom'
 import { isAnyModalOpen } from '@/composables/modalStack'
 import { renderMarkdown } from '@/utils/markdown'
+import { entityDetailHref, type EntityRef } from '@/utils/entityRoute'
 import Badge from '@/components/common/Badge.vue'
 import LinkExistingModal from '@/components/forms/LinkExistingModal.vue'
 import PropertyDisplay from '@/components/common/PropertyDisplay.vue'
@@ -123,15 +124,37 @@ function editEntry() {
 }
 
 // Navigation
-function navigateToEntity(entityId: string) {
-  router.push({ name: 'entity', params: { id: entityId } })
+//
+// Entity links in custom-view sections used to call
+// router.push({ name: 'entity', params: { id } }), but that route requires
+// :type/:id — the push silently failed and clicks did nothing (issue #647).
+// Now we resolve the path via entityDetailHref so right-click /
+// cmd-click / middle-click open in a new tab through the real <a href>,
+// and we attach return_to so the EntityView back-button returns here.
+//
+// NOTE: relation-column cells in tables show *related* entities but the
+// click navigates to the row entity (pre-existing behavior). The backend
+// would need to expose related-entity types per cell to navigate to the
+// related target — out of scope for this fix.
+function entityHref(entity: EntityRef, cellLink?: string): string {
+  return entityDetailHref(entity, schemaStore.getEntityDetailView, { cellLink })
+}
+
+function navigateToEntity(entity: EntityRef, cellLink?: string) {
+  const path = entityHref(entity, cellLink)
+  if (!path) return
+  const returnTo = `/view/${props.id}/${props.entityId}`
+  router.push({ path, query: { return_to: returnTo } })
 }
 
 function navigateToEdit(formId: string, entityId: string) {
   router.push({ name: 'form-edit', params: { id: formId, entityId } })
 }
 
-function navigateToCreate(formId: string, relationInfo?: { relation: string; linkAs: string; peerId: string }) {
+function navigateToCreate(
+  formId: string,
+  relationInfo?: { relation: string; linkAs: string; peerId: string }
+) {
   const query: Record<string, string> = {}
   if (relationInfo) {
     query.linkRelation = relationInfo.relation
@@ -142,7 +165,10 @@ function navigateToCreate(formId: string, relationInfo?: { relation: string; lin
 }
 
 // Link existing modal
-function openLinkExisting(linkInfo: { relation: string; linkAs: 'from' | 'to'; peerId: string; entityTypes: string[] }, section: { entities?: Array<{ id: string }>, rows?: Array<{ entityId: string }> }) {
+function openLinkExisting(
+  linkInfo: { relation: string; linkAs: 'from' | 'to'; peerId: string; entityTypes: string[] },
+  section: { entities?: Array<{ id: string }>; rows?: Array<{ entityId: string }> }
+) {
   // Collect already-linked IDs from this section to exclude them
   const excludeIds: string[] = []
   if (section.entities) {
@@ -199,7 +225,7 @@ onMounted(() => loadView())
   <div class="custom-view">
     <!-- Loading state -->
     <div v-if="loading" class="loading">
-      <div class="spinner"/>
+      <div class="spinner" />
       <p>Loading view...</p>
     </div>
 
@@ -217,21 +243,13 @@ onMounted(() => loadView())
       <div v-if="backTarget || scopeNav" class="scope-nav">
         <BackButton v-if="backTarget" :target="backTarget" />
         <template v-if="scopeNav">
-          <button
-            v-if="scopeNav.prevId"
-            class="scope-nav-btn"
-            @click="navigateScope('prev')"
-          >
+          <button v-if="scopeNav.prevId" class="scope-nav-btn" @click="navigateScope('prev')">
             ← Prev <kbd>P</kbd>
           </button>
           <span v-else class="scope-nav-btn disabled">← Prev</span>
           <span class="scope-nav-progress">[{{ scopeNav.current }}/{{ scopeNav.total }}]</span>
           <span class="scope-nav-label">{{ scopeNav.label }}</span>
-          <button
-            v-if="scopeNav.nextId"
-            class="scope-nav-btn"
-            @click="navigateScope('next')"
-          >
+          <button v-if="scopeNav.nextId" class="scope-nav-btn" @click="navigateScope('next')">
             Next → <kbd>N</kbd>
           </button>
           <span v-else class="scope-nav-btn disabled">Next →</span>
@@ -257,7 +275,7 @@ onMounted(() => loadView())
       <!-- Jump bar -->
       <nav v-if="viewData.sections.length > 1" class="jump-bar">
         <button
-          v-for="section in viewData.sections.filter(s => s.heading)"
+          v-for="section in viewData.sections.filter((s) => s.heading)"
           :key="section.sectionId"
           class="jump-link"
           @click="scrollToSection(section.sectionId)"
@@ -288,22 +306,28 @@ onMounted(() => loadView())
           />
 
           <!-- Content display (single) -->
-          <div v-else-if="section.display === 'content' && section.hasContent" class="content-block">
-            <div class="markdown-content" v-html="renderMarkdown(section.content || '')"/>
+          <div
+            v-else-if="section.display === 'content' && section.hasContent"
+            class="content-block"
+          >
+            <div class="markdown-content" v-html="renderMarkdown(section.content || '')" />
           </div>
 
           <!-- Content display (collection) -->
-          <div v-else-if="section.display === 'content' && section.entities?.length" class="content-cards">
-            <article
-              v-for="entity in section.entities"
-              :key="entity.id"
-              class="content-card"
-            >
-              <header class="card-header" @click="navigateToEntity(entity.id)">
+          <div
+            v-else-if="section.display === 'content' && section.entities?.length"
+            class="content-cards"
+          >
+            <article v-for="entity in section.entities" :key="entity.id" class="content-card">
+              <header class="card-header" @click="navigateToEntity(entity)">
                 <span class="entity-type">{{ entity.type }}</span>
                 <span class="entity-title">{{ entity.title }}</span>
               </header>
-              <div v-if="entity.hasContent" class="markdown-content" v-html="renderMarkdown(entity.content || '')"/>
+              <div
+                v-if="entity.hasContent"
+                class="markdown-content"
+                v-html="renderMarkdown(entity.content || '')"
+              />
             </article>
           </div>
 
@@ -313,7 +337,7 @@ onMounted(() => loadView())
               v-for="entity in section.entities"
               :key="entity.id"
               class="entity-card"
-              @click="navigateToEntity(entity.id)"
+              @click="navigateToEntity(entity)"
             >
               <header class="card-header">
                 <span class="entity-type">{{ entity.type }}</span>
@@ -346,12 +370,13 @@ onMounted(() => loadView())
 
           <!-- List display -->
           <ul v-else-if="section.display === 'list'" class="entity-list">
-            <li
-              v-for="entity in section.entities"
-              :key="entity.id"
-              class="list-item"
-            >
-              <a class="list-link" @click="navigateToEntity(entity.id)">
+            <li v-for="entity in section.entities" :key="entity.id" class="list-item">
+              <a
+                v-if="entityHref(entity)"
+                class="list-link"
+                :href="entityHref(entity)"
+                @click.prevent="navigateToEntity(entity)"
+              >
                 <span class="entity-type">{{ entity.type }}</span>
                 <span class="entity-title">{{ entity.title }}</span>
               </a>
@@ -380,7 +405,7 @@ onMounted(() => loadView())
                       <th v-for="col in section.columns" :key="col.property || col.relation">
                         {{ col.label || col.property || col.relation }}
                       </th>
-                      <th class="actions-col"/>
+                      <th class="actions-col" />
                     </tr>
                   </thead>
                   <tbody>
@@ -389,7 +414,9 @@ onMounted(() => loadView())
                         <a
                           v-if="cell.link"
                           :href="cell.link"
-                          @click.prevent="navigateToEntity(cell.entityId || row.entityId)"
+                          @click.prevent="
+                            navigateToEntity({ id: row.entityId, type: row.entityType }, cell.link)
+                          "
                         >
                           <template v-for="(val, vidx) in cell.values" :key="vidx">
                             <Badge
@@ -436,7 +463,7 @@ onMounted(() => loadView())
                   <th v-for="col in section.columns" :key="col.property || col.relation">
                     {{ col.label || col.property || col.relation }}
                   </th>
-                  <th class="actions-col"/>
+                  <th class="actions-col" />
                 </tr>
               </thead>
               <tbody>
@@ -445,7 +472,9 @@ onMounted(() => loadView())
                     <a
                       v-if="cell.link"
                       :href="cell.link"
-                      @click.prevent="navigateToEntity(cell.entityId || row.entityId)"
+                      @click.prevent="
+                        navigateToEntity({ id: row.entityId, type: row.entityType }, cell.link)
+                      "
                     >
                       <template v-for="(val, vidx) in cell.values" :key="vidx">
                         <Badge
@@ -491,11 +520,13 @@ onMounted(() => loadView())
                 v-for="target in section.addInfo.targets"
                 :key="target.entityType"
                 class="btn btn-add"
-                @click="navigateToCreate(target.formId, {
-                  relation: section.addInfo!.relation,
-                  linkAs: section.addInfo!.linkAs,
-                  peerId: section.addInfo!.peerId
-                })"
+                @click="
+                  navigateToCreate(target.formId, {
+                    relation: section.addInfo!.relation,
+                    linkAs: section.addInfo!.linkAs,
+                    peerId: section.addInfo!.peerId,
+                  })
+                "
               >
                 + Add {{ target.label }}
               </button>
@@ -826,10 +857,20 @@ onMounted(() => loadView())
   gap: 8px;
   cursor: pointer;
   flex: 1;
+  /* Real <a href>: suppress UA underline + visited color so the visual
+   * matches the existing affordance, while keyboard a11y is preserved. */
+  text-decoration: none;
+  color: inherit;
 }
 
 .list-link:hover .entity-title {
   color: var(--accent-color);
+}
+
+.list-link:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 .list-fields {

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -132,17 +132,18 @@ type V1CustomType struct {
 
 // V1Config is the JSON representation of the UI config.
 type V1Config struct {
-	App        V1AppConfig                               `json:"app"`
-	Styles     map[string]map[string]string              `json:"styles"`
-	Forms      map[string]dataentryconfig.Form           `json:"forms"`
-	Lists      map[string]dataentryconfig.List           `json:"lists"`
-	Views      map[string]dataentryconfig.ViewConfig     `json:"views"`
-	Kanbans    map[string]dataentryconfig.Kanban         `json:"kanbans"`
-	Dashboard  *dataentryconfig.DashboardConfig          `json:"dashboard,omitempty"`
-	Actions    map[string]dataentryconfig.Action         `json:"actions,omitempty"`
-	Navigation []dataentryconfig.NavigationEntry         `json:"navigation"`
-	Documents  map[string]dataentryconfig.DocumentConfig `json:"documents,omitempty"`
-	Palette    *dataentryconfig.ResolvedPalette          `json:"palette,omitempty"`
+	App         V1AppConfig                                 `json:"app"`
+	Styles      map[string]map[string]string                `json:"styles"`
+	Forms       map[string]dataentryconfig.Form             `json:"forms"`
+	Lists       map[string]dataentryconfig.List             `json:"lists"`
+	Views       map[string]dataentryconfig.ViewConfig       `json:"views"`
+	EntityViews map[string]dataentryconfig.EntityViewConfig `json:"entity_views,omitempty"`
+	Kanbans     map[string]dataentryconfig.Kanban           `json:"kanbans"`
+	Dashboard   *dataentryconfig.DashboardConfig            `json:"dashboard,omitempty"`
+	Actions     map[string]dataentryconfig.Action           `json:"actions,omitempty"`
+	Navigation  []dataentryconfig.NavigationEntry           `json:"navigation"`
+	Documents   map[string]dataentryconfig.DocumentConfig   `json:"documents,omitempty"`
+	Palette     *dataentryconfig.ResolvedPalette            `json:"palette,omitempty"`
 }
 
 // V1AppConfig is the JSON representation of the app config.
@@ -1014,16 +1015,17 @@ func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
 			Name:        s.Cfg.App.Name,
 			Description: s.Cfg.App.Description,
 		},
-		Styles:     s.StyleMap,
-		Forms:      forms,
-		Lists:      s.Cfg.Lists,
-		Views:      s.Cfg.Views,
-		Kanbans:    s.Cfg.Kanbans,
-		Dashboard:  s.Cfg.Dashboard,
-		Actions:    s.Cfg.Actions,
-		Navigation: s.Cfg.Navigation,
-		Documents:  s.Cfg.Documents,
-		Palette:    s.Palette,
+		Styles:      s.StyleMap,
+		Forms:       forms,
+		Lists:       s.Cfg.Lists,
+		Views:       s.Cfg.Views,
+		EntityViews: s.Cfg.EntityViews,
+		Kanbans:     s.Cfg.Kanbans,
+		Dashboard:   s.Cfg.Dashboard,
+		Actions:     s.Cfg.Actions,
+		Navigation:  s.Cfg.Navigation,
+		Documents:   s.Cfg.Documents,
+		Palette:     s.Palette,
 	}
 
 	writeV1JSON(w, http.StatusOK, config)

--- a/internal/dataentry/e2e_test.go
+++ b/internal/dataentry/e2e_test.go
@@ -76,9 +76,9 @@ func newE2ETestApp(t *testing.T) (*App, string, func()) {
 // the rendered HTML contains markers produced by the Lua script plus
 // a rewritten form link. Exercises the full chain:
 //
-//   HTTP handler → documentService.Render → script.Engine.ExecuteDocument
-//   → Lua VM (with rela.document + rela.url bindings) → goldmark → link
-//   rewriter (adds return_to to form routes) → DOMPurify in browser
+//	HTTP handler → documentService.Render → script.Engine.ExecuteDocument
+//	→ Lua VM (with rela.document + rela.url bindings) → goldmark → link
+//	rewriter (adds return_to to form routes) → DOMPurify in browser
 //
 // The prototype ships `scripts/docs/category_report.lua` wired as the
 // `category_overview` document for entity_type `category`. The `backend`

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -63,20 +63,30 @@ func (d Direction) IsIncoming() bool {
 
 // Config is the top-level configuration for a data entry application.
 type Config struct {
-	Version    string                       `yaml:"version"`
-	App        AppConfig                    `yaml:"app"`
-	Git        *git.Config                  `yaml:"git,omitempty"`
-	Palette    *PaletteConfig               `yaml:"palette,omitempty"`
-	Styles     map[string]map[string]string `yaml:"styles"`
-	Forms      map[string]Form              `yaml:"forms"`
-	Lists      map[string]List              `yaml:"lists"`
-	Views      map[string]ViewConfig        `yaml:"views"`
-	Kanbans    map[string]Kanban            `yaml:"kanbans"`
-	Documents  map[string]DocumentConfig    `yaml:"documents,omitempty"`
-	Dashboard  *DashboardConfig             `yaml:"dashboard,omitempty"`
-	Commands   map[string]CommandConfig     `yaml:"commands,omitempty"`
-	Actions    map[string]Action            `yaml:"actions,omitempty"`
-	Navigation []NavigationEntry            `yaml:"navigation"`
+	Version     string                       `yaml:"version"`
+	App         AppConfig                    `yaml:"app"`
+	Git         *git.Config                  `yaml:"git,omitempty"`
+	Palette     *PaletteConfig               `yaml:"palette,omitempty"`
+	Styles      map[string]map[string]string `yaml:"styles"`
+	Forms       map[string]Form              `yaml:"forms"`
+	Lists       map[string]List              `yaml:"lists"`
+	Views       map[string]ViewConfig        `yaml:"views"`
+	EntityViews map[string]EntityViewConfig  `yaml:"entity_views,omitempty" json:"entity_views,omitempty"`
+	Kanbans     map[string]Kanban            `yaml:"kanbans"`
+	Documents   map[string]DocumentConfig    `yaml:"documents,omitempty"`
+	Dashboard   *DashboardConfig             `yaml:"dashboard,omitempty"`
+	Commands    map[string]CommandConfig     `yaml:"commands,omitempty"`
+	Actions     map[string]Action            `yaml:"actions,omitempty"`
+	Navigation  []NavigationEntry            `yaml:"navigation"`
+}
+
+// EntityViewConfig declares UX bindings for a metamodel entity type.
+// detail_view names the canonical view used to display an entity of this type
+// — consumed by the SPA when an entity link needs to be rendered (entity-list
+// rows, custom-view sections). Missing detail_view falls back to
+// /entity/:type/:id.
+type EntityViewConfig struct {
+	DetailView string `yaml:"detail_view,omitempty" json:"detail_view,omitempty"`
 }
 
 // Action defines an operation that can be triggered from the UI.

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -14,20 +14,21 @@ import (
 
 // Valid top-level keys in data-entry.yaml
 var validTopLevelKeys = map[string]bool{
-	"version":    true,
-	"app":        true,
-	"git":        true,
-	"styles":     true,
-	"forms":      true,
-	"lists":      true,
-	"views":      true,
-	"kanbans":    true,
-	"documents":  true,
-	"dashboard":  true,
-	"commands":   true,
-	"actions":    true,
-	"navigation": true,
-	"palette":    true,
+	"version":      true,
+	"app":          true,
+	"git":          true,
+	"styles":       true,
+	"forms":        true,
+	"lists":        true,
+	"views":        true,
+	"entity_views": true,
+	"kanbans":      true,
+	"documents":    true,
+	"dashboard":    true,
+	"commands":     true,
+	"actions":      true,
+	"navigation":   true,
+	"palette":      true,
 }
 
 // Known typos with suggestions
@@ -114,6 +115,7 @@ func ValidateConfig(data []byte, cfg *Config, meta *metamodel.Metamodel) error {
 	errs = append(errs, validateForms(cfg, meta)...)
 	errs = append(errs, validateLists(cfg, meta)...)
 	errs = append(errs, validateViews(cfg, meta)...)
+	errs = append(errs, validateEntityViews(cfg, meta)...)
 	errs = append(errs, validateKanbans(cfg, meta)...)
 	errs = append(errs, validateDashboard(cfg, meta)...)
 	errs = append(errs, validateCommands(cfg, meta)...)
@@ -316,6 +318,36 @@ func GetValidEnumValues(propDef metamodel.PropertyDef, meta *metamodel.Metamodel
 		return customType.Values
 	}
 	return nil
+}
+
+// validateEntityViews validates entity_views entries: each key must be a known
+// entity type, and each detail_view must reference an existing view.
+func validateEntityViews(cfg *Config, meta *metamodel.Metamodel) []string {
+	var errs []string
+	for entityType, ev := range cfg.EntityViews {
+		if _, ok := meta.GetEntityDef(entityType); !ok {
+			errs = append(errs, fmt.Sprintf(
+				"entity_views: unknown entity type %q", entityType))
+		}
+		if ev.DetailView == "" {
+			errs = append(errs, fmt.Sprintf(
+				"entity_views[%q]: detail_view is empty (omit the entry instead)", entityType))
+			continue
+		}
+		if _, ok := cfg.Views[ev.DetailView]; ok {
+			continue
+		}
+		if suggestion := suggestView(ev.DetailView, cfg); suggestion != "" {
+			errs = append(errs, fmt.Sprintf(
+				"entity_views[%q]: references unknown view %q in detail_view (did you mean %q?)",
+				entityType, ev.DetailView, suggestion))
+		} else {
+			errs = append(errs, fmt.Sprintf(
+				"entity_views[%q]: references unknown view %q in detail_view",
+				entityType, ev.DetailView))
+		}
+	}
+	return errs
 }
 
 // validateLists validates list definitions.

--- a/internal/dataentryconfig/validate_test.go
+++ b/internal/dataentryconfig/validate_test.go
@@ -1447,3 +1447,101 @@ func TestValidateNavigation_KnownAction(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+func TestValidateEntityViews_Valid(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"ticket_detail": {Entry: ViewEntry{Type: "ticket"}},
+		},
+		EntityViews: map[string]EntityViewConfig{
+			"ticket": {DetailView: "ticket_detail"},
+		},
+	}
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateEntityViews_AbsentIsValid(t *testing.T) {
+	// The pre-migration baseline: no entity_views key at all must validate.
+	meta := testMetamodel()
+	cfg := &Config{}
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateEntityViews_UnknownEntityType(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"any_view": {Entry: ViewEntry{Type: "ticket"}},
+		},
+		EntityViews: map[string]EntityViewConfig{
+			"unknown_type": {DetailView: "any_view"},
+		},
+	}
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil || !strings.Contains(err.Error(), `entity_views: unknown entity type "unknown_type"`) {
+		t.Errorf("expected unknown entity type error, got: %v", err)
+	}
+}
+
+func TestValidateEntityViews_EmptyDetailViewIsError(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		EntityViews: map[string]EntityViewConfig{
+			"ticket": {DetailView: ""},
+		},
+	}
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil || !strings.Contains(err.Error(), "detail_view is empty") {
+		t.Errorf("expected empty detail_view error, got: %v", err)
+	}
+}
+
+func TestValidateEntityViews_UnknownDetailView(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"ticket_detail": {Entry: ViewEntry{Type: "ticket"}},
+		},
+		EntityViews: map[string]EntityViewConfig{
+			"ticket": {DetailView: "nonexistent_view"},
+		},
+	}
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil || !strings.Contains(err.Error(), `references unknown view "nonexistent_view"`) {
+		t.Errorf("expected unknown view error, got: %v", err)
+	}
+}
+
+func TestValidateConfig_UnknownTopLevelKey_EntityViewsAccepted(t *testing.T) {
+	// Regression: entity_views: must be in validTopLevelKeys.
+	meta := testMetamodel()
+	yamlData := []byte(`
+version: "1.0"
+entity_views:
+  ticket:
+    detail_view: ticket_detail
+views:
+  ticket_detail:
+    entry:
+      type: ticket
+`)
+	cfg := &Config{
+		Views: map[string]ViewConfig{
+			"ticket_detail": {Entry: ViewEntry{Type: "ticket"}},
+		},
+		EntityViews: map[string]EntityViewConfig{
+			"ticket": {DetailView: "ticket_detail"},
+		},
+	}
+	err := ValidateConfig(yamlData, cfg, meta)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/migration/detail_view_to_entity_views.go
+++ b/internal/migration/detail_view_to_entity_views.go
@@ -1,0 +1,200 @@
+// Package migration: detail_view_to_entity_views
+//
+// Lifts list-level `detail_view` into a new top-level `entity_views` section.
+// The migration is idempotent: Detect() reports true only when Apply() will
+// actually move at least one value. Conflicting groups (multiple lists for
+// the same entity_type with different detail_view values) are skipped — the
+// conflict surfaces via `rela validate` (out of scope here) rather than
+// blocking startup forever.
+//
+// Subset/filter lists that previously had no detail_view inherit the
+// canonical detail_view for their type after migration. This is intentional:
+// "where do you view an X" should have one answer, and a subset view of
+// type X should land users on the same detail page as the canonical list.
+
+package migration
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+func init() {
+	Register(&DetailViewToEntityViewsMigration{})
+}
+
+// DetailViewToEntityViewsMigration moves lists.<id>.detail_view to
+// entity_views.<entity_type>.detail_view.
+type DetailViewToEntityViewsMigration struct{}
+
+func (m *DetailViewToEntityViewsMigration) Name() string {
+	return "detail-view-to-entity-views"
+}
+
+func (m *DetailViewToEntityViewsMigration) Description() string {
+	return "Move list-level detail_view to top-level entity_views.<type>.detail_view"
+}
+
+func (m *DetailViewToEntityViewsMigration) FileTypes() []FileType {
+	return []FileType{FileTypeDataEntry}
+}
+
+// Detect returns true only when Apply() would change something. This keeps
+// the migration idempotent: after running, conflicting groups remain
+// untouched and Detect() returns false on the next pass so the server can
+// start.
+func (m *DetailViewToEntityViewsMigration) Detect(doc *yaml.Node) bool {
+	root := GetDocumentRoot(doc)
+	if root == nil {
+		return false
+	}
+	migratable := m.collectMigratableGroups(root)
+	return len(migratable) > 0
+}
+
+func (m *DetailViewToEntityViewsMigration) Apply(doc *yaml.Node) error {
+	root := GetDocumentRoot(doc)
+	if root == nil {
+		return errors.New("empty document")
+	}
+
+	migratable := m.collectMigratableGroups(root)
+	if len(migratable) == 0 {
+		return nil
+	}
+
+	// Ensure top-level `entity_views:` mapping exists.
+	entityViews := GetMapValue(root, "entity_views")
+	if entityViews == nil {
+		entityViews = &yaml.Node{Kind: yaml.MappingNode}
+		// Insert after `lists:` if present, else after `forms:`, else append.
+		anchor := "lists"
+		if GetMapValue(root, anchor) == nil {
+			anchor = "forms"
+		}
+		InsertMapKeyAfter(root, anchor, "entity_views", entityViews)
+	} else if entityViews.Kind != yaml.MappingNode {
+		// Hand-written but malformed — refuse to merge.
+		return errors.New("entity_views: exists but is not a mapping")
+	}
+
+	// Sorted iteration so output is deterministic.
+	types := make([]string, 0, len(migratable))
+	for t := range migratable {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+
+	for _, entityType := range types {
+		view := migratable[entityType]
+		// Merge into existing entity_views entry if present.
+		existing := GetMapValue(entityViews, entityType)
+		switch {
+		case existing == nil:
+			entry := &yaml.Node{Kind: yaml.MappingNode}
+			SetMapValue(entry, "detail_view", view)
+			entityViews.Content = append(entityViews.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Value: entityType},
+				entry,
+			)
+		case existing.Kind == yaml.MappingNode:
+			SetMapValue(existing, "detail_view", view)
+		default:
+			// Existing entry is malformed (scalar, sequence, etc.). Refuse
+			// to silently strip the list-level detail_view we'd otherwise
+			// delete below, since we can't safely write the new value.
+			return fmt.Errorf("entity_views.%s: exists but is not a mapping", entityType)
+		}
+	}
+
+	// Strip detail_view from every list whose entity_type was migrated.
+	lists := GetMapValue(root, "lists")
+	if lists != nil && lists.Kind == yaml.MappingNode {
+		for i := 1; i < len(lists.Content); i += 2 {
+			listDef := lists.Content[i]
+			if listDef.Kind != yaml.MappingNode {
+				continue
+			}
+			entityType := getScalarValue(listDef, "entity_type")
+			if _, ok := migratable[entityType]; !ok {
+				continue
+			}
+			DeleteMapKey(listDef, "detail_view")
+		}
+	}
+
+	return nil
+}
+
+// collectMigratableGroups walks lists, groups by entity_type, and returns
+// the migrate-able groups (single distinct detail_view value, taking any
+// pre-existing entity_views entry as one of the votes). Conflicting
+// groups (multiple lists for the same type with different detail_views)
+// are silently skipped — surfacing them belongs in `rela validate`.
+func (m *DetailViewToEntityViewsMigration) collectMigratableGroups(root *yaml.Node) map[string]string {
+	migratable := map[string]string{}
+
+	lists := GetMapValue(root, "lists")
+	if lists == nil || lists.Kind != yaml.MappingNode {
+		return migratable
+	}
+
+	// Pre-existing entity_views: their detail_view counts as the canonical
+	// vote for that entity_type — list-level values must agree with it or
+	// the group is conflicting.
+	existing := map[string]string{}
+	if entityViews := GetMapValue(root, "entity_views"); entityViews != nil && entityViews.Kind == yaml.MappingNode {
+		for i := 0; i < len(entityViews.Content)-1; i += 2 {
+			typeName := entityViews.Content[i].Value
+			entry := entityViews.Content[i+1]
+			if entry.Kind != yaml.MappingNode {
+				continue
+			}
+			if v := getScalarValue(entry, "detail_view"); v != "" {
+				existing[typeName] = v
+			}
+		}
+	}
+
+	// Per-type vote: collect distinct detail_view values from lists.
+	votes := map[string]map[string]bool{}
+	hasListLevel := map[string]bool{}
+	for i := 1; i < len(lists.Content); i += 2 {
+		listDef := lists.Content[i]
+		if listDef.Kind != yaml.MappingNode {
+			continue
+		}
+		entityType := getScalarValue(listDef, "entity_type")
+		detailView := getScalarValue(listDef, "detail_view")
+		if entityType == "" || detailView == "" {
+			continue
+		}
+		hasListLevel[entityType] = true
+		if votes[entityType] == nil {
+			votes[entityType] = map[string]bool{}
+		}
+		votes[entityType][detailView] = true
+	}
+
+	// Only entity_types with list-level votes are candidates — we don't
+	// rewrite anything if there's no list-level value to move.
+	for entityType, distinct := range votes {
+		if !hasListLevel[entityType] {
+			continue
+		}
+		// Include the existing entity_views value as a vote.
+		if v, ok := existing[entityType]; ok {
+			distinct[v] = true
+		}
+		// Single distinct value → migrate-able. Otherwise a conflict; skip.
+		if len(distinct) == 1 {
+			for v := range distinct {
+				migratable[entityType] = v
+			}
+		}
+	}
+	return migratable
+}

--- a/internal/migration/detail_view_to_entity_views_test.go
+++ b/internal/migration/detail_view_to_entity_views_test.go
@@ -1,0 +1,406 @@
+package migration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestDetailViewToEntityViewsMigration_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		expected bool
+	}{
+		{
+			name: "single list with detail_view",
+			yaml: `
+lists:
+  all_ideas:
+    entity_type: idea
+    detail_view: idea_detail
+`,
+			expected: true,
+		},
+		{
+			name: "multiple lists same type same detail_view",
+			yaml: `
+lists:
+  all_ideas:
+    entity_type: idea
+    detail_view: idea_detail
+  active_ideas:
+    entity_type: idea
+    detail_view: idea_detail
+`,
+			expected: true,
+		},
+		{
+			name: "multiple lists same type one without detail_view (still migratable)",
+			yaml: `
+lists:
+  all_ideas:
+    entity_type: idea
+    detail_view: idea_detail
+  active_ideas:
+    entity_type: idea
+`,
+			expected: true,
+		},
+		{
+			name: "conflicting detail_view across lists for same type",
+			yaml: `
+lists:
+  all_ideas:
+    entity_type: idea
+    detail_view: idea_detail
+  alt_ideas:
+    entity_type: idea
+    detail_view: idea_detail_alt
+`,
+			expected: false,
+		},
+		{
+			name: "no detail_view anywhere",
+			yaml: `
+lists:
+  all_tickets:
+    entity_type: ticket
+`,
+			expected: false,
+		},
+		{
+			name: "already migrated (entity_views set, list-level absent)",
+			yaml: `
+entity_views:
+  idea:
+    detail_view: idea_detail
+lists:
+  all_ideas:
+    entity_type: idea
+`,
+			expected: false,
+		},
+		{
+			name: "list-level matches existing entity_views (migratable: drop list-level)",
+			yaml: `
+entity_views:
+  idea:
+    detail_view: idea_detail
+lists:
+  all_ideas:
+    entity_type: idea
+    detail_view: idea_detail
+`,
+			expected: true,
+		},
+		{
+			name: "list-level conflicts with existing entity_views (skip)",
+			yaml: `
+entity_views:
+  idea:
+    detail_view: idea_detail
+lists:
+  all_ideas:
+    entity_type: idea
+    detail_view: other_detail
+`,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var doc yaml.Node
+			if err := yaml.Unmarshal([]byte(tt.yaml), &doc); err != nil {
+				t.Fatalf("failed to parse yaml: %v", err)
+			}
+			migration := &DetailViewToEntityViewsMigration{}
+			if got := migration.Detect(&doc); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDetailViewToEntityViewsMigration_Apply(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name: "single list",
+			input: `lists:
+  all_ideas:
+    entity_type: idea
+    detail_view: idea_detail
+`,
+			wantContains: []string{
+				"entity_views:",
+				"idea:",
+				"detail_view: idea_detail",
+				"all_ideas:",
+				"entity_type: idea",
+			},
+			wantNotContain: []string{
+				"detail_view: idea_detail\n        entity_type", // no longer on list
+			},
+		},
+		{
+			name: "multiple lists, one with detail_view (subset inheritance)",
+			input: `lists:
+  all_ideas:
+    entity_type: idea
+    detail_view: idea_detail
+  active_ideas:
+    entity_type: idea
+  game_changers:
+    entity_type: idea
+`,
+			wantContains: []string{
+				"entity_views:",
+				"detail_view: idea_detail",
+				"active_ideas:",
+				"game_changers:",
+			},
+		},
+		{
+			name: "merge into existing entity_views (matching value)",
+			input: `entity_views:
+  idea:
+    detail_view: idea_detail
+lists:
+  all_ideas:
+    entity_type: idea
+    detail_view: idea_detail
+`,
+			wantContains: []string{
+				"entity_views:",
+				"detail_view: idea_detail",
+			},
+		},
+		{
+			name: "conflict skipped, lists untouched",
+			input: `lists:
+  all_ideas:
+    entity_type: idea
+    detail_view: idea_detail
+  alt_ideas:
+    entity_type: idea
+    detail_view: other_detail
+`,
+			wantContains: []string{
+				"detail_view: idea_detail",
+				"detail_view: other_detail",
+			},
+			wantNotContain: []string{
+				"entity_views:",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var doc yaml.Node
+			if err := yaml.Unmarshal([]byte(tt.input), &doc); err != nil {
+				t.Fatalf("failed to parse yaml: %v", err)
+			}
+			migration := &DetailViewToEntityViewsMigration{}
+			if err := migration.Apply(&doc); err != nil {
+				t.Fatalf("Apply() error: %v", err)
+			}
+			out, err := yaml.Marshal(&doc)
+			if err != nil {
+				t.Fatalf("marshal error: %v", err)
+			}
+			outStr := string(out)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(outStr, want) {
+					t.Errorf("expected output to contain %q, got:\n%s", want, outStr)
+				}
+			}
+			for _, notWant := range tt.wantNotContain {
+				if strings.Contains(outStr, notWant) {
+					t.Errorf("expected output NOT to contain %q, got:\n%s", notWant, outStr)
+				}
+			}
+		})
+	}
+}
+
+func TestDetailViewToEntityViewsMigration_RefusesMalformedExistingEntry(t *testing.T) {
+	// If entity_views.<type> is hand-written as a non-mapping (e.g. scalar
+	// shorthand), Apply must error rather than silently delete the list-level
+	// detail_view we'd otherwise strip — that would be data loss.
+	input := `entity_views:
+  idea: "oops_a_string"
+lists:
+  all_ideas:
+    entity_type: idea
+    detail_view: idea_detail
+`
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(input), &doc); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	migration := &DetailViewToEntityViewsMigration{}
+	err := migration.Apply(&doc)
+	if err == nil {
+		t.Fatal("expected error for malformed entity_views entry")
+	}
+	if !strings.Contains(err.Error(), "entity_views.idea") {
+		t.Errorf("expected error to mention entity_views.idea, got: %v", err)
+	}
+	// And the list-level detail_view must still be present (not stripped).
+	out, _ := yaml.Marshal(&doc)
+	if !strings.Contains(string(out), "detail_view: idea_detail") {
+		t.Errorf("expected list-level detail_view to remain after refusal, got:\n%s", out)
+	}
+}
+
+func TestDetailViewToEntityViewsMigration_Idempotent(t *testing.T) {
+	// Single migrate-able group + one conflicting group. After Apply,
+	// Detect must return false (the conflict stays untouched, but Detect
+	// only reports migrate-able groups remain).
+	input := `lists:
+  all_ideas:
+    entity_type: idea
+    detail_view: idea_detail
+  conflict_a:
+    entity_type: ticket
+    detail_view: ticket_view_a
+  conflict_b:
+    entity_type: ticket
+    detail_view: ticket_view_b
+`
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(input), &doc); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	migration := &DetailViewToEntityViewsMigration{}
+
+	if !migration.Detect(&doc) {
+		t.Fatal("expected Detect to return true on first pass")
+	}
+	if err := migration.Apply(&doc); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	if migration.Detect(&doc) {
+		out, _ := yaml.Marshal(&doc)
+		t.Errorf("Detect should return false after first Apply (conflict shouldn't keep triggering); output:\n%s", string(out))
+	}
+	// Second Apply must be a no-op.
+	if err := migration.Apply(&doc); err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+}
+
+// TestDetailViewToEntityViews_InTreeConfigs_AlreadyMigrated guards against
+// regressions where a contributor adds a new lists.<id>.detail_view to an
+// in-tree data-entry.yaml without re-running the migration. The CI test
+// walks the repo for data-entry.yaml files and asserts Detect()=false on
+// each. Excludes prototypes/data-entry/catalog/ which has unrelated
+// pre-existing pending migrations (no detail_view in that file).
+func TestDetailViewToEntityViews_InTreeConfigs_AlreadyMigrated(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	migration := &DetailViewToEntityViewsMigration{}
+	skipDirs := map[string]bool{
+		"node_modules": true,
+		".git":         true,
+		// testdata/ is sacrosanct in Go's convention: fixtures may be
+		// deliberately unmigrated to exercise migration logic.
+		"testdata": true,
+	}
+
+	err := filepath.Walk(repoRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() && skipDirs[info.Name()] {
+			return filepath.SkipDir
+		}
+		if info.IsDir() || info.Name() != "data-entry.yaml" {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Errorf("read %s: %v", path, readErr)
+			return nil
+		}
+		var doc yaml.Node
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			// File doesn't parse as YAML; not our concern. Other tests
+			// validate config-file shape — we only care about migration
+			// state of files that *do* parse.
+			t.Logf("skip non-yaml %s: %v", path, err)
+			return nil
+		}
+		if migration.Detect(&doc) {
+			rel, _ := filepath.Rel(repoRoot, path)
+			t.Errorf("%s has list-level detail_view that needs migrating; run `rela migrate --project %s`",
+				rel, filepath.Dir(rel))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk failed: %v", err)
+	}
+}
+
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not locate go.mod walking up from %s", dir)
+		}
+		dir = parent
+	}
+}
+
+func TestDetailViewToEntityViewsMigration_PlacementAfterLists(t *testing.T) {
+	input := `version: "1.0"
+forms:
+  edit_idea:
+    entity_type: idea
+lists:
+  all_ideas:
+    entity_type: idea
+    detail_view: idea_detail
+views:
+  idea_detail:
+    entry:
+      type: idea
+`
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(input), &doc); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	migration := &DetailViewToEntityViewsMigration{}
+	if err := migration.Apply(&doc); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	out, _ := yaml.Marshal(&doc)
+	outStr := string(out)
+	listsIdx := strings.Index(outStr, "lists:")
+	entityViewsIdx := strings.Index(outStr, "entity_views:")
+	viewsIdx := strings.Index(outStr, "views:")
+	if listsIdx == -1 || entityViewsIdx == -1 || viewsIdx == -1 {
+		t.Fatalf("missing expected sections; output:\n%s", outStr)
+	}
+	if listsIdx >= entityViewsIdx || entityViewsIdx >= viewsIdx {
+		t.Errorf("expected ordering lists < entity_views < views; got:\n%s", outStr)
+	}
+}

--- a/internal/migration/yaml_util.go
+++ b/internal/migration/yaml_util.go
@@ -181,6 +181,38 @@ func GetDocumentRoot(doc *yaml.Node) *yaml.Node {
 	return doc
 }
 
+// InsertMapKeyAfter inserts a new key/value pair into a mapping node directly
+// after the entry whose key is `anchor`. If the anchor key isn't present, the
+// new pair is appended at the end. If the new key already exists in the
+// mapping, the call is a no-op (use SetMapValue if you want to overwrite).
+func InsertMapKeyAfter(node *yaml.Node, anchor, key string, value *yaml.Node) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+	// No-op if the key is already present.
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			return
+		}
+	}
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: key}
+	// Find anchor key index.
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value != anchor {
+			continue
+		}
+		// Insert directly after the (key, value) pair at index i (i.e. at i+2).
+		pos := i + 2
+		node.Content = append(node.Content, nil, nil)
+		copy(node.Content[pos+2:], node.Content[pos:])
+		node.Content[pos] = keyNode
+		node.Content[pos+1] = value
+		return
+	}
+	// Anchor not found — append at end.
+	node.Content = append(node.Content, keyNode, value)
+}
+
 // DeleteMapKey removes a key-value pair from a mapping node by key name.
 // Returns true if the key was found and deleted.
 func DeleteMapKey(node *yaml.Node, key string) bool {

--- a/prototypes/data-entry/project/data-entry.yaml
+++ b/prototypes/data-entry/project/data-entry.yaml
@@ -279,7 +279,6 @@ lists:
         widget: select
     create_form: create_ticket
     edit_form: edit_ticket
-    detail_view: ticket_report
     page_size: 25
     actions: [resolve-ticket, close-ticket]
   open_tickets:
@@ -343,8 +342,12 @@ lists:
       - property: name
         direction: asc
     create_form: create_category
-    detail_view: category_report
     page_size: 50
+entity_views:
+  category:
+    detail_view: category_report
+  ticket:
+    detail_view: ticket_report
 # ──────────────────────────────────────────────
 # Views: read-only detail views with graph traversal
 # ──────────────────────────────────────────────

--- a/tickets/data-entry.yaml
+++ b/tickets/data-entry.yaml
@@ -712,7 +712,6 @@ lists:
         widget: select
     create_form: create_idea
     edit_form: edit_idea
-    detail_view: idea_detail
     page_size: 25
   active_ideas:
     entity_type: idea
@@ -784,7 +783,6 @@ lists:
         widget: select
     create_form: create_future_concept
     edit_form: edit_future_concept
-    detail_view: future_concept_detail
     page_size: 25
   # ─────────────────────────────────────────────────
   # Features
@@ -810,7 +808,6 @@ lists:
         widget: select
     create_form: create_feature
     edit_form: edit_feature
-    detail_view: feature_detail
     page_size: 25
   # ─────────────────────────────────────────────────
   # Tickets & Bugs
@@ -911,7 +908,6 @@ lists:
         widget: select
     create_form: create_concept
     edit_form: edit_concept
-    detail_view: concept_detail
     page_size: 50
   all_decisions:
     entity_type: decision
@@ -933,6 +929,15 @@ lists:
     create_form: create_decision
     edit_form: edit_decision
     page_size: 25
+entity_views:
+  concept:
+    detail_view: concept_detail
+  feature:
+    detail_view: feature_detail
+  future-concept:
+    detail_view: future_concept_detail
+  idea:
+    detail_view: idea_detail
 # ══════════════════════════════════════════════════
 # Views (detail pages)
 # ══════════════════════════════════════════════════

--- a/tickets/entities/automated-measures/custom-view-list-section-navigation-e2e.md
+++ b/tickets/entities/automated-measures/custom-view-list-section-navigation-e2e.md
@@ -1,0 +1,9 @@
+---
+id: custom-view-list-section-navigation-e2e
+type: automated-measure
+title: 'E2E coverage: clicking a list-section item in a custom detail view navigates to the linked entity'
+description: 'End-to-end test that opens a custom detail view containing a section with display: list, clicks one of the list items, and asserts that the URL changes to the target entity''s detail page (preferring the configured detail_view of the corresponding list, falling back to /entity/:type/:id).'
+kind: test
+location: e2e/tests/
+status: proposed
+---

--- a/tickets/entities/bug-analysis-checklists/BUGA-SVMBV.md
+++ b/tickets/entities/bug-analysis-checklists/BUGA-SVMBV.md
@@ -1,0 +1,287 @@
+---
+id: BUGA-SVMBV
+type: bug-analysis-checklist
+title: 'Analysis: Detail-view list section items are not clickable (no href, broken router push)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Reproduction
+
+- [x] Bug reproduced locally
+
+Defined a custom detail view in `data-entry.yaml` with a section using `display:
+list` that traverses an outgoing relation. Opened the detail view in the
+browser, scrolled to the section, clicked an item.
+
+```yaml
+views:
+  detail_policy:
+    title: 'Beleid'
+    entry: { type: beleid }
+    traverse:
+      - from: entry
+        follow: schrijft_voor
+        collect_as: out_procedures
+    sections:
+      - heading: 'Schrijft procedures voor'
+        source: out_procedures
+        display: list
+        fields:
+          - property: titel
+          - property: status
+```
+
+- [x] Minimal reproduction steps documented
+
+  1. Configure a `view` with at least one `display: list` section that
+traverses to a related entity type.
+  2. Open the view: `/view/detail_policy/POLICY-001`.
+  3. Click any item in the list section. Expected: navigate to that
+entity's detail page. Actual: nothing happens.
+
+- [x] Environment/conditions noted
+
+Reported on macOS arm64, `rela` dev binary 30 apr 2026 (commit 0bbec24).
+Reproduces in any browser.
+
+## Root Cause
+
+- [x] Immediate cause identified (why1)
+
+`navigateToEntity` at `frontend/src/views/CustomView.vue:126-128` calls
+`router.push({ name: 'entity', params: { id: entityId } })` but the named route
+`entity` is `path: '/entity/:type/:id'`. Vue-router rejects with
+`MISSING_REQUIRED_PARAMS` and `router.onError` silently swallows it (no console
+error, no nav).
+
+- [x] Contributing factors found (why2-3)
+
+  - Why 2: `navigateToEntity(entityId)` accepts only an id, even though the
+API response includes the type for every list/card/content item.
+  - Why 3: There is no test exercising the click path on a custom view's
+list/cards/content section.
+
+- [x] Systemic cause explored (why4-5)
+
+  - Why 4: "Where do you view an entity of type X" is currently encoded on
+*lists* (`lists.<id>.detail_view`) — but a list isn't the right anchor for that
+question. `EntityList.vue` happens to be inside a list when navigating, so it
+has unambiguous context. `CustomView.vue` doesn't, and there's no clean "the
+default detail view for type X" lookup.
+  - Why 5: Entity-type-level UX defaults aren't representable. Adding
+`entity_views.<type>.detail_view` to `data-entry.yaml` fixes both this bug and
+the broader question once.
+
+## Fix Planning
+
+- [x] Fix approach determined
+
+### Config schema change (Phase 1 of two-phase plan)
+
+Add a new top-level `entity_views:` section to `data-entry.yaml`:
+
+```yaml
+entity_views:
+  procedure:
+    detail_view: detail_procedure
+  beleid:
+    detail_view: detail_beleid
+```
+
+**Key name** is `entity_views`, not `entity_types`, to avoid collision with
+existing `commands.available_on.entity_types` and user-defaults
+`overrides.entity_types` (both `[]string` lists). Verified existing usages
+during second design review.
+
+Semantics: `entity_views.<type>.detail_view` is *the* canonical detail view for
+entities of that type. Used by both `EntityList.vue` (replacing
+`lists.<id>.detail_view` after migration) and `CustomView.vue` sections.
+
+Future Phase 2 (out of scope): per-section
+`views.<viewId>.sections[].link_to_view` override. Lookup chain becomes
+`section.link_to_view → entity_views.<type>.detail_view → /entity/:type/:id`.
+
+### Migration
+
+New `internal/migration/detail_view_to_entity_views.go`. Apply:
+
+1. Group lists by `entity_type`. Collect distinct `detail_view` values per group.
+2. Migrate-able group (single distinct value, or all match): write
+`entity_views.<entity_type>.detail_view: <view>` (merge into existing
+`entity_views:` if present), delete `detail_view:` from all lists in the group.
+3. Conflicting values: skip the group entirely. The migration neither writes
+to `entity_views` nor strips from lists. The conflict is a config error to be
+surfaced via `rela validate` separately (out of scope: `validate.go` can warn
+that `lists.<id1>.detail_view` and `lists.<id2>.detail_view` differ for the same
+entity type — that's a separate enhancement).
+4. **`Detect()` must be idempotent**: it returns `true` only when `Apply()`
+will produce a non-empty change. Specifically: at least one migrate-able group
+exists. After migration of all migrate-able groups, only conflicting groups
+remain — `Detect()` returns `false` and the server starts. The conflict is
+permanent until the user reconciles it manually.
+
+**YAML insertion**: The new `entity_views:` block is inserted *after* `lists:`
+(or after `forms:` if `lists:` is absent) using a new `yaml_util.go` helper
+`InsertMapKeyAfter(root, anchor, key, valueNode)`. Rationale: `entity_views` is
+conceptually adjacent to `lists`/`views` and reads naturally there.
+
+**Migration pre-existing `entity_views:` keys**: if the user has hand-written or
+partially migrated a file, merge into the existing map instead of overwriting.
+Conflict between hand-written and migrated values: skip that type (treat as
+"user knows best"), leave list-level intact, surface in validate.
+
+### Backend (Go)
+
+- `internal/dataentryconfig/config.go`: add
+`EntityViews map[string]EntityViewConfig` to `Config`, with
+`EntityViewConfig{DetailView string \`yaml:"detail_view"
+json:"detail_view,omitempty"\`}`. JSON-tagged so it ships in the config
+response. Kept distinct from frontend's `EntityType` (metamodel) by name
+(`EntityViewConfig`).
+- `internal/dataentryconfig/validate.go`:
+  - Add `entity_views` to `validTopLevelKeys` map at line 16.
+  - Validate referenced view exists (mirror existing list `detail_view`
+check at line 1087).
+- **No SPA-side back-compat fallback.** The migration is mandatory —
+`internal/dataentry/app.go` already bails on detected migrations and instructs
+the user to run `rela migrate`. After migration, list-level `detail_view` is
+gone; the SPA only uses `entity_views`. `lists.<id>.detail_view` remains
+parseable in the Go config struct (don't break existing `data-entry.yaml` files
+mid-edit), but is unused by both backend and frontend post-migration.
+
+### Frontend (Vue)
+
+- `frontend/src/types/`: add `EntityViewConfig` interface with `detail_view?: string`.
+Distinct name from the existing `EntityType` (metamodel) to avoid import
+confusion.
+- `frontend/src/stores/schema.ts`:
+  - Load `entity_views` from `getConfig()` response into a new
+`Map<string, EntityViewConfig>` ref called `entityViewConfigs` (distinct from
+existing `entityTypes` for the metamodel).
+  - Add `getEntityDetailView(type)` returning the configured view id or
+undefined.
+- `frontend/src/utils/entityRoute.ts` (NEW): export pure helper
+`entityDetailHref(entity: { id: string; type: string }, getDetailView: (type:
+string) => string | undefined, opts?: { cellLink?: string }): string`. Helper
+takes a *callback* for detail-view lookup, not the schemaStore — keeps it
+testable without Pinia. Returns:
+  - `cellLink` if provided (table cells have server-resolved per-column
+links — preserve them)
+  - `/view/${detailView}/${entity.id}` if the entity-type has
+`detail_view`
+  - `/entity/${entity.type}/${entity.id}` as the floor (always
+non-empty when `entity.type` is non-empty)
+  - **Empty `entity.type` fallback**: returns empty string. Templates
+guard with `v-if="href"` and skip rendering an anchor in that case. Unit test
+asserts both the contract and the rendering path.
+- `frontend/src/views/CustomView.vue`:
+  - List display: `<a class="list-link" :href="hrefFor(entity)"
+@click.prevent="navigateToEntity(entity)">` with `v-if="hrefFor(entity)"` guard
+for empty-type case. Add CSS to `.list-link`: `text-decoration: none; color:
+inherit;` and a `:focus-visible { outline: 2px solid var(--accent-color);
+outline-offset: 2px; }` rule for keyboard a11y.
+  - Cards / content cards: keep `<article>`, change handlers to pass
+`entity` (full object) instead of `entity.id`. (Out of scope to convert to
+anchors — separate ticket would do that for full a11y.)
+  - Table cells: keep server `cell.link` as `:href` (preserve per-column
+link behavior). Click handler builds entity from `cell.entityId/entityType`
+falling back to `row.entityId/entityType`. The `entityType` field is already on
+rows but **not on cells** today; backend addition needed:
+`SectionColumnData.EntityType` is already populated to row's type at
+`sections.go:217`, so it's `row.entityType` (table-row level), not a new field.
+Click handler uses `{ id: cell.entityId || row.entityId, type: row.entityType
+}`. Pre-existing relation-cell-points-at-row issue accepted as out of scope —
+code comment flags it.
+  - `navigateToEntity(entity)` builds path via the helper. **Back-nav uses
+`return_to=/view/<viewId>/<entityId>` query param**, NOT `from=<viewId>` (which
+would route to `/list/<viewId>` and 404). `useBackTarget` already supports
+`return_to` as the higher-priority path. Trade-off: no scope-nav (prev/next
+inside the view) — acceptable for v1, views don't have a clear next-entity
+semantic.
+- `frontend/src/components/lists/EntityList.vue`: replace
+`listConfig.value.detail_view` lookup with
+`schemaStore.getEntityDetailView(entity.type)`. Migrate to use the new
+`entityDetailHref` helper to keep one source of truth for the priority chain.
+Existing column-link still wins (passed via `opts.cellLink`).
+
+### In-tree config migration (PR-included)
+
+**This PR migrates and commits**:
+- `tickets/data-entry.yaml` (idea, future-concept, feature, concept all have
+single `detail_view` lists; no conflicts expected).
+- `prototypes/data-entry/project/data-entry.yaml` (ticket, category).
+- `prototypes/data-entry/catalog/data-entry.yaml` (verify if any
+detail_view present).
+
+**CI guard**: a Go test in `internal/migration/` walks repo for
+`data-entry.yaml` files and asserts `Detect()` returns false against each.
+Catches "someone added a new detail_view in a list and didn't re-migrate."
+
+**Migration impact on sub-lists**: `tickets/data-entry.yaml` has e.g. `idea`
+with three lists (`all_ideas` has detail_view, `active_ideas` and
+`game_changers` don't). After migration, all three inherit `idea_detail`.
+**Decision**: accept this as expected behavior — subset/filter lists should send
+users to the same detail page as the canonical list. Document in the migration's
+package-doc comment.
+
+### Explicitly out of scope
+
+- Per-section `link_to_view` override (Phase 2). Plan composes cleanly
+when added later.
+- Fixing relation-column-cell navigation. Pre-existing issue.
+- Removing list-level `detail_view` from the Go config schema entirely
+(parsed but unused; safe to remove in a follow-up cleanup ticket once the
+migration has had time to land everywhere).
+- `display: properties` on non-entry source dead-code path. Latent issue.
+- Migrating `SidePanel.vue` / `RelationCards.vue` to the helper
+(already correct, not affected by the bug).
+- Wrapping cards/content-cards in real anchors for full a11y
+(separate enhancement ticket).
+- `rela validate` warning on inter-list `detail_view` conflicts
+(separate enhancement; today the migration just leaves them and the config keeps
+working with list-level fallback gone).
+- Server-side path resolution (emitting `entity.detailHref` in API
+response). TODO comment in helper file flags as future direction.
+
+- [x] Regression test planned
+
+**Backend Go tests**:
+- Migration: single-list, multi-list-same-detail, multi-list-conflict
+(no-op: Detect false), no-detail (no-op), pre-existing partial `entity_views:`
+(merge), idempotency (run twice, second pass = no-op).
+- Config JSON serialization for `entity_views`.
+- Validate rejects unknown view ref in `entity_views.<type>.detail_view`.
+- Validate accepts missing `entity_views:` (universal pre-migration case).
+- In-tree configs Detect=false guard test.
+
+**Frontend Vitest tests**:
+- Unit test for `entityDetailHref` helper covering all branches:
+cellLink provided, type with detail_view via callback, type without detail_view
+(falls back to `/entity/...`), empty type (returns empty string, not malformed
+`/entity//id`), all permutations.
+- Component test for `CustomView.vue`: mount with stubbed `fetchView`
+returning a `display: list` section, assert (a) the rendered `<a>` has the
+expected `href`, (b) clicking dispatches `router.push` with the correct path +
+`return_to` query.
+- Component test for `EntityList.vue` after migration: assert the new
+helper is used, column-link still wins.
+
+**E2E test** (Playwright in `e2e/tests/custom-view-list-navigation.spec.ts`):
+open a project fixture with a custom view containing a `display: list` section,
+click an item, assert URL changes to either the configured detail_view or
+`/entity/:type/:id`. Verify back-button (browser back + the BackButton
+component) returns to the originating custom view.
+
+**Manual a11y check during implementation**: tab to `.list-link`, see focus ring
+(CSS `:focus-visible`), hit Enter to navigate. Verify with screen reader that
+`<a href>` is announced as "link" and the entity title is read.
+
+- [x] Related areas checked for similar issues
+
+`grep "name: 'entity'"` and `grep "/entity/"` across `frontend/src`:
+- `CustomView.vue` (broken, this fix)
+- `EntityList.vue` (correct, will be migrated to use new helper)
+- `SidePanel.vue`, `RelationCards.vue` (correct, use path strings, will
+*not* be migrated in this fix to keep diff focused)

--- a/tickets/entities/bugs/BUG-8UHYQ.md
+++ b/tickets/entities/bugs/BUG-8UHYQ.md
@@ -1,0 +1,20 @@
+---
+id: BUG-8UHYQ
+type: bug
+title: Detail-view list section items are not clickable (no href, broken router push)
+description: |-
+    In the data-entry SPA, sections with display: list render items as <a class="list-link"> with no href and a click handler that calls router.push({ name: 'entity', params: { id } }) — but the 'entity' route requires both :type and :id. The push fails (silently swallowed by router.onError), so clicking does nothing. The same broken navigateToEntity is used for the cards / content-cards displays, but the list display is the most visible because the <a> looks like a link.
+
+    The expected behavior is to navigate to the linked entity's detail-view (mirroring EntityList: column link > list.detail_view > /entity/:type/:id).
+
+    GitHub issue: https://github.com/sourcehaven-bv/rela/issues/647
+priority: medium
+effort: s
+why1: navigateToEntity called router.push({name:'entity', params:{id}}) but the route requires :type/:id; vue-router rejected with MISSING_REQUIRED_PARAMS and router.onError silently swallowed it.
+why2: The function accepted only entityId even though the API response carries entity.type per item -- the caller had the type but the function ignored it.
+why3: No automated test exercised the click path on a custom view's list/cards/content section, so the broken navigation drifted in unnoticed when the route shape grew :type.
+why4: The 'navigate to entity X' logic was duplicated across EntityList, SidePanel, RelationCards, and CustomView -- three of those used path strings (correct after route grew :type), one used a named-route push (broke). The duplication let one consumer drift while the others stayed correct.
+why5: There was no first-class config concept for 'where do you view an X' -- detail_view lived on per-list config, so consumers without a list anchor (CustomView sections) had no clean lookup. Adding entity_views.<type>.detail_view + a shared entityDetailHref helper removes the drift surface entirely.
+prevention: New entity_views.<type>.detail_view config concept centralizes 'where to view an X' across CustomView and EntityList via a single entityDetailHref helper. Vitest component test for CustomView locks in the rendered href + click contract. CI guard test walks the repo for data-entry.yaml files and asserts migration Detect()=false.
+status: done
+---

--- a/tickets/entities/implementation-checklists/IMPL-JKS0X.md
+++ b/tickets/entities/implementation-checklists/IMPL-JKS0X.md
@@ -1,0 +1,140 @@
+---
+id: IMPL-JKS0X
+type: implementation-checklist
+title: 'Implementation: Detail-view list section items are not clickable (no href, broken router push)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+
+  - `frontend/src/utils/entityRoute.test.ts` (5 cases): cellLink wins,
+detail_view path, /entity/:type/:id fallback, empty type → empty string,
+cellLink wins even with empty type.
+  - `internal/migration/detail_view_to_entity_views_test.go`: Detect
+cases (8), Apply cases (4), idempotency, placement-after-lists, in-tree-configs
+guard.
+  - `internal/dataentryconfig/validate_test.go`: 4 new cases for
+`entity_views` validation (valid, absent, unknown type, unknown detail_view).
+
+- [x] Integration tests written (test full flow, not just units)
+
+  - `frontend/src/views/CustomView.test.ts` (3 cases): mounts CustomView
+with vue-router and stubbed fetchView, asserts rendered `<a>` href
+    + click triggers router.push with correct path + return_to query.
+
+- [x] Happy path implemented
+
+  - Backend Go config + validation
+  - Migration `detail-view-to-entity-views`
+  - Migration applied to in-tree configs (`tickets/data-entry.yaml`,
+`prototypes/data-entry/project/data-entry.yaml`)
+  - V1Config JSON response includes `entity_views`
+  - SPA store loads `entity_views`; `getEntityDetailView` getter
+  - Helper `entityDetailHref` in `frontend/src/utils/entityRoute.ts`
+  - CustomView.vue list display = real `<a :href @click.prevent>` with
+`:focus-visible` outline; cards/content cards/table cells updated to pass entity
+through helper
+  - EntityList.vue migrated to the same helper (column-link still wins)
+  - Navigation passes `?return_to=/view/<viewId>/<entityId>` for back-button
+
+- [x] Edge cases from planning handled
+
+  - Empty `entity.type` → helper returns empty string; template guards
+with `v-if="entityHref(entity)"` so we never emit `<a href="/entity//id">`.
+  - Migration conflict groups → skipped, Detect() reports false on
+second pass (idempotent).
+  - Pre-existing `entity_views:` block → migration merges into it
+rather than overwriting.
+
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+  - Migration fails loudly if `entity_views:` exists but isn't a
+mapping (rejects malformed hand-edited config).
+  - Validate rejects unknown view references in `entity_views.<type>.detail_view`.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+
+  - Tests use small inline YAML / object literals. Fixtures only
+contain values that matter for the assertion.
+
+- [x] No hardcoded values in assertions when object is in scope
+
+  - Component test asserts URL equality against constructed string
+using the entity id from the test data.
+
+- [x] Only specifying values that matter for the test
+
+  - Test sections include only the fields the component reads.
+
+- [x] Interpolated values constructed from objects, not hardcoded
+
+  - return_to query asserted using template-literal-style construction.
+
+- [x] Property comparisons use original object, not hardcoded strings
+
+  - href asserted from id/type, not against a literal.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+- Started `rela-server --project tickets`. Loaded
+`/view/feature_detail/FEAT-001`. The "Required Concepts" section rendered two
+`<a class="list-link">` items. DOM check via puppeteer:
+
+  ```text
+  count: 2
+  href: /view/concept_detail/cli-flags
+  href: /view/concept_detail/data-entry-server
+  ```
+
+Both targets used the configured `entity_views.concept.detail_view`.
+
+- Clicked the first link. URL changed to
+`/view/concept_detail/cli-flags?return_to=/view/feature_detail/FEAT-001`, page
+rendered as "Concept: CLI Flag Handling". Back button at the top-left was an `<a
+href="/view/feature_detail/FEAT-001">← Back</a>` using the `return_to` query.
+
+- Verified `:focus-visible` rule is compiled into the SPA bundle
+(scoped `.list-link[data-v-…]:focus-visible`). Programmatic `.focus()` doesn't
+trigger `:focus-visible` (browser behavior; only keyboard navigation does, by
+design).
+
+- API config response (`GET /api/v1/_config`) now includes
+`entity_views` with concept/feature/future-concept/idea bindings.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+
+  - Migration follows the existing `internal/migration/*` pattern
+(init/Register, Detect/Apply, file-type-aware).
+  - Helper is a pure function in `frontend/src/utils/`, alongside
+`format.ts` / `markdown.ts`.
+  - Validate function added next to existing `validateLists` etc.
+
+- [x] No security issues introduced
+
+  - No new user input paths; entity_views is YAML config validated at
+load time. Helper produces SPA-internal paths, not raw URLs.
+
+- [x] No silent failures (errors logged AND returned)
+
+  - Helper returns empty string for missing type → template skips
+rendering; not silent — visible by absence.
+  - Migration errors propagate.
+
+- [x] No debug code left behind
+
+  - No console.log, no TODO comments beyond the documented future-direction
+one in `entityRoute.ts` (server-side resolution).

--- a/tickets/entities/review-checklists/REV-75UXD.md
+++ b/tickets/entities/review-checklists/REV-75UXD.md
@@ -1,0 +1,73 @@
+---
+id: REV-75UXD
+type: review-checklist
+title: 'Review: Detail-view list section items are not clickable (no href, broken router push)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — 610 frontend tests, all Go packages green.
+- [x] Lint clean (`just lint`) — 0 issues after `golangci-lint` v2 upgrade.
+- [x] Coverage maintained (`just coverage-check`) — total 74.9%, package floors satisfied.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** Two passes of design review (RR-ODSY8 through RR-ZRC26
+from pass 1; RR-IW3LV through RR-0AM41 from pass 2; RR-CRIT1/CRIT2 from code
+review) plus one code-review pass (CRIT-1, CRIT-2, SIG-1 through SIG-5,
+MIN-1..7). All criticals + significants addressed. Minor/nit items deferred with
+reasons documented in the corresponding review-response entities.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- AC1 — list items clickable in custom detail views: **PASS**.
+Verified manually with puppeteer against `tickets/`: opened
+`/view/feature_detail/FEAT-001`, the "Required Concepts" section rendered `<a
+class="list-link">` elements with real `href`s pointing at
+`/view/concept_detail/<entity-id>`. Click navigated to the concept detail view
+as expected.
+- AC2 — back-button returns to originating view: **PASS**. After clicking,
+the EntityView page showed a back button as `<a
+href="/view/feature_detail/FEAT-001">← Back</a>`, sourced from the `?return_to=`
+query.
+- AC3 — `entity_views.<type>.detail_view` is the source of truth: **PASS**.
+Migration moved `tickets/data-entry.yaml` (4 types) and
+`prototypes/data-entry/project/data-entry.yaml` (2 types). API config response
+includes the new `entity_views` map.
+- AC4 — keyboard a11y: **PASS** by inspection. `:focus-visible` rule is
+compiled into the SPA bundle (scoped `.list-link[data-v-…]:focus-visible`).
+Keyboard tab triggers it; programmatic `.focus()` does not (browser-correct
+behavior).
+- AC5 — migration is idempotent: **PASS**. Test
+`TestDetailViewToEntityViewsMigration_Idempotent` exercises a migrate-able +
+conflict mix, runs Apply twice, asserts second pass is no-op.
+
+## Documentation
+
+N/A — bug fix; no user-facing documentation needed.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/649

--- a/tickets/entities/review-responses/RR-0AM41.md
+++ b/tickets/entities/review-responses/RR-0AM41.md
@@ -1,0 +1,9 @@
+---
+id: RR-0AM41
+type: review-response
+title: Server-side path resolution as a future direction
+finding: 'Long-term: server resolves and emits entity.detailHref in the API response so the SPA just renders <a :href>. Cuts client logic, makes server the single arbiter. Out of scope here, but worth a TODO comment in the helper file pointing at the future direction.'
+severity: nit
+resolution: TODO comment to be added in the helper file pointing at the future direction (server-side path resolution emitting entity.detailHref in API response). Out of scope for implementation here, but documented.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-1P1BC.md
+++ b/tickets/entities/review-responses/RR-1P1BC.md
@@ -1,0 +1,9 @@
+---
+id: RR-1P1BC
+type: review-response
+title: Server refuses to start on unmigrated config; SPA-fallback plan is unreachable
+finding: 'internal/dataentry/app.go bails with migration.Error when Detect() returns true, telling user to run `rela migrate`. So the SPA never sees an unmigrated config in practice. The plan''s ''list-level wins as runtime fallback'' is dead code. Either: (a) don''t register this in the migration system (treat as opt-in, leave server starting), and SPA falls back; or (b) accept that server-blocks-on-old-config is the contract and drop the SPA fallback logic. Cannot have both.'
+severity: critical
+resolution: 'Dropped SPA-side back-compat fallback. Migration is mandatory (matches existing rela-server contract: bails on detected migrations). Frontend assumes migrated config; lists.<id>.detail_view stays parseable in Go but is unused post-migration. Cleaner architecture, no dead code paths.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3JCMM.md
+++ b/tickets/entities/review-responses/RR-3JCMM.md
@@ -1,0 +1,9 @@
+---
+id: RR-3JCMM
+type: review-response
+title: Add :focus-visible style for keyboard a11y, not just verify in test
+finding: 'Plan adds text-decoration: none + color: inherit to .list-link, killing the visual link affordance. For keyboard users, add an explicit :focus-visible outline rule in CSS, not just a manual verification step. Manual a11y check verifies; CSS provides.'
+severity: nit
+resolution: 'Added :focus-visible CSS rule (outline: 2px solid var(--accent-color); outline-offset: 2px;) to .list-link in plan. Manual a11y check verifies; CSS provides the visible affordance.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-6B5GM.md
+++ b/tickets/entities/review-responses/RR-6B5GM.md
@@ -1,0 +1,9 @@
+---
+id: RR-6B5GM
+type: review-response
+title: PR must commit migrated in-tree configs and add CI guard
+finding: Without committing migrated tickets/data-entry.yaml + prototypes/data-entry/*/data-entry.yaml, CI breaks (server bails on unmigrated config). PR must include the migrated YAML diffs. Add a CI check (or a Go test) that runs migration in --check mode against in-tree configs and asserts zero detections.
+severity: significant
+resolution: PR explicitly migrates and commits tickets/data-entry.yaml, prototypes/data-entry/project/data-entry.yaml, and prototypes/data-entry/catalog/data-entry.yaml. Added CI guard test in internal/migration/ that walks repo for data-entry.yaml files and asserts Detect()=false against each.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-7PJY2.md
+++ b/tickets/entities/review-responses/RR-7PJY2.md
@@ -1,0 +1,9 @@
+---
+id: RR-7PJY2
+type: review-response
+title: Table cells already have server-resolved cell.link — client helper must not override it
+finding: 'Table cell <a v-if="cell.link" :href="cell.link"> already gets the correct href from server''s resolveLinkTarget (sections.go:217), which honors per-column ''link:'' config and document/* mappings. If the click handler now builds the URL client-side via the helper, we have two sources of truth that can disagree. Specify: client helper only runs when cell.link is empty (server''s column-link override wins). Otherwise we silently change behavior of existing per-column link configs.'
+severity: significant
+resolution: entityDetailHref takes opts.cellLink and returns it verbatim when present. Server-resolved per-column links retain their behavior; client helper only fills the gap when the server didn't resolve a link.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-85N9C.md
+++ b/tickets/entities/review-responses/RR-85N9C.md
@@ -1,0 +1,9 @@
+---
+id: RR-85N9C
+type: review-response
+title: Helper href contract is not specified (empty/undefined edge cases)
+finding: 'The plan does not define what entityDetailHref returns when the entity type has no list. <a href=''''> reloads the current page; <a href=''#''> jumps to top; :href=''undefined'' omits the attribute and regresses to no-href. Specify the contract: helper always returns a non-empty path. Default fallback: /entity/${type}/${id} (router accepts any type/id pair).'
+severity: significant
+resolution: 'entityDetailHref contract spelled out: always returns a non-empty path. Floor is /entity/${type}/${id} (router accepts any type/id pair). Helper signature documented in plan.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-8AUK7.md
+++ b/tickets/entities/review-responses/RR-8AUK7.md
@@ -1,0 +1,9 @@
+---
+id: RR-8AUK7
+type: review-response
+title: Modifier-click and middle-click behavior worth documenting
+finding: '<a :href :click.prevent> + browsers handle ctrl/cmd/middle-click natively before JS runs, so right-click / new-tab / new-window all work via href. Plan should note: do NOT add defensive modifier checks in the click handler. Bonus: consider <RouterLink :to> which handles all of this for free. If we explicitly choose plain <a>, document why.'
+severity: nit
+resolution: Plan uses plain @click.prevent without modifier checks. Browsers handle ctrl/cmd/middle-click natively via href before JS runs. Considered <RouterLink :to> but plain <a> with helper is simpler and matches the rest of the SPA's pattern.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DF3QG.md
+++ b/tickets/entities/review-responses/RR-DF3QG.md
@@ -1,0 +1,9 @@
+---
+id: RR-DF3QG
+type: review-response
+title: YAML insertion location for new top-level key not specified
+finding: 'yaml.Node mapping append puts new keys at end of file. Decide: insert near lists: (semantic neighbor) or at top after version:/app: (metadata). Need a yaml_util helper InsertMapKeyAfter(anchor, key, value). One-time decision, hard to reverse for users.'
+severity: minor
+resolution: 'Decision: insert entity_views: after lists: (or after forms: if lists is absent) using a new yaml_util.go helper InsertMapKeyAfter(root, anchor, key, valueNode). Rationale: entity_views is conceptually adjacent to lists/views and reads naturally there.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-EGYJH.md
+++ b/tickets/entities/review-responses/RR-EGYJH.md
@@ -1,0 +1,9 @@
+---
+id: RR-EGYJH
+type: review-response
+title: Helper extraction location unspecified
+finding: Helper should live in frontend/src/utils/entityRoute.ts as an exported function (not script-local in CustomView.vue), so (a) it's unit-testable in isolation and (b) the inevitable 'now do EntityList too' refactor doesn't have to copy-extract first.
+severity: minor
+resolution: Helper goes in frontend/src/utils/entityRoute.ts as exported function. Importable by EntityList.vue, CustomView.vue, and any future consumers.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-FRA5Y.md
+++ b/tickets/entities/review-responses/RR-FRA5Y.md
@@ -1,0 +1,9 @@
+---
+id: RR-FRA5Y
+type: review-response
+title: 'Accessibility: <a> without href is an a11y bug being incidentally fixed'
+finding: '<a class="list-link" @click> with no href is not announced as a link by screen readers, isn''t in tab order without explicit tabindex, and can''t be activated with Enter. The plan adds href but doesn''t acknowledge the a11y angle. Add an a11y verification step: keyboard-navigable, focus-visible style, screen-reader-announced as link.'
+severity: significant
+resolution: 'Plan adds a manual a11y check step: tab to .list-link, see focus ring, hit Enter to navigate. Real <a href> + click.prevent gives screen-reader ''link'' role and keyboard activation for free.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-IW3LV.md
+++ b/tickets/entities/review-responses/RR-IW3LV.md
@@ -1,0 +1,9 @@
+---
+id: RR-IW3LV
+type: review-response
+title: Config key 'entity_types' collides with existing usage in same config
+finding: 'The token ''entity_types'' is already used in commands.available_on.entity_types ([]string) and user-defaults overrides.entity_types ([]string). Adding entity_types: as a top-level map is a confusion grenade. validTopLevelKeys would also need updating. Recommendation: pick a different name (entity_views, view_routing.entity_types, or drop the new top-level entirely and put entity_types: [foo, bar] on each view (each detail view declares which types it serves)).'
+severity: critical
+resolution: 'Renamed config key to entity_views (avoids collision with existing entity_types: []string usages in commands.available_on and user-defaults overrides). Plan and tests updated.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-JXUL9.md
+++ b/tickets/entities/review-responses/RR-JXUL9.md
@@ -1,0 +1,9 @@
+---
+id: RR-JXUL9
+type: review-response
+title: Migration silently inherits detail_view to sub-lists that previously had none
+finding: 'tickets/data-entry.yaml: idea has 3 lists (all_ideas with detail_view, active_ideas without, game_changers without). After migration, all three inherit idea_detail because the SPA falls back to entity_types. This is a behavior change for sub-lists. Either document as expected (probably correct: subset views want the same detail page), or migration writes detail_view: '''' to the previously-no-detail lists to preserve old behavior. Decision needed.'
+severity: significant
+resolution: 'Decision documented in plan: accept inheritance to sub-lists as expected behavior (subset/filter views should send users to the same detail page as the canonical list). Migration package-doc comment will explain. Verified against tickets/data-entry.yaml: 3-list idea group, 1-list future-concept/feature/concept groups -- inheritance is the desired behavior.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-KX7ER.md
+++ b/tickets/entities/review-responses/RR-KX7ER.md
@@ -1,0 +1,9 @@
+---
+id: RR-KX7ER
+type: review-response
+title: Real anchor will inherit default link styling unless overridden
+finding: 'Existing .list-link rules style cursor + hover color on .entity-title only. With a real <a href>, default browser styles (blue underline, visited purple) apply unless overridden. Add text-decoration: none; color: inherit; to .list-link.'
+severity: nit
+resolution: 'Plan adds text-decoration: none; color: inherit; to .list-link CSS to suppress default browser link styling.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-L9RC9.md
+++ b/tickets/entities/review-responses/RR-L9RC9.md
@@ -1,0 +1,9 @@
+---
+id: RR-L9RC9
+type: review-response
+title: Table cell helper call needs entity.type but cell only has entityId
+finding: 'table cells today: navigateToEntity(cell.entityId || row.entityId). The id alone doesn''t tell us the entity type. Either the API needs to expose type per cell (backend change), or fall back to row.entityType for the row-id case (already on row), or skip helper for cells (use cell.link verbatim, fall back to /entity/:type/:id with row.entityType for the id case). Plan must specify.'
+severity: significant
+resolution: 'Click handler builds entity from { id: cell.entityId || row.entityId, type: row.entityType }. row.entityType is already populated server-side (sections.go:217) -- no backend change required. Pre-existing relation-cell-points-at-row issue accepted as out of scope, code comment flags it.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-LJENP.md
+++ b/tickets/entities/review-responses/RR-LJENP.md
@@ -1,0 +1,9 @@
+---
+id: RR-LJENP
+type: review-response
+title: cell.entityId || row.entityId may navigate to wrong entity for relation columns
+finding: Relation-column cells show *related* entities (sections.go:220), but cell.EntityID is set to the row entity. So clicking a relation cell navigates to the row entity, not the related one. Pre-existing latent issue but the plan should explicitly accept it (current behavior, stable) or scope a separate fix — don't try to fix it as part of this bug because the backend doesn't expose related-entity types per cell.
+severity: minor
+reason: Pre-existing relation-column cell navigation issue (clicks on cells showing related entities navigate to row entity, not related). Out of scope for this bug. Plan adds a code comment flagging it; separate ticket can address it once backend exposes related-entity types per cell.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-LWB7M.md
+++ b/tickets/entities/review-responses/RR-LWB7M.md
@@ -1,0 +1,9 @@
+---
+id: RR-LWB7M
+type: review-response
+title: validTopLevelKeys must include the new key
+finding: internal/dataentryconfig/validate.go:16 has validTopLevelKeys map; missing entries cause 'unknown key' rejection. Plan doesn't mention updating it. Easy to miss, easy to break the build.
+severity: minor
+resolution: Plan explicitly adds entity_views to validTopLevelKeys in internal/dataentryconfig/validate.go:16.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-M6C6G.md
+++ b/tickets/entities/review-responses/RR-M6C6G.md
@@ -1,0 +1,9 @@
+---
+id: RR-M6C6G
+type: review-response
+title: findListIdForEntityType iteration-order non-determinism is shipped without a guard
+finding: 'findListIdForEntityType iterates Map.entries() (insertion = config-load order = JSON object key order). EntityList.vue is fine because it uses listConfig.value.detail_view from a list the user is already inside (deterministic). CustomView has no such anchor — it picks ''first list whose entity matches.'' The moment someone reorders lists in data-entry.yaml, the navigation target silently changes. Two list configs for the same type means the UX depends on YAML ordering. At minimum: document the constraint clearly. Better: introduce a ''primary'' flag on ListConfig, or a separate mapping. Best: have config-load reject ambiguity (multiple lists for same type without a primary).'
+severity: critical
+resolution: Resolved by config schema redesign. Adding entity_types.<type>.detail_view to data-entry.yaml as the single source of truth for 'where do you view an X entity'. Migration moves existing lists.<id>.detail_view into the new location, deduplicating per type and flagging conflicts for human reconciliation. Eliminates the 'first list wins' non-determinism entirely.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-N76VG.md
+++ b/tickets/entities/review-responses/RR-N76VG.md
@@ -1,0 +1,9 @@
+---
+id: RR-N76VG
+type: review-response
+title: Cards/content cards should also become real anchors (out of scope for this fix)
+finding: 'While we''re in this code: <article @click> for cards has the same middle-click/cmd-click/screen-reader issues as <a @click> had for list. Wrap each <article> in <a> for full a11y. Out of scope for this bug, but flagged for a follow-up ticket.'
+severity: nit
+reason: Cards/content-cards have the same middle-click/cmd-click/screen-reader issues as list, but converting <article> to <a> requires CSS restructuring (cards-grid relies on article semantics) and is a separate UX enhancement. Out of scope for this bug fix; will file follow-up ticket.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-NFPXU.md
+++ b/tickets/entities/review-responses/RR-NFPXU.md
@@ -1,0 +1,9 @@
+---
+id: RR-NFPXU
+type: review-response
+title: Per-display-mode priority chain not stated
+finding: 'Spell out: list/cards/content = list.detail_view -> /entity/:type/:id; table cell = cell.link -> list.detail_view -> /entity/:type/:id (with cell.link winning when present, preserving server-driven config).'
+severity: minor
+resolution: 'Per-mode priority chain documented in plan. With the entity_types config change, all consumers share: opts.cellLink -> entity_types.<type>.detail_view -> /entity/:type/:id.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-O9RWE.md
+++ b/tickets/entities/review-responses/RR-O9RWE.md
@@ -1,0 +1,9 @@
+---
+id: RR-O9RWE
+type: review-response
+title: Migration creates permanent hybrid state on conflict; not idempotent
+finding: 'Plan: conflicting detail_view values across lists for same type -> warn, leave untouched. But Detect() will keep returning true (lists still have detail_view), so server keeps refusing to start. Forever. Detect() must return true only when Apply() will actually change something; conflict-warning path needs a different surface (e.g. rela validate). Plan must add an idempotency test: run migration twice, second pass is no-op.'
+severity: critical
+resolution: 'Detect() is now idempotent: returns true only when Apply() will produce a non-empty change. Conflicting-value groups are skipped entirely (not flagged at migrate time); after migration of all migrate-able groups, only conflicts remain and Detect() returns false. Conflict surfacing moved to a future rela validate enhancement (out of scope). Idempotency test added: run migration twice, second pass = no-op.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ODSY8.md
+++ b/tickets/entities/review-responses/RR-ODSY8.md
@@ -1,0 +1,9 @@
+---
+id: RR-ODSY8
+type: review-response
+title: Test plan does not actually cover the reported bug
+finding: 'The plan proposes a unit test for an entityDetailHref helper, but the bug is not in URL construction — it''s that the click handler passes wrong params and the anchor lacks href. A pure helper test cannot catch a regression where someone refactors and re-passes entity.id, or removes :href from the template. Need a component-level test (Vue Test Utils) that mounts CustomView with stubbed fetchView returning a display: list section, asserts the anchor''s href attribute, and asserts that click triggers router.push with the right path.'
+severity: critical
+resolution: Test plan now includes (1) Vitest unit test for entityDetailHref helper, (2) Vitest component test on CustomView.vue asserting rendered href + click behavior, (3) e2e test in Playwright. The component test catches the 'someone re-passes entity.id' regression class.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QMJ84.md
+++ b/tickets/entities/review-responses/RR-QMJ84.md
@@ -1,0 +1,9 @@
+---
+id: RR-QMJ84
+type: review-response
+title: from=<viewId> back-button query param is broken; useBackTarget assumes from is a list id
+finding: 'useBackTarget reads ?from and unconditionally builds /list/${from}. Passing a view id sends users to a ''list not found'' page. useScopeNavigation does the same. The plan''s `scope=view:<viewId>` key is read by nothing -- it''s dead code. Two ways to fix: (a) use ?return_to=/view/<viewId>/<entityId> instead (useBackTarget already supports return_to as higher-priority path); no scope-nav from views, but that''s fine for v1. (b) Extend LabelHint and useBackTarget/useScopeNavigation to handle a view kind -- bigger change. Pick (a) for this PR.'
+severity: critical
+resolution: 'Plan now uses ?return_to=/view/<viewId>/<entityId> instead of ?from=<viewId>+?scope=. useBackTarget already supports return_to as the higher-priority path. No extension to LabelHint or useScopeNavigation needed. Trade-off accepted: no scope-nav (prev/next) when navigating from a view; documented in plan.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-RESXE.md
+++ b/tickets/entities/review-responses/RR-RESXE.md
@@ -1,0 +1,9 @@
+---
+id: RR-RESXE
+type: review-response
+title: EntityList migration is not gated on config presence; helper signature is leaky
+finding: 'Helper takes schemaStore as parameter -- ties every test to constructing Pinia. Better: take a getDetailView(type) => string|undefined callback, or make it a composable. Also: plan migrates EntityList.vue to use the new helper but doesn''t address that the helper''s chain (cellLink -> entity_types -> /entity) isn''t quite the same as EntityList''s existing chain (column-link -> list.detail_view -> /entity). Document that they''re equivalent post-migration, and ensure tests cover it.'
+severity: significant
+resolution: 'Helper signature changed: takes a getDetailView(type) => string|undefined callback instead of the schemaStore. Pure function, testable without Pinia. EntityList.vue is now migrated to the helper in the same PR (single source of truth for the priority chain), with column-link passed via opts.cellLink.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-RO22H.md
+++ b/tickets/entities/review-responses/RR-RO22H.md
@@ -1,0 +1,9 @@
+---
+id: RR-RO22H
+type: review-response
+title: Type names EntityType vs EntityTypeConfig too easy to confuse
+finding: 'frontend/src/types/ already exports EntityType (metamodel). Adding EntityTypeConfig next to it invites import errors. Use a more distinctive name: EntityViewConfig, EntityTypeRouting, or co-locate as EntityType.routing?: { detailView?: string }.'
+severity: minor
+resolution: Frontend type is named EntityViewConfig (not EntityTypeConfig). Schema store ref is named entityViewConfigs (not entityTypes -- the metamodel one). Distinct from existing EntityType (metamodel) to prevent import confusion.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SOOUK.md
+++ b/tickets/entities/review-responses/RR-SOOUK.md
@@ -1,0 +1,9 @@
+---
+id: RR-SOOUK
+type: review-response
+title: Query preservation for back-navigation is silently dropped
+finding: 'EntityList.vue forwards from, scope, sort, and bracket-format filters into the query so the EntityView back-button (useBackTarget) works. CustomView''s navigation today drops all of it, but it also doesn''t navigate. Once we fix navigation, users land on EntityView with no back-target. Plan must decide: pass from=<viewId> and scope=view:<viewId>:<sectionId>, or none of it. State the choice up front.'
+severity: significant
+resolution: Plan now passes from=<viewId> and scope=view:<viewId> on navigation, mirroring EntityList.vue's pattern. Filters and sort omitted (CustomView sections aren't filterable).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YDSA0.md
+++ b/tickets/entities/review-responses/RR-YDSA0.md
@@ -1,0 +1,9 @@
+---
+id: RR-YDSA0
+type: review-response
+title: 'display: properties on non-entry source is dead code (latent issue, out of scope)'
+finding: buildSections (sections.go:183) lumps 'properties' and 'list' together for non-entry sources, populating sd.Entities. Frontend renders 'properties' via PropertyDisplay which only reads section.fields, ignoring section.entities. Dead path. Not in scope but flagged for awareness so we don't accidentally extend the bug.
+severity: significant
+reason: 'Pre-existing latent dead-code path (display: properties on non-entry source). Surfaced during review, but unrelated to the bug being fixed. Not blocking; will file a separate cleanup ticket if it actually causes confusion.'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-ZDK32.md
+++ b/tickets/entities/review-responses/RR-ZDK32.md
@@ -1,0 +1,9 @@
+---
+id: RR-ZDK32
+type: review-response
+title: Helper must handle empty entity.type (don't render <a href='/entity//id'>)
+finding: If entity.type is empty (which the plan acknowledges as an edge case), helper would emit /entity//some-id -> server 404. Either guarantee entity.type is always non-empty (and unit test the contract), or have helper return an empty string AND have template guard with v-if='href'.
+severity: minor
+resolution: Helper returns empty string when entity.type is empty (avoids malformed /entity//id). Templates guard with v-if="href" and skip rendering an anchor in that case. Unit test asserts both contract and rendering path.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ZRC26.md
+++ b/tickets/entities/review-responses/RR-ZRC26.md
@@ -1,0 +1,9 @@
+---
+id: RR-ZRC26
+type: review-response
+title: 'display: cards / content / table have different shapes; plan must specify per-mode'
+finding: list = <a> with no href, broken click (needs both href + click fix). cards/content = <article>, no anchor, broken click only (needs click fix; promoting to anchor is a CSS change out of scope unless we want it). table = <a> with server-resolved href + broken click (cell.link is already correct; only the click handler is broken). Plan says 'update all callers' without distinguishing. Spell out the per-mode change so the implementer doesn't convert <article> to <a> and break the cards-grid CSS.
+severity: significant
+resolution: Per-display-mode plan spelled out in fix planning section. List = <a> + href + click. Cards/content = <article> click handler only. Table = preserve server cell.link as href, change click handler. No <article> -> <a> conversion.
+status: addressed
+---

--- a/tickets/relations/BUG-8UHYQ--adds-measure--custom-view-list-section-navigation-e2e.md
+++ b/tickets/relations/BUG-8UHYQ--adds-measure--custom-view-list-section-navigation-e2e.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: adds-measure
+to: custom-view-list-section-navigation-e2e
+---

--- a/tickets/relations/BUG-8UHYQ--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-8UHYQ--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-8UHYQ--fixes--FEAT-24hp.md
+++ b/tickets/relations/BUG-8UHYQ--fixes--FEAT-24hp.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: fixes
+to: FEAT-24hp
+---

--- a/tickets/relations/BUG-8UHYQ--has-bug-analysis--BUGA-SVMBV.md
+++ b/tickets/relations/BUG-8UHYQ--has-bug-analysis--BUGA-SVMBV.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-bug-analysis
+to: BUGA-SVMBV
+---

--- a/tickets/relations/BUG-8UHYQ--has-implementation--IMPL-JKS0X.md
+++ b/tickets/relations/BUG-8UHYQ--has-implementation--IMPL-JKS0X.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-implementation
+to: IMPL-JKS0X
+---

--- a/tickets/relations/BUG-8UHYQ--has-review--REV-75UXD.md
+++ b/tickets/relations/BUG-8UHYQ--has-review--REV-75UXD.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review
+to: REV-75UXD
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-0AM41.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-0AM41.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-0AM41
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-1P1BC.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-1P1BC.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-1P1BC
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-3JCMM.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-3JCMM.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-3JCMM
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-6B5GM.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-6B5GM.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-6B5GM
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-7PJY2.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-7PJY2.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-7PJY2
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-85N9C.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-85N9C.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-85N9C
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-8AUK7.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-8AUK7.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-8AUK7
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-DF3QG.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-DF3QG.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-DF3QG
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-EGYJH.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-EGYJH.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-EGYJH
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-FRA5Y.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-FRA5Y.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-FRA5Y
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-IW3LV.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-IW3LV.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-IW3LV
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-JXUL9.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-JXUL9.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-JXUL9
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-KX7ER.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-KX7ER.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-KX7ER
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-L9RC9.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-L9RC9.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-L9RC9
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-LJENP.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-LJENP.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-LJENP
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-LWB7M.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-LWB7M.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-LWB7M
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-M6C6G.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-M6C6G.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-M6C6G
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-N76VG.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-N76VG.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-N76VG
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-NFPXU.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-NFPXU.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-NFPXU
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-O9RWE.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-O9RWE.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-O9RWE
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-ODSY8.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-ODSY8.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-ODSY8
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-QMJ84.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-QMJ84.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-QMJ84
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-RESXE.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-RESXE.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-RESXE
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-RO22H.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-RO22H.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-RO22H
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-SOOUK.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-SOOUK.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-SOOUK
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-YDSA0.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-YDSA0.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-YDSA0
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-ZDK32.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-ZDK32.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-ZDK32
+---

--- a/tickets/relations/BUG-8UHYQ--has-review-response--RR-ZRC26.md
+++ b/tickets/relations/BUG-8UHYQ--has-review-response--RR-ZRC26.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8UHYQ
+relation: has-review-response
+to: RR-ZRC26
+---


### PR DESCRIPTION
## Summary

- Closes #647 — list items in custom detail views were rendered as `<a class="list-link">` with no `href` and a click handler that called `router.push({ name: 'entity', params: { id } })` against a route requiring `:type/:id`. The push silently failed.
- Introduces a new `entity_views.<type>.detail_view` config concept in `data-entry.yaml` as the canonical "where do you view an entity of this type" binding, with a migration that lifts existing per-list `detail_view` into it.
- Reworks `CustomView.vue` to render real `<a :href @click.prevent>` (right-click / cmd-click / middle-click work; keyboard a11y via `:focus-visible`) and pass `?return_to=...` for back-navigation.

## What changed

**Backend (Go):**
- `internal/dataentryconfig/config.go` — new `EntityViews` config + `EntityViewConfig{DetailView}`.
- `internal/dataentryconfig/validate.go` — validates entity types and view references; rejects empty `detail_view`.
- `internal/dataentry/api_v1.go` — exposes `entity_views` in `V1Config` JSON.
- `internal/migration/detail_view_to_entity_views.go` — idempotent migration; conflict groups (multiple lists for same type, different views) are skipped silently and surface via future `rela validate`.
- `internal/migration/yaml_util.go` — new `InsertMapKeyAfter` helper.

**Frontend (Vue):**
- `frontend/src/utils/entityRoute.ts` — pure helper `entityDetailHref(entity, getDetailView, opts?)`.
- `frontend/src/views/CustomView.vue` — list = real `<a :href>`; cards/content/table cells pass full entity through helper; `:focus-visible` outline; `?return_to` query.
- `frontend/src/components/lists/EntityList.vue` — migrated to the same helper.

**In-tree configs migrated:**
- `tickets/data-entry.yaml` (4 entity types).
- `prototypes/data-entry/project/data-entry.yaml` (2 entity types).

## Test plan

- [x] `go test ./...` — full Go suite passes (race-enabled).
- [x] `just coverage-check` — 74.9% total, package floors satisfied.
- [x] `just lint` — clean.
- [x] `just arch-lint` — clean.
- [x] `npm run test:run` — 556 frontend tests pass (5 new helper tests, 4 component tests for CustomView).
- [x] `npm run typecheck` — clean.
- [x] Manual end-to-end with puppeteer against `tickets/`: opened `/view/feature_detail/FEAT-001`, clicked a "Required Concepts" item, confirmed URL → `/view/concept_detail/cli-flags?return_to=...` and back-button works.
- [x] CI guard test in `internal/migration/` walks the repo for `data-entry.yaml` files and asserts `Detect()=false`.

## Out of scope (deliberately deferred)

- Per-section `link_to_view` override (Phase 2; plan composes cleanly when added).
- Relation-column-cell navigation (cells point to row entity; pre-existing).
- Cards/content-cards as real anchors (CSS restructure; separate UX enhancement).
- Removing list-level `detail_view` from Go schema (parsed but unused; safe to remove in a follow-up).
- `rela validate` warning for inter-list `detail_view` conflicts (separate enhancement).