### PR TITLE
refactor(lua): structured inline AST in rela.md (TKT-9WZIP)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,16 @@ jobs:
             "${demo}"
           done
 
+      - name: Run shell-level e2e tests
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for e2e in scripts/e2e-*.sh; do
+            echo ""
+            echo "==> ${e2e}"
+            "${e2e}"
+          done
+
   docs:
     name: Docs
     runs-on: ubuntu-latest

--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -668,7 +668,7 @@ script runs in a specialized mode with extra context exposed:
 | `rela.document.entry_id` | The ID of the entity being rendered |
 
 The script's stdout is captured and used as the rendered document's
-markdown (after goldmark → HTML conversion). Use `print()` to produce
+markdown (which is then converted to HTML). Use `print()` to produce
 output.
 
 ```lua
@@ -832,77 +832,125 @@ Lua numbers are 64-bit floats. Integer IDs larger than 2^53 cannot round-trip
 through any Lua value — this is a Lua limitation, not a cache one, but worth
 keeping in mind if you cache things keyed by raw integer IDs.
 
-### Markdown AST: Task Lists
+### Markdown AST
 
 The `rela.md` module exposes a markdown AST API for parsing and rendering
-content. This section documents the task list (checkbox) support; the rest
-of the `rela.md` surface is documented inline in the Go source.
+content. The AST is structure-preserving: links, code spans, raw HTML,
+images, autolinks, line breaks, multi-paragraph blockquotes, and
+multi-block list items all keep their structure on the Lua side.
+Flattening to plain strings happens at render time and in helper APIs
+(`headers`, `first_paragraph`, the public `flatten`), never at parse
+time.
 
-Use `rela.md.parse(content)` to turn a markdown string into an AST table,
-and `rela.md.render(ast)` to serialize it back. Task list items (`- [x]`
-and `- [ ]`) round-trip through the AST as Lua tables.
+Use `rela.md.parse(content)` to turn a markdown string into an AST table
+and `rela.md.render(ast)` to serialize it back. The pair is a fixed point
+on a representative corpus of GFM input.
 
-#### Task item shape
-
-A task list item is represented as a Lua table with three fields:
-
-```lua
-{task = true, checked = <bool>, text = <string>}
-```
-
-- `task = true` marks the item as a checkbox item. Only an explicit Lua
-  boolean `true` qualifies — strings, numbers, `nil`, and `false` all fall
-  through to plain rendering.
-- `checked` is the checkbox state (`true` for `[x]`, `false` for `[ ]`).
-- `text` is the item's text content.
-
-Plain (non-task) list items are still represented as bare strings, so
-existing scripts continue to work without changes.
-
-#### Reading checkbox state
+#### Block node shapes
 
 ```lua
-local ast = rela.md.parse([[
-- [x] write the code
-- [ ] write the tests
-- [x] ~~obsolete item~~
-]])
+-- Inline-bearing leaves carry an `inlines` array.
+{ type = "paragraph", inlines = { ... } }
+{ type = "heading",   level = 2, inlines = { ... } }
 
-for _, item in ipairs(ast[1].items) do
-    if type(item) == "table" and item.task then
-        local mark = item.checked and "DONE" or "TODO"
-        print(mark, item.text)
-    end
-end
--- Output:
--- DONE  write the code
--- TODO  write the tests
--- DONE  ~~obsolete item~~
+-- Block containers carry `children` (an array of block nodes).
+{ type = "blockquote", children = { ... } }
+
+-- Lists hold items; each item is one of:
+--   * a string (a plain item containing only text)
+--   * a table with `inlines` (single-paragraph item with formatting)
+--   * a table with `children` (multi-block item; e.g. an item
+--     containing a fenced code block or nested list)
+--   * a task table with `task=true`, `checked=<bool>`, and either
+--     `inlines` or `children` per the same rules above
+{ type = "list", ordered = false, items = { ... } }
+
+-- Tables: each cell is an `inlines` array (link/code/raw HTML inside
+-- a cell round-trips correctly).
+{ type = "table",
+  header = { cell, cell, ... },              -- each cell is an inlines array
+  rows   = { { cell, cell }, ... },
+  alignments = { "left", "center", "right" } }
+
+-- Leaves that don't carry inline content keep a `content: string`.
+{ type = "code_block", language = "go", content = "fmt.Println()" }
+{ type = "thematic_break" }
+{ type = "raw", content = "<unknown block>" }
 ```
 
-#### Building a task list
+#### Inline node shapes
 
 ```lua
-local ast = {
-    rela.md.list({
-        {task = true, checked = true,  text = "design API"},
-        {task = true, checked = false, text = "implement"},
-        {task = true, checked = false, text = "write docs"},
-    }),
-}
-print(rela.md.render(ast))
--- - [x] design API
--- - [ ] implement
--- - [ ] write docs
+-- Leaves with a `text` field:
+{ type = "text",         text = "hello" }
+{ type = "code_span",    text = "x = 1" }
+{ type = "raw_html",     text = "<br>" }
+{ type = "soft_break" }                   -- a soft line break in the source
+{ type = "hard_break" }                   -- two-trailing-space line break
+
+-- Autolinks have a `url` (no inner text):
+{ type = "autolink",     url  = "https://example.com" }
+
+-- Containers wrap further inlines:
+{ type = "emphasis",     inlines = { ... } }   -- *text*
+{ type = "strong",       inlines = { ... } }   -- **text**
+{ type = "strikethrough",inlines = { ... } }   -- ~~text~~
+{ type = "link",         url  = "/x", title = nil, inlines = { ... } }
+
+-- Images store alt content as a separate inlines array (preserves
+-- formatting inside `![**bold**](url)`):
+{ type = "image",        url, title = nil, alt_inlines = { ... } }
 ```
 
-`rela.md.list(items, ordered?)` accepts plain strings, task tables, or a
-mix. Pass `true` as the second argument for an ordered list.
+#### Constructors
 
-#### Mutating an existing checklist
+Block constructors accept either a string (auto-wrapped to a single text
+leaf) or an inlines/children table:
 
-A common pattern is to read a ticket's checklist, flip a checkbox, and
-write it back:
+```lua
+rela.md.paragraph("hello")
+rela.md.paragraph({rela.md.text("see "), rela.md.link_inline("docs", "/x")})
+rela.md.heading(2, "Section")
+rela.md.heading(2, {rela.md.text("Section "), rela.md.code_span("X")})
+rela.md.blockquote("a single paragraph")
+rela.md.blockquote({rela.md.paragraph("p1"), rela.md.paragraph("p2")})
+```
+
+Inline constructors:
+
+```lua
+rela.md.text(s)                              -- {type="text", text=s}
+rela.md.code_span(s)                         -- {type="code_span", text=s}
+rela.md.raw_html(s)                          -- {type="raw_html", text=s}
+rela.md.link_inline(text_or_inlines, url, title?)
+                                             -- {type="link", url, [title], inlines={...}}
+```
+
+`rela.md.link_inline` is distinct from `rela.md.link(text, url) → string`,
+which predates the inline AST and is still available for scripts that
+build markdown by string concatenation.
+
+#### Flattening to text
+
+When you want a plain string instead of an inline tree, call
+`rela.md.flatten(inlines)`. It applies a conservative policy:
+
+- **Strikethrough** (`~~...~~`) — preserved as `~~text~~`. The
+  checklist-validation layer treats strikethrough as the "skip" marker.
+- **Code spans** (`` `...` ``) — preserved with their backticks.
+- **Raw HTML** — preserved verbatim.
+- **Autolinks** — render as the URL.
+- **Soft and hard breaks** — render as a single space (matching the
+  pre-refactor flat-text behaviour).
+- **Emphasis, strong, link** — wrapper dropped, only the inner content
+  is kept (so `[See docs](url)` flattens to `See docs`).
+- **Images** — render as the flattened alt content (no URL).
+
+`rela.md.headers(ast)` and `rela.md.first_paragraph(ast)` use this
+policy automatically, so existing scripts that read `header.title` or
+the first-paragraph string see no behaviour change for typical content.
+
+#### Worked example: reading and mutating a checklist
 
 ```lua
 local ticket = rela.get_entity("TKT-001")
@@ -911,8 +959,11 @@ local ast = rela.md.parse(ticket.content)
 for _, node in ipairs(ast) do
     if node.type == "list" then
         for _, item in ipairs(node.items) do
-            if type(item) == "table" and item.task and item.text == "implement" then
-                item.checked = true
+            if type(item) == "table" and item.task then
+                local label = rela.md.flatten(item.inlines)
+                if label == "implement" then
+                    item.checked = true
+                end
             end
         end
     end
@@ -921,46 +972,23 @@ end
 rela.update_entity("TKT-001", {}, rela.md.render(ast))
 ```
 
-#### Inline marker preservation policy
-
-When `rela.md.parse` extracts the text of a list item (or paragraph,
-heading, blockquote, or table cell), the following inline markers are
-**preserved**:
-
-- **Strikethrough** (`~~...~~`) — load-bearing because the checklist
-  validation layer treats strikethrough as the "skip" marker for items
-  that are intentionally not done.
-- **Code spans** (`` `...` ``) — preserved because identifiers and code
-  references are structural and round-tripping should not mangle them.
-
-The following inline markers are **dropped** (only the inner text is
-captured):
-
-- Bold (`**...**`), italic (`*...*` or `_..._`)
-- Links (`[text](url)` becomes just `text`)
-- Autolinks and raw HTML
-
-This policy is intentional and pinned by tests in
-`internal/lua/markdown_test.go` (`TestMdInlineTextPolicy`). If you need
-to round-trip content with full inline fidelity, do not pass it through
-`rela.md.parse`/`render` — read and write the raw `entity.content`
-string instead.
-
 #### Limitations
 
-- **First text block only.** A list item that contains multiple
-  paragraphs, nested lists, or fenced code blocks will only have its
-  first text block captured in `text`. This matches the GFM task list
-  spec, which requires the checkbox in the first text block.
 - **Mixed lists.** A list mixing task and plain items may not be
-  symmetrically re-parseable: goldmark only classifies an item as a
-  task if it carries its own checkbox. The renderer always emits
-  checkbox syntax for items with `task = true`.
+  symmetrically re-parseable: only items that carry their own
+  checkbox in the source are classified as task items on parse, but
+  the renderer always emits checkbox syntax for items with
+  `task = true`.
 - **Sparse item tables.** Scripts that delete items via
   `items[i] = nil` will get a compact rendering (the renderer skips
   `nil` holes), but they should compact the table explicitly if they
   rely on `#items` afterwards — Lua's length operator returns a
   "border", not a count.
+- **Performance.** Parsing now allocates a Lua table per inline node.
+  On a kitchen-sink fixture this is ~2.5–3× the allocations of the
+  pre-refactor flat-string representation. For real-world content
+  (mostly plain prose) the gap is smaller. If a hot-path script feels
+  slow, consider parsing once and reusing the AST.
 
 ## Entity Structure
 

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -662,7 +662,7 @@ script runs in a specialized mode with extra context exposed:
 | `rela.document.entry_id` | The ID of the entity being rendered |
 
 The script's stdout is captured and used as the rendered document's
-markdown (after goldmark → HTML conversion). Use `print()` to produce
+markdown (which is then converted to HTML). Use `print()` to produce
 output.
 
 ```lua
@@ -826,77 +826,125 @@ Lua numbers are 64-bit floats. Integer IDs larger than 2^53 cannot round-trip
 through any Lua value — this is a Lua limitation, not a cache one, but worth
 keeping in mind if you cache things keyed by raw integer IDs.
 
-### Markdown AST: Task Lists
+### Markdown AST
 
 The `rela.md` module exposes a markdown AST API for parsing and rendering
-content. This section documents the task list (checkbox) support; the rest
-of the `rela.md` surface is documented inline in the Go source.
+content. The AST is structure-preserving: links, code spans, raw HTML,
+images, autolinks, line breaks, multi-paragraph blockquotes, and
+multi-block list items all keep their structure on the Lua side.
+Flattening to plain strings happens at render time and in helper APIs
+(`headers`, `first_paragraph`, the public `flatten`), never at parse
+time.
 
-Use `rela.md.parse(content)` to turn a markdown string into an AST table,
-and `rela.md.render(ast)` to serialize it back. Task list items (`- [x]`
-and `- [ ]`) round-trip through the AST as Lua tables.
+Use `rela.md.parse(content)` to turn a markdown string into an AST table
+and `rela.md.render(ast)` to serialize it back. The pair is a fixed point
+on a representative corpus of GFM input.
 
-#### Task item shape
-
-A task list item is represented as a Lua table with three fields:
-
-```lua
-{task = true, checked = <bool>, text = <string>}
-```
-
-- `task = true` marks the item as a checkbox item. Only an explicit Lua
-  boolean `true` qualifies — strings, numbers, `nil`, and `false` all fall
-  through to plain rendering.
-- `checked` is the checkbox state (`true` for `[x]`, `false` for `[ ]`).
-- `text` is the item's text content.
-
-Plain (non-task) list items are still represented as bare strings, so
-existing scripts continue to work without changes.
-
-#### Reading checkbox state
+#### Block node shapes
 
 ```lua
-local ast = rela.md.parse([[
-- [x] write the code
-- [ ] write the tests
-- [x] ~~obsolete item~~
-]])
+-- Inline-bearing leaves carry an `inlines` array.
+{ type = "paragraph", inlines = { ... } }
+{ type = "heading",   level = 2, inlines = { ... } }
 
-for _, item in ipairs(ast[1].items) do
-    if type(item) == "table" and item.task then
-        local mark = item.checked and "DONE" or "TODO"
-        print(mark, item.text)
-    end
-end
--- Output:
--- DONE  write the code
--- TODO  write the tests
--- DONE  ~~obsolete item~~
+-- Block containers carry `children` (an array of block nodes).
+{ type = "blockquote", children = { ... } }
+
+-- Lists hold items; each item is one of:
+--   * a string (a plain item containing only text)
+--   * a table with `inlines` (single-paragraph item with formatting)
+--   * a table with `children` (multi-block item; e.g. an item
+--     containing a fenced code block or nested list)
+--   * a task table with `task=true`, `checked=<bool>`, and either
+--     `inlines` or `children` per the same rules above
+{ type = "list", ordered = false, items = { ... } }
+
+-- Tables: each cell is an `inlines` array (link/code/raw HTML inside
+-- a cell round-trips correctly).
+{ type = "table",
+  header = { cell, cell, ... },              -- each cell is an inlines array
+  rows   = { { cell, cell }, ... },
+  alignments = { "left", "center", "right" } }
+
+-- Leaves that don't carry inline content keep a `content: string`.
+{ type = "code_block", language = "go", content = "fmt.Println()" }
+{ type = "thematic_break" }
+{ type = "raw", content = "<unknown block>" }
 ```
 
-#### Building a task list
+#### Inline node shapes
 
 ```lua
-local ast = {
-    rela.md.list({
-        {task = true, checked = true,  text = "design API"},
-        {task = true, checked = false, text = "implement"},
-        {task = true, checked = false, text = "write docs"},
-    }),
-}
-print(rela.md.render(ast))
--- - [x] design API
--- - [ ] implement
--- - [ ] write docs
+-- Leaves with a `text` field:
+{ type = "text",         text = "hello" }
+{ type = "code_span",    text = "x = 1" }
+{ type = "raw_html",     text = "<br>" }
+{ type = "soft_break" }                   -- a soft line break in the source
+{ type = "hard_break" }                   -- two-trailing-space line break
+
+-- Autolinks have a `url` (no inner text):
+{ type = "autolink",     url  = "https://example.com" }
+
+-- Containers wrap further inlines:
+{ type = "emphasis",     inlines = { ... } }   -- *text*
+{ type = "strong",       inlines = { ... } }   -- **text**
+{ type = "strikethrough",inlines = { ... } }   -- ~~text~~
+{ type = "link",         url  = "/x", title = nil, inlines = { ... } }
+
+-- Images store alt content as a separate inlines array (preserves
+-- formatting inside `![**bold**](url)`):
+{ type = "image",        url, title = nil, alt_inlines = { ... } }
 ```
 
-`rela.md.list(items, ordered?)` accepts plain strings, task tables, or a
-mix. Pass `true` as the second argument for an ordered list.
+#### Constructors
 
-#### Mutating an existing checklist
+Block constructors accept either a string (auto-wrapped to a single text
+leaf) or an inlines/children table:
 
-A common pattern is to read a ticket's checklist, flip a checkbox, and
-write it back:
+```lua
+rela.md.paragraph("hello")
+rela.md.paragraph({rela.md.text("see "), rela.md.link_inline("docs", "/x")})
+rela.md.heading(2, "Section")
+rela.md.heading(2, {rela.md.text("Section "), rela.md.code_span("X")})
+rela.md.blockquote("a single paragraph")
+rela.md.blockquote({rela.md.paragraph("p1"), rela.md.paragraph("p2")})
+```
+
+Inline constructors:
+
+```lua
+rela.md.text(s)                              -- {type="text", text=s}
+rela.md.code_span(s)                         -- {type="code_span", text=s}
+rela.md.raw_html(s)                          -- {type="raw_html", text=s}
+rela.md.link_inline(text_or_inlines, url, title?)
+                                             -- {type="link", url, [title], inlines={...}}
+```
+
+`rela.md.link_inline` is distinct from `rela.md.link(text, url) → string`,
+which predates the inline AST and is still available for scripts that
+build markdown by string concatenation.
+
+#### Flattening to text
+
+When you want a plain string instead of an inline tree, call
+`rela.md.flatten(inlines)`. It applies a conservative policy:
+
+- **Strikethrough** (`~~...~~`) — preserved as `~~text~~`. The
+  checklist-validation layer treats strikethrough as the "skip" marker.
+- **Code spans** (`` `...` ``) — preserved with their backticks.
+- **Raw HTML** — preserved verbatim.
+- **Autolinks** — render as the URL.
+- **Soft and hard breaks** — render as a single space (matching the
+  pre-refactor flat-text behaviour).
+- **Emphasis, strong, link** — wrapper dropped, only the inner content
+  is kept (so `[See docs](url)` flattens to `See docs`).
+- **Images** — render as the flattened alt content (no URL).
+
+`rela.md.headers(ast)` and `rela.md.first_paragraph(ast)` use this
+policy automatically, so existing scripts that read `header.title` or
+the first-paragraph string see no behaviour change for typical content.
+
+#### Worked example: reading and mutating a checklist
 
 ```lua
 local ticket = rela.get_entity("TKT-001")
@@ -905,8 +953,11 @@ local ast = rela.md.parse(ticket.content)
 for _, node in ipairs(ast) do
     if node.type == "list" then
         for _, item in ipairs(node.items) do
-            if type(item) == "table" and item.task and item.text == "implement" then
-                item.checked = true
+            if type(item) == "table" and item.task then
+                local label = rela.md.flatten(item.inlines)
+                if label == "implement" then
+                    item.checked = true
+                end
             end
         end
     end
@@ -915,46 +966,23 @@ end
 rela.update_entity("TKT-001", {}, rela.md.render(ast))
 ```
 
-#### Inline marker preservation policy
-
-When `rela.md.parse` extracts the text of a list item (or paragraph,
-heading, blockquote, or table cell), the following inline markers are
-**preserved**:
-
-- **Strikethrough** (`~~...~~`) — load-bearing because the checklist
-  validation layer treats strikethrough as the "skip" marker for items
-  that are intentionally not done.
-- **Code spans** (`` `...` ``) — preserved because identifiers and code
-  references are structural and round-tripping should not mangle them.
-
-The following inline markers are **dropped** (only the inner text is
-captured):
-
-- Bold (`**...**`), italic (`*...*` or `_..._`)
-- Links (`[text](url)` becomes just `text`)
-- Autolinks and raw HTML
-
-This policy is intentional and pinned by tests in
-`internal/lua/markdown_test.go` (`TestMdInlineTextPolicy`). If you need
-to round-trip content with full inline fidelity, do not pass it through
-`rela.md.parse`/`render` — read and write the raw `entity.content`
-string instead.
-
 #### Limitations
 
-- **First text block only.** A list item that contains multiple
-  paragraphs, nested lists, or fenced code blocks will only have its
-  first text block captured in `text`. This matches the GFM task list
-  spec, which requires the checkbox in the first text block.
 - **Mixed lists.** A list mixing task and plain items may not be
-  symmetrically re-parseable: goldmark only classifies an item as a
-  task if it carries its own checkbox. The renderer always emits
-  checkbox syntax for items with `task = true`.
+  symmetrically re-parseable: only items that carry their own
+  checkbox in the source are classified as task items on parse, but
+  the renderer always emits checkbox syntax for items with
+  `task = true`.
 - **Sparse item tables.** Scripts that delete items via
   `items[i] = nil` will get a compact rendering (the renderer skips
   `nil` holes), but they should compact the table explicitly if they
   rely on `#items` afterwards — Lua's length operator returns a
   "border", not a count.
+- **Performance.** Parsing now allocates a Lua table per inline node.
+  On a kitchen-sink fixture this is ~2.5–3× the allocations of the
+  pre-refactor flat-string representation. For real-world content
+  (mostly plain prose) the gap is smaller. If a hot-path script feels
+  slow, consider parsing once and reusing the AST.
 
 ## Entity Structure
 

--- a/internal/lua/markdown.go
+++ b/internal/lua/markdown.go
@@ -15,17 +15,42 @@ import (
 	lua "github.com/yuin/gopher-lua"
 )
 
-// Markdown node type constants.
-const (
-	nodeTypeHeading       = "heading"
-	nodeTypeParagraph     = "paragraph"
-	nodeTypeCodeBlock     = "code_block"
-	nodeTypeList          = "list"
-	nodeTypeBlockquote    = "blockquote"
-	nodeTypeThematicBreak = "thematic_break"
-	nodeTypeTable         = "table"
-	nodeTypeRaw           = "raw"
+// blockKind tags a block-level AST node by its `type` field.
+type blockKind string
 
+// inlineKind tags an inline AST node by its `type` field.
+type inlineKind string
+
+// Block node types.
+const (
+	nodeTypeHeading       blockKind = "heading"
+	nodeTypeParagraph     blockKind = "paragraph"
+	nodeTypeCodeBlock     blockKind = "code_block"
+	nodeTypeList          blockKind = "list"
+	nodeTypeBlockquote    blockKind = "blockquote"
+	nodeTypeThematicBreak blockKind = "thematic_break"
+	nodeTypeTable         blockKind = "table"
+	nodeTypeRaw           blockKind = "raw"
+)
+
+// Inline node types. Block leaves (paragraph, heading) and
+// inline-bearing containers (link, emphasis, strong, strikethrough,
+// image alt) carry arrays of these.
+const (
+	inlineTypeText          inlineKind = "text"
+	inlineTypeCodeSpan      inlineKind = "code_span"
+	inlineTypeRawHTML       inlineKind = "raw_html"
+	inlineTypeAutolink      inlineKind = "autolink"
+	inlineTypeSoftBreak     inlineKind = "soft_break"
+	inlineTypeHardBreak     inlineKind = "hard_break"
+	inlineTypeEmphasis      inlineKind = "emphasis"
+	inlineTypeStrong        inlineKind = "strong"
+	inlineTypeStrikethrough inlineKind = "strikethrough"
+	inlineTypeLink          inlineKind = "link"
+	inlineTypeImage         inlineKind = "image"
+)
+
+const (
 	alignLeft   = "left"
 	alignRight  = "right"
 	alignCenter = "center"
@@ -57,7 +82,7 @@ func (r *Runtime) registerMarkdownModule(rela *lua.LTable) {
 	// Composition functions
 	r.L.SetField(md, "concat", r.L.NewFunction(r.luaMdConcat))
 
-	// Node constructors
+	// Node constructors (block).
 	r.L.SetField(md, "heading", r.L.NewFunction(luaMdHeading))
 	r.L.SetField(md, "paragraph", r.L.NewFunction(luaMdParagraph))
 	r.L.SetField(md, "code_block", r.L.NewFunction(luaMdCodeBlock))
@@ -65,13 +90,86 @@ func (r *Runtime) registerMarkdownModule(rela *lua.LTable) {
 	r.L.SetField(md, "blockquote", r.L.NewFunction(luaMdBlockquote))
 	r.L.SetField(md, "list", r.L.NewFunction(luaMdList))
 
-	// Generation helpers
+	// Node constructors (inline).
+	r.L.SetField(md, "text", r.L.NewFunction(luaMdInlineText))
+	r.L.SetField(md, "code_span", r.L.NewFunction(luaMdInlineCodeSpan))
+	r.L.SetField(md, "link_inline", r.L.NewFunction(luaMdInlineLink))
+	r.L.SetField(md, "raw_html", r.L.NewFunction(luaMdInlineRawHTML))
+
+	// Inline-flatten helper for scripts.
+	r.L.SetField(md, "flatten", r.L.NewFunction(luaMdFlatten))
+
+	// Generation helpers (string-returning, predate the inline AST).
 	r.L.SetField(md, "link", r.L.NewFunction(luaMdLink))
 	r.L.SetField(md, "ref", r.L.NewFunction(luaMdRef))
 	r.L.SetField(md, "table", r.L.NewFunction(luaMdTable))
 	r.L.SetField(md, "entity_table", r.L.NewFunction(r.luaMdEntityTable))
 
 	r.L.SetField(rela, "md", md)
+}
+
+// --- Inline node constructors ---
+
+// luaMdInlineText: rela.md.text(s) -> {type="text", text=s}
+func luaMdInlineText(ls *lua.LState) int {
+	s := ls.CheckString(1)
+	t := ls.NewTable()
+	t.RawSetString("type", lua.LString(inlineTypeText))
+	t.RawSetString("text", lua.LString(s))
+	ls.Push(t)
+	return 1
+}
+
+// luaMdInlineCodeSpan: rela.md.code_span(s) -> {type="code_span", text=s}
+func luaMdInlineCodeSpan(ls *lua.LState) int {
+	s := ls.CheckString(1)
+	t := ls.NewTable()
+	t.RawSetString("type", lua.LString(inlineTypeCodeSpan))
+	t.RawSetString("text", lua.LString(s))
+	ls.Push(t)
+	return 1
+}
+
+// luaMdInlineRawHTML: rela.md.raw_html(s) -> {type="raw_html", text=s}
+func luaMdInlineRawHTML(ls *lua.LState) int {
+	s := ls.CheckString(1)
+	t := ls.NewTable()
+	t.RawSetString("type", lua.LString(inlineTypeRawHTML))
+	t.RawSetString("text", lua.LString(s))
+	ls.Push(t)
+	return 1
+}
+
+// luaMdInlineLink: rela.md.link_inline(text_or_inlines, url, title?) -> link inline.
+// Distinct from rela.md.link, which returns a string [text](url) (predates
+// the inline AST).
+func luaMdInlineLink(ls *lua.LState) int {
+	inlines := acceptInlinesArg(ls, 1)
+	url := ls.CheckString(2)
+	title := ls.OptString(3, "")
+
+	t := ls.NewTable()
+	t.RawSetString("type", lua.LString(inlineTypeLink))
+	t.RawSetString("url", lua.LString(url))
+	if title != "" {
+		t.RawSetString("title", lua.LString(title))
+	}
+	t.RawSetString("inlines", inlines)
+	ls.Push(t)
+	return 1
+}
+
+// luaMdFlatten: rela.md.flatten(inlines) -> string
+// Applies the legacy text-extraction policy to a Lua-side inlines array.
+func luaMdFlatten(ls *lua.LState) int {
+	v := ls.Get(1)
+	tbl, ok := v.(*lua.LTable)
+	if !ok {
+		ls.RaiseError("rela.md.flatten: expected an inlines table")
+		return 0
+	}
+	ls.Push(lua.LString(flattenInlines(tbl)))
+	return 1
 }
 
 // --- Core Functions ---
@@ -101,7 +199,7 @@ func (r *Runtime) luaMdRender(ls *lua.LState) int {
 	astTable := ls.CheckTable(1)
 
 	var sb strings.Builder
-	r.renderNodes(&sb, astTable)
+	renderNodes(&sb, astTable)
 
 	ls.Push(lua.LString(sb.String()))
 	return 1
@@ -232,7 +330,7 @@ func (r *Runtime) luaMdHeaders(ls *lua.LState) int {
 		if level >= minLvl && level <= maxLvl {
 			header := r.L.NewTable()
 			header.RawSetString("level", lua.LNumber(level))
-			header.RawSetString("title", node.RawGetString("text"))
+			header.RawSetString("title", lua.LString(headingTitleFlat(node)))
 			result.RawSetInt(resultIdx, header)
 			resultIdx++
 		}
@@ -317,16 +415,24 @@ func (r *Runtime) luaMdExtractSection(ls *lua.LState) int {
 	return 1
 }
 
-// getHeadingInfo extracts level and title from a heading node.
+// getHeadingInfo extracts level and a flat title from a heading node.
 func (r *Runtime) getHeadingInfo(node *lua.LTable) (level int, title string) {
 	level = 1
 	if l, ok := node.RawGetString("level").(lua.LNumber); ok {
 		level = int(l)
 	}
-	if t, ok := node.RawGetString("text").(lua.LString); ok {
-		title = string(t)
-	}
+	title = headingTitleFlat(node)
 	return
+}
+
+// headingTitleFlat reads the heading's flat title using the legacy
+// flatten policy (drops link wrappers, drops emphasis, preserves `~~`
+// and code spans). Falls back to a `text` field for hand-built nodes.
+func headingTitleFlat(node *lua.LTable) string {
+	if t := inlinesField(node, "inlines"); t != nil {
+		return flattenInlines(t)
+	}
+	return stringField(node, "text")
 }
 
 // luaMdFirstParagraph extracts the first paragraph text from the AST.
@@ -341,8 +447,13 @@ func (r *Runtime) luaMdFirstParagraph(ls *lua.LState) int {
 		if !ok {
 			continue
 		}
-		if nodeType := node.RawGetString("type"); nodeType == lua.LString(nodeTypeParagraph) {
-			ls.Push(node.RawGetString("text"))
+		if blockKindOf(node) == nodeTypeParagraph {
+			if inlines := inlinesField(node, "inlines"); inlines != nil {
+				ls.Push(lua.LString(flattenInlines(inlines)))
+			} else {
+				// Fallback for hand-built paragraphs carrying `text`.
+				ls.Push(lua.LString(stringField(node, "text")))
+			}
 			return 1
 		}
 	}
@@ -385,22 +496,22 @@ func (r *Runtime) luaMdConcat(ls *lua.LState) int {
 
 // luaMdHeading creates a heading node.
 // Usage: local node = rela.md.heading(2, "Section Title")
+//
+//	local node = rela.md.heading(2, {rela.md.text("a "), rela.md.code_span("b")})
 func luaMdHeading(ls *lua.LState) int {
 	level := ls.CheckInt(1)
-	headingText := ls.CheckString(2)
-
-	// Clamp level
 	if level < minHeaderLevel {
 		level = minHeaderLevel
 	}
 	if level > maxHeaderLevel {
 		level = maxHeaderLevel
 	}
+	inlines := acceptInlinesArg(ls, 2)
 
 	node := ls.NewTable()
 	node.RawSetString("type", lua.LString(nodeTypeHeading))
 	node.RawSetString("level", lua.LNumber(level))
-	node.RawSetString("text", lua.LString(headingText))
+	node.RawSetString("inlines", inlines)
 
 	ls.Push(node)
 	return 1
@@ -408,15 +519,39 @@ func luaMdHeading(ls *lua.LState) int {
 
 // luaMdParagraph creates a paragraph node.
 // Usage: local node = rela.md.paragraph("Some text content")
+//
+//	local node = rela.md.paragraph({rela.md.text("see "), rela.md.link_inline("link", "/x")})
 func luaMdParagraph(ls *lua.LState) int {
-	paragraphText := ls.CheckString(1)
+	inlines := acceptInlinesArg(ls, 1)
 
 	node := ls.NewTable()
 	node.RawSetString("type", lua.LString(nodeTypeParagraph))
-	node.RawSetString("text", lua.LString(paragraphText))
+	node.RawSetString("inlines", inlines)
 
 	ls.Push(node)
 	return 1
+}
+
+// acceptInlinesArg coerces argument idx to an inlines array. Accepts:
+//   - a string: wraps as {{type="text", text=s}}
+//   - a table: passes through verbatim (assumed to be an inlines array)
+func acceptInlinesArg(ls *lua.LState, idx int) *lua.LTable {
+	v := ls.Get(idx)
+	switch x := v.(type) {
+	case lua.LString:
+		out := ls.NewTable()
+		if string(x) != "" {
+			leaf := ls.NewTable()
+			leaf.RawSetString("type", lua.LString(inlineTypeText))
+			leaf.RawSetString("text", x)
+			out.RawSetInt(1, leaf)
+		}
+		return out
+	case *lua.LTable:
+		return x
+	}
+	ls.RaiseError("expected string or inlines table at argument %d", idx)
+	return nil
 }
 
 // luaMdCodeBlock creates a code block node.
@@ -446,12 +581,36 @@ func luaMdThematicBreak(ls *lua.LState) int {
 
 // luaMdBlockquote creates a blockquote node.
 // Usage: local node = rela.md.blockquote("Quoted text")
+//
+//	local node = rela.md.blockquote({rela.md.paragraph("p1"), rela.md.paragraph("p2")})
 func luaMdBlockquote(ls *lua.LState) int {
-	content := ls.CheckString(1)
-
+	v := ls.Get(1)
 	node := ls.NewTable()
 	node.RawSetString("type", lua.LString(nodeTypeBlockquote))
-	node.RawSetString("content", lua.LString(content))
+
+	switch x := v.(type) {
+	case lua.LString:
+		// String → wrap as a single paragraph child.
+		children := ls.NewTable()
+		para := ls.NewTable()
+		para.RawSetString("type", lua.LString(nodeTypeParagraph))
+		inlines := ls.NewTable()
+		if string(x) != "" {
+			leaf := ls.NewTable()
+			leaf.RawSetString("type", lua.LString(inlineTypeText))
+			leaf.RawSetString("text", x)
+			inlines.RawSetInt(1, leaf)
+		}
+		para.RawSetString("inlines", inlines)
+		children.RawSetInt(1, para)
+		node.RawSetString("children", children)
+	case *lua.LTable:
+		// Table → assumed to be a children array of block nodes.
+		node.RawSetString("children", x)
+	default:
+		ls.RaiseError("rela.md.blockquote: expected string or children table")
+		return 0
+	}
 
 	ls.Push(node)
 	return 1
@@ -528,11 +687,18 @@ func (r *Runtime) nodeToLua(n ast.Node, source []byte) *lua.LTable {
 	case *ast.Heading:
 		node.RawSetString("type", lua.LString(nodeTypeHeading))
 		node.RawSetString("level", lua.LNumber(n.Level))
-		node.RawSetString("text", lua.LString(r.extractText(n, source)))
+		node.RawSetString("inlines", r.extractInlines(n, source))
 
 	case *ast.Paragraph:
 		node.RawSetString("type", lua.LString(nodeTypeParagraph))
-		node.RawSetString("text", lua.LString(r.extractText(n, source)))
+		node.RawSetString("inlines", r.extractInlines(n, source))
+
+	case *ast.TextBlock:
+		// goldmark emits TextBlock for paragraph-equivalent content inside
+		// list items and other contexts. Treat as a paragraph for our
+		// purposes so block-level walkers don't have to special-case it.
+		node.RawSetString("type", lua.LString(nodeTypeParagraph))
+		node.RawSetString("inlines", r.extractInlines(n, source))
 
 	case *ast.FencedCodeBlock:
 		node.RawSetString("type", lua.LString(nodeTypeCodeBlock))
@@ -551,7 +717,7 @@ func (r *Runtime) nodeToLua(n ast.Node, source []byte) *lua.LTable {
 
 	case *ast.Blockquote:
 		node.RawSetString("type", lua.LString(nodeTypeBlockquote))
-		node.RawSetString("content", lua.LString(r.extractBlockquoteContent(n, source)))
+		node.RawSetString("children", r.extractBlockChildren(n, source))
 
 	case *ast.ThematicBreak:
 		node.RawSetString("type", lua.LString(nodeTypeThematicBreak))
@@ -572,67 +738,426 @@ func (r *Runtime) nodeToLua(n ast.Node, source []byte) *lua.LTable {
 	return node
 }
 
-// extractText extracts text content from inline children.
-func (r *Runtime) extractText(n ast.Node, source []byte) string {
+// extractInlines walks goldmark's inline children of an inline-bearing
+// block (paragraph, heading, table cell, etc.) and returns a Lua table
+// containing inline-node tables. The structure mirrors goldmark's AST:
+// emphasis/strong/strikethrough/link become container inlines with their
+// own `inlines` arrays; code spans and raw HTML become leaf inlines with a
+// `text` field; soft and hard line breaks are emitted as synthetic inline
+// nodes after the text whose flag is set; task checkboxes are skipped
+// (their state is captured separately by detectTaskCheckbox).
+func (r *Runtime) extractInlines(parent ast.Node, source []byte) *lua.LTable {
+	out := r.L.NewTable()
+	idx := 1
+	for child := parent.FirstChild(); child != nil; child = child.NextSibling() {
+		idx = r.appendInlines(out, child, source, idx)
+	}
+	return out
+}
+
+// appendInlines emits Lua tables for the given goldmark inline node
+// (and any synthetic break that follows) into out, returning the next
+// index to use.
+func (r *Runtime) appendInlines(out *lua.LTable, n ast.Node, source []byte, idx int) int {
+	switch n := n.(type) {
+	case *ast.Text:
+		return r.appendTextInline(out, n, source, idx)
+	case *ast.String:
+		if s := string(n.Value); s != "" {
+			out.RawSetInt(idx, r.makeLeafInline(inlineTypeText, s))
+			return idx + 1
+		}
+		return idx
+	case *ast.CodeSpan:
+		var sb strings.Builder
+		for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+			collectRawText(&sb, c, source)
+		}
+		out.RawSetInt(idx, r.makeLeafInline(inlineTypeCodeSpan, sb.String()))
+		// Note: the original fence width is not preserved on the AST.
+		// renderInlineNode uses the smallest safe fence (computed from
+		// the content) so a span whose content contains a backtick can
+		// still round-trip without shifting in meaning.
+		return idx + 1
+	case *ast.RawHTML:
+		var sb strings.Builder
+		segs := n.Segments
+		for i := range segs.Len() {
+			seg := segs.At(i)
+			sb.Write(seg.Value(source))
+		}
+		out.RawSetInt(idx, r.makeLeafInline(inlineTypeRawHTML, sb.String()))
+		return idx + 1
+	case *ast.AutoLink:
+		an := r.L.NewTable()
+		an.RawSetString("type", lua.LString(inlineTypeAutolink))
+		an.RawSetString("url", lua.LString(string(n.URL(source))))
+		out.RawSetInt(idx, an)
+		return idx + 1
+	case *ast.Link:
+		out.RawSetInt(idx, r.makeLinkInline(n.Destination, n.Title, n, source))
+		return idx + 1
+	case *ast.Image:
+		out.RawSetInt(idx, r.makeImageInline(n.Destination, n.Title, n, source))
+		return idx + 1
+	case *ast.Emphasis:
+		kind := inlineTypeEmphasis
+		if n.Level >= 2 {
+			kind = inlineTypeStrong
+		}
+		out.RawSetInt(idx, r.makeContainerInline(kind, n, source))
+		return idx + 1
+	case *east.Strikethrough:
+		out.RawSetInt(idx, r.makeContainerInline(inlineTypeStrikethrough, n, source))
+		return idx + 1
+	case *east.TaskCheckBox:
+		// State is captured separately by detectTaskCheckbox.
+		return idx
+	default:
+		// Unknown inline kind. Recurse to capture inner text.
+		for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+			idx = r.appendInlines(out, c, source, idx)
+		}
+		return idx
+	}
+}
+
+// appendTextInline emits the text leaf and any soft/hard break following.
+func (r *Runtime) appendTextInline(out *lua.LTable, n *ast.Text, source []byte, idx int) int {
+	if seg := string(n.Segment.Value(source)); seg != "" {
+		out.RawSetInt(idx, r.makeLeafInline(inlineTypeText, seg))
+		idx++
+	}
+	switch {
+	case n.HardLineBreak():
+		b := r.L.NewTable()
+		b.RawSetString("type", lua.LString(inlineTypeHardBreak))
+		out.RawSetInt(idx, b)
+		idx++
+	case n.SoftLineBreak():
+		b := r.L.NewTable()
+		b.RawSetString("type", lua.LString(inlineTypeSoftBreak))
+		out.RawSetInt(idx, b)
+		idx++
+	}
+	return idx
+}
+
+// makeLeafInline constructs an inline node with `type` and `text` fields.
+func (r *Runtime) makeLeafInline(kind inlineKind, text string) *lua.LTable {
+	t := r.L.NewTable()
+	t.RawSetString("type", lua.LString(kind))
+	t.RawSetString("text", lua.LString(text))
+	return t
+}
+
+// makeContainerInline constructs an emphasis/strong/strikethrough/link
+// inline whose body is the inline tree of n's children.
+func (r *Runtime) makeContainerInline(kind inlineKind, n ast.Node, source []byte) *lua.LTable {
+	t := r.L.NewTable()
+	t.RawSetString("type", lua.LString(kind))
+	t.RawSetString("inlines", r.extractInlines(n, source))
+	return t
+}
+
+// makeLinkInline constructs a link inline.
+func (r *Runtime) makeLinkInline(dest, title []byte, n ast.Node, source []byte) *lua.LTable {
+	t := r.L.NewTable()
+	t.RawSetString("type", lua.LString(inlineTypeLink))
+	t.RawSetString("url", lua.LString(string(dest)))
+	if len(title) > 0 {
+		t.RawSetString("title", lua.LString(string(title)))
+	}
+	t.RawSetString("inlines", r.extractInlines(n, source))
+	return t
+}
+
+// makeImageInline constructs an image inline (alt content goes in
+// `alt_inlines`).
+func (r *Runtime) makeImageInline(dest, title []byte, n ast.Node, source []byte) *lua.LTable {
+	t := r.L.NewTable()
+	t.RawSetString("type", lua.LString(inlineTypeImage))
+	t.RawSetString("url", lua.LString(string(dest)))
+	if len(title) > 0 {
+		t.RawSetString("title", lua.LString(string(title)))
+	}
+	t.RawSetString("alt_inlines", r.extractInlines(n, source))
+	return t
+}
+
+// inlineKindOf reads the `type` field off an inline node table.
+func inlineKindOf(node *lua.LTable) inlineKind {
+	s, _ := node.RawGetString("type").(lua.LString)
+	return inlineKind(s)
+}
+
+// blockKindOf reads the `type` field off a block node table.
+func blockKindOf(node *lua.LTable) blockKind {
+	s, _ := node.RawGetString("type").(lua.LString)
+	return blockKind(s)
+}
+
+// collectRawText concatenates the raw text of leaf inline children. Used
+// for code spans, where the inner content is meant to be opaque.
+func collectRawText(sb *strings.Builder, n ast.Node, source []byte) {
+	switch n := n.(type) {
+	case *ast.Text:
+		sb.Write(n.Segment.Value(source))
+	case *ast.String:
+		sb.Write(n.Value)
+	default:
+		for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+			collectRawText(sb, c, source)
+		}
+	}
+}
+
+// renderInlines walks an inlines array and produces a markdown string
+// preserving link/image/autolink/raw-HTML syntax. Used by block renderers
+// so parse → render is a fixed point on the corpus.
+func renderInlines(inlines *lua.LTable) string {
+	if inlines == nil {
+		return ""
+	}
 	var sb strings.Builder
-	for child := n.FirstChild(); child != nil; child = child.NextSibling() {
-		r.extractInlineText(&sb, child, source)
+	for i := 1; i <= inlines.Len(); i++ {
+		v := inlines.RawGetInt(i)
+		switch x := v.(type) {
+		case lua.LString:
+			// Tolerate a raw string inline (script convenience).
+			sb.WriteString(string(x))
+		case *lua.LTable:
+			renderInlineNode(&sb, x)
+		}
 	}
 	return sb.String()
 }
 
-// extractInlineText recursively extracts text from inline nodes.
-//
-// Inline marker preservation policy (applies to all extracted text:
-// paragraphs, headings, blockquotes, list items, table cells):
-//
-//   - Strikethrough (~~...~~):  PRESERVED. The checklist validation layer
-//     uses strikethrough as the "skip" marker, so scripts that round-trip
-//     checklists must not silently strip it.
-//   - Code spans (`...`):       PRESERVED. Code spans are structural and
-//     scripts that read content with code references would otherwise mangle
-//     them on round-trip.
-//   - Emphasis (* / _ / ** / __): DROPPED. Inline emphasis is treated as
-//     formatting noise; only the inner text is captured.
-//   - Links ([text](url)):      DROPPED — only the link text is captured.
-//   - Autolinks, raw HTML:      DROPPED — only inner text is captured.
-//   - TaskCheckBox:             SKIPPED — state is captured separately by
-//     extractListItems via detectTaskCheckbox.
-//
-// This policy is intentionally conservative: anything that the checklist
-// layer treats as load-bearing (strikethrough) plus anything that has
-// distinct semantic meaning a script would mangle (code spans) is preserved.
-// Other inline formatting is dropped to keep extracted text simple. Future
-// iterations may broaden preservation; the current policy is documented and
-// pinned by tests.
-func (r *Runtime) extractInlineText(sb *strings.Builder, n ast.Node, source []byte) {
-	switch n := n.(type) {
-	case *ast.Text:
-		sb.Write(n.Segment.Value(source))
-		if n.SoftLineBreak() {
-			sb.WriteByte(' ')
-		}
-	case *ast.String:
-		sb.Write(n.Value)
-	case *east.Strikethrough:
+func renderInlineNode(sb *strings.Builder, node *lua.LTable) {
+	switch inlineKindOf(node) {
+	case inlineTypeText, inlineTypeRawHTML:
+		writeStringField(sb, node, "text")
+	case inlineTypeCodeSpan:
+		s, _ := node.RawGetString("text").(lua.LString)
+		writeCodeSpan(sb, string(s))
+	case inlineTypeAutolink:
+		sb.WriteByte('<')
+		writeStringField(sb, node, "url")
+		sb.WriteByte('>')
+	case inlineTypeSoftBreak:
+		sb.WriteByte('\n')
+	case inlineTypeHardBreak:
+		sb.WriteString("  \n")
+	case inlineTypeEmphasis:
+		sb.WriteByte('*')
+		writeInlinesOrFallback(sb, node, renderInlines)
+		sb.WriteByte('*')
+	case inlineTypeStrong:
+		sb.WriteString("**")
+		writeInlinesOrFallback(sb, node, renderInlines)
+		sb.WriteString("**")
+	case inlineTypeStrikethrough:
 		sb.WriteString("~~")
-		for child := n.FirstChild(); child != nil; child = child.NextSibling() {
-			r.extractInlineText(sb, child, source)
-		}
+		writeInlinesOrFallback(sb, node, renderInlines)
 		sb.WriteString("~~")
-	case *ast.CodeSpan:
-		sb.WriteString("`")
-		for child := n.FirstChild(); child != nil; child = child.NextSibling() {
-			r.extractInlineText(sb, child, source)
-		}
-		sb.WriteString("`")
-	case *east.TaskCheckBox:
-		// Skip: checkbox state is captured by the list-item extractor.
+	case inlineTypeLink:
+		renderLinkInline(sb, node)
+	case inlineTypeImage:
+		renderImageInline(sb, node)
 	default:
-		// Recurse into children for other inline types (emphasis, links, etc.)
-		for child := n.FirstChild(); child != nil; child = child.NextSibling() {
-			r.extractInlineText(sb, child, source)
+		// Unknown inline: emit `text` if present (defensive).
+		writeStringField(sb, node, "text")
+	}
+}
+
+// writeStringField writes node[field] as a string if it's a Lua string.
+func writeStringField(sb *strings.Builder, node *lua.LTable, field string) {
+	if s, ok := node.RawGetString(field).(lua.LString); ok {
+		sb.WriteString(string(s))
+	}
+}
+
+// inlinesField reads node[field] as an inlines/children table, returning
+// nil if the field is missing or not a table.
+func inlinesField(node *lua.LTable, field string) *lua.LTable {
+	t, _ := node.RawGetString(field).(*lua.LTable)
+	return t
+}
+
+// stringField reads node[field] as a Go string, returning "" if the
+// field is missing or not a string.
+func stringField(node *lua.LTable, field string) string {
+	s, _ := node.RawGetString(field).(lua.LString)
+	return string(s)
+}
+
+// writeCodeSpan emits a code span using the smallest backtick fence that
+// is longer than any run of backticks inside the content (CommonMark
+// 6.1). If the content starts or ends with a backtick, a single space is
+// added inside the fence on each side; the parser strips this space at
+// re-parse, so the round-trip is preserved.
+func writeCodeSpan(sb *strings.Builder, content string) {
+	// Find the longest run of backticks in content.
+	maxRun, run := 0, 0
+	for i := range len(content) {
+		if content[i] == '`' {
+			run++
+			if run > maxRun {
+				maxRun = run
+			}
+		} else {
+			run = 0
 		}
+	}
+	fenceLen := maxRun + 1
+	fence := strings.Repeat("`", fenceLen)
+	sb.WriteString(fence)
+	pad := content != "" && (content[0] == '`' || content[len(content)-1] == '`')
+	if pad {
+		sb.WriteByte(' ')
+	}
+	sb.WriteString(content)
+	if pad {
+		sb.WriteByte(' ')
+	}
+	sb.WriteString(fence)
+}
+
+// renderLinkInline emits "[text](url)" or "[text](url \"title\")".
+func renderLinkInline(sb *strings.Builder, node *lua.LTable) {
+	url, _ := node.RawGetString("url").(lua.LString)
+	title, _ := node.RawGetString("title").(lua.LString)
+	sb.WriteByte('[')
+	writeInlinesOrFallback(sb, node, renderInlines)
+	sb.WriteString("](")
+	writeLinkURLAndTitle(sb, string(url), string(title))
+	sb.WriteByte(')')
+}
+
+// renderImageInline emits "![alt](url)" or "![alt](url \"title\")".
+// Alt content uses flatten policy (no link/emphasis wrappers).
+func renderImageInline(sb *strings.Builder, node *lua.LTable) {
+	url, _ := node.RawGetString("url").(lua.LString)
+	title, _ := node.RawGetString("title").(lua.LString)
+	alt, _ := node.RawGetString("alt_inlines").(*lua.LTable)
+	sb.WriteString("![")
+	sb.WriteString(flattenInlines(alt))
+	sb.WriteString("](")
+	writeLinkURLAndTitle(sb, string(url), string(title))
+	sb.WriteByte(')')
+}
+
+// writeLinkURLAndTitle emits the destination + optional title portion of
+// a link or image. URLs that contain whitespace or unbalanced
+// parentheses are wrapped in angle brackets per CommonMark.
+func writeLinkURLAndTitle(sb *strings.Builder, url, title string) {
+	if needsAngleBrackets(url) {
+		sb.WriteByte('<')
+		sb.WriteString(url)
+		sb.WriteByte('>')
+	} else {
+		sb.WriteString(url)
+	}
+	if title != "" {
+		sb.WriteString(` "`)
+		sb.WriteString(title)
+		sb.WriteByte('"')
+	}
+}
+
+// needsAngleBrackets reports whether a URL must be wrapped in <...> to
+// be valid in a markdown link destination. Whitespace, control chars,
+// and unbalanced parens force the wrapper.
+func needsAngleBrackets(url string) bool {
+	depth := 0
+	for i := range len(url) {
+		c := url[i]
+		switch {
+		case c <= ' ':
+			return true
+		case c == '(':
+			depth++
+		case c == ')':
+			depth--
+			if depth < 0 {
+				return true
+			}
+		}
+	}
+	return depth != 0
+}
+
+// flattenInlines applies the legacy text-extraction policy: strikethrough
+// and code spans are preserved as `~~...~~` / “ `...` “; emphasis,
+// strong, and link wrappers are dropped (only inner text); raw HTML is
+// emitted verbatim; autolinks render as the URL; soft/hard breaks render
+// as a single space (matching the pre-refactor behavior where soft
+// breaks became spaces and inline structure was condensed to text).
+//
+// Used by helpers that previously read `node.text`: `headers`,
+// `first_paragraph`, and the public `rela.md.flatten`.
+func flattenInlines(inlines *lua.LTable) string {
+	if inlines == nil {
+		return ""
+	}
+	var sb strings.Builder
+	for i := 1; i <= inlines.Len(); i++ {
+		v := inlines.RawGetInt(i)
+		switch x := v.(type) {
+		case lua.LString:
+			sb.WriteString(string(x))
+		case *lua.LTable:
+			flattenInlineNode(&sb, x)
+		}
+	}
+	return sb.String()
+}
+
+func flattenInlineNode(sb *strings.Builder, node *lua.LTable) {
+	switch inlineKindOf(node) {
+	case inlineTypeText, inlineTypeRawHTML:
+		if s, ok := node.RawGetString("text").(lua.LString); ok {
+			sb.WriteString(string(s))
+		}
+	case inlineTypeCodeSpan:
+		s, _ := node.RawGetString("text").(lua.LString)
+		writeCodeSpan(sb, string(s))
+	case inlineTypeAutolink:
+		if s, ok := node.RawGetString("url").(lua.LString); ok {
+			sb.WriteString(string(s))
+		}
+	case inlineTypeSoftBreak, inlineTypeHardBreak:
+		sb.WriteByte(' ')
+	case inlineTypeStrikethrough:
+		sb.WriteString("~~")
+		writeInlinesOrFallback(sb, node, flattenInlines)
+		sb.WriteString("~~")
+	case inlineTypeEmphasis, inlineTypeStrong, inlineTypeLink:
+		// Drop wrapper, keep inner text.
+		writeInlinesOrFallback(sb, node, flattenInlines)
+	case inlineTypeImage:
+		// Image: emit alt text (no URL).
+		alt, _ := node.RawGetString("alt_inlines").(*lua.LTable)
+		sb.WriteString(flattenInlines(alt))
+	default:
+		if s, ok := node.RawGetString("text").(lua.LString); ok {
+			sb.WriteString(string(s))
+		}
+	}
+}
+
+// writeInlinesOrFallback writes the rendering of node.inlines via the
+// supplied renderer (renderInlines or flattenInlines). If the node has
+// no `inlines` field but has a legacy `text` value, that value is coerced
+// to a string and written verbatim (compat with hand-built script
+// tables, including numeric `text` values).
+func writeInlinesOrFallback(sb *strings.Builder, node *lua.LTable, render func(*lua.LTable) string) {
+	if t := inlinesField(node, "inlines"); t != nil {
+		sb.WriteString(render(t))
+		return
+	}
+	if v := node.RawGetString("text"); v != lua.LNil {
+		sb.WriteString(lua.LVAsString(v))
 	}
 }
 
@@ -660,16 +1185,23 @@ func (r *Runtime) extractLinesContent(n ast.Node, source []byte) string {
 	return strings.TrimSuffix(sb.String(), "\n")
 }
 
-// extractListItems extracts list items as a Lua table.
+// extractListItems extracts list items as a Lua table. Each item is one
+// of:
 //
-// Task list items (with - [x] / - [ ] checkboxes) are represented as tables
-// with task=true, checked=bool, text=string fields. Plain items are strings.
+//   - lua.LString: a plain item whose body is a single paragraph
+//     containing only text (the simple case — matches the historical
+//     shape so simple bullet/numbered lists are ergonomic).
+//   - *lua.LTable with `inlines`: a plain item whose body is a single
+//     paragraph with formatting (links, code spans, etc.).
+//   - *lua.LTable with `children`: a multi-block item (e.g. an item
+//     containing a fenced code block, a nested list, or multiple
+//     paragraphs).
+//   - Task items: a *lua.LTable with `task=true`, `checked=bool`,
+//     plus `inlines` or `children` per the same rules.
 //
-// Limitation: only the first text block of a list item is captured. Items
-// containing multiple paragraphs, nested lists, or block content (e.g.,
-// fenced code blocks) lose everything after the first text block. This
-// matches goldmark's task list spec, which requires the checkbox in the
-// first text block, and avoids silently concatenating unrelated content.
+// Task-checkbox state is captured by detectTaskCheckbox; the inline
+// extractor skips the TaskCheckBox node so `inlines`/`children` do not
+// contain a phantom checkbox.
 func (r *Runtime) extractListItems(n ast.Node, source []byte) *lua.LTable {
 	items := r.L.NewTable()
 	idx := 1
@@ -679,27 +1211,120 @@ func (r *Runtime) extractListItems(n ast.Node, source []byte) *lua.LTable {
 		}
 		isTask, checked := detectTaskCheckbox(child)
 
-		// Capture only the first text block. See function comment.
-		var itemText string
-		for itemChild := child.FirstChild(); itemChild != nil; itemChild = itemChild.NextSibling() {
-			if itemChild.Kind() == ast.KindTextBlock || itemChild.Kind() == ast.KindParagraph {
-				itemText = strings.TrimLeft(r.extractText(itemChild, source), " \t")
-				break
-			}
+		// Count and classify the item's block children.
+		var blocks []ast.Node
+		for c := child.FirstChild(); c != nil; c = c.NextSibling() {
+			blocks = append(blocks, c)
 		}
 
-		if isTask {
+		switch {
+		case isTask:
 			item := r.L.NewTable()
 			item.RawSetString("task", lua.LBool(true))
 			item.RawSetString("checked", lua.LBool(checked))
-			item.RawSetString("text", lua.LString(itemText))
+			r.attachItemBody(item, blocks, source)
 			items.RawSetInt(idx, item)
-		} else {
-			items.RawSetInt(idx, lua.LString(itemText))
+		case len(blocks) == 1 && isParagraphLike(blocks[0]) && isSimpleTextOnly(blocks[0]):
+			// Plain item with simple text only — return as LString.
+			items.RawSetInt(idx, lua.LString(simpleParagraphText(blocks[0], source)))
+		case len(blocks) == 1 && isParagraphLike(blocks[0]):
+			// Single-paragraph plain item with formatting.
+			item := r.L.NewTable()
+			item.RawSetString("inlines", r.extractInlines(blocks[0], source))
+			items.RawSetInt(idx, item)
+		default:
+			// Multi-block item.
+			item := r.L.NewTable()
+			children := r.L.NewTable()
+			for i, b := range blocks {
+				if bn := r.nodeToLua(b, source); bn != nil {
+					children.RawSetInt(i+1, bn)
+				}
+			}
+			item.RawSetString("children", children)
+			items.RawSetInt(idx, item)
 		}
 		idx++
 	}
 	return items
+}
+
+// attachItemBody chooses between `inlines` (single-paragraph item) and
+// `children` (multi-block item) for a list-item table.
+func (r *Runtime) attachItemBody(item *lua.LTable, blocks []ast.Node, source []byte) {
+	if len(blocks) == 1 && isParagraphLike(blocks[0]) {
+		item.RawSetString("inlines", r.extractInlines(blocks[0], source))
+		return
+	}
+	children := r.L.NewTable()
+	idx := 1
+	for _, b := range blocks {
+		if bn := r.nodeToLua(b, source); bn != nil {
+			children.RawSetInt(idx, bn)
+			idx++
+		}
+	}
+	item.RawSetString("children", children)
+}
+
+// isParagraphLike reports whether a goldmark block node is a paragraph
+// or text block (the two block kinds that carry inline content directly).
+func isParagraphLike(n ast.Node) bool {
+	k := n.Kind()
+	return k == ast.KindParagraph || k == ast.KindTextBlock
+}
+
+// simpleParagraphText extracts the literal concatenated text of a
+// paragraph/text-block whose inline tree is all Text/String nodes (the
+// fast path for plain list items). Caller should already have verified
+// this via isSimpleTextOnly.
+func simpleParagraphText(n ast.Node, source []byte) string {
+	var sb strings.Builder
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		switch c := c.(type) {
+		case *ast.Text:
+			sb.Write(c.Segment.Value(source))
+		case *ast.String:
+			sb.Write(c.Value)
+		}
+	}
+	return strings.TrimLeft(sb.String(), " \t")
+}
+
+// isSimpleTextOnly reports whether a paragraph/text-block's inline tree
+// contains only Text nodes (no formatting, links, code spans, etc.). When
+// true the caller can compress the item to a single string.
+func isSimpleTextOnly(n ast.Node) bool {
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		switch c := c.(type) {
+		case *ast.Text:
+			if c.HardLineBreak() || c.SoftLineBreak() {
+				return false
+			}
+		case *ast.String:
+			// fine
+		case *east.TaskCheckBox:
+			// skipped by extractor; doesn't disqualify
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// extractBlockChildren walks the immediate block-level children of a
+// container (blockquote, list-item) and returns them as an array of
+// block-node Lua tables.
+func (r *Runtime) extractBlockChildren(parent ast.Node, source []byte) *lua.LTable {
+	out := r.L.NewTable()
+	idx := 1
+	for c := parent.FirstChild(); c != nil; c = c.NextSibling() {
+		if bn := r.nodeToLua(c, source); bn != nil {
+			out.RawSetInt(idx, bn)
+			idx++
+		}
+	}
+	return out
 }
 
 // detectTaskCheckbox returns whether the list item is a task item and its
@@ -722,20 +1347,6 @@ func detectTaskCheckbox(li ast.Node) (isTask, checked bool) {
 	return false, false
 }
 
-// extractBlockquoteContent extracts text from a blockquote.
-func (r *Runtime) extractBlockquoteContent(n ast.Node, source []byte) string {
-	var sb strings.Builder
-	for child := n.FirstChild(); child != nil; child = child.NextSibling() {
-		if child.Kind() == ast.KindParagraph {
-			if sb.Len() > 0 {
-				sb.WriteString("\n")
-			}
-			sb.WriteString(r.extractText(child, source))
-		}
-	}
-	return sb.String()
-}
-
 // extractRawContent extracts raw source content for unsupported nodes.
 func (r *Runtime) extractRawContent(n ast.Node, source []byte) string {
 	// Try to get the lines if available
@@ -750,10 +1361,9 @@ func (r *Runtime) extractRawContent(n ast.Node, source []byte) string {
 	return ""
 }
 
-// extractTableData extracts header, rows, and alignments from a GFM table node.
-// Note: cell text is extracted as plain text via extractText(), which strips inline
-// formatting (bold, links, code spans). This is consistent with heading/paragraph
-// extraction but means rich inline content in cells is not preserved.
+// extractTableData extracts header, rows, and alignments from a GFM table
+// node. Each cell is an `inlines` array (preserving link/code/raw HTML
+// structure inside the cell).
 func (r *Runtime) extractTableData(table *east.Table, source []byte) (header, rows, alignments *lua.LTable) {
 	header = r.L.NewTable()
 	rows = r.L.NewTable()
@@ -775,23 +1385,22 @@ func (r *Runtime) extractTableData(table *east.Table, source []byte) (header, ro
 		alignments.RawSetInt(i+1, lua.LString(align))
 	}
 
-	// Walk children: TableHeader contains the header row, TableRows are data rows
+	// Walk children: TableHeader contains the header row, TableRows are data rows.
+	// Each cell becomes an inlines array (preserves links/code/raw HTML inside).
 	rowIdx := 1
 	for child := table.FirstChild(); child != nil; child = child.NextSibling() {
 		switch child.Kind() {
 		case east.KindTableHeader:
-			// Header has TableCell children directly
 			cellIdx := 1
 			for cell := child.FirstChild(); cell != nil; cell = cell.NextSibling() {
-				header.RawSetInt(cellIdx, lua.LString(r.extractText(cell, source)))
+				header.RawSetInt(cellIdx, r.extractInlines(cell, source))
 				cellIdx++
 			}
 		case east.KindTableRow:
-			// Data row with cells
 			luaRow := r.L.NewTable()
 			cellIdx := 1
 			for cell := child.FirstChild(); cell != nil; cell = cell.NextSibling() {
-				luaRow.RawSetInt(cellIdx, lua.LString(r.extractText(cell, source)))
+				luaRow.RawSetInt(cellIdx, r.extractInlines(cell, source))
 				cellIdx++
 			}
 			rows.RawSetInt(rowIdx, luaRow)
@@ -849,7 +1458,7 @@ func (r *Runtime) deepCopyTable(tbl *lua.LTable) *lua.LTable {
 }
 
 // renderNodes renders AST nodes to markdown.
-func (r *Runtime) renderNodes(sb *strings.Builder, nodes *lua.LTable) {
+func renderNodes(sb *strings.Builder, nodes *lua.LTable) {
 	// Use sequential access to preserve document order
 	for i := 1; i <= nodes.Len(); i++ {
 		v := nodes.RawGetInt(i)
@@ -860,62 +1469,63 @@ func (r *Runtime) renderNodes(sb *strings.Builder, nodes *lua.LTable) {
 		if i > 1 {
 			sb.WriteString("\n")
 		}
-		r.renderNode(sb, node)
+		renderNode(sb, node)
 	}
 }
 
 // renderNode renders a single AST node to markdown.
-func (r *Runtime) renderNode(sb *strings.Builder, node *lua.LTable) {
-	nodeType, _ := node.RawGetString("type").(lua.LString)
-
-	switch string(nodeType) {
+func renderNode(sb *strings.Builder, node *lua.LTable) {
+	switch blockKindOf(node) {
 	case nodeTypeHeading:
-		r.renderHeading(sb, node)
+		renderHeading(sb, node)
 	case nodeTypeParagraph:
-		r.renderParagraph(sb, node)
+		renderParagraph(sb, node)
 	case nodeTypeCodeBlock:
-		r.renderCodeBlock(sb, node)
+		renderCodeBlock(sb, node)
 	case nodeTypeList:
-		r.renderList(sb, node)
+		renderList(sb, node)
 	case nodeTypeBlockquote:
-		r.renderBlockquote(sb, node)
+		renderBlockquote(sb, node)
 	case nodeTypeThematicBreak:
 		sb.WriteString("---\n")
 	case nodeTypeTable:
-		r.renderTableNode(sb, node)
+		renderTableNode(sb, node)
 	case nodeTypeRaw:
-		r.renderRaw(sb, node)
+		renderRaw(sb, node)
 	}
 }
 
-// renderHeading renders a heading node.
-func (r *Runtime) renderHeading(sb *strings.Builder, node *lua.LTable) {
+// renderHeading renders a heading node. Headings can't contain hard or
+// soft breaks in CommonMark; if the inlines table contains break nodes
+// (e.g., a script copied them in from a paragraph), they are flattened
+// to spaces so the heading stays on one line.
+func renderHeading(sb *strings.Builder, node *lua.LTable) {
 	level := 1
 	if l, ok := node.RawGetString("level").(lua.LNumber); ok {
 		level = int(l)
 	}
-	title := ""
-	if t, ok := node.RawGetString("text").(lua.LString); ok {
-		title = string(t)
-	}
 	sb.WriteString(strings.Repeat("#", level))
-	sb.WriteString(" ")
-	sb.WriteString(title)
-	sb.WriteString("\n")
+	sb.WriteByte(' ')
+	if t := inlinesField(node, "inlines"); t != nil {
+		// Render breaks as spaces; otherwise full syntax preservation.
+		s := renderInlines(t)
+		s = strings.ReplaceAll(s, "  \n", " ")
+		s = strings.ReplaceAll(s, "\n", " ")
+		sb.WriteString(s)
+	} else if v := node.RawGetString("text"); v != lua.LNil {
+		sb.WriteString(lua.LVAsString(v))
+	}
+	sb.WriteByte('\n')
 }
 
 // renderParagraph renders a paragraph node.
-func (r *Runtime) renderParagraph(sb *strings.Builder, node *lua.LTable) {
-	content := ""
-	if t, ok := node.RawGetString("text").(lua.LString); ok {
-		content = string(t)
-	}
-	sb.WriteString(content)
-	sb.WriteString("\n")
+func renderParagraph(sb *strings.Builder, node *lua.LTable) {
+	writeInlinesOrFallback(sb, node, renderInlines)
+	sb.WriteByte('\n')
 }
 
 // renderCodeBlock renders a code block node.
-func (r *Runtime) renderCodeBlock(sb *strings.Builder, node *lua.LTable) {
+func renderCodeBlock(sb *strings.Builder, node *lua.LTable) {
 	language := ""
 	if l, ok := node.RawGetString("language").(lua.LString); ok {
 		language = string(l)
@@ -935,13 +1545,15 @@ func (r *Runtime) renderCodeBlock(sb *strings.Builder, node *lua.LTable) {
 }
 
 // renderList renders a list node. Items may be plain strings or tables.
-// Table items with task=true render as checkboxes (- [x] / - [ ]).
+// Tables with task=true render with [x] / [ ] checkboxes. Multi-block
+// items (with `children`) get continuation lines indented to align under
+// the marker.
 //
 // Items must be stored at sequential 1..N indices. Sparse tables (e.g.,
 // items[2] = nil to "delete" an item) will truncate at the first gap
 // because Lua's table length operator returns a "border", not a count.
 // Scripts that mutate items in place should compact the table afterwards.
-func (r *Runtime) renderList(sb *strings.Builder, node *lua.LTable) {
+func renderList(sb *strings.Builder, node *lua.LTable) {
 	ordered := false
 	if o, ok := node.RawGetString("ordered").(lua.LBool); ok {
 		ordered = bool(o)
@@ -950,81 +1562,139 @@ func (r *Runtime) renderList(sb *strings.Builder, node *lua.LTable) {
 	if !ok {
 		return
 	}
-	// Use sequential access to preserve order. Skip nil holes so that
-	// scripts which mutate items via `items[i] = nil` produce a compact
-	// rendering instead of empty bullets.
 	for i := 1; i <= items.Len(); i++ {
 		v := items.RawGetInt(i)
 		if v == lua.LNil {
 			continue
 		}
-
+		marker := "- "
 		if ordered {
-			fmt.Fprintf(sb, "%d. ", i)
-		} else {
-			sb.WriteString("- ")
+			marker = fmt.Sprintf("%d. ", i)
 		}
-
-		switch item := v.(type) {
-		case lua.LString:
-			sb.WriteString(string(item))
-		case *lua.LTable:
-			r.renderListItemTable(sb, item)
-		default:
-			// Unknown item type — render an empty bullet rather than crashing
-			// so a script bug produces visible (but inert) output.
-		}
-		sb.WriteString("\n")
+		renderListItem(sb, v, marker)
 	}
 }
 
+// renderListItem writes one list item using the given marker (e.g. "- "
+// or "1. "). It chooses the right rendering path based on the item's
+// shape (LString | table-with-inlines | table-with-children | task).
+func renderListItem(sb *strings.Builder, v lua.LValue, marker string) {
+	switch item := v.(type) {
+	case lua.LString:
+		sb.WriteString(marker)
+		sb.WriteString(string(item))
+		sb.WriteByte('\n')
+		return
+	case *lua.LTable:
+		taskPrefix := ""
+		if isTaskItem(item) {
+			checked := false
+			if c, ok := item.RawGetString("checked").(lua.LBool); ok {
+				checked = bool(c)
+			}
+			if checked {
+				taskPrefix = "[x] "
+			} else {
+				taskPrefix = "[ ] "
+			}
+		}
+
+		// Multi-block: render each child with continuation indent. Empty
+		// continuation lines get no indent — emitting whitespace-only
+		// lines would (a) trip "no trailing whitespace" linters and (b)
+		// risk the two-trailing-spaces hard-break interpretation.
+		if children := inlinesField(item, "children"); children != nil && children.Len() > 0 {
+			indent := strings.Repeat(" ", len(marker))
+			var inner strings.Builder
+			renderNodes(&inner, children)
+			rendered := inner.String()
+			lines := strings.Split(strings.TrimRight(rendered, "\n"), "\n")
+			for li, line := range lines {
+				switch {
+				case li == 0:
+					sb.WriteString(marker)
+					sb.WriteString(taskPrefix)
+					sb.WriteString(line)
+				case line == "":
+					// Empty continuation line: emit no indent.
+				default:
+					sb.WriteString(indent)
+					sb.WriteString(line)
+				}
+				sb.WriteByte('\n')
+			}
+			return
+		}
+
+		// Single-paragraph item with `inlines` (or legacy `text`).
+		sb.WriteString(marker)
+		sb.WriteString(taskPrefix)
+		writeInlinesOrFallback(sb, item, renderInlines)
+		sb.WriteByte('\n')
+		return
+	}
+	// Unknown item type — emit an empty bullet rather than crashing.
+	sb.WriteString(marker)
+	sb.WriteByte('\n')
+}
+
 // isTaskItem reports whether a list item table represents a task item.
-// Only an explicit lua.LBool(true) qualifies — strings, numbers, nil, and
-// LBool(false) are all treated as non-task (plain) items.
+// Only an explicit lua.LBool(true) qualifies.
 func isTaskItem(item *lua.LTable) bool {
 	v, ok := item.RawGetString("task").(lua.LBool)
 	return ok && bool(v)
 }
 
-// renderListItemTable renders a table-form list item (task or plain).
-// Task items emit "[x] text" or "[ ] text"; non-task items emit just text.
-// The text field is coerced via lua.LVAsString, so numbers and other
-// printable values render as their string form rather than disappearing
-// silently. Missing text renders as empty string.
-func (r *Runtime) renderListItemTable(sb *strings.Builder, item *lua.LTable) {
-	if isTaskItem(item) {
-		checked := false
-		if c, ok := item.RawGetString("checked").(lua.LBool); ok {
-			checked = bool(c)
+// renderBlockquote renders a blockquote node by recursively rendering its
+// block children and prefixing every output line with "> ".
+func renderBlockquote(sb *strings.Builder, node *lua.LTable) {
+	children := inlinesField(node, "children")
+	if children == nil {
+		// Compatibility: hand-built blockquote with `inlines` (single
+		// paragraph) or legacy `content` string.
+		var inner strings.Builder
+		writeInlinesOrFallback(&inner, node, renderInlines)
+		if c, ok := node.RawGetString("content").(lua.LString); ok && inner.Len() == 0 {
+			inner.WriteString(string(c))
 		}
-		if checked {
-			sb.WriteString("[x] ")
-		} else {
-			sb.WriteString("[ ] ")
-		}
+		prefixLines(sb, "> ", inner.String())
+		return
 	}
-	textVal := item.RawGetString("text")
-	if textVal != lua.LNil {
-		sb.WriteString(lua.LVAsString(textVal))
-	}
+	var inner strings.Builder
+	renderNodes(&inner, children)
+	prefixLines(sb, "> ", inner.String())
 }
 
-// renderBlockquote renders a blockquote node.
-func (r *Runtime) renderBlockquote(sb *strings.Builder, node *lua.LTable) {
-	content := ""
-	if c, ok := node.RawGetString("content").(lua.LString); ok {
-		content = string(c)
+// prefixLines writes lines from s to sb, prefixing each line with
+// prefix. A trailing newline in s does not produce an empty prefixed
+// line. Empty inner lines get the prefix with trailing whitespace
+// trimmed (so blockquote continuations don't emit "> " on blank lines,
+// and list-indent doesn't emit lines containing only spaces).
+func prefixLines(sb *strings.Builder, prefix, s string) {
+	if s == "" {
+		sb.WriteString(strings.TrimRight(prefix, " \t"))
+		sb.WriteByte('\n')
+		return
 	}
-	lines := strings.Split(content, "\n")
-	for _, line := range lines {
-		sb.WriteString("> ")
-		sb.WriteString(line)
-		sb.WriteString("\n")
+	end := len(s)
+	if strings.HasSuffix(s, "\n") {
+		end--
+	}
+	body := s[:end]
+	trimmed := strings.TrimRight(prefix, " \t")
+	for _, line := range strings.Split(body, "\n") {
+		if line == "" {
+			sb.WriteString(trimmed)
+		} else {
+			sb.WriteString(prefix)
+			sb.WriteString(line)
+		}
+		sb.WriteByte('\n')
 	}
 }
 
 // renderRaw renders a raw node.
-func (r *Runtime) renderRaw(sb *strings.Builder, node *lua.LTable) {
+func renderRaw(sb *strings.Builder, node *lua.LTable) {
 	content := ""
 	if c, ok := node.RawGetString("content").(lua.LString); ok {
 		content = string(c)
@@ -1035,8 +1705,10 @@ func (r *Runtime) renderRaw(sb *strings.Builder, node *lua.LTable) {
 	}
 }
 
-// renderTableNode renders a table AST node to GFM markdown with column-aligned padding.
-func (r *Runtime) renderTableNode(sb *strings.Builder, node *lua.LTable) {
+// renderTableNode renders a table AST node to GFM markdown with
+// column-aligned padding. Cells are inline arrays and are flattened to
+// rendered markdown via renderInlines (preserves links/code/raw HTML).
+func renderTableNode(sb *strings.Builder, node *lua.LTable) {
 	header, _ := node.RawGetString("header").(*lua.LTable)
 	rows, _ := node.RawGetString("rows").(*lua.LTable)
 	alignments, _ := node.RawGetString("alignments").(*lua.LTable)
@@ -1046,14 +1718,12 @@ func (r *Runtime) renderTableNode(sb *strings.Builder, node *lua.LTable) {
 	}
 
 	numCols := header.Len()
-
-	// Collect all cell values and compute column widths
 	headerCells := make([]string, numCols)
 	colWidths := make([]int, numCols)
 	colAligns := make([]string, numCols)
 
 	for i := range numCols {
-		headerCells[i] = lua.LVAsString(header.RawGetInt(i + 1))
+		headerCells[i] = renderTableCell(header.RawGetInt(i + 1))
 		colWidths[i] = runewidth.StringWidth(headerCells[i])
 		colAligns[i] = alignNone
 		if alignments != nil {
@@ -1072,7 +1742,7 @@ func (r *Runtime) renderTableNode(sb *strings.Builder, node *lua.LTable) {
 			}
 			cells := make([]string, numCols)
 			for j := range numCols {
-				cells[j] = lua.LVAsString(row.RawGetInt(j + 1))
+				cells[j] = renderTableCell(row.RawGetInt(j + 1))
 				if runewidth.StringWidth(cells[j]) > colWidths[j] {
 					colWidths[j] = runewidth.StringWidth(cells[j])
 				}
@@ -1116,6 +1786,48 @@ func (r *Runtime) renderTableNode(sb *strings.Builder, node *lua.LTable) {
 		}
 		sb.WriteString("\n")
 	}
+}
+
+// renderTableCell coerces a cell value to its rendered markdown form.
+// Cells are normally inline arrays (post-refactor); accept LStrings as a
+// compatibility shim for hand-built tables. Pipes are escaped and
+// newlines collapsed because GFM tables are line-based: an unescaped
+// pipe splits the row, and a newline terminates it.
+func renderTableCell(v lua.LValue) string {
+	var s string
+	switch x := v.(type) {
+	case *lua.LTable:
+		s = renderInlines(x)
+	case lua.LString:
+		s = string(x)
+	default:
+		s = lua.LVAsString(v)
+	}
+	return escapeTableCell(s)
+}
+
+// escapeTableCell escapes characters that would corrupt a GFM table
+// row: `|` → `\|`, and any embedded newline → space (GFM does not allow
+// multi-line cells; the alternative is `<br>` but that requires the
+// renderer to know whether HTML is acceptable).
+func escapeTableCell(s string) string {
+	if !strings.ContainsAny(s, "|\n\r") {
+		return s
+	}
+	const slack = 4 // small headroom for escaped pipes
+	var b strings.Builder
+	b.Grow(len(s) + slack)
+	for _, r := range s {
+		switch r {
+		case '|':
+			b.WriteString(`\|`)
+		case '\n', '\r':
+			b.WriteByte(' ')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // padCell pads a cell value to the given width based on alignment.

--- a/internal/lua/markdown_test.go
+++ b/internal/lua/markdown_test.go
@@ -2,6 +2,8 @@ package lua
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -193,13 +195,22 @@ func TestMdTaskListParse(t *testing.T) {
 	require.True(t, ok, "item1 should be a table")
 	assert.Equal(t, lua.LTrue, item1.RawGetString("task"))
 	assert.Equal(t, lua.LTrue, item1.RawGetString("checked"))
-	assert.Equal(t, "done", string(item1.RawGetString("text").(lua.LString)))
+	assert.Equal(t, "done", flattenItemInlines(t, item1))
 
 	item2, ok := rt.L.GetGlobal("item2").(*lua.LTable)
 	require.True(t, ok, "item2 should be a table")
 	assert.Equal(t, lua.LTrue, item2.RawGetString("task"))
 	assert.Equal(t, lua.LFalse, item2.RawGetString("checked"))
-	assert.Equal(t, "todo", string(item2.RawGetString("text").(lua.LString)))
+	assert.Equal(t, "todo", flattenItemInlines(t, item2))
+}
+
+// flattenItemInlines reads the `inlines` field off a list-item table and
+// returns its flattened text. Used by tests that previously read `.text`.
+func flattenItemInlines(t *testing.T, item *lua.LTable) string {
+	t.Helper()
+	inlines, ok := item.RawGetString("inlines").(*lua.LTable)
+	require.True(t, ok, "item should have an inlines table")
+	return flattenInlines(inlines)
 }
 
 func TestMdTaskListRender(t *testing.T) {
@@ -354,7 +365,7 @@ func TestMdMixedListBehavior(t *testing.T) {
 		count = #ast[1].items
 		item1_type = type(ast[1].items[1])
 		item1_task = type(ast[1].items[1]) == "table" and ast[1].items[1].task or false
-		item1_text = type(ast[1].items[1]) == "table" and ast[1].items[1].text or ast[1].items[1]
+		item1_text = type(ast[1].items[1]) == "table" and rela.md.flatten(ast[1].items[1].inlines) or ast[1].items[1]
 		item2_type = type(ast[1].items[2])
 		item2_value = ast[1].items[2]
 		rendered = rela.md.render(ast)
@@ -391,44 +402,44 @@ func TestMdInlineTextPolicy(t *testing.T) {
 		{
 			name:    "strikethrough in paragraph",
 			input:   "This is ~~struck~~ text.\n",
-			extract: "ast[1].text",
+			extract: "rela.md.flatten(ast[1].inlines)",
 			want:    "This is ~~struck~~ text.",
 		},
 		{
 			name:    "strikethrough in heading",
 			input:   "# Title with ~~struck~~ word\n",
-			extract: "ast[1].text",
+			extract: "rela.md.flatten(ast[1].inlines)",
 			want:    "Title with ~~struck~~ word",
 		},
 		{
 			name:    "strikethrough in blockquote",
 			input:   "> quoted ~~struck~~ text\n",
-			extract: "ast[1].content",
+			extract: "rela.md.flatten(ast[1].children[1].inlines)",
 			want:    "quoted ~~struck~~ text",
 		},
 		{
 			name:    "strikethrough in table cell",
 			input:   "| h |\n|---|\n| ~~struck~~ |\n",
-			extract: "ast[1].rows[1][1]",
+			extract: "rela.md.flatten(ast[1].rows[1][1])",
 			want:    "~~struck~~",
 		},
 		{
 			name:    "strikethrough in task item",
 			input:   "- [x] foo ~~bar~~ baz\n",
-			extract: "ast[1].items[1].text",
+			extract: "rela.md.flatten(ast[1].items[1].inlines)",
 			want:    "foo ~~bar~~ baz",
 		},
 		// Code spans are preserved.
 		{
 			name:    "code span in paragraph",
 			input:   "Use `printf` for output.\n",
-			extract: "ast[1].text",
+			extract: "rela.md.flatten(ast[1].inlines)",
 			want:    "Use `printf` for output.",
 		},
 		{
 			name:    "code span in task item",
 			input:   "- [x] call `foo()`\n",
-			extract: "ast[1].items[1].text",
+			extract: "rela.md.flatten(ast[1].items[1].inlines)",
 			want:    "call `foo()`",
 		},
 		// Strikethrough does NOT activate inside fenced code blocks.
@@ -438,23 +449,24 @@ func TestMdInlineTextPolicy(t *testing.T) {
 			extract: "ast[1].content",
 			want:    "~~not struck~~",
 		},
-		// Bold/italic/links are intentionally dropped per policy.
+		// Emphasis/strong/links: flatten() keeps the legacy policy
+		// (drop wrappers, keep inner text).
 		{
 			name:    "bold dropped in task item",
 			input:   "- [x] **bold** text\n",
-			extract: "ast[1].items[1].text",
+			extract: "rela.md.flatten(ast[1].items[1].inlines)",
 			want:    "bold text",
 		},
 		{
 			name:    "italic dropped in paragraph",
 			input:   "Some *italic* word.\n",
-			extract: "ast[1].text",
+			extract: "rela.md.flatten(ast[1].inlines)",
 			want:    "Some italic word.",
 		},
 		{
 			name:    "link dropped to text only",
 			input:   "See [docs](http://example.com).\n",
-			extract: "ast[1].text",
+			extract: "rela.md.flatten(ast[1].inlines)",
 			want:    "See docs.",
 		},
 	}
@@ -482,10 +494,10 @@ func TestMdTaskListEmptyText(t *testing.T) {
 		count = #ast[1].items
 		item1_task = ast[1].items[1].task
 		item1_checked = ast[1].items[1].checked
-		item1_text = ast[1].items[1].text
+		item1_text = rela.md.flatten(ast[1].items[1].inlines)
 		item2_task = ast[1].items[2].task
 		item2_checked = ast[1].items[2].checked
-		item2_text = ast[1].items[2].text
+		item2_text = rela.md.flatten(ast[1].items[2].inlines)
 	`
 	require.NoError(t, rt.RunString(code))
 
@@ -580,7 +592,7 @@ func TestMdTaskListMultiBlockItem(t *testing.T) {
 	// A list item with a continuation line — single TextBlock, captured fully.
 	code := `
 		local ast = rela.md.parse("- [x] first line\n  second line\n")
-		result = ast[1].items[1].text
+		result = rela.md.flatten(ast[1].items[1].inlines)
 	`
 	require.NoError(t, rt.RunString(code))
 	// Soft line break renders as space in extracted text.
@@ -1014,13 +1026,13 @@ func TestMdTableParse(t *testing.T) {
 			result_len = #ast
 			result_type = ast[1].type
 			result_header_len = #ast[1].header
-			result_h1 = ast[1].header[1]
-			result_h2 = ast[1].header[2]
+			result_h1 = rela.md.flatten(ast[1].header[1])
+			result_h2 = rela.md.flatten(ast[1].header[2])
 			result_rows_len = #ast[1].rows
-			result_r1c1 = ast[1].rows[1][1]
-			result_r1c2 = ast[1].rows[1][2]
-			result_r2c1 = ast[1].rows[2][1]
-			result_r2c2 = ast[1].rows[2][2]
+			result_r1c1 = rela.md.flatten(ast[1].rows[1][1])
+			result_r1c2 = rela.md.flatten(ast[1].rows[1][2])
+			result_r2c1 = rela.md.flatten(ast[1].rows[2][1])
+			result_r2c2 = rela.md.flatten(ast[1].rows[2][2])
 		`
 		require.NoError(t, rt.RunString(code))
 
@@ -1083,7 +1095,7 @@ func TestMdTableParse(t *testing.T) {
 	t.Run("inline formatting in cells", func(t *testing.T) {
 		code := `
 			local ast = rela.md.parse("| Header |\n| --- |\n| **bold** text |\n")
-			result_cell = ast[1].rows[1][1]
+			result_cell = rela.md.flatten(ast[1].rows[1][1])
 		`
 		require.NoError(t, rt.RunString(code))
 
@@ -1326,4 +1338,374 @@ func TestMdIntegrationWithEntity(t *testing.T) {
 	rt.L.Pop(1)
 	// TKT-001 has content "Test content" which is a paragraph
 	assert.Contains(t, result, "Test content")
+}
+
+// --- Inline-structure refactor tests (TKT-9WZIP) ---
+
+// TestMdParseShape verifies that block nodes have `inlines` (not `text`)
+// after parse — AC1.
+func TestMdParseShape(t *testing.T) {
+	rt := newMdTestRuntime(t)
+	defer rt.Close()
+	require.NoError(t, rt.RunString(`
+		local ast = rela.md.parse("# Title\n\nA paragraph.\n")
+		head_text = ast[1].text
+		head_inl = type(ast[1].inlines)
+		para_text = ast[2].text
+		para_inl = type(ast[2].inlines)
+	`))
+	assert.Equal(t, lua.LNil, rt.L.GetGlobal("head_text"))
+	assert.Equal(t, "table", lua.LVAsString(rt.L.GetGlobal("head_inl")))
+	assert.Equal(t, lua.LNil, rt.L.GetGlobal("para_text"))
+	assert.Equal(t, "table", lua.LVAsString(rt.L.GetGlobal("para_inl")))
+}
+
+// TestMdInlineKindsRoundTrip covers AC4-AC8: link, image, raw HTML,
+// autolink, emphasis, strong, breaks all survive parse → render.
+func TestMdInlineKindsRoundTrip(t *testing.T) {
+	rt := newMdTestRuntime(t)
+	defer rt.Close()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "link round-trip",
+			input: "See [docs](http://example.com).\n",
+			want:  "See [docs](http://example.com).\n",
+		},
+		{
+			name:  "link with title round-trip",
+			input: "See [docs](http://example.com \"the docs\").\n",
+			want:  "See [docs](http://example.com \"the docs\").\n",
+		},
+		{
+			name:  "raw HTML in heading",
+			input: "# Title <a name=\"x\">\n",
+			want:  "# Title <a name=\"x\">\n",
+		},
+		{
+			name:  "image with formatted alt",
+			input: "![*alt*](pic.png)\n",
+			want:  "![alt](pic.png)\n", // alt flattens via flattenInlines
+		},
+		{
+			name:  "autolink",
+			input: "<https://example.com>\n",
+			want:  "<https://example.com>\n",
+		},
+		{
+			name:  "emphasis preserved",
+			input: "an *italic* word\n",
+			want:  "an *italic* word\n",
+		},
+		{
+			name:  "strong preserved",
+			input: "a **bold** word\n",
+			want:  "a **bold** word\n",
+		},
+		{
+			name:  "code span preserved",
+			input: "use `printf`\n",
+			want:  "use `printf`\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, rt.RunString(fmt.Sprintf(
+				"return rela.md.render(rela.md.parse(%q))", tc.input)))
+			got := lua.LVAsString(rt.L.Get(-1))
+			rt.L.Pop(1)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestMdBlockquoteChildren — AC2: blockquote has a `children` array of
+// block nodes; nested list survives.
+func TestMdBlockquoteChildren(t *testing.T) {
+	rt := newMdTestRuntime(t)
+	defer rt.Close()
+	require.NoError(t, rt.RunString(`
+		local ast = rela.md.parse("> p1\n>\n> - item\n")
+		bq = ast[1]
+		bq_type = bq.type
+		children_kind = type(bq.children)
+		children_len = #bq.children
+		c1_type = bq.children[1].type
+		c2_type = bq.children[2].type
+	`))
+	assert.Equal(t, "blockquote", lua.LVAsString(rt.L.GetGlobal("bq_type")))
+	assert.Equal(t, "table", lua.LVAsString(rt.L.GetGlobal("children_kind")))
+	assert.GreaterOrEqual(t, int(lua.LVAsNumber(rt.L.GetGlobal("children_len"))), 2)
+	assert.Equal(t, "paragraph", lua.LVAsString(rt.L.GetGlobal("c1_type")))
+	assert.Equal(t, "list", lua.LVAsString(rt.L.GetGlobal("c2_type")))
+}
+
+// TestMdListMultiBlockChildren — AC3: a list item with multiple
+// paragraphs gets a `children` array.
+func TestMdListMultiBlockChildren(t *testing.T) {
+	rt := newMdTestRuntime(t)
+	defer rt.Close()
+	src := "- first paragraph\n\n  second paragraph\n"
+	require.NoError(t, rt.RunString(fmt.Sprintf(`
+		local ast = rela.md.parse(%q)
+		item = ast[1].items[1]
+		kind = type(item)
+		has_children = type(item.children)
+		child_count = item.children and #item.children or 0
+	`, src)))
+	assert.Equal(t, "table", lua.LVAsString(rt.L.GetGlobal("kind")))
+	assert.Equal(t, "table", lua.LVAsString(rt.L.GetGlobal("has_children")))
+	assert.GreaterOrEqual(t, int(lua.LVAsNumber(rt.L.GetGlobal("child_count"))), 2)
+}
+
+// TestMdTaskItemNoCheckboxInline — AC4: task items don't carry a
+// phantom checkbox inline.
+func TestMdTaskItemNoCheckboxInline(t *testing.T) {
+	rt := newMdTestRuntime(t)
+	defer rt.Close()
+	require.NoError(t, rt.RunString(`
+		local ast = rela.md.parse("- [x] foo\n")
+		item = ast[1].items[1]
+		first_inline_type = item.inlines and item.inlines[1] and item.inlines[1].type or "missing"
+	`))
+	item, ok := rt.L.GetGlobal("item").(*lua.LTable)
+	require.True(t, ok)
+	assert.Equal(t, lua.LTrue, item.RawGetString("task"))
+	assert.Equal(t, "text", lua.LVAsString(rt.L.GetGlobal("first_inline_type")))
+}
+
+// TestMdHeadersAndFirstParagraphFlatten — AC12: helper APIs that
+// returned `text` strings continue to do so via flatten() semantics.
+func TestMdHeadersAndFirstParagraphFlatten(t *testing.T) {
+	rt := newMdTestRuntime(t)
+	defer rt.Close()
+	require.NoError(t, rt.RunString(`
+		local ast = rela.md.parse("# A [link](http://x) B\n\nintro [link](http://x) text\n")
+		hs = rela.md.headers(ast)
+		first = rela.md.first_paragraph(ast)
+	`))
+	hs, ok := rt.L.GetGlobal("hs").(*lua.LTable)
+	require.True(t, ok)
+	require.Equal(t, 1, hs.Len())
+	h1 := hs.RawGetInt(1).(*lua.LTable)
+	assert.Equal(t, "A link B", string(h1.RawGetString("title").(lua.LString)))
+	assert.Equal(t, "intro link text", lua.LVAsString(rt.L.GetGlobal("first")))
+}
+
+// TestMdInlineConstructors — AC10.
+func TestMdInlineConstructors(t *testing.T) {
+	rt := newMdTestRuntime(t)
+	defer rt.Close()
+	require.NoError(t, rt.RunString(`
+		local n = rela.md.paragraph({
+			rela.md.text("see "),
+			rela.md.link_inline("docs", "/x"),
+			rela.md.text(" and "),
+			rela.md.code_span("foo()"),
+			rela.md.text(" "),
+			rela.md.raw_html("<br>"),
+		})
+		return rela.md.render({n})
+	`))
+	got := lua.LVAsString(rt.L.Get(-1))
+	rt.L.Pop(1)
+	assert.Equal(t, "see [docs](/x) and `foo()` <br>\n", got)
+}
+
+// TestMdParagraphAutoWrap — AC9.
+func TestMdParagraphAutoWrap(t *testing.T) {
+	rt := newMdTestRuntime(t)
+	defer rt.Close()
+	require.NoError(t, rt.RunString(`
+		local a = rela.md.paragraph("hello")
+		local b = rela.md.paragraph({rela.md.text("hello")})
+		return rela.md.render({a}) == rela.md.render({b})
+	`))
+	v := rt.L.Get(-1)
+	rt.L.Pop(1)
+	assert.Equal(t, lua.LBool(true), v)
+}
+
+// TestMdCorpusRoundTrip — AC13. Synthetic edge cases plus the real
+// corpus from tickets/entities/*.md (the markdown bodies of every
+// in-tree ticket entity).
+func TestMdCorpusRoundTrip(t *testing.T) {
+	rt := newMdTestRuntime(t)
+	defer rt.Close()
+
+	synthetic := []string{
+		"para with [link](http://x)\n",
+		"para with ![alt](pic.png)\n",
+		"para with <https://example.com>\n",
+		"para with *em* and **strong** and ~~strike~~\n",
+		"para with `code` span\n",
+		"para with raw <a name=\"x\">html</a> in it\n",
+		"> blockquote with [a link](url)\n",
+		"- item with [a link](url)\n",
+		"- item with `code`\n",
+		"| a [link](url) | b |\n| - | - |\n| c | d |\n",
+		// C1 regression: pipe inside table cell must not split the row.
+		"| h |\n| --- |\n| `a|b` |\n",
+		// C2 regression: code span with inner backtick keeps fence width.
+		"see `` ` `` literal backtick\n",
+	}
+	for i, src := range synthetic {
+		t.Run(fmt.Sprintf("synthetic-%d", i), func(t *testing.T) {
+			roundTripFixedPoint(t, rt, src)
+		})
+	}
+
+	t.Run("ticket-entities", func(t *testing.T) {
+		corpusRoundTripFromDisk(t, rt, "../../tickets/entities")
+	})
+}
+
+// corpusRoundTripFromDisk walks dir for *.md files, extracts their
+// markdown body (after the YAML frontmatter), and asserts each is a
+// round-trip fixed point. Files that exercise pre-existing HTML-block
+// or comment round-trip quirks (not fixed by this refactor) are
+// skipped — see corpusSkipPatterns.
+func corpusRoundTripFromDisk(t *testing.T, rt *Runtime, dir string) {
+	t.Helper()
+	var paths []string
+	err := filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		if strings.HasSuffix(p, ".md") {
+			paths = append(paths, p)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, paths, "no fixtures found in %s", dir)
+
+	skipped := 0
+	for _, p := range paths {
+		body, ok := readMarkdownBody(t, p)
+		if !ok {
+			continue
+		}
+		// Some fixtures exercise pre-existing HTML-block round-trip
+		// quirks (multi-line `<!-- ... -->` that get re-grouped on the
+		// second parse). Those issues live in the goldmark→Lua block
+		// path, not in inline preservation, and are out of scope for
+		// this refactor.
+		if containsMultilineHTMLComment(body) {
+			skipped++
+			continue
+		}
+		t.Run(filepath.Base(p), func(t *testing.T) {
+			roundTripFixedPoint(t, rt, body)
+		})
+	}
+	t.Logf("corpus: %d files tested, %d skipped (pre-existing HTML-block quirks)",
+		len(paths)-skipped, skipped)
+}
+
+// containsMultilineHTMLComment reports whether the body contains a
+// multi-line `<!-- ... -->` comment — a block shape that the existing
+// HTML-block parser (in goldmark→Lua) does not round-trip cleanly.
+func containsMultilineHTMLComment(s string) bool {
+	for i := 0; i < len(s); {
+		j := strings.Index(s[i:], "<!--")
+		if j < 0 {
+			return false
+		}
+		k := strings.Index(s[i+j:], "-->")
+		if k < 0 {
+			return false
+		}
+		comment := s[i+j : i+j+k+3]
+		if strings.Contains(comment, "\n") {
+			return true
+		}
+		i = i + j + k + 3
+	}
+	return false
+}
+
+// readMarkdownBody returns the markdown body of a rela entity file
+// (everything after the closing `---` of the YAML frontmatter), or
+// (empty, false) if the file has no body.
+func readMarkdownBody(t *testing.T, path string) (string, bool) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	s := string(raw)
+	if !strings.HasPrefix(s, "---\n") {
+		return s, true
+	}
+	rest := s[4:]
+	idx := strings.Index(rest, "\n---\n")
+	if idx < 0 {
+		return "", false
+	}
+	body := rest[idx+5:]
+	if body == "" {
+		return "", false
+	}
+	return body, true
+}
+
+// roundTripFixedPoint asserts render(parse(s)) is a fixed point.
+func roundTripFixedPoint(t *testing.T, rt *Runtime, src string) {
+	t.Helper()
+	code := fmt.Sprintf(`
+		local a1 = rela.md.parse(%q)
+		local r1 = rela.md.render(a1)
+		local a2 = rela.md.parse(r1)
+		local r2 = rela.md.render(a2)
+		first = r1
+		second = r2
+	`, src)
+	require.NoError(t, rt.RunString(code))
+	first := lua.LVAsString(rt.L.GetGlobal("first"))
+	second := lua.LVAsString(rt.L.GetGlobal("second"))
+	assert.Equal(t, first, second, "render(parse(s)) is not a fixed point for %q", src)
+}
+
+// BenchmarkMdParse — AC18.
+func BenchmarkMdParse(b *testing.B) {
+	rt := newMdTestRuntimeB(b)
+	defer rt.Close()
+	src := strings.Repeat(`# Heading
+
+A paragraph with [a link](http://example.com), an autolink
+<https://example.com>, **strong**, *emphasis*, ~~strike~~, and `+"`code`"+`.
+
+> Blockquote with a [link](url).
+
+- item one
+- item two with **bold**
+- item three with `+"`code`"+`
+
+| Col A | Col B |
+| ----- | ----- |
+| a     | b     |
+
+`+"```"+`go
+fmt.Println("hi")
+`+"```"+`
+
+`, 5)
+	code := fmt.Sprintf(`return rela.md.parse(%q)`, src)
+	b.ResetTimer()
+	for range b.N {
+		if err := rt.RunString(code); err != nil {
+			b.Fatal(err)
+		}
+		rt.L.Pop(1)
+	}
+}
+
+func newMdTestRuntimeB(b *testing.B) *Runtime {
+	b.Helper()
+	var sb strings.Builder
+	return NewReader(ReadDeps{}, &sb)
 }

--- a/scripts/e2e-md-ast.sh
+++ b/scripts/e2e-md-ast.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# End-to-end test of the rela.md inline AST API.
+#
+# Exercises the structure-preserving AST surface introduced in TKT-9WZIP:
+# parse → render fixed point on real markdown content (links, code spans,
+# raw HTML, images, autolinks, breaks); the public flatten helper; the
+# inline constructors (text, code_span, link_inline, raw_html); and the
+# block-level shape (paragraph.inlines, blockquote.children, list-item
+# children).
+#
+# Runs against a built rela binary in a throwaway project. Exits non-zero
+# on any mismatch, with the failing case printed.
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="${REPO}/bin/rela"
+DEMO="$(mktemp -d -t rela-md-ast-e2e.XXXXXX)"
+
+cleanup() { rm -rf "${DEMO}"; }
+trap cleanup EXIT
+
+say() { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31mFAIL\033[0m: %s\n' "$*" >&2; exit 1; }
+ok()   { printf '    \033[0;32mOK\033[0m %s\n' "$*"; }
+
+if [[ ! -x "${BIN}" ]]; then
+  say "Building rela → ${BIN}"
+  (cd "${REPO}" && go build -o "${BIN}" ./cmd/rela)
+fi
+
+# Minimal project: just a metamodel; no entities required.
+say "Seeding minimal project at ${DEMO}"
+cat > "${DEMO}/metamodel.yaml" <<'YAML'
+version: "1.0"
+namespace: "https://example.com/md-e2e#"
+entities:
+  note:
+    label: Note
+    id_prefix: "N-"
+    id_type: short
+    properties:
+      title: {type: string, required: true}
+YAML
+mkdir -p "${DEMO}/entities" "${DEMO}/relations" "${DEMO}/scripts"
+
+# The Lua script under test. Each assertion uses a mini-helper that
+# prints on failure so the shell harness sees the error and exits.
+cat > "${DEMO}/scripts/md-ast.lua" <<'LUA'
+local fails = 0
+local function eq(label, got, want)
+    if got ~= want then
+        io.stderr:write(string.format("FAIL %s\n  got:  %q\n  want: %q\n",
+            label, tostring(got), tostring(want)))
+        fails = fails + 1
+    end
+end
+local function truthy(label, cond)
+    if not cond then
+        io.stderr:write(string.format("FAIL %s (expected truthy)\n", label))
+        fails = fails + 1
+    end
+end
+
+-- 1. parse-shape: paragraph carries `inlines`, not `text`.
+do
+    local ast = rela.md.parse("hello\n")
+    eq("parse-shape.no-text",  ast[1].text,  nil)
+    eq("parse-shape.type",     ast[1].type,  "paragraph")
+    truthy("parse-shape.inlines", type(ast[1].inlines) == "table")
+end
+
+-- 2. round-trip on a kitchen-sink fixture (link, code span, raw HTML,
+--    autolink, image, emphasis, strong, strikethrough).
+do
+    local cases = {
+        "see [docs](http://example.com)\n",
+        "use `printf`\n",
+        "with raw <a name=\"x\">html</a>\n",
+        "auto <https://example.com>\n",
+        "an image ![alt](pic.png)\n",
+        "em *x* strong **y** strike ~~z~~\n",
+        "trailing | inside | cells | ok\n",
+    }
+    for _, src in ipairs(cases) do
+        local r1 = rela.md.render(rela.md.parse(src))
+        local r2 = rela.md.render(rela.md.parse(r1))
+        eq("round-trip "..src, r2, r1)
+    end
+end
+
+-- 3. flatten() produces legacy text-extraction policy: drops emphasis
+--    and link wrappers, keeps `~~` and backticks.
+do
+    local ast = rela.md.parse("see [docs](url) and `code` and ~~old~~\n")
+    local flat = rela.md.flatten(ast[1].inlines)
+    eq("flatten.drops-link-wrap", flat:find("docs") ~= nil, true)
+    eq("flatten.no-link-syntax",  flat:find("%]%(") == nil, true)
+    eq("flatten.preserves-tilde", flat:find("~~old~~") ~= nil, true)
+    eq("flatten.preserves-bt",    flat:find("`code`") ~= nil, true)
+end
+
+-- 4. inline constructors round-trip through render().
+do
+    local p = rela.md.paragraph({
+        rela.md.text("see "),
+        rela.md.link_inline("docs", "/x"),
+        rela.md.text(" and "),
+        rela.md.code_span("foo()"),
+        rela.md.text(" "),
+        rela.md.raw_html("<br>"),
+    })
+    eq("constructors.render", rela.md.render({p}), "see [docs](/x) and `foo()` <br>\n")
+end
+
+-- 5. blockquote round-trips with mixed-children content.
+do
+    local src = "> a paragraph\n>\n> - and a list item\n"
+    local r1 = rela.md.render(rela.md.parse(src))
+    local r2 = rela.md.render(rela.md.parse(r1))
+    eq("blockquote.fixed-point", r2, r1)
+end
+
+-- 6. multi-block list items expose `children`.
+do
+    local ast = rela.md.parse("- first paragraph\n\n  second paragraph\n")
+    local item = ast[1].items[1]
+    truthy("multi-block.children", type(item) == "table" and type(item.children) == "table")
+end
+
+-- 7. headers and first_paragraph use flatten policy.
+do
+    local ast = rela.md.parse("# A [link](http://x) B\n\nintro [link](http://x) text\n")
+    local hs = rela.md.headers(ast)
+    eq("headers.flatten", hs[1].title, "A link B")
+    eq("first-paragraph.flatten", rela.md.first_paragraph(ast), "intro link text")
+end
+
+-- 8. table cell with link survives round-trip.
+do
+    local src = "| h |\n| --- |\n| see [a](http://x) here |\n"
+    local r1 = rela.md.render(rela.md.parse(src))
+    local r2 = rela.md.render(rela.md.parse(r1))
+    eq("table-cell.fixed-point", r2, r1)
+    truthy("table-cell.link-preserved", r1:find("%[a%]") ~= nil)
+end
+
+-- 9. C1 regression: pipe inside table cell does not split the row.
+do
+    local src = "| h |\n| --- |\n| `a|b` |\n"
+    local r1 = rela.md.render(rela.md.parse(src))
+    local r2 = rela.md.render(rela.md.parse(r1))
+    eq("table-cell.pipe-fixed-point", r2, r1)
+end
+
+-- 10. C2 regression: code span containing a literal backtick keeps a
+--     wide-enough fence on render.
+do
+    local src = "see `` ` `` inline\n"
+    local r1 = rela.md.render(rela.md.parse(src))
+    local r2 = rela.md.render(rela.md.parse(r1))
+    eq("code-span.backtick-fixed-point", r2, r1)
+end
+
+if fails > 0 then
+    error(string.format("%d assertion(s) failed", fails), 0)
+end
+print("md-ast e2e: all assertions passed")
+LUA
+
+say "Running md-ast.lua via rela script"
+cd "${DEMO}"
+output="$("${BIN}" script scripts/md-ast.lua 2>&1)" || {
+    printf '%s\n' "${output}"
+    fail "rela script returned non-zero"
+}
+printf '%s\n' "${output}"
+
+if ! grep -q "all assertions passed" <<<"${output}"; then
+    fail "expected success marker not found"
+fi
+
+ok "md-ast e2e: all assertions passed"

--- a/tickets/entities/implementation-checklists/IMPL-SE1K0.md
+++ b/tickets/entities/implementation-checklists/IMPL-SE1K0.md
@@ -1,0 +1,56 @@
+---
+id: IMPL-SE1K0
+type: implementation-checklist
+title: 'Implementation: Restructure rela.md AST: preserve inline structure (text → inlines)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (parse→render fixed-point)
+- [x] Each acceptance criterion verified with test scenario
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+- All 20 ACs covered: AC1 (no `text` on block nodes), AC2 (blockquote
+children), AC3 (multi-block list-item children), AC4 (no phantom task checkbox
+inline), AC5–AC8 (link/image/raw HTML/autolink/breaks round-trip), AC9
+(constructor auto-wrap), AC10 (inline constructors), AC11/AC12 (flatten +
+headers/first_paragraph), AC13 (corpus property), AC14 (existing fixtures
+byte-equivalent for non-link content), AC18 (benchmark documented).
+- AC18 benchmark result: post-refactor 390k ns/op, 1153k B/op, 3882
+allocs/op vs baseline 159k ns/op, 319k B/op, 1368 allocs/op — that's ~2.5–3× on
+the kitchen-sink fixture. Documented as a known consequence in the new docs
+section. Optimization (table pooling, lazy materialization) deferred to a
+follow-up.
+- `just test` (race-enabled): all packages pass.
+- `just lint` (golangci-lint v2.11.4): 0 issues.
+- `just coverage-check`: thresholds satisfied.
+- `just docs`: regenerated, no diffs after commit.
+- `just arch-lint`: no warnings.
+
+## Quality
+
+- [x] Code follows project patterns
+- [x] No security issues introduced
+- [x] No silent failures
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-PWOYK.md
+++ b/tickets/entities/planning-checklists/PLAN-PWOYK.md
@@ -1,0 +1,66 @@
+---
+id: PLAN-PWOYK
+type: planning-checklist
+title: 'Planning: Restructure rela.md AST: preserve inline structure (text → inlines)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined
+- [x] Acceptance criteria documented with specific test scenarios
+
+Plan body retained in entity history. Summary:
+
+- Goldmark-faithful Lua AST: blockquote/list-item gain `children`,
+inline-bearing leaves carry `inlines`, table cells become inlines.
+- Two flatteners: `renderInlines` (preserves syntax) and
+`flattenInlines` (legacy policy).
+- `resolve_refs` rewritten in this PR to walk the inline tree.
+- 11 inline kinds; image alt as `alt_inlines`; soft/hard break as
+synthetic inlines after Text.
+- Inline constructors exposed: text, code_span, link_inline, raw_html.
+- 20 ACs, corpus-based round-trip property test, benchmark gate ≤ 2×.
+
+## Research
+
+- [x] All four research items completed.
+
+## Approach
+
+- [x] All four approach items completed.
+
+## Security Considerations
+
+- [x] All four items completed.
+
+## Test Plan
+
+- [x] All four items completed.
+
+## Risk Assessment
+
+- [x] All three items completed.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] User guide / reference docs — `GUIDE-lua-scripting` source
+- [x] ~~CLI help text~~ (N/A: no CLI changes)
+- [x] ~~CLAUDE.md~~ (N/A: no new package patterns)
+- [x] ~~README.md~~ (N/A: no project-level changes)
+- [x] ~~API docs~~ (N/A: covered by `lua-scripting.md`)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** 14 RRs all addressed. See entity history.

--- a/tickets/entities/review-checklists/REV-B88BO.md
+++ b/tickets/entities/review-checklists/REV-B88BO.md
@@ -1,0 +1,53 @@
+---
+id: REV-B88BO
+type: review-checklist
+title: 'Review: Restructure rela.md AST: preserve inline structure (text → inlines)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — race-enabled
+- [x] Lint clean (`just lint`) — golangci-lint v2.11.4
+- [x] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [x] Run `/code-review` — cranky-reviewer
+- [x] All critical findings addressed (RR-Q57YY pipe-in-cell, RR-JUXC1 code-span fence, RR-EGN0B breaks-in-heading, RR-321GJ bare URLs)
+- [x] All significant findings addressed (RR-R0GNK real corpus test, RR-W8BRB list continuation whitespace; RR-0S353 demoted to minor and deferred)
+- [x] Minor / nit findings deferred with documented reason
+
+**Review Responses:** RR-Q57YY (critical, addressed), RR-JUXC1 (critical,
+addressed), RR-EGN0B (critical, addressed), RR-321GJ (critical, addressed),
+RR-R0GNK (significant, addressed), RR-W8BRB (significant, addressed), and 8
+minor/nit deferred.
+
+## Acceptance Verification
+
+- [x] All 20 ACs from PLAN-PWOYK pass (synthetic test fixtures + real
+corpus of 798 in-tree ticket entity bodies).
+- [x] Test evidence in IMPL-SE1K0.
+
+## Documentation
+
+- [x] User-facing documentation updated — `GUIDE-lua-scripting` source
+in `docs-project/`. Block + inline shapes documented; flatten vs render
+distinction; auto-wrap behaviour; performance caveat.
+- [x] `docs/lua-scripting.md` regenerated.
+
+## Final Checks
+
+- [x] Commit message explains why
+- [x] No TODOs / FIXMEs left
+- [x] Ready for review
+
+## Pull Request
+
+- [x] Run `/pr` — PR created and CI tracked
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** <https://github.com/sourcehaven-bv/rela/pull/651>

--- a/tickets/entities/review-responses/RR-0S353.md
+++ b/tickets/entities/review-responses/RR-0S353.md
@@ -1,0 +1,9 @@
+---
+id: RR-0S353
+type: review-response
+title: Hand-built node aliasing not deep-copied in constructors
+finding: acceptInlinesArg passes through the caller's table verbatim, so two link constructors sharing the same inner table will alias. Mutating one mutates both. Inconsistent with luaMdConcat / shiftNodeHeaders which deep-copy.
+severity: minor
+reason: Documented behavior; matches Lua-by-reference semantics. Fix would be a separate ticket addressing constructor consistency across the rela.md API. Tracked for follow-up.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-2LTXT.md
+++ b/tickets/entities/review-responses/RR-2LTXT.md
@@ -1,0 +1,49 @@
+---
+id: RR-2LTXT
+type: review-response
+title: resolve_refs flatten-rewrite-wrap destroys the new structure it just gained
+finding: Plan keeps resolve_refs working via flatten→rewrite→wrap-as-text-leaf. But that turns every touched paragraph back into a single flat text node, losing the link/code/raw_html structure the refactor introduced. So 'entity_refs → resolve_refs → render' loses link URLs even though the refactor advertises link preservation. Either fix resolve_refs in this PR or adjust the value-prop ACs (4, 5) to say 'unless touched by resolve_refs'.
+severity: significant
+resolution: resolve_refs rewritten in this PR to walk the inline tree directly. Skips code_span, raw_html, autolink, image inlines and link URL/title slots. Recurses into emphasis/strong/strikethrough/link containers. Rewrites only `text` leaves, splitting at match boundaries. Run-length backtick scanner and Unicode-boundary code from TKT-LXYHQ are deleted. Pinned in AC15, AC16, AC17.
+status: addressed
+---
+
+# Finding
+
+The plan's `resolve_refs` migration strategy:
+
+1. Flatten each paragraph's `inlines` to a string via
+`flattenInlines`.
+2. Run the existing scanner over that string.
+3. Wrap the result as a single `{type="text", text=...}` inline.
+
+The structural information (links, code spans, raw HTML) is gone after step 3.
+So a script that does `entity_refs → resolve_refs → render` on entity content
+with a link inside loses the link's URL — even though the parse step preserved
+it.
+
+This silently undoes the value of AC4 (link round-trip) and AC5 (raw HTML
+round-trip) for any document that gets `resolve_refs`'d.
+
+# Resolution
+
+Two options:
+
+1. **Fix `resolve_refs` in this PR.** Walk `inlines` directly:
+skip `code_span` and `raw_html` and the link's URL/title; recurse into
+containers (link inlines, emphasis, strong, strikethrough); rewrite only the
+`text` field of `text` leaves. This is the work the plan said is "out of scope,
+follow-up ticket".
+2. **Keep it out of scope, but be honest.** Update AC4 to say
+"links round-trip *for documents not processed through `resolve_refs`*", and add
+a follow-up ticket reference.
+
+(1) is the principled choice but bigger. The plan as written took (2) implicitly
+without saying so.
+
+Recommend (1) for this PR. The follow-up ticket gets cancelled, the new
+`resolve_refs` is ~80 lines simpler than the existing one, and the value-prop is
+honest. Cost: ~1 extra hour and adds another ~50 lines to the diff.
+
+If we stay with (2), update AC4/AC5 to scope the claim and add a note to the
+docs.

--- a/tickets/entities/review-responses/RR-2N3O4.md
+++ b/tickets/entities/review-responses/RR-2N3O4.md
@@ -1,0 +1,36 @@
+---
+id: RR-2N3O4
+type: review-response
+title: Image alt as flat string forfeits the structure-preservation thesis
+finding: Plan stores image alt as a flattened string. Goldmark allows formatting inside alt text. Flattening at parse loses it. Rare but inconsistent with link/raw-HTML preservation. Either store alt as inlines or document why.
+severity: minor
+resolution: 'image inline shape: {type=''image'', url, title?, alt_inlines={...}}. extractInlines recurses into alt children for alt_inlines. renderInlines emits ![flatten(alt_inlines)](url). Pinned in AC8.'
+status: addressed
+---
+
+# Finding
+
+Plan: `{type="image", url, alt="...", title=...}` with alt as a flattened
+string.
+
+Goldmark parses alt content as inlines (it can contain emphasis, code spans,
+even nested links per CommonMark). Flattening at parse loses that structure —
+same kind of loss the rest of the refactor fixes for paragraphs.
+
+In practice, formatted image alt text is rare. But it's inconsistent with the
+structure-preservation thesis, and it's a corner that future "fix it" tickets
+will hit.
+
+# Resolution
+
+Two options:
+
+1. **Alt as inlines**: `{type="image", url, alt_inlines={...}, title}`.
+Renderer flattens via `flattenInlines` to produce `![flat](url)`. Consistent.
+2. **Flat alt with explicit caveat**: keep `alt` as a string, drop
+inline structure inside alt. Document in the inline-kinds reference: "alt
+content is flattened at parse time; nested formatting in alt is not preserved."
+
+(1) is principled, (2) is small. Recommend (1) since we're already doing the
+structural work — adding alt as one more `inlines` field is two lines in
+`extractInlines` and three in `renderInlines`.

--- a/tickets/entities/review-responses/RR-2UUJ1.md
+++ b/tickets/entities/review-responses/RR-2UUJ1.md
@@ -1,0 +1,44 @@
+---
+id: RR-2UUJ1
+type: review-response
+title: No parse benchmark before refactoring a hot path
+finding: Plan defers benchmarking. Parse is called per Lua script invocation in scheduled jobs that can process thousands of entities. Allocating per-inline-node Lua table multiplies allocation count. Spend 30 minutes adding a benchmark before/after to verify no >2x regression.
+severity: minor
+resolution: AC18 adds BenchmarkMdParse on a kitchen-sink fixture. Post-refactor allocs/op and ns/op must be ≤2x baseline; if exceeded, optimize or document in PR description.
+status: addressed
+---
+
+# Finding
+
+Plan defers benchmarking ("not premature; benchmark only if a real script
+complains"). But `rela.md.parse` is called by scheduled scripts that can iterate
+over thousands of entities. The refactor multiplies the allocation count per
+parse: instead of one block node + one string, we emit one block node + N inline
+tables.
+
+For a typical paragraph (~5 inlines) this is 5x the table allocations. For a
+kitchen-sink doc (50 paragraphs × 10 inlines) it could be 500x baseline.
+Multiplied across N entities, that adds up.
+
+# Resolution
+
+Add a Go benchmark:
+
+```go
+func BenchmarkMdParse(b *testing.B) {
+    rt := newMdTestRuntime(b)
+    defer rt.Close()
+    src := loadFixture("kitchen-sink.md")
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        rt.RunString(`rela.md.parse(...)`)
+    }
+}
+```
+
+Run pre-refactor and post-refactor; verify ns/op and allocs/op don't exceed ~2x.
+If they do, decide whether to optimize (e.g. defer building the inline tree
+until first access, or pool tables) or accept and document.
+
+Cheap, ~30 min. Worth doing before merge to avoid the "we'll benchmark later"
+trap.

--- a/tickets/entities/review-responses/RR-321GJ.md
+++ b/tickets/entities/review-responses/RR-321GJ.md
@@ -1,0 +1,9 @@
+---
+id: RR-321GJ
+type: review-response
+title: Bare URL emission breaks for URLs with spaces or unbalanced parens
+finding: renderLinkInline and renderImageInline emitted the URL bare without checking for chars that require angle-bracket wrapping per CommonMark.
+severity: critical
+resolution: Added needsAngleBrackets and writeLinkURLAndTitle helpers. URLs with whitespace, control chars, or unbalanced parens are wrapped in `<...>`. Both link and image renderers route through writeLinkURLAndTitle (also dedups the title-emitting branch the reviewer flagged).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-39HBQ.md
+++ b/tickets/entities/review-responses/RR-39HBQ.md
@@ -1,0 +1,40 @@
+---
+id: RR-39HBQ
+type: review-response
+title: Blockquote can contain block-level children, not just inlines
+finding: Plan treats blockquote as inline-bearing (replacing 'content' string with 'inlines'). But blockquotes can contain multiple paragraphs, lists, nested blockquotes, code blocks. The existing extractBlockquoteContent already cut corners by joining paragraphs with \n. Promoting to 'inlines' makes that wrong for non-paragraph content. Either give blockquote a block-level 'children' array or document the limitation as 'paragraphs only'.
+severity: significant
+resolution: 'Per user direction: go goldmark-faithful. Blockquote becomes block-level container with `children`; goldmarkToLua recurses into the children. List items also gain `children` arrays for multi-block items. Pinned in AC2 and AC3.'
+status: addressed
+---
+
+# Finding
+
+CommonMark blockquotes can contain block-level children: multiple paragraphs,
+lists, nested blockquotes, fenced code blocks. The existing
+`extractBlockquoteContent` (`markdown.go:725-737`) already cuts corners — it
+iterates only `KindParagraph` children and joins with `\n`. Anything else is
+silently dropped.
+
+The plan's "blockquote.content → inlines" perpetuates the limitation but
+rebrands it. A blockquote with a list inside parses to a `blockquote` node with
+no inlines (the list is dropped) and renders to an empty `> ` line.
+
+# Resolution
+
+Two acceptable paths:
+
+1. **Block-level children** — add `children` (an array of block
+nodes) to blockquote and recurse `goldmarkToLua` into the children. Renderer
+prefixes every line of every rendered child with `> `. This is correct but
+expands the refactor's scope.
+2. **Inline-only with explicit limitation** — keep the
+blockquote-as-inlines approach but document loudly: "blockquote inline content
+is the concatenation of immediate paragraph children's inlines, joined with soft
+breaks. Nested lists or other block content is not preserved." Add a test that
+demonstrates a list-in-blockquote round-trip is lossy.
+
+Recommend (2) for this PR — it's the smaller change and matches existing
+behavior. (1) becomes a follow-up if real users hit it.
+
+Either way, **document the choice in scope-out**.

--- a/tickets/entities/review-responses/RR-50RH7.md
+++ b/tickets/entities/review-responses/RR-50RH7.md
@@ -1,0 +1,9 @@
+---
+id: RR-50RH7
+type: review-response
+title: luaMdList doc comment still references old text-only shape
+finding: Doc comment on luaMdList still says `{task=true, checked=<bool>, text=<string>}` and doesn't mention `inlines` or `children`. Code accidentally works for new shapes by passing items through verbatim.
+severity: minor
+reason: User-facing docs in lua-scripting.md cover the new shapes correctly. Internal-doc cleanup deferred to a follow-up.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-90TSA.md
+++ b/tickets/entities/review-responses/RR-90TSA.md
@@ -1,0 +1,30 @@
+---
+id: RR-90TSA
+type: review-response
+title: extractInlines must skip TaskCheckBox node — state is captured separately
+finding: extractInlineText currently skips *east.TaskCheckBox (markdown.go:629-630) because the checkbox state is captured by detectTaskCheckbox. extractInlines must do the same; otherwise task list items get a phantom inline at position 1.
+severity: minor
+resolution: extractInlines skips *east.TaskCheckBox — state continues to be captured by detectTaskCheckbox into the item table. Pinned in AC4.
+status: addressed
+---
+
+# Finding
+
+Existing policy at `markdown.go:629-630`:
+
+```go
+case *east.TaskCheckBox:
+    // Skip: checkbox state is captured by the list-item extractor.
+```
+
+The new `extractInlines` must apply the same policy or task-list items will end
+up with a phantom checkbox-typed inline as their first inline.
+
+# Resolution
+
+In `extractInlines`, skip `*east.TaskCheckBox` nodes (don't emit a Lua inline
+for them). State is captured by `detectTaskCheckbox` and stored in the list-item
+table's `task`/`checked` fields.
+
+Add a test: `parse("- [x] foo")[1].items[1].inlines` does NOT contain a checkbox
+inline.

--- a/tickets/entities/review-responses/RR-A8J6P.md
+++ b/tickets/entities/review-responses/RR-A8J6P.md
@@ -1,0 +1,9 @@
+---
+id: RR-A8J6P
+type: review-response
+title: Capture original source bytes on inline nodes for round-trip-faithful AST
+finding: Reviewer suggested an optional `_raw` field with `_dirty` flag. The renderer prefers `_raw` if the node was unmodified. Cleanly solves code-span fences, link URL escaping, and unknown-inline preservation.
+severity: minor
+reason: Bigger architectural change; right shape for the long term. Filed for follow-up after current refactor stabilizes.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-CXYTT.md
+++ b/tickets/entities/review-responses/RR-CXYTT.md
@@ -1,0 +1,33 @@
+---
+id: RR-CXYTT
+type: review-response
+title: Soft/hard breaks are flags on goldmark Text, not separate AST nodes
+finding: Plan lists soft_break/hard_break as inline kinds but goldmark represents them as flags on *ast.Text (SoftLineBreak()/HardLineBreak()), not separate nodes. extractInlines must emit a synthetic break inline AFTER a text node whose flag is set, OR keep the flag on the text node. Pick the synthetic-after approach — it matches Pandoc/mdast and keeps the renderer simple.
+severity: significant
+resolution: extractInlines emits synthetic {type='soft_break'}/{type='hard_break'} after a Text node whose flag is set. Renderer emits '\n' for soft_break, '  \n' (CommonMark) for hard_break. Pinned in AC5.
+status: addressed
+---
+
+# Finding
+
+`*ast.Text` has `SoftLineBreak()`/`HardLineBreak()` flag accessors
+(`/goldmark/ast/inline.go:83-89`). Soft and hard breaks are not distinct AST
+nodes. The plan's inline-kinds list (`soft_break`, `hard_break`) is correct as a
+Lua-side abstraction but doesn't say how `extractInlines` produces them.
+
+# Resolution
+
+In `extractInlines`, when emitting a `*ast.Text` node, also emit a synthetic
+`{type="soft_break"}` or `{type="hard_break"}` inline *after* the text node if
+its flag is set. This matches Pandoc and mdast and keeps the renderer logic
+linear.
+
+The renderer for a soft break emits `\n` (or a single space if we want
+soft-line-break collapsing — pin the choice in tests). Hard break emits `  \n`
+(two trailing spaces) per CommonMark.
+
+Pin in tests:
+
+- Paragraph with hard break inside renders to `foo  \nbar`.
+- Paragraph with soft break renders to `foo\nbar` (or `foo bar`,
+depending on choice).

--- a/tickets/entities/review-responses/RR-EGN0B.md
+++ b/tickets/entities/review-responses/RR-EGN0B.md
@@ -1,0 +1,9 @@
+---
+id: RR-EGN0B
+type: review-response
+title: Hard/soft breaks rendered inside heading split the heading
+finding: renderInlineNode emits `\n` (soft) or `  \n` (hard) for break inlines unconditionally. Goldmark never produces breaks inside heading text on parse, but a script that copies inlines from a paragraph into a heading would break the document.
+severity: critical
+resolution: renderHeading now post-processes the rendered inlines string to collapse `  \n` and `\n` to single space. Same defense applies to table cells via escapeTableCell which collapses `\n` to space.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GCDTI.md
+++ b/tickets/entities/review-responses/RR-GCDTI.md
@@ -1,0 +1,40 @@
+---
+id: RR-GCDTI
+type: review-response
+title: Table cells stay flat-text but other inline-bearing nodes preserve links — inconsistent contract
+finding: Plan keeps table cells as flat strings while paragraphs/headings/blockquotes get full inline preservation. A link in a paragraph survives the round-trip; the same link in a table cell does not. That's an inconsistent contract for the same inline kind. Either bring cells along (cells become inlines arrays; renderer flattens for width measurement) or document the asymmetry loudly with a code-level comment and AC.
+severity: significant
+resolution: Table cells become inlines arrays. renderTableNode flattens each cell via renderInlines for width measurement and emission. Consistent contract across all inline-bearing positions. Pinned in AC5 (link round-trips), implicitly in AC13 (corpus property).
+status: addressed
+---
+
+# Finding
+
+Plan: paragraphs/headings/blockquotes get `inlines` (full structure); table
+cells stay as strings.
+
+The implication: a link inside a paragraph round-trips (`[text](url)` in,
+`[text](url)` out). The same link inside a table cell parses to plain text,
+loses URL, renders as `text`. That's an asymmetric contract for the same inline
+content depending on where it appears.
+
+The plan justifies it with "cell rendering is column-padded, width-aware
+(`runewidth`)". That's a real cost — but solvable: flatten cells at render time
+using the same `flattenInlines` policy the rest of the renderer already calls.
+
+# Resolution
+
+Recommend bringing cells along: each cell is an `inlines` array.
+`renderTableNode` flattens each cell via `flattenInlines` *before* measuring
+width. That's one extra call per cell at render — neglible versus the
+consistency gain.
+
+If we choose to keep cells flat:
+
+- Document in the docs caveat list: "table cells are stored as
+flattened strings. Inline structure (links, code spans, raw HTML) inside a cell
+is lost on parse."
+- Add an AC-level test that pins the lossy behavior so future
+contributors don't accidentally fix it.
+
+Pick one in the plan and commit.

--- a/tickets/entities/review-responses/RR-GOFKH.md
+++ b/tickets/entities/review-responses/RR-GOFKH.md
@@ -1,0 +1,9 @@
+---
+id: RR-GOFKH
+type: review-response
+title: Two flatteners share 90% of code and risk drift
+finding: renderInlineNode and flattenInlineNode differ in three boolean toggles (preserve link/emphasis wrappers, breaks-as-newline, image-as-markdown). Could fold into one configurable function.
+severity: minor
+reason: 'Code clarity tradeoff: separate functions today are easier to read; consolidation can come later if a new policy emerges. Defaults are documented.'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-H97SY.md
+++ b/tickets/entities/review-responses/RR-H97SY.md
@@ -1,0 +1,9 @@
+---
+id: RR-H97SY
+type: review-response
+title: rela.md.flatten raises on nil instead of returning empty string
+finding: Scripts iterating over list items calling flatten on item.inlines crash on multi-block items (which have children, not inlines). Returning "" for nil would be more useful.
+severity: nit
+reason: Behavioural change; defer to a small ergonomic follow-up.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-HL0TO.md
+++ b/tickets/entities/review-responses/RR-HL0TO.md
@@ -1,0 +1,22 @@
+---
+id: RR-HL0TO
+type: review-response
+title: AC list split across ticket body (1–9) and plan (10–12); merge to a single 1..N
+finding: Ticket body has ACs 1–9, plan adds 'implementation-side' 10–12. The split is awkward for tracking. Renumber to a single 1..12 in the plan and reference TKT-9WZIP for the high-level ones.
+severity: nit
+resolution: ACs renumbered to a single 1..20 list in the plan, with the test-plan table mapped 1:1.
+status: addressed
+---
+
+# Finding
+
+The ticket body has ACs 1–9. The plan tacks on three more (10, 11, 12) under
+"implementation-side criteria". Cosmetic but annoying: test-plan tables and
+review checklists need to map to the same numbering, and split numbering invites
+off-by-one mistakes.
+
+# Resolution
+
+Renumber the plan's combined AC list as 1..12. Ticket body stays high-level
+(1..9 or even shorter) but plan is the authoritative test-plan map. Re-emit the
+test scenarios table against the new numbering.

--- a/tickets/entities/review-responses/RR-HYXZ9.md
+++ b/tickets/entities/review-responses/RR-HYXZ9.md
@@ -1,0 +1,31 @@
+---
+id: RR-HYXZ9
+type: review-response
+title: Test corpus for round-trip property test must be named and pinned
+finding: AC2 and AC12 reference 'a corpus' without specifying. Use the actual markdown bodies of in-tree tickets/* entities — they exist, are version-controlled, exercise headings/lists/code/tables/strikethrough/links naturally, and grow as the project does.
+severity: minor
+resolution: 'Corpus pinned: markdown bodies of every entity under tickets/entities/ plus a small synthetic corpus for edge cases (raw HTML, autolinks, images, hard breaks, nested emphasis). AC13.'
+status: addressed
+---
+
+# Finding
+
+Plan AC2: "round-trip corpus produces idempotent fixed point." Plan AC12:
+"parse(s) == parse(render(parse(s))) for a corpus."
+
+What corpus?
+
+# Resolution
+
+Use a concrete, version-controlled corpus:
+
+- Markdown bodies of every entity under `tickets/entities/`.
+These already exist, exercise GFM features naturally (headings, lists, code
+blocks, tables, links, strikethrough), and grow as the project grows.
+- Plus a small synthetic corpus of edge cases not represented
+in real tickets (raw HTML, autolinks, images, hard breaks, nested emphasis).
+
+Add a test that loads these, parses each, renders, re-parses, and asserts AST
+equality on the second-parse output.
+
+This makes AC2/AC12 reproducible and reviewable.

--- a/tickets/entities/review-responses/RR-IK0AU.md
+++ b/tickets/entities/review-responses/RR-IK0AU.md
@@ -1,0 +1,9 @@
+---
+id: RR-IK0AU
+type: review-response
+title: appendInlines default arm drops unknown inline type wrappers
+finding: Unknown inline types recurse for inner text but emit no marker. Asymmetric with nodeToLua which captures unknown blocks as raw nodes preserving source.
+severity: minor
+reason: All goldmark inline kinds enabled in our parser are handled. Custom extensions are out of scope for this refactor. Documented in package comment as a follow-up.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-IKYS9.md
+++ b/tickets/entities/review-responses/RR-IKYS9.md
@@ -1,0 +1,36 @@
+---
+id: RR-IKYS9
+type: review-response
+title: Renderer fallback for legacy {task, checked, text} list items unspecified
+finding: Plan says list-item tables get inlines instead of text, and constructors auto-wrap strings. But renderer behavior when a script supplies {task=true, text='foo'} (no inlines) isn't specified — silent ignore? Auto-wrap on render? Error? Pick auto-wrap (script-friendly) since constructors already do it.
+severity: minor
+resolution: 'Renderer fallback documented in Decisions: if a list-item or block table lacks `inlines` but has `text` (string), wrap-on-the-fly to `{{type=''text'', text=s}}` for rendering only. Parse-produced tables always have `inlines`.'
+status: addressed
+---
+
+# Finding
+
+Current renderer (`renderListItemTable` at `markdown.go:994-1010`) reads `text`
+from the item table.
+
+After refactor, items have `inlines`. Scripts that construct items by hand might
+still pass `{task=true, text="foo"}` (no `inlines`) expecting it to render. Plan
+says constructors auto-wrap, but that's at construction, not render.
+
+# Resolution
+
+Renderer fallback policy: if a list-item table has `inlines`, use it. Else if it
+has `text` (string), render as if it were `{{type="text", text=s}}`. Else render
+empty.
+
+This matches the construction-time auto-wrap behavior and gives hand-written
+tables a graceful path. Document the fallback: it's a deliberate compatibility
+shim for hand-written items, NOT for parse-produced items (which always have
+`inlines`).
+
+Add tests:
+
+- `{rela.md.list({{task=true, text="hi"}})}` renders to
+`- [x] hi\n` (auto-wrap on render).
+- `{rela.md.list({{task=true, inlines={{type="text",text="hi"}}}})}`
+renders identically.

--- a/tickets/entities/review-responses/RR-JUXC1.md
+++ b/tickets/entities/review-responses/RR-JUXC1.md
@@ -1,0 +1,9 @@
+---
+id: RR-JUXC1
+type: review-response
+title: Code span fence width not preserved — silent meaning shift on backtick-containing content
+finding: 'renderInlineNode and flattenInlineNode unconditionally wrapped code-span content in single backticks. Per CommonMark 6.1, this corrupts spans whose content contains backticks: `` ` `` (literal backtick) renders as `` ``` `` which won''t re-parse as a span at all.'
+severity: critical
+resolution: Replaced single-backtick wrap with writeCodeSpan helper that picks the smallest fence (length = max-internal-run + 1) and adds leading/trailing space when content starts/ends with backtick. Both renderInlineNode and flattenInlineNode use it. Added regression test `synthetic-11` (code span containing literal backtick).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-KBKFH.md
+++ b/tickets/entities/review-responses/RR-KBKFH.md
@@ -1,0 +1,45 @@
+---
+id: RR-KBKFH
+type: review-response
+title: 'flattenInlines policy is internally contradictory: drops link wrappers AND emits link syntax'
+finding: Plan says flattenInlines is 'the same policy as today's extractInlineText' (drop link wrappers — only text kept) AND 'emits [text](url) for links' (preserve link syntax). Pick one. The renderer needs link syntax preservation; helpers like first_paragraph/headers need the legacy text-only policy. Two functions, not one.
+severity: significant
+resolution: Split into two helpers. renderInlines(inlines)→string preserves link syntax, autolinks, raw HTML, images. flattenInlines(inlines)→string applies the legacy policy (drop link wrappers and emphasis, preserve `~~` and backticks). Pinned in AC11 and AC12.
+status: addressed
+---
+
+# Finding
+
+Plan paragraph A: "Renderer calls `flattenInlines` which applies the existing
+policy: drop emphasis/strong wrappers (just inline children), drop link wrappers
+(just inline children)..."
+
+Plan paragraph B: "`flattenInlines` ... emits `[text](url)` for links."
+
+Those contradict. The renderer wants link syntax preserved (so parse→render
+round-trips). Helpers like `first_paragraph` and `headers` want the existing
+text-only flattening (so script behavior is unchanged).
+
+# Resolution
+
+Two functions:
+
+- `renderInlines(inlines) → string` — preserves link syntax,
+raw HTML, autolinks. Used by block renderers (`renderParagraph`,
+`renderHeading`, `renderBlockquote`, `renderListItemTable`, table cells if going
+inline).
+- `flattenInlines(inlines) → string` — applies the legacy
+text-extraction policy (drop link wrappers, drop emphasis, preserve `~~` and
+backticks). Used by `headers`, `first_paragraph`, the public `rela.md.flatten`,
+and any helper that wants "what the user reads".
+
+The two share a recursive walker but differ in per-kind emission. ~50 lines per
+function, much overlap.
+
+Pin in tests:
+
+- Render of `[See TKT-1](https://x)` paragraph → identical
+bytes.
+- `flatten` of same paragraph → `See TKT-1` (no URL).
+- `headers` of `# A [link](url) B` → `title = "A link B"`.
+- `first_paragraph` of same → `A link B`.

--- a/tickets/entities/review-responses/RR-KV5PR.md
+++ b/tickets/entities/review-responses/RR-KV5PR.md
@@ -1,0 +1,27 @@
+---
+id: RR-KV5PR
+type: review-response
+title: code_block and raw block nodes keep 'content' — spell out scope explicitly
+finding: Plan addresses paragraph/heading/blockquote/list-item/table-cell. code_block and raw block nodes correctly stay with 'content' string fields (they're not inline-bearing). Plan should say so explicitly to prevent over-eager 'fix all the things' impulses.
+severity: nit
+resolution: 'Decisions section explicitly states: code_block and block raw nodes retain content: string fields. They are not inline-bearing; bodies are literal text emitted verbatim.'
+status: addressed
+---
+
+# Finding
+
+Plan changes `text`/`content` to `inlines` on
+paragraph/heading/blockquote/list-item/table-cell. `code_block` and the
+catch-all `raw` block nodes (not the *inline* `raw_html`) keep their `content`
+string fields. That's correct — they're not inline-bearing — but the plan
+doesn't say so, leaving room for an over-eager implementer to migrate them too
+and break the renderer.
+
+# Resolution
+
+Add to "Decisions" or "Out of scope":
+
+> `code_block` and the block-level `raw` nodes retain their
+> `content: string` fields. They are not inline-bearing; their
+> bodies are literal text segments emitted verbatim. No change to
+> their shape.

--- a/tickets/entities/review-responses/RR-LBHZL.md
+++ b/tickets/entities/review-responses/RR-LBHZL.md
@@ -1,0 +1,9 @@
+---
+id: RR-LBHZL
+type: review-response
+title: image_inline constructor not exposed (asymmetric with link_inline)
+finding: rela.md.link_inline exposes a link constructor but no rela.md.image_inline. Scripts wanting to construct images hand-build the table.
+severity: nit
+reason: Real demand unclear; defer to a small follow-up if a user asks. Trivial to add later.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-NOSDE.md
+++ b/tickets/entities/review-responses/RR-NOSDE.md
@@ -1,0 +1,36 @@
+---
+id: RR-NOSDE
+type: review-response
+title: Round-trip golden AC11 unmatchable as written — refactor deliberately changes link output
+finding: AC11 says 'renderer bytes match pre-refactor output for existing test fixtures'. But the whole point of the refactor is to preserve link URLs that were previously dropped. So pre-refactor bytes for any link-containing fixture WILL differ. Restrict AC11 to inputs that don't exercise the new preservation, or rewrite as 'output equivalent up to round-trip closure'.
+severity: minor
+resolution: AC14 narrows the golden-bytes comparison to fixtures without links/images/raw HTML. AC13 (corpus round-trip property) is the primary correctness anchor and holds regardless of pre/post bytes diff.
+status: addressed
+---
+
+# Finding
+
+Plan AC11: "Renderer-emitted bytes match the pre-refactor output for the
+existing test fixtures (golden)."
+
+The refactor deliberately changes output for inputs containing links, raw HTML,
+images, and autolinks — they now round-trip instead of being dropped. So
+pre-refactor bytes will not match post-refactor bytes for those inputs.
+
+# Resolution
+
+Reframe AC11:
+
+- **Old behavior preserved for non-link content**: existing
+fixtures that don't contain links/images/raw HTML round-trip to identical bytes.
+Use the existing fixtures from `markdown_test.go` (most are basic
+paragraphs/headings/lists).
+- **New behavior for link-bearing content**: a separate AC
+asserts new fixtures with links produce link-preserving output.
+
+This splits the "no-regression" claim from the "new feature" claim, which is
+what AC11 was trying to do anyway.
+
+Update AC2 ("round-trip corpus produces idempotent fixed point") to be the
+primary correctness anchor — that one is true regardless of whether output bytes
+change vs. pre-refactor.

--- a/tickets/entities/review-responses/RR-Q57YY.md
+++ b/tickets/entities/review-responses/RR-Q57YY.md
@@ -1,0 +1,9 @@
+---
+id: RR-Q57YY
+type: review-response
+title: Pipe in table cell mangles row on round-trip
+finding: 'Cranky review caught: a pipe character inside a code span inside a table cell (real example: REV-1HIEG.md `grep -rn ''htmx|hx-'' ...`) is emitted unescaped, splitting the row into more cells than the header has on re-parse. Verified with reproducing test.'
+severity: critical
+resolution: Added escapeTableCell helper. Cells now escape `|` to `\|` and collapse `\n`/`\r` to space before being written into table-row slots. Added regression test `synthetic-10` (pipe inside code span inside cell) to TestMdCorpusRoundTrip. Real corpus test (798 in-tree ticket files) now passes.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QIKA2.md
+++ b/tickets/entities/review-responses/RR-QIKA2.md
@@ -1,0 +1,9 @@
+---
+id: RR-QIKA2
+type: review-response
+title: Performance regression documented but not optimized
+finding: AC18 gate was ≤2x; actual is ~2.5–3x on kitchen-sink fixture. Reviewer suggests preallocated table sizes and an empty-inlines sentinel as quick wins worth ~30–40% of the regression.
+severity: minor
+reason: 'Optimizations deferred to a dedicated perf ticket so they can be benchmarked carefully. Documented in user-facing docs (Limitations: Performance section). Bench results captured in IMPL-SE1K0 verification evidence.'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-QS266.md
+++ b/tickets/entities/review-responses/RR-QS266.md
@@ -1,0 +1,9 @@
+---
+id: RR-QS266
+type: review-response
+title: Stale `text` and `inlines` together is silently ignored
+finding: writeInlinesOrFallback prefers inlines over text. If a script sets both during a half-finished migration, text is silently dropped. No diagnostic.
+severity: minor
+reason: Migration shim by design. Document removal-target deferred to follow-up.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-R0GNK.md
+++ b/tickets/entities/review-responses/RR-R0GNK.md
@@ -1,0 +1,9 @@
+---
+id: RR-R0GNK
+type: review-response
+title: Corpus round-trip test was synthetic-only despite plan saying tickets/entities/*.md
+finding: TestMdCorpusRoundTrip used 10 hand-written one-liners instead of the version-controlled corpus the plan specified. C1 and C2 above survived only because the test was incomplete.
+severity: significant
+resolution: Added corpusRoundTripFromDisk that walks tickets/entities/*.md, parses each file's body, asserts parse→render→parse fixed point. 798 of 801 files pass (the 3 skipped contain multi-line HTML comments — a pre-existing goldmark HTML-block round-trip quirk unrelated to this refactor). Skip rule documented in containsMultilineHTMLComment.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-S52XS.md
+++ b/tickets/entities/review-responses/RR-S52XS.md
@@ -1,0 +1,39 @@
+---
+id: RR-S52XS
+type: review-response
+title: Inline constructors not committed to in plan; scripts will write {type='text'} literals
+finding: Plan mentions exposing rela.md.text(s) 'for the most common case' but doesn't commit. If scripts ever build inlines (custom format callbacks, document composition), they need at minimum text/code_span/link constructors. Otherwise the API is awkward.
+severity: minor
+resolution: 'Inline constructors committed: rela.md.text(s), rela.md.code_span(s), rela.md.link_inline(text_or_inlines, url, title?), rela.md.raw_html(s). The new link constructor uses a different name (link_inline) to avoid collision with the existing string-returning rela.md.link. Pinned in AC10.'
+status: addressed
+---
+
+# Finding
+
+Plan: "Add Lua-exposed inline node constructors (or a single `rela.md.text(s)`
+builder) for the most common case so scripts don't have to write `{type="text",
+text=s}` by hand."
+
+That's an "or", not a commitment. With nothing exposed, scripts that build
+inlines write Lua literals like `{type="text", text=s}`. Workable, but ugly
+enough that people will work around it (build their own helpers, copy our
+internal constants).
+
+# Resolution
+
+Commit to a minimal set of inline constructors at the same level as the existing
+block constructors (`paragraph`, `heading`, etc.):
+
+- `rela.md.text(s)` → `{type="text", text=s}`
+- `rela.md.code_span(s)` → `{type="code_span", text=s}`
+- `rela.md.link(text_or_inlines, url, title?)` —
+**note name collision** with the existing `rela.md.link(text, url) → string`
+helper. The string-returning link helper has been around since the original
+`rela.md` API; we shouldn't break it. Pick a different name
+(`rela.md.link_inline`) or namespace under `rela.md.inline.*`.
+- `rela.md.raw_html(s)` → `{type="raw_html", text=s}`
+
+Skip `emphasis`/`strong`/`autolink`/`image` constructors for now; add if real
+users ask.
+
+Document in the `rela.md` reference.

--- a/tickets/entities/review-responses/RR-W8BRB.md
+++ b/tickets/entities/review-responses/RR-W8BRB.md
@@ -1,0 +1,9 @@
+---
+id: RR-W8BRB
+type: review-response
+title: Multi-block list continuation emitted lines with trailing whitespace
+finding: Empty continuation lines in multi-block list items got `  ` (two-space indent), which (a) trips MD009 lint and (b) is the CommonMark hard-break marker, risking misinterpretation.
+severity: significant
+resolution: renderListItem and prefixLines now emit empty continuation lines with no indent (or, for blockquote, the trimmed `>` prefix). prefixLines comment explains the policy.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-9WZIP.md
+++ b/tickets/entities/tickets/TKT-9WZIP.md
@@ -1,0 +1,127 @@
+---
+id: TKT-9WZIP
+type: ticket
+title: 'Restructure rela.md AST: preserve inline structure (text → inlines)'
+kind: refactor
+priority: medium
+effort: l
+status: done
+---
+
+# Restructure rela.md AST to Preserve Inline Structure
+
+## Problem
+
+`rela.md.parse` returns a "block-level AST": each block node (paragraph,
+heading, blockquote, list-item, table-cell) carries a flat `text` string where
+the goldmark parser's inline structure has been collapsed at extraction time
+(`extractInlineText` in `internal/lua/markdown.go`). Some inline markers are
+re-emitted as literal characters (`` `code spans` ``, `~~strike~~     `), some
+are dropped entirely (link wrappers, emphasis, autolinks, raw HTML, image alt
+text).
+
+This forces every consumer that needs to *recognize* an inline kind (e.g. "skip
+code spans" or "preserve link text/URL") to re-scan the flat string and
+reconstruct the structure. `rela.md.resolve_refs     ` (TKT-LXYHQ) had to add
+run-length backtick matching and Unicode-aware boundary checks just to avoid
+linking inside code spans — a class of fragility that does not exist in goldmark
+itself, only in our flattened representation.
+
+It also bakes irreversible information loss into parse:
+
+- `[See TKT-1](https://example.com)     ` parses to plain text
+`See TKT-1     ` — the URL is lost. `resolve_refs     ` then re-links it with a
+different URL than the author wrote.
+- Raw HTML in headings/paragraphs is silently stripped.
+- Image alt text and titles are gone.
+
+## Proposal
+
+Replace the `text     ` field on block nodes with a structured `inlines     `
+array. Each inline is a small Lua table identifying its kind and its
+content/attributes:
+
+```lua
+node = {
+  type = "paragraph",
+  inlines = {
+    { type = "text", text = "see " },
+    { type = "code_span", text = "TKT-1" },
+    { type = "text", text = " or " },
+    { type = "link", url = "/x", inlines = { { type = "text", text = "this" } } },
+    { type = "text", text = "." },
+  },
+}
+```
+
+Move the existing flattening logic (the "preserve backticks, preserve `~~     `,
+drop emphasis, drop link wrappers" policy) **into the renderer**.
+`renderParagraph     ` etc. walk `inlines     `, applying the same policy. End
+result is identical bytes for the existing flatten-everything path, but with the
+structure available to consumers that need it.
+
+`resolve_refs     ` (TKT-LXYHQ) becomes much simpler: walk `inlines     `, skip
+`code_span     ` and `raw_html     ` nodes, rewrite only `text     ` nodes'
+`text ` field. The run-length backtick scanner and Unicode-boundary checks that
+exist solely to compensate for flat strings can be deleted in a follow-up.
+
+## Bundled fixes (in scope for this refactor)
+
+These fall out naturally from preserving structure and are conceptually part of
+the same change:
+
+- **Link preservation.** Source links retain `url     ` and inline children
+(the link text). Re-rendering produces `[text](url)     `.
+- **Raw HTML preservation.** Inline raw HTML is preserved as a
+`raw_html     ` inline node and re-emitted verbatim by the renderer.
+- **Image preservation.** Images become `image     ` inlines with `url     `,
+`alt     `, and optional `title     `.
+- **Autolink preservation.** Autolinks become `autolink     ` inlines.
+
+## Migration
+
+To minimize breakage:
+
+- Block constructors (`paragraph(s)     `, `heading(level, s)     `,
+`blockquote(s)     `, `list(items)     `, table cells) accept either a string
+(auto-wrapped to `{{type="text", text=s}}     `) or an `inlines     ` table.
+- Existing in-tree scripts and tests that read `node.text     ` directly
+must migrate to either `node.inlines     ` or a new flat-text view (TBD in
+planning: provide `flatten(inlines) → string     ` helper, or a computed `text `
+view).
+- The `text     ` field itself is removed (no compat shim) — keeping it
+alive double-stores the same data and invites scripts to drift.
+
+## Out of scope
+
+- Refactoring `resolve_refs     ` to use the new structure. (Follow-up
+ticket once this lands; this ticket only enables it.)
+- Frontend / data-entry markdown rendering changes.
+- New inline kinds beyond what goldmark already produces.
+
+## Acceptance Criteria
+
+1. `rela.md.parse     ` emits block nodes with an `inlines     ` array; no
+`text     ` field on paragraph/heading/blockquote/list-item/table-cell.
+2. `rela.md.render     ` round-trips parse output to byte-equivalent
+markdown for: plain paragraphs, headings, blockquotes, plain and task lists, GFM
+tables, fenced code blocks, raw HTML blocks, thematic breaks.
+3. Inline kinds preserved: `text     `, `code_span     `, `link     `, `image     `,
+`autolink     `, `raw_html     `, `emphasis     `, `strong     `, `strikethrough
+`, `soft_break    `, `hard_break     `.
+4. **Link round-trip.** Source `[See TKT-1](https://example.com)     `
+parses to a `link     ` inline and renders back to identical syntax.
+5. **Raw HTML round-trip.** Source `<a name="x">     ` in a heading is
+preserved.
+6. Block constructors accept strings (auto-wrap) and inlines tables.
+7. Helpers that previously consumed `text     ` (`shift_headers     `,
+`extract_section     `, `headers     `, `first_paragraph     `, `concat     `,
+`entity_table   `) work against the new structure with no API regression visible
+to existing scripts that don't read inline structure directly.
+8. All existing tests pass (after migration). All existing in-repo
+Lua scripts (in `scripts/     `, `automation/     `, etc.) continue to work
+after migration.
+9. The existing `extractInlineText     ` policy (drop emphasis, preserve
+`~~     ` and backticks) survives as the default `flatten(inlines)     `
+behavior, so consumers that just want the old flat string can opt in via one
+helper call.

--- a/tickets/relations/TKT-9WZIP--affects--lua-scripting.md
+++ b/tickets/relations/TKT-9WZIP--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-9WZIP--has-implementation--IMPL-SE1K0.md
+++ b/tickets/relations/TKT-9WZIP--has-implementation--IMPL-SE1K0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-implementation
+to: IMPL-SE1K0
+---

--- a/tickets/relations/TKT-9WZIP--has-planning--PLAN-PWOYK.md
+++ b/tickets/relations/TKT-9WZIP--has-planning--PLAN-PWOYK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-planning
+to: PLAN-PWOYK
+---

--- a/tickets/relations/TKT-9WZIP--has-review--REV-B88BO.md
+++ b/tickets/relations/TKT-9WZIP--has-review--REV-B88BO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review
+to: REV-B88BO
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-0S353.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-0S353.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-0S353
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-2LTXT.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-2LTXT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-2LTXT
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-2N3O4.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-2N3O4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-2N3O4
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-2UUJ1.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-2UUJ1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-2UUJ1
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-321GJ.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-321GJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-321GJ
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-39HBQ.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-39HBQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-39HBQ
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-50RH7.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-50RH7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-50RH7
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-90TSA.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-90TSA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-90TSA
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-A8J6P.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-A8J6P.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-A8J6P
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-CXYTT.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-CXYTT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-CXYTT
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-EGN0B.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-EGN0B.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-EGN0B
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-GCDTI.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-GCDTI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-GCDTI
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-GOFKH.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-GOFKH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-GOFKH
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-H97SY.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-H97SY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-H97SY
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-HL0TO.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-HL0TO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-HL0TO
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-HYXZ9.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-HYXZ9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-HYXZ9
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-IK0AU.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-IK0AU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-IK0AU
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-IKYS9.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-IKYS9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-IKYS9
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-JUXC1.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-JUXC1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-JUXC1
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-KBKFH.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-KBKFH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-KBKFH
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-KV5PR.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-KV5PR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-KV5PR
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-LBHZL.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-LBHZL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-LBHZL
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-NOSDE.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-NOSDE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-NOSDE
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-Q57YY.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-Q57YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-Q57YY
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-QIKA2.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-QIKA2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-QIKA2
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-QS266.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-QS266.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-QS266
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-R0GNK.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-R0GNK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-R0GNK
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-S52XS.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-S52XS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-S52XS
+---

--- a/tickets/relations/TKT-9WZIP--has-review-response--RR-W8BRB.md
+++ b/tickets/relations/TKT-9WZIP--has-review-response--RR-W8BRB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: has-review-response
+to: RR-W8BRB
+---

--- a/tickets/relations/TKT-9WZIP--implements--FEAT-i5ji.md
+++ b/tickets/relations/TKT-9WZIP--implements--FEAT-i5ji.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9WZIP
+relation: implements
+to: FEAT-i5ji
+---


### PR DESCRIPTION
## Summary

- Replaces flat-string `text` field on block nodes with a structured `inlines` array, faithful to goldmark's parse tree.
- Block containers (blockquote, list items) now carry `children`. Table cells carry inlines.
- Inline kinds preserved: text, code_span, link, image (with `alt_inlines`), autolink, raw_html, emphasis, strong, strikethrough, soft_break, hard_break.
- Two flatteners: `renderInlines` preserves syntax (parse↔render fixed point), `flattenInlines` keeps the legacy text-extraction policy. Exposed as `rela.md.flatten`.
- New inline constructors: `rela.md.text`, `rela.md.code_span`, `rela.md.link_inline`, `rela.md.raw_html`. Block constructors auto-wrap a string argument.

Code review (cranky-reviewer) caught four critical correctness bugs that would have caused silent data corruption: pipe-in-table-cell row mangling, code-span fence-width loss, breaks rendered inside heading splitting the document, and bare URL emission breaking on URLs with spaces or unbalanced parens. All four are fixed and have regression tests. Real-corpus test now exercises 798 in-tree ticket files (3 skipped for a pre-existing HTML-block round-trip quirk unrelated to this refactor).

## Performance note

Parse allocates ~2.5–3× the tables of the pre-refactor flat-string representation on a kitchen-sink fixture (`BenchmarkMdParse`). Documented in user-facing docs; quick wins (preallocated table sizes, empty-inlines sentinel) tracked as follow-up. For typical content (mostly plain prose) the regression is smaller.

## Test plan

- [x] `just test` (race-enabled) — all packages pass
- [x] `just lint` (golangci-lint v2.11.4) — 0 issues
- [x] `just coverage-check` — thresholds satisfied
- [x] `just arch-lint` — no warnings
- [x] `just docs` — generated docs in sync
- [x] `just ci` — full pre-flight green
- [x] 20 ACs from PLAN-PWOYK covered, plus 4 critical regression tests from code review (C1–C4)
- [x] Real-corpus round-trip on 798 in-tree ticket entity files