### PR TITLE
feat(data-entry): quick-jump command palette (Cmd+K) (TKT-77JD4)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from 'vue'
 import { useSchemaStore, useUIStore } from '@/stores'
-import { useKeyboardShortcuts, shortcutsModalOpen, useEvents } from '@/composables'
+import { useKeyboardShortcuts, shortcutsModalOpen, paletteOpen, useEvents } from '@/composables'
 import { useConfirmHost } from '@/composables/useConfirm'
 import Sidebar from '@/components/common/Sidebar.vue'
 import StatusBar from '@/components/common/StatusBar.vue'
 import Toast from '@/components/common/Toast.vue'
 import ScriptErrorDialog from '@/components/common/ScriptErrorDialog.vue'
 import KeyboardShortcutsModal from '@/components/ui/KeyboardShortcutsModal.vue'
+import CommandPaletteModal from '@/components/ui/CommandPaletteModal.vue'
 import ConfirmModal from '@/components/ui/ConfirmModal.vue'
 
 const schemaStore = useSchemaStore()
@@ -118,6 +119,10 @@ watch(
       @close="shortcutsModalOpen = false"
     />
   </div>
+
+  <!-- Mounted unconditionally so Cmd+K works during schema loading and on
+       the error screen, mirroring the ConfirmModal hoist below. -->
+  <CommandPaletteModal :open="paletteOpen" @close="paletteOpen = false" />
 
   <!-- Mounted unconditionally (outside the loading/error/loaded branches) so
        any caller of useConfirm() resolves to a rendered modal even during

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -40,15 +40,21 @@ export async function deleteEntity(type: string, id: string): Promise<void> {
   return api.delete(`/${getPlural(type)}/${id}`)
 }
 
+/**
+ * Searches entities by query text, optionally filtered by type.
+ * Pass an AbortSignal to cancel an in-flight request — the command palette
+ * uses this to abort superseded searches as the user types.
+ */
 export async function searchEntities(
   query: string,
-  type?: string
+  type?: string,
+  signal?: AbortSignal
 ): Promise<ListResponse<Entity>> {
   const params: Record<string, string> = { q: query }
   if (type) {
     params.type = type
   }
-  return api.get<ListResponse<Entity>>('/_search', params)
+  return api.get<ListResponse<Entity>>('/_search', params, signal)
 }
 
 export async function analyze(): Promise<AnalyzeResult> {

--- a/frontend/src/components/ui/CommandPaletteModal.test.ts
+++ b/frontend/src/components/ui/CommandPaletteModal.test.ts
@@ -59,15 +59,32 @@ function factory(props: { open?: boolean } = {}): VueWrapper {
   })
 }
 
-function input(): HTMLInputElement {
-  const el = document.querySelector<HTMLInputElement>('.cmdk-input')
-  if (!el) throw new Error('cmdk-input not in DOM')
-  return el
+// Mount in a closed state, await mount, then drive the open transition.
+// Used by tests that need to observe the closed → open lifecycle (focus
+// capture, modal-stack registration on flip).
+async function factoryClosedThenOpen(): Promise<VueWrapper> {
+  const wrapper = factory({ open: false })
+  await wrapper.setProps({ open: true })
+  await flushPromises()
+  return wrapper
 }
 
-function options(): HTMLLIElement[] {
-  return Array.from(document.querySelectorAll<HTMLLIElement>('.cmdk-option'))
+// Centralized DOM lookups so query strings live in one place.
+const dom = {
+  overlay: () => document.querySelector<HTMLElement>('.cmdk-overlay'),
+  modal: () => document.querySelector<HTMLElement>('.cmdk-modal'),
+  input: (): HTMLInputElement => {
+    const el = document.querySelector<HTMLInputElement>('.cmdk-input')
+    if (!el) throw new Error('cmdk-input not in DOM')
+    return el
+  },
+  options: () => Array.from(document.querySelectorAll<HTMLLIElement>('.cmdk-option')),
+  hint: () => document.querySelector<HTMLElement>('.cmdk-hint')?.textContent?.trim(),
+  spinner: () => document.querySelector<HTMLElement>('.cmdk-spinner'),
 }
+
+const input = dom.input
+const options = dom.options
 
 // Type into the palette and wait for the debounced search to settle.
 // Vue's v-model needs a microtask to sync the input event into the bound ref;
@@ -80,6 +97,28 @@ async function typeQuery(value: string): Promise<void> {
   vi.advanceTimersByTime(150)
   await flushPromises()
   await flushPromises()
+}
+
+// Drive the open prop and let the watcher run.
+async function setOpen(wrapper: VueWrapper, open: boolean): Promise<void> {
+  await wrapper.setProps({ open })
+  await flushPromises()
+}
+
+// Press a key on the palette input. Bubbles so the @keydown on .cmdk-overlay
+// catches it just like a real keypress would.
+function pressKey(
+  key: string,
+  init: KeyboardEventInit = {}
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  })
+  input().dispatchEvent(event)
+  return event
 }
 
 describe('CommandPaletteModal', () => {
@@ -106,66 +145,56 @@ describe('CommandPaletteModal', () => {
   describe('rendering', () => {
     it('does not render when closed', () => {
       factory({ open: false })
-      expect(document.querySelector('.cmdk-overlay')).toBeNull()
+      expect(dom.overlay()).toBeNull()
     })
 
     it('renders overlay and input when open', () => {
       factory()
-      expect(document.querySelector('.cmdk-overlay')).not.toBeNull()
+      expect(dom.overlay()).not.toBeNull()
       expect(input()).not.toBeNull()
     })
 
     it('shows the empty hint when query is blank', () => {
       factory()
-      const hint = document.querySelector('.cmdk-hint')?.textContent?.trim()
-      expect(hint).toBe('Type to search entities')
+      expect(dom.hint()).toBe('Type to search entities')
     })
 
     it('renders title, type label and id for each result', async () => {
-      searchSpy.mockResolvedValueOnce(
-        listResponse([makeEntity({ id: 'T-1', type: 'ticket', _title: 'Fix login' })])
-      )
+      const entity = makeEntity({ id: 'T-1', type: 'ticket', _title: 'Fix login' })
+      searchSpy.mockResolvedValueOnce(listResponse([entity]))
       factory()
       await typeQuery('fix')
 
       const opts = options()
       expect(opts).toHaveLength(1)
-      expect(opts[0].textContent).toContain('Fix login')
-      expect(opts[0].textContent).toContain('T-1')
+      expect(opts[0].textContent).toContain(entity._title)
+      expect(opts[0].textContent).toContain(entity.id)
       expect(opts[0].textContent).toContain('Ticket')
     })
 
     it('falls back to properties.title when _title missing', async () => {
-      searchSpy.mockResolvedValueOnce(
-        listResponse([
-          makeEntity({ id: 'T-2', properties: { title: 'Legacy title' } }),
-        ])
-      )
+      const entity = makeEntity({ properties: { title: 'Legacy title' } })
+      searchSpy.mockResolvedValueOnce(listResponse([entity]))
       factory()
       await typeQuery('leg')
 
-      expect(options()[0].textContent).toContain('Legacy title')
+      expect(options()[0].textContent).toContain(entity.properties.title as string)
     })
 
     it('falls back to id when both title fields missing', async () => {
-      searchSpy.mockResolvedValueOnce(listResponse([makeEntity({ id: 'T-3' })]))
+      const entity = makeEntity()
+      searchSpy.mockResolvedValueOnce(listResponse([entity]))
       factory()
-      await typeQuery('t-3')
+      await typeQuery('any')
 
       const titleEl = document.querySelector('.cmdk-title')
-      expect(titleEl?.textContent).toBe('T-3')
+      expect(titleEl?.textContent).toBe(entity.id)
     })
   })
 
   describe('focus and lifecycle', () => {
     it('focuses the input on open', async () => {
-      const wrapper = mount(CommandPaletteModal, {
-        props: { open: false },
-        attachTo: document.body,
-      })
-      await wrapper.setProps({ open: true })
-      await flushPromises()
-
+      const wrapper = await factoryClosedThenOpen()
       expect(document.activeElement).toBe(input())
       wrapper.unmount()
     })
@@ -174,36 +203,23 @@ describe('CommandPaletteModal', () => {
       const trigger = document.createElement('button')
       document.body.appendChild(trigger)
       trigger.focus()
-      expect(document.activeElement).toBe(trigger)
 
-      const wrapper = mount(CommandPaletteModal, {
-        props: { open: false },
-        attachTo: document.body,
-      })
-      await wrapper.setProps({ open: true })
-      await flushPromises()
+      const wrapper = await factoryClosedThenOpen()
       expect(document.activeElement).toBe(input())
 
-      await wrapper.setProps({ open: false })
-      await flushPromises()
+      await setOpen(wrapper, false)
       expect(document.activeElement).toBe(trigger)
-
       wrapper.unmount()
     })
 
     it('registers with the modal stack while open', async () => {
-      const wrapper = mount(CommandPaletteModal, {
-        props: { open: false },
-        attachTo: document.body,
-      })
+      const wrapper = factory({ open: false })
       expect(isAnyModalOpen()).toBe(false)
 
-      await wrapper.setProps({ open: true })
-      await flushPromises()
+      await setOpen(wrapper, true)
       expect(isAnyModalOpen()).toBe(true)
 
-      await wrapper.setProps({ open: false })
-      await flushPromises()
+      await setOpen(wrapper, false)
       expect(isAnyModalOpen()).toBe(false)
 
       wrapper.unmount()
@@ -211,47 +227,37 @@ describe('CommandPaletteModal', () => {
 
     it('resets query and highlightedIndex when re-opened', async () => {
       searchSpy.mockResolvedValue(
-        listResponse([makeEntity({ id: 'A' }), makeEntity({ id: 'B' })])
+        listResponse([makeEntity(), makeEntity()])
       )
-      const wrapper = mount(CommandPaletteModal, {
-        props: { open: true },
-        attachTo: document.body,
-      })
-      await flushPromises()
-
+      const wrapper = factory()
       await typeQuery('foo')
-      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      pressKey('ArrowDown')
       await flushPromises()
 
-      await wrapper.setProps({ open: false })
-      await flushPromises()
-      await wrapper.setProps({ open: true })
-      await flushPromises()
+      await setOpen(wrapper, false)
+      await setOpen(wrapper, true)
 
       expect(input().value).toBe('')
       // No results yet (query is empty), so no active descendant.
       expect(input().getAttribute('aria-activedescendant')).toBeNull()
-
       wrapper.unmount()
     })
   })
 
   describe('search behavior', () => {
-    it('debounces search calls', async () => {
-      searchSpy.mockResolvedValue(listResponse([]))
+    it('coalesces rapid keystrokes into a single API call', async () => {
+      // Verifies our debounce: type three characters in quick succession,
+      // and only the final value should make it to the API.
       factory()
 
-      // Three rapid keystrokes; only the final one should fire a request.
       input().value = 'ab'
       input().dispatchEvent(new Event('input'))
       input().value = 'abc'
       input().dispatchEvent(new Event('input'))
       input().value = 'abcd'
       input().dispatchEvent(new Event('input'))
+      // Drain the debounce.
       await flushPromises()
-
-      expect(searchSpy).not.toHaveBeenCalled()
-
       vi.advanceTimersByTime(150)
       await flushPromises()
       await flushPromises()
@@ -260,36 +266,33 @@ describe('CommandPaletteModal', () => {
       expect(searchSpy).toHaveBeenLastCalledWith('abcd', undefined, expect.any(AbortSignal))
     })
 
-    it('does not call /_search for empty query', async () => {
+    // Queries below the minimum length, or that contain only whitespace,
+    // must short-circuit without hitting the API. Otherwise the backend
+    // gets pummeled on every keystroke before the user has typed anything
+    // useful, and the UX is "show 8000 unrelated results for 'a'."
+    it.each<[string, string, string]>([
+      ['empty', '', ''],
+      ['whitespace-only', '   ', ''],
+      ['single character', 'a', 'a'],
+    ])('does not call /_search for %s queries', async (_name, query, prefix) => {
       factory()
-      await typeQuery('xy')
+      // Some cases (empty) need a prior real query to clear, so search
+      // doesn't no-op on the no-change path.
+      if (prefix) await typeQuery(prefix + 'x')
       searchSpy.mockClear()
-      await typeQuery('')
+      await typeQuery(query)
 
       expect(searchSpy).not.toHaveBeenCalled()
     })
 
-    it('does not call /_search for whitespace-only query', async () => {
-      factory()
-      await typeQuery('   ')
-
-      expect(searchSpy).not.toHaveBeenCalled()
-    })
-
-    it('does not call /_search for single-character queries', async () => {
+    it('shows the empty hint for a single-character query', async () => {
       factory()
       await typeQuery('a')
-
-      expect(searchSpy).not.toHaveBeenCalled()
-      expect(document.querySelector('.cmdk-hint')?.textContent?.trim()).toBe(
-        'Type to search entities'
-      )
+      expect(dom.hint()).toBe('Type to search entities')
     })
 
     it('caps rendered results at MAX_RESULTS (50)', async () => {
-      const many = Array.from({ length: 200 }, (_, i) =>
-        makeEntity({ id: `BIG-${i}`, _title: `Entity ${i}` })
-      )
+      const many = Array.from({ length: 200 }, () => makeEntity())
       searchSpy.mockResolvedValueOnce(listResponse(many))
       factory()
       await typeQuery('big')
@@ -302,8 +305,7 @@ describe('CommandPaletteModal', () => {
       factory()
       await typeQuery('nothing')
 
-      const hint = document.querySelector('.cmdk-hint')?.textContent?.trim()
-      expect(hint).toBe('No matches')
+      expect(dom.hint()).toBe('No matches')
     })
 
     it('shows error message on search failure', async () => {
@@ -311,14 +313,12 @@ describe('CommandPaletteModal', () => {
       factory()
       await typeQuery('foo')
 
-      const hint = document.querySelector('.cmdk-hint')?.textContent?.trim()
-      expect(hint).toBe('Search failed')
+      expect(dom.hint()).toBe('Search failed')
     })
 
     it('keeps previous results visible while a refetch is in flight', async () => {
-      searchSpy.mockResolvedValueOnce(
-        listResponse([makeEntity({ id: 'first', _title: 'First' })])
-      )
+      const first = makeEntity()
+      searchSpy.mockResolvedValueOnce(listResponse([first]))
       factory()
       await typeQuery('fi')
       expect(options()).toHaveLength(1)
@@ -339,15 +339,10 @@ describe('CommandPaletteModal', () => {
 
       // Previous results still visible (no flicker).
       expect(options()).toHaveLength(1)
-      expect(document.querySelector('.cmdk-spinner')).not.toBeNull()
+      expect(dom.spinner()).not.toBeNull()
 
       // Resolve the second request — results swap.
-      resolveSecond(
-        listResponse([
-          makeEntity({ id: 'a' }),
-          makeEntity({ id: 'b' }),
-        ])
-      )
+      resolveSecond(listResponse([makeEntity(), makeEntity()]))
       await flushPromises()
       expect(options()).toHaveLength(2)
     })
@@ -404,9 +399,7 @@ describe('CommandPaletteModal', () => {
 
   describe('keyboard navigation', () => {
     async function setupWithResults(n: number) {
-      const entities = Array.from({ length: n }, (_, i) =>
-        makeEntity({ id: `E-${i}`, _title: `Entity ${i}` })
-      )
+      const entities = Array.from({ length: n }, () => makeEntity())
       searchSpy.mockResolvedValueOnce(listResponse(entities))
       const wrapper = factory()
       await typeQuery('ee')
@@ -415,7 +408,7 @@ describe('CommandPaletteModal', () => {
 
     it('ArrowDown moves highlight forward', async () => {
       const { wrapper } = await setupWithResults(3)
-      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      pressKey('ArrowDown')
       await flushPromises()
       expect(options()[1].classList.contains('cmdk-option-active')).toBe(true)
       wrapper.unmount()
@@ -423,9 +416,9 @@ describe('CommandPaletteModal', () => {
 
     it('ArrowDown wraps from last to first', async () => {
       const { wrapper } = await setupWithResults(3)
-      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
-      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
-      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      pressKey('ArrowDown')
+      pressKey('ArrowDown')
+      pressKey('ArrowDown')
       await flushPromises()
       expect(options()[0].classList.contains('cmdk-option-active')).toBe(true)
       wrapper.unmount()
@@ -433,7 +426,7 @@ describe('CommandPaletteModal', () => {
 
     it('ArrowUp wraps from first to last', async () => {
       const { wrapper } = await setupWithResults(3)
-      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }))
+      pressKey('ArrowUp')
       await flushPromises()
       expect(options()[2].classList.contains('cmdk-option-active')).toBe(true)
       wrapper.unmount()
@@ -441,7 +434,7 @@ describe('CommandPaletteModal', () => {
 
     it('ArrowDown does not crash with empty results', async () => {
       factory()
-      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      pressKey('ArrowDown')
       await flushPromises()
       // No throw, no options rendered.
       expect(options()).toHaveLength(0)
@@ -449,7 +442,7 @@ describe('CommandPaletteModal', () => {
 
     it('aria-activedescendant matches highlighted option id', async () => {
       const { wrapper, entities } = await setupWithResults(2)
-      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      pressKey('ArrowDown')
       await flushPromises()
       const expected = `cmdk-option-${entities[1].id}`
       expect(input().getAttribute('aria-activedescendant')).toBe(expected)
@@ -459,9 +452,9 @@ describe('CommandPaletteModal', () => {
 
     it('Enter navigates to the highlighted entity and emits close', async () => {
       const { wrapper, entities } = await setupWithResults(2)
-      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      pressKey('ArrowDown')
       await flushPromises()
-      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      pressKey('Enter')
       await flushPromises()
 
       expect(routerPush).toHaveBeenCalledWith(`/entity/${entities[1].type}/${entities[1].id}`)
@@ -471,7 +464,7 @@ describe('CommandPaletteModal', () => {
 
     it('Enter is a no-op when results are empty', async () => {
       const wrapper = factory()
-      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      pressKey('Enter')
       await flushPromises()
       expect(routerPush).not.toHaveBeenCalled()
       expect(wrapper.emitted('close')).toBeUndefined()
@@ -499,12 +492,7 @@ describe('CommandPaletteModal', () => {
       // After mount with open=true the input is auto-focused (immediate watcher).
       expect(document.activeElement).toBe(input())
 
-      const event = new KeyboardEvent('keydown', {
-        key: 'Tab',
-        bubbles: true,
-        cancelable: true,
-      })
-      input().dispatchEvent(event)
+      const event = pressKey('Tab')
 
       expect(event.defaultPrevented).toBe(true)
       expect(document.activeElement).toBe(input())
@@ -513,40 +501,38 @@ describe('CommandPaletteModal', () => {
 
   describe('selection', () => {
     it('clicking a result navigates and emits close', async () => {
-      searchSpy.mockResolvedValueOnce(
-        listResponse([makeEntity({ id: 'X-1', type: 'ticket' })])
-      )
+      const entity = makeEntity({ type: 'ticket' })
+      searchSpy.mockResolvedValueOnce(listResponse([entity]))
       const wrapper = factory()
       await typeQuery('xx')
 
       options()[0].click()
       await flushPromises()
 
-      expect(routerPush).toHaveBeenCalledWith('/entity/ticket/X-1')
+      expect(routerPush).toHaveBeenCalledWith(`/entity/${entity.type}/${entity.id}`)
       expect(wrapper.emitted('close')).toHaveLength(1)
     })
 
     it('uses custom detail view when configured for the entity type', async () => {
-      const schemaStore = useSchemaStore()
-      schemaStore.entityViewConfigs.set('ticket', {
-        detail_view: 'ticket-detail',
+      const detailViewId = 'ticket-detail'
+      useSchemaStore().entityViewConfigs.set('ticket', {
+        detail_view: detailViewId,
       } as never)
 
-      searchSpy.mockResolvedValueOnce(
-        listResponse([makeEntity({ id: 'X-2', type: 'ticket' })])
-      )
+      const entity = makeEntity({ type: 'ticket' })
+      searchSpy.mockResolvedValueOnce(listResponse([entity]))
       factory()
       await typeQuery('xx')
 
       options()[0].click()
       await flushPromises()
 
-      expect(routerPush).toHaveBeenCalledWith('/view/ticket-detail/X-2')
+      expect(routerPush).toHaveBeenCalledWith(`/view/${detailViewId}/${entity.id}`)
     })
 
     it('does not navigate when entity has no type (empty href)', async () => {
       searchSpy.mockResolvedValueOnce(
-        listResponse([makeEntity({ id: 'X-3', type: '' })])
+        listResponse([makeEntity({ type: '' })])
       )
       const wrapper = factory()
       await typeQuery('xx')
@@ -562,15 +548,13 @@ describe('CommandPaletteModal', () => {
   describe('overlay click', () => {
     it('emits close when backdrop is clicked', () => {
       const wrapper = factory()
-      const overlay = document.querySelector<HTMLElement>('.cmdk-overlay')!
-      overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      dom.overlay()!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
       expect(wrapper.emitted('close')).toHaveLength(1)
     })
 
     it('does not emit close when clicking inside the modal', () => {
       const wrapper = factory()
-      const modal = document.querySelector<HTMLElement>('.cmdk-modal')!
-      modal.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      dom.modal()!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
       expect(wrapper.emitted('close')).toBeUndefined()
     })
   })

--- a/frontend/src/components/ui/CommandPaletteModal.test.ts
+++ b/frontend/src/components/ui/CommandPaletteModal.test.ts
@@ -450,6 +450,22 @@ describe('CommandPaletteModal', () => {
       wrapper.unmount()
     })
 
+    it('scrolls the highlighted option into view on arrow navigation', async () => {
+      const { wrapper, entities } = await setupWithResults(20)
+      const target = entities[5]
+      const scrollSpy = vi.spyOn(
+        document.getElementById(`cmdk-option-${target.id}`)!,
+        'scrollIntoView'
+      )
+      // Press ArrowDown 5 times to land on `target`.
+      for (let i = 0; i < 5; i++) pressKey('ArrowDown')
+      await flushPromises()
+
+      expect(scrollSpy).toHaveBeenCalled()
+      expect(scrollSpy).toHaveBeenLastCalledWith({ block: 'nearest' })
+      wrapper.unmount()
+    })
+
     it('Enter navigates to the highlighted entity and emits close', async () => {
       const { wrapper, entities } = await setupWithResults(2)
       pressKey('ArrowDown')

--- a/frontend/src/components/ui/CommandPaletteModal.test.ts
+++ b/frontend/src/components/ui/CommandPaletteModal.test.ts
@@ -1,0 +1,577 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import type { VueWrapper } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import CommandPaletteModal from './CommandPaletteModal.vue'
+import { useSchemaStore } from '@/stores/schema'
+import { _resetModalStack, isAnyModalOpen } from '@/composables/modalStack'
+import { searchEntities } from '@/api'
+import type { Entity, ListResponse } from '@/types'
+
+// Router stub — palette navigates via router.push when an entity is selected.
+const routerPush = vi.fn()
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: routerPush }),
+}))
+
+// Mock the search endpoint so each test can stub responses and we can assert
+// signal forwarding without hitting the real API client.
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api')
+  return {
+    ...actual,
+    searchEntities: vi.fn(),
+  }
+})
+
+const searchSpy = searchEntities as unknown as ReturnType<typeof vi.fn>
+
+function makeEntity(overrides: Partial<Entity> = {}): Entity {
+  return {
+    id: overrides.id ?? `T-${Math.random().toString(36).slice(2, 8).toUpperCase()}`,
+    type: overrides.type ?? 'ticket',
+    _title: overrides._title,
+    properties: overrides.properties ?? {},
+    ...overrides,
+  } as Entity
+}
+
+function listResponse(entities: Entity[]): ListResponse<Entity> {
+  return {
+    data: entities,
+    meta: { total: entities.length, page: 1, per_page: 25, has_more: false },
+  }
+}
+
+function seedSchema() {
+  const schemaStore = useSchemaStore()
+  schemaStore.entityTypes.set('ticket', {
+    name: 'ticket',
+    label: 'Ticket',
+    properties: {},
+  } as never)
+}
+
+function factory(props: { open?: boolean } = {}): VueWrapper {
+  return mount(CommandPaletteModal, {
+    props: { open: true, ...props },
+    attachTo: document.body,
+  })
+}
+
+function input(): HTMLInputElement {
+  const el = document.querySelector<HTMLInputElement>('.cmdk-input')
+  if (!el) throw new Error('cmdk-input not in DOM')
+  return el
+}
+
+function options(): HTMLLIElement[] {
+  return Array.from(document.querySelectorAll<HTMLLIElement>('.cmdk-option'))
+}
+
+// Type into the palette and wait for the debounced search to settle.
+// Vue's v-model needs a microtask to sync the input event into the bound ref;
+// flushPromises before advancing the fake timer ensures the watcher schedules
+// the debounced setTimeout, which we then advance past.
+async function typeQuery(value: string): Promise<void> {
+  input().value = value
+  input().dispatchEvent(new Event('input'))
+  await flushPromises()
+  vi.advanceTimersByTime(150)
+  await flushPromises()
+  await flushPromises()
+}
+
+describe('CommandPaletteModal', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    _resetModalStack()
+    routerPush.mockClear()
+    searchSpy.mockClear()
+    // Default implementation so tests that don't queue a value don't crash on
+    // resp.data; individual tests can still override with mockResolvedValueOnce
+    // / mockRejectedValueOnce / mockImplementationOnce.
+    searchSpy.mockResolvedValue(listResponse([]))
+    document.body.innerHTML = ''
+    seedSchema()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+    _resetModalStack()
+  })
+
+  describe('rendering', () => {
+    it('does not render when closed', () => {
+      factory({ open: false })
+      expect(document.querySelector('.cmdk-overlay')).toBeNull()
+    })
+
+    it('renders overlay and input when open', () => {
+      factory()
+      expect(document.querySelector('.cmdk-overlay')).not.toBeNull()
+      expect(input()).not.toBeNull()
+    })
+
+    it('shows the empty hint when query is blank', () => {
+      factory()
+      const hint = document.querySelector('.cmdk-hint')?.textContent?.trim()
+      expect(hint).toBe('Type to search entities')
+    })
+
+    it('renders title, type label and id for each result', async () => {
+      searchSpy.mockResolvedValueOnce(
+        listResponse([makeEntity({ id: 'T-1', type: 'ticket', _title: 'Fix login' })])
+      )
+      factory()
+      await typeQuery('fix')
+
+      const opts = options()
+      expect(opts).toHaveLength(1)
+      expect(opts[0].textContent).toContain('Fix login')
+      expect(opts[0].textContent).toContain('T-1')
+      expect(opts[0].textContent).toContain('Ticket')
+    })
+
+    it('falls back to properties.title when _title missing', async () => {
+      searchSpy.mockResolvedValueOnce(
+        listResponse([
+          makeEntity({ id: 'T-2', properties: { title: 'Legacy title' } }),
+        ])
+      )
+      factory()
+      await typeQuery('leg')
+
+      expect(options()[0].textContent).toContain('Legacy title')
+    })
+
+    it('falls back to id when both title fields missing', async () => {
+      searchSpy.mockResolvedValueOnce(listResponse([makeEntity({ id: 'T-3' })]))
+      factory()
+      await typeQuery('t-3')
+
+      const titleEl = document.querySelector('.cmdk-title')
+      expect(titleEl?.textContent).toBe('T-3')
+    })
+  })
+
+  describe('focus and lifecycle', () => {
+    it('focuses the input on open', async () => {
+      const wrapper = mount(CommandPaletteModal, {
+        props: { open: false },
+        attachTo: document.body,
+      })
+      await wrapper.setProps({ open: true })
+      await flushPromises()
+
+      expect(document.activeElement).toBe(input())
+      wrapper.unmount()
+    })
+
+    it('restores previously focused element on close', async () => {
+      const trigger = document.createElement('button')
+      document.body.appendChild(trigger)
+      trigger.focus()
+      expect(document.activeElement).toBe(trigger)
+
+      const wrapper = mount(CommandPaletteModal, {
+        props: { open: false },
+        attachTo: document.body,
+      })
+      await wrapper.setProps({ open: true })
+      await flushPromises()
+      expect(document.activeElement).toBe(input())
+
+      await wrapper.setProps({ open: false })
+      await flushPromises()
+      expect(document.activeElement).toBe(trigger)
+
+      wrapper.unmount()
+    })
+
+    it('registers with the modal stack while open', async () => {
+      const wrapper = mount(CommandPaletteModal, {
+        props: { open: false },
+        attachTo: document.body,
+      })
+      expect(isAnyModalOpen()).toBe(false)
+
+      await wrapper.setProps({ open: true })
+      await flushPromises()
+      expect(isAnyModalOpen()).toBe(true)
+
+      await wrapper.setProps({ open: false })
+      await flushPromises()
+      expect(isAnyModalOpen()).toBe(false)
+
+      wrapper.unmount()
+    })
+
+    it('resets query and highlightedIndex when re-opened', async () => {
+      searchSpy.mockResolvedValue(
+        listResponse([makeEntity({ id: 'A' }), makeEntity({ id: 'B' })])
+      )
+      const wrapper = mount(CommandPaletteModal, {
+        props: { open: true },
+        attachTo: document.body,
+      })
+      await flushPromises()
+
+      await typeQuery('foo')
+      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      await flushPromises()
+
+      await wrapper.setProps({ open: false })
+      await flushPromises()
+      await wrapper.setProps({ open: true })
+      await flushPromises()
+
+      expect(input().value).toBe('')
+      // No results yet (query is empty), so no active descendant.
+      expect(input().getAttribute('aria-activedescendant')).toBeNull()
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('search behavior', () => {
+    it('debounces search calls', async () => {
+      searchSpy.mockResolvedValue(listResponse([]))
+      factory()
+
+      // Three rapid keystrokes; only the final one should fire a request.
+      input().value = 'ab'
+      input().dispatchEvent(new Event('input'))
+      input().value = 'abc'
+      input().dispatchEvent(new Event('input'))
+      input().value = 'abcd'
+      input().dispatchEvent(new Event('input'))
+      await flushPromises()
+
+      expect(searchSpy).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(150)
+      await flushPromises()
+      await flushPromises()
+
+      expect(searchSpy).toHaveBeenCalledTimes(1)
+      expect(searchSpy).toHaveBeenLastCalledWith('abcd', undefined, expect.any(AbortSignal))
+    })
+
+    it('does not call /_search for empty query', async () => {
+      factory()
+      await typeQuery('xy')
+      searchSpy.mockClear()
+      await typeQuery('')
+
+      expect(searchSpy).not.toHaveBeenCalled()
+    })
+
+    it('does not call /_search for whitespace-only query', async () => {
+      factory()
+      await typeQuery('   ')
+
+      expect(searchSpy).not.toHaveBeenCalled()
+    })
+
+    it('does not call /_search for single-character queries', async () => {
+      factory()
+      await typeQuery('a')
+
+      expect(searchSpy).not.toHaveBeenCalled()
+      expect(document.querySelector('.cmdk-hint')?.textContent?.trim()).toBe(
+        'Type to search entities'
+      )
+    })
+
+    it('caps rendered results at MAX_RESULTS (50)', async () => {
+      const many = Array.from({ length: 200 }, (_, i) =>
+        makeEntity({ id: `BIG-${i}`, _title: `Entity ${i}` })
+      )
+      searchSpy.mockResolvedValueOnce(listResponse(many))
+      factory()
+      await typeQuery('big')
+
+      expect(options()).toHaveLength(50)
+    })
+
+    it('shows "No matches" when results are empty', async () => {
+      searchSpy.mockResolvedValueOnce(listResponse([]))
+      factory()
+      await typeQuery('nothing')
+
+      const hint = document.querySelector('.cmdk-hint')?.textContent?.trim()
+      expect(hint).toBe('No matches')
+    })
+
+    it('shows error message on search failure', async () => {
+      searchSpy.mockRejectedValueOnce(new Error('network down'))
+      factory()
+      await typeQuery('foo')
+
+      const hint = document.querySelector('.cmdk-hint')?.textContent?.trim()
+      expect(hint).toBe('Search failed')
+    })
+
+    it('keeps previous results visible while a refetch is in flight', async () => {
+      searchSpy.mockResolvedValueOnce(
+        listResponse([makeEntity({ id: 'first', _title: 'First' })])
+      )
+      factory()
+      await typeQuery('fi')
+      expect(options()).toHaveLength(1)
+
+      // Trigger a second search but don't resolve it.
+      let resolveSecond: (value: ListResponse<Entity>) => void = () => {}
+      searchSpy.mockImplementationOnce(
+        () =>
+          new Promise<ListResponse<Entity>>((resolve) => {
+            resolveSecond = resolve
+          })
+      )
+      input().value = 'fix'
+      input().dispatchEvent(new Event('input'))
+      await flushPromises()
+      vi.advanceTimersByTime(150)
+      await flushPromises()
+
+      // Previous results still visible (no flicker).
+      expect(options()).toHaveLength(1)
+      expect(document.querySelector('.cmdk-spinner')).not.toBeNull()
+
+      // Resolve the second request — results swap.
+      resolveSecond(
+        listResponse([
+          makeEntity({ id: 'a' }),
+          makeEntity({ id: 'b' }),
+        ])
+      )
+      await flushPromises()
+      expect(options()).toHaveLength(2)
+    })
+
+    it('aborts the previous request when a new one is issued', async () => {
+      const seenSignals: AbortSignal[] = []
+      searchSpy.mockImplementation(
+        async (
+          _q: string,
+          _t?: string,
+          signal?: AbortSignal
+        ): Promise<ListResponse<Entity>> => {
+          if (signal) seenSignals.push(signal)
+          return listResponse([])
+        }
+      )
+      factory()
+
+      await typeQuery('aa')
+      await typeQuery('aab')
+
+      expect(seenSignals).toHaveLength(2)
+      // First signal was aborted before the second request was issued.
+      expect(seenSignals[0].aborted).toBe(true)
+      expect(seenSignals[1].aborted).toBe(false)
+    })
+
+    it('cancels in-flight request and timer on unmount', async () => {
+      let resolveFn: (value: ListResponse<Entity>) => void = () => {}
+      const seenSignals: AbortSignal[] = []
+      searchSpy.mockImplementationOnce(
+        (_q: string, _t?: string, signal?: AbortSignal) =>
+          new Promise<ListResponse<Entity>>((resolve) => {
+            if (signal) seenSignals.push(signal)
+            resolveFn = resolve
+          })
+      )
+      const wrapper = factory()
+      input().value = 'foo'
+      input().dispatchEvent(new Event('input'))
+      await flushPromises()
+      vi.advanceTimersByTime(150)
+      await flushPromises()
+
+      expect(seenSignals[0].aborted).toBe(false)
+      wrapper.unmount()
+      expect(seenSignals[0].aborted).toBe(true)
+
+      // Even if the request resolves after unmount, no error is thrown.
+      resolveFn(listResponse([makeEntity()]))
+      await flushPromises()
+    })
+  })
+
+  describe('keyboard navigation', () => {
+    async function setupWithResults(n: number) {
+      const entities = Array.from({ length: n }, (_, i) =>
+        makeEntity({ id: `E-${i}`, _title: `Entity ${i}` })
+      )
+      searchSpy.mockResolvedValueOnce(listResponse(entities))
+      const wrapper = factory()
+      await typeQuery('ee')
+      return { wrapper, entities }
+    }
+
+    it('ArrowDown moves highlight forward', async () => {
+      const { wrapper } = await setupWithResults(3)
+      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      await flushPromises()
+      expect(options()[1].classList.contains('cmdk-option-active')).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('ArrowDown wraps from last to first', async () => {
+      const { wrapper } = await setupWithResults(3)
+      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      await flushPromises()
+      expect(options()[0].classList.contains('cmdk-option-active')).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('ArrowUp wraps from first to last', async () => {
+      const { wrapper } = await setupWithResults(3)
+      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }))
+      await flushPromises()
+      expect(options()[2].classList.contains('cmdk-option-active')).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('ArrowDown does not crash with empty results', async () => {
+      factory()
+      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      await flushPromises()
+      // No throw, no options rendered.
+      expect(options()).toHaveLength(0)
+    })
+
+    it('aria-activedescendant matches highlighted option id', async () => {
+      const { wrapper, entities } = await setupWithResults(2)
+      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      await flushPromises()
+      const expected = `cmdk-option-${entities[1].id}`
+      expect(input().getAttribute('aria-activedescendant')).toBe(expected)
+      expect(options()[1].id).toBe(expected)
+      wrapper.unmount()
+    })
+
+    it('Enter navigates to the highlighted entity and emits close', async () => {
+      const { wrapper, entities } = await setupWithResults(2)
+      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      await flushPromises()
+      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      await flushPromises()
+
+      expect(routerPush).toHaveBeenCalledWith(`/entity/${entities[1].type}/${entities[1].id}`)
+      expect(wrapper.emitted('close')).toHaveLength(1)
+      wrapper.unmount()
+    })
+
+    it('Enter is a no-op when results are empty', async () => {
+      const wrapper = factory()
+      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      await flushPromises()
+      expect(routerPush).not.toHaveBeenCalled()
+      expect(wrapper.emitted('close')).toBeUndefined()
+    })
+
+    it('Escape emits close and stops propagation', async () => {
+      const wrapper = factory()
+      const event = new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      })
+      const stopSpy = vi.spyOn(event, 'stopPropagation')
+      input().dispatchEvent(event)
+      await flushPromises()
+
+      expect(stopSpy).toHaveBeenCalled()
+      expect(wrapper.emitted('close')).toHaveLength(1)
+      expect(routerPush).not.toHaveBeenCalled()
+    })
+
+    it('Tab is preventDefault’d so focus stays on the input', async () => {
+      factory()
+      await flushPromises()
+      // After mount with open=true the input is auto-focused (immediate watcher).
+      expect(document.activeElement).toBe(input())
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'Tab',
+        bubbles: true,
+        cancelable: true,
+      })
+      input().dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(true)
+      expect(document.activeElement).toBe(input())
+    })
+  })
+
+  describe('selection', () => {
+    it('clicking a result navigates and emits close', async () => {
+      searchSpy.mockResolvedValueOnce(
+        listResponse([makeEntity({ id: 'X-1', type: 'ticket' })])
+      )
+      const wrapper = factory()
+      await typeQuery('xx')
+
+      options()[0].click()
+      await flushPromises()
+
+      expect(routerPush).toHaveBeenCalledWith('/entity/ticket/X-1')
+      expect(wrapper.emitted('close')).toHaveLength(1)
+    })
+
+    it('uses custom detail view when configured for the entity type', async () => {
+      const schemaStore = useSchemaStore()
+      schemaStore.entityViewConfigs.set('ticket', {
+        detail_view: 'ticket-detail',
+      } as never)
+
+      searchSpy.mockResolvedValueOnce(
+        listResponse([makeEntity({ id: 'X-2', type: 'ticket' })])
+      )
+      factory()
+      await typeQuery('xx')
+
+      options()[0].click()
+      await flushPromises()
+
+      expect(routerPush).toHaveBeenCalledWith('/view/ticket-detail/X-2')
+    })
+
+    it('does not navigate when entity has no type (empty href)', async () => {
+      searchSpy.mockResolvedValueOnce(
+        listResponse([makeEntity({ id: 'X-3', type: '' })])
+      )
+      const wrapper = factory()
+      await typeQuery('xx')
+
+      options()[0].click()
+      await flushPromises()
+
+      expect(routerPush).not.toHaveBeenCalled()
+      expect(wrapper.emitted('close')).toBeUndefined()
+    })
+  })
+
+  describe('overlay click', () => {
+    it('emits close when backdrop is clicked', () => {
+      const wrapper = factory()
+      const overlay = document.querySelector<HTMLElement>('.cmdk-overlay')!
+      overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      expect(wrapper.emitted('close')).toHaveLength(1)
+    })
+
+    it('does not emit close when clicking inside the modal', () => {
+      const wrapper = factory()
+      const modal = document.querySelector<HTMLElement>('.cmdk-modal')!
+      modal.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      expect(wrapper.emitted('close')).toBeUndefined()
+    })
+  })
+})

--- a/frontend/src/components/ui/CommandPaletteModal.vue
+++ b/frontend/src/components/ui/CommandPaletteModal.vue
@@ -177,6 +177,20 @@ function moveHighlight(delta: number): void {
     return
   }
   highlightedIndex.value = (highlightedIndex.value + delta + len) % len
+  scrollHighlightedIntoView()
+}
+
+// Keep the highlighted option in view as the user arrow-keys through long
+// result lists. `block: 'nearest'` no-ops when the option is already visible,
+// so the listbox doesn't jiggle on every move — only on actual overshoot.
+// Called from keyboard handlers only; mouseenter sets highlightedIndex
+// directly without scrolling so hovering doesn't fight with the user's mouse.
+function scrollHighlightedIntoView(): void {
+  void nextTick(() => {
+    const entity = results.value[highlightedIndex.value]
+    if (!entity) return
+    document.getElementById(optionId(entity))?.scrollIntoView({ block: 'nearest' })
+  })
 }
 
 function handleKeydown(e: KeyboardEvent): void {

--- a/frontend/src/components/ui/CommandPaletteModal.vue
+++ b/frontend/src/components/ui/CommandPaletteModal.vue
@@ -1,0 +1,413 @@
+<script setup lang="ts">
+/**
+ * Quick-jump command palette.
+ *
+ * Cmd/Ctrl+K opens this from anywhere in the SPA. Type a few characters of an
+ * entity title or ID, ArrowUp/ArrowDown to highlight, Enter to navigate. Esc
+ * or backdrop click closes. Mirrors ConfirmModal's focus-restore lifecycle
+ * and registers with the shared modal stack so list-shortcut handlers stand
+ * down while it's open.
+ *
+ * Escape uses stopPropagation() — without it the global useKeyboardShortcuts
+ * Escape branch fires next and may invoke router.back() on form pages.
+ *
+ * Tab and Shift+Tab are preventDefault'd on the dialog so focus cannot escape
+ * behind the overlay (we don't have a generic useFocusTrap composable yet).
+ */
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { searchEntities } from '@/api'
+import { useSchemaStore } from '@/stores'
+import { useModalStack } from '@/composables/modalStack'
+import { isCancelledFetch } from '@/composables/usePageData'
+import { entityDetailHref } from '@/utils/entityRoute'
+import type { Entity } from '@/types'
+
+// Perceptually-instant on a fast connection; tune up if the API is slow.
+const DEBOUNCE_MS = 150
+// Minimum characters before we hit /_search. 1-letter queries return
+// thousands of unrelated results in any non-trivial project.
+const MIN_QUERY_LEN = 2
+// Cap rendered options regardless of what the backend returns. Avoids OOMing
+// the browser when the user types a common letter and the backend has no
+// per_page on /_search yet.
+const MAX_RESULTS = 50
+
+const props = defineProps<{
+  open: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const router = useRouter()
+const schemaStore = useSchemaStore()
+
+const query = ref('')
+const results = ref<Entity[]>([])
+const highlightedIndex = ref(0)
+const loading = ref(false)
+const errorMsg = ref('')
+
+const inputRef = ref<HTMLInputElement | null>(null)
+const previouslyFocused = ref<HTMLElement | null>(null)
+
+// 8-char random suffix so multiple Teleport-mounted listboxes don't collide.
+const listboxId = `cmdk-listbox-${Math.random().toString(36).slice(2, 10)}`
+const optionId = (entity: Entity) => `cmdk-option-${entity.id}`
+
+const activeDescendant = computed(() => {
+  const r = results.value[highlightedIndex.value]
+  return r ? optionId(r) : undefined
+})
+
+useModalStack(computed(() => props.open))
+
+let abort: AbortController | null = null
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+function cancelInflight(): void {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer)
+    debounceTimer = null
+  }
+  abort?.abort()
+  abort = null
+}
+
+watch(query, (q) => {
+  cancelInflight()
+  const trimmed = q.trim()
+  if (trimmed.length < MIN_QUERY_LEN) {
+    results.value = []
+    loading.value = false
+    errorMsg.value = ''
+    highlightedIndex.value = 0
+    return
+  }
+  debounceTimer = setTimeout(() => {
+    void runSearch(trimmed)
+  }, DEBOUNCE_MS)
+})
+
+async function runSearch(q: string): Promise<void> {
+  abort = new AbortController()
+  loading.value = true
+  try {
+    const resp = await searchEntities(q, undefined, abort.signal)
+    // Replace results only on success — keep stale results visible until
+    // the new ones arrive, to avoid flicker.
+    results.value = resp.data.slice(0, MAX_RESULTS)
+    errorMsg.value = ''
+    highlightedIndex.value = 0
+  } catch (err: unknown) {
+    if (isCancelledFetch(err)) return
+    errorMsg.value = 'Search failed'
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => props.open,
+  (isOpen, wasOpen) => {
+    if (isOpen && !wasOpen) {
+      query.value = ''
+      results.value = []
+      highlightedIndex.value = 0
+      errorMsg.value = ''
+      loading.value = false
+      previouslyFocused.value = (document.activeElement as HTMLElement) ?? null
+      // Sync flush means the v-if has already swapped — wait one tick for
+      // the input ref to be populated, then focus it.
+      void nextTick(() => inputRef.value?.focus())
+    } else if (!isOpen && wasOpen) {
+      cancelInflight()
+      const prev = previouslyFocused.value
+      previouslyFocused.value = null
+      if (prev?.isConnected) {
+        prev.focus()
+      }
+    }
+  },
+  // flush: 'sync' so a rapid open: true → false → true sequence sees both
+  // transitions instead of the post-flush watcher coalescing to the latest.
+  { immediate: true, flush: 'sync' }
+)
+
+// Cleans up after teardown when the component unmounts while still open
+// (HMR, route-mounted variants, etc.). The watcher above only fires its
+// cleanup on an open→closed transition; without this hook a pending timer
+// or fetch would outlive the component.
+onBeforeUnmount(() => {
+  cancelInflight()
+  previouslyFocused.value = null
+})
+
+function entityLabel(entity: Entity): string {
+  if (typeof entity._title === 'string' && entity._title !== '') return entity._title
+  const t = entity.properties?.title
+  if (typeof t === 'string' && t !== '') return t
+  return entity.id
+}
+
+function entityTypeLabel(type: string): string {
+  if (!type) return 'Unknown'
+  return schemaStore.entityTypes.get(type)?.label || type
+}
+
+function selectEntity(entity: Entity): void {
+  const href = entityDetailHref(entity, (t) => schemaStore.getEntityDetailView(t))
+  if (!href) return
+  router.push(href)
+  emit('close')
+}
+
+function handleOverlayClick(e: MouseEvent): void {
+  if (e.target === e.currentTarget) {
+    emit('close')
+  }
+}
+
+function moveHighlight(delta: number): void {
+  const len = results.value.length
+  if (len === 0) {
+    highlightedIndex.value = 0
+    return
+  }
+  highlightedIndex.value = (highlightedIndex.value + delta + len) % len
+}
+
+function handleKeydown(e: KeyboardEvent): void {
+  switch (e.key) {
+    case 'Escape':
+      // Block the global useKeyboardShortcuts Escape branch from firing
+      // (would otherwise call router.back() on form routes).
+      e.stopPropagation()
+      emit('close')
+      return
+    case 'Enter': {
+      const selected = results.value[highlightedIndex.value]
+      if (selected) {
+        e.preventDefault()
+        selectEntity(selected)
+      }
+      return
+    }
+    case 'ArrowDown':
+      e.preventDefault()
+      moveHighlight(1)
+      return
+    case 'ArrowUp':
+      e.preventDefault()
+      moveHighlight(-1)
+      return
+    case 'Tab':
+      // Pin focus on the input. The palette has only one focusable element
+      // today, so a real focus trap would be overkill; preventDefault keeps
+      // focus from leaking behind the overlay. When more controls are added
+      // (clear button, filter chips), swap this for a proper focus trap.
+      e.preventDefault()
+      return
+  }
+}
+
+const showEmptyHint = computed(
+  () =>
+    query.value.trim().length < MIN_QUERY_LEN &&
+    results.value.length === 0 &&
+    !loading.value
+)
+const showNoMatches = computed(
+  () =>
+    query.value.trim().length >= MIN_QUERY_LEN &&
+    !loading.value &&
+    results.value.length === 0 &&
+    !errorMsg.value
+)
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="cmdk-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Quick jump"
+      @click="handleOverlayClick"
+      @keydown="handleKeydown"
+    >
+      <div class="cmdk-modal">
+        <div class="cmdk-input-wrap">
+          <input
+            ref="inputRef"
+            v-model="query"
+            type="text"
+            class="cmdk-input"
+            placeholder="Type to search entities…"
+            autocomplete="off"
+            spellcheck="false"
+            role="combobox"
+            aria-autocomplete="list"
+            :aria-controls="listboxId"
+            :aria-expanded="results.length > 0"
+            :aria-activedescendant="activeDescendant"
+          />
+          <span v-if="loading" class="cmdk-spinner" aria-hidden="true" />
+        </div>
+
+        <div v-if="showEmptyHint" class="cmdk-hint">Type to search entities</div>
+        <div v-else-if="errorMsg" class="cmdk-hint cmdk-error">{{ errorMsg }}</div>
+        <div v-else-if="showNoMatches" class="cmdk-hint">No matches</div>
+
+        <ul
+          v-if="results.length > 0"
+          :id="listboxId"
+          class="cmdk-results"
+          role="listbox"
+        >
+          <li
+            v-for="(entity, idx) in results"
+            :id="optionId(entity)"
+            :key="entity.id"
+            class="cmdk-option"
+            :class="{ 'cmdk-option-active': idx === highlightedIndex }"
+            role="option"
+            :aria-selected="idx === highlightedIndex"
+            @click="selectEntity(entity)"
+            @mouseenter="highlightedIndex = idx"
+          >
+            <span class="cmdk-type">{{ entityTypeLabel(entity.type) }}</span>
+            <span class="cmdk-title">{{ entityLabel(entity) }}</span>
+            <span class="cmdk-id">{{ entity.id }}</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.cmdk-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+  z-index: 1000;
+}
+
+.cmdk-modal {
+  background: var(--card-bg);
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+  width: 90%;
+  max-width: 640px;
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.cmdk-input-wrap {
+  position: relative;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.cmdk-input {
+  width: 100%;
+  padding: 16px 44px 16px 18px;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text-color);
+  font-size: 16px;
+  font-family: inherit;
+}
+
+.cmdk-spinner {
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--border-color);
+  border-top-color: var(--accent-color);
+  border-radius: 50%;
+  animation: cmdk-spin 0.8s linear infinite;
+}
+
+@keyframes cmdk-spin {
+  to {
+    transform: translateY(-50%) rotate(360deg);
+  }
+}
+
+.cmdk-hint {
+  padding: 24px 18px;
+  color: var(--muted-text);
+  font-size: 14px;
+  text-align: center;
+}
+
+.cmdk-error {
+  color: var(--error-color);
+}
+
+.cmdk-results {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  overflow-y: auto;
+  max-height: calc(70vh - 60px);
+}
+
+.cmdk-option {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 18px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.cmdk-option-active {
+  background: var(--hover-bg);
+}
+
+.cmdk-type {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  background: var(--hover-bg);
+  color: var(--muted-text);
+  border-radius: 4px;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.cmdk-option-active .cmdk-type {
+  background: var(--card-bg);
+}
+
+.cmdk-title {
+  flex: 1;
+  color: var(--text-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cmdk-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  color: var(--muted-text);
+  flex-shrink: 0;
+}
+</style>

--- a/frontend/src/components/ui/KeyboardShortcutsModal.vue
+++ b/frontend/src/components/ui/KeyboardShortcutsModal.vue
@@ -18,6 +18,7 @@ const shortcuts = computed(() => [
     items: [
       { keys: '?', description: 'Show keyboard shortcuts' },
       { keys: '/', description: 'Focus search' },
+      { keys: `${mod.value} + K`, description: 'Quick jump' },
       { keys: 'Esc', description: 'Close modal / cancel' },
     ],
   },

--- a/frontend/src/composables/index.ts
+++ b/frontend/src/composables/index.ts
@@ -1,5 +1,5 @@
 /* v8 ignore start - re-exports only */
-export { useKeyboardShortcuts, shortcutsModalOpen } from './useKeyboardShortcuts'
+export { useKeyboardShortcuts, shortcutsModalOpen, paletteOpen } from './useKeyboardShortcuts'
 export { useListKeyboard } from './useListKeyboard'
 export { useEvents } from './useEvents'
 export type { SSEEventType, EntityEventData, SSEConnectionState } from './useEvents'

--- a/frontend/src/composables/useKeyboardShortcuts.test.ts
+++ b/frontend/src/composables/useKeyboardShortcuts.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { defineComponent, nextTick } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
-import { shortcutsModalOpen, useKeyboardShortcuts } from './useKeyboardShortcuts'
+import { paletteOpen, shortcutsModalOpen, useKeyboardShortcuts } from './useKeyboardShortcuts'
+import { _resetModalStack, registerModal } from './modalStack'
 
 // Helper to create a keyboard event
 function createKeyEvent(key: string, options: Partial<KeyboardEvent> = {}): KeyboardEvent {
@@ -24,6 +25,8 @@ describe('useKeyboardShortcuts', () => {
   beforeEach(() => {
     // Reset modal state
     shortcutsModalOpen.value = false
+    paletteOpen.value = false
+    _resetModalStack()
 
     // Create router with routes
     router = createRouter({
@@ -208,8 +211,8 @@ describe('useKeyboardShortcuts', () => {
     })
   })
 
-  describe('meta key shortcuts', () => {
-    it('handles Cmd+K (reserved for command palette)', async () => {
+  describe('command palette (Cmd/Ctrl+K)', () => {
+    it('opens the palette on Cmd+K', async () => {
       await mountWithRouter()
 
       const event = createKeyEvent('k', { metaKey: true })
@@ -218,9 +221,10 @@ describe('useKeyboardShortcuts', () => {
       document.dispatchEvent(event)
 
       expect(preventDefaultSpy).toHaveBeenCalled()
+      expect(paletteOpen.value).toBe(true)
     })
 
-    it('handles Ctrl+K (reserved for command palette)', async () => {
+    it('opens the palette on Ctrl+K', async () => {
       await mountWithRouter()
 
       const event = createKeyEvent('k', { ctrlKey: true })
@@ -229,6 +233,67 @@ describe('useKeyboardShortcuts', () => {
       document.dispatchEvent(event)
 
       expect(preventDefaultSpy).toHaveBeenCalled()
+      expect(paletteOpen.value).toBe(true)
+    })
+
+    it('opens even when an input is focused (bypasses isInputFocused)', async () => {
+      await mountWithRouter()
+
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+
+      document.dispatchEvent(createKeyEvent('k', { metaKey: true }))
+
+      expect(paletteOpen.value).toBe(true)
+
+      document.body.removeChild(input)
+    })
+
+    it('is idempotent when palette is already open', async () => {
+      await mountWithRouter()
+
+      document.dispatchEvent(createKeyEvent('k', { metaKey: true }))
+      expect(paletteOpen.value).toBe(true)
+
+      // Second press: still open, no flip-flop.
+      document.dispatchEvent(createKeyEvent('k', { metaKey: true }))
+      expect(paletteOpen.value).toBe(true)
+    })
+
+    it('opens even when another modal is registered (Cmd+K bypasses the modal-stack gate)', async () => {
+      await mountWithRouter()
+      registerModal(Symbol('confirm'))
+
+      document.dispatchEvent(createKeyEvent('k', { metaKey: true }))
+      expect(paletteOpen.value).toBe(true)
+    })
+  })
+
+  describe('modal-stack gate', () => {
+    it('global handlers stand down while any modal is registered', async () => {
+      await mountWithRouter()
+      await router.push({ name: 'form-create', params: { id: 'test' } })
+      await nextTick()
+      registerModal(Symbol('palette'))
+
+      const backSpy = vi.spyOn(router, 'back')
+      const pushSpy = vi.spyOn(router, 'push')
+
+      // Escape on a form route — without the modal-stack gate this would
+      // call router.back(). With the gate it must not.
+      document.dispatchEvent(createKeyEvent('Escape'))
+      expect(backSpy).not.toHaveBeenCalled()
+
+      // ? would normally open the shortcuts modal. The gate suppresses it
+      // because another modal is already on the stack.
+      document.dispatchEvent(createKeyEvent('?'))
+      expect(shortcutsModalOpen.value).toBe(false)
+
+      // g-prefix nav also stands down.
+      document.dispatchEvent(createKeyEvent('g'))
+      document.dispatchEvent(createKeyEvent('d'))
+      expect(pushSpy).not.toHaveBeenCalled()
     })
   })
 

--- a/frontend/src/composables/useKeyboardShortcuts.ts
+++ b/frontend/src/composables/useKeyboardShortcuts.ts
@@ -1,6 +1,7 @@
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { isInputFocused } from '@/utils/dom'
+import { isAnyModalOpen } from './modalStack'
 
 /**
  * Shared state for keyboard shortcuts modal.
@@ -11,6 +12,10 @@ import { isInputFocused } from '@/utils/dom'
  * 3. Multiple components may need to check/toggle this state
  */
 export const shortcutsModalOpen = ref(false)
+
+// Module-level ref so the global Cmd+K handler can flip it and the App-level
+// CommandPaletteModal can react. Same single-instance rationale as above.
+export const paletteOpen = ref(false)
 
 /**
  * Global keyboard shortcuts composable.
@@ -34,12 +39,20 @@ export function useKeyboardShortcuts() {
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    // Cmd/Ctrl+K: reserved for command palette (future)
+    // Cmd/Ctrl+K opens the command palette. Bypasses isInputFocused and
+    // isAnyModalOpen on purpose — users expect the palette to open from
+    // anywhere, including form fields and on top of other modals.
+    // Idempotent: already-open is a no-op.
     if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
       e.preventDefault()
-      // TODO: implement command palette
+      paletteOpen.value = true
       return
     }
+
+    // Stand down while any modal is open. The modal owns its own keyboard
+    // semantics (Escape to close, etc.); we must not double-handle Escape
+    // and accidentally trigger router.back() on a form page underneath.
+    if (isAnyModalOpen()) return
 
     // Escape: close shortcuts modal first
     if (e.key === 'Escape') {
@@ -126,5 +139,6 @@ export function useKeyboardShortcuts() {
 
   return {
     shortcutsModalOpen,
+    paletteOpen,
   }
 }

--- a/tickets/entities/docs-checklists/DOCS-TM2LG.md
+++ b/tickets/entities/docs-checklists/DOCS-TM2LG.md
@@ -1,0 +1,29 @@
+---
+id: DOCS-TM2LG
+type: docs-checklist
+title: 'Documentation: Quick-search/jump command palette'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] New component has a top-of-file comment explaining purpose, behavior, and notable design decisions (focus restoration, Escape stopPropagation, Tab trap rationale).
+- [x] `searchEntities` JSDoc explains the new optional `signal: AbortSignal` parameter and its use case.
+- [x] Tab handler comment documents the limitation: "When more controls are added (clear button, filter chips), swap this for a proper focus trap."
+- [x] Named constants (`DEBOUNCE_MS`, `MIN_QUERY_LEN`, `MAX_RESULTS`) carry inline justifications.
+
+## Project Documentation
+
+- [x] In-app keyboard-shortcuts modal (`KeyboardShortcutsModal.vue`) — new row "Cmd/Ctrl+K — Quick jump" under Global section. This is the user-facing reference for the SPA's keyboard surface.
+- [x] ~~User guide / reference docs~~ (N/A: no separate user guide for the SPA)
+- [x] ~~CLI help text~~ (N/A: no CLI surface)
+- [x] ~~CLAUDE.md~~ (N/A: no new patterns introduced; uses existing modalStack + ConfirmModal patterns)
+- [x] ~~README.md~~ (N/A: no project-level changes)
+
+## External Documentation
+
+- [x] ~~Public API documentation~~ (N/A: no public API change. The `searchEntities` signature change is frontend-internal — `/api/v1/_search` is unchanged.)
+- [x] ~~Migration notes~~ (N/A: additive feature; no breaking changes)
+- [x] ~~Changelog~~ (N/A: project does not maintain a changelog file)

--- a/tickets/entities/implementation-checklists/IMPL-OSH68.md
+++ b/tickets/entities/implementation-checklists/IMPL-OSH68.md
@@ -1,0 +1,78 @@
+---
+id: IMPL-OSH68
+type: implementation-checklist
+title: 'Implementation: Quick-search/jump command palette for data-entry UI'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (31 component tests in `CommandPaletteModal.test.ts`, 4 new tests in `useKeyboardShortcuts.test.ts`)
+- [x] Integration tests written (modal-stack registration, focus restoration, debounced search, AbortController forwarding, custom-detail-view routing)
+- [x] Happy path implemented (Cmd+K → palette → type → ArrowDown → Enter → navigate)
+- [x] Edge cases from planning handled (empty query, whitespace-only query, network failure, race on rapid typing, in-flight refetch flicker, missing _title, custom detail view, Cmd+K idempotency, Tab trapping)
+- [x] Error handling in place (network failures show "Search failed" inline; abort errors silently swallowed via shared `isCancelledFetch`)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data (`makeEntity`, `listResponse`, `seedSchema` helpers)
+- [x] No hardcoded values in assertions when object is in scope (most tests use `entities[1].id`, `entities[1].type`)
+- [x] Only specifying values that matter for the test (`makeEntity` auto-generates IDs when not given)
+- [x] Interpolated values constructed from objects, not hardcoded (`/entity/${entities[1].type}/${entities[1].id}`)
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (`rela-server -port 8901 -project tickets/`, puppeteer-driven SPA interaction)
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified (backdrop click, Escape from focused input, route navigation)
+
+**Verification Evidence:**
+
+Manual smoke test against `rela-server` on port 8901 with the project's own
+`tickets/` folder (828 entities, 928 relations) using Puppeteer:
+
+| AC | Verified behavior |
+|----|-------------------|
+| AC1 | `Cmd+K` from `/v2/` opened the palette modal. `.cmdk-overlay` appeared, input received focus. |
+| AC2 | Re-tested with focus on a `<input>` outside the palette — Cmd+K still opened it (bypass works). |
+| AC3 | Typed "palette" into the input; debounced fetch returned 14 hits; results rendered (TKT-77JD4 first, with title, type label "Ticket", and ID column). |
+| AC4 | ArrowDown advanced highlight; deterministic re-test confirmed `aria-activedescendant === activeRowId` after re-renders complete. |
+| AC5 | Pressed Enter on highlighted row → `location.pathname === '/entity/ticket/TKT-77JD4'`, palette closed. |
+| AC6 | Clicked first result → same navigation, palette closed. |
+| AC7 | Escape on focused input closed the palette (modal removed from DOM). Backdrop click also closed. |
+| AC8 | Re-opening after a search showed empty input again. |
+| AC9 | New row in `KeyboardShortcutsModal.vue` under Global section: "Cmd/Ctrl+K — Quick jump". |
+| AC10 | Modal-stack integration verified by `useModalStack(computed(() => props.open))` — covered by unit test asserting `isAnyModalOpen() === true` while open. |
+
+Final screenshot: palette centered, ticket types shown as left-aligned chips
+("TICKET", "PLANNING CHECKLIST", "REVIEW RESPONSE"), titles in the middle
+(truncated with ellipsis when long), entity IDs right-aligned in monospace.
+First row visibly highlighted via `--hover-bg`.
+
+## Quality
+
+- [x] Code follows project patterns (mirrors ConfirmModal: Teleport, modalStack, focus restore, stopPropagation on Escape)
+- [x] No security issues introduced (read-only navigation aid; query passed through existing trusted endpoint; rendered as text via `{{ }}`, never `v-html`)
+- [x] No silent failures (network errors surface "Search failed" inline; abort errors deliberately ignored via shared `isCancelledFetch`)
+- [x] No debug code left behind (removed temporary `console.log` from tests after diagnosing the v-model timing issue)
+
+## Files modified
+
+- `frontend/src/composables/useKeyboardShortcuts.ts` — added `paletteOpen` ref, replaced TODO with `paletteOpen.value = true`
+- `frontend/src/composables/useKeyboardShortcuts.test.ts` — replaced "reserved" tests with assertion-bearing palette-open tests
+- `frontend/src/composables/index.ts` — re-exported `paletteOpen`
+- `frontend/src/api/entities.ts` — extended `searchEntities` with optional `signal: AbortSignal`
+- `frontend/src/components/ui/CommandPaletteModal.vue` — new component (262 lines incl. styles)
+- `frontend/src/components/ui/CommandPaletteModal.test.ts` — new test file (31 tests)
+- `frontend/src/components/ui/KeyboardShortcutsModal.vue` — added Cmd/Ctrl+K row to Global section
+- `frontend/src/App.vue` — imported `paletteOpen` and `CommandPaletteModal`; mounted unconditionally next to `ConfirmModal`
+
+## Test results
+
+- `npm run test:run` → 643 passed (38 files)
+- `npm run typecheck` → clean
+- `npm run lint` → clean (0 errors; only pre-existing warnings unrelated to this change)
+- `just build` → frontend bundle + rela-server + rela-desktop all built clean

--- a/tickets/entities/planning-checklists/PLAN-DK28G.md
+++ b/tickets/entities/planning-checklists/PLAN-DK28G.md
@@ -1,0 +1,142 @@
+---
+id: PLAN-DK28G
+type: planning-checklist
+title: 'Planning: Quick-search/jump command palette for data-entry UI'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+In scope: a global `Cmd+K` / `Ctrl+K` modal that searches entities by
+title/ID/type, with up/down/Enter navigation and Esc/click-outside dismissal.
+Reachable from every data-entry route. Closes when an entity is selected and
+routes to that entity's detail view (respecting custom detail views).
+
+Out of scope: command actions (create/toggle), recents/pinned entries,
+dashboard/view targets, server-side ranking changes, customizable keybinding.
+
+**Acceptance Criteria:**
+
+See ticket TKT-77JD4 for the canonical AC1–AC10 list. Each is mapped to a test
+scenario in the Test Plan section below.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+See full list in earlier revision; key reuse: existing `searchEntities` endpoint
+(extended with optional `signal: AbortSignal`), `entityDetailHref`,
+`useModalStack`, `isCancelledFetch` from `usePageData.ts`. No new dependencies.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Implemented as `frontend/src/components/ui/CommandPaletteModal.vue` mirroring
+the ConfirmModal pattern (Teleport, modalStack registration, focus restore on
+close, Escape stopPropagation). `paletteOpen` ref lives in
+`useKeyboardShortcuts` and is flipped on Cmd/Ctrl+K. Search uses an
+AbortController per request, debounced at 150ms, with a 2-char minimum and
+client-side cap at 50 results. ARIA combobox/listbox pattern with
+`aria-activedescendant`.
+
+**Files modified:**
+
+- `frontend/src/composables/useKeyboardShortcuts.ts` — added `paletteOpen` ref + Cmd+K handler + `isAnyModalOpen()` short-circuit for non-trigger shortcuts.
+- `frontend/src/composables/useKeyboardShortcuts.test.ts` — extended.
+- `frontend/src/composables/index.ts` — re-exported `paletteOpen`.
+- `frontend/src/api/entities.ts` — extended `searchEntities` with optional `signal: AbortSignal` (with JSDoc).
+- `frontend/src/components/ui/CommandPaletteModal.vue` — new component (~270 lines).
+- `frontend/src/components/ui/CommandPaletteModal.test.ts` — new test file (34 tests).
+- `frontend/src/components/ui/KeyboardShortcutsModal.vue` — added Cmd/Ctrl+K row to Global section.
+- `frontend/src/App.vue` — mounted `<CommandPaletteModal>` next to `ConfirmModal`.
+
+**Dependencies:** None new.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- **Search query (user input):** sent verbatim as `q=` to the existing `/api/v1/_search` endpoint (already in production for the standalone Search page). Result fields are rendered as text via `{{ }}`, never `v-html`, so XSS via title/ID is not a concern.
+- **Entity ID/type from results:** passed to `entityDetailHref` which returns `''` for missing type/id; `selectEntity` early-returns on empty href before `router.push`.
+
+**Security-Sensitive Operations:** None. Read-only navigation aid.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+All 10 ACs have mapped test scenarios. 34 component tests + 4 composable tests
+cover happy path, debounce, AbortController forwarding, race conditions,
+in-flight refetch flicker prevention, custom detail views, idempotency, Tab
+trap, Escape stopPropagation, modal-stack integration, MAX_RESULTS cap,
+single-character query short-circuit, unmount cleanup.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Effort:** **m**. Final scope ended up slightly larger than estimated due to
+the cranky review round (added `isAnyModalOpen` gate, MAX_RESULTS cap, unmount
+cleanup) — still a single-day implementation.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] In-app shortcuts modal (`KeyboardShortcutsModal.vue`) — new row for Cmd+K (Quick jump)
+- [x] N/A: User guide / reference docs (no separate SPA user guide)
+- [x] N/A: CLI help text (no CLI surface)
+- [x] N/A: CLAUDE.md (no new patterns)
+- [x] N/A: README.md (no project-level changes)
+- [x] N/A: API docs (no API change — `searchEntities` signature change is frontend-internal)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings (pre-implementation):**
+
+| RR | Severity | Title | Status |
+|----|----------|-------|--------|
+| RR-4LHM6 | significant | Title field name: title vs _title | addressed |
+| RR-MP29E | significant | Escape must stopPropagation | addressed |
+| RR-HTS2Q | significant | Cmd+K idempotency when already open | addressed |
+| RR-2H6YE | significant | Tab key leaks focus to background | addressed |
+| RR-GMZZP | minor | Empty query must not call /_search | addressed |
+| RR-9IHU2 | minor | Prefer AbortController | addressed |
+| RR-R51D0 | minor | Don't blank results during refetch | addressed |
+| RR-QL4SD | minor | aria-activedescendant + per-row id | addressed |
+| RR-WQRYA | nit | Naming: command palette vs quick jump | addressed (user chose "Quick jump") |

--- a/tickets/entities/review-checklists/REV-2FKBJ.md
+++ b/tickets/entities/review-checklists/REV-2FKBJ.md
@@ -2,7 +2,7 @@
 id: REV-2FKBJ
 type: review-checklist
 title: 'Review: Quick-search/jump command palette for data-entry UI'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -28,8 +28,7 @@ Pre-implementation design-review (9):
 Post-implementation cranky review (17):
 - Critical (3): RR-4JTM7, RR-YWWAL, RR-9EEZO — addressed.
 - Significant (3): RR-5J4RI, RR-VC0UY, RR-2GL4R — addressed.
-- Minor (7): RR-AKGMZ, RR-GYUUF, RR-HW4EE, RR-WAGAP, RR-508T7, RR-198P7 (nit), RR-KQKRG (nit) — addressed.
-- Deferred / wont-fix (4): RR-VGS4J (deferred — extract on third modal), RR-K64Z9 (deferred — same), RR-FKKFB (deferred — mechanical move), RR-WA2H9 (wont-fix — pre-existing).
+- Minor / nit (10): RR-AKGMZ, RR-GYUUF, RR-HW4EE, RR-WAGAP, RR-508T7, RR-198P7, RR-KQKRG — addressed; RR-VGS4J, RR-K64Z9, RR-FKKFB — deferred (architectural follow-ups, not blocking); RR-WA2H9 — wont-fix (pre-existing, out of scope).
 
 ## Acceptance Verification
 
@@ -61,14 +60,15 @@ Post-implementation cranky review (17):
 
 ## Final Checks
 
-- [x] Commit message explains the why, not just what (drafted for the PR)
-- [x] No TODOs or FIXMEs left unaddressed (the original `// TODO: implement command palette` is removed)
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
 - [x] Ready for another developer to use
 
 ## Pull Request
 
-- [x] Run `/pr` command to create PR and monitor CI (next step)
-- [ ] All CI checks pass (pending PR creation)
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] PR created: https://github.com/sourcehaven-bv/rela/pull/652
+- [x] Branch: `feat/command-palette` based on `develop`
+- [x] All CI checks pass (verified before merge; ticket transitions to done are synchronized with the PR)
 
-**PR:** *(to be filled in after PR creation)*
+**PR:** https://github.com/sourcehaven-bv/rela/pull/652

--- a/tickets/entities/review-checklists/REV-2FKBJ.md
+++ b/tickets/entities/review-checklists/REV-2FKBJ.md
@@ -1,0 +1,74 @@
+---
+id: REV-2FKBJ
+type: review-checklist
+title: 'Review: Quick-search/jump command palette for data-entry UI'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test` — full backend race-enabled run, 0 failures; `npm run test:run` — 648 frontend tests, 0 failures)
+- [x] Lint clean (`just lint` — 0 issues; `npm run lint` — 0 errors, only pre-existing warnings unrelated to this change)
+- [x] Coverage maintained (`just coverage-check` — total 74.3%, package floors satisfied)
+
+## Code Review
+
+- [x] Run `/code-review` command (cranky-code-reviewer agent)
+- [x] All critical review-responses addressed (RR-4JTM7, RR-YWWAL, RR-9EEZO)
+- [x] All significant review-responses addressed (RR-5J4RI, RR-VC0UY, RR-2GL4R)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:**
+
+Pre-implementation design-review (9):
+- RR-4LHM6, RR-MP29E, RR-HTS2Q, RR-2H6YE, RR-GMZZP, RR-9IHU2, RR-R51D0, RR-QL4SD, RR-WQRYA — all addressed.
+
+Post-implementation cranky review (17):
+- Critical (3): RR-4JTM7, RR-YWWAL, RR-9EEZO — addressed.
+- Significant (3): RR-5J4RI, RR-VC0UY, RR-2GL4R — addressed.
+- Minor (7): RR-AKGMZ, RR-GYUUF, RR-HW4EE, RR-WAGAP, RR-508T7, RR-198P7 (nit), RR-KQKRG (nit) — addressed.
+- Deferred / wont-fix (4): RR-VGS4J (deferred — extract on third modal), RR-K64Z9 (deferred — same), RR-FKKFB (deferred — mechanical move), RR-WA2H9 (wont-fix — pre-existing).
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented in implementation checklist (IMPL-OSH68)
+
+**Acceptance Status:**
+
+| AC | Status | Evidence |
+|----|--------|----------|
+| AC1: Cmd+K opens palette from any route | PASS | `useKeyboardShortcuts.test.ts` + manual smoke (Puppeteer) |
+| AC2: Cmd+K bypasses isInputFocused | PASS | "opens even when an input is focused" test |
+| AC3: Debounced search by title/ID/type | PASS | "debounces search calls" test (3 keystrokes, 1 API call) |
+| AC4: Arrow keys with wrap | PASS | 3 dedicated tests (down, wrap, up-wrap) |
+| AC5: Enter navigates and closes | PASS | "Enter navigates to the highlighted entity" test |
+| AC6: Click navigates and closes | PASS | "clicking a result navigates and emits close" test + manual |
+| AC7: Esc/backdrop close, focus restored | PASS | 3 tests (Escape, backdrop click, focus restoration) |
+| AC8: Re-open starts clean | PASS | "resets query and highlightedIndex when re-opened" test |
+| AC9: Documented in shortcuts modal | PASS | "Cmd/Ctrl+K — Quick jump" row added |
+| AC10: List-shortcut suppression while open | PASS | modal-stack registration test + new isAnyModalOpen() gate |
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-TM2LG
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what (drafted for the PR)
+- [x] No TODOs or FIXMEs left unaddressed (the original `// TODO: implement command palette` is removed)
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI (next step)
+- [ ] All CI checks pass (pending PR creation)
+- [ ] PR URL documented below
+
+**PR:** *(to be filled in after PR creation)*

--- a/tickets/entities/review-responses/RR-198P7.md
+++ b/tickets/entities/review-responses/RR-198P7.md
@@ -1,0 +1,9 @@
+---
+id: RR-198P7
+type: review-response
+title: entityTypeLabel empty-string fallback renders empty chip
+finding: 'entityTypeLabel('''') returns '''' so the .cmdk-type chip renders as empty. selectEntity guards against missing type via entityRoute.ts:38, but the row still shows an empty chip. Fix: v-if guard or default to ''Unknown''.'
+severity: nit
+resolution: entityTypeLabel now returns 'Unknown' when the type is empty (e.g. malformed entity), so an empty .cmdk-type chip never renders.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-2GL4R.md
+++ b/tickets/entities/review-responses/RR-2GL4R.md
@@ -1,0 +1,9 @@
+---
+id: RR-2GL4R
+type: review-response
+title: Race when open prop oscillates rapidly (true→false→true)
+finding: 'watch(() => props.open, ...) does `await nextTick()` before focusing input. If parent flips open: true→false→true within one tick, Vue''s non-sync watcher fires once with latest value (true), the false transition is missed, and the reset/focus-restore code runs incorrectly (or not at all). Specifically: query/results aren''t reset, previouslyFocused isn''t updated. Cmd+K idempotency test doesn''t catch this because the second press doesn''t change paletteOpen. But Cmd+K → backdrop click → Cmd+K within one tick would. Fix: use { flush: ''sync'', immediate: true } on the watcher (verify focus-on-open test still passes; may need nextTick adjustment).'
+severity: significant
+resolution: 'Changed the open-watcher to { immediate: true, flush: ''sync'' }. Sync flush sees every transition individually so a rapid true→false→true sequence triggers reset+focus correctly. Manual smoke test with Cmd+K → backdrop click → Cmd+K confirmed clean state on each open.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-2H6YE.md
+++ b/tickets/entities/review-responses/RR-2H6YE.md
@@ -1,0 +1,9 @@
+---
+id: RR-2H6YE
+type: review-response
+title: Tab key behavior unspecified — no focus trap means Tab leaks to background
+finding: 'Plan skips a focus trap because useFocusTrap is not yet implemented. Defensible *if* Tab is handled — but the plan is silent. Without intervention, Tab from the palette input moves focus to the next tabbable element behind the modal overlay. The user then tabs around an invisible page while the palette stays open. Visually broken and a11y-broken. Simplest fix: handle Tab and Shift+Tab on the input with e.preventDefault() — palette has only one tabbable element + a listbox controlled via aria-activedescendant, so trapping Tab to the input is correct. Add: in Approach, list Tab/Shift+Tab among the keys handled on the input. Test: open palette, press Tab, assert document.activeElement is still the palette input.'
+severity: significant
+resolution: 'Plan updated: the input''s keydown handler calls e.preventDefault() on Tab and Shift+Tab so focus cannot escape the palette. Combined with aria-activedescendant on the input (RR-QL4SD), the palette is keyboard-trappable without a full useFocusTrap composable. Test added: open palette, press Tab and Shift+Tab, assert document.activeElement is still the palette input.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-4JTM7.md
+++ b/tickets/entities/review-responses/RR-4JTM7.md
@@ -1,0 +1,9 @@
+---
+id: RR-4JTM7
+type: review-response
+title: Double role="combobox" — invalid ARIA
+finding: 'CommandPaletteModal.vue:217 and :227 both carry role="combobox". ARIA 1.2 says one combobox per widget; the input owns it, the wrapping div is presentational. AT software (NVDA/VoiceOver) gets confused when nested combobox roles point at the same listbox via aria-controls. Fix: drop role="combobox", aria-controls, aria-haspopup, aria-expanded from the cmdk-modal div. Keep role="dialog" on the overlay; modal div has no ARIA role.'
+severity: critical
+resolution: Removed role="combobox", aria-controls, aria-haspopup, aria-expanded from the cmdk-modal div. Kept role="dialog" on the overlay, role="combobox" on the input only, and moved aria-expanded to the input where it semantically belongs. Now matches WAI-ARIA 1.2 combobox-with-listbox pattern correctly.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-4LHM6.md
+++ b/tickets/entities/review-responses/RR-4LHM6.md
@@ -1,0 +1,9 @@
+---
+id: RR-4LHM6
+type: review-response
+title: 'Title field name: title vs _title'
+finding: 'The plan says we''ll display each result''s title and fall back to ID. SearchView.vue:155 reads entity.properties.title. The Explore-agent survey says V1Entity JSON uses _title. These cannot both be right. If the plan picks the wrong field, every result row falls back to the ID for entities whose title is in fact populated. Required: read frontend/src/types/ Entity definition and a sample API response to confirm the canonical field. If both can occur, document an explicit fallback chain (entity._title ?? entity.properties.title ?? entity.id). Update the Approach section''s ''Render results'' bullet with the verified field name.'
+severity: significant
+resolution: 'Verified frontend/src/types/entity.ts:4 declares `_title?: string` as the server-populated display title (metamodel-aware). EntityList.vue:469 uses the precedence `_title || properties.title || id`, which is the canonical fallback chain in the codebase. Plan updated: render uses `entity._title || entity.properties?.title || entity.id`.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-508T7.md
+++ b/tickets/entities/review-responses/RR-508T7.md
@@ -1,0 +1,9 @@
+---
+id: RR-508T7
+type: review-response
+title: searchEntities signature change undocumented
+finding: 'frontend/src/api/entities.ts:42-51: a third optional `signal: AbortSignal` arg appears with no comment. Future devs will wonder why one search API takes a signal and the others don''t. Fix: add JSDoc on searchEntities explaining ''Pass an AbortSignal to cancel an in-flight request — used by the command palette to abort superseded searches.'''
+severity: minor
+resolution: Added JSDoc on searchEntities explaining the optional AbortSignal parameter and the command-palette use case for it.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-5J4RI.md
+++ b/tickets/entities/review-responses/RR-5J4RI.md
@@ -1,0 +1,9 @@
+---
+id: RR-5J4RI
+type: review-response
+title: useKeyboardShortcuts doesn't check isAnyModalOpen()
+finding: 'useKeyboardShortcuts.handleKeydown does NOT call isAnyModalOpen(). isInputFocused() papers over most cases, but the Escape branch is checked BEFORE isInputFocused and explicitly calls router.back() on form pages. The palette adds e.stopPropagation() to suppress this — works ONLY because the palette''s keydown handler is on the input. If focus ever drifts (future close button, browser quirk), Escape escapes the palette and triggers router.back() on the underlying form. useListActions:151 already checks isAnyModalOpen — useKeyboardShortcuts should too. Fix: add `if (isAnyModalOpen()) return` early in handleKeydown (after the Cmd+K branch, since Cmd+K must still work to *re*-open, and Escape must still work for ConfirmModal which already stopPropagates).'
+severity: significant
+resolution: 'Added `if (isAnyModalOpen()) return` early in useKeyboardShortcuts.handleKeydown, after the Cmd+K branch (so Cmd+K still works to open palette on top of any modal). New test suite ''modal-stack gate'' verifies that on a form-edit route with a modal registered: Escape doesn''t trigger router.back(), ? doesn''t open shortcuts modal, g-prefix nav doesn''t navigate.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-9EEZO.md
+++ b/tickets/entities/review-responses/RR-9EEZO.md
@@ -1,0 +1,9 @@
+---
+id: RR-9EEZO
+type: review-response
+title: Unbounded /_search results — palette will OOM the browser on common letters
+finding: 'internal/dataentry/api_v1.go:1034-1077 returns every matching entity with no per_page cap. Type a single common letter (''a'', ''e'') in a project with 5000+ entities and you''re rendering 5000 <li> nodes inside a 70vh listbox. Either add a limit query parameter to /_search (default 50) and pass limit=20 from the palette, or slice client-side: results.slice(0, 50). Also: short-circuit on queries shorter than 2 chars (1-letter queries return garbage anyway in a large project).'
+severity: critical
+resolution: 'Added two named constants: MIN_QUERY_LEN=2 (short-circuits the watcher before any API call) and MAX_RESULTS=50 (slices results client-side). New tests: ''does not call /_search for single-character queries'' and ''caps rendered results at MAX_RESULTS (50)'' (mocks 200 entities, asserts only 50 li nodes render). Backend per_page support is a follow-up; this caps the client side fully.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-9IHU2.md
+++ b/tickets/entities/review-responses/RR-9IHU2.md
@@ -1,0 +1,9 @@
+---
+id: RR-9IHU2
+type: review-response
+title: Prefer AbortController over sequence number for stale-request cancellation
+finding: 'Plan proposes a sequence-number guard for dropping stale searchEntities responses on rapid typing. Works, but axios (used by api.get) supports AbortController natively (axios 0.22+), which actually cancels in-flight HTTP requests, freeing the server early and avoiding rendering of cancelled-but-completed responses. Required: check frontend/src/api/client.ts to see if api.get accepts an AbortSignal. If yes, use AbortController in the palette and update plan accordingly. If no (and adding it is out of scope), keep the sequence number and document why.'
+severity: minor
+resolution: 'Verified frontend/src/api/client.ts:49-56 — api.get already accepts an optional `signal: AbortSignal` parameter. searchEntities will be extended with an optional third arg `signal?: AbortSignal` and forward it to api.get. Plan updated to use AbortController per request, aborting the previous in-flight call before issuing a new one.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-AKGMZ.md
+++ b/tickets/entities/review-responses/RR-AKGMZ.md
@@ -1,0 +1,9 @@
+---
+id: RR-AKGMZ
+type: review-response
+title: entityLabel inconsistent empty-string handling
+finding: 'CommandPaletteModal.vue:130-135. `if (entity._title)` treats explicit empty-string _title as missing (truthy check). Line 133 explicitly checks `t !== ''''` for properties.title. Inconsistent. Fix: use the same check on both lines: `if (entity._title && entity._title !== '''')` or just `if (typeof entity._title === ''string'' && entity._title !== '''')`.'
+severity: minor
+resolution: Aligned both branches of entityLabel to use `typeof x === 'string' && x !== ''` (was just truthy check on _title). Empty-string _title now falls through to properties.title instead of being treated as a valid title.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-FKKFB.md
+++ b/tickets/entities/review-responses/RR-FKKFB.md
@@ -1,0 +1,9 @@
+---
+id: RR-FKKFB
+type: review-response
+title: isCancelledFetch location is awkward (in usePageData.ts)
+finding: 'We import isCancelledFetch from @/composables/usePageData. The helper is exported and stable, but its location has nothing to do with usePageData''s lifecycle role. Fix: move to src/api/cancellation.ts (or src/utils/cancellation.ts) so future callers don''t pull in a usePageData import they don''t need. Defer; not blocking this ticket.'
+severity: nit
+reason: Nit-level. isCancelledFetch is already exported and stable; moving it is mechanical and unrelated to the palette feature. Track as cleanup for whoever adds the next AbortController-using consumer.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-GMZZP.md
+++ b/tickets/entities/review-responses/RR-GMZZP.md
@@ -1,0 +1,9 @@
+---
+id: RR-GMZZP
+type: review-response
+title: Empty query must not call /_search
+finding: 'Plan says ''when query is empty, show "Type to search entities"''. But the watcher described is just watch(query, debounce(searchEntities)). If wired naively, an empty query (after Backspace, or after re-opening the modal) fires searchEntities(''''). Backend behavior is undefined — likely 400 or unbounded results. Required: in Approach, state the debounced search guards ''if query.trim() === "" then results = [], return'' before the API call. Test: type ''abc'', clear with Backspace, advance timers, assert searchEntities was not called for the empty state.'
+severity: minor
+resolution: 'Plan updated: the debounced search effect early-returns when query.trim() === '''' — clears results, cancels any in-flight AbortController, and renders the ''Type to search entities'' hint without calling searchEntities. Test added in Edge Cases section.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GYUUF.md
+++ b/tickets/entities/review-responses/RR-GYUUF.md
@@ -1,0 +1,9 @@
+---
+id: RR-GYUUF
+type: review-response
+title: Tab trap will silently break a11y when more controls are added
+finding: 'CommandPaletteModal.vue:187-191. e.preventDefault() on Tab keeps focus on input — fine for the happy path with only one tabbable element. But the moment someone adds a ''Clear'' button or filter chips, the trap blocks them. Fix: add a comment + test documenting the limitation: ''Only one focusable element — keep focus pinned. When more controls are added, swap for a real focus trap (TKT-X4P99 useFocusTrap).'' Defer until needed.'
+severity: minor
+resolution: 'Updated the inline comment on the Tab handler to make the limitation explicit: ''When more controls are added (clear button, filter chips), swap this for a proper focus trap.'' Future maintainers will know to revisit.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-HTS2Q.md
+++ b/tickets/entities/review-responses/RR-HTS2Q.md
@@ -1,0 +1,9 @@
+---
+id: RR-HTS2Q
+type: review-response
+title: Cmd+K idempotency when palette is already open
+finding: 'Plan replaces the // TODO with paletteOpen.value = true but doesn''t specify behavior when Cmd+K is pressed while the palette is already open. Two reasonable behaviors: (1) no-op (recommended, matches ''?'' for shortcuts modal) or (2) toggle off. Lock one in with a test. Also pin behavior for Cmd+K while a ConfirmModal is open: palette opens on top (allowed; supported by Teleport + modalStack). Add tests for both cases. Implementation gives no-op for free since paletteOpen.value = true is idempotent — but the test prevents future regressions.'
+severity: significant
+resolution: 'Plan updated to specify no-op semantics when Cmd+K is pressed while the palette is already open (paletteOpen.value = true is idempotent — no watcher re-fire). Edge-cases section adds two tests: (1) press Cmd+K twice in sequence and assert the modal isn''t re-mounted (no transition), and (2) open ConfirmModal then press Cmd+K and assert palette opens on top with both registered in the modal stack.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-HW4EE.md
+++ b/tickets/entities/review-responses/RR-HW4EE.md
@@ -1,0 +1,9 @@
+---
+id: RR-HW4EE
+type: review-response
+title: mockReset wipes implementation; safer to mockClear + default
+finding: 'searchSpy.mockReset() in beforeEach (CommandPaletteModal.test.ts:90) wipes implementation AND queued mockResolvedValueOnce. Today no test triggers a search without queuing a value, but a future test might silently break (resp.data on undefined). Fix: use mockClear() in beforeEach and add a default `searchSpy.mockResolvedValue(listResponse([]))` so missing queues don''t blow up.'
+severity: minor
+resolution: Switched beforeEach from searchSpy.mockReset() to searchSpy.mockClear() and added a default `searchSpy.mockResolvedValue(listResponse([]))` so missing per-test queues don't crash on resp.data.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-K64Z9.md
+++ b/tickets/entities/review-responses/RR-K64Z9.md
@@ -1,0 +1,9 @@
+---
+id: RR-K64Z9
+type: review-response
+title: paletteOpen module-level ref is service-locator-y
+finding: 'useKeyboardShortcuts.ts defines paletteOpen at module scope, exports it, imports it in App.vue. Works for one global modal — shortcutsModalOpen and paletteOpen now make two; three would be a service locator. Fix: track as follow-up — extract useGlobalModals() composable or drive palette state via a Pinia store action when a third lands.'
+severity: nit
+reason: Nit-level. shortcutsModalOpen already follows the same module-level pattern; consistency with prior art beats a one-off refactor here. Revisit when a third global modal needs the same wiring — then extract useGlobalModals() or move to a Pinia store.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-KQKRG.md
+++ b/tickets/entities/review-responses/RR-KQKRG.md
@@ -1,0 +1,9 @@
+---
+id: RR-KQKRG
+type: review-response
+title: Magic 150ms debounce should be a named constant
+finding: 'CommandPaletteModal.vue:82 inlines 150 as a magic number. Fix: hoist to `const DEBOUNCE_MS = 150` at the top with a one-line comment (''perceptually-instant on a fast connection; tune up if API is slow'').'
+severity: nit
+resolution: Hoisted to const DEBOUNCE_MS = 150 with a one-line comment explaining tuning. Same treatment for MIN_QUERY_LEN and MAX_RESULTS (added together).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MP29E.md
+++ b/tickets/entities/review-responses/RR-MP29E.md
@@ -1,0 +1,9 @@
+---
+id: RR-MP29E
+type: review-response
+title: Escape handling must stopPropagation to avoid global handler firing
+finding: 'useKeyboardShortcuts.ts:44-61 has a global Escape branch that runs *before* the isInputFocused guard. While the palette is open with its input focused, an Escape keydown bubbles to the document handler which may try to blur() the now-removed input or router.back() on form pages. ConfirmModal solves this with e.stopPropagation() on Escape (lines 80-83). Required: in Approach, expand the keyboard handler description to call e.stopPropagation() on Escape, and e.preventDefault() on Arrow keys (caret movement). Add an integration test asserting Escape closes the palette without invoking router.back() on a form route.'
+severity: significant
+resolution: 'Plan updated: the input''s keydown handler now calls e.stopPropagation() on Escape (mirroring ConfirmModal:79-84) and e.preventDefault() on ArrowUp/ArrowDown/Tab/Shift+Tab. Added an integration test (AC7 + edge case ''Escape on form route'') asserting that opening the palette on /form/edit/... and pressing Escape emits close without invoking router.back().'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QL4SD.md
+++ b/tickets/entities/review-responses/RR-QL4SD.md
@@ -1,0 +1,9 @@
+---
+id: RR-QL4SD
+type: review-response
+title: 'ARIA listbox: aria-activedescendant + per-row id required'
+finding: 'Plan mentions role=listbox / role=option / aria-selected. For screen readers to announce the highlighted option without focus moving from the input, the WAI-ARIA combobox-with-listbox pattern requires the input to carry aria-activedescendant=<id-of-highlighted-option>, and each <li role=option> needs a unique stable id. Without aria-activedescendant, screen-reader users cannot perceive which result is highlighted. Required: in Approach, add aria-activedescendant wiring (input attribute bound to highlighted row''s id) and per-row id generation (e.g., cmdk-option-${entity.id}). Test: stub results, ArrowDown, assert input''s aria-activedescendant matches the second row''s id.'
+severity: minor
+resolution: 'Plan updated: each <li role=''option''> gets a stable id `cmdk-option-${entity.id}`; the <input> carries aria-activedescendant bound to the highlighted row''s id. Implements the WAI-ARIA combobox-with-listbox pattern. Test added: stub results, ArrowDown, assert input''s aria-activedescendant matches the second row''s id.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-R51D0.md
+++ b/tickets/entities/review-responses/RR-R51D0.md
@@ -1,0 +1,9 @@
+---
+id: RR-R51D0
+type: review-response
+title: Don't blank results during in-flight refetch (flicker)
+finding: 'Plan doesn''t specify the visual state during a debounced/in-flight refetch. If we clear results on every keystroke and only refill on response, the listbox flickers between empty and populated — palette feels stuttery. Required: in Approach, keep previous results visible during in-flight refetch; render a subtle loading indicator (small spinner in the input) instead of blanking the list. Clear results only on (a) new response arriving (replace) or (b) query becoming empty. Test: type ''a'', let response settle; type ''b'', advance timers but don''t resolve the second request — assert previous results still rendered and a loading hint visible.'
+severity: minor
+resolution: 'Plan updated: results.value is replaced only inside the success branch of the try block — the previous results stay rendered while a new request is in flight. A loading indicator (loading.value) is rendered alongside. Test added: type ''a'', resolve; type ''b'', advance timers but don''t resolve; assert previous results visible and loading=true.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-VC0UY.md
+++ b/tickets/entities/review-responses/RR-VC0UY.md
@@ -1,0 +1,9 @@
+---
+id: RR-VC0UY
+type: review-response
+title: Keydown handler bound to input only, not the dialog
+finding: 'CommandPaletteModal.vue:231 binds @keydown to <input>. ConfirmModal binds it to the overlay (ConfirmModal.vue:97). If focus ever leaves the input while palette is open, Escape/Arrow keys go nowhere. Today this is ''fine'' because Tab is preventDefault''d and clicks on options navigate-and-close — but it''s brittle (system overlay steals focus, screen-reader VO+arrow nav, future ''clear'' button). Fix: bind handler to the modal container or overlay so keydown bubbles up. Mirror ConfirmModal''s approach.'
+severity: significant
+resolution: 'Moved @keydown="handleKeydown" from the input to the .cmdk-overlay div so it catches keydown via bubbling regardless of which descendant is focused. Updated existing tests to dispatch with bubbles: true. Mirrors ConfirmModal:97 pattern.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-VGS4J.md
+++ b/tickets/entities/review-responses/RR-VGS4J.md
@@ -1,0 +1,9 @@
+---
+id: RR-VGS4J
+type: review-response
+title: Modal lifecycle pattern duplicated across ConfirmModal and CommandPaletteModal — extract
+finding: 'ConfirmModal and CommandPaletteModal now share Teleport, useModalStack(computed(() => props.open)), previouslyFocused capture/restore via watcher, Escape with stopPropagation, overlay click target===currentTarget guard, random-suffix ID for ARIA labelling. Five duplicated patterns. Fix: extract useModalLifecycle({ open, onClose, focusOnOpen }) when a third modal lands. Defer; current code is acceptable, but track as follow-up.'
+severity: minor
+reason: Not blocking. Two duplicates is acceptable; extract on the third modal. Tracked as architectural follow-up; revisit when a third modal type lands. The current code is small enough that DRY-prematurely would obscure intent.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-WA2H9.md
+++ b/tickets/entities/review-responses/RR-WA2H9.md
@@ -1,0 +1,9 @@
+---
+id: RR-WA2H9
+type: review-response
+title: schemaStore.getEntityDetailView misuses computed
+finding: 'stores/schema.ts:70: `computed(() => (type) => entityViewConfigs.value.get(type)?.detail_view)` — the outer computed body doesn''t read entityViewConfigs.value, only the inner closure does, at call time. The computed wrapper signals ''memoized derivation'' but provides neither memoization nor reactivity. It should just be a plain function on the store. Pre-existing code; not introduced here. Defer.'
+severity: nit
+reason: Pre-existing code in stores/schema.ts not introduced by this ticket. Calling it works correctly because the closure reads reactively at call time. Refactoring schema-store internals is out of scope for a frontend feature ticket; should be done in a focused store cleanup pass that touches all 'computed-returning-function' instances at once.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-WAGAP.md
+++ b/tickets/entities/review-responses/RR-WAGAP.md
@@ -1,0 +1,9 @@
+---
+id: RR-WAGAP
+type: review-response
+title: Inline cleanup in query watcher duplicates cancelInflight()
+finding: 'CommandPaletteModal.vue:68-83 clears the timer and aborts inline instead of calling cancelInflight(). Refactor for one source of truth: `cancelInflight()` at the top of the watcher; then the empty-query branch only handles results/loading state.'
+severity: minor
+resolution: Refactored the query watcher to call cancelInflight() at the top, eliminating the duplicated inline timer/abort cleanup. One source of truth for cancellation.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-WQRYA.md
+++ b/tickets/entities/review-responses/RR-WQRYA.md
@@ -1,0 +1,9 @@
+---
+id: RR-WQRYA
+type: review-response
+title: 'Naming: ''command palette'' implies actions; this iteration is entity-only'
+finding: 'Throughout the plan and the in-app KeyboardShortcutsModal row, the feature is called ''command palette''. In its current scope it has no commands — only entity navigation. ''Command palette'' sets expectations the iteration does not meet. The ticket title (''Quick-search/jump command palette'') already acknowledges this tension. Two choices: (a) keep ''command palette'' in code/UI (acknowledges this is the foundation for future commands), or (b) use ''Quick jump'' / ''Quick search'' in user-visible strings (KeyboardShortcutsModal) while keeping CommandPaletteModal.vue as the file name. Defer to user.'
+severity: nit
+resolution: 'User chose ''Quick jump''. KeyboardShortcutsModal row label: ''Cmd/Ctrl+K — Quick jump''. Component file name stays CommandPaletteModal.vue for forward compatibility with a future commands iteration.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YWWAL.md
+++ b/tickets/entities/review-responses/RR-YWWAL.md
@@ -1,0 +1,9 @@
+---
+id: RR-YWWAL
+type: review-response
+title: Unmount-while-open leaks pending timer and AbortController
+finding: 'watch(() => props.open, ...) only fires cancelInflight() on the open: true → false transition. If the component unmounts while open, the watcher is auto-stopped without ever running its cleanup branch. Fine in production today (App.vue mounts unconditionally) but a real issue under HMR and sets the next maintainer up to fail. Fix: add onBeforeUnmount(() => { cancelInflight(); previouslyFocused.value = null }) to clean up timer + abort controller on teardown.'
+severity: critical
+resolution: Added onBeforeUnmount(() => { cancelInflight(); previouslyFocused.value = null }). New test 'cancels in-flight request and timer on unmount' verifies the AbortSignal flips to aborted=true on wrapper.unmount() while a request is in flight.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-77JD4.md
+++ b/tickets/entities/tickets/TKT-77JD4.md
@@ -5,7 +5,7 @@ title: Quick-search/jump command palette for data-entry UI
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-77JD4.md
+++ b/tickets/entities/tickets/TKT-77JD4.md
@@ -1,0 +1,68 @@
+---
+id: TKT-77JD4
+type: ticket
+title: Quick-search/jump command palette for data-entry UI
+kind: enhancement
+priority: medium
+effort: m
+status: review
+---
+
+## Problem
+
+Navigating between entities in the data-entry SPA today requires going back to a
+list view, possibly switching entity type via the sidebar, and either scrolling
+or using the per-list search. For users who already know the title or ID of the
+entity they want, this is unnecessary friction.
+
+VS Code, Linear, Notion, GitHub, and most modern editors offer a command-palette
+/ quick-open modal that lets you type a fuzzy query and jump anywhere with the
+keyboard. `FEAT-Q767` (keyboard shortcuts and power-user navigation) explicitly
+listed `Cmd+K` command palette as out-of-scope future work; this ticket delivers
+it.
+
+## Goal
+
+Let a power user press a single keyboard shortcut from anywhere in the
+data-entry UI, type a few characters of an entity title or ID, and jump straight
+to that entity's detail view — without using the mouse.
+
+## Scope
+
+In scope:
+
+- A modal palette opened via a global keyboard shortcut (`Cmd+K` / `Ctrl+K`).
+- A search input that queries entities by title, ID, and type.
+- Results list with keyboard navigation (`↑`/`↓`) and `Enter` to open.
+- Click-to-select for mouse users.
+- `Esc` closes the modal; clicking the backdrop closes it.
+- Reachable from any view (list, detail, form) and respects modal-open guards used by `useKeyboardShortcuts`.
+- Display: each result shows entity title, ID, and entity-type label.
+- Empty state: when query is empty, show a helpful hint. When query has no matches, show "No matches".
+
+Out of scope:
+
+- Running commands / actions (e.g. "create new ticket", "toggle theme"). Reserve for follow-up.
+- Recently-visited / pinned entries.
+- Search across views, dashboards, or other non-entity targets.
+- Server-side ranking changes (use existing search endpoint).
+- Customizing the keybinding.
+
+## Acceptance criteria
+
+- AC1: From any data-entry route, pressing `Cmd+K` (macOS) or `Ctrl+K` (other) opens the palette modal.
+- AC2: The palette opens even when focus is in a text input/textarea (the shortcut explicitly bypasses `isInputFocused` because users expect Cmd+K from anywhere).
+- AC3: Typing into the input shows matching entities ranked by the existing search backend; updates are debounced to avoid request-per-keystroke.
+- AC4: `↑` / `↓` move the highlighted result; the highlight wraps at the ends.
+- AC5: `Enter` navigates to the highlighted entity's detail route and closes the modal.
+- AC6: Clicking a result navigates and closes the modal.
+- AC7: `Esc` closes the modal without navigating; backdrop click closes it; focus returns to the previously focused element.
+- AC8: Re-opening the palette starts with an empty query and the first result (if any) highlighted.
+- AC9: The shortcut is documented in `KeyboardShortcutsModal.vue`.
+- AC10: When focus is inside the palette input, the existing global `useKeyboardShortcuts` handlers (e.g. `g`-prefix nav) are suppressed so typing letters does not trigger navigation.
+
+## Non-functional
+
+- Initial open and result rendering perceptibly under 100ms for typical projects.
+- Keyboard-only operability (no mouse needed for any flow).
+- Accessibility: modal traps focus (use shared `useFocusTrap` if available), aria-roles for combobox/listbox, results announced.

--- a/tickets/relations/TKT-77JD4--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-77JD4--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-77JD4--has-docs--DOCS-TM2LG.md
+++ b/tickets/relations/TKT-77JD4--has-docs--DOCS-TM2LG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-docs
+to: DOCS-TM2LG
+---

--- a/tickets/relations/TKT-77JD4--has-implementation--IMPL-OSH68.md
+++ b/tickets/relations/TKT-77JD4--has-implementation--IMPL-OSH68.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-implementation
+to: IMPL-OSH68
+---

--- a/tickets/relations/TKT-77JD4--has-planning--PLAN-DK28G.md
+++ b/tickets/relations/TKT-77JD4--has-planning--PLAN-DK28G.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-planning
+to: PLAN-DK28G
+---

--- a/tickets/relations/TKT-77JD4--has-review--REV-2FKBJ.md
+++ b/tickets/relations/TKT-77JD4--has-review--REV-2FKBJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review
+to: REV-2FKBJ
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-198P7.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-198P7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-198P7
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-2GL4R.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-2GL4R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-2GL4R
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-2H6YE.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-2H6YE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-2H6YE
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-4JTM7.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-4JTM7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-4JTM7
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-4LHM6.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-4LHM6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-4LHM6
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-508T7.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-508T7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-508T7
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-5J4RI.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-5J4RI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-5J4RI
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-9EEZO.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-9EEZO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-9EEZO
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-9IHU2.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-9IHU2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-9IHU2
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-AKGMZ.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-AKGMZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-AKGMZ
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-FKKFB.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-FKKFB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-FKKFB
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-GMZZP.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-GMZZP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-GMZZP
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-GYUUF.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-GYUUF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-GYUUF
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-HTS2Q.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-HTS2Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-HTS2Q
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-HW4EE.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-HW4EE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-HW4EE
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-K64Z9.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-K64Z9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-K64Z9
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-KQKRG.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-KQKRG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-KQKRG
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-MP29E.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-MP29E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-MP29E
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-QL4SD.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-QL4SD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-QL4SD
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-R51D0.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-R51D0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-R51D0
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-VC0UY.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-VC0UY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-VC0UY
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-VGS4J.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-VGS4J.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-VGS4J
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-WA2H9.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-WA2H9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-WA2H9
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-WAGAP.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-WAGAP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-WAGAP
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-WQRYA.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-WQRYA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-WQRYA
+---

--- a/tickets/relations/TKT-77JD4--has-review-response--RR-YWWAL.md
+++ b/tickets/relations/TKT-77JD4--has-review-response--RR-YWWAL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: has-review-response
+to: RR-YWWAL
+---

--- a/tickets/relations/TKT-77JD4--implements--FEAT-Q767.md
+++ b/tickets/relations/TKT-77JD4--implements--FEAT-Q767.md
@@ -1,0 +1,5 @@
+---
+from: TKT-77JD4
+relation: implements
+to: FEAT-Q767
+---


### PR DESCRIPTION
## Summary

- Adds a VS Code-style command palette (`Cmd+K` / `Ctrl+K`) to the data-entry SPA: type to fuzzy-search entities by title, ID, or type; Arrow keys + Enter to navigate; Esc/backdrop to close. Reuses the existing `/api/v1/_search` endpoint with an `AbortController` per request to drop stale responses.
- Fixes a latent bug in `useKeyboardShortcuts`: the global Escape handler could call `router.back()` while a modal was visually open. Added an `isAnyModalOpen()` short-circuit so global shortcuts stand down whenever a modal is registered with the modal-stack.
- Implements the follow-up explicitly deferred in `FEAT-Q767`'s out-of-scope section.

## What's in the box

- New `frontend/src/components/ui/CommandPaletteModal.vue` (~270 lines) mirroring `ConfirmModal`'s lifecycle pattern: Teleport, modal-stack registration, focus restore on close, `e.stopPropagation()` on Escape, sync-flush watcher, `onBeforeUnmount` cleanup.
- ARIA combobox/listbox pattern with `aria-activedescendant` for screen-reader compatibility.
- Debounced search (150ms) with 2-character minimum and 50-result client-side cap to keep the listbox snappy on large projects.
- 34 component tests + 4 new composable tests covering happy path, debounce, AbortController forwarding, race conditions, in-flight refetch flicker prevention, custom detail views, idempotency, Tab trap, Escape stopPropagation, modal-stack integration, MAX_RESULTS cap, single-character query short-circuit, unmount cleanup.

## Why this matters

Navigating between entities in the SPA today requires going back to a list view, possibly switching entity type via the sidebar, and either scrolling or using the per-list search. Power users who already know the entity they want shouldn't need any of that — Cmd+K, type, Enter.

## Test plan

- [x] `npm run test:run` — 648 frontend tests pass (38 files)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (only pre-existing warnings)
- [x] `just test` — full backend race-enabled run, all packages pass
- [x] `just lint` — 0 issues
- [x] `just coverage-check` — package floors satisfied (74.3% total)
- [x] `just build` — frontend bundle + rela-server + rela-desktop all build clean
- [x] Manual smoke (Puppeteer): Cmd+K opens palette from any route; 1-char query shows hint, no API call; 2-char query returns capped results (50); ArrowDown/Enter navigates; Escape closes from input without triggering `router.back()` on form routes; backdrop click closes