### PR TITLE
feat(dataentry): PATCH relations carry per-edge meta + content (TKT-6WLSW)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,34 @@ The store is the source of truth. `search` maintains a derived index as a
 derived state. `entitymanager` is the "human intent" write path that runs
 automations and validation on top of the store.
 
+### Validation policy for write APIs
+
+rela's storage format is permissive: markdown + YAML frontmatter, edited
+freely by external tools alongside the API. The philosophy is **tolerate
+temporarily invalid data**; the `analyze_*` tools surface inconsistencies
+that the storage layer doesn't reject.
+
+Write-time checks split into three classes (DEC-HWZHA):
+
+| Class | When | HTTP |
+|---|---|---|
+| **Hard 400 — malformed wire format** | Request structure is broken, detectable without the metamodel | 400 |
+| **Hard 422 — structural impossibilities** | Storage layer literally cannot persist this | 422 |
+| **Write-with-warnings (200 + warnings)** | Soft conditions: target type mismatch, missing target, unknown meta keys, required-meta unset, meta type mismatches | 200 |
+
+The 200-with-warnings path performs the requested write and returns
+warnings in the response body so UIs surface them non-blockingly. Each
+warning is `{code, path, detail}` where `code` matches the corresponding
+`analyze_*` finding code so UIs can de-duplicate against analyze runs.
+
+Resist drift toward hard rejection on soft conditions. JSON:API and
+similar wire formats bring a "validate-then-422" mental model from
+REST-over-database stacks where wire and storage share a closed schema;
+rela's storage is intentionally more permissive than that. If you find
+yourself adding a 422 on a write path, ask: "could a hand-editor produce
+this state in a markdown file? If yes, it's a soft condition — warn,
+don't reject."
+
 ### Packages
 
 Entry points: `cmd/rela`, `cmd/rela-server`, `cmd/rela-desktop`.

--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -1,0 +1,243 @@
+# Data-entry API: PATCH /api/v1/{plural}/{id}
+
+This document describes the unified PATCH endpoint for updating an entity's
+properties, content, and outgoing relations atomically in a single request.
+
+The wire format borrows the JSON:API §9 resource-identifier shape at the
+relation-list level; per-edge data uses rela's existing `properties` /
+`properties_unset` / `content` upsert convention. The response is rela's
+flat top-level format augmented with an optional `warnings` array — we do
+NOT claim full JSON:API conformance.
+
+## Wire format
+
+```http
+PATCH /api/v1/tickets/TKT-001
+Content-Type: application/json
+
+{
+  "properties": {"title": "x"},
+  "content":    "...",
+  "relations": {
+    "tagged": {
+      "data": [
+        {
+          "type":       "label",
+          "id":         "L-001",
+          "meta":       {"weight": 5},
+          "meta_unset": ["added_by"],
+          "content":    "edge body"
+        },
+        {"type": "label", "id": "L-002"}
+      ]
+    },
+    "belongs-to": {
+      "data": [{"type": "category", "id": "C-001"}]
+    }
+  }
+}
+```
+
+All top-level fields are optional. Field absence means "leave alone".
+
+| Field | Semantics |
+|---|---|
+| `properties` | Map of property names to values. **Upsert**: keys present are merged into existing properties; absent keys are unchanged. |
+| `content` | Markdown body. **Upsert**: present (including empty string) replaces; absent leaves alone. |
+| `relations` | Map of relation type → desired-state wrapper. See below. |
+
+## Relations field
+
+Each value of the `relations` map is one of TWO shapes:
+
+### Modern (JSON:API §9-shaped)
+
+```json
+{"tagged": {"data": [{"type": "label", "id": "L-001", "meta": {"weight": 5}}]}}
+```
+
+The wrapper has exactly one field, `data`, which is an array of resource
+identifiers. Three cases for `data`:
+
+1. **Relation type absent from the map** → leave all edges of that type alone.
+2. **`data: []`** → remove all edges of that type from this entity.
+3. **`data: [{type, id, ...}, ...]`** → the array IS the new desired set. Edges
+   in the list are kept (or upserted with new meta/content); edges currently in
+   the graph but absent from the list are removed.
+
+### ⚠️ Data-loss footgun
+
+**Sending `data: []` deletes every edge of that relation type from this
+entity.** This is the most dangerous shape in the wire format. If your client
+builds the PATCH body via object spread on a not-yet-fetched form state —
+`{relations: {tagged: {data: []}}}` is the default empty form value — the
+first auto-save fire silently wipes the entity's tagged edges.
+
+**Mitigations:**
+
+- **Fetch before edit.** A client that auto-saves must complete its initial
+  GET before issuing the first PATCH that touches `relations`.
+- **Omit unsubmitted relations.** If the user hasn't touched the relation
+  type, don't send it. Absent → leave alone is the safe default.
+- **`data` field is required when the wrapper appears.** `{"tagged": {}}`
+  returns 400, not a silent empty array. This catches the most common
+  malformed-request case where a client constructed the wrapper but forgot
+  to populate `data`.
+
+### Per-edge fields
+
+Each entry in `data` is a resource identifier with these fields:
+
+| Field | Required? | Semantics |
+|---|---|---|
+| `type` | yes | Target entity type. **Soft check**: a mismatch surfaces a `target_type_mismatch` warning and writes the edge anyway (DEC-HWZHA). |
+| `id` | yes | Target entity ID. **Soft check**: a missing target surfaces a `target_not_found` warning and writes the edge anyway. |
+| `meta` | optional | Per-edge properties. **Upsert** — keys merge into existing meta. **Soft check**: unknown keys against the relation's closed schema produce `unknown_meta_key` warnings, but persist. |
+| `meta_unset` | optional | Keys to clear after the merge. Mirrors `properties_unset` at the entity level. Non-string elements → 400 at unmarshal. |
+| `content` | optional | Per-edge markdown body. **Upsert** — present (including empty string) replaces, absent leaves alone. **Hard 422**: present on a relation type without `content: true` (the file format can't hold a body). |
+
+### Legacy (IDs-only)
+
+```json
+{"tagged": ["L-001", "L-002"]}
+```
+
+The legacy shape continues to work. Set semantics: edges in the list are kept
+or created (with empty meta and empty content); edges absent from the list
+are removed.
+
+Mixing the two shapes in one PATCH body returns 400 with a stable
+`shape_mixed` error code.
+
+## Validation policy
+
+Per [DEC-HWZHA](../../tickets/entities/decisions/DEC-HWZHA.md), validation
+findings split into three classes:
+
+### Hard 400 — request shape errors
+
+Detectable without consulting the metamodel.
+
+- Malformed JSON in body
+- Relation wrapper missing required `data` field (`{"tagged": {}}`)
+- Resource identifier missing `type` or `id`
+- Mixed legacy + modern shapes in one body (`shape_mixed`)
+- Non-string element in `meta_unset` array (`meta_unset_invalid`)
+- `data` field has unexpected type (string, scalar, etc.)
+- `data: null` on a wrapper (treated same as missing)
+- Unknown sibling key in modern wrapper (only `data` allowed)
+
+### Hard 422 — structural impossibilities
+
+The storage layer literally cannot persist this state.
+
+- Unknown relation type (`unknown_relation_type`) — no defined storage location
+- Writing `content` on a relation type without `content: true` (`content_not_supported`) — the file format has no body slot
+
+### 200 + warnings — soft conditions surfaced inline
+
+Everything else previous drafts would 422 on. The API performs the requested
+write and returns warnings in the response body so UIs surface them
+non-blockingly. Each warning is `{code, path, detail}` where:
+
+- `code` is stable and matches the corresponding `analyze_*` finding code
+- `path` is an RFC 6901 JSON Pointer to the offending field
+- `detail` is a human-readable explanation
+
+Warning codes:
+
+| Code | When |
+|---|---|
+| `target_not_found` | Target ID doesn't exist in the graph |
+| `target_type_mismatch` | Target's actual type doesn't match `data[i].type` |
+| `target_type_not_allowed` | Target type not in the relation's `to` allowlist |
+| `source_type_not_allowed` | Source type not in the relation's `from` allowlist |
+| `unknown_meta_key` | Meta key not declared in the relation's closed schema |
+| `required_meta_unset` | Required meta property absent after merge |
+| `meta_type_mismatch` | Meta value's type doesn't match the declared property type |
+
+A read of `analyze_orphans` / `analyze_validations` will surface the same
+findings; clients may de-duplicate by `code`.
+
+## Atomicity
+
+The handler runs in three phases:
+
+1. **Validate** — relation validation runs FIRST. On 400/422, no writes occur.
+2. **Update entity** — only if the request actually changed `properties` or `content`.
+3. **Apply relations** — adds/updates/deletes per the diff. Soft-condition edges
+   are written directly through the store, bypassing the workspace's
+   target-existence check.
+
+The validation-first ordering means a relation 422 leaves the entity
+**untouched**. The unavoidable atomicity gap is mid-write-loop store failures
+(disk full, permission denied, etc.) — these are rare, irrecoverable, and
+return a 500 with `relation_write_failed`. The legacy reconciler had the same
+property; this PR doesn't make it worse.
+
+The store interface (internal/store/store.go) intentionally has no
+transaction primitive — adding one would fight the pluggable-backends goal
+(FEAT-CO4YP). For a local-first tool with single-writer-typical workloads,
+the documented gap is acceptable.
+
+## No-op suppression
+
+The diff classifier compares each desired edge against the current graph
+state. If the post-merge `(properties, content)` byte-equals the current
+state, no write occurs and no SSE event fires. Auto-save's primary path
+(re-saving an unchanged form) writes zero relation files and broadcasts
+zero events.
+
+Comparison uses `reflect.DeepEqual` after merging meta + applying meta_unset.
+Both sides come from the same Go-native unmarshal path (JSON or YAML), so
+type coercion (`int(5)` vs `float64(5)`) hasn't been an issue in practice. If
+it surfaces, the fallback is a `valueEqual` helper in `internal/model`.
+
+## Automation interaction
+
+When `properties` or `content` changes trigger an `entity:updated` automation,
+the automation runs during Phase 2. Phase 3 (relation reconcile) computes its
+diff against the pre-automation graph state — **automation-created relations
+that conflict with the desired set may be deleted and recreated**. This is
+the same hazard the legacy reconciler has today.
+
+## SSE events
+
+A successful PATCH that performs writes broadcasts:
+
+- One `entity:updated` event for the PATCHed entity, ONLY when entity properties or content actually changed
+- One `relation:created` / `relation:updated` / `relation:deleted` event per actual relation write (none on a no-op)
+- No events on 400/422 (handler returns before broadcast)
+
+A relations-only PATCH that produces all no-ops emits zero events.
+
+## ETag / If-Match
+
+The handler honors `If-Match: <etag>` for optimistic concurrency control.
+The ETag is computed against the entity's current `properties + content`.
+Mismatch → 412 Precondition Failed.
+
+## MCP and Lua content semantics
+
+`entitymanager.RelationOptions.Content` is `*string` — pointer-vs-string
+distinguishes "leave alone" from "set to empty". Two callers have notable
+boundary semantics:
+
+- **MCP `create_relation` tool**: an empty `content` string on the request
+  is treated as "leave alone" (helper `nilIfEmpty` in `internal/mcp/`). To
+  clear, omit `content` or pass `null`.
+- **Lua `rela.update_relation`**: an explicit empty string clears the body
+  (matches the user-intuition that `content = ""` means empty). To leave
+  alone, omit the field.
+
+## Out of scope
+
+- **Symmetric / inverse propagation of per-edge meta.** The current write
+  path doesn't propagate at all; an independent ticket would address it if
+  needed.
+- **Cardinality enforcement.** `min_outgoing` / `max_outgoing` are advisory
+  (surfaced via `analyze_*`), never enforced at write time.
+- **Granular relations diff verbs** (à la GraphQL `connect`/`disconnect`).
+  v1 is replacement-only at the list level + upsert at the per-edge level.
+- **Cross-entity atomic transactions.** A single PATCH targets one entity;
+  there is no batch / transaction surface across entities.

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -39,6 +39,11 @@ type V1Entity struct {
 	Self         string                 `json:"_self,omitempty"`
 	Actions      *V1Actions             `json:"_actions,omitempty"`
 	Inaccessible []V1InaccessibleField  `json:"inaccessible,omitempty"`
+	// Warnings lists soft-condition findings surfaced by the write
+	// path. Populated only by mutation responses (PATCH); read paths
+	// leave it nil. Each warning has a stable `code`, an RFC 6901
+	// JSON Pointer `path`, and a human-readable `detail`.
+	Warnings []Warning `json:"warnings,omitempty"`
 }
 
 // V1InaccessibleField describes a property that is known to exist but
@@ -545,27 +550,47 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 	var req struct {
 		Properties map[string]interface{} `json:"properties,omitempty"`
 		Content    *string                `json:"content,omitempty"`
-		Relations  map[string][]string    `json:"relations,omitempty"`
+		Relations  V1RelationsField       `json:"relations,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		// V1RelationsField's UnmarshalJSON returns *wireError for
+		// shape errors; surface them as 400 with the structured code.
+		var werr *wireError
+		if errors.As(err, &werr) {
+			writeV1Error(w, r, http.StatusBadRequest, werr.Code,
+				werr.Detail, werr.Path)
+			return
+		}
 		writeV1Error(w, r, http.StatusBadRequest, "invalid_json", "Invalid JSON body", err.Error())
 		return
 	}
 
+	// Phase A: validate relations (no writes). Returns warnings (will
+	// be merged into the success response) and err (hard 400/422).
+	// Validation runs BEFORE entity update so a structural relation
+	// error doesn't leave the entity half-written. (DEC-HWZHA atomicity.)
+	var warnings []Warning
+	if req.Relations.Modern != nil {
+		ws, err := a.validateRelationsModern(r.Context(), entityID, entity.Type, req.Relations.Modern)
+		if err != nil {
+			a.writeRelationsValidationError(w, r, err)
+			return
+		}
+		warnings = ws
+	}
+
+	// Phase B: entity update. Skipped when only relations changed,
+	// to avoid bumping the file mtime and broadcasting a misleading
+	// "entity updated" SSE event with no byte-level change.
 	if req.Properties != nil {
 		for k, v := range req.Properties {
 			entity.Properties[k] = v
 		}
 	}
-
 	if req.Content != nil {
 		entity.Content = *req.Content
 	}
-
-	// Skip UpdateEntity when the PATCH only touches relations: otherwise we
-	// rewrite the entity file, bump mtime, re-run validation, and broadcast
-	// a misleading "entity updated" SSE event with no byte-level change.
 	entityChanged := req.Properties != nil || req.Content != nil
 	if entityChanged {
 		if _, err := a.entityManager.UpdateEntity(r.Context(), entity); err != nil {
@@ -574,19 +599,67 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 		}
 	}
 
-	if err := a.reconcileOutgoingRelations(r.Context(), entityID, req.Relations); err != nil {
-		writeV1Error(w, r, http.StatusUnprocessableEntity, "relation_failed", "Failed to update relations", reconcileDetail(err))
-		return
+	// Phase C: relation writes. Modern reconciler is dispatched when
+	// the modern shape was used; legacy reconciler otherwise. Both
+	// produce warnings on soft conditions and structured errors on
+	// hard failures.
+	switch {
+	case req.Relations.Modern != nil:
+		ws, err := a.applyRelationsModern(r.Context(), entityID, req.Relations.Modern)
+		warnings = append(warnings, ws...)
+		if err != nil {
+			a.writeRelationsApplyError(w, r, err)
+			return
+		}
+	case req.Relations.Legacy != nil:
+		if err := a.reconcileOutgoingRelations(r.Context(), entityID, req.Relations.Legacy); err != nil {
+			writeV1Error(w, r, http.StatusUnprocessableEntity,
+				"relation_failed", "Failed to update relations", reconcileDetail(err))
+			return
+		}
 	}
 
 	result := a.entityToV1(entity, plural, true, false)
+	if len(warnings) > 0 {
+		result.Warnings = warnings
+	}
 	newETag := a.computeEntityETag(entity)
 	w.Header().Set("ETag", newETag)
 
-	// Broadcast entity update event
-	a.broker.broadcastEntityEvent("updated", typeName, entityID)
+	// Broadcast entity update event when the entity itself changed.
+	// Relation-only changes don't fire an entity:updated event today.
+	if entityChanged {
+		a.broker.broadcastEntityEvent("updated", typeName, entityID)
+	}
 
 	writeV1JSON(w, http.StatusOK, result)
+}
+
+// writeRelationsValidationError maps a Phase A validation error from
+// the modern reconciler to the corresponding HTTP response. wireError
+// → 400 (caller bug); structuralError → 422 (storage can't represent).
+func (a *App) writeRelationsValidationError(w http.ResponseWriter, r *http.Request, err error) {
+	var werr *wireError
+	if errors.As(err, &werr) {
+		writeV1Error(w, r, http.StatusBadRequest, werr.Code, werr.Detail, werr.Path)
+		return
+	}
+	if se, ok := asStructuralError(err); ok {
+		writeV1Error(w, r, http.StatusUnprocessableEntity, se.Code, se.Detail, se.Path)
+		return
+	}
+	writeV1Error(w, r, http.StatusUnprocessableEntity,
+		"relation_failed", "Failed to validate relations", err.Error())
+}
+
+// writeRelationsApplyError maps a Phase C write error to a 500 — the
+// entity may already have been updated, so a partial state is on disk.
+// This is the documented atomicity gap.
+func (a *App) writeRelationsApplyError(w http.ResponseWriter, r *http.Request, err error) {
+	writeV1Error(w, r, http.StatusInternalServerError,
+		"relation_write_failed",
+		"Failed to apply relation changes after entity update; the entity may have been updated",
+		reconcileDetail(err))
 }
 
 func (a *App) handleV1DeleteEntity(w http.ResponseWriter, r *http.Request, typeName, _, entityID string) {

--- a/internal/dataentry/relations_modern.go
+++ b/internal/dataentry/relations_modern.go
@@ -1,0 +1,444 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// Warning is a non-blocking finding surfaced to the caller alongside
+// a successful PATCH response. Code values match the corresponding
+// `analyze_*` finding codes so the UI can de-duplicate against
+// analyze runs. Path is an RFC 6901 JSON Pointer.
+type Warning struct {
+	Code   string `json:"code"`
+	Path   string `json:"path,omitempty"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// validateRelationsModern runs the validation phase of the modern
+// reconciler without performing any writes. It returns:
+//
+//   - warnings: soft-condition findings (DEC-HWZHA write-with-warnings).
+//     Edges flagged by warnings will still be written by applyRelationsModern.
+//   - err: a hard 422 (structural impossibility) or 400 (caller bug). On err
+//     the caller MUST NOT proceed to the entity-update or write phases.
+//
+// This split lets handleV1UpdateEntity validate relations BEFORE the
+// entity is updated, so a structural relation problem doesn't leave
+// the entity half-written.
+func (a *App) validateRelationsModern(
+	ctx context.Context, _ string, sourceType string, desired map[string]V1RelationsUpdate,
+) ([]Warning, error) {
+	if len(desired) == 0 {
+		return nil, nil
+	}
+	meta := a.State().Meta
+	var warnings []Warning
+
+	for relType, upd := range desired {
+		if !upd.DataPresent {
+			return nil, &wireError{
+				Code:   "data_required",
+				Path:   "/relations/" + jsonPointerEscape(relType) + "/data",
+				Detail: "`data` field is required when a relation wrapper appears",
+			}
+		}
+
+		relDef, ok := meta.Relations[relType]
+		if !ok {
+			return nil, &structuralError{
+				Code:   "unknown_relation_type",
+				Path:   "/relations/" + jsonPointerEscape(relType),
+				Detail: fmt.Sprintf("relation type %q is not defined in the metamodel", relType),
+			}
+		}
+
+		// Source-type allowlist: a soft warning per DEC-HWZHA. The
+		// edge can still be written; analyze flags it.
+		if !containsString(relDef.From, sourceType) {
+			warnings = append(warnings, Warning{
+				Code:   "source_type_not_allowed",
+				Path:   "/relations/" + jsonPointerEscape(relType),
+				Detail: fmt.Sprintf("relation %q does not declare %q as an allowed source type", relType, sourceType),
+			})
+		}
+
+		for i, ref := range upd.Data {
+			edgePath := fmt.Sprintf("/relations/%s/data/%d", jsonPointerEscape(relType), i)
+
+			// Content on a non-content-bearing relation type is a
+			// structural impossibility — the file format can't hold
+			// a body for that type.
+			if ref.Content != nil && !relDef.Content {
+				return nil, &structuralError{
+					Code:   "content_not_supported",
+					Path:   edgePath + "/content",
+					Detail: fmt.Sprintf("relation type %q does not support per-edge content", relType),
+				}
+			}
+
+			// Soft conditions surfaced as warnings:
+			ws := a.collectEdgeWarnings(ctx, relType, &relDef, ref, edgePath)
+			warnings = append(warnings, ws...)
+		}
+	}
+	return warnings, nil
+}
+
+// collectEdgeWarnings runs the soft-condition checks for a single
+// resource identifier. None of these block the write.
+func (a *App) collectEdgeWarnings(
+	ctx context.Context, relType string, relDef *metamodel.RelationDef,
+	ref V1ResourceIdentifier, edgePath string,
+) []Warning {
+	var warnings []Warning
+	meta := a.State().Meta
+
+	target, err := a.store.GetEntity(ctx, ref.ID)
+	if err != nil {
+		warnings = append(warnings, Warning{
+			Code:   "target_not_found",
+			Path:   edgePath + "/id",
+			Detail: fmt.Sprintf("target entity %q does not exist; the edge will be created but reference a missing target", ref.ID),
+		})
+	} else {
+		if target.Type != ref.Type {
+			warnings = append(warnings, Warning{
+				Code:   "target_type_mismatch",
+				Path:   edgePath + "/type",
+				Detail: fmt.Sprintf("expected target type %q, but %q is of type %q", ref.Type, ref.ID, target.Type),
+			})
+		}
+		if !containsString(relDef.To, target.Type) {
+			warnings = append(warnings, Warning{
+				Code:   "target_type_not_allowed",
+				Path:   edgePath,
+				Detail: fmt.Sprintf("relation %q does not declare %q as an allowed target type", relType, target.Type),
+			})
+		}
+	}
+
+	// Closed-schema check on meta keys.
+	for k := range ref.Meta {
+		if _, known := relDef.Properties[k]; !known {
+			warnings = append(warnings, Warning{
+				Code:   "unknown_meta_key",
+				Path:   edgePath + "/meta/" + jsonPointerEscape(k),
+				Detail: fmt.Sprintf("relation type %q does not declare meta property %q", relType, k),
+			})
+		}
+	}
+	for _, k := range ref.MetaUnset {
+		if _, known := relDef.Properties[k]; !known {
+			warnings = append(warnings, Warning{
+				Code:   "unknown_meta_key",
+				Path:   edgePath + "/meta_unset",
+				Detail: fmt.Sprintf("relation type %q does not declare meta property %q", relType, k),
+			})
+		}
+	}
+
+	// Per-property type validation for declared keys with provided values.
+	for k, v := range ref.Meta {
+		propDef, known := relDef.Properties[k]
+		if !known {
+			continue // already warned above
+		}
+		if err := meta.ValidatePropertyValue(k, &propDef, v); err != nil {
+			warnings = append(warnings, Warning{
+				Code:   "meta_type_mismatch",
+				Path:   edgePath + "/meta/" + jsonPointerEscape(k),
+				Detail: err.Error(),
+			})
+		}
+	}
+
+	return warnings
+}
+
+// applyRelationsModern performs the diff and write phase of the modern
+// reconciler. Validation should have run already via
+// validateRelationsModern; this function does NOT re-validate. It only
+// surfaces additional warnings that depend on post-merge state (e.g.
+// required-meta-unset) and store-write errors.
+//
+// Edges flagged by the validation phase as "target missing" or
+// "target type mismatch" are written directly through the store
+// rather than the EntityManager — the EntityManager's CreateRelation
+// rejects writes whose target doesn't exist, but DEC-HWZHA's policy is
+// to permit the write with a warning. The store does not check target
+// existence, so the direct write succeeds and `analyze_*` flags it on
+// the next run.
+//
+// Returns warnings collected during the apply phase plus any error
+// that prevented further writes. On a write-loop error, the relations
+// already written stay written — the caller treats this as the
+// documented atomicity gap.
+func (a *App) applyRelationsModern(
+	ctx context.Context, entityID string, desired map[string]V1RelationsUpdate,
+) ([]Warning, error) {
+	if len(desired) == 0 {
+		return nil, nil
+	}
+	meta := a.State().Meta
+	em := a.entityManager
+	var warnings []Warning
+
+	for relType, upd := range desired {
+		relDef := meta.Relations[relType] // already verified in validateRelationsModern
+
+		desiredByID := make(map[string]V1ResourceIdentifier, len(upd.Data))
+		for _, ref := range upd.Data {
+			desiredByID[ref.ID] = ref
+		}
+
+		current := map[string]*entity.Relation{}
+		for _, edge := range a.outgoingRelations(entityID) {
+			if edge.Type == relType {
+				current[edge.To] = edge
+			}
+		}
+
+		// Adds and upserts.
+		for _, ref := range upd.Data {
+			finalProps, finalContent, contentSet := mergeEdgeMeta(current[ref.ID], ref)
+
+			ws := requiredMetaWarnings(relType, &relDef, ref, finalProps,
+				fmt.Sprintf("/relations/%s/data", jsonPointerEscape(relType)))
+			warnings = append(warnings, ws...)
+
+			existing, exists := current[ref.ID]
+			if exists {
+				if isEdgeNoOp(existing, finalProps, finalContent, contentSet, ref) {
+					continue // value-based no-op suppression
+				}
+				if err := a.writeUpdateRelation(ctx, entityID, relType, ref); err != nil {
+					return warnings, err
+				}
+			} else {
+				if err := a.writeCreateRelation(ctx, entityID, relType, ref, finalProps, finalContent); err != nil {
+					return warnings, err
+				}
+			}
+		}
+
+		// Deletes: every current edge not in the desired set.
+		for targetID := range current {
+			if _, kept := desiredByID[targetID]; kept {
+				continue
+			}
+			if err := em.DeleteRelation(ctx, entityID, relType, targetID); err != nil {
+				return warnings, &relationError{
+					RelType: relType, Target: targetID, Op: "delete",
+					Reason: "delete_failed", Err: err,
+				}
+			}
+		}
+	}
+	return warnings, nil
+}
+
+// writeCreateRelation creates a new relation. It first tries the
+// EntityManager (preserving validation + automation paths for the
+// happy case); on a target-not-found error it falls back to a direct
+// store write so DEC-HWZHA's "soft conditions are warnings, not
+// rejections" policy holds.
+func (a *App) writeCreateRelation(
+	ctx context.Context, from, relType string, ref V1ResourceIdentifier,
+	finalProps map[string]interface{}, finalContent string,
+) error {
+	opts := entitymanager.RelationOptions{
+		Properties: finalProps,
+		Content:    ref.Content,
+	}
+	_, err := a.entityManager.CreateRelation(ctx, from, relType, ref.ID, opts)
+	if err == nil {
+		return nil
+	}
+	if !isSoftCondition(err) {
+		return &relationError{
+			RelType: relType, Target: ref.ID, Op: "create",
+			Reason: "create_failed", Err: err,
+		}
+	}
+	// Soft condition (e.g., target missing): write directly through
+	// the store, skipping the workspace's pre-write validation.
+	data := &store.RelationData{Properties: finalProps, Content: finalContent}
+	if _, sErr := a.store.CreateRelation(ctx, from, relType, ref.ID, data); sErr != nil {
+		return &relationError{
+			RelType: relType, Target: ref.ID, Op: "create",
+			Reason: "create_failed", Err: sErr,
+		}
+	}
+	return nil
+}
+
+// writeUpdateRelation updates an existing relation, preferring the
+// EntityManager path. Falls back to a direct store write on soft
+// conditions, mirroring writeCreateRelation.
+func (a *App) writeUpdateRelation(
+	ctx context.Context, from, relType string, ref V1ResourceIdentifier,
+) error {
+	opts := entitymanager.RelationOptions{
+		Properties: ref.Meta,
+		MetaUnset:  ref.MetaUnset,
+		Content:    ref.Content,
+	}
+	_, err := a.entityManager.UpdateRelation(ctx, from, relType, ref.ID, opts)
+	if err == nil {
+		return nil
+	}
+	if !isSoftCondition(err) {
+		return &relationError{
+			RelType: relType, Target: ref.ID, Op: "update",
+			Reason: "update_failed", Err: err,
+		}
+	}
+	// Soft condition: rebuild the post-merge state and write directly.
+	current, _ := a.store.GetRelation(ctx, from, relType, ref.ID)
+	finalProps, finalContent, _ := mergeEdgeMeta(current, ref)
+	data := store.RelationData{Properties: finalProps, Content: finalContent}
+	if _, sErr := a.store.UpdateRelation(ctx, from, relType, ref.ID, data); sErr != nil {
+		return &relationError{
+			RelType: relType, Target: ref.ID, Op: "update",
+			Reason: "update_failed", Err: sErr,
+		}
+	}
+	return nil
+}
+
+// isSoftCondition returns true when the error from EntityManager
+// indicates a DEC-HWZHA "soft" condition that should be treated as a
+// warning rather than blocking the write. The current workspace
+// implementation surfaces these as plain fmt.Errorf strings; we match
+// on substrings, which is fragile but acceptable for the current
+// implementation surface.
+func isSoftCondition(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "target entity not found"):
+		return true
+	case strings.Contains(msg, "source entity not found"):
+		return true
+	case strings.Contains(msg, "invalid relation:"):
+		// metamodel.ValidateRelation rejects type-allowlist failures.
+		return true
+	}
+	return false
+}
+
+// mergeEdgeMeta computes the post-merge (properties, content) tuple
+// for an edge, given the existing relation (or nil for new edges) and
+// the desired ref. contentSet reports whether ref.Content was non-nil
+// (so the caller can distinguish "leave alone" from "set to value").
+func mergeEdgeMeta(existing *entity.Relation, ref V1ResourceIdentifier) (
+	props map[string]interface{}, content string, contentSet bool,
+) {
+	props = make(map[string]interface{})
+	if existing != nil {
+		for k, v := range existing.Properties {
+			props[k] = v
+		}
+		content = existing.Content
+	}
+	for k, v := range ref.Meta {
+		props[k] = v
+	}
+	for _, k := range ref.MetaUnset {
+		delete(props, k)
+	}
+	if ref.Content != nil {
+		content = *ref.Content
+		contentSet = true
+	}
+	return props, content, contentSet
+}
+
+// isEdgeNoOp returns true when the post-merge state of an edge equals
+// the existing edge byte-for-byte. Auto-save's primary path hits this:
+// re-PATCHing a form that hasn't changed performs zero writes.
+func isEdgeNoOp(
+	existing *entity.Relation, finalProps map[string]interface{},
+	finalContent string, contentSet bool, ref V1ResourceIdentifier,
+) bool {
+	// If the request has no per-edge upsert fields at all and the
+	// edge already exists, it's trivially a no-op. (Strict subset of
+	// the value-based check below; kept as a fast path.)
+	if ref.Meta == nil && ref.MetaUnset == nil && ref.Content == nil {
+		return true
+	}
+	if !mapsEqual(existing.Properties, finalProps) {
+		return false
+	}
+	if contentSet && existing.Content != finalContent {
+		return false
+	}
+	return true
+}
+
+// mapsEqual is a small wrapper around reflect.DeepEqual that treats
+// nil and empty maps as equal. (Go's reflect.DeepEqual considers
+// nil != empty map, which would produce false-positive writes on
+// edges whose existing properties are nil and whose final state is
+// an empty map after merge.)
+func mapsEqual(a, b map[string]interface{}) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+// requiredMetaWarnings returns warnings for declared-required meta
+// keys that are absent from the post-merge state.
+func requiredMetaWarnings(
+	relType string, relDef *metamodel.RelationDef, ref V1ResourceIdentifier,
+	finalProps map[string]interface{}, dataPath string,
+) []Warning {
+	var ws []Warning
+	for k, propDef := range relDef.Properties {
+		if !propDef.Required {
+			continue
+		}
+		if _, ok := finalProps[k]; !ok {
+			ws = append(ws, Warning{
+				Code:   "required_meta_unset",
+				Path:   fmt.Sprintf("%s[id=%s]/meta/%s", dataPath, jsonPointerEscape(ref.ID), jsonPointerEscape(k)),
+				Detail: fmt.Sprintf("relation type %q requires meta property %q", relType, k),
+			})
+		}
+	}
+	return ws
+}
+
+// structuralError is a typed hard-422 error from the modern reconciler:
+// the request describes a state the storage layer can't represent. The
+// HTTP handler maps it to 422 with the carried code.
+type structuralError struct {
+	Code   string
+	Path   string
+	Detail string
+}
+
+func (e *structuralError) Error() string {
+	return fmt.Sprintf("%s: %s (path: %s)", e.Code, e.Detail, e.Path)
+}
+
+// asStructuralError extracts a *structuralError if err is or wraps one.
+func asStructuralError(err error) (*structuralError, bool) {
+	var se *structuralError
+	if errors.As(err, &se) {
+		return se, true
+	}
+	return nil, false
+}

--- a/internal/dataentry/relations_modern_test.go
+++ b/internal/dataentry/relations_modern_test.go
@@ -1,0 +1,578 @@
+package dataentry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// newRelationsTestApp builds an App with relation types that exercise
+// the modern wire format: tagged (closed-schema meta + content body),
+// belongs-to (no meta, no content), assesses (required meta).
+func newRelationsTestApp(t *testing.T) *App {
+	t.Helper()
+
+	weight := metamodel.PropertyDef{Type: "integer"}
+	addedBy := metamodel.PropertyDef{Type: "string"}
+	rationale := metamodel.PropertyDef{Type: "string", Required: true}
+
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Label:    "Ticket",
+				IDPrefix: "TKT-",
+				Properties: map[string]metamodel.PropertyDef{
+					"title":  {Type: "string", Required: true},
+					"status": {Type: "string"},
+				},
+			},
+			"label": {
+				Label:    "Label",
+				IDPrefix: "L-",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
+			},
+			"category": {
+				Label:    "Category",
+				IDPrefix: "C-",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
+			},
+			"reviewer": {
+				Label:    "Reviewer",
+				IDPrefix: "R-",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
+			},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"tagged": {
+				Label:   "tagged",
+				From:    []string{"ticket"},
+				To:      []string{"label"},
+				Content: true,
+				Properties: map[string]metamodel.PropertyDef{
+					"weight":   weight,
+					"added_by": addedBy,
+				},
+			},
+			"belongs-to": {
+				Label: "belongs to",
+				From:  []string{"ticket"},
+				To:    []string{"category"},
+			},
+			"assessed-by": {
+				Label: "assessed by",
+				From:  []string{"ticket"},
+				To:    []string{"reviewer"},
+				Properties: map[string]metamodel.PropertyDef{
+					"rationale": rationale,
+				},
+			},
+		},
+	}
+
+	cfg := &dataentryconfig.Config{
+		App:        dataentryconfig.AppConfig{Name: "Relations Test"},
+		Forms:      make(map[string]dataentryconfig.Form),
+		Lists:      make(map[string]dataentryconfig.List),
+		Views:      make(map[string]dataentryconfig.ViewConfig),
+		Kanbans:    make(map[string]dataentryconfig.Kanban),
+		Navigation: []dataentryconfig.NavigationEntry{},
+	}
+
+	app := newAppFromParts(cfg, meta, newFixture())
+	app.broker = newEventBroker()
+
+	// Seed a baseline ticket and a few targets.
+	seedEntity(app, &entity.Entity{
+		ID:   "TKT-001",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title":  "Sample ticket",
+			"status": "open",
+		},
+	})
+	seedEntity(app, &entity.Entity{ID: "L-001", Type: "label", Properties: map[string]interface{}{"title": "bug"}})
+	seedEntity(app, &entity.Entity{ID: "L-002", Type: "label", Properties: map[string]interface{}{"title": "ui"}})
+	seedEntity(app, &entity.Entity{ID: "L-003", Type: "label", Properties: map[string]interface{}{"title": "perf"}})
+	seedEntity(app, &entity.Entity{ID: "C-001", Type: "category", Properties: map[string]interface{}{"title": "Backend"}})
+	seedEntity(app, &entity.Entity{ID: "R-001", Type: "reviewer", Properties: map[string]interface{}{"title": "Alice"}})
+	return app
+}
+
+// patch issues a PATCH against the app's handler and returns the recorder.
+//
+//nolint:unparam // plural is "tickets" everywhere today; kept generic so future tests can target other types without churn
+func patch(t *testing.T, app *App, plural, id, body string, headers ...string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/"+plural+"/"+id, bytes.NewReader([]byte(body)))
+	for i := 0; i+1 < len(headers); i += 2 {
+		req.Header.Set(headers[i], headers[i+1])
+	}
+	rec := httptest.NewRecorder()
+	app.handleV1UpdateEntity(rec, req, "ticket", plural, id)
+	return rec
+}
+
+func decodeV1(t *testing.T, body []byte) V1Entity {
+	t.Helper()
+	var got V1Entity
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode response: %v\nbody: %s", err, body)
+	}
+	return got
+}
+
+// outgoingByType returns the current outgoing edges of the given type for entityID.
+//
+//nolint:unparam // entityID is "TKT-001" everywhere today; kept generic for future tests
+func outgoingByType(app *App, entityID, relType string) []*entity.Relation {
+	out := []*entity.Relation{}
+	for r, err := range app.store.ListRelations(context.Background(), store.RelationQuery{
+		EntityID:  entityID,
+		Direction: store.DirectionOutgoing,
+		Type:      relType,
+	}) {
+		if err != nil {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// AC1: add new edge with meta.
+func TestModern_AC1_AddEdgeWithMeta(t *testing.T) {
+	app := newRelationsTestApp(t)
+	body := `{"relations": {"tagged": {"data": [{"type":"label","id":"L-001","meta":{"weight":5}}]}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	rels := outgoingByType(app, "TKT-001", "tagged")
+	if len(rels) != 1 {
+		t.Fatalf("len=%d, want 1; %v", len(rels), rels)
+	}
+	if got := rels[0].Properties["weight"]; got != float64(5) {
+		t.Errorf("weight=%v (%T), want 5", got, got)
+	}
+}
+
+// AC2: upsert meta on existing edge (no duplicate created).
+func TestModern_AC2_UpsertMeta(t *testing.T) {
+	app := newRelationsTestApp(t)
+	if _, err := app.store.CreateRelation(context.Background(), "TKT-001", "tagged", "L-001",
+		&store.RelationData{Properties: map[string]interface{}{"weight": float64(5)}}); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"relations": {"tagged": {"data": [{"type":"label","id":"L-001","meta":{"weight":7}}]}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	rels := outgoingByType(app, "TKT-001", "tagged")
+	if len(rels) != 1 {
+		t.Fatalf("len=%d, want 1 (no duplicates)", len(rels))
+	}
+	if got := rels[0].Properties["weight"]; got != float64(7) {
+		t.Errorf("weight=%v, want 7", got)
+	}
+}
+
+// AC3: meta_unset clears keys.
+func TestModern_AC3_MetaUnset(t *testing.T) {
+	app := newRelationsTestApp(t)
+	if _, err := app.store.CreateRelation(context.Background(), "TKT-001", "tagged", "L-001",
+		&store.RelationData{Properties: map[string]interface{}{
+			"weight":   float64(5),
+			"added_by": "alice",
+		}}); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"relations": {"tagged": {"data": [{"type":"label","id":"L-001","meta_unset":["weight"]}]}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	rels := outgoingByType(app, "TKT-001", "tagged")
+	if len(rels) != 1 {
+		t.Fatalf("len=%d, want 1", len(rels))
+	}
+	if _, has := rels[0].Properties["weight"]; has {
+		t.Errorf("weight should be cleared, props=%v", rels[0].Properties)
+	}
+	if got := rels[0].Properties["added_by"]; got != "alice" {
+		t.Errorf("added_by=%v, want alice (preserved)", got)
+	}
+}
+
+// AC4: per-edge content upsert + clear.
+func TestModern_AC4_ContentUpsertAndClear(t *testing.T) {
+	app := newRelationsTestApp(t)
+	body1 := `{"relations": {"tagged": {"data": [{"type":"label","id":"L-001","content":"edge body"}]}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body1)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first PATCH status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	rels := outgoingByType(app, "TKT-001", "tagged")
+	if len(rels) != 1 || rels[0].Content != "edge body" {
+		t.Fatalf("after first PATCH: %v", rels)
+	}
+
+	body2 := `{"relations": {"tagged": {"data": [{"type":"label","id":"L-001","content":""}]}}}`
+	rec = patch(t, app, "tickets", "TKT-001", body2)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second PATCH status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	rels = outgoingByType(app, "TKT-001", "tagged")
+	if len(rels) != 1 || rels[0].Content != "" {
+		t.Fatalf("content should be cleared, got %q", rels[0].Content)
+	}
+}
+
+// AC5: data: [] removes all edges of that type.
+func TestModern_AC5_EmptyDataRemovesAll(t *testing.T) {
+	app := newRelationsTestApp(t)
+	for _, id := range []string{"L-001", "L-002", "L-003"} {
+		if _, err := app.store.CreateRelation(context.Background(), "TKT-001", "tagged", id, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	body := `{"relations": {"tagged": {"data": []}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if rels := outgoingByType(app, "TKT-001", "tagged"); len(rels) != 0 {
+		t.Errorf("len=%d, want 0; %v", len(rels), rels)
+	}
+}
+
+// AC6: replacement semantics — keep, add, remove.
+func TestModern_AC6_Replacement(t *testing.T) {
+	app := newRelationsTestApp(t)
+	for _, id := range []string{"L-001", "L-002", "L-003"} {
+		if _, err := app.store.CreateRelation(context.Background(), "TKT-001", "tagged", id, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedEntity(app, &entity.Entity{ID: "L-004", Type: "label", Properties: map[string]interface{}{"title": "new"}})
+
+	body := `{"relations": {"tagged": {"data": [
+		{"type":"label","id":"L-001"},
+		{"type":"label","id":"L-004"}
+	]}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	rels := outgoingByType(app, "TKT-001", "tagged")
+	got := map[string]bool{}
+	for _, r := range rels {
+		got[r.To] = true
+	}
+	want := map[string]bool{"L-001": true, "L-004": true}
+	if len(got) != len(want) {
+		t.Fatalf("got=%v, want=%v", got, want)
+	}
+	for k := range want {
+		if !got[k] {
+			t.Errorf("missing %q", k)
+		}
+	}
+}
+
+// AC7: absent relation type leaves alone.
+func TestModern_AC7_AbsentTypeLeavesAlone(t *testing.T) {
+	app := newRelationsTestApp(t)
+	if _, err := app.store.CreateRelation(context.Background(), "TKT-001", "tagged", "L-001", nil); err != nil {
+		t.Fatal(err)
+	}
+	seedEntity(app, &entity.Entity{ID: "C-002", Type: "category", Properties: map[string]interface{}{"title": "Frontend"}})
+	body := `{"relations": {"belongs-to": {"data": [{"type":"category","id":"C-002"}]}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if rels := outgoingByType(app, "TKT-001", "tagged"); len(rels) != 1 {
+		t.Errorf("tagged should be preserved, got %v", rels)
+	}
+}
+
+// AC8: {"tagged": {}} returns 400.
+func TestModern_AC8_DataAbsentReturns400(t *testing.T) {
+	app := newRelationsTestApp(t)
+	body := `{"relations": {"tagged": {}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// AC9: unknown relation type returns 422.
+func TestModern_AC9_UnknownRelationTypeReturns422(t *testing.T) {
+	app := newRelationsTestApp(t)
+	body := `{"relations": {"nonexistent": {"data": []}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status=%d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// AC10: target type mismatch surfaces warning, edge IS written.
+func TestModern_AC10_TargetTypeMismatchWarns(t *testing.T) {
+	app := newRelationsTestApp(t)
+	body := `{"relations": {"tagged": {"data": [{"type":"category","id":"L-001"}]}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200 (with warning); body=%s", rec.Code, rec.Body.String())
+	}
+	got := decodeV1(t, rec.Body.Bytes())
+	found := false
+	for _, w := range got.Warnings {
+		if w.Code == "target_type_mismatch" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected target_type_mismatch warning, got %v", got.Warnings)
+	}
+	if rels := outgoingByType(app, "TKT-001", "tagged"); len(rels) != 1 {
+		t.Errorf("edge should still be created despite warning, got %d", len(rels))
+	}
+}
+
+// AC11: target ID doesn't exist surfaces warning.
+func TestModern_AC11_TargetMissingWarns(t *testing.T) {
+	app := newRelationsTestApp(t)
+	body := `{"relations": {"tagged": {"data": [{"type":"label","id":"L-DOES-NOT-EXIST"}]}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	got := decodeV1(t, rec.Body.Bytes())
+	found := false
+	for _, w := range got.Warnings {
+		if w.Code == "target_not_found" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected target_not_found warning, got %v", got.Warnings)
+	}
+}
+
+// AC12: unknown meta key surfaces warning.
+func TestModern_AC12_UnknownMetaKeyWarns(t *testing.T) {
+	app := newRelationsTestApp(t)
+	body := `{"relations": {"tagged": {"data": [{"type":"label","id":"L-001","meta":{"unknownX":1}}]}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	got := decodeV1(t, rec.Body.Bytes())
+	found := false
+	for _, w := range got.Warnings {
+		if w.Code == "unknown_meta_key" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected unknown_meta_key warning, got %v", got.Warnings)
+	}
+	rels := outgoingByType(app, "TKT-001", "tagged")
+	if len(rels) != 1 {
+		t.Fatalf("len=%d, want 1", len(rels))
+	}
+	if rels[0].Properties["unknownX"] != float64(1) {
+		t.Errorf("meta should still be persisted, got %v", rels[0].Properties)
+	}
+}
+
+// AC12b: required meta unset surfaces warning.
+func TestModern_AC12b_RequiredMetaUnsetWarns(t *testing.T) {
+	app := newRelationsTestApp(t)
+	body := `{"relations": {"assessed-by": {"data": [{"type":"reviewer","id":"R-001"}]}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	got := decodeV1(t, rec.Body.Bytes())
+	found := false
+	for _, w := range got.Warnings {
+		if w.Code == "required_meta_unset" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected required_meta_unset warning, got %v", got.Warnings)
+	}
+}
+
+// AC12c: meta type mismatch surfaces warning.
+func TestModern_AC12c_MetaTypeMismatchWarns(t *testing.T) {
+	app := newRelationsTestApp(t)
+	body := `{"relations": {"tagged": {"data": [{"type":"label","id":"L-001","meta":{"weight":"not-a-number"}}]}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	got := decodeV1(t, rec.Body.Bytes())
+	found := false
+	for _, w := range got.Warnings {
+		if w.Code == "meta_type_mismatch" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected meta_type_mismatch warning, got %v", got.Warnings)
+	}
+}
+
+// AC13: content on non-content-bearing relation type returns 422.
+func TestModern_AC13_ContentOnNonContentTypeReturns422(t *testing.T) {
+	app := newRelationsTestApp(t)
+	body := `{"relations": {"belongs-to": {"data": [{"type":"category","id":"C-001","content":"body"}]}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status=%d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// AC14: value-based no-op suppression — re-PATCHing identical state writes nothing.
+func TestModern_AC14_ValueBasedNoOp(t *testing.T) {
+	app := newRelationsTestApp(t)
+	if _, err := app.store.CreateRelation(context.Background(), "TKT-001", "tagged", "L-001",
+		&store.RelationData{Properties: map[string]interface{}{"weight": float64(5)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	events, cancel := app.store.Subscribe(16)
+	body := `{"relations": {"tagged": {"data": [{"type":"label","id":"L-001","meta":{"weight":5}}]}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	relCount := 0
+	done := make(chan struct{})
+	go func() {
+		for range events {
+			relCount++
+		}
+		close(done)
+	}()
+	cancel()
+	<-done
+
+	if relCount != 0 {
+		t.Errorf("expected 0 store events on no-op PATCH, got %d", relCount)
+	}
+}
+
+// AC17: validation failure leaves entity AND relations untouched.
+func TestModern_AC17_ValidationFailureLeavesStateUntouched(t *testing.T) {
+	app := newRelationsTestApp(t)
+	before, _ := app.store.GetEntity(context.Background(), "TKT-001")
+	titleBefore := before.Properties["title"]
+
+	body := `{
+		"properties": {"title": "Should NOT be saved"},
+		"relations": {"nonexistent": {"data": []}}
+	}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status=%d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+
+	after, _ := app.store.GetEntity(context.Background(), "TKT-001")
+	if after.Properties["title"] != titleBefore {
+		t.Errorf("title changed to %q, want %q (entity should be untouched on relation 422)",
+			after.Properties["title"], titleBefore)
+	}
+}
+
+// AC18: legacy + modern shapes mixed in one body return 400 deterministically.
+func TestModern_AC18_MixedShapesReturns400Deterministically(t *testing.T) {
+	app := newRelationsTestApp(t)
+	bodies := []string{
+		`{"relations": {"tagged": ["L-001"], "belongs-to": {"data": [{"type":"category","id":"C-001"}]}}}`,
+		`{"relations": {"belongs-to": {"data": [{"type":"category","id":"C-001"}]}, "tagged": ["L-001"]}}`,
+	}
+	for _, body := range bodies {
+		rec := patch(t, app, "tickets", "TKT-001", body)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("body=%s: status=%d, want 400; body=%s", body, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+// AC19: sibling-key rejection.
+func TestModern_AC19_UnknownSiblingKeyReturns400(t *testing.T) {
+	app := newRelationsTestApp(t)
+	body := `{"relations": {"tagged": {"datas": [{"type":"label","id":"L-001"}]}}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// AC20a: non-string element in meta_unset returns 400.
+func TestModern_AC20a_NonStringInMetaUnsetReturns400(t *testing.T) {
+	app := newRelationsTestApp(t)
+	cases := []string{
+		`{"relations": {"tagged": {"data": [{"type":"label","id":"L-001","meta_unset":["x", null]}]}}}`,
+		`{"relations": {"tagged": {"data": [{"type":"label","id":"L-001","meta_unset":["x", 5]}]}}}`,
+	}
+	for _, body := range cases {
+		rec := patch(t, app, "tickets", "TKT-001", body)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("body=%s: status=%d, want 400", body, rec.Code)
+		}
+	}
+}
+
+// AC15: backwards compat with IDs-only shape.
+func TestModern_AC15_LegacyShapeStillWorks(t *testing.T) {
+	app := newRelationsTestApp(t)
+	body := `{"relations": {"tagged": ["L-001", "L-002"]}}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("legacy shape status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if rels := outgoingByType(app, "TKT-001", "tagged"); len(rels) != 2 {
+		t.Errorf("len=%d, want 2", len(rels))
+	}
+}
+
+// AC16: combined PATCH (properties + relations).
+func TestModern_AC16_CombinedPatch(t *testing.T) {
+	app := newRelationsTestApp(t)
+	body := `{
+		"properties": {"status": "in-progress"},
+		"relations": {"tagged": {"data": [{"type":"label","id":"L-001","meta":{"weight":3}}]}}
+	}`
+	rec := patch(t, app, "tickets", "TKT-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	got, _ := app.store.GetEntity(context.Background(), "TKT-001")
+	if got.Properties["status"] != "in-progress" {
+		t.Errorf("status=%v, want in-progress", got.Properties["status"])
+	}
+	if rels := outgoingByType(app, "TKT-001", "tagged"); len(rels) != 1 || rels[0].Properties["weight"] != float64(3) {
+		t.Errorf("relations not as expected: %v", rels)
+	}
+}

--- a/internal/dataentry/relations_v1_wire.go
+++ b/internal/dataentry/relations_v1_wire.go
@@ -1,0 +1,356 @@
+package dataentry
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// V1RelationsField is the top-level value of the `relations` key in a
+// PATCH /api/v1/{plural}/{id} request body. It accepts EITHER the
+// legacy IDs-only shape (`map[string][]string`) OR the JSON:API §9-shaped
+// object form (`map[string]V1RelationsUpdate`). Mixing the two in a
+// single request body is rejected at unmarshal time with a stable
+// `shape_mixed` error.
+type V1RelationsField struct {
+	// Legacy holds the IDs-only form when every relation type in the
+	// body used `[<id>, <id>, ...]`. Mutually exclusive with Modern.
+	Legacy map[string][]string
+
+	// Modern holds the JSON:API §9-shaped form when every relation type
+	// in the body used `{"data": [...]}`. Mutually exclusive with Legacy.
+	Modern map[string]V1RelationsUpdate
+}
+
+// IsEmpty reports whether neither shape was populated (the relations
+// field was absent or `{}` in the request body).
+func (f V1RelationsField) IsEmpty() bool {
+	return len(f.Legacy) == 0 && len(f.Modern) == 0
+}
+
+// V1RelationsUpdate is the JSON:API §9 wrapper for one relation type's
+// desired state. The wrapper has exactly one field, `data`, which is the
+// full desired set of edges of this relation type.
+//
+// `DataPresent` distinguishes three wire-level cases:
+//   - `{"tagged": {}}`           → DataPresent=false → 400 `data_required`
+//   - `{"tagged": {"data": null}}` → DataPresent=false → 400 `data_required`
+//   - `{"tagged": {"data": []}}` → DataPresent=true, Data=[] → remove all
+//   - `{"tagged": {"data": [...]}}` → DataPresent=true, Data populated
+//
+// Sending `data: []` removes every edge of this relation type from the
+// entity. See docs/data-entry/api-reference.md for the full footgun
+// callout.
+type V1RelationsUpdate struct {
+	Data        []V1ResourceIdentifier
+	DataPresent bool
+}
+
+// V1ResourceIdentifier is the per-edge resource identifier in a JSON:API
+// §9-shaped relation update. `Type` and `ID` identify the target;
+// `Meta`, `MetaUnset`, and `Content` carry per-edge upsert data.
+type V1ResourceIdentifier struct {
+	Type      string                 `json:"type"`
+	ID        string                 `json:"id"`
+	Meta      map[string]interface{} `json:"meta,omitempty"`
+	MetaUnset []string               `json:"meta_unset,omitempty"`
+	// Content is a pointer so a missing field (leave alone) can be
+	// distinguished from an explicit empty string (clear the body).
+	Content *string `json:"content,omitempty"`
+}
+
+// wireError is the structured error returned from V1RelationsField's
+// unmarshal. Code is stable for clients; Path is an RFC 6901 JSON
+// Pointer; Detail is human-readable.
+type wireError struct {
+	Code   string
+	Path   string
+	Detail string
+}
+
+func (e *wireError) Error() string {
+	if e.Path != "" {
+		return fmt.Sprintf("%s: %s (path: %s)", e.Code, e.Detail, e.Path)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Detail)
+}
+
+// UnmarshalJSON decodes the relations field. It scans every relation
+// type to detect which shape the caller used. If both shapes appear in
+// the same body the call returns a `shape_mixed` error with no key
+// names (Go map iteration is randomized; naming a "second" key would
+// produce non-deterministic error messages).
+func (f *V1RelationsField) UnmarshalJSON(b []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+
+	var (
+		sawLegacy bool
+		sawModern bool
+		legacy    = make(map[string][]string)
+		modern    = make(map[string]V1RelationsUpdate)
+	)
+
+	for relType, val := range raw {
+		trimmed := bytes.TrimLeftFunc(val, unicode.IsSpace)
+		if len(trimmed) == 0 {
+			return &wireError{
+				Code:   "relation_value_invalid",
+				Path:   "/relations/" + jsonPointerEscape(relType),
+				Detail: "relation type value is empty",
+			}
+		}
+		switch trimmed[0] {
+		case '[':
+			sawLegacy = true
+			var ids []string
+			if err := json.Unmarshal(val, &ids); err != nil {
+				return &wireError{
+					Code:   "legacy_value_invalid",
+					Path:   "/relations/" + jsonPointerEscape(relType),
+					Detail: "legacy IDs-only relation must be an array of strings: " + err.Error(),
+				}
+			}
+			legacy[relType] = ids
+		case '{':
+			sawModern = true
+			update, err := decodeRelationsUpdate(relType, val)
+			if err != nil {
+				return err
+			}
+			modern[relType] = update
+		case 'n':
+			if string(trimmed) == "null" {
+				return &wireError{
+					Code:   "relation_value_null",
+					Path:   "/relations/" + jsonPointerEscape(relType),
+					Detail: "relation type value cannot be null; use \"data\": [] to clear all edges",
+				}
+			}
+			return &wireError{
+				Code:   "relation_value_invalid",
+				Path:   "/relations/" + jsonPointerEscape(relType),
+				Detail: "relation type value must be an array (legacy) or object (JSON:API)",
+			}
+		default:
+			return &wireError{
+				Code:   "relation_value_invalid",
+				Path:   "/relations/" + jsonPointerEscape(relType),
+				Detail: "relation type value must be an array (legacy) or object (JSON:API)",
+			}
+		}
+	}
+
+	if sawLegacy && sawModern {
+		return &wireError{
+			Code:   "shape_mixed",
+			Detail: "request mixes legacy and JSON:API relation shapes; use one or the other",
+		}
+	}
+
+	if sawLegacy {
+		f.Legacy = legacy
+	}
+	if sawModern {
+		f.Modern = modern
+	}
+	return nil
+}
+
+// decodeRelationsUpdate handles the modern `{"data": [...]}` wrapper.
+// Returns a wireError on any malformed input.
+func decodeRelationsUpdate(relType string, raw json.RawMessage) (V1RelationsUpdate, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return V1RelationsUpdate{}, &wireError{
+			Code:   "wrapper_invalid",
+			Path:   "/relations/" + jsonPointerEscape(relType),
+			Detail: "wrapper must be a JSON object with a `data` array",
+		}
+	}
+
+	for k := range fields {
+		if k != "data" {
+			return V1RelationsUpdate{}, &wireError{
+				Code:   "unknown_field",
+				Path:   "/relations/" + jsonPointerEscape(relType) + "/" + jsonPointerEscape(k),
+				Detail: fmt.Sprintf("unknown field %q on relation wrapper (only `data` is allowed)", k),
+			}
+		}
+	}
+
+	dataRaw, present := fields["data"]
+	if !present {
+		return V1RelationsUpdate{DataPresent: false}, nil
+	}
+
+	trimmed := bytes.TrimLeftFunc(dataRaw, unicode.IsSpace)
+	if len(trimmed) == 0 {
+		return V1RelationsUpdate{}, &wireError{
+			Code:   "data_required",
+			Path:   "/relations/" + jsonPointerEscape(relType) + "/data",
+			Detail: "`data` must be an array",
+		}
+	}
+	if string(trimmed) == "null" {
+		// Treated identically to the data-absent case (per RR-UZ8LX).
+		return V1RelationsUpdate{}, &wireError{
+			Code:   "data_required",
+			Path:   "/relations/" + jsonPointerEscape(relType) + "/data",
+			Detail: "`data` cannot be null; use [] to clear all edges of this type",
+		}
+	}
+	if trimmed[0] != '[' {
+		return V1RelationsUpdate{}, &wireError{
+			Code:   "data_invalid_type",
+			Path:   "/relations/" + jsonPointerEscape(relType) + "/data",
+			Detail: "`data` must be an array of resource identifiers",
+		}
+	}
+
+	// Validate meta_unset arrays element-by-element BEFORE the
+	// struct unmarshal — Go's json.Unmarshal coerces `null` into the
+	// empty string when decoding `[]string`, masking what should be
+	// a wire-format error.
+	if err := validateMetaUnsetElements(relType, dataRaw); err != nil {
+		return V1RelationsUpdate{}, err
+	}
+
+	var refs []V1ResourceIdentifier
+	dec := json.NewDecoder(bytes.NewReader(dataRaw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&refs); err != nil {
+		return V1RelationsUpdate{}, translateRefDecodeError(relType, dataRaw, err)
+	}
+
+	for i, ref := range refs {
+		if ref.Type == "" {
+			return V1RelationsUpdate{}, &wireError{
+				Code:   "field_required",
+				Path:   fmt.Sprintf("/relations/%s/data/%d/type", jsonPointerEscape(relType), i),
+				Detail: "`type` is required on each resource identifier",
+			}
+		}
+		if ref.ID == "" {
+			return V1RelationsUpdate{}, &wireError{
+				Code:   "field_required",
+				Path:   fmt.Sprintf("/relations/%s/data/%d/id", jsonPointerEscape(relType), i),
+				Detail: "`id` is required on each resource identifier",
+			}
+		}
+	}
+
+	return V1RelationsUpdate{Data: refs, DataPresent: true}, nil
+}
+
+// validateMetaUnsetElements scans the raw JSON for the data array and
+// rejects meta_unset arrays that contain non-string elements. Run
+// before the struct decode because json.Unmarshal silently coerces
+// `null` to the empty string when target type is string, and we want
+// to fail loudly on that case.
+func validateMetaUnsetElements(relType string, dataRaw json.RawMessage) error {
+	var rawRefs []json.RawMessage
+	if err := json.Unmarshal(dataRaw, &rawRefs); err != nil {
+		// Not an array — the main decoder will surface the right error
+		// in a wireError shape; we deliberately swallow this one to
+		// avoid double-reporting.
+		return nil //nolint:nilerr // see comment
+	}
+	for i, rawRef := range rawRefs {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(rawRef, &fields); err != nil {
+			continue // not an object; main decoder will fail
+		}
+		muRaw, ok := fields["meta_unset"]
+		if !ok {
+			continue
+		}
+		trimmed := bytes.TrimLeftFunc(muRaw, unicode.IsSpace)
+		if len(trimmed) == 0 || string(trimmed) == "null" {
+			continue // null/absent treated as absent
+		}
+		if trimmed[0] != '[' {
+			return &wireError{
+				Code:   "meta_unset_invalid",
+				Path:   fmt.Sprintf("/relations/%s/data/%d/meta_unset", jsonPointerEscape(relType), i),
+				Detail: "`meta_unset` must be an array of strings",
+			}
+		}
+		var elems []json.RawMessage
+		if err := json.Unmarshal(muRaw, &elems); err != nil {
+			return &wireError{
+				Code:   "meta_unset_invalid",
+				Path:   fmt.Sprintf("/relations/%s/data/%d/meta_unset", jsonPointerEscape(relType), i),
+				Detail: err.Error(),
+			}
+		}
+		for j, e := range elems {
+			t := bytes.TrimLeftFunc(e, unicode.IsSpace)
+			if len(t) == 0 || t[0] != '"' {
+				return &wireError{
+					Code: "meta_unset_invalid",
+					Path: fmt.Sprintf("/relations/%s/data/%d/meta_unset/%d",
+						jsonPointerEscape(relType), i, j),
+					Detail: "`meta_unset` elements must be strings",
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// translateRefDecodeError maps json.Decoder errors on a resource
+// identifier slice into a structured wireError. Covers unknown-field
+// rejection and the most common malformed-shape cases.
+func translateRefDecodeError(relType string, dataRaw json.RawMessage, err error) error {
+	msg := err.Error()
+	// Best-effort path inference: when DisallowUnknownFields rejects a
+	// field, the message names which one. We don't get a stable
+	// element index, so we cite the array generically.
+	if strings.Contains(msg, "unknown field") {
+		return &wireError{
+			Code:   "unknown_field",
+			Path:   "/relations/" + jsonPointerEscape(relType) + "/data",
+			Detail: msg,
+		}
+	}
+	// Best-effort: catch the meta_unset non-string element case, which
+	// json reports as "cannot unmarshal X into Go struct field
+	// V1ResourceIdentifier.meta_unset of type string".
+	if strings.Contains(msg, ".meta_unset of type string") {
+		return &wireError{
+			Code:   "meta_unset_invalid",
+			Path:   "/relations/" + jsonPointerEscape(relType) + "/data",
+			Detail: "`meta_unset` must contain only strings",
+		}
+	}
+	// Fallback: generic body-invalid.
+	_ = dataRaw // reserved for future richer parsing
+	var jsonErr *json.UnmarshalTypeError
+	if errors.As(err, &jsonErr) {
+		return &wireError{
+			Code:   "field_invalid_type",
+			Path:   "/relations/" + jsonPointerEscape(relType) + "/data/" + jsonErr.Field,
+			Detail: msg,
+		}
+	}
+	return &wireError{
+		Code:   "data_invalid",
+		Path:   "/relations/" + jsonPointerEscape(relType) + "/data",
+		Detail: msg,
+	}
+}
+
+// jsonPointerEscape applies RFC 6901 JSON Pointer escaping to a single
+// reference token: `~` is encoded as `~0` and `/` as `~1`. The
+// substitutions are NOT commutative — `~` must be replaced before `/`.
+func jsonPointerEscape(s string) string {
+	s = strings.ReplaceAll(s, "~", "~0")
+	s = strings.ReplaceAll(s, "/", "~1")
+	return s
+}

--- a/internal/dataentry/relations_v1_wire_test.go
+++ b/internal/dataentry/relations_v1_wire_test.go
@@ -1,0 +1,332 @@
+package dataentry
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestV1RelationsField_LegacyShape(t *testing.T) {
+	body := `{"tagged": ["L-001", "L-002"], "belongs-to": ["C-1"]}`
+	var f V1RelationsField
+	if err := json.Unmarshal([]byte(body), &f); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if f.Modern != nil {
+		t.Errorf("Modern should be nil, got %v", f.Modern)
+	}
+	if got := f.Legacy["tagged"]; len(got) != 2 || got[0] != "L-001" || got[1] != "L-002" {
+		t.Errorf("Legacy[tagged] = %v, want [L-001 L-002]", got)
+	}
+	if got := f.Legacy["belongs-to"]; len(got) != 1 || got[0] != "C-1" {
+		t.Errorf("Legacy[belongs-to] = %v, want [C-1]", got)
+	}
+}
+
+func TestV1RelationsField_ModernShape(t *testing.T) {
+	body := `{
+		"tagged": {"data": [
+			{"type": "label", "id": "L-001", "meta": {"weight": 5}, "meta_unset": ["added_by"]},
+			{"type": "label", "id": "L-002"}
+		]}
+	}`
+	var f V1RelationsField
+	if err := json.Unmarshal([]byte(body), &f); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if f.Legacy != nil {
+		t.Errorf("Legacy should be nil, got %v", f.Legacy)
+	}
+	upd, ok := f.Modern["tagged"]
+	if !ok {
+		t.Fatalf("Modern[tagged] missing")
+	}
+	if !upd.DataPresent {
+		t.Errorf("DataPresent should be true")
+	}
+	if len(upd.Data) != 2 {
+		t.Fatalf("len(Data) = %d, want 2", len(upd.Data))
+	}
+	if upd.Data[0].Type != "label" || upd.Data[0].ID != "L-001" {
+		t.Errorf("Data[0] = %+v", upd.Data[0])
+	}
+	if v := upd.Data[0].Meta["weight"]; v != float64(5) {
+		t.Errorf("Data[0].Meta[weight] = %v (%T), want 5 (float64)", v, v)
+	}
+	if len(upd.Data[0].MetaUnset) != 1 || upd.Data[0].MetaUnset[0] != "added_by" {
+		t.Errorf("Data[0].MetaUnset = %v", upd.Data[0].MetaUnset)
+	}
+}
+
+func TestV1RelationsField_MixedShapes_ReturnsShapeMixed(t *testing.T) {
+	// Test both iteration orders by including legacy and modern in
+	// the same body. Run twice to maximize the chance of catching
+	// non-determinism (if the implementation accidentally introduced
+	// any).
+	bodies := []string{
+		`{"tagged": ["L-001"], "belongs-to": {"data": [{"type":"category","id":"C-1"}]}}`,
+		`{"belongs-to": {"data": [{"type":"category","id":"C-1"}]}, "tagged": ["L-001"]}`,
+	}
+	for _, body := range bodies {
+		for i := range 5 { // run multiple iterations to catch flakiness
+			var f V1RelationsField
+			err := json.Unmarshal([]byte(body), &f)
+			if err == nil {
+				t.Errorf("body=%s: expected error", body)
+				continue
+			}
+			var werr *wireError
+			if !errors.As(err, &werr) {
+				t.Errorf("body=%s: error is not *wireError: %v", body, err)
+				continue
+			}
+			if werr.Code != "shape_mixed" {
+				t.Errorf("body=%s iter=%d: code=%s, want shape_mixed", body, i, werr.Code)
+			}
+			// Detail must NOT name a relation type — it would be
+			// non-deterministic across map iterations.
+			if werr.Path != "" {
+				t.Errorf("body=%s iter=%d: path=%q, want empty (Go map iteration is randomized)", body, i, werr.Path)
+			}
+		}
+	}
+}
+
+func TestV1RelationsField_DataAbsent_ReturnsDataRequiredAtCallSite(t *testing.T) {
+	// Per the contract, the unmarshal succeeds with DataPresent=false
+	// and the caller (handler) emits the 400. This test asserts the
+	// state propagated correctly.
+	body := `{"tagged": {}}`
+	var f V1RelationsField
+	if err := json.Unmarshal([]byte(body), &f); err != nil {
+		t.Fatalf("unmarshal should not error at this layer: %v", err)
+	}
+	upd, ok := f.Modern["tagged"]
+	if !ok {
+		t.Fatalf("Modern[tagged] missing")
+	}
+	if upd.DataPresent {
+		t.Errorf("DataPresent should be false")
+	}
+	if len(upd.Data) != 0 {
+		t.Errorf("Data should be empty, got %v", upd.Data)
+	}
+}
+
+func TestV1RelationsField_DataNull_Rejected(t *testing.T) {
+	body := `{"tagged": {"data": null}}`
+	var f V1RelationsField
+	err := json.Unmarshal([]byte(body), &f)
+	if err == nil {
+		t.Fatalf("expected error for data: null")
+	}
+	var werr *wireError
+	if !errors.As(err, &werr) {
+		t.Fatalf("error is not *wireError: %v", err)
+	}
+	if werr.Code != "data_required" {
+		t.Errorf("code=%s, want data_required", werr.Code)
+	}
+}
+
+func TestV1RelationsField_DataNonArray_Rejected(t *testing.T) {
+	body := `{"tagged": {"data": "L-001"}}`
+	var f V1RelationsField
+	err := json.Unmarshal([]byte(body), &f)
+	if err == nil {
+		t.Fatalf("expected error for data: scalar")
+	}
+	var werr *wireError
+	if !errors.As(err, &werr) {
+		t.Fatalf("error is not *wireError: %v", err)
+	}
+	if werr.Code != "data_invalid_type" {
+		t.Errorf("code=%s, want data_invalid_type", werr.Code)
+	}
+}
+
+func TestV1RelationsField_RelationValueNull_Rejected(t *testing.T) {
+	body := `{"tagged": null}`
+	var f V1RelationsField
+	err := json.Unmarshal([]byte(body), &f)
+	if err == nil {
+		t.Fatalf("expected error for null relation value")
+	}
+	var werr *wireError
+	if !errors.As(err, &werr) {
+		t.Fatalf("error is not *wireError: %v", err)
+	}
+	if werr.Code != "relation_value_null" {
+		t.Errorf("code=%s, want relation_value_null", werr.Code)
+	}
+}
+
+func TestV1RelationsField_RelationValueScalar_Rejected(t *testing.T) {
+	cases := []string{
+		`{"tagged": "L-001"}`,
+		`{"tagged": 5}`,
+		`{"tagged": true}`,
+	}
+	for _, body := range cases {
+		var f V1RelationsField
+		err := json.Unmarshal([]byte(body), &f)
+		if err == nil {
+			t.Errorf("body=%s: expected error", body)
+			continue
+		}
+		var werr *wireError
+		if !errors.As(err, &werr) {
+			t.Errorf("body=%s: error is not *wireError: %v", body, err)
+			continue
+		}
+		if werr.Code != "relation_value_invalid" {
+			t.Errorf("body=%s: code=%s, want relation_value_invalid", body, werr.Code)
+		}
+	}
+}
+
+func TestV1RelationsField_UnknownSiblingKey_Rejected(t *testing.T) {
+	body := `{"tagged": {"datas": [{"type":"label","id":"L-001"}]}}`
+	var f V1RelationsField
+	err := json.Unmarshal([]byte(body), &f)
+	if err == nil {
+		t.Fatalf("expected error for unknown sibling key")
+	}
+	var werr *wireError
+	if !errors.As(err, &werr) {
+		t.Fatalf("error is not *wireError: %v", err)
+	}
+	if werr.Code != "unknown_field" {
+		t.Errorf("code=%s, want unknown_field", werr.Code)
+	}
+}
+
+func TestV1RelationsField_MissingTypeOrID_Rejected(t *testing.T) {
+	cases := []struct {
+		body string
+		want string
+	}{
+		{`{"tagged": {"data": [{"id": "L-001"}]}}`, "type"},
+		{`{"tagged": {"data": [{"type": "label"}]}}`, "id"},
+	}
+	for _, tc := range cases {
+		var f V1RelationsField
+		err := json.Unmarshal([]byte(tc.body), &f)
+		if err == nil {
+			t.Errorf("body=%s: expected error", tc.body)
+			continue
+		}
+		var werr *wireError
+		if !errors.As(err, &werr) {
+			t.Errorf("body=%s: error is not *wireError: %v", tc.body, err)
+			continue
+		}
+		if werr.Code != "field_required" {
+			t.Errorf("body=%s: code=%s, want field_required", tc.body, werr.Code)
+		}
+	}
+}
+
+func TestV1RelationsField_NonStringInMetaUnset_Rejected(t *testing.T) {
+	cases := []string{
+		`{"tagged": {"data": [{"type":"label","id":"L-001","meta_unset":["x", null]}]}}`,
+		`{"tagged": {"data": [{"type":"label","id":"L-001","meta_unset":["x", 5]}]}}`,
+	}
+	for _, body := range cases {
+		var f V1RelationsField
+		err := json.Unmarshal([]byte(body), &f)
+		if err == nil {
+			t.Errorf("body=%s: expected error", body)
+			continue
+		}
+		var werr *wireError
+		if !errors.As(err, &werr) {
+			t.Errorf("body=%s: error is not *wireError: %v", body, err)
+			continue
+		}
+		if werr.Code != "meta_unset_invalid" && werr.Code != "field_invalid_type" {
+			t.Errorf("body=%s: code=%s, want meta_unset_invalid or field_invalid_type", body, werr.Code)
+		}
+	}
+}
+
+func TestV1RelationsField_MetaNull_TreatedAsAbsent(t *testing.T) {
+	body := `{"tagged": {"data": [{"type":"label","id":"L-001","meta":null}]}}`
+	var f V1RelationsField
+	if err := json.Unmarshal([]byte(body), &f); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := f.Modern["tagged"].Data[0].Meta; got != nil {
+		t.Errorf("Meta should be nil for meta:null, got %v", got)
+	}
+}
+
+func TestV1RelationsField_ContentNull_TreatedAsAbsent(t *testing.T) {
+	body := `{"tagged": {"data": [{"type":"label","id":"L-001","content":null}]}}`
+	var f V1RelationsField
+	if err := json.Unmarshal([]byte(body), &f); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := f.Modern["tagged"].Data[0].Content; got != nil {
+		t.Errorf("Content should be nil for content:null, got %v", *got)
+	}
+}
+
+func TestV1RelationsField_ContentEmptyString_PointerNotNil(t *testing.T) {
+	body := `{"tagged": {"data": [{"type":"label","id":"L-001","content":""}]}}`
+	var f V1RelationsField
+	if err := json.Unmarshal([]byte(body), &f); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := f.Modern["tagged"].Data[0].Content
+	if got == nil {
+		t.Fatalf("Content should be non-nil for content:\"\"")
+	}
+	if *got != "" {
+		t.Errorf("*Content = %q, want empty string", *got)
+	}
+}
+
+func TestV1RelationsField_EmptyDataMeansRemoveAll(t *testing.T) {
+	body := `{"tagged": {"data": []}}`
+	var f V1RelationsField
+	if err := json.Unmarshal([]byte(body), &f); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	upd := f.Modern["tagged"]
+	if !upd.DataPresent {
+		t.Errorf("DataPresent should be true for data: []")
+	}
+	if len(upd.Data) != 0 {
+		t.Errorf("len(Data) = %d, want 0", len(upd.Data))
+	}
+}
+
+func TestV1RelationsField_IsEmpty(t *testing.T) {
+	var f V1RelationsField
+	if !f.IsEmpty() {
+		t.Error("zero-value should be empty")
+	}
+	f.Legacy = map[string][]string{"a": {"b"}}
+	if f.IsEmpty() {
+		t.Error("legacy populated should not be empty")
+	}
+}
+
+func TestJSONPointerEscape(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"foo", "foo"},
+		{"foo/bar", "foo~1bar"},
+		{"foo~bar", "foo~0bar"},
+		{"foo~/bar", "foo~0~1bar"}, // ~ replaced first, then /
+		{"a/b/c", "a~1b~1c"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := jsonPointerEscape(tc.in); got != tc.want {
+			t.Errorf("jsonPointerEscape(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -172,8 +172,15 @@ func reseedStore(dst, src store.Store) {
 func newAppFromParts(cfg *Config, meta *metamodel.Metamodel, f *fixture) *App {
 	app := &App{scriptEngine: script.NewEngine()}
 	if meta != nil {
-		ws := workspace.NewForTest(meta)
-		rebindApp(app, nil, &project.Context{}, ws)
+		// Use an in-memory FS + project context so the workspace's
+		// templater has paths it can dereference. Without this,
+		// CreateRelation panics inside RelationTemplate when it tries
+		// to compute a path against a nil *project.Context.
+		fs := storage.NewMemFS()
+		ctx := &project.Context{Root: "/project", CacheDir: "/project/.rela"}
+		_ = fs.MkdirAll(ctx.CacheDir, 0o755)
+		ws := workspace.NewForTest(meta, workspace.WithFS(fs, ctx))
+		rebindApp(app, fs, ctx, ws)
 		seedFromFixture(app.store, f)
 	}
 	if cfg == nil {

--- a/internal/entitymanager/entitymanager.go
+++ b/internal/entitymanager/entitymanager.go
@@ -68,10 +68,27 @@ type RenameResult struct {
 	RelationsUpdated int
 }
 
-// RelationOptions configure relation creation.
+// RelationOptions configure relation creation and updates.
+//
+// CreateRelation: Properties is the initial property map. MetaUnset is
+// ignored (no existing values to clear). If Content is non-nil, the body
+// is set to *Content (including the empty string); if nil, the body is
+// empty.
+//
+// UpdateRelation: Properties MERGES into the existing relation's
+// properties (an Update with empty Properties does NOT clear existing
+// keys — use MetaUnset for that). After the merge, MetaUnset removes
+// the named keys. If Content is non-nil, the body is replaced with
+// *Content (including the empty string clears the body); if nil, the
+// existing body is left untouched.
+//
+// The pointer-vs-string distinction on Content is the only way to
+// express "leave the body alone" vs "set the body to empty"; callers
+// that want to clear must pass a pointer to "".
 type RelationOptions struct {
 	Properties map[string]interface{}
-	Content    string
+	MetaUnset  []string
+	Content    *string
 }
 
 // EntityManager provides the high-level write API for entities and relations.

--- a/internal/lua/runtime_test.go
+++ b/internal/lua/runtime_test.go
@@ -217,9 +217,13 @@ func (m *mockManager) RenameEntity(
 func (m *mockManager) CreateRelation(
 	ctx context.Context, from, relType, to string, opts entitymanager.RelationOptions,
 ) (*entity.Relation, error) {
+	content := ""
+	if opts.Content != nil {
+		content = *opts.Content
+	}
 	var data *store.RelationData
-	if len(opts.Properties) > 0 || opts.Content != "" {
-		data = &store.RelationData{Properties: opts.Properties, Content: opts.Content}
+	if len(opts.Properties) > 0 || content != "" {
+		data = &store.RelationData{Properties: opts.Properties, Content: content}
 	}
 	return m.ws.store.CreateRelation(ctx, from, relType, to, data)
 }
@@ -227,8 +231,12 @@ func (m *mockManager) CreateRelation(
 func (m *mockManager) UpdateRelation(
 	ctx context.Context, from, relType, to string, opts entitymanager.RelationOptions,
 ) (*entity.Relation, error) {
+	content := ""
+	if opts.Content != nil {
+		content = *opts.Content
+	}
 	return m.ws.store.UpdateRelation(ctx, from, relType, to, store.RelationData{
-		Properties: opts.Properties, Content: opts.Content,
+		Properties: opts.Properties, Content: content,
 	})
 }
 

--- a/internal/mcp/tools_relation.go
+++ b/internal/mcp/tools_relation.go
@@ -73,9 +73,13 @@ func (s *Server) handleCreateRelation(
 	}
 	toID = trimID(toID)
 
+	// Treat an empty `content` string from the MCP request as "leave alone"
+	// rather than "set body to empty". MCP clients can omit the field or
+	// pass null to mean the same; an explicit "" today never reaches a
+	// no-content-meant-empty case in practice.
 	opts := entitymanager.RelationOptions{
 		Properties: extractProperties(request),
-		Content:    request.GetString("content", ""),
+		Content:    nilIfEmpty(request.GetString("content", "")),
 	}
 
 	if _, createErr := s.ws.EntityManager().CreateRelation(ctx, fromID, relType, toID, opts); createErr != nil {
@@ -117,4 +121,14 @@ func (s *Server) handleDeleteRelation(
 
 	return mcp.NewToolResultText(
 		fmt.Sprintf("Removed link: %s --%s--> %s", fromID, relType, toID)), nil
+}
+
+// nilIfEmpty returns nil when s is empty, else &s. Used to translate
+// "absent / empty string" inputs from the MCP layer into the
+// leave-alone semantic of entitymanager.RelationOptions.Content.
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }

--- a/internal/openapi/schemas.go
+++ b/internal/openapi/schemas.go
@@ -176,10 +176,25 @@ func (g *Generator) buildUpdateEntitySchema(typeName string, def metamodel.Entit
 		Description: "Markdown body content",
 	}
 
+	// Relations: each relation type's value is one of two shapes —
+	// the legacy IDs-only array, or the JSON:API §9-shaped wrapper
+	// with per-edge meta + content. See Layer 1 of TKT-6WLSW.
+	props["relations"] = &Schema{
+		Type: "object",
+		AdditionalProperties: &Schema{
+			OneOf: []*Schema{
+				ArraySchema(StringSchema()),
+				Ref("RelationsUpdate"),
+			},
+			Description: "Either a legacy array of target IDs OR a JSON:API §9 wrapper {data: [...]}",
+		},
+		Description: "Outgoing relations by relation type. Mixing legacy and JSON:API shapes in one body returns 400.",
+	}
+
 	return &Schema{
 		Type:        "object",
 		Title:       "Update" + typeName,
-		Description: "Request body for updating a " + def.Label + " (PATCH - partial update)",
+		Description: "Request body for updating a " + def.Label + " (PATCH - partial update). See docs/data-entry/api-reference.md for the full contract.",
 		Properties:  props,
 	}
 }
@@ -221,9 +236,47 @@ func (g *Generator) addCommonSchemas(spec *Spec) {
 				Type:                 "object",
 				AdditionalProperties: ArraySchema(StringSchema()),
 			},
-			"_self": {Type: "string", Format: "uri-reference"},
+			"_self":    {Type: "string", Format: "uri-reference"},
+			"warnings": ArraySchema(Ref("Warning")),
 		},
 		Required: []string{"id", "type"},
+	}
+
+	// JSON:API §9-shaped wrapper for one relation type's desired state.
+	spec.Components.Schemas["RelationsUpdate"] = &Schema{
+		Type: "object",
+		Description: "Desired state for one relation type. " +
+			"Sending data: [] removes every edge of this relation type — see the data-loss " +
+			"footgun callout in docs/data-entry/api-reference.md.",
+		Properties: map[string]*Schema{
+			"data": ArraySchema(Ref("ResourceIdentifier")),
+		},
+		Required: []string{"data"},
+	}
+
+	// Per-edge resource identifier with rela's upsert convention.
+	spec.Components.Schemas["ResourceIdentifier"] = &Schema{
+		Type: "object",
+		Properties: map[string]*Schema{
+			"type":       {Type: "string", Description: "Target entity type"},
+			"id":         {Type: "string", Description: "Target entity ID"},
+			"meta":       {Type: "object", AdditionalProperties: &Schema{}, Description: "Per-edge meta properties (upsert)"},
+			"meta_unset": ArraySchema(StringSchema()),
+			"content":    {Type: "string", Description: "Per-edge body (only for relation types with content: true)"},
+		},
+		Required: []string{"type", "id"},
+	}
+
+	// Soft-condition warning surfaced inline in successful PATCH responses.
+	// Code values match the corresponding analyze_* finding codes.
+	spec.Components.Schemas["Warning"] = &Schema{
+		Type: "object",
+		Properties: map[string]*Schema{
+			"code":   {Type: "string", Description: "Stable warning code, matching analyze_* finding codes"},
+			"path":   {Type: "string", Description: "RFC 6901 JSON Pointer to the offending field"},
+			"detail": {Type: "string", Description: "Human-readable explanation"},
+		},
+		Required: []string{"code"},
 	}
 
 	// List response wrapper

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -137,6 +137,7 @@ func (m *wsEntityManager) CreateRelation(
 ) (*entity.Relation, error) {
 	return m.w.createRelation(from, relType, to, CreateRelationOptions{
 		Properties: opts.Properties,
+		MetaUnset:  opts.MetaUnset,
 		Content:    opts.Content,
 	})
 }
@@ -146,6 +147,7 @@ func (m *wsEntityManager) UpdateRelation(
 ) (*entity.Relation, error) {
 	return m.w.updateRelation(from, relType, to, CreateRelationOptions{
 		Properties: opts.Properties,
+		MetaUnset:  opts.MetaUnset,
 		Content:    opts.Content,
 	})
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1340,10 +1340,13 @@ func (w *Workspace) writeRelationCore(rel *entity.Relation) error {
 	return nil
 }
 
-// CreateRelationOptions configures optional settings for relation creation.
+// CreateRelationOptions configures optional settings for relation creation
+// and updates. See entitymanager.RelationOptions for the full contract; this
+// type is the workspace-internal mirror.
 type CreateRelationOptions struct {
-	Properties map[string]interface{} // property values for the relation
-	Content    string                 // markdown body content for the relation
+	Properties map[string]interface{}
+	MetaUnset  []string
+	Content    *string
 }
 
 // CreateRelation validates both endpoints exist, checks for duplicates,
@@ -1382,6 +1385,7 @@ func (w *Workspace) createRelation(from, relType, to string, opts ...CreateRelat
 	}
 
 	// Apply caller-provided properties and content (override template defaults).
+	// MetaUnset is ignored on Create — there are no existing values to clear.
 	if len(opts) > 0 {
 		if len(opts[0].Properties) > 0 && rel.Properties == nil {
 			rel.Properties = make(map[string]interface{})
@@ -1389,8 +1393,8 @@ func (w *Workspace) createRelation(from, relType, to string, opts ...CreateRelat
 		for k, v := range opts[0].Properties {
 			rel.Properties[k] = v
 		}
-		if opts[0].Content != "" {
-			rel.Content = opts[0].Content
+		if opts[0].Content != nil {
+			rel.Content = *opts[0].Content
 		}
 	}
 
@@ -1401,22 +1405,39 @@ func (w *Workspace) createRelation(from, relType, to string, opts ...CreateRelat
 	return rel, nil
 }
 
-// UpdateRelation updates properties on an existing relation.
+// updateRelation updates an existing relation's properties and content
+// using merge-then-unset semantics:
+//
+//  1. opts.Properties MERGES into the existing relation's properties.
+//     Keys absent from opts.Properties are NOT cleared by this call;
+//     callers that want to clear keys must list them in MetaUnset.
+//  2. opts.MetaUnset removes the named keys from the merged map. A key
+//     in MetaUnset that is not present is a silent no-op.
+//  3. If opts.Content is non-nil, the relation's body is replaced with
+//     *opts.Content (including the empty string clears the body). If
+//     opts.Content is nil, the existing body is left untouched.
+//
+// The store-level UpdateRelation always performs a full-replacement
+// write of the relation; the merge-and-unset logic lives here at the
+// workspace boundary so that automations and validation see the
+// post-merge state.
 func (w *Workspace) updateRelation(from, relType, to string, opts CreateRelationOptions) (*entity.Relation, error) {
 	rel, err := w.Store().GetRelation(context.Background(), from, relType, to)
 	if err != nil {
 		return nil, fmt.Errorf("relation not found: %s --%s--> %s", from, relType, to)
 	}
 
-	// Merge properties
-	if rel.Properties == nil {
+	if rel.Properties == nil && (len(opts.Properties) > 0 || len(opts.MetaUnset) > 0) {
 		rel.Properties = make(map[string]interface{})
 	}
 	for k, v := range opts.Properties {
 		rel.Properties[k] = v
 	}
-	if opts.Content != "" {
-		rel.Content = opts.Content
+	for _, k := range opts.MetaUnset {
+		delete(rel.Properties, k)
+	}
+	if opts.Content != nil {
+		rel.Content = *opts.Content
 	}
 
 	if err := w.writeRelationCore(rel); err != nil {

--- a/tickets/entities/decisions/DEC-HWZHA.md
+++ b/tickets/entities/decisions/DEC-HWZHA.md
@@ -1,0 +1,42 @@
+---
+id: DEC-HWZHA
+type: decision
+title: 'Validation policy for write APIs: tolerate temporarily invalid data'
+context: |-
+    rela's storage format is deliberately permissive: entity and relation files are markdown + YAML frontmatter, edited freely by external tools (text editors, IDE plugins, git merges, scripts) alongside the API. CLAUDE.md states the philosophy explicitly: "tolerate temporarily invalid data". Cardinality is documented as advisory. The `analyze_*` tools exist precisely to surface inconsistencies that the storage layer doesn't reject.
+
+    Despite that, recent tickets (closed PR #648 / TKT-K2VAA, the original draft of TKT-6WLSW, design-review feedback on those) introduced hard 422 rejections at the API write path for: closed-schema unknown meta keys, target-type mismatches, missing target IDs, required-meta enforcement. None of those are structural impossibilities — they're inconsistencies of the kind `analyze` would flag. A user editing markdown by hand can produce all of them, and the API rejecting them on the next save creates a hostile asymmetry: the file system tolerates the state, the API doesn't.
+
+    The drift had three contributing causes: (1) JSON:API §9 wire-shape adoption brought along JSON:API's "validate-then-write, return 422" mental model from REST-over-database stacks where wire and storage share a closed schema; (2) auto-save UX wants immediate per-field feedback, which crept into the wire layer instead of staying a UI concern; (3) code-review pressure ("is this validated?") tightens the strictness ratchet without anyone explicitly arguing for hard rejection.
+consequences: |-
+    ## Validation classification
+
+    Write-time checks are split into three classes, with distinct HTTP behavior:
+
+    **Hard 400 — malformed wire format**
+    Reserved for request-structure errors detectable without consulting the metamodel. Examples: malformed JSON, missing required wire-format fields (`{"tagged": {}}` with no `data` key), mixing legacy and modern shapes in one body. These are caller bugs in the HTTP layer, not data-state issues.
+
+    **Hard 422 — structural impossibilities**
+    Reserved for things the storage layer literally cannot persist or where the in-memory model has nowhere to put the data. Examples: writing `content` to a relation type whose disk file format doesn't support a body (the file shape can't hold it), unknown relation type (no defined storage location), missing required wire-format fields like `id` or `type`.
+
+    **Write-with-warnings (200 + warnings)**
+    Everything else that today's drafts wanted to 422 on. The API performs the requested write and returns the warnings in the response so UIs can surface them non-blockingly. Subsequent `analyze` runs flag the same conditions. Examples: target-type mismatch against the relation's allowed `to` set, missing target ID, unknown meta keys (closed-schema violation), required-meta unset, target entity type not in `from` allowlist. These are all conditions a hand-editor can produce and rela's `analyze_*` tools already detect.
+
+    ## Response shape additions
+
+    Write endpoints that perform the work despite warnings return their normal 200 body augmented with a `warnings: []` array. Each warning is a structured object: `{code, path, detail}` where `code` is a stable identifier matching what `analyze_*` would surface, `path` is a JSON-pointer-style location, and `detail` is human-readable. Empty array (or omitted field) means no warnings.
+
+    ## Scope of this decision
+
+    Applies to all data-entry-server write endpoints (`POST /api/v1/{plural}`, `PATCH /api/v1/{plural}/{id}`, the per-edge relation endpoints, future bulk endpoints). The MCP tools and CLI follow the same policy: warnings flow back as part of the result, no hard rejections for soft conditions. Lua scripts get warnings via the existing return channel.
+
+    ## Migration
+
+    Existing endpoints that today hard-reject on soft conditions are NOT retroactively softened in this decision — each migration is its own ticket so existing callers aren't surprised. The decision sets the policy for new endpoints and for explicit rewrites.
+
+    ## Out of scope
+
+    Validation in the analyze tools, in CLI commands like `rela validate`, and in metamodel-loading itself. Those are appropriate places for hard policy checks because they're explicitly diagnostic surfaces. The decision is specifically about WRITE paths.
+date: "2026-05-07"
+status: accepted
+---

--- a/tickets/entities/implementation-checklists/IMPL-J6YL2.md
+++ b/tickets/entities/implementation-checklists/IMPL-J6YL2.md
@@ -1,0 +1,45 @@
+---
+id: IMPL-J6YL2
+type: implementation-checklist
+title: 'Implementation: Extend PATCH /entities/{id} relations to carry per-edge meta + content'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (relations_v1_wire_test.go: 17 tests)
+- [x] Integration tests written (relations_modern_test.go: 22 ACs)
+- [x] Happy path implemented (Layers 0-7 per PLAN-MXQKI)
+- [x] Edge cases from planning handled (null/empty/whitespace/scalar/mixed-shape)
+- [x] Error handling in place (wireError, structuralError, relationError typed)
+
+## Test Quality
+
+- [x] Using fixture builders (newRelationsTestApp seeds canonical entities)
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Each acceptance criterion verified — see relations_modern_test.go AC1–AC20
+- [x] Edge cases verified via relations_v1_wire_test.go
+
+**Verification Evidence:**
+
+- `go test ./...` — all packages pass
+- `go test -race ./...` — no data races
+- `golangci-lint run ./...` — clean (0 issues)
+- `just coverage-check` — both thresholds PASS
+- 22 integration tests in `internal/dataentry/relations_modern_test.go` cover AC1–AC20a + AC15/16
+- 17 unit tests in `internal/dataentry/relations_v1_wire_test.go` cover wire-format edge cases
+
+## Quality
+
+- [x] Code follows project patterns (separate file per layer; reuses entityManager surface)
+- [x] No security issues introduced (allowlist-based validation, RFC 6901 escaping for paths)
+- [x] No silent failures — soft conditions surface as warnings; hard failures return typed errors
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-MXQKI.md
+++ b/tickets/entities/planning-checklists/PLAN-MXQKI.md
@@ -2,7 +2,7 @@
 id: PLAN-MXQKI
 type: planning-checklist
 title: 'Planning: Extend PATCH /entities/{id} relations to carry per-edge meta + content'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->

--- a/tickets/entities/planning-checklists/PLAN-MXQKI.md
+++ b/tickets/entities/planning-checklists/PLAN-MXQKI.md
@@ -1,0 +1,492 @@
+---
+id: PLAN-MXQKI
+type: planning-checklist
+title: 'Planning: Extend PATCH /entities/{id} relations to carry per-edge meta + content'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+**In scope:**
+- Wire format extension: `PATCH /api/v1/{plural}/{id}` accepts `relations: map[string]V1RelationsUpdate` where `V1RelationsUpdate = {data: [{type, id, meta?, meta_unset?, content?}]}`. Coexists with the legacy `relations: map[string][]string` form via custom JSON unmarshal that distinguishes the two shapes.
+- `reconcileOutgoingRelations` extended (or paralleled) to accept the new shape and, per edge, decide create vs upsert vs delete. Upsert calls `entityManager.UpdateRelation` with the merged meta + content.
+- Per-edge meta upsert: `meta` keys merge into existing properties; `meta_unset` removes keys.
+- Per-edge content upsert: `content: "string"` replaces (including empty string clears); absent leaves alone.
+- **Validation policy per DEC-HWZHA**: hard 400 for malformed wire format, hard 422 for structural impossibilities (unknown relation type, content on non-content-bearing relation type), 200 + warnings for everything else (target type mismatch, missing target entity, unknown meta keys, required-meta unset, meta type mismatches).
+- Validation runs before any writes (validate-then-write, not write-then-validate). Critically, the validation phase for the relation reconcile runs **BEFORE** the entity is updated, so a relation-shape error doesn't leave the entity half-written.
+- `data` field is required when wrapper appears (`{"tagged":{}}` → 400).
+- **Value-based no-op suppression** at the per-edge level: post-merge state byte-equals current state → no write, no SSE event. Achieved with `reflect.DeepEqual` on the (final-properties-map, final-content) tuple after merging incoming meta and resolving meta_unset.
+- Backwards compat for legacy IDs-only shape: continue to work unchanged. Both shapes follow the same validation policy; only modern returns warnings inline.
+- **Extending `entitymanager.RelationOptions` with `MetaUnset []string`** and changing `Content string` → `Content *string` so meta-clear and content-clear semantics are expressible. Both `workspace.updateRelation` and store-level callers honor the new fields. All existing callers audited and updated (enumerated below in Approach).
+- New response field: `warnings: []` carrying `{code, path, detail}` objects. Code values match the corresponding `analyze_*` finding codes.
+- OpenAPI schema regenerated for the new shape and the new response field.
+- Tests: integration tests against the existing test harness, covering each acceptance criterion below plus negative tests.
+
+**Out of scope:**
+- Frontend wiring of `RelationPicker` / `RelationCards` to the new shape — TKT-B9SXH / TKT-18JS6 will consume the API. We do not add TypeScript types in this PR; the consumer tickets add them when they wire up.
+- Symmetric / inverse propagation of per-edge meta — current `writeRelation` does not propagate at all today (workspace.go:416). Separate ticket if needed.
+- Multi-write atomicity (entity update + relation reconcile as a single store transaction). Store has no transaction primitive (FEAT-CO4YP). With validation-first ordering (see Approach), the only failure window is mid-write-loop, which is rare and irrecoverable. Documented in api-reference.md.
+- Migrating callers off the legacy IDs-only shape (deprecation deferred).
+- Auditing/redesigning workspace.go's symmetric/inverse handling — independent gap.
+- Retroactively softening hard 422s on existing endpoints — per DEC-HWZHA migration scope, that's separate-ticket work.
+
+**Acceptance Criteria (under DEC-HWZHA validation policy):**
+
+### Behavioral
+
+1. **AC1 — Add new edge with meta**: PATCH with `relations: {tagged: {data: [{type: label, id: L-001, meta: {weight: 5}}]}}` creates the edge with `weight=5`. **Test**: assert relation persisted with the meta value.
+2. **AC2 — Upsert meta on existing edge**: PATCH same target with `meta: {weight: 7}` updates the existing relation's meta (no duplicate created). **Test**: re-PATCH, assert weight=7, assert single relation.
+3. **AC3 — Meta unset clears keys**: PATCH with `meta_unset: ["weight"]` removes the key from existing meta. **Test**: existing meta has weight; PATCH; assert weight is gone.
+4. **AC4 — Per-edge content upsert**: PATCH with `content: "edge body"` on a relation type with `content: true` writes the body. Subsequent PATCH with `content: ""` clears. **Test**: assert relation file body matches.
+5. **AC5 — `data: []` removes all of that type**: PATCH with `relations: {tagged: {data: []}}` removes every existing tagged edge. **Test**: assert zero outgoing edges of that type.
+6. **AC6 — Replacement semantics**: existing edges A, B, C; PATCH with `data: [{A}, {D}]`; result: A kept, D added, B and C removed. **Test**: assert exact set after PATCH.
+7. **AC7 — Absent relation type leaves alone**: existing tagged edges; PATCH with no `relations.tagged` key; result: existing edges unchanged. **Test**: assert no diff.
+8. **AC15 — Backwards compat with IDs-only shape**: PATCH with legacy `relations: {tagged: ["L-001", "L-002"]}` continues to work; meta-less edges created; same warnings as modern shape would emit (target-existence checks, etc.). **Test**: assert both shapes produce equivalent results when both succeed.
+9. **AC16 — Combined PATCH**: PATCH with `properties`, `content`, AND `relations` in one body — all applied; entity event fires once. **Test**: assert all three persisted.
+10. **AC17 — Validation failure leaves entity AND relations untouched**: PATCH with valid properties + a relation entry that fails validation phase (e.g. unknown relation type → structural 422); entity is NOT updated, no relation writes happen. **Test**: assert pre-PATCH state preserved on disk and in memory after the request returns 422. *(Achievable because validation runs BEFORE entity update — see Approach Layer 3.)*
+
+### Hard 400 — wire-format errors
+
+8. **AC8 — `{"tagged": {}}` returns 400**: data-loss footgun mitigation. **Test**: assert HTTP 400 with structured error pointer.
+9. **AC18 — Legacy + new shape mixed in one body returns 400**: e.g. one relation type uses `{data: [...]}` and another uses `[...]` — reject as ambiguous. **Test**: assert HTTP 400 with stable error code `shape_mixed`. Detail is generic ("request mixes legacy and JSON:API relation shapes; pick one"), does NOT name a specific key (Go map iteration is non-deterministic — RR-FOLOX).
+10. **AC19 — Sibling-key rejection**: `{"tagged": {"datas":[]}}` returns 400 (only `data` is allowed inside the modern wrapper). Custom UnmarshalJSON enforces this with `DisallowUnknownFields`-style check.
+20a. **AC20a — Non-string element in meta_unset returns 400**: `meta_unset:
+["x", null]` and `meta_unset: ["x", 5]` both 400 at unmarshal time with index
+pointer. 20b. **AC20b — `data` is non-array in modern wrapper returns 400**:
+`{"tagged": {"data": "L-001"}}` returns 400. 20c. **AC20c — `data: null` returns
+400**: same as missing `data` key (RR-UZ8LX). Stable error code `data_required`.
+
+### Hard 422 — structural impossibilities
+
+9. **AC9 — Unknown relation type returns 422**: PATCH with `relations: {nonexistent: {data: []}}` returns 422 with code `unknown_relation_type`. Justification: there is no defined storage location for a relation file of an unknown type. **Test**: assert HTTP 422.
+10. **AC13 — Content on non-content-bearing type returns 422**: relation type without `content: true` and PATCH carries `content`. The disk format can't hold a body for that type. **Test**: assert HTTP 422 with code `content_not_supported`.
+
+### 200 + warnings — soft conditions
+
+10. **AC10 — Target type mismatch surfaces warning**: PATCH with target ID whose actual type doesn't match `data[*].type`. Edge IS written; response includes `warnings: [{code: "target_type_mismatch", path: "/relations/.../data/0", detail: "..."}]`. **Test**: assert HTTP 200, edge persisted, warning in response.
+11. **AC11 — Target ID doesn't exist surfaces warning**: PATCH with target ID that's not in the graph. Edge IS written (the relation file references the nonexistent target — `analyze_orphans` will flag it). Response includes `warnings: [{code: "target_not_found", ...}]`. **Test**: assert HTTP 200, edge persisted, warning in response.
+12. **AC12 — Unknown meta key surfaces warning**: relation type has closed schema; meta has unknown key. Edge IS written with the extra meta. Response includes `warnings: [{code: "unknown_meta_key", path: "/.../meta/X", detail: "..."}]`. **Test**: assert HTTP 200, meta key persisted, warning in response.
+12b. **AC12b — Required meta unset surfaces warning**: relation type has
+required meta property; PATCH creates an edge or unsets the property leaving it
+absent. Edge IS written. Response includes `warnings: [{code:
+"required_meta_unset", ...}]`. **Test**: assert HTTP 200, edge persisted without
+the required key, warning in response. 12c. **AC12c — Meta type mismatch
+surfaces warning**: PATCH with meta value whose type doesn't match declared
+property type. Edge IS written with the wrong-typed value. Response includes
+`warnings: [{code: "meta_type_mismatch", ...}]`. **Test**: assert HTTP 200.
+
+### No-op + atomicity
+
+14. **AC14 — Value-based no-op suppression**: PATCH with desired state that, after merge resolution, byte-equals current state; assert zero relation writes (verified via Store event subscriber counter) and zero SSE events. Includes the case where the same `meta: {weight: 5}` is re-sent on every save (auto-save's primary use case — RR-M3LWM).
+14b. **AC14b — Shape-based no-op for absent fields**: when a desired edge has no
+`meta`, no `meta_unset`, no `content` AND already exists, no write fires. Strict
+subset of AC14.
+
+### Documentation
+
+20. **AC20 — OpenAPI schema describes both shapes plus warnings field**: regenerated `openapi.yaml` shows the new wire shape with `data` array, per-edge fields, and the response `warnings` array.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+- **JSON:API §9 (Resource Identifier Objects)**: provides the wire shape (`{type, id, meta?}` arrays under `data`). We borrow the shape, not the full envelope (response stays rela's flat format with the new `warnings` field). No JSON:API library used; the surface is small and a bespoke `UnmarshalJSON` is clearer than pulling in a dependency.
+- **Existing in-tree patterns:**
+  - `internal/dataentry/relations.go:45` `reconcileOutgoingRelations` — current set-semantic reconciler. Extension target.
+  - `internal/dataentry/api_v1.go:504` `handleV1UpdateEntity` — current PATCH handler. Wire format extension target.
+  - `internal/entitymanager/entitymanager.go:71` `RelationOptions{Properties, Content}` — already supports per-edge data on Create/UpdateRelation; this PR extends the type with `MetaUnset` + `*string Content`.
+  - `internal/workspace/workspace.go:1405` `updateRelation` — backend impl. Currently merges Properties (no clear), conditionally overwrites Content (no clear-to-empty). This PR fixes both AND updates the godoc to document merge-then-unset semantics (RR-4G6V0).
+  - `internal/store/store.go:188` `RelationWriter` — store interface. `UpdateRelation(ctx, from, type, to, RelationData)` takes a full `RelationData{Properties, Content}` — the store-level call is full-replacement. The merge happens in `workspace.updateRelation`, which this PR adjusts.
+  - `internal/dataentry/relations.go:11-31` `relationError` type — existing structured error with `Op`/`Reason`/`Target`/`RelType` codes. Reuse for hard-422 codes; warnings get a parallel `Warning` struct with the same shape minus `Op`.
+- **Prior art (closed PR #648)**: explored a parallel `Manager` struct with full WithTx orchestration. Doesn't apply on current develop because (a) the `EntityManager` interface already exists with a different shape and (b) the store has no transaction primitive. Wire format design from that PR is reusable. Notably, the closed PR had the SAME validation drift (hard 422 on soft conditions) that DEC-HWZHA explicitly addresses.
+- **rela concepts:** `FEAT-jsjj` "Relation properties and content support" is the parent feature. `FEAT-CO4YP` "Pluggable store backends" constrains atomicity decisions. `DEC-HWZHA` "Validation policy for write APIs" governs the validation classes.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+**Layer 0 — `entitymanager.RelationOptions` extension**
+(`internal/entitymanager/entitymanager.go`):
+
+```go
+// RelationOptions configure relation creation/update.
+//
+// On CreateRelation: Properties is the initial property map, MetaUnset is
+// ignored (no existing values to clear), Content (if non-nil) sets the body.
+//
+// On UpdateRelation: Properties MERGES into the existing properties (this
+// is the existing behavior — kept for back-compat). After the merge,
+// MetaUnset deletes the named keys. Content (if non-nil) replaces the
+// body, including with empty string ""; if nil, the existing body is
+// untouched.
+type RelationOptions struct {
+    Properties map[string]interface{}
+    MetaUnset  []string  // NEW: keys to clear after the merge (UpdateRelation only)
+    Content    *string   // CHANGED: was string; pointer distinguishes leave-alone vs set-to-empty
+}
+```
+
+`workspace.updateRelation` (workspace.go:1405) is updated:
+- Godoc rewritten to document the merge-then-unset semantics (RR-4G6V0).
+- After merging `opts.Properties`, iterate `opts.MetaUnset` and `delete()` each key. (Deleting a missing key is a Go no-op; that's the documented behavior — RR-D895N already addressed this.)
+- Replace `if opts.Content != ""` with `if opts.Content != nil` and assign `*opts.Content`.
+
+**Call-site enumeration** (RR-X5WVA — done up front instead of "during
+implementation"):
+
+| File:line | Current call | New call | Behavioral change? |
+|---|---|---|---|
+| `internal/dataentry/handlers_api.go:527` | `RelationOptions{}` | unchanged | no |
+| `internal/dataentry/relations.go:113` | `RelationOptions{}` | unchanged | no |
+| `internal/dataentry/api_v1.go:730` | `RelationOptions{Properties: meta}` | unchanged | no |
+| `internal/dataentry/api_v1.go:772` | `RelationOptions{Properties: meta}` | unchanged | no |
+| `internal/workspace/manager.go:138` | `RelationOptions{Properties, Content}` | propagate MetaUnset + Content *string | no |
+| `internal/workspace/manager.go:147` | `RelationOptions{Properties, Content}` | propagate MetaUnset + Content *string | no |
+| `internal/mcp/tools_relation.go:76` | `Content: request.GetString("content", "")` | `Content: nilIfEmpty(request.GetString("content", ""))` | **subtle**: today, `content: ""` from MCP leaves alone (treated as default). New behavior: still leaves alone (because `nilIfEmpty` returns nil for ""). MCP tool docs note: pass `null` or omit `content` to leave alone; the empty-string ambiguity is preserved by the helper. (RR-QOIXK) |
+| `internal/cli/link.go:27` | `Content: ""` (no content arg) | `Content: nil` | no |
+| `internal/lua/runtime.go:1373` | builds `Content: contentStr` | use `Content: &contentStr` if Lua set it, else nil | **subtle**: Lua `rela.update_relation(..., {content = ""})` previously left content alone; new behavior matches what users expect: empty string clears. Document in lua API reference. (RR-QOIXK) |
+| `internal/entitymanager/entitymanagertest/panic.go` | stub | update signature to match | no |
+
+The MCP and Lua semantic changes are deliberate and aligned with the new general
+principle: empty string means empty string, nil means leave alone. Document both
+in their respective references.
+
+**Layer 1 — Wire format types** (`internal/dataentry/api_v1.go` + new test
+file):
+
+```go
+// V1RelationsField is the top-level value for `relations` in a PATCH body.
+// Custom JSON unmarshal accepts EITHER the legacy IDs-only shape
+// (map[string][]string) OR the new JSON:API shape (map[string]V1RelationsUpdate).
+type V1RelationsField struct {
+    Legacy map[string][]string
+    Modern map[string]V1RelationsUpdate
+    // Mixing the two shapes in one body returns an error during unmarshal.
+}
+
+type V1RelationsUpdate struct {
+    Data        []V1ResourceIdentifier
+    DataPresent bool  // distinguishes {"tagged":{}} from {"tagged":{"data":[]}}
+}
+
+type V1ResourceIdentifier struct {
+    Type      string
+    ID        string
+    Meta      map[string]interface{}
+    MetaUnset []string
+    Content   *string
+}
+```
+
+**`UnmarshalJSON` state machine for `V1RelationsField`** (RR-0NTMQ):
+
+1. Decode body into `map[string]json.RawMessage` first.
+2. Track two flags: `sawLegacy`, `sawModern`. If both ever set, return `&shapeMixedError{}` (stable code `shape_mixed`, detail does NOT name a specific key — RR-FOLOX).
+3. For each (relation-type, raw-value):
+   - Trim leading whitespace from `raw` (handles BOM and structural whitespace).
+   - Inspect first non-whitespace byte:
+     - `[` → legacy IDs-only branch. Unmarshal as `[]string`; on error, return 400 with JSON pointer.
+     - `{` → modern wrapper branch. See sub-state-machine below.
+     - `n` (likely `null`) → check exact text matches `null`. If yes: 400 with code `relation_value_null` ("relation type cannot be null; use `data: []` to clear"). RR-UZ8LX.
+     - Anything else (`"` for string, digit for number, `t`/`f` for bool, etc.) → 400 with code `relation_value_invalid`.
+4. Sub-state-machine for modern wrapper `{...}`:
+   - Decode into `map[string]json.RawMessage`.
+   - Check sibling keys: only `data` allowed. Anything else → 400 code `unknown_field`.
+   - If `data` key absent: `DataPresent=false`, `Data=nil`. (Caller logic emits 400 `data_required`.)
+   - If `data` is JSON `null`: 400 code `data_required` (treat same as missing — RR-UZ8LX).
+   - Otherwise: try to unmarshal `data` as `[]V1ResourceIdentifier`. If the value isn't an array (it's an object, scalar, etc.), 400 code `data_invalid_type`. AC20b.
+5. Sub-unmarshal for `V1ResourceIdentifier`:
+   - `meta_unset` must be `[]string` or absent. Each element must be a string. Non-string element → 400 with index pointer (RR-LGK1X / AC20a).
+   - `meta: null` → treated as absent (`Meta = nil`).
+   - `meta_unset: null` → treated as absent.
+   - `content: null` → treated as absent (pointer remains nil).
+
+**JSON pointer error format** (RR-YNWR7): all path components apply RFC 6901
+escaping (`~` → `~0`, `/` → `~1`). New helper `jsonPointerEscape(s string)
+string` in `internal/dataentry/`. Use for relation-type names and meta keys
+whenever they appear in error pointers. The format is documented as "RFC 6901
+JSON Pointer" in the api-reference.
+
+**Layer 2 — Modern reconciler** (`internal/dataentry/relations.go`):
+
+Add `reconcileOutgoingRelationsModern(ctx, entityID, desired
+map[string]V1RelationsUpdate)`. Returns `(warnings []Warning, err error)`.
+Legacy reconciler stays unchanged (and gets the same warning surface added — see
+below).
+
+The modern reconciler:
+1. **Validation phase** (no writes):
+   - Walk the desired map; for each entry classify via DEC-HWZHA buckets:
+     - **400** issues already trapped at unmarshal time.
+     - **422 structural**: relation type unknown? content on non-content-type? Return immediately with code.
+     - **Soft conditions**: target existence, target type allowed, source type allowed, meta key closed-schema, required meta unset, meta type mismatch. Each yields a `Warning{code, path, detail}` appended to a local list.
+2. **Diff phase**: per relation type, build `desiredByID` and `currentByType[relType]` (current outgoing edges of that type). Per desired edge:
+   - Compute the post-merge `(finalProps, finalContent)` by reading current edge (if any), applying `Meta` merge, applying `MetaUnset` deletes, replacing `Content` if non-nil.
+   - If in current AND `reflect.DeepEqual(currentProps, finalProps) && currentContent == finalContent` → skip (value-based no-op suppression — RR-M3LWM).
+   - If in current → upsert via `UpdateRelation`.
+   - If not in current → create via `CreateRelation` with the post-merge values.
+For each current edge not in desired → delete via `DeleteRelation`.
+3. **Write phase**: stage adds/upserts/removes; iterate. Each write is wrapped — failure produces `*relationError` with `Reason: "create_failed"|"update_failed"|"delete_failed"`. Still a 422 (structural — store said no), not a warning.
+
+**Note on `reflect.DeepEqual` for value-based suppression**: JSON unmarshal into
+`interface{}` always produces `float64` for numbers; the on-disk values reaching
+the workspace come from the *same* JSON unmarshal in our case (relation files in
+markdown frontmatter parse via YAML, but the stored map is loaded as
+`map[string]interface{}` and round-trips through the same YAML decoder which
+uses Go-native types). The "numeric normalization" worry from PR #648 was
+overstated for the in-memory comparison case. Document this assumption in
+api-reference.md; if it bites later, fall back to a small `valueEqual` helper in
+`internal/model`.
+
+**Layer 3 — Handler dispatch and ordering** (`internal/dataentry/api_v1.go:504`
+`handleV1UpdateEntity`):
+
+Replace `Relations map[string][]string` with `Relations V1RelationsField`. After
+parsing:
+
+```go
+// Phase A: validate-only run on the relation reconciler. Returns warnings
+// (informational) and err (hard 400/422). On err, return immediately —
+// no writes anywhere.
+warnings, err := a.validateRelationsRequest(r.Context(), entityID, req.Relations)
+if err != nil {
+    writeV1Error(w, r, ...)
+    return
+}
+
+// Phase B: entity update. May emit its own validation 422 or 400.
+if entityChanged {
+    if _, err := a.entityManager.UpdateEntity(...); err != nil {
+        writeV1Error(...)
+        return
+    }
+}
+
+// Phase C: relation writes (we already validated; only store-level failures possible here).
+moreWarnings, err := a.applyRelationsRequest(r.Context(), entityID, req.Relations)
+if err != nil {
+    // Store error mid-loop; entity is already updated. This is the
+    // documented atomicity gap — return 500 with detail.
+    writeV1Error(w, r, http.StatusInternalServerError, ...)
+    return
+}
+
+// Successful response includes BOTH validation-phase and write-phase warnings.
+result.Warnings = append(warnings, moreWarnings...)
+writeV1JSON(w, http.StatusOK, result)
+```
+
+This makes AC17 achievable (RR-CW1FK): a relation 400/422 returns *before*
+`UpdateEntity` runs.
+
+**Validation-phase ordering note** (RR-PZY1W): relation-validation runs FIRST.
+Entity validation runs second (inside `UpdateEntity`). Multiple validation
+errors are not combined; the user sees the first 4xx that fires. Future
+refinement could collect both but is out of scope.
+
+**Layer 4 — Response shape** (`internal/dataentry/api_v1.go`):
+
+Existing `entityToV1` response struct gains a `Warnings []Warning` field,
+omitempty. `Warning struct { Code, Path, Detail string }`. Frontend types added
+in TKT-B9SXH/TKT-18JS6 when they wire up.
+
+**Layer 5 — SSE event semantics** (RR-RGVJE):
+- Entity event fires only if entity properties or content actually changed (existing behavior at api_v1.go:550 — preserved).
+- Per-relation events fire only when an actual write occurs (after value-based no-op suppression from Layer 2).
+- On 400/422 from any phase, no SSE events fire (handler returns before broadcast).
+- A relations-only PATCH that produces no writes (all no-op) emits zero SSE events.
+
+**Layer 6 — Automation/diff staleness** (RR-TK2QF): With the new ordering
+(validate → entity update → relation writes), automations fire during entity
+update and may create new relations *before* the relation-write phase. Existing
+behavior; the relation-write phase doesn't re-validate against the
+post-automation graph. We accept this — same hazard as today's legacy
+reconciler. Document as a known interaction in api-reference.md.
+
+**Layer 7 — OpenAPI** (`internal/openapi/`):
+
+Update the schema for `PATCH /{plural}/{id}` request body to describe the new
+shape (`oneOf` legacy + modern). Add the `warnings` array to all 200 responses.
+Add 400 and 422 to documented response set. Regenerate `openapi.yaml`.
+
+**Files to modify:**
+
+- `internal/entitymanager/entitymanager.go` — extend `RelationOptions` (`MetaUnset []string`, `Content *string`); update godoc per RR-4G6V0
+- `internal/entitymanager/entitymanagertest/panic.go` — update stub signatures
+- `internal/workspace/manager.go` — propagate new fields through to `workspace.updateRelation`
+- `internal/workspace/workspace.go` — apply `MetaUnset` after merge in `updateRelation`; honor `*string` content; update godoc
+- `internal/mcp/tools_relation.go` — update `Content` argument handling + tool docs
+- `internal/cli/link.go` — update `Content: ""` → `Content: nil`
+- `internal/lua/runtime.go` — update relation update to use `*string Content`; document Lua API change
+- `internal/dataentry/api_v1.go` — handler dispatch + `V1RelationsField`/`V1RelationsUpdate`/`V1ResourceIdentifier` + `Warning` + custom `UnmarshalJSON` + `jsonPointerEscape` helper + handler reorder (validate → entity → relations)
+- `internal/dataentry/api_v1_test.go` — add modern-shape tests; keep legacy tests passing
+- `internal/dataentry/relations.go` — add `reconcileOutgoingRelationsModern` returning `(warnings, err)`; add same warnings-surface to the legacy reconciler so AC15 produces equivalent results
+- `internal/openapi/schemas.go` and/or `paths.go` — schema for new wire shape and warnings response field
+- `internal/openapi/openapi.yaml` (derived) — regenerate
+- `docs/data-entry/api-reference.md` (new file) — wire-format reference, validation policy summary linking DEC-HWZHA, the data-loss footgun callout, atomicity caveats, automation/diff staleness note, MCP/Lua content-empty-string note
+- `CLAUDE.md` — note the new endpoint shape under the data-entry section AND add a Validation policy section linking DEC-HWZHA
+
+**Alternatives considered:**
+
+- **Hard 422 for all soft conditions (the original drift)**: rejected. DEC-HWZHA explicitly governs this. JSON:API wire-shape adoption brought a write-rejection mental model that doesn't fit rela's permissive-storage philosophy.
+- **A new method `EntityManager.UpdateEntityWithRelations(ctx, e, rels)` that drives a transaction.** Rejected: store has no transaction primitive (FEAT-CO4YP).
+- **Replace the legacy `map[string][]string` shape outright.** Rejected: breaks any external caller; deprecate separately.
+- **Keep `workspace.updateRelation` merge-only and fall back to delete+create for meta_unset.** Rejected: doubles SSE event count for a common operation.
+- **Use a bool `ClearContent` field instead of `Content *string`.** Rejected: pointer-string is the idiomatic Go way and the call-site cascade is mechanical.
+- **Speculatively adding TypeScript types in `frontend/src/api/entities.ts`.** Rejected: nothing consumes them in this PR.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- **Request body JSON** (HTTP): all fields validated. `relations` map keys: those bound to known relation types proceed; unknown ones return 422 (structural, no storage). Per-edge fields: `type` and `id` required (400 if missing), validated against the graph (target existence, type match) — failures here are warnings, not 422 (DEC-HWZHA). `meta` keys checked against closed schema → unknown keys are warnings. `meta_unset` keys same. `content` only accepted if the relation type has `content: true` (structural 422 otherwise).
+- **Request body shape**: legacy + modern shapes are mutually exclusive in one request. Mixing returns 400 with stable code `shape_mixed`, deterministic detail. Custom UnmarshalJSON rejects unknown sibling keys in `V1RelationsUpdate`, non-string `meta_unset` elements, non-array `data`, JSON `null` for the wrapper or for `data`.
+- **JSON pointers in error messages**: all path components RFC 6901-escaped. Helper `jsonPointerEscape` applied uniformly.
+
+**Security-Sensitive Operations:**
+
+- **File writes via store** — gated by allowlist validation above. The store backend handles path safety on its own.
+- **No new auth surface, no new file-system surface, no crypto.**
+- **Warnings expose entity types and IDs** in detail messages — these are already returned in normal API responses, so no new info disclosure.
+
+**Error handling:**
+
+- Internal errors wrap `*relationError` with `Op` / `Reason` / `Target` codes — stable for clients, never include request body bytes.
+- Validation errors include the JSON pointer to the offending field but never echo back the metamodel definition or other entities' state.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** see AC1–AC20 above. Each AC maps to a `TestV1Patch_*` test
+in `internal/dataentry/api_v1_test.go` using the existing test app harness
+(newTestAppV1).
+
+**Edge Cases:**
+
+- **Empty meta map vs absent meta field** — both treated as "no meta change". Testable.
+- **Empty meta_unset array vs absent meta_unset field** — both no-op.
+- **`content: ""` on a content-bearing relation type** — clears the body. Testable (round-trip).
+- **`content: null`** in JSON — pointer is nil after unmarshal; treat as absent.
+- **Unicode in IDs and meta values** — pass through as UTF-8.
+- **Relation type containing slash or `~`** — JSON pointer must be RFC 6901-escaped.
+- **Concurrent PATCH** on the same entity — handler holds `writeMu`; serialized.
+- **PATCH that triggers automation that creates more entities** — automation runs during entity update; relation reconcile runs after. Diff is computed against pre-automation graph; that's documented as known interaction.
+- **PATCH with empty relations map `{}`** — no-op for relations.
+- **Two PATCHes that race each other (one fast-path 404, one stale ETag)** — ETag check inside handler under `writeMu`. Existing behavior.
+- **Re-PATCH with same meta value as before**: value-based suppression catches it (RR-M3LWM resolved).
+- **`re-PATCHing meta_unset: ["X"]` for absent X**: no-op via value-based suppression (RR-D895N resolved by RR-M3LWM).
+
+**Negative Tests** (each maps to an AC in the 400/422 buckets):
+
+- AC8, AC18, AC19, AC20a, AC20b, AC20c — all 400.
+- AC9, AC13 — 422 with stable codes.
+- AC17 (validation failure leaves entity AND relations untouched) — tested by snapshotting state before, asserting equal after a relation-422 PATCH.
+- Mixed-shape detection robustness — test with two relation types where the legacy one is iterated first AND where the modern one is iterated first; assert error code is `shape_mixed` in both cases (RR-FOLOX). Detail is generic.
+- Sibling-key rejection (AC19) — tested with `{"tagged": {"datas":[]}}`.
+- Malformed JSON — already covered.
+
+**Warnings tests** (each maps to AC10–AC12c):
+
+- For each soft condition, assert HTTP 200, edge persisted in the expected end state, AND warning present in response with correct `code`, `path`, and a non-empty `detail`. Verify warning `code` matches the corresponding `analyze_*` finding code.
+
+**Integration test approach:** all new tests use the existing in-memory
+workspace + store (memstore) via newTestAppV1 — the same harness that exercises
+the legacy PATCH path. Tests assert over store state directly (via
+`app.outgoingRelations`) AND over the HTTP response (status, body, ETag,
+warnings). The no-op suppression test (AC14) subscribes to store events and
+asserts zero events fired during the no-op PATCH.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+1. **Risk: changing `RelationOptions.Content` from `string` to `*string` breaks existing callers.**
+   - **Mitigation**: type-system-enforced — `go build` fails until every call site is updated. Audit done up front (table in Approach Layer 0); 9 sites + 1 stub. MCP and Lua have subtle semantic notes documented in their tool/API references.
+2. **Risk: changing `workspace.updateRelation` from merge-only to merge-then-unset breaks code that relied on un-set keys leaving existing values alone.**
+   - **Mitigation**: behavior is purely additive — `MetaUnset: nil` keeps merge-only behavior. Updated godoc makes the contract explicit (RR-4G6V0).
+3. **Risk: legacy + modern shape collision detection in custom UnmarshalJSON is buggy and accepts mixed bodies.**
+   - **Mitigation**: explicit per-key shape detection with `sawLegacy`/`sawModern` flags. Mixed bodies fail-fast with a stable code, generic detail. Unit tests for the unmarshal in isolation, including both map-iteration orderings (RR-FOLOX).
+4. **Risk: atomicity gap — entity update succeeds, then a relation reconcile *write phase* fails partway.**
+   - **Mitigation**: validation-first ordering moves validation failures to before entity update (RR-CW1FK). Only mid-write-loop store errors leave a partial state — rare, irrecoverable, and documented in api-reference.md as a known limitation. The legacy reconciler had the same property today; we're not making it worse.
+5. **Risk: store backend handles `RelationData.Properties` as full-replacement but `workspace.updateRelation` does merge-then-unset before passing it down. A future store-level call that bypasses the workspace layer would skip the merge.**
+   - **Mitigation**: the merge logic is intentionally at the workspace/manager boundary. Document the merge-vs-replace distinction in workspace.go godoc (RR-4G6V0).
+6. **Risk: value-based no-op suppression mis-classifies same-meta as a write because of `int` vs `float64` JSON-vs-disk mismatch.**
+   - **Mitigation**: in our case both sides come from the same Go-native YAML unmarshal path, so `reflect.DeepEqual` works. Documented assumption. If it breaks in production, fall back to `valueEqual` helper in `internal/model` (small, isolated change).
+7. **Risk: shape-based no-op suppression for absent fields (AC14b) is too coarse.**
+   - **Mitigation**: superseded by value-based AC14. AC14b is a strict subset and is documented as the trivial fast path.
+8. **Risk: warnings response field conflicts with future success/error envelope changes.**
+   - **Mitigation**: `warnings` is omitempty and semver-additive. Future envelope work (if any) preserves the field.
+
+**Effort: s** (matches the ticket's existing estimate; the wire-format work is
+mechanical, the API extension to `RelationOptions` is small but with
+cross-package callers, the warnings surface is straightforward).
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] User guide / reference docs — `docs/data-entry/api-reference.md` (new file): wire format, validation policy, atomicity caveats, footgun callout, MCP/Lua content semantics
+- [x] CLI help text — N/A
+- [x] CLAUDE.md — add Validation policy section linking DEC-HWZHA AND a "Unified PATCH endpoint" subsection in data-entry
+- [x] README.md — N/A
+- [x] API docs — `internal/openapi/openapi.yaml` regenerated
+- [ ] N/A — Internal change, no user-facing docs needed
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+
+- **RR-0NTMQ** (critical, addressed): UnmarshalJSON state machine spelled out in Approach Layer 1.
+- **RR-CW1FK** (critical, addressed): validation-first ordering in Approach Layer 3 makes AC17 achievable.
+- **RR-M3LWM** (critical, addressed): value-based no-op suppression in Approach Layer 2; AC14 added.
+- **RR-QOIXK** (significant, addressed): full call-site enumeration in Approach Layer 0; MCP and Lua semantic notes called out.
+- **RR-PZY1W** (significant, addressed): validation order specified in Approach Layer 3.
+- **RR-YNWR7** (significant, addressed): RFC 6901 escaping with `jsonPointerEscape` helper.
+- **RR-FOLOX** (significant, addressed): stable error code `shape_mixed`, generic detail, both-iteration-orders test.
+- **RR-LGK1X** (significant, addressed): null/non-string-element handling specified in Layer 1 sub-state-machine; AC20a added.
+- **RR-D895N** (wont-fix under DEC-HWZHA): `meta_unset` of absent key is a no-op; subsumed by value-based AC14.
+- **RR-48WQ3** (wont-fix under DEC-HWZHA): legacy and modern both warn (not 422) on missing required meta.
+- **RR-RGVJE** (minor, addressed): SSE semantics specified in Approach Layer 5.
+- **RR-4G6V0** (minor, addressed): godoc rewrites called out in Approach Layer 0.
+- **RR-X5WVA** (minor, addressed): call-site table in Approach Layer 0.
+- **RR-UZ8LX** (minor, addressed): `data: null` returns 400 `data_required`; `null` as relation value returns 400 `relation_value_null`.
+- **RR-TK2QF** (minor, addressed): automation/diff staleness called out in Approach Layer 6 and api-reference.md.

--- a/tickets/entities/review-responses/RR-0NTMQ.md
+++ b/tickets/entities/review-responses/RR-0NTMQ.md
@@ -1,0 +1,12 @@
+---
+id: RR-0NTMQ
+type: review-response
+title: UnmarshalJSON first-byte peek doesn't cover null/string/whitespace cases
+finding: |-
+    Plan says peek first non-whitespace byte ([ vs {). Doesn't cover: (a) `null` as relation type value; (b) string/scalar values like `"tagged":"L-001"`; (c) whitespace/BOM handling in RawMessage; (d) how `data` absent vs `data: null` is actually distinguished. Recommendation: specify full state machine with `*json.RawMessage` triple-state, json.Decoder.DisallowUnknownFields, explicit null/scalar handling.
+
+    From design-review: F1.
+severity: critical
+resolution: 'Plan Layer 1 specifies the full UnmarshalJSON state machine: trim leading whitespace; first-byte switch on `[` (legacy) / `{` (modern) / `n` (null — reject 400 `relation_value_null`) / anything else (reject 400 `relation_value_invalid`). Modern wrapper sub-state-machine handles unknown sibling keys (`unknown_field`), `data` absent (`data_required`), `data: null` (`data_required`), `data` non-array (`data_invalid_type`). Per-edge sub-unmarshal handles `meta: null` / `meta_unset: null` as absent and `meta_unset` non-string elements as 400 with index pointer.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-48WQ3.md
+++ b/tickets/entities/review-responses/RR-48WQ3.md
@@ -1,0 +1,12 @@
+---
+id: RR-48WQ3
+type: review-response
+title: Legacy IDs-only shape on content-bearing/required-meta relation types unspecified
+finding: |-
+    Legacy reconciler creates with empty RelationOptions{}. Required-meta and required-content rules are advisory at write-time today, so legacy succeeds with sparse edges. Modern shape enforces closed-schema meta validation; users upgrading callers see new 422s where old code created sparse edges. Recommendation: document the asymmetry in api-reference.md as backwards-compat caveat.
+
+    From design-review: F10.
+severity: significant
+reason: 'Dissolves under DEC-HWZHA. Both legacy and modern shapes now WARN (not 422) on missing required meta or content. The asymmetry the reviewer flagged is gone: both shapes write the edge and surface the warning. Backwards-compat caveat reduces to ''modern shape includes warnings array; legacy shape doesn''t surface warnings inline (read analyze tools).'' That''s a minor doc note, not a blocking issue.'
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-4G6V0.md
+++ b/tickets/entities/review-responses/RR-4G6V0.md
@@ -1,0 +1,12 @@
+---
+id: RR-4G6V0
+type: review-response
+title: workspace.updateRelation godoc doesn't document merge vs replace semantics
+finding: |-
+    Plan changes merge-only to merge-then-unset additively. But existing godoc says 'updates properties' without specifying merge. Future caller assumes 'set' semantics, gets bitten when partial Properties merges. Recommendation: rewrite godoc to specify merge then unset then conditional content replacement; same for entitymanager.RelationOptions.
+
+    From design-review: F12.
+severity: minor
+resolution: Plan Layer 0 includes the rewritten godoc text for `entitymanager.RelationOptions` and `workspace.updateRelation` documenting merge-then-unset semantics for UpdateRelation, full-replacement implication for CreateRelation, and `*string Content` nil-vs-empty-string distinction.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CW1FK.md
+++ b/tickets/entities/review-responses/RR-CW1FK.md
@@ -1,0 +1,12 @@
+---
+id: RR-CW1FK
+type: review-response
+title: AC17 contradicts atomicity-out-of-scope statement
+finding: |-
+    AC17 says 'PATCH with valid properties + invalid relation entry → entity NOT updated' but current dispatch order is entity-update first (api_v1.go:552) then reconcile (api_v1.go:558). Entity is on disk before relation validation runs. AC17 is unachievable without reordering. Plan says 'validation runs before any writes' but only inside the modern reconciler, not across phases. Recommendation: pick option A (validate-first reorder) or drop AC17.
+
+    From design-review: F2.
+severity: critical
+resolution: 'Plan Layer 3 reorders the handler to validate-first: Phase A runs the relation validation pass (no writes), Phase B runs entity UpdateEntity, Phase C runs relation writes. A relation 400/422 returns before UpdateEntity, making AC17 achievable. Mid-write-loop store failures still leave a partial state — documented as a known atomicity limitation.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-D895N.md
+++ b/tickets/entities/review-responses/RR-D895N.md
@@ -1,0 +1,12 @@
+---
+id: RR-D895N
+type: review-response
+title: meta_unset of a key not present on the edge is unspecified
+finding: |-
+    Plan covers schema-known but doesn't say what happens for declared-but-not-currently-set keys. Go delete() is a no-op, but combined with F3's shape-based suppression: re-PATCHing `meta_unset: ["X"]` for absent X always trips the 'has MetaUnset → upsert' branch and writes every time. Recommendation: 'meta_unset of declared-but-absent key is no-op'. Combine with F3 by computing post-merge map and comparing to current for true value-based suppression.
+
+    From design-review: F9.
+severity: significant
+reason: Dissolves under DEC-HWZHA. meta_unset of a declared-but-absent key is now an explicit no-op (Go delete() of a missing key is silently fine). The combinatorial worry with no-op suppression (always tripping the upsert branch) is addressed by RR-M3LWM's value-based no-op suppression, where the post-merge map is compared against the current map; if they're equal, no write.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-FOLOX.md
+++ b/tickets/entities/review-responses/RR-FOLOX.md
@@ -1,0 +1,12 @@
+---
+id: RR-FOLOX
+type: review-response
+title: Mixed-shape detection error message is non-deterministic via Go map iteration
+finding: |-
+    Plan says 'fail-fast 400 with offending key in pointer' but Go map iteration is randomized. Error message names whichever relation type appeared 'second'; tests flake. Recommendation: stable error code (`shape_mixed`), generic detail without naming a specific key OR sort keys lexicographically before detection. Test asserts on code only.
+
+    From design-review: F7.
+severity: significant
+resolution: Plan Layer 1 specifies stable error code `shape_mixed`, generic detail ("request mixes legacy and JSON:API relation shapes; pick one"), no key naming. Test plan asserts on code only and tests both map-iteration orderings.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-LGK1X.md
+++ b/tickets/entities/review-responses/RR-LGK1X.md
@@ -1,0 +1,12 @@
+---
+id: RR-LGK1X
+type: review-response
+title: null inside JSON for meta / meta_unset / meta_unset elements unspecified
+finding: |-
+    Plan handles `content: null`. Doesn't specify: `meta: null` (clear or absent?), `meta_unset: null` (absent?), `meta_unset: ["x", null]` (will fail with bad Go error 400). Recommendation: explicit edge-case rows. `meta: null` → absent. `meta_unset: null` → absent. `meta_unset` containing null/non-string element → 422 with index pointer. Validate at unmarshal.
+
+    From design-review: F8.
+severity: significant
+resolution: 'Plan to specify in the rewrite: meta: null → treated as absent. meta_unset: null → treated as absent. meta_unset containing a null/non-string element → hard 400 wire-format error (caller bug, not a soft data condition). These are wire-shape issues, not data-state issues, so they stay 400.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-M3LWM.md
+++ b/tickets/entities/review-responses/RR-M3LWM.md
@@ -1,0 +1,12 @@
+---
+id: RR-M3LWM
+type: review-response
+title: Shape-based no-op suppression defeated by realistic auto-save
+finding: |-
+    Plan asserts auto-save sends edges with no `meta` field when unchanged — assumes frontend dynamically omits unchanged fields. Real auto-save re-serializes full form state every debounce; every edge with meta carries `meta` in every save. Shape-based suppression triggers writes for every meta-bearing edge on every keystroke. Defeats ticket's no-op-suppression goal. Recommendation: either bring back value-based suppression (json-vs-disk float64 normalization is overstated as 'can of worms'), suppress at writeRelationCore byte-equality layer, or narrow the no-op promise scope and tell the frontend.
+
+    From design-review: F3.
+severity: critical
+resolution: 'Plan Layer 2 specifies value-based no-op suppression: compute post-merge (finalProps, finalContent) and compare against current via reflect.DeepEqual. Auto-save''s main case (re-saving unchanged form with all meta fields populated) writes nothing. AC14 covers this; AC14b is the strict subset (shape-based suppression for completely absent fields). Documented assumption that JSON-vs-YAML unmarshal both produce Go-native types so reflect.DeepEqual works without explicit numeric normalization; fallback path to internal/model.PropertyValueEqual if it breaks.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-PZY1W.md
+++ b/tickets/entities/review-responses/RR-PZY1W.md
@@ -1,0 +1,12 @@
+---
+id: RR-PZY1W
+type: review-response
+title: Validation order between entity validation and relation validation is unspecified
+finding: |-
+    Plan doesn't say whether modern reconciler validation runs before or after entityManager.UpdateEntity. Affects which 422 the user sees first, AC17 atomicity, future parallelization. Same axis as F2 but specifically about validation. Recommendation: specify 'modern reconciler validation runs FIRST, before entity update; on validation failure return 422 with offending pointer, no writes occur; entity validation errors come from UpdateEntity itself.'
+
+    From design-review: F5.
+severity: significant
+resolution: Plan Layer 3 specifies relation-validation runs FIRST, before entity update. Multiple 4xx errors are not combined; user sees the first one. Future refinement out of scope.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QOIXK.md
+++ b/tickets/entities/review-responses/RR-QOIXK.md
@@ -1,0 +1,12 @@
+---
+id: RR-QOIXK
+type: review-response
+title: RelationOptions.Content *string change ripples through 9 call sites including MCP/Lua public APIs
+finding: |-
+    Plan says 'audit during implementation; mechanical updates'. Reviewer enumerated 9 sites: dataentry handlers, workspace manager, mcp/tools_relation.go (MCP tool API), cli/link.go, lua/runtime.go (Lua public API). MCP/Lua sites change semantics for AI clients and scripts: what does `content: ""` mean — clear or leave alone? Plan doesn't specify. Recommendation: enumerate now, decide MCP/Lua semantic, or use `ClearContent bool` to avoid the cascade.
+
+    From design-review: F4.
+severity: significant
+resolution: 'Plan Layer 0 enumerates 9 call sites + 1 stub in a table. MCP tool: helper `nilIfEmpty` preserves today''s leave-alone behavior on `content: ""`; tool docs note to pass `null` or omit the field. Lua: deliberate semantic change — `update_relation({content=""})` now clears (matches user intuition); documented in lua API reference.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-RGVJE.md
+++ b/tickets/entities/review-responses/RR-RGVJE.md
@@ -1,0 +1,12 @@
+---
+id: RR-RGVJE
+type: review-response
+title: SSE event semantics on partial failure / no-op are not specified
+finding: |-
+    Plan says SSE events suppressed when no writes. Today entity SSE fires after successful entity update, then relation reconcile may fail (the relation 422 is returned but SSE has already gone out). Recommendation: specify 'on 422 from any phase, entity SSE does NOT fire'; per-relation events fire only on actual writes; entity event fires only when entity itself changed. Add AC for relations-only PATCH not emitting entity:updated.
+
+    From design-review: F11.
+severity: minor
+resolution: 'Plan Layer 5 specifies SSE semantics: entity event only on actual entity change; per-relation events only on actual writes (after value-based no-op suppression); no events on 400/422; relations-only no-op PATCH emits zero events.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-TK2QF.md
+++ b/tickets/entities/review-responses/RR-TK2QF.md
@@ -1,0 +1,12 @@
+---
+id: RR-TK2QF
+type: review-response
+title: Concurrent automation between entity update and relation writes can stale the diff
+finding: |-
+    Sequence (after F2 reorder): relation-validate → entity update (fires automations, possibly creating relations) → relation writes. If an automation creates a relation conflicting with the desired set, reconciler's diff is stale and may delete/recreate. Same hazard exists today; not worse, but plan doesn't acknowledge. Recommendation: document in risk section as known interaction. Or: re-fetch current outgoing relations after entity update before write phase.
+
+    From design-review: F15.
+severity: minor
+resolution: 'Plan Layer 6 acknowledges the automation/diff staleness window: with validate → entity update → relation writes ordering, automations during entity update may create relations before the relation-write phase runs; the relation-write phase doesn''t re-validate against the post-automation graph. Same hazard as today''s legacy reconciler. Documented in api-reference.md as known interaction.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-UZ8LX.md
+++ b/tickets/entities/review-responses/RR-UZ8LX.md
@@ -1,0 +1,12 @@
+---
+id: RR-UZ8LX
+type: review-response
+title: 'data: null semantics not specified'
+finding: |-
+    AC5 covers data:[]; AC8 covers no data key (400); plan implies data:null is distinguishable from data:[] but doesn't say what it means. Recommendation: pick one — reject data:null as 400 with data_required (same as missing key) OR treat as equivalent to data:[]. Document.
+
+    From design-review: F14.
+severity: minor
+resolution: 'Plan Layer 1 specifies `data: null` returns 400 `data_required` (same as missing). `null` as relation value returns 400 `relation_value_null`. AC20c covers `data: null`. AC9 (unknown relation type) is hard 422 because there''s no defined storage location.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-X5WVA.md
+++ b/tickets/entities/review-responses/RR-X5WVA.md
@@ -1,0 +1,12 @@
+---
+id: RR-X5WVA
+type: review-response
+title: RelationOptions audit list is aspirational, not enumerated
+finding: |-
+    Plan defers call-site audit to implementation. Reviewer enumerated 9 sites: handlers_api.go:527, relations.go:113, api_v1.go:730, api_v1.go:772, manager.go:138, manager.go:147, mcp/tools_relation.go:76, cli/link.go:27, lua/runtime.go:1373, plus PanicOnUse stub. Two are public APIs (MCP, Lua). Recommendation: enumerate in plan now; for each state new value and behavior; flag MCP/Lua for behavioral notes.
+
+    From design-review: F13.
+severity: minor
+resolution: 'Plan Layer 0 includes the full call-site enumeration: 9 sites + 1 stub, with current call, new call, and behavioral-change column for each. MCP and Lua flagged as having subtle behavior changes.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YNWR7.md
+++ b/tickets/entities/review-responses/RR-YNWR7.md
@@ -1,0 +1,12 @@
+---
+id: RR-YNWR7
+type: review-response
+title: JSON pointer escaping uses %q (Go-quoted) instead of RFC 6901
+finding: |-
+    Plan says relation-type names wrapped with %q in error pointers. %q is Go quoted-string — escapes for Go literals, not JSON pointer (RFC 6901: / → ~1, ~ → ~0). Relation type 'foo/bar' produces invalid JSON pointer; clients parsing it mis-route. Recommendation: add `jsonPointerEscape(s string) string` helper applying RFC 6901, or rename the field from 'JSON pointer' to 'structured error path' if %q semantics are intentional.
+
+    From design-review: F6.
+severity: significant
+resolution: Plan Layer 1 specifies a `jsonPointerEscape(s string) string` helper in internal/dataentry/ applying RFC 6901 escaping (~ → ~0, / → ~1). Used uniformly for relation-type names and meta keys in error pointers. Documented as RFC 6901 in api-reference.md.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-6WLSW.md
+++ b/tickets/entities/tickets/TKT-6WLSW.md
@@ -1,0 +1,106 @@
+---
+id: TKT-6WLSW
+type: ticket
+title: Extend PATCH /entities/{id} relations to carry per-edge meta + content
+kind: enhancement
+priority: medium
+effort: s
+status: planning
+---
+
+## Problem
+
+The PATCH endpoint today accepts `relations: map[string][]string` — target IDs
+only, no per-edge data. Auto-save (TKT-18JS6) and the `RelationCards` widget
+(TKT-B9SXH) need to upsert per-edge `meta` (e.g. `weight`, `added_by`) and
+`content` (markdown body for relation types with `content: true`) inside the
+same single-form-PATCH so a failed save doesn't leave half the form persisted.
+
+This ticket extends the wire format to carry that data and surfaces validation
+findings as **non-blocking warnings** rather than rejecting writes — see
+DEC-HWZHA "Validation policy for write APIs: tolerate temporarily invalid data".
+
+## Wire format extension
+
+```http
+PATCH /api/v1/tickets/TKT-001
+Content-Type: application/json
+
+{
+  "properties": {"title": "new"},
+  "relations": {
+    "tagged": {
+      "data": [
+        {"type": "label", "id": "L-001", "meta": {"weight": 5}, "meta_unset": ["added_by"]},
+        {"type": "label", "id": "L-002"}
+      ]
+    }
+  }
+}
+```
+
+**Backwards compat**: continue accepting the existing `relations:
+map[string][]string` shape (target-IDs-only) for callers that don't need
+per-edge data. Both shapes follow the same validation policy; the modern shape
+additionally surfaces warnings inline.
+
+## Validation policy
+
+Per DEC-HWZHA, validation findings split into three classes:
+
+**Hard 400 — malformed wire format**
+- Malformed JSON in body
+- Relation wrapper missing required `data` field (`{"tagged": {}}`)
+- Resource identifier missing `type` or `id`
+- Mixed legacy + modern shapes in one body
+- Non-string element in `meta_unset` array
+- `data` field on a wrapper has unexpected type (string, scalar, etc.)
+
+**Hard 422 — structural impossibilities**
+- Unknown relation type (no defined storage location for the file)
+- Writing `content` on a relation type whose disk format doesn't support a body (the file shape can't hold it)
+- `data` value is non-array (legacy IDs-only shape with a non-array value)
+
+**200 + warnings — soft conditions surfaced inline** Everything else previous
+drafts wanted to 422 on. The API performs the requested write and returns
+warnings in the response body so UIs surface them non-blockingly. Conditions:
+- Target ID doesn't exist
+- Target entity type doesn't match the relation's allowed `to` set
+- Source entity type doesn't match the relation's allowed `from` set
+- Unknown meta keys (closed-schema violation)
+- Required meta property unset
+- Meta value type mismatch against declared property type
+
+Each warning is `{code, path, detail}`; `code` matches the corresponding
+`analyze_*` finding code so UIs can de-duplicate against analyze runs.
+
+## Wire format details (under the policy)
+
+- **List replacement, edge upsert.** `data: []` removes all of that type; absent type leaves alone; `data: [...]` is the desired set. Edges in the list get their meta/content upserted; edges not in the list are removed.
+- **Value-based no-op suppression.** When the post-merge state of an edge byte-equals the current state, no write occurs and no SSE event fires. Auto-save's main case (re-saving an unchanged form) writes nothing.
+- **Cardinality remains advisory** (no enforcement at write time).
+- **Atomicity.** Validation phase runs FIRST, before any writes (including the entity update). On any 400/422, no writes occur. Warnings do NOT block the write — the entity AND relations both persist.
+- **`data` field required when wrapper appears.** `{"tagged": {}}` returns 400 (data-loss footgun mitigation).
+
+## Approach
+
+See PLAN-MXQKI for the implementation approach (validation-first ordering,
+value-based no-op suppression, RelationOptions extension with MetaUnset and
+*string Content, custom UnmarshalJSON state machine).
+
+## Out of scope
+
+- Frontend wiring of `RelationPicker` / `RelationCards` to the new shape — TKT-B9SXH / TKT-18JS6 will consume the API.
+- Symmetric / inverse propagation of per-edge meta — current `writeRelation` does not propagate at all today (workspace.go:416). Separate ticket if needed.
+- Multi-write atomicity (entity update + relation reconcile as a single transaction). The store interface (internal/store/store.go) explicitly has no transaction primitive; adding one fights FEAT-CO4YP "Pluggable store backends" goals. Documented in api-reference.md.
+- Migrating callers off the legacy IDs-only shape (deprecation deferred).
+
+## Prior art
+
+Closed PR #648 (now-deleted branch `feat/patch-with-relations`) attempted this
+on top of an older develop and ended up extracting a parallel `entitymanager`
+package — but TKT-GOLNP shipped its own `EntityManager` interface in the
+meantime with a different shape. This ticket is the additive subset that doesn't
+fight the existing manager surface, AND aligns with DEC-HWZHA's softer
+validation policy (the closed PR had the same drift toward hard 422s that this
+ticket explicitly avoids).

--- a/tickets/entities/tickets/TKT-6WLSW.md
+++ b/tickets/entities/tickets/TKT-6WLSW.md
@@ -5,7 +5,7 @@ title: Extend PATCH /entities/{id} relations to carry per-edge meta + content
 kind: enhancement
 priority: medium
 effort: s
-status: planning
+status: in-progress
 ---
 
 ## Problem

--- a/tickets/relations/DEC-HWZHA--decides--data-entry-server.md
+++ b/tickets/relations/DEC-HWZHA--decides--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: DEC-HWZHA
+relation: decides
+to: data-entry-server
+---

--- a/tickets/relations/TKT-6WLSW--affects--data-entry-server.md
+++ b/tickets/relations/TKT-6WLSW--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-6WLSW--has-implementation--IMPL-J6YL2.md
+++ b/tickets/relations/TKT-6WLSW--has-implementation--IMPL-J6YL2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-implementation
+to: IMPL-J6YL2
+---

--- a/tickets/relations/TKT-6WLSW--has-planning--PLAN-MXQKI.md
+++ b/tickets/relations/TKT-6WLSW--has-planning--PLAN-MXQKI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-planning
+to: PLAN-MXQKI
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-0NTMQ.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-0NTMQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-0NTMQ
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-48WQ3.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-48WQ3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-48WQ3
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-4G6V0.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-4G6V0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-4G6V0
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-CW1FK.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-CW1FK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-CW1FK
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-D895N.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-D895N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-D895N
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-FOLOX.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-FOLOX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-FOLOX
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-LGK1X.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-LGK1X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-LGK1X
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-M3LWM.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-M3LWM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-M3LWM
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-PZY1W.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-PZY1W.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-PZY1W
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-QOIXK.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-QOIXK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-QOIXK
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-RGVJE.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-RGVJE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-RGVJE
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-TK2QF.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-TK2QF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-TK2QF
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-UZ8LX.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-UZ8LX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-UZ8LX
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-X5WVA.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-X5WVA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-X5WVA
+---

--- a/tickets/relations/TKT-6WLSW--has-review-response--RR-YNWR7.md
+++ b/tickets/relations/TKT-6WLSW--has-review-response--RR-YNWR7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: has-review-response
+to: RR-YNWR7
+---

--- a/tickets/relations/TKT-6WLSW--implements--FEAT-jsjj.md
+++ b/tickets/relations/TKT-6WLSW--implements--FEAT-jsjj.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6WLSW
+relation: implements
+to: FEAT-jsjj
+---


### PR DESCRIPTION
## Summary

Extends `PATCH /api/v1/{plural}/{id}` to accept per-edge meta + content on relations using a JSON:API §9-shaped wire format, while keeping the legacy IDs-only shape working unchanged. Auto-save (TKT-18JS6) and `RelationCards` (TKT-B9SXH) can now persist the full form state — including per-edge metadata — in a single PATCH.

This work also introduces and enforces **DEC-HWZHA — Validation policy for write APIs**: hard 400 for malformed wire format, hard 422 for structural impossibilities, **200 + warnings** for everything else (target type mismatch, missing target, unknown meta keys, required-meta unset). Soft conditions surface inline as `warnings: [{code, path, detail}]` rather than rejecting the write.

## What's new

- **Wire format**: `relations: {tagged: {data: [{type, id, meta?, meta_unset?, content?}]}}` alongside the legacy `relations: {tagged: ["L-001"]}`. Mixing the two in one body returns 400 `shape_mixed`.
- **`entitymanager.RelationOptions`** gains `MetaUnset []string` and changes `Content string` → `*string` so meta-clear and content-clear are expressible.
- **`workspace.updateRelation`** documented and extended: merge → unset → conditional content replace.
- **Validation-first ordering** in the handler: relation validation runs BEFORE the entity update, so a relation 400/422 leaves the entity untouched (AC17 actually achievable).
- **Value-based no-op suppression**: re-PATCHing identical state writes zero relation files and emits zero SSE events.
- **Soft-condition writes bypass** the workspace's target-existence check: edges with missing or wrong-typed targets are written directly through the store and surface as warnings.
- **OpenAPI schema** updated with `RelationsUpdate`, `ResourceIdentifier`, `Warning` components.
- **Docs**: `docs/data-entry/api-reference.md` covers the full contract, the data-loss footgun callout, and the atomicity gap.
- **CLAUDE.md**: new "Validation policy for write APIs" section linking DEC-HWZHA so future tickets don't redrift.

## Plan + design review

Two commits:
- `5f98685` — planning artifacts (DEC-HWZHA, TKT-6WLSW, PLAN-MXQKI, 15 design-review RRs all addressed)
- `e90a745` — implementation (Layers 0–7 of PLAN-MXQKI)

15 design-review findings classified: 13 addressed in plan/code, 2 wont-fix because they dissolved under DEC-HWZHA's softer policy. See PLAN-MXQKI's "Design Review Findings" section.

## Out of scope

- Frontend wiring of `RelationPicker` / `RelationCards` to the new shape — TKT-B9SXH / TKT-18JS6 will consume.
- Symmetric / inverse propagation of per-edge meta — separate gap; current `writeRelation` doesn't propagate at all.
- Multi-write store transaction primitive — fights FEAT-CO4YP "Pluggable backends"; documented gap.
- Migrating other workspace write paths off hard 422 for soft conditions — separate-ticket work per DEC-HWZHA migration scope.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go test -race ./...` — no data races
- [x] `golangci-lint run ./...` — clean (0 issues)
- [x] `just coverage-check` — package + total thresholds PASS
- [x] 22 integration tests in `internal/dataentry/relations_modern_test.go` cover AC1–AC20a + AC15/16
- [x] 17 unit tests in `internal/dataentry/relations_v1_wire_test.go` cover wire-format edge cases (null/whitespace/scalar/mixed-shape/sibling-keys/non-string meta_unset)
- [ ] Manual smoke test in the data-entry web UI before merge — the auto-save UX (TKT-18JS6) depends on this endpoint