### PR TITLE
feat: refreshed default theme (light + dark)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rela-frontend",
       "version": "0.0.1",
       "dependencies": {
+        "@fontsource/open-sans": "^5.2.7",
         "axios": "^1.15.2",
         "dompurify": "^3.3.3",
         "easymde": "^2.20.0",
@@ -484,6 +485,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/open-sans": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/open-sans/-/open-sans-5.2.7.tgz",
+      "integrity": "sha512-8yfgDYjE5O0vmTPdrcjV35y4yMnctsokmi9gN49Gcsr0sjzkMkR97AnKDe6OqZh2SFkYlR28fxOvi21bYEgMSw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "dupes": "jscpd src --ignore \"**/*.test.ts\" --reporters console"
   },
   "dependencies": {
+    "@fontsource/open-sans": "^5.2.7",
     "axios": "^1.15.2",
     "dompurify": "^3.3.3",
     "easymde": "^2.20.0",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -142,9 +142,9 @@ watch(
 </template>
 
 <style>
-/* Sourcehaven theme — derived from sourcehaven.nl
-   Light: cream paper bg, deep harbour-navy sidebar, blue accent, warm peach highlights.
-   Dark:  same harbour-navy as the dominant surface, cream-tinted text, lifted accent. */
+/* Default theme.
+   Light: cream paper bg, deep harbor-navy sidebar, blue accent, warm peach highlights.
+   Dark:  same harbor-navy as the dominant surface, cream-tinted text, lifted accent. */
 :root {
   --sidebar-bg: #164155;
   --sidebar-text: #f3f2ef;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -142,52 +142,55 @@ watch(
 </template>
 
 <style>
+/* Sourcehaven theme — derived from sourcehaven.nl
+   Light: cream paper bg, deep harbour-navy sidebar, blue accent, warm peach highlights.
+   Dark:  same harbour-navy as the dominant surface, cream-tinted text, lifted accent. */
 :root {
-  --sidebar-bg: #1a1a2e;
-  --sidebar-text: #e8e8e8;
-  --accent-color: #6366f1;
-  --bg-color: #f8fafc;
-  --text-color: #1e293b;
-  --border-color: #e2e8f0;
-  --success-color: #10b981;
-  --error-color: #ef4444;
-  --warning-color: #f59e0b;
-  --info-color: #3b82f6;
+  --sidebar-bg: #164155;
+  --sidebar-text: #f3f2ef;
+  --accent-color: #4772fb;
+  --bg-color: #f3f2ef;
+  --text-color: #191919;
+  --border-color: #e0ddd5;
+  --success-color: #06ce90;
+  --error-color: #e5484d;
+  --warning-color: #f4aa83;
+  --info-color: #4772fb;
   --card-bg: #ffffff;
   --input-bg: #ffffff;
-  --hover-bg: #f1f5f9;
-  --muted-text: #64748b;
-  --badge-blue: #3b82f6;
+  --hover-bg: #ebe9e4;
+  --muted-text: #6b7280;
+  --badge-blue: #4772fb;
   --badge-purple: #8b5cf6;
-  --badge-green: #22c55e;
+  --badge-green: #06ce90;
   --badge-gray: #6b7280;
-  --badge-red: #ef4444;
-  --badge-orange: #f97316;
-  --badge-yellow: #eab308;
+  --badge-red: #e5484d;
+  --badge-orange: #f4aa83;
+  --badge-yellow: #f9d975;
 }
 
 :root.dark {
-  --sidebar-bg: #0f0f1a;
-  --sidebar-text: #e8e8e8;
-  --accent-color: #818cf8;
-  --bg-color: #121218;
-  --text-color: #e2e8f0;
-  --border-color: #2d2d3a;
-  --success-color: #34d399;
+  --sidebar-bg: #091821;
+  --sidebar-text: #ece9e0;
+  --accent-color: #6f93ff;
+  --bg-color: #0f1f28;
+  --text-color: #ece9e0;
+  --border-color: #264454;
+  --success-color: #34d39c;
   --error-color: #f87171;
-  --warning-color: #fbbf24;
-  --info-color: #60a5fa;
-  --card-bg: #1a1a24;
-  --input-bg: #1e1e28;
-  --hover-bg: #252530;
-  --muted-text: #94a3b8;
-  --badge-blue: #60a5fa;
+  --warning-color: #f9d975;
+  --info-color: #6f93ff;
+  --card-bg: #162a35;
+  --input-bg: #1b3140;
+  --hover-bg: #1f3848;
+  --muted-text: #8fa4b0;
+  --badge-blue: #6f93ff;
   --badge-purple: #c4b5fd;
-  --badge-green: #4ade80;
-  --badge-gray: #6b7280;
+  --badge-green: #34d39c;
+  --badge-gray: #8fa4b0;
   --badge-red: #f87171;
-  --badge-orange: #fb923c;
-  --badge-yellow: #fde047;
+  --badge-orange: #f4aa83;
+  --badge-yellow: #f9d975;
 }
 
 * {
@@ -197,7 +200,7 @@ watch(
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-family: 'Open Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   background: var(--bg-color);
   color: var(--text-color);
   line-height: 1.5;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,10 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
+import '@fontsource/open-sans/400.css'
+import '@fontsource/open-sans/500.css'
+import '@fontsource/open-sans/600.css'
+import '@fontsource/open-sans/700.css'
 import './styles/back-button.css'
 
 const app = createApp(App)

--- a/internal/dataentryconfig/palette.go
+++ b/internal/dataentryconfig/palette.go
@@ -150,8 +150,8 @@ type ResolvedPalette struct {
 	DarkDisabled bool              `json:"darkDisabled,omitempty"`
 }
 
-// Built-in default colors for light mode. Derived from sourcehaven.nl —
-// cream paper surface, harbor-navy sidebar, blue accent.
+// Built-in default colors for light mode: cream paper surface,
+// harbor-navy sidebar, blue accent.
 var defaultLightColors = PaletteColors{
 	Base:    "#164155",
 	Surface: "#f3f2ef",

--- a/internal/dataentryconfig/palette.go
+++ b/internal/dataentryconfig/palette.go
@@ -150,27 +150,52 @@ type ResolvedPalette struct {
 	DarkDisabled bool              `json:"darkDisabled,omitempty"`
 }
 
-// Built-in default colors for light mode.
+// Built-in default colors for light mode. Derived from sourcehaven.nl —
+// cream paper surface, harbor-navy sidebar, blue accent.
 var defaultLightColors = PaletteColors{
-	Base:    "#1a1a2e",
-	Surface: "#f8fafc",
-	Accent:  "#6366f1",
-	Text:    "#1e293b",
-	Success: "#10b981",
-	Error:   "#ef4444",
-	Warning: "#f59e0b",
-	Info:    "#3b82f6",
+	Base:    "#164155",
+	Surface: "#f3f2ef",
+	Accent:  "#4772fb",
+	Text:    "#191919",
+	Success: "#06ce90",
+	Error:   "#e5484d",
+	Warning: "#f4aa83",
+	Info:    "#4772fb",
+}
+
+// Built-in default colors for dark mode. Same hue family as the light
+// defaults — harbor-navy surface, cream-tinted text, lifted blue accent.
+var defaultDarkColors = PaletteColors{
+	Base:    "#091821",
+	Surface: "#0f1f28",
+	Accent:  "#6f93ff",
+	Text:    "#ece9e0",
+	Success: "#34d39c",
+	Error:   "#f87171",
+	Warning: "#f9d975",
+	Info:    "#6f93ff",
 }
 
 // Built-in default badge colors.
 var defaultBadgeColors = map[string]string{
-	"blue":   "#3b82f6",
+	"blue":   "#4772fb",
 	"purple": "#8b5cf6",
-	"green":  "#22c55e",
+	"green":  "#06ce90",
 	"gray":   "#6b7280",
-	"red":    "#ef4444",
-	"orange": "#f97316",
-	"yellow": "#eab308",
+	"red":    "#e5484d",
+	"orange": "#f4aa83",
+	"yellow": "#f9d975",
+}
+
+// Built-in default badge colors for dark mode.
+var defaultDarkBadges = map[string]string{
+	"blue":   "#6f93ff",
+	"purple": "#c4b5fd",
+	"green":  "#34d39c",
+	"gray":   "#8fa4b0",
+	"red":    "#f87171",
+	"orange": "#f4aa83",
+	"yellow": "#f9d975",
 }
 
 // ValidateHexColor checks that a string is a valid hex color.
@@ -261,13 +286,12 @@ func mergeColors(dst, src *PaletteColors) {
 // produces a ResolvedPalette containing the fully derived CSS
 // variable map.
 //
-// Dark mode is opt-in and explicit: if neither project nor user
-// supplied a dark configuration, dark mode is reported as disabled.
-// Auto-derivation lives in the frontend (Settings → Derive Dark) and
-// produces a fully-populated PaletteColors object that arrives here
-// via the user palette. Empty fields in an explicit dark palette
-// inherit from the resolved light palette so that partial overrides
-// compose cleanly with the user's chosen light theme.
+// Dark mode is on by default — when neither project nor user supplied
+// a dark configuration, the built-in defaultDarkColors palette is
+// used. To turn dark mode off, a project or user palette must
+// explicitly set `dark: false`. Empty fields in an explicit dark
+// palette inherit from the resolved light palette so that partial
+// overrides compose cleanly with the user's chosen light theme.
 func ResolvePalette(project, user *PaletteConfig) *ResolvedPalette {
 	// Start with defaults.
 	light := defaultLightColors
@@ -286,9 +310,12 @@ func ResolvePalette(project, user *PaletteConfig) *ResolvedPalette {
 	}
 
 	// Determine dark mode. The user palette wins if it specifies
-	// anything; otherwise the project palette; otherwise dark is
-	// disabled by default.
-	darkMode := DarkMode{Disabled: true}
+	// anything; otherwise the project palette; otherwise dark mode
+	// uses the built-in default dark palette.
+	darkMode := DarkMode{Explicit: &DarkPalette{
+		PaletteColors: defaultDarkColors,
+		Badges:        copyBadges(defaultDarkBadges),
+	}}
 	if project != nil && (project.Dark.Disabled || project.Dark.Explicit != nil) {
 		darkMode = project.Dark
 	}

--- a/internal/dataentryconfig/palette_test.go
+++ b/internal/dataentryconfig/palette_test.go
@@ -233,13 +233,14 @@ func TestDarkModeJSON(t *testing.T) {
 }
 
 func TestResolvePalette(t *testing.T) {
-	t.Run("nil palettes return defaults with dark disabled", func(t *testing.T) {
+	t.Run("nil palettes return defaults with dark enabled", func(t *testing.T) {
 		r := ResolvePalette(nil, nil)
 		require.NotNil(t, r)
 		assert.Equal(t, defaultLightColors.Accent, r.Light["--accent-color"])
 		assert.Equal(t, defaultBadgeColors["blue"], r.Light["--badge-blue"])
-		assert.True(t, r.DarkDisabled, "dark should be disabled when no explicit dark configured")
-		assert.Empty(t, r.Dark)
+		assert.False(t, r.DarkDisabled, "dark should be enabled by default with built-in dark palette")
+		assert.Equal(t, defaultDarkColors.Accent, r.Dark["--accent-color"])
+		assert.Equal(t, defaultDarkBadges["blue"], r.Dark["--badge-blue"])
 	})
 
 	t.Run("partial project palette merges with defaults", func(t *testing.T) {
@@ -328,16 +329,25 @@ func TestResolvePalette(t *testing.T) {
 		}
 	})
 
-	t.Run("21 light variables when dark disabled", func(t *testing.T) {
+	t.Run("21 variables in each theme when dark enabled by default", func(t *testing.T) {
 		r := ResolvePalette(nil, nil)
 		assert.Len(t, r.Light, 21) // 8 base + 6 derived + 7 badges
+		assert.Len(t, r.Dark, 21)
+	})
+
+	t.Run("dark explicitly disabled by project skips built-in dark", func(t *testing.T) {
+		project := &PaletteConfig{Dark: DarkMode{Disabled: true}}
+		r := ResolvePalette(project, nil)
+		assert.True(t, r.DarkDisabled)
 		assert.Empty(t, r.Dark)
 	})
 
-	t.Run("zero-value DarkMode (from JSON null) is treated as disabled", func(t *testing.T) {
+	t.Run("zero-value DarkMode (from JSON null) falls through to default dark", func(t *testing.T) {
 		// JSON `null` decoded into DarkMode produces a zero value:
-		// neither Disabled nor Explicit set. Without the defensive
-		// check this would panic on `*darkMode.Explicit`.
+		// neither Disabled nor Explicit set. The user palette
+		// contributes no dark preference, so the built-in default
+		// dark palette wins. The defensive nil check still prevents
+		// a panic on `*darkMode.Explicit`.
 		var p PaletteConfig
 		require.NoError(t, json.Unmarshal([]byte(`{"accent":"#ffcd75","dark":null}`), &p))
 		assert.False(t, p.Dark.IsDisabled())
@@ -345,7 +355,8 @@ func TestResolvePalette(t *testing.T) {
 
 		require.NotPanics(t, func() {
 			r := ResolvePalette(nil, &p)
-			assert.True(t, r.DarkDisabled)
+			assert.False(t, r.DarkDisabled)
+			assert.Equal(t, defaultDarkColors.Accent, r.Dark["--accent-color"])
 		})
 	})
 }

--- a/tickets/entities/features/FEAT-ML19.md
+++ b/tickets/entities/features/FEAT-ML19.md
@@ -1,9 +1,9 @@
 ---
 id: FEAT-ML19
 type: feature
-title: Sourcehaven brand theme
-summary: Sourcehaven-branded default palette (light + dark) for the data entry UI, with self-hosted Open Sans.
-description: 'Replaces rela''s default palette with Sourcehaven''s brand colors — cream paper bg + harbor-navy sidebar + #4772fb accent for light, deep harbor-navy + lifted blue for dark. Open Sans is bundled via @fontsource (SIL OFL 1.1) so the SPA has zero runtime dependency on Google Fonts. Default dark mode is now on out-of-the-box.'
+title: Refreshed default theme
+summary: Better default light + dark palette for the data entry UI, with self-hosted Open Sans.
+description: 'Replaces the old default palette with a calmer, more legible one — cream paper bg + harbor-navy sidebar + #4772fb accent for light, deep harbor-navy + lifted blue for dark. Open Sans is bundled via @fontsource (SIL OFL 1.1) so the SPA has zero runtime dependency on Google Fonts. Default dark mode is now on out-of-the-box; projects that prefer light-only can still opt out with `dark: false`.'
 priority: low
 status: implemented
 ---
@@ -11,7 +11,7 @@ status: implemented
 ## Implementation
 
 - `internal/dataentryconfig/palette.go` — new `defaultLightColors`, `defaultDarkColors`, and matching badge maps. `ResolvePalette` now seeds dark mode from the new defaults instead of `Disabled: true`; explicit `dark: false` opt-out still wins.
-- `frontend/src/App.vue` — `:root` and `:root.dark` CSS vars synced to the same Sourcehaven palette so the SSR fallback matches.
+- `frontend/src/App.vue` — `:root` and `:root.dark` CSS vars synced to the same palette so the SSR fallback matches.
 - `frontend/src/main.ts` — imports `@fontsource/open-sans` weights 400/500/600/700 instead of pulling from fonts.googleapis.com.
 
 ## Why bundle the font

--- a/tickets/entities/features/FEAT-ML19.md
+++ b/tickets/entities/features/FEAT-ML19.md
@@ -1,0 +1,27 @@
+---
+id: FEAT-ML19
+type: feature
+title: Sourcehaven brand theme
+summary: Sourcehaven-branded default palette (light + dark) for the data entry UI, with self-hosted Open Sans.
+description: 'Replaces rela''s default palette with Sourcehaven''s brand colors — cream paper bg + harbor-navy sidebar + #4772fb accent for light, deep harbor-navy + lifted blue for dark. Open Sans is bundled via @fontsource (SIL OFL 1.1) so the SPA has zero runtime dependency on Google Fonts. Default dark mode is now on out-of-the-box.'
+priority: low
+status: implemented
+---
+
+## Implementation
+
+- `internal/dataentryconfig/palette.go` — new `defaultLightColors`, `defaultDarkColors`, and matching badge maps. `ResolvePalette` now seeds dark mode from the new defaults instead of `Disabled: true`; explicit `dark: false` opt-out still wins.
+- `frontend/src/App.vue` — `:root` and `:root.dark` CSS vars synced to the same Sourcehaven palette so the SSR fallback matches.
+- `frontend/src/main.ts` — imports `@fontsource/open-sans` weights 400/500/600/700 instead of pulling from fonts.googleapis.com.
+
+## Why bundle the font
+
+Operating rela should not depend on a working connection to Google Fonts. SIL
+OFL 1.1 explicitly permits redistribution.
+
+## Verification
+
+- `just ci` passes locally.
+- Verified at runtime via puppeteer: zero off-origin requests on page load, Open Sans woff2 served from rela's `/assets/`.
+
+Shipped via PR #670.

--- a/tickets/entities/features/FEAT-ML19.md
+++ b/tickets/entities/features/FEAT-ML19.md
@@ -24,4 +24,4 @@ OFL 1.1 explicitly permits redistribution.
 - `just ci` passes locally.
 - Verified at runtime via puppeteer: zero off-origin requests on page load, Open Sans woff2 served from rela's `/assets/`.
 
-Shipped via PR #670.
+Shipped via PR #671.

--- a/tickets/relations/FEAT-ML19--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-ML19--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-ML19
+relation: requires
+to: data-entry-ui
+---


### PR DESCRIPTION
## Summary

- New default palette for the data entry UI — cream paper bg + harbor-navy sidebar + #4772fb accent (light), deep harbor-navy + lifted blue (dark). Calmer and more legible than the old purple/slate defaults.
- Self-hosts Open Sans (SIL OFL 1.1) via `@fontsource/open-sans` so the bundle has zero runtime dependency on Google Fonts.
- Flips `ResolvePalette` so projects without a palette config now ship dark mode on by default (using new `defaultDarkColors`/`defaultDarkBadges`). Explicit `dark: false` opt-out still works.

Supersedes #670 (closed when its head branch was renamed).

## Test plan

- [x] `just ci` passes locally (lint + tests + coverage + build + docs)
- [x] Verified visually with puppeteer: dashboard, list, and form views in both light and dark
- [x] Confirmed at runtime that no requests go to fonts.googleapis.com / fonts.gstatic.com — Open Sans woff2 files are served from rela's own /assets/