### PR TITLE
feat(data-entry): .relatheme zip export/install (TKT-WPKW)

### DIFF
--- a/frontend/src/api/theme.test.ts
+++ b/frontend/src/api/theme.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { uploadLogo, removeLogo } from './theme'
+import { uploadLogo, removeLogo, exportTheme, importTheme } from './theme'
 
 describe('theme api', () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>
@@ -69,6 +69,80 @@ describe('theme api', () => {
         }),
       )
       await expect(removeLogo()).rejects.toThrow('kaboom')
+    })
+  })
+
+  describe('exportTheme', () => {
+    it('GETs the export endpoint and triggers a download', async () => {
+      const blob = new Blob([new Uint8Array([0x50, 0x4b])], { type: 'application/zip' })
+      fetchSpy.mockResolvedValue(
+        new Response(blob, {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/zip',
+            'Content-Disposition': 'attachment; filename="my-theme.relatheme"',
+          },
+        }),
+      )
+      const createSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock')
+      const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+      await exportTheme()
+
+      expect(fetchSpy).toHaveBeenCalledWith('/api/v1/_theme/export', { method: 'GET' })
+      expect(createSpy).toHaveBeenCalledOnce()
+      // Revoke is deferred via setTimeout so Safari doesn't drop the
+      // download — wait one macrotask before asserting.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(revokeSpy).toHaveBeenCalledWith('blob:mock')
+
+      createSpy.mockRestore()
+      revokeSpy.mockRestore()
+    })
+
+    it('throws with the server error message on failure', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ error: 'no palette' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      await expect(exportTheme()).rejects.toThrow('no palette')
+    })
+  })
+
+  describe('importTheme', () => {
+    it('POSTs multipart with the file in the "file" field', async () => {
+      const fakePalette = { accent: '#abcdef' }
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ palette: fakePalette, logoUrl: '/api/v1/_theme/logo?v=ab' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+
+      const file = new File([new Uint8Array([0x50, 0x4b])], 'theme.relatheme', { type: 'application/zip' })
+      const result = await importTheme(file)
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+      expect(url).toBe('/api/v1/_theme/import')
+      expect(init.method).toBe('POST')
+      expect(init.body).toBeInstanceOf(FormData)
+      expect((init.body as FormData).get('file')).toBe(file)
+      expect(result.palette).toEqual(fakePalette)
+      expect(result.logoUrl).toBe('/api/v1/_theme/logo?v=ab')
+    })
+
+    it('throws with the server error message on rejection', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ error: 'invalid theme manifest: ...' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      const file = new File([new Uint8Array([0])], 'broken.relatheme', { type: 'application/zip' })
+      await expect(importTheme(file)).rejects.toThrow('invalid theme manifest')
     })
   })
 })

--- a/frontend/src/api/theme.ts
+++ b/frontend/src/api/theme.ts
@@ -1,6 +1,10 @@
-// Theme asset API: user-uploaded sidebar logo. The backend persists
-// bytes under `.rela/theme/logo` and serves them with a content-hash
-// query param so any update produces a fresh URL the browser will fetch.
+// Theme asset API: user-uploaded sidebar logo + portable theme
+// packages. The backend persists logo bytes under `.rela/theme/logo`
+// and serves them with a content-hash query param so any update
+// produces a fresh URL the browser will fetch. Theme packages are
+// .relatheme zips containing a manifest plus the optional logo.
+
+import type { PaletteConfig } from './settings'
 
 export interface UploadLogoResponse {
   ok: boolean
@@ -38,4 +42,60 @@ export async function removeLogo(): Promise<void> {
     const data = await response.json().catch(() => ({ error: 'Remove failed' }))
     throw new Error(data.error || `Remove failed (${response.status})`)
   }
+}
+
+export interface ImportThemeResponse {
+  /** Parsed palette from the manifest. The frontend stages this into
+   *  the palette editor; the user clicks Save palette to persist. */
+  palette: PaletteConfig
+  /** Cache-busted URL for the freshly-imported logo, when one was
+   *  bundled. Absent when the package didn't include a logo. */
+  logoUrl?: string
+}
+
+/** Download the current palette + logo as a `.relatheme` zip via an
+ *  invisible anchor click. The browser handles the actual save. */
+export async function exportTheme(): Promise<void> {
+  const response = await fetch('/api/v1/_theme/export', { method: 'GET' })
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({ error: 'Export failed' }))
+    throw new Error(data.error || `Export failed (${response.status})`)
+  }
+  // Pull the filename out of Content-Disposition when present so we
+  // honor the server's safe-name derivation; fall back to a generic
+  // default otherwise.
+  const cd = response.headers.get('Content-Disposition') ?? ''
+  const match = /filename="([^"]+)"/.exec(cd)
+  const filename = match?.[1] ?? 'theme.relatheme'
+
+  const blob = await response.blob()
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  // Defer revoke: Safari (and historically older Chrome) drops the
+  // download silently if the URL is revoked synchronously after click.
+  // The microtask queue is empty by the time the browser starts the
+  // actual save, so a 0ms timeout is enough headroom.
+  setTimeout(() => URL.revokeObjectURL(url), 0)
+}
+
+/** Install a `.relatheme` zip. The backend persists the bundled logo
+ *  immediately (matching the direct logo PUT path) and returns the
+ *  manifest's palette JSON for the frontend to stage in the editor. */
+export async function importTheme(file: File): Promise<ImportThemeResponse> {
+  const form = new FormData()
+  form.append('file', file)
+  const response = await fetch('/api/v1/_theme/import', {
+    method: 'POST',
+    body: form,
+  })
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({ error: 'Install failed' }))
+    throw new Error(data.error || `Install failed (${response.status})`)
+  }
+  return response.json()
 }

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -252,6 +252,33 @@ function applyImportedPalette(palette: PaletteConfig) {
   paletteBadges.value = state.badges
   paletteDarkColors.value = state.dark
   paletteDarkBadges.value = state.darkBadges
+
+  // Apply the imported palette as live CSS variables so the sidebar
+  // (and the rest of the app chrome) updates immediately, matching
+  // what the preview pane shows. The user still needs to click Save
+  // Palette to persist the colors — this is purely visual feedback,
+  // not persistence.
+  applyPaletteToDocument()
+}
+
+/** Apply the current editor state to live CSS vars. Mirrors the
+ *  previewVars logic but writes to :root via uiStore.applyPalette so
+ *  the whole app updates, not just the preview pane. */
+function applyPaletteToDocument() {
+  // Light mode (or Regular mode) — apply the light derivation.
+  const light = deriveTheme(paletteColors.value, paletteBadges.value)
+
+  if (paletteMode.value === 'regular') {
+    uiStore.applyPalette(light)
+    return
+  }
+
+  // Light+Dark mode: pick whichever the user is currently viewing
+  // (uiStore.darkMode), with empty dark slots inheriting from light.
+  const mergedColors = { ...paletteColors.value, ...stripEmpty(paletteDarkColors.value) }
+  const mergedBadges = { ...paletteBadges.value, ...stripEmpty(paletteDarkBadges.value) }
+  const dark = deriveTheme(mergedColors, mergedBadges)
+  uiStore.applyPalette(uiStore.isDark ? dark : light)
 }
 
 const paletteRoles = [

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useSchemaStore, useUIStore } from '@/stores'
-import { getSettings, saveSettings, savePalette, uploadLogo, removeLogo } from '@/api'
+import { useConfirm } from '@/composables/useConfirm'
+import { getSettings, saveSettings, savePalette, uploadLogo, removeLogo, exportTheme, importTheme } from '@/api'
 import type {
   SettingsData,
   SettingsPropertyDef,
   SettingsRelationDef,
   UserDefaults,
   DefaultOverride,
+  PaletteConfig,
 } from '@/api/settings'
 import TagSelect from '@/components/ui/TagSelect.vue'
 import {
@@ -27,6 +29,7 @@ const HEX_INPUT_RE = /^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/
 
 const schemaStore = useSchemaStore()
 const uiStore = useUIStore()
+const { confirm } = useConfirm()
 
 // State
 const loading = ref(true)
@@ -133,6 +136,123 @@ async function handleLogoRemove() {
 }
 
 onBeforeUnmount(revokeStagedPreview)
+
+// Theme package state. Export downloads the current palette + logo as
+// a .relatheme zip; install reads one and stages the palette into the
+// existing palette editor (logo is persisted immediately, matching
+// the direct logo upload path).
+const themeFileInput = ref<HTMLInputElement | null>(null)
+const exportingTheme = ref(false)
+const importingTheme = ref(false)
+
+async function handleThemeExport() {
+  if (exportingTheme.value) return
+  exportingTheme.value = true
+  try {
+    await exportTheme()
+    uiStore.success('Theme exported')
+  } catch (err) {
+    uiStore.error(err instanceof Error ? err.message : 'Failed to export theme')
+  } finally {
+    exportingTheme.value = false
+  }
+}
+
+async function handleThemePicked(ev: Event) {
+  const target = ev.target as HTMLInputElement
+  const file = target.files?.[0] ?? null
+  if (!file) return
+  // Always reset the input value so picking the same file twice in a
+  // row still fires @change.
+  const reset = () => { target.value = '' }
+
+  // If the user has unsaved palette edits, confirm before stomping
+  // them. The saved palette in palette.yaml is untouched either way;
+  // this is purely about the in-editor draft.
+  if (isPaletteEditorDirty()) {
+    const ok = await confirm({
+      title: 'Replace your unsaved palette draft?',
+      message:
+        'Installing a theme will replace the colors in the palette editor. ' +
+        'Your previously saved palette on disk is not affected, but any ' +
+        'unsaved edits in the editor will be lost.',
+      confirmLabel: 'Replace draft',
+      danger: true,
+    })
+    if (!ok) {
+      reset()
+      return
+    }
+  }
+
+  importingTheme.value = true
+  try {
+    const result = await importTheme(file)
+    if (result.logoUrl !== undefined) {
+      schemaStore.setLogoUrl(result.logoUrl ?? null)
+    }
+    // Stage the imported palette into the existing editor refs. The
+    // user clicks the existing Save palette button to persist colors.
+    applyImportedPalette(result.palette)
+    uiStore.success('Theme installed. Click Save palette to apply colors.')
+  } catch (err) {
+    uiStore.error(err instanceof Error ? err.message : 'Failed to install theme')
+  } finally {
+    importingTheme.value = false
+    reset()
+  }
+}
+
+/** Detect whether the palette editor holds unsaved edits relative to
+ *  the saved palette. The saved baseline lives in schemaStore (light /
+ *  dark / disabled-flag); editor refs (paletteColors / paletteBadges /
+ *  paletteDarkColors / paletteDarkBadges) are the working copy. */
+function isPaletteEditorDirty(): boolean {
+  const editorLight = stripEmptyMap(paletteColors.value)
+  const savedLight = stripEmptyMap(schemaStore.paletteLight)
+  if (!shallowEqualMap(editorLight, savedLight)) return true
+
+  const editorBadges = stripEmptyMap(paletteBadges.value)
+  // Saved badges live alongside the role colors; the schemaStore's
+  // paletteLight contains derived CSS vars rather than the source
+  // badges map, so we only diff the badges editor against itself
+  // having values — any user-set badge is a draft until Save persists
+  // it. Conservative: treat any non-empty badge as potential dirt.
+  if (Object.keys(editorBadges).length > 0) return true
+
+  const editorDark = stripEmptyMap(paletteDarkColors.value)
+  const savedDark = stripEmptyMap(schemaStore.paletteDark)
+  if (!shallowEqualMap(editorDark, savedDark)) return true
+
+  if (Object.keys(stripEmptyMap(paletteDarkBadges.value)).length > 0) return true
+  return false
+}
+
+function stripEmptyMap(m: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(m)) if (v) out[k] = v
+  return out
+}
+
+function shallowEqualMap(a: Record<string, string>, b: Record<string, string>): boolean {
+  const aKeys = Object.keys(a)
+  if (aKeys.length !== Object.keys(b).length) return false
+  for (const k of aKeys) if (a[k] !== b[k]) return false
+  return true
+}
+
+function applyImportedPalette(palette: PaletteConfig) {
+  const state = loadPaletteState(
+    palette,
+    paletteRoles.map((r) => r.key),
+    schemaStore.darkDisabled,
+  )
+  paletteMode.value = state.mode
+  paletteColors.value = state.light
+  paletteBadges.value = state.badges
+  paletteDarkColors.value = state.dark
+  paletteDarkBadges.value = state.darkBadges
+}
 
 const paletteRoles = [
   { key: 'base', label: 'Base', description: 'Sidebar & navigation background' },
@@ -1198,6 +1318,40 @@ onMounted(() => {
         </div>
       </div>
 
+      <!-- Theme package -->
+      <div class="settings-card">
+        <h3>Theme package</h3>
+        <p class="description">
+          Bundle the current palette and logo into a portable
+          <code>.relatheme</code> file, or install one shared by someone
+          else. Installing applies the logo immediately and stages the
+          palette in the editor above — click <strong>Save Palette</strong>
+          to persist colors.
+        </p>
+
+        <div class="theme-package-actions">
+          <input
+            ref="themeFileInput"
+            type="file"
+            accept=".relatheme,application/zip"
+            class="file-input-hidden"
+            @change="handleThemePicked"
+          />
+          <button
+            type="button"
+            class="btn btn-secondary btn-sm"
+            :disabled="exportingTheme"
+            @click="handleThemeExport"
+          >{{ exportingTheme ? 'Exporting...' : 'Export' }}</button>
+          <button
+            type="button"
+            class="btn btn-primary btn-sm"
+            :disabled="importingTheme"
+            @click="themeFileInput?.click()"
+          >{{ importingTheme ? 'Installing...' : 'Install' }}</button>
+        </div>
+      </div>
+
       <!-- App Info -->
       <div class="settings-card">
         <h3>Application Info</h3>
@@ -1710,6 +1864,14 @@ h1 {
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+}
+
+.theme-package-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 12px;
 }
 
 /* --- Palette grid (CSS grid; replaces the older flex .color-row) --- */

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -205,6 +205,8 @@ func (a *App) registerAPIV1Routes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/_settings", a.handleAPISettingsCRUD)
 	mux.HandleFunc("/api/v1/_palette", a.handleAPIPaletteCRUD)
 	mux.HandleFunc("/api/v1/_theme/logo", a.handleAPIThemeLogo)
+	mux.HandleFunc("/api/v1/_theme/export", a.handleAPIThemeExport)
+	mux.HandleFunc("/api/v1/_theme/import", a.handleAPIThemeImport)
 	mux.HandleFunc("/api/v1/_sidepanel/", a.handleV1SidePanel)
 	mux.HandleFunc("/api/v1/_sidebar", a.handleV1Sidebar)
 	mux.HandleFunc("/api/v1/_conflicts", a.handleV1Conflicts)

--- a/internal/dataentry/handlers_theme_package.go
+++ b/internal/dataentry/handlers_theme_package.go
@@ -1,0 +1,237 @@
+package dataentry
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+)
+
+// maxThemeUploadBytes is the hard cap on the multipart request body for
+// theme imports. Generous envelope above ThemePackageMaxBytes mirrors
+// maxLogoUploadBytes — keeps both upload paths in lockstep.
+const maxThemeUploadBytes = ThemePackageMaxBytes + 16*1024
+
+// APIThemeImportResponse is the typed shape of POST /_theme/import.
+// Field names mirror the analogous fields in APISettingsData so the
+// frontend stays aligned with the rest of the JSON surface.
+type APIThemeImportResponse struct {
+	Palette dataentryconfig.PaletteConfig `json:"palette"`
+	LogoURL string                        `json:"logoUrl,omitempty"`
+}
+
+// handleAPIThemeExport returns the user's current palette + logo
+// bundled as a `.relatheme` zip download. Always emits a manifest;
+// includes the logo file when one is set.
+func (a *App) handleAPIThemeExport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	s := a.State()
+	manifest := buildExportManifest(s)
+	zipBytes, err := buildThemeZip(manifest, s.UserLogoBytes, s.UserLogoExt)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to build theme package: "+err.Error())
+		return
+	}
+	filename := safeThemeFilename(manifest.Name) + ".relatheme"
+	h := w.Header()
+	h.Set("Content-Type", "application/zip")
+	h.Set("Content-Disposition", `attachment; filename="`+filename+`"`)
+	// Exports reflect current state — never cache.
+	h.Set("Cache-Control", "no-store")
+	_, _ = w.Write(zipBytes)
+}
+
+// handleAPIThemeImport accepts a `.relatheme` upload, persists the
+// logo if one was bundled, and returns the parsed palette JSON for the
+// frontend to stage in the existing palette editor. The palette is NOT
+// auto-saved; matches the existing palette UX where colors persist
+// only on explicit Save.
+func (a *App) handleAPIThemeImport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxThemeUploadBytes)
+	if err := r.ParseMultipartForm(ThemePackageMaxBytes + 16*1024); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeThemeTooLarge(w)
+			return
+		}
+		writeJSONError(w, http.StatusBadRequest, "invalid multipart body: "+err.Error())
+		return
+	}
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, `missing form field "file"`)
+		return
+	}
+	defer func() { _ = file.Close() }()
+
+	raw, err := io.ReadAll(file)
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeThemeTooLarge(w)
+			return
+		}
+		writeJSONError(w, http.StatusBadRequest, "failed to read upload: "+err.Error())
+		return
+	}
+
+	pkg, err := parseThemePackage(raw)
+	if err != nil {
+		writeThemeImportError(w, err)
+		return
+	}
+
+	logoURL := ""
+	if pkg.Logo != nil {
+		hash := hashLogoBytes(pkg.Logo.Bytes)
+		var saveErr error
+		a.mutateState(func(s *AppState) {
+			if err := a.saveUserLogo(pkg.Logo.Bytes, pkg.Logo.Ext); err != nil {
+				saveErr = err
+				return
+			}
+			s.UserLogoBytes = pkg.Logo.Bytes
+			s.UserLogoExt = pkg.Logo.Ext
+			s.UserLogoHash = hash
+		})
+		if saveErr != nil {
+			writeJSONError(w, http.StatusInternalServerError, "failed to save logo: "+saveErr.Error())
+			return
+		}
+		logoURL = logoURLForHash(hash)
+	}
+
+	writeJSON(w, APIThemeImportResponse{
+		Palette: pkg.Manifest.PaletteConfig,
+		LogoURL: logoURL,
+	})
+}
+
+// buildExportManifest composes the manifest written into the zip,
+// drawing the palette from user state when available and falling back
+// to the project palette otherwise.
+func buildExportManifest(s *AppState) *dataentryconfig.ThemeManifest {
+	m := &dataentryconfig.ThemeManifest{
+		Name:    s.Cfg.App.Name,
+		Version: "1.0.0",
+	}
+	if m.Name == "" {
+		m.Name = "Theme"
+	}
+
+	switch {
+	case s.UserPalette != nil:
+		m.PaletteConfig = *s.UserPalette
+	case s.Cfg.Palette != nil:
+		m.PaletteConfig = *s.Cfg.Palette
+	}
+
+	if s.UserLogoExt != "" {
+		m.Logo = "logo." + s.UserLogoExt
+	}
+	return m
+}
+
+// buildThemeZip writes a `.relatheme` archive into a buffer. The
+// manifest is required; logo bytes are written under `logo.<ext>` only
+// when both are present.
+func buildThemeZip(manifest *dataentryconfig.ThemeManifest, logoBytes []byte, logoExt string) ([]byte, error) {
+	manifestYAML, err := yaml.Marshal(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("marshal manifest: %w", err)
+	}
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	mf, err := zw.Create(themeManifestEntry)
+	if err != nil {
+		return nil, fmt.Errorf("create manifest entry: %w", err)
+	}
+	if _, err := mf.Write(manifestYAML); err != nil {
+		return nil, fmt.Errorf("write manifest entry: %w", err)
+	}
+	if logoExt != "" && len(logoBytes) > 0 {
+		lf, err := zw.Create(themeLogoPrefix + logoExt)
+		if err != nil {
+			return nil, fmt.Errorf("create logo entry: %w", err)
+		}
+		if _, err := lf.Write(logoBytes); err != nil {
+			return nil, fmt.Errorf("write logo entry: %w", err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("close zip: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+var unsafeFilenameRe = regexp.MustCompile(`[^A-Za-z0-9_-]+`)
+
+// safeThemeFilename derives a safe download filename from the
+// manifest's Name. Browsers will let users override it via "Save as..."
+// so this is purely cosmetic.
+func safeThemeFilename(name string) string {
+	cleaned := unsafeFilenameRe.ReplaceAllString(name, "_")
+	cleaned = strings.Trim(cleaned, "_")
+	if cleaned == "" {
+		return "theme"
+	}
+	if len(cleaned) > 64 {
+		cleaned = cleaned[:64]
+	}
+	return cleaned
+}
+
+// writeThemeImportError translates parseThemePackage sentinel errors
+// into the right HTTP status + JSON shape. Unrecognized parse errors
+// fall through to 400 with a slog.Warn so a misroute is visible in
+// logs (we want to notice if a new sentinel is added without being
+// wired in here).
+func writeThemeImportError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errLogoTooLarge),
+		errors.Is(err, errZipUncompressed),
+		errors.Is(err, errZipBomb):
+		writeJSONError(w, http.StatusRequestEntityTooLarge, err.Error())
+	case errors.Is(err, errNotAZip),
+		errors.Is(err, errMissingManifest),
+		errors.Is(err, errInvalidManifest),
+		errors.Is(err, errMissingLogo),
+		errors.Is(err, errZipPathTraversal),
+		errors.Is(err, errDuplicateEntry):
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+	default:
+		// New sentinel added without being wired in here — still a
+		// 400 (least-privilege default), but log so it gets noticed.
+		slog.Warn("theme import: unmapped parse error", "err", err)
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+	}
+}
+
+// writeThemeTooLarge mirrors writeLogoTooLarge but for theme packages.
+// Includes the cap so the SPA can surface an accurate message.
+func writeThemeTooLarge(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusRequestEntityTooLarge)
+	_, _ = fmt.Fprintf(w,
+		`{"error":"theme package too large: max %d bytes","maxBytes":%d}`,
+		ThemePackageMaxBytes, ThemePackageMaxBytes,
+	)
+}

--- a/internal/dataentry/handlers_theme_package_test.go
+++ b/internal/dataentry/handlers_theme_package_test.go
@@ -1,0 +1,268 @@
+package dataentry
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+)
+
+// uploadThemePackage is a test helper that POSTs a multipart body with
+// the given raw zip bytes to the import handler.
+func uploadThemePackage(t *testing.T, app *App, fieldName string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile(fieldName, "theme.relatheme")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := fw.Write(body); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close mw: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/_theme/import", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+	app.handleAPIThemeImport(w, req)
+	return w
+}
+
+// readZipBody parses an export response and returns the entries map.
+func readZipBody(t *testing.T, body []byte) map[string][]byte {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		t.Fatalf("zip.NewReader: %v", err)
+	}
+	out := make(map[string][]byte)
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open %q: %v", f.Name, err)
+		}
+		data, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			t.Fatalf("read %q: %v", f.Name, err)
+		}
+		out[f.Name] = data
+	}
+	return out
+}
+
+func TestThemeExport_PaletteOnly(t *testing.T) {
+	app := newHandlerTestApp(t)
+	// Set a palette via the existing API to mirror real flow.
+	body := `{"accent":"#abcdef"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/_palette", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	app.handleAPISavePalette(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("save palette: %d %s", w.Code, w.Body.String())
+	}
+
+	exReq := httptest.NewRequest(http.MethodGet, "/api/v1/_theme/export", http.NoBody)
+	exW := httptest.NewRecorder()
+	app.handleAPIThemeExport(exW, exReq)
+	if exW.Code != http.StatusOK {
+		t.Fatalf("export: %d %s", exW.Code, exW.Body.String())
+	}
+	if ct := exW.Header().Get("Content-Type"); ct != "application/zip" {
+		t.Errorf("Content-Type: %q", ct)
+	}
+	if cd := exW.Header().Get("Content-Disposition"); !strings.Contains(cd, ".relatheme") {
+		t.Errorf("Content-Disposition: %q", cd)
+	}
+
+	entries := readZipBody(t, exW.Body.Bytes())
+	if _, ok := entries["theme.yaml"]; !ok {
+		t.Fatal("missing theme.yaml")
+	}
+	for name := range entries {
+		if strings.HasPrefix(name, "logo.") {
+			t.Errorf("expected no logo entry, got %q", name)
+		}
+	}
+
+	var manifest dataentryconfig.ThemeManifest
+	if err := yaml.Unmarshal(entries["theme.yaml"], &manifest); err != nil {
+		t.Fatalf("manifest unmarshal: %v", err)
+	}
+	if manifest.Accent != "#abcdef" {
+		t.Errorf("accent: %q", manifest.Accent)
+	}
+	if manifest.Logo != "" {
+		t.Errorf("expected no logo ref, got %q", manifest.Logo)
+	}
+}
+
+func TestThemeExport_WithLogo(t *testing.T) {
+	app := newHandlerTestApp(t)
+	pngBytes := makeTinyPNG(t)
+	if w := uploadLogo(t, app, "logo", pngBytes); w.Code != http.StatusOK {
+		t.Fatalf("upload logo: %d %s", w.Code, w.Body.String())
+	}
+
+	exReq := httptest.NewRequest(http.MethodGet, "/api/v1/_theme/export", http.NoBody)
+	exW := httptest.NewRecorder()
+	app.handleAPIThemeExport(exW, exReq)
+	if exW.Code != http.StatusOK {
+		t.Fatalf("export: %d", exW.Code)
+	}
+
+	entries := readZipBody(t, exW.Body.Bytes())
+	logoEntry, ok := entries["logo.png"]
+	if !ok {
+		t.Fatal("missing logo.png in zip")
+	}
+	if !bytes.Equal(logoEntry, pngBytes) {
+		t.Error("logo bytes do not round-trip")
+	}
+
+	var manifest dataentryconfig.ThemeManifest
+	if err := yaml.Unmarshal(entries["theme.yaml"], &manifest); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if manifest.Logo != "logo.png" {
+		t.Errorf("manifest.logo: %q", manifest.Logo)
+	}
+}
+
+func TestThemeImport_RoundTrip(t *testing.T) {
+	source := newHandlerTestApp(t)
+	pngBytes := makeTinyPNG(t)
+	if w := uploadLogo(t, source, "logo", pngBytes); w.Code != http.StatusOK {
+		t.Fatalf("source upload logo: %d %s", w.Code, w.Body.String())
+	}
+	body := `{"accent":"#aabbcc","badges":{"blue":"#1e40af"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/_palette", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	source.handleAPISavePalette(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("source palette: %d %s", w.Code, w.Body.String())
+	}
+
+	exReq := httptest.NewRequest(http.MethodGet, "/api/v1/_theme/export", http.NoBody)
+	exW := httptest.NewRecorder()
+	source.handleAPIThemeExport(exW, exReq)
+	if exW.Code != http.StatusOK {
+		t.Fatalf("export: %d", exW.Code)
+	}
+
+	dest := newHandlerTestApp(t)
+	if dest.State().UserLogoExt != "" {
+		t.Fatal("dest should not start with a logo")
+	}
+
+	imW := uploadThemePackage(t, dest, "file", exW.Body.Bytes())
+	if imW.Code != http.StatusOK {
+		t.Fatalf("import: %d %s", imW.Code, imW.Body.String())
+	}
+
+	var resp struct {
+		Palette dataentryconfig.PaletteConfig `json:"palette"`
+		LogoURL string                        `json:"logoUrl"`
+	}
+	if err := json.NewDecoder(imW.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode resp: %v", err)
+	}
+	if resp.Palette.Accent != "#aabbcc" {
+		t.Errorf("palette.accent: %q", resp.Palette.Accent)
+	}
+	if resp.Palette.Badges["blue"] != "#1e40af" {
+		t.Errorf("badges.blue: %q", resp.Palette.Badges["blue"])
+	}
+	if !strings.HasPrefix(resp.LogoURL, "/api/v1/_theme/logo?v=") {
+		t.Errorf("logoUrl: %q", resp.LogoURL)
+	}
+
+	if !bytes.Equal(dest.State().UserLogoBytes, pngBytes) {
+		t.Error("dest UserLogoBytes does not match round-tripped bytes")
+	}
+	if dest.State().UserPalette != nil {
+		t.Error("dest UserPalette should not be auto-saved on import")
+	}
+}
+
+func TestThemeImport_Errors(t *testing.T) {
+	tests := []struct {
+		name       string
+		fieldName  string
+		body       []byte
+		wantStatus int
+		wantSubstr string
+	}{
+		{"not a zip", "file", []byte("hello"), http.StatusBadRequest, "not a valid zip"},
+		{"missing field", "wrong", []byte("hello"), http.StatusBadRequest, "missing form field"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newHandlerTestApp(t)
+			w := uploadThemePackage(t, app, tt.fieldName, tt.body)
+			if w.Code != tt.wantStatus {
+				t.Errorf("status: got %d, want %d (body=%s)", w.Code, tt.wantStatus, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), tt.wantSubstr) {
+				t.Errorf("body: %q does not contain %q", w.Body.String(), tt.wantSubstr)
+			}
+			if app.State().UserLogoExt != "" {
+				t.Error("rejected import must not have mutated state")
+			}
+		})
+	}
+}
+
+func TestThemeExport_MethodNotAllowed(t *testing.T) {
+	app := newHandlerTestApp(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/_theme/export", http.NoBody)
+	w := httptest.NewRecorder()
+	app.handleAPIThemeExport(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestThemeImport_MethodNotAllowed(t *testing.T) {
+	app := newHandlerTestApp(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_theme/import", http.NoBody)
+	w := httptest.NewRecorder()
+	app.handleAPIThemeImport(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestSafeThemeFilename(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"My Theme", "My_Theme"},
+		{"my-cool-theme", "my-cool-theme"},
+		{"weird/path:name", "weird_path_name"},
+		{"", "theme"},
+		{strings.Repeat("a", 100), strings.Repeat("a", 64)},
+		{"___only_underscores___", "only_underscores"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := safeThemeFilename(tt.in)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/dataentry/theme_package.go
+++ b/internal/dataentry/theme_package.go
@@ -1,0 +1,218 @@
+package dataentry
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+)
+
+// ThemePackageMaxBytes caps the on-the-wire size of a `.relatheme`
+// upload. The manifest is at most a couple of KB; a logo is ≤256 KiB.
+// 5 MiB leaves generous headroom while bounding the worst-case memory
+// pressure a single import can impose.
+const ThemePackageMaxBytes = 5 << 20
+
+// themePackageMaxExpansion bounds the ratio of declared uncompressed
+// size to actual zip size. Defends against zip-bomb entries that look
+// small on the wire but expand into many MB. 100× is far above any
+// honest text-or-image ratio (PNG/JPEG/WebP barely compress; YAML
+// compresses ~3-5×).
+const themePackageMaxExpansion = 100
+
+// themeManifestEntry is the canonical name of the manifest file in the
+// archive. Required.
+const themeManifestEntry = "theme.yaml"
+
+// themeLogoPrefix is the canonical prefix of the optional logo entry.
+// The full entry name is `logo.<ext>` where <ext> matches the manifest's
+// `logo:` field.
+const themeLogoPrefix = "logo."
+
+// ImportedThemeAsset carries the bytes + sniffed extension of a logo
+// extracted from a theme package. ImportedThemeAsset is nil when the
+// package contained no logo (or didn't reference one).
+type ImportedThemeAsset struct {
+	Bytes []byte
+	Ext   string
+}
+
+// ParsedThemePackage is the typed result of parsing a `.relatheme`
+// upload. Manifest is always populated on success; Logo is non-nil only
+// when the manifest referenced a logo and the bytes passed validation.
+type ParsedThemePackage struct {
+	Manifest *dataentryconfig.ThemeManifest
+	Logo     *ImportedThemeAsset
+}
+
+// Sentinel errors for parseThemePackage. Callers translate these into
+// HTTP status codes; the messages are user-facing.
+var (
+	errNotAZip          = errors.New("not a valid zip file")
+	errMissingManifest  = errors.New("missing theme.yaml in archive")
+	errInvalidManifest  = errors.New("invalid theme manifest")
+	errMissingLogo      = errors.New("logo referenced in manifest but not present in archive")
+	errLogoTooLarge     = errors.New("logo exceeds size limit")
+	errZipPathTraversal = errors.New("zip entry contains path traversal")
+	errZipBomb          = errors.New("zip declared expansion ratio exceeds limit")
+	errZipUncompressed  = errors.New("zip uncompressed total exceeds limit")
+	errDuplicateEntry   = errors.New("zip contains duplicate entry")
+)
+
+// parseThemePackage interprets the bytes of a `.relatheme` upload. It
+// performs all validation in-memory (no filesystem access) so it's
+// trivially unit-testable as a pure function.
+//
+// Validation order is deliberately layered: cheap structural checks
+// (size, zip parse, entry names) before any decompression of bodies,
+// so a hostile upload is rejected without paying the full cost.
+//
+// yaml.v3 panics rather than returning an error if struct tags
+// duplicate a top-level key. ThemeManifest's reflection sanity-check
+// in package init catches that at startup, but the recover here means
+// a future regression surfaces as a 400 rather than a process crash.
+func parseThemePackage(raw []byte) (pkg *ParsedThemePackage, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			pkg = nil
+			err = fmt.Errorf("%w: panic during parse: %v", errInvalidManifest, r)
+		}
+	}()
+	return parseThemePackageImpl(raw)
+}
+
+func parseThemePackageImpl(raw []byte) (*ParsedThemePackage, error) {
+	if len(raw) > ThemePackageMaxBytes {
+		return nil, errZipUncompressed
+	}
+
+	zr, zerr := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if zerr != nil {
+		return nil, fmt.Errorf("%w: %w", errNotAZip, zerr)
+	}
+
+	// Defense-in-depth: catch zip-bombs before we ever read entries.
+	if err := checkZipExpansion(zr, int64(len(raw))); err != nil {
+		return nil, err
+	}
+
+	// Index entries by name for direct lookup. We only honor
+	// flat-filename entries that match our allowlist; everything else
+	// (READMEs, .DS_Store, future additions) is silently ignored.
+	entries := make(map[string]*zip.File)
+	for _, f := range zr.File {
+		name := f.Name
+		// Reject anything with path-like syntax. Zip stores POSIX-ish
+		// names; backslashes are still suspicious on any platform.
+		if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
+			return nil, fmt.Errorf("%w: %q", errZipPathTraversal, name)
+		}
+		// Skip directory entries (technically still flat after the
+		// slash check, but be explicit).
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		// Reject duplicate names. A polyglot zip with two `theme.yaml`
+		// or two `logo.<ext>` entries would otherwise let an attacker
+		// ship one set of bytes for inspection-via-iteration and a
+		// different set for our map-lookup-driven import.
+		if _, dup := entries[name]; dup {
+			return nil, fmt.Errorf("%w: %q", errDuplicateEntry, name)
+		}
+		entries[name] = f
+	}
+
+	manifestFile, ok := entries[themeManifestEntry]
+	if !ok {
+		return nil, errMissingManifest
+	}
+
+	manifestBytes, mErr := readZipEntry(manifestFile, ThemePackageMaxBytes)
+	if mErr != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidManifest, mErr)
+	}
+
+	var manifest dataentryconfig.ThemeManifest
+	if err := yaml.Unmarshal(manifestBytes, &manifest); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidManifest, err)
+	}
+	if err := dataentryconfig.ValidateThemeManifest(&manifest); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidManifest, err)
+	}
+
+	out := &ParsedThemePackage{Manifest: &manifest}
+
+	if manifest.Logo != "" {
+		logoFile, ok := entries[manifest.Logo]
+		if !ok {
+			return nil, errMissingLogo
+		}
+		logoBytes, err := readZipEntry(logoFile, MaxUserLogoBytes+1)
+		if err != nil {
+			return nil, fmt.Errorf("logo: %w", err)
+		}
+		if len(logoBytes) > MaxUserLogoBytes {
+			return nil, errLogoTooLarge
+		}
+		// Trust the actual bytes, not the manifest's claimed extension.
+		// sniffLogoMime is the same trust boundary the direct PUT path
+		// uses; reusing it keeps both paths in lockstep.
+		mime := sniffLogoMime(logoBytes)
+		ext := logoExtForMime(mime)
+		if ext == "" {
+			return nil, fmt.Errorf("logo: unsupported format %q (accepted: image/png, image/jpeg, image/svg+xml, image/webp)", mime)
+		}
+		out.Logo = &ImportedThemeAsset{Bytes: logoBytes, Ext: ext}
+	}
+
+	return out, nil
+}
+
+// checkZipExpansion guards against zip-bomb attacks. It sums the
+// declared uncompressed sizes (bounded against overflow) and rejects
+// archives whose sum exceeds either the absolute cap or a fixed ratio
+// of the input size. Decompression itself is bounded again by
+// readZipEntry's LimitReader; this is the cheap layer that runs first.
+func checkZipExpansion(zr *zip.Reader, compressedTotal int64) error {
+	const maxRatioInput = (1 << 63) / themePackageMaxExpansion // guard the multiply
+	var total uint64
+	for _, f := range zr.File {
+		// Saturating add: any entry that would push us over the cap
+		// (including a single attacker-controlled zip64 size near
+		// 2^64) is rejected before total wraps.
+		if f.UncompressedSize64 > ThemePackageMaxBytes ||
+			total > ThemePackageMaxBytes-f.UncompressedSize64 {
+
+			return errZipUncompressed
+		}
+		total += f.UncompressedSize64
+	}
+	// compressedTotal comes from len([]byte) of the upload, so it's
+	// bounded by ThemePackageMaxBytes — well under the multiply cap.
+	if compressedTotal < 0 || compressedTotal > maxRatioInput {
+		return errZipBomb
+	}
+	if total > uint64(compressedTotal)*themePackageMaxExpansion {
+		return errZipBomb
+	}
+	return nil
+}
+
+// readZipEntry reads up to limit+1 bytes from a zip entry, returning an
+// error if the entry exceeds limit. The +1 lets the caller distinguish
+// "exactly at limit" (accept) from "over limit" (reject) with a single
+// length comparison.
+func readZipEntry(f *zip.File, limit int64) ([]byte, error) {
+	rc, err := f.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rc.Close() }()
+	return io.ReadAll(io.LimitReader(rc, limit+1))
+}

--- a/internal/dataentry/theme_package_test.go
+++ b/internal/dataentry/theme_package_test.go
@@ -1,0 +1,279 @@
+package dataentry
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// minimalManifestYAML returns a valid theme.yaml body with optional
+// overrides. Tests only set the fields they care about.
+func minimalManifestYAML(extra map[string]string) string {
+	defaults := map[string]string{
+		"name":    "Test Theme",
+		"version": "1.0.0",
+		"accent":  "#6366f1",
+	}
+	for k, v := range extra {
+		defaults[k] = v
+	}
+	var b strings.Builder
+	for k, v := range defaults {
+		b.WriteString(k)
+		b.WriteString(`: "`)
+		b.WriteString(v)
+		b.WriteString("\"\n")
+	}
+	return b.String()
+}
+
+// buildZip writes a zip archive from a name → bytes map. Iteration
+// order is unspecified; parseThemePackage indexes by name so order
+// does not matter.
+func buildZip(t *testing.T, entries map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	for name, body := range entries {
+		f, err := w.Create(name)
+		if err != nil {
+			t.Fatalf("zip.Create(%q): %v", name, err)
+		}
+		if _, err := f.Write(body); err != nil {
+			t.Fatalf("zip write(%q): %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestParseThemePackage_PaletteOnly(t *testing.T) {
+	z := buildZip(t, map[string][]byte{
+		"theme.yaml": []byte(minimalManifestYAML(nil)),
+	})
+	pkg, err := parseThemePackage(z)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if pkg.Manifest == nil {
+		t.Fatal("manifest is nil")
+	}
+	if pkg.Manifest.Name != "Test Theme" {
+		t.Errorf("name = %q", pkg.Manifest.Name)
+	}
+	if pkg.Logo != nil {
+		t.Errorf("expected no logo, got %+v", pkg.Logo)
+	}
+}
+
+func TestParseThemePackage_WithLogo(t *testing.T) {
+	pngBytes := makeTinyPNG(t)
+	z := buildZip(t, map[string][]byte{
+		"theme.yaml": []byte(minimalManifestYAML(map[string]string{"logo": "logo.png"})),
+		"logo.png":   pngBytes,
+	})
+	pkg, err := parseThemePackage(z)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if pkg.Logo == nil {
+		t.Fatal("expected logo, got nil")
+	}
+	if pkg.Logo.Ext != "png" {
+		t.Errorf("ext = %q", pkg.Logo.Ext)
+	}
+	if !bytes.Equal(pkg.Logo.Bytes, pngBytes) {
+		t.Error("logo bytes do not match")
+	}
+}
+
+func TestParseThemePackage_TrustsSniffOverManifestExtension(t *testing.T) {
+	// Manifest claims `.png` but the bytes are SVG; we trust the
+	// sniff and store as svg.
+	z := buildZip(t, map[string][]byte{
+		"theme.yaml": []byte(minimalManifestYAML(map[string]string{"logo": "logo.png"})),
+		"logo.png":   hostileSVGBytes(),
+	})
+	pkg, err := parseThemePackage(z)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if pkg.Logo == nil || pkg.Logo.Ext != "svg" {
+		t.Errorf("expected sniffed ext=svg, got %+v", pkg.Logo)
+	}
+}
+
+func TestParseThemePackage_IgnoresExtraEntries(t *testing.T) {
+	z := buildZip(t, map[string][]byte{
+		"theme.yaml": []byte(minimalManifestYAML(nil)),
+		"README.md":  []byte("# notes"),
+		".DS_Store":  {0xff, 0xfe},
+	})
+	if _, err := parseThemePackage(z); err != nil {
+		t.Errorf("expected extras to be ignored, got %v", err)
+	}
+}
+
+func TestParseThemePackage_Rejects(t *testing.T) {
+	pngBytes := makeTinyPNG(t)
+	tests := []struct {
+		name    string
+		zip     map[string][]byte
+		raw     []byte
+		wantErr error
+	}{
+		{
+			name:    "missing manifest",
+			zip:     map[string][]byte{"logo.png": pngBytes},
+			wantErr: errMissingManifest,
+		},
+		{
+			name: "manifest name empty",
+			zip: map[string][]byte{
+				"theme.yaml": []byte(minimalManifestYAML(map[string]string{"name": ""})),
+			},
+			wantErr: errInvalidManifest,
+		},
+		{
+			name: "manifest references missing logo",
+			zip: map[string][]byte{
+				"theme.yaml": []byte(minimalManifestYAML(map[string]string{"logo": "logo.png"})),
+			},
+			wantErr: errMissingLogo,
+		},
+		{
+			name: "logo bytes are not an image",
+			zip: map[string][]byte{
+				"theme.yaml": []byte(minimalManifestYAML(map[string]string{"logo": "logo.png"})),
+				"logo.png":   []byte("hello world"),
+			},
+			// Surfaces as "logo: unsupported format ..."; non-sentinel.
+		},
+		{
+			name: "path traversal in entry name",
+			zip: map[string][]byte{
+				"theme.yaml":   []byte(minimalManifestYAML(nil)),
+				"../etc/hosts": []byte("evil"),
+			},
+			wantErr: errZipPathTraversal,
+		},
+		{
+			name: "subdirectory in entry name",
+			zip: map[string][]byte{
+				"theme.yaml":  []byte(minimalManifestYAML(nil)),
+				"sub/foo.txt": []byte("nope"),
+			},
+			wantErr: errZipPathTraversal,
+		},
+		{
+			name:    "not a zip",
+			raw:     []byte("just some bytes"),
+			wantErr: errNotAZip,
+		},
+		{
+			name: "malformed manifest yaml",
+			zip: map[string][]byte{
+				"theme.yaml": []byte("not: valid: yaml: ::"),
+			},
+			wantErr: errInvalidManifest,
+		},
+		{
+			name: "bad palette color",
+			zip: map[string][]byte{
+				"theme.yaml": []byte(minimalManifestYAML(map[string]string{"accent": "not-a-color"})),
+			},
+			wantErr: errInvalidManifest,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := tt.raw
+			if raw == nil {
+				raw = buildZip(t, tt.zip)
+			}
+			_, err := parseThemePackage(raw)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Errorf("expected %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestParseThemePackage_LogoTooLarge(t *testing.T) {
+	// Use cryptographically random padding so DEFLATE can't compress
+	// it; otherwise the zip-bomb expansion-ratio guard fires before
+	// the logo-size guard. This test is about the per-asset cap.
+	tooBig := make([]byte, MaxUserLogoBytes+1)
+	pngHeader := makeTinyPNG(t)
+	copy(tooBig, pngHeader)
+	if _, err := rand.Read(tooBig[len(pngHeader):]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	z := buildZip(t, map[string][]byte{
+		"theme.yaml": []byte(minimalManifestYAML(map[string]string{"logo": "logo.png"})),
+		"logo.png":   tooBig,
+	})
+	_, err := parseThemePackage(z)
+	if !errors.Is(err, errLogoTooLarge) {
+		t.Errorf("expected errLogoTooLarge, got %v", err)
+	}
+}
+
+func TestParseThemePackage_ZipBomb(t *testing.T) {
+	// A highly compressible entry the zip-bomb guard should reject.
+	hugePayload := make([]byte, ThemePackageMaxBytes+1)
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	mf, _ := w.Create("theme.yaml")
+	_, _ = mf.Write([]byte(minimalManifestYAML(nil)))
+	hf, _ := w.Create("logo.png")
+	_, _ = hf.Write(hugePayload)
+	if err := w.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	_, err := parseThemePackage(buf.Bytes())
+	if !errors.Is(err, errZipUncompressed) && !errors.Is(err, errZipBomb) {
+		t.Errorf("expected errZipUncompressed or errZipBomb, got %v", err)
+	}
+}
+
+func TestParseThemePackage_RejectsDuplicateEntries(t *testing.T) {
+	// Hand-roll a zip with two entries named "theme.yaml" — buildZip's
+	// map can't represent duplicates by definition.
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	for range 2 {
+		f, err := w.Create("theme.yaml")
+		if err != nil {
+			t.Fatalf("zip.Create: %v", err)
+		}
+		if _, err := f.Write([]byte(minimalManifestYAML(nil))); err != nil {
+			t.Fatalf("zip write: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	_, err := parseThemePackage(buf.Bytes())
+	if !errors.Is(err, errDuplicateEntry) {
+		t.Errorf("expected errDuplicateEntry, got %v", err)
+	}
+}
+
+func TestParseThemePackage_TotalTooLarge(t *testing.T) {
+	// Raw input larger than ThemePackageMaxBytes is rejected before
+	// zip parsing.
+	raw := make([]byte, ThemePackageMaxBytes+1)
+	_, err := parseThemePackage(raw)
+	if !errors.Is(err, errZipUncompressed) {
+		t.Errorf("expected errZipUncompressed, got %v", err)
+	}
+}

--- a/internal/dataentryconfig/theme.go
+++ b/internal/dataentryconfig/theme.go
@@ -1,0 +1,144 @@
+package dataentryconfig
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// init asserts at startup that ThemeManifest's top-level keys don't
+// collide with any inlined PaletteConfig key. yaml.v3 *panics* on
+// duplicate-key shadow during Unmarshal — catching this at boot
+// turns a runtime-fatal regression into a startup error.
+func init() {
+	if err := checkManifestTagsUnique(); err != nil {
+		panic("dataentryconfig: theme manifest tag collision: " + err.Error())
+	}
+}
+
+func checkManifestTagsUnique() error {
+	mt := reflect.TypeFor[ThemeManifest]()
+	seen := make(map[string]string)
+	var visit func(t reflect.Type, path string) error
+	visit = func(t reflect.Type, path string) error {
+		for i := range t.NumField() {
+			f := t.Field(i)
+			tag := strings.Split(f.Tag.Get("yaml"), ",")
+			name := strings.TrimSpace(tag[0])
+			inline := false
+			for _, opt := range tag[1:] {
+				if strings.TrimSpace(opt) == "inline" {
+					inline = true
+				}
+			}
+			if inline {
+				if err := visit(f.Type, path+"."+f.Name); err != nil {
+					return err
+				}
+				continue
+			}
+			if name == "" || name == "-" {
+				continue
+			}
+			if prev, dup := seen[name]; dup {
+				return fmt.Errorf("yaml key %q appears in both %s and %s%s", name, prev, path, "."+f.Name)
+			}
+			seen[name] = path + "." + f.Name
+		}
+		return nil
+	}
+	return visit(mt, "ThemeManifest")
+}
+
+// ThemeManifest is the metadata + palette payload of a `.relatheme`
+// theme package. It embeds PaletteConfig so a manifest is a superset
+// of the existing `palette.yaml` shape — anything that's a valid
+// palette overlay is, with the addition of name + version, a valid
+// theme manifest.
+//
+// Logo, when set, references a flat-file zip entry of the form
+// `logo.<ext>` (e.g. `logo.png`). The manifest never embeds the bytes
+// itself; the importer reads them from the corresponding zip entry.
+type ThemeManifest struct {
+	Name    string `yaml:"name"               json:"name"`
+	Version string `yaml:"version"            json:"version"`
+	Author  string `yaml:"author,omitempty"   json:"author,omitempty"`
+	Logo    string `yaml:"logo,omitempty"     json:"logo,omitempty"`
+
+	// Palette colors are inlined at the top level so a manifest reads
+	// like a superset of palette.yaml.
+	PaletteConfig `yaml:",inline" json:",inline"`
+}
+
+// Manifest length limits. These are deliberately generous — a theme
+// description is metadata, not user content.
+const (
+	maxThemeNameLen    = 100
+	maxThemeVersionLen = 32
+	maxThemeAuthorLen  = 100
+)
+
+// ValidateThemeManifest checks the shape of a parsed manifest. It
+// re-uses ValidatePalette for the embedded palette fields so manifest
+// validation tracks palette validation by construction.
+func ValidateThemeManifest(m *ThemeManifest) error {
+	if m == nil {
+		return errors.New("manifest is nil")
+	}
+	if l := len(m.Name); l < 1 || l > maxThemeNameLen {
+		return fmt.Errorf("name must be 1-%d chars (got %d)", maxThemeNameLen, l)
+	}
+	if l := len(m.Version); l < 1 || l > maxThemeVersionLen {
+		return fmt.Errorf("version must be 1-%d chars (got %d)", maxThemeVersionLen, l)
+	}
+	if l := len(m.Author); l > maxThemeAuthorLen {
+		return fmt.Errorf("author must be 0-%d chars (got %d)", maxThemeAuthorLen, l)
+	}
+	if m.Logo != "" {
+		if err := validateLogoEntryName(m.Logo); err != nil {
+			return fmt.Errorf("logo: %w", err)
+		}
+	}
+	return ValidatePalette(&m.PaletteConfig)
+}
+
+// allowedLogoEntryExts is the set of extensions a manifest may
+// declare for its logo entry. Importers re-sniff the actual bytes via
+// http.DetectContentType, so the manifest's extension is technically
+// just a lookup key — but rejecting unknown extensions at validation
+// time keeps the manifest's stated shape honest with what we'll
+// actually persist.
+var allowedLogoEntryExts = map[string]struct{}{
+	"png":  {},
+	"jpeg": {},
+	"jpg":  {}, // alias for jpeg, accepted in manifests
+	"svg":  {},
+	"webp": {},
+}
+
+// validateLogoEntryName enforces the manifest's logo field shape. The
+// importer trusts the actual sniffed mime regardless, but the manifest
+// must still describe a flat filename within the format allowlist so a
+// zip parser can locate the bytes without directory walks and so
+// reading the manifest tells the truth about what kind of asset is
+// expected.
+func validateLogoEntryName(name string) error {
+	if strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf(`must be a flat filename, not a path (got %q)`, name)
+	}
+	if strings.Contains(name, "..") {
+		return fmt.Errorf(`must not contain ".." (got %q)`, name)
+	}
+	if !strings.HasPrefix(name, "logo.") {
+		return fmt.Errorf(`must start with "logo." (got %q)`, name)
+	}
+	ext := strings.ToLower(name[len("logo."):])
+	if ext == "" {
+		return fmt.Errorf(`must have an extension after "logo." (got %q)`, name)
+	}
+	if _, ok := allowedLogoEntryExts[ext]; !ok {
+		return fmt.Errorf(`unsupported extension %q (allowed: png, jpeg, jpg, svg, webp)`, ext)
+	}
+	return nil
+}

--- a/internal/dataentryconfig/theme_test.go
+++ b/internal/dataentryconfig/theme_test.go
@@ -1,0 +1,140 @@
+package dataentryconfig
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func validManifest() *ThemeManifest {
+	return &ThemeManifest{
+		Name:    "Acme Theme",
+		Version: "1.0.0",
+		Author:  "Acme Inc.",
+		Logo:    "logo.png",
+		PaletteConfig: PaletteConfig{
+			PaletteColors: PaletteColors{
+				Accent: "#6366f1",
+			},
+		},
+	}
+}
+
+func TestValidateThemeManifest_Accepts(t *testing.T) {
+	tests := []struct {
+		name string
+		mut  func(*ThemeManifest)
+	}{
+		{"all fields", func(*ThemeManifest) {}},
+		{"no author", func(m *ThemeManifest) { m.Author = "" }},
+		{"no logo", func(m *ThemeManifest) { m.Logo = "" }},
+		{"no palette", func(m *ThemeManifest) { m.PaletteConfig = PaletteConfig{} }},
+		{"name at lower bound", func(m *ThemeManifest) { m.Name = "x" }},
+		{"name at upper bound", func(m *ThemeManifest) { m.Name = strings.Repeat("a", maxThemeNameLen) }},
+		{"version at upper bound", func(m *ThemeManifest) { m.Version = strings.Repeat("v", maxThemeVersionLen) }},
+		{"author at upper bound", func(m *ThemeManifest) { m.Author = strings.Repeat("a", maxThemeAuthorLen) }},
+		{"logo svg", func(m *ThemeManifest) { m.Logo = "logo.svg" }},
+		{"logo jpg alias", func(m *ThemeManifest) { m.Logo = "logo.jpg" }},
+		{"logo webp", func(m *ThemeManifest) { m.Logo = "logo.webp" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := validManifest()
+			tt.mut(m)
+			if err := ValidateThemeManifest(m); err != nil {
+				t.Errorf("expected accept, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateThemeManifest_Rejects(t *testing.T) {
+	tests := []struct {
+		name      string
+		mut       func(*ThemeManifest)
+		errSubstr string
+	}{
+		{"nil manifest", nil, "nil"},
+		{"empty name", func(m *ThemeManifest) { m.Name = "" }, "name"},
+		{"name too long", func(m *ThemeManifest) { m.Name = strings.Repeat("a", maxThemeNameLen+1) }, "name"},
+		{"empty version", func(m *ThemeManifest) { m.Version = "" }, "version"},
+		{"version too long", func(m *ThemeManifest) { m.Version = strings.Repeat("v", maxThemeVersionLen+1) }, "version"},
+		{"author too long", func(m *ThemeManifest) { m.Author = strings.Repeat("a", maxThemeAuthorLen+1) }, "author"},
+		{"logo with slash", func(m *ThemeManifest) { m.Logo = "sub/logo.png" }, "logo"},
+		{"logo with backslash", func(m *ThemeManifest) { m.Logo = `sub\logo.png` }, "logo"},
+		{"logo with parent ref", func(m *ThemeManifest) { m.Logo = "..logo.png" }, "logo"},
+		{"logo without prefix", func(m *ThemeManifest) { m.Logo = "image.png" }, "logo"},
+		{"logo bare prefix", func(m *ThemeManifest) { m.Logo = "logo." }, "logo"},
+		{"logo no extension", func(m *ThemeManifest) { m.Logo = "logo" }, "logo"},
+		{"logo unsupported extension", func(m *ThemeManifest) { m.Logo = "logo.tar.gz" }, "unsupported extension"},
+		{"logo gif extension", func(m *ThemeManifest) { m.Logo = "logo.gif" }, "unsupported extension"},
+		{"bad palette hex", func(m *ThemeManifest) { m.Accent = "not-a-color" }, "palette"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m *ThemeManifest
+			if tt.mut != nil {
+				m = validManifest()
+				tt.mut(m)
+			}
+			err := ValidateThemeManifest(m)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errSubstr)
+			}
+			if !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Errorf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+			}
+		})
+	}
+}
+
+// TestCheckManifestTagsUnique guarantees the package-init guard works
+// against the actual ThemeManifest declaration. If a future palette
+// field introduces a yaml-tag shadow, yaml.v3 would panic on import;
+// init catches it at startup, this test pins the contract.
+func TestCheckManifestTagsUnique(t *testing.T) {
+	if err := checkManifestTagsUnique(); err != nil {
+		t.Errorf("expected no tag collisions in ThemeManifest, got: %v", err)
+	}
+}
+
+// TestThemeManifest_YAMLRoundTrip pins down the on-disk shape so a
+// future palette-field collision (e.g. someone adds a `name:` field to
+// PaletteConfig) is caught loudly. Top-level keys are spelled here.
+func TestThemeManifest_YAMLRoundTrip(t *testing.T) {
+	src := `name: My Theme
+version: 1.0.0
+author: Me
+logo: logo.png
+accent: "#6366f1"
+text: "#222222"
+badges:
+  blue: "#1e40af"
+`
+	var m ThemeManifest
+	if err := yaml.Unmarshal([]byte(src), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.Name != "My Theme" || m.Version != "1.0.0" || m.Author != "Me" || m.Logo != "logo.png" {
+		t.Errorf("metadata fields not parsed correctly: %+v", m)
+	}
+	if m.Accent != "#6366f1" || m.Text != "#222222" {
+		t.Errorf("palette colors not inlined: %+v", m.PaletteColors)
+	}
+	if m.Badges["blue"] != "#1e40af" {
+		t.Errorf("badges not parsed: %+v", m.Badges)
+	}
+
+	// Re-marshal and verify the top-level keys appear once.
+	out, err := yaml.Marshal(&m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	str := string(out)
+	for _, key := range []string{"name:", "version:", "author:", "logo:", "accent:"} {
+		if strings.Count(str, key) != 1 {
+			t.Errorf("expected exactly one occurrence of %q in marshaled output:\n%s", key, str)
+		}
+	}
+}

--- a/tickets/entities/implementation-checklists/IMPL-VIQW.md
+++ b/tickets/entities/implementation-checklists/IMPL-VIQW.md
@@ -1,0 +1,74 @@
+---
+id: IMPL-VIQW
+type: implementation-checklist
+title: 'Implementation: Theme packages: export/install bundled palette + logo as .relatheme zip'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+**New code under test:**
+
+| File | Test |
+|---|---|
+| `internal/dataentryconfig/theme.go` | `theme_test.go`: accept matrix, reject matrix, YAML round-trip with key-collision sentinel. |
+| `internal/dataentry/theme_package.go` | `theme_package_test.go`: palette-only / with-logo / sniff-trumps-manifest-extension / extras-ignored / reject matrix (missing manifest, name empty, missing logo, bytes-not-image, path traversal, subdirectory entries, not-a-zip, malformed yaml, bad palette color) / logo-too-large / total-too-large / zip-bomb. |
+| `internal/dataentry/handlers_theme_package.go` | `handlers_theme_package_test.go`: export with/without logo, full round-trip (export → import → state assertions), error paths (not-zip, missing field), method-not-allowed for both endpoints, `safeThemeFilename` table. |
+| `frontend/src/api/theme.ts` (new exports) | `frontend/src/api/theme.test.ts`: exportTheme triggers download via `URL.createObjectURL`, importTheme POSTs FormData with `file` field, both surface server errors. |
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+`buildZip(t, entries)` and `minimalManifestYAML(extra)` are test helpers so each
+test only specifies the bytes/fields that matter to its scenario. Round-trip
+test compares against the original input bytes (`bytes.Equal(dest.UserLogoBytes,
+pngBytes)`), not hardcoded literals. Reject matrix uses sentinel-error matching
+(`errors.Is`) rather than substring comparisons.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Built `cmd/rela-server` against the SPA bundle, ran against `tickets/`,
+exercised the round-trip via curl:
+
+| AC | Manual check |
+|---|---|
+| 1. Settings shows Export/Install | Theme Package card rendered between Logo and App Info; Export + Install buttons visible. |
+| 2. Export with palette + logo | `GET /api/v1/_theme/export` returned `application/zip` (394 bytes) with `Content-Disposition: attachment; filename="..."`; `unzip -l` showed `theme.yaml` (99 bytes) + `logo.png` (56 bytes). |
+| 3. Export with no logo | Confirmed by Go test `TestThemeExport_PaletteOnly`. Manifest carries no `logo:` field; zip has only `theme.yaml`. |
+| 4. Import staging | `POST /api/v1/_theme/import` returned `{logoUrl: ".../logo?v=<hash>", palette: {accent: "#aabbcc", badges: {...}}}`. The existing `/_palette` endpoint still showed the previous saved palette afterward — confirming palette is *staged*, not auto-saved. |
+| 5. Live sidebar update | After import, `_sidebar.logoUrl` reflected the new hash. |
+| 6. Validation matrix | Curl tests: non-zip → 400 `not a valid zip file`; zip with subdirectory entry → 400 `zip entry contains path traversal`. |
+| 7. No new abstractions | `just arch-lint`: clean. Backend uses `state.KV` + `mutateState` + reused `saveUserLogo` / `sniffLogoMime`. No repo / transaction layers. |
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+- Mirrors the merged logo PR's plumbing: state-cached snapshot via `mutateState`, structured 413 with `maxBytes`, reuse of `sniffLogoMime` / `MaxUserLogoBytes` / `saveUserLogo` / `logoURLForHash`.
+- Stdlib zip only — no third-party Go dep.
+- Server-side parsing only — `parseThemePackage` is a pure helper, no `App` access; trivially unit-testable.
+- Layered defenses: total-size cap, expansion-ratio cap, path-traversal check, manifest validation, sniff-on-bytes for logos.
+- Lint clean (`just lint`); coverage threshold satisfied (75.5 % total).
+- All Go tests pass (`just test`); all 659 frontend tests pass (`npm run test:run`).

--- a/tickets/entities/planning-checklists/PLAN-KZ5H.md
+++ b/tickets/entities/planning-checklists/PLAN-KZ5H.md
@@ -1,8 +1,8 @@
 ---
 id: PLAN-KZ5H
 type: planning-checklist
-title: 'Planning: Theme packages: export and install bundled colors, font, and logo in data-entry'
-status: in-progress
+title: 'Planning: Theme packages: export and install bundled palette + logo as .relatheme zip'
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -15,41 +15,38 @@ status: in-progress
 
 **Scope:**
 
-**In scope:**
+**In scope (TKT-WPKW, builds on the merged logo PR TKT-WN7O):**
 
-- New `.relatheme` zip package format containing manifest + optional logo + optional font.
-- Backend persistence under `.rela/theme/` (via existing `kv` abstraction, like `.rela/palette.yaml`).
-- Backend HTTP routes for theme export, install, and serving the assets to the SPA.
-- Settings UI additions: Logo upload + preview, Font upload + preview, Export button, Install button.
-- Apply the bundled font as the UI font via a CSS `@font-face` declaration loaded from the asset URL.
-- Apply the bundled logo as the sidebar branding image (replacing/supplementing the current text-only `appName`).
-- Reuse the existing palette validation, save flow, and `kv` storage — no new abstractions.
-- Install flow: matches the existing palette flow — populates the editor; user clicks the existing Save buttons to apply.
+- New `.relatheme` zip format containing a YAML manifest plus an optional logo image.
+- Backend endpoints under `/api/v1/_theme`:
+  - `GET /api/v1/_theme/export` → returns a `.relatheme` zip download.
+  - `POST /api/v1/_theme/import` → accepts a `.relatheme` upload, persists the logo (if present), and returns the parsed palette JSON for the editor (does NOT auto-save the palette).
+- Manifest type: `ThemeManifest` defined alongside `dataentryconfig.PaletteConfig` (palette fields embedded; adds `name`, `version`, `author`, optional `logo` filename reference).
+- Frontend: Settings → Appearance gains a Theme package sub-section with **Export** and **Install** buttons.
+- Install flow: persists the logo bytes immediately (matches PR 1's PUT behaviour), stages the palette into the existing palette editor for an explicit Save.
+- Standard library zip (`archive/zip`) — no new third-party Go dependency.
+- No browser-side zip parsing — server handles both zip directions, frontend uses `fetch` + `Blob`.
 
-**Out of scope:**
+**Out of scope (deferred):**
 
-- Multi-theme libraries / switching between several saved themes (one active theme only).
-- Project-level theme defaults baked into the binary (project ships `data-entry.yaml` palette already; this ticket is purely user-side).
-- Web fonts loaded over HTTP (only locally-bundled font files).
-- Per-component icon packs, animations, sound packs, etc.
-- Cryptographic signing or trust verification for theme packages.
-- Drag-and-drop install (use a standard `<input type=file>`).
-- Theme registry / discoverability (themes are just files).
-- Multi-resolution raster logo bundles (`srcset` / `<picture>` / `@2x`
-  variants). Vector marks are covered by SVG, which is in the allowlist;
-  raster bundles would require a richer `logo` manifest object and additional
-  asset slots. The manifest can grow `logo: string` → `logo: object` later
-  without breaking existing themes.
+- **Custom UI fonts** — the font slot is omitted from the manifest entirely. Adding it later is non-breaking (manifest can grow).
+- **Custom CSS overrides** — explicit non-goal; large attack surface, no concrete user need.
+- **Multi-resolution rasters** (`srcset` / `<picture>` / `@2x`).
+- **Multi-theme libraries** / switching between several saved themes.
+- **Theme registries / discoverability** — themes are just files.
+- **Cryptographic signing or trust verification** for theme packages.
+- **Drag-and-drop install** — standard `<input type="file">` only.
+- **Project-level theme defaults baked into the binary** — already covered by `data-entry.yaml`.
 
 **Acceptance Criteria:**
 
-1. **Settings page exposes Logo upload, Font upload, and Theme Export buttons.** Test: open Settings → Appearance, verify three new affordances are visible alongside existing palette controls.
-2. **Theme Export produces a `.relatheme` zip downloadable by the browser.** Test: with palette + logo + font set, click Export; verify a `.relatheme` file downloads and unzipping reveals `theme.yaml`, `logo.<ext>`, `font.<ext>`.
-3. **Theme Install accepts a `.relatheme` zip and stages colors / logo / font into the editor.** Test: click Install, choose a `.relatheme` file; verify color inputs populate, logo preview updates, font preview updates. The user then clicks Save palette / Save logo / Save font (existing pattern) to persist.
-4. **Bundled fonts load via @font-face and apply to data-entry text.** Test: install a theme with a recognizable font; after Save, the sidebar / form labels render in that font.
-5. **Bundled logos replace the existing branding text in the sidebar.** Test: install a theme with a logo; after Save, the sidebar shows an `<img>` instead of the text `appName`. When no logo is set, sidebar falls back to text (current behavior).
-6. **Invalid / corrupt theme files surface a clear error to the user; existing theme is preserved.** Test cases: not-a-zip, zip without `theme.yaml`, manifest with invalid YAML, manifest with bad hex colors, font file too large, image file too large, font with disallowed mime, image with disallowed mime → each produces a clear toast error and leaves all current settings unchanged.
-7. **Theme persistence reuses the existing settings system.** Implementation review: changes only extend `palette.yaml` (or co-located files in `.rela/theme/`); no new repo / transaction / store abstractions introduced.
+1. **Settings page exposes Export and Install buttons in the Appearance section.** Test: Vitest mount of `SettingsView` asserts the Theme package sub-section has both buttons.
+2. **Theme Export produces a `.relatheme` zip containing `theme.yaml` plus `logo.<ext>` when set.** Test (Go): set up an app with a palette + logo, hit `/api/v1/_theme/export`, parse response as zip, assert `theme.yaml` parses cleanly and `logo.<ext>` is present with byte-identical content.
+3. **Theme Export with no logo set produces a zip containing only `theme.yaml`.** Test (Go): same as above with logo unset; assert `theme.yaml` exists and there is no `logo.*` entry.
+4. **Theme Install accepts a `.relatheme` zip, stages palette into the editor.** Test (e2e Playwright): export from one app instance, install into a fresh app instance, verify color inputs in the editor match the source. Click Save palette; verify persistence.
+5. **Theme Install persists the bundled logo immediately and the sidebar updates without reload.** Test (e2e): install a theme containing a logo, observe `<img>` in sidebar without a page reload (uses the live-update mechanism added during PR 1's review fixup).
+6. **Invalid / corrupt theme files surface a clear toast error and leave existing settings unchanged.** Test cases (Go table): not-a-zip, zip without `theme.yaml`, manifest with malformed YAML, manifest with bad hex colors, logo entry referenced but missing, oversized logo, total zip > 5 MiB. Each row asserts the response code and that `AppState.UserPalette` / `AppState.UserLogoBytes` are unchanged.
+7. **Theme persistence reuses existing storage patterns.** Implementation review + `just arch-lint`: no new repo / transaction abstractions; palette stays in `palette.yaml`; logo stays at `theme/logo` + sidecar.
 
 ## Research
 
@@ -60,40 +57,47 @@ status: in-progress
 
 **Existing Solutions:**
 
-- **Zip archive in Go:** stdlib `archive/zip` — chosen, no third-party dep needed. Read via `zip.NewReader(bytes.NewReader, size)`; write via `zip.NewWriter(w)`.
-- **Existing palette plumbing (`internal/dataentryconfig/palette.go`):** `PaletteConfig`, `ValidatePalette`, `ResolvePalette` — the theme manifest will reuse `PaletteConfig` directly so light/dark/badge logic is unchanged.
-- **Existing `kv` abstraction in `internal/dataentry/app.go`:** already used for `user-defaults.yaml`, `palette.yaml`, `ui-state.json`. Reuse for `theme/manifest.yaml`, `theme/logo.<ext>`, `theme/font.<ext>` (separate files inside a sub-key, since the manifest lives next to existing files).
-- **Existing palette save flow (`SettingsView.handleSavePalette`):** Edit → Save button → POST → schemaStore.reload(). Theme install will follow this — populate editor, user clicks existing Save buttons.
-- **Reference: VS Code theme zips (.vsix), Obsidian theme dirs:** both decoupled palette + (optional) assets via manifest. We mirror the manifest pattern with a single `theme.yaml`.
-- **Reference: `data-entry.yaml` `app.name` (handled in `schemaStore.app.name`, used by `Sidebar.vue:25`):** there is no existing image-based logo pipeline in the SPA. The Sidebar renders `appName` as text only. This ticket adds an optional image to the same slot.
-- **Existing dependencies** (`frontend/package.json`): no zip library yet client-side. Use the **JSZip** library (small, MIT) — it is the de-facto standard. Alternative: hand-roll with the browser-native `CompressionStream` (only zlib, not zip container). Verdict: JSZip.
+- **Stdlib `archive/zip`** — fully sufficient. Read via `zip.NewReader(bytes.NewReader, size)`; write via `zip.NewWriter(w)`. No third-party dep.
+- **Existing palette plumbing** (`internal/dataentryconfig/palette.go`):
+  - `PaletteConfig` (line 24) — exported struct already used by the `_palette` API.
+  - `ValidatePalette(p *PaletteConfig) error` (line 210) — central validator; we reuse it on the imported manifest's color fields.
+  - `ResolvePalette(project, user *PaletteConfig) *ResolvedPalette` (line 295) — used at app boot. Not needed by import (we don't auto-save palette).
+- **Logo plumbing** (merged via TKT-WN7O):
+  - `internal/dataentry/theme_logo.go`:
+    - `userLogoFile` (`"theme/logo"`) and `userLogoExtFile` (sidecar) — same storage we re-use for imports.
+    - `MaxUserLogoBytes` (256 KiB), `allowedLogoExts`, `logoExtForMime`, `logoContentType` — all reusable.
+    - `loadUserLogo`, `saveUserLogo`, `deleteUserLogo`, `hashLogoBytes`, `(*AppState).LogoURL()` — ready to call.
+  - `internal/dataentry/handlers_theme.go`:
+    - `sniffLogoMime`, `looksLikeSVG`, `writeLogoTooLarge`, `logoURLForHash` — reuse where they fit; do not extend gratuitously.
+- **Existing settings save flow** (`SettingsView.handleSavePalette`, `handleAPISavePalette`): this is the pattern install must blend into. Stage the palette via `loadPaletteState` / setting the editor refs; user clicks the existing **Save Palette** button to commit.
+- **Existing live logo update** (added during PR 1 review): `schemaStore.setLogoUrl(url)` causes the Sidebar to swap to the new image without a page reload. Install pushes the URL through this same setter.
+- **Reference packagings:** VS Code `.vsix` (zip + JSON manifest), Obsidian theme dirs, Sketch `.sketchpalette`. The pattern of "manifest + asset files inside a zip" is standard; we mirror it.
+- **No third-party deps needed.** JSZip was considered when I thought we'd parse zips client-side; rejected — server-side parsing is simpler and reuses the existing trust boundary.
 
-**Files to modify (preliminary, may grow during implementation):**
+**Files to modify:**
 
 Backend (Go):
 
-- `internal/dataentryconfig/palette.go` (or new `theme.go` next to it): add `ThemeManifest` type with embedded `PaletteConfig` + optional `Logo` + `Font` filename pointers. Add `ValidateThemeManifest`.
-- `internal/dataentry/app.go`: add `loadUserTheme` / `saveUserTheme` (manifest), `loadUserLogo` / `saveUserLogo`, `loadUserFont` / `saveUserFont`. Add `UserTheme`, `UserLogoFilename`, `UserFontFilename` fields to `AppState`.
-- `internal/dataentry/handlers_api.go`:
-  - `GET /api/v1/_theme/logo` → serve bytes (with proper Content-Type, ETag, Cache-Control: no-store while editing).
-  - `GET /api/v1/_theme/font` → serve bytes.
-  - `PUT /api/v1/_theme/logo` (multipart) → save logo.
-  - `PUT /api/v1/_theme/font` (multipart) → save font.
-  - `DELETE /api/v1/_theme/logo` → remove logo.
-  - `DELETE /api/v1/_theme/font` → remove font.
-  - `GET /api/v1/_theme/export` → produces a `.relatheme` zip with the current user palette + logo + font.
-  - `POST /api/v1/_theme/import` (multipart, `.relatheme`) → unpacks; returns the parsed `PaletteConfig` + the saved logo/font URLs (does NOT persist palette, only stages logo/font and returns palette JSON for the editor).
-- `internal/dataentry/api_v1.go`: register the new routes.
+- `internal/dataentryconfig/theme.go` (new): defines `ThemeManifest`. Embeds `PaletteConfig`. Adds:
+  - `Name string` (required, 1–100 chars).
+  - `Version string` (required, any non-empty 1–32 char string for v1 — no semver enforcement).
+  - `Author string` (optional, ≤100 chars).
+  - `Logo string` (optional, references zip entry filename like `"logo.png"`).
+- `internal/dataentryconfig/theme.go`: `ValidateThemeManifest(m *ThemeManifest) error` — calls `ValidatePalette(&m.PaletteConfig)`, then validates name/version/author/logo length and shape.
+- `internal/dataentry/handlers_theme.go`:
+  - `handleAPIThemeExport(w, r)` — reads `AppState`, builds a `ThemeManifest`, writes a zip to `bytes.Buffer`, sets `Content-Type: application/zip` + `Content-Disposition: attachment; filename="<safe-name>.relatheme"`.
+  - `handleAPIThemeImport(w, r)` — multipart receive (single `file` field); calls a pure helper `parseThemePackage(bytes []byte) (*ThemeManifest, *ImportedAsset, error)`; on success, persists logo via `saveUserLogo`, returns `{palette: PaletteConfig, logoUrl: string|null}`.
+- `internal/dataentry/theme_package.go` (new): `parseThemePackage(bytes []byte) (*ThemeManifest, *ImportedAsset, error)` — pure helper, no `App` access, easy to unit test. Caps zip size, expansion ratio, entry name set, asset size.
+- `internal/dataentry/api_v1.go`: register `/api/v1/_theme/export` and `/api/v1/_theme/import`.
 
 Frontend (Vue/TS):
 
-- `frontend/package.json`: add `jszip` runtime dep.
-- `frontend/src/api/theme.ts` (new): typed clients for `getLogoUrl()`, `uploadLogo(file)`, `uploadFont(file)`, `deleteLogo()`, `deleteFont()`, `exportTheme()`, `importTheme(file): Promise<{palette, logoUrl?, fontUrl?}>`.
-- `frontend/src/views/SettingsView.vue`: add three new sub-sections in Appearance: Logo (upload + remove), Font (upload + remove), Theme package (Export, Install).
-- `frontend/src/components/common/Sidebar.vue`: render `<img class="logo-img" :src=logoUrl />` when a logo is set; fall back to text otherwise.
-- `frontend/src/stores/ui.ts` or `frontend/src/stores/schema.ts`: track `logoUrl`, `fontFamily` reactively; `applyFont(url)` injects a `@font-face` rule and sets `--ui-font` CSS var on `:root`.
-- `frontend/src/App.vue`: declare `--ui-font` CSS variable and use it in the global `font-family` rule (replacing/wrapping the existing system-font stack so we keep the fallback chain).
-- `frontend/src/utils/theme-package.ts` (new): pure helpers to build/parse the zip in-browser using JSZip. Used for client-side export and to *show* the manifest contents during install before round-tripping to the server.
+- `frontend/src/api/theme.ts`: add `exportTheme()` (returns `Blob`, triggers a download via `URL.createObjectURL` + anchor click) and `importTheme(file: File)` (returns `{palette, logoUrl}`).
+- `frontend/src/views/SettingsView.vue`: new sub-section under the existing Logo card titled **"Theme package"**. Two buttons: Export + Install. Install reuses the file-input pattern with `accept=".relatheme,application/zip"`. After import: `schemaStore.setLogoUrl(result.logoUrl)` (so sidebar updates live); call `loadPaletteState(result.palette, ...)` to populate the existing palette editor. Toast: "Theme installed. Click Save palette to apply colors."
+- No store changes — logo flows through the existing `setLogoUrl`; palette flows through the existing editor refs.
+
+Total surface area: **~3 new backend files + 2 modified backend files + 2
+modified frontend files**. Effort `m` (already set).
 
 ## Approach
 
@@ -110,63 +114,140 @@ A standard zip archive with these entries:
 
 ```text
 theme.yaml          # required: ThemeManifest (YAML)
-logo.<ext>          # optional: PNG / JPEG / SVG / WebP
-font.<ext>          # optional: WOFF2 / WOFF / TTF / OTF
+logo.<ext>          # optional: PNG / JPEG / SVG / WebP, exists iff manifest.logo is set
 ```
 
-`theme.yaml` shape (a superset of `palette.yaml`, so existing palettes are valid
-manifests with name/version added):
+`theme.yaml` shape (a superset of `palette.yaml`):
 
 ```yaml
 name: "My Theme"            # required, 1-100 chars
-version: "1.0.0"            # required, semver-ish (any non-empty string for now)
-author: "..."               # optional
+version: "1.0.0"            # required, 1-32 chars (any non-empty)
+author: "..."               # optional, 1-100 chars
 # colors: identical shape to existing palette.yaml
 base: "#1a1a2e"
 surface: "#f8fafc"
 accent: "#6366f1"
-# ... (all 8 role keys, badges, dark — same as PaletteConfig)
+# ... (all PaletteConfig fields: 8 role keys, badges, dark)
 logo: "logo.png"            # optional, references zip entry
-font:                       # optional
-  filename: "font.woff2"    # references zip entry
-  family: "MyFont"          # required if font block present (used in @font-face)
 ```
+
+The author of `theme.yaml` always uses the literal entry name `logo.<ext>` so a
+parser doesn't need to discover the extension by directory listing.
 
 ### Backend export flow
 
-1. `GET /api/v1/_theme/export` reads the current user palette, logo bytes, font bytes from `kv`.
-2. Composes a `ThemeManifest` (palette fields + name defaulting to `app.name`, version `1.0.0`, logo/font entries if present).
-3. Writes a zip to `bytes.Buffer` using `archive/zip`; returns it with `Content-Type: application/zip` and `Content-Disposition: attachment; filename="<safe-name>.relatheme"`.
+1. `GET /api/v1/_theme/export` reads `AppState`. If a user palette is set use it; otherwise fall back to `cfg.Palette` (the project palette).
+2. Compose a `ThemeManifest`:
+   - `Name`: defaults to `cfg.App.Name` if not set on the palette/somewhere else.
+   - `Version`: `"1.0.0"` (constant for v1).
+   - `Author`: empty unless we add a setting later.
+   - Palette fields: copied from the source palette.
+   - `Logo`: `"logo." + UserLogoExt` if a logo is set, otherwise empty.
+3. Marshal to YAML.
+4. Build a zip in `bytes.Buffer`:
+   - Always write `theme.yaml`.
+   - If `UserLogoExt` is set, write `logo.<ext>` containing `UserLogoBytes`.
+5. Response headers:
+   - `Content-Type: application/zip`
+   - `Content-Disposition: attachment; filename="<safeName>.relatheme"` where `safeName` is `Name` with `[^A-Za-z0-9_-]` replaced by `_`, capped to 64 chars; falls back to `theme` if empty.
+6. Body = the zip bytes.
 
 ### Backend install flow
 
-1. `POST /api/v1/_theme/import` accepts `multipart/form-data` with a single file (`.relatheme`).
-2. Validates: zip parses; `theme.yaml` exists, parses, validates as `ThemeManifest`; logo/font entries (if referenced) exist in zip and pass mime-type allowlist + size limit (logo ≤ 256 KiB, font ≤ 2 MiB).
-3. **Persists logo and font bytes** to `.rela/theme/logo.<ext>`, `.rela/theme/font.<ext>` via `kv`. (Reasoning: assets need a stable URL the browser can fetch; staging only in memory wouldn't survive page reload.)
-4. **Does NOT persist the palette.** Returns the parsed palette JSON in the response so the SPA stages it in the existing palette editor; user clicks "Save palette" to commit, matching the current pattern.
+1. `POST /api/v1/_theme/import` accepts `multipart/form-data` with one file (`file` field, must end in `.relatheme` or `.zip` — content-type sniffed in code).
+2. `MaxBytesReader` capped at **5 MiB total** (room for manifest + a 256 KiB logo + headroom).
+3. Read the body; parse as zip via `zip.NewReader`.
+4. Pass to `parseThemePackage(bytes []byte)`:
+   - Reject zips whose **uncompressed total** > 5 MiB or whose **expansion ratio** (declared uncompressed / actual compressed) > 100×.
+   - Reject any entry whose normalized name contains `/`, `\`, or `..`. Only flat-file entries with the literal names `theme.yaml` and `logo.<ext>` are accepted; everything else is ignored (so themes with `README.md`, `.DS_Store`, or future entries don't fail).
+   - Read `theme.yaml`, parse YAML, run `ValidateThemeManifest`.
+   - If `manifest.Logo` is set:
+     - Locate the entry `logo.<ext>` exactly. If missing → 400 `"logo referenced in manifest but not present in archive"`.
+     - Read up to `MaxUserLogoBytes` + 1 bytes; reject if larger.
+     - `sniffLogoMime(bytes)` → must produce one of the allowlist mimes; map back to `ext`. If the sniffed ext doesn't match the manifest's claimed extension we *trust the sniff* and use that.
+   - Return `(*ThemeManifest, *ImportedAsset{ext, bytes}, nil)`.
+5. Under `mutateState`:
+   - If asset present: write logo bytes via `saveUserLogo(bytes, ext)`, recompute hash, update AppState fields.
+   - **Do not touch the palette.**
+6. Response: `{palette: PaletteConfig, logoUrl: string|null}`.
 
-Trade-off: this means logo/font are committed atomically on install, but palette
-is not. That mismatch is acceptable because logo/font are bytes (you can't
-reasonably "stage" them without a temp store) and the user can still un-install
-via the Remove button. Alternative considered: tempfile staging with a "commit"
-endpoint — rejected as overengineered for an MVP.
+Why logo persists immediately but palette doesn't: bytes need a stable URL the
+browser can fetch, so staging-only would require a tempfile mechanism that
+doesn't exist. Palette is JSON, easy to round-trip through the editor; the
+existing palette UX already requires explicit Save.
+
+### Manifest type
+
+```go
+package dataentryconfig
+
+type ThemeManifest struct {
+    Name    string `yaml:"name"`
+    Version string `yaml:"version"`
+    Author  string `yaml:"author,omitempty"`
+    Logo    string `yaml:"logo,omitempty"`
+    PaletteConfig `yaml:",inline"`
+}
+
+func ValidateThemeManifest(m *ThemeManifest) error {
+    if m == nil {
+        return errors.New("manifest is nil")
+    }
+    if l := len(m.Name); l < 1 || l > 100 {
+        return fmt.Errorf("name must be 1-100 chars (got %d)", l)
+    }
+    if l := len(m.Version); l < 1 || l > 32 {
+        return fmt.Errorf("version must be 1-32 chars (got %d)", l)
+    }
+    if l := len(m.Author); l > 100 {
+        return fmt.Errorf("author must be 0-100 chars (got %d)", l)
+    }
+    if m.Logo != "" {
+        // Logo entry must be a flat filename matching logo.<ext>.
+        if strings.ContainsAny(m.Logo, "/\\") || !strings.HasPrefix(m.Logo, "logo.") {
+            return fmt.Errorf(`logo entry must be "logo.<ext>"`)
+        }
+    }
+    return ValidatePalette(&m.PaletteConfig)
+}
+```
 
 ### Frontend install UX
 
-- Click "Install theme" → file picker (`accept=".relatheme,application/zip"`).
-- POST file to `/api/v1/_theme/import`. Backend persists logo/font and returns the palette.
-- On response, call existing palette load functions to populate the editor with the returned palette (just like the current "Reset palette" path), then call `schemaStore.reload()` to pick up the new logo/font URLs.
-- Toast: "Theme installed. Click Save to persist colors."
+```vue
+<section class="settings-card">
+  <h3>Theme package</h3>
+  <p class="description">
+    Bundle the current palette and logo into a portable <code>.relatheme</code>
+    file, or install one shared by someone else.
+  </p>
+  <div class="theme-package-actions">
+    <input ref="themeFileInput" type="file"
+           accept=".relatheme,application/zip"
+           class="file-input-hidden"
+           @change="handleThemePicked" />
+    <button class="btn btn-secondary btn-sm" @click="handleExport">Export</button>
+    <button class="btn btn-primary btn-sm" @click="themeFileInput?.click()">Install</button>
+  </div>
+</section>
+```
 
-### Logo wiring in Sidebar
+Export handler builds an anchor tag, sets `download` to `<safeName>.relatheme`,
+clicks it, revokes the object URL.
 
-- `schemaStore` exposes `logoUrl` (computed): `userTheme?.logo ? '/api/v1/_theme/logo?v=<hash>' : null`.
-- `Sidebar.vue`: `<img v-if="logoUrl" :src="logoUrl" />` else `{{ appName }}`. Cache-bust query param uses content hash so updates are immediate.
+Install handler POSTs the file, then:
 
-### Font wiring
+```ts
+const result = await importTheme(file)
+schemaStore.setLogoUrl(result.logoUrl)        // sidebar updates live
+applyImportedPalette(result.palette)           // populate the editor refs
+uiStore.success('Theme installed. Click Save palette to apply colors.')
+```
 
-- On schemaStore load (or after install), if `userTheme?.font`, inject a `<style>` in `<head>`: `@font-face { font-family: "<family>"; src: url("/api/v1/_theme/font?v=<hash>") }` and set `:root { --ui-font: "<family>", -apple-system, ... }`.
-- `App.vue` global `font-family` rule already uses a system stack — change it to `var(--ui-font, -apple-system, BlinkMacSystemFont, ...)`.
+`applyImportedPalette` calls the existing `loadPaletteState(result.palette,
+paletteRoles.map(r=>r.key), schemaStore.darkDisabled)` and copies the result
+into `paletteMode`, `paletteColors`, `paletteBadges`, etc. The same code path
+that runs on Settings page mount already does this; install just re-uses it.
 
 ### Persistence layout
 
@@ -175,23 +256,24 @@ endpoint — rejected as overengineered for an MVP.
   palette.yaml         # existing, unchanged
   user-defaults.yaml   # existing, unchanged
   theme/
-    manifest.yaml      # name, version, author, font.family — metadata only
-    logo.<ext>         # bytes
-    font.<ext>         # bytes
+    logo               # logo bytes (existing PR 1)
+    logo.ext           # sidecar (existing PR 1)
 ```
 
-The manifest under `theme/` carries metadata (name / version / author / font
-family) that isn't part of `palette.yaml`. We deliberately keep the palette in
-its existing `palette.yaml` location rather than denormalising it into the theme
-manifest, so users who only edit colors don't need to know about themes.
+`.rela/theme/manifest.yaml` is **not** persisted. The manifest exists only
+inside `.relatheme` zips at export time; on import, only the colors and logo
+flow into existing storage. This keeps the install side perfectly aligned with
+the existing logo + palette stories.
 
 **Alternatives considered:**
 
-1. **Embed assets as base64 in `palette.yaml`.** Rejected: bloats the YAML, awkward for binary, and violates the "permissive markdown + YAML" philosophy in CLAUDE.md.
-2. **Browser-only theme storage (localStorage).** Rejected: doesn't match the existing settings system; loses the theme on cache clear; user picked the disk-backed option.
-3. **Apply theme immediately on install (no Save step).** Rejected per user clarification — the current palette flow requires explicit Save, themes should match.
-4. **Use only browser-native `CompressionStream` (no JSZip).** Rejected: only handles zlib, not zip container format.
-5. **Sign theme packages.** Rejected: out of scope; no trust model in rela today.
+1. **Persist a `theme/manifest.yaml` on import** to capture name/version/author. Rejected: those fields have no display purpose in the SPA today (no "current theme name" UI). When a future ticket needs them, persist then.
+2. **Browser-side zip parsing with JSZip.** Rejected: doubles the trust boundary surface area, requires bundling a runtime dep, and brings no UX benefit (server is already handling the upload). Server-side parsing reuses the existing logo/palette validators.
+3. **Auto-save palette on import.** Rejected per the user's earlier guidance and consistent with the existing palette UX (explicit Save).
+4. **Single endpoint `/api/v1/_theme` with method-based dispatch.** Rejected for clarity: `/_theme/export` (GET) and `/_theme/import` (POST) read more naturally than `GET /_theme` returning a download.
+5. **Versioned manifest (`schemaVersion: 1`).** Rejected for v1; defer until we have a second version. The current `version` field is the *theme's* user-facing version, not the schema version.
+6. **Reject themes whose manifest references a logo extension we don't allow.** Already covered: `parseThemePackage` always sniffs the actual bytes via `sniffLogoMime`, which is the trust boundary. The manifest's claimed extension is informational only.
+7. **Validate that `safeName` matches the user's intent.** Not necessary; download filename is purely cosmetic. Browser's "Save as..." prompt lets users override.
 
 **Files to modify:** see Research section above.
 
@@ -206,21 +288,20 @@ manifest, so users who only edit colors don't need to know about themes.
 
 | Input | Source | Validation |
 |---|---|---|
-| `.relatheme` upload | Multipart from logged-in user | Size cap on entire upload (≤ 5 MiB). Must parse as zip. Must contain `theme.yaml`. |
-| `theme.yaml` content | Inside zip | YAML parse + `ValidateThemeManifest` (allowlist of keys; reuse `ValidatePalette` for color fields; require name 1–100 chars; font.family 1–64 chars matching `[A-Za-z0-9 _-]`). |
-| Logo bytes | Inside zip | Mime-sniff allowlist: `image/png`, `image/jpeg`, `image/svg+xml`, `image/webp`. Size ≤ 256 KiB. **SVG: also strip `<script>`, `on*=` attributes, and `xlink:href` to non-data URIs** (or reject SVG entirely if sanitization is judged risky in review — both options on the table). |
-| Font bytes | Inside zip | Magic-byte check for WOFF2 (`wOF2`), WOFF (`wOFF`), TTF (`\x00\x01\x00\x00` / `OTTO`), OTF. Size ≤ 2 MiB. |
-| Logo upload (separate) | Multipart | Same allowlist + size as above. |
-| Font upload (separate) | Multipart | Same allowlist + size as above. |
+| `.relatheme` upload | Logged-in user via POST | `MaxBytesReader` 5 MiB. Must parse as zip via `zip.NewReader`. Total uncompressed > 5 MiB → reject; expansion ratio > 100× → reject. |
+| `theme.yaml` content | Inside zip | YAML parse + `ValidateThemeManifest` (length-bounded name/version/author; logo entry name pattern; embedded `ValidatePalette`). |
+| Logo entry inside zip | Inside zip | Entry name is exactly `logo.<sniffed-ext>` flat (no `/`, `\`, `..`). Bytes ≤ `MaxUserLogoBytes` (256 KiB). `sniffLogoMime` must return one of the allowlist mimes — same trust boundary as the direct PUT path. |
+| Zip entry names beyond allowlist | Inside zip | Ignored (not enumerated, not extracted). Future themes can add files we don't know about without breaking import. |
+| Filename of upload | Multipart header | Ignored. Never reflected in HTML or filenames. |
 
 **Security-Sensitive Operations:**
 
-- **Zip path traversal:** parse zip entries by name only (`logo.<ext>`, `font.<ext>`); never use `entry.Name` to construct a filesystem path. Reject any entry whose normalized name contains `/`, `\`, or `..`.
-- **Zip-bomb protection:** uncompressed-size cap per entry + total cap. Reject zip with declared/observed expansion ratio > 100×.
-- **Stored XSS via SVG logo:** the `<img src>` attribute renders SVGs as images, which DOES NOT execute scripts (browsers sandbox `<img>`-loaded SVGs). Confirm we never inline the SVG. For belt-and-braces, serve with `Content-Security-Policy: sandbox`.
-- **Stored XSS via filename:** never reflect the uploaded filename into HTML; we always rename to `logo.<ext>` / `font.<ext>` based on sniffed type.
-- **Authn:** these endpoints inherit the existing data-entry auth (none today; localhost-only). No new attack surface beyond what `_palette` already has.
-- **Error messages:** report failure category (`"unsupported font format"`, `"manifest missing 'name' field"`) without echoing back input bytes, file headers, or stack traces.
+- **Zip path traversal:** entry names are checked against an allowlist of literal patterns (`theme.yaml`, `logo.*`); anything containing `/`, `\`, or `..` is rejected on the spot. Even allowlist-matching entries are read via `zip.File.Open()` and never used to construct a filesystem path — we hand the bytes to the existing `saveUserLogo` flow which writes to fixed `theme/logo` + `theme/logo.ext` keys.
+- **Zip-bomb:** uncompressed-total cap (5 MiB) and per-entry expansion ratio (100×). Both checked before reading entry bodies into memory. The ratio is computed using `zip.File.UncompressedSize64` against the request body length.
+- **Stored XSS via SVG logo:** the import path goes through the same logo storage as the merged `_theme/logo` PUT, so the GET path serves bytes with the same `nosniff` + `Content-Security-Policy: sandbox; frame-ancestors 'none'` + `X-Frame-Options: DENY` headers. No new attack surface.
+- **YAML deserialization:** `gopkg.in/yaml.v3` (already used) does not execute arbitrary types. We unmarshal into a typed struct; unknown fields are ignored.
+- **Authn:** inherits the existing data-entry origin allowlist middleware; same surface as `_palette` / `_theme/logo`.
+- **Error responses:** JSON `{error: "<short category>"}`. Categories: `payload_too_large`, `not_a_zip`, `missing_manifest`, `invalid_manifest`, `unsupported_format`, `logo_too_large`, `internal`. No raw bytes / file contents / stack traces in the response.
 
 ## Test Plan
 
@@ -233,47 +314,54 @@ manifest, so users who only edit colors don't need to know about themes.
 
 | AC | How tested |
 |---|---|
-| 1. Settings exposes Logo / Font / Export buttons | `SettingsView` mount test (Vitest) — verify the three new controls are present. |
-| 2. Export produces valid `.relatheme` | Go test for `/api/v1/_theme/export`: set up app with palette + logo + font, hit endpoint, parse response as zip, assert `theme.yaml` parses and `logo.png` / `font.woff2` are present with the expected bytes. |
-| 3. Install populates editor + applies after Save | E2E (Playwright in `/e2e/`): export from one app, install into a fresh app, verify editor populated; click Save; reload; verify persisted. |
-| 4. Font applied via @font-face | E2E: install theme with `Lobster.woff2`; assert `getComputedStyle(sidebar).fontFamily` includes `Lobster`. |
-| 5. Logo replaces sidebar text | E2E: install theme with logo; assert `<img>` present in sidebar header; remove logo; assert text fallback. |
-| 6. Invalid theme files | Go table-driven test for `/api/v1/_theme/import`: each row is a malformed zip, assert 400 + specific error code. Vitest test for client-side rejection (file > 5MB before upload). |
-| 7. No new abstractions | Code review checks; `just arch-lint` must pass. |
+| 1. Settings shows Export/Install buttons | Vitest mount of `SettingsView`: assert the new card and both buttons are present. |
+| 2. Export with palette + logo | Go test in `handlers_theme_package_test.go`: set up app with palette + logo, hit `handleAPIThemeExport`, parse response as zip, assert manifest YAML round-trips and `logo.<ext>` matches the source bytes. |
+| 3. Export with no logo | Go test: same setup minus the logo upload; assert the zip has only `theme.yaml`. |
+| 4. Install round-trip | Go test: build a zip with `parseThemePackage`-friendly inputs, POST to `handleAPIThemeImport`, assert the response carries the expected palette and logo URL, and that `AppState.UserLogoBytes` was updated. Plus a Playwright e2e: export from one app, install into a fresh app, assert palette editor populated and Save persists. |
+| 5. Live sidebar update on install | Playwright e2e: install a theme with a logo, observe `<img>` in sidebar without page reload. |
+| 6. Validation matrix | Go table-driven on `parseThemePackage` (pure helper, easy to drive): rows for each error category. Each row asserts the returned error and that no app state was mutated. |
+| 7. No new abstractions | Code review + `just arch-lint`. |
 
 **Edge Cases:**
 
-- Manifest with palette ONLY (no logo, no font) — valid; round-trips through export/import.
-- Manifest with logo only / font only.
-- Light-only palette vs light+dark palette in the manifest.
-- Zip with extra unrelated entries (`README.md`, `.DS_Store`) — ignore unknown entries with no error.
-- Logo file referenced in manifest but missing in zip → reject manifest at install.
-- Empty zip → reject.
-- Non-UTF8 bytes in `theme.yaml` → YAML parser surfaces error.
-- Extension mismatch (logo says `logo.png`, bytes are JPEG) — accept on sniffed type, normalize stored filename to sniffed extension.
-- Unicode characters in name / family.
-- Concurrent imports from two browser tabs — last write wins (matches existing `palette.yaml` behavior; `mutateState` serializes).
-- Reload while font is loading — `<style>` re-injection is idempotent.
-- Removing a logo when none is set → 204, no error.
+- Manifest with palette ONLY (no logo) — round-trips through export/import.
+- Manifest with logo only — palette fields omitted resolve to defaults via `ValidatePalette` (palette is permissive on missing fields).
+- Light-only palette vs light+dark palette — both round-trip.
+- Zip with extra unrelated entries (`README.md`, `.DS_Store`) — ignored, no error.
+- Logo file referenced in manifest but missing in zip → reject with `missing_logo`.
+- Logo bytes present in zip but manifest doesn't reference them → ignored (manifest is the source of truth).
+- Manifest claims `logo: logo.png` but the actual bytes are SVG → trust the sniff, store as `.svg`.
+- Empty zip → reject `missing_manifest`.
+- Zip without `theme.yaml` → reject `missing_manifest`.
+- `theme.yaml` is a directory entry → reject `invalid_manifest`.
+- Non-UTF8 bytes in `theme.yaml` → YAML parser surfaces error → reject `invalid_manifest`.
+- Concurrent imports from two browser tabs — last write wins; `mutateState` serializes the writes.
+- Two imports in quick succession with the same logo bytes → second hash equals first; no disk thrash.
+- 256 KiB logo + 4 MiB of comments in the manifest → zip-total cap (5 MiB) catches it.
+- Compressed entry that decompresses to 30 MiB → expansion ratio cap rejects.
+- Entry name `../../../etc/passwd` → path-traversal check rejects.
+- Entry name `LOGO.PNG` (uppercase) → not matched (case-sensitive); manifest `logo: LOGO.PNG` would similarly fail the pattern check.
 
 **Negative Tests:**
 
-- Upload non-zip → 400 "not a valid zip".
-- Upload zip without `theme.yaml` → 400 "missing theme.yaml".
-- `theme.yaml` with malformed YAML → 400 with parse error category.
-- `theme.yaml` with bad hex color → 400 "invalid color".
-- Logo file > 256 KiB → 400 "logo too large".
-- Font file > 2 MiB → 400 "font too large".
-- Total zip size > 5 MiB → 400.
-- Logo with disallowed mime (e.g. `application/octet-stream`) → 400.
-- Font that fails magic-byte check → 400.
-- Zip-bomb (entry with 100× expansion) → 400 "compressed entry too large".
-- Path-traversal entry name (`../foo`) → 400 "invalid zip entry".
+- Upload a non-zip → 400 `not_a_zip`.
+- Upload zip without `theme.yaml` → 400 `missing_manifest`.
+- `theme.yaml` with malformed YAML → 400 `invalid_manifest`.
+- `theme.yaml` with name = "" → 400 `invalid_manifest`.
+- `theme.yaml` with name = 200 chars → 400 `invalid_manifest`.
+- `theme.yaml` with bad hex color → 400 `invalid_manifest`.
+- `theme.yaml` with `logo: ../foo` → 400 `invalid_manifest`.
+- Logo entry > 256 KiB → 400 `logo_too_large`.
+- Total zip > 5 MiB → 413.
+- Zip-bomb (single entry with 100×+ expansion) → 400 `payload_too_large` (or 413 if reaching the body cap first).
+- Logo with disallowed mime (e.g. GIF in the zip) → 400 `unsupported_format`.
+- GET `/_theme/export` while no palette and no logo → 200 with manifest containing project defaults; this matches the natural "I want a baseline theme" use case.
 
 **Integration test approach:**
 
-- New Go integration test in `internal/dataentry/handlers_api_test.go` that drives export then import end-to-end against an in-memory `kv`, asserting that the round-trip preserves palette + logo bytes + font bytes byte-for-byte.
-- Playwright e2e in `/e2e/` that exercises the full UI flow.
+- Pure-helper Go tests against `parseThemePackage` for the validation matrix (fast, no HTTP layer).
+- HTTP-level Go tests against `handleAPIThemeExport` + `handleAPIThemeImport` for the round-trip (export with state X, import the result, assert state still matches).
+- Playwright e2e for the user-facing flow: export from one in-process app, install into a second, verify visible state changes.
 
 ## Risk Assessment
 
@@ -285,16 +373,16 @@ manifest, so users who only edit colors don't need to know about themes.
 
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
-| SVG XSS via logo | Medium | High | `<img>`-only rendering (no inline SVG); CSP sandbox header; test with known-malicious SVG fixture. If sanitization adds significant complexity, drop SVG from the allowlist for v1 and add it later. |
-| Font file licensing user error | High | Low | Out of our control (user's responsibility); add a one-line warning under the font upload control: "Only upload fonts you are licensed to redistribute". |
-| Logo / font bloats `.rela/` directory in git | Medium | Low | Document that `.rela/theme/` should be gitignored (it follows the same convention as `.rela/user-defaults.yaml` per CLAUDE.md). |
-| Browser caches old logo after replacement | High | Low | Cache-bust query param using a content hash. |
-| Zip parsing CPU on large file | Low | Medium | 5 MiB upper bound; `archive/zip` reader is O(n) with no decompression on file listing. |
-| `appName` text already accommodates long strings; image will require new CSS | Low | Low | Add `.logo-img { max-height: ...; max-width: 100%; object-fit: contain; }` and visually verify. |
+| YAML embedding via `yaml:",inline"` causes name/palette field collisions | Low | Medium | `PaletteConfig` field tags are well-defined; explicitly write tests asserting that `name`/`version`/`author`/`logo` are top-level YAML keys distinct from any palette key. |
+| Zip-bomb defenses too tight, reject legitimate palettes with long author strings | Low | Low | 5 MiB total + 100× ratio is generous: a manifest is ~2 KB; logos are ≤256 KiB. Real headroom is >19×. |
+| Logo size cap differs between `parseThemePackage` and direct PUT | Low | Medium | Both paths reuse `MaxUserLogoBytes` constant. A test asserts both reject at the same boundary. |
+| Browser caches an old export | Low | Low | We don't cache exports — `Cache-Control: no-store` on the export response. |
+| Import succeeds at logo persist but palette response shape changes downstream | Low | Medium | The palette response shape mirrors the existing `userPalette` field returned by `/api/v1/_settings`. Type-shared: extend `frontend/src/api/theme.ts` to re-use `PaletteConfig`. |
+| User imports a theme on a workspace where colors are project-locked | Low | Low | Out of scope for this PR — the same constraint exists for the direct palette PUT today. The install simply stages; user can't save if locked. |
 
-**Effort:** **m** (already set on the ticket). Backend: ~4 new endpoints +
-manifest type + tests. Frontend: ~3 UI controls + ~2 stores updates + JSZip
-integration + tests + e2e. Realistic estimate 1.5–2 working days.
+**Effort:** **m** — already set on TKT-WPKW. Backend ~250 LOC + tests; frontend
+~80 LOC + tests; one new Go file (`theme_package.go`) and one new manifest type.
+Realistic estimate: 1 working day.
 
 ## Documentation Planning
 
@@ -305,15 +393,15 @@ For enhancements: identify what documentation needs updating.
 
 **Documentation Impact:**
 
-- [x] User guide / reference docs — add a "Theme packages" section to the data-entry user docs explaining export/import format.
-- [ ] CLI help text — N/A (no CLI surface).
-- [x] CLAUDE.md — add a brief note in the "Don't do this" list reminding future contributors not to embed binary assets in YAML.
-- [ ] README.md — N/A.
-- [x] API docs — document the new `/api/v1/_theme/*` endpoints alongside the existing `_palette` docs.
+- [x] User guide / reference docs — add a "Theme packages" subsection under data-entry settings docs explaining export/import format.
+- [x] ~~CLI help text~~ (N/A: no CLI surface).
+- [x] ~~CLAUDE.md~~ (N/A: no new architecture concept).
+- [x] ~~README.md~~ (N/A: feature is internal to data-entry).
+- [x] API docs — document `/api/v1/_theme/export` and `/api/v1/_theme/import` alongside `_palette` and `_theme/logo`.
 
 ## Design Review
 
-- [ ] Run `/design-review` before starting implementation
-- [ ] All critical/significant findings addressed in plan
+- [x] Run `/design-review` before starting implementation — used `/crit:crit`. Plan went through one round; the only inline question (font/CSS scope) was addressed by the prior umbrella restructuring before this rewrite, so no plan-stage review responses were filed.
+- [x] All critical/significant findings addressed in plan — none surfaced at plan stage; implementation review yielded RR-84YM, RR-YEVY, RR-0PTF, RR-5QTT, RR-U2S9 (significant) + RR-MP1R, RR-7P3O (minor) + RR-5EHQ, RR-YMSC, RR-OMEN (nit) — all addressed.
 
-**Design Review Findings:** <!-- List review-response IDs, e.g., RR-xxxx -->
+**Design Review Findings:** None at plan stage. Implementation findings tracked under TKT-WPKW has-review-response.

--- a/tickets/entities/planning-checklists/PLAN-M2UZ.md
+++ b/tickets/entities/planning-checklists/PLAN-M2UZ.md
@@ -1,0 +1,399 @@
+---
+id: PLAN-M2UZ
+type: planning-checklist
+title: 'Planning: Custom UI font upload for data-entry'
+status: pending
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+**In scope (PR 2 of the three-PR theme system split):**
+
+- Backend: `GET / PUT / DELETE /api/v1/_theme/font`. Storage at `.rela/theme/font.<ext>` via the existing `state.KV` (Delete added by PR 1).
+- Mime / magic-byte validation: WOFF2 (`wOF2`), WOFF (`wOFF`), TTF (`\x00\x01\x00\x00` / `OTTO`), OTF (`OTTO`). Max 2 MiB.
+- Family name: stored in a small sidecar `theme/font.meta` (YAML or single-line `family\n<name>` plain text — see Approach). Validated 1–64 chars `[A-Za-z0-9 _-]`.
+- `AppState` additions: `UserFontBytes`, `UserFontExt`, `UserFontFamily`, `UserFontHash`. Loaded at app boot, mutated under `mutateState` on PUT/DELETE.
+- `_sidebar` and `_settings` responses gain `fontUrl` + `fontFamily` (or a single `font: {url, family}` object — see Approach).
+- Frontend: `frontend/src/api/theme.ts` extends with `uploadFont(file, family)`, `removeFont()`, `FontInfo` type.
+- Frontend: Settings → Appearance gets a Font sub-section with file picker + family-name input + preview text + Remove button.
+- Frontend: `schemaStore` gains `fontUrl` / `fontFamily` refs + `setFont(url, family)`. A new composable `applyFont` in `composables/useFont.ts` injects an `@font-face` `<style>` and toggles `:root` `--ui-font`.
+- `App.vue`: global `font-family` becomes `var(--ui-font, <existing stack>)`.
+- Cache-busting via SHA-256 content hash, same approach as the logo.
+
+**Out of scope (deferred):**
+
+- Web fonts from external URLs (Google Fonts, etc.) — local upload only.
+- Multiple weights / styles (italic, bold variants) — single file = single weight; CSS handles synthesized variants.
+- Font as part of a `.relatheme` package (PR 3 / TKT-WPKW).
+- Per-component font choices (mono vs body) — one font, one slot.
+- Variable-font subsetting / pre-processing.
+
+**Acceptance Criteria:**
+
+1. **Settings shows a Font control.** Test: Vitest mount of `SettingsView` asserts the file picker (`accept=".woff2,.woff,.ttf,.otf,font/*"`), the family-name input, the preview text element, and Upload + Remove buttons.
+2. **Upload persists + applies live.** Test (e2e): pick a `.woff2` fixture, type a family, click Upload. Assert (a) `_settings.fontUrl` populates on next fetch; (b) `getComputedStyle(document.body).fontFamily` includes the family name; (c) `<style data-rela-font>` exists in `<head>`.
+3. **Remove reverts to system stack.** Test (e2e): with a font set, click Remove, assert `--ui-font` is unset and the family name is no longer in `getComputedStyle(body).fontFamily`.
+4. **Validation matrix.** Go table-driven: rows for 2 MiB + 1 byte (413), TTF magic / OTF magic / WOFF magic / WOFF2 magic (accepted), random bytes claiming font extension (rejected on magic-byte mismatch), missing form field (400), bad family name (400). On any failure the existing font is unchanged.
+5. **Family name validation.** `family` must match `/^[A-Za-z0-9 _-]{1,64}$/`. Test: empty / 65-char / `<script>` / Unicode chars all rejected at the API.
+6. **Licensing notice.** Visible caption next to the upload control: "Only upload fonts you are licensed to redistribute / use locally." Vitest mount assertion.
+7. **Persistence across restart.** Manual: upload, kill server, restart; `_settings.fontUrl` returns the same hash; bytes served byte-for-byte.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+- **`state.KV` interface** (added in PR 1, TKT-WN7O): Get / Put / Delete. Already supports the Delete contract we need. **Important: PR 2 branches off `develop`, so this method only exists once PR 1 merges.** If PR 1 stalls beyond PR 2, rebase will pull in the interface change.
+- **Logo PR (TKT-WN7O) plumbing** as the reference template:
+  - `internal/dataentry/theme_logo.go` — load/save/delete + `LogoURL()` accessor. Mirror the structure for fonts.
+  - `internal/dataentry/handlers_theme.go` — multipart parsing, `MaxBytesReader`, `mutateState`, hash computation, response shape. Mirror.
+  - `internal/dataentry/handlers_theme_test.go` — fixture builders, validation table. Mirror.
+  - `frontend/src/api/theme.ts` — typed client. Extend.
+  - `frontend/src/stores/schema.ts` — `logoUrl` + `setLogoUrl`. Add `fontUrl`, `fontFamily`, `setFont`.
+  - `frontend/src/views/SettingsView.vue` — Logo card pattern. Add a sibling Font card.
+- **`http.DetectContentType` does NOT identify fonts** — sniffs the first 512 bytes against image / text / video / audio signatures. Returns `application/octet-stream` for fonts. We have to magic-byte them ourselves:
+  - **WOFF2:** first 4 bytes `wOF2` (`0x77 0x4F 0x46 0x32`).
+  - **WOFF:** first 4 bytes `wOFF` (`0x77 0x4F 0x46 0x46`).
+  - **TTF:** first 4 bytes `\x00\x01\x00\x00` (TrueType outlines) or `true` (Apple) or `typ1` (rare PostScript).
+  - **OTF:** first 4 bytes `OTTO` (CFF outlines).
+  - References: <https://www.w3.org/TR/WOFF2/#table-overall-file-structure>, <https://learn.microsoft.com/en-us/typography/opentype/spec/otff>.
+- **`@font-face` injection in JS:** standard pattern is to insert a `<style>` element with the rule into `<head>`. The browser resolves the URL and applies the font once any element references the family. No need for `FontFace` API (more code, no benefit here).
+- **Existing `--*` CSS vars in App.vue:** the palette story already uses `--accent-color`, `--text-color`, etc. Add `--ui-font` as a sibling.
+- **Family-name validation regex:** `/^[A-Za-z0-9 _-]{1,64}$/`. The CSS spec allows wider names with quoting, but limiting to ASCII identifier chars eliminates quoting / escape ambiguity in the inline `<style>` we generate. Users with weirder fonts can rename via the input field — we never auto-derive from the file.
+- **Font sniff library** — none in stdlib, none popular in third-party Go. Magic-byte check is 8 lines of code.
+
+**Files to modify:**
+
+Backend (Go):
+
+- `internal/dataentry/theme_font.go` (new): `loadUserFont`, `saveUserFont`, `deleteUserFont`, `sniffFontExt`, `hashFontBytes`, `FontURL()` on AppState — all mirroring `theme_logo.go`.
+- `internal/dataentry/app.go`: extend `AppState` with `UserFontBytes`, `UserFontExt`, `UserFontFamily`, `UserFontHash`. Boot path calls `loadUserFont` next to `loadUserLogo`.
+- `internal/dataentry/handlers_theme.go`: add `handleAPIThemeFont` with the same GET / PUT / DELETE shape. Multipart PUT carries both the file and a `family` form field. **Refactor opportunity:** lift shared multipart-upload helpers if the duplication starts hurting; do not preempt the abstraction.
+- `internal/dataentry/api_v1.go`: register `/api/v1/_theme/font` route.
+- `internal/dataentry/api_v1.go::handleV1Sidebar` + `handlers_api.go::handleAPIGetSettings`: extend response with `font: {url, family}`.
+
+Frontend (Vue/TS):
+
+- `frontend/src/api/theme.ts`: add `uploadFont(file, family) → {fontUrl, fontFamily}`, `removeFont()`. Reuse `LogoUploadError` shape (or rename to `ThemeUploadError`).
+- `frontend/src/api/settings.ts`: extend `SettingsData` with `font?: {url, family} | null`.
+- `frontend/src/types/config.ts`: extend `SidebarData` with same.
+- `frontend/src/stores/schema.ts`: add `fontUrl`, `fontFamily`, `setFont(url, family) | clearFont()`.
+- `frontend/src/composables/useFont.ts` (new): `applyFont(url, family)` injects/updates the `<style data-rela-font>` element and sets `--ui-font`. `clearFont()` removes both.
+- `frontend/src/App.vue`: watch `schemaStore.fontUrl` / `fontFamily`, call `applyFont` / `clearFont` on changes. Update global `font-family` to `var(--ui-font, -apple-system, ...)`.
+- `frontend/src/components/common/Sidebar.vue::loadSidebar`: push `data.font` into `schemaStore.setFont` (mirror `setLogoUrl`).
+- `frontend/src/views/SettingsView.vue`: new Font card with file picker, family input, preview text, Upload + Remove. Mirror SettingsView's Logo card.
+
+Total surface area: ~5 new backend lines + ~3 modified backend files / ~6
+frontend files. Effort `s`.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+### Storage layout
+
+```text
+.rela/
+  theme/
+    logo            # PR 1 (existing)
+    logo.ext        # PR 1 (existing)
+    font            # bytes
+    font.ext        # 3-5 bytes: "woff2" | "woff" | "ttf" | "otf"
+    font.family     # 1-64 bytes: the family name as raw UTF-8
+```
+
+The decision to store family in its own sidecar (rather than
+`theme/manifest.yaml` as the original umbrella plan suggested) keeps the on-disk
+shape symmetrical with the logo and avoids having two mechanisms (sidecar files
++ a manifest) for the same kind of metadata. PR 3 (the `.relatheme` zip) creates
+the manifest only at export time.
+
+### Endpoint behavior
+
+#### `GET /api/v1/_theme/font`
+
+- 404 if `state.UserFontExt == ""`.
+- 200 with body = bytes, `Content-Type` per `UserFontExt`:
+  - `woff2` → `font/woff2`
+  - `woff` → `font/woff`
+  - `ttf` → `font/ttf`
+  - `otf` → `font/otf`
+- `X-Content-Type-Options: nosniff`.
+- `Cache-Control: public, max-age=86400, immutable` (URL carries content hash).
+- **No CSP sandbox** (unlike logos): a font response isn't an executable surface. We do set `Cross-Origin-Resource-Policy: same-origin` so cross-origin pages can't `@font-face` from our server.
+
+#### `PUT /api/v1/_theme/font`
+
+- Body: `multipart/form-data` with `file` (the font) and `family` (the name).
+- Step 1: `MaxBytesReader` at `MaxUserFontBytes + 16 KiB` (= 2 MiB + envelope headroom, mirrors logo).
+- Step 2: `r.ParseMultipartForm`.
+- Step 3: validate `family`: `^[A-Za-z0-9 _-]{1,64}$`.
+- Step 4: read file bytes; verify size ≤ 2 MiB.
+- Step 5: magic-byte check → derive extension. Reject anything not in the allowlist.
+- Step 6: under `mutateState`, persist bytes + `font.ext` + `font.family`. Update AppState.
+- Response: `{ok: true, fontUrl: "/api/v1/_theme/font?v=<hash>", fontFamily: "<name>"}`.
+
+#### `DELETE /api/v1/_theme/font`
+
+- Under `mutateState`: `kv.Delete` on all three keys (idempotent). Clear AppState fields.
+- Returns 204.
+
+### Magic-byte detection
+
+```go
+func sniffFontExt(b []byte) string {
+    if len(b) < 4 {
+        return ""
+    }
+    switch {
+    case bytes.HasPrefix(b, []byte("wOF2")):
+        return "woff2"
+    case bytes.HasPrefix(b, []byte("wOFF")):
+        return "woff"
+    case bytes.HasPrefix(b, []byte{0x00, 0x01, 0x00, 0x00}),
+         bytes.HasPrefix(b, []byte("true")),
+         bytes.HasPrefix(b, []byte("typ1")):
+        return "ttf"
+    case bytes.HasPrefix(b, []byte("OTTO")):
+        return "otf"
+    }
+    return ""
+}
+```
+
+### Frontend application
+
+`composables/useFont.ts`:
+
+```ts
+const STYLE_ID = 'rela-user-font'
+
+export function applyFont(url: string, family: string) {
+  let el = document.getElementById(STYLE_ID) as HTMLStyleElement | null
+  if (!el) {
+    el = document.createElement('style')
+    el.id = STYLE_ID
+    document.head.appendChild(el)
+  }
+  // family is server-validated to [A-Za-z0-9 _-], so quoting is safe
+  // without escaping; URL is server-controlled (internal route).
+  el.textContent =
+    `@font-face { font-family: "${family}"; src: url("${url}"); font-display: swap; }`
+  document.documentElement.style.setProperty(
+    '--ui-font',
+    `"${family}", -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif`,
+  )
+}
+
+export function clearFont() {
+  document.getElementById(STYLE_ID)?.remove()
+  document.documentElement.style.removeProperty('--ui-font')
+}
+```
+
+`App.vue` style update:
+
+```css
+body {
+  font-family: var(--ui-font, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif);
+}
+```
+
+`App.vue` script: `watch([() => schemaStore.fontUrl, () =>
+schemaStore.fontFamily], ([url, family]) => { url && family ? applyFont(url,
+family) : clearFont() }, {immediate: true})`.
+
+### Settings UI
+
+```vue
+<section class="settings-card">
+  <h3>Font</h3>
+  <p class="description">
+    Upload a custom UI font. WOFF2, WOFF, TTF, or OTF. Max 2 MiB.
+  </p>
+  <p class="muted-caption">
+    Only upload fonts you are licensed to redistribute or use locally.
+  </p>
+  <div class="font-preview-row">
+    <div
+      class="font-preview-frame"
+      :style="stagedFontFamily ? { fontFamily: stagedFontFamily } : {}"
+    >
+      The quick brown fox jumps over the lazy dog. 0123456789
+    </div>
+    <div class="font-actions">
+      <input type="text" v-model="stagedFamilyName" placeholder="Family name" maxlength="64" />
+      <input ref="fontFileInput" type="file" accept=".woff2,.woff,.ttf,.otf,font/*" hidden @change="handleFontPicked" />
+      <button class="btn btn-secondary btn-sm" @click="fontFileInput?.click()">Choose font</button>
+      <button
+        class="btn btn-primary btn-sm"
+        :disabled="!stagedFontFile || !stagedFamilyName.trim() || uploadingFont"
+        @click="handleFontUpload"
+      >Upload</button>
+      <button v-if="fontUrl" class="btn btn-danger btn-sm" :disabled="removingFont" @click="handleFontRemove">Remove</button>
+    </div>
+  </div>
+</section>
+```
+
+Preview behavior: the staged file is loaded into a temp `FontFace` instance via
+the `FontFace` API (`new FontFace(family, src)` then `document.fonts.add(...)`),
+so the preview frame can render in the picked font even before Upload. After
+Upload, the persisted `applyFont` takes over and the temp instance is dropped.
+
+### Persistence layout
+
+The on-disk story is intentionally identical to the logo so PR 3 (`.relatheme`)
+can iterate over `theme/<asset>{,.ext,.family?}` uniformly.
+
+**Alternatives considered:**
+
+1. **Family in `theme/manifest.yaml` (umbrella plan).** Rejected for this PR: introduces a YAML manifest that nothing else needs, and PR 3 will create one anyway. Two manifests vs. one symmetrical sidecar story — symmetry wins.
+2. **Drop family input, derive from filename.** Rejected: filenames are user-uncontrolled noise (`MyFont-Regular-v2.woff2`); the user typing the family name eliminates ambiguity.
+3. **Use `FontFace` API instead of injected `<style>`.** Both work; `<style>` injection composes with CSS variables more cleanly and matches how the rest of the SPA handles theming. `FontFace` API is used only for the staged preview where we need synchronous loading.
+4. **Allow Unicode family names.** Rejected for v1: harder to safely embed in inline CSS without escape risk. The user can name it whatever they like during display ("Helvetica Sans"); we just store ASCII.
+5. **Sniff via `mime.TypeByExtension(filename)`.** Rejected: trusts user-supplied filename. Magic bytes are the trust boundary.
+6. **Reuse PR 1's `writeLogoTooLarge` helper directly.** Rejected: too coupled. Mirror the pattern with `writeFontTooLarge` to keep error wording specific. Lift to a shared helper only if a third asset arrives.
+
+**Files to modify:** see Research section above.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+| Input | Source | Validation |
+|---|---|---|
+| Multipart `file` field | PUT body | `MaxBytesReader` 2 MiB + 16 KiB envelope. After parse, `len(bytes) > 2 MiB` → 413. |
+| Font bytes | Inside multipart | Magic-byte allowlist: `wOF2` / `wOFF` / `\x00\x01\x00\x00` / `true` / `typ1` / `OTTO`. No fallback. |
+| `family` form field | PUT body | `^[A-Za-z0-9 _-]{1,64}$`. Empty / overlong / invalid char → 400. |
+| Filename in upload | Multipart header | Ignored. Always renamed to sniffed extension. |
+| Sidecar `font.ext` | `.rela/theme/font.ext` on boot | Read back validated as one of `{woff2,woff,ttf,otf}`. Anything else → treat as no font, log warning. |
+| Sidecar `font.family` | `.rela/theme/font.family` on boot | Same regex re-validation. Anything else → no font, log warning. |
+
+**Security-Sensitive Operations:**
+
+- **Inline `<style>` injection** (`composables/useFont.ts`): the `family` is server-validated, so no quote-escape risk in `font-family: "<family>"`. The URL is a server-internal route (`/api/v1/_theme/font?v=<hex hash>`), never user-controllable in shape. No `eval`, no `innerHTML`-derived-from-input.
+- **CSS injection via family**: even if validation drifts, the format-string surface in the inline style is one place. Worst case (validation lapses): an attacker who can already PUT to the local-only API can also break their own SPA — no privilege escalation.
+- **Cross-origin font theft**: not a concern (no auth secrets in fonts), but we set `Cross-Origin-Resource-Policy: same-origin` so the font response can't be loaded by foreign pages.
+- **Path traversal**: keys are static literals; user input never reaches the path. Same as logo PR.
+- **Image-decoder vulnerabilities equivalent**: we never decode the font server-side. No `freetype`, no `image/font` library. Browsers do the parsing; that's the same trust surface as any web font.
+- **DoS via large upload**: 2 MiB cap. `MaxBytesReader` enforced before parse.
+- **Server-side magic-byte inspection only on first 4 bytes** — no full-format validation. A malformed font that passes the 4-byte check will load and the browser will reject it on render. Acceptable because the user's own browser is the victim of malformed data they uploaded themselves.
+
+**Error responses:** JSON `{error: "<category>"[, maxBytes: 2097152]}` for 413.
+No bytes / hex dumps / stack traces in the body.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | How tested |
+|---|---|
+| 1. Settings shows Font control | `frontend/src/views/SettingsView.test.ts`: mount + assert presence of file input, family input, preview text, Upload + Remove. |
+| 2. Upload persists + applies live | Playwright e2e in `/e2e/`: pick fixture WOFF2 + family, click Upload, await `<style data-rela-font>`, assert `getComputedStyle(body).fontFamily.includes(family)`. |
+| 3. Remove reverts to system stack | Playwright e2e: with font set, click Remove, assert `<style data-rela-font>` gone, assert `getComputedStyle(body).fontFamily` no longer contains family. |
+| 4. Validation matrix | Go table-driven test in `internal/dataentry/handlers_theme_font_test.go`: covers 2 MiB+1, each magic-byte (accept), GIF bytes (reject), missing field, bad family. Assert state unchanged on rejection. |
+| 5. Family name validation | Go table-driven: empty, 65 chars, `<script>`, `My Font`, `Inter-Display`, `name with quotes "x"` — each row asserts 200 vs 400 + that AppState reflects only successes. |
+| 6. Licensing notice | Vitest mount: `expect(wrapper.text()).toContain('Only upload fonts you are licensed')`. |
+| 7. Persistence across restart | Manual: e2e or `curl`-driven smoke test in implementation. |
+
+**Edge Cases:**
+
+- Upload exactly 2 MiB → accepted.
+- Upload 2 MiB + 1 → 413.
+- Two concurrent PUTs (multi-tab) → `mutateState` serializes, last write wins, hash converges on next fetch.
+- Upload, immediately rename family via second PUT → bytes preserved, only metadata changes if the family field is the only thing different (current path always rewrites bytes; could optimize later, but the simpler "PUT replaces all" is fine).
+- App restart with `font` + `font.ext` present but `font.family` missing → log warning, treat as no font.
+- App restart with valid `font` + `font.ext` + `font.family` containing invalid chars → same — no font, log warning.
+- WOFF2 with EOF padding → magic check sees prefix only; bytes pass through opaquely.
+- Browser caches old font after replacement → URL hash changes; cache miss; new bytes fetched.
+- User unloads page mid-upload → standard fetch abort; no partial state because `mutateState` is the gate.
+
+**Negative Tests:**
+
+- POST a PNG → 400 unsupported_format.
+- POST `text/plain` claiming to be `.ttf` → magic check fails, 400.
+- POST without `family` field → 400 missing_family.
+- POST with empty `family` → 400 invalid_family.
+- POST with `family="<script>alert(1)</script>"` → 400 invalid_family (regex rejects `<`, `>`).
+- POST with `family` of 65 chars → 400.
+- DELETE before upload → 204 (idempotent).
+- GET before upload → 404 + JSON error.
+- PATCH method → 405.
+
+**Integration test approach:**
+
+- Go test driving full PUT → GET → DELETE → GET cycle against an in-memory `state.KV`. Asserts byte-for-byte preservation, hash propagation, family round-trip, 404 after DELETE.
+- Vitest test for `frontend/src/api/theme.ts::uploadFont` with mocked fetch — confirms `FormData` shape (`file` + `family`) and response handling.
+- Vitest test for `composables/useFont.ts::applyFont` / `clearFont` — assert `<style data-rela-font>` is created/updated/removed and `--ui-font` is set/cleared.
+- Playwright e2e for the round-trip flow.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Branch-off-`develop` while PR 1 unmerged ⇒ rebase conflicts | High | Low | Limit textual conflicts: each new asset adds *next to* the logo's lines, never modifying them. Conflict resolution = keep both blocks. |
+| `state.KV.Delete` only exists on `feat/theme-logo` ⇒ won't compile on `develop` | High | Low | If PR 1 hasn't merged at PR 2's commit time, cherry-pick the `state.KV.Delete` change into PR 2 and let one of them rebase later. |
+| Browser fails to load the font (corrupt magic bytes pass our 4-byte check) | Medium | Low | Document that the user sees the system font fallback if their font is malformed. No server-side fix; we don't decode fonts. |
+| Family name with embedded quotes breaks injected `<style>` | Low | Medium | Server-side regex bans `"`; even if it slipped through, the consequence is a malformed CSS rule on the user's own browser. |
+| `font-display: swap` causes layout shift on first paint | High | Low | This is the standard tradeoff (vs `block` which delays render or `optional` which may skip the font). Acceptable; matches Google Fonts default. |
+| FontFace API for staged preview unsupported on old Safari | Low | Low | Feature-detect; fall back to "no preview" with a static text label. |
+| Magic-byte allowlist misses an edge case (TrueType collection `ttcf` etc.) | Low | Low | TTC is a font *collection* (multiple fonts in one file); not in the spec for `@font-face` single-family use. Reject with the same error; if a real user need surfaces, add it. |
+
+**Effort:** **s** — already set on TKT-KE0C. Backend ~150 LOC + tests; frontend
+~100 LOC + composable + tests. Realistic estimate: half a working day.
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] User guide / reference docs — extend the "Custom logo" section (added in PR 1) with a sibling "Custom font" subsection.
+- [x] ~~CLI help text~~ (N/A: no CLI surface).
+- [x] ~~CLAUDE.md~~ (N/A: deferred to PR 3 with the broader theme system pass).
+- [x] ~~README.md~~ (N/A: feature is internal to data-entry).
+- [x] API docs — document `/api/v1/_theme/font` (GET / PUT / DELETE) alongside `_palette` and `_theme/logo`.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation — will use `/crit:crit` per project pattern (see PR 1's PLAN-65IV).
+- [ ] All critical/significant findings addressed in plan — pending crit round.
+
+**Design Review Findings:** TBD (will be filled in after `/crit:crit` round).

--- a/tickets/entities/review-checklists/REV-T61A.md
+++ b/tickets/entities/review-checklists/REV-T61A.md
@@ -74,8 +74,8 @@ in data-entry" story is ready for a docs pass.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI — created PR #691 via `gh pr create`.
+- [x] All CI checks pass — required jobs all green (Test, E2E, Lint, Frontend, Architecture, Build, CodeQL, Vulnerability Check, Rela Tickets, Fuzz, Lint Markdown, Analyze ×3, Docs).
+- [x] PR URL documented below.
 
-**PR:** <!-- to be added after `gh pr create` -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/691

--- a/tickets/entities/review-checklists/REV-T61A.md
+++ b/tickets/entities/review-checklists/REV-T61A.md
@@ -2,7 +2,7 @@
 id: REV-T61A
 type: review-checklist
 title: 'Review: Theme packages: export/install bundled palette + logo as .relatheme zip'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->

--- a/tickets/entities/review-checklists/REV-T61A.md
+++ b/tickets/entities/review-checklists/REV-T61A.md
@@ -1,0 +1,81 @@
+---
+id: REV-T61A
+type: review-checklist
+title: 'Review: Theme packages: export/install bundled palette + logo as .relatheme zip'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — all packages pass; 75.5 % total coverage.
+- [x] Lint clean (`just lint`) — 0 issues.
+- [x] Coverage maintained (`just coverage-check`) — package floor satisfied; total 75.5 % > 65 % threshold.
+- [x] Architecture lint clean (`just arch-lint`).
+- [x] Frontend tests pass (`npm run test:run`) — 659/659.
+- [x] Frontend typecheck clean (`npm run typecheck`).
+- [x] Frontend lint clean (`npm run lint`) — 0 errors.
+- [x] Frontend build succeeds (`npm run build`).
+
+## Code Review
+
+- [x] Run `cranky-code-reviewer` agent — done; 10 findings.
+- [x] All critical review-responses addressed — none filed (no critical findings).
+- [x] All significant review-responses addressed — RR-84YM, RR-YEVY, RR-0PTF, RR-5QTT, RR-U2S9.
+- [x] Self-reviewed the diff for unrelated changes.
+
+**Review Responses:**
+
+| ID | Severity | Status |
+|---|---|---|
+| RR-84YM | significant | addressed (saturating-add zip-bomb guard, uint64 throughout) |
+| RR-YEVY | significant | addressed (duplicate-entry rejection + sentinel + test) |
+| RR-0PTF | significant | addressed (init-time tag-collision check + parseThemePackage panic recovery) |
+| RR-5QTT | significant | addressed (useConfirm dirty-check before staging palette) |
+| RR-U2S9 | significant | addressed (deferred URL.revokeObjectURL) |
+| RR-MP1R | minor | addressed (typed APIThemeImportResponse) |
+| RR-7P3O | minor | addressed (manifest extension allowlist {png, jpeg, jpg, svg, webp}) |
+| RR-5EHQ | nit | addressed (maxThemeUploadBytes constant) |
+| RR-YMSC | nit | addressed (overflow-protected ratio multiply) |
+| RR-OMEN | nit | addressed (exhaustive switch + slog.Warn default) |
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist (IMPL-VIQW)
+
+**Acceptance Status:**
+
+| AC | Result | Evidence |
+|---|---|---|
+| 1. Settings shows Export/Install | PASS | New Theme Package card rendered between Logo and App Info; Export + Install buttons. |
+| 2. Export with palette + logo | PASS | curl test: 394 byte zip with `theme.yaml` (99 b) + `logo.png` (56 b); `Content-Disposition` header present. |
+| 3. Export with no logo | PASS | `TestThemeExport_PaletteOnly` asserts only `theme.yaml` in zip and no `logo.*`. |
+| 4. Import staging | PASS | curl test: returned `{logoUrl, palette}` JSON; `_palette` GET still showed previous saved value (palette is staged, not auto-saved). |
+| 5. Live sidebar update | PASS | After import, `_sidebar.logoUrl` reflected the new hash. |
+| 6. Validation matrix | PASS | curl tests: non-zip → 400 `not a valid zip file`; zip with subdirectory → 400 `path traversal`. Plus the full Go reject matrix in `theme_package_test.go`. |
+| 7. No new abstractions | PASS | `just arch-lint`: clean. Backend reuses `state.KV`, `mutateState`, `saveUserLogo`, `sniffLogoMime`, `MaxUserLogoBytes`. |
+
+## Documentation (enhancements only)
+
+Deferred. The umbrella plan's documentation impact (theme-system docs, API
+reference) lands together with this PR's merge — `IMPL-VIQW` Documentation
+Planning calls this out. End-user docs ride along when the broader "theme system
+in data-entry" story is ready for a docs pass.
+
+- [x] Logged in `IMPL-VIQW` Documentation Planning section.
+
+## Final Checks
+
+- [x] Commit message will explain why (PR 2 of theme system, builds on TKT-WN7O, font dropped).
+- [x] No TODOs or FIXMEs left unaddressed.
+- [x] Ready for another developer to use.
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- to be added after `gh pr create` -->

--- a/tickets/entities/review-responses/RR-0PTF.md
+++ b/tickets/entities/review-responses/RR-0PTF.md
@@ -1,0 +1,9 @@
+---
+id: RR-0PTF
+type: review-response
+title: yaml.v3 panics on duplicated-key shadow at unmarshal
+finding: theme.go:18-27 + theme_test.go:92-127 — yaml.v3 *panics* on duplicated key tags during Unmarshal (verified empirically). The current TestThemeManifest_YAMLRoundTrip catches collisions on marshal output but not on unmarshal-time panics, leaving a runtime-fatal path live. Add a defer-recover in parseThemePackage that maps the panic to errInvalidManifest, plus a reflection-based test that fails at compile/test time when a yaml-tag shadow is introduced between ThemeManifest and PaletteConfig (so the test catches the bug before it ships).
+severity: significant
+resolution: 'Two layers: (1) parseThemePackage now defer-recovers and translates any panic into errInvalidManifest. (2) New init() in dataentryconfig/theme.go runs checkManifestTagsUnique() at startup via reflection — if any future PaletteConfig field shadows a top-level manifest key (yaml or otherwise), the binary refuses to start. Test TestCheckManifestTagsUnique pins the contract.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-5EHQ.md
+++ b/tickets/entities/review-responses/RR-5EHQ.md
@@ -1,0 +1,9 @@
+---
+id: RR-5EHQ
+type: review-response
+title: Extract maxThemeUploadBytes constant
+finding: handlers_theme_package.go:53-54 — `ThemePackageMaxBytes+16*1024` repeated for MaxBytesReader and ParseMultipartForm. Mirror handlers_theme.go::maxLogoUploadBytes by introducing maxThemeUploadBytes near the constant definition so they can't drift.
+severity: nit
+resolution: Extracted maxThemeUploadBytes constant near ThemePackageMaxBytes. Both MaxBytesReader and ParseMultipartForm now use the constant; mirrors the maxLogoUploadBytes pattern.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-5QTT.md
+++ b/tickets/entities/review-responses/RR-5QTT.md
@@ -1,0 +1,9 @@
+---
+id: RR-5QTT
+type: review-response
+title: Import silently overwrites unsaved palette draft
+finding: 'SettingsView.vue:159-179 + applyImportedPalette:181-192 — User with edited-but-unsaved palette colors clicks Install; editor refs are stomped without warning. Mirror the existing showDeriveConfirm flow: detect dirtiness against schemaStore.paletteLight/Dark and prompt ''Replace your unsaved palette draft?'' before applying. At minimum, surface a Reset link in the success toast so the user can recover.'
+severity: significant
+resolution: 'Theme install now calls isPaletteEditorDirty() and, when dirty, prompts via the project''s useConfirm composable: ''Replace your unsaved palette draft? — Installing a theme will replace the colors in the palette editor. Your previously saved palette on disk is not affected, but any unsaved edits in the editor will be lost.'' If user cancels, the file input is reset and no import occurs. Saved palette in palette.yaml is untouched either way.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-7P3O.md
+++ b/tickets/entities/review-responses/RR-7P3O.md
@@ -1,0 +1,9 @@
+---
+id: RR-7P3O
+type: review-response
+title: Manifest accepts logo extensions we will never serve
+finding: theme.go::validateLogoEntryName + test 'logo with multiple dots' — Manifest validation accepts `logo.tar.gz` even though the sniffed-mime → ext path will only ever store .png/.jpeg/.svg/.webp. Either reject manifest-time extensions outside allowedLogoExts (matches what we persist) or document explicitly that manifest.logo is a lookup-key string thrown away after sniff.
+severity: minor
+resolution: validateLogoEntryName now rejects extensions outside the allowlist {png, jpeg, jpg, svg, webp}. Test 'logo with multiple dots' (logo.tar.gz) was moved from the accept matrix to the reject matrix with `unsupported extension`. New tests cover jpg alias and gif rejection.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-84YM.md
+++ b/tickets/entities/review-responses/RR-84YM.md
@@ -1,0 +1,9 @@
+---
+id: RR-84YM
+type: review-response
+title: checkZipExpansion uint64-wrap defeats defense-in-depth
+finding: 'theme_package.go:158-173 — `total += f.UncompressedSize64` wraps on crafted zip64 entries (single value >= 2^64 - 5MB collapses below the cap). The post-loop `int64(total)` cast also truncates. The doc comment claims overflow is caught, but it isn''t. Only `LimitReader` in readZipEntry actually saves us. Use a saturating add and stay in uint64 throughout: `if f.UncompressedSize64 > ThemePackageMaxBytes || total > ThemePackageMaxBytes-f.UncompressedSize64 { return errZipUncompressed }`.'
+severity: significant
+resolution: 'checkZipExpansion now uses saturating add: any entry whose UncompressedSize64 > ThemePackageMaxBytes or would push the running total over the cap is rejected before total wraps. Stayed in uint64 throughout (no int64 cast); guard the multiply by clamping compressedTotal first.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MP1R.md
+++ b/tickets/entities/review-responses/RR-MP1R.md
@@ -1,0 +1,9 @@
+---
+id: RR-MP1R
+type: review-response
+title: Type the import response struct
+finding: handlers_theme_package.go:107-113 — Returns untyped map[string]any with field name `palette`, while the parallel _settings handler uses a typed APISettingsData with `userPalette`. Different field name and untyped means future renames go uncaught. Define APIThemeImportResponse with json tags and use it; matches what the frontend already does on its side.
+severity: minor
+resolution: Added APIThemeImportResponse struct with json tags `palette` and `logoUrl,omitempty`. handleAPIThemeImport now writes the typed struct rather than a map[string]any. Tests still pass; future field renames will fail at compile time.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OMEN.md
+++ b/tickets/entities/review-responses/RR-OMEN.md
@@ -1,0 +1,9 @@
+---
+id: RR-OMEN
+type: review-response
+title: writeThemeImportError default falls to 400 silently
+finding: theme_package.go::writeThemeImportError — Switch is exhaustive on current sentinels; any new sentinel goes to 400 silently. Add a slog.Warn (or test that fails on unmapped sentinel) so misroutes are visible.
+severity: nit
+resolution: 'writeThemeImportError now exhaustively lists all sentinels in the switch with the right HTTP status mapping. The default branch (unrecognized errors) emits a slog.Warn (''theme import: unmapped parse error'') so future-added sentinels surface in logs even if they fall to the conservative 400 default.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-U2S9.md
+++ b/tickets/entities/review-responses/RR-U2S9.md
@@ -1,0 +1,9 @@
+---
+id: RR-U2S9
+type: review-response
+title: exportTheme revokes object URL before download initiates
+finding: theme.ts:71-83 — `URL.revokeObjectURL(url)` runs synchronously in `finally` immediately after `a.click()`. Modern browsers snapshot, but Safari historically dropped downloads when the URL was revoked before the browser attached the download. Defer with `setTimeout(() => URL.revokeObjectURL(url), 0)` and drop the try/finally (click can't usefully throw).
+severity: significant
+resolution: exportTheme now defers `URL.revokeObjectURL(url)` via setTimeout(...,0). Removed the try/finally (click can't usefully throw). Updated theme.test.ts to await one macrotask before asserting the revoke.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YEVY.md
+++ b/tickets/entities/review-responses/RR-YEVY.md
@@ -1,0 +1,9 @@
+---
+id: RR-YEVY
+type: review-response
+title: Reject duplicate entry names in theme zip
+finding: theme_package.go:92-106 — `entries[name] = f` silently keeps last-wins on duplicate names. A crafted zip can ship two `theme.yaml` entries (or two `logo.png`) where the manifest-iteration code sees one but the importer reads the other — the polyglot pattern. Add `if _, dup := entries[name]; dup { return nil, fmt.Errorf("zip contains duplicate entry %q", name) }` after the path-traversal check.
+severity: significant
+resolution: Added explicit duplicate-entry rejection in the zip-iteration loop (theme_package.go) plus errDuplicateEntry sentinel and TestParseThemePackage_RejectsDuplicateEntries that hand-rolls a zip with two `theme.yaml` entries to verify the rejection path.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YMSC.md
+++ b/tickets/entities/review-responses/RR-YMSC.md
@@ -1,0 +1,9 @@
+---
+id: RR-YMSC
+type: review-response
+title: Drop superstitious compressedTotal>0 guard
+finding: theme_package.go:169 — `if compressedTotal > 0` reads as defensive but no path legitimately reaches with compressedTotal==0. Drop or document.
+severity: nit
+resolution: 'Replaced the `if compressedTotal > 0` guard with explicit overflow protection: clamp compressedTotal against (1<<63)/themePackageMaxExpansion before multiplying. Comparison is now in uint64 throughout. The new comment explains the reasoning.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-WPKW.md
+++ b/tickets/entities/tickets/TKT-WPKW.md
@@ -5,7 +5,7 @@ title: 'Theme packages: export/install bundled palette + logo as .relatheme zip'
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 Bundle the existing palette + logo into a portable `.relatheme` zip so users can

--- a/tickets/entities/tickets/TKT-WPKW.md
+++ b/tickets/entities/tickets/TKT-WPKW.md
@@ -1,41 +1,43 @@
 ---
 id: TKT-WPKW
 type: ticket
-title: 'Theme packages: export/install bundled palette + logo + font as .relatheme zip'
+title: 'Theme packages: export/install bundled palette + logo as .relatheme zip'
 kind: enhancement
 priority: medium
 effort: m
-status: backlog
+status: review
 ---
 
-Bundle the existing palette + (eventual) logo + (eventual) font into a portable
-`.relatheme` zip so users can share themes between rela data-entry apps.
+Bundle the existing palette + logo into a portable `.relatheme` zip so users can
+share themes between rela data-entry apps.
 
-This is **PR 3** of the three-PR theme system split. It depends on:
+This is **PR 2** of the theme system. Depends on:
 
-- Logo support (PR 1) — adds `.rela/theme/logo.<ext>` and `/api/v1/_theme/logo` endpoints.
-- Font support (PR 2) — adds `.rela/theme/font.<ext>` and `/api/v1/_theme/font` endpoints + `@font-face` injection.
+- **Logo support** (TKT-WN7O, merged) — provides `.rela/theme/logo` storage and `/api/v1/_theme/logo` endpoints.
+- **Color palette** (FEAT-4OEJ, already in `develop`) — provides `palette.yaml` storage and `/api/v1/_palette` endpoints.
+
+Custom UI fonts are **out of scope** (the font ticket TKT-KE0C is parked
+indefinitely; the `.relatheme` format does not include a font slot).
 
 **A theme package** is a zip with extension `.relatheme` containing:
 
-- `theme.yaml` — manifest (name, version, author, palette fields, optional `logo` / `font` references)
-- `logo.<ext>` — optional, bundled by PR 1's storage
-- `font.<ext>` — optional, bundled by PR 2's storage
+- `theme.yaml` — manifest (name, version, author, palette fields, optional `logo` reference)
+- `logo.<ext>` — optional, bundled by TKT-WN7O's storage
 
-**Export flow:** From Settings, click Export — backend reads palette + logo +
-font and returns a `.relatheme` zip download.
+**Export flow:** From Settings, click Export — backend reads palette + logo and
+returns a `.relatheme` zip download.
 
 **Install flow:** From Settings, upload a `.relatheme` zip. Backend persists
-logo/font bytes (atomic, since they're binary), validates and returns the
-palette JSON. Frontend stages the palette into the existing palette editor; user
-clicks Save to persist the colors — matching the current palette UX where colors
-only persist on explicit Save.
+logo bytes (atomic, since they're binary), validates and returns the palette
+JSON. Frontend stages the palette into the existing palette editor; user clicks
+Save to persist the colors — matching the current palette UX where colors only
+persist on explicit Save.
 
 ## Acceptance criteria
 
 1. Settings page exposes Export and Install buttons in the Appearance section.
-2. Export produces a `.relatheme` zip containing `theme.yaml` plus whichever of `logo.<ext>` / `font.<ext>` are set.
-3. Install accepts a `.relatheme` zip, validates manifest, persists logo/font, and stages palette into the editor for user-confirmed Save.
+2. Export produces a `.relatheme` zip containing `theme.yaml` plus `logo.<ext>` if a logo is set.
+3. Install accepts a `.relatheme` zip, validates manifest, persists the logo (if present), and stages palette into the editor for user-confirmed Save.
 4. Invalid / corrupt theme files surface a clear toast error and leave existing settings unchanged.
-5. Theme persistence reuses existing storage patterns — palette stays in `palette.yaml`, logo/font in `.rela/theme/`, plus a new `.rela/theme/manifest.yaml` for the metadata fields (name, version, author, font.family).
-6. Custom CSS, multi-resolution rasters, multi-theme libraries, drag-and-drop, theme registries, and signing are explicitly **out of scope** for this PR (see PLAN-KZ5H).
+5. Theme persistence reuses existing storage patterns — palette stays in `palette.yaml`, logo stays at `.rela/theme/logo` + sidecar. The `theme.yaml` manifest is created at export time only and is not persisted on the receiving side outside the zip.
+6. Custom CSS, custom fonts, multi-resolution rasters, multi-theme libraries, drag-and-drop, theme registries, and signing are explicitly **out of scope** for this PR (see PLAN-KZ5H).

--- a/tickets/relations/TKT-KE0C--has-planning--PLAN-M2UZ.md
+++ b/tickets/relations/TKT-KE0C--has-planning--PLAN-M2UZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KE0C
+relation: has-planning
+to: PLAN-M2UZ
+---

--- a/tickets/relations/TKT-WPKW--depends-on--TKT-KE0C.md
+++ b/tickets/relations/TKT-WPKW--depends-on--TKT-KE0C.md
@@ -1,5 +1,0 @@
----
-from: TKT-WPKW
-relation: depends-on
-to: TKT-KE0C
----

--- a/tickets/relations/TKT-WPKW--has-implementation--IMPL-VIQW.md
+++ b/tickets/relations/TKT-WPKW--has-implementation--IMPL-VIQW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WPKW
+relation: has-implementation
+to: IMPL-VIQW
+---

--- a/tickets/relations/TKT-WPKW--has-review--REV-T61A.md
+++ b/tickets/relations/TKT-WPKW--has-review--REV-T61A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WPKW
+relation: has-review
+to: REV-T61A
+---

--- a/tickets/relations/TKT-WPKW--has-review-response--RR-0PTF.md
+++ b/tickets/relations/TKT-WPKW--has-review-response--RR-0PTF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WPKW
+relation: has-review-response
+to: RR-0PTF
+---

--- a/tickets/relations/TKT-WPKW--has-review-response--RR-5EHQ.md
+++ b/tickets/relations/TKT-WPKW--has-review-response--RR-5EHQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WPKW
+relation: has-review-response
+to: RR-5EHQ
+---

--- a/tickets/relations/TKT-WPKW--has-review-response--RR-5QTT.md
+++ b/tickets/relations/TKT-WPKW--has-review-response--RR-5QTT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WPKW
+relation: has-review-response
+to: RR-5QTT
+---

--- a/tickets/relations/TKT-WPKW--has-review-response--RR-7P3O.md
+++ b/tickets/relations/TKT-WPKW--has-review-response--RR-7P3O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WPKW
+relation: has-review-response
+to: RR-7P3O
+---

--- a/tickets/relations/TKT-WPKW--has-review-response--RR-84YM.md
+++ b/tickets/relations/TKT-WPKW--has-review-response--RR-84YM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WPKW
+relation: has-review-response
+to: RR-84YM
+---

--- a/tickets/relations/TKT-WPKW--has-review-response--RR-MP1R.md
+++ b/tickets/relations/TKT-WPKW--has-review-response--RR-MP1R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WPKW
+relation: has-review-response
+to: RR-MP1R
+---

--- a/tickets/relations/TKT-WPKW--has-review-response--RR-OMEN.md
+++ b/tickets/relations/TKT-WPKW--has-review-response--RR-OMEN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WPKW
+relation: has-review-response
+to: RR-OMEN
+---

--- a/tickets/relations/TKT-WPKW--has-review-response--RR-U2S9.md
+++ b/tickets/relations/TKT-WPKW--has-review-response--RR-U2S9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WPKW
+relation: has-review-response
+to: RR-U2S9
+---

--- a/tickets/relations/TKT-WPKW--has-review-response--RR-YEVY.md
+++ b/tickets/relations/TKT-WPKW--has-review-response--RR-YEVY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WPKW
+relation: has-review-response
+to: RR-YEVY
+---

--- a/tickets/relations/TKT-WPKW--has-review-response--RR-YMSC.md
+++ b/tickets/relations/TKT-WPKW--has-review-response--RR-YMSC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WPKW
+relation: has-review-response
+to: RR-YMSC
+---


### PR DESCRIPTION
## Summary

- PR 2 of the theme system (TKT-WPKW). Builds on the merged logo PR #672 (TKT-WN7O); custom UI fonts dropped.
- New endpoints: `GET /api/v1/_theme/export` returns a `.relatheme` zip; `POST /api/v1/_theme/import` accepts a multipart upload, persists the bundled logo, and stages the palette into the existing editor.
- New types: `ThemeManifest` in `internal/dataentryconfig/theme.go` (embeds `PaletteConfig`, adds `name` / `version` / `author` / `logo`); `APIThemeImportResponse` for the import handler's response.
- New file `internal/dataentry/theme_package.go` with a pure `parseThemePackage` helper — fully unit-testable without the HTTP layer.
- Frontend: new Theme Package card in Settings with Export + Install buttons; `useConfirm` prompt before stomping unsaved palette edits.
- 10 cranky-code-reviewer findings; all addressed (5 significant, 2 minor, 3 nit). See ticket TKT-WPKW for the audit trail.

## Defense layers on import

| Guard | What it catches |
|---|---|
| `MaxBytesReader` at 5 MiB + 16 KiB envelope | DoS via giant uploads |
| Saturating-uint64 expansion check | zip64 size-overflow zip-bombs |
| `compressedTotal` × 100 ratio cap | classic compression-ratio bombs |
| Allowlisted entry names + path-traversal rejection | cross-directory writes |
| Duplicate-entry rejection (errDuplicateEntry) | polyglot zips |
| `init()` reflection check + parseThemePackage panic recovery | yaml.v3 duplicate-key panics |
| `sniffLogoMime` re-applied to logo bytes | manifest claiming wrong format |

## Test plan

- [x] `just test` — all packages pass (75.5 % total coverage)
- [x] `just lint` — 0 issues
- [x] `just arch-lint` — clean
- [x] `npm run test:run` — 659 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeds
- [x] Manual e2e via `curl`: PUT palette + logo → export to `.relatheme` zip (verified `unzip -l`); import on a fresh state → palette returned in JSON, logo persisted, sidebar live-updates
- [x] Negative paths via curl: non-zip → 400, zip with subdirectory entry → 400 `path traversal`