### PR TITLE
feat(data-entry): resolve entity-ID code spans to titled links (TKT-747O)

### DIFF
--- a/e2e/pages/entity.page.ts
+++ b/e2e/pages/entity.page.ts
@@ -171,4 +171,27 @@ export class EntityPage extends BasePage {
       .locator(`input[type="checkbox"][data-cb-idx="${index}"]`)
       .isChecked();
   }
+
+  // --- content entity-reference helpers ---
+
+  /** Locator for an in-content link rewritten from a `\`<id>\`` code span
+   *  to a navigable entity detail link (TKT-747O). Returns the <a> element
+   *  whose href routes to the target's detail page. */
+  contentEntityRefLink(entityType: string, id: string): Locator {
+    return this.contentBody.locator(`a[href="/entity/${entityType}/${id}"]`).first();
+  }
+
+  /** Locator for an inline `<code>` element in the entity content with the
+   *  given exact text. Used in negative tests to assert a code span was
+   *  NOT rewritten into an anchor — e.g. unknown IDs or fenced blocks. */
+  contentCodeSpan(text: string): Locator {
+    return this.contentBody.locator('code', { hasText: text });
+  }
+
+  /** Click the in-content entity-reference link for `(entityType, id)` and
+   *  wait for the SPA route to settle on the target page. */
+  async clickContentEntityRef(entityType: string, id: string): Promise<void> {
+    await this.contentEntityRefLink(entityType, id).click();
+    await this.page.waitForURL(new RegExp(`/entity/${entityType}/${id}(\\?|$)`));
+  }
 }

--- a/e2e/tests/entity-refs.spec.ts
+++ b/e2e/tests/entity-refs.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from './fixtures';
+import { EntityPage } from '../pages';
+
+// Verifies the implicit entity-reference resolution that turns bare-ID code
+// spans in markdown content into in-app links (TKT-747O). The server attaches
+// a `mentions` map to the view response and the SPA markdown renderer
+// rewrites matching `<code>` nodes to `<a>` nodes with the target's title.
+test.describe('Entity reference resolution', () => {
+  let originId: string | null = null;
+  let targetId: string | null = null;
+
+  test.beforeEach(async ({ api }) => {
+    const target = await api.createEntity('features', {
+      properties: {
+        title: 'Resolved Target',
+        description: 'Target referenced by code-span ID from another entity',
+        status: 'draft',
+        priority: 'medium',
+      },
+    });
+    targetId = target.id;
+
+    const origin = await api.createEntity('features', {
+      properties: {
+        title: 'Origin With Reference',
+        description: 'Content references the target via code span',
+        status: 'draft',
+        priority: 'medium',
+      },
+      // Body content carries a bare-ID code span; the renderer must rewrite
+      // it to an <a> linking to the target's detail page.
+      content: `see \`${target.id}\` for the dependency`,
+    });
+    originId = origin.id;
+  });
+
+  test.afterEach(async ({ api }) => {
+    if (originId) {
+      await api.deleteEntity('features', originId).catch(() => {});
+      originId = null;
+    }
+    if (targetId) {
+      await api.deleteEntity('features', targetId).catch(() => {});
+      targetId = null;
+    }
+  });
+
+  test('renders a known-ID code span as a titled in-app link', async ({ appPage }) => {
+    const entity = new EntityPage(appPage);
+    await entity.navigateToEntity('feature', originId!);
+
+    const link = entity.contentEntityRefLink('feature', targetId!);
+    await expect(link).toBeVisible();
+    await expect(link).toHaveText('Resolved Target');
+    // Negative: a known-ID code span must NOT remain as <code> in the
+    // rendered output (the rewrite either fires or it doesn't —
+    // partial rewrites are not allowed).
+    await expect(entity.contentCodeSpan(targetId!)).toHaveCount(0);
+  });
+
+  test('clicking the rendered link navigates to the target entity', async ({ appPage }) => {
+    const entity = new EntityPage(appPage);
+    await entity.navigateToEntity('feature', originId!);
+
+    await entity.clickContentEntityRef('feature', targetId!);
+    // The target's title appears on the destination page.
+    expect(await entity.containsText('Resolved Target')).toBeTruthy();
+  });
+
+  test('unknown-ID code spans remain as <code> (no link)', async ({ api, appPage }) => {
+    // A separate entity whose content references an ID that doesn't
+    // resolve. The renderer must leave the code span untouched.
+    const unknownRefOwner = await api.createEntity('features', {
+      properties: {
+        title: 'Unknown Reference Owner',
+        description: 'Code span references a nonexistent ID',
+        status: 'draft',
+        priority: 'medium',
+      },
+      content: 'see `FEAT-DOES-NOT-EXIST` for a non-resolution',
+    });
+
+    try {
+      const entity = new EntityPage(appPage);
+      await entity.navigateToEntity('feature', unknownRefOwner.id);
+      // The code span is rendered as <code>...</code>, not as an <a>.
+      await expect(entity.contentCodeSpan('FEAT-DOES-NOT-EXIST')).toHaveCount(1);
+      await expect(
+        entity.contentEntityRefLink('feature', 'FEAT-DOES-NOT-EXIST'),
+      ).toHaveCount(0);
+    } finally {
+      await api.deleteEntity('features', unknownRefOwner.id).catch(() => {});
+    }
+  });
+
+  test('IDs inside fenced code blocks are not linkified', async ({ api, appPage }) => {
+    // Even a known ID, when it appears inside a fenced code block, must
+    // stay as code — the resolver only fires on inline code spans.
+    const fencedOwner = await api.createEntity('features', {
+      properties: {
+        title: 'Fenced Reference Owner',
+        description: 'Known ID inside a fenced code block',
+        status: 'draft',
+        priority: 'medium',
+      },
+      content: `prose\n\n\`\`\`\n${targetId}\n\`\`\`\n`,
+    });
+
+    try {
+      const entity = new EntityPage(appPage);
+      await entity.navigateToEntity('feature', fencedOwner.id);
+      // Fenced blocks render as <pre><code>; the rewrite must not fire.
+      await expect(
+        entity.contentEntityRefLink('feature', targetId!),
+      ).toHaveCount(0);
+    } finally {
+      await api.deleteEntity('features', fencedOwner.id).catch(() => {});
+    }
+  });
+});

--- a/e2e/tests/entity-refs.spec.ts
+++ b/e2e/tests/entity-refs.spec.ts
@@ -63,8 +63,10 @@ test.describe('Entity reference resolution', () => {
     await entity.navigateToEntity('feature', originId!);
 
     await entity.clickContentEntityRef('feature', targetId!);
-    // The target's title appears on the destination page.
-    expect(await entity.containsText('Resolved Target')).toBeTruthy();
+    // Wait for the destination page to finish hydrating before asserting
+    // on its content — the SPA transitions in two phases (route change,
+    // then loadView), and the heading isn't visible until the second.
+    await entity.expectHeadingText('Resolved Target');
   });
 
   test('unknown-ID code spans remain as <code> (no link)', async ({ api, appPage }) => {

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -88,7 +88,7 @@ export interface PaginatedResponse<T = EntityResponse> {
 }
 
 export interface ApiHelpers {
-  createEntity(plural: string, data: { properties: Record<string, unknown>; relations?: Record<string, string[]>; id?: string; prefix?: string }): Promise<EntityResponse>;
+  createEntity(plural: string, data: { properties: Record<string, unknown>; content?: string; relations?: Record<string, string[]>; id?: string; prefix?: string }): Promise<EntityResponse>;
   getEntity(plural: string, id: string): Promise<EntityResponse>;
   updateEntity(plural: string, id: string, properties: Record<string, unknown>): Promise<EntityResponse>;
   deleteEntity(plural: string, id: string): Promise<void>;

--- a/frontend/src/api/views.ts
+++ b/frontend/src/api/views.ts
@@ -101,10 +101,30 @@ export interface ViewSection {
   linkInfo?: ViewLinkInfo
 }
 
+// Mention is the resolved target of an entity-ID code span found inside
+// any markdown body the response carries (entry content + section
+// content). Mirrors the server-side `Mention` Go struct (TKT-747O); the
+// SPA's `renderMarkdown` consumes this map to rewrite bare-ID code spans
+// into titled in-app links. `inaccessible` flags targets whose display
+// title is unreadable (e.g. git-crypt encrypted) so the renderer can
+// show a lock affordance.
+//
+// `inaccessible_reason` carries the matching `entity.InaccessibleReason`
+// value as a bare string. Today only `"git-crypt"` is produced; the SPA
+// treats unknown reasons as opaque and falls back to a generic tooltip,
+// so adding new reasons server-side never breaks the client.
+export interface Mention {
+  type: string
+  title: string
+  inaccessible?: boolean
+  inaccessible_reason?: string
+}
+
 // Full view API response
 export interface ViewResponse {
   entry: Entity
   sections: ViewSection[]
+  mentions?: Record<string, Mention>
 }
 
 // Fetch executed view data for an entity. The backend looks up the

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -12,7 +12,12 @@ import { getEditFormId } from '@/types'
 import { entityDetailHref } from '@/utils/entityRoute'
 import { isInputFocused } from '@/utils/dom'
 import { isAnyModalOpen } from '@/composables/modalStack'
-import { renderMarkdown, renderMermaidDiagrams, getCheckboxStats } from '@/utils/markdown'
+import {
+  renderMarkdown,
+  renderMermaidDiagrams,
+  getCheckboxStats,
+  type EntityRefResolver,
+} from '@/utils/markdown'
 import BackButton from '@/components/common/BackButton.vue'
 import Badge from '@/components/common/Badge.vue'
 import PropertyDisplay from '@/components/common/PropertyDisplay.vue'
@@ -101,8 +106,29 @@ const checkboxStats = computed(() => {
   return c ? getCheckboxStats(c) : null
 })
 
+// refResolver wires the server-supplied mentions map into the markdown
+// renderer so bare-ID code spans become titled in-app links. Null when
+// the response carries no mentions; renderMarkdown then behaves exactly
+// as before (no resolver, no rewrite).
+const refResolver = computed<EntityRefResolver | undefined>(() => {
+  const mentions = viewData.value?.mentions
+  if (!mentions) return undefined
+  return (id) => {
+    const m = mentions[id]
+    if (!m) return null
+    return {
+      type: m.type,
+      title: m.title,
+      inaccessible: m.inaccessible,
+      inaccessibleReason: m.inaccessible_reason,
+    }
+  }
+})
+
 const renderedEntryContent = computed(() =>
-  entryContentSection.value ? renderMarkdown(entryContentSection.value.content || '') : '',
+  entryContentSection.value
+    ? renderMarkdown(entryContentSection.value.content || '', refResolver.value)
+    : '',
 )
 
 watch(renderedEntryContent, async () => {
@@ -509,7 +535,7 @@ watch(
 
           <!-- Other content sections (e.g. content cards from a configured view). -->
           <div v-else-if="section.display === 'content' && section.hasContent" class="content-block">
-            <div class="markdown-content" v-html="renderMarkdown(section.content || '')"/>
+            <div class="markdown-content" v-html="renderMarkdown(section.content || '', refResolver)"/>
           </div>
 
           <div v-else-if="section.display === 'content' && section.entities?.length" class="content-cards">
@@ -524,7 +550,7 @@ watch(
                 <span class="entity-title">{{ ent.title }}</span>
                 <span class="entity-id">{{ ent.id }}</span>
               </header>
-              <div v-if="ent.hasContent" class="markdown-content" v-html="renderMarkdown(ent.content || '')"/>
+              <div v-if="ent.hasContent" class="markdown-content" v-html="renderMarkdown(ent.content || '', refResolver)"/>
             </article>
           </div>
 
@@ -1053,6 +1079,18 @@ watch(
   border-radius: 4px;
   font-size: 13px;
   color: var(--text-color);
+}
+
+.content-body :deep(a),
+.markdown-content :deep(a) {
+  color: var(--accent-color);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.content-body :deep(a:hover),
+.markdown-content :deep(a:hover) {
+  text-decoration-thickness: 2px;
 }
 
 .content-body :deep(input[type="checkbox"]) {

--- a/frontend/src/utils/markdown.test.ts
+++ b/frontend/src/utils/markdown.test.ts
@@ -87,6 +87,216 @@ describe('markdown', () => {
       expect(result).toContain('<strong>')
       expect(result).toContain('<em>')
     })
+
+    describe('refResolver (entity-ID code spans)', () => {
+      // A reusable resolver covering the seed below; each test passes only
+      // the IDs it expects to hit, mirroring the server-side mentions map.
+      function makeResolver(map: Record<string, { type: string; title: string; inaccessible?: boolean; inaccessibleReason?: string }>) {
+        return (id: string) => map[id] ?? null
+      }
+
+      it('rewrites a known-ID code span into a titled link', () => {
+        const resolver = makeResolver({
+          'TKT-LXYHQ': { type: 'ticket', title: 'Resolve refs' },
+        })
+        const result = renderMarkdown('see `TKT-LXYHQ` for details', resolver)
+        expect(result).toContain('href="/entity/ticket/TKT-LXYHQ"')
+        expect(result).toContain('Resolve refs')
+        // The code span should be gone (collapsed into the link).
+        expect(result).not.toMatch(/<code>TKT-LXYHQ<\/code>/)
+      })
+
+      it('rewrites a manual-ID code span into a titled link', () => {
+        const resolver = makeResolver({
+          'data-entry-ui': { type: 'concept', title: 'Data Entry Web UI' },
+        })
+        const result = renderMarkdown('covered by `data-entry-ui`', resolver)
+        expect(result).toContain('href="/entity/concept/data-entry-ui"')
+        expect(result).toContain('Data Entry Web UI')
+      })
+
+      it('leaves unknown-ID code spans as <code>', () => {
+        const resolver = makeResolver({})
+        const result = renderMarkdown('`TKT-NOPE` is unknown', resolver)
+        expect(result).toContain('<code>TKT-NOPE</code>')
+        expect(result).not.toContain('href=')
+      })
+
+      it('does not rewrite multi-token code spans (exact-match only)', () => {
+        const resolver = makeResolver({
+          'TKT-LXYHQ': { type: 'ticket', title: 'Resolve refs' },
+        })
+        const result = renderMarkdown('`TKT-LXYHQ and FEAT-010`', resolver)
+        expect(result).toContain('<code>TKT-LXYHQ and FEAT-010</code>')
+        expect(result).not.toContain('href=')
+      })
+
+      it('does not rewrite IDs inside fenced code blocks', () => {
+        const resolver = makeResolver({
+          'TKT-LXYHQ': { type: 'ticket', title: 'Resolve refs' },
+        })
+        const result = renderMarkdown('```\nTKT-LXYHQ on a code line\n```', resolver)
+        expect(result).not.toContain('href="/entity/ticket/TKT-LXYHQ"')
+      })
+
+      it('does not rewrite IDs inside existing link text', () => {
+        const resolver = makeResolver({
+          'TKT-LXYHQ': { type: 'ticket', title: 'Resolve refs' },
+        })
+        const result = renderMarkdown('see [TKT-LXYHQ](https://example.com)', resolver)
+        expect(result).toContain('href="https://example.com"')
+        expect(result).not.toContain('href="/entity/ticket/TKT-LXYHQ"')
+      })
+
+      it('renders dangerous titles as escaped text without breaking the link', () => {
+        const resolver = makeResolver({
+          'TKT-EVIL': { type: 'ticket', title: '<img src=x onerror=alert(1)>' },
+        })
+        const result = renderMarkdown('see `TKT-EVIL`', resolver)
+        // Parse the result to assert against actual DOM structure rather
+        // than substring-matching escaped-text payloads.
+        const doc = new DOMParser().parseFromString(`<div>${result}</div>`, 'text/html')
+        // No live <img> element was injected — only an <a> with text.
+        expect(doc.querySelector('img')).toBeNull()
+        const a = doc.querySelector('a[href="/entity/ticket/TKT-EVIL"]')
+        expect(a).not.toBeNull()
+        // The payload survives as text content, never as live markup.
+        expect(a?.textContent).toBe('<img src=x onerror=alert(1)>')
+        // Defensive: the link node itself carries no event handlers.
+        expect(a?.getAttributeNames().some((n) => n.startsWith('on'))).toBe(false)
+      })
+
+      it('renders inaccessible targets with a lock affordance and tooltip', () => {
+        const resolver = makeResolver({
+          'TKT-LOCKED': {
+            type: 'ticket',
+            title: '',
+            inaccessible: true,
+            inaccessibleReason: 'git-crypt',
+          },
+        })
+        const result = renderMarkdown('locked: `TKT-LOCKED`', resolver)
+        expect(result).toContain('href="/entity/ticket/TKT-LOCKED"')
+        // Lock emoji rendered as link text alongside the ID (the title
+        // was empty, so the renderer falls back to the bare ID).
+        expect(result).toContain('TKT-LOCKED 🔒')
+        // Tooltip mirrors PropertyDisplay's inaccessibleTooltip copy.
+        expect(result).toContain('title="git-crypt encrypted (run `git-crypt unlock` to read)"')
+      })
+
+      it('keeps the readable title alongside the lock when one is supplied', () => {
+        // Server may report inaccessible=true while still being able to
+        // produce a display title (e.g. the title property is readable
+        // but the body is encrypted). The renderer should keep the title
+        // as link text and only add the lock affordance afterwards.
+        const resolver = makeResolver({
+          'TKT-PARTIAL': {
+            type: 'ticket',
+            title: 'Encrypted Body',
+            inaccessible: true,
+            inaccessibleReason: 'git-crypt',
+          },
+        })
+        const result = renderMarkdown('locked: `TKT-PARTIAL`', resolver)
+        expect(result).toContain('href="/entity/ticket/TKT-PARTIAL"')
+        expect(result).toContain('Encrypted Body 🔒')
+        // The bare ID is NOT the visible text in this case.
+        expect(result).not.toContain('>TKT-PARTIAL 🔒<')
+      })
+
+      it('falls back to "inaccessible" tooltip when reason is missing', () => {
+        const resolver = makeResolver({
+          'TKT-OPAQUE': { type: 'ticket', title: '', inaccessible: true },
+        })
+        const result = renderMarkdown('`TKT-OPAQUE`', resolver)
+        expect(result).toContain('title="inaccessible"')
+      })
+
+      it('produces only same-origin entity hrefs (no javascript: or data: URLs)', () => {
+        // The href is derived entirely from server-validated (type, id)
+        // pairs — there is no path for a resolver to inject a foreign
+        // URL scheme. This test guards that invariant against future
+        // refactors that might widen the rewriter's input surface.
+        const resolver = makeResolver({
+          // Pathological type strings would still produce a same-origin
+          // path; DOMPurify sanitizes the resulting <a> anyway.
+          'TKT-OK': { type: 'ticket', title: 'Fine' },
+        })
+        const result = renderMarkdown('`TKT-OK`', resolver)
+        const doc = new DOMParser().parseFromString(`<div>${result}</div>`, 'text/html')
+        const a = doc.querySelector('a')
+        expect(a).not.toBeNull()
+        const href = a?.getAttribute('href') ?? ''
+        // Same-origin path only.
+        expect(href.startsWith('/entity/')).toBe(true)
+        expect(href).not.toMatch(/^javascript:/i)
+        expect(href).not.toMatch(/^data:/i)
+        // No on* event handlers on the link.
+        const handlerAttrs = a?.getAttributeNames().filter((n) => n.startsWith('on')) ?? []
+        expect(handlerAttrs).toEqual([])
+      })
+
+      it('cannot inject script via a malicious inaccessible-reason tooltip', () => {
+        // Inaccessible tooltip is built from the reason string. Verify a
+        // payload in the reason cannot break out of the attribute and
+        // inject markup — the worst case is a stripped `title` attribute
+        // (DOMPurify's choice), which is still safe.
+        const resolver = makeResolver({
+          'TKT-EVIL-TIP': {
+            type: 'ticket',
+            title: '',
+            inaccessible: true,
+            inaccessibleReason: 'x"><script>alert(1)</script>',
+          },
+        })
+        const result = renderMarkdown('`TKT-EVIL-TIP`', resolver)
+        const doc = new DOMParser().parseFromString(`<div>${result}</div>`, 'text/html')
+        // No script element survived.
+        expect(doc.querySelector('script')).toBeNull()
+        // The link is still rendered safely with the lock affordance.
+        const a = doc.querySelector('a[href="/entity/ticket/TKT-EVIL-TIP"]')
+        expect(a).not.toBeNull()
+        expect(a?.textContent).toContain('🔒')
+      })
+
+      it('swallows resolver exceptions and leaves the code span intact', () => {
+        const resolver = () => {
+          throw new Error('boom')
+        }
+        const result = renderMarkdown('`TKT-WHATEVER`', resolver)
+        expect(result).toContain('<code>TKT-WHATEVER</code>')
+      })
+
+      it('handles mixed known + unknown spans in the same paragraph', () => {
+        const resolver = makeResolver({
+          'TKT-LXYHQ': { type: 'ticket', title: 'Resolve refs' },
+        })
+        const result = renderMarkdown(
+          '`TKT-LXYHQ` is real, `TKT-NOPE` is not',
+          resolver,
+        )
+        expect(result).toContain('href="/entity/ticket/TKT-LXYHQ"')
+        expect(result).toContain('<code>TKT-NOPE</code>')
+      })
+
+      it('behaves like today when no resolver is supplied', () => {
+        const result = renderMarkdown('see `TKT-LXYHQ`')
+        expect(result).toContain('<code>TKT-LXYHQ</code>')
+        expect(result).not.toContain('href=')
+      })
+
+      it('rewrites a self-reference like any other entity link', () => {
+        // The renderer is symmetric: self-references resolve through the
+        // same path. The destination route is a no-op navigation but the
+        // affordance is harmless and matches the Lua-side semantics.
+        const resolver = makeResolver({
+          'TKT-SELF': { type: 'ticket', title: 'Mirror' },
+        })
+        const result = renderMarkdown('this is `TKT-SELF`', resolver)
+        expect(result).toContain('href="/entity/ticket/TKT-SELF"')
+        expect(result).toContain('Mirror')
+      })
+    })
   })
 
   describe('getCheckboxStats', () => {

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -1,4 +1,4 @@
-import { marked } from 'marked'
+import { marked, type Tokens } from 'marked'
 import mermaid from 'mermaid'
 import DOMPurify from 'dompurify'
 
@@ -13,16 +13,42 @@ mermaid.initialize({
 let mermaidCounter = 0
 
 /**
+ * Resolution result for an entity-ID code span. Mirrors the server-side
+ * `Mention` shape returned in `ViewResponse.mentions` (TKT-747O): the
+ * server walks each rendered markdown blob, resolves bare-ID code spans
+ * against the store, and surfaces the resulting `{type, title}` map so
+ * the renderer can rewrite the code spans into in-app links without a
+ * second round-trip.
+ */
+export interface EntityRef {
+  type: string
+  title: string
+  inaccessible?: boolean
+  inaccessibleReason?: string
+}
+
+export type EntityRefResolver = (id: string) => EntityRef | null
+
+/**
  * Render markdown to HTML with GFM support.
  * Returns sanitized HTML string (mermaid diagrams are placeholders).
  * Checkboxes get data-cb-idx attributes for toggle support.
+ *
+ * When a `refResolver` is supplied, inline code spans whose entire text
+ * matches an entity ID known to the resolver are rewritten as in-app
+ * links titled with the target entity's title. Matches the Lua-side
+ * semantics from TKT-LXYHQ exactly: only bare-content code spans are
+ * touched; code blocks, link text, and multi-token spans are left
+ * alone. Inaccessible targets (e.g. git-crypt encrypted) render as
+ * `<a>ID 🔒</a>` with a tooltip mirroring `PropertyDisplay.vue`.
  */
-export function renderMarkdown(content: string): string {
+export function renderMarkdown(content: string, refResolver?: EntityRefResolver): string {
   if (!content) return ''
 
   const rawHtml = marked.parse(content, {
     gfm: true,
     breaks: true,
+    walkTokens: refResolver ? (token) => rewriteEntityRefToken(token, refResolver) : undefined,
   }) as string
 
   // Add data-cb-idx to checkboxes for toggle support
@@ -36,6 +62,70 @@ export function renderMarkdown(content: string): string {
   return DOMPurify.sanitize(htmlWithCbIdx, {
     ADD_ATTR: ['data-cb-idx'],
   })
+}
+
+// rewriteEntityRefToken mutates a `codespan` token in place into a `link`
+// token when its text matches a resolver hit. Token-level rewriting keeps
+// the eventual HTML escaping under marked's control: link text flows
+// through marked's text-renderer (which HTML-escapes) so a malicious entity
+// title cannot break out of the `<a>` element.
+function rewriteEntityRefToken(token: unknown, resolve: EntityRefResolver): void {
+  if (!isCodespanToken(token)) return
+  let hit: EntityRef | null
+  try {
+    hit = resolve(token.text)
+  } catch {
+    // Defensive: a resolver bug must never break markdown rendering.
+    return
+  }
+  // Require a type so we can build a stable URL. Title may be empty for
+  // an inaccessible target whose display source is unreadable; in that
+  // case we fall back to using the ID as link text. For everything else
+  // a missing title is the resolver telling us "I don't know enough to
+  // present this", and we leave the code span alone.
+  if (!hit || !hit.type) return
+  const visibleTitle = hit.title || (hit.inaccessible ? token.text : '')
+  if (!visibleTitle) return
+
+  const href = `/entity/${hit.type}/${token.text}`
+  // Inaccessible targets get a trailing lock affordance; keep the
+  // readable title when one was supplied (the lock only conveys "the
+  // underlying file is encrypted") and only fall back to the bare ID
+  // when the title would otherwise be empty.
+  const linkText = hit.inaccessible ? `${visibleTitle} 🔒` : visibleTitle
+  const tokenTitle = hit.inaccessible ? inaccessibleTooltipFor(hit.inaccessibleReason) : null
+
+  const rewritten = token as unknown as Tokens.Link & { raw?: string }
+  rewritten.type = 'link'
+  rewritten.href = href
+  rewritten.title = tokenTitle
+  rewritten.text = linkText
+  rewritten.tokens = [{ type: 'text', raw: linkText, text: linkText } as Tokens.Text]
+  // Clear the original codespan `raw` (the backticked source) so any
+  // downstream consumer that re-emits markdown sees the link shape, not
+  // a stale code-span literal. Marked's HTML renderer doesn't read
+  // `raw` on links, but defensive consistency is cheap.
+  rewritten.raw = `[${linkText}](${href})`
+}
+
+function isCodespanToken(token: unknown): token is Tokens.Codespan {
+  return (
+    typeof token === 'object' &&
+    token !== null &&
+    (token as { type?: unknown }).type === 'codespan' &&
+    typeof (token as { text?: unknown }).text === 'string'
+  )
+}
+
+// inaccessibleTooltipFor mirrors PropertyDisplay.vue's inaccessibleTooltip
+// helper so users see consistent copy whether the lock indicator appears
+// on a property or on an entity-ref link.
+function inaccessibleTooltipFor(reason: string | undefined): string {
+  if (reason === 'git-crypt') {
+    return 'git-crypt encrypted (run `git-crypt unlock` to read)'
+  }
+  if (reason) return `inaccessible (${reason})`
+  return 'inaccessible'
 }
 
 /**

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -2426,9 +2426,22 @@ func (a *App) handleV1OpenAPI(w http.ResponseWriter, r *http.Request) {
 // --- Views API ---
 
 // V1ViewResponse contains the executed view data.
+//
+// Mentions carries the implicit-relation set discovered by scanning the
+// entry and section markdown contents for bare-content entity-ID code
+// spans (see collectMentions). The SPA's markdown renderer consumes this
+// map to rewrite those code spans into titled in-app links. Mirrors the
+// Lua-side `rela.md.entity_refs` shape (TKT-LXYHQ) for SPA consumers
+// that don't go through the Lua document path.
+//
+// Wire stability: `mentions` is part of the public v1 API. The set of
+// `inaccessible_reason` values may grow as new locking mechanisms are
+// added (today: `git-crypt`); clients must treat unknown reasons as
+// opaque rather than enumerating them.
 type V1ViewResponse struct {
-	Entry    V1Entity        `json:"entry"`
-	Sections []V1ViewSection `json:"sections"`
+	Entry    V1Entity           `json:"entry"`
+	Sections []V1ViewSection    `json:"sections"`
+	Mentions map[string]Mention `json:"mentions,omitempty"`
 }
 
 // V1ViewSection represents a section with resolved data.
@@ -2695,5 +2708,39 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 		resp.Sections = append(resp.Sections, v1Sec)
 	}
 
+	resp.Mentions = collectMentions(r.Context(), a.store, s.Meta, viewContentBlobs(result.Entry, sections)...)
+
 	writeV1JSON(w, http.StatusOK, resp)
+}
+
+// viewContentBlobs gathers every markdown body that will be rendered by
+// the SPA for a single view response: the entry's content, every section's
+// own content, and every entity card's content (sections with display
+// "content"/"cards" surface related entities, each carrying its own
+// `Content` markdown that EntityDetail.vue renders with the same
+// `refResolver`). Used to scope the mentions scan to text the user
+// actually sees on this screen.
+func viewContentBlobs(entry *entityPkg.Entity, sections []SectionData) []string {
+	blobs := make([]string, 0, 1+len(sections))
+	if entry != nil && entry.Content != "" {
+		blobs = append(blobs, entry.Content)
+	}
+	for _, sec := range sections {
+		if sec.HasContent && sec.Content != "" {
+			blobs = append(blobs, sec.Content)
+		}
+		for _, ent := range sec.Entities {
+			if ent.HasContent && ent.Content != "" {
+				blobs = append(blobs, ent.Content)
+			}
+		}
+		for _, grp := range sec.Groups {
+			for _, ent := range grp.Entities {
+				if ent.HasContent && ent.Content != "" {
+					blobs = append(blobs, ent.Content)
+				}
+			}
+		}
+	}
+	return blobs
 }

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -3900,3 +3900,70 @@ func TestV1Views_MethodNotAllowed(t *testing.T) {
 		t.Errorf("status: want 405, got %d", rec.Code)
 	}
 }
+
+func TestV1Views_MentionsPopulated(t *testing.T) {
+	app := newTestAppV1(t)
+	target := &entity.Entity{
+		ID:   "TKT-002",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title":  "Target Ticket",
+			"status": "open",
+		},
+	}
+	seedEntity(app, target)
+	seedEntity(app, &entity.Entity{
+		ID:   "TKT-001",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title":  "Origin Ticket",
+			"status": "open",
+		},
+		Content: "see `TKT-002` for the dependency; `TKT-NOPE` is unknown",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_views/ticket/TKT-001", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1Views(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	var resp V1ViewResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got := resp.Mentions["TKT-002"]; got.Type != target.Type || got.Title != target.Title() {
+		t.Errorf("mentions[TKT-002]: want {%q,%q}, got %+v", target.Type, target.Title(), got)
+	}
+	if _, ok := resp.Mentions["TKT-NOPE"]; ok {
+		t.Errorf("mentions must not include unknown ID TKT-NOPE; got %+v", resp.Mentions)
+	}
+}
+
+func TestV1Views_MentionsAbsentWhenNoRefs(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{
+		ID:   "TKT-001",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title":  "Plain Ticket",
+			"status": "open",
+		},
+		Content: "no entity references here",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_views/ticket/TKT-001", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1Views(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", rec.Code)
+	}
+	// Assert the JSON omits the mentions key entirely; the SPA treats a
+	// missing key the same as an empty map, but `omitempty` is the
+	// documented wire contract.
+	if strings.Contains(rec.Body.String(), `"mentions"`) {
+		t.Errorf("response must omit mentions when none collected; body: %s", rec.Body.String())
+	}
+}

--- a/internal/dataentry/mentions.go
+++ b/internal/dataentry/mentions.go
@@ -1,0 +1,208 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/text"
+
+	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// Mention is the resolved target of an entity-ID code span found in
+// markdown content. Mirrors the Lua-side `rela.md.entity_refs`/`resolve_refs`
+// semantics (TKT-LXYHQ): only bare-content code spans whose entire text is
+// an entity ID are collected; the data-entry SPA uses this map to rewrite
+// those code spans into titled in-app links.
+//
+// `Inaccessible` is true when the entity's display title is unreadable
+// (e.g. the file is git-crypt encrypted) — the SPA renders such links
+// with a lock affordance using the same tooltip copy as inaccessible
+// properties. `InaccessibleReason` carries the matching
+// `entity.InaccessibleReason` value as a string so the wire shape stays
+// stable across reason-enum additions.
+type Mention struct {
+	Type               string `json:"type"`
+	Title              string `json:"title"`
+	Inaccessible       bool   `json:"inaccessible,omitempty"`
+	InaccessibleReason string `json:"inaccessible_reason,omitempty"`
+}
+
+// collectMentions scans the supplied markdown blobs for inline code spans
+// whose entire content is an entity ID known to the store, and returns a
+// deduplicated map keyed by ID. Self-references (the viewer's own ID) are
+// included — the renderer treats them like any other reference and the SPA
+// route handles them as no-op navigation. Returns nil when no mentions
+// are found so callers can rely on JSON `omitempty` for empty maps.
+//
+// Store failures other than ErrNotFound are logged and skipped: a flaky
+// per-ID lookup must not break the whole view-fetch response. The
+// fall-through degrades to "code span stays as <code>" which matches the
+// unknown-ID UX. Context cancellation is honored — callers (HTTP handlers)
+// have already bound the request context and abandoning further lookups
+// after the client disconnects saves wasted work.
+func collectMentions(ctx context.Context, s store.EntityReader, meta *metamodel.Metamodel, contents ...string) map[string]Mention {
+	candidates := scanCodeSpanCandidates(contents...)
+	if len(candidates) == 0 {
+		return nil
+	}
+	out := make(map[string]Mention, len(candidates))
+	for id := range candidates {
+		if err := ctx.Err(); err != nil {
+			if len(out) == 0 {
+				return nil
+			}
+			return out
+		}
+		ent, err := s.GetEntity(ctx, id)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				continue
+			}
+			slog.WarnContext(ctx, "mentions: store lookup failed",
+				"id", id, "err", err)
+			continue
+		}
+		out[id] = buildMention(ent, meta)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// buildMention turns a resolved entity into a wire-shape Mention. Title
+// uses the metamodel's DisplayTitle so entity types whose primary
+// property is something other than `title` (e.g. concept's `name`)
+// still produce readable link text. Inaccessibility flips on only when
+// the display-title source is itself unreadable — a partial lock on an
+// unrelated property must not turn a link into a lock affordance.
+func buildMention(e *entityPkg.Entity, meta *metamodel.Metamodel) Mention {
+	m := Mention{Type: e.Type}
+	if meta != nil {
+		m.Title = meta.DisplayTitle(e.ID, e.Type, e.Properties)
+	} else {
+		m.Title = e.Title()
+	}
+
+	primary := displayProperty(meta, e.Type)
+	if reason, locked := lockedReasonFor(e, primary); locked {
+		m.Inaccessible = true
+		m.InaccessibleReason = reason
+	}
+	return m
+}
+
+// displayProperty returns the property name whose value backs the display
+// title for this entity type. Empty when the metamodel has no entry for
+// the type or no primary property is configured — falls back to the ID
+// being the source of truth, in which case the entity can't really be
+// "locked behind its title."
+func displayProperty(meta *metamodel.Metamodel, entityType string) string {
+	if meta == nil {
+		return "title"
+	}
+	def, ok := meta.GetEntityDef(entityType)
+	if !ok {
+		return ""
+	}
+	return def.GetPrimaryProperty()
+}
+
+// lockedReasonFor reports whether the entity's display title is
+// unreadable (and the matching reason). The entity's whole content body
+// being inaccessible (`InaccessibleFieldContent`) counts too, because the
+// lookup of the title property may have failed for the same reason —
+// markdown loaders produce a `content` inaccessible field for the whole
+// file when git-crypt blocks the read. A property unrelated to the title
+// being locked does not affect the link.
+func lockedReasonFor(e *entityPkg.Entity, displayProp string) (string, bool) {
+	if e == nil {
+		return "", false
+	}
+	for _, f := range e.Inaccessible {
+		if f.Name == displayProp || f.Name == entityPkg.InaccessibleFieldContent {
+			return string(f.Reason), true
+		}
+	}
+	return "", false
+}
+
+// scanCodeSpanCandidates parses each markdown blob and returns the set of
+// distinct strings that appear as the entire text of an inline code span.
+// Code blocks (fenced and indented) are walked over by goldmark as
+// FencedCodeBlock / CodeBlock — never CodeSpan — so they are naturally
+// excluded.
+func scanCodeSpanCandidates(contents ...string) map[string]struct{} {
+	if len(contents) == 0 {
+		return nil
+	}
+	candidates := make(map[string]struct{})
+	parser := mentionsMarkdown.Parser()
+	for _, src := range contents {
+		if src == "" {
+			continue
+		}
+		source := []byte(src)
+		doc := parser.Parse(text.NewReader(source))
+		_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+			if !entering {
+				return ast.WalkContinue, nil
+			}
+			cs, ok := n.(*ast.CodeSpan)
+			if !ok {
+				return ast.WalkContinue, nil
+			}
+			text, complete := codeSpanText(cs, source)
+			if !complete {
+				return ast.WalkSkipChildren, nil
+			}
+			candidates[text] = struct{}{}
+			return ast.WalkSkipChildren, nil
+		})
+	}
+	delete(candidates, "")
+	return candidates
+}
+
+// codeSpanText concatenates the literal text segments inside a code span.
+// goldmark stores the content as one or more `*ast.Text` children whose
+// `Segment` slices the source bytes. Returns complete=false (and an
+// empty string) when the span contains any child that isn't a plain
+// text segment, so we never silently match a partial reconstruction
+// against an entity ID.
+func codeSpanText(cs *ast.CodeSpan, source []byte) (string, bool) {
+	var b []byte
+	for c := cs.FirstChild(); c != nil; c = c.NextSibling() {
+		t, ok := c.(*ast.Text)
+		if !ok {
+			return "", false
+		}
+		b = append(b, t.Segment.Value(source)...)
+	}
+	return string(b), true
+}
+
+// mentionsMarkdown is a goldmark instance used solely for AST walking.
+// Configured with the same GFM extension set as the document renderer
+// (internal/dataentry/document.go) so the parse matches what the SPA
+// will eventually render — in particular, table cell inlines (which GFM
+// enables) yield CodeSpan nodes we expect to scan.
+//
+// goldmark.Markdown is safe for concurrent use across goroutines: the
+// instance is configuration-only and each Parse call constructs its own
+// parser state from the source.
+var mentionsMarkdown = goldmark.New(
+	goldmark.WithExtensions(
+		extension.GFM,
+		extension.Table,
+		extension.Strikethrough,
+		extension.TaskList,
+	),
+)

--- a/internal/dataentry/mentions_test.go
+++ b/internal/dataentry/mentions_test.go
@@ -1,0 +1,364 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"sync"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+func TestCollectMentions(t *testing.T) {
+	t.Parallel()
+
+	seed := []*entity.Entity{
+		mustEntity("TKT-LXYHQ", "ticket", "Resolve entity-ID references"),
+		mustEntity("FEAT-010", "feature", "Use goldmark for markdown rendering"),
+		mustEntityNamed("data-entry-ui", "concept", "Data Entry Web UI"),
+		// Locked entity whose content (and therefore display title) is
+		// unreadable — link must render with the inaccessible affordance.
+		lockedEntity("TKT-LOCKED", "ticket", entity.InaccessibleReasonGitCrypt),
+		// Locked-but-readable: a property OTHER than the display source
+		// (`status`) is locked. The display title is still readable, so
+		// the resulting mention must NOT carry the inaccessible flag.
+		entityWithLockedProperty("TKT-PARTIAL", "ticket", "Mostly Readable", "status"),
+	}
+
+	tests := []struct {
+		name     string
+		contents []string
+		want     map[string]Mention
+	}{
+		{
+			name:     "known short-ID code span resolves",
+			contents: []string{"see `TKT-LXYHQ` for context"},
+			want: map[string]Mention{
+				"TKT-LXYHQ": {Type: "ticket", Title: "Resolve entity-ID references"},
+			},
+		},
+		{
+			name:     "manual-ID concept resolves via DisplayTitle (name)",
+			contents: []string{"covered by `data-entry-ui`"},
+			want: map[string]Mention{
+				// concept's primary property is `name` per its metamodel;
+				// the title comes from there, not the `title` property
+				// (which the seed never sets for concept).
+				"data-entry-ui": {Type: "concept", Title: "Data Entry Web UI"},
+			},
+		},
+		{
+			name:     "unknown ID is dropped",
+			contents: []string{"`TKT-NOPE` is not real"},
+			want:     nil,
+		},
+		{
+			name:     "multi-token code span is not collected",
+			contents: []string{"`TKT-LXYHQ and FEAT-010` mention both"},
+			want:     nil,
+		},
+		{
+			name:     "ID inside fenced code block is ignored",
+			contents: []string{"prose\n\n```\nTKT-LXYHQ in a block\n```\n"},
+			want:     nil,
+		},
+		{
+			name:     "ID inside indented code block is ignored",
+			contents: []string{"prose\n\n    TKT-LXYHQ indented\n"},
+			want:     nil,
+		},
+		{
+			name:     "link text containing an ID is not a code span",
+			contents: []string{"see [TKT-LXYHQ](https://example.com)"},
+			want:     nil,
+		},
+		{
+			name:     "multiple distinct mentions are deduplicated across blobs",
+			contents: []string{"`TKT-LXYHQ` and `FEAT-010`", "again: `TKT-LXYHQ`"},
+			want: map[string]Mention{
+				"TKT-LXYHQ": {Type: "ticket", Title: "Resolve entity-ID references"},
+				"FEAT-010":  {Type: "feature", Title: "Use goldmark for markdown rendering"},
+			},
+		},
+		{
+			name:     "inaccessible target carries inaccessible + reason",
+			contents: []string{"locked: `TKT-LOCKED`"},
+			want: map[string]Mention{
+				"TKT-LOCKED": {
+					Type:               "ticket",
+					Title:              "TKT-LOCKED",
+					Inaccessible:       true,
+					InaccessibleReason: "git-crypt",
+				},
+			},
+		},
+		{
+			name:     "partially-locked entity keeps its readable title and is NOT inaccessible",
+			contents: []string{"partial: `TKT-PARTIAL`"},
+			want: map[string]Mention{
+				"TKT-PARTIAL": {Type: "ticket", Title: "Mostly Readable"},
+			},
+		},
+		{
+			name:     "code span inside list item is collected",
+			contents: []string{"- see `TKT-LXYHQ` here\n"},
+			want: map[string]Mention{
+				"TKT-LXYHQ": {Type: "ticket", Title: "Resolve entity-ID references"},
+			},
+		},
+		{
+			name:     "code span inside blockquote is collected",
+			contents: []string{"> quoted: `TKT-LXYHQ`\n"},
+			want: map[string]Mention{
+				"TKT-LXYHQ": {Type: "ticket", Title: "Resolve entity-ID references"},
+			},
+		},
+		{
+			name: "code span inside GFM table cell is collected",
+			contents: []string{
+				"| col |\n| --- |\n| `TKT-LXYHQ` |\n",
+			},
+			want: map[string]Mention{
+				"TKT-LXYHQ": {Type: "ticket", Title: "Resolve entity-ID references"},
+			},
+		},
+		{
+			name:     "empty content returns nil",
+			contents: []string{""},
+			want:     nil,
+		},
+	}
+
+	meta := buildTestMetamodel(t)
+	st := memstore.New()
+	for _, e := range seed {
+		if err := st.CreateEntity(context.Background(), e); err != nil {
+			t.Fatalf("seed %q: %v", e.ID, err)
+		}
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := collectMentions(context.Background(), st, meta, tc.contents...)
+			assertMentionsEqual(t, tc.want, got)
+		})
+	}
+}
+
+func TestCollectMentions_SelfReference(t *testing.T) {
+	t.Parallel()
+
+	self := mustEntity("TKT-SELF", "ticket", "Looking inward")
+	meta := buildTestMetamodel(t)
+	st := memstore.New()
+	if err := st.CreateEntity(context.Background(), self); err != nil {
+		t.Fatalf("seed self: %v", err)
+	}
+
+	got := collectMentions(context.Background(), st, meta, "see `TKT-SELF` for the recursion")
+	want := map[string]Mention{
+		"TKT-SELF": {Type: self.Type, Title: self.Title()},
+	}
+	assertMentionsEqual(t, want, got)
+}
+
+func TestCollectMentions_ContextCancellationStops(t *testing.T) {
+	t.Parallel()
+
+	// Cancelled context — the per-ID loop must bail out before touching the
+	// store. Even with a known candidate it returns nil because we never
+	// resolved anything.
+	meta := buildTestMetamodel(t)
+	st := memstore.New()
+	if err := st.CreateEntity(context.Background(), mustEntity("TKT-CTX", "ticket", "T")); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got := collectMentions(ctx, st, meta, "`TKT-CTX`")
+	if got != nil {
+		t.Errorf("expected nil on cancelled context, got %+v", got)
+	}
+}
+
+func TestCollectMentions_StoreErrorIsLoggedAndSkipped(t *testing.T) {
+	t.Parallel()
+
+	// A flaky store error must not break the whole view-fetch response —
+	// it degrades to "code span stays as <code>" (the same UX as
+	// unknown-ID), and the bad ID drops out of the result.
+	meta := buildTestMetamodel(t)
+	flaky := &flakyStore{
+		err:  errors.New("backend offline"),
+		good: mustEntity("TKT-OK", "ticket", "Resolves fine"),
+	}
+
+	got := collectMentions(context.Background(), flaky, meta, "`TKT-FAIL` then `TKT-OK`")
+	want := map[string]Mention{
+		"TKT-OK": {Type: "ticket", Title: "Resolves fine"},
+	}
+	assertMentionsEqual(t, want, got)
+}
+
+func TestCollectMentions_ConcurrentScanIsSafe(t *testing.T) {
+	t.Parallel()
+
+	// `mentionsMarkdown` is a package-level goldmark.Markdown shared by all
+	// callers. Verify goroutine safety: many concurrent scans of the same
+	// content produce the same result every time.
+	meta := buildTestMetamodel(t)
+	st := memstore.New()
+	if err := st.CreateEntity(context.Background(), mustEntity("TKT-CONC", "ticket", "Concurrent")); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	const n = 64
+	var wg sync.WaitGroup
+	wg.Add(n)
+	results := make([]map[string]Mention, n)
+	for i := range n {
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = collectMentions(context.Background(), st, meta, "ref to `TKT-CONC`")
+		}(i)
+	}
+	wg.Wait()
+
+	want := map[string]Mention{"TKT-CONC": {Type: "ticket", Title: "Concurrent"}}
+	for i, got := range results {
+		if len(got) != 1 || got["TKT-CONC"] != want["TKT-CONC"] {
+			t.Fatalf("goroutine %d: want %+v, got %+v", i, want, got)
+		}
+	}
+}
+
+// buildTestMetamodel returns a small metamodel covering the entity types
+// the table-driven tests above seed: `ticket` (primary=title) and
+// `concept` (primary=name) — the latter is what exercises the
+// DisplayTitle path for `id_type: manual` entities like data-entry-ui.
+func buildTestMetamodel(t *testing.T) *metamodel.Metamodel {
+	t.Helper()
+	// GetPrimaryProperty picks `title`/`name` automatically when defined
+	// as a required string. Status property is included to exercise the
+	// "locked non-display property" case.
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Label: "Ticket",
+				Properties: map[string]metamodel.PropertyDef{
+					"title":  {Type: "string", Required: true},
+					"status": {Type: "string"},
+				},
+			},
+			"feature": {
+				Label: "Feature",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
+			},
+			"concept": {
+				Label: "Concept",
+				Properties: map[string]metamodel.PropertyDef{
+					"name": {Type: "string", Required: true},
+				},
+			},
+		},
+	}
+}
+
+func mustEntity(id, typeName, title string) *entity.Entity {
+	e := entity.New(id, typeName)
+	e.Properties["title"] = title
+	return e
+}
+
+// mustEntityNamed builds an entity whose display title comes from `name`
+// (the primary property for `concept`) rather than `title`. Used to
+// exercise the DisplayTitle path with `id_type: manual` types.
+func mustEntityNamed(id, typeName, name string) *entity.Entity {
+	e := entity.New(id, typeName)
+	e.Properties["name"] = name
+	return e
+}
+
+func lockedEntity(id, typeName string, reason entity.InaccessibleReason) *entity.Entity {
+	e := entity.New(id, typeName)
+	// Lock the entity by marking content inaccessible — matches what the
+	// markdown loader produces for git-crypt encrypted files. The display
+	// title is therefore unknown, so the SPA renders the link with a lock.
+	e.Inaccessible = []entity.InaccessibleField{
+		{Name: entity.InaccessibleFieldContent, Reason: reason},
+	}
+	return e
+}
+
+// entityWithLockedProperty produces an entity whose `title` is readable
+// but some unrelated property is locked. The wire-shape Mention should
+// keep `Inaccessible == false` because the displayed link text comes
+// from a readable source.
+func entityWithLockedProperty(id, typeName, title, lockedProp string) *entity.Entity {
+	e := entity.New(id, typeName)
+	e.Properties["title"] = title
+	e.Inaccessible = []entity.InaccessibleField{
+		{Name: lockedProp, Reason: entity.InaccessibleReasonGitCrypt},
+	}
+	return e
+}
+
+func assertMentionsEqual(t *testing.T, want, got map[string]Mention) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Fatalf("mention count mismatch: want %d, got %d (want=%v got=%v)",
+			len(want), len(got), want, got)
+	}
+	for id, w := range want {
+		g, ok := got[id]
+		if !ok {
+			t.Fatalf("missing mention %q (got=%v)", id, got)
+		}
+		if g != w {
+			t.Fatalf("mention %q mismatch: want %+v, got %+v", id, w, g)
+		}
+	}
+}
+
+// flakyStore is an EntityReader test double: GetEntity returns `err` for
+// every lookup except the one matching `good.ID`. Other EntityReader
+// methods panic — collectMentions does not call them.
+type flakyStore struct {
+	err  error
+	good *entity.Entity
+}
+
+func (f *flakyStore) GetEntity(_ context.Context, id string) (*entity.Entity, error) {
+	if f.good != nil && f.good.ID == id {
+		return f.good, nil
+	}
+	return nil, f.err
+}
+
+func (f *flakyStore) ListEntities(_ context.Context, _ store.EntityQuery) iter.Seq2[*entity.Entity, error] {
+	panic("flakyStore: ListEntities not implemented")
+}
+
+func (f *flakyStore) ListEntitiesPage(_ context.Context, _ store.EntityQuery) (store.Page[*entity.Entity], error) {
+	panic("flakyStore: ListEntitiesPage not implemented")
+}
+
+func (f *flakyStore) CountEntities(_ context.Context, _ store.EntityQuery) (int, error) {
+	panic("flakyStore: CountEntities not implemented")
+}
+
+func (f *flakyStore) HighestID(_ context.Context, _ string) (int, error) {
+	panic("flakyStore: HighestID not implemented")
+}
+
+func (f *flakyStore) PropertyValues(_ context.Context, _ string, _ int) ([]string, error) {
+	panic("flakyStore: PropertyValues not implemented")
+}

--- a/tickets/entities/implementation-checklists/IMPL-L5OQ.md
+++ b/tickets/entities/implementation-checklists/IMPL-L5OQ.md
@@ -1,0 +1,80 @@
+---
+id: IMPL-L5OQ
+type: implementation-checklist
+title: 'Implementation: Resolve entity-ID code spans to titled links in data-entry views'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+- **Built `rela-server` against the in-tree `tickets/` project** and queried
+`GET /api/v1/_views/ticket/TKT-77JD4` (a ticket whose body uses a clean ``
+`FEAT-Q767` `` code span). Response carried `mentions["FEAT-Q767"] = {type:
+"feature", title: "Keyboard shortcuts and power-user navigation in data-entry
+UI"} ` exactly as planned (AC 1 + 2).
+- **Unit tests passing:**
+  - Go `internal/dataentry/mentions_test.go ` — 9 cases covering known
+short-ID, manual-ID (concept), unknown, multi-token, fenced/indented code
+blocks, link-text fixtures, dedup across blobs, inaccessible target (`git-crypt
+` reason), empty content, plus self-reference test.
+  - Go `internal/dataentry/api_v1_test.go ` — two new view-response tests
+(`TestV1Views_MentionsPopulated `, `TestV1Views_MentionsAbsentWhenNoRefs `)
+asserting the `mentions ` field is populated for refs and omitted entirely (no
+`"mentions" ` JSON key) when there are none.
+  - TS `frontend/src/utils/markdown.test.ts ` — 11 new cases under
+`refResolver (entity-ID code spans) ` covering happy path, manual IDs, unknown,
+multi-token, fenced blocks, existing link text, XSS-y title (DOMParser-based
+assertion confirms no live `<img> `/`onerror `), inaccessible with tooltip,
+unreasoned fallback, resolver exceptions swallowed, mixed known/unknown spans,
+no-resolver backwards compat.
+- **Round-trip corpus regression cleared** — `TestMdCorpusRoundTrip ` was
+flagged on `PLAN-V6BB.md ` because a markdown bullet started with `+ ` on a
+continuation line; reformatted the bullet to keep the corpus round-trip a fixed
+point.
+- **Full Go suite:** `go test -race ./... ` — all packages green
+(`internal/dataentry ` 3.2s; `internal/lua ` 1.9s).
+- **Full frontend suite:** `npm run test:run ` — 662 tests across 38 files
+pass (was 651 before, +11 new ref-resolver cases).
+- **Frontend typecheck:** `npm run typecheck ` — clean.
+- **Frontend lint:** `npm run lint ` — no new errors (pre-existing
+warnings unchanged).
+- **e2e typecheck/lint:** `npm --prefix e2e run typecheck && npm --prefix
+e2e run lint ` — both clean. Lint forced the use of a page-object method, so
+added `contentEntityRefLink ` / `clickContentEntityRef ` helpers to `EntityPage
+`.
+- **Coverage:** `just coverage-check ` — total 75.5%, all package floors
+satisfied.
+- **Go lint + arch lint:** `just lint `, `just arch-lint ` — both clean.
+- **Build:** `just build ` — `rela `, `rela-server `, `rela-desktop ` all
+build successfully.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-V6BB.md
+++ b/tickets/entities/planning-checklists/PLAN-V6BB.md
@@ -1,0 +1,372 @@
+---
+id: PLAN-V6BB
+type: planning-checklist
+title: 'Planning: Resolve entity-ID code spans to titled links in data-entry views'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+In scope:
+
+- Backend computes, for each view-fetch response, the set of entity IDs that
+appear as bare-content code spans in any markdown body the response carries
+(entry content + content sections), resolves each to `{type, title}` via the
+store, and attaches it as a new top-level `mentions` field on the `ViewResponse`
+returned by `/_views/<type>/<id>`. This is an **implicit relation set** —
+derived at read time, not declared.
+- Frontend `renderMarkdown` learns an optional sync `refResolver:
+(id) => {type, title} | null` parameter and uses marked's `walkTokens` to
+rewrite `codespan` tokens whose `text` exactly matches a known entity ID into
+`link` tokens (`href = /entity/<type>/<id>`, link text = title).
+- `EntityDetail.vue` (the unified detail screen after the TKT-J5BET merge)
+builds the resolver from `viewData.value?.mentions ?? {}` and passes it to every
+`renderMarkdown` call it makes.
+
+Out of scope:
+
+- Lua/document-render path — `rela.md.resolve_refs` already covers it
+(TKT-LXYHQ + FEAT-023).
+- Wiki-style `[[ID]]` syntax (IDEA-011).
+- Bare prose mentions outside code spans.
+- Hover previews, backlinks panel, graph affordances.
+- `MarkdownEditor` source-edit view — only **rendered** output is rewritten.
+- Generic entity-fetch endpoint (`/api/v1/<plural>/<id>`) — only the view
+fetch carries `mentions` for now, because that's what the detail screen
+consumes. Other consumers can opt in later.
+- Server-side rewriting of the markdown payload itself — the markdown stays
+raw on the wire; the resolver is what gives the renderer everything it needs.
+
+**Acceptance Criteria:**
+
+1. **Known-ID code span → titled link.** A view response for an entity whose
+content includes `` `TKT-LXYHQ` `` carries `mentions["TKT-LXYHQ"] =
+{"type":"ticket","title":"Resolve entity-ID references…"}  `. The SPA renders
+that code span as `<a href="/entity/ticket/TKT-LXYHQ">Resolve entity-ID
+references…</a>  `.
+2. **Manual-ID code span → titled link.** Same flow works for `id_type:
+manual  ` entities (e.g. `` `data-entry-ui` `` → link to
+`/entity/concept/data-entry-ui  `). Verified server-side via store resolution,
+not a prefix map.
+3. **Unknown-ID code span → unchanged.** `` `TKT-NOPE` `` (no such entity)
+stays rendered as `<code>TKT-NOPE</code>  `. Server's `mentions  ` doesn't
+include it; resolver returns null; renderer falls through.
+4. **Multi-token code span → unchanged.** `` `TKT-1 and TKT-2` ``,
+`` `TKT-LXYHQ extras` `` — exact-match-only, matching Lua semantics. No entry in
+`mentions  `; renderer leaves them as `<code>  `.
+5. **Code block / link contexts untouched.** Fenced/indented code blocks
+containing IDs and existing `[label](url)  ` link text with IDs are not
+rewritten. The walkTokens hook only fires on `codespan  ` (not `code  `), and
+tokens inside an already-formed `link  ` are not match candidates because marked
+never tokenizes link **text** as standalone `codespan  ` for the link-as-a-whole
+shape `[TKT-1](url)  `.
+6. **DOMPurify-safe.** Titles containing `<  `, `>  `, `"  `, `&  ` flow through
+marked's link renderer, which HTML-escapes link text. Final DOMPurify pass keeps
+the link intact. Unit test asserts both no-XSS and no-mangled-title.
+7. **Self-reference.** Entity references itself in content (`` `<own-id>` ``)
+→ still rewritten; href routes to its own detail screen — harmless.
+8. **Inaccessible target.** Code span pointing at a git-crypt-encrypted
+entity → mention carries `inaccessible: true, inaccessible_reason: "git-crypt"
+`; SPA renders `<a href="…">ID 🔒</a> ` with the standard git-crypt tooltip copy.
+Link still navigates to the target detail page.
+9. **Manual end-to-end.** With `npm run dev  ` running, opening an entity
+whose content references another entity by ID in backticks shows the link,
+clicking navigates correctly.
+10. **Playwright e2e.** New spec under `e2e/tests/ ` seeds a project where
+entity A's content references entity B in backticks, visits A's detail page,
+asserts the rendered link points at B's URL and carries B's title as text, and
+clicks through to verify navigation. Covers the happy path end-to-end against
+the built `rela-server ` binary that embeds the SPA bundle.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+- **Server-side reference (Lua):** `internal/lua/markdown.go  ` (TKT-LXYHQ).
+`rela.md.entity_refs  ` walks the store and builds an ID→link-text map;
+`rela.md.resolve_refs  ` walks the AST and rewrites `code_span  ` nodes whose
+entire text matches a known ID. We mirror the AST-walk semantics on the server
+(goldmark) and the resolution-map shape on the wire.
+- **Server-side renderer (goldmark):** `internal/dataentry/helpers.go  `
+(`simpleMarkdownToHTML  ` for help content) and `internal/dataentry/document.go
+` (FEAT-023 document panels) already use goldmark. We reuse goldmark's parser
+for the code-span scan but do **not** render to HTML here — we just walk the AST
+collecting matched IDs.
+- **Frontend renderer (`marked  `):** `frontend/src/utils/markdown.ts  `'s
+`renderMarkdown  ` is the only call site for `marked.parse  `. Marked exposes a
+`walkTokens  ` option that fires once per parsed token, so we can mutate a
+`codespan  ` token into a `link  ` token before render. Confirmed shape: a `link
+` token is `{type:'link', href, title, text, tokens:[{type:'text', raw:...,
+text:...}]}  `; marked renders it via its default link template, which
+HTML-escapes link text correctly.
+- **Unified detail screen (recent on develop):** commit 6aa0b0e
+("Merge EntityDetail and CustomView into a single config-driven detail screen")
+landed on 2026-05-10 — `CustomView.vue  ` is gone; every entity type uses
+`EntityDetail.vue  ` via `EntityView.vue  `. One render path, one `fetchView  `
+call, one place to plug in the resolver.
+- **Wire shape:** `ViewResponse  ` (frontend `api/views.ts:105  ` + backend
+views.go) is the natural carrier. `entry.relations  ` is a flat `Record<string,
+string[]>  ` keyed by metamodel relation types — squatting on that would confuse
+analyzers and the schema-keyed UI. A separate top-level `mentions  ` field keeps
+the implicit/derived edges distinct from explicit metamodel relations.
+- **Route + helper:** `/entity/:type/:id  ` (router/index.ts) via
+`entityDetailHref  ` (utils/entityRoute.ts). Reused as the link target.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+1. **Server-side mentions collection** (`internal/dataentry/  `).
+   - Add a small helper `collectMentions(state, contents []string) map[string]Mention  `
+that:
+     - Concatenates the content blobs and parses them once with goldmark.
+     - Walks the AST collecting every `ast.KindCodeSpan  ` whose entire text
+value matches the syntactic ID shape (one short non-space token; the precise
+regex matches the Lua side — keep them in lock-step).
+     - Looks each candidate ID up in `state.Store  ` (via the entitymanager /
+store helpers already used by view-rendering code). On hit, records `{Type:
+e.Type, Title: e.Title()}  `; if the entity is inaccessible (git-crypt) the
+record also carries `Inaccessible: true, InaccessibleReason: "git-crypt" `. On
+miss, drops it silently.
+   - Wire it into the view-response builder so the returned `ViewResponse  `
+carries `Mentions map[string]Mention  ` — populated from `entry.Content  ` and
+from each section's `Content  ` field.
+2. **API wire shape.**
+   - Add `Mention { type: string, title: string, inaccessible?: bool,
+inaccessible_reason?: string }  ` and `Mentions map[string]Mention
+`json:"mentions,omitempty"`` to the view-response Go type. `inaccessible ` and
+`inaccessible_reason ` are omitempty so the common case stays compact. Mirror in
+`ViewResponse  ` TS interface in `frontend/src/api/views.ts  `.
+3. **Frontend resolver.**
+   - Mirror the wire shape in `ViewResponse.mentions  `.
+   - In `EntityDetail.vue  `, derive a `refResolver  ` `computed  ` from
+`viewData.value?.mentions  ` — `(id) => mentions[id] ?? null  `.
+   - Pass the resolver to every `renderMarkdown(content)  ` call the component
+makes (currently three sites for entry content, content sections, and
+entity-card content).
+4. **`renderMarkdown  ` extension** (`frontend/src/utils/markdown.ts  `).
+   - Add optional second arg `refResolver?: (id: string) => { type: string;
+title: string; inaccessible?: boolean; inaccessibleReason?: string } | null  `.
+   - Configure `marked.parse  ` with `walkTokens: token => { ... }  `. For each
+`codespan  ` whose `.text  ` matches the syntactic ID regex and whose resolver
+lookup returns a hit, mutate the token in place into a `link  ` token: set
+`type='link'  `, `href=/entity/<type>/<id>  `, `title=undefined  ` (don't reuse
+the HTML `title  ` attribute — keeps the surface minimal), `text=<entity-title>
+`, `tokens=[{type:'text', raw:title, text:title}]  `. Marked's link renderer
+handles HTML-escaping the text.
+   - **Inaccessible entities:** when the resolver returns `inaccessible:
+true `, use the **ID** as link text (since the title isn't readable) and append
+a 🔒 trailing affordance inside the link via a second `text ` token. Set the
+`title ` attribute on the resulting `<a> ` to the existing `inaccessibleTooltip
+` copy from `PropertyDisplay.vue ` (`"git-crypt encrypted (run 'git-crypt
+unlock' to read)" ` for the `git-crypt ` reason; otherwise `"inaccessible
+(<reason>)" `). This reuses the visual language users already see on
+inaccessible properties.
+   - No-resolver and no-hit cases: do nothing — output stays as today.
+5. **No new sanitizer config.** DOMPurify already permits `<a href>  ` on
+same-origin paths starting with `/  `. We don't add `data-*  ` attributes.
+
+**Files to modify:**
+
+Server:
+- `internal/dataentry/sections.go  ` and/or
+`internal/dataentry/default_view.go  ` — wire `collectMentions  ` into the view
+response builder.
+- `internal/dataentry/api_v1.go  ` (or wherever the view-response Go type
+lives — `default_view.go  ` per the recent merge commit) — add `Mention  ` type
+and `Mentions  ` field.
+- New: `internal/dataentry/mentions.go  ` (or co-locate in `sections.go  `) —
+goldmark-based scan + store resolution.
+- New: `internal/dataentry/mentions_test.go  ` — table-driven tests for the
+scan (known/manual/unknown/multi-token/inside-code-block).
+
+Frontend:
+- `frontend/src/api/views.ts  ` — add `Mention  ` and `mentions  ` to
+`ViewResponse  `.
+- `frontend/src/utils/markdown.ts  ` — extend `renderMarkdown  ` with
+`refResolver  `; add walkTokens rewrite.
+- `frontend/src/utils/markdown.test.ts  ` — add cases (see Test Plan).
+- `frontend/src/components/entity/EntityDetail.vue  ` — derive resolver from
+`viewData.value.mentions  `; pass to all three `renderMarkdown  ` call sites.
+
+**Alternatives considered (rejected):**
+
+- Client-side prefix map from schema `IDPrefix  ` — rejected: misses `id_type:
+manual  ` entities (e.g. concepts like `data-entry-ui  `).
+- Standalone `GET /api/v1/_entity_refs  ` endpoint covering the whole project
+— rejected per user: payload bigger than necessary; only the IDs referenced by
+the currently-viewed entity matter.
+- Server pre-rewrites markdown into markdown links before returning content
+— rejected: changes content semantics on the wire, harder to reason about for
+downstream consumers (export, copy-content, etc.).
+- Two-phase client render (scan content for IDs, fetch missing entities,
+re-render) — rejected: visible flicker, async glue in render path, no benefit
+over a server-supplied per-response map.
+
+**Dependencies:** None new. goldmark + GFM extensions already imported in
+`internal/dataentry/  `; `marked  ` already in the frontend bundle.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- **Entity content (markdown body).** Author-controlled. Already rendered
+via marked + DOMPurify today. The new rewrite happens at the **token level**
+before HTML serialization, so HTML-significant chars are escaped by marked's
+renderer like any other inline.
+- **Entity titles** (link text). Author-controlled. Risk: `<script>  ` in a
+title could break out if injected as raw HTML. **Mitigation:** title is pushed
+into a `text  ` token (`tokens:[{type:'text', text: title}]  `); marked's link
+renderer HTML-escapes link text. Final DOMPurify pass is a second line of
+defense, not the primary defense.
+- **ID syntax matched against** a small anchored regex on the server (same
+shape as the Lua side: one short non-space token). Only matched candidates are
+looked up in the store. Unknown IDs are silently dropped.
+- **href**: built server-side from validated `(type, id)  ` strings already
+in the store. Same-origin path `/entity/<type>/<id>  `. No query strings, no
+user-controllable URL parts.
+- **Inaccessible entities (git-crypt):** the store's `Title()  ` may return
+the ID for an inaccessible entity. That's still a valid link target — the detail
+screen handles inaccessible entities (commit 6dc2efa). Acceptable.
+
+**Security-Sensitive Operations:**
+
+- Title-as-link-text composition: rely on marked's link renderer for
+escaping; DOMPurify final pass.
+- Server goldmark parse is on already-loaded markdown; no extra IO.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Test | Layer |
+|----|------|-------|
+| 1 | View response for an entity whose body has `` `TKT-LXYHQ` `` includes `mentions["TKT-LXYHQ"]  ` and SPA renders an `<a>  ` with the target title | Go (`mentions_test.go  `) + TS (`markdown.test.ts  `) |
+| 2 | Same flow with a manual ID concept (e.g. `data-entry-ui  `) | Go + TS |
+| 3 | View response for `` `TKT-NOPE` `` does NOT include the ID in `mentions  `; renderer leaves `<code>  ` | Go + TS |
+| 4 | `` `TKT-1 and TKT-2` `` → not collected, not rewritten | Go + TS |
+| 5 | Content with ID inside a fenced/indented code block → not collected; existing `[TKT-1](url)  ` link text → not rewritten | Go (server skips code blocks); TS (`walkTokens  ` only fires on `codespan  `) |
+| 6 | Title `<img onerror=x>  ` → link text rendered as escaped text; no DOM injection; DOMPurify pass preserves the link | TS |
+| 7 | Self-reference: entity content includes its own ID; link appears with own title | Go + TS |
+| 8 | Inaccessible target: server emits `inaccessible:true, inaccessible_reason:"git-crypt" `; renderer outputs `<a>ID 🔒</a> ` with tooltip | Go + TS |
+| 9 | Manual run: dev server, click a rendered link, verify navigation | Manual |
+| 10 | Playwright e2e: built `rela-server ` serves SPA; spec asserts rendered link + click navigates | e2e (`e2e/tests/entity-refs.spec.ts  `) |
+
+**Edge Cases:**
+
+- Empty content → empty `mentions: {}  `; renderer fast path returns `''  `.
+- Resolver not passed → `renderMarkdown  ` behaves exactly like today
+(backwards-compatible). Existing tests stay green.
+- Resolver throws (defensive) → swallow; leave codespan intact.
+- Unicode title → preserved verbatim by marked's text-token escaping.
+- Many refs in one document → single goldmark walk server-side; single
+`walkTokens  ` pass client-side. O(n) in token count.
+- Mixed known/unknown in one paragraph → each handled independently.
+- Inaccessible entity title (git-crypt) → server-side resolution detects
+the entity is inaccessible and surfaces it in the `mentions ` map with an
+`inaccessible ` flag and the reason (`"git-crypt" `). The frontend renders the
+link with the ID as text plus a trailing 🔒 lock affordance, mirroring the
+existing `PropertyDisplay.vue ` pattern (commit 6dc2efa). Tooltip on the lock
+gives `"git-crypt encrypted (run 'git-crypt unlock' to read)" ` — same copy as
+`PropertyDisplay `'s `inaccessibleTooltip `. The link still navigates to the
+entity's detail page (where the existing inaccessible handling takes over). Wire
+shape: `Mention { type, title, inaccessible?, inaccessibleReason? } `.
+
+**Negative Tests:**
+
+- `mentions  ` includes an entry whose value is missing `type  ` or `title  `
+→ frontend resolver defensively returns null, codespan untouched.
+
+**Integration approach:**
+
+- **Go:** add a focused unit test in `internal/dataentry/mentions_test.go  `
+for the scan + resolve logic against an in-memory store/metamodel. Existing
+view-response tests get extra assertions for the `Mentions  ` field on the JSON
+payload.
+- **TS:** `markdown.test.ts  ` extends with `walkTokens  ` cases (the existing
+Vitest harness uses JSDOM; perfect for the DOM-walking that DOMPurify does at
+the end).
+- **Playwright e2e:** new `e2e/tests/entity-refs.spec.ts  ` against the
+built `rela-server ` binary that embeds the SPA bundle. Mirrors the existing
+patterns in `e2e/tests/entity-detail.spec.ts ` and `git-crypt.spec.ts `. Seeds a
+fixture project (or uses an existing fixture) with two entities where one
+references the other in a backticked code span; asserts the rendered `<a> `
+exists with the expected href and title text, then clicks it and asserts
+navigation to the target detail page (AC 10).
+- **Manual:** dev server end-to-end click-through (AC 9).
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- **Goldmark parse cost per view fetch.** The content is small (a single
+entity's body + section blobs); negligible vs. the rest of the view rendering.
+Mitigation: cheap.
+- **Store lookup cost.** A handful of `Get(type, id)  ` per view fetch.
+Negligible.
+- **Wire-payload growth.** `mentions  ` adds ~50–150 bytes per referenced
+entity. For a typical entity with 0–10 refs, payload growth is in the low
+hundreds of bytes. Acceptable.
+- **Marked token-mutation contract.** Marked's `walkTokens  ` lets you mutate
+the token in place; the contract is documented and stable. Mitigation: add an
+explicit unit test asserting the mutation pattern, so a future marked upgrade
+that changes the token shape fails loudly.
+- **Inaccessible entity titles.** Surfaced explicitly via `inaccessible` and
+`inaccessible_reason` on the mention record; rendered as ID + 🔒 with the same
+tooltip copy as inaccessible properties (see Approach §4).
+
+**Effort:** `m  ` (matches the ticket's recorded effort).
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [ ] User guide: brief mention in the data-entry guide (rela-docs) that
+backticked entity IDs in markdown content become clickable links — same
+convention as the Lua side. Create a `docs-checklist  ` on the ticket when
+transitioning to review unless the user opts out.
+- [x] N/A — CLAUDE.md, README.md, internal architecture docs unaffected.
+- [x] N/A — no new CLI flags / no new API surface beyond `mentions  ` on
+`/_views/<type>/<id>  `.
+
+## Design Review
+
+- [ ] Run `/design-review  ` before starting implementation
+- [ ] All critical/significant findings addressed in plan
+
+**Design Review Findings:** <!-- populated after running /design-review -->

--- a/tickets/entities/review-checklists/REV-KGV0.md
+++ b/tickets/entities/review-checklists/REV-KGV0.md
@@ -1,0 +1,75 @@
+---
+id: REV-KGV0
+type: review-checklist
+title: 'Review: Resolve entity-ID code spans to titled links in data-entry views'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] `just test` passes — all packages green (Go race-detector on; `internal/dataentry` 2.6s, `internal/lua` 6.7s)
+- [x] `just lint` passes — 0 issues
+- [x] `just arch-lint` passes — no boundary warnings
+- [x] `just coverage-check` passes — total 75.5%, all package floors satisfied
+- [x] Frontend `npm run test:run` passes — 666 tests / 38 files
+- [x] Frontend `npm run typecheck` passes — clean
+- [x] Frontend `npm run lint` passes — no new errors (pre-existing warnings unchanged)
+- [x] e2e `npm run typecheck && npm run lint` passes — both clean
+- [x] `just build` produces all three binaries
+
+## Code Review
+
+- [x] Ran the cranky-code-reviewer agent against the full diff
+- [x] All findings filed as `review-response` entities and linked via
+`has-review-response`
+
+**Findings summary** (19 total):
+
+| Severity | Count | Status |
+|----------|-------|--------|
+| critical | 1     | 1 addressed |
+| significant | 4 | 4 addressed |
+| minor | 7      | 7 addressed |
+| nit   | 7      | 6 addressed, 1 deferred (RR-A9DU — shared scanner refactor, out of scope) |
+
+- **RR-OKQD (critical)** — `viewContentBlobs` missed entity-card content;
+fixed by walking `sec.Entities` + `sec.Groups[].Entities`.
+- **RR-58F4** — switched `Mention.Title` from `ent.Title()` to
+`meta.DisplayTitle(...)` so entities with non-title primary properties
+(concept's `name`, etc.) resolve correctly.
+- **RR-47N9** — partial-lock entities no longer flip into the lock
+affordance: new `lockedReasonFor` only checks the display-property field or the
+`InaccessibleFieldContent` sentinel.
+- **RR-07K2** — `mentionsMarkdown` now enables GFM/Table/Strikethrough/
+TaskList extensions so GFM table cells produce CodeSpans the scanner expects.
+- **RR-ZK8N** — non-NotFound store errors logged via `slog.WarnContext`;
+context cancellation honored.
+- All minor and nit findings either addressed or explicitly deferred
+with a documented reason. No open critical/significant findings remain.
+
+## Acceptance Verification
+
+| AC | Status | Evidence |
+|----|--------|----------|
+| 1 (known-ID → titled link) | PASS | Go: `TestCollectMentions/known short-ID code span resolves`; TS: `rewrites a known-ID code span into a titled link`; manual `curl /_views/ticket/TKT-77JD4` returns the expected mention |
+| 2 (manual-ID concept) | PASS | Go: `manual-ID concept resolves via DisplayTitle (name)`; TS: `rewrites a manual-ID code span into a titled link` |
+| 3 (unknown-ID unchanged) | PASS | Go: `unknown ID is dropped`; TS: `leaves unknown-ID code spans as <code>`; e2e: `unknown-ID code spans remain as <code> (no link)` |
+| 4 (multi-token unchanged) | PASS | Go: `multi-token code span is not collected`; TS: `does not rewrite multi-token code spans (exact-match only)` |
+| 5 (code block / link text untouched) | PASS | Go: `ID inside fenced code block`, `ID inside indented code block`, `link text containing an ID is not a code span`; TS: `does not rewrite IDs inside fenced code blocks`, `does not rewrite IDs inside existing link text`; e2e: `IDs inside fenced code blocks are not linkified` |
+| 6 (DOMPurify-safe) | PASS | TS: `renders dangerous titles as escaped text without breaking the link` (DOMParser-based), `produces only same-origin entity hrefs`, `cannot inject script via a malicious inaccessible-reason tooltip` |
+| 7 (self-reference) | PASS | Go: `TestCollectMentions_SelfReference`; TS: `rewrites a self-reference like any other entity link` |
+| 8 (inaccessible target) | PASS | Go: `inaccessible target carries inaccessible + reason`, `partially-locked entity keeps its readable title and is NOT inaccessible`; TS: `renders inaccessible targets with a lock affordance and tooltip`, `keeps the readable title alongside the lock when one is supplied`, `falls back to "inaccessible" tooltip when reason is missing` |
+| 9 (manual end-to-end) | PASS | Built `rela-server` against `tickets/`, hit `GET /api/v1/_views/ticket/TKT-77JD4`; response carried the expected `mentions` entry |
+| 10 (Playwright e2e) | PASS | `e2e/tests/entity-refs.spec.ts` with two happy-path cases (link rendered, click navigates) and two negative cases (unknown ID, fenced block) |
+
+## Verification Evidence
+
+- See `IMPL-L5OQ` for the implementation-phase verification trail; the
+code-review cycle on top added the GFM extension wiring, the `meta.DisplayTitle`
+switch, the locked-property refinement, error logging, and additional test
+coverage. All of those have unit-test evidence above.
+- Coverage floor for `internal/dataentry` unchanged; new code is
+well-covered by the table-driven tests in `mentions_test.go` plus the
+view-response tests in `api_v1_test.go`.

--- a/tickets/entities/review-responses/RR-07K2.md
+++ b/tickets/entities/review-responses/RR-07K2.md
@@ -1,0 +1,9 @@
+---
+id: RR-07K2
+type: review-response
+title: mentionsMarkdown uses bare goldmark.New() — GFM extensions missing despite doc comment claim
+finding: 'internal/dataentry/mentions.go line 125 declares `var mentionsMarkdown = goldmark.New()` with a comment on line 122-124 stating it ''shares the GFM extension set with the document renderer so the parse is consistent with how the same content would render elsewhere.'' That claim is false. The data-entry''s own document renderer (helpers.go line 347) configures `goldmark.WithExtensions(extension.GFM)`; the mentions parser does not. Today the gap is mostly cosmetic because plain CommonMark still parses code spans inside paragraphs/headings/lists/blockquotes, which covers the common cases. But it diverges for GFM tables: a `| header |` line is parsed as a plain paragraph by mentionsMarkdown, while it parses as a Table by the rendering pipeline. The CodeSpan is still found either way because the walk is recursive — but the comment-vs-implementation drift is a maintenance trap. Either enable extension.GFM here (preferred, since the comment already promises it) or correct the comment to state explicitly that CommonMark-level parsing is sufficient for the scan. Bonus: enabling GFM gets you strikethrough handling for free in case a future test catches a code span inside `~~stricken~~ text` that the doc renderer would emit differently.'
+severity: significant
+resolution: mentionsMarkdown now configures extension.GFM, extension.Table, extension.Strikethrough, and extension.TaskList. New test 'code span inside GFM table cell is collected' exercises this -- without the Table extension goldmark would emit the row as a single paragraph.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-47N9.md
+++ b/tickets/entities/review-responses/RR-47N9.md
@@ -1,0 +1,9 @@
+---
+id: RR-47N9
+type: review-response
+title: Partially-locked entity — e.g. only `title` encrypted — wrongly renders ID with lock affordance
+finding: "internal/dataentry/mentions.go uses `ent.IsLocked()` to set Mention.Inaccessible. IsLocked returns `len(e.Inaccessible) > 0` (entity.go line 71) — i.e. ANY inaccessible field triggers it. If a future deployment encrypts only one property (e.g. SOPS field-level), an entity whose title is perfectly readable will be flagged Inaccessible. The renderer then displays the link as `<ID> \U0001F512` with a 'inaccessible' tooltip and discards the title — a misleading downgrade of available information. The doc comment on IsLocked (entity.go line 62-70) already anticipates this future ('today: git-crypt encrypted files; future: SOPS field encryption, Lua-driven access control'), so the conservative read is that the heuristic is wrong from the start. Suggestion: gate Inaccessible on whether the title (or display property) is itself inaccessible, e.g. `ent.IsInaccessible(\"title\") || ent.IsInaccessible(\"*\") || ent.Inaccessible[i].Name == entity.InaccessibleFieldContent` per your design intent. At minimum, document the coarse-grained semantics so the next reviewer knows the choice was deliberate."
+severity: significant
+resolution: New lockedReasonFor(e, displayProp) only flags when the display-property or InaccessibleFieldContent sentinel is unreadable. Property unrelated to title no longer flips the link into a lock. Regression test 'partially-locked entity keeps its readable title and is NOT inaccessible' covers this.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-58F4.md
+++ b/tickets/entities/review-responses/RR-58F4.md
@@ -1,0 +1,9 @@
+---
+id: RR-58F4
+type: review-response
+title: 'Entity title fallback inconsistency: Mention uses ent.Title() without DisplayTitle''s ID fallback'
+finding: 'internal/dataentry/mentions.go line 49 uses `ent.Title()` (returns `GetString("title")`, returns "" when missing) to populate Mention.Title. Meanwhile sections.go line 196 (and elsewhere) uses `s.Meta.DisplayTitle(e.ID, e.Type, e.Properties)` which falls back to the entity ID when the title is empty and supports a configurable `display_property`. Consequence: a code-spanned ID for an entity with display_property:''name'' (e.g. tag/module in the e2e fixture) or with primary property bound to a non-title field will resolve to Mention{Type:..., Title:""} — the resolver then skips the rewrite (`if (!hit.inaccessible && !hit.title) return`), and the user sees a `<code>` block while the same entity in a cards section renders with its name. Even worse: the e2e fixture defines `tag` entity with `id_type: manual` and primary `name` — a `\`my-tag\`` code span would not be resolved to a link because `Title()` reads only the literal ''title'' property. Fix: use `meta.DisplayTitle(ent.ID, ent.Type, ent.Properties)` consistently, and let the title field genuinely be empty (in which case the renderer can still fall back to the ID as link text).'
+severity: significant
+resolution: buildMention uses meta.DisplayTitle(e.ID, e.Type, e.Properties) instead of e.Title(). New test 'manual-ID concept resolves via DisplayTitle (name)' confirms entities whose primary property is 'name' (e.g. concept) get readable titles.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-74JH.md
+++ b/tickets/entities/review-responses/RR-74JH.md
@@ -1,0 +1,9 @@
+---
+id: RR-74JH
+type: review-response
+title: 'scanCodeSpanCandidates: codeSpanText concatenation may drop non-Text children silently'
+finding: 'internal/dataentry/mentions.go lines 112-120: codeSpanText iterates the CodeSpan''s children but only keeps `*ast.Text` ones. goldmark generally builds CodeSpan contents as Text segments, but if any extension (or a future goldmark internal) introduces another inline kind inside a CodeSpan, the function silently drops content — the resulting candidate key would be a substring of the real code span text, never matching any entity ID. The error is invisible. Either (a) document the invariant ''goldmark CodeSpan children are *ast.Text only'' and `_, _ = c.(*ast.Text)` won''t fail open, or (b) walk all descendants and fall back to source byte slicing using the node''s segments. The Lua-side analog (markdown.go line 781 area in internal/lua) does the same plus a length check on the source bytes — worth aligning.'
+severity: nit
+resolution: codeSpanText now returns (text string, complete bool). Code spans containing non-*ast.Text children return complete=false; scanner skips them. We never silently match a partial reconstruction.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-A9DU.md
+++ b/tickets/entities/review-responses/RR-A9DU.md
@@ -1,0 +1,9 @@
+---
+id: RR-A9DU
+type: review-response
+title: 'Leverage: extract a shared ''entity-ID code span resolution'' contract between Lua and HTTP path'
+finding: 'The Lua-side path (internal/lua/markdown.go rela.md.entity_refs / resolve_refs) and the new data-entry path (internal/dataentry/mentions.go) implement the same conceptual operation: ''scan markdown for bare-content code spans whose text matches an entity ID; emit a resolution map''. Today they diverge slightly: Lua uses titleSlug-style anchors, data-entry uses /entity/<type>/<id> URLs. Both have their own AST walk, both have their own ''must be bare-content'' rule, both have to be kept in sync as the markdown surface grows. As the platform adds more rendering paths (e.g. RSS feed, doc export, MCP resource exposure), this duplication compounds. Suggest factoring a shared `internal/mentions` (or `internal/refscan`) package that exposes ScanCandidates(content) []string and lets each caller decide what to do with the resolution. Out of scope for this PR — file it as a follow-up ticket.'
+severity: nit
+reason: 'Factoring a shared internal/refscan between Lua-side entity_refs and HTTP-side collectMentions is useful leverage but out of scope for this ticket. The two paths differ in how they consume the result (Lua: project-wide map; HTTP: per-response scope) and consolidating now expands blast radius beyond what this PR delivers. Test suites for both paths cover the shared semantics independently.'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-BQA3.md
+++ b/tickets/entities/review-responses/RR-BQA3.md
@@ -1,0 +1,9 @@
+---
+id: RR-BQA3
+type: review-response
+title: Mentions includes self-reference — worth assertion that the rendered link is harmless
+finding: TestCollectMentions_SelfReference (mentions_test.go line 112) verifies the scan emits the entity's own ID when the viewer references itself. The doc comment on collectMentions says 'the SPA route handles them as no-op navigation.' That's not asserted anywhere — there's no Vue test, no e2e test for the self-reference case. If a future change to the router or to EntityDetail.vue's route-change watch causes a self-link click to reload (or worse, infinite-loop), nothing in the test suite catches it. Add either (a) a Playwright case where origin === target and the link click stays on the same page without an error, or (b) a Vue test for `navigateToEntity` with the current entity that asserts no loadView re-entry.
+severity: nit
+resolution: Added 'rewrites a self-reference like any other entity link' to markdown.test.ts. Server-side already had TestCollectMentions_SelfReference; now parity on the frontend.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DW2V.md
+++ b/tickets/entities/review-responses/RR-DW2V.md
@@ -1,0 +1,9 @@
+---
+id: RR-DW2V
+type: review-response
+title: primaryInaccessibleReason returns first reason regardless of which field is locked
+finding: 'internal/dataentry/mentions.go lines 67-74: iterates Inaccessible and returns the first non-empty Reason. With a single InaccessibleField (content, today), that''s correct. But the comment ''Today only git-crypt is produced; the indirection keeps the call site stable when other reasons are added'' anticipates richer cases. When that happens, an entity with multiple inaccessible fields could have different reasons per field (e.g. title=sops, content=git-crypt). Returning the FIRST non-empty reason ties UI behavior to map-iteration order. Slice iteration is deterministic in Go, but the implicit assumption is ''all reasons are equal'' — not documented. If you keep this shape, document the precedence; if you want to be honest, return the reason matched to the inaccessible field most relevant to the rewrite intent (content or title). Otherwise leave a TODO so the next dev hits the question deliberately.'
+severity: nit
+resolution: 'Doc-comment on lockedReasonFor explains precedence: a field matching either the display property or InaccessibleFieldContent sentinel triggers the lock; the first match wins. With one inaccessible field per entity today (git-crypt locks the whole file) precedence is deterministic; comment captures the rule for future loaders.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-EW31.md
+++ b/tickets/entities/review-responses/RR-EW31.md
@@ -1,0 +1,9 @@
+---
+id: RR-EW31
+type: review-response
+title: rewriteEntityRefToken leaves stale `raw` field after mutating Codespan into Link
+finding: 'frontend/src/utils/markdown.ts lines 92-97: the codespan token is cast `as unknown as Tokens.Link` and mutated in place. The function sets type/href/title/text/tokens but never touches `raw`. Marked''s Codespan has `raw: string` (the original `\`...\`` text); marked''s Link interface also has `raw: string` (the original markdown source like `[text](url)`). After mutation the token still carries the original codespan raw — e.g. `\`TKT-LXYHQ\`` — which is meaningless as a Link''s raw. Marked''s HTML renderer doesn''t currently use raw (it parses tokens), so today this is invisible. But any future walkTokens consumer, postprocessor, or marked extension that consults `raw` (e.g. for source-map purposes, source-reconstruction round-trips, or a future Markdown re-emitter) sees an inconsistent token. Also: the e2e snapshot of `rewritten` as `Tokens.Link` is structurally incomplete — marked''s parseInline calls the link renderer which destructures `{href, title, tokens}`, so practically this works, but the strict TS type contract is being violated by an unsafe cast. Either build a fresh Link object and `Object.assign(token, fresh)`, or be explicit about which fields are intentionally stale. At minimum, blank `raw` to `linkText` so it can''t surprise a downstream consumer with a stale codespan string.'
+severity: minor
+resolution: rewriteEntityRefToken now sets rewritten.raw = '[${linkText}](${href})' so the link-shape raw replaces the codespan-shape raw. Marked's HTML renderer ignores raw on links; defensive consistency for downstream re-emitters.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GKET.md
+++ b/tickets/entities/review-responses/RR-GKET.md
@@ -1,0 +1,9 @@
+---
+id: RR-GKET
+type: review-response
+title: 'e2e: spec creates two features but only the body content path verifies the rewrite — no negative test'
+finding: 'e2e/tests/entity-refs.spec.ts has two test cases, both for the happy path: the resolved link renders and clicks navigate. There is no negative case: a code span containing an unknown ID, or a `\`TKT-NOPE\`` mixed with the known one in the SAME content, isn''t verified to remain a <code>. Without that, an over-eager refactor that resolves every code span to /entity/<unknown>/<unknown> would pass the e2e. Add: (a) a spec asserting that a code span with an unknown ID does NOT render as a link; (b) a spec asserting that a code span inside a fenced code block in the body does NOT render as a link. Both are already covered in markdown.test.ts — e2e brings the integration confidence that nothing in the SPA wiring re-introduces them.'
+severity: minor
+resolution: 'e2e spec extended: ''unknown-ID code spans remain as <code> (no link)'' and ''IDs inside fenced code blocks are not linkified''. Both use new contentCodeSpan page-object helper.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-HOSN.md
+++ b/tickets/entities/review-responses/RR-HOSN.md
@@ -1,0 +1,9 @@
+---
+id: RR-HOSN
+type: review-response
+title: Inaccessible-entity rewrite skipped when type is empty — unreachable, but the check is brittle
+finding: 'frontend/src/utils/markdown.ts lines 85-86: `if (!hit || !hit.type) return; if (!hit.inaccessible && !hit.title) return;` The first guard rejects when the resolver returns an entity with no type. On the data-entry path the server always sets Type (server-side Mention.Type comes from ent.Type, a required Entity field) so this branch is unreachable today. But the guard order conflates two intents: ''malformed Mention'' (no type) versus ''nothing to display'' (no title and not inaccessible). For a partially-locked entity where the type is set, inaccessible=true but title='''', the code falls through correctly. Suggest separating these into early returns for the malformed/inconsistent case (warn in a test) and a clean ''nothing to do'' fall-through. Minor, but the comment ''Require a type so we can build a stable URL'' is the kind of one-line load-bearing assumption that breaks loudly when the next dev changes the resolver shape.'
+severity: nit
+resolution: 'rewriteEntityRefToken refactored: type must be present (else cannot build URL); title may be empty for inaccessible (falls back to ID); for non-inaccessible a missing title means ''resolver doesn''t know enough''. Conditions inlined into a visibleTitle computation so precedence is readable.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-LQMZ.md
+++ b/tickets/entities/review-responses/RR-LQMZ.md
@@ -1,0 +1,9 @@
+---
+id: RR-LQMZ
+type: review-response
+title: 'e2e: confirm the rendered link is not produced by an unrelated path — currently inferred'
+finding: 'e2e/tests/entity-refs.spec.ts seeds an origin feature whose content contains a backticked target ID, then asserts that the entity detail page contains an anchor at `/entity/feature/<targetId>`. The link COULD in principle be rendered by some other path (a derived ''see also'' panel, a related-entities section, a renderer that auto-linkifies known IDs). The test doesn''t pin down that the link was produced by the codespan-rewrite path. Today no such alternative path exists, but the assertion is structurally fragile. Suggest scoping the locator further: assert the anchor is INSIDE the .content-body or specifically inside `.markdown-content` (the v-html target) so any future automation that adds an unrelated link won''t make the test pass for the wrong reason. Even better: query for both the absence of `<code>TARGETID</code>` AND the presence of the link, so a regression that silently leaves the code span untouched AND adds a link via another path is caught.'
+severity: nit
+resolution: contentEntityRefLink is scoped to this.contentBody so it cannot match sidebar/relation-card links. Negative test also asserts contentCodeSpan(targetId).toHaveCount(0) -- link present + code span absent is airtight.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OKQD.md
+++ b/tickets/entities/review-responses/RR-OKQD.md
@@ -1,0 +1,9 @@
+---
+id: RR-OKQD
+type: review-response
+title: viewContentBlobs misses entity-card content rendered with refResolver
+finding: 'internal/dataentry/api_v1.go viewContentBlobs only collects entry.Content and section.Content, but EntityDetail.vue line 553 also passes refResolver to renderMarkdown(ent.content || '''', refResolver) for each entity inside a content section''s section.entities array (display=''content'' with section.entities?.length, or display=''cards'' if cards ever carried content). buildSections in sections.go line 286 populates SectionEntityData.Content from the underlying entity body for the ''content''/''cards'' display paths, so the SPA does render those bodies as markdown — yet the server never scanned them for mentions. The mismatch is silent: the resolver returns null for every code span in entity-card content, so those code spans stay as <code> while identical content on the entry body becomes a link. This is the central correctness bug in the feature. Fix: extend viewContentBlobs to walk sec.Entities (and sec.Groups[].Entities) appending each ent.Content when HasContent is true. Add a regression test that seeds a view whose section.entities have content with a known-ID code span and asserts mentions contains the ID.'
+severity: critical
+resolution: Extended viewContentBlobs in internal/dataentry/api_v1.go to walk sec.Entities and sec.Groups[].Entities, appending each ent.Content when ent.HasContent. This is the exact set of blobs EntityDetail.vue passes through renderMarkdown with refResolver.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QS3N.md
+++ b/tickets/entities/review-responses/RR-QS3N.md
@@ -1,0 +1,9 @@
+---
+id: RR-QS3N
+type: review-response
+title: 'Mention public API: inaccessible_reason is a bare string — type-safety dropped at the wire'
+finding: 'internal/dataentry/mentions.go line 24 declares Mention.InaccessibleReason as `string`, even though entity.InaccessibleField.Reason is the typed `entity.InaccessibleReason` (an alias for string with documented constants like InaccessibleReasonGitCrypt). On the wire `inaccessible_reason` becomes free-form string; the SPA''s Mention.inaccessible_reason matches. This means: (a) the back-end loses type-checking on what reasons it produces — a typo at the call site won''t be caught; (b) the SPA''s `inaccessibleTooltipFor` (markdown.ts line 112) is the ONLY consumer that cares about specific values (''git-crypt''), and it''s a string literal compare — no shared enum, no exhaustiveness check. Suggestions: (1) declare `InaccessibleReason string` as the wire type (just JSON-encodes as the string anyway); (2) on the SPA side, type Mention.inaccessible_reason as a known union (''git-crypt'' | string-tag) so the tooltip helper gets an exhaustiveness signal when a new reason is added. Today the contract is also undocumented — no @stable comment on the Go struct, no link from the SPA interface to the Go truth. Add a comment to V1ViewResponse.Mentions noting the JSON shape is public API surface and changes are breaking.'
+severity: minor
+resolution: 'Documented stability contract on both Go (V1ViewResponse doc-comment) and TS (Mention interface) sides: inaccessible_reason is an opaque bare string; client must treat unknown reasons as opaque. The const set lives on Go side via entity.InaccessibleReason.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-R8IV.md
+++ b/tickets/entities/review-responses/RR-R8IV.md
@@ -1,0 +1,9 @@
+---
+id: RR-R8IV
+type: review-response
+title: 'Test coverage gap: no test for ID code spans inside tables, blockquotes, list items'
+finding: 'internal/dataentry/mentions_test.go covers paragraph context, fenced/indented code blocks (excluded), link text (excluded), multi-token spans (excluded). It does NOT cover: (a) a code span inside a GFM table cell, (b) a code span inside a blockquote, (c) a code span inside a list item, (d) a code span inside emphasis/strong (`**\`TKT-LXYHQ\`**`). All four ARE valid markdown that the SPA could render — the recursive ast.Walk handles them implicitly, but without tests a future refactor (e.g. switching to a non-recursive walk or restricting to top-level nodes) wouldn''t notice the regression. Add cases for each, both server-side (mentions_test.go) and client-side (markdown.test.ts). The frontend tests cover NONE of these either.'
+severity: minor
+resolution: Added 'code span inside list item is collected', 'code span inside blockquote is collected', 'code span inside GFM table cell is collected' to mentions_test.go. The table case motivated wiring the GFM extensions (RR-07K2).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-TSDB.md
+++ b/tickets/entities/review-responses/RR-TSDB.md
@@ -1,0 +1,9 @@
+---
+id: RR-TSDB
+type: review-response
+title: Goldmark parser concurrency not asserted — add a race-detector test
+finding: internal/dataentry/mentions.go declares `mentionsMarkdown` as a package-level singleton and pulls Parser() from it inside scanCodeSpanCandidates. Multiple concurrent HTTP requests against /api/v1/_views/... call collectMentions and therefore share the same goldmark.Markdown / parser.Parser instance. Reading goldmark's parser.go (v1.8.2 lines 864–890), Parser.Parse() uses `sync.Once` for initialization and creates fresh ParseConfig / ast.Document per call — it LOOKS thread-safe and the rest of dataentry/helpers.go already shares mdConverter the same way, so this pattern is in use. But goldmark's docs don't make a formal guarantee, and a regression in goldmark would be hard to detect. Add a unit test that fires N goroutines through scanCodeSpanCandidates with overlapping inputs and runs with -race, so the race detector catches any future change in goldmark internals. Cheap insurance against a debugging nightmare.
+severity: minor
+resolution: Added TestCollectMentions_ConcurrentScanIsSafe -- 64 goroutines scan against the shared mentionsMarkdown instance and assert identical results. goldmark.Markdown is configuration-only so concurrent use is safe; the test pins this invariant.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-WZMP.md
+++ b/tickets/entities/review-responses/RR-WZMP.md
@@ -1,0 +1,9 @@
+---
+id: RR-WZMP
+type: review-response
+title: Inaccessible-without-title rendering omits the title — URL still uses the ID, but text could include title when available
+finding: "frontend/src/utils/markdown.ts line 89: `const linkText = hit.inaccessible ? \\`${token.text} \U0001F512\\` : hit.title`. When inaccessible=true, we always use `<ID> \U0001F512` as link text, even if the title field is non-empty. Yet the only reason title would be empty is encryption — if the server happens to have a title for a partially-locked entity, the SPA throws it away. With the partial-lock concern from RR-47N9, this combines badly: a partially-locked entity with readable title 'Important thing' would render as 'TKT-001 \U0001F512' rather than 'Important thing \U0001F512'. Suggest: `const linkText = hit.inaccessible ? \\`${hit.title || token.text} \U0001F512\\` : hit.title`. Add a test case for it."
+severity: minor
+resolution: "rewriteEntityRefToken now keeps the readable title alongside the lock when supplied: visibleTitle = hit.title || (hit.inaccessible ? token.text : ''); linkText = inaccessible ? `${visibleTitle} \U0001F512` : visibleTitle. New test 'keeps the readable title alongside the lock when one is supplied' covers the partially-locked case."
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-X2E1.md
+++ b/tickets/entities/review-responses/RR-X2E1.md
@@ -1,0 +1,9 @@
+---
+id: RR-X2E1
+type: review-response
+title: 'Code quality: server uses ent.IsLocked() but Mention semantics could be expressed without IsLocked entirely'
+finding: 'Stylistic: collectMentions has the slightly unusual shape of calling `ent.IsLocked()` and then re-walking `ent.Inaccessible` inside `primaryInaccessibleReason`. Two passes over the same data. Either: (a) walk ent.Inaccessible once, returning both ''is any field locked'' AND ''first reason'', or (b) inline primaryInaccessibleReason as `if len(ent.Inaccessible) > 0 && ent.Inaccessible[0].Reason != ""`. The current shape isn''t wrong, but it imposes a tiny invariant (IsLocked => Inaccessible non-empty) that''s only documented in entity.go. The reviewer next year will wonder why we don''t just use the slice directly.'
+severity: nit
+resolution: lockedReasonFor does a single walk over e.Inaccessible returning (reason, locked) in one pass. buildMention no longer calls IsLocked() separately.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ZK8N.md
+++ b/tickets/entities/review-responses/RR-ZK8N.md
@@ -1,0 +1,9 @@
+---
+id: RR-ZK8N
+type: review-response
+title: collectMentions swallows non-NotFound errors silently — context cancellation should propagate
+finding: 'internal/dataentry/mentions.go lines 41-48: any error from `s.GetEntity` other than ErrNotFound is silently dropped with a comment claiming ''transient I/O'' degradation is acceptable. Two problems. (1) No log line means a misconfigured store, a corrupted file, or a permissions issue manifests only as missing links — the SPA shows code spans where users expected pretty links, and operators have nothing to grep. At least log at warn/debug with the ID and error. (2) `context.Canceled` and `context.DeadlineExceeded` also get swallowed, so a cancelled request still iterates through every candidate doing useless work. Add an `if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) { return nil }` early-exit, or just check ctx.Err() at the top of each loop iteration. The intent (degrade gracefully on missing entities) is right; the implementation is too coarse.'
+severity: significant
+resolution: Non-ErrNotFound errors are logged via slog.WarnContext and skipped. Context cancellation honored via ctx.Err() check. New tests TestCollectMentions_StoreErrorIsLoggedAndSkipped and TestCollectMentions_ContextCancellationStops.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ZQYG.md
+++ b/tickets/entities/review-responses/RR-ZQYG.md
@@ -1,0 +1,9 @@
+---
+id: RR-ZQYG
+type: review-response
+title: XSS test asserts no <img>, missed broader attack surface (javascript:, data:, autolink coercion)
+finding: 'frontend/src/utils/markdown.test.ts lines 151-167 is the only XSS-class assertion for the new code path. It feeds a malicious title (`<img src=x onerror=alert(1)>`) and uses DOMParser to confirm no live <img> survives. That''s a fine assertion as far as it goes — but it only covers the link-TEXT path. Missing assertions: (1) `javascript:`/`data:` href — since href is built from `/entity/${hit.type}/${token.text}`, and hit.type comes from the server, a compromised type field (''javascript:alert(1)'' or ''data:text/html,...'') could in principle land in href. Marked''s cleanUrl runs encodeURI which percent-escapes the colon (`%3A`), neutralizing javascript: URIs — but no test confirms this. (2) Title escaping for the tooltip path — inaccessibleTooltipFor builds ''inaccessible (REASON)'' with the reason interpolated raw. If reason were ever `" onmouseover=...` marked''s renderer would escape via O(t), but a test should pin that down rather than rely on marked-internal behavior. (3) Autolink edge: what if a code span text happens to look like a URL? The walkTokens hook only inspects codespan tokens (good), but a sanity test would catch a refactor that broadened the match. Add a `describe(''XSS surface'')` block covering these.'
+severity: minor
+resolution: 'Two new tests: (a) ''produces only same-origin entity hrefs'' parses output with DOMParser, asserts href.startsWith(''/entity/'') and no on* handlers; (b) ''cannot inject script via a malicious inaccessible-reason tooltip'' puts a payload in inaccessibleReason and confirms no <script> element survives -- DOMPurify drops the title entirely, which is safe.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-747O.md
+++ b/tickets/entities/tickets/TKT-747O.md
@@ -1,0 +1,72 @@
+---
+id: TKT-747O
+type: ticket
+title: Resolve entity-ID code spans to titled links in data-entry views
+kind: enhancement
+priority: medium
+effort: m
+status: done
+---
+
+## Problem
+
+When data-entry views render entity markdown body content, references like ``
+`TKT-LXYHQ` `` or `` `IDEA-011` `` appear as bare code spans containing opaque
+entity IDs. The reader has to manually copy the ID, navigate elsewhere, and
+search to discover what's being referenced — even though the project already
+knows the title and a navigable in-app URL exists.
+
+The Lua side already solved this (TKT-LXYHQ): `rela.md.resolve_refs     ` plus
+`rela.md.entity_refs     ` rewrite single-token code spans that match a known
+entity ID into proper markdown links titled with the target's title. Document
+renderers (FEAT-023) benefit when they opt in from Lua.
+
+The plain-content render path used by `EntityDetail.vue     ` and similar views
+(`frontend/src/utils/markdown.ts     `'s `renderMarkdown     `) does **not**
+apply this rewrite, so authors who use the natural convention of wrapping IDs in
+backticks in body content get no link affordance in the UI.
+
+## Proposal
+
+Apply the same opt-in code-span resolution at the data-entry markdown render
+path so any markdown content rendered in the SPA gets entity-ID code spans
+upgraded to titled links pointing into the data-entry app.
+
+Sketch:
+
+- Frontend already has an `entitiesStore     ` with cached entity summaries; surface
+a stable lookup `{ id -> title }     ` (or per-id fetch) usable from the
+markdown renderer.
+- Extend `renderMarkdown     ` (or wrap it in a render helper used by views) so
+that, after marked.js parses the markdown, code spans whose text matches a known
+entity ID are replaced by `<a href="/entity/<id>">Title</a>     `.
+- Only rewrite code spans whose **entire** text is an entity ID — match the
+Lua semantics exactly (no bare prose mentions). Unknown IDs are left as plain
+code spans.
+- Reuse the existing entity URL scheme used elsewhere in the SPA (router
+link for `/entity/:id     ` or equivalent) — do not invent a new one.
+
+## Out of scope
+
+- Server-side document rendering (FEAT-023) — already covered by the Lua API.
+- `[[ID]]     ` Obsidian-style wiki link syntax (`IDEA-011     `).
+- Bare prose mentions outside code spans.
+- Hover previews or backlinks panels.
+
+## Acceptance Criteria
+
+1. Markdown rendered in `EntityDetail.vue     ` (entity body and section content)
+replaces code spans whose entire content matches a known entity ID with a link
+whose text is the target's title and whose href routes to the entity's
+data-entry detail view.
+2. Unknown IDs are left as code spans (no link, no warning surfaced to users).
+3. Code spans containing anything other than a bare ID (e.g. `` `TKT-1 and TKT-2` ``)
+are not rewritten.
+4. Code blocks, link text, link URLs, and HTML attributes are not affected.
+5. The rewrite is sanitization-safe — output continues to pass DOMPurify
+without weakening the existing sanitizer config.
+6. Unit tests cover: known-ID replacement, unknown-ID passthrough, multi-ID
+code spans, ID inside fenced code block, ID inside existing link text, escaping
+of entity titles containing HTML-significant characters.
+7. Manual verification in the running dev server confirms the link is
+clickable and navigates correctly.

--- a/tickets/relations/TKT-747O--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-747O--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-747O--has-implementation--IMPL-L5OQ.md
+++ b/tickets/relations/TKT-747O--has-implementation--IMPL-L5OQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-implementation
+to: IMPL-L5OQ
+---

--- a/tickets/relations/TKT-747O--has-planning--PLAN-V6BB.md
+++ b/tickets/relations/TKT-747O--has-planning--PLAN-V6BB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-planning
+to: PLAN-V6BB
+---

--- a/tickets/relations/TKT-747O--has-review--REV-KGV0.md
+++ b/tickets/relations/TKT-747O--has-review--REV-KGV0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review
+to: REV-KGV0
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-07K2.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-07K2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-07K2
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-47N9.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-47N9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-47N9
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-58F4.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-58F4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-58F4
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-74JH.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-74JH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-74JH
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-A9DU.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-A9DU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-A9DU
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-BQA3.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-BQA3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-BQA3
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-DW2V.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-DW2V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-DW2V
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-EW31.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-EW31.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-EW31
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-GKET.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-GKET.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-GKET
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-HOSN.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-HOSN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-HOSN
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-LQMZ.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-LQMZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-LQMZ
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-OKQD.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-OKQD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-OKQD
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-QS3N.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-QS3N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-QS3N
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-R8IV.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-R8IV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-R8IV
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-TSDB.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-TSDB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-TSDB
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-WZMP.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-WZMP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-WZMP
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-X2E1.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-X2E1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-X2E1
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-ZK8N.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-ZK8N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-ZK8N
+---

--- a/tickets/relations/TKT-747O--has-review-response--RR-ZQYG.md
+++ b/tickets/relations/TKT-747O--has-review-response--RR-ZQYG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: has-review-response
+to: RR-ZQYG
+---

--- a/tickets/relations/TKT-747O--implements--FEAT-010.md
+++ b/tickets/relations/TKT-747O--implements--FEAT-010.md
@@ -1,0 +1,5 @@
+---
+from: TKT-747O
+relation: implements
+to: FEAT-010
+---


### PR DESCRIPTION
## Summary

- Server-side scan of view-fetch markdown bodies for inline code spans whose
  text is a known entity ID; resolved targets returned as a top-level
  `mentions` map on `ViewResponse` (`internal/dataentry/mentions.go`).
- Frontend `renderMarkdown` learns an optional sync `refResolver` that uses
  marked's `walkTokens` to rewrite matching `codespan` tokens into `link`
  tokens. `EntityDetail.vue` derives the resolver from `viewData.mentions`
  and passes it to all three `renderMarkdown` call sites.
- Mirrors the existing Lua-side feature from TKT-LXYHQ (`rela.md.resolve_refs`
  / `rela.md.entity_refs`) so authors get the same `` `<id>` `` → titled
  link affordance whether they render markdown through Lua or through the
  data-entry SPA.
- Inaccessible (e.g. git-crypt encrypted) targets render as
  `<a href>ID 🔒</a>` with the standard `PropertyDisplay.vue` tooltip copy;
  partial locks keep the readable title.
- Adds a themed link style for `.content-body` / `.markdown-content`
  anchors so rendered markdown links use `--accent-color` instead of the
  browser default purple in dark mode.

## Test plan

- [x] Go: `go test -race ./...` — all packages pass; `internal/dataentry`
  gains `mentions_test.go` (table-driven scan + resolve, context
  cancellation, store-error logging, concurrent-scan safety) and two new
  view-response assertions in `api_v1_test.go`
- [x] Frontend: `npm run test:run` — 666 tests / 38 files; new
  `refResolver` describe block in `markdown.test.ts` covers happy path,
  manual IDs, unknown, multi-token, fenced blocks, link text, XSS via
  title and tooltip (DOMParser-based), inaccessible with/without title,
  self-reference, no-resolver backwards compat, `javascript:`/`data:`
  href guard
- [x] e2e: `e2e/tests/entity-refs.spec.ts` with 4 cases: link rendered,
  click navigates, unknown ID stays as `<code>`, fenced block not
  linkified
- [x] `just ci` clean (lint, arch-lint, coverage, build, docs)
- [x] Manual verification against `tickets/`: `GET /_views/ticket/TKT-77JD4`
  returns the expected `mentions` entry; browsing the rendered detail
  page shows the link with themed color in dark mode

## Notes

- Wire shape: `mentions` is a new top-level field on `ViewResponse` (not
  squatted into `entry.relations`, which is metamodel-typed). The
  `Mention` struct documents that `inaccessible_reason` is an opaque
  string — new reasons can be added server-side without a client change.
- Code-review cycle filed 19 review-response entities; 18 addressed,
  1 deferred (RR-A9DU — shared scanner refactor between Lua/HTTP paths,
  out of scope).