### PR TITLE
feat(data-entry): unify relation-widget save via PATCH (TKT-ZEKO4)

### DIFF
--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -1,5 +1,14 @@
 import { api } from './client'
-import type { Entity, CreateEntity, ListResponse, ListParams, AnalyzeResult, Template, RelationEntry } from '@/types'
+import type {
+  Entity,
+  CreateEntity,
+  ListResponse,
+  ListParams,
+  AnalyzeResult,
+  Template,
+  RelationEntry,
+  ModernRelationsField,
+} from '@/types'
 import { useSchemaStore } from '@/stores/schema'
 
 function getPlural(type: string): string {
@@ -27,10 +36,18 @@ export async function createEntity(type: string, entity: CreateEntity): Promise<
   return api.post<Entity>(`/${getPlural(type)}`, entity)
 }
 
+// EntityPatch is the union of legacy IDs-only and modern JSON:API §9
+// relation shapes the unified PATCH endpoint accepts. The body must
+// not mix shapes (`shape_mixed` 400); the SPA's body-assembly helper
+// in DynamicForm ensures all-modern-or-all-legacy.
+export type EntityPatch = Omit<Partial<Entity>, 'relations'> & {
+  relations?: Record<string, string[]> | ModernRelationsField
+}
+
 export async function updateEntity(
   type: string,
   id: string,
-  patch: Partial<Entity>,
+  patch: EntityPatch,
   etag?: string
 ): Promise<Entity> {
   return api.patch<Entity>(`/${getPlural(type)}/${id}`, patch, etag)

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -6,9 +6,15 @@ import { isCancelledFetch } from '@/composables/usePageData'
 import { readReturnTo } from '@/utils/returnPath'
 import { useEntityIDControls } from '@/composables/useEntityIDControls'
 import { useConfirm } from '@/composables/useConfirm'
-import type { PropertyDef, FormFieldOrRelation, Template } from '@/types'
-import { getTemplates, createRelation, updateRelationProperties, deleteRelation } from '@/api'
+import type { PropertyDef, FormFieldOrRelation, Template, ModernRelationsField } from '@/types'
+import { getTemplates, createRelation, deleteRelation, updateRelationProperties } from '@/api'
 import type { RelationCardState } from './RelationCards.vue'
+import {
+  buildRelationsPatch,
+  reshapeLegacyToModern,
+  OUTGOING_SUFFIX,
+  INCOMING_SUFFIX,
+} from './relationsPatch'
 import FieldRenderer from './FieldRenderer.vue'
 import RelationPicker from './RelationPicker.vue'
 import RelationCards from './RelationCards.vue'
@@ -40,6 +46,11 @@ const returnTo = ref<string | null>(null)
 // State
 const formData = ref<Record<string, unknown>>({})
 const relations = ref<Record<string, string[]>>({})
+// Per-relation `id -> entity type` map, fed by RelationPicker's
+// `update:types` emit. Required by the unified PATCH builder to emit
+// JSON:API §9 resource identifiers without guessing target types
+// via `to[0]` (which is wrong for polymorphic relations).
+const pickerTypes = ref<Record<string, Map<string, string>>>({})
 const content = ref('')
 const loading = ref(true)
 const saveGeneration = ref(0) // Incremented after save to reset RelationCards
@@ -332,8 +343,9 @@ async function handleSubmit() {
 
   saving.value = true
   try {
-    // Exclude card-managed relations from the entity update payload —
-    // those are saved separately via savePendingRelationCards()
+    // Card-managed relations are not put into the legacy
+    // `filteredRelations` IDs-only map — they're delivered through
+    // pendingCardChanges and the unified PATCH-with-relations shape.
     const cardRelations = new Set(
       fields.value
         .filter((f) => f.relation && f.widget === 'cards')
@@ -346,26 +358,63 @@ async function handleSubmit() {
       }
     }
 
+    // Build modern relations from card edits. If any outgoing card was
+    // touched, the entire body must use modern shape (`shape_mixed`
+    // 400). Reshape the legacy picker IDs via `pickerTypes`; if any
+    // picker target has no resolved type, fall back to legacy + warn
+    // (TKT-ZEKO4 Q5).
+    const modernRelations = buildRelationsPatch(pendingCardChanges.value)
+    const hasModernCardEntries = Object.keys(modernRelations).length > 0
+    let relationsPayload: Record<string, string[]> | ModernRelationsField = filteredRelations
+    if (hasModernCardEntries) {
+      const reshaped = reshapeLegacyToModern(filteredRelations, pickerTypes.value)
+      if (reshaped) {
+        relationsPayload = { ...reshaped, ...modernRelations }
+      } else {
+        // Pathological form — surface and stay legacy for THIS save.
+        // Per-edge card meta is lost; user is told to reload to get
+        // fresh edge types from backend Step 0.
+        uiStore.error(
+          'Some related entities have unknown types. Card-only changes are not saved. Reload the form and try again.',
+        )
+        // Drop the outgoing card-edit Map entries so they aren't
+        // mistakenly cleared on success below.
+        for (const key of Array.from(pendingCardChanges.value.keys())) {
+          if (key.endsWith(OUTGOING_SUFFIX)) pendingCardChanges.value.delete(key)
+        }
+      }
+    }
+
     const payload: {
       id?: string
       prefix?: string
       properties: Record<string, unknown>
-      relations: Record<string, string[]>
+      relations: Record<string, string[]> | ModernRelationsField
       content?: string
     } = {
       properties: formData.value,
-      relations: filteredRelations,
+      relations: relationsPayload,
       content: content.value || undefined,
     }
 
     if (isEdit.value && props.entityId) {
-      await entitiesStore.update(formConfig.value.entity, props.entityId, payload)
-      // Save any pending relation card changes (adds, removes, property edits)
-      await savePendingRelationCards()
+      const updated = await entitiesStore.update(formConfig.value.entity, props.entityId, payload)
+      // Incoming-direction edits remain on the per-edge path; the
+      // unified wire format has no `direction:incoming` concept.
+      await savePendingIncomingChanges()
+      surfaceWarnings(updated.warnings)
       uiStore.success('Entity updated successfully')
     } else {
+      // Create path stays legacy: POST handler hard-codes
+      // `map[string][]string`, modern shape is not accepted. Cards
+      // never render in create mode (they require entityId), so
+      // `pendingCardChanges` is empty and relationsPayload is the
+      // legacy `filteredRelations`. The cast is safe by construction.
       Object.assign(payload, idControls.buildPayloadFields())
-      const entity = await entitiesStore.create(formConfig.value.entity, payload)
+      const entity = await entitiesStore.create(formConfig.value.entity, {
+        ...payload,
+        relations: filteredRelations,
+      })
 
       // Handle auto-linking from link_* params (e.g., from custom view "Add" buttons)
       // For link_as=to, the relation is already included in relations.value (pre-filled)
@@ -445,6 +494,10 @@ function updateRelation(relation: string, value: string[]) {
   checkDirty()
 }
 
+function updateRelationTypes(relation: string, types: Map<string, string>) {
+  pickerTypes.value[relation] = types
+}
+
 // Pending relation card changes (for batch save)
 const pendingCardChanges = ref<Map<string, RelationCardState>>(new Map())
 
@@ -453,16 +506,16 @@ function updateRelationCards(relation: string, state: RelationCardState) {
   checkDirty()
 }
 
-// Bridge incoming-direction RelationPicker changes into the same pending-
-// changes map that RelationCards uses so savePendingRelationCards reconciles
-// them through the direction-aware create/delete path. Keyed with the
-// `-incoming` suffix that the save loop already understands. Pickers have
-// no editable relation-properties so `updated` is always empty.
+// Bridge incoming-direction RelationPicker changes into the pending-
+// changes map under an `-incoming` suffix. The unified PATCH wire
+// format has no `direction:incoming` concept, so these are NOT
+// merged into the entity PATCH — they're applied via the legacy
+// per-edge endpoints in savePendingIncomingChanges below.
 function updateIncomingPicker(
   relation: string,
   state: { added: Array<{ targetId: string }>; removed: string[] },
 ) {
-  pendingCardChanges.value.set(`${relation}-incoming`, {
+  pendingCardChanges.value.set(`${relation}${INCOMING_SUFFIX}`, {
     entries: [],
     added: state.added,
     removed: state.removed,
@@ -471,28 +524,47 @@ function updateIncomingPicker(
   checkDirty()
 }
 
-async function savePendingRelationCards() {
+// Apply incoming-direction edits via per-edge endpoints. The unified
+// PATCH wire format has no `direction:incoming` concept, so incoming
+// adds, removes, AND meta updates all stay on the per-edge path.
+// Outgoing edits were already saved as part of the unified PATCH body,
+// so the Map's outgoing entries are no-ops here; we filter by suffix
+// for clarity. After this returns, clear the whole map: both channels'
+// work is complete.
+async function savePendingIncomingChanges() {
   const entity = formConfig.value!.entity
   const entityId = props.entityId!
 
   await Promise.all(
-    Array.from(pendingCardChanges.value.entries()).map(async ([key, state]) => {
-      const relation = key.replace(/-outgoing$|-incoming$/, '')
-      const direction = key.endsWith('-incoming') ? 'incoming' : undefined
-      for (const targetId of state.removed) {
-        await deleteRelation(entity, entityId, relation, targetId, direction)
-      }
-      for (const add of state.added) {
-        await createRelation(entity, entityId, relation, add.targetId, add.meta, direction)
-      }
-      for (const upd of state.updated) {
-        await updateRelationProperties(entity, entityId, relation, upd.targetId, upd.meta, direction)
-      }
-    })
+    Array.from(pendingCardChanges.value.entries())
+      .filter(([key]) => key.endsWith(INCOMING_SUFFIX))
+      .map(async ([key, state]) => {
+        const relation = key.slice(0, -INCOMING_SUFFIX.length)
+        for (const targetId of state.removed) {
+          await deleteRelation(entity, entityId, relation, targetId, 'incoming')
+        }
+        for (const add of state.added) {
+          await createRelation(entity, entityId, relation, add.targetId, add.meta, 'incoming')
+        }
+        for (const upd of state.updated) {
+          await updateRelationProperties(entity, entityId, relation, upd.targetId, upd.meta, 'incoming')
+        }
+      }),
   )
 
   pendingCardChanges.value.clear()
   saveGeneration.value++
+}
+
+// Surface soft validation warnings from a mutation response as a
+// non-blocking toast. Per DEC-HWZHA, soft conditions (target type
+// mismatch, unknown meta key, required-meta unset, etc.) ride on the
+// 200 response rather than failing it. Without this, the conditions
+// would be invisible to the user.
+function surfaceWarnings(warnings: { code: string; path: string; detail: string }[] | undefined) {
+  if (!warnings || warnings.length === 0) return
+  const codes = [...new Set(warnings.map((w) => w.code))].join(', ')
+  uiStore.warning(`Saved with ${warnings.length} warning(s): ${codes}`)
 }
 
 function updateContent(value: string) {
@@ -663,6 +735,7 @@ onBeforeRouteLeave(async () => {
                   :entity-id="entityId"
                   :value="relations[field.relation] || []"
                   @update="updateRelation(field.relation!, $event)"
+                  @update:types="(types) => updateRelationTypes(field.relation!, types)"
                   @incoming-changed="(state) => updateIncomingPicker(field.relation!, state)"
                 />
               </template>

--- a/frontend/src/components/forms/RelationCards.vue
+++ b/frontend/src/components/forms/RelationCards.vue
@@ -12,13 +12,11 @@ import {
 import type { FormFieldOrRelation, RelationProperty } from '@/types/config'
 import type { RelationEntry, Entity } from '@/types/entity'
 import type { PropertyDef } from '@/types/schema'
+import type { RelationCardState } from './relationsPatch'
 
-export interface RelationCardState {
-  entries: RelationEntry[]
-  added: Array<{ targetId: string; meta?: Record<string, unknown> }>
-  removed: string[]
-  updated: Array<{ targetId: string; meta: Record<string, unknown> }>
-}
+// Re-export so existing `import type { RelationCardState } from './RelationCards.vue'`
+// callers keep working without a churn rename.
+export type { RelationCardState }
 
 const props = defineProps<{
   field: FormFieldOrRelation
@@ -277,6 +275,7 @@ function addRelation() {
   // Add to local entries
   const newEntry: RelationEntry = {
     id: targetId,
+    type: selectedTarget.value.type,
     direction: isIncoming.value ? 'incoming' : 'outgoing',
     meta,
   }

--- a/frontend/src/components/forms/RelationPicker.vue
+++ b/frontend/src/components/forms/RelationPicker.vue
@@ -24,6 +24,11 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   update: [value: string[]]
+  // Companion to `update`: a Map of selected-target ID → entity type.
+  // The unified PATCH builder needs `type` for every resource identifier
+  // (JSON:API §9). RelationPicker is the only widget that knows the
+  // type at pick time. Emitted on every `update` and on initial load.
+  'update:types': [types: Map<string, string>]
   'incoming-changed': [payload: RelationPickerIncomingState]
 }>()
 
@@ -137,16 +142,28 @@ function emitIncomingDiff() {
   emit('incoming-changed', { added, removed })
 }
 
+// Build a Map<id, type> from candidates for the current outgoing
+// selection. Used to feed DynamicForm's pickerTypes so the unified
+// PATCH builder can populate `type` per resource identifier without
+// guessing via `to[0]` or `id_prefix`.
+function buildOutgoingTypes(ids: string[]): Map<string, string> {
+  const out = new Map<string, string>()
+  for (const c of candidates.value) {
+    if (ids.includes(c.id)) out.set(c.id, c.type)
+  }
+  return out
+}
+
 function selectEntity(entity: Entity) {
   if (isIncoming.value) {
     incomingValue.value = isMulti.value
       ? [...incomingValue.value, entity.id]
       : [entity.id]
     emitIncomingDiff()
-  } else if (isMulti.value) {
-    emit('update', [...props.value, entity.id])
   } else {
-    emit('update', [entity.id])
+    const next = isMulti.value ? [...props.value, entity.id] : [entity.id]
+    emit('update', next)
+    emit('update:types', buildOutgoingTypes(next))
   }
   searchQuery.value = ''
   showDropdown.value = false
@@ -157,7 +174,9 @@ function removeEntity(entityId: string) {
     incomingValue.value = incomingValue.value.filter((id) => id !== entityId)
     emitIncomingDiff()
   } else {
-    emit('update', props.value.filter((id) => id !== entityId))
+    const next = props.value.filter((id) => id !== entityId)
+    emit('update', next)
+    emit('update:types', buildOutgoingTypes(next))
   }
 }
 
@@ -186,6 +205,12 @@ function handleEntityCreated(entity: Entity) {
 onMounted(async () => {
   await loadCandidates()
   await loadIncomingValue()
+  // Surface types for any pre-existing outgoing selection so the
+  // submit-time PATCH builder knows the type even when the user
+  // didn't touch this widget.
+  if (!isIncoming.value && props.value.length > 0) {
+    emit('update:types', buildOutgoingTypes(props.value))
+  }
 })
 
 // Close dropdown when clicking outside

--- a/frontend/src/components/forms/relationsPatch.test.ts
+++ b/frontend/src/components/forms/relationsPatch.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildRelationsPatch,
+  reshapeLegacyToModern,
+  OUTGOING_SUFFIX,
+  INCOMING_SUFFIX,
+  type RelationCardState,
+} from './relationsPatch'
+
+// Test builder helpers for RelationCardState — minimize boilerplate
+// per the project's test-writing guidance.
+function card(overrides: Partial<RelationCardState> = {}): RelationCardState {
+  return {
+    entries: [],
+    added: [],
+    removed: [],
+    updated: [],
+    ...overrides,
+  }
+}
+
+function pending(entries: Record<string, RelationCardState>): Map<string, RelationCardState> {
+  return new Map(Object.entries(entries))
+}
+
+describe('buildRelationsPatch', () => {
+  it('emits no entry when the card was not touched (autosave/stale-Map safety)', () => {
+    // The Map may legitimately contain a key for a card that the user
+    // never edited (e.g., autosave wires the same Map for many cards).
+    // Emitting `data: []` here would WIPE every edge of that type.
+    const result = buildRelationsPatch(
+      pending({
+        ['tagged' + OUTGOING_SUFFIX]: card({
+          entries: [{ id: 'L-1', type: 'label' }],
+          added: [],
+          removed: [],
+          updated: [],
+        }),
+      }),
+    )
+    expect(result).toEqual({})
+  })
+
+  it('add-one produces single-entry data', () => {
+    const result = buildRelationsPatch(
+      pending({
+        ['tagged' + OUTGOING_SUFFIX]: card({
+          entries: [{ id: 'L-1', type: 'label' }],
+          added: [{ targetId: 'L-1' }],
+        }),
+      }),
+    )
+    expect(result).toEqual({ tagged: { data: [{ type: 'label', id: 'L-1' }] } })
+  })
+
+  it('removal keeps only retained rows in data', () => {
+    const result = buildRelationsPatch(
+      pending({
+        ['tagged' + OUTGOING_SUFFIX]: card({
+          entries: [{ id: 'L-2', type: 'label' }],
+          removed: ['L-1'],
+        }),
+      }),
+    )
+    expect(result.tagged.data).toEqual([{ type: 'label', id: 'L-2' }])
+  })
+
+  it('clear-all sends data: []', () => {
+    const result = buildRelationsPatch(
+      pending({
+        ['tagged' + OUTGOING_SUFFIX]: card({
+          entries: [],
+          removed: ['L-1', 'L-2'],
+        }),
+      }),
+    )
+    expect(result.tagged.data).toEqual([])
+  })
+
+  it('preserves per-edge meta', () => {
+    const result = buildRelationsPatch(
+      pending({
+        ['tagged' + OUTGOING_SUFFIX]: card({
+          entries: [{ id: 'L-1', type: 'label', meta: { weight: 5 } }],
+          updated: [{ targetId: 'L-1', meta: { weight: 5 } }],
+        }),
+      }),
+    )
+    expect(result.tagged.data[0]).toEqual({
+      type: 'label',
+      id: 'L-1',
+      meta: { weight: 5 },
+    })
+  })
+
+  it('omits empty meta (no key) — wire shape stays minimal', () => {
+    const result = buildRelationsPatch(
+      pending({
+        ['tagged' + OUTGOING_SUFFIX]: card({
+          entries: [{ id: 'L-1', type: 'label', meta: {} }],
+          added: [{ targetId: 'L-1' }],
+        }),
+      }),
+    )
+    expect(result.tagged.data[0]).toEqual({ type: 'label', id: 'L-1' })
+  })
+
+  it('preserves per-edge content when present (plumbing for future UI)', () => {
+    const result = buildRelationsPatch(
+      pending({
+        ['tagged' + OUTGOING_SUFFIX]: card({
+          entries: [{ id: 'L-1', type: 'label', content: 'why this label' }],
+          added: [{ targetId: 'L-1' }],
+        }),
+      }),
+    )
+    expect(result.tagged.data[0]).toEqual({
+      type: 'label',
+      id: 'L-1',
+      content: 'why this label',
+    })
+  })
+
+  it('skips incoming-suffix keys (they take the per-edge path)', () => {
+    const result = buildRelationsPatch(
+      pending({
+        ['tagged' + INCOMING_SUFFIX]: card({
+          entries: [{ id: 'T-1', type: 'ticket' }],
+          added: [{ targetId: 'T-1' }],
+        }),
+      }),
+    )
+    expect(result).toEqual({})
+  })
+
+  it('mixed in+out keeps outgoing, skips incoming', () => {
+    const result = buildRelationsPatch(
+      pending({
+        ['tagged' + OUTGOING_SUFFIX]: card({
+          entries: [{ id: 'L-1', type: 'label' }],
+          added: [{ targetId: 'L-1' }],
+        }),
+        ['referenced-by' + INCOMING_SUFFIX]: card({
+          entries: [{ id: 'T-1', type: 'ticket' }],
+          added: [{ targetId: 'T-1' }],
+        }),
+      }),
+    )
+    expect(Object.keys(result)).toEqual(['tagged'])
+  })
+
+  it('throws loudly when an entry is missing type (drift surfaces, not silent corruption)', () => {
+    expect(() =>
+      buildRelationsPatch(
+        pending({
+          ['tagged' + OUTGOING_SUFFIX]: card({
+            // Cast deliberately — simulates older-server payload that
+            // landed in entries via a stale RelationEntry without
+            // backend Step 0.
+            entries: [{ id: 'L-1' } as unknown as { id: string; type: string }],
+            added: [{ targetId: 'L-1' }],
+          }),
+        }),
+      ),
+    ).toThrow(/missing 'type'/)
+  })
+})
+
+describe('reshapeLegacyToModern', () => {
+  it('returns null when ANY id has no type — caller falls back to legacy', () => {
+    const result = reshapeLegacyToModern(
+      { 'depends-on': ['T-1', 'C-unknown'] },
+      { 'depends-on': new Map([['T-1', 'ticket']]) },
+    )
+    expect(result).toBeNull()
+  })
+
+  it('reshapes when all ids have known types', () => {
+    const result = reshapeLegacyToModern(
+      { 'depends-on': ['T-1', 'BUG-1'] },
+      {
+        'depends-on': new Map([
+          ['T-1', 'ticket'],
+          ['BUG-1', 'bug'],
+        ]),
+      },
+    )
+    expect(result).toEqual({
+      'depends-on': {
+        data: [
+          { type: 'ticket', id: 'T-1' },
+          { type: 'bug', id: 'BUG-1' },
+        ],
+      },
+    })
+  })
+
+  it('empty legacy lists become explicit data: [] (clear-all preserved)', () => {
+    const result = reshapeLegacyToModern({ tagged: [] }, { tagged: new Map() })
+    expect(result).toEqual({ tagged: { data: [] } })
+  })
+
+  it('preserves polymorphic-target type per row (no to[0] guessing)', () => {
+    // Hard-coded values are the load-bearing assertion: that types come
+    // from the per-id Map, not from a "first allowed target type"
+    // schema fallback that would homogenize them.
+    const result = reshapeLegacyToModern(
+      { 'depends-on': ['T-1', 'BUG-1', 'FEAT-1', 'DT-1'] },
+      {
+        'depends-on': new Map([
+          ['T-1', 'ticket'],
+          ['BUG-1', 'bug'],
+          ['FEAT-1', 'feature'],
+          ['DT-1', 'doc-task'],
+        ]),
+      },
+    )
+    expect(result?.['depends-on'].data.map((d) => d.type)).toEqual([
+      'ticket',
+      'bug',
+      'feature',
+      'doc-task',
+    ])
+  })
+})

--- a/frontend/src/components/forms/relationsPatch.ts
+++ b/frontend/src/components/forms/relationsPatch.ts
@@ -1,0 +1,116 @@
+// Patch-builder helpers for the unified PATCH-with-relations endpoint
+// landed in TKT-6WLSW. Consumed by DynamicForm.handleSubmit.
+//
+// Two responsibilities:
+//
+// 1. buildRelationsPatch turns the per-relation pendingCardChanges Map
+//    (kept by RelationCards via the cards-changed event) into the
+//    JSON:API §9 modern relations field carried on the PATCH body.
+//
+// 2. reshapeLegacyToModern converts a legacy IDs-only relations record
+//    into the modern shape using a per-relation Map<id, type> sourced
+//    from RelationPicker's `update:types` emit. Used when card edits
+//    force the whole body to modern (the wire format forbids mixing).
+
+import type {
+  ModernRelationsField,
+  ResourceIdentifier,
+  RelationEntry,
+} from '@/types'
+
+// Suffix keys used by DynamicForm's pendingCardChanges Map to
+// distinguish outgoing vs incoming card-managed widgets. The builder
+// must understand these to skip incoming entries (they take the
+// per-edge path), and so DynamicForm/RelationCards don't sprinkle
+// string literals.
+export const OUTGOING_SUFFIX = '-outgoing'
+export const INCOMING_SUFFIX = '-incoming'
+
+// Structural shape of RelationCards' cards-changed payload. Defined
+// inline (rather than re-imported from RelationCards.vue) to keep this
+// module free of Vue-SFC imports — Vitest's vue-tsc can chew on the
+// .vue, but plain .ts helpers should not depend on SFC types.
+export interface RelationCardState {
+  entries: RelationEntry[]
+  added: Array<{ targetId: string; meta?: Record<string, unknown> }>
+  removed: string[]
+  updated: Array<{ targetId: string; meta: Record<string, unknown> }>
+}
+
+// Build the modern relations field for the unified PATCH from the
+// pending card-changes Map. Contract:
+//
+//   - Input keys are `<relation>${OUTGOING_SUFFIX}` or
+//     `<relation>${INCOMING_SUFFIX}`. Incoming keys are skipped here;
+//     they take the per-edge path.
+//   - Emit a relation entry ONLY when the user actually touched it
+//     during this form session (added/removed/updated non-empty).
+//     A pristine card in the Map produces no key — preventing
+//     `data: []` wipes on autosave with a stale Map (TKT-ZEKO4 Q6).
+//   - `state.entries` is the post-edit desired set; the builder maps
+//     it to resource identifiers directly.
+//   - Every entry MUST carry `type` (backend Step 0 + RelationCards
+//     populate). The builder throws on missing `type` to surface a
+//     drift bug loudly instead of emitting a malformed body.
+export function buildRelationsPatch(
+  pending: Map<string, RelationCardState>,
+): ModernRelationsField {
+  const out: ModernRelationsField = {}
+  for (const [key, state] of pending.entries()) {
+    if (key.endsWith(INCOMING_SUFFIX)) continue
+    if (!key.endsWith(OUTGOING_SUFFIX)) continue
+    if (
+      state.added.length === 0 &&
+      state.removed.length === 0 &&
+      state.updated.length === 0
+    ) {
+      continue
+    }
+    const relation = key.slice(0, -OUTGOING_SUFFIX.length)
+    const data: ResourceIdentifier[] = state.entries.map((e) => {
+      if (!e.type) {
+        throw new Error(
+          `RelationEntry ${e.id} missing 'type'. ` +
+            `Backend or RelationCards drift — refusing to emit a malformed PATCH.`,
+        )
+      }
+      const ri: ResourceIdentifier = { type: e.type, id: e.id }
+      if (e.meta && Object.keys(e.meta).length > 0) {
+        ri.meta = { ...e.meta }
+      }
+      if (e.content !== undefined) {
+        ri.content = e.content
+      }
+      return ri
+    })
+    out[relation] = { data }
+  }
+  return out
+}
+
+// Reshape a legacy IDs-only relations record into the modern shape
+// using a per-relation `pickerTypes` map.
+//
+// Returns null if any ID has no resolved type. Caller's choice on
+// fallback (DynamicForm falls back to a legacy body + warning toast).
+//
+// Empty `[]` for a relation type maps to `{data: []}` which clears
+// all edges of that type on the server — exactly mirrors legacy
+// semantics, so this is correct.
+export function reshapeLegacyToModern(
+  legacy: Record<string, string[]>,
+  pickerTypes: Record<string, Map<string, string>>,
+): ModernRelationsField | null {
+  const out: ModernRelationsField = {}
+  for (const [relation, ids] of Object.entries(legacy)) {
+    const types = pickerTypes[relation]
+    const data: ResourceIdentifier[] = []
+    for (const id of ids) {
+      const type = types?.get(id)
+      if (!type) return null
+      data.push({ type, id })
+    }
+    out[relation] = { data }
+  }
+  return out
+}

--- a/frontend/src/components/forms/relationsPatchBodyAssembly.test.ts
+++ b/frontend/src/components/forms/relationsPatchBodyAssembly.test.ts
@@ -1,0 +1,126 @@
+// End-to-end assertions about how DynamicForm.handleSubmit composes
+// `relations` for the unified PATCH body. These cases mirror the
+// `relationsPayload` selection in DynamicForm — buildRelationsPatch
+// produces card edits, reshapeLegacyToModern handles the
+// mixed-shape constraint, and the fallback path keeps legacy when
+// any picker target's type is unresolved (TKT-ZEKO4 AC7, AC8).
+
+import { describe, it, expect } from 'vitest'
+import {
+  buildRelationsPatch,
+  reshapeLegacyToModern,
+  OUTGOING_SUFFIX,
+  type RelationCardState,
+} from './relationsPatch'
+
+function card(overrides: Partial<RelationCardState> = {}): RelationCardState {
+  return { entries: [], added: [], removed: [], updated: [], ...overrides }
+}
+
+function assemble(
+  pending: Map<string, RelationCardState>,
+  legacy: Record<string, string[]>,
+  pickerTypes: Record<string, Map<string, string>>,
+): { shape: 'modern' | 'legacy' | 'mixed-blocked'; body: unknown } {
+  const modern = buildRelationsPatch(pending)
+  const hasModern = Object.keys(modern).length > 0
+  if (!hasModern) return { shape: 'legacy', body: legacy }
+  const reshaped = reshapeLegacyToModern(legacy, pickerTypes)
+  if (!reshaped) return { shape: 'mixed-blocked', body: legacy }
+  return { shape: 'modern', body: { ...reshaped, ...modern } }
+}
+
+describe('relations body assembly', () => {
+  it('AC7: no card edits → legacy shape unchanged', () => {
+    const result = assemble(
+      new Map(),
+      { 'depends-on': ['T-1'] },
+      { 'depends-on': new Map([['T-1', 'ticket']]) },
+    )
+    expect(result.shape).toBe('legacy')
+    expect(result.body).toEqual({ 'depends-on': ['T-1'] })
+  })
+
+  it('AC7: card edits + picker with all types known → all modern', () => {
+    const pending = new Map<string, RelationCardState>([
+      [
+        'tagged' + OUTGOING_SUFFIX,
+        card({
+          entries: [{ id: 'L-1', type: 'label' }],
+          added: [{ targetId: 'L-1' }],
+        }),
+      ],
+    ])
+    const result = assemble(
+      pending,
+      { 'depends-on': ['T-1'] },
+      { 'depends-on': new Map([['T-1', 'ticket']]) },
+    )
+    expect(result.shape).toBe('modern')
+    expect(result.body).toEqual({
+      'depends-on': { data: [{ type: 'ticket', id: 'T-1' }] },
+      tagged: { data: [{ type: 'label', id: 'L-1' }] },
+    })
+  })
+
+  it('AC8: card edits + picker with missing type → mixed-blocked', () => {
+    const pending = new Map<string, RelationCardState>([
+      [
+        'tagged' + OUTGOING_SUFFIX,
+        card({
+          entries: [{ id: 'L-1', type: 'label' }],
+          added: [{ targetId: 'L-1' }],
+        }),
+      ],
+    ])
+    const result = assemble(
+      pending,
+      { 'depends-on': ['T-1', 'C-unknown'] },
+      { 'depends-on': new Map([['T-1', 'ticket']]) },
+    )
+    expect(result.shape).toBe('mixed-blocked')
+  })
+
+  it('card edits only, no other relations in body → modern, no reshape needed', () => {
+    const pending = new Map<string, RelationCardState>([
+      [
+        'tagged' + OUTGOING_SUFFIX,
+        card({
+          entries: [{ id: 'L-1', type: 'label' }],
+          added: [{ targetId: 'L-1' }],
+        }),
+      ],
+    ])
+    const result = assemble(pending, {}, {})
+    expect(result.shape).toBe('modern')
+    expect(result.body).toEqual({
+      tagged: { data: [{ type: 'label', id: 'L-1' }] },
+    })
+  })
+
+  it('polymorphic depends-on: types preserved per row, no to[0] guess', () => {
+    const pending = new Map<string, RelationCardState>([
+      [
+        'tagged' + OUTGOING_SUFFIX,
+        card({
+          entries: [{ id: 'L-1', type: 'label' }],
+          added: [{ targetId: 'L-1' }],
+        }),
+      ],
+    ])
+    const result = assemble(
+      pending,
+      { 'depends-on': ['T-1', 'BUG-1', 'FEAT-1'] },
+      {
+        'depends-on': new Map([
+          ['T-1', 'ticket'],
+          ['BUG-1', 'bug'],
+          ['FEAT-1', 'feature'],
+        ]),
+      },
+    )
+    expect(result.shape).toBe('modern')
+    const body = result.body as Record<string, { data: { type: string; id: string }[] }>
+    expect(body['depends-on'].data.map((d) => d.type)).toEqual(['ticket', 'bug', 'feature'])
+  })
+})

--- a/frontend/src/stores/entities.ts
+++ b/frontend/src/stores/entities.ts
@@ -1,6 +1,13 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { listEntities, getEntity, createEntity, updateEntity, deleteEntity } from '@/api/entities'
+import {
+  listEntities,
+  getEntity,
+  createEntity,
+  updateEntity,
+  deleteEntity,
+  type EntityPatch,
+} from '@/api/entities'
 import type { Entity, CreateEntity, ListParams, ListMeta } from '@/types'
 import { useGitStore } from './git'
 
@@ -146,7 +153,7 @@ export const useEntitiesStore = defineStore('entities', () => {
   async function update(
     type: string,
     id: string,
-    data: Partial<Entity>,
+    data: EntityPatch,
     etag?: string
   ): Promise<Entity> {
     const entity = await updateEntity(type, id, data, etag)

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -9,6 +9,37 @@ export interface Entity {
   _self?: string
   _actions?: EntityActions
   inaccessible?: InaccessibleField[]
+  // Soft-validation findings on mutation responses (DEC-HWZHA).
+  // Present on PATCH/POST results; absent on GETs.
+  warnings?: Warning[]
+}
+
+// Warning is a soft validation finding returned alongside a successful
+// mutation. Code matches the analyze_* finding code so UIs can
+// de-duplicate. See docs/data-entry/api-reference.md for stable codes.
+export interface Warning {
+  code: string
+  path: string
+  detail: string
+}
+
+// JSON:API §9 resource identifier — the per-edge shape inside the
+// unified PATCH's modern relations field. Used by the patch builder
+// to emit edges with explicit type, meta, and (future) content.
+export interface ResourceIdentifier {
+  type: string
+  id: string
+  meta?: Record<string, unknown>
+  meta_unset?: string[]
+  content?: string
+}
+
+// Modern relations field shape for the unified PATCH body. Keys are
+// relation names; each value's `data` is the desired set of edges.
+// Sending `data: []` clears all edges of that type — see the
+// data-loss footgun docs in docs/data-entry/api-reference.md.
+export interface ModernRelationsField {
+  [relationName: string]: { data: ResourceIdentifier[] }
 }
 
 // InaccessibleField marks a property whose value is known to exist but is
@@ -38,8 +69,17 @@ export interface CreateEntity {
 
 export interface RelationEntry {
   id: string
+  // type of the peer entity on the other end of the edge. Required for
+  // the unified PATCH builder to emit JSON:API §9 resource identifiers
+  // without consulting the schema. Backend started emitting this in
+  // TKT-ZEKO4; older servers omit it.
+  type: string
   direction?: 'outgoing' | 'incoming'
   meta?: Record<string, unknown>
+  // Plumbing-only — no widget exposes per-edge body editing yet, but
+  // the wire shape carries it so a future ticket can wire UI without
+  // touching types again.
+  content?: string
 }
 
 export interface ListResponse<T> {

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -717,6 +717,7 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 	for _, edge := range outgoing {
 		rel := map[string]interface{}{
 			"id":        edge.To,
+			"type":      a.peerType(edge.To),
 			"direction": "outgoing",
 		}
 		if len(edge.Properties) > 0 {
@@ -736,6 +737,7 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 		}
 		rel := map[string]interface{}{
 			"id":        edge.From,
+			"type":      a.peerType(edge.From),
 			"direction": "incoming",
 		}
 		if len(edge.Properties) > 0 {
@@ -794,7 +796,8 @@ func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, ty
 			peerID = edge.From
 		}
 		rel := map[string]interface{}{
-			"id": peerID,
+			"id":   peerID,
+			"type": a.peerType(peerID),
 		}
 		if len(edge.Properties) > 0 {
 			rel["meta"] = edge.Properties

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -2822,6 +2822,9 @@ func TestV1GetRelationType_IncomingReturnsEdgeWithMeta(t *testing.T) {
 	if got := edges[0]["id"]; got != sourceID {
 		t.Errorf("incoming edge peer = %v, want %s", got, sourceID)
 	}
+	if got := edges[0]["type"]; got != "feature" {
+		t.Errorf("incoming edge peer type = %v, want %q", got, "feature")
+	}
 	meta, ok := edges[0]["meta"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("expected meta object on edge, got %T: %v", edges[0]["meta"], edges[0])
@@ -2862,8 +2865,42 @@ func TestV1EntityRelations_GroupsIncomingUnderInverseName(t *testing.T) {
 	if got := blockedBy[0]["id"]; got != sourceID {
 		t.Errorf("blockedBy[0].id = %v, want %s", got, sourceID)
 	}
+	if got := blockedBy[0]["type"]; got != "feature" {
+		t.Errorf("blockedBy[0].type = %v, want %q", got, "feature")
+	}
 	if got := blockedBy[0]["direction"]; got != "incoming" {
 		t.Errorf("blockedBy[0].direction = %v, want %q", got, "incoming")
+	}
+}
+
+// TestV1GetRelationType_OutgoingIncludesPeerType verifies the outgoing
+// path emits `type` per resource identifier — required by the SPA to
+// build JSON:API §9 resource identifiers without consulting the
+// schema or guessing from ID prefix. (TKT-ZEKO4 Step 0.)
+func TestV1GetRelationType_OutgoingIncludesPeerType(t *testing.T) {
+	app := newReverseRelationsTestApp(t)
+	sourceID, targetID := seedBlocksReverseFixture(t, app)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/features/"+sourceID+"/relations/blocks", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1GetRelationType(rec, req, "feature", sourceID, "blocks")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var edges []map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &edges); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 outgoing edge, got %d", len(edges))
+	}
+	if got := edges[0]["id"]; got != targetID {
+		t.Errorf("outgoing edge peer id = %v, want %s", got, targetID)
+	}
+	if got := edges[0]["type"]; got != "feature" {
+		t.Errorf("outgoing edge peer type = %v, want %q", got, "feature")
 	}
 }
 

--- a/internal/dataentry/services.go
+++ b/internal/dataentry/services.go
@@ -52,6 +52,18 @@ func (a *App) getEntity(id string) (*entity.Entity, bool) {
 	return e, true
 }
 
+// peerType returns the entity type for the peer ID on the other end of
+// a relation edge, or empty string if the peer can't be resolved. Used
+// by the relation GET handlers to emit a `type` field per edge so SPA
+// clients can construct JSON:API §9 resource identifiers without
+// guessing.
+func (a *App) peerType(id string) string {
+	if e, ok := a.getEntity(id); ok {
+		return e.Type
+	}
+	return ""
+}
+
 // outgoingRelations returns all outgoing relations for id using the
 // background context. Prefer outgoingRelationsCtx when a request context
 // is in scope.

--- a/tickets/entities/tickets/TKT-ZEKO4.md
+++ b/tickets/entities/tickets/TKT-ZEKO4.md
@@ -5,7 +5,7 @@ title: Migrate RelationCards + RelationPicker to unified PATCH-with-relations wi
 kind: enhancement
 priority: medium
 effort: m
-status: ready
+status: review
 ---
 
 ## Problem


### PR DESCRIPTION
## Summary

- Migrate `DynamicForm` outgoing relation-card save from N parallel per-edge calls to a single unified `PATCH /api/v1/{plural}/{id}` body using the JSON:API §9 modern shape from TKT-6WLSW.
- Backend: per-edge relation GET responses now emit `type` so SPA clients can build resource identifiers without `to[0]` guessing (the design-review blocker for polymorphic relations like `depends-on: [ticket, bug, feature, doc-task]`).
- Frontend: `RelationPicker` emits a parallel `update:types` Map so polymorphic-target IDs are typed precisely at submit time. Body assembly enforces no-mixed-shape: if any card is touched, all picker relations re-shape to modern; if any target's type is unresolved, fall back to legacy + a user-visible toast (no silent corruption).
- Soft-validation warnings from the unified PATCH (DEC-HWZHA) now surface as a non-blocking toast.
- Incoming-direction widgets stay on per-edge endpoints — the wire format has no `direction:incoming` concept. `savePendingRelationCards` is renamed `savePendingIncomingChanges` and scoped to `-incoming` keys.

Unblocks autosave (TKT-E6094) for forms that include relation widgets.

## Out of scope

- Create-path modern shape (backend POST handler hard-codes `map[string][]string`; cards don't render in create mode anyway).
- `If-Match` ETag wiring (SPA's GET path doesn't capture response headers today; lost-update window unchanged from baseline).
- Per-edge `content` body editor UI (the type is plumbed; no widget added).

## Test plan

- [x] `go test ./internal/dataentry/` — green, including new `TestV1GetRelationType_OutgoingIncludesPeerType` plus two extended tests asserting `type` on per-edge responses.
- [x] `npm run test:run` — 688/689 (1 pre-existing markdown XSS test failure on develop, unrelated).
- [x] `just lint` (backend) — 0 issues.
- [x] `npm run lint` (frontend) — 0 errors.
- [x] `just arch-lint` — OK.
- [x] `just e2e --grep "Relation|Reverse|Form|CRUD"` — 61/61 green.
- [x] `just ci` — green.