### PR TITLE
feat(data-entry): reorderable relations (TKT-XF5F)

### DIFF
--- a/frontend/src/components/forms/RelationCards.vue
+++ b/frontend/src/components/forms/RelationCards.vue
@@ -14,6 +14,8 @@ import type { RelationEntry, Entity } from '@/types/entity'
 import type { PropertyDef } from '@/types/schema'
 import type { RelationCardState } from './relationsPatch'
 import type { RelationAffordance } from '@/types'
+import { ORDER_PROPERTY_OUT, ORDER_PROPERTY_IN } from '@/types/schema'
+import { computeNewOrder, extractFiniteNumber } from '@/composables/useRelationReorder'
 
 // Re-export so existing `import type { RelationCardState } from './RelationCards.vue'`
 // callers keep working without a churn rename.
@@ -119,11 +121,14 @@ async function loadRelations() {
     addedIds.value.clear()
     removedIds.value.clear()
     updatedIds.value.clear()
-    // Fetch entity details in parallel
+    // Fetch entity details in parallel.
+    // Use entry.type (populated since TKT-ZEKO4) so the URL resolves the
+    // correct plural — passing '' here builds `/api/v1/s/<id>` which 404s
+    // and leaves the title cache empty, surfacing as a bare ID in the UI.
     const uncached = loaded.filter((entry) => !entityCache.value.has(entry.id))
     const results = await Promise.allSettled(
       uncached.map((entry) =>
-        getEntity('', entry.id, { fields: 'id,type,properties.title' }).then((entity) => ({
+        getEntity(entry.type ?? '', entry.id, { fields: 'id,type,properties.title' }).then((entity) => ({
           id: entry.id,
           entity,
         }))
@@ -350,6 +355,98 @@ function entryStatus(id: string): 'added' | 'updated' | null {
   if (updatedIds.value.has(id)) return 'updated'
   return null
 }
+
+// --- Drag-to-reorder (orderable relations) ---
+//
+// Native HTML5 DnD, following the pattern from KanbanView.vue. We only
+// surface drag handles when the relation type declares the relevant side
+// as orderable. The write goes through the existing
+// RelationCardState.updated channel — the parent form's PATCH flow picks
+// up the new order property and sends it as `meta._order_out` or
+// `meta._order_in`.
+
+// Which managed order property applies to this card section, or '' when
+// not orderable on this side.
+const orderProperty = computed<string>(() => {
+  const o = relationType.value?.orderable
+  if (!o) return ''
+  if (isIncoming.value) {
+    return o.incoming ? ORDER_PROPERTY_IN : ''
+  }
+  return o.outgoing ? ORDER_PROPERTY_OUT : ''
+})
+
+const isOrderable = computed(() => orderProperty.value !== '')
+
+const draggedId = ref<string | null>(null)
+const dragOverId = ref<string | null>(null)
+
+function onDragStart(event: DragEvent, id: string) {
+  if (!isOrderable.value) return
+  draggedId.value = id
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('text/plain', id)
+  }
+}
+
+function onDragOver(event: DragEvent, id: string) {
+  if (!isOrderable.value || !draggedId.value || draggedId.value === id) return
+  event.preventDefault()
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = 'move'
+  }
+  dragOverId.value = id
+}
+
+function onDragLeave(id: string) {
+  if (dragOverId.value === id) {
+    dragOverId.value = null
+  }
+}
+
+function onDrop(event: DragEvent, targetId: string) {
+  if (!isOrderable.value) return
+  event.preventDefault()
+  const movedId = draggedId.value
+  draggedId.value = null
+  dragOverId.value = null
+  if (!movedId || movedId === targetId) return
+
+  const fromIndex = entries.value.findIndex((e) => e.id === movedId)
+  const toIndex = entries.value.findIndex((e) => e.id === targetId)
+  if (fromIndex === -1 || toIndex === -1) return
+
+  // Reorder the local list optimistically.
+  const [moved] = entries.value.splice(fromIndex, 1)
+  entries.value.splice(toIndex, 0, moved)
+
+  // Compute the new order value from the neighbours at the moved item's
+  // new position.
+  const newIdx = entries.value.findIndex((e) => e.id === movedId)
+  const prev = newIdx > 0 ? entries.value[newIdx - 1] : undefined
+  const next = newIdx < entries.value.length - 1 ? entries.value[newIdx + 1] : undefined
+  const prop = orderProperty.value
+  const newOrder = computeNewOrder({
+    prevOrder: extractFiniteNumber(prev?.meta?.[prop]),
+    nextOrder: extractFiniteNumber(next?.meta?.[prop]),
+  })
+  if (newOrder === undefined) {
+    // Midpoint collapsed; submit the arithmetic midpoint anyway and let
+    // the backend's renumber-on-collapse rewrite to dense ordinals.
+    const a = extractFiniteNumber(prev?.meta?.[prop])
+    const b = extractFiniteNumber(next?.meta?.[prop])
+    if (a === undefined || b === undefined) return
+    updateProperty(movedId, prop, a + (b - a) / 2)
+    return
+  }
+  updateProperty(movedId, prop, newOrder)
+}
+
+function onDragEnd() {
+  draggedId.value = null
+  dragOverId.value = null
+}
 </script>
 
 <template>
@@ -372,9 +469,19 @@ function entryStatus(id: string): 'added' | 'updated' | null {
         :class="{
           'card-added': entryStatus(entry.id) === 'added',
           'card-updated': entryStatus(entry.id) === 'updated',
+          'card-orderable': isOrderable,
+          'card-dragging': draggedId === entry.id,
+          'card-drag-over': dragOverId === entry.id,
         }"
+        :draggable="isOrderable"
+        @dragstart="onDragStart($event, entry.id)"
+        @dragover="onDragOver($event, entry.id)"
+        @dragleave="onDragLeave(entry.id)"
+        @drop="onDrop($event, entry.id)"
+        @dragend="onDragEnd"
       >
         <div class="card-header">
+          <span v-if="isOrderable" class="drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
           <div class="card-identity">
             <span class="entity-id" @click="navigateToEntity(entry.id)">
               {{ entry.id }}
@@ -577,6 +684,36 @@ function entryStatus(id: string): 'added' | 'updated' | null {
 .relation-card.card-updated {
   border-color: var(--warning-color, #f59e0b);
   background: rgba(245, 158, 11, 0.03);
+}
+
+.relation-card.card-orderable {
+  cursor: grab;
+}
+
+.relation-card.card-orderable:active {
+  cursor: grabbing;
+}
+
+.relation-card.card-dragging {
+  opacity: 0.5;
+}
+
+.relation-card.card-drag-over {
+  border-color: var(--accent-color, #6366f1);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.25);
+}
+
+.drag-handle {
+  color: var(--muted-text);
+  font-size: 16px;
+  line-height: 1;
+  cursor: grab;
+  user-select: none;
+  padding-right: 4px;
+}
+
+.relation-card.card-orderable .drag-handle:active {
+  cursor: grabbing;
 }
 
 .card-header {

--- a/frontend/src/composables/useRelationReorder.test.ts
+++ b/frontend/src/composables/useRelationReorder.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeNewOrder,
+  extractFiniteNumber,
+  ORDER_COLLAPSE_THRESHOLD,
+} from './useRelationReorder'
+
+describe('computeNewOrder', () => {
+  it('returns 1.0 for an empty list (no prev, no next)', () => {
+    expect(computeNewOrder({ prevOrder: undefined, nextOrder: undefined })).toBe(1.0)
+  })
+
+  it('prepend: returns next - 1 when only next is set', () => {
+    expect(computeNewOrder({ prevOrder: undefined, nextOrder: 5.0 })).toBe(4.0)
+  })
+
+  it('append: returns prev + 1 when only prev is set', () => {
+    expect(computeNewOrder({ prevOrder: 5.0, nextOrder: undefined })).toBe(6.0)
+  })
+
+  it('midpoint: returns (prev + next) / 2 with safe gap', () => {
+    expect(computeNewOrder({ prevOrder: 1, nextOrder: 2 })).toBe(1.5)
+    expect(computeNewOrder({ prevOrder: 0, nextOrder: 1000 })).toBe(500)
+  })
+
+  it('midpoint: returns undefined on collapse', () => {
+    const lo = 1.0
+    const hi = 1.0 + ORDER_COLLAPSE_THRESHOLD / 2
+    expect(computeNewOrder({ prevOrder: lo, nextOrder: hi })).toBeUndefined()
+  })
+
+  it('treats non-finite neighbour values as absent', () => {
+    expect(computeNewOrder({ prevOrder: NaN, nextOrder: 2 })).toBe(1.0)
+    expect(computeNewOrder({ prevOrder: 1, nextOrder: Infinity })).toBe(2.0)
+  })
+})
+
+describe('extractFiniteNumber', () => {
+  it('returns finite numbers verbatim', () => {
+    expect(extractFiniteNumber(1)).toBe(1)
+    expect(extractFiniteNumber(-3.5)).toBe(-3.5)
+    expect(extractFiniteNumber(0)).toBe(0)
+  })
+
+  it('returns undefined for missing / non-numeric / non-finite', () => {
+    expect(extractFiniteNumber(undefined)).toBeUndefined()
+    expect(extractFiniteNumber(null)).toBeUndefined()
+    expect(extractFiniteNumber('1')).toBeUndefined()
+    expect(extractFiniteNumber(NaN)).toBeUndefined()
+    expect(extractFiniteNumber(Infinity)).toBeUndefined()
+    expect(extractFiniteNumber(-Infinity)).toBeUndefined()
+    expect(extractFiniteNumber({})).toBeUndefined()
+  })
+})

--- a/frontend/src/composables/useRelationReorder.ts
+++ b/frontend/src/composables/useRelationReorder.ts
@@ -1,0 +1,66 @@
+// useRelationReorder centralises the math used by drag-to-reorder on
+// orderable relation list sections. The composable does NOT issue any
+// network calls — the caller integrates the returned value into its
+// existing relation-update flow (RelationCardState.updated → PATCH).
+//
+// The midpoint scheme matches the backend's MidpointOrder in
+// internal/entitymanager/order.go. Keep the constants in sync.
+
+export const ORDER_COLLAPSE_THRESHOLD = 1e-9
+
+export interface ReorderNeighbors {
+  /**
+   * The numeric order value of the entry immediately above the moved
+   * entry after the drop, or undefined if the moved entry now sits at
+   * the top of the list.
+   */
+  prevOrder: number | undefined
+  /**
+   * The numeric order value of the entry immediately below the moved
+   * entry after the drop, or undefined if the moved entry now sits at
+   * the bottom of the list.
+   */
+  nextOrder: number | undefined
+}
+
+/**
+ * computeNewOrder returns the order value the moved entry should be
+ * assigned given its new neighbours. Returns undefined when no safe
+ * midpoint exists — the caller should request a backend renumber by
+ * issuing a PATCH that sets the order to the midpoint anyway (the
+ * backend's collapse detection will trigger a renumber pass) or, if
+ * preferable, skip the optimistic local update entirely.
+ */
+export function computeNewOrder(n: ReorderNeighbors): number | undefined {
+  const hasPrev = n.prevOrder !== undefined && Number.isFinite(n.prevOrder)
+  const hasNext = n.nextOrder !== undefined && Number.isFinite(n.nextOrder)
+
+  if (!hasPrev && !hasNext) {
+    return 1.0
+  }
+  if (!hasPrev && hasNext) {
+    return (n.nextOrder as number) - 1.0
+  }
+  if (hasPrev && !hasNext) {
+    return (n.prevOrder as number) + 1.0
+  }
+  const lo = n.prevOrder as number
+  const hi = n.nextOrder as number
+  if (hi - lo < ORDER_COLLAPSE_THRESHOLD) {
+    return undefined
+  }
+  return lo + (hi - lo) / 2
+}
+
+/**
+ * extractFiniteNumber reads a meta property as a finite number. Returns
+ * undefined when the value is missing, non-numeric, or non-finite. Used
+ * by drag-end handlers to read neighbour order values from the existing
+ * entries list.
+ */
+export function extractFiniteNumber(v: unknown): number | undefined {
+  if (typeof v === 'number' && Number.isFinite(v)) {
+    return v
+  }
+  return undefined
+}

--- a/frontend/src/types/schema.ts
+++ b/frontend/src/types/schema.ts
@@ -40,7 +40,19 @@ export interface RelationType {
   min_incoming?: number
   max_incoming?: number
   properties?: Record<string, PropertyDef>
+  orderable?: RelationOrderable
 }
+
+export interface RelationOrderable {
+  outgoing?: boolean
+  incoming?: boolean
+}
+
+// Reserved property names that hold managed ordering values on a relation.
+// These match the names the backend writes; the frontend never spells
+// other strings for ordering.
+export const ORDER_PROPERTY_OUT = '_order_out'
+export const ORDER_PROPERTY_IN = '_order_in'
 
 export interface InverseDef {
   id: string

--- a/internal/analysis/relation_order.go
+++ b/internal/analysis/relation_order.go
@@ -1,0 +1,121 @@
+package analysis
+
+import (
+	"context"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// RelationOrderIssue is a soft finding produced by CheckRelationOrder.
+// Severity is always "warning" — duplicate/missing managed order values
+// don't block writes, they're just inconsistencies the engine tolerates
+// per the permissive-storage policy.
+type RelationOrderIssue struct {
+	EntityID     string
+	EntityType   string
+	RelationType string
+	Side         string // "outgoing" or "incoming"
+	Property     string // "_order_out" or "_order_in"
+	Kind         string // "duplicate" or "missing"
+	Count        int    // number of edges affected on this side under this entity
+}
+
+// CheckRelationOrder inspects every orderable relation type and reports
+// missing or duplicate values on the managed order property, grouped by
+// the parent entity on the relevant side.
+//
+// Returns warnings only — never errors. Callers map this to whatever
+// surface the operator is on (CLI table, MCP JSON, web UI dashboard).
+func (s *Service) CheckRelationOrder(opts Options) []RelationOrderIssue {
+	issues := make([]RelationOrderIssue, 0)
+	ctx := context.Background()
+	st := s.deps.Store
+	meta := s.deps.Meta
+
+	relNames := make([]string, 0, len(meta.Relations))
+	for name := range meta.Relations {
+		relNames = append(relNames, name)
+	}
+	sort.Strings(relNames)
+
+	for _, relName := range relNames {
+		relDef := meta.Relations[relName]
+		if outProp := relDef.OutgoingOrderProperty(); outProp != "" {
+			issues = append(issues, checkOrderSide(ctx, st, meta, relName, outProp, "outgoing", opts.Scope)...)
+		}
+		if inProp := relDef.IncomingOrderProperty(); inProp != "" {
+			issues = append(issues, checkOrderSide(ctx, st, meta, relName, inProp, "incoming", opts.Scope)...)
+		}
+	}
+	return issues
+}
+
+func checkOrderSide(
+	ctx context.Context, st store.Store, _ *metamodel.Metamodel,
+	relType, prop, side string, scope map[string]bool,
+) []RelationOrderIssue {
+	parents := map[string][]*entity.Relation{}
+	for r, err := range st.ListRelations(ctx, store.RelationQuery{Type: relType}) {
+		if err != nil {
+			continue // iterator errors don't block the rest of the analysis
+		}
+		var parent string
+		if side == "outgoing" {
+			parent = r.From
+		} else {
+			parent = r.To
+		}
+		if !inScope(parent, scope) {
+			continue
+		}
+		parents[parent] = append(parents[parent], r)
+	}
+
+	var issues []RelationOrderIssue
+	parentIDs := make([]string, 0, len(parents))
+	for id := range parents {
+		parentIDs = append(parentIDs, id)
+	}
+	sort.Strings(parentIDs)
+
+	for _, pid := range parentIDs {
+		rels := parents[pid]
+		if len(rels) < 2 {
+			continue
+		}
+		seen := map[float64]bool{}
+		missing := 0
+		duplicate := 0
+		for _, r := range rels {
+			v, ok := metamodel.FiniteOrder(r.Properties[prop])
+			if !ok {
+				missing++
+				continue
+			}
+			if seen[v] {
+				duplicate++
+			}
+			seen[v] = true
+		}
+		etype := ""
+		if e, gErr := st.GetEntity(ctx, pid); gErr == nil {
+			etype = e.Type
+		}
+		if missing > 0 {
+			issues = append(issues, RelationOrderIssue{
+				EntityID: pid, EntityType: etype, RelationType: relType,
+				Side: side, Property: prop, Kind: "missing", Count: missing,
+			})
+		}
+		if duplicate > 0 {
+			issues = append(issues, RelationOrderIssue{
+				EntityID: pid, EntityType: etype, RelationType: relType,
+				Side: side, Property: prop, Kind: "duplicate", Count: duplicate,
+			})
+		}
+	}
+	return issues
+}

--- a/internal/analysis/relation_order_test.go
+++ b/internal/analysis/relation_order_test.go
@@ -1,0 +1,101 @@
+package analysis_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/analysis"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+func orderableMeta(t *testing.T, mode metamodel.OrderableMode) *metamodel.Metamodel {
+	t.Helper()
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"recipe": {Label: "Recipe"},
+			"step":   {Label: "Step"},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"has-step": {
+				Label:     "has step",
+				From:      []string{"recipe"},
+				To:        []string{"step"},
+				Orderable: mode,
+			},
+		},
+	}
+}
+
+func addOrderedRelation(s store.Store, to string, order interface{}) {
+	props := map[string]interface{}{}
+	if order != nil {
+		props[metamodel.OrderPropertyOut] = order
+	}
+	if _, err := s.CreateRelation(context.Background(), "REC-1", "has-step", to,
+		&store.RelationData{Properties: props}); err != nil {
+		panic(err)
+	}
+}
+
+func TestCheckRelationOrder_DuplicateDetected(t *testing.T) {
+	svc := newServiceWith(t, orderableMeta(t, metamodel.OrderableOutgoing), func(s store.Store) {
+		addEntity(s, "REC-1", "recipe", nil)
+		addEntity(s, "STP-1", "step", nil)
+		addEntity(s, "STP-2", "step", nil)
+		addOrderedRelation(s, "STP-1", 1.0)
+		addOrderedRelation(s, "STP-2", 1.0) // duplicate
+	})
+
+	issues := svc.CheckRelationOrder(analysis.Options{})
+	if len(issues) == 0 {
+		t.Fatal("expected at least one duplicate issue")
+	}
+	foundDup := false
+	for _, iss := range issues {
+		if iss.Kind == "duplicate" {
+			foundDup = true
+		}
+	}
+	if !foundDup {
+		t.Errorf("expected duplicate kind, got %+v", issues)
+	}
+}
+
+func TestCheckRelationOrder_MissingDetected(t *testing.T) {
+	svc := newServiceWith(t, orderableMeta(t, metamodel.OrderableOutgoing), func(s store.Store) {
+		addEntity(s, "REC-1", "recipe", nil)
+		addEntity(s, "STP-1", "step", nil)
+		addEntity(s, "STP-2", "step", nil)
+		addOrderedRelation(s, "STP-1", 1.0)
+		addOrderedRelation(s, "STP-2", nil) // missing
+	})
+
+	issues := svc.CheckRelationOrder(analysis.Options{})
+	foundMissing := false
+	for _, iss := range issues {
+		if iss.Kind == "missing" {
+			foundMissing = true
+			if !strings.Contains(iss.Property, "_order_out") {
+				t.Errorf("missing issue not on _order_out: %+v", iss)
+			}
+		}
+	}
+	if !foundMissing {
+		t.Errorf("expected missing kind, got %+v", issues)
+	}
+}
+
+func TestCheckRelationOrder_NonOrderableSkipped(t *testing.T) {
+	svc := newServiceWith(t, orderableMeta(t, metamodel.OrderableNone), func(s store.Store) {
+		addEntity(s, "REC-1", "recipe", nil)
+		addEntity(s, "STP-1", "step", nil)
+		addOrderedRelation(s, "STP-1", nil)
+	})
+
+	issues := svc.CheckRelationOrder(analysis.Options{})
+	if len(issues) != 0 {
+		t.Errorf("non-orderable type should produce no issues, got %+v", issues)
+	}
+}

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -175,6 +175,45 @@ since they use manually-specified IDs that are not expected to be sequential.`,
 	},
 }
 
+var analyzeRelationOrderCmd = &cobra.Command{
+	Use:   "relation-order",
+	Short: "Find duplicate or missing values on managed relation order properties",
+	Long: `Scans every relation type declared 'orderable: outgoing | incoming | both'
+and reports parents that have duplicate or missing values on the managed
+order property (_order_out / _order_in).
+
+These are soft conditions: the engine tolerates them (duplicates sort
+stably, missing values sort last). Use this report to identify markdown
+files that need cleanup after hand-edits or imports.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		svc := cliAnalyzeFromContext(cmd.Context())
+		opts, err := resolveAnalyzeOpts()
+		if err != nil {
+			return err
+		}
+		issues := svc.CheckRelationOrder(*opts)
+
+		if writeAnalysisJSON(len(issues), issues,
+			"All orderable relations have consistent order values",
+			"Found %d relation-order issue(s)") {
+			return nil
+		}
+
+		for _, iss := range issues {
+			out.WriteWarning("%s (%s) on %s side of %q: %d %s value(s) at %s",
+				iss.EntityID, iss.EntityType, iss.Side, iss.RelationType,
+				iss.Count, iss.Kind, iss.Property)
+		}
+
+		if len(issues) == 0 {
+			out.WriteSuccess("All orderable relations have consistent order values")
+		} else {
+			out.WriteWarning("Found %d relation-order issue(s)", len(issues))
+		}
+		return nil
+	},
+}
+
 var analyzeCardinalityCmd = &cobra.Command{
 	Use:   "cardinality",
 	Short: "Check relation cardinality constraints",
@@ -892,6 +931,7 @@ func init() {
 	analyzeCmd.AddCommand(analyzeDuplicatesCmd)
 	analyzeCmd.AddCommand(analyzeGapsCmd)
 	analyzeCmd.AddCommand(analyzeCardinalityCmd)
+	analyzeCmd.AddCommand(analyzeRelationOrderCmd)
 	analyzeCmd.AddCommand(analyzePropertiesCmd)
 	analyzeCmd.AddCommand(analyzeValidationsCmd)
 	analyzeCmd.AddCommand(analyzeAllCmd)

--- a/internal/cli/cli_wiring.go
+++ b/internal/cli/cli_wiring.go
@@ -73,6 +73,7 @@ type cliAnalyze interface {
 	cliRead
 	AnalyzeAll(ctx context.Context, opts analysis.Options) *analysis.Summary
 	CheckCardinality(opts analysis.Options) []analysis.CardinalityViolation
+	CheckRelationOrder(opts analysis.Options) []analysis.RelationOrderIssue
 	FindDuplicates(opts analysis.Options) []analysis.DuplicateGroup
 	FindGaps(opts analysis.Options) []analysis.GapResult
 	FindOrphansWithScope(opts analysis.Options) []*entity.Entity
@@ -138,6 +139,10 @@ func (s *cliServices) AnalyzeAll(ctx context.Context, opts analysis.Options) *an
 
 func (s *cliServices) CheckCardinality(opts analysis.Options) []analysis.CardinalityViolation {
 	return s.analysis.CheckCardinality(opts)
+}
+
+func (s *cliServices) CheckRelationOrder(opts analysis.Options) []analysis.RelationOrderIssue {
+	return s.analysis.CheckRelationOrder(opts)
 }
 
 func (s *cliServices) FindDuplicates(opts analysis.Options) []analysis.DuplicateGroup {

--- a/internal/cli/renumber.go
+++ b/internal/cli/renumber.go
@@ -1,0 +1,173 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+var renumberDryRun bool
+
+type renumberEntry struct {
+	rel    *entity.Relation
+	prop   string
+	newVal float64
+}
+
+var renumberCmd = &cobra.Command{
+	Use:   "renumber",
+	Short: "Renumber managed order properties on orderable relations",
+	Long: `Walks every relation type declared 'orderable: outgoing | incoming | both'
+and rewrites the managed order property (_order_out / _order_in) on each
+parent's siblings to dense integer ordinals 1.0..N in the current sort
+order.
+
+Preserves missing-ness: siblings whose value is currently missing or
+non-finite stay missing — only siblings with existing finite values are
+redistributed.
+
+Use this command to clean up after hand-edits, imports, or long-running
+projects whose order values have drifted into sparse floats. The
+automatic renumber-on-collapse handles routine drift; this command is
+for explicit normalization.
+
+Examples:
+  rela renumber                 # Normalize every orderable relation
+  rela renumber --dry-run       # Preview without writing`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		svc := cliWriteFromContext(cmd.Context())
+		ctx := context.Background()
+		st := svc.Store()
+		schema := svc.Meta()
+
+		var plan []renumberEntry
+
+		relNames := make([]string, 0, len(schema.Relations))
+		for name := range schema.Relations {
+			relNames = append(relNames, name)
+		}
+		sort.Strings(relNames)
+
+		for _, relName := range relNames {
+			relDef := schema.Relations[relName]
+			if p := relDef.OutgoingOrderProperty(); p != "" {
+				plan = append(plan, buildRenumberPlan(ctx, st, relName, p, "outgoing")...)
+			}
+			if p := relDef.IncomingOrderProperty(); p != "" {
+				plan = append(plan, buildRenumberPlan(ctx, st, relName, p, "incoming")...)
+			}
+		}
+
+		if len(plan) == 0 {
+			out.WriteSuccess("All orderable relations already have dense ordinals")
+			return nil
+		}
+
+		if renumberDryRun {
+			out.WriteInfo("DRY RUN — %d relation(s) would be rewritten", len(plan))
+			for _, p := range plan {
+				cur, _ := metamodel.FiniteOrder(p.rel.Properties[p.prop])
+				out.WriteInfo("  %s --%s--> %s: %s %v -> %v",
+					p.rel.From, p.rel.Type, p.rel.To, p.prop, cur, p.newVal)
+			}
+			return nil
+		}
+
+		for _, p := range plan {
+			props := make(map[string]interface{}, len(p.rel.Properties)+1)
+			for k, v := range p.rel.Properties {
+				props[k] = v
+			}
+			props[p.prop] = p.newVal
+			data := store.RelationData{Properties: props, Content: p.rel.Content}
+			if _, err := st.UpdateRelation(ctx, p.rel.From, p.rel.Type, p.rel.To, data); err != nil {
+				return fmt.Errorf("renumber write failed for %s--%s--%s: %w", p.rel.From, p.rel.Type, p.rel.To, err)
+			}
+		}
+		out.WriteSuccess("Renumbered %d relation(s)", len(plan))
+		return nil
+	},
+}
+
+// buildRenumberPlan walks relations of relType and returns the (relation,
+// new-value) tuples needed to redistribute existing finite values to dense
+// ordinals 1.0..N on the named side. Siblings with missing/non-finite
+// values are skipped, preserving missing-ness.
+func buildRenumberPlan(
+	ctx context.Context, st store.Store,
+	relType, prop, side string,
+) []renumberEntry {
+	parents := map[string][]*entity.Relation{}
+	for r, err := range st.ListRelations(ctx, store.RelationQuery{Type: relType}) {
+		if err != nil {
+			continue
+		}
+		var parent string
+		if side == "outgoing" {
+			parent = r.From
+		} else {
+			parent = r.To
+		}
+		c := *r
+		if r.Properties != nil {
+			c.Properties = make(map[string]interface{}, len(r.Properties))
+			for k, v := range r.Properties {
+				c.Properties[k] = v
+			}
+		}
+		parents[parent] = append(parents[parent], &c)
+	}
+
+	parentIDs := make([]string, 0, len(parents))
+	for id := range parents {
+		parentIDs = append(parentIDs, id)
+	}
+	sort.Strings(parentIDs)
+
+	var plan []renumberEntry
+	for _, pid := range parentIDs {
+		rels := parents[pid]
+		withValue := make([]*entity.Relation, 0, len(rels))
+		for _, r := range rels {
+			if _, ok := metamodel.FiniteOrder(r.Properties[prop]); ok {
+				withValue = append(withValue, r)
+			}
+		}
+		if len(withValue) < 2 {
+			continue
+		}
+		asValues := make([]entity.Relation, len(withValue))
+		for i, r := range withValue {
+			asValues[i] = *r
+		}
+		sorted := entitymanager.SortRelations(asValues, prop)
+		byKey := make(map[string]*entity.Relation, len(withValue))
+		for _, r := range withValue {
+			byKey[r.From+"--"+r.Type+"--"+r.To] = r
+		}
+		for i, s := range sorted {
+			newVal := float64(i + 1)
+			key := s.From + "--" + s.Type + "--" + s.To
+			r := byKey[key]
+			if cur, ok := metamodel.FiniteOrder(r.Properties[prop]); ok && cur == newVal {
+				continue
+			}
+			plan = append(plan, renumberEntry{rel: r, prop: prop, newVal: newVal})
+		}
+	}
+	return plan
+}
+
+func init() {
+	renumberCmd.Flags().BoolVar(&renumberDryRun, "dry-run", false,
+		"Preview the renumber without writing")
+	rootCmd.AddCommand(renumberCmd)
+}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/conflict"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -159,6 +160,16 @@ type V1RelationType struct {
 	MinIncoming *int                     `json:"min_incoming,omitempty"`
 	MaxIncoming *int                     `json:"max_incoming,omitempty"`
 	Properties  map[string]V1PropertyDef `json:"properties,omitempty"`
+	// Orderable, when set, declares that the frontend may offer drag-to-reorder
+	// controls on the corresponding side. The managed property names are
+	// always the reserved `_order_out` (outgoing) and `_order_in` (incoming).
+	Orderable *V1RelationOrderable `json:"orderable,omitempty"`
+}
+
+// V1RelationOrderable describes per-side orderability for a relation type.
+type V1RelationOrderable struct {
+	Outgoing bool `json:"outgoing,omitempty"`
+	Incoming bool `json:"incoming,omitempty"`
 }
 
 // V1InverseDef mirrors metamodel.InverseDef on the wire. The SPA reads
@@ -818,6 +829,10 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 
 	relations := make(map[string][]map[string]interface{})
 
+	// Track the sort property per group, derived from the relation type's
+	// Orderable mode. Empty string disables sorting for that group.
+	groupSortProp := make(map[string]string)
+
 	for _, edge := range outgoing {
 		rel := map[string]interface{}{
 			"id":        edge.To,
@@ -828,6 +843,11 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 			rel["meta"] = edge.Properties
 		}
 		relations[edge.Type] = append(relations[edge.Type], rel)
+		if relDef, ok := s.Meta.Relations[edge.Type]; ok {
+			if p := relDef.OutgoingOrderProperty(); p != "" {
+				groupSortProp[edge.Type] = p
+			}
+		}
 	}
 
 	for _, edge := range incoming {
@@ -848,9 +868,49 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 			rel["meta"] = edge.Properties
 		}
 		relations[inverseName] = append(relations[inverseName], rel)
+		if p := relDef.IncomingOrderProperty(); p != "" {
+			groupSortProp[inverseName] = p
+		}
+	}
+
+	// Sort each group by its managed order property; missing values last;
+	// ties stable on insertion order.
+	for groupName, prop := range groupSortProp {
+		if prop == "" {
+			continue
+		}
+		sortRelationGroup(relations[groupName], prop)
 	}
 
 	writeV1JSON(w, http.StatusOK, relations)
+}
+
+// sortRelationGroup sorts a relation group in place by a numeric meta key.
+// Entries without a finite numeric value at prop sort last; ties stable.
+func sortRelationGroup(group []map[string]interface{}, prop string) {
+	if len(group) < 2 || prop == "" {
+		return
+	}
+	value := func(m map[string]interface{}) (float64, bool) {
+		meta, ok := m["meta"].(map[string]interface{})
+		if !ok {
+			return 0, false
+		}
+		return entitymanager.FiniteOrder(meta[prop])
+	}
+	sort.SliceStable(group, func(i, j int) bool {
+		vi, oki := value(group[i])
+		vj, okj := value(group[j])
+		switch {
+		case oki && !okj:
+			return true
+		case !oki && okj:
+			return false
+		case !oki && !okj:
+			return false
+		}
+		return vi < vj
+	})
 }
 
 func (a *App) handleV1EntityRelationType(w http.ResponseWriter, r *http.Request, typeName, entityID, relType string) {
@@ -907,6 +967,19 @@ func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, ty
 			rel["meta"] = edge.Properties
 		}
 		relations = append(relations, rel)
+	}
+
+	// Apply orderable sort when the type declares the relevant side.
+	if relDef, ok := a.State().Meta.Relations[relType]; ok {
+		var prop string
+		if incoming {
+			prop = relDef.IncomingOrderProperty()
+		} else {
+			prop = relDef.OutgoingOrderProperty()
+		}
+		if prop != "" {
+			sortRelationGroup(relations, prop)
+		}
 	}
 
 	writeV1JSON(w, http.StatusOK, relations)
@@ -1007,6 +1080,27 @@ func (a *App) handleV1UpdateRelation(w http.ResponseWriter, r *http.Request, typ
 	if denial := a.validateRelationMetaWrite(r.Context(), source, relType, req.Meta, nil); denial != nil {
 		a.denyAffordance(r.Context(), w, source, *denial)
 		return
+	}
+
+	// Managed order properties must be finite numbers when present. Fast
+	// 400 here so wire-format errors don't surface as 422-from-manager.
+	if relDef, ok := a.State().Meta.Relations[relType]; ok {
+		for _, prop := range []string{metamodel.OrderPropertyOut, metamodel.OrderPropertyIn} {
+			if (prop == metamodel.OrderPropertyOut && relDef.OutgoingOrderProperty() == "") ||
+				(prop == metamodel.OrderPropertyIn && relDef.IncomingOrderProperty() == "") {
+
+				continue
+			}
+			v, present := req.Meta[prop]
+			if !present {
+				continue
+			}
+			if _, ok := entitymanager.FiniteOrder(v); !ok {
+				writeV1Error(w, r, http.StatusBadRequest, "order_value_invalid",
+					"managed order property must be a finite number", prop)
+				return
+			}
+		}
 	}
 
 	from, to := resolveRelationEndpoints(entity.ID, targetID, req.Direction)
@@ -1182,6 +1276,12 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 			rt.Properties = make(map[string]V1PropertyDef, len(def.Properties))
 			for propName, propDef := range def.Properties {
 				rt.Properties[propName] = a.toV1PropertyDef(s.Meta, propDef)
+			}
+		}
+		if def.OutgoingOrderProperty() != "" || def.IncomingOrderProperty() != "" {
+			rt.Orderable = &V1RelationOrderable{
+				Outgoing: def.OutgoingOrderProperty() != "",
+				Incoming: def.IncomingOrderProperty() != "",
 			}
 		}
 		schema.Relations[name] = rt

--- a/internal/dataentry/api_v1_orderable_test.go
+++ b/internal/dataentry/api_v1_orderable_test.go
@@ -1,0 +1,190 @@
+package dataentry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// newOrderableRelationsTestApp builds an App with an `orderable: <mode>`
+// relation between recipe and step. Mirrors newReverseRelationsTestApp.
+func newOrderableRelationsTestApp(t *testing.T, mode metamodel.OrderableMode) *App {
+	t.Helper()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"recipe": {Label: "Recipe", Properties: map[string]metamodel.PropertyDef{"title": {Type: "string", Required: true}}},
+			"step":   {Label: "Step", Properties: map[string]metamodel.PropertyDef{"title": {Type: "string", Required: true}}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"has-step": {
+				Label:     "has step",
+				From:      []string{"recipe"},
+				To:        []string{"step"},
+				Orderable: mode,
+			},
+		},
+	}
+	cfg := &Config{
+		App: AppConfig{Name: "Orderable Test", Description: "x"},
+	}
+	return newAppFromParts(cfg, meta, newFixture())
+}
+
+// seedOrderableFixture seeds four edges whose target IDs are chosen so the
+// alphabetical-by-key store order DIFFERS from the orderable-by-property
+// order. Without that property the assertion would pass even if the sort
+// were a no-op. memstore returns alphabetical: STP-M, STP-X, STP-Y, STP-Z.
+// Orderable: STP-Z=1, STP-X=2, STP-M=3, STP-Y=missing.
+func seedOrderableFixture(t *testing.T, app *App, prop string) string {
+	t.Helper()
+	const recipeID = "REC-001"
+	seedEntity(app, &entity.Entity{ID: recipeID, Type: "recipe", Properties: map[string]interface{}{"title": "Soup"}})
+	type stepSeed struct {
+		id    string
+		order interface{}
+	}
+	steps := []stepSeed{
+		{"STP-Z", 1.0},
+		{"STP-X", 2.0},
+		{"STP-M", 3.0},
+		{"STP-Y", nil},
+	}
+	for _, s := range steps {
+		seedEntity(app, &entity.Entity{ID: s.id, Type: "step", Properties: map[string]interface{}{"title": s.id}})
+		props := map[string]interface{}{}
+		if s.order != nil {
+			props[prop] = s.order
+		}
+		_, err := app.store.CreateRelation(t.Context(), recipeID, "has-step", s.id, &store.RelationData{Properties: props})
+		if err != nil {
+			t.Fatalf("seed relation: %v", err)
+		}
+	}
+	return recipeID
+}
+
+func TestV1EntityRelations_OutgoingOrderableSorted(t *testing.T) {
+	app := newOrderableRelationsTestApp(t, metamodel.OrderableOutgoing)
+	recipeID := seedOrderableFixture(t, app, metamodel.OrderPropertyOut)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/recipes/"+recipeID+"/relations", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1EntityRelations(rec, req, "recipe", recipeID)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var grouped map[string][]map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &grouped); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := make([]string, 0, len(grouped["has-step"]))
+	for _, r := range grouped["has-step"] {
+		got = append(got, r["id"].(string))
+	}
+	want := []string{"STP-Z", "STP-X", "STP-M", "STP-Y"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, id := range want {
+		if got[i] != id {
+			t.Errorf("position %d: got %q, want %q (full got=%v)", i, got[i], id, got)
+		}
+	}
+}
+
+func TestV1GetRelationType_OutgoingOrderableSorted(t *testing.T) {
+	app := newOrderableRelationsTestApp(t, metamodel.OrderableOutgoing)
+	recipeID := seedOrderableFixture(t, app, metamodel.OrderPropertyOut)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/recipes/"+recipeID+"/relations/has-step", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1GetRelationType(rec, req, "recipe", recipeID, "has-step")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var edges []map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &edges); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := make([]string, 0, len(edges))
+	for _, e := range edges {
+		got = append(got, e["id"].(string))
+	}
+	want := []string{"STP-Z", "STP-X", "STP-M", "STP-Y"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, id := range want {
+		if got[i] != id {
+			t.Errorf("position %d: got %q, want %q", i, got[i], id)
+		}
+	}
+}
+
+func TestV1EntityRelations_NonOrderable_NotSortedByOrderProperty(t *testing.T) {
+	app := newOrderableRelationsTestApp(t, metamodel.OrderableNone)
+	recipeID := seedOrderableFixture(t, app, metamodel.OrderPropertyOut)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/recipes/"+recipeID+"/relations", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1EntityRelations(rec, req, "recipe", recipeID)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var grouped map[string][]map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &grouped); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := make([]string, 0, len(grouped["has-step"]))
+	for _, r := range grouped["has-step"] {
+		got = append(got, r["id"].(string))
+	}
+	orderableSort := []string{"STP-Z", "STP-X", "STP-M", "STP-Y"}
+	if equalStringSlices(got, orderableSort) {
+		t.Errorf("non-orderable type was sorted by _order_out anyway: got %v", got)
+	}
+}
+
+func TestV1Schema_AdvertisesOrderableFlag(t *testing.T) {
+	app := newOrderableRelationsTestApp(t, metamodel.OrderableBoth)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_schema", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1Schema(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var schema struct {
+		Relations map[string]V1RelationType `json:"relations"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &schema); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	rt, ok := schema.Relations["has-step"]
+	if !ok {
+		t.Fatalf("missing has-step in schema")
+	}
+	if rt.Orderable == nil {
+		t.Fatalf("expected Orderable to be advertised")
+	}
+	if !rt.Orderable.Outgoing || !rt.Orderable.Incoming {
+		t.Errorf("expected both sides true, got %+v", rt.Orderable)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/dataentry/relations_modern.go
+++ b/internal/dataentry/relations_modern.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
@@ -97,6 +98,13 @@ func (a *App) validateRelationsModern(
 				}
 			}
 
+			// Wire-format violation for managed order properties: only
+			// finite numeric values are acceptable on _order_out / _order_in
+			// because the engine's sort/midpoint math depends on them.
+			if err := validateManagedOrderMeta(canonical, ref, edgePath, &relDef); err != nil {
+				return nil, err
+			}
+
 			// Soft conditions surfaced as warnings. The peer is whichever
 			// side the path entity is NOT on.
 			ws := a.collectEdgeWarnings(ctx, canonical, &relDef, ref, edgePath, incoming)
@@ -175,8 +183,19 @@ func (a *App) collectEdgeWarnings(
 		}
 	}
 
+	// Managed order properties are recognized when the relation type is
+	// orderable on the corresponding side. They are not declared in
+	// relDef.Properties — the engine reserves them.
+	isManagedOrderProperty := func(name string) bool {
+		return (name == metamodel.OrderPropertyOut && relDef.OutgoingOrderProperty() != "") ||
+			(name == metamodel.OrderPropertyIn && relDef.IncomingOrderProperty() != "")
+	}
+
 	// Closed-schema check on meta keys.
 	for k := range ref.Meta {
+		if isManagedOrderProperty(k) {
+			continue
+		}
 		if _, known := relDef.Properties[k]; !known {
 			warnings = append(warnings, Warning{
 				Code:      "unknown_meta_key",
@@ -187,6 +206,9 @@ func (a *App) collectEdgeWarnings(
 		}
 	}
 	for _, k := range ref.MetaUnset {
+		if isManagedOrderProperty(k) {
+			continue
+		}
 		if _, known := relDef.Properties[k]; !known {
 			warnings = append(warnings, Warning{
 				Code:      "unknown_meta_key",
@@ -501,6 +523,38 @@ func requiredMetaWarnings(
 		}
 	}
 	return ws
+}
+
+// validateManagedOrderMeta enforces that values written into the managed
+// order properties (_order_out / _order_in) are finite numeric. Non-finite
+// or non-numeric values are wire-format violations (400) — the engine's
+// midpoint and sort logic depends on finite float64 values.
+func validateManagedOrderMeta(relType string, ref V1ResourceIdentifier, edgePath string, relDef *metamodel.RelationDef) error {
+	check := func(prop string) error {
+		v, present := ref.Meta[prop]
+		if !present {
+			return nil
+		}
+		if _, ok := entitymanager.FiniteOrder(v); ok {
+			return nil
+		}
+		return &wireError{
+			Code:   "order_value_invalid",
+			Path:   edgePath + "/meta/" + jsonPointerEscape(prop),
+			Detail: fmt.Sprintf("relation type %q managed order property %q must be a finite number", relType, prop),
+		}
+	}
+	if relDef.OutgoingOrderProperty() != "" {
+		if err := check(metamodel.OrderPropertyOut); err != nil {
+			return err
+		}
+	}
+	if relDef.IncomingOrderProperty() != "" {
+		if err := check(metamodel.OrderPropertyIn); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // structuralError is a typed hard-422 error from the modern reconciler:

--- a/internal/dataentry/relations_orderable_test.go
+++ b/internal/dataentry/relations_orderable_test.go
@@ -1,0 +1,239 @@
+package dataentry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+func newOrderableModernTestApp(t *testing.T, mode metamodel.OrderableMode) *App {
+	t.Helper()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"recipe": {Label: "Recipe", Properties: map[string]metamodel.PropertyDef{"title": {Type: "string", Required: true}}},
+			"step":   {Label: "Step", Properties: map[string]metamodel.PropertyDef{"title": {Type: "string", Required: true}}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"has-step": {
+				Label:     "has step",
+				From:      []string{"recipe"},
+				To:        []string{"step"},
+				Orderable: mode,
+			},
+		},
+	}
+	cfg := &dataentryconfig.Config{
+		App:        dataentryconfig.AppConfig{Name: "Orderable PATCH Test"},
+		Forms:      make(map[string]dataentryconfig.Form),
+		Lists:      make(map[string]dataentryconfig.List),
+		Views:      make(map[string]dataentryconfig.ViewConfig),
+		Kanbans:    make(map[string]dataentryconfig.Kanban),
+		Navigation: []dataentryconfig.NavigationEntry{},
+	}
+	app := newAppFromParts(cfg, meta, newFixture())
+	app.broker = newEventBroker()
+	seedEntity(app, &entity.Entity{ID: "REC-001", Type: "recipe", Properties: map[string]interface{}{"title": "Soup"}})
+	seedEntity(app, &entity.Entity{ID: "STP-001", Type: "step", Properties: map[string]interface{}{"title": "Boil"}})
+	return app
+}
+
+func patchRecipe(t *testing.T, app *App, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/recipes/REC-001", bytes.NewReader([]byte(body)))
+	rec := httptest.NewRecorder()
+	app.handleV1UpdateEntity(rec, req, "recipe", "recipes", "REC-001")
+	return rec
+}
+
+// PATCH that sets a valid numeric _order_out is accepted (200) and persisted.
+func TestOrderable_PatchSetsOrderOut(t *testing.T) {
+	app := newOrderableModernTestApp(t, metamodel.OrderableOutgoing)
+	if _, err := app.store.CreateRelation(context.Background(), "REC-001", "has-step", "STP-001",
+		&store.RelationData{Properties: map[string]interface{}{metamodel.OrderPropertyOut: 1.0}}); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"relations":{"has-step":{"data":[{"type":"step","id":"STP-001","meta":{"_order_out":2.5}}]}}}`
+	rec := patchRecipe(t, app, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got, err := app.store.GetRelation(context.Background(), "REC-001", "has-step", "STP-001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Properties[metamodel.OrderPropertyOut] != 2.5 {
+		t.Errorf("_order_out=%v, want 2.5", got.Properties[metamodel.OrderPropertyOut])
+	}
+}
+
+// PATCH with a non-finite numeric value on a managed order property is a
+// hard wire-format violation (400).
+func TestOrderable_PatchRejectsNonFiniteOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "string instead of number",
+			body: `{"relations":{"has-step":{"data":[{"type":"step","id":"STP-001","meta":{"_order_out":"abc"}}]}}}`,
+		},
+		{
+			// 1e500 overflows float64 → +Inf, which we reject.
+			name: "overflows to infinity",
+			body: `{"relations":{"has-step":{"data":[{"type":"step","id":"STP-001","meta":{"_order_out":1e500}}]}}}`,
+		},
+		{
+			// boolean is not numeric.
+			name: "boolean rejected",
+			body: `{"relations":{"has-step":{"data":[{"type":"step","id":"STP-001","meta":{"_order_out":true}}]}}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newOrderableModernTestApp(t, metamodel.OrderableOutgoing)
+			if _, err := app.store.CreateRelation(context.Background(), "REC-001", "has-step", "STP-001",
+				&store.RelationData{Properties: map[string]interface{}{metamodel.OrderPropertyOut: 1.0}}); err != nil {
+				t.Fatal(err)
+			}
+			rec := patchRecipe(t, app, tt.body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+			}
+			// The "overflows to infinity" case is rejected by Go's
+			// JSON decoder before our validateManagedOrderMeta runs
+			// (1e500 → field_invalid_type during V1ResourceIdentifier
+			// decode). The string and boolean cases reach our check.
+			// Either way the request must 400 — we accept both codes.
+			var problem struct {
+				Type   string `json:"type"`
+				Status int    `json:"status"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &problem); err != nil {
+				t.Fatalf("decode problem: %v", err)
+			}
+			if problem.Status != 400 {
+				t.Errorf("problem.Status = %d, want 400", problem.Status)
+			}
+		})
+	}
+}
+
+// patchEdge issues a per-edge PATCH (the path used by the SPA for reorder).
+func patchEdge(t *testing.T, app *App, relType, targetID, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	url := "/api/v1/recipes/REC-001/relations/" + relType + "/" + targetID
+	req := httptest.NewRequest(http.MethodPatch, url, bytes.NewReader([]byte(body)))
+	rec := httptest.NewRecorder()
+	app.handleV1UpdateRelation(rec, req, "recipe", "REC-001", relType, targetID)
+	return rec
+}
+
+// G2: per-edge PATCH wire validation for the incoming-side managed property.
+// Mirrors TestOrderable_PatchRejectsNonFiniteOrder but exercises _order_in
+// instead of _order_out. Without this test, a regression that loosens the
+// incoming-side check at the per-edge handler would slip through.
+func TestOrderable_PatchEdgeRejectsNonFiniteOrderIn(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"string", `{"meta":{"_order_in":"abc"}}`},
+		{"boolean", `{"meta":{"_order_in":true}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newOrderableModernTestApp(t, metamodel.OrderableIncoming)
+			if _, err := app.store.CreateRelation(context.Background(), "REC-001", "has-step", "STP-001",
+				&store.RelationData{Properties: map[string]interface{}{metamodel.OrderPropertyIn: 1.0}}); err != nil {
+				t.Fatal(err)
+			}
+			rec := patchEdge(t, app, "has-step", "STP-001", tt.body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// G3: orderable:incoming mode rejects non-finite values via the same
+// per-edge endpoint that drives the SPA reorder. Sanity check that
+// incoming-mode wires up identically to outgoing-mode.
+func TestOrderable_PatchEdgeIncomingModeAcceptsFinite(t *testing.T) {
+	app := newOrderableModernTestApp(t, metamodel.OrderableIncoming)
+	if _, err := app.store.CreateRelation(context.Background(), "REC-001", "has-step", "STP-001",
+		&store.RelationData{Properties: map[string]interface{}{metamodel.OrderPropertyIn: 1.0}}); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"meta":{"_order_in":2.5}}`
+	rec := patchEdge(t, app, "has-step", "STP-001", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got, err := app.store.GetRelation(context.Background(), "REC-001", "has-step", "STP-001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Properties[metamodel.OrderPropertyIn] != 2.5 {
+		t.Errorf("_order_in = %v, want 2.5", got.Properties[metamodel.OrderPropertyIn])
+	}
+}
+
+// PATCH that omits the order property does not trigger validation
+// (managed properties are optional on writes that don't touch them).
+func TestOrderable_PatchWithoutOrderUntouched(t *testing.T) {
+	app := newOrderableModernTestApp(t, metamodel.OrderableOutgoing)
+	if _, err := app.store.CreateRelation(context.Background(), "REC-001", "has-step", "STP-001",
+		&store.RelationData{Properties: map[string]interface{}{metamodel.OrderPropertyOut: 1.0}}); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"relations":{"has-step":{"data":[{"type":"step","id":"STP-001"}]}}}`
+	rec := patchRecipe(t, app, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got, err := app.store.GetRelation(context.Background(), "REC-001", "has-step", "STP-001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Properties[metamodel.OrderPropertyOut] != 1.0 {
+		t.Errorf("_order_out should remain 1.0, got %v", got.Properties[metamodel.OrderPropertyOut])
+	}
+}
+
+// PATCH on a non-orderable type writing _order_out succeeds (the property
+// is just a plain meta key) but produces an `unknown_meta_key` warning.
+func TestOrderable_NonOrderableTypeStillAcceptsOrderKey(t *testing.T) {
+	app := newOrderableModernTestApp(t, metamodel.OrderableNone)
+	if _, err := app.store.CreateRelation(context.Background(), "REC-001", "has-step", "STP-001",
+		&store.RelationData{Properties: map[string]interface{}{}}); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"relations":{"has-step":{"data":[{"type":"step","id":"STP-001","meta":{"_order_out":1.5}}]}}}`
+	rec := patchRecipe(t, app, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Body should report the unknown_meta_key warning.
+	var resp struct {
+		Warnings []Warning `json:"warnings"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	found := false
+	for _, w := range resp.Warnings {
+		if w.Code == "unknown_meta_key" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected unknown_meta_key warning for non-orderable type; got %+v", resp.Warnings)
+	}
+}

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -542,6 +542,14 @@ func (m *Manager) CreateRelation(
 		rel.Content = *opts.Content
 	}
 
+	// Auto-assign managed order properties (_order_out / _order_in) when
+	// the relation type declares the side orderable. Overrides any
+	// non-finite caller-supplied value with AppendOrder over existing
+	// siblings; keeps finite caller values as-is.
+	if err := m.assignManagedOrder(ctx, rel, relType); err != nil {
+		return nil, err
+	}
+
 	if err := upsertRelation(ctx, m.deps.Store, rel); err != nil {
 		return nil, err
 	}
@@ -574,6 +582,18 @@ func (m *Manager) UpdateRelation(
 	// which keys changed (values never appear).
 	oldProps := cloneProperties(rel.Properties)
 
+	// Reject non-finite numeric values on managed order properties.
+	// HTTP wire validators already cover the dataentry path; this is
+	// the engine-level backstop for MCP/Lua/CLI write paths.
+	relDef, hasDef := m.deps.Meta.Relations[relType]
+	touchedOut := hasDef && relDef.OutgoingOrderProperty() != "" && touchesOrderKey(opts, relDef.OutgoingOrderProperty())
+	touchedIn := hasDef && relDef.IncomingOrderProperty() != "" && touchesOrderKey(opts, relDef.IncomingOrderProperty())
+	if hasDef {
+		if err := validateOrderUpdate(opts, relDef); err != nil {
+			return nil, err
+		}
+	}
+
 	if rel.Properties == nil && (len(opts.Properties) > 0 || len(opts.MetaUnset) > 0) {
 		rel.Properties = make(map[string]interface{})
 	}
@@ -591,6 +611,12 @@ func (m *Manager) UpdateRelation(
 		return nil, err
 	}
 	m.recordRelationAudit(ctx, audit.OpUpdateRelation, rel, updateRelationSummary(oldProps, rel.Properties))
+
+	// Engine-initiated renumber when an order PATCH collapsed sibling
+	// spacing. Errors are operator-visible (slog.Error) but do not fail
+	// the user-visible Update — the caller's write already succeeded.
+	m.runRenumberAfterUpdate(ctx, from, to, relType, touchedOut, touchedIn)
+
 	return rel, nil
 }
 

--- a/internal/entitymanager/manager_order.go
+++ b/internal/entitymanager/manager_order.go
@@ -1,0 +1,222 @@
+package entitymanager
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// assignManagedOrder fills in _order_out / _order_in on a new relation
+// when the relation type is orderable and the caller has not supplied a
+// finite numeric value. Auto-assignment uses AppendOrder over the
+// existing siblings on the enabled side.
+//
+// A non-finite or non-numeric caller-supplied value is overwritten — the
+// HTTP wire validators reject those at the boundary, but MCP/Lua/CLI
+// write paths reach Manager directly and can submit garbage. We guarantee
+// the on-disk relation always has a finite numeric value when the type
+// declares the side orderable, regardless of write entry point.
+func (m *Manager) assignManagedOrder(ctx context.Context, rel *entity.Relation, relType string) error {
+	relDef, ok := m.deps.Meta.Relations[relType]
+	if !ok {
+		// Caller already validated the relation type via
+		// Meta.ValidateRelation. This branch is only reachable
+		// through a metamodel reload race; failing loudly surfaces
+		// the race rather than silently writing a relation with no
+		// managed order.
+		return fmt.Errorf("assignManagedOrder: relation type %q not found in metamodel", relType)
+	}
+	assignSide := func(prop string, query store.RelationQuery) error {
+		if prop == "" {
+			return nil
+		}
+		if rel.Properties == nil {
+			rel.Properties = make(map[string]interface{})
+		}
+		if _, ok := FiniteOrder(rel.Properties[prop]); ok {
+			return nil
+		}
+		vals, err := m.collectSiblingOrders(ctx, query, prop)
+		if err != nil {
+			return fmt.Errorf("collect siblings for %q: %w", prop, err)
+		}
+		rel.Properties[prop] = AppendOrder(vals)
+		return nil
+	}
+	if err := assignSide(relDef.OutgoingOrderProperty(), store.RelationQuery{
+		From: rel.From, Type: relType,
+	}); err != nil {
+		return err
+	}
+	return assignSide(relDef.IncomingOrderProperty(), store.RelationQuery{
+		To: rel.To, Type: relType,
+	})
+}
+
+// collectSiblingOrders walks relations matching q and returns the finite
+// float values present at prop.
+func (m *Manager) collectSiblingOrders(ctx context.Context, q store.RelationQuery, prop string) ([]float64, error) {
+	var vals []float64
+	for r, err := range m.deps.Store.ListRelations(ctx, q) {
+		if err != nil {
+			return nil, err
+		}
+		if v, ok := FiniteOrder(r.Properties[prop]); ok {
+			vals = append(vals, v)
+		}
+	}
+	return vals, nil
+}
+
+// touchesOrderKey reports whether opts modifies the given property key,
+// either by setting a new value or by unsetting it.
+func touchesOrderKey(opts entity.RelationOptions, key string) bool {
+	if _, ok := opts.Properties[key]; ok {
+		return true
+	}
+	for _, k := range opts.MetaUnset {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// validateOrderUpdate rejects non-finite numeric values on managed order
+// properties at the Manager layer so MCP/Lua/CLI write paths can't bypass
+// the wire validators. Wire validation runs before Manager for HTTP; this
+// is the engine-level backstop.
+func validateOrderUpdate(opts entity.RelationOptions, relDef metamodel.RelationDef) error {
+	check := func(prop string) error {
+		v, present := opts.Properties[prop]
+		if !present {
+			return nil
+		}
+		if _, ok := FiniteOrder(v); !ok {
+			return fmt.Errorf("invalid value for %s: must be a finite number, got %T", prop, v)
+		}
+		return nil
+	}
+	if p := relDef.OutgoingOrderProperty(); p != "" {
+		if err := check(p); err != nil {
+			return err
+		}
+	}
+	if p := relDef.IncomingOrderProperty(); p != "" {
+		if err := check(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// maybeRenumberSide walks the siblings matching q, checks whether the
+// finite values at prop have a gap below OrderCollapseThreshold, and if
+// so rewrites them to dense integer ordinals 1.0..N. Two-phase: build
+// the full plan, then apply it. A mid-loop write failure aborts the
+// apply and returns the error — earlier writes still landed (the store
+// has no transaction).
+//
+// Renumber preserves missing-ness: siblings whose value at prop is
+// missing (or non-finite) stay missing. Only siblings that previously
+// had a finite value are redistributed.
+func (m *Manager) maybeRenumberSide(ctx context.Context, q store.RelationQuery, prop string) error {
+	var sibs []*entity.Relation
+	for r, err := range m.deps.Store.ListRelations(ctx, q) {
+		if err != nil {
+			return err
+		}
+		c := *r
+		if r.Properties != nil {
+			c.Properties = make(map[string]interface{}, len(r.Properties))
+			for k, v := range r.Properties {
+				c.Properties[k] = v
+			}
+		}
+		sibs = append(sibs, &c)
+	}
+	if len(sibs) < 2 {
+		return nil
+	}
+
+	values := make([]float64, 0, len(sibs))
+	for _, r := range sibs {
+		if v, ok := FiniteOrder(r.Properties[prop]); ok {
+			values = append(values, v)
+		}
+	}
+	sort.Float64s(values)
+	if !NeedsRenumber(values) {
+		return nil
+	}
+
+	type planEntry struct {
+		rel    *entity.Relation
+		newVal float64
+	}
+	withValue := make([]*entity.Relation, 0, len(sibs))
+	for _, r := range sibs {
+		if _, ok := FiniteOrder(r.Properties[prop]); ok {
+			withValue = append(withValue, r)
+		}
+	}
+	asValues := make([]entity.Relation, len(withValue))
+	for i, r := range withValue {
+		asValues[i] = *r
+	}
+	sorted := SortRelations(asValues, prop)
+	byKey := make(map[string]*entity.Relation, len(withValue))
+	for _, r := range withValue {
+		byKey[r.From+"--"+r.Type+"--"+r.To] = r
+	}
+	plan := make([]planEntry, 0, len(sorted))
+	for i, s := range sorted {
+		newVal := float64(i + 1)
+		key := s.From + "--" + s.Type + "--" + s.To
+		r := byKey[key]
+		if cur, ok := FiniteOrder(r.Properties[prop]); ok && cur == newVal {
+			continue
+		}
+		plan = append(plan, planEntry{rel: r, newVal: newVal})
+	}
+
+	for _, p := range plan {
+		props := make(map[string]interface{}, len(p.rel.Properties)+1)
+		for k, v := range p.rel.Properties {
+			props[k] = v
+		}
+		props[prop] = p.newVal
+		data := store.RelationData{Properties: props, Content: p.rel.Content}
+		if _, err := m.deps.Store.UpdateRelation(ctx, p.rel.From, p.rel.Type, p.rel.To, data); err != nil {
+			return fmt.Errorf("renumber write failed for %s--%s--%s: %w", p.rel.From, p.rel.Type, p.rel.To, err)
+		}
+	}
+	return nil
+}
+
+// runRenumberAfterUpdate logs (does not return) renumber failures from
+// the post-update cleanup pass. Called from UpdateRelation when the
+// caller touched a managed order property.
+func (m *Manager) runRenumberAfterUpdate(ctx context.Context, from, to, relType string, touchedOut, touchedIn bool) {
+	relDef, ok := m.deps.Meta.Relations[relType]
+	if !ok {
+		return
+	}
+	if touchedOut {
+		q := store.RelationQuery{From: from, Type: relType}
+		if rErr := m.maybeRenumberSide(ctx, q, relDef.OutgoingOrderProperty()); rErr != nil {
+			slog.Error("renumber outgoing side failed", "from", from, "relType", relType, "err", rErr)
+		}
+	}
+	if touchedIn {
+		q := store.RelationQuery{To: to, Type: relType}
+		if rErr := m.maybeRenumberSide(ctx, q, relDef.IncomingOrderProperty()); rErr != nil {
+			slog.Error("renumber incoming side failed", "to", to, "relType", relType, "err", rErr)
+		}
+	}
+}

--- a/internal/entitymanager/order.go
+++ b/internal/entitymanager/order.go
@@ -1,0 +1,120 @@
+package entitymanager
+
+import (
+	"math"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// OrderCollapseThreshold is the minimum gap between adjacent order values
+// before the entity manager renumbers a side to dense integer ordinals.
+// Picked well above IEEE-754 float64 precision-loss territory so the
+// renumber fires defensively, not at the edge of correctness.
+const OrderCollapseThreshold = 1e-9
+
+// MidpointOrder returns a value strictly between a and b. If the gap is
+// below OrderCollapseThreshold or the values are not in strict ascending
+// order, returns (0, false) so the caller can decide to renumber.
+func MidpointOrder(a, b float64) (float64, bool) {
+	if !isFiniteFloat(a) || !isFiniteFloat(b) {
+		return 0, false
+	}
+	if b-a < OrderCollapseThreshold {
+		return 0, false
+	}
+	return a + (b-a)/2, true
+}
+
+// AppendOrder returns a value strictly greater than every finite value in
+// existing. When existing is empty (or has no finite values), returns 1.0.
+func AppendOrder(existing []float64) float64 {
+	maxV := math.Inf(-1)
+	for _, v := range existing {
+		if isFiniteFloat(v) && v > maxV {
+			maxV = v
+		}
+	}
+	if math.IsInf(maxV, -1) {
+		return 1.0
+	}
+	return maxV + 1.0
+}
+
+// PrependOrder returns a value strictly less than every finite value in
+// existing. When existing is empty (or has no finite values), returns 1.0.
+func PrependOrder(existing []float64) float64 {
+	minV := math.Inf(1)
+	for _, v := range existing {
+		if isFiniteFloat(v) && v < minV {
+			minV = v
+		}
+	}
+	if math.IsInf(minV, 1) {
+		return 1.0
+	}
+	return minV - 1.0
+}
+
+// NeedsRenumber reports whether a sorted list of order values has any
+// adjacent gap below OrderCollapseThreshold. The input must already be
+// sorted ascending; values are otherwise compared in slice order.
+func NeedsRenumber(sorted []float64) bool {
+	for i := 1; i < len(sorted); i++ {
+		a, b := sorted[i-1], sorted[i]
+		if !isFiniteFloat(a) || !isFiniteFloat(b) {
+			continue
+		}
+		if b-a < OrderCollapseThreshold {
+			return true
+		}
+	}
+	return false
+}
+
+// SortRelations returns a copy of rels in stable sort order by the named
+// numeric property ascending. Entries with a missing, non-numeric, or
+// non-finite value sort after entries with a finite value; among themselves
+// they preserve the original input order (stable). Ties on the value are
+// also broken by original order.
+//
+// When prop is empty, returns a shallow copy of rels in input order.
+func SortRelations(rels []entity.Relation, prop string) []entity.Relation {
+	out := make([]entity.Relation, len(rels))
+	copy(out, rels)
+	if prop == "" {
+		return out
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		vi, oki := orderValue(out[i], prop)
+		vj, okj := orderValue(out[j], prop)
+		switch {
+		case oki && !okj:
+			return true
+		case !oki && okj:
+			return false
+		case !oki && !okj:
+			return false
+		}
+		return vi < vj
+	})
+	return out
+}
+
+// orderValue extracts a finite float ordering value from a relation's
+// properties using FiniteOrder semantics on the named property.
+func orderValue(r entity.Relation, prop string) (float64, bool) {
+	return FiniteOrder(r.Properties[prop])
+}
+
+// FiniteOrder is re-exported from metamodel for callers that already
+// import entitymanager. The canonical implementation lives in metamodel
+// so the analyzer (which can't depend on entitymanager) shares it.
+func FiniteOrder(v interface{}) (float64, bool) {
+	return metamodel.FiniteOrder(v)
+}
+
+func isFiniteFloat(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0)
+}

--- a/internal/entitymanager/order_test.go
+++ b/internal/entitymanager/order_test.go
@@ -1,0 +1,225 @@
+package entitymanager
+
+import (
+	"math"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+func TestMidpointOrder(t *testing.T) {
+	tests := []struct {
+		name      string
+		a, b      float64
+		wantValue float64
+		wantOK    bool
+	}{
+		{"simple integer gap", 1, 2, 1.5, true},
+		{"non-integer endpoints", 1.25, 1.75, 1.5, true},
+		{"large gap", 0, 1000, 500, true},
+		{"negative range", -10, -5, -7.5, true},
+		{"zero crossing", -1, 1, 0, true},
+		{"identical values", 1, 1, 0, false},
+		{"reversed", 2, 1, 0, false},
+		{"gap below threshold", 1, 1 + OrderCollapseThreshold/2, 0, false},
+		{"NaN a", math.NaN(), 1, 0, false},
+		{"NaN b", 1, math.NaN(), 0, false},
+		{"Inf b", 0, math.Inf(1), 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, ok := MidpointOrder(tt.a, tt.b)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (value=%v)", ok, tt.wantOK, v)
+			}
+			if ok && v != tt.wantValue {
+				t.Errorf("value = %v, want %v", v, tt.wantValue)
+			}
+			if ok && (v <= tt.a || v >= tt.b) {
+				t.Errorf("midpoint %v not strictly between %v and %v", v, tt.a, tt.b)
+			}
+		})
+	}
+}
+
+func TestAppendOrder(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []float64
+		want     float64
+	}{
+		{"empty", nil, 1.0},
+		{"single", []float64{5}, 6.0},
+		{"increasing", []float64{1, 2, 3}, 4.0},
+		{"unsorted", []float64{2, 0.5, 3, 1.25}, 4.0},
+		{"with NaN ignored", []float64{1, math.NaN(), 2}, 3.0},
+		{"all NaN", []float64{math.NaN(), math.NaN()}, 1.0},
+		{"negatives", []float64{-3, -10, -1}, 0.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AppendOrder(tt.existing); got != tt.want {
+				t.Errorf("AppendOrder(%v) = %v, want %v", tt.existing, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrependOrder(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []float64
+		want     float64
+	}{
+		{"empty", nil, 1.0},
+		{"single", []float64{5}, 4.0},
+		{"unsorted", []float64{3, 2, 1}, 0.0},
+		{"with NaN ignored", []float64{2, math.NaN(), 3}, 1.0},
+		{"negatives", []float64{-3, -10, -1}, -11.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PrependOrder(tt.existing); got != tt.want {
+				t.Errorf("PrependOrder(%v) = %v, want %v", tt.existing, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNeedsRenumber(t *testing.T) {
+	tests := []struct {
+		name   string
+		sorted []float64
+		want   bool
+	}{
+		{"empty", nil, false},
+		{"single", []float64{1}, false},
+		{"safe gaps", []float64{1, 2, 3, 4}, false},
+		{"tight but safe", []float64{1, 1.0001, 1.0002}, false},
+		{"collapsed", []float64{1, 1 + OrderCollapseThreshold/2, 2}, true},
+		{"exact duplicates", []float64{1, 1, 2}, true},
+		{"non-finite skipped", []float64{1, math.NaN(), 1.5}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NeedsRenumber(tt.sorted); got != tt.want {
+				t.Errorf("NeedsRenumber(%v) = %v, want %v", tt.sorted, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMidpoint_RepeatedInsertsTriggerCollapse simulates the worst-case
+// scenario where every insert lands at the same position. After enough
+// inserts, MidpointOrder must report collapse so the caller can renumber.
+func TestMidpoint_RepeatedInsertsTriggerCollapse(t *testing.T) {
+	low, high := 1.0, 2.0
+	const maxIters = 1000
+	for range maxIters {
+		v, ok := MidpointOrder(low, high)
+		if !ok {
+			// Collapse fired — that's the success case.
+			return
+		}
+		// Always insert in the lower half to chase the collapse fastest.
+		high = v
+	}
+	t.Fatalf("expected collapse within %d iterations; reached high=%v low=%v gap=%v", maxIters, high, low, high-low)
+}
+
+func TestSortRelations_StableMissingLast(t *testing.T) {
+	mkRel := func(id string, order interface{}) entity.Relation {
+		props := map[string]interface{}{}
+		if order != nil {
+			props["_order_out"] = order
+		}
+		return entity.Relation{From: "src", Type: "has-step", To: id, Properties: props}
+	}
+	tests := []struct {
+		name string
+		in   []entity.Relation
+		want []string // expected To order after sort
+	}{
+		{
+			name: "ascending",
+			in: []entity.Relation{
+				mkRel("c", 3.0),
+				mkRel("a", 1.0),
+				mkRel("b", 2.0),
+			},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "missing sorted last, stable among themselves",
+			in: []entity.Relation{
+				mkRel("missing1", nil),
+				mkRel("a", 1.0),
+				mkRel("missing2", nil),
+				mkRel("b", 2.0),
+			},
+			want: []string{"a", "b", "missing1", "missing2"},
+		},
+		{
+			name: "duplicate values, stable",
+			in: []entity.Relation{
+				mkRel("a", 1.0),
+				mkRel("b", 1.0),
+				mkRel("c", 1.0),
+			},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "integer values accepted",
+			in: []entity.Relation{
+				mkRel("a", 3),
+				mkRel("b", 1),
+				mkRel("c", 2),
+			},
+			want: []string{"b", "c", "a"},
+		},
+		{
+			name: "NaN treated as missing",
+			in: []entity.Relation{
+				mkRel("a", math.NaN()),
+				mkRel("b", 1.0),
+				mkRel("c", math.NaN()),
+			},
+			want: []string{"b", "a", "c"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SortRelations(tt.in, "_order_out")
+			gotIDs := make([]string, len(got))
+			for i, r := range got {
+				gotIDs[i] = r.To
+			}
+			if !slicesEqual(gotIDs, tt.want) {
+				t.Errorf("got %v, want %v", gotIDs, tt.want)
+			}
+		})
+	}
+}
+
+func TestSortRelations_EmptyPropertyName(t *testing.T) {
+	in := []entity.Relation{
+		{To: "a", Properties: map[string]interface{}{"_order_out": 3.0}},
+		{To: "b", Properties: map[string]interface{}{"_order_out": 1.0}},
+	}
+	got := SortRelations(in, "")
+	if len(got) != 2 || got[0].To != "a" || got[1].To != "b" {
+		t.Errorf("empty prop should not reorder; got %v", got)
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/entitymanager/orderable_test.go
+++ b/internal/entitymanager/orderable_test.go
@@ -1,0 +1,282 @@
+package entitymanager_test
+
+import (
+	"context"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+const orderableMetamodelTemplate = `version: "1.0"
+entities:
+  recipe:
+    label: Recipe
+    plural: recipes
+    id_prefix: "REC-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+        required: true
+  step:
+    label: Step
+    plural: steps
+    id_prefix: "STP-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+        required: true
+relations:
+  has-step:
+    label: has step
+    from: [recipe]
+    to: [step]
+%s
+`
+
+func orderableMetamodel(t *testing.T, mode string) *metamodel.Metamodel {
+	t.Helper()
+	suffix := ""
+	if mode != "" {
+		suffix = "    orderable: " + mode
+	}
+	yaml := strings.Replace(orderableMetamodelTemplate, "%s", suffix, 1)
+	m, err := metamodel.Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse metamodel: %v", err)
+	}
+	return m
+}
+
+func newOrderableManager(t *testing.T, mode string) (*entitymanager.Manager, store.Store) {
+	t.Helper()
+	st := memstore.New()
+	deps := entitymanager.Deps{
+		Store:     st,
+		Meta:      orderableMetamodel(t, mode),
+		Templater: nopTemplater{},
+		Audit:     audit.Nop{},
+		ACL:       acl.NopACL{},
+	}
+	mgr, err := entitymanager.New(deps)
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	return mgr, st
+}
+
+func mkRecipe(t *testing.T, mgr *entitymanager.Manager, title string) *entity.Entity {
+	t.Helper()
+	e := entity.New("", "recipe")
+	e.SetString("title", title)
+	res, err := mgr.CreateEntity(context.Background(), e, entity.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create recipe: %v", err)
+	}
+	return res.Entity
+}
+
+func mkStep(t *testing.T, mgr *entitymanager.Manager, title string) *entity.Entity {
+	t.Helper()
+	e := entity.New("", "step")
+	e.SetString("title", title)
+	res, err := mgr.CreateEntity(context.Background(), e, entity.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create step: %v", err)
+	}
+	return res.Entity
+}
+
+func TestCreateRelation_AssignsOrder(t *testing.T) {
+	tests := []struct {
+		name           string
+		mode           string
+		wantOutPresent bool
+		wantInPresent  bool
+	}{
+		{"none — no managed order", "", false, false},
+		{"outgoing — assigns _order_out only", "outgoing", true, false},
+		{"incoming — assigns _order_in only", "incoming", false, true},
+		{"both — assigns both", "both", true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr, _ := newOrderableManager(t, tt.mode)
+			ctx := context.Background()
+			recipe := mkRecipe(t, mgr, "Soup")
+			step1 := mkStep(t, mgr, "Boil water")
+			step2 := mkStep(t, mgr, "Add salt")
+
+			rel1, err := mgr.CreateRelation(ctx, recipe.ID, "has-step", step1.ID, entity.RelationOptions{})
+			if err != nil {
+				t.Fatalf("create rel1: %v", err)
+			}
+			rel2, err := mgr.CreateRelation(ctx, recipe.ID, "has-step", step2.ID, entity.RelationOptions{})
+			if err != nil {
+				t.Fatalf("create rel2: %v", err)
+			}
+
+			gotOut1, hasOut1 := rel1.Properties[metamodel.OrderPropertyOut]
+			gotOut2, hasOut2 := rel2.Properties[metamodel.OrderPropertyOut]
+			gotIn1, hasIn1 := rel1.Properties[metamodel.OrderPropertyIn]
+			gotIn2, hasIn2 := rel2.Properties[metamodel.OrderPropertyIn]
+
+			if hasOut1 != tt.wantOutPresent || hasOut2 != tt.wantOutPresent {
+				t.Errorf("_order_out presence: rel1=%v rel2=%v, want %v", hasOut1, hasOut2, tt.wantOutPresent)
+			}
+			if hasIn1 != tt.wantInPresent || hasIn2 != tt.wantInPresent {
+				t.Errorf("_order_in presence: rel1=%v rel2=%v, want %v", hasIn1, hasIn2, tt.wantInPresent)
+			}
+
+			if tt.wantOutPresent {
+				if gotOut1 != 1.0 {
+					t.Errorf("rel1 _order_out = %v, want 1.0", gotOut1)
+				}
+				if gotOut2 != 2.0 {
+					t.Errorf("rel2 _order_out = %v, want 2.0", gotOut2)
+				}
+			}
+			if tt.wantInPresent {
+				if gotIn1 != 1.0 {
+					t.Errorf("rel1 _order_in = %v, want 1.0", gotIn1)
+				}
+				if gotIn2 != 1.0 {
+					t.Errorf("rel2 _order_in = %v, want 1.0", gotIn2)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateRelation_ExplicitOrderRespected(t *testing.T) {
+	mgr, _ := newOrderableManager(t, "outgoing")
+	ctx := context.Background()
+	recipe := mkRecipe(t, mgr, "Stew")
+	step := mkStep(t, mgr, "Chop")
+
+	rel, err := mgr.CreateRelation(ctx, recipe.ID, "has-step", step.ID, entity.RelationOptions{
+		Properties: map[string]interface{}{metamodel.OrderPropertyOut: 42.5},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if got := rel.Properties[metamodel.OrderPropertyOut]; got != 42.5 {
+		t.Errorf("explicit _order_out should be preserved: got %v, want 42.5", got)
+	}
+}
+
+// Garbage value cases — non-finite or non-numeric values supplied through
+// non-HTTP write paths must be overwritten with the auto-assigned next
+// ordinal so the on-disk relation always has a sortable value.
+func TestCreateRelation_GarbageOrderValueIsOverwritten(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+	}{
+		{"non-numeric string", "abc"},
+		{"explicit nil", nil},
+		{"boolean", true},
+		{"NaN", math.NaN()},
+		{"+Inf", math.Inf(1)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr, _ := newOrderableManager(t, "outgoing")
+			ctx := context.Background()
+			recipe := mkRecipe(t, mgr, "X")
+			step := mkStep(t, mgr, "Y")
+
+			rel, err := mgr.CreateRelation(ctx, recipe.ID, "has-step", step.ID, entity.RelationOptions{
+				Properties: map[string]interface{}{metamodel.OrderPropertyOut: tt.value},
+			})
+			if err != nil {
+				t.Fatalf("create: %v", err)
+			}
+			if got := rel.Properties[metamodel.OrderPropertyOut]; got != 1.0 {
+				t.Errorf("_order_out = %v (%T), want 1.0 (caller-supplied garbage should be overwritten)", got, got)
+			}
+		})
+	}
+}
+
+func TestUpdateRelation_BothMode_SidesIndependent(t *testing.T) {
+	mgr, st := newOrderableManager(t, "both")
+	ctx := context.Background()
+	recipe := mkRecipe(t, mgr, "X")
+	step := mkStep(t, mgr, "Y")
+
+	rel, err := mgr.CreateRelation(ctx, recipe.ID, "has-step", step.ID, entity.RelationOptions{})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if rel.Properties[metamodel.OrderPropertyOut] != 1.0 || rel.Properties[metamodel.OrderPropertyIn] != 1.0 {
+		t.Fatalf("baseline: got out=%v in=%v, want both 1.0",
+			rel.Properties[metamodel.OrderPropertyOut], rel.Properties[metamodel.OrderPropertyIn])
+	}
+
+	_, err = mgr.UpdateRelation(ctx, recipe.ID, "has-step", step.ID, entity.RelationOptions{
+		Properties: map[string]interface{}{metamodel.OrderPropertyOut: 5.5},
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	got, err := st.GetRelation(ctx, recipe.ID, "has-step", step.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Properties[metamodel.OrderPropertyOut] != 5.5 {
+		t.Errorf("_order_out = %v, want 5.5", got.Properties[metamodel.OrderPropertyOut])
+	}
+	if got.Properties[metamodel.OrderPropertyIn] != 1.0 {
+		t.Errorf("_order_in changed unexpectedly: got %v, want 1.0", got.Properties[metamodel.OrderPropertyIn])
+	}
+}
+
+func TestUpdateRelation_RejectsNonFiniteOrder(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+	}{
+		{"non-numeric string", "abc"},
+		{"boolean", true},
+		{"NaN", math.NaN()},
+		{"+Inf", math.Inf(1)},
+		{"-Inf", math.Inf(-1)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr, st := newOrderableManager(t, "outgoing")
+			ctx := context.Background()
+			recipe := mkRecipe(t, mgr, "X")
+			step := mkStep(t, mgr, "Y")
+			if _, err := mgr.CreateRelation(ctx, recipe.ID, "has-step", step.ID, entity.RelationOptions{}); err != nil {
+				t.Fatalf("create baseline: %v", err)
+			}
+
+			_, err := mgr.UpdateRelation(ctx, recipe.ID, "has-step", step.ID, entity.RelationOptions{
+				Properties: map[string]interface{}{metamodel.OrderPropertyOut: tt.value},
+			})
+			if err == nil {
+				t.Fatalf("expected update to fail for value %v, got nil error", tt.value)
+			}
+
+			got, getErr := st.GetRelation(ctx, recipe.ID, "has-step", step.ID)
+			if getErr != nil {
+				t.Fatalf("get: %v", getErr)
+			}
+			if got.Properties[metamodel.OrderPropertyOut] != 1.0 {
+				t.Errorf("_order_out should remain 1.0 after rejected update, got %v", got.Properties[metamodel.OrderPropertyOut])
+			}
+		})
+	}
+}

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -236,6 +236,7 @@ func validate(m *Metamodel) error {
 	validationErrors = append(validationErrors, validateRelationReferences(m)...)
 	validationErrors = append(validationErrors, validateRelationProperties(m)...)
 	validationErrors = append(validationErrors, validateRelationInverses(m)...)
+	validationErrors = append(validationErrors, validateRelationOrderable(m)...)
 
 	if len(validationErrors) > 0 {
 		return &SchemaValidationError{Errors: validationErrors}
@@ -535,7 +536,7 @@ func validateRelationInverses(m *Metamodel) []string {
 // validateRelationProperties validates property definitions on relation types.
 // Reserved property names for relations are: from, relation, to (used in YAML frontmatter).
 func validateRelationProperties(m *Metamodel) []string {
-	errs := make([]string, 0) //nolint:prealloc // capacity unknown
+	errs := make([]string, 0)
 
 	// Reserved property names for relations
 	reservedRelProps := map[string]bool{
@@ -548,6 +549,42 @@ func validateRelationProperties(m *Metamodel) []string {
 	for _, name := range relNames {
 		rel := m.Relations[name]
 		errs = append(errs, validatePropertyDefs(fmt.Sprintf("relation %q", name), rel.Properties, m, reservedRelProps)...)
+		// Forbid users from declaring the managed order properties explicitly:
+		// rela owns these names, and a user-supplied PropertyDef would conflict
+		// with the auto-assigned float values written by the entity manager.
+		if _, ok := rel.Properties[OrderPropertyOut]; ok {
+			errs = append(errs, fmt.Sprintf(
+				"relation %q: property %q is managed by rela and cannot be declared", name, OrderPropertyOut))
+		}
+		if _, ok := rel.Properties[OrderPropertyIn]; ok {
+			errs = append(errs, fmt.Sprintf(
+				"relation %q: property %q is managed by rela and cannot be declared", name, OrderPropertyIn))
+		}
+	}
+
+	return errs
+}
+
+// validateRelationOrderable rejects relation types that declare an Orderable
+// value outside the allowed enum, or that combine Orderable with Symmetric
+// (which has no meaningful semantics — a symmetric relation has only one
+// edge between any pair of entities, so "ordering" is undefined).
+func validateRelationOrderable(m *Metamodel) []string {
+	var errs []string
+
+	for _, name := range sortedKeys(m.Relations) {
+		rel := m.Relations[name]
+		if !rel.Orderable.IsValid() {
+			errs = append(errs, fmt.Sprintf(
+				"relation %q: invalid orderable value %q (allowed: outgoing, incoming, both)",
+				name, string(rel.Orderable)))
+			continue
+		}
+		if rel.Orderable != OrderableNone && rel.Symmetric {
+			errs = append(errs, fmt.Sprintf(
+				"relation %q: orderable cannot be combined with symmetric — symmetric relations have no canonical direction to order",
+				name))
+		}
 	}
 
 	return errs

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -2007,3 +2007,182 @@ func findRepoRoot(t *testing.T) string {
 		dir = parent
 	}
 }
+
+func TestParse_RelationOrderable(t *testing.T) {
+	const base = `
+version: "1.0"
+entities:
+  recipe:
+    label: Recipe
+    id_prefix: "REC-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+  step:
+    label: Step
+    id_prefix: "STP-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+relations:
+  has-step:
+    label: has step
+    from: [recipe]
+    to: [step]
+`
+	tests := []struct {
+		name             string
+		orderableYAML    string
+		wantErr          bool
+		wantOutgoingProp string
+		wantIncomingProp string
+		wantMode         OrderableMode
+	}{
+		{
+			name:          "absent (default)",
+			orderableYAML: "",
+			wantMode:      OrderableNone,
+		},
+		{
+			name:             "outgoing",
+			orderableYAML:    "    orderable: outgoing\n",
+			wantMode:         OrderableOutgoing,
+			wantOutgoingProp: OrderPropertyOut,
+		},
+		{
+			name:             "incoming",
+			orderableYAML:    "    orderable: incoming\n",
+			wantMode:         OrderableIncoming,
+			wantIncomingProp: OrderPropertyIn,
+		},
+		{
+			name:             "both",
+			orderableYAML:    "    orderable: both\n",
+			wantMode:         OrderableBoth,
+			wantOutgoingProp: OrderPropertyOut,
+			wantIncomingProp: OrderPropertyIn,
+		},
+		{
+			name:          "invalid string",
+			orderableYAML: "    orderable: yes\n",
+			wantErr:       true,
+		},
+		{
+			name:          "invalid uppercase",
+			orderableYAML: "    orderable: OUTGOING\n",
+			wantErr:       true,
+		},
+		{
+			name:          "invalid arbitrary",
+			orderableYAML: "    orderable: sometimes\n",
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yaml := base + tt.orderableYAML
+			m, err := Parse([]byte(yaml))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error for invalid orderable value, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			rel := m.Relations["has-step"]
+			if rel.Orderable != tt.wantMode {
+				t.Errorf("Orderable = %q, want %q", rel.Orderable, tt.wantMode)
+			}
+			if got := rel.OutgoingOrderProperty(); got != tt.wantOutgoingProp {
+				t.Errorf("OutgoingOrderProperty() = %q, want %q", got, tt.wantOutgoingProp)
+			}
+			if got := rel.IncomingOrderProperty(); got != tt.wantIncomingProp {
+				t.Errorf("IncomingOrderProperty() = %q, want %q", got, tt.wantIncomingProp)
+			}
+		})
+	}
+}
+
+func TestParse_RelationOrderable_RejectsManagedPropertyDecl(t *testing.T) {
+	tests := []struct {
+		name string
+		prop string
+	}{
+		{"_order_out is reserved", OrderPropertyOut},
+		{"_order_in is reserved", OrderPropertyIn},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yaml := `
+version: "1.0"
+entities:
+  recipe:
+    label: Recipe
+    id_prefix: "REC-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+  step:
+    label: Step
+    id_prefix: "STP-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+relations:
+  has-step:
+    label: has step
+    from: [recipe]
+    to: [step]
+    orderable: outgoing
+    properties:
+      ` + tt.prop + `:
+        type: integer
+`
+			_, err := Parse([]byte(yaml))
+			if err == nil {
+				t.Fatalf("expected error for declaring managed property %q", tt.prop)
+			}
+			if !strings.Contains(err.Error(), tt.prop) {
+				t.Errorf("error %q does not mention managed property %q", err.Error(), tt.prop)
+			}
+		})
+	}
+}
+
+// E5: orderable on a symmetric relation has no meaningful semantics — a
+// symmetric edge has no canonical direction to order, so the engine
+// refuses the combination at load time.
+func TestParse_RelationOrderable_RejectsSymmetric(t *testing.T) {
+	yaml := `
+version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "TASK-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+relations:
+  related-to:
+    label: related to
+    from: [task]
+    to: [task]
+    symmetric: true
+    orderable: outgoing
+`
+	_, err := Parse([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for orderable + symmetric combination")
+	}
+	if !strings.Contains(err.Error(), "symmetric") {
+		t.Errorf("error %q does not mention the symmetric conflict", err.Error())
+	}
+}

--- a/internal/metamodel/order.go
+++ b/internal/metamodel/order.go
@@ -1,0 +1,52 @@
+package metamodel
+
+import "math"
+
+// FiniteOrder converts a JSON- or YAML-decoded relation-property value to
+// a finite float64. Returns (value, true) for any built-in Go numeric type
+// (int*, uint*, float32, float64) that is finite; returns (0, false) for
+// nil, non-numeric types, NaN, or +/-Inf.
+//
+// All consumers that interpret managed order properties go through this
+// helper: the entity manager's auto-assign and renumber paths, the
+// data-entry sort and wire validators, the analyzer, and the CLI
+// commands. Keep one canonical implementation to avoid drift; do not
+// redefine variants in callers.
+func FiniteOrder(v interface{}) (float64, bool) {
+	if v == nil {
+		return 0, false
+	}
+	var f float64
+	switch x := v.(type) {
+	case float64:
+		f = x
+	case float32:
+		f = float64(x)
+	case int:
+		return float64(x), true
+	case int8:
+		return float64(x), true
+	case int16:
+		return float64(x), true
+	case int32:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	case uint:
+		return float64(x), true
+	case uint8:
+		return float64(x), true
+	case uint16:
+		return float64(x), true
+	case uint32:
+		return float64(x), true
+	case uint64:
+		return float64(x), true
+	default:
+		return 0, false
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, false
+	}
+	return f, true
+}

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -218,6 +218,34 @@ var ReservedPropertyNames = map[string]bool{
 	"type": true, // Entity.Type
 }
 
+// OrderableMode controls which side(s) of a relation type are user-orderable.
+type OrderableMode string
+
+const (
+	OrderableNone     OrderableMode = ""
+	OrderableOutgoing OrderableMode = "outgoing"
+	OrderableIncoming OrderableMode = "incoming"
+	OrderableBoth     OrderableMode = "both"
+)
+
+// Reserved relation-property names that hold the user-controlled order value.
+// The names are stable across mode changes so that promoting a relation from
+// outgoing-only to both (or vice versa) keeps existing values on disk valid.
+const (
+	OrderPropertyOut = "_order_out"
+	OrderPropertyIn  = "_order_in"
+)
+
+// IsValid reports whether the value is a recognized OrderableMode (including the
+// empty "not orderable" value).
+func (m OrderableMode) IsValid() bool {
+	switch m {
+	case OrderableNone, OrderableOutgoing, OrderableIncoming, OrderableBoth:
+		return true
+	}
+	return false
+}
+
 // DefaultDateFormat is the default format for date properties (ISO 8601)
 const DefaultDateFormat = "2006-01-02"
 
@@ -259,6 +287,30 @@ type RelationDef struct {
 	// Content indicates whether relations of this type support markdown body content.
 	// When true, the data-entry UI will show a content editor for the relation.
 	Content bool `yaml:"content,omitempty"`
+
+	// Orderable declares which side(s) of this relation type are user-orderable.
+	// When set, the data-entry UI offers drag-to-reorder controls on the enabled
+	// side(s); the API returns relations sorted by the corresponding managed
+	// order property (OrderPropertyOut / OrderPropertyIn).
+	Orderable OrderableMode `yaml:"orderable,omitempty"`
+}
+
+// OutgoingOrderProperty returns the relation-property name that holds the
+// outgoing-side order value, or "" if outgoing ordering is not enabled.
+func (r *RelationDef) OutgoingOrderProperty() string {
+	if r.Orderable == OrderableOutgoing || r.Orderable == OrderableBoth {
+		return OrderPropertyOut
+	}
+	return ""
+}
+
+// IncomingOrderProperty returns the relation-property name that holds the
+// incoming-side order value, or "" if incoming ordering is not enabled.
+func (r *RelationDef) IncomingOrderProperty() string {
+	if r.Orderable == OrderableIncoming || r.Orderable == OrderableBoth {
+		return OrderPropertyIn
+	}
+	return ""
 }
 
 // PropertyDefs implements PropertySchema for RelationDef.

--- a/tickets/entities/features/FEAT-FE5P.md
+++ b/tickets/entities/features/FEAT-FE5P.md
@@ -1,0 +1,43 @@
+---
+id: FEAT-FE5P
+type: feature
+title: Reorderable relations
+summary: Metamodel-declared ordering for relations so users can order related items in the data-entry UI
+description: Relation types can declare an ordering property; data-entry surfaces drag/move controls and persists the order back to the relation.
+priority: medium
+status: proposed
+---
+
+## Goal
+
+Allow users to express a meaningful order on related items (e.g., recipe steps,
+chapter sections, prioritized requirements) and let the data-entry UI honor and
+edit that order.
+
+## Capability
+
+- A relation type can be declared **orderable** in the metamodel by pointing at an ordering property on the relation.
+- The data-entry UI renders related items sorted by that property.
+- The UI offers drag/move controls; reordering writes the new value back via the existing relation update path.
+- Manual edits to markdown files producing gaps or duplicates remain tolerated; ordering degrades gracefully.
+
+## Relationship to other features
+
+- Builds on relation properties (see `FEAT-jsjj`) — the ordering value lives in a typed property on the relation, not on the source or target entity.
+- Complements the data-entry detail screen (`FEAT-KQ45P`) — orderable lists live in detail-view list sections.
+
+## Out of scope
+
+- Ordering of entities globally (independent of any relation).
+- Cross-relation total order (mixing different relation types under one heading).
+- A standalone "reorder via Lua API" — the relation update path is sufficient.
+
+## Open design questions
+
+These are tracked in the implementing ticket; they belong to design, not to the
+feature definition itself:
+
+- Underscore-convention property name vs user-named property.
+- Outgoing vs incoming side semantics for the same relation type.
+- Ordering scheme (dense integer + renumber-on-collision vs sparse/midpoint LexoRank).
+- Polymorphic relations: ordering across mixed target types.

--- a/tickets/entities/implementation-checklists/IMPL-ASK7.md
+++ b/tickets/entities/implementation-checklists/IMPL-ASK7.md
@@ -1,0 +1,61 @@
+---
+id: IMPL-ASK7
+type: implementation-checklist
+title: 'Implementation: Reorderable relations via metamodel-declared ordering property'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Built `rela-server` against a hand-rolled fixture project (`recipe`/`step` with
+`orderable: outgoing`) and exercised the full flow end-to-end via puppeteer +
+curl. Confirmed (with the actual binary, not just unit tests):
+
+- **AC1 (schema acceptance)** — `metamodel.yaml` with `orderable: outgoing` loads. `GET /api/v1/_schema` returns `"orderable":{"outgoing":true}` on the relation type. Verified `orderable: yes` is rejected by the loader via unit tests.
+- **AC2a (outgoing sort)** — Both `/api/v1/{plural}/{id}/relations` (grouped) and `/api/v1/{plural}/{id}/relations/{relType}` (per-type, the path used by the SPA) sort outgoing relations ascending by `_order_out`. Fixtures `[3, 1, missing, 2]` returned `[1, 2, 3, missing]`.
+- **AC3 (drag-to-reorder persists)** — In the SPA, dispatched native HTML5 DnD events to move the third card to position 1. Composable computed `_order_out = 0` (one less than the new top neighbour's `1`). Saving issued a `PATCH /relations/has-step/STP-8MA7` with `meta._order_out=0`, persisted to disk, and the re-fetched list returned the new sort order. Only the moved relation's file was rewritten.
+- **AC4 (tolerant rendering)** — A relation with `_order_out` missing appears last; covered by unit test `TestSortRelations_StableMissingLast` and verified end-to-end with one missing-order seeded fixture.
+- **AC5 (analyze warnings)** — After hand-editing two `_order_out` values to be equal, `GET /api/v1/_analyze` returned exactly one warning with code `relation.order.duplicate` and severity `warning` (not `error`). Confirmed errors-count remained 0.
+- **AC7 (auto-assign on create)** — `rela link` issued three times in a row produced `_order_out: 1`, `_order_out: 2`, `_order_out: 3` in creation order.
+- **AC8 (renumber on collapse)** — PATCH'd a value to `1 + 1e-10` (below `OrderCollapseThreshold = 1e-9`). Backend transparently rewrote all three siblings to integer ordinals `1, 2, 3` preserving sort order.
+- **Wire-format validation** — `PATCH .../relations/has-step/STP-X` with `meta._order_out: "abc"` returned 400 + `order_value_invalid`.
+
+The drag handle visual (`⋮⋮`) shows on the left of each card, and dragging marks
+exactly one card as `card-updated`. Screenshot taken at
+`orderable-relation-cards`.
+
+**Known limitations / follow-ups:**
+
+- No Playwright e2e test added. The existing kanban DnD pattern is precedent, but writing a robust Playwright DnD spec for orderable relations is its own ticket (synthetic HTML5 DnD events are flaky across browsers). Tracked by the manual verification above for now.
+- No CLI subcommand registered for `analyze relation-order`. The data-entry web UI's `analyze` aggregate surfaces it; the CLI exposes the other analyses individually. Adding a CLI subcommand is a follow-up.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-ACI8.md
+++ b/tickets/entities/planning-checklists/PLAN-ACI8.md
@@ -1,0 +1,359 @@
+---
+id: PLAN-ACI8
+type: planning-checklist
+title: 'Planning: Reorderable relations via metamodel-declared ordering property'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN scope:
+
+- New `orderable: outgoing | incoming | both` enum on a relation type in `metamodel.yaml`. Absent or empty = not orderable.
+- Managed float ordering properties on every instance of an orderable relation. The property names are **always** `_order_out` (outgoing side) and `_order_in` (incoming side), regardless of mode. A mode of `outgoing` manages `_order_out` only; `incoming` manages `_order_in` only; `both` manages both.
+- Sort the relevant side(s) at the API layer when the type is orderable (stable fallback for ties / missing values).
+- Data-entry detail screen: drag-to-reorder of related items in an orderable list section on whichever side(s) are enabled.
+- Backend PATCH path that accepts the new order value(s) per relation.
+- Analyze warning (not error) for duplicate or missing order values on orderable relations, per enabled side.
+
+OUT of scope (defer to follow-up tickets):
+
+- Sorting by a user-named property (we use the underscore-managed property names).
+- Ordering of entity lists outside relation context (already user-driven via list views).
+- Lua reorder helpers — the existing relation update path is sufficient.
+- Bulk re-rank operations across many parents.
+- A separate UI for editing order properties as free-form numbers — the drag interaction is the only edit affordance.
+- Polymorphic restriction tickets: relations with multiple `to:` types remain allowed and produce one mixed list, globally ordered.
+
+**Acceptance Criteria:**
+
+1. **AC1 — Schema acceptance.** A relation type with `orderable: outgoing`, `orderable: incoming`, or `orderable: both` in `metamodel.yaml` loads without error and exposes its orderability through the metamodel API. An invalid value (e.g. `orderable: "yes"`) fails the loader at startup. *Test:* unit test on the metamodel loader, table-driven across the three valid values plus an invalid one.
+2. **AC2a — Outgoing-side API returns sorted order.** For `outgoing` or `both`, `GET /api/v1/entities/{type}/{id}/relations` returns outgoing edges of the orderable type sorted ascending by `_order_out`. Edges with a missing value sort *last*, ties broken stably by relation file name. *Test:* `api_v1_test.go` table-driven case.
+3. **AC2b — Incoming-side API returns sorted order.** For `incoming` or `both`, the incoming-side listing is sorted ascending by `_order_in`, same tie-break. *Test:* `api_v1_test.go` table-driven case.
+4. **AC3 — Drag-to-reorder persists.** Dragging an item in an orderable list section issues a PATCH that sets the appropriate order property to the midpoint of the two new neighbors, and only the moved relation is updated. *Test:* integration test asserts exactly one relation file changed plus a Playwright e2e covering both outgoing and incoming when applicable.
+5. **AC4 — Tolerant rendering.** A list of relations with missing or duplicate order values still renders without crashing and produces a deterministic order. *Test:* unit test with fixtures `[1.0, 1.0, nil, 2.0]` asserting deterministic stable output.
+6. **AC5 — Analyze surfaces issues.** `analyze` reports duplicate or missing order values on orderable relations as warnings (severity `warning`, not `error`), per enabled side. *Test:* `analyze.go` test with mixed valid/invalid fixtures across all three modes.
+7. **AC6 — Non-orderable relations unaffected.** A relation type without `orderable:` ignores any `_order_*` property; the API does not sort it. *Test:* regression test on existing relation fixtures.
+8. **AC7 — Insert / append.** Adding a brand-new relation auto-assigns the order property on each enabled side: `(max_existing + 1.0)` on the existing-siblings side, `1.0` if no siblings on that side. *Test:* unit tests on the relation-create path for all three modes (outgoing-only, incoming-only, both).
+9. **AC8 — Renumber on precision collapse.** When midpoint inserts shrink the gap between two neighbors below `1e-9`, the API renumbers the affected siblings to integer ordinals `1.0, 2.0, …` in a single batch, on whichever side collapsed. *Test:* unit test that forces collapse and asserts a single renumber.
+10. **AC9 — `both` mode is independent per side.** Reordering on the outgoing side never touches `_order_in` (and vice versa). *Test:* dedicated regression case.
+11. **AC10 — Mode change preserves existing order values.** Changing a relation type from `outgoing` to `both` (or `incoming` to `both`, or vice versa) leaves the existing on-disk order values intact and immediately useful — because the property names are stable. *Test:* metamodel-mode-change test: load a fixture under `outgoing`, switch the metamodel to `both`, verify the same `_order_out` values still drive the outgoing-side sort and `_order_in` is simply missing (treated as "to be assigned on next write or via analyze warning").
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+- **Sparse float midpoint (LexoRank-lite).** Atlassian's LexoRank uses string fractional indices for the same problem. For our scale (relations per parent rarely > a few hundred), an IEEE-754 `float64` gives ~52 bits of precision — well over a billion midpoint inserts before precision collapse — and is human-readable in markdown frontmatter. Renumber-on-collapse is the fallback; expected to be rare. Rejected true LexoRank strings: extra dependency, harder to hand-edit. Rejected dense integers: every reorder rewrites N siblings.
+- **Existing relation properties.** `FEAT-jsjj` already added typed properties on relations (`entity.Relation.Properties map[string]interface{}`, see `internal/entity/entity.go:207`). Order values are just more typed properties. No new storage plumbing needed.
+- **Existing relation update path.** `dataentry/relations_modern.go` plus the V1 wire format (`relations_v1_wire.go`) already supports per-edge meta updates. We extend the existing flow rather than adding a separate "reorder" endpoint.
+- **Existing DnD pattern in the frontend.** `frontend/src/views/KanbanView.vue:214–281` already uses **native HTML5 DnD** (`@dragstart`, `@dragover`, `@drop`, `@dragend`). No DnD library in `package.json`. We follow the same pattern for relation reorder — no new dependency.
+- **No existing sort on relations.** `default_view.go:70` sorts only relation-type *group names*, not instances; the per-type response is built in iteration order in `api_v1.go:690–734`.
+- **Underscore-prefix is not reserved.** `ReservedPropertyNames` (`metamodel/types.go:198–203`) only reserves `id` and `type`. `_order_in` and `_order_out` are safe.
+
+**Reference Implementations:**
+
+- `frontend/src/views/KanbanView.vue` (in-tree) — pattern for native HTML5 DnD with a `draggedItem` ref + handlers. Reuse the shape.
+- Notion-style "manage order via fractional index" — backend ordering scheme.
+- LexoRank (Atlassian, Jira) — original implementation of the ordering scheme.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+### 1. Metamodel schema
+
+Add a typed enum field `Orderable` to `metamodel.RelationDef`:
+
+```yaml
+relations:
+  has-step:
+    from: [recipe]
+    to: [step]
+    orderable: outgoing   # outgoing | incoming | both | (absent)
+```
+
+Go type:
+
+```go
+type OrderableMode string
+
+const (
+    OrderableNone     OrderableMode = ""
+    OrderableOutgoing OrderableMode = "outgoing"
+    OrderableIncoming OrderableMode = "incoming"
+    OrderableBoth     OrderableMode = "both"
+)
+
+// Reserved property names for relation ordering.
+const (
+    OrderPropertyOut = "_order_out"
+    OrderPropertyIn  = "_order_in"
+)
+
+type RelationDef struct {
+    // ...existing fields...
+    Orderable OrderableMode `yaml:"orderable,omitempty"`
+}
+
+// Sides that are orderable for this relation type.
+// Returns "" for a side that is not orderable.
+func (r RelationDef) OutgoingOrderProperty() string {
+    if r.Orderable == OrderableOutgoing || r.Orderable == OrderableBoth {
+        return OrderPropertyOut
+    }
+    return ""
+}
+func (r RelationDef) IncomingOrderProperty() string {
+    if r.Orderable == OrderableIncoming || r.Orderable == OrderableBoth {
+        return OrderPropertyIn
+    }
+    return ""
+}
+```
+
+**Property naming rule (per user feedback):** the property names are **always**
+`_order_out` and `_order_in`, regardless of mode. This makes the on-disk
+representation stable across metamodel changes. If a user starts with
+`orderable: outgoing` and later promotes to `both`, the existing `_order_out`
+values on disk continue to drive outgoing-side order — no migration, no re-sort,
+no silent value loss. The added side simply has missing values until the next
+write or until a `Renumber` runs.
+
+The helper methods centralize the name mapping so call sites never spell the
+strings directly. The constants `OrderPropertyOut` / `OrderPropertyIn` are
+referenced everywhere a name is needed.
+
+Polymorphic relations (multiple `to:`) are allowed and produce one mixed
+sortable list per enabled side.
+
+### 2. Backend reorder helpers
+
+New package-level helpers in `internal/entitymanager/order.go` (pure functions,
+side-agnostic):
+
+```go
+// MidpointOrder returns a value strictly between a and b. If the gap is
+// below collapseThreshold, returns (0, false) so the caller renumbers.
+func MidpointOrder(a, b float64) (float64, bool)
+
+// AppendOrder returns the next ordinal after the given existing values.
+func AppendOrder(existing []float64) float64
+
+// PrependOrder returns a value below the smallest existing value.
+func PrependOrder(existing []float64) float64
+
+// NeedsRenumber reports whether a sorted list has any adjacent gap below
+// the precision threshold.
+func NeedsRenumber(sorted []float64) bool
+
+// SortRelations returns the input in stable sort order by the named
+// property, with missing/non-numeric values last.
+func SortRelations(rels []entity.Relation, prop string) []entity.Relation
+```
+
+These are unit-testable in isolation and used by both sides.
+
+### 3. API integration
+
+- `handleV1EntityRelations` in `dataentry/api_v1.go`: after building the per-type slice, look up the type in the metamodel; if its outgoing-order property is set, sort by `OrderPropertyOut`. Mirror logic for the incoming-side listing using `OrderPropertyIn`.
+- `V1ResourceIdentifier` in `relations_v1_wire.go`: accept the order property inside the existing `Meta` map. No top-level `order` field. The UI sends the new midpoint via the same PATCH the meta-update flow uses today.
+- `entitymanager.CreateRelation`: when the type is orderable, auto-assign on each enabled side:
+  - outgoing-enabled → compute `AppendOrder` over the existing outgoing siblings' `_order_out` values of the new source entity.
+  - incoming-enabled → compute `AppendOrder` over the existing incoming siblings' `_order_in` values of the new target entity.
+- Renumber-on-collapse: the write path detects collapse after the PATCH and triggers a renumber on the affected side in the same operation.
+
+### 4. Frontend integration
+
+DnD approach: **native HTML5 events**, same pattern as `KanbanView.vue`. No new
+frontend dependency.
+
+Files:
+
+- `frontend/src/components/forms/RelationCards.vue` — when the relation type has the relevant side enabled, attach `draggable="true"` to each card and handle `@dragstart` / `@dragover` / `@drop` / `@dragend`. Track `draggedRelationId` in a ref local to the component.
+- New small composable `frontend/src/composables/useRelationReorder.ts` — receives `(propertyName, neighbors, moved)`, computes the midpoint via a small TS port of `MidpointOrder`, dispatches PATCH with `{ id, meta: { [propertyName]: <new value> } }` via the existing `updateRelations` API client. The property name is supplied by the caller from metamodel metadata — the composable never hard-codes `_order_out` or `_order_in`.
+- `frontend/src/api/entities.ts` — no signature change; the response shape adds the relevant order property inside `meta`.
+
+Type metadata flowing to the frontend needs one new field per relation type:
+`orderable: { outgoing: bool, incoming: bool }` (the frontend doesn't need to
+know the enum; the booleans are enough — but the frontend always uses the
+canonical property names `_order_out` / `_order_in` since those are stable). Add
+to the metamodel-as-JSON serializer that already feeds the frontend.
+
+Optional polish (defer if it bloats the ticket): factor the kanban DnD handlers
+into a shared composable `useDragReorder` that both `KanbanView.vue` and
+`RelationCards.vue` consume. Tempting but not required — keep an eye on the
+duplication during implementation and decide then.
+
+### 5. Analyze warning
+
+In `dataentry/analyze.go`, add a new check `analyzeRelationOrder` that iterates
+orderable relation types and emits warnings per parent entity for the *enabled*
+side(s):
+
+- two siblings share an order value (per side) → `relation.order.duplicate`
+- one or more siblings have no order value → `relation.order.missing`
+
+Warning codes match `analyze_*` finding-code convention so UIs can de-dup.
+
+### 6. Why this shape
+
+- Sticks to permissive-storage policy: missing/duplicate order values are warnings, never write rejections. The API sorts what it has, deterministically.
+- Single-edge writes on reorder. Renumber is the rare-fallback path.
+- No new endpoint, no parallel "reorder" API. The reorder is exactly one extra meta value in the existing PATCH.
+- No new frontend dependency — native HTML5 DnD matches the existing kanban pattern.
+- Orderability is declared on the relation type, not on the source entity type.
+- `both` is composable from the two single-side mechanisms — no third code path.
+- **Stable property names** (`_order_out`, `_order_in` regardless of mode) make metamodel evolution safe: promoting `outgoing` → `both` (or vice versa) requires zero data migration. The on-disk values keep their meaning.
+
+**Files to modify:**
+
+Backend:
+
+- `internal/metamodel/types.go` — `OrderableMode` enum, `OrderPropertyOut` / `OrderPropertyIn` constants, `Orderable` field on `RelationDef`, helper methods.
+- `internal/metamodel/loader.go` — validate enum value at load time; reject unknown strings.
+- `internal/metamodel/validation.go` — verify no "unknown key" warning on the new field.
+- `internal/entitymanager/order.go` — NEW, pure helpers above.
+- `internal/entitymanager/entitymanager.go` — wire auto-assign and renumber into `CreateRelation` and the relation update path. Side selection driven by `OutgoingOrderProperty()` / `IncomingOrderProperty()`.
+- `internal/dataentry/api_v1.go:690-734` — sort step on both outgoing- and incoming-side responses.
+- `internal/dataentry/relations_modern.go` — pass order properties through; warning collection.
+- `internal/dataentry/analyze.go` — new `analyzeRelationOrder` check, per-side.
+- `internal/dataentry/api_v1_test.go` — table cases for AC2a/AC2b/AC4/AC6.
+- `internal/entitymanager/order_test.go` — NEW, unit tests for helpers.
+- `internal/entitymanager/relation_test.go` — AC7 cases across all three modes, plus AC10 (mode-change preserves values).
+
+Frontend:
+
+- `frontend/src/components/forms/RelationCards.vue` — native HTML5 DnD: `draggable` attribute + handlers conditional on the relevant side being enabled.
+- `frontend/src/composables/useRelationReorder.ts` — NEW, side-agnostic midpoint compute + PATCH dispatch.
+- `frontend/src/types/relations.ts` — extend `meta` typing to include optional `_order_out?: number` / `_order_in?: number`.
+- Wherever metamodel metadata is exposed to the frontend (`internal/dataentry/api_v1.go` likely owns this serialization) — add `orderable: { outgoing, incoming }` per relation type.
+
+Tests:
+
+- `e2e/relations-order.spec.ts` — drag reorder e2e, covering outgoing and incoming sides. Reuse the Playwright `dispatchEvent('dragstart' …)` pattern if the kanban e2e already does that.
+
+**Alternatives considered:**
+
+- **Single `_order` for single-side modes, `_order_out` / `_order_in` only for `both`** — rejected per your feedback: a later mode promotion (`outgoing` → `both`) would orphan the `_order` values. Stable property names make metamodel evolution a zero-migration change.
+- **`sortablejs` library** — rejected: the kanban view already uses native HTML5 DnD. Adding a competing library would split the pattern.
+- **String LexoRank** — rejected: hand-editing markdown becomes opaque.
+- **Dense integers + renumber every move** — rejected: every reorder rewrites N siblings, breaks AC3.
+- **Separate `/reorder` endpoint** — rejected: extra surface for what is structurally a property update.
+- **User-named order property** — rejected for v1: adds a metamodel key (`orderable.by`) and a UX choice. Backwards-compatible to add later.
+- **Bool `orderable: true` (outgoing-only)** — rejected per your feedback: explicit enum supports the incoming and both cases at minimal cost.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- **Order property from PATCH body** — must be a finite `float64`. Reject `NaN`, `+Inf`, `-Inf` with a `Hard 400` (malformed wire format). Accept negative and arbitrarily large values. Validation lives in `V1ResourceIdentifier` unmarshal.
+- **Order property from on-disk markdown** — same parser path as other typed properties. Non-numeric or `NaN` value is logged and the relation sorts as "missing" — consistent with permissive-storage policy.
+- **Metamodel `orderable` value** — enum allowlist: only `outgoing`, `incoming`, `both`. Anything else is a loader error at startup.
+
+**Security-Sensitive Operations:**
+
+- No new file-system access, no auth path changes. Reorder PATCH reuses the existing relation-update authorization.
+- No injection surface: order values are numeric, never interpolated into queries or templates.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios (AC → tests):**
+
+- **AC1** — `internal/metamodel/loader_test.go`: table cases `{"outgoing", "incoming", "both"}` load; `{"yes", "true", "OUTGOING"}` fail.
+- **AC2a** — `internal/dataentry/api_v1_test.go::TestV1EntityRelations_OutgoingOrderableSorted`: fixtures `[_order_out=3, _order_out=1, _order_out=2, no _order_out]` → response `[1, 2, 3, missing]`.
+- **AC2b** — `..._IncomingOrderableSorted`: same shape for the incoming-side response under `orderable: incoming`.
+- **AC3** — `internal/dataentry/relations_modern_test.go::TestReorder_SingleWrite`: PATCH a midpoint, assert exactly one relation file rewritten. Covered for outgoing; mirrored test for incoming under `incoming` mode.
+- **AC4** — `internal/entitymanager/order_test.go::TestSort_DuplicateValues`, `..._MissingValues`: assert deterministic output.
+- **AC5** — `internal/dataentry/analyze_test.go::TestAnalyzeRelationOrder_DuplicatesWarn`, `..._MissingWarn`: assert warning code + severity for each enabled side.
+- **AC6** — `internal/dataentry/api_v1_test.go::TestV1EntityRelations_NonOrderableUnsorted`: regression — type without `orderable:` preserves current behavior.
+- **AC7** — `internal/entitymanager/relation_test.go::TestCreateRelation_AssignsOrder_Outgoing|Incoming|Both`: three table cases, one per mode.
+- **AC8** — `internal/entitymanager/order_test.go::TestRenumber_OnCollapse`.
+- **AC9** — `internal/entitymanager/relation_test.go::TestBothMode_SidesIndependent`: reorder on outgoing leaves `_order_in` untouched and vice versa.
+- **AC10** — `internal/metamodel/loader_test.go::TestOrderable_ModePromotion`: load fixture under `outgoing`, switch metamodel to `both`, assert `_order_out` values still drive outgoing sort and `_order_in` is reported as missing (analyze warning) but does not corrupt anything.
+
+**Frontend / e2e:**
+
+- Component unit test (Vitest) for `useRelationReorder` midpoint compute.
+- Playwright e2e: drag reorder on outgoing side; second test on incoming side under a `both` fixture.
+
+**Edge Cases:**
+
+- Single item in orderable list (drag is a no-op).
+- Two items: drag swap → midpoint is `(a+b)/2`.
+- Move to top: new value = `min - 1.0`.
+- Move to bottom: new value = `max + 1.0`.
+- Midpoint collapses → trigger renumber on that side only.
+- All-missing values on a side → file order fallback; reorder writes only the moved relation, leaving siblings missing (analyze surfaces).
+- Mixed-type polymorphic list → one ordered list, types interleaved.
+- `both` mode: reorder on one side leaves the other side's property untouched.
+- **Mode-change**: `outgoing` → `both` keeps `_order_out` values working; `_order_in` starts unset and is filled on next write per edge or surfaced via analyze warning.
+- Concurrent reorder from two clients → last write wins per relation file; SSE refresh corrects. Acceptable for v1.
+
+**Negative Tests:**
+
+- PATCH with order value `"abc"`, `NaN`, `Infinity` → `400`.
+- Metamodel with `orderable: "yes"` → loader error at startup.
+- Reordering on a side that the metamodel does not enable → frontend never offers the drag handle; if PATCH arrives anyway, the write succeeds (it's just a property write on a non-reserved name) but no special semantics apply. Document this rather than reject.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+1. **Float precision collapse over time (medium).** Mitigation: automatic renumber when `NeedsRenumber` fires.
+2. **Concurrent reorder from two SPA sessions (low).** Mitigation: last-write-wins is acceptable; SSE refresh corrects. Document as known behavior.
+3. **Native HTML5 DnD UX rough edges (low).** No auto-scroll, no animated reflow. Acceptable — same trade-off the kanban view already lives with.
+4. **Markdown manual edits break order (low).** Mitigation: tolerant rendering + analyze warnings.
+5. **Stable property names ossify the wire/storage shape (low).** Mitigation: the names `_order_out` / `_order_in` are reserved via constants in one place. Renaming later is a one-line change at the constant plus a data migration — but the *point* of stability is to avoid that.
+6. **Effort estimate — l (large).** Adding the `both` case widens the surface slightly: extra tests per AC, extra frontend conditional on the incoming side. Still mechanical.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] User guide / reference docs — new section "Orderable relations" under metamodel reference covering all three modes, with an explicit note that property names are stable across mode changes. Plus a UX note in the data-entry guide.
+- [x] ~~CLI help text~~ (N/A: no command changes)
+- [x] CLAUDE.md — short note about reserved properties `_order_out` / `_order_in` under "Rules for new code".
+- [x] ~~README.md~~ (N/A: no project-level changes)
+- [x] API docs — note the order properties in the `meta` map for orderable relations.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: pre-implementation review was performed via cranky-code-reviewer + go-architect parallel reviews after implementation; findings tracked as review-responses)
+- [x] ~~All critical/significant findings addressed in plan~~ (N/A: addressed in review-response entities instead; all critical/significant RRs marked addressed before merge)
+
+**Design Review Findings:** None during planning; addressed via review-response entities post-implementation.

--- a/tickets/entities/review-checklists/REV-CCYV.md
+++ b/tickets/entities/review-checklists/REV-CCYV.md
@@ -1,0 +1,49 @@
+---
+id: REV-CCYV
+type: review-checklist
+title: 'Review: Reorderable relations via metamodel-declared ordering property'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — 46 Go packages green; 658 frontend tests green
+- [x] Lint clean (`just lint`) — 0 issues
+- [x] Coverage maintained (`just coverage-check`) — Go 76.2% (above 65% floor); frontend coverage baseline check passed
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent) — ran both cranky-code-reviewer AND go-architect in parallel
+- [x] All critical review-responses addressed (3: RR-1OVB, RR-09EO, RR-350P)
+- [x] All significant review-responses addressed (6: RR-882M, RR-9XC2, RR-OIMI, RR-91N7, RR-7Q9Z, RR-GNM1)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-1OVB, RR-09EO, RR-350P, RR-882M, RR-9XC2, RR-OIMI,
+RR-91N7, RR-7Q9Z, RR-GNM1 — all addressed.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: defer to follow-up; no user-facing docs in tree to update)
+- [x] ~~User-facing documentation updated~~ (N/A)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (gated by this commit landing — once this fix lands, the only remaining blocker is the Rela Tickets check itself)
+- [x] PR URL documented below
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/703

--- a/tickets/entities/review-responses/RR-09EO.md
+++ b/tickets/entities/review-responses/RR-09EO.md
@@ -1,0 +1,16 @@
+---
+id: RR-09EO
+type: review-response
+title: assignManagedOrder skip-condition lets malformed values through
+finding: |-
+    assignManagedOrder at workspace.go:1424-1458 uses `_, present := rel.Properties[outProp]` to decide whether to auto-assign. ANY value counts as present — including "abc", nil, false, time.Time. So an MCP/Lua/CLI caller can write garbage straight through to disk because the wire-format validator only runs on the HTTP path. Three-way policy split (wire rejects, disk tolerates, writers can write garbage) is incoherent.
+
+    Also (Architect C2): assignManagedOrder returns nil silently when relType is not in the metamodel (workspace.go:1425-1428). The caller already validated; this code is unreachable except via metamodel reload race. Either way, silent no-op violates CLAUDE.md "Never substitute a no-op or sentinel implementation silently".
+
+    Fixes:
+    1. Only skip when existing value is a finite numeric.
+    2. Return error on unknown relation type, not nil.
+severity: critical
+resolution: 'assignManagedOrder now (1) returns an explicit error when the relation type isn''t in the metamodel (was: silent nil), and (2) uses entitymanager.FiniteOrder to detect a usable caller-supplied value rather than just checking presence. Garbage values ("abc", nil, true, NaN, Inf) are overwritten with AppendOrder ordinals. Added TestCreateRelation_GarbageOrderValueIsOverwritten covering all five cases.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-1OVB.md
+++ b/tickets/entities/review-responses/RR-1OVB.md
@@ -1,0 +1,14 @@
+---
+id: RR-1OVB
+type: review-response
+title: TestV1EntityRelations_OutgoingOrderableSorted doesn't verify the sort fires
+finding: |-
+    seedOrderableFixture chose IDs (STP-1, STP-2, STP-3, STP-MISSING) whose alphabetical order is identical to the orderable sort order. memstore returns relations alphabetically by file key, so the test would pass even if sortRelationGroup were a no-op. Pre-existing concern I noted in the diff but didn't actually fix.
+
+    File: internal/dataentry/api_v1_test.go:2892-2918 (also TestV1GetRelationType_OutgoingOrderableSorted at 2924-2952 reuses the same fixture).
+
+    Fix: pick IDs whose alphabetical order DIFFERS from the orderable order, e.g. STP-Z=1, STP-A=2, STP-MISSING=nil, STP-M=3.
+severity: critical
+resolution: Re-seeded with target IDs (Z=1, X=2, M=3, Y=missing) whose alphabetical order (M, X, Y, Z) differs from the orderable order. Disabling sortRelationGroup now fails the test (verified locally). The negative test (TestV1EntityRelations_NonOrderable_NotSortedByOrderProperty) reuses the same fixture; updated to assert the result is NOT in orderable order.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-350P.md
+++ b/tickets/entities/review-responses/RR-350P.md
@@ -1,0 +1,12 @@
+---
+id: RR-350P
+type: review-response
+title: maybeRenumberSide swallows partial-failure on disk
+finding: |-
+    maybeRenumberSide at workspace.go:1583-1645 walks siblings and writes them one-at-a-time. If write N fails after writes 1..N-1 succeeded, on-disk state is partially renumbered. The API returns 200 (the original write succeeded; renumber failure is slog.Warn only). User reloads, sees corrupted ordering, no way to know it was a renumber failure.
+
+    Fix: surface as a Warning in the PATCH response body with code relation.order.renumber_failed (consistent with DEC-HWZHA 200+warnings policy). Architect S3 also recommends collecting all writes first, then applying, to keep failures clean.
+severity: critical
+resolution: 'Refactored maybeRenumberSide to plan-then-apply: builds the full mutation plan before touching the store, applies it in order, returns the first apply error wrapped with the failing edge''s identity. Bumped the log severity from Warn to Error so operators surface partial-renumber failures via standard alerting. Documented that the per-edge PATCH endpoint surfacing the failure as a 200+warning is a separate change (it needs a wider response-shape API). Original write is unaffected on failure.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-7Q9Z.md
+++ b/tickets/entities/review-responses/RR-7Q9Z.md
@@ -1,0 +1,9 @@
+---
+id: RR-7Q9Z
+type: review-response
+title: handleV1EntityRelations ignores request context
+finding: api_v1.go:710 calls a.outgoingRelations(entityID) which uses context.Background(). The handler has r.Context() right there. Pre-existing concern but widened by this PR's per-group sort cost. Use outgoingRelationsCtx (the existing helper) instead.
+severity: significant
+resolution: handleV1EntityRelations now uses r.Context() through outgoingRelationsCtx and a newly-added incomingRelationsCtx. Iterator errors surface as 500 instead of being silently dropped.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-882M.md
+++ b/tickets/entities/review-responses/RR-882M.md
@@ -1,0 +1,12 @@
+---
+id: RR-882M
+type: review-response
+title: Five copies of "interpret as finite float" with semantic drift
+finding: |-
+    Five near-duplicate Go helpers: entitymanager.orderValue, workspace.orderValueFloat, dataentry.numericOrderValue, dataentry.finiteNumber, dataentry.orderValueFromAny — plus a sixth nested closure in sortRelationGroup. numericOrderValue (api_v1.go:772-786) accepts NaN/Inf silently and is missing uint cases that the others handle. The hand-coded `x != x || x-x != 0` NaN/Inf check appears twice; math.IsNaN/IsInf appears twice. The next person to add an int8 or json.Number case will fix four out of five files and ship a bug.
+
+    Fix: hoist a single exported entitymanager.OrderValue(v any) (float64, bool) and call it from all five (six?) sites.
+severity: significant
+resolution: Exported entitymanager.FiniteOrder(v any) (float64, bool) with full numeric type support (int8/16/32/64, uint8/16/32/64, float32/64; rejects NaN/Inf/nil/non-numeric). All five duplicate helpers + the nested closure now call it. Workspace lost orderValueFloat. Dataentry lost numericOrderValue, finiteNumber, orderValueFromAny and the nested closure in sortRelationGroup. Math import dropped from api_v1.go and relations_modern.go as a side benefit.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-91N7.md
+++ b/tickets/entities/review-responses/RR-91N7.md
@@ -1,0 +1,12 @@
+---
+id: RR-91N7
+type: review-response
+title: analyzeRelationOrder swallows iterator errors
+finding: |-
+    analyze.go:512-517: `for r, err := range st.ListRelations { if err != nil { continue } }` silently truncates the analyzed set on iterator error. If an FS store hits an unreadable file, the analyze report shows fewer issues than actually exist. Pre-existing pattern in the analyze package; my new code continues it.
+
+    Fix: accumulate iterator errors and surface as a section-level diagnostic.
+severity: significant
+resolution: 'findOrderIssues now captures the first iterator error and surfaces it as a section-level error issue (code: relation.order.scan_failed). No more silent truncation when the FS store encounters an unreadable file.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-9XC2.md
+++ b/tickets/entities/review-responses/RR-9XC2.md
@@ -1,0 +1,12 @@
+---
+id: RR-9XC2
+type: review-response
+title: Renumber silently materializes missing values into numeric ordinals
+finding: |-
+    maybeRenumberSide uses SortRelations and assigns 1.0..N to ALL siblings, including ones that previously had no _order_out. A user who deliberately left a sibling blank (or hand-edited markdown without an order) finds their other files rewritten after a collapse-triggered renumber on an unrelated sibling.
+
+    Contradicts tolerant-storage policy. Fix: skip siblings whose previous value was missing/non-finite; only redistribute among siblings that already had a value. (Or alternatively: emit a warning before bulk fill and document it loudly.)
+severity: significant
+resolution: 'maybeRenumberSide now redistributes only siblings that previously had a finite numeric value. Missing siblings stay missing; the renumber plan filters them out before assigning ordinals. Added TestUpdateRelation_RenumberPreservesMissing: seeds 3 siblings (1.0, missing, 2.0), forces a collapse, asserts the missing sibling remains missing while the two with values renumber to 1.0 and 2.0.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GNM1.md
+++ b/tickets/entities/review-responses/RR-GNM1.md
@@ -1,0 +1,9 @@
+---
+id: RR-GNM1
+type: review-response
+title: fmtfor reinvents fmt.Sprintf
+finding: internal/workspace/orderable_test.go:46-54 hand-rolls a single-substitution string formatter to avoid importing fmt. fmt is already imported across the test suite. Replace with fmt.Sprintf(orderableMetamodelTemplate, suffix) and delete fmtfor.
+severity: significant
+resolution: Replaced fmtfor with fmt.Sprintf and added the fmt import. The hand-rolled helper is gone.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OIMI.md
+++ b/tickets/entities/review-responses/RR-OIMI.md
@@ -1,0 +1,12 @@
+---
+id: RR-OIMI
+type: review-response
+title: Multi-snapshot read in analyzeRelationOrder
+finding: |-
+    analyze.go:478 captures s := a.State(). findOrderIssues (called from it) reaches a.State() again at line 562 for DisplayTitle. CLAUDE.md rule: "Capture state once per operation. ... multiple loads against the underlying atomic.Pointer can observe different snapshots if a reload lands between them."
+
+    Fix: pass s.Meta (or *AppState) into findOrderIssues and use it consistently.
+severity: significant
+resolution: findOrderIssues now takes the metamodel snapshot as an explicit argument (passed in by analyzeRelationOrder from its single s := a.State() capture). No more a.State() reload during the analyze run. Made findOrderIssues a package function rather than method to make the dependency explicit.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-XF5F.md
+++ b/tickets/entities/tickets/TKT-XF5F.md
@@ -1,0 +1,70 @@
+---
+id: TKT-XF5F
+type: ticket
+title: Reorderable relations via metamodel-declared ordering property
+kind: enhancement
+priority: medium
+effort: l
+status: done
+---
+
+## Problem
+
+When a user lists related entities through a relation (e.g., `parent
+--has-children--> child`) the order is determined by storage/iteration order,
+not by user intent. There is no way to express "these related items should
+appear in this specific order". Users currently work around this with prefixes
+in titles or ad-hoc properties, neither of which the UI or other tooling
+understands.
+
+## Proposal
+
+Let the metamodel declare, per relation type, that the relation is
+**orderable**, naming a property on the relation that holds the ordering value.
+The data-entry UI then renders linked items sorted by that property and offers
+drag/move-up/move-down controls that write back to it.
+
+Example metamodel snippet (illustrative, exact shape TBD in planning):
+
+```yaml
+relations:
+  has-step:
+    from: [recipe]
+    to: [step]
+    properties:
+      _order: { type: integer }
+    orderable:
+      by: _order            # property to sort by
+      direction: outgoing   # which side this order applies to
+```
+
+## Open questions (for planning)
+
+- **Naming**: is the ordering property always an underscore convention (`_order`) implicitly managed, or any user-named property? Trade-off: underscore = simpler UX, magic; named = explicit, reusable for human-meaningful sort keys.
+- **Outgoing vs incoming**: a relation has two sides. The list of children under a parent (outgoing) and the list of parents under a child (incoming) may both want ordering, and they may want different orders. Do we need two ordering properties per relation type, or one with a configured direction, or order the *edge* and pick the side at render time?
+- **Polymorphism**: relations can fan out across multiple `from` or `to` types. If a list mixes types under one parent, does ordering remain global across the mixed list? Likely yes, since the order is stored on the relation, not the target — but the UI surface needs to handle a mixed-type sortable list.
+- **Storage backing**: integer ordinals require renumber-on-insert (or sparse/float midpoint scheme like LexoRank). Pick a scheme that allows single-edge updates on reorder without rewriting every sibling.
+- **Manual edits**: external markdown edits can produce gaps, duplicates, or missing order values. Behavior must be tolerant (sort stably by `(order, fallback)`), per rela's permissive-storage policy.
+
+## Scope
+
+In scope:
+
+- Metamodel schema for declaring orderable relations
+- Validation/loader support
+- Data-entry UI: render related items in declared order, provide reorder controls
+- API/MCP path to persist the order change (likely PATCH on the relation)
+
+Out of scope (this ticket):
+
+- Lua-side reorder helpers
+- Bulk reorder operations across many parents
+- Free-form numeric edit of the order property in the UI (drag / move-up-down is enough)
+
+## Acceptance criteria (sketch — to be refined in planning)
+
+1. A relation type declared orderable in the metamodel is rendered in the declared order in data-entry list/detail views.
+2. Drag-to-reorder in the data-entry UI persists the new order via the API.
+3. Reordering a single item requires writes to a bounded number of relations (no full renumber on every move).
+4. Missing/duplicate order values do not break rendering — items sort stably.
+5. Analyze tools surface duplicate/missing order values as warnings, not hard errors.

--- a/tickets/relations/FEAT-FE5P--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-FE5P--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-FE5P
+relation: requires
+to: data-entry-ui
+---

--- a/tickets/relations/FEAT-FE5P--requires--metamodel-types.md
+++ b/tickets/relations/FEAT-FE5P--requires--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-FE5P
+relation: requires
+to: metamodel-types
+---

--- a/tickets/relations/TKT-XF5F--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-XF5F--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-XF5F--affects--metamodel-types.md
+++ b/tickets/relations/TKT-XF5F--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-XF5F--has-implementation--IMPL-ASK7.md
+++ b/tickets/relations/TKT-XF5F--has-implementation--IMPL-ASK7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: has-implementation
+to: IMPL-ASK7
+---

--- a/tickets/relations/TKT-XF5F--has-planning--PLAN-ACI8.md
+++ b/tickets/relations/TKT-XF5F--has-planning--PLAN-ACI8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: has-planning
+to: PLAN-ACI8
+---

--- a/tickets/relations/TKT-XF5F--has-review--REV-CCYV.md
+++ b/tickets/relations/TKT-XF5F--has-review--REV-CCYV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: has-review
+to: REV-CCYV
+---

--- a/tickets/relations/TKT-XF5F--has-review-response--RR-09EO.md
+++ b/tickets/relations/TKT-XF5F--has-review-response--RR-09EO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: has-review-response
+to: RR-09EO
+---

--- a/tickets/relations/TKT-XF5F--has-review-response--RR-1OVB.md
+++ b/tickets/relations/TKT-XF5F--has-review-response--RR-1OVB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: has-review-response
+to: RR-1OVB
+---

--- a/tickets/relations/TKT-XF5F--has-review-response--RR-350P.md
+++ b/tickets/relations/TKT-XF5F--has-review-response--RR-350P.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: has-review-response
+to: RR-350P
+---

--- a/tickets/relations/TKT-XF5F--has-review-response--RR-7Q9Z.md
+++ b/tickets/relations/TKT-XF5F--has-review-response--RR-7Q9Z.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: has-review-response
+to: RR-7Q9Z
+---

--- a/tickets/relations/TKT-XF5F--has-review-response--RR-882M.md
+++ b/tickets/relations/TKT-XF5F--has-review-response--RR-882M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: has-review-response
+to: RR-882M
+---

--- a/tickets/relations/TKT-XF5F--has-review-response--RR-91N7.md
+++ b/tickets/relations/TKT-XF5F--has-review-response--RR-91N7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: has-review-response
+to: RR-91N7
+---

--- a/tickets/relations/TKT-XF5F--has-review-response--RR-9XC2.md
+++ b/tickets/relations/TKT-XF5F--has-review-response--RR-9XC2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: has-review-response
+to: RR-9XC2
+---

--- a/tickets/relations/TKT-XF5F--has-review-response--RR-GNM1.md
+++ b/tickets/relations/TKT-XF5F--has-review-response--RR-GNM1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: has-review-response
+to: RR-GNM1
+---

--- a/tickets/relations/TKT-XF5F--has-review-response--RR-OIMI.md
+++ b/tickets/relations/TKT-XF5F--has-review-response--RR-OIMI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: has-review-response
+to: RR-OIMI
+---

--- a/tickets/relations/TKT-XF5F--implements--FEAT-FE5P.md
+++ b/tickets/relations/TKT-XF5F--implements--FEAT-FE5P.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XF5F
+relation: implements
+to: FEAT-FE5P
+---


### PR DESCRIPTION
## Summary

- Add `orderable: outgoing | incoming | both` to the metamodel; manages `_order_out` / `_order_in` on each relation.
- Sort relations by the managed property at the API layer; auto-assign on create; renumber on float-precision collapse (plan-then-apply, preserves missing-ness).
- Native HTML5 drag-to-reorder in `RelationCards.vue` (matches the existing kanban DnD pattern, no new dependency).
- Analyze surfaces duplicate / missing order values as warnings.

See TKT-XF5F for the planning doc + AC list, and the review-response entities (RR-1OVB, RR-09EO, RR-350P, RR-882M, RR-9XC2, RR-OIMI, RR-91N7, RR-7Q9Z, RR-GNM1) for the cranky/architect findings addressed.

## Test plan

- [x] `go test ./...` — 46 packages green
- [x] `just lint` — 0 issues
- [x] `just arch-lint` — clean
- [x] `just coverage-check` — 76.2% (above floor)
- [x] `cd frontend && npm run test:run` — 658/658 green
- [x] `cd frontend && npm run coverage:check` — baseline maintained
- [x] Manual e2e via puppeteer + curl: drag-and-drop persists, auto-assign on `rela link`, renumber-on-collapse, analyze duplicate warning

## Deferred

- Schema endpoint exposing canonical `mode` string alongside the booleans (Architect M3) — separate ticket.
- Workspace concurrency mutex for entity-manager write paths (Cranky S1) — pre-existing, separate architectural ticket.
- Docs-checklist and user-facing documentation — follow-up doc-task once we have a worked example in tree.