### PR TITLE
feat(metamodel): reject inverse-name collisions and canonical shadowing (TKT-4VLN)

### DIFF
--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -595,6 +595,49 @@ API's `GET /api/v1/{plural}/{id}/relations` response, and it's what surfaces in 
 modal's "Incoming relations" section. See [data-entry.md → Reverse Relations](data-entry.md#reverse-incoming-relations)
 for how form widgets and list columns opt into reverse direction with `direction: incoming`.
 
+#### Inverse name uniqueness
+
+Inverse names must be globally unique across the metamodel. Two failure modes
+are rejected at load time:
+
+- **`inverse_name_collision`** — two relations declare the same `inverse:` ID.
+  rela cannot tell which canonical relation an inverse-keyed lookup refers to,
+  so this is treated as a structural error. Example:
+
+  ```yaml
+  relations:
+    blocks:
+      inverse: blockedBy
+    prevents:
+      inverse: blockedBy   # rejected: collides with `blocks`
+  ```
+
+- **`inverse_shadows_canonical`** — a relation declares `inverse: X` where `X`
+  is also the name of a separate canonical relation. The metamodel author
+  most likely didn't mean for `X` to refer to two different relation sets at
+  once. Example:
+
+  ```yaml
+  relations:
+    r1:
+      inverse: r2
+    r2:                    # rejected: shadows the inverse of `r1`
+      from: [...]
+      to: [...]
+  ```
+
+**Exception:** symmetric relations are allowed to be their own inverse:
+
+```yaml
+relations:
+  related-to:
+    symmetric: true
+    inverse: related-to    # OK — symmetric self-inverse
+```
+
+Use the symmetric form when the relation has no preferred direction (e.g. "is
+related to" reads the same from either side).
+
 ### Cardinality Constraints
 
 Use cardinality to enforce rules:

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -589,6 +589,49 @@ API's `GET /api/v1/{plural}/{id}/relations` response, and it's what surfaces in 
 modal's "Incoming relations" section. See [data-entry.md → Reverse Relations](data-entry.md#reverse-incoming-relations)
 for how form widgets and list columns opt into reverse direction with `direction: incoming`.
 
+#### Inverse name uniqueness
+
+Inverse names must be globally unique across the metamodel. Two failure modes
+are rejected at load time:
+
+- **`inverse_name_collision`** — two relations declare the same `inverse:` ID.
+  rela cannot tell which canonical relation an inverse-keyed lookup refers to,
+  so this is treated as a structural error. Example:
+
+  ```yaml
+  relations:
+    blocks:
+      inverse: blockedBy
+    prevents:
+      inverse: blockedBy   # rejected: collides with `blocks`
+  ```
+
+- **`inverse_shadows_canonical`** — a relation declares `inverse: X` where `X`
+  is also the name of a separate canonical relation. The metamodel author
+  most likely didn't mean for `X` to refer to two different relation sets at
+  once. Example:
+
+  ```yaml
+  relations:
+    r1:
+      inverse: r2
+    r2:                    # rejected: shadows the inverse of `r1`
+      from: [...]
+      to: [...]
+  ```
+
+**Exception:** symmetric relations are allowed to be their own inverse:
+
+```yaml
+relations:
+  related-to:
+    symmetric: true
+    inverse: related-to    # OK — symmetric self-inverse
+```
+
+Use the symmetric form when the relation has no preferred direction (e.g. "is
+related to" reads the same from either side).
+
 ### Cardinality Constraints
 
 Use cardinality to enforce rules:

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -507,14 +507,18 @@ func validateRelationInverses(m *Metamodel) []string {
 
 		if existing, ok := owners[inv]; ok {
 			errs = append(errs, fmt.Sprintf(
-				"inverse_name_collision: relations %q and %q both declare inverse %q",
+				"inverse_name_collision: relations %q and %q both declare inverse %q "+
+					"(each inverse name must be unique across the metamodel; "+
+					"rename one of the `inverse:` values or remove the duplicate)",
 				existing, relType, inv))
 			continue
 		}
 
 		if _, shadowsCanonical := m.Relations[inv]; shadowsCanonical && !isSelfSymmetric {
 			errs = append(errs, fmt.Sprintf(
-				"inverse_shadows_canonical: relation %q declares inverse %q which is also the name of canonical relation %q",
+				"inverse_shadows_canonical: relation %q declares inverse %q which is also the name of canonical relation %q "+
+					"(rename the inverse to a unique name; "+
+					"for a self-inverse, set `symmetric: true` on the canonical relation and use its own name as inverse)",
 				relType, inv, inv))
 			continue
 		}

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -235,6 +235,7 @@ func validate(m *Metamodel) error {
 	validationErrors = append(validationErrors, validateEntitySemantics(m)...)
 	validationErrors = append(validationErrors, validateRelationReferences(m)...)
 	validationErrors = append(validationErrors, validateRelationProperties(m)...)
+	validationErrors = append(validationErrors, validateRelationInverses(m)...)
 
 	if len(validationErrors) > 0 {
 		return &SchemaValidationError{Errors: validationErrors}
@@ -465,6 +466,65 @@ func validateRelationReferences(m *Metamodel) []string {
 		}
 	}
 
+	return errs
+}
+
+// validateRelationInverses enforces the cross-relation uniqueness
+// rules on `inverse:` declarations and, on success, populates
+// `m.inverseOwners` for O(1) runtime lookup.
+//
+// Two failure modes are rejected:
+//
+//   - Two unrelated canonical relations declare the same `inverse:` ID.
+//     Without this guard, a consumer that resolves a body key by
+//     inverse name would pick non-deterministically across runs
+//     (Go map iteration is randomized).
+//   - A relation declares `inverse: X` where `X` is also the name of
+//     a separate canonical relation. The lookup precedence would be
+//     ambiguous: canonical first wins by convention, but the
+//     metamodel author likely didn't intend the shadowing.
+//
+// Symmetric self-inverse (`symmetric: true` AND `inverse.id == relType`)
+// is the one allowed case where a name appears in both maps — it
+// describes a single relation that is its own inverse.
+//
+// If any violation is found, `inverseOwners` is left nil so callers
+// surface a clear "metamodel did not pass validation" failure rather
+// than reading a partially populated map.
+func validateRelationInverses(m *Metamodel) []string {
+	var errs []string
+	owners := make(map[string]string, len(m.Relations))
+
+	for _, relType := range sortedKeys(m.Relations) {
+		rel := m.Relations[relType]
+		if rel.Inverse == nil || rel.Inverse.ID == "" {
+			continue
+		}
+		inv := rel.Inverse.ID
+
+		// Symmetric self-inverse is the only allowed name overlap.
+		isSelfSymmetric := rel.Symmetric && inv == relType
+
+		if existing, ok := owners[inv]; ok {
+			errs = append(errs, fmt.Sprintf(
+				"inverse_name_collision: relations %q and %q both declare inverse %q",
+				existing, relType, inv))
+			continue
+		}
+
+		if _, shadowsCanonical := m.Relations[inv]; shadowsCanonical && !isSelfSymmetric {
+			errs = append(errs, fmt.Sprintf(
+				"inverse_shadows_canonical: relation %q declares inverse %q which is also the name of canonical relation %q",
+				relType, inv, inv))
+			continue
+		}
+
+		owners[inv] = relType
+	}
+
+	if len(errs) == 0 {
+		m.inverseOwners = owners
+	}
 	return errs
 }
 

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -1802,6 +1802,190 @@ func TestLoad_AllShippedMetamodels(t *testing.T) {
 	}
 }
 
+// Inverse-name validation tests (TKT-4VLN).
+//
+// `inverse:` on a RelationDef is a free-form string. The loader must
+// reject two failure modes so downstream consumers (TKT-GFQK's
+// unified-PATCH inverse-name resolver) can rely on the lookup being
+// unambiguous:
+//
+//   - Two relations declaring the same `inverse:` ID
+//     (`inverse_name_collision`).
+//   - A relation declaring `inverse: X` where `X` is also the name of
+//     a separate canonical relation (`inverse_shadows_canonical`).
+//
+// The symmetric-self-inverse case (`symmetric: true` AND
+// `inverse: <self>`) is the one allowed name overlap.
+
+func TestParse_InverseNameCollision_Rejected(t *testing.T) {
+	yaml := `version: "1.0"
+entities:
+  doc:
+    label: Doc
+    id_prefix: "D-"
+    properties:
+      title:
+        type: string
+        required: true
+relations:
+  blocks:
+    label: blocks
+    from: [doc]
+    to: [doc]
+    inverse: blockedBy
+  prevents:
+    label: prevents
+    from: [doc]
+    to: [doc]
+    inverse: blockedBy
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+	if !strings.Contains(err.Error(), "inverse_name_collision") {
+		t.Errorf("expected inverse_name_collision in error, got: %v", err)
+	}
+	// Both offending relations should be named.
+	if !strings.Contains(err.Error(), `"blocks"`) || !strings.Contains(err.Error(), `"prevents"`) {
+		t.Errorf("error should name both colliding relations: %v", err)
+	}
+	if !strings.Contains(err.Error(), `"blockedBy"`) {
+		t.Errorf("error should name the duplicate inverse: %v", err)
+	}
+}
+
+func TestParse_InverseShadowsCanonical_Rejected(t *testing.T) {
+	// `r1`'s inverse is named `r2`, AND a separate canonical `r2` exists.
+	// The metamodel author likely didn't intend the shadowing — reject.
+	yaml := `version: "1.0"
+entities:
+  doc:
+    label: Doc
+    id_prefix: "D-"
+    properties:
+      title:
+        type: string
+        required: true
+relations:
+  r1:
+    label: r1
+    from: [doc]
+    to: [doc]
+    inverse: r2
+  r2:
+    label: r2
+    from: [doc]
+    to: [doc]
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+	if !strings.Contains(err.Error(), "inverse_shadows_canonical") {
+		t.Errorf("expected inverse_shadows_canonical in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), `"r1"`) || !strings.Contains(err.Error(), `"r2"`) {
+		t.Errorf("error should name both the declaring and shadowed relation: %v", err)
+	}
+}
+
+func TestParse_SymmetricSelfInverse_OK(t *testing.T) {
+	// `symmetric: true` with `inverse: <self>` is the intended way to
+	// express "this relation is its own inverse". Must load.
+	yaml := `version: "1.0"
+entities:
+  doc:
+    label: Doc
+    id_prefix: "D-"
+    properties:
+      title:
+        type: string
+        required: true
+relations:
+  related-to:
+    label: related to
+    from: [doc]
+    to: [doc]
+    symmetric: true
+    inverse: related-to
+`
+	m, err := Parse([]byte(yaml))
+	assertNoError(t, err)
+	owner, ok := m.InverseOwner("related-to")
+	if !ok {
+		t.Fatal("symmetric self-inverse should populate InverseOwner")
+	}
+	assertEqual(t, owner, "related-to")
+}
+
+func TestInverseOwner_PopulatedOnValidLoad(t *testing.T) {
+	yaml := `version: "1.0"
+entities:
+  doc:
+    label: Doc
+    id_prefix: "D-"
+    properties:
+      title:
+        type: string
+        required: true
+relations:
+  blocks:
+    label: blocks
+    from: [doc]
+    to: [doc]
+    inverse: blockedBy
+  affects:
+    label: affects
+    from: [doc]
+    to: [doc]
+    inverse: affectedBy
+`
+	m, err := Parse([]byte(yaml))
+	assertNoError(t, err)
+
+	owner, ok := m.InverseOwner("blockedBy")
+	if !ok {
+		t.Fatal("expected blockedBy to be in InverseOwner")
+	}
+	assertEqual(t, owner, "blocks")
+
+	owner, ok = m.InverseOwner("affectedBy")
+	if !ok {
+		t.Fatal("expected affectedBy to be in InverseOwner")
+	}
+	assertEqual(t, owner, "affects")
+
+	// Canonical name should NOT appear in the inverse map.
+	if _, ok := m.InverseOwner("blocks"); ok {
+		t.Error("canonical relation name should not appear in InverseOwner")
+	}
+
+	// Unknown name returns false.
+	if _, ok := m.InverseOwner("does-not-exist"); ok {
+		t.Error("unknown inverse name should return ok=false")
+	}
+}
+
+func TestInverseOwner_AbsentWhenNoInverseDeclared(t *testing.T) {
+	yaml := `version: "1.0"
+entities:
+  doc:
+    label: Doc
+    id_prefix: "D-"
+    properties:
+      title:
+        type: string
+        required: true
+relations:
+  r:
+    label: r
+    from: [doc]
+    to: [doc]
+`
+	m, err := Parse([]byte(yaml))
+	assertNoError(t, err)
+	if _, ok := m.InverseOwner("r"); ok {
+		t.Error("relation without declared inverse should not appear in InverseOwner")
+	}
+}
+
 // findRepoRoot walks up from the test's working directory until it
 // finds a directory containing go.mod, then returns it. Fails the test
 // if go.mod is never found — indicates the package was moved without

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -16,7 +16,23 @@ type Metamodel struct {
 	Automations []AutomationDef        `yaml:"automations,omitempty"`
 
 	// Computed lookups (not from YAML)
-	aliasMap map[string]string // alias -> canonical name
+	aliasMap      map[string]string // alias -> canonical name
+	inverseOwners map[string]string // inverse name -> owning canonical relation name
+}
+
+// InverseOwner returns the canonical relation type that declares the
+// given inverse name, if any. Populated at load time by the metamodel
+// loader after rejecting collisions and canonical-name shadowing. The
+// data-entry unified-PATCH wire format uses this to resolve inverse
+// body keys without scanning the relation map on every request.
+//
+// For a relation declared `symmetric: true` with `inverse: <self>`,
+// the inverse maps back to the same canonical relation — callers that
+// care about direction should consult `RelationDef.Symmetric` and
+// treat the path entity as source regardless of the body key.
+func (m *Metamodel) InverseOwner(inverseName string) (string, bool) {
+	owner, ok := m.inverseOwners[inverseName]
+	return owner, ok
 }
 
 // ValidationRule defines a custom validation rule for entities

--- a/tickets/entities/planning-checklists/PLAN-K49T.md
+++ b/tickets/entities/planning-checklists/PLAN-K49T.md
@@ -1,0 +1,117 @@
+---
+id: PLAN-K49T
+type: planning-checklist
+title: 'Planning: Reject inverse-name collisions and shadowing in metamodel loader'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [ ] Problem/requirements clearly understood
+- [ ] Scope defined (what's in/out documented below)
+- [ ] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+<!-- Document explicitly what IS and IS NOT in scope -->
+
+**Acceptance Criteria:**
+<!-- Each criterion must have a concrete test scenario -->
+1. ...
+
+## Research
+
+- [ ] Searched for existing libraries that solve this problem
+- [ ] Checked codebase for similar patterns or reusable code
+- [ ] Looked for reference implementations in other projects
+- [ ] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+<!-- Document what you found:
+- Libraries considered (with pros/cons, why chosen or rejected)
+- Similar patterns in codebase (file:line references)
+- Reference implementations that inspired the approach
+- Relevant concepts from rela-docs or rela-issues-and-design-tickets
+-->
+
+## Approach
+
+- [ ] Technical approach chosen and documented
+- [ ] Approach builds on existing patterns (not reinventing)
+- [ ] Alternatives considered (document why rejected)
+- [ ] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+<!-- Document the approach with enough detail that implementation is mechanical -->
+
+**Files to modify:**
+<!-- List specific files that will change -->
+
+## Security Considerations
+
+- [ ] Input sources identified (user input, config, external APIs)
+- [ ] Input validation approach defined (allowlist preferred over blocklist)
+- [ ] Security-sensitive operations identified (file access, auth, crypto)
+- [ ] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+<!-- For each input: source, validation approach, what happens on invalid input -->
+
+**Security-Sensitive Operations:**
+<!-- List operations and how they're protected -->
+
+## Test Plan
+
+- [ ] Test scenarios documented for each acceptance criterion
+- [ ] Edge cases identified and documented
+- [ ] Negative test cases defined (invalid input, error conditions)
+- [ ] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+<!-- Map each acceptance criterion to how it will be tested -->
+
+**Edge Cases:**
+<!-- List specific edge cases and expected behavior. Consider:
+- Empty/null/missing values
+- Boundary values (0, -1, MAX_INT)
+- Special characters, unicode, null bytes
+- Concurrent access
+- Resource exhaustion
+-->
+
+**Negative Tests:**
+<!-- What should fail? How should it fail? -->
+
+## Risk Assessment
+
+- [ ] Technical risks assessed with mitigations
+- [ ] Security risks assessed (see Security Considerations)
+- [ ] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+<!-- List risks and how they will be mitigated -->
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [ ] User-facing docs identified (skip if internal refactor)
+- [ ] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+<!-- Which docs need updating? Check all that apply:
+- [ ] User guide / reference docs
+- [ ] CLI help text (if commands changed)
+- [ ] CLAUDE.md (if new patterns)
+- [ ] README.md (if project-level changes)
+- [ ] API docs (if applicable)
+- [ ] N/A - Internal change, no user-facing docs needed
+-->
+
+## Design Review
+
+- [ ] Run `/design-review` before starting implementation
+- [ ] All critical/significant findings addressed in plan
+
+**Design Review Findings:** <!-- List review-response IDs, e.g., RR-xxxx -->

--- a/tickets/entities/review-checklists/REV-06ZH.md
+++ b/tickets/entities/review-checklists/REV-06ZH.md
@@ -1,0 +1,56 @@
+---
+id: REV-06ZH
+type: review-checklist
+title: 'Review: Reject inverse-name collisions and shadowing in metamodel loader'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/tickets/TKT-4VLN.md
+++ b/tickets/entities/tickets/TKT-4VLN.md
@@ -1,0 +1,96 @@
+---
+id: TKT-4VLN
+type: ticket
+title: Reject inverse-name collisions and shadowing in metamodel loader
+kind: refactor
+priority: high
+effort: s
+status: review
+---
+
+## Problem
+
+`metamodel.RelationDef.Inverse` is a free-form string
+(`internal/metamodel/types.go:232`) and the loader
+(`internal/metamodel/loader.go`) does no cross-relation uniqueness validation.
+Two failure modes are silently accepted today:
+
+1. **Inverse-name collision** — two unrelated canonical relations
+declare the same `inverse:` ID. E.g., `blocks` → `blockedBy` AND `prevents` →
+`blockedBy`. A consumer that looks up a relation by inverse name has to pick
+one; Go map iteration is randomized, so the choice is non-deterministic across
+runs.
+
+2. **Inverse shadowing a canonical name** — a relation declares
+`inverse: X` where `X` is also the name of a separate canonical relation. A
+consumer that resolves a body key by name has to choose precedence between
+"canonical X" and "inverse-of-Y, which is X".
+
+Today no code path in rela depends on inverse-name lookup, so neither mode
+causes observable bugs. But TKT-GFQK builds the unified data-entry PATCH wire
+format on top of inverse-name resolution. Without this validation, that work is
+built on quicksand: a future metamodel author silently corrupts data.
+
+## What we want
+
+Reject both failure modes at metamodel load time with clear error messages, so
+the constraint can be relied on by downstream code.
+
+## Scope
+
+In:
+
+- `internal/metamodel/loader.go` (or a new `internal/metamodel/validation.go`):
+load-time check that builds `inverseOwners := map[string]string{}` (`inverse.ID
+→ owning canonical relation name`) in one pass over the relation set.
+- On duplicate inverse ID: reject with `inverse_name_collision: relations %q and %q both declare inverse %q`.
+- On inverse shadowing a canonical name (other than `symmetric: true`
+self-inverse — see exception below): reject with `inverse_shadows_canonical:
+relation %q declares inverse %q which is also the name of canonical relation
+%q`.
+- Exception: when `relDef.Symmetric == true` AND `relDef.Inverse.ID == relType`,
+the relation is its own inverse — this is intentional and must load OK.
+- Tests in `internal/metamodel/loader_test.go` covering each rejection
+case and the symmetric exception.
+- After the pass, attach `inverseOwners` to the loaded metamodel so
+downstream consumers (TKT-GFQK and future) can do O(1) lookups without
+re-scanning.
+
+Out of scope:
+
+- Any consumer of the new lookup. TKT-GFQK does that.
+- Migration tooling for projects whose metamodel currently has a
+collision. None of the in-tree metamodels (tickets/, docs-project/,
+prototypes/data-entry/{,project/,catalog-metamodel.yaml}) currently trip the new
+rules, verified by grep before opening this ticket.
+
+## Acceptance criteria
+
+| ID | Statement | Test |
+|---|---|---|
+| AC1 | Loading a metamodel where two relations declare the same `inverse:` ID fails with error code `inverse_name_collision` and names both relations + the duplicate inverse. | unit |
+| AC2 | Loading a metamodel where a relation's `inverse:` ID matches a separate canonical relation's name fails with error code `inverse_shadows_canonical`. | unit |
+| AC3 | Loading a metamodel where `symmetric: true` AND `inverse: <self>` is set on the same relation succeeds. | unit |
+| AC4 | The loaded `Metamodel` exposes a way to look up the owning canonical relation type for any inverse name (e.g., `meta.InverseOwner(name string) (string, bool)`). | unit |
+| AC5 | All in-tree metamodels (tickets, docs-project, prototypes/data-entry/*) continue to load after the change. | `just test` |
+| AC6 | The existing metamodel test corpus continues to pass without modification — this is purely additive validation, not a change to existing accepted shapes. | `just test` |
+
+## Risks
+
+- A user's out-of-tree metamodel might trip the new validation
+unintentionally. This is a desirable failure (they had a bug); the error message
+names the offending relations so the fix is mechanical.
+- If `loader.go` already performs some inverse validation (it doesn't,
+verified by grep), we'd duplicate the check. Implementation must start by
+re-confirming there's no overlap.
+
+## Relation to other work
+
+- **Unblocks**: TKT-GFQK — the unified data-entry PATCH wire format
+resolves inverse names at runtime; without this validation, that resolver is
+non-deterministic.
+- **Independent of**: TKT-ZEKO4, TKT-6WLSW.
+
+## Effort
+
+s. A focused loader-validation pass + tests. Half a day.

--- a/tickets/relations/TKT-4VLN--affects--metamodel-types.md
+++ b/tickets/relations/TKT-4VLN--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-4VLN
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-4VLN--has-planning--PLAN-K49T.md
+++ b/tickets/relations/TKT-4VLN--has-planning--PLAN-K49T.md
@@ -1,0 +1,5 @@
+---
+from: TKT-4VLN
+relation: has-planning
+to: PLAN-K49T
+---

--- a/tickets/relations/TKT-4VLN--has-review--REV-06ZH.md
+++ b/tickets/relations/TKT-4VLN--has-review--REV-06ZH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-4VLN
+relation: has-review
+to: REV-06ZH
+---

--- a/tickets/relations/TKT-4VLN--implements--FEAT-57oh.md
+++ b/tickets/relations/TKT-4VLN--implements--FEAT-57oh.md
@@ -1,0 +1,5 @@
+---
+from: TKT-4VLN
+relation: implements
+to: FEAT-57oh
+---


### PR DESCRIPTION
## Summary

- Reject two failure modes in metamodel loader:
  - **`inverse_name_collision`**: two relations declaring the same `inverse:` ID
  - **`inverse_shadows_canonical`**: a relation's `inverse:` matches another canonical relation name
- Symmetric self-inverse (`symmetric: true` AND `inverse: <self>`) remains valid.
- Loader now populates `Metamodel.inverseOwners` for O(1) inverse-name lookups; exposed via the new `Metamodel.InverseOwner(name)` method.
- No callers added in this PR; consumed by TKT-GFQK (unified data-entry PATCH wire format).

## Why

`RelationDef.Inverse` is a free-form string with no cross-relation uniqueness check. Today no code path resolves relations by inverse name so the bug is latent. TKT-GFQK will resolve inverse body keys at runtime via Go map iteration — which is randomized — so the same input would non-deterministically route writes to different relations. Closing the gap at load time so downstream consumers can rely on the invariant.

## Test plan

- [x] New tests: `TestParse_InverseNameCollision_Rejected`, `TestParse_InverseShadowsCanonical_Rejected`, `TestParse_SymmetricSelfInverse_OK`, `TestInverseOwner_PopulatedOnValidLoad`, `TestInverseOwner_AbsentWhenNoInverseDeclared`.
- [x] All in-tree metamodels (`tickets/`, `docs-project/`, `prototypes/data-entry/*`) still load — grepped before opening this work, validated by `go test ./...` green.
- [x] `just lint` — 0 issues.
- [x] `just arch-lint` — OK.
- [x] `just ci` — green.