### PR TITLE
feat(data-entry): per-property + content + relation auto-save (TKT-E6094)

### DIFF
--- a/e2e/pages/base.page.ts
+++ b/e2e/pages/base.page.ts
@@ -97,9 +97,32 @@ export class BasePage {
    *  RelationCardsPage share that same contract, so this helper is the
    *  single source of truth for the navigation predicate. */
   async submitFormAndWaitForNavigation(submitButton: Locator) {
+    const submitVisible = await submitButton
+      .waitFor({ state: 'visible', timeout: 2000 })
+      .then(() => true)
+      .catch(() => false);
+    if (submitVisible) {
+      await Promise.all([
+        this.page.waitForURL((url) => !url.pathname.includes('/form/'), { timeout: 10000 }),
+        submitButton.click(),
+      ]);
+      return;
+    }
+    // TKT-E6094: in autosave mode there is no explicit submit; the form
+    // saves continuously. Blur to flush pending input, wait for any
+    // in-flight or queued autosave PATCH to land, then navigate back.
+    await this.page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+    // Wait for at least one PATCH on the current entity (the autosave),
+    // bounded so a clean form (no edits) doesn't hang.
+    await this.page
+      .waitForResponse(
+        (r) => r.url().includes('/api/v1/') && r.request().method() === 'PATCH',
+        { timeout: 2000 },
+      )
+      .catch(() => {});
     await Promise.all([
       this.page.waitForURL((url) => !url.pathname.includes('/form/'), { timeout: 10000 }),
-      submitButton.click(),
+      this.page.goBack(),
     ]);
   }
 

--- a/e2e/pages/form.page.ts
+++ b/e2e/pages/form.page.ts
@@ -112,9 +112,26 @@ export class FormPage extends BasePage {
 
   async submit() {
     const startUrl = this.page.url();
-    await this.submitButton.click();
-    // Submit is a client-side fetch followed by a router.push on success. Wait
-    // briefly for the URL to change; if validation fails we stay on the form.
+    // Wait briefly for the submit button to appear; in create mode the
+    // form always has it. In autosave edit mode it never appears.
+    const submitVisible = await this.submitButton
+      .first()
+      .waitFor({ state: 'visible', timeout: 2000 })
+      .then(() => true)
+      .catch(() => false);
+    if (submitVisible) {
+      await this.submitButton.first().click();
+      // Submit is a client-side fetch followed by a router.push on success.
+      // Wait briefly for the URL to change; if validation fails we stay on the form.
+      await this.page.waitForURL((url) => url.toString() !== startUrl, { timeout: 2000 }).catch(() => {});
+      return;
+    }
+    // TKT-E6094 autosave: no explicit Submit. Blur, wait for the autosave
+    // PATCH(es) to drain, then navigate back; the route guard flushes any
+    // pending edits before the URL changes.
+    await this.page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+    await this.page.waitForTimeout(1000);
+    await this.page.goBack();
     await this.page.waitForURL((url) => url.toString() !== startUrl, { timeout: 2000 }).catch(() => {});
   }
 
@@ -166,15 +183,47 @@ export class FormPage extends BasePage {
     return values;
   }
 
-  /** Submit and wait for the save PATCH on the given entity, returning the response. */
+  /** Submit and wait for the save PATCH on the given entity, returning
+   *  the response. After TKT-E6094 (autosave) edit forms no longer have
+   *  an explicit Save button: the PATCH fires automatically after a
+   *  debounce. We detect either mode and wait for the same PATCH.
+   *
+   *  For autosave forms, the caller should have just performed an edit
+   *  (fillField/selectField etc.) — this helper triggers a blur to flush
+   *  the debounce and then waits for the PATCH. */
   async saveAndWaitForPatch(plural: string, entityId: string) {
-    const [resp] = await Promise.all([
-      this.page.waitForResponse(
-        (r) => r.url().includes(`/api/v1/${plural}/${entityId}`) && r.request().method() === 'PATCH',
-      ),
-      this.submitButton.first().click(),
-    ]);
-    return resp;
+    const submitVisible = await this.submitButton
+      .first()
+      .waitFor({ state: 'visible', timeout: 2000 })
+      .then(() => true)
+      .catch(() => false);
+    if (submitVisible) {
+      const [resp] = await Promise.all([
+        this.page.waitForResponse(
+          (r) => r.url().includes(`/api/v1/${plural}/${entityId}`) && r.request().method() === 'PATCH',
+        ),
+        this.submitButton.first().click(),
+      ]);
+      return resp;
+    }
+    // Autosave path: blur to flush pending input, then wait for the
+    // PATCH chain to drain. Multiple edits in quick succession serialize
+    // through the FIFO queue, so we wait for an idle window of no PATCH
+    // activity. Bounded so a no-edit form doesn't hang.
+    await this.page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+    let lastResp: Awaited<ReturnType<typeof this.page.waitForResponse>> | undefined;
+    // Poll for PATCH responses until 1s elapses without one.
+    for (;;) {
+      const resp = await this.page
+        .waitForResponse(
+          (r) => r.url().includes(`/api/v1/${plural}/${entityId}`) && r.request().method() === 'PATCH',
+          { timeout: 1500 },
+        )
+        .catch(() => undefined);
+      if (!resp) break;
+      lastResp = resp;
+    }
+    return lastResp;
   }
 
   /** True if the page shows an inline-create UI for related entities. */

--- a/e2e/tests/document-edit-button.spec.ts
+++ b/e2e/tests/document-edit-button.spec.ts
@@ -43,7 +43,11 @@ test.describe('Document view: Edit button', () => {
     expect(returnTo).toBe(`/document/${DOC_WITH_EDIT}/${FEATURE_ID}`);
   });
 
-  test('saving the form returns to the document URL', async ({ appPage }) => {
+  test('navigating back from the form returns to the document URL', async ({ appPage }) => {
+    // Was: 'saving the form returns to the document URL'. After
+    // TKT-E6094 there's no explicit Save in edit mode — autosave runs
+    // continuously and never triggers navigation. The user goes back
+    // explicitly; this test verifies the return_to round-trips.
     const doc = new DocumentPage(appPage);
     await doc.navigateToDocument(DOC_WITH_EDIT, FEATURE_ID);
 
@@ -51,8 +55,9 @@ test.describe('Document view: Edit button', () => {
     await doc.editButton(EDIT_LABEL).click();
     await form.expectAtFormUrl(EDIT_FORM, FEATURE_ID);
 
-    // Submit the form unchanged. Edit mode allows a no-op save.
-    await form.saveAndWaitForPatch('features', FEATURE_ID);
+    // No edits — go back. The route guard's commitImmediately returns
+    // settled:true on a quiet queue, so navigation proceeds silently.
+    await appPage.goBack();
 
     await doc.expectAtDocumentUrl(DOC_WITH_EDIT, FEATURE_ID);
   });

--- a/e2e/tests/forms.spec.ts
+++ b/e2e/tests/forms.spec.ts
@@ -164,10 +164,18 @@ test.describe('Edit Form - Default Relation Picker Save (BUG-UNEBR regression)',
     const formPage = new FormPage(appPage);
     await formPage.navigateToEditForm('task', taskId!);
 
+    // After TKT-E6094, edit forms autosave on debounce. Arm the
+    // PATCH waiter BEFORE the picker action so the response can't
+    // land before we start listening.
+    const patchPromise = appPage.waitForResponse(
+      (r) => r.url().includes(`/api/v1/tasks/${taskId!}`) && r.request().method() === 'PATCH',
+      { timeout: 5000 },
+    );
+
     // Add the second feature via the `implements` relation picker.
     await formPage.addRelation('Implements Feature', featureBId!);
 
-    const response = await formPage.saveAndWaitForPatch('tasks', taskId!);
+    const response = await patchPromise;
     expect(response.status()).toBe(200);
 
     const updated = await api.getEntity('tasks', taskId!);

--- a/e2e/tests/relation-cards.spec.ts
+++ b/e2e/tests/relation-cards.spec.ts
@@ -94,31 +94,34 @@ test.describe('Relation Cards', () => {
     }
   });
 
-  test('batch save: changes are not persisted until Save is clicked', async ({ appPage, api }) => {
+  test('autosave persists relation card text edits', async ({ appPage, api }) => {
+    // Was: 'batch save: changes are not persisted until Save is clicked'.
+    // After TKT-E6094 there is no explicit Save in edit mode; autosave
+    // fires automatically after a debounce. Assert the server reflects
+    // the edit after blur + the autosave PATCH lands.
     const rc = new RelationCardsPage(appPage);
     await rc.navigateToEdit('feature', SEED.features.authentication);
 
     const card = rc.cardByTargetId(SEED.features.exportData);
     await expect(card).toBeVisible();
 
-    const original = await rc.getTextInputValue(card);
     const updated = 'batch save test reason';
     await rc.editTextInput(card, updated);
 
-    // The pending-edit lives only in the client until Save is clicked. We can't
-    // assert this through the rendered SPA — the SPA is what's holding the
-    // pending change — so query the server directly and confirm it still has
-    // the original value.
-    const before = await api.listRelations('features', SEED.features.authentication, 'blocks');
-    expect(before.find((r) => r.id === SEED.features.exportData)?.meta?.reason).toBe(original);
-
-    await rc.saveAndWaitForNavigation();
+    await appPage.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+    await appPage.waitForResponse(
+      (r) =>
+        r.url().includes(`/api/v1/features/${SEED.features.authentication}`) &&
+        r.request().method() === 'PATCH',
+    );
 
     const after = await api.listRelations('features', SEED.features.authentication, 'blocks');
     expect(after.find((r) => r.id === SEED.features.exportData)?.meta?.reason).toBe(updated);
   });
 
-  test('removing a relation is only persisted on save', async ({ appPage, api }) => {
+  test('autosave persists relation card removal', async ({ appPage, api }) => {
+    // Was: 'removing a relation is only persisted on save'. Same
+    // TKT-E6094 rationale as above: autosave fires the PATCH directly.
     const rc = new RelationCardsPage(appPage);
     await rc.navigateToEdit('feature', SEED.features.authentication);
 
@@ -127,12 +130,11 @@ test.describe('Relation Cards', () => {
     const firstId = await rc.getFirstCardEntityId(tagged);
     await rc.clickRemoveFirstCardIn(tagged);
 
-    // Server-side assertion for the same reason as the batch-save test above:
-    // the SPA will happily show the card as gone regardless of persistence.
-    const before = await api.listRelations('features', SEED.features.authentication, 'tagged');
-    expect(before.some((r) => r.id === firstId)).toBeTruthy();
-
-    await rc.saveAndWaitForNavigation();
+    await appPage.waitForResponse(
+      (r) =>
+        r.url().includes(`/api/v1/features/${SEED.features.authentication}`) &&
+        r.request().method() === 'PATCH',
+    );
 
     const after = await api.listRelations('features', SEED.features.authentication, 'tagged');
     expect(after.some((r) => r.id === firstId)).toBeFalsy();

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -60,12 +60,12 @@ class ApiClient {
     return response.data
   }
 
-  async patch<T>(url: string, data: unknown, etag?: string): Promise<T> {
+  async patch<T>(url: string, data: unknown, etag?: string, signal?: AbortSignal): Promise<T> {
     const headers: Record<string, string> = {}
     if (etag) {
       headers['If-Match'] = etag
     }
-    const response: AxiosResponse<T> = await this.client.patch(url, data, { headers })
+    const response: AxiosResponse<T> = await this.client.patch(url, data, { headers, signal })
     return response.data
   }
 

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -40,7 +40,12 @@ export async function createEntity(type: string, entity: CreateEntity): Promise<
 // relation shapes the unified PATCH endpoint accepts. The body must
 // not mix shapes (`shape_mixed` 400); the SPA's body-assembly helper
 // in DynamicForm ensures all-modern-or-all-legacy.
+//
+// `properties_unset` (TKT-E6094) lets callers express "user cleared
+// this field" distinct from "field was untouched". Autosave uses it
+// to delete keys atomically alongside property upserts.
 export type EntityPatch = Omit<Partial<Entity>, 'relations'> & {
+  properties_unset?: string[]
   relations?: Record<string, string[]> | ModernRelationsField
 }
 
@@ -48,9 +53,10 @@ export async function updateEntity(
   type: string,
   id: string,
   patch: EntityPatch,
-  etag?: string
+  etag?: string,
+  signal?: AbortSignal,
 ): Promise<Entity> {
-  return api.patch<Entity>(`/${getPlural(type)}/${id}`, patch, etag)
+  return api.patch<Entity>(`/${getPlural(type)}/${id}`, patch, etag, signal)
 }
 
 export async function deleteEntity(type: string, id: string): Promise<void> {

--- a/frontend/src/components/forms/AutoSaveIndicator.vue
+++ b/frontend/src/components/forms/AutoSaveIndicator.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { SaveStatus } from '@/composables/useAutoSave'
+
+const props = defineProps<{
+  status: SaveStatus
+  error?: string | null
+}>()
+
+// Always-on ambient indicator: glyph swaps with state.
+// - saved/idle: check mark in circle (rela is local-first; no cloud).
+// - saving: spinning ring.
+// - error: warning triangle.
+const tooltip = computed(() => {
+  if (props.error) return props.error
+  switch (props.status) {
+    case 'saving':
+      return 'Saving…'
+    case 'saved':
+      return 'Saved'
+    case 'error':
+      return 'Save failed'
+    default:
+      return 'All changes saved'
+  }
+})
+
+const renderState = computed(() => {
+  if (props.status === 'saving') return 'saving'
+  if (props.status === 'error') return 'error'
+  // idle and saved both render the same "saved" cloud — no flash on success.
+  return 'saved'
+})
+</script>
+
+<template>
+  <div
+    class="autosave-indicator"
+    :class="`autosave-${renderState}`"
+    :title="tooltip"
+    data-testid="autosave-indicator"
+    :data-status="status"
+    role="status"
+    aria-live="polite"
+    :aria-label="tooltip"
+  >
+    <!-- Saved: check mark in circle (no cloud — rela is local-first) -->
+    <svg
+      v-if="renderState === 'saved'"
+      class="autosave-icon"
+      viewBox="0 0 24 24"
+      width="20"
+      height="20"
+      aria-hidden="true"
+    >
+      <path
+        fill="currentColor"
+        d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm-1.4 14.6L6 12l1.4-1.4 3.2 3.2 6-6L18 9.2z"
+      />
+    </svg>
+
+    <!-- Saving: spinning ring -->
+    <svg
+      v-else-if="renderState === 'saving'"
+      class="autosave-icon autosave-spin"
+      viewBox="0 0 24 24"
+      width="20"
+      height="20"
+      aria-hidden="true"
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r="9"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-dasharray="14 42"
+      />
+    </svg>
+
+    <!-- Error: triangle with exclamation -->
+    <svg
+      v-else
+      class="autosave-icon"
+      viewBox="0 0 24 24"
+      width="20"
+      height="20"
+      aria-hidden="true"
+    >
+      <path
+        fill="currentColor"
+        d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+      />
+    </svg>
+  </div>
+</template>
+
+<style scoped>
+.autosave-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  user-select: none;
+  cursor: default;
+  transition: color 0.2s ease;
+}
+
+.autosave-icon {
+  display: block;
+}
+
+.autosave-saved {
+  color: var(--text-2, #888);
+  opacity: 0.7;
+}
+.autosave-saved:hover {
+  opacity: 1;
+}
+
+.autosave-saving {
+  color: var(--accent, #4a90e2);
+}
+
+.autosave-error {
+  color: var(--danger, #c2342f);
+}
+
+.autosave-spin {
+  animation: autosave-rotate 1s linear infinite;
+  transform-origin: center;
+}
+
+@keyframes autosave-rotate {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -16,6 +16,9 @@ import {
   OUTGOING_SUFFIX,
   INCOMING_SUFFIX,
 } from './relationsPatch'
+import { useAutoSave } from '@/composables/useAutoSave'
+import { registerForm } from './dirtyFormRegistry'
+import AutoSaveIndicator from './AutoSaveIndicator.vue'
 import FieldRenderer from './FieldRenderer.vue'
 import RelationPicker from './RelationPicker.vue'
 import RelationCards from './RelationCards.vue'
@@ -498,11 +501,30 @@ function handleCancel() {
 function updateField(property: string, value: unknown) {
   formData.value[property] = value
   checkDirty()
+  if (!autoSave.value) return
+  // TKT-E6094: clear semantics per type. For string/list properties an
+  // empty value means "user cleared" → properties_unset. Boolean false
+  // is a legitimate value, never an unset.
+  const def = entityType.value?.properties[property]
+  if (isClearedForType(value, def)) {
+    autoSave.value.scheduleUnset(property)
+  } else {
+    autoSave.value.scheduleFieldSave(property, value)
+  }
+}
+
+function isClearedForType(value: unknown, def: PropertyDef | undefined): boolean {
+  if (def?.type === 'boolean') return false
+  if (Array.isArray(value)) return value.length === 0
+  return value === '' || value === null || value === undefined
 }
 
 function updateRelation(relation: string, value: string[]) {
   relations.value[relation] = value
   checkDirty()
+  // Legacy IDs-only relation widget. Autosave routes this through the
+  // pendingCardChanges map: any change triggers a relations PATCH.
+  autoSave.value?.scheduleRelationsChange()
 }
 
 function updateRelationTypes(relation: string, types: Map<string, string>) {
@@ -512,9 +534,67 @@ function updateRelationTypes(relation: string, types: Map<string, string>) {
 // Pending relation card changes (for batch save)
 const pendingCardChanges = ref<Map<string, RelationCardState>>(new Map())
 
+// TKT-E6094: autosave is mounted only in edit mode. In create mode
+// the user explicitly clicks Save; the form delays the entity into
+// existence until then.
+const autoSave = computed(() => {
+  if (!isEdit.value || !props.entityId || !formConfig.value) return null
+  return _autoSaveInstance.value
+})
+// Lazy holder so we construct the composable once per (entityId, formId).
+const _autoSaveInstance = ref<ReturnType<typeof useAutoSave> | null>(null)
+
+function buildAutoSaveRelationsBody(): ModernRelationsField | null {
+  // Mirror handleSubmit's body assembly. Two sources of relation
+  // edits flow through autosave:
+  //   - card-managed widgets (`pendingCardChanges`) — modern shape
+  //     via buildRelationsPatch (per-edge meta + content).
+  //   - legacy IDs-only widgets (`relations`) — non-card pickers
+  //     write IDs; reshapeLegacyToModern wraps them in {data:[{type,id}]}
+  //     so they ride the same modern PATCH.
+  //
+  // Returns null when neither source is dirty.
+  const inverseByRelation = new Map<string, string>()
+  const cardRelations = new Set<string>()
+  if (formConfig.value) {
+    for (const f of fields.value) {
+      if (!f.relation) continue
+      const inv = schemaStore.getInverseName(f.relation)
+      if (inv) inverseByRelation.set(f.relation, inv)
+      if (f.widget === 'cards') cardRelations.add(f.relation)
+    }
+  }
+  // Legacy picker edits — non-card relations from `relations.value`.
+  const filteredRelations: Record<string, string[]> = {}
+  for (const [rel, ids] of Object.entries(relations.value)) {
+    if (cardRelations.has(rel)) continue
+    filteredRelations[rel] = ids
+  }
+  const modernCards = buildRelationsPatch(pendingCardChanges.value, inverseByRelation)
+  const hasModernCards = Object.keys(modernCards).length > 0
+  const hasLegacy = Object.keys(filteredRelations).length > 0
+  if (!hasModernCards && !hasLegacy) return null
+  // Reshape legacy IDs to modern shape (autosave always uses modern;
+  // shape_mixed 400 otherwise).
+  const reshaped = hasLegacy
+    ? reshapeLegacyToModern(filteredRelations, pickerTypes.value)
+    : {}
+  if (reshaped === null) {
+    // Pathological: a picker target without a known type. Surface
+    // and skip — explicit Save in create mode handles this case;
+    // autosave is best-effort.
+    uiStore.error(
+      'Some related entities have unknown types; relation changes were not saved. Reload the form and try again.',
+    )
+    return null
+  }
+  return { ...reshaped, ...modernCards }
+}
+
 function updateRelationCards(relation: string, state: RelationCardState) {
   pendingCardChanges.value.set(relation, state)
   checkDirty()
+  autoSave.value?.scheduleRelationsChange()
 }
 
 // Bridge incoming-direction RelationPicker changes into the pending-
@@ -536,6 +616,7 @@ function updateIncomingPicker(
     updated: [],
   })
   checkDirty()
+  autoSave.value?.scheduleRelationsChange()
 }
 
 // Surface soft validation warnings from a mutation response as a
@@ -552,6 +633,7 @@ function surfaceWarnings(warnings: { code: string; path: string; detail: string 
 function updateContent(value: string) {
   content.value = value
   checkDirty()
+  autoSave.value?.scheduleContentSave(value)
 }
 
 function checkDirty() {
@@ -601,6 +683,42 @@ onMounted(async () => {
   }
   loading.value = false
 
+  // TKT-E6094: mount the autosave composable in edit mode. The save
+  // path replaces handleSubmit's Save button for edit forms; create
+  // forms keep the explicit submit.
+  if (isEdit.value && props.entityId && formConfig.value) {
+    const inverseToCanonical = new Map<string, string>()
+    for (const f of fields.value) {
+      if (!f.relation) continue
+      const inv = schemaStore.getInverseName(f.relation)
+      if (inv) inverseToCanonical.set(inv, f.relation)
+    }
+    _autoSaveInstance.value = useAutoSave({
+      getEntityType: () => formConfig.value!.entity,
+      getEntityId: () => props.entityId!,
+      formData,
+      contentRef: content,
+      inverseToCanonical,
+      buildRelationsBody: () => buildAutoSaveRelationsBody(),
+      applyServerProperty: (property, value) => {
+        if (value === undefined) {
+          delete formData.value[property]
+        } else {
+          formData.value[property] = value
+        }
+      },
+      applyServerContent: (c) => { content.value = c },
+      onError: (msg) => uiStore.error(msg),
+    })
+    // Register with the dirty registry so SSE-driven re-fetches in
+    // other forms on the same entity preserve this form's dirty state.
+    const unregister = registerForm(
+      props.entityId,
+      (property) => _autoSaveInstance.value?.isDirty(property) ?? false,
+    )
+    onBeforeUnmount(unregister)
+  }
+
   // TKT-GFQK pre-flight: a `direction: incoming` widget on a relation
   // without an `inverse:` declared in the metamodel can't be saved
   // through the unified PATCH. Warn the user at form-load time so the
@@ -634,6 +752,23 @@ onBeforeUnmount(() => {
 // navigation downstream — if one were added, the assignment should move into
 // a router.afterEach hook gated on success.
 onBeforeRouteLeave(async () => {
+  // TKT-E6094: in edit mode, flush autosave before navigating away.
+  // On clean commit we proceed silently; on error or timeout we
+  // prompt the user to confirm.
+  if (autoSave.value) {
+    const result = await autoSave.value.commitImmediately()
+    if (result.settled && !result.error) {
+      dirty.value = false
+      return true
+    }
+    return await confirm({
+      title: 'Unsaved changes',
+      message: result.error ?? 'Some changes are still saving.',
+      confirmLabel: 'Leave anyway',
+      danger: true,
+    })
+  }
+  // Create-mode / no autosave: original prompt.
   if (!dirty.value) return true
   const ok = await confirm({
     title: 'Unsaved changes',
@@ -770,6 +905,7 @@ onBeforeRouteLeave(async () => {
               :entity-id="entityId"
               :value="relations[field.relation] || []"
               @update="updateRelation(field.relation!, $event)"
+              @update:types="(types) => updateRelationTypes(field.relation!, types)"
               @incoming-changed="(state) => updateIncomingPicker(field.relation!, state)"
             />
           </template>
@@ -786,21 +922,40 @@ onBeforeRouteLeave(async () => {
         </div>
 
         <div class="form-actions">
-          <button
-            type="button"
-            class="btn btn-secondary"
-            :disabled="saving"
-            @click="handleCancel"
-          >
-            Cancel <kbd>Esc</kbd>
-          </button>
-          <button
-            type="submit"
-            class="btn btn-primary"
-            :disabled="saving"
-          >
-            {{ saving ? 'Saving...' : (isEdit ? 'Save Changes' : 'Create') }} <kbd>&#8984;&#8629;</kbd>
-          </button>
+          <!-- Edit mode: ambient autosave indicator replaces the
+               explicit Save button. Cancel is repurposed as a Back
+               button to navigate away (with the autosave-flushing
+               route guard catching any pending edits). -->
+          <template v-if="autoSave">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              @click="handleCancel"
+            >
+              Back <kbd>Esc</kbd>
+            </button>
+            <AutoSaveIndicator
+              :status="autoSave.status"
+              :error="autoSave.lastError"
+            />
+          </template>
+          <template v-else>
+            <button
+              type="button"
+              class="btn btn-secondary"
+              :disabled="saving"
+              @click="handleCancel"
+            >
+              Cancel <kbd>Esc</kbd>
+            </button>
+            <button
+              type="submit"
+              class="btn btn-primary"
+              :disabled="saving"
+            >
+              {{ saving ? 'Saving...' : (isEdit ? 'Save Changes' : 'Create') }} <kbd>&#8984;&#8629;</kbd>
+            </button>
+          </template>
         </div>
       </form>
     </div>

--- a/frontend/src/components/forms/dirtyFormRegistry.test.ts
+++ b/frontend/src/components/forms/dirtyFormRegistry.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { registerForm, anyFormDirty, _registrySize, _registryClear } from './dirtyFormRegistry'
+
+describe('dirtyFormRegistry', () => {
+  beforeEach(() => {
+    _registryClear()
+  })
+
+  it('starts empty', () => {
+    expect(_registrySize()).toBe(0)
+    expect(anyFormDirty('TKT-001', 'title')).toBe(false)
+  })
+
+  it('reports dirty after register when callback returns true', () => {
+    registerForm('TKT-001', (prop) => prop === 'title')
+    expect(anyFormDirty('TKT-001', 'title')).toBe(true)
+    expect(anyFormDirty('TKT-001', 'status')).toBe(false)
+  })
+
+  it('returns false for unregistered entities', () => {
+    registerForm('TKT-001', () => true)
+    expect(anyFormDirty('TKT-002', 'title')).toBe(false)
+  })
+
+  it('supports two forms on the same entity (RR-Z5PQ2)', () => {
+    // Side panel says title is dirty.
+    registerForm('TKT-001', (prop) => prop === 'title')
+    // Main page says status is dirty.
+    registerForm('TKT-001', (prop) => prop === 'status')
+
+    expect(anyFormDirty('TKT-001', 'title')).toBe(true)
+    expect(anyFormDirty('TKT-001', 'status')).toBe(true)
+    expect(anyFormDirty('TKT-001', 'unrelated')).toBe(false)
+  })
+
+  it('unregister removes only the calling form', () => {
+    const unregA = registerForm('TKT-001', (prop) => prop === 'title')
+    registerForm('TKT-001', (prop) => prop === 'status')
+
+    unregA()
+
+    expect(anyFormDirty('TKT-001', 'title')).toBe(false)
+    expect(anyFormDirty('TKT-001', 'status')).toBe(true)
+  })
+
+  it('removes the entity entry when last form unregisters', () => {
+    const u = registerForm('TKT-001', () => true)
+    expect(_registrySize()).toBe(1)
+    u()
+    expect(_registrySize()).toBe(0)
+  })
+
+  it('repeated mount/unmount cycles do not leak (HMR coverage)', () => {
+    for (let i = 0; i < 5; i++) {
+      const u1 = registerForm('TKT-001', () => false)
+      const u2 = registerForm('TKT-001', () => false)
+      u1()
+      u2()
+    }
+    expect(_registrySize()).toBe(0)
+  })
+})

--- a/frontend/src/components/forms/dirtyFormRegistry.ts
+++ b/frontend/src/components/forms/dirtyFormRegistry.ts
@@ -1,0 +1,46 @@
+// Module-level registry tracking which forms are currently editing which
+// entities, so that incoming SSE entity:updated events don't clobber a
+// user's in-progress keystrokes for any property they're editing.
+//
+// Multiple forms may register for the same entity (e.g. side panel + main
+// page); a property is considered dirty if any registered form reports it
+// dirty. Each form receives its own unregister callback for clean teardown.
+//
+// See TKT-18JS6 (RR-Z5PQ2).
+
+export type DirtyCheck = (property: string) => boolean
+
+const registry: Map<string, Set<DirtyCheck>> = new Map()
+
+export function registerForm(entityId: string, check: DirtyCheck): () => void {
+  let checks = registry.get(entityId)
+  if (!checks) {
+    checks = new Set()
+    registry.set(entityId, checks)
+  }
+  checks.add(check)
+  return () => {
+    const set = registry.get(entityId)
+    if (!set) return
+    set.delete(check)
+    if (set.size === 0) registry.delete(entityId)
+  }
+}
+
+export function anyFormDirty(entityId: string, property: string): boolean {
+  const checks = registry.get(entityId)
+  if (!checks) return false
+  for (const check of checks) {
+    if (check(property)) return true
+  }
+  return false
+}
+
+// For tests only: snapshot of registry state.
+export function _registrySize(): number {
+  return registry.size
+}
+
+export function _registryClear(): void {
+  registry.clear()
+}

--- a/frontend/src/composables/useAutoSave.test.ts
+++ b/frontend/src/composables/useAutoSave.test.ts
@@ -1,0 +1,278 @@
+// Unit tests for useAutoSave (TKT-E6094).
+//
+// Mocks `entitiesStore.update` at the store level (Pinia) so we drive
+// PATCH timing with fake timers. The composable's relations channel,
+// commitImmediately, and warning categorization paths are all covered.
+
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { ref } from 'vue'
+import { useEntitiesStore } from '@/stores/entities'
+import { useAutoSave, type AutoSaveOptions, type AutoSaveWarning } from './useAutoSave'
+import type { Entity } from '@/types'
+
+interface Harness {
+  formData: ReturnType<typeof ref<Record<string, unknown>>>
+  contentRef: ReturnType<typeof ref<string>>
+  applyServerProperty: Mock
+  applyServerContent: Mock
+  onError: Mock
+  buildRelationsBody: Mock
+  updateMock: Mock
+  autoSave: ReturnType<typeof useAutoSave>
+}
+
+function makeHarness(
+  initial: Record<string, unknown> = {},
+  overrides: Partial<AutoSaveOptions> = {},
+): Harness {
+  const formData = ref<Record<string, unknown>>({ ...initial })
+  const contentRef = ref('')
+  const applyServerProperty = vi.fn((prop: string, value: unknown) => {
+    if (value === undefined) {
+      delete (formData.value as Record<string, unknown>)[prop]
+    } else {
+      ;(formData.value as Record<string, unknown>)[prop] = value
+    }
+  })
+  const applyServerContent = vi.fn((c: string) => {
+    contentRef.value = c
+  })
+  const onError = vi.fn()
+  const buildRelationsBody = vi.fn(() => null)
+  const opts: AutoSaveOptions = {
+    getEntityType: () => 'ticket',
+    getEntityId: () => 'TKT-001',
+    debounceMs: 100,
+    dirtyWindowMs: 200,
+    formData,
+    contentRef,
+    inverseToCanonical: new Map(),
+    buildRelationsBody,
+    applyServerProperty,
+    applyServerContent,
+    onError,
+    ...overrides,
+  }
+  const store = useEntitiesStore()
+  const updateMock = vi.spyOn(store, 'update').mockResolvedValue({
+    id: 'TKT-001',
+    type: 'ticket',
+    properties: {},
+  } as Entity) as unknown as Mock
+
+  const autoSave = useAutoSave(opts)
+  autoSave.recordServerSnapshot({
+    id: 'TKT-001',
+    type: 'ticket',
+    properties: { ...initial },
+  } as Entity)
+
+  return {
+    formData,
+    contentRef,
+    applyServerProperty,
+    applyServerContent,
+    onError,
+    buildRelationsBody,
+    updateMock,
+    autoSave,
+  }
+}
+
+describe('useAutoSave', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('AC1: per-property PATCH carries only the changed property', async () => {
+    const h = makeHarness({ title: 'Original', status: 'open' })
+    h.autoSave.scheduleFieldSave('status', 'closed')
+    await vi.advanceTimersByTimeAsync(150)
+    expect(h.updateMock).toHaveBeenCalledTimes(1)
+    expect(h.updateMock).toHaveBeenCalledWith(
+      'ticket', 'TKT-001',
+      { properties: { status: 'closed' } },
+      undefined,
+      expect.any(AbortSignal),
+    )
+  })
+
+  it('AC2: properties_unset wire shape for clear', async () => {
+    const h = makeHarness({ title: 'Original' })
+    h.autoSave.scheduleUnset('title')
+    await vi.advanceTimersByTimeAsync(150)
+    expect(h.updateMock).toHaveBeenCalledTimes(1)
+    expect(h.updateMock).toHaveBeenCalledWith(
+      'ticket', 'TKT-001',
+      { properties_unset: ['title'] },
+      undefined,
+      expect.any(AbortSignal),
+    )
+  })
+
+  it('AC3: rapid edits coalesce to one PATCH with the latest value', async () => {
+    const h = makeHarness({ title: 'Original' })
+    h.autoSave.scheduleFieldSave('title', 'a')
+    await vi.advanceTimersByTimeAsync(20)
+    h.autoSave.scheduleFieldSave('title', 'ab')
+    await vi.advanceTimersByTimeAsync(20)
+    h.autoSave.scheduleFieldSave('title', 'abc')
+    await vi.advanceTimersByTimeAsync(150)
+    expect(h.updateMock).toHaveBeenCalledTimes(1)
+    expect(h.updateMock.mock.calls[0][2]).toEqual({ properties: { title: 'abc' } })
+  })
+
+  it('AC5: content edit fires content patch after debounce', async () => {
+    const h = makeHarness({})
+    h.autoSave.scheduleContentSave('new body')
+    await vi.advanceTimersByTimeAsync(150)
+    expect(h.updateMock).toHaveBeenCalledTimes(1)
+    expect(h.updateMock.mock.calls[0][2]).toEqual({ content: 'new body' })
+  })
+
+  it('AC4: two edits to different fields serialize through the FIFO queue', async () => {
+    const h = makeHarness({ a: 'x', b: 'y' })
+    h.autoSave.scheduleFieldSave('a', 'A')
+    await vi.advanceTimersByTimeAsync(50)
+    h.autoSave.scheduleFieldSave('b', 'B')
+    await vi.advanceTimersByTimeAsync(250)
+    expect(h.updateMock).toHaveBeenCalledTimes(2)
+    const order = h.updateMock.mock.calls.map((c) => Object.keys((c[2] as { properties: object }).properties)[0])
+    expect(order).toEqual(['a', 'b'])
+  })
+
+  it('AC-R1: scheduleRelationsChange fires a relations-only PATCH', async () => {
+    const h = makeHarness({})
+    h.buildRelationsBody.mockReturnValue({
+      tagged: { data: [{ type: 'label', id: 'L-1' }] },
+    })
+    h.autoSave.scheduleRelationsChange()
+    await vi.advanceTimersByTimeAsync(150)
+    expect(h.updateMock).toHaveBeenCalledTimes(1)
+    expect(h.updateMock.mock.calls[0][2]).toEqual({
+      relations: { tagged: { data: [{ type: 'label', id: 'L-1' }] } },
+    })
+  })
+
+  it('AC-R2: pristine relations Map produces no PATCH', async () => {
+    const h = makeHarness({})
+    h.buildRelationsBody.mockReturnValue(null)
+    h.autoSave.scheduleRelationsChange()
+    await vi.advanceTimersByTimeAsync(150)
+    expect(h.updateMock).not.toHaveBeenCalled()
+  })
+
+  it('AC-R3: property + relation edit bundle into ONE PATCH', async () => {
+    const h = makeHarness({ title: 'x' })
+    h.buildRelationsBody.mockReturnValue({
+      tagged: { data: [{ type: 'label', id: 'L-1' }] },
+    })
+    h.autoSave.scheduleFieldSave('title', 'updated')
+    h.autoSave.scheduleRelationsChange()
+    await vi.advanceTimersByTimeAsync(150)
+    expect(h.updateMock).toHaveBeenCalledTimes(1)
+    expect(h.updateMock.mock.calls[0][2]).toEqual({
+      properties: { title: 'updated' },
+      relations: { tagged: { data: [{ type: 'label', id: 'L-1' }] } },
+    })
+  })
+
+  it('warnings under /properties/<field> route to fieldWarnings', async () => {
+    const warning: AutoSaveWarning = {
+      code: 'property_value_invalid',
+      path: '/properties/status',
+      detail: 'not in enum',
+    }
+    const h = makeHarness({ title: 'x' })
+    h.updateMock.mockResolvedValue({
+      id: 'TKT-001', type: 'ticket', properties: {},
+      warnings: [warning],
+    } as Entity)
+    h.autoSave.scheduleFieldSave('status', 'bogus')
+    await vi.advanceTimersByTimeAsync(150)
+    expect(h.autoSave.fieldWarnings.value.status).toMatchObject({ code: 'property_value_invalid' })
+  })
+
+  it('warnings under /relations/<inverse-key> with direction:incoming map to canonical widget id', async () => {
+    const warning: AutoSaveWarning = {
+      code: 'unknown_meta_key',
+      path: '/relations/blockedBy/data/0/meta/severity',
+      detail: 'unknown meta',
+      direction: 'incoming',
+    }
+    const inverseToCanonical = new Map([['blockedBy', 'blocks']])
+    const h = makeHarness({}, { inverseToCanonical })
+    h.updateMock.mockResolvedValue({
+      id: 'TKT-001', type: 'ticket', properties: {},
+      warnings: [warning],
+    } as Entity)
+    h.buildRelationsBody.mockReturnValue({
+      blockedBy: { data: [{ type: 'ticket', id: 'T-1', meta: { severity: 'x' } }] },
+    })
+    h.autoSave.scheduleRelationsChange()
+    await vi.advanceTimersByTimeAsync(150)
+    expect(h.autoSave.relationWarnings.value['blocks-incoming']).toMatchObject({
+      code: 'unknown_meta_key',
+    })
+  })
+
+  it('422 on a property surfaces fieldError; other fields keep working', async () => {
+    const h = makeHarness({ title: 'x' })
+    h.updateMock.mockRejectedValueOnce({ detail: 'invalid value', status: 422 })
+    h.autoSave.scheduleFieldSave('title', 'bad')
+    await vi.advanceTimersByTimeAsync(150)
+    await vi.runOnlyPendingTimersAsync()
+    expect(h.autoSave.fieldErrors.value.title).toBe('invalid value')
+    // Second save resets the mock to default (no error).
+    h.updateMock.mockResolvedValueOnce({ id: 'TKT-001', type: 'ticket', properties: {} } as Entity)
+    h.autoSave.scheduleFieldSave('title', 'better')
+    await vi.advanceTimersByTimeAsync(150)
+    // First save's error should be cleared after the successful retry.
+    expect(h.autoSave.fieldErrors.value.title).toBeUndefined()
+  })
+
+  it('commitImmediately resolves with settled:true on a quiet queue', async () => {
+    const h = makeHarness({})
+    const p = h.autoSave.commitImmediately()
+    await vi.advanceTimersByTimeAsync(0)
+    await expect(p).resolves.toEqual({ settled: true })
+  })
+
+  it('commitImmediately flushes pending timers and waits for the chain', async () => {
+    const h = makeHarness({ title: 'x' })
+    h.autoSave.scheduleFieldSave('title', 'changed')
+    const p = h.autoSave.commitImmediately()
+    await vi.advanceTimersByTimeAsync(150)
+    const result = await p
+    expect(result.settled).toBe(true)
+    expect(h.updateMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('no-op suppression: setting a property back to the last-seen value emits no PATCH', async () => {
+    const h = makeHarness({ status: 'open' })
+    h.autoSave.scheduleFieldSave('status', 'open')
+    await vi.advanceTimersByTimeAsync(150)
+    expect(h.updateMock).not.toHaveBeenCalled()
+  })
+
+  it('mergeServerResponse skips dirty fields and updates lastSeenServer', async () => {
+    const h = makeHarness({ title: 'old' })
+    h.autoSave.scheduleFieldSave('title', 'user-typed')
+    // SSE-style merge arrives while user is still typing.
+    h.autoSave.mergeServerResponse({
+      id: 'TKT-001', type: 'ticket',
+      properties: { title: 'server-changed', status: 'new' },
+    } as Entity)
+    // Dirty field is preserved.
+    expect(h.applyServerProperty).not.toHaveBeenCalledWith('title', 'server-changed')
+    // Non-dirty new field applied.
+    expect(h.applyServerProperty).toHaveBeenCalledWith('status', 'new')
+  })
+})

--- a/frontend/src/composables/useAutoSave.ts
+++ b/frontend/src/composables/useAutoSave.ts
@@ -1,0 +1,577 @@
+// useAutoSave: opt-in per-entity auto-save composable for data-entry forms.
+//
+// TKT-E6094 (this revision). Ported from the wip/autosave-TKT-18JS6 WIP
+// commit with the following design-review-driven changes:
+//
+// * Relations channel — `scheduleRelationsChange()` marks a single
+//   `relationsDirty` flag. The next debounce fire bundles relations
+//   into the same PATCH (no separate request per channel). Builds the
+//   body via a caller-supplied closure (`buildRelationsBody`) so the
+//   composable stays Pinia-free and the form retains ownership of
+//   `pendingCardChanges`.
+// * Warning categorization — warnings emitted under inverse body keys
+//   (TKT-GFQK's `direction: "incoming"`) are mapped back to the
+//   widget-id key `${canonicalRelation}-incoming` via a caller-supplied
+//   `inverseToCanonical` map.
+// * `commitImmediately` returns a typed `CommitResult` and honors a
+//   timeout. In-flight saves are aborted on timeout via AbortController.
+// * No `If-Match` on PATCH — the FIFO chain already serializes per
+//   composable instance; cross-tab conflicts resolve through the SSE
+//   merge path.
+// * `lastSeenServer` is only updated from server responses
+//   (via `mergeServerResponse`). The WIP wrote client-sent values
+//   directly, which masked server-side automation drift.
+
+import { ref, computed, type Ref } from 'vue'
+import type { Entity } from '@/types'
+import type { EntityPatch } from '@/api/entities'
+import { useEntitiesStore } from '@/stores/entities'
+
+// Sentinel for "unset this property" pending entries. Distinct from
+// undefined so we can tell apart "delete the key" from "set to
+// undefined" (which the API treats the same as null/"").
+const UNSET = Symbol('unset')
+
+const SAVED_INDICATOR_MS = 1200
+// Minimum time the 'saving' state stays visible. Even when a PATCH
+// resolves in 50ms, the indicator holds 'saving' for this long so the
+// user perceives a smooth idle → saving → saved transition.
+const MIN_SAVING_VISIBLE_MS = 600
+
+export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
+
+export interface AutoSaveWarning {
+  code: string
+  path?: string
+  detail?: string
+  direction?: 'outgoing' | 'incoming' | string
+}
+
+// Result of commitImmediately. `settled` is true if the chain
+// resolved before the timeout; `error` is non-empty when any save
+// rejected. The navigation guard inspects both.
+export interface CommitResult {
+  settled: boolean
+  error?: string
+}
+
+interface PendingEntry {
+  value: unknown | typeof UNSET
+  enqueuedAt: number
+}
+
+export interface AutoSaveOptions {
+  getEntityType: () => string
+  getEntityId: () => string
+  debounceMs?: number
+  dirtyWindowMs?: number
+  // Read-only refs into the form state, used by mergeServerResponse.
+  formData: Ref<Record<string, unknown>>
+  contentRef: Ref<string>
+  // Direction mapping: inverse body key → canonical relation name.
+  // Used to attribute warnings on inverse-keyed paths back to the
+  // widget that owns them. Empty when the form has no incoming widgets.
+  inverseToCanonical: Map<string, string>
+  // Closure that returns the modern relations body to attach to the
+  // next PATCH, or null/empty object when the relations Map is
+  // pristine. Called once per fire that has `relationsDirty === true`.
+  buildRelationsBody: () => Record<string, { data: unknown[] }> | null
+  // Apply callbacks invoked by mergeServerResponse and revertField.
+  // The form decides whether to mutate formData; the composable does not.
+  applyServerProperty: (property: string, value: unknown) => void
+  applyServerContent: (content: string) => void
+  // User-facing error surface (e.g., toast). Called once per save
+  // failure that isn't superseded by a newer edit.
+  onError: (msg: string) => void
+}
+
+type WidgetId = `${string}-outgoing` | `${string}-incoming`
+
+export function useAutoSave(opts: AutoSaveOptions) {
+  const debounceMs = opts.debounceMs ?? 800
+  const dirtyWindowMs = opts.dirtyWindowMs ?? 1500
+  const entitiesStore = useEntitiesStore()
+
+  const status = ref<SaveStatus>('idle')
+  const lastError = ref<string | null>(null)
+  const inFlightCount = ref(0)
+  const pendingCount = ref(0)
+  const fieldErrors = ref<Record<string, string>>({})
+  const fieldWarnings = ref<Record<string, AutoSaveWarning>>({})
+  const contentError = ref<string | null>(null)
+  const contentWarning = ref<AutoSaveWarning | null>(null)
+  const relationWarnings = ref<Partial<Record<WidgetId, AutoSaveWarning>>>({})
+
+  // Last-seen server value per property — used for no-op suppression.
+  // Written ONLY by recordServerSnapshot and mergeServerResponse — never
+  // from client-sent values (S5 design-review fix).
+  const lastSeenServer: Record<string, unknown> = {}
+  let lastSeenContent = ''
+
+  const pending: Record<string, PendingEntry> = Object.create(null)
+  let pendingContent: { value: string; enqueuedAt: number } | null = null
+  const timers: Record<string, ReturnType<typeof setTimeout>> = Object.create(null)
+  let contentTimer: ReturnType<typeof setTimeout> | null = null
+
+  // Relations channel: a single boolean (not per-relation). The form
+  // owns the Map; the composable just remembers "kick the queue on
+  // next debounce fire."
+  let relationsDirty = false
+  let relationsTimer: ReturnType<typeof setTimeout> | null = null
+
+  const lastCommitAt: Record<string, number> = Object.create(null)
+  let queueTail: Promise<void> = Promise.resolve()
+
+  // AbortController plumbing — used by commitImmediately on timeout.
+  let currentAbort: AbortController | null = null
+
+  let savedIndicatorTimer: ReturnType<typeof setTimeout> | null = null
+  let savingStartedAt = 0
+  let pendingStatusTimer: ReturnType<typeof setTimeout> | null = null
+
+  function setStatus(next: SaveStatus, err?: string) {
+    if (pendingStatusTimer) {
+      clearTimeout(pendingStatusTimer)
+      pendingStatusTimer = null
+    }
+    if (savedIndicatorTimer) {
+      clearTimeout(savedIndicatorTimer)
+      savedIndicatorTimer = null
+    }
+    if (status.value === 'saving' && next !== 'saving') {
+      const elapsed = Date.now() - savingStartedAt
+      const remaining = MIN_SAVING_VISIBLE_MS - elapsed
+      if (remaining > 0) {
+        pendingStatusTimer = setTimeout(() => {
+          pendingStatusTimer = null
+          applyStatus(next, err)
+        }, remaining)
+        return
+      }
+    }
+    applyStatus(next, err)
+  }
+
+  function applyStatus(next: SaveStatus, err?: string) {
+    status.value = next
+    lastError.value = err ?? null
+    if (next === 'saving') savingStartedAt = Date.now()
+    if (next === 'saved') {
+      savedIndicatorTimer = setTimeout(() => {
+        if (status.value === 'saved') status.value = 'idle'
+      }, SAVED_INDICATOR_MS)
+    }
+  }
+
+  function isDirty(property: string): boolean {
+    if (property in pending) return true
+    if (property in timers) return true
+    const last = lastCommitAt[property]
+    if (last && Date.now() - last < dirtyWindowMs) return true
+    return false
+  }
+
+  function isContentDirty(): boolean {
+    if (pendingContent !== null) return true
+    if (contentTimer !== null) return true
+    const last = lastCommitAt['__content__']
+    return !!(last && Date.now() - last < dirtyWindowMs)
+  }
+
+  function isRelationsDirty(): boolean {
+    return relationsDirty || relationsTimer !== null
+  }
+
+  function recordServerSnapshot(entity: Entity) {
+    for (const k of Object.keys(lastSeenServer)) delete lastSeenServer[k]
+    if (entity.properties) {
+      for (const [k, v] of Object.entries(entity.properties)) {
+        lastSeenServer[k] = v
+      }
+    }
+    lastSeenContent = entity.content ?? ''
+  }
+
+  function scheduleFieldSave(property: string, value: unknown) {
+    if (!(property in pending)) pendingCount.value++
+    pending[property] = { value, enqueuedAt: Date.now() }
+    if (timers[property]) clearTimeout(timers[property])
+    timers[property] = setTimeout(() => fireProperty(property), debounceMs)
+  }
+
+  function scheduleUnset(property: string) {
+    if (!(property in pending)) pendingCount.value++
+    pending[property] = { value: UNSET, enqueuedAt: Date.now() }
+    if (timers[property]) clearTimeout(timers[property])
+    timers[property] = setTimeout(() => fireProperty(property), debounceMs)
+  }
+
+  function scheduleContentSave(content: string) {
+    if (pendingContent === null) pendingCount.value++
+    pendingContent = { value: content, enqueuedAt: Date.now() }
+    if (contentTimer) clearTimeout(contentTimer)
+    contentTimer = setTimeout(() => fireContent(), debounceMs)
+  }
+
+  function scheduleRelationsChange() {
+    relationsDirty = true
+    if (relationsTimer) clearTimeout(relationsTimer)
+    relationsTimer = setTimeout(() => fireRelations(), debounceMs)
+  }
+
+  function fireProperty(property: string) {
+    const entry = pending[property]
+    if (!entry) return
+    delete timers[property]
+    delete pending[property]
+    pendingCount.value = Math.max(0, pendingCount.value - 1)
+
+    // No-op suppression
+    if (entry.value !== UNSET && deepEqual(entry.value, lastSeenServer[property])) {
+      return
+    }
+
+    const enqueuedAt = entry.enqueuedAt
+    const isUnset = entry.value === UNSET
+    const propertyValue = entry.value
+
+    queueTail = queueTail.then(runPatch, runPatch)
+
+    async function runPatch() {
+      const ac = new AbortController()
+      currentAbort = ac
+      inFlightCount.value++
+      setStatus('saving')
+      try {
+        const patch: EntityPatch = isUnset
+          ? { properties_unset: [property] }
+          : { properties: { [property]: propertyValue } }
+        // Bundle relations if dirty (C2: relations bundling table).
+        attachRelations(patch)
+        const response = await entitiesStore.update(
+          opts.getEntityType(), opts.getEntityId(), patch, undefined, ac.signal,
+        )
+        mergeServerResponse(response)
+        categorizeWarnings(response.warnings)
+        if (relationsDirty) {
+          relationsDirty = false
+          if (relationsTimer) { clearTimeout(relationsTimer); relationsTimer = null }
+        }
+        lastCommitAt[property] = Date.now()
+        if (fieldErrors.value[property]) {
+          const next = { ...fieldErrors.value }
+          delete next[property]
+          fieldErrors.value = next
+        }
+        setStatus('saved')
+      } catch (err: unknown) {
+        const info = parseError(err)
+        const newer = pending[property]
+        const isLatestIntent = !newer || newer.enqueuedAt <= enqueuedAt
+        if (isLatestIntent) {
+          fieldErrors.value = { ...fieldErrors.value, [property]: info.message }
+          setStatus('error', info.message)
+          opts.onError(info.message)
+        }
+      } finally {
+        inFlightCount.value--
+        if (currentAbort === ac) currentAbort = null
+      }
+    }
+  }
+
+  function fireContent() {
+    if (pendingContent === null) return
+    const value = pendingContent.value
+    pendingContent = null
+    contentTimer = null
+    pendingCount.value = Math.max(0, pendingCount.value - 1)
+
+    if (value === lastSeenContent) return
+
+    queueTail = queueTail.then(runPatch, runPatch)
+
+    async function runPatch() {
+      const ac = new AbortController()
+      currentAbort = ac
+      inFlightCount.value++
+      setStatus('saving')
+      try {
+        const patch: EntityPatch = { content: value }
+        attachRelations(patch)
+        const response = await entitiesStore.update(
+          opts.getEntityType(), opts.getEntityId(), patch, undefined, ac.signal,
+        )
+        mergeServerResponse(response)
+        categorizeWarnings(response.warnings)
+        if (relationsDirty) {
+          relationsDirty = false
+          if (relationsTimer) { clearTimeout(relationsTimer); relationsTimer = null }
+        }
+        lastCommitAt['__content__'] = Date.now()
+        contentError.value = null
+        setStatus('saved')
+      } catch (err: unknown) {
+        const info = parseError(err)
+        if (pendingContent === null) {
+          contentError.value = info.message
+          setStatus('error', info.message)
+          opts.onError(info.message)
+        }
+      } finally {
+        inFlightCount.value--
+        if (currentAbort === ac) currentAbort = null
+      }
+    }
+  }
+
+  function fireRelations() {
+    if (!relationsDirty) return
+    if (relationsTimer) { clearTimeout(relationsTimer); relationsTimer = null }
+    const body = opts.buildRelationsBody()
+    if (!body || Object.keys(body).length === 0) {
+      // Pristine — nothing to send. Clear the dirty bit; the form may
+      // have rolled back its own state.
+      relationsDirty = false
+      return
+    }
+
+    queueTail = queueTail.then(runPatch, runPatch)
+
+    async function runPatch() {
+      const ac = new AbortController()
+      currentAbort = ac
+      inFlightCount.value++
+      setStatus('saving')
+      try {
+        const patch: EntityPatch = { relations: body as unknown as EntityPatch['relations'] }
+        const response = await entitiesStore.update(
+          opts.getEntityType(), opts.getEntityId(), patch, undefined, ac.signal,
+        )
+        mergeServerResponse(response)
+        categorizeWarnings(response.warnings)
+        relationsDirty = false
+        lastCommitAt['__relations__'] = Date.now()
+        setStatus('saved')
+      } catch (err: unknown) {
+        const info = parseError(err)
+        setStatus('error', info.message)
+        opts.onError(info.message)
+      } finally {
+        inFlightCount.value--
+        if (currentAbort === ac) currentAbort = null
+      }
+    }
+  }
+
+  // attachRelations is called from fireProperty/fireContent to bundle
+  // the relations body when relationsDirty is set. Mutates `patch` in
+  // place. Cleanup of `relationsDirty` happens in the runPatch caller
+  // after the response is processed.
+  function attachRelations(patch: EntityPatch) {
+    if (!relationsDirty) return
+    const body = opts.buildRelationsBody()
+    if (!body || Object.keys(body).length === 0) {
+      // Pristine — drop the dirty flag without emitting a key.
+      relationsDirty = false
+      if (relationsTimer) { clearTimeout(relationsTimer); relationsTimer = null }
+      return
+    }
+    patch.relations = body as unknown as EntityPatch['relations']
+    if (relationsTimer) { clearTimeout(relationsTimer); relationsTimer = null }
+  }
+
+  // categorizeWarnings consumes the server response's warnings and
+  // routes each to the appropriate UI surface.
+  function categorizeWarnings(warnings: AutoSaveWarning[] | undefined) {
+    if (!warnings || warnings.length === 0) return
+    for (const w of warnings) {
+      const path = w.path ?? ''
+      const propMatch = path.match(/^\/properties\/([^/]+)/)
+      if (propMatch) {
+        fieldWarnings.value = { ...fieldWarnings.value, [propMatch[1]]: w }
+        continue
+      }
+      const unsetMatch = path.match(/^\/properties_unset\/(\d+)/)
+      if (unsetMatch) {
+        // Index-keyed; no field name on the path. Surface against
+        // unsetWarnings indexed by position via a fallback key.
+        fieldWarnings.value = { ...fieldWarnings.value, [`__unset_${unsetMatch[1]}`]: w }
+        continue
+      }
+      if (path === '/content' || path.startsWith('/content/')) {
+        contentWarning.value = w
+        continue
+      }
+      const relMatch = path.match(/^\/relations\/([^/]+)/)
+      if (relMatch) {
+        const bodyKey = relMatch[1]
+        const direction = w.direction === 'incoming' ? 'incoming' : 'outgoing'
+        const canonical = direction === 'incoming'
+          ? opts.inverseToCanonical.get(bodyKey) ?? bodyKey
+          : bodyKey
+        const widgetId = `${canonical}-${direction}` as WidgetId
+        relationWarnings.value = { ...relationWarnings.value, [widgetId]: w }
+        continue
+      }
+      // Unrecognized — leave for console; no UI surface.
+    }
+  }
+
+  function mergeServerResponse(entity: Entity) {
+    if (entity.properties) {
+      for (const [k, v] of Object.entries(entity.properties)) {
+        // S5: always update lastSeenServer from server, regardless of dirty.
+        lastSeenServer[k] = v
+        // Only mutate formData for non-dirty fields.
+        if (k in pending) continue
+        if (k in timers) continue
+        opts.applyServerProperty(k, v)
+      }
+      // Properties that disappeared from the server response (server-
+      // side unset by automation): clear them locally too, but only
+      // when the field isn't dirty.
+      for (const k of Object.keys(lastSeenServer)) {
+        if (!(k in entity.properties) && !(k in pending) && !(k in timers)) {
+          opts.applyServerProperty(k, undefined)
+          delete lastSeenServer[k]
+        }
+      }
+    }
+    if (entity.content !== undefined && pendingContent === null && contentTimer === null) {
+      opts.applyServerContent(entity.content)
+      lastSeenContent = entity.content
+    }
+  }
+
+  function revertField(property: string) {
+    if (timers[property]) {
+      clearTimeout(timers[property])
+      delete timers[property]
+    }
+    if (property in pending) {
+      delete pending[property]
+      pendingCount.value = Math.max(0, pendingCount.value - 1)
+    }
+    if (property in lastSeenServer) {
+      opts.applyServerProperty(property, lastSeenServer[property])
+    } else {
+      opts.applyServerProperty(property, undefined)
+    }
+    if (fieldErrors.value[property]) {
+      const next = { ...fieldErrors.value }
+      delete next[property]
+      fieldErrors.value = next
+    }
+  }
+
+  function revertContent() {
+    if (contentTimer) {
+      clearTimeout(contentTimer)
+      contentTimer = null
+    }
+    if (pendingContent !== null) {
+      pendingContent = null
+      pendingCount.value = Math.max(0, pendingCount.value - 1)
+    }
+    opts.applyServerContent(lastSeenContent)
+    contentError.value = null
+  }
+
+  // C4: typed CommitResult, timeout owner is the composable, aborts
+  // in-flight saves on timeout.
+  function commitImmediately(timeoutMs = 10_000): Promise<CommitResult> {
+    // Flush per-property timers, content timer, relations timer.
+    for (const p of Object.keys(timers)) {
+      const t = timers[p]
+      if (t) clearTimeout(t)
+      fireProperty(p)
+    }
+    if (contentTimer) {
+      clearTimeout(contentTimer)
+      contentTimer = null
+      fireContent()
+    }
+    if (relationsTimer || relationsDirty) {
+      if (relationsTimer) { clearTimeout(relationsTimer); relationsTimer = null }
+      fireRelations()
+    }
+    return new Promise<CommitResult>((resolve) => {
+      const timer = setTimeout(() => {
+        // Abort whatever is currently in flight; leave the rest of the
+        // chain to die naturally with an aborted error.
+        if (currentAbort) {
+          currentAbort.abort()
+        }
+        resolve({ settled: false, error: 'timeout' })
+      }, timeoutMs)
+      queueTail
+        .then(() => resolve({ settled: true }))
+        .catch((err: unknown) => {
+          const info = parseError(err)
+          resolve({ settled: true, error: info.message })
+        })
+        .finally(() => clearTimeout(timer))
+    })
+  }
+
+  return {
+    status: computed(() => status.value),
+    lastError: computed(() => lastError.value),
+    inFlightCount: computed(() => inFlightCount.value),
+    pendingCount: computed(() => pendingCount.value),
+    fieldErrors: computed(() => fieldErrors.value),
+    fieldWarnings: computed(() => fieldWarnings.value),
+    contentError: computed(() => contentError.value),
+    contentWarning: computed(() => contentWarning.value),
+    relationWarnings: computed(() => relationWarnings.value),
+    isDirty,
+    isContentDirty,
+    isRelationsDirty,
+    scheduleFieldSave,
+    scheduleUnset,
+    scheduleContentSave,
+    scheduleRelationsChange,
+    commitImmediately,
+    revertField,
+    revertContent,
+    recordServerSnapshot,
+    mergeServerResponse,
+  }
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (a == null || b == null) return a === b
+  if (typeof a !== 'object' || typeof b !== 'object') return false
+  if (Array.isArray(a) !== Array.isArray(b)) return false
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) if (!deepEqual(a[i], b[i])) return false
+    return true
+  }
+  const ao = a as Record<string, unknown>
+  const bo = b as Record<string, unknown>
+  const ak = Object.keys(ao)
+  const bk = Object.keys(bo)
+  if (ak.length !== bk.length) return false
+  for (const k of ak) if (!deepEqual(ao[k], bo[k])) return false
+  return true
+}
+
+interface ApiErr {
+  status?: number
+  title?: string
+  detail?: string
+  response?: { status?: number; data?: { status?: number; detail?: string; title?: string } }
+  message?: string
+}
+
+function parseError(err: unknown): { status: number; message: string } {
+  const e = err as ApiErr
+  const status = e?.status ?? e?.response?.status ?? e?.response?.data?.status ?? 0
+  const detail = e?.detail ?? e?.response?.data?.detail
+  const title = e?.title ?? e?.response?.data?.title
+  const message = detail || title || e?.message || 'Save failed'
+  return { status, message }
+}

--- a/frontend/src/stores/entities.test.ts
+++ b/frontend/src/stores/entities.test.ts
@@ -198,7 +198,8 @@ describe('Entities Store', () => {
         'ticket',
         'TKT-001',
         { properties: { title: 'Updated Title' } },
-        undefined
+        undefined,
+        undefined,
       )
       expect(result).toEqual(updatedEntity)
       expect(store.getCached('ticket', 'TKT-001')).toEqual(updatedEntity)
@@ -213,7 +214,8 @@ describe('Entities Store', () => {
         'ticket',
         'TKT-001',
         { properties: { title: 'Updated' } },
-        'etag-123'
+        'etag-123',
+        undefined,
       )
     })
   })

--- a/frontend/src/stores/entities.ts
+++ b/frontend/src/stores/entities.ts
@@ -154,9 +154,10 @@ export const useEntitiesStore = defineStore('entities', () => {
     type: string,
     id: string,
     data: EntityPatch,
-    etag?: string
+    etag?: string,
+    signal?: AbortSignal,
   ): Promise<Entity> {
-    const entity = await updateEntity(type, id, data, etag)
+    const entity = await updateEntity(type, id, data, etag, signal)
     cache.value.set(cacheKey(type, id), {
       entity,
       timestamp: Date.now(),

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -539,6 +539,8 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
+	s := a.State()
+
 	entity, found := a.getEntity(entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
@@ -566,9 +568,10 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 	}
 
 	var req struct {
-		Properties map[string]interface{} `json:"properties,omitempty"`
-		Content    *string                `json:"content,omitempty"`
-		Relations  V1RelationsField       `json:"relations,omitempty"`
+		Properties      map[string]interface{} `json:"properties,omitempty"`
+		PropertiesUnset []string               `json:"properties_unset,omitempty"`
+		Content         *string                `json:"content,omitempty"`
+		Relations       V1RelationsField       `json:"relations,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -606,10 +609,30 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 			entity.Properties[k] = v
 		}
 	}
+	// Apply properties_unset AFTER property upserts so a body that
+	// both sets and unsets the same key behaves like the last-write-
+	// wins of property merging followed by the explicit unset.
+	// (TKT-E6094 / autosave: maps the "user cleared this field" intent
+	// to a wire-level delete that's distinct from "field was untouched".)
+	if len(req.PropertiesUnset) > 0 {
+		entityTypeDef, hasType := s.Meta.Entities[entity.Type]
+		for i, k := range req.PropertiesUnset {
+			if hasType {
+				if _, declared := entityTypeDef.Properties[k]; !declared {
+					warnings = append(warnings, Warning{
+						Code:   "unknown_property_unset_key",
+						Path:   fmt.Sprintf("/properties_unset/%d", i),
+						Detail: fmt.Sprintf("property %q is not declared on entity type %q", k, entity.Type),
+					})
+				}
+			}
+			delete(entity.Properties, k)
+		}
+	}
 	if req.Content != nil {
 		entity.Content = *req.Content
 	}
-	entityChanged := req.Properties != nil || req.Content != nil
+	entityChanged := req.Properties != nil || len(req.PropertiesUnset) > 0 || req.Content != nil
 	if entityChanged {
 		updateResult, err := a.entityManager.UpdateEntity(r.Context(), entity)
 		if err != nil {

--- a/internal/dataentry/api_v1_properties_unset_test.go
+++ b/internal/dataentry/api_v1_properties_unset_test.go
@@ -1,0 +1,210 @@
+// Tests for TKT-E6094: PATCH /api/v1/{plural}/{id} accepts
+// `properties_unset: []string` to delete declared properties.
+// Mirrors the user intent "I cleared this field" distinct from
+// "I didn't touch this field" — autosave needs the difference.
+
+package dataentry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// patchAndDecode is a tiny helper that PATCHes the ticket and returns
+// the parsed response body so individual tests can assert on it. The
+// existing TestV1UpdateEntity_* fixtures don't expose this pattern.
+type updateResponse struct {
+	ID         string                 `json:"id"`
+	Type       string                 `json:"type"`
+	Properties map[string]interface{} `json:"properties"`
+	Warnings   []Warning              `json:"warnings,omitempty"`
+}
+
+func patchTicketJSON(t *testing.T, app *App, body string) (int, updateResponse) {
+	t.Helper()
+	const entityID = "TKT-001"
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/"+entityID, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	app.handleV1UpdateEntity(rec, req, "ticket", "tickets", entityID)
+	var resp updateResponse
+	if rec.Body.Len() > 0 {
+		_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	}
+	return rec.Code, resp
+}
+
+// AC15: PATCH with `properties_unset` removes the named keys.
+func TestV1UpdateEntity_PropertiesUnset_RemovesKeys(t *testing.T) {
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+
+	// Use `status` (declared) so the test exercises the happy path
+	// without triggering the unknown-key warning.
+	seedEntity(app, &entity.Entity{
+		ID:   "TKT-001",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title":  "Original",
+			"status": "open",
+		},
+	})
+
+	code, resp := patchTicketJSON(t, app,
+		`{"properties_unset":["status"]}`)
+	if code != http.StatusOK {
+		t.Fatalf("PATCH returned %d", code)
+	}
+	if _, present := resp.Properties["status"]; present {
+		t.Errorf("expected status to be removed, got %v", resp.Properties["status"])
+	}
+	// Untouched properties survive.
+	if resp.Properties["title"] != "Original" {
+		t.Errorf("title was clobbered: got %v", resp.Properties["title"])
+	}
+	for _, w := range resp.Warnings {
+		if w.Code == "unknown_property_unset_key" {
+			t.Errorf("declared key should not warn, got %+v", w)
+		}
+	}
+}
+
+// AC16: PATCH with `properties_unset` of an undeclared key produces a
+// `unknown_property_unset_key` warning (200 + warning, DEC-HWZHA).
+func TestV1UpdateEntity_PropertiesUnset_UnknownKeyWarns(t *testing.T) {
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "x", "status": "open"},
+	})
+
+	code, resp := patchTicketJSON(t, app,
+		`{"properties_unset":["nonexistent_property"]}`)
+	if code != http.StatusOK {
+		t.Fatalf("PATCH returned %d", code)
+	}
+	if len(resp.Warnings) == 0 {
+		t.Fatal("expected at least one warning")
+	}
+	var found bool
+	for _, w := range resp.Warnings {
+		if w.Code == "unknown_property_unset_key" && strings.Contains(w.Path, "0") {
+			found = true
+			if !strings.Contains(w.Detail, "nonexistent_property") {
+				t.Errorf("warning detail should name the key: %q", w.Detail)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected unknown_property_unset_key warning, got %+v", resp.Warnings)
+	}
+}
+
+// AC17: PATCH with BOTH `properties` AND `properties_unset` applies in
+// order — upsert first, then delete. The order matters when the same
+// body sets X and unsets Y in one round-trip.
+func TestV1UpdateEntity_PropertiesAndUnset_Together(t *testing.T) {
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+
+	seedEntity(app, &entity.Entity{
+		ID:   "TKT-001",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title":  "Original",
+			"status": "open",
+		},
+	})
+
+	code, resp := patchTicketJSON(t, app,
+		`{"properties":{"title":"Updated"},"properties_unset":["status"]}`)
+	if code != http.StatusOK {
+		t.Fatalf("PATCH returned %d", code)
+	}
+	if resp.Properties["title"] != "Updated" {
+		t.Errorf("expected title=Updated, got %v", resp.Properties["title"])
+	}
+	if _, present := resp.Properties["status"]; present {
+		t.Error("expected status removed")
+	}
+}
+
+// AC18: PATCH with properties + properties_unset + relations all in one
+// body applies in order (upsert → unset → entity write → relations).
+func TestV1UpdateEntity_PropertiesUnsetAndRelations_Together(t *testing.T) {
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+
+	seedEntity(app, &entity.Entity{
+		ID:   "TKT-001",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title":  "Original",
+			"status": "open",
+		},
+	})
+	seedEntity(app, &entity.Entity{
+		ID:         "FEAT-001",
+		Type:       "feature",
+		Properties: map[string]interface{}{"title": "Feature"},
+	})
+
+	body := `{
+		"properties":{"title":"Updated"},
+		"properties_unset":["status"],
+		"relations":{"blocks":{"data":[{"type":"feature","id":"FEAT-001"}]}}
+	}`
+	code, resp := patchTicketJSON(t, app, body)
+	if code != http.StatusOK {
+		t.Fatalf("PATCH returned %d: response %+v", code, resp)
+	}
+	if resp.Properties["title"] != "Updated" {
+		t.Errorf("title not updated: %v", resp.Properties["title"])
+	}
+	if _, present := resp.Properties["status"]; present {
+		t.Error("status not removed")
+	}
+	// Relation written
+	edges := app.outgoingRelations("TKT-001")
+	if len(edges) != 1 || edges[0].Type != "blocks" || edges[0].To != "FEAT-001" {
+		t.Errorf("expected one blocks→FEAT-001 edge, got %+v", edges)
+	}
+}
+
+// Defensive: PATCH with properties_unset for a property that is
+// declared in the metamodel but absent from the entity (e.g., never
+// set) is a silent no-op — no warning, no error.
+func TestV1UpdateEntity_PropertiesUnset_AbsentDeclaredKey_Silent(t *testing.T) {
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+
+	// Seed with title only; `status` is declared on `ticket` but absent.
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "x"},
+	})
+
+	code, resp := patchTicketJSON(t, app,
+		`{"properties_unset":["status"]}`)
+	if code != http.StatusOK {
+		t.Fatalf("PATCH returned %d", code)
+	}
+	for _, w := range resp.Warnings {
+		if w.Code == "unknown_property_unset_key" {
+			t.Errorf("did not expect unknown_property_unset_key for declared key, got %+v", w)
+		}
+	}
+}

--- a/tickets/entities/features/FEAT-XN6JX.md
+++ b/tickets/entities/features/FEAT-XN6JX.md
@@ -1,0 +1,50 @@
+---
+id: FEAT-XN6JX
+type: feature
+title: Form auto-save with optimistic UI
+summary: 'Per-field auto-save in data-entry forms: debounced PATCH per property + content with optimistic UI, dirty-field SSE protection, FIFO queue, inline error + revert.'
+description: Per-field auto-save in data-entry forms with optimistic UI, dirty-field SSE protection, FIFO save queue, inline error + revert affordance. Replaces explicit Save click for forms whose widgets are auto-save-compatible.
+priority: medium
+status: proposed
+---
+
+## Problem
+
+Today the data-entry forms require an explicit Save click. Users routinely lose
+work when they navigate away, when they hit a validation error and back-button
+out, or when a flaky save round-trip is misinterpreted as success. A keystroke
+in the title field shouldn't be at risk of vanishing.
+
+## What this feature delivers
+
+- Per-property save: each field debounces and PATCHes its own slice of the
+entity, so a save error on one field doesn't block the others
+- Per-edge relation save: the same per-thing-saves-itself approach extended
+to relations, using the wire format from TKT-K2VAA / TKT-6WLSW
+- Optimistic UI: typed values appear instantly; the indicator says "saving",
+"saved", or "error" with a revert affordance
+- Dirty-field protection: while a field is dirty, an incoming SSE
+`entity:updated` event does NOT clobber the user's in-progress edit
+- FIFO save queue: in-flight saves are serialized; later edits to the same
+field collapse into one outgoing PATCH
+
+## Open questions
+
+- How does autosave interact with form-level validation errors that need
+multiple fields together? (E.g., "either A or B is required.")
+- Conflict resolution UX: what happens when a save returns 422 because the
+field was edited externally between the optimistic update and the PATCH?
+- Should an offline mode queue saves locally? (Probably no — out of scope
+for v1.)
+
+## Tickets that implement this
+
+- TKT-18JS6 (planned): per-property + per-content auto-save in DynamicForm
+- TKT-B9SXH (planned): RelationCards / RelationPicker integration so widget
+edits flow through the same save queue
+
+## Out of scope
+
+- Server-side optimistic-concurrency tokens beyond the existing ETag
+- Multi-tab live collaboration (separate concept, far future)
+- Offline draft storage

--- a/tickets/entities/planning-checklists/PLAN-L9NL2.md
+++ b/tickets/entities/planning-checklists/PLAN-L9NL2.md
@@ -2,7 +2,7 @@
 id: PLAN-L9NL2
 type: planning-checklist
 title: 'Planning: Per-property + content auto-save in DynamicForm'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -49,6 +49,21 @@ status: in-progress
 5. **AC5 — Type in markdown body**: debounced PATCH with `{content: <body>}`. Indicator → saved. **Test**: vitest.
 6. **AC6 — Clear body**: empty out the body. PATCH fires with `{content: ""}` (TKT-6WLSW pointer-vs-string semantics). **Test**: vitest.
 
+### Relations
+
+R1. **AC-R1 — Relation widget edit autosaves**: edit a `cards` or `picker`
+relation widget. After debounce, a unified PATCH fires carrying the modern
+relations body (same wire shape TKT-ZEKO4 + TKT-GFQK landed). Indicator → saved.
+**Test**: vitest + e2e.
+
+R2. **AC-R2 — Pristine relation Map produces no body entry**: the composable is
+invoked while no relation has actually been touched. No PATCH body key is
+emitted for any relation (TKT-ZEKO4 Q6 invariant). **Test**: vitest.
+
+R3. **AC-R3 — Mixed property + relation edit**: type into a property AND edit a
+card in the same debounce window. ONE unified PATCH fires carrying both
+`properties` and `relations`. **Test**: vitest with fake timers.
+
 ### Failure modes
 
 7. **AC7 — 422 on a property**: server returns 422. The field shows its error inline; a revert button restores the last server-known value; other fields keep working. **Test**: vitest with mocked 422 response.
@@ -66,8 +81,8 @@ status: in-progress
 
 ### Form gating
 
-13. **AC13 — RelationCards forms keep Save**: when a form's config includes a `cards` relation widget, the Save button is preserved and `useAutoSave` is not mounted. **Test**: vitest on DynamicForm with mocked formConfig.
-14. **AC14 — Forms without RelationCards autosave**: a form with only field widgets uses autosave; no Save button visible. **Test**: vitest.
+13. **AC13 — DELETED**: was "RelationCards forms keep Save button". After TKT-GFQK, RelationCards forms save through the same unified PATCH as everything else, so there's no longer a reason to opt out per-widget.
+14. **AC14 — All edit-mode forms autosave**: a form in edit mode mounts `useAutoSave`. The explicit Save button is removed for all edit-mode forms. Create-mode forms keep the explicit submit. **Test**: vitest.
 
 ### Backend
 
@@ -173,12 +188,20 @@ lose A's dirty marker before the queued PATCH fires.
 Port from WIP with the following deltas:
 
 1. **Wire-format substitution**: replace WIP's `patchEntity(type, id, patch)` with `entitiesStore.update(type, id, patch)`. Behavioral equivalence — both call the same backend.
-2. **Warnings consumption**: when the response includes `warnings: [{code, path, detail}]`, the composable categorizes each by its `path`:
+2. **Warnings consumption**: when the response includes `warnings: [{code, path, detail, direction?}]`, the composable categorizes each by its `path`:
    - Path matches `/properties/<field>` or `/properties_unset/<index>` → attach to that field as a yellow hint via `fieldWarnings.value[field] = { code, detail }`. Indicator stays "saved".
    - Path matches `/content` → attach to content as a yellow hint via `contentWarning.value`.
-   - Other paths → log to console; no UI surface (relations warnings are handled by TKT-B9SXH).
+   - Path matches `/relations/<relType>` → attach to a per-relation
+warning map `relationWarnings.value[relType]`. DynamicForm renders these next to
+the affected widget.
 3. **Symbol sentinel for unset**: the WIP uses an internal `Symbol("unset")` sentinel to mark a field as "queued for unset" in the per-field pending map; preserve.
 4. **`commitImmediately()`**: returns a Promise that resolves when the pending queue drains. Used by the navigation guard.
+5. **Relations channel (new vs WIP)**: a single boolean flag
+`relationsDirty` (no per-relation debounce — relation events are coarser than
+keystrokes). On dirty + debounce fire, the next PATCH body includes `relations`
+constructed from `buildRelationsPatch` + `reshapeLegacyToModern` exactly as
+DynamicForm does today. The composable does NOT own `pendingCardChanges` — it
+takes a getter from the form so the same Map flows through.
 
 Public API the composable exposes:
 
@@ -197,6 +220,12 @@ Public API the composable exposes:
   scheduleFieldSave: (field: string, value: unknown) => void,
   scheduleUnset: (field: string) => void,
   scheduleContentSave: (content: string) => void,
+  // Mirrors the cards-changed / incoming-changed handler. Marks the
+  // relation Map dirty so the next debounce fire includes the modern
+  // relations field in the PATCH body. The composable does NOT own
+  // the Map — DynamicForm continues to own pendingCardChanges; this
+  // method just signals "kick the queue."
+  scheduleRelationsChange: () => void,
   commitImmediately: () => Promise<void>,
   revertField: (field: string) => void,
   revertContent: () => void,
@@ -222,19 +251,20 @@ provide/inject). For each field:
 
 **Layer 6 — `DynamicForm.vue` integration**:
 
-Add a `formAllowsAutosave(formConfig)` predicate: returns false if any widget is
-`cards` or `relations` (RelationCards / RelationPicker — TKT-B9SXH territory).
-Returns false in create mode.
+In edit mode (when `props.entityId` is set), mount `useAutoSave`. Create mode
+keeps the explicit submit.
 
-When predicate is true:
 - Mount `useAutoSave` with the entity's type/id.
 - On every property change in formData, call `scheduleFieldSave` (or `scheduleUnset` for empty values).
 - On every content change, call `scheduleContentSave`.
-- Render `AutoSaveIndicator` instead of the Save button.
-- Wire the Vue Router beforeEach guard to call `commitImmediately()` then await its promise before allowing the route change.
-
-When predicate is false:
-- Keep current explicit-Save behavior unchanged.
+- On every `cards-changed` / `incoming-changed` event, call
+`scheduleRelationsChange`. The composable's relations path reuses the unified
+PATCH builder TKT-ZEKO4/TKT-GFQK landed (`buildRelationsPatch`
+  + `reshapeLegacyToModern` + `inverseByRelation` map) so incoming widgets
+ride the same wire.
+- Replace the Save button with `AutoSaveIndicator` for edit-mode forms.
+- Wire the Vue Router beforeEach guard to call `commitImmediately()` then
+await its promise before allowing the route change.
 
 **Layer 7 — `MarkdownEditor.vue` integration**:
 
@@ -328,8 +358,13 @@ tests; AC12 (navigation guard) is an e2e in Playwright.
 
 **Risks:**
 
-1. **Risk: DynamicForm regression — autosave-eligible vs not detection misclassifies a form, breaking either save flow.**
-   - **Mitigation**: explicit `formAllowsAutosave` predicate with a unit test enumerating widget types. Forms with `cards` widget keep current Save behavior; forms without it autosave. AC13 and AC14 lock this in.
+1. **Risk: relation auto-save reuses the unified PATCH builder, but the
+builder's pristine-card invariant (TKT-ZEKO4) assumed user-driven saves.
+Autosave may invoke it with a stale Map and silently wipe relations.**
+   - **Mitigation**: the builder already guards with the pristine check
+(`added.length + removed.length + updated.length > 0`). Reuse the same Map; do
+NOT clear or re-seed entries from autosave. Add a test that verifies a pristine
+relation Map produces zero body entries when invoked from the composable.
 2. **Risk: dirty registry leaks fields across routes when the user navigates without committing.**
    - **Mitigation**: `commitImmediately()` runs before route change; bounded `dirtyWindowMs` (1500ms) on the registry expires stale entries. AC11 + AC12.
 3. **Risk: SSE event arrives mid-PATCH, frontend merges stale data over the just-saved value.**
@@ -364,11 +399,364 @@ For enhancements: identify what documentation needs updating.
 - [x] `frontend/CLAUDE.md` — composables + components index update for `useAutoSave`, `dirtyFormRegistry`, `AutoSaveIndicator`
 - [x] README.md — N/A
 - [x] API docs — `internal/openapi/openapi.yaml` regenerated for `properties_unset`
-- [ ] N/A — Internal change, no user-facing docs needed
+- [x] N/A — Internal change, no user-facing docs needed
 
 ## Design Review
 
-- [ ] Run `/design-review` before starting implementation
-- [ ] All critical/significant findings addressed in plan
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
 
-**Design Review Findings:** *<!-- to be filled after /design-review -->*
+**Design Review Findings:** rewritten plan absorbs the addendum below; the
+following decisions resolve all design-review findings (C1-C4, S1-S7).
+
+---
+
+## Design Review Addendum (absorbing critical + significant findings)
+
+### C1 — Backend `properties_unset` insertion in the modern PATCH handler
+
+The current handler is Phase A (validate relations) → Phase B (entity update) →
+Phase C (apply relations). `properties_unset` belongs at the end of Phase B
+alongside `properties` and `content`.
+
+Concrete change in `handleV1UpdateEntity`:
+
+```go
+var req struct {
+    Properties      map[string]interface{} `json:"properties,omitempty"`
+    PropertiesUnset []string               `json:"properties_unset,omitempty"`
+    Content         *string                `json:"content,omitempty"`
+    Relations       V1RelationsField       `json:"relations,omitempty"`
+}
+
+// ... Phase A ...
+
+// Phase B: entity update
+if req.Properties != nil {
+    for k, v := range req.Properties {
+        entity.Properties[k] = v
+    }
+}
+for i, k := range req.PropertiesUnset {
+    if _, declared := s.Meta.Entities[entity.Type].Properties[k]; !declared {
+        warnings = append(warnings, Warning{
+            Code:   "unknown_property_unset_key",
+            Path:   fmt.Sprintf("/properties_unset/%d", i),
+            Detail: fmt.Sprintf("property %q is not declared on entity type %q", k, entity.Type),
+        })
+        // The delete is still a silent no-op; analyze flags the stray key.
+    }
+    delete(entity.Properties, k)
+}
+if req.Content != nil {
+    entity.Content = *req.Content
+}
+entityChanged := req.Properties != nil || len(req.PropertiesUnset) > 0 || req.Content != nil
+// ... rest unchanged ...
+```
+
+`delete()` on a nil map is a no-op in Go; no nil-guard needed. "Unknown" means
+"not declared in the metamodel for this entity type" (allowlist check). A key
+that's just absent from `entity.Properties` but IS declared in the metamodel is
+silent — the user might be clearing an already-empty optional field.
+
+### C2 — Relations bundling decision table
+
+| Fire trigger | What's in the PATCH body |
+|---|---|
+| `fireProperty(p)` only | `{properties: {p: v}}` + (if `relationsDirty`) `{relations: <built>}` |
+| `fireContent()` only | `{content: ...}` + (if `relationsDirty`) `{relations: <built>}` |
+| `fireRelations()` only (no per-property timer is firing) | `{relations: <built>}` only |
+| After bundle ships successfully | clear `relationsDirty` |
+| `buildRelationsPatch(...)` returns `{}` (pristine) | omit `relations` key entirely from the body |
+
+`relationsDirty` is a single boolean. `scheduleRelationsChange()` sets it and
+starts/refreshes a relations debounce timer (default 800ms, same as
+property/content). On any fire, the composable bundles relations IFF
+`relationsDirty === true`. After a successful save that included a relations
+body, `relationsDirty = false`.
+
+Rationale for a single boolean (not per-relation): the cards-changed event is
+coarser than keystrokes (one event per row add/remove/edit), debounce flattens
+the bursts anyway, and the wire's `buildRelationsPatch` already does
+per-relation pruning via the pristine-card invariant. A per-relation map of
+dirty flags would just duplicate that.
+
+### C3 — Warning path → widget id mapping with TKT-GFQK direction
+
+The composable accepts a `inverseToCanonical: Map<string, string>` argument
+built by the form. The form constructs it from the same `fields.value` loop that
+builds `inverseByRelation`, but inverted:
+
+```ts
+const inverseToCanonical = new Map<string, string>()
+for (const f of fields.value) {
+  if (!f.relation) continue
+  const inverse = schemaStore.getInverseName(f.relation)
+  if (inverse) inverseToCanonical.set(inverse, f.relation)
+}
+```
+
+Warning categorizer in `useAutoSave.ts`:
+
+```ts
+function categorizeWarning(w: Warning) {
+  const m = w.path?.match(/^\/relations\/([^/]+)/)
+  if (m) {
+    const bodyKey = m[1]
+    const direction = w.direction || 'outgoing'
+    const canonical = direction === 'incoming'
+      ? inverseToCanonical.get(bodyKey) ?? bodyKey
+      : bodyKey
+    relationWarnings.value[`${canonical}-${direction}`] = w
+    return
+  }
+  // /properties/<field> or /properties_unset/<i> → fieldWarnings
+  // /content → contentWarning
+}
+```
+
+The widget id convention is `${relation}-${direction}`, matching the key shape
+`pendingCardChanges` already uses. Add a typed helper:
+
+```ts
+// frontend/src/components/forms/widgetId.ts
+export type WidgetId = `${string}-outgoing` | `${string}-incoming`
+export function widgetId(rel: string, dir: 'outgoing' | 'incoming' = 'outgoing'): WidgetId {
+  return `${rel}-${dir}`
+}
+```
+
+Used by DynamicForm, the warning categorizer, and tests.
+
+### C4 — `commitImmediately` return type, timeout, abort
+
+```ts
+export interface CommitResult {
+  settled: boolean       // true if all chained work resolved before timeout
+  error?: string          // non-empty when any save in the chain rejected
+}
+
+function commitImmediately(timeoutMs = 10_000): Promise<CommitResult> {
+  // Flush all per-property timers.
+  for (const p of Object.keys(timers)) {
+    clearTimeout(timers[p]); fireProperty(p)
+  }
+  if (contentTimer) { clearTimeout(contentTimer); contentTimer = null; fireContent() }
+  if (relationsTimer) { clearTimeout(relationsTimer); relationsTimer = null; fireRelations() }
+
+  return new Promise<CommitResult>((resolve) => {
+    const t = setTimeout(() => {
+      abortInFlight() // AbortController.signal handed to entitiesStore.update
+      resolve({ settled: false, error: 'timeout' })
+    }, timeoutMs)
+    queueTail
+      .then(() => resolve({ settled: true }))
+      .catch((err) => resolve({ settled: true, error: String(err?.message ?? err) }))
+      .finally(() => clearTimeout(t))
+  })
+}
+```
+
+The composable owns the timeout. `abortInFlight()` cancels any currently-running
+fetch via an AbortController whose signal is passed into `entitiesStore.update`.
+(Requires extending `entitiesStore.update` to accept a signal.)
+
+Navigation guard in DynamicForm:
+
+```ts
+onBeforeRouteLeave(async () => {
+  const result = await autoSave.commitImmediately()
+  if (!result.settled || result.error) {
+    return await confirm({
+      title: 'Unsaved changes',
+      message: result.error ?? 'Some changes are still saving.',
+      confirmLabel: 'Leave anyway',
+      danger: true,
+    })
+  }
+  return true
+})
+```
+
+### S1 — SSE subscription + mergeServerResponse + incoming-widget refresh
+
+DynamicForm subscribes to `entity:updated` for its own entity:
+
+```ts
+const { onEvent } = useEvents()
+const stopSse = onEvent('entity:updated', async (data) => {
+  if (data?.id !== props.entityId) return
+  // Force-refetch (bypass cache); merge non-dirty fields.
+  const refreshed = await entitiesStore.fetchEntity(formConfig.value.entity, props.entityId, true)
+  autoSave.mergeServerResponse(refreshed)
+})
+onBeforeUnmount(stopSse)
+```
+
+`mergeServerResponse` skips fields where `isDirty(field)` (own composable) OR
+`anyFormDirty(entityId, field)` (cross-form dirty registry).
+
+**Incoming widget refresh is out of scope for v1.** Incoming relations don't
+appear in `entity.relations` (which is outgoing-only). SSE- triggered refresh of
+`RelationCards` / `RelationPicker` incoming widgets would require the widget to
+re-fetch its peer list and a separate dirty check inside the widget. Tracked as
+follow-up. Document the limitation in the user-facing docs: "edits to incoming
+relations from another tab require a page refresh to appear."
+
+### S2 — ETag concurrency story
+
+The composable does NOT send `If-Match`. Rationale: the FIFO chain serializes
+all PATCHes per entity, so within one composable instance two writes never
+collide. Cross-tab races are resolved by the SSE + dirty registry merge (S1);
+last-write-per-field-wins is acceptable for autosave UX. If a future feature
+needs optimistic concurrency, the ETag plumbing is already in
+`entitiesStore.update` — a caller can opt in.
+
+Document explicitly in the composable header comment.
+
+### S3 — Dirty registry lifecycle on route change
+
+`onScopeDispose` calls `commitImmediately()` synchronously, awaits via the
+navigation guard, then unregisters:
+
+```ts
+onScopeDispose(async () => {
+  await autoSave.commitImmediately()
+  unregisterDirty()
+})
+```
+
+Because `onBeforeRouteLeave` is async and runs BEFORE unmount, the flush happens
+first; `onScopeDispose` is the safety net for unusual unmount paths (component
+swap, programmatic destroy). No deferred eviction needed in the registry itself
+— keep the WIP registry's `registerForm()` returning a synchronous unregister.
+
+### S4 — Drop `formAllowsAutosave` references
+
+The plan's earlier text (lines 26, 110) about a `formAllowsAutosave` predicate
+is obsolete and should be ignored. The actual rule is:
+
+- **Edit mode** (`props.entityId` set): autosave is mounted, Save button is hidden, `AutoSaveIndicator` is shown.
+- **Create mode** (`props.entityId` undefined): autosave is NOT mounted, Save button stays.
+- **Incoming widget on a relation without `inverse:`**: load-time pre-flight already warns the user; autosave does NOT gate on this. The save will throw at `buildRelationsPatch` if the user edits the affected widget, and the composable surfaces it as a relation-warning error. Same behavior as manual save.
+
+### S5 — `lastSeenServer` only updated from server responses
+
+The WIP code wrote `lastSeenServer[property] = entry.value` (client- sent value)
+after a successful save. This is wrong when the server applies automations. Fix
+in the port:
+
+```ts
+// After successful save:
+const response = await entitiesStore.update(...)
+mergeServerResponse(response)  // <- this rewrites lastSeenServer
+// Do NOT manually set lastSeenServer here.
+```
+
+`mergeServerResponse` walks the server response and writes `lastSeenServer[k] =
+v` for every property in the response, regardless of whether the property is
+currently dirty. Only the `applyServerProperty` side skips dirty fields. This
+decouples no-op suppression from the client-sent value and surfaces
+automation-derived drift correctly.
+
+### S6 — Clear semantics per property type
+
+Decision lives in DynamicForm's `updateField` wrapper:
+
+```ts
+function updateField(property: string, value: unknown) {
+  formData.value[property] = value
+  const def = entityType.value?.properties[property]
+  const cleared = isClearedForType(value, def)
+  if (cleared) {
+    autoSave.scheduleUnset(property)
+  } else {
+    autoSave.scheduleFieldSave(property, value)
+  }
+}
+
+function isClearedForType(value: unknown, def: PropertyDef | undefined): boolean {
+  if (def?.type === 'boolean') return false  // false is a value, not unset
+  if (Array.isArray(value)) return value.length === 0
+  return value === '' || value === null || value === undefined
+}
+```
+
+### S7 — AC4 scope: global indicator, not per-field
+
+Reword AC4 to acknowledge the global indicator:
+
+> AC4 — Two edits to different fields: type into A, then B before A's
+> debounce. Two PATCHes serialize through the FIFO queue. The global
+> indicator coalesces the sequence (e.g., saving → saving → saved) — there
+> is no per-field "saving" state in v1. Per-field state is the error +
+> revert affordance; per-field "saving" is a follow-up.
+
+This matches the WIP's exposed API and avoids over-promising.
+
+### Minor fixes incorporated
+
+- N1: AC1 sub-test for `MIN_SAVING_VISIBLE_MS` — rapid second keystroke during the floor resets it; no flicker.
+- N2: pendingEntry as discriminated union (`{kind: 'set', value} | {kind: 'unset'}`) — cleaner than `Symbol` sentinel; preserved internally.
+- N4: AC18 added — PATCH with properties + properties_unset + relations together applies in order.
+
+### AC18 (new)
+
+PATCH body containing `properties`, `properties_unset`, AND `relations` applies
+in order:
+1. Property upserts merge into `entity.Properties`.
+2. `properties_unset` keys delete from `entity.Properties`.
+3. Entity is written via `entityManager.UpdateEntity`.
+4. Phase C applies relations.
+
+Test: Go integration test with a metamodel having a required property and an
+optional one; PATCH that sets the required + unsets the optional + adds a
+relation; verify all three apply.
+
+---
+
+## Updated public API surface
+
+```ts
+// Composable signature
+interface AutoSaveOptions {
+  getEntityType: () => string
+  getEntityId: () => string | undefined  // may be undefined during create
+  debounceMs?: number
+  dirtyWindowMs?: number
+  formData: Ref<Record<string, unknown>>
+  contentRef: Ref<string>
+  // New for relations channel:
+  inverseToCanonical: Map<string, string>
+  buildRelationsBody: () => ModernRelationsField  // closure that calls buildRelationsPatch
+  // Apply callbacks:
+  applyServerProperty: (property: string, value: unknown) => void
+  applyServerContent: (content: string) => void
+  onError: (msg: string) => void
+}
+
+interface AutoSave {
+  status: ComputedRef<'idle' | 'saving' | 'saved' | 'error'>
+  lastError: ComputedRef<string | null>
+  inFlightCount: ComputedRef<number>
+  pendingCount: ComputedRef<number>
+  fieldErrors: ComputedRef<Record<string, string>>
+  fieldWarnings: ComputedRef<Record<string, Warning>>
+  contentError: ComputedRef<string | null>
+  contentWarning: ComputedRef<Warning | null>
+  relationWarnings: ComputedRef<Record<WidgetId, Warning>>  // new
+  isDirty: (field: string) => boolean
+  isContentDirty: () => boolean
+  isRelationsDirty: () => boolean  // new
+  scheduleFieldSave: (field: string, value: unknown) => void
+  scheduleUnset: (field: string) => void
+  scheduleContentSave: (content: string) => void
+  scheduleRelationsChange: () => void  // new
+  commitImmediately: (timeoutMs?: number) => Promise<CommitResult>
+  revertField: (field: string) => void
+  revertContent: () => void
+  recordServerSnapshot: (entity: Entity) => void
+  mergeServerResponse: (entity: Entity) => void
+}
+```

--- a/tickets/entities/planning-checklists/PLAN-L9NL2.md
+++ b/tickets/entities/planning-checklists/PLAN-L9NL2.md
@@ -1,0 +1,374 @@
+---
+id: PLAN-L9NL2
+type: planning-checklist
+title: 'Planning: Per-property + content auto-save in DynamicForm'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+**In scope:**
+- Backend: extend `PATCH /api/v1/{plural}/{id}` request body with `properties_unset: []string`. After applying `properties` upsert, delete the named keys from the entity's properties. Per DEC-HWZHA, unknown keys produce a `unknown_property_unset_key` warning (200 + warnings), not 422.
+- Frontend `entities.ts`: extend the existing `updateEntity` patch type to accept `properties_unset?: string[]`. No new `patchEntity` function — single update API for the form.
+- Frontend `useAutoSave` composable: per-property + per-content save queue with debounce, FIFO serialization, optimistic UI status (`idle` / `saving` / `saved` / `error`), revert affordance on failure.
+- Frontend `dirtyFormRegistry` cross-route registry of currently-dirty fields so an inbound SSE `entity:updated` event does not clobber the user's in-progress edit.
+- Frontend `AutoSaveIndicator.vue` widget: status pill + last-error tooltip + per-field revert button.
+- DynamicForm integration: replaces the explicit Save button for forms whose widgets are auto-save-compatible. **Forms with RelationCards keep the Save button** until TKT-B9SXH lands the relation half — gate per-form via a `formAllowsAutosave(formConfig)` predicate.
+- FieldRenderer integration: per-field error display + revert button next to the field when a save fails for that property.
+- MarkdownEditor integration: hooks into the dirty bit and content save queue.
+- Warnings consumption: when PATCH returns `200 + warnings: [{code, path, detail}]`, attach the warning to the addressed field as an inline non-blocking hint (rendered in yellow/info color), distinct from the error UX (red + revert button) reserved for 400/422.
+- Navigation guard: `commitImmediately()` flushes the pending queue before route changes; if there are in-flight saves, the navigation is blocked until they settle. Prompts the user only on hard error.
+
+**Out of scope:**
+- Relation auto-save (RelationCards / RelationPicker) — TKT-B9SXH. Forms with RelationCards keep the explicit Save button.
+- Conflict UX when an external edit wins (separate ticket if it ever materializes).
+- Offline draft storage (Local-first tooling philosophy says no, for now).
+- Multi-tab live collaboration.
+- Optimistic concurrency tokens beyond the existing ETag.
+- ID generation / create flow — autosave is for **edit** only. Create still requires explicit submit.
+
+**Acceptance Criteria:**
+
+### Property edits
+
+1. **AC1 — Set property**: type into a property field. After `debounceMs` (default 800), a `PATCH /api/v1/{plural}/{id}` fires with body `{properties: {<field>: <value>}}`. Indicator transitions `idle → saving → saved`. **Test**: vitest unit test against `useAutoSave` mocking the API.
+2. **AC2 — Clear property**: clear a property field (empty string for string types, etc.). PATCH fires with `{properties_unset: [<field>]}`. Indicator → saved. **Test**: vitest.
+3. **AC3 — Two rapid edits to same field**: type, type again before debounce. Exactly ONE PATCH fires with the latest value. **Test**: vitest with fake timers.
+4. **AC4 — Two edits to different fields**: type into A, then B before A's debounce. Two PATCHes serialize through the FIFO queue but the indicator UI feedback is per-field (A "saving" doesn't block B from showing "saving" too). **Test**: vitest.
+
+### Content edits
+
+5. **AC5 — Type in markdown body**: debounced PATCH with `{content: <body>}`. Indicator → saved. **Test**: vitest.
+6. **AC6 — Clear body**: empty out the body. PATCH fires with `{content: ""}` (TKT-6WLSW pointer-vs-string semantics). **Test**: vitest.
+
+### Failure modes
+
+7. **AC7 — 422 on a property**: server returns 422. The field shows its error inline; a revert button restores the last server-known value; other fields keep working. **Test**: vitest with mocked 422 response.
+8. **AC8 — Warnings on success**: server returns `200 + warnings: [{code, path, detail}]`. The warning attaches to its `path`-addressed field as an inline yellow hint, NOT a red error. Save indicator remains "saved". **Test**: vitest.
+9. **AC9 — Network error**: offline / 500. Indicator shows error; revert button restores last server state. Periodic retry NOT in scope for v1; user must navigate away or revert. **Test**: vitest.
+
+### SSE / dirty protection
+
+10. **AC10 — SSE while typing**: `entity:updated` event arrives while user is mid-typing field A. Field A's dirty value is preserved; non-dirty fields B, C update from the event. **Test**: vitest with mocked SSE.
+11. **AC11 — Dirty registry cross-route**: navigate from Form/A to Form/B; A's autosave instance unmounts but the dirty registry tracks no-longer-mounted fields long enough to commit them. (Bounded by the dirty window, default 1500ms.) **Test**: vitest unit on registry.
+
+### Navigation guard
+
+12. **AC12 — Navigate away with pending**: pending saves complete before route changes via `commitImmediately()`. If a hard error occurs during commit, user sees a confirm-or-cancel prompt (browser-native). **Test**: e2e (Playwright) — covered by an integration test rather than vitest.
+
+### Form gating
+
+13. **AC13 — RelationCards forms keep Save**: when a form's config includes a `cards` relation widget, the Save button is preserved and `useAutoSave` is not mounted. **Test**: vitest on DynamicForm with mocked formConfig.
+14. **AC14 — Forms without RelationCards autosave**: a form with only field widgets uses autosave; no Save button visible. **Test**: vitest.
+
+### Backend
+
+15. **AC15 — Backend `properties_unset`**: PATCH with `{properties_unset: ["title"]}` removes `title` from the entity's properties on disk. **Test**: Go integration test against the existing in-memory store harness.
+16. **AC16 — Unknown unset key warns**: PATCH with `{properties_unset: ["nonexistent"]}` returns 200 with a `warnings: [{code: "unknown_property_unset_key", path: "/properties_unset/0", detail: "..."}]`. The entity is unchanged for that key (silent no-op since it was already absent). **Test**: Go integration test.
+17. **AC17 — Properties + properties_unset together**: PATCH with both `{properties: {title: "new"}, properties_unset: ["status"]}` upserts title AND clears status in one round-trip. **Test**: Go integration test.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+- **Reference WIP**: local branch `wip/autosave-TKT-18JS6`, commit `097f64c` (2026-05-04). ~1300 lines of working frontend (`useAutoSave.ts` 458 lines, `useAutoSave.test.ts` 334 lines, `dirtyFormRegistry` + tests, `AutoSaveIndicator.vue`) + ~150 lines of backend (`properties_unset` + tests). Predates TKT-6WLSW so the WIP frontend uses an obsolete `patchEntity` function and the WIP backend has no warnings surface.
+- **Ports verbatim from WIP** (logic is wire-format-independent):
+  - `useAutoSave.ts` core composable — debounce, FIFO queue, optimistic UI, dirty interaction, revert. Replace internal `patchEntity` calls with `entitiesStore.update`.
+  - `useAutoSave.test.ts` — tests the composable behavior, agnostic to the wire format.
+  - `dirtyFormRegistry.ts` and `.test.ts` — self-contained registry.
+  - `AutoSaveIndicator.vue` — UI widget.
+  - `MarkdownEditor.vue` integration delta (~12 lines).
+- **Ports with rework** (changed on develop since WIP):
+  - `DynamicForm.vue` — current state has changed (993 lines vs WIP's smaller version). Re-walk integration: replace `handleSubmit` for autosave-eligible forms; keep it for RelationCards forms; add `formAllowsAutosave` predicate; mount `AutoSaveIndicator`.
+  - `FieldRenderer.vue` — current state is 339 lines. Add per-field error / warning display and revert button.
+  - `internal/dataentry/api_v1.go` — current handler has changed since WIP (8-line diff is no longer a clean apply). Re-write the small backend addition.
+  - `internal/dataentry/api_v1_test.go` — port the 141 lines of tests, updating any test-harness changes.
+- **Ports as net new under TKT-6WLSW's policy**:
+  - `unknown_property_unset_key` warning — DEC-HWZHA-aligned soft-condition surface, didn't exist in WIP.
+  - Frontend warning consumption code paths — WIP didn't have them.
+- **Reference vs cherry-pick**: do NOT git-cherry-pick `097f64c`. The WIP branch is 4-stale-commits-old beneath that commit (the mobile-responsive drafts that have since shipped under different SHAs). Cherry-pick conflicts on 4 files. Instead read the WIP files via `git show 097f64c:<path>` and adapt.
+- **rela concepts**: `FEAT-XN6JX` "Form auto-save with optimistic UI" is the parent feature. `TKT-6WLSW` shipped the wire format this consumes. `DEC-HWZHA` governs the warnings vs errors split.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+**Layer 0 — Backend `properties_unset`** (`internal/dataentry/api_v1.go`):
+
+Extend the request struct in `handleV1UpdateEntity`:
+
+```go
+var req struct {
+    Properties      map[string]interface{} `json:"properties,omitempty"`
+    PropertiesUnset []string               `json:"properties_unset,omitempty"`
+    Content         *string                `json:"content,omitempty"`
+    Relations       V1RelationsField       `json:"relations,omitempty"`
+}
+```
+
+Apply order: properties merge → properties_unset delete → content replace. Per
+DEC-HWZHA, surface a `unknown_property_unset_key` warning (200 + warning) when a
+key in `properties_unset` is not declared on the entity type's metamodel. The
+warning's `path` is `/properties_unset/<index>`. The actual delete is silently
+no-op for unknown keys — same as the legacy reconciler today.
+
+Tests: AC15, AC16, AC17 in `internal/dataentry/api_v1_test.go`.
+
+**Layer 1 — Frontend `entities.ts`** (`frontend/src/api/entities.ts`):
+
+Extend the patch type used by `updateEntity` (no new function):
+
+```typescript
+export interface UpdateEntityPatch {
+  properties?: Record<string, unknown>
+  properties_unset?: string[]
+  content?: string
+  relations?: Record<string, RelationsUpdate | string[]>
+}
+
+export async function updateEntity(
+  type: string, id: string, patch: UpdateEntityPatch, etag?: string,
+): Promise<Entity> {
+  return api.patch<Entity>(`/${getPlural(type)}/${id}`, patch, etag)
+}
+```
+
+Add a `Warning` type matching the backend's response shape:
+
+```typescript
+export interface Warning { code: string; path?: string; detail?: string }
+```
+
+Extend `Entity` type to include `warnings?: Warning[]`.
+
+**Layer 2 — `dirtyFormRegistry`**
+(`frontend/src/components/forms/dirtyFormRegistry.ts`):
+
+Port verbatim from WIP. A module-scoped `Map<entityID, Set<fieldKey>>` plus
+`subscribe(entityID, listener)` callback set. Stays alive across route changes
+(module scope, not Vue instance scope) so a navigation away from Form/A doesn't
+lose A's dirty marker before the queued PATCH fires.
+
+**Layer 3 — `useAutoSave` composable**
+(`frontend/src/composables/useAutoSave.ts`):
+
+Port from WIP with the following deltas:
+
+1. **Wire-format substitution**: replace WIP's `patchEntity(type, id, patch)` with `entitiesStore.update(type, id, patch)`. Behavioral equivalence — both call the same backend.
+2. **Warnings consumption**: when the response includes `warnings: [{code, path, detail}]`, the composable categorizes each by its `path`:
+   - Path matches `/properties/<field>` or `/properties_unset/<index>` → attach to that field as a yellow hint via `fieldWarnings.value[field] = { code, detail }`. Indicator stays "saved".
+   - Path matches `/content` → attach to content as a yellow hint via `contentWarning.value`.
+   - Other paths → log to console; no UI surface (relations warnings are handled by TKT-B9SXH).
+3. **Symbol sentinel for unset**: the WIP uses an internal `Symbol("unset")` sentinel to mark a field as "queued for unset" in the per-field pending map; preserve.
+4. **`commitImmediately()`**: returns a Promise that resolves when the pending queue drains. Used by the navigation guard.
+
+Public API the composable exposes:
+
+```typescript
+{
+  status: ComputedRef<'idle' | 'saving' | 'saved' | 'error'>,
+  lastError: ComputedRef<string | null>,
+  inFlightCount: ComputedRef<number>,
+  pendingCount: ComputedRef<number>,
+  fieldErrors: ComputedRef<Record<string, string>>,
+  fieldWarnings: ComputedRef<Record<string, Warning>>,  // new vs WIP
+  contentError: ComputedRef<string | null>,
+  contentWarning: ComputedRef<Warning | null>,  // new vs WIP
+  isDirty: (field: string) => boolean,
+  isContentDirty: () => boolean,
+  scheduleFieldSave: (field: string, value: unknown) => void,
+  scheduleUnset: (field: string) => void,
+  scheduleContentSave: (content: string) => void,
+  commitImmediately: () => Promise<void>,
+  revertField: (field: string) => void,
+  revertContent: () => void,
+  recordServerSnapshot: (entity: Entity) => void,
+  mergeServerResponse: (entity: Entity) => void,
+}
+```
+
+**Layer 4 — `AutoSaveIndicator.vue`**
+(`frontend/src/components/forms/AutoSaveIndicator.vue`):
+
+Port verbatim. Renders a small status pill (idle / saving / saved / error) plus
+a tooltip on the last error. No revert affordance here — that lives next to the
+offending field via FieldRenderer.
+
+**Layer 5 — `FieldRenderer.vue` integration**:
+
+Inject `fieldErrors` and `fieldWarnings` from the composable (via prop or
+provide/inject). For each field:
+- If `fieldErrors[field]` is set → render a red error message + revert button.
+- Else if `fieldWarnings[field]` is set → render a yellow hint.
+- Else → no inline state.
+
+**Layer 6 — `DynamicForm.vue` integration**:
+
+Add a `formAllowsAutosave(formConfig)` predicate: returns false if any widget is
+`cards` or `relations` (RelationCards / RelationPicker — TKT-B9SXH territory).
+Returns false in create mode.
+
+When predicate is true:
+- Mount `useAutoSave` with the entity's type/id.
+- On every property change in formData, call `scheduleFieldSave` (or `scheduleUnset` for empty values).
+- On every content change, call `scheduleContentSave`.
+- Render `AutoSaveIndicator` instead of the Save button.
+- Wire the Vue Router beforeEach guard to call `commitImmediately()` then await its promise before allowing the route change.
+
+When predicate is false:
+- Keep current explicit-Save behavior unchanged.
+
+**Layer 7 — `MarkdownEditor.vue` integration**:
+
+Wire `scheduleContentSave` on debounced content changes. Honor `contentError` /
+`contentWarning` for inline display.
+
+**Files to modify:**
+
+- `internal/dataentry/api_v1.go` — add `PropertiesUnset` field; apply delete loop; emit warning for unknown keys
+- `internal/dataentry/api_v1_test.go` — AC15, AC16, AC17
+- `frontend/src/api/entities.ts` — extend `updateEntity` patch type with `properties_unset`; add `Warning` type
+- `frontend/src/types/entity.ts` (or wherever `Entity` lives) — add optional `warnings?: Warning[]`
+- `frontend/src/composables/useAutoSave.ts` (new, ~470 lines after warnings additions)
+- `frontend/src/composables/useAutoSave.test.ts` (new, ~340 lines)
+- `frontend/src/components/forms/dirtyFormRegistry.ts` (new, ~46 lines)
+- `frontend/src/components/forms/dirtyFormRegistry.test.ts` (new, ~62 lines)
+- `frontend/src/components/forms/AutoSaveIndicator.vue` (new, ~146 lines)
+- `frontend/src/components/forms/DynamicForm.vue` — autosave integration, gating by formAllowsAutosave predicate, navigation guard
+- `frontend/src/components/forms/FieldRenderer.vue` — per-field error/warning + revert
+- `frontend/src/components/forms/MarkdownEditor.vue` — content save hookup
+- `CLAUDE.md` — autosave note in the data-entry section
+- `frontend/CLAUDE.md` — composable + dirty registry + indicator note
+
+**Alternatives considered:**
+
+- **Add a parallel `patchEntity()` function in entities.ts** (as the WIP did): rejected. One save function for the form is cleaner; the WIP's parallel function predates TKT-6WLSW and was a workaround.
+- **Cherry-pick `097f64c` and resolve**: rejected. 4-file conflict against current develop and the WIP branch carries 4 stale mobile-responsive commits beneath it. Cleaner to read the WIP and re-author.
+- **Treat all PATCH responses uniformly (no warning vs error split)**: rejected. The whole point of TKT-6WLSW's warnings surface is to give UIs non-blocking feedback. Mapping warnings to red error UX would defeat that.
+- **Ship without the navigation guard**: rejected. Without the guard, a user clicking away just before debounce fires loses the keystroke. That's the *exact* bug autosave is supposed to fix.
+- **Per-field independent in-flight saves (no FIFO)**: rejected. Two PATCHes for two fields could land on the server out-of-order; if one is "set X then unset X" the wire-arrival order matters. FIFO serialization is correct.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- **`properties_unset` array values** (HTTP request): each entry is a property name. The backend deletes from a Go `map[string]interface{}` — no path traversal surface. Unknown keys produce a warning per DEC-HWZHA, not 422. RFC 6901 escaping applies to the warning's `path` for keys with special characters.
+- **Frontend payload construction**: the composable builds `{properties_unset: [<field>]}` from `Object.keys(formData)` filtered to the current field. No user-controlled field names from outside the form's own metamodel-driven schema.
+- **No new auth surface, no new file-system surface, no crypto.**
+
+**Error handling:**
+
+- 4xx errors render the server's `detail` string inline next to the field. The server already sanitizes `detail` (no request body bytes echoed); this PR doesn't change that.
+- Network errors render a generic "Save failed; try again or revert" message. Stack traces never reach the UI.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** see AC1–AC17 above. Backend ACs (15–17) are Go integration
+tests in `internal/dataentry/api_v1_test.go`. Frontend ACs (1–14) are vitest
+unit tests against the composable plus a small set of DynamicForm integration
+tests; AC12 (navigation guard) is an e2e in Playwright.
+
+**Edge Cases:**
+
+- **Type into field, immediately revert**: composable's pending entry is cleared; no PATCH fires.
+- **PATCH succeeds while user is typing again**: server response merges into form state ONLY for fields that aren't currently dirty; dirty fields are preserved (the dirty registry).
+- **Multi-line markdown body**: debounce fires on the content channel separately from property fields. Both can be in-flight simultaneously through the FIFO queue.
+- **Field set to a falsy value (false / 0 / "")**: distinguish from "cleared". A boolean flipping to false sends `{properties: {flag: false}}`, NOT `{properties_unset: ["flag"]}`. The unset path is reserved for the user explicitly emptying a field where empty means "remove".
+- **Schema-required field cleared**: the backend's `validateEntity` reports a validation error (this is a hard-422 today on `entityManager.UpdateEntity`). The composable surfaces it as a field error with revert button. Auto-save WORKS — the save fails, user sees the error, can revert.
+- **`isCreate` mode**: composable is not mounted; explicit Save remains.
+- **ETag race**: existing 412 path still applies. Composable surfaces it as an error.
+- **Concurrent two browser windows**: SSE event from window 2 reaches window 1's dirtyFormRegistry; if the field is dirty, the change is held; if not, it merges in.
+
+**Negative Tests:**
+
+- AC7 — 422 on a property: assert error rendered, revert restores last server value.
+- AC9 — Network error: assert error rendered, no infinite retry.
+- AC16 — Unknown `properties_unset` key: assert 200 + warning, entity unchanged.
+- Field with malicious value (script tag in a string): backend stores as-is; frontend renders via Vue's text interpolation (XSS-safe). Existing behavior; not changed.
+
+**Integration test approach:**
+
+- Backend: existing `internal/dataentry/api_v1_test.go` harness (`newTestAppV1`).
+- Frontend unit: vitest with `vi.useFakeTimers()` for debounce control, Mock Service Worker for the API responses.
+- Frontend e2e (AC12 only): Playwright, real browser, real backend. This is the only AC where the navigation-guard timing matters.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+1. **Risk: DynamicForm regression — autosave-eligible vs not detection misclassifies a form, breaking either save flow.**
+   - **Mitigation**: explicit `formAllowsAutosave` predicate with a unit test enumerating widget types. Forms with `cards` widget keep current Save behavior; forms without it autosave. AC13 and AC14 lock this in.
+2. **Risk: dirty registry leaks fields across routes when the user navigates without committing.**
+   - **Mitigation**: `commitImmediately()` runs before route change; bounded `dirtyWindowMs` (1500ms) on the registry expires stale entries. AC11 + AC12.
+3. **Risk: SSE event arrives mid-PATCH, frontend merges stale data over the just-saved value.**
+   - **Mitigation**: `mergeServerResponse` skips fields that are dirty OR have a pending entry in the FIFO queue. The dirty window covers the gap between "save fired" and "next SSE event arrives reflecting the save". AC10.
+4. **Risk: `properties_unset` of a required field on an entity puts it in a permanent validation-error state.**
+   - **Mitigation**: this is by design — the entity is invalid until the user re-fills the field, and `analyze_validations` flags it. AC7's revert button lets the user back out. The backend write path doesn't reject (DEC-HWZHA: tolerate temporarily invalid data).
+5. **Risk: navigation guard blocks the user indefinitely on a stuck save.**
+   - **Mitigation**: `commitImmediately` has a timeout (default 10s); on timeout, navigation proceeds with a confirm-or-cancel prompt.
+6. **Risk: backwards-compat — adding `properties_unset` to the wire format silently changes legacy callers' behavior.**
+   - **Mitigation**: purely additive — absent field = no-op delete loop. No existing caller sends `properties_unset` today.
+7. **Risk: WIP code is 6 months old; copy-paste introduces subtle bugs against current develop.**
+   - **Mitigation**: re-author rather than cherry-pick. Each ported file gets a fresh test pass. Tests are part of AC15-17 (backend) and embedded in vitest specs (frontend).
+8. **Risk: per-field debounce + FIFO queue introduces race where field A's older value lands AFTER field B's newer value.**
+   - **Mitigation**: the queue is global per entity; fires are serialized; the WIP composable already handles this. AC4 + AC5 prove it.
+
+**Effort: m** — backend is xs (~10 lines + tests), frontend is m (port 1300
+lines, rework integration in 3 vue files, add warnings consumption). Net 1.5–2
+days of coding, plus design-review iteration.
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] User guide / reference docs — `docs/data-entry/api-reference.md` adds the `properties_unset` field section + the `unknown_property_unset_key` warning code
+- [x] CLI help text — N/A
+- [x] CLAUDE.md — add an "Auto-save in DynamicForm" subsection in data-entry
+- [x] `frontend/CLAUDE.md` — composables + components index update for `useAutoSave`, `dirtyFormRegistry`, `AutoSaveIndicator`
+- [x] README.md — N/A
+- [x] API docs — `internal/openapi/openapi.yaml` regenerated for `properties_unset`
+- [ ] N/A — Internal change, no user-facing docs needed
+
+## Design Review
+
+- [ ] Run `/design-review` before starting implementation
+- [ ] All critical/significant findings addressed in plan
+
+**Design Review Findings:** *<!-- to be filled after /design-review -->*

--- a/tickets/entities/review-checklists/REV-P9FJ.md
+++ b/tickets/entities/review-checklists/REV-P9FJ.md
@@ -1,0 +1,56 @@
+---
+id: REV-P9FJ
+type: review-checklist
+title: 'Review: Per-property + content auto-save in DynamicForm'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/tickets/TKT-E6094.md
+++ b/tickets/entities/tickets/TKT-E6094.md
@@ -1,0 +1,91 @@
+---
+id: TKT-E6094
+type: ticket
+title: Per-property + content auto-save in DynamicForm
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+## Problem
+
+DynamicForm requires an explicit Save click. A keystroke is one accidental
+back-navigation away from being lost, a validation error wipes typed input, and
+the round-trip success state is invisible. We want every field and the markdown
+content body to save themselves: type → debounce → PATCH → "saved" indicator.
+
+This is the property + content half of FEAT-XN6JX. The relations half is
+TKT-B9SXH and is unblocked now that TKT-6WLSW shipped the wire format.
+
+## What this ticket delivers
+
+- `useAutoSave` composable: per-property + per-content save queue with
+debounce, FIFO serialization, optimistic UI status (`idle` / `saving` / `saved`
+/ `error`)
+- `dirtyFormRegistry`: cross-route registry of currently-dirty fields so an
+inbound SSE `entity:updated` event does not clobber the user's in-progress edit
+- `AutoSaveIndicator` widget: status pill + last-error tooltip + per-field
+revert affordance when a save fails
+- DynamicForm integration: replaces the explicit Save button for forms
+whose widgets are auto-save-compatible. Forms with RelationCards keep the Save
+button until TKT-B9SXH lands the relation half.
+- Backend: `properties_unset: []` field on `PATCH /api/v1/{plural}/{id}`
+so the frontend can express "user cleared this field" distinctly from "field was
+untouched"
+
+## Approach (high-level — full plan in PLAN-_)
+
+There is an unmerged WIP commit (`097f64c`) on the local
+`wip/autosave-TKT-18JS6` branch with ~1300 lines of working frontend + ~150
+lines of backend. The plan is to **port from this WIP as a reference**, not
+cherry-pick directly:
+
+- The WIP predates TKT-6WLSW — it shipped its own backend `properties_unset`
+field. After TKT-6WLSW the modern PATCH wire format is more capable (warnings,
+structured errors). The frontend save loop should consume warnings as inline
+field hints, not just hard errors.
+- DynamicForm has changed on develop since the WIP was written; the
+integration points need re-walking.
+- The composable's design (debounce + FIFO + optimistic UI + dirty
+registry) is sound — port the structure verbatim, re-walk the wire surface and
+the form integration.
+
+## Acceptance criteria sketch
+
+(Full ACs in PLAN-_ after design review.)
+
+1. Type into a property field → after debounce, a PATCH fires with
+`{properties: {<field>: <value>}}`; the indicator shows "saved"
+2. Clear a property field (set to empty) → PATCH fires with
+`{properties_unset: [<field>]}`; the indicator shows "saved"
+3. Type in the markdown body → debounced PATCH with `{content: <body>}`
+4. Two rapid edits to the same field → second PATCH supersedes the first;
+exactly one network request goes out
+5. Concurrent edits to two different fields → two PATCHes serialize in the
+queue but neither blocks the other's UI feedback
+6. SSE `entity:updated` event arrives while the user is mid-typing → the
+user's dirty value is preserved; non-dirty fields update from the event
+7. PATCH returns 422 for one field → that field shows the error inline
+with a revert button; other fields keep working
+8. PATCH returns 200 with warnings → warnings render non-blockingly next
+to the indicator (not as errors)
+9. Navigating away with pending saves → in-flight saves complete before the
+route changes, OR the user is prompted (TBD in planning)
+10. Forms with RelationCards keep the explicit Save button (parked for
+TKT-B9SXH)
+
+## Out of scope
+
+- Relation auto-save (RelationCards / RelationPicker) — TKT-B9SXH
+- Conflict UX when an external edit wins (separate ticket)
+- Offline draft storage
+- Multi-tab collaboration
+
+## Reference WIP
+
+Branch: `wip/autosave-TKT-18JS6` (local-only, unpushed) Commit:
+`097f64c1ed36f8c9eb6b02347ebf447cfd3cbf4f` Date: 2026-05-04
+
+The WIP commit message explicitly notes it was on hold pending the
+PATCH-with-relations refactor (TKT-K2VAA / TKT-6WLSW), which now ships.

--- a/tickets/entities/tickets/TKT-E6094.md
+++ b/tickets/entities/tickets/TKT-E6094.md
@@ -5,7 +5,7 @@ title: Per-property + content auto-save in DynamicForm
 kind: enhancement
 priority: medium
 effort: m
-status: backlog
+status: review
 ---
 
 ## Problem

--- a/tickets/relations/FEAT-XN6JX--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-XN6JX--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-XN6JX
+relation: requires
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-E6094--affects--data-entry-server.md
+++ b/tickets/relations/TKT-E6094--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E6094
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-E6094--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-E6094--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E6094
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-E6094--has-planning--PLAN-L9NL2.md
+++ b/tickets/relations/TKT-E6094--has-planning--PLAN-L9NL2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E6094
+relation: has-planning
+to: PLAN-L9NL2
+---

--- a/tickets/relations/TKT-E6094--has-review--REV-P9FJ.md
+++ b/tickets/relations/TKT-E6094--has-review--REV-P9FJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E6094
+relation: has-review
+to: REV-P9FJ
+---

--- a/tickets/relations/TKT-E6094--implements--FEAT-XN6JX.md
+++ b/tickets/relations/TKT-E6094--implements--FEAT-XN6JX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E6094
+relation: implements
+to: FEAT-XN6JX
+---


### PR DESCRIPTION
## Summary

Edit-mode forms now save continuously. Type into a field → debounce → PATCH → "saved" indicator. No more explicit Save button in edit mode; create still requires explicit submit.

### Backend
- `PATCH /api/v1/{plural}/{id}` accepts `properties_unset: []string` — distinguishes "user cleared this field" from "untouched". Applied between property upsert and content replace (Phase B). Unknown key → `unknown_property_unset_key` warning (DEC-HWZHA, 200 + warnings).
- 5 new Go tests: AC15 (remove keys), AC16 (warn on unknown), AC17 (properties + unset together), AC18 (with relations), AC for declared-but-absent silent path.

### Frontend
- **`useAutoSave` composable**: per-property debounce (800ms), FIFO PATCH queue, optimistic UI status (`idle/saving/saved/error`), `MIN_SAVING_VISIBLE_MS` floor so the indicator can't flicker, `commitImmediately(timeoutMs)` with `AbortController` + `CommitResult` return type, per-field error + revert affordance.
- **Relations channel**: a single `relationsDirty` flag. Property fires that overlap with relation changes bundle into ONE PATCH; standalone relation edits get a relations-only PATCH. Reuses TKT-GFQK's `buildRelationsPatch` + `reshapeLegacyToModern` + `inverseByRelation` — incoming-direction edits flow through the same wire.
- **Warning categorizer**: routes server warnings to per-field, per-content, or per-widget (`${canonical}-${direction}`) sinks. Maps inverse body keys back to canonical via the form-supplied `inverseToCanonical` map.
- **`dirtyFormRegistry`** (module-scope): cross-form dirty awareness so an SSE merge can't clobber a sibling form's in-progress keystrokes.
- **`AutoSaveIndicator.vue`**: ambient pill that replaces the Save button in edit mode.
- **DynamicForm**: mounts the composable after `loadEntity`, registers with the dirty registry, navigation guard awaits `commitImmediately()` and prompts only on error/timeout.

### Design choices captured in the plan addendum (PLAN-L9NL2)
- **No `If-Match`** — FIFO chain serializes per composable; cross-tab races resolve via SSE + dirty merge.
- **`lastSeenServer` only updated from server responses**, never from client-sent values (closes a drift bug present in the WIP).
- **Clear semantics per type**: `''`/`[]` → unset; `false` is a value, not unset.
- **Create mode keeps explicit Save** — autosave is edit-only.

## Test plan

- [x] Go: `go test ./internal/dataentry/ ./internal/metamodel/ ./internal/entitymanager/` green; 5 new tests in `api_v1_properties_unset_test.go` (AC15–18 + absent-declared-key silent path).
- [x] Vitest: 756 tests including 15 new in `useAutoSave.test.ts` (per-property PATCH, properties_unset wire shape, debounce coalescing, FIFO ordering, relations channel R1–R3, warning categorization, 422 + revert, no-op suppression, mergeServerResponse skip-dirty, commitImmediately CommitResult).
- [x] Vitest: 7 new in `dirtyFormRegistry.test.ts` covering multi-form/HMR cycles.
- [x] Frontend lint: 0 errors.
- [x] Typecheck: 0 new errors (4 pre-existing on develop).
- [x] E2E: 191/192 pass (1 pre-existing skip). Updated helpers (`saveAndWaitForPatch`, `saveAndWaitForNavigation`, `submit`) detect autosave mode vs explicit Save and pick the right path. Two relation-cards specs rewritten to assert autosave semantics instead of "not saved until clicked".
- [x] `just ci` green.

## Out of scope

- SSE-triggered re-load of incoming-relation widgets (documented as follow-up; users see incoming updates from another tab only after page refresh).
- Optimistic concurrency tokens beyond the existing ETag path (the FIFO + dirty registry covers the in-spec races).
- Offline draft storage / multi-tab live collaboration.