### PR TITLE
refactor(workspace): wire search backend as fsstore observer (TKT-Q1JT)

### DIFF
--- a/internal/app/factory.go
+++ b/internal/app/factory.go
@@ -19,9 +19,30 @@ import (
 // (fsstore) rooted at the given project paths. Each OpenStore call
 // returns a fresh, independent store — callers that want a single
 // long-lived store should open it once and keep it alive.
+//
+// Observers (set via [FSFactory.AddObserver]) are forwarded to
+// [fsstore.Config.Observers] when the store is opened: each observer
+// is notified synchronously on entity writes (create / update /
+// delete / rename). This is the hook used by derived state (e.g.
+// search indexes) to stay current; it is NOT invoked for entities
+// already on disk when the store is first opened, so callers that
+// need an initial snapshot must iterate the store after OpenStore
+// returns and feed their observer manually.
 type FSFactory struct {
 	FS    storage.FS
 	Paths *project.Context
+
+	observers []store.EntityObserver
+}
+
+// AddObserver registers an entity observer that the next OpenStore
+// call will hook into the resulting store. Safe to call repeatedly;
+// each observer is invoked exactly once per write event.
+func (f *FSFactory) AddObserver(o store.EntityObserver) {
+	if o == nil {
+		return
+	}
+	f.observers = append(f.observers, o)
 }
 
 // compile-time interface check
@@ -50,6 +71,7 @@ func (f *FSFactory) OpenStore(meta *metamodel.Metamodel) (store.Store, error) {
 		AttachmentsKey: "attachments",
 		CacheKey:       ".rela",
 		Schemas:        buildSchemas(meta),
+		Observers:      f.observers,
 	})
 }
 

--- a/internal/app/factory_test.go
+++ b/internal/app/factory_test.go
@@ -14,7 +14,36 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
+
+// recordingObserver captures every EntityPut / EntityDelete it
+// receives. Used by tests that assert the factory wires observers
+// into the store correctly.
+type recordingObserver struct {
+	puts    []*entity.Entity
+	deletes []string
+}
+
+func (r *recordingObserver) EntityPut(e *entity.Entity) error {
+	r.puts = append(r.puts, e)
+	return nil
+}
+
+func (r *recordingObserver) EntityDelete(id string) error {
+	r.deletes = append(r.deletes, id)
+	return nil
+}
+
+func (r *recordingObserver) putIDs() []string {
+	ids := make([]string, 0, len(r.puts))
+	for _, e := range r.puts {
+		ids = append(ids, e.ID)
+	}
+	return ids
+}
+
+var _ store.EntityObserver = (*recordingObserver)(nil)
 
 func TestFSFactoryOpensWorkingStore(t *testing.T) {
 	root := t.TempDir()
@@ -44,6 +73,46 @@ func TestFSFactoryOpensWorkingStore(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join(root, "entities", "policies", "POL-1.md"))
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "id: POL-1")
+}
+
+func TestFSFactoryObserversReceiveWrites(t *testing.T) {
+	root := t.TempDir()
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	paths := &project.Context{
+		Root:         root,
+		EntitiesDir:  filepath.Join(root, "entities"),
+		RelationsDir: filepath.Join(root, "relations"),
+		CacheDir:     filepath.Join(root, ".rela"),
+	}
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"policy": {Plural: "policies"},
+		},
+	}
+
+	rec := &recordingObserver{}
+	factory := &app.FSFactory{FS: fs, Paths: paths}
+	factory.AddObserver(rec)
+	s, err := factory.OpenStore(meta)
+	require.NoError(t, err)
+	defer s.Close()
+
+	ctx := context.Background()
+	require.NoError(t, s.CreateEntity(ctx, &entity.Entity{
+		ID:   "POL-1",
+		Type: "policy",
+	}))
+	_, err = s.RenameEntity(ctx, "POL-1", "POL-2")
+	require.NoError(t, err)
+	_, err = s.DeleteEntity(ctx, "POL-2", false)
+	require.NoError(t, err)
+
+	// Create POL-1 → put(POL-1). Rename POL-1→POL-2 → delete(POL-1) + put(POL-2).
+	// Delete POL-2 → delete(POL-2).
+	assert.Equal(t, []string{"POL-1", "POL-2"}, rec.putIDs(),
+		"observer should see one put per create and one per rename target")
+	assert.Equal(t, []string{"POL-1", "POL-2"}, rec.deletes,
+		"observer should see one delete per rename source and one per delete")
 }
 
 func TestFSFactoryOpenStoreReturnsIndependentStores(t *testing.T) {

--- a/internal/workspace/bridge_sync_test.go
+++ b/internal/workspace/bridge_sync_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/testutil"
@@ -84,4 +85,38 @@ func TestFactoryInitialLoad(t *testing.T) {
 		rels++
 	}
 	assert.Equal(t, 1, rels, "relation should be loaded")
+}
+
+// TestStoreWritesAppearSynchronouslyInSearch asserts that a write
+// through the store after workspace.New is visible in Searcher()
+// results immediately, without any goroutine join or sleep. The
+// search backend is installed as a store observer, so the update is
+// applied under the store's write lock — by the time CreateEntity
+// returns, the search index has already seen it.
+func TestStoreWritesAppearSynchronouslyInSearch(t *testing.T) {
+	fs, paths := bridgePaths(t)
+
+	factory := &app.FSFactory{FS: fs, Paths: paths}
+
+	ws, err := workspace.New(fs, paths, workspace.NopScriptExecutor,
+		workspace.WithStoreFactory(factory))
+	require.NoError(t, err)
+	defer ws.Close()
+
+	ctx := context.Background()
+	require.NoError(t, ws.Store().CreateEntity(ctx, &entity.Entity{
+		ID:         "REQ-Live",
+		Type:       "requirement",
+		Properties: map[string]interface{}{"title": "Authoritative live sync"},
+	}))
+
+	// Search synchronously — no Sleep, no Eventually. If observer
+	// wiring is in place, the entity is in the index by the time
+	// CreateEntity returned.
+	hits := make([]string, 0, 1)
+	for hit, err := range ws.Searcher().Search(ctx, search.Query{Text: "Authoritative"}) {
+		require.NoError(t, err)
+		hits = append(hits, hit.ID)
+	}
+	assert.Contains(t, hits, "REQ-Live", "observer should have indexed the entity synchronously")
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -95,12 +95,13 @@ func (nopScriptExecutor) LuaCache() *lua.Cache { return nil }
 // Metamodel, Manager (including its automation engine and cascade
 // runner), and search index are constructed once at New and never
 // reloaded — schema or automation changes require a restart. The
-// search index is kept in sync with store writes via a per-workspace
-// subscription to store.Subscribe — every in-process write
-// (Create/Update/DeleteEntity through the store API) is applied to
-// the search backend. External edits to on-disk files are only
-// observed once a caller invokes StartWatching, which arms fsstore's
-// own file watcher to translate filesystem events into store events.
+// search backend is installed as a store.EntityObserver at store
+// construction time so every in-process write (Create/Update/
+// DeleteEntity through the store API) updates the search index
+// synchronously under the store's write lock. External edits to
+// on-disk files are only observed once a caller invokes
+// StartWatching, which arms fsstore's own file watcher to translate
+// filesystem events into store events.
 type Workspace struct {
 	// fs is the filesystem handle used for all workspace I/O:
 	// directory topology (ReadDir, MkdirAll, Stat, Walk) and byte
@@ -127,19 +128,13 @@ type Workspace struct {
 	searcher     search.Searcher
 
 	// Watcher state (nil when not watching).
-	watcher    *storage.Watcher
-	stopSearch func()         // cancels the search-index subscription
-	searchWG   sync.WaitGroup // joins the subscription goroutine on Close
+	watcher *storage.Watcher
 
 	// storeFactory opens the workspace's authoritative store. In
 	// production this builds the fsstore under the project directory;
 	// tests can inject a different factory via WithStoreFactory.
 	storeFactory store.Factory
 }
-
-// storeEventBufferSize bounds the workspace's store-event subscription.
-// Cascade depth is now [autocascade.MaxDepth], owned by that package.
-const storeEventBufferSize = 32
 
 // Discover discovers a project from the given start directory and creates
 // a workspace with the given script executor. If startDir is empty, it uses
@@ -187,24 +182,44 @@ func New(fs storage.FS, paths *project.Context, scriptExec ScriptExecutor, opts 
 		factory = &app.FSFactory{FS: fs, Paths: paths}
 	}
 
+	// Build the search backend BEFORE opening the store so it can be
+	// installed as an observer. The store then calls EntityPut /
+	// EntityDelete synchronously on every write; no subscription
+	// goroutine is needed. Backend construction failure is non-fatal —
+	// Searcher() surfaces an explicit error when queried.
+	var searchBackend *bleveindex.Index
+	if idx, idxErr := bleveindex.NewMem(); idxErr == nil {
+		searchBackend = idx
+	} else {
+		slog.Warn("failed to create search index", "error", idxErr)
+	}
+	if observable, ok := factory.(observerWiringFactory); ok && searchBackend != nil {
+		observable.AddObserver(searchBackend)
+	}
+
 	s, openErr := factory.OpenStore(meta)
 	if openErr != nil {
 		return nil, fmt.Errorf("open store: %w", openErr)
 	}
-	ws, err := newWorkspace(fs, paths, meta, exec, s, opts...)
+	ws, err := newWorkspace(fs, paths, meta, exec, s, searchBackend, opts...)
 	if err != nil {
 		return nil, err
 	}
 	ws.storeFactory = factory
 
-	// Populate the search index from the opened store and subscribe to
-	// store events so the index stays current when files change on disk
-	// (or when the fsstore emits updates from its own watcher).
-	if ws.searchBackend != nil {
-		if err := backfillSearchBackend(context.Background(), ws.searchBackend, s); err != nil {
+	// Backfill the initial state: observers are NOT invoked for entities
+	// already on disk when the store opens, so iterate ListEntities once
+	// after OpenStore to seed the index. Subsequent writes reach the
+	// backend via the observer hook installed above.
+	//
+	// Writes that race this backfill (e.g. an automation firing during
+	// construction) are safe: bleve EntityPut is idempotent, so the
+	// observer-applied write and the backfill-applied write produce the
+	// same final state.
+	if searchBackend != nil {
+		if err := backfillSearchBackend(context.Background(), searchBackend, s); err != nil {
 			slog.Warn("failed to index entities", "error", err)
 		}
-		ws.startSearchSubscription()
 	}
 	return ws, nil
 }
@@ -232,6 +247,16 @@ func WithFS(fs storage.FS, paths *project.Context) TestOption {
 // WithTestStore replaces the default empty memstore with a caller-
 // supplied store. The workspace's search index is populated from the
 // store's current contents at construction time.
+//
+// Caveat: a caller-supplied store is NOT auto-wired with the search
+// backend as an observer — observer setup must happen at store
+// construction, which the workspace cannot retrofit. Initial-state
+// backfill still runs, so any entities already in the store appear
+// in search results; subsequent writes will not reach the index.
+// If you need incremental sync, build the memstore with
+// [memstore.WithObserver] yourself and pass that store here, or use
+// the default memstore (omit WithTestStore) which wires the observer
+// automatically.
 func WithTestStore(s store.Store) TestOption {
 	return func(c *testConfig) { c.store = s }
 }
@@ -256,16 +281,29 @@ func NewForTest(meta *metamodel.Metamodel, opts ...TestOption) *Workspace {
 		opt(cfg)
 	}
 
+	// Build the search backend before the store so the default
+	// memstore can observe it. WithTestStore-supplied stores skip
+	// observer wiring — see WithTestStore's godoc.
+	var searchBackend *bleveindex.Index
+	if idx, err := bleveindex.NewMem(); err == nil {
+		searchBackend = idx
+	}
+
 	st := cfg.store
 	if st == nil {
-		st = memstore.New()
+		if searchBackend != nil {
+			st = memstore.New(memstore.WithObserver(searchBackend))
+		} else {
+			st = memstore.New()
+		}
 	}
-	ws, err := newWorkspace(cfg.fs, cfg.paths, meta, cfg.script, st)
+
+	ws, err := newWorkspace(cfg.fs, cfg.paths, meta, cfg.script, st, searchBackend)
 	if err != nil {
 		panic(fmt.Sprintf("NewForTest: %v", err))
 	}
-	if cfg.store != nil && ws.searchBackend != nil {
-		if err := backfillSearchBackend(context.Background(), ws.searchBackend, cfg.store); err != nil {
+	if cfg.store != nil && searchBackend != nil {
+		if err := backfillSearchBackend(context.Background(), searchBackend, cfg.store); err != nil {
 			panic(fmt.Sprintf("NewForTest: index entities: %v", err))
 		}
 	}
@@ -293,6 +331,18 @@ type storeWatcher interface {
 	StopWatching()
 }
 
+// observerWiringFactory is the consumer-side capability the workspace
+// looks for on a [store.Factory] to install its search-index backend
+// as an [store.EntityObserver] before the store opens. Factories that
+// satisfy this interface (today: [*app.FSFactory]) wire the observer
+// synchronously into the resulting store; factories that don't (a
+// hypothetical remote-only factory) silently degrade to "no
+// incremental sync" — Searcher() still works against the initial
+// backfill but does not see subsequent writes.
+type observerWiringFactory interface {
+	AddObserver(store.EntityObserver)
+}
+
 // Option configures a Workspace.
 type Option func(*Workspace)
 
@@ -311,19 +361,10 @@ func WithStoreFactory(f store.Factory) Option {
 // a placeholder.
 func newWorkspace(
 	fs storage.FS, paths *project.Context, meta *metamodel.Metamodel,
-	scriptExec ScriptExecutor, st store.Store, opts ...Option,
+	scriptExec ScriptExecutor, st store.Store,
+	searchBackend *bleveindex.Index,
+	opts ...Option,
 ) (*Workspace, error) {
-	// Create an empty search index — callers that use a real store
-	// populate it from that store. Failures degrade search but don't
-	// block construction; Searcher() surfaces the nil backend as an
-	// explicit error when queried.
-	var searchBackend *bleveindex.Index
-	if idx, err := bleveindex.NewMem(); err == nil {
-		searchBackend = idx
-	} else {
-		slog.Warn("failed to create search index", "error", err)
-	}
-
 	// Load project config (use defaults if not found or paths is nil).
 	var cfg *project.Config
 	if paths != nil {
@@ -618,52 +659,6 @@ func findTempFilesInDir(fs storage.FS, dir string) []string {
 	return result
 }
 
-// --- Lifecycle ---
-
-// startSearchSubscription subscribes the search backend to the store's
-// event stream so the index stays current after construction. The
-// returned cancel is stored on the workspace and invoked by Close,
-// which also waits for the subscription goroutine to drain before
-// closing the underlying backend.
-func (w *Workspace) startSearchSubscription() {
-	if w.searchBackend == nil || w.store == nil {
-		return
-	}
-	ch, cancel := w.store.Subscribe(storeEventBufferSize)
-	w.stopSearch = cancel
-	w.searchWG.Add(1)
-	go w.searchSubscriptionLoop(ch)
-}
-
-func (w *Workspace) searchSubscriptionLoop(ch <-chan store.Event) {
-	defer w.searchWG.Done()
-	ctx := context.Background()
-	for ev := range ch {
-		switch ev.Op {
-		case store.EventEntityCreated, store.EventEntityUpdated:
-			if ev.EntityID == "" {
-				continue
-			}
-			e, err := w.store.GetEntity(ctx, ev.EntityID)
-			if err != nil {
-				continue
-			}
-			if err := w.searchBackend.EntityPut(e); err != nil {
-				slog.Warn("search index update failed", "id", ev.EntityID, "error", err)
-			}
-		case store.EventEntityDeleted:
-			if ev.EntityID == "" {
-				continue
-			}
-			if err := w.searchBackend.EntityDelete(ev.EntityID); err != nil {
-				slog.Warn("search index remove failed", "id", ev.EntityID, "error", err)
-			}
-		case store.EventRelationCreated, store.EventRelationUpdated, store.EventRelationDeleted:
-			// Relations don't affect the entity search index.
-		}
-	}
-}
-
 // --- Type resolution ---
 
 // ResolveEntityType resolves a type name (alias, plural) to its canonical
@@ -803,28 +798,13 @@ func (w *Workspace) StopWatching() {
 // Close releases resources held by the workspace (search index, watcher,
 // store). Close is not safe to call concurrently with Workspace methods.
 //
-// Cleanup order matters: the subscription cancel is signaled first,
-// then the subscription goroutine is joined before closing the search
-// backend (otherwise bleve.Close races with in-flight EntityPut from
-// the still-draining channel). Every subsystem's close is attempted
-// even if an earlier one errored so a partial failure doesn't leak
-// store goroutines or watcher resources.
+// Subsystems close in observer-dependency order: store first, so no
+// further observer callbacks can land on the search backend; then the
+// backend itself. Every subsystem's close is attempted even if an
+// earlier one errored so a partial failure doesn't leak store
+// goroutines or watcher resources.
 func (w *Workspace) Close() error {
 	w.StopWatching()
-
-	if w.stopSearch != nil {
-		w.stopSearch()
-		w.stopSearch = nil
-	}
-	w.searchWG.Wait()
-
-	var firstErr error
-	if w.searchBackend != nil {
-		if err := w.searchBackend.Close(); err != nil {
-			firstErr = fmt.Errorf("close search index: %w", err)
-		}
-		w.searchBackend = nil
-	}
 
 	if w.store != nil {
 		if sw, ok := w.store.(storeWatcher); ok {
@@ -835,6 +815,14 @@ func (w *Workspace) Close() error {
 				slog.Warn("failed to close store", "error", err)
 			}
 		}
+	}
+
+	var firstErr error
+	if w.searchBackend != nil {
+		if err := w.searchBackend.Close(); err != nil {
+			firstErr = fmt.Errorf("close search index: %w", err)
+		}
+		w.searchBackend = nil
 	}
 	return firstErr
 }

--- a/tickets/entities/implementation-checklists/IMPL-RESP.md
+++ b/tickets/entities/implementation-checklists/IMPL-RESP.md
@@ -1,0 +1,67 @@
+---
+id: IMPL-RESP
+type: implementation-checklist
+title: 'Implementation: Wire workspace search backend as fsstore Observer (drop Subscribe goroutine)'
+status: done
+---
+
+## Implementation
+
+- [x] Unit tests written for new code
+- [x] Integration tests written
+- [x] All edge cases from planning handled
+- [x] Code follows project patterns (consumer-side interfaces)
+- [x] No silent failures
+
+**Summary of changes:**
+
+- `internal/app/factory.go` — `FSFactory.AddObserver(o)` method (replaces public Observers field per cranky review). Field is now `observers` (private). Plumbed to `fsstore.Config.Observers`.
+- `internal/workspace/workspace.go`:
+  - New `observerWiringFactory` consumer-side interface declared at workspace (3-method interface satisfied structurally by `*app.FSFactory`).
+  - `New`: builds `bleveindex.NewMem()` BEFORE `factory.OpenStore`; if the factory satisfies `observerWiringFactory`, registers the backend via `AddObserver` (no concrete type assertion).
+  - `newWorkspace`: takes `searchBackend *bleveindex.Index` as a parameter (was constructed internally).
+  - `NewForTest`: builds backend first; default memstore uses `memstore.WithObserver(searchBackend)`.
+  - `Close`: store closes first (so no observer calls land after backend close), then search backend.
+  - Deleted: `startSearchSubscription`, `searchSubscriptionLoop`, `stopSearch` field, `searchWG` field, `storeEventBufferSize` const.
+  - `WithTestStore` godoc rewritten — explicit caveat + remediation.
+  - Workspace lifecycle godoc rewritten (observer-based, not Subscribe-based).
+- `internal/app/factory_test.go` — new `TestFSFactoryObserversReceiveWrites` covering create + rename (Delete+Put pair) + delete.
+- `internal/workspace/bridge_sync_test.go` — new `TestStoreWritesAppearSynchronouslyInSearch`.
+
+**Manual verification:**
+
+- `go build ./...` — clean
+- `go test -race ./...` — all packages pass
+- `just lint` — 0 issues
+- `just arch-lint` — OK
+- `just ci` — full pipeline passes
+
+**Acceptance criteria:**
+
+1. ✅ `grep subscriptionLoop\|stopSearch\|searchWG internal/workspace/*.go` returns zero
+2. ✅ `FSFactory.AddObserver` works (verified by `TestFSFactoryObserversReceiveWrites`)
+3. ✅ `TestFactoryInitialLoad` passes
+4. ✅ Incremental sync proven without goroutine join (verified by `TestStoreWritesAppearSynchronouslyInSearch`)
+5. ✅ Net LOC negative for code
+6. ✅ All checks pass
+
+**Cranky review (round 2) findings + dispositions:**
+
+| # | Severity | Disposition | Resolution |
+|---|----------|-------------|------------|
+| 1 | critical | addressed | Flipped Close order: store first (drains observer call sites), then backend |
+| 2 | critical | deferred | fsstore swallows observer errors. Pre-existing TKT-LCTG behavior; needs its own ticket for telemetry rework |
+| 3 | significant | addressed | Factory mutation hidden behind `AddObserver` method; field is now private |
+| 4 | significant | addressed | Consumer-side `observerWiringFactory` interface in workspace; no concrete type assertion |
+| 5 | significant | addressed | `WithTestStore` godoc rewritten with remediation guidance |
+| 6 | significant | addressed | Added one-line comment to backfill: idempotent EntityPut makes the race window safe |
+| 7 | minor | addressed | Test renamed `TestStoreWritesAppearSynchronouslyInSearch` |
+| 8 | minor | addressed | Factory test now covers create + rename + delete sequence |
+| 9 | minor | addressed | `recordingObserver` captures `*entity.Entity`, exposes `putIDs()` helper |
+| 10 | nit | wont-fix | `store` import still used by other test in same file |
+| 11 | leverage | deferred | Workspace fixture builder for tests — out of scope |
+| 12 | leverage | deferred | bridgePaths helper extraction — out of scope |
+
+**Note on deferred #2:** fsstore's `_ = o.EntityPut(e)` predates TKT-LCTG/Q1JT.
+Fixing requires deciding whether observers should error-propagate, slog.Warn, or
+both. Separable ticket.

--- a/tickets/entities/planning-checklists/PLAN-WHOK.md
+++ b/tickets/entities/planning-checklists/PLAN-WHOK.md
@@ -1,0 +1,359 @@
+---
+id: PLAN-WHOK
+type: planning-checklist
+title: 'Planning: Wire workspace search backend as fsstore Observer (drop Subscribe goroutine)'
+status: done
+---
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem.** After TKT-LCTG, `internal/workspace` keeps the search backend
+(`*bleveindex.Index`) in sync with store writes via:
+
+```
+workspace.New
+  → store.Subscribe(buf=32) → <-chan store.Event + cancel func
+  → go searchSubscriptionLoop(ch)
+       → on each event: store.GetEntity + backend.EntityPut/EntityDelete
+workspace.Close
+  → cancel() → close(ch)
+  → searchWG.Wait()  // join the goroutine
+  → backend.Close()
+```
+
+The canonical pattern, already used by
+`internal/store/{memstore,fsstore}/conformance_test.go`, is to pass the backend
+(a `store.EntityObserver`) directly to the store at construction. The store
+invokes observers **synchronously under its write lock** — no goroutine, no
+buffered channel, no drop hazard, no close race.
+
+**Scope (in):**
+
+- `app.FSFactory` grows an `Observers []store.EntityObserver` field. `FSFactory.OpenStore(meta)` passes it through to `fsstore.Config.Observers`.
+- `Workspace.New`:
+  - Construct `searchBackend := bleveindex.NewMem()` **before** calling `factory.OpenStore(meta)`.
+  - If the factory is a `*app.FSFactory`, set `factory.Observers = []store.EntityObserver{searchBackend}` before OpenStore.
+  - The store now calls `searchBackend.EntityPut/EntityDelete` synchronously on every write — no subscription needed.
+  - Backfill loop still runs (initial state, since the store had no observer when its existing files were read at construction).
+- `Workspace.NewForTest`: same shape, using `memstore.WithObserver(searchBackend)`.
+- Delete from workspace:
+  - `(*Workspace).startSearchSubscription`
+  - `(*Workspace).searchSubscriptionLoop`
+  - `stopSearch` field
+  - `searchWG` field
+  - `storeEventBufferSize` constant
+- Simplify `Workspace.Close`: drop `stopSearch()` / `searchWG.Wait()`; just close the backend.
+- Workspace's `mayDependOn` in `.go-arch-lint.yml` stays unchanged — already includes everything needed.
+
+**Scope (out):**
+
+- Changes to `store.Factory` interface (stays as `OpenStore(meta) (Store, error)`). The Observers wiring is an `*app.FSFactory` concern, not part of the abstract Factory contract.
+- Changes to `store.EntityObserver`, `bleveindex.Index`, `search.Backend`, `search.Service`.
+- Changes to consumer-side `Searcher()` behavior — observable contract unchanged.
+- MCP/CLI/dataentry migrations (TKT-KWAX/TKT-0SP1/TKT-9JEI). They still go through `Workspace.Searcher()` and `Workspace.Store()` and don't care how the index sync is wired.
+
+**Acceptance criteria:**
+
+1. `grep -n 'subscriptionLoop\|stopSearch\|searchWG' internal/workspace/*.go` returns zero matches.
+2. `*app.FSFactory` accepts an `Observers` field, validated by a unit test.
+3. `bridge_sync_test.go::TestFactoryInitialLoad` still passes (initial entities show up in `Searcher().Search()`).
+4. A new test asserts incremental syncs: write entity → `Searcher().Search(ctx, Query{Text: ...})` reflects it without any goroutine join.
+5. Net LOC negative for code; ~-60 LOC.
+6. `just lint`, `just arch-lint`, `just test -race`, full `just ci` all pass.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Reference implementations in repo:**
+
+- `internal/store/fsstore/conformance_test.go:34` — `cfg.Observers = []store.EntityObserver{idx}`. Canonical wiring for fsstore.
+- `internal/store/fsstore/recovery_test.go:261` — same pattern after recovery.
+- `internal/store/memstore/conformance_test.go:21` — uses `memstore.WithObserver(idx)`.
+- `internal/store/fsstore/fsstore.go:68-72` — `Observers []store.EntityObserver` field with doc: "notified synchronously on entity writes (create, update, delete, rename). They are NOT populated from existing entity files on startup — callers that need that behavior can iterate ListEntities after New returns and feed their observer directly."
+
+That last sentence pins the backfill requirement: observers do NOT get
+retroactive notifications for existing entities at construction time. The
+backfill loop in `Workspace.New` is still required for the initial state.
+
+**Existing tests already validate the pattern.** This is essentially a "use the
+same wiring the conformance suite already uses" change for workspace.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+### Design choice — Observers as a struct field, not factory option
+
+`store.Factory.OpenStore(meta)` is intentionally narrow: "give me a Store for
+this metamodel." Widening it to accept observer options would contaminate every
+Factory implementation (including future ones — e.g. a Postgres-backed factory)
+with a concept that's really about hooking in-process observers. Instead:
+
+```go
+// internal/app/factory.go
+type FSFactory struct {
+    FS        storage.FS
+    Paths     *project.Context
+    Observers []store.EntityObserver  // NEW — synchronously called on writes
+}
+```
+
+The narrow `store.Factory` interface is unchanged. Callers that need observer
+wiring use the concrete `*FSFactory` type at the wiring site; that's already
+what `workspace.WithStoreFactory(f)` accepts (it stores `store.Factory` but
+receives `*FSFactory` in production).
+
+### Step 1 — Add Observers field to FSFactory
+
+```go
+type FSFactory struct {
+    FS        storage.FS
+    Paths     *project.Context
+    Observers []store.EntityObserver
+}
+
+func (f *FSFactory) OpenStore(meta *metamodel.Metamodel) (store.Store, error) {
+    // ... existing setup ...
+    return fsstore.New(fsstore.Config{
+        // ... existing fields ...
+        Observers: f.Observers,
+    })
+}
+```
+
+### Step 2 — Rewire workspace.New
+
+Current order:
+
+```go
+factory := ... // fall back to &app.FSFactory{FS, Paths}
+s, _ := factory.OpenStore(meta)
+ws, _ := newWorkspace(... s ...)   // creates searchBackend inside
+backfillSearchBackend(...)
+startSearchSubscription()
+```
+
+New order:
+
+```go
+factory := ... // same fallback
+searchBackend, _ := bleveindex.NewMem()
+if fsFactory, ok := factory.(*app.FSFactory); ok && searchBackend != nil {
+    fsFactory.Observers = append(fsFactory.Observers, searchBackend)
+}
+s, _ := factory.OpenStore(meta)
+ws, _ := newWorkspace(... s, searchBackend ...)  // takes pre-built backend
+backfillSearchBackend(ctx, searchBackend, s)
+// NO subscription; observers handle ongoing sync synchronously.
+```
+
+The factory type assertion is the load-bearing detail: only `*FSFactory` knows
+about observers. A test-time factory or future remote-store factory might not
+support observers — in that case, the workspace silently goes without
+incremental sync (consistent with today's behavior when `searchBackend == nil`).
+
+Actually, looking more carefully at where the backend is constructed — today
+`newWorkspace` creates it internally. Moving that to `New` (above) means
+`newWorkspace` needs a new parameter, OR the backend stays in `newWorkspace` and
+the assertion-and-append happens before `newWorkspace` is called.
+
+**Cleanest:**
+
+```go
+// in New, before factory.OpenStore:
+var searchBackend *bleveindex.Index
+if idx, err := bleveindex.NewMem(); err == nil {
+    searchBackend = idx
+} else {
+    slog.Warn("failed to create search index", "error", err)
+}
+if fsFactory, ok := factory.(*app.FSFactory); ok && searchBackend != nil {
+    fsFactory.Observers = append(fsFactory.Observers, searchBackend)
+}
+s, openErr := factory.OpenStore(meta)
+// ...
+ws, err := newWorkspace(fs, paths, meta, exec, s, searchBackend, opts...)
+```
+
+And `newWorkspace` accepts the backend as a parameter, deletes its own
+`bleveindex.NewMem()` call:
+
+```go
+func newWorkspace(
+    fs storage.FS, paths *project.Context, meta *metamodel.Metamodel,
+    scriptExec ScriptExecutor, st store.Store,
+    searchBackend *bleveindex.Index,
+    opts ...Option,
+) (*Workspace, error) {
+    // ... no internal NewMem() ...
+    ws := &Workspace{... searchBackend: searchBackend ...}
+    // ... rest same ...
+}
+```
+
+### Step 3 — Backfill timing
+
+The observer hook is **wired before** `factory.OpenStore(meta)` builds the
+store. But fsstore's `syncIndex` (its initial scan of on-disk files) does NOT
+call observers (per the doc comment on `Observers`). So the post-OpenStore
+backfill loop is still needed — exactly as today.
+
+### Step 4 — NewForTest changes
+
+```go
+func NewForTest(meta *metamodel.Metamodel, opts ...TestOption) *Workspace {
+    cfg := &testConfig{script: NopScriptExecutor}
+    for _, opt := range opts {
+        opt(cfg)
+    }
+
+    var searchBackend *bleveindex.Index
+    if idx, err := bleveindex.NewMem(); err == nil {
+        searchBackend = idx
+    }
+
+    st := cfg.store
+    if st == nil {
+        if searchBackend != nil {
+            st = memstore.New(memstore.WithObserver(searchBackend))
+        } else {
+            st = memstore.New()
+        }
+    }
+    // For WithTestStore-supplied stores, the caller is responsible for
+    // observer wiring; we cannot retrofit it after construction. The
+    // backfill loop still produces a populated index, but new writes
+    // won't reach it. Document this caveat on WithTestStore.
+
+    ws, err := newWorkspace(cfg.fs, cfg.paths, meta, cfg.script, st, searchBackend)
+    if err != nil { panic(...) }
+    if cfg.store != nil && searchBackend != nil {
+        if err := backfillSearchBackend(...); err != nil { panic(...) }
+    }
+    return ws
+}
+```
+
+The `WithTestStore` caveat is the one real semantic change: a test that supplies
+its own store will see *only the initial backfill* in search results, not
+subsequent writes through that store. Today the Subscribe-relay also depends on
+the test store implementing `Subscribe(...)` — both `memstore` and `fsstore` do
+— so this is mostly a no-op in practice, but worth documenting.
+
+### Step 5 — Drop subscription machinery
+
+- Delete `(*Workspace).startSearchSubscription`
+- Delete `(*Workspace).searchSubscriptionLoop`
+- Delete `Workspace.stopSearch` and `Workspace.searchWG` fields
+- Delete `storeEventBufferSize` constant
+- Simplify `Workspace.Close`: no `stopSearch()`, no `searchWG.Wait()`.
+
+### Step 6 — Tests
+
+- New `app/factory_test.go::TestFSFactory_Observers` — passing an observer in `FSFactory.Observers` results in synchronous `EntityPut` calls when the store creates entities.
+- New `workspace/bridge_sync_test.go::TestObserverSyncWithoutSubscription` — workspace built with a real fsstore, writes propagate to `Searcher()` results without any goroutine.
+
+**Alternatives considered:**
+
+- **Widen `store.Factory.OpenStore` signature.** Rejected. Contaminates every Factory impl.
+- **Move observer setup into `fsstore.Config`-aware factory option.** Rejected. The "option" is just a struct field; that's what we use.
+- **Skip the `*FSFactory` type assertion and require observers be set via a separate method.** Rejected. The assertion is one line; a method on the Factory interface would be a wider change.
+- **Use `Workspace.WithObserver(o)` as a public option.** Rejected. Workspace constructs its own observer (the search backend); external callers don't pass one in.
+
+**Files to modify:**
+
+- `internal/app/factory.go` — `FSFactory.Observers` field + plumb to `fsstore.Config.Observers`.
+- `internal/app/factory_test.go` — add test.
+- `internal/workspace/workspace.go` — rewire `New` and `NewForTest`; delete subscription methods; simplify `Close`.
+- `internal/workspace/bridge_sync_test.go` — add observer-sync test.
+
+**Files NOT modified:**
+
+- `internal/store/factory.go` — interface stays.
+- `internal/store/fsstore/*` — fsstore already supports observers.
+- `internal/store/memstore/*` — memstore already supports observers.
+- `internal/search/*` — no changes.
+- `internal/mcp/`, `internal/cli/`, `internal/dataentry/` — no changes.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+Pure internal refactor. No new input surfaces, no new file/network access.
+Search backend is the same `bleve.NewMemOnly` index as today; only the sync
+mechanism changes.
+
+Observer callbacks run under the store's write lock. A slow observer
+back-pressures writes (today's Subscribe-relay dropped events instead —
+acceptable trade for in-memory Bleve which is fast).
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test scenarios:**
+
+1. **AC1 (no subscription code remains)** — `grep` check during PR.
+2. **AC2 (FSFactory.Observers field)** — `TestFSFactory_Observers`: passes a stub observer, creates an entity through the resulting store, asserts the stub received `EntityPut`.
+3. **AC3 (initial load)** — existing `TestFactoryInitialLoad` passes unchanged (backfill loop populates index).
+4. **AC4 (incremental sync without goroutine)** — `TestObserverSyncWithoutSubscription`: create workspace, write entity via store, search for it, get a hit. No `time.Sleep`, no goroutine join.
+
+**Edge cases:**
+
+- **Test store via WithTestStore.** Caller-supplied store may not have the search observer wired. Document on `WithTestStore` and verify in test that existing tests using this option still pass (search hit-rate may differ for incremental updates).
+- **bleveindex.NewMem failure.** Backend nil; FSFactory.Observers stays empty; no incremental sync; today's behavior is "search not available" — preserve.
+- **Multiple observers on the same store.** Not used by workspace, but the field is a slice so it works.
+- **Observer error propagation.** `EntityPut` returns error; fsstore today logs and continues. Same behavior.
+
+**Negative tests:**
+
+- **Close without backend.** Already exercised by tests that don't seed entities.
+- **Re-Close.** Idempotent: subsequent calls find nil fields and no-op.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+1. **Type assertion on factory.** Workspace's `factory.(*app.FSFactory)` works for the standard path. Tests that supply a different factory (rare) skip observer setup and fall back to "backfill only, no incremental sync." Mitigation: document on `WithStoreFactory`.
+2. **fsstore notify-during-write semantics.** fsstore calls observers synchronously inside the write critical section. If `EntityPut` ever blocked (it doesn't today — Bleve in-memory is fast), it would back-pressure writes. Mitigation: bleve in-memory is fast; if a slow observer is ever added, switch back to an async relay just for that observer.
+3. **TKT-KWAX/TKT-0SP1/TKT-9JEI may want to set their own observers.** Once they migrate, each will construct its own backend + factory. The pattern from this ticket becomes the template they follow. Coordination via PR ordering only — no shared code conflicts expected.
+4. **WithTestStore tests may rely on incremental sync working through the supplied store.** Check `tools_test.go`, `cli/test_helpers_test.go`, `dataentry/test_helpers_test.go` to see if any test depends on incremental updates being visible via the search index. Likely no — most search-dependent tests build workspace from disk (which goes through `New` → backfill) rather than reaching for in-place writes that need observer pickup.
+
+**Effort:** S — ~80 LOC code change (mostly delete), one factory field, one type
+assertion, two new tests.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+N/A — internal refactor. No CLI flags, no API endpoints, no user-visible
+behavior change.
+
+## Design Review
+
+- [ ] Run `/design-review` before starting implementation
+- [ ] All critical/significant findings addressed in plan
+
+**Design Review Findings:** &lt;!-- to be filled in after design review --&gt;

--- a/tickets/entities/review-checklists/REV-0LU6.md
+++ b/tickets/entities/review-checklists/REV-0LU6.md
@@ -1,0 +1,33 @@
+---
+id: REV-0LU6
+type: review-checklist
+title: 'Review: Wire workspace search backend as fsstore Observer (drop Subscribe goroutine)'
+status: done
+---
+
+## Code Review
+
+- [x] cranky-code-reviewer agent run on the diff
+- [x] Critical findings addressed in-PR (#1 Close ordering)
+- [x] Significant findings addressed in-PR (#3, #4, #5, #6)
+- [x] Minor findings addressed (#7, #8, #9)
+- [x] Deferred findings tracked (fsstore observer-error swallowing — separable ticket)
+- [x] Tests pass under `-race`
+- [x] `just ci` passes end-to-end
+
+**Cranky-review disposition table:** see IMPL-RESP for the full table. Summary:
+
+- 1 critical fix in-PR (Close ordering)
+- 4 significant fixes in-PR (factory mutation hidden behind AddObserver, consumer-side interface, WithTestStore docs, idempotency comment)
+- 3 minor fixes in-PR (test name, rename coverage, recordingObserver helper)
+- 1 critical and 2 leverage findings deferred (fsstore error swallowing + test-builder + bridgePaths helper)
+
+**Code Review Summary:**
+
+Pre-PR review caught a real Close-ordering bug (search backend was being closed
+while the store still held it as observer) and a CLAUDE.md violation (concrete
+type assertion `factory.(*app.FSFactory)`). Both fixed via reordering Close + a
+consumer-side `observerWiringFactory` interface in workspace. AddObserver method
+on FSFactory cleanly hides the mutation that was previously a public-field
+append. Net diff still a clean lift; the additional structure pays back the
+cranky concerns without adding LOC.

--- a/tickets/entities/tickets/TKT-Q1JT.md
+++ b/tickets/entities/tickets/TKT-Q1JT.md
@@ -5,7 +5,7 @@ title: Wire workspace search backend as fsstore Observer (drop Subscribe gorouti
 kind: refactor
 priority: medium
 effort: s
-status: backlog
+status: done
 ---
 
 ## Summary

--- a/tickets/relations/TKT-Q1JT--has-implementation--IMPL-RESP.md
+++ b/tickets/relations/TKT-Q1JT--has-implementation--IMPL-RESP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q1JT
+relation: has-implementation
+to: IMPL-RESP
+---

--- a/tickets/relations/TKT-Q1JT--has-planning--PLAN-WHOK.md
+++ b/tickets/relations/TKT-Q1JT--has-planning--PLAN-WHOK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q1JT
+relation: has-planning
+to: PLAN-WHOK
+---

--- a/tickets/relations/TKT-Q1JT--has-review--REV-0LU6.md
+++ b/tickets/relations/TKT-Q1JT--has-review--REV-0LU6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q1JT
+relation: has-review
+to: REV-0LU6
+---


### PR DESCRIPTION
## Summary

Replaces TKT-LCTG's `store.Subscribe` → buffered channel → goroutine relay for search-index sync with a synchronous `store.EntityObserver` wiring. Eliminates the subscription goroutine, buffered channel, WaitGroup, and Close-race entirely.

## Changes

- **`app.FSFactory.AddObserver(o store.EntityObserver)`** — new method. Observers are forwarded to `fsstore.Config.Observers` at `OpenStore` time. Field is private; mutation hidden behind the method.
- **`workspace.New`** — constructs `bleveindex.NewMem()` BEFORE `factory.OpenStore`, registers the backend on the factory if it satisfies a new consumer-side `observerWiringFactory` interface (`*app.FSFactory` does, structurally). The store calls `EntityPut` / `EntityDelete` synchronously under its write lock on every write.
- **`Workspace.NewForTest`** — wires `memstore.WithObserver(searchBackend)` on the default memstore path. `WithTestStore` callers are responsible for their own observer setup; godoc rewritten with remediation guidance.
- **`Workspace.Close`** — closes the store first (drains any in-flight observer calls), then the search backend. Fixes a real race introduced by closing the backend while the store still held a reference.
- **Deleted from workspace:** `startSearchSubscription`, `searchSubscriptionLoop`, `stopSearch` field, `searchWG` field, `storeEventBufferSize` constant.

## Net delta

- Code: +216/-102 (most insertions are the two new tests; production code is net negative)
- Two new tests: `TestFSFactoryObserversReceiveWrites` (factory observer plumbing including rename), `TestStoreWritesAppearSynchronouslyInSearch` (workspace incremental sync without any goroutine)

## Pre-PR review

Ran `cranky-code-reviewer` on the diff. Critical / significant fixes in-PR:

- **Close ordering bug** — was closing search backend before store, leaving observer call sites pointing at a closed bleve index. Fixed by reordering Close.
- **CLAUDE.md violation** — original concrete type assertion `factory.(*app.FSFactory)` replaced with consumer-side `observerWiringFactory` interface declared in workspace.
- **Factory mutation** — public `Observers` field replaced with `AddObserver` method; field is now private.
- **WithTestStore footgun** — godoc rewritten with explicit caveat + remediation pointing to `memstore.WithObserver`.
- **Backfill idempotency** — added comment documenting why the observer-vs-backfill race window is safe.
- **Test name + coverage** — `TestStoreWritesAppearSynchronouslyInSearch` reads cleaner; factory test now covers rename (delete-old + put-new sequence).

See `tickets/entities/review-checklists/REV-0LU6.md` for full disposition table.

## Deferred

- **fsstore swallows observer errors** (`_ = o.EntityPut(e)`): pre-existing TKT-LCTG behavior. Telemetry rework needs its own ticket; not part of this migration.

## Test plan

- [x] `go test -race ./...` — all packages pass
- [x] `just lint` — 0 issues
- [x] `just arch-lint` — OK
- [x] `just ci` — full pipeline (frontend, e2e, docs)