### PR TITLE
refactor(dataentry): decouple from internal/workspace type imports (TKT-B8ZJ)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -227,7 +227,6 @@ deps:
       - templating
       - tracer
       - validator
-      - workspace
     canUse:
       - goldmark
       - gogit

--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -141,7 +141,15 @@ func (d *Desktop) LoadProject(dir string) string {
 	app, err := dataentry.NewApp(
 		fs, projCtx, ws.Meta(), ws.Store(),
 		ws.EntityManager(), ws.Searcher(),
-		ws.StartWatching,
+		// Adapter: bridge dataentry.WatchOptions (consumer-side type)
+		// to workspace.WatchOptions (producer-side type).
+		func(opts dataentry.WatchOptions) error {
+			return ws.StartWatching(workspace.WatchOptions{
+				ExtraFiles: opts.ExtraFiles,
+				ExtraDirs:  opts.ExtraDirs,
+				OnChange:   opts.OnChange,
+			})
+		},
 	)
 	if err != nil {
 		d.mu.Lock()

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -71,7 +71,15 @@ func main() {
 	app, err := dataentry.NewApp(
 		ws.FS(), ws.Paths(), ws.Meta(), ws.Store(),
 		ws.EntityManager(), ws.Searcher(),
-		ws.StartWatching,
+		// Adapter: bridge dataentry.WatchOptions (consumer-side type)
+		// to workspace.WatchOptions (producer-side type).
+		func(opts dataentry.WatchOptions) error {
+			return ws.StartWatching(workspace.WatchOptions{
+				ExtraFiles: opts.ExtraFiles,
+				ExtraDirs:  opts.ExtraDirs,
+				OnChange:   opts.OnChange,
+			})
+		},
 	)
 	if err != nil {
 		var configErr *dataentry.ConfigValidationError

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -34,7 +34,6 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/templating"
 	"github.com/Sourcehaven-BV/rela/internal/tracer"
 	"github.com/Sourcehaven-BV/rela/internal/validator"
-	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 // AppState bundles the reloadable fields of App into an immutable snapshot.
@@ -113,7 +112,7 @@ type App struct {
 	templater     templating.Templater
 	cfgLoader     config.Loader
 	kv            state.KV
-	startWatching func(workspace.WatchOptions) error
+	startWatching func(WatchOptions) error
 
 	// documents renders and caches documents. Created once in NewApp so
 	// singleflight deduplication is stable across requests.
@@ -232,7 +231,7 @@ func NewApp(
 	st store.Store,
 	em entitymanager.EntityManager,
 	searcher search.Searcher,
-	startWatching func(workspace.WatchOptions) error,
+	startWatching func(WatchOptions) error,
 ) (*App, error) {
 	// Reject nil required collaborators up front rather than letting a
 	// downstream handler panic on the first request that exercises them.

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -127,7 +127,13 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, ws *workspace.Wo
 	app.templater = ws.Templater()
 	app.cfgLoader = ws.Config()
 	app.kv = ws.State()
-	app.startWatching = ws.StartWatching
+	app.startWatching = func(opts WatchOptions) error {
+		return ws.StartWatching(workspace.WatchOptions{
+			ExtraFiles: opts.ExtraFiles,
+			ExtraDirs:  opts.ExtraDirs,
+			OnChange:   opts.OnChange,
+		})
+	}
 	// Wire a minimal documentService for tests that hit the documents
 	// handler. Script engine can be the real one (tests that use script:
 	// configs will need to seed scripts on disk).

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -12,8 +12,22 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/config"
-	"github.com/Sourcehaven-BV/rela/internal/workspace"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
+
+// WatchOptions describes the watch contract dataentry needs from
+// its wiring site. Defined here at the consumer per CLAUDE.md
+// "interfaces at the call site"; the wiring site supplies an
+// implementation that bridges to whatever watch mechanism it
+// exposes (today, the workspace's StartWatching).
+type WatchOptions struct {
+	// ExtraFiles lists additional files to watch (e.g., data-entry.yaml).
+	ExtraFiles []string
+	// ExtraDirs lists additional directories to watch.
+	ExtraDirs []string
+	// OnChange fires when any watched extra file changes.
+	OnChange func(events []storage.ChangeEvent)
+}
 
 // sseEvent represents a Server-Sent Event with optional JSON data.
 type sseEvent struct {
@@ -102,8 +116,8 @@ func (a *App) StartWatching() error {
 	if a.startWatching == nil {
 		return nil
 	}
-	return a.startWatching(workspace.WatchOptions{
-		OnChange: func(events []workspace.ChangeEvent) {
+	return a.startWatching(WatchOptions{
+		OnChange: func(events []storage.ChangeEvent) {
 			for _, e := range events {
 				slog.Debug("file changed", "path", e.Path, "op", e.Op)
 			}
@@ -157,7 +171,7 @@ func (a *App) StartGitFetch() (stop func()) {
 // no-op: dataentry's AppState doesn't depend on entity data directly,
 // so there's nothing to rebuild. Kept in place so the test helper has a
 // callable and so future per-entity reactions have an obvious hook.
-func (a *App) onDataReload(_ []workspace.ChangeEvent) {}
+func (a *App) onDataReload(_ []storage.ChangeEvent) {}
 
 // rebuildState re-reads changed inputs and publishes a fresh AppState
 // snapshot atomically. Readers observe either the pre-reload or the

--- a/tickets/entities/implementation-checklists/IMPL-AC1I.md
+++ b/tickets/entities/implementation-checklists/IMPL-AC1I.md
@@ -1,0 +1,30 @@
+---
+id: IMPL-AC1I
+type: implementation-checklist
+title: 'Implementation: Decouple dataentry from internal/workspace type imports'
+status: done
+---
+
+## Implementation
+
+- [x] New `dataentry.WatchOptions` type using `storage.ChangeEvent` directly
+- [x] `App.startWatching` field signature changes from `func(workspace.WatchOptions) error` to `func(WatchOptions) error`
+- [x] `cmd/rela-server/main.go` wraps `ws.StartWatching` with 5-line adapter closure
+- [x] `cmd/rela-desktop/main.go` same adapter pattern
+- [x] `internal/dataentry/test_helpers_test.go` adapter inline in `rebindApp`
+- [x] `internal/dataentry/app.go` drops `internal/workspace` import
+- [x] `internal/dataentry/watcher.go` drops `internal/workspace` import; uses `storage.ChangeEvent` directly
+- [x] `.go-arch-lint.yml` removes `dataentry → workspace`
+- [x] `go test -race ./...` clean
+- [x] `just lint` clean
+- [x] `just arch-lint` OK
+- [x] `just ci` full pipeline green
+
+## Cranky review disposition
+
+| # | Severity | Status | Notes |
+|---|----------|--------|-------|
+| 1 | minor | **Addressed** | Doc comment on `WatchOptions` no longer names `workspace.WatchOptions` — talks about "the wiring site" abstractly. dataentry's docs shouldn't re-introduce the coupling the ticket removes. |
+| 2 | leverage | Won't fix | Reviewer suggested checking `onDataReload` for deadness — verified it IS called (StartWatching → onDataReload). Not dead. |
+| - | - | Confirmed | Adapter duplication in 3 sites: intentional. A helper would have to live in workspace (re-couples) or dataentry (defeats ticket) or a new package (over-engineering for 15 lines of wiring boilerplate). |
+| - | - | Confirmed | `storage.ChangeEvent` on dataentry surface: not new — dataentry already imports `storage` for FS/RootedFS. |

--- a/tickets/entities/review-checklists/REV-GEYB.md
+++ b/tickets/entities/review-checklists/REV-GEYB.md
@@ -1,0 +1,28 @@
+---
+id: REV-GEYB
+type: review-checklist
+title: 'Review: Decouple dataentry from internal/workspace type imports'
+status: done
+---
+
+## Code Review
+
+- [x] cranky-code-reviewer run on the diff
+- [x] No critical, no significant findings
+- [x] 1 minor finding addressed (doc comment no longer names workspace.WatchOptions)
+- [x] 1 leverage finding verified-and-rejected (onDataReload IS called from StartWatching)
+- [x] Tests pass under `-race`
+- [x] `just ci` green
+
+## Disposition
+
+Mechanical type-decouple. Cranky's verdict: "solid, surgical." See IMPL-AC1I for
+the table.
+
+**One real fix:** dataentry's doc comment originally named
+`workspace.WatchOptions` — exactly the coupling the ticket removes. Now it talks
+about the wiring site abstractly.
+
+**Confirmed non-issues:**
+- Adapter duplication across server/desktop/test helper is intentional. Extracting a helper would have to live somewhere that re-creates the coupling.
+- `storage.ChangeEvent` on dataentry's surface is not a new dependency — `internal/storage` was already imported for FS types.

--- a/tickets/entities/tickets/TKT-B8ZJ.md
+++ b/tickets/entities/tickets/TKT-B8ZJ.md
@@ -1,0 +1,38 @@
+---
+id: TKT-B8ZJ
+type: ticket
+title: Decouple dataentry from internal/workspace type imports
+kind: refactor
+priority: medium
+effort: s
+status: done
+---
+
+## Summary
+
+Narrow precursor to TKT-9JEI. `internal/dataentry` imports
+`workspace.WatchOptions` / `workspace.ChangeEvent` for the watcher signature.
+Define a consumer-side `WatchOptions` in dataentry using `storage.ChangeEvent`
+directly; the wiring sites bridge to `workspace.WatchOptions`. After this lands,
+`internal/dataentry` no longer imports `internal/workspace` at all (tests still
+construct workspace as a fixture — that's fine).
+
+## In scope
+
+- New `dataentry.WatchOptions` type (mirrors `workspace.WatchOptions` but uses `storage.ChangeEvent` for OnChange — consumer-side interfaces at the call site per CLAUDE.md).
+- `dataentry.App.startWatching` field signature changes to `func(WatchOptions) error`.
+- `cmd/rela-server/main.go` + `cmd/rela-desktop/main.go` wrap `ws.StartWatching` with an adapter that bridges types.
+- `internal/dataentry/app.go` drops `internal/workspace` import.
+- `.go-arch-lint.yml` removes `dataentry → workspace`.
+- Tests pass.
+
+## Out of scope
+
+- Full TKT-9JEI scope (wiring dataentry without `workspace.Discover` at all — that requires extracting the indexer/watcher orchestration). This ticket is the type-decoupling slice.
+
+## Why
+
+Three lifts (TKT-2W0X / TKT-04YA / TKT-B01S) just removed workspace facade
+methods. dataentry's remaining tie was the watcher-options type. Cutting it now
+keeps the post-lift arch-lint matrix honest (cli ✗ workspace; dataentry ✗
+workspace in production code).

--- a/tickets/relations/TKT-9JEI--depends-on--TKT-B8ZJ.md
+++ b/tickets/relations/TKT-9JEI--depends-on--TKT-B8ZJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9JEI
+relation: depends-on
+to: TKT-B8ZJ
+---

--- a/tickets/relations/TKT-B8ZJ--affects--data-entry-server.md
+++ b/tickets/relations/TKT-B8ZJ--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-B8ZJ
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-B8ZJ--has-implementation--IMPL-AC1I.md
+++ b/tickets/relations/TKT-B8ZJ--has-implementation--IMPL-AC1I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-B8ZJ
+relation: has-implementation
+to: IMPL-AC1I
+---

--- a/tickets/relations/TKT-B8ZJ--has-review--REV-GEYB.md
+++ b/tickets/relations/TKT-B8ZJ--has-review--REV-GEYB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-B8ZJ
+relation: has-review
+to: REV-GEYB
+---

--- a/tickets/relations/TKT-B8ZJ--implements--FEAT-workspace.md
+++ b/tickets/relations/TKT-B8ZJ--implements--FEAT-workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-B8ZJ
+relation: implements
+to: FEAT-workspace
+---


### PR DESCRIPTION
## Summary

Narrow precursor to TKT-9JEI. After this lands, `internal/dataentry` production code no longer imports `internal/workspace` at all.

## What changed

- **NEW `dataentry.WatchOptions`** — consumer-side type using `storage.ChangeEvent` for OnChange directly. Defined at the call site per CLAUDE.md "interfaces at the call site."
- `App.startWatching` signature: `func(workspace.WatchOptions) error` → `func(WatchOptions) error`.
- `cmd/rela-server/main.go` + `cmd/rela-desktop/main.go` wrap `ws.StartWatching` with a 5-line adapter that bridges `dataentry.WatchOptions` → `workspace.WatchOptions`.
- `internal/dataentry/test_helpers_test.go` has the same adapter inline in `rebindApp`.
- `internal/dataentry/{app.go,watcher.go}` drop the `internal/workspace` import.
- `.go-arch-lint.yml` removes `dataentry → workspace`.

## Code review notes

Cranky review verdict: "solid, surgical." One real fix:
- Doc comment on `WatchOptions` originally named `workspace.WatchOptions` — exactly the coupling the ticket removes. Now talks about "the wiring site" abstractly.

Confirmed non-issues:
- Adapter duplication in 3 sites is intentional. A shared helper would have to live in `workspace` (re-couples) or `dataentry` (defeats the ticket).
- `storage.ChangeEvent` on dataentry's surface is not new — `internal/storage` was already imported for FS types.

See REV-GEYB / IMPL-AC1I for the disposition.

## Stacked

Base is `refactor/lift-analysis` (PR #727). After all four PRs merge in order, the `cli ↛ workspace` (production) and `dataentry ↛ workspace` (production) deps are both gone. No auto-merge.

## Test plan

- [x] `just test` (race) — clean
- [x] `just lint` — 0 issues
- [x] `just arch-lint` — OK
- [x] `just ci` — full pipeline green