### PR TITLE
refactor(scheduler): route CLI command through cli services bundle (TKT-2IAC)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -190,6 +190,7 @@ deps:
       - schema
       - script
       - search
+      - state
       - storage
       - store
       - templating

--- a/internal/cli/cli_wiring.go
+++ b/internal/cli/cli_wiring.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/renametype"
 	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/search"
+	"github.com/Sourcehaven-BV/rela/internal/state"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/templating"
@@ -48,13 +49,16 @@ type cliRead interface {
 
 // cliWrite is cliRead + the write-path services that mutating
 // subcommands need (create / delete / update / link / unlink /
-// detach / import / normalize / script).
+// detach / import / normalize / script / scheduler). State() lives
+// here (not on cliRead) because state.KV.Put/Delete mutate
+// persistent state — same write-bundle invariant as EntityManager.
 type cliWrite interface {
 	cliRead
 	EntityManager() entitymanager.EntityManager
 	Validator() validator.Validator
 	LuaCache() *lua.Cache
 	LuaWriteDeps() lua.WriteDeps
+	State() state.KV
 }
 
 // cliAnalyze bundles the read-side analysis surface plus the CLI's
@@ -125,6 +129,7 @@ func (s *cliServices) EntityManager() entitymanager.EntityManager { return s.ws.
 func (s *cliServices) Validator() validator.Validator             { return s.ws.Validator() }
 func (s *cliServices) LuaCache() *lua.Cache                       { return s.ws.LuaCache() }
 func (s *cliServices) LuaWriteDeps() lua.WriteDeps                { return s.ws.LuaWriteDeps() }
+func (s *cliServices) State() state.KV                            { return s.ws.State() }
 
 // --- cliAnalyze ---
 

--- a/internal/cli/scheduler.go
+++ b/internal/cli/scheduler.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -11,14 +10,12 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/scheduler"
 	"github.com/Sourcehaven-BV/rela/internal/script"
-	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 // coverage-ignore: scheduler command - long-running process
 var schedulerCmd = &cobra.Command{
-	Use:         "scheduler",
-	Short:       "Run scheduled Lua tasks",
-	Annotations: map[string]string{skipProjectDiscovery: "true"},
+	Use:   "scheduler",
+	Short: "Run scheduled Lua tasks",
 	Long: `Starts a long-running process that executes Lua scripts on recurring schedules.
 
 Schedules are defined in schedules.yaml in the project root:
@@ -54,19 +51,9 @@ Graceful shutdown via Ctrl+C / SIGTERM.`,
 }
 
 func runScheduler(cmd *cobra.Command) error {
-	startDir := projectPath
-	if startDir == "" {
-		startDir = os.Getenv("RELA_PROJECT")
-	}
+	svc := cliWriteFromContext(cmd.Context())
 
-	engine := script.NewEngine()
-
-	schedWs, err := workspace.Discover(startDir, engine)
-	if err != nil {
-		return errors.New("no project found: run 'rela init' to create one")
-	}
-
-	data, err := schedWs.Config().Load(context.Background(), scheduler.ConfigFile)
+	data, err := svc.Config().Load(context.Background(), scheduler.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("cannot read %s: %w", scheduler.ConfigFile, err)
 	}
@@ -80,7 +67,9 @@ func runScheduler(cmd *cobra.Command) error {
 		Level: slog.LevelInfo,
 	}))
 
-	s := scheduler.New(cfg, engine, schedWs, logger)
+	// cliWrite satisfies scheduler.WorkspaceProvider structurally
+	// (Paths / Config / State / LuaWriteDeps).
+	s := scheduler.New(cfg, script.NewEngine(), svc, logger)
 	return s.Run(cmd.Context())
 }
 

--- a/tickets/entities/implementation-checklists/IMPL-B6ZF.md
+++ b/tickets/entities/implementation-checklists/IMPL-B6ZF.md
@@ -1,0 +1,29 @@
+---
+id: IMPL-B6ZF
+type: implementation-checklist
+title: 'Implementation: Migrate scheduler to wire its own services (off Workspace)'
+status: done
+---
+
+## Implementation
+
+- [x] `cli_wiring.go`: `State() state.KV` added to `cliWrite` (not `cliRead` — `state.KV.Put/Delete` mutates persistent state, belongs on the write bundle)
+- [x] `cli_wiring.go`: import `internal/state` added; `cliServices.State()` delegates to `s.ws.State()`
+- [x] `scheduler.go`: `skipProjectDiscovery` annotation removed — command now flows through `PersistentPreRunE → newCLIServices` like every other subcommand
+- [x] `scheduler.go`: imports `internal/workspace` dropped entirely
+- [x] `scheduler.go`: `runScheduler` calls `cliWriteFromContext(cmd.Context())` and passes the bundle directly into `scheduler.New` — `cliWrite` satisfies `scheduler.WorkspaceProvider` structurally (Paths / Config / State / LuaWriteDeps)
+- [x] `.go-arch-lint.yml`: adds `state` to `cli.mayDependOn`
+- [x] `go test -race ./...` clean
+- [x] `just lint` clean
+- [x] `just arch-lint` OK
+- [x] `just ci` full pipeline green
+
+## Cranky review disposition
+
+| # | Severity | Status | Notes |
+|---|----------|--------|-------|
+| 1 | critical | **Addressed** | `State()` moved from `cliRead` to `cliWrite`. Original draft put it on `cliRead` ("persistence-layer ops, orthogonal to entity mutation") — reviewer correctly called that out as a lie. `state.KV.Put` mutates persistent state. |
+| 2 | significant | **Addressed** | `schedulerProvider` adapter dropped entirely. `cliWrite` satisfies `scheduler.WorkspaceProvider` structurally. The narrow contract is already declared at the scheduler side; the CLI doesn't need to re-narrow. |
+| 3 | minor | Acknowledged | "Deck chairs" concern: this PR doesn't decouple cli from workspace — that's TKT-9JEI/64R3 scope. The win is wiring uniformity: scheduler command now flows through the same PersistentPreRunE path as every other subcommand. Worth doing, not oversold. |
+| 4 | minor | Verified | Error path: lost no information. `wrapDiscoverError` produces the same "no project found" message and surfaces other errors more informatively than the old single-error swallow. |
+| 5 | minor | Resolved | Coverage: `schedulerCmd` still `coverage-ignore`. The adapter that would have needed its own coverage no longer exists (dropped per #2). |

--- a/tickets/entities/review-checklists/REV-Z4GK.md
+++ b/tickets/entities/review-checklists/REV-Z4GK.md
@@ -1,0 +1,30 @@
+---
+id: REV-Z4GK
+type: review-checklist
+title: 'Review: Migrate scheduler to wire its own services (off Workspace)'
+status: done
+---
+
+## Code Review
+
+- [x] cranky-code-reviewer run on the diff
+- [x] 1 critical finding addressed (State() moved from cliRead to cliWrite)
+- [x] 1 significant finding addressed (schedulerProvider adapter dropped — cliWrite satisfies WorkspaceProvider structurally)
+- [x] 3 minor findings verified/acknowledged
+- [x] Tests pass under `-race`
+- [x] `just ci` green
+
+## Disposition
+
+Reviewer caught two real design errors in the first draft:
+
+1. **`State()` on `cliRead` was a lie.** state.KV exposes Put/Delete — putting that on a "read" bundle defeats the read/write split. Moved to `cliWrite` with a clarifying comment.
+
+2. **Adapter was producer-side-interface anti-pattern in disguise.** `schedulerProvider` held a wide `cliWrite` reference behind a narrow facade — same coupling, just one indirection. Dropped entirely; `cliWrite` happens to expose Paths/Config/State/LuaWriteDeps, so it satisfies `scheduler.WorkspaceProvider` structurally. Zero adapter code.
+
+Final shape is the cleanest version of the migration: scheduler command flows
+through the same PersistentPreRunE wiring as every other subcommand; the
+scheduler-side `WorkspaceProvider` interface is the only contract that has to
+exist.
+
+See IMPL-B6ZF for the full table.

--- a/tickets/entities/tickets/TKT-2IAC.md
+++ b/tickets/entities/tickets/TKT-2IAC.md
@@ -5,7 +5,7 @@ title: Migrate scheduler to wire its own services (off Workspace)
 kind: refactor
 priority: medium
 effort: s
-status: ready
+status: done
 ---
 
 ## Summary

--- a/tickets/relations/TKT-2IAC--has-implementation--IMPL-B6ZF.md
+++ b/tickets/relations/TKT-2IAC--has-implementation--IMPL-B6ZF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2IAC
+relation: has-implementation
+to: IMPL-B6ZF
+---

--- a/tickets/relations/TKT-2IAC--has-review--REV-Z4GK.md
+++ b/tickets/relations/TKT-2IAC--has-review--REV-Z4GK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2IAC
+relation: has-review
+to: REV-Z4GK
+---


### PR DESCRIPTION
## Summary

Migrates `rela scheduler` CLI command off direct `workspace.Discover` and onto the shared cli services bundle used by every other subcommand.

## What changed

- **`internal/cli/cli_wiring.go`** — adds `State() state.KV` to the `cliWrite` bundle (not cliRead — `state.KV.Put/Delete` mutates persistent state). New import `internal/state`.
- **`internal/cli/scheduler.go`** — drops `internal/workspace` import; removes `skipProjectDiscovery` annotation so command flows through `PersistentPreRunE → newCLIServices` like every other subcommand. `runScheduler` calls `cliWriteFromContext` and passes the bundle directly into `scheduler.New` — `cliWrite` satisfies `scheduler.WorkspaceProvider` (Paths/Config/State/LuaWriteDeps) structurally. **No adapter type needed.**
- **`.go-arch-lint.yml`** — adds `state` to `cli.mayDependOn`.

Net: 14 lines added, 19 removed.

## Code review wins

Cranky caught two real design errors in the first draft, both fixed:

1. **`State()` on `cliRead` was a lie.** state.KV exposes write methods — placing it on the read bundle defeats the read/write split. Moved to `cliWrite`.
2. **First draft had a `schedulerProvider` adapter struct** holding a `cliWrite` reference and delegating 4 methods. That was the producer-side-interface anti-pattern in disguise. Dropped entirely; structural typing handles it.

See REV-Z4GK / IMPL-B6ZF for the full disposition.

## Stacked

Base is `refactor/dataentry-off-workspace` (PR #728). Merge order: develop ← #724 ← #726 ← #727 ← #728 ← this.

## Test plan

- [x] `just test` (race) — clean
- [x] `just lint` — 0 issues
- [x] `just arch-lint` — OK
- [x] `just ci` — full pipeline green