### PR TITLE
refactor(dataentry): own the watcher; delete workspace.StartWatching (TKT-2MY1)

### DIFF
--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -141,15 +141,6 @@ func (d *Desktop) LoadProject(dir string) string {
 	app, err := dataentry.NewApp(
 		fs, projCtx, ws.Meta(), ws.Store(),
 		ws.EntityManager(), ws.Searcher(),
-		// Adapter: bridge dataentry.WatchOptions (consumer-side type)
-		// to workspace.WatchOptions (producer-side type).
-		func(opts dataentry.WatchOptions) error {
-			return ws.StartWatching(workspace.WatchOptions{
-				ExtraFiles: opts.ExtraFiles,
-				ExtraDirs:  opts.ExtraDirs,
-				OnChange:   opts.OnChange,
-			})
-		},
 	)
 	if err != nil {
 		d.mu.Lock()

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -71,15 +71,6 @@ func main() {
 	app, err := dataentry.NewApp(
 		ws.FS(), ws.Paths(), ws.Meta(), ws.Store(),
 		ws.EntityManager(), ws.Searcher(),
-		// Adapter: bridge dataentry.WatchOptions (consumer-side type)
-		// to workspace.WatchOptions (producer-side type).
-		func(opts dataentry.WatchOptions) error {
-			return ws.StartWatching(workspace.WatchOptions{
-				ExtraFiles: opts.ExtraFiles,
-				ExtraDirs:  opts.ExtraDirs,
-				OnChange:   opts.OnChange,
-			})
-		},
 	)
 	if err != nil {
 		var configErr *dataentry.ConfigValidationError

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -101,9 +101,9 @@ type App struct {
 	fs    storage.FS
 	paths *project.Context
 
-	// Core services. Some are passed in (store, entityManager, searcher,
-	// startWatching are genuinely workspace-owned); the rest are
-	// constructed from primitives inside NewApp.
+	// Core services. Some are passed in (store, entityManager,
+	// searcher); the rest are constructed from primitives inside
+	// NewApp.
 	store         store.Store
 	entityManager entitymanager.EntityManager
 	searcher      search.Searcher
@@ -112,7 +112,6 @@ type App struct {
 	templater     templating.Templater
 	cfgLoader     config.Loader
 	kv            state.KV
-	startWatching func(WatchOptions) error
 
 	// documents renders and caches documents. Created once in NewApp so
 	// singleflight deduplication is stable across requests.
@@ -150,8 +149,11 @@ type App struct {
 	security *security
 }
 
-// StopWatching releases dataentry-specific watchers (config, etc.).
-// The workspace's own watcher is stopped separately by its owner.
+// StopWatching releases the data-entry.yaml subscription started by
+// [App.StartWatching]. The store-level watcher (when present) has its
+// own lifecycle managed by the store and is stopped during store
+// close, not here — asymmetric on purpose: dataentry doesn't own the
+// store, only its config subscription.
 func (a *App) StopWatching() {
 	if a.stopConfigWatch != nil {
 		a.stopConfigWatch()
@@ -217,13 +219,17 @@ func (a *App) SetSecurityConfig(cfg SecurityConfig) error {
 	return nil
 }
 
-// NewApp creates and initializes an App. Callers pass in the primitives
-// (fs, paths, meta, store) plus the services that are genuinely
-// workspace-owned and cannot be reconstructed from primitives:
-// entityManager (runs workspace's automation engine), searcher (reads
-// the live Bleve index maintained by the workspace), and startWatching
-// (a lifecycle hook). Everything else — state.KV, config.Loader,
-// tracer, templater, validator, lua.WriteDeps — is constructed locally.
+// NewApp creates and initializes an App. Callers pass in the
+// primitives (fs, paths, meta, store) plus the services that depend
+// on workspace assembly: entityManager (the production write path)
+// and searcher (the live Bleve index). Everything else — state.KV,
+// config.Loader, tracer, templater, validator — is constructed
+// locally.
+//
+// The store-level file watcher (live-reload of external entity /
+// relation edits) is feature-detected on `st` inside
+// [App.StartWatching] via the [storeWatcher] interface; callers do
+// not wire it.
 func NewApp(
 	fs storage.FS,
 	paths *project.Context,
@@ -231,7 +237,6 @@ func NewApp(
 	st store.Store,
 	em entitymanager.EntityManager,
 	searcher search.Searcher,
-	startWatching func(WatchOptions) error,
 ) (*App, error) {
 	// Reject nil required collaborators up front rather than letting a
 	// downstream handler panic on the first request that exercises them.
@@ -336,7 +341,6 @@ func NewApp(
 		templater:     templater,
 		cfgLoader:     cfgLoader,
 		kv:            kv,
-		startWatching: startWatching,
 		broker:        newEventBroker(),
 		scriptEngine:  scriptEngine,
 	}

--- a/internal/dataentry/e2e_test.go
+++ b/internal/dataentry/e2e_test.go
@@ -57,7 +57,6 @@ func newE2ETestApp(t *testing.T) (*App, string, func()) {
 	app, err := NewApp(
 		ws.FS(), ws.Paths(), ws.Meta(), ws.Store(),
 		ws.EntityManager(), ws.Searcher(),
-		ws.StartWatching,
 	)
 	if err != nil {
 		t.Fatalf("creating app: %v", err)

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -127,13 +127,6 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, ws *workspace.Wo
 	app.templater = ws.Templater()
 	app.cfgLoader = ws.Config()
 	app.kv = ws.State()
-	app.startWatching = func(opts WatchOptions) error {
-		return ws.StartWatching(workspace.WatchOptions{
-			ExtraFiles: opts.ExtraFiles,
-			ExtraDirs:  opts.ExtraDirs,
-			OnChange:   opts.OnChange,
-		})
-	}
 	// Wire a minimal documentService for tests that hit the documents
 	// handler. Script engine can be the real one (tests that use script:
 	// configs will need to seed scripts on disk).

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -12,21 +12,14 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/config"
-	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
-// WatchOptions describes the watch contract dataentry needs from
-// its wiring site. Defined here at the consumer per CLAUDE.md
-// "interfaces at the call site"; the wiring site supplies an
-// implementation that bridges to whatever watch mechanism it
-// exposes (today, the workspace's StartWatching).
-type WatchOptions struct {
-	// ExtraFiles lists additional files to watch (e.g., data-entry.yaml).
-	ExtraFiles []string
-	// ExtraDirs lists additional directories to watch.
-	ExtraDirs []string
-	// OnChange fires when any watched extra file changes.
-	OnChange func(events []storage.ChangeEvent)
+// storeWatcher is the optional capability dataentry needs from a
+// store to drive live-reload of entity/relation files. fsstore
+// satisfies it; in-memory backends don't. Defined here at the
+// consumer per CLAUDE.md "interfaces at the call site".
+type storeWatcher interface {
+	StartWatching() error
 }
 
 // sseEvent represents a Server-Sent Event with optional JSON data.
@@ -93,15 +86,29 @@ func (b *eventBroker) broadcastGitStatus() {
 	b.broadcastEvent(sseEvent{Type: "git:status", Data: "{}"})
 }
 
-// StartWatching begins file watching for live-reload of views when project
-// files change. The workspace handles metamodel + graph reload; this method
-// subscribes to the config service for data-entry.yaml changes and adds
-// SSE broadcast side-effects.
-// Stop via a.StopWatching() plus the workspace's own watcher shutdown.
+// StartWatching begins file watching for live-reload. It does two
+// independent things:
+//
+//  1. Subscribes to `data-entry.yaml` via the config loader so SPA
+//     reloads pick up dashboard / palette / form config changes.
+//  2. Asks the store to start watching its own entity/relation files
+//     (feature-detected via [storeWatcher] — fsstore implements it;
+//     in-memory backends don't). The store's observer chain handles
+//     reindex automatically; no callback wiring is needed at this
+//     layer.
+//
+// The returned error covers only the config-subscriber failure
+// (step 1). Store-watcher errors (step 2) are logged via slog.Warn
+// because store watching is a live-reload nice-to-have, not a
+// startup requirement.
+//
+// Stop via [App.StopWatching]. Note: that only releases the config
+// subscription — the store-watcher lifecycle is owned by the store
+// (closed when the store is closed).
 //
 // coverage-ignore: requires real filesystem events via fsnotify
 func (a *App) StartWatching() error {
-	// Subscribe to data-entry.yaml via the config loader.
+	// (1) data-entry.yaml subscription.
 	if sub, ok := a.cfgLoader.(config.Subscriber); ok {
 		stop, err := sub.Subscribe(context.Background(), ConfigFile, func() {
 			a.rebuildState(true, false)
@@ -113,18 +120,21 @@ func (a *App) StartWatching() error {
 		a.stopConfigWatch = stop
 	}
 
-	if a.startWatching == nil {
-		return nil
+	// (2) Store-level watcher (fsstore). Errors are logged, not
+	// returned — store watching is a live-reload nice-to-have, not a
+	// startup requirement. Stores that don't implement [storeWatcher]
+	// (memstore, etc.) get a debug log instead of silence so
+	// "why isn't live-reload working" doesn't require a goose chase.
+	if sw, ok := a.store.(storeWatcher); ok {
+		if err := sw.StartWatching(); err != nil {
+			slog.Warn("store watcher not started", "error", err)
+		}
+	} else {
+		slog.Debug("store does not implement watching; live-reload of external edits disabled",
+			"store", fmt.Sprintf("%T", a.store))
 	}
-	return a.startWatching(WatchOptions{
-		OnChange: func(events []storage.ChangeEvent) {
-			for _, e := range events {
-				slog.Debug("file changed", "path", e.Path, "op", e.Op)
-			}
-			a.onDataReload(events)
-			a.broker.broadcast("refresh")
-		},
-	})
+
+	return nil
 }
 
 // StartGitFetch begins periodic git fetch in the background.
@@ -165,13 +175,6 @@ func (a *App) StartGitFetch() (stop func()) {
 		close(done)
 	}
 }
-
-// onDataReload handles dataentry-specific side-effects after the workspace
-// has re-synced the graph from entity/relation changes. Today this is a
-// no-op: dataentry's AppState doesn't depend on entity data directly,
-// so there's nothing to rebuild. Kept in place so the test helper has a
-// callable and so future per-entity reactions have an obvious hook.
-func (a *App) onDataReload(_ []storage.ChangeEvent) {}
 
 // rebuildState re-reads changed inputs and publishes a fresh AppState
 // snapshot atomically. Readers observe either the pre-reload or the

--- a/internal/dataentry/watcher_test.go
+++ b/internal/dataentry/watcher_test.go
@@ -242,29 +242,18 @@ func TestEventBrokerConcurrency(t *testing.T) {
 	}
 }
 
-// simulateReload mimics what the watcher subscriptions do in production:
-// a config-path event triggers rebuildState(config); other events go to
-// onDataReload. Metamodel changes are ignored — the workspace does not
-// reload the metamodel while running.
+// simulateReload mimics what the data-entry.yaml subscriber does in
+// production: a config-path event triggers rebuildState(config). Other
+// event paths are ignored — entity/relation changes are reconciled by
+// the store's own observer chain (see [App.StartWatching]), not via a
+// dataentry-level callback.
 func (a *App) simulateReload(events []storage.ChangeEvent) {
 	configPath := a.paths.Root + "/" + ConfigFile
-	configEvent := false
-	var dataEvents []storage.ChangeEvent
 	for _, e := range events {
-		switch e.Path {
-		case configPath:
-			configEvent = true
-		default:
-			dataEvents = append(dataEvents, e)
+		if e.Path == configPath {
+			a.rebuildState(true, false)
+			return
 		}
-	}
-	if configEvent {
-		a.rebuildState(true, false)
-	}
-	if len(dataEvents) > 0 {
-		// Data changes no longer require an explicit workspace sync;
-		// the store watches its own files and reconciles internally.
-		a.onDataReload(dataEvents)
 	}
 }
 
@@ -532,7 +521,10 @@ func TestConcurrentReadDuringOnReload(t *testing.T) {
 				return
 			default:
 			}
-			app.onDataReload(nil)
+			// Hammer the actual reload path (config-driven rebuild)
+			// concurrently with reader goroutines so torn snapshots
+			// would be observable.
+			app.rebuildState(true, false)
 		}
 	}()
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -19,7 +19,6 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
-	"time"
 
 	"context"
 
@@ -102,9 +101,10 @@ func (nopScriptExecutor) LuaCache() *lua.Cache { return nil }
 // construction time so every in-process write (Create/Update/
 // DeleteEntity through the store API) updates the search index
 // synchronously under the store's write lock. External edits to
-// on-disk files are only observed once a caller invokes
-// StartWatching, which arms fsstore's own file watcher to translate
-// filesystem events into store events.
+// on-disk files are observed only when a caller (typically
+// [dataentry.App.StartWatching]) asks the store to start watching;
+// the store's own observer chain then carries those events into the
+// search index.
 type Workspace struct {
 	// fs is the filesystem handle used for all workspace I/O:
 	// directory topology (ReadDir, MkdirAll, Stat, Walk) and byte
@@ -129,9 +129,6 @@ type Workspace struct {
 	tracer       tracer.Tracer
 	searcherOnce sync.Once
 	searcher     search.Searcher
-
-	// Watcher state (nil when not watching).
-	watcher *storage.Watcher
 
 	// storeFactory opens the workspace's authoritative store. In
 	// production this builds the fsstore under the project directory;
@@ -710,74 +707,9 @@ func (w *Workspace) collectAllIDs() []string {
 	return ids
 }
 
-// WatchOptions configures the file watcher.
-type WatchOptions struct {
-	// ExtraFiles lists additional files to watch (e.g., data-entry.yaml).
-	ExtraFiles []string
-	// ExtraDirs lists additional directories to watch (e.g., metamodel/).
-	ExtraDirs []string
-	// OnChange is called when any watched extra file changes. Store
-	// events are handled internally (they keep the search index in sync);
-	// only consumers of ExtraFiles/ExtraDirs receive events here.
-	OnChange func(events []ChangeEvent)
-}
-
-// StartWatching begins watching for file changes.
-//
-//   - Entity/relation changes: the store's own watcher (fsstore) emits
-//     events; the workspace subscribes at New() to keep the search index
-//     in sync. Nothing is wired here for entity/relation changes.
-//   - Extra files/dirs (views.yaml, etc.) are watched via a separate
-//     storage.Watcher and fire opts.OnChange.
-//
-// Metamodel and automation changes are not picked up while the workspace
-// is running — restart to apply them.
-func (w *Workspace) StartWatching(opts WatchOptions) error {
-	// Ask the store to start watching its own data files. The interface
-	// doesn't mandate this capability, so we feature-test via type
-	// assertion — fsstore supports it; memstore and other in-memory
-	// backends don't need to.
-	if w.store != nil {
-		if sw, ok := w.store.(storeWatcher); ok {
-			if err := sw.StartWatching(); err != nil {
-				slog.Warn("store watcher not started", "error", err)
-			}
-		}
-	}
-
-	// Optional extra watcher for non-store files (views.yaml, etc.).
-	if len(opts.ExtraDirs) > 0 || len(opts.ExtraFiles) > 0 {
-		watcher, err := storage.NewWatcher(storage.WatchConfig{
-			Dirs:       opts.ExtraDirs,
-			Files:      opts.ExtraFiles,
-			Extensions: []string{".yaml", ".yml"},
-			Debounce:   200 * time.Millisecond,
-			SkipHidden: true,
-			OnChange: func(events []storage.ChangeEvent) {
-				if opts.OnChange != nil {
-					opts.OnChange(events)
-				}
-			},
-		})
-		if err != nil {
-			return err
-		}
-		go watcher.Start()
-		w.watcher = watcher
-	}
-	return nil
-}
-
-// StopWatching stops the file watcher.
-func (w *Workspace) StopWatching() {
-	if w.watcher != nil {
-		w.watcher.Stop()
-		w.watcher = nil
-	}
-}
-
-// Close releases resources held by the workspace (search index, watcher,
-// store). Close is not safe to call concurrently with Workspace methods.
+// Close releases resources held by the workspace (search index,
+// store). Close is not safe to call concurrently with Workspace
+// methods.
 //
 // Subsystems close in observer-dependency order: store first, so no
 // further observer callbacks can land on the search backend; then the
@@ -785,8 +717,6 @@ func (w *Workspace) StopWatching() {
 // earlier one errored so a partial failure doesn't leak store
 // goroutines or watcher resources.
 func (w *Workspace) Close() error {
-	w.StopWatching()
-
 	if w.store != nil {
 		if sw, ok := w.store.(storeWatcher); ok {
 			sw.StopWatching()
@@ -806,20 +736,6 @@ func (w *Workspace) Close() error {
 		w.searchBackend = nil
 	}
 	return firstErr
-}
-
-// PauseWatching temporarily suppresses file change events.
-func (w *Workspace) PauseWatching() {
-	if w.watcher != nil {
-		w.watcher.Pause()
-	}
-}
-
-// ResumeWatching re-enables file change events after PauseWatching.
-func (w *Workspace) ResumeWatching() {
-	if w.watcher != nil {
-		w.watcher.Resume()
-	}
 }
 
 // --- Filesystem access ---

--- a/tickets/entities/implementation-checklists/IMPL-NPYI.md
+++ b/tickets/entities/implementation-checklists/IMPL-NPYI.md
@@ -1,0 +1,30 @@
+---
+id: IMPL-NPYI
+type: implementation-checklist
+title: 'Implementation: dataentry owns its data-entry.yaml watcher (remove WatchOptions indirection)'
+status: done
+---
+
+## Implementation
+
+- [x] `dataentry.WatchOptions` deleted.
+- [x] `dataentry.App.startWatching` field + `NewApp` constructor parameter removed.
+- [x] `dataentry.App.StartWatching` now feature-detects `a.store.(storeWatcher)` and asks the store directly. Errors logged via slog.Warn; non-watching stores get a slog.Debug for visibility.
+- [x] New `storeWatcher` consumer-side interface in `internal/dataentry/watcher.go` (2 methods, but only StartWatching is needed here).
+- [x] Adapter closures in `cmd/rela-server/main.go`, `cmd/rela-desktop/main.go`, `test_helpers_test.go::rebindApp` deleted.
+- [x] **Workspace's `StartWatching` / `StopWatching` / `PauseWatching` / `ResumeWatching` / `WatchOptions` + `watcher` field deleted.** Last consumer is gone; per CLAUDE.md "migrate out, don't extend." Bonus 60-line deletion.
+- [x] `onDataReload` removed (was no-op; only test-helper called it).
+- [x] `e2e_test.go` fixed (was still passing `ws.StartWatching` to NewApp).
+- [x] `go test -race ./...` clean. `just ci` green. `go test -tags=e2e` builds clean.
+
+## Cranky review disposition
+
+| # | Severity | Status | Notes |
+|---|----------|--------|-------|
+| 1 | critical | **Addressed** | `e2e_test.go` still passed `ws.StartWatching` to NewApp — caught by `go test -tags=e2e`. Fixed. |
+| 2 | significant | **Addressed** | `onDataReload` was no-op + dead-code-with-test-hook; deleted along with the simulateReload data-event branch. simulateReload now models only the config-path event (the only watcher branch that survives). |
+| 3 | significant | **Addressed** | Workspace's `StartWatching` / `WatchOptions` / `Pause` / `Resume` / `watcher` field deleted — all four were unreachable from production after this PR. CLAUDE.md "migrate out" rule applied. |
+| 4 | minor | **Addressed** | Added slog.Debug when `a.store` doesn't implement `storeWatcher` so misconfigured deployments aren't silent. |
+| 5 | minor | **Addressed** | `App.StopWatching` doc clarified: it releases only the config subscription; store-watcher lifecycle is store-owned. |
+| 6 | minor | **Addressed** | `App.StartWatching` doc clarified: returned error covers only config-subscriber failure; store-watcher errors logged not returned. |
+| - | leverage | Acknowledged | Feature-detection pattern (storeWatcher in dataentry, storeStartStopper in cli/mcp_wiring) intentionally duplicated per CLAUDE.md "interfaces at the call site." Not factored. |

--- a/tickets/entities/review-checklists/REV-6W33.md
+++ b/tickets/entities/review-checklists/REV-6W33.md
@@ -1,0 +1,27 @@
+---
+id: REV-6W33
+type: review-checklist
+title: 'Review: dataentry owns its data-entry.yaml watcher (remove WatchOptions indirection)'
+status: done
+---
+
+## Code Review
+
+- [x] cranky-code-reviewer run on the diff
+- [x] 1 critical finding addressed (e2e_test.go was broken; `go test -tags=e2e` catches it now)
+- [x] 2 significant findings addressed (onDataReload removed; workspace.StartWatching et al. deleted)
+- [x] 3 minor findings addressed (slog.Debug on missing watcher; doc clarifications on Start/StopWatching)
+- [x] Tests pass under `-race`
+- [x] `just test -tags=e2e` builds clean
+- [x] `just ci` green
+
+## Disposition
+
+See IMPL-NPYI for the full table.
+
+**Headline outcomes:**
+
+- **Net 111-line deletion** across 8 files. The watcher indirection that TKT-B8ZJ partially decoupled is now gone entirely.
+- **Workspace shed 60+ lines.** `StartWatching` / `StopWatching` / `PauseWatching` / `ResumeWatching` / `WatchOptions` type / `watcher` field all deleted. They were unreachable from production after this PR; per CLAUDE.md "migrate out, don't extend" the right move is delete-now, not wait-for-TKT-64R3.
+- **Build-tag catch.** Cranky ran `go test -tags=e2e` and found a file I'd missed — `e2e_test.go` still passed the now-removed parameter. Fixed.
+- **`onDataReload` removed.** Was a no-op called only by test infrastructure modeling a code path that no longer exists in production.

--- a/tickets/entities/tickets/TKT-2MY1.md
+++ b/tickets/entities/tickets/TKT-2MY1.md
@@ -5,7 +5,7 @@ title: dataentry owns its data-entry.yaml watcher (remove WatchOptions indirecti
 kind: refactor
 priority: medium
 effort: s
-status: ready
+status: done
 ---
 
 ## Summary

--- a/tickets/relations/TKT-2MY1--has-implementation--IMPL-NPYI.md
+++ b/tickets/relations/TKT-2MY1--has-implementation--IMPL-NPYI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2MY1
+relation: has-implementation
+to: IMPL-NPYI
+---

--- a/tickets/relations/TKT-2MY1--has-review--REV-6W33.md
+++ b/tickets/relations/TKT-2MY1--has-review--REV-6W33.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2MY1
+relation: has-review
+to: REV-6W33
+---


### PR DESCRIPTION
## Summary

Finishes the watcher decoupling that TKT-B8ZJ started. After this lands:

- `dataentry.WatchOptions` is gone.
- `dataentry.NewApp` constructor's `startWatching` parameter is gone.
- `dataentry.App.StartWatching` asks the store directly (feature-detected `storeWatcher` interface) instead of bridging through workspace.
- **`workspace.StartWatching`, `StopWatching`, `PauseWatching`, `ResumeWatching`, `WatchOptions` type, and `watcher` field are all deleted** — every production caller is gone after this PR. Per CLAUDE.md "migrate out, don't extend."

Net: **111-line deletion** across 8 files. Precursor to TKT-9JEI.

## What changed

- `internal/dataentry/watcher.go` — new tiny `storeWatcher` consumer-side interface; `StartWatching` rewritten to use it directly. `slog.Debug` log when store doesn't implement watching (memstore, etc.).
- `internal/dataentry/app.go` — `startWatching` field + ctor param removed. Doc comments on `StartWatching` / `StopWatching` clarified re: store-watcher lifecycle ownership and error-return semantics.
- `internal/workspace/workspace.go` — `StartWatching` et al. deleted (~80 LOC); top-of-file comment updated.
- `cmd/rela-server/main.go`, `cmd/rela-desktop/main.go` — adapter closures dropped.
- `internal/dataentry/{test_helpers_test.go,watcher_test.go,e2e_test.go}` — test fixtures updated. `onDataReload` deleted (was no-op + test-only).

## Code review wins

Cranky caught:

1. **(Critical)** `e2e_test.go` was still passing the now-removed `ws.StartWatching` parameter. Build-tagged so the regular test run hid it. Fixed; verified `go test -tags=e2e` builds clean.
2. **(Significant)** `onDataReload` was dead production code with only test reach. Deleted; `simulateReload` now models only the config-path event (the only watcher branch that survives).
3. **(Significant)** Workspace's `StartWatching` et al. were unreachable after this PR. Deleted them in this PR rather than leaving tombstones for TKT-64R3.

Plus minor: slog.Debug on missing watcher capability; doc clarifications on Start/StopWatching asymmetry.

See REV-6W33 / IMPL-NPYI for the disposition.

## Stacked

Based on `refactor/cli-off-workspace` (PR #724, the bundled workspace decomposition awaiting review). When #724 merges to develop, the cron will request tschmits review on this PR.

## Test plan

- [x] `just test` (race) — clean
- [x] `just lint` — 0 issues
- [x] `just arch-lint` — OK
- [x] `just ci` — full pipeline green
- [x] `go test -tags=e2e -count=1` builds clean