### PR TITLE
refactor(projectsetup): extract from workspace (TKT-G8SX)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -72,6 +72,9 @@ components:
   memstore:         { in: internal/store/memstore }
   storeutil:        { in: internal/store/storeutil }
 
+  # Project bootstrap utilities
+  projectsetup:     { in: internal/projectsetup }
+
   # Infrastructure
   ai:               { in: internal/ai }
   secrets:          { in: internal/secrets }
@@ -184,6 +187,7 @@ deps:
       - metamodel
       - output
       - project
+      - projectsetup
       - rename
       - renametype
       - scheduler
@@ -280,12 +284,10 @@ deps:
       - automation
       - bleveindex
       - config
-      - dataentryconfig
       - entitymanager
       - lua
       - memstore
       - metamodel
-      - migration
       - project
       - rename
       - schema
@@ -298,6 +300,13 @@ deps:
       - tracer
       - validation
       - validator
+  projectsetup:
+    mayDependOn:
+      - dataentryconfig
+      - metamodel
+      - migration
+      - project
+      - storage
 
   # Domain services
   analysis:

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Sourcehaven-BV/rela/internal/workspace"
+	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
 )
 
 var initCmd = &cobra.Command{
@@ -20,7 +20,7 @@ var initCmd = &cobra.Command{
 			targetDir = os.Getenv("RELA_PROJECT")
 		}
 
-		result, err := workspace.Initialize(targetDir)
+		result, err := projectsetup.Initialize(targetDir)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Sourcehaven-BV/rela/internal/workspace"
+	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
 )
 
 var (
@@ -41,7 +41,7 @@ Examples:
 }
 
 func runMigrateCheck(startDir string) error {
-	detections, err := workspace.DetectMigrations(startDir)
+	detections, err := projectsetup.DetectMigrations(startDir)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func runMigrateCheck(startDir string) error {
 }
 
 func runMigrate(startDir string) error {
-	result, err := workspace.Migrate(startDir)
+	result, err := projectsetup.Migrate(startDir)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/errors"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/output"
+	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
 	"github.com/Sourcehaven-BV/rela/internal/schema"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
@@ -88,7 +89,7 @@ func runValidate(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Always validate config files first
-	result, err := workspace.Validate(startDir)
+	result, err := projectsetup.Validate(startDir)
 	if err != nil {
 		return err
 	}
@@ -480,7 +481,7 @@ func parseValidationFilter(filterStr string, meta metamodelAccessor) (analysis.V
 }
 
 // reportDataEntryValidation reports data-entry.yaml validation results.
-func reportDataEntryValidation(result *workspace.ValidateResult, hasErrors bool) bool {
+func reportDataEntryValidation(result *projectsetup.ValidateResult, hasErrors bool) bool {
 	if result.DataEntrySkipped {
 		if quiet {
 			return hasErrors

--- a/internal/projectsetup/init.go
+++ b/internal/projectsetup/init.go
@@ -1,4 +1,4 @@
-package workspace
+package projectsetup
 
 import (
 	"errors"
@@ -86,17 +86,4 @@ func InitializeWithFS(targetDir string, fs storage.FS) (*InitResult, error) {
 	}
 
 	return result, nil
-}
-
-// NewAfterInit creates a workspace for a newly initialized project.
-// Use this after Initialize() when you need a workspace immediately.
-// Uses NopScriptExecutor since newly initialized projects don't have
-// Lua automations configured.
-func NewAfterInit(targetDir string) (*Workspace, error) {
-	fs := storage.NewSafeFS(storage.NewOsFS())
-	ctx, err := project.Discover(targetDir, fs)
-	if err != nil {
-		return nil, err
-	}
-	return New(fs, ctx, NopScriptExecutor)
 }

--- a/internal/projectsetup/init_test.go
+++ b/internal/projectsetup/init_test.go
@@ -1,0 +1,78 @@
+package projectsetup_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+func TestInitializeWithFS_CreatesProject(t *testing.T) {
+	fs := storage.NewMemFS()
+	target := "/proj"
+
+	result, err := projectsetup.InitializeWithFS(target, fs)
+	if err != nil {
+		t.Fatalf("InitializeWithFS: %v", err)
+	}
+
+	if result.Root != target {
+		t.Errorf("Root = %q, want %q", result.Root, target)
+	}
+	want := filepath.Join(target, project.MetamodelFile)
+	if result.MetamodelPath != want {
+		t.Errorf("MetamodelPath = %q, want %q", result.MetamodelPath, want)
+	}
+
+	data, err := fs.ReadFile(want)
+	if err != nil {
+		t.Fatalf("metamodel not written: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("metamodel.yaml is empty")
+	}
+}
+
+func TestInitializeWithFS_AlreadyInitialized(t *testing.T) {
+	fs := storage.NewMemFS()
+	target := "/proj"
+
+	if _, err := projectsetup.InitializeWithFS(target, fs); err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+	_, err := projectsetup.InitializeWithFS(target, fs)
+	if err == nil {
+		t.Fatal("expected error on re-init, got nil")
+	}
+	if !strings.Contains(err.Error(), "already initialized") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestInitializeWithFS_UpdatesGitignore(t *testing.T) {
+	fs := storage.NewMemFS()
+	target := "/proj"
+
+	if err := fs.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := fs.WriteFile(filepath.Join(target, ".gitignore"), []byte("node_modules/\n"), 0o644); err != nil {
+		t.Fatalf("seed gitignore: %v", err)
+	}
+
+	result, err := projectsetup.InitializeWithFS(target, fs)
+	if err != nil {
+		t.Fatalf("InitializeWithFS: %v", err)
+	}
+	if !result.GitignoreUpdate {
+		t.Error("expected GitignoreUpdate=true")
+	}
+
+	data, _ := fs.ReadFile(filepath.Join(target, ".gitignore"))
+	if !strings.Contains(string(data), ".rela") {
+		t.Errorf("gitignore not updated: %q", data)
+	}
+}

--- a/internal/projectsetup/migrate.go
+++ b/internal/projectsetup/migrate.go
@@ -1,4 +1,4 @@
-package workspace
+package projectsetup
 
 import (
 	"errors"

--- a/internal/projectsetup/migrate_test.go
+++ b/internal/projectsetup/migrate_test.go
@@ -1,0 +1,60 @@
+package projectsetup_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+func TestDetectMigrationsWithFS_NoProject(t *testing.T) {
+	fs := storage.NewMemFS()
+	_, err := projectsetup.DetectMigrationsWithFS("/missing", fs)
+	if err == nil {
+		t.Fatal("expected error for missing project, got nil")
+	}
+}
+
+func TestMigrateWithFS_NoProject(t *testing.T) {
+	fs := storage.NewMemFS()
+	_, err := projectsetup.MigrateWithFS("/missing", fs)
+	if err == nil {
+		t.Fatal("expected error for missing project, got nil")
+	}
+}
+
+func TestDetectMigrationsWithFS_RunsSuccessfully(t *testing.T) {
+	fs := storage.NewMemFS()
+	root := "/proj"
+	if _, err := projectsetup.InitializeWithFS(root, fs); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if _, err := projectsetup.DetectMigrationsWithFS(root, fs); err != nil {
+		t.Fatalf("DetectMigrationsWithFS: %v", err)
+	}
+}
+
+func TestMigrateWithFS_AppliesPending(t *testing.T) {
+	fs := storage.NewMemFS()
+	root := "/proj"
+	if _, err := projectsetup.InitializeWithFS(root, fs); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	result, err := projectsetup.MigrateWithFS(root, fs)
+	if err != nil {
+		t.Fatalf("MigrateWithFS: %v", err)
+	}
+	if result == nil {
+		t.Fatal("nil result")
+	}
+
+	after, err := projectsetup.DetectMigrationsWithFS(root, fs)
+	if err != nil {
+		t.Fatalf("DetectMigrationsWithFS after migrate: %v", err)
+	}
+	if len(after) != 0 {
+		t.Errorf("expected no pending migrations after Migrate, got %d", len(after))
+	}
+}

--- a/internal/projectsetup/validate.go
+++ b/internal/projectsetup/validate.go
@@ -1,4 +1,4 @@
-package workspace
+package projectsetup
 
 import (
 	"errors"

--- a/internal/projectsetup/validate_test.go
+++ b/internal/projectsetup/validate_test.go
@@ -1,0 +1,60 @@
+package projectsetup_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+func TestValidateWithFS_NoProject(t *testing.T) {
+	fs := storage.NewMemFS()
+	_, err := projectsetup.ValidateWithFS("/missing", fs)
+	if err == nil {
+		t.Fatal("expected error for missing project, got nil")
+	}
+}
+
+func TestValidateWithFS_ValidProject(t *testing.T) {
+	fs := storage.NewMemFS()
+	root := "/proj"
+	if _, err := projectsetup.InitializeWithFS(root, fs); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	result, err := projectsetup.ValidateWithFS(root, fs)
+	if err != nil {
+		t.Fatalf("ValidateWithFS: %v", err)
+	}
+	if !result.MetamodelValid {
+		t.Errorf("MetamodelValid = false, err = %v", result.MetamodelError)
+	}
+	if result.HasErrors() {
+		t.Errorf("HasErrors() = true, want false")
+	}
+}
+
+func TestValidateResult_HasErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		r    projectsetup.ValidateResult
+		want bool
+	}{
+		{"clean", projectsetup.ValidateResult{}, false},
+		{"metamodel err", projectsetup.ValidateResult{MetamodelError: errExample}, true},
+		{"data-entry err", projectsetup.ValidateResult{DataEntryError: errExample}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.r.HasErrors(); got != tc.want {
+				t.Errorf("HasErrors() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+type sentinel struct{ msg string }
+
+func (s sentinel) Error() string { return s.msg }
+
+var errExample = sentinel{msg: "x"}

--- a/tickets/entities/tickets/TKT-DS43.md
+++ b/tickets/entities/tickets/TKT-DS43.md
@@ -1,0 +1,44 @@
+---
+id: TKT-DS43
+type: ticket
+title: Migrate CLI production code off workspace.Workspace to appbuild.Services
+kind: refactor
+priority: high
+effort: m
+status: backlog
+---
+
+Replace `*workspace.Workspace` usage in `internal/cli` production code with
+`*appbuild.Services`. `cliServices`'s accessor methods already match
+`appbuild.Services`'s surface 1:1, so the migration is largely mechanical.
+
+**Changes:**
+
+1. `internal/cli/cli_wiring.go`:
+   - `cliServices.ws *workspace.Workspace` → `svc *appbuild.Services`
+   - All `s.ws.X()` → `s.svc.X()`
+   - `newCLIServices` → `appbuild.Discover` (not `workspace.Discover`)
+   - Rename `newCLIServicesFromWorkspace` → `newCLIServicesFromAppbuild`
+   - Drop `cliWrite.LuaCache()` from the bundle interface entirely. The prior LuaWriteDeps refactor already plumbed cache through WriteDeps; only `flow.go` consumes `LuaCache()`.
+   - Update the renametype panic message reference from `workspace.WithFS` → `appbuild.WithFS`
+
+2. `internal/cli/flow.go`:
+   - `workspace.Discover` → `appbuild.Discover`
+   - `flowWs.LuaCache()` / `lua.WithCache(...)` → dropped. **AUDIT FIRST**: confirm `script.NewWriterRuntime` reads the cache from `WriteDeps`; if not, that's a real gap to surface
+   - `flowWs.LuaWriteDeps()` → `svc.LuaWriteDeps()` (same shape)
+   - No `defer svc.Close()` — short-lived CLI subcommand
+
+3. `internal/cli/validate.go`:
+   - `workspace.Discover(startDir, workspace.NopScriptExecutor)` → `appbuild.Discover(startDir, script.NewEngine())`
+   - Engine init is cheap; no NopScriptExecutor equivalent on appbuild
+   - `*workspace.Workspace` parameter on `runValidationChecks`/`runPropertiesCheck`/etc. → `*appbuild.Services`
+   - No `defer checkWs.Close()`
+
+4. `.go-arch-lint.yml`: `cli.mayDependOn`: add `appbuild` (keep `workspace` until TKT-NEW-C completes).
+
+Does NOT touch CLI test files (those use `workspace.NewForTest`; covered by
+follow-up TKT-NEW-C).
+
+**Scope:** ~150 LOC modified.
+
+See `.ignored/cli-off-workspace-plan.md` PR 2 for full detail.

--- a/tickets/entities/tickets/TKT-G8SX.md
+++ b/tickets/entities/tickets/TKT-G8SX.md
@@ -1,0 +1,41 @@
+---
+id: TKT-G8SX
+type: ticket
+title: Move project-setup utilities out of workspace into projectsetup
+kind: refactor
+priority: high
+effort: s
+status: ready
+---
+
+Lift the four free utility functions out of `internal/workspace` into a new
+`internal/projectsetup` package:
+
+- `Validate(startDir)` (+ `ValidateWithFS`, `ValidateResult`, `HasErrors`)
+- `Migrate(startDir)` (+ `MigrateWithFS`, `MigrateResult`, `MigrateDetection`, `MigrateFile`, `MigrateFileResult`)
+- `DetectMigrations(startDir)` (+ `DetectMigrationsWithFS`)
+- `Initialize(targetDir)` (+ `InitializeWithFS`, `InitResult`)
+
+These are pure file-IO utilities that don't need the workspace's stateful
+services. Moving them frees the rest of `internal/workspace` to be deleted in
+TKT-64R3.
+
+Also delete dead code: `workspace.NewAfterInit` (zero callers verified via `grep
+-rn NewAfterInit --include="*.go"`).
+
+**Callers to update:**
+
+- `internal/cli/init.go`: `workspace.Initialize` → `projectsetup.Initialize`
+- `internal/cli/migrate.go`: `workspace.DetectMigrations`, `workspace.Migrate` → `projectsetup.*`
+- `internal/cli/validate.go`: `workspace.Validate` → `projectsetup.Validate` (plus the `ValidateResult` type and `reportDataEntryValidation` parameter)
+
+**`.go-arch-lint.yml` changes:**
+
+- Add `projectsetup: { in: internal/projectsetup }` component
+- `projectsetup.mayDependOn`: `dataentryconfig, metamodel, migration, project, storage`
+- `cli.mayDependOn`: add `projectsetup` (keep `workspace` for now)
+- `workspace.mayDependOn`: drop `dataentryconfig, migration`
+
+**Scope:** ~360 LOC moved + ~100 LOC dead code deleted. No behavior change.
+
+See `.ignored/cli-off-workspace-plan.md` PR 1 for full detail.

--- a/tickets/entities/tickets/TKT-UG3C.md
+++ b/tickets/entities/tickets/TKT-UG3C.md
@@ -1,0 +1,41 @@
+---
+id: TKT-UG3C
+type: ticket
+title: Add appbuild.NewForTest fixture and migrate CLI tests off workspace.NewForTest
+kind: refactor
+priority: high
+effort: m
+status: backlog
+---
+
+Add a `NewForTest` fixture to `internal/appbuild` matching the shape CLI tests
+need, then swap the four CLI test files off `workspace.NewForTest`.
+
+**API:**
+
+```go
+func NewForTest(meta *metamodel.Metamodel, opts ...TestOption) *Services
+```
+
+**Design decisions:**
+
+- Takes `*Metamodel` directly (bypasses the loader, so pre-migration test metamodels work; matches `workspace.NewForTest` behavior)
+- Returns production `*Services` so tests use the same accessor surface
+- Options:
+  - `WithTestStore(store.Store)` — pre-built store for seeded fixtures
+  - `WithFS(fs storage.FS, paths *project.Context)` — for paths-aware code
+- **No `WithScript`** — CLI tests do not need to drive automation. Lua-cascade paths are covered at e2e/script level. Engine setup happens unconditionally; tests with empty automation sets pay the cheap construction cost
+- No `Close()` in test cleanup — tests today don't bother with workspace cleanup either
+
+**Files to migrate:**
+
+- `internal/cli/test_helpers_test.go`
+- `internal/cli/export_test.go`
+- `internal/cli/validate_test.go`
+- `internal/cli/rename_test.go` (uses pre-migration test metamodel; the `*Metamodel`-direct path matters here)
+
+Also adds `internal/appbuild/appbuild_test.go` cases for `NewForTest` itself.
+
+**Scope:** ~250 LOC.
+
+See `.ignored/cli-off-workspace-plan.md` PR 3 for full detail.

--- a/tickets/relations/TKT-DS43--affects--workspace.md
+++ b/tickets/relations/TKT-DS43--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DS43
+relation: affects
+to: workspace
+---

--- a/tickets/relations/TKT-DS43--implements--FEAT-workspace.md
+++ b/tickets/relations/TKT-DS43--implements--FEAT-workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DS43
+relation: implements
+to: FEAT-workspace
+---

--- a/tickets/relations/TKT-G8SX--affects--workspace.md
+++ b/tickets/relations/TKT-G8SX--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G8SX
+relation: affects
+to: workspace
+---

--- a/tickets/relations/TKT-G8SX--implements--FEAT-workspace.md
+++ b/tickets/relations/TKT-G8SX--implements--FEAT-workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G8SX
+relation: implements
+to: FEAT-workspace
+---

--- a/tickets/relations/TKT-UG3C--affects--test-fixtures.md
+++ b/tickets/relations/TKT-UG3C--affects--test-fixtures.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UG3C
+relation: affects
+to: test-fixtures
+---

--- a/tickets/relations/TKT-UG3C--affects--workspace.md
+++ b/tickets/relations/TKT-UG3C--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UG3C
+relation: affects
+to: workspace
+---

--- a/tickets/relations/TKT-UG3C--implements--FEAT-workspace.md
+++ b/tickets/relations/TKT-UG3C--implements--FEAT-workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UG3C
+relation: implements
+to: FEAT-workspace
+---


### PR DESCRIPTION
## Summary

PR 1 of the CLI-off-workspace arc. Lifts four pure file-IO utility functions out of `internal/workspace` into a new `internal/projectsetup` package:

- `Validate / ValidateWithFS` (+ `ValidateResult`, `HasErrors`)
- `Migrate / MigrateWithFS` (+ result/file types)
- `DetectMigrations / DetectMigrationsWithFS`
- `Initialize / InitializeWithFS` (+ `InitResult`)

Also deletes dead `workspace.NewAfterInit` (zero callers, verified).

These utilities don't need any of the workspace's stateful services — they walk static project files. Moving them frees the rest of `internal/workspace` to be deleted in TKT-64R3 once subsequent PRs migrate the CLI off `*workspace.Workspace`.

CLI call sites updated: `init.go`, `migrate.go`, `validate.go`. `cli` continues to import `workspace` for the type-parameter code that PR 2 (TKT-DS43) will handle.

Arch-lint: new `projectsetup` component, `cli.mayDependOn` gains it, `workspace.mayDependOn` drops `dataentryconfig` and `migration` (no longer needed).

Also files three follow-up tickets covering the full arc (TKT-G8SX/DS43/UG3C).

## Test plan

- [x] `go build ./...` clean
- [x] `just arch-lint` passes
- [x] `just lint` passes
- [x] `just test` passes
- [x] `just coverage-check` passes
- [x] New `projectsetup` package has 73% test coverage
- [x] Full `just ci` green locally