### PR TITLE
refactor(cli): migrate off workspace to appbuild.Services (TKT-DS43)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -72,6 +72,9 @@ components:
   memstore:         { in: internal/store/memstore }
   storeutil:        { in: internal/store/storeutil }
 
+  # Project bootstrap utilities
+  projectsetup:     { in: internal/projectsetup }
+
   # Infrastructure
   ai:               { in: internal/ai }
   secrets:          { in: internal/secrets }
@@ -184,6 +187,7 @@ deps:
       - metamodel
       - output
       - project
+      - projectsetup
       - rename
       - renametype
       - scheduler
@@ -280,12 +284,10 @@ deps:
       - automation
       - bleveindex
       - config
-      - dataentryconfig
       - entitymanager
       - lua
       - memstore
       - metamodel
-      - migration
       - project
       - rename
       - schema
@@ -298,6 +300,13 @@ deps:
       - tracer
       - validation
       - validator
+  projectsetup:
+    mayDependOn:
+      - dataentryconfig
+      - metamodel
+      - migration
+      - project
+      - storage
 
   # Domain services
   analysis:

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -166,6 +166,7 @@ deps:
       - ai
       - analysis
       - app
+      - appbuild
       - attachment
       - autocascade
       - automation
@@ -280,6 +281,7 @@ deps:
       - config
       - entitymanager
       - lua
+      - memstore
       - metamodel
       - project
       - script

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -103,6 +103,11 @@ func (s *Services) Validator() validator.Validator { return s.validator }
 // Templater returns the entity/relation template service.
 func (s *Services) Templater() templating.Templater { return s.templater }
 
+// ScriptEngine returns the Lua script engine. Callers that need the
+// engine's shared lua.Cache (for [lua.WithCache] when building runtimes
+// directly) reach it via [script.Engine.LuaCache].
+func (s *Services) ScriptEngine() *script.Engine { return s.scriptEngine }
+
 // Config returns the project's data-entry config loader.
 func (s *Services) Config() config.Loader { return s.cfgLoader }
 

--- a/internal/appbuild/testfixture.go
+++ b/internal/appbuild/testfixture.go
@@ -1,0 +1,178 @@
+package appbuild
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/Sourcehaven-BV/rela/internal/autocascade"
+	"github.com/Sourcehaven-BV/rela/internal/automation"
+	"github.com/Sourcehaven-BV/rela/internal/config"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/script"
+	"github.com/Sourcehaven-BV/rela/internal/search"
+	"github.com/Sourcehaven-BV/rela/internal/search/bleveindex"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+	"github.com/Sourcehaven-BV/rela/internal/templating"
+	"github.com/Sourcehaven-BV/rela/internal/tracer"
+	"github.com/Sourcehaven-BV/rela/internal/validator"
+)
+
+// TestOption configures a [Services] built via [NewForTest].
+type TestOption func(*testConfig)
+
+type testConfig struct {
+	fs    storage.FS
+	paths *project.Context
+	store store.Store
+}
+
+// WithTestStore replaces the default empty memstore with a
+// caller-supplied store. The fixture's search index is populated from
+// the store's current contents at construction time.
+//
+// Caveat: a caller-supplied store is NOT auto-wired with the search
+// backend as an observer — observer setup must happen at store
+// construction, which the fixture cannot retrofit. Initial-state
+// backfill still runs, so any entities already in the store appear in
+// search results; subsequent writes will not reach the index. If you
+// need incremental sync, build the memstore with [memstore.WithObserver]
+// yourself and pass that store here, or use the default memstore
+// (omit WithTestStore) which wires the observer automatically.
+func WithTestStore(s store.Store) TestOption {
+	return func(c *testConfig) { c.store = s }
+}
+
+// WithFS attaches a filesystem and project paths to the test fixture,
+// enabling paths-aware behavior (Paths(), Config(), templating against
+// project files). Without this, those accessors return zero values.
+func WithFS(fs storage.FS, paths *project.Context) TestOption {
+	return func(c *testConfig) {
+		c.fs = fs
+		c.paths = paths
+	}
+}
+
+// NewForTest constructs a *Services bundle suitable for tests. By
+// default the fixture has no filesystem, an empty memstore, and a real
+// script engine (cheap to construct; only exercised when automations
+// fire, which require WithFS-backed automation config). Use
+// [WithFS] / [WithTestStore] to customize.
+//
+// NewForTest takes *Metamodel directly and bypasses the loader, so test
+// metamodels that use pre-migration syntax work without running
+// migrations first. Mirrors workspace.NewForTest semantics for callers
+// migrating off the legacy fixture.
+//
+// Panics on construction failure: tests have no recovery path, and a
+// loud panic surfaces fixture-setup bugs at their source.
+func NewForTest(meta *metamodel.Metamodel, opts ...TestOption) *Services {
+	cfg := &testConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if meta == nil {
+		panic("appbuild.NewForTest: meta is required")
+	}
+
+	var searchBackend *bleveindex.Index
+	if idx, err := bleveindex.NewMem(); err == nil {
+		searchBackend = idx
+	} else {
+		slog.Warn("appbuild.NewForTest: failed to create search index", "error", err)
+	}
+
+	st := cfg.store
+	if st == nil {
+		if searchBackend != nil {
+			st = memstore.New(memstore.WithObserver(searchBackend))
+		} else {
+			st = memstore.New()
+		}
+	}
+
+	tr := tracer.New(st)
+	var searcher search.Searcher
+	if searchBackend != nil {
+		searcher = search.New(st, searchBackend)
+	} else {
+		searcher = search.ErrSearcher(errors.New("search index not available"))
+	}
+
+	root := ""
+	if cfg.paths != nil {
+		root = cfg.paths.Root
+	}
+	readDeps := lua.ReadDeps{
+		Store:       st,
+		Tracer:      tr,
+		Searcher:    searcher,
+		Meta:        meta,
+		ProjectRoot: root,
+	}
+
+	scriptEngine := script.NewEngine()
+
+	var autoEngine *automation.Engine
+	var cascadeRunner *autocascade.Runner
+	if len(meta.Automations) > 0 {
+		autoEngine = automation.NewEngineFromMetamodel(meta.Automations)
+		r, rerr := autocascade.New(autocascade.Deps{Engine: autoEngine})
+		if rerr != nil {
+			panic(fmt.Sprintf("appbuild.NewForTest: build autocascade runner: %v", rerr))
+		}
+		cascadeRunner = r
+	}
+
+	templater := templating.NewFSTemplater(cfg.fs, cfg.paths)
+	var cfgLoader config.Loader
+	if cfg.fs != nil && cfg.paths != nil {
+		cfgLoader = config.NewFSLoader(cfg.fs, cfg.paths.Root)
+	}
+
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:        st,
+		Meta:         meta,
+		Templater:    templater,
+		Automations:  autoEngine,
+		Cascade:      cascadeRunner,
+		ScriptRunner: script.NewLuaScriptRunner(scriptEngine, readDeps),
+	})
+	if err != nil {
+		panic(fmt.Sprintf("appbuild.NewForTest: build entitymanager: %v", err))
+	}
+
+	val := validator.New(st, meta, readDeps)
+
+	// Backfill the search index when a caller-supplied store is used:
+	// observers are NOT invoked for entities already present at
+	// construction time. (The default memstore wires the observer at
+	// build time so backfill is unnecessary there.)
+	if cfg.store != nil && searchBackend != nil {
+		if err := backfillSearchBackend(context.Background(), searchBackend, cfg.store); err != nil {
+			panic(fmt.Sprintf("appbuild.NewForTest: index entities: %v", err))
+		}
+	}
+
+	return &Services{
+		fs:            cfg.fs,
+		paths:         cfg.paths,
+		meta:          meta,
+		store:         st,
+		searcher:      searcher,
+		entityManager: mgr,
+		tracer:        tr,
+		validator:     val,
+		templater:     templater,
+		cfgLoader:     cfgLoader,
+		stateKV:       nopKV{},
+		scriptEngine:  scriptEngine,
+		searchBackend: searchBackend,
+	}
+}

--- a/internal/appbuild/testfixture_test.go
+++ b/internal/appbuild/testfixture_test.go
@@ -1,0 +1,61 @@
+package appbuild_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+func parseTestMetamodel(t *testing.T) *metamodel.Metamodel {
+	t.Helper()
+	meta, err := metamodel.Parse([]byte(metamodelYAML))
+	if err != nil {
+		t.Fatalf("parse metamodel: %v", err)
+	}
+	return meta
+}
+
+func TestNewForTest_Defaults(t *testing.T) {
+	meta := parseTestMetamodel(t)
+
+	svc := appbuild.NewForTest(meta)
+	if svc == nil {
+		t.Fatal("NewForTest returned nil")
+	}
+	if svc.Store() == nil {
+		t.Error("Store() == nil")
+	}
+	if svc.Meta() != meta {
+		t.Error("Meta() did not return the supplied metamodel")
+	}
+	if svc.EntityManager() == nil {
+		t.Error("EntityManager() == nil")
+	}
+	if svc.Tracer() == nil {
+		t.Error("Tracer() == nil")
+	}
+	if svc.ScriptEngine() == nil {
+		t.Error("ScriptEngine() == nil")
+	}
+}
+
+func TestNewForTest_WithTestStore(t *testing.T) {
+	meta := parseTestMetamodel(t)
+	customStore := memstore.New()
+
+	svc := appbuild.NewForTest(meta, appbuild.WithTestStore(customStore))
+	if svc.Store() != customStore {
+		t.Error("WithTestStore did not install the supplied store")
+	}
+}
+
+func TestNewForTest_NilMetaPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on nil metamodel, got none")
+		}
+	}()
+	_ = appbuild.NewForTest(nil)
+}

--- a/internal/cli/cli_wiring.go
+++ b/internal/cli/cli_wiring.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Sourcehaven-BV/rela/internal/analysis"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
 	"github.com/Sourcehaven-BV/rela/internal/attachment"
 	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -21,7 +22,6 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/templating"
 	"github.com/Sourcehaven-BV/rela/internal/tracer"
 	"github.com/Sourcehaven-BV/rela/internal/validator"
-	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 // Services bundles are scoped by purpose (read / write / analyze) so
@@ -90,14 +90,13 @@ type cliAnalyze interface {
 }
 
 // cliServices is the single concrete implementation that satisfies
-// all three bundle interfaces. It holds a *workspace.Workspace for
-// the methods still rooted there + dedicated services that have
-// been lifted out (currently: attachment; more to follow as
-// TKT-04YA / TKT-B01S land). The interfaces — not the struct — are
-// the consumer-facing contracts: subcommands see only the bundle
-// they pulled from context.
+// all three bundle interfaces. It holds an *appbuild.Services for the
+// per-project collaborators plus dedicated services that have been
+// lifted out (attachment, renametype, analysis). The interfaces — not
+// the struct — are the consumer-facing contracts: subcommands see
+// only the bundle they pulled from context.
 type cliServices struct {
-	ws         *workspace.Workspace
+	svc        *appbuild.Services
 	attachment *attachment.Service
 	renametype *renametype.Service
 	analysis   *analysis.Service
@@ -114,22 +113,22 @@ var (
 
 // --- cliRead ---
 
-func (s *cliServices) Store() store.Store              { return s.ws.Store() }
-func (s *cliServices) Meta() *metamodel.Metamodel      { return s.ws.Meta() }
-func (s *cliServices) Paths() *project.Context         { return s.ws.Paths() }
-func (s *cliServices) Tracer() tracer.Tracer           { return s.ws.Tracer() }
-func (s *cliServices) Searcher() search.Searcher       { return s.ws.Searcher() }
-func (s *cliServices) Config() config.Loader           { return s.ws.Config() }
-func (s *cliServices) Templater() templating.Templater { return s.ws.Templater() }
-func (s *cliServices) FS() storage.FS                  { return s.ws.FS() }
+func (s *cliServices) Store() store.Store              { return s.svc.Store() }
+func (s *cliServices) Meta() *metamodel.Metamodel      { return s.svc.Meta() }
+func (s *cliServices) Paths() *project.Context         { return s.svc.Paths() }
+func (s *cliServices) Tracer() tracer.Tracer           { return s.svc.Tracer() }
+func (s *cliServices) Searcher() search.Searcher       { return s.svc.Searcher() }
+func (s *cliServices) Config() config.Loader           { return s.svc.Config() }
+func (s *cliServices) Templater() templating.Templater { return s.svc.Templater() }
+func (s *cliServices) FS() storage.FS                  { return s.svc.FS() }
 
 // --- cliWrite ---
 
-func (s *cliServices) EntityManager() entitymanager.EntityManager { return s.ws.EntityManager() }
-func (s *cliServices) Validator() validator.Validator             { return s.ws.Validator() }
-func (s *cliServices) LuaCache() *lua.Cache                       { return s.ws.LuaCache() }
-func (s *cliServices) LuaWriteDeps() lua.WriteDeps                { return s.ws.LuaWriteDeps() }
-func (s *cliServices) State() state.KV                            { return s.ws.State() }
+func (s *cliServices) EntityManager() entitymanager.EntityManager { return s.svc.EntityManager() }
+func (s *cliServices) Validator() validator.Validator             { return s.svc.Validator() }
+func (s *cliServices) LuaCache() *lua.Cache                       { return s.svc.ScriptEngine().LuaCache() }
+func (s *cliServices) LuaWriteDeps() lua.WriteDeps                { return s.svc.LuaWriteDeps() }
+func (s *cliServices) State() state.KV                            { return s.svc.State() }
 
 // --- cliAnalyze ---
 
@@ -176,11 +175,11 @@ func (s *cliServices) RunValidationsFiltered(
 func (s *cliServices) RenameEntityType(oldType, newType, newPlural string) (int, error) {
 	if s.renametype == nil {
 		// Reached only when a test built cliServices from an
-		// FS-less workspace.NewForTest fixture and then drove a
+		// FS-less appbuild.NewForTest fixture and then drove a
 		// rename. Production wiring always populates renametype
-		// (workspace.Discover guarantees FS + Paths). Panic loudly
+		// (appbuild.Discover guarantees FS + Paths). Panic loudly
 		// so the test setup gap is unmistakable.
-		panic("cli: renametype service not wired — test fixture must use workspace.WithFS")
+		panic("cli: renametype service not wired — test fixture must use appbuild.WithFS")
 	}
 	return s.renametype.Rename(oldType, newType, newPlural)
 }
@@ -247,57 +246,55 @@ func cliAnalyzeFromContext(ctx context.Context) cliAnalyze {
 }
 
 // newCLIServices discovers the project at startDir and constructs
-// the focused-services bundle. Mirrors workspace.Discover's
-// behavior; the returned *cliServices satisfies cliRead / cliWrite /
-// cliAnalyze.
+// the focused-services bundle. Mirrors appbuild.Discover's behavior;
+// the returned *cliServices satisfies cliRead / cliWrite / cliAnalyze.
 func newCLIServices(startDir string) (*cliServices, error) {
-	ws, err := workspace.Discover(startDir, script.NewEngine())
+	svc, err := appbuild.Discover(startDir, script.NewEngine())
 	if err != nil {
 		return nil, err
 	}
-	return newCLIServicesFromWorkspace(ws)
+	return newCLIServicesFromAppbuild(svc)
 }
 
-// newCLIServicesFromWorkspace wires the focused services around an
-// already-constructed workspace. Used by [newCLIServices] in
-// production and by the test fixture (which constructs workspace
-// via [workspace.NewForTest]).
-func newCLIServicesFromWorkspace(ws *workspace.Workspace) (*cliServices, error) {
+// newCLIServicesFromAppbuild wires the focused services around an
+// already-constructed appbuild.Services. Used by [newCLIServices] in
+// production and by the CLI test fixtures.
+func newCLIServicesFromAppbuild(svc *appbuild.Services) (*cliServices, error) {
 	att, err := attachment.New(attachment.Deps{
-		Store:         ws.Store(),
-		Meta:          ws.Meta(),
-		EntityManager: ws.EntityManager(),
+		Store:         svc.Store(),
+		Meta:          svc.Meta(),
+		EntityManager: svc.EntityManager(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("attachment service: %w", err)
 	}
-	// renametype needs FS + Paths; the test fixture's
-	// workspace.NewForTest skips both. Skip wiring renametype when
-	// either is absent — handlers panic clearly via the unset-service
-	// check rather than nil-deref when an FS-less workspace is given
-	// to a rename test by accident.
+	// renametype needs FS + Paths; the FS-less appbuild.NewForTest
+	// fixture skips both. Skip wiring renametype when either is
+	// absent — handlers panic clearly via the unset-service check
+	// rather than nil-deref when an FS-less fixture is given to a
+	// rename test by accident.
 	var rt *renametype.Service
-	if ws.FS() != nil && ws.Paths() != nil {
+	if svc.FS() != nil && svc.Paths() != nil {
 		rt, err = renametype.New(renametype.Deps{
-			FS:    ws.FS(),
-			Meta:  ws.Meta(),
-			Paths: ws.Paths(),
+			FS:    svc.FS(),
+			Meta:  svc.Meta(),
+			Paths: svc.Paths(),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("renametype service: %w", err)
 		}
 	}
 	an, err := analysis.New(analysis.Deps{
-		Store:       ws.Store(),
-		Meta:        ws.Meta(),
-		Tracer:      ws.Tracer(),
-		LuaReadDeps: ws.LuaReadDeps(),
-		LuaCache:    ws.LuaCache(),
-		FS:          ws.FS(),
-		Paths:       ws.Paths(),
+		Store:       svc.Store(),
+		Meta:        svc.Meta(),
+		Tracer:      svc.Tracer(),
+		LuaReadDeps: svc.LuaReadDeps(),
+		LuaCache:    svc.ScriptEngine().LuaCache(),
+		FS:          svc.FS(),
+		Paths:       svc.Paths(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("analysis service: %w", err)
 	}
-	return &cliServices{ws: ws, attachment: att, renametype: rt, analysis: an}, nil
+	return &cliServices{svc: svc, attachment: att, renametype: rt, analysis: an}, nil
 }

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -11,12 +11,12 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/output"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 	"github.com/Sourcehaven-BV/rela/internal/testutil"
-	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 // setupTestGraph builds a small graph and attaches services to the
@@ -85,10 +85,11 @@ func setupTestGraph(t *testing.T) *metamodel.Metamodel {
 	seedR("CTRL-002", "mitigates", "RISK-001")
 	seedR("CTRL-001", "evidencedBy", "EV-001")
 
-	ws := workspace.NewForTest(meta, workspace.WithTestStore(s))
-	svc, err := newCLIServicesFromWorkspace(ws)
+	svc, err := newCLIServicesFromAppbuild(
+		appbuild.NewForTest(meta, appbuild.WithTestStore(s)),
+	)
 	if err != nil {
-		t.Fatalf("newCLIServicesFromWorkspace: %v", err)
+		t.Fatalf("newCLIServicesFromAppbuild: %v", err)
 	}
 	//nolint:fatcontext // testCtx is a sequential-test fixture, not a per-call context
 	testCtx = attachServices(t.Context(), svc)

--- a/internal/cli/flow.go
+++ b/internal/cli/flow.go
@@ -14,9 +14,9 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/script"
-	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 var flowOutputDir string
@@ -62,20 +62,20 @@ Example:
 		// Discover project from script location (walk up from script's directory)
 		// This allows shebang scripts to work from any directory
 		scriptDir := filepath.Dir(scriptPath)
-		flowWs, err := workspace.Discover(scriptDir, script.NewEngine())
+		flowSvc, err := appbuild.Discover(scriptDir, script.NewEngine())
 		if err != nil {
 			return fmt.Errorf("no project found for script %s", scriptPath)
 		}
 
 		opts := []lua.Option{
 			lua.WithContext(cmd.Context()),
-			lua.WithCache(flowWs.LuaCache()),
+			lua.WithCache(flowSvc.ScriptEngine().LuaCache()),
 		}
 		if flowOutputDir != "" {
 			opts = append(opts, lua.WithOutputDir(flowOutputDir))
 		}
 
-		runtime, rtErr := script.NewWriterRuntime(flowWs.LuaWriteDeps(),
+		runtime, rtErr := script.NewWriterRuntime(flowSvc.LuaWriteDeps(),
 			scriptPath, os.Stdout, opts...)
 		if rtErr != nil {
 			return rtErr

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Sourcehaven-BV/rela/internal/workspace"
+	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
 )
 
 var initCmd = &cobra.Command{
@@ -20,7 +20,7 @@ var initCmd = &cobra.Command{
 			targetDir = os.Getenv("RELA_PROJECT")
 		}
 
-		result, err := workspace.Initialize(targetDir)
+		result, err := projectsetup.Initialize(targetDir)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Sourcehaven-BV/rela/internal/workspace"
+	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
 )
 
 var (
@@ -41,7 +41,7 @@ Examples:
 }
 
 func runMigrateCheck(startDir string) error {
-	detections, err := workspace.DetectMigrations(startDir)
+	detections, err := projectsetup.DetectMigrations(startDir)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func runMigrateCheck(startDir string) error {
 }
 
 func runMigrate(startDir string) error {
-	result, err := workspace.Migrate(startDir)
+	result, err := projectsetup.Migrate(startDir)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/rename_test.go
+++ b/internal/cli/rename_test.go
@@ -6,12 +6,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/output"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/testutil"
-	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 // renameTestEnv is the bundle returned by setupRenameTestEnv; the
@@ -53,15 +53,17 @@ func setupRenameTestEnv(t *testing.T) renameTestEnv {
 		t.Fatalf("failed to parse metamodel: %v", err)
 	}
 
-	// Set up workspace backed by a real filesystem so the rename
-	// command can modify files on disk. Use NewForTest rather than
-	// workspace.New here because SimpleMetamodelYAML deliberately uses
-	// pre-migration syntax, which workspace.New rejects.
+	// Set up project services backed by a real filesystem so the
+	// rename command can modify files on disk. NewForTest takes
+	// *Metamodel directly (bypassing the loader) because
+	// SimpleMetamodelYAML deliberately uses pre-migration syntax which
+	// the loader rejects.
 	fs := storage.NewSafeFS(storage.NewOsFS())
-	ws := workspace.NewForTest(meta, workspace.WithFS(fs, paths))
-	svc, err := newCLIServicesFromWorkspace(ws)
+	svc, err := newCLIServicesFromAppbuild(
+		appbuild.NewForTest(meta, appbuild.WithFS(fs, paths)),
+	)
 	if err != nil {
-		t.Fatalf("newCLIServicesFromWorkspace: %v", err)
+		t.Fatalf("newCLIServicesFromAppbuild: %v", err)
 	}
 	//nolint:fatcontext // test setup
 	testCtx = attachServices(t.Context(), svc)

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 	"github.com/Sourcehaven-BV/rela/internal/testutil"
-	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 // testCtx is the cobra-context the test fixture stamps services into.
@@ -91,15 +91,13 @@ func (ss *storeSeeder) addRelation(from, relType, to string) {
 	}
 }
 
-// build wraps the seeded store in a workspace.Workspace (the
-// transitional facade still constructed via workspace.NewForTest)
-// and returns a *cliServices that satisfies cliRead / cliWrite /
-// cliAnalyze. TKT-2W0X moves the facade methods to dedicated
-// packages; until then, tests share the same workspace-backed
-// implementation production uses.
+// build wraps the seeded store in an *appbuild.Services and returns a
+// *cliServices that satisfies cliRead / cliWrite / cliAnalyze. Tests
+// share the same appbuild-backed implementation production uses.
 func (ss *storeSeeder) build() *cliServices {
-	ws := workspace.NewForTest(ss.meta, workspace.WithTestStore(ss.s))
-	svc, err := newCLIServicesFromWorkspace(ws)
+	svc, err := newCLIServicesFromAppbuild(
+		appbuild.NewForTest(ss.meta, appbuild.WithTestStore(ss.s)),
+	)
 	if err != nil {
 		panic("storeSeeder.build: " + err.Error())
 	}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -11,13 +11,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Sourcehaven-BV/rela/internal/analysis"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/errors"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/output"
 	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
 	"github.com/Sourcehaven-BV/rela/internal/schema"
-	"github.com/Sourcehaven-BV/rela/internal/workspace"
+	"github.com/Sourcehaven-BV/rela/internal/script"
 )
 
 // metamodelAccessor is the narrow consumer-side interface
@@ -128,26 +129,29 @@ func runValidate(cmd *cobra.Command, _ []string) error {
 		return errors.NewExitError(1)
 	}
 
-	// Initialize workspace for entity checks (no Lua executor needed for validation)
-	checkWs, err := workspace.Discover(startDir, workspace.NopScriptExecutor)
+	// Initialize project services for entity checks. The Lua engine is
+	// cheap to construct; validation rules load lazily, so paying the
+	// engine-init cost here is fine even though most validate runs
+	// don't execute Lua.
+	checkSvc, err := appbuild.Discover(startDir, script.NewEngine())
 	if err != nil {
-		return fmt.Errorf("failed to initialize workspace: %w", err)
+		return fmt.Errorf("failed to initialize project services: %w", err)
 	}
 	checkAnalysis, err := analysis.New(analysis.Deps{
-		Store:       checkWs.Store(),
-		Meta:        checkWs.Meta(),
-		Tracer:      checkWs.Tracer(),
-		LuaReadDeps: checkWs.LuaReadDeps(),
-		LuaCache:    checkWs.LuaCache(),
-		FS:          checkWs.FS(),
-		Paths:       checkWs.Paths(),
+		Store:       checkSvc.Store(),
+		Meta:        checkSvc.Meta(),
+		Tracer:      checkSvc.Tracer(),
+		LuaReadDeps: checkSvc.LuaReadDeps(),
+		LuaCache:    checkSvc.ScriptEngine().LuaCache(),
+		FS:          checkSvc.FS(),
+		Paths:       checkSvc.Paths(),
 	})
 	if err != nil {
 		return fmt.Errorf("initialize analysis service: %w", err)
 	}
 
 	// Run requested checks
-	checkErrors, err := runValidationChecks(cmd.Context(), checkWs, checkAnalysis, out, result.Metamodel)
+	checkErrors, err := runValidationChecks(cmd.Context(), checkSvc, checkAnalysis, out, result.Metamodel)
 	if err != nil {
 		return err
 	}
@@ -169,7 +173,7 @@ func runValidate(cmd *cobra.Command, _ []string) error {
 // runValidationChecks runs the requested validation checks and returns true if errors were found.
 func runValidationChecks(
 	ctx context.Context,
-	checkWs *workspace.Workspace,
+	checkSvc *appbuild.Services,
 	checkAnalysis *analysis.Service,
 	checkOut *output.Writer,
 	meta metamodelAccessor,
@@ -190,7 +194,7 @@ func runValidationChecks(
 	}
 
 	if checks.properties {
-		if runPropertiesCheck(checkWs, checkOut, opts) {
+		if runPropertiesCheck(checkSvc, checkOut, opts) {
 			hasErrors = true
 		}
 	}
@@ -239,11 +243,11 @@ func runCardinalityCheck(checkAnalysis *analysis.Service, checkOut *output.Write
 }
 
 // runPropertiesCheck runs property validation. Returns true if errors found.
-func runPropertiesCheck(checkWs *workspace.Workspace, checkOut *output.Writer, opts analysis.Options) bool {
+func runPropertiesCheck(checkSvc *appbuild.Services, checkOut *output.Writer, opts analysis.Options) bool {
 	if !quiet {
 		fmt.Println("\nValidating entity properties...")
 	}
-	propErrors := schema.ValidateEntityProperties(checkWs.Store(), checkWs.Meta())
+	propErrors := schema.ValidateEntityProperties(checkSvc.Store(), checkSvc.Meta())
 	if opts.Scope != nil {
 		filtered := propErrors[:0]
 		for _, pe := range propErrors {

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/errors"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/output"
+	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
 	"github.com/Sourcehaven-BV/rela/internal/schema"
 	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
@@ -88,7 +89,7 @@ func runValidate(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Always validate config files first
-	result, err := workspace.Validate(startDir)
+	result, err := projectsetup.Validate(startDir)
 	if err != nil {
 		return err
 	}
@@ -480,7 +481,7 @@ func parseValidationFilter(filterStr string, meta metamodelAccessor) (analysis.V
 }
 
 // reportDataEntryValidation reports data-entry.yaml validation results.
-func reportDataEntryValidation(result *workspace.ValidateResult, hasErrors bool) bool {
+func reportDataEntryValidation(result *projectsetup.ValidateResult, hasErrors bool) bool {
 	if result.DataEntrySkipped {
 		if quiet {
 			return hasErrors

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/analysis"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/output"
 	"github.com/Sourcehaven-BV/rela/internal/testutil"
 	"github.com/Sourcehaven-BV/rela/internal/tracer"
-	"github.com/Sourcehaven-BV/rela/internal/workspace"
 )
 
 // validate_test.go covers only the CLI concerns:
@@ -96,17 +96,17 @@ func TestParseChecks(t *testing.T) {
 	}
 }
 
-// seedWorkspace builds a workspace from a seeded memstore using the
-// given metamodel and seed function. Used to feed runValidationChecks
-// in CLI-layer tests — that function takes *workspace.Workspace
-// directly because validate.go (the package-global-free validate
-// command) constructs its own workspace for the --check pass.
-func seedWorkspace(meta *metamodel.Metamodel, seed func(*storeSeeder)) *workspace.Workspace {
+// seedServices builds an *appbuild.Services from a seeded memstore
+// using the given metamodel and seed function. Used to feed
+// runValidationChecks in CLI-layer tests — that function takes
+// *appbuild.Services directly because validate.go constructs its own
+// services bundle for the --check pass.
+func seedServices(meta *metamodel.Metamodel, seed func(*storeSeeder)) *appbuild.Services {
 	seeder := newStoreSeeder(meta)
 	if seed != nil {
 		seed(seeder)
 	}
-	return workspace.NewForTest(meta, workspace.WithTestStore(seeder.s))
+	return appbuild.NewForTest(meta, appbuild.WithTestStore(seeder.s))
 }
 
 // TestRunValidationChecks_JSONOutput exercises the CLI JSON output
@@ -136,7 +136,7 @@ func TestRunValidationChecks_JSONOutput(t *testing.T) {
 	}
 	meta.InitAliases()
 
-	ws := seedWorkspace(meta, func(s *storeSeeder) {
+	svc := seedServices(meta, func(s *storeSeeder) {
 		s.addEntity(testutil.EntityFor(meta, "feature").ID("FEAT-001"))
 	})
 
@@ -145,17 +145,17 @@ func TestRunValidationChecks_JSONOutput(t *testing.T) {
 
 	validateChecks = []string{"cardinality"}
 
-	tr := tracer.New(ws.Store())
+	tr := tracer.New(svc.Store())
 	an, err := analysis.New(analysis.Deps{
-		Store:       ws.Store(),
-		Meta:        ws.Meta(),
+		Store:       svc.Store(),
+		Meta:        svc.Meta(),
 		Tracer:      tr,
-		LuaReadDeps: ws.LuaReadDeps(),
+		LuaReadDeps: svc.LuaReadDeps(),
 	})
 	if err != nil {
 		t.Fatalf("analysis.New: %v", err)
 	}
-	hasErrors, err := runValidationChecks(context.Background(), ws, an, out, meta)
+	hasErrors, err := runValidationChecks(context.Background(), svc, an, out, meta)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/projectsetup/init.go
+++ b/internal/projectsetup/init.go
@@ -1,4 +1,4 @@
-package workspace
+package projectsetup
 
 import (
 	"errors"
@@ -86,17 +86,4 @@ func InitializeWithFS(targetDir string, fs storage.FS) (*InitResult, error) {
 	}
 
 	return result, nil
-}
-
-// NewAfterInit creates a workspace for a newly initialized project.
-// Use this after Initialize() when you need a workspace immediately.
-// Uses NopScriptExecutor since newly initialized projects don't have
-// Lua automations configured.
-func NewAfterInit(targetDir string) (*Workspace, error) {
-	fs := storage.NewSafeFS(storage.NewOsFS())
-	ctx, err := project.Discover(targetDir, fs)
-	if err != nil {
-		return nil, err
-	}
-	return New(fs, ctx, NopScriptExecutor)
 }

--- a/internal/projectsetup/init_test.go
+++ b/internal/projectsetup/init_test.go
@@ -1,0 +1,78 @@
+package projectsetup_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+func TestInitializeWithFS_CreatesProject(t *testing.T) {
+	fs := storage.NewMemFS()
+	target := "/proj"
+
+	result, err := projectsetup.InitializeWithFS(target, fs)
+	if err != nil {
+		t.Fatalf("InitializeWithFS: %v", err)
+	}
+
+	if result.Root != target {
+		t.Errorf("Root = %q, want %q", result.Root, target)
+	}
+	want := filepath.Join(target, project.MetamodelFile)
+	if result.MetamodelPath != want {
+		t.Errorf("MetamodelPath = %q, want %q", result.MetamodelPath, want)
+	}
+
+	data, err := fs.ReadFile(want)
+	if err != nil {
+		t.Fatalf("metamodel not written: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("metamodel.yaml is empty")
+	}
+}
+
+func TestInitializeWithFS_AlreadyInitialized(t *testing.T) {
+	fs := storage.NewMemFS()
+	target := "/proj"
+
+	if _, err := projectsetup.InitializeWithFS(target, fs); err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+	_, err := projectsetup.InitializeWithFS(target, fs)
+	if err == nil {
+		t.Fatal("expected error on re-init, got nil")
+	}
+	if !strings.Contains(err.Error(), "already initialized") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestInitializeWithFS_UpdatesGitignore(t *testing.T) {
+	fs := storage.NewMemFS()
+	target := "/proj"
+
+	if err := fs.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := fs.WriteFile(filepath.Join(target, ".gitignore"), []byte("node_modules/\n"), 0o644); err != nil {
+		t.Fatalf("seed gitignore: %v", err)
+	}
+
+	result, err := projectsetup.InitializeWithFS(target, fs)
+	if err != nil {
+		t.Fatalf("InitializeWithFS: %v", err)
+	}
+	if !result.GitignoreUpdate {
+		t.Error("expected GitignoreUpdate=true")
+	}
+
+	data, _ := fs.ReadFile(filepath.Join(target, ".gitignore"))
+	if !strings.Contains(string(data), ".rela") {
+		t.Errorf("gitignore not updated: %q", data)
+	}
+}

--- a/internal/projectsetup/migrate.go
+++ b/internal/projectsetup/migrate.go
@@ -1,4 +1,4 @@
-package workspace
+package projectsetup
 
 import (
 	"errors"

--- a/internal/projectsetup/migrate_test.go
+++ b/internal/projectsetup/migrate_test.go
@@ -1,0 +1,60 @@
+package projectsetup_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+func TestDetectMigrationsWithFS_NoProject(t *testing.T) {
+	fs := storage.NewMemFS()
+	_, err := projectsetup.DetectMigrationsWithFS("/missing", fs)
+	if err == nil {
+		t.Fatal("expected error for missing project, got nil")
+	}
+}
+
+func TestMigrateWithFS_NoProject(t *testing.T) {
+	fs := storage.NewMemFS()
+	_, err := projectsetup.MigrateWithFS("/missing", fs)
+	if err == nil {
+		t.Fatal("expected error for missing project, got nil")
+	}
+}
+
+func TestDetectMigrationsWithFS_RunsSuccessfully(t *testing.T) {
+	fs := storage.NewMemFS()
+	root := "/proj"
+	if _, err := projectsetup.InitializeWithFS(root, fs); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if _, err := projectsetup.DetectMigrationsWithFS(root, fs); err != nil {
+		t.Fatalf("DetectMigrationsWithFS: %v", err)
+	}
+}
+
+func TestMigrateWithFS_AppliesPending(t *testing.T) {
+	fs := storage.NewMemFS()
+	root := "/proj"
+	if _, err := projectsetup.InitializeWithFS(root, fs); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	result, err := projectsetup.MigrateWithFS(root, fs)
+	if err != nil {
+		t.Fatalf("MigrateWithFS: %v", err)
+	}
+	if result == nil {
+		t.Fatal("nil result")
+	}
+
+	after, err := projectsetup.DetectMigrationsWithFS(root, fs)
+	if err != nil {
+		t.Fatalf("DetectMigrationsWithFS after migrate: %v", err)
+	}
+	if len(after) != 0 {
+		t.Errorf("expected no pending migrations after Migrate, got %d", len(after))
+	}
+}

--- a/internal/projectsetup/validate.go
+++ b/internal/projectsetup/validate.go
@@ -1,4 +1,4 @@
-package workspace
+package projectsetup
 
 import (
 	"errors"

--- a/internal/projectsetup/validate_test.go
+++ b/internal/projectsetup/validate_test.go
@@ -1,0 +1,60 @@
+package projectsetup_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+func TestValidateWithFS_NoProject(t *testing.T) {
+	fs := storage.NewMemFS()
+	_, err := projectsetup.ValidateWithFS("/missing", fs)
+	if err == nil {
+		t.Fatal("expected error for missing project, got nil")
+	}
+}
+
+func TestValidateWithFS_ValidProject(t *testing.T) {
+	fs := storage.NewMemFS()
+	root := "/proj"
+	if _, err := projectsetup.InitializeWithFS(root, fs); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	result, err := projectsetup.ValidateWithFS(root, fs)
+	if err != nil {
+		t.Fatalf("ValidateWithFS: %v", err)
+	}
+	if !result.MetamodelValid {
+		t.Errorf("MetamodelValid = false, err = %v", result.MetamodelError)
+	}
+	if result.HasErrors() {
+		t.Errorf("HasErrors() = true, want false")
+	}
+}
+
+func TestValidateResult_HasErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		r    projectsetup.ValidateResult
+		want bool
+	}{
+		{"clean", projectsetup.ValidateResult{}, false},
+		{"metamodel err", projectsetup.ValidateResult{MetamodelError: errExample}, true},
+		{"data-entry err", projectsetup.ValidateResult{DataEntryError: errExample}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.r.HasErrors(); got != tc.want {
+				t.Errorf("HasErrors() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+type sentinel struct{ msg string }
+
+func (s sentinel) Error() string { return s.msg }
+
+var errExample = sentinel{msg: "x"}

--- a/tickets/entities/tickets/TKT-DS43.md
+++ b/tickets/entities/tickets/TKT-DS43.md
@@ -5,40 +5,57 @@ title: Migrate CLI production code off workspace.Workspace to appbuild.Services
 kind: refactor
 priority: high
 effort: m
-status: backlog
+status: ready
 ---
 
-Replace `*workspace.Workspace` usage in `internal/cli` production code with
+Replace `*workspace.Workspace` usage in `internal/cli` (production + tests) with
 `*appbuild.Services`. `cliServices`'s accessor methods already match
 `appbuild.Services`'s surface 1:1, so the migration is largely mechanical.
 
+**Note:** TKT-UG3C (test fixture) was folded into this ticket — the production
+swap can't compile while CLI tests still use `workspace.NewForTest` +
+`newCLIServicesFromWorkspace` (they share the `cliServices.svc` field). Doing
+them together produces a single coherent diff.
+
 **Changes:**
 
-1. `internal/cli/cli_wiring.go`:
+1. `internal/appbuild/appbuild.go`:
+   - Add `Services.ScriptEngine() *script.Engine` accessor so consumers can reach `script.Engine.LuaCache()` (audit confirmed: `script.NewWriterRuntime` reads cache from `lua.Option` not `WriteDeps`, so `flow.go` still needs the explicit `WithCache`)
+
+2. `internal/appbuild/testfixture.go` (new):
+   - `NewForTest(meta *metamodel.Metamodel, opts ...TestOption) *Services`
+   - `WithTestStore(store.Store)` — pre-built store for seeded fixtures
+   - `WithFS(fs storage.FS, paths *project.Context)` — for paths-aware code
+   - No `WithScript` (CLI tests don't drive automation)
+   - Takes `*Metamodel` directly (bypasses loader → works with pre-migration test metamodels)
+
+3. `internal/cli/cli_wiring.go`:
    - `cliServices.ws *workspace.Workspace` → `svc *appbuild.Services`
    - All `s.ws.X()` → `s.svc.X()`
-   - `newCLIServices` → `appbuild.Discover` (not `workspace.Discover`)
-   - Rename `newCLIServicesFromWorkspace` → `newCLIServicesFromAppbuild`
-   - Drop `cliWrite.LuaCache()` from the bundle interface entirely. The prior LuaWriteDeps refactor already plumbed cache through WriteDeps; only `flow.go` consumes `LuaCache()`.
-   - Update the renametype panic message reference from `workspace.WithFS` → `appbuild.WithFS`
+   - `LuaCache()` delegates via `s.svc.ScriptEngine().LuaCache()`
+   - `newCLIServices` → `appbuild.Discover`
+   - `newCLIServicesFromWorkspace` → `newCLIServicesFromAppbuild`
+   - Renametype panic message references `appbuild.WithFS` not `workspace.WithFS`
 
-2. `internal/cli/flow.go`:
+4. `internal/cli/flow.go`:
    - `workspace.Discover` → `appbuild.Discover`
-   - `flowWs.LuaCache()` / `lua.WithCache(...)` → dropped. **AUDIT FIRST**: confirm `script.NewWriterRuntime` reads the cache from `WriteDeps`; if not, that's a real gap to surface
-   - `flowWs.LuaWriteDeps()` → `svc.LuaWriteDeps()` (same shape)
-   - No `defer svc.Close()` — short-lived CLI subcommand
+   - `lua.WithCache(flowSvc.ScriptEngine().LuaCache())` (cache plumbing audit found `script.NewWriterRuntime` doesn't read cache from WriteDeps)
 
-3. `internal/cli/validate.go`:
+5. `internal/cli/validate.go`:
    - `workspace.Discover(startDir, workspace.NopScriptExecutor)` → `appbuild.Discover(startDir, script.NewEngine())`
-   - Engine init is cheap; no NopScriptExecutor equivalent on appbuild
-   - `*workspace.Workspace` parameter on `runValidationChecks`/`runPropertiesCheck`/etc. → `*appbuild.Services`
-   - No `defer checkWs.Close()`
+   - `*workspace.Workspace` parameter on `runValidationChecks`/`runPropertiesCheck` → `*appbuild.Services`
 
-4. `.go-arch-lint.yml`: `cli.mayDependOn`: add `appbuild` (keep `workspace` until TKT-NEW-C completes).
+6. CLI test files migrated: `test_helpers_test.go`, `export_test.go`, `validate_test.go`, `rename_test.go`. `seedWorkspace` → `seedServices`.
 
-Does NOT touch CLI test files (those use `workspace.NewForTest`; covered by
-follow-up TKT-NEW-C).
+7. `.go-arch-lint.yml`: `cli.mayDependOn` gains `appbuild`; `appbuild.mayDependOn` gains `memstore` (for `NewForTest`).
 
-**Scope:** ~150 LOC modified.
+**Audit finding (worth noting for future):** `script.NewWriterRuntime` does NOT
+plumb the lua.Cache through `WriteDeps` — cache flows through `lua.Option`. The
+original plan claimed otherwise. This means dropping `LuaCache()` from
+`cliWrite` would have broken `flow.go`. Kept it; delegates via
+`ScriptEngine().LuaCache()`.
 
-See `.ignored/cli-off-workspace-plan.md` PR 2 for full detail.
+**Scope:** ~400 LOC modified across production + tests; appbuild.NewForTest is
+~150 LOC new.
+
+Closes TKT-UG3C.

--- a/tickets/entities/tickets/TKT-DS43.md
+++ b/tickets/entities/tickets/TKT-DS43.md
@@ -1,0 +1,44 @@
+---
+id: TKT-DS43
+type: ticket
+title: Migrate CLI production code off workspace.Workspace to appbuild.Services
+kind: refactor
+priority: high
+effort: m
+status: backlog
+---
+
+Replace `*workspace.Workspace` usage in `internal/cli` production code with
+`*appbuild.Services`. `cliServices`'s accessor methods already match
+`appbuild.Services`'s surface 1:1, so the migration is largely mechanical.
+
+**Changes:**
+
+1. `internal/cli/cli_wiring.go`:
+   - `cliServices.ws *workspace.Workspace` → `svc *appbuild.Services`
+   - All `s.ws.X()` → `s.svc.X()`
+   - `newCLIServices` → `appbuild.Discover` (not `workspace.Discover`)
+   - Rename `newCLIServicesFromWorkspace` → `newCLIServicesFromAppbuild`
+   - Drop `cliWrite.LuaCache()` from the bundle interface entirely. The prior LuaWriteDeps refactor already plumbed cache through WriteDeps; only `flow.go` consumes `LuaCache()`.
+   - Update the renametype panic message reference from `workspace.WithFS` → `appbuild.WithFS`
+
+2. `internal/cli/flow.go`:
+   - `workspace.Discover` → `appbuild.Discover`
+   - `flowWs.LuaCache()` / `lua.WithCache(...)` → dropped. **AUDIT FIRST**: confirm `script.NewWriterRuntime` reads the cache from `WriteDeps`; if not, that's a real gap to surface
+   - `flowWs.LuaWriteDeps()` → `svc.LuaWriteDeps()` (same shape)
+   - No `defer svc.Close()` — short-lived CLI subcommand
+
+3. `internal/cli/validate.go`:
+   - `workspace.Discover(startDir, workspace.NopScriptExecutor)` → `appbuild.Discover(startDir, script.NewEngine())`
+   - Engine init is cheap; no NopScriptExecutor equivalent on appbuild
+   - `*workspace.Workspace` parameter on `runValidationChecks`/`runPropertiesCheck`/etc. → `*appbuild.Services`
+   - No `defer checkWs.Close()`
+
+4. `.go-arch-lint.yml`: `cli.mayDependOn`: add `appbuild` (keep `workspace` until TKT-NEW-C completes).
+
+Does NOT touch CLI test files (those use `workspace.NewForTest`; covered by
+follow-up TKT-NEW-C).
+
+**Scope:** ~150 LOC modified.
+
+See `.ignored/cli-off-workspace-plan.md` PR 2 for full detail.

--- a/tickets/entities/tickets/TKT-G8SX.md
+++ b/tickets/entities/tickets/TKT-G8SX.md
@@ -1,0 +1,41 @@
+---
+id: TKT-G8SX
+type: ticket
+title: Move project-setup utilities out of workspace into projectsetup
+kind: refactor
+priority: high
+effort: s
+status: ready
+---
+
+Lift the four free utility functions out of `internal/workspace` into a new
+`internal/projectsetup` package:
+
+- `Validate(startDir)` (+ `ValidateWithFS`, `ValidateResult`, `HasErrors`)
+- `Migrate(startDir)` (+ `MigrateWithFS`, `MigrateResult`, `MigrateDetection`, `MigrateFile`, `MigrateFileResult`)
+- `DetectMigrations(startDir)` (+ `DetectMigrationsWithFS`)
+- `Initialize(targetDir)` (+ `InitializeWithFS`, `InitResult`)
+
+These are pure file-IO utilities that don't need the workspace's stateful
+services. Moving them frees the rest of `internal/workspace` to be deleted in
+TKT-64R3.
+
+Also delete dead code: `workspace.NewAfterInit` (zero callers verified via `grep
+-rn NewAfterInit --include="*.go"`).
+
+**Callers to update:**
+
+- `internal/cli/init.go`: `workspace.Initialize` → `projectsetup.Initialize`
+- `internal/cli/migrate.go`: `workspace.DetectMigrations`, `workspace.Migrate` → `projectsetup.*`
+- `internal/cli/validate.go`: `workspace.Validate` → `projectsetup.Validate` (plus the `ValidateResult` type and `reportDataEntryValidation` parameter)
+
+**`.go-arch-lint.yml` changes:**
+
+- Add `projectsetup: { in: internal/projectsetup }` component
+- `projectsetup.mayDependOn`: `dataentryconfig, metamodel, migration, project, storage`
+- `cli.mayDependOn`: add `projectsetup` (keep `workspace` for now)
+- `workspace.mayDependOn`: drop `dataentryconfig, migration`
+
+**Scope:** ~360 LOC moved + ~100 LOC dead code deleted. No behavior change.
+
+See `.ignored/cli-off-workspace-plan.md` PR 1 for full detail.

--- a/tickets/entities/tickets/TKT-UG3C.md
+++ b/tickets/entities/tickets/TKT-UG3C.md
@@ -1,0 +1,41 @@
+---
+id: TKT-UG3C
+type: ticket
+title: Add appbuild.NewForTest fixture and migrate CLI tests off workspace.NewForTest
+kind: refactor
+priority: high
+effort: m
+status: backlog
+---
+
+Add a `NewForTest` fixture to `internal/appbuild` matching the shape CLI tests
+need, then swap the four CLI test files off `workspace.NewForTest`.
+
+**API:**
+
+```go
+func NewForTest(meta *metamodel.Metamodel, opts ...TestOption) *Services
+```
+
+**Design decisions:**
+
+- Takes `*Metamodel` directly (bypasses the loader, so pre-migration test metamodels work; matches `workspace.NewForTest` behavior)
+- Returns production `*Services` so tests use the same accessor surface
+- Options:
+  - `WithTestStore(store.Store)` — pre-built store for seeded fixtures
+  - `WithFS(fs storage.FS, paths *project.Context)` — for paths-aware code
+- **No `WithScript`** — CLI tests do not need to drive automation. Lua-cascade paths are covered at e2e/script level. Engine setup happens unconditionally; tests with empty automation sets pay the cheap construction cost
+- No `Close()` in test cleanup — tests today don't bother with workspace cleanup either
+
+**Files to migrate:**
+
+- `internal/cli/test_helpers_test.go`
+- `internal/cli/export_test.go`
+- `internal/cli/validate_test.go`
+- `internal/cli/rename_test.go` (uses pre-migration test metamodel; the `*Metamodel`-direct path matters here)
+
+Also adds `internal/appbuild/appbuild_test.go` cases for `NewForTest` itself.
+
+**Scope:** ~250 LOC.
+
+See `.ignored/cli-off-workspace-plan.md` PR 3 for full detail.

--- a/tickets/entities/tickets/TKT-UG3C.md
+++ b/tickets/entities/tickets/TKT-UG3C.md
@@ -5,37 +5,12 @@ title: Add appbuild.NewForTest fixture and migrate CLI tests off workspace.NewFo
 kind: refactor
 priority: high
 effort: m
-status: backlog
+status: wont-fix
 ---
 
-Add a `NewForTest` fixture to `internal/appbuild` matching the shape CLI tests
-need, then swap the four CLI test files off `workspace.NewForTest`.
-
-**API:**
-
-```go
-func NewForTest(meta *metamodel.Metamodel, opts ...TestOption) *Services
-```
-
-**Design decisions:**
-
-- Takes `*Metamodel` directly (bypasses the loader, so pre-migration test metamodels work; matches `workspace.NewForTest` behavior)
-- Returns production `*Services` so tests use the same accessor surface
-- Options:
-  - `WithTestStore(store.Store)` — pre-built store for seeded fixtures
-  - `WithFS(fs storage.FS, paths *project.Context)` — for paths-aware code
-- **No `WithScript`** — CLI tests do not need to drive automation. Lua-cascade paths are covered at e2e/script level. Engine setup happens unconditionally; tests with empty automation sets pay the cheap construction cost
-- No `Close()` in test cleanup — tests today don't bother with workspace cleanup either
-
-**Files to migrate:**
-
-- `internal/cli/test_helpers_test.go`
-- `internal/cli/export_test.go`
-- `internal/cli/validate_test.go`
-- `internal/cli/rename_test.go` (uses pre-migration test metamodel; the `*Metamodel`-direct path matters here)
-
-Also adds `internal/appbuild/appbuild_test.go` cases for `NewForTest` itself.
-
-**Scope:** ~250 LOC.
-
-See `.ignored/cli-off-workspace-plan.md` PR 3 for full detail.
+**Folded into TKT-DS43.** The production swap to `*appbuild.Services` can't
+compile while CLI tests still use `workspace.NewForTest` +
+`newCLIServicesFromWorkspace` — both production and test code share the
+`cliServices.svc` field type. Doing them in one PR produces a coherent single
+diff. `appbuild.NewForTest`, the test fixture migration, and all four CLI test
+file migrations now live in TKT-DS43.

--- a/tickets/relations/TKT-DS43--affects--workspace.md
+++ b/tickets/relations/TKT-DS43--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DS43
+relation: affects
+to: workspace
+---

--- a/tickets/relations/TKT-DS43--implements--FEAT-workspace.md
+++ b/tickets/relations/TKT-DS43--implements--FEAT-workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DS43
+relation: implements
+to: FEAT-workspace
+---

--- a/tickets/relations/TKT-G8SX--affects--workspace.md
+++ b/tickets/relations/TKT-G8SX--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G8SX
+relation: affects
+to: workspace
+---

--- a/tickets/relations/TKT-G8SX--implements--FEAT-workspace.md
+++ b/tickets/relations/TKT-G8SX--implements--FEAT-workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G8SX
+relation: implements
+to: FEAT-workspace
+---

--- a/tickets/relations/TKT-UG3C--affects--test-fixtures.md
+++ b/tickets/relations/TKT-UG3C--affects--test-fixtures.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UG3C
+relation: affects
+to: test-fixtures
+---

--- a/tickets/relations/TKT-UG3C--affects--workspace.md
+++ b/tickets/relations/TKT-UG3C--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UG3C
+relation: affects
+to: workspace
+---

--- a/tickets/relations/TKT-UG3C--implements--FEAT-workspace.md
+++ b/tickets/relations/TKT-UG3C--implements--FEAT-workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UG3C
+relation: implements
+to: FEAT-workspace
+---


### PR DESCRIPTION
## Summary

PR 2 of the CLI-off-workspace arc. Migrates `internal/cli` production AND test code off `*workspace.Workspace` onto `*appbuild.Services`.

**Stacked on:** #735 (appbuild package) + transitively #737 (projectsetup).

**Folded in TKT-UG3C** — the production swap couldn't compile while CLI tests still used `workspace.NewForTest` (both share the `cliServices.svc` field type). Adding `appbuild.NewForTest` here is the smaller PR than splitting.

### Changes

- **`appbuild.Services.ScriptEngine()`** accessor added (consumers need `script.Engine.LuaCache()` for `lua.WithCache(...)`; audit found cache flows through `lua.Option`, not `WriteDeps`)
- **`appbuild.NewForTest`** + `WithTestStore` / `WithFS` options. Takes `*Metamodel` directly so pre-migration test metamodels work.
- **`cli_wiring.go`**: `ws *workspace.Workspace` → `svc *appbuild.Services`; constructor renamed `…FromAppbuild`; renametype panic message updated.
- **`flow.go`**: `workspace.Discover` → `appbuild.Discover`; cache via `ScriptEngine().LuaCache()`.
- **`validate.go`**: `workspace.Discover(_, workspace.NopScriptExecutor)` → `appbuild.Discover(_, script.NewEngine())`. `runValidationChecks` / `runPropertiesCheck` retyped from `*workspace.Workspace` → `*appbuild.Services`.
- 4 CLI test files migrated (`test_helpers_test.go`, `export_test.go`, `validate_test.go`, `rename_test.go`); `seedWorkspace` renamed `seedServices`.
- `.go-arch-lint.yml`: `cli.mayDependOn` gains `appbuild`; `appbuild.mayDependOn` gains `memstore`.

### Audit finding (correction to plan)

Plan claimed `script.NewWriterRuntime` reads the cache from `WriteDeps`. **It doesn't** — cache flows through `lua.Option`. So `cliWrite.LuaCache()` stays in the bundle interface (delegating via `ScriptEngine().LuaCache()`); not dropped as the plan suggested. Plan revised in `.ignored/cli-off-workspace-plan.md` (not in this PR).

### Post-merge

After this lands, `internal/cli` no longer imports `internal/workspace`. PR 4 (TKT-64R3) can `git rm -r internal/workspace/`.

## Test plan

- [x] `go build ./...` clean
- [x] `just arch-lint` passes
- [x] `just lint` passes
- [x] `just test` — full suite green
- [x] `just coverage-check` passes (total 76.6%, appbuild 73%)
- [x] `just ci` full pipeline green locally