### PR TITLE
chore(tickets): mark TKT-QTNX/6OMC done

### DIFF
--- a/tickets/entities/tickets/TKT-6OMC.md
+++ b/tickets/entities/tickets/TKT-6OMC.md
@@ -5,7 +5,7 @@ title: Extract automation.Runner with consumer-side Host interface
 kind: refactor
 priority: high
 effort: m
-status: review
+status: done
 ---
 
 ## Summary

--- a/tickets/entities/tickets/TKT-QTNX.md
+++ b/tickets/entities/tickets/TKT-QTNX.md
@@ -5,7 +5,7 @@ title: Define entitymanager.Manager (real implementation, not adapter)
 kind: refactor
 priority: high
 effort: m
-status: in-progress
+status: done
 ---
 
 ## Summary


### PR DESCRIPTION
Both shipped already:
- TKT-QTNX in fc1d9d2 (#702)
- TKT-6OMC in 66d5096 (#694)

Just flipping status so analyze_validations stops flagging them.