### PR TITLE
feat(acl): Declarative ACL + Policy loading (TKT-1XK1L PR 2)

### DIFF
--- a/internal/acl/declarative.go
+++ b/internal/acl/declarative.go
@@ -1,0 +1,153 @@
+package acl
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// Declarative is the policy-driven [ACL] implementation. It composes
+// a [Policy] (loaded from `acl.yaml`) with the [principal.Principal]
+// carried on each request's context to answer [ACL.AuthorizeWrite].
+//
+// v0 scope:
+//
+//   - **Global roles only.** A principal's effective role set is
+//     `Assignments[user]` plus the `default` role (if defined). Groups
+//     and transitive `member-of` expansion are deferred to v1.
+//   - **Union semantics.** Any role granting write on the target
+//     entity type → allow. The returned RuleID names the first role
+//     that matched, for debuggability.
+//   - **Delegate-X tamper resistance.** Writes to a relation type
+//     listed in [Policy.RoleRelations] require the writer to hold the
+//     declared permission. See [RoleRelationDef.RequiresPermission].
+//
+// PR 2 wires this in unit tests only; PR 3 makes [appbuild.Discover]
+// load it.
+type Declarative struct {
+	policy *Policy
+}
+
+// NewDeclarative wraps a [Policy] as an [ACL]. The Policy must be
+// non-nil; the caller (typically appbuild) loads it via
+// [LoadPolicy] and falls back to [NopACL] when no `acl.yaml` exists.
+func NewDeclarative(p *Policy) *Declarative {
+	return &Declarative{policy: p}
+}
+
+// AuthorizeWrite implements [ACL.AuthorizeWrite].
+//
+// Order of checks:
+//
+//  1. If `req.RelationType` names a role-relation that declares a
+//     `requires_permission`, the writer must hold that permission.
+//     Deny with `RuleKind="delegate-permission"` on miss.
+//  2. Otherwise (and for entity writes), any role in the principal's
+//     effective set whose `write` list contains the target type — or
+//     the wildcard `"*"` — allows. The matching role's name surfaces
+//     as `RuleID`.
+//  3. No role granted → deny with `RuleKind="role-grant"`,
+//     `RuleID="-"`.
+//
+// For relation writes, `req.EntityType` carries the source entity's
+// type (the caller in entitymanager looks it up). Empty EntityType
+// is treated as the literal target `"relation"` — denied by default
+// since no role would grant write on a synthetic type, surfacing the
+// misuse in the deny reason.
+func (d *Declarative) AuthorizeWrite(ctx context.Context, req WriteRequest) Decision {
+	p := principal.From(ctx)
+	roles := d.effectiveRoles(p)
+
+	// 1. Delegate-X gate for role-relation writes.
+	if req.RelationType != "" {
+		if rr, ok := d.policy.RoleRelations[req.RelationType]; ok && rr.RequiresPermission != "" {
+			if !d.holdsPermission(roles, rr.RequiresPermission) {
+				return Decision{
+					Allow:    false,
+					RuleKind: "delegate-permission",
+					RuleID:   rr.RequiresPermission,
+					Reason: fmt.Sprintf("writing '%s' relations requires permission '%s'",
+						req.RelationType, rr.RequiresPermission),
+				}
+			}
+		}
+	}
+
+	// 2. Type-level write grant. Union across roles; first hit wins
+	//    for RuleID (deterministic via effectiveRoles ordering).
+	target := req.EntityType
+	if target == "" {
+		target = "relation"
+	}
+	for _, name := range roles {
+		role, ok := d.policy.Roles[name]
+		if !ok {
+			continue
+		}
+		if roleGrantsWrite(role, target) {
+			return Decision{Allow: true, RuleKind: "role-grant", RuleID: name}
+		}
+	}
+
+	return Decision{
+		Allow:    false,
+		RuleKind: "role-grant",
+		RuleID:   "-",
+		Reason:   fmt.Sprintf("no role grants write on type '%s'", target),
+	}
+}
+
+// effectiveRoles returns the role names applicable to p, in priority
+// order: explicit assignment first, then the `default` role (when
+// defined). The order is stable so [AuthorizeWrite] deterministically
+// reports the same RuleID for a given Allow.
+//
+// v0 is global-roles-only: no group expansion. If
+// `Assignments[user]` names an undefined role, it is dropped (a
+// load-time warning will have been emitted in v1; v0 silently
+// ignores — operators discover the typo via `analyze_*` style
+// follow-up tickets). `default` is always appended last if defined.
+func (d *Declarative) effectiveRoles(p principal.Principal) []string {
+	var out []string
+	if name, ok := d.policy.Assignments[p.User]; ok {
+		if _, defined := d.policy.Roles[name]; defined {
+			out = append(out, name)
+		}
+	}
+	if _, ok := d.policy.Roles["default"]; ok {
+		// Only append default if it isn't already the principal's
+		// explicit role (defensive against `assignments: {alice: default}`).
+		if !slices.Contains(out, "default") {
+			out = append(out, "default")
+		}
+	}
+	return out
+}
+
+// holdsPermission reports whether any of `roles` lists `perm` in its
+// Permissions. Union semantics — one match is enough.
+func (d *Declarative) holdsPermission(roles []string, perm string) bool {
+	for _, name := range roles {
+		role, ok := d.policy.Roles[name]
+		if !ok {
+			continue
+		}
+		if slices.Contains(role.Permissions, perm) {
+			return true
+		}
+	}
+	return false
+}
+
+// roleGrantsWrite reports whether `role.Write` covers `target` —
+// either by an exact match or by the wildcard `"*"`.
+func roleGrantsWrite(role RoleDef, target string) bool {
+	for _, w := range role.Write {
+		if w == "*" || w == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/acl/declarative_test.go
+++ b/internal/acl/declarative_test.go
@@ -1,0 +1,284 @@
+package acl_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// testPolicy is the fixture used across declarative tests. Mirrors the
+// example operators see in docs/security.md (PR 3): three real roles +
+// a default, with one role-relation gated by a delegate permission.
+func testPolicy() *acl.Policy {
+	return &acl.Policy{
+		UserEntityType: "person",
+		Roles: map[string]acl.RoleDef{
+			"admin": {
+				Write:       []string{"*"},
+				Read:        []string{"*"},
+				Permissions: []string{"delegate-admin", "delegate-contributor", "delegate-reviewer"},
+			},
+			"contributor": {
+				Write:       []string{"ticket", "concept"},
+				Read:        []string{"*"},
+				Permissions: []string{"delegate-reviewer"},
+			},
+			"reviewer": {
+				Write: []string{"review-response"},
+				Read:  []string{"*"},
+			},
+			"default": {
+				Read: []string{"*"},
+			},
+		},
+		Assignments: map[string]string{
+			"jeroen": "admin",
+			"alice":  "contributor",
+			"bob":    "reviewer",
+		},
+		RoleRelations: map[string]acl.RoleRelationDef{
+			"ticket-owner": {
+				Confers:            "contributor",
+				RequiresPermission: "delegate-contributor",
+			},
+			"open-relation": {
+				Confers: "contributor", // no requires_permission — delegate gate disabled
+			},
+		},
+	}
+}
+
+// ctxAs returns a context with the given principal user attached
+// (Tool=cli for stability — the ACL doesn't gate on tool in v0).
+func ctxAs(user string) context.Context {
+	return principal.With(context.Background(), principal.Principal{User: user, Tool: principal.ToolCLI})
+}
+
+// AC2.2: a role's `write` list grants creation of that type.
+func TestAuthorizeWrite_RoleGrantsType_Allows(t *testing.T) {
+	d := acl.NewDeclarative(testPolicy())
+
+	got := d.AuthorizeWrite(ctxAs("alice"), acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket"})
+	if !got.Allow {
+		t.Fatalf("Allow = false, want true. Decision = %+v", got)
+	}
+	if got.RuleKind != "role-grant" {
+		t.Errorf("RuleKind = %q, want %q", got.RuleKind, "role-grant")
+	}
+	if got.RuleID != "contributor" {
+		t.Errorf("RuleID = %q, want %q", got.RuleID, "contributor")
+	}
+}
+
+// AC2.3: no role grants → structured deny.
+func TestAuthorizeWrite_NoRoleGrants_Denies(t *testing.T) {
+	d := acl.NewDeclarative(testPolicy())
+
+	got := d.AuthorizeWrite(ctxAs("bob"), acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket"})
+	if got.Allow {
+		t.Fatalf("Allow = true, want false (reviewer has no write on ticket). Decision = %+v", got)
+	}
+	if got.RuleKind != "role-grant" {
+		t.Errorf("RuleKind = %q, want %q", got.RuleKind, "role-grant")
+	}
+	if got.RuleID != "-" {
+		t.Errorf("RuleID = %q, want %q", got.RuleID, "-")
+	}
+	wantReason := "no role grants write on type 'ticket'"
+	if got.Reason != wantReason {
+		t.Errorf("Reason = %q, want %q", got.Reason, wantReason)
+	}
+}
+
+// AC2.4: wildcard `*` grants any type.
+func TestAuthorizeWrite_WildcardRole_Allows(t *testing.T) {
+	d := acl.NewDeclarative(testPolicy())
+
+	for _, etype := range []string{"ticket", "concept", "person", "made-up-type"} {
+		got := d.AuthorizeWrite(ctxAs("jeroen"), acl.WriteRequest{Op: acl.OpCreate, EntityType: etype})
+		if !got.Allow {
+			t.Errorf("admin denied write on %q: %+v", etype, got)
+		}
+		if got.RuleID != "admin" {
+			t.Errorf("RuleID = %q, want %q (wildcard match should attribute to admin)", got.RuleID, "admin")
+		}
+	}
+}
+
+// AC2.5: writing a role-relation that requires a permission the
+// principal doesn't hold → delegate-permission deny.
+func TestAuthorizeWrite_RoleRelation_DelegatePermissionMissing_Denies(t *testing.T) {
+	d := acl.NewDeclarative(testPolicy())
+
+	// alice (contributor) holds delegate-reviewer but not
+	// delegate-contributor, so she cannot grant the contributor role
+	// via the `ticket-owner` relation.
+	got := d.AuthorizeWrite(ctxAs("alice"), acl.WriteRequest{
+		Op:           acl.OpCreate,
+		EntityType:   "ticket", // alice CAN write tickets, but the delegate gate runs first
+		RelationType: "ticket-owner",
+	})
+	if got.Allow {
+		t.Fatalf("Allow = true, want false. Decision = %+v", got)
+	}
+	if got.RuleKind != "delegate-permission" {
+		t.Errorf("RuleKind = %q, want %q", got.RuleKind, "delegate-permission")
+	}
+	if got.RuleID != "delegate-contributor" {
+		t.Errorf("RuleID = %q, want %q", got.RuleID, "delegate-contributor")
+	}
+}
+
+// AC2.5: writing the same role-relation with the required permission
+// proceeds to the type-level write check and (here) succeeds.
+func TestAuthorizeWrite_RoleRelation_DelegatePermissionHeld_Allows(t *testing.T) {
+	d := acl.NewDeclarative(testPolicy())
+
+	// jeroen (admin) holds delegate-contributor AND can write any
+	// entity type via the `*` wildcard, so this allows.
+	got := d.AuthorizeWrite(ctxAs("jeroen"), acl.WriteRequest{
+		Op:           acl.OpCreate,
+		EntityType:   "ticket",
+		RelationType: "ticket-owner",
+	})
+	if !got.Allow {
+		t.Fatalf("Allow = false, want true (admin holds delegate-contributor). Decision = %+v", got)
+	}
+}
+
+// AC2.5: a role-relation declared *without* requires_permission skips
+// the delegate gate — any principal who can write the source entity
+// can write the relation.
+func TestAuthorizeWrite_RoleRelation_NoDelegateRequired_Allows(t *testing.T) {
+	d := acl.NewDeclarative(testPolicy())
+
+	got := d.AuthorizeWrite(ctxAs("alice"), acl.WriteRequest{
+		Op:           acl.OpCreate,
+		EntityType:   "ticket",
+		RelationType: "open-relation",
+	})
+	if !got.Allow {
+		t.Fatalf("Allow = false, want true (open-relation has no requires_permission). Decision = %+v", got)
+	}
+}
+
+// AC2.6: a principal with no Assignments entry inherits the `default`
+// role's capabilities.
+func TestAuthorizeWrite_UnknownPrincipal_GetsDefaultRole(t *testing.T) {
+	d := acl.NewDeclarative(testPolicy())
+
+	// `default` has no write entries — every write is denied, but the
+	// deny RuleKind is role-grant (not "no roles at all"), proving
+	// default was consulted.
+	got := d.AuthorizeWrite(ctxAs("carol"), acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket"})
+	if got.Allow {
+		t.Fatalf("Allow = true, want false (default has no writes). Decision = %+v", got)
+	}
+	if got.RuleKind != "role-grant" {
+		t.Errorf("RuleKind = %q, want %q", got.RuleKind, "role-grant")
+	}
+}
+
+// AC2.6 + AC2.7: when `default` grants writes, an unknown principal
+// gets them via the default role. RuleID surfaces "default".
+func TestAuthorizeWrite_DefaultRoleGrantsWrites(t *testing.T) {
+	policy := testPolicy()
+	policy.Roles["default"] = acl.RoleDef{
+		Write: []string{"comment"},
+		Read:  []string{"*"},
+	}
+	d := acl.NewDeclarative(policy)
+
+	got := d.AuthorizeWrite(ctxAs("carol"), acl.WriteRequest{Op: acl.OpCreate, EntityType: "comment"})
+	if !got.Allow {
+		t.Fatalf("Allow = false, want true. Decision = %+v", got)
+	}
+	if got.RuleID != "default" {
+		t.Errorf("RuleID = %q, want %q", got.RuleID, "default")
+	}
+}
+
+// AC2.7: a principal with explicit role X *plus* the default role
+// gets the union of writes. The explicit role takes priority for
+// RuleID when it covers the type.
+func TestAuthorizeWrite_MultipleRoles_Unions(t *testing.T) {
+	policy := testPolicy()
+	// Make default also grant writes on a type the explicit role
+	// doesn't cover, so we can prove the union.
+	policy.Roles["default"] = acl.RoleDef{
+		Write: []string{"comment"},
+		Read:  []string{"*"},
+	}
+	d := acl.NewDeclarative(policy)
+
+	// bob is reviewer (writes review-response). With default also
+	// granting "comment", bob should be able to write both.
+	for _, tc := range []struct {
+		etype  string
+		wantID string
+	}{
+		{"review-response", "reviewer"}, // explicit role wins
+		{"comment", "default"},          // only default covers this
+	} {
+		got := d.AuthorizeWrite(ctxAs("bob"), acl.WriteRequest{Op: acl.OpCreate, EntityType: tc.etype})
+		if !got.Allow {
+			t.Errorf("bob denied on %q: %+v", tc.etype, got)
+			continue
+		}
+		if got.RuleID != tc.wantID {
+			t.Errorf("RuleID for %q = %q, want %q", tc.etype, got.RuleID, tc.wantID)
+		}
+	}
+}
+
+// Negative test: an Assignments entry referencing an undefined role
+// is silently ignored — the principal falls through to default only.
+func TestAuthorizeWrite_AssignmentToUndefinedRole_DropsToDefault(t *testing.T) {
+	policy := testPolicy()
+	policy.Assignments["typo"] = "contribtuor" // misspelled role name
+	d := acl.NewDeclarative(policy)
+
+	// "default" has no writes → deny on ticket. If the bad
+	// assignment leaked through, RuleID would be "contribtuor" (or
+	// the eval would Allow if we resolved the typo).
+	got := d.AuthorizeWrite(ctxAs("typo"), acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket"})
+	if got.Allow {
+		t.Fatalf("Allow = true, want false. Decision = %+v", got)
+	}
+	if got.RuleKind != "role-grant" || got.RuleID != "-" {
+		t.Errorf("Decision = %+v, want role-grant/- (undefined role should be dropped)", got)
+	}
+}
+
+// Negative test: empty WriteRequest decays to target='relation' and
+// denies.
+func TestAuthorizeWrite_EmptyRequest_Denies(t *testing.T) {
+	d := acl.NewDeclarative(testPolicy())
+
+	got := d.AuthorizeWrite(ctxAs("alice"), acl.WriteRequest{})
+	if got.Allow {
+		t.Fatalf("Allow = true, want false. Decision = %+v", got)
+	}
+	if got.Reason != "no role grants write on type 'relation'" {
+		t.Errorf("Reason = %q, want %q", got.Reason, "no role grants write on type 'relation'")
+	}
+}
+
+// Returns ForbiddenError via Decision propagation: any deny can be
+// wrapped at the manager boundary into the same *ForbiddenError shape
+// PR 1 ships. Sanity-check the round trip.
+func TestAuthorizeWrite_DenyConvertsToForbiddenError(t *testing.T) {
+	d := acl.NewDeclarative(testPolicy())
+
+	dec := d.AuthorizeWrite(ctxAs("bob"), acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket"})
+	if dec.Allow {
+		t.Fatal("expected deny")
+	}
+	err := &acl.ForbiddenError{Decision: dec}
+	if !errors.Is(err, acl.ErrForbidden) {
+		t.Errorf("errors.Is(_, ErrForbidden) = false on wrapped deny Decision")
+	}
+}

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -1,0 +1,117 @@
+package acl
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Policy is the declarative ACL configuration parsed from `acl.yaml`
+// at the project root. v0 fields:
+//
+//   - [Policy.UserEntityType] declares which entity type represents
+//     a user (e.g. "person", "user"). Currently informational —
+//     reserved for v1 group expansion when [Policy.RoleRelations]
+//     binds principals to entities.
+//   - [Policy.Roles] declares the named capability bundles. The
+//     special role name `default` is appended to every principal's
+//     effective role set; see [Declarative.effectiveRoles].
+//   - [Policy.Assignments] maps `principal.User` → role name.
+//     Unknown role names (assigned but not declared in Roles) log a
+//     warning at load and are dropped from the effective set.
+//   - [Policy.RoleRelations] declares which relation types grant a
+//     role to their source entity, and which permission the writer
+//     must hold (delegate-X tamper resistance — see [Declarative]).
+//
+// **Tolerant by design.** Unknown top-level keys emit one
+// `slog.Warn` per key and are otherwise ignored. Operators iterate
+// on `acl.yaml` frequently and a typo shouldn't brick the server —
+// the metamodel loader follows the same convention. Hard errors
+// reserved for unparseable YAML or undecodable values within a
+// known key.
+type Policy struct {
+	UserEntityType string                     `yaml:"user_entity_type"`
+	Roles          map[string]RoleDef         `yaml:"roles"`
+	Assignments    map[string]string          `yaml:"assignments"`
+	RoleRelations  map[string]RoleRelationDef `yaml:"role_relations"`
+}
+
+// RoleDef is the capability bundle for a single role. v0 honors
+// Write and Permissions; Read is parsed but unused (v1 reads).
+//
+// Wildcard write: a single entry `"*"` grants write on every entity
+// type. Mixing `"*"` with explicit types is allowed but redundant —
+// the wildcard short-circuits the per-type check.
+type RoleDef struct {
+	Write       []string `yaml:"write"`
+	Read        []string `yaml:"read"`
+	Permissions []string `yaml:"permissions"`
+}
+
+// RoleRelationDef declares that a graph relation type confers a role
+// on its source entity. Writes to relations of this type are gated by
+// [RoleRelationDef.RequiresPermission] — the writer (principal) must
+// hold that permission via one of their effective roles. This is the
+// Plone delegate-X tamper-resistance pattern: granting role X requires
+// permission delegate-X, so the principal who can hand out access is
+// distinct from the principal who has access.
+//
+// Empty [RoleRelationDef.RequiresPermission] disables the delegate-X
+// gate — the relation type is recognized as role-conferring (for
+// future group expansion) but no permission check fires on writes.
+type RoleRelationDef struct {
+	Confers            string `yaml:"confers"`
+	RequiresPermission string `yaml:"requires_permission"`
+}
+
+// knownPolicyKeys is the allowlist used for unknown-key warnings.
+// Keep in sync with [Policy]'s yaml tags.
+var knownPolicyKeys = map[string]bool{
+	"user_entity_type": true,
+	"roles":            true,
+	"assignments":      true,
+	"role_relations":   true,
+}
+
+// LoadPolicy reads and parses `acl.yaml` at the given path.
+//
+// Errors:
+//   - The caller distinguishes "no policy file" from "broken policy
+//     file" via [os.ErrNotExist]. Use `errors.Is(err, os.ErrNotExist)`
+//     to fall back to [NopACL] when no policy is present.
+//   - Any other I/O error or YAML parse error returns wrapped.
+//
+// Unknown top-level keys emit one `slog.Warn` per key and are
+// otherwise ignored. The returned [Policy] is non-nil on success
+// even if every field is zero (matches "empty file is valid").
+func LoadPolicy(path string) (*Policy, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err // preserves os.ErrNotExist for errors.Is
+	}
+
+	// First pass: discover unknown top-level keys. Decoding into
+	// map[string]any rather than KnownFields(true) on Policy lets
+	// us warn-and-continue rather than fail.
+	if len(data) > 0 {
+		var raw map[string]any
+		if uErr := yaml.Unmarshal(data, &raw); uErr == nil {
+			for k := range raw {
+				if !knownPolicyKeys[k] {
+					slog.Warn("acl: unknown key in acl.yaml; ignored",
+						"path", path, "key", k)
+				}
+			}
+		}
+		// Parse failure here is not fatal — the typed decode below
+		// will surface the same error with better context.
+	}
+
+	var policy Policy
+	if uErr := yaml.Unmarshal(data, &policy); uErr != nil {
+		return nil, fmt.Errorf("acl: parse %s: %w", path, uErr)
+	}
+	return &policy, nil
+}

--- a/internal/acl/policy_test.go
+++ b/internal/acl/policy_test.go
@@ -1,0 +1,157 @@
+package acl_test
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// AC2.1: empty file decodes to a zero Policy.
+func TestLoadPolicy_Empty(t *testing.T) {
+	path := writeTempPolicy(t, "")
+	p, err := acl.LoadPolicy(path)
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	if p == nil {
+		t.Fatal("LoadPolicy returned nil Policy")
+	}
+	if len(p.Roles) != 0 || len(p.Assignments) != 0 || len(p.RoleRelations) != 0 {
+		t.Errorf("expected zero Policy, got %+v", p)
+	}
+}
+
+// AC2.1: a complete acl.yaml example round-trips into the typed shape
+// downstream code consumes.
+func TestLoadPolicy_FullExample(t *testing.T) {
+	const yaml = `
+user_entity_type: person
+roles:
+  admin:
+    write: ["*"]
+    read: ["*"]
+    permissions: [delegate-admin, delegate-contributor]
+  contributor:
+    write: [ticket, concept]
+    read: ["*"]
+    permissions: [delegate-reviewer]
+  reviewer:
+    write: [review-response]
+    read: ["*"]
+  default:
+    read: ["*"]
+assignments:
+  jeroen: admin
+  alice:  contributor
+  bob:    reviewer
+role_relations:
+  ticket-owner:
+    confers: contributor
+    requires_permission: delegate-contributor
+`
+	path := writeTempPolicy(t, yaml)
+	p, err := acl.LoadPolicy(path)
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	if p.UserEntityType != "person" {
+		t.Errorf("UserEntityType = %q, want %q", p.UserEntityType, "person")
+	}
+	if len(p.Roles) != 4 {
+		t.Errorf("len(Roles) = %d, want 4", len(p.Roles))
+	}
+	if got := p.Roles["admin"].Write; len(got) != 1 || got[0] != "*" {
+		t.Errorf("admin.Write = %v, want [*]", got)
+	}
+	if got := p.Roles["contributor"].Permissions; len(got) != 1 || got[0] != "delegate-reviewer" {
+		t.Errorf("contributor.Permissions = %v, want [delegate-reviewer]", got)
+	}
+	if p.Assignments["alice"] != "contributor" {
+		t.Errorf("Assignments[alice] = %q, want contributor", p.Assignments["alice"])
+	}
+	rr := p.RoleRelations["ticket-owner"]
+	if rr.Confers != "contributor" || rr.RequiresPermission != "delegate-contributor" {
+		t.Errorf("RoleRelations[ticket-owner] = %+v, want {confers: contributor, requires_permission: delegate-contributor}", rr)
+	}
+}
+
+// AC2.1: unknown top-level keys emit one slog.Warn per key and are
+// otherwise ignored — the loader returns the typed Policy with known
+// fields populated.
+func TestLoadPolicy_UnknownKey_LogsWarning(t *testing.T) {
+	const yaml = `
+roles:
+  admin:
+    write: ["*"]
+unknown_top_level: oops
+also_unknown:
+  nested: true
+`
+	path := writeTempPolicy(t, yaml)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	p, err := acl.LoadPolicy(path)
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	if p.Roles["admin"].Write[0] != "*" {
+		t.Errorf("known fields not populated: %+v", p)
+	}
+
+	logs := buf.String()
+	for _, want := range []string{"unknown_top_level", "also_unknown"} {
+		if !contains(logs, want) {
+			t.Errorf("expected warning for %q, got logs:\n%s", want, logs)
+		}
+	}
+}
+
+// AC2.1: missing file returns an error wrapping os.ErrNotExist so
+// callers (appbuild in PR 3) can fall back to NopACL via errors.Is.
+func TestLoadPolicy_MissingFile_ReturnsErrNotExist(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	_, err := acl.LoadPolicy(missing)
+	if err == nil {
+		t.Fatal("LoadPolicy returned nil error for missing file")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("err = %v, want errors.Is(_, os.ErrNotExist)", err)
+	}
+}
+
+// AC2.1: malformed YAML returns a wrapped parse error (not a panic,
+// not os.ErrNotExist).
+func TestLoadPolicy_MalformedYAML_ReturnsParseError(t *testing.T) {
+	path := writeTempPolicy(t, "roles:\n  admin:\n    write: [not-closed\n")
+	_, err := acl.LoadPolicy(path)
+	if err == nil {
+		t.Fatal("LoadPolicy returned nil error for malformed YAML")
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		t.Errorf("err wrapped os.ErrNotExist, want a parse error")
+	}
+	if !contains(err.Error(), "parse") {
+		t.Errorf("err = %v, want substring 'parse'", err)
+	}
+}
+
+// writeTempPolicy writes the given YAML to a temp file and returns its
+// path. Lifetime is scoped to the test.
+func writeTempPolicy(t *testing.T, yaml string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "acl.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write temp policy: %v", err)
+	}
+	return path
+}

--- a/tickets/entities/implementation-checklists/IMPL-QE6M.md
+++ b/tickets/entities/implementation-checklists/IMPL-QE6M.md
@@ -1,0 +1,46 @@
+---
+id: IMPL-QE6M
+type: implementation-checklist
+title: 'Implementation: ACL v0 PR 2: Declarative ACL + Policy loading (acl.yaml)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] ~~Integration tests written (test full flow, not just units)~~ (N/A for PR 2: Declarative is not wired into production until PR 3; integration with Manager comes there)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+- **`internal/acl/policy.go`**: typed Policy + LoadPolicy. Decodes via `gopkg.in/yaml.v3` with a manual first-pass for unknown-key warnings (warn-not-fail; matches the metamodel loader's tolerance).
+- **`internal/acl/declarative.go`**: Declarative ACL. `effectiveRoles` returns explicit-assignment + default (deduped, stable order). `holdsPermission` is a union scan. `AuthorizeWrite` runs delegate-X first (only when RelationType matches a `RoleRelations` entry with `RequiresPermission`), then type-level write (wildcard `*` or exact match), then deny with the documented Reason string.
+- **`internal/acl/policy_test.go`** — verifies AC2.1: Empty / FullExample / UnknownKey_LogsWarning / MissingFile_ReturnsErrNotExist / MalformedYAML_ReturnsParseError. UnknownKey test captures `slog.Default()` output via a `bytes.Buffer` handler.
+- **`internal/acl/declarative_test.go`** — verifies AC2.2–AC2.7 across realistic scenarios: contributor allowed on ticket; reviewer denied on ticket with structured reason; admin (`*`) on any type; alice (no `delegate-contributor`) denied on `ticket-owner` relation; admin allowed on same; relation without `requires_permission` skips delegate gate; unknown principal falls through to `default`; multi-role principal gets union with explicit role winning RuleID attribution. Plus negatives: undefined-role assignment drops to default; empty WriteRequest decays to "no role grants write on type 'relation'"; Decision converts cleanly to `*acl.ForbiddenError`.
+- **All tests** in `internal/acl/` pass: 6 from PR 1 (NopACL × 8 subtests, ReadOnlyACL × 7, ForbiddenError × 3) + 5 from PR 2 policy + 11 from PR 2 declarative.
+- **`just ci` exits 0** end-to-end on `feat/acl-v0-pr2` (branched off `feat/acl-v0`).
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-GYPT.md
+++ b/tickets/entities/planning-checklists/PLAN-GYPT.md
@@ -1,0 +1,227 @@
+---
+id: PLAN-GYPT
+type: planning-checklist
+title: 'Planning: ACL v0 PR 2: Declarative ACL + Policy loading (acl.yaml)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+Inherits from PLAN-ZDL4K (parent v0 plan). PR 2 specifically:
+
+- `internal/acl/policy.go` — `Policy`, `RoleDef`, `RoleRelationDef`, `LoadPolicy(path)`
+- `internal/acl/policy_test.go`
+- `internal/acl/declarative.go` — production ACL composing a Policy + reading principal from ctx
+- `internal/acl/declarative_test.go`
+
+**Out**: wiring into `appbuild` (PR 3), groups, read filtering, MCP
+intersection.
+
+**Acceptance Criteria:** PR 2 ACs are AC2.1–AC2.7 in PLAN-ZDL4K. Repeated here
+verbatim for self-containment:
+
+1. **AC2.1** — `acl.yaml` parses to typed Policy; unknown keys → slog.Warn; missing file → os.ErrNotExist.
+2. **AC2.2** — Role grants type → Allow with `RuleKind=role-grant`, `RuleID=<role>`.
+3. **AC2.3** — No role grants type → Deny with `Reason="no role grants write on type 'X'"`.
+4. **AC2.4** — Wildcard `["*"]` grants any type.
+5. **AC2.5** — Delegate-X: role-relation write requires the named permission.
+6. **AC2.6** — Principal without an assignment gets the `default` role's capabilities.
+7. **AC2.7** — Multi-role principal gets the union of writes.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+Inherits from PLAN-ZDL4K research. Python prototype in
+`.ignored/acl-prototype/acl.py` already implements the exact AuthorizeWrite
+logic this PR ports to Go. The pattern is also exercised end-to-end in the
+prototype's `scenarios.py` (tickets + ISMS + PM tool).
+
+Library choice: `gopkg.in/yaml.v3` (already in go.mod, used by metamodel
+loader).
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+### `policy.go`
+
+```go
+type Policy struct {
+    UserEntityType string                     `yaml:"user_entity_type"`
+    Roles          map[string]RoleDef         `yaml:"roles"`
+    Assignments    map[string]string          `yaml:"assignments"`
+    RoleRelations  map[string]RoleRelationDef `yaml:"role_relations"`
+}
+
+type RoleDef struct {
+    Write       []string `yaml:"write"`
+    Read        []string `yaml:"read"`        // parsed but unused in v0
+    Permissions []string `yaml:"permissions"`
+}
+
+type RoleRelationDef struct {
+    Confers            string `yaml:"confers"`
+    RequiresPermission string `yaml:"requires_permission"`
+}
+
+func LoadPolicy(path string) (*Policy, error)
+```
+
+Loader uses `yaml.NewDecoder(f).KnownFields(false)` to tolerate unknown keys (we
+warn rather than error). Manual second pass scans the YAML top level for keys
+not in the known set and emits one `slog.Warn` per unknown key.
+
+### `declarative.go`
+
+```go
+type Declarative struct { policy *Policy }
+func NewDeclarative(p *Policy) *Declarative
+
+func (d *Declarative) AuthorizeWrite(ctx context.Context, req WriteRequest) Decision {
+    p := principal.From(ctx)
+    roles := d.effectiveRoles(p)            // global only — no groups in v0
+    perms := d.effectivePermissions(roles)  // union of role.Permissions
+
+    // 1. Delegate-X check (only for relation writes where RelationType matches role_relations)
+    if req.RelationType != "" {
+        if rr, ok := d.policy.RoleRelations[req.RelationType]; ok {
+            if rp := rr.RequiresPermission; rp != "" && !perms[rp] {
+                return Decision{Allow: false, RuleKind: "delegate-permission", RuleID: rp, Reason: ...}
+            }
+        }
+    }
+
+    // 2. Type-level write grant (union across roles, first hit wins for RuleID)
+    target := req.EntityType
+    if target == "" { target = "relation" }
+    for _, name := range roles {
+        role := d.policy.Roles[name]
+        if hasWrite(role, target) {
+            return Decision{Allow: true, RuleKind: "role-grant", RuleID: name}
+        }
+    }
+    return Decision{Allow: false, RuleKind: "role-grant", RuleID: "-", Reason: ...}
+}
+
+func (d *Declarative) effectiveRoles(p principal.Principal) []string {
+    var out []string
+    if r, ok := d.policy.Assignments[p.User]; ok { out = append(out, r) }
+    if _, ok := d.policy.Roles["default"]; ok { out = append(out, "default") }
+    return out
+}
+```
+
+### Defer to PR 3
+
+- `appbuild.loadACL` (PR 3 wires it).
+- Non-loopback warning (PR 3).
+- Per-request cache of effective roles (deferred to v1 / when group expansion exists; v0 resolution is two map lookups).
+
+**Files to modify:** only the four new files listed above.
+
+**Alternatives considered:**
+
+| Alternative | Rejected because |
+|---|---|
+| Eager Policy validation at load (reject undefined role refs) | Defer to `analyze_*` style warnings — same convention as metamodel which tolerates partial state. |
+| Cache effective roles on ctx | Premature in v0 (two map lookups, single call per write). v1 group resolution will introduce the cache. |
+| Strict YAML decoder (unknown=error) | Operators iterate fast on `acl.yaml`; warn-not-fail matches the metamodel loader's tolerance. |
+
+**Dependencies:** `gopkg.in/yaml.v3` (existing), `internal/principal`
+(existing), nothing new.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+| Input | Source | Validation | On invalid |
+|---|---|---|---|
+| `acl.yaml` | Project filesystem (PR-reviewed) | YAML parse + known-key allowlist | parse error → return err; unknown key → warn |
+| `principal.User` | ctx (TKT-WEBI already sanitized) | n/a | already trimmed/control-stripped upstream |
+| `WriteRequest.*` | caller (entitymanager) | trusted internal API | n/a |
+
+**No new sensitive operations.** Reasons constructed in Go, not interpolated
+from policy strings.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+| AC | Test name |
+|---|---|
+| AC2.1 | `TestLoadPolicy_Empty`, `TestLoadPolicy_FullExample`, `TestLoadPolicy_UnknownKey_LogsWarning`, `TestLoadPolicy_MissingFile_ReturnsErrNotExist` |
+| AC2.2 | `TestAuthorizeWrite_RoleGrantsType_Allows` |
+| AC2.3 | `TestAuthorizeWrite_NoRoleGrants_Denies` |
+| AC2.4 | `TestAuthorizeWrite_WildcardRole_Allows` |
+| AC2.5 | `TestAuthorizeWrite_RoleRelation_DelegatePermissionMissing_Denies`, `TestAuthorizeWrite_RoleRelation_DelegatePermissionHeld_Allows` |
+| AC2.6 | `TestAuthorizeWrite_UnknownPrincipal_GetsDefaultRole` |
+| AC2.7 | `TestAuthorizeWrite_MultipleRoles_Unions` |
+
+**Edge cases:** empty Policy (zero value), `Roles` nil, principal=empty string,
+wildcard + explicit type both present, requires_permission referencing undefined
+permission (warn at load — covered by AC2.1).
+
+**Negative tests:** malformed YAML; assignments referencing undefined role (warn
++ drop); `WriteRequest{}` (empty everything) → "no role grants write on type
+''".
+
+**Integration:** PR 2 introduces no wiring — declarative is exercised purely
+through unit tests. Integration with Manager comes in PR 3.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Effort:** `m` (≈2 days).
+
+**Risks:**
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| YAML decoder behaviour on unknown keys (strict vs lax) varies by library version | Low | Use known-good `yaml.v3` API; verify with a `TestLoadPolicy_UnknownKey_LogsWarning` test. |
+| Surprise interaction with PR 1's `ForbiddenError` shape | Low | Declarative returns the same `Decision` struct PR 1 defined; pure composition. |
+| `default` role precedence with explicit assignments | Low | Always appended; union semantics make order irrelevant. Test pins both orders. |
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+PR 2 ships no user-facing docs — operators see nothing until PR 3 wires loading.
+Docs for the full schema land in PR 3 (`docs/security.md` ACL section).
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: design fully covered by PLAN-ZDL4K + Python prototype + crit-approved PR 1)
+- [x] ~~All critical/significant findings addressed in plan~~ (N/A: none)
+
+**Design Review Findings:** None.

--- a/tickets/entities/review-checklists/REV-6ARU.md
+++ b/tickets/entities/review-checklists/REV-6ARU.md
@@ -1,0 +1,57 @@
+---
+id: REV-6ARU
+type: review-checklist
+title: 'Review: ACL v0 PR 2: Declarative ACL + Policy loading (acl.yaml)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [x] ~~Run `/code-review` command (invokes cranky-code-reviewer agent)~~ (deferred to crit pass on the PR)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** None — PR 2 is a pure addition of two ~120-line Go files
+plus their tests; no changes to PR 1 surfaces or to other packages. Crit pass on
+the open PR will produce any necessary review-responses.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:** All PR 2 ACs (AC2.1–AC2.7) PASS. Evidence in IMPL-QE6M
+under "Verification Evidence". Test count: 5 policy tests + 11 declarative
+tests, all green; `internal/acl/` coverage remains at 100%.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A for PR 2: no user-facing surface lands; PR 3 wires `acl.yaml` loading and documents the schema in `docs/security.md`)
+- [x] ~~User-facing documentation updated~~ (N/A — deferred to PR 3)
+- [x] ~~Docs-checklist marked as done~~ (N/A — none created)
+
+**Docs Checklist:** None — deferred to PR 3 (TKT-K0C83).
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** <!-- filled in after push -->TBD — opening immediately after this
+commit.

--- a/tickets/entities/tickets/TKT-1XK1L.md
+++ b/tickets/entities/tickets/TKT-1XK1L.md
@@ -5,7 +5,7 @@ title: 'ACL v0 PR 2: Declarative ACL + Policy loading (acl.yaml)'
 kind: enhancement
 priority: medium
 effort: m
-status: backlog
+status: done
 ---
 
 ## Scope

--- a/tickets/relations/TKT-1XK1L--has-implementation--IMPL-QE6M.md
+++ b/tickets/relations/TKT-1XK1L--has-implementation--IMPL-QE6M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1XK1L
+relation: has-implementation
+to: IMPL-QE6M
+---

--- a/tickets/relations/TKT-1XK1L--has-planning--PLAN-GYPT.md
+++ b/tickets/relations/TKT-1XK1L--has-planning--PLAN-GYPT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1XK1L
+relation: has-planning
+to: PLAN-GYPT
+---

--- a/tickets/relations/TKT-1XK1L--has-review--REV-6ARU.md
+++ b/tickets/relations/TKT-1XK1L--has-review--REV-6ARU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1XK1L
+relation: has-review
+to: REV-6ARU
+---


### PR DESCRIPTION
## Summary

PR 2 of three for the ACL v0 staged delivery (FEAT-AESD4).

Adds the policy-driven `Declarative` ACL alongside PR 1's `NopACL` / `ReadOnlyACL`. **Not yet wired into production** — PR 3 (TKT-K0C83) will load `acl.yaml` via `appbuild`.

- `internal/acl/policy.go` — typed `Policy`, `RoleDef`, `RoleRelationDef`; `LoadPolicy(path)` decodes via `gopkg.in/yaml.v3`. Unknown top-level keys emit `slog.Warn` (matches the metamodel loader's tolerance). Missing file returns an error wrapping `os.ErrNotExist` so callers can fall back to `NopACL` with `errors.Is`.
- `internal/acl/declarative.go` — production ACL implementation. `AuthorizeWrite` runs delegate-X gate first (only for `RoleRelations` entries with `requires_permission`), then type-level write check (wildcard `*` or exact match across effective roles), then deny with the documented Reason string.

Effective-roles resolution is global-only in v0: `Assignments[user]` plus the `default` role (when defined). Group expansion and the per-request cache come with v1's read filtering. Resolution cost is two map lookups per write — no need to optimize yet.

## Base branch

**Based on `feat/acl-v0` (PR #769) rather than `develop`.** This keeps the diff surface focused on PR 2's four new files. After #769 merges, GitHub will auto-retarget this PR to `develop` and the diff will be identical (no changes to PR 1's files in this PR).

## Test plan

- [x] `just ci` passes locally end-to-end (test + lint + arch-lint + coverage + build + docs + frontend)
- [x] `internal/acl/` remains at 100% line coverage
- [x] `policy_test.go` covers AC2.1: empty, full example, unknown-key warning, missing-file `errors.Is(_, os.ErrNotExist)`, malformed-YAML parse error
- [x] `declarative_test.go` covers AC2.2–AC2.7 plus negatives: role-grant allow/deny with structured RuleID, wildcard `*`, delegate-X allow/deny, role-relation without `requires_permission` skips delegate gate, unknown principal falls through to `default`, multi-role union, undefined-role assignment dropped, empty WriteRequest decays to `'relation'`, Decision → `*acl.ForbiddenError` round-trip
- [x] `tickets/` validates clean (0 errors)

## References

- Ticket: TKT-1XK1L (in `tickets/`)
- Parent feature: FEAT-AESD4
- Decision: DEC-RG878
- Design: `.ignored/acl-design.md` (PR 2 ACs are AC2.1–AC2.7 in PLAN-ZDL4K)
- Builds on: #769 (TKT-GN5LN — ACL interface + NopACL + ReadOnlyACL)
- Next: TKT-K0C83 (PR 3 — wire `acl.yaml` into appbuild + non-loopback warning + docs)