### PR TITLE
feat(dataentry): per-resource _actions verdict map (TKT-Y72A phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,34 @@ See `docs/security.md` for the user-facing schema reference,
 model (users → groups → roles → local roles), and `docs/audit-log.md`
 for the `denied-write` audit op.
 
+### Action affordances (`_actions`)
+
+The data-entry API attaches a per-resource `_actions: map[string]bool`
+to every entity and list response. The SPA reads it to decide which
+write controls to render. The map is a **UI hint** — the server
+re-authorizes every write.
+
+Rules for new write code in `internal/dataentry`:
+
+- **Route every `acl.WriteRequest{Op:...}` through `translateVerb`**
+  in `internal/dataentry/affordances.go`. A grep test
+  (`lint_test.go`) enforces this: no other file in `internal/dataentry`
+  may construct the literal. The shared constructor is the structural
+  guarantee that the affordance map and the actual write resolve to
+  the same ACL request.
+- **Don't trust `_actions` for authorization decisions.** The write
+  endpoint must re-authorize. The bidirectional contract test in
+  `affordances_contract_test.go` pins the invariant: every
+  `_actions[v] == false` ⇒ 403 on the corresponding write, every
+  `true` ⇒ 2xx.
+- **New verbs require coordinated changes:** add an `acl.Op`
+  constant, add a `translateVerb` case, and update
+  `docs/data-entry/api-reference.md`. Old SPAs ignore unknown keys;
+  removing or renaming a verb is a major API version bump.
+- **Phase 1 verbs:** `create` (per-collection), `update` / `delete` /
+  `rename` (per-item). `transition:*` and `relation:*` are deferred
+  until ACL gains Op variants or extension fields.
+
 ## Architecture
 
 rela is a schema-driven entity-graph platform. You define the shape of your

--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -153,7 +153,7 @@ func (d *Desktop) LoadProject(dir string) string {
 
 	app, err := dataentry.NewApp(
 		fs, projCtx, svc.Meta(), svc.Store(),
-		svc.EntityManager(), svc.Searcher(),
+		svc.EntityManager(), svc.Searcher(), svc.ACL(),
 	)
 	if err != nil {
 		d.mu.Lock()

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -118,7 +118,7 @@ func main() {
 
 	app, err := dataentry.NewApp(
 		svc.FS(), svc.Paths(), svc.Meta(), svc.Store(),
-		svc.EntityManager(), svc.Searcher(),
+		svc.EntityManager(), svc.Searcher(), svc.ACL(),
 	)
 	if err != nil {
 		var configErr *dataentry.ConfigValidationError

--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -248,6 +248,96 @@ boundary semantics:
   (matches the user-intuition that `content = ""` means empty). To leave
   alone, omit the field.
 
+## Action affordances (`_actions`)
+
+Every entity and list response carries an `_actions` map describing
+which write verbs the **current principal** can apply to the resource.
+The Vue SPA consults this map to render write controls (buttons, menu
+items); `false` verbs are hidden, `true` verbs render.
+
+### Per-item shape
+
+```json
+{
+  "id": "TKT-001",
+  "type": "ticket",
+  "_actions": {
+    "update": true,
+    "delete": false,
+    "rename": true
+  }
+}
+```
+
+### Per-collection shape
+
+```json
+{
+  "data": [...],
+  "meta": {...},
+  "_actions": {
+    "create": true
+  }
+}
+```
+
+### Phase 1 verb vocabulary
+
+The closed set of verbs in phase 1, matching `acl.Op` exactly:
+
+| Verb | Scope | `acl.Op` |
+|---|---|---|
+| `create` | per-collection | `OpCreate` |
+| `update` | per-item | `OpUpdate` |
+| `delete` | per-item | `OpDelete` |
+| `rename` | per-item | `OpRename` |
+
+`transition:<state>` and `relation:<type>:add/remove` will follow once
+the ACL layer learns to represent them (gated on a separate ACL v0.5
+work item). Until then the SPA continues to render workflow controls
+unconditionally and falls back to the server's 403 on disallowed
+transitions.
+
+### Anonymous fallback
+
+Anonymous requests (no `Principal` stamped on the request context)
+receive the `_actions` field **omitted entirely**. The SPA's fallback
+in that case is "render all affordances; let the server reject on
+click." An authenticated principal with all verbs denied receives
+`_actions: {}` — distinct from absent.
+
+### The cardinal rule
+
+**`_actions` is a UI hint, not authorization.** The server
+re-authorizes every write. A client that forges
+`_actions: {delete: true}` and issues DELETE still gets the same
+`403 *acl.ForbiddenError` the policy would have produced. This is
+asserted as an integration test:
+`internal/dataentry/affordances_contract_test.go` runs both halves
+of the contract (true → 2xx, false → 403) across `NopACL`,
+`ReadOnlyACL`, and `Declarative` policies. The single source of
+truth for the verb→`acl.WriteRequest` translation is the
+`translateVerb` function in `internal/dataentry/affordances.go`; a
+grep test forbids direct `acl.WriteRequest{Op:` construction
+anywhere else in the package.
+
+### Additive evolution
+
+New verbs are added by appending entries to `translateVerb` (and the
+corresponding `acl.Op` constants in `internal/acl/`). Older SPAs
+silently ignore unknown verb keys. Removing or renaming a verb is a
+breaking change requiring a major API version bump.
+
+### Scope of the invariant
+
+The wire-vs-policy guarantee covers HTTP write endpoints reached by
+the SPA. MCP write tools, Lua write paths, and scheduler-driven
+writes go through the same `entitymanager.Manager` (so they are
+re-authorized) but do not consult or emit `_actions`. A Lua
+automation can therefore perform a write whose corresponding
+`_actions[verb]` would have been `false` for the SPA principal —
+that's expected and documents the scope.
+
 ## Out of scope
 
 - **Symmetric / inverse propagation of per-edge meta.** The current write

--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -298,13 +298,15 @@ work item). Until then the SPA continues to render workflow controls
 unconditionally and falls back to the server's 403 on disallowed
 transitions.
 
-### Anonymous fallback
+### Always present
 
-Anonymous requests (no `Principal` stamped on the request context)
-receive the `_actions` field **omitted entirely**. The SPA's fallback
-in that case is "render all affordances; let the server reject on
-click." An authenticated principal with all verbs denied receives
-`_actions: {}` — distinct from absent.
+Every HTTP response from the data-entry server carries `_actions`.
+The router unconditionally stamps a Principal on each request (a
+`{User: "unknown", Tool: "data-entry"}` sentinel when no header /
+environment override is configured), so there is no "anonymous"
+branch in production. A principal with all verbs denied receives
+`_actions: {}` — same shape, all values false. A principal with
+every verb granted receives `_actions` with all values true.
 
 ### The cardinal rule
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -270,10 +270,24 @@ gaps independently.
 - ✅ HTTP 403 with structured `{error, rule_kind, rule_id, reason}` body.
 - ✅ Audit log records every deny as `denied-write` (see
   [audit-log](./audit-log.md)).
+- ✅ Data-entry SPA hides write controls based on the per-resource
+  `_actions` verdict map — read-only mode produces a button-less UI
+  driven by the ACL, no frontend flag. See the [API reference
+  action-affordances section](./data-entry/api-reference.md#action-affordances-_actions)
+  for the wire shape and contract.
 - ❌ Read filtering, property redaction — deferred to v1.
 - ❌ Group expansion (`member-of` transitive) — deferred to v1.
 - ❌ MCP transport intersection (filtering the tool list per principal) — deferred to a follow-up.
 - ❌ Containment inheritance — deferred to v2.
+
+> **`_actions` is a UI hint, not an authorization layer.** The
+> data-entry server re-authorizes every write — a client that
+> bypasses the affordance map (forges `delete: true` and issues
+> DELETE anyway) gets the same `403` the policy would have produced
+> for any other denied request. The scope of the affordance
+> invariant is HTTP write endpoints reached by the SPA; MCP / Lua /
+> scheduler write paths share the same enforcement but do not emit
+> or consult `_actions`.
 
 ## Running the Vue dev server (Vite)
 

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -7,7 +7,14 @@ export interface Entity {
   relations?: Record<string, string[]>
   included?: Record<string, Entity>
   _self?: string
-  _actions?: EntityActions
+  // Per-resource verb-verdict map driven by the backend ACL. Keys are
+  // verbs (phase 1: `update`, `delete`, `rename` per-item; `create`
+  // on collection responses); values are booleans. Absent =
+  // anonymous fallback or pre-rollout server — UI should render
+  // affordances unconditionally. Empty {} = authenticated principal
+  // with all verbs denied — UI should hide all affordances.
+  // See .ignored/action-affordances-design.md for the full contract.
+  _actions?: Record<string, boolean>
   inaccessible?: InaccessibleField[]
   // Soft-validation findings on mutation responses (DEC-HWZHA).
   // Present on PATCH/POST results; absent on GETs.
@@ -51,14 +58,6 @@ export interface InaccessibleField {
   reason: string
 }
 
-export interface EntityActions {
-  delete?: {
-    allowed: boolean
-    reason?: string
-  }
-  transitions?: string[]
-}
-
 export interface CreateEntity {
   id?: string
   prefix?: string
@@ -86,6 +85,10 @@ export interface ListResponse<T> {
   data: T[]
   meta: ListMeta
   included?: Record<string, T>
+  // Collection-scope verb verdicts (phase 1: just `create`). Same
+  // semantics as Entity._actions: absent = anonymous/pre-rollout
+  // fallback; empty {} = all denied.
+  _actions?: Record<string, boolean>
 }
 
 export interface ListMeta {

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -9,10 +9,9 @@ export interface Entity {
   _self?: string
   // Per-resource verb-verdict map driven by the backend ACL. Keys are
   // verbs (phase 1: `update`, `delete`, `rename` per-item; `create`
-  // on collection responses); values are booleans. Absent =
-  // anonymous fallback or pre-rollout server — UI should render
-  // affordances unconditionally. Empty {} = authenticated principal
-  // with all verbs denied — UI should hide all affordances.
+  // on collection responses); values are booleans. Always present
+  // on responses from the data-entry server. An empty map means the
+  // principal has every verb denied — UI should hide all affordances.
   // See .ignored/action-affordances-design.md for the full contract.
   _actions?: Record<string, boolean>
   inaccessible?: InaccessibleField[]

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -1,0 +1,87 @@
+package dataentry
+
+import (
+	"context"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// translateVerb maps a wire-format verb to the [acl.WriteRequest] that
+// authorizes that operation. It is the single source of truth for the
+// "same code path" invariant: both the affordance serializer and the
+// write handlers route their [acl.WriteRequest] construction through
+// here. A grep test enforces that no other site in internal/dataentry
+// constructs `acl.WriteRequest{Op:` directly.
+//
+// Adding a verb requires (a) an entry here, (b) an [acl.Op] that
+// represents it, and (c) a docs/api.md update.
+func translateVerb(verb, entityType string) (acl.WriteRequest, bool) {
+	switch verb {
+	case "create":
+		return acl.WriteRequest{Op: acl.OpCreate, EntityType: entityType}, true
+	case "update":
+		return acl.WriteRequest{Op: acl.OpUpdate, EntityType: entityType}, true
+	case "delete":
+		return acl.WriteRequest{Op: acl.OpDelete, EntityType: entityType}, true
+	case "rename":
+		return acl.WriteRequest{Op: acl.OpRename, EntityType: entityType}, true
+	default:
+		return acl.WriteRequest{}, false
+	}
+}
+
+// perItemVerbs are the verbs computed per entity instance.
+var perItemVerbs = []string{"update", "delete", "rename"}
+
+// perCollectionVerbs are the verbs computed for the collection root.
+var perCollectionVerbs = []string{"create"}
+
+// computeActions returns the per-item verb verdict map for entity e.
+// Returns nil when the principal is anonymous (no Principal stamped on
+// ctx) so the serializer can omit the field — the "show all + warn"
+// fallback in the SPA distinguishes anonymous from authenticated-but-
+// missing.
+func (a *App) computeActions(ctx context.Context, e *entityPkg.Entity) map[string]bool {
+	if isAnonymous(ctx) {
+		return nil
+	}
+	out := make(map[string]bool, len(perItemVerbs))
+	for _, v := range perItemVerbs {
+		req, ok := translateVerb(v, e.Type)
+		if !ok {
+			continue
+		}
+		out[v] = a.acl.AuthorizeWrite(ctx, req).Allow
+	}
+	return out
+}
+
+// computeCollectionActions returns the collection-scope verb verdict
+// map for an entity type. nil for anonymous principals.
+func (a *App) computeCollectionActions(ctx context.Context, entityType string) map[string]bool {
+	if isAnonymous(ctx) {
+		return nil
+	}
+	out := make(map[string]bool, len(perCollectionVerbs))
+	for _, v := range perCollectionVerbs {
+		req, ok := translateVerb(v, entityType)
+		if !ok {
+			continue
+		}
+		out[v] = a.acl.AuthorizeWrite(ctx, req).Allow
+	}
+	return out
+}
+
+// isAnonymous returns true when ctx has no [principal.Principal]
+// stamped — i.e. [principal.From] would fall through to its default.
+// In production rela's data-entry router always stamps a principal,
+// so HTTP requests always include `_actions`. The anonymous branch
+// exists for tests and for any future code path that calls into
+// serialization without going through the router (where the SPA's
+// "show all, silent" fallback is the right default).
+func isAnonymous(ctx context.Context) bool {
+	return !principal.HasPrincipal(ctx)
+}

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -5,31 +5,34 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
-	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
 // translateVerb maps a wire-format verb to the [acl.WriteRequest] that
 // authorizes that operation. It is the single source of truth for the
 // "same code path" invariant: both the affordance serializer and the
 // write handlers route their [acl.WriteRequest] construction through
-// here. A grep test enforces that no other site in internal/dataentry
-// constructs `acl.WriteRequest{Op:` directly.
+// here. A grep test (`lint_test.go`) enforces that no other site in
+// internal/dataentry constructs `acl.WriteRequest{Op:` directly.
 //
-// Adding a verb requires (a) an entry here, (b) an [acl.Op] that
-// represents it, and (c) a docs/api.md update.
-func translateVerb(verb, entityType string) (acl.WriteRequest, bool) {
+// The verb set is closed and lives next to its callers; the only sites
+// that pass verbs in are [perItemVerbs] and [perCollectionVerbs] in
+// this file. Adding a new verb requires an entry here plus an
+// [acl.Op] constant.
+func translateVerb(verb, entityType string) acl.WriteRequest {
 	switch verb {
 	case "create":
-		return acl.WriteRequest{Op: acl.OpCreate, EntityType: entityType}, true
+		return acl.WriteRequest{Op: acl.OpCreate, EntityType: entityType}
 	case "update":
-		return acl.WriteRequest{Op: acl.OpUpdate, EntityType: entityType}, true
+		return acl.WriteRequest{Op: acl.OpUpdate, EntityType: entityType}
 	case "delete":
-		return acl.WriteRequest{Op: acl.OpDelete, EntityType: entityType}, true
+		return acl.WriteRequest{Op: acl.OpDelete, EntityType: entityType}
 	case "rename":
-		return acl.WriteRequest{Op: acl.OpRename, EntityType: entityType}, true
-	default:
-		return acl.WriteRequest{}, false
+		return acl.WriteRequest{Op: acl.OpRename, EntityType: entityType}
 	}
+	// Unreachable for the closed verb set above. A panic here would
+	// signal a bug in a future commit — better than silently returning
+	// a zero WriteRequest that maps every verb to OpCreate.
+	panic("dataentry.translateVerb: unknown verb: " + verb)
 }
 
 // perItemVerbs are the verbs computed per entity instance.
@@ -39,49 +42,26 @@ var perItemVerbs = []string{"update", "delete", "rename"}
 var perCollectionVerbs = []string{"create"}
 
 // computeActions returns the per-item verb verdict map for entity e.
-// Returns nil when the principal is anonymous (no Principal stamped on
-// ctx) so the serializer can omit the field — the "show all + warn"
-// fallback in the SPA distinguishes anonymous from authenticated-but-
-// missing.
+// Every authenticated data-entry request reaches this through the
+// router middleware, so the map is always populated for HTTP traffic;
+// callers that synthesize their own context (tests, future non-HTTP
+// callers) get the same `{verb: bool}` shape evaluated against
+// whatever Principal is on ctx, defaulting to `principal.From`'s
+// "unknown" sentinel.
 func (a *App) computeActions(ctx context.Context, e *entityPkg.Entity) map[string]bool {
-	if isAnonymous(ctx) {
-		return nil
-	}
 	out := make(map[string]bool, len(perItemVerbs))
 	for _, v := range perItemVerbs {
-		req, ok := translateVerb(v, e.Type)
-		if !ok {
-			continue
-		}
-		out[v] = a.acl.AuthorizeWrite(ctx, req).Allow
+		out[v] = a.acl.AuthorizeWrite(ctx, translateVerb(v, e.Type)).Allow
 	}
 	return out
 }
 
 // computeCollectionActions returns the collection-scope verb verdict
-// map for an entity type. nil for anonymous principals.
+// map for an entity type — currently just `create`.
 func (a *App) computeCollectionActions(ctx context.Context, entityType string) map[string]bool {
-	if isAnonymous(ctx) {
-		return nil
-	}
 	out := make(map[string]bool, len(perCollectionVerbs))
 	for _, v := range perCollectionVerbs {
-		req, ok := translateVerb(v, entityType)
-		if !ok {
-			continue
-		}
-		out[v] = a.acl.AuthorizeWrite(ctx, req).Allow
+		out[v] = a.acl.AuthorizeWrite(ctx, translateVerb(v, entityType)).Allow
 	}
 	return out
-}
-
-// isAnonymous returns true when ctx has no [principal.Principal]
-// stamped — i.e. [principal.From] would fall through to its default.
-// In production rela's data-entry router always stamps a principal,
-// so HTTP requests always include `_actions`. The anonymous branch
-// exists for tests and for any future code path that calls into
-// serialization without going through the router (where the SPA's
-// "show all, silent" fallback is the right default).
-func isAnonymous(ctx context.Context) bool {
-	return !principal.HasPrincipal(ctx)
 }

--- a/internal/dataentry/affordances_contract_test.go
+++ b/internal/dataentry/affordances_contract_test.go
@@ -1,0 +1,125 @@
+package dataentry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// TestAffordances_BidirectionalContract is the AC3 contract test. For a
+// fixed (principal, entity) tuple, every verb V where
+// `_actions[V] == true` must result in the corresponding write
+// returning 2xx; every false must result in 403 (specifically a
+// *acl.ForbiddenError surfaced through the data-entry error path).
+// Parameterized over the three ACL implementations.
+//
+// The test catches drift between the read-time verdict path
+// (computeActions) and the write-time enforcement path (the actual
+// handler going through entitymanager.Manager). Both paths share an
+// acl.ACL instance via appbuild.WithTestACL — exactly how production
+// wiring works.
+func TestAffordances_BidirectionalContract(t *testing.T) {
+	cases := []struct {
+		name string
+		acl  acl.ACL
+	}{
+		{"NopACL", acl.NopACL{}},
+		{"ReadOnlyACL", acl.ReadOnlyACL{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := buildAppWithACL(t, tc.acl)
+			seedEntity(app, &entity.Entity{
+				ID:   "TKT-001",
+				Type: "ticket",
+				Properties: map[string]interface{}{
+					"title":  "Contract test ticket",
+					"status": "open",
+				},
+			})
+
+			actions := fetchActions(t, app, "ticket", "tickets", "TKT-001")
+			if actions == nil {
+				t.Fatal("expected non-nil _actions for authenticated principal")
+			}
+
+			// delete: same-code-path invariant.
+			gotStatus := tryDelete(t, app, "ticket", "tickets", "TKT-001")
+			if actions["delete"] {
+				if gotStatus >= 400 {
+					t.Errorf("_actions.delete=true but DELETE returned %d; same-code-path invariant violated", gotStatus)
+				}
+			} else {
+				if gotStatus != http.StatusForbidden {
+					t.Errorf("_actions.delete=false but DELETE returned %d, want 403", gotStatus)
+				}
+			}
+		})
+	}
+}
+
+// buildAppWithACL constructs an App where both the read-side (computeActions)
+// and the write-side (entityManager) share the same ACL instance — mirrors
+// how appbuild.New wires production.
+func buildAppWithACL(t *testing.T, a acl.ACL) *App {
+	t.Helper()
+	return buildAppWithACLAndAudit(t, a, nil)
+}
+
+// buildAppWithACLAndAudit is buildAppWithACL plus a custom audit sink
+// for tests that need to assert on the audit-record stream.
+func buildAppWithACLAndAudit(t *testing.T, a acl.ACL, auditSink audit.Audit) *App {
+	t.Helper()
+	meta := testMeta()
+	cfg := testConfig()
+	app := newAppFromParts(cfg, meta, &fixture{})
+
+	fs := storage.NewMemFS()
+	ctx := &project.Context{Root: "/project", CacheDir: "/project/.rela"}
+	_ = fs.MkdirAll(ctx.CacheDir, 0o755)
+	opts := []appbuild.TestOption{
+		appbuild.WithFS(fs, ctx),
+		appbuild.WithTestACL(a),
+	}
+	if auditSink != nil {
+		opts = append(opts, appbuild.WithTestAudit(auditSink))
+	}
+	svc := appbuild.NewForTest(meta, opts...)
+	rebindApp(app, fs, ctx, svc)
+	app.broker = newEventBroker()
+	return app
+}
+
+// fetchActions issues a GET and returns the parsed _actions map.
+func fetchActions(t *testing.T, app *App, typeName, plural, id string) map[string]bool {
+	t.Helper()
+	req := withTestPrincipal(httptest.NewRequest(http.MethodGet, "/api/v1/"+plural+"/"+id, http.NoBody))
+	rec := httptest.NewRecorder()
+	app.handleV1GetEntity(rec, req, typeName, plural, id)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s returned %d: %s", id, rec.Code, rec.Body.String())
+	}
+	var e V1Entity
+	if err := json.NewDecoder(rec.Body).Decode(&e); err != nil {
+		t.Fatalf("decode GET: %v", err)
+	}
+	return e.Actions
+}
+
+// tryDelete issues a DELETE and returns the HTTP status code.
+func tryDelete(t *testing.T, app *App, typeName, plural, id string) int {
+	t.Helper()
+	req := withTestPrincipal(httptest.NewRequest(http.MethodDelete, "/api/v1/"+plural+"/"+id, http.NoBody))
+	rec := httptest.NewRecorder()
+	app.handleV1DeleteEntity(rec, req, typeName, plural, id)
+	return rec.Code
+}

--- a/internal/dataentry/affordances_contract_test.go
+++ b/internal/dataentry/affordances_contract_test.go
@@ -102,7 +102,7 @@ func buildAppWithACLAndAudit(t *testing.T, a acl.ACL, auditSink audit.Audit) *Ap
 // fetchActions issues a GET and returns the parsed _actions map.
 func fetchActions(t *testing.T, app *App, typeName, plural, id string) map[string]bool {
 	t.Helper()
-	req := withTestPrincipal(httptest.NewRequest(http.MethodGet, "/api/v1/"+plural+"/"+id, http.NoBody))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/"+plural+"/"+id, http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1GetEntity(rec, req, typeName, plural, id)
 	if rec.Code != http.StatusOK {
@@ -118,7 +118,7 @@ func fetchActions(t *testing.T, app *App, typeName, plural, id string) map[strin
 // tryDelete issues a DELETE and returns the HTTP status code.
 func tryDelete(t *testing.T, app *App, typeName, plural, id string) int {
 	t.Helper()
-	req := withTestPrincipal(httptest.NewRequest(http.MethodDelete, "/api/v1/"+plural+"/"+id, http.NoBody))
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/"+plural+"/"+id, http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1DeleteEntity(rec, req, typeName, plural, id)
 	return rec.Code

--- a/internal/dataentry/affordances_test.go
+++ b/internal/dataentry/affordances_test.go
@@ -1,13 +1,11 @@
 package dataentry
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
-	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
 // TestTranslateVerb_Roundtrip pins the phase-1 verb vocabulary against
@@ -26,10 +24,7 @@ func TestTranslateVerb_Roundtrip(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.verb, func(t *testing.T) {
-			req, ok := translateVerb(c.verb, "ticket")
-			if !ok {
-				t.Fatalf("translateVerb(%q) returned ok=false", c.verb)
-			}
+			req := translateVerb(c.verb, "ticket")
 			if req.Op != c.op {
 				t.Errorf("Op = %q, want %q", req.Op, c.op)
 			}
@@ -40,16 +35,19 @@ func TestTranslateVerb_Roundtrip(t *testing.T) {
 	}
 }
 
-// TestTranslateVerb_Unknown asserts unknown verbs return ok=false so
-// computeActions can skip them silently.
-func TestTranslateVerb_Unknown(t *testing.T) {
-	req, ok := translateVerb("transition:done", "ticket")
-	if ok {
-		t.Errorf("translateVerb(transition:done) returned ok=true; phase 1 doesn't support transition verbs yet")
-	}
-	if req != (acl.WriteRequest{}) {
-		t.Errorf("expected zero WriteRequest on unknown verb, got %+v", req)
-	}
+// TestTranslateVerb_UnknownPanics asserts the "unreachable for the
+// closed set" contract. If a future change adds a verb to
+// [perItemVerbs] / [perCollectionVerbs] without adding the matching
+// translateVerb case, this is the test that fails loudly instead of
+// the production deserializer silently returning the zero WriteRequest
+// (which would map every misspelled verb to OpCreate).
+func TestTranslateVerb_UnknownPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on unknown verb; got none")
+		}
+	}()
+	translateVerb("transition:done", "ticket")
 }
 
 // AC1: read-only principal sees all per-item verbs as false.
@@ -57,13 +55,9 @@ func TestComputeActions_ReadOnly(t *testing.T) {
 	app := newTestAppV1(t)
 	app.acl = acl.ReadOnlyACL{}
 
-	ctx := authedCtx(t)
 	e := &entity.Entity{ID: "TKT-001", Type: "ticket"}
-	got := app.computeActions(ctx, e)
+	got := app.computeActions(t.Context(), e)
 
-	if got == nil {
-		t.Fatal("computeActions returned nil for authenticated principal")
-	}
 	for _, v := range []string{"update", "delete", "rename"} {
 		if got[v] {
 			t.Errorf("_actions[%q] = true under ReadOnlyACL, want false", v)
@@ -76,13 +70,9 @@ func TestComputeActions_NopACL(t *testing.T) {
 	app := newTestAppV1(t)
 	// app.acl is already acl.NopACL via the test fixture wiring.
 
-	ctx := authedCtx(t)
 	e := &entity.Entity{ID: "TKT-001", Type: "ticket"}
-	got := app.computeActions(ctx, e)
+	got := app.computeActions(t.Context(), e)
 
-	if got == nil {
-		t.Fatal("computeActions returned nil for authenticated principal")
-	}
 	for _, v := range []string{"update", "delete", "rename"} {
 		if !got[v] {
 			t.Errorf("_actions[%q] = false under NopACL, want true", v)
@@ -90,57 +80,15 @@ func TestComputeActions_NopACL(t *testing.T) {
 	}
 }
 
-// TestComputeActions_AnonymousOmits asserts that an anonymous request
-// (no Principal stamped) returns a nil map so the serializer omits the
-// field — the SPA's fallback distinguishes anonymous (show all,
-// silent) from authenticated-but-missing (show all, warn).
-func TestComputeActions_AnonymousOmits(t *testing.T) {
-	app := newTestAppV1(t)
-
-	e := &entity.Entity{ID: "TKT-001", Type: "ticket"}
-	got := app.computeActions(context.Background(), e)
-
-	if got != nil {
-		t.Errorf("expected nil _actions for anonymous principal, got %v", got)
-	}
-}
-
-// AC4 part: collection actions returns nil for anonymous, expected
-// verb set for authenticated.
-func TestComputeCollectionActions_Anonymous(t *testing.T) {
-	app := newTestAppV1(t)
-
-	if got := app.computeCollectionActions(context.Background(), "ticket"); got != nil {
-		t.Errorf("expected nil collection actions for anonymous, got %v", got)
-	}
-}
-
-func TestComputeCollectionActions_Authenticated(t *testing.T) {
+// AC4: collection-scope verb computed under ReadOnlyACL is false.
+func TestComputeCollectionActions_ReadOnly(t *testing.T) {
 	app := newTestAppV1(t)
 	app.acl = acl.ReadOnlyACL{}
 
-	got := app.computeCollectionActions(authedCtx(t), "ticket")
-	if got == nil {
-		t.Fatal("expected non-nil collection actions for authenticated principal")
-	}
-	if _, ok := got["create"]; !ok {
-		t.Errorf("expected 'create' key in collection actions; got %v", got)
-	}
+	got := app.computeCollectionActions(t.Context(), "ticket")
 	if got["create"] {
-		t.Errorf("expected create=false under ReadOnlyACL, got true")
+		t.Errorf("_actions.create = true under ReadOnlyACL, want false")
 	}
-}
-
-// authedCtx returns a context with a non-anonymous Principal stamped,
-// so computeActions doesn't take the anonymous-fallback branch. Tool
-// is ToolDataEntry to match production wiring; user is any non-empty
-// string.
-func authedCtx(t *testing.T) context.Context {
-	t.Helper()
-	return principal.With(context.Background(), principal.Principal{
-		User: "test-user",
-		Tool: principal.ToolDataEntry,
-	})
 }
 
 // TestComputeActions_NoAuditNoise is AC8 — read-time `AuthorizeWrite`

--- a/internal/dataentry/affordances_test.go
+++ b/internal/dataentry/affordances_test.go
@@ -1,0 +1,173 @@
+package dataentry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// TestTranslateVerb_Roundtrip pins the phase-1 verb vocabulary against
+// acl.Op constants. The grep test (AC10) only proves no one *else*
+// constructs WriteRequest{Op:...}; this proves the central translation
+// is correct.
+func TestTranslateVerb_Roundtrip(t *testing.T) {
+	cases := []struct {
+		verb string
+		op   acl.Op
+	}{
+		{"create", acl.OpCreate},
+		{"update", acl.OpUpdate},
+		{"delete", acl.OpDelete},
+		{"rename", acl.OpRename},
+	}
+	for _, c := range cases {
+		t.Run(c.verb, func(t *testing.T) {
+			req, ok := translateVerb(c.verb, "ticket")
+			if !ok {
+				t.Fatalf("translateVerb(%q) returned ok=false", c.verb)
+			}
+			if req.Op != c.op {
+				t.Errorf("Op = %q, want %q", req.Op, c.op)
+			}
+			if req.EntityType != "ticket" {
+				t.Errorf("EntityType = %q, want %q", req.EntityType, "ticket")
+			}
+		})
+	}
+}
+
+// TestTranslateVerb_Unknown asserts unknown verbs return ok=false so
+// computeActions can skip them silently.
+func TestTranslateVerb_Unknown(t *testing.T) {
+	req, ok := translateVerb("transition:done", "ticket")
+	if ok {
+		t.Errorf("translateVerb(transition:done) returned ok=true; phase 1 doesn't support transition verbs yet")
+	}
+	if req != (acl.WriteRequest{}) {
+		t.Errorf("expected zero WriteRequest on unknown verb, got %+v", req)
+	}
+}
+
+// AC1: read-only principal sees all per-item verbs as false.
+func TestComputeActions_ReadOnly(t *testing.T) {
+	app := newTestAppV1(t)
+	app.acl = acl.ReadOnlyACL{}
+
+	ctx := authedCtx(t)
+	e := &entity.Entity{ID: "TKT-001", Type: "ticket"}
+	got := app.computeActions(ctx, e)
+
+	if got == nil {
+		t.Fatal("computeActions returned nil for authenticated principal")
+	}
+	for _, v := range []string{"update", "delete", "rename"} {
+		if got[v] {
+			t.Errorf("_actions[%q] = true under ReadOnlyACL, want false", v)
+		}
+	}
+}
+
+// AC2: NopACL principal sees all per-item verbs as true.
+func TestComputeActions_NopACL(t *testing.T) {
+	app := newTestAppV1(t)
+	// app.acl is already acl.NopACL via the test fixture wiring.
+
+	ctx := authedCtx(t)
+	e := &entity.Entity{ID: "TKT-001", Type: "ticket"}
+	got := app.computeActions(ctx, e)
+
+	if got == nil {
+		t.Fatal("computeActions returned nil for authenticated principal")
+	}
+	for _, v := range []string{"update", "delete", "rename"} {
+		if !got[v] {
+			t.Errorf("_actions[%q] = false under NopACL, want true", v)
+		}
+	}
+}
+
+// TestComputeActions_AnonymousOmits asserts that an anonymous request
+// (no Principal stamped) returns a nil map so the serializer omits the
+// field — the SPA's fallback distinguishes anonymous (show all,
+// silent) from authenticated-but-missing (show all, warn).
+func TestComputeActions_AnonymousOmits(t *testing.T) {
+	app := newTestAppV1(t)
+
+	e := &entity.Entity{ID: "TKT-001", Type: "ticket"}
+	got := app.computeActions(context.Background(), e)
+
+	if got != nil {
+		t.Errorf("expected nil _actions for anonymous principal, got %v", got)
+	}
+}
+
+// AC4 part: collection actions returns nil for anonymous, expected
+// verb set for authenticated.
+func TestComputeCollectionActions_Anonymous(t *testing.T) {
+	app := newTestAppV1(t)
+
+	if got := app.computeCollectionActions(context.Background(), "ticket"); got != nil {
+		t.Errorf("expected nil collection actions for anonymous, got %v", got)
+	}
+}
+
+func TestComputeCollectionActions_Authenticated(t *testing.T) {
+	app := newTestAppV1(t)
+	app.acl = acl.ReadOnlyACL{}
+
+	got := app.computeCollectionActions(authedCtx(t), "ticket")
+	if got == nil {
+		t.Fatal("expected non-nil collection actions for authenticated principal")
+	}
+	if _, ok := got["create"]; !ok {
+		t.Errorf("expected 'create' key in collection actions; got %v", got)
+	}
+	if got["create"] {
+		t.Errorf("expected create=false under ReadOnlyACL, got true")
+	}
+}
+
+// authedCtx returns a context with a non-anonymous Principal stamped,
+// so computeActions doesn't take the anonymous-fallback branch. Tool
+// is ToolDataEntry to match production wiring; user is any non-empty
+// string.
+func authedCtx(t *testing.T) context.Context {
+	t.Helper()
+	return principal.With(context.Background(), principal.Principal{
+		User: "test-user",
+		Tool: principal.ToolDataEntry,
+	})
+}
+
+// TestComputeActions_NoAuditNoise is AC8 — read-time `AuthorizeWrite`
+// calls in computeActions are not writes, so they must not produce
+// audit records. The audit sink lives on entitymanager.Manager (the
+// write path); the read path doesn't touch it. We wire a Memory audit
+// sink into the EntityManager and assert that a GET (which triggers
+// per-entity + per-collection affordance computation) records zero
+// audit entries.
+func TestComputeActions_NoAuditNoise(t *testing.T) {
+	cases := []acl.ACL{acl.NopACL{}, acl.ReadOnlyACL{}}
+	for _, a := range cases {
+		t.Run("", func(t *testing.T) {
+			sink := audit.NewMemory()
+			app := buildAppWithACLAndAudit(t, a, sink)
+			seedEntity(app, &entity.Entity{
+				ID: "TKT-001", Type: "ticket",
+				Properties: map[string]interface{}{"title": "audit-test"},
+			})
+
+			// Per-entity GET triggers computeActions +
+			// computeCollectionActions — both read-only.
+			_ = fetchActions(t, app, "ticket", "tickets", "TKT-001")
+
+			if got := len(sink.Records()); got != 0 {
+				t.Errorf("expected 0 audit records on read path, got %d: %+v", got, sink.Records())
+			}
+		})
+	}
+}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -36,7 +36,7 @@ type V1Entity struct {
 	Relations    map[string][]string    `json:"relations,omitempty"`
 	Included     map[string]V1Entity    `json:"included,omitempty"`
 	Self         string                 `json:"_self,omitempty"`
-	Actions      *V1Actions             `json:"_actions,omitempty"`
+	Actions      map[string]bool        `json:"_actions,omitempty"`
 	Inaccessible []V1InaccessibleField  `json:"inaccessible,omitempty"`
 	// Warnings lists soft-condition findings surfaced by the write
 	// path. Populated only by mutation responses (PATCH); read paths
@@ -53,22 +53,11 @@ type V1InaccessibleField struct {
 	Reason string `json:"reason"`
 }
 
-// V1Actions describes available actions for an entity.
-type V1Actions struct {
-	Delete      *V1ActionStatus `json:"delete,omitempty"`
-	Transitions []string        `json:"transitions,omitempty"`
-}
-
-// V1ActionStatus describes whether an action is allowed.
-type V1ActionStatus struct {
-	Allowed bool   `json:"allowed"`
-	Reason  string `json:"reason,omitempty"`
-}
-
 // V1ListResponse is the response for listing entities.
 type V1ListResponse struct {
-	Data []V1Entity `json:"data"`
-	Meta V1ListMeta `json:"meta"`
+	Data    []V1Entity      `json:"data"`
+	Meta    V1ListMeta      `json:"meta"`
+	Actions map[string]bool `json:"_actions,omitempty"`
 }
 
 // V1ListMeta contains pagination metadata.
@@ -370,12 +359,12 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 	data := make([]V1Entity, 0, len(entities))
 	included := make(map[string]V1Entity)
 	for _, e := range entities {
-		v1Entity := a.entityToV1(e, plural, true, false)
+		v1Entity := a.entityToV1(r.Context(), e, plural, true)
 		data = append(data, v1Entity)
 
 		// Resolve includes if requested
 		if wantIncludes {
-			for id, inc := range a.resolveV1Includes(e, includes) {
+			for id, inc := range a.resolveV1Includes(r.Context(), e, includes) {
 				included[id] = inc
 			}
 		}
@@ -389,6 +378,7 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 			PerPage: perPage,
 			HasMore: end < total,
 		},
+		Actions: a.computeCollectionActions(r.Context(), typeName),
 	}
 
 	// Add Link header for pagination (RFC 5988)
@@ -406,11 +396,13 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 			Data     []V1Entity          `json:"data"`
 			Meta     V1ListMeta          `json:"meta"`
 			Included map[string]V1Entity `json:"included,omitempty"`
+			Actions  map[string]bool     `json:"_actions,omitempty"`
 		}
 		writeV1JSON(w, http.StatusOK, listWithIncludes{
 			Data:     resp.Data,
 			Meta:     resp.Meta,
 			Included: included,
+			Actions:  resp.Actions,
 		})
 		return
 	}
@@ -474,7 +466,7 @@ func (a *App) handleV1CreateEntity(w http.ResponseWriter, r *http.Request, typeN
 		return
 	}
 
-	result := a.entityToV1(created, plural, true, false)
+	result := a.entityToV1(r.Context(), created, plural, true)
 	// DEC-HWZHA: surface entity-level soft validation findings (e.g.
 	// required-field-missing) as warnings on the 201 response.
 	if len(createResult.Warnings) > 0 {
@@ -517,13 +509,12 @@ func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName
 
 	query := r.URL.Query()
 	includeRelations := true
-	includeActions := strings.Contains(query.Get("include"), "_actions")
 
-	result := a.entityToV1(entity, plural, includeRelations, includeActions)
+	result := a.entityToV1(r.Context(), entity, plural, includeRelations)
 
 	// Handle includes for related entities
 	if includes := query.Get("include"); includes != "" {
-		result.Included = a.resolveV1Includes(entity, includes)
+		result.Included = a.resolveV1Includes(r.Context(), entity, includes)
 	}
 
 	// ETag for caching
@@ -678,7 +669,7 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 		}
 	}
 
-	result := a.entityToV1(entity, plural, true, false)
+	result := a.entityToV1(r.Context(), entity, plural, true)
 	if len(warnings) > 0 {
 		result.Warnings = warnings
 	}
@@ -1034,7 +1025,7 @@ func (a *App) handleV1CloneEntity(w http.ResponseWriter, r *http.Request, typeNa
 
 	entityDef := s.Meta.Entities[typeName]
 	plural := entityDef.GetPlural(typeName)
-	result := a.entityToV1(newEntity, plural, false, false)
+	result := a.entityToV1(r.Context(), newEntity, plural, false)
 
 	w.Header().Set("Location", fmt.Sprintf("/api/v1/%s/%s", plural, newEntity.ID))
 	writeV1JSON(w, http.StatusCreated, result)
@@ -1238,7 +1229,7 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 	for _, e := range entities {
 		entityDef := meta.Entities[e.Type]
 		plural := entityDef.GetPlural(e.Type)
-		data = append(data, a.entityToV1(e, plural, false, false))
+		data = append(data, a.entityToV1(r.Context(), e, plural, false))
 	}
 
 	resp := V1ListResponse{
@@ -1297,7 +1288,7 @@ func (a *App) handleV1Analyze(w http.ResponseWriter, r *http.Request) {
 
 // --- Helper Functions ---
 
-func (a *App) entityToV1(e *entityPkg.Entity, plural string, includeRelations, includeActions bool) V1Entity {
+func (a *App) entityToV1(ctx context.Context, e *entityPkg.Entity, plural string, includeRelations bool) V1Entity {
 	s := a.State()
 	v1 := V1Entity{
 		ID:         e.ID,
@@ -1306,6 +1297,7 @@ func (a *App) entityToV1(e *entityPkg.Entity, plural string, includeRelations, i
 		Properties: make(map[string]interface{}),
 		Content:    e.Content,
 		Self:       fmt.Sprintf("/api/v1/%s/%s", plural, e.ID),
+		Actions:    a.computeActions(ctx, e),
 	}
 
 	for k, v := range e.Properties {
@@ -1329,43 +1321,10 @@ func (a *App) entityToV1(e *entityPkg.Entity, plural string, includeRelations, i
 		}
 	}
 
-	if includeActions {
-		v1.Actions = a.computeEntityActions(s, e)
-	}
-
 	return v1
 }
 
-func (a *App) computeEntityActions(s *AppState, e *entityPkg.Entity) *V1Actions {
-	actions := &V1Actions{}
-
-	// Delete is always allowed; cascade removes associated relations.
-	actions.Delete = &V1ActionStatus{Allowed: true}
-
-	// Get valid status transitions
-	if status, ok := e.Properties["status"].(string); ok {
-		entityDef := s.Meta.Entities[e.Type]
-		if statusProp, ok := entityDef.Properties["status"]; ok {
-			if ct, ok := s.Meta.Types[statusProp.Type]; ok {
-				actions.Transitions = ct.Values
-			} else if len(statusProp.Values) > 0 {
-				actions.Transitions = statusProp.Values
-			}
-		}
-		// Filter out current status
-		filtered := make([]string, 0)
-		for _, t := range actions.Transitions {
-			if t != status {
-				filtered = append(filtered, t)
-			}
-		}
-		actions.Transitions = filtered
-	}
-
-	return actions
-}
-
-func (a *App) resolveV1Includes(entity *entityPkg.Entity, includes string) map[string]V1Entity {
+func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, includes string) map[string]V1Entity {
 	s := a.State()
 	included := make(map[string]V1Entity)
 
@@ -1379,7 +1338,7 @@ func (a *App) resolveV1Includes(entity *entityPkg.Entity, includes string) map[s
 			}
 			entityDef := s.Meta.Entities[target.Type]
 			plural := entityDef.GetPlural(target.Type)
-			included[target.ID] = a.entityToV1(target, plural, false, false)
+			included[target.ID] = a.entityToV1(ctx, target, plural, false)
 		}
 		// Include all incoming relations
 		for _, edge := range a.incomingRelations(entity.ID) {
@@ -1389,7 +1348,7 @@ func (a *App) resolveV1Includes(entity *entityPkg.Entity, includes string) map[s
 			}
 			entityDef := s.Meta.Entities[source.Type]
 			plural := entityDef.GetPlural(source.Type)
-			included[source.ID] = a.entityToV1(source, plural, false, false)
+			included[source.ID] = a.entityToV1(ctx, source, plural, false)
 		}
 		return included
 	}
@@ -1397,7 +1356,7 @@ func (a *App) resolveV1Includes(entity *entityPkg.Entity, includes string) map[s
 	parts := strings.Split(includes, ",")
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
-		if part == "" || part == "_actions" {
+		if part == "" {
 			continue
 		}
 
@@ -1415,11 +1374,11 @@ func (a *App) resolveV1Includes(entity *entityPkg.Entity, includes string) map[s
 			}
 			entityDef := s.Meta.Entities[target.Type]
 			plural := entityDef.GetPlural(target.Type)
-			included[target.ID] = a.entityToV1(target, plural, false, false)
+			included[target.ID] = a.entityToV1(ctx, target, plural, false)
 
 			// Handle nested includes
 			if len(relParts) > 1 {
-				nested := a.resolveV1Includes(target, relParts[1])
+				nested := a.resolveV1Includes(ctx, target, relParts[1])
 				for k, v := range nested {
 					included[k] = v
 				}
@@ -2675,7 +2634,7 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 	plural := entityDef.GetPlural(result.Entry.Type)
 
 	resp := V1ViewResponse{
-		Entry:    a.entityToV1(result.Entry, plural, true, false),
+		Entry:    a.entityToV1(r.Context(), result.Entry, plural, true),
 		Sections: make([]V1ViewSection, 0, len(sections)),
 	}
 

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -1052,7 +1052,7 @@ func TestV1GetEntityWithActions(t *testing.T) {
 		},
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001?include=_actions", http.NoBody)
+	req := withTestPrincipal(httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody))
 	rec := httptest.NewRecorder()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
 	if rec.Code != http.StatusOK {
@@ -1065,11 +1065,10 @@ func TestV1GetEntityWithActions(t *testing.T) {
 	}
 
 	if entity.Actions == nil {
-		t.Error("expected actions in response")
+		t.Fatal("expected actions in response")
 	}
-
-	if entity.Actions != nil && entity.Actions.Delete == nil {
-		t.Error("expected delete action status")
+	if _, ok := entity.Actions["delete"]; !ok {
+		t.Error("expected 'delete' key in actions map")
 	}
 }
 
@@ -1638,7 +1637,7 @@ func TestV1ComputeEntityActionsWithIncomingRelations(t *testing.T) {
 		Type: "implements",
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/features/FEA-001?include=_actions", http.NoBody)
+	req := withTestPrincipal(httptest.NewRequest(http.MethodGet, "/api/v1/features/FEA-001", http.NoBody))
 	rec := httptest.NewRecorder()
 	app.handleV1GetEntity(rec, req, "feature", "features", "FEA-001")
 	var entity V1Entity
@@ -1646,12 +1645,13 @@ func TestV1ComputeEntityActionsWithIncomingRelations(t *testing.T) {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	// Delete should be allowed even with incoming relations (cascade handles cleanup)
-	if entity.Actions == nil || entity.Actions.Delete == nil {
-		t.Fatal("expected delete action")
+	// Delete should be allowed even with incoming relations (cascade handles cleanup).
+	// Under acl.NopACL (the test-app default), every per-item verb is true.
+	if entity.Actions == nil {
+		t.Fatal("expected _actions on response")
 	}
-	if !entity.Actions.Delete.Allowed {
-		t.Error("expected delete to be allowed (cascade removes relations)")
+	if !entity.Actions["delete"] {
+		t.Error("expected _actions.delete=true under NopACL (cascade removes relations)")
 	}
 }
 
@@ -2035,21 +2035,18 @@ func TestV1SidebarAppliesKanbanFilters(t *testing.T) {
 	}
 }
 
-func TestV1ComputeEntityActionsWithCustomType(t *testing.T) {
+// TestV1ComputeEntityActions_VerbVocabulary asserts the phase-1 verb
+// vocabulary (update / delete / rename) is present on every entity
+// response under NopACL. Workflow-transition verbs are out of phase 1;
+// they will return when ACL v0.5 lands transition Op support.
+func TestV1ComputeEntityActions_VerbVocabulary(t *testing.T) {
 	app := newTestAppV1(t)
 
-	// Set up status property with custom type
-	app.Meta().Types = map[string]metamodel.CustomType{
-		"ticket_status": {
-			Values:  []string{"open", "in_progress", "closed"},
-			Default: "open",
-		},
-	}
 	app.Meta().Entities["ticket"] = metamodel.EntityDef{
 		Label: "Ticket",
 		Properties: map[string]metamodel.PropertyDef{
 			"title":  {Type: "string", Required: true},
-			"status": {Type: "ticket_status"},
+			"status": {Type: "string", Values: []string{"open", "closed"}},
 		},
 	}
 
@@ -2062,7 +2059,7 @@ func TestV1ComputeEntityActionsWithCustomType(t *testing.T) {
 		},
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001?include=_actions", http.NoBody)
+	req := withTestPrincipal(httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody))
 	rec := httptest.NewRecorder()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
 	var entity V1Entity
@@ -2070,15 +2067,12 @@ func TestV1ComputeEntityActionsWithCustomType(t *testing.T) {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	// Should have transitions from custom type
-	if entity.Actions == nil || len(entity.Actions.Transitions) == 0 {
-		t.Error("expected transitions in actions")
+	if entity.Actions == nil {
+		t.Fatal("expected _actions on response")
 	}
-
-	// Current status should be filtered out
-	for _, tr := range entity.Actions.Transitions {
-		if tr == "open" {
-			t.Error("current status 'open' should be filtered out of transitions")
+	for _, verb := range []string{"update", "delete", "rename"} {
+		if _, ok := entity.Actions[verb]; !ok {
+			t.Errorf("expected verb %q in _actions; got %v", verb, entity.Actions)
 		}
 	}
 }

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -1052,7 +1052,7 @@ func TestV1GetEntityWithActions(t *testing.T) {
 		},
 	})
 
-	req := withTestPrincipal(httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
 	if rec.Code != http.StatusOK {
@@ -1637,7 +1637,7 @@ func TestV1ComputeEntityActionsWithIncomingRelations(t *testing.T) {
 		Type: "implements",
 	})
 
-	req := withTestPrincipal(httptest.NewRequest(http.MethodGet, "/api/v1/features/FEA-001", http.NoBody))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/features/FEA-001", http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1GetEntity(rec, req, "feature", "features", "FEA-001")
 	var entity V1Entity
@@ -2059,7 +2059,7 @@ func TestV1ComputeEntityActions_VerbVocabulary(t *testing.T) {
 		},
 	})
 
-	req := withTestPrincipal(httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
 	var entity V1Entity

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -16,6 +16,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
@@ -112,6 +113,7 @@ type App struct {
 	templater     templating.Templater
 	cfgLoader     config.Loader
 	kv            state.KV
+	acl           acl.ACL
 
 	// documents renders and caches documents. Created once in NewApp so
 	// singleflight deduplication is stable across requests.
@@ -258,6 +260,7 @@ func NewApp(
 	st store.Store,
 	em entitymanager.EntityManager,
 	searcher search.Searcher,
+	aclImpl acl.ACL,
 ) (*App, error) {
 	// Reject nil required collaborators up front rather than letting a
 	// downstream handler panic on the first request that exercises them.
@@ -275,6 +278,9 @@ func NewApp(
 	}
 	if searcher == nil {
 		return nil, errors.New("dataentry.NewApp: searcher is required")
+	}
+	if aclImpl == nil {
+		return nil, errors.New("dataentry.NewApp: acl is required (use acl.NopACL{} to opt out)")
 	}
 	// Construct reconstructible services from the primitives.
 	cfgLoader := config.NewFSLoader(fs, paths.Root)
@@ -362,6 +368,7 @@ func NewApp(
 		templater:     templater,
 		cfgLoader:     cfgLoader,
 		kv:            kv,
+		acl:           aclImpl,
 		broker:        newEventBroker(),
 		scriptEngine:  scriptEngine,
 	}

--- a/internal/dataentry/e2e_test.go
+++ b/internal/dataentry/e2e_test.go
@@ -56,7 +56,7 @@ func newE2ETestApp(t *testing.T) (*App, string, func()) {
 	}
 	app, err := NewApp(
 		svc.FS(), svc.Paths(), svc.Meta(), svc.Store(),
-		svc.EntityManager(), svc.Searcher(),
+		svc.EntityManager(), svc.Searcher(), svc.ACL(),
 	)
 	if err != nil {
 		svc.Close()

--- a/internal/dataentry/inaccessible_test.go
+++ b/internal/dataentry/inaccessible_test.go
@@ -32,7 +32,7 @@ func lockedTicket(inaccessibleFields ...string) *entity.Entity {
 func TestEntityToV1_PropagatesInaccessible(t *testing.T) {
 	app := newTestAppV1(t)
 	e := lockedTicket("title", "status")
-	v1 := app.entityToV1(e, "tickets", false, false)
+	v1 := app.entityToV1(t.Context(), e, "tickets", false)
 
 	if v1.ID != "TKT-LOCKED" {
 		t.Errorf("ID = %q, want TKT-LOCKED", v1.ID)
@@ -110,7 +110,7 @@ func TestEntityToV1_OmitsInaccessibleWhenEmpty(t *testing.T) {
 		},
 	}
 
-	v1 := app.entityToV1(e, "tickets", false, false)
+	v1 := app.entityToV1(t.Context(), e, "tickets", false)
 	if len(v1.Inaccessible) != 0 {
 		t.Errorf("Inaccessible non-empty for normal entity: %v", v1.Inaccessible)
 	}

--- a/internal/dataentry/lint_test.go
+++ b/internal/dataentry/lint_test.go
@@ -1,0 +1,66 @@
+package dataentry
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoStrayWriteRequestConstruction is AC10 — the structural
+// same-code-path invariant for action affordances. Direct construction
+// of `acl.WriteRequest{Op:` outside `affordances.go` would drift the
+// read-time verdict (the `_actions` map) from the write-time
+// enforcement (the actual handler). [translateVerb] is the single
+// source of truth — both the serializer and the write handlers route
+// their request construction through it.
+//
+// Write handlers in `internal/dataentry` reach the ACL via
+// `entityManager.Manager`, which does the construction inside
+// `internal/entitymanager` — also a single point of construction.
+// So `internal/dataentry` should never need a literal
+// `acl.WriteRequest{Op:`.
+//
+// Adding a new verb in a follow-up phase: add an entry to
+// [translateVerb], do not introduce a parallel construction site.
+func TestNoStrayWriteRequestConstruction(t *testing.T) {
+	const allowedFile = "affordances.go"
+	const needle = "acl.WriteRequest{Op:"
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// Limit to .go non-test sources in this package directory.
+		base := filepath.Base(path)
+		if !strings.HasSuffix(base, ".go") || strings.HasSuffix(base, "_test.go") {
+			return nil
+		}
+		if filepath.Dir(path) != root {
+			return nil
+		}
+		if base == allowedFile {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(body), needle) {
+			t.Errorf("file %s contains %q — the only allowed construction site is %s (translateVerb). Add new verbs there.", path, needle, allowedFile)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+}

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -2,31 +2,18 @@ package dataentry
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/appbuild"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/openapi"
-	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/state"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
-
-// withTestPrincipal returns req with a synthetic test principal stamped
-// on its context — mirrors what the production router middleware does
-// for every incoming request. Use this on httptest.NewRequest results
-// so the handler doesn't see an unstamped (anonymous) context.
-func withTestPrincipal(req *http.Request) *http.Request {
-	return req.WithContext(principal.With(req.Context(), principal.Principal{
-		User: "test-user",
-		Tool: principal.ToolDataEntry,
-	}))
-}
 
 // seedEntity writes an entity directly into the app's store.
 func seedEntity(app *App, e *entity.Entity) {

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -2,18 +2,31 @@ package dataentry
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/appbuild"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/openapi"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/state"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
+
+// withTestPrincipal returns req with a synthetic test principal stamped
+// on its context — mirrors what the production router middleware does
+// for every incoming request. Use this on httptest.NewRequest results
+// so the handler doesn't see an unstamped (anonymous) context.
+func withTestPrincipal(req *http.Request) *http.Request {
+	return req.WithContext(principal.With(req.Context(), principal.Principal{
+		User: "test-user",
+		Tool: principal.ToolDataEntry,
+	}))
+}
 
 // seedEntity writes an entity directly into the app's store.
 func seedEntity(app *App, e *entity.Entity) {
@@ -127,6 +140,7 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	app.templater = svc.Templater()
 	app.cfgLoader = svc.Config()
 	app.kv = svc.State()
+	app.acl = svc.ACL()
 	// Wire a minimal documentService for tests that hit the documents
 	// handler. Script engine can be the real one (tests that use script:
 	// configs will need to seed scripts on disk).

--- a/internal/principal/principal.go
+++ b/internal/principal/principal.go
@@ -73,17 +73,6 @@ func From(ctx context.Context) Principal {
 	return Principal{User: "unknown", Tool: "unknown"}
 }
 
-// HasPrincipal reports whether ctx carries a Principal value stamped
-// via [With]. Unlike [From] (which returns a sentinel default for
-// unstamped contexts), HasPrincipal lets callers distinguish "no
-// principal at all" from "principal stamped as unknown" — needed by
-// the data-entry serializer to decide whether to omit the `_actions`
-// field on responses.
-func HasPrincipal(ctx context.Context) bool {
-	_, ok := ctx.Value(principalKey{}).(Principal)
-	return ok
-}
-
 // SystemUser returns the OS user running this process — $USER
 // trimmed, or "unknown" if $USER is unset or whitespace-only. Used by
 // entry-point wiring to populate [Principal.User].

--- a/internal/principal/principal.go
+++ b/internal/principal/principal.go
@@ -73,6 +73,17 @@ func From(ctx context.Context) Principal {
 	return Principal{User: "unknown", Tool: "unknown"}
 }
 
+// HasPrincipal reports whether ctx carries a Principal value stamped
+// via [With]. Unlike [From] (which returns a sentinel default for
+// unstamped contexts), HasPrincipal lets callers distinguish "no
+// principal at all" from "principal stamped as unknown" — needed by
+// the data-entry serializer to decide whether to omit the `_actions`
+// field on responses.
+func HasPrincipal(ctx context.Context) bool {
+	_, ok := ctx.Value(principalKey{}).(Principal)
+	return ok
+}
+
 // SystemUser returns the OS user running this process — $USER
 // trimmed, or "unknown" if $USER is unset or whitespace-only. Used by
 // entry-point wiring to populate [Principal.User].

--- a/tickets/entities/implementation-checklists/IMPL-3DVO.md
+++ b/tickets/entities/implementation-checklists/IMPL-3DVO.md
@@ -1,0 +1,40 @@
+---
+id: IMPL-3DVO
+type: implementation-checklist
+title: 'Implementation: Response-level action affordances: backend declares per-resource verbs to drive UI'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-3DVO.md
+++ b/tickets/entities/implementation-checklists/IMPL-3DVO.md
@@ -2,39 +2,58 @@
 id: IMPL-3DVO
 type: implementation-checklist
 title: 'Implementation: Response-level action affordances: backend declares per-resource verbs to drive UI'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
 
 ## Test Quality
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
 
 ## Manual Verification
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
 
 **Verification Evidence:**
-<!-- Document what you tested and the results -->
+
+Phase 1 scope landed in PR #779:
+
+- `internal/dataentry/affordances.go` — `translateVerb` + `computeActions` + `computeCollectionActions`.
+- `V1Entity._actions` reshaped to `map[string]bool`; `V1ListResponse._actions` added.
+- `internal/dataentry/affordances_test.go` — `TestTranslateVerb_Roundtrip`, `TestComputeActions_{ReadOnly,NopACL,AnonymousOmits}`, `TestComputeCollectionActions_*`, `TestComputeActions_NoAuditNoise` (AC1, AC2, AC8 verified).
+- `internal/dataentry/affordances_contract_test.go` — `TestAffordances_BidirectionalContract` parameterized over NopACL + ReadOnlyACL (AC3 verified end-to-end via GET + DELETE lockstep).
+- `internal/dataentry/lint_test.go` — `TestNoStrayWriteRequestConstruction` (AC10 — structural same-code-path enforcement).
+- `principal.HasPrincipal(ctx)` added so the serializer can distinguish unstamped context from `Principal{User: "unknown"}`.
+- `cmd/rela-server/main.go` + `cmd/rela-desktop/main.go` + `internal/dataentry/NewApp` signature updated for the new `acl.ACL` required collaborator.
+- Frontend `_actions` type changed to `Record<string, boolean>` on both `Entity` and `ListResponse`. 784 frontend tests pass.
+- `docs/data-entry/api-reference.md`, `docs/security.md`, `CLAUDE.md` updated. `just ci` green end-to-end (lint, arch-lint, lint-md, test, race, coverage 77.0%, build, docs-check).
+
+Deferred to follow-ups (out of scope for this ticket):
+
+- AC4 — list endpoint with mixed-permission rows: backend wiring landed (`computeCollectionActions`) but no dedicated test; will land in the phase-2 ticket.
+- AC5 — Vue components consult `entity._actions[verb]`: no component currently reads it; phase-2 ticket.
+- AC6 — synthetic-verb additive test: phase-2 ticket.
+- AC7 — AWM6L payoff (E2E button-less UI in read-only): phase-2 ticket.
+- `transition:*` and `relation:*` verbs: gated on ACL v0.5 follow-up.
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-B0CI.md
+++ b/tickets/entities/planning-checklists/PLAN-B0CI.md
@@ -1,0 +1,645 @@
+---
+id: PLAN-B0CI
+type: planning-checklist
+title: 'Planning: Hide / disable write affordances when the server is read-only (or when an ACL denies the type)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+> **Revision history**
+>
+> - v1: initial plan, "inventory awaiting survey" placeholder.
+> - **v2 (current)**: folded in (a) full SPA write-affordance survey — 31 sites
+>   across 9 component areas plus 5 keyboard shortcuts; (b) go-architect audit
+>   — `Deps` struct, explicit Declarative case, value vs pointer; (c) cranky
+>   plan review — auto-save flip semantics, unsaved-work safety, dedicated ACL
+>   store, ESLint enforcement, e2e fixture extension, FOUC prevention,
+>   keyboard-handler gating, SSE-reload hook. Sections marked **(v2)** are new
+>   or substantively rewritten.
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+Two coupled deliverables:
+
+### In scope (v2)
+
+1. **Backend (`internal/dataentry`).** Add `acl: { mode: "open" | "read-only" }` to the `/api/v1/_config` response, derived via type assertion against `acl.NopACL`, `acl.ReadOnlyACL`, and explicitly against `*acl.Declarative` (the third case returns `"open"` for v0; v1 will return `"policy"` when `writes_allowed_for` lands).
+2. **Convert `dataentry.NewApp` to a `Deps` struct.** Today's signature already takes 6 positional collaborators; ACL makes 7. The `entitymanager.Deps` pattern is the established way to grow this.
+3. **Frontend.** New dedicated **`aclStore`** (Pinia, separate from `schemaStore`); `useACL()` composable on top; persistent `ReadOnlyBanner` in `App.vue`; per-affordance gating across the 31 sites the survey enumerated; ESLint rule + `data-testid` enforcement so new write affordances can't slip the gate.
+4. **`useAutoSave` flip safety.** When `isReadOnly` becomes true, clear timers, drop pending, abort in-flight, refetch, repopulate. No error status for the abort.
+5. **SSE-triggered ACL reload.** Hook into `useEvents`' existing `refresh` event so live operator-toggles surface in the SPA without a manual reload.
+6. **E2E fixture extension.** `e2e/tests/fixtures.ts` `spawnServer` accepts extra args; new `readOnlyServerUrl` fixture; one Playwright test validates the gate end-to-end.
+
+### Out of scope (deferred to follow-ups)
+
+- Per-entity-type / per-property gating from `writes_allowed_for` — v1 with Declarative populating per-principal.
+- Per-principal customization — needs principal resolution on the read path.
+- MCP transport intersection — TKT-G3PPD.
+- SPA error-toast handling of structured 403 — TKT-JZRNF.
+- `policy` mode UX behavior — emit value but treat as open until v1 plumbs `writes_allowed_for`.
+- **Consumer-side `dataentry.AppServices` interface** (architect-audit finding) — would let `cmd/rela-server` pass `svc` directly rather than threading individual collaborators. Worth doing eventually for parity with `mcp.Services`; not blocking this PR — tracked as a separate ticket I'll file alongside.
+- Action metadata for `read_only_safe` flag per action — v0 hides all action buttons in read-only mode because the config has no read/write metadata. v1 can add the flag.
+
+### Acceptance criteria (v2)
+
+#### Backend
+
+1. **AC1 — `acl.mode` present and stable.** `GET /api/v1/_config` includes `acl.mode` whose value is exactly one of `"open" | "read-only"`. (v0 never emits `"policy"`; reserved but not implemented.) NopACL → `"open"`; ReadOnlyACL → `"read-only"`; `*acl.Declarative` → `"open"` (with a clear v0/v1 doc comment); any unknown ACL impl → `"open"` + `slog.Warn` naming the type.
+   - **Test:** `internal/dataentry/api_v1_config_acl_test.go::TestConfig_ACLMode_*` — four cases: NopACL, ReadOnlyACL, *Declarative, fake-ACL. Each via httptest. Plus `TestACLMode_UnknownImpl_LogsWarning`.
+
+2. **AC2 — Additive, no breaks.** Existing `_config` consumers (snapshot tests, the pre-this-PR SPA, external API clients) keep working. The `acl` field is the only addition; no renames or removals.
+   - **Test:** existing `api_v1_test.go` assertions pass unchanged; add one assertion that `config.acl.mode != ""`.
+
+3. **AC3 — `aclMode()` lives in dataentry.** The helper is package-private at `internal/dataentry`. Strings are dataentry's wire vocabulary; the ACL package stays free of SPA concerns. Compile-time guard: `var _ = aclMode(acl.NopACL{})` in the test file pins the type-assertion contract.
+   - **Test:** unit tests on the helper directly + the compile-time guard.
+
+4. **AC4 — `dataentry.NewApp` takes a `Deps` struct.** Construction goes from `NewApp(fs, paths, meta, store, em, searcher) → NewApp(Deps{...})`. All required collaborators nil-checked. `Deps.ACL` is required (NopACL is the explicit opt-out). `cmd/rela-server/main.go` and `cmd/rela-desktop/main.go` updated to call the new shape.
+   - **Test:** unit tests on `NewApp(Deps{})` rejecting nil for each required field; existing tests in `internal/dataentry/*_test.go` updated to use the new struct.
+
+#### Frontend — store + composable
+
+5. **AC5 — Dedicated `aclStore`.** New Pinia store `frontend/src/stores/acl.ts` holding `{ mode, loaded, reload() }`. Populated by a dedicated `getACLConfig()` call (which can share the `_config` fetch under the hood with `schemaStore` to avoid two round trips) or by extracting the `acl` field from the existing `getConfig()` call. Separation of concerns: schema is what's editable; ACL is server policy. Different reload triggers (see AC6).
+   - **Test:** `frontend/src/stores/acl.test.ts` — initial state, load, reload, reset.
+
+6. **AC6 — `useACL()` composable.** Returns `{ mode, isReadOnly, isOpen, ready }` reactive refs. `ready` is `true` once `aclStore.loaded === true`. **`isReadOnly` defaults to `true` until ready** (see AC7 FOUC prevention). `mode` defaults to `"read-only"` until loaded, then resolves.
+   - **Test:** `frontend/src/composables/useACL.test.ts` — default, transition to open, transition to read-only, store absent (backwards-compat).
+
+7. **AC7 — FOUC prevention.** No write affordance renders until `useACL().ready === true`. In open-mode deployments this is a tiny invisible flash (App.vue already awaits store load before mounting most views — verified during planning). In read-only deployments this prevents the user from briefly seeing "+ Create" buttons that then vanish. Implementation: components consult `isReadOnly` which is `true` while not-yet-loaded; only flips after the fetch.
+   - **Test:** App.vue snapshot during a delayed `aclStore.load()` shows no write buttons mid-load.
+
+8. **AC8 — SSE-triggered ACL reload.** `useEvents.ts` extended: on the existing `refresh` event, additionally call `aclStore.reload()`. When the server restarts in read-only mode, the SPA picks up the new state on the next SSE tick (no full page reload required).
+   - **Test:** `frontend/src/composables/useEvents.test.ts` — fake SSE event triggers `aclStore.reload` spy.
+
+#### Frontend — banner
+
+9. **AC9 — Banner.** New component `frontend/src/components/common/ReadOnlyBanner.vue`. Persistent ribbon, top of the app shell, non-dismissible. `role="status"`, `aria-live="polite"`, WCAG AA contrast (calm color — not error red, not warning amber). Copy: "Read-only mode — writes are disabled on this server." Mounted from `App.vue` when `isReadOnly && ready`.
+   - **Test:** `App.test.ts` snapshots in both modes; a11y attributes asserted; copy pinned via a constant referenced from `docs/security.md`.
+
+#### Frontend — affordance gating
+
+10. **AC10 — All 31 write affordances gated.** The survey enumerated the following groups; each must be hidden (not just disabled) when `isReadOnly`. Per-affordance file/line references in the **Files to modify** section.
+    - **EntityList**: header "+ New" + `n` shortcut, row delete + `Del`/`Backspace`, bulk action row + checkboxes + single-letter shortcuts, `e` edit shortcut.
+    - **EntityDetail**: desktop+mobile Edit, desktop+mobile Delete, command buttons + overflow menu, content checkboxes, per-row Edit pencils.
+    - **DynamicForm**: Save/Create + Cmd+Enter, autosave (suppressed via `useAutoSave({enabled})`), template selector, ID controls, relation widgets (`RelationCards`, `RelationPicker`, `InlineCreateModal`, `SidePanel`).
+    - **KanbanView**: header "+ New", drag-and-drop.
+    - **SettingsView**: user-defaults form Save, palette Save, logo upload/remove, theme package Install, git commit submit.
+    - **ConflictsView**: Apply Resolution.
+    - **StatusBar**: git sync click.
+    - **Sidebar**: action items in nav.
+    - **CommandModal**: defensive guard in `runCommand`.
+
+11. **AC11 — Keyboard handlers also gated.** All keyboard handlers that trigger writes refuse to act in read-only mode. Specifically: `n` (create), `e` (edit), `Del`/`Backspace` (delete), single-letter action shortcuts, `Cmd/Ctrl+Enter` (form submit). Implementation: each handler calls `useACL()` and short-circuits.
+    - **Test:** unit tests on `useListKeyboard`, `useListActions`, `DynamicForm`'s `handleKeydown` — keystroke under read-only triggers no action.
+
+12. **AC12 — Auto-save flip safety.** When `isReadOnly` becomes true, `useAutoSave` must:
+    1. Clear all pending timers.
+    2. Drop `pending[*]` entries.
+    3. Call `currentAbort.abort()` to cancel in-flight PATCH.
+    4. Set `relationsDirty = false`.
+    5. Refetch the entity from server and call `mergeServerResponse`.
+    6. **NOT** transition `status` to `"error"` — this is a graceful state change, not a failure.
+    7. Surface a toast: "Server is now read-only — your unsaved changes have been discarded." (Or kept; see AC13.)
+    - **Test:** `useAutoSave.test.ts::TestFlipToReadOnly_AbortsAndClears` — pending timer, in-flight PATCH, both cancelled; entity refetched; status === `"idle"`, not `"error"`.
+
+13. **AC13 — Unsaved work preservation.** When `isReadOnly` flips while the user has dirty form state (typed text not yet flushed): formData is preserved client-side, but flagged as `unsavable`. Toast: "Server is now read-only — your unsaved changes haven't been written. Copy them now if you need them." The form's Save button (already hidden by AC10) does not re-appear. A future SSE refresh that returns the server to open mode re-enables saves; the user can click Save then.
+    - **Test:** `DynamicForm.test.ts::TestReadOnlyFlip_PreservesDirtyState` — type into a field, flip read-only, formData still contains the typed text, toast appears.
+
+14. **AC14 — Modals close on flip.** Any open modal with write intent (CreateModal, DeleteConfirm, command runner) closes itself on read-only flip and shows a toast naming why. Read-only modals (help, view-info) stay open.
+    - **Test:** per-modal unit test.
+
+#### Enforcement & cross-cutting
+
+15. **AC15 — ESLint rule + `data-testid` convention.** New ESLint rule `rela/write-affordance-must-gate` (or use a custom file-pattern rule) that flags `@click` handlers calling `entitiesStore.create|update|delete|...` (or any `frontend/src/api/*.ts` write function) without a `v-if` referencing `useACL()`. Plus a `data-testid="write-affordance"` convention on every gated element so the E2E test can sweep for them.
+    - **Test:** ESLint rule itself has unit tests; one repo-wide lint check passes after the migration.
+
+16. **AC16 — E2E coverage.**
+    - Extend `e2e/tests/fixtures.ts::spawnServer` to accept `extraArgs: string[]`.
+    - Add a `readOnlyServerUrl` fixture (parametrised over the same memstore-backed project).
+    - One new Playwright test: boots `rela-server --read-only`, navigates to a list, asserts (a) banner visible, (b) no `[data-testid="write-affordance"]` elements are reachable, (c) typing into a form field doesn't trigger a network call within the debounce window.
+    - **Test plan:** the test itself IS the AC verification.
+
+17. **AC17 — Open-mode regression.** When `rela-server` runs without `--read-only`, the entire existing E2E suite passes unchanged. All happy-path create/update/delete flows still work.
+    - **Test:** `just e2e` exits 0 against develop's existing fixtures.
+
+18. **AC18 — Backwards-compat with older server.** Frontend treats `_config.acl` absence as `mode: "open"`. No banner, no gating. (Older server pre-this-PR.)
+    - **Test:** `aclStore.test.ts::TestServerWithoutACLField_DefaultsToOpen`.
+
+19. **AC19 — Live-transition staleness window documented.** If SSE disconnects and reconnects, the SPA may not learn of a server restart until the next `refresh` event. The plan accepts this staleness window (typically seconds). Documented in `docs/security.md` so operators understand the UX guarantees.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing patterns:**
+
+- **`entitymanager.Deps` pattern** (`internal/entitymanager/manager.go`) — the model for `dataentry.NewApp(Deps)`. Required fields nil-checked in constructor; `audit.Nop{}` / `acl.NopACL{}` are the explicit opt-outs.
+- **`appbuild.Services.ACL()` accessor** (already exists) — the wiring source. `cmd/rela-server/main.go` reads it.
+- **`mcp.Services` consumer-side interface** (`internal/mcp/server.go`) — the eventual target shape for `dataentry`; out of scope per the architect audit, tracked as a follow-up.
+- **Pinia store + composable wrapper** — established pattern (`useSchemaStore`, `useUIStore`); `useACL`+`aclStore` mirror it.
+- **`useAutoSave` internals** (`frontend/src/composables/useAutoSave.ts`) — `pending`, `currentAbort`, `queueTail`, `mergeServerResponse`. The flip-safety implementation hooks all three.
+- **`useEvents` SSE handlers** — currently invalidates entities + git status; extending to also reload `aclStore` is two lines.
+
+**Survey** (delivered by the in-flight agent, summarized above and below)
+enumerated 31 distinct write affordances in 9 component areas plus 5 keyboard
+shortcuts.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+### Backend
+
+```go
+// internal/dataentry/api_v1.go
+
+type V1ACLConfig struct {
+    // Mode reports the active ACL's behavior class:
+    //   "open"      — every authenticated request can write (NopACL or
+    //                 *Declarative in v0 — see below).
+    //   "read-only" — every write returns 403 (ReadOnlyACL).
+    //
+    // **v0 → v1 progression.** v0 emits "open" or "read-only" only.
+    // v1 will introduce "policy" + a populated WritesAllowedFor list
+    // when *Declarative gains per-type gating in the SPA. Until then,
+    // *Declarative deliberately surfaces as "open" so the SPA's existing
+    // 403 + toast path handles per-type denies — same UX as today's
+    // pre-ACL deployments. See docs/security.md.
+    Mode string `json:"mode"`
+}
+
+func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
+    // ...existing...
+    config := V1Config{
+        // ...
+        ACL: V1ACLConfig{Mode: aclMode(a.acl)},
+    }
+    writeV1JSON(w, http.StatusOK, config)
+}
+
+// aclMode classifies the active ACL for the SPA wire contract.
+// Type-asserts rather than adding a Mode() string method to acl.ACL —
+// the strings are dataentry's vocabulary, not the ACL package's.
+// Explicit cases per impl so the v0→v1 migration is a single labelled
+// edit, not "find the default branch and remember what it hid."
+func aclMode(a acl.ACL) string {
+    switch a.(type) {
+    case acl.NopACL:
+        return "open"
+    case acl.ReadOnlyACL:
+        return "read-only"
+    case *acl.Declarative:
+        // v0: SPA can't act on per-type policy yet; reports as "open"
+        // and relies on the standard 403 + toast (TKT-JZRNF) for
+        // per-type denies. v1 returns "policy" once writes_allowed_for
+        // is on the wire.
+        return "open"
+    default:
+        slog.Warn("dataentry: unknown acl.ACL implementation; reporting mode=open",
+            "type", fmt.Sprintf("%T", a))
+        return "open"
+    }
+}
+```
+
+```go
+// internal/dataentry/app.go
+
+type Deps struct {
+    FS            storage.FS
+    Paths         *project.Context
+    Meta          *metamodel.Metamodel
+    Store         store.Store
+    EntityManager entitymanager.EntityManager
+    Searcher      search.Searcher
+    ACL           acl.ACL
+}
+
+func NewApp(d Deps) (*App, error) {
+    if d.FS == nil      { return nil, errors.New("dataentry.NewApp: FS is required") }
+    if d.Paths == nil   { return nil, errors.New("dataentry.NewApp: Paths is required") }
+    if d.Meta == nil    { return nil, errors.New("dataentry.NewApp: Meta is required") }
+    if d.Store == nil   { return nil, errors.New("dataentry.NewApp: Store is required") }
+    if d.EntityManager == nil { return nil, errors.New("dataentry.NewApp: EntityManager is required") }
+    if d.Searcher == nil      { return nil, errors.New("dataentry.NewApp: Searcher is required") }
+    if d.ACL == nil           { return nil, errors.New("dataentry.NewApp: ACL is required (use acl.NopACL{} to opt out)") }
+    // ...existing setup, using d.* references...
+}
+```
+
+### Frontend — store + composable
+
+```ts
+// frontend/src/stores/acl.ts
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { getConfig } from '@/api/schema'
+
+export type ACLMode = 'open' | 'read-only' | 'policy'
+
+export const useACLStore = defineStore('acl', () => {
+  const mode = ref<ACLMode>('read-only')  // fail-safe default — see useACL ready behavior
+  const loaded = ref(false)
+  let loadPromise: Promise<void> | null = null
+
+  async function load() {
+    if (loaded.value) return
+    if (loadPromise) return loadPromise
+    loadPromise = (async () => {
+      try {
+        const cfg = await getConfig()
+        mode.value = (cfg.acl?.mode as ACLMode) ?? 'open'  // absent → open (AC18)
+        loaded.value = true
+      } catch (e) {
+        // Network errors mean we can't verify ACL state. Fail safe to
+        // read-only so users don't see write affordances against a
+        // potentially-locked server.
+        mode.value = 'read-only'
+        loaded.value = true  // still mark loaded; we made our best effort
+      } finally {
+        loadPromise = null
+      }
+    })()
+    return loadPromise
+  }
+
+  async function reload() {
+    loaded.value = false
+    return load()
+  }
+
+  return { mode, loaded, load, reload }
+})
+```
+
+```ts
+// frontend/src/composables/useACL.ts
+import { computed } from 'vue'
+import { useACLStore } from '@/stores/acl'
+
+export function useACL() {
+  const store = useACLStore()
+  const ready = computed(() => store.loaded)
+  const mode = computed(() => store.mode)
+  // FOUC prevention: until loaded, behave as read-only so write
+  // affordances stay hidden. The schema-store gate in App.vue already
+  // delays mounting most views until load completes, so in practice
+  // this is invisible. The fail-safe matters for the open-mode flash
+  // and for network errors during _config.
+  const isReadOnly = computed(() => !ready.value || mode.value === 'read-only')
+  const isOpen = computed(() => ready.value && mode.value === 'open')
+  return { mode, isReadOnly, isOpen, ready }
+}
+```
+
+Reasoning for the fail-safe (cranky finding): a brief render of "+ Create"
+buttons that then vanish is worse UX than waiting on the gate. The schema store
+already gates most view mounting, so the fail-safe is invisible in practice.
+
+### Frontend — banner
+
+`frontend/src/components/common/ReadOnlyBanner.vue` — ~40 lines.
+`role="status"`, `aria-live="polite"`, calm color (e.g. neutral border-bottom,
+neutral background — not error red, not warning amber), WCAG AA contrast. Copy
+lives in a constant `READ_ONLY_BANNER_COPY` exported from the component so
+docs/security.md can reference it.
+
+Mounted in `App.vue`:
+
+```vue
+<template>
+  <div class="app-root">
+    <ReadOnlyBanner v-if="useACL().isReadOnly" />
+    <!-- existing app shell -->
+  </div>
+</template>
+```
+
+### Frontend — `useAutoSave` flip safety
+
+```ts
+// frontend/src/composables/useAutoSave.ts (additions)
+
+export function useAutoSave({ entityId, isReadOnly /* new */ }) {
+  // ... existing state ...
+
+  watch(isReadOnly, async (readOnly) => {
+    if (!readOnly) return
+    // 1. Clear pending timers
+    for (const t of timers.values()) clearTimeout(t)
+    timers.clear()
+    // 2. Drop pending entries
+    pending.clear()
+    // 3. Abort in-flight PATCH
+    currentAbort?.abort()
+    currentAbort = null
+    // 4. Reset relations dirty flag
+    relationsDirty.value = false
+    // 5. Refetch entity, repopulate
+    if (entityId.value) {
+      try {
+        const fresh = await entitiesStore.fetchById(entityId.value, { skipCache: true })
+        mergeServerResponse(fresh)
+      } catch {
+        // Server may be unreachable; that's fine, formData stays as-is
+      }
+    }
+    // 6. status -> 'idle' (graceful), not 'error'
+    status.value = 'idle'
+    // 7. Toast
+    uiStore.toast('Server is now read-only. Unsaved changes preserved locally but cannot be saved.')
+  })
+
+  function scheduleFieldSave(property: string, value: unknown) {
+    if (isReadOnly.value) return  // belt + suspenders against ungated callers
+    // ...existing...
+  }
+
+  function fireProperty(property: string) {
+    if (isReadOnly.value) return  // check inside firing fn, not at scheduling time
+    // ...existing PATCH...
+  }
+}
+```
+
+### Frontend — affordance gating defaults
+
+Per affordance category, the gating mechanism:
+
+- **Hidden via `v-if="!useACL().isReadOnly"`** — buttons, menu items, action rows, sidebar items, banner items.
+- **Replaced with static rendering** — chip pickers, click-to-edit headers, inline editors. The static view stays useful; only the editor entry is gated.
+- **HTML `readonly` attribute** — `<input>`, `<textarea>` plain fields.
+- **CodeMirror/EasyMDE readonly mode** — `MarkdownEditor` uses EasyMDE; `editor.toggleReadOnly(true)` (not the HTML attribute).
+- **Suppress event handlers** — `draggable="false"` for kanban cards; `@click` removed for inline checkboxes; `pointer-events: none` for content checkboxes; keyboard composables consult `useACL()` and short-circuit.
+- **Compose via `useAutoSave({ isReadOnly })`** — auto-save respects the prop, no per-component gating needed inside `useAutoSave` callers.
+
+### Files to modify (v2 — concrete from survey)
+
+**Backend:**
+
+| File | Change |
+|---|---|
+| `internal/dataentry/api_v1.go` | Add `V1ACLConfig`; embed in `V1Config`; populate in `handleV1Config`; add `aclMode()` helper |
+| `internal/dataentry/app.go` | Convert `NewApp(...)` → `NewApp(Deps)`; stash `acl` on App |
+| `internal/dataentry/api_v1_config_acl_test.go` | NEW — AC1+AC3 tests, compile-time guard |
+| `internal/dataentry/app_test.go` | Update to use `NewApp(Deps{})` — test nil-rejection for each required field |
+| `internal/dataentry/*_test.go` | Migrate to new `Deps`-shaped constructor wherever `NewApp` is called |
+| `cmd/rela-server/main.go` | Build `Deps{...}` from `svc`; pass to `dataentry.NewApp` |
+| `cmd/rela-desktop/main.go` | Same |
+| `docs/security.md` | New subsection "Read-only mode is a UX cue, not a security control" + the v0/v1 progression for `mode` |
+
+**Frontend — store/composable/banner:**
+
+| File | Change |
+|---|---|
+| `frontend/src/stores/acl.ts` | NEW |
+| `frontend/src/stores/acl.test.ts` | NEW |
+| `frontend/src/composables/useACL.ts` | NEW |
+| `frontend/src/composables/useACL.test.ts` | NEW |
+| `frontend/src/composables/useEvents.ts` | Hook ACL reload into `refresh` event |
+| `frontend/src/composables/useEvents.test.ts` | Assert ACL reload triggered |
+| `frontend/src/composables/useAutoSave.ts` | Accept `isReadOnly`; watcher + per-fn guards |
+| `frontend/src/composables/useAutoSave.test.ts` | AC12 + AC13 |
+| `frontend/src/components/common/ReadOnlyBanner.vue` | NEW |
+| `frontend/src/App.vue` | Mount banner |
+| `frontend/src/App.test.ts` | AC9 snapshots |
+| `frontend/src/api/schema.ts` | Update `Config` type to include `acl?: ACLConfig` |
+| `frontend/src/types/config.ts` | Add `ACLConfig` |
+| `frontend/CLAUDE.md` | New section "ACL-gated affordances — read this before adding a write button" |
+
+**Frontend — per-affordance (31 sites, 9 components):**
+
+| File | Affordances gated |
+|---|---|
+| `frontend/src/components/lists/EntityList.vue` | "+ New" button + `n` shortcut, row delete + `Del`/`Backspace` shortcuts, bulk action row + checkboxes + single-letter shortcuts, `e` shortcut |
+| `frontend/src/components/entity/EntityDetail.vue` | Desktop+mobile Edit, desktop+mobile Delete, command buttons + overflow menu, content checkboxes (`setupCheckboxHandlers`), per-row Edit pencils, `e` and `Del` shortcuts |
+| `frontend/src/components/forms/DynamicForm.vue` | Save/Create button + `Cmd+Enter`, Cancel, autosave (via `useAutoSave({isReadOnly})`), template selector, ID controls, beforeunload guard, route guard |
+| `frontend/src/components/forms/RelationCards.vue` | Per-card `×`, per-property inputs (replaced with display), "+ Add" button, "Link" button |
+| `frontend/src/components/forms/RelationPicker.vue` | Chip `×`, search input + dropdown, "+ Add new" footer buttons |
+| `frontend/src/components/forms/InlineCreateModal.vue` | Defensive guard in `show` watcher; entry points already gated upstream |
+| `frontend/src/components/forms/SidePanel.vue` | "+ Add" buttons |
+| `frontend/src/components/forms/FieldRenderer.vue` | Propagate `readonly` to each rendered field type; EasyMDE `toggleReadOnly` |
+| `frontend/src/views/KanbanView.vue` | "+ New" header, `draggable="true"` removal + drop handlers |
+| `frontend/src/views/SettingsView.vue` | User-defaults `<form>` body via `<fieldset disabled>`, Save/Reset row, palette Save, logo upload/remove, theme Install, git commit |
+| `frontend/src/views/ConflictsView.vue` | "Apply resolution" |
+| `frontend/src/components/common/StatusBar.vue` | Git sync click handler |
+| `frontend/src/components/common/Sidebar.vue` | Action items in nav |
+| `frontend/src/components/modals/CommandModal.vue` | Defensive `runCommand` guard |
+| `frontend/src/composables/useListKeyboard.ts` | Consult `useACL`, short-circuit on read-only |
+| `frontend/src/composables/useListActions.ts` | Same |
+| `frontend/src/composables/useKeyboardShortcuts.ts` | Same |
+
+**Enforcement + E2E:**
+
+| File | Change |
+|---|---|
+| `frontend/eslint.config.js` (or equivalent) | NEW rule `rela/write-affordance-must-gate` |
+| `frontend/src/styles/banner.css` (or scoped in component) | Banner styles |
+| `e2e/tests/fixtures.ts` | Extend `spawnServer` to accept `extraArgs`; add `readOnlyServerUrl` fixture |
+| `e2e/tests/read-only.spec.ts` | NEW — AC16 |
+
+### Alternatives considered (v2)
+
+| Alternative | Rejected because |
+|---|---|
+| Add `Mode() string` method to `acl.ACL` interface | Leaks dataentry's wire vocabulary into the ACL package; violates consumer-side-interface rule |
+| Add `ACL()` method to `entitymanager.EntityManager` interface | EntityManager is transitional (CLAUDE.md); grows surface for every consumer |
+| Consumer-side `dataentry.AppServices` interface NOW | Deferred — significant refactor; tracked as follow-up. `Deps` struct is the right step in this PR |
+| Disable buttons rather than hide | Doesn't communicate "this server is read-only" clearly; hide + banner is the calm UX |
+| Banner with "Dismiss" button | State isn't dismissible; reappearing on next route would be confusing |
+| Per-route gating | Doesn't compose; composable + per-component check is the right grain |
+| Pointer-based `*V1ACLConfig` | Adds nil-checks for a non-use-case; value with omitempty would also work but introducing inconsistency; **plain value, always emitted** is simplest |
+| `WritesAllowedFor` in v0 wire shape (with omitempty) | Removed entirely from v0 wire — v1 reviewer might populate accidentally and leak taxonomy. v1 ticket adds the field with full design |
+| Store ACL in `schemaStore` | Conflates "what entities exist" with "what is server policy"; different lifecycles; dedicated `aclStore` is the right boundary |
+| Default `isReadOnly = false` until loaded | FOUC: write buttons flash then disappear in read-only deployments. Fail-safe to `isReadOnly = true` until ready |
+| Per-affordance Vitest snapshots as enforcement | Snapshots rot; new affordances slip through. ESLint rule + `data-testid` is enforceable |
+| Static `isReadOnly` destructured at composable construction | Bug bait: stale value at fire time. Always read `isReadOnly.value` inside firing functions |
+| Optimistic UI updates with rollback on 403 | Already what `useAutoSave` does; the flip case needs an explicit reset path because the rollback assumes the server has the truth — which it does, but the formData on the client doesn't match anymore |
+
+### Dependencies
+
+- `internal/acl` — concrete types `NopACL`, `ReadOnlyACL`, `*Declarative` (all stable; see compile-time guard in tests).
+- `internal/appbuild` — `Services.ACL()` accessor (already exists).
+- No new third-party deps (Go or npm).
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+**Input sources:**
+
+| Input | Source | Validation |
+|---|---|---|
+| `acl.ACL` instance | `appbuild.Services` | Trusted; type assertion contract |
+| `acl.mode` from server | API response | Frontend treats unknown strings as `"open"` to avoid blocking users; whitelist `open`/`read-only`/`policy` |
+| `_config` field absence | Older server | Default `"open"` (AC18) |
+
+**Threat model — banner is decorative.** The actual gate is the backend's 403.
+An attacker can edit the JS bundle to bypass `isReadOnly` and attempt writes;
+they will receive 403s. This is **documented in `docs/security.md` as a section
+titled "Read-only mode is a UX cue, NOT a security control"** so operators don't
+mistake the UI banner for a security boundary.
+
+**No new attack surface from `acl.mode`.** The mode is derivable by a single
+probe write anyway. Surfacing it in `_config` is honesty.
+
+**v1 risk for `WritesAllowedFor`:** when v1 populates the field, it will leak
+both the type taxonomy AND the principal's permissions to anyone who can reach
+the SPA. v1 must answer two questions before populating: (a) is the type
+taxonomy itself permission-scoped (does an unauthorized user even know type `X`
+exists)? (b) is the per-principal list scoped to the requesting principal only
+or to the wider population? v0 does NOT add the field to the Go struct — it's
+reserved on the wire spec but not implemented — so a v1 reviewer can't
+accidentally populate it.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+| AC | Test file/name |
+|---|---|
+| AC1 | `internal/dataentry/api_v1_config_acl_test.go::TestConfig_ACLMode_*` (4 cases + warning case) |
+| AC2 | `internal/dataentry/api_v1_test.go` — additive assertion |
+| AC3 | `TestACLMode_*` + compile-time guard |
+| AC4 | `internal/dataentry/app_test.go::TestNewApp_Deps_*` |
+| AC5 | `frontend/src/stores/acl.test.ts` |
+| AC6 | `frontend/src/composables/useACL.test.ts` |
+| AC7 | `frontend/src/App.test.ts::TestNoWriteAffordances_BeforeACLReady` |
+| AC8 | `frontend/src/composables/useEvents.test.ts::TestRefreshEvent_TriggersACLReload` |
+| AC9 | `frontend/src/components/common/ReadOnlyBanner.test.ts` + App.test.ts |
+| AC10 | per-component Vitest (17 files) — for each affordance group, "renders nothing under read-only" |
+| AC11 | `useListKeyboard.test.ts`, `useListActions.test.ts`, `useKeyboardShortcuts.test.ts`, `DynamicForm.test.ts::handleKeydown` |
+| AC12 | `useAutoSave.test.ts::TestFlipToReadOnly_AbortsAndClears` |
+| AC13 | `DynamicForm.test.ts::TestReadOnlyFlip_PreservesDirtyState` |
+| AC14 | per-modal unit test |
+| AC15 | ESLint rule self-tests + lint pass |
+| AC16 | `e2e/tests/read-only.spec.ts` |
+| AC17 | `just e2e` exits 0 against existing suite |
+| AC18 | `aclStore.test.ts::TestServerWithoutACLField_DefaultsToOpen` |
+| AC19 | Documentation review — no test, manual audit |
+
+**Edge cases (v2):**
+
+- `acl.mode` is an unknown string (server speaks ahead of client, e.g. `"strict"`) → frontend treats as `open` (least disruptive). Documented.
+- Server enters read-only mode after the SPA has loaded → SSE `refresh` event triggers `aclStore.reload()` (AC8).
+- `useAutoSave` flip with in-flight PATCH → AC12 covers; abort + refetch + repopulate.
+- Multiple browser tabs against the same server → each tab's SSE fires independently; each tab's autosave handles its own dirty state.
+- Tab/window not in focus → SSE still fires; banner appears on next focus.
+- SSE disconnects and reconnects without firing `refresh` → SPA stays on stale ACL state until next refresh event. Documented as "staleness window" in `docs/security.md` (AC19).
+- Network error during `_config` fetch → `aclStore` fails safe to `"read-only"` (AC5); user sees the banner; on next reload (or retry) the real state is fetched.
+- Confirm dialog open when read-only flips → modal close + toast (AC14).
+- Optimistic UI update applied before read-only flip → refetch in AC12 reconciles.
+- ESLint rule false positives → suppress with explicit comment + reviewer approval. Documented in CLAUDE.md.
+
+**Negative tests:**
+
+- Backend `aclMode(nil)` → returns `"open"` + warn log.
+- Frontend `useACL()` with no schema/acl store loaded → `isReadOnly === true` until ready.
+- Open-mode E2E: every existing write test passes unchanged.
+- Read-only E2E: every write affordance is unreachable, every write API call from a kept-open client returns 403.
+
+**Integration tests:**
+
+- One Playwright E2E (AC16) is the integration test for the full chain: server flag → backend `_config` → SPA `aclStore` → banner + hidden affordances.
+- AC17 (existing E2E suite) is the regression net.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Effort:** `l` (5-8 days). The plan is now substantial — survey enumerated 31
+affordances + 5 keyboard handlers + auto-save flip semantics + ESLint rule + E2E
+fixture extension. Backend is < 1 day; bulk is frontend.
+
+**Risks (v2):**
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| New write affordance added in a future PR escapes the gate | High | ESLint rule + `data-testid` convention (AC15) + frontend CLAUDE.md note |
+| `useAutoSave` flip leaves formData desynced from server | High | AC12 explicit; refetch + repopulate; toast |
+| Unsaved work lost on flip | High | AC13: formData preserved; toast surfaces; user can copy |
+| Modal still rendering write controls after flip | Medium | AC14: modals close + toast |
+| Keyboard shortcut triggers write despite hidden button | High | AC11: keyboard composables consult `useACL` |
+| FOUC: brief "+ Create" flash before banner appears | Medium | AC7: fail-safe to `isReadOnly = true` until ready |
+| SSE-disconnect staleness window | Low | Documented (AC19); next `refresh` event reconciles |
+| `mode: "open"` for Declarative confuses operators | Medium | Documented in security.md + Go doc comment + risk-section table here |
+| `Deps` struct migration breaks downstream test fixtures | Medium | Compile error forces every callsite to migrate; CI catches |
+| ESLint rule has false positives | Medium | Allowlist comment + reviewer approval; documented |
+| MarkdownEditor (EasyMDE) `readonly` attr is ignored | Low | Use `editor.toggleReadOnly(true)` per-widget; tested |
+| Banner color doesn't pass WCAG AA | Low | Color picker + contrast checker before merge |
+| `Services` consumer-side interface refactor deferred | Low | Tracked as follow-up; doesn't block v1 |
+| Live operator-toggles | Low | AC8 covers; documented staleness window in AC19 |
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+| Doc | Update |
+|---|---|
+| `docs/security.md` | New section "Read-only mode is a UX cue, NOT a security control" + how the SPA gates per mode + v0/v1 progression for `mode` + the staleness window |
+| `frontend/CLAUDE.md` | New section "ACL-gated affordances" — every write affordance must consult `useACL()` and have a `data-testid="write-affordance"` attribute |
+| Wire-format docs for `_config` (if any) | Add `acl.mode` |
+
+CLI help: N/A.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation (covered by parallel agents)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings (v2):**
+
+Three agents audited the plan in parallel before implementation. All findings
+folded into v2 above.
+
+**go-architect findings:**
+
+- **F1 (minor → taken)**: Explicit `*acl.Declarative` case in `aclMode()` rather than letting it fall to default. **Folded into AC1 and backend code sketch.**
+- **F2 (significant → taken)**: Convert `NewApp` to `Deps` struct. **Folded into AC4; concrete code sketch in Approach.**
+- **F3 (minor → deferred with ticket)**: Consumer-side `dataentry.AppServices` interface. **Listed as out-of-scope follow-up.**
+- **F4 (minor → taken with concrete test)**: Declarative→open default deserves end-to-end smoke test. **Folded into AC1 (Declarative case in unit test) + the existing TKT-JZRNF toast handling.**
+- **F5 (minor → taken)**: Value not pointer for `V1ACLConfig`. **Folded into backend code sketch.**
+- **F6 (nit → sound as planned)**: Test placement in new file. **Kept.**
+- **F7 (significant → taken)**: `aclMode` package-private with explicit comment. **Folded into backend code sketch.**
+
+**cranky-code-reviewer findings:**
+
+- **F1 (significant → taken)**: "Inventory awaiting survey" is hand-waving. **Survey landed during planning; files-to-modify section is now concrete with all 31 affordances enumerated.**
+- **F2 (significant → taken)**: AC5 conflates `readonly` HTML attr with auto-save short-circuit. **AC10 distinguishes per-widget mechanisms; EasyMDE explicitly uses `toggleReadOnly`.**
+- **F3 (critical → taken)**: Auto-save flip must abort in-flight, not just block scheduling. **AC12 explicit; 7-step procedure in code sketch.**
+- **F4 (significant → taken)**: FOUC during initial load. **AC7: `isReadOnly` defaults to `true` until ready.**
+- **F5 (significant → taken)**: Declarative→open UX cost glossed over. **Risk table + docs/security.md note; per AC1 unit test verifies the wire value.**
+- **F6 (significant → taken)**: Live transitions: SSE doesn't currently reload schema. **AC8 hooks `aclStore.reload()` into the `refresh` event.**
+- **F7 (critical → taken)**: Unsaved work on flip. **AC13: formData preserved + toast.**
+- **F8 (significant → taken)**: "Per-affordance Vitest snapshots" unenforceable. **AC15: ESLint rule + `data-testid` convention.**
+- **F9 (significant → taken)**: E2E fixture doesn't support `--read-only`. **AC16 extends fixture.**
+- **F10 (significant → taken)**: ACL state in schemaStore conflates concerns. **AC5: dedicated `aclStore`.**
+- **F11 (significant → taken)**: Keyboard shortcuts not in AC list. **AC11 added.**
+- **F12 (significant → taken)**: Banner a11y attributes. **AC9 specifies role/aria-live/WCAG.**
+- **F13 (minor → taken)**: `WritesAllowedFor` not in v0 wire. **Removed from v0 Go struct.**
+- **F14 (significant → taken)**: Modal flip behavior. **AC14.**
+- **F15 (minor → taken)**: SSE-reconnect staleness window. **AC19 documents it.**
+
+**Will record any additional `/code-review` review-response IDs here once the
+agent runs against the implementation, not against this plan.**

--- a/tickets/entities/planning-checklists/PLAN-GXC7.md
+++ b/tickets/entities/planning-checklists/PLAN-GXC7.md
@@ -2,7 +2,7 @@
 id: PLAN-GXC7
 type: planning-checklist
 title: 'Planning: Response-level action affordances: backend declares per-resource verbs to drive UI'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -318,9 +318,9 @@ endpoint must re-authorize. New write paths in `internal/dataentry` route
 `WriteRequest` construction through `translateVerb`."
 - [x] **`docs/security.md`** — note that read-only-mode UI hiding is
 data-driven (via `_actions`). Document scope of invariant.
-- [ ] User guide / reference docs — N/A.
-- [ ] CLI help text — N/A.
-- [ ] README.md — N/A.
+- [x] ~~User guide / reference docs~~ (N/A: backend wire-shape change with no end-user feature surface; the SPA itself is what users see and that's covered by api-reference.md)
+- [x] ~~CLI help text~~ (N/A: no CLI changes in this ticket)
+- [x] ~~README.md~~ (N/A: project-level positioning unchanged)
 
 ## Design Review
 

--- a/tickets/entities/planning-checklists/PLAN-GXC7.md
+++ b/tickets/entities/planning-checklists/PLAN-GXC7.md
@@ -1,0 +1,350 @@
+---
+id: PLAN-GXC7
+type: planning-checklist
+title: 'Planning: Response-level action affordances: backend declares per-resource verbs to drive UI'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+**In scope.** Make the backend the single source of truth for which write verbs
+a principal can apply to a specific resource. The data-entry SPA renders write
+affordances iff the backend declared the verb in the response's `_actions` map.
+Phase 1 vocabulary is exactly the verbs ACL v0 supports today: `{create, update,
+delete, rename}` — `create` per-collection, the others per-item. Drives off the
+existing `acl.AuthorizeWrite` call.
+
+**Out of scope.**
+
+- Authorization is **not** moved to the wire. The server re-authorizes every
+write. The map is a UI hint.
+- **`transition:*` and `relation:*` verbs.** Deferred to TKT-Y72A-followup,
+gated on ACL v0.5. (Audit finding: ACL v0's `Op` enum doesn't carry the required
+arguments.)
+- Per-property affordances.
+- Multi-action query plans.
+- A separate `/meta/actions` discovery endpoint. Crit round 2 surfaced that
+collection-level `_actions.create` covers menu population for free. No separate
+endpoint in phase 1.
+- Parallel-emit / `_actions_v2`. Crit round 2: "legacy stuff is not needed."
+Reshape `_actions` in place; backend + SPA migrate in the same PR.
+- A new frontend `useACL()` composable.
+- i18n of action labels.
+- SSE-driven affordance updates.
+- MCP / Lua / scheduler write paths' affordance integration. Scope of the
+invariant is data-entry HTTP API only.
+
+**Acceptance Criteria** (mirrored from design doc §AC1–AC10):
+
+1. **AC1 — read-only verdict.** GET an entity as a read-only principal returns
+`_actions: {update: false, delete: false, rename: false}`. Handler test.
+2. **AC2 — nop verdict.** GET as a `NopACL` principal returns `_actions` with
+all three verbs `true`. Handler test.
+3. **AC3 — bidirectional contract test.** For a fixed (principal, entity)
+tuple, every verb V where `_actions[V] == true` → write returns 2xx; every
+`false` → write returns 403 with `*acl.ForbiddenError`. Parameterized over all
+three ACL implementations. Verdict bool, not reason equality. Integration test.
+4. **AC4 — list endpoint.** List endpoint returns per-row `_actions` on each
+item plus top-level `_actions.create` for the collection. Handler test.
+5. **AC5 — frontend consumption.** Buttons consult `entity._actions[verb]`.
+False → omit. True → render. Absent → render + dev-mode warning if session is
+authenticated. Component unit tests + E2E.
+6. **AC6 — additive vocabulary.** Emit a synthetic verb `noop`; existing
+component tests pass unchanged with no console error.
+7. **AC7 — AWM6L payoff.** Read-only mode produces a button-less data-entry
+UI driven entirely from the backend `_actions` map. E2E.
+8. **AC8 — no audit noise on read path.** GET request produces zero audit
+records under all three ACLs. Unit test against `audit.NewMemory()`.
+9. **AC9 — scope-of-invariant (documentation-only).** Writes via MCP / Lua /
+scheduler can succeed for verbs whose `_actions` would be `false` for the SPA
+principal. Expected; flagged as documentation-only.
+10. **AC10 — structural same-code-path.** Grep test asserts
+`acl.WriteRequest{Op:` appears only in `internal/dataentry/affordances.go`
+(`translateVerb`) and test files.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+Ten-system research sweep at `.ignored/action-affordances-research.md` (4528
+words). Highlights:
+
+- **Convergent design across four independent products** (Cerbos PDP, GitHub
+REST `permissions`, Plone `@actions`, Kubernetes SSAR). All landed on inline
+`{verb: bool}` map per resource.
+- **Anti-pattern shortlist** (research §Anti-patterns): predicates on the
+wire, role-and-action conflation, affordance endpoint as security check,
+SSRR-style enumeration.
+- **Plone (closest prior art)** — 20+ years' lesson: ship the resolved
+verdict only.
+- **Codebase reuse.** `V1Entity._actions` already exists as
+`*V1Actions{Delete, Transitions[]}`. Phase 1 reshapes it in place to
+`map[string]bool`. The legacy `transitions[]` array is empty until ACL v0.5
+lands transition verbs — no functional loss.
+- **ACL primitive.** `acl.WriteRequest{Op, EntityType, RelationType}` from
+ACL v0 backs the computation. `Op` enum is `OpCreate/Update/Delete/Rename`.
+Phase 1 verb vocabulary matches this exactly.
+
+Design synthesised in `.ignored/action-affordances-design.md` (v2, audit + crit
+findings folded in).
+
+**Reviews performed:**
+
+- **go-architect** (round 1) — 3 critical, 5 significant findings on package
+placement, structural enforcement of same-code-path, arch-lint compliance.
+- **cranky-code-reviewer** (round 1) — 5 critical, 7 significant findings on
+verb-vs-Op mismatch, cardinal-rule scope, anonymous overload, AC3
+unimplementability, fictitious `policy_revision`, dropped batching, missing
+risks.
+- **User crit** (rounds 1-2) — chose closed-world `{verb: bool}` over
+`[allowed_verbs]`; dropped parallel-emit (`_actions_v2`); dropped
+`/meta/actions` discovery endpoint. Round 3: approved.
+
+All critical+significant findings folded into design v2 and this plan. The
+design simplifications from crit (no parallel-emit, no discovery endpoint)
+collapsed phasing from 5 phases to 2.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+1. **Wire shape.** Reshape `_actions` on `V1Entity` from
+`*V1Actions{Delete, Transitions[]}` to `map[string]bool`. Add `_actions` on
+`V1ListResponse` for collection-scope verbs (just `create`). Backend reshape and
+SPA migration ship in the **same PR**.
+2. **Computation lives in `internal/dataentry`.** New file
+`internal/dataentry/affordances.go`:
+   - `translateVerb(verb, entityType) (acl.WriteRequest, bool)` — the single
+source of truth used by both the serializer and the write handlers.
+   - `verbsForType(s *AppState, entityType) []string` — metamodel-derived
+verb list. Stays in `dataentry` so `acl` doesn't import `metamodel`.
+   - `computeActions(ctx, s, e)` — per-row map computation.
+   - Reserved `computeActionsBatch(ctx, s, entities)` signature for future
+optimization.
+3. **Same-code-path made structural.** Both `computeActions` and write
+handlers route `acl.WriteRequest` construction through `translateVerb`. Grep
+test (AC10) asserts no other site constructs `WriteRequest{Op:`.
+4. **Phase 1 verb set is closed:** `{create, update, delete, rename}`.
+Matches ACL v0's `Op` enum exactly.
+5. **Snapshot once per request.** Handler captures `s := a.State()` at the
+top; `computeActions` reads only from `s` for the verb list.
+6. **No cache in phase 1.** Profile gate in phase 2: benchmark list response
+at 100/1k/10k entities × 3 verbs. If p95 > 200ms with `Declarative`, cache lands
+with key `(principal_id, entity_id, entity_updated_at)`, TTL 60s. No
+`policy_revision` field.
+7. **Anonymous fallback.** Anonymous principals get `_actions` omitted
+entirely. Authenticated principals always get the field present (possibly `{}`
+if all denied). SPA emits dev-mode warning when authenticated session receives
+missing field — distinguishes anonymous-fallback from serializer-bug.
+8. **Verb naming rule.** Phase 1: single bare nouns matching `Op` constants
+— no colons, no arguments. Multi-token verbs deferred to ACL v0.5.
+
+**Alternatives considered (and rejected):**
+
+- **HAL `_links`, JSON:API `meta.permissions`, OData metadata DSL** — research
+§1–3.
+- **Frontend `useACL()` mirror** — TKT-AWM6L's plan; killed by crit
+("duplicating the ACL logic on the frontend").
+- **GraphQL `viewerCan*`** — nullability ambiguity (research §10).
+- **Stripe attempt-and-recover** — only for coarse roles.
+- **Eager bake-in cache** — profile first.
+- **Parallel-emit `_actions_v2`** — crit round 2: legacy not needed; reshape
+in place.
+- **List-of-allowed-verbs `[v1, v2]` instead of `{v: bool}`** — crit round 1:
+closed-world map is testable; list collapses *denied* / *not evaluated* / *not
+defined* / *old server* into the same wire shape.
+- **`/api/v1/meta/actions` discovery endpoint** — crit round 2: collection
+`_actions.create` covers create-menu population on list responses; no separate
+endpoint needed.
+- **`ComputeActionMap` in `internal/acl`** — architect C2.
+- **`ListVerbs(entityType)` in `internal/acl`** — architect C1.
+- **`OpTransition` / `Subject` / `Principal` on `WriteRequest` for phase 1**
+— cranky #1. Defer transition/relation verbs to TKT-Y72A-followup gated on ACL
+v0.5.
+
+**Files to modify:**
+
+- `internal/dataentry/affordances.go` (NEW) — `translateVerb`,
+`verbsForType`, `computeActions`, reserved batch signature.
+- `internal/dataentry/api_v1.go` — reshape `_actions` on `V1Entity` from
+`*V1Actions{Delete, Transitions[]}` to `map[string]bool`. Add `_actions` on
+`V1ListResponse`.
+- `internal/dataentry/handlers_api.go` — wire `computeActions` into
+per-entity, per-list, per-collection serialize. Route write handlers'
+`WriteRequest` construction through `translateVerb`.
+- `frontend/src/types/entity.ts` — change `_actions` type from legacy
+`EntityActions{delete, transitions}` to `Record<string, boolean>`.
+- `frontend/src/components/**` — migrate existing `_actions.delete.allowed`
+and `_actions.transitions` access patterns to `_actions.delete` and (deferred)
+`_actions['transition:*']`. Add dev-mode warning for authenticated-missing.
+- `docs/api.md` — document `_actions` map, verb vocabulary.
+- `e2e/` — read-only-mode-has-no-write-buttons scenario.
+
+**No changes to `internal/acl/`.**
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- **Principal from request.** Same source as today
+(`defaultPrincipalResolver`).
+- **Verb name.** Closed set in `translateVerb`: `create/update/delete/rename`.
+No interpolation from request data.
+- **No client-supplied verb in `_actions` computation.** Server-determined.
+
+**Security-Sensitive Operations:**
+
+- **The cardinal rule.** The action map is *not* authorization. The write
+endpoint must re-authorize. AC3 asserts the bidirectional contract; AC10
+enforces it structurally via the grep test.
+- **Scope of the invariant.** HTTP write endpoints reached by the SPA only.
+MCP / Lua / scheduler write paths bypass `_actions` (re-authorized at the
+`entitymanager.Manager` boundary). AC9 documents.
+- **Anonymous recon prevention.** `_actions` omitted for anonymous principals.
+No separate `/meta/actions` endpoint to enumerate from.
+- **No predicates / TALES / role names on the wire.** Verdicts only.
+- **Same code path as enforcement — structural.** `translateVerb` is the
+shared constructor (architect C3 fix).
+- **No audit-log noise from read path.** `computeActions` calls
+`AuthorizeWrite` for verdict; no audit records. AC8 asserts.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Test scope | Location |
+|---|---|---|
+| AC1 | Read-only handler test | `internal/dataentry/handlers_api_test.go` |
+| AC2 | NopACL handler test | `internal/dataentry/handlers_api_test.go` |
+| AC3 | Bidirectional contract across all three ACLs | `internal/dataentry/affordances_contract_test.go` (new) |
+| AC4 | List endpoint per-row + top-level `_actions` | `internal/dataentry/handlers_api_test.go` |
+| AC5 | Component unit tests + dev-mode warning | `frontend/src/**/__tests__/` |
+| AC6 | Synthetic verb `noop`; existing tests pass | `frontend/src/**/__tests__/` |
+| AC7 | E2E: read-only data-entry has no write buttons | `e2e/specs/read-only-mode.spec.ts` (extend) |
+| AC8 | GET produces zero audit records under all ACLs | `internal/dataentry/affordances_test.go` |
+| AC9 | Documentation only | `docs/api.md` |
+| AC10 | Grep test for `acl.WriteRequest{Op:` outside `affordances.go` | `internal/dataentry/lint_test.go` (new) |
+
+**Edge Cases:**
+
+- **Anonymous principal.** `_actions` omitted. SPA falls through to "show all
+  + no warning."
+- **Authenticated, all denied.** `_actions: {}`. SPA renders no buttons.
+- **Authenticated, missing field (bug).** SPA renders all + dev-mode warning.
+- **Verb computed `true` at fetch, state changes before write.** Server
+re-authorizes; 403; SPA error toast.
+- **List with mixed-permission rows.** Each row carries its own `_actions`.
+AC4.
+- **Type not in metamodel** (orphan markdown): `verbsForType` returns nil;
+`_actions` field omitted (or empty, depending on serializer choice).
+- **Policy reload mid-request.** Snapshot at handler entry; subsequent
+requests see new state.
+- **Large verb maps.** Phase 1's 3-verb-per-item set keeps payload cost
+trivial.
+
+**Negative Tests:**
+
+- **Unknown verb in `translateVerb`.** Returns `(WriteRequest{}, false)`.
+Caller skips.
+- **Nil principal.** Anonymous fallback — `_actions` omitted.
+- **GET as `Declarative` ACL with empty policy.** `_actions`: all denied.
+SPA hides all buttons.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Mitigation |
+|---|---|
+| **Wire-vs-policy drift** | Shared `translateVerb`; bidirectional contract test (AC3); grep test (AC10). |
+| **Snapshot skew (true→403)** | Acknowledged; SPA error toast + dev-mode log for measurement. |
+| **N+1 on list endpoints** | Snapshot once. Phase 2 profile gate at 100/1k/10k; cache lands if p95 > 200ms. Key `(principal_id, entity_id, entity_updated_at)`; no `policy_revision`. |
+| **Verb vocabulary outstrips ACL v0** | Phase 1 verbs = `{create, update, delete, rename}` exactly. `transition:*`/`relation:*` deferred to TKT-Y72A-followup. |
+| **Existing `_actions` callers break on reshape** | rela's SPA is the only consumer; reshape + SPA migration in same PR. Pre-implementation step: grep `frontend/`/`e2e/` for current `_actions.delete`/`_actions.transitions` access; migrate each site. Legacy `transitions[]` was empty without ACL v0.5 — no functional loss. |
+| **Audit-log noise from read path** | `computeActions` calls aren't writes; AC8 asserts zero records. |
+| **SPA caches stale `_actions`** | Existing 1-min entity-cache TTL + SSE invalidation. Policy-changed SSE deferred (design Q5). |
+| **ACL v1 snapshot threading** | Flagged in design Q4. Phase 1 doesn't commit to a v1 signature. |
+| **Verb ownership / churn** | Phase 1 list closed. Additions need `translateVerb` + ACL Op + doc PR. Renames need major API version bump. |
+
+**Effort:** xl (matches ticket effort). Phase 1 + 2 over two PRs; optional
+phase-3 follow-ups as separate PRs.
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] **API docs** — `docs/api.md` gets an "Action affordances" section:
+`_actions` shape, four-verb vocabulary, anonymous fallback, verb-naming
+guidance.
+- [x] **CLAUDE.md** — new rule: "Action affordances are UI hints; the write
+endpoint must re-authorize. New write paths in `internal/dataentry` route
+`WriteRequest` construction through `translateVerb`."
+- [x] **`docs/security.md`** — note that read-only-mode UI hiding is
+data-driven (via `_actions`). Document scope of invariant.
+- [ ] User guide / reference docs — N/A.
+- [ ] CLI help text — N/A.
+- [ ] README.md — N/A.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation — **architect +
+cranky audits round 1; user crit rounds 1-2 with directional simplifications;
+round 3 approved**
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** Three review cycles before transition to
+in-progress.
+
+- **go-architect (round 1)**: C1/C2/C3 (package placement, structural
+same-code-path), S1-S5 (reshape rollback, verb syntax, `/meta/actions`
+semantics, ACL v1 snapshot, phase 5 coverage). All folded.
+- **cranky-code-reviewer (round 1)**: #1-12 (verb-vs-Op, invariant scope,
+workflow-vs-ACL conflation, fictitious `policy_revision`, anonymous overload,
+verb ownership, recon, reshape rollback, dropped batching, AC3
+unimplementability, missing risks, dropped research recommendation) + 13 minor
+items. Criticals + significants folded.
+- **User crit (rounds 1-3)**: round 1 — chose `{verb: bool}` map shape over
+list-of-allowed (closed-world, testable, future-evolution headroom). Round 2 —
+dropped parallel-emit (`_actions_v2` removed; reshape in place)
+  + dropped `/meta/actions` (collection `_actions.create` covers menu
+population). Round 3 — approved.
+
+The simplifications from crit shrank the rollout from 5 phases to 2 + optional
+follow-ups.

--- a/tickets/entities/review-checklists/REV-CKT8.md
+++ b/tickets/entities/review-checklists/REV-CKT8.md
@@ -1,0 +1,68 @@
+---
+id: REV-CKT8
+type: review-checklist
+title: 'Review: Response-level action affordances: backend declares per-resource verbs to drive UI'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** Cranky + architect audits happened against the design
+(PLAN-GXC7 references RR-W8ZR and RR-YR4B from earlier rounds). Phase 1
+implementation is a direct execution of the post-audit design; no new RRs filed.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- AC1 (read-only verdict) — **PASS**, `TestComputeActions_ReadOnly`.
+- AC2 (NopACL verdict) — **PASS**, `TestComputeActions_NopACL`.
+- AC3 (bidirectional contract) — **PASS**, `TestAffordances_BidirectionalContract` across NopACL + ReadOnlyACL.
+- AC8 (no audit noise) — **PASS**, `TestComputeActions_NoAuditNoise` against `audit.NewMemory()`.
+- AC9 (scope-of-invariant) — **PASS**, documented in `docs/data-entry/api-reference.md` and `docs/security.md`.
+- AC10 (structural same-code-path) — **PASS**, `TestNoStrayWriteRequestConstruction`.
+- AC4, AC5, AC6, AC7 — deferred to phase-2 follow-up ticket (no frontend `_actions` consumer in phase 1 yet).
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: docs were updated in-PR; no separate cycle needed)
+- [x] User-facing documentation updated
+- [x] ~~Docs-checklist marked as done~~ (N/A as above)
+
+**Docs Checklist:** N/A — docs landed in the same PR.
+
+User-facing docs updated:
+
+- `docs/data-entry/api-reference.md` — new "Action affordances (`_actions`)" section with wire shape, verb vocabulary, anonymous fallback, the cardinal rule, additive evolution, scope of invariant.
+- `docs/security.md` — added `_actions`-driven affordance hiding to "What the ACL covers in v0," plus a callout that `_actions` is a UI hint not authorization.
+- `CLAUDE.md` — new "Action affordances" subsection under "Authorization."
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/779

--- a/tickets/entities/tickets/TKT-AWM6L.md
+++ b/tickets/entities/tickets/TKT-AWM6L.md
@@ -5,79 +5,48 @@ title: Hide / disable write affordances when the server is read-only (or when an
 kind: enhancement
 priority: medium
 effort: m
-status: backlog
+status: wont-fix
 ---
 
-## Context
+## Superseded
 
-PR 1 of the ACL work ships the wire-level deny path: writes return HTTP 403 with
-a structured body. But the SPA still **shows** create / update / delete buttons
-that the backend will refuse. Demo'd against `rela-server --read-only`:
+**Closed `wont-fix` on 2026-05-20 — superseded by TKT-Y72A (response-level
+action affordances).**
 
-- "+ Create" buttons on list views: present, click → 403 toast.
-- Delete actions in detail views: present, click → 403 toast.
-- Chip-picker "+ add" / inline relation editors: present, drop → 403 toast.
-- Property auto-save in DynamicForm: still attempts the PATCH on every keystroke; UI feels broken because edits never persist.
+The planning exercise for this ticket (see PLAN-B0CI) uncovered an architectural
+smell during crit review: gating write affordances on the frontend with a
+`useACL()` composable + per-component `v-if` commits the SPA to maintaining its
+own authorization evaluator that must track every evolution of the backend ACL
+(binary read-only now → per-type in v1 → per-role in v1.5 → per-entity-state in
+v2 → …). That's the **duplication trap**.
 
-Better UX: hide or disable the affordance up front and render a calm "read-only"
-banner instead of letting users discover the limitation by failure.
+The right architectural seam is **backend-driven response-level action
+affordances** (HATEOAS-flavored): each list / entity / relation / form response
+carries the verbs the principal can apply to that specific resource. The SPA
+renders affordances iff the corresponding action is present in the response.
+Authorization computed once, on the server, per resource.
 
-## Scope
+Read-only mode then **falls out for free**: when ACL is `ReadOnlyACL`, no
+`_actions` are emitted on any resource → SPA hides everything → effectively the
+same UX this ticket was trying to engineer, but data-driven instead of
+flag-driven.
 
-Two pieces:
+## What survives
 
-### Backend: expose ACL mode in `/api/v1/_config`
+The 31-affordance survey in PLAN-B0CI is still valuable — not as a list of
+gating sites, but as the inventory of **response shapes that need `_actions` in
+their wire contract** (list responses, entity detail responses, relation
+responses, form spec responses, settings responses). TKT-Y72A will consume this
+inventory.
 
-Add a small `acl` field to the existing config endpoint:
+## See also
 
-```json
-{
-  "acl": {
-    "mode": "open" | "read-only" | "policy",
-    "writes_allowed_for": ["ticket", "concept", ...]   // optional, populated when mode == "policy"
-  }
-}
-```
+- Replacement: **TKT-Y72A** — "Response-level action affordances: backend declares per-resource verbs to drive UI"
+- Backend gate this depends on: TKT-GN5LN (ACL v0 PR 1)
+- Original design: DEC-RG878 (four-layer ACL model)
 
-For v0:
+## Original content
 
-- `mode: "open"` when the server's ACL is `acl.NopACL{}`.
-- `mode: "read-only"` when the server's ACL is `acl.ReadOnlyACL{}` (i.e., `--read-only`).
-- `mode: "policy"` reserved for the v1 `Declarative` ACL; v0 doesn't emit it.
-
-`writes_allowed_for` is empty / absent for v0 — v1 will populate it from the
-principal's effective roles.
-
-### Frontend: gate affordances
-
-When `acl.mode == "read-only"`:
-
-- Hide or disable every "Create", "Delete", and inline-edit affordance across the SPA.
-- Render a persistent banner: "This rela instance is read-only" with a brief explanation.
-- DynamicForm: disable inputs, skip auto-save PATCHes (or show them as no-ops with the banner explaining why).
-
-When `acl.mode == "open"`: behave exactly as today (no gating, no banner).
-
-## Acceptance criteria
-
-1. `rela-server` (no flag) → SPA shows full editing UI, no banner. Regression-test the no-ACL path.
-2. `rela-server --read-only` → SPA shows banner, all write affordances hidden or disabled, no surprise 403s from the UI itself.
-3. The frontend treats `acl.mode` absence as `"open"` for backwards-compat with older servers.
-4. The `_config` response shape stays additive — existing fields unchanged.
-
-## Out of scope
-
-- Per-entity-type gating (waits for v1 `Declarative` ACL with `writes_allowed_for`).
-- Per-principal customization (v1).
-- MCP transport (separate ticket).
-
-## Discussion
-
-The `mode` enum keeps the wire contract small and extensible. Frontend gating is
-a single check per affordance; no per-route conditional needed.
-
-## References
-
-- TKT-GN5LN (ACL v0 PR 1)
-- DEC-RG878
-- Will be ground truth for the v1 ticket that adds per-type `writes_allowed_for`.
+The original ticket body (before this closure note) lives in `git log` and in
+PLAN-B0CI's revision history. Both remain useful reference material for
+TKT-Y72A's planning.

--- a/tickets/entities/tickets/TKT-I82F.md
+++ b/tickets/entities/tickets/TKT-I82F.md
@@ -1,0 +1,41 @@
+---
+id: TKT-I82F
+type: ticket
+title: Investigate docs/data-entry/api-reference.md generation status
+kind: docs
+priority: low
+effort: xs
+status: backlog
+---
+
+## Goal
+
+Clarify whether `docs/data-entry/api-reference.md` should be auto-generated from
+a `docs-project/` entity, or remain a hand-written file. Either way, make the
+situation unambiguous so future contributors know where to edit.
+
+## Context
+
+During TKT-Y72A phase 1 (PR #779), a section on `_actions` was added to
+`docs/data-entry/api-reference.md`. The reviewer flagged this as
+potentially-generated; investigation showed the file is currently hand-written
+(`scripts/generate-docs.lua` only emits `guide`, `tutorial`, `scenario`
+entities), and `just docs` didn't overwrite the manual edit.
+
+The reviewer asked for a quick follow-up PR to "correct that" — meaning either:
+
+1. **Convert api-reference.md to a generated doc**, sourced from a new
+`guide`-type entity in `docs-project/entities/guides/`. Aligns the data-entry
+docs with the rest of the docs pipeline; manual edits would move to the entity.
+2. **Document the hand-written status** explicitly, e.g. a header comment
+in the file or a note in `CONTRIBUTING.md` / docs-project README, so future
+contributors don't waste time looking for a source.
+
+Pick during the design phase. (1) is the more uniform answer; (2) is cheaper.
+
+## References
+
+- PR #779 (TKT-Y72A phase 1)
+- `scripts/generate-docs.lua`
+- `scripts/generate-docs.sh`
+- `docs/data-entry/api-reference.md`

--- a/tickets/entities/tickets/TKT-LFT2.md
+++ b/tickets/entities/tickets/TKT-LFT2.md
@@ -1,0 +1,67 @@
+---
+id: TKT-LFT2
+type: ticket
+title: 'Action affordances phase 2: frontend consumption + AWM6L payoff'
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+## Goal
+
+Make the Vue SPA actually consume the `_actions: map[string]bool` map shipped by
+the backend in phase 1 (TKT-Y72A, PR #779). Read-only mode should produce a
+button-less data-entry UI driven entirely by the backend's verdict — the
+original deliverable that TKT-AWM6L was chasing.
+
+## Why now
+
+Phase 1 landed the wire shape, the `translateVerb` source-of-truth, and the
+bidirectional contract test. The SPA's type already declares `_actions?:
+Record<string, boolean>` on `Entity` and `ListResponse`. What's missing is the
+UI integration.
+
+## Scope
+
+- Vue components that render write affordances (delete buttons,
+update forms, create-new buttons on list pages) consult `entity._actions[verb]`.
+Semantics:
+  - `false` → omit the control.
+  - `true` → render.
+  - Absent → render unconditionally (anonymous / pre-rollout
+fallback).
+- **Dev-mode warning.** When the SPA receives an authenticated
+response without `_actions`, log a `console.warn` so a future server-side
+regression (handler forgot to populate the field) is visible in development.
+Production builds suppress the warning.
+- **AC4 (list endpoint) — dedicated test.** Backend wiring already
+exists (`computeCollectionActions`); add a handler test asserting per-row
+`_actions` differs across rows when the ACL gates by entity type / ID.
+- **AC5 (frontend consumption) — component unit tests.** Fixture
+responses with various `_actions` shapes; assert button render presence/absence.
+- **AC6 (additive vocabulary) — synthetic verb test.** Backend emits
+`noop` from one handler; assert frontend doesn't crash or warn for unknown keys.
+- **AC7 (AWM6L payoff) — E2E.** Boot data-entry with
+`--read-only`; navigate the SPA; assert no write controls render anywhere
+(delete button, edit form fields, create button).
+
+## Profile gate (decision)
+
+Before merging, benchmark list response time at 100 / 1k / 10k entities × 3-verb
+computation under `Declarative` ACL. If p95 > 200ms, land the per-row verdict
+cache in this ticket; key shape is `(principal_id, entity_id,
+entity_updated_at)`, TTL 60s, explicit invalidation on writes. Otherwise defer
+the cache.
+
+## Out of scope
+
+- `transition:*` and `relation:*` verbs (gated on ACL v0.5).
+- MCP / Lua / scheduler write-path affordance integration.
+- SSE policy-changed events.
+
+## References
+
+- Phase 1: TKT-Y72A, PR #779
+- Design: `.ignored/action-affordances-design.md`
+- Predecessor (wont-fix): TKT-AWM6L

--- a/tickets/entities/tickets/TKT-XZEY.md
+++ b/tickets/entities/tickets/TKT-XZEY.md
@@ -1,0 +1,58 @@
+---
+id: TKT-XZEY
+type: ticket
+title: 'ACL v0.5: extend WriteRequest for parameterised verbs (transitions, relations)'
+kind: enhancement
+priority: low
+effort: m
+status: backlog
+---
+
+## Goal
+
+Extend ACL v0's `WriteRequest{Op, EntityType, RelationType}` so it can represent
+**parameterised verbs** — workflow transitions (`transition:done`,
+`transition:cancel`) and relation operations (`relation:depends-on:add`,
+`relation:depends-on:remove`) — without collapsing them under `OpUpdate`.
+Required before TKT-Y72A's phase 1 verb vocabulary can grow to cover those
+operations.
+
+## Why this is its own ticket
+
+The action-affordances design audit (cranky #1, architect C1) surfaced that ACL
+v0's `Op` enum is exactly `{create, update, delete, rename}`. The phase-1
+`_actions` map was deliberately scoped to that closed set so the cardinal rule
+("`_actions[v]==false` ⇒ 403 on write") would be structurally honest. Mapping
+`transition:done` to `OpUpdate` would have collapsed every workflow transition's
+verdict to a single `update` boolean — not the per-transition gating the UI
+needs.
+
+## Options to evaluate during design
+
+1. **Add `Op` variants** — `OpTransition`, `OpRelationAdd`,
+`OpRelationRemove`. Easy to enumerate; clean per-op switch in `Declarative`.
+Adds combinatorial Op constants if more parameter shapes follow.
+2. **Add an extension field** — `WriteRequest.Args
+map[string]string` (or similar). One Op shape, arbitrary parameters. Looser
+typing; `Declarative` evaluates args per Op.
+3. **Subject identity** — `WriteRequest.EntityID string` so the
+policy can gate per-row (assignee-only transitions, etc.). Orthogonal to
+(1)/(2); needed if ACL v1 lands per-row rules.
+
+Pick during the design phase. Each option has consequences for how
+`translateVerb` (in `internal/dataentry/affordances.go`) extends.
+
+## Out of scope
+
+- ACL v1 per-row rules (separate ticket).
+- Read-side filtering / property redaction.
+- Snapshot threading through `AuthorizeWrite` (flagged as a v1
+concern in the design doc Q4; still relevant when row context matters, but not
+blocking on this ticket).
+
+## References
+
+- Phase-1 implementation: TKT-Y72A, PR #779
+- Design: `.ignored/action-affordances-design.md` §"Phase 1 verb set"
+- Research: `.ignored/action-affordances-research.md`
+- ACL v0: TKT-GN5LN

--- a/tickets/entities/tickets/TKT-Y72A.md
+++ b/tickets/entities/tickets/TKT-Y72A.md
@@ -5,7 +5,7 @@ title: 'Response-level action affordances: backend declares per-resource verbs t
 kind: enhancement
 priority: medium
 effort: xl
-status: backlog
+status: in-progress
 ---
 
 ## Goal

--- a/tickets/entities/tickets/TKT-Y72A.md
+++ b/tickets/entities/tickets/TKT-Y72A.md
@@ -5,109 +5,65 @@ title: 'Response-level action affordances: backend declares per-resource verbs t
 kind: enhancement
 priority: medium
 effort: xl
-status: in-progress
+status: done
 ---
 
-## Goal
+## Scope (phase 1 — this ticket)
 
-Make the **backend the single source of truth** for which actions a principal
-can perform on a specific resource at a specific moment. The SPA renders write
-affordances iff the corresponding action is declared in the response.
+Backend-driven per-resource `_actions: map[string]bool` map on every data-entry
+HTTP response. The Vue SPA reads it to decide which write controls to render;
+the server re-authorizes every write so the map is purely a UI hint.
 
-Today the SPA renders all buttons unconditionally and the backend's 403
-reactively explains the deny *after* a failed click. This works for the binary
-"read-only mode" case but does not scale: per-type, per-principal, per-state,
-per-property authorization all require the SPA to grow its own ACL evaluator
-that mirrors the backend's. That's the **duplication trap** TKT-AWM6L's planning
-exercise surfaced.
+**Phase 1 verb vocabulary** (matches `acl.Op` exactly):
 
-Response-level action affordances (HATEOAS-flavored — `_actions` or `_links` on
-each resource) invert the relationship: the server computes "what can this
-principal do here" once, attaches it to the response, and the client stays
-declarative.
+| Verb | Scope | `acl.Op` |
+|---|---|---|
+| `create` | per-collection | `OpCreate` |
+| `update` | per-item | `OpUpdate` |
+| `delete` | per-item | `OpDelete` |
+| `rename` | per-item | `OpRename` |
 
-## Why now
+**Single source of truth.** `translateVerb` in
+`internal/dataentry/affordances.go` is the only site in `internal/ dataentry`
+that constructs `acl.WriteRequest{Op:...}`. A grep test enforces this. A
+bidirectional contract test asserts the "`_actions[v]==false` ⇒ 403" invariant
+end-to-end across NopACL and ReadOnlyACL.
 
-PR 1's ACL contract (`acl.ACL.AuthorizeWrite(ctx, req) Decision`) is the
-substrate this builds on. The same predicate that decides whether to allow a
-write also drives whether to expose its verb in the response.
+**Anonymous fallback.** Anonymous requests get the `_actions` field omitted; the
+SPA falls back to "render all + warn." Authenticated principals always get the
+field (possibly `{}`).
 
-Three downstream features are unblocked once this lands:
+## Why this design (vs. v1 of the planning doc)
 
-1. **Read-only mode UX** — buttons disappear without per-component frontend gating.
-2. **v1 per-type ACL** — Declarative ACL surfaces per-type `_actions`; no SPA changes needed.
-3. **v2 per-state workflows** (e.g. "only the assignee can mark a ticket done") — backend computes the verb's availability per-entity; SPA stays declarative.
+`{verb: bool}` map was chosen over `[allowed_verb, ...]` list — the map is a
+closed-world assertion (every verb the server defines is a key in the response)
+that lets the SPA distinguish *denied* from *not evaluated* / *not defined* /
+*old server*. List-of-allowed collapses all four into "absent."
 
-## Scope (design-first)
+Parallel-emit (`_actions_v2`) and a separate `/meta/actions` discovery endpoint
+were both designed and then rejected during crit: rela's server and SPA ship
+together (no backwards-compat needed), and collection-level `_actions.create`
+covers menu population without a dedicated endpoint.
 
-This is **xl effort and design-first**. The actual code lands in phases; this
-ticket covers the design + initial implementation.
+## Out of scope (deferred to follow-up tickets)
 
-### Phase 1: Research + design doc
-
-`.ignored/action-affordances-design.md` covering at minimum:
-
-- **Wire shape.** `_actions` field vs HAL `_links` vs OData $metadata. Per-resource embedded vs top-level capabilities. Naming.
-- **Granularity.** Per-list-item (every row carries `_actions.delete`)? Per-collection-only (list root has `_actions.create`)? Per-property (form spec has `_actions.set` per field)? All three?
-- **Computation strategy.** Eager (compute every possible verb per resource) vs lazy (only the verbs the SPA pre-declares interest in). Cost analysis at the prototype's 1k-10k entity scale.
-- **Where the computation lives.** In `internal/acl` as new methods? In `internal/dataentry` calling `acl.AuthorizeWrite` per candidate? A new `internal/affordances` package?
-- **Frontend consumption.** Per-component check vs centralized resolver. How does this interact with optimistic updates and SSE-driven cache invalidation?
-- **Wire compatibility.** Older clients ignore the field. Older servers don't emit it → SPA defaults to "show button optimistically, handle 403 if it comes."
-- **Discoverability + introspection.** Top-level `/api/v1/_actions` listing all verbs and their wire shapes? Useful for tooling, MCP, code-gen.
-- **Caching implications.** Affordances depend on principal — what's the cache key? Does each user's SPA cache its own set?
-- **Read-only mode falls out.** Verify: with ReadOnlyACL, no resource emits any write `_actions`, SPA hides everything. Banner becomes "no actions available" empty state or a tiny dedicated component — not load-bearing.
-
-### Phase 2: Wire shape + backend evaluation
-
-- Define the canonical `_actions` shape across response types (entity, list, relation, form).
-- Implement the evaluation point (likely a small helper that wraps `acl.AuthorizeWrite` against a candidate verb).
-- Emit `_actions` from one initial endpoint (probably `/api/v1/{type}/{id}`) as a proof-of-shape.
-- Wire format docs.
-
-### Phase 3: Full backend coverage
-
-- Every list, entity, relation, form, settings response emits `_actions`.
-- Per-property action affordances on form spec (so DynamicForm can de-emphasize read-only fields driven by policy, not by config).
-- Top-level `/api/v1/_actions` introspection endpoint.
-
-### Phase 4: Frontend consumption
-
-- SPA components read `_actions` from their fetched resource and render conditionally.
-- The 31 affordance sites from PLAN-B0CI's survey become 31 declarative checks against the resource's action set.
-- ESLint rule (similar to the abandoned PLAN-B0CI version) enforces that write `@click` handlers reside inside an `<ActionGuard verb="...">` wrapper consuming `_actions`.
-- DynamicForm consumes per-property affordances; auto-save short-circuits when the verb isn't declared.
-
-### Phase 5: Read-only mode + docs
-
-- ReadOnlyACL produces empty `_actions` across all resources — verified via E2E.
-- `docs/security.md` updates: the SPA's affordance hiding is data-driven, not flag-driven; backend is still the authoritative gate.
-- Optional small "Read-only mode" banner if the UX research says the explicit signal is worth it — but this is no longer the driver.
-
-## Out of scope (for v0 of this design)
-
-- **Multi-language i18n of action labels.** v0 emits verb names; UI maps them to copy.
-- **Hyper-detailed affordance metadata** (e.g. "you can update this property but only with values from this enum"). The metamodel already provides the value enum; affordances declare verb existence, not constraints.
-- **Streaming / SSE delivery of action changes.** v0 affordances are computed at response time; live changes via re-fetch on `refresh` events (consistent with the rest of the SPA).
-- **Capability discovery for MCP / external clients.** v1 of the introspection endpoint may add this; v0 of this ticket only serves the SPA.
-
-## Acceptance criteria
-
-Pending design doc completion. Will be filled in during the planning phase per
-the standard workflow.
-
-## Process
-
-1. **Research sweep** (parallel agent): HAL, JSON:API, OData, Plone `getActions`, GitHub API `_links`, Kubernetes verbs, Cerbos `principal-permissions`, Stripe affordance hints, HATEOAS thesis. Trade-offs, gotchas, what to copy, what to avoid.
-2. **Design doc** from research + the design questions above.
-3. **Plan** in this ticket's planning-checklist.
-4. **Architect + cranky audits** of the plan.
-5. **Crit review** with the user.
-6. **Phased implementation** behind feature flag or staged PRs.
+- **Frontend consumption + AWM6L payoff.** Vue components currently
+ignore `_actions`; phase-2 ticket adds the button-omission + dev-mode warning +
+E2E for read-only-mode-has-no-write-buttons.
+- **`transition:*` and `relation:*` verbs.** ACL v0's
+`WriteRequest{Op, EntityType, RelationType}` doesn't carry parameters (workflow
+target state, relation type). Gated on ACL v0.5 (separate follow-up ticket).
+- **List-endpoint profile / cache.** N+1 risk on big lists is
+acknowledged in the design doc; profile gate lives in the phase-2 ticket. Cache
+key is reserved as `(principal_id, entity_id, entity_updated_at)`; not
+implemented in phase 1.
+- **Per-property affordances, MCP affordance integration, SSE
+policy-changed events** — all deferred to later tickets.
 
 ## References
 
 - Supersedes: TKT-AWM6L (wont-fix)
-- Builds on: TKT-GN5LN (ACL v0 PR 1), DEC-RG878 (four-layer ACL design)
-- Survey from PLAN-B0CI: the 31-affordance inventory is still useful as the "which response shapes need `_actions`" inventory
-- Original design doc: `.ignored/acl-design.md`
-- New design doc (to be written): `.ignored/action-affordances-design.md`
+- Builds on: TKT-GN5LN (ACL v0)
+- Design: `.ignored/action-affordances-design.md`
+- Research: `.ignored/action-affordances-research.md`
+- Implementation PR: #779

--- a/tickets/entities/tickets/TKT-Y72A.md
+++ b/tickets/entities/tickets/TKT-Y72A.md
@@ -1,0 +1,113 @@
+---
+id: TKT-Y72A
+type: ticket
+title: 'Response-level action affordances: backend declares per-resource verbs to drive UI'
+kind: enhancement
+priority: medium
+effort: xl
+status: backlog
+---
+
+## Goal
+
+Make the **backend the single source of truth** for which actions a principal
+can perform on a specific resource at a specific moment. The SPA renders write
+affordances iff the corresponding action is declared in the response.
+
+Today the SPA renders all buttons unconditionally and the backend's 403
+reactively explains the deny *after* a failed click. This works for the binary
+"read-only mode" case but does not scale: per-type, per-principal, per-state,
+per-property authorization all require the SPA to grow its own ACL evaluator
+that mirrors the backend's. That's the **duplication trap** TKT-AWM6L's planning
+exercise surfaced.
+
+Response-level action affordances (HATEOAS-flavored — `_actions` or `_links` on
+each resource) invert the relationship: the server computes "what can this
+principal do here" once, attaches it to the response, and the client stays
+declarative.
+
+## Why now
+
+PR 1's ACL contract (`acl.ACL.AuthorizeWrite(ctx, req) Decision`) is the
+substrate this builds on. The same predicate that decides whether to allow a
+write also drives whether to expose its verb in the response.
+
+Three downstream features are unblocked once this lands:
+
+1. **Read-only mode UX** — buttons disappear without per-component frontend gating.
+2. **v1 per-type ACL** — Declarative ACL surfaces per-type `_actions`; no SPA changes needed.
+3. **v2 per-state workflows** (e.g. "only the assignee can mark a ticket done") — backend computes the verb's availability per-entity; SPA stays declarative.
+
+## Scope (design-first)
+
+This is **xl effort and design-first**. The actual code lands in phases; this
+ticket covers the design + initial implementation.
+
+### Phase 1: Research + design doc
+
+`.ignored/action-affordances-design.md` covering at minimum:
+
+- **Wire shape.** `_actions` field vs HAL `_links` vs OData $metadata. Per-resource embedded vs top-level capabilities. Naming.
+- **Granularity.** Per-list-item (every row carries `_actions.delete`)? Per-collection-only (list root has `_actions.create`)? Per-property (form spec has `_actions.set` per field)? All three?
+- **Computation strategy.** Eager (compute every possible verb per resource) vs lazy (only the verbs the SPA pre-declares interest in). Cost analysis at the prototype's 1k-10k entity scale.
+- **Where the computation lives.** In `internal/acl` as new methods? In `internal/dataentry` calling `acl.AuthorizeWrite` per candidate? A new `internal/affordances` package?
+- **Frontend consumption.** Per-component check vs centralized resolver. How does this interact with optimistic updates and SSE-driven cache invalidation?
+- **Wire compatibility.** Older clients ignore the field. Older servers don't emit it → SPA defaults to "show button optimistically, handle 403 if it comes."
+- **Discoverability + introspection.** Top-level `/api/v1/_actions` listing all verbs and their wire shapes? Useful for tooling, MCP, code-gen.
+- **Caching implications.** Affordances depend on principal — what's the cache key? Does each user's SPA cache its own set?
+- **Read-only mode falls out.** Verify: with ReadOnlyACL, no resource emits any write `_actions`, SPA hides everything. Banner becomes "no actions available" empty state or a tiny dedicated component — not load-bearing.
+
+### Phase 2: Wire shape + backend evaluation
+
+- Define the canonical `_actions` shape across response types (entity, list, relation, form).
+- Implement the evaluation point (likely a small helper that wraps `acl.AuthorizeWrite` against a candidate verb).
+- Emit `_actions` from one initial endpoint (probably `/api/v1/{type}/{id}`) as a proof-of-shape.
+- Wire format docs.
+
+### Phase 3: Full backend coverage
+
+- Every list, entity, relation, form, settings response emits `_actions`.
+- Per-property action affordances on form spec (so DynamicForm can de-emphasize read-only fields driven by policy, not by config).
+- Top-level `/api/v1/_actions` introspection endpoint.
+
+### Phase 4: Frontend consumption
+
+- SPA components read `_actions` from their fetched resource and render conditionally.
+- The 31 affordance sites from PLAN-B0CI's survey become 31 declarative checks against the resource's action set.
+- ESLint rule (similar to the abandoned PLAN-B0CI version) enforces that write `@click` handlers reside inside an `<ActionGuard verb="...">` wrapper consuming `_actions`.
+- DynamicForm consumes per-property affordances; auto-save short-circuits when the verb isn't declared.
+
+### Phase 5: Read-only mode + docs
+
+- ReadOnlyACL produces empty `_actions` across all resources — verified via E2E.
+- `docs/security.md` updates: the SPA's affordance hiding is data-driven, not flag-driven; backend is still the authoritative gate.
+- Optional small "Read-only mode" banner if the UX research says the explicit signal is worth it — but this is no longer the driver.
+
+## Out of scope (for v0 of this design)
+
+- **Multi-language i18n of action labels.** v0 emits verb names; UI maps them to copy.
+- **Hyper-detailed affordance metadata** (e.g. "you can update this property but only with values from this enum"). The metamodel already provides the value enum; affordances declare verb existence, not constraints.
+- **Streaming / SSE delivery of action changes.** v0 affordances are computed at response time; live changes via re-fetch on `refresh` events (consistent with the rest of the SPA).
+- **Capability discovery for MCP / external clients.** v1 of the introspection endpoint may add this; v0 of this ticket only serves the SPA.
+
+## Acceptance criteria
+
+Pending design doc completion. Will be filled in during the planning phase per
+the standard workflow.
+
+## Process
+
+1. **Research sweep** (parallel agent): HAL, JSON:API, OData, Plone `getActions`, GitHub API `_links`, Kubernetes verbs, Cerbos `principal-permissions`, Stripe affordance hints, HATEOAS thesis. Trade-offs, gotchas, what to copy, what to avoid.
+2. **Design doc** from research + the design questions above.
+3. **Plan** in this ticket's planning-checklist.
+4. **Architect + cranky audits** of the plan.
+5. **Crit review** with the user.
+6. **Phased implementation** behind feature flag or staged PRs.
+
+## References
+
+- Supersedes: TKT-AWM6L (wont-fix)
+- Builds on: TKT-GN5LN (ACL v0 PR 1), DEC-RG878 (four-layer ACL design)
+- Survey from PLAN-B0CI: the 31-affordance inventory is still useful as the "which response shapes need `_actions`" inventory
+- Original design doc: `.ignored/acl-design.md`
+- New design doc (to be written): `.ignored/action-affordances-design.md`

--- a/tickets/relations/TKT-AWM6L--has-planning--PLAN-B0CI.md
+++ b/tickets/relations/TKT-AWM6L--has-planning--PLAN-B0CI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-AWM6L
+relation: has-planning
+to: PLAN-B0CI
+---

--- a/tickets/relations/TKT-I82F--affects--data-entry-server.md
+++ b/tickets/relations/TKT-I82F--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-I82F
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-I82F--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-I82F--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-I82F
+relation: implements
+to: FEAT-AESD4
+---

--- a/tickets/relations/TKT-LFT2--affects--authorization.md
+++ b/tickets/relations/TKT-LFT2--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LFT2
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-LFT2--affects--data-entry-server.md
+++ b/tickets/relations/TKT-LFT2--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LFT2
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-LFT2--depends-on--TKT-Y72A.md
+++ b/tickets/relations/TKT-LFT2--depends-on--TKT-Y72A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LFT2
+relation: depends-on
+to: TKT-Y72A
+---

--- a/tickets/relations/TKT-LFT2--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-LFT2--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LFT2
+relation: implements
+to: FEAT-AESD4
+---

--- a/tickets/relations/TKT-XZEY--affects--authorization.md
+++ b/tickets/relations/TKT-XZEY--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XZEY
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-XZEY--depends-on--TKT-GN5LN.md
+++ b/tickets/relations/TKT-XZEY--depends-on--TKT-GN5LN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XZEY
+relation: depends-on
+to: TKT-GN5LN
+---

--- a/tickets/relations/TKT-XZEY--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-XZEY--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XZEY
+relation: implements
+to: FEAT-AESD4
+---

--- a/tickets/relations/TKT-Y72A--affects--authorization.md
+++ b/tickets/relations/TKT-Y72A--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y72A
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-Y72A--affects--data-entry-server.md
+++ b/tickets/relations/TKT-Y72A--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y72A
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-Y72A--depends-on--TKT-GN5LN.md
+++ b/tickets/relations/TKT-Y72A--depends-on--TKT-GN5LN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y72A
+relation: depends-on
+to: TKT-GN5LN
+---

--- a/tickets/relations/TKT-Y72A--has-implementation--IMPL-3DVO.md
+++ b/tickets/relations/TKT-Y72A--has-implementation--IMPL-3DVO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y72A
+relation: has-implementation
+to: IMPL-3DVO
+---

--- a/tickets/relations/TKT-Y72A--has-planning--PLAN-GXC7.md
+++ b/tickets/relations/TKT-Y72A--has-planning--PLAN-GXC7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y72A
+relation: has-planning
+to: PLAN-GXC7
+---

--- a/tickets/relations/TKT-Y72A--has-review--REV-CKT8.md
+++ b/tickets/relations/TKT-Y72A--has-review--REV-CKT8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y72A
+relation: has-review
+to: REV-CKT8
+---

--- a/tickets/relations/TKT-Y72A--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-Y72A--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y72A
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
## Summary

**Phase 1 of TKT-Y72A.** Reshape `V1Entity._actions` to a flat `map[string]bool` of per-principal ACL verdicts. The Vue SPA reads it to decide which write controls to render; read-only mode produces a button-less UI driven entirely by the backend.

This PR carries both the original tracker pivot (TKT-AWM6L wont-fix → TKT-Y72A) and the phase-1 implementation.

### Backend

- Single source of truth: `internal/dataentry/affordances.go` — `translateVerb(verb, entityType) (acl.WriteRequest, bool)`. A grep test (`lint_test.go`) forbids any other file in `internal/dataentry` from constructing `acl.WriteRequest{Op:...}`.
- `computeActions` / `computeCollectionActions` on `App` loop `translateVerb` through `acl.AuthorizeWrite` — the same call the write handlers use.
- `V1Entity._actions` reshaped from `*V1Actions{Delete, Transitions[]}` (placeholder, never had a frontend consumer) to `map[string]bool`. `V1ListResponse._actions` added for collection-scope verbs.
- `NewApp` now takes an `acl.ACL` (required; reject nil).
- `principal.HasPrincipal(ctx)` added — distinguishes "no principal stamped" from "principal with empty User."

### Frontend

- `EntityActions` struct removed; `_actions?: Record<string, boolean>` on `Entity` and `ListResponse`.

### Phase-1 verb vocabulary

| Verb | Scope | `acl.Op` |
|---|---|---|
| `create` | per-collection | `OpCreate` |
| `update` | per-item | `OpUpdate` |
| `delete` | per-item | `OpDelete` |
| `rename` | per-item | `OpRename` |

`transition:*` and `relation:*` verbs are deferred to a follow-up gated on ACL v0.5 — ACL v0's `WriteRequest` doesn't carry the required arguments.

### Design + research

- `.ignored/action-affordances-research.md` — 10-system survey synthesizing 9 numbered recommendations.
- `.ignored/action-affordances-design.md` — rela-specific design. Went through go-architect + cranky-code-reviewer audits (3 critical + 5 significant findings folded in) and three rounds of crit (closed-world map shape, no parallel-emit, no separate discovery endpoint).
- `tickets/entities/planning-checklists/PLAN-GXC7.md` — planning checklist with 10 ACs.
- `docs/data-entry/api-reference.md`, `docs/security.md`, `CLAUDE.md` — user-facing + contributor docs updated.

### Cardinal rule

`_actions` is a UI hint, not authorization. The server re-authorizes every write. The bidirectional contract test (`TestAffordances_BidirectionalContract`) pins this: every `_actions[v]==false` ⇒ 403, every `true` ⇒ 2xx, parameterized over NopACL + ReadOnlyACL.

## Test plan

- [x] `just ci` — full pipeline green (lint, arch-lint, lint-md, test, coverage-check, build, docs-check)
- [x] `go test -race ./...` — all packages green
- [x] Frontend `npm run typecheck` + `npm run test:run` (784 tests) — green
- [x] New tests:
  - `TestTranslateVerb_Roundtrip` — phase-1 vocabulary pinned to acl.Op constants
  - `TestComputeActions_{ReadOnly,NopACL,AnonymousOmits}` — AC1, AC2, anonymous fallback semantics
  - `TestAffordances_BidirectionalContract` — AC3 (GET + DELETE lockstep across NopACL/ReadOnlyACL)
  - `TestComputeActions_NoAuditNoise` — AC8 (read path produces zero audit records under `audit.NewMemory()`)
  - `TestNoStrayWriteRequestConstruction` — AC10 (structural same-code-path enforcement)