### PR TITLE
fix(dataentryconfig): clearer errors for inverse + wrong-side form relations (#780)

### DIFF
--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -241,10 +242,25 @@ func validateForms(cfg *Config, meta *metamodel.Metamodel) []string {
 
 		// Validate relations
 		for i, r := range form.Relations {
-			if _, ok := meta.GetRelationDef(r.Relation); !ok {
-				errs = append(errs, fmt.Sprintf(
-					"form %q: relation[%d] references unknown relation %q",
-					formID, i, r.Relation))
+			relDef, ok := meta.GetRelationDef(r.Relation)
+			switch {
+			case ok:
+				// Canonical name resolved — check that the form's entity
+				// type is on the correct side of the edge for the chosen
+				// direction. Wrong-side configs are silently broken
+				// otherwise: the widget searches the wrong target type
+				// and never shows existing edges.
+				errs = append(errs, validateFormRelationSide(formID, i, form.EntityType, r, relDef)...)
+			default:
+				if canonical, isInverse := meta.InverseOwner(r.Relation); isInverse {
+					errs = append(errs, fmt.Sprintf(
+						"form %q: relation[%d] uses inverse name %q; use `relation: %s` with `direction: incoming` to bind the inverse of %q",
+						formID, i, r.Relation, canonical, canonical))
+				} else {
+					errs = append(errs, fmt.Sprintf(
+						"form %q: relation[%d] references unknown relation %q",
+						formID, i, r.Relation))
+				}
 			}
 
 			// Validate direction
@@ -273,6 +289,37 @@ func validateForms(cfg *Config, meta *metamodel.Metamodel) []string {
 	}
 
 	return errs
+}
+
+// validateFormRelationSide checks that the form's entity type sits on
+// the side of the relation that matches the chosen direction. An
+// outgoing relation must be authored from a `From:` type; an incoming
+// one must be authored from a `To:` type. Mismatch returns an error;
+// when the entity is on the opposite side the message hints at
+// flipping the direction.
+func validateFormRelationSide(formID string, i int, entityType string, r FormRelation, relDef *metamodel.RelationDef) []string {
+	if entityType == "" {
+		return nil
+	}
+	incoming := r.Direction.IsIncoming()
+	expected, opposite := relDef.From, relDef.To
+	expectedSide, oppositeSide := "from", "to"
+	flipDir := DirectionIncoming
+	if incoming {
+		expected, opposite = relDef.To, relDef.From
+		expectedSide, oppositeSide = "to", "from"
+		flipDir = DirectionOutgoing
+	}
+	if slices.Contains(expected, entityType) {
+		return nil
+	}
+	hint := ""
+	if r.Direction == "" && slices.Contains(opposite, entityType) {
+		hint = fmt.Sprintf(" (set `direction: %s` to bind the %s side of %q)", flipDir, oppositeSide, r.Relation)
+	}
+	return []string{fmt.Sprintf(
+		"form %q: relation[%d] entity type %q is not a %s of relation %q (valid: %s)%s",
+		formID, i, entityType, expectedSide, r.Relation, strings.Join(expected, ", "), hint)}
 }
 
 // validateTransitions checks that transition values are valid for the property's type.

--- a/internal/dataentryconfig/validate_test.go
+++ b/internal/dataentryconfig/validate_test.go
@@ -221,6 +221,199 @@ func TestValidateConfig_UnknownFormRelation(t *testing.T) {
 	}
 }
 
+// inverseTestMetamodel parses a metamodel via the real loader so
+// inverseOwners is populated — needed for tests that exercise the
+// inverse-name and wrong-side branches in validateForms.
+func inverseTestMetamodel(t *testing.T) *metamodel.Metamodel {
+	t.Helper()
+	yaml := `version: "1.0"
+entities:
+  from_entity:
+    label: From
+    id_prefix: "FROM-"
+    properties:
+      title:
+        type: string
+        required: true
+  to_entity:
+    label: To
+    id_prefix: "TO-"
+    properties:
+      title:
+        type: string
+        required: true
+  other_entity:
+    label: Other
+    id_prefix: "OTH-"
+    properties:
+      title:
+        type: string
+        required: true
+relations:
+  connects_to:
+    label: connects to
+    from: [from_entity]
+    to: [to_entity]
+    inverse: connects_from
+  multi_source:
+    label: multi source
+    from: [from_entity, other_entity]
+    to: [to_entity]
+`
+	m, err := metamodel.Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse inverse test metamodel: %v", err)
+	}
+	return m
+}
+
+func TestValidateConfig_FormRelationInverseName(t *testing.T) {
+	meta := inverseTestMetamodel(t)
+	cfg := &Config{
+		Forms: map[string]Form{
+			"edit_to": {
+				EntityType: "to_entity",
+				Relations:  []FormRelation{{Relation: "connects_from"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for inverse-name relation")
+	}
+	msg := err.Error()
+	// Error must identify the inverse name and point the user at the
+	// canonical relation plus direction: incoming.
+	if !strings.Contains(msg, `"connects_from"`) {
+		t.Errorf("expected error to mention inverse name, got: %v", err)
+	}
+	if !strings.Contains(msg, `"connects_to"`) {
+		t.Errorf("expected error to point at canonical name, got: %v", err)
+	}
+	if !strings.Contains(msg, "direction: incoming") {
+		t.Errorf("expected error to mention direction: incoming, got: %v", err)
+	}
+}
+
+func TestValidateConfig_FormRelationWrongSide_HintsIncoming(t *testing.T) {
+	meta := inverseTestMetamodel(t)
+	// to_entity is on the TO side of connects_to; the default outgoing
+	// direction makes this form silently broken.
+	cfg := &Config{
+		Forms: map[string]Form{
+			"edit_to": {
+				EntityType: "to_entity",
+				Relations:  []FormRelation{{Relation: "connects_to"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for form entity not on the source side of an outgoing relation")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `"to_entity"`) {
+		t.Errorf("expected error to mention form entity type, got: %v", err)
+	}
+	if !strings.Contains(msg, `"connects_to"`) {
+		t.Errorf("expected error to mention the relation, got: %v", err)
+	}
+	if !strings.Contains(msg, "direction: incoming") {
+		t.Errorf("expected hint to set direction: incoming, got: %v", err)
+	}
+}
+
+func TestValidateConfig_FormRelationWrongSide_NoHintWhenDirectionExplicit(t *testing.T) {
+	meta := inverseTestMetamodel(t)
+	// Explicit outgoing with form entity on the wrong side — flipping the
+	// direction would help, but the user has explicitly chosen outgoing,
+	// so we error without a "did you mean" hint.
+	cfg := &Config{
+		Forms: map[string]Form{
+			"edit_to": {
+				EntityType: "to_entity",
+				Relations:  []FormRelation{{Relation: "connects_to", Direction: DirectionOutgoing}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for form entity not on the source side")
+	}
+	if !strings.Contains(err.Error(), `"to_entity"`) {
+		t.Errorf("expected error to mention form entity type, got: %v", err)
+	}
+}
+
+func TestValidateConfig_FormRelationIncomingWrongSide(t *testing.T) {
+	meta := inverseTestMetamodel(t)
+	// from_entity is the SOURCE side; declaring direction: incoming on it
+	// for connects_to is a configuration error.
+	cfg := &Config{
+		Forms: map[string]Form{
+			"edit_from": {
+				EntityType: "from_entity",
+				Relations:  []FormRelation{{Relation: "connects_to", Direction: DirectionIncoming}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for direction: incoming on the source side")
+	}
+	if !strings.Contains(err.Error(), `"from_entity"`) {
+		t.Errorf("expected error to mention form entity type, got: %v", err)
+	}
+}
+
+func TestValidateConfig_FormRelationCorrectSide(t *testing.T) {
+	meta := inverseTestMetamodel(t)
+	// from_entity → connects_to (outgoing default) is the correct shape.
+	// to_entity   → connects_to with direction: incoming is also correct.
+	cfg := &Config{
+		Forms: map[string]Form{
+			"edit_from": {
+				EntityType: "from_entity",
+				Relations:  []FormRelation{{Relation: "connects_to"}},
+			},
+			"edit_to": {
+				EntityType: "to_entity",
+				Relations:  []FormRelation{{Relation: "connects_to", Direction: DirectionIncoming}},
+			},
+		},
+	}
+
+	if err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta); err != nil {
+		t.Errorf("expected valid config to pass, got: %v", err)
+	}
+}
+
+func TestValidateConfig_FormRelationMultiSourceSide(t *testing.T) {
+	meta := inverseTestMetamodel(t)
+	// multi_source allows from_entity OR other_entity as the source.
+	// Both should pass when used as the form entity with outgoing default.
+	cfg := &Config{
+		Forms: map[string]Form{
+			"edit_from": {
+				EntityType: "from_entity",
+				Relations:  []FormRelation{{Relation: "multi_source"}},
+			},
+			"edit_other": {
+				EntityType: "other_entity",
+				Relations:  []FormRelation{{Relation: "multi_source"}},
+			},
+		},
+	}
+
+	if err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta); err != nil {
+		t.Errorf("expected valid config with multi-type source to pass, got: %v", err)
+	}
+}
+
 func TestValidateConfig_InvalidRelationDirection(t *testing.T) {
 	meta := testMetamodel()
 	cfg := &Config{

--- a/tickets/entities/automated-measures/data-entry-form-relation-side-checks.md
+++ b/tickets/entities/automated-measures/data-entry-form-relation-side-checks.md
@@ -1,0 +1,9 @@
+---
+id: data-entry-form-relation-side-checks
+type: automated-measure
+title: Validator checks for inverse-name and wrong-side form relations
+description: 'Table-driven tests in `internal/dataentryconfig/validate_test.go` pin every branch of `validateForms`'' relation handling. `inverseTestMetamodel` parses a metamodel through the real loader so `inverseOwners` is populated the same way the runtime sees it. Branches covered: inverse-name produces an error pointing at the canonical name + `direction: incoming`; wrong-side binding with no direction produces a hint to flip the direction; wrong-side with explicit direction errors without the hint; `direction: incoming` on the source side also errors; correct-shape configs (canonical+outgoing, canonical+incoming) and multi-source-type relations pass.'
+kind: test
+location: internal/dataentryconfig/validate_test.go (TestValidateConfig_FormRelation*)
+status: active
+---

--- a/tickets/entities/bugs/BUG-TJLA.md
+++ b/tickets/entities/bugs/BUG-TJLA.md
@@ -1,0 +1,15 @@
+---
+id: BUG-TJLA
+type: bug
+title: 'data-entry config: misleading ''unknown relation'' error for inverse names and wrong-side form bindings'
+description: 'On data-entry forms, using an inverse relation name (e.g. `relation: connects_from` for the inverse of `connects_to`) was rejected at config-load time with `references unknown relation`, with no hint that the supported shape is `relation: connects_to` + `direction: incoming`. Worse, the natural workaround — using the canonical name on a form whose `entity_type` is on the wrong side of the edge — passed validation but silently produced a broken widget: the picker searched the wrong target type and existing edges never rendered. Reported in GitHub issue #780.'
+priority: medium
+effort: xs
+why1: '`validateForms` rejected any relation name that wasn''t a canonical metamodel relation, including declared inverse names'
+why2: the validator only called `meta.GetRelationDef`, never `meta.InverseOwner`, so it couldn't distinguish an inverse name from a typo
+why3: and it never checked that the form's `entity_type` sat on the side of the relation the chosen direction implied, so a wrong-side binding produced no error at all — only a silently broken widget at runtime
+why4: the original validator pass treated relation references as a flat name lookup and didn't reason about edge endpoints; the runtime layers downstream (`resolveDirection`, the direction-aware widget) already handled inverse and direction correctly
+why5: there was no test exercising the validator with a metamodel that declared `inverse:`, so neither failure mode had ever produced a clear error message
+prevention: '`validateForms` now (a) resolves inverse names via `Metamodel.InverseOwner` and points users at `relation: <canonical>` + `direction: incoming`, and (b) checks the form entity type against `relDef.From`/`relDef.To` for the chosen direction, hinting at the direction flip when the entity is on the opposite side. Table-driven tests in `validate_test.go` pin every branch using a metamodel parsed through the real loader so `inverseOwners` is populated the same way the runtime sees it.'
+status: done
+---

--- a/tickets/relations/BUG-TJLA--adds-measure--data-entry-form-relation-side-checks.md
+++ b/tickets/relations/BUG-TJLA--adds-measure--data-entry-form-relation-side-checks.md
@@ -1,0 +1,5 @@
+---
+from: BUG-TJLA
+relation: adds-measure
+to: data-entry-form-relation-side-checks
+---

--- a/tickets/relations/BUG-TJLA--affects--data-entry-server.md
+++ b/tickets/relations/BUG-TJLA--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: BUG-TJLA
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/BUG-TJLA--fixes--FEAT-R7SOT.md
+++ b/tickets/relations/BUG-TJLA--fixes--FEAT-R7SOT.md
@@ -1,0 +1,5 @@
+---
+from: BUG-TJLA
+relation: fixes
+to: FEAT-R7SOT
+---


### PR DESCRIPTION
## Summary

Fixes #780. Two form-relation validation issues were surfacing as the same opaque "unknown relation" error:

- A `relation:` value matching an **inverse name** (e.g. `connects_from` when the canonical is `connects_to` with `inverse: connects_from`) was rejected with no hint that the supported shape is `relation: connects_to` + `direction: incoming`.
- A `relation:` value matching a **canonical name** on a form whose `entity_type` sits on the wrong side of the edge silently produced a broken widget — the search hit the wrong target type and existing edges never rendered.

`validateForms` now detects both:

- Inverse-name → error points at the canonical name and `direction: incoming`.
- Wrong-side binding → error names the entity type and the relation; when `direction:` is unset and the entity sits on the opposite side, the message includes a "set `direction: incoming` to bind the other side" hint.

The widget itself was already correct; only the config-time errors were misleading.

## Test plan

- [x] `go test ./internal/dataentryconfig/...` — 6 new tests covering: inverse-name error, wrong-side with flip hint, wrong-side without hint when direction is explicit, incoming-on-source-side error, correct-shape passes, multi-source-type relation passes.
- [x] `go test ./...` — full suite clean.
- [x] `just lint` and `just arch-lint` clean.
- [x] `just ci` clean locally.
- [x] Manual repro of issue #780:
  - Original (inverse-name) config now errors with: `relation[0] uses inverse name "connects_from"; use `relation: connects_to` with `direction: incoming` to bind the inverse of "connects_to"`.
  - Workaround-but-wrong-side config (`relation: connects_to` on `to_entity` with no direction) now errors with: `entity type "to_entity" is not a from of relation "connects_to" (valid: from_entity) (set `direction: incoming` to bind the to side of "connects_to")`.
  - Correct shape (`relation: connects_to` + `direction: incoming` on `to_entity`) loads cleanly and the widget shows the existing FROM-AAAA → TO-AAAA edge and lets it be edited.