### PR TITLE
deps: ignore vue-router major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,13 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 14
+    # vue-router@5+ on npm is a separate package (the vue-router unplugin
+    # tool, by the same maintainers); the actual router for Vue 3 stays
+    # on the 4.x line. Pin to 4.x to keep Dependabot from re-proposing
+    # what looks like a major bump but is in fact a different package.
+    ignore:
+      - dependency-name: "vue-router"
+        update-types: ["version-update:semver-major"]
     # Groups bundle minor+patch only. Majors fall out as individual PRs
     # so a single breaking upgrade can't block the safe ones in its group.
     # Auto-merge is unconditional on green CI, so each PR (group or


### PR DESCRIPTION
## Summary

- The `vue-router` npm package now publishes a different project (a Vue Router unplugin tooling package) on the 5.x line. The actual router for Vue 3 stays on 4.x (4.6.x is current).
- Dependabot keeps proposing what looks like a `4.x → 5.x` major upgrade but is in fact a swap to a different package, with completely different dependencies (`unplugin`, `chokidar`, `@babel/generator`, etc.) and an incompatible peer set (`pinia ^3.0.4`, which conflicts with our `@pinia/testing@0.1.7` pin on pinia 2.x).
- Adds an ignore rule for `vue-router` semver-major updates so Dependabot stops re-proposing #755.
- Closes #755.

## Test plan

- [ ] CI green on this PR (config-only change; only the dependabot config validates it).
- [ ] After merge, verify #755 is closed and not re-opened on the next Dependabot run.