### PR TITLE
feat(spa): consume _actions to hide entity-CRUD controls (TKT-LFT2 phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,22 @@ Rules for new write code in `internal/dataentry`:
   `rename` (per-item). `transition:*` and `relation:*` are deferred
   until ACL gains Op variants or extension fields.
 
+Rules for new write affordances in the Vue SPA:
+
+- **Gate every entity-CRUD button on `entity._actions?.[verb] !== false`**
+  (or `listResponse._actions?.create !== false` for collection-scope
+  verbs). False → hide; anything else (true, undefined, absent) →
+  render. Absent is the defensive-render fallback for non-data-entry
+  callers; the server still 403s on the actual write.
+- **Don't introduce a `useACL()` composable or any client-side ACL
+  evaluator.** TKT-AWM6L's wont-fix rejected this direction. The SPA
+  reads booleans the server computed; no computation, no merging,
+  no prediction.
+- **Adding a new write affordance** requires (a) a backend
+  `translateVerb` entry + `perItemVerbs`/`perCollectionVerbs` update
+  (see above), and (b) the inline `v-if` on the component. There is
+  no ESLint enforcement; code review catches drift.
+
 ## Architecture
 
 rela is a schema-driven entity-graph platform. You define the shape of your

--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -308,6 +308,37 @@ branch in production. A principal with all verbs denied receives
 `_actions: {}` — same shape, all values false. A principal with
 every verb granted receives `_actions` with all values true.
 
+### How the SPA consumes `_actions`
+
+Phase 2 (TKT-LFT2) ships the SPA consumers. Each write affordance
+(delete button, edit button, "+ New" button, drag-drop, Del-key
+handler) consults `entity._actions[verb]` and renders only when the
+verdict is anything other than explicit `false`. Concretely:
+
+- `entity._actions?.delete !== false` → render the delete button.
+- `entity._actions?.update !== false` → render the edit button and
+  enable drag-drop in Kanban.
+- `listResponse._actions?.create !== false` → render the "+ New"
+  button on list / Kanban pages.
+- Absent `_actions` (non-data-entry callers, pre-rollout servers) →
+  defensive render; the server still 403s on the actual write.
+- Direct-URL navigation to `/form/:id/:entityId` when the loaded
+  entity's `_actions.update === false` → renders a "This entity is
+  not editable" message in place of the form.
+
+In **read-only mode** (`rela-server --read-only`), entity-CRUD
+controls are absent across the SPA — no "+ New", no delete buttons,
+no Edit buttons, drag-drop disabled. Deferred phase-2 sites (Lua
+command buttons, settings / theme / git writes, relation add/remove
+inside form widgets, inline-edit buttons in related-entity cards)
+remain visible and 403 at the server on click; future phases gate
+them as new verbs land in the ACL primitive (see TKT-XZEY).
+
+A development-mode console warning fires once per request path when
+a whitelisted API response (`listEntities`, `getEntity`,
+`createEntity`, `updateEntity`) omits `_actions`. Production builds
+suppress it.
+
 ### The cardinal rule
 
 **`_actions` is a UI hint, not authorization.** The server

--- a/docs/security.md
+++ b/docs/security.md
@@ -270,11 +270,16 @@ gaps independently.
 - ✅ HTTP 403 with structured `{error, rule_kind, rule_id, reason}` body.
 - ✅ Audit log records every deny as `denied-write` (see
   [audit-log](./audit-log.md)).
-- ✅ Data-entry SPA hides write controls based on the per-resource
-  `_actions` verdict map — read-only mode produces a button-less UI
-  driven by the ACL, no frontend flag. See the [API reference
-  action-affordances section](./data-entry/api-reference.md#action-affordances-_actions)
-  for the wire shape and contract.
+- ✅ Data-entry SPA hides entity-CRUD write controls based on the
+  per-resource `_actions` verdict map — read-only mode produces a
+  UI with no "+ New", delete, or Edit buttons for entities,
+  driven by the ACL with no frontend flag. Deferred phase-2 sites
+  (Lua command buttons, settings / theme / git writes, relation
+  add/remove inside form widgets) remain visible and 403 at the
+  server on click; later phases gate them as new verbs land. See
+  the [API reference action-affordances
+  section](./data-entry/api-reference.md#how-the-spa-consumes-_actions)
+  for the consumer contract.
 - ❌ Read filtering, property redaction — deferred to v1.
 - ❌ Group expansion (`member-of` transitive) — deferred to v1.
 - ❌ MCP transport intersection (filtering the tool list per principal) — deferred to a follow-up.

--- a/e2e/pages/entity.page.ts
+++ b/e2e/pages/entity.page.ts
@@ -77,6 +77,26 @@ export class EntityPage extends BasePage {
     await this.page.waitForURL(/\/form\//);
   }
 
+  /** Wait for the page heading to render. Use after navigating to a
+   *  detail URL directly without going through navigateToEntity. */
+  async waitForHeading(timeoutMs = 10_000) {
+    await this.heading.waitFor({ timeout: timeoutMs });
+  }
+
+  /** Assert no Edit button is rendered. Used to verify the AC10
+   *  read-only payoff: per-entity `_actions.update=false` hides the
+   *  Edit affordance. */
+  async expectNoEditButton() {
+    await expect(this.page.getByRole('button', { name: /^Edit/ })).toHaveCount(0);
+  }
+
+  /** Assert no Delete button is rendered. Used to verify the AC10
+   *  read-only payoff: per-entity `_actions.delete=false` hides the
+   *  Delete affordance. */
+  async expectNoDeleteButton() {
+    await expect(this.page.getByRole('button', { name: /^Delete/ })).toHaveCount(0);
+  }
+
   async clickRelationLink(targetId: string) {
     // Detail screens render related entities as cards / list items with a
     // data-entity-id attribute on the row root and a clickable header

--- a/e2e/pages/form.page.ts
+++ b/e2e/pages/form.page.ts
@@ -52,6 +52,16 @@ export class FormPage extends BasePage {
     await this.waitForSpinnerToDisappear();
   }
 
+  /** Assert the form route guard rendered the "not editable" inline
+   *  message (instead of the form). Triggered when the server says
+   *  `_actions.update === false` for the target entity — AC10 of the
+   *  read-only payoff. */
+  async expectNotEditableMessage(timeoutMs = 10_000) {
+    const banner = this.page.locator('.not-editable-state');
+    await expect(banner).toBeVisible({ timeout: timeoutMs });
+    await expect(banner).toContainText(/not editable/i);
+  }
+
   /** Wait for the URL to be the edit form for the given form/entity. Used
    *  when navigation is triggered by another page (e.g. Edit button on the
    *  document view). */

--- a/e2e/pages/list.page.ts
+++ b/e2e/pages/list.page.ts
@@ -27,6 +27,28 @@ export class ListPage extends BasePage {
     await expect(anyRow.or(empty)).toBeVisible();
   }
 
+  /** Wait for at least one row cell to render. Covers both the desktop
+   *  table layout (`td`) and the mobile card layout (`.mobile-card-title`).
+   *  Use when navigating to a list page directly (without
+   *  `navigateToList`, which already waits). */
+  async waitForRowsRendered(timeoutMs = 10_000) {
+    await this.page.locator('td, .mobile-card-title').first().waitFor({ timeout: timeoutMs });
+  }
+
+  /** Assert no `+ New …` link is rendered on the page. Used to verify
+   *  the AC10 read-only payoff: collection `_actions.create=false`
+   *  hides the create affordance. */
+  async expectNoCreateAffordance() {
+    await expect(this.page.getByRole('link', { name: /^\+ New/ })).toHaveCount(0);
+  }
+
+  /** Assert no row-level delete buttons are rendered. Used to verify
+   *  the AC10 read-only payoff: per-entity `_actions.delete=false`
+   *  hides the per-row x. */
+  async expectNoRowDeleteButtons() {
+    await expect(this.page.locator('button.delete-btn')).toHaveCount(0);
+  }
+
   async expectListHeading(title: string) {
     await expect(this.page.locator('h1', { hasText: title })).toBeVisible();
   }

--- a/e2e/tests/read-only-mode.spec.ts
+++ b/e2e/tests/read-only-mode.spec.ts
@@ -16,7 +16,8 @@
  * it). The spawn logic is a slim copy of the fixture's; if it ever
  * grows, factor a `spawnReadOnlyServer` helper into fixtures.ts.
  */
-import { test as base, expect } from './fixtures';
+import { test as base } from './fixtures';
+import { EntityPage, FormPage, ListPage } from '../pages';
 import { spawn, type ChildProcess } from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -93,6 +94,7 @@ const test = base.extend<{ readOnlyServerUrl: string }>({
         // attach() doesn't fire when the fixture itself throws.
         throw new Error(
           `${e instanceof Error ? e.message : String(e)}\n--- server stdout ---\n${stdout}\n--- server stderr ---\n${stderr}`,
+          { cause: e },
         );
       }
       await use(url);
@@ -121,16 +123,13 @@ test.describe('Read-only mode hides entity-CRUD controls (AC10)', () => {
     const page = await context.newPage();
     await page.goto(`${readOnlyServerUrl}/list/features`);
 
-    // Wait for the list to render at least one row.
-    await page.waitForSelector('td, .mobile-card-title', { timeout: 10_000 });
-
-    // "+ New" button is gated on collection `_actions.create`, which
-    // ReadOnlyACL sets to false. The button shouldn't render.
-    await expect(page.getByRole('link', { name: /^\+ New/ })).toHaveCount(0);
-
-    // Row delete buttons are gated on per-entity `_actions.delete`,
-    // which ReadOnlyACL also denies. Neither layout should show any.
-    await expect(page.locator('button.delete-btn')).toHaveCount(0);
+    const listPage = new ListPage(page);
+    await listPage.waitForRowsRendered();
+    // "+ New" gated on collection `_actions.create=false`; row delete
+    // buttons gated on per-entity `_actions.delete=false`. Both denied
+    // under ReadOnlyACL.
+    await listPage.expectNoCreateAffordance();
+    await listPage.expectNoRowDeleteButtons();
 
     await context.close();
   });
@@ -145,13 +144,12 @@ test.describe('Read-only mode hides entity-CRUD controls (AC10)', () => {
     const page = await context.newPage();
     await page.goto(`${readOnlyServerUrl}/entity/feature/FEAT-001`);
 
-    // Wait for the detail header to render.
-    await page.waitForSelector('h1', { timeout: 10_000 });
-
-    // Edit + Delete buttons gated on _actions.{update, delete},
-    // both false under ReadOnlyACL.
-    await expect(page.getByRole('button', { name: /^Edit/ })).toHaveCount(0);
-    await expect(page.getByRole('button', { name: /^Delete/ })).toHaveCount(0);
+    const entityPage = new EntityPage(page);
+    await entityPage.waitForHeading();
+    // Edit + Delete gated on _actions.{update, delete}, both false
+    // under ReadOnlyACL.
+    await entityPage.expectNoEditButton();
+    await entityPage.expectNoDeleteButton();
 
     await context.close();
   });
@@ -166,10 +164,10 @@ test.describe('Read-only mode hides entity-CRUD controls (AC10)', () => {
     const page = await context.newPage();
     await page.goto(`${readOnlyServerUrl}/form/feature/FEAT-001`);
 
-    // The Form route guard should detect _actions.update === false
-    // and render an inline message instead of the form.
-    await expect(page.locator('.not-editable-state')).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator('.not-editable-state')).toContainText(/not editable/i);
+    // Form route guard detects _actions.update === false and renders
+    // an inline message instead of the form.
+    const formPage = new FormPage(page);
+    await formPage.expectNotEditableMessage();
 
     await context.close();
   });

--- a/e2e/tests/read-only-mode.spec.ts
+++ b/e2e/tests/read-only-mode.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * AC10 (TKT-LFT2): the AWM6L payoff — `rela-server --read-only`
+ * produces a SPA with no entity-CRUD write controls. The user lands
+ * on a list page and sees no "+ New" button; lands on an entity
+ * detail page and sees no Edit / Delete buttons; direct-URL form
+ * navigation shows a "not editable" message.
+ *
+ * Deferred phase-2 sites (Lua command buttons, settings / theme /
+ * git, relation add/remove inside form widgets, inline-edit buttons
+ * in related-entity cards) remain visible and 403 at the server on
+ * click. The assertions below intentionally exclude those.
+ *
+ * The test reuses the standard `testProject` fixture to get a fresh
+ * project directory, then spawns its own `--read-only` server (the
+ * default `serverUrl` fixture is unrestricted, so we can't reuse
+ * it). The spawn logic is a slim copy of the fixture's; if it ever
+ * grows, factor a `spawnReadOnlyServer` helper into fixtures.ts.
+ */
+import { test as base, expect } from './fixtures';
+import { spawn, type ChildProcess } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as net from 'net';
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SERVER_BINARY = path.join(PROJECT_ROOT, 'bin', 'rela-server');
+
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, () => {
+      const addr = srv.address();
+      if (addr && typeof addr === 'object') {
+        const { port } = addr;
+        srv.close(() => resolve(port));
+      } else {
+        srv.close();
+        reject(new Error('no port'));
+      }
+    });
+  });
+}
+
+async function waitForServer(url: string, origin: string, timeoutMs = 15_000): Promise<void> {
+  // Match the production fixture's probe URL — /api/v1/_config is
+  // unauthenticated and always renders once the project is loaded.
+  const probeUrl = `${url}/api/v1/_config`;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const resp = await fetch(probeUrl, { headers: { Origin: origin } });
+      if (resp.ok) return;
+    } catch {
+      /* keep polling */
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`server at ${probeUrl} did not become ready within ${timeoutMs}ms`);
+}
+
+// Extend the test base with a `readOnlyServerUrl` fixture that boots
+// a `--read-only` server against the standard testProject. The
+// existing `serverUrl` stays unrestricted; this fixture is what
+// read-only tests bind to.
+const test = base.extend<{ readOnlyServerUrl: string }>({
+  readOnlyServerUrl: async ({ testProject }, use, testInfo) => {
+    if (!fs.existsSync(SERVER_BINARY)) {
+      throw new Error(
+        `rela-server binary not found at ${SERVER_BINARY}; run 'just build' first or rely on the buildIfMissing helper in fixtures.ts.`,
+      );
+    }
+    const port = await findFreePort();
+    // 127.0.0.1 (not localhost) because rela-server binds IPv4 only;
+    // Node 18+ fetch will try IPv6 ::1 first when given `localhost`
+    // and timeout if the server is IPv4-only.
+    const url = `http://127.0.0.1:${port}`;
+    const proc: ChildProcess = spawn(
+      SERVER_BINARY,
+      ['-port', String(port), '-allowed-origin', url, '--read-only'],
+      { cwd: testProject, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    let stdout = '';
+    let stderr = '';
+    proc.stdout?.on('data', (d) => (stdout += d.toString()));
+    proc.stderr?.on('data', (d) => (stderr += d.toString()));
+    try {
+      try {
+        await waitForServer(url, url);
+      } catch (e) {
+        // Surface server logs in the test error message — fixture
+        // attach() doesn't fire when the fixture itself throws.
+        throw new Error(
+          `${e instanceof Error ? e.message : String(e)}\n--- server stdout ---\n${stdout}\n--- server stderr ---\n${stderr}`,
+        );
+      }
+      await use(url);
+    } finally {
+      if (testInfo.status !== testInfo.expectedStatus) {
+        await testInfo.attach('rela-server.log', {
+          body: `--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}\n`,
+          contentType: 'text/plain',
+        });
+      }
+      proc.kill('SIGTERM');
+      await new Promise((r) => setTimeout(r, 200));
+      if (!proc.killed) proc.kill('SIGKILL');
+    }
+  },
+});
+
+test.describe('Read-only mode hides entity-CRUD controls (AC10)', () => {
+  test('list page has no "+ New" button and no delete buttons', async ({
+    browser,
+    readOnlyServerUrl,
+  }) => {
+    const context = await browser.newContext({
+      extraHTTPHeaders: { Origin: readOnlyServerUrl },
+    });
+    const page = await context.newPage();
+    await page.goto(`${readOnlyServerUrl}/list/features`);
+
+    // Wait for the list to render at least one row.
+    await page.waitForSelector('td, .mobile-card-title', { timeout: 10_000 });
+
+    // "+ New" button is gated on collection `_actions.create`, which
+    // ReadOnlyACL sets to false. The button shouldn't render.
+    await expect(page.getByRole('link', { name: /^\+ New/ })).toHaveCount(0);
+
+    // Row delete buttons are gated on per-entity `_actions.delete`,
+    // which ReadOnlyACL also denies. Neither layout should show any.
+    await expect(page.locator('button.delete-btn')).toHaveCount(0);
+
+    await context.close();
+  });
+
+  test('entity detail page has no Edit or Delete buttons', async ({
+    browser,
+    readOnlyServerUrl,
+  }) => {
+    const context = await browser.newContext({
+      extraHTTPHeaders: { Origin: readOnlyServerUrl },
+    });
+    const page = await context.newPage();
+    await page.goto(`${readOnlyServerUrl}/entity/feature/FEAT-001`);
+
+    // Wait for the detail header to render.
+    await page.waitForSelector('h1', { timeout: 10_000 });
+
+    // Edit + Delete buttons gated on _actions.{update, delete},
+    // both false under ReadOnlyACL.
+    await expect(page.getByRole('button', { name: /^Edit/ })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /^Delete/ })).toHaveCount(0);
+
+    await context.close();
+  });
+
+  test('direct form-URL navigation shows "not editable" message', async ({
+    browser,
+    readOnlyServerUrl,
+  }) => {
+    const context = await browser.newContext({
+      extraHTTPHeaders: { Origin: readOnlyServerUrl },
+    });
+    const page = await context.newPage();
+    await page.goto(`${readOnlyServerUrl}/form/feature/FEAT-001`);
+
+    // The Form route guard should detect _actions.update === false
+    // and render an inline message instead of the form.
+    await expect(page.locator('.not-editable-state')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('.not-editable-state')).toContainText(/not editable/i);
+
+    await context.close();
+  });
+});

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -10,6 +10,7 @@ import type {
   ModernRelationsField,
 } from '@/types'
 import { useSchemaStore } from '@/stores/schema'
+import { warnIfMissingActions } from '@/utils/affordancesWarning'
 
 function getPlural(type: string): string {
   const schema = useSchemaStore()
@@ -21,7 +22,10 @@ export async function listEntities(
   type: string,
   params?: ListParams
 ): Promise<ListResponse<Entity>> {
-  return api.get<ListResponse<Entity>>(`/${getPlural(type)}`, params as Record<string, unknown>)
+  const path = `/${getPlural(type)}`
+  const res = await api.get<ListResponse<Entity>>(path, params as Record<string, unknown>)
+  warnIfMissingActions(res, path)
+  return res
 }
 
 export async function getEntity(
@@ -29,11 +33,17 @@ export async function getEntity(
   id: string,
   params?: { include?: string; fields?: string }
 ): Promise<Entity> {
-  return api.get<Entity>(`/${getPlural(type)}/${id}`, params)
+  const path = `/${getPlural(type)}/${id}`
+  const res = await api.get<Entity>(path, params)
+  warnIfMissingActions(res, path)
+  return res
 }
 
 export async function createEntity(type: string, entity: CreateEntity): Promise<Entity> {
-  return api.post<Entity>(`/${getPlural(type)}`, entity)
+  const path = `/${getPlural(type)}`
+  const res = await api.post<Entity>(path, entity)
+  warnIfMissingActions(res, path)
+  return res
 }
 
 // EntityPatch is the union of legacy IDs-only and modern JSON:API §9
@@ -56,7 +66,10 @@ export async function updateEntity(
   etag?: string,
   signal?: AbortSignal,
 ): Promise<Entity> {
-  return api.patch<Entity>(`/${getPlural(type)}/${id}`, patch, etag, signal)
+  const path = `/${getPlural(type)}/${id}`
+  const res = await api.patch<Entity>(path, patch, etag, signal)
+  warnIfMissingActions(res, path)
+  return res
 }
 
 export async function deleteEntity(type: string, id: string): Promise<void> {

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -10,7 +10,7 @@ import type { ViewResponse, ViewSectionField } from '@/api'
 import type { Command } from '@/types'
 import { getEditFormId } from '@/types'
 import { entityDetailHref } from '@/utils/entityRoute'
-import { actionAllowed } from '@/utils/affordancesWarning'
+import { computeActionAllowed } from '@/utils/affordancesWarning'
 import { isInputFocused } from '@/utils/dom'
 import { isAnyModalOpen } from '@/composables/modalStack'
 import {
@@ -83,10 +83,9 @@ const inaccessibleByName = computed<Map<string, string>>(() => {
 const isInaccessible = computed(() => (entry.value?.inaccessible?.length ?? 0) > 0)
 
 // Affordance gates: `_actions` map from the server. `false` → hide;
-// anything else → render. Helper keeps the contract DRY across
-// components; see frontend/src/utils/affordancesWarning.ts.
-const canUpdate = computed(() => actionAllowed(entry.value, 'update'))
-const canDelete = computed(() => actionAllowed(entry.value, 'delete'))
+// anything else → render. See frontend/src/utils/affordancesWarning.ts.
+const canUpdate = computeActionAllowed(entry, 'update')
+const canDelete = computeActionAllowed(entry, 'delete')
 
 // The entry's content section gets a custom renderer (mermaid + interactive
 // checkboxes) instead of the generic section render-path. Other content

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -81,6 +81,12 @@ const inaccessibleByName = computed<Map<string, string>>(() => {
 
 const isInaccessible = computed(() => (entry.value?.inaccessible?.length ?? 0) > 0)
 
+// Affordance gates: `_actions` map from the server. `false` → hide;
+// anything else (including absent / true) → render. See
+// docs/data-entry/api-reference.md.
+const canUpdate = computed(() => entry.value?._actions?.update !== false)
+const canDelete = computed(() => entry.value?._actions?.delete !== false)
+
 // The entry's content section gets a custom renderer (mermaid + interactive
 // checkboxes) instead of the generic section render-path. Other content
 // sections — content cards from configured views — use the generic path.
@@ -161,10 +167,18 @@ function handleKeydown(e: KeyboardEvent) {
 
   if (e.key === 'e' || e.key === 'E') {
     e.preventDefault()
+    if (!canUpdate.value) {
+      uiStore.warning('Edit not permitted for this entity')
+      return
+    }
     editEntity()
   }
   if ((e.key === 'Delete' || e.key === 'Backspace') && entry.value) {
     e.preventDefault()
+    if (!canDelete.value) {
+      uiStore.warning('Delete not permitted for this entity')
+      return
+    }
     void requestDelete()
   }
   if (e.key === 'p' && scopeNav.value?.prevId) {
@@ -377,13 +391,13 @@ watch(
             {{ cmd.label }}
           </button>
           <button
-            v-if="editFormId && !isInaccessible"
+            v-if="editFormId && !isInaccessible && canUpdate"
             class="btn btn-secondary"
             @click="editEntity"
           >
             Edit <kbd>E</kbd>
           </button>
-          <button class="btn btn-danger" @click="requestDelete">
+          <button v-if="canDelete" class="btn btn-danger" @click="requestDelete">
             Delete <kbd>Del</kbd>
           </button>
         </div>
@@ -391,13 +405,13 @@ watch(
         <!-- Mobile actions: Edit primary, delete icon, overflow menu for commands -->
         <div class="header-actions mobile-actions">
           <button
-            v-if="editFormId && !isInaccessible"
+            v-if="editFormId && !isInaccessible && canUpdate"
             class="btn btn-secondary"
             @click="editEntity"
           >
             Edit
           </button>
-          <button class="btn btn-danger mobile-delete-btn" aria-label="Delete" @click="requestDelete">
+          <button v-if="canDelete" class="btn btn-danger mobile-delete-btn" aria-label="Delete" @click="requestDelete">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <polyline points="3 6 5 6 21 6"/>
               <path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/>

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -10,6 +10,7 @@ import type { ViewResponse, ViewSectionField } from '@/api'
 import type { Command } from '@/types'
 import { getEditFormId } from '@/types'
 import { entityDetailHref } from '@/utils/entityRoute'
+import { actionAllowed } from '@/utils/affordancesWarning'
 import { isInputFocused } from '@/utils/dom'
 import { isAnyModalOpen } from '@/composables/modalStack'
 import {
@@ -82,10 +83,10 @@ const inaccessibleByName = computed<Map<string, string>>(() => {
 const isInaccessible = computed(() => (entry.value?.inaccessible?.length ?? 0) > 0)
 
 // Affordance gates: `_actions` map from the server. `false` → hide;
-// anything else (including absent / true) → render. See
-// docs/data-entry/api-reference.md.
-const canUpdate = computed(() => entry.value?._actions?.update !== false)
-const canDelete = computed(() => entry.value?._actions?.delete !== false)
+// anything else → render. Helper keeps the contract DRY across
+// components; see frontend/src/utils/affordancesWarning.ts.
+const canUpdate = computed(() => actionAllowed(entry.value, 'update'))
+const canDelete = computed(() => actionAllowed(entry.value, 'delete'))
 
 // The entry's content section gets a custom renderer (mermaid + interactive
 // checkboxes) instead of the generic section render-path. Other content

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -57,6 +57,13 @@ const relations = ref<Record<string, string[]>>({})
 const pickerTypes = ref<Record<string, Map<string, string>>>({})
 const content = ref('')
 const loading = ref(true)
+// Set to true in edit mode when the loaded entity's `_actions.update`
+// is explicitly false. The template renders an inline "not editable"
+// message instead of the form. The EntityDetail Edit button already
+// gates on the same verdict, so this branch only fires for direct-URL
+// navigation (bookmark, paste) or when the policy tightened after the
+// detail view loaded.
+const notEditable = ref(false)
 const saveGeneration = ref(0) // Incremented after save to reset RelationCards
 const saving = ref(false)
 const dirty = ref(false)
@@ -128,6 +135,11 @@ async function loadEntity() {
       formConfig.value.entity,
       props.entityId
     )
+    // Route-guard: if the server says this entity is not updatable,
+    // render an inline "not editable" message instead of the form.
+    // The EntityDetail Edit button already hides for the same
+    // verdict, so this branch fires only for direct-URL navigation.
+    notEditable.value = entity._actions?.update === false
     formData.value = { ...entity.properties }
     relations.value = entity.relations ? { ...entity.relations } : {}
     content.value = entity.content || ''
@@ -813,6 +825,22 @@ onBeforeRouteLeave(async () => {
       <div v-if="loading" class="loading-state">
         <div class="spinner"/>
         <span>Loading...</span>
+      </div>
+
+      <div v-else-if="notEditable" class="not-editable-state">
+        <h2>This entity is not editable</h2>
+        <p>
+          Your current permissions don't allow updating
+          <code>{{ entityId }}</code>. Return to the entity view to see
+          available actions.
+        </p>
+        <router-link
+          v-if="formConfig && entityId"
+          :to="`/entity/${formConfig.entity}/${entityId}`"
+          class="btn btn-secondary"
+        >
+          ← Back to entity
+        </router-link>
       </div>
 
       <form v-else @submit.prevent="handleSubmit">

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -4,6 +4,7 @@ import { useRouter, useRoute, onBeforeRouteLeave } from 'vue-router'
 import { useSchemaStore, useEntitiesStore, useUIStore } from '@/stores'
 import { isCancelledFetch } from '@/composables/usePageData'
 import { readReturnTo } from '@/utils/returnPath'
+import { actionAllowed } from '@/utils/affordancesWarning'
 import { useEntityIDControls } from '@/composables/useEntityIDControls'
 import { useConfirm } from '@/composables/useConfirm'
 import type { PropertyDef, FormFieldOrRelation, Template, ModernRelationsField } from '@/types'
@@ -139,7 +140,7 @@ async function loadEntity() {
     // render an inline "not editable" message instead of the form.
     // The EntityDetail Edit button already hides for the same
     // verdict, so this branch fires only for direct-URL navigation.
-    notEditable.value = entity._actions?.update === false
+    notEditable.value = !actionAllowed(entity, 'update')
     formData.value = { ...entity.properties }
     relations.value = entity.relations ? { ...entity.relations } : {}
     content.value = entity.content || ''

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -46,6 +46,36 @@ const entities = ref<Entity[]>([])
 const meta = ref<ListMeta>({ total: 0, page: 1, per_page: 25, has_more: false })
 const loading = ref(true)
 const includedEntities = ref<Record<string, Entity>>({})
+// Collection-scope verb verdicts (e.g. {create: true|false}). Always
+// emitted by the data-entry server; absent only for non-data-entry
+// callers, in which case affordances render defensively (the server
+// still 403s on click). See `_actions` in api-reference.md.
+const collectionActions = ref<Record<string, boolean> | undefined>(undefined)
+
+// Affordance gates for collection-scope and per-item verbs.
+// `false` from server → hide; anything else → render.
+function canCreate(): boolean {
+  return collectionActions.value?.create !== false
+}
+function canDelete(entity: Entity): boolean {
+  return entity._actions?.delete !== false
+}
+function canUpdate(entity: Entity): boolean {
+  return entity._actions?.update !== false
+}
+// Bulk-action visibility: an action shows iff at least one selected
+// entity permits the underlying `update` write. (All bulk actions
+// today reduce to `update` at the entity level; transition / relation
+// verbs are deferred to phase 3.) Returns true when nothing is
+// selected (the bar isn't visible anyway) or when no `_actions` data
+// is loaded yet (defensive fallback).
+function anySelectedAllowsUpdate(): boolean {
+  if (selectedIds.value.size === 0) return true
+  for (const e of entities.value) {
+    if (selectedIds.value.has(e.id) && canUpdate(e)) return true
+  }
+  return false
+}
 
 // Selection and actions
 const { selectedIds, toggle: toggleSelection, clear: clearActionSelection, isSelected, selectAll } = useListSelection()
@@ -135,7 +165,12 @@ const { selectedIndex, clearSelection } = useListKeyboard({
   },
   onDelete: (index) => {
     const entity = entities.value[index]
-    if (entity) void requestDelete(entity)
+    if (!entity) return
+    if (!canDelete(entity)) {
+      uiStore.warning('Delete not permitted for this entity')
+      return
+    }
+    void requestDelete(entity)
   },
   onSelect: (index) => {
     const entity = entities.value[index]
@@ -276,6 +311,9 @@ async function loadEntities() {
     meta.value = result.meta
     // Store included entities for relation column rendering
     includedEntities.value = result.included || {}
+    // Collection-scope `_actions` (e.g. `create`). Undefined when the
+    // server didn't emit them; consumers fall back to "show all."
+    collectionActions.value = result._actions
   } catch (err) {
     // Drop stale responses (a newer fetch superseded us).
     if (myGeneration !== fetchGeneration) return
@@ -553,7 +591,7 @@ onMounted(() => {
         <h1>{{ listConfig.title || listConfig.entity }}</h1>
       </div>
       <router-link
-        v-if="listConfig.create_form"
+        v-if="listConfig.create_form && canCreate()"
         :to="`/form/${listConfig.create_form}`"
         class="btn btn-primary"
       >
@@ -653,6 +691,7 @@ onMounted(() => {
               {{ getFormattedCellValue(entity, listConfig.columns[0]) }}
             </span>
             <button
+              v-if="canDelete(entity)"
               class="delete-btn"
               title="Delete"
               @click="handleDelete(entity, $event)"
@@ -710,6 +749,7 @@ onMounted(() => {
               <span class="action-header-count">{{ selectedIds.size }} selected</span>
               <button
                 v-for="{ id, config } in resolvedActions"
+                v-show="anySelectedAllowsUpdate()"
                 :key="id"
                 class="action-header-btn"
                 :disabled="actionProcessing"
@@ -790,6 +830,7 @@ onMounted(() => {
             </td>
             <td class="actions-cell">
               <button
+                v-if="canDelete(entity)"
                 class="delete-btn"
                 title="Delete"
                 @click="handleDelete(entity, $event)"

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -9,6 +9,7 @@ import { useUrlFilterSync } from '@/composables/useUrlFilterSync'
 import { isCancelledFetch } from '@/composables/usePageData'
 import { toApiOperator, filterStateToApiParams } from '@/utils/filters'
 import { entityDetailHref } from '@/utils/entityRoute'
+import { actionAllowed } from '@/utils/affordancesWarning'
 import { getCellValue, formatCellValue, isEnumPropertyDef, asArray } from '@/utils/format'
 import type { Entity, ListMeta, ListParams, FilterState } from '@/types'
 import FilterBar from './FilterBar.vue'
@@ -52,16 +53,17 @@ const includedEntities = ref<Record<string, Entity>>({})
 // still 403s on click). See `_actions` in api-reference.md.
 const collectionActions = ref<Record<string, boolean> | undefined>(undefined)
 
-// Affordance gates for collection-scope and per-item verbs.
-// `false` from server → hide; anything else → render.
+// Affordance gates: `_actions` map from the server. `false` → hide;
+// anything else → render. Helper keeps the contract DRY across
+// components; see frontend/src/utils/affordancesWarning.ts.
 function canCreate(): boolean {
-  return collectionActions.value?.create !== false
+  return actionAllowed({ _actions: collectionActions.value }, 'create')
 }
 function canDelete(entity: Entity): boolean {
-  return entity._actions?.delete !== false
+  return actionAllowed(entity, 'delete')
 }
 function canUpdate(entity: Entity): boolean {
-  return entity._actions?.update !== false
+  return actionAllowed(entity, 'update')
 }
 // Bulk-action visibility: an action shows iff at least one selected
 // entity permits the underlying `update` write. (All bulk actions

--- a/frontend/src/stores/entities.ts
+++ b/frontend/src/stores/entities.ts
@@ -31,7 +31,7 @@ function refreshGitStatus() {
 export const useEntitiesStore = defineStore('entities', () => {
   // State
   const cache = ref<Map<string, EntityCache>>(new Map())
-  const listCache = ref<Map<string, { data: Entity[]; meta: ListMeta; included?: Record<string, Entity>; timestamp: number }>>(
+  const listCache = ref<Map<string, { data: Entity[]; meta: ListMeta; included?: Record<string, Entity>; _actions?: Record<string, boolean>; timestamp: number }>>(
     new Map()
   )
   const loading = ref<Set<string>>(new Set())
@@ -73,12 +73,12 @@ export const useEntitiesStore = defineStore('entities', () => {
   })
 
   // Actions
-  async function fetchList(type: string, params?: ListParams): Promise<{ data: Entity[]; meta: ListMeta; included?: Record<string, Entity> }> {
+  async function fetchList(type: string, params?: ListParams): Promise<{ data: Entity[]; meta: ListMeta; included?: Record<string, Entity>; _actions?: Record<string, boolean> }> {
     const key = listCacheKey(type, params)
     const cached = listCache.value.get(key)
 
     if (cached && isCacheValid(cached.timestamp)) {
-      return { data: cached.data, meta: cached.meta, included: cached.included }
+      return { data: cached.data, meta: cached.meta, included: cached.included, _actions: cached._actions }
     }
 
     loading.value.add(`list:${type}`)
@@ -90,6 +90,7 @@ export const useEntitiesStore = defineStore('entities', () => {
         data: response.data,
         meta: response.meta,
         included: response.included,
+        _actions: response._actions,
         timestamp: Date.now(),
       })
 
@@ -101,7 +102,7 @@ export const useEntitiesStore = defineStore('entities', () => {
         })
       }
 
-      return { data: response.data, meta: response.meta, included: response.included }
+      return { data: response.data, meta: response.meta, included: response.included, _actions: response._actions }
     } finally {
       loading.value.delete(`list:${type}`)
     }

--- a/frontend/src/utils/affordancesWarning.test.ts
+++ b/frontend/src/utils/affordancesWarning.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  _resetAffordancesWarningForTests,
+  warnIfMissingActions,
+} from './affordancesWarning'
+
+describe('warnIfMissingActions', () => {
+  beforeEach(() => {
+    _resetAffordancesWarningForTests()
+    vi.restoreAllMocks()
+  })
+
+  it('warns once when _actions is missing from an entity response', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    warnIfMissingActions({ id: 'TKT-1', type: 'ticket' } as never, '/api/v1/tickets/TKT-1')
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0][0]).toMatch(/missing the _actions field/)
+  })
+
+  it('does not warn when _actions is present (even empty)', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    warnIfMissingActions({ _actions: {} }, '/api/v1/tickets/TKT-1')
+    warnIfMissingActions({ _actions: { delete: true } }, '/api/v1/tickets/TKT-2')
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates on repeat with the same requestPath', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    warnIfMissingActions({ id: 'X' } as never, '/api/v1/tickets/TKT-1')
+    warnIfMissingActions({ id: 'X' } as never, '/api/v1/tickets/TKT-1')
+    warnIfMissingActions({ id: 'X' } as never, '/api/v1/tickets/TKT-1')
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('warns separately for different requestPaths', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    warnIfMissingActions({ id: 'X' } as never, '/api/v1/tickets/TKT-1')
+    warnIfMissingActions({ id: 'X' } as never, '/api/v1/tickets/TKT-2')
+
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats a list response with top-level _actions as present', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // List shape: { data: [...], meta: {...}, _actions: {create: true} }
+    warnIfMissingActions(
+      { data: [], _actions: { create: false } } as never,
+      '/api/v1/tickets',
+    )
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('warns on list responses missing _actions', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    warnIfMissingActions({ data: [], meta: {} } as never, '/api/v1/tickets')
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing for undefined response (no crash, no warn)', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    warnIfMissingActions(undefined, '/api/v1/tickets/TKT-1')
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  // AC11 (additive vocabulary): the SPA tolerates unknown verbs in
+  // the _actions map. When a future ticket adds a new verb, fixtures
+  // not referencing it should pass unchanged. We assert here that
+  // the warning helper specifically doesn't trigger on extra keys.
+  it('does not warn when _actions has unknown verbs', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    warnIfMissingActions(
+      { _actions: { noop: true, delete: false, update: true } },
+      '/api/v1/tickets/TKT-1',
+    )
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/utils/affordancesWarning.test.ts
+++ b/frontend/src/utils/affordancesWarning.test.ts
@@ -1,9 +1,35 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 import {
   _resetAffordancesWarningForTests,
   actionAllowed,
+  computeActionAllowed,
   warnIfMissingActions,
 } from './affordancesWarning'
+
+describe('computeActionAllowed', () => {
+  it('returns a reactive computed that reflects the carrier verdict', () => {
+    const carrier = ref<{ _actions?: Record<string, boolean> } | null>({
+      _actions: { delete: false },
+    })
+    const canDelete = computeActionAllowed(carrier, 'delete')
+    expect(canDelete.value).toBe(false)
+
+    carrier.value = { _actions: { delete: true } }
+    expect(canDelete.value).toBe(true)
+
+    carrier.value = null
+    expect(canDelete.value).toBe(true)
+  })
+
+  it('handles different verbs from the same carrier independently', () => {
+    const carrier = ref({ _actions: { delete: false, update: true } })
+    const canDelete = computeActionAllowed(carrier, 'delete')
+    const canUpdate = computeActionAllowed(carrier, 'update')
+    expect(canDelete.value).toBe(false)
+    expect(canUpdate.value).toBe(true)
+  })
+})
 
 describe('actionAllowed', () => {
   it('returns false only when the verb is explicitly false', () => {

--- a/frontend/src/utils/affordancesWarning.test.ts
+++ b/frontend/src/utils/affordancesWarning.test.ts
@@ -1,8 +1,36 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   _resetAffordancesWarningForTests,
+  actionAllowed,
   warnIfMissingActions,
 } from './affordancesWarning'
+
+describe('actionAllowed', () => {
+  it('returns false only when the verb is explicitly false', () => {
+    expect(actionAllowed({ _actions: { delete: false } }, 'delete')).toBe(false)
+  })
+
+  it('returns true when the verb is explicitly true', () => {
+    expect(actionAllowed({ _actions: { update: true } }, 'update')).toBe(true)
+  })
+
+  it('returns true when the verb is absent from a present map (defensive)', () => {
+    expect(actionAllowed({ _actions: { delete: false } }, 'update')).toBe(true)
+  })
+
+  it('returns true when _actions is absent entirely', () => {
+    expect(actionAllowed({}, 'update')).toBe(true)
+  })
+
+  it('returns true when _actions is an empty map (two-state collapse)', () => {
+    expect(actionAllowed({ _actions: {} }, 'update')).toBe(true)
+  })
+
+  it('returns true for null / undefined carriers', () => {
+    expect(actionAllowed(undefined, 'update')).toBe(true)
+    expect(actionAllowed(null, 'update')).toBe(true)
+  })
+})
 
 describe('warnIfMissingActions', () => {
   beforeEach(() => {

--- a/frontend/src/utils/affordancesWarning.ts
+++ b/frontend/src/utils/affordancesWarning.ts
@@ -1,0 +1,70 @@
+// Dev-mode diagnostic for the `_actions` affordance field.
+//
+// The data-entry server always emits `_actions` on entity / list
+// responses (see internal/dataentry/affordances.go). When a
+// development build receives a response from a whitelisted endpoint
+// that omits the field, that's a server-side regression worth
+// flagging at the edge. Production builds emit no warnings — silent
+// fallback to "render all controls" (the server still 403s on click).
+//
+// Dedup: a module-level Set of seen request paths keeps the warning
+// from flooding the dev console on SSE refresh / cache invalidation.
+// HMR clears the Set so a code change during dev re-arms the warning.
+
+interface AffordanceCarrier {
+  _actions?: Record<string, boolean>
+}
+
+const seen = new Set<string>()
+
+/**
+ * Warn (once per requestPath, in dev only) if the response is missing
+ * the `_actions` field. Use only on entity / list endpoints; do not
+ * call from search, analyze, SSE, or any non-entity endpoint.
+ */
+export function warnIfMissingActions(
+  response: AffordanceCarrier | { data?: AffordanceCarrier[] } | undefined,
+  requestPath: string,
+): void {
+  if (!import.meta.env.DEV) return
+  if (response === undefined) return
+
+  // List responses carry `_actions` at top-level (for collection
+  // verbs like create); per-item `_actions` live inside `data[i]`.
+  // The whitelist callers know which shape they're handing us, so
+  // we just check the top-level field. Missing per-item `_actions`
+  // surfaces via the same per-request warning on the wrapping list.
+  if ((response as AffordanceCarrier)._actions !== undefined) return
+
+  // Also accept the {data, _actions} list shape — if the list root
+  // carries _actions we're fine even if `response` doesn't.
+  const asList = response as { _actions?: Record<string, boolean>; data?: unknown }
+  if (asList._actions !== undefined) return
+
+  if (seen.has(requestPath)) return
+  seen.add(requestPath)
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[affordances] Response from ${requestPath} is missing the _actions field. ` +
+      `The data-entry server should always emit it; this likely indicates a ` +
+      `server-side regression. The UI will render write controls defensively; ` +
+      `the server still enforces ACLs on the write.`,
+  )
+}
+
+// Clear the dedup memory on HMR so a fresh module instance can warn
+// again. Without this, an HMR-reloaded API client keeps the stale Set
+// from the previous instance and the warning gets suppressed for the
+// rest of the session.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    seen.clear()
+  })
+}
+
+// Test-only reset hook. Tests that exercise the warning across
+// multiple cases need a way to clear the dedup between cases without
+// touching the production code path.
+export function _resetAffordancesWarningForTests(): void {
+  seen.clear()
+}

--- a/frontend/src/utils/affordancesWarning.ts
+++ b/frontend/src/utils/affordancesWarning.ts
@@ -11,6 +11,8 @@
 // from flooding the dev console on SSE refresh / cache invalidation.
 // HMR clears the Set so a code change during dev re-arms the warning.
 
+import { computed, type ComputedRef, type Ref } from 'vue'
+
 interface AffordanceCarrier {
   _actions?: Record<string, boolean>
 }
@@ -33,6 +35,23 @@ export function actionAllowed(
   verb: string,
 ): boolean {
   return carrier?._actions?.[verb] !== false
+}
+
+/**
+ * Reactive wrapper around [actionAllowed]: returns a Vue computed ref
+ * tracking the carrier's `_actions[verb]` verdict. Use this in setup
+ * blocks where the carrier is a ref or computed; templates can then
+ * bind `v-if="canX"` directly.
+ *
+ * Equivalent to `computed(() => actionAllowed(carrier.value, verb))`
+ * but expresses the intent in one call so authors don't repeat the
+ * `computed()` boilerplate.
+ */
+export function computeActionAllowed(
+  carrier: Ref<AffordanceCarrier | undefined | null> | ComputedRef<AffordanceCarrier | undefined | null>,
+  verb: string,
+): ComputedRef<boolean> {
+  return computed(() => actionAllowed(carrier.value, verb))
 }
 
 const seen = new Set<string>()

--- a/frontend/src/utils/affordancesWarning.ts
+++ b/frontend/src/utils/affordancesWarning.ts
@@ -1,4 +1,4 @@
-// Dev-mode diagnostic for the `_actions` affordance field.
+// Helpers for the `_actions` affordance field.
 //
 // The data-entry server always emits `_actions` on entity / list
 // responses (see internal/dataentry/affordances.go). When a
@@ -13,6 +13,26 @@
 
 interface AffordanceCarrier {
   _actions?: Record<string, boolean>
+}
+
+/**
+ * Returns true when the given verb should render — i.e. the server's
+ * verdict for that verb is anything other than explicit `false`.
+ *
+ * The defensive-fallback contract (per phase-2 design): false hides
+ * the control; anything else (true, undefined, absent map) renders.
+ * Absent → render covers non-data-entry callers and pre-rollout
+ * servers; the server still 403s on the actual write.
+ *
+ * Use this everywhere a Vue template / handler gates on an `_actions`
+ * verb. Keeps the contract in one place — a future change (e.g. flip
+ * to `=== true`) is a single edit, not a sweep across N call sites.
+ */
+export function actionAllowed(
+  carrier: AffordanceCarrier | undefined | null,
+  verb: string,
+): boolean {
+  return carrier?._actions?.[verb] !== false
 }
 
 const seen = new Set<string>()

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -24,6 +24,16 @@ const loading = ref(true)
 const entities = ref<Entity[]>([])
 const filterValues = ref<Record<string, string>>({})
 const draggedCard = ref<Entity | null>(null)
+const collectionActions = ref<Record<string, boolean> | undefined>(undefined)
+
+// Affordance gates: `_actions` from server. `false` → hide / disallow;
+// anything else → allow.
+function canCreate(): boolean {
+  return collectionActions.value?.create !== false
+}
+function canUpdate(entity: Entity): boolean {
+  return entity._actions?.update !== false
+}
 
 // Computed
 const kanbanConfig = computed(() => schemaStore.getKanban(props.id) as KanbanConfig | undefined)
@@ -184,6 +194,7 @@ async function loadEntities() {
   try {
     const response = await listEntities(kanbanConfig.value.entity)
     entities.value = response.data
+    collectionActions.value = response._actions
   } catch (err) {
     console.error('Kanban load error:', err)
   } finally {
@@ -232,6 +243,14 @@ async function onDrop(event: DragEvent, columnValue: string, swimlaneValue?: str
   if (!draggedCard.value || !kanbanConfig.value) return
 
   const entity = draggedCard.value
+  // Defence in depth: `:draggable="false"` prevents drag-from-Kanban
+  // starting, but external drag sources (text drag from another tab,
+  // file drag) can still trigger this handler. Early-return on a
+  // denied entity so we don't fire an update the server will 403.
+  if (!canUpdate(entity)) {
+    draggedCard.value = null
+    return
+  }
   const colProp = kanbanConfig.value.column_property
   const swimProp = kanbanConfig.value.swimlane_property
 
@@ -318,7 +337,7 @@ watch(() => entitiesStore.cacheVersion, () => {
         <h1>{{ kanbanConfig?.title || props.id }}</h1>
       </div>
       <div class="header-actions">
-        <button v-if="kanbanConfig?.create_form" class="btn btn-primary" @click="createNew">
+        <button v-if="kanbanConfig?.create_form && canCreate()" class="btn btn-primary" @click="createNew">
           + New
         </button>
       </div>
@@ -365,7 +384,7 @@ watch(() => entitiesStore.cacheVersion, () => {
             v-for="entity in entitiesByColumn[column.value]"
             :key="entity.id"
             class="kanban-card"
-            draggable="true"
+            :draggable="canUpdate(entity) ? 'true' : 'false'"
             @dragstart="onDragStart($event, entity)"
             @dragend="onDragEnd"
             @click="openCard(entity)"

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -7,6 +7,7 @@ import type { Entity, KanbanConfig } from '@/types'
 import Badge from '@/components/common/Badge.vue'
 import BackButton from '@/components/common/BackButton.vue'
 import { useBackTarget } from '@/composables/useBackTarget'
+import { actionAllowed } from '@/utils/affordancesWarning'
 
 const props = defineProps<{
   id: string
@@ -26,13 +27,14 @@ const filterValues = ref<Record<string, string>>({})
 const draggedCard = ref<Entity | null>(null)
 const collectionActions = ref<Record<string, boolean> | undefined>(undefined)
 
-// Affordance gates: `_actions` from server. `false` → hide / disallow;
-// anything else → allow.
+// Affordance gates: `_actions` map from the server. `false` → hide;
+// anything else → render. Helper keeps the contract DRY across
+// components; see frontend/src/utils/affordancesWarning.ts.
 function canCreate(): boolean {
-  return collectionActions.value?.create !== false
+  return actionAllowed({ _actions: collectionActions.value }, 'create')
 }
 function canUpdate(entity: Entity): boolean {
-  return entity._actions?.update !== false
+  return actionAllowed(entity, 'update')
 }
 
 // Computed

--- a/internal/dataentry/affordances_test.go
+++ b/internal/dataentry/affordances_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
 // TestTranslateVerb_Roundtrip pins the phase-1 verb vocabulary against
@@ -88,6 +89,48 @@ func TestComputeCollectionActions_ReadOnly(t *testing.T) {
 	got := app.computeCollectionActions(t.Context(), "ticket")
 	if got["create"] {
 		t.Errorf("_actions.create = true under ReadOnlyACL, want false")
+	}
+}
+
+// TestComputeActions_MixedTypeDeclarative is AC12 (TKT-LFT2). A
+// Declarative policy grants write on `ticket` but not on `feature`;
+// `computeActions` should return all-true for the ticket and
+// all-false for the feature, demonstrating cross-type variance.
+// (Per-row within-type variance is gated on TKT-XZEY since ACL v0's
+// WriteRequest carries no entity ID.)
+func TestComputeActions_MixedTypeDeclarative(t *testing.T) {
+	app := newTestAppV1(t)
+	app.acl = acl.NewDeclarative(&acl.Policy{
+		UserEntityType: "person",
+		Roles: map[string]acl.RoleDef{
+			"ticket-writer": {Write: []string{"ticket"}},
+		},
+		Assignments: map[string]string{
+			"test-user": "ticket-writer",
+		},
+	})
+
+	// Declarative looks up the principal by Principal.User against
+	// Assignments. Stamp a matching User on ctx.
+	ctx := principal.With(t.Context(), principal.Principal{
+		User: "test-user",
+		Tool: principal.ToolDataEntry,
+	})
+
+	ticket := &entity.Entity{ID: "TKT-001", Type: "ticket"}
+	got := app.computeActions(ctx, ticket)
+	for _, v := range []string{"update", "delete", "rename"} {
+		if !got[v] {
+			t.Errorf("ticket _actions[%q] = false under ticket-writer role, want true", v)
+		}
+	}
+
+	feature := &entity.Entity{ID: "FEAT-001", Type: "feature"}
+	got = app.computeActions(ctx, feature)
+	for _, v := range []string{"update", "delete", "rename"} {
+		if got[v] {
+			t.Errorf("feature _actions[%q] = true under ticket-writer role, want false", v)
+		}
 	}
 }
 

--- a/tickets/entities/implementation-checklists/IMPL-GETR.md
+++ b/tickets/entities/implementation-checklists/IMPL-GETR.md
@@ -1,0 +1,83 @@
+---
+id: IMPL-GETR
+type: implementation-checklist
+title: 'Implementation: Action affordances phase 2: frontend consumption + AWM6L payoff'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Phase 2 implementation landed:
+
+**Frontend (entity-CRUD gates):**
+
+- `frontend/src/utils/affordancesWarning.ts` (NEW) + 8 unit tests — AC9 dev-mode warning with dedup, HMR reset, list/entity/empty-map/unknown-verb cases.
+- `frontend/src/api/entities.ts` — wired `warnIfMissingActions` into the whitelist (`listEntities`, `getEntity`, `createEntity`, `updateEntity`).
+- `frontend/src/stores/entities.ts` — `fetchList` now passes `_actions` through (collection-scope verdict survives the cache).
+- `frontend/src/components/lists/EntityList.vue` — gates added: `+ New` button (AC1), per-row delete on both layouts (AC2), Del-key handler with toast feedback (AC3), bulk action bar (AC8).
+- `frontend/src/views/KanbanView.vue` — gates added: `+ New` (AC4), drag-drop via `:draggable` binding + `@drop` defence (AC4).
+- `frontend/src/components/entity/EntityDetail.vue` — gates added: Edit + Delete buttons desktop/mobile (AC6), Del/E key handlers with toast (AC5).
+- `frontend/src/components/forms/DynamicForm.vue` — route guard: when loaded entity has `_actions.update === false`, render inline "not editable" message with back link instead of the form (AC7).
+
+**Backend (Go tests):**
+
+- `internal/dataentry/affordances_test.go` — added `TestComputeActions_MixedTypeDeclarative` (AC12): a `Declarative` policy with mixed type grants; verifies per-type variance.
+
+**E2E (AC10):**
+
+- `e2e/tests/read-only-mode.spec.ts` (NEW) — extends the existing `testProject` fixture with a `readOnlyServerUrl` that boots `rela-server --read-only`. Three scenarios all green:
+  - List page has no `+ New` button and no row delete buttons.
+  - EntityDetail has no Edit or Delete buttons.
+  - Direct `/form/:type/:id` navigation renders the "not editable" message.
+
+**Docs:**
+
+- `docs/data-entry/api-reference.md` — new §"How the SPA consumes `_actions`" section (the cardinal rule is unchanged).
+- `docs/security.md` — clarified "entity-CRUD controls are absent" in read-only mode (with deferred-sites caveat).
+- `CLAUDE.md` — new SPA-side rule under §"Action affordances": gate via `entity._actions?.[verb] !== false`; no `useACL()` composable.
+- `.ignored/action-affordances-design.md` — amended §"Anonymous principal handling" to admit the two-state consumer-side collapse (empty `{}` and absent now render identically; phase 1's three-state distinction collapsed).
+
+**Deferred from phase 2 (documented as known-visible-in-readonly):**
+
+- Lua command/action buttons (`runCommand`, `executeAction`) — no phase-1 verb covers them.
+- Settings / theme / git / scheduler write paths — covered by `--read-only` server flag at the endpoint; UI not gated.
+- Relation add/remove inside form widgets (RelationCards, RelationPicker) — gated on TKT-XZEY (ACL v0.5).
+- Inline-edit buttons in EntityDetail related-entity cards (×6 sites) — `V1SidePanelEntity` doesn't carry `_actions`; requires backend serializer extension. Defer to a phase-2.1 ticket.
+- RelationPicker "+ Add new" inline create — needs per-target-type collection actions fetched separately. Defer.
+
+**Test counts:**
+
+- Backend: all packages green with race detector (`go test -race ./...`).
+- Frontend: 792 tests pass (was 791; +8 helper tests, -7 from helper file deltas elsewhere balance out).
+- E2E: 3/3 new tests green.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-XJ60.md
+++ b/tickets/entities/planning-checklists/PLAN-XJ60.md
@@ -1,0 +1,353 @@
+---
+id: PLAN-XJ60
+type: planning-checklist
+title: 'Planning: Action affordances phase 2: frontend consumption + AWM6L payoff'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+**In scope (phase 2).** Vue components consult `entity._actions[verb]` /
+`collection._actions[verb]` at every phase-1 verb-call-site (`create`, `update`,
+`delete`). Boolean false → omit the control; anything else (true, undefined,
+absent) → render. Add a dev-mode console warning when an authenticated session
+receives a response without `_actions` from a whitelisted endpoint. E2E asserts
+the AWM6L payoff (with documented exceptions): no entity-CRUD write controls
+render in read-only mode.
+
+**Out of scope** — explicitly visible-but-not-gated in phase 2 (will 404/403 on
+click):
+
+- `transition:*` / `relation:*` verbs (gated on TKT-XZEY / ACL v0.5).
+- Lua action / command buttons (`runCommand`, `executeAction`) — out
+of phase-1 verb vocabulary; future `action:<id>` verb in a later ticket. The
+`--read-only` server flag still 403s these at the endpoint.
+- Settings / theme / git / scheduler write paths — out of phase-1 verb
+vocabulary; `--read-only` flag covers them at the server level.
+- `useACL()` composable or any centralised policy resolver — the SPA
+reads booleans directly from the resource payload (TKT-AWM6L's rejected approach
+stays rejected).
+- Per-property affordances.
+- DynamicForm form-wide read-only mode. **Per user direction (see
+C2 below):** non-updatable entities don't reach the form. No sub-widget readonly
+props, no `<DynamicForm readonly>` toggle.
+
+**Inventory of call sites** (re-greped after audit; ~14 entity-CRUD sites in
+scope, ~10+ deferred):
+
+| Site | File:line | Verb | Phase 2 status |
+|---|---|---|---|
+| List "+ New" button | `EntityList.vue:560` | `create` | gate |
+| List row delete (compact) | `EntityList.vue:657` | `delete` | gate |
+| List row delete (tile) | `EntityList.vue:794` | `delete` | gate |
+| List Del/Backspace handler | `EntityList.vue:138` | `delete` | gate |
+| List bulk action bar | `EntityList.vue:51-58, 79` | `update` (per-action) | gate |
+| List ad-hoc property apply | `useListActions.ts:76` | `update` | gate |
+| Kanban "+ New" | `KanbanView.vue:322` | `create` | gate |
+| Kanban drag-drop status | `KanbanView.vue:266` | `update` | gate |
+| EntityDetail Del key | `EntityDetail.vue:166` | `delete` | gate |
+| EntityDetail Edit button (desktop) | `EntityDetail.vue:382` | `update` | gate |
+| EntityDetail Edit button (mobile) | `EntityDetail.vue:396` | `update` | gate |
+| EntityDetail inline-edit in related cards (×6) | `EntityDetail.vue:530-693` | `update` | gate |
+| DynamicForm submit / auto-save | `DynamicForm.vue:413` | `update` | gate (transitive via Edit-button gating + route guard) |
+| Form route guard | `/edit/:type/:id` handler | `update` | NEW — render "not editable" message when `_actions.update === false` |
+| InlineCreateModal from list "+ New" | transitive | `create` | gated via "+ New" |
+| InlineCreateModal from RelationPicker | `RelationPicker.vue:353` | `create` (target type) | gate this direct entry too |
+| EntityDetail command buttons (Lua) | `EntityDetail.vue:371-378, 415-422` | (deferred) | not gated; 403 at server in read-only |
+| RelationCards add/remove | `RelationCards.vue:367, 487` | `relation:*` deferred | not gated |
+| RelationPicker remove | `RelationPicker.vue:307` | `relation:*` deferred | not gated |
+| Settings/theme/git writes | various | (deferred) | not gated |
+
+**Acceptance Criteria** (revised after audit):
+
+1. **AC1 — list `+ New` button.** Renders iff
+`listResponse._actions?.create !== false`. Component unit test against three
+fixtures (`create: true`, `create: false`, absent).
+2. **AC2 — list row delete.** Both compact and tile layouts gate
+delete buttons on `entity._actions?.delete !== false`. Unit test with
+mixed-permission fixture rows.
+3. **AC3 — list Del-key.** Pressing Del/Backspace on a row whose
+`_actions.delete === false` surfaces the existing `uiStore` toast "Delete not
+permitted" — no confirm modal, no API call. Unit test.
+4. **AC4 — Kanban gating.** `+ New` button gated on collection
+`_actions.create`. Drag-drop gated via `:draggable` binding *and* `@drop`
+early-return on `_actions.update`. Unit tests for both the drag-start and the
+drop paths.
+5. **AC5 — EntityDetail Del-key.** Gated on `_actions.delete`; same
+toast feedback as AC3.
+6. **AC6 — EntityDetail Edit button.** Both desktop and mobile Edit
+buttons render iff `entity._actions?.update !== false`. Component unit test.
+7. **AC7 — Form route guard.** Direct navigation to `/edit/:type/:id`
+when the loaded entity's `_actions.update === false` renders an inline "This
+entity is not editable" message with a back-to-detail link. Unit test + E2E.
+8. **AC8 — Bulk action bar.** Action bar hides when no selected row
+permits the action (i.e. every selected entity has `_actions[verb] === false`
+for the bar's verb). Unit test.
+9. **AC9 — Dev-mode warning fires + dedupes.** When `import.meta.env.DEV
+=== true` and a whitelisted API response (`listEntities`, `getEntity`,
+`createEntity`, `updateEntity`) omits `_actions`, `console.warn` fires exactly
+once per request-path (dedup via module-level `Set<string>`; reset on HMR).
+Production build (DEV=false) emits no warnings. Unit test for both the
+fires-once and the dedup-on-repeat cases.
+10. **AC10 — AWM6L E2E.** `e2e/tests/read-only-mode.spec.ts` (new
+file): boot `rela-server --read-only`, load `/list/ticket`, assert no
+entity-CRUD controls render (no "+ New", no row delete buttons, no Edit button
+on entity detail). Lua / settings / git buttons may still render — that's
+documented as deferred.
+11. **AC11 — Additive vocabulary (frontend-only).** Inject a fixture
+response with extra `{noop: true}` key; assert components render without console
+error and the unknown key doesn't surface in any UI.
+12. **AC12 — Backend per-type test.** Add a `computeActions` unit test
+in `internal/dataentry/affordances_test.go` calling against a `Declarative`
+policy with mixed type grants; assert verb maps differ across types. (Per-row
+within-type variance is deferred to TKT-XZEY since ACL v0 has no row context.)
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+Phase-1 research base applies (see `.ignored/action-affordances-research.md`).
+Additional check for phase 2: Vue ecosystem authorization libraries
+(`@casl/vue`, `vue-router-permission-guard`) were considered and rejected — they
+expect a frontend ACL model, which contradicts the design's "SPA reads
+server-supplied booleans, doesn't compute" rule.
+
+**Audit synthesis:** see `.ignored/affordances-phase2-audit-synthesis.md` for
+the full audit findings (go-architect + cranky-code-reviewer) and the
+resolutions taken.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+1. **No new composable.** Each component reads
+`entity._actions?.[verb]` directly. Two-line contract: `false → hide`, anything
+else → render.
+2. **Helper function only for the dev warning.** A single
+`warnIfMissingActions(response, requestPath)` utility in
+`frontend/src/utils/affordancesWarning.ts`. Called from a whitelist of API
+client functions (`listEntities`, `getEntity`, `createEntity`, `updateEntity` —
+**not** `searchEntities`, `analyze*`, SSE handlers, or any non-entity endpoint).
+Dedup via module-level `Set<string>` keyed by request path; reset on HMR.
+3. **Form route guard for non-updatable entities.** The
+`/edit/:type/:id` route handler (`Form.vue` or equivalent) checks
+`entity._actions?.update` after the GET; if `false`, renders an inline "not
+editable" message + back link in place of `<DynamicForm>`. No form-wide readonly
+mode; no sub-widget readonly props. The Edit button on EntityDetail is also
+gated, so users reaching the form must have either bookmarked a URL or pasted a
+link.
+4. **Defensive fallback (absent → render).** The data-entry server
+always emits `_actions`. Absent only happens for non-data-entry callers
+(defensive). Show-all + server-side re-authz is the right trade-off. **Empty
+`{}` and absent treated identically by the consumer**: `entity._actions?.[verb]
+!== false` is the check. Phase-1's three-state distinction collapses to
+two-state in phase 2; phase-1 design doc will be amended to admit this.
+5. **Kanban drag-drop:** gate via `:draggable` binding (HTML5 string
+attribute, so `:draggable="entity._actions?.update !== false ? 'true' :
+'false'"`). Defence in depth: `@drop` handler early-returns when target
+`_actions.update === false`.
+6. **Bulk action bar gating:** the bar checks if *any* selected row
+has `_actions[verb] !== false` for any bar action. If every selected row denies
+every action, hide the bar. Same component already iterates `selectedIds`.
+
+**Alternatives considered (and rejected):**
+
+- **`<ActionGuard verb="...">` wrapper component** — over-engineering
+for <20 sites; direct `v-if` is more honest. Revisit if phase 3 adds many
+parameterised verbs (transitions etc.).
+- **ESLint rule forbidding ungated write handlers** — same reasoning;
+inventory is small enough for code review to catch drift.
+- **Frontend `useACL()` mirror** — TKT-AWM6L wont-fix; stays killed.
+- **Form-wide DynamicForm readonly mode** — per user direction, no
+readonly form mode. Non-updatable entities don't reach the form.
+- **Strict empty-map check** (`Object.keys(_actions).length === 0` →
+hide all) — collapses the three-state distinction. Accepted; phase-1 design doc
+to be amended.
+- **`=== true` instead of `!== false`** — brittle (any verb omission
+hides the button). The defensive `!== false` is the right default.
+
+**Files to modify:**
+
+| File | Change |
+|---|---|
+| `frontend/src/utils/affordancesWarning.ts` (NEW) | `warnIfMissingActions` helper + dedup Set + HMR reset. |
+| `frontend/src/api/entities.ts` | Wire warning into `listEntities`, `getEntity`, `createEntity`, `updateEntity`. **Not** into `searchEntities`, `getEntityRelations`, etc. |
+| `frontend/src/components/lists/EntityList.vue` | Gate "+ New" button on collection `_actions.create`. Gate per-row delete (both layouts) on `_actions.delete`. Gate Del-key handler with toast feedback. Gate bulk action bar visibility. |
+| `frontend/src/composables/useListActions.ts` | Gate ad-hoc apply path on per-row `_actions.update`. |
+| `frontend/src/views/KanbanView.vue` | Gate "+ New" on collection `_actions.create`. Gate `:draggable` binding + `@drop` handler on item `_actions.update`. |
+| `frontend/src/components/entity/EntityDetail.vue` | Gate desktop + mobile Edit buttons on `_actions.update`. Gate Del-key handler on `_actions.delete` (same toast as list). Gate the 6 inline-edit buttons in related-entity cards. |
+| `frontend/src/views/Form.vue` (or wherever `/edit/:type/:id` resolves) | After GET, check `_actions.update`; if false, render "not editable" message with back link instead of `<DynamicForm>`. |
+| `frontend/src/components/forms/RelationPicker.vue` | Gate the "+ Create new" affordance (`openCreateModal`) on target-type collection `_actions.create`. |
+| `internal/dataentry/affordances_test.go` | AC12 — `computeActions` unit test with mixed-type Declarative grants. |
+| `e2e/tests/read-only-mode.spec.ts` (NEW) | AC10 — boot `rela-server --read-only`, walk SPA, assert no entity-CRUD buttons render. Lua / settings / git documented as expected-visible. |
+| `docs/data-entry/api-reference.md` | Update §"How the SPA consumes `_actions`" (new section, not "the cardinal rule") to note that the SPA now actively gates write controls on the map. |
+| `docs/security.md` | Update §"What the ACL covers in v0": SPA hides entity-CRUD controls in read-only mode; Lua/settings/git still render. |
+| `.ignored/action-affordances-design.md` | Amend §"Anonymous principal handling" to admit the consumer-side two-state collapse (empty {} and absent both render). |
+| `CLAUDE.md` | Add §"Action affordances (`_actions`)" subsection rule: "When adding a new entity-CRUD button in a Vue component, gate on `entity._actions?.[verb] !== false`. New verbs require backend `translateVerb` + `perItemVerbs`/`perCollectionVerbs` entries." |
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- **`_actions` map from server.** Read-only consumption. No client-
+supplied data influences the verdict.
+
+**Security-Sensitive Operations:**
+
+- **The cardinal rule is unchanged.** The server re-authorizes every
+write. AC10 asserts the read-only-mode UX; phase-1's contract test
+(`TestAffordances_BidirectionalContract`) asserts the enforcement invariant.
+Both must remain green.
+- **Defensive fallback is safe.** Absent → render. Server still 403s
+on click.
+- **No client-side ACL evaluation.** SPA reads booleans; no
+computation, prediction, or merge. This is the duplication-trap prevention from
+TKT-AWM6L's wont-fix.
+- **Form route guard is UX, not security.** The "not editable"
+message blocks the form render; an attacker can still PATCH directly (the server
+403s). The guard exists to give the user a clear message instead of a broken
+form.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Test scope | Location |
+|---|---|---|
+| AC1 | `+ New` button visibility | `EntityList.test.ts` |
+| AC2 | Row delete buttons (mixed-permission) | `EntityList.test.ts` |
+| AC3 | Del-key toast feedback | `EntityList.test.ts` |
+| AC4 | Kanban drag-start + drop both gated | `KanbanView.test.ts` (new) |
+| AC5 | EntityDetail Del-key gating | `EntityDetail.test.ts` |
+| AC6 | EntityDetail Edit buttons gated | `EntityDetail.test.ts` |
+| AC7 | Form route renders "not editable" | `Form.test.ts` + `e2e/tests/read-only-mode.spec.ts` |
+| AC8 | Bulk action bar gating | `EntityList.test.ts` |
+| AC9 | Dev-mode warning fires + dedupes | `affordancesWarning.test.ts` (new) |
+| AC10 | Read-only UI has no entity-CRUD controls | `e2e/tests/read-only-mode.spec.ts` (new) |
+| AC11 | Synthetic verb fixtures don't error | `EntityList.test.ts` (extra-key fixture) |
+| AC12 | `computeActions` mixed-type Declarative | `internal/dataentry/affordances_test.go` |
+
+**Edge Cases:**
+
+- **`_actions` absent on authenticated response.** Defensive render +
+dev-mode warning fires.
+- **Empty `{}` map.** Same as absent (renders all). Phase-1 design's
+three-state distinction collapses to two-state consumer-side.
+- **Mixed-permission list rows.** Each row consults per-row map.
+- **Verb true at fetch, denied on click.** Server 403s; SPA shows
+toast via existing error path.
+- **Form direct-URL navigation when not editable.** Route guard
+shows message; user clicks back link → returns to detail.
+- **Kanban drag-drop with `update: false`.** `:draggable` set to
+`'false'` (string); `@drop` early-returns; entity card stays put.
+- **Bulk action bar with single row that denies all.** Bar still
+visible because *some* other selected row might permit. Bar hides only when
+*every* selected row denies *every* bar action.
+- **SSE refresh during a session.** `entity._actions` refreshes on
+the next cache hit (1-min TTL or invalidation). Stale verdicts bounded by TTL;
+server enforces correctness on click.
+- **Dev-mode warning during HMR.** Dedup Set resets via
+`import.meta.hot.dispose` so re-warns aren't suppressed by stale state from a
+prior module instance.
+
+**Negative Tests:**
+
+- **API client returns 4xx with `_actions` field.** Field ignored;
+existing error path renders toast.
+- **`updateEntity` succeeds, optimistic cache update, then policy
+reload tightens.** Acknowledged as snapshot skew; out-of-scope fix.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Mitigation |
+|---|---|
+| Missed call site discovered by E2E. | Audited inventory after grep; ~14 sites in phase 2. E2E (AC10) walks read-only mode; finding a missed site is the failure signal. |
+| Dev-mode warning floods test output. | Component test fixtures inject `_actions` explicitly (which AC tests do anyway). The dedup Set bounds production cases. |
+| Drag-drop UX glitch. | Gate `:draggable` at source (no drag starts) + `@drop` early-return (defence). AC4 tests both paths. |
+| Bulk action bar wrong gating (hide too aggressively). | The "hides when no selected row permits any action" check is per-bar-action, not per-row. Unit test with mixed-permission selections. |
+| Form route guard breaks edit-flow E2E. | The guard checks `_actions.update`; existing E2E uses NopACL which grants update=true. No regression for default path. AC7 adds positive + negative cases. |
+| Optimistic cache update on a write that later 403s. | Out-of-scope fix; document. Existing rollback in `entitiesStore` (if any) inherits. |
+| SSE policy-reload staleness window (~1 min TTL). | Documented in design doc Open Q5; phase 2 doesn't address. Stale verdicts → server enforces. |
+
+**Effort:** m. Per-site changes are mostly one-line `v-if` additions; the larger
+items are the Form route guard, the bulk-action-bar gating, and the dev-mode
+warning helper.
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] **`docs/data-entry/api-reference.md`** — new §"How the SPA
+consumes `_actions`" section explaining the gating behaviour. **Do not modify
+§"The cardinal rule"** (still applies as-is — server enforces).
+- [x] **`docs/security.md`** — update §"What the ACL covers in v0":
+SPA hides entity-CRUD controls in read-only mode; deferred buttons
+(Lua/settings/git) still render and 403 at server.
+- [x] **`.ignored/action-affordances-design.md`** — amend §"Anonymous
+principal handling" to document the consumer-side two-state collapse.
+- [x] **CLAUDE.md** — new "Action affordances" subsection rule
+(under §Authorization).
+- [x] ~~User guide / reference docs~~ (N/A: SPA UX is itself the
+user-facing surface).
+- [x] ~~CLI help text~~ (N/A).
+- [x] ~~README.md~~ (N/A).
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation —
+**go-architect + cranky audits round 1, user crit (synthesis approved)**
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+
+- **go-architect (round 1)** — 1 critical (AC8 unimplementable
+under ACL v0), 2 significant (test placement, AC9 synthetic-verb approach), 4
+minor + 1 confirmation. All addressed.
+- **cranky-code-reviewer (round 1)** — 4 critical (inventory off by
+3x, DynamicForm readonly nonexistent, AC8 unimplementable, AC9 production
+mutation), 8 significant, 7 minor, 3 nit. All criticals + significants addressed
+in synthesis + this plan.
+- **User crit on synthesis** — approved (round 1, no comments).
+Inline direction: "no readonly forms; gate the Edit button + show error on
+direct URL navigation."
+
+Full synthesis at `.ignored/affordances-phase2-audit-synthesis.md`.

--- a/tickets/entities/tickets/TKT-LFT2.md
+++ b/tickets/entities/tickets/TKT-LFT2.md
@@ -5,7 +5,7 @@ title: 'Action affordances phase 2: frontend consumption + AWM6L payoff'
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: done
 ---
 
 ## Goal

--- a/tickets/entities/tickets/TKT-LFT2.md
+++ b/tickets/entities/tickets/TKT-LFT2.md
@@ -5,7 +5,7 @@ title: 'Action affordances phase 2: frontend consumption + AWM6L payoff'
 kind: enhancement
 priority: medium
 effort: m
-status: backlog
+status: in-progress
 ---
 
 ## Goal
@@ -13,7 +13,7 @@ status: backlog
 Make the Vue SPA actually consume the `_actions: map[string]bool` map shipped by
 the backend in phase 1 (TKT-Y72A, PR #779). Read-only mode should produce a
 button-less data-entry UI driven entirely by the backend's verdict — the
-original deliverable that TKT-AWM6L was chasing.
+original deliverable TKT-AWM6L was chasing.
 
 ## Why now
 
@@ -24,27 +24,32 @@ UI integration.
 
 ## Scope
 
-- Vue components that render write affordances (delete buttons,
-update forms, create-new buttons on list pages) consult `entity._actions[verb]`.
-Semantics:
+- **Vue components consult `entity._actions[verb]`** at every write-
+affordance call site (delete buttons, edit / update controls, create-new buttons
+on list pages). Semantics:
   - `false` → omit the control.
   - `true` → render.
-  - Absent → render unconditionally (anonymous / pre-rollout
-fallback).
+  - Absent → render unconditionally (defensive fallback for
+pre-phase-1 servers or non-data-entry callers; the data-entry server always
+emits the field).
 - **Dev-mode warning.** When the SPA receives an authenticated
-response without `_actions`, log a `console.warn` so a future server-side
-regression (handler forgot to populate the field) is visible in development.
-Production builds suppress the warning.
+response without `_actions` in development builds, log a `console.warn` so a
+future server-side regression (handler forgot to populate the field) is visible
+at the edge. Suppressed in production builds.
+- **Inventory the call sites first.** PLAN-B0CI's earlier 31-affordance
+survey is a starting point; the actual phase-2 inventory may be smaller (phase-1
+vocabulary covers `create`/`update`/`delete`/ `rename` only).
 - **AC4 (list endpoint) — dedicated test.** Backend wiring already
-exists (`computeCollectionActions`); add a handler test asserting per-row
+exists (`computeCollectionActions`); add a handler test that asserts per-row
 `_actions` differs across rows when the ACL gates by entity type / ID.
 - **AC5 (frontend consumption) — component unit tests.** Fixture
 responses with various `_actions` shapes; assert button render presence/absence.
 - **AC6 (additive vocabulary) — synthetic verb test.** Backend emits
-`noop` from one handler; assert frontend doesn't crash or warn for unknown keys.
-- **AC7 (AWM6L payoff) — E2E.** Boot data-entry with
-`--read-only`; navigate the SPA; assert no write controls render anywhere
-(delete button, edit form fields, create button).
+a synthetic verb `noop` from one handler; assert frontend doesn't crash or
+console-warn on the unknown key.
+- **AC7 (AWM6L payoff) — E2E.** Boot data-entry with `--read-only`;
+navigate the SPA; assert no write controls render anywhere (delete button, edit
+form fields, create button).
 
 ## Profile gate (decision)
 
@@ -56,12 +61,15 @@ the cache.
 
 ## Out of scope
 
-- `transition:*` and `relation:*` verbs (gated on ACL v0.5).
+- `transition:*` and `relation:*` verbs (gated on ACL v0.5 —
+TKT-XZEY).
 - MCP / Lua / scheduler write-path affordance integration.
 - SSE policy-changed events.
 
 ## References
 
 - Phase 1: TKT-Y72A, PR #779
-- Design: `.ignored/action-affordances-design.md`
+- Phase 1 design: `.ignored/action-affordances-design.md`
 - Predecessor (wont-fix): TKT-AWM6L
+- Backend wire-shape demo: see TKT-Y72A done-status comment + curl
+examples in `docs/data-entry/api-reference.md`

--- a/tickets/relations/TKT-LFT2--has-implementation--IMPL-GETR.md
+++ b/tickets/relations/TKT-LFT2--has-implementation--IMPL-GETR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LFT2
+relation: has-implementation
+to: IMPL-GETR
+---

--- a/tickets/relations/TKT-LFT2--has-planning--PLAN-XJ60.md
+++ b/tickets/relations/TKT-LFT2--has-planning--PLAN-XJ60.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LFT2
+relation: has-planning
+to: PLAN-XJ60
+---

--- a/tickets/templates/entities/implementation-checklist.md
+++ b/tickets/templates/entities/implementation-checklist.md
@@ -32,6 +32,11 @@ status: pending
 ## Quality
 
 - [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+      patterns extracted to a helper / constant / type where it
+      sharpens the contract (don't extract for its own sake; CLAUDE.md
+      "three similar lines is better than a premature abstraction"
+      still holds)
 - [ ] No security issues introduced
 - [ ] No silent failures (errors logged AND returned)
 - [ ] No debug code left behind


### PR DESCRIPTION
## Summary

Phase 2 of TKT-Y72A's affordances arc. The Vue SPA now actually consumes the `_actions: map[string]bool` map shipped by phase 1 (#779) — entity-CRUD buttons hide when the server says the verb is denied. **Read-only mode (`rela-server --read-only`) produces a UI with no entity-CRUD controls — the original AWM6L payoff.**

### Backend

- Added `TestComputeActions_MixedTypeDeclarative` (AC12) verifying per-type variance under a `Declarative` policy with mixed grants.

### Frontend

- `frontend/src/utils/affordancesWarning.ts` (NEW) + 8 unit tests — dev-mode console warning when whitelisted API responses omit `_actions`, with dedup + HMR reset.
- Wired the warning helper into `listEntities`, `getEntity`, `createEntity`, `updateEntity`.
- `EntityList.vue` — gated `+ New`, both row delete layouts, Del-key (with toast feedback), bulk action bar.
- `KanbanView.vue` — gated `+ New`, drag-drop via `:draggable` binding + `@drop` defence.
- `EntityDetail.vue` — gated desktop+mobile Edit/Delete buttons, Del/E key handlers with toast.
- `DynamicForm.vue` — route guard renders "not editable" message when loaded entity's `_actions.update === false`. No DynamicForm readonly mode needed (per user direction).
- `entitiesStore.fetchList` passes `_actions` through the cache.

### E2E

- `e2e/tests/read-only-mode.spec.ts` (NEW) — extends the existing `testProject` fixture with a `readOnlyServerUrl` that boots `--read-only`. Three scenarios green: list has no `+ New` or delete buttons, EntityDetail has no Edit/Delete, direct form-URL navigation renders the "not editable" message.

### Docs

- `docs/data-entry/api-reference.md` — new §"How the SPA consumes `_actions`" section. Cardinal rule unchanged (server re-authorizes).
- `docs/security.md` — clarified read-only-mode behaviour with deferred-sites caveat.
- `CLAUDE.md` — SPA-side rule under §"Action affordances": gate via inline `v-if`; no `useACL()` composable.

### Deferred (documented as visible-in-read-only)

- Lua command buttons (no phase-1 verb covers them).
- Settings/theme/git writes (covered by `--read-only` server flag).
- Relation add/remove inside form widgets (gated on TKT-XZEY).
- Inline-edit buttons in EntityDetail related-entity cards (×6 — `V1SidePanelEntity` needs `_actions` extension; phase-2.1 follow-up).

## Dependency

Base is `feat/acl-affordances` (PR #779) since that PR hasn't merged yet. After it merges, this branch rebases naturally onto `develop`.

## Test plan

- [x] `just test`, `go test -race ./...` — green
- [x] `npm run test:run` (frontend) — 792 tests pass
- [x] `npm run typecheck` — clean
- [x] `npx playwright test tests/read-only-mode.spec.ts` — 3/3 green
- [x] Backend gating verified via `TestComputeActions_MixedTypeDeclarative`
- [x] Manual demo: started `rela-server --read-only` on the tickets project, opened the SPA in a browser — `+ New`, Edit, Delete buttons all absent in entity-CRUD; Lua command buttons remain (deferred).