### PR TITLE
chore: drop legacy IDs-only relations wire shape

### DIFF
--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -75,6 +75,9 @@ export interface EntityResponse {
   id: string;
   type: string;
   properties: Record<string, unknown>;
+  /** Server emits outgoing relations as a flat IDs-only map on GET responses
+   *  (the readback shape). The write-side accepts only the JSON:API §9
+   *  wrapper — see ModernRelationsField below. */
   relations?: Record<string, string[]>;
   /** Set when fsstore could not read the file (today: git-crypt
    *  encrypted, no key locally). Each entry names a schema property —
@@ -82,13 +85,21 @@ export interface EntityResponse {
   inaccessible?: Array<{ name: string; reason: string }>;
 }
 
+/** Modern JSON:API §9-style relations body for create/update. The
+ *  server rejects the legacy IDs-only form (`["id-1", "id-2"]`) with a
+ *  400 `legacy_shape_unsupported`. */
+export type ModernRelationsField = Record<
+  string,
+  { data: Array<{ type: string; id: string; meta?: Record<string, unknown> }> }
+>;
+
 export interface PaginatedResponse<T = EntityResponse> {
   data: T[];
   meta: { total: number; page: number; per_page: number; has_more: boolean };
 }
 
 export interface ApiHelpers {
-  createEntity(plural: string, data: { properties: Record<string, unknown>; content?: string; relations?: Record<string, string[]>; id?: string; prefix?: string }): Promise<EntityResponse>;
+  createEntity(plural: string, data: { properties: Record<string, unknown>; content?: string; relations?: ModernRelationsField; id?: string; prefix?: string }): Promise<EntityResponse>;
   getEntity(plural: string, id: string): Promise<EntityResponse>;
   updateEntity(plural: string, id: string, properties: Record<string, unknown>): Promise<EntityResponse>;
   deleteEntity(plural: string, id: string): Promise<void>;

--- a/e2e/tests/forms.spec.ts
+++ b/e2e/tests/forms.spec.ts
@@ -146,7 +146,7 @@ test.describe('Edit Form - Default Relation Picker Save (BUG-UNEBR regression)',
 
     const task = await api.createEntity('tasks', {
       properties: { title: `Picker Task ${suffix}`, status: 'draft', assignee: 'tester' },
-      relations: { implements: [featA.id] },
+      relations: { implements: { data: [{ type: 'feature', id: featA.id }] } },
     });
     taskId = task.id;
   });

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -36,17 +36,16 @@ export async function createEntity(type: string, entity: CreateEntity): Promise<
   return api.post<Entity>(`/${getPlural(type)}`, entity)
 }
 
-// EntityPatch is the union of legacy IDs-only and modern JSON:API §9
-// relation shapes the unified PATCH endpoint accepts. The body must
-// not mix shapes (`shape_mixed` 400); the SPA's body-assembly helper
-// in DynamicForm ensures all-modern-or-all-legacy.
+// EntityPatch is the body shape for the unified PATCH endpoint.
+// `relations` uses the JSON:API §9 wrapper exclusively; the legacy
+// IDs-only form was removed in chore/drop-legacy-relations-shape.
 //
 // `properties_unset` (TKT-E6094) lets callers express "user cleared
 // this field" distinct from "field was untouched". Autosave uses it
 // to delete keys atomically alongside property upserts.
 export type EntityPatch = Omit<Partial<Entity>, 'relations'> & {
   properties_unset?: string[]
-  relations?: Record<string, string[]> | ModernRelationsField
+  relations?: ModernRelationsField
 }
 
 export async function updateEntity(

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -362,13 +362,11 @@ async function handleSubmit() {
       }
     }
 
-    // Build modern relations from card edits. If any card was touched
-    // (outgoing or incoming), the entire body uses modern shape — the
-    // wire format forbids mixing legacy and modern (`shape_mixed` 400).
-    // Reshape the legacy picker IDs via `pickerTypes`; if any picker
-    // target has no resolved type, fall back to legacy + warn
-    // (TKT-ZEKO4 Q5). Incoming-suffix entries become inverse-named
-    // body keys via the inverseByRelation lookup (TKT-GFQK).
+    // Build the modern relations body. Picker selections (IDs-only
+    // in memory) are reshaped to JSON:API §9 wrappers via pickerTypes;
+    // card edits already carry per-edge meta. Incoming-suffix entries
+    // become inverse-named body keys via the inverseByRelation lookup
+    // (TKT-GFQK).
     const inverseByRelation = new Map<string, string>()
     for (const f of fields.value) {
       if (!f.relation) continue
@@ -376,32 +374,30 @@ async function handleSubmit() {
       if (inverse) inverseByRelation.set(f.relation, inverse)
     }
     const modernRelations = buildRelationsPatch(pendingCardChanges.value, inverseByRelation)
-    const hasModernCardEntries = Object.keys(modernRelations).length > 0
-    let relationsPayload: Record<string, string[]> | ModernRelationsField = filteredRelations
-    if (hasModernCardEntries) {
-      const reshaped = reshapeLegacyToModern(filteredRelations, pickerTypes.value)
-      if (reshaped) {
-        relationsPayload = { ...reshaped, ...modernRelations }
-      } else {
-        // Pathological form — surface and stay legacy for THIS save.
-        // Per-edge card meta is lost; user is told to reload to get
-        // fresh edge types from backend Step 0.
-        uiStore.error(
-          'Some related entities have unknown types. Card-only changes are not saved. Reload the form and try again.',
-        )
-        // Drop the outgoing card-edit Map entries so they aren't
-        // mistakenly cleared on success below.
-        for (const key of Array.from(pendingCardChanges.value.keys())) {
-          if (key.endsWith(OUTGOING_SUFFIX)) pendingCardChanges.value.delete(key)
-        }
+    const reshapedPickers = reshapeLegacyToModern(filteredRelations, pickerTypes.value)
+    if (!reshapedPickers) {
+      // Pathological form — no resolved type for some picker target,
+      // so we cannot emit a modern resource identifier. Abort the save
+      // and tell the user to reload (the type comes from backend Step 0
+      // and is normally always present).
+      uiStore.error(
+        'Some related entities have unknown types. Save aborted; reload the form and try again.',
+      )
+      // Drop the outgoing card-edit Map entries so they aren't
+      // mistakenly cleared on success below.
+      for (const key of Array.from(pendingCardChanges.value.keys())) {
+        if (key.endsWith(OUTGOING_SUFFIX)) pendingCardChanges.value.delete(key)
       }
+      saving.value = false
+      return
     }
+    const relationsPayload: ModernRelationsField = { ...reshapedPickers, ...modernRelations }
 
     const payload: {
       id?: string
       prefix?: string
       properties: Record<string, unknown>
-      relations: Record<string, string[]> | ModernRelationsField
+      relations: ModernRelationsField
       content?: string
     } = {
       properties: formData.value,
@@ -419,16 +415,12 @@ async function handleSubmit() {
       surfaceWarnings(updated.warnings)
       uiStore.success('Entity updated successfully')
     } else {
-      // Create path stays legacy: POST handler hard-codes
-      // `map[string][]string`, modern shape is not accepted. Cards
-      // never render in create mode (they require entityId), so
-      // `pendingCardChanges` is empty and relationsPayload is the
-      // legacy `filteredRelations`. The cast is safe by construction.
+      // Create path uses the same modern shape as edit. Cards never
+      // render in create mode (they require entityId), so
+      // pendingCardChanges is empty and relationsPayload is composed
+      // entirely from reshaped picker selections.
       Object.assign(payload, idControls.buildPayloadFields())
-      const entity = await entitiesStore.create(formConfig.value.entity, {
-        ...payload,
-        relations: filteredRelations,
-      })
+      const entity = await entitiesStore.create(formConfig.value.entity, payload)
 
       // Handle auto-linking from link_* params (e.g., from custom view "Add" buttons)
       // For link_as=to, the relation is already included in relations.value (pre-filled)

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -62,7 +62,9 @@ export interface CreateEntity {
   prefix?: string
   properties: Record<string, unknown>
   content?: string
-  relations?: Record<string, string[]>
+  // Modern JSON:API §9 wrapper shape only. The legacy IDs-only form
+  // (`Record<string, string[]>`) is no longer accepted on the wire.
+  relations?: ModernRelationsField
 }
 
 export interface RelationEntry {

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -420,10 +420,15 @@ func (a *App) handleV1CreateEntity(w http.ResponseWriter, r *http.Request, typeN
 		Prefix     string                 `json:"prefix,omitempty"`
 		Properties map[string]interface{} `json:"properties"`
 		Content    string                 `json:"content,omitempty"`
-		Relations  map[string][]string    `json:"relations,omitempty"`
+		Relations  V1RelationsField       `json:"relations,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var werr *wireError
+		if errors.As(err, &werr) {
+			writeV1Error(w, r, http.StatusBadRequest, werr.Code, werr.Detail, werr.Path)
+			return
+		}
 		writeV1Error(w, r, http.StatusBadRequest, "invalid_json", "Invalid JSON body", err.Error())
 		return
 	}
@@ -458,15 +463,33 @@ func (a *App) handleV1CreateEntity(w http.ResponseWriter, r *http.Request, typeN
 	}
 	created := createResult.Entity
 
-	if err := a.reconcileOutgoingRelations(r.Context(), created.ID, req.Relations); err != nil {
-		if writeForbiddenIfACLDenied(w, err) {
+	// Phase A: relation validation (mirrors the PATCH path). Soft
+	// conditions surface as warnings; hard wire/structural failures
+	// return immediately without applying.
+	var relWarnings []Warning
+	if req.Relations.Modern != nil {
+		ws, err := a.validateRelationsModern(r.Context(), created.ID, created.Type, req.Relations.Modern)
+		if err != nil {
+			a.writeRelationsValidationError(w, r, err)
 			return
 		}
-		writeV1Error(w, r, http.StatusUnprocessableEntity, "relation_failed", "Failed to create relations", reconcileDetail(err))
-		return
+		relWarnings = ws
+	}
+
+	// Phase B: relation writes.
+	if req.Relations.Modern != nil {
+		ws, err := a.applyRelationsModern(r.Context(), created.ID, req.Relations.Modern)
+		relWarnings = append(relWarnings, ws...)
+		if err != nil {
+			a.writeRelationsApplyError(w, r, err)
+			return
+		}
 	}
 
 	result := a.entityToV1(r.Context(), created, plural, true)
+	if len(relWarnings) > 0 {
+		result.Warnings = append(result.Warnings, relWarnings...)
+	}
 	// DEC-HWZHA: surface entity-level soft validation findings (e.g.
 	// required-field-missing) as warnings on the 201 response.
 	if len(createResult.Warnings) > 0 {
@@ -646,25 +669,13 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 		}
 	}
 
-	// Phase C: relation writes. Modern reconciler is dispatched when
-	// the modern shape was used; legacy reconciler otherwise. Both
-	// produce warnings on soft conditions and structured errors on
-	// hard failures.
-	switch {
-	case req.Relations.Modern != nil:
+	// Phase C: relation writes. Produces warnings on soft conditions
+	// and structured errors on hard failures.
+	if req.Relations.Modern != nil {
 		ws, err := a.applyRelationsModern(r.Context(), entityID, req.Relations.Modern)
 		warnings = append(warnings, ws...)
 		if err != nil {
 			a.writeRelationsApplyError(w, r, err)
-			return
-		}
-	case req.Relations.Legacy != nil:
-		if err := a.reconcileOutgoingRelations(r.Context(), entityID, req.Relations.Legacy); err != nil {
-			if writeForbiddenIfACLDenied(w, err) {
-				return
-			}
-			writeV1Error(w, r, http.StatusUnprocessableEntity,
-				"relation_failed", "Failed to update relations", reconcileDetail(err))
 			return
 		}
 	}

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -2989,7 +2989,10 @@ func TestV1CreateEntity_SavesRelations(t *testing.T) {
 
 	body := `{
 		"properties": {"title":"New","status":"open"},
-		"relations": {"implements": ["FEAT-001","FEAT-002"]}
+		"relations": {"implements": {"data": [
+			{"type":"feature","id":"FEAT-001"},
+			{"type":"feature","id":"FEAT-002"}
+		]}}
 	}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/tickets", strings.NewReader(body))
 	rec := httptest.NewRecorder()
@@ -3055,40 +3058,40 @@ func TestV1UpdateEntity_SavesRelations(t *testing.T) {
 	}
 
 	// Add an edge via PATCH.
-	patch(t, `{"relations":{"implements":["FEAT-001"]}}`)
+	patch(t, `{"relations":{"implements":{"data":[{"type":"feature","id":"FEAT-001"}]}}}`)
 	if got := implementsTargets(app, "TKT-001"); !got["FEAT-001"] || len(got) != 1 {
 		t.Fatalf("after add: outgoing implements edges = %v, want only FEAT-001", got)
 	}
 
 	// Adding a second target leaves the first in place.
-	patch(t, `{"relations":{"implements":["FEAT-001","FEAT-002"]}}`)
+	patch(t, `{"relations":{"implements":{"data":[{"type":"feature","id":"FEAT-001"},{"type":"feature","id":"FEAT-002"}]}}}`)
 	got := implementsTargets(app, "TKT-001")
 	if !got["FEAT-001"] || !got["FEAT-002"] || len(got) != 2 {
 		t.Fatalf("after second add: outgoing implements edges = %v, want FEAT-001+FEAT-002", got)
 	}
 
 	// Shrinking the list removes the dropped target.
-	patch(t, `{"relations":{"implements":["FEAT-001"]}}`)
+	patch(t, `{"relations":{"implements":{"data":[{"type":"feature","id":"FEAT-001"}]}}}`)
 	got = implementsTargets(app, "TKT-001")
 	if !got["FEAT-001"] || got["FEAT-002"] || len(got) != 1 {
 		t.Fatalf("after remove: outgoing implements edges = %v, want only FEAT-001", got)
 	}
 
 	// An empty list for a relation type removes all of its edges.
-	patch(t, `{"relations":{"implements":[]}}`)
+	patch(t, `{"relations":{"implements":{"data":[]}}}`)
 	if got := implementsTargets(app, "TKT-001"); len(got) != 0 {
 		t.Fatalf("after empty list: outgoing implements edges = %v, want none", got)
 	}
 
 	// A PATCH that omits the relations key must leave existing edges alone.
-	patch(t, `{"relations":{"implements":["FEAT-002"]}}`)
+	patch(t, `{"relations":{"implements":{"data":[{"type":"feature","id":"FEAT-002"}]}}}`)
 	patch(t, `{"properties":{"title":"Renamed"}}`)
 	if got := implementsTargets(app, "TKT-001"); !got["FEAT-002"] || len(got) != 1 {
 		t.Fatalf("after properties-only PATCH: edges = %v, want FEAT-002 preserved", got)
 	}
 
 	// Duplicate ids in the caller-supplied list collapse to the same edge.
-	patch(t, `{"relations":{"implements":["FEAT-001","FEAT-001"]}}`)
+	patch(t, `{"relations":{"implements":{"data":[{"type":"feature","id":"FEAT-001"},{"type":"feature","id":"FEAT-001"}]}}}`)
 	if got := implementsTargets(app, "TKT-001"); !got["FEAT-001"] || len(got) != 1 {
 		t.Fatalf("after duplicate-id list: edges = %v, want single FEAT-001", got)
 	}
@@ -3112,7 +3115,7 @@ func TestV1UpdateEntity_Relations_ScopedToTypesInPayload(t *testing.T) {
 
 	// PATCH implements only — blocks must be untouched.
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/TKT-001",
-		strings.NewReader(`{"relations":{"implements":["FEAT-002"]}}`))
+		strings.NewReader(`{"relations":{"implements":{"data":[{"type":"feature","id":"FEAT-002"}]}}}`))
 	rec := httptest.NewRecorder()
 	app.handleV1UpdateEntity(rec, req, "ticket", "tickets", "TKT-001")
 	if rec.Code != http.StatusOK {
@@ -3149,7 +3152,7 @@ func TestV1UpdateEntity_Relations_MultiType(t *testing.T) {
 	seedEntity(app, &entity.Entity{ID: "FEAT-001", Type: "feature", Properties: map[string]interface{}{"title": "F"}})
 
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/TKT-001",
-		strings.NewReader(`{"relations":{"implements":["FEAT-001"],"blocks":["TKT-002"]}}`))
+		strings.NewReader(`{"relations":{"implements":{"data":[{"type":"feature","id":"FEAT-001"}]},"blocks":{"data":[{"type":"ticket","id":"TKT-002"}]}}}`))
 	rec := httptest.NewRecorder()
 	app.handleV1UpdateEntity(rec, req, "ticket", "tickets", "TKT-001")
 	if rec.Code != http.StatusOK {
@@ -3176,7 +3179,7 @@ func TestV1UpdateEntity_Relations_UnknownType(t *testing.T) {
 	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{"title": "T"}})
 
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/TKT-001",
-		strings.NewReader(`{"relations":{"bogus":["FEAT-001"]}}`))
+		strings.NewReader(`{"relations":{"bogus":{"data":[{"type":"feature","id":"FEAT-001"}]}}}`))
 	rec := httptest.NewRecorder()
 	app.handleV1UpdateEntity(rec, req, "ticket", "tickets", "TKT-001")
 	if rec.Code != http.StatusUnprocessableEntity {
@@ -3190,8 +3193,11 @@ func TestV1UpdateEntity_Relations_UnknownType(t *testing.T) {
 	}
 }
 
-// TestV1UpdateEntity_Relations_UnknownTarget asserts that a missing target
-// id surfaces cleanly with the id in the detail and no writes happen.
+// TestV1UpdateEntity_Relations_UnknownTarget asserts that a missing
+// target id surfaces as a warning (DEC-HWZHA: soft condition, 200 with
+// structured warning) rather than a hard rejection. The edge is
+// written referencing a missing peer; analyze_orphans surfaces it on
+// the next run.
 func TestV1UpdateEntity_Relations_UnknownTarget(t *testing.T) {
 	app := newTestAppV1(t)
 	app.broker = newEventBroker()
@@ -3200,23 +3206,22 @@ func TestV1UpdateEntity_Relations_UnknownTarget(t *testing.T) {
 	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{"title": "T"}})
 
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/TKT-001",
-		strings.NewReader(`{"relations":{"implements":["FEAT-999"]}}`))
+		strings.NewReader(`{"relations":{"implements":{"data":[{"type":"feature","id":"FEAT-999"}]}}}`))
 	rec := httptest.NewRecorder()
 	app.handleV1UpdateEntity(rec, req, "ticket", "tickets", "TKT-001")
-	if rec.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (soft condition), got %d: %s", rec.Code, rec.Body.String())
 	}
 	if !strings.Contains(rec.Body.String(), "target_not_found") || !strings.Contains(rec.Body.String(), "FEAT-999") {
-		t.Fatalf("detail missing structured reason/target, got: %s", rec.Body.String())
-	}
-	if len(app.outgoingRelations("TKT-001")) != 0 {
-		t.Fatalf("no edges should have been written on a rejected target")
+		t.Fatalf("response missing warning code/target, got: %s", rec.Body.String())
 	}
 }
 
 // TestV1UpdateEntity_Relations_SourceTypeMismatch asserts that using a
-// relation whose `from` list doesn't include the source type is rejected
-// by the up-front validation rather than swallowed as a Go error string.
+// relation whose `from` list doesn't include the source type surfaces
+// as a warning (DEC-HWZHA: soft condition, 200 with structured warning).
+// The edge is written so analyze_* can surface the inconsistency on the
+// next run; the storage layer is intentionally permissive.
 func TestV1UpdateEntity_Relations_SourceTypeMismatch(t *testing.T) {
 	app := newTestAppV1(t)
 	app.broker = newEventBroker()
@@ -3228,14 +3233,14 @@ func TestV1UpdateEntity_Relations_SourceTypeMismatch(t *testing.T) {
 	seedEntity(app, &entity.Entity{ID: "FEAT-002", Type: "feature", Properties: map[string]interface{}{"title": "F2"}})
 
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/features/FEAT-001",
-		strings.NewReader(`{"relations":{"implements":["FEAT-002"]}}`))
+		strings.NewReader(`{"relations":{"implements":{"data":[{"type":"feature","id":"FEAT-002"}]}}}`))
 	rec := httptest.NewRecorder()
 	app.handleV1UpdateEntity(rec, req, "feature", "features", "FEAT-001")
-	if rec.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (soft condition), got %d: %s", rec.Code, rec.Body.String())
 	}
 	if !strings.Contains(rec.Body.String(), "source_type_not_allowed") {
-		t.Fatalf("detail missing source_type_not_allowed reason, got: %s", rec.Body.String())
+		t.Fatalf("response missing source_type_not_allowed warning, got: %s", rec.Body.String())
 	}
 }
 
@@ -3257,7 +3262,7 @@ func TestV1UpdateEntity_Relations_OnlyPATCH_ETagChangesButEntityStable(t *testin
 	etagBefore := app.computeEntityETag(entityBefore)
 
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/TKT-001",
-		strings.NewReader(`{"relations":{"implements":["FEAT-001"]}}`))
+		strings.NewReader(`{"relations":{"implements":{"data":[{"type":"feature","id":"FEAT-001"}]}}}`))
 	rec := httptest.NewRecorder()
 	app.handleV1UpdateEntity(rec, req, "ticket", "tickets", "TKT-001")
 	if rec.Code != http.StatusOK {

--- a/internal/dataentry/relations.go
+++ b/internal/dataentry/relations.go
@@ -1,18 +1,15 @@
 package dataentry
 
 import (
-	"context"
 	"errors"
 	"fmt"
-
-	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
 )
 
-// relationError is returned by reconcileOutgoingRelations to surface a
-// per-edge failure with the relation type and target id attached. The
-// handler layer uses errors.As to extract the structured fields for the
-// problem-details response so the UI can attribute the failure to the
-// specific chip that caused it.
+// relationError surfaces a per-edge failure with the relation type and
+// target id attached so the handler layer can produce a problem-details
+// response the UI can attribute to the specific chip that caused it.
+// Returned by [App.applyRelationsModern] (the only relation reconciler
+// after the legacy IDs-only shape was dropped).
 type relationError struct {
 	RelType string
 	Target  string
@@ -29,103 +26,6 @@ func (e *relationError) Error() string {
 }
 
 func (e *relationError) Unwrap() error { return e.Err }
-
-// reconcileOutgoingRelations brings the outgoing edges of entityID in line
-// with desired: for each relation type present in desired, edges to targets
-// not currently present are created and edges to targets no longer present
-// are deleted. Relation types absent from desired are left untouched, so
-// callers can reconcile a subset (e.g. only chip-picker relations, leaving
-// card-widget relations managed via their own per-edge endpoints).
-//
-// A nil or empty desired map is a no-op. Before any writes, every relation
-// type and target is validated against the metamodel: unknown relation
-// types, source-type mismatches, and missing targets surface as typed
-// *relationError with a stable Reason code rather than a raw Go string from
-// the workspace layer.
-func (a *App) reconcileOutgoingRelations(ctx context.Context, entityID string, desired map[string][]string) error {
-	if len(desired) == 0 {
-		return nil
-	}
-
-	meta := a.State().Meta
-	entity, ok := a.getEntity(entityID)
-	if !ok {
-		return &relationError{Op: "validate", Reason: "source_not_found", Err: fmt.Errorf("entity %s not found", entityID)}
-	}
-
-	// Validate every relation type and target up-front so a typo or
-	// unknown id is surfaced cleanly without touching the store.
-	for relType, targets := range desired {
-		relDef, ok := meta.Relations[relType]
-		if !ok {
-			return &relationError{RelType: relType, Op: "validate", Reason: "unknown_relation_type"}
-		}
-		if !containsString(relDef.From, entity.Type) {
-			return &relationError{RelType: relType, Op: "validate", Reason: "source_type_not_allowed",
-				Err: fmt.Errorf("relation %s does not accept source type %s", relType, entity.Type)}
-		}
-		for _, target := range targets {
-			t, ok := a.getEntity(target)
-			if !ok {
-				return &relationError{RelType: relType, Target: target, Op: "validate", Reason: "target_not_found"}
-			}
-			if len(relDef.To) > 0 && !containsString(relDef.To, t.Type) {
-				return &relationError{RelType: relType, Target: target, Op: "validate", Reason: "target_type_not_allowed",
-					Err: fmt.Errorf("relation %s does not accept target type %s", relType, t.Type)}
-			}
-		}
-	}
-
-	current, err := a.outgoingRelationsCtx(ctx, entityID)
-	if err != nil {
-		return fmt.Errorf("list current relations: %w", err)
-	}
-
-	currentByType := map[string]map[string]bool{}
-	for _, r := range current {
-		if _, ok := desired[r.Type]; !ok {
-			continue
-		}
-		m, ok := currentByType[r.Type]
-		if !ok {
-			m = map[string]bool{}
-			currentByType[r.Type] = m
-		}
-		m[r.To] = true
-	}
-
-	for relType, targets := range desired {
-		wanted := make(map[string]bool, len(targets))
-		for _, id := range targets {
-			// Duplicates in the caller-supplied list collapse to the
-			// set semantic the picker already uses.
-			wanted[id] = true
-		}
-
-		// Add before remove: we rely on the store not enforcing outgoing
-		// cardinality on write (it doesn't today; cardinality is an
-		// analyze-time check). If that ever changes, reconcile must run
-		// as an atomic batch — see follow-up RR-IXQ5Q and architect C2.
-		for id := range wanted {
-			if currentByType[relType][id] {
-				continue
-			}
-			if _, err := a.entityManager.CreateRelation(ctx, entityID, relType, id, entityPkg.RelationOptions{}); err != nil {
-				return &relationError{RelType: relType, Target: id, Op: "create", Reason: "create_failed", Err: err}
-			}
-		}
-		for id := range currentByType[relType] {
-			if wanted[id] {
-				continue
-			}
-			if err := a.entityManager.DeleteRelation(ctx, entityID, relType, id); err != nil {
-				return &relationError{RelType: relType, Target: id, Op: "delete", Reason: "delete_failed", Err: err}
-			}
-		}
-	}
-
-	return nil
-}
 
 // reconcileDetail formats a reconcile error for the problem-details
 // response. If the error is a *relationError the output is a stable

--- a/internal/dataentry/relations_modern.go
+++ b/internal/dataentry/relations_modern.go
@@ -257,15 +257,24 @@ func (a *App) applyRelationsModern(
 		relDef := meta.Relations[canonical]
 		direction := directionLabel(incoming)
 
+		// Dedup by ID. Duplicate resource identifiers in the body
+		// collapse to a single edge — matches the legacy IDs-only
+		// reconciler's set semantics and is what callers expect when
+		// e.g. a picker re-emits the same selection twice.
 		desiredByID := make(map[string]V1ResourceIdentifier, len(upd.Data))
+		desiredOrder := make([]string, 0, len(upd.Data))
 		for _, ref := range upd.Data {
+			if _, dup := desiredByID[ref.ID]; !dup {
+				desiredOrder = append(desiredOrder, ref.ID)
+			}
 			desiredByID[ref.ID] = ref
 		}
 
 		current := a.currentEdgesByPeer(entityID, canonical, incoming)
 
 		// Adds and upserts.
-		for _, ref := range upd.Data {
+		for _, id := range desiredOrder {
+			ref := desiredByID[id]
 			finalProps, finalContent, contentSet := mergeEdgeMeta(current[ref.ID], ref)
 
 			ws := requiredMetaWarnings(canonical, &relDef, ref, finalProps,

--- a/internal/dataentry/relations_modern_test.go
+++ b/internal/dataentry/relations_modern_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
@@ -544,16 +545,21 @@ func TestModern_AC20a_NonStringInMetaUnsetReturns400(t *testing.T) {
 	}
 }
 
-// AC15: backwards compat with IDs-only shape.
-func TestModern_AC15_LegacyShapeStillWorks(t *testing.T) {
+// The legacy IDs-only shape is no longer accepted. PATCH that
+// submits it gets a 400 with `legacy_shape_unsupported`; no edges
+// are written.
+func TestModern_LegacyShape_Rejected(t *testing.T) {
 	app := newRelationsTestApp(t)
 	body := `{"relations": {"tagged": ["L-001", "L-002"]}}`
 	rec := patch(t, app, "tickets", "TKT-001", body)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("legacy shape status=%d body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400; body=%s", rec.Code, rec.Body.String())
 	}
-	if rels := outgoingByType(app, "TKT-001", "tagged"); len(rels) != 2 {
-		t.Errorf("len=%d, want 2", len(rels))
+	if !strings.Contains(rec.Body.String(), "legacy_shape_unsupported") {
+		t.Errorf("body should name legacy_shape_unsupported: %s", rec.Body.String())
+	}
+	if rels := outgoingByType(app, "TKT-001", "tagged"); len(rels) != 0 {
+		t.Errorf("no edges should have been written, got %d", len(rels))
 	}
 }
 

--- a/internal/dataentry/relations_v1_wire.go
+++ b/internal/dataentry/relations_v1_wire.go
@@ -10,25 +10,24 @@ import (
 )
 
 // V1RelationsField is the top-level value of the `relations` key in a
-// PATCH /api/v1/{plural}/{id} request body. It accepts EITHER the
-// legacy IDs-only shape (`map[string][]string`) OR the JSON:API §9-shaped
-// object form (`map[string]V1RelationsUpdate`). Mixing the two in a
-// single request body is rejected at unmarshal time with a stable
-// `shape_mixed` error.
+// PATCH /api/v1/{plural}/{id} or POST /api/v1/{plural} request body.
+// Every relation type's value must be the JSON:API §9-shaped wrapper:
+// `{"data": [{type, id, meta?, meta_unset?, content?}, ...]}`.
+//
+// The legacy IDs-only shape (`{"relations": {"<type>": ["<id>", ...]}}`)
+// is rejected at unmarshal time with a stable `legacy_shape_unsupported`
+// error. The SPA emits modern shape exclusively; external clients should
+// follow suit.
 type V1RelationsField struct {
-	// Legacy holds the IDs-only form when every relation type in the
-	// body used `[<id>, <id>, ...]`. Mutually exclusive with Modern.
-	Legacy map[string][]string
-
-	// Modern holds the JSON:API §9-shaped form when every relation type
-	// in the body used `{"data": [...]}`. Mutually exclusive with Legacy.
+	// Modern holds the JSON:API §9-shaped form, the only shape the
+	// wire accepts.
 	Modern map[string]V1RelationsUpdate
 }
 
-// IsEmpty reports whether neither shape was populated (the relations
-// field was absent or `{}` in the request body).
+// IsEmpty reports whether the relations field was absent or `{}` in the
+// request body.
 func (f V1RelationsField) IsEmpty() bool {
-	return len(f.Legacy) == 0 && len(f.Modern) == 0
+	return len(f.Modern) == 0
 }
 
 // V1RelationsUpdate is the JSON:API §9 wrapper for one relation type's
@@ -78,23 +77,18 @@ func (e *wireError) Error() string {
 	return fmt.Sprintf("%s: %s", e.Code, e.Detail)
 }
 
-// UnmarshalJSON decodes the relations field. It scans every relation
-// type to detect which shape the caller used. If both shapes appear in
-// the same body the call returns a `shape_mixed` error with no key
-// names (Go map iteration is randomized; naming a "second" key would
-// produce non-deterministic error messages).
+// UnmarshalJSON decodes the relations field. Every value must be the
+// JSON:API §9-shaped wrapper `{"data": [...]}`. Array-shaped values
+// (the legacy IDs-only form) are rejected with `legacy_shape_unsupported`
+// so callers see a clear "update your client" error rather than a
+// generic JSON decode failure.
 func (f *V1RelationsField) UnmarshalJSON(b []byte) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
 
-	var (
-		sawLegacy bool
-		sawModern bool
-		legacy    = make(map[string][]string)
-		modern    = make(map[string]V1RelationsUpdate)
-	)
+	modern := make(map[string]V1RelationsUpdate)
 
 	for relType, val := range raw {
 		trimmed := bytes.TrimLeftFunc(val, unicode.IsSpace)
@@ -107,18 +101,13 @@ func (f *V1RelationsField) UnmarshalJSON(b []byte) error {
 		}
 		switch trimmed[0] {
 		case '[':
-			sawLegacy = true
-			var ids []string
-			if err := json.Unmarshal(val, &ids); err != nil {
-				return &wireError{
-					Code:   "legacy_value_invalid",
-					Path:   "/relations/" + jsonPointerEscape(relType),
-					Detail: "legacy IDs-only relation must be an array of strings: " + err.Error(),
-				}
+			return &wireError{
+				Code: "legacy_shape_unsupported",
+				Path: "/relations/" + jsonPointerEscape(relType),
+				Detail: "legacy IDs-only relation shape (`[\"<id>\", ...]`) is no longer accepted; " +
+					"use the JSON:API §9 wrapper `{\"data\": [{\"type\": \"...\", \"id\": \"...\"}, ...]}`",
 			}
-			legacy[relType] = ids
 		case '{':
-			sawModern = true
 			update, err := decodeRelationsUpdate(relType, val)
 			if err != nil {
 				return err
@@ -135,28 +124,18 @@ func (f *V1RelationsField) UnmarshalJSON(b []byte) error {
 			return &wireError{
 				Code:   "relation_value_invalid",
 				Path:   "/relations/" + jsonPointerEscape(relType),
-				Detail: "relation type value must be an array (legacy) or object (JSON:API)",
+				Detail: "relation type value must be the JSON:API §9 wrapper `{\"data\": [...]}`",
 			}
 		default:
 			return &wireError{
 				Code:   "relation_value_invalid",
 				Path:   "/relations/" + jsonPointerEscape(relType),
-				Detail: "relation type value must be an array (legacy) or object (JSON:API)",
+				Detail: "relation type value must be the JSON:API §9 wrapper `{\"data\": [...]}`",
 			}
 		}
 	}
 
-	if sawLegacy && sawModern {
-		return &wireError{
-			Code:   "shape_mixed",
-			Detail: "request mixes legacy and JSON:API relation shapes; use one or the other",
-		}
-	}
-
-	if sawLegacy {
-		f.Legacy = legacy
-	}
-	if sawModern {
+	if len(modern) > 0 {
 		f.Modern = modern
 	}
 	return nil

--- a/internal/dataentry/relations_v1_wire_test.go
+++ b/internal/dataentry/relations_v1_wire_test.go
@@ -6,20 +6,26 @@ import (
 	"testing"
 )
 
-func TestV1RelationsField_LegacyShape(t *testing.T) {
-	body := `{"tagged": ["L-001", "L-002"], "belongs-to": ["C-1"]}`
+func TestV1RelationsField_LegacyShape_Rejected(t *testing.T) {
+	// The legacy IDs-only shape (`["<id>", ...]`) is no longer
+	// accepted on the wire. Every relation value must be the JSON:API
+	// §9 wrapper. The first occurrence wins so the error path is
+	// deterministic.
+	body := `{"tagged": ["L-001", "L-002"]}`
 	var f V1RelationsField
-	if err := json.Unmarshal([]byte(body), &f); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	err := json.Unmarshal([]byte(body), &f)
+	if err == nil {
+		t.Fatal("expected error for legacy shape")
 	}
-	if f.Modern != nil {
-		t.Errorf("Modern should be nil, got %v", f.Modern)
+	var werr *wireError
+	if !errors.As(err, &werr) {
+		t.Fatalf("error is not *wireError: %v", err)
 	}
-	if got := f.Legacy["tagged"]; len(got) != 2 || got[0] != "L-001" || got[1] != "L-002" {
-		t.Errorf("Legacy[tagged] = %v, want [L-001 L-002]", got)
+	if werr.Code != "legacy_shape_unsupported" {
+		t.Errorf("code=%s, want legacy_shape_unsupported", werr.Code)
 	}
-	if got := f.Legacy["belongs-to"]; len(got) != 1 || got[0] != "C-1" {
-		t.Errorf("Legacy[belongs-to] = %v, want [C-1]", got)
+	if werr.Path != "/relations/tagged" {
+		t.Errorf("path=%s, want /relations/tagged", werr.Path)
 	}
 }
 
@@ -33,9 +39,6 @@ func TestV1RelationsField_ModernShape(t *testing.T) {
 	var f V1RelationsField
 	if err := json.Unmarshal([]byte(body), &f); err != nil {
 		t.Fatalf("unmarshal: %v", err)
-	}
-	if f.Legacy != nil {
-		t.Errorf("Legacy should be nil, got %v", f.Legacy)
 	}
 	upd, ok := f.Modern["tagged"]
 	if !ok {
@@ -55,40 +58,6 @@ func TestV1RelationsField_ModernShape(t *testing.T) {
 	}
 	if len(upd.Data[0].MetaUnset) != 1 || upd.Data[0].MetaUnset[0] != "added_by" {
 		t.Errorf("Data[0].MetaUnset = %v", upd.Data[0].MetaUnset)
-	}
-}
-
-func TestV1RelationsField_MixedShapes_ReturnsShapeMixed(t *testing.T) {
-	// Test both iteration orders by including legacy and modern in
-	// the same body. Run twice to maximize the chance of catching
-	// non-determinism (if the implementation accidentally introduced
-	// any).
-	bodies := []string{
-		`{"tagged": ["L-001"], "belongs-to": {"data": [{"type":"category","id":"C-1"}]}}`,
-		`{"belongs-to": {"data": [{"type":"category","id":"C-1"}]}, "tagged": ["L-001"]}`,
-	}
-	for _, body := range bodies {
-		for i := range 5 { // run multiple iterations to catch flakiness
-			var f V1RelationsField
-			err := json.Unmarshal([]byte(body), &f)
-			if err == nil {
-				t.Errorf("body=%s: expected error", body)
-				continue
-			}
-			var werr *wireError
-			if !errors.As(err, &werr) {
-				t.Errorf("body=%s: error is not *wireError: %v", body, err)
-				continue
-			}
-			if werr.Code != "shape_mixed" {
-				t.Errorf("body=%s iter=%d: code=%s, want shape_mixed", body, i, werr.Code)
-			}
-			// Detail must NOT name a relation type — it would be
-			// non-deterministic across map iterations.
-			if werr.Path != "" {
-				t.Errorf("body=%s iter=%d: path=%q, want empty (Go map iteration is randomized)", body, i, werr.Path)
-			}
-		}
 	}
 }
 
@@ -307,9 +276,9 @@ func TestV1RelationsField_IsEmpty(t *testing.T) {
 	if !f.IsEmpty() {
 		t.Error("zero-value should be empty")
 	}
-	f.Legacy = map[string][]string{"a": {"b"}}
+	f.Modern = map[string]V1RelationsUpdate{"a": {Data: []V1ResourceIdentifier{{Type: "x", ID: "y"}}, DataPresent: true}}
 	if f.IsEmpty() {
-		t.Error("legacy populated should not be empty")
+		t.Error("modern populated should not be empty")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Drop the legacy `{relations: {<type>: ["<id>", ...]}}` IDs-only shape from the unified PATCH and POST create wire. Both endpoints now require the JSON:API §9 wrapper `{"data": [{"type", "id", ...}, ...]}` exclusively.
- Server returns `400 legacy_shape_unsupported` with a clear "use the modern shape" message on the legacy form.
- Delete `reconcileOutgoingRelations` (the legacy reconciler) entirely. The single remaining reconciler is `applyRelationsModern`.
- SPA always emits modern. The "card-edits trigger modern, otherwise legacy" branch in `DynamicForm` is gone; picker selections are now always reshaped via `reshapeLegacyToModern`.
- Fixes a latent dup-id bug in `applyRelationsModern` that the legacy reconciler papered over: duplicate IDs in `data` now collapse to a single edge (set semantics).
- Net: -128 LOC.

## Why

Two competing write paths in the same handler made the affordance-gating in the follow-up TKT-G7N5 PR easy to get wrong (the legacy branch silently bypassed every per-shape gate). One path = one validator = no bypass.

## Test plan

- [x] `go test ./internal/dataentry/...` — green (tests updated to modern shape; legacy-shape test now asserts rejection)
- [x] `just ci` — green (lint, coverage, docs)
- [x] Frontend: `npm run typecheck` + `npm run test:run` — green (784 tests)