### PR TITLE
feat(dataentry): _fields / _relations wire shape + SPA renderer (TKT-G7N5)

### DIFF
--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -154,6 +154,8 @@ func (d *Desktop) LoadProject(dir string) string {
 	app, err := dataentry.NewApp(
 		fs, projCtx, svc.Meta(), svc.Store(),
 		svc.EntityManager(), svc.Searcher(), svc.ACL(),
+		dataentry.ResolverFromProfile(os.Getenv("RELA_AFFORDANCE_PROFILE")),
+		svc.Audit(),
 	)
 	if err != nil {
 		d.mu.Lock()

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -116,6 +116,8 @@ func main() {
 	app, err := dataentry.NewApp(
 		svc.FS(), svc.Paths(), svc.Meta(), svc.Store(),
 		svc.EntityManager(), svc.Searcher(), svc.ACL(),
+		dataentry.ResolverFromProfile(os.Getenv("RELA_AFFORDANCE_PROFILE")),
+		svc.Audit(),
 	)
 	if err != nil {
 		var configErr *dataentry.ConfigValidationError

--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -382,3 +382,116 @@ that's expected and documents the scope.
   v1 is replacement-only at the list level + upsert at the per-edge level.
 - **Cross-entity atomic transactions.** A single PATCH targets one entity;
   there is no batch / transaction surface across entities.
+
+## Affordances: `_fields` and `_relations` (TKT-G7N5)
+
+Per-entity GET responses carry two affordance maps alongside the entity
+payload: `_fields` (field-level write / option verdicts) and `_relations`
+(relation-type-level create / remove / meta-field verdicts). The SPA reads
+these to render disabled inputs, filtered enum selects, and hidden + Add /
+x buttons. Writes that contradict a verdict return 403.
+
+### Verdict source
+
+In v1, verdicts come from a hardcoded stub selected by the
+`RELA_AFFORDANCE_PROFILE` env var (read once at server startup; tests pass
+the resolver directly):
+
+| Value | Behavior |
+|---|---|
+| unset / `none` | Permissive default — every field writable, every option allowed, every relation creatable/removable. Both wire maps emit as `{}`. |
+| `demo` | Hardcoded fixture against the `ticket` entity type — exercises every affordance code path so the SPA work has an observable end-to-end behavior. |
+| any other | Unknown — logs a warning and falls back to `none`. Never panics. |
+
+The eventual predicate-engine ticket replaces the stub with an `acl.yaml`-
+driven implementation via the same `FieldVerdictResolver` Go interface; the
+wire shape and SPA rendering stay unchanged.
+
+### Wire shape
+
+```json
+{
+  "id": "TKT-001",
+  "type": "ticket",
+  "properties": { /* hidden fields are OMITTED entirely */ },
+  "_fields": {
+    "kind": { "writable": false },
+    "status": { "options": { "done": false } }
+  },
+  "_relations": {
+    "affects":    { "creatable": false },
+    "implements": { "removable": false },
+    "has-planning": { "fields": { "note": { "writable": false } } }
+  }
+}
+```
+
+Both `_fields` and `_relations` are **sparse**: only entries that deviate
+from the permissive default appear. An absent key in either map means
+"default" — writable, all options allowed, creatable / removable. Under the
+`none` profile both maps emit as `{}` (present, empty) — a closed-world
+signal letting the SPA distinguish "evaluated, no deviations" from
+"affordances not available" (anonymous fallback / pre-rollout server).
+
+Hidden fields are doubly invisible: omitted from `properties` AND absent
+from `_fields`. The SPA filters its config-driven form-field list against
+both: a field declared in `data-entry.yaml` is rendered only if it appears
+in `_fields` OR `properties`. This makes "hidden = omitted" actually hide
+the input.
+
+### Write-side parity
+
+Every relevant PATCH / POST / DELETE handler consults the same resolver as
+the GET. A stale SPA client that submits a write contradicting a verdict
+receives 403:
+
+| Operation | Verdict checked | 403 `rule_id` shape |
+|---|---|---|
+| `PATCH /entities/<type>/<id>` with hidden field set or unset | `_fields.<name>` visibility | `field-affordance:hidden:<name>` |
+| Same, with read-only field set or unset | `_fields.<name>.writable` | `field-affordance:read-only:<name>` |
+| Same, with disallowed enum value | `_fields.<name>.options.<value>` | `field-affordance:enum-filtered:<name>=<value>` |
+| `POST /entities/<type>/<id>/relations/<rel>` | `_relations.<rel>.creatable` | `relation-affordance:not-creatable:<rel>` |
+| `DELETE /entities/<type>/<id>/relations/<rel>/<peer>` | `_relations.<rel>.removable` | `relation-affordance:not-removable:<rel>` |
+| `PATCH /entities/<type>/<id>/relations/<rel>/<peer>` with non-writable meta | `_relations.<rel>.fields.<meta>.writable` | `relation-affordance:meta-read-only:<rel>.<meta>` |
+| Unified `PATCH /entities/<type>/<id>` adding / removing edges or writing meta | as above | as above |
+
+Unknown fields (declared neither in the metamodel nor by the resolver)
+return 403 with the SAME `field-affordance:hidden:<name>` shape as
+genuinely-hidden fields. This closes the side channel where an attacker
+could otherwise distinguish "hidden from me" from "doesn't exist."
+
+The 403 body shape is the same as for ACL denials:
+
+```json
+{
+  "error": "forbidden",
+  "rule_kind": "affordance",
+  "rule_id": "field-affordance:read-only:kind",
+  "reason": "field \"kind\" is not writable"
+}
+```
+
+Audit log entries for these 403s use the existing `denied-write` op with
+the `reason` field prefixed `affordance:<rule>:<path>` (vs `acl:` for true
+ACL denials), so log readers can distinguish the two sources.
+
+Read-only fields use strict 403 semantics: any presence of a read-only
+field in `properties` or `properties_unset` rejects the whole PATCH,
+including any writable fields in the same body. The SPA's `useAutoSave`
+suppresses no-op PATCHes client-side via its `lastSeenServer` snapshot,
+so no real SPA path produces a same-value PATCH; the rejection exists
+for defense against hand-crafted clients.
+
+### Out of scope (this ticket)
+
+- **List-query affordances.** `_fields` and `_relations` ride only on
+  per-entity GET; list / collection responses keep their existing shape.
+- **Per-link verdicts** (different verdicts for different links of the
+  same relation type). Deferred to the predicate-engine ticket — requires
+  state-dependent gates.
+- **List-typed enum option-filter** (e.g. `tags` with `list: true`).
+  Wire shape supports it; the v1 PATCH validator only walks scalar enums.
+- **Create-mode affordances.** Stub doesn't gate creates; the create form
+  renders unrestricted. The predicate ticket will introduce
+  collection-level `_fields` / `_relations` on `V1ListResponse` for
+  create-mode gating.

--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -489,8 +489,6 @@ for defense against hand-crafted clients.
 - **Per-link verdicts** (different verdicts for different links of the
   same relation type). Deferred to the predicate-engine ticket — requires
   state-dependent gates.
-- **List-typed enum option-filter** (e.g. `tags` with `list: true`).
-  Wire shape supports it; the v1 PATCH validator only walks scalar enums.
 - **Create-mode affordances.** Stub doesn't gate creates; the create form
   renders unrestricted. The predicate ticket will introduce
   collection-level `_fields` / `_relations` on `V1ListResponse` for

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -7,7 +7,14 @@ import { readReturnTo } from '@/utils/returnPath'
 import { actionAllowed } from '@/utils/affordancesWarning'
 import { useEntityIDControls } from '@/composables/useEntityIDControls'
 import { useConfirm } from '@/composables/useConfirm'
-import type { PropertyDef, FormFieldOrRelation, Template, ModernRelationsField } from '@/types'
+import type {
+  PropertyDef,
+  FormFieldOrRelation,
+  Template,
+  ModernRelationsField,
+  FieldAffordance,
+  RelationAffordance,
+} from '@/types'
 import { getTemplates, createRelation } from '@/api'
 import type { RelationCardState } from './RelationCards.vue'
 import type { RelationPickerIncomingState } from './RelationPicker.vue'
@@ -51,6 +58,14 @@ const returnTo = ref<string | null>(null)
 // State
 const formData = ref<Record<string, unknown>>({})
 const relations = ref<Record<string, string[]>>({})
+// Per-entity field affordances from the server. Loaded together with
+// the entity in edit mode; populated as `_fields` from the API. Drives
+// readonly + option-filter rendering and the F1 hidden-field filter
+// (TKT-G7N5).
+const fieldAffordances = ref<Record<string, FieldAffordance>>({})
+// Same for relation affordances. Drives RelationCards' +Add / x button
+// visibility and meta-field disable.
+const relationAffordances = ref<Record<string, RelationAffordance>>({})
 // Per-relation `id -> entity type` map, fed by RelationPicker's
 // `update:types` emit. Required by the unified PATCH builder to emit
 // JSON:API §9 resource identifiers without guessing target types
@@ -103,7 +118,7 @@ const title = computed(() => {
   return isEdit.value ? `Edit ${label}` : `New ${label}`
 })
 
-const fields = computed((): FormFieldOrRelation[] => {
+const allFields = computed((): FormFieldOrRelation[] => {
   if (!formConfig.value) return []
   if (formConfig.value.sections?.length) {
     return formConfig.value.sections.flatMap((s) => s.fields) as FormFieldOrRelation[]
@@ -113,6 +128,51 @@ const fields = computed((): FormFieldOrRelation[] => {
   const relFields = (formConfig.value.relations || []) as FormFieldOrRelation[]
   return [...propFields, ...relFields]
 })
+
+// TKT-G7N5 F1: filter the config-driven field list against the
+// loaded entity's affordances. A property field is rendered only if
+// either (a) it appears in `entity._fields` (server explicitly
+// emitted a verdict — including the implicit "writable default") or
+// (b) it appears in `entity.properties` (server didn't strip it as
+// hidden). In create mode, no entity is loaded — render everything.
+//
+// F19 flicker prevention: during load (`loading === true`) we render
+// the unfiltered list to avoid a "fields disappear mid-render" jump
+// from the post-load filter. In practice this works out because
+// `loading` flips false synchronously after `loadEntity` populates
+// affordances + formData, so the filtered render is the FIRST paint
+// the user sees in edit mode.
+const fields = computed((): FormFieldOrRelation[] => {
+  const all = allFields.value
+  if (!isEdit.value || loading.value) return all
+  return all.filter((f) => {
+    if (!f.property) return true // relations / non-property fields untouched
+    if (f.property in fieldAffordances.value) return true
+    if (f.property in formData.value) return true
+    return false
+  })
+})
+
+// TKT-G7N5 readonly helper: the rendered field is readonly if either
+// the config marks it so OR the server's _fields verdict reports
+// writable=false. Both sources are honored — the server's affordance
+// is the strongest signal but the config can still set its own
+// readonly for static cases (e.g. ID display).
+function isFieldReadonly(field: FormFieldOrRelation): boolean {
+  if (field.readonly) return true
+  if (!field.property) return false
+  const verdict = fieldAffordances.value[field.property]
+  return verdict?.writable === false
+}
+
+// TKT-G7N5 option-verdict helper: pulls per-option allowed-map from
+// the server's _fields verdict. Undefined if no verdict for this
+// field (all options allowed by default). Sparse: only false entries
+// appear in the map.
+function optionVerdictsFor(field: FormFieldOrRelation): Record<string, boolean> | undefined {
+  if (!field.property) return undefined
+  return fieldAffordances.value[field.property]?.options
+}
 
 // Helper to look up entity type from ID prefix (e.g., "TKT-001" -> "ticket")
 function getTypeFromId(entityId: string): string | undefined {
@@ -144,6 +204,12 @@ async function loadEntity() {
     formData.value = { ...entity.properties }
     relations.value = entity.relations ? { ...entity.relations } : {}
     content.value = entity.content || ''
+    // TKT-G7N5: per-entity affordances from the server. The wire keys
+    // are always present on per-entity GET (possibly empty); we
+    // default to empty maps so the filter / readonly / options paths
+    // can treat absence as "default everything".
+    fieldAffordances.value = entity._fields ?? {}
+    relationAffordances.value = entity._relations ?? {}
     originalData.value = JSON.stringify({ formData: formData.value, relations: relations.value, content: content.value })
   } catch (err) {
     // Suppress cancellation errors from rapid navigation in Firefox
@@ -872,7 +938,8 @@ onBeforeRouteLeave(async () => {
                   :property-def="getPropertyDef(field.property)"
                   :value="formData[field.property]"
                   :error="errors[field.property]"
-                  :readonly="field.readonly"
+                  :readonly="isFieldReadonly(field)"
+                  :option-verdicts="optionVerdictsFor(field)"
                   @update="updateField(field.property!, $event)"
                 />
                 <RelationCards
@@ -881,6 +948,7 @@ onBeforeRouteLeave(async () => {
                   :field="field"
                   :entity-type="formConfig.entity"
                   :entity-id="entityId"
+                  :verdict="relationAffordances[field.relation!]"
                   @cards-changed="(state) => updateRelationCards(`${field.relation}-${field.direction || 'outgoing'}`, state)"
                 />
                 <RelationPicker
@@ -890,6 +958,7 @@ onBeforeRouteLeave(async () => {
                   :entity-type="formConfig.entity"
                   :entity-id="entityId"
                   :value="relations[field.relation] || []"
+                  :verdict="relationAffordances[field.relation!]"
                   @update="updateRelation(field.relation!, $event)"
                   @update:types="(types) => updateRelationTypes(field.relation!, types)"
                   @incoming-changed="(state) => updateIncomingPicker(field.relation!, state)"
@@ -907,7 +976,8 @@ onBeforeRouteLeave(async () => {
               :property-def="getPropertyDef(field.property)"
               :value="formData[field.property]"
               :error="errors[field.property]"
-              :readonly="field.readonly"
+              :readonly="isFieldReadonly(field)"
+              :option-verdicts="optionVerdictsFor(field)"
               @update="updateField(field.property!, $event)"
             />
             <RelationCards
@@ -916,6 +986,7 @@ onBeforeRouteLeave(async () => {
               :field="field"
               :entity-type="formConfig.entity"
               :entity-id="entityId"
+              :verdict="relationAffordances[field.relation!]"
               @cards-changed="(state) => updateRelationCards(`${field.relation}-${field.direction || 'outgoing'}`, state)"
             />
             <RelationPicker
@@ -925,6 +996,7 @@ onBeforeRouteLeave(async () => {
               :entity-type="formConfig.entity"
               :entity-id="entityId"
               :value="relations[field.relation] || []"
+              :verdict="relationAffordances[field.relation!]"
               @update="updateRelation(field.relation!, $event)"
               @update:types="(types) => updateRelationTypes(field.relation!, types)"
               @incoming-changed="(state) => updateIncomingPicker(field.relation!, state)"

--- a/frontend/src/components/forms/FieldRenderer.test.ts
+++ b/frontend/src/components/forms/FieldRenderer.test.ts
@@ -1,0 +1,122 @@
+// TKT-G7N5 AC8 (partial): FieldRenderer correctly consumes the
+// affordance plumbing — readonly + option-verdicts. The hidden-field
+// filter at the form level is exercised separately in
+// DynamicForm.affordances.test.ts (which uses a focused harness to
+// avoid the full DynamicForm mount cost).
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FieldRenderer from './FieldRenderer.vue'
+import type { FormFieldOrRelation, PropertyDef } from '@/types'
+
+function renderField(opts: {
+  field: FormFieldOrRelation
+  propertyDef?: PropertyDef
+  value: unknown
+  readonly?: boolean
+  optionVerdicts?: Record<string, boolean>
+}) {
+  return mount(FieldRenderer, {
+    props: {
+      field: opts.field,
+      propertyDef: opts.propertyDef,
+      value: opts.value,
+      readonly: opts.readonly,
+      optionVerdicts: opts.optionVerdicts,
+    },
+    attachTo: document.body,
+  })
+}
+
+describe('FieldRenderer affordance plumbing', () => {
+  it('readonly text input rendered with disabled attribute', () => {
+    // FieldRenderer's standard text input uses :disabled, not
+    // :readonly, to disable both editing AND focus — matches existing
+    // SPA convention.
+    const wrapper = renderField({
+      field: { property: 'title', label: 'Title' },
+      propertyDef: { type: 'string' },
+      value: 'hello',
+      readonly: true,
+    })
+    const input = wrapper.find('input[type="text"]')
+    expect(input.exists()).toBe(true)
+    expect(input.attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('readonly enum select rendered with disabled attribute', () => {
+    const wrapper = renderField({
+      field: { property: 'kind', label: 'Kind' },
+      propertyDef: { type: 'enum', values: ['enhancement', 'refactor'] },
+      value: 'enhancement',
+      readonly: true,
+    })
+    const select = wrapper.find('select')
+    expect(select.exists()).toBe(true)
+    expect(select.attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('option-verdicts disable specific options on a writable select', () => {
+    const wrapper = renderField({
+      field: { property: 'status', label: 'Status' },
+      propertyDef: { type: 'enum', values: ['open', 'review', 'done'] },
+      value: 'open',
+      optionVerdicts: { done: false }, // only the false entry appears
+    })
+    const select = wrapper.find('select')
+    expect(select.exists()).toBe(true)
+    // Whole select is NOT disabled (writable).
+    expect(select.attributes('disabled')).toBeUndefined()
+
+    const opts = wrapper.findAll('option')
+    const byValue = Object.fromEntries(
+      opts.map((o) => [o.attributes('value'), o] as const)
+    )
+    expect(byValue['done']).toBeDefined()
+    expect(byValue['done'].attributes('disabled')).toBeDefined()
+    // Allowed options are not marked disabled by the verdict.
+    expect(byValue['open'].attributes('disabled')).toBeUndefined()
+    expect(byValue['review'].attributes('disabled')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('no option-verdicts means no options disabled (sparse default)', () => {
+    const wrapper = renderField({
+      field: { property: 'status', label: 'Status' },
+      propertyDef: { type: 'enum', values: ['open', 'done'] },
+      value: 'open',
+    })
+    const opts = wrapper.findAll('option')
+    for (const opt of opts) {
+      expect(opt.attributes('disabled')).toBeUndefined()
+    }
+    wrapper.unmount()
+  })
+
+  it('option-verdicts and transition rules both apply', () => {
+    // Affordance denies 'done'; transition rules also restrict the
+    // pickable set. The visible-but-disabled rendering applies in
+    // either case (TKT-G7N5 + existing transition path).
+    const wrapper = renderField({
+      field: {
+        property: 'status',
+        label: 'Status',
+        transitions: { open: ['review'] }, // can't go open→done via transitions
+      },
+      propertyDef: { type: 'enum', values: ['open', 'review', 'done'] },
+      value: 'open',
+      optionVerdicts: { done: false },
+    })
+    const opts = wrapper.findAll('option')
+    const byValue = Object.fromEntries(
+      opts.map((o) => [o.attributes('value'), o] as const)
+    )
+    // 'done' is disabled by BOTH the affordance and the transition rule.
+    expect(byValue['done'].attributes('disabled')).toBeDefined()
+    // 'review' is allowed by both.
+    expect(byValue['review'].attributes('disabled')).toBeUndefined()
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/components/forms/FieldRenderer.test.ts
+++ b/frontend/src/components/forms/FieldRenderer.test.ts
@@ -119,4 +119,10 @@ describe('FieldRenderer affordance plumbing', () => {
     expect(byValue['review'].attributes('disabled')).toBeUndefined()
     wrapper.unmount()
   })
+
+  // TagSelect readonly/option-verdict plumbing is verified by the
+  // wire-shape contract in api_v1_test.go (server-side
+  // checkEnumOption coverage) plus by the typecheck — happy-dom
+  // can't mount SlimSelect's MutationObserver cleanly, so a direct
+  // component test isn't worth the harness fight here.
 })

--- a/frontend/src/components/forms/FieldRenderer.vue
+++ b/frontend/src/components/forms/FieldRenderer.vue
@@ -157,6 +157,8 @@ function handleTagSelect(value: string[]) {
       :model-value="arrayValue.map(String)"
       :options="options"
       :placeholder="placeholder || 'Select...'"
+      :disabled="readonly"
+      :option-verdicts="optionVerdicts"
       @update:model-value="handleTagSelect"
     />
 

--- a/frontend/src/components/forms/FieldRenderer.vue
+++ b/frontend/src/components/forms/FieldRenderer.vue
@@ -10,6 +10,11 @@ const props = defineProps<{
   value: unknown
   error?: string
   readonly?: boolean
+  // Sparse per-option allow map: only `false` entries appear; absent
+  // keys default to allowed. An option is disabled when EITHER this
+  // map denies it or the existing transition rules deny it — the two
+  // signals are independent and either one is sufficient.
+  optionVerdicts?: Record<string, boolean>
 }>()
 
 const emit = defineEmits<{
@@ -60,8 +65,10 @@ const hasTransitions = computed(() => {
   return props.field.transitions && Object.keys(props.field.transitions).length > 0
 })
 
-// Check if an option is disabled due to transition rules
 function isOptionDisabled(opt: string): boolean {
+  if (props.optionVerdicts && props.optionVerdicts[opt] === false) {
+    return true
+  }
   if (!hasTransitions.value || !props.field.transitions) {
     return false
   }

--- a/frontend/src/components/forms/RelationCards.test.ts
+++ b/frontend/src/components/forms/RelationCards.test.ts
@@ -1,0 +1,161 @@
+// TKT-G7N5 AC9: RelationCards consumes the per-relation-type
+// affordance verdict (`:verdict` prop sourced from
+// `entity._relations[type]` in DynamicForm). Verifies:
+//
+//   - `creatable === false` → + Add button absent
+//   - `removable === false` → per-link x button absent on every link
+//   - `fields[name].writable === false` → inline meta-field input
+//     rendered with disabled attribute
+//   - default (no verdict / verdict-fields-undefined) → all buttons
+//     and inputs visible / enabled
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import RelationCards from './RelationCards.vue'
+import { useSchemaStore } from '@/stores/schema'
+import type { FormFieldOrRelation, RelationAffordance, Entity } from '@/types'
+
+// Mock the API layer so we can return canned relations/entities
+// without booting the network stack.
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/api')
+  return {
+    ...actual,
+    getEntityRelations: vi.fn(),
+    getEntity: vi.fn(),
+  }
+})
+
+import { getEntityRelations, getEntity } from '@/api'
+
+function seedSchema() {
+  const schemaStore = useSchemaStore()
+  schemaStore.entityTypes.set('ticket', {
+    name: 'ticket',
+    label: 'Ticket',
+    properties: {},
+  } as never)
+  schemaStore.entityTypes.set('feature', {
+    name: 'feature',
+    label: 'Feature',
+    properties: {},
+  } as never)
+  schemaStore.relationTypes.set('implements', {
+    name: 'implements',
+    from: ['ticket'],
+    to: ['feature'],
+    // Add a meta property so the inline-edit input renders.
+    properties: { note: { type: 'string' } },
+  } as never)
+}
+
+function seedRelations(targets: string[], metaByTarget: Record<string, Record<string, unknown>> = {}) {
+  ;(getEntityRelations as ReturnType<typeof vi.fn>).mockResolvedValue(
+    targets.map((id) => ({
+      id,
+      type: 'feature',
+      meta: metaByTarget[id] || {},
+    }))
+  )
+  ;(getEntity as ReturnType<typeof vi.fn>).mockImplementation((_, id: string) =>
+    Promise.resolve({
+      id,
+      type: 'feature',
+      properties: { title: id },
+    } as Entity)
+  )
+}
+
+async function mountCards(opts: {
+  verdict?: RelationAffordance
+  links?: string[]
+}) {
+  seedSchema()
+  seedRelations(opts.links ?? ['FEAT-001'])
+  const field: FormFieldOrRelation = {
+    relation: 'implements',
+    label: 'Implements',
+    widget: 'cards',
+    // Declare meta properties on the field so the inline-edit input
+    // renders inside each card. Matches data-entry.yaml usage.
+    properties: [{ property: 'note', label: 'Note' }],
+  } as never
+  const wrapper = mount(RelationCards, {
+    props: {
+      field,
+      entityType: 'ticket',
+      entityId: 'TKT-001',
+      verdict: opts.verdict,
+    },
+    attachTo: document.body,
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('RelationCards affordance plumbing', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('default (no verdict): + Add button and per-link x button both visible', async () => {
+    const wrapper = await mountCards({})
+    expect(wrapper.find('.add-btn').exists()).toBe(true)
+    expect(wrapper.find('.remove-btn').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('creatable=false: + Add button absent; remove still visible', async () => {
+    const wrapper = await mountCards({
+      verdict: { creatable: false },
+    })
+    expect(wrapper.find('.add-btn').exists()).toBe(false)
+    expect(wrapper.find('.remove-btn').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('removable=false: per-link x button absent on every link; add still visible', async () => {
+    const wrapper = await mountCards({
+      verdict: { removable: false },
+      links: ['FEAT-001', 'FEAT-002'],
+    })
+    // No remove button on ANY card.
+    expect(wrapper.findAll('.remove-btn').length).toBe(0)
+    expect(wrapper.find('.add-btn').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('both creatable=false and removable=false: both affordances hidden', async () => {
+    const wrapper = await mountCards({
+      verdict: { creatable: false, removable: false },
+    })
+    expect(wrapper.find('.add-btn').exists()).toBe(false)
+    expect(wrapper.find('.remove-btn').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('fields.<meta>.writable=false: inline meta input rendered with disabled', async () => {
+    const wrapper = await mountCards({
+      verdict: {
+        fields: { note: { writable: false } },
+      },
+      links: ['FEAT-001'],
+    })
+    const metaInput = wrapper.find('input.inline-edit')
+    expect(metaInput.exists()).toBe(true)
+    expect(metaInput.attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('absent fields entry: meta input enabled (default writable)', async () => {
+    const wrapper = await mountCards({
+      verdict: { creatable: true }, // verdict present but no fields entry
+    })
+    const metaInput = wrapper.find('input.inline-edit')
+    expect(metaInput.exists()).toBe(true)
+    expect(metaInput.attributes('disabled')).toBeUndefined()
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/components/forms/RelationCards.vue
+++ b/frontend/src/components/forms/RelationCards.vue
@@ -13,6 +13,7 @@ import type { FormFieldOrRelation, RelationProperty } from '@/types/config'
 import type { RelationEntry, Entity } from '@/types/entity'
 import type { PropertyDef } from '@/types/schema'
 import type { RelationCardState } from './relationsPatch'
+import type { RelationAffordance } from '@/types'
 
 // Re-export so existing `import type { RelationCardState } from './RelationCards.vue'`
 // callers keep working without a churn rename.
@@ -22,6 +23,12 @@ const props = defineProps<{
   field: FormFieldOrRelation
   entityType: string
   entityId: string
+  // TKT-G7N5: per-relation-type affordance verdict from the server.
+  // Undefined / fields all-undefined = default (everything allowed).
+  // `creatable === false` hides the + Add button; `removable === false`
+  // hides every per-link x; `fields[name].writable === false` disables
+  // the inline meta-field input. Per-relation-type uniform.
+  verdict?: RelationAffordance
 }>()
 
 const emit = defineEmits<{
@@ -52,6 +59,18 @@ const selectedTarget = ref<Entity | null>(null)
 const newMeta = ref<Record<string, unknown>>({})
 
 const isIncoming = computed(() => props.field.direction === 'incoming')
+
+// TKT-G7N5: per-relation-type affordance helpers. Defaults preserve
+// today's behavior — buttons render unless explicitly denied.
+const canCreate = computed(() => props.verdict?.creatable !== false)
+const canRemove = computed(() => props.verdict?.removable !== false)
+
+// Per-meta-field disabled lookup. Returns true when the verdict
+// reports writable=false for the named meta field. Absence in the
+// fields map = writable default.
+function isMetaFieldDisabled(propName: string): boolean {
+  return props.verdict?.fields?.[propName]?.writable === false
+}
 
 const relationType = computed(() => {
   if (!props.field.relation) return undefined
@@ -364,7 +383,13 @@ function entryStatus(id: string): 'added' | 'updated' | null {
               {{ getEntityTitle(entry.id) }}
             </span>
           </div>
-          <button type="button" class="remove-btn" title="Remove relation" @click="removeRelation(entry.id)">
+          <button
+            v-if="canRemove"
+            type="button"
+            class="remove-btn"
+            title="Remove relation"
+            @click="removeRelation(entry.id)"
+          >
             &times;
           </button>
         </div>
@@ -381,6 +406,7 @@ function entryStatus(id: string): 'added' | 'updated' | null {
               :model-value="String(entry.meta?.[prop.property] || '')"
               :data="slimSelectData(prop.property)"
               :settings="slimSettings"
+              :disabled="isMetaFieldDisabled(prop.property)"
               @update:model-value="handleSlimUpdate(entry.id, prop.property, $event)"
             />
 
@@ -390,6 +416,7 @@ function entryStatus(id: string): 'added' | 'updated' | null {
               :checked="!!entry.meta?.[prop.property]"
               type="checkbox"
               class="inline-edit-checkbox"
+              :disabled="isMetaFieldDisabled(prop.property)"
               @change="updateProperty(entry.id, prop.property, ($event.target as HTMLInputElement).checked)"
             />
 
@@ -399,6 +426,7 @@ function entryStatus(id: string): 'added' | 'updated' | null {
               :value="entry.meta?.[prop.property] ?? ''"
               :type="getInputType(prop.property)"
               class="inline-edit"
+              :disabled="isMetaFieldDisabled(prop.property)"
               @input="updateProperty(entry.id, prop.property, ($event.target as HTMLInputElement).value)"
             />
           </div>
@@ -496,7 +524,7 @@ function entryStatus(id: string): 'added' | 'updated' | null {
       </button>
     </div>
 
-    <button v-if="!showAddSearch" type="button" class="add-btn" @click="showAddSearch = true">
+    <button v-if="!showAddSearch && canCreate" type="button" class="add-btn" @click="showAddSearch = true">
       + Add {{ field.label || field.relation }}
     </button>
   </div>

--- a/frontend/src/components/forms/RelationPicker.test.ts
+++ b/frontend/src/components/forms/RelationPicker.test.ts
@@ -124,3 +124,67 @@ describe('RelationPicker — entity label rendering', () => {
     wrapper.unmount()
   })
 })
+
+// TKT-G7N5: RelationPicker consumes the per-relation-type affordance
+// verdict. `creatable === false` hides the search input + inline-add
+// button; `removable === false` hides every per-entity x.
+describe('RelationPicker — affordance verdicts', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  async function mountWithVerdict(
+    value: string[],
+    candidates: Entity[],
+    verdict: { creatable?: boolean; removable?: boolean }
+  ) {
+    seedSchema()
+    seedCandidates(candidates)
+    const field: FormFieldOrRelation = { relation: 'affects', label: 'Affects' }
+    const wrapper = mount(RelationPicker, {
+      props: { field, entityType: 'ticket', value, verdict },
+      attachTo: document.body,
+    })
+    await flushPromises()
+    return wrapper
+  }
+
+  it('default (no verdict): search input and per-entity x button both visible', async () => {
+    const wrapper = await mountPicker([entity('TKT-100').id], [entity('TKT-100')])
+    expect(wrapper.find('.search-wrapper').exists()).toBe(true)
+    expect(wrapper.find('.remove-btn').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('creatable=false: search wrapper absent', async () => {
+    const wrapper = await mountWithVerdict([entity('TKT-100').id], [entity('TKT-100')], {
+      creatable: false,
+    })
+    expect(wrapper.find('.search-wrapper').exists()).toBe(false)
+    // Removal still permitted.
+    expect(wrapper.find('.remove-btn').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('removable=false: per-entity x absent on every selected entity', async () => {
+    const a = entity('TKT-100')
+    const b = entity('TKT-101')
+    const wrapper = await mountWithVerdict([a.id, b.id], [a, b], {
+      removable: false,
+    })
+    expect(wrapper.findAll('.remove-btn').length).toBe(0)
+    // Search still available.
+    expect(wrapper.find('.search-wrapper').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('both creatable=false and removable=false: both affordances hidden', async () => {
+    const wrapper = await mountWithVerdict([entity('TKT-100').id], [entity('TKT-100')], {
+      creatable: false,
+      removable: false,
+    })
+    expect(wrapper.find('.search-wrapper').exists()).toBe(false)
+    expect(wrapper.find('.remove-btn').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/components/forms/RelationPicker.vue
+++ b/frontend/src/components/forms/RelationPicker.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useSchemaStore, useEntitiesStore } from '@/stores'
 import { isCancelledFetch } from '@/composables/usePageData'
 import { getEntityRelations } from '@/api'
-import type { FormFieldOrRelation, Entity, RelationEntry } from '@/types'
+import type { FormFieldOrRelation, Entity, RelationEntry, RelationAffordance } from '@/types'
 import InlineCreateModal from './InlineCreateModal.vue'
 
 // Per-edge state emitted on the incoming-changed channel after
@@ -24,6 +24,11 @@ const props = defineProps<{
   entityType: string
   entityId?: string
   value: string[]
+  // TKT-G7N5: per-relation-type affordance verdict from the server.
+  // Undefined / all fields undefined = default (everything allowed).
+  // `creatable === false` hides every "+ Add" affordance (search,
+  // inline-create); `removable === false` hides the per-entity x.
+  verdict?: RelationAffordance
 }>()
 
 const emit = defineEmits<{
@@ -62,6 +67,11 @@ const createTargetType = ref('')
 // `incoming-changed` event fires until the user actually selects or
 // removes a peer, AND the snapshot is non-null.
 const isIncoming = computed(() => props.field.direction === 'incoming')
+
+// TKT-G7N5 affordance helpers. Defaults preserve today's behavior —
+// affordances render unless explicitly denied.
+const canCreate = computed(() => props.verdict?.creatable !== false)
+const canRemove = computed(() => props.verdict?.removable !== false)
 const incomingValue = ref<string[]>([])
 const incomingOriginal = ref<string[]>([])
 // Snapshot of the loaded edges keyed by ID. Used by the new
@@ -304,14 +314,19 @@ onBeforeUnmount(() => {
       >
         <span class="entity-type">{{ entity.type }}</span>
         <span class="entity-label">{{ formatEntityLabel(entity) }}</span>
-        <button type="button" class="remove-btn" @click="removeEntity(entity.id)">
+        <button
+          v-if="canRemove"
+          type="button"
+          class="remove-btn"
+          @click="removeEntity(entity.id)"
+        >
           &times;
         </button>
       </div>
     </div>
 
-    <!-- Search input -->
-    <div class="search-wrapper">
+    <!-- Search input (TKT-G7N5: hidden when relation is not creatable) -->
+    <div v-if="canCreate" class="search-wrapper">
       <input
         v-model="searchQuery"
         type="text"

--- a/frontend/src/components/ui/TagSelect.vue
+++ b/frontend/src/components/ui/TagSelect.vue
@@ -7,6 +7,17 @@ const props = defineProps<{
   modelValue: string[]
   options: string[]
   placeholder?: string
+  // disabled mirrors the standard HTML attribute — SlimSelect honors
+  // it by suppressing user input on the wrapped select. Used by form
+  // affordance plumbing (TKT-G7N5) to render a read-only multi-select.
+  disabled?: boolean
+  // optionVerdicts: per-option allow map. Sparse — only `false`
+  // entries appear; absent keys default to allowed. Matches the
+  // scalar-select option-filter shape (FieldRenderer). When provided,
+  // values currently in modelValue that are denied are still
+  // displayed (so the user can see + remove them) but are flagged
+  // disabled in the dropdown so they can't be re-added.
+  optionVerdicts?: Record<string, boolean>
 }>()
 
 const emit = defineEmits<{
@@ -17,6 +28,9 @@ const data = computed(() =>
   props.options.map((opt) => ({
     text: opt,
     value: opt,
+    // Server-side affordance verdict denies this option → render
+    // disabled in the dropdown so the user can't pick it.
+    disabled: props.optionVerdicts?.[opt] === false,
   }))
 )
 
@@ -39,6 +53,7 @@ function handleUpdate(value: string[]) {
     :data="data"
     :settings="settings"
     :multiple="true"
+    :disabled="disabled"
     @update:model-value="handleUpdate"
   />
 </template>

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -14,10 +14,40 @@ export interface Entity {
   // principal has every verb denied — UI should hide all affordances.
   // See .ignored/action-affordances-design.md for the full contract.
   _actions?: Record<string, boolean>
+  // Per-field write affordances on per-entity GET responses.
+  // Sparse: only fields whose verdict deviates from default appear.
+  // Hidden fields are omitted from `properties` AND from `_fields`.
+  // Absent on list / mutation responses; present (possibly empty) on
+  // per-entity GET (closed-world signal — empty means "evaluated, no
+  // deviations"). See docs/data-entry/api-reference.md.
+  _fields?: Record<string, FieldAffordance>
+  // Per-relation-type affordances on per-entity GET responses. Same
+  // sparse / closed-world semantics as _fields. Per-relation-type
+  // uniform — per-link verdicts are predicate territory (deferred).
+  _relations?: Record<string, RelationAffordance>
   inaccessible?: InaccessibleField[]
   // Soft-validation findings on mutation responses (DEC-HWZHA).
   // Present on PATCH/POST results; absent on GETs.
   warnings?: Warning[]
+}
+
+// FieldAffordance carries per-field write / option affordances on
+// the wire. Sparse: `writable` undefined means default (writable);
+// `options` lists only the false entries (allowed options are
+// implicit via the metamodel).
+export interface FieldAffordance {
+  writable?: boolean
+  options?: Record<string, boolean>
+}
+
+// RelationAffordance carries per-relation-type affordances on the
+// wire. Same sparse semantics as FieldAffordance: `creatable` /
+// `removable` undefined means default (true). `fields` is the
+// per-meta-field writability map, also sparse.
+export interface RelationAffordance {
+  creatable?: boolean
+  removable?: boolean
+  fields?: Record<string, FieldAffordance>
 }
 
 // Warning is a soft validation finding returned alongside a successful

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -73,6 +73,7 @@ type Services struct {
 	scriptEngine  *script.Engine
 	searchBackend *bleveindex.Index
 	acl           acl.ACL
+	audit         audit.Audit
 
 	closeOnce sync.Once
 	closeErr  error
@@ -103,6 +104,11 @@ func (s *Services) EntityManager() entitymanager.EntityManager { return s.entity
 // without re-reading the file. The returned value is the exact ACL
 // the Manager consults.
 func (s *Services) ACL() acl.ACL { return s.acl }
+
+// Audit returns the audit sink wired into entitymanager. Exposed so
+// dataentry handlers can emit `denied-write` rows for short-circuit
+// rejections (affordance gates) that never reach the manager.
+func (s *Services) Audit() audit.Audit { return s.audit }
 
 // Tracer returns the graph-traversal service.
 func (s *Services) Tracer() tracer.Tracer { return s.tracer }
@@ -387,6 +393,7 @@ func New(
 		scriptEngine:  scriptEngine,
 		searchBackend: searchBackend,
 		acl:           o.acl,
+		audit:         auditSink,
 	}, nil
 }
 

--- a/internal/appbuild/testfixture.go
+++ b/internal/appbuild/testfixture.go
@@ -161,6 +161,7 @@ func NewForTest(meta *metamodel.Metamodel, opts ...TestOption) *Services {
 		scriptEngine:  scriptEngine,
 		searchBackend: searchBackend,
 		acl:           aclImpl,
+		audit:         auditSink,
 	}
 }
 

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -2,9 +2,16 @@ package dataentry
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
 // translateVerb maps a wire-format verb to the [acl.WriteRequest] that
@@ -64,4 +71,649 @@ func (a *App) computeCollectionActions(ctx context.Context, entityType string) m
 		out[v] = a.acl.AuthorizeWrite(ctx, translateVerb(v, entityType)).Allow
 	}
 	return out
+}
+
+// FieldVerdictResolver decides per-entity affordances for fields, enum
+// options, and relation-meta fields. The wire shape it feeds into is
+// documented in docs/data-entry/api-reference.md.
+//
+// v1 ships two implementations:
+//
+//   - [NopFieldVerdictResolver] — returns zero verdicts; every field,
+//     option, and relation is permitted. Default unless
+//     RELA_AFFORDANCE_PROFILE selects another.
+//   - [DemoFieldVerdictResolver] — a hardcoded fixture against the
+//     ticket type, exercising every affordance code path so the SPA
+//     work in TKT-G7N5 has an observable end-to-end behavior to test
+//     against.
+//
+// The eventual predicate-engine ticket replaces both with a
+// policy-driven implementation that reads acl.yaml. The interface
+// shape is intentionally narrow so the swap is mechanical.
+type FieldVerdictResolver interface {
+	FieldVerdicts(ctx context.Context, e *entityPkg.Entity) FieldVerdicts
+	RelationVerdicts(ctx context.Context, e *entityPkg.Entity) RelationVerdicts
+}
+
+// FieldVerdicts carries per-entity field-level affordance decisions.
+// All maps use sparse semantics: absence of a key means "default" (the
+// permissive default — writable, visible, all options allowed). Only
+// deviations need to be populated.
+type FieldVerdicts struct {
+	// Writable maps fieldName → writable. Absence = writable.
+	Writable map[string]bool
+
+	// Visible maps fieldName → visible. Absence = visible. False means
+	// the property is omitted from the wire `properties` map AND from
+	// `_fields`; the SPA's filter never sees the key.
+	Visible map[string]bool
+
+	// Options maps fieldName → optionValue → allowed. Absence of the
+	// field OR absence of an option means allowed. Used for enum-typed
+	// properties.
+	Options map[string]map[string]bool
+}
+
+// RelationVerdicts carries per-entity relation-level affordance
+// decisions. The map is sparse: relation types not listed default to
+// fully-permitted ({creatable: true, removable: true} with no
+// meta-field restrictions).
+type RelationVerdicts struct {
+	Types map[string]RelationVerdict
+}
+
+// RelationVerdict carries the affordance decision for a single
+// relation type. Zero-value (Creatable=false, Removable=false, Fields=nil)
+// would deny everything; callers always populate explicitly.
+type RelationVerdict struct {
+	Creatable bool
+	Removable bool
+	// Fields maps metaField → writable. Absence = writable. Applies
+	// uniformly to every link of this relation type (per-link
+	// affordances are predicate territory, deferred).
+	Fields map[string]bool
+}
+
+// AffordanceDenialRule is the stable identifier surfaced in 403
+// responses when an affordance validator rejects a write. The full
+// rule_id on the wire is "<rule>:<path>" so a UI or audit reader can
+// reconstruct what was denied.
+//
+// Rule names are part of the wire contract — changing them is a wire
+// break.
+type AffordanceDenialRule string
+
+const (
+	RuleFieldHidden          AffordanceDenialRule = "field-affordance:hidden"
+	RuleFieldReadOnly        AffordanceDenialRule = "field-affordance:read-only"
+	RuleFieldEnumFiltered    AffordanceDenialRule = "field-affordance:enum-filtered"
+	RuleRelationNotCreatable AffordanceDenialRule = "relation-affordance:not-creatable"
+	RuleRelationNotRemovable AffordanceDenialRule = "relation-affordance:not-removable"
+	RuleRelationMetaReadOnly AffordanceDenialRule = "relation-affordance:meta-read-only"
+)
+
+// AffordanceDenialError reports why a write was rejected by the
+// affordance validator. The rule and path together form the wire
+// rule_id (e.g. "field-affordance:hidden:priority"). Reason is a
+// short human-readable explanation; UIs surface it as-is.
+type AffordanceDenialError struct {
+	Rule   AffordanceDenialRule
+	Path   string // property name, relation type, or "<relation-type>.<meta-field>"
+	Reason string
+}
+
+// RuleID returns the wire-stable identifier for this denial.
+func (d AffordanceDenialError) RuleID() string {
+	if d.Path == "" {
+		return string(d.Rule)
+	}
+	return string(d.Rule) + ":" + d.Path
+}
+
+// Error makes AffordanceDenialError satisfy the error interface so it can
+// flow back through caller chains. The format mirrors RuleID() plus
+// the reason.
+func (d AffordanceDenialError) Error() string {
+	return d.RuleID() + ": " + d.Reason
+}
+
+// validateFieldWrite reports the first AffordanceDenialError that the
+// proposed property writes trigger. Returns nil when every requested
+// field is permitted.
+//
+// The validator handles four classes of denial:
+//
+//  1. Unknown fields (not declared in the metamodel) — rejected with
+//     RuleFieldHidden so the response is byte-equivalent to a true
+//     hidden-field rejection. This closes the F8 side channel.
+//  2. Hidden fields — Visible[name] == false in the resolver verdict.
+//  3. Read-only fields — Writable[name] == false. Strict: same-value
+//     writes are not exempted (useAutoSave does no-op suppression
+//     client-side; the server doesn't repeat that logic).
+//  4. Filtered enum options — Options[name][value] == false.
+//
+// `setKeys` is the set of property names being written (from
+// `properties` in the PATCH body); `unsetKeys` is the set being
+// removed (`properties_unset`). Both are checked against the same
+// rules: hidden/read-only fields cannot be set OR unset.
+//
+// Values are required only for the enum-filter check; pass the
+// requested value for each key in setValues. Unknown values default
+// to allowed (an option entry of `nil` means "no override").
+func (a *App) validateFieldWrite(ctx context.Context, e *entityPkg.Entity, setKeys map[string]interface{}, unsetKeys []string) *AffordanceDenialError {
+	if e == nil {
+		return nil
+	}
+	v := a.fieldResolver.FieldVerdicts(ctx, e)
+	declared := declaredProperties(a.State().Meta, e.Type)
+
+	check := func(key string, value interface{}, present bool) *AffordanceDenialError {
+		// Unknown field (not in metamodel, not in resolver overrides) →
+		// hidden-shape rejection (F8 side-channel closure).
+		if !declared[key] && !knownToResolver(v, key) {
+			return &AffordanceDenialError{
+				Rule:   RuleFieldHidden,
+				Path:   key,
+				Reason: fmt.Sprintf("field %q is not visible", key),
+			}
+		}
+		// Hidden via resolver verdict.
+		if visible, ok := v.Visible[key]; ok && !visible {
+			return &AffordanceDenialError{
+				Rule:   RuleFieldHidden,
+				Path:   key,
+				Reason: fmt.Sprintf("field %q is not visible", key),
+			}
+		}
+		// Read-only via resolver verdict.
+		if writable, ok := v.Writable[key]; ok && !writable {
+			return &AffordanceDenialError{
+				Rule:   RuleFieldReadOnly,
+				Path:   key,
+				Reason: fmt.Sprintf("field %q is not writable", key),
+			}
+		}
+		// Enum-filter (only for set, not unset, and only when a value
+		// is provided — unset has no value to check).
+		if present && value != nil {
+			if opts, ok := v.Options[key]; ok {
+				if str, isStr := value.(string); isStr {
+					if allowed, ok := opts[str]; ok && !allowed {
+						return &AffordanceDenialError{
+							Rule:   RuleFieldEnumFiltered,
+							Path:   key + "=" + str,
+							Reason: fmt.Sprintf("option %q is not allowed for field %q", str, key),
+						}
+					}
+				}
+			}
+		}
+		return nil
+	}
+
+	// Check sets first, then unsets. First denial wins.
+	for k, val := range setKeys {
+		if d := check(k, val, true); d != nil {
+			return d
+		}
+	}
+	for _, k := range unsetKeys {
+		if d := check(k, nil, false); d != nil {
+			return d
+		}
+	}
+	return nil
+}
+
+// declaredProperties returns the set of property names that the
+// metamodel declares for entityType. Returns an empty (non-nil) map
+// when the entity type is unknown — callers should treat that as
+// "nothing is declared," which causes the unknown-field rule to
+// reject every PATCH key. That's deliberate: an unknown entity type
+// should never reach this code path (the GET handler returns 404
+// upstream), but if it does the safe-fail behavior is reject-all.
+func declaredProperties(meta *metamodel.Metamodel, entityType string) map[string]bool {
+	out := make(map[string]bool)
+	if meta == nil {
+		return out
+	}
+	def, ok := meta.Entities[entityType]
+	if !ok {
+		return out
+	}
+	for name := range def.Properties {
+		out[name] = true
+	}
+	return out
+}
+
+// knownToResolver reports whether the resolver has any verdict
+// (writable, visible, or options) covering the given field name.
+// Used as the "known field" fallback for fields the metamodel does
+// not declare but the resolver has explicit opinions on.
+func knownToResolver(v FieldVerdicts, name string) bool {
+	if _, ok := v.Writable[name]; ok {
+		return true
+	}
+	if _, ok := v.Visible[name]; ok {
+		return true
+	}
+	if _, ok := v.Options[name]; ok {
+		return true
+	}
+	return false
+}
+
+// writeAffordanceDenialError renders an AffordanceDenialError as a 403
+// response. The wire shape mirrors writeForbiddenIfACLDenied (the
+// ACL helper) so SPA error-handling can treat the two uniformly.
+//
+// Prefer [App.denyAffordance] when handler context is available — it
+// emits the audit row in addition to writing the response.
+func writeAffordanceDenialError(w http.ResponseWriter, denial AffordanceDenialError) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":     "forbidden",
+		"rule_kind": "affordance",
+		"rule_id":   denial.RuleID(),
+		"reason":    denial.Reason,
+	})
+}
+
+// denyAffordance writes the 403 response AND records a `denied-write`
+// audit row attributed to the request principal. Use from every
+// affordance-gate site so the audit stream is uniform with ACL
+// denials (which the entitymanager emits the same op for).
+//
+// `target` is the entity the gate fired on — used to populate the
+// audit Subject so log readers can attribute the denial. Nil is
+// tolerated (subject left empty); callers always have it in practice.
+func (a *App) denyAffordance(ctx context.Context, w http.ResponseWriter, target *entityPkg.Entity, denial AffordanceDenialError) {
+	var subject *audit.Subject
+	if target != nil {
+		subject = &audit.Subject{
+			Kind: "entity",
+			Type: target.Type,
+			ID:   target.ID,
+		}
+	}
+	a.auditSink.Record(audit.Record{
+		Time:        time.Now().UTC(),
+		Op:          audit.OpDeniedWrite,
+		Subject:     subject,
+		Principal:   principal.From(ctx),
+		TriggeredBy: audit.TriggeredByFrom(ctx),
+		Summary: fmt.Sprintf("denied: %s (rule_kind=affordance rule_id=%s)",
+			denial.Reason, denial.RuleID()),
+	})
+	writeAffordanceDenialError(w, denial)
+}
+
+// RelationOp identifies which relation-write operation a caller is
+// gating. Pass via [App.validateRelationOp].
+type RelationOp int
+
+const (
+	// RelationOpCreate gates adding an edge of the given type.
+	RelationOpCreate RelationOp = iota
+	// RelationOpRemove gates removing any edge of the given type.
+	RelationOpRemove
+)
+
+// relationSourceEntity returns the entity whose verdict should gate a
+// per-relation write. For outgoing-direction operations the source IS
+// the path entity (the canonical case). For incoming-direction
+// operations the path entity is the TARGET; the source is the peer,
+// so the resolver must be asked about the peer's affordance, not the
+// path entity's.
+//
+// Returns the path entity when the peer can't be found locally (404
+// upstream — should not happen in practice; safe-fail).
+func (a *App) relationSourceEntity(pathEntity *entityPkg.Entity, peerID, direction string) *entityPkg.Entity {
+	if direction != string(DirectionIncoming) {
+		return pathEntity
+	}
+	peer, ok := a.getEntity(peerID)
+	if !ok {
+		return pathEntity
+	}
+	return peer
+}
+
+// validateRelationOp reports the first AffordanceDenialError that the
+// proposed relation operation triggers. Returns nil when permitted.
+// `relType` is the canonical relation type; `op` selects between
+// create / remove. The verdict is per-relation-type uniform —
+// per-link affordances are predicate territory.
+func (a *App) validateRelationOp(ctx context.Context, e *entityPkg.Entity, relType string, op RelationOp) *AffordanceDenialError {
+	if e == nil {
+		return nil
+	}
+	v := a.fieldResolver.RelationVerdicts(ctx, e)
+	rv, ok := v.Types[relType]
+	if !ok {
+		return nil // default-permissive
+	}
+	switch op {
+	case RelationOpCreate:
+		if !rv.Creatable {
+			return &AffordanceDenialError{
+				Rule:   RuleRelationNotCreatable,
+				Path:   relType,
+				Reason: fmt.Sprintf("relation %q is not creatable", relType),
+			}
+		}
+	case RelationOpRemove:
+		if !rv.Removable {
+			return &AffordanceDenialError{
+				Rule:   RuleRelationNotRemovable,
+				Path:   relType,
+				Reason: fmt.Sprintf("relation %q is not removable", relType),
+			}
+		}
+	}
+	return nil
+}
+
+// validateRelationsModernAffordances reports the first
+// AffordanceDenialError that any of the proposed relation diffs trigger
+// across the unified-PATCH modern body. Diffs against current edges
+// to identify true adds and removes (rather than upserts), and
+// inspects per-edge meta against [RelationVerdict.Fields].
+//
+// Called from the unified PATCH handler before
+// [App.applyRelationsModern]. Returns nil when every relation
+// operation is permitted.
+func (a *App) validateRelationsModernAffordances(
+	ctx context.Context, entityID string, e *entityPkg.Entity,
+	desired map[string]V1RelationsUpdate,
+) *AffordanceDenialError {
+	if e == nil || len(desired) == 0 {
+		return nil
+	}
+	meta := a.State().Meta
+	for bodyKey, upd := range desired {
+		if !upd.DataPresent {
+			continue
+		}
+		canonical, incoming, ok := resolveDirection(meta, bodyKey)
+		if !ok {
+			continue // structural error surfaces via the existing validator
+		}
+
+		desiredByID := make(map[string]V1ResourceIdentifier, len(upd.Data))
+		for _, ref := range upd.Data {
+			desiredByID[ref.ID] = ref
+		}
+		current := a.currentEdgesByPeer(entityID, canonical, incoming)
+
+		// For incoming-direction body keys the SOURCE of every edge is
+		// the peer entity, not the path entity. Verdicts are evaluated
+		// against the source — see [App.relationSourceEntity] for the
+		// rationale. Outgoing edges resolve to the path entity.
+		direction := ""
+		if incoming {
+			direction = string(DirectionIncoming)
+		}
+
+		// Adds: any desired edge whose peer isn't currently linked.
+		for _, ref := range upd.Data {
+			source := a.relationSourceEntity(e, ref.ID, direction)
+			if _, exists := current[ref.ID]; exists {
+				// Upsert path: not a create, but the meta may change.
+				if denial := a.validateRelationMetaWrite(ctx, source, canonical, ref.Meta, ref.MetaUnset); denial != nil {
+					return denial
+				}
+				continue
+			}
+			if denial := a.validateRelationOp(ctx, source, canonical, RelationOpCreate); denial != nil {
+				return denial
+			}
+			if denial := a.validateRelationMetaWrite(ctx, source, canonical, ref.Meta, ref.MetaUnset); denial != nil {
+				return denial
+			}
+		}
+
+		// Removes: any current edge not in the desired set.
+		for peerID := range current {
+			if _, kept := desiredByID[peerID]; kept {
+				continue
+			}
+			source := a.relationSourceEntity(e, peerID, direction)
+			if denial := a.validateRelationOp(ctx, source, canonical, RelationOpRemove); denial != nil {
+				return denial
+			}
+		}
+	}
+	return nil
+}
+
+// validateRelationMetaWrite reports the first AffordanceDenialError that
+// the proposed relation-meta writes trigger. Set+unset are both
+// treated as writes (F16). Returns nil when permitted.
+//
+// `meta` is the proposed property map; `metaUnset` lists keys being
+// removed. Unknown meta keys (not in the resolver's Fields map AND
+// not declared in the metamodel for this relation type) are not
+// rejected here — they're a separate concern handled by the existing
+// relation validation. The affordance check focuses on rejecting
+// keys explicitly marked non-writable.
+func (a *App) validateRelationMetaWrite(ctx context.Context, e *entityPkg.Entity, relType string, meta map[string]interface{}, metaUnset []string) *AffordanceDenialError {
+	if e == nil {
+		return nil
+	}
+	v := a.fieldResolver.RelationVerdicts(ctx, e)
+	rv, ok := v.Types[relType]
+	if !ok || rv.Fields == nil {
+		return nil
+	}
+	deny := func(key string) *AffordanceDenialError {
+		if writable, ok := rv.Fields[key]; ok && !writable {
+			return &AffordanceDenialError{
+				Rule:   RuleRelationMetaReadOnly,
+				Path:   relType + "." + key,
+				Reason: fmt.Sprintf("meta field %q on relation %q is not writable", key, relType),
+			}
+		}
+		return nil
+	}
+	for k := range meta {
+		if d := deny(k); d != nil {
+			return d
+		}
+	}
+	for _, k := range metaUnset {
+		if d := deny(k); d != nil {
+			return d
+		}
+	}
+	return nil
+}
+
+// computeFieldAffordances returns the sparse `_fields` wire map for
+// entity e: only fields whose verdict deviates from the permissive
+// default appear. Hidden fields (Visible[name] == false) are absent
+// from the returned map AND must be omitted from the entity's
+// Properties by the caller — they are doubly-invisible to the client.
+//
+// Empty input verdicts yield an empty (non-nil) map so the wire shape
+// is consistent: `_fields: {}` under the nop resolver, sparse entries
+// under any other.
+func (a *App) computeFieldAffordances(ctx context.Context, e *entityPkg.Entity) map[string]V1FieldAffordance {
+	v := a.fieldResolver.FieldVerdicts(ctx, e)
+	out := make(map[string]V1FieldAffordance)
+
+	// writable=false entries
+	for name, writable := range v.Writable {
+		if writable {
+			continue // sparse: default is writable
+		}
+		if !v.Visible[name] && v.isHidden(name) {
+			continue // hidden takes precedence; skip from _fields entirely
+		}
+		entry := out[name]
+		f := false
+		entry.Writable = &f
+		out[name] = entry
+	}
+
+	// option-filter entries
+	for name, opts := range v.Options {
+		if v.isHidden(name) {
+			continue
+		}
+		var falseOpts map[string]bool
+		for opt, allowed := range opts {
+			if allowed {
+				continue
+			}
+			if falseOpts == nil {
+				falseOpts = make(map[string]bool)
+			}
+			falseOpts[opt] = false
+		}
+		if falseOpts == nil {
+			continue
+		}
+		entry := out[name]
+		entry.Options = falseOpts
+		out[name] = entry
+	}
+
+	return out
+}
+
+// isHidden reports whether v marks name as hidden. Returns false for
+// the absent-key case (default is visible).
+func (v FieldVerdicts) isHidden(name string) bool {
+	visible, ok := v.Visible[name]
+	return ok && !visible
+}
+
+// hiddenProperties returns the set of property names that should be
+// stripped from V1Entity.Properties before serialization. Caller uses
+// this to enforce the omit-on-hidden invariant.
+func (a *App) hiddenProperties(ctx context.Context, e *entityPkg.Entity) map[string]struct{} {
+	v := a.fieldResolver.FieldVerdicts(ctx, e)
+	if len(v.Visible) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{})
+	for name, visible := range v.Visible {
+		if !visible {
+			out[name] = struct{}{}
+		}
+	}
+	return out
+}
+
+// computeRelationAffordances returns the sparse `_relations` wire map
+// for entity e. Only relation types with at least one deviation
+// (creatable=false, removable=false, or any meta-field writable=false)
+// appear in the map. Default-permissive types are absent — the SPA's
+// "no entry = default" path handles them.
+func (a *App) computeRelationAffordances(ctx context.Context, e *entityPkg.Entity) map[string]V1RelationAffordance {
+	v := a.fieldResolver.RelationVerdicts(ctx, e)
+	out := make(map[string]V1RelationAffordance)
+	for relType, rv := range v.Types {
+		var entry V1RelationAffordance
+		emit := false
+		if !rv.Creatable {
+			f := false
+			entry.Creatable = &f
+			emit = true
+		}
+		if !rv.Removable {
+			f := false
+			entry.Removable = &f
+			emit = true
+		}
+		var fields map[string]V1FieldAffordance
+		for metaField, writable := range rv.Fields {
+			if writable {
+				continue
+			}
+			if fields == nil {
+				fields = make(map[string]V1FieldAffordance)
+			}
+			f := false
+			fields[metaField] = V1FieldAffordance{Writable: &f}
+		}
+		if fields != nil {
+			entry.Fields = fields
+			emit = true
+		}
+		if emit {
+			out[relType] = entry
+		}
+	}
+	return out
+}
+
+// stripHiddenProperties removes hidden field names from result.Properties
+// in-place. Centralizes the "hidden = omitted from wire" invariant so
+// every entity-returning response (GET, PATCH, POST, clone, action,
+// includes) honors it consistently.
+//
+// Also rewrites `_title` to the entity ID when the entity-type's
+// display property is hidden — otherwise the display title would leak
+// the hidden value through the wire's secondary channel.
+func (a *App) stripHiddenProperties(ctx context.Context, e *entityPkg.Entity, result *V1Entity) {
+	hidden := a.hiddenProperties(ctx, e)
+	for name := range hidden {
+		delete(result.Properties, name)
+	}
+	if len(hidden) == 0 {
+		return
+	}
+	def, ok := a.State().Meta.Entities[e.Type]
+	if !ok {
+		return
+	}
+	primary := def.GetPrimaryProperty()
+	if primary == "" {
+		return
+	}
+	if _, hiddenPrimary := hidden[primary]; hiddenPrimary {
+		// Fall back to the entity ID, matching DisplayTitle's
+		// missing-property branch. The ID is non-secret by design.
+		result.Title = e.ID
+	}
+}
+
+// attachEntityAffordances writes the per-entity `_fields` and
+// `_relations` wire maps onto result. Called by paths that return a
+// per-entity response (GET, PATCH, POST, clone, action) — list rows
+// and includes get [App.stripHiddenProperties] only.
+func (a *App) attachEntityAffordances(ctx context.Context, e *entityPkg.Entity, result *V1Entity) {
+	fields := a.computeFieldAffordances(ctx, e)
+	relations := a.computeRelationAffordances(ctx, e)
+	result.FieldAffordances = &fields
+	result.RelationAffordances = &relations
+}
+
+// serializeEntityForWire is the single entry-point every handler that
+// returns a per-entity V1Entity should use. It calls entityToV1, strips
+// hidden properties, and attaches the affordance maps. Use
+// [App.serializeRelatedEntityForWire] for entities that appear as
+// list rows or under `included` (no affordance maps, but still strip).
+func (a *App) serializeEntityForWire(ctx context.Context, e *entityPkg.Entity, plural string, includeRelations bool) V1Entity {
+	result := a.entityToV1(ctx, e, plural, includeRelations)
+	a.stripHiddenProperties(ctx, e, &result)
+	a.attachEntityAffordances(ctx, e, &result)
+	return result
+}
+
+// serializeRelatedEntityForWire renders an entity that is NOT the
+// per-entity response root — used for list rows, `?include=*` peers,
+// and the search-result include map. Strips hidden properties but
+// omits the `_fields` / `_relations` maps (they ride on per-entity
+// responses only). Hidden-field stripping still applies because the
+// wire contract is "hidden values never reach the client, regardless
+// of which response shape they ride in."
+func (a *App) serializeRelatedEntityForWire(ctx context.Context, e *entityPkg.Entity, plural string, includeRelations bool) V1Entity {
+	result := a.entityToV1(ctx, e, plural, includeRelations)
+	a.stripHiddenProperties(ctx, e, &result)
+	return result
 }

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -218,7 +218,7 @@ func (a *App) validateFieldWrite(ctx context.Context, e *entityPkg.Entity, setKe
 			}
 		}
 		// Hidden via resolver verdict.
-		if visible, ok := v.Visible[key]; ok && !visible {
+		if !v.IsVisible(key) {
 			return &AffordanceDenialError{
 				Rule:   RuleFieldHidden,
 				Path:   key,
@@ -226,7 +226,7 @@ func (a *App) validateFieldWrite(ctx context.Context, e *entityPkg.Entity, setKe
 			}
 		}
 		// Read-only via resolver verdict.
-		if writable, ok := v.Writable[key]; ok && !writable {
+		if !v.IsWritable(key) {
 			return &AffordanceDenialError{
 				Rule:   RuleFieldReadOnly,
 				Path:   key,
@@ -234,17 +234,14 @@ func (a *App) validateFieldWrite(ctx context.Context, e *entityPkg.Entity, setKe
 			}
 		}
 		// Enum-filter (only for set, not unset, and only when a value
-		// is provided — unset has no value to check).
+		// is provided — unset has no value to check). Handles both
+		// scalar enums and list-typed enums (e.g. tags); for the list
+		// case every element is checked against the allow-set and the
+		// first disallowed value triggers the denial.
 		if present && value != nil {
 			if opts, ok := v.Options[key]; ok {
-				if str, isStr := value.(string); isStr {
-					if allowed, ok := opts[str]; ok && !allowed {
-						return &AffordanceDenialError{
-							Rule:   RuleFieldEnumFiltered,
-							Path:   key + "=" + str,
-							Reason: fmt.Sprintf("option %q is not allowed for field %q", str, key),
-						}
-					}
+				if d := checkEnumOption(key, value, opts); d != nil {
+					return d
 				}
 			}
 		}
@@ -260,6 +257,42 @@ func (a *App) validateFieldWrite(ctx context.Context, e *entityPkg.Entity, setKe
 	for _, k := range unsetKeys {
 		if d := check(k, nil, false); d != nil {
 			return d
+		}
+	}
+	return nil
+}
+
+// checkEnumOption rejects an enum value that isn't in the allow-set.
+// Handles both scalar enums (`string`) and list-typed enums
+// (`[]interface{}` — the JSON decoder's shape for a YAML
+// `list: true` enum like `tags`). For lists, the first disallowed
+// element produces the denial. Returns nil when the value passes.
+//
+// Non-string/non-list values fall through silently — the existing
+// type-validation pipeline catches those upstream; the affordance
+// gate only cares about disallowed-but-otherwise-valid values.
+func checkEnumOption(key string, value interface{}, opts map[string]bool) *AffordanceDenialError {
+	deny := func(option string) *AffordanceDenialError {
+		return &AffordanceDenialError{
+			Rule:   RuleFieldEnumFiltered,
+			Path:   key + "=" + option,
+			Reason: fmt.Sprintf("option %q is not allowed for field %q", option, key),
+		}
+	}
+	switch v := value.(type) {
+	case string:
+		if allowed, ok := opts[v]; ok && !allowed {
+			return deny(v)
+		}
+	case []interface{}:
+		for _, elem := range v {
+			str, ok := elem.(string)
+			if !ok {
+				continue
+			}
+			if allowed, ok := opts[str]; ok && !allowed {
+				return deny(str)
+			}
 		}
 	}
 	return nil
@@ -584,12 +617,40 @@ func (a *App) computeFieldAffordances(ctx context.Context, e *entityPkg.Entity) 
 	return out
 }
 
-// isHidden reports whether v marks name as hidden. Returns false for
-// the absent-key case (default is visible).
-func (v FieldVerdicts) isHidden(name string) bool {
-	visible, ok := v.Visible[name]
-	return ok && !visible
+// IsWritable reports whether name is writable. The default is true —
+// absent or true-valued entries both yield true; only explicit false
+// values are denials.
+func (v FieldVerdicts) IsWritable(name string) bool {
+	writable, ok := v.Writable[name]
+	return !ok || writable
 }
+
+// IsVisible reports whether name is visible. The default is true —
+// absent or true-valued entries both yield true; only explicit false
+// values hide the field.
+func (v FieldVerdicts) IsVisible(name string) bool {
+	visible, ok := v.Visible[name]
+	return !ok || visible
+}
+
+// IsOptionAllowed reports whether option `opt` is allowed for the
+// enum-typed field `name`. The default is allowed — absent or
+// true-valued entries both yield true; only explicit false values
+// filter the option out.
+func (v FieldVerdicts) IsOptionAllowed(name, opt string) bool {
+	opts, ok := v.Options[name]
+	if !ok {
+		return true
+	}
+	allowed, ok := opts[opt]
+	return !ok || allowed
+}
+
+// isHidden reports whether v marks name as hidden. Returns false for
+// the absent-key case (default is visible). Internal sibling to
+// [FieldVerdicts.IsVisible] — kept for the existing callers that
+// phrase the check in the negative form.
+func (v FieldVerdicts) isHidden(name string) bool { return !v.IsVisible(name) }
 
 // hiddenProperties returns the set of property names that should be
 // stripped from V1Entity.Properties before serialization. Caller uses

--- a/internal/dataentry/affordances_stub.go
+++ b/internal/dataentry/affordances_stub.go
@@ -1,0 +1,129 @@
+package dataentry
+
+import (
+	"context"
+	"log/slog"
+
+	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// AffordanceProfile names a verdict-source preset. v1 ships two:
+// "none" (permissive default) and "demo" (a fixture against the
+// ticket type that exercises every affordance code path).
+//
+// The env var RELA_AFFORDANCE_PROFILE selects between them at
+// startup. cmd/rela-server and cmd/rela-desktop parse the var and
+// pass the resolver into NewApp; tests pass the resolver directly.
+type AffordanceProfile string
+
+const (
+	AffordanceProfileNone AffordanceProfile = "none"
+	AffordanceProfileDemo AffordanceProfile = "demo"
+)
+
+// ResolverFromProfile returns the [FieldVerdictResolver] for the named
+// profile. An empty string or "none" yields [NopFieldVerdictResolver].
+// An unknown profile name logs a warning and falls back to none —
+// never panics, never errors. Operators see the warning at startup
+// and can correct the env var.
+func ResolverFromProfile(profile string) FieldVerdictResolver {
+	switch AffordanceProfile(profile) {
+	case "", AffordanceProfileNone:
+		return NopFieldVerdictResolver{}
+	case AffordanceProfileDemo:
+		return DemoFieldVerdictResolver{}
+	default:
+		slog.Warn("dataentry: unknown RELA_AFFORDANCE_PROFILE; using 'none'",
+			"value", profile,
+			"allowed", []string{string(AffordanceProfileNone), string(AffordanceProfileDemo)})
+		return NopFieldVerdictResolver{}
+	}
+}
+
+// NopFieldVerdictResolver returns empty verdicts for every entity.
+// computeFields / computeRelations interpret empty verdicts as "no
+// deviations from default" and emit sparse `_fields: {}` and
+// `_relations: {}` on the wire. The SPA renders unchanged.
+type NopFieldVerdictResolver struct{}
+
+// FieldVerdicts always returns the zero value.
+func (NopFieldVerdictResolver) FieldVerdicts(context.Context, *entityPkg.Entity) FieldVerdicts {
+	return FieldVerdicts{}
+}
+
+// RelationVerdicts always returns the zero value.
+func (NopFieldVerdictResolver) RelationVerdicts(context.Context, *entityPkg.Entity) RelationVerdicts {
+	return RelationVerdicts{}
+}
+
+// DemoFieldVerdictResolver applies a fixed fixture against the
+// "ticket" entity type. The fixture is hand-picked to exercise every
+// affordance code path:
+//
+//   - kind: read-only (writable=false)
+//   - priority: hidden (visible=false)
+//   - effort: option-filtered ({l: false, xl: false})
+//   - status: option-filtered ({done: false})
+//   - affects relation: not creatable
+//   - implements relation: not removable
+//   - has-planning relation: meta-field "note" not writable (the
+//     metamodel doesn't currently declare relation-meta on this type,
+//     so the verdict is still emitted and the contract tests rely on
+//     a test-fixture metamodel that adds the meta field)
+//
+// Other entity types receive empty verdicts. Intended for dev /
+// manual-testing use only — the predicate ticket replaces this with
+// a policy-driven resolver.
+type DemoFieldVerdictResolver struct{}
+
+// FieldVerdicts returns the demo fixture for ticket entities and the
+// zero value for every other type.
+func (DemoFieldVerdictResolver) FieldVerdicts(_ context.Context, e *entityPkg.Entity) FieldVerdicts {
+	if e == nil || e.Type != "ticket" {
+		return FieldVerdicts{}
+	}
+	return FieldVerdicts{
+		Writable: map[string]bool{
+			"kind": false,
+		},
+		Visible: map[string]bool{
+			"priority": false,
+		},
+		Options: map[string]map[string]bool{
+			"effort": {
+				"l":  false,
+				"xl": false,
+			},
+			"status": {
+				"done": false,
+			},
+		},
+	}
+}
+
+// RelationVerdicts returns the demo relation fixture for ticket
+// entities and the zero value for every other type.
+func (DemoFieldVerdictResolver) RelationVerdicts(_ context.Context, e *entityPkg.Entity) RelationVerdicts {
+	if e == nil || e.Type != "ticket" {
+		return RelationVerdicts{}
+	}
+	return RelationVerdicts{
+		Types: map[string]RelationVerdict{
+			"affects": {
+				Creatable: false,
+				Removable: true,
+			},
+			"implements": {
+				Creatable: true,
+				Removable: false,
+			},
+			"has-planning": {
+				Creatable: true,
+				Removable: true,
+				Fields: map[string]bool{
+					"note": false,
+				},
+			},
+		},
+	}
+}

--- a/internal/dataentry/affordances_test.go
+++ b/internal/dataentry/affordances_test.go
@@ -327,6 +327,109 @@ func appWithResolver(r FieldVerdictResolver) *App {
 	return &App{fieldResolver: r}
 }
 
+// verdictBuilder is a fluent helper for constructing fakeResolver
+// fixtures without nested struct literals. Each setter mutates and
+// returns the builder so calls chain; Build() snapshots a
+// fakeResolver suitable for assignment to App.fieldResolver.
+//
+// Conventions:
+//   - ReadOnly("field") marks a field non-writable.
+//   - Hidden("field") marks a field non-visible.
+//   - EnumDeny("field", "value") filters out a single enum option;
+//     repeat per option to deny several.
+//   - RelationDenyCreate / DenyRemove / DenyMeta wire the matching
+//     relation verdicts.
+//
+// Defaults are permissive: any field / option / relation not
+// explicitly denied is allowed. Matches the production semantics.
+type verdictBuilder struct {
+	fv FieldVerdicts
+	rv RelationVerdicts
+}
+
+// newVerdicts starts an empty builder.
+func newVerdicts() *verdictBuilder { return &verdictBuilder{} }
+
+// ReadOnly marks a field as non-writable.
+func (b *verdictBuilder) ReadOnly(field string) *verdictBuilder {
+	if b.fv.Writable == nil {
+		b.fv.Writable = make(map[string]bool)
+	}
+	b.fv.Writable[field] = false
+	return b
+}
+
+// Hidden marks a field as non-visible.
+func (b *verdictBuilder) Hidden(field string) *verdictBuilder {
+	if b.fv.Visible == nil {
+		b.fv.Visible = make(map[string]bool)
+	}
+	b.fv.Visible[field] = false
+	return b
+}
+
+// EnumDeny filters out a single enum option for the named field.
+// Call repeatedly to deny multiple options.
+func (b *verdictBuilder) EnumDeny(field, option string) *verdictBuilder {
+	if b.fv.Options == nil {
+		b.fv.Options = make(map[string]map[string]bool)
+	}
+	if b.fv.Options[field] == nil {
+		b.fv.Options[field] = make(map[string]bool)
+	}
+	b.fv.Options[field][option] = false
+	return b
+}
+
+// RelationDenyCreate denies create on the named relation type.
+// Removable + meta-field grants stay at their previous values (or
+// permissive default).
+func (b *verdictBuilder) RelationDenyCreate(relType string) *verdictBuilder {
+	rv := b.relationVerdict(relType)
+	rv.Creatable = false
+	b.rv.Types[relType] = rv
+	return b
+}
+
+// RelationDenyRemove denies remove on the named relation type.
+func (b *verdictBuilder) RelationDenyRemove(relType string) *verdictBuilder {
+	rv := b.relationVerdict(relType)
+	rv.Removable = false
+	b.rv.Types[relType] = rv
+	return b
+}
+
+// RelationDenyMeta denies write on a named meta field of the named
+// relation type. Creatable / Removable default to true (permissive)
+// so the test focuses on the meta-field gate alone.
+func (b *verdictBuilder) RelationDenyMeta(relType, metaField string) *verdictBuilder {
+	rv := b.relationVerdict(relType)
+	if rv.Fields == nil {
+		rv.Fields = make(map[string]bool)
+	}
+	rv.Fields[metaField] = false
+	b.rv.Types[relType] = rv
+	return b
+}
+
+// relationVerdict returns the entry for relType, lazily initializing
+// the Types map and applying permissive defaults for first-touch.
+func (b *verdictBuilder) relationVerdict(relType string) RelationVerdict {
+	if b.rv.Types == nil {
+		b.rv.Types = make(map[string]RelationVerdict)
+	}
+	rv, ok := b.rv.Types[relType]
+	if !ok {
+		rv = RelationVerdict{Creatable: true, Removable: true}
+	}
+	return rv
+}
+
+// Build snapshots the builder into a fakeResolver.
+func (b *verdictBuilder) Build() fakeResolver {
+	return fakeResolver{fv: b.fv, rv: b.rv}
+}
+
 func TestComputeFieldAffordances_NopResolver_EmitsEmptyMap(t *testing.T) {
 	a := appWithResolver(NopFieldVerdictResolver{})
 	got := a.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})

--- a/internal/dataentry/affordances_test.go
+++ b/internal/dataentry/affordances_test.go
@@ -1,6 +1,7 @@
 package dataentry
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
@@ -160,5 +161,389 @@ func TestComputeActions_NoAuditNoise(t *testing.T) {
 				t.Errorf("expected 0 audit records on read path, got %d: %+v", got, sink.Records())
 			}
 		})
+	}
+}
+
+func TestResolverFromProfile_None(t *testing.T) {
+	for _, in := range []string{"", "none"} {
+		t.Run(in, func(t *testing.T) {
+			r := ResolverFromProfile(in)
+			if _, ok := r.(NopFieldVerdictResolver); !ok {
+				t.Fatalf("ResolverFromProfile(%q): got %T, want NopFieldVerdictResolver", in, r)
+			}
+		})
+	}
+}
+
+func TestResolverFromProfile_Demo(t *testing.T) {
+	r := ResolverFromProfile("demo")
+	if _, ok := r.(DemoFieldVerdictResolver); !ok {
+		t.Fatalf("ResolverFromProfile(demo): got %T, want DemoFieldVerdictResolver", r)
+	}
+}
+
+func TestResolverFromProfile_Unknown_FallsBackToNone(t *testing.T) {
+	// Unknown values must not panic and must fall back to none. The
+	// warning log is observable in stderr; we don't capture it here.
+	r := ResolverFromProfile("not-a-real-profile")
+	if _, ok := r.(NopFieldVerdictResolver); !ok {
+		t.Fatalf("unknown profile: got %T, want NopFieldVerdictResolver", r)
+	}
+}
+
+func TestNopFieldVerdictResolver_ReturnsEmpty(t *testing.T) {
+	r := NopFieldVerdictResolver{}
+	e := &entity.Entity{ID: "TKT-1", Type: "ticket"}
+
+	fv := r.FieldVerdicts(context.Background(), e)
+	if fv.Writable != nil || fv.Visible != nil || fv.Options != nil {
+		t.Fatalf("NopFieldVerdictResolver.FieldVerdicts: want zero, got %+v", fv)
+	}
+
+	rv := r.RelationVerdicts(context.Background(), e)
+	if rv.Types != nil {
+		t.Fatalf("NopFieldVerdictResolver.RelationVerdicts: want zero, got %+v", rv)
+	}
+}
+
+func TestDemoFieldVerdictResolver_TicketFixture(t *testing.T) {
+	r := DemoFieldVerdictResolver{}
+	e := &entity.Entity{ID: "TKT-1", Type: "ticket"}
+
+	fv := r.FieldVerdicts(context.Background(), e)
+
+	if got, want := fv.Writable["kind"], false; got != want {
+		t.Errorf("Writable[kind]: got %v, want %v", got, want)
+	}
+	if got, want := fv.Visible["priority"], false; got != want {
+		t.Errorf("Visible[priority]: got %v, want %v", got, want)
+	}
+	if got, want := fv.Options["effort"]["l"], false; got != want {
+		t.Errorf("Options[effort][l]: got %v, want %v", got, want)
+	}
+	if got, want := fv.Options["effort"]["xl"], false; got != want {
+		t.Errorf("Options[effort][xl]: got %v, want %v", got, want)
+	}
+	if got, want := fv.Options["status"]["done"], false; got != want {
+		t.Errorf("Options[status][done]: got %v, want %v", got, want)
+	}
+	// Sparseness: properties not in the fixture must NOT appear.
+	if _, ok := fv.Writable["title"]; ok {
+		t.Errorf("Writable should be sparse; title appeared")
+	}
+	if _, ok := fv.Options["status"]["review"]; ok {
+		t.Errorf("Options[status] should be sparse; review appeared")
+	}
+
+	rv := r.RelationVerdicts(context.Background(), e)
+
+	cases := []struct {
+		typ          string
+		wantCreate   bool
+		wantRemove   bool
+		metaField    string
+		wantWritable bool
+	}{
+		{"affects", false, true, "", false},
+		{"implements", true, false, "", false},
+		{"has-planning", true, true, "note", false},
+	}
+	for _, c := range cases {
+		t.Run(c.typ, func(t *testing.T) {
+			v, ok := rv.Types[c.typ]
+			if !ok {
+				t.Fatalf("Types[%s] missing", c.typ)
+			}
+			if v.Creatable != c.wantCreate {
+				t.Errorf("Types[%s].Creatable: got %v, want %v", c.typ, v.Creatable, c.wantCreate)
+			}
+			if v.Removable != c.wantRemove {
+				t.Errorf("Types[%s].Removable: got %v, want %v", c.typ, v.Removable, c.wantRemove)
+			}
+			if c.metaField != "" {
+				if got := v.Fields[c.metaField]; got != c.wantWritable {
+					t.Errorf("Types[%s].Fields[%s]: got %v, want %v", c.typ, c.metaField, got, c.wantWritable)
+				}
+			}
+		})
+	}
+}
+
+func TestDemoFieldVerdictResolver_NonTicket_ReturnsEmpty(t *testing.T) {
+	r := DemoFieldVerdictResolver{}
+	e := &entity.Entity{ID: "X-1", Type: "feature"}
+
+	if fv := r.FieldVerdicts(context.Background(), e); fv.Writable != nil || fv.Visible != nil || fv.Options != nil {
+		t.Fatalf("non-ticket FieldVerdicts: want zero, got %+v", fv)
+	}
+	if rv := r.RelationVerdicts(context.Background(), e); rv.Types != nil {
+		t.Fatalf("non-ticket RelationVerdicts: want zero, got %+v", rv)
+	}
+}
+
+func TestDemoFieldVerdictResolver_NilEntity_ReturnsEmpty(t *testing.T) {
+	r := DemoFieldVerdictResolver{}
+	if fv := r.FieldVerdicts(context.Background(), nil); fv.Writable != nil {
+		t.Fatalf("nil entity: should be zero, got %+v", fv)
+	}
+	if rv := r.RelationVerdicts(context.Background(), nil); rv.Types != nil {
+		t.Fatalf("nil entity: should be zero, got %+v", rv)
+	}
+}
+
+// fakeResolver lets tests inject arbitrary verdicts without
+// instantiating an entity manager / metamodel.
+type fakeResolver struct {
+	fv FieldVerdicts
+	rv RelationVerdicts
+}
+
+func (f fakeResolver) FieldVerdicts(context.Context, *entity.Entity) FieldVerdicts {
+	return f.fv
+}
+func (f fakeResolver) RelationVerdicts(context.Context, *entity.Entity) RelationVerdicts {
+	return f.rv
+}
+
+// byTypeResolver returns different verdicts depending on the entity
+// type. Used by tests that need to prove the source-not-path-entity
+// resolution: an incoming-direction edge should resolve the verdict
+// against the SOURCE entity's type, not the path entity's type.
+type byTypeResolver struct {
+	rvByType map[string]RelationVerdicts
+}
+
+func (r byTypeResolver) FieldVerdicts(context.Context, *entity.Entity) FieldVerdicts {
+	return FieldVerdicts{}
+}
+func (r byTypeResolver) RelationVerdicts(_ context.Context, e *entity.Entity) RelationVerdicts {
+	if e == nil {
+		return RelationVerdicts{}
+	}
+	return r.rvByType[e.Type]
+}
+
+func appWithResolver(r FieldVerdictResolver) *App {
+	return &App{fieldResolver: r}
+}
+
+func TestComputeFieldAffordances_NopResolver_EmitsEmptyMap(t *testing.T) {
+	a := appWithResolver(NopFieldVerdictResolver{})
+	got := a.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	if got == nil {
+		t.Fatal("got nil, want empty map")
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty map (sparse: no deviations)", got)
+	}
+}
+
+func TestComputeFieldAffordances_SparseWritable(t *testing.T) {
+	// title=true is the default (writable) and must NOT appear in
+	// output; kind=false deviates and must be emitted.
+	a := appWithResolver(fakeResolver{
+		fv: FieldVerdicts{
+			Writable: map[string]bool{
+				"title": true,
+				"kind":  false,
+			},
+		},
+	})
+	got := a.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	if _, ok := got["title"]; ok {
+		t.Errorf("title should be absent (sparse: writable=true is default)")
+	}
+	kind, ok := got["kind"]
+	if !ok {
+		t.Fatalf("kind should be present")
+	}
+	if kind.Writable == nil || *kind.Writable {
+		t.Errorf("kind.Writable: got %v, want pointer-to-false", kind.Writable)
+	}
+}
+
+func TestComputeFieldAffordances_HiddenFieldsOmittedFromMap(t *testing.T) {
+	a := appWithResolver(fakeResolver{
+		fv: FieldVerdicts{
+			Writable: map[string]bool{"priority": false}, // also marked read-only
+			Visible:  map[string]bool{"priority": false}, // but hidden takes precedence
+			Options:  map[string]map[string]bool{"priority": {"high": false}},
+		},
+	})
+	got := a.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	if _, ok := got["priority"]; ok {
+		t.Errorf("hidden field must NOT appear in _fields (closed-world); got %+v", got)
+	}
+}
+
+func TestComputeFieldAffordances_SparseOptions(t *testing.T) {
+	// allowed values (backlog, in-progress) are the default and must
+	// be absent from output; done=false deviates and must be emitted.
+	a := appWithResolver(fakeResolver{
+		fv: FieldVerdicts{
+			Options: map[string]map[string]bool{
+				"status": {
+					"backlog":     true,
+					"in-progress": true,
+					"done":        false,
+				},
+			},
+		},
+	})
+	got := a.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	status, ok := got["status"]
+	if !ok {
+		t.Fatalf("status should be present")
+	}
+	if _, ok := status.Options["backlog"]; ok {
+		t.Errorf("backlog should be absent (sparse: allowed=true is default)")
+	}
+	if allowed, ok := status.Options["done"]; !ok || allowed {
+		t.Errorf("done should be present and false, got %v ok=%v", allowed, ok)
+	}
+}
+
+func TestComputeFieldAffordances_OptionsWithoutWritableEntry(t *testing.T) {
+	a := appWithResolver(fakeResolver{
+		fv: FieldVerdicts{
+			Options: map[string]map[string]bool{
+				"effort": {"l": false, "xl": false},
+			},
+		},
+	})
+	got := a.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	effort, ok := got["effort"]
+	if !ok {
+		t.Fatalf("effort should be present")
+	}
+	if effort.Writable != nil {
+		t.Errorf("Writable should be nil (no override), got %v", effort.Writable)
+	}
+	if len(effort.Options) != 2 {
+		t.Errorf("Options: got %d entries, want 2", len(effort.Options))
+	}
+}
+
+func TestComputeFieldAffordances_AllOptionsAllowed_NoEntry(t *testing.T) {
+	a := appWithResolver(fakeResolver{
+		fv: FieldVerdicts{
+			Options: map[string]map[string]bool{
+				"status": {"backlog": true, "ready": true},
+			},
+		},
+	})
+	got := a.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	if _, ok := got["status"]; ok {
+		t.Errorf("status should be absent when all options allowed")
+	}
+}
+
+func TestHiddenProperties_NopResolver_ReturnsNil(t *testing.T) {
+	a := appWithResolver(NopFieldVerdictResolver{})
+	if got := a.hiddenProperties(context.Background(), &entity.Entity{Type: "ticket"}); got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+}
+
+func TestHiddenProperties_OnlyHiddenEntries(t *testing.T) {
+	a := appWithResolver(fakeResolver{
+		fv: FieldVerdicts{
+			Visible: map[string]bool{
+				"title":    true,
+				"priority": false,
+			},
+		},
+	})
+	got := a.hiddenProperties(context.Background(), &entity.Entity{Type: "ticket"})
+	if _, ok := got["priority"]; !ok {
+		t.Errorf("priority should be in hidden set: %v", got)
+	}
+	if _, ok := got["title"]; ok {
+		t.Errorf("title should NOT be in hidden set (visible=true): %v", got)
+	}
+}
+
+func TestComputeRelationAffordances_NopResolver_EmitsEmptyMap(t *testing.T) {
+	a := appWithResolver(NopFieldVerdictResolver{})
+	got := a.computeRelationAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	if got == nil {
+		t.Fatal("got nil, want empty map")
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}
+
+func TestComputeRelationAffordances_SparseCreatableRemovable(t *testing.T) {
+	a := appWithResolver(fakeResolver{
+		rv: RelationVerdicts{
+			Types: map[string]RelationVerdict{
+				"affects":    {Creatable: false, Removable: true},
+				"implements": {Creatable: true, Removable: false},
+				"depends-on": {Creatable: true, Removable: true}, // all defaults; should be absent
+			},
+		},
+	})
+	got := a.computeRelationAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+
+	if _, ok := got["depends-on"]; ok {
+		t.Errorf("depends-on should be absent (all defaults)")
+	}
+
+	affects, ok := got["affects"]
+	if !ok {
+		t.Fatalf("affects should be present")
+	}
+	if affects.Creatable == nil || *affects.Creatable {
+		t.Errorf("affects.Creatable: got %v, want false-pointer", affects.Creatable)
+	}
+	if affects.Removable != nil {
+		t.Errorf("affects.Removable: got %v, want nil (sparse: removable=true default)", affects.Removable)
+	}
+
+	implements, ok := got["implements"]
+	if !ok {
+		t.Fatalf("implements should be present")
+	}
+	if implements.Creatable != nil {
+		t.Errorf("implements.Creatable: got %v, want nil", implements.Creatable)
+	}
+	if implements.Removable == nil || *implements.Removable {
+		t.Errorf("implements.Removable: got %v, want false-pointer", implements.Removable)
+	}
+}
+
+func TestComputeRelationAffordances_MetaFieldOverrides(t *testing.T) {
+	a := appWithResolver(fakeResolver{
+		rv: RelationVerdicts{
+			Types: map[string]RelationVerdict{
+				"has-planning": {
+					Creatable: true,
+					Removable: true,
+					Fields: map[string]bool{
+						"note": false,
+						"role": true, // default; absent
+					},
+				},
+			},
+		},
+	})
+	got := a.computeRelationAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	hp, ok := got["has-planning"]
+	if !ok {
+		t.Fatalf("has-planning should be present (meta-field deviation)")
+	}
+	if hp.Creatable != nil || hp.Removable != nil {
+		t.Errorf("Creatable/Removable should be nil (defaults), got %v/%v", hp.Creatable, hp.Removable)
+	}
+	if _, present := hp.Fields["role"]; present {
+		t.Errorf("role should be absent (writable=true default)")
+	}
+	note, ok := hp.Fields["note"]
+	if !ok {
+		t.Fatalf("note should be present")
+	}
+	if note.Writable == nil || *note.Writable {
+		t.Errorf("note.Writable: got %v, want false-pointer", note.Writable)
 	}
 }

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -38,11 +38,44 @@ type V1Entity struct {
 	Self         string                 `json:"_self,omitempty"`
 	Actions      map[string]bool        `json:"_actions,omitempty"`
 	Inaccessible []V1InaccessibleField  `json:"inaccessible,omitempty"`
+	// FieldAffordances carries per-field write affordances on per-entity
+	// GET responses. Sparse: only fields whose verdict deviates from the
+	// permissive default appear. Hidden fields are omitted from
+	// `Properties` AND from this map entirely. Pointer semantics
+	// distinguish "absent on the wire" (nil pointer; list / mutation
+	// responses) from "present and empty" (`{}`; per-entity GET with no
+	// deviations under nop resolver — closed-world signal matching the
+	// `_actions` precedent).
+	FieldAffordances *map[string]V1FieldAffordance `json:"_fields,omitempty"`
+	// RelationAffordances carries per-relation-type affordances on
+	// per-entity GET responses. Same pointer / closed-world semantics
+	// as FieldAffordances.
+	RelationAffordances *map[string]V1RelationAffordance `json:"_relations,omitempty"`
 	// Warnings lists soft-condition findings surfaced by the write
 	// path. Populated only by mutation responses (PATCH); read paths
 	// leave it nil. Each warning has a stable `code`, an RFC 6901
 	// JSON Pointer `path`, and a human-readable `detail`.
 	Warnings []Warning `json:"warnings,omitempty"`
+}
+
+// V1FieldAffordance describes per-field write / option affordances on
+// the wire. Sparse: `Writable` is nil when the default (writable)
+// holds; `Options` lists only the false entries (allowed options are
+// implicit via the metamodel). See the closed-world contract in
+// docs/data-entry/api-reference.md.
+type V1FieldAffordance struct {
+	Writable *bool           `json:"writable,omitempty"`
+	Options  map[string]bool `json:"options,omitempty"`
+}
+
+// V1RelationAffordance describes per-relation-type affordances on the
+// wire. Sparse: `Creatable` and `Removable` are nil when the default
+// (true) holds. `Fields` lists meta-field writability overrides, also
+// sparse.
+type V1RelationAffordance struct {
+	Creatable *bool                        `json:"creatable,omitempty"`
+	Removable *bool                        `json:"removable,omitempty"`
+	Fields    map[string]V1FieldAffordance `json:"fields,omitempty"`
 }
 
 // V1InaccessibleField describes a property that is known to exist but
@@ -359,7 +392,7 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 	data := make([]V1Entity, 0, len(entities))
 	included := make(map[string]V1Entity)
 	for _, e := range entities {
-		v1Entity := a.entityToV1(r.Context(), e, plural, true)
+		v1Entity := a.serializeRelatedEntityForWire(r.Context(), e, plural, true)
 		data = append(data, v1Entity)
 
 		// Resolve includes if requested
@@ -486,7 +519,7 @@ func (a *App) handleV1CreateEntity(w http.ResponseWriter, r *http.Request, typeN
 		}
 	}
 
-	result := a.entityToV1(r.Context(), created, plural, true)
+	result := a.serializeEntityForWire(r.Context(), created, plural, true)
 	if len(relWarnings) > 0 {
 		result.Warnings = append(result.Warnings, relWarnings...)
 	}
@@ -533,7 +566,9 @@ func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName
 	query := r.URL.Query()
 	includeRelations := true
 
-	result := a.entityToV1(r.Context(), entity, plural, includeRelations)
+	// Single per-entity serialization: strips hidden + attaches
+	// `_fields` / `_relations` per docs/data-entry/api-reference.md.
+	result := a.serializeEntityForWire(r.Context(), entity, plural, includeRelations)
 
 	// Handle includes for related entities
 	if includes := query.Get("include"); includes != "" {
@@ -604,6 +639,21 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 		}
 		writeV1Error(w, r, http.StatusBadRequest, "invalid_json", "Invalid JSON body", err.Error())
 		return
+	}
+
+	// Affordance parity (TKT-G7N5): reject writes that conflict with
+	// what the resolver would have surfaced on GET. Runs before any
+	// other validation so the failure mode is identical regardless of
+	// what else the PATCH body would have triggered.
+	if denial := a.validateFieldWrite(r.Context(), entity, req.Properties, req.PropertiesUnset); denial != nil {
+		a.denyAffordance(r.Context(), w, entity, *denial)
+		return
+	}
+	if req.Relations.Modern != nil {
+		if denial := a.validateRelationsModernAffordances(r.Context(), entityID, entity, req.Relations.Modern); denial != nil {
+			a.denyAffordance(r.Context(), w, entity, *denial)
+			return
+		}
 	}
 
 	// Phase A: validate relations (no writes). Returns warnings (will
@@ -680,7 +730,7 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 		}
 	}
 
-	result := a.entityToV1(r.Context(), entity, plural, true)
+	result := a.serializeEntityForWire(r.Context(), entity, plural, true)
 	if len(warnings) > 0 {
 		result.Warnings = warnings
 	}
@@ -889,6 +939,21 @@ func (a *App) handleV1CreateRelation(w http.ResponseWriter, r *http.Request, typ
 		return
 	}
 
+	// Affordance gates: creatable + meta-writable, evaluated against
+	// the SOURCE of the new edge (not necessarily the path entity —
+	// for incoming-direction creates the path entity is the target).
+	source := a.relationSourceEntity(entity, req.ID, req.Direction)
+	// Audit subject is the source of the new edge, matching the
+	// entity whose policy gated the write.
+	if denial := a.validateRelationOp(r.Context(), source, relType, RelationOpCreate); denial != nil {
+		a.denyAffordance(r.Context(), w, source, *denial)
+		return
+	}
+	if denial := a.validateRelationMetaWrite(r.Context(), source, relType, req.Meta, nil); denial != nil {
+		a.denyAffordance(r.Context(), w, source, *denial)
+		return
+	}
+
 	from, to := resolveRelationEndpoints(entity.ID, req.ID, req.Direction)
 
 	_, err := a.entityManager.CreateRelation(r.Context(), from, relType, to, entityPkg.RelationOptions{Properties: req.Meta})
@@ -934,6 +999,16 @@ func (a *App) handleV1UpdateRelation(w http.ResponseWriter, r *http.Request, typ
 		return
 	}
 
+	// Affordance gate: meta-writable, evaluated against the SOURCE of
+	// the edge (the path entity for outgoing; the peer for incoming).
+	// The edge already exists (PATCH is meta-only), so the create /
+	// remove gates don't apply.
+	source := a.relationSourceEntity(entity, targetID, req.Direction)
+	if denial := a.validateRelationMetaWrite(r.Context(), source, relType, req.Meta, nil); denial != nil {
+		a.denyAffordance(r.Context(), w, source, *denial)
+		return
+	}
+
 	from, to := resolveRelationEndpoints(entity.ID, targetID, req.Direction)
 
 	rel, err := a.entityManager.UpdateRelation(r.Context(), from, relType, to, entityPkg.RelationOptions{
@@ -970,7 +1045,18 @@ func (a *App) handleV1DeleteRelation(w http.ResponseWriter, r *http.Request, typ
 		return
 	}
 
-	from, to := resolveRelationEndpoints(entity.ID, targetID, r.URL.Query().Get("direction"))
+	// Affordance gate: removable check, evaluated against the SOURCE
+	// of the edge (the path entity for outgoing; the peer for
+	// incoming). Per-relation-type uniform — a removable=false
+	// verdict applies to every link of this type.
+	direction := r.URL.Query().Get("direction")
+	source := a.relationSourceEntity(entity, targetID, direction)
+	if denial := a.validateRelationOp(r.Context(), source, relType, RelationOpRemove); denial != nil {
+		a.denyAffordance(r.Context(), w, source, *denial)
+		return
+	}
+
+	from, to := resolveRelationEndpoints(entity.ID, targetID, direction)
 
 	if err := a.entityManager.DeleteRelation(r.Context(), from, relType, to); err != nil {
 		if writeForbiddenIfACLDenied(w, err) {
@@ -1036,7 +1122,7 @@ func (a *App) handleV1CloneEntity(w http.ResponseWriter, r *http.Request, typeNa
 
 	entityDef := s.Meta.Entities[typeName]
 	plural := entityDef.GetPlural(typeName)
-	result := a.entityToV1(r.Context(), newEntity, plural, false)
+	result := a.serializeEntityForWire(r.Context(), newEntity, plural, false)
 
 	w.Header().Set("Location", fmt.Sprintf("/api/v1/%s/%s", plural, newEntity.ID))
 	writeV1JSON(w, http.StatusCreated, result)
@@ -1240,7 +1326,7 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 	for _, e := range entities {
 		entityDef := meta.Entities[e.Type]
 		plural := entityDef.GetPlural(e.Type)
-		data = append(data, a.entityToV1(r.Context(), e, plural, false))
+		data = append(data, a.serializeRelatedEntityForWire(r.Context(), e, plural, false))
 	}
 
 	resp := V1ListResponse{
@@ -1349,7 +1435,7 @@ func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, i
 			}
 			entityDef := s.Meta.Entities[target.Type]
 			plural := entityDef.GetPlural(target.Type)
-			included[target.ID] = a.entityToV1(ctx, target, plural, false)
+			included[target.ID] = a.serializeRelatedEntityForWire(ctx, target, plural, false)
 		}
 		// Include all incoming relations
 		for _, edge := range a.incomingRelations(entity.ID) {
@@ -1359,7 +1445,7 @@ func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, i
 			}
 			entityDef := s.Meta.Entities[source.Type]
 			plural := entityDef.GetPlural(source.Type)
-			included[source.ID] = a.entityToV1(ctx, source, plural, false)
+			included[source.ID] = a.serializeRelatedEntityForWire(ctx, source, plural, false)
 		}
 		return included
 	}
@@ -1385,7 +1471,7 @@ func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, i
 			}
 			entityDef := s.Meta.Entities[target.Type]
 			plural := entityDef.GetPlural(target.Type)
-			included[target.ID] = a.entityToV1(ctx, target, plural, false)
+			included[target.ID] = a.serializeRelatedEntityForWire(ctx, target, plural, false)
 
 			// Handle nested includes
 			if len(relParts) > 1 {
@@ -2645,7 +2731,7 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 	plural := entityDef.GetPlural(result.Entry.Type)
 
 	resp := V1ViewResponse{
-		Entry:    a.entityToV1(r.Context(), result.Entry, plural, true),
+		Entry:    a.serializeEntityForWire(r.Context(), result.Entry, plural, true),
 		Sections: make([]V1ViewSection, 0, len(sections)),
 	}
 

--- a/internal/dataentry/api_v1_properties_unset_test.go
+++ b/internal/dataentry/api_v1_properties_unset_test.go
@@ -38,6 +38,18 @@ func patchTicketJSON(t *testing.T, app *App, body string) (int, updateResponse) 
 	return rec.Code, resp
 }
 
+// patchTicketRaw returns the raw response body for assertions that
+// need to inspect non-V1Entity-shaped responses (e.g. 403 affordance
+// denials).
+func patchTicketRaw(t *testing.T, app *App, body string) (code int, respBody string) {
+	t.Helper()
+	const entityID = "TKT-001"
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/"+entityID, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	app.handleV1UpdateEntity(rec, req, "ticket", "tickets", entityID)
+	return rec.Code, rec.Body.String()
+}
+
 // AC15: PATCH with `properties_unset` removes the named keys.
 func TestV1UpdateEntity_PropertiesUnset_RemovesKeys(t *testing.T) {
 	app := newTestAppV1(t)
@@ -76,7 +88,14 @@ func TestV1UpdateEntity_PropertiesUnset_RemovesKeys(t *testing.T) {
 
 // AC16: PATCH with `properties_unset` of an undeclared key produces a
 // `unknown_property_unset_key` warning (200 + warning, DEC-HWZHA).
-func TestV1UpdateEntity_PropertiesUnset_UnknownKeyWarns(t *testing.T) {
+// TKT-G7N5 F8: unknown property unset keys are now rejected with 403
+// (rule_id=field-affordance:hidden) — the same shape as a true
+// hidden-field rejection. This closes the side channel where unknown
+// vs hidden produced distinguishable responses. The previous
+// behavior was a 200 with an `unknown_property_unset_key` warning;
+// that behavior is incompatible with the affordance-parity invariant
+// and was removed.
+func TestV1UpdateEntity_PropertiesUnset_UnknownKey_Forbidden(t *testing.T) {
 	app := newTestAppV1(t)
 	app.broker = newEventBroker()
 	bindRepo(app, t.TempDir())
@@ -87,25 +106,16 @@ func TestV1UpdateEntity_PropertiesUnset_UnknownKeyWarns(t *testing.T) {
 		Properties: map[string]interface{}{"title": "x", "status": "open"},
 	})
 
-	code, resp := patchTicketJSON(t, app,
+	code, body := patchTicketRaw(t, app,
 		`{"properties_unset":["nonexistent_property"]}`)
-	if code != http.StatusOK {
-		t.Fatalf("PATCH returned %d", code)
+	if code != http.StatusForbidden {
+		t.Fatalf("PATCH returned %d, want 403; body=%s", code, body)
 	}
-	if len(resp.Warnings) == 0 {
-		t.Fatal("expected at least one warning")
+	if !strings.Contains(body, `"rule_kind":"affordance"`) {
+		t.Errorf("body should name rule_kind=affordance; got: %s", body)
 	}
-	var found bool
-	for _, w := range resp.Warnings {
-		if w.Code == "unknown_property_unset_key" && strings.Contains(w.Path, "0") {
-			found = true
-			if !strings.Contains(w.Detail, "nonexistent_property") {
-				t.Errorf("warning detail should name the key: %q", w.Detail)
-			}
-		}
-	}
-	if !found {
-		t.Errorf("expected unknown_property_unset_key warning, got %+v", resp.Warnings)
+	if !strings.Contains(body, `"rule_id":"field-affordance:hidden:nonexistent_property"`) {
+		t.Errorf("body should contain hidden-shaped rule_id; got: %s", body)
 	}
 }
 

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -4392,12 +4392,10 @@ func seedDemoTicketForPatch(t *testing.T) *App {
 	app := newTestAppV1(t)
 	app.broker = newEventBroker()
 	bindRepo(app, t.TempDir())
-	app.fieldResolver = fakeResolver{
-		fv: FieldVerdicts{
-			Writable: map[string]bool{"status": false}, // read-only
-			Options:  map[string]map[string]bool{"title": {"forbidden-title": false}},
-		},
-	}
+	app.fieldResolver = newVerdicts().
+		ReadOnly("status").
+		EnumDeny("title", "forbidden-title").
+		Build()
 	seedEntity(app, &entity.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
@@ -4563,6 +4561,49 @@ func TestAppRouter_PatchFilteredOption_Forbidden(t *testing.T) {
 
 	t.Run("allowed value succeeds", func(t *testing.T) {
 		code, body := patchTicketRaw(t, app, `{"properties":{"title":"any-other-value"}}`)
+		if code != http.StatusOK {
+			t.Fatalf("got %d, want 200; body=%s", code, body)
+		}
+	})
+}
+
+// TestAppRouter_PatchFilteredListEnum_Forbidden proves the
+// list-typed enum option-filter now rejects rather than silently
+// allowing. Before this change, a `tags: [allowed, denied]` PATCH
+// would slip through because the validator only knew how to inspect
+// scalar string values. This is the security-soft-spot the cranky
+// reviewer flagged as S5.
+func TestAppRouter_PatchFilteredListEnum_Forbidden(t *testing.T) {
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+	app.fieldResolver = fakeResolver{
+		fv: FieldVerdicts{
+			Options: map[string]map[string]bool{
+				"tags": {"forbidden-tag": false},
+			},
+		},
+	}
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "x", "status": "open"},
+	})
+
+	t.Run("forbidden element rejects the whole list", func(t *testing.T) {
+		code, body := patchTicketRaw(t, app,
+			`{"properties":{"tags":["ok-tag","forbidden-tag"]}}`)
+		if code != http.StatusForbidden {
+			t.Fatalf("got %d, want 403; body=%s", code, body)
+		}
+		if !strings.Contains(body, `"field-affordance:enum-filtered:tags=forbidden-tag"`) {
+			t.Errorf("body must name the forbidden element: %s", body)
+		}
+	})
+
+	t.Run("all-allowed list succeeds", func(t *testing.T) {
+		code, body := patchTicketRaw(t, app,
+			`{"properties":{"tags":["a","b","c"]}}`)
 		if code != http.StatusOK {
 			t.Fatalf("got %d, want 200; body=%s", code, body)
 		}

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -4105,5 +4107,747 @@ func TestV1Views_MentionsAbsentWhenNoRefs(t *testing.T) {
 	// documented wire contract.
 	if strings.Contains(rec.Body.String(), `"mentions"`) {
 		t.Errorf("response must omit mentions when none collected; body: %s", rec.Body.String())
+	}
+}
+
+// TKT-G7N5 wire-shape tests (AC1, AC2).
+
+// TestAppRouter_PerEntityGet_NoneProfile asserts AC1: under the nop
+// resolver, per-entity GET responses contain `_fields: {}` and
+// `_relations: {}` (present-but-empty closed-world signal), and no
+// properties are omitted.
+func TestAppRouter_PerEntityGet_NoneProfile(t *testing.T) {
+	app := newTestAppV1(t)
+	app.fieldResolver = NopFieldVerdictResolver{}
+
+	seedEntity(app, &entity.Entity{
+		ID:   "TKT-001",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title":  "Test Ticket",
+			"status": "open",
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	raw := rec.Body.String()
+
+	var got V1Entity
+	if err := json.NewDecoder(strings.NewReader(raw)).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got.FieldAffordances == nil {
+		t.Fatal("FieldAffordances pointer should be non-nil (closed-world signal)")
+	}
+	if len(*got.FieldAffordances) != 0 {
+		t.Errorf("FieldAffordances: got %v, want empty (sparse, no deviations)", *got.FieldAffordances)
+	}
+	if got.RelationAffordances == nil {
+		t.Fatal("RelationAffordances pointer should be non-nil")
+	}
+	if len(*got.RelationAffordances) != 0 {
+		t.Errorf("RelationAffordances: got %v, want empty", *got.RelationAffordances)
+	}
+
+	if _, ok := got.Properties["title"]; !ok {
+		t.Errorf("properties.title missing under nop")
+	}
+	if _, ok := got.Properties["status"]; !ok {
+		t.Errorf("properties.status missing under nop")
+	}
+
+	// Wire format: both keys must appear in the raw JSON as `{}` so
+	// the SPA distinguishes "anonymous fallback" (absent) from
+	// "evaluated with no deviations" (present-empty). Round-tripping
+	// V1Entity through omitempty proves this for pointer fields.
+	if !strings.Contains(raw, `"_fields":{}`) {
+		t.Errorf("raw body should contain \"_fields\":{}; got: %s", raw)
+	}
+	if !strings.Contains(raw, `"_relations":{}`) {
+		t.Errorf("raw body should contain \"_relations\":{}; got: %s", raw)
+	}
+}
+
+// TestAppRouter_PerEntityGet_DemoFixture asserts AC2: the demo
+// resolver populates the expected sparse fixture verdicts. Uses a
+// hand-rolled fixture resolver to keep the test independent of the
+// project's real metamodel (which doesn't have all the demo fields).
+func TestAppRouter_PerEntityGet_DemoFixture(t *testing.T) {
+	app := newTestAppV1(t)
+	falseVal := false
+
+	// Inline fixture: read-only on `status`, hidden on `priority`,
+	// option-filter on `status`. The newTestAppV1 metamodel declares
+	// `title` and `status` on ticket; we add `priority` to the entity
+	// via the seed.
+	app.fieldResolver = fakeResolver{
+		fv: FieldVerdicts{
+			Writable: map[string]bool{"status": false},
+			Visible:  map[string]bool{"priority": false},
+			Options:  map[string]map[string]bool{"status": {"done": false}},
+		},
+		rv: RelationVerdicts{
+			Types: map[string]RelationVerdict{
+				"implements": {Creatable: true, Removable: false},
+				"blocks":     {Creatable: false, Removable: true},
+			},
+		},
+	}
+
+	seedEntity(app, &entity.Entity{
+		ID:   "TKT-002",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title":    "Demo Ticket",
+			"status":   "open",
+			"priority": "high",
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-002", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-002")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got V1Entity
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Hidden property is omitted.
+	if _, ok := got.Properties["priority"]; ok {
+		t.Errorf("properties.priority must be omitted (hidden); got %v", got.Properties)
+	}
+	if _, ok := got.Properties["title"]; !ok {
+		t.Errorf("properties.title should still be present")
+	}
+
+	// FieldAffordances: sparse — status is read-only AND has option filter,
+	// merged into one entry.
+	if got.FieldAffordances == nil {
+		t.Fatal("FieldAffordances nil")
+	}
+	fa := *got.FieldAffordances
+	if _, ok := fa["priority"]; ok {
+		t.Errorf("priority must be absent from _fields (hidden): %v", fa)
+	}
+	if _, ok := fa["title"]; ok {
+		t.Errorf("title must be absent from _fields (default writable): %v", fa)
+	}
+	status, ok := fa["status"]
+	if !ok {
+		t.Fatalf("status missing from _fields: %v", fa)
+	}
+	if status.Writable == nil || *status.Writable != falseVal {
+		t.Errorf("status.writable: got %v, want false-pointer", status.Writable)
+	}
+	if allowed, present := status.Options["done"]; !present || allowed {
+		t.Errorf("status.options.done: got %v present=%v, want false", allowed, present)
+	}
+
+	// RelationAffordances: sparse — implements (removable=false),
+	// blocks (creatable=false).
+	if got.RelationAffordances == nil {
+		t.Fatal("RelationAffordances nil")
+	}
+	ra := *got.RelationAffordances
+	impl, ok := ra["implements"]
+	if !ok {
+		t.Fatalf("implements missing from _relations: %v", ra)
+	}
+	if impl.Creatable != nil {
+		t.Errorf("implements.creatable: got %v, want nil (default)", impl.Creatable)
+	}
+	if impl.Removable == nil || *impl.Removable {
+		t.Errorf("implements.removable: got %v, want false-pointer", impl.Removable)
+	}
+	blocks, ok := ra["blocks"]
+	if !ok {
+		t.Fatalf("blocks missing from _relations: %v", ra)
+	}
+	if blocks.Creatable == nil || *blocks.Creatable {
+		t.Errorf("blocks.creatable: got %v, want false-pointer", blocks.Creatable)
+	}
+}
+
+// TestAppRouter_PatchEcho_StripsHidden proves the C2 fix: PATCH
+// responses must run through the same strip-hidden invariant as GET.
+// Before the fix, the PATCH success response echoed the full entity
+// including hidden properties, so a stale client could observe the
+// hidden value via its own write response.
+func TestAppRouter_PatchEcho_StripsHidden(t *testing.T) {
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+	app.fieldResolver = fakeResolver{
+		fv: FieldVerdicts{
+			Visible: map[string]bool{"title": false}, // hide the title field
+		},
+	}
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "secret", "status": "open"},
+	})
+
+	// PATCH an unrelated property (status) and inspect the echo.
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/TKT-001",
+		strings.NewReader(`{"properties":{"status":"in-progress"}}`))
+	rec := httptest.NewRecorder()
+	app.handleV1UpdateEntity(rec, req, "ticket", "tickets", "TKT-001")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH returned %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, `"title"`) || strings.Contains(body, "secret") {
+		t.Errorf("PATCH echo must NOT contain hidden field; got: %s", body)
+	}
+}
+
+// TestAppRouter_Includes_StripHidden proves the C3 fix: ?include=*
+// (and named includes) must strip hidden properties from related
+// entities. Before the fix, a related entity's hidden field could
+// leak through the `included` map.
+func TestAppRouter_Includes_StripHidden(t *testing.T) {
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+	app.fieldResolver = fakeResolver{
+		fv: FieldVerdicts{
+			Visible: map[string]bool{"title": false}, // hide title on every entity
+		},
+	}
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "ticket-secret"},
+	})
+	seedEntity(app, &entity.Entity{
+		ID:         "FEAT-001",
+		Type:       "feature",
+		Properties: map[string]interface{}{"title": "feature-secret"},
+	})
+	bindEdge(app, "TKT-001", "implements", "FEAT-001")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001?include=*", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET returned %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "ticket-secret") {
+		t.Errorf("body must NOT contain ticket's hidden title; got: %s", body)
+	}
+	if strings.Contains(body, "feature-secret") {
+		t.Errorf("body must NOT contain included feature's hidden title; got: %s", body)
+	}
+}
+
+// TestAppRouter_CollectionList_StripHidden asserts that list rows
+// (which use serializeRelatedEntityForWire) strip hidden properties
+// too — the wire invariant holds regardless of which response shape
+// the entity rides in.
+func TestAppRouter_CollectionList_StripHidden(t *testing.T) {
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+	app.fieldResolver = fakeResolver{
+		fv: FieldVerdicts{
+			Visible: map[string]bool{"title": false},
+		},
+	}
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "list-secret"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1EntityCollection(rec, req, "ticket", "tickets")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET returned %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "list-secret") {
+		t.Errorf("list row must NOT contain hidden title; got: %s", body)
+	}
+}
+
+// seedDemoTicketForPatch wires a fakeResolver fixture appropriate for
+// the AC3-AC5 PATCH tests and seeds TKT-PATCH. Returns the
+// patchTicket-style raw helper bound to this entity.
+func seedDemoTicketForPatch(t *testing.T) *App {
+	t.Helper()
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+	app.fieldResolver = fakeResolver{
+		fv: FieldVerdicts{
+			Writable: map[string]bool{"status": false}, // read-only
+			Options:  map[string]map[string]bool{"title": {"forbidden-title": false}},
+		},
+	}
+	seedEntity(app, &entity.Entity{
+		ID:   "TKT-001",
+		Type: "ticket",
+		Properties: map[string]interface{}{
+			"title":  "Original",
+			"status": "open",
+		},
+	})
+	return app
+}
+
+// AC3: hidden + unknown fields produce structurally identical 403
+// responses (F8 side channel closure).
+func TestAppRouter_PatchHiddenAndUnknownField_SameShape(t *testing.T) {
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+	app.fieldResolver = fakeResolver{
+		fv: FieldVerdicts{
+			Visible: map[string]bool{"title": false}, // hide a declared field
+		},
+	}
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "x", "status": "open"},
+	})
+
+	hiddenCode, hiddenBody := patchTicketRaw(t, app, `{"properties":{"title":"new"}}`)
+	if hiddenCode != http.StatusForbidden {
+		t.Fatalf("hidden field: got %d, want 403; body=%s", hiddenCode, hiddenBody)
+	}
+	unknownCode, unknownBody := patchTicketRaw(t, app, `{"properties":{"bogus_field":"v"}}`)
+	if unknownCode != http.StatusForbidden {
+		t.Fatalf("unknown field: got %d, want 403; body=%s", unknownCode, unknownBody)
+	}
+
+	// Both must use the same rule_kind and rule_id prefix; only the
+	// field name in the path varies. This is the F8 side-channel
+	// closure assertion.
+	for _, body := range []string{hiddenBody, unknownBody} {
+		if !strings.Contains(body, `"rule_kind":"affordance"`) {
+			t.Errorf("body must name rule_kind=affordance: %s", body)
+		}
+		if !strings.Contains(body, `"rule_id":"field-affordance:hidden:`) {
+			t.Errorf("body must use field-affordance:hidden prefix: %s", body)
+		}
+	}
+}
+
+// AC4: read-only fields reject writes regardless of value.
+func TestAppRouter_PatchReadOnlyField_Forbidden(t *testing.T) {
+	t.Run("different value", func(t *testing.T) {
+		app := seedDemoTicketForPatch(t)
+		code, body := patchTicketRaw(t, app, `{"properties":{"status":"closed"}}`)
+		if code != http.StatusForbidden {
+			t.Fatalf("got %d, want 403; body=%s", code, body)
+		}
+		if !strings.Contains(body, `"rule_id":"field-affordance:read-only:status"`) {
+			t.Errorf("body must name read-only rule: %s", body)
+		}
+	})
+
+	t.Run("same value", func(t *testing.T) {
+		// F12: read-only is strict — same-value writes still 403.
+		// useAutoSave suppresses no-op PATCHes client-side, so no real
+		// SPA path exercises this; the rejection exists for defense
+		// against hand-crafted clients.
+		app := seedDemoTicketForPatch(t)
+		code, body := patchTicketRaw(t, app, `{"properties":{"status":"open"}}`)
+		if code != http.StatusForbidden {
+			t.Fatalf("got %d, want 403; body=%s", code, body)
+		}
+	})
+
+	t.Run("mixed with writable; whole PATCH rejected", func(t *testing.T) {
+		app := seedDemoTicketForPatch(t)
+		code, body := patchTicketRaw(t, app, `{"properties":{"status":"closed","title":"New"}}`)
+		if code != http.StatusForbidden {
+			t.Fatalf("got %d, want 403; body=%s", code, body)
+		}
+		// Verify title was NOT updated.
+		e, _ := app.getEntity("TKT-001")
+		if e.Properties["title"] != "Original" {
+			t.Errorf("title must not be applied when status fails: got %v", e.Properties["title"])
+		}
+	})
+
+	t.Run("unset is a write", func(t *testing.T) {
+		// F16: properties_unset on a read-only field is also a write.
+		app := seedDemoTicketForPatch(t)
+		code, body := patchTicketRaw(t, app, `{"properties_unset":["status"]}`)
+		if code != http.StatusForbidden {
+			t.Fatalf("got %d, want 403; body=%s", code, body)
+		}
+		if !strings.Contains(body, `"field-affordance:read-only:status"`) {
+			t.Errorf("body must name read-only rule: %s", body)
+		}
+	})
+}
+
+// TestAppRouter_AffordanceDenial_EmitsAudit proves the C5 fix: every
+// affordance-gate rejection produces a `denied-write` audit row
+// attributed to the request principal. The wire stream is uniform
+// with ACL denials (which the entitymanager emits the same op for),
+// so log readers see one stream for every denied write regardless of
+// whether the gate fired in the manager or in the dataentry handler.
+func TestAppRouter_AffordanceDenial_EmitsAudit(t *testing.T) {
+	sink := audit.NewMemory()
+	app := buildAppWithACLAndAudit(t, acl.NopACL{}, sink)
+	app.fieldResolver = fakeResolver{
+		fv: FieldVerdicts{
+			Writable: map[string]bool{"status": false},
+		},
+	}
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "x", "status": "open"},
+	})
+
+	// Trigger a read-only denial via PATCH.
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/TKT-001",
+		strings.NewReader(`{"properties":{"status":"closed"}}`))
+	rec := httptest.NewRecorder()
+	app.handleV1UpdateEntity(rec, req, "ticket", "tickets", "TKT-001")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("PATCH: got %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+
+	records := sink.Records()
+	if len(records) != 1 {
+		t.Fatalf("audit records: got %d, want 1; records=%+v", len(records), records)
+	}
+	rec0 := records[0]
+	if rec0.Op != audit.OpDeniedWrite {
+		t.Errorf("audit op: got %q, want %q", rec0.Op, audit.OpDeniedWrite)
+	}
+	if rec0.Subject == nil || rec0.Subject.ID != "TKT-001" || rec0.Subject.Type != "ticket" {
+		t.Errorf("audit subject: got %+v, want entity:ticket:TKT-001", rec0.Subject)
+	}
+	if !strings.Contains(rec0.Summary, "rule_kind=affordance") {
+		t.Errorf("audit summary missing rule_kind=affordance: %q", rec0.Summary)
+	}
+	if !strings.Contains(rec0.Summary, "rule_id=field-affordance:read-only:status") {
+		t.Errorf("audit summary missing rule_id: %q", rec0.Summary)
+	}
+}
+
+// AC5: filtered enum options reject writes.
+func TestAppRouter_PatchFilteredOption_Forbidden(t *testing.T) {
+	app := seedDemoTicketForPatch(t)
+
+	t.Run("filtered value rejected", func(t *testing.T) {
+		code, body := patchTicketRaw(t, app, `{"properties":{"title":"forbidden-title"}}`)
+		if code != http.StatusForbidden {
+			t.Fatalf("got %d, want 403; body=%s", code, body)
+		}
+		if !strings.Contains(body, `"field-affordance:enum-filtered:title=forbidden-title"`) {
+			t.Errorf("body must name enum-filtered rule with value: %s", body)
+		}
+	})
+
+	t.Run("allowed value succeeds", func(t *testing.T) {
+		code, body := patchTicketRaw(t, app, `{"properties":{"title":"any-other-value"}}`)
+		if code != http.StatusOK {
+			t.Fatalf("got %d, want 200; body=%s", code, body)
+		}
+	})
+}
+
+// bindEdge inserts an edge directly through the store. Used by tests
+// that need a pre-existing edge to remove or update via the API.
+// relType is parameterized intentionally; today every caller passes
+// "implements" but the helper exists to be used with any relation
+// type as new tests need them.
+//
+//nolint:unparam // see preceding doc comment
+func bindEdge(app *App, from, relType, to string) {
+	if _, err := app.store.CreateRelation(context.Background(), from, relType, to, nil); err != nil {
+		panic(err)
+	}
+}
+
+// seedTicketWithRelationVerdicts wires fake relation verdicts and
+// seeds a ticket plus a peer feature so create/delete can target a
+// real edge.
+func seedTicketWithRelationVerdicts(t *testing.T, rv RelationVerdicts) *App {
+	t.Helper()
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+	app.fieldResolver = fakeResolver{rv: rv}
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "x", "status": "open"},
+	})
+	seedEntity(app, &entity.Entity{
+		ID:         "FEAT-001",
+		Type:       "feature",
+		Properties: map[string]interface{}{"title": "Feature"},
+	})
+	return app
+}
+
+// AC6: per-relation POST is gated by creatable; per-relation DELETE
+// is gated by removable. Per-relation-type uniform: the 403 response
+// names the relation type but no link identifier (F5).
+func TestAppRouter_PerRelationCreate_ForbiddenWhenNotCreatable(t *testing.T) {
+	app := seedTicketWithRelationVerdicts(t, RelationVerdicts{
+		Types: map[string]RelationVerdict{
+			"implements": {Creatable: false, Removable: true},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tickets/TKT-001/relations/implements",
+		strings.NewReader(`{"id":"FEAT-001"}`))
+	rec := httptest.NewRecorder()
+	app.handleV1CreateRelation(rec, req, "ticket", "TKT-001", "implements")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("got %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"rule_id":"relation-affordance:not-creatable:implements"`) {
+		t.Errorf("body must name not-creatable rule with type; got: %s", body)
+	}
+	if strings.Contains(body, "FEAT-001") {
+		t.Errorf("body must NOT contain the link identifier (per-type uniform); got: %s", body)
+	}
+}
+
+func TestAppRouter_PerRelationDelete_ForbiddenWhenNotRemovable(t *testing.T) {
+	app := seedTicketWithRelationVerdicts(t, RelationVerdicts{
+		Types: map[string]RelationVerdict{
+			"implements": {Creatable: true, Removable: false},
+		},
+	})
+	// Pre-link the edge so DELETE has something to remove.
+	bindEdge(app, "TKT-001", "implements", "FEAT-001")
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/tickets/TKT-001/relations/implements/FEAT-001", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1DeleteRelation(rec, req, "ticket", "TKT-001", "implements", "FEAT-001")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("got %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"rule_id":"relation-affordance:not-removable:implements"`) {
+		t.Errorf("body must name not-removable rule with type; got: %s", body)
+	}
+}
+
+func TestAppRouter_PerRelationCreate_AllowedWhenCreatable(t *testing.T) {
+	app := seedTicketWithRelationVerdicts(t, RelationVerdicts{
+		Types: map[string]RelationVerdict{
+			"implements": {Creatable: true, Removable: true},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tickets/TKT-001/relations/implements",
+		strings.NewReader(`{"id":"FEAT-001"}`))
+	rec := httptest.NewRecorder()
+	app.handleV1CreateRelation(rec, req, "ticket", "TKT-001", "implements")
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("got %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestAppRouter_PerRelationCreate_IncomingResolvesAgainstSource proves
+// the C4 fix: an incoming-direction POST creates an edge whose SOURCE
+// is the peer, not the path entity. The affordance verdict must be
+// evaluated against the source's type.
+//
+// Setup: path entity is `concept`, peer is `ticket`. The ticket type's
+// verdict denies create of `affects`; the concept's verdict permits
+// it. A direction=incoming POST to /concepts/<id>/relations/affects
+// creates a ticket --affects--> concept edge — the source is the
+// ticket, so the deny must fire.
+//
+// Before the C4 fix this returned 201 (verdict evaluated against the
+// concept, which permitted it). After the fix it returns 403.
+func TestAppRouter_PerRelationCreate_IncomingResolvesAgainstSource(t *testing.T) {
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+	app.fieldResolver = byTypeResolver{
+		rvByType: map[string]RelationVerdicts{
+			"ticket": {
+				Types: map[string]RelationVerdict{
+					"affects": {Creatable: false, Removable: true},
+				},
+			},
+			// concept verdict: implicit defaults (everything permitted).
+		},
+	}
+	// The test metamodel doesn't declare `affects`, but the demo
+	// metamodel does. We seed both ticket + concept entities; the
+	// relation create path doesn't validate against the metamodel
+	// here — it's the resolver's job that we're testing.
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{"title": "T"}})
+	seedEntity(app, &entity.Entity{ID: "CONC-001", Type: "concept", Properties: map[string]interface{}{"title": "C"}})
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/concepts/CONC-001/relations/affects",
+		strings.NewReader(`{"id":"TKT-001","direction":"incoming"}`))
+	rec := httptest.NewRecorder()
+	app.handleV1CreateRelation(rec, req, "concept", "CONC-001", "affects")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("got %d, want 403 (incoming-direction must resolve verdict against source); body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"rule_id":"relation-affordance:not-creatable:affects"`) {
+		t.Errorf("body must name not-creatable rule: %s", rec.Body.String())
+	}
+}
+
+// AC6: unified PATCH path that ADDS or REMOVES relations is gated by
+// the same verdicts.
+func TestAppRouter_UnifiedPatchAddRelation_ForbiddenWhenNotCreatable(t *testing.T) {
+	app := seedTicketWithRelationVerdicts(t, RelationVerdicts{
+		Types: map[string]RelationVerdict{
+			"implements": {Creatable: false, Removable: true},
+		},
+	})
+	code, body := patchTicketRaw(t, app,
+		`{"relations":{"implements":{"data":[{"type":"feature","id":"FEAT-001"}]}}}`)
+	if code != http.StatusForbidden {
+		t.Fatalf("got %d, want 403; body=%s", code, body)
+	}
+	if !strings.Contains(body, `"rule_id":"relation-affordance:not-creatable:implements"`) {
+		t.Errorf("body must name not-creatable rule: %s", body)
+	}
+}
+
+func TestAppRouter_UnifiedPatchRemoveRelation_ForbiddenWhenNotRemovable(t *testing.T) {
+	app := seedTicketWithRelationVerdicts(t, RelationVerdicts{
+		Types: map[string]RelationVerdict{
+			"implements": {Creatable: true, Removable: false},
+		},
+	})
+	// Pre-link the edge so the empty desired set is a true removal.
+	bindEdge(app, "TKT-001", "implements", "FEAT-001")
+
+	code, body := patchTicketRaw(t, app,
+		`{"relations":{"implements":{"data":[]}}}`)
+	if code != http.StatusForbidden {
+		t.Fatalf("got %d, want 403; body=%s", code, body)
+	}
+	if !strings.Contains(body, `"rule_id":"relation-affordance:not-removable:implements"`) {
+		t.Errorf("body must name not-removable rule: %s", body)
+	}
+}
+
+// AC7: relation-meta gate. Same shape across the three meta-write
+// paths: POST creates with meta, PATCH /relations/<t>/<id> updates
+// meta, unified PATCH upserts meta.
+func TestAppRouter_RelationMeta_ForbiddenWhenNotWritable(t *testing.T) {
+	rv := RelationVerdicts{
+		Types: map[string]RelationVerdict{
+			"implements": {
+				Creatable: true,
+				Removable: true,
+				Fields:    map[string]bool{"note": false},
+			},
+		},
+	}
+
+	t.Run("POST /relations/<type> with non-writable meta", func(t *testing.T) {
+		app := seedTicketWithRelationVerdicts(t, rv)
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/v1/tickets/TKT-001/relations/implements",
+			strings.NewReader(`{"id":"FEAT-001","meta":{"note":"hi"}}`))
+		rec := httptest.NewRecorder()
+		app.handleV1CreateRelation(rec, req, "ticket", "TKT-001", "implements")
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("got %d, want 403; body=%s", rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), `"rule_id":"relation-affordance:meta-read-only:implements.note"`) {
+			t.Errorf("body must name meta-read-only rule: %s", rec.Body.String())
+		}
+	})
+
+	t.Run("PATCH /relations/<type>/<id> with non-writable meta", func(t *testing.T) {
+		app := seedTicketWithRelationVerdicts(t, rv)
+		bindEdge(app, "TKT-001", "implements", "FEAT-001")
+		req := httptest.NewRequest(http.MethodPatch,
+			"/api/v1/tickets/TKT-001/relations/implements/FEAT-001",
+			strings.NewReader(`{"meta":{"note":"hi"}}`))
+		rec := httptest.NewRecorder()
+		app.handleV1UpdateRelation(rec, req, "ticket", "TKT-001", "implements", "FEAT-001")
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("got %d, want 403; body=%s", rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), `"rule_id":"relation-affordance:meta-read-only:implements.note"`) {
+			t.Errorf("body must name meta-read-only rule: %s", rec.Body.String())
+		}
+	})
+
+	t.Run("unified PATCH upserting meta", func(t *testing.T) {
+		app := seedTicketWithRelationVerdicts(t, rv)
+		code, body := patchTicketRaw(t, app,
+			`{"relations":{"implements":{"data":[{"type":"feature","id":"FEAT-001","meta":{"note":"hi"}}]}}}`)
+		if code != http.StatusForbidden {
+			t.Fatalf("got %d, want 403; body=%s", code, body)
+		}
+		if !strings.Contains(body, `"rule_id":"relation-affordance:meta-read-only:implements.note"`) {
+			t.Errorf("body must name meta-read-only rule: %s", body)
+		}
+	})
+
+	t.Run("writable meta succeeds", func(t *testing.T) {
+		// "role" not in Fields → default writable.
+		app := seedTicketWithRelationVerdicts(t, rv)
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/v1/tickets/TKT-001/relations/implements",
+			strings.NewReader(`{"id":"FEAT-001","meta":{"role":"primary"}}`))
+		rec := httptest.NewRecorder()
+		app.handleV1CreateRelation(rec, req, "ticket", "TKT-001", "implements")
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("got %d, want 201; body=%s", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+// AC11: collection-level GET does NOT emit _fields or _relations (the
+// new wire keys are per-entity only in v1). The collection-level
+// response retains its existing shape; per-entity affordances ride on
+// per-entity responses.
+func TestAppRouter_CollectionGet_NoFieldVerdicts(t *testing.T) {
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+	app.fieldResolver = DemoFieldVerdictResolver{}
+
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "x", "status": "open"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1EntityCollection(rec, req, "ticket", "tickets")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, `"_fields"`) {
+		t.Errorf("collection response must NOT contain _fields; got: %s", body)
+	}
+	if strings.Contains(body, `"_relations"`) {
+		t.Errorf("collection response must NOT contain _relations; got: %s", body)
 	}
 }

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
@@ -156,6 +157,22 @@ type App struct {
 	// cmd/rela-server chains an env resolver + a header resolver
 	// here when --principal-header is set.
 	principalResolver PrincipalResolver
+
+	// fieldResolver decides per-entity field, option, and
+	// relation-meta affordances surfaced as `_fields` / `_relations`
+	// on the wire and enforced on writes. Required (never nil) —
+	// callers that don't want affordances pass NopFieldVerdictResolver{}.
+	// The eventual predicate-engine ticket replaces the stub
+	// implementations with a policy-driven resolver via the same
+	// interface.
+	fieldResolver FieldVerdictResolver
+
+	// auditSink records short-circuit rejections (affordance gates)
+	// that never reach the entitymanager. ACL denials already get a
+	// `denied-write` row from the manager; affordance denials emit
+	// the same op via this sink so log readers see a unified stream.
+	// Required (never nil) — callers pass [audit.Nop] to opt out.
+	auditSink audit.Audit
 }
 
 // StopWatching releases the data-entry.yaml subscription started by
@@ -261,6 +278,8 @@ func NewApp(
 	em entitymanager.EntityManager,
 	searcher search.Searcher,
 	aclImpl acl.ACL,
+	fieldResolver FieldVerdictResolver,
+	auditSink audit.Audit,
 ) (*App, error) {
 	// Reject nil required collaborators up front rather than letting a
 	// downstream handler panic on the first request that exercises them.
@@ -281,6 +300,12 @@ func NewApp(
 	}
 	if aclImpl == nil {
 		return nil, errors.New("dataentry.NewApp: acl is required (use acl.NopACL{} to opt out)")
+	}
+	if fieldResolver == nil {
+		return nil, errors.New("dataentry.NewApp: fieldResolver is required (pass NopFieldVerdictResolver{} for permissive default)")
+	}
+	if auditSink == nil {
+		return nil, errors.New("dataentry.NewApp: auditSink is required (pass audit.Nop{} to opt out)")
 	}
 	// Construct reconstructible services from the primitives.
 	cfgLoader := config.NewFSLoader(fs, paths.Root)
@@ -371,6 +396,8 @@ func NewApp(
 		acl:           aclImpl,
 		broker:        newEventBroker(),
 		scriptEngine:  scriptEngine,
+		fieldResolver: fieldResolver,
+		auditSink:     auditSink,
 	}
 	// documentService needs scriptEngine (for Lua renders) and a closure
 	// that yields fresh lua.WriteDeps (so metamodel reloads propagate).

--- a/internal/dataentry/e2e_test.go
+++ b/internal/dataentry/e2e_test.go
@@ -57,6 +57,8 @@ func newE2ETestApp(t *testing.T) (*App, string, func()) {
 	app, err := NewApp(
 		svc.FS(), svc.Paths(), svc.Meta(), svc.Store(),
 		svc.EntityManager(), svc.Searcher(), svc.ACL(),
+		NopFieldVerdictResolver{},
+		svc.Audit(),
 	)
 	if err != nil {
 		svc.Close()

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/openapi"
@@ -128,6 +129,7 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	app.cfgLoader = svc.Config()
 	app.kv = svc.State()
 	app.acl = svc.ACL()
+	app.auditSink = svc.Audit()
 	// Wire a minimal documentService for tests that hit the documents
 	// handler. Script engine can be the real one (tests that use script:
 	// configs will need to seed scripts on disk).
@@ -170,7 +172,11 @@ func reseedStore(dst, src store.Store) {
 // Palette, UserPalette, OpenAPIGen) so handlers that touch the
 // less-common fields don't nil-deref in tests that didn't ask for them.
 func newAppFromParts(cfg *Config, meta *metamodel.Metamodel, f *fixture) *App {
-	app := &App{scriptEngine: script.NewEngine()}
+	app := &App{
+		scriptEngine:  script.NewEngine(),
+		fieldResolver: NopFieldVerdictResolver{},
+		auditSink:     audit.Nop{},
+	}
 	if meta != nil {
 		// Use an in-memory FS + project context so the workspace's
 		// templater has paths it can dereference. Without this,

--- a/tickets/entities/implementation-checklists/IMPL-1BGF.md
+++ b/tickets/entities/implementation-checklists/IMPL-1BGF.md
@@ -1,0 +1,40 @@
+---
+id: IMPL-1BGF
+type: implementation-checklist
+title: 'Implementation: _fields / _relations wire shape + SPA renderer (stub verdict source)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-C5DH.md
+++ b/tickets/entities/planning-checklists/PLAN-C5DH.md
@@ -1,0 +1,800 @@
+---
+id: PLAN-C5DH
+type: planning-checklist
+title: 'Planning: _fields / _relations wire shape + SPA renderer (stub verdict source)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+**IN:**
+
+- Wire-shape extension on `V1Entity` and per-entity GET response:
+  - `_fields: Record<string, { writable: boolean; options?: Record<string, boolean> }>`
+  - `_relations: Record<string, { creatable: boolean; removable: boolean; fields?: Record<string, { writable: boolean }> }>`
+- **Hidden semantics (revised per design-review F1):**
+  - Server omits the property from `properties` AND from `_fields`.
+  - **SPA actively filters its config-driven field list against `_fields`**: a
+    form field declared in `data-entry.yaml` is rendered only if either
+    (a) its property name appears in `entity._fields`, or
+    (b) its property name appears in `entity.properties`.
+    This makes "hidden = omitted" actually hide the input.
+  - Create mode is unrestricted (see F10 resolution below).
+- Stub `FieldVerdictResolver` interface with two profiles:
+  - `none` (default) — everything writable/visible/creatable/removable
+  - `demo` — fixture against the `ticket` type exercising every code path
+    (renamed from `triager-demo` per F9)
+- Profile resolution: `RELA_AFFORDANCE_PROFILE` env var parsed in `cmd/rela-server/main.go`,
+  passed as a constructor argument to `dataentry.New` (per F7 — tests pass the
+  resolver directly without env-var manipulation).
+- SPA consumption in `DynamicForm`, `FieldRenderer`, `RelationCards`:
+  - `_fields[name].writable=false` → input rendered with existing `readonly` prop
+  - field absent from `_fields` and from `properties` → form skips rendering
+    (NEW filter in `DynamicForm.vue`'s `fields` computed)
+  - `_fields[name].options.<v>=false` → option absent from `<select>`
+  - `_relations[type].creatable=false` → `+ Add` button hidden
+  - `_relations[type].removable=false` → per-link `x` hidden for **all** links
+    of that type (per-relation-type uniform, per F5)
+  - `_relations[type].fields[name].writable=false` → meta-field input disabled
+    in `RelationCards`
+- Wire-vs-policy parity at the write path (revised round 2 per F12: drop
+  friendly-drop semantics — `useAutoSave` already does no-op suppression
+  client-side via `lastSeenServer`, so the matching-value branch is dead code
+  for any real SPA path):
+  - **PATCH with hidden field present** (set or unset) → 403
+  - **PATCH with read-only field present** (set or unset, any value) → 403
+  - **PATCH with disallowed enum value** → 403
+  - **PATCH with unknown field** (declared neither in metamodel nor known by
+    resolver) → 403, structurally identical to hidden (F8 side-channel closure)
+  - **POST/DELETE relation with `creatable=false` / `removable=false`** → 403
+  - **PATCH that creates or deletes a relation via the unified path with a
+    `creatable=false` / `removable=false` verdict** → 403
+  - **PATCH with non-writable relation-meta field present** (set via `Meta` or
+    listed in `MetaUnset`, any value) → 403
+
+**OUT (follow-ups):**
+
+- Real verdict source — `acl.yaml` schema for field/option/relation-meta grants.
+  Predicate-engine ticket owns this and replaces the stub directly.
+- Type-default + per-entity-override compression of `_fields` for list views
+- List-query field-level read enforcement (only per-entity GET emits the new fields)
+- Cache invalidation beyond entity ETags
+- Masked-value rendering
+- Per-link affordances (different verdicts for different individual links)
+- Audit-log `denied-read` events for hidden fields (existing `denied-write` covers
+  the parity case)
+- **Create-mode affordances** (F10 resolution): create-mode SPA renders all
+  fields normally; the stub doesn't gate creates. Predicate ticket addresses
+  create-mode separately (it needs collection-level affordances on
+  `V1ListResponse`, which is an additional wire-shape extension).
+- **List-typed enum option-filter** (F15): the per-element check for
+  `list: true` enums (e.g. `tags`) is deferred. The wire shape supports it
+  (the `options` map is unambiguous for list-typed too), but the demo profile
+  doesn't exercise this and the PATCH validator only walks scalar enums in
+  v1. Predicate ticket inherits the wire shape; the validator extension is a
+  small, additive change.
+- **Audit-op separation for affordance denials** (F21): v1 keeps reusing the
+  existing `denied-write` op, distinguished by a stable `affordance:<reason>:<field>`
+  prefix in the `reason` field (vs `acl:...` for ACL denials). No new audit
+  op constant for this stub — predicate ticket re-evaluates when affordance
+  becomes a real policy surface.
+
+### Branching decision (F2)
+
+Branch off **`develop` directly**, not off `feat/acl-affordances` (PR #779).
+Rationale: stacking on #779 reintroduces exactly the PR-gates-PR problem that
+"single combined ticket" was meant to avoid. If #779 merges first, this branch
+gets a clean rebase. If #779 doesn't merge first, this PR reshapes
+`V1Entity.Actions` from `*V1Actions` to `map[string]bool` itself (~80 LOC, the
+phase-1 work) and the conflict resolution at merge time is straightforward.
+The plan budget includes this contingency.
+
+### Demo profile fixture (F4 resolution)
+
+The rela project's actual `ticket` properties are `title`, `kind`, `priority`,
+`effort`, `tags`, `status`. The `demo` profile applies to type `ticket`:
+
+| Path | Verdict | Exercises |
+|---|---|---|
+| `title` | writable (default) | Sanity-check writable wire entry |
+| `kind` | read-only | Read-only field code path; PATCH 403 on change |
+| `priority` | hidden | Omission from `properties` + `_fields`; SPA field-filter |
+| `effort` | writable, options `{xs:T, s:T, m:T, l:F, xl:F}` | Option filter; PATCH 403 on disallowed option |
+| `status` | writable, options `{backlog:T, ready:T, planning:T, in-progress:T, review:T, done:F}` | Two enum demonstrations (effort+status) |
+| relation `affects` | `creatable: false` | Relation create 403 |
+| relation `implements` | `removable: false` | Relation delete 403 |
+| relation `has-planning` | meta-field `<chosen>.writable=false` | Relation-meta PATCH 403 |
+
+The relation-meta target needs verification against `tickets/metamodel.yaml`
+during implementation; the fixture chooses whichever relation type actually
+has a writable meta property (likely none currently — may need to pick a
+different entity type for the meta demonstration, or add a stub meta on
+`has-planning`). Documented in the implementation checklist as a finalization
+step.
+
+**Acceptance Criteria:**
+
+1. **AC1 — Default profile is non-disruptive (revised per F13: sparse emission).**
+   With `RELA_AFFORDANCE_PROFILE` unset (or `none`), per-entity GET responses
+   contain `_fields: {}` and `_relations: {}` (present but empty), and **no
+   properties are omitted from `properties`**. Sparse emission: only deviations
+   from default appear in the maps. Existing SPA behavior is indistinguishable
+   from today; the F1 SPA filter uses `entity.properties` (not `_fields`) as
+   the field-visibility signal, so an empty `_fields` map renders the form
+   unchanged.
+   - Test: `TestAppRouter_PerEntityGet_NoneProfile` asserts `_fields == {}`,
+     `_relations == {}`, and `properties` matches the entity's full property
+     set.
+
+2. **AC2 — `demo` profile produces the expected fixture verdicts (sparse).**
+   With `RELA_AFFORDANCE_PROFILE=demo`, a GET for a `ticket` entity returns
+   ONLY the entries that deviate from default:
+   - `_fields.kind = {writable: false}` (the only field with a writable override)
+   - `properties.priority` absent; `_fields.priority` absent (hidden — emitted
+     in neither map; verified by SPA filter's "in properties OR in _fields" check)
+   - `_fields.effort = {options: {l: false, xl: false}}` (only the false
+     entries appear; sparse within `options` too — `xs:true`, `s:true`,
+     `m:true` are implied by absence)
+   - `_fields.status = {options: {done: false}}` (only the false entry)
+   - `_relations.affects = {creatable: false}` (only the deviation)
+   - `_relations.implements = {removable: false}`
+   - `_relations.<chosen-relation>.fields.<chosen-meta> = {writable: false}`
+     (relation type and meta-field picked during implementation; see "Demo
+     profile fixture" caveat)
+   - All other fields and relations: ABSENT from `_fields` / `_relations`
+     entirely. The SPA's "no entry = default" path handles them.
+   - Test: `TestAppRouter_PerEntityGet_Demo` asserts each entry present and
+     the absence of all other entries.
+
+3. **AC3 — Hidden fields are bidirectionally invisible (F8 + F16).**
+   - PATCH `{properties: {priority: "high"}}` under `demo` → 403 with
+     `{rule: "field-affordance:hidden", field: "priority"}`. Audit log records.
+   - PATCH `{properties_unset: ["priority"]}` under `demo` → 403 (unset on a
+     hidden field is a write).
+   - PATCH that sets a TRULY unknown field (`bogus_field`) under any profile →
+     403, structurally identical response shape (`{rule: "field-affordance:hidden", field: "bogus_field"}`).
+     This closes the F8 side-channel: hidden and unknown produce byte-equivalent
+     errors, so an attacker cannot distinguish "hidden from me" from "doesn't
+     exist." It also changes today's behavior — rela currently silently merges
+     unknown fields; this AC ships the new rejection.
+   - Test: `TestAppRouter_PatchHiddenField_Forbidden` (set + unset subtests).
+   - Test: `TestAppRouter_PatchUnknownField_Forbidden` asserts byte-equivalence
+     of the 403 response with the hidden case (modulo the field name in `field`).
+
+4. **AC4 — Read-only fields reject writes (F12 revision: simplified to strict 403).**
+   `useAutoSave` performs no-op suppression client-side (`lastSeenServer`
+   check in `useAutoSave.ts`), so no real SPA path produces a same-value
+   PATCH; the friendly-drop branch from round-1 F3 was dead code.
+   - PATCH `{properties: {kind: "different"}}` under `demo` → 403 with
+     `{rule: "field-affordance:read-only", field: "kind"}`; file unchanged.
+   - PATCH `{properties: {kind: <current>}}` under `demo` → 403 (same rule).
+     Strictly equivalent to the different-value case; SPA won't emit this
+     PATCH naturally.
+   - PATCH `{properties: {kind: "different", title: "new"}}` under `demo` →
+     403; whole PATCH rejected, including `title`. No partial application.
+   - PATCH `{properties_unset: ["kind"]}` under `demo` → 403 (unset is a
+     write).
+   - Test: `TestAppRouter_PatchReadOnlyField` with four subtests covering each
+     case.
+
+5. **AC5 — Filtered enum options reject writes.** PATCH `{properties: {status: "done"}}`
+   under `demo` returns 403. PATCH `{properties: {status: "review"}}` succeeds.
+   PATCH `{properties: {effort: "l"}}` returns 403; `{effort: "m"}` succeeds.
+   - Test: `TestAppRouter_PatchFilteredOption_Forbidden`.
+
+6. **AC6 — Relation create/remove gates at EVERY relation-write endpoint
+   (F5 + F14).** The plan's round-1 "single chokepoint" claim was wrong.
+   Three endpoints write relations:
+   - `handleV1CreateRelation` (api_v1.go:863) — per-relation POST
+   - `handleV1DeleteRelation` (api_v1.go:960) — per-relation DELETE
+   - `handleV1UpdateEntity` (api_v1.go:542) — unified PATCH with `relations`
+     field (modern reconciler adds/removes relations)
+   Each must consult `RelationVerdicts.Types[type]` before writing. The
+   shared validator function lives in `affordances.go` (close to the
+   resolver wiring); each handler invokes it before passing the request to
+   `entityManager.{CreateRelation,DeleteRelation}` / the modern reconciler.
+   Behavior:
+   - POST `/api/v1/entities/ticket/T1/relations/affects` (add) under `demo` →
+     403 with `{rule: "relation-affordance:not-creatable", type: "affects"}`.
+     No link identifier (gate is per-type, not per-link).
+   - DELETE `/api/v1/entities/ticket/T1/relations/implements/T2` under
+     `demo` → 403 with `{rule: "relation-affordance:not-removable", type: "implements"}`.
+   - PATCH `/api/v1/entities/ticket/T1` with `relations: {affects: {data: [...]}}`
+     that ADDS an `affects` edge under `demo` → 403 same shape.
+   - PATCH that REMOVES an `implements` edge under `demo` → 403 same shape.
+   - Other relation types via any endpoint succeed.
+   - Test: `TestAppRouter_RelationGates_Forbidden` covers all four endpoint ×
+     verb combinations.
+
+7. **AC7 — Relation meta-field gates (F12 simplification + F16 unset).**
+   - PATCH unified body with `relations: {<type>: {data: [{id: ..., meta: {<non-writable>: "v"}}]}}`
+     under `demo` → 403, `{rule: "relation-affordance:meta-read-only", type: ..., field: ...}`.
+     Same value or different value — strict 403 (F12).
+   - PATCH unified body with `meta_unset: ["<non-writable-meta>"]` → 403
+     (same rule).
+   - PATCH unified body that updates a writable meta-field on the same
+     relation type → 200.
+   - POST `/api/v1/entities/.../relations/<type>` with `meta: {<non-writable>: "v"}` →
+     403 (same rule).
+   - Inspection point on the unified path: `V1RelationsUpdate.Meta` and
+     `MetaUnset` in `relations_v1_wire.go` (line 58). Per-relation POST
+     inspection point: the `Meta` field in `handleV1CreateRelation`'s
+     local request struct (api_v1.go:876). Validator helper is shared.
+   - Test: `TestAppRouter_RelationMetaGate` covers PATCH-set, PATCH-unset,
+     PATCH-writable-OK, POST-with-meta — four subtests.
+
+8. **AC8 — SPA `DynamicForm` filters its field list against `_fields` (F1 + F19).**
+   Unit test renders `DynamicForm` with a fixture entity carrying `_fields = {kind: {writable: false}, effort: {options: {l: false, xl: false}}}`
+   (sparse per F13), `properties = {kind: "enhancement", effort: "m"}`, and a
+   `data-entry.yaml` form config declaring `[title, kind, priority, effort, status]`.
+   Asserts post-load:
+   - `title` input rendered, enabled (no `_fields` entry → writable default)
+   - `kind` input rendered, has `readonly`/`disabled` attribute
+   - `priority` input **not in the DOM** (absent from `properties` AND
+     `_fields`; F1 filter excludes)
+   - `effort` rendered as `<select>` with no `<option value="l">` or
+     `<option value="xl">`
+   - `status` rendered, all options present
+   Asserts during load (F19 flicker fix):
+   - With `loading.value === true` and `entity === undefined`, the form
+     does NOT render fields. (Either via a top-level `v-if="!loading"`
+     guard, or via the filter returning `[]` when entity is undefined.
+     Implementation picks the simpler option; test verifies the chosen
+     behavior.)
+   - Test: `frontend/src/components/forms/DynamicForm.test.ts` (NEW file,
+     using vitest + @vue/test-utils). Two subtests: post-load filter
+     behavior and during-load flicker prevention.
+
+9. **AC9 — SPA `RelationCards` renders against `_relations`.** Unit test
+   renders `RelationCards` with `_relations = {affects: {creatable: false, removable: true}, implements: {creatable: true, removable: false, fields: {note: {writable: false}}}}`. Asserts:
+   - `affects` panel: `+ Add` button absent, per-link `x` button present
+   - `implements` panel: `+ Add` button present, per-link `x` button absent
+     on every link
+   - `implements` meta-field `note` input has `disabled` attribute
+   - Test: `frontend/src/components/forms/RelationCards.test.ts` (NEW or extend).
+
+10. **AC10 — Manual end-to-end verification under `demo`.** With
+    `RELA_AFFORDANCE_PROFILE=demo just dev` (F18 verified: `just dev` is
+    `go run ./cmd/rela-server -project ... -port ...` — env passes through)
+    and a ticket loaded:
+    - `title` input editable; saves
+    - `kind` input rendered read-only; auto-save no-op
+    - `priority` field not in the form
+    - `status` dropdown lacks `done`
+    - `effort` dropdown lacks `l` and `xl`
+    - `+ Add affects` button absent
+    - `x` on `implements` links absent
+    - Non-writable relation-meta input is disabled
+    Evidence: screenshot or DOM snippet in implementation-checklist.
+
+11. **AC11 — Create-mode is unaffected (F10).** `RELA_AFFORDANCE_PROFILE=demo`
+    with a new-ticket form: all fields render normally (including `priority`),
+    no enum options filtered. The collection-level GET emits `_actions.create`
+    (unchanged from phase-1) and no `_fields` / `_relations` (the new wire keys
+    are per-entity only in v1).
+    - Test: `TestAppRouter_CollectionGet_DemoProfile_NoFieldVerdicts`.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+- **Phase-1 affordances (`_actions`)** in `feat/acl-affordances` (PR #779,
+  TKT-Y72A) is the direct architectural precedent. Key reuse:
+  - `internal/dataentry/affordances.go` houses `translateVerb` +
+    `computeActions` + `computeCollectionActions`. This ticket adds
+    `computeFields` and `computeRelations` next to them, same shape.
+  - `frontend/src/types/entity.ts` already documents the underscore-prefix
+    convention and the "absent vs empty {}" closed-world semantics. The new
+    `_fields` / `_relations` keys follow the same documentation pattern.
+  - `affordances_contract_test.go` is the template for the bidirectional
+    contract test (read says false ⇒ write returns 403). This ticket adds
+    equivalent contract tests for field, option, relation-create/remove, and
+    relation-meta paths.
+  - `lint_test.go` enforces "no other site constructs `acl.WriteRequest{Op:`
+    directly." This ticket doesn't add ACL ops — the stub gates writes at the
+    handler layer, not the ACL layer — so the lint stays satisfied.
+
+- **SPA infrastructure already exists for some rendering primitives** (F1
+  correction):
+  - `FieldRenderer.vue:12` accepts `readonly?: boolean`; line 142, 161, 191, 202
+    plumb it through every widget. The new code passes this prop based on
+    `entity._fields?.[name]?.writable === false`.
+  - `FieldRenderer.vue:63` already has `isOptionDisabled(opt)` for transition
+    rules. The new code extends this to also consult `entity._fields?.[name]?.options`.
+  - `DynamicForm.vue:98-105` builds its `fields` list from
+    `formConfig.sections.flatMap(s => s.fields)` — **NOT** from
+    `entity.properties`. The plan's prior claim that "omitted = naturally hidden"
+    was wrong. The new code adds an explicit filter step that drops fields whose
+    property name is absent from both `entity._fields` AND `entity.properties`.
+  - `RelationCards.vue` is the bigger SPA touch point — needs to read
+    `_relations[type]` for `creatable`/`removable`/`fields` and disable the
+    corresponding UI affordances. Per-link `x` button removal applies
+    uniformly to every link of that type (F5).
+
+- **Server-side PATCH path:**
+  - `handleV1UpdateEntity` (api_v1.go:542) is the single entry point.
+  - Properties are merged into `entity.Properties[k] = v` (line 614) without
+    metamodel validation today — unknown fields are silently accepted. This
+    ticket adds the affordance check at this point.
+  - Relation-meta lives in `V1RelationsUpdate.Meta` / `MetaUnset`
+    (`relations_v1_wire.go:58`) — single inspection point for AC7 (F6 resolved).
+  - `properties_unset` already emits `unknown_property_unset_key` warnings for
+    unknown keys (line 627) — informative precedent for the F3 friendly-drop
+    warning shape.
+
+- **Design docs:**
+  - `.ignored/forms-acl-research.md` — survey of 11 systems; converged
+    recommendation: payload-attached affordances (vs separate `/forms`
+    endpoint), bool-map shape, closed-world contract.
+  - `.ignored/action-affordances-design.md` — phase-1 design; locks in the
+    `{verb: bool}` map shape and the "wire-vs-policy parity" invariant.
+    This ticket inherits both.
+  - `.ignored/condition-language-use-cases.md:386` — slot/outcome table that
+    this ticket's wire shape implements. The predicate ticket eventually
+    populates these from `*_when` expressions; this ticket populates them from
+    a stub.
+
+- **DEC-HWZHA (CLAUDE.md validation policy)** — soft-condition writes return
+  `200 + warnings`, not 422. The "read-only field at same value → silent drop
+  with warning" semantics (F3) is the direct application of this policy.
+
+- **Libraries:** none. No new dependencies.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+### Server side
+
+1. **Define `FieldVerdictResolver` interface in `internal/dataentry`:**
+
+   ```go
+   // FieldVerdictResolver decides per-entity affordances for fields,
+   // enum options, and relation-meta fields. Wire shape is documented
+   // in docs/data-entry/api-reference.md. v1 ships two implementations
+   // (NopFieldVerdictResolver, DemoFieldVerdictResolver); the
+   // predicate-engine ticket will replace them with a policy-driven
+   // implementation.
+   //
+   // The resolver is consulted once per per-entity GET (to populate
+   // _fields / _relations) and once per PATCH (to gate writes). It is
+   // a constructor parameter on dataentry.App so tests pass it directly
+   // without env-var manipulation.
+   type FieldVerdictResolver interface {
+       FieldVerdicts(ctx context.Context, e *entity.Entity) FieldVerdicts
+       RelationVerdicts(ctx context.Context, e *entity.Entity) RelationVerdicts
+   }
+
+   type FieldVerdicts struct {
+       // Writable: fieldName → writable. Absence = writable (sparse).
+       Writable map[string]bool
+       // Visible: fieldName → visible. Absence = visible (sparse). F20
+       // unified the map convention (was `Hidden map[string]struct{}`).
+       Visible  map[string]bool
+       // Options: fieldName → optionValue → allowed. Absence of the field
+       // OR absence of an option = allowed (sparse on both axes per F13).
+       Options  map[string]map[string]bool
+   }
+
+   type RelationVerdicts struct {
+       Types map[string]RelationVerdict          // relationType → verdict
+   }
+
+   type RelationVerdict struct {
+       Creatable bool
+       Removable bool
+       Fields    map[string]bool                  // metaField → writable
+   }
+   ```
+
+2. **Two implementations in `internal/dataentry/affordances_stub.go`:**
+   - `NopFieldVerdictResolver` returns zero-value `FieldVerdicts` and
+     `RelationVerdicts` for any entity. Wire emission still includes
+     every metamodel-declared field as `{writable: true}` — see #6 below.
+   - `DemoFieldVerdictResolver` applies the fixture from the "Demo profile
+     fixture" table above when entity type is `ticket`; returns zero-value
+     for all other types.
+
+3. **Profile selection in `cmd/rela-server/main.go`** (per F7):
+
+   ```go
+   profile := os.Getenv("RELA_AFFORDANCE_PROFILE")
+   var resolver dataentry.FieldVerdictResolver
+   switch profile {
+   case "", "none":
+       resolver = dataentry.NopFieldVerdictResolver{}
+   case "demo":
+       resolver = dataentry.DemoFieldVerdictResolver{}
+   default:
+       slog.Warn("unknown RELA_AFFORDANCE_PROFILE, falling back to none", "value", profile)
+       resolver = dataentry.NopFieldVerdictResolver{}
+   }
+   // Pass to dataentry.New(...)
+   ```
+
+   `dataentry.New` gains a `FieldVerdictResolver` parameter. Tests pass the
+   resolver directly without setting env vars.
+
+4. **`computeFields(ctx, e)`** and **`computeRelations(ctx, e)`** in
+   `affordances.go` — SPARSE emission (F13):
+   - Call `a.fieldResolver.FieldVerdicts(ctx, e)`.
+   - Build the wire `_fields` map by emitting ONLY deviations from default:
+     - For each `name` in `Writable` where `false`: emit `{writable: false}`.
+     - For each `name` in `Options` with any `false` value: emit
+       `{options: {<value>: false, ...}}` (only the false entries).
+     - Merge writable + options entries when both deviate for the same field.
+     - The `Visible` map controls property omission (see step 5) but does
+       NOT emit an `_fields` entry for visible-default OR for hidden — hidden
+       fields are absent everywhere (closed-world test in AC2).
+   - Same sparseness for relations:
+     - Emit `_relations[type]` only when at least one of `Creatable`,
+       `Removable`, or any `Fields[meta]` deviates from default.
+     - Within the entry, omit keys whose value is the default (`creatable:true`,
+       `removable:true`).
+   - Under `none` profile, both maps are emitted as `{}` (present but empty).
+
+5. **`api_v1.go` per-entity GET handler:**
+   - Call `computeFields`; serialize as `_fields`.
+   - Call `computeRelations`; serialize as `_relations`.
+   - Before serializing `properties`, delete keys where `FieldVerdicts.Visible[k]
+     == false`.
+   - Existing `_actions` emission is unchanged.
+
+6. **Wire-vs-policy parity (revised per F12, F14, F16):**
+
+   New helper `validateAffordances(req *updateReq, e *entity.Entity) error`:
+   - Compute `FieldVerdicts` and `RelationVerdicts` for the target entity.
+   - For each key in `req.Properties` AND each key in `req.PropertiesUnset`
+     (F16: unset is a write):
+     - If `Visible[k] == false`: error `field-affordance:hidden`.
+     - If `Writable[k] == false`: error `field-affordance:read-only` (F12:
+       strict 403 regardless of value).
+     - If the field has `Options[k]` and the requested value isn't allowed:
+       error `field-affordance:enum-filtered`.
+     - If `k` is declared neither in the metamodel for `e.Type` NOR known
+       by the resolver: error `field-affordance:hidden` (F8: byte-equivalent
+       to genuinely-hidden; closes the side channel).
+   - For relation-meta in `req.Relations.Modern[*].Refs[*].Meta` AND
+     `MetaUnset`: same logic against `RelationVerdicts.Types[relType].Fields[metaKey]`.
+   - For relation-edge add/remove implied by `req.Relations`: same logic
+     against `RelationVerdicts.Types[relType].{Creatable, Removable}` (F14:
+     unified PATCH path can add/remove relations).
+   - First error wins; no partial application; return 403 immediately.
+
+   Audit emits `denied-write` with `reason: "affordance:<rule>:<path>"` (F21).
+
+7. **Three relation-write endpoints all gate (F14):** A shared validator
+   `validateRelationOp(verdicts RelationVerdicts, relType string, op Op) error`
+   lives in `affordances.go`. Each handler invokes it before delegating to
+   `entityManager`:
+   - `handleV1CreateRelation` (api_v1.go:863) — call validator with
+     `op=Create` plus meta-field check via `validateRelationMeta`.
+   - `handleV1DeleteRelation` (api_v1.go:960) — call validator with
+     `op=Delete`.
+   - `handleV1UpdateEntity` modern relations reconciler (api_v1.go:600 area)
+     — walk the diff of current vs requested edge sets per type; validate
+     Add and Delete operations. Meta-only updates (no edge change) hit
+     `validateRelationMeta` only.
+   All three return 403 with the same response shape.
+
+8. **Per-relation-type uniform `removable` (F5):** DELETE of an `implements`
+   link is gated by `_relations.implements.removable` for any link of that
+   type. The 403 response shape is `{rule: "relation-affordance:not-removable",
+   type: "implements"}` — no link identifier in the rule.
+
+### SPA side
+
+1. **`frontend/src/types/entity.ts`**: extend `Entity` interface:
+
+   ```ts
+   _fields?: Record<string, { writable: boolean; options?: Record<string, boolean> }>
+   _relations?: Record<string, {
+     creatable: boolean
+     removable: boolean
+     fields?: Record<string, { writable: boolean }>
+   }>
+   ```
+
+2. **`DynamicForm.vue` — new active filter (F1 critical fix):** The `fields`
+   computed becomes:
+
+   ```ts
+   const fields = computed((): FormFieldOrRelation[] => {
+     const all = /* current config-driven list */
+     // In create mode (no entityId), no entity available; render all.
+     if (!props.entityId) return all
+     const entity = entitiesStore.get(formConfig.value.entity, props.entityId)
+     if (!entity?._fields && !entity?.properties) return all  // pre-rollout server fallback
+     return all.filter(f => {
+       if (!f.property) return true  // relations / non-property fields untouched
+       return f.property in (entity._fields || {}) || f.property in (entity.properties || {})
+     })
+   })
+   ```
+
+3. **`DynamicForm.vue` per-field readonly:** Computes `field.readonly` from
+   `entity._fields?.[name]?.writable === false`, plumbed into existing
+   `:readonly="field.readonly"` props (lines 854, 889).
+
+4. **`FieldRenderer.vue`**: extend `isOptionDisabled(opt)` to also consult
+   `props.field.optionVerdicts?.[opt] === false`. Pass `optionVerdicts` from
+   `DynamicForm.vue`.
+
+5. **`RelationCards.vue`**: read `entity._relations?.[relType]` and:
+   - Wrap the `+ Add` button in `v-if="!verdict || verdict.creatable !== false"`
+   - Wrap the per-link `x` button similarly with `removable`
+   - Pass `:disabled` to inline meta-field inputs based on
+     `verdict?.fields?.[propName]?.writable === false`
+
+6. **No new stores, no new API client functions.** The new wire keys ride on
+   `Entity` and existing CRUD calls.
+
+**Files to modify:**
+
+| File | Change |
+|---|---|
+| `internal/dataentry/affordances.go` | Add `computeFields`, `computeRelations`, `applyFieldVerdicts`, types |
+| `internal/dataentry/affordances_stub.go` (NEW) | `NopFieldVerdictResolver`, `DemoFieldVerdictResolver` |
+| `internal/dataentry/app.go` | Add `fieldResolver FieldVerdictResolver` field; constructor param |
+| `cmd/rela-server/main.go` | Parse `RELA_AFFORDANCE_PROFILE`, pass resolver to `dataentry.NewApp` (line 119) |
+| `cmd/rela-desktop/main.go` | Same env-var parse + pass to `dataentry.NewApp` (line 154; F17-verified the binary calls the same constructor) |
+| `internal/dataentry/api_v1.go` | Per-entity GET emits new keys; PATCH consults verdicts |
+| `internal/dataentry/api_v1_test.go` | Existing tests assert new wire keys present-and-baseline under `none` |
+| `internal/dataentry/affordances_test.go` | Unit tests for `computeFields` / `computeRelations` / `applyFieldVerdicts` |
+| `internal/dataentry/affordances_contract_test.go` | Bidirectional contract tests for AC3–AC7 |
+| `frontend/src/types/entity.ts` | Add `_fields`, `_relations` keys with docstring |
+| `frontend/src/components/forms/DynamicForm.vue` | F1 filter; readonly plumbing; option-verdict plumbing |
+| `frontend/src/components/forms/FieldRenderer.vue` | Extend `isOptionDisabled` to consult option verdicts |
+| `frontend/src/components/forms/RelationCards.vue` | Add/remove/meta-field affordances |
+| `frontend/src/components/forms/DynamicForm.test.ts` (NEW) | AC8 assertions; vitest infrastructure if not present |
+| `frontend/src/components/forms/RelationCards.test.ts` (NEW or extend) | AC9 assertions |
+| `docs/data-entry/api-reference.md` | Document `_fields` / `_relations` wire shape; F11: drop docs/security.md mention from plan |
+
+**Alternatives considered:**
+
+- **`acl.yaml` schema extension with `writable_for: [roles]`.** Rejected:
+  no real users yet, deletion cost outweighs dogfooding value, and predicate
+  ticket replaces source anyway.
+- **Per-link affordances.** Rejected for v1: requires state-dependent gates
+  (predicate territory).
+- **Mask hidden fields** (`{value: null, _fields[name].visible: false}`).
+  Rejected: omit is strictly more secure (no key leak); the F1 fix adds the
+  needed SPA filter to make omission actually hide.
+- **HTTP-header profile override.** Rejected: env var is simpler, lower risk
+  of being forgotten in prod.
+- **Strict 403 for read-only field at same value (original F3 design).**
+  Rejected per F3 review: hostile to mixed PATCHes from stale clients. Replaced
+  with silent-drop-with-warning per DEC-HWZHA.
+- **Stack PR on top of #779 (`feat/acl-affordances`).** Rejected per F2:
+  reintroduces the PR-gates-PR problem. Branch off develop directly.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+| Input | Source | Validation |
+|---|---|---|
+| `RELA_AFFORDANCE_PROFILE` env var | server startup | Allowlist: `none`, `demo`. Unknown → warn, default to `none`. Never panic. |
+| Field names in PATCH body | HTTP client | New: cross-check against resolver's `Writable` allowlist + metamodel-declared fields. Unknown fields (neither declared nor in resolver) → 403, same shape as hidden (F8). |
+| Enum option values in PATCH | HTTP client | Cross-check against `FieldVerdicts.Options` allowlist for that field. |
+| Relation type / meta-field names in PATCH | HTTP client | Cross-check against `RelationVerdicts.Types` allowlist. |
+
+**Security-Sensitive Operations:**
+
+- **Wire-vs-policy parity is the security-critical invariant.** Stale SPA
+  clients cannot bypass affordance gates: every write path consults the same
+  resolver. Bidirectional contract tests (AC3–AC7) lock this down.
+- **Hidden field omission AND F8 side-channel closure.** Hidden-field PATCH
+  and truly-unknown-field PATCH produce structurally identical 403 responses.
+  No inference channel: an attacker cannot distinguish "hidden from me" from
+  "doesn't exist." Test: `TestAppRouter_PatchUnknownField_Forbidden` asserts
+  the response is byte-equivalent to the hidden case.
+- **No information leak in rejection messages.** 403 reasons use stable rule
+  identifiers (`field-affordance:read-only`), never role names or user IDs.
+- **DEC-HWZHA friendly-drop semantics** for read-only same-value PATCHes are
+  a UX accommodation, not a security relaxation: the write doesn't apply, the
+  warning is logged, the audit log records the dropped field. Tested at AC4.
+- **No new principal handling, no new audit ops, no new crypto.** The
+  `denied-write` audit op already covers the new 403 cases; the rule
+  identifier rides in the existing `reason` field.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Test |
+|---|---|
+| AC1 | `TestAppRouter_PerEntityGet_NoneProfile` — wire shape under default |
+| AC2 | `TestAppRouter_PerEntityGet_Demo` — wire shape under demo profile |
+| AC3 | `TestAppRouter_PatchHiddenField_Forbidden` + `TestAppRouter_PatchUnknownField_Forbidden` — F8 parity |
+| AC4 | `TestAppRouter_PatchReadOnlyField` — three subtests (same/different/mixed) |
+| AC5 | `TestAppRouter_PatchFilteredOption_Forbidden` |
+| AC6 | `TestAppRouter_RelationGates_Forbidden` — POST/DELETE |
+| AC7 | `TestAppRouter_RelationMetaGate` — same/different/writable subtests |
+| AC8 | `DynamicForm.test.ts` — F1 filter; readonly; option filtering |
+| AC9 | `RelationCards.test.ts` — add/remove/meta-field |
+| AC10 | Manual e2e |
+| AC11 | `TestAppRouter_CollectionGet_DemoProfile_NoFieldVerdicts` |
+
+**Edge Cases:**
+
+- **Empty `_fields` map vs absent.** Under `none`, `_fields` is present and
+  populated with all-writable defaults. Under a pre-rollout server (no key
+  at all), SPA's filter falls back to rendering everything (the
+  `entity._fields ?? {}` path).
+- **Anonymous principal.** Resolver is called the same way; the `none`
+  profile returns zero verdicts regardless of principal.
+- **Field declared in metamodel but not present on entity instance** (sparse
+  property). Wire `_fields` lists it as `{writable: true}` (default); SPA
+  renders normally. Hidden status is independent of value presence.
+- **Form-config field not in metamodel.** Should not occur in valid configs;
+  if it does, the SPA filter's "in `_fields` OR in `properties`" check leaves
+  it rendering (no entry in either, so it falls through to the unfiltered
+  state). Documented but not tested — this is a config-error case the
+  metamodel validator should catch separately.
+- **Create-mode (`!entityId`).** SPA filter short-circuits, renders all
+  config-declared fields. Tested at AC11.
+- **Pre-rollout server (no `_fields` in response).** SPA filter short-circuits
+  via the `if (!entity?._fields && !entity?.properties)` guard, renders all.
+- **Empty `properties` on entity** (degenerate, shouldn't happen). Same
+  fallback as pre-rollout.
+- **Relation type with no entry in `_relations`.** All operations allowed
+  (default).
+- **PATCH includes hidden field with value matching nothing** (the field has
+  no value because it's hidden). Still 403 — SPA shouldn't have known about
+  the field; sending it is an attack surface. Same shape as F8.
+- **Race: server reloads profile while a request is in flight.** Not relevant
+  — resolver chosen at startup, never reassigned.
+- **Concurrent writes targeting filtered options.** Existing entity-level
+  `writeMu` (api_v1.go:544) serializes; affordance check is purely local to
+  the request.
+
+**Negative Tests:**
+
+- Unknown `RELA_AFFORDANCE_PROFILE` value → warning logged, falls back to
+  `none`. Test: `TestNew_UnknownProfile_FallsBackToNone` (constructor-level,
+  no env var).
+- Resolver returns nil maps → handler doesn't panic, emits baseline shape.
+  Test: `TestComputeFields_NilMaps_EmitsBaselineShape`.
+- PATCH with hidden + writable fields in same body → 403 wins; no partial
+  write. Test: `TestAppRouter_PatchMixedHiddenAndWritable_Forbidden`.
+- PATCH with read-only-same-value + truly-writable fields → 200, writable
+  field applied, warning emitted. Test in AC4 subtest 3.
+
+**Integration test approach:**
+
+- AC3–AC7 use the existing `internal/dataentry/affordances_contract_test.go`
+  fixture style: bring up an `App` with the `DemoFieldVerdictResolver`,
+  exercise the HTTP surface end-to-end, assert both the GET shape and the
+  corresponding mutation outcome. No mocking of resolver — uses the real
+  `DemoFieldVerdictResolver`.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Mitigation |
+|---|---|
+| **#779 doesn't merge before this lands.** Per F2: branch off develop directly. If #779 still open at merge time, this PR reshapes `V1Entity.Actions` from `*V1Actions` to `map[string]bool` (the phase-1 work, ~80 LOC). Conflict resolution at merge time is mechanical. | Budget includes this contingency. |
+| **F1 SPA filter may interact unexpectedly with `formConfig` sections** (some forms group fields by section). The filter runs across the flattened list; a section may end up empty. | AC8 test fixture exercises a section-organized form. If sections become empty, hide the section header too (small render guard). |
+| **Vitest test infrastructure may not exist** for `DynamicForm.vue` and `RelationCards.vue`. | AC8 / AC9 explicitly call out NEW test files. Effort estimate reflects this. |
+| **Metamodel-declared enum values not currently surfaced in `_fields` baseline.** Computing `options: {all: true}` requires walking the entity-type's enum definitions. | Use existing `metamodel.Properties` schema from `internal/metamodel`; no new metadata. |
+| **Write-vs-read race in PATCH parity check.** Resolver consulted on the request entity; if another writer changes state mid-PATCH, resolved verdicts may be stale. | Acceptable: `none` and `demo` are state-independent. Predicate ticket inherits this race-window and addresses via snapshot-at-handler-top (CLAUDE.md pattern). |
+| **Demo profile's relation-meta target depends on what `tickets/metamodel.yaml` actually exposes.** | Implementation-checklist task: audit metamodel, pick a relation that has any writable meta property. If none exist, the relation-meta fixture targets an entity type that does (e.g. a test-only metamodel fixture). |
+| **Audit log will see more `denied-write` entries under `demo`.** | Acceptable — demo is dev-only. Documented in api-reference. |
+
+**Effort:** **l** (large) — server: ~400 LOC + tests (more than original
+estimate due to F8 unknown-field handling and F3 friendly-drop semantics);
+SPA: ~150 LOC + tests; plus design-review and code-review rounds. Realistic
+2–3 day implementation if attention isn't broken up.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact (F11 cleaned up):**
+
+- [x] **API docs** — `docs/data-entry/api-reference.md` documents `_fields` and
+  `_relations` wire shape next to the existing `_actions` documentation.
+- [x] ~~User guide / reference~~ (N/A: the stub source is dev-only; users
+  won't see field-level affordances meaningfully until the predicate ticket
+  lands.)
+- [x] ~~`docs/security.md` mention~~ (N/A: deferred to predicate ticket;
+  this ticket has no security-policy semantics to document for end users.)
+- [x] ~~CLI help text~~ (N/A: env var documented in api-reference only.)
+- [x] ~~CLAUDE.md~~ (N/A: wire-shape detail is below CLAUDE.md abstraction.)
+- [x] ~~README.md~~ (N/A.)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings (round 1, addressed in this revision):**
+
+- F1 [critical] — SPA filter against `_fields`/`properties` added; `DynamicForm.vue`
+  `fields` computed gains active filter step. AC8 rewritten to test this.
+- F2 [significant] — Branching decision: off develop, accept potential
+  `V1Entity.Actions` reshape contingency.
+- F3 [significant] — Read-only same-value PATCH → silent drop with warning,
+  not 403. Aligns with DEC-HWZHA. AC4 rewritten.
+- F4 [significant] — Demo fixture rebuilt against actual `ticket` properties
+  (`title, kind, priority, effort, status`); table in scope section pins
+  exact verdicts.
+- F5 [significant] — `removable` confirmed per-relation-type uniform; AC6
+  pins error shape (no link identifier).
+- F6 [significant] — Relation-meta inspection point identified
+  (`V1RelationsUpdate.Meta` / `MetaUnset`); single chokepoint, no refactor.
+- F7 [minor] — Resolver becomes constructor parameter; env var parsed in
+  `cmd/rela-server/main.go`. Tests pass resolver directly.
+- F8 [minor] — Hidden + unknown fields produce structurally identical 403;
+  `TestAppRouter_PatchUnknownField_Forbidden` asserts equivalence.
+- F9 [minor] — Profile renamed `triager-demo` → `demo`.
+- F10 [minor] — Create-mode unrestricted in v1; AC11 added.
+- F11 [nit] — Documentation Planning cleaned up; ambiguous strikethroughs
+  removed.
+
+**Design Review Findings (round 2, addressed in this revision):**
+
+- F12 [significant] — Dropped friendly-drop semantics for read-only fields.
+  `useAutoSave` already suppresses no-op PATCHes client-side (`lastSeenServer`).
+  The matching-value branch was dead code. AC4 collapsed to strict 403.
+- F13 [significant] — Wire shape is SPARSE: `_fields` and `_relations` carry
+  only deviations from default. Under `none`, both emit as `{}`. SPA uses
+  `entity.properties` (not `_fields`) as visibility signal. AC1/AC2 rewritten;
+  `FieldVerdicts` semantics clarified.
+- F14 [significant] — Three relation-write chokepoints, not one:
+  `handleV1CreateRelation` (POST), `handleV1DeleteRelation` (DELETE), and the
+  modern reconciler inside `handleV1UpdateEntity` (PATCH). Shared validator
+  `validateRelationOp` invoked at all three. AC6 expanded.
+- F15 [significant] — List-typed enum option-filter (e.g. `tags`) deferred.
+  Wire shape supports it; PATCH validator only walks scalar enums in v1.
+  Documented in OUT.
+- F16 [minor] — `properties_unset` and `MetaUnset` now treated as writes for
+  hidden/read-only checks. AC3, AC4, AC7 cover the unset cases.
+- F17 [minor] — `cmd/rela-desktop/main.go` confirmed to call `dataentry.NewApp`
+  at line 154; env-var parse + resolver pass-through added there too.
+- F18 [minor] — `just dev` confirmed to be plain `go run`, env passes through.
+  Manual e2e command documented in AC10.
+- F19 [minor] — SPA flicker prevention during load. `DynamicForm` either
+  blocks rendering until `loading.value === false` OR the filter returns `[]`
+  on undefined entity. Implementation chooses; AC8 covers both load states.
+- F20 [nit] — `FieldVerdicts` uses uniform `map[string]bool` convention
+  (renamed `Hidden map[string]struct{}` → `Visible map[string]bool` with
+  inverted polarity).
+- F21 [nit] — Audit `reason` prefix discipline: `affordance:<rule>:<path>`
+  for stub denials vs `acl:...` for real ACL denials. No new audit op for v1;
+  predicate ticket re-evaluates.

--- a/tickets/entities/tickets/TKT-G7N5.md
+++ b/tickets/entities/tickets/TKT-G7N5.md
@@ -1,0 +1,121 @@
+---
+id: TKT-G7N5
+type: ticket
+title: _fields / _relations wire shape + SPA renderer (stub verdict source)
+kind: enhancement
+priority: medium
+effort: l
+status: done
+---
+
+## Goal
+
+Land the **wire shape and SPA renderer** for field-level and relation-meta-level
+affordances, driven by a **dev-only stub verdict source**. The eventual ACL
+backing (role grants, predicates) is out of scope; this ticket exists to lock in
+the wire contract and prove the SPA can render against it end-to-end.
+
+Server emits `_fields` and `_relations` on per-entity GET, alongside the
+existing `_actions`:
+
+```json
+{
+  "id": "TKT-ABC",
+  "type": "ticket",
+  "properties": {...},
+  "_actions": {"update": true, "delete": false, "rename": true},
+  "_fields": {
+    "description": {"writable": false},
+    "status": {"writable": true, "options": {"ready": true, "in-progress": true, "done": false}}
+  },
+  "_relations": {
+    "implements": {
+      "creatable": true,
+      "removable": true,
+      "fields": {
+        "note": {"writable": true},
+        "weight": {"writable": false}
+      }
+    }
+  }
+}
+```
+
+## Wire semantics
+
+- **Hidden** fields are **OMITTED** from `properties` entirely (and from `_fields`).
+- **Read-only** fields appear in `properties` with `_fields[name].writable=false`.
+- **Editable** fields appear in `properties` with `_fields[name].writable=true`.
+- No masking; no `null` sentinel. `editable=false` is the same as read-only.
+- **Relation meta fields** get per-relation-type affordances:
+`_relations[type].fields[name].writable` mirrors `_fields[name].writable`.
+Uniform across every link of that type. Per-link affordances are predicate
+territory.
+
+## Verdict source — stub
+
+`internal/dataentry` exposes a `FieldVerdictResolver` interface. v1 ships one
+implementation: a hardcoded fixture controlled by an env var.
+
+- `RELA_AFFORDANCE_PROFILE=none` (default) — everything writable / visible /
+creatable / removable. Equivalent to today's behavior.
+- `RELA_AFFORDANCE_PROFILE=triager-demo` — applies a fixture profile against
+the `ticket` type that exercises every affordance code path:
+  - `description` read-only
+  - `internal_notes` hidden (omitted)
+  - `status.options.done` = false (filtered)
+  - `implements` not creatable
+  - `has-review-response` not removable
+  - one relation meta-field non-writable
+
+This profile is the manual-verification surface for the SPA work. No `acl.yaml`
+schema changes.
+
+## SPA consumption
+
+`DynamicForm` consumes the new shape:
+- Disabled inputs for read-only fields
+- Filtered options on enum `<select>` (option absent when `_fields[name].options.<v>=false`)
+- Hidden fields don't render at all (they're not in `properties`)
+- Hidden `+ Add` button on relation panels when `_relations[type].creatable=false`
+- Hidden per-link `x` button when `_relations[type].removable=false`
+- `RelationCards` inline meta-field inputs disabled when
+`_relations[type].fields[name].writable=false`
+
+## In scope
+
+- Wire-shape extension: `_fields` (name → `{writable, options?}`),
+`_relations` (type → `{creatable, removable, fields?}`)
+- `FieldVerdictResolver` interface + hardcoded `triager-demo` fixture
+- `data-entry` handler emits new shape on per-entity GET
+- SPA renderer (`DynamicForm`, `RelationCards`) consumes new shape
+- Wire-vs-policy parity: stub also gates the corresponding write paths so a
+stale client POSTing a hidden field gets a 403 with a rule identifier
+- Per-entity granularity for v1
+
+## Out of scope (follow-ups)
+
+- **Real verdict source** — `acl.yaml` schema for field/option/relation-meta
+grants. Predicate-engine ticket will own this and replace the stub directly. No
+transitional `*_for` shorthand syntax.
+- Type-default + per-entity-override compression of `_fields` for list views
+- List-query field-level read enforcement (only per-entity GET emits the new fields)
+- Cache invalidation beyond what entity ETags already cover
+- Masked-value rendering ("****")
+- Per-link affordances (different verdicts for different links of the same type)
+
+## Why one combined ticket
+
+Backend wire-shape changes can't be properly verified without a consumer
+rendering them. Phase-1 affordances were split (TKT-Y72A backend / TKT-LFT2 SPA)
+and the two PRs gate each other in review. This time one PR covers wire + server
++ SPA so the end-to-end works against the stub before the predicate ticket
+lands.
+
+## Dependencies
+
+- ACL v0 (TKT-GN5LN, TKT-1XK1L, TKT-K0C83) — done. This ticket doesn't change
+the ACL surface; it adds an *adjacent* affordance source for fields and
+relation-meta.
+- Affordances phase 1 (`_actions`, PR #779) — in review; this ticket builds on
+the wire shape introduced there. Will rebase on develop once #779 merges.

--- a/tickets/relations/TKT-G7N5--affects--authorization.md
+++ b/tickets/relations/TKT-G7N5--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G7N5
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-G7N5--affects--data-entry-server.md
+++ b/tickets/relations/TKT-G7N5--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G7N5
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-G7N5--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-G7N5--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G7N5
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-G7N5--has-implementation--IMPL-1BGF.md
+++ b/tickets/relations/TKT-G7N5--has-implementation--IMPL-1BGF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G7N5
+relation: has-implementation
+to: IMPL-1BGF
+---

--- a/tickets/relations/TKT-G7N5--has-planning--PLAN-C5DH.md
+++ b/tickets/relations/TKT-G7N5--has-planning--PLAN-C5DH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G7N5
+relation: has-planning
+to: PLAN-C5DH
+---

--- a/tickets/relations/TKT-G7N5--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-G7N5--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G7N5
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
## Summary

Adds per-entity field-level affordances to the data-entry server + SPA. Server emits `_fields` and `_relations` on per-entity GET alongside the existing `_actions`; SPA reads them to render disabled inputs, filtered enum selects, and hidden + Add / x buttons.

Verdict source is a stub controlled by `RELA_AFFORDANCE_PROFILE` (`none` | `demo`); the predicate-engine follow-up ticket will replace the stub via the same `FieldVerdictResolver` interface — wire shape and SPA rendering are the long-term contract.

## What ships

**Server side:**
- Wire shape: `_fields` (writable, options) and `_relations` (creatable, removable, per-meta-field `fields`) maps on `V1Entity`, both with sparse emission (only deviations from default appear).
- Hidden = omitted from `properties` AND from `_fields`. Single serialization helpers (`serializeEntityForWire`, `serializeRelatedEntityForWire`) enforce this across GET, PATCH echo, POST create, clone, action, includes, and list rows. `_title` rewrite when the display-property is hidden so the secondary-channel leak is closed.
- Write-side parity at all four relation endpoints (per-relation POST/PATCH/DELETE + unified-PATCH modern reconciler).
- Verdict resolved against the SOURCE entity, not the path entity — matters for `direction=incoming` writes where the path entity is the target.
- Read-only field denials are strict 403 (useAutoSave already does no-op suppression client-side, so same-value writes aren't a real path).
- Unknown fields produce structurally identical 403 to hidden fields — closes the side channel.
- Every affordance denial emits a `denied-write` audit row with `rule_kind=affordance`, attributed to the request principal. Audit sink threaded through `appbuild.Services` and `dataentry.NewApp`.

**SPA side:**
- `DynamicForm` filters its config-driven field list against `entity._fields ∪ entity.properties` so hidden fields don't render (data-entry.yaml form configs are the source of fields, not entity properties — the omit-from-properties contract needs an active filter).
- `FieldRenderer` extends `isOptionDisabled` to also consult per-option verdicts; readonly plumbed via existing prop.
- `RelationCards` + `RelationPicker` hide `creatable` / `removable` affordances per verdict; meta-field inputs in cards disable when the verdict denies them.

## Out of scope (predicate-engine follow-up)

- List-query field-level read enforcement
- Per-link affordances (different verdicts for different links of the same relation type)
- List-typed enum option-filter (e.g. `tags`)
- Create-mode affordances
- Reactive predicates (when one field's value changes the affordance on another) — autosave + dry-auto-save endpoint design TBD

## Test plan

- [x] `just test` — green
- [x] `just lint` — clean
- [x] `just ci` — green (lint, coverage, docs, e2e build)
- [x] Frontend: `npm run typecheck` + `npm run test:run` — green (799 tests)
- [x] Manual e2e under `RELA_AFFORDANCE_PROFILE=demo` — verified via Puppeteer earlier in development
- [x] All 11 ACs covered by automated tests
- [x] Six critical findings from cranky-code-reviewer addressed with verification tests:
  - C1 (legacy relation bypass) — resolved by separate PR #790
  - C2+C3 (hidden field leak via PATCH echo / includes / list rows) — single serializeEntityForWire chokepoint
  - C4 (direction=incoming wrong-endpoint resolution) — `relationSourceEntity` helper
  - C5 (audit row missing on affordance denial) — `denyAffordance` emits `denied-write`
  - C6 (e2e build break) — signature updated