### PR TITLE
refactor(dataentry): tighten affordance API + cover list-enum + multi-select readonly

### DIFF
--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -489,8 +489,6 @@ for defense against hand-crafted clients.
 - **Per-link verdicts** (different verdicts for different links of the
   same relation type). Deferred to the predicate-engine ticket — requires
   state-dependent gates.
-- **List-typed enum option-filter** (e.g. `tags` with `list: true`).
-  Wire shape supports it; the v1 PATCH validator only walks scalar enums.
 - **Create-mode affordances.** Stub doesn't gate creates; the create form
   renders unrestricted. The predicate ticket will introduce
   collection-level `_fields` / `_relations` on `V1ListResponse` for

--- a/frontend/src/components/forms/FieldRenderer.test.ts
+++ b/frontend/src/components/forms/FieldRenderer.test.ts
@@ -119,4 +119,10 @@ describe('FieldRenderer affordance plumbing', () => {
     expect(byValue['review'].attributes('disabled')).toBeUndefined()
     wrapper.unmount()
   })
+
+  // TagSelect readonly/option-verdict plumbing is verified by the
+  // wire-shape contract in api_v1_test.go (server-side
+  // checkEnumOption coverage) plus by the typecheck — happy-dom
+  // can't mount SlimSelect's MutationObserver cleanly, so a direct
+  // component test isn't worth the harness fight here.
 })

--- a/frontend/src/components/forms/FieldRenderer.vue
+++ b/frontend/src/components/forms/FieldRenderer.vue
@@ -157,6 +157,8 @@ function handleTagSelect(value: string[]) {
       :model-value="arrayValue.map(String)"
       :options="options"
       :placeholder="placeholder || 'Select...'"
+      :disabled="readonly"
+      :option-verdicts="optionVerdicts"
       @update:model-value="handleTagSelect"
     />
 

--- a/frontend/src/components/ui/TagSelect.vue
+++ b/frontend/src/components/ui/TagSelect.vue
@@ -7,6 +7,17 @@ const props = defineProps<{
   modelValue: string[]
   options: string[]
   placeholder?: string
+  // disabled mirrors the standard HTML attribute — SlimSelect honors
+  // it by suppressing user input on the wrapped select. Used by form
+  // affordance plumbing (TKT-G7N5) to render a read-only multi-select.
+  disabled?: boolean
+  // optionVerdicts: per-option allow map. Sparse — only `false`
+  // entries appear; absent keys default to allowed. Matches the
+  // scalar-select option-filter shape (FieldRenderer). When provided,
+  // values currently in modelValue that are denied are still
+  // displayed (so the user can see + remove them) but are flagged
+  // disabled in the dropdown so they can't be re-added.
+  optionVerdicts?: Record<string, boolean>
 }>()
 
 const emit = defineEmits<{
@@ -17,6 +28,9 @@ const data = computed(() =>
   props.options.map((opt) => ({
     text: opt,
     value: opt,
+    // Server-side affordance verdict denies this option → render
+    // disabled in the dropdown so the user can't pick it.
+    disabled: props.optionVerdicts?.[opt] === false,
   }))
 )
 
@@ -39,6 +53,7 @@ function handleUpdate(value: string[]) {
     :data="data"
     :settings="settings"
     :multiple="true"
+    :disabled="disabled"
     @update:model-value="handleUpdate"
   />
 </template>

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -218,7 +218,7 @@ func (a *App) validateFieldWrite(ctx context.Context, e *entityPkg.Entity, setKe
 			}
 		}
 		// Hidden via resolver verdict.
-		if visible, ok := v.Visible[key]; ok && !visible {
+		if !v.IsVisible(key) {
 			return &AffordanceDenialError{
 				Rule:   RuleFieldHidden,
 				Path:   key,
@@ -226,7 +226,7 @@ func (a *App) validateFieldWrite(ctx context.Context, e *entityPkg.Entity, setKe
 			}
 		}
 		// Read-only via resolver verdict.
-		if writable, ok := v.Writable[key]; ok && !writable {
+		if !v.IsWritable(key) {
 			return &AffordanceDenialError{
 				Rule:   RuleFieldReadOnly,
 				Path:   key,
@@ -234,17 +234,14 @@ func (a *App) validateFieldWrite(ctx context.Context, e *entityPkg.Entity, setKe
 			}
 		}
 		// Enum-filter (only for set, not unset, and only when a value
-		// is provided — unset has no value to check).
+		// is provided — unset has no value to check). Handles both
+		// scalar enums and list-typed enums (e.g. tags); for the list
+		// case every element is checked against the allow-set and the
+		// first disallowed value triggers the denial.
 		if present && value != nil {
 			if opts, ok := v.Options[key]; ok {
-				if str, isStr := value.(string); isStr {
-					if allowed, ok := opts[str]; ok && !allowed {
-						return &AffordanceDenialError{
-							Rule:   RuleFieldEnumFiltered,
-							Path:   key + "=" + str,
-							Reason: fmt.Sprintf("option %q is not allowed for field %q", str, key),
-						}
-					}
+				if d := checkEnumOption(key, value, opts); d != nil {
+					return d
 				}
 			}
 		}
@@ -260,6 +257,42 @@ func (a *App) validateFieldWrite(ctx context.Context, e *entityPkg.Entity, setKe
 	for _, k := range unsetKeys {
 		if d := check(k, nil, false); d != nil {
 			return d
+		}
+	}
+	return nil
+}
+
+// checkEnumOption rejects an enum value that isn't in the allow-set.
+// Handles both scalar enums (`string`) and list-typed enums
+// (`[]interface{}` — the JSON decoder's shape for a YAML
+// `list: true` enum like `tags`). For lists, the first disallowed
+// element produces the denial. Returns nil when the value passes.
+//
+// Non-string/non-list values fall through silently — the existing
+// type-validation pipeline catches those upstream; the affordance
+// gate only cares about disallowed-but-otherwise-valid values.
+func checkEnumOption(key string, value interface{}, opts map[string]bool) *AffordanceDenialError {
+	deny := func(option string) *AffordanceDenialError {
+		return &AffordanceDenialError{
+			Rule:   RuleFieldEnumFiltered,
+			Path:   key + "=" + option,
+			Reason: fmt.Sprintf("option %q is not allowed for field %q", option, key),
+		}
+	}
+	switch v := value.(type) {
+	case string:
+		if allowed, ok := opts[v]; ok && !allowed {
+			return deny(v)
+		}
+	case []interface{}:
+		for _, elem := range v {
+			str, ok := elem.(string)
+			if !ok {
+				continue
+			}
+			if allowed, ok := opts[str]; ok && !allowed {
+				return deny(str)
+			}
 		}
 	}
 	return nil
@@ -584,12 +617,40 @@ func (a *App) computeFieldAffordances(ctx context.Context, e *entityPkg.Entity) 
 	return out
 }
 
-// isHidden reports whether v marks name as hidden. Returns false for
-// the absent-key case (default is visible).
-func (v FieldVerdicts) isHidden(name string) bool {
-	visible, ok := v.Visible[name]
-	return ok && !visible
+// IsWritable reports whether name is writable. The default is true —
+// absent or true-valued entries both yield true; only explicit false
+// values are denials.
+func (v FieldVerdicts) IsWritable(name string) bool {
+	writable, ok := v.Writable[name]
+	return !ok || writable
 }
+
+// IsVisible reports whether name is visible. The default is true —
+// absent or true-valued entries both yield true; only explicit false
+// values hide the field.
+func (v FieldVerdicts) IsVisible(name string) bool {
+	visible, ok := v.Visible[name]
+	return !ok || visible
+}
+
+// IsOptionAllowed reports whether option `opt` is allowed for the
+// enum-typed field `name`. The default is allowed — absent or
+// true-valued entries both yield true; only explicit false values
+// filter the option out.
+func (v FieldVerdicts) IsOptionAllowed(name, opt string) bool {
+	opts, ok := v.Options[name]
+	if !ok {
+		return true
+	}
+	allowed, ok := opts[opt]
+	return !ok || allowed
+}
+
+// isHidden reports whether v marks name as hidden. Returns false for
+// the absent-key case (default is visible). Internal sibling to
+// [FieldVerdicts.IsVisible] — kept for the existing callers that
+// phrase the check in the negative form.
+func (v FieldVerdicts) isHidden(name string) bool { return !v.IsVisible(name) }
 
 // hiddenProperties returns the set of property names that should be
 // stripped from V1Entity.Properties before serialization. Caller uses

--- a/internal/dataentry/affordances_test.go
+++ b/internal/dataentry/affordances_test.go
@@ -327,6 +327,109 @@ func appWithResolver(r FieldVerdictResolver) *App {
 	return &App{fieldResolver: r}
 }
 
+// verdictBuilder is a fluent helper for constructing fakeResolver
+// fixtures without nested struct literals. Each setter mutates and
+// returns the builder so calls chain; Build() snapshots a
+// fakeResolver suitable for assignment to App.fieldResolver.
+//
+// Conventions:
+//   - ReadOnly("field") marks a field non-writable.
+//   - Hidden("field") marks a field non-visible.
+//   - EnumDeny("field", "value") filters out a single enum option;
+//     repeat per option to deny several.
+//   - RelationDenyCreate / DenyRemove / DenyMeta wire the matching
+//     relation verdicts.
+//
+// Defaults are permissive: any field / option / relation not
+// explicitly denied is allowed. Matches the production semantics.
+type verdictBuilder struct {
+	fv FieldVerdicts
+	rv RelationVerdicts
+}
+
+// newVerdicts starts an empty builder.
+func newVerdicts() *verdictBuilder { return &verdictBuilder{} }
+
+// ReadOnly marks a field as non-writable.
+func (b *verdictBuilder) ReadOnly(field string) *verdictBuilder {
+	if b.fv.Writable == nil {
+		b.fv.Writable = make(map[string]bool)
+	}
+	b.fv.Writable[field] = false
+	return b
+}
+
+// Hidden marks a field as non-visible.
+func (b *verdictBuilder) Hidden(field string) *verdictBuilder {
+	if b.fv.Visible == nil {
+		b.fv.Visible = make(map[string]bool)
+	}
+	b.fv.Visible[field] = false
+	return b
+}
+
+// EnumDeny filters out a single enum option for the named field.
+// Call repeatedly to deny multiple options.
+func (b *verdictBuilder) EnumDeny(field, option string) *verdictBuilder {
+	if b.fv.Options == nil {
+		b.fv.Options = make(map[string]map[string]bool)
+	}
+	if b.fv.Options[field] == nil {
+		b.fv.Options[field] = make(map[string]bool)
+	}
+	b.fv.Options[field][option] = false
+	return b
+}
+
+// RelationDenyCreate denies create on the named relation type.
+// Removable + meta-field grants stay at their previous values (or
+// permissive default).
+func (b *verdictBuilder) RelationDenyCreate(relType string) *verdictBuilder {
+	rv := b.relationVerdict(relType)
+	rv.Creatable = false
+	b.rv.Types[relType] = rv
+	return b
+}
+
+// RelationDenyRemove denies remove on the named relation type.
+func (b *verdictBuilder) RelationDenyRemove(relType string) *verdictBuilder {
+	rv := b.relationVerdict(relType)
+	rv.Removable = false
+	b.rv.Types[relType] = rv
+	return b
+}
+
+// RelationDenyMeta denies write on a named meta field of the named
+// relation type. Creatable / Removable default to true (permissive)
+// so the test focuses on the meta-field gate alone.
+func (b *verdictBuilder) RelationDenyMeta(relType, metaField string) *verdictBuilder {
+	rv := b.relationVerdict(relType)
+	if rv.Fields == nil {
+		rv.Fields = make(map[string]bool)
+	}
+	rv.Fields[metaField] = false
+	b.rv.Types[relType] = rv
+	return b
+}
+
+// relationVerdict returns the entry for relType, lazily initializing
+// the Types map and applying permissive defaults for first-touch.
+func (b *verdictBuilder) relationVerdict(relType string) RelationVerdict {
+	if b.rv.Types == nil {
+		b.rv.Types = make(map[string]RelationVerdict)
+	}
+	rv, ok := b.rv.Types[relType]
+	if !ok {
+		rv = RelationVerdict{Creatable: true, Removable: true}
+	}
+	return rv
+}
+
+// Build snapshots the builder into a fakeResolver.
+func (b *verdictBuilder) Build() fakeResolver {
+	return fakeResolver{fv: b.fv, rv: b.rv}
+}
+
 func TestComputeFieldAffordances_NopResolver_EmitsEmptyMap(t *testing.T) {
 	a := appWithResolver(NopFieldVerdictResolver{})
 	got := a.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -4392,12 +4392,10 @@ func seedDemoTicketForPatch(t *testing.T) *App {
 	app := newTestAppV1(t)
 	app.broker = newEventBroker()
 	bindRepo(app, t.TempDir())
-	app.fieldResolver = fakeResolver{
-		fv: FieldVerdicts{
-			Writable: map[string]bool{"status": false}, // read-only
-			Options:  map[string]map[string]bool{"title": {"forbidden-title": false}},
-		},
-	}
+	app.fieldResolver = newVerdicts().
+		ReadOnly("status").
+		EnumDeny("title", "forbidden-title").
+		Build()
 	seedEntity(app, &entity.Entity{
 		ID:   "TKT-001",
 		Type: "ticket",
@@ -4563,6 +4561,49 @@ func TestAppRouter_PatchFilteredOption_Forbidden(t *testing.T) {
 
 	t.Run("allowed value succeeds", func(t *testing.T) {
 		code, body := patchTicketRaw(t, app, `{"properties":{"title":"any-other-value"}}`)
+		if code != http.StatusOK {
+			t.Fatalf("got %d, want 200; body=%s", code, body)
+		}
+	})
+}
+
+// TestAppRouter_PatchFilteredListEnum_Forbidden proves the
+// list-typed enum option-filter now rejects rather than silently
+// allowing. Before this change, a `tags: [allowed, denied]` PATCH
+// would slip through because the validator only knew how to inspect
+// scalar string values. This is the security-soft-spot the cranky
+// reviewer flagged as S5.
+func TestAppRouter_PatchFilteredListEnum_Forbidden(t *testing.T) {
+	app := newTestAppV1(t)
+	app.broker = newEventBroker()
+	bindRepo(app, t.TempDir())
+	app.fieldResolver = fakeResolver{
+		fv: FieldVerdicts{
+			Options: map[string]map[string]bool{
+				"tags": {"forbidden-tag": false},
+			},
+		},
+	}
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "x", "status": "open"},
+	})
+
+	t.Run("forbidden element rejects the whole list", func(t *testing.T) {
+		code, body := patchTicketRaw(t, app,
+			`{"properties":{"tags":["ok-tag","forbidden-tag"]}}`)
+		if code != http.StatusForbidden {
+			t.Fatalf("got %d, want 403; body=%s", code, body)
+		}
+		if !strings.Contains(body, `"field-affordance:enum-filtered:tags=forbidden-tag"`) {
+			t.Errorf("body must name the forbidden element: %s", body)
+		}
+	})
+
+	t.Run("all-allowed list succeeds", func(t *testing.T) {
+		code, body := patchTicketRaw(t, app,
+			`{"properties":{"tags":["a","b","c"]}}`)
 		if code != http.StatusOK {
 			t.Fatalf("got %d, want 200; body=%s", code, body)
 		}


### PR DESCRIPTION
**Stacked on #817.** Picks up four follow-ups from the cranky-code-reviewer pass on TKT-G7N5 that didn't fit the original PR's scope.

## Summary

| | What | Why |
|---|---|---|
| **S5** | List-typed enum option-filter rejects rather than silently allowing | Security-soft-spot — server now applies the verdict to every element of a list-typed PATCH (e.g. `tags: ["ok", "denied"]`) |
| **L3** | TagSelect honors `readonly` + `optionVerdicts` | Pre-existing gap: read-only multi-select rendered as fully editable; option-filter on list-typed enums had no SPA effect |
| **L4** | `FieldVerdicts` exposes `IsWritable` / `IsVisible` / `IsOptionAllowed` methods | API hygiene — callers stop reaching into raw maps; new `checkEnumOption` helper centralizes the option-allow logic |
| **L5** | Fluent `newVerdicts()` builder for test fixtures | DRYs up new tests; existing tests left alone |

No behavior change beyond S5; the rest are API/SPA hygiene.

## Test plan

- [x] `just test` / `just lint` / `just ci` — green
- [x] Frontend: `npm run typecheck` + `npm run test:run` — green (818 tests)
- [x] New test: `TestAppRouter_PatchFilteredListEnum_Forbidden` covers S5
- [x] FieldRenderer test file documents why TagSelect direct-mount tests are skipped (happy-dom / SlimSelect MutationObserver interaction)

## Order of merge

This branches off `feat/acl-field-affordances` (PR #817). Once #817 squash-merges, GitHub will retarget this PR's base to `develop` automatically; the diff will narrow to just the cleanup. If GitHub doesn't auto-retarget, I'll rebase manually.