### PR TITLE
docs(tickets): list specific docs paths in planning checklist

### DIFF
--- a/tickets/entities/tickets/TKT-YPHQE.md
+++ b/tickets/entities/tickets/TKT-YPHQE.md
@@ -1,0 +1,16 @@
+---
+id: TKT-YPHQE
+type: ticket
+title: List specific docs paths in planning-checklist template
+priority: low
+effort: s
+kind: docs
+status: done
+description: Replace vague placeholders in the planning-checklist template's Documentation Impact comment with concrete repo doc paths so planners know exactly which files to consider.
+---
+
+Documentation-template-only change. The planning-checklist template listed
+generic doc placeholders that did not map to actual files in this repo. This
+lists the real paths (docs/metamodel.md, docs/cli-reference.md,
+docs/data-entry.md, CLAUDE.md, README.md) instead, making the planning step
+actionable. No code or behavior affected.

--- a/tickets/relations/TKT-YPHQE--affects--metamodel-types.md
+++ b/tickets/relations/TKT-YPHQE--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YPHQE
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-YPHQE--implements--FEAT-GM14.md
+++ b/tickets/relations/TKT-YPHQE--implements--FEAT-GM14.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YPHQE
+relation: implements
+to: FEAT-GM14
+---

--- a/tickets/templates/entities/planning-checklist.md
+++ b/tickets/templates/entities/planning-checklist.md
@@ -101,11 +101,11 @@ For enhancements: identify what documentation needs updating.
 
 **Documentation Impact:**
 <!-- Which docs need updating? Check all that apply:
-- [ ] User guide / reference docs
-- [ ] CLI help text (if commands changed)
-- [ ] CLAUDE.md (if new patterns)
-- [ ] README.md (if project-level changes)
-- [ ] API docs (if applicable)
+- [ ] docs/metamodel.md - New metamodel features
+- [ ] docs/cli-reference.md - New/changed commands
+- [ ] docs/data-entry.md - UI changes
+- [ ] CLAUDE.md - New patterns or conventions
+- [ ] README.md - Project-level changes
 - [ ] N/A - Internal change, no user-facing docs needed
 -->
 


### PR DESCRIPTION
## Summary
- Replace the generic Documentation Impact list in `planning-checklist.md` with the project's actual user-facing doc paths (`docs/metamodel.md`, `docs/cli-reference.md`, `docs/data-entry.md`, `CLAUDE.md`, `README.md`).
- Makes the checklist more actionable — authors pick from real files instead of categories.

## Test plan
- [x] Verified all referenced doc paths exist in the repo.
- [ ] No code changes; CI lint/test will run as usual.