### PR TITLE
Add research workflow

### DIFF
--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -1,0 +1,81 @@
+<!-- @managed: claude-workflow v1 -->
+# Research
+
+Conduct structured research before implementing a feature or making a technical decision. The user has described the topic: $ARGUMENTS
+
+## Purpose
+
+Survey approaches, document tradeoffs, and arrive at a recommendation — so that implementation becomes mechanical and design decisions are recorded.
+
+## Step 1: Create the Research Entity
+
+Using the rela MCP tools (rela-issues-and-design-tickets):
+
+1. Parse the user's description to extract:
+   - A concise title framing the research question
+   - Affected concepts (search existing concepts)
+   - Related ticket or feature if mentioned
+
+2. Create the research entity with:
+   - Title framed as a question or topic
+   - Status: `in-progress`
+   - Link to concepts via `researches` relation
+   - Link to ticket/feature via the ticket/feature's `has-research` relation (if applicable)
+
+3. Run `analyze_cardinality` and `analyze_validations` to verify
+
+## Step 2: Survey
+
+Investigate the topic thoroughly. Use the Explore agent for broad codebase searches.
+
+**Existing patterns:**
+- Search the codebase for similar problems already solved
+- Check for libraries or utilities that could be reused
+- Look at how related subsystems handle the same concern
+
+**External approaches:**
+- Consider well-known patterns or libraries for this problem
+- Check if reference implementations exist
+
+**Constraints:**
+- Review relevant architectural rules (CLAUDE.md, metamodel, arch-lint boundaries)
+- Identify security, performance, or compatibility constraints
+
+## Step 3: Document Options
+
+Update the research entity body with findings:
+
+**## Problem** — What question are we answering? Why does it matter now?
+
+**## Context** — Constraints, existing patterns, prior art found in the codebase
+
+**## Options** — For each viable approach:
+- What would we do?
+- Pros and cons
+- Rough effort estimate
+- Reference implementations or examples found
+
+**## Recommendation** — Which option and why. What tradeoffs are we accepting?
+
+## Step 4: Complete
+
+1. Update the research entity:
+   - Set `summary` to a one-line conclusion
+   - Set status to `done`
+2. If research was linked to a ticket, create an `informs` relation from the research to any decisions it led to
+3. Run `analyze_validations` — must pass
+
+## Step 5: Present to User
+
+Present the research summary:
+- The problem framing
+- Options considered (brief)
+- The recommendation with key tradeoff
+- ASK: "Does this direction look right, or should I explore any option further?"
+
+## Key Principles
+
+1. **Survey before deciding**: Don't jump to a recommendation without exploring alternatives
+2. **Ground in the codebase**: Every option should reference existing patterns or explain why it departs from them
+3. **Record for posterity**: The research entity is a durable record — future developers can understand why an approach was chosen
+4. **Keep it proportional**: A small spike gets a short doc; a large feature gets thorough analysis

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -598,6 +598,25 @@ When creating or updating entities in `rela-issues-and-design-tickets`:
 | feature | `requires` → concept (min 1) |
 | test-case/test-suite | `test-covers` → concept (min 1), `verifies` → feature/ticket (min 1) |
 | doc-task | `affects` → concept (min 1), `triggered-by` → ticket/feature/decision (min 1), `updates` → guide/tutorial/scenario (min 1) |
+| research | `researches` → concept (min 1) |
+
+### Research Documents
+
+For larger features, run `/research <topic>` before planning to survey
+approaches and document tradeoffs. This creates a `research` entity (RES-xxxx)
+with structured sections: Problem, Context, Options, Recommendation.
+
+**Workflow:**
+1. `/research` creates the entity in `in-progress` and links it to concepts
+2. The agent surveys the codebase and external approaches
+3. Options are documented with pros/cons/effort
+4. A recommendation is made and presented for user review
+5. The research is linked to the ticket/feature via `has-research`
+
+**When to use:** Enhancements or features where the approach isn't obvious,
+multiple viable options exist, or the change touches unfamiliar subsystems.
+The planning checklist has a research item that can be skipped with N/A for
+smaller work.
 
 ### Validation Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -607,6 +607,7 @@ approaches and document tradeoffs. This creates a `research` entity (RES-xxxx)
 with structured sections: Problem, Context, Options, Recommendation.
 
 **Workflow:**
+
 1. `/research` creates the entity in `in-progress` and links it to concepts
 2. The agent surveys the codebase and external approaches
 3. Options are documented with pros/cons/effort

--- a/tickets/entities/tickets/TKT-EML3Y.md
+++ b/tickets/entities/tickets/TKT-EML3Y.md
@@ -1,0 +1,7 @@
+---
+id: TKT-EML3Y
+type: ticket
+title: Add research entity and /research skill
+kind: enhancement
+status: backlog
+---

--- a/tickets/metamodel.yaml
+++ b/tickets/metamodel.yaml
@@ -42,6 +42,9 @@ types:
   doc_status:
     values: [stub, draft, review, published, outdated]
     default: stub
+  research_status:
+    values: [open, in-progress, done, superseded]
+    default: open
   # Enums
   priority:
     values: [critical, high, medium, low]
@@ -212,6 +215,32 @@ entities:
     default_sort:
       - property: date
         direction: desc
+  research:
+    label: Research
+    aliases: [research-doc, spike]
+    id_prefix: "RES-"
+    id_type: short
+    color: "#E8EAF6"
+    border_color: "#5C6BC0"
+    description: Structured research document surveying approaches before implementation
+    properties:
+      title:
+        type: string
+        required: true
+      summary:
+        type: string
+        description: One-line summary of what was researched and the conclusion
+      status:
+        type: research_status
+        required: true
+    default_sort:
+      - property: status
+      - property: title
+    content:
+      required-headers:
+        - "## Problem"
+        - "## Options"
+        - "## Recommendation"
   # ===================
   # Planning
   # ===================
@@ -963,6 +992,29 @@ relations:
     inverse: triggers
     min_outgoing: 1 # Doc tasks must be triggered by something
   # ===================
+  # Research Relations
+  # ===================
+  has-research:
+    label: has research
+    description: Research document informing this work
+    from: [ticket, feature]
+    to: [research]
+    inverse: researches-for
+    max_outgoing: 3
+  researches:
+    label: researches
+    description: Research touches this architectural concept
+    from: [research]
+    to: [concept]
+    inverse: researchedBy
+    min_outgoing: 1
+  informs:
+    label: informs
+    description: Research findings inform this decision or ticket
+    from: [research]
+    to: [decision, ticket]
+    inverse: informedBy
+  # ===================
   # Workflow Checklist Relations
   # ===================
   has-planning:
@@ -1010,6 +1062,15 @@ relations:
 # Validation Rules
 # ===================
 validations:
+  # --- Research completeness (progressive) ---
+  - name: done-research-needs-summary
+    description: "Done research must have a summary of findings"
+    entity_type: research
+    when:
+      - "status=done"
+    then:
+      - "summary!="
+    severity: error
   # --- Ticket completeness (progressive) ---
   - name: ready-tickets-need-effort
     description: "Ready tickets must have effort estimated"
@@ -1906,6 +1967,15 @@ validations:
       - "status=blocked"
     then:
       - "status!=blocked"
+    severity: error
+  # --- Research in progress ---
+  - name: ci-no-in-progress-research
+    description: "CI: Research in 'in-progress' status cannot be merged - complete or revert"
+    entity_type: research
+    when:
+      - "status=in-progress"
+    then:
+      - "status!=in-progress"
     severity: error
   # --- Checklists in progress ---
   - name: ci-no-in-progress-checklists-planning

--- a/tickets/relations/TKT-EML3Y--affects--metamodel-types.md
+++ b/tickets/relations/TKT-EML3Y--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EML3Y
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-EML3Y--implements--FEAT-012.md
+++ b/tickets/relations/TKT-EML3Y--implements--FEAT-012.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EML3Y
+relation: implements
+to: FEAT-012
+---

--- a/tickets/templates/entities/planning-checklist.md
+++ b/tickets/templates/entities/planning-checklist.md
@@ -19,10 +19,13 @@ status: pending
 
 ## Research
 
+- [ ] For larger features: run `/research` to create a structured research doc
 - [ ] Searched for existing libraries that solve this problem
 - [ ] Checked codebase for similar patterns or reusable code
 - [ ] Looked for reference implementations in other projects
 - [ ] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** <!-- Link RES-xxxx if created, or N/A for small changes -->
 
 **Existing Solutions:**
 <!-- Document what you found:

--- a/tickets/templates/entities/research.md
+++ b/tickets/templates/entities/research.md
@@ -1,0 +1,27 @@
+<!-- @managed: claude-workflow v1 -->
+---
+title: Research
+status: open
+---
+
+## Problem
+
+<!-- What question are we trying to answer? What decision needs to be informed? -->
+
+## Context
+
+<!-- Relevant constraints, existing patterns, or prior art in the codebase -->
+
+## Options
+
+<!-- For each option:
+### Option N: Name
+- **Approach**: What would we do?
+- **Pros**: What's good about it?
+- **Cons**: What's bad about it?
+- **Effort**: Rough estimate
+-->
+
+## Recommendation
+
+<!-- Which option and why. What tradeoffs are we accepting? -->


### PR DESCRIPTION
## Summary
- Adds a `research` entity type (RES-xxxx) with `research_status` workflow and structured headers (Problem, Options, Recommendation)
- Adds `has-research`, `researches`, and `informs` relations, a done-needs-summary validation, and a CI gate against in-progress research
- Adds the `/research` skill to survey approaches and produce a research doc before implementation
- Adds a "Research doc reviewed" item to the planning checklist (skippable with N/A for small work)
- Documents the workflow in CLAUDE.md

## Test plan
- [ ] `rela analyze schema` / `analyze validations` pass on `tickets/`
- [ ] `/research <topic>` creates a valid RES entity linked to a concept
- [ ] Planning checklist renders the new research item