### PR TITLE
refactor(mcp): mcp.Deps struct replaces Services interface (TKT-7I3P)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -258,6 +258,12 @@ deps:
       - wails
 
   # Server protocols
+  #
+  # mcp takes a focused mcp.Deps struct (domain types only) from the
+  # cli wiring site; it holds no composition-root aggregate, so
+  # appbuild is deliberately absent from this whitelist. The project
+  # context no longer leaks in either — mcp.Deps carries ProjectRoot
+  # as a plain string rather than a *project.Context.
   mcp:
     mayDependOn:
       - ai
@@ -269,7 +275,6 @@ deps:
       - principal
       - lua
       - metamodel
-      - project
       - rename
       - schema
       - script

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -73,7 +73,7 @@ func runMCPServer() error {
 		User: principal.SystemUser(),
 		Tool: principal.ToolMCP,
 	}
-	srv, srvErr := relamcp.NewServer(svc, Version, relamcp.WithPrincipal(mcpPrincipal))
+	srv, srvErr := relamcp.NewServer(svc.Deps(), Version, relamcp.WithPrincipal(mcpPrincipal))
 	if srvErr != nil {
 		return fmt.Errorf("mcp startup: %w", srvErr)
 	}

--- a/internal/cli/mcp_wiring.go
+++ b/internal/cli/mcp_wiring.go
@@ -27,9 +27,12 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/validator"
 )
 
-// mcpServices is the focused-services bundle MCP needs. It satisfies
-// [mcp.Services] without going through workspace. Constructed once by
-// [newMCPServices] and held for the lifetime of the MCP process.
+// mcpServices owns the per-project services the MCP process needs and
+// their lifecycle (Close). It is constructed once by [newMCPServices]
+// and held for the lifetime of the MCP process. The MCP server itself
+// receives a flattened [mcp.Deps] via [mcpServices.Deps] — it never
+// holds a reference to this struct, so `internal/mcp` does not depend
+// on this wiring code.
 type mcpServices struct {
 	paths        *project.Context
 	meta         *metamodel.Metamodel
@@ -46,15 +49,10 @@ type mcpServices struct {
 	closeOnce sync.Once
 }
 
-// compile-time check that *mcpServices satisfies mcp.Services so a
-// method-signature drift surfaces here rather than at the call site
-// where the value is handed to relamcp.NewServer.
-var _ relamcp.Services = (*mcpServices)(nil)
-
 // newMCPServices discovers the project at startDir, opens its store
 // with the search backend pre-wired as an [store.EntityObserver],
 // constructs the focused services MCP needs, and returns a bundle
-// that satisfies [mcp.Services].
+// whose [mcpServices.Deps] builds the [mcp.Deps] handed to the server.
 func newMCPServices(startDir string) (*mcpServices, error) {
 	fs := storage.NewSafeFS(storage.NewOsFS())
 	paths, discErr := project.Discover(startDir, fs)
@@ -136,21 +134,28 @@ func newMCPServices(startDir string) (*mcpServices, error) {
 	return svc, nil
 }
 
-// --- mcp.Services satisfaction ---
-
-func (s *mcpServices) Store() store.Store                         { return s.store }
-func (s *mcpServices) Meta() *metamodel.Metamodel                 { return s.meta }
-func (s *mcpServices) Tracer() tracer.Tracer                      { return s.tracer }
-func (s *mcpServices) Searcher() search.Searcher                  { return s.searcher }
-func (s *mcpServices) Validator() validator.Validator             { return s.validator }
-func (s *mcpServices) EntityManager() entitymanager.EntityManager { return s.manager }
-func (s *mcpServices) Config() config.Loader                      { return s.cfg }
-func (s *mcpServices) Paths() *project.Context                    { return s.paths }
-func (s *mcpServices) LuaCache() *lua.Cache                       { return s.scriptEngine.LuaCache() }
-func (s *mcpServices) Watcher() relamcp.Watcher                   { return s.watcher }
-
-func (s *mcpServices) LuaWriteDeps() lua.WriteDeps {
-	return lua.WriteDeps{ReadDeps: s.luaReadDeps(), EntityManager: s.manager}
+// Deps flattens the per-project services into the focused [mcp.Deps]
+// the MCP server consumes. Built once at wiring time; the resulting
+// value holds domain types only, so the server has no path back to
+// this struct or to any composition-root aggregate.
+func (s *mcpServices) Deps() relamcp.Deps {
+	var root string
+	if s.paths != nil {
+		root = s.paths.Root
+	}
+	return relamcp.Deps{
+		Store:         s.store,
+		Meta:          s.meta,
+		Tracer:        s.tracer,
+		Searcher:      s.searcher,
+		Validator:     s.validator,
+		EntityManager: s.manager,
+		Config:        s.cfg,
+		LuaWriteDeps:  lua.WriteDeps{ReadDeps: s.luaReadDeps(), EntityManager: s.manager},
+		LuaCache:      s.scriptEngine.LuaCache(),
+		Watcher:       s.watcher,
+		ProjectRoot:   root,
+	}
 }
 
 func (s *mcpServices) luaReadDeps() lua.ReadDeps {

--- a/internal/cli/mcp_wiring_test.go
+++ b/internal/cli/mcp_wiring_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	relaerrors "github.com/Sourcehaven-BV/rela/internal/errors"
-	relamcp "github.com/Sourcehaven-BV/rela/internal/mcp"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
@@ -72,19 +71,17 @@ func TestNewMCPServices_Succeeds(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = svc.Close() })
 
-	assert.NotNil(t, svc.Store())
-	assert.NotNil(t, svc.Meta())
-	assert.NotNil(t, svc.Tracer())
-	assert.NotNil(t, svc.Searcher())
-	assert.NotNil(t, svc.Validator())
-	assert.NotNil(t, svc.EntityManager())
-	assert.NotNil(t, svc.Config())
-	assert.NotNil(t, svc.Paths())
-	assert.NotNil(t, svc.LuaCache())
-	assert.NotNil(t, svc.Watcher())
-	// Variadic var _ = (*mcpServices)(nil) on the type already
-	// pins the Services interface assertion at compile time.
-	var _ relamcp.Services = svc
+	deps := svc.Deps()
+	assert.NotNil(t, deps.Store)
+	assert.NotNil(t, deps.Meta)
+	assert.NotNil(t, deps.Tracer)
+	assert.NotNil(t, deps.Searcher)
+	assert.NotNil(t, deps.Validator)
+	assert.NotNil(t, deps.EntityManager)
+	assert.NotNil(t, deps.Config)
+	assert.NotNil(t, deps.LuaCache)
+	assert.NotNil(t, deps.Watcher)
+	assert.NotEmpty(t, deps.ProjectRoot)
 }
 
 func TestNewMCPServices_WritesReachSearchIndex(t *testing.T) {
@@ -95,14 +92,15 @@ func TestNewMCPServices_WritesReachSearchIndex(t *testing.T) {
 	t.Cleanup(func() { _ = svc.Close() })
 
 	ctx := context.Background()
-	require.NoError(t, svc.Store().CreateEntity(ctx, &entity.Entity{
+	deps := svc.Deps()
+	require.NoError(t, deps.Store.CreateEntity(ctx, &entity.Entity{
 		ID:         "ITEM-1",
 		Type:       "item",
 		Properties: map[string]interface{}{"title": "Synchronous indexing"},
 	}))
 
 	hits := make([]string, 0, 1)
-	for hit, hitErr := range svc.Searcher().Search(ctx, search.Query{Text: "Synchronous"}) {
+	for hit, hitErr := range deps.Searcher.Search(ctx, search.Query{Text: "Synchronous"}) {
 		require.NoError(t, hitErr)
 		hits = append(hits, hit.ID)
 	}

--- a/internal/mcp/principal_test.go
+++ b/internal/mcp/principal_test.go
@@ -15,7 +15,7 @@ import (
 // unknown/unknown audit attribution in production would be an
 // invisible bug.
 func TestNewServer_RejectsZeroPrincipal(t *testing.T) {
-	_, err := NewServer(nil, "0.0.0")
+	_, err := NewServer(Deps{}, "0.0.0")
 	if err == nil {
 		t.Fatal("expected error when WithPrincipal is omitted")
 	}

--- a/internal/mcp/principal_test.go
+++ b/internal/mcp/principal_test.go
@@ -21,6 +21,42 @@ func TestNewServer_RejectsZeroPrincipal(t *testing.T) {
 	}
 }
 
+// TestNewServer_RejectsIncompleteDeps verifies that NewServer rejects a
+// Deps missing any required field, with a valid Principal supplied so
+// the Deps validation (not the Principal gate) is what fails. A zero
+// field deferred to request time would either nil-deref in a handler or
+// — for ProjectRoot — make lua_list silently walk the process CWD.
+func TestNewServer_RejectsIncompleteDeps(t *testing.T) {
+	withPrincipal := WithPrincipal(principal.Principal{User: "test", Tool: principal.ToolMCP})
+
+	// makeTestServer builds a complete Deps; reuse it as the baseline.
+	complete := makeTestServer(t).deps
+	if _, err := NewServer(complete, "0.0.0", withPrincipal); err != nil {
+		t.Fatalf("complete Deps should construct: %v", err)
+	}
+
+	mutators := map[string]func(*Deps){
+		"Store":         func(d *Deps) { d.Store = nil },
+		"Meta":          func(d *Deps) { d.Meta = nil },
+		"Tracer":        func(d *Deps) { d.Tracer = nil },
+		"Searcher":      func(d *Deps) { d.Searcher = nil },
+		"Validator":     func(d *Deps) { d.Validator = nil },
+		"EntityManager": func(d *Deps) { d.EntityManager = nil },
+		"Config":        func(d *Deps) { d.Config = nil },
+		"Watcher":       func(d *Deps) { d.Watcher = nil },
+		"ProjectRoot":   func(d *Deps) { d.ProjectRoot = "" },
+	}
+	for field, zero := range mutators {
+		t.Run(field, func(t *testing.T) {
+			deps := makeTestServer(t).deps
+			zero(&deps)
+			if _, err := NewServer(deps, "0.0.0", withPrincipal); err == nil {
+				t.Fatalf("expected error when %s is zero", field)
+			}
+		})
+	}
+}
+
 // TestPrincipalMiddleware_WithOption verifies AC4 for the MCP entry
 // point — the configured Principal flows into every tool ctx via the
 // middleware. Registered handlers (including new write tools added

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -66,7 +66,7 @@ func (s *Server) handleAnalyzeTraceabilityPrompt(
 	}
 
 	ctx := context.Background()
-	st := s.ws.Store()
+	st := s.deps.Store
 	e, getErr := st.GetEntity(ctx, id)
 	if getErr != nil {
 		return nil, fmt.Errorf("entity not found: %s", id)
@@ -78,7 +78,7 @@ func (s *Server) handleAnalyzeTraceabilityPrompt(
 	}
 
 	// Get trace trees
-	tracer := s.ws.Tracer()
+	tracer := s.deps.Tracer
 	traceFrom := tracer.TraceFrom(ctx, id, 0)
 	traceTo := tracer.TraceTo(ctx, id, 0)
 
@@ -129,9 +129,9 @@ func (s *Server) handleReviewOrphansPrompt(
 	entityType := request.Params.Arguments["type"]
 
 	ctx := context.Background()
-	orphanIDs, _ := s.ws.Tracer().FindOrphans(ctx)
+	orphanIDs, _ := s.deps.Tracer.FindOrphans(ctx)
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	var resolved string
 	if entityType != "" {
 		resolved = s.resolveType(entityType)
@@ -163,7 +163,7 @@ func (s *Server) handleReviewOrphansPrompt(
 	}
 
 	// Get available relation types
-	meta := s.ws.Meta()
+	meta := s.deps.Meta
 	relTypes := meta.RelationTypes()
 	natsort.Strings(relTypes)
 	var relInfo strings.Builder
@@ -209,8 +209,8 @@ func (s *Server) handleSummarizeProjectPrompt(
 ) (*mcp.GetPromptResult, error) {
 	// Entity counts by type
 	ctx := context.Background()
-	meta := s.ws.Meta()
-	st := s.ws.Store()
+	meta := s.deps.Meta
+	st := s.deps.Store
 	entityTypes := meta.EntityTypes()
 	natsort.Strings(entityTypes)
 	var entityCounts strings.Builder
@@ -238,7 +238,7 @@ func (s *Server) handleSummarizeProjectPrompt(
 	}
 
 	// Analysis summary
-	orphanIDs, _ := s.ws.Tracer().FindOrphans(ctx)
+	orphanIDs, _ := s.deps.Tracer.FindOrphans(ctx)
 	orphanCount := len(orphanIDs)
 
 	content := fmt.Sprintf(`Generate a comprehensive project summary based on the following data.
@@ -287,7 +287,7 @@ func (s *Server) handleReviewEntityPrompt(
 		return nil, errors.New("id argument is required")
 	}
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	entity, getErr := st.GetEntity(context.Background(), id)
 	if getErr != nil {
 		return nil, fmt.Errorf("entity not found: %s", id)
@@ -299,7 +299,7 @@ func (s *Server) handleReviewEntityPrompt(
 	}
 
 	// Get entity type schema
-	meta := s.ws.Meta()
+	meta := s.deps.Meta
 	def, _ := meta.GetEntityDef(entity.Type)
 	var schemaText string
 	if def != nil {

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -47,7 +47,7 @@ func (s *Server) registerResources() {
 func (s *Server) handleReadMetamodel(
 	_ context.Context, _ mcp.ReadResourceRequest,
 ) ([]mcp.ResourceContents, error) {
-	meta := s.ws.Meta()
+	meta := s.deps.Meta
 	result := map[string]interface{}{
 		"version":   meta.GetVersion(),
 		"namespace": meta.GetNamespace(),
@@ -86,7 +86,7 @@ func (s *Server) handleReadEntity(
 	}
 	entityType, id := segments[0], segments[1]
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	e, getErr := st.GetEntity(context.Background(), id)
 	if getErr != nil {
 		return nil, fmt.Errorf("entity not found: %s", id)
@@ -122,7 +122,7 @@ func (s *Server) handleReadRelation(
 	}
 	fromID, relType, toID := segments[0], segments[1], segments[2]
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	relation, getErr := st.GetRelation(context.Background(), fromID, relType, toID)
 	if getErr != nil {
 		return nil, fmt.Errorf("relation not found: %s --%s--> %s", fromID, relType, toID)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -33,29 +33,35 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
-	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/tracer"
 	"github.com/Sourcehaven-BV/rela/internal/validator"
 )
 
-// Services is the slice of backend services the MCP server actually
-// uses. Tests that need a narrower surface can implement Services
-// directly. The wiring site (internal/cli) constructs a concrete
-// implementation from focused services and supplies it to NewServer.
-type Services interface {
-	Store() store.Store
-	Meta() *metamodel.Metamodel
-	Tracer() tracer.Tracer
-	Searcher() search.Searcher
-	Validator() validator.Validator
-	EntityManager() entitymanager.EntityManager
-	Config() config.Loader
-	Paths() *project.Context
-	LuaWriteDeps() lua.WriteDeps
-	LuaCache() *lua.Cache
-	Watcher() Watcher
+// Deps is the focused bundle of backend services the MCP server needs.
+// Every field is a domain type — the server holds no reference to any
+// composition-root aggregate, so `internal/mcp` does not import
+// `internal/appbuild` (enforced by arch-lint). The wiring site
+// (`internal/cli`) constructs a Deps from focused services and supplies
+// it to [NewServer]; tests build a Deps literal directly.
+//
+// ProjectRoot is the absolute project root, used by the lua tools to
+// resolve relative script paths. It is the only piece of the project
+// context MCP consumes — passing the string instead of a
+// `*project.Context` keeps that type from leaking into MCP test stubs.
+type Deps struct {
+	Store         store.Store
+	Meta          *metamodel.Metamodel
+	Tracer        tracer.Tracer
+	Searcher      search.Searcher
+	Validator     validator.Validator
+	EntityManager entitymanager.EntityManager
+	Config        config.Loader
+	LuaWriteDeps  lua.WriteDeps
+	LuaCache      *lua.Cache
+	Watcher       Watcher
+	ProjectRoot   string
 }
 
 // Watcher is the narrow file-watching capability MCP requires from
@@ -74,7 +80,7 @@ type Watcher interface {
 // Server wraps the MCP server with rela-specific state.
 type Server struct {
 	mcp       *server.MCPServer
-	ws        Services
+	deps      Deps
 	logger    *slog.Logger
 	principal principal.Principal
 }
@@ -112,9 +118,9 @@ func (s *Server) principalMiddleware(next server.ToolHandlerFunc) server.ToolHan
 // production bug (CLAUDE.md "constructors reject nil required
 // fields"). Tests must pass a non-zero Principal too — use any
 // non-empty `principal.Principal{User: ..., Tool: ...}`.
-func NewServer(ws Services, version string, opts ...Option) (*Server, error) {
+func NewServer(deps Deps, version string, opts ...Option) (*Server, error) {
 	s := &Server{
-		ws:     ws,
+		deps:   deps,
 		logger: slog.Default().With("component", "mcp"),
 	}
 	for _, opt := range opts {
@@ -158,7 +164,7 @@ func (s *Server) Serve() error {
 	s.logger.Info("starting rela MCP server on stdio")
 
 	// Start the file watcher; MCP only cares "something changed."
-	if err := s.ws.Watcher().Start(func() {
+	if err := s.deps.Watcher.Start(func() {
 		s.logger.Info("graph re-synced from file changes")
 		if s.mcp != nil {
 			s.mcp.SendNotificationToAllClients(
@@ -169,7 +175,7 @@ func (s *Server) Serve() error {
 		s.logger.Warn("file watcher not started", "error", err)
 	}
 
-	defer s.ws.Watcher().Stop()
+	defer s.deps.Watcher.Stop()
 
 	// mcp-go's WithErrorLogger expects a stdlib *log.Logger; bridge to slog
 	// so all output flows through the configured slog handler.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -64,6 +64,38 @@ type Deps struct {
 	ProjectRoot   string
 }
 
+// validate rejects a Deps missing any field whose zero value would
+// defer a failure to request time — a nil collaborator panics inside a
+// tool handler, and an empty ProjectRoot makes lua_list silently walk
+// the process CWD instead of the project's scripts/ dir. Catching these
+// at construction keeps the failure where it can be diagnosed.
+//
+// LuaCache is intentionally absent: a nil cache is a valid "no cache"
+// signal that lua.WithCache tolerates.
+func (d Deps) validate() error {
+	switch {
+	case d.Store == nil:
+		return errors.New("mcp: Deps.Store is required")
+	case d.Meta == nil:
+		return errors.New("mcp: Deps.Meta is required")
+	case d.Tracer == nil:
+		return errors.New("mcp: Deps.Tracer is required")
+	case d.Searcher == nil:
+		return errors.New("mcp: Deps.Searcher is required")
+	case d.Validator == nil:
+		return errors.New("mcp: Deps.Validator is required")
+	case d.EntityManager == nil:
+		return errors.New("mcp: Deps.EntityManager is required")
+	case d.Config == nil:
+		return errors.New("mcp: Deps.Config is required")
+	case d.Watcher == nil:
+		return errors.New("mcp: Deps.Watcher is required")
+	case d.ProjectRoot == "":
+		return errors.New("mcp: Deps.ProjectRoot is required")
+	}
+	return nil
+}
+
 // Watcher is the narrow file-watching capability MCP requires from
 // its wiring site. Start arms the watcher with an opaque "something
 // changed" callback; Pause / Resume temporarily suppress callbacks
@@ -128,6 +160,9 @@ func NewServer(deps Deps, version string, opts ...Option) (*Server, error) {
 	}
 	if s.principal == (principal.Principal{}) {
 		return nil, errors.New("mcp.NewServer: Principal is required (use WithPrincipal)")
+	}
+	if err := deps.validate(); err != nil {
+		return nil, err
 	}
 
 	mcpServer := server.NewMCPServer(

--- a/internal/mcp/test_helpers_test.go
+++ b/internal/mcp/test_helpers_test.go
@@ -9,11 +9,9 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/autocascade"
 	"github.com/Sourcehaven-BV/rela/internal/automation"
-	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
-	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/search/bleveindex"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -22,53 +20,16 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/validator"
 )
 
-// testServices is the in-test Services bundle used by MCP tool tests.
+// newTestDeps wires the focused services MCP tools exercise around a
+// caller-supplied store and returns the [Deps] the server consumes.
 // Mirrors the production cli.mcpServices wiring but without project
-// discovery, fsstore, or the Lua engine — the surface MCP tools
-// actually exercise.
-type testServices struct {
-	store    store.Store
-	meta     *metamodel.Metamodel
-	tracer   tracer.Tracer
-	searcher search.Searcher
-	valid    validator.Validator
-	manager  *entitymanager.Manager
-	watcher  Watcher
-}
-
-var _ Services = (*testServices)(nil)
-
-func (s *testServices) Store() store.Store                         { return s.store }
-func (s *testServices) Meta() *metamodel.Metamodel                 { return s.meta }
-func (s *testServices) Tracer() tracer.Tracer                      { return s.tracer }
-func (s *testServices) Searcher() search.Searcher                  { return s.searcher }
-func (s *testServices) Validator() validator.Validator             { return s.valid }
-func (s *testServices) EntityManager() entitymanager.EntityManager { return s.manager }
-func (s *testServices) Config() config.Loader                      { return nopConfigLoader{} }
-func (s *testServices) Paths() *project.Context                    { return nil }
-func (s *testServices) LuaCache() *lua.Cache                       { return nil }
-func (s *testServices) Watcher() Watcher                           { return nopWatcher{} }
-
-func (s *testServices) LuaWriteDeps() lua.WriteDeps {
-	return lua.WriteDeps{
-		ReadDeps: lua.ReadDeps{
-			Store:    s.store,
-			Tracer:   s.tracer,
-			Searcher: s.searcher,
-			Meta:     s.meta,
-		},
-		EntityManager: s.manager,
-	}
-}
-
-// newTestServices wires the focused services around a caller-supplied
-// store. The store is hooked to a fresh bleve search backend via
-// observer wiring so writes through the store reach the index
-// synchronously.
+// discovery, fsstore, or the Lua engine. The store is hooked to a
+// fresh bleve search backend via observer wiring so writes through
+// the store reach the index synchronously.
 //
 // Callers that want to seed entities before the bleve observer is
 // installed should call backfill manually after seeding.
-func newTestServices(t *testing.T, meta *metamodel.Metamodel, st store.Store) *testServices {
+func newTestDeps(t *testing.T, meta *metamodel.Metamodel, st store.Store) Deps {
 	t.Helper()
 
 	backend, err := bleveindex.NewMem()
@@ -123,14 +84,24 @@ func newTestServices(t *testing.T, meta *metamodel.Metamodel, st store.Store) *t
 		t.Fatalf("entitymanager.New: %v", err)
 	}
 
-	return &testServices{
-		store:    st,
-		meta:     meta,
-		tracer:   tr,
-		searcher: srch,
-		valid:    val,
-		manager:  mgr,
-		watcher:  nopWatcher{},
+	return Deps{
+		Store:         st,
+		Meta:          meta,
+		Tracer:        tr,
+		Searcher:      srch,
+		Validator:     val,
+		EntityManager: mgr,
+		Config:        nopConfigLoader{},
+		LuaWriteDeps: lua.WriteDeps{
+			ReadDeps: lua.ReadDeps{
+				Store:    st,
+				Tracer:   tr,
+				Searcher: srch,
+				Meta:     meta,
+			},
+			EntityManager: mgr,
+		},
+		Watcher: nopWatcher{},
 	}
 }
 

--- a/internal/mcp/test_helpers_test.go
+++ b/internal/mcp/test_helpers_test.go
@@ -101,7 +101,8 @@ func newTestDeps(t *testing.T, meta *metamodel.Metamodel, st store.Store) Deps {
 			},
 			EntityManager: mgr,
 		},
-		Watcher: nopWatcher{},
+		Watcher:     nopWatcher{},
+		ProjectRoot: t.TempDir(),
 	}
 }
 

--- a/internal/mcp/tools_analysis.go
+++ b/internal/mcp/tools_analysis.go
@@ -19,9 +19,9 @@ func (s *Server) handleAnalyzeOrphans(
 ) (*mcp.CallToolResult, error) {
 	entityType := request.GetString("type", "")
 
-	orphanIDs, _ := s.ws.Tracer().FindOrphans(ctx)
+	orphanIDs, _ := s.deps.Tracer.FindOrphans(ctx)
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	resolved := ""
 	if entityType != "" {
 		resolved = s.resolveType(entityType)
@@ -70,7 +70,7 @@ func (s *Server) handleAnalyzeCardinality(
 ) (*mcp.CallToolResult, error) {
 	violations := make([]cardinalityViolation, 0) //nolint:prealloc // capacity unknown
 
-	for relName, relDef := range s.ws.Meta().Relations {
+	for relName, relDef := range s.deps.Meta.Relations {
 		violations = append(violations, s.checkCardinalityForRelation(relName, relDef)...)
 	}
 
@@ -106,7 +106,7 @@ func (s *Server) checkCardinalityBound(
 	var violations []cardinalityViolation
 
 	ctx := context.Background()
-	st := s.ws.Store()
+	st := s.deps.Store
 	for _, entityType := range entityTypes {
 		for e, err := range st.ListEntities(ctx, store.EntityQuery{Type: entityType}) {
 			if err != nil {
@@ -161,8 +161,8 @@ func (s *Server) handleAnalyzeProperties(
 		Errors       []string `json:"errors"`
 	}
 
-	meta := s.ws.Meta()
-	st := s.ws.Store()
+	meta := s.deps.Meta
+	st := s.deps.Store
 	var allEntityErrors []entityErrors
 
 	// Validate entity properties
@@ -185,7 +185,7 @@ func (s *Server) handleAnalyzeProperties(
 	}
 
 	// Validate relation properties
-	relErrors := schema.ValidateRelationProperties(s.ws.Store(), s.ws.Meta())
+	relErrors := schema.ValidateRelationProperties(s.deps.Store, s.deps.Meta)
 	allRelationErrors := make([]relationErrors, 0, len(relErrors))
 	for _, rpe := range relErrors {
 		errStrings := make([]string, len(rpe.Errors))
@@ -236,7 +236,7 @@ func (s *Server) handleAnalyzeProperties(
 func (s *Server) handleAnalyzeValidations(
 	ctx context.Context, _ mcp.CallToolRequest,
 ) (*mcp.CallToolResult, error) {
-	rules := s.ws.Meta().Validations
+	rules := s.deps.Meta.Validations
 	if len(rules) == 0 {
 		return mcp.NewToolResultText("No custom validation rules defined in metamodel"), nil
 	}
@@ -247,7 +247,7 @@ func (s *Server) handleAnalyzeValidations(
 		Violations []string `json:"violations"`
 	}
 
-	validator := s.ws.Validator()
+	validator := s.deps.Validator
 	var results []ruleResult
 	for _, rule := range rules {
 		ids, err := validator.CheckRule(ctx, rule)
@@ -283,8 +283,8 @@ func (s *Server) handleAnalyzeSchema(
 
 	dataEntry := s.loadDataEntryConfig()
 
-	counter := &schema.StoreCounter{Store: s.ws.Store()}
-	analysis := schema.Analyze(s.ws.Meta(), counter, dataEntry, threshold)
+	counter := &schema.StoreCounter{Store: s.deps.Store}
+	analysis := schema.Analyze(s.deps.Meta, counter, dataEntry, threshold)
 
 	if !analysis.HasIssues() {
 		return mcp.NewToolResultText("All schema types are in use"), nil
@@ -311,7 +311,7 @@ func (s *Server) handleAnalyzeSchema(
 
 // loadDataEntryConfig loads data-entry.yaml if it exists.
 func (s *Server) loadDataEntryConfig() *dataentryconfig.Config {
-	data, err := s.ws.Config().Load(context.Background(), dataentryconfig.ConfigFile)
+	data, err := s.deps.Config.Load(context.Background(), dataentryconfig.ConfigFile)
 	if err != nil {
 		return nil
 	}

--- a/internal/mcp/tools_entity.go
+++ b/internal/mcp/tools_entity.go
@@ -24,7 +24,7 @@ func (s *Server) handleListEntities(
 	limit := request.GetInt("limit", 0)
 	offset := request.GetInt("offset", 0)
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	q := store.EntityQuery{}
 	if entityType != "" {
 		q.Type = s.resolveType(entityType)
@@ -81,7 +81,7 @@ func (s *Server) handleShowEntity(
 	}
 	id = trimID(id)
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	e, getErr := st.GetEntity(ctx, id)
 	if getErr != nil {
 		return mcp.NewToolResultError("entity not found: " + id), nil
@@ -110,9 +110,9 @@ func (s *Server) handleSearchEntities(
 		q.Types = []string{s.resolveType(entityType)}
 	}
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	summaries := make([]map[string]interface{}, 0)
-	for hit, searchErr := range s.ws.Searcher().Search(ctx, q) {
+	for hit, searchErr := range s.deps.Searcher.Search(ctx, q) {
 		if searchErr != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("search failed: %v", searchErr)), nil
 		}
@@ -159,7 +159,7 @@ func (s *Server) handleCreateEntity(
 		return errResult, nil
 	}
 
-	result, createErr := s.ws.EntityManager().CreateEntity(ctx,
+	result, createErr := s.deps.EntityManager.CreateEntity(ctx,
 		&entity.Entity{
 			Type:       resolvedType,
 			Properties: properties,
@@ -172,7 +172,7 @@ func (s *Server) handleCreateEntity(
 	}
 	created := result.Entity
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	e, _ := st.GetEntity(ctx, created.ID)
 	if e == nil {
 		// Fallback: return minimal info
@@ -196,7 +196,7 @@ func (s *Server) handleUpdateEntity(
 	}
 	id = trimID(id)
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	e, getErr := st.GetEntity(ctx, id)
 	if getErr != nil {
 		return mcp.NewToolResultError("entity not found: " + id), nil
@@ -226,7 +226,7 @@ func (s *Server) handleUpdateEntity(
 		e.Content = content
 	}
 
-	updateResult, updateErr := s.ws.EntityManager().UpdateEntity(ctx, e)
+	updateResult, updateErr := s.deps.EntityManager.UpdateEntity(ctx, e)
 	if updateErr != nil {
 		return mcp.NewToolResultError(updateErr.Error()), nil
 	}
@@ -281,7 +281,7 @@ func (s *Server) handleDeleteEntity(
 	id = trimID(id)
 	cascade := request.GetBool("cascade", false)
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	e, getErr := st.GetEntity(ctx, id)
 	if getErr != nil {
 		return mcp.NewToolResultError("entity not found: " + id), nil
@@ -296,7 +296,7 @@ func (s *Server) handleDeleteEntity(
 		}
 	}
 
-	result, delErr := s.ws.EntityManager().DeleteEntity(ctx, id, cascade)
+	result, delErr := s.deps.EntityManager.DeleteEntity(ctx, id, cascade)
 	if delErr != nil {
 		return mcp.NewToolResultError(delErr.Error()), nil
 	}
@@ -327,10 +327,10 @@ func (s *Server) handleRenameEntity(
 	dryRun := request.GetBool("dry_run", false)
 
 	// Pause watcher during rename
-	s.ws.Watcher().Pause()
-	defer s.ws.Watcher().Resume()
+	s.deps.Watcher.Pause()
+	defer s.deps.Watcher.Resume()
 
-	result, renameErr := s.ws.EntityManager().RenameEntity(
+	result, renameErr := s.deps.EntityManager.RenameEntity(
 		ctx, oldID, newID, entity.RenameOptions{DryRun: dryRun})
 	if renameErr != nil {
 		return mcp.NewToolResultError(renameErr.Error()), nil

--- a/internal/mcp/tools_export.go
+++ b/internal/mcp/tools_export.go
@@ -24,7 +24,7 @@ func (s *Server) handleExport(
 	}
 	entityType := request.GetString("type", "")
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	q := store.EntityQuery{}
 	if entityType != "" {
 		q.Type = s.resolveType(entityType)

--- a/internal/mcp/tools_helpers.go
+++ b/internal/mcp/tools_helpers.go
@@ -12,7 +12,7 @@ import (
 
 func (s *Server) resolveType(typeName string) string {
 	typeName = strings.TrimSpace(typeName)
-	meta := s.ws.Meta()
+	meta := s.deps.Meta
 	resolved := meta.ResolveAlias(typeName)
 	if _, ok := meta.GetEntityDef(resolved); ok {
 		return resolved
@@ -38,7 +38,7 @@ func trimID(id string) string {
 
 func (s *Server) resolveEntityType(typeName string) (string, *metamodel.EntityDef, error) {
 	resolved := s.resolveType(typeName)
-	def, ok := s.ws.Meta().GetEntityDef(resolved)
+	def, ok := s.deps.Meta.GetEntityDef(resolved)
 	if !ok {
 		return "", nil, fmt.Errorf("unknown entity type: %s", typeName)
 	}
@@ -128,7 +128,7 @@ func (s *Server) validatePropertyNames(entityType string, properties map[string]
 		return nil
 	}
 
-	meta := s.ws.Meta()
+	meta := s.deps.Meta
 	entityDef, ok := meta.GetEntityDef(entityType)
 	if !ok {
 		return nil // Type validation will catch this

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -64,8 +64,8 @@ func (s *Server) handleLuaEval(ctx context.Context, req mcp.CallToolRequest) (*m
 	// Capture output
 	var output bytes.Buffer
 
-	runtime, err := script.NewWriterRuntime(s.ws.LuaWriteDeps(), "",
-		&output, lua.WithContext(ctx), lua.WithCache(s.ws.LuaCache()))
+	runtime, err := script.NewWriterRuntime(s.deps.LuaWriteDeps, "",
+		&output, lua.WithContext(ctx), lua.WithCache(s.deps.LuaCache))
 	if err != nil {
 		return mcp.NewToolResultError("config error: " + err.Error()), nil
 	}
@@ -110,7 +110,7 @@ func (s *Server) handleLuaRun(ctx context.Context, req mcp.CallToolRequest) (*mc
 	// Parse args if provided
 	args := req.GetStringSlice("args", nil)
 
-	projectRoot := s.ws.Paths().Root
+	projectRoot := s.deps.ProjectRoot
 
 	// Security: Scripts must be in the scripts/ directory
 	// Use os.Root for traversal-resistant path access
@@ -143,8 +143,8 @@ func (s *Server) handleLuaRun(ctx context.Context, req mcp.CallToolRequest) (*mc
 	// Capture output
 	var output bytes.Buffer
 
-	runtime, err := script.NewWriterRuntime(s.ws.LuaWriteDeps(), path,
-		&output, lua.WithContext(ctx), lua.WithCache(s.ws.LuaCache()))
+	runtime, err := script.NewWriterRuntime(s.deps.LuaWriteDeps, path,
+		&output, lua.WithContext(ctx), lua.WithCache(s.deps.LuaCache))
 	if err != nil {
 		return mcp.NewToolResultError("config error: " + err.Error()), nil
 	}
@@ -208,7 +208,7 @@ func luaScriptErrorResult(surface lua.Surface, envelopePath, projectRoot string,
 }
 
 func (s *Server) handleLuaList(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	projectRoot := s.ws.Paths().Root
+	projectRoot := s.deps.ProjectRoot
 
 	// Only search the scripts/ directory (security restriction)
 	scriptsPath := filepath.Join(projectRoot, scriptsDir)

--- a/internal/mcp/tools_relation.go
+++ b/internal/mcp/tools_relation.go
@@ -21,7 +21,7 @@ func (s *Server) handleListRelations(
 	limit := request.GetInt("limit", 0)
 	offset := request.GetInt("offset", 0)
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	q := store.RelationQuery{Type: relType, From: from, To: to}
 
 	all := make([]*entity.Relation, 0)
@@ -81,7 +81,7 @@ func (s *Server) handleCreateRelation(
 		Content:    nilIfEmpty(request.GetString("content", "")),
 	}
 
-	if _, createErr := s.ws.EntityManager().CreateRelation(ctx, fromID, relType, toID, opts); createErr != nil {
+	if _, createErr := s.deps.EntityManager.CreateRelation(ctx, fromID, relType, toID, opts); createErr != nil {
 		return mcp.NewToolResultError(createErr.Error()), nil
 	}
 
@@ -108,13 +108,13 @@ func (s *Server) handleDeleteRelation(
 	}
 	toID = trimID(toID)
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	if _, getErr := st.GetRelation(ctx, fromID, relType, toID); getErr != nil {
 		return mcp.NewToolResultError(
 			fmt.Sprintf("relation not found: %s --%s--> %s", fromID, relType, toID)), nil
 	}
 
-	if delErr := s.ws.EntityManager().DeleteRelation(ctx, fromID, relType, toID); delErr != nil {
+	if delErr := s.deps.EntityManager.DeleteRelation(ctx, fromID, relType, toID); delErr != nil {
 		return mcp.NewToolResultError(delErr.Error()), nil
 	}
 

--- a/internal/mcp/tools_schema.go
+++ b/internal/mcp/tools_schema.go
@@ -14,7 +14,7 @@ import (
 func (s *Server) handleGetMetamodel(
 	_ context.Context, _ mcp.CallToolRequest,
 ) (*mcp.CallToolResult, error) {
-	meta := s.ws.Meta()
+	meta := s.deps.Meta
 	result := map[string]interface{}{
 		"version":   meta.GetVersion(),
 		"namespace": meta.GetNamespace(),
@@ -45,8 +45,8 @@ func (s *Server) handleListEntityTypes(
 		Count      int                              `json:"count"`
 	}
 
-	meta := s.ws.Meta()
-	st := s.ws.Store()
+	meta := s.deps.Meta
+	st := s.deps.Store
 	types := meta.EntityTypes()
 	natsort.Strings(types)
 
@@ -87,8 +87,8 @@ func (s *Server) handleListRelationTypes(
 		Count       int      `json:"count"`
 	}
 
-	meta := s.ws.Meta()
-	st := s.ws.Store()
+	meta := s.deps.Meta
+	st := s.deps.Store
 	types := meta.RelationTypes()
 	natsort.Strings(types)
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -64,10 +64,8 @@ func makeTestServer(t *testing.T) *Server {
 		t.Fatalf("seed relation: %v", err)
 	}
 
-	svc := newTestServices(t, meta, st)
-
 	return &Server{
-		ws:     svc,
+		deps:   newTestDeps(t, meta, st),
 		logger: slog.New(slog.DiscardHandler),
 	}
 }
@@ -272,7 +270,7 @@ func TestHandleUpdateEntity_DeletesPropertyOnNil(t *testing.T) {
 	if isErrorResult(result) {
 		t.Fatalf("expected success, got error: %s", getResultText(t, result))
 	}
-	updated, getErr := s.ws.Store().GetEntity(context.Background(), "REQ-001")
+	updated, getErr := s.deps.Store.GetEntity(context.Background(), "REQ-001")
 	if getErr != nil {
 		t.Fatalf("get entity: %v", getErr)
 	}
@@ -304,7 +302,7 @@ func TestHandleUpdateEntity_DeleteOnlyCallSurvivesGuard(t *testing.T) {
 func TestHandleUpdateEntity_DeleteAbsentPropertyIsNoOp(t *testing.T) {
 	// `priority` is in the metamodel but not set on REQ-001; deleting it should be a no-op.
 	s := makeTestServer(t)
-	before, _ := s.ws.Store().GetEntity(context.Background(), "REQ-001")
+	before, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
 	if _, present := before.Properties["priority"]; present {
 		t.Fatalf("test setup: REQ-001 should not have a priority property")
 	}
@@ -320,7 +318,7 @@ func TestHandleUpdateEntity_DeleteAbsentPropertyIsNoOp(t *testing.T) {
 	if isErrorResult(result) {
 		t.Fatalf("expected success on no-op delete, got error: %s", getResultText(t, result))
 	}
-	after, _ := s.ws.Store().GetEntity(context.Background(), "REQ-001")
+	after, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
 	if _, present := after.Properties["priority"]; present {
 		t.Errorf("priority should remain absent")
 	}
@@ -333,7 +331,7 @@ func TestHandleUpdateEntity_DeleteRequiredPropertyRejected(t *testing.T) {
 	// `title` is required; attempting to delete it must surface an actionable error
 	// rather than silently producing a now-invalid entity.
 	s := makeTestServer(t)
-	before, _ := s.ws.Store().GetEntity(context.Background(), "REQ-001")
+	before, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
 	beforeTitle := before.GetString("title")
 
 	req := makeToolRequest(map[string]interface{}{
@@ -351,7 +349,7 @@ func TestHandleUpdateEntity_DeleteRequiredPropertyRejected(t *testing.T) {
 		t.Errorf("expected 'required' in error message, got %s", getResultText(t, result))
 	}
 	// Entity must be unchanged.
-	after, _ := s.ws.Store().GetEntity(context.Background(), "REQ-001")
+	after, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
 	if after.GetString("title") != beforeTitle {
 		t.Errorf("entity must be unchanged after rejected delete: title was %q, now %q", beforeTitle, after.GetString("title"))
 	}
@@ -371,7 +369,7 @@ func TestHandleUpdateEntity_JSONStringPropertiesNullDeletes(t *testing.T) {
 	if isErrorResult(result) {
 		t.Fatalf("expected success, got error: %s", getResultText(t, result))
 	}
-	updated, _ := s.ws.Store().GetEntity(context.Background(), "REQ-001")
+	updated, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
 	if _, present := updated.Properties["status"]; present {
 		t.Errorf("status should be removed when sent as JSON string with null")
 	}
@@ -411,7 +409,7 @@ func TestHandleUpdateEntity_MixedSetAndUnset(t *testing.T) {
 	if isErrorResult(result) {
 		t.Fatalf("expected success, got error: %s", getResultText(t, result))
 	}
-	updated, _ := s.ws.Store().GetEntity(context.Background(), "REQ-001")
+	updated, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
 	if _, present := updated.Properties["status"]; present {
 		t.Errorf("status should be removed")
 	}
@@ -440,7 +438,7 @@ func TestHandleUpdateEntity_EmptyStringIsNoOp(t *testing.T) {
 		t.Errorf("expected 'no updates specified', got %s", getResultText(t, result))
 	}
 	// And the existing status is untouched.
-	updated, _ := s.ws.Store().GetEntity(context.Background(), "REQ-001")
+	updated, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
 	if got := updated.GetString("status"); got != "accepted" {
 		t.Errorf("status should remain 'accepted', got %q", got)
 	}
@@ -460,7 +458,7 @@ func TestHandleUpdateEntity_SetAndOverwriteStillWorks(t *testing.T) {
 	if isErrorResult(result) {
 		t.Fatalf("expected success, got error: %s", getResultText(t, result))
 	}
-	updated, _ := s.ws.Store().GetEntity(context.Background(), "REQ-001")
+	updated, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
 	if got := updated.GetString("status"); got != "rejected" {
 		t.Errorf("expected status 'rejected', got %q", got)
 	}
@@ -579,7 +577,7 @@ func TestHandleListRelations_NoMatch(t *testing.T) {
 func TestHandleListRelations_Pagination(t *testing.T) {
 	s := makeTestServer(t)
 	// Add another relation for pagination testing
-	if _, err := s.ws.Store().CreateRelation(context.Background(), "DEC-001", "addresses", "REQ-002", nil); err != nil {
+	if _, err := s.deps.Store.CreateRelation(context.Background(), "DEC-001", "addresses", "REQ-002", nil); err != nil {
 		t.Fatalf("seed relation: %v", err)
 	}
 
@@ -819,7 +817,7 @@ func TestHandleAnalyzeCardinality_WithViolation(t *testing.T) {
 	s := makeTestServer(t)
 	// Set a minimum cardinality that won't be met
 	minVal := 5
-	meta := s.ws.Meta()
+	meta := s.deps.Meta
 	meta.Relations["addresses"] = metamodel.RelationDef{
 		From:        []string{"decision"},
 		To:          []string{"requirement"},

--- a/internal/mcp/tools_trace.go
+++ b/internal/mcp/tools_trace.go
@@ -39,11 +39,11 @@ func (s *Server) handleTrace(
 	id = trimID(id)
 	maxDepth := request.GetInt("max_depth", 0)
 
-	if _, getErr := s.ws.Store().GetEntity(ctx, id); getErr != nil {
+	if _, getErr := s.deps.Store.GetEntity(ctx, id); getErr != nil {
 		return mcp.NewToolResultError("entity not found: " + id), nil
 	}
 
-	result := traceFn(s.ws.Tracer(), id, maxDepth)
+	result := traceFn(s.deps.Tracer, id, maxDepth)
 	if result == nil {
 		return mcp.NewToolResultText(emptyMsg), nil
 	}
@@ -69,7 +69,7 @@ func (s *Server) handleFindPath(
 	}
 	to = trimID(to)
 
-	st := s.ws.Store()
+	st := s.deps.Store
 	if _, fromErr := st.GetEntity(ctx, from); fromErr != nil {
 		return mcp.NewToolResultError("source entity not found: " + from), nil
 	}
@@ -77,7 +77,7 @@ func (s *Server) handleFindPath(
 		return mcp.NewToolResultError("target entity not found: " + to), nil
 	}
 
-	path := s.ws.Tracer().FindPath(ctx, from, to)
+	path := s.deps.Tracer.FindPath(ctx, from, to)
 	if path == nil {
 		return mcp.NewToolResultText(
 			fmt.Sprintf("No path found between %s and %s", from, to)), nil

--- a/tickets/entities/features/FEAT-B9VS.md
+++ b/tickets/entities/features/FEAT-B9VS.md
@@ -1,0 +1,8 @@
+---
+id: FEAT-B9VS
+type: feature
+title: Consumer-side service narrowing at subsystem boundaries
+summary: 'Subsystems (mcp, cli, dataentry, scheduler) take focused per-subsystem Deps structs of domain types instead of depending on the appbuild.Services aggregate. Enforced by arch-lint: Layer-3 subsystems may not import internal/appbuild.'
+description: Each subsystem declares its own consumer-side Deps (named struct of domain types) in its own package; the entry-point wiring constructs it from the per-project services. appbuild.New stays as a construction helper because the construction order is load-bearing (search observer before store open; lua read deps before entity manager; validator and manager must share the same lua surface), but *appbuild.Services only escapes to Layer-4 wiring. arch-lint forbids internal/{mcp,cli,dataentry,scheduler} from importing internal/appbuild. Plan reviewed and approved via crit (.ignored/service-layering-plan.md).
+status: in-progress
+---

--- a/tickets/entities/review-responses/RR-CN7Q.md
+++ b/tickets/entities/review-responses/RR-CN7Q.md
@@ -1,0 +1,10 @@
+---
+id: RR-CN7Q
+type: review-response
+title: 'Cranky #3: NewServer validated only Principal, not Deps fields'
+finding: 'NewServer checked only the Principal; a Deps with nil Store/Meta/Watcher/etc. or empty ProjectRoot would defer the failure to request time (nil-deref in a handler, or CWD-walk). CLAUDE.md: ''Constructors reject nil required fields.'' Reviewer noted this was equivalent to the prior interface-nil behavior (not a regression) but the natural place to fix now that fields are enumerable on a struct.'
+severity: minor
+resolution: 'Added Deps.validate() (required: Store, Meta, Tracer, Searcher, Validator, EntityManager, Config, Watcher, ProjectRoot; LuaCache optional). NewServer calls it after the Principal check. Covered by TestNewServer_RejectsIncompleteDeps in internal/mcp/principal_test.go.'
+reason: 'Added Deps.validate() (required: Store, Meta, Tracer, Searcher, Validator, EntityManager, Config, Watcher, ProjectRoot; LuaCache intentionally optional since nil is a valid ''no cache'' signal). NewServer calls it after the Principal gate. Covered by TestNewServer_RejectsIncompleteDeps.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CP51.md
+++ b/tickets/entities/review-responses/RR-CP51.md
@@ -1,0 +1,9 @@
+---
+id: RR-CP51
+type: review-response
+title: 'Cranky #4: arch-lint does not scan _test.go files'
+finding: .go-arch-lint.yml excludeFiles skips _test.go, so the mcp->appbuild (and mcp->project) boundary is only enforced for non-test code. A future test stub could re-import internal/project and arch-lint would stay green. Confirmed zero such imports at HEAD; the guarantee is currently held by manual grep, not the linter.
+severity: minor
+reason: Real but pre-existing and broader than this slice (affects every component boundary, not just mcp). The grep-based lint-test pattern (cf. dataentry/lint_test.go) is the right fix; tracked as a follow-up rather than bolted onto slice 1.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-LH5W.md
+++ b/tickets/entities/review-responses/RR-LH5W.md
@@ -1,0 +1,9 @@
+---
+id: RR-LH5W
+type: review-response
+title: 'Cranky #1: dead nil-guard on s.paths in Deps()'
+finding: 'mcp_wiring.go Deps(): the `if s.paths != nil` guard cannot trigger — project.Discover never returns (nil, nil), so paths is always non-nil by the time any *mcpServices exists. Cargo-culted from the identical guard in luaReadDeps.'
+severity: nit
+reason: Left as-is for consistency with the sibling luaReadDeps guard; removing one of a matched pair adds asymmetry for a nit. Both guards dissolve when the composition-root unification follow-up collapses cli/mcp_wiring.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-N0G4.md
+++ b/tickets/entities/review-responses/RR-N0G4.md
@@ -1,0 +1,10 @@
+---
+id: RR-N0G4
+type: review-response
+title: 'Cranky #2: empty ProjectRoot makes lua_list silently walk CWD'
+finding: 'tools_lua.go handleLuaList: with an empty ProjectRoot, filepath.Join("", "scripts") yields the relative path "scripts" and WalkDir then walks $CWD/scripts, silently listing the wrong directory (errors swallowed via SkipDir). Silent-wrong-answer class. Unreachable in production wiring (ProjectRoot always populated) but a landmine for hand-built Deps{} literals.'
+severity: minor
+resolution: Added Deps.validate() in internal/mcp/server.go, called from NewServer after the Principal gate; it rejects an empty ProjectRoot (and every nil collaborator). The silent-CWD-walk path in handleLuaList is now unreachable through construction. Covered by TestNewServer_RejectsIncompleteDeps (9 subtests).
+reason: 'Fixed at the root: NewServer now calls Deps.validate() which rejects an empty ProjectRoot (plus every nil collaborator) at construction. The silent-CWD-walk path is unreachable through construction. Added TestNewServer_RejectsIncompleteDeps covering all 9 required fields.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-7I3P.md
+++ b/tickets/entities/tickets/TKT-7I3P.md
@@ -1,0 +1,32 @@
+---
+id: TKT-7I3P
+type: ticket
+title: 'Slice 1: mcp.Deps replaces mcp.Services interface'
+kind: refactor
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+Slice 1 of the service-layering plan (`.ignored/service-layering-plan.md`,
+crit-approved).
+
+Replaces the `mcp.Services` interface (11 producer-shaped accessor methods) with
+a `mcp.Deps` struct of domain types. The MCP `Server` holds a `Deps` value built
+by the cli wiring site; it has no reference to any composition-root aggregate.
+
+## Changes
+
+- `internal/mcp/server.go`: `Services` interface → `Deps` struct; `Server.ws` → `Server.deps`; `NewServer(Deps, ...)`.
+- All `s.ws.X()` accessor calls → `s.deps.X` field reads across the mcp tool/resource/prompt files.
+- `Paths() *project.Context` narrowed to `ProjectRoot string` — the only piece mcp consumed. Eliminates the `internal/project` import from mcp's non-test code and from its test stubs.
+- `internal/cli/mcp_wiring.go`: `mcpServices` keeps lifecycle (Close) but exposes `Deps() mcp.Deps` instead of satisfying `mcp.Services`.
+- Test stubs become struct literals: `newTestServices` (+ the `testServices` adapter type) replaced by `newTestDeps` returning a `mcp.Deps`.
+- `.go-arch-lint.yml`: removed stale `project` from mcp's `mayDependOn`; documented that appbuild is deliberately absent (whitelist model).
+
+## Verification
+
+- `just build` (default + `-tags memorybackend`), `just test`, `just lint`, `just arch-lint` all clean.
+- `internal/mcp` imports neither `internal/appbuild` nor `internal/project`.

--- a/tickets/relations/FEAT-B9VS--requires--mcp-api.md
+++ b/tickets/relations/FEAT-B9VS--requires--mcp-api.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-B9VS
+relation: requires
+to: mcp-api
+---

--- a/tickets/relations/TKT-7I3P--affects--mcp-api.md
+++ b/tickets/relations/TKT-7I3P--affects--mcp-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I3P
+relation: affects
+to: mcp-api
+---

--- a/tickets/relations/TKT-7I3P--has-review-response--RR-CN7Q.md
+++ b/tickets/relations/TKT-7I3P--has-review-response--RR-CN7Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I3P
+relation: has-review-response
+to: RR-CN7Q
+---

--- a/tickets/relations/TKT-7I3P--has-review-response--RR-CP51.md
+++ b/tickets/relations/TKT-7I3P--has-review-response--RR-CP51.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I3P
+relation: has-review-response
+to: RR-CP51
+---

--- a/tickets/relations/TKT-7I3P--has-review-response--RR-LH5W.md
+++ b/tickets/relations/TKT-7I3P--has-review-response--RR-LH5W.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I3P
+relation: has-review-response
+to: RR-LH5W
+---

--- a/tickets/relations/TKT-7I3P--has-review-response--RR-N0G4.md
+++ b/tickets/relations/TKT-7I3P--has-review-response--RR-N0G4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I3P
+relation: has-review-response
+to: RR-N0G4
+---

--- a/tickets/relations/TKT-7I3P--implements--FEAT-B9VS.md
+++ b/tickets/relations/TKT-7I3P--implements--FEAT-B9VS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I3P
+relation: implements
+to: FEAT-B9VS
+---


### PR DESCRIPTION
## Summary

Slice 1 of the service-layering refactor (FEAT-B9VS, plan crit-approved at `.ignored/service-layering-plan.md`). Replaces the producer-shaped `mcp.Services` interface (11 accessor methods) with a focused `mcp.Deps` struct of domain types. `internal/mcp` no longer imports `internal/appbuild` or `internal/project`.

- **`mcp.Services` interface → `mcp.Deps` struct.** `Server.ws` → `Server.deps`; `NewServer(Deps, ...)`. ~60 `s.ws.X()` accessor calls became `s.deps.X` field reads across 11 tool/resource/prompt files.
- **`Paths() *project.Context` narrowed to `ProjectRoot string`** — the only piece mcp consumed. Removes the `internal/project` import from mcp entirely.
- **`cli/mcp_wiring.go`:** `mcpServices` keeps lifecycle (Close) but exposes `Deps() mcp.Deps` instead of satisfying a producer interface.
- **Test stubs collapsed:** the `testServices` adapter type + its 11 methods deleted; `newTestDeps` returns a `Deps` literal.
- **arch-lint:** removed stale `project` from mcp's `mayDependOn`; documented that appbuild is deliberately absent (whitelist model).
- **Review fix (e5a8345):** added `Deps.validate()` — `NewServer` rejects any incomplete `Deps` (9 required collaborators + non-empty `ProjectRoot`; `LuaCache` optional) at construction, per CLAUDE.md "constructors reject nil required fields." Makes the empty-`ProjectRoot` silent-CWD-walk path unreachable.

## Why

The `mcp.Services` interface coupled mcp to a producer-side contract. Per CLAUDE.md ("define interfaces at the call site, not next to the implementation"), each subsystem should declare its own focused consumer-side deps. This is the first of several slices; later ones cover cli, dataentry, scheduler.

## Reviews

- **cranky-code-reviewer:** no critical/significant findings; 4 minor/nit (2 addressed via the validation fix, 2 deferred/wont-fix with rationale — see RR-N0G4, RR-CN7Q, RR-LH5W, RR-CP51).
- **crit (human):** approved, zero comments.

## Test plan

- [x] `just ci` clean (build default + `-tags memorybackend`, test, lint, arch-lint, docs)
- [x] `internal/mcp` imports neither `internal/appbuild` nor `internal/project`
- [x] `TestNewServer_RejectsIncompleteDeps` covers all 9 required fields
- [x] mcp coverage 48.2% → 55.7%