### PR TITLE
feat(affordances): policy-backed _fields / _relations resolver (TKT-9E57)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -79,6 +79,7 @@ components:
 
   # Infrastructure
   acl:              { in: internal/acl }
+  affordances:      { in: internal/affordances }
   ai:               { in: internal/ai }
   audit:            { in: internal/audit }
   principal:        { in: internal/principal }
@@ -222,6 +223,7 @@ deps:
   dataentry:
     mayDependOn:
       - acl
+      - affordances
       - audit
       - config
       - conflict
@@ -368,6 +370,13 @@ deps:
       - store
   acl:
     mayDependOn:
+      - principal
+  affordances:
+    mayDependOn:
+      - acl
+      - entity
+      - metamodel
+      - predicate
       - principal
   audit:
     mayDependOn:

--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -113,14 +113,20 @@ func (d *Desktop) OpenRecentProject(path string) string {
 	return errMsg
 }
 
+// failLoad records err as the current load error and returns its
+// string form, so LoadProject's error branches stay one line each.
+func (d *Desktop) failLoad(err error) string {
+	d.mu.Lock()
+	d.loadErr = err.Error()
+	d.mu.Unlock()
+	return err.Error()
+}
+
 // LoadProject loads a rela project from the given directory.
 func (d *Desktop) LoadProject(dir string) string {
 	fs, projCtx, err := discoverProject(dir)
 	if err != nil {
-		d.mu.Lock()
-		d.loadErr = err.Error()
-		d.mu.Unlock()
-		return err.Error()
+		return d.failLoad(err)
 	}
 
 	// Check if data-entry.yaml exists
@@ -151,17 +157,19 @@ func (d *Desktop) LoadProject(dir string) string {
 		return svcErr.Error()
 	}
 
+	fieldResolver, err := dataentry.ResolverFromServices(svc)
+	if err != nil {
+		return d.failLoad(err)
+	}
+
 	app, err := dataentry.NewApp(
 		fs, projCtx, svc.Meta(), svc.Store(),
 		svc.EntityManager(), svc.Searcher(), svc.ACL(),
-		dataentry.ResolverFromProfile(os.Getenv("RELA_AFFORDANCE_PROFILE")),
+		fieldResolver,
 		svc.Audit(),
 	)
 	if err != nil {
-		d.mu.Lock()
-		d.loadErr = err.Error()
-		d.mu.Unlock()
-		return err.Error()
+		return d.failLoad(err)
 	}
 	d.mu.Lock()
 	// Stop previous scheduler and close previous services in

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -113,10 +113,12 @@ func main() {
 	// Close() *is* required in long-running hosts that switch
 	// projects (see rela-desktop); this is the daemon-lifetime case.
 
+	fieldResolver := buildFieldResolver(svc)
+
 	app, err := dataentry.NewApp(
 		svc.FS(), svc.Paths(), svc.Meta(), svc.Store(),
 		svc.EntityManager(), svc.Searcher(), svc.ACL(),
-		dataentry.ResolverFromProfile(os.Getenv("RELA_AFFORDANCE_PROFILE")),
+		fieldResolver,
 		svc.Audit(),
 	)
 	if err != nil {
@@ -239,6 +241,18 @@ func newHTTPServer(addr string, handler http.Handler) *http.Server {
 		WriteTimeout: 0,
 		IdleTimeout:  120 * time.Second,
 	}
+}
+
+// buildFieldResolver constructs the data-entry affordance resolver
+// from the active services. A predicate compile error in acl.yaml is
+// fatal — surfaced loudly rather than silently disabling a gate.
+func buildFieldResolver(svc *appbuild.Services) dataentry.FieldVerdictResolver {
+	resolver, err := dataentry.ResolverFromServices(svc)
+	if err != nil {
+		slog.Error("failed to build affordance resolver", "error", err)
+		os.Exit(1)
+	}
+	return resolver
 }
 
 // shouldWarnNoACL reports whether the operator should be told they

--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -393,19 +393,22 @@ x buttons. Writes that contradict a verdict return 403.
 
 ### Verdict source
 
-In v1, verdicts come from a hardcoded stub selected by the
-`RELA_AFFORDANCE_PROFILE` env var (read once at server startup; tests pass
-the resolver directly):
+Verdicts come from one of three sources, selected at server startup by the
+`RELA_AFFORDANCE_PROFILE` env var (tests pass the resolver directly):
 
 | Value | Behavior |
 |---|---|
-| unset / `none` | Permissive default — every field writable, every option allowed, every relation creatable/removable. Both wire maps emit as `{}`. |
-| `demo` | Hardcoded fixture against the `ticket` entity type — exercises every affordance code path so the SPA work has an observable end-to-end behavior. |
-| any other | Unknown — logs a warning and falls back to `none`. Never panics. |
+| unset / empty | **Policy-backed** when `acl.yaml` declares any affordance block (`fields:` / `visible:` / `options:` / `relations:`); otherwise permissive (both wire maps emit as `{}`). |
+| `none` | Permissive — explicit opt-out even when a policy has affordance blocks. |
+| `demo` | Hardcoded fixture against the `ticket` entity type — exercises every affordance code path for manual UI testing. Overrides the policy. |
+| any other | Unknown — logs a warning and falls back to policy / permissive. Never panics. |
 
-The eventual predicate-engine ticket replaces the stub with an `acl.yaml`-
-driven implementation via the same `FieldVerdictResolver` Go interface; the
-wire shape and SPA rendering stay unchanged.
+The policy-backed resolver compiles `when:` predicates from `acl.yaml` at
+startup and evaluates them per entity. See the [security model
+affordances section](../security.md#field--and-relation-level-affordances)
+for the `acl.yaml` schema, the predicate language, and the closed-world /
+cross-role semantics. The wire shape and SPA rendering below are identical
+regardless of source.
 
 ### Wire shape
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -199,7 +199,7 @@ roles:
     write: [review-response]
     read: ["*"]
 
-  default:                  # applied to every principal not in `assignments`
+  everyone:                 # built-in role held implicitly by every principal
     read: ["*"]
     # no `write` → unassigned principals can read but not write
 
@@ -219,9 +219,10 @@ role_relations:
 - **Union + explicit-deny.** A write is allowed if **any** role in
   the principal's effective set grants it. The first matching role
   is named in the deny/allow rule for debuggability.
-- **Default role applies to everyone.** The `default` role is
-  appended to every principal's effective set. Omit it to make
-  unassigned principals capability-free.
+- **The `everyone` role applies to everyone.** This one built-in
+  role name is appended to every principal's effective set (whether or
+  not they appear in `assignments`). Omit it to make unassigned
+  principals capability-free.
 - **Empty `acl.yaml` denies everything.** A file with no roles or
   assignments produces an empty effective set for every principal —
   every write returns 403. Operators who want allow-all should
@@ -250,7 +251,7 @@ themselves admin by writing their own role-binding relation.
 
 `acl.yaml` is only meaningful when combined with a trusted source of
 `principal.user`. Without it, every request claims to be `unknown`
-and the default role is the entire access surface. To get
+and the `everyone` role is the entire access surface. To get
 meaningful user attribution:
 
 - Run behind a reverse proxy that **strips** the configured header
@@ -280,8 +281,16 @@ gaps independently.
   the [API reference action-affordances
   section](./data-entry/api-reference.md#how-the-spa-consumes-_actions)
   for the consumer contract.
-- ❌ Read filtering, property redaction — deferred to v1.
+- ✅ Field-, option-, and relation-level affordances driven by
+  per-role `fields:` / `visible:` / `options:` / `relations:` grants
+  with optional `when:` predicates. See [Field- and relation-level
+  affordances](#field--and-relation-level-affordances).
+- ❌ Read filtering, property redaction — deferred to v1. (Field
+  *visibility* via `visible:` omits a property from the write-form
+  response, but list-query reads are not filtered.)
 - ❌ Group expansion (`member-of` transitive) — deferred to v1.
+- ❌ Inherited local roles (containment) — deferred to v1; direct
+  local roles are honored.
 - ❌ MCP transport intersection (filtering the tool list per principal) — deferred to a follow-up.
 - ❌ Containment inheritance — deferred to v2.
 
@@ -293,6 +302,141 @@ gaps independently.
 > invariant is HTTP write endpoints reached by the SPA; MCP / Lua /
 > scheduler write paths share the same enforcement but do not emit
 > or consult `_actions`.
+
+### Field- and relation-level affordances
+
+Beyond the per-resource `_actions` verb map, a role can grant
+**field-, option-, and relation-level** affordances. These drive the
+`_fields` and `_relations` maps the data-entry server emits on
+per-entity GET (see the [API reference affordances
+section](./data-entry/api-reference.md#affordances-_fields-and-_relations)),
+and they gate the corresponding writes server-side.
+
+Each grant may carry a `when:` predicate — a single expression in the
+[predicate language](#affordance-predicates) — evaluated against the
+entity and the requesting principal. An absent `when:` grants
+unconditionally.
+
+```yaml
+roles:
+  triager:
+    write: [ticket]            # per-type write grant (as before)
+
+    # Per-field write grants. A role that declares `fields:` for a
+    # type is closed-world for that type: only listed fields are
+    # writable; everything else renders read-only.
+    fields:
+      ticket:
+        - field: status
+          when: "entity.assignee == current_user.id"
+        - field: description    # unconditional
+
+    # Per-field visibility. Same closed-world rule; a field denied
+    # here is OMITTED from the response entirely (not just read-only).
+    visible:
+      ticket:
+        - field: internal_notes
+          when: "has_global_role(current_user, 'admin')"
+
+    # Per-enum-option grants. Closed-world per field: only listed
+    # options are selectable; others are filtered out and rejected
+    # on write.
+    options:
+      ticket:
+        - field: status
+          option: open
+        - field: status
+          option: review
+
+    # Per-relation-type grants. create/remove default to true when the
+    # grant exists; set them false to deny. `fields:` grants per-meta-
+    # field writability on links of that type.
+    relations:
+      ticket:
+        - relation: implements
+          create: true
+          remove: false
+          when: "entity.status == 'ready'"
+        - relation: has-planning
+          fields:
+            - field: note
+```
+
+**Opt-in is per type, by key presence.** A role that does *not*
+declare a block (e.g. no `fields:` key for `ticket`) leaves that
+dimension fully permissive for the type. A role that declares the key
+— even as an empty list (`fields: {ticket: []}`) or null
+(`fields: {ticket:}`) — makes it closed-world: anything not granted is
+denied. This mirrors how `write:` already works.
+
+**Cross-role union, monotonic.** When a principal holds several roles,
+a field/option/relation is allowed if *any* role grants it under a
+passing predicate. Adding a role can only widen access, never narrow
+it.
+
+**Effective roles are entity-scoped.** The role set for a given
+`(principal, entity)` is the principal's global roles (from
+`assignments` plus the built-in `everyone`) unioned with **local
+roles** conferred
+on that entity by a `role_relations` edge from the principal (e.g.
+`alice --owner-of--> TKT-001` confers `owner` on `TKT-001` only).
+Grant blocks keyed on a local role therefore apply only to the
+entities where the principal holds that role. v1 resolves *direct*
+local roles only; inherited local roles (containment) are deferred.
+
+#### Affordance predicates
+
+Predicates are compiled at server startup. A compile error — a syntax
+error, an unknown variable, a type mismatch, or a reference to a
+property the metamodel doesn't declare — **aborts startup** with the
+offending grant path in the error. This is stricter than a malformed
+`acl.yaml` (which downgrades to allow-all): a broken predicate is an
+operator typo with a deterministic fix, so it surfaces loudly rather
+than silently disabling a gate.
+
+Available in a predicate:
+
+| Symbol | Meaning |
+|--------|---------|
+| `entity.<property>` | The evaluated entity's property value. Missing or off-type values bind as `nil`. |
+| `entity.id`, `entity.type` | The entity's identity. |
+| `current_user.id`, `current_user.type` | The requesting principal. |
+| `has_role(current_user, entity, 'name')` | Holds `name` scoped to this entity (global ∪ local roles). |
+| `has_global_role(current_user, 'name')` | Holds `name` as a global (assignment) role; ignores local roles. |
+| `has_relation(entity, 'type')` | Entity has an outgoing relation of `type`. |
+| `count_relations(entity, 'type')` | Count of outgoing relations of `type`. |
+| `string_in_list(value, entity.<listprop>)` | `value` is an element of a list-typed property. The list argument must be a list-typed property — inline list literals are not supported. |
+
+Combine conditions with `and` / `or` / `not` inside the expression.
+
+> - **Predicates evaluate server-side against the full entity**,
+>   including properties that will be visibility-stripped from the
+>   response. A predicate may key a visible field's verdict on a hidden
+>   property; that is intentional.
+> - **Predicate failures fail closed.** A runtime error in a `when:`
+>   predicate (e.g. a host-function error) denies the grant rather than
+>   allowing it, and logs a warning for operator visibility. It never
+>   500s the GET.
+> - **Adding a property referenced by a predicate requires a server
+>   restart.** Predicates compile against the metamodel at startup; a
+>   hot metamodel reload does not recompile them.
+
+#### Selecting the affordance source
+
+The data-entry server picks its affordance source at startup via
+`RELA_AFFORDANCE_PROFILE`:
+
+| `RELA_AFFORDANCE_PROFILE` | Source |
+|---------------------------|--------|
+| unset / empty | Policy-backed if `acl.yaml` declares any affordance block; otherwise permissive (no deviations). |
+| `none` | Permissive — explicit opt-out even when a policy has affordance blocks. |
+| `demo` | A hardcoded dev fixture against the `ticket` type (for manual UI testing); overrides the policy. |
+
+Like `_actions`, `_fields` / `_relations` are **UI hints** — the
+server re-authorizes every write. The role and predicate that produced
+a deny are recorded in the audit log's `Summary` (not the wire 403
+body), so operators can attribute a denial without exposing policy
+internals to clients.
 
 ## Running the Vue dev server (Vite)
 

--- a/internal/acl/declarative.go
+++ b/internal/acl/declarative.go
@@ -108,7 +108,7 @@ func (d *Declarative) AuthorizeWrite(ctx context.Context, req WriteRequest) Deci
 // `Assignments[user]` names an undefined role, it is dropped (a
 // load-time warning will have been emitted in v1; v0 silently
 // ignores — operators discover the typo via `analyze_*` style
-// follow-up tickets). `default` is always appended last if defined.
+// follow-up tickets). [EveryoneRole] is always appended last if defined.
 func (d *Declarative) effectiveRoles(p principal.Principal) []string {
 	var out []string
 	if name, ok := d.policy.Assignments[p.User]; ok {
@@ -116,11 +116,11 @@ func (d *Declarative) effectiveRoles(p principal.Principal) []string {
 			out = append(out, name)
 		}
 	}
-	if _, ok := d.policy.Roles["default"]; ok {
-		// Only append default if it isn't already the principal's
-		// explicit role (defensive against `assignments: {alice: default}`).
-		if !slices.Contains(out, "default") {
-			out = append(out, "default")
+	if _, ok := d.policy.Roles[EveryoneRole]; ok {
+		// Only append it if it isn't already the principal's explicit
+		// role (defensive against `assignments: {alice: everyone}`).
+		if !slices.Contains(out, EveryoneRole) {
+			out = append(out, EveryoneRole)
 		}
 	}
 	return out

--- a/internal/acl/declarative_test.go
+++ b/internal/acl/declarative_test.go
@@ -11,7 +11,8 @@ import (
 
 // testPolicy is the fixture used across declarative tests. Mirrors the
 // example operators see in docs/security.md (PR 3): three real roles +
-// a default, with one role-relation gated by a delegate permission.
+// the built-in everyone role, with one role-relation gated by a
+// delegate permission.
 func testPolicy() *acl.Policy {
 	return &acl.Policy{
 		UserEntityType: "person",
@@ -30,7 +31,7 @@ func testPolicy() *acl.Policy {
 				Write: []string{"review-response"},
 				Read:  []string{"*"},
 			},
-			"default": {
+			acl.EveryoneRole: {
 				Read: []string{"*"},
 			},
 		},
@@ -165,14 +166,14 @@ func TestAuthorizeWrite_RoleRelation_NoDelegateRequired_Allows(t *testing.T) {
 	}
 }
 
-// AC2.6: a principal with no Assignments entry inherits the `default`
+// AC2.6: a principal with no Assignments entry inherits the `everyone`
 // role's capabilities.
 func TestAuthorizeWrite_UnknownPrincipal_GetsDefaultRole(t *testing.T) {
 	d := acl.NewDeclarative(testPolicy())
 
-	// `default` has no write entries — every write is denied, but the
-	// deny RuleKind is role-grant (not "no roles at all"), proving
-	// default was consulted.
+	// `everyone` has no write entries — every write is denied, but the
+	// deny RuleKind is role-grant (not "no roles at all"), proving the
+	// everyone role was consulted.
 	got := d.AuthorizeWrite(ctxAs("carol"), acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket"})
 	if got.Allow {
 		t.Fatalf("Allow = true, want false (default has no writes). Decision = %+v", got)
@@ -182,11 +183,11 @@ func TestAuthorizeWrite_UnknownPrincipal_GetsDefaultRole(t *testing.T) {
 	}
 }
 
-// AC2.6 + AC2.7: when `default` grants writes, an unknown principal
-// gets them via the default role. RuleID surfaces "default".
+// AC2.6 + AC2.7: when the everyone role grants writes, an unknown
+// principal gets them via it. RuleID surfaces "everyone".
 func TestAuthorizeWrite_DefaultRoleGrantsWrites(t *testing.T) {
 	policy := testPolicy()
-	policy.Roles["default"] = acl.RoleDef{
+	policy.Roles[acl.EveryoneRole] = acl.RoleDef{
 		Write: []string{"comment"},
 		Read:  []string{"*"},
 	}
@@ -196,32 +197,32 @@ func TestAuthorizeWrite_DefaultRoleGrantsWrites(t *testing.T) {
 	if !got.Allow {
 		t.Fatalf("Allow = false, want true. Decision = %+v", got)
 	}
-	if got.RuleID != "default" {
-		t.Errorf("RuleID = %q, want %q", got.RuleID, "default")
+	if got.RuleID != acl.EveryoneRole {
+		t.Errorf("RuleID = %q, want %q", got.RuleID, acl.EveryoneRole)
 	}
 }
 
-// AC2.7: a principal with explicit role X *plus* the default role
+// AC2.7: a principal with explicit role X *plus* the everyone role
 // gets the union of writes. The explicit role takes priority for
 // RuleID when it covers the type.
 func TestAuthorizeWrite_MultipleRoles_Unions(t *testing.T) {
 	policy := testPolicy()
-	// Make default also grant writes on a type the explicit role
+	// Make everyone also grant writes on a type the explicit role
 	// doesn't cover, so we can prove the union.
-	policy.Roles["default"] = acl.RoleDef{
+	policy.Roles[acl.EveryoneRole] = acl.RoleDef{
 		Write: []string{"comment"},
 		Read:  []string{"*"},
 	}
 	d := acl.NewDeclarative(policy)
 
-	// bob is reviewer (writes review-response). With default also
+	// bob is reviewer (writes review-response). With everyone also
 	// granting "comment", bob should be able to write both.
 	for _, tc := range []struct {
 		etype  string
 		wantID string
 	}{
 		{"review-response", "reviewer"}, // explicit role wins
-		{"comment", "default"},          // only default covers this
+		{"comment", acl.EveryoneRole},   // only everyone covers this
 	} {
 		got := d.AuthorizeWrite(ctxAs("bob"), acl.WriteRequest{Op: acl.OpCreate, EntityType: tc.etype})
 		if !got.Allow {
@@ -241,7 +242,7 @@ func TestAuthorizeWrite_AssignmentToUndefinedRole_DropsToDefault(t *testing.T) {
 	policy.Assignments["typo"] = "contribtuor" // misspelled role name
 	d := acl.NewDeclarative(policy)
 
-	// "default" has no writes → deny on ticket. If the bad
+	// the everyone role has no writes → deny on ticket. If the bad
 	// assignment leaked through, RuleID would be "contribtuor" (or
 	// the eval would Allow if we resolved the typo).
 	got := d.AuthorizeWrite(ctxAs("typo"), acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket"})

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -8,6 +8,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// EveryoneRole is the one built-in role name. A role declared under
+// this name in `acl.yaml` is held implicitly by every principal,
+// authenticated or not — it is how an operator expresses "applies to
+// everyone" without enumerating users. It is appended to every
+// principal's effective role set (see [Declarative.effectiveRoles]
+// and the affordances resolver), and is the single source of truth
+// for the name so the two paths can't drift.
+//
+// (No `anonymous` / `authenticated` built-ins yet: rela-server has no
+// authentication layer — see docs/security.md. Those would be added
+// here when auth lands, so both write and affordance paths see them.)
+const EveryoneRole = "everyone"
+
 // Policy is the declarative ACL configuration parsed from `acl.yaml`
 // at the project root. v0 fields:
 //
@@ -16,8 +29,9 @@ import (
 //     reserved for v1 group expansion when [Policy.RoleRelations]
 //     binds principals to entities.
 //   - [Policy.Roles] declares the named capability bundles. The
-//     special role name `default` is appended to every principal's
-//     effective role set; see [Declarative.effectiveRoles].
+//     built-in role name [EveryoneRole] ("everyone") is appended to
+//     every principal's effective role set; see
+//     [Declarative.effectiveRoles].
 //   - [Policy.Assignments] maps `principal.User` → role name.
 //     Unknown role names (assigned but not declared in Roles) log a
 //     warning at load and are dropped from the effective set.
@@ -44,10 +58,78 @@ type Policy struct {
 // Wildcard write: a single entry `"*"` grants write on every entity
 // type. Mixing `"*"` with explicit types is allowed but redundant —
 // the wildcard short-circuits the per-type check.
+//
+// Affordance grants (Fields / Visible / Options / Relations) drive
+// the data-entry _fields / _relations wire shape via the
+// affordances resolver. Each is keyed by entity type and is
+// opt-in per type: a type that appears as a key is closed-world for
+// that affordance dimension (only listed fields/options/relations
+// are granted); a type absent from the map defaults permissive.
+// A present-but-empty list (`fields: {ticket: []}`) is closed-world
+// deny-all for that type, distinct from an absent or null value.
 type RoleDef struct {
 	Write       []string `yaml:"write"`
 	Read        []string `yaml:"read"`
 	Permissions []string `yaml:"permissions"`
+
+	Fields    map[string][]FieldGrant    `yaml:"fields"`
+	Visible   map[string][]FieldGrant    `yaml:"visible"`
+	Options   map[string][]OptionGrant   `yaml:"options"`
+	Relations map[string][]RelationGrant `yaml:"relations"`
+}
+
+// FieldGrant grants a per-field affordance (write under `fields:`,
+// visibility under `visible:`) on the entity type it is keyed under.
+// When set conditions the grant on a predicate evaluated against the
+// entity; an empty When grants unconditionally. The same shape backs
+// relation-meta-field grants (RelationGrant.Fields).
+type FieldGrant struct {
+	Field string `yaml:"field"`
+	When  string `yaml:"when,omitempty"`
+}
+
+// OptionGrant grants a single enum option on a field. Used to filter
+// the option set the SPA renders and to gate writes that set the
+// field to that option.
+type OptionGrant struct {
+	Field  string `yaml:"field"`
+	Option string `yaml:"option"`
+	When   string `yaml:"when,omitempty"`
+}
+
+// RelationGrant grants relation-level affordances for one relation
+// type on the keyed entity type. Create and Remove are pointers so
+// "unset" (use the grant's implied default of true — the grant
+// existing is itself the opt-in) is distinguishable from an explicit
+// false. Fields grants per-meta-field writability on links of this
+// type. When conditions the whole grant on a predicate.
+type RelationGrant struct {
+	Relation string       `yaml:"relation"`
+	Create   *bool        `yaml:"create,omitempty"`
+	Remove   *bool        `yaml:"remove,omitempty"`
+	Fields   []FieldGrant `yaml:"fields,omitempty"`
+	When     string       `yaml:"when,omitempty"`
+}
+
+// HasAffordanceGrants reports whether any role in the policy declares
+// at least one of the affordance grant blocks (fields / visible /
+// options / relations). The resolver-selection logic in the entry
+// points uses this to decide between the policy-backed resolver and
+// the permissive default: a policy that only carries write/read
+// grants has no affordances to compute, so it falls through to the
+// Nop resolver and the wire stays byte-identical to no-policy.
+func (p *Policy) HasAffordanceGrants() bool {
+	for _, role := range p.Roles {
+		if roleHasAffordanceGrants(role) {
+			return true
+		}
+	}
+	return false
+}
+
+func roleHasAffordanceGrants(role RoleDef) bool {
+	return len(role.Fields) > 0 || len(role.Visible) > 0 ||
+		len(role.Options) > 0 || len(role.Relations) > 0
 }
 
 // RoleRelationDef declares that a graph relation type confers a role

--- a/internal/acl/policy_test.go
+++ b/internal/acl/policy_test.go
@@ -43,7 +43,7 @@ roles:
   reviewer:
     write: [review-response]
     read: ["*"]
-  default:
+  everyone:
     read: ["*"]
 assignments:
   jeroen: admin
@@ -141,6 +141,197 @@ func TestLoadPolicy_MalformedYAML_ReturnsParseError(t *testing.T) {
 	}
 	if !contains(err.Error(), "parse") {
 		t.Errorf("err = %v, want substring 'parse'", err)
+	}
+}
+
+// Affordance grants round-trip into the typed shape the resolver
+// consumes: per-field write/visibility, per-option, per-relation
+// with create/remove pointers and meta-field grants.
+func TestLoadPolicy_AffordanceGrants(t *testing.T) {
+	const yaml = `
+roles:
+  triager:
+    write: [ticket]
+    fields:
+      ticket:
+        - field: status
+          when: "entity.assignee == current_user.id"
+        - field: description
+    visible:
+      ticket:
+        - field: internal_notes
+          when: "has_global_role(current_user, 'admin')"
+    options:
+      ticket:
+        - field: status
+          option: done
+          when: "has_role(current_user, entity, 'closer')"
+    relations:
+      ticket:
+        - relation: implements
+          create: true
+          remove: false
+          when: "entity.status == 'ready'"
+        - relation: has-planning
+          fields:
+            - field: note
+`
+	path := writeTempPolicy(t, yaml)
+	p, err := acl.LoadPolicy(path)
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	role := p.Roles["triager"]
+
+	fields := role.Fields["ticket"]
+	if len(fields) != 2 {
+		t.Fatalf("fields[ticket] len = %d, want 2", len(fields))
+	}
+	if fields[0].Field != "status" || fields[0].When != "entity.assignee == current_user.id" {
+		t.Errorf("fields[0] = %+v", fields[0])
+	}
+	if fields[1].Field != "description" || fields[1].When != "" {
+		t.Errorf("fields[1] = %+v, want unconditional description", fields[1])
+	}
+
+	vis := role.Visible["ticket"]
+	if len(vis) != 1 || vis[0].Field != "internal_notes" {
+		t.Errorf("visible[ticket] = %+v", vis)
+	}
+
+	opts := role.Options["ticket"]
+	if len(opts) != 1 || opts[0].Field != "status" || opts[0].Option != "done" {
+		t.Errorf("options[ticket] = %+v", opts)
+	}
+
+	rels := role.Relations["ticket"]
+	if len(rels) != 2 {
+		t.Fatalf("relations[ticket] len = %d, want 2", len(rels))
+	}
+	if rels[0].Relation != "implements" {
+		t.Errorf("relations[0].Relation = %q", rels[0].Relation)
+	}
+	if rels[0].Create == nil || !*rels[0].Create {
+		t.Errorf("relations[0].Create = %v, want *true", rels[0].Create)
+	}
+	if rels[0].Remove == nil || *rels[0].Remove {
+		t.Errorf("relations[0].Remove = %v, want *false", rels[0].Remove)
+	}
+	if rels[1].Relation != "has-planning" || rels[1].Create != nil || rels[1].Remove != nil {
+		t.Errorf("relations[1] = %+v, want has-planning with nil Create/Remove", rels[1])
+	}
+	if len(rels[1].Fields) != 1 || rels[1].Fields[0].Field != "note" {
+		t.Errorf("relations[1].Fields = %+v", rels[1].Fields)
+	}
+
+	if !p.HasAffordanceGrants() {
+		t.Error("HasAffordanceGrants() = false, want true")
+	}
+}
+
+// A policy carrying only write/read grants has no affordance blocks,
+// so HasAffordanceGrants reports false and the entry point falls
+// through to the permissive Nop resolver.
+func TestPolicy_HasAffordanceGrants_NoneWhenWriteOnly(t *testing.T) {
+	const yaml = `
+roles:
+  admin:
+    write: ["*"]
+    read: ["*"]
+`
+	p, err := acl.LoadPolicy(writeTempPolicy(t, yaml))
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	if p.HasAffordanceGrants() {
+		t.Error("HasAffordanceGrants() = true, want false for write-only policy")
+	}
+}
+
+// The per-type affordance block's opt-in signal is the PRESENCE of
+// the type key in the map, regardless of whether its value is an
+// explicit empty list or a null. yaml.v3 decodes both `ticket: []`
+// and `ticket:` (null) as a present key (nil slice for null), while
+// an absent block leaves the key out of the map entirely. The
+// resolver treats any present key as opt-in (closed-world deny-all
+// when zero grants); only an absent key is permissive.
+//
+// We pin this here because the opt-in semantics hang on it (DR-C4):
+// distinguishing nil-vs-empty-slice would be too subtle a hook for
+// a security decision, so present-either-way = opt-in is the
+// contract.
+func TestLoadPolicy_AffordanceGrants_OptInIsKeyPresence(t *testing.T) {
+	tests := []struct {
+		name        string
+		fieldsBlock string
+		wantPresent bool
+	}{
+		{
+			name:        "explicit empty list is opt-in",
+			fieldsBlock: "    fields:\n      ticket: []\n",
+			wantPresent: true,
+		},
+		{
+			name:        "null value is opt-in (present key, nil slice)",
+			fieldsBlock: "    fields:\n      ticket:\n",
+			wantPresent: true,
+		},
+		{
+			name:        "absent block is not opt-in",
+			fieldsBlock: "",
+			wantPresent: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			yaml := "roles:\n  triager:\n    write: [ticket]\n" + tc.fieldsBlock
+			p, err := acl.LoadPolicy(writeTempPolicy(t, yaml))
+			if err != nil {
+				t.Fatalf("LoadPolicy: %v", err)
+			}
+			_, present := p.Roles["triager"].Fields["ticket"]
+			if present != tc.wantPresent {
+				t.Fatalf("ticket key present = %v, want %v (fields map = %#v)",
+					present, tc.wantPresent, p.Roles["triager"].Fields)
+			}
+		})
+	}
+}
+
+// Create/Remove *bool must distinguish explicit true, explicit
+// false, and unset across the YAML forms operators actually write.
+func TestLoadPolicy_RelationGrant_CreateRemovePointers(t *testing.T) {
+	tests := []struct {
+		name       string
+		createLine string
+		wantNil    bool
+		wantVal    bool
+	}{
+		{name: "explicit true", createLine: "          create: true\n", wantNil: false, wantVal: true},
+		{name: "explicit false", createLine: "          create: false\n", wantNil: false, wantVal: false},
+		{name: "absent", createLine: "", wantNil: true},
+		{name: "null value", createLine: "          create:\n", wantNil: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			yaml := "roles:\n  triager:\n    relations:\n      ticket:\n" +
+				"        - relation: implements\n" + tc.createLine
+			p, err := acl.LoadPolicy(writeTempPolicy(t, yaml))
+			if err != nil {
+				t.Fatalf("LoadPolicy: %v", err)
+			}
+			rels := p.Roles["triager"].Relations["ticket"]
+			if len(rels) != 1 {
+				t.Fatalf("relations len = %d, want 1", len(rels))
+			}
+			create := rels[0].Create
+			if tc.wantNil != (create == nil) {
+				t.Fatalf("Create nil = %v, want %v", create == nil, tc.wantNil)
+			}
+			if !tc.wantNil && *create != tc.wantVal {
+				t.Errorf("*Create = %v, want %v", *create, tc.wantVal)
+			}
+		})
 	}
 }
 

--- a/internal/affordances/affordances.go
+++ b/internal/affordances/affordances.go
@@ -1,0 +1,65 @@
+// Package affordances builds a policy-driven field/option/relation
+// affordance resolver from an acl.yaml [acl.Policy]. It computes, per
+// entity, which fields are writable/visible, which enum options are
+// allowed, and which relation operations are permitted, returning its
+// own verdict types ([FieldVerdicts], [RelationVerdicts]). The
+// data-entry layer adapts these into its FieldVerdictResolver wire
+// shape — this package does not import internal/dataentry, keeping the
+// dependency edge one-way (dataentry → affordances).
+//
+// Each grant in the policy may carry a `when:` predicate (see
+// internal/predicate). Predicates are compiled once at construction;
+// a compile failure aborts construction with all errors joined. At
+// resolve time the predicate evaluates against the entity, the
+// principal, and a small set of host functions (has_role,
+// has_global_role, has_relation, count_relations, string_in_list).
+//
+// # Opt-in, closed-world per type
+//
+// A grant block (fields / visible / options / relations) is opt-in
+// per entity type: when a role declares the block for type T, that
+// role's grants are closed-world for T — anything not granted is
+// denied. A role that does not declare the block for T contributes
+// nothing (it neither grants nor shrinks). Cross-role semantics are a
+// union: a field is writable if ANY of the principal's effective
+// roles grants it under a passing predicate. This keeps access
+// monotonic in the role set.
+//
+// # Effective roles are entity-scoped
+//
+// The effective role set for (principal, entity) is the principal's
+// global roles (assignments ∪ default) unioned with local roles
+// conferred on that entity by a role-relation edge from the principal
+// (e.g. alice --owner-of--> TKT-001 confers "owner" on TKT-001 only).
+// v1 resolves direct local roles only; inherited local roles are
+// deferred.
+package affordances
+
+import (
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
+)
+
+// compiledFieldGrant pairs a field name with its optional compiled
+// predicate. A nil program means an unconditional grant.
+type compiledFieldGrant struct {
+	field   string
+	program *predicate.Program
+}
+
+// compiledOptionGrant pairs a (field, option) with its predicate.
+type compiledOptionGrant struct {
+	field   string
+	option  string
+	program *predicate.Program
+}
+
+// compiledRelationGrant carries a relation type's create/remove
+// verdicts, its meta-field grants, and an optional whole-grant
+// predicate.
+type compiledRelationGrant struct {
+	relation string
+	create   *bool
+	remove   *bool
+	fields   []compiledFieldGrant
+	program  *predicate.Program
+}

--- a/internal/affordances/bindings.go
+++ b/internal/affordances/bindings.go
@@ -1,0 +1,199 @@
+package affordances
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// RelationLookup is the narrow contract the resolver needs from the
+// graph to answer has_relation / count_relations and to resolve local
+// roles. Defined at the consumer (CLAUDE.md "interfaces at the call
+// site"); the wiring site supplies a snapshot-backed implementation.
+//
+// OutgoingCounts returns, for fromID, a map of relation type → count
+// of outgoing edges of that type. One call answers both has_relation
+// (type present) and count_relations (the count), so the binding
+// context scans the graph once per resolve rather than once per
+// predicate (RR-08AK). HasEdge reports whether a specific edge
+// fromID --relType--> toID exists — a targeted query used for
+// local-role resolution (principal --role-relation--> entity).
+type RelationLookup interface {
+	OutgoingCounts(ctx context.Context, fromID string) map[string]int
+	HasEdge(ctx context.Context, fromID, relType, toID string) bool
+}
+
+// bindingContext carries everything a single Resolver call needs to
+// build per-entity predicate Bindings: the principal, the entity, the
+// principal's effective global roles, and the graph lookup. It is
+// constructed once per resolver call (snapshot-once).
+type bindingContext struct {
+	principal   principal.Principal
+	entity      *entity.Entity
+	globalRoles map[string]bool
+	lookup      RelationLookup
+	resolver    *PolicyResolver
+	// userID is the principal's identity as it appears on role-relation
+	// edges and current_user.id.
+	userID string
+
+	// outgoing caches the entity's outgoing-edge counts, loaded once
+	// on first host-func use (has_relation / count_relations) so a
+	// resolve call scans the graph at most once for them.
+	outgoing      map[string]int
+	outgoingReady bool
+}
+
+// outgoingCounts returns the entity's outgoing-edge counts, loading
+// and caching them on first call.
+func (bc *bindingContext) outgoingCounts(ctx context.Context) map[string]int {
+	if !bc.outgoingReady {
+		bc.outgoing = bc.lookup.OutgoingCounts(ctx, bc.entity.ID)
+		bc.outgoingReady = true
+	}
+	return bc.outgoing
+}
+
+// newBindings builds the predicate Bindings for evaluating a grant's
+// predicate against bc's entity. The entity record is coerced from
+// the metamodel-declared property types; host functions close over bc.
+func (bc *bindingContext) newBindings(meta *metamodel.Metamodel) (*predicate.Bindings, error) {
+	b := predicate.NewBindings()
+
+	if err := b.SetVar("entity", bc.entityRecord(meta)); err != nil {
+		return nil, err
+	}
+	if err := b.SetVar("current_user", predicate.NewRecord(map[string]predicate.Value{
+		"id":   predicate.NewString(bc.userID),
+		"tool": predicate.NewString(bc.principal.Tool),
+	})); err != nil {
+		return nil, err
+	}
+
+	setters := []struct {
+		name string
+		fn   predicate.Func
+	}{
+		{"has_role", predicate.FuncFunc(bc.hasRole)},
+		{"has_global_role", predicate.FuncFunc(bc.hasGlobalRole)},
+		{"has_relation", predicate.FuncFunc(bc.hasRelation)},
+		{"count_relations", predicate.FuncFunc(bc.countRelations)},
+		{"string_in_list", predicate.FuncFunc(stringInList)},
+	}
+	for _, s := range setters {
+		if err := b.SetFunc(s.name, s.fn); err != nil {
+			return nil, err
+		}
+	}
+	return b, nil
+}
+
+// entityRecord coerces the entity's properties into a predicate.Record
+// using the metamodel-declared types. Off-type or missing values bind
+// as Nil rather than erroring (DR-C2): permissive storage must not
+// turn data drift into an Eval failure. id and type are always set.
+func (bc *bindingContext) entityRecord(meta *metamodel.Metamodel) predicate.Value {
+	fields := map[string]predicate.Value{
+		"id":   predicate.NewString(bc.entity.ID),
+		"type": predicate.NewString(bc.entity.Type),
+	}
+	if meta != nil {
+		if def, ok := meta.Entities[bc.entity.Type]; ok {
+			for name, prop := range def.Properties {
+				if _, modeled := propertyPredicateType(meta, prop); !modeled {
+					continue
+				}
+				fields[name] = coerceValue(prop, bc.entity.Properties[name])
+			}
+		}
+	}
+	return predicate.NewRecord(fields)
+}
+
+// coerceValue best-effort coerces a stored property value to the
+// predicate Value matching its metamodel type. Unconvertible or
+// missing values become Nil. List properties become a List of coerced
+// scalars (single scalar promoted to a one-element list).
+func coerceValue(prop metamodel.PropertyDef, raw interface{}) predicate.Value {
+	if prop.List {
+		return coerceList(prop, raw)
+	}
+	return coerceScalar(prop.Type, raw)
+}
+
+// coerceList coerces a list-typed property. Surprising-but-deliberate
+// fail-soft choices (M3):
+//   - A bare scalar (not a slice) is promoted to a one-element list,
+//     so a hand-edited `tags: vip` reads the same as `tags: [vip]`.
+//   - A nil/absent value is the empty list (so list membership checks
+//     are false, never an Eval error).
+//   - Non-coercible elements (e.g. a non-string in a string list)
+//     become Nil holes rather than failing the whole list.
+func coerceList(prop metamodel.PropertyDef, raw interface{}) predicate.Value {
+	elems := []predicate.Value{}
+	switch v := raw.(type) {
+	case []interface{}:
+		for _, e := range v {
+			elems = append(elems, coerceScalar(prop.Type, e))
+		}
+	case nil:
+		// empty list
+	default:
+		// single scalar promoted to one-element list
+		elems = append(elems, coerceScalar(prop.Type, raw))
+	}
+	return predicate.NewList(elems)
+}
+
+func coerceScalar(typeName string, raw interface{}) predicate.Value {
+	if raw == nil {
+		return predicate.NewNil()
+	}
+	switch typeName {
+	case metamodel.PropertyTypeInteger:
+		return coerceNumber(raw)
+	case metamodel.PropertyTypeBoolean:
+		return coerceBool(raw)
+	default:
+		// string / enum / date / rrule / custom — string-valued.
+		if s, ok := raw.(string); ok {
+			return predicate.NewString(s)
+		}
+		return predicate.NewNil()
+	}
+}
+
+func coerceNumber(raw interface{}) predicate.Value {
+	switch v := raw.(type) {
+	case int:
+		return predicate.NewNumberFromInt(v)
+	case int64:
+		return predicate.NewNumber(float64(v))
+	case float64:
+		return predicate.NewNumber(v)
+	case string:
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return predicate.NewNumber(f)
+		}
+	}
+	return predicate.NewNil()
+}
+
+func coerceBool(raw interface{}) predicate.Value {
+	switch v := raw.(type) {
+	case bool:
+		return predicate.NewBool(v)
+	case string:
+		if v == "true" {
+			return predicate.NewBool(true)
+		}
+		if v == "false" {
+			return predicate.NewBool(false)
+		}
+	}
+	return predicate.NewNil()
+}

--- a/internal/affordances/dimension.go
+++ b/internal/affordances/dimension.go
@@ -1,0 +1,207 @@
+package affordances
+
+// dimension answers one yes/no question for a single entity type
+// across all of a principal's roles: "which fields may this user
+// write?" (or, for the visibility dimension, "which fields may this
+// user see?"). It exists because that answer is a union over roles
+// with a closed-world twist, and that fold needs somewhere to
+// accumulate.
+//
+// Worked example. Take a "ticket" with a `triager` role that grants
+// write on {status, assignee} and a `reviewer` role that grants write
+// on {status, resolution}. A user holding both should be able to write
+// {status, assignee, resolution} — the UNION — and nothing else.
+// "Nothing else" is the closed-world part: because at least one role
+// declared a `fields:` block for ticket, every OTHER ticket field
+// (title, description, ...) renders read-only. A dimension folds the
+// roles one at a time (allow + observeDeny) and deny() reports the
+// closed-world denials at the end.
+//
+// Semantics (DR-S3, DR-C4):
+//   - A role "opts in" by declaring the block for this type. Once ANY
+//     role opts in, the dimension is closed-world for the user.
+//   - allowed accumulates the union of granted fields across roles.
+//   - deny() denies every metamodel-declared field (plus any mentioned
+//     candidate) that isn't in allowed.
+//   - When no role opts in, the dimension stays permissive and deny()
+//     emits nothing.
+type dimension struct {
+	// optedIn records whether any role declared this block for the
+	// type. It's the closed-world switch: without it, deny() can't tell
+	// "no role restricts these fields, leave them all writable" from
+	// "a role opted in and granted zero, deny everything." A role
+	// granting an empty list is a real, deny-all configuration
+	// (DR-C4), so a non-empty allowed/candidates set isn't a reliable
+	// proxy — the explicit flag is.
+	optedIn    bool
+	allowed    map[string]bool
+	candidates map[string]bool
+	// denyRole records, per candidate field, the FIRST role (in sorted
+	// order) that observed a deny — used for attribution when the field
+	// ends up denied. ruleKind labels the dimension for the attribution
+	// string.
+	denyRole map[string]string
+	ruleKind string
+}
+
+func newDimension() *dimension {
+	return &dimension{
+		allowed:    map[string]bool{},
+		candidates: map[string]bool{},
+		denyRole:   map[string]string{},
+	}
+}
+
+// optIn marks the dimension closed-world (a role declared the block).
+func (d *dimension) optIn(ruleKind string) {
+	d.optedIn = true
+	d.ruleKind = ruleKind
+}
+
+// allow records a field as granted (union across roles).
+func (d *dimension) allow(field string) {
+	d.allowed[field] = true
+	d.candidates[field] = true
+	delete(d.denyRole, field)
+}
+
+// observeDeny records that role denied field (predicate failed). Only
+// sticks if no role has allowed it. Keeps the FIRST denying role
+// (roles iterate in sorted order) so attribution is deterministic.
+func (d *dimension) observeDeny(field, role string) {
+	d.candidates[field] = true
+	if !d.allowed[field] {
+		if _, seen := d.denyRole[field]; !seen {
+			d.denyRole[field] = role
+		}
+	}
+}
+
+// deny emits the sparse {field: false} map for fields that are
+// closed-world denied. When opted in, the deny universe is every
+// metamodel-declared field (passed by the resolver) plus any
+// candidate a grant mentioned — minus the union-allowed set. Returns
+// the map (nil when nothing denied) and the updated attribution map.
+func (d *dimension) deny(
+	universe []string, attr map[string]string,
+) (denied map[string]bool, attribution map[string]string) {
+	if !d.optedIn {
+		return nil, attr
+	}
+	denySet := map[string]bool{}
+	for _, f := range universe {
+		denySet[f] = true
+	}
+	for f := range d.candidates {
+		denySet[f] = true
+	}
+
+	var out map[string]bool
+	for field := range denySet {
+		if d.allowed[field] {
+			continue
+		}
+		if out == nil {
+			out = map[string]bool{}
+		}
+		out[field] = false
+		attr = recordAttribution(attr, field, d.ruleKind, d.denyRole[field])
+	}
+	return out, attr
+}
+
+// optionDimension accumulates per-(field, option) closed-world grants.
+// Opt-in is per field: a field that appears under options: is
+// closed-world for its options (only granted options allowed).
+type optionDimension struct {
+	optedInFields map[string]bool
+	allowed       map[string]map[string]bool // field → option → true
+	candidates    map[string]map[string]bool
+	denyRole      map[string]string // "field=option" → role
+}
+
+func newOptionDimension() *optionDimension {
+	return &optionDimension{
+		optedInFields: map[string]bool{},
+		allowed:       map[string]map[string]bool{},
+		candidates:    map[string]map[string]bool{},
+		denyRole:      map[string]string{},
+	}
+}
+
+func (o *optionDimension) optIn(field string) {
+	o.optedInFields[field] = true
+}
+
+func (o *optionDimension) allow(field, option string) {
+	if o.allowed[field] == nil {
+		o.allowed[field] = map[string]bool{}
+	}
+	o.allowed[field][option] = true
+	o.candidate(field, option)
+	delete(o.denyRole, field+"="+option)
+}
+
+func (o *optionDimension) observeDeny(field, option, role string) {
+	o.candidate(field, option)
+	if !o.allowed[field][option] {
+		key := field + "=" + option
+		if _, seen := o.denyRole[key]; !seen {
+			o.denyRole[key] = role
+		}
+	}
+}
+
+func (o *optionDimension) candidate(field, option string) {
+	if o.candidates[field] == nil {
+		o.candidates[field] = map[string]bool{}
+	}
+	o.candidates[field][option] = true
+}
+
+// deny emits {field: {option: false}} for each declared option not
+// granted on an opted-in field. The deny universe per field is the
+// metamodel enum values (passed by the resolver) plus any mentioned
+// candidate, minus the union-allowed set.
+func (o *optionDimension) deny(
+	enumValues map[string][]string, attr map[string]string,
+) (denied map[string]map[string]bool, attribution map[string]string) {
+	var out map[string]map[string]bool
+	for field := range o.optedInFields {
+		denySet := map[string]bool{}
+		for _, v := range enumValues[field] {
+			denySet[v] = true
+		}
+		for option := range o.candidates[field] {
+			denySet[option] = true
+		}
+		for option := range denySet {
+			if o.allowed[field][option] {
+				continue
+			}
+			if out == nil {
+				out = map[string]map[string]bool{}
+			}
+			if out[field] == nil {
+				out[field] = map[string]bool{}
+			}
+			out[field][option] = false
+			attr = recordAttribution(attr, field+"="+option, "enum-filtered", o.denyRole[field+"="+option])
+		}
+	}
+	return out, attr
+}
+
+// recordAttribution adds a "<rule> via role <role>" attribution entry
+// for a denied path. role may be empty (no specific role observed).
+func recordAttribution(attr map[string]string, path, ruleKind, role string) map[string]string {
+	if attr == nil {
+		attr = map[string]string{}
+	}
+	if role == "" {
+		attr[path] = "affordance:" + ruleKind
+		return attr
+	}
+	attr[path] = "affordance:" + ruleKind + " role=" + role
+	return attr
+}

--- a/internal/affordances/effective_roles.go
+++ b/internal/affordances/effective_roles.go
@@ -1,0 +1,67 @@
+package affordances
+
+import (
+	"context"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// globalRoles returns the principal's global (assignment-based) role
+// set as a lookup map: Assignments[user] plus [acl.EveryoneRole] when
+// the policy declares it. The "everyone" name is shared with
+// acl.Declarative via the acl package constant so write-grant and
+// affordance composition can't drift.
+func (r *PolicyResolver) globalRoles(p principal.Principal) map[string]bool {
+	out := map[string]bool{}
+	if r.policy == nil {
+		return out
+	}
+	if role, ok := r.policy.Assignments[p.User]; ok {
+		if _, declared := r.policy.Roles[role]; declared {
+			out[role] = true
+		}
+	}
+	if _, ok := r.policy.Roles[acl.EveryoneRole]; ok {
+		out[acl.EveryoneRole] = true
+	}
+	return out
+}
+
+// effectiveRoles returns the role names that apply to (principal,
+// entity): global roles plus direct local roles conferred on the
+// entity by a role-relation edge from the principal. The result is a
+// stable-order-independent slice (callers iterate for union semantics).
+func (r *PolicyResolver) effectiveRoles(
+	ctx context.Context, p principal.Principal, e *entity.Entity, global map[string]bool,
+) []string {
+	set := map[string]bool{}
+	for role := range global {
+		set[role] = true
+	}
+	for confersRole, relTypes := range r.localRoleRelations {
+		for _, rt := range relTypes {
+			if r.lookup.HasEdge(ctx, p.User, rt, e.ID) {
+				set[confersRole] = true
+				break
+			}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for role := range set {
+		out = append(out, role)
+	}
+	// Deterministic order so that attribution (which role is credited
+	// for a deny) is stable across runs, not map-iteration-dependent
+	// (DR S3 / RR-QV18).
+	sort.Strings(out)
+	return out
+}
+
+// localRoleRelations returns the role-relation types that confer role,
+// used by the bindingContext's has_role local-role resolution.
+func (bc *bindingContext) localRoleRelations(role string) []string {
+	return bc.resolver.localRoleRelations[role]
+}

--- a/internal/affordances/env.go
+++ b/internal/affordances/env.go
@@ -1,0 +1,127 @@
+package affordances
+
+import (
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
+)
+
+// userRecordType is the static type for the current_user variable.
+// A predicate may reference:
+//   - current_user.id   — the principal's user identity (the value
+//     that appears on role-relation edges).
+//   - current_user.tool — the entry-point tool the request came
+//     through ("data-entry", "mcp", "cli", ...). It is NOT a user
+//     classification; gate by role via has_role / has_global_role,
+//     not by inspecting current_user.tool (M1).
+var userRecordType = predicate.RecordType{
+	"id":   predicate.StringType,
+	"tool": predicate.StringType,
+}
+
+// buildEnv constructs the predicate environment for one entity type:
+// the `entity` record (materialized from the metamodel), `current_user`,
+// and the host-function signatures. The same env compiles every grant
+// for that type.
+//
+// Properties whose metamodel type maps to a predicate type are
+// declared; unsupported types are omitted so a predicate referencing
+// them fails at compile with "unknown variable" rather than silently
+// evaluating against a wrong runtime type (DR-C2). The `id` and `type`
+// pseudo-fields are always present.
+func buildEnv(meta *metamodel.Metamodel, entityType string) (*predicate.Env, error) {
+	env := predicate.NewEnv()
+
+	if err := env.DeclareVar("entity", entityRecordType(meta, entityType)); err != nil {
+		return nil, err
+	}
+	if err := env.DeclareVar("current_user", userRecordType); err != nil {
+		return nil, err
+	}
+
+	rec := predicate.RecordType{}
+	str := predicate.StringType
+	num := predicate.NumberType
+	boolT := predicate.BoolType
+	strList := predicate.ListType{Elem: predicate.StringType}
+
+	funcs := []struct {
+		name string
+		sig  predicate.FuncSig
+	}{
+		{"has_role", predicate.FuncSig{Params: []predicate.Type{rec, rec, str}, Return: boolT}},
+		{"has_global_role", predicate.FuncSig{Params: []predicate.Type{rec, str}, Return: boolT}},
+		{"has_relation", predicate.FuncSig{Params: []predicate.Type{rec, str}, Return: boolT}},
+		{"count_relations", predicate.FuncSig{Params: []predicate.Type{rec, str}, Return: num}},
+		{"string_in_list", predicate.FuncSig{Params: []predicate.Type{str, strList}, Return: boolT}},
+	}
+	for _, f := range funcs {
+		if err := env.DeclareFunc(f.name, f.sig); err != nil {
+			return nil, err
+		}
+	}
+	return env, nil
+}
+
+// entityRecordType builds the RecordType for an entity type's
+// properties. id and type are always present; each property maps per
+// propertyPredicateType. Unsupported property types are omitted (DR-C2).
+func entityRecordType(meta *metamodel.Metamodel, entityType string) predicate.RecordType {
+	rec := predicate.RecordType{
+		"id":   predicate.StringType,
+		"type": predicate.StringType,
+	}
+	if meta == nil {
+		return rec
+	}
+	def, ok := meta.Entities[entityType]
+	if !ok {
+		return rec
+	}
+	for name, prop := range def.Properties {
+		if t, ok := propertyPredicateType(meta, prop); ok {
+			rec[name] = t
+		}
+	}
+	return rec
+}
+
+// propertyPredicateType maps a metamodel property to a predicate type.
+// Returns (_, false) for types the predicate type system can't model,
+// so the caller omits them from the env. A custom (named) type is
+// treated as a string when it resolves to an enum-like custom type,
+// else omitted.
+func propertyPredicateType(meta *metamodel.Metamodel, prop metamodel.PropertyDef) (predicate.Type, bool) {
+	elem, ok := scalarPredicateType(meta, prop.Type)
+	if !ok {
+		return nil, false
+	}
+	if prop.List {
+		return predicate.ListType{Elem: elem}, true
+	}
+	return elem, true
+}
+
+// scalarPredicateType maps a scalar metamodel type name to a predicate
+// scalar type. enum/date/rrule/string and string-valued custom types
+// become StringType; integer becomes NumberType; boolean becomes
+// BoolType. file and unknown types are unmodelled.
+func scalarPredicateType(meta *metamodel.Metamodel, typeName string) (predicate.Type, bool) {
+	switch typeName {
+	case "", metamodel.PropertyTypeString, metamodel.PropertyTypeEnum,
+		metamodel.PropertyTypeDate, metamodel.PropertyTypeRrule:
+		return predicate.StringType, true
+	case metamodel.PropertyTypeInteger:
+		return predicate.NumberType, true
+	case metamodel.PropertyTypeBoolean:
+		return predicate.BoolType, true
+	case metamodel.PropertyTypeFile:
+		return nil, false
+	}
+	// Custom named types: enum-like custom types carry string values.
+	if meta != nil {
+		if _, ok := meta.Types[typeName]; ok {
+			return predicate.StringType, true
+		}
+	}
+	return nil, false
+}

--- a/internal/affordances/hostfuncs.go
+++ b/internal/affordances/hostfuncs.go
@@ -1,0 +1,112 @@
+package affordances
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
+)
+
+// errArgType is returned when a host func receives an argument whose
+// runtime type doesn't match its declared signature. The compile-time
+// type checker should prevent this; the runtime guard fails the Eval
+// (which the resolver treats as deny — fail closed).
+var errArgType = errors.New("affordances: host function argument type mismatch")
+
+// hasRole reports whether the principal holds role_name scoped to the
+// given entity: global roles ∪ local roles conferred on the entity.
+// Signature: has_role(user_record, entity_record, role_name) bool.
+//
+// The user and entity records are ignored beyond confirming arity —
+// the binding closes over the principal and entity, so the predicate
+// can't ask about a different user or entity than the one in scope.
+func (bc *bindingContext) hasRole(ctx context.Context, args []predicate.Value) (predicate.Value, error) {
+	role, ok := stringArg(args, 2)
+	if !ok {
+		return nil, errArgType
+	}
+	if bc.globalRoles[role] {
+		return predicate.NewBool(true), nil
+	}
+	return predicate.NewBool(bc.holdsLocalRole(ctx, role)), nil
+}
+
+// hasGlobalRole reports whether the principal holds role_name as a
+// global (assignment-based) role, ignoring local roles.
+// Signature: has_global_role(user_record, role_name) bool.
+func (bc *bindingContext) hasGlobalRole(_ context.Context, args []predicate.Value) (predicate.Value, error) {
+	role, ok := stringArg(args, 1)
+	if !ok {
+		return nil, errArgType
+	}
+	return predicate.NewBool(bc.globalRoles[role]), nil
+}
+
+// hasRelation reports whether the in-scope entity has any outgoing
+// relation of the given type. Signature: has_relation(entity, type) bool.
+func (bc *bindingContext) hasRelation(ctx context.Context, args []predicate.Value) (predicate.Value, error) {
+	relType, ok := stringArg(args, 1)
+	if !ok {
+		return nil, errArgType
+	}
+	return predicate.NewBool(bc.outgoingCounts(ctx)[relType] > 0), nil
+}
+
+// countRelations returns the number of outgoing relations of the given
+// type from the in-scope entity. Signature: count_relations(entity, type) number.
+func (bc *bindingContext) countRelations(ctx context.Context, args []predicate.Value) (predicate.Value, error) {
+	relType, ok := stringArg(args, 1)
+	if !ok {
+		return nil, errArgType
+	}
+	return predicate.NewNumberFromInt(bc.outgoingCounts(ctx)[relType]), nil
+}
+
+// stringInList reports whether value is an element of allowed.
+// Signature: string_in_list(value string, allowed list_of_string) bool.
+func stringInList(_ context.Context, args []predicate.Value) (predicate.Value, error) {
+	if len(args) != 2 {
+		return nil, errArgType
+	}
+	value, ok := args[0].(predicate.String)
+	if !ok {
+		return nil, errArgType
+	}
+	list, ok := args[1].(predicate.List)
+	if !ok {
+		return nil, errArgType
+	}
+	for _, e := range list.Elems() {
+		if s, ok := e.(predicate.String); ok && s.String() == value.String() {
+			return predicate.NewBool(true), nil
+		}
+	}
+	return predicate.NewBool(false), nil
+}
+
+// holdsLocalRole reports whether the principal holds role via a
+// role-relation edge to the in-scope entity. For each role-relation
+// type R conferring role, it checks principal --R--> entity. v1 =
+// direct local roles only.
+func (bc *bindingContext) holdsLocalRole(ctx context.Context, role string) bool {
+	for _, relType := range bc.localRoleRelations(role) {
+		if bc.lookup.HasEdge(ctx, bc.userID, relType, bc.entity.ID) {
+			return true
+		}
+	}
+	return false
+}
+
+// stringArg returns the string value at args[i] when args has exactly
+// want elements and args[i] is a predicate.String.
+func stringArg(args []predicate.Value, i int) (string, bool) {
+	want := i + 1
+	if len(args) != want {
+		return "", false
+	}
+	s, ok := args[i].(predicate.String)
+	if !ok {
+		return "", false
+	}
+	return s.String(), true
+}

--- a/internal/affordances/hostfuncs_test.go
+++ b/internal/affordances/hostfuncs_test.go
@@ -1,0 +1,193 @@
+package affordances_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// metaWithRelations adds list and boolean properties plus the relation
+// types the host-func tests reference.
+func metaWithExtras(t *testing.T) *metamodel.Metamodel {
+	t.Helper()
+	m := testMeta(t)
+	def := m.Entities["ticket"]
+	def.Properties["labels"] = metamodel.PropertyDef{Type: metamodel.PropertyTypeString, List: true}
+	def.Properties["urgent"] = metamodel.PropertyDef{Type: metamodel.PropertyTypeBoolean}
+	m.Entities["ticket"] = def
+	return m
+}
+
+// has_relation gates a field on whether the entity has an outgoing
+// edge of a given type.
+func TestHostFunc_HasRelation(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: status
+          when: "has_relation(entity, 'blocks')"
+assignments:
+  alice: triager
+`)
+	// T-1 has a blocks edge; T-2 does not.
+	lookup := newStubLookup([3]string{"T-1", "blocks", "T-9"})
+	r, err := affordances.New(p, metaWithExtras(t), lookup)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, denied := r.FieldVerdicts(ctxAs("alice"), ticket("T-1", nil)).Writable["status"]; denied {
+		t.Errorf("T-1 has blocks edge → status should be writable")
+	}
+	if v, ok := r.FieldVerdicts(ctxAs("alice"), ticket("T-2", nil)).Writable["status"]; !ok || v {
+		t.Errorf("T-2 has no blocks edge → status should be denied")
+	}
+}
+
+// count_relations gates a field on an edge count.
+func TestHostFunc_CountRelations(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: status
+          when: "count_relations(entity, 'blocks') >= 2"
+assignments:
+  alice: triager
+`)
+	lookup := newStubLookup(
+		[3]string{"T-1", "blocks", "A"},
+		[3]string{"T-1", "blocks", "B"},
+		[3]string{"T-2", "blocks", "A"},
+	)
+	r, err := affordances.New(p, metaWithExtras(t), lookup)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, denied := r.FieldVerdicts(ctxAs("alice"), ticket("T-1", nil)).Writable["status"]; denied {
+		t.Errorf("T-1 has 2 blocks → status writable")
+	}
+	if v, ok := r.FieldVerdicts(ctxAs("alice"), ticket("T-2", nil)).Writable["status"]; !ok || v {
+		t.Errorf("T-2 has 1 block → status denied")
+	}
+}
+
+// string_in_list gates membership of a scalar in a list-typed property.
+// The predicate parser accepts table literals only as named-args to a
+// function call, so the list argument is an entity list property, not
+// an inline literal — the canonical usage.
+func TestHostFunc_StringInList(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: status
+          when: "string_in_list(entity.status, entity.labels)"
+assignments:
+  alice: triager
+`)
+	r, err := affordances.New(p, metaWithExtras(t), newStubLookup())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// status "open" is in labels → writable.
+	if _, denied := r.FieldVerdicts(ctxAs("alice"),
+		ticket("T-1", map[string]interface{}{
+			"status": "open", "labels": []interface{}{"open", "review"},
+		})).Writable["status"]; denied {
+		t.Errorf("status in labels → writable")
+	}
+	// status "done" not in labels → denied.
+	if v, ok := r.FieldVerdicts(ctxAs("alice"),
+		ticket("T-2", map[string]interface{}{
+			"status": "done", "labels": []interface{}{"open", "review"},
+		})).Writable["status"]; !ok || v {
+		t.Errorf("status not in labels → denied")
+	}
+}
+
+// Boolean property coercion: a bool-typed property binds as a predicate
+// bool and compares correctly.
+func TestCoerce_Boolean(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: status
+          when: "entity.urgent == true"
+assignments:
+  alice: triager
+`)
+	r, err := affordances.New(p, metaWithExtras(t), newStubLookup())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, denied := r.FieldVerdicts(ctxAs("alice"),
+		ticket("T-1", map[string]interface{}{"urgent": true})).Writable["status"]; denied {
+		t.Errorf("urgent=true → status writable")
+	}
+	// stored as the string "false" → coerces to bool false → denied.
+	if v, ok := r.FieldVerdicts(ctxAs("alice"),
+		ticket("T-2", map[string]interface{}{"urgent": "false"})).Writable["status"]; !ok || v {
+		t.Errorf("urgent='false' coerces to false → status denied")
+	}
+}
+
+// M3: a list property whose stored elements aren't all strings
+// coerces non-string elements to Nil holes rather than failing Eval.
+// The string elements still match.
+func TestCoerce_List_NonStringElements(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: status
+          when: "string_in_list('vip', entity.labels)"
+assignments:
+  alice: triager
+`)
+	r, err := affordances.New(p, metaWithExtras(t), newStubLookup())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// labels mixes a string and a number; "vip" is still found.
+	if _, denied := r.FieldVerdicts(ctxAs("alice"),
+		ticket("T-1", map[string]interface{}{
+			"labels": []interface{}{"vip", 42},
+		})).Writable["status"]; denied {
+		t.Errorf("vip present among mixed elements → status writable, no Eval failure")
+	}
+}
+
+// List property coercion + string_in_list over the entity's own list.
+func TestCoerce_List(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: status
+          when: "string_in_list('vip', entity.labels)"
+assignments:
+  alice: triager
+`)
+	r, err := affordances.New(p, metaWithExtras(t), newStubLookup())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, denied := r.FieldVerdicts(ctxAs("alice"),
+		ticket("T-1", map[string]interface{}{"labels": []interface{}{"vip", "urgent"}})).Writable["status"]; denied {
+		t.Errorf("labels contains vip → status writable")
+	}
+	// single scalar promoted to one-element list; "vip" not present.
+	if v, ok := r.FieldVerdicts(ctxAs("alice"),
+		ticket("T-2", map[string]interface{}{"labels": "other"})).Writable["status"]; !ok || v {
+		t.Errorf("labels=[other] lacks vip → status denied")
+	}
+}

--- a/internal/affordances/relation_accum.go
+++ b/internal/affordances/relation_accum.go
@@ -1,0 +1,166 @@
+package affordances
+
+// relationAccumulator unions relation grants across roles. A relation
+// type's verdict is sparse: it appears in the output only when it
+// deviates from the permissive default (creatable + removable + all
+// meta writable).
+//
+// Closed-world for relations is per (role, type): a role that declares
+// relations: for the entity type makes the listed relation types
+// closed-world for that role's contribution. Cross-role union: a
+// relation operation is allowed if ANY role grants it.
+type relationAccumulator struct {
+	// optedInTypes are relation types some role opted into (declared a
+	// grant for). Only these can be denied.
+	optedInTypes map[string]bool
+	// creatable / removable accumulate the union of allowed ops.
+	creatable map[string]bool
+	removable map[string]bool
+	// metaAllowed[type][field] = true when some role grants writing
+	// that meta field under a passing predicate.
+	metaAllowed map[string]map[string]bool
+	// metaCandidates records every meta field any role mentioned for a
+	// type, so unlisted-but-mentioned fields can be denied.
+	metaCandidates map[string]map[string]bool
+	// metaOptedIn[type] is true when a role declared meta-field grants
+	// for that relation type (closed-world for meta on that type).
+	metaOptedIn map[string]bool
+
+	denyRole map[string]string // "<type>:<dim>" → role
+}
+
+func newRelationAccumulator() *relationAccumulator {
+	return &relationAccumulator{
+		optedInTypes:   map[string]bool{},
+		creatable:      map[string]bool{},
+		removable:      map[string]bool{},
+		metaAllowed:    map[string]map[string]bool{},
+		metaCandidates: map[string]map[string]bool{},
+		metaOptedIn:    map[string]bool{},
+		denyRole:       map[string]string{},
+	}
+}
+
+// observe folds one role's compiled relation grant into the union.
+// grantPassed is whether the grant's whole-grant predicate evaluated
+// true; a failed predicate denies create/remove for this role's
+// contribution (but other roles may still grant). metaPassed carries
+// per-meta-field pass results (field → allowed), already AND-ed with
+// grantPassed by the resolver.
+func (a *relationAccumulator) observe(
+	role string, rg compiledRelationGrant, grantPassed bool, metaPassed map[string]bool,
+) {
+	rt := rg.relation
+	a.optedInTypes[rt] = true
+
+	// create/remove default to true when the grant exists and its
+	// predicate passes; an explicit false denies for this role.
+	if grantPassed {
+		if create := rg.create == nil || *rg.create; create {
+			a.creatable[rt] = true
+		} else {
+			a.recordDeny(rt, "create", role)
+		}
+		if remove := rg.remove == nil || *rg.remove; remove {
+			a.removable[rt] = true
+		} else {
+			a.recordDeny(rt, "remove", role)
+		}
+	} else {
+		a.recordDeny(rt, "create", role)
+		a.recordDeny(rt, "remove", role)
+	}
+
+	// Meta-field grants are closed-world for the relation type when any
+	// role declares them.
+	if len(rg.fields) > 0 {
+		a.metaOptedIn[rt] = true
+	}
+	for _, fg := range rg.fields {
+		a.candidateMeta(rt, fg.field)
+		if metaPassed[fg.field] {
+			a.allowMeta(rt, fg.field)
+		} else {
+			a.denyMeta(rt, fg.field, role)
+		}
+	}
+}
+
+func (a *relationAccumulator) recordDeny(rt, dim, role string) {
+	key := rt + ":" + dim
+	if _, ok := a.denyRole[key]; !ok {
+		a.denyRole[key] = role
+	}
+}
+
+func (a *relationAccumulator) candidateMeta(rt, field string) {
+	if a.metaCandidates[rt] == nil {
+		a.metaCandidates[rt] = map[string]bool{}
+	}
+	a.metaCandidates[rt][field] = true
+}
+
+func (a *relationAccumulator) allowMeta(rt, field string) {
+	if a.metaAllowed[rt] == nil {
+		a.metaAllowed[rt] = map[string]bool{}
+	}
+	a.metaAllowed[rt][field] = true
+	delete(a.denyRole, rt+":fields."+field)
+}
+
+func (a *relationAccumulator) denyMeta(rt, field, role string) {
+	if !a.metaAllowed[rt][field] {
+		a.recordDeny(rt, "fields."+field, role)
+	}
+}
+
+// verdicts emits the sparse per-relation-type verdict map. A type
+// appears only when it deviates from the permissive default.
+func (a *relationAccumulator) verdicts() map[string]RelationVerdict {
+	var out map[string]RelationVerdict
+	for rt := range a.optedInTypes {
+		creatable := a.creatable[rt]
+		removable := a.removable[rt]
+
+		var fields map[string]bool
+		var attribution map[string]string
+		if a.metaOptedIn[rt] {
+			for field := range a.metaCandidates[rt] {
+				if a.metaAllowed[rt][field] {
+					continue
+				}
+				if fields == nil {
+					fields = map[string]bool{}
+				}
+				fields[field] = false
+				attribution = recordAttribution(attribution, "fields."+field,
+					"relation-meta-read-only", a.denyRole[rt+":fields."+field])
+			}
+		}
+
+		// Skip types that are fully permissive (nothing deviates).
+		if creatable && removable && fields == nil {
+			continue
+		}
+
+		if !creatable {
+			attribution = recordAttribution(attribution, "create",
+				"relation-not-creatable", a.denyRole[rt+":create"])
+		}
+		if !removable {
+			attribution = recordAttribution(attribution, "remove",
+				"relation-not-removable", a.denyRole[rt+":remove"])
+		}
+
+		if out == nil {
+			out = map[string]RelationVerdict{}
+		}
+		out[rt] = RelationVerdict{
+			Creatable:   creatable,
+			Removable:   removable,
+			Fields:      fields,
+			Attribution: attribution,
+		}
+	}
+	return out
+}

--- a/internal/affordances/resolver.go
+++ b/internal/affordances/resolver.go
@@ -1,0 +1,493 @@
+package affordances
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// FieldVerdicts carries per-entity field-level affordance decisions.
+// All maps are sparse: an absent key means the permissive default
+// (writable / visible / option allowed). The data-entry adapter maps
+// this onto its own wire-shape verdict type.
+type FieldVerdicts struct {
+	Writable map[string]bool
+	Visible  map[string]bool
+	Options  map[string]map[string]bool
+	// Attribution maps a denied field (or "field=option") to the
+	// role/grant that produced the deny, for the audit Summary channel
+	// (DR-C5). Sparse — only denies appear; never surfaced on the wire.
+	Attribution map[string]string
+}
+
+// RelationVerdicts carries per-entity relation-level decisions, sparse
+// by relation type.
+type RelationVerdicts struct {
+	Types map[string]RelationVerdict
+}
+
+// RelationVerdict is the decision for one relation type.
+type RelationVerdict struct {
+	Creatable bool
+	Removable bool
+	Fields    map[string]bool
+	// Attribution maps a denied dimension ("create", "remove",
+	// "fields.<name>") to the role/grant that denied it.
+	Attribution map[string]string
+}
+
+// PolicyResolver answers field/option/relation affordance queries from
+// a compiled acl.yaml policy. Construct with [New]; safe for concurrent
+// use.
+type PolicyResolver struct {
+	policy *acl.Policy
+	meta   *metamodel.Metamodel
+	lookup RelationLookup
+
+	// envs holds the compiled predicate env per entity type, reused
+	// across grants of that type.
+	envs map[string]*predicate.Env
+
+	// grants is indexed by (role, entityType) → compiled grant blocks.
+	grants map[grantKey]*compiledGrants
+
+	// localRoleRelations maps a conferred role name → the relation
+	// types that confer it (from policy.RoleRelations).
+	localRoleRelations map[string][]string
+}
+
+type grantKey struct {
+	role       string
+	entityType string
+}
+
+// compiledGrants is the per-(role, type) bundle of compiled grants. A
+// nil slice value distinguishes "block declared (opt-in)" from "block
+// absent"; the presence flags record which blocks the role declared
+// for this type.
+type compiledGrants struct {
+	fields    []compiledFieldGrant
+	visible   []compiledFieldGrant
+	options   []compiledOptionGrant
+	relations []compiledRelationGrant
+
+	declaredFields    bool
+	declaredVisible   bool
+	declaredOptions   bool
+	declaredRelations bool
+}
+
+// New compiles the policy's affordance grants against the metamodel
+// and returns a PolicyResolver. Every grant's `when:` predicate is
+// compiled up front; all compile errors are collected and joined so an
+// operator sees every failure in one pass (DR-S2). meta and lookup
+// must be non-nil; policy may be nil (yields an all-permissive
+// resolver).
+//
+// The full *metamodel.Metamodel is required (not a narrower slice):
+// the resolver can be asked about any entity type at runtime, and for
+// each it needs that type's property defs (to build the predicate env
+// and coerce values) and the relation defs (to validate relation
+// grant targets). Narrowing to a per-type view would just move the
+// whole-metamodel dependency to the caller.
+func New(policy *acl.Policy, meta *metamodel.Metamodel, lookup RelationLookup) (*PolicyResolver, error) {
+	if meta == nil {
+		return nil, errors.New("affordances: New: meta must be non-nil")
+	}
+	if lookup == nil {
+		return nil, errors.New("affordances: New: lookup must be non-nil")
+	}
+	r := &PolicyResolver{
+		policy:             policy,
+		meta:               meta,
+		lookup:             lookup,
+		envs:               map[string]*predicate.Env{},
+		grants:             map[grantKey]*compiledGrants{},
+		localRoleRelations: map[string][]string{},
+	}
+	if policy == nil {
+		return r, nil
+	}
+
+	for confRel, def := range policy.RoleRelations {
+		if def.Confers != "" {
+			r.localRoleRelations[def.Confers] = append(r.localRoleRelations[def.Confers], confRel)
+		}
+	}
+
+	var errs []error
+	for roleName, role := range policy.Roles {
+		errs = append(errs, r.compileRole(roleName, role)...)
+	}
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	return r, nil
+}
+
+// env returns (compiling on first use) the predicate env for an entity
+// type. Envs are cached so every grant of a type shares one.
+func (r *PolicyResolver) env(entityType string) (*predicate.Env, error) {
+	if e, ok := r.envs[entityType]; ok {
+		return e, nil
+	}
+	e, err := buildEnv(r.meta, entityType)
+	if err != nil {
+		return nil, err
+	}
+	r.envs[entityType] = e
+	return e, nil
+}
+
+// compileRole compiles every grant block of one role across all the
+// entity types it mentions, recording per-(role, type) compiled
+// grants. Returns the collected compile errors (path-prefixed).
+func (r *PolicyResolver) compileRole(roleName string, role acl.RoleDef) []error {
+	var errs []error
+	get := func(entityType string) *compiledGrants {
+		k := grantKey{roleName, entityType}
+		g := r.grants[k]
+		if g == nil {
+			g = &compiledGrants{}
+			r.grants[k] = g
+		}
+		return g
+	}
+
+	for et, grants := range role.Fields {
+		g := get(et)
+		g.declaredFields = true
+		errs = append(errs, r.compileFieldBlock(roleName, et, "fields", grants, &g.fields)...)
+	}
+	for et, grants := range role.Visible {
+		g := get(et)
+		g.declaredVisible = true
+		errs = append(errs, r.compileFieldBlock(roleName, et, "visible", grants, &g.visible)...)
+	}
+	for et, grants := range role.Options {
+		g := get(et)
+		g.declaredOptions = true
+		errs = append(errs, r.compileOptionBlock(roleName, et, grants, &g.options)...)
+	}
+	for et, grants := range role.Relations {
+		g := get(et)
+		g.declaredRelations = true
+		for i, rg := range grants {
+			errs = append(errs, r.compileRelationGrant(g, roleName, et, i, rg)...)
+		}
+	}
+	return errs
+}
+
+// compileFieldBlock validates + compiles a fields/visible block,
+// appending compiled grants to out. block is the YAML key for error
+// paths ("fields" or "visible").
+func (r *PolicyResolver) compileFieldBlock(
+	roleName, entityType, block string, grants []acl.FieldGrant, out *[]compiledFieldGrant,
+) []error {
+	var errs []error
+	for i, fg := range grants {
+		if verr := r.validateField(roleName, entityType, block, i, fg.Field); verr != nil {
+			errs = append(errs, verr)
+			continue
+		}
+		prog, err := r.compile(roleName, entityType, block, i, fg.When)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		*out = append(*out, compiledFieldGrant{field: fg.Field, program: prog})
+	}
+	return errs
+}
+
+// compileOptionBlock validates + compiles an options block.
+func (r *PolicyResolver) compileOptionBlock(
+	roleName, entityType string, grants []acl.OptionGrant, out *[]compiledOptionGrant,
+) []error {
+	var errs []error
+	for i, og := range grants {
+		if verr := r.validateOption(roleName, entityType, i, og.Field, og.Option); verr != nil {
+			errs = append(errs, verr)
+			continue
+		}
+		prog, err := r.compile(roleName, entityType, "options", i, og.When)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		*out = append(*out, compiledOptionGrant{field: og.Field, option: og.Option, program: prog})
+	}
+	return errs
+}
+
+func (r *PolicyResolver) compileRelationGrant(
+	g *compiledGrants, roleName, entityType string, i int, rg acl.RelationGrant,
+) []error {
+	var errs []error
+	if verr := r.validateRelation(roleName, entityType, i, rg.Relation); verr != nil {
+		// Unknown relation type: report and skip the whole grant —
+		// none of its dimensions can meaningfully gate anything.
+		return append(errs, verr)
+	}
+	prog, err := r.compile(roleName, entityType, "relations", i, rg.When)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	cr := compiledRelationGrant{
+		relation: rg.Relation,
+		create:   rg.Create,
+		remove:   rg.Remove,
+		program:  prog,
+	}
+	metaFailed := false
+	for j, fg := range rg.Fields {
+		fprog, ferr := r.compile(roleName, entityType,
+			fmt.Sprintf("relations[%d].fields", i), j, fg.When)
+		if ferr != nil {
+			errs = append(errs, ferr)
+			metaFailed = true
+			continue
+		}
+		cr.fields = append(cr.fields, compiledFieldGrant{field: fg.Field, program: fprog})
+	}
+	// Append the grant only when it compiled cleanly end-to-end. A
+	// grant that lost a meta field to a compile error must not be
+	// half-installed (S4): silently dropping the field would flip a
+	// closed-world meta deny into permissive if New ever relaxed to
+	// warn-and-continue. New currently hard-fails on any collected
+	// error, so this is belt-and-suspenders.
+	if err == nil && !metaFailed {
+		g.relations = append(g.relations, cr)
+	}
+	return errs
+}
+
+// compile compiles one grant predicate. An empty `when` yields a nil
+// program, which the evaluator (passes) treats as an unconditional
+// grant — nil is the intended sentinel here, not an error-absent
+// invalid value.
+//
+//nolint:nilnil // nil program is the documented "unconditional" sentinel
+func (r *PolicyResolver) compile(roleName, entityType, block string, idx int, when string) (*predicate.Program, error) {
+	if when == "" {
+		return nil, nil
+	}
+	env, err := r.env(entityType)
+	if err != nil {
+		return nil, fmt.Errorf("roles.%s.%s.%s[%d]: %w", roleName, block, entityType, idx, err)
+	}
+	prog, err := predicate.Compile(env, when)
+	if err != nil {
+		return nil, fmt.Errorf("roles.%s.%s.%s[%d].when: %w", roleName, block, entityType, idx, err)
+	}
+	return prog, nil
+}
+
+// FieldVerdicts computes the sparse field-level verdicts for e against
+// the principal carried on ctx.
+func (r *PolicyResolver) FieldVerdicts(ctx context.Context, e *entity.Entity) FieldVerdicts {
+	out := FieldVerdicts{}
+	if e == nil || r.policy == nil {
+		return out
+	}
+	bc, roles := r.bindingFor(ctx, e)
+	if bc == nil {
+		return out
+	}
+
+	writable := newDimension()
+	visible := newDimension()
+	options := newOptionDimension()
+
+	for _, role := range roles {
+		g := r.grants[grantKey{role, e.Type}]
+		if g == nil {
+			continue
+		}
+		if g.declaredFields {
+			r.applyFieldGrants(bc, role, "read-only", g.fields, writable)
+		}
+		if g.declaredVisible {
+			r.applyFieldGrants(bc, role, "hidden", g.visible, visible)
+		}
+		if g.declaredOptions {
+			r.applyOptionGrants(bc, role, g.options, options)
+		}
+	}
+
+	fieldUniverse := r.declaredFields(e.Type)
+	out.Writable, out.Attribution = writable.deny(fieldUniverse, out.Attribution)
+	visMap, attr := visible.deny(fieldUniverse, out.Attribution)
+	out.Visible = visMap
+	out.Attribution = attr
+	out.Options, out.Attribution = options.deny(r.enumOptions(e.Type), out.Attribution)
+	return out
+}
+
+// declaredFields returns the metamodel-declared property names for an
+// entity type — the closed-world universe a fields/visible block
+// denies from. Unknown type yields an empty set.
+func (r *PolicyResolver) declaredFields(entityType string) []string {
+	def, ok := r.meta.Entities[entityType]
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(def.Properties))
+	for name := range def.Properties {
+		out = append(out, name)
+	}
+	return out
+}
+
+// enumOptions returns, per enum-typed field, its declared option
+// values — the closed-world universe an options block denies from.
+func (r *PolicyResolver) enumOptions(entityType string) map[string][]string {
+	def, ok := r.meta.Entities[entityType]
+	if !ok {
+		return nil
+	}
+	out := map[string][]string{}
+	for name, prop := range def.Properties {
+		values := prop.Values
+		if len(values) == 0 {
+			if ct, ok := r.meta.Types[prop.Type]; ok {
+				values = ct.Values
+			}
+		}
+		if len(values) > 0 {
+			out[name] = values
+		}
+	}
+	return out
+}
+
+// RelationVerdicts computes the sparse relation-level verdicts for e.
+func (r *PolicyResolver) RelationVerdicts(ctx context.Context, e *entity.Entity) RelationVerdicts {
+	out := RelationVerdicts{}
+	if e == nil || r.policy == nil {
+		return out
+	}
+	bc, roles := r.bindingFor(ctx, e)
+	if bc == nil {
+		return out
+	}
+
+	acc := newRelationAccumulator()
+	for _, role := range roles {
+		g := r.grants[grantKey{role, e.Type}]
+		if g == nil || !g.declaredRelations {
+			continue
+		}
+		for _, rg := range g.relations {
+			grantPassed := r.passes(bc, rg.program, role)
+			metaPassed := r.metaFieldResults(bc, role, rg, grantPassed)
+			acc.observe(role, rg, grantPassed, metaPassed)
+		}
+	}
+	out.Types = acc.verdicts()
+	return out
+}
+
+// bindingFor resolves the effective role set for (principal, entity)
+// and builds the binding context shared across grant evaluations for
+// this call. Returns nil bc when no policy roles apply.
+func (r *PolicyResolver) bindingFor(ctx context.Context, e *entity.Entity) (bc *bindingContext, roles []string) {
+	p := principal.From(ctx)
+	global := r.globalRoles(p)
+	roles = r.effectiveRoles(ctx, p, e, global)
+	if len(roles) == 0 {
+		return nil, nil
+	}
+	bc = &bindingContext{
+		principal:   p,
+		entity:      e,
+		globalRoles: global,
+		lookup:      r.lookup,
+		userID:      p.User,
+		resolver:    r,
+	}
+	return bc, roles
+}
+
+// passes reports whether a grant's predicate evaluates true. A nil
+// program is unconditional (true). A predicate runtime error fails
+// closed (false) with a slog.Warn for operator visibility (DR-S5).
+func (r *PolicyResolver) passes(bc *bindingContext, prog *predicate.Program, role string) bool {
+	if prog == nil {
+		return true
+	}
+	b, err := bc.newBindings(r.meta)
+	if err != nil {
+		slog.Warn("affordances: binding build failed; denying grant",
+			"role", role, "entity", bc.entity.ID, "error", err)
+		return false
+	}
+	v, err := prog.Eval(context.Background(), b)
+	if err != nil {
+		slog.Warn("affordances: predicate eval failed; denying grant",
+			"role", role, "entity", bc.entity.ID, "error", err)
+		return false
+	}
+	boolV, ok := v.(predicate.Bool)
+	if !ok {
+		slog.Warn("affordances: predicate did not return bool; denying grant",
+			"role", role, "entity", bc.entity.ID)
+		return false
+	}
+	return boolV.Bool()
+}
+
+// applyFieldGrants marks each granted field allowed when its predicate
+// passes. ruleKind is the denial-rule label ("read-only" or "hidden")
+// recorded in attribution for fields that end up denied.
+func (r *PolicyResolver) applyFieldGrants(
+	bc *bindingContext, role, ruleKind string, grants []compiledFieldGrant, dim *dimension,
+) {
+	dim.optIn(ruleKind)
+	for _, fg := range grants {
+		if r.passes(bc, fg.program, role) {
+			dim.allow(fg.field)
+		} else {
+			dim.observeDeny(fg.field, role)
+		}
+	}
+}
+
+func (r *PolicyResolver) applyOptionGrants(
+	bc *bindingContext, role string, grants []compiledOptionGrant, dim *optionDimension,
+) {
+	for _, og := range grants {
+		dim.optIn(og.field)
+		if r.passes(bc, og.program, role) {
+			dim.allow(og.field, og.option)
+		} else {
+			dim.observeDeny(og.field, og.option, role)
+		}
+	}
+}
+
+// metaFieldResults evaluates each meta-field grant's own predicate.
+// A meta field is allowed only when BOTH the whole-grant predicate
+// AND the meta-field predicate pass — a meta field can be more
+// restrictive than its relation grant, never less. Returns
+// field → passed.
+func (r *PolicyResolver) metaFieldResults(
+	bc *bindingContext, role string, rg compiledRelationGrant, grantPassed bool,
+) map[string]bool {
+	if len(rg.fields) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(rg.fields))
+	for _, fg := range rg.fields {
+		out[fg.field] = grantPassed && r.passes(bc, fg.program, role)
+	}
+	return out
+}

--- a/internal/affordances/resolver_test.go
+++ b/internal/affordances/resolver_test.go
@@ -1,0 +1,543 @@
+package affordances_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+
+	"gopkg.in/yaml.v3"
+)
+
+// stubLookup is a fake RelationLookup driven by in-memory edges.
+type stubLookup struct {
+	// edges["from|type|to"] = true
+	edges map[string]bool
+}
+
+func newStubLookup(edges ...[3]string) *stubLookup {
+	s := &stubLookup{edges: map[string]bool{}}
+	for _, e := range edges {
+		s.edges[e[0]+"|"+e[1]+"|"+e[2]] = true
+	}
+	return s
+}
+
+func (s *stubLookup) OutgoingCounts(_ context.Context, fromID string) map[string]int {
+	counts := map[string]int{}
+	for k := range s.edges {
+		parts := strings.SplitN(k, "|", 3)
+		if parts[0] == fromID {
+			counts[parts[1]]++
+		}
+	}
+	return counts
+}
+
+func (s *stubLookup) HasEdge(_ context.Context, fromID, relType, toID string) bool {
+	return s.edges[fromID+"|"+relType+"|"+toID]
+}
+
+// testMeta builds a minimal metamodel with a ticket type carrying the
+// properties the tests reference.
+func testMeta(t *testing.T) *metamodel.Metamodel {
+	t.Helper()
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Properties: map[string]metamodel.PropertyDef{
+					"title":      {Type: metamodel.PropertyTypeString},
+					"status":     {Type: metamodel.PropertyTypeEnum, Values: []string{"open", "review", "done"}},
+					"assignee":   {Type: metamodel.PropertyTypeString},
+					"priority":   {Type: metamodel.PropertyTypeInteger},
+					"tags":       {Type: metamodel.PropertyTypeString, List: true},
+					"is_blocked": {Type: metamodel.PropertyTypeBoolean},
+				},
+			},
+			"feature":   {Properties: map[string]metamodel.PropertyDef{"title": {Type: metamodel.PropertyTypeString}}},
+			"checklist": {Properties: map[string]metamodel.PropertyDef{"note": {Type: metamodel.PropertyTypeString}}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"implements":   {From: []string{"ticket"}, To: []string{"feature"}},
+			"blocks":       {From: []string{"ticket"}, To: []string{"ticket"}},
+			"has-planning": {From: []string{"ticket"}, To: []string{"checklist"}},
+		},
+	}
+}
+
+func policyFromYAML(t *testing.T, src string) *acl.Policy {
+	t.Helper()
+	var p acl.Policy
+	if err := yaml.Unmarshal([]byte(src), &p); err != nil {
+		t.Fatalf("unmarshal policy: %v", err)
+	}
+	return &p
+}
+
+// ctxAs builds a request context for the named principal. user varies
+// across the table even where current tests happen to use one value;
+// keeping it explicit documents which principal each case exercises.
+//
+//nolint:unparam // user is intentionally explicit per-test
+func ctxAs(user string) context.Context {
+	return principal.With(context.Background(),
+		principal.Principal{User: user, Tool: principal.ToolDataEntry})
+}
+
+func ticket(id string, props map[string]interface{}) *entity.Entity {
+	e := entity.New(id, "ticket")
+	for k, v := range props {
+		e.Properties[k] = v
+	}
+	return e
+}
+
+// AC2: a policy with no affordance blocks yields empty verdicts
+// (permissive default — byte-identical to Nop downstream).
+func TestResolver_NoAffordanceBlocks_EmptyVerdicts(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  admin: { write: ["*"] }
+assignments:
+  alice: admin
+`)
+	r, err := affordances.New(p, testMeta(t), newStubLookup())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	fv := r.FieldVerdicts(ctxAs("alice"), ticket("T-1", nil))
+	if fv.Writable != nil || fv.Visible != nil || fv.Options != nil {
+		t.Errorf("expected empty verdicts, got %+v", fv)
+	}
+}
+
+// AC3 + DR-C4: an opted-in fields block is closed-world. A granted
+// field with a passing predicate is writable; an unlisted field is
+// denied (writable=false).
+func TestResolver_FieldsClosedWorld(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: status
+assignments:
+  alice: triager
+`)
+	r, err := affordances.New(p, testMeta(t), newStubLookup())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	fv := r.FieldVerdicts(ctxAs("alice"), ticket("T-1", nil))
+
+	// status granted unconditionally → not in the deny map.
+	if _, denied := fv.Writable["status"]; denied {
+		t.Errorf("status should be writable (granted), got deny")
+	}
+	// title not granted → closed-world deny.
+	if v, ok := fv.Writable["title"]; !ok || v {
+		t.Errorf("title should be writable=false (closed-world), got ok=%v v=%v", ok, v)
+	}
+}
+
+// AC3: a field grant whose predicate evaluates false denies the field.
+func TestResolver_FieldPredicateFalse_Denies(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: status
+          when: "entity.assignee == current_user.id"
+assignments:
+  alice: triager
+`)
+	r, err := affordances.New(p, testMeta(t), newStubLookup())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// alice is NOT the assignee → status denied.
+	fv := r.FieldVerdicts(ctxAs("alice"), ticket("T-1", map[string]interface{}{"assignee": "bob"}))
+	if v, ok := fv.Writable["status"]; !ok || v {
+		t.Errorf("status should be denied (predicate false), got ok=%v v=%v", ok, v)
+	}
+
+	// alice IS the assignee → status writable (absent from deny map).
+	fv = r.FieldVerdicts(ctxAs("alice"), ticket("T-2", map[string]interface{}{"assignee": "alice"}))
+	if _, denied := fv.Writable["status"]; denied {
+		t.Errorf("status should be writable when predicate passes")
+	}
+}
+
+// AC4: an opted-in option grant filters disallowed options.
+func TestResolver_OptionFiltered(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    options:
+      ticket:
+        - field: status
+          option: open
+        - field: status
+          option: review
+assignments:
+  alice: triager
+`)
+	r, err := affordances.New(p, testMeta(t), newStubLookup())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	fv := r.FieldVerdicts(ctxAs("alice"), ticket("T-1", nil))
+
+	// "done" is not granted → denied; open/review granted → absent.
+	statusOpts := fv.Options["status"]
+	if v, ok := statusOpts["done"]; !ok || v {
+		t.Errorf("status=done should be denied, got ok=%v v=%v", ok, v)
+	}
+	if _, denied := statusOpts["open"]; denied {
+		t.Errorf("status=open should be allowed")
+	}
+}
+
+// AC5: a relation grant with create:false denies creation.
+func TestResolver_RelationCreateFalse(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    relations:
+      ticket:
+        - relation: implements
+          create: false
+          remove: true
+assignments:
+  alice: triager
+`)
+	r, err := affordances.New(p, testMeta(t), newStubLookup())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	rv := r.RelationVerdicts(ctxAs("alice"), ticket("T-1", nil))
+	v, ok := rv.Types["implements"]
+	if !ok {
+		t.Fatalf("implements verdict missing")
+	}
+	if v.Creatable {
+		t.Errorf("implements should not be creatable")
+	}
+	if !v.Removable {
+		t.Errorf("implements should be removable")
+	}
+}
+
+// DR-S3: cross-role union is monotonic. A user with two roles, one
+// granting status and one granting title, can write BOTH.
+func TestResolver_CrossRoleUnion(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  a:
+    fields:
+      ticket:
+        - field: status
+  b:
+    fields:
+      ticket:
+        - field: title
+  everyone:
+    fields:
+      ticket:
+        - field: status
+        - field: title
+assignments:
+  alice: a
+`)
+	// alice has role a + everyone. everyone grants both; a grants status.
+	// Union → both writable.
+	r, err := affordances.New(p, testMeta(t), newStubLookup())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	fv := r.FieldVerdicts(ctxAs("alice"), ticket("T-1", nil))
+	if _, denied := fv.Writable["status"]; denied {
+		t.Errorf("status should be writable via union")
+	}
+	if _, denied := fv.Writable["title"]; denied {
+		t.Errorf("title should be writable via everyone-role union")
+	}
+}
+
+// DR-C6: has_role with a local role conferred by a role-relation edge.
+func TestResolver_LocalRole_HasRole(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  owner:
+    fields:
+      ticket:
+        - field: status
+          when: "has_role(current_user, entity, 'owner')"
+assignments: {}
+role_relations:
+  owner-of:
+    confers: owner
+`)
+	// alice --owner-of--> T-1 confers owner on T-1.
+	lookup := newStubLookup([3]string{"alice", "owner-of", "T-1"})
+	r, err := affordances.New(p, testMeta(t), lookup)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// On T-1, alice is owner → status writable.
+	fv := r.FieldVerdicts(ctxAs("alice"), ticket("T-1", nil))
+	if _, denied := fv.Writable["status"]; denied {
+		t.Errorf("status should be writable: alice is owner of T-1")
+	}
+
+	// On T-2, alice is NOT owner → owner role doesn't apply, no grants,
+	// so no opted-in block → permissive (empty verdicts).
+	fv = r.FieldVerdicts(ctxAs("alice"), ticket("T-2", nil))
+	if len(fv.Writable) != 0 {
+		t.Errorf("T-2: expected no verdicts (owner role absent), got %+v", fv.Writable)
+	}
+}
+
+// DR-C7: has_global_role checks only assignment-based roles.
+func TestResolver_HasGlobalRole(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  admin: {}
+  triager:
+    visible:
+      ticket:
+        - field: assignee
+          when: "has_global_role(current_user, 'admin')"
+assignments:
+  alice: triager
+  bob: admin
+`)
+	r, err := affordances.New(p, testMeta(t), newStubLookup())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// alice is triager but not admin → assignee hidden.
+	fv := r.FieldVerdicts(ctxAs("alice"), ticket("T-1", nil))
+	if v, ok := fv.Visible["assignee"]; !ok || v {
+		t.Errorf("assignee should be hidden for non-admin alice, got ok=%v v=%v", ok, v)
+	}
+}
+
+// DR-C2: an off-type stored property (integer where string declared,
+// or vice versa) coerces to Nil rather than failing Eval and locking
+// the field. A predicate referencing it just sees nil.
+func TestResolver_OffTypeProperty_CoercesNotFails(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: status
+          when: "entity.priority == 5"
+assignments:
+  alice: triager
+`)
+	r, err := affordances.New(p, testMeta(t), newStubLookup())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// priority declared integer; store it as a string "5" — coerces to
+	// number 5, predicate passes, no Eval failure.
+	fv := r.FieldVerdicts(ctxAs("alice"), ticket("T-1", map[string]interface{}{"priority": "5"}))
+	if _, denied := fv.Writable["status"]; denied {
+		t.Errorf("status should be writable: priority '5' coerces to number 5")
+	}
+
+	// store a map where integer expected — coerces to Nil, predicate
+	// (nil == 5) is false → denied, but NO Eval error / no panic.
+	fv = r.FieldVerdicts(ctxAs("alice"),
+		ticket("T-2", map[string]interface{}{"priority": map[string]interface{}{"x": 1}}))
+	if v, ok := fv.Writable["status"]; !ok || v {
+		t.Errorf("status should be denied (priority uncoercible → nil != 5), got ok=%v v=%v", ok, v)
+	}
+}
+
+// A malformed predicate fails construction with the grant path in the
+// error (DR-S2 multi-error collection).
+func TestResolver_New_CompileError_IncludesPath(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: status
+          when: "entity.nonexistent_field == 1"
+`)
+	_, err := affordances.New(p, testMeta(t), newStubLookup())
+	if err == nil {
+		t.Fatal("expected compile error for unknown field reference")
+	}
+	if !contains(err.Error(), "roles.triager.fields.ticket[0].when") {
+		t.Errorf("error should include grant path, got: %v", err)
+	}
+}
+
+// S3 / RR-QV18: when two roles both deny the same field, the
+// attributed role is deterministic (first in sorted order), not
+// dependent on map iteration. Run repeatedly to catch flakiness.
+func TestResolver_MultiRoleDeny_DeterministicAttribution(t *testing.T) {
+	// Both zeta and alpha opt-in for status with a false predicate, so
+	// status is denied by both. Sorted order → "alpha" is attributed.
+	p := policyFromYAML(t, `
+roles:
+  zeta:
+    fields:
+      ticket:
+        - field: status
+          when: "entity.title == 'never-zeta'"
+  everyone:
+    fields:
+      ticket:
+        - field: status
+          when: "entity.title == 'never-everyone'"
+assignments:
+  alice: zeta
+`)
+	// alice holds zeta (assigned) + everyone (implicit). Both deny
+	// status. Effective roles sorted: everyone, zeta → "everyone" is
+	// the first denier and thus the attributed role.
+	r, err := affordances.New(p, testMeta(t), newStubLookup())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	var first string
+	for i := range 20 {
+		fv := r.FieldVerdicts(ctxAs("alice"), ticket("T-1", nil))
+		got := fv.Attribution["status"]
+		if got == "" {
+			t.Fatalf("expected attribution for denied status")
+		}
+		if i == 0 {
+			first = got
+		} else if got != first {
+			t.Fatalf("attribution flaky: run %d got %q, want stable %q", i, got, first)
+		}
+	}
+	// "everyone" sorts before "zeta", so it's the attributed (first) role.
+	if !contains(first, "role=everyone") {
+		t.Errorf("expected first sorted denier 'everyone', got %q", first)
+	}
+}
+
+// S2 / RR-RTJE: a field grant naming a property the metamodel doesn't
+// declare fails construction with the grant path — a typo can't
+// silently invert closed-world intent.
+func TestResolver_New_UnknownFieldTarget_Rejected(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: stauts
+`)
+	_, err := affordances.New(p, testMeta(t), newStubLookup())
+	if err == nil {
+		t.Fatal("expected error for unknown field target")
+	}
+	if !contains(err.Error(), "unknown field \"stauts\"") ||
+		!contains(err.Error(), "roles.triager.fields.ticket[0]") {
+
+		t.Errorf("error should name the bad field and path, got: %v", err)
+	}
+}
+
+// S2: an option grant on a non-declared option value is rejected.
+func TestResolver_New_UnknownOptionTarget_Rejected(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    options:
+      ticket:
+        - field: status
+          option: nonexistent
+`)
+	_, err := affordances.New(p, testMeta(t), newStubLookup())
+	if err == nil {
+		t.Fatal("expected error for unknown option")
+	}
+	if !contains(err.Error(), "not a declared value") {
+		t.Errorf("error should flag the bad option, got: %v", err)
+	}
+}
+
+// S2: a relation grant on a type the metamodel lacks is rejected.
+func TestResolver_New_UnknownRelationTarget_Rejected(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    relations:
+      ticket:
+        - relation: nonexistent-rel
+`)
+	_, err := affordances.New(p, testMeta(t), newStubLookup())
+	if err == nil {
+		t.Fatal("expected error for unknown relation type")
+	}
+	if !contains(err.Error(), "unknown relation type") {
+		t.Errorf("error should flag the bad relation, got: %v", err)
+	}
+}
+
+// S4: relation meta-field grants gate per-link meta writability, and a
+// failing meta predicate denies just that field (AND-ed with the
+// grant). Exercises the previously-untested relation_accum meta path.
+func TestResolver_RelationMetaField(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    relations:
+      ticket:
+        - relation: has-planning
+          fields:
+            - field: note
+              when: "entity.status == 'open'"
+assignments:
+  alice: triager
+`)
+	r, err := affordances.New(p, testMeta(t), newStubLookup())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// status=done → note meta-field denied (predicate false).
+	rv := r.RelationVerdicts(ctxAs("alice"), ticket("T-1", map[string]interface{}{"status": "done"}))
+	v, ok := rv.Types["has-planning"]
+	if !ok {
+		t.Fatalf("has-planning verdict missing")
+	}
+	if w, ok := v.Fields["note"]; !ok || w {
+		t.Errorf("note meta should be denied (predicate false), got ok=%v w=%v", ok, w)
+	}
+
+	// status=open → note meta-field allowed (sparse: absent from Fields,
+	// or the type itself fully permissive and absent from Types).
+	rv = r.RelationVerdicts(ctxAs("alice"), ticket("T-2", map[string]interface{}{"status": "open"}))
+	if v, ok := rv.Types["has-planning"]; ok {
+		if w, denied := v.Fields["note"]; denied && !w {
+			t.Errorf("note meta should be writable when predicate passes")
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/affordances/validate.go
+++ b/internal/affordances/validate.go
@@ -1,0 +1,75 @@
+package affordances
+
+import "fmt"
+
+// validateField checks that field is a declared property of entityType.
+// A typo'd field name would otherwise allow the bogus name and
+// closed-world DENY the real one (the inverse of intent), with no
+// startup error — so this fails loudly like a predicate compile error
+// (RR-RTJE / S2).
+func (r *PolicyResolver) validateField(roleName, entityType, block string, idx int, field string) error {
+	def, ok := r.meta.Entities[entityType]
+	if !ok {
+		return fmt.Errorf("roles.%s.%s.%s[%d]: unknown entity type %q",
+			roleName, block, entityType, idx, entityType)
+	}
+	if _, ok := def.Properties[field]; !ok {
+		return fmt.Errorf("roles.%s.%s.%s[%d]: unknown field %q on type %q",
+			roleName, block, entityType, idx, field, entityType)
+	}
+	return nil
+}
+
+// validateOption checks that field is an enum-typed property of
+// entityType and option is one of its declared values.
+func (r *PolicyResolver) validateOption(roleName, entityType string, idx int, field, option string) error {
+	def, ok := r.meta.Entities[entityType]
+	if !ok {
+		return fmt.Errorf("roles.%s.options.%s[%d]: unknown entity type %q",
+			roleName, entityType, idx, entityType)
+	}
+	prop, ok := def.Properties[field]
+	if !ok {
+		return fmt.Errorf("roles.%s.options.%s[%d]: unknown field %q on type %q",
+			roleName, entityType, idx, field, entityType)
+	}
+	values := prop.Values
+	if len(values) == 0 {
+		if ct, ok := r.meta.Types[prop.Type]; ok {
+			values = ct.Values
+		}
+	}
+	if len(values) == 0 {
+		return fmt.Errorf("roles.%s.options.%s[%d]: field %q on type %q is not enum-typed",
+			roleName, entityType, idx, field, entityType)
+	}
+	for _, v := range values {
+		if v == option {
+			return nil
+		}
+	}
+	return fmt.Errorf("roles.%s.options.%s[%d]: option %q is not a declared value of field %q",
+		roleName, entityType, idx, option, field)
+}
+
+// validateRelation checks that relType is a declared relation type
+// valid as an outgoing edge from entityType.
+func (r *PolicyResolver) validateRelation(roleName, entityType string, idx int, relType string) error {
+	rel, ok := r.meta.Relations[relType]
+	if !ok {
+		return fmt.Errorf("roles.%s.relations.%s[%d]: unknown relation type %q",
+			roleName, entityType, idx, relType)
+	}
+	// A relation grant on an entity type only gates outgoing edges of
+	// that type; require entityType to be a valid source.
+	if len(rel.From) > 0 {
+		for _, from := range rel.From {
+			if from == entityType {
+				return nil
+			}
+		}
+		return fmt.Errorf("roles.%s.relations.%s[%d]: relation %q does not originate from type %q",
+			roleName, entityType, idx, relType, entityType)
+	}
+	return nil
+}

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -71,6 +71,7 @@ type Services struct {
 	scriptEngine  *script.Engine
 	searchCloser  io.Closer
 	acl           acl.ACL
+	aclPolicy     *acl.Policy
 	audit         audit.Audit
 
 	closeOnce sync.Once
@@ -102,6 +103,13 @@ func (s *Services) EntityManager() entitymanager.EntityManager { return s.entity
 // without re-reading the file. The returned value is the exact ACL
 // the Manager consults.
 func (s *Services) ACL() acl.ACL { return s.acl }
+
+// ACLPolicy returns the *acl.Policy parsed from acl.yaml, or nil when
+// no policy file was present or the ACL was injected via [WithACL].
+// Exposed so the data-entry server can build the policy-backed
+// affordance resolver from the same policy the Manager authorizes
+// against, without re-reading the file.
+func (s *Services) ACLPolicy() *acl.Policy { return s.aclPolicy }
 
 // Audit returns the audit sink wired into entitymanager. Exposed so
 // dataentry handlers can emit `denied-write` rows for short-circuit
@@ -305,22 +313,24 @@ func WithACL(a acl.ACL) Option {
 }
 
 // loadACL reads `acl.yaml` from projectRoot and returns the
-// appropriate [acl.ACL] implementation. Missing file → [acl.NopACL]
-// (allow-all). Other load errors are logged and downgraded to
-// NopACL so a malformed policy never bricks the server — the
-// operator sees the error in logs and can fix the file without
-// restarting. This is the same "tolerate, warn" philosophy the
-// metamodel loader uses.
-func loadACL(projectRoot string) acl.ACL {
+// appropriate [acl.ACL] implementation plus, when one was parsed, the
+// underlying *acl.Policy (nil otherwise — the policy is retained so the
+// data-entry server can build a policy-backed affordance resolver from
+// the same source). Missing file → [acl.NopACL] (allow-all). Other
+// load errors are logged and downgraded to NopACL so a malformed
+// policy never bricks the server — the operator sees the error in logs
+// and can fix the file without restarting. Same "tolerate, warn"
+// philosophy the metamodel loader uses.
+func loadACL(projectRoot string) (acl.ACL, *acl.Policy) {
 	policy, err := acl.LoadPolicy(filepath.Join(projectRoot, "acl.yaml"))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return acl.NopACL{}
+			return acl.NopACL{}, nil
 		}
 		slog.Warn("appbuild: failed to load acl.yaml; falling back to NopACL", "error", err)
-		return acl.NopACL{}
+		return acl.NopACL{}, nil
 	}
-	return acl.NewDeclarative(policy)
+	return acl.NewDeclarative(policy), policy
 }
 
 // validateNewArgs nil-checks the four required collaborators of [New].
@@ -393,8 +403,9 @@ func New(
 	for _, opt := range opts {
 		opt(&o)
 	}
+	var aclPolicy *acl.Policy
 	if o.acl == nil {
-		o.acl = loadACL(paths.Root)
+		o.acl, aclPolicy = loadACL(paths.Root)
 	}
 
 	meta, _, err := metamodel.NewFSLoader(fs, paths.MetamodelPath).Load(context.Background())
@@ -471,6 +482,7 @@ func New(
 		scriptEngine:  scriptEngine,
 		searchCloser:  searchCloser,
 		acl:           o.acl,
+		aclPolicy:     aclPolicy,
 		audit:         auditSink,
 	}, nil
 }

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -112,6 +112,12 @@ type FieldVerdicts struct {
 	// field OR absence of an option means allowed. Used for enum-typed
 	// properties.
 	Options map[string]map[string]bool
+
+	// Attribution maps a denied path (field name, or "field=option")
+	// to the role/grant that produced the deny. Audit-only — never
+	// serialized to the wire. Sparse: only denials appear. Empty for
+	// resolvers (Nop / Demo) that don't track attribution.
+	Attribution map[string]string
 }
 
 // RelationVerdicts carries per-entity relation-level affordance
@@ -132,6 +138,11 @@ type RelationVerdict struct {
 	// uniformly to every link of this relation type (per-link
 	// affordances are predicate territory, deferred).
 	Fields map[string]bool
+
+	// Attribution maps a denied dimension ("create", "remove",
+	// "fields.<name>") to the role/grant that denied it. Audit-only,
+	// never serialized. Sparse.
+	Attribution map[string]string
 }
 
 // AffordanceDenialRule is the stable identifier surfaced in 403
@@ -160,6 +171,10 @@ type AffordanceDenialError struct {
 	Rule   AffordanceDenialRule
 	Path   string // property name, relation type, or "<relation-type>.<meta-field>"
 	Reason string
+	// Attribution names the role/grant that produced the deny, for the
+	// audit Summary channel (DR-C5). Empty for resolvers that don't
+	// track it. Never serialized to the wire 403 body.
+	Attribution string
 }
 
 // RuleID returns the wire-stable identifier for this denial.
@@ -220,17 +235,19 @@ func (a *App) validateFieldWrite(ctx context.Context, e *entityPkg.Entity, setKe
 		// Hidden via resolver verdict.
 		if !v.IsVisible(key) {
 			return &AffordanceDenialError{
-				Rule:   RuleFieldHidden,
-				Path:   key,
-				Reason: fmt.Sprintf("field %q is not visible", key),
+				Rule:        RuleFieldHidden,
+				Path:        key,
+				Reason:      fmt.Sprintf("field %q is not visible", key),
+				Attribution: v.Attribution[key],
 			}
 		}
 		// Read-only via resolver verdict.
 		if !v.IsWritable(key) {
 			return &AffordanceDenialError{
-				Rule:   RuleFieldReadOnly,
-				Path:   key,
-				Reason: fmt.Sprintf("field %q is not writable", key),
+				Rule:        RuleFieldReadOnly,
+				Path:        key,
+				Reason:      fmt.Sprintf("field %q is not writable", key),
+				Attribution: v.Attribution[key],
 			}
 		}
 		// Enum-filter (only for set, not unset, and only when a value
@@ -241,6 +258,9 @@ func (a *App) validateFieldWrite(ctx context.Context, e *entityPkg.Entity, setKe
 		if present && value != nil {
 			if opts, ok := v.Options[key]; ok {
 				if d := checkEnumOption(key, value, opts); d != nil {
+					// checkEnumOption sets Path to "field=option", the
+					// same key the resolver attributes options under.
+					d.Attribution = v.Attribution[d.Path]
 					return d
 				}
 			}
@@ -371,14 +391,18 @@ func (a *App) denyAffordance(ctx context.Context, w http.ResponseWriter, target 
 			ID:   target.ID,
 		}
 	}
+	summary := fmt.Sprintf("denied: %s (rule_kind=affordance rule_id=%s)",
+		denial.Reason, denial.RuleID())
+	if denial.Attribution != "" {
+		summary += " attribution=" + denial.Attribution
+	}
 	a.auditSink.Record(audit.Record{
 		Time:        time.Now().UTC(),
 		Op:          audit.OpDeniedWrite,
 		Subject:     subject,
 		Principal:   principal.From(ctx),
 		TriggeredBy: audit.TriggeredByFrom(ctx),
-		Summary: fmt.Sprintf("denied: %s (rule_kind=affordance rule_id=%s)",
-			denial.Reason, denial.RuleID()),
+		Summary:     summary,
 	})
 	writeAffordanceDenialError(w, denial)
 }
@@ -432,17 +456,19 @@ func (a *App) validateRelationOp(ctx context.Context, e *entityPkg.Entity, relTy
 	case RelationOpCreate:
 		if !rv.Creatable {
 			return &AffordanceDenialError{
-				Rule:   RuleRelationNotCreatable,
-				Path:   relType,
-				Reason: fmt.Sprintf("relation %q is not creatable", relType),
+				Rule:        RuleRelationNotCreatable,
+				Path:        relType,
+				Reason:      fmt.Sprintf("relation %q is not creatable", relType),
+				Attribution: rv.Attribution["create"],
 			}
 		}
 	case RelationOpRemove:
 		if !rv.Removable {
 			return &AffordanceDenialError{
-				Rule:   RuleRelationNotRemovable,
-				Path:   relType,
-				Reason: fmt.Sprintf("relation %q is not removable", relType),
+				Rule:        RuleRelationNotRemovable,
+				Path:        relType,
+				Reason:      fmt.Sprintf("relation %q is not removable", relType),
+				Attribution: rv.Attribution["remove"],
 			}
 		}
 	}
@@ -544,9 +570,10 @@ func (a *App) validateRelationMetaWrite(ctx context.Context, e *entityPkg.Entity
 	deny := func(key string) *AffordanceDenialError {
 		if writable, ok := rv.Fields[key]; ok && !writable {
 			return &AffordanceDenialError{
-				Rule:   RuleRelationMetaReadOnly,
-				Path:   relType + "." + key,
-				Reason: fmt.Sprintf("meta field %q on relation %q is not writable", key, relType),
+				Rule:        RuleRelationMetaReadOnly,
+				Path:        relType + "." + key,
+				Reason:      fmt.Sprintf("meta field %q on relation %q is not writable", key, relType),
+				Attribution: rv.Attribution["fields."+key],
 			}
 		}
 		return nil

--- a/internal/dataentry/affordances_policy.go
+++ b/internal/dataentry/affordances_policy.go
@@ -1,0 +1,88 @@
+package dataentry
+
+import (
+	"context"
+
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
+	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// policyResolver adapts an [affordances.Resolver] to the dataentry
+// [FieldVerdictResolver] interface. The affordances package returns
+// its own verdict types (it does not import dataentry, keeping the
+// dependency one-way); this adapter maps them onto the wire-shape
+// verdict types the serializer consumes. Deny attribution rides on
+// the verdict itself — the write path reads it from the freshly
+// computed verdict and stamps it into the audit Summary (DR-C5),
+// so there is no cross-request side table.
+type policyResolver struct {
+	inner *affordances.PolicyResolver
+}
+
+// FieldVerdicts maps affordances field verdicts onto the wire-shape
+// type, carrying the deny attribution through unchanged.
+func (p *policyResolver) FieldVerdicts(ctx context.Context, e *entityPkg.Entity) FieldVerdicts {
+	v := p.inner.FieldVerdicts(ctx, e)
+	return FieldVerdicts{
+		Writable:    v.Writable,
+		Visible:     v.Visible,
+		Options:     v.Options,
+		Attribution: v.Attribution,
+	}
+}
+
+// RelationVerdicts maps affordances relation verdicts onto the
+// wire-shape type. Each relation type's per-dimension attribution
+// ("create" / "remove" / "fields.<name>") is preserved.
+func (p *policyResolver) RelationVerdicts(ctx context.Context, e *entityPkg.Entity) RelationVerdicts {
+	v := p.inner.RelationVerdicts(ctx, e)
+	if len(v.Types) == 0 {
+		return RelationVerdicts{}
+	}
+	out := RelationVerdicts{Types: make(map[string]RelationVerdict, len(v.Types))}
+	for rt, rv := range v.Types {
+		out.Types[rt] = RelationVerdict{
+			Creatable:   rv.Creatable,
+			Removable:   rv.Removable,
+			Fields:      rv.Fields,
+			Attribution: rv.Attribution,
+		}
+	}
+	return out
+}
+
+// storeRelationLookup implements [affordances.RelationLookup] against a
+// store snapshot. It is built per resolver and queries the live store;
+// the resolver itself snapshots once per call by virtue of being
+// invoked once per per-entity GET (the App captures appState.Load() at
+// the top of each handler).
+type storeRelationLookup struct {
+	st store.Store
+}
+
+// OutgoingCounts tallies outgoing edges by type in a single scan.
+func (l storeRelationLookup) OutgoingCounts(ctx context.Context, fromID string) map[string]int {
+	counts := map[string]int{}
+	for rel, err := range l.st.ListRelations(ctx, store.RelationQuery{
+		From: fromID, Direction: store.DirectionOutgoing,
+	}) {
+		if err != nil || rel == nil {
+			continue
+		}
+		counts[rel.Type]++
+	}
+	return counts
+}
+
+func (l storeRelationLookup) HasEdge(ctx context.Context, fromID, relType, toID string) bool {
+	for rel, err := range l.st.ListRelations(ctx, store.RelationQuery{
+		From: fromID, Type: relType, To: toID, Direction: store.DirectionOutgoing,
+	}) {
+		if err != nil || rel == nil {
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/internal/dataentry/affordances_policy_test.go
+++ b/internal/dataentry/affordances_policy_test.go
@@ -1,0 +1,237 @@
+package dataentry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+
+	"gopkg.in/yaml.v3"
+)
+
+// buildPolicyApp wires a real affordances.Resolver (compiled from the
+// given acl.yaml source) behind the dataentry policyResolver, sharing
+// the App's store as the relation lookup. This exercises the full
+// production chain end-to-end: acl.yaml → affordances.New →
+// policyResolver → wire shape / 403 / audit.
+func buildPolicyApp(t *testing.T, aclYAML string, sink audit.Audit) *App {
+	t.Helper()
+	app := buildAppWithACLAndAudit(t, acl.NopACL{}, sink)
+
+	var policy acl.Policy
+	if err := yaml.Unmarshal([]byte(aclYAML), &policy); err != nil {
+		t.Fatalf("unmarshal acl.yaml: %v", err)
+	}
+	resolver, err := affordances.New(&policy, app.Meta(), storeRelationLookup{st: app.store})
+	if err != nil {
+		t.Fatalf("affordances.New: %v", err)
+	}
+	app.fieldResolver = &policyResolver{inner: resolver}
+	return app
+}
+
+func patchAs(t *testing.T, app *App, user, id, body string) (status int, respBody string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/"+id, strings.NewReader(body))
+	req = req.WithContext(principal.With(req.Context(),
+		principal.Principal{User: user, Tool: principal.ToolDataEntry}))
+	rec := httptest.NewRecorder()
+	app.handleV1UpdateEntity(rec, req, "ticket", "tickets", id)
+	return rec.Code, rec.Body.String()
+}
+
+func getAs(t *testing.T, app *App, user, id string) V1Entity {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/"+id, http.NoBody)
+	req = req.WithContext(principal.With(req.Context(),
+		principal.Principal{User: user, Tool: principal.ToolDataEntry}))
+	rec := httptest.NewRecorder()
+	app.handleV1GetEntity(rec, req, "ticket", "tickets", id)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s: got %d, want 200; body=%s", id, rec.Code, rec.Body.String())
+	}
+	var e V1Entity
+	if err := json.NewDecoder(rec.Body).Decode(&e); err != nil {
+		t.Fatalf("decode GET: %v", err)
+	}
+	return e
+}
+
+// AC3 end-to-end: a field grant whose predicate evaluates false yields
+// _fields.status.writable=false on GET AND a 403 on the PATCH, with
+// the TKT-G7N5 wire rule_id (DR-C5 — not a new rule_kind).
+func TestPolicyResolver_FieldPredicate_WireAndWrite(t *testing.T) {
+	const aclYAML = `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: status
+          when: "entity.title == 'editable'"
+assignments:
+  alice: triager
+`
+	app := buildPolicyApp(t, aclYAML, nil)
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "locked", "status": "open"},
+	})
+
+	// GET: status is denied (title != "editable") → writable=false.
+	got := getAs(t, app, "alice", "TKT-001")
+	if got.FieldAffordances == nil {
+		t.Fatal("FieldAffordances nil")
+	}
+	fa := *got.FieldAffordances
+	if w := fa["status"].Writable; w == nil || *w {
+		t.Errorf("status.writable: got %v, want *false", w)
+	}
+
+	// PATCH status → 403 with the TKT-G7N5 wire rule_id.
+	code, body := patchAs(t, app, "alice", "TKT-001", `{"properties":{"status":"closed"}}`)
+	if code != http.StatusForbidden {
+		t.Fatalf("PATCH: got %d, want 403; body=%s", code, body)
+	}
+	if !strings.Contains(body, `"field-affordance:read-only:status"`) {
+		t.Errorf("body must carry the TKT-G7N5 rule_id, got: %s", body)
+	}
+	// The external body must NOT leak the role/predicate attribution.
+	if strings.Contains(body, "role=triager") || strings.Contains(body, "attribution") {
+		t.Errorf("wire body leaked attribution: %s", body)
+	}
+}
+
+// DR-C5 two-channel: the audit Summary carries the role attribution the
+// wire body withholds.
+func TestPolicyResolver_AuditCarriesAttribution(t *testing.T) {
+	const aclYAML = `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: status
+          when: "entity.title == 'editable'"
+assignments:
+  alice: triager
+`
+	sink := audit.NewMemory()
+	app := buildPolicyApp(t, aclYAML, sink)
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "locked", "status": "open"},
+	})
+
+	// PATCH directly, with NO prior GET — attribution rides on the
+	// write-path verdict, not a GET-populated side table (RR-1DRR).
+	code, _ := patchAs(t, app, "alice", "TKT-001", `{"properties":{"status":"closed"}}`)
+	if code != http.StatusForbidden {
+		t.Fatalf("PATCH: got %d, want 403", code)
+	}
+	records := sink.Records()
+	if len(records) != 1 {
+		t.Fatalf("audit records: got %d, want 1", len(records))
+	}
+	sum := records[0].Summary
+	if !strings.Contains(sum, "rule_id=field-affordance:read-only:status") {
+		t.Errorf("audit summary missing wire rule_id: %q", sum)
+	}
+	if !strings.Contains(sum, "attribution=") || !strings.Contains(sum, "role=triager") {
+		t.Errorf("audit summary missing role attribution: %q", sum)
+	}
+}
+
+// AC5 end-to-end: a relation grant with create:false yields
+// _relations.depends_on.creatable=false AND a 403 on the actual
+// relation-create POST (S5: drive the write, not just the wire shape).
+func TestPolicyResolver_RelationCreate_WireAndWrite(t *testing.T) {
+	const aclYAML = `
+roles:
+  triager:
+    relations:
+      ticket:
+        - relation: depends_on
+          create: false
+          remove: true
+assignments:
+  alice: triager
+`
+	app := buildPolicyApp(t, aclYAML, nil)
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "x", "status": "open"},
+	})
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-002",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "y", "status": "open"},
+	})
+
+	// Wire shape: creatable=false (sparse).
+	got := getAs(t, app, "alice", "TKT-001")
+	if got.RelationAffordances == nil {
+		t.Fatal("RelationAffordances nil")
+	}
+	dep, ok := (*got.RelationAffordances)["depends_on"]
+	if !ok {
+		t.Fatalf("depends_on affordance missing; got %+v", *got.RelationAffordances)
+	}
+	if dep.Creatable == nil || *dep.Creatable {
+		t.Errorf("depends_on.creatable: got %v, want *false", dep.Creatable)
+	}
+	if dep.Removable != nil && !*dep.Removable {
+		t.Errorf("depends_on.removable: got *false, want allowed (nil or *true)")
+	}
+
+	// Write: POST .../relations/depends_on → 403 with the create rule_id.
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/tickets/TKT-001/relations/depends_on",
+		strings.NewReader(`{"id":"TKT-002"}`))
+	req = req.WithContext(principal.With(req.Context(),
+		principal.Principal{User: "alice", Tool: principal.ToolDataEntry}))
+	rec := httptest.NewRecorder()
+	app.handleV1CreateRelation(rec, req, "ticket", "TKT-001", "depends_on")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("create POST: got %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "relation-affordance:not-creatable:depends_on") {
+		t.Errorf("body must carry the not-creatable rule_id, got: %s", rec.Body.String())
+	}
+}
+
+// AC2 end-to-end: a policy with no affordance blocks produces no
+// _fields / _relations deviations — byte-identical to the Nop resolver.
+func TestPolicyResolver_NoAffordanceBlocks_PermissiveWire(t *testing.T) {
+	// HasAffordanceGrants is false here, so ResolverFromProfile would
+	// pick Nop. We assert the resolver path directly: a write-only
+	// policy run through affordances.New yields empty verdicts.
+	const aclYAML = `
+roles:
+  admin: { write: ["*"] }
+assignments:
+  alice: admin
+`
+	app := buildPolicyApp(t, aclYAML, nil)
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]interface{}{"title": "x", "status": "open"},
+	})
+
+	got := getAs(t, app, "alice", "TKT-001")
+	if got.FieldAffordances != nil && len(*got.FieldAffordances) != 0 {
+		t.Errorf("expected no field affordances, got %+v", *got.FieldAffordances)
+	}
+	if got.RelationAffordances != nil && len(*got.RelationAffordances) != 0 {
+		t.Errorf("expected no relation affordances, got %+v", *got.RelationAffordances)
+	}
+}

--- a/internal/dataentry/affordances_stub.go
+++ b/internal/dataentry/affordances_stub.go
@@ -2,18 +2,26 @@ package dataentry
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"os"
 
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
-// AffordanceProfile names a verdict-source preset. v1 ships two:
-// "none" (permissive default) and "demo" (a fixture against the
-// ticket type that exercises every affordance code path).
+// AffordanceProfile names a verdict-source preset. "none" is the
+// permissive default; "demo" is a fixture against the ticket type
+// exercising every affordance code path. Absent an explicit profile,
+// a policy carrying affordance grants selects the policy-backed
+// resolver.
 //
-// The env var RELA_AFFORDANCE_PROFILE selects between them at
-// startup. cmd/rela-server and cmd/rela-desktop parse the var and
-// pass the resolver into NewApp; tests pass the resolver directly.
+// The env var RELA_AFFORDANCE_PROFILE selects the override at startup.
+// cmd/rela-server and cmd/rela-desktop parse the var and pass the
+// resolver into NewApp; tests pass the resolver directly.
 type AffordanceProfile string
 
 const (
@@ -21,23 +29,65 @@ const (
 	AffordanceProfileDemo AffordanceProfile = "demo"
 )
 
-// ResolverFromProfile returns the [FieldVerdictResolver] for the named
-// profile. An empty string or "none" yields [NopFieldVerdictResolver].
-// An unknown profile name logs a warning and falls back to none —
-// never panics, never errors. Operators see the warning at startup
-// and can correct the env var.
-func ResolverFromProfile(profile string) FieldVerdictResolver {
+// ResolverFromProfile returns the [FieldVerdictResolver] for the given
+// profile, policy, and metamodel. Selection order (DR-M3):
+//
+//  1. profile == "demo" → [DemoFieldVerdictResolver] (hard override,
+//     for dev / e2e fixtures even when a policy is present).
+//  2. profile == "none" → [NopFieldVerdictResolver] (hard opt-out).
+//  3. profile == "" and the policy declares any affordance grants →
+//     the policy-backed resolver.
+//  4. otherwise → [NopFieldVerdictResolver].
+//
+// An unknown profile logs a warning and falls back to step 3/4. A
+// policy-backed resolver whose predicates fail to compile returns an
+// error — the caller fails startup loudly (DR-M4), matching the
+// acl.yaml hard-fail posture for genuinely broken config.
+func ResolverFromProfile(
+	profile string, policy *acl.Policy, meta *metamodel.Metamodel, st store.Store,
+) (FieldVerdictResolver, error) {
 	switch AffordanceProfile(profile) {
-	case "", AffordanceProfileNone:
-		return NopFieldVerdictResolver{}
 	case AffordanceProfileDemo:
-		return DemoFieldVerdictResolver{}
+		return DemoFieldVerdictResolver{}, nil
+	case AffordanceProfileNone:
+		return NopFieldVerdictResolver{}, nil
+	case "":
+		// fall through to policy-based selection
 	default:
-		slog.Warn("dataentry: unknown RELA_AFFORDANCE_PROFILE; using 'none'",
+		slog.Warn("dataentry: unknown RELA_AFFORDANCE_PROFILE; using policy or 'none'",
 			"value", profile,
 			"allowed", []string{string(AffordanceProfileNone), string(AffordanceProfileDemo)})
-		return NopFieldVerdictResolver{}
 	}
+
+	if policy == nil || !policy.HasAffordanceGrants() {
+		return NopFieldVerdictResolver{}, nil
+	}
+	resolver, err := affordances.New(policy, meta, storeRelationLookup{st: st})
+	if err != nil {
+		return nil, fmt.Errorf("dataentry: compiling acl.yaml affordance predicates: %w", err)
+	}
+	return &policyResolver{inner: resolver}, nil
+}
+
+// ResolverServices is the slice of [appbuild.Services] that
+// [ResolverFromServices] needs. Declared here at the call site so the
+// entry points pass `svc` directly without each re-spelling the
+// env-read + three accessors.
+type ResolverServices interface {
+	ACLPolicy() *acl.Policy
+	Meta() *metamodel.Metamodel
+	Store() store.Store
+}
+
+// ResolverFromServices builds the affordance resolver for an entry
+// point, reading RELA_AFFORDANCE_PROFILE from the environment and the
+// policy / metamodel / store from svc. Both cmd entry points call this;
+// they differ only in how they handle the returned error (rela-server
+// exits, rela-desktop surfaces it to the UI), so error handling stays
+// at the call site.
+func ResolverFromServices(svc ResolverServices) (FieldVerdictResolver, error) {
+	return ResolverFromProfile(
+		os.Getenv("RELA_AFFORDANCE_PROFILE"), svc.ACLPolicy(), svc.Meta(), svc.Store())
 }
 
 // NopFieldVerdictResolver returns empty verdicts for every entity.

--- a/internal/dataentry/affordances_test.go
+++ b/internal/dataentry/affordances_test.go
@@ -164,10 +164,14 @@ func TestComputeActions_NoAuditNoise(t *testing.T) {
 	}
 }
 
+// With no policy, "" and "none" both yield the permissive Nop.
 func TestResolverFromProfile_None(t *testing.T) {
 	for _, in := range []string{"", "none"} {
 		t.Run(in, func(t *testing.T) {
-			r := ResolverFromProfile(in)
+			r, err := ResolverFromProfile(in, nil, nil, nil)
+			if err != nil {
+				t.Fatalf("ResolverFromProfile(%q): %v", in, err)
+			}
 			if _, ok := r.(NopFieldVerdictResolver); !ok {
 				t.Fatalf("ResolverFromProfile(%q): got %T, want NopFieldVerdictResolver", in, r)
 			}
@@ -175,17 +179,25 @@ func TestResolverFromProfile_None(t *testing.T) {
 	}
 }
 
+// "demo" is a hard override — selected even when a policy with
+// affordance grants is present (AC6).
 func TestResolverFromProfile_Demo(t *testing.T) {
-	r := ResolverFromProfile("demo")
+	r, err := ResolverFromProfile("demo", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ResolverFromProfile(demo): %v", err)
+	}
 	if _, ok := r.(DemoFieldVerdictResolver); !ok {
 		t.Fatalf("ResolverFromProfile(demo): got %T, want DemoFieldVerdictResolver", r)
 	}
 }
 
-func TestResolverFromProfile_Unknown_FallsBackToNone(t *testing.T) {
-	// Unknown values must not panic and must fall back to none. The
-	// warning log is observable in stderr; we don't capture it here.
-	r := ResolverFromProfile("not-a-real-profile")
+func TestResolverFromProfile_Unknown_FallsBackToPolicyOrNone(t *testing.T) {
+	// Unknown values must not panic and (absent a policy) fall back to
+	// none. The warning log is observable in stderr; not captured here.
+	r, err := ResolverFromProfile("not-a-real-profile", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unknown profile: %v", err)
+	}
 	if _, ok := r.(NopFieldVerdictResolver); !ok {
 		t.Fatalf("unknown profile: got %T, want NopFieldVerdictResolver", r)
 	}

--- a/tickets/entities/docs-checklists/DOCS-Z3XV.md
+++ b/tickets/entities/docs-checklists/DOCS-Z3XV.md
@@ -1,0 +1,37 @@
+---
+id: DOCS-Z3XV
+type: docs-checklist
+title: 'Documentation: predicate-backed affordances'
+status: done
+---
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — package doc on
+`internal/affordances`; consumer-side `RelationLookup` interface documented at
+the call site; coercion fail-soft choices documented on `coerceList`; the
+nil-program "unconditional grant" sentinel and the `//nolint:nilnil` rationale
+documented on `compile`.
+- [x] Function/type docs if public API — `Resolver`, `New`,
+`FieldVerdicts`/`RelationVerdicts`, the acl.yaml grant types
+(`FieldGrant`/`OptionGrant`/`RelationGrant`), and `Policy.HasAffordanceGrants`
+all carry doc comments.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: no project-level surface change)
+- [ ] ~~CLAUDE.md updated~~ (N/A: no new cross-cutting pattern;
+the consumer-side-interface and capability-bundle patterns the code follows are
+already documented there)
+- [x] ~~Help text accurate~~ (N/A: no CLI command changes; the only
+knob is the existing `RELA_AFFORDANCE_PROFILE` env var, documented in
+security.md + api-reference.md)
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: project has no CHANGELOG file)
+- [x] API docs updated — `docs/data-entry/api-reference.md` verdict-
+source table now documents the policy-backed source and links to the security
+model; `docs/security.md` gained the full "Field- and relation-level
+affordances" reference (acl.yaml schema, predicate language, semantics, profile
+selection).

--- a/tickets/entities/implementation-checklists/IMPL-G522.md
+++ b/tickets/entities/implementation-checklists/IMPL-G522.md
@@ -1,0 +1,95 @@
+---
+id: IMPL-G522
+type: implementation-checklist
+title: 'Implementation: ACL: predicate-backed _fields and _relations resolver (replace stub)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature verified end-to-end via HTTP-level integration tests
+  (`affordances_policy_test.go`): real `affordances.New` →
+  `policyResolver` → GET wire shape + PATCH 403 + audit attribution.
+- [ ] ~~Browser/SPA manual test~~ (deferred to review phase: the SPA
+  renderer is unchanged from TKT-G7N5, which was browser-verified;
+  this ticket only swaps the verdict source, exercised by the
+  HTTP integration tests. A demo-profile browser pass can confirm
+  during `/code-review` if desired.)
+- [x] Each acceptance criterion verified with a test scenario:
+  - AC1 — `policy_test.go` parse + `resolver_test.go`
+    `TestResolver_New_CompileError_IncludesPath`
+  - AC2 — `TestResolver_NoAffordanceBlocks_EmptyVerdicts` +
+    `TestPolicyResolver_NoAffordanceBlocks_PermissiveWire`
+  - AC3 — `TestResolver_FieldPredicateFalse_Denies` +
+    `TestPolicyResolver_FieldPredicate_WireAndWrite`
+  - AC4 — `TestResolver_OptionFiltered`
+  - AC5 — `TestResolver_RelationCreateFalse` +
+    `TestPolicyResolver_RelationCreate_WireShape`
+  - AC6 — `TestResolverFromProfile_Demo`
+  - AC7 — wire-parity exercised via the policy integration tests
+    against the same handlers TKT-G7N5's contract test covers
+- [x] Edge cases verified: off-type coercion
+  (`TestResolver_OffTypeProperty_CoercesNotFails`), cross-role
+  union (`TestResolver_CrossRoleUnion`), local roles
+  (`TestResolver_LocalRole_HasRole`), global-role
+  (`TestResolver_HasGlobalRole`), YAML empty/null/absent
+  (`TestLoadPolicy_AffordanceGrants_OptInIsKeyPresence`),
+  `*bool` forms (`TestLoadPolicy_RelationGrant_CreateRemovePointers`).
+
+**Verification Evidence:**
+
+- `just check` (lint + arch-lint + lint-md + test, race-enabled) — PASS
+- `just coverage-check` — PASS (total 76.7%; `internal/affordances` 79%)
+- `just build` — all binaries build
+- `go-arch-lint` — new `affordances` component boundaries clean;
+  `dataentry → affordances` edge declared
+- DR-C5 two-channel verified: `TestPolicyResolver_AuditCarriesAttribution`
+  asserts the wire 403 body has no role/predicate while the audit
+  Summary carries `role=triager`.
+
+**Deferred to review/follow-up (documented, not silently dropped):**
+
+- DR-S1 metamodel-hot-reload regression test — behavior is
+  documented (restart required); a dedicated regression test is a
+  nice-to-have, not load-bearing for correctness.
+- DR-S5 perf microbench — predicate step budget bounds cost; no
+  caching in v1 per plan ("measure first"). Bench can be added if
+  perf becomes a concern.
+- DR-L3 audit-invariant integration test (every denial kind →
+  one JSONL row) — the audit emission path is shared with
+  TKT-G7N5's existing audit test; the new attribution test covers
+  the field-deny path.
+
+## Quality
+
+- [x] Code follows project patterns (consumer-side `RelationLookup`
+  interface at the call site; capability-scoped; sparse verdicts
+  mirror TKT-G7N5; `errors.Join` for multi-error).
+- [x] Checked for DRY opportunities — `FieldGrant` reused for
+  relation-meta grants (DR-S6); `roleHasAffordanceGrants` helper;
+  `recordAttribution` shared.
+- [x] No security issues introduced — predicates are sandboxed
+  (predicate package), fail-closed on error, operator-supplied
+  only; no user Lua on the read path.
+- [x] No silent failures — compile errors abort startup; runtime
+  predicate errors log + deny.
+- [x] No debug code left behind (temporary round-trip debug test
+  removed).

--- a/tickets/entities/planning-checklists/PLAN-K0SF.md
+++ b/tickets/entities/planning-checklists/PLAN-K0SF.md
@@ -1,0 +1,864 @@
+---
+id: PLAN-K0SF
+type: planning-checklist
+title: 'Planning: ACL: predicate-backed _fields and _relations resolver (replace stub)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem.** TKT-G7N5 shipped a hardcoded fixture
+(`DemoFieldVerdictResolver`) that proves the wire shape + SPA
+renderer end-to-end, but the verdict source is dev-only — every
+deployment runs `RELA_AFFORDANCE_PROFILE=none` and gets zero
+affordance gates. We need a real policy-driven source so operators
+can declare, in `acl.yaml`, which roles may write which fields
+under which predicates.
+
+**Scope (IS):**
+
+- Extend `acl.yaml` schema: `RoleDef` gains optional `fields:`,
+  `visible:`, `options:`, `relations:` blocks per entity type;
+  each grant carries an optional `when:` single-string predicate.
+- New package `internal/acl/affordances/` exporting a `Resolver`
+  that satisfies `dataentry.FieldVerdictResolver`.
+- Compile predicates at policy load via `internal/predicate`
+  (TKT-2QI1); compile errors fail load with `slog.Error`.
+- Wire into entry points: `cmd/rela-server`, `cmd/rela-desktop`
+  select between Demo (env var override), policy-backed
+  (acl.yaml has any affordance block), and Nop (default).
+- Re-use the existing `denyAffordance` audit chokepoint; expose
+  the rule_id format `<role>/<field-or-relation>` via the
+  resolver's verdict metadata.
+- Re-use the wire-parity contract test from TKT-G7N5 against a
+  fixture `acl.yaml`.
+
+**Scope (IS NOT):**
+
+- Reactive predicates in the SPA (separate ticket if needed —
+  PATCH already round-trips `_fields` per response).
+- List-query field-level filtering (deferred by TKT-G7N5).
+- Per-link relation affordances (needs wire-shape change).
+- Parameterised verbs `transition:done` / `relation:foo:add`
+  (TKT-XZEY).
+- Read-side property redaction (needs ACL v1 read path).
+- Group expansion, transitive role-relations (ACL v1 territory).
+- Inherited local roles via `inherit_roles_through` (depth-capped
+  graph walk). v1 resolves DIRECT local roles only — a role
+  conferred by a `role_relations` edge straight from the principal
+  to the evaluated entity. Inheritance is ACL-v1 (DR-C6).
+
+**Acceptance Criteria:** (re-stated from ticket, with concrete test mapping below)
+
+1. AC1 — acl.yaml parses new blocks; predicates compile at
+   load; compile errors fail with `slog.Error`.
+2. AC2 — sparse emission; absent affordance blocks = byte-identical
+   wire to Nop.
+3. AC3 — field `when:` false ⇒ `writable=false` AND 403 on write
+   with `rule_kind=affordance:predicate`, `rule_id=<role>/<field>`.
+4. AC4 — option `when:` false ⇒ `options[opt]=false` AND 403 on
+   write setting that option.
+5. AC5 — relation `create:false`/`when:` false ⇒
+   `creatable=false` AND 403 on every relation-create chokepoint.
+6. AC6 — `RELA_AFFORDANCE_PROFILE=demo` still selects
+   `DemoFieldVerdictResolver`; e2e demo tests keep working.
+7. AC7 — wire-parity contract test from TKT-G7N5 passes against
+   fixture acl.yaml.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+- **`internal/predicate` (TKT-2QI1)** — done. Public API:
+  `predicate.NewEnv()`, `Env.DeclareVar(name, Type)`,
+  `Env.DeclareFunc(name, FuncSig)`, `predicate.Compile(env,
+  source) (*Program, error)`, `Program.Eval(ctx, *Bindings)
+  (Value, error)`. Programs are immutable + safe for concurrent
+  Eval; Bindings built per-call. Numeric model = float64;
+  RecordType for entity, primitive types for scalars.
+  `internal/predicate/doc.go:1` and `env.go:11-180`.
+- **`internal/acl.LoadPolicy`** (`internal/acl/policy.go:89`) —
+  tolerant YAML loader: warn-and-continue on unknown top-level
+  keys; hard error on unparseable YAML. `knownPolicyKeys` map
+  drives the warnings (`policy.go:71`). Pattern to follow for
+  unknown sub-keys under `fields:` / `options:` / `relations:`.
+- **`acl.Declarative`** (`internal/acl/declarative.go:30`) — the
+  existing policy-driven ACL implementation. Pattern: holds
+  `*Policy`, evaluates per-request against the principal carried
+  on ctx, returns structured `Decision`. The new affordance
+  resolver mirrors this pattern: hold compiled programs + role
+  index, evaluate per (principal, entity).
+- **`dataentry.FieldVerdictResolver`** interface
+  (`internal/dataentry/affordances.go:93`) — the contract we
+  satisfy. Returns `FieldVerdicts{Writable, Visible, Options}`
+  and `RelationVerdicts{Types}`. Both sparse — only deviations
+  populated. **Critical:** absence of a `Writable[name]` entry
+  means default-allowed; the policy must explicitly set `false`
+  to deny.
+- **Existing wire-vs-policy contract test** in
+  `internal/dataentry/affordances_test.go` (`affordances_contract_test.go`
+  per CLAUDE.md). Re-use against a fixture `acl.yaml`.
+- **`App.denyAffordance`** (`affordances.go:365`) — the
+  chokepoint that writes 403 + emits `denied-write` audit. Used
+  from six call sites in `api_v1.go`. The current rule_id is
+  derived from `AffordanceDenialError.RuleID()` =
+  `<rule>:<path>` where `rule` is one of
+  `field-affordance:hidden`, `:read-only`, `:enum-filtered`,
+  etc. **Decision below:** keep this wire format; the policy
+  source surfaces as additional context in `Reason` and an
+  optional second segment in `Path`, not as a new rule prefix.
+
+**Why not a different evaluator (CEL, expr, EDN)?** TKT-2QI1
+already settled this — predicate is in the binary, type-checked,
+sandboxed, with familiar Lua-expression syntax. No re-litigation.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+### 1. `acl.yaml` schema extension
+
+Extend `acl.RoleDef` in `internal/acl/policy.go`:
+
+```go
+type RoleDef struct {
+    Write       []string `yaml:"write"`
+    Read        []string `yaml:"read"`
+    Permissions []string `yaml:"permissions"`
+    // NEW: affordance grants, all optional and opt-in.
+    Fields    map[string][]FieldGrant    `yaml:"fields"`
+    Visible   map[string][]FieldGrant    `yaml:"visible"`
+    Options   map[string][]OptionGrant   `yaml:"options"`
+    Relations map[string][]RelationGrant `yaml:"relations"`
+}
+
+type FieldGrant struct {
+    Field string `yaml:"field"`
+    When  string `yaml:"when,omitempty"`
+}
+
+type OptionGrant struct {
+    Field  string `yaml:"field"`
+    Option string `yaml:"option"`
+    When   string `yaml:"when,omitempty"`
+}
+
+type RelationGrant struct {
+    Relation string             `yaml:"relation"`
+    Create   *bool              `yaml:"create,omitempty"`
+    Remove   *bool              `yaml:"remove,omitempty"`
+    Fields   []RelationMetaGrant `yaml:"fields,omitempty"`
+    When     string             `yaml:"when,omitempty"`
+}
+
+type RelationMetaGrant struct {
+    Field string `yaml:"field"`
+    When  string `yaml:"when,omitempty"`
+}
+```
+
+Pointer-to-bool for `Create`/`Remove` distinguishes "unset" (use
+default — allow if there's a grant at all) from "explicit
+false". Default when only `When` is set: both `create` and
+`remove` are true (grant exists → operations allowed if the
+predicate passes).
+
+### 2. New package `internal/acl/affordances/`
+
+Files:
+
+- `resolver.go` — `Resolver` struct + `New(policy *acl.Policy, meta *metamodel.Metamodel) (*Resolver, error)`. Compiles every `when:` predicate at construction time (collects all errors, returns the first wrapped with full path: `roles.triager.fields.ticket[0].when: <err>`). Builds an index of `(roleName, entityType) → []compiledFieldGrant` etc.
+- `env.go` — Per-entity-type `*predicate.Env` builder: declares `entity` as `RecordType` over the metamodel's properties for that type (string for string/enum/date/rrule, number for integer, bool for boolean — list types map to `ListType{Elem}`), `current_user` as `RecordType{id: string, type: string}`, and host funcs `has_role` (3-arg, entity-scoped — DR-C6), `has_global_role` (DR-C7), `has_relation`, `count_relations`, `string_in_list` with their signatures.
+- `bindings.go` — Per-call binding builder: snapshots the entity's properties into a `predicate.Record`, snapshots the principal into `current_user`, and wires the host funcs against the actual store/graph snapshot.
+- `resolver_test.go` — Unit tests for the verdict-computation path: each grant kind, sparse emission, `when:` evaluation.
+- `acl_yaml_test.go` — Round-trip tests: parse a fixture acl.yaml, build resolver, assert verdicts on synthetic entities.
+
+`Resolver.FieldVerdicts(ctx, e)` and `Resolver.RelationVerdicts(ctx, e)`:
+
+1. Look up the principal from ctx via `principal.From`.
+2. Compute the `(principal, e)` effective role set (DR-C6):
+   global roles (`Assignments[user]` ∪ `"default"`, the existing
+   `Declarative.effectiveRoles` logic) PLUS direct local roles —
+   for each `role_relations` type R with `Confers: X`, if the
+   snapshot graph has `user --R--> e`, add role X. Resolved once
+   per call against the snapshot (CLAUDE.md snapshot-once;
+   acl-design.md §"Snapshot semantics" warns this is Plone's #1
+   stale-cache bug class). Inherited local roles deferred.
+3. For each role in that set, evaluate its grants on `e.Type`
+   under the per-role-per-type opt-in model (DR-S3). The
+   cross-role semantic is **union**: if ANY role grants write on
+   field X with a passing `when`, X is writable.
+4. Build the sparse `FieldVerdicts` / `RelationVerdicts`: emit
+   `false` for any field/option/relation that has no granting
+   role under a passing predicate.
+
+**Critical: closed-world semantics.** The current `Nop` resolver
+returns empty maps = "everything default-allowed." The policy
+resolver must instead emit `false` for everything **not granted**
+— `fields:` is opt-in like `write:`. But: only when the role has
+*any* `fields:` declaration for that type. A role with `write:
+[ticket]` and no `fields:` block at all should leave fields fully
+writable (else this becomes a backwards-incompatible change for
+every existing acl.yaml).
+
+**Decision:** "opt-in per type" — if a role declares `fields:` for
+type T at all, that role's per-field grants are closed-world for
+T (unlisted fields denied). If no role declares any `fields:` for
+T, all fields default-writable for that type. Same logic for
+`visible:`, `options:`, `relations:`.
+
+### 3. Wire-up
+
+- `cmd/rela-server/main.go:119` and
+  `cmd/rela-desktop/main.go:157` currently pass
+  `dataentry.ResolverFromProfile(os.Getenv("RELA_AFFORDANCE_PROFILE"))`.
+- Change `ResolverFromProfile` signature:
+  `ResolverFromProfile(profile string, policy *acl.Policy, meta *metamodel.Metamodel) FieldVerdictResolver`.
+- Logic:
+  1. `profile == "demo"` → `DemoFieldVerdictResolver{}` (override).
+  2. `policy != nil && policyHasAffordances(policy)` →
+     `affordances.New(policy, meta)`.
+  3. else → `NopFieldVerdictResolver{}`.
+- Both entry points already have `svc.ACL()` and the metamodel
+  via `svc.Meta()`; expose `svc.ACLPolicy()` to surface the raw
+  `*Policy` (currently held internally by `appbuild.Services`).
+- The resolver constructor's compile errors propagate up — same
+  fail-fast behavior as `LoadPolicy` for malformed YAML.
+
+### 4. Audit + denial path
+
+- `denyAffordance` (`affordances.go:365`) is unchanged.
+- The resolver's verdict carries no extra metadata — it just
+  returns `Writable[field]=false`. The downstream
+  `validateFieldWrite` produces `AffordanceDenialError{Rule:
+  RuleFieldReadOnly, Path: field}`, which renders as
+  `rule_id=field-affordance:read-only:<field>`.
+- Predicate-evaluation errors at runtime (e.g., a host func
+  errors): the resolver logs `slog.Warn` and treats the grant
+  as not-applied (deny-by-default — fail closed). The verdict
+  for the affected field surfaces as `writable=false`.
+- The `rule_kind=affordance:predicate` / `rule_id=<role>/<field>`
+  format from the ticket's AC3 is **dropped** in favor of the
+  existing wire shape. Reason: introducing a new rule_kind
+  prefix is a wire change; the existing format is what TKT-G7N5
+  callers (SPA, audit consumers) already parse. The role/predicate
+  attribution lives in the audit row's `Summary` field and in
+  server-side debug logs, not on the wire.
+- AC3/AC4/AC5 are amended accordingly during implementation:
+  the wire assertion is `rule_id=field-affordance:read-only:<field>`,
+  not a new prefix.
+
+### 5. Predicate env shape (AMENDED per DR-C2, DR-C3)
+
+```go
+// Declared once per entity type, cached on the resolver.
+env := predicate.NewEnv()
+env.DeclareVar("entity", recordTypeFor(meta, entityType))
+env.DeclareVar("current_user", predicate.RecordType{
+    "id":   predicate.StringType,
+    "type": predicate.StringType,
+})
+// has_role takes BOTH current_user AND the target entity (DR-C6):
+// local roles (owner, editor) are entity-scoped, conferred by a
+// role-relation like alice --owner-of--> TKT-001. "is current_user
+// an owner?" is meaningless without "owner of WHAT" — the entity
+// supplies that scope.
+env.DeclareFunc("has_role", predicate.FuncSig{
+    Params: []predicate.Type{predicate.RecordType{}, predicate.RecordType{}, predicate.StringType},
+    Return: predicate.BoolType,
+})
+// has_global_role is the entity-INDEPENDENT check (DR-C7): for
+// global roles assigned via `assignments` (admin, triager, etc.)
+// where no entity scope applies. Two clearly-typed funcs beats one
+// func with a nullable entity arg whose semantics shift — the
+// nil-entity footgun the design review warned about. In THIS
+// ticket every predicate has an entity (field/relation affordances
+// are per-entity), so has_global_role is a convenience that lets a
+// predicate skip the entity arg when it only cares about a global
+// role. Collection-scope predicates (gating `create` before any
+// entity exists) are a future ticket; when they land, they declare
+// an env WITHOUT `entity` and only has_global_role is available —
+// no nil entity is ever constructed.
+env.DeclareFunc("has_global_role", predicate.FuncSig{
+    Params: []predicate.Type{predicate.RecordType{}, predicate.StringType},
+    Return: predicate.BoolType,
+})
+env.DeclareFunc("has_relation", predicate.FuncSig{
+    Params: []predicate.Type{predicate.RecordType{}, predicate.StringType},
+    Return: predicate.BoolType,
+})
+env.DeclareFunc("count_relations", predicate.FuncSig{
+    Params: []predicate.Type{predicate.RecordType{}, predicate.StringType},
+    Return: predicate.NumberType,
+})
+env.DeclareFunc("string_in_list", predicate.FuncSig{
+    Params: []predicate.Type{predicate.StringType, predicate.ListType{Elem: predicate.StringType}},
+    Return: predicate.BoolType,
+})
+```
+
+**Metamodel → predicate type mapping (NO `AnyType` — see DR-C2):**
+
+| metamodel | predicate type |
+|-----------|----------------|
+| string, enum, date, rrule | `StringType` |
+| integer | `NumberType` |
+| boolean | `BoolType` |
+| `list: true` of string-ish | `ListType{Elem: StringType}` |
+| `list: true` of integer | `ListType{Elem: NumberType}` |
+| any unsupported type | **NOT declared in env** — predicate referencing it fails at compile with a clear operator-facing error (`predicate: env: unknown variable "entity.<prop>"`) |
+
+The "not declared" choice is deliberate: a predicate referencing a
+property the env doesn't know about should be a hard operator
+error at server startup, not a silent runtime quirk.
+
+### 6. Host function implementations (AMENDED per DR-C3)
+
+Bound per-`Resolver.FieldVerdicts` call against a single store
+snapshot taken at the top of the resolver call (DR-S5; consistent
+with CLAUDE.md "capture state once per operation"):
+
+- `has_role(user_record, entity_record, role_name string) bool` —
+  checks whether the user holds `role_name` **scoped to the given
+  entity** (DR-C6). The effective role set for `(user, entity)` is
+  global roles (from `Assignments`) ∪ local roles conferred on
+  `entity` by a `role_relations` edge from the user (e.g.
+  `alice --owner-of--> entity` confers `owner` per
+  `RoleRelationDef.Confers`). The `.ignored/acl-design.md`
+  four-layer model (users → groups → roles → local roles) requires
+  this entity dimension; a global-only `has_role` could never
+  express owner/editor/reviewer affordances.
+- `has_global_role(user_record, role_name string) bool` — the
+  entity-INDEPENDENT check (DR-C7) for global roles assigned via
+  `assignments` (admin, triager, etc.). Use when a predicate only
+  cares about a global role and doesn't want to thread the entity.
+  Distinct func rather than a nullable entity arg on `has_role` —
+  avoids the nil-entity footgun. (`has_role(u, e, r)` is the
+  superset: it ALSO matches global roles, since the effective set
+  is global ∪ local. `has_global_role` is the convenience form
+  that ignores local roles by construction.)
+- `has_relation(entity_record, rel_type string) bool` — checks
+  whether the entity has any outgoing relation of the given type.
+- `count_relations(entity_record, rel_type string) number` — count
+  of outgoing edges of the given type.
+- `string_in_list(value string, allowed list_of_string) bool` —
+  typed membership.
+
+**Effective-role resolution (DR-C6).** The resolver computes the
+`(principal, entity)` effective role set once per
+`Resolver.FieldVerdicts` call against the snapshot:
+
+1. Global roles: `Assignments[user]` ∪ `default` (existing
+   `Declarative.effectiveRoles` logic).
+2. Local roles: for each `role_relations` type R with
+   `Confers: X`, if the graph has `user --R--> entity`, add role
+    X. (v1 = direct local roles only; inherited local roles via
+   `inherit_roles_through` are ACL-v1 / deferred — flagged below.)
+   `has_global_role` (DR-C7) consults only step 1 of this set.
+
+This set is what `has_role(user, entity, name)` consults. It is
+also what gates which roles' `fields:`/`options:`/`relations:`
+grants apply for this entity — local-role grants (a role granted
+only via `owner-of`) participate in the same per-role-per-type
+opt-in union (DR-S3). **NOTE:** this means a grant block keyed on
+a local role (e.g. `roles.owner.fields.ticket`) only contributes
+for entities where the principal holds that local role — naturally
+entity-scoped, which is the whole point of local roles.
+
+Dropped from v1 scope (DR-C3): `is_one_of`, `contains` — neither
+can be typed safely under predicate's monomorphic FuncSig without
+falling through to `AnyType`-in-Params, which defeats the
+compile-time type checker for policy authors. Polymorphic variants
+land in follow-up tickets if predicate authors demonstrate the
+need. Numeric membership: `x == 1 or x == 2 or x == 3` (verbose
+but type-checked).
+
+Implementations live in `internal/acl/affordances/` (not in
+`internal/predicate` — predicate is host-agnostic).
+
+**Alternatives considered:**
+
+- **`internal/acl/affordances` vs `internal/acl/declarative_affordances.go`**: sub-package wins. Affordances have their own YAML schema, their own predicate env, their own tests — fits the rela "separate package per subsystem" pattern (CLAUDE.md). The sub-package also keeps `acl.Declarative` un-bloated.
+- **Single string `when:` vs list of conditions**: single string. Composing with `and`/`or` inside the expression is the same in predicate as it would be in YAML. Lists add YAML rope without expressive power. User confirmed.
+- **Per-grant `when:` vs role-level `when:`**: per-grant. A role like "triager" gating `status` on `entity.assignee == current_user.id` AND gating `priority` on a different predicate is the canonical case.
+- **New `rule_kind=affordance:predicate` wire format**: rejected. Wire change, and the SPA already routes the existing `field-affordance:read-only:<field>` to the right UI affordance. The role/predicate attribution belongs in audit + server logs, not on the wire.
+
+**Files to modify:**
+
+- `internal/acl/policy.go` — extend `RoleDef`; add new grant types; update `knownPolicyKeys` (still tolerant for unknown grants).
+- `internal/acl/policy_test.go` — parse-roundtrip tests for the new schema.
+- `internal/acl/affordances/resolver.go` — **new**.
+- `internal/acl/affordances/env.go` — **new**.
+- `internal/acl/affordances/bindings.go` — **new**.
+- `internal/acl/affordances/resolver_test.go` — **new**.
+- `internal/acl/affordances/acl_yaml_test.go` — **new**.
+- `internal/dataentry/affordances_stub.go` — update `ResolverFromProfile` signature and dispatch logic.
+- `internal/dataentry/affordances_test.go` — re-run the wire-parity contract test against a fixture acl.yaml resolver.
+- `cmd/rela-server/main.go` — pass policy + meta into ResolverFromProfile.
+- `cmd/rela-desktop/main.go` — same.
+- `internal/appbuild/appbuild.go` — expose `Services.ACLPolicy() *acl.Policy` (currently only the ACL is exposed).
+- `internal/appbuild/testfixture.go` — same change for tests.
+- `docs/security.md` — document the new acl.yaml fields with examples.
+- `docs/data-entry/api-reference.md` — note that affordances are now policy-driven, link to security.md.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+| Source | Validation | On invalid |
+|--------|------------|------------|
+| `acl.yaml` (operator-supplied at server start) | YAML parse + `predicate.Compile` on every `when:` | Hard fail at startup (matches existing `LoadPolicy` behavior for parse errors). Unknown sub-keys: `slog.Warn` + ignore (matches existing tolerance convention). |
+| Per-request principal (ctx) | Existing `principal.From` middleware | Already validated upstream — same trust assumption as `acl.Declarative`. |
+| Per-request entity (loaded from store) | Already validated upstream by store layer | Entity properties may be of unexpected runtime types (storage is permissive — CLAUDE.md "tolerate temporarily invalid data"). The binding code coerces to `predicate.Value` defensively: unconvertible values bind as `Nil`, not an error. |
+
+**Security-Sensitive Operations:**
+
+1. **Predicate evaluation as authorization signal.** Same trust
+   posture as `Declarative.AuthorizeWrite` — the policy is the
+   source of truth, the operator owns the policy file.
+   `predicate` is sandboxed (no I/O, no goroutines, step budget,
+   depth budget). Host funcs are explicitly named; the resolver
+   does not register any arbitrary-code-execution capability.
+
+2. **Fail-closed on predicate errors.** A runtime error in a
+   `when:` predicate (e.g., a host func panics or returns
+   error) MUST NOT default to allow. The resolver logs and
+   treats the grant as not-applied. **Verified by test.**
+
+3. **Cross-role grant union — deny-by-default is preserved
+   per-type.** If role A grants `fields.ticket.status` and role
+   B grants `fields.ticket.description`, a user with both roles
+   gets writability of BOTH. But a user with neither role and
+   no other grant gets nothing — closed-world.
+
+4. **No predicate evaluation on the read path beyond verdict
+   computation.** Per CLAUDE.md "Don't run user-supplied Lua on
+   the read path" — predicate IS NOT user-supplied; it's
+   operator-supplied via acl.yaml, same trust class as the
+   policy file itself. But: per-entity GET evaluates predicates
+   to populate `_fields` / `_relations`. The cost is bounded by
+   the step budget (10k per Eval) and the number of grants
+   (operator-controlled — practical sizes are dozens). List
+   queries do NOT evaluate predicates (out of scope) — this
+   keeps the perf cliff at bay per the ACL design rationale.
+
+5. **Predicate environment cannot reach the store directly.** Host
+   funcs are the only escape; each is bounded and named. No
+   `os.ReadFile` reachable, no `entitymanager.CreateEntity`
+   reachable.
+
+**Error handling — no information leaks:**
+
+- 403 body uses the existing wire shape: `{error, rule_kind,
+  rule_id, reason}`. The reason is the field name + "is not
+  writable" — same as TKT-G7N5; no policy details leak (role
+  name, predicate text).
+- Server-side `slog.Debug` carries the policy attribution
+  (`role=triager grant=fields.ticket.status when="..."`) for
+  operators debugging deny decisions; not exposed via API.
+- Audit `Summary` includes `rule_kind=affordance rule_id=...`
+  but not the predicate source (the predicate text is in
+  acl.yaml, which audit readers should consult separately).
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Test |
+|----|------|
+| AC1 | `policy_test.go`: round-trip parse of fixture acl.yaml with `fields:`, `visible:`, `options:`, `relations:` blocks. `resolver_test.go`: `affordances.New` with malformed `when:` returns wrapped error including grant path. |
+| AC2 | `affordances_contract_test.go` (existing): re-run with a `Nop`-equivalent acl.yaml (only `write:`, no affordance blocks). Assert byte-identical wire to the Nop resolver. |
+| AC3 | `resolver_test.go`: build resolver from fixture acl.yaml with `fields.ticket[0].when: "entity.status == 'ready'"`. Synth entity with `status=done`. Assert `FieldVerdicts.Writable["status"] == false`. End-to-end: `api_v1_test.go` PATCH to that field returns 403 with `rule_id=field-affordance:read-only:status`. |
+| AC4 | `resolver_test.go`: option grant with falsy `when:`. Assert `FieldVerdicts.Options["status"]["done"] == false`. E2E: PATCH setting `status=done` returns 403 with `rule_id=field-affordance:enum-filtered:status=done`. |
+| AC5 | `resolver_test.go`: relation grant with `create: false`. Assert `RelationVerdicts.Types["implements"].Creatable == false`. E2E: POST to each relation-create endpoint returns 403 with `rule_id=relation-affordance:not-creatable:implements`. Same for modern PATCH reconciler. |
+| AC6 | `affordances_stub_test.go` (existing): `ResolverFromProfile("demo", nil, nil)` returns `DemoFieldVerdictResolver{}`. With a non-nil policy that has affordance blocks AND profile=demo, demo still wins. |
+| AC7 | The existing wire-parity contract test re-runs with a fixture acl.yaml resolver and passes byte-identical to TKT-G7N5's expectations. |
+
+**Edge Cases:**
+
+- **Empty `when:`**: grants unconditionally. Tested.
+- **`when:` referencing unknown variable**: compile error at
+  load. Tested.
+- **`when:` referencing entity property not in metamodel**:
+  compile error (predicate type-checks against the declared
+  RecordType). Tested.
+- **`when:` returning non-bool** (e.g., `entity.title`): compile
+  error (predicate enforces return type at the relational/logical
+  combinator level; a bare expression returning a string is
+  rejected by the resolver wrapper with an explicit error: "when:
+  must evaluate to a boolean").
+- **Grant declared for unknown role**: ignored with `slog.Warn`,
+  matches existing `Declarative` behavior for unknown role names
+  in `Assignments`.
+- **Grant declared for unknown entity type**: ignored with
+  `slog.Warn`. Same rationale.
+- **Field grant for unknown field in known type**: ignored with
+  `slog.Warn`. Operators iterate; typo shouldn't brick.
+- **Principal with no roles** (anonymous): only `default` role
+  applies if present; otherwise zero grants. Closed-world ⇒
+  every opt-in field is denied. Matches existing
+  `Declarative.AuthorizeWrite` deny-by-default.
+- **`Create: nil, Remove: nil` on RelationGrant**: defaults both to true (operator opted in via the grant existing at all).
+- **`Create: ptr(false), Remove: nil`**: create denied, remove allowed.
+- **Multiple roles, conflicting grants**: union semantics — any
+  passing grant allows. Same as `write:`.
+- **Predicate runtime error during per-entity GET**: fail-closed
+  on that grant; verdict surfaces as deny; `slog.Warn` for
+  operator visibility. Does NOT 500 the GET.
+- **Predicate step-budget exhaustion**: same — fail-closed.
+- **Resolver called with nil entity**: returns zero verdicts
+  (existing pattern in `validateFieldWrite`).
+- **acl.yaml present but no affordance blocks**: behavior
+  byte-identical to Nop (AC2). No closed-world for any type.
+- **acl.yaml present with affordance blocks for type A but not
+  type B**: type B is permissive; type A is closed-world.
+  Per-type opt-in.
+
+**Negative Tests:**
+
+- Compile error in `when:` (parse error, unknown var, type error)
+  ⇒ resolver constructor returns error with the grant path in the
+  error message, server exits non-zero at startup.
+- Host func error at runtime ⇒ verdict deny, `slog.Warn`, no HTTP
+  500 response.
+- Stale SPA POSTing a hidden field ⇒ 403 with hidden-shape rule
+  (per the F8 closure that TKT-G7N5 added).
+- Policy load failure ⇒ existing `LoadPolicy` hard-fail, no change.
+
+**Integration tests:**
+
+- `cmd/rela-server/main_acl_test.go` (existing) — extend with a
+  fixture acl.yaml carrying affordance blocks; assert the GET
+  response carries the expected `_fields` / `_relations` shape
+  AND that PATCH against denied fields returns 403 with the
+  right rule_id.
+- `internal/dataentry/api_v1_test.go` — re-run a subset of the
+  TKT-G7N5 contract tests against the policy resolver to prove
+  wire-parity.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Mitigation |
+|------|------------|
+| Performance: per-entity GET evaluates N predicates × M roles. | Per CLAUDE.md, list queries skip predicates entirely (out of scope). Per-entity GET is bounded: N≈dozens of grants, M=user's effective roles. Step budget caps any single Eval at 10k. No caching in v1 — measure first, cache later if needed. |
+| Closed-world semantics break existing deployments. | Per-type opt-in: a role with no `fields:` block leaves fields permissive for that type. Existing acl.yaml files keep working unchanged. **AC2 pins this.** |
+| Predicate env divergence from store types. | Type mapping table is explicit; unknown property types map to `AnyType` with a debug log; tests cover every metamodel primitive type. |
+| Resolver+policy lifecycle (policy reload). | v1: no live policy reload. Resolver is built once at startup. Matches existing `Declarative` lifecycle. |
+| Rule_id wire format drift between Demo and policy resolvers. | Both go through the same `validateFieldWrite` / `validateRelationOp` → `AffordanceDenialError` path. Wire format is determined by the validators, not the resolver. **Contract test pins this.** |
+| Per-type `RecordType` mutation during reload. | `predicate.Env` is mutable until first Compile. Build the env, compile every program, then discard the env — programs hold what they need. Per-type envs are not shared across types. |
+
+**Effort:** L (matches the ticket). Bulk of the work is the new
+sub-package + tests; the YAML schema extension and the wire-up
+changes are mechanical.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] User guide / reference docs — `docs/security.md` gets a new
+  "Affordances" section under the ACL reference. Schema +
+  examples for `fields:`, `visible:`, `options:`, `relations:`.
+- [ ] CLI help text — N/A
+- [ ] CLAUDE.md — possibly a small note under "Authorization
+  (`internal/acl`)" referencing the new sub-package; decide
+  during implementation.
+- [ ] README.md — N/A
+- [x] API docs — `docs/data-entry/api-reference.md` note that
+  affordances are now policy-driven; link to security.md for
+  the schema.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+- [x] Crit review approved (3 rounds; DR-C6, DR-C7 added + addressed)
+
+**Design Review Findings (addressed inline below; tracked as RRs against TKT-9E57):**
+
+### Critical (all addressed in the amended approach)
+
+- **DR-C1: `Visible` verdict semantics under closed-world.** The
+  original draft listed `visible:` as a YAML block sibling but never
+  spelled out the resolver logic, and the closed-world rule means an
+  opt-in `visible:` block invisibly hides every undeclared field —
+  including stripping them from wire `properties` and from `_title`.
+  **Fix applied:** `visible:` follows the same per-type opt-in rule
+  as `fields:` (a role declaring `visible:` for type T is closed-
+  world for T's visibility; absent block = fully visible). Hidden
+  takes precedence over read-only when both apply (matches
+  `affordances.go:585`); a hidden field is skipped from `_fields`
+  entirely. Added explicit ACs and test scenarios below.
+
+- **DR-C2: `AnyType` would fail every Eval, not bypass type
+  checking.** `predicate/eval.go:79-100`'s `runtimeTypeAccepts` only
+  short-circuits for `RecordType` and `ListType`; `AnyType`
+  (`primitiveType{"any"}`) falls through to a name-match equality
+  that rejects every concrete value. The original draft proposed
+  `AnyType` for unknown metamodel property types, which would have
+  promoted a soft data-integrity issue (permissive storage carrying
+  off-type values) into a hard deny under fail-closed — locking
+  operators out of editing entities with drifted data.
+  **Fix applied:** dropped `AnyType` entirely from the entity
+  RecordType. Defined a value-coercion contract at the binding
+  layer:
+
+  | metamodel | runtime stored | binds as |
+  |-----------|----------------|----------|
+  | string / enum / date / rrule | string | `String(v)` |
+  | string / enum / date / rrule | other or missing | `Nil` |
+  | integer | int / float64 / numeric string | `Number(v)` |
+  | integer | other or missing | `Nil` |
+  | boolean | bool | `Bool(v)` |
+  | boolean | "true" / "false" | `Bool(v)` |
+  | boolean | other or missing | `Nil` |
+  | list-typed | `[]interface{}` of elem | `List(...)` |
+  | list-typed | scalar | `List([elem])` (single-elem promotion) |
+  | list-typed | other or missing | `List([])` |
+  | unsupported metamodel type | any | NOT declared in env (predicate referencing it fails to compile — operator-facing error) |
+
+  Coercion is best-effort: a stored map where a string is declared
+  binds as `Nil`, not an Eval error. Authors writing `entity.foo ==
+  "x" and entity.foo ~= nil` (or just `entity.foo == "x"` — nil ==
+  "x" is `false`) handle the missing-property case cleanly. Failing
+  closed on coercion was rejected: it turns hand-edit data drift
+  into permissions outages.
+
+- **DR-C3: `is_one_of` and `contains` cannot be declared.**
+  `predicate.FuncSig.Params` is `[]Type` with no union/generic.
+  `is_one_of(value, list)` requires polymorphism the type system
+  doesn't have. The escape hatch (`AnyType` in Params + runtime
+  type-switch) defeats the compile-time type checker for policy
+  authors.
+  **Fix applied:** drop `is_one_of` and `contains` from this
+  ticket's host-func set. Ship the typed primitive
+  `string_in_list(value string, allowed list_of_string) bool` as
+  the only collection primitive. Predicate authors needing numeric
+  membership write `x == 1 or x == 2 or x == 3` — verbose but
+  unambiguous and type-checked. The full host-func set for v1:
+
+  | Function | Sig | Use |
+  |----------|-----|-----|
+  | `has_role(user, entity, name)` | `(Record, Record, String) → Bool` | role membership scoped to entity (global ∪ local roles — DR-C6) |
+  | `has_global_role(user, name)` | `(Record, String) → Bool` | global-role-only check, entity-independent (DR-C7) |
+  | `has_relation(entity, type)` | `(Record, String) → Bool` | any outgoing edge of type |
+  | `count_relations(entity, type)` | `(Record, String) → Number` | count of outgoing edges |
+  | `string_in_list(value, allowed)` | `(String, List<String>) → Bool` | membership |
+
+  Other helpers (numeric_in_list, contains_substring) can land in
+  follow-up tickets if predicate authors demonstrate the need.
+
+- **DR-C4: Empty-list grant semantics ambiguous.** YAML
+  `fields: {ticket: []}`, `fields: {ticket: null}`, and `fields:
+  {ticket:}` parse differently and the plan didn't say which the
+  resolver distinguishes.
+  **Fix applied (corrected during implementation):** the opt-in
+  signal is the **presence of the per-type key** in the map.
+  Verified yaml.v3 behavior (`TestLoadPolicy_AffordanceGrants_
+  OptInIsKeyPresence`):
+  - `fields: {ticket: []}` → present key, non-nil empty slice.
+  - `fields: {ticket:}` (null) → present key, nil slice.
+  - `fields:` key absent → key NOT in map.
+
+  Both empty-list and null forms yield a **present** key, so both
+  are opt-in (closed-world deny-all when zero grants). Only an
+  absent key is permissive. The original plan claimed null/empty
+  decoded to "absent" — that was wrong; yaml.v3 keeps the key for
+  a null value. Hanging the security decision on nil-vs-empty-slice
+  would be too subtle, so the contract is simply: present (either
+  form) = opt-in. Tests pin all three shapes.
+
+- **DR-C5: Wire-format amendment changed ACs without updating the
+  ticket, and the dropped role/predicate attribution hurts
+  operator debuggability.**
+  **Fix applied, two parts:**
+  1. The ticket text (TKT-9E57) will be updated to match before
+     PR — task added to the implementation checklist. Wire-format
+     stays as TKT-G7N5 shipped:
+     `rule_id=field-affordance:read-only:<field>` etc.
+  2. Operator attribution is preserved via a **two-channel split**:
+     the wire response is unchanged (no role/predicate in the
+     external 403), but `AffordanceDenialError` gains an
+     `Attribution string` field (e.g.,
+     `role=triager/grant=fields.ticket[0]/when=...`) that flows
+     into `denyAffordance`'s audit `Summary` but NOT into the wire
+     response. Audit consumers see the full attribution chain;
+     external clients see only the wire-stable rule_id. Pinned by
+     test.
+
+### Critical added in crit round 1
+
+- **DR-C6: `has_role` needs the entity for local (entity-scoped)
+  roles.** The draft declared `has_role(user, role_name)` —
+  global-only. But the ACL four-layer model
+  (`.ignored/acl-design.md`) has *local roles* (`owner`, `editor`,
+  `reviewer`) conferred per-entity by a `role_relations` edge
+  (`alice --owner-of--> TKT-001`). "Is current_user an owner?" is
+  meaningless without "owner of WHAT." A global-only `has_role`
+  could never express the most common affordance ("owners may edit
+  internal notes"). **Fix applied:** `has_role` is now 3-arg —
+  `has_role(current_user, entity, role_name) bool` — and the
+  resolver computes the `(principal, entity)` effective role set
+  (global ∪ direct local roles conferred on that entity) once per
+  call. Local-role grant blocks (`roles.owner.fields.ticket`)
+  participate in the same per-role-per-type union (DR-S3),
+  naturally entity-scoped. Inherited local roles (via
+  `inherit_roles_through`, depth-capped graph walk) are **deferred
+  to ACL v1** — v1 of this ticket resolves direct local roles
+  only; documented in scope.
+
+- **DR-C7: Global-role checks (e.g. gating a "create" button)
+  need an entity-independent form.** Follow-up to DR-C6 (crit
+  round 2): once `has_role` is entity-scoped, how does a predicate
+  express a purely global-role check where no entity applies?
+  **Fix applied:** added a distinct `has_global_role(current_user,
+  role_name) bool` rather than overloading `has_role` with a
+  nullable entity. Two clearly-typed funcs avoid the nil-entity
+  footgun the design review flagged. `has_role` remains the
+  superset (global ∪ local); `has_global_role` is the convenience
+  form for global-only. **Scope note:** in THIS ticket every
+  predicate is per-entity (field/relation affordances attach only
+  to per-entity GET; the `create` verb is already gated by the
+  phase-1 `_actions` / `acl.AuthorizeWrite` path, not by the field
+  resolver). Collection-scope predicates that gate `create` before
+  an entity exists are a future ticket — when they land they'll
+  declare an env WITHOUT `entity`, so only `has_global_role` is
+  available and no nil entity is ever constructed.
+
+### Significant (addressed)
+
+- **DR-S1: Metamodel hot-reload not handled.** `cmd/rela-server`'s
+  `app.StartWatching()` may reload the metamodel without rebuilding
+  the resolver. **Fix applied:** document "**adding properties
+  referenced by predicates requires server restart**" in
+  `docs/security.md`. Add a regression test: after metamodel
+  reload, the resolver still uses the original RecordType; predicates
+  referencing newly-added properties don't auto-compile. If the
+  watcher's reload path turns out to rebuild the resolver (read
+  `app.StartWatching()` to confirm during implementation), update
+  the docs accordingly. v1 explicitly does not support live
+  predicate reload.
+
+- **DR-S2: Compile-error collection should be multi-error, not
+  first-wins.** **Fix applied:** `affordances.New` uses
+  `errors.Join` to collect ALL compile errors and renders each as
+  `roles.<role>.<block>.<type>[<i>].when: <err>`. Fail-fast at the
+  resolver level; show every failure operators need to fix in one
+  pass.
+
+- **DR-S3: Cross-role union under opt-in is non-monotonic.** The
+  draft's per-type opt-in meant "more roles can give less access."
+  **Fix applied:** redefine as **per-role-per-type opt-in,
+  evaluated independently, unioned**:
+  - For each (user, type), iterate the user's roles.
+  - Each role that declared `fields: {T: [...]}` is closed-world
+    *for that role's contribution*.
+  - A role without a `fields:` block contributes the empty
+    writability set (it doesn't grant per-field writability, but
+    it also doesn't shrink other roles' grants).
+  - Union the per-role "writable" sets.
+  - The role's type-level `write:` still authorizes the verb at
+    `acl.AuthorizeWrite` time; the per-field gate fires *additionally*
+    via `_fields.writable=false`.
+
+  Result: adding a role monotonically adds access. Added 4 cross-
+  role union tests to pin behavior with mixed declared/undeclared
+  `fields:` blocks per role.
+
+### Significant (deferred with rationale)
+
+- **DR-S4: Predicates evaluate against full entity, including
+  visibility-stripped properties.** Documented as intentional —
+  predicates server-side see plaintext; wire response strips. Added
+  to security.md.
+- **DR-S5: Host-func snapshot scope.** Snapshot once per
+  `Resolver.FieldVerdicts` call; pass to host funcs by binding.
+  Bound by predicate's step budget (10k ticks; host calls are one
+  tick each per `predicate/eval.go:122-157`). Add perf microbench
+  in implementation: 50 grants × 5 roles × 3 relation-walks per
+  resolver call, assert <10ms.
+- **DR-S6: `FieldGrant` and `RelationMetaGrant` are byte-identical.**
+  Unified as a single `FieldGrant` type used in both contexts.
+- **DR-S7: `*bool` YAML edge cases.** Test fixtures cover explicit
+  true/false, absent, null, empty-value, string `"false"`, integer
+  `0`. Considered enum alternative (`grant`/`deny`) but `*bool` with
+  explicit edge-case tests is simpler and the YAML semantics are
+  pinned.
+- **DR-S8: Integration tests vs unit tests.** Added
+  `cmd/rela-server/main_affordances_test.go`: load a project dir
+  with `acl.yaml` carrying affordance blocks, drive HTTP GET +
+  PATCH, assert response shape and 403 wiring. This closes the
+  end-to-end gap.
+- **DR-S9: Missing properties bind as `nil`.** Documented; added
+  edge-case test for predicate referencing optional unset property.
+
+### Minor / leverage (acknowledged for implementation)
+
+- **DR-M1: `default` role under per-type opt-in.** Documented:
+  adding `fields:` to `default` makes the world closed-world for
+  that type. Test pins this surprising-but-correct behavior.
+- **DR-M3: `RELA_AFFORDANCE_PROFILE=none` precedence.** Treat
+  `none` as a hard override to `NopFieldVerdictResolver`, even
+  when policy has affordance blocks. Allows operators to opt out
+  explicitly.
+- **DR-M4: Asymmetric malformed-YAML (warn) vs malformed-predicate
+  (exit).** Documented in `docs/security.md`: predicate compile
+  errors are operator typos with deterministic fixes; surface
+  loudly.
+- **DR-M5: Test fixture location.**
+  `internal/acl/affordances/testdata/` for unit-level fixtures,
+  `cmd/rela-server/testdata/affordances-project/` for end-to-end.
+- **DR-M6: Audit `Summary` format pinning.** Define
+  `Summary` format as space-separated `key=value` pairs (e.g.
+  `denied: rule_kind=affordance rule_id=... attribution=role=...`)
+  and add a regex-based parsing test.
+- **DR-L1: Adapter-pattern predicate runtime out of the resolver.**
+  Internal `predicateRunner` interface in
+  `internal/acl/affordances/` separates resolver from
+  predicate-engine specifics. Tests can stub `predicateRunner`
+  without standing up the predicate type system.
+- **DR-L3: Audit-log invariant integration test.** Walk every
+  denial kind, grep audit JSONL, assert one row per denial with
+  full attribution.
+- **DR-L4: Lint test for `AffordanceDenialError` construction.**
+  Add to `internal/dataentry/lint_test.go`: no direct construction
+  outside the two owning packages.
+
+Deferred to follow-ups (not addressed in this ticket):
+
+- **DR-L2: Verdict caching.** Documented as future work; resolver
+  API shape doesn't preclude adding a `Cache` collaborator.

--- a/tickets/entities/planning-checklists/PLAN-K0SF.md
+++ b/tickets/entities/planning-checklists/PLAN-K0SF.md
@@ -593,11 +593,13 @@ changes are mechanical.
 - [x] User guide / reference docs — `docs/security.md` gets a new
   "Affordances" section under the ACL reference. Schema +
   examples for `fields:`, `visible:`, `options:`, `relations:`.
-- [ ] CLI help text — N/A
-- [ ] CLAUDE.md — possibly a small note under "Authorization
-  (`internal/acl`)" referencing the new sub-package; decide
-  during implementation.
-- [ ] README.md — N/A
+- [x] ~~CLI help text~~ (N/A: no CLI command changes; the only knob
+  is the existing `RELA_AFFORDANCE_PROFILE` env var)
+- [x] ~~CLAUDE.md~~ (N/A: no new cross-cutting pattern — the
+  consumer-side-interface and capability-bundle patterns the code
+  follows are already documented there; decided during
+  implementation, see DOCS-Z3XV)
+- [x] ~~README.md~~ (N/A: no project-level surface change)
 - [x] API docs — `docs/data-entry/api-reference.md` note that
   affordances are now policy-driven; link to security.md for
   the schema.

--- a/tickets/entities/review-checklists/REV-BA12.md
+++ b/tickets/entities/review-checklists/REV-BA12.md
@@ -1,0 +1,99 @@
+---
+id: REV-BA12
+type: review-checklist
+title: 'Review: ACL: predicate-backed _fields and _relations resolver (replace stub)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`, race-enabled)
+- [x] Lint clean (`just lint` → 0 issues; `just arch-lint` → no warnings;
+  `just lint-md` → 0 errors)
+- [x] Coverage maintained (`just coverage-check` PASS; total 76.7%,
+  `internal/affordances` 84.6%)
+
+## Code Review
+
+- [x] Ran `/code-review` (cranky-code-reviewer agent over the full
+  new + modified file set)
+- [x] All critical review-responses addressed (RR-1DRR — the C1/C2/C3
+  attribution side-channel — resolved by deleting the side table and
+  threading attribution through the write-path verdict)
+- [x] All significant review-responses addressed (RR-08AK, RR-RTJE,
+  RR-QV18, RR-XYTO)
+- [x] Self-reviewed the diff for unrelated changes — only the
+  `newSearchBackend` extraction in appbuild and the entry-point
+  `buildFieldResolver` / `failLoad` helpers are incidental, and each
+  was extracted to satisfy funlen while wiring the resolver; no
+  drive-by behavior changes.
+
+**Review Responses:**
+
+Design-review (planning phase): RR-ZH1D, RR-ZAGR, RR-D2CP, RR-OGQF,
+RR-BWDE, RR-P6HP, RR-QXUF, RR-QKRT, RR-SQJU — all addressed.
+
+Code-review (this phase): RR-1DRR (critical), RR-08AK / RR-RTJE /
+RR-QV18 / RR-XYTO (significant), RR-TL9I (minor) — all addressed.
+
+No open critical or significant review-responses for this ticket.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (see implementation checklist
+  IMPL-G522 for the test-to-AC mapping)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- AC1 — PASS. `policy_test.go` parses the new blocks;
+  `TestResolver_New_CompileError_IncludesPath` + the S2 target-
+  validation tests prove load-time failure with the grant path.
+- AC2 — PASS. `TestResolver_NoAffordanceBlocks_EmptyVerdicts` +
+  `TestPolicyResolver_NoAffordanceBlocks_PermissiveWire`.
+- AC3 — PASS. `TestPolicyResolver_FieldPredicate_WireAndWrite` (GET
+  writable=false + PATCH 403 with `field-affordance:read-only:status`,
+  wire body carries no attribution).
+- AC4 — PASS. `TestResolver_OptionFiltered` + the enum-filter wire
+  rule_id path in `validateFieldWrite`.
+- AC5 — PASS. `TestPolicyResolver_RelationCreate_WireAndWrite` drives
+  the actual create POST → 403 `relation-affordance:not-creatable`.
+- AC6 — PASS. `TestResolverFromProfile_Demo` (hard override).
+- AC7 — PASS. Policy integration tests run against the same handlers
+  TKT-G7N5's contract test covers; wire shape unchanged.
+
+Plus DR-C5 two-channel: `TestPolicyResolver_AuditCarriesAttribution`
+(PATCH with no prior GET; wire body clean, audit Summary has
+`role=triager`).
+
+## Documentation (enhancement)
+
+- [x] Docs-checklist created and linked via `has-docs` (DOCS-Z3XV)
+- [x] User-facing documentation updated — `docs/security.md`
+  "Field- and relation-level affordances" section (acl.yaml schema,
+  predicate language table, closed-world / cross-role semantics,
+  fail-closed + restart-required notes) and `docs/data-entry/
+  api-reference.md` verdict-source table now lists the policy-backed
+  source.
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-Z3XV
+
+## Final Checks
+
+- [x] Commit message will explain the why (replacing the dev stub with
+  a policy-driven source), not just the what
+- [x] No TODOs or FIXMEs left unaddressed (temporary round-trip debug
+  test removed; no debug code)
+- [x] Ready for another developer to use — acl.yaml schema documented,
+  predicate language documented, profile selection documented
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- filled by /pr -->

--- a/tickets/entities/review-checklists/REV-BA12.md
+++ b/tickets/entities/review-checklists/REV-BA12.md
@@ -2,7 +2,7 @@
 id: REV-BA12
 type: review-checklist
 title: 'Review: ACL: predicate-backed _fields and _relations resolver (replace stub)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -92,8 +92,10 @@ Plus DR-C5 two-channel: `TestPolicyResolver_AuditCarriesAttribution`
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Ran `/pr` — PR created and CI monitored
+- [x] All CI checks pass (the `Rela Tickets` dogfood job clears once
+  this ticket transitions to `done`; all build/test/lint/coverage/
+  arch/e2e/docs jobs green)
+- [x] PR URL documented below
 
-**PR:** <!-- filled by /pr -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/841

--- a/tickets/entities/review-responses/RR-08AK.md
+++ b/tickets/entities/review-responses/RR-08AK.md
@@ -1,0 +1,9 @@
+---
+id: RR-08AK
+type: review-response
+title: Per-GET resolver work tripled; relation predicates are full store scans (S1)
+finding: serializeEntityForWire computes verdicts 3x per GET (hiddenProperties, computeFieldAffordances, computeRelationAffordances). Each call re-runs effectiveRoles (HasEdge per role-relation type = full linear scan that clones each match), and re-evaluates every grant predicate (each has_relation/count_relations = another full scan). Cost ~O(3 x grants x relations) per GET plus O(roleRelationTypes x relations) x3. This is the per-row-scan perf cliff CLAUDE.md warns about for a daemon backing the SPA.
+severity: significant
+resolution: RelationLookup collapsed to a single OutgoingCounts(fromID) map[string]int, cached once per resolve call on bindingContext (lazy, first host-func use). has_relation/count_relations now read the cache instead of scanning per call. storeRelationLookup tallies by type in one ListRelations scan. HasEdge stays a targeted query for local-role resolution. effectiveRoles still calls HasEdge per role-relation type but that's a bounded targeted query, not a full type scan. The dominant per-row scan cliff is removed; remaining 3x verdict computation across serialization is now cheap in-memory map work, documented as a follow-up if it ever matters.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-1DRR.md
+++ b/tickets/entities/review-responses/RR-1DRR.md
@@ -1,0 +1,9 @@
+---
+id: RR-1DRR
+type: review-response
+title: 'Attribution side-channel: cross-principal bleed, TOCTOU, unbounded growth (C1/C2/C3)'
+finding: 'attributionStore keys on (entityID, path) without the principal, so concurrent denials for the same path attribute to the wrong role (C1). Attribution is recorded on GET and read on a later PATCH via process-global sync.Map: a PATCH without a prior GET gets NO attribution (the common case silently no-ops), and the value can be stale (C2 TOCTOU). The map accretes one entry per (entity,path) for the daemon lifetime with no eviction (C3). The ''determinism makes races benign'' claim is false because the value embeds principal-dependent role= text.'
+severity: critical
+resolution: 'Deleted attributionStore entirely (L1). Attribution now rides the verdict: dataentry FieldVerdicts/RelationVerdicts gained an Attribution map populated by the policyResolver adapter; validateFieldWrite/validateRelationOp/validateRelationMetaWrite stamp it onto AffordanceDenialError.Attribution from the freshly-computed write-path verdict; denyAffordance appends it to the audit Summary. No cross-request side table, so no cross-principal bleed (C1), no GET-dependency/TOCTOU (C2 — PATCH-without-GET now carries attribution, pinned by TestPolicyResolver_AuditCarriesAttribution), no unbounded growth (C3).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-BHSM.md
+++ b/tickets/entities/review-responses/RR-BHSM.md
@@ -1,0 +1,9 @@
+---
+id: RR-BHSM
+type: review-response
+title: Rename default role to everyone; share name via acl constant
+finding: 'Crit round 3 (Jeroen): the implicit role name ''default'' feels off; prefer ''everyone''. And the name was duplicated between acl.Declarative and the affordances resolver, kept in sync manually. Asked to rename in both and share the constant.'
+severity: minor
+resolution: Added acl.EveryoneRole = "everyone" in internal/acl/policy.go as the single source of truth. acl.Declarative.effectiveRoles and affordances.globalRoles both reference it. Updated all tests and docs/security.md. Doc note added that anonymous/authenticated built-ins would join it there alongside a future auth layer.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-BWDE.md
+++ b/tickets/entities/review-responses/RR-BWDE.md
@@ -1,0 +1,9 @@
+---
+id: RR-BWDE
+type: review-response
+title: Wire-format amendment changed ACs without updating ticket; operator attribution dropped to slog.Debug
+finding: Plan unilaterally amended TKT-9E57 AC3-AC5 (rule_kind=affordance:predicate, rule_id=<role>/<field>) to use TKT-G7N5's existing wire format. (1) Ticket text wasn't updated → reviewer comparing ticket to PR will fail it. (2) Role/predicate attribution moved to slog.Debug only — operators reading audit JSONL see rule_id=field-affordance:read-only:status for every deny with no way to attribute to which acl.yaml grant fired. Reproducing 'user X cannot edit field Y' becomes 'tail server log while user X clicks.'
+severity: critical
+resolution: 'Two-channel split: (1) Update ticket AC3-AC5 to match plan''s wire format before PR (added to implementation checklist). (2) AffordanceDenialError gains Attribution field (role=triager/grant=fields.ticket[0]/when=...) that flows into denyAffordance''s audit Summary but NOT into the external wire response. Audit consumers see full attribution; external clients see wire-stable rule_id. Pinned by test.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-D2CP.md
+++ b/tickets/entities/review-responses/RR-D2CP.md
@@ -1,0 +1,9 @@
+---
+id: RR-D2CP
+type: review-response
+title: is_one_of and contains cannot be declared with monomorphic FuncSig
+finding: predicate.FuncSig.Params is []Type with no union/generic. is_one_of(value, list) requires polymorphism the type system lacks. The escape hatch (AnyType in Params + runtime type-switch) defeats the compile-time type checker for policy authors — typos like `is_one_of(entity, 'x')` (passing Record where scalar meant) become runtime errors instead of startup errors.
+severity: critical
+resolution: Dropped is_one_of and contains from v1 scope. Shipped typed primitive string_in_list(value string, allowed list_of_string) bool as the only collection helper. Numeric membership uses verbose `x == 1 or x == 2 or x == 3` (type-checked). Polymorphic variants land in follow-up tickets if predicate authors demonstrate the need.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OGQF.md
+++ b/tickets/entities/review-responses/RR-OGQF.md
@@ -1,0 +1,9 @@
+---
+id: RR-OGQF
+type: review-response
+title: Empty-list YAML grant semantics ambiguous
+finding: 'fields: {ticket: []}, fields: {ticket: null}, fields: {ticket:} parse differently in YAML and the plan didn''t say which the resolver distinguishes. One operator writes ''no grants for ticket fields,'' another writes ''empty allowlist,'' both deploy, one is silently wrong.'
+severity: critical
+resolution: 'Explicit decision: fields: key absent OR fields: {ticket: null} OR fields: {ticket:} → NOT opt-in (permissive). fields: {ticket: []} → opt-in with zero grants (closed-world deny-all). The PRESENCE of the per-type key signals intent. Matches write: [] meaning ''grants no writes.'' Added tests for all four YAML shapes.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-P6HP.md
+++ b/tickets/entities/review-responses/RR-P6HP.md
@@ -1,0 +1,9 @@
+---
+id: RR-P6HP
+type: review-response
+title: Metamodel hot-reload not handled; resolver holds stale RecordType
+finding: 'cmd/rela-server''s app.StartWatching() may reload the metamodel without rebuilding the resolver. The resolver holds *metamodel.Metamodel captured at construction; after hot-reload, predicate compiles succeed against the old shape but Evals reference stale fields. Adding a property like ''assignee'' and writing `when: entity.assignee == current_user.id` would silently bind as Nil until restart.'
+severity: significant
+resolution: 'Documented in docs/security.md: ''adding properties referenced by predicates requires server restart.'' Added regression test: after metamodel reload via watcher, resolver still uses original RecordType. v1 explicitly does not support live predicate reload. If app.StartWatching''s reload turns out to rebuild the resolver (TBD during implementation), update docs accordingly.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QKRT.md
+++ b/tickets/entities/review-responses/RR-QKRT.md
@@ -1,0 +1,9 @@
+---
+id: RR-QKRT
+type: review-response
+title: has_role must take the entity for local (entity-scoped) roles like owner
+finding: Draft declared has_role(user, role_name) bool — global-only. But the ACL four-layer model (.ignored/acl-design.md) has local roles (owner, editor, reviewer) conferred per-entity by role_relations edges (alice --owner-of--> TKT-001). 'Is current_user an owner?' is meaningless without 'owner of WHAT.' A global-only has_role could never express the canonical affordance 'owners may edit internal notes.' Raised by Jeroen in crit round 1.
+severity: critical
+resolution: 'has_role is now 3-arg: has_role(current_user, entity, role_name) bool. The resolver computes the (principal, entity) effective role set (global roles ∪ direct local roles conferred on that entity) once per FieldVerdicts call against the snapshot. Local-role grant blocks participate in the same per-role-per-type union (DR-S3), naturally entity-scoped. Inherited local roles via inherit_roles_through are deferred to ACL v1; v1 resolves direct local roles only.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QV18.md
+++ b/tickets/entities/review-responses/RR-QV18.md
@@ -1,0 +1,9 @@
+---
+id: RR-QV18
+type: review-response
+title: Attributed role is nondeterministic (map-iteration order) (S3)
+finding: 'effectiveRoles returns roles by ranging a map (random order); observeDeny records ''the last role that observed a deny.'' When a path is denied by multiple roles, which role is attributed varies run to run, making the audit role= suffix flaky. Fix: sort the effective-role slice and define a deterministic attribution-selection rule (first denying role in sorted order).'
+severity: significant
+resolution: effectiveRoles now sort.Strings the role slice; dimension/option observeDeny keep the FIRST denying role (was last-writer). relationAccumulator.recordDeny already kept-first. Attribution is now deterministic (first denier in sorted role order). Pinned by TestResolver_MultiRoleDeny_DeterministicAttribution (20 iterations, asserts stable 'default' wins over 'zeta').
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QXUF.md
+++ b/tickets/entities/review-responses/RR-QXUF.md
@@ -1,0 +1,9 @@
+---
+id: RR-QXUF
+type: review-response
+title: Cross-role union under per-type opt-in was non-monotonic (more roles = less access)
+finding: 'Original draft''s ''any role declaring fields: T opts T into closed-world for the user'' meant adding a role could SHRINK access: user with permissive role B (write: [ticket], no fields:) and restrictive role A (fields: {ticket: [status]}) gets closed-world for ticket, losing B''s implicit write access on all non-status fields. Surprising and unreasonable.'
+severity: significant
+resolution: 'Redefined as per-role-per-type opt-in evaluated independently and unioned: each role with fields: {T: [...]} is closed-world FOR THAT ROLE''s contribution. Roles without fields: contribute empty writability sets (don''t grant per-field, but don''t shrink other roles'' grants). Union per-role writable sets. Result: monotonic — more roles = strictly more or equal access. Added 4 cross-role union tests with mixed declared/undeclared fields: blocks.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-RTJE.md
+++ b/tickets/entities/review-responses/RR-RTJE.md
@@ -1,0 +1,9 @@
+---
+id: RR-RTJE
+type: review-response
+title: Grant target names not validated against metamodel — typos silently invert intent (S2)
+finding: 'Only when: predicates are compiled (which catches unknown field refs). fg.Field, og.Field/og.Option, rg.Relation are stored verbatim with no metamodel check. A typo `field: stauts` allows the bogus name and closed-world DENIES the real `status` — exact opposite of intent, no startup error. A relation typo (depends_on vs depends-on) emits a verdict for a nonexistent type that never gates. Predicates fail loudly; grant targets should too.'
+severity: significant
+resolution: 'Added internal/affordances/validate.go: validateField/validateOption/validateRelation run in compileRole before predicate compile. Unknown field, unknown/ non-enum option, unknown relation type, and relation-not-originating-from-type all fail New() with path-prefixed errors joined like predicate compile errors. Tests: TestResolver_New_UnknownFieldTarget_Rejected, _UnknownOptionTarget_, _UnknownRelationTarget_.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SQJU.md
+++ b/tickets/entities/review-responses/RR-SQJU.md
@@ -1,0 +1,9 @@
+---
+id: RR-SQJU
+type: review-response
+title: Global-role checks need an entity-independent has_global_role func
+finding: 'Follow-up to DR-C6 (crit round 2, Jeroen): once has_role is entity-scoped (3-arg), how does a predicate express a purely global-role check where no entity applies — e.g. gating a ''create'' button? Passing entity=nil into has_role is the nil-entity footgun the cranky review warned against.'
+severity: significant
+resolution: 'Added distinct has_global_role(current_user, role_name) bool rather than overloading has_role with a nullable entity. has_role stays the superset (global ∪ local); has_global_role is the global-only convenience form. Scope note: in THIS ticket every predicate is per-entity (field/relation affordances attach only to per-entity GET; create is gated by the phase-1 _actions/acl.AuthorizeWrite path, not the field resolver). Collection-scope predicates gating create are a future ticket; they''ll declare an env WITHOUT entity so only has_global_role is available — no nil entity ever constructed.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-TL9I.md
+++ b/tickets/entities/review-responses/RR-TL9I.md
@@ -1,0 +1,9 @@
+---
+id: RR-TL9I
+type: review-response
+title: Relation integration test asserts wire shape but not the 403 it claims, uses wrong relation type (S5)
+finding: TestPolicyResolver_RelationCreate_WireShape comment says 'and a 403 on relation create' but only does a GET inspecting _relations — no create PATCH issued. Policy grants on depends_on (underscore) while the real type is depends-on (hyphen); passes only because the resolver echoes whatever string the policy contains (see S2). Either drive the create PATCH and assert 403, or fix the comment, and use the real relation type.
+severity: minor
+resolution: Renamed test to TestPolicyResolver_RelationCreate_WireAndWrite; it now drives an actual POST .../relations/depends_on and asserts 403 with rule_id=relation-affordance:not-creatable:depends_on, in addition to the GET wire shape. depends_on is the correct relation type for dataentry's testMeta (ticket->ticket). The affordances-package testMeta gained real relation defs (implements/blocks/has-planning) so its relation tests reflect a valid metamodel.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-WEOB.md
+++ b/tickets/entities/review-responses/RR-WEOB.md
@@ -1,0 +1,9 @@
+---
+id: RR-WEOB
+type: review-response
+title: 'Discussion: per-block opt-in vs mandatory-grant-everything (deny-by-default)'
+finding: 'Crit (Jeroen): consider making the policy resolver require operators to specify all access (deny-by-default everywhere) rather than per-block opt-in — simpler code, fewer footguns. Brainstorm pros/cons.'
+severity: nit
+reason: 'Kept per-block opt-in. Pros of mandatory-grant (simpler code, can''t-forget-a-field) are real but outweighed: it would make every metamodel field addition silently read-only until re-granted (violates ''tolerate temporarily invalid data''), block incremental adoption (can''t lock just ticket.status without enumerating every field of every type), and diverge from how write: already defaults. Per-block opt-in already gives mandatory-grant WITHIN a governed (type,dimension); the S2 unknown-target validation closes the sharpest footgun. A per-type strict:/default_deny: flag was proposed as a future middle-ground if stronger guarantees are wanted. No code change this PR.'
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-XYTO.md
+++ b/tickets/entities/review-responses/RR-XYTO.md
@@ -1,0 +1,9 @@
+---
+id: RR-XYTO
+type: review-response
+title: Relation-meta-field path untested; partial-compile is latent fail-open (S4)
+finding: relation_accum.go candidateMeta/allowMeta/denyMeta at 0% coverage; metaFieldResults at 33%; no test exercises RelationGrant.Fields meta grants. The 'meta field can be more restrictive than its grant' AND-logic ships unverified. compileRelationGrant appends the grant when err==nil even if a meta-field predicate failed (skipped via continue) — harmless today since New hard-fails on any error, but a latent fail-open if New ever relaxes to warn-and-continue.
+severity: significant
+resolution: 'Added TestResolver_RelationMetaField exercising RelationGrant.Fields with a conditional when (AND-ed with grant): status=done denies note meta, status=open allows it. compileRelationGrant now tracks metaFailed and appends the grant only when err==nil AND !metaFailed — a grant that lost a meta field to a compile error is no longer half-installed. Affordances coverage rose to 84.6%.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ZAGR.md
+++ b/tickets/entities/review-responses/RR-ZAGR.md
@@ -1,0 +1,9 @@
+---
+id: RR-ZAGR
+type: review-response
+title: AnyType in entity RecordType would fail every Eval, locking out edits on drifted data
+finding: 'Plan proposed AnyType for unknown metamodel property types. Verified at predicate/eval.go:79-100: runtimeTypeAccepts only short-circuits for RecordType/ListType; AnyType (primitiveType{any}) falls through to name-match equality that rejects every concrete value. Under fail-closed-on-Eval-error, a hand-edited property of off-type (storage is permissive per CLAUDE.md) would deny every grant referencing that field — locking operators out of editing the entity (P0 at 3am pattern).'
+severity: critical
+resolution: 'Dropped AnyType entirely. Defined value-coercion contract at binding layer (full table in plan): off-type stored values bind as Nil rather than failing Eval. Unsupported metamodel types are NOT declared in env — predicate referencing them fails at compile with a clear operator-facing error. Coercion failures bind Nil, not error: hand-edit data drift becomes a slog.Warn, not a permissions outage.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ZH1D.md
+++ b/tickets/entities/review-responses/RR-ZH1D.md
@@ -1,0 +1,9 @@
+---
+id: RR-ZH1D
+type: review-response
+title: Visible verdict semantics under closed-world were unspecified
+finding: 'The draft listed `visible:` as a YAML block sibling but never spelled out the resolver logic. Under closed-world per-type opt-in, a `visible: {ticket: []}` block would silently hide every undeclared ticket field — stripping properties from wire AND from _title. UIs would render blank cards. No AC or test scenario covered this.'
+severity: critical
+resolution: 'Added explicit semantics: visible: follows per-type opt-in like fields: (declared block for type T is closed-world for T''s visibility; absent block = fully visible). Hidden takes precedence over read-only when both apply (matches affordances.go:585). Added ACs and integration test for closed-world visibility.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-9E57.md
+++ b/tickets/entities/tickets/TKT-9E57.md
@@ -1,0 +1,184 @@
+---
+id: TKT-9E57
+type: ticket
+title: 'ACL: predicate-backed _fields and _relations resolver (replace stub)'
+kind: enhancement
+priority: medium
+effort: l
+status: review
+---
+
+## Goal
+
+Replace the dev-only `DemoFieldVerdictResolver` (TKT-G7N5) with a policy-driven
+resolver backed by `internal/predicate` (TKT-2QI1). The wire contract
+(`_fields`, `_relations`) and SPA renderer stay exactly as shipped — this ticket
+changes only the **source of verdicts**.
+
+## Background
+
+- TKT-G7N5 landed the `_fields` / `_relations` wire shape on
+per-entity GET, plus the SPA `DynamicForm` / `RelationCards` consumers and a
+`FieldVerdictResolver` interface in `internal/dataentry`. The shipped resolver
+is a hardcoded `triager-demo` fixture controlled by `RELA_AFFORDANCE_PROFILE`.
+- TKT-2QI1 landed `internal/predicate` — a sandboxed Lua-expression
+evaluator with a typed Env, `Compile` (parse + walk against allow-list, depth
+budget), and `Eval` (per-call step budget, pure-function semantics).
+
+This ticket plugs the two together.
+
+## In scope
+
+### `acl.yaml` extensions
+
+Extend `RoleDef` with three new optional sections. Each grant carries an
+optional `when:` *single-string predicate*; absent `when:` unconditionally
+grants.
+
+```yaml
+roles:
+  triager:
+    write: [ticket]              # existing per-type write grant
+    fields:                       # NEW: per-field write grant
+      ticket:
+        - field: status
+          when: "entity.assignee == current_user.id"
+        - field: description
+          when: "entity.status != 'done'"
+    options:                      # NEW: per-enum-option grant
+      ticket:
+        - field: status
+          option: done
+          when: "has_role(current_user, 'closer')"
+    relations:                    # NEW: per-relation-type grants
+      ticket:
+        - relation: implements
+          create: true
+          remove: false
+          when: "entity.status == 'ready'"
+        - relation: has-planning
+          fields:
+            - field: note
+              when: "true"
+```
+
+Semantics:
+
+- Each grant block is **opt-in**: a field/option/relation with no
+matching grant is denied (denied = read-only / hidden / not creatable, depending
+on context). This matches `write:`'s closed-world behavior.
+- `fields:` controls field **writability** for the type. **Field
+visibility** (hide vs read-only) is a separate `visible:` block with the same
+shape — kept parallel so the wire shape stays symmetric.
+- A single `when:` per grant, compiled at load via
+`predicate.Compile`. Compose multiple conditions with `and` / `or` inside the
+expression. Compile errors fail policy load (same behavior as today for
+unparseable YAML).
+- Unknown sub-keys under a grant emit `slog.Warn` per the existing
+acl.yaml tolerance convention.
+
+### Resolver implementation
+
+New package `internal/affordances/` (a top-level component, not under
+`internal/acl` — arch-lint restricts `acl` to depend only on
+`principal`, while the resolver needs `predicate` / `metamodel` /
+`entity`):
+
+- `affordances.Resolver` satisfies
+`dataentry.FieldVerdictResolver` (compiled programs + role index, looked up per
+(principal, type)).
+- Predicate env declarations:
+  - `entity` — `RecordType` materialised from the metamodel for
+the entity's type at policy load. Properties become typed record fields; unknown
+properties on the entity surface as nil (consistent with predicate package
+semantics).
+  - `current_user` — `RecordType{id, type}`.
+  - Host funcs: `has_role(user, entity, name)` (entity-scoped,
+global ∪ local roles — DR-C6), `has_global_role(user, name)` (DR-C7),
+`has_relation(entity, type)`, `count_relations(entity, type)`,
+`string_in_list(value, list)`. `is_one_of`/`contains` dropped — can't be typed
+under predicate's monomorphic FuncSig (DR-C3).
+- Sparse emission: the resolver only writes `false` entries into
+the verdict maps. Empty result = no deviations from default.
+
+### Wiring
+
+- `appbuild.New` selects between resolvers:
+  1. `RELA_AFFORDANCE_PROFILE=demo` → `DemoFieldVerdictResolver`
+(kept for dev / e2e fixtures).
+  2. else if `acl.yaml` declares any `fields:`, `options:`, or
+`relations:` blocks → policy-backed resolver.
+  3. else → `NopFieldVerdictResolver`.
+- The policy-backed resolver is `acl.yaml`-discovered at startup;
+no separate config knob.
+
+### Audit + wire-parity
+
+- Existing `denied-write` audit op keeps its semantics. The **wire
+`rule_id` is unchanged from TKT-G7N5** (`field-affordance:read-only:<field>`,
+`field-affordance:enum-filtered:<field>=<opt>`,
+`relation-affordance:not-creatable:<type>`, etc.) — introducing a new
+`rule_kind=affordance:predicate` prefix would be a wire break for SPA / audit
+consumers already parsing the existing shape (DR-C5). Role + predicate
+attribution (`role=<role>/grant=<block>.<type>[<i>]`) flows into the audit
+record's `Summary` field via a new `AffordanceDenialError.Attribution` channel,
+NOT into the external 403 body. Operators get full attribution from the audit
+log; clients see only the wire-stable `rule_id`.
+- The contract test from TKT-G7N5 (every `_fields[x] == false` ⇒
+403 on the corresponding write, every `true` ⇒ 2xx) re-runs against a fixture
+`acl.yaml`. Sparse-emission invariant (absent ⇒ default-allowed) re-asserted.
+
+## Out of scope (explicit)
+
+- **Reactive predicates on the SPA.** PATCH already round-trips
+`_fields` per response (TKT-G7N5 + the autosave migration in PR #820), so
+verdicts refresh whenever an edit lands. Dry-run- on-create (form re-evaluation
+as the user types, before any PATCH) is a separate ticket if it proves needed.
+- **List-query field-level filtering.** TKT-G7N5 deferred it;
+this ticket leaves it deferred. Per-entity GET only.
+- **Per-link relation affordances** (different verdicts for
+different links of the same type). Needs a wire-shape ticket first.
+- **Parameterised verbs** (`transition:done`, `relation:foo:add`)
+— TKT-XZEY owns that.
+- **Read-side property redaction** (vs hiding via `visible:`).
+Same: needs ACL v1 read path first.
+
+## Why this is its own ticket
+
+TKT-G7N5 deliberately shipped with a stub so the wire shape + renderer could be
+reviewed and verified end-to-end without entangling them with `acl.yaml` schema
+discussion. Plumbing the predicate engine through is a meaningful design surface
+in its own right (predicate env shape, sparse emission semantics under
+predicates, compile-time vs eval-time error policy, audit rule_id format) and
+earns its own design review and code review.
+
+## Dependencies
+
+- TKT-G7N5 (wire shape + stub resolver) — done.
+- TKT-2QI1 (predicate language) — done.
+
+## Acceptance criteria
+
+- AC1: `acl.yaml` parses the new `fields:` / `options:` /
+`relations:` blocks; predicates compile at load; compile errors surface with
+`slog.Error` + non-zero exit (matches existing acl.yaml hard-fail behavior).
+- AC2: The resolver emits sparse verdict maps; an `acl.yaml`
+with no affordance blocks produces byte-identical wire output to
+`NopFieldVerdictResolver`.
+- AC3: A field grant with `when:` evaluating false produces
+`_fields[name].writable=false` AND a 403 on the corresponding write, with the
+TKT-G7N5 wire shape `rule_id=field-affordance:read-only:<field>` (DR-C5). The
+denying role + grant path appears in the audit `Summary` only, not the wire
+body.
+- AC4: An option grant with `when:` false produces
+`_fields[name].options[opt]=false` AND a 403 on a write that sets the field to
+that option, with `rule_id=field-affordance:enum-filtered:<field>=<opt>`.
+- AC5: A relation grant with `create: false` (or `when:` false)
+produces `_relations[type].creatable=false` AND a 403 on every relation-create
+endpoint (per-relation POST, modern PATCH reconciler, etc. — same chokepoints
+TKT-G7N5 gates), with `rule_id=relation-affordance:not-creatable:<type>`.
+- AC6: `RELA_AFFORDANCE_PROFILE=demo` still selects the hardcoded
+demo fixture, overriding any policy-backed resolver. E2E tests that use the demo
+profile keep working.
+- AC7: Wire-vs-policy parity test (re-used from TKT-G7N5) passes
+against a fixture `acl.yaml`.

--- a/tickets/entities/tickets/TKT-9E57.md
+++ b/tickets/entities/tickets/TKT-9E57.md
@@ -5,7 +5,7 @@ title: 'ACL: predicate-backed _fields and _relations resolver (replace stub)'
 kind: enhancement
 priority: medium
 effort: l
-status: review
+status: done
 ---
 
 ## Goal

--- a/tickets/relations/TKT-9E57--affects--authorization.md
+++ b/tickets/relations/TKT-9E57--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-9E57--affects--data-entry-server.md
+++ b/tickets/relations/TKT-9E57--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-9E57--depends-on--TKT-2QI1.md
+++ b/tickets/relations/TKT-9E57--depends-on--TKT-2QI1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: depends-on
+to: TKT-2QI1
+---

--- a/tickets/relations/TKT-9E57--depends-on--TKT-G7N5.md
+++ b/tickets/relations/TKT-9E57--depends-on--TKT-G7N5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: depends-on
+to: TKT-G7N5
+---

--- a/tickets/relations/TKT-9E57--has-docs--DOCS-Z3XV.md
+++ b/tickets/relations/TKT-9E57--has-docs--DOCS-Z3XV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-docs
+to: DOCS-Z3XV
+---

--- a/tickets/relations/TKT-9E57--has-implementation--IMPL-G522.md
+++ b/tickets/relations/TKT-9E57--has-implementation--IMPL-G522.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-implementation
+to: IMPL-G522
+---

--- a/tickets/relations/TKT-9E57--has-planning--PLAN-K0SF.md
+++ b/tickets/relations/TKT-9E57--has-planning--PLAN-K0SF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-planning
+to: PLAN-K0SF
+---

--- a/tickets/relations/TKT-9E57--has-review--REV-BA12.md
+++ b/tickets/relations/TKT-9E57--has-review--REV-BA12.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review
+to: REV-BA12
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-08AK.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-08AK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-08AK
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-1DRR.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-1DRR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-1DRR
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-BHSM.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-BHSM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-BHSM
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-BWDE.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-BWDE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-BWDE
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-D2CP.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-D2CP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-D2CP
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-OGQF.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-OGQF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-OGQF
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-P6HP.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-P6HP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-P6HP
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-QKRT.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-QKRT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-QKRT
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-QV18.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-QV18.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-QV18
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-QXUF.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-QXUF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-QXUF
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-RTJE.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-RTJE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-RTJE
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-SQJU.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-SQJU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-SQJU
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-TL9I.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-TL9I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-TL9I
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-WEOB.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-WEOB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-WEOB
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-XYTO.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-XYTO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-XYTO
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-ZAGR.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-ZAGR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-ZAGR
+---

--- a/tickets/relations/TKT-9E57--has-review-response--RR-ZH1D.md
+++ b/tickets/relations/TKT-9E57--has-review-response--RR-ZH1D.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: has-review-response
+to: RR-ZH1D
+---

--- a/tickets/relations/TKT-9E57--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-9E57--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9E57
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
## Summary

Replaces the dev-only `DemoFieldVerdictResolver` stub (TKT-G7N5) with a real
`acl.yaml`-policy-driven affordance resolver. The data-entry server's
`_fields` / `_relations` wire shape and the SPA renderer are **unchanged** —
this PR only swaps the source of verdicts.

- **New `internal/affordances` package** (own arch-lint component): compiles
  per-role `fields:` / `visible:` / `options:` / `relations:` grants from
  `acl.yaml`, each gated by an optional `when:` predicate
  (`internal/predicate`), evaluated per entity.
- **`acl.Policy` schema extension**: `RoleDef` gains the four grant blocks;
  `HasAffordanceGrants()` drives resolver selection.
- **Closed-world, per-block opt-in, monotonic cross-role union**: a role that
  declares a block for a type makes it closed-world *for that role*; a field
  is permitted if any role grants it under a passing predicate. Ungoverned
  types stay permissive (incremental adoption).
- **Entity-scoped roles**: `has_role(user, entity, name)` resolves global ∪
  direct local roles; `has_global_role(user, name)` for global-only. The
  implicit role is renamed `default` → `everyone` and shared as
  `acl.EveryoneRole` so the write path and affordance path can't drift.
- **Two-channel attribution** (DR-C5): the wire 403 keeps TKT-G7N5's
  `rule_id`; the denying role/grant rides the verdict into the audit
  `Summary` only — no cross-request side table.
- **Fail-closed**: predicate runtime errors deny + log; grant-target typos
  (unknown field/option/relation) fail at startup with the grant path.

Both design review and code review were run; all critical/significant
findings addressed (see the linked review-responses on TKT-9E57).

## Test plan

- [ ] `just ci` green locally (lint, arch-lint, lint-md, race tests,
      coverage, build, docs-check) — confirmed before push
- [ ] `internal/affordances` unit tests: closed-world, cross-role union,
      local/global roles, off-type coercion, target validation, relation-meta
- [ ] `internal/dataentry` integration tests: GET wire shape + PATCH 403 +
      audit attribution, relation-create POST 403, permissive-when-no-blocks
- [ ] `RELA_AFFORDANCE_PROFILE=demo` still selects the demo fixture (AC6)