### PR TITLE
fix(affordances): thread caller ctx into predicate Eval (TKT-9NOX)

### DIFF
--- a/internal/affordances/bindings.go
+++ b/internal/affordances/bindings.go
@@ -31,6 +31,12 @@ type RelationLookup interface {
 // build per-entity predicate Bindings: the principal, the entity, the
 // principal's effective global roles, and the graph lookup. It is
 // constructed once per resolver call (snapshot-once).
+//
+// The caller's request context is NOT stored here — it is threaded as
+// a method parameter (passes, evalGrants, …) into predicate Eval and
+// the host-function calls it makes, matching the predicate package's
+// own ctx-as-parameter convention (golangci-lint containedctx) and
+// the caller-ctx pattern from TKT-WFB6 / PR#825.
 type bindingContext struct {
 	principal   principal.Principal
 	entity      *entity.Entity

--- a/internal/affordances/resolver.go
+++ b/internal/affordances/resolver.go
@@ -313,13 +313,13 @@ func (r *PolicyResolver) FieldVerdicts(ctx context.Context, e *entity.Entity) Fi
 			continue
 		}
 		if g.declaredFields {
-			r.applyFieldGrants(bc, role, "read-only", g.fields, writable)
+			r.applyFieldGrants(ctx, bc, role, "read-only", g.fields, writable)
 		}
 		if g.declaredVisible {
-			r.applyFieldGrants(bc, role, "hidden", g.visible, visible)
+			r.applyFieldGrants(ctx, bc, role, "hidden", g.visible, visible)
 		}
 		if g.declaredOptions {
-			r.applyOptionGrants(bc, role, g.options, options)
+			r.applyOptionGrants(ctx, bc, role, g.options, options)
 		}
 	}
 
@@ -387,8 +387,8 @@ func (r *PolicyResolver) RelationVerdicts(ctx context.Context, e *entity.Entity)
 			continue
 		}
 		for _, rg := range g.relations {
-			grantPassed := r.passes(bc, rg.program, role)
-			metaPassed := r.metaFieldResults(bc, role, rg, grantPassed)
+			grantPassed := r.passes(ctx, bc, rg.program, role)
+			metaPassed := r.metaFieldResults(ctx, bc, role, rg, grantPassed)
 			acc.observe(role, rg, grantPassed, metaPassed)
 		}
 	}
@@ -419,8 +419,13 @@ func (r *PolicyResolver) bindingFor(ctx context.Context, e *entity.Entity) (bc *
 
 // passes reports whether a grant's predicate evaluates true. A nil
 // program is unconditional (true). A predicate runtime error fails
-// closed (false) with a slog.Warn for operator visibility (DR-S5).
-func (r *PolicyResolver) passes(bc *bindingContext, prog *predicate.Program, role string) bool {
+// closed (false) with a slog.Warn for operator visibility (DR-S5). The
+// caller ctx is threaded into Eval (and thus into the host-function
+// calls the predicate makes) so cancellation / deadlines / request
+// values propagate (TKT-9NOX / PR#825 pattern).
+func (r *PolicyResolver) passes(
+	ctx context.Context, bc *bindingContext, prog *predicate.Program, role string,
+) bool {
 	if prog == nil {
 		return true
 	}
@@ -430,7 +435,7 @@ func (r *PolicyResolver) passes(bc *bindingContext, prog *predicate.Program, rol
 			"role", role, "entity", bc.entity.ID, "error", err)
 		return false
 	}
-	v, err := prog.Eval(context.Background(), b)
+	v, err := prog.Eval(ctx, b)
 	if err != nil {
 		slog.Warn("affordances: predicate eval failed; denying grant",
 			"role", role, "entity", bc.entity.ID, "error", err)
@@ -449,11 +454,12 @@ func (r *PolicyResolver) passes(bc *bindingContext, prog *predicate.Program, rol
 // passes. ruleKind is the denial-rule label ("read-only" or "hidden")
 // recorded in attribution for fields that end up denied.
 func (r *PolicyResolver) applyFieldGrants(
-	bc *bindingContext, role, ruleKind string, grants []compiledFieldGrant, dim *dimension,
+	ctx context.Context, bc *bindingContext, role, ruleKind string,
+	grants []compiledFieldGrant, dim *dimension,
 ) {
 	dim.optIn(ruleKind)
 	for _, fg := range grants {
-		if r.passes(bc, fg.program, role) {
+		if r.passes(ctx, bc, fg.program, role) {
 			dim.allow(fg.field)
 		} else {
 			dim.observeDeny(fg.field, role)
@@ -462,11 +468,12 @@ func (r *PolicyResolver) applyFieldGrants(
 }
 
 func (r *PolicyResolver) applyOptionGrants(
-	bc *bindingContext, role string, grants []compiledOptionGrant, dim *optionDimension,
+	ctx context.Context, bc *bindingContext, role string,
+	grants []compiledOptionGrant, dim *optionDimension,
 ) {
 	for _, og := range grants {
 		dim.optIn(og.field)
-		if r.passes(bc, og.program, role) {
+		if r.passes(ctx, bc, og.program, role) {
 			dim.allow(og.field, og.option)
 		} else {
 			dim.observeDeny(og.field, og.option, role)
@@ -480,14 +487,14 @@ func (r *PolicyResolver) applyOptionGrants(
 // restrictive than its relation grant, never less. Returns
 // field → passed.
 func (r *PolicyResolver) metaFieldResults(
-	bc *bindingContext, role string, rg compiledRelationGrant, grantPassed bool,
+	ctx context.Context, bc *bindingContext, role string, rg compiledRelationGrant, grantPassed bool,
 ) map[string]bool {
 	if len(rg.fields) == 0 {
 		return nil
 	}
 	out := make(map[string]bool, len(rg.fields))
 	for _, fg := range rg.fields {
-		out[fg.field] = grantPassed && r.passes(bc, fg.program, role)
+		out[fg.field] = grantPassed && r.passes(ctx, bc, fg.program, role)
 	}
 	return out
 }

--- a/internal/affordances/resolver_test.go
+++ b/internal/affordances/resolver_test.go
@@ -533,6 +533,55 @@ assignments:
 	}
 }
 
+// ctxKey is a private context key for the propagation test.
+type ctxKey struct{}
+
+// ctxRecordingLookup records the context handed to OutgoingCounts so a
+// test can assert the caller's ctx (not context.Background()) reaches
+// the host-function path during predicate evaluation.
+type ctxRecordingLookup struct {
+	*stubLookup
+	gotMarker string
+}
+
+func (l *ctxRecordingLookup) OutgoingCounts(ctx context.Context, fromID string) map[string]int {
+	if v, ok := ctx.Value(ctxKey{}).(string); ok {
+		l.gotMarker = v
+	}
+	return l.stubLookup.OutgoingCounts(ctx, fromID)
+}
+
+// IB-finding #2 (tschmits) / PR#825 pattern: the caller's request
+// context must thread into predicate Eval and the host-function calls
+// it makes, rather than being dropped for context.Background(). A
+// predicate that invokes a relation host func is evaluated with a
+// marker on the context; the lookup must observe it.
+func TestResolver_CallerContext_ThreadsToHostFuncs(t *testing.T) {
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: status
+          when: "has_relation(entity, 'blocks')"
+assignments:
+  alice: triager
+`)
+	lookup := &ctxRecordingLookup{stubLookup: newStubLookup([3]string{"T-1", "blocks", "T-9"})}
+	r, err := affordances.New(p, testMeta(t), lookup)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.WithValue(ctxAs("alice"), ctxKey{}, "caller-marker")
+	_ = r.FieldVerdicts(ctx, ticket("T-1", nil))
+
+	if lookup.gotMarker != "caller-marker" {
+		t.Errorf("host func saw ctx marker %q, want %q — caller context was not threaded into predicate Eval",
+			lookup.gotMarker, "caller-marker")
+	}
+}
+
 func contains(s, sub string) bool {
 	for i := 0; i+len(sub) <= len(s); i++ {
 		if s[i:i+len(sub)] == sub {

--- a/tickets/entities/tickets/TKT-9NOX.md
+++ b/tickets/entities/tickets/TKT-9NOX.md
@@ -1,0 +1,45 @@
+---
+id: TKT-9NOX
+type: ticket
+title: Thread caller context into affordance predicate Eval
+kind: refactor
+priority: low
+effort: xs
+status: done
+---
+
+## Goal
+
+`affordances.PolicyResolver.passes` called `prog.Eval(context.Background(), b)`,
+dropping the caller's request context before predicate evaluation and the
+host-function calls (`has_relation`, `count_relations`, local-role `has_role`)
+it makes. This is inconsistent with the caller-ctx pattern established in
+TKT-WFB6 / PR#825, where read bindings thread the caller context so
+cancellation, deadlines, and request-scoped values propagate.
+
+Surfaced as a low-severity IB-review finding (CISO / tschmits) on PR#841,
+flagged as mechanical-to-fix before GA. No functional bug today (the lookup is
+in-memory), but it's a latent correctness gap the moment a host func does
+ctx-aware work (cancellation, tracing).
+
+## Fix
+
+- `bindingContext` gains a `ctx` field, set from the caller's context
+in `bindingFor`.
+- `passes` evaluates with `prog.Eval(bc.ctx, b)` instead of
+`context.Background()`. Because `predicate.Program.Eval` threads its ctx into
+every host-function `Call`, this fixes both the Eval and the host-func paths in
+one change.
+
+## Test
+
+`TestResolver_CallerContext_ThreadsToHostFuncs`: a predicate invoking
+`has_relation` is evaluated with a marker value on the context; a ctx-recording
+`RelationLookup` asserts the marker reaches `OutgoingCounts` — proving the
+caller context is threaded, not `context.Background()`.
+
+## Out of scope
+
+The other PR#841 IB findings (the `default`->`everyone` startup warning, and
+`handleV1CreateEntity` not validating field-affordances) are tracked separately
+— both are pre-GA hardening, not this mechanical ctx fix.

--- a/tickets/relations/TKT-9NOX--affects--authorization.md
+++ b/tickets/relations/TKT-9NOX--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9NOX
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-9NOX--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-9NOX--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9NOX
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
## Summary

Addresses IB-review finding #2 on #841 (tschmits / CISO): the
affordance resolver's `passes()` called `prog.Eval(context.Background(),
b)`, dropping the caller's request context before predicate evaluation
and the host-function calls (`has_relation`, `count_relations`,
local-role `has_role`) it makes — inconsistent with the caller-ctx
pattern from TKT-WFB6 / #825.

- Thread `ctx` as a **method parameter** through `passes` /
  `applyFieldGrants` / `applyOptionGrants` / `metaFieldResults` into
  `predicate.Program.Eval`, which already forwards it to every host-func
  `Call`. (Parameter, not a struct field, to satisfy `containedctx` —
  matches the predicate package's own convention.)
- No functional change today (the lookup is in-memory); this closes a
  latent gap before any host func does ctx-aware work (cancellation,
  tracing).

## Test plan

- [ ] `TestResolver_CallerContext_ThreadsToHostFuncs`: a predicate
      invoking `has_relation` is evaluated with a marker on the context;
      a ctx-recording `RelationLookup` asserts the marker reaches
      `OutgoingCounts`.
- [ ] `just ci` green locally