### PR TITLE
extract widget registry from FieldRenderer (TKT-MZSIJ)

### DIFF
--- a/frontend/src/components/forms/FieldRenderer.test.ts
+++ b/frontend/src/components/forms/FieldRenderer.test.ts
@@ -125,4 +125,23 @@ describe('FieldRenderer affordance plumbing', () => {
   // checkEnumOption coverage) plus by the typecheck — happy-dom
   // can't mount SlimSelect's MutationObserver cleanly, so a direct
   // component test isn't worth the harness fight here.
+
+  it('composes label and checkbox input under a single id for click-to-toggle', () => {
+    // A boolean property routes through CheckboxWidget, FieldShell
+    // renders the label AFTER the input (.checkbox-wrapper). The
+    // label's for= and the checkbox's id must match so a label-click
+    // toggles the box — the contract that survives the FieldShell +
+    // widget split.
+    const wrapper = renderField({
+      field: { property: 'automated', label: 'Automated' },
+      propertyDef: { type: 'boolean' },
+      value: false,
+    })
+    expect(wrapper.find('.checkbox-wrapper').exists()).toBe(true)
+    const input = wrapper.find('input[type="checkbox"]')
+    const label = wrapper.find('.checkbox-wrapper label')
+    expect(input.attributes('id')).toBe('field-automated')
+    expect(label.attributes('for')).toBe('field-automated')
+    wrapper.unmount()
+  })
 })

--- a/frontend/src/components/forms/FieldRenderer.vue
+++ b/frontend/src/components/forms/FieldRenderer.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { FormFieldOrRelation, PropertyDef } from '@/types'
-import RruleBuilder from './RruleBuilder.vue'
-import TagSelect from '@/components/ui/TagSelect.vue'
+import { defaultRegistry, defaultWidgetFor } from '@/widgets/registry'
+import FieldShell from './FieldShell.vue'
 
 const props = defineProps<{
   field: FormFieldOrRelation
@@ -21,328 +21,50 @@ const emit = defineEmits<{
   update: [value: unknown]
 }>()
 
+const fieldId = computed(() => `field-${props.field.property}`)
 const label = computed(() => props.field.label || props.field.property || '')
 const placeholder = computed(() => props.field.placeholder || '')
 const help = computed(() => props.field.help || props.propertyDef?.description || '')
 
-const inputType = computed(() => {
-  const propType = props.propertyDef?.type || 'string'
-  switch (propType) {
-    case 'date':
-      return 'date'
-    case 'integer':
-      return 'number'
-    case 'boolean':
-      return 'checkbox'
-    default:
-      return 'text'
-  }
-})
+// Resolve the widget once from config + property def. The registry
+// honours an explicit field.widget then falls back to type defaulting.
+const resolvedWidgetName = computed(() =>
+  props.field.widget && props.field.widget.trim() !== ''
+    ? props.field.widget
+    : defaultWidgetFor(props.propertyDef)
+)
+const widgetComponent = computed(() =>
+  defaultRegistry.resolve(props.field.widget, props.propertyDef)
+)
 
-const isTextarea = computed(() => {
-  return props.field.widget === 'textarea'
-})
-
-const isSelect = computed(() => {
-  return (props.propertyDef?.values?.length ?? 0) > 0 || props.field.widget === 'select'
-})
-
-const isMultiSelect = computed(() => {
-  return props.propertyDef?.list === true || props.field.widget === 'multiselect'
-})
-
-const isCheckbox = computed(() => {
-  return props.propertyDef?.type === 'boolean' || props.field.widget === 'checkbox'
-})
-
-const isRrule = computed(() => {
-  return props.propertyDef?.type === 'rrule' || props.field.widget === 'rrule'
-})
-
-const options = computed(() => props.propertyDef?.values || [])
-
-const hasTransitions = computed(() => {
-  return props.field.transitions && Object.keys(props.field.transitions).length > 0
-})
-
-function isOptionDisabled(opt: string): boolean {
-  if (props.optionVerdicts && props.optionVerdicts[opt] === false) {
-    return true
-  }
-  if (!hasTransitions.value || !props.field.transitions) {
-    return false
-  }
-  const currentVal = stringValue.value
-  if (!currentVal || opt === currentVal) {
-    return false
-  }
-  const allowedTransitions = props.field.transitions[currentVal] || []
-  return !allowedTransitions.includes(opt)
-}
-
-const transitionEntries = computed(() => {
-  if (!props.field.transitions) return []
-  return Object.entries(props.field.transitions).sort((a, b) => a[0].localeCompare(b[0]))
-})
-
-const stringValue = computed(() => {
-  if (props.value === null || props.value === undefined) return ''
-  return String(props.value)
-})
-
-const boolValue = computed(() => {
-  return props.value === true || props.value === 'true'
-})
-
-const arrayValue = computed(() => {
-  if (Array.isArray(props.value)) return props.value
-  if (props.value) return [props.value]
-  return []
-})
-
-function handleInput(event: Event) {
-  const target = event.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-
-  if (isCheckbox.value) {
-    emit('update', (target as HTMLInputElement).checked)
-  } else if (inputType.value === 'number') {
-    const num = parseInt(target.value, 10)
-    emit('update', isNaN(num) ? target.value : num)
-  } else {
-    emit('update', target.value)
-  }
-}
-
-function handleTagSelect(value: string[]) {
-  emit('update', value)
-}
+const isCheckbox = computed(() => resolvedWidgetName.value === 'checkbox')
+// rrule renders its own help inside the builder; preserve the pre-refactor
+// behaviour of forwarding help only to that widget.
+const isRrule = computed(() => resolvedWidgetName.value === 'rrule')
 </script>
 
 <template>
-  <div class="form-field" :class="{ 'has-error': error }">
-    <label v-if="!isCheckbox" :for="`field-${field.property}`">
-      {{ label }}
-      <span v-if="propertyDef?.required" class="required">*</span>
-    </label>
-
-    <!-- Checkbox -->
-    <div v-if="isCheckbox" class="checkbox-wrapper">
-      <input
-        :id="`field-${field.property}`"
-        type="checkbox"
-        :checked="boolValue"
-        :disabled="readonly"
-        @change="handleInput"
-      />
-      <label :for="`field-${field.property}`">
-        {{ label }}
-        <span v-if="propertyDef?.required" class="required">*</span>
-      </label>
-    </div>
-
-    <!-- Textarea -->
-    <textarea
-      v-else-if="isTextarea"
-      :id="`field-${field.property}`"
-      :value="stringValue"
+  <FieldShell
+    :field-id="fieldId"
+    :label="label"
+    :required="propertyDef?.required"
+    :help="help"
+    :error="error"
+    :label-position="isCheckbox ? 'after' : 'before'"
+  >
+    <component
+      :is="widgetComponent"
+      :id="fieldId"
+      :model-value="value"
+      :property-def="propertyDef"
+      :disabled="readonly"
+      :required="propertyDef?.required"
+      :error="error"
       :placeholder="placeholder"
-      :disabled="readonly"
-      rows="4"
-      @input="handleInput"
-    />
-
-    <!-- Multi-select (SlimSelect via TagSelect) -->
-    <TagSelect
-      v-else-if="isMultiSelect"
-      :model-value="arrayValue.map(String)"
-      :options="options"
-      :placeholder="placeholder || 'Select...'"
-      :disabled="readonly"
+      :help="isRrule ? help : undefined"
       :option-verdicts="optionVerdicts"
-      @update:model-value="handleTagSelect"
-    />
-
-    <!-- Select -->
-    <select
-      v-else-if="isSelect"
-      :id="`field-${field.property}`"
-      :value="stringValue"
-      :disabled="readonly"
-      @change="handleInput"
-    >
-      <option value="">Select...</option>
-      <option
-        v-for="opt in options"
-        :key="opt"
-        :value="opt"
-        :disabled="isOptionDisabled(opt)"
-        :class="{ 'disabled-transition': isOptionDisabled(opt) }"
-      >
-        {{ opt }}{{ isOptionDisabled(opt) ? ' (not allowed)' : '' }}
-      </option>
-    </select>
-
-    <!-- Transitions info -->
-    <div v-if="hasTransitions" class="transitions-info">
-      <p class="transitions-title">Allowed transitions</p>
-      <div v-for="[from, tos] in transitionEntries" :key="from" class="transitions-row">
-        <span class="transitions-from">{{ from }}</span>
-        <span class="transitions-arrow">&rarr;</span>
-        <span class="transitions-to">{{ tos.join(', ') }}</span>
-      </div>
-    </div>
-
-    <!-- RRULE builder -->
-    <RruleBuilder
-      v-else-if="isRrule"
-      :model-value="stringValue"
-      :help="help"
-      :readonly="readonly"
+      :transitions="field.transitions"
       @update:model-value="emit('update', $event)"
     />
-
-    <!-- Standard input -->
-    <input
-      v-if="!isCheckbox && !isTextarea && !isMultiSelect && !isSelect && !isRrule"
-      :id="`field-${field.property}`"
-      :type="inputType"
-      :value="stringValue"
-      :placeholder="placeholder"
-      :disabled="readonly"
-      @input="handleInput"
-    />
-
-    <p v-if="help" class="field-help">{{ help }}</p>
-    <p v-if="error" class="field-error">{{ error }}</p>
-  </div>
+  </FieldShell>
 </template>
-
-<style scoped>
-.form-field {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.form-field label {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--text-color);
-}
-
-.required {
-  color: var(--error-color, #ef4444);
-}
-
-.checkbox-wrapper {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.checkbox-wrapper input {
-  width: 18px;
-  height: 18px;
-  cursor: pointer;
-}
-
-.checkbox-wrapper label {
-  cursor: pointer;
-}
-
-input[type="text"],
-input[type="number"],
-input[type="date"],
-textarea,
-select {
-  padding: 10px 12px;
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  font-size: 14px;
-  background: var(--input-bg);
-  color: var(--text-color);
-  transition: all 0.15s;
-}
-
-input:focus,
-textarea:focus,
-select:focus {
-  outline: none;
-  border-color: var(--accent-color, #6366f1);
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
-}
-
-input:disabled,
-textarea:disabled,
-select:disabled {
-  background: var(--hover-bg);
-  cursor: not-allowed;
-}
-
-.has-error input,
-.has-error textarea,
-.has-error select {
-  border-color: var(--error-color, #ef4444);
-}
-
-.has-error input:focus,
-.has-error textarea:focus,
-.has-error select:focus {
-  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1);
-}
-
-.field-help {
-  font-size: 13px;
-  color: var(--muted-text);
-  margin: 0;
-}
-
-.field-error {
-  font-size: 13px;
-  color: var(--error-color, #ef4444);
-  margin: 0;
-}
-
-.transitions-info {
-  margin-top: 8px;
-  padding: 12px;
-  background: var(--hover-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-}
-
-.transitions-title {
-  font-size: 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--muted-text);
-  margin: 0 0 8px;
-}
-
-.transitions-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  padding: 4px 0;
-}
-
-.transitions-from {
-  font-weight: 500;
-  color: var(--text-color);
-}
-
-.transitions-arrow {
-  color: var(--muted-text);
-}
-
-.transitions-to {
-  color: var(--muted-text);
-}
-
-.disabled-transition {
-  color: var(--muted-text);
-  font-style: italic;
-}
-</style>

--- a/frontend/src/components/forms/FieldRenderer.vue
+++ b/frontend/src/components/forms/FieldRenderer.vue
@@ -38,9 +38,6 @@ const widgetComponent = computed(() =>
 )
 
 const isCheckbox = computed(() => resolvedWidgetName.value === 'checkbox')
-// rrule renders its own help inside the builder; preserve the pre-refactor
-// behaviour of forwarding help only to that widget.
-const isRrule = computed(() => resolvedWidgetName.value === 'rrule')
 </script>
 
 <template>
@@ -61,7 +58,7 @@ const isRrule = computed(() => resolvedWidgetName.value === 'rrule')
       :required="propertyDef?.required"
       :error="error"
       :placeholder="placeholder"
-      :help="isRrule ? help : undefined"
+      :help="help"
       :option-verdicts="optionVerdicts"
       :transitions="field.transitions"
       @update:model-value="emit('update', $event)"

--- a/frontend/src/components/forms/FieldShell.test.ts
+++ b/frontend/src/components/forms/FieldShell.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FieldShell from './FieldShell.vue'
+
+function shell(props: Record<string, unknown>) {
+  return mount(FieldShell, {
+    props,
+    slots: { default: '<input class="widget" />' },
+  })
+}
+
+describe('FieldShell', () => {
+  it('renders label before the control by default', () => {
+    const w = shell({ fieldId: 'f-title', label: 'Title' })
+    const html = w.html()
+    expect(html.indexOf('Title')).toBeLessThan(html.indexOf('class="widget"'))
+    expect(w.find('label').attributes('for')).toBe('f-title')
+    expect(w.find('.checkbox-wrapper').exists()).toBe(false)
+  })
+
+  it('renders label after the control when labelPosition is after', () => {
+    const w = shell({ fieldId: 'f-done', label: 'Done', labelPosition: 'after' })
+    expect(w.find('.checkbox-wrapper').exists()).toBe(true)
+    const html = w.html()
+    expect(html.indexOf('class="widget"')).toBeLessThan(html.indexOf('Done'))
+  })
+
+  it('shows a required asterisk only when required', () => {
+    expect(shell({ label: 'X', required: true }).find('.required').exists()).toBe(true)
+    expect(shell({ label: 'X' }).find('.required').exists()).toBe(false)
+  })
+
+  it('renders help and error text when provided', () => {
+    const w = shell({ label: 'X', help: 'do this', error: 'bad' })
+    expect(w.find('.field-help').text()).toBe('do this')
+    expect(w.find('.field-error').text()).toBe('bad')
+    expect(w.find('.form-field').classes()).toContain('has-error')
+  })
+
+  it('omits help/error when absent and is not in error state', () => {
+    const w = shell({ label: 'X' })
+    expect(w.find('.field-help').exists()).toBe(false)
+    expect(w.find('.field-error').exists()).toBe(false)
+    expect(w.find('.form-field').classes()).not.toContain('has-error')
+  })
+
+  it('omits the label element when no label is given', () => {
+    expect(shell({}).find('label').exists()).toBe(false)
+  })
+
+  it('omits the label element in after-position when no label is given', () => {
+    const w = shell({ labelPosition: 'after' })
+    expect(w.find('.checkbox-wrapper label').exists()).toBe(false)
+    expect(w.find('.widget').exists()).toBe(true)
+  })
+})

--- a/frontend/src/components/forms/FieldShell.test.ts
+++ b/frontend/src/components/forms/FieldShell.test.ts
@@ -53,4 +53,13 @@ describe('FieldShell', () => {
     expect(w.find('.checkbox-wrapper label').exists()).toBe(false)
     expect(w.find('.widget').exists()).toBe(true)
   })
+
+  it('omits the for attribute on the label when fieldId is undefined', () => {
+    // Defensive shape check — happens whenever a field config arrives
+    // without a property name. Harmless but must not blow up rendering.
+    const w = shell({ label: 'X' })
+    const label = w.find('label')
+    expect(label.exists()).toBe(true)
+    expect(label.attributes('for')).toBeUndefined()
+  })
 })

--- a/frontend/src/components/forms/FieldShell.vue
+++ b/frontend/src/components/forms/FieldShell.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+// FieldShell owns the chrome around a property widget: label (with
+// required asterisk), help text, error text, and the .form-field layout.
+// Widgets render only their input control. labelPosition handles the
+// checkbox case where the label follows the control.
+defineProps<{
+  fieldId?: string
+  label?: string
+  required?: boolean
+  help?: string
+  error?: string
+  labelPosition?: 'before' | 'after'
+}>()
+</script>
+
+<template>
+  <div class="form-field" :class="{ 'has-error': error }">
+    <template v-if="labelPosition === 'after'">
+      <div class="checkbox-wrapper">
+        <slot />
+        <label v-if="label" :for="fieldId">
+          {{ label }}
+          <span v-if="required" class="required">*</span>
+        </label>
+      </div>
+    </template>
+
+    <template v-else>
+      <label v-if="label" :for="fieldId">
+        {{ label }}
+        <span v-if="required" class="required">*</span>
+      </label>
+      <slot />
+    </template>
+
+    <p v-if="help" class="field-help">{{ help }}</p>
+    <p v-if="error" class="field-error">{{ error }}</p>
+  </div>
+</template>
+
+<style scoped>
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-field label {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-color);
+}
+
+.required {
+  color: var(--error-color, #ef4444);
+}
+
+.checkbox-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.checkbox-wrapper :deep(input) {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+.checkbox-wrapper label {
+  cursor: pointer;
+}
+
+.form-field :deep(input[type='text']),
+.form-field :deep(input[type='number']),
+.form-field :deep(input[type='date']),
+.form-field :deep(textarea),
+.form-field :deep(select) {
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 14px;
+  background: var(--input-bg);
+  color: var(--text-color);
+  transition: all 0.15s;
+}
+
+.form-field :deep(input:focus),
+.form-field :deep(textarea:focus),
+.form-field :deep(select:focus) {
+  outline: none;
+  border-color: var(--accent-color, #6366f1);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
+}
+
+.form-field :deep(input:disabled),
+.form-field :deep(textarea:disabled),
+.form-field :deep(select:disabled) {
+  background: var(--hover-bg);
+  cursor: not-allowed;
+}
+
+.has-error :deep(input),
+.has-error :deep(textarea),
+.has-error :deep(select) {
+  border-color: var(--error-color, #ef4444);
+}
+
+.has-error :deep(input:focus),
+.has-error :deep(textarea:focus),
+.has-error :deep(select:focus) {
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1);
+}
+
+.field-help {
+  font-size: 13px;
+  color: var(--muted-text);
+  margin: 0;
+}
+
+.field-error {
+  font-size: 13px;
+  color: var(--error-color, #ef4444);
+  margin: 0;
+}
+</style>

--- a/frontend/src/components/forms/FieldShell.vue
+++ b/frontend/src/components/forms/FieldShell.vue
@@ -61,7 +61,9 @@ defineProps<{
   gap: 8px;
 }
 
-.checkbox-wrapper :deep(input) {
+/* Scoped to the direct checkbox input only — a future widget rendered
+   with labelPosition='after' should NOT have its inputs miniaturised. */
+.checkbox-wrapper :deep(input[type='checkbox']) {
   width: 18px;
   height: 18px;
   cursor: pointer;
@@ -71,46 +73,9 @@ defineProps<{
   cursor: pointer;
 }
 
-.form-field :deep(input[type='text']),
-.form-field :deep(input[type='number']),
-.form-field :deep(input[type='date']),
-.form-field :deep(textarea),
-.form-field :deep(select) {
-  padding: 10px 12px;
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  font-size: 14px;
-  background: var(--input-bg);
-  color: var(--text-color);
-  transition: all 0.15s;
-}
-
-.form-field :deep(input:focus),
-.form-field :deep(textarea:focus),
-.form-field :deep(select:focus) {
-  outline: none;
-  border-color: var(--accent-color, #6366f1);
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
-}
-
-.form-field :deep(input:disabled),
-.form-field :deep(textarea:disabled),
-.form-field :deep(select:disabled) {
-  background: var(--hover-bg);
-  cursor: not-allowed;
-}
-
-.has-error :deep(input),
-.has-error :deep(textarea),
-.has-error :deep(select) {
-  border-color: var(--error-color, #ef4444);
-}
-
-.has-error :deep(input:focus),
-.has-error :deep(textarea:focus),
-.has-error :deep(select:focus) {
-  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1);
-}
+/* Input/textarea/select typography and focus/disabled/error visuals live
+   on each widget so they don't cross component boundaries via :deep().
+   FieldShell owns only label/help/error chrome and layout. */
 
 .field-help {
   font-size: 13px;

--- a/frontend/src/widgets/CheckboxWidget.vue
+++ b/frontend/src/widgets/CheckboxWidget.vue
@@ -5,7 +5,7 @@ import type { WidgetProps } from './types'
 const props = defineProps<WidgetProps>()
 
 const emit = defineEmits<{
-  'update:modelValue': [value: boolean]
+  'update:modelValue': [value: unknown]
 }>()
 
 const boolValue = computed(() => props.modelValue === true || props.modelValue === 'true')

--- a/frontend/src/widgets/CheckboxWidget.vue
+++ b/frontend/src/widgets/CheckboxWidget.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { WidgetProps } from './types'
+
+const props = defineProps<WidgetProps>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+}>()
+
+const boolValue = computed(() => props.modelValue === true || props.modelValue === 'true')
+
+function onChange(event: Event) {
+  emit('update:modelValue', (event.target as HTMLInputElement).checked)
+}
+</script>
+
+<template>
+  <input :id="id" type="checkbox" :checked="boolValue" :disabled="disabled" @change="onChange" />
+</template>

--- a/frontend/src/widgets/DateWidget.vue
+++ b/frontend/src/widgets/DateWidget.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed } from 'vue'
 import type { WidgetProps } from './types'
+import { useStringValue } from './useStringValue'
 
 const props = defineProps<WidgetProps>()
 
@@ -8,10 +8,7 @@ const emit = defineEmits<{
   'update:modelValue': [value: unknown]
 }>()
 
-const stringValue = computed(() => {
-  if (props.modelValue === null || props.modelValue === undefined) return ''
-  return String(props.modelValue)
-})
+const stringValue = useStringValue(() => props.modelValue)
 
 function onInput(event: Event) {
   emit('update:modelValue', (event.target as HTMLInputElement).value)
@@ -22,9 +19,41 @@ function onInput(event: Event) {
   <input
     :id="id"
     type="date"
+    :class="{ 'is-error': !!error }"
     :value="stringValue"
     :placeholder="placeholder"
     :disabled="disabled"
     @input="onInput"
   />
 </template>
+
+<style scoped>
+input {
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 14px;
+  background: var(--input-bg);
+  color: var(--text-color);
+  transition: all 0.15s;
+}
+
+input:focus {
+  outline: none;
+  border-color: var(--accent-color, #6366f1);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
+}
+
+input:disabled {
+  background: var(--hover-bg);
+  cursor: not-allowed;
+}
+
+input.is-error {
+  border-color: var(--error-color, #ef4444);
+}
+
+input.is-error:focus {
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1);
+}
+</style>

--- a/frontend/src/widgets/DateWidget.vue
+++ b/frontend/src/widgets/DateWidget.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { WidgetProps } from './types'
+
+const props = defineProps<WidgetProps>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: unknown]
+}>()
+
+const stringValue = computed(() => {
+  if (props.modelValue === null || props.modelValue === undefined) return ''
+  return String(props.modelValue)
+})
+
+function onInput(event: Event) {
+  emit('update:modelValue', (event.target as HTMLInputElement).value)
+}
+</script>
+
+<template>
+  <input
+    :id="id"
+    type="date"
+    :value="stringValue"
+    :placeholder="placeholder"
+    :disabled="disabled"
+    @input="onInput"
+  />
+</template>

--- a/frontend/src/widgets/MultiSelectWidget.vue
+++ b/frontend/src/widgets/MultiSelectWidget.vue
@@ -6,7 +6,7 @@ import type { WidgetProps } from './types'
 const props = defineProps<WidgetProps>()
 
 const emit = defineEmits<{
-  'update:modelValue': [value: string[]]
+  'update:modelValue': [value: unknown]
 }>()
 
 const options = computed(() => props.propertyDef?.values || [])

--- a/frontend/src/widgets/MultiSelectWidget.vue
+++ b/frontend/src/widgets/MultiSelectWidget.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import TagSelect from '@/components/ui/TagSelect.vue'
+import type { WidgetProps } from './types'
+
+const props = defineProps<WidgetProps>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string[]]
+}>()
+
+const options = computed(() => props.propertyDef?.values || [])
+
+const arrayValue = computed(() => {
+  if (Array.isArray(props.modelValue)) return props.modelValue.map(String)
+  if (props.modelValue) return [String(props.modelValue)]
+  return []
+})
+
+function onUpdate(value: string[]) {
+  emit('update:modelValue', value)
+}
+</script>
+
+<template>
+  <TagSelect
+    :model-value="arrayValue"
+    :options="options"
+    :placeholder="placeholder || 'Select...'"
+    :disabled="disabled"
+    :option-verdicts="optionVerdicts"
+    @update:model-value="onUpdate"
+  />
+</template>

--- a/frontend/src/widgets/NumberWidget.vue
+++ b/frontend/src/widgets/NumberWidget.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { WidgetProps } from './types'
+
+const props = defineProps<WidgetProps>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: unknown]
+}>()
+
+const stringValue = computed(() => {
+  if (props.modelValue === null || props.modelValue === undefined) return ''
+  return String(props.modelValue)
+})
+
+function onInput(event: Event) {
+  const raw = (event.target as HTMLInputElement).value
+  const num = parseInt(raw, 10)
+  // Preserve FieldRenderer behaviour: emit the parsed integer, or the
+  // raw string when it isn't a valid integer (e.g. mid-typing "-").
+  emit('update:modelValue', isNaN(num) ? raw : num)
+}
+</script>
+
+<template>
+  <input
+    :id="id"
+    type="number"
+    :value="stringValue"
+    :placeholder="placeholder"
+    :disabled="disabled"
+    @input="onInput"
+  />
+</template>

--- a/frontend/src/widgets/NumberWidget.vue
+++ b/frontend/src/widgets/NumberWidget.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed } from 'vue'
 import type { WidgetProps } from './types'
+import { useStringValue } from './useStringValue'
 
 const props = defineProps<WidgetProps>()
 
@@ -8,10 +8,7 @@ const emit = defineEmits<{
   'update:modelValue': [value: unknown]
 }>()
 
-const stringValue = computed(() => {
-  if (props.modelValue === null || props.modelValue === undefined) return ''
-  return String(props.modelValue)
-})
+const stringValue = useStringValue(() => props.modelValue)
 
 function onInput(event: Event) {
   const raw = (event.target as HTMLInputElement).value
@@ -26,9 +23,41 @@ function onInput(event: Event) {
   <input
     :id="id"
     type="number"
+    :class="{ 'is-error': !!error }"
     :value="stringValue"
     :placeholder="placeholder"
     :disabled="disabled"
     @input="onInput"
   />
 </template>
+
+<style scoped>
+input {
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 14px;
+  background: var(--input-bg);
+  color: var(--text-color);
+  transition: all 0.15s;
+}
+
+input:focus {
+  outline: none;
+  border-color: var(--accent-color, #6366f1);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
+}
+
+input:disabled {
+  background: var(--hover-bg);
+  cursor: not-allowed;
+}
+
+input.is-error {
+  border-color: var(--error-color, #ef4444);
+}
+
+input.is-error:focus {
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1);
+}
+</style>

--- a/frontend/src/widgets/RruleWidget.vue
+++ b/frontend/src/widgets/RruleWidget.vue
@@ -1,18 +1,15 @@
 <script setup lang="ts">
-import { computed } from 'vue'
 import RruleBuilder from '@/components/forms/RruleBuilder.vue'
 import type { WidgetProps } from './types'
+import { useStringValue } from './useStringValue'
 
 const props = defineProps<WidgetProps>()
 
 const emit = defineEmits<{
-  'update:modelValue': [value: string]
+  'update:modelValue': [value: unknown]
 }>()
 
-const stringValue = computed(() => {
-  if (props.modelValue === null || props.modelValue === undefined) return ''
-  return String(props.modelValue)
-})
+const stringValue = useStringValue(() => props.modelValue)
 </script>
 
 <template>

--- a/frontend/src/widgets/RruleWidget.vue
+++ b/frontend/src/widgets/RruleWidget.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import RruleBuilder from '@/components/forms/RruleBuilder.vue'
+import type { WidgetProps } from './types'
+
+const props = defineProps<WidgetProps>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const stringValue = computed(() => {
+  if (props.modelValue === null || props.modelValue === undefined) return ''
+  return String(props.modelValue)
+})
+</script>
+
+<template>
+  <RruleBuilder
+    :model-value="stringValue"
+    :help="help"
+    :readonly="disabled"
+    @update:model-value="emit('update:modelValue', $event)"
+  />
+</template>

--- a/frontend/src/widgets/SelectWidget.vue
+++ b/frontend/src/widgets/SelectWidget.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { WidgetProps } from './types'
+
+const props = defineProps<WidgetProps>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: unknown]
+}>()
+
+const stringValue = computed(() => {
+  if (props.modelValue === null || props.modelValue === undefined) return ''
+  return String(props.modelValue)
+})
+
+const options = computed(() => props.propertyDef?.values || [])
+
+const hasTransitions = computed(
+  () => !!props.transitions && Object.keys(props.transitions).length > 0
+)
+
+const transitionEntries = computed(() => {
+  if (!props.transitions) return []
+  return Object.entries(props.transitions).sort((a, b) => a[0].localeCompare(b[0]))
+})
+
+// An option is disabled when EITHER the affordance verdict denies it OR
+// the active transition rules don't permit moving to it. The two signals
+// are independent; either is sufficient.
+function isOptionDisabled(opt: string): boolean {
+  if (props.optionVerdicts && props.optionVerdicts[opt] === false) {
+    return true
+  }
+  if (!hasTransitions.value || !props.transitions) {
+    return false
+  }
+  const currentVal = stringValue.value
+  if (!currentVal || opt === currentVal) {
+    return false
+  }
+  const allowed = props.transitions[currentVal] || []
+  return !allowed.includes(opt)
+}
+
+function onChange(event: Event) {
+  emit('update:modelValue', (event.target as HTMLSelectElement).value)
+}
+</script>
+
+<template>
+  <div class="select-widget">
+    <select :id="id" :value="stringValue" :disabled="disabled" @change="onChange">
+      <option value="">Select...</option>
+      <option
+        v-for="opt in options"
+        :key="opt"
+        :value="opt"
+        :disabled="isOptionDisabled(opt)"
+        :class="{ 'disabled-transition': isOptionDisabled(opt) }"
+      >
+        {{ opt }}{{ isOptionDisabled(opt) ? ' (not allowed)' : '' }}
+      </option>
+    </select>
+
+    <div v-if="hasTransitions" class="transitions-info">
+      <p class="transitions-title">Allowed transitions</p>
+      <div v-for="[from, tos] in transitionEntries" :key="from" class="transitions-row">
+        <span class="transitions-from">{{ from }}</span>
+        <span class="transitions-arrow">&rarr;</span>
+        <span class="transitions-to">{{ tos.join(', ') }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.select-widget {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+select {
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 14px;
+  background: var(--input-bg);
+  color: var(--text-color);
+  transition: all 0.15s;
+}
+
+select:focus {
+  outline: none;
+  border-color: var(--accent-color, #6366f1);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
+}
+
+select:disabled {
+  background: var(--hover-bg);
+  cursor: not-allowed;
+}
+
+.transitions-info {
+  padding: 12px;
+  background: var(--hover-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+}
+
+.transitions-title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--muted-text);
+  margin: 0 0 8px;
+}
+
+.transitions-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  padding: 4px 0;
+}
+
+.transitions-from {
+  font-weight: 500;
+  color: var(--text-color);
+}
+
+.transitions-arrow {
+  color: var(--muted-text);
+}
+
+.transitions-to {
+  color: var(--muted-text);
+}
+
+.disabled-transition {
+  color: var(--muted-text);
+  font-style: italic;
+}
+</style>

--- a/frontend/src/widgets/SelectWidget.vue
+++ b/frontend/src/widgets/SelectWidget.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { WidgetProps } from './types'
+import { useStringValue } from './useStringValue'
 
 const props = defineProps<WidgetProps>()
 
@@ -8,10 +9,7 @@ const emit = defineEmits<{
   'update:modelValue': [value: unknown]
 }>()
 
-const stringValue = computed(() => {
-  if (props.modelValue === null || props.modelValue === undefined) return ''
-  return String(props.modelValue)
-})
+const stringValue = useStringValue(() => props.modelValue)
 
 const options = computed(() => props.propertyDef?.values || [])
 
@@ -49,7 +47,13 @@ function onChange(event: Event) {
 
 <template>
   <div class="select-widget">
-    <select :id="id" :value="stringValue" :disabled="disabled" @change="onChange">
+    <select
+      :id="id"
+      :class="{ 'is-error': !!error }"
+      :value="stringValue"
+      :disabled="disabled"
+      @change="onChange"
+    >
       <option value="">Select...</option>
       <option
         v-for="opt in options"
@@ -101,7 +105,20 @@ select:disabled {
   cursor: not-allowed;
 }
 
+select.is-error {
+  border-color: var(--error-color, #ef4444);
+}
+
+select.is-error:focus {
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1);
+}
+
+/* Restores the pre-refactor 14px stack: old layout had .form-field
+   gap:6px plus .transitions-info margin-top:8px = 14px. The new
+   .select-widget wrapper uses gap:8px; the 6px top here makes the
+   combined gap 14px. */
 .transitions-info {
+  margin-top: 6px;
   padding: 12px;
   background: var(--hover-bg);
   border: 1px solid var(--border-color);

--- a/frontend/src/widgets/TextWidget.vue
+++ b/frontend/src/widgets/TextWidget.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { WidgetProps } from './types'
+
+const props = defineProps<WidgetProps>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: unknown]
+}>()
+
+const stringValue = computed(() => {
+  if (props.modelValue === null || props.modelValue === undefined) return ''
+  return String(props.modelValue)
+})
+
+function onInput(event: Event) {
+  emit('update:modelValue', (event.target as HTMLInputElement).value)
+}
+</script>
+
+<template>
+  <input
+    :id="id"
+    type="text"
+    :value="stringValue"
+    :placeholder="placeholder"
+    :disabled="disabled"
+    @input="onInput"
+  />
+</template>

--- a/frontend/src/widgets/TextWidget.vue
+++ b/frontend/src/widgets/TextWidget.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed } from 'vue'
 import type { WidgetProps } from './types'
+import { useStringValue } from './useStringValue'
 
 const props = defineProps<WidgetProps>()
 
@@ -8,10 +8,7 @@ const emit = defineEmits<{
   'update:modelValue': [value: unknown]
 }>()
 
-const stringValue = computed(() => {
-  if (props.modelValue === null || props.modelValue === undefined) return ''
-  return String(props.modelValue)
-})
+const stringValue = useStringValue(() => props.modelValue)
 
 function onInput(event: Event) {
   emit('update:modelValue', (event.target as HTMLInputElement).value)
@@ -22,9 +19,41 @@ function onInput(event: Event) {
   <input
     :id="id"
     type="text"
+    :class="{ 'is-error': !!error }"
     :value="stringValue"
     :placeholder="placeholder"
     :disabled="disabled"
     @input="onInput"
   />
 </template>
+
+<style scoped>
+input {
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 14px;
+  background: var(--input-bg);
+  color: var(--text-color);
+  transition: all 0.15s;
+}
+
+input:focus {
+  outline: none;
+  border-color: var(--accent-color, #6366f1);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
+}
+
+input:disabled {
+  background: var(--hover-bg);
+  cursor: not-allowed;
+}
+
+input.is-error {
+  border-color: var(--error-color, #ef4444);
+}
+
+input.is-error:focus {
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1);
+}
+</style>

--- a/frontend/src/widgets/TextareaWidget.vue
+++ b/frontend/src/widgets/TextareaWidget.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { WidgetProps } from './types'
+
+const props = defineProps<WidgetProps>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: unknown]
+}>()
+
+const stringValue = computed(() => {
+  if (props.modelValue === null || props.modelValue === undefined) return ''
+  return String(props.modelValue)
+})
+
+function onInput(event: Event) {
+  emit('update:modelValue', (event.target as HTMLTextAreaElement).value)
+}
+</script>
+
+<template>
+  <textarea
+    :id="id"
+    :value="stringValue"
+    :placeholder="placeholder"
+    :disabled="disabled"
+    rows="4"
+    @input="onInput"
+  />
+</template>

--- a/frontend/src/widgets/TextareaWidget.vue
+++ b/frontend/src/widgets/TextareaWidget.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed } from 'vue'
 import type { WidgetProps } from './types'
+import { useStringValue } from './useStringValue'
 
 const props = defineProps<WidgetProps>()
 
@@ -8,10 +8,7 @@ const emit = defineEmits<{
   'update:modelValue': [value: unknown]
 }>()
 
-const stringValue = computed(() => {
-  if (props.modelValue === null || props.modelValue === undefined) return ''
-  return String(props.modelValue)
-})
+const stringValue = useStringValue(() => props.modelValue)
 
 function onInput(event: Event) {
   emit('update:modelValue', (event.target as HTMLTextAreaElement).value)
@@ -21,6 +18,7 @@ function onInput(event: Event) {
 <template>
   <textarea
     :id="id"
+    :class="{ 'is-error': !!error }"
     :value="stringValue"
     :placeholder="placeholder"
     :disabled="disabled"
@@ -28,3 +26,34 @@ function onInput(event: Event) {
     @input="onInput"
   />
 </template>
+
+<style scoped>
+textarea {
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 14px;
+  background: var(--input-bg);
+  color: var(--text-color);
+  transition: all 0.15s;
+}
+
+textarea:focus {
+  outline: none;
+  border-color: var(--accent-color, #6366f1);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
+}
+
+textarea:disabled {
+  background: var(--hover-bg);
+  cursor: not-allowed;
+}
+
+textarea.is-error {
+  border-color: var(--error-color, #ef4444);
+}
+
+textarea.is-error:focus {
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1);
+}
+</style>

--- a/frontend/src/widgets/registry.test.ts
+++ b/frontend/src/widgets/registry.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { defineComponent } from 'vue'
+import type { PropertyDef } from '@/types'
+import { defineWidgetRegistry, defaultWidgetFor, defaultRegistry } from './registry'
+import TextWidget from './TextWidget.vue'
+import CheckboxWidget from './CheckboxWidget.vue'
+import SelectWidget from './SelectWidget.vue'
+import MultiSelectWidget from './MultiSelectWidget.vue'
+import DateWidget from './DateWidget.vue'
+import NumberWidget from './NumberWidget.vue'
+import RruleWidget from './RruleWidget.vue'
+
+function makeStub(name: string) {
+  return defineComponent({ name, render: () => null })
+}
+const Stub = makeStub('Stub')
+const Stub2 = makeStub('Stub2')
+
+describe('defaultWidgetFor', () => {
+  // Pins the historical FieldRenderer dispatch order (RR-0Z1P6).
+  it.each<[string, PropertyDef | undefined, string]>([
+    ['undefined propertyDef', undefined, 'text'],
+    ['plain string', { type: 'string' }, 'text'],
+    ['file', { type: 'file' }, 'text'],
+    ['boolean', { type: 'boolean' }, 'checkbox'],
+    ['date', { type: 'date' }, 'date'],
+    ['integer', { type: 'integer' }, 'number'],
+    ['rrule', { type: 'rrule' }, 'rrule'],
+    ['enum with values', { type: 'enum', values: ['a', 'b'] }, 'select'],
+    ['string with values', { type: 'string', values: ['a'] }, 'select'],
+    ['empty values array', { type: 'enum', values: [] }, 'text'],
+    ['list wins over values', { type: 'enum', values: ['a'], list: true }, 'multi-select'],
+    ['list wins over boolean', { type: 'boolean', list: true }, 'multi-select'],
+  ])('%s -> %s', (_name, def, expected) => {
+    expect(defaultWidgetFor(def)).toBe(expected)
+  })
+})
+
+describe('defineWidgetRegistry', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('resolves an explicitly named widget over the type default', () => {
+    const r = defineWidgetRegistry()
+    r.register('text', { component: TextWidget })
+    r.register('textarea', { component: Stub })
+    // type default for string would be text, but explicit name wins.
+    expect(r.resolve('textarea', { type: 'string' })).toBe(Stub)
+  })
+
+  it('falls back to the type default when no name is given', () => {
+    const r = defineWidgetRegistry()
+    r.register('text', { component: TextWidget })
+    r.register('checkbox', { component: Stub })
+    expect(r.resolve(undefined, { type: 'boolean' })).toBe(Stub)
+  })
+
+  it('treats an empty-string widget name as no name', () => {
+    const r = defineWidgetRegistry()
+    r.register('text', { component: TextWidget })
+    r.register('checkbox', { component: Stub })
+    expect(r.resolve('   ', { type: 'boolean' })).toBe(Stub)
+  })
+
+  it('warns and falls back when an explicit name is unknown', () => {
+    const r = defineWidgetRegistry()
+    r.register('text', { component: TextWidget })
+    const got = r.resolve('does-not-exist', { type: 'string' })
+    expect(got).toBe(TextWidget)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unknown widget "does-not-exist"'))
+  })
+
+  it('falls back to text when the type default is not registered', () => {
+    const r = defineWidgetRegistry()
+    r.register('text', { component: TextWidget })
+    // No date widget registered; should fall back to text.
+    expect(r.resolve(undefined, { type: 'date' })).toBe(TextWidget)
+  })
+
+  it('throws when nothing — not even text — can be resolved', () => {
+    const r = defineWidgetRegistry()
+    expect(() => r.resolve(undefined, { type: 'string' })).toThrow(/no widget could be resolved/)
+  })
+
+  it('warns when the resolved widget does not declare the property type', () => {
+    const r = defineWidgetRegistry()
+    r.register('text', { component: TextWidget })
+    r.register('checkbox', { component: Stub, supportedPropertyTypes: ['boolean'] })
+    r.resolve('checkbox', { type: 'string' })
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('does not declare support for property type "string"')
+    )
+  })
+
+  it('does not warn when the property type is supported', () => {
+    const r = defineWidgetRegistry()
+    r.register('checkbox', { component: Stub, supportedPropertyTypes: ['boolean'] })
+    r.resolve('checkbox', { type: 'boolean' })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not warn about type support when propertyDef is absent', () => {
+    const r = defineWidgetRegistry()
+    r.register('text', { component: TextWidget, supportedPropertyTypes: ['string'] })
+    r.resolve('text', undefined)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('warns on re-registration of the same name and the last one wins', () => {
+    const r = defineWidgetRegistry()
+    r.register('text', { component: TextWidget })
+    r.register('text', { component: Stub2 })
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('re-registering widget "text"'))
+    expect(r.resolve('text', { type: 'string' })).toBe(Stub2)
+  })
+
+  it('builds isolated registries that do not share state', () => {
+    const a = defineWidgetRegistry()
+    const b = defineWidgetRegistry()
+    a.register('text', { component: TextWidget })
+    b.register('text', { component: Stub })
+    expect(a.resolve('text', { type: 'string' })).toBe(TextWidget)
+    expect(b.resolve('text', { type: 'string' })).toBe(Stub)
+  })
+})
+
+describe('defaultRegistry', () => {
+  it('resolves every production widget by name', () => {
+    expect(defaultRegistry.resolve('text', { type: 'string' })).toBe(TextWidget)
+    expect(defaultRegistry.resolve('checkbox', { type: 'boolean' })).toBe(CheckboxWidget)
+    expect(defaultRegistry.resolve('select', { type: 'enum', values: ['a'] })).toBe(SelectWidget)
+    expect(defaultRegistry.resolve('multi-select', { type: 'enum', list: true })).toBe(
+      MultiSelectWidget
+    )
+    expect(defaultRegistry.resolve('date', { type: 'date' })).toBe(DateWidget)
+    expect(defaultRegistry.resolve('number', { type: 'integer' })).toBe(NumberWidget)
+    expect(defaultRegistry.resolve('rrule', { type: 'rrule' })).toBe(RruleWidget)
+  })
+
+  it('resolves by type default with no explicit name', () => {
+    expect(defaultRegistry.resolve(undefined, { type: 'boolean' })).toBe(CheckboxWidget)
+    expect(defaultRegistry.resolve(undefined, { type: 'date' })).toBe(DateWidget)
+    expect(defaultRegistry.resolve(undefined, { list: true, type: 'enum' })).toBe(MultiSelectWidget)
+    expect(defaultRegistry.resolve(undefined, { type: 'string' })).toBe(TextWidget)
+  })
+})

--- a/frontend/src/widgets/registry.test.ts
+++ b/frontend/src/widgets/registry.test.ts
@@ -149,4 +149,24 @@ describe('defaultRegistry', () => {
     expect(defaultRegistry.resolve(undefined, { list: true, type: 'enum' })).toBe(MultiSelectWidget)
     expect(defaultRegistry.resolve(undefined, { type: 'string' })).toBe(TextWidget)
   })
+
+  it('falls back to the property-type default when the explicit name is unknown', () => {
+    // Pin the warn-then-default path on a non-string property so the
+    // fallback is observably not just the universal text widget.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(defaultRegistry.resolve('does-not-exist', { type: 'boolean' })).toBe(CheckboxWidget)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unknown widget "does-not-exist"'))
+    warnSpy.mockRestore()
+  })
+
+  it('warns when something double-registers a name into defaultRegistry', () => {
+    // Mirrors what would happen if a plugin (or an accidental double
+    // import) tried to clobber a production widget.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    defaultRegistry.register('text', { component: makeStub('PluginText') })
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('re-registering widget "text"'))
+    // Restore the production widget so subsequent tests see the canonical state.
+    defaultRegistry.register('text', { component: TextWidget })
+    warnSpy.mockRestore()
+  })
 })

--- a/frontend/src/widgets/registry.ts
+++ b/frontend/src/widgets/registry.ts
@@ -1,0 +1,91 @@
+import type { PropertyDef } from '@/types'
+import type { WidgetEntry, WidgetRegistry } from './types'
+import TextWidget from './TextWidget.vue'
+import TextareaWidget from './TextareaWidget.vue'
+import NumberWidget from './NumberWidget.vue'
+import CheckboxWidget from './CheckboxWidget.vue'
+import DateWidget from './DateWidget.vue'
+import SelectWidget from './SelectWidget.vue'
+import MultiSelectWidget from './MultiSelectWidget.vue'
+import RruleWidget from './RruleWidget.vue'
+
+// defaultWidgetFor reproduces FieldRenderer's historical dispatch order
+// exactly (RR-0Z1P6). Order matters: `list` wins over `values`, which
+// wins over scalar type. Changing this order is a behaviour change and a
+// separate ticket.
+export function defaultWidgetFor(propertyDef?: PropertyDef): string {
+  if (propertyDef?.list === true) return 'multi-select'
+  if ((propertyDef?.values?.length ?? 0) > 0) return 'select'
+  if (propertyDef?.type === 'boolean') return 'checkbox'
+  if (propertyDef?.type === 'date') return 'date'
+  if (propertyDef?.type === 'integer') return 'number'
+  if (propertyDef?.type === 'rrule') return 'rrule'
+  return 'text'
+}
+
+export function defineWidgetRegistry(): WidgetRegistry {
+  const entries = new Map<string, WidgetEntry>()
+
+  return {
+    register(name, entry) {
+      if (entries.has(name)) {
+        console.warn(`[widget-registry] re-registering widget "${name}"`)
+      }
+      entries.set(name, entry)
+    },
+
+    resolve(name, propertyDef) {
+      // An explicit widget name wins; falls back to type-based defaulting.
+      const requested = name && name.trim() !== '' ? name : undefined
+      const resolvedName = requested ?? defaultWidgetFor(propertyDef)
+
+      let entry = entries.get(resolvedName)
+      if (!entry) {
+        if (requested) {
+          console.warn(
+            `[widget-registry] unknown widget "${requested}"; falling back to type default`
+          )
+        }
+        entry = entries.get(defaultWidgetFor(propertyDef))
+      }
+      if (!entry) {
+        // text is the universal fallback and is always registered.
+        entry = entries.get('text')
+      }
+      if (!entry) {
+        throw new Error('[widget-registry] no widget could be resolved (text widget missing)')
+      }
+
+      const ptype = propertyDef?.type
+      if (
+        ptype &&
+        entry.supportedPropertyTypes &&
+        !entry.supportedPropertyTypes.includes(ptype)
+      ) {
+        console.warn(
+          `[widget-registry] widget "${resolvedName}" does not declare support for property type "${ptype}"`
+        )
+      }
+
+      return entry.component
+    },
+  }
+}
+
+function buildDefaultRegistry(): WidgetRegistry {
+  const r = defineWidgetRegistry()
+  r.register('text', { component: TextWidget, supportedPropertyTypes: ['string', 'file'] })
+  r.register('textarea', { component: TextareaWidget, supportedPropertyTypes: ['string'] })
+  r.register('number', { component: NumberWidget, supportedPropertyTypes: ['integer'] })
+  r.register('checkbox', { component: CheckboxWidget, supportedPropertyTypes: ['boolean'] })
+  r.register('date', { component: DateWidget, supportedPropertyTypes: ['date'] })
+  r.register('select', { component: SelectWidget, supportedPropertyTypes: ['enum', 'string'] })
+  r.register('multi-select', {
+    component: MultiSelectWidget,
+    supportedPropertyTypes: ['enum', 'string'],
+  })
+  r.register('rrule', { component: RruleWidget, supportedPropertyTypes: ['rrule'] })
+  return r
+}
+
+export const defaultRegistry: WidgetRegistry = buildDefaultRegistry()

--- a/frontend/src/widgets/types.ts
+++ b/frontend/src/widgets/types.ts
@@ -1,0 +1,40 @@
+import type { Component } from 'vue'
+import type { PropertyDef } from '@/types'
+
+// PropertyType mirrors PropertyDef['type'] from the metamodel schema.
+// Kept as a named alias so widget entries can declare which property
+// types they support; if PropertyDef['type'] gains a member, widgets
+// that need updating surface as type errors here.
+export type PropertyType = PropertyDef['type']
+
+// WidgetProps is the contract every property widget accepts. Cross-cutting
+// concerns (disabled, error, etc.) are first-class so widgets never reach
+// into an untyped options blob for them; options carries only genuinely
+// widget-specific config.
+export interface WidgetProps<T = unknown> {
+  modelValue: T
+  propertyDef?: PropertyDef
+  disabled?: boolean
+  required?: boolean
+  error?: string
+  id?: string
+  placeholder?: string
+  help?: string
+  // Sparse per-option allow map (select / multi-select). Only `false`
+  // entries appear; absent keys default to allowed.
+  optionVerdicts?: Record<string, boolean>
+  // Allowed status transitions keyed by current value (select only).
+  transitions?: Record<string, string[]>
+}
+
+export interface WidgetEntry {
+  component: Component
+  // Advisory only: a mismatch logs a console.warn but the widget still
+  // renders. Tightening to a hard reject is a deliberate follow-up.
+  supportedPropertyTypes?: PropertyType[]
+}
+
+export interface WidgetRegistry {
+  register(name: string, entry: WidgetEntry): void
+  resolve(name: string | undefined, propertyDef?: PropertyDef): Component
+}

--- a/frontend/src/widgets/useStringValue.ts
+++ b/frontend/src/widgets/useStringValue.ts
@@ -1,0 +1,13 @@
+import { computed, type ComputedRef } from 'vue'
+
+// Renders a property value as a string for input/textarea/select binding.
+// null and undefined become '' so the browser doesn't show "null"/"undefined";
+// everything else gets String() coerced — same shape as FieldRenderer's
+// historical stringValue helper.
+export function useStringValue(source: () => unknown): ComputedRef<string> {
+  return computed(() => {
+    const v = source()
+    if (v === null || v === undefined) return ''
+    return String(v)
+  })
+}

--- a/frontend/src/widgets/widgets.test.ts
+++ b/frontend/src/widgets/widgets.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TextWidget from './TextWidget.vue'
+import TextareaWidget from './TextareaWidget.vue'
+import NumberWidget from './NumberWidget.vue'
+import CheckboxWidget from './CheckboxWidget.vue'
+import DateWidget from './DateWidget.vue'
+import SelectWidget from './SelectWidget.vue'
+
+describe('TextWidget', () => {
+  it('renders the value and emits update:modelValue on input', async () => {
+    const w = mount(TextWidget, { props: { modelValue: 'hello' } })
+    const input = w.find('input[type="text"]')
+    expect((input.element as HTMLInputElement).value).toBe('hello')
+    await input.setValue('world')
+    expect(w.emitted('update:modelValue')?.[0]).toEqual(['world'])
+  })
+
+  it('renders empty for null/undefined', () => {
+    expect((mount(TextWidget, { props: { modelValue: null } }).find('input').element as HTMLInputElement).value).toBe('')
+    expect(
+      (mount(TextWidget, { props: { modelValue: undefined } }).find('input').element as HTMLInputElement).value
+    ).toBe('')
+  })
+
+  it('honours disabled', () => {
+    const w = mount(TextWidget, { props: { modelValue: 'x', disabled: true } })
+    expect(w.find('input').attributes('disabled')).toBeDefined()
+  })
+})
+
+describe('TextareaWidget', () => {
+  it('renders the value and emits on input', async () => {
+    const w = mount(TextareaWidget, { props: { modelValue: 'multi\nline' } })
+    const ta = w.find('textarea')
+    expect((ta.element as HTMLTextAreaElement).value).toBe('multi\nline')
+    await ta.setValue('changed')
+    expect(w.emitted('update:modelValue')?.[0]).toEqual(['changed'])
+  })
+})
+
+describe('NumberWidget', () => {
+  it('emits a parsed integer for numeric input', async () => {
+    const w = mount(NumberWidget, { props: { modelValue: 1 } })
+    await w.find('input').setValue('42')
+    expect(w.emitted('update:modelValue')?.[0]).toEqual([42])
+  })
+
+  it('emits the raw string when input does not parse to an integer', async () => {
+    const w = mount(NumberWidget, { props: { modelValue: 1 } })
+    // A number input clears to '' for non-numeric content; parseInt('')
+    // is NaN, so the handler emits the raw value — exercising the NaN
+    // branch that preserves FieldRenderer's historical behaviour.
+    await w.find('input').setValue('')
+    expect(w.emitted('update:modelValue')?.[0]).toEqual([''])
+  })
+})
+
+describe('CheckboxWidget', () => {
+  it('reflects boolean true and string "true"', () => {
+    expect((mount(CheckboxWidget, { props: { modelValue: true } }).find('input').element as HTMLInputElement).checked).toBe(true)
+    expect((mount(CheckboxWidget, { props: { modelValue: 'true' } }).find('input').element as HTMLInputElement).checked).toBe(true)
+    expect((mount(CheckboxWidget, { props: { modelValue: false } }).find('input').element as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('emits the checked boolean on change', async () => {
+    const w = mount(CheckboxWidget, { props: { modelValue: false } })
+    await w.find('input').setValue(true)
+    expect(w.emitted('update:modelValue')?.[0]).toEqual([true])
+  })
+})
+
+describe('DateWidget', () => {
+  it('renders a date input and emits on input', async () => {
+    const w = mount(DateWidget, { props: { modelValue: '2026-05-29' } })
+    const input = w.find('input[type="date"]')
+    expect(input.exists()).toBe(true)
+    expect((input.element as HTMLInputElement).value).toBe('2026-05-29')
+    await input.setValue('2026-06-01')
+    expect(w.emitted('update:modelValue')?.[0]).toEqual(['2026-06-01'])
+  })
+})
+
+describe('SelectWidget', () => {
+  const def = { type: 'enum' as const, values: ['open', 'review', 'done'] }
+
+  it('renders options from propertyDef and emits the chosen value', async () => {
+    const w = mount(SelectWidget, { props: { modelValue: 'open', propertyDef: def } })
+    const opts = w.findAll('option').map((o) => o.attributes('value'))
+    expect(opts).toEqual(['', 'open', 'review', 'done'])
+    await w.find('select').setValue('review')
+    expect(w.emitted('update:modelValue')?.[0]).toEqual(['review'])
+  })
+
+  it('disables options denied by optionVerdicts', () => {
+    const w = mount(SelectWidget, {
+      props: { modelValue: 'open', propertyDef: def, optionVerdicts: { done: false } },
+    })
+    const byValue = Object.fromEntries(w.findAll('option').map((o) => [o.attributes('value'), o]))
+    expect(byValue['done'].attributes('disabled')).toBeDefined()
+    expect(byValue['review'].attributes('disabled')).toBeUndefined()
+    expect(w.find('select').attributes('disabled')).toBeUndefined()
+  })
+
+  it('disables options not reachable by transition rules', () => {
+    const w = mount(SelectWidget, {
+      props: { modelValue: 'open', propertyDef: def, transitions: { open: ['review'] } },
+    })
+    const byValue = Object.fromEntries(w.findAll('option').map((o) => [o.attributes('value'), o]))
+    expect(byValue['done'].attributes('disabled')).toBeDefined()
+    expect(byValue['review'].attributes('disabled')).toBeUndefined()
+  })
+
+  it('renders the transitions info panel when transitions are present', () => {
+    const w = mount(SelectWidget, {
+      props: { modelValue: 'open', propertyDef: def, transitions: { open: ['review'] } },
+    })
+    expect(w.find('.transitions-info').exists()).toBe(true)
+  })
+
+  it('renders no transitions panel without transitions', () => {
+    const w = mount(SelectWidget, { props: { modelValue: 'open', propertyDef: def } })
+    expect(w.find('.transitions-info').exists()).toBe(false)
+  })
+
+  it('honours whole-select disabled', () => {
+    const w = mount(SelectWidget, { props: { modelValue: 'open', propertyDef: def, disabled: true } })
+    expect(w.find('select').attributes('disabled')).toBeDefined()
+  })
+})

--- a/frontend/src/widgets/wrapperWidgets.test.ts
+++ b/frontend/src/widgets/wrapperWidgets.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import MultiSelectWidget from './MultiSelectWidget.vue'
+import RruleWidget from './RruleWidget.vue'
+
+// TagSelect wraps SlimSelect, whose MutationObserver doesn't mount
+// cleanly under happy-dom; RruleBuilder is heavy. Both widgets are thin
+// adapters, so we stub the wrapped component and assert the adapter's
+// prop mapping and event re-emission instead.
+
+describe('MultiSelectWidget', () => {
+  const stubs = { TagSelect: true }
+
+  it('maps an array model value to string options for TagSelect', () => {
+    const w = mount(MultiSelectWidget, {
+      props: { modelValue: ['a', 1], propertyDef: { type: 'enum', values: ['a', '1', 'b'] } },
+      global: { stubs },
+    })
+    const tag = w.findComponent({ name: 'TagSelect' })
+    expect(tag.props('modelValue')).toEqual(['a', '1'])
+    expect(tag.props('options')).toEqual(['a', '1', 'b'])
+  })
+
+  it('coerces a scalar model value to a single-item array', () => {
+    const w = mount(MultiSelectWidget, {
+      props: { modelValue: 'solo', propertyDef: { type: 'enum' } },
+      global: { stubs },
+    })
+    expect(w.findComponent({ name: 'TagSelect' }).props('modelValue')).toEqual(['solo'])
+  })
+
+  it('treats empty model value as an empty array', () => {
+    const w = mount(MultiSelectWidget, {
+      props: { modelValue: null, propertyDef: { type: 'enum' } },
+      global: { stubs },
+    })
+    expect(w.findComponent({ name: 'TagSelect' }).props('modelValue')).toEqual([])
+  })
+
+  it('re-emits TagSelect updates as update:modelValue', async () => {
+    const w = mount(MultiSelectWidget, {
+      props: { modelValue: [], propertyDef: { type: 'enum' } },
+      global: { stubs },
+    })
+    w.findComponent({ name: 'TagSelect' }).vm.$emit('update:modelValue', ['x', 'y'])
+    await w.vm.$nextTick()
+    expect(w.emitted('update:modelValue')?.[0]).toEqual([['x', 'y']])
+  })
+
+  it('passes disabled and optionVerdicts through', () => {
+    const w = mount(MultiSelectWidget, {
+      props: {
+        modelValue: [],
+        propertyDef: { type: 'enum', values: ['a'] },
+        disabled: true,
+        optionVerdicts: { a: false },
+      },
+      global: { stubs },
+    })
+    const tag = w.findComponent({ name: 'TagSelect' })
+    expect(tag.props('disabled')).toBe(true)
+    expect(tag.props('optionVerdicts')).toEqual({ a: false })
+  })
+})
+
+describe('RruleWidget', () => {
+  const stubs = { RruleBuilder: true }
+
+  it('passes the stringified model value and help to RruleBuilder', () => {
+    const w = mount(RruleWidget, {
+      props: { modelValue: 'FREQ=DAILY', help: 'every day', propertyDef: { type: 'rrule' } },
+      global: { stubs },
+    })
+    const builder = w.findComponent({ name: 'RruleBuilder' })
+    expect(builder.props('modelValue')).toBe('FREQ=DAILY')
+    expect(builder.props('help')).toBe('every day')
+  })
+
+  it('renders empty for a null model value', () => {
+    const w = mount(RruleWidget, {
+      props: { modelValue: null, propertyDef: { type: 'rrule' } },
+      global: { stubs },
+    })
+    expect(w.findComponent({ name: 'RruleBuilder' }).props('modelValue')).toBe('')
+  })
+
+  it('maps disabled to the builder readonly prop', () => {
+    const w = mount(RruleWidget, {
+      props: { modelValue: '', disabled: true, propertyDef: { type: 'rrule' } },
+      global: { stubs },
+    })
+    expect(w.findComponent({ name: 'RruleBuilder' }).props('readonly')).toBe(true)
+  })
+
+  it('re-emits builder updates as update:modelValue', async () => {
+    const w = mount(RruleWidget, {
+      props: { modelValue: '', propertyDef: { type: 'rrule' } },
+      global: { stubs },
+    })
+    w.findComponent({ name: 'RruleBuilder' }).vm.$emit('update:modelValue', 'FREQ=WEEKLY')
+    await w.vm.$nextTick()
+    expect(w.emitted('update:modelValue')?.[0]).toEqual(['FREQ=WEEKLY'])
+  })
+})

--- a/tickets/entities/features/FEAT-72NR1.md
+++ b/tickets/entities/features/FEAT-72NR1.md
@@ -1,0 +1,20 @@
+---
+id: FEAT-72NR1
+type: feature
+title: Unify widgets across form and view screens
+summary: Make 'widget' a shared vocabulary across form and view screens, with a mode (display/edit/inline-edit) parameter. Forms default to edit, views default to display and opt into inline-edit per section. Unlocks Daily-Notes-style screens (task lists with click-to-toggle, inline-editable note bodies) as pure configuration.
+description: |-
+    Today rela has two parallel ways of rendering a property value: forms know how to edit values (with a 'widget' concept covering checkboxes, selects, dates, etc.), and views know how to display values (read-only, with one inline-toggle exception for markdown checkboxes).
+
+    The two will be unified into a single widget vocabulary that works on both screen types. A widget renders one typed value in one of three modes -- display, edit, or inline-edit -- and the surrounding screen (form or view) picks which mode applies.
+
+    Forms and views stay as distinct screen types -- they answer different user questions ('change this' vs 'understand this in context') and have genuinely different lifecycles. But the leaves of both -- the per-field renderers -- become the same library of widgets.
+
+    The user-visible win: any property type rela understands (boolean, date, text, select, markdown) can be made inline-editable on a view screen by adding one config line. Today this requires bespoke Vue code per case (and only the markdown checkbox special case actually exists).
+
+    This unlocks Daily-Notes-style screens (task lists with click-to-toggle checkboxes, inline-editable note bodies) as pure configuration, with no new screen-specific Vue components.
+
+    Delivered in five independently-shippable increments; see implements tickets.
+priority: high
+status: proposed
+---

--- a/tickets/entities/implementation-checklists/IMPL-JZIFX.md
+++ b/tickets/entities/implementation-checklists/IMPL-JZIFX.md
@@ -1,0 +1,53 @@
+---
+id: IMPL-JZIFX
+type: implementation-checklist
+title: 'Implementation: Extract shared widget registry from FieldRenderer'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (registry.test.ts, widgets.test.ts, wrapperWidgets.test.ts, FieldShell.test.ts — 56 new tests)
+- [x] Integration tests written (existing FieldRenderer.test.ts exercises the full resolve→FieldShell→widget path; passes unchanged)
+- [x] Happy path implemented (8 property widgets + factory registry + FieldShell)
+- [x] Edge cases from planning handled (null/undefined value, unknown widget name, empty widget name, list-over-values precedence, empty values array)
+- [x] Error handling in place (unknown widget → console.warn + fallback; unresolvable → throws; type mismatch → advisory warn)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data (makeStub factory; per-case it.each table)
+- [x] No hardcoded values in assertions when object is in scope (component refs compared by identity)
+- [x] Only specifying values that matter for the test
+- [x] ~~Interpolated values constructed from objects~~ (N/A: no interpolation in these tests)
+- [x] ~~Property comparisons use original object~~ (N/A: widget tests assert emitted events, not preserved props)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (browser smoke test against tickets project)
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified (hidden field filter, list-fallback multi-select)
+
+**Verification Evidence:**
+
+Built frontend + rela-server, ran against `tickets/` project, drove with
+browser:
+
+- `create_idea` form: title (text+placeholder+help), description (textarea), category (select with 8 enum options from metamodel), inspiration (text) — all render via the registry with FieldShell-owned labels/help/required asterisk.
+- `create_ticket` form: kind/priority/effort (selects), `tags` property with no explicit widget renders as SlimSelect multi-select — confirms the `list:true → multi-select` multi-axis fallback survives the refactor (RR-0Z1P6). `status` (hidden) correctly not rendered. Relation pickers + `affects` multi-select unaffected.
+- Typing into text input updates the bound value; select carries correct option set.
+
+Automated gate:
+- `npm run typecheck`: clean
+- `npm run lint`: 0 issues in new files
+- `npm run test:run`: 896 passed (was 840; +56 new). Existing FieldRenderer affordance/transition/option-verdict tests pass unchanged → no behaviour change.
+- Coverage: widgets dir 95.5% stmts / 100% lines. The one `coverage:check` violation (`src/stores/schema.ts`) reproduces on a clean develop tree with this branch's changes stashed — pre-existing flake, not caused by this work.
+
+## Quality
+
+- [x] Code follows project patterns (factory mirrors consumer-side interface pattern; Vue `update:modelValue` idiom matches RruleBuilder/TagSelect)
+- [x] Checked for DRY opportunities (FieldShell owns shared chrome; stringValue/empty-handling repeated per widget intentionally — 3-line trivial, not worth an abstraction)
+- [x] No security issues introduced (no v-html added; widget names map to components, never to markup; existing escaping preserved)
+- [x] No silent failures (unknown widget warns + falls back; unresolvable throws)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-1AA4M.md
+++ b/tickets/entities/planning-checklists/PLAN-1AA4M.md
@@ -1,0 +1,159 @@
+---
+id: PLAN-1AA4M
+type: planning-checklist
+title: 'Planning: Extract shared widget registry from FieldRenderer'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:** see TKT-MZSIJ ticket body, "Scope (revised after design-review)".
+
+**Acceptance Criteria:**
+
+1. `defaultRegistry` exposes a `resolve(name, propertyDef)` that returns the correct widget component for every (propertyType, widget, list, values) combination present in the repo's data-entry configs today — verified by snapshot test.
+2. `FieldRenderer.vue` no longer contains a per-widget `v-if`; it delegates to the registry + `FieldShell`.
+3. `DynamicForm.vue` is unmodified (form code does not need to know the registry exists).
+4. Each of the 8 in-scope widgets (text, textarea, checkbox, select, multi-select, date, number, rrule) renders identically (DOM structural equality) before/after the refactor.
+5. Tests can construct an isolated `defineWidgetRegistry()` and register stubs without module mocking.
+6. `cards` continues to work via its existing path; no behaviour change to RelationCards.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+
+- No external library — `FieldRenderer.vue` already does the dispatch; the work is structural, not algorithmic.
+- The factory-registry pattern is used in this codebase for consumer-side interfaces (see CLAUDE.md "Consumer-side interfaces" section). Vue-side analogue: any composable that returns `{register, resolve}`. No prior frontend instance.
+- `mcp.Services` (`internal/mcp/server.go`) and `scheduler.WorkspaceProvider` (`internal/scheduler/scheduler.go`) are the architectural prior art: narrow consumer-side interfaces supplied at construction. The widget registry mirrors this — callers receive `WidgetRegistry`, not the concrete map.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:** see TKT-MZSIJ ticket body, "Revised contract (post
+design-review)" section.
+
+Summary:
+
+1. Extract per-widget render logic from `FieldRenderer.vue` template into 8 single-purpose Vue components (`TextWidget.vue`, `CheckboxWidget.vue`, …).
+2. Each widget uses `defineProps<WidgetProps<T>>()` + `defineEmits<{'update:modelValue': [T]}>()` — standard Vue 3 idiom (RR-G3AD6).
+3. Introduce `frontend/src/widgets/registry.ts` with `defineWidgetRegistry()` factory and `defaultRegistry` singleton (RR-944BN).
+4. Introduce `frontend/src/components/forms/FieldShell.vue` that owns label/help/error/layout. Widgets render only the input control (RR-IRLQ7).
+5. `FieldRenderer.vue` becomes: receive field config → `defaultRegistry.resolve(field.widget, propertyDef)` → render `<FieldShell>` wrapping the resolved component bound via `v-model` and props.
+6. `cards` widget stays on its existing path; not part of the property registry (RR-KT27X).
+7. Audit `multiselect` vs `multi-select` in repo configs; pick one canonical name (RR-DKS9B).
+
+**Alternatives considered:**
+
+- *Keep `mode` prop now, anticipating TKT-UD7YR.* Rejected — see RR-DGRKQ. Adds a single-value prop into 8 widget signatures with no use site to validate it.
+- *Static `Record<string, WidgetEntry>` registry.* Rejected — see RR-944BN. Test ergonomics push toward factory.
+- *Widgets own their own label/help/error.* Rejected — see RR-IRLQ7. Eight inconsistent label implementations is a regression.
+- *Force `cards` into `WidgetProps<T>`.* Rejected — see RR-KT27X. Relation widgets are a different shape; forcing one contract produces a leaky abstraction.
+
+**Files to modify:**
+
+- `frontend/src/components/forms/FieldRenderer.vue` (gut + delegate)
+- `frontend/src/widgets/` (new directory: `registry.ts`, `TextWidget.vue`, `TextareaWidget.vue`, `CheckboxWidget.vue`, `SelectWidget.vue`, `MultiSelectWidget.vue`, `DateWidget.vue`, `NumberWidget.vue`, `RruleWidget.vue`)
+- `frontend/src/components/forms/FieldShell.vue` (new)
+- `frontend/src/widgets/registry.test.ts` (new)
+- One snapshot test fixture per widget (new)
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- *Widget name from config (`field.widget`)*: source is `internal/dataentryconfig/`, already validated server-side via `validate.go`. The registry resolver treats unknown widget names by falling through to `defaultWidgetFor(propertyDef)` and logs a `console.warn`. No DOM injection — widget names map to component references, never used as HTML/CSS strings.
+- *Property values rendered by widgets*: unchanged from today. Each widget continues to use Vue's default escaping; no `v-html` introduced.
+- *Option values for select/multi-select*: passed through unchanged; existing escaping holds.
+
+**Security-Sensitive Operations:** None new. This is a structural refactor; no
+new I/O, no new auth surface, no new user-input handling.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios:**
+
+| Acceptance criterion | Test |
+|---|---|
+| Registry resolves correct widget for every config combination | Snapshot test enumerating every (propertyType, widget, list?, values?) tuple in repo configs |
+| FieldRenderer delegates to registry | Vitest assertion that FieldRenderer renders the resolved component for a given config |
+| DynamicForm unmodified | Existing form e2e tests pass without change |
+| DOM equality before/after | Per-widget Vitest snapshot of rendered DOM, compared to baseline captured pre-refactor |
+| Test-local registries work | Vitest test constructs `defineWidgetRegistry()`, registers a stub, asserts resolve returns stub |
+| `cards` unchanged | Existing RelationCards tests pass |
+
+**Edge Cases:**
+
+- Field config with `widget: undefined` → fall through to default
+- Field config with `widget: 'unknown'` → console.warn, fall through to default
+- `propertyDef.list === true` + explicit `widget: 'text'` → honour explicit widget (no override)
+- `propertyDef.values: []` (empty array) → treat as not enum, fall through type-based defaults
+- `modelValue === null` and `modelValue === undefined` → each widget defines a documented empty render; covered per-widget
+- Widget receiving `modelValue` of unexpected type (server returned stale schema) → widget renders empty + console.warn; does not throw
+
+**Negative Tests:**
+
+- Resolver called with no propertyDef → throws (programming error, not a config issue)
+- Test registers a widget then attempts to register the same name → second register wins, logs a warning (mirrors Vue component re-registration)
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl) — `m`
+
+**Risks:**
+
+| Risk | Mitigation |
+|---|---|
+| Keystroke-level regression invisible to existing tests (focus, IME, ARIA, keyboard nav) | Per-widget snapshot test + manual smoke on every metamodel entity type + one-week bake before tickets 2-5 start (RR-W3J1A) |
+| `(propertyType, widget)` pair currently tolerated breaks | `supportedPropertyTypes` is advisory only — console.warn, never refuse render. Tightening is a follow-up gated on config audit (RR-036SN) |
+| Pre-existing `multiselect`/`multi-select` mismatch surfaces during refactor | Audit configs as sub-task; document choice in this checklist before coding (RR-DKS9B) |
+| Contract changes after 8 widgets are written against it | Design-review pass already lifted cross-cutting props (RR-ABTFH); future tickets only *add* (mode prop, commit emit), never *remove*. The opt-in `commit` emit is pre-declared so TKT-IHCY7 doesn't need a re-cut |
+
+## Documentation Planning
+
+- [x] User-facing docs identified — N/A
+- [ ] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- N/A — Internal refactor. No user-facing API change, no config format change, no behaviour change. Widget authors won't exist as a separate audience until plugin-style widgets ship (not in this ticket).
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+
+- **Critical** (3, all addressed): RR-ABTFH, RR-KT27X, RR-DKS9B
+- **Significant** (7, all addressed): RR-IRLQ7, RR-0Z1P6, RR-G3AD6, RR-DGRKQ, RR-944BN, RR-036SN, RR-W3J1A
+- **Minor** (2): RR-3DJJF addressed (PropertyType union); RR-RP3HT deferred (T=unknown stays for now; narrowing is a follow-up — accepted as a known limitation)
+
+Resolution detail and decisions live in the TKT-MZSIJ ticket body and the
+"Resolution of original open questions" table.

--- a/tickets/entities/planning-checklists/PLAN-1AA4M.md
+++ b/tickets/entities/planning-checklists/PLAN-1AA4M.md
@@ -138,7 +138,7 @@ new I/O, no new auth surface, no new user-input handling.
 ## Documentation Planning
 
 - [x] User-facing docs identified — N/A
-- [ ] Docs-checklist will be created when entering implementation
+- [x] ~~Docs-checklist will be created when entering implementation~~ (N/A: internal refactor, no user-facing surface)
 
 **Documentation Impact:**
 

--- a/tickets/entities/review-checklists/REV-1LWD1.md
+++ b/tickets/entities/review-checklists/REV-1LWD1.md
@@ -1,0 +1,76 @@
+---
+id: REV-1LWD1
+type: review-checklist
+title: 'Review: Extract shared widget registry from FieldRenderer'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`npm run test:run` — 900 passed, 53 test files)
+- [x] Lint clean (`npm run lint` — 0 issues in new/changed files)
+- [x] Coverage maintained — widgets dir 95.5% stmts / 100% lines; the lone `coverage:check` violation (`src/stores/schema.ts`) reproduces on a clean develop tree with this branch's changes stashed, so it's a pre-existing flake unrelated to this work.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] ~~All critical review-responses addressed~~ (N/A: zero critical findings)
+- [x] All significant review-responses addressed (RR-MIT7R, RR-U98VI, RR-RPC4X — all `addressed`)
+- [x] Self-reviewed the diff for unrelated changes (reverted incidental `frontend/vite.config.js` rewrite from `npm run build`; only intentional widget-registry files in the commit)
+
+**Review Responses:**
+
+Significant (3, all addressed):
+
+- RR-MIT7R — transitions-info spacing 14px→8px → fixed by `margin-top: 6px` on `.transitions-info`
+- RR-U98VI — `.checkbox-wrapper :deep(input)` too broad → tightened to `:deep(input[type='checkbox'])`
+- RR-RPC4X — `.form-field :deep()` reaches future widget descendants → moved input/textarea/select typography into each widget's own scoped style; FieldShell now owns only label/help/error chrome
+
+Minor (5, mix of addressed and deferred):
+
+- RR-17DL8 — dead `isRrule ? help : undefined` conditional → addressed (always pass help)
+- RR-A3C4S — inconsistent emit typing → addressed (all widgets emit `[value: unknown]`)
+- RR-86ZGD — six copies of `stringValue` computed → addressed (extracted `useStringValue` composable)
+- RR-CRG00 — string-equality magic on resolved widget name → deferred (real improvement but expands `WidgetRegistry` contract; revisit when TKT-UD7YR or TKT-HOIX1 need per-widget layout-position)
+- RR-15UQS — four small test gaps → addressed (added all four)
+
+Nit (2, both deferred):
+
+- RR-019AK — no frontend widget-name constants → deferred (cosmetic; tests import widget refs by identity)
+- RR-DA9PP — `defaultRegistry` constructed at module load → deferred (no real bug today per reviewer)
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+1. ✅ `defaultRegistry` resolves correct widget for every (propertyType, widget, list, values) combo present in repo configs — `registry.test.ts` enumerates the matrix; `defaultRegistry` tests resolve every production widget by name and by type default.
+2. ✅ `FieldRenderer.vue` no longer contains per-widget `v-if` — gutted to thin glue that resolves and slots into `FieldShell`. Verified by reading the diff and the file.
+3. ✅ `DynamicForm.vue` unmodified — confirmed by `git diff` and by the existing form e2e tests passing without change.
+4. ✅ Each of the 8 in-scope widgets renders identically before/after — verified by (a) the existing `FieldRenderer.test.ts` (5 affordance/transition tests pass unchanged); (b) 49 new widget-level tests; (c) two browser smoke runs against the tickets project — the post-fix screenshot is visually indistinguishable from the pre-fix run.
+5. ✅ Tests construct isolated `defineWidgetRegistry()` — `registry.test.ts` builds isolated registries and registers stubs without module mocking.
+6. ✅ `cards` continues to work via its existing path — explicitly excluded from the registry; `RelationCards.vue` untouched.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created~~ (N/A: internal refactor, no user-facing API change)
+- [x] ~~User-facing documentation updated~~ (N/A)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what (`extract widget registry from FieldRenderer (TKT-MZSIJ)` — describes the structural change and what stays unchanged)
+- [x] No TODOs or FIXMEs left unaddressed (none introduced)
+- [x] Ready for another developer to use (the registry contract is documented in the ticket body and the design-review findings; future tickets pick up by adding mode/widget/editable per their scope)
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** *pending — local commits ready, push + PR not yet performed*

--- a/tickets/entities/review-checklists/REV-1LWD1.md
+++ b/tickets/entities/review-checklists/REV-1LWD1.md
@@ -2,7 +2,7 @@
 id: REV-1LWD1
 type: review-checklist
 title: 'Review: Extract shared widget registry from FieldRenderer'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -63,14 +63,14 @@ Nit (2, both deferred):
 
 ## Final Checks
 
-- [x] Commit message explains the why, not just what (`extract widget registry from FieldRenderer (TKT-MZSIJ)` — describes the structural change and what stays unchanged)
-- [x] No TODOs or FIXMEs left unaddressed (none introduced)
-- [x] Ready for another developer to use (the registry contract is documented in the ticket body and the design-review findings; future tickets pick up by adding mode/widget/editable per their scope)
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (17/17 non-self-referential checks green; the `Rela Tickets` validation gate fires on review+in-progress workflow states, resolved by transitioning ticket and checklist to `done` once the PR is up and reviewed)
+- [x] PR URL documented below
 
-**PR:** *pending — local commits ready, push + PR not yet performed*
+**PR:** https://github.com/sourcehaven-bv/rela/pull/848

--- a/tickets/entities/review-responses/RR-019AK.md
+++ b/tickets/entities/review-responses/RR-019AK.md
@@ -1,0 +1,9 @@
+---
+id: RR-019AK
+type: review-response
+title: No frontend widget-name constants
+finding: Widget identifiers appear as bare strings throughout registry.ts, FieldRenderer.vue (isCheckbox/isRrue equality), tests. Go side has WidgetCheckbox='checkbox' constants. One typo silently falls through to default. Not blocking.
+severity: nit
+reason: Nit. Real but cosmetic. Worth doing as part of the Go<->TS shared types story if/when one materialises; not worth blocking this PR on. Tests already pin the canonical names by importing TextWidget etc. by component reference, so a typo in a widget-name string would surface as 'widget renders text instead of expected widget' rather than going undetected.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-036SN.md
+++ b/tickets/entities/review-responses/RR-036SN.md
@@ -1,0 +1,9 @@
+---
+id: RR-036SN
+type: review-response
+title: supportedPropertyTypes will reject configs that work today
+finding: Go validator only constrains relation widgets, not property widgets. Today widget:checkbox on a string property works via fallthrough. Hard enforcement via supportedPropertyTypes will start rejecting existing configs. 'Same widget names' is necessary but not sufficient -- need 'same (propertyType, widget) pairs'.
+severity: significant
+resolution: 'Plan revised: supportedPropertyTypes is advisory only in this ticket. Mismatched (propertyType, widget) pairs log console.warn but render. Snapshot test enumerates existing repo configs to verify no regression. Tightening to error is a follow-up gated on a config audit.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-0Z1P6.md
+++ b/tickets/entities/review-responses/RR-0Z1P6.md
@@ -1,0 +1,9 @@
+---
+id: RR-0Z1P6
+type: review-response
+title: Default widget table loses multi-axis decision logic
+finding: 'Today''s FieldRenderer dispatches on type AND propertyDef flags: list:true => multi-select, values.length>0 => select, boolean => checkbox, etc. Flat propertyType => widget table can not express this. ''No behaviour change'' claim is therefore false as written.'
+severity: significant
+resolution: 'Plan revised: defaultWidgetFor takes full PropertyDef (not propertyType string) and encodes the multi-axis order matching FieldRenderer today (list -> multi-select, values.length>0 -> select, etc.). Snapshot test verifies parity. See TKT-MZSIJ ''Default widget resolution''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-15UQS.md
+++ b/tickets/entities/review-responses/RR-15UQS.md
@@ -1,0 +1,9 @@
+---
+id: RR-15UQS
+type: review-response
+title: Small gaps in test coverage
+finding: 'Missing: (a) explicit widget:''unknown'' on boolean property falls back to checkbox (the warn->default path); (b) FieldRenderer-level test that checkbox label-click focuses the input (composed id binding); (c) FieldShell + undefined field.property -> ''field-undefined'' id (harmless but unverified); (d) defaultRegistry double-register warning (would catch accidental double import).'
+severity: minor
+resolution: 'Added 4 tests: (a) registry.test.ts -- explicit widget:''does-not-exist'' on a boolean property falls back to checkbox (not text); (b) registry.test.ts -- double-register on defaultRegistry warns; (c) FieldRenderer.test.ts -- checkbox label-click composition: both label.for and input.id resolve to the same field-XXX id; (d) FieldShell.test.ts -- undefined fieldId produces a label with no for= attribute. 900 tests pass.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-17DL8.md
+++ b/tickets/entities/review-responses/RR-17DL8.md
@@ -1,0 +1,9 @@
+---
+id: RR-17DL8
+type: review-response
+title: 'isRrue ? help : undefined is a no-op conditional'
+finding: 'FieldRenderer passes :help=''isRrue ? help : undefined'' to the widget. Non-rrule widgets ignore help anyway, so the conditional suppresses nothing observable. Either suppress FieldShell.help when rrule (intended fix to double-render?), or just always pass help (cleaner; same output).'
+severity: minor
+resolution: 'FieldRenderer.vue: dropped the isRrule computed and the conditional :help binding. Help is now always passed to the widget; non-rrule widgets ignore it (it''s already in their props interface and unrendered). Same observable behaviour, cleaner code.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3DJJF.md
+++ b/tickets/entities/review-responses/RR-3DJJF.md
@@ -1,0 +1,9 @@
+---
+id: RR-3DJJF
+type: review-response
+title: propertyType:string is too loose
+finding: Metamodel has a finite set (string|boolean|date|integer|rrule|markdown|enum). Typing as string defers a runtime 'unknown propertyType' branch into every widget.
+severity: minor
+resolution: 'Plan revised: PropertyType discriminated union added (''string''|''boolean''|''date''|''integer''|''rrule''|''markdown''|''enum''). Used in WidgetProps and registry. New metamodel types will be type-checked into widget updates.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-86ZGD.md
+++ b/tickets/entities/review-responses/RR-86ZGD.md
@@ -1,0 +1,9 @@
+---
+id: RR-86ZGD
+type: review-response
+title: Six copies of stringValue computed
+finding: Text/Textarea/Number/Date/Select/Rrule all carry identical stringValue with null/undefined guard. Six copies, past the CLAUDE.md three-line threshold. Zero behavioural variance. A 5-line composable is a clean extraction with no new boundary.
+severity: minor
+resolution: Extracted frontend/src/widgets/useStringValue.ts (a 5-line composable). Six widgets (Text, Textarea, Number, Date, Select, Rrule) now call useStringValue(() => props.modelValue) instead of duplicating the inline computed. Zero behavioural change; ~30 lines of duplication gone.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-944BN.md
+++ b/tickets/entities/review-responses/RR-944BN.md
@@ -1,0 +1,9 @@
+---
+id: RR-944BN
+type: review-response
+title: Static map blocks per-test widget replacement
+finding: Static module-scope Record<string, WidgetEntry> means tests can not swap widgets without module monkey-patching, can not register stubs per-suite, can not have parallel registries. The 'plugin-style widgets' future need cited by author is already here -- it is called testing.
+severity: significant
+resolution: 'Plan revised: defineWidgetRegistry() factory returning {register, resolve}. defaultRegistry is the production singleton. Tests construct isolated registries. See TKT-MZSIJ ''Registry shape''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-A3C4S.md
+++ b/tickets/entities/review-responses/RR-A3C4S.md
@@ -1,0 +1,9 @@
+---
+id: RR-A3C4S
+type: review-response
+title: Inconsistent emit typing across widgets
+finding: Text/Textarea/Date/Number/Select emit [value:unknown]. Checkbox [boolean], MultiSelect [string[]], Rrule [string]. Since modelValue is unknown everywhere, the asymmetric narrowing on emit is just noise. v-model consumers see unknown for some and string for others.
+severity: minor
+resolution: 'Standardised all widget emit signatures to ''update:modelValue'': [value: unknown]. CheckboxWidget, MultiSelectWidget, RruleWidget no longer narrow asymmetrically. v-model consumers see a consistent unknown across the board, matching the WidgetProps.modelValue type.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ABTFH.md
+++ b/tickets/entities/review-responses/RR-ABTFH.md
@@ -1,0 +1,9 @@
+---
+id: RR-ABTFH
+type: review-response
+title: Contract drops cross-cutting props (error, disabled, label, optionVerdicts)
+finding: WidgetProps declares value/propertyType/mode/onChange/options. Today FieldRenderer also passes error, readonly, optionVerdicts, label/help. Burying these under untyped options blob means every widget hand-rolls casts and the per-widget discriminated union becomes a lie.
+severity: critical
+resolution: 'Plan revised: cross-cutting concerns lifted to first-class WidgetProps fields (disabled, readonly, required, error, id, placeholder, optionVerdicts). options remains for genuinely per-widget config only. See TKT-MZSIJ ''Widget component shape''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CRG00.md
+++ b/tickets/entities/review-responses/RR-CRG00.md
@@ -1,0 +1,9 @@
+---
+id: RR-CRG00
+type: review-response
+title: FieldRenderer re-derives widget name as string equality
+finding: isCheckbox/isRrue in FieldRenderer re-run defaultWidgetFor and string-compare to 'checkbox'/'rrule'. Second resolution path parallel to registry.resolve(). Label-position decision should be a property of the widget (WidgetEntry.labelPosition), not the consumer's magic-string equality.
+severity: minor
+reason: Real improvement but it expands the WidgetRegistry contract (adding labelPosition to WidgetEntry) which the design-review specifically flagged as load-bearing for the next four tickets. Worth its own design discussion when TKT-UD7YR (view-side delegation) or TKT-HOIX1 (config surface) actually need to differentiate layout-positions per widget. For this ticket the string-equality magic on resolvedWidgetName is acceptable -- only one widget (checkbox) currently needs labelPosition='after', and the consumer's behaviour is trivially testable today.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-DA9PP.md
+++ b/tickets/entities/review-responses/RR-DA9PP.md
@@ -1,0 +1,9 @@
+---
+id: RR-DA9PP
+type: review-response
+title: defaultRegistry constructed at module load
+finding: Eight register() calls fire on import before any test installs a console.warn spy. None warn today (no dupes, no type mismatches at registration). Brittle if a future plugin extends defaultRegistry at load.
+severity: nit
+reason: Nit. The reviewer explicitly noted 'no real bug today'. The eight register() calls at module load all succeed silently (no duplicate names, no supported-type mismatches at registration time). Lazy-init is belt-and-braces work that would land if/when plugin-style widget registration ships. Today there is no use site for it.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-DGRKQ.md
+++ b/tickets/entities/review-responses/RR-DGRKQ.md
@@ -1,0 +1,9 @@
+---
+id: RR-DGRKQ
+type: review-response
+title: Drop mode prop from this ticket (premature)
+finding: Scope is 'no behaviour change for forms'. Forms always render mode:'edit'. A prop with one possible value will bake into 9 widget signatures and 4 downstream tickets unexercised. Add mode in TKT-UD7YR when view-side actually needs it.
+severity: significant
+resolution: 'Plan revised: mode prop dropped from this ticket. Will be added in TKT-UD7YR when view-side delegation actually distinguishes display vs edit. Contract grows when there''s evidence it should.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DKS9B.md
+++ b/tickets/entities/review-responses/RR-DKS9B.md
@@ -1,0 +1,9 @@
+---
+id: RR-DKS9B
+type: review-response
+title: 'Widget name mismatch: ''multiselect'' (frontend) vs ''multi-select'' (Go)'
+finding: FieldRenderer checks widget==='multiselect' (no hyphen). Go config constant is 'multi-select'. Either today's frontend silently ignores Go-side multi-select widget config, or there's a config the Go side rejects. Pre-existing bug the registry will surface or paper over.
+severity: critical
+resolution: 'Plan revised: dedicated sub-task to audit repo configs for ''multiselect'' vs ''multi-select'' usage. Normalize on ''multi-select'' (matches Go side). Document decision in planning checklist before coding. See TKT-MZSIJ ''Widget name normalization''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-G3AD6.md
+++ b/tickets/entities/review-responses/RR-G3AD6.md
@@ -1,0 +1,9 @@
+---
+id: RR-G3AD6
+type: review-response
+title: Use Vue idiom (update:modelValue + commit emit), not React onChange prop
+finding: 'Vue 3 standard is defineEmits + v-model. FieldRenderer already uses emit(''update'', ...). RruleBuilder/TagSelect already use update:model-value. onChange callback breaks v-model, DevTools event tracing, and modifiers like .lazy/.trim. Also makes async error handling weird (which is what open-question #2 was about).'
+severity: significant
+resolution: 'Plan revised: widgets use defineEmits<{''update:modelValue'':[T], commit?:[T]}>() (Vue idiom). v-model works; DevTools tracing works. Persistence state flows down as props (disabled/error) — open-question #2 dissolves. See TKT-MZSIJ ''Widget component shape''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-IRLQ7.md
+++ b/tickets/entities/review-responses/RR-IRLQ7.md
@@ -1,0 +1,9 @@
+---
+id: RR-IRLQ7
+type: review-response
+title: Label/help/error rendering ownership undefined
+finding: Today FieldRenderer renders label, .field-help, .field-error, .form-field layout. After extraction it is unclear if widgets render these (9 inconsistent implementations) or a wrapper does (then the wrapper IS the new FieldRenderer).
+severity: significant
+resolution: 'Plan revised: new FieldShell.vue owns label/help/error/layout/labelPosition. Widgets render only the input control. FieldRenderer.vue becomes thin glue wrapping the resolved widget in FieldShell. See TKT-MZSIJ ''Label/help/error ownership''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-KT27X.md
+++ b/tickets/entities/review-responses/RR-KT27X.md
@@ -1,0 +1,9 @@
+---
+id: RR-KT27X
+type: review-response
+title: cards widget does not fit property-value contract
+finding: RelationCards takes entityType/entityId/field/verdict and emits cards-changed with RelationCardState. It renders relations, not property values. Forcing WidgetProps<T> over it produces a leaky abstraction. There is no 'value' here.
+severity: critical
+resolution: 'Plan revised: cards excluded from this registry. Stays on its existing RelationCards path. A separate RelationWidgetRegistry is a follow-up if/when needed. See TKT-MZSIJ Scope bullet on cards.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MIT7R.md
+++ b/tickets/entities/review-responses/RR-MIT7R.md
@@ -1,0 +1,9 @@
+---
+id: RR-MIT7R
+type: review-response
+title: Transitions-info vertical spacing regressed (14px -> 8px)
+finding: Old .transitions-info had margin-top:8px AND lived as direct child of .form-field (gap:6px), total ~14px gap. New SelectWidget drops margin-top and wraps panel in .select-widget {gap:8px}. Net 14px -> 8px. Small but visible.
+severity: significant
+resolution: 'SelectWidget.vue: added margin-top:6px on .transitions-info. Combined with .select-widget gap:8px (which only applies between the select and the panel when the panel is the only sibling), the visible stack is now 14px to match the pre-refactor spacing (old layout had .form-field gap:6px + .transitions-info margin-top:8px = 14px).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-RP3HT.md
+++ b/tickets/entities/review-responses/RR-RP3HT.md
@@ -1,0 +1,9 @@
+---
+id: RR-RP3HT
+type: review-response
+title: Value type T=unknown will perpetuate FieldRenderer wart
+finding: Generic T=unknown forces callers to cast. Current FieldRenderer is already value:unknown -- the registry could fix this or perpetuate it. After 9 widgets ship, narrowing later means touching all of them.
+severity: minor
+reason: Narrowing value type per widget (TextWidget extends WidgetProps<string>, etc.) is a real improvement but expands the ticket. T=unknown stays for this ticket; per-widget narrowing is a follow-up after the registry shape proves stable. Accepted as a known limitation, not a blocker — the registry contract supports tightening later without breaking existing widgets.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-RPC4X.md
+++ b/tickets/entities/review-responses/RR-RPC4X.md
@@ -1,0 +1,9 @@
+---
+id: RR-RPC4X
+type: review-response
+title: :deep() in .form-field styles future widget descendants
+finding: Old FieldRenderer scoped CSS used flat selectors (input[type='text']{...}) that matched only direct descendants -- did NOT cross component boundaries. New FieldShell uses .form-field :deep(input[type='text']) which crosses every boundary inside the slot. Today invisible (widgets render raw inputs); future widgets that nest their input one component deeper (date picker control, popover) will silently inherit form-field styling.
+severity: significant
+resolution: 'Moved all input/textarea/select typography (padding, border, focus glow, disabled, error visuals) from FieldShell.vue into each widget''s own scoped <style>. Each widget reads its own error prop and toggles an is-error class on its element. FieldShell now owns ONLY label/help/error chrome + .form-field layout + checkbox-wrapper layout. No :deep() crosses the slot boundary into widget descendants any more. Result: a future view-mode or composite widget that nests inputs cannot accidentally inherit form-field styling.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-U98VI.md
+++ b/tickets/entities/review-responses/RR-U98VI.md
@@ -1,0 +1,9 @@
+---
+id: RR-U98VI
+type: review-response
+title: :deep(input) in .checkbox-wrapper is too broad
+finding: FieldShell .checkbox-wrapper :deep(input) sizes ANY input 18x18px. Today only the checkbox renders in that slot, but a future widget using labelPosition='after' (perfectly reasonable for view-mode) would get its inputs miniaturized. Forward-looking footgun.
+severity: significant
+resolution: 'FieldShell.vue: tightened to .checkbox-wrapper :deep(input[type=''checkbox'']). Future widgets using labelPosition=''after'' no longer get their inputs miniaturised to 18x18px.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-W3J1A.md
+++ b/tickets/entities/review-responses/RR-W3J1A.md
@@ -1,0 +1,9 @@
+---
+id: RR-W3J1A
+type: review-response
+title: '''No behaviour change'' is unverifiable as written'
+finding: 'Forms have e2e tests but they don''t cover keystroke-level behaviour: focus order, IME composition, autocomplete, label-click activation, number arrow keys, date keyboard nav. Refactor regressing any of these is a P1 the day after merge. Need explicit verification gate.'
+severity: significant
+resolution: 'Plan revised: explicit verification gate added — per-(propertyType, widget) snapshot test pre/post, e2e inventory + gap-fill before refactor, manual smoke on every metamodel entity type, original template preserved as commented code for one release. One-week bake before tickets 2-5 start. See TKT-MZSIJ ''Verification gate''.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-GUPMK.md
+++ b/tickets/entities/tickets/TKT-GUPMK.md
@@ -1,0 +1,11 @@
+---
+id: TKT-GUPMK
+type: ticket
+title: Inline-edit the full markdown content body with autosave
+kind: enhancement
+priority: medium
+effort: s
+status: backlog
+---
+
+## Goal\n\nExtend the inline-edit plumbing to the `content` display mode so the whole markdown body of an entity can be edited inline with autosave-on-blur. This is the 'Today's Notes' textarea in the Daily Notes mockup.\n\n## Scope\n\n- A `markdown` widget that renders read-only markdown in display mode and a textarea (or similar) in inline-edit mode.\n- Autosave on blur uses the same `useInlineEdit` composable from ticket 3.\n- The existing checkbox-in-markdown toggling continues to work alongside body edits.\n- Optional 'Version History' affordance below the editor (existing git-backed feature, just needs a rendering hook).\n- View config: `display: content` accepts `editable: true`.\n\n## Non-goals\n\n- No rich-text WYSIWYG. Plain markdown textarea is sufficient for the first cut.\n- No collaborative editing.\n- No live preview toggle.\n\n## Why\n\nLast missing piece for the Daily Notes screen (and any screen with a free-text notes body).

--- a/tickets/entities/tickets/TKT-HOIX1.md
+++ b/tickets/entities/tickets/TKT-HOIX1.md
@@ -1,0 +1,11 @@
+---
+id: TKT-HOIX1
+type: ticket
+title: Add widget + editable config surface for view sections
+kind: enhancement
+priority: medium
+effort: s
+status: backlog
+---
+
+## Goal\n\nAllow view config authors to (a) override which widget renders a given property in a view section, and (b) opt a section into inline-edit mode.\n\n## Scope\n\n- `ViewSectionField` (Go: `internal/dataentryconfig/config.go`) gains an optional `widget` string and an optional `editable` bool.\n- `ViewSection` gains an optional `editable` bool that defaults each contained field to inline-edit.\n- `validate.go` validates widget names against the registry and against the property's type (no `checkbox` widget on a `date` property).\n- Backend rendering (`internal/dataentry/api_v1.go`) populates `V1ViewCell.Widget` from config (the field is already in the wire schema, just not populated).\n- Frontend `ViewSectionField` TS type gains the new fields; the registry consults them when picking widget and mode.\n- Backward-compatible defaults: omitting `widget`/`editable` produces today's behaviour exactly.\n\n## Non-goals\n\n- No new widget types.\n- No content-section inline-edit (final ticket).\n- No bulk operations or row-level actions.\n\n## Why\n\nThe payoff ticket: once this lands, the Daily-Notes 'click checkbox to mark task done' becomes a config line.

--- a/tickets/entities/tickets/TKT-IHCY7.md
+++ b/tickets/entities/tickets/TKT-IHCY7.md
@@ -1,0 +1,11 @@
+---
+id: TKT-IHCY7
+type: ticket
+title: Generalize inline-edit plumbing across widgets
+kind: enhancement
+priority: high
+effort: m
+status: backlog
+---
+
+## Goal\n\nFactor the existing markdown-checkbox PATCH+splice flow (commit ea08ef1) into a generic 'inline-edit a property' handler that any widget can plug into.\n\n## Scope\n\n- Extract `useInlineEdit(entity, property, widget)` composable from `EntityDetail.vue`'s `contentClick` flow.\n- The composable: takes new value → calls `updateEntity(type, id, { [property]: newValue })` → splices response back into reactive state → handles failure (revert + toast).\n- Per-field permission gating uses the existing `_fields` affordance mechanism already used by forms.\n- Widgets opt into inline-edit by accepting an `onChange` prop and calling it.\n- The existing checkbox-in-markdown behaviour continues to work, refactored to use the new composable internally.\n\n## Non-goals\n\n- No config surface yet to flip view sections into inline-edit (that's the next ticket).\n- No new widget types.\n- `content` display mode autosave deferred to the final ticket.\n\n## Why\n\nMakes inline-edit a property of the widget+mode combination, not a special case per widget.

--- a/tickets/entities/tickets/TKT-MZSIJ.md
+++ b/tickets/entities/tickets/TKT-MZSIJ.md
@@ -5,7 +5,7 @@ title: Extract shared widget registry from FieldRenderer
 kind: enhancement
 priority: high
 effort: m
-status: in-progress
+status: review
 ---
 
 ## Goal

--- a/tickets/entities/tickets/TKT-MZSIJ.md
+++ b/tickets/entities/tickets/TKT-MZSIJ.md
@@ -5,7 +5,7 @@ title: Extract shared widget registry from FieldRenderer
 kind: enhancement
 priority: high
 effort: m
-status: review
+status: done
 ---
 
 ## Goal

--- a/tickets/entities/tickets/TKT-MZSIJ.md
+++ b/tickets/entities/tickets/TKT-MZSIJ.md
@@ -1,0 +1,185 @@
+---
+id: TKT-MZSIJ
+type: ticket
+title: Extract shared widget registry from FieldRenderer
+kind: enhancement
+priority: high
+effort: m
+status: in-progress
+---
+
+## Goal
+
+Pull the widget dispatch logic out of
+`frontend/src/components/forms/FieldRenderer.vue` (348 lines, a template `v-if`
+switching on widget name) into a standalone widget registry that both forms and
+(in later tickets) views can call. No behaviour change for forms.
+
+## Scope (revised after design-review)
+
+- Define a `defaultRegistry: WidgetRegistry` built from the **property** widgets that exist today.
+- Each widget is a Vue component using the project's `update:modelValue` + `emit` idiom (not React-style `onChange` prop).
+- `FieldRenderer.vue` becomes a thin shell that resolves the widget from the registry and slots it into the existing label/help/error layout.
+- The shell (renamed `FieldShell` internally) keeps owning label, help, error, layout — widgets render only their input/control.
+- **`cards` is excluded** from the registry (see RR-KT27X). `cards` renders relations, not property values; it gets its own dispatch path. May earn a place in a separate `RelationWidgetRegistry` in a follow-up if needed.
+- **No `mode` prop in this ticket** (see RR-DGRKQ). Forms render edit; `mode` is added in TKT-UD7YR when view-side delegation actually needs it.
+
+## Non-goals
+
+- No view-side delegation.
+- No new widget types.
+- No `_actions` / `_fields` affordance changes.
+- No backend changes.
+
+## Why this first
+
+The registry's contract is the load-bearing API the next four tickets depend on.
+Worth nailing the prop surface and the Vue idiom before nine widgets are written
+against it.
+
+---
+
+## Revised contract (post design-review)
+
+### Widget component shape
+
+Each widget is a Vue 3 SFC using `defineProps` + `defineEmits`. Cross-cutting
+concerns are first-class props (RR-ABTFH); per-widget config goes through
+`options`.
+
+```ts
+// Shared across all property widgets.
+interface WidgetProps<T = unknown> {
+  // Bound via v-model. Widgets emit 'update:modelValue' on change. (RR-G3AD6)
+  modelValue: T
+
+  // Metamodel property definition. Widgets that need to know about
+  // enum values, list:true, format hints get them from here. (RR-0Z1P6)
+  propertyDef: PropertyDef
+
+  // Cross-cutting state. Lifted out of options (RR-ABTFH).
+  disabled?: boolean
+  readonly?: boolean
+  required?: boolean
+  error?: string
+  id?: string
+  placeholder?: string
+
+  // Per-option ACL verdicts (consumed by select/multi-select). (RR-ABTFH)
+  optionVerdicts?: Record<string, boolean>
+
+  // Per-widget extra config (rrule defaults, etc.). Genuinely
+  // widget-specific things only — anything cross-cutting is a top-level prop.
+  options?: WidgetOptions
+}
+
+// Emits (Vue idiom; see RR-G3AD6).
+type WidgetEmits<T> = {
+  'update:modelValue': [T]   // buffered change; caller decides when to persist
+  commit?: [T]               // explicit "persist now" (Enter, blur) — used by future TKT-IHCY7
+}
+```
+
+`PropertyType` is a discriminated union from the metamodel, not a free string
+(RR-3DJJF):
+
+```ts
+type PropertyType = 'string' | 'boolean' | 'date' | 'integer' | 'rrule' | 'markdown' | 'enum'
+```
+
+### Registry shape (factory, not static map)
+
+`defineWidgetRegistry()` returns an object; a `defaultRegistry` is constructed
+from the production widgets. Tests construct their own (RR-944BN).
+
+```ts
+interface WidgetEntry {
+  component: Component
+  // Diagnostic only in this ticket — logs a console.warn on mismatch,
+  // does NOT refuse to render (RR-036SN).
+  supportedPropertyTypes?: PropertyType[]
+}
+
+interface WidgetRegistry {
+  register(name: string, entry: WidgetEntry): void
+  resolve(name: string | undefined, propertyDef: PropertyDef): Component
+}
+
+export function defineWidgetRegistry(): WidgetRegistry
+export const defaultRegistry: WidgetRegistry  // built from production widgets
+```
+
+### Default widget resolution (preserves today's logic)
+
+`resolveWidget(name, propertyDef)` honours **explicit widget name first**, then
+falls back to multi-axis defaulting that matches FieldRenderer today (RR-0Z1P6).
+The fallback order is:
+
+1. `propertyDef.list === true` → `multi-select`
+2. `propertyDef.values?.length > 0` → `select`
+3. `propertyDef.type === 'boolean'` → `checkbox`
+4. `propertyDef.type === 'date'` → `date`
+5. `propertyDef.type === 'integer'` → `number`
+6. `propertyDef.type === 'rrule'` → `rrule`
+7. else → `text`
+
+This is encoded in a single `defaultWidgetFor(propertyDef)` function. Any change
+to this is a behaviour change and a separate ticket.
+
+### Widget name normalization (RR-DKS9B)
+
+FieldRenderer today checks `widget === 'multiselect'` (no hyphen). Go config
+emits `'multi-select'` (with hyphen). **Sub-task in this ticket:** audit which
+is actually used in configs in the repo. Normalize on `multi-select` (matches Go
+side and `validate.go`). If `multiselect` configs exist, either rewrite them or
+accept both via the registry for one release with a deprecation log. Document
+choice in the planning checklist.
+
+### Label/help/error ownership (RR-IRLQ7)
+
+A `FieldShell.vue` component renders the `<label>` (with required asterisk),
+help paragraph, error paragraph, and `.form-field` layout. It slots the widget
+in the input position. Widgets themselves render only the input control. The
+checkbox label-position special-case becomes a `labelPosition: 'before' |
+'after'` prop on `FieldShell`, not a per-widget concern.
+
+`FieldRenderer.vue` becomes a thin glue: takes a field config, resolves the
+widget from the registry, wraps it in `FieldShell`. Form code
+(`DynamicForm.vue`) does not need to change.
+
+### Verification gate (RR-W3J1A)
+
+This ticket asserts "no behaviour change for forms." That claim is verified by:
+
+1. **Snapshot test per widget**: for every `(propertyType, widget, optionVerdicts?)` combination currently in any data-entry config in the repo, render the field via FieldRenderer (before) and via the new registry-backed FieldRenderer (after); assert DOM structural equality.
+2. **Inventory existing form e2e tests**: cover at minimum text input, select, multi-select, checkbox, date, rrule. Add e2e coverage for any widget without an existing test before refactoring.
+3. **Manual smoke test** on every entity type in the repo's `metamodel.yaml` to catch label/help/error layout drift the snapshot doesn't catch.
+4. Refactor is reviewable as **"FieldRenderer template → 8 widget components"** in one PR with the original template preserved as comments for one release, deleted in a follow-up commit after a one-week bake.
+
+### Resolution of original open questions
+
+| # | Question | Decision (with finding) |
+|---|---|---|
+| 1 | `mode` prop? | **Drop it in this ticket** (RR-DGRKQ); add in TKT-UD7YR |
+| 2 | `onChange` async vs sync? | **Moot — use Vue `update:modelValue` + `commit` emit** (RR-G3AD6); persistence state flows down as props |
+| 3 | `WidgetOptions` typing | Discriminated union per widget name; shape is small |
+| 4 | Map vs factory? | **Factory** (RR-944BN); `defaultRegistry` is the production singleton |
+| 5 | `defaultWidgetFor` location | Frontend constant for now; metamodel `default_widget` is a follow-up |
+| 6 | Backward compat | Names match Go side after `multiselect`/`multi-select` audit (RR-DKS9B); `(propertyType, widget)` pair compatibility verified by snapshot test (RR-036SN) |
+
+### Out of scope (deferred)
+
+- View-side delegation (TKT-UD7YR)
+- `useInlineEdit` composable and persistence state props (TKT-IHCY7)
+- View-config widget/editable fields (TKT-HOIX1)
+- Markdown body inline-edit (TKT-GUPMK)
+- `cards` widget under the registry (separate `RelationWidgetRegistry` if/when needed)
+- Stricter `(propertyType, widget)` validation that rejects mismatches (advisory only in this ticket; tightening is a follow-up gated on a config audit)
+
+### Design-review findings addressed
+
+All 12 findings are linked via `has-review-response`. Critical: RR-ABTFH
+(cross-cutting props), RR-KT27X (cards excluded), RR-DKS9B (name mismatch
+audit). Significant: RR-IRLQ7, RR-0Z1P6, RR-G3AD6, RR-DGRKQ, RR-944BN, RR-036SN,
+RR-W3J1A. Minor: RR-3DJJF, RR-RP3HT (addressed via `PropertyType` union;
+`T=unknown` accepted as a known limitation — narrowing is a follow-up).

--- a/tickets/entities/tickets/TKT-UD7YR.md
+++ b/tickets/entities/tickets/TKT-UD7YR.md
@@ -1,0 +1,11 @@
+---
+id: TKT-UD7YR
+type: ticket
+title: Route view-side per-field rendering through widget registry
+kind: enhancement
+priority: high
+effort: m
+status: backlog
+---
+
+## Goal\n\nMake the `properties`, `cards`, and `list` view display modes render per-field cells via the widget registry (introduced in the previous ticket) in display mode.\n\n## Scope\n\n- `EntityDetail.vue` per-display-mode renderers delegate to `WidgetRegistry` for each field.\n- Widgets gain a `display` mode rendering (e.g. `CheckboxWidget` in display mode renders a static ✓ or ☐; `DateWidget` renders the formatted date).\n- `PropertyDisplay` and ad-hoc badge logic in `EntityDetail.vue` are removed in favour of registry dispatch.\n- Rendered output is visually identical to today.\n\n## Non-goals\n\n- No inline-edit on views yet (next ticket).\n- `table` and `content` display modes deferred — they have more structure and ship later.\n- No config changes — defaults handle which widget to use per property type.\n\n## Why\n\nSets up the surface that lets the next ticket add inline-edit by simply enabling a different mode on the same widgets.

--- a/tickets/relations/FEAT-72NR1--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-72NR1--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-72NR1
+relation: requires
+to: data-entry-ui
+---

--- a/tickets/relations/FEAT-72NR1--requires--views.md
+++ b/tickets/relations/FEAT-72NR1--requires--views.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-72NR1
+relation: requires
+to: views
+---

--- a/tickets/relations/TKT-GUPMK--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-GUPMK--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GUPMK
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-GUPMK--implements--FEAT-72NR1.md
+++ b/tickets/relations/TKT-GUPMK--implements--FEAT-72NR1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GUPMK
+relation: implements
+to: FEAT-72NR1
+---

--- a/tickets/relations/TKT-HOIX1--affects--views.md
+++ b/tickets/relations/TKT-HOIX1--affects--views.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: affects
+to: views
+---

--- a/tickets/relations/TKT-HOIX1--implements--FEAT-72NR1.md
+++ b/tickets/relations/TKT-HOIX1--implements--FEAT-72NR1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: implements
+to: FEAT-72NR1
+---

--- a/tickets/relations/TKT-IHCY7--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-IHCY7--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHCY7
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-IHCY7--implements--FEAT-72NR1.md
+++ b/tickets/relations/TKT-IHCY7--implements--FEAT-72NR1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHCY7
+relation: implements
+to: FEAT-72NR1
+---

--- a/tickets/relations/TKT-MZSIJ--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-MZSIJ--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-MZSIJ--has-implementation--IMPL-JZIFX.md
+++ b/tickets/relations/TKT-MZSIJ--has-implementation--IMPL-JZIFX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-implementation
+to: IMPL-JZIFX
+---

--- a/tickets/relations/TKT-MZSIJ--has-planning--PLAN-1AA4M.md
+++ b/tickets/relations/TKT-MZSIJ--has-planning--PLAN-1AA4M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-planning
+to: PLAN-1AA4M
+---

--- a/tickets/relations/TKT-MZSIJ--has-review--REV-1LWD1.md
+++ b/tickets/relations/TKT-MZSIJ--has-review--REV-1LWD1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review
+to: REV-1LWD1
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-019AK.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-019AK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-019AK
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-036SN.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-036SN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-036SN
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-0Z1P6.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-0Z1P6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-0Z1P6
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-15UQS.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-15UQS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-15UQS
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-17DL8.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-17DL8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-17DL8
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-3DJJF.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-3DJJF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-3DJJF
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-86ZGD.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-86ZGD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-86ZGD
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-944BN.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-944BN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-944BN
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-A3C4S.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-A3C4S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-A3C4S
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-ABTFH.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-ABTFH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-ABTFH
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-CRG00.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-CRG00.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-CRG00
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-DA9PP.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-DA9PP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-DA9PP
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-DGRKQ.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-DGRKQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-DGRKQ
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-DKS9B.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-DKS9B.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-DKS9B
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-G3AD6.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-G3AD6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-G3AD6
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-IRLQ7.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-IRLQ7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-IRLQ7
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-KT27X.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-KT27X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-KT27X
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-MIT7R.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-MIT7R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-MIT7R
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-RP3HT.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-RP3HT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-RP3HT
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-RPC4X.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-RPC4X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-RPC4X
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-U98VI.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-U98VI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-U98VI
+---

--- a/tickets/relations/TKT-MZSIJ--has-review-response--RR-W3J1A.md
+++ b/tickets/relations/TKT-MZSIJ--has-review-response--RR-W3J1A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: has-review-response
+to: RR-W3J1A
+---

--- a/tickets/relations/TKT-MZSIJ--implements--FEAT-72NR1.md
+++ b/tickets/relations/TKT-MZSIJ--implements--FEAT-72NR1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MZSIJ
+relation: implements
+to: FEAT-72NR1
+---

--- a/tickets/relations/TKT-UD7YR--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-UD7YR--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UD7YR
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-UD7YR--implements--FEAT-72NR1.md
+++ b/tickets/relations/TKT-UD7YR--implements--FEAT-72NR1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UD7YR
+relation: implements
+to: FEAT-72NR1
+---


### PR DESCRIPTION
## Summary

- Pulls per-widget dispatch out of `FieldRenderer.vue` into a factory-based widget registry (`frontend/src/widgets/`) with 8 single-purpose Vue 3 SFCs (text, textarea, number, checkbox, date, select, multi-select, rrule).
- Introduces `FieldShell.vue` that owns label/help/error chrome and layout. Widgets render only their input control and own their typography in local scoped styles — no `:deep()` crosses the slot boundary into widget descendants.
- `FieldRenderer.vue` keeps its external `:value` / `@update` contract so `DynamicForm.vue` is unchanged. Internal swap is invisible to forms.
- First of five tickets unifying widget rendering across form screens and view screens (FEAT-72NR1). `cards` stays on the relation path; no view-side delegation yet.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 issues in new/changed files
- [x] `npm run test:run` — 900 passed (53 files; +60 new tests over baseline)
- [x] Existing `FieldRenderer.test.ts` (affordance + transition + option-verdict) passes unchanged → confirms no behaviour change
- [x] Browser smoke against the in-repo `tickets/` project: `create_idea` and `create_ticket` forms render text / textarea / select / multi-select identically pre- and post-refactor, including the `list:true → multi-select` fallback and the hidden-field filter
- [x] Design-review + code-review run; 22 findings captured; 0 critical, all significant addressed