### PR TITLE
feat(lint): enable contextcheck rule (TKT-B11W0)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,10 +13,7 @@ linters:
   enable:
     - bodyclose
     - containedctx
-    # contextcheck: surfaces 84 real ctx-threading gaps across dataentry/mcp/workspace.
-    # Enabling requires a ~15-file refactor that's out of scope for this lint
-    # expansion; tracked as a follow-up ticket.
-    # - contextcheck
+    - contextcheck
     - copyloopvar
     - depguard
     - dogsled

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -131,8 +131,7 @@ func New(d Deps) (*Service, error) {
 // existing CLI summary behavior (AnalyzeAll reports `len(orphans)`
 // without an error channel). A returning-errors variant is a
 // candidate follow-up; not in scope for the package lift.
-func (s *Service) FindOrphansWithScope(opts Options) []*entity.Entity {
-	ctx := context.Background()
+func (s *Service) FindOrphansWithScope(ctx context.Context, opts Options) []*entity.Entity {
 	ids, err := s.deps.Tracer.FindOrphans(ctx)
 	if err != nil {
 		slog.Warn("analysis: tracer.FindOrphans failed; returning no orphans (results may under-count)", "error", err)
@@ -158,8 +157,8 @@ func (s *Service) FindOrphansWithScope(opts Options) []*entity.Entity {
 
 // FindDuplicates returns groups of entities with similar titles,
 // filtered by scope.
-func (s *Service) FindDuplicates(opts Options) []DuplicateGroup {
-	entities := filterByScope(collectEntities(s.deps.Store, store.EntityQuery{}), opts.Scope)
+func (s *Service) FindDuplicates(ctx context.Context, opts Options) []DuplicateGroup {
+	entities := filterByScope(collectEntities(ctx, s.deps.Store, store.EntityQuery{}), opts.Scope)
 
 	titleGroups := make(map[string][]*entity.Entity)
 	for _, e := range entities {
@@ -185,7 +184,7 @@ func (s *Service) FindDuplicates(opts Options) []DuplicateGroup {
 
 // FindGaps returns gaps in ID sequences, filtered by scope. Excludes
 // entity types with manual (string) IDs.
-func (s *Service) FindGaps(opts Options) []GapResult {
+func (s *Service) FindGaps(ctx context.Context, opts Options) []GapResult {
 	meta := s.deps.Meta
 	stringIDPrefixes := make(map[string]bool)
 	for _, entityDef := range meta.Entities {
@@ -198,7 +197,7 @@ func (s *Service) FindGaps(opts Options) []GapResult {
 	}
 
 	prefixGroups := make(map[string][]int)
-	for _, e := range collectEntities(s.deps.Store, store.EntityQuery{}) {
+	for _, e := range collectEntities(ctx, s.deps.Store, store.EntityQuery{}) {
 		if !inScope(e.ID, opts.Scope) {
 			continue
 		}
@@ -242,28 +241,29 @@ func (s *Service) FindGaps(opts Options) []GapResult {
 
 // CheckCardinality checks all cardinality constraints, filtered by
 // scope.
-func (s *Service) CheckCardinality(opts Options) []CardinalityViolation {
+func (s *Service) CheckCardinality(ctx context.Context, opts Options) []CardinalityViolation {
 	violations := make([]CardinalityViolation, 0) //nolint:prealloc // capacity unknown
 
 	for relName, relDef := range s.deps.Meta.Relations {
-		violations = append(violations, s.checkMinOutgoing(relName, relDef, opts.Scope)...)
-		violations = append(violations, s.checkMaxOutgoing(relName, relDef, opts.Scope)...)
-		violations = append(violations, s.checkMinIncoming(relName, relDef, opts.Scope)...)
-		violations = append(violations, s.checkMaxIncoming(relName, relDef, opts.Scope)...)
+		violations = append(violations, s.checkMinOutgoing(ctx, relName, relDef, opts.Scope)...)
+		violations = append(violations, s.checkMaxOutgoing(ctx, relName, relDef, opts.Scope)...)
+		violations = append(violations, s.checkMinIncoming(ctx, relName, relDef, opts.Scope)...)
+		violations = append(violations, s.checkMaxIncoming(ctx, relName, relDef, opts.Scope)...)
 	}
 	return violations
 }
 
 func (s *Service) checkMinOutgoing(
-	relName string, relDef metamodel.RelationDef, scope map[string]bool,
+	ctx context.Context, relName string, relDef metamodel.RelationDef, scope map[string]bool,
 ) []CardinalityViolation {
 	if relDef.MinOutgoing == nil || *relDef.MinOutgoing == 0 {
 		return nil
 	}
 	var violations []CardinalityViolation
 	for _, sourceType := range relDef.From {
-		for _, e := range filterByScope(collectEntities(s.deps.Store, store.EntityQuery{Type: sourceType}), scope) {
-			count := s.countOutgoingByType(e.ID, relName)
+		entities := collectEntities(ctx, s.deps.Store, store.EntityQuery{Type: sourceType})
+		for _, e := range filterByScope(entities, scope) {
+			count := s.countOutgoingByType(ctx, e.ID, relName)
 			if count < *relDef.MinOutgoing {
 				violations = append(violations, CardinalityViolation{
 					EntityID:     e.ID,
@@ -279,15 +279,16 @@ func (s *Service) checkMinOutgoing(
 }
 
 func (s *Service) checkMaxOutgoing(
-	relName string, relDef metamodel.RelationDef, scope map[string]bool,
+	ctx context.Context, relName string, relDef metamodel.RelationDef, scope map[string]bool,
 ) []CardinalityViolation {
 	if relDef.MaxOutgoing == nil {
 		return nil
 	}
 	var violations []CardinalityViolation
 	for _, sourceType := range relDef.From {
-		for _, e := range filterByScope(collectEntities(s.deps.Store, store.EntityQuery{Type: sourceType}), scope) {
-			count := s.countOutgoingByType(e.ID, relName)
+		entities := collectEntities(ctx, s.deps.Store, store.EntityQuery{Type: sourceType})
+		for _, e := range filterByScope(entities, scope) {
+			count := s.countOutgoingByType(ctx, e.ID, relName)
 			if count > *relDef.MaxOutgoing {
 				violations = append(violations, CardinalityViolation{
 					EntityID:     e.ID,
@@ -303,15 +304,16 @@ func (s *Service) checkMaxOutgoing(
 }
 
 func (s *Service) checkMinIncoming(
-	relName string, relDef metamodel.RelationDef, scope map[string]bool,
+	ctx context.Context, relName string, relDef metamodel.RelationDef, scope map[string]bool,
 ) []CardinalityViolation {
 	if relDef.MinIncoming == nil || *relDef.MinIncoming == 0 {
 		return nil
 	}
 	var violations []CardinalityViolation
 	for _, targetType := range relDef.To {
-		for _, e := range filterByScope(collectEntities(s.deps.Store, store.EntityQuery{Type: targetType}), scope) {
-			count := s.countIncomingByType(e.ID, relName)
+		entities := collectEntities(ctx, s.deps.Store, store.EntityQuery{Type: targetType})
+		for _, e := range filterByScope(entities, scope) {
+			count := s.countIncomingByType(ctx, e.ID, relName)
 			if count < *relDef.MinIncoming {
 				relLabel := relName
 				if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
@@ -331,15 +333,16 @@ func (s *Service) checkMinIncoming(
 }
 
 func (s *Service) checkMaxIncoming(
-	relName string, relDef metamodel.RelationDef, scope map[string]bool,
+	ctx context.Context, relName string, relDef metamodel.RelationDef, scope map[string]bool,
 ) []CardinalityViolation {
 	if relDef.MaxIncoming == nil {
 		return nil
 	}
 	var violations []CardinalityViolation
 	for _, targetType := range relDef.To {
-		for _, e := range filterByScope(collectEntities(s.deps.Store, store.EntityQuery{Type: targetType}), scope) {
-			count := s.countIncomingByType(e.ID, relName)
+		entities := collectEntities(ctx, s.deps.Store, store.EntityQuery{Type: targetType})
+		for _, e := range filterByScope(entities, scope) {
+			count := s.countIncomingByType(ctx, e.ID, relName)
 			if count > *relDef.MaxIncoming {
 				relLabel := relName
 				if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
@@ -358,8 +361,8 @@ func (s *Service) checkMaxIncoming(
 	return violations
 }
 
-func (s *Service) countOutgoingByType(entityID, relName string) int {
-	n, _ := s.deps.Store.CountRelations(context.Background(), store.RelationQuery{
+func (s *Service) countOutgoingByType(ctx context.Context, entityID, relName string) int {
+	n, _ := s.deps.Store.CountRelations(ctx, store.RelationQuery{
 		EntityID:  entityID,
 		Direction: store.DirectionOutgoing,
 		Type:      relName,
@@ -367,8 +370,8 @@ func (s *Service) countOutgoingByType(entityID, relName string) int {
 	return n
 }
 
-func (s *Service) countIncomingByType(entityID, relName string) int {
-	n, _ := s.deps.Store.CountRelations(context.Background(), store.RelationQuery{
+func (s *Service) countIncomingByType(ctx context.Context, entityID, relName string) int {
+	n, _ := s.deps.Store.CountRelations(ctx, store.RelationQuery{
 		EntityID:  entityID,
 		Direction: store.DirectionIncoming,
 		Type:      relName,
@@ -393,7 +396,7 @@ func (s *Service) newValidationService() *validation.Service {
 // RunValidations executes all custom validation rules from the
 // metamodel, filtered by scope.
 func (s *Service) RunValidations(ctx context.Context, opts Options) ValidationResult {
-	return s.newValidationService().Check(ctx, collectEntities(s.deps.Store, store.EntityQuery{}), opts.Scope)
+	return s.newValidationService().Check(ctx, collectEntities(ctx, s.deps.Store, store.EntityQuery{}), opts.Scope)
 }
 
 // RunValidationsFiltered executes custom validation rules matching
@@ -415,7 +418,7 @@ func (s *Service) RunValidationsFiltered(
 		}
 	}
 
-	return svc.CheckRules(ctx, collectEntities(s.deps.Store, store.EntityQuery{}), opts.Scope, ruleNames)
+	return svc.CheckRules(ctx, collectEntities(ctx, s.deps.Store, store.EntityQuery{}), opts.Scope, ruleNames)
 }
 
 // matchesFilter returns true if the rule matches the filter criteria.
@@ -440,13 +443,13 @@ func CountValidationsBySeverity(violations []ValidationViolation) (errors, warni
 // AnalyzeAll runs all analyses and returns a summary of counts.
 func (s *Service) AnalyzeAll(ctx context.Context, opts Options) *Summary {
 	summary := &Summary{
-		Orphans:     len(s.FindOrphansWithScope(opts)),
-		Duplicates:  len(s.FindDuplicates(opts)),
-		Gaps:        len(s.FindGaps(opts)),
-		Cardinality: len(s.CheckCardinality(opts)),
+		Orphans:     len(s.FindOrphansWithScope(ctx, opts)),
+		Duplicates:  len(s.FindDuplicates(ctx, opts)),
+		Gaps:        len(s.FindGaps(ctx, opts)),
+		Cardinality: len(s.CheckCardinality(ctx, opts)),
 	}
 
-	for _, pe := range schema.ValidateEntityProperties(s.deps.Store, s.deps.Meta) {
+	for _, pe := range schema.ValidateEntityProperties(ctx, s.deps.Store, s.deps.Meta) {
 		if !inScope(pe.EntityID, opts.Scope) {
 			continue
 		}
@@ -517,9 +520,9 @@ func findTempFilesInDir(fs storage.FS, dir string) []string {
 // collectEntities iterates the store yielding entities. On iteration
 // error, logs and returns the partial slice (callers cannot signal
 // errors today — see [Service.FindOrphansWithScope] for the rationale).
-func collectEntities(s store.Store, q store.EntityQuery) []*entity.Entity {
+func collectEntities(ctx context.Context, s store.Store, q store.EntityQuery) []*entity.Entity {
 	out := make([]*entity.Entity, 0)
-	for e, err := range s.ListEntities(context.Background(), q) {
+	for e, err := range s.ListEntities(ctx, q) {
 		if err != nil {
 			slog.Warn("analysis: store.ListEntities iterator error; results may under-count",
 				"type", q.Type, "error", err)

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -73,7 +73,7 @@ func TestFindOrphansWithScope(t *testing.T) {
 	})
 
 	t.Run("no scope", func(t *testing.T) {
-		orphans := svc.FindOrphansWithScope(analysis.Options{})
+		orphans := svc.FindOrphansWithScope(context.Background(), analysis.Options{})
 		if len(orphans) != 1 {
 			t.Errorf("got %d orphans, want 1", len(orphans))
 		}
@@ -83,7 +83,7 @@ func TestFindOrphansWithScope(t *testing.T) {
 	})
 
 	t.Run("with scope including orphan", func(t *testing.T) {
-		orphans := svc.FindOrphansWithScope(analysis.Options{
+		orphans := svc.FindOrphansWithScope(context.Background(), analysis.Options{
 			Scope: map[string]bool{"DOC-003": true},
 		})
 		if len(orphans) != 1 {
@@ -92,7 +92,7 @@ func TestFindOrphansWithScope(t *testing.T) {
 	})
 
 	t.Run("with scope excluding orphan", func(t *testing.T) {
-		orphans := svc.FindOrphansWithScope(analysis.Options{
+		orphans := svc.FindOrphansWithScope(context.Background(), analysis.Options{
 			Scope: map[string]bool{"DOC-001": true, "DOC-002": true},
 		})
 		if len(orphans) != 0 {
@@ -115,7 +115,7 @@ func TestFindDuplicates(t *testing.T) {
 	})
 
 	t.Run("finds duplicates", func(t *testing.T) {
-		dups := svc.FindDuplicates(analysis.Options{})
+		dups := svc.FindDuplicates(context.Background(), analysis.Options{})
 		if len(dups) != 1 {
 			t.Errorf("got %d duplicate groups, want 1", len(dups))
 		}
@@ -125,7 +125,7 @@ func TestFindDuplicates(t *testing.T) {
 	})
 
 	t.Run("scope filters duplicates", func(t *testing.T) {
-		dups := svc.FindDuplicates(analysis.Options{
+		dups := svc.FindDuplicates(context.Background(), analysis.Options{
 			Scope: map[string]bool{"DOC-001": true},
 		})
 		if len(dups) != 0 {
@@ -159,7 +159,7 @@ func TestCheckCardinality(t *testing.T) {
 	})
 
 	t.Run("finds violations", func(t *testing.T) {
-		violations := svc.CheckCardinality(analysis.Options{})
+		violations := svc.CheckCardinality(context.Background(), analysis.Options{})
 		if len(violations) != 1 {
 			t.Errorf("got %d violations, want 1", len(violations))
 		}
@@ -174,7 +174,7 @@ func TestCheckCardinality(t *testing.T) {
 	})
 
 	t.Run("scope filters violations", func(t *testing.T) {
-		violations := svc.CheckCardinality(analysis.Options{
+		violations := svc.CheckCardinality(context.Background(), analysis.Options{
 			Scope: map[string]bool{"TKT-001": true},
 		})
 		if len(violations) != 0 {

--- a/internal/analysis/relation_order.go
+++ b/internal/analysis/relation_order.go
@@ -29,9 +29,8 @@ type RelationOrderIssue struct {
 //
 // Returns warnings only — never errors. Callers map this to whatever
 // surface the operator is on (CLI table, MCP JSON, web UI dashboard).
-func (s *Service) CheckRelationOrder(opts Options) []RelationOrderIssue {
+func (s *Service) CheckRelationOrder(ctx context.Context, opts Options) []RelationOrderIssue {
 	issues := make([]RelationOrderIssue, 0)
-	ctx := context.Background()
 	st := s.deps.Store
 	meta := s.deps.Meta
 

--- a/internal/analysis/relation_order_test.go
+++ b/internal/analysis/relation_order_test.go
@@ -48,7 +48,7 @@ func TestCheckRelationOrder_DuplicateDetected(t *testing.T) {
 		addOrderedRelation(s, "STP-2", 1.0) // duplicate
 	})
 
-	issues := svc.CheckRelationOrder(analysis.Options{})
+	issues := svc.CheckRelationOrder(context.Background(), analysis.Options{})
 	if len(issues) == 0 {
 		t.Fatal("expected at least one duplicate issue")
 	}
@@ -72,7 +72,7 @@ func TestCheckRelationOrder_MissingDetected(t *testing.T) {
 		addOrderedRelation(s, "STP-2", nil) // missing
 	})
 
-	issues := svc.CheckRelationOrder(analysis.Options{})
+	issues := svc.CheckRelationOrder(context.Background(), analysis.Options{})
 	foundMissing := false
 	for _, iss := range issues {
 		if iss.Kind == "missing" {
@@ -94,7 +94,7 @@ func TestCheckRelationOrder_NonOrderableSkipped(t *testing.T) {
 		addOrderedRelation(s, "STP-1", nil)
 	})
 
-	issues := svc.CheckRelationOrder(analysis.Options{})
+	issues := svc.CheckRelationOrder(context.Background(), analysis.Options{})
 	if len(issues) != 0 {
 		t.Errorf("non-orderable type should produce no issues, got %+v", issues)
 	}

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -76,7 +76,7 @@ var analyzeOrphansCmd = &cobra.Command{
 			return err
 		}
 
-		orphans := svc.FindOrphansWithScope(*opts)
+		orphans := svc.FindOrphansWithScope(cmd.Context(), *opts)
 		filter.SortByID(orphans, storeEntityRecord, false)
 
 		if writeAnalysisJSON(len(orphans), orphans,
@@ -103,7 +103,7 @@ var analyzeDuplicatesCmd = &cobra.Command{
 			return err
 		}
 
-		duplicates := svc.FindDuplicates(*opts)
+		duplicates := svc.FindDuplicates(cmd.Context(), *opts)
 
 		// Handle JSON output format
 		if out.Format == "json" {
@@ -155,7 +155,7 @@ since they use manually-specified IDs that are not expected to be sequential.`,
 			return err
 		}
 
-		allGaps := svc.FindGaps(*opts)
+		allGaps := svc.FindGaps(cmd.Context(), *opts)
 
 		if writeAnalysisJSON(len(allGaps), allGaps,
 			"No ID sequence gaps found", "Found gaps in %d ID sequences") {
@@ -191,7 +191,7 @@ files that need cleanup after hand-edits or imports.`,
 		if err != nil {
 			return err
 		}
-		issues := svc.CheckRelationOrder(*opts)
+		issues := svc.CheckRelationOrder(cmd.Context(), *opts)
 
 		if writeAnalysisJSON(len(issues), issues,
 			"All orderable relations have consistent order values",
@@ -224,7 +224,7 @@ var analyzeCardinalityCmd = &cobra.Command{
 			return err
 		}
 
-		violations := svc.CheckCardinality(*opts)
+		violations := svc.CheckCardinality(cmd.Context(), *opts)
 
 		if writeAnalysisJSON(len(violations), violations,
 			"All cardinality constraints satisfied", "Found %d cardinality violations") {
@@ -271,13 +271,13 @@ This catches issues in manually-edited markdown files that bypass CLI validation
 		if err != nil {
 			return err
 		}
-		return runPropertyValidation(svc, *opts)
+		return runPropertyValidation(cmd.Context(), svc, *opts)
 	},
 }
 
 // runPropertyValidation validates entity and relation properties against the metamodel.
-func runPropertyValidation(svc cliAnalyze, opts analysis.Options) error {
-	allEntityErrors := schema.ValidateEntityProperties(svc.Store(), svc.Meta())
+func runPropertyValidation(ctx context.Context, svc cliAnalyze, opts analysis.Options) error {
+	allEntityErrors := schema.ValidateEntityProperties(ctx, svc.Store(), svc.Meta())
 	if opts.Scope != nil {
 		filtered := allEntityErrors[:0]
 		for _, ee := range allEntityErrors {
@@ -287,7 +287,7 @@ func runPropertyValidation(svc cliAnalyze, opts analysis.Options) error {
 		}
 		allEntityErrors = filtered
 	}
-	allRelationErrors := schema.ValidateRelationProperties(svc.Store(), svc.Meta())
+	allRelationErrors := schema.ValidateRelationProperties(ctx, svc.Store(), svc.Meta())
 
 	errorCount := 0
 	for _, ee := range allEntityErrors {
@@ -686,7 +686,7 @@ var analyzeAllCmd = &cobra.Command{
 
 		out.WriteMessage("")
 		out.WriteSectionHeader("Property Validation")
-		if err := runPropertyValidation(svc, *opts); err != nil {
+		if err := runPropertyValidation(cmd.Context(), svc, *opts); err != nil {
 			errs = append(errs, fmt.Errorf("property validation: %w", err))
 		}
 

--- a/internal/cli/cli_wiring.go
+++ b/internal/cli/cli_wiring.go
@@ -72,11 +72,11 @@ type cliWrite interface {
 type cliAnalyze interface {
 	cliRead
 	AnalyzeAll(ctx context.Context, opts analysis.Options) *analysis.Summary
-	CheckCardinality(opts analysis.Options) []analysis.CardinalityViolation
-	CheckRelationOrder(opts analysis.Options) []analysis.RelationOrderIssue
-	FindDuplicates(opts analysis.Options) []analysis.DuplicateGroup
-	FindGaps(opts analysis.Options) []analysis.GapResult
-	FindOrphansWithScope(opts analysis.Options) []*entity.Entity
+	CheckCardinality(ctx context.Context, opts analysis.Options) []analysis.CardinalityViolation
+	CheckRelationOrder(ctx context.Context, opts analysis.Options) []analysis.RelationOrderIssue
+	FindDuplicates(ctx context.Context, opts analysis.Options) []analysis.DuplicateGroup
+	FindGaps(ctx context.Context, opts analysis.Options) []analysis.GapResult
+	FindOrphansWithScope(ctx context.Context, opts analysis.Options) []*entity.Entity
 	FindOrphanedTempFiles() ([]string, error)
 	CleanupOrphanedTempFiles() (int, error)
 	RunValidations(ctx context.Context, opts analysis.Options) analysis.ValidationResult
@@ -137,24 +137,24 @@ func (s *cliServices) AnalyzeAll(ctx context.Context, opts analysis.Options) *an
 	return s.analysis.AnalyzeAll(ctx, opts)
 }
 
-func (s *cliServices) CheckCardinality(opts analysis.Options) []analysis.CardinalityViolation {
-	return s.analysis.CheckCardinality(opts)
+func (s *cliServices) CheckCardinality(ctx context.Context, opts analysis.Options) []analysis.CardinalityViolation {
+	return s.analysis.CheckCardinality(ctx, opts)
 }
 
-func (s *cliServices) CheckRelationOrder(opts analysis.Options) []analysis.RelationOrderIssue {
-	return s.analysis.CheckRelationOrder(opts)
+func (s *cliServices) CheckRelationOrder(ctx context.Context, opts analysis.Options) []analysis.RelationOrderIssue {
+	return s.analysis.CheckRelationOrder(ctx, opts)
 }
 
-func (s *cliServices) FindDuplicates(opts analysis.Options) []analysis.DuplicateGroup {
-	return s.analysis.FindDuplicates(opts)
+func (s *cliServices) FindDuplicates(ctx context.Context, opts analysis.Options) []analysis.DuplicateGroup {
+	return s.analysis.FindDuplicates(ctx, opts)
 }
 
-func (s *cliServices) FindGaps(opts analysis.Options) []analysis.GapResult {
-	return s.analysis.FindGaps(opts)
+func (s *cliServices) FindGaps(ctx context.Context, opts analysis.Options) []analysis.GapResult {
+	return s.analysis.FindGaps(ctx, opts)
 }
 
-func (s *cliServices) FindOrphansWithScope(opts analysis.Options) []*entity.Entity {
-	return s.analysis.FindOrphansWithScope(opts)
+func (s *cliServices) FindOrphansWithScope(ctx context.Context, opts analysis.Options) []*entity.Entity {
+	return s.analysis.FindOrphansWithScope(ctx, opts)
 }
 
 func (s *cliServices) FindOrphanedTempFiles() ([]string, error) {

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -188,13 +188,13 @@ func runValidationChecks(
 	hasErrors := false
 
 	if checks.cardinality {
-		if runCardinalityCheck(checkAnalysis, checkOut, opts) {
+		if runCardinalityCheck(ctx, checkAnalysis, checkOut, opts) {
 			hasErrors = true
 		}
 	}
 
 	if checks.properties {
-		if runPropertiesCheck(checkSvc, checkOut, opts) {
+		if runPropertiesCheck(ctx, checkSvc, checkOut, opts) {
 			hasErrors = true
 		}
 	}
@@ -209,11 +209,13 @@ func runValidationChecks(
 }
 
 // runCardinalityCheck runs cardinality validation. Returns true if errors found.
-func runCardinalityCheck(checkAnalysis *analysis.Service, checkOut *output.Writer, opts analysis.Options) bool {
+func runCardinalityCheck(
+	ctx context.Context, checkAnalysis *analysis.Service, checkOut *output.Writer, opts analysis.Options,
+) bool {
 	if !quiet {
 		fmt.Println("\nChecking cardinality constraints...")
 	}
-	violations := checkAnalysis.CheckCardinality(opts)
+	violations := checkAnalysis.CheckCardinality(ctx, opts)
 	if len(violations) == 0 {
 		if !quiet && checkOut.Format != output.FormatJSON {
 			checkOut.WriteSuccess("All cardinality constraints satisfied")
@@ -243,11 +245,13 @@ func runCardinalityCheck(checkAnalysis *analysis.Service, checkOut *output.Write
 }
 
 // runPropertiesCheck runs property validation. Returns true if errors found.
-func runPropertiesCheck(checkSvc *appbuild.Services, checkOut *output.Writer, opts analysis.Options) bool {
+func runPropertiesCheck(
+	ctx context.Context, checkSvc *appbuild.Services, checkOut *output.Writer, opts analysis.Options,
+) bool {
 	if !quiet {
 		fmt.Println("\nValidating entity properties...")
 	}
-	propErrors := schema.ValidateEntityProperties(checkSvc.Store(), checkSvc.Meta())
+	propErrors := schema.ValidateEntityProperties(ctx, checkSvc.Store(), checkSvc.Meta())
 	if opts.Scope != nil {
 		filtered := propErrors[:0]
 		for _, pe := range propErrors {

--- a/internal/dataentry/actions.go
+++ b/internal/dataentry/actions.go
@@ -1,7 +1,6 @@
 package dataentry
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -93,7 +92,7 @@ func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 	// Resolve entity if provided in the request.
 	var ent *entity.Entity
 	if req.EntityID != "" {
-		if e, err := a.store.GetEntity(context.Background(), req.EntityID); err == nil {
+		if e, err := a.store.GetEntity(r.Context(), req.EntityID); err == nil {
 			ent = e
 		}
 	}
@@ -101,7 +100,7 @@ func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 	// Reuse the App's long-lived engine so rela.cache state persists
 	// across action invocations. Constructing a fresh engine per
 	// request would reset the cache each time and defeat memoization.
-	resp, err := a.scriptEngine.ExecuteAction(action.Script, a.luaWriteDeps(),
+	resp, err := a.scriptEngine.ExecuteAction(r.Context(), action.Script, a.luaWriteDeps(),
 		ent, action.Params, actionTimeout, correlationID)
 	if err != nil {
 		slog.Warn("action failed", "action", id, "correlation", correlationID, "error", err)

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -427,11 +427,13 @@ const (
 //
 // Returns the path entity when the peer can't be found locally (404
 // upstream — should not happen in practice; safe-fail).
-func (a *App) relationSourceEntity(pathEntity *entityPkg.Entity, peerID, direction string) *entityPkg.Entity {
+func (a *App) relationSourceEntity(
+	ctx context.Context, pathEntity *entityPkg.Entity, peerID, direction string,
+) *entityPkg.Entity {
 	if direction != string(DirectionIncoming) {
 		return pathEntity
 	}
-	peer, ok := a.getEntity(peerID)
+	peer, ok := a.getEntity(ctx, peerID)
 	if !ok {
 		return pathEntity
 	}
@@ -505,7 +507,7 @@ func (a *App) validateRelationsModernAffordances(
 		for _, ref := range upd.Data {
 			desiredByID[ref.ID] = ref
 		}
-		current := a.currentEdgesByPeer(entityID, canonical, incoming)
+		current := a.currentEdgesByPeer(ctx, entityID, canonical, incoming)
 
 		// For incoming-direction body keys the SOURCE of every edge is
 		// the peer entity, not the path entity. Verdicts are evaluated
@@ -518,7 +520,7 @@ func (a *App) validateRelationsModernAffordances(
 
 		// Adds: any desired edge whose peer isn't currently linked.
 		for _, ref := range upd.Data {
-			source := a.relationSourceEntity(e, ref.ID, direction)
+			source := a.relationSourceEntity(ctx, e, ref.ID, direction)
 			if _, exists := current[ref.ID]; exists {
 				// Upsert path: not a create, but the meta may change.
 				if denial := a.validateRelationMetaWrite(ctx, source, canonical, ref.Meta, ref.MetaUnset); denial != nil {
@@ -539,7 +541,7 @@ func (a *App) validateRelationsModernAffordances(
 			if _, kept := desiredByID[peerID]; kept {
 				continue
 			}
-			source := a.relationSourceEntity(e, peerID, direction)
+			source := a.relationSourceEntity(ctx, e, peerID, direction)
 			if denial := a.validateRelationOp(ctx, source, canonical, RelationOpRemove); denial != nil {
 				return denial
 			}

--- a/internal/dataentry/analyze.go
+++ b/internal/dataentry/analyze.go
@@ -67,14 +67,14 @@ type AnalysisResult struct {
 }
 
 // runAnalysis executes all analysis checks and returns a combined result.
-func (a *App) runAnalysis() AnalysisResult {
+func (a *App) runAnalysis(ctx context.Context) AnalysisResult {
 	sections := []AnalysisSection{
-		a.analyzeProperties(),
-		a.analyzeCardinality(),
-		a.analyzeValidations(),
-		a.analyzeOrphans(),
-		a.analyzeDuplicates(),
-		a.analyzeGaps(),
+		a.analyzeProperties(ctx),
+		a.analyzeCardinality(ctx),
+		a.analyzeValidations(ctx),
+		a.analyzeOrphans(ctx),
+		a.analyzeDuplicates(ctx),
+		a.analyzeGaps(ctx),
 	}
 
 	var errors, warnings int
@@ -92,20 +92,19 @@ func (a *App) runAnalysis() AnalysisResult {
 
 // analysisIssueCounts returns just the total error and warning counts
 // without building the full issue details. Used by the dashboard.
-func (a *App) analysisIssueCounts() (errors, warnings int) {
-	result := a.runAnalysis()
+func (a *App) analysisIssueCounts(ctx context.Context) (errors, warnings int) {
+	result := a.runAnalysis(ctx)
 	return result.ErrorCount, result.WarningCount
 }
 
 // analyzeOrphans finds entities with no connections.
-func (a *App) analyzeOrphans() AnalysisSection {
+func (a *App) analyzeOrphans(ctx context.Context) AnalysisSection {
 	s := a.State()
 	section := AnalysisSection{
 		Name:        "Orphans",
 		Description: "Entities with no incoming or outgoing relations",
 	}
 
-	ctx := context.Background()
 	orphanIDs, _ := a.tracer.FindOrphans(ctx)
 
 	var orphans []*entity.Entity
@@ -131,14 +130,13 @@ func (a *App) analyzeOrphans() AnalysisSection {
 }
 
 // analyzeDuplicates finds entities with identical normalized titles.
-func (a *App) analyzeDuplicates() AnalysisSection {
+func (a *App) analyzeDuplicates(ctx context.Context) AnalysisSection {
 	s := a.State()
 	section := AnalysisSection{
 		Name:        "Duplicates",
 		Description: "Entities with identical titles",
 	}
 
-	ctx := context.Background()
 	titleGroups := make(map[string][]*entity.Entity)
 	for e, err := range a.store.ListEntities(ctx, store.EntityQuery{}) {
 		if err != nil {
@@ -181,7 +179,7 @@ func (a *App) analyzeDuplicates() AnalysisSection {
 }
 
 // analyzeGaps finds gaps in ID sequences for auto-numbered entity types.
-func (a *App) analyzeGaps() AnalysisSection {
+func (a *App) analyzeGaps(ctx context.Context) AnalysisSection {
 	s := a.State()
 	section := AnalysisSection{
 		Name:        "ID Gaps",
@@ -204,7 +202,6 @@ func (a *App) analyzeGaps() AnalysisSection {
 	}
 
 	// Group IDs by prefix
-	ctx := context.Background()
 	prefixGroups := make(map[string][]int)
 	for e, err := range a.store.ListEntities(ctx, store.EntityQuery{}) {
 		if err != nil {
@@ -257,14 +254,13 @@ func (a *App) analyzeGaps() AnalysisSection {
 }
 
 // analyzeCardinality checks relation cardinality constraints.
-func (a *App) analyzeCardinality() AnalysisSection {
+func (a *App) analyzeCardinality(ctx context.Context) AnalysisSection {
 	s := a.State()
 	section := AnalysisSection{
 		Name:        "Cardinality",
 		Description: "Relation cardinality constraint violations",
 	}
 
-	ctx := context.Background()
 	st := a.store
 
 	// Sort relation names for deterministic output
@@ -383,14 +379,13 @@ func (a *App) analyzeCardinality() AnalysisSection {
 }
 
 // analyzeProperties validates all entity properties against the metamodel.
-func (a *App) analyzeProperties() AnalysisSection {
+func (a *App) analyzeProperties(ctx context.Context) AnalysisSection {
 	s := a.State()
 	section := AnalysisSection{
 		Name:        "Properties",
 		Description: "Property validation errors (required fields, invalid values, ID patterns)",
 	}
 
-	ctx := context.Background()
 	entities := make([]*entity.Entity, 0)
 	for e, err := range a.store.ListEntities(ctx, store.EntityQuery{}) {
 		if err != nil {
@@ -423,14 +418,13 @@ func (a *App) analyzeProperties() AnalysisSection {
 // (lua_file: missing, traversal-rejected) appear as error issues
 // alongside per-entity violations. Without this, broken Lua rules
 // would vanish silently from the data-entry analyze view.
-func (a *App) analyzeValidations() AnalysisSection {
+func (a *App) analyzeValidations(ctx context.Context) AnalysisSection {
 	s := a.State()
 	section := AnalysisSection{
 		Name:        "Validations",
 		Description: "Custom validation rules defined in the metamodel",
 	}
 
-	ctx := context.Background()
 	st := a.store
 	validator := a.validator
 

--- a/internal/dataentry/analyze_test.go
+++ b/internal/dataentry/analyze_test.go
@@ -1,6 +1,7 @@
 package dataentry
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -30,7 +31,7 @@ func TestAnalyzeOrphans(t *testing.T) {
 	g.AddEdge(&entity.Relation{From: "T-002", Type: "blocks", To: "T-003"})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeOrphans()
+	section := app.analyzeOrphans(context.Background())
 
 	if section.Name != "Orphans" {
 		t.Errorf("expected section name 'Orphans', got %q", section.Name)
@@ -59,7 +60,7 @@ func TestAnalyzeOrphans_NoOrphans(t *testing.T) {
 	g.AddEdge(&entity.Relation{From: "T-001", Type: "blocks", To: "T-002"})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeOrphans()
+	section := app.analyzeOrphans(context.Background())
 
 	if len(section.Issues) != 0 {
 		t.Errorf("expected 0 orphans, got %d", len(section.Issues))
@@ -81,7 +82,7 @@ func TestAnalyzeDuplicates(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "T-003", Type: "ticket", Properties: map[string]interface{}{"title": "Unique"}})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeDuplicates()
+	section := app.analyzeDuplicates(context.Background())
 
 	if len(section.Issues) != 2 {
 		t.Fatalf("expected 2 duplicate issues (for the pair), got %d", len(section.Issues))
@@ -107,7 +108,7 @@ func TestAnalyzeDuplicates_NoDuplicates(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{"title": "Beta"}})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeDuplicates()
+	section := app.analyzeDuplicates(context.Background())
 
 	if len(section.Issues) != 0 {
 		t.Errorf("expected 0 duplicate issues, got %d", len(section.Issues))
@@ -127,7 +128,7 @@ func TestAnalyzeGaps(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "T-003", Type: "ticket", Properties: map[string]interface{}{}})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeGaps()
+	section := app.analyzeGaps(context.Background())
 
 	if len(section.Issues) != 1 {
 		t.Fatalf("expected 1 gap issue, got %d", len(section.Issues))
@@ -160,7 +161,7 @@ func TestAnalyzeGaps_ManualIDsSkipped(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "C-005", Type: "component", Properties: map[string]interface{}{}})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeGaps()
+	section := app.analyzeGaps(context.Background())
 
 	if len(section.Issues) != 0 {
 		t.Errorf("expected 0 gap issues for manual ID type, got %d", len(section.Issues))
@@ -185,7 +186,7 @@ func TestAnalyzeGaps_MultiplePrefixes(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "FEAT-003", Type: "feature", Properties: map[string]interface{}{}})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeGaps()
+	section := app.analyzeGaps(context.Background())
 
 	if len(section.Issues) != 1 {
 		t.Fatalf("expected 1 gap issue, got %d", len(section.Issues))
@@ -223,7 +224,7 @@ func TestAnalyzeCardinality(t *testing.T) {
 	g.AddEdge(&entity.Relation{From: "T-001", Type: "implements", To: "C-001"})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeCardinality()
+	section := app.analyzeCardinality(context.Background())
 
 	if len(section.Issues) != 1 {
 		t.Fatalf("expected 1 cardinality violation, got %d", len(section.Issues))
@@ -258,7 +259,7 @@ func TestAnalyzeCardinality_AllSatisfied(t *testing.T) {
 	g.AddEdge(&entity.Relation{From: "T-001", Type: "implements", To: "C-001"})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeCardinality()
+	section := app.analyzeCardinality(context.Background())
 
 	if len(section.Issues) != 0 {
 		t.Errorf("expected 0 violations, got %d", len(section.Issues))
@@ -285,7 +286,7 @@ func TestAnalyzeProperties(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{"title": "Good", "status": "open"}})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeProperties()
+	section := app.analyzeProperties(context.Background())
 
 	if len(section.Issues) < 2 {
 		t.Fatalf("expected at least 2 property errors (missing title + invalid enum), got %d", len(section.Issues))
@@ -317,7 +318,7 @@ func TestAnalyzeProperties_AllValid(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{"title": "Valid"}})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeProperties()
+	section := app.analyzeProperties(context.Background())
 
 	if len(section.Issues) != 0 {
 		t.Errorf("expected 0 property issues, got %d", len(section.Issues))
@@ -353,7 +354,7 @@ func TestAnalyzeValidations(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "T-003", Type: "ticket", Properties: map[string]interface{}{"status": "draft"}})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeValidations()
+	section := app.analyzeValidations(context.Background())
 
 	if len(section.Issues) != 1 {
 		t.Fatalf("expected 1 validation issue, got %d", len(section.Issues))
@@ -388,7 +389,7 @@ func TestAnalyzeValidations_SurfacesScriptError(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{}})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeValidations()
+	section := app.analyzeValidations(context.Background())
 
 	if len(section.Issues) == 0 {
 		t.Fatal("expected the script error to surface as an analysis issue, got 0 issues")
@@ -433,7 +434,7 @@ func TestAnalyzeValidations_SurfacesLoadError(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{}})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeValidations()
+	section := app.analyzeValidations(context.Background())
 
 	if len(section.Issues) == 0 {
 		t.Fatal("expected the load error to surface as an analysis issue, got 0 issues")
@@ -467,7 +468,7 @@ func TestAnalyzeValidations_NoRules(t *testing.T) {
 	}
 
 	app := newTestApp(g, meta)
-	section := app.analyzeValidations()
+	section := app.analyzeValidations(context.Background())
 
 	if len(section.Issues) != 0 {
 		t.Errorf("expected 0 issues with no rules, got %d", len(section.Issues))
@@ -491,7 +492,7 @@ func TestRunAnalysis(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{}})
 
 	app := newTestApp(g, meta)
-	result := app.runAnalysis()
+	result := app.runAnalysis(context.Background())
 
 	if len(result.Sections) != 6 {
 		t.Errorf("expected 6 sections, got %d", len(result.Sections))
@@ -512,7 +513,7 @@ func TestRunAnalysis_EmptyGraph(t *testing.T) {
 	}
 
 	app := newTestApp(g, meta)
-	result := app.runAnalysis()
+	result := app.runAnalysis(context.Background())
 
 	if result.ErrorCount != 0 {
 		t.Errorf("expected 0 errors for empty graph, got %d", result.ErrorCount)
@@ -558,7 +559,7 @@ func TestAnalysisIssueCounts(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{}})
 
 	app := newTestApp(g, meta)
-	errors, warnings := app.analysisIssueCounts()
+	errors, warnings := app.analysisIssueCounts(context.Background())
 
 	if errors < 1 {
 		t.Errorf("expected at least 1 error, got %d", errors)
@@ -634,7 +635,7 @@ func TestAnalyzeValidationsWithContentRules(t *testing.T) {
 	})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeValidations()
+	section := app.analyzeValidations(context.Background())
 
 	if len(section.Issues) != 1 {
 		t.Fatalf("expected 1 content validation issue, got %d", len(section.Issues))
@@ -697,7 +698,7 @@ func TestAnalyzeValidationsWithCombinedRules(t *testing.T) {
 	})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeValidations()
+	section := app.analyzeValidations(context.Background())
 
 	if len(section.Issues) != 2 {
 		t.Fatalf("expected 2 violations (DEC-001 and DEC-002), got %d", len(section.Issues))
@@ -764,7 +765,7 @@ func TestAnalyzeValidationsWithChecklistRule(t *testing.T) {
 	})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeValidations()
+	section := app.analyzeValidations(context.Background())
 
 	if len(section.Issues) != 1 {
 		t.Fatalf("expected 1 checklist validation issue, got %d", len(section.Issues))
@@ -819,7 +820,7 @@ func TestAnalyzeValidationsWithChecklistAllowSkipped(t *testing.T) {
 	})
 
 	app := newTestApp(g, meta)
-	section := app.analyzeValidations()
+	section := app.analyzeValidations(context.Background())
 
 	if len(section.Issues) != 1 {
 		t.Fatalf("expected 1 checklist validation issue, got %d", len(section.Issues))
@@ -838,7 +839,7 @@ func TestAnalyzeValidationsWithChecklistAllowSkipped(t *testing.T) {
 // regresses the GH#785 hidden-card bug.
 func TestRunAnalysisSectionNames(t *testing.T) {
 	app := newTestApp(newFixture(), &metamodel.Metamodel{})
-	result := app.runAnalysis()
+	result := app.runAnalysis(context.Background())
 	got := make([]string, len(result.Sections))
 	for i, s := range result.Sections {
 		got[i] = s.Name

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -360,7 +360,7 @@ func (a *App) handleV1EntityCollection(w http.ResponseWriter, r *http.Request, t
 }
 
 func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeName, plural string) {
-	entities := listFromStoreByTypes(a.Services(), []string{typeName})
+	entities := listFromStoreByTypes(r.Context(), a.Services(), []string{typeName})
 
 	query := r.URL.Query()
 
@@ -696,7 +696,7 @@ func (a *App) handleV1SingleEntity(w http.ResponseWriter, r *http.Request, typeN
 }
 
 func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName, plural, entityID string) {
-	entity, found := a.getEntity(entityID)
+	entity, found := a.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -715,7 +715,7 @@ func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName
 	}
 
 	// ETag for caching
-	etag := a.computeEntityETag(entity)
+	etag := a.computeEntityETag(r.Context(), entity)
 	w.Header().Set("ETag", etag)
 
 	// Check If-None-Match
@@ -734,7 +734,7 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 
 	s := a.State()
 
-	entity, found := a.getEntity(entityID)
+	entity, found := a.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -752,7 +752,7 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 	// Check If-Match for optimistic locking
 	ifMatch := r.Header.Get("If-Match")
 	if ifMatch != "" {
-		currentETag := a.computeEntityETag(entity)
+		currentETag := a.computeEntityETag(r.Context(), entity)
 		if ifMatch != currentETag {
 			writeV1Error(w, r, http.StatusPreconditionFailed, "precondition_failed",
 				"Entity has been modified", "ETag mismatch")
@@ -873,7 +873,7 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 	if len(warnings) > 0 {
 		result.Warnings = warnings
 	}
-	newETag := a.computeEntityETag(entity)
+	newETag := a.computeEntityETag(r.Context(), entity)
 	w.Header().Set("ETag", newETag)
 
 	// Broadcast entity update event when the entity itself changed.
@@ -922,7 +922,7 @@ func (a *App) handleV1DeleteEntity(w http.ResponseWriter, r *http.Request, typeN
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
-	entity, found := a.getEntity(entityID)
+	entity, found := a.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -946,14 +946,14 @@ func (a *App) handleV1DeleteEntity(w http.ResponseWriter, r *http.Request, typeN
 
 func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, typeName, entityID string) {
 	s := a.State()
-	entity, found := a.getEntity(entityID)
+	entity, found := a.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
 	}
 
-	outgoing := a.outgoingRelations(entityID)
-	incoming := a.incomingRelations(entityID)
+	outgoing := a.outgoingRelations(r.Context(), entityID)
+	incoming := a.incomingRelations(r.Context(), entityID)
 
 	relations := make(map[string][]map[string]interface{})
 
@@ -964,7 +964,7 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 	for _, edge := range outgoing {
 		rel := map[string]interface{}{
 			"id":        edge.To,
-			"type":      a.peerType(edge.To),
+			"type":      a.peerType(r.Context(), edge.To),
 			"direction": "outgoing",
 		}
 		if len(edge.Properties) > 0 {
@@ -989,7 +989,7 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 		}
 		rel := map[string]interface{}{
 			"id":        edge.From,
-			"type":      a.peerType(edge.From),
+			"type":      a.peerType(r.Context(), edge.From),
 			"direction": "incoming",
 		}
 		if len(edge.Properties) > 0 {
@@ -1062,7 +1062,7 @@ func resolveRelationEndpoints(entityID, peerID, direction string) (from, to stri
 }
 
 func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, typeName, entityID, relType string) {
-	entity, found := a.getEntity(entityID)
+	entity, found := a.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -1072,9 +1072,9 @@ func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, ty
 
 	var edges []*entityPkg.Relation
 	if incoming {
-		edges = a.incomingRelations(entityID)
+		edges = a.incomingRelations(r.Context(), entityID)
 	} else {
-		edges = a.outgoingRelations(entityID)
+		edges = a.outgoingRelations(r.Context(), entityID)
 	}
 
 	relations := make([]map[string]interface{}, 0, len(edges))
@@ -1089,7 +1089,7 @@ func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, ty
 		}
 		rel := map[string]interface{}{
 			"id":   peerID,
-			"type": a.peerType(peerID),
+			"type": a.peerType(r.Context(), peerID),
 		}
 		if len(edge.Properties) > 0 {
 			rel["meta"] = edge.Properties
@@ -1118,7 +1118,7 @@ func (a *App) handleV1CreateRelation(w http.ResponseWriter, r *http.Request, typ
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
-	entity, found := a.getEntity(entityID)
+	entity, found := a.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -1143,7 +1143,7 @@ func (a *App) handleV1CreateRelation(w http.ResponseWriter, r *http.Request, typ
 	// Affordance gates: creatable + meta-writable, evaluated against
 	// the SOURCE of the new edge (not necessarily the path entity —
 	// for incoming-direction creates the path entity is the target).
-	source := a.relationSourceEntity(entity, req.ID, req.Direction)
+	source := a.relationSourceEntity(r.Context(), entity, req.ID, req.Direction)
 	// Audit subject is the source of the new edge, matching the
 	// entity whose policy gated the write.
 	if denial := a.validateRelationOp(r.Context(), source, relType, RelationOpCreate); denial != nil {
@@ -1185,7 +1185,7 @@ func (a *App) handleV1UpdateRelation(w http.ResponseWriter, r *http.Request, typ
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
-	entity, found := a.getEntity(entityID)
+	entity, found := a.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -1204,7 +1204,7 @@ func (a *App) handleV1UpdateRelation(w http.ResponseWriter, r *http.Request, typ
 	// the edge (the path entity for outgoing; the peer for incoming).
 	// The edge already exists (PATCH is meta-only), so the create /
 	// remove gates don't apply.
-	source := a.relationSourceEntity(entity, targetID, req.Direction)
+	source := a.relationSourceEntity(r.Context(), entity, targetID, req.Direction)
 	if denial := a.validateRelationMetaWrite(r.Context(), source, relType, req.Meta, nil); denial != nil {
 		a.denyAffordance(r.Context(), w, source, *denial)
 		return
@@ -1261,7 +1261,7 @@ func (a *App) handleV1DeleteRelation(w http.ResponseWriter, r *http.Request, typ
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 
-	entity, found := a.getEntity(entityID)
+	entity, found := a.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -1272,7 +1272,7 @@ func (a *App) handleV1DeleteRelation(w http.ResponseWriter, r *http.Request, typ
 	// incoming). Per-relation-type uniform — a removable=false
 	// verdict applies to every link of this type.
 	direction := r.URL.Query().Get("direction")
-	source := a.relationSourceEntity(entity, targetID, direction)
+	source := a.relationSourceEntity(r.Context(), entity, targetID, direction)
 	if denial := a.validateRelationOp(r.Context(), source, relType, RelationOpRemove); denial != nil {
 		a.denyAffordance(r.Context(), w, source, *denial)
 		return
@@ -1313,7 +1313,7 @@ func (a *App) handleV1CloneEntity(w http.ResponseWriter, r *http.Request, typeNa
 	defer a.writeMu.Unlock()
 
 	s := a.State()
-	entity, found := a.getEntity(entityID)
+	entity, found := a.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -1536,7 +1536,7 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entities := a.executeQuery(query)
+	entities := a.executeQuery(r.Context(), query)
 
 	// Apply type filter if provided
 	if typeFilter := r.URL.Query().Get("type"); typeFilter != "" {
@@ -1575,7 +1575,7 @@ func (a *App) handleV1Analyze(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	analysisResult := a.runAnalysis()
+	analysisResult := a.runAnalysis(r.Context())
 
 	result := APIAnalysisResult{
 		Errors:   analysisResult.ErrorCount,
@@ -1641,7 +1641,7 @@ func (a *App) entityToV1(ctx context.Context, e *entityPkg.Entity, plural string
 
 	if includeRelations {
 		v1.Relations = make(map[string][]string)
-		for _, edge := range a.outgoingRelations(e.ID) {
+		for _, edge := range a.outgoingRelations(ctx, e.ID) {
 			v1.Relations[edge.Type] = append(v1.Relations[edge.Type], edge.To)
 		}
 	}
@@ -1656,8 +1656,8 @@ func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, i
 	// Support include=* to include all related entities
 	if includes == "*" {
 		// Include all outgoing relations
-		for _, edge := range a.outgoingRelations(entity.ID) {
-			target, found := a.getEntity(edge.To)
+		for _, edge := range a.outgoingRelations(ctx, entity.ID) {
+			target, found := a.getEntity(ctx, edge.To)
 			if !found {
 				continue
 			}
@@ -1666,8 +1666,8 @@ func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, i
 			included[target.ID] = a.serializeRelatedEntityForWire(ctx, target, plural, false)
 		}
 		// Include all incoming relations
-		for _, edge := range a.incomingRelations(entity.ID) {
-			source, found := a.getEntity(edge.From)
+		for _, edge := range a.incomingRelations(ctx, entity.ID) {
+			source, found := a.getEntity(ctx, edge.From)
 			if !found {
 				continue
 			}
@@ -1689,11 +1689,11 @@ func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, i
 		relParts := strings.SplitN(part, ".", 2)
 		relType := relParts[0]
 
-		for _, edge := range a.outgoingRelations(entity.ID) {
+		for _, edge := range a.outgoingRelations(ctx, entity.ID) {
 			if edge.Type != relType {
 				continue
 			}
-			target, found := a.getEntity(edge.To)
+			target, found := a.getEntity(ctx, edge.To)
 			if !found {
 				continue
 			}
@@ -1941,7 +1941,7 @@ func (a *App) addPaginationLinks(w http.ResponseWriter, _ *http.Request, page, p
 	w.Header().Set("Link", strings.Join(links, ", "))
 }
 
-func (a *App) computeEntityETag(e *entityPkg.Entity) string {
+func (a *App) computeEntityETag(ctx context.Context, e *entityPkg.Entity) string {
 	h := sha256.New()
 	_, _ = h.Write([]byte(e.ID))
 	_, _ = h.Write([]byte(e.Type))
@@ -1961,7 +1961,7 @@ func (a *App) computeEntityETag(e *entityPkg.Entity) string {
 	// Fold outgoing relations into the hash so PATCHes that only change
 	// edges also change the ETag — otherwise If-Match / If-None-Match
 	// round-trips poison client caches.
-	edges := a.outgoingRelations(e.ID)
+	edges := a.outgoingRelations(ctx, e.ID)
 	edgeKeys := make([]string, 0, len(edges))
 	for _, edge := range edges {
 		edgeKeys = append(edgeKeys, edge.Type+"|"+edge.To)
@@ -2117,14 +2117,14 @@ func (a *App) handleV1SidePanel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the entry entity
-	entry, found := a.getEntity(entityID)
+	entry, found := a.getEntity(r.Context(), entityID)
 	if !found {
 		writeV1Error(w, r, http.StatusNotFound, "entity_not_found", "Entity not found", "")
 		return
 	}
 
 	// Execute side panel traversal
-	sections := a.executeSidePanel(form.SidePanel, entityID, form.EntityType)
+	sections := a.executeSidePanel(r.Context(), form.SidePanel, entityID, form.EntityType)
 	if sections == nil {
 		writeV1JSON(w, http.StatusOK, []V1SidePanelSection{})
 		return
@@ -2237,7 +2237,7 @@ func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 	// Build entity type counts as a fallback for items without filters.
 	typeCounts := make(map[string]int)
 	for _, entityType := range s.Meta.EntityTypes() {
-		n, err := svc.Store.CountEntities(context.Background(), store.EntityQuery{Type: entityType})
+		n, err := svc.Store.CountEntities(r.Context(), store.EntityQuery{Type: entityType})
 		if err != nil {
 			typeCounts[entityType] = 0
 			continue
@@ -2262,13 +2262,13 @@ func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 				Items:     make([]V1SidebarItem, 0),
 			}
 			for _, item := range entry.Items {
-				sidebarItem := a.navEntryToSidebarItem(item, counts)
+				sidebarItem := a.navEntryToSidebarItem(r.Context(), item, counts)
 				group.Items = append(group.Items, sidebarItem)
 			}
 			navigation = append(navigation, group)
 		} else {
 			// Top-level item without group
-			item := a.navEntryToSidebarItem(entry, counts)
+			item := a.navEntryToSidebarItem(r.Context(), entry, counts)
 			navigation = append(navigation, V1SidebarGroup{
 				Items: []V1SidebarItem{item},
 			})
@@ -2298,24 +2298,24 @@ type sidebarCounts struct {
 
 // listCount returns the entity count for the given list, applying any
 // configured filters. Results are cached per call.
-func (c *sidebarCounts) listCount(listID string, list dataentryconfig.List) int {
+func (c *sidebarCounts) listCount(ctx context.Context, listID string, list dataentryconfig.List) int {
 	key := "list:" + listID
 	if n, ok := c.filterCache[key]; ok {
 		return n
 	}
-	n := c.countWithFilters(list.EntityType, list.Filters)
+	n := c.countWithFilters(ctx, list.EntityType, list.Filters)
 	c.filterCache[key] = n
 	return n
 }
 
 // kanbanCount returns the entity count for the given kanban, applying
 // any configured filters. Results are cached per call.
-func (c *sidebarCounts) kanbanCount(kanbanID string, kanban dataentryconfig.Kanban) int {
+func (c *sidebarCounts) kanbanCount(ctx context.Context, kanbanID string, kanban dataentryconfig.Kanban) int {
 	key := "kanban:" + kanbanID
 	if n, ok := c.filterCache[key]; ok {
 		return n
 	}
-	n := c.countWithFilters(kanban.EntityType, kanban.Filters)
+	n := c.countWithFilters(ctx, kanban.EntityType, kanban.Filters)
 	c.filterCache[key] = n
 	return n
 }
@@ -2323,16 +2323,16 @@ func (c *sidebarCounts) kanbanCount(kanbanID string, kanban dataentryconfig.Kanb
 // countWithFilters returns the count of entities of the given type that
 // pass the supplied filters. When filters is empty, the precomputed
 // type total is returned directly.
-func (c *sidebarCounts) countWithFilters(entityType string, filters []dataentryconfig.FilterConfig) int {
+func (c *sidebarCounts) countWithFilters(ctx context.Context, entityType string, filters []dataentryconfig.FilterConfig) int {
 	if len(filters) == 0 {
 		return c.typeCounts[entityType]
 	}
-	entities := listFromStoreByTypes(c.app.Services(), []string{entityType})
+	entities := listFromStoreByTypes(ctx, c.app.Services(), []string{entityType})
 	return len(applyFilters(entities, filters))
 }
 
 // navEntryToSidebarItem converts a navigation entry to a sidebar item with count.
-func (a *App) navEntryToSidebarItem(entry dataentryconfig.NavigationEntry, counts sidebarCounts) V1SidebarItem {
+func (a *App) navEntryToSidebarItem(ctx context.Context, entry dataentryconfig.NavigationEntry, counts sidebarCounts) V1SidebarItem {
 	s := a.State()
 	item := V1SidebarItem{
 		Label: entry.Label,
@@ -2343,14 +2343,14 @@ func (a *App) navEntryToSidebarItem(entry dataentryconfig.NavigationEntry, count
 		item.Href = "/list/" + entry.List
 		item.Icon = "list"
 		if list, ok := s.Cfg.Lists[entry.List]; ok {
-			count := counts.listCount(entry.List, list)
+			count := counts.listCount(ctx, entry.List, list)
 			item.Count = &count
 		}
 	case entry.Kanban != "":
 		item.Href = "/kanban/" + entry.Kanban
 		item.Icon = "kanban"
 		if kanban, ok := s.Cfg.Kanbans[entry.Kanban]; ok {
-			count := counts.kanbanCount(entry.Kanban, kanban)
+			count := counts.kanbanCount(ctx, entry.Kanban, kanban)
 			item.Count = &count
 		}
 	case entry.Dashboard:
@@ -2632,7 +2632,7 @@ func (a *App) handleV1Documents(w http.ResponseWriter, r *http.Request) {
 	// read for script: docs so we don't serve a stale command:-era file
 	// after a doc is switched to a Lua script.
 	if !forceRefresh && docCfg.Script == "" {
-		result := a.documents.GetCached(entityID)
+		result := a.documents.GetCached(r.Context(), entityID)
 		if result != nil {
 			html := RewriteDocumentLinks(result.HTML, returnPath, nil)
 			writeV1JSON(w, http.StatusOK, V1DocumentResponse{
@@ -2645,7 +2645,7 @@ func (a *App) handleV1Documents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Render the document
-	result, err := a.documents.Render(entityID, renderCfg)
+	result, err := a.documents.Render(r.Context(), entityID, renderCfg)
 	if err != nil {
 		var se *lua.ScriptError
 		if errors.As(err, &se) {
@@ -2945,14 +2945,14 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Execute view
-	result, err := a.executeView(viewCfg, entityID)
+	result, err := a.executeView(r.Context(), viewCfg, entityID)
 	if err != nil {
 		writeV1Error(w, r, http.StatusUnprocessableEntity, "view_execution_failed", "View execution failed", err.Error())
 		return
 	}
 
 	// Build sections
-	sections := a.buildSections(viewCfg.Sections, result)
+	sections := a.buildSections(r.Context(), viewCfg.Sections, result)
 
 	// Build response
 	entityDef := s.Meta.Entities[result.Entry.Type]

--- a/internal/dataentry/api_v1_properties_unset_test.go
+++ b/internal/dataentry/api_v1_properties_unset_test.go
@@ -6,6 +6,7 @@
 package dataentry
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -186,7 +187,7 @@ func TestV1UpdateEntity_PropertiesUnsetAndRelations_Together(t *testing.T) {
 		t.Error("status not removed")
 	}
 	// Relation written
-	edges := app.outgoingRelations("TKT-001")
+	edges := app.outgoingRelations(context.Background(), "TKT-001")
 	if len(edges) != 1 || edges[0].Type != "blocks" || edges[0].To != "FEAT-001" {
 		t.Errorf("expected one blocks→FEAT-001 edge, got %+v", edges)
 	}

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -2961,7 +2961,7 @@ func TestV1UpdateEntityInvalidJSON(t *testing.T) {
 // edges for entityID, used to keep the relation-save tests concise.
 func implementsTargets(app *App, entityID string) map[string]bool {
 	out := map[string]bool{}
-	for _, r := range app.outgoingRelations(entityID) {
+	for _, r := range app.outgoingRelations(context.Background(), entityID) {
 		if r.Type == "implements" {
 			out[r.To] = true
 		}
@@ -3126,7 +3126,7 @@ func TestV1UpdateEntity_Relations_ScopedToTypesInPayload(t *testing.T) {
 
 	impls := map[string]bool{}
 	blocks := map[string]bool{}
-	for _, r := range app.outgoingRelations("TKT-001") {
+	for _, r := range app.outgoingRelations(context.Background(), "TKT-001") {
 		switch r.Type {
 		case "implements":
 			impls[r.To] = true
@@ -3162,7 +3162,7 @@ func TestV1UpdateEntity_Relations_MultiType(t *testing.T) {
 	}
 
 	types := map[string]bool{}
-	for _, r := range app.outgoingRelations("TKT-001") {
+	for _, r := range app.outgoingRelations(context.Background(), "TKT-001") {
 		types[r.Type+"->"+r.To] = true
 	}
 	if !types["implements->FEAT-001"] || !types["blocks->TKT-002"] || len(types) != 2 {
@@ -3190,7 +3190,7 @@ func TestV1UpdateEntity_Relations_UnknownType(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), "unknown_relation_type") || !strings.Contains(rec.Body.String(), "bogus") {
 		t.Fatalf("detail missing structured reason/type, got: %s", rec.Body.String())
 	}
-	if len(app.outgoingRelations("TKT-001")) != 0 {
+	if len(app.outgoingRelations(context.Background(), "TKT-001")) != 0 {
 		t.Fatalf("no edges should have been written on a rejected type")
 	}
 }
@@ -3260,8 +3260,8 @@ func TestV1UpdateEntity_Relations_OnlyPATCH_ETagChangesButEntityStable(t *testin
 	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{"title": "T"}})
 	seedEntity(app, &entity.Entity{ID: "FEAT-001", Type: "feature", Properties: map[string]interface{}{"title": "F"}})
 
-	entityBefore, _ := app.getEntity("TKT-001")
-	etagBefore := app.computeEntityETag(entityBefore)
+	entityBefore, _ := app.getEntity(context.Background(), "TKT-001")
+	etagBefore := app.computeEntityETag(context.Background(), entityBefore)
 
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/TKT-001",
 		strings.NewReader(`{"relations":{"implements":{"data":[{"type":"feature","id":"FEAT-001"}]}}}`))
@@ -3271,7 +3271,7 @@ func TestV1UpdateEntity_Relations_OnlyPATCH_ETagChangesButEntityStable(t *testin
 		t.Fatalf("PATCH returned %d: %s", rec.Code, rec.Body.String())
 	}
 
-	entityAfter, _ := app.getEntity("TKT-001")
+	entityAfter, _ := app.getEntity(context.Background(), "TKT-001")
 	// Entity fields (id/type/props/content) should be byte-identical.
 	if entityAfter.Content != entityBefore.Content ||
 		len(entityAfter.Properties) != len(entityBefore.Properties) {
@@ -3279,7 +3279,7 @@ func TestV1UpdateEntity_Relations_OnlyPATCH_ETagChangesButEntityStable(t *testin
 		t.Fatalf("relations-only PATCH mutated entity fields: before=%+v after=%+v", entityBefore, entityAfter)
 	}
 	// ETag must change because it now folds in relations.
-	etagAfter := app.computeEntityETag(entityAfter)
+	etagAfter := app.computeEntityETag(context.Background(), entityAfter)
 	if etagAfter == etagBefore {
 		t.Fatalf("ETag did not change after relations-only PATCH: %s", etagAfter)
 	}
@@ -3453,7 +3453,7 @@ func TestHandleV1Documents_CacheInvariance(t *testing.T) {
 	// no `return_to=` token. Read it via documentService.GetCached,
 	// which reconstructs the cache file path from the entry's content
 	// hash and reads the underlying bytes verbatim.
-	cached := app.documents.GetCached("TKT-001")
+	cached := app.documents.GetCached(context.Background(), "TKT-001")
 	if cached == nil {
 		t.Fatalf("expected cache file for TKT-001 to exist after two renders")
 	}
@@ -4478,7 +4478,7 @@ func TestAppRouter_PatchReadOnlyField_Forbidden(t *testing.T) {
 			t.Fatalf("got %d, want 403; body=%s", code, body)
 		}
 		// Verify title was NOT updated.
-		e, _ := app.getEntity("TKT-001")
+		e, _ := app.getEntity(context.Background(), "TKT-001")
 		if e.Properties["title"] != "Original" {
 			t.Errorf("title must not be applied when status fails: got %v", e.Properties["title"])
 		}

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -479,7 +479,7 @@ type NavElement struct {
 }
 
 // enrichNavEntry resolves a single NavigationEntry into a NavItem with entity type and count.
-func (a *App) enrichNavEntry(nav NavigationEntry) NavItem {
+func (a *App) enrichNavEntry(ctx context.Context, nav NavigationEntry) NavItem {
 	item := NavItem{Label: nav.Label, List: nav.List, Dashboard: nav.Dashboard, Kanban: nav.Kanban}
 	if nav.Dashboard || nav.Kanban != "" {
 		return item
@@ -487,7 +487,7 @@ func (a *App) enrichNavEntry(nav NavigationEntry) NavItem {
 	s := a.State()
 	if list, ok := s.Cfg.Lists[nav.List]; ok {
 		item.EntityType = list.EntityType
-		entities := listFromStoreByTypes(a.Services(), []string{list.EntityType})
+		entities := listFromStoreByTypes(ctx, a.Services(), []string{list.EntityType})
 		entities = applyFilters(entities, list.Filters)
 		item.Count = len(entities)
 	}
@@ -496,8 +496,8 @@ func (a *App) enrichNavEntry(nav NavigationEntry) NavItem {
 
 // navElements returns the navigation structure with groups and items resolved.
 // The activeList parameter is used to auto-expand the group containing the active item.
-func (a *App) navElements(activeList string) []NavElement {
-	uiState := a.loadUIState()
+func (a *App) navElements(ctx context.Context, activeList string) []NavElement {
+	uiState := a.loadUIState(ctx)
 	cfgNav := a.State().Cfg.Navigation
 	elements := make([]NavElement, 0, len(cfgNav))
 	for _, nav := range cfgNav {
@@ -511,7 +511,7 @@ func (a *App) navElements(activeList string) []NavElement {
 			}
 			grp.Items = make([]NavItem, len(nav.Items))
 			for i, child := range nav.Items {
-				grp.Items[i] = a.enrichNavEntry(child)
+				grp.Items[i] = a.enrichNavEntry(ctx, child)
 				// Auto-expand group if it contains the active list
 				if child.List == activeList && activeList != "" {
 					grp.Collapsed = false
@@ -519,7 +519,7 @@ func (a *App) navElements(activeList string) []NavElement {
 			}
 			elements = append(elements, NavElement{Group: &grp})
 		} else {
-			item := a.enrichNavEntry(nav)
+			item := a.enrichNavEntry(ctx, nav)
 			elements = append(elements, NavElement{Item: &item})
 		}
 	}
@@ -528,12 +528,12 @@ func (a *App) navElements(activeList string) []NavElement {
 
 // loadUIState reads .rela/ui-state.json and returns the persisted state.
 // Returns an empty UIState if the file doesn't exist or can't be parsed.
-func (a *App) loadUIState() UIState {
+func (a *App) loadUIState(ctx context.Context) UIState {
 	st := UIState{CollapsedGroups: make(map[string]bool)}
 	if a.kv == nil {
 		return st
 	}
-	data, err := a.kv.Get(context.Background(), uiStateFile)
+	data, err := a.kv.Get(ctx, uiStateFile)
 	if err != nil {
 		return st
 	}
@@ -576,7 +576,7 @@ func (a *App) loadUserDefaults() *UserDefaults {
 }
 
 // saveUserDefaults writes the user defaults to .rela/user-defaults.yaml.
-func (a *App) saveUserDefaults(ud *UserDefaults) error {
+func (a *App) saveUserDefaults(ctx context.Context, ud *UserDefaults) error {
 	if a.kv == nil {
 		return nil
 	}
@@ -584,7 +584,7 @@ func (a *App) saveUserDefaults(ud *UserDefaults) error {
 	if err != nil {
 		return err
 	}
-	return a.kv.Put(context.Background(), userDefaultsFile, data)
+	return a.kv.Put(ctx, userDefaultsFile, data)
 }
 
 // coverage-ignore: requires running workspace, tested via e2e
@@ -619,7 +619,7 @@ func (a *App) loadUserPalette() (*PaletteConfig, error) {
 }
 
 // saveUserPalette writes the user palette to .rela/palette.yaml.
-func (a *App) saveUserPalette(p *PaletteConfig) error {
+func (a *App) saveUserPalette(ctx context.Context, p *PaletteConfig) error {
 	if a.kv == nil {
 		return nil
 	}
@@ -627,7 +627,7 @@ func (a *App) saveUserPalette(p *PaletteConfig) error {
 	if err != nil {
 		return err
 	}
-	return a.kv.Put(context.Background(), userPaletteFile, data)
+	return a.kv.Put(ctx, userPaletteFile, data)
 }
 
 // firstNavTarget returns the first navigable item from the navigation config,

--- a/internal/dataentry/app_test.go
+++ b/internal/dataentry/app_test.go
@@ -1,6 +1,7 @@
 package dataentry
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -493,7 +494,7 @@ func TestNavElements(t *testing.T) {
 	app, _ := testAppInstance()
 
 	t.Run("flat items with counts", func(t *testing.T) {
-		elements := app.navElements("")
+		elements := app.navElements(context.Background(), "")
 		if len(elements) != 2 {
 			t.Fatalf("expected 2 elements, got %d", len(elements))
 		}
@@ -528,7 +529,7 @@ func TestNavElements(t *testing.T) {
 			{Label: "Dashboard", Dashboard: true},
 			{Label: "Tickets", List: "tickets"},
 		}
-		elements := app2.navElements("")
+		elements := app2.navElements(context.Background(), "")
 		if len(elements) != 2 {
 			t.Fatalf("expected 2 elements, got %d", len(elements))
 		}
@@ -548,7 +549,7 @@ func TestNavElements(t *testing.T) {
 				{Property: "status", Operator: "=", Value: "open"},
 			},
 		}
-		elements := app2.navElements("")
+		elements := app2.navElements(context.Background(), "")
 		// Only TKT-001 has status=open
 		if elements[0].Item == nil {
 			t.Fatal("expected first element to be an item")
@@ -570,7 +571,7 @@ func TestNavElements(t *testing.T) {
 			},
 			{Label: "Components", List: "components"},
 		}
-		elements := app2.navElements("")
+		elements := app2.navElements(context.Background(), "")
 		if len(elements) != 3 {
 			t.Fatalf("expected 3 elements, got %d", len(elements))
 		}
@@ -612,7 +613,7 @@ func TestNavElements(t *testing.T) {
 				},
 			},
 		}
-		elements := app2.navElements("")
+		elements := app2.navElements(context.Background(), "")
 		if elements[0].Group == nil {
 			t.Fatal("expected group element")
 		}
@@ -632,7 +633,7 @@ func TestNavElements(t *testing.T) {
 				},
 			},
 		}
-		elements := app2.navElements("tickets")
+		elements := app2.navElements(context.Background(), "tickets")
 		if elements[0].Group == nil {
 			t.Fatal("expected group element")
 		}
@@ -710,7 +711,7 @@ func TestUIStateLoadSave(t *testing.T) {
 	bindRepoWithFS(app, fs, ctx)
 
 	t.Run("load returns defaults when file missing", func(t *testing.T) {
-		state := app.loadUIState()
+		state := app.loadUIState(context.Background())
 		if len(state.CollapsedGroups) != 0 {
 			t.Errorf("expected empty collapsed groups, got %v", state.CollapsedGroups)
 		}
@@ -721,7 +722,7 @@ func TestUIStateLoadSave(t *testing.T) {
 		if err := app.saveUIState(state); err != nil {
 			t.Fatalf("save error: %v", err)
 		}
-		loaded := app.loadUIState()
+		loaded := app.loadUIState(context.Background())
 		if !loaded.CollapsedGroups["Tickets"] {
 			t.Error("expected Tickets to be collapsed after load")
 		}
@@ -744,7 +745,7 @@ func TestUIStateLoadSave(t *testing.T) {
 		if err := app2.saveUIState(state); err != nil {
 			t.Fatalf("save error: %v", err)
 		}
-		elements := app2.navElements("")
+		elements := app2.navElements(context.Background(), "")
 		if elements[0].Group == nil {
 			t.Fatal("expected group element")
 		}
@@ -756,7 +757,7 @@ func TestUIStateLoadSave(t *testing.T) {
 	t.Run("nil kv is safe", func(t *testing.T) {
 		app2, _ := testAppInstance()
 		app2.kv = nil
-		state := app2.loadUIState()
+		state := app2.loadUIState(context.Background())
 		if len(state.CollapsedGroups) != 0 {
 			t.Error("expected empty state")
 		}
@@ -796,7 +797,7 @@ func TestUserDefaultsLoadSave(t *testing.T) {
 				},
 			},
 		}
-		if err := app.saveUserDefaults(ud); err != nil {
+		if err := app.saveUserDefaults(context.Background(), ud); err != nil {
 			t.Fatalf("save error: %v", err)
 		}
 		loaded := app.loadUserDefaults()
@@ -827,7 +828,7 @@ func TestUserDefaultsLoadSave(t *testing.T) {
 		if ud != nil {
 			t.Errorf("expected nil, got %+v", ud)
 		}
-		if err := app2.saveUserDefaults(&UserDefaults{}); err != nil {
+		if err := app2.saveUserDefaults(context.Background(), &UserDefaults{}); err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
 	})

--- a/internal/dataentry/commands.go
+++ b/internal/dataentry/commands.go
@@ -150,21 +150,21 @@ type commandProjectInfo struct {
 	Metamodel string `json:"metamodel"`
 }
 
-func (a *App) buildEntityInput(e *entity.Entity) *commandInput {
+func (a *App) buildEntityInput(ctx context.Context, e *entity.Entity) *commandInput {
 	return &commandInput{
 		Context:   "entity",
 		Entity:    e,
-		Relations: relationsForEntity(a.Services(), e.ID),
+		Relations: relationsForEntity(ctx, a.Services(), e.ID),
 		Project:   a.projectInfo(),
 	}
 }
 
 // relationsForEntity loads every relation where id is either endpoint
 // and returns them as []*entity.Relation for the command-input payload.
-func relationsForEntity(svc Services, id string) []*entity.Relation {
+func relationsForEntity(ctx context.Context, svc Services, id string) []*entity.Relation {
 	rels := make([]*entity.Relation, 0)
 	q := store.RelationQuery{EntityID: id, Direction: store.DirectionBoth}
-	for r, err := range svc.Store.ListRelations(context.Background(), q) {
+	for r, err := range svc.Store.ListRelations(ctx, q) {
 		if err != nil {
 			return rels
 		}
@@ -182,7 +182,7 @@ func (a *App) buildListInput(listID string, entities []*entity.Entity) *commandI
 	}
 }
 
-func (a *App) buildViewInput(viewID string, vr *viewResult) *commandInput {
+func (a *App) buildViewInput(ctx context.Context, viewID string, vr *viewResult) *commandInput {
 	// Collect all entity IDs in the result set.
 	idSet := map[string]bool{vr.Entry.ID: true}
 	for _, entities := range vr.Collections {
@@ -196,7 +196,7 @@ func (a *App) buildViewInput(viewID string, vr *viewResult) *commandInput {
 	var rels []*entity.Relation
 	for id := range idSet {
 		q := store.RelationQuery{EntityID: id, Direction: store.DirectionOutgoing}
-		for r, err := range svc.Store.ListRelations(context.Background(), q) {
+		for r, err := range svc.Store.ListRelations(ctx, q) {
 			if err != nil {
 				break
 			}
@@ -306,12 +306,12 @@ func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 	case "entity":
 		entityID := r.URL.Query().Get("entity_id")
 		svc := a.Services()
-		entityDomain, err := svc.Store.GetEntity(context.Background(), entityID)
+		entityDomain, err := svc.Store.GetEntity(r.Context(), entityID)
 		if err != nil {
 			http.Error(w, "Entity not found: "+entityID, http.StatusNotFound)
 			return
 		}
-		input = a.buildEntityInput(entityDomain)
+		input = a.buildEntityInput(r.Context(), entityDomain)
 	case "list":
 		listID := r.URL.Query().Get("list_id")
 		listCfg, found := s.Cfg.Lists[listID]
@@ -319,7 +319,7 @@ func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "List not found: "+listID, http.StatusNotFound)
 			return
 		}
-		entities := listFromStoreByTypes(a.Services(), []string{listCfg.EntityType})
+		entities := listFromStoreByTypes(r.Context(), a.Services(), []string{listCfg.EntityType})
 		entities = applyFilters(entities, listCfg.Filters)
 		input = a.buildListInput(listID, entities)
 	case "view":
@@ -330,12 +330,12 @@ func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "View not found: "+viewID, http.StatusNotFound)
 			return
 		}
-		vr, err := a.executeView(viewCfg, entityID)
+		vr, err := a.executeView(r.Context(), viewCfg, entityID)
 		if err != nil {
 			http.Error(w, "View error: "+err.Error(), http.StatusBadRequest)
 			return
 		}
-		input = a.buildViewInput(viewID, vr)
+		input = a.buildViewInput(r.Context(), viewID, vr)
 	case "global":
 		input = a.buildGlobalInput()
 	default:

--- a/internal/dataentry/commands_test.go
+++ b/internal/dataentry/commands_test.go
@@ -2,6 +2,7 @@ package dataentry
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -254,7 +255,7 @@ func TestBuildEntityInput(t *testing.T) {
 	bindRepo(app, "/test/project")
 	seedRelation(app, entity.NewRelation(entities.ticket1.ID, "depends_on", entities.ticket2.ID))
 
-	input := app.buildEntityInput(entities.ticket1)
+	input := app.buildEntityInput(context.Background(), entities.ticket1)
 
 	if input.Context != "entity" {
 		t.Errorf("expected entity context, got %s", input.Context)
@@ -313,12 +314,12 @@ func TestBuildViewInput(t *testing.T) {
 			{From: "entry", Follow: "belongs_to", CollectAs: "components"},
 		},
 	}
-	vr, err := app.executeView(view, "TKT-001")
+	vr, err := app.executeView(context.Background(), view, "TKT-001")
 	if err != nil {
 		t.Fatalf("executeView: %v", err)
 	}
 
-	input := app.buildViewInput("test_view", vr)
+	input := app.buildViewInput(context.Background(), "test_view", vr)
 
 	if input.Context != "view" {
 		t.Errorf("expected view context, got %s", input.Context)
@@ -362,7 +363,7 @@ func TestBuildCommandEnv(t *testing.T) {
 		Context: "entity",
 		Env:     map[string]string{"FORMAT": "pdf"},
 	}
-	input := app.buildEntityInput(entities.ticket1)
+	input := app.buildEntityInput(context.Background(), entities.ticket1)
 	env := app.buildCommandEnv(cmd, input)
 
 	envMap := envToMap(env)

--- a/internal/dataentry/document.go
+++ b/internal/dataentry/document.go
@@ -138,14 +138,14 @@ func newDocumentService(st store.Store, kv state.KV, projectRoot string,
 // Script renders do NOT populate this cache and callers should not read
 // it for script: docs (see Render); a stale command:-era file at the
 // same path would otherwise shadow the Lua render.
-func (s *documentService) GetCached(entryID string) *DocumentResult {
-	entities, contentHash, err := s.computeDocumentHash(entryID)
+func (s *documentService) GetCached(ctx context.Context, entryID string) *DocumentResult {
+	entities, contentHash, err := s.computeDocumentHash(ctx, entryID)
 	if err != nil {
 		return nil
 	}
 
 	cacheFile := fmt.Sprintf("%s/%s-%s.html", docCacheSubdir, entryID, contentHash)
-	cachedHTML, _ := s.state.Get(context.Background(), cacheFile)
+	cachedHTML, _ := s.state.Get(ctx, cacheFile)
 	if cachedHTML == nil {
 		return nil
 	}
@@ -162,8 +162,8 @@ func (s *documentService) GetCached(entryID string) *DocumentResult {
 // (entryID, ConfigID) pair — renders of the same entry under *different*
 // document configs proceed in parallel. Command renders cache to disk;
 // script renders do not.
-func (s *documentService) Render(entryID string, cfg documentRenderConfig) (*DocumentResult, error) {
-	entities, contentHash, err := s.computeDocumentHash(entryID)
+func (s *documentService) Render(ctx context.Context, entryID string, cfg documentRenderConfig) (*DocumentResult, error) {
+	entities, contentHash, err := s.computeDocumentHash(ctx, entryID)
 	if err != nil {
 		return nil, fmt.Errorf("computing document hash: %w", err)
 	}
@@ -175,7 +175,7 @@ func (s *documentService) Render(entryID string, cfg documentRenderConfig) (*Doc
 	// not collapse onto one another's HTML (RR-4QSBN).
 	sfKey := entryID + "|" + cfg.ConfigID
 	result, err, _ := s.group.Do(sfKey, func() (interface{}, error) {
-		return s.doRender(entryID, cfg, entities, contentHash, cacheFile)
+		return s.doRender(ctx, entryID, cfg, entities, contentHash, cacheFile)
 	})
 	if err != nil {
 		return nil, err
@@ -189,14 +189,14 @@ func (s *documentService) Render(entryID string, cfg documentRenderConfig) (*Doc
 // Command — these are mutually exclusive at config load (see
 // dataentryconfig.validateDocuments) so exactly one branch fires.
 func (s *documentService) doRender(
-	entryID string, cfg documentRenderConfig, entities []*entity.Entity, contentHash, cacheFile string,
+	ctx context.Context, entryID string, cfg documentRenderConfig, entities []*entity.Entity, contentHash, cacheFile string,
 ) (*DocumentResult, error) {
 	var markdown string
 	var err error
 	if cfg.Script != "" {
 		markdown, err = s.renderScript(entryID, cfg)
 	} else {
-		markdown, err = s.renderCommand(entryID, cfg)
+		markdown, err = s.renderCommand(ctx, entryID, cfg)
 	}
 	if err != nil {
 		return nil, err
@@ -213,7 +213,7 @@ func (s *documentService) doRender(
 	// so writing script-render output here would make a subsequent
 	// command: run read stale bytes from the wrong renderer.
 	if cfg.Script == "" {
-		if writeErr := s.state.Put(context.Background(), cacheFile, []byte(htmlContent)); writeErr != nil {
+		if writeErr := s.state.Put(ctx, cacheFile, []byte(htmlContent)); writeErr != nil {
 			slog.Warn("document cache write failed", "error", writeErr)
 		}
 	}
@@ -227,11 +227,11 @@ func (s *documentService) doRender(
 
 // renderCommand invokes the external render command and returns its stdout
 // as markdown. Placeholder substitution happens on the command string.
-func (s *documentService) renderCommand(entryID string, cfg documentRenderConfig) (string, error) {
+func (s *documentService) renderCommand(ctx context.Context, entryID string, cfg documentRenderConfig) (string, error) {
 	command := cfg.Command
 	command = strings.ReplaceAll(command, "{id}", entryID)
 	command = strings.ReplaceAll(command, "{id_lower}", strings.ToLower(entryID))
-	return s.executeCommand(command, cfg.Timeout)
+	return s.executeCommand(ctx, command, cfg.Timeout)
 }
 
 // renderScript executes a Lua document script and returns its captured
@@ -257,8 +257,8 @@ func (s *documentService) renderScript(entryID string, cfg documentRenderConfig)
 
 // computeDocumentHash computes a content hash for cache validation.
 // Uses the entry entity for hashing. Returns the entities and their hash.
-func (s *documentService) computeDocumentHash(entryID string) ([]*entity.Entity, string, error) {
-	e, err := s.store.GetEntity(context.Background(), entryID)
+func (s *documentService) computeDocumentHash(ctx context.Context, entryID string) ([]*entity.Entity, string, error) {
+	e, err := s.store.GetEntity(ctx, entryID)
 	if err != nil {
 		return nil, "", fmt.Errorf("entity %q not found", entryID)
 	}
@@ -306,11 +306,11 @@ func hashEntities(entities []*entity.Entity) string {
 const commandDefaultTimeout = 30 * time.Second
 
 // executeCommand runs an external command and returns its stdout.
-func (s *documentService) executeCommand(command string, timeout time.Duration) (string, error) {
+func (s *documentService) executeCommand(ctx context.Context, command string, timeout time.Duration) (string, error) {
 	if timeout <= 0 {
 		timeout = commandDefaultTimeout
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)

--- a/internal/dataentry/document_script_test.go
+++ b/internal/dataentry/document_script_test.go
@@ -118,7 +118,7 @@ func TestDocumentService_ScriptRender_CapturesMarkdown(t *testing.T) {
 	s, fake := newTestService(t, reqEntity())
 	fake.stdout = func(_ fakeScriptCall) string { return "# Heading\n\nbody" }
 
-	result, err := s.Render("REQ-001", documentRenderConfig{
+	result, err := s.Render(context.Background(), "REQ-001", documentRenderConfig{
 		ConfigID: "notes",
 		Script:   "docs/notes.lua",
 		Timeout:  5 * time.Second,
@@ -159,7 +159,7 @@ func TestDocumentService_ScriptRender_NoDiskCacheWrite(t *testing.T) {
 	s, fake := newTestService(t, reqEntity())
 	fake.stdout = func(_ fakeScriptCall) string { return "lua output" }
 
-	if _, err := s.Render("REQ-001", documentRenderConfig{
+	if _, err := s.Render(context.Background(), "REQ-001", documentRenderConfig{
 		ConfigID: "notes",
 		Script:   "docs/notes.lua",
 	}); err != nil {
@@ -167,7 +167,7 @@ func TestDocumentService_ScriptRender_NoDiskCacheWrite(t *testing.T) {
 	}
 
 	// After render, GetCached should return nil — nothing was written.
-	if result := s.GetCached("REQ-001"); result != nil {
+	if result := s.GetCached(context.Background(), "REQ-001"); result != nil {
 		t.Errorf("expected no cache entry after script render, got %q", result.HTML)
 	}
 }
@@ -187,7 +187,7 @@ func TestDocumentService_ScriptRender_StaleCommandCacheIgnored(t *testing.T) {
 	fake.stdout = func(_ fakeScriptCall) string { return "fresh lua output" }
 
 	// Manually seed a stale command-era cache entry.
-	_, hash, err := s.computeDocumentHash("REQ-001")
+	_, hash, err := s.computeDocumentHash(context.Background(), "REQ-001")
 	if err != nil {
 		t.Fatalf("computeDocumentHash: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestDocumentService_ScriptRender_StaleCommandCacheIgnored(t *testing.T) {
 		t.Fatalf("seed stale cache: %v", putErr)
 	}
 
-	result, err := s.Render("REQ-001", documentRenderConfig{
+	result, err := s.Render(context.Background(), "REQ-001", documentRenderConfig{
 		ConfigID: "notes",
 		Script:   "docs/notes.lua",
 	})
@@ -238,7 +238,7 @@ func TestDocumentService_SingleflightNoCollapseAcrossConfigs(t *testing.T) {
 	resultsCh := make(chan renderResult, 2)
 	for _, docID := range []string{"docA", "docB"} {
 		go func(d string) {
-			r, err := s.Render("REQ-001", documentRenderConfig{
+			r, err := s.Render(context.Background(), "REQ-001", documentRenderConfig{
 				ConfigID: d,
 				Script:   "docs/" + d + ".lua",
 			})
@@ -283,7 +283,7 @@ func TestDocumentService_SingleflightCollapsesSameConfig(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, _ = s.Render("REQ-001", documentRenderConfig{
+			_, _ = s.Render(context.Background(), "REQ-001", documentRenderConfig{
 				ConfigID: "same",
 				Script:   "docs/same.lua",
 			})
@@ -301,7 +301,7 @@ func TestDocumentService_ScriptError(t *testing.T) {
 	s, fake := newTestService(t, reqEntity())
 	fake.err = errors.New("lua blew up")
 
-	_, err := s.Render("REQ-001", documentRenderConfig{
+	_, err := s.Render(context.Background(), "REQ-001", documentRenderConfig{
 		ConfigID: "notes",
 		Script:   "docs/notes.lua",
 	})
@@ -378,7 +378,7 @@ print(got)
 	}
 
 	for i := range 2 {
-		if _, renderErr := s.Render("REQ-001", cfg); renderErr != nil {
+		if _, renderErr := s.Render(context.Background(), "REQ-001", cfg); renderErr != nil {
 			t.Fatalf("render %d: %v", i, renderErr)
 		}
 	}

--- a/internal/dataentry/handlers_api.go
+++ b/internal/dataentry/handlers_api.go
@@ -181,7 +181,7 @@ func (a *App) handleAPIEntities(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-		result = append(result, a.entityToAPI(e, false))
+		result = append(result, a.entityToAPI(ctx, e, false))
 	}
 
 	writeJSON(w, result)
@@ -201,7 +201,7 @@ func (a *App) handleAPIEntity(w http.ResponseWriter, r *http.Request) { // Extra
 		return
 	}
 
-	result := a.entityToAPI(e, true)
+	result := a.entityToAPI(r.Context(), e, true)
 	writeJSON(w, result)
 }
 
@@ -248,7 +248,7 @@ func (a *App) handleAPIMetamodel(w http.ResponseWriter, _ *http.Request) {
 }
 
 // entityToAPI converts an entity.Entity to APIEntity.
-func (a *App) entityToAPI(e *entity.Entity, includeRelations bool) APIEntity {
+func (a *App) entityToAPI(ctx context.Context, e *entity.Entity, includeRelations bool) APIEntity {
 	s := a.State()
 	api := APIEntity{
 		ID:         e.ID,
@@ -262,7 +262,6 @@ func (a *App) entityToAPI(e *entity.Entity, includeRelations bool) APIEntity {
 	}
 
 	if includeRelations {
-		ctx := context.Background()
 		st := a.store
 		api.Relations = make([]APIRelation, 0)
 
@@ -449,7 +448,7 @@ func (a *App) handleAPICreateEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apiResult := a.entityToAPI(result.Entity, false)
+	apiResult := a.entityToAPI(r.Context(), result.Entity, false)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(apiResult)
@@ -508,7 +507,7 @@ func (a *App) handleAPIUpdateEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apiResult := a.entityToAPI(result.Entity, false)
+	apiResult := a.entityToAPI(r.Context(), result.Entity, false)
 	writeJSON(w, apiResult)
 }
 
@@ -626,11 +625,11 @@ func (a *App) handleAPIListRelations(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case from != "":
-		relations = a.listOutgoingRelations(from)
+		relations = a.listOutgoingRelations(r.Context(), from)
 	case to != "":
-		relations = a.listIncomingRelations(to)
+		relations = a.listIncomingRelations(r.Context(), to)
 	default:
-		relations = a.listAllRelations()
+		relations = a.listAllRelations(r.Context())
 	}
 
 	if relations == nil {
@@ -641,8 +640,7 @@ func (a *App) handleAPIListRelations(w http.ResponseWriter, r *http.Request) {
 }
 
 // listOutgoingRelations returns relations where the given entity is the source.
-func (a *App) listOutgoingRelations(from string) []APIRelation {
-	ctx := context.Background()
+func (a *App) listOutgoingRelations(ctx context.Context, from string) []APIRelation {
 	st := a.store
 	relations := make([]APIRelation, 0)
 	q := store.RelationQuery{EntityID: from, Direction: store.DirectionOutgoing}
@@ -660,8 +658,7 @@ func (a *App) listOutgoingRelations(from string) []APIRelation {
 }
 
 // listIncomingRelations returns relations where the given entity is the target.
-func (a *App) listIncomingRelations(to string) []APIRelation {
-	ctx := context.Background()
+func (a *App) listIncomingRelations(ctx context.Context, to string) []APIRelation {
 	st := a.store
 	relations := make([]APIRelation, 0)
 	q := store.RelationQuery{EntityID: to, Direction: store.DirectionIncoming}
@@ -679,8 +676,7 @@ func (a *App) listIncomingRelations(to string) []APIRelation {
 }
 
 // listAllRelations returns all relations in the graph.
-func (a *App) listAllRelations() []APIRelation {
-	ctx := context.Background()
+func (a *App) listAllRelations(ctx context.Context) []APIRelation {
 	st := a.store
 	relations := make([]APIRelation, 0)
 	for edge, err := range st.ListRelations(ctx, store.RelationQuery{}) {
@@ -779,7 +775,7 @@ func (a *App) handleAPISettingsCRUD(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleAPIGetSettings returns the settings data for the settings page.
-func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
+func (a *App) handleAPIGetSettings(w http.ResponseWriter, r *http.Request) {
 	s := a.State()
 	ud := s.UserDefaults
 	if ud == nil {
@@ -862,7 +858,7 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, _ *http.Request) {
 		if len(relDef.To) > 0 {
 			rd.TargetType = relDef.To[0]
 			for _, targetType := range relDef.To {
-				for _, e := range listFromStoreByTypes(a.Services(), []string{targetType}) {
+				for _, e := range listFromStoreByTypes(r.Context(), a.Services(), []string{targetType}) {
 					rd.Targets = append(rd.Targets, APIRelationTarget{
 						ID:    e.ID,
 						Title: s.Meta.DisplayTitle(e.ID, e.Type, e.Properties),
@@ -913,8 +909,9 @@ func (a *App) handleAPISaveSettings(w http.ResponseWriter, r *http.Request) {
 	// are wrapped together so a concurrent reader cannot observe a
 	// State whose UserDefaults disagrees with what's on disk.
 	var saveErr error
+	ctx := r.Context()
 	a.mutateState(func(s *AppState) {
-		if err := a.saveUserDefaults(&ud); err != nil {
+		if err := a.saveUserDefaults(ctx, &ud); err != nil {
 			saveErr = err
 			return
 		}
@@ -968,8 +965,9 @@ func (a *App) handleAPISavePalette(w http.ResponseWriter, r *http.Request) {
 	// readers see the new palette via state.Load() rather than
 	// observing torn writes through a shared snapshot pointer.
 	var saveErr error
+	ctx := r.Context()
 	a.mutateState(func(s *AppState) {
-		if err := a.saveUserPalette(&input); err != nil {
+		if err := a.saveUserPalette(ctx, &input); err != nil {
 			saveErr = err
 			return
 		}

--- a/internal/dataentry/handlers_api_test.go
+++ b/internal/dataentry/handlers_api_test.go
@@ -164,7 +164,7 @@ func TestEntityToAPI_WithoutRelations(t *testing.T) {
 		},
 	}
 
-	result := app.entityToAPI(e, false)
+	result := app.entityToAPI(context.Background(), e, false)
 
 	if result.ID != "TKT-001" {
 		t.Errorf("expected ID TKT-001, got %q", result.ID)
@@ -186,7 +186,7 @@ func TestEntityToAPI_WithRelations(t *testing.T) {
 	// Add a relation to test graph
 	seedRelation(app, entity.NewRelation(entities.ticket1.ID, "depends_on", entities.ticket2.ID))
 
-	result := app.entityToAPI(entities.ticket1, true)
+	result := app.entityToAPI(context.Background(), entities.ticket1, true)
 
 	if len(result.Relations) == 0 {
 		t.Fatal("expected relations, got none")
@@ -203,7 +203,7 @@ func TestEntityToAPI_WithRelations(t *testing.T) {
 	}
 
 	// Check incoming from perspective of TKT-002
-	result2 := app.entityToAPI(entities.ticket2, true)
+	result2 := app.entityToAPI(context.Background(), entities.ticket2, true)
 	hasIncoming := false
 	for _, r := range result2.Relations {
 		if r.Direction == DirectionIncoming && r.Type == "depends_on" && r.From == entities.ticket1.ID {

--- a/internal/dataentry/handlers_theme.go
+++ b/internal/dataentry/handlers_theme.go
@@ -120,8 +120,9 @@ func (a *App) handleAPIPutThemeLogo(w http.ResponseWriter, r *http.Request) {
 	hash := hashLogoBytes(bytes)
 
 	var saveErr error
+	ctx := r.Context()
 	a.mutateState(func(s *AppState) {
-		if err := a.saveUserLogo(bytes, ext); err != nil {
+		if err := a.saveUserLogo(ctx, bytes, ext); err != nil {
 			// On failure the snapshot copy is left untouched and
 			// mutateState republishes a bytewise-identical pointer.
 			// Cheap (one struct copy) and keeps the path simple — do
@@ -148,10 +149,11 @@ func (a *App) handleAPIPutThemeLogo(w http.ResponseWriter, r *http.Request) {
 // logo is set the call still succeeds (the on-disk Delete is itself
 // idempotent), so callers that don't track current logo state can just
 // hit the endpoint.
-func (a *App) handleAPIDeleteThemeLogo(w http.ResponseWriter, _ *http.Request) {
+func (a *App) handleAPIDeleteThemeLogo(w http.ResponseWriter, r *http.Request) {
 	var deleteErr error
+	ctx := r.Context()
 	a.mutateState(func(s *AppState) {
-		if err := a.deleteUserLogo(); err != nil {
+		if err := a.deleteUserLogo(ctx); err != nil {
 			deleteErr = err
 			return
 		}

--- a/internal/dataentry/handlers_theme_package.go
+++ b/internal/dataentry/handlers_theme_package.go
@@ -102,8 +102,9 @@ func (a *App) handleAPIThemeImport(w http.ResponseWriter, r *http.Request) {
 	if pkg.Logo != nil {
 		hash := hashLogoBytes(pkg.Logo.Bytes)
 		var saveErr error
+		ctx := r.Context()
 		a.mutateState(func(s *AppState) {
-			if err := a.saveUserLogo(pkg.Logo.Bytes, pkg.Logo.Ext); err != nil {
+			if err := a.saveUserLogo(ctx, pkg.Logo.Bytes, pkg.Logo.Ext); err != nil {
 				saveErr = err
 				return
 			}

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -393,7 +393,7 @@ func addCheckboxIndices(s string) string {
 // It supports the same query syntax as the search page: type:, prop:, status:,
 // and free text. Free-text words use OR logic with fuzzy matching via Bleve;
 // results are ranked by score.
-func (a *App) executeQuery(query string) []*entity.Entity {
+func (a *App) executeQuery(ctx context.Context, query string) []*entity.Entity {
 	sq := searchparser.ParseQuery(query)
 	if sq.IsEmpty() {
 		return nil
@@ -404,9 +404,9 @@ func (a *App) executeQuery(query string) []*entity.Entity {
 	if sq.HasFreeText() {
 		// Searcher returns entities in relevance order. Scores are dropped
 		// because executeQuery never sorted by them.
-		candidates = runFreeTextSearch(svc, sq, maxFreeTextSearchResults)
+		candidates, _ = runFreeTextSearchE(ctx, svc, sq, maxFreeTextSearchResults)
 	} else {
-		candidates = listFromStoreByTypes(svc, sq.EntityTypes)
+		candidates = listFromStoreByTypes(ctx, svc, sq.EntityTypes)
 	}
 
 	results := make([]*entity.Entity, 0, len(candidates))
@@ -471,20 +471,11 @@ func (a *App) freeTextIDsForType(ctx context.Context, query, typeName string) (f
 // path stay in lockstep on the bound.
 const maxFreeTextSearchResults = 1000
 
-// runFreeTextSearch issues a Searcher query from a parsed SearchQuery and
+// runFreeTextSearchE issues a Searcher query from a parsed SearchQuery and
 // loads the full entity bodies from the store. Phrases are re-quoted so the
 // searcher's text layer can rebuild the same fuzzy-words + exact-phrases
-// compound query the dataentry UI used to build upstream.
-//
-// Errors are swallowed (returns nil) — callers that need to surface them
-// should use runFreeTextSearchE instead.
-func runFreeTextSearch(svc Services, sq *searchparser.SearchQuery, limit int) []*entity.Entity {
-	out, _ := runFreeTextSearchE(context.Background(), svc, sq, limit)
-	return out
-}
-
-// runFreeTextSearchE is the error-returning variant of runFreeTextSearch.
-// New callers should use this so backend failures surface to the client.
+// compound query the dataentry UI used to build upstream. Backend failures
+// surface to the caller.
 func runFreeTextSearchE(ctx context.Context, svc Services, sq *searchparser.SearchQuery, limit int) ([]*entity.Entity, error) {
 	parts := make([]string, 0, len(sq.FreeTextWords)+len(sq.FreeTextPhrases))
 	parts = append(parts, sq.FreeTextWords...)
@@ -515,13 +506,13 @@ func runFreeTextSearchE(ctx context.Context, svc Services, sq *searchparser.Sear
 
 // listFromStoreByTypes loads all entities matching the given types (or every
 // entity when types is empty) from the store.
-func listFromStoreByTypes(svc Services, types []string) []*entity.Entity {
+func listFromStoreByTypes(ctx context.Context, svc Services, types []string) []*entity.Entity {
 	if len(types) == 0 {
-		return listAllFromStore(svc)
+		return listAllFromStore(ctx, svc)
 	}
 	var out []*entity.Entity
 	for _, t := range types {
-		for e, err := range svc.Store.ListEntities(context.Background(), store.EntityQuery{Type: t}) {
+		for e, err := range svc.Store.ListEntities(ctx, store.EntityQuery{Type: t}) {
 			if err != nil {
 				return out
 			}
@@ -532,9 +523,9 @@ func listFromStoreByTypes(svc Services, types []string) []*entity.Entity {
 }
 
 // listAllFromStore drains every entity from the store.
-func listAllFromStore(svc Services) []*entity.Entity {
+func listAllFromStore(ctx context.Context, svc Services) []*entity.Entity {
 	out := make([]*entity.Entity, 0)
-	for e, err := range svc.Store.ListEntities(context.Background(), store.EntityQuery{}) {
+	for e, err := range svc.Store.ListEntities(ctx, store.EntityQuery{}) {
 		if err != nil {
 			return out
 		}
@@ -546,7 +537,9 @@ func listAllFromStore(svc Services) []*entity.Entity {
 // resolveRelationColumnValues returns display titles for all targets of the given
 // relation type from an entity. Direction controls whether to follow edges pointing
 // to the entity (incoming) or from the entity (outgoing, the default).
-func (a *App) resolveRelationColumnValues(entityID, relationType string, direction dataentryconfig.Direction) []string {
+func (a *App) resolveRelationColumnValues(
+	ctx context.Context, entityID, relationType string, direction dataentryconfig.Direction,
+) []string {
 	svc := a.Services()
 	q := store.RelationQuery{
 		EntityID:  entityID,
@@ -555,7 +548,7 @@ func (a *App) resolveRelationColumnValues(entityID, relationType string, directi
 	}
 
 	var titles []string
-	for r, err := range svc.Store.ListRelations(context.Background(), q) {
+	for r, err := range svc.Store.ListRelations(ctx, q) {
 		if err != nil {
 			return titles
 		}
@@ -563,7 +556,7 @@ func (a *App) resolveRelationColumnValues(entityID, relationType string, directi
 		if direction.IsIncoming() {
 			targetID = r.From
 		}
-		if title, ok := entityTitle(svc, targetID); ok {
+		if title, ok := entityTitle(ctx, svc, targetID); ok {
 			titles = append(titles, title)
 		}
 	}
@@ -572,11 +565,13 @@ func (a *App) resolveRelationColumnValues(entityID, relationType string, directi
 
 // filterByRelation filters entities to those that have an outgoing edge of the given
 // relation type pointing to a target whose display title matches value.
-func (a *App) filterByRelation(entities []*entity.Entity, relationType, value string) []*entity.Entity {
+func (a *App) filterByRelation(
+	ctx context.Context, entities []*entity.Entity, relationType, value string,
+) []*entity.Entity {
 	svc := a.Services()
 	var result []*entity.Entity
 	for _, e := range entities {
-		if hasOutgoingRelationTo(svc, e.ID, relationType, value) {
+		if hasOutgoingRelationTo(ctx, svc, e.ID, relationType, value) {
 			result = append(result, e)
 		}
 	}
@@ -585,7 +580,9 @@ func (a *App) filterByRelation(entities []*entity.Entity, relationType, value st
 
 // resolveRelationFilterValues returns sorted, unique display titles of all entities
 // reachable via the given relation type from any of the provided entities.
-func (a *App) resolveRelationFilterValues(entities []*entity.Entity, relationType string) []string {
+func (a *App) resolveRelationFilterValues(
+	ctx context.Context, entities []*entity.Entity, relationType string,
+) []string {
 	svc := a.Services()
 	seen := make(map[string]bool)
 	var vals []string
@@ -595,11 +592,11 @@ func (a *App) resolveRelationFilterValues(entities []*entity.Entity, relationTyp
 			Type:      relationType,
 			Direction: store.DirectionOutgoing,
 		}
-		for r, err := range svc.Store.ListRelations(context.Background(), q) {
+		for r, err := range svc.Store.ListRelations(ctx, q) {
 			if err != nil {
 				break
 			}
-			title, ok := entityTitle(svc, r.To)
+			title, ok := entityTitle(ctx, svc, r.To)
 			if !ok {
 				continue
 			}
@@ -615,8 +612,8 @@ func (a *App) resolveRelationFilterValues(entities []*entity.Entity, relationTyp
 
 // entityTitle resolves an entity ID to its metamodel-rendered display title.
 // Returns ("", false) when the entity does not exist (e.g. dangling relation).
-func entityTitle(svc Services, id string) (string, bool) {
-	e, err := svc.Store.GetEntity(context.Background(), id)
+func entityTitle(ctx context.Context, svc Services, id string) (string, bool) {
+	e, err := svc.Store.GetEntity(ctx, id)
 	if err != nil {
 		return "", false
 	}
@@ -625,17 +622,17 @@ func entityTitle(svc Services, id string) (string, bool) {
 
 // hasOutgoingRelationTo reports whether fromID has an outgoing relation of
 // the given type pointing to a target whose display title matches value.
-func hasOutgoingRelationTo(svc Services, fromID, relationType, value string) bool {
+func hasOutgoingRelationTo(ctx context.Context, svc Services, fromID, relationType, value string) bool {
 	q := store.RelationQuery{
 		EntityID:  fromID,
 		Type:      relationType,
 		Direction: store.DirectionOutgoing,
 	}
-	for r, err := range svc.Store.ListRelations(context.Background(), q) {
+	for r, err := range svc.Store.ListRelations(ctx, q) {
 		if err != nil {
 			return false
 		}
-		if title, ok := entityTitle(svc, r.To); ok && title == value {
+		if title, ok := entityTitle(ctx, svc, r.To); ok && title == value {
 			return true
 		}
 	}
@@ -681,7 +678,7 @@ func (a *App) resolveScope(currentEntityID string, r *http.Request) *ScopeNav {
 		if !ok {
 			return nil
 		}
-		entities := listFromStoreByTypes(a.Services(), []string{list.EntityType})
+		entities := listFromStoreByTypes(r.Context(), a.Services(), []string{list.EntityType})
 		entities = applyFilters(entities, list.Filters)
 
 		// Apply dynamic filter params (same as handleList)
@@ -691,7 +688,7 @@ func (a *App) resolveScope(currentEntityID string, r *http.Request) *ScopeNav {
 				continue
 			}
 			if fc.IsRelation() {
-				entities = a.filterByRelation(entities, fc.Relation, val)
+				entities = a.filterByRelation(r.Context(), entities, fc.Relation, val)
 			} else {
 				entities = applyFilters(entities, []FilterConfig{{
 					Property: fc.Property,
@@ -719,7 +716,7 @@ func (a *App) resolveScope(currentEntityID string, r *http.Request) *ScopeNav {
 
 	case strings.HasPrefix(scope, "search:"):
 		query := strings.TrimPrefix(scope, "search:")
-		entities := a.executeQuery(query)
+		entities := a.executeQuery(r.Context(), query)
 		sort.Slice(entities, func(i, j int) bool { return natsort.Less(entities[i].ID, entities[j].ID) })
 		ids = make([]string, len(entities))
 		for i, e := range entities {

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -1,6 +1,7 @@
 package dataentry
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -707,7 +708,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	app := newAppFromParts(nil, meta, g)
 
 	t.Run("resolves multiple targets", func(t *testing.T) {
-		got := app.resolveRelationColumnValues(assessment.ID, "assessmentBy", "")
+		got := app.resolveRelationColumnValues(context.Background(), assessment.ID, "assessmentBy", "")
 		want := []string{"Alice", "Bob"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -715,7 +716,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	})
 
 	t.Run("filters by relation type", func(t *testing.T) {
-		got := app.resolveRelationColumnValues(assessment.ID, "otherRel", "")
+		got := app.resolveRelationColumnValues(context.Background(), assessment.ID, "otherRel", "")
 		want := []string{"Alice"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -723,21 +724,21 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	})
 
 	t.Run("returns empty for no matching relations", func(t *testing.T) {
-		got := app.resolveRelationColumnValues(assessment.ID, "nonexistent", "")
+		got := app.resolveRelationColumnValues(context.Background(), assessment.ID, "nonexistent", "")
 		if len(got) != 0 {
 			t.Errorf("got %v, want empty slice", got)
 		}
 	})
 
 	t.Run("returns empty for unknown entity", func(t *testing.T) {
-		got := app.resolveRelationColumnValues("UNKNOWN", "assessmentBy", "")
+		got := app.resolveRelationColumnValues(context.Background(), "UNKNOWN", "assessmentBy", "")
 		if len(got) != 0 {
 			t.Errorf("got %v, want empty slice", got)
 		}
 	})
 
 	t.Run("direction outgoing explicit", func(t *testing.T) {
-		got := app.resolveRelationColumnValues(assessment.ID, "assessmentBy", "outgoing")
+		got := app.resolveRelationColumnValues(context.Background(), assessment.ID, "assessmentBy", "outgoing")
 		want := []string{"Alice", "Bob"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -747,7 +748,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	t.Run("direction incoming returns sources", func(t *testing.T) {
 		// PER-001 has an incoming edge from ASS-001 via assessmentBy
 		// Assessment title is not required, so falls back to ID
-		got := app.resolveRelationColumnValues(person1.ID, "assessmentBy", "incoming")
+		got := app.resolveRelationColumnValues(context.Background(), person1.ID, "assessmentBy", "incoming")
 		want := []string{assessment.ID}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -756,7 +757,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 
 	t.Run("direction incoming returns multiple sources", func(t *testing.T) {
 		// PER-001 is target of both assessmentBy and otherRel from ASS-001
-		got := app.resolveRelationColumnValues(person1.ID, "otherRel", "incoming")
+		got := app.resolveRelationColumnValues(context.Background(), person1.ID, "otherRel", "incoming")
 		want := []string{assessment.ID}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -764,7 +765,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	})
 
 	t.Run("direction incoming no matches", func(t *testing.T) {
-		got := app.resolveRelationColumnValues(assessment.ID, "assessmentBy", "incoming")
+		got := app.resolveRelationColumnValues(context.Background(), assessment.ID, "assessmentBy", "incoming")
 		if len(got) != 0 {
 			t.Errorf("got %v, want empty slice", got)
 		}
@@ -884,7 +885,7 @@ func TestFilterByRelation(t *testing.T) {
 	allTickets := g.NodesByType("ticket")
 
 	t.Run("filters by relation target title", func(t *testing.T) {
-		got := app.filterByRelation(allTickets, "belongs_to", "Frontend")
+		got := app.filterByRelation(context.Background(), allTickets, "belongs_to", "Frontend")
 		gotIDs := collectModelIDs(got)
 		if len(got) != 2 {
 			t.Fatalf("expected 2 results, got %d: %v", len(got), gotIDs)
@@ -895,7 +896,7 @@ func TestFilterByRelation(t *testing.T) {
 	})
 
 	t.Run("filters by different relation target", func(t *testing.T) {
-		got := app.filterByRelation(allTickets, "belongs_to", "Backend")
+		got := app.filterByRelation(context.Background(), allTickets, "belongs_to", "Backend")
 		gotIDs := collectModelIDs(got)
 		if len(got) != 1 {
 			t.Fatalf("expected 1 result, got %d: %v", len(got), gotIDs)
@@ -906,21 +907,21 @@ func TestFilterByRelation(t *testing.T) {
 	})
 
 	t.Run("returns empty for non-matching value", func(t *testing.T) {
-		got := app.filterByRelation(allTickets, "belongs_to", "Nonexistent")
+		got := app.filterByRelation(context.Background(), allTickets, "belongs_to", "Nonexistent")
 		if len(got) != 0 {
 			t.Errorf("expected 0 results, got %d", len(got))
 		}
 	})
 
 	t.Run("returns empty for unknown relation type", func(t *testing.T) {
-		got := app.filterByRelation(allTickets, "unknown_relation", "Frontend")
+		got := app.filterByRelation(context.Background(), allTickets, "unknown_relation", "Frontend")
 		if len(got) != 0 {
 			t.Errorf("expected 0 results, got %d", len(got))
 		}
 	})
 
 	t.Run("handles entities without relations", func(t *testing.T) {
-		got := app.filterByRelation(allTickets, "belongs_to", "Frontend")
+		got := app.filterByRelation(context.Background(), allTickets, "belongs_to", "Frontend")
 		for _, e := range got {
 			if e.ID == tkt4.ID {
 				t.Errorf("%s should not be in results (has no belongs_to relation)", tkt4.ID)
@@ -983,7 +984,7 @@ func TestResolveRelationFilterValues(t *testing.T) {
 	allTickets := g.NodesByType("ticket")
 
 	t.Run("returns unique sorted values", func(t *testing.T) {
-		got := app.resolveRelationFilterValues(allTickets, "belongs_to")
+		got := app.resolveRelationFilterValues(context.Background(), allTickets, "belongs_to")
 		// Only Frontend and Backend are referenced, API is not
 		// Should be sorted: Backend, Frontend
 		if len(got) != 2 {
@@ -998,14 +999,14 @@ func TestResolveRelationFilterValues(t *testing.T) {
 	})
 
 	t.Run("returns empty for unknown relation type", func(t *testing.T) {
-		got := app.resolveRelationFilterValues(allTickets, "unknown_relation")
+		got := app.resolveRelationFilterValues(context.Background(), allTickets, "unknown_relation")
 		if len(got) != 0 {
 			t.Errorf("expected 0 values, got %d", len(got))
 		}
 	})
 
 	t.Run("returns empty for empty entities list", func(t *testing.T) {
-		got := app.resolveRelationFilterValues([]*entity.Entity{}, "belongs_to")
+		got := app.resolveRelationFilterValues(context.Background(), []*entity.Entity{}, "belongs_to")
 		if len(got) != 0 {
 			t.Errorf("expected 0 values, got %d", len(got))
 		}

--- a/internal/dataentry/relations_direction.go
+++ b/internal/dataentry/relations_direction.go
@@ -1,6 +1,7 @@
 package dataentry
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -161,13 +162,15 @@ func pathEntityInBothSets(entityID string, keys []string, desired map[string]V1R
 // end of each edge relative to `entityID`). The direction flag picks
 // whether the path entity is on the source (outgoing) or target
 // (incoming) side. This is the read-side mirror of edgeEndpoints.
-func (a *App) currentEdgesByPeer(entityID, canonical string, incoming bool) map[string]*entity.Relation {
+func (a *App) currentEdgesByPeer(
+	ctx context.Context, entityID, canonical string, incoming bool,
+) map[string]*entity.Relation {
 	current := map[string]*entity.Relation{}
 	var edges []*entity.Relation
 	if incoming {
-		edges = a.incomingRelations(entityID)
+		edges = a.incomingRelations(ctx, entityID)
 	} else {
-		edges = a.outgoingRelations(entityID)
+		edges = a.outgoingRelations(ctx, entityID)
 	}
 	for _, edge := range edges {
 		if edge.Type != canonical {

--- a/internal/dataentry/relations_modern.go
+++ b/internal/dataentry/relations_modern.go
@@ -292,7 +292,7 @@ func (a *App) applyRelationsModern(
 			desiredByID[ref.ID] = ref
 		}
 
-		current := a.currentEdgesByPeer(entityID, canonical, incoming)
+		current := a.currentEdgesByPeer(ctx, entityID, canonical, incoming)
 
 		// Adds and upserts.
 		for _, id := range desiredOrder {

--- a/internal/dataentry/relations_modern_direction_test.go
+++ b/internal/dataentry/relations_modern_direction_test.go
@@ -96,7 +96,7 @@ func TestApplyRelationsModern_IncomingBodyKey_BothEndpoints(t *testing.T) {
 	}
 
 	// outgoingRelations(source) must include the edge.
-	outEdges := app.outgoingRelations(sourceID)
+	outEdges := app.outgoingRelations(context.Background(), sourceID)
 	if len(outEdges) != 1 {
 		t.Fatalf("expected 1 outgoing edge from %s, got %d", sourceID, len(outEdges))
 	}
@@ -110,7 +110,7 @@ func TestApplyRelationsModern_IncomingBodyKey_BothEndpoints(t *testing.T) {
 	}
 
 	// incomingRelations(target) must include the SAME edge.
-	inEdges := app.incomingRelations(targetID)
+	inEdges := app.incomingRelations(context.Background(), targetID)
 	if len(inEdges) != 1 {
 		t.Fatalf("expected 1 incoming edge to %s, got %d", targetID, len(inEdges))
 	}
@@ -135,10 +135,10 @@ func TestApplyRelationsModern_IncomingDelete(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	if got := len(app.outgoingRelations(sourceID)); got != 0 {
+	if got := len(app.outgoingRelations(context.Background(), sourceID)); got != 0 {
 		t.Errorf("expected 0 outgoing from %s after delete, got %d", sourceID, got)
 	}
-	if got := len(app.incomingRelations(targetID)); got != 0 {
+	if got := len(app.incomingRelations(context.Background(), targetID)); got != 0 {
 		t.Errorf("expected 0 incoming to %s after delete, got %d", targetID, got)
 	}
 }
@@ -150,7 +150,7 @@ func TestApplyRelationsModern_IncomingNoOp(t *testing.T) {
 	app := newDirectionTestApp(t)
 	sourceID, targetID := seedDirectionFixture(t, app)
 
-	preEdge := app.outgoingRelations(sourceID)[0]
+	preEdge := app.outgoingRelations(context.Background(), sourceID)[0]
 	body := `{"relations":{"blockedBy":{"data":[{"type":"feature","id":"` + sourceID + `","meta":{"reason":"test block"}}]}}}`
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/features/"+targetID, strings.NewReader(body))
 	rec := httptest.NewRecorder()
@@ -159,7 +159,7 @@ func TestApplyRelationsModern_IncomingNoOp(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	postEdge := app.outgoingRelations(sourceID)[0]
+	postEdge := app.outgoingRelations(context.Background(), sourceID)[0]
 	// No new edge, no property drift.
 	if postEdge.Properties["reason"] != preEdge.Properties["reason"] {
 		t.Errorf("no-op should not change properties: before=%v after=%v",
@@ -229,12 +229,12 @@ func TestApplyRelationsModern_MixedCanonicalAndInverse(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 	// FEAT-A → FEAT-B (outgoing)
-	outA := app.outgoingRelations("FEAT-A")
+	outA := app.outgoingRelations(context.Background(), "FEAT-A")
 	if len(outA) != 1 || outA[0].To != "FEAT-B" {
 		t.Errorf("FEAT-A should have 1 outgoing to FEAT-B, got %+v", outA)
 	}
 	// FEAT-C → FEAT-A (incoming view from FEAT-A's perspective)
-	inA := app.incomingRelations("FEAT-A")
+	inA := app.incomingRelations(context.Background(), "FEAT-A")
 	if len(inA) != 1 || inA[0].From != "FEAT-C" {
 		t.Errorf("FEAT-A should have 1 incoming from FEAT-C, got %+v", inA)
 	}

--- a/internal/dataentry/sections.go
+++ b/internal/dataentry/sections.go
@@ -1,6 +1,7 @@
 package dataentry
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -140,7 +141,7 @@ type SectionData struct {
 }
 
 // buildSections builds template-ready section data from view sections and a view result.
-func (a *App) buildSections(sections []ViewSection, result *viewResult) []SectionData {
+func (a *App) buildSections(ctx context.Context, sections []ViewSection, result *viewResult) []SectionData {
 	s := a.State()
 	out := make([]SectionData, 0, len(sections))
 
@@ -226,7 +227,7 @@ func (a *App) buildSections(sections []ViewSection, result *viewResult) []Sectio
 							Link: a.resolveLinkTarget(col.Link, e.Type, e.ID), EntityID: e.ID, EntityType: e.Type,
 						}
 						if col.Relation != "" {
-							cell.Values = a.resolveRelationColumnValues(e.ID, col.Relation, col.Direction)
+							cell.Values = a.resolveRelationColumnValues(ctx, e.ID, col.Relation, col.Direction)
 						} else {
 							var pd metamodel.PropertyDef
 							if eDef != nil {
@@ -316,7 +317,7 @@ func (a *App) buildSections(sections []ViewSection, result *viewResult) []Sectio
 
 // executeSidePanel runs the side panel traversal and builds section data.
 // Returns nil if the form has no side panel or the entity doesn't exist.
-func (a *App) executeSidePanel(panel *SidePanelConfig, entityID, entityType string) []SectionData {
+func (a *App) executeSidePanel(ctx context.Context, panel *SidePanelConfig, entityID, entityType string) []SectionData {
 	if panel == nil || entityID == "" {
 		return nil
 	}
@@ -328,12 +329,12 @@ func (a *App) executeSidePanel(panel *SidePanelConfig, entityID, entityType stri
 		Sections: panel.Sections,
 	}
 
-	result, err := a.executeView(viewCfg, entityID)
+	result, err := a.executeView(ctx, viewCfg, entityID)
 	if err != nil {
 		return nil
 	}
 
-	return a.buildSections(panel.Sections, result)
+	return a.buildSections(ctx, panel.Sections, result)
 }
 
 // resolveSectionButtonsWithTraverse populates AddInfo and LinkInfo on

--- a/internal/dataentry/services.go
+++ b/internal/dataentry/services.go
@@ -44,8 +44,8 @@ func (a *App) Services() Services {
 }
 
 // getEntity looks up an entity by ID via the store.
-func (a *App) getEntity(id string) (*entity.Entity, bool) {
-	e, err := a.store.GetEntity(context.Background(), id)
+func (a *App) getEntity(ctx context.Context, id string) (*entity.Entity, bool) {
+	e, err := a.store.GetEntity(ctx, id)
 	if err != nil {
 		return nil, false
 	}
@@ -57,18 +57,17 @@ func (a *App) getEntity(id string) (*entity.Entity, bool) {
 // by the relation GET handlers to emit a `type` field per edge so SPA
 // clients can construct JSON:API §9 resource identifiers without
 // guessing.
-func (a *App) peerType(id string) string {
-	if e, ok := a.getEntity(id); ok {
+func (a *App) peerType(ctx context.Context, id string) string {
+	if e, ok := a.getEntity(ctx, id); ok {
 		return e.Type
 	}
 	return ""
 }
 
-// outgoingRelations returns all outgoing relations for id using the
-// background context. Prefer outgoingRelationsCtx when a request context
-// is in scope.
-func (a *App) outgoingRelations(id string) []*entity.Relation {
-	rels, _ := a.outgoingRelationsCtx(context.Background(), id)
+// outgoingRelations returns all outgoing relations for id. Iterator
+// errors are swallowed; use outgoingRelationsCtx to surface them.
+func (a *App) outgoingRelations(ctx context.Context, id string) []*entity.Relation {
+	rels, _ := a.outgoingRelationsCtx(ctx, id)
 	return rels
 }
 
@@ -82,15 +81,11 @@ func (a *App) outgoingRelationsCtx(ctx context.Context, id string) ([]*entity.Re
 }
 
 // incomingRelations returns all incoming relations for id.
-func (a *App) incomingRelations(id string) []*entity.Relation {
-	return listRelations(a.store, store.RelationQuery{
+func (a *App) incomingRelations(ctx context.Context, id string) []*entity.Relation {
+	rels, _ := listRelationsCtx(ctx, a.store, store.RelationQuery{
 		EntityID:  id,
 		Direction: store.DirectionIncoming,
 	})
-}
-
-func listRelations(s store.Store, q store.RelationQuery) []*entity.Relation {
-	rels, _ := listRelationsCtx(context.Background(), s, q)
 	return rels
 }
 

--- a/internal/dataentry/theme_logo.go
+++ b/internal/dataentry/theme_logo.go
@@ -144,14 +144,13 @@ func (a *App) loadUserLogo() ([]byte, string, error) {
 // saveUserLogo persists the bytes and extension. Caller must hold
 // writeMu (i.e. invoke from inside mutateState) so the bytes/sidecar
 // pair cannot be observed half-written by a concurrent reload.
-func (a *App) saveUserLogo(bytes []byte, ext string) error {
+func (a *App) saveUserLogo(ctx context.Context, bytes []byte, ext string) error {
 	if a.kv == nil {
 		return errors.New("kv not configured")
 	}
 	if _, ok := allowedLogoExts[ext]; !ok {
 		return fmt.Errorf("invalid logo extension %q", ext)
 	}
-	ctx := context.Background()
 	if err := a.kv.Put(ctx, userLogoFile, bytes); err != nil {
 		return fmt.Errorf("write %s: %w", userLogoFile, err)
 	}
@@ -163,11 +162,10 @@ func (a *App) saveUserLogo(bytes []byte, ext string) error {
 
 // deleteUserLogo removes both the bytes file and the sidecar. Idempotent;
 // missing files are not errors.
-func (a *App) deleteUserLogo() error {
+func (a *App) deleteUserLogo(ctx context.Context) error {
 	if a.kv == nil {
 		return nil
 	}
-	ctx := context.Background()
 	if err := a.kv.Delete(ctx, userLogoFile); err != nil {
 		return fmt.Errorf("delete %s: %w", userLogoFile, err)
 	}

--- a/internal/dataentry/views.go
+++ b/internal/dataentry/views.go
@@ -16,8 +16,7 @@ type viewResult struct {
 }
 
 // executeView runs a view's traversal rules and returns the result.
-func (a *App) executeView(view ViewConfig, entryID string) (*viewResult, error) {
-	ctx := context.Background()
+func (a *App) executeView(ctx context.Context, view ViewConfig, entryID string) (*viewResult, error) {
 	entry, err := a.store.GetEntity(ctx, entryID)
 	if err != nil {
 		return nil, fmt.Errorf("entry entity not found: %s", entryID)
@@ -36,7 +35,7 @@ func (a *App) executeView(view ViewConfig, entryID string) (*viewResult, error) 
 	for range maxPasses {
 		before := countViewEntities(result.Collections)
 		for _, rule := range view.Traverse {
-			a.applyViewTraverse(rule, result)
+			a.applyViewTraverse(ctx, rule, result)
 		}
 		if countViewEntities(result.Collections) == before {
 			break
@@ -49,7 +48,7 @@ func (a *App) executeView(view ViewConfig, entryID string) (*viewResult, error) 
 	return result, nil
 }
 
-func (a *App) applyViewTraverse(rule ViewTraverse, result *viewResult) {
+func (a *App) applyViewTraverse(ctx context.Context, rule ViewTraverse, result *viewResult) {
 	// Gather source entities
 	var sources []*entity.Entity
 	if rule.From == "*" {
@@ -75,9 +74,9 @@ func (a *App) applyViewTraverse(rule ViewTraverse, result *viewResult) {
 			if maxD <= 0 {
 				maxD = maxRecursionDepth
 			}
-			found = append(found, a.traverseViewRecursive(src.ID, rule, 0, maxD, map[string]bool{})...)
+			found = append(found, a.traverseViewRecursive(ctx, src.ID, rule, 0, maxD, map[string]bool{})...)
 		} else {
-			found = append(found, a.traverseViewOnce(src.ID, rule)...)
+			found = append(found, a.traverseViewOnce(ctx, src.ID, rule)...)
 		}
 	}
 
@@ -106,8 +105,7 @@ func (a *App) applyViewTraverse(rule ViewTraverse, result *viewResult) {
 	}
 }
 
-func (a *App) traverseViewOnce(sourceID string, rule ViewTraverse) []*entity.Entity {
-	ctx := context.Background()
+func (a *App) traverseViewOnce(ctx context.Context, sourceID string, rule ViewTraverse) []*entity.Entity {
 	st := a.store
 	var out []*entity.Entity
 
@@ -143,16 +141,18 @@ func (a *App) traverseViewOnce(sourceID string, rule ViewTraverse) []*entity.Ent
 	return out
 }
 
-func (a *App) traverseViewRecursive(sourceID string, rule ViewTraverse, depth, maxDepth int, visited map[string]bool) []*entity.Entity {
+func (a *App) traverseViewRecursive(
+	ctx context.Context, sourceID string, rule ViewTraverse, depth, maxDepth int, visited map[string]bool,
+) []*entity.Entity {
 	if depth >= maxDepth || visited[sourceID] {
 		return nil
 	}
 	visited[sourceID] = true
-	immediate := a.traverseViewOnce(sourceID, rule)
+	immediate := a.traverseViewOnce(ctx, sourceID, rule)
 	var all []*entity.Entity
 	all = append(all, immediate...)
 	for _, e := range immediate {
-		all = append(all, a.traverseViewRecursive(e.ID, rule, depth+1, maxDepth, visited)...)
+		all = append(all, a.traverseViewRecursive(ctx, e.ID, rule, depth+1, maxDepth, visited)...)
 	}
 	return all
 }

--- a/internal/dataentry/views_test.go
+++ b/internal/dataentry/views_test.go
@@ -1,6 +1,7 @@
 package dataentry
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -87,7 +88,7 @@ func TestExecuteView(t *testing.T) {
 				{From: "entry", Follow: "depends_on", CollectAs: "dependencies"},
 			},
 		}
-		result, err := app.executeView(view, "TKT-001")
+		result, err := app.executeView(context.Background(), view, "TKT-001")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -108,7 +109,7 @@ func TestExecuteView(t *testing.T) {
 				{From: "entry", FollowIncoming: "depends_on", CollectAs: "dependents"},
 			},
 		}
-		result, err := app.executeView(view, "TKT-002")
+		result, err := app.executeView(context.Background(), view, "TKT-002")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -126,7 +127,7 @@ func TestExecuteView(t *testing.T) {
 				{From: "entry", Follow: "depends_on", CollectAs: "all_deps", Recursive: true},
 			},
 		}
-		result, err := app.executeView(view, "TKT-001")
+		result, err := app.executeView(context.Background(), view, "TKT-001")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -144,7 +145,7 @@ func TestExecuteView(t *testing.T) {
 				{From: "entry", Follow: "depends_on", CollectAs: "limited_deps", Recursive: true, MaxDepth: 1},
 			},
 		}
-		result, err := app.executeView(view, "TKT-001")
+		result, err := app.executeView(context.Background(), view, "TKT-001")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -163,7 +164,7 @@ func TestExecuteView(t *testing.T) {
 				{From: "*", Follow: "depends_on", CollectAs: "transitive_deps"},
 			},
 		}
-		result, err := app.executeView(view, "TKT-001")
+		result, err := app.executeView(context.Background(), view, "TKT-001")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -178,7 +179,7 @@ func TestExecuteView(t *testing.T) {
 
 	t.Run("entry not found", func(t *testing.T) {
 		view := ViewConfig{Entry: ViewEntry{Type: "ticket"}}
-		_, err := app.executeView(view, "NONEXISTENT")
+		_, err := app.executeView(context.Background(), view, "NONEXISTENT")
 		if err == nil {
 			t.Error("expected error for nonexistent entry")
 		}
@@ -186,7 +187,7 @@ func TestExecuteView(t *testing.T) {
 
 	t.Run("wrong entry type", func(t *testing.T) {
 		view := ViewConfig{Entry: ViewEntry{Type: "component"}}
-		_, err := app.executeView(view, "TKT-001")
+		_, err := app.executeView(context.Background(), view, "TKT-001")
 		if err == nil {
 			t.Error("expected error for wrong entry type")
 		}
@@ -196,7 +197,7 @@ func TestExecuteView(t *testing.T) {
 		view := ViewConfig{
 			Entry: ViewEntry{Type: "ticket"},
 		}
-		result, err := app.executeView(view, "TKT-001")
+		result, err := app.executeView(context.Background(), view, "TKT-001")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -213,7 +214,7 @@ func TestExecuteView(t *testing.T) {
 				{From: "entry", Follow: "belongs_to", CollectAs: "components"},
 			},
 		}
-		result, err := app.executeView(view, "TKT-001")
+		result, err := app.executeView(context.Background(), view, "TKT-001")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -238,7 +239,7 @@ func TestExecuteView(t *testing.T) {
 				{From: "entry", Follow: "depends_on", CollectAs: "collected"}, // same rule again
 			},
 		}
-		result, err := app.executeView(view, "TKT-001")
+		result, err := app.executeView(context.Background(), view, "TKT-001")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -355,7 +356,7 @@ func TestExecuteViewWithWhere(t *testing.T) {
 				},
 			},
 		}
-		result, err := app.executeView(view, "BOUWBLOK-001")
+		result, err := app.executeView(context.Background(), view, "BOUWBLOK-001")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -383,7 +384,7 @@ func TestExecuteViewWithWhere(t *testing.T) {
 				},
 			},
 		}
-		result, err := app.executeView(view, "BOUWBLOK-001")
+		result, err := app.executeView(context.Background(), view, "BOUWBLOK-001")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -406,7 +407,7 @@ func TestExecuteViewWithWhere(t *testing.T) {
 				},
 			},
 		}
-		result, err := app.executeView(view, "BOUWBLOK-001")
+		result, err := app.executeView(context.Background(), view, "BOUWBLOK-001")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -434,7 +435,7 @@ func TestExecuteViewWithWhere(t *testing.T) {
 				},
 			},
 		}
-		result, err := app.executeView(view, "BOUWBLOK-001")
+		result, err := app.executeView(context.Background(), view, "BOUWBLOK-001")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -471,7 +472,7 @@ func TestExecuteViewWithWhere(t *testing.T) {
 				},
 			},
 		}
-		result, err := app.executeView(view, "BOUWBLOK-001")
+		result, err := app.executeView(context.Background(), view, "BOUWBLOK-001")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -498,7 +499,7 @@ func TestExecuteViewWithWhere(t *testing.T) {
 				},
 			},
 		}
-		result, err := app.executeView(view, "BOUWBLOK-001")
+		result, err := app.executeView(context.Background(), view, "BOUWBLOK-001")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/internal/lua/runtime_test.go
+++ b/internal/lua/runtime_test.go
@@ -136,9 +136,9 @@ func (m *mockWorkspace) Meta() *metamodel.Metamodel {
 }
 
 // entityCount returns the number of entities currently in the mock's store.
-func (m *mockWorkspace) entityCount() int {
+func (m *mockWorkspace) entityCount(ctx context.Context) int {
 	n := 0
-	for _, err := range m.store.ListEntities(context.Background(), store.EntityQuery{}) {
+	for _, err := range m.store.ListEntities(ctx, store.EntityQuery{}) {
 		if err != nil {
 			continue
 		}
@@ -169,7 +169,7 @@ func (m *mockManager) CreateEntity(
 	}
 	id := opts.ID
 	if id == "" {
-		id = fmt.Sprintf("%s-%03d", strings.ToUpper(e.Type[:3]), m.ws.entityCount()+1)
+		id = fmt.Sprintf("%s-%03d", strings.ToUpper(e.Type[:3]), m.ws.entityCount(ctx)+1)
 	}
 	newE := &entity.Entity{
 		ID:         id,

--- a/internal/mcp/convert.go
+++ b/internal/mcp/convert.go
@@ -62,7 +62,7 @@ type pathStepJSON struct {
 }
 
 // convertStoreEntity converts an entity.Entity to JSON string with optional relations from store.
-func convertStoreEntity(e *entity.Entity, st store.Store, includeRelations bool) (string, error) {
+func convertStoreEntity(ctx context.Context, e *entity.Entity, st store.Store, includeRelations bool) (string, error) {
 	ej := entityJSON{
 		ID:         e.ID,
 		Type:       e.Type,
@@ -70,7 +70,7 @@ func convertStoreEntity(e *entity.Entity, st store.Store, includeRelations bool)
 		Content:    e.Content,
 	}
 	if includeRelations {
-		ej.Relations = buildStoreRelations(e.ID, st)
+		ej.Relations = buildStoreRelations(ctx, e.ID, st)
 	}
 	return marshalJSON(ej)
 }
@@ -91,8 +91,7 @@ func convertStoreEntitySummary(e *entity.Entity) map[string]interface{} {
 }
 
 // buildStoreRelations builds relation JSON for an entity using the store.
-func buildStoreRelations(entityID string, st store.Store) *relationsJSON {
-	ctx := context.Background()
+func buildStoreRelations(ctx context.Context, entityID string, st store.Store) *relationsJSON {
 	rels := &relationsJSON{
 		Outgoing: make(map[string][]relationTargetJSON),
 		Incoming: make(map[string][]relationTargetJSON),

--- a/internal/mcp/convert_test.go
+++ b/internal/mcp/convert_test.go
@@ -89,7 +89,7 @@ func TestConvertStoreEntity_WithoutRelations(t *testing.T) {
 	e := buildEntity(testutil.EntityFor(meta, "requirement").ID("REQ-001").With("title", "Test requirement").WithContent("Some content"))
 	seedEntity(t, st, e)
 
-	result, err := convertStoreEntity(e, st, false)
+	result, err := convertStoreEntity(context.Background(), e, st, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestConvertStoreEntity_WithRelations(t *testing.T) {
 	seedEntity(t, st, e2)
 	seedRelation(t, st, e2.ID, "addresses", e1.ID)
 
-	result, err := convertStoreEntity(e1, st, true)
+	result, err := convertStoreEntity(context.Background(), e1, st, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestConvertStoreEntity_NoRelationsPresent(t *testing.T) {
 	e := buildEntity(testutil.EntityFor(meta, "requirement").ID("REQ-001"))
 	seedEntity(t, st, e)
 
-	result, err := convertStoreEntity(e, st, true)
+	result, err := convertStoreEntity(context.Background(), e, st, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -365,7 +365,7 @@ func TestBuildStoreRelations_NoEdges(t *testing.T) {
 	e := buildEntity(testutil.EntityFor(meta, "requirement").ID("REQ-001"))
 	seedEntity(t, st, e)
 
-	rels := buildStoreRelations(e.ID, st)
+	rels := buildStoreRelations(context.Background(), e.ID, st)
 	if rels != nil {
 		t.Error("expected nil relations for entity with no edges")
 	}
@@ -380,7 +380,7 @@ func TestBuildStoreRelations_OutgoingOnly(t *testing.T) {
 	seedEntity(t, st, req)
 	seedRelation(t, st, sol.ID, "addresses", req.ID)
 
-	rels := buildStoreRelations(sol.ID, st)
+	rels := buildStoreRelations(context.Background(), sol.ID, st)
 	if rels == nil {
 		t.Fatal("expected non-nil relations")
 	}
@@ -407,7 +407,7 @@ func TestBuildStoreRelations_IncomingOnly(t *testing.T) {
 	seedEntity(t, st, sol)
 	seedRelation(t, st, sol.ID, "addresses", req.ID)
 
-	rels := buildStoreRelations(req.ID, st)
+	rels := buildStoreRelations(context.Background(), req.ID, st)
 	if rels == nil {
 		t.Fatal("expected non-nil relations")
 	}
@@ -431,7 +431,7 @@ func TestBuildStoreRelations_BothDirections(t *testing.T) {
 	seedRelation(t, st, "SOL-001", "addresses", "REQ-001")
 	seedRelation(t, st, "REQ-001", "motivates", "DEC-001")
 
-	rels := buildStoreRelations("REQ-001", st)
+	rels := buildStoreRelations(context.Background(), "REQ-001", st)
 	if rels == nil {
 		t.Fatal("expected non-nil relations")
 	}
@@ -611,7 +611,7 @@ func TestConvertStoreEntity_WithProperties(t *testing.T) {
 	e := buildEntity(testutil.EntityFor(meta, "decision").ID("DEC-001").With("title", "Use Go").With("status", "accepted").With("priority", "high"))
 	seedEntity(t, st, e)
 
-	result, err := convertStoreEntity(e, st, false)
+	result, err := convertStoreEntity(context.Background(), e, st, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -58,21 +58,20 @@ func promptReviewEntity() mcp.Prompt {
 // --- Prompt Handlers ---
 
 func (s *Server) handleAnalyzeTraceabilityPrompt(
-	_ context.Context, request mcp.GetPromptRequest,
+	ctx context.Context, request mcp.GetPromptRequest,
 ) (*mcp.GetPromptResult, error) {
 	id := request.Params.Arguments["id"]
 	if id == "" {
 		return nil, errors.New("id argument is required")
 	}
 
-	ctx := context.Background()
 	st := s.deps.Store
 	e, getErr := st.GetEntity(ctx, id)
 	if getErr != nil {
 		return nil, fmt.Errorf("entity not found: %s", id)
 	}
 
-	entityText, err := convertStoreEntity(e, st, true)
+	entityText, err := convertStoreEntity(ctx, e, st, true)
 	if err != nil {
 		return nil, err
 	}
@@ -124,11 +123,10 @@ Please analyze:
 }
 
 func (s *Server) handleReviewOrphansPrompt(
-	_ context.Context, request mcp.GetPromptRequest,
+	ctx context.Context, request mcp.GetPromptRequest,
 ) (*mcp.GetPromptResult, error) {
 	entityType := request.Params.Arguments["type"]
 
-	ctx := context.Background()
 	orphanIDs, _ := s.deps.Tracer.FindOrphans(ctx)
 
 	st := s.deps.Store
@@ -205,10 +203,9 @@ For each orphan entity:
 }
 
 func (s *Server) handleSummarizeProjectPrompt(
-	_ context.Context, _ mcp.GetPromptRequest,
+	ctx context.Context, _ mcp.GetPromptRequest,
 ) (*mcp.GetPromptResult, error) {
 	// Entity counts by type
-	ctx := context.Background()
 	meta := s.deps.Meta
 	st := s.deps.Store
 	entityTypes := meta.EntityTypes()
@@ -280,7 +277,7 @@ Please provide:
 }
 
 func (s *Server) handleReviewEntityPrompt(
-	_ context.Context, request mcp.GetPromptRequest,
+	ctx context.Context, request mcp.GetPromptRequest,
 ) (*mcp.GetPromptResult, error) {
 	id := request.Params.Arguments["id"]
 	if id == "" {
@@ -288,12 +285,12 @@ func (s *Server) handleReviewEntityPrompt(
 	}
 
 	st := s.deps.Store
-	entity, getErr := st.GetEntity(context.Background(), id)
+	entity, getErr := st.GetEntity(ctx, id)
 	if getErr != nil {
 		return nil, fmt.Errorf("entity not found: %s", id)
 	}
 
-	entityText, err := convertStoreEntity(entity, st, true)
+	entityText, err := convertStoreEntity(ctx, entity, st, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -74,7 +74,7 @@ func (s *Server) handleReadMetamodel(
 }
 
 func (s *Server) handleReadEntity(
-	_ context.Context, request mcp.ReadResourceRequest,
+	ctx context.Context, request mcp.ReadResourceRequest,
 ) ([]mcp.ResourceContents, error) {
 	uri := request.Params.URI
 
@@ -87,7 +87,7 @@ func (s *Server) handleReadEntity(
 	entityType, id := segments[0], segments[1]
 
 	st := s.deps.Store
-	e, getErr := st.GetEntity(context.Background(), id)
+	e, getErr := st.GetEntity(ctx, id)
 	if getErr != nil {
 		return nil, fmt.Errorf("entity not found: %s", id)
 	}
@@ -95,7 +95,7 @@ func (s *Server) handleReadEntity(
 		return nil, fmt.Errorf("entity %s is type %s, not %s", id, e.Type, entityType)
 	}
 
-	text, err := convertStoreEntity(e, st, true)
+	text, err := convertStoreEntity(ctx, e, st, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert entity: %w", err)
 	}
@@ -110,7 +110,7 @@ func (s *Server) handleReadEntity(
 }
 
 func (s *Server) handleReadRelation(
-	_ context.Context, request mcp.ReadResourceRequest,
+	ctx context.Context, request mcp.ReadResourceRequest,
 ) ([]mcp.ResourceContents, error) {
 	uri := request.Params.URI
 
@@ -123,7 +123,7 @@ func (s *Server) handleReadRelation(
 	fromID, relType, toID := segments[0], segments[1], segments[2]
 
 	st := s.deps.Store
-	relation, getErr := st.GetRelation(context.Background(), fromID, relType, toID)
+	relation, getErr := st.GetRelation(ctx, fromID, relType, toID)
 	if getErr != nil {
 		return nil, fmt.Errorf("relation not found: %s --%s--> %s", fromID, relType, toID)
 	}

--- a/internal/mcp/tools_analysis.go
+++ b/internal/mcp/tools_analysis.go
@@ -66,12 +66,12 @@ type cardinalityViolation struct {
 }
 
 func (s *Server) handleAnalyzeCardinality(
-	_ context.Context, _ mcp.CallToolRequest,
+	ctx context.Context, _ mcp.CallToolRequest,
 ) (*mcp.CallToolResult, error) {
 	violations := make([]cardinalityViolation, 0) //nolint:prealloc // capacity unknown
 
 	for relName, relDef := range s.deps.Meta.Relations {
-		violations = append(violations, s.checkCardinalityForRelation(relName, relDef)...)
+		violations = append(violations, s.checkCardinalityForRelation(ctx, relName, relDef)...)
 	}
 
 	if len(violations) == 0 {
@@ -87,25 +87,24 @@ func (s *Server) handleAnalyzeCardinality(
 }
 
 func (s *Server) checkCardinalityForRelation(
-	relName string, relDef metamodel.RelationDef,
+	ctx context.Context, relName string, relDef metamodel.RelationDef,
 ) []cardinalityViolation {
 	violations := make([]cardinalityViolation, 0) //nolint:prealloc // capacity unknown
 
 	violations = append(violations,
-		s.checkCardinalityBound(relName, relDef.From, relDef.MinOutgoing, relDef.MaxOutgoing, true)...)
+		s.checkCardinalityBound(ctx, relName, relDef.From, relDef.MinOutgoing, relDef.MaxOutgoing, true)...)
 
 	violations = append(violations,
-		s.checkCardinalityBound(relName, relDef.To, relDef.MinIncoming, relDef.MaxIncoming, false)...)
+		s.checkCardinalityBound(ctx, relName, relDef.To, relDef.MinIncoming, relDef.MaxIncoming, false)...)
 
 	return violations
 }
 
 func (s *Server) checkCardinalityBound(
-	relName string, entityTypes []string, minVal, maxVal *int, outgoing bool,
+	ctx context.Context, relName string, entityTypes []string, minVal, maxVal *int, outgoing bool,
 ) []cardinalityViolation {
 	var violations []cardinalityViolation
 
-	ctx := context.Background()
 	st := s.deps.Store
 	for _, entityType := range entityTypes {
 		for e, err := range st.ListEntities(ctx, store.EntityQuery{Type: entityType}) {
@@ -185,7 +184,7 @@ func (s *Server) handleAnalyzeProperties(
 	}
 
 	// Validate relation properties
-	relErrors := schema.ValidateRelationProperties(s.deps.Store, s.deps.Meta)
+	relErrors := schema.ValidateRelationProperties(ctx, s.deps.Store, s.deps.Meta)
 	allRelationErrors := make([]relationErrors, 0, len(relErrors))
 	for _, rpe := range relErrors {
 		errStrings := make([]string, len(rpe.Errors))
@@ -277,11 +276,11 @@ func (s *Server) handleAnalyzeValidations(
 }
 
 func (s *Server) handleAnalyzeSchema(
-	_ context.Context, request mcp.CallToolRequest,
+	ctx context.Context, request mcp.CallToolRequest,
 ) (*mcp.CallToolResult, error) {
 	threshold := request.GetInt("threshold", 0)
 
-	dataEntry := s.loadDataEntryConfig()
+	dataEntry := s.loadDataEntryConfig(ctx)
 
 	counter := &schema.StoreCounter{Store: s.deps.Store}
 	analysis := schema.Analyze(s.deps.Meta, counter, dataEntry, threshold)
@@ -310,8 +309,8 @@ func (s *Server) handleAnalyzeSchema(
 }
 
 // loadDataEntryConfig loads data-entry.yaml if it exists.
-func (s *Server) loadDataEntryConfig() *dataentryconfig.Config {
-	data, err := s.deps.Config.Load(context.Background(), dataentryconfig.ConfigFile)
+func (s *Server) loadDataEntryConfig(ctx context.Context) *dataentryconfig.Config {
+	data, err := s.deps.Config.Load(ctx, dataentryconfig.ConfigFile)
 	if err != nil {
 		return nil
 	}

--- a/internal/mcp/tools_entity.go
+++ b/internal/mcp/tools_entity.go
@@ -87,7 +87,7 @@ func (s *Server) handleShowEntity(
 		return mcp.NewToolResultError("entity not found: " + id), nil
 	}
 
-	text, err := convertStoreEntity(e, st, true)
+	text, err := convertStoreEntity(ctx, e, st, true)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -179,7 +179,7 @@ func (s *Server) handleCreateEntity(
 		return mcp.NewToolResultText(fmt.Sprintf("Created %s %s", resolvedType, created.ID)), nil
 	}
 
-	text, err := convertStoreEntity(e, st, false)
+	text, err := convertStoreEntity(ctx, e, st, false)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -236,7 +236,7 @@ func (s *Server) handleUpdateEntity(
 		return mcp.NewToolResultText(prefixWarnings(updateResult.Warnings) + "Updated " + id), nil
 	}
 
-	text, convertErr := convertStoreEntity(updated, st, true)
+	text, convertErr := convertStoreEntity(ctx, updated, st, true)
 	if convertErr != nil {
 		return mcp.NewToolResultError(convertErr.Error()), nil
 	}

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -74,6 +74,11 @@ func (s *Server) handleLuaEval(ctx context.Context, req mcp.CallToolRequest) (*m
 	// scriptPath is intentionally left empty: rela.cache.* in lua_eval
 	// raises "not available in inline/eval contexts" so sessions can't
 	// accidentally share a nameless namespace.
+	//
+	// ctx is threaded via lua.WithContext(ctx) above; the runtime caches it and
+	// RunString applies it to the LState. contextcheck can't see that flow
+	// because it crosses the gopher-lua SetContext boundary.
+	//nolint:contextcheck // ctx threaded via WithContext; see comment above
 	if err := runtime.RunString(code); err != nil {
 		// output stays empty here: print() in non-document/non-action
 		// runtimes writes to os.Stdout (see lua/runtime.go:256), which
@@ -156,6 +161,8 @@ func (s *Server) handleLuaRun(ctx context.Context, req mcp.CallToolRequest) (*mc
 	// os.OpenRoot above) specifically for traversal resistance; passing
 	// them through RunFileContent keeps that while sharing all the
 	// downstream invariants.
+	//
+	//nolint:contextcheck // ctx threaded via WithContext; see handleLuaEval note
 	if err := runtime.RunFileContent(path, scriptContent, args); err != nil {
 		// See note above: print() bypasses `output` for MCP runs.
 		return luaScriptErrorResult(lua.SurfaceLuaRun,

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -129,7 +129,7 @@ func New(
 // Tasks are executed sequentially in a single goroutine — no concurrent
 // script execution, no mutexes needed.
 func (s *Scheduler) Run(ctx context.Context) error {
-	s.loadState()
+	s.loadState(ctx)
 
 	if len(s.config.Tasks) == 0 {
 		s.logger.Info("no tasks configured, waiting for shutdown")
@@ -213,11 +213,11 @@ func (s *Scheduler) doExecuteTask(ctx context.Context, task TaskConfig) {
 
 	// Record successful run — no mutex needed, single goroutine.
 	s.state.Tasks[task.Name] = s.now()
-	s.saveState()
+	s.saveState(ctx)
 }
 
-func (s *Scheduler) loadState() {
-	data, err := s.ws.State().Get(context.Background(), stateFile)
+func (s *Scheduler) loadState(ctx context.Context) {
+	data, err := s.ws.State().Get(ctx, stateFile)
 	if err != nil {
 		s.state = newState()
 		return
@@ -225,13 +225,13 @@ func (s *Scheduler) loadState() {
 	s.state = parseState(data)
 }
 
-func (s *Scheduler) saveState() {
+func (s *Scheduler) saveState(ctx context.Context) {
 	data, err := s.state.marshal()
 	if err != nil {
 		s.logger.Error("failed to marshal scheduler state", "error", err)
 		return
 	}
-	if err := s.ws.State().Put(context.Background(), stateFile, data); err != nil {
+	if err := s.ws.State().Put(ctx, stateFile, data); err != nil {
 		s.logger.Error("failed to save scheduler state", "error", err)
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -130,10 +130,10 @@ func newTestScheduler(
 		logger: discardLogger(),
 		now:    func() time.Time { return now },
 	}
-	s.executeTaskFunc = func(_ context.Context, task TaskConfig) {
+	s.executeTaskFunc = func(ctx context.Context, task TaskConfig) {
 		tracker.record(task.Script)
 		s.state.Tasks[task.Name] = s.now()
-		s.saveState()
+		s.saveState(ctx)
 	}
 	return s, ws, tracker
 }
@@ -284,7 +284,7 @@ func TestScheduler_loadState_noFile(t *testing.T) {
 
 	ws := newMockWorkspace(t)
 	s := &Scheduler{ws: ws, logger: discardLogger()}
-	s.loadState()
+	s.loadState(context.Background())
 
 	if s.state == nil || s.state.Tasks == nil {
 		t.Fatal("expected initialized state")
@@ -300,7 +300,7 @@ func TestScheduler_loadState_existing(t *testing.T) {
 	ws.cacheFiles[stateFile] = stateData
 
 	s := &Scheduler{ws: ws, logger: discardLogger()}
-	s.loadState()
+	s.loadState(context.Background())
 
 	if got := s.state.Tasks["daily"]; !got.Equal(ts) {
 		t.Errorf("loaded state: daily = %v, want %v", got, ts)

--- a/internal/schema/validate_properties.go
+++ b/internal/schema/validate_properties.go
@@ -19,11 +19,10 @@ type PropertyError struct {
 // PropertyError for each entity whose properties fail the metamodel's
 // entity-property validation. Callers that need scope filtering should
 // filter the returned slice themselves.
-func ValidateEntityProperties(st store.Store, meta *metamodel.Metamodel) []PropertyError {
+func ValidateEntityProperties(ctx context.Context, st store.Store, meta *metamodel.Metamodel) []PropertyError {
 	if st == nil || meta == nil {
 		return nil
 	}
-	ctx := context.Background()
 	var out []PropertyError
 	for e, err := range st.ListEntities(ctx, store.EntityQuery{}) {
 		if err != nil {
@@ -52,11 +51,12 @@ type RelationPropertyError struct {
 // ValidateRelationProperties iterates every relation in st and returns
 // a RelationPropertyError for each relation whose properties fail the
 // metamodel's relation-property validation.
-func ValidateRelationProperties(st store.Store, meta *metamodel.Metamodel) []RelationPropertyError {
+func ValidateRelationProperties(
+	ctx context.Context, st store.Store, meta *metamodel.Metamodel,
+) []RelationPropertyError {
 	if st == nil || meta == nil {
 		return nil
 	}
-	ctx := context.Background()
 	var out []RelationPropertyError
 	for rel, err := range st.ListRelations(ctx, store.RelationQuery{}) {
 		if err != nil {

--- a/internal/schema/validate_properties_test.go
+++ b/internal/schema/validate_properties_test.go
@@ -39,7 +39,7 @@ func TestValidateEntityProperties(t *testing.T) {
 		}
 	}
 
-	errs := schema.ValidateEntityProperties(st, meta)
+	errs := schema.ValidateEntityProperties(ctx, st, meta)
 	if len(errs) != 1 {
 		t.Fatalf("got %d entities with errors, want 1", len(errs))
 	}
@@ -81,7 +81,7 @@ func TestValidateRelationProperties(t *testing.T) {
 		t.Fatalf("seed relation: %v", err)
 	}
 
-	errs := schema.ValidateRelationProperties(st, meta)
+	errs := schema.ValidateRelationProperties(ctx, st, meta)
 	if len(errs) != 1 {
 		t.Fatalf("got %d relations with errors, want 1", len(errs))
 	}
@@ -91,10 +91,10 @@ func TestValidateRelationProperties(t *testing.T) {
 }
 
 func TestValidateProperties_NilInputs(t *testing.T) {
-	if errs := schema.ValidateEntityProperties(nil, nil); errs != nil {
+	if errs := schema.ValidateEntityProperties(context.Background(), nil, nil); errs != nil {
 		t.Errorf("ValidateEntityProperties(nil,nil) = %v, want nil", errs)
 	}
-	if errs := schema.ValidateRelationProperties(nil, nil); errs != nil {
+	if errs := schema.ValidateRelationProperties(context.Background(), nil, nil); errs != nil {
 		t.Errorf("ValidateRelationProperties(nil,nil) = %v, want nil", errs)
 	}
 }

--- a/internal/script/action.go
+++ b/internal/script/action.go
@@ -2,6 +2,7 @@ package script
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -49,6 +50,7 @@ var validMessageTypes = map[string]bool{
 // HTTP response and the slog log line stay matched up. Callers without
 // a correlation context (CLI, scheduler) may pass "".
 func (e *Engine) ExecuteAction(
+	ctx context.Context,
 	scriptPath string,
 	deps lua.WriteDeps,
 	triggerEntity *entity.Entity,
@@ -67,6 +69,7 @@ func (e *Engine) ExecuteAction(
 		lua.WithActionMode(),
 		lua.WithTimeout(timeout),
 		lua.WithCache(e.cache),
+		lua.WithContext(ctx),
 	)
 	if err != nil {
 		return nil, err
@@ -83,6 +86,10 @@ func (e *Engine) ExecuteAction(
 		ls.SetGlobal("entity", lua.EntityToTable(ls, triggerEntity))
 	}
 
+	// ctx is threaded into the runtime via lua.WithContext(ctx) above;
+	// RunActionString applies it to the LState. contextcheck can't follow that
+	// flow across the gopher-lua SetContext boundary.
+	//nolint:contextcheck // ctx threaded via WithContext; see comment above
 	ret, err := runtime.RunActionString(scriptCode, scriptPath)
 	if errors.Is(err, lua.ErrNoReturnValue) {
 		return &ActionResponse{}, nil

--- a/internal/script/action_test.go
+++ b/internal/script/action_test.go
@@ -1,6 +1,7 @@
 package script
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -127,7 +128,7 @@ func TestExecuteAction_PathTraversal(t *testing.T) {
 	engine := NewEngine()
 	deps := testWriteDeps("/project")
 
-	_, err := engine.ExecuteAction("../etc/passwd", deps, nil, nil, time.Second, "")
+	_, err := engine.ExecuteAction(context.Background(), "../etc/passwd", deps, nil, nil, time.Second, "")
 	if err == nil {
 		t.Fatal("expected error for path traversal")
 	}
@@ -137,7 +138,7 @@ func TestExecuteAction_WrongExtension(t *testing.T) {
 	engine := NewEngine()
 	deps := testWriteDeps("/project")
 
-	_, err := engine.ExecuteAction("script.txt", deps, nil, nil, time.Second, "")
+	_, err := engine.ExecuteAction(context.Background(), "script.txt", deps, nil, nil, time.Second, "")
 	if err == nil {
 		t.Fatal("expected error for wrong extension")
 	}
@@ -166,7 +167,7 @@ func TestExecuteAction_RealFile(t *testing.T) {
 	engine := NewEngine()
 	deps := testWriteDeps(tmpDir)
 
-	resp, err := engine.ExecuteAction("test.lua", deps, nil, nil, 5*time.Second, "")
+	resp, err := engine.ExecuteAction(context.Background(), "test.lua", deps, nil, nil, 5*time.Second, "")
 	if err != nil {
 		t.Fatalf("ExecuteAction failed: %v", err)
 	}
@@ -194,7 +195,7 @@ func TestExecuteAction_WithTriggerEntity(t *testing.T) {
 	deps := testWriteDeps(tmpDir)
 	ent := &entity.Entity{ID: "T-42", Type: "ticket"}
 
-	resp, err := engine.ExecuteAction("ent.lua", deps, ent, nil, 5*time.Second, "")
+	resp, err := engine.ExecuteAction(context.Background(), "ent.lua", deps, ent, nil, 5*time.Second, "")
 	if err != nil {
 		t.Fatalf("ExecuteAction failed: %v", err)
 	}
@@ -220,7 +221,7 @@ func TestExecuteAction_WithParams(t *testing.T) {
 	deps := testWriteDeps(tmpDir)
 	params := map[string]string{"greeting": "hello"}
 
-	resp, err := engine.ExecuteAction("params.lua", deps, nil, params, 5*time.Second, "")
+	resp, err := engine.ExecuteAction(context.Background(), "params.lua", deps, nil, params, 5*time.Second, "")
 	if err != nil {
 		t.Fatalf("ExecuteAction failed: %v", err)
 	}
@@ -247,7 +248,7 @@ error("kaboom")`
 	deps := testWriteDeps(tmpDir)
 	ent := &entity.Entity{ID: "T-99", Type: "ticket"}
 
-	_, err := engine.ExecuteAction("boom.lua", deps, ent,
+	_, err := engine.ExecuteAction(context.Background(), "boom.lua", deps, ent,
 		map[string]string{"greeting": "hi", "password": "leak"}, 5*time.Second, "corr-test")
 	if err == nil {
 		t.Fatal("expected error from script")

--- a/internal/script/executor.go
+++ b/internal/script/executor.go
@@ -204,6 +204,10 @@ func (e *Engine) execute(ctx context.Context, code string, deps lua.WriteDeps, s
 		}
 	}
 
+	// ctx is threaded into the runtime via lua.WithContext(ctx) above; RunString
+	// applies it to the LState. contextcheck can't follow that flow across the
+	// gopher-lua SetContext boundary.
+	//nolint:contextcheck // ctx threaded via WithContext; see comment above
 	if runErr := runtime.RunString(code); runErr != nil {
 		// Surface tag is "automation" — this seam is invoked from the
 		// automation engine (workspace) for both inline `lua: |` blocks

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -191,6 +191,11 @@ func (s *Service) CheckRule(
 	}()
 
 	for _, e := range candidates {
+		// The Lua path under checkEntityAgainstRule runs through luaCtx.runtime,
+		// which was built with lua.WithContext(ctx); applyTimeout derives the
+		// per-entity budget from that cached parent ctx. contextcheck can't
+		// follow that flow across the gopher-lua SetContext boundary.
+		//nolint:contextcheck // ctx threaded via WithContext on luaCtx.runtime
 		entityResult := s.checkEntityAgainstRule(e, rule, whenFilters, thenFilters, luaCtx)
 		result.Violations = append(result.Violations, entityResult.Violations...)
 		result.ScriptErrors = append(result.ScriptErrors, entityResult.ScriptErrors...)

--- a/tickets/entities/implementation-checklists/IMPL-H250G.md
+++ b/tickets/entities/implementation-checklists/IMPL-H250G.md
@@ -1,0 +1,55 @@
+---
+id: IMPL-H250G
+type: implementation-checklist
+title: 'Implementation: Enable contextcheck golangci-lint rule'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] ~~Unit tests written for new code~~ (N/A: pure ctx-threading refactor, no new logic; existing tests cover behavior)
+- [x] ~~Integration tests written~~ (N/A: refactor; existing handler/integration tests exercise the threaded paths unchanged)
+- [x] Happy path implemented — ctx threaded through all flagged chains
+- [x] Edge cases from planning handled (helpers called from both ctx-aware and ctx-less sites threaded; iterator reads carry ctx; test entrypoints use Background)
+- [x] Error handling in place — no error paths changed; ctx threading only
+
+## Test Quality
+
+- [x] ~~Using fixture builders~~ (N/A: no new test data introduced)
+- [x] No hardcoded values added in assertions
+- [x] Only ctx args added; no test values changed
+- [x] ~~Interpolated values~~ (N/A)
+- [x] ~~Property comparisons~~ (N/A)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end — see evidence below
+- [x] Each acceptance criterion verified
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+- **AC1** (contextcheck enabled, comment removed): `.golangci.yml` now lists `- contextcheck` with the 4-line explanatory block removed. Verified via grep.
+- **AC2** (`just lint` clean): `golangci-lint cache clean && just lint` → `0 issues.` No contextcheck violations, no new violations from other linters (gofmt/nolintlint/lll all clean).
+- **AC3** (no behavioral regression): `just test` (race-enabled) → exit 0, all packages pass. The reverted-by-subagent incident was caught and fully reconstructed; affordances/dataentry/mcp/analysis/cli/lua/validation/scheduler tests all green.
+- `just arch-lint` → `OK - No warnings found`.
+
+Scope delivered: 101 violations resolved across internal/dataentry (58),
+internal/mcp (22), internal/analysis (7), internal/affordances (5),
+internal/scheduler (3), internal/cli (2), internal/validation/script/lua (1
+each). Lua-runtime seams
+(RunString/RunFileContent/RunActionString/RunValidationString) that bind ctx
+once via `lua.WithContext` carry a targeted `//nolint:contextcheck` with
+rationale — contextcheck can't follow ctx across the gopher-lua SetContext
+boundary. ExecuteAction additionally gained a real `ctx` param (was previously
+uncancellable).
+
+## Quality
+
+- [x] Code follows project patterns — ctx-first param convention; mirrors existing `outgoingRelationsCtx` precedent
+- [x] Checked for DRY — no new duplication; lll-overflow lines hoisted rather than nolint'd
+- [x] No security issues — auth-path predicate eval (affordances `passes`) now cancellable; verdict logic untouched
+- [x] No silent failures introduced
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-DTMAB.md
+++ b/tickets/entities/planning-checklists/PLAN-DTMAB.md
@@ -1,0 +1,137 @@
+---
+id: PLAN-DTMAB
+type: planning-checklist
+title: 'Planning: Enable contextcheck golangci-lint rule'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN scope:
+- Enable `contextcheck` in `.golangci.yml`, remove the commented-out block + explanatory comment (lines 16-19).
+- Fix all 101 violations by threading the real request/caller `ctx` to the bottom of each call chain.
+
+OUT of scope:
+- Any unrelated linter or broader ctx-cancellation hardening beyond what contextcheck flags.
+- Refactoring `bindingContext`/predicate internals beyond passing ctx through `passes`.
+
+**Acceptance Criteria:**
+1. `contextcheck` uncommented in `.golangci.yml`, 4-line comment gone. Test: grep config; `golangci-lint linters` shows it enabled.
+2. `just lint` clean — zero contextcheck violations, zero new violations from other linters. Test: `just lint` exits 0.
+3. No behavioral regression: every threaded ctx is the actual request/caller ctx, never a swapped-in `context.Background()`. Test: `just test` passes.
+
+## Research
+
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Existing Solutions:**
+- Built-in golangci-lint linter; no library needed.
+- **Precedent in tree:** `App.outgoingRelationsCtx(ctx, id)` (services.go:77) is the ctx-aware twin of legacy `App.outgoingRelations(id)` (services.go:70) wrapping `context.Background()`. Migration shape: add `*Ctx` variant, route ctx-aware callers to it, retire background wrapper. RR-JWDHH confirms this direction.
+- Predecessor **TKT-AHUNF** enabled the rest of the v2 linters and deferred contextcheck; this finishes it.
+- dataentry HTTP handlers carry `r *http.Request` → `r.Context()` available at every call site.
+- MCP prompt handlers receive `context.Context` but discard as `_` and create `context.Background()`.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:** Two mechanical transforms, bottom-up, package by
+package: A. `Non-inherited new context` (14×) — replace local
+`context.Background()` with in-scope ctx (`r.Context()` / named first param).
+MCP handlers: rename `_ context.Context`→`ctx`, drop the `Background()` line. B.
+`should pass the context parameter` (86×) — add `ctx context.Context` first
+param to each flagged helper, pass down to store/tracer/predicate call, update
+callers.
+
+Per-package: affordances/resolver.go (thread through
+passes/applyFieldGrants/applyOptionGrants/metaFieldResults →
+prog.Eval(ctx,...)); dataentry (add getEntityCtx; thread
+getEntity/outgoingRelations/incomingRelations/listAllFromStore/computeDocumentHash/view+query
+helpers); mcp (name+use ctx params; thread
+buildStoreRelations/convertStoreEntity/tool helpers); analysis (collectEntities
+chain + callers); scheduler/cli/validation/script/lua (thread available ctx).
+
+**Alternatives:** nolint-suppress (rejected — leaves real gaps); `--new` only
+(rejected — goal is full enablement); big-bang commit (discouraged — stage by
+package).
+
+**Files:** `.golangci.yml`, `internal/affordances/resolver.go`,
+`internal/dataentry/*` (services, api_v1, handlers_api, commands, affordances,
+actions, handlers_theme*, relations_modern, helpers, document), `internal/mcp/*`
+(prompts, resources, convert, tools_*), `internal/analysis/analysis.go`,
+`internal/scheduler/scheduler.go`, `internal/cli/validate.go`,
+`internal/validation/validation.go`, `internal/script/executor.go`,
+`internal/lua/*` + flagged `_test.go`.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** None changed. Pure ctx-threading refactor.
+
+**Security-Sensitive Operations:** affordances resolver (`passes`→`prog.Eval`)
+is on the auth path. Threading real ctx is strictly an improvement (eval becomes
+cancellable); verdict logic untouched. Verify ACL/affordances tests pass — no
+verdict drift.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** AC1 grep config + `golangci-lint linters`. AC2 `just lint`
+exits 0. AC3 `just test` (race) for affordances/dataentry/mcp/analysis.
+
+**Edge Cases:** helper called from both ctx-aware and ctx-less sites (thread ctx
+into both); iterator store reads must carry ctx; test entrypoints may
+legitimately originate Background — fix the helper signature, not by
+suppressing.
+
+**Negative Tests:** handler tests asserting 404/422 must pass unchanged — ctx
+threading must not alter status codes.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:** ripple into public signatures (mitigated: mostly unexported; exported
+ones are internal-pkg, all callers in-tree, compile catches); Background-swap
+silencing the linter without fixing (mitigated: review every Background()
+deletion); large diff (mitigated: stage by package, lint+test per package).
+Effort: **m**.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] N/A - Internal refactor + lint-config change, no user-facing docs needed.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (Skipped: user approved going straight to implementation; mechanical ctx threading with established in-tree precedent)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** None — design review skipped per user approval.

--- a/tickets/entities/review-checklists/REV-UJ1S7.md
+++ b/tickets/entities/review-checklists/REV-UJ1S7.md
@@ -1,0 +1,57 @@
+---
+id: REV-UJ1S7
+type: review-checklist
+title: 'Review: Enable contextcheck golangci-lint rule'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — race-enabled, exit 0, all packages green
+- [x] Lint clean (`just lint`) — `0 issues.` with contextcheck enabled (cache cleaned first)
+- [x] Coverage maintained (`just coverage-check`) — PASS; total 77.3%, all package floors satisfied
+
+## Code Review
+
+- [x] Run `/code-review` — cranky-code-reviewer invoked on `git diff develop...HEAD`
+- [x] All critical review-responses addressed — none found
+- [x] All significant review-responses addressed — none found
+- [x] Self-reviewed the diff for unrelated changes — pure ctx-threading
+
+**Review Responses:** RR-0VVCI (nit, wont-fix: test-file `context.Background()`
+vs `t.Context()`)
+
+Reviewer verdict: "clean, mechanical, correct refactor… Ship it."
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented in implementation checklist (IMPL-H250G)
+
+**Acceptance Status:**
+- **AC1** — PASS. `.golangci.yml` lists `- contextcheck`, comment block removed.
+- **AC2** — PASS. `just lint` → `0 issues.`
+- **AC3** — PASS. `just test` exit 0; threaded ctx is the real request/caller ctx.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist~~ (N/A: internal refactor + lint-config change)
+- [x] ~~User-facing documentation~~ (N/A)
+- [x] ~~Docs-checklist marked done~~ (N/A)
+
+## Final Checks
+
+- [x] Commit message explains the why
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` — PR #854 created; rebased onto current develop (resolved conflicts from TKT-9NOX #843 affordances-ctx + TKT-7I3P #840 mcp Deps refactors landed on develop)
+- [x] All CI checks pass — Lint, Test, Build, E2E, Frontend, Fuzz, Architecture, Docs, Demos, Rela Tickets, CodeQL, Vulnerability Check all green
+- [x] PR URL documented below
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/854 — MERGEABLE, all checks
+green; awaiting reviewer approval (branch protection).

--- a/tickets/entities/review-responses/RR-0VVCI.md
+++ b/tickets/entities/review-responses/RR-0VVCI.md
@@ -1,0 +1,9 @@
+---
+id: RR-0VVCI
+type: review-response
+title: Test files use context.Background() instead of t.Context()
+finding: Some _test.go files (api_v1_test.go, app_test.go, document_script_test.go, views_test.go, helpers_test.go) use context.Background() for the newly-added ctx args where the package elsewhere uses t.Context(). Stylistically inconsistent within the same file.
+severity: nit
+reason: Acceptable per ticket scope (test-file Background() explicitly allowed in the planning AC). Several call sites are in helpers with no *testing.T in scope (e.g. implementsTargets(app, entityID)), where Background() is the only option. A churn-only follow-up to standardize on t.Context() is out of scope for this lint-enablement ticket.
+status: wont-fix
+---

--- a/tickets/entities/tickets/TKT-B11W0.md
+++ b/tickets/entities/tickets/TKT-B11W0.md
@@ -1,0 +1,52 @@
+---
+id: TKT-B11W0
+type: ticket
+title: Enable contextcheck golangci-lint rule
+kind: refactor
+priority: medium
+effort: m
+status: done
+---
+
+Enable the `contextcheck` linter (currently commented out in `.golangci.yml`)
+and fix the violations it surfaces.
+
+Follow-up to TKT-AHUNF, which deferred contextcheck because enabling it required
+a refactor that was out of scope for that lint-expansion ticket. A current run
+(golangci-lint v2.11.4) reports **101 violations** (the stale comment in the
+config says 84).
+
+## Violation breakdown
+
+Two distinct message shapes:
+
+- **86× `should pass the context parameter`** — a ctx-aware caller invokes a helper that does not accept ctx, so the request context cannot be threaded down to the store/tracer/predicate call at the bottom. Fix = thread `ctx context.Context` through the private helper chains.
+- **14× `Non-inherited new context`** — code in request scope creates a fresh `context.Background()` instead of inheriting the incoming request ctx. Fix = accept the incoming ctx and delete the `context.Background()` line.
+
+## By package
+
+| Package | Violations | Notes |
+|---|---|---|
+| internal/dataentry | 58 | api_v1.go (34, mostly `getEntity`/`outgoingRelations` helper chains), handlers_api.go (10), commands.go (5), affordances.go (3) |
+| internal/mcp | 22 | prompts.go (11, mostly `_ context.Context` + `context.Background()` in prompt handlers), tools_*.go, resources.go |
+| internal/analysis | 7 | analysis.go — `collectEntities` chain not ctx-threaded |
+| internal/affordances | 5 | resolver.go — `passes`/`applyFieldGrants` chain ending in `prog.Eval(context.Background(), ...)` |
+| internal/scheduler | 3 | scheduler.go + one test |
+| internal/cli | 2 | validate.go |
+| internal/{validation,script,lua} | 1 each | one is a test |
+
+## Nature of the work
+
+Mostly mechanical ctx threading. A partial migration already exists as
+precedent: `App.outgoingRelationsCtx(ctx,...)` (ctx-aware) sits alongside the
+legacy `App.outgoingRelations(id)` background-ctx wrapper; the work is to push
+the Ctx variants up through the call chains and retire the
+`context.Background()` wrappers. Several `context.Background()` calls are
+genuine bugs where request cancellation cannot propagate (see RR-JWDHH, already
+noted in review history).
+
+## Acceptance
+
+- `contextcheck` enabled in `.golangci.yml`, the explanatory comment block removed.
+- `just lint` clean (no contextcheck violations, no new violations from other linters).
+- No behavioral regressions — the threaded ctx must be the actual request/caller ctx, not a swapped-in `context.Background()`.

--- a/tickets/relations/TKT-B11W0--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-B11W0--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-B11W0
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-B11W0--has-implementation--IMPL-H250G.md
+++ b/tickets/relations/TKT-B11W0--has-implementation--IMPL-H250G.md
@@ -1,0 +1,5 @@
+---
+from: TKT-B11W0
+relation: has-implementation
+to: IMPL-H250G
+---

--- a/tickets/relations/TKT-B11W0--has-planning--PLAN-DTMAB.md
+++ b/tickets/relations/TKT-B11W0--has-planning--PLAN-DTMAB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-B11W0
+relation: has-planning
+to: PLAN-DTMAB
+---

--- a/tickets/relations/TKT-B11W0--has-review--REV-UJ1S7.md
+++ b/tickets/relations/TKT-B11W0--has-review--REV-UJ1S7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-B11W0
+relation: has-review
+to: REV-UJ1S7
+---

--- a/tickets/relations/TKT-B11W0--has-review-response--RR-0VVCI.md
+++ b/tickets/relations/TKT-B11W0--has-review-response--RR-0VVCI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-B11W0
+relation: has-review-response
+to: RR-0VVCI
+---

--- a/tickets/relations/TKT-B11W0--implements--FEAT-022.md
+++ b/tickets/relations/TKT-B11W0--implements--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: TKT-B11W0
+relation: implements
+to: FEAT-022
+---


### PR DESCRIPTION
Enables the `contextcheck` golangci-lint rule (previously commented out in `.golangci.yml`) and resolves the 101 violations it surfaced. Follow-up to TKT-AHUNF, which deferred contextcheck as out-of-scope for that lint-expansion ticket.

## What

Thread the real request/caller `ctx` through every flagged chain so cancellation and request context reach the store/tracer/predicate calls at the bottom — instead of a fresh `context.Background()` minted mid-stack.

| Package | Sites |
|---|---|
| internal/dataentry | 58 |
| internal/mcp | 22 |
| internal/analysis | 7 |
| internal/affordances | 5 |
| internal/scheduler | 3 |
| internal/cli | 2 |
| internal/{validation,script,lua} | 1 each |

## Notable

- **Real cancellation fixes**, not just lint noise: the affordances auth-path predicate eval (`passes → prog.Eval`) now uses the request ctx; `script.Engine.ExecuteAction` gained a real `ctx` param (was previously uncancellable — `actionTimeout` still applies, now *also* cancels on client disconnect / shutdown).
- 4 lua-runtime seams (`RunString`/`RunFileContent`/`RunActionString`/`RunValidationString`) bind ctx once via `lua.WithContext(ctx)`; contextcheck can't follow ctx across the gopher-lua `SetContext` boundary, so these carry a targeted `//nolint:contextcheck` with rationale.
- Pure ctx-threading: no logic or behavior changes. One redundant `Background()`-injecting shim removed.

## Verification

- `just ci` → pass (lint `0 issues.`, race tests, coverage 77.3% PASS, arch-lint OK, docs up to date)
- cranky-code-reviewer: no critical/significant/minor findings

Closes TKT-B11W0.