### PR TITLE
fix(renumber): route writes through Manager / emit audit records (#886)

### DIFF
--- a/internal/cli/renumber.go
+++ b/internal/cli/renumber.go
@@ -56,14 +56,15 @@ func (c *RenumberCmd) Run(ctx context.Context, svc *cliServices) error {
 		return nil
 	}
 
+	// Write through entitymanager.Manager (not the store directly) so every
+	// renumber emits an audit record and passes ACL, like all other write
+	// paths. A merge-style RelationOptions carrying only the order property is
+	// enough — Manager preserves the relation's other properties and content.
+	// See issue #886.
+	em := svc.EntityManager()
 	for _, p := range plan {
-		props := make(map[string]interface{}, len(p.rel.Properties)+1)
-		for k, v := range p.rel.Properties {
-			props[k] = v
-		}
-		props[p.prop] = p.newVal
-		data := store.RelationData{Properties: props, Content: p.rel.Content}
-		if _, err := st.UpdateRelation(ctx, p.rel.From, p.rel.Type, p.rel.To, data); err != nil {
+		opts := entity.RelationOptions{Properties: map[string]interface{}{p.prop: p.newVal}}
+		if _, err := em.UpdateRelation(ctx, p.rel.From, p.rel.Type, p.rel.To, opts); err != nil {
 			return fmt.Errorf("renumber write failed for %s--%s--%s: %w", p.rel.From, p.rel.Type, p.rel.To, err)
 		}
 	}

--- a/internal/entitymanager/manager_order.go
+++ b/internal/entitymanager/manager_order.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"sort"
 
+	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -185,6 +186,14 @@ func (m *Manager) maybeRenumberSide(ctx context.Context, q store.RelationQuery, 
 		plan = append(plan, planEntry{rel: r, newVal: newVal})
 	}
 
+	// Renumber writes go directly to the store rather than through
+	// Manager.UpdateRelation: that method calls runRenumberAfterUpdate, so
+	// routing renumber through it would recurse (renumber → update → renumber).
+	// To keep these cascaded writes traceable anyway, emit one audit record per
+	// write here — the same approach cascadeHost uses for cascade deletes
+	// (cascadehost.go). The triggered-by marker distinguishes renumber writes
+	// from the user-initiated UpdateRelation that spawned them. See issue #886.
+	renumberCtx := audit.WithTriggeredBy(ctx, "renumber:"+prop)
 	for _, p := range plan {
 		props := make(map[string]interface{}, len(p.rel.Properties)+1)
 		for k, v := range p.rel.Properties {
@@ -192,9 +201,11 @@ func (m *Manager) maybeRenumberSide(ctx context.Context, q store.RelationQuery, 
 		}
 		props[prop] = p.newVal
 		data := store.RelationData{Properties: props, Content: p.rel.Content}
-		if _, err := m.deps.Store.UpdateRelation(ctx, p.rel.From, p.rel.Type, p.rel.To, data); err != nil {
+		updated, err := m.deps.Store.UpdateRelation(ctx, p.rel.From, p.rel.Type, p.rel.To, data)
+		if err != nil {
 			return fmt.Errorf("renumber write failed for %s--%s--%s: %w", p.rel.From, p.rel.Type, p.rel.To, err)
 		}
+		m.recordRelationAudit(renumberCtx, audit.OpUpdateRelation, updated, "renumbered "+prop)
 	}
 	return nil
 }

--- a/internal/entitymanager/orderable_test.go
+++ b/internal/entitymanager/orderable_test.go
@@ -59,19 +59,28 @@ func orderableMetamodel(t *testing.T, mode string) *metamodel.Metamodel {
 
 func newOrderableManager(t *testing.T, mode string) (*entitymanager.Manager, store.Store) {
 	t.Helper()
+	mgr, st, _ := newOrderableManagerWithAudit(t, mode)
+	return mgr, st
+}
+
+// newOrderableManagerWithAudit is newOrderableManager with a capturing audit
+// sink so tests can assert which writes produced records (issue #886).
+func newOrderableManagerWithAudit(t *testing.T, mode string) (*entitymanager.Manager, store.Store, *audit.Memory) {
+	t.Helper()
 	st := memstore.New()
+	mem := audit.NewMemory()
 	deps := entitymanager.Deps{
 		Store:     st,
 		Meta:      orderableMetamodel(t, mode),
 		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
+		Audit:     mem,
 		ACL:       acl.NopACL{},
 	}
 	mgr, err := entitymanager.New(deps)
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)
 	}
-	return mgr, st
+	return mgr, st, mem
 }
 
 func mkRecipe(t *testing.T, mgr *entitymanager.Manager, title string) *entity.Entity {
@@ -278,5 +287,54 @@ func TestUpdateRelation_RejectsNonFiniteOrder(t *testing.T) {
 				t.Errorf("_order_out should remain 1.0 after rejected update, got %v", got.Properties[metamodel.OrderPropertyOut])
 			}
 		})
+	}
+}
+
+// TestRenumber_EmitsAuditRecords pins issue #886: engine-triggered renumber
+// writes (maybeRenumberSide) must produce audit records, marked with a
+// renumber: triggered-by so they are distinguishable from the user-initiated
+// UpdateRelation that spawned them.
+func TestRenumber_EmitsAuditRecords(t *testing.T) {
+	mgr, _, mem := newOrderableManagerWithAudit(t, "outgoing")
+	ctx := context.Background()
+	recipe := mkRecipe(t, mgr, "X")
+	s1 := mkStep(t, mgr, "S1")
+	s2 := mkStep(t, mgr, "S2")
+	s3 := mkStep(t, mgr, "S3")
+
+	// Steps get dense orders 1, 2, 3.
+	for _, s := range []*entity.Entity{s1, s2, s3} {
+		if _, err := mgr.CreateRelation(ctx, recipe.ID, "has-step", s.ID, entity.RelationOptions{}); err != nil {
+			t.Fatalf("create relation: %v", err)
+		}
+	}
+
+	// Collapse s3's order onto s2's (gap < threshold) -> triggers renumber of
+	// the outgoing side. The update itself is one audited write; the renumber
+	// writes are additional records.
+	before := len(mem.Records())
+	if _, err := mgr.UpdateRelation(ctx, recipe.ID, "has-step", s3.ID, entity.RelationOptions{
+		Properties: map[string]interface{}{metamodel.OrderPropertyOut: 2.0},
+	}); err != nil {
+		t.Fatalf("update relation: %v", err)
+	}
+
+	var update, renumber int
+	for _, r := range mem.Records()[before:] {
+		if r.Op != audit.OpUpdateRelation {
+			continue
+		}
+		if strings.HasPrefix(r.TriggeredBy, "renumber:") {
+			renumber++
+		} else {
+			update++
+		}
+	}
+
+	if update < 1 {
+		t.Errorf("want at least 1 user-initiated update-relation record, got %d", update)
+	}
+	if renumber < 1 {
+		t.Errorf("want at least 1 renumber audit record (issue #886), got %d", renumber)
 	}
 }

--- a/tickets/entities/automated-measures/renumber-audit-record-test.md
+++ b/tickets/entities/automated-measures/renumber-audit-record-test.md
@@ -1,0 +1,9 @@
+---
+id: renumber-audit-record-test
+type: automated-measure
+title: 'Test: renumber writes emit audit records'
+description: 'Regression test for BUG-Q7GYJ. TestRenumber_EmitsAuditRecords collapses sibling order spacing so an UpdateRelation triggers maybeRenumberSide, then asserts the cascaded renumber writes emit update-relation audit records carrying a renumber: triggered-by marker — distinct from the user-initiated update. Guards against renumber writes silently bypassing the audit log again. The CLI path (rela renumber) is covered structurally by routing through entitymanager.Manager, which all audited write paths use.'
+kind: test
+location: internal/entitymanager/orderable_test.go (TestRenumber_EmitsAuditRecords)
+status: active
+---

--- a/tickets/entities/bugs/BUG-Q7GYJ.md
+++ b/tickets/entities/bugs/BUG-Q7GYJ.md
@@ -1,0 +1,41 @@
+---
+id: BUG-Q7GYJ
+type: bug
+title: rela renumber bypasses Manager — no audit records emitted
+description: |-
+    Two renumber write paths wrote directly to `store.Store` via `st.UpdateRelation`, bypassing `entitymanager.Manager`, so neither produced audit records:
+
+    1. **`rela renumber` (CLI)** — `internal/cli/renumber.go` wrote each renumbered relation straight to the store. A user-initiated write with no audit trail at all.
+    2. **Engine renumber (`maybeRenumberSide`)** — `internal/entitymanager/manager_order.go` rewrites sibling order values to dense ordinals when an `UpdateRelation` collapses spacing. While the triggering update is audited, the cascaded renumber writes themselves were not traceable.
+
+    This violates the architecture rule in CLAUDE.md: *"New write paths inherit audit automatically. Any code that calls entitymanager.Manager.{Create,Update,Delete,Rename}{Entity,Relation} produces a record without further wiring."* Both sites skipped that path.
+
+    **Fix:**
+    - **CLI (Site 1):** route writes through `svc.EntityManager().UpdateRelation` with a merge-style `RelationOptions`. This emits an audit record AND applies ACL, consistent with every other write path. Verified live: `rela renumber` now writes `.rela/audit/<date>.jsonl` (previously the audit dir was never even created).
+    - **Engine (Site 2):** routing `maybeRenumberSide` through `Manager.UpdateRelation` would recurse (UpdateRelation → runRenumberAfterUpdate → maybeRenumberSide → …), so instead it emits an audit record directly per renumber write — the same approach `cascadeHost` uses for cascade deletes — on a context marked `WithTriggeredBy("renumber:<prop>")`. This makes the cascaded writes traceable and distinguishable from the user write that spawned them, without the re-entrancy hazard.
+priority: medium
+effort: s
+why1: rela renumber wrote relations directly to store.Store, so no audit record was produced for a user-initiated write.
+why2: The command predates the audit log and was never migrated to the Manager write path when audit was added; the engine-internal renumber (maybeRenumberSide) likewise wrote to the store directly.
+why3: The maybeRenumberSide helper writes to the store deliberately — routing it through Manager.UpdateRelation would recurse, since UpdateRelation triggers the renumber cleanup pass. That correct avoidance of recursion also (incorrectly) skipped audit emission.
+why4: There was no single chokepoint that guarantees "a relation write is audited"; audit emission lives inside Manager.UpdateRelation, so any code that writes to the store directly silently opts out — the rule is documented in CLAUDE.md but not mechanically enforced.
+why5: The system has two legitimate write tiers (Manager for human intent, store-direct for engine cascades) but only the Manager tier emits audit; cascade-tier writes must each remember to emit a record (as cascadeHost does). Renumber is a cascade-tier write that forgot — the systemic root is that cascade-tier audit is by-convention, not enforced.
+prevention: |-
+    Regression test `TestRenumber_EmitsAuditRecords` in
+    `internal/entitymanager/orderable_test.go` collapses sibling order
+    spacing to trigger maybeRenumberSide and asserts that renumber writes
+    emit update-relation audit records carrying a `renumber:` triggered-by
+    marker (distinct from the user-initiated update).
+
+    The CLI path is covered by routing through entitymanager.Manager, which
+    every other audited write path already uses — so it now inherits audit
+    and ACL automatically rather than re-implementing a store write.
+
+    Systemic follow-up (tracked separately): the cascade write tier emits
+    audit by convention (cascadeHost and now renumber each call
+    recordRelationAudit by hand). A shared cascade-write helper that emits
+    the record would make the guarantee structural rather than by-convention.
+status: done
+---
+
+See GitHub issue #886.

--- a/tickets/relations/BUG-Q7GYJ--adds-measure--renumber-audit-record-test.md
+++ b/tickets/relations/BUG-Q7GYJ--adds-measure--renumber-audit-record-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-Q7GYJ
+relation: adds-measure
+to: renumber-audit-record-test
+---

--- a/tickets/relations/BUG-Q7GYJ--affects--audit-log.md
+++ b/tickets/relations/BUG-Q7GYJ--affects--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: BUG-Q7GYJ
+relation: affects
+to: audit-log
+---

--- a/tickets/relations/BUG-Q7GYJ--fixes--FEAT-831A.md
+++ b/tickets/relations/BUG-Q7GYJ--fixes--FEAT-831A.md
@@ -1,0 +1,5 @@
+---
+from: BUG-Q7GYJ
+relation: fixes
+to: FEAT-831A
+---


### PR DESCRIPTION
Fixes #886.

## Problem

Two renumber write paths wrote directly to `store.Store`, bypassing `entitymanager.Manager`, so neither produced audit records — violating the CLAUDE.md rule that all write paths inherit audit via the Manager:

1. **`rela renumber` (CLI)** — `internal/cli/renumber.go` wrote each relation straight to the store. A user-initiated write with **no audit trail at all**.
2. **Engine renumber (`maybeRenumberSide`)** — rewrites sibling order values to dense ordinals when an `UpdateRelation` collapses spacing. The triggering update is audited, but the cascaded renumber writes were not traceable.

## Fix (the two sites are different cases)

- **CLI (Site 1):** route through `svc.EntityManager().UpdateRelation` with a merge-style `RelationOptions`. Emits an audit record **and** applies ACL, consistent with every other write path.
- **Engine (Site 2):** routing `maybeRenumberSide` through `Manager.UpdateRelation` would **recurse** (`UpdateRelation → runRenumberAfterUpdate → maybeRenumberSide → …`). So instead it emits an audit record directly per renumber write — the same pattern `cascadeHost` uses for cascade deletes — on a context marked `WithTriggeredBy("renumber:<prop>")`. Traceable, distinguishable from the user write, no re-entrancy hazard.

## Verification

- **Live:** a throwaway project with collapsed order values, `rela renumber` → `.rela/audit/<date>.jsonl` now contains an `update-relation` record (`principal: jeroen/cli`, subject `REC-001 --has-step--> STP-003`). Previously the audit dir was never even created.
- **Test:** `TestRenumber_EmitsAuditRecords` collapses sibling spacing to trigger `maybeRenumberSide` and asserts renumber writes emit `update-relation` records carrying the `renumber:` triggered-by marker.
- `go build ./...`, `go test ./internal/entitymanager/ ./internal/cli/`, `golangci-lint`, `just arch-lint` — clean.

## Note

The cascade write tier emits audit by convention (cascadeHost and now renumber each call `recordRelationAudit` by hand). A shared cascade-write helper that emits the record structurally would make this a guarantee rather than a convention — flagged as systemic follow-up in the bug's `prevention`, out of scope here.

Dogfood: BUG-Q7GYJ (`fixes` FEAT-831A, `affects` audit-log, `adds-measure` renumber-audit-record-test).