### PR TITLE
fix(delete): fail-secure cascade delete, stop swallowing relation I/O errors (#888)

### DIFF
--- a/internal/entitymanager/cascadehost.go
+++ b/internal/entitymanager/cascadehost.go
@@ -2,7 +2,6 @@ package entitymanager
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -120,32 +119,22 @@ func (h *cascadeHost) DeleteEntity(ctx context.Context, _, id string, cascade bo
 		return ErrHasRelations
 	}
 
+	// Delegate to the store's cascade (single lock, fail-secure on a
+	// relation-file error) and audit exactly what it reports deleting, the
+	// same way Manager.DeleteEntity does. A real error surfaces instead of
+	// being swallowed, so a replacement never leaves orphaned relations
+	// behind a deleted entity (issue #888).
+	res, delErr := h.deps.Store.DeleteEntity(ctx, id, cascade)
+	if delErr != nil {
+		return fmt.Errorf("delete entity: %w", delErr)
+	}
+
 	cascadeCtx := ctx
-	if cascade && (len(incoming)+len(outgoing)) > 0 {
+	if cascade && len(res.DeletedRelations) > 0 {
 		cascadeCtx = audit.WithTriggeredBy(ctx, "cascade:delete-entity:"+id)
 	}
-
-	for _, rel := range incoming {
-		if delErr := h.deps.Store.DeleteRelation(ctx, rel.From, rel.Type, rel.To); delErr != nil &&
-			!errors.Is(delErr, store.ErrNotFound) {
-
-			continue
-		}
+	for _, rel := range res.DeletedRelations {
 		h.recordCascade(cascadeCtx, audit.OpDeleteRelation, relationSubject(rel), "deleted")
-	}
-	for _, rel := range outgoing {
-		if delErr := h.deps.Store.DeleteRelation(ctx, rel.From, rel.Type, rel.To); delErr != nil &&
-			!errors.Is(delErr, store.ErrNotFound) {
-
-			continue
-		}
-		h.recordCascade(cascadeCtx, audit.OpDeleteRelation, relationSubject(rel), "deleted")
-	}
-
-	if _, delErr := h.deps.Store.DeleteEntity(ctx, id, false); delErr != nil &&
-		!errors.Is(delErr, store.ErrNotFound) {
-
-		return fmt.Errorf("delete entity: %w", delErr)
 	}
 	h.recordCascade(ctx, audit.OpDeleteEntity, entitySubject(current), "deleted")
 	return nil

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -443,51 +443,38 @@ func (m *Manager) DeleteEntity(ctx context.Context, id string, cascade bool) (*e
 		return nil, ErrHasRelations
 	}
 
-	// Cascade-deleted relations get triggered_by set so the audit log
-	// records the parent op that caused them. Wrap ctx once before the
-	// delete loop — recordRelationAudit reads triggered_by from this
-	// derived ctx, the original ctx still flows to anything else that
-	// needs the un-decorated principal context.
-	cascadeCtx := ctx
-	if cascade && totalRelations > 0 {
-		cascadeCtx = audit.WithTriggeredBy(ctx, "cascade:delete-entity:"+id)
-	}
-
-	deletedRelations := make([]*entity.Relation, 0, totalRelations)
-	for _, rel := range incoming {
-		if delErr := m.deps.Store.DeleteRelation(ctx, rel.From, rel.Type, rel.To); delErr != nil &&
-			!errors.Is(delErr, store.ErrNotFound) {
-
-			continue
-		}
-		deletedRelations = append(deletedRelations, rel)
-		m.recordRelationAudit(cascadeCtx, audit.OpDeleteRelation, rel, "deleted")
-	}
-	for _, rel := range outgoing {
-		if delErr := m.deps.Store.DeleteRelation(ctx, rel.From, rel.Type, rel.To); delErr != nil &&
-			!errors.Is(delErr, store.ErrNotFound) {
-
-			continue
-		}
-		deletedRelations = append(deletedRelations, rel)
-		m.recordRelationAudit(cascadeCtx, audit.OpDeleteRelation, rel, "deleted")
-	}
-
-	if _, delErr := m.deps.Store.DeleteEntity(ctx, id, false); delErr != nil &&
-		!errors.Is(delErr, store.ErrNotFound) {
-
+	// Delegate the actual deletion to the store's cascade, which removes
+	// the relation files and the entity file under a single lock and aborts
+	// fail-secure if any relation file cannot be removed — so the entity is
+	// never deleted while a relation is left behind (issue #888). A real
+	// error surfaces to the caller rather than being swallowed; previously
+	// the Manager looped per-relation and `continue`d past I/O failures,
+	// deleting the entity anyway and leaving orphans untraced.
+	res, delErr := m.deps.Store.DeleteEntity(ctx, id, cascade)
+	if delErr != nil {
 		return nil, fmt.Errorf("delete entity: %w", delErr)
 	}
 
+	// Audit exactly what the store reports deleting. Cascade-deleted
+	// relations carry triggered_by so the log attributes them to this
+	// delete; recordRelationAudit reads it from cascadeCtx.
+	cascadeCtx := ctx
+	if cascade && len(res.DeletedRelations) > 0 {
+		cascadeCtx = audit.WithTriggeredBy(ctx, "cascade:delete-entity:"+id)
+	}
+	for _, rel := range res.DeletedRelations {
+		m.recordRelationAudit(cascadeCtx, audit.OpDeleteRelation, rel, "deleted")
+	}
+
 	deleteSummary := "deleted"
-	if cascade && totalRelations > 0 {
-		deleteSummary = fmt.Sprintf("deleted (cascade: %d relations)", totalRelations)
+	if cascade && len(res.DeletedRelations) > 0 {
+		deleteSummary = fmt.Sprintf("deleted (cascade: %d relations)", len(res.DeletedRelations))
 	}
 	m.recordEntityAudit(ctx, audit.OpDeleteEntity, current, deleteSummary)
 
 	return &entity.DeleteResult{
 		DeletedEntities:  []*entity.Entity{current},
-		DeletedRelations: deletedRelations,
+		DeletedRelations: res.DeletedRelations,
 	}, nil
 }
 

--- a/internal/entitymanager/manager_delete_test.go
+++ b/internal/entitymanager/manager_delete_test.go
@@ -1,0 +1,126 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// failingDeleteStore wraps a store and forces DeleteEntity to return a
+// sentinel error, modeling an I/O failure during cascade cleanup.
+type failingDeleteStore struct {
+	store.Store
+	err error
+}
+
+func (s *failingDeleteStore) DeleteEntity(context.Context, string, bool) (*store.DeleteResult, error) {
+	return nil, s.err
+}
+
+// TestDeleteEntity_PropagatesStoreError pins issue #888: a real error from the
+// store's cascade delete must surface to the caller, not be swallowed. Before
+// the fix, Manager.DeleteEntity looped per-relation and `continue`d past I/O
+// errors, deleting the entity anyway and returning success.
+func TestDeleteEntity_PropagatesStoreError(t *testing.T) {
+	sentinel := errors.New("simulated delete failure")
+	deps := entitymanager.Deps{
+		Store:     &failingDeleteStore{Store: memstore.New(), err: sentinel},
+		Meta:      parseMeta(t),
+		Templater: nopTemplater{},
+		Audit:     audit.Nop{},
+		ACL:       acl.NopACL{},
+	}
+	mgr, err := entitymanager.New(deps)
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+
+	// Seed an entity directly in the underlying store so GetEntity (the
+	// pre-delete lookup) succeeds but the delete itself fails. The failing
+	// store wraps a memstore; seed via that same memstore through the
+	// Manager's create path would also hit the override, so seed the inner
+	// store directly.
+	inner := deps.Store.(*failingDeleteStore).Store
+	if seedErr := inner.CreateEntity(context.Background(), entity.New("REQ-1", "requirement")); seedErr != nil {
+		t.Fatalf("seed: %v", seedErr)
+	}
+
+	_, err = mgr.DeleteEntity(context.Background(), "REQ-1", true)
+	if err == nil {
+		t.Fatal("expected DeleteEntity to propagate the store error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("error = %v, want it to wrap the sentinel store error", err)
+	}
+}
+
+// TestDeleteEntity_CascadeAuditsReportedRelations pins that the cascade delete
+// emits one delete-relation audit record per relation the store reports
+// deleting, each carrying the cascade triggered-by, plus the delete-entity
+// record (issue #888 — audit preserved after delegating to the store cascade).
+func TestDeleteEntity_CascadeAuditsReportedRelations(t *testing.T) {
+	mem := audit.NewMemory()
+	deps := entitymanager.Deps{
+		Store:     memstore.New(),
+		Meta:      parseMeta(t),
+		Templater: nopTemplater{},
+		Audit:     mem,
+		ACL:       acl.NopACL{},
+	}
+	mgr, err := entitymanager.New(deps)
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	ctx := context.Background()
+
+	// decision --addresses--> requirement; deleting the requirement cascades
+	// the relation. IDs are assigned by the sequential id_type, so use the
+	// returned IDs rather than the placeholders passed to entity.New.
+	reqRes, err := mgr.CreateEntity(ctx, entity.New("", "requirement"), entity.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create requirement: %v", err)
+	}
+	decRes, err := mgr.CreateEntity(ctx, entity.New("", "decision"), entity.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create decision: %v", err)
+	}
+	if _, relErr := mgr.CreateRelation(ctx, decRes.Entity.ID, "addresses", reqRes.Entity.ID, entity.RelationOptions{}); relErr != nil {
+		t.Fatalf("create relation: %v", relErr)
+	}
+
+	before := len(mem.Records())
+	res, err := mgr.DeleteEntity(ctx, reqRes.Entity.ID, true)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if len(res.DeletedRelations) != 1 {
+		t.Fatalf("DeletedRelations = %d, want 1", len(res.DeletedRelations))
+	}
+
+	var relRecords, entRecords int
+	for _, r := range mem.Records()[before:] {
+		switch r.Op {
+		case audit.OpDeleteRelation:
+			relRecords++
+			if !strings.HasPrefix(r.TriggeredBy, "cascade:delete-entity:") {
+				t.Errorf("relation record triggered_by = %q, want cascade:delete-entity: prefix", r.TriggeredBy)
+			}
+		case audit.OpDeleteEntity:
+			entRecords++
+		}
+	}
+	if relRecords != 1 {
+		t.Errorf("delete-relation records = %d, want 1", relRecords)
+	}
+	if entRecords != 1 {
+		t.Errorf("delete-entity records = %d, want 1", entRecords)
+	}
+}

--- a/internal/storage/errorfs.go
+++ b/internal/storage/errorfs.go
@@ -11,6 +11,13 @@ import (
 type ErrorFS struct {
 	FS        FS
 	WalkError error // Error to return from Walk
+
+	// RemoveError, when non-nil, is returned from Remove for paths that
+	// satisfy RemoveErrorOn (or for every path when RemoveErrorOn is nil).
+	// The underlying Remove is not attempted when the error fires, so the
+	// wrapped file stays in place — modeling an unremovable file.
+	RemoveError   error
+	RemoveErrorOn func(path string) bool
 }
 
 // NewErrorFS creates an ErrorFS wrapping the given FS.
@@ -27,6 +34,9 @@ func (e *ErrorFS) WriteFile(path string, data []byte, perm os.FileMode) error {
 }
 
 func (e *ErrorFS) Remove(path string) error {
+	if e.RemoveError != nil && (e.RemoveErrorOn == nil || e.RemoveErrorOn(path)) {
+		return e.RemoveError
+	}
 	return e.FS.Remove(path)
 }
 

--- a/internal/store/fsstore/entity.go
+++ b/internal/store/fsstore/entity.go
@@ -304,10 +304,18 @@ func (s *FSStore) DeleteEntity(_ context.Context, id string, cascade bool) (*sto
 		deletedRelations = append(deletedRelations, r)
 	}
 
-	// Delete relation files first, then entity file.
+	// Delete relation files first, then the entity file. A real removal
+	// error (not "already gone") aborts before the entity file is touched
+	// and before the in-memory index is mutated, so the entity is never
+	// removed while one of its relations could not be — fail-secure, no
+	// orphaned-from entity (BUG-C20T / issue #888). Not transactional: a
+	// relation file removed before a later failure stays removed, but the
+	// whole op runs under s.mu and the index is updated only on success.
 	for _, rm := range related {
 		key := s.relationFileKey(rm.From, rm.Type, rm.To)
-		_ = s.rooted.Remove(key)
+		if err := s.rooted.Remove(key); err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("delete relation file %s--%s--%s: %w", rm.From, rm.Type, rm.To, err)
+		}
 		s.echoes.Forget(s.absPath(key))
 	}
 	key := s.entityFileKey(meta.Type, id)

--- a/internal/store/fsstore/recovery_test.go
+++ b/internal/store/fsstore/recovery_test.go
@@ -2,6 +2,7 @@ package fsstore_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -14,6 +15,47 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/fsstore"
 )
+
+// TestDeleteEntity_RelationRemoveError_FailsSecure pins issue #888: when a
+// relation file cannot be removed during a cascade delete, the store must
+// abort with an error and NOT delete the entity — never leaving an entity
+// removed while one of its relations is orphaned.
+func TestDeleteEntity_RelationRemoveError_FailsSecure(t *testing.T) {
+	mem := storage.NewMemFS()
+	ctx := context.Background()
+
+	// Seed an entity with a relation through a normal store.
+	s1 := openStore(t, mem)
+	require.NoError(t, s1.CreateEntity(ctx, entity.New("REQ-1", "requirement")))
+	require.NoError(t, s1.CreateEntity(ctx, entity.New("SOL-1", "solution")))
+	_, err := s1.CreateRelation(ctx, "SOL-1", "implements", "REQ-1", nil)
+	require.NoError(t, err)
+	require.NoError(t, s1.Close())
+
+	// Reopen with an FS that fails to remove relation files.
+	errFS := storage.NewErrorFS(mem)
+	errFS.RemoveError = errors.New("simulated I/O failure")
+	errFS.RemoveErrorOn = func(path string) bool { return strings.Contains(path, "/relations/") }
+	rooted, err := storage.NewRootedFS(errFS, "/")
+	require.NoError(t, err)
+	cfg := newConfig(mem)
+	cfg.FS = errFS
+	cfg.Rooted = rooted
+	s2, err := fsstore.New(cfg)
+	require.NoError(t, err)
+	defer s2.Close()
+
+	// Cascade delete must fail (the relation file can't be removed)...
+	_, err = s2.DeleteEntity(ctx, "REQ-1", true)
+	require.Error(t, err)
+
+	// ...and the entity must still exist — not orphaned behind a deleted
+	// entity. The relation is still present too.
+	_, err = s2.GetEntity(ctx, "REQ-1")
+	require.NoError(t, err, "entity must survive a failed cascade delete")
+	_, err = s2.GetRelation(ctx, "SOL-1", "implements", "REQ-1")
+	require.NoError(t, err, "relation must survive a failed cascade delete")
+}
 
 // --- Orphaned temp file cleanup ---
 

--- a/tickets/entities/automated-measures/deleteentity-failsecure-test.md
+++ b/tickets/entities/automated-measures/deleteentity-failsecure-test.md
@@ -1,0 +1,9 @@
+---
+id: deleteentity-failsecure-test
+type: automated-measure
+title: 'Test: DeleteEntity is fail-secure on relation-cleanup I/O errors'
+description: 'Regression tests for BUG-2W3AJ. TestDeleteEntity_RelationRemoveError_FailsSecure (fsstore) injects a relation-file Remove failure via storage.ErrorFS and asserts the cascade delete errors and leaves both entity and relation in place (never orphaned). TestDeleteEntity_PropagatesStoreError and TestDeleteEntity_CascadeAuditsReportedRelations (entitymanager) assert the Manager surfaces a store delete error rather than swallowing it, and that a successful cascade emits one delete-relation audit record per reported relation plus the delete-entity record.'
+kind: test
+location: internal/store/fsstore/recovery_test.go (TestDeleteEntity_RelationRemoveError_FailsSecure) + internal/entitymanager/manager_delete_test.go (TestDeleteEntity_PropagatesStoreError, TestDeleteEntity_CascadeAuditsReportedRelations)
+status: active
+---

--- a/tickets/entities/bugs/BUG-2W3AJ.md
+++ b/tickets/entities/bugs/BUG-2W3AJ.md
@@ -1,0 +1,43 @@
+---
+id: BUG-2W3AJ
+type: bug
+title: DeleteEntity silently swallows I/O errors on relation cleanup
+description: |-
+    `Manager.DeleteEntity` and `cascadeHost.DeleteEntity` looped over a deleted entity's incident relations and, on a non-`ErrNotFound` error from `DeleteRelation`, executed `continue` — no log, no audit record, no error returned. Execution then fell through to deleting the entity anyway. Result: the entity is removed while one or more of its relations are left behind — an inconsistent store state, silently. The store has no transaction, so there is no rollback.
+
+    A secondary quirk: when a relation was already gone (`ErrNotFound`), the loop still emitted a "deleted" audit record for a deletion that never happened.
+
+    **Fix (fail-secure, per ISMS direction):**
+    - **Store (`fsstore.DeleteEntity`):** the cascade path stopped swallowing relation-file removal errors. A real `Remove` error now aborts before the entity file is touched and before the in-memory index is mutated, so the entity is never removed while a relation could not be — the store holds its lock for the whole op. (Still not transactional: a relation file removed before a later failure stays removed; but the entity is never orphaned-from.)
+    - **Manager + cascadeHost:** replaced the per-relation delete loop with a single `store.DeleteEntity(cascade)` call, then emit one audit record per relation the store reports deleting (with the `cascade:delete-entity:<id>` triggered-by) plus the entity record. This removes the duplicated cleanup logic, keeps full per-relation audit, surfaces real errors to callers instead of swallowing them, and eliminates the phantom `ErrNotFound` record.
+
+    **Behavior change (intended):** a relation that genuinely cannot be removed now surfaces as a failed delete to HTTP / MCP / CLI / Lua / cascade callers, rather than a silent "success" with an orphan left behind.
+priority: medium
+effort: m
+why1: A non-ErrNotFound error from DeleteRelation in the cascade loop was handled with `continue` — silently skipped, with no log, no audit, no returned error.
+why2: The loop's intent was best-effort cleanup (delete what you can), but it also fell through to deleting the entity regardless, so a partial failure left the entity gone and a relation orphaned.
+why3: The Manager re-implemented relation cleanup as its own loop (instead of using the store's atomic cascade) specifically so it could emit a per-relation audit record — the store cascade emits none — which is why the swallow lived at the Manager layer.
+why4: Even the store's own cascade ignored relation-file removal errors (`_ = s.rooted.Remove(...)`), so delegating alone wouldn't have been fail-secure — both layers swallowed.
+why5: There is no transactional delete primitive and no single chokepoint guaranteeing "an entity is only removed once all its relations are"; consistency on multi-file deletes was by-convention, and the convention silently degraded on I/O error.
+prevention: |-
+    Two regression tests pin the fix:
+
+    - `TestDeleteEntity_RelationRemoveError_FailsSecure`
+      (`internal/store/fsstore/recovery_test.go`) injects a relation-file
+      Remove failure via storage.ErrorFS and asserts the cascade delete
+      errors AND leaves both the entity and the relation in place — never
+      orphaned.
+    - `TestDeleteEntity_PropagatesStoreError` and
+      `TestDeleteEntity_CascadeAuditsReportedRelations`
+      (`internal/entitymanager/manager_delete_test.go`) assert the Manager
+      surfaces a store delete error instead of swallowing it, and that a
+      successful cascade emits one delete-relation audit record per reported
+      relation (with the cascade triggered-by) plus the delete-entity record.
+
+    storage.ErrorFS gained a configurable Remove fault (RemoveError /
+    RemoveErrorOn) so future store error-path tests have a reusable way to
+    inject filesystem failures.
+status: done
+---
+
+See GitHub issue #888 (also referenced as BUG-C20T).

--- a/tickets/relations/BUG-2W3AJ--adds-measure--deleteentity-failsecure-test.md
+++ b/tickets/relations/BUG-2W3AJ--adds-measure--deleteentity-failsecure-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-2W3AJ
+relation: adds-measure
+to: deleteentity-failsecure-test
+---

--- a/tickets/relations/BUG-2W3AJ--affects--store-backends.md
+++ b/tickets/relations/BUG-2W3AJ--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-2W3AJ
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-2W3AJ--fixes--FEAT-831A.md
+++ b/tickets/relations/BUG-2W3AJ--fixes--FEAT-831A.md
@@ -1,0 +1,5 @@
+---
+from: BUG-2W3AJ
+relation: fixes
+to: FEAT-831A
+---


### PR DESCRIPTION
Fixes #888 (BUG-C20T).

## Problem

`Manager.DeleteEntity` and `cascadeHost.DeleteEntity` looped over a deleted entity's relations and, on a real (non-`ErrNotFound`) `DeleteRelation` error, executed `continue` — no log, no audit, no returned error — then **deleted the entity anyway**. Result: entity gone, orphan relation left behind, silently. (Secondary quirk: an already-gone relation still emitted a phantom "deleted" audit record.)

## Fix — fail-secure (per ISMS direction)

- **Store (`fsstore.DeleteEntity`):** the cascade path stops swallowing relation-file `Remove` errors. A real error aborts **before** the entity file is touched and before the in-memory index is mutated, so the entity is never removed while a relation couldn't be. The whole op runs under one lock. (Not transactional — a relation removed before a later failure stays removed — but the entity is never orphaned-from.)
- **Manager + cascadeHost:** replaced the per-relation delete loop with a single `store.DeleteEntity(cascade)` call, then emit one audit record per relation the store reports deleting (with the `cascade:delete-entity:<id>` triggered-by) plus the entity record. Removes duplicated cleanup logic, **keeps full per-relation audit**, surfaces real errors, and eliminates the phantom `ErrNotFound` record.

**Behavior change (intended):** an unremovable relation now surfaces as a failed delete to HTTP/MCP/CLI/Lua/cascade callers instead of a silent success-with-orphan.

## Tests

- `TestDeleteEntity_RelationRemoveError_FailsSecure` (fsstore): injects a relation-file Remove failure via `storage.ErrorFS`; asserts the delete errors AND leaves entity + relation intact.
- `TestDeleteEntity_PropagatesStoreError` / `TestDeleteEntity_CascadeAuditsReportedRelations` (entitymanager): Manager surfaces the store error; a successful cascade audits each reported relation + the entity.
- `storage.ErrorFS` gained a configurable `Remove` fault (`RemoveError`/`RemoveErrorOn`) — reusable for future store error-path tests.

## Verification

- **Live:** CLI cascade delete still works; audit log shows `delete-relation … triggered_by=cascade:delete-entity:REC-001` + `delete-entity`.
- `go build ./...`, `go test ./internal/{entitymanager,store/...,storage,autocascade,dataentry,mcp,cli,lua}`, `golangci-lint`, `just arch-lint` — clean.

Dogfood: BUG-2W3AJ (`fixes` FEAT-831A, `affects` store-backends, `adds-measure` deleteentity-failsecure-test).