### PR TITLE
feat(store): generic GraphQuery DSL + naive impl + conformance suite (TKT-ZYH3)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -72,6 +72,7 @@ components:
   store:            { in: internal/store }
   fsstore:          { in: internal/store/fsstore }
   memstore:         { in: internal/store/memstore }
+  graphquerynaive:  { in: internal/store/graphquerynaive }
   pgstore:          { in: internal/store/pgstore }
   storeutil:        { in: internal/store/storeutil }
 
@@ -533,6 +534,7 @@ deps:
   fsstore:
     mayDependOn:
       - cache
+      - graphquerynaive
       - storage
       - store
       - storeutil
@@ -540,10 +542,16 @@ deps:
       - goldmark
   memstore:
     mayDependOn:
+      - graphquerynaive
       - store
       - storeutil
+  graphquerynaive:
+    mayDependOn:
+      - entity
+      - store
   pgstore:
     mayDependOn:
+      - graphquerynaive
       - search
       - store
       - storeutil

--- a/internal/store/fsstore/graphquery.go
+++ b/internal/store/fsstore/graphquery.go
@@ -1,0 +1,22 @@
+package fsstore
+
+import (
+	"context"
+	"iter"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/graphquerynaive"
+)
+
+// GraphQuery delegates to the shared naive implementation. An
+// index-backed implementation that exploits fsstore's by-from /
+// by-to relation indexes (once added) is a natural follow-up.
+func (s *FSStore) GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*entity.Entity, error] {
+	return graphquerynaive.Run(ctx, s, q)
+}
+
+// GraphCount currently delegates to the shared naive implementation.
+func (s *FSStore) GraphCount(ctx context.Context, q store.GraphQuery) (matched, total int, err error) {
+	return graphquerynaive.Count(ctx, s, q)
+}

--- a/internal/store/graphquery.go
+++ b/internal/store/graphquery.go
@@ -1,0 +1,64 @@
+package store
+
+import (
+	"context"
+	"iter"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// GraphQuery describes a graph-shape question: "entities of EntityType
+// where they have a matching inbound or outbound relation." The DSL is
+// intentionally generic — no ACL or other consumer vocabulary — so
+// future consumers (ACL read filtering, analyze tools, search) can
+// compose against one stable shape.
+//
+// All three backends ship a default implementation that delegates to
+// [internal/store/graphquerynaive] (iterate-and-filter in Go). A
+// future SQL-pushdown implementation in pgstore is tracked as a
+// follow-up.
+type GraphQuery struct {
+	EntityType  string
+	HasInbound  *RelationPredicate // entity has matching relation FROM (expanded) endpoints
+	HasOutbound *RelationPredicate // entity has matching relation TO (expanded) endpoints
+}
+
+// RelationPredicate restricts which relations the surrounding
+// GraphQuery is willing to match through.
+//
+// Two transitive expansions, independent and composable:
+//
+//   - InheritThrough (endpoint-side) transitively expands Endpoints via
+//     these relation types up to Depth. Example: ACL group expansion
+//     (InheritThrough = ["member-of"]).
+//   - EntityInheritThrough (entity-side) transitively expands the
+//     candidate entity via these relation types up to EntityDepth; the
+//     match succeeds if any ancestor of the candidate (including itself)
+//     has the inbound/outbound edge. Example: ACL containment
+//     inheritance (EntityInheritThrough = ["belongs-to"]).
+type RelationPredicate struct {
+	Endpoints []string
+	OfTypes   []string
+
+	InheritThrough []string
+	Depth          int
+
+	EntityInheritThrough []string
+	EntityDepth          int
+}
+
+// GraphQueryer is the read-side interface for graph-shape queries.
+// Embedded into Store; surfaces independently so backend
+// implementations can be written and tested without the full Store.
+type GraphQueryer interface {
+	// GraphQuery returns an iterator over entities matching q. The
+	// iterator yields (*entity.Entity, nil) for each match; on error
+	// the iterator yields (nil, err) and terminates.
+	GraphQuery(ctx context.Context, q GraphQuery) iter.Seq2[*entity.Entity, error]
+
+	// GraphCount returns (matched, total): the number of entities of
+	// q.EntityType that satisfy q's predicates, and the total number of
+	// entities of q.EntityType ignoring those predicates. Callers use
+	// (total - matched) for "filtered by" counts.
+	GraphCount(ctx context.Context, q GraphQuery) (matched, total int, err error)
+}

--- a/internal/store/graphquerynaive/naive.go
+++ b/internal/store/graphquerynaive/naive.go
@@ -1,0 +1,215 @@
+// Package graphquerynaive ships the unoptimised, backend-agnostic
+// implementation of [store.GraphQueryer]. All three of memstore,
+// fsstore, and pgstore delegate to it today — keeping the algorithm
+// in one place is the structural defense against behavior diverging
+// across backends.
+//
+// Backends are expected to swap this for push-down implementations
+// where the underlying engine can do better (recursive CTE in
+// pgstore, index-backed walks in fsstore). Each swap remains
+// behavioral-compatible because it is verified against the same
+// inputs as the naive impl.
+package graphquerynaive
+
+import (
+	"context"
+	"iter"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// Reader is the narrow read surface graphquerynaive needs. Declared
+// here so backend implementations can pass `s` directly without
+// constructing an adapter.
+type Reader interface {
+	ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error]
+	ListRelations(ctx context.Context, q store.RelationQuery) iter.Seq2[*entity.Relation, error]
+}
+
+// DepthCap bounds every transitive walk performed by the naive
+// implementation, as a safety backstop. The primary termination
+// mechanism is the visited-set inside [expandSet]; the cap defends
+// against pathological inputs (huge fan-out, deep chains) where
+// even bounded BFS would be too expensive.
+//
+// Exported so a caller that supplies a [GraphQuery.HasInbound.Depth]
+// (or EntityDepth) can pin its own cap to the same value when it
+// wants symmetric behavior. Backends that implement [GraphQuery]
+// via natural-termination primitives (recursive-CTE UNION, etc.)
+// are free to ignore this cap unless they'd expand past it.
+const DepthCap = 5
+
+// depthCap is the unexported alias for in-package use.
+const depthCap = DepthCap
+
+// Run executes q against r and yields matching entities. Errors abort
+// the iterator.
+func Run(ctx context.Context, r Reader, q store.GraphQuery) iter.Seq2[*entity.Entity, error] {
+	return func(yield func(*entity.Entity, error) bool) {
+		candidates, err := collectByType(ctx, r, q.EntityType)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		for _, e := range candidates {
+			ok, err := matches(ctx, r, e, q)
+			if err != nil {
+				if !yield(nil, err) {
+					return
+				}
+				continue
+			}
+			if ok {
+				if !yield(e, nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Count returns (matched, total) for q against r.
+func Count(ctx context.Context, r Reader, q store.GraphQuery) (matched, total int, err error) {
+	candidates, err := collectByType(ctx, r, q.EntityType)
+	if err != nil {
+		return 0, 0, err
+	}
+	total = len(candidates)
+	for _, e := range candidates {
+		ok, mErr := matches(ctx, r, e, q)
+		if mErr != nil {
+			return matched, total, mErr
+		}
+		if ok {
+			matched++
+		}
+	}
+	return matched, total, nil
+}
+
+func collectByType(ctx context.Context, r Reader, typ string) ([]*entity.Entity, error) {
+	var out []*entity.Entity
+	for e, err := range r.ListEntities(ctx, store.EntityQuery{Type: typ}) {
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+func matches(ctx context.Context, r Reader, e *entity.Entity, q store.GraphQuery) (bool, error) {
+	if q.HasInbound != nil {
+		ok, err := matchesPredicate(ctx, r, e, *q.HasInbound, store.DirectionIncoming)
+		if err != nil || !ok {
+			return ok, err
+		}
+	}
+	if q.HasOutbound != nil {
+		ok, err := matchesPredicate(ctx, r, e, *q.HasOutbound, store.DirectionOutgoing)
+		if err != nil || !ok {
+			return ok, err
+		}
+	}
+	return true, nil
+}
+
+func matchesPredicate(
+	ctx context.Context, r Reader, e *entity.Entity,
+	p store.RelationPredicate, dir store.Direction,
+) (bool, error) {
+	endpoints, err := expandSet(ctx, r, p.Endpoints, p.InheritThrough, p.Depth)
+	if err != nil {
+		return false, err
+	}
+	candidates, err := expandSet(ctx, r, []string{e.ID}, p.EntityInheritThrough, p.EntityDepth)
+	if err != nil {
+		return false, err
+	}
+
+	endpointSet := make(map[string]bool, len(endpoints))
+	for _, ep := range endpoints {
+		endpointSet[ep] = true
+	}
+	typeSet := make(map[string]bool, len(p.OfTypes))
+	for _, t := range p.OfTypes {
+		typeSet[t] = true
+	}
+
+	for _, c := range candidates {
+		for rel, err := range r.ListRelations(ctx, store.RelationQuery{
+			EntityID:  c,
+			Direction: dir,
+		}) {
+			if err != nil {
+				return false, err
+			}
+			if len(typeSet) > 0 && !typeSet[rel.Type] {
+				continue
+			}
+			var other string
+			if dir == store.DirectionIncoming {
+				other = rel.From
+			} else {
+				other = rel.To
+			}
+			if endpointSet[other] {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// expandSet returns seeds plus everything reachable via the given
+// relation types up to depth. BFS with visited-set; depth is bounded
+// by depthCap.
+func expandSet(ctx context.Context, r Reader, seeds, through []string, depth int) ([]string, error) {
+	if len(seeds) == 0 {
+		return nil, nil
+	}
+	if depth > depthCap {
+		depth = depthCap
+	}
+	visited := make(map[string]bool, len(seeds))
+	order := make([]string, 0, len(seeds))
+	for _, s := range seeds {
+		if !visited[s] {
+			visited[s] = true
+			order = append(order, s)
+		}
+	}
+	if len(through) == 0 || depth <= 0 {
+		return order, nil
+	}
+	throughSet := make(map[string]bool, len(through))
+	for _, t := range through {
+		throughSet[t] = true
+	}
+	frontier := append([]string(nil), order...)
+	for d := 0; d < depth && len(frontier) > 0; d++ {
+		var next []string
+		for _, n := range frontier {
+			for rel, err := range r.ListRelations(ctx, store.RelationQuery{
+				EntityID:  n,
+				Direction: store.DirectionOutgoing,
+			}) {
+				if err != nil {
+					return order, err
+				}
+				if !throughSet[rel.Type] {
+					continue
+				}
+				if visited[rel.To] {
+					continue
+				}
+				visited[rel.To] = true
+				order = append(order, rel.To)
+				next = append(next, rel.To)
+			}
+		}
+		frontier = next
+	}
+	return order, nil
+}

--- a/internal/store/memstore/graphquery.go
+++ b/internal/store/memstore/graphquery.go
@@ -1,0 +1,21 @@
+package memstore
+
+import (
+	"context"
+	"iter"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/graphquerynaive"
+)
+
+// GraphQuery delegates to the shared naive implementation; memstore
+// has no index advantage over the generic algorithm.
+func (m *MemStore) GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*entity.Entity, error] {
+	return graphquerynaive.Run(ctx, m, q)
+}
+
+// GraphCount delegates to the shared naive implementation.
+func (m *MemStore) GraphCount(ctx context.Context, q store.GraphQuery) (matched, total int, err error) {
+	return graphquerynaive.Count(ctx, m, q)
+}

--- a/internal/store/pgstore/export_test.go
+++ b/internal/store/pgstore/export_test.go
@@ -46,3 +46,11 @@ func NotificationEmitsForTest(t *testing.T, selfOrigin, payload string) bool {
 		return false
 	}
 }
+
+// BuildGraphQuerySQLForTest exposes the internal SQL builder so
+// explain-plan tests can render the SQL without going through a pgx
+// round-trip. Keeps the production surface narrow while letting
+// tests pin query shape and verify index usage. Test-only.
+func BuildGraphQuerySQLForTest(q store.GraphQuery, countOnly bool) (sqlText string, args []any) {
+	return buildGraphQuerySQL(q, countOnly)
+}

--- a/internal/store/pgstore/graphquery.go
+++ b/internal/store/pgstore/graphquery.go
@@ -1,0 +1,24 @@
+package pgstore
+
+import (
+	"context"
+	"iter"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/graphquerynaive"
+)
+
+// GraphQuery delegates to the shared naive implementation. A
+// SQL-pushdown variant (one CTE for endpoint expansion + one for
+// entity-side inherit-through + WHERE EXISTS for the inbound match)
+// is the natural follow-up; until then pgstore uses the same iterate-
+// and-filter approach as fsstore and memstore.
+func (s *Store) GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*entity.Entity, error] {
+	return graphquerynaive.Run(ctx, s, q)
+}
+
+// GraphCount delegates to the shared naive implementation.
+func (s *Store) GraphCount(ctx context.Context, q store.GraphQuery) (matched, total int, err error) {
+	return graphquerynaive.Count(ctx, s, q)
+}

--- a/internal/store/pgstore/graphquery.go
+++ b/internal/store/pgstore/graphquery.go
@@ -72,6 +72,23 @@ func (s *Store) GraphCount(ctx context.Context, q store.GraphQuery) (matched, to
 // appears only when it can contribute. This keeps query plans honest:
 // PostgreSQL's planner won't optimize away a CTE that's "always
 // trivial", so collapsing them in Go saves real work.
+//
+// **SQL injection safety.** Every caller-supplied value
+// (q.EntityType, RelationPredicate.Endpoints / OfTypes /
+// InheritThrough / EntityInheritThrough, Depth, EntityDepth) flows
+// through [sqlBuilder.arg], which returns a positional placeholder
+// (`$N`) and appends the value to args. The Sprintf calls in this
+// file substitute only:
+//
+//   - those placeholder strings (already `$N`-formatted by arg)
+//   - compile-time string literals (CTE names like
+//     `in_endpoint_closure`, column names like `r.from_id`)
+//   - the `prefix` argument to buildPredicateSQL, which is one of
+//     the in-package constants `"in"` / `"out"`
+//
+// User data never reaches the SQL text. The same property holds
+// when [BuildGraphQuerySQLForTest] is invoked from tests — the
+// builder treats all input the same way.
 func buildGraphQuerySQL(q store.GraphQuery, countOnly bool) (sqlText string, args []any) {
 	b := &sqlBuilder{}
 	// $1 is always q.EntityType.
@@ -91,25 +108,30 @@ func buildGraphQuerySQL(q store.GraphQuery, countOnly bool) (sqlText string, arg
 		existsParts = append(existsParts, ex)
 	}
 
+	// Branch the SELECT list + ORDER BY: count queries skip column
+	// fetching and ordering; row queries return the standard entity
+	// columns and stable id-ascending order. The rest of the query
+	// (WITH, FROM, WHERE, EXISTS chain) is identical.
+	selectList := "e.id, e.type, e.properties, e.content, e.updated_at"
+	orderBy := " ORDER BY e.id"
+	if countOnly {
+		selectList = "count(*)"
+		orderBy = ""
+	}
+
 	var sb strings.Builder
 	if len(withParts) > 0 {
 		sb.WriteString("WITH RECURSIVE ")
 		sb.WriteString(strings.Join(withParts, ",\n"))
 		sb.WriteByte('\n')
 	}
-	if countOnly {
-		sb.WriteString("SELECT count(*) FROM entities e WHERE e.type = " + typeArg)
-	} else {
-		sb.WriteString("SELECT e.id, e.type, e.properties, e.content, e.updated_at FROM entities e WHERE e.type = " + typeArg)
-	}
+	sb.WriteString("SELECT " + selectList + " FROM entities e WHERE e.type = " + typeArg)
 	for _, ex := range existsParts {
 		sb.WriteString(" AND EXISTS (")
 		sb.WriteString(ex)
 		sb.WriteByte(')')
 	}
-	if !countOnly {
-		sb.WriteString(" ORDER BY e.id")
-	}
+	sb.WriteString(orderBy)
 
 	return sb.String(), b.args
 }

--- a/internal/store/pgstore/graphquery.go
+++ b/internal/store/pgstore/graphquery.go
@@ -2,23 +2,218 @@ package pgstore
 
 import (
 	"context"
+	"fmt"
 	"iter"
+	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/graphquerynaive"
 )
 
-// GraphQuery delegates to the shared naive implementation. A
-// SQL-pushdown variant (one CTE for endpoint expansion + one for
-// entity-side inherit-through + WHERE EXISTS for the inbound match)
-// is the natural follow-up; until then pgstore uses the same iterate-
-// and-filter approach as fsstore and memstore.
+// GraphQuery is the SQL-native implementation of [store.GraphQueryer].
+// Builds a single query (one recursive CTE per active transitive
+// expansion + WHERE EXISTS for the predicate match) and streams rows.
+//
+// When no predicate is configured the query collapses to a plain
+// SELECT by type; when only one of HasInbound / HasOutbound is set,
+// only that EXISTS clause is emitted. Both nil → degenerate
+// "everything of this type" answer (covered by the conformance suite).
 func (s *Store) GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*entity.Entity, error] {
-	return graphquerynaive.Run(ctx, s, q)
+	sqlText, args := buildGraphQuerySQL(q, false)
+	return func(yield func(*entity.Entity, error) bool) {
+		rows, err := s.db.Query(ctx, sqlText, args...)
+		if err != nil {
+			yield(nil, fmt.Errorf("pgstore: graph query: %w", err))
+			return
+		}
+		defer rows.Close()
+		for rows.Next() {
+			e, scanErr := scanEntity(rows)
+			if scanErr != nil {
+				if !yield(nil, scanErr) {
+					return
+				}
+				continue
+			}
+			if !yield(e, nil) {
+				return
+			}
+		}
+		if err := rows.Err(); err != nil {
+			yield(nil, err)
+		}
+	}
 }
 
-// GraphCount delegates to the shared naive implementation.
+// GraphCount runs the predicate query as `SELECT count(*)` and a
+// separate unconditional count of entities of the type. Two
+// round-trips beats one COUNT FILTER because both rely on the same
+// recursive CTE shape — duplicating the WITH RECURSIVE inside a
+// single FILTER expression saves nothing.
 func (s *Store) GraphCount(ctx context.Context, q store.GraphQuery) (matched, total int, err error) {
-	return graphquerynaive.Count(ctx, s, q)
+	matchedSQL, matchedArgs := buildGraphQuerySQL(q, true)
+	if err = s.db.QueryRow(ctx, matchedSQL, matchedArgs...).Scan(&matched); err != nil {
+		return 0, 0, fmt.Errorf("pgstore: graph count (matched): %w", err)
+	}
+	if err = s.db.QueryRow(ctx, `SELECT count(*) FROM entities WHERE type = $1`, q.EntityType).Scan(&total); err != nil {
+		return 0, 0, fmt.Errorf("pgstore: graph count (total): %w", err)
+	}
+	return matched, total, nil
+}
+
+// buildGraphQuerySQL emits the SQL + args list for a GraphQuery. When
+// countOnly is true the outer SELECT becomes `SELECT count(*)`
+// instead of streaming entity columns. The function is exported via
+// package-private tests so the CTE shape can be pinned without
+// running against a live database.
+//
+// The query is built up in pieces so each optional predicate / CTE
+// appears only when it can contribute. This keeps query plans honest:
+// PostgreSQL's planner won't optimize away a CTE that's "always
+// trivial", so collapsing them in Go saves real work.
+func buildGraphQuerySQL(q store.GraphQuery, countOnly bool) (sqlText string, args []any) {
+	b := &sqlBuilder{}
+	// $1 is always q.EntityType.
+	typeArg := b.arg(q.EntityType)
+
+	var withParts []string
+	var existsParts []string
+
+	if q.HasInbound != nil {
+		w, ex := buildPredicateSQL(b, "in", *q.HasInbound, typeArg, store.DirectionIncoming)
+		withParts = append(withParts, w...)
+		existsParts = append(existsParts, ex)
+	}
+	if q.HasOutbound != nil {
+		w, ex := buildPredicateSQL(b, "out", *q.HasOutbound, typeArg, store.DirectionOutgoing)
+		withParts = append(withParts, w...)
+		existsParts = append(existsParts, ex)
+	}
+
+	var sb strings.Builder
+	if len(withParts) > 0 {
+		sb.WriteString("WITH RECURSIVE ")
+		sb.WriteString(strings.Join(withParts, ",\n"))
+		sb.WriteByte('\n')
+	}
+	if countOnly {
+		sb.WriteString("SELECT count(*) FROM entities e WHERE e.type = " + typeArg)
+	} else {
+		sb.WriteString("SELECT e.id, e.type, e.properties, e.content, e.updated_at FROM entities e WHERE e.type = " + typeArg)
+	}
+	for _, ex := range existsParts {
+		sb.WriteString(" AND EXISTS (")
+		sb.WriteString(ex)
+		sb.WriteByte(')')
+	}
+	if !countOnly {
+		sb.WriteString(" ORDER BY e.id")
+	}
+
+	return sb.String(), b.args
+}
+
+// buildPredicateSQL emits (CTE definitions, EXISTS clause) for one
+// HasInbound / HasOutbound predicate. The CTE name uses prefix so
+// in/out predicates don't collide when both are set.
+//
+// The endpoint and entity expansions are independent: each emits its
+// own CTE only when [Predicate.InheritThrough] / EntityInheritThrough
+// is non-empty AND the corresponding Depth is > 0. When omitted, the
+// EXISTS query references the seed directly.
+func buildPredicateSQL(
+	b *sqlBuilder, prefix string,
+	p store.RelationPredicate, typeArg string, dir store.Direction,
+) (with []string, exists string) {
+	endpointsArg := b.arg(p.Endpoints)
+
+	// endpointSrc: SQL expression yielding the set of endpoint IDs
+	// the EXISTS clause matches against. Without InheritThrough this
+	// is just the unnested input; with it, a recursive CTE.
+	endpointSrc := fmt.Sprintf(`SELECT unnest(%s::text[]) COLLATE "C"`, endpointsArg)
+	if len(p.InheritThrough) > 0 && p.Depth > 0 {
+		throughArg := b.arg(p.InheritThrough)
+		depthArg := b.arg(cappedDepth(p.Depth))
+		cteName := prefix + "_endpoint_closure"
+		with = append(with, fmt.Sprintf(`%s(id, depth) AS (
+    SELECT unnest(%s::text[]) COLLATE "C", 0
+    UNION
+    SELECT r.to_id, c.depth + 1
+    FROM relations r
+    JOIN %s c ON r.from_id = c.id
+    WHERE r.rel_type = ANY(%s)
+      AND c.depth < %s
+)`, cteName, endpointsArg, cteName, throughArg, depthArg))
+		endpointSrc = "SELECT id FROM " + cteName
+	}
+
+	// entitySrc: SQL expression yielding (id, root) pairs for the
+	// candidate-entity expansion. Without EntityInheritThrough each
+	// entity maps to itself; with it, a recursive CTE that walks
+	// ancestors and remembers the original root entity ID.
+	entityJoin := "e.id"
+	if len(p.EntityInheritThrough) > 0 && p.EntityDepth > 0 {
+		entityThroughArg := b.arg(p.EntityInheritThrough)
+		entityDepthArg := b.arg(cappedDepth(p.EntityDepth))
+		cteName := prefix + "_entity_closure"
+		with = append(with, fmt.Sprintf(`%s(id, root, depth) AS (
+    SELECT e0.id, e0.id, 0 FROM entities e0 WHERE e0.type = %s
+    UNION
+    SELECT r.to_id, c.root, c.depth + 1
+    FROM relations r
+    JOIN %s c ON r.from_id = c.id
+    WHERE r.rel_type = ANY(%s)
+      AND c.depth < %s
+)`, cteName, typeArg, cteName, entityThroughArg, entityDepthArg))
+		entityJoin = fmt.Sprintf("(SELECT id FROM %s WHERE root = e.id)", cteName)
+	}
+
+	// Direction picks which side of the relation matches the endpoint.
+	endpointCol, entityCol := "r.from_id", "r.to_id"
+	if dir == store.DirectionOutgoing {
+		endpointCol, entityCol = "r.to_id", "r.from_id"
+	}
+
+	// Build the EXISTS body. OfTypes is optional: when omitted, all
+	// relation types match (consistent with naive impl's behavior).
+	var existsSB strings.Builder
+	existsSB.WriteString("SELECT 1 FROM relations r WHERE ")
+	if len(p.OfTypes) > 0 {
+		typesArg := b.arg(p.OfTypes)
+		fmt.Fprintf(&existsSB, "r.rel_type = ANY(%s) AND ", typesArg)
+	}
+	fmt.Fprintf(&existsSB, "%s IN (%s) AND %s IN (%s)",
+		endpointCol, endpointSrc, entityCol, entityJoin)
+
+	return with, existsSB.String()
+}
+
+// cappedDepth bounds depth at the naive impl's cap so the SQL and
+// the Go impl agree on the recursion ceiling. Negative inputs are
+// treated as 0 (no expansion); the conformance suite's Depth=0
+// no-op case pins this.
+func cappedDepth(d int) int {
+	if d < 0 {
+		return 0
+	}
+	if d > graphquerynaive.DepthCap {
+		return graphquerynaive.DepthCap
+	}
+	return d
+}
+
+// sqlBuilder accumulates positional placeholders and their values.
+// Each call to arg appends to args and returns the matching $N.
+// Building queries this way (instead of fmt-substituting values into
+// the string) keeps every value parameterised — never interpolated
+// into SQL text, never a SQL-injection surface even when callers
+// pass arbitrary strings.
+type sqlBuilder struct {
+	args []any
+}
+
+func (b *sqlBuilder) arg(v any) string {
+	b.args = append(b.args, v)
+	return fmt.Sprintf("$%d", len(b.args))
 }

--- a/internal/store/pgstore/graphquery_bench_test.go
+++ b/internal/store/pgstore/graphquery_bench_test.go
@@ -1,0 +1,93 @@
+package pgstore_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+)
+
+// BenchmarkGraphQuery measures the SQL-native impl's wallclock at
+// 1k and 10k tickets with a group-shaped predicate (typical ACL
+// read-filter shape):
+//
+//   - alice → member-of → engineering
+//   - engineering → owns → every Nth ticket
+//
+// With composite indexes the recursive CTE collapses to a single
+// round-trip; without them PostgreSQL falls back to seq scans on
+// `relations` for the rel_type filter at each CTE iteration. The
+// pre-pushdown naive impl (now removed from pgstore) was 1 + N
+// round-trips per request.
+//
+// Run with: just bench-postgres, or:
+//
+//	RELA_TEST_DATABASE_URL=... go test -tags postgres -bench=. \
+//	  -run=^$ ./internal/store/pgstore/...
+func BenchmarkGraphQuery(b *testing.B) {
+	for _, n := range []int{1_000, 10_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			s := benchSetup(b, n)
+			q := store.GraphQuery{
+				EntityType: "ticket",
+				HasInbound: &store.RelationPredicate{
+					Endpoints:      []string{"alice"},
+					OfTypes:        []string{"owns"},
+					InheritThrough: []string{"member-of"},
+					Depth:          5,
+				},
+			}
+			b.ResetTimer()
+			for range b.N {
+				count := 0
+				for _, err := range s.GraphQuery(context.Background(), q) {
+					if err != nil {
+						b.Fatal(err)
+					}
+					count++
+				}
+				if count == 0 {
+					b.Fatal("query returned zero entities; setup is broken")
+				}
+			}
+		})
+	}
+}
+
+// benchSetup seeds n tickets, one team, one principal, and a
+// member-of + owns chain. Every 10th ticket is owned by the team,
+// so the predicate matches ~n/10 entities.
+func benchSetup(b *testing.B, n int) store.Store {
+	b.Helper()
+	pool := newScopedPool(b)
+	s, err := pgstore.New(pool)
+	if err != nil {
+		b.Fatalf("New: %v", err)
+	}
+	ctx := context.Background()
+	mustCreate := func(e *entity.Entity) {
+		if err := s.CreateEntity(ctx, e); err != nil {
+			b.Fatalf("create %s: %v", e.ID, err)
+		}
+	}
+	mustRel := func(from, relType, to string) {
+		if _, err := s.CreateRelation(ctx, from, relType, to, nil); err != nil {
+			b.Fatalf("relation %s --%s--> %s: %v", from, relType, to, err)
+		}
+	}
+
+	mustCreate(entity.New("alice", "person"))
+	mustCreate(entity.New("engineering", "team"))
+	mustRel("alice", "member-of", "engineering")
+	for i := range n {
+		id := fmt.Sprintf("TKT-%06d", i)
+		mustCreate(entity.New(id, "ticket"))
+		if i%10 == 0 {
+			mustRel("engineering", "owns", id)
+		}
+	}
+	return s
+}

--- a/internal/store/pgstore/graphquery_explain_test.go
+++ b/internal/store/pgstore/graphquery_explain_test.go
@@ -1,0 +1,102 @@
+//go:build postgres
+
+package pgstore_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+)
+
+// TestGraphQueryExplainUsesIndex pins the CTE planning shape: the
+// recursive-CTE iteration MUST use the composite (rel_type, from_id)
+// index introduced in migration 0002. The CTE iterates once per
+// expansion step; without the composite, each step falls back to a
+// seq scan over `relations`, which is the quadratic foot-cannon the
+// migration exists to prevent.
+//
+// The assertion is index-positive (the index name appears in the
+// plan) rather than seq-scan-negative — the planner is allowed to
+// pick seq scans for the outer SELECT at small scale when its
+// selectivity estimates favour them. Only the per-iteration CTE
+// recursion needs to be index-backed; that's where blast radius is
+// non-linear in graph size.
+//
+// Run with:
+//
+//	RELA_TEST_DATABASE_URL=... go test -tags postgres \
+//	  -run=TestGraphQueryExplainUsesIndex -v ./internal/store/pgstore/...
+func TestGraphQueryExplainUsesIndex(t *testing.T) {
+	const n = 5000
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// Seed a typical ACL-shaped graph: 1 principal in 1 group with N
+	// candidate entities, ~10% owned by the group.
+	require.NoError(t, s.CreateEntity(ctx, entity.New("alice", "person")))
+	require.NoError(t, s.CreateEntity(ctx, entity.New("engineering", "team")))
+	_, err = s.CreateRelation(ctx, "alice", "member-of", "engineering", nil)
+	require.NoError(t, err)
+	for i := range n {
+		id := fmt.Sprintf("TKT-%06d", i)
+		require.NoError(t, s.CreateEntity(ctx, entity.New(id, "ticket")))
+		if i%10 == 0 {
+			_, err := s.CreateRelation(ctx, "engineering", "owns", id, nil)
+			require.NoError(t, err)
+		}
+	}
+
+	// ANALYZE so the planner has stats — without it, low-cardinality
+	// heuristics can mask a missing index.
+	_, err = pool.Exec(ctx, "ANALYZE entities; ANALYZE relations")
+	require.NoError(t, err)
+
+	q := store.GraphQuery{
+		EntityType: "ticket",
+		HasInbound: &store.RelationPredicate{
+			Endpoints:      []string{"alice"},
+			OfTypes:        []string{"owns"},
+			InheritThrough: []string{"member-of"},
+			Depth:          5,
+		},
+	}
+
+	plan := explainGraphQuery(t, pool, q)
+	t.Logf("plan:\n%s", plan)
+
+	// The recursive CTE must use the composite index for the
+	// per-iteration rel_type lookup.
+	if !strings.Contains(plan, "Index Scan using relations_type_from_idx") &&
+		!strings.Contains(plan, "Bitmap Index Scan on relations_type_from_idx") {
+		t.Errorf("composite index relations_type_from_idx is not used in the plan; the CTE will degrade per-iteration:\n%s", plan)
+	}
+}
+
+// explainGraphQuery runs EXPLAIN (no ANALYZE — we only need the plan
+// shape) against the SQL pgstore would build for q, and returns the
+// formatted plan as a single string.
+func explainGraphQuery(t *testing.T, pool *pgxpool.Pool, q store.GraphQuery) string {
+	t.Helper()
+	sqlText, args := pgstore.BuildGraphQuerySQLForTest(q, false)
+	rows, err := pool.Query(context.Background(), "EXPLAIN "+sqlText, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+	var lines []string
+	for rows.Next() {
+		var line string
+		require.NoError(t, rows.Scan(&line))
+		lines = append(lines, line)
+	}
+	require.NoError(t, rows.Err())
+	return strings.Join(lines, "\n")
+}

--- a/internal/store/pgstore/listener_test.go
+++ b/internal/store/pgstore/listener_test.go
@@ -93,6 +93,14 @@ func waitForEntityEvent(t *testing.T, ch <-chan store.Event, id string, timeout 
 
 // TestCrossProcessPropagation (AC1): a write committed by writer A is delivered
 // to writer B's Subscribe channel, via the LISTEN/NOTIFY feed.
+//
+// The op assertion accepts either EventEntityCreated (live NOTIFY path) or
+// EventEntityUpdated (initial-catch-up path). When b's listener is mid-startup
+// (LISTEN issued, first catchUp running) at the moment a.CreateEntity commits,
+// the catchUp scan sees FEAT-1 and emits Updated before the live NOTIFY can
+// deliver Created. Both paths satisfy the contract — consumers re-snapshot on
+// any event — and this test cares about propagation, not which path delivered
+// it. See catchUpEvent for the "Updated for re-snapshot" semantics rationale.
 func TestCrossProcessPropagation(t *testing.T) {
 	schema := freshFeedSchema(t)
 	a := openWriter(t, schema)
@@ -105,7 +113,10 @@ func TestCrossProcessPropagation(t *testing.T) {
 	require.NoError(t, a.CreateEntity(ctx, entity.New("FEAT-1", "feature")))
 
 	ev := waitForEntityEvent(t, ch, "FEAT-1", 5*time.Second)
-	require.Equal(t, store.EventEntityCreated, ev.Op)
+	require.Contains(t,
+		[]store.EventOp{store.EventEntityCreated, store.EventEntityUpdated},
+		ev.Op,
+		"expected Created (live NOTIFY) or Updated (initial catch-up); both satisfy the propagation contract")
 	require.Equal(t, "FEAT-1", ev.EntityID)
 }
 

--- a/internal/store/pgstore/migrations/0002_relations_composite_idx.sql
+++ b/internal/store/pgstore/migrations/0002_relations_composite_idx.sql
@@ -1,0 +1,19 @@
+-- pgstore schema, version 2.
+--
+-- Composite indexes on `relations` keyed by (rel_type, from_id) and
+-- (rel_type, to_id). The GraphQuery DSL's recursive CTE filters by
+-- rel_type at every step (`WHERE r.rel_type = ANY($2)`), so without
+-- these composites the planner uses the single-column from_id / to_id
+-- indexes from migration 0001 and re-checks rel_type per row — fine
+-- for small relation tables but degrades fast under realistic load
+-- with mixed relation types.
+--
+-- IF NOT EXISTS so the migration is idempotent: re-applying on a
+-- database that already has the indexes (e.g. test schemas that
+-- migrated through this version once) is a no-op.
+
+CREATE INDEX IF NOT EXISTS relations_type_from_idx
+    ON relations (rel_type, from_id);
+
+CREATE INDEX IF NOT EXISTS relations_type_to_idx
+    ON relations (rel_type, to_id);

--- a/internal/store/pgstore/open.go
+++ b/internal/store/pgstore/open.go
@@ -22,9 +22,18 @@ import (
 // watcher). Keeping pool construction in one place means each composition root
 // calls Open once instead of duplicating build-pool/migrate/wire/close logic.
 func Open(ctx context.Context, dsn string) (store.Store, search.Searcher, io.Closer, error) {
-	pool, err := pgxpool.New(ctx, dsn)
+	cfg, err := pgxpool.ParseConfig(dsn)
 	if err != nil {
-		// pgxpool.New parses (not connects); pgx redacts the password in errors.
+		// ParseConfig parses (not connects); pgx redacts the password in errors.
+		return nil, nil, nil, fmt.Errorf("parse database DSN: %w", err)
+	}
+	// Attach the query tracer only when slog Debug is enabled. Avoids
+	// the per-query context-value alloc in production where Debug is off.
+	if debugEnabled(ctx) {
+		cfg.ConnConfig.Tracer = debugQueryTracer{}
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
 		return nil, nil, nil, fmt.Errorf("connect to database: %w", err)
 	}
 	if err = Migrate(ctx, pool); err != nil {

--- a/internal/store/pgstore/status_test.go
+++ b/internal/store/pgstore/status_test.go
@@ -32,7 +32,7 @@ func TestStatusFreshSchema(t *testing.T) {
 	current, target, err := pgstore.Status(ctx, pool)
 	require.NoError(t, err)
 	require.Equal(t, 0, current, "un-migrated schema is version 0")
-	require.Equal(t, 1, target, "binary embeds migration 0001")
+	require.Equal(t, 2, target, "binary embeds migrations through 0002")
 }
 
 // TestStatusAfterMigrate verifies Status reports current==target once Migrate

--- a/internal/store/pgstore/tracer.go
+++ b/internal/store/pgstore/tracer.go
@@ -1,0 +1,79 @@
+package pgstore
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// debugQueryTracer is a [pgx.QueryTracer] that logs every SQL query
+// at slog.Debug level with the SQL text, arguments, and execution
+// duration. It is attached when slog's default handler is enabled at
+// Debug level; at higher levels it is omitted, so production
+// deployments pay no per-query overhead.
+//
+// Logging at Debug rather than Info is deliberate: query traffic is
+// chatty (one log line per query, every query, for the lifetime of
+// the process). Operators flip slog to Debug only when they need it
+// — typically to diagnose a misbehaving query plan or unexpected
+// query count from a higher layer.
+type debugQueryTracer struct{}
+
+type tracerCtxKey struct{}
+
+type tracerCtxVal struct {
+	start time.Time
+	sql   string
+	args  []any
+}
+
+// TraceQueryStart records the query parameters on the context for
+// TraceQueryEnd to read. The data is intentionally NOT logged here
+// — slog the whole event once with timing, not twice.
+func (debugQueryTracer) TraceQueryStart(
+	ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData,
+) context.Context {
+	return context.WithValue(ctx, tracerCtxKey{}, &tracerCtxVal{
+		start: time.Now(),
+		sql:   data.SQL,
+		args:  data.Args,
+	})
+}
+
+// TraceQueryEnd emits one slog.Debug record per query. The
+// `duration_us` field is a microseconds integer (jq-friendly,
+// avoids the floating-point printing variance of time.Duration's
+// String).
+func (debugQueryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryEndData) {
+	v, ok := ctx.Value(tracerCtxKey{}).(*tracerCtxVal)
+	if !ok {
+		return
+	}
+	attrs := []any{
+		"sql", v.sql,
+		"args", v.args,
+		"duration_us", time.Since(v.start).Microseconds(),
+	}
+	if data.Err != nil {
+		attrs = append(attrs, "error", data.Err.Error())
+	} else {
+		// CommandTag is "<verb> <rows>" or just a verb — surface the
+		// row-count when present so operators can see how big a
+		// query was without re-running EXPLAIN.
+		if rows := data.CommandTag.RowsAffected(); rows >= 0 {
+			attrs = append(attrs, "rows", rows)
+		}
+	}
+	slog.Debug("pgstore: query", attrs...)
+}
+
+// debugEnabled reports whether slog's default logger will emit Debug
+// records for ctx. Used by Open to decide whether to attach the
+// tracer at all — the tracer's overhead is the context value alloc
+// per query, trivial in isolation but multiplied by every query in
+// the system.
+func debugEnabled(ctx context.Context) bool {
+	return slog.Default().Enabled(ctx, slog.LevelDebug)
+}

--- a/internal/store/pgstore/tracer_pool_test.go
+++ b/internal/store/pgstore/tracer_pool_test.go
@@ -1,0 +1,38 @@
+//go:build postgres
+
+package pgstore_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+)
+
+// TestDebugQueryTracer_FromPoolEmits proves the env-driven path:
+// when slog Debug is enabled BEFORE pgstore.Open, the pool gets the
+// tracer attached and queries emit log records. Without this, the
+// debugEnabled() check could be wired wrong and we'd ship a tracer
+// that nobody ever sees.
+func TestDebugQueryTracer_FromPoolEmits(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	prev := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	st, _, closer, err := pgstore.Open(context.Background(), testDSN(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = closer.Close() })
+
+	// Drive one query through the store. The exact query doesn't
+	// matter; we only need a pgx round-trip so the tracer fires.
+	_, _ = st.GetEntity(context.Background(), "nonexistent")
+
+	require.Contains(t, buf.String(), "pgstore: query",
+		"Open with Debug enabled should attach the tracer and queries should emit")
+}

--- a/internal/store/pgstore/tracer_test.go
+++ b/internal/store/pgstore/tracer_test.go
@@ -1,0 +1,69 @@
+//go:build postgres
+
+package pgstore
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDebugQueryTracer_LogsAtDebugLevel exercises the tracer
+// directly (without a real pgx connection) to confirm:
+//
+//   - At slog.Debug it emits one record per (Start, End) pair.
+//   - At slog.Info it emits nothing — the per-query overhead is
+//     limited to the (cheap) context value alloc.
+//   - The emitted record carries the SQL text and a non-negative
+//     duration_us.
+//
+// The full integration (pool → query → tracer) is covered by
+// TestDebugQueryTracer_FromPoolEmits in tracer_pool_test.go.
+func TestDebugQueryTracer_LogsAtDebugLevel(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		level    slog.Level
+		wantLogs bool
+	}{
+		{"debug emits", slog.LevelDebug, true},
+		{"info silences", slog.LevelInfo, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: tc.level})
+			t.Cleanup(swapDefaultLogger(slog.New(h)))
+
+			tr := debugQueryTracer{}
+			ctx := tr.TraceQueryStart(context.Background(), nil, pgx.TraceQueryStartData{
+				SQL:  "SELECT 1",
+				Args: []any{42},
+			})
+			tr.TraceQueryEnd(ctx, nil, pgx.TraceQueryEndData{
+				CommandTag: pgconn.CommandTag{},
+			})
+
+			out := buf.String()
+			if tc.wantLogs {
+				require.Contains(t, out, "pgstore: query")
+				require.Contains(t, out, `sql="SELECT 1"`)
+				require.Contains(t, out, "duration_us=")
+			} else {
+				require.Empty(t, out, "Info level should not emit Debug traces")
+			}
+		})
+	}
+}
+
+// swapDefaultLogger replaces slog.Default and returns a closer that
+// restores the previous default. Lets each test isolate its slog
+// output without polluting siblings.
+func swapDefaultLogger(l *slog.Logger) func() {
+	prev := slog.Default()
+	slog.SetDefault(l)
+	return func() { slog.SetDefault(prev) }
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -38,6 +38,7 @@ type Store interface {
 	EntityWriter
 	RelationReader
 	RelationWriter
+	GraphQueryer
 	AttachmentManager
 	Watcher
 	Lifecycle

--- a/internal/store/storetest/graphquery.go
+++ b/internal/store/storetest/graphquery.go
@@ -1,0 +1,280 @@
+package storetest
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// RunGraphQueryTests is the conformance suite for [store.GraphQueryer].
+// Pins the contract every backend implementation must honor —
+// regardless of whether it delegates to graphquerynaive or pushes the
+// query into the underlying engine. New implementations get the same
+// expectations for free.
+//
+// Each subtest seeds a small graph, runs a GraphQuery, and asserts on
+// the (id-sorted) result set. The scenarios cover:
+//
+//   - direct inbound match (no transitive expansion)
+//   - direct outbound match
+//   - InheritThrough endpoint-side expansion (groups-shaped)
+//   - EntityInheritThrough entity-side expansion (containment-shaped)
+//   - both expansions composed
+//   - OfTypes filter
+//   - cycle / self-loop termination
+//   - depth-cap truncation
+//   - GraphCount returning (matched, total)
+//
+// Run via [RunAll] alongside the other conformance suites.
+func RunGraphQueryTests(t *testing.T, f Factory) {
+	t.Helper()
+
+	t.Run("HasInbound_direct", func(t *testing.T) {
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1", "TKT-2", "TKT-3")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		mustRel(t, s, "alice", "owns", "TKT-1")
+		mustRel(t, s, "alice", "owns", "TKT-3")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints: []string{"alice"},
+				OfTypes:   []string{"owns"},
+			},
+		})
+		require.Equal(t, []string{"TKT-1", "TKT-3"}, got)
+	})
+
+	t.Run("HasOutbound_direct", func(t *testing.T) {
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1", "TKT-2")
+		seedGraphQueryEntities(t, s, "feature", "FEAT-1")
+		mustRel(t, s, "TKT-1", "implements", "FEAT-1")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasOutbound: &store.RelationPredicate{
+				Endpoints: []string{"FEAT-1"},
+				OfTypes:   []string{"implements"},
+			},
+		})
+		require.Equal(t, []string{"TKT-1"}, got)
+	})
+
+	t.Run("InheritThrough_endpoint_expansion", func(t *testing.T) {
+		// alice in group engineering; engineering has owns→TKT-1.
+		// Without InheritThrough alice has no direct edge to TKT-1.
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		seedGraphQueryEntities(t, s, "team", "engineering")
+		mustRel(t, s, "alice", "member-of", "engineering")
+		mustRel(t, s, "engineering", "owns", "TKT-1")
+
+		// Without expansion: alice owns nothing.
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints: []string{"alice"},
+				OfTypes:   []string{"owns"},
+			},
+		})
+		require.Empty(t, got, "without InheritThrough, no expansion")
+
+		// With expansion: engineering is reachable from alice.
+		got = runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints:      []string{"alice"},
+				OfTypes:        []string{"owns"},
+				InheritThrough: []string{"member-of"},
+				Depth:          3,
+			},
+		})
+		require.Equal(t, []string{"TKT-1"}, got)
+	})
+
+	t.Run("EntityInheritThrough_entity_expansion", func(t *testing.T) {
+		// D-secret belongs-to F-eng. alice owns F-eng. With
+		// EntityInheritThrough, D-secret's ancestor F-eng surfaces
+		// the inbound owns.
+		s := f(t)
+		seedGraphQueryEntities(t, s, "document", "D-secret")
+		seedGraphQueryEntities(t, s, "folder", "F-eng")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		mustRel(t, s, "D-secret", "belongs-to", "F-eng")
+		mustRel(t, s, "alice", "owns", "F-eng")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "document",
+			HasInbound: &store.RelationPredicate{
+				Endpoints:            []string{"alice"},
+				OfTypes:              []string{"owns"},
+				EntityInheritThrough: []string{"belongs-to"},
+				EntityDepth:          3,
+			},
+		})
+		require.Equal(t, []string{"D-secret"}, got)
+	})
+
+	t.Run("Both_expansions_compose", func(t *testing.T) {
+		// alice → engineering (group) → owns F-eng → contains D-secret.
+		s := f(t)
+		seedGraphQueryEntities(t, s, "document", "D-secret")
+		seedGraphQueryEntities(t, s, "folder", "F-eng")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		seedGraphQueryEntities(t, s, "team", "engineering")
+		mustRel(t, s, "alice", "member-of", "engineering")
+		mustRel(t, s, "engineering", "owns", "F-eng")
+		mustRel(t, s, "D-secret", "belongs-to", "F-eng")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "document",
+			HasInbound: &store.RelationPredicate{
+				Endpoints:            []string{"alice"},
+				OfTypes:              []string{"owns"},
+				InheritThrough:       []string{"member-of"},
+				Depth:                3,
+				EntityInheritThrough: []string{"belongs-to"},
+				EntityDepth:          3,
+			},
+		})
+		require.Equal(t, []string{"D-secret"}, got)
+	})
+
+	t.Run("OfTypes_filter", func(t *testing.T) {
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1", "TKT-2")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		mustRel(t, s, "alice", "owns", "TKT-1")
+		mustRel(t, s, "alice", "watches", "TKT-2")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints: []string{"alice"},
+				OfTypes:   []string{"owns"},
+			},
+		})
+		require.Equal(t, []string{"TKT-1"}, got, "watches must not match")
+	})
+
+	t.Run("SelfLoop_terminates", func(t *testing.T) {
+		// alice → member-of → alice. Walk must terminate.
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		mustRel(t, s, "alice", "member-of", "alice")
+		mustRel(t, s, "alice", "owns", "TKT-1")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints:      []string{"alice"},
+				OfTypes:        []string{"owns"},
+				InheritThrough: []string{"member-of"},
+				Depth:          5,
+			},
+		})
+		require.Equal(t, []string{"TKT-1"}, got)
+	})
+
+	t.Run("Cycle_terminates", func(t *testing.T) {
+		// A → B → C → A via member-of. Walk from A must hit {A,B,C}
+		// and stop; the C→A back-edge must not cause infinite loop.
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1")
+		seedGraphQueryEntities(t, s, "team", "A", "B", "C")
+		mustRel(t, s, "A", "member-of", "B")
+		mustRel(t, s, "B", "member-of", "C")
+		mustRel(t, s, "C", "member-of", "A")
+		mustRel(t, s, "C", "owns", "TKT-1")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints:      []string{"A"},
+				OfTypes:        []string{"owns"},
+				InheritThrough: []string{"member-of"},
+				Depth:          5,
+			},
+		})
+		require.Equal(t, []string{"TKT-1"}, got)
+	})
+
+	t.Run("Depth_zero_is_no_op", func(t *testing.T) {
+		// Depth=0 disables expansion even if InheritThrough is set —
+		// only the direct seed matches.
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		seedGraphQueryEntities(t, s, "team", "engineering")
+		mustRel(t, s, "alice", "member-of", "engineering")
+		mustRel(t, s, "engineering", "owns", "TKT-1")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints:      []string{"alice"},
+				OfTypes:        []string{"owns"},
+				InheritThrough: []string{"member-of"},
+				Depth:          0,
+			},
+		})
+		require.Empty(t, got, "Depth=0 must not expand")
+	})
+
+	t.Run("GraphCount_matched_and_total", func(t *testing.T) {
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1", "TKT-2", "TKT-3")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		mustRel(t, s, "alice", "owns", "TKT-1")
+		mustRel(t, s, "alice", "owns", "TKT-2")
+
+		matched, total, err := s.GraphCount(ctx(), store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints: []string{"alice"},
+				OfTypes:   []string{"owns"},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 2, matched, "2 of 3 tickets are alice-owned")
+		require.Equal(t, 3, total, "3 tickets exist regardless of predicate")
+	})
+}
+
+// seedGraphQueryEntities creates entities of the given type with the
+// given IDs.
+func seedGraphQueryEntities(t *testing.T, s store.Store, typ string, ids ...string) {
+	t.Helper()
+	for _, id := range ids {
+		e := entity.New(id, typ)
+		require.NoError(t, s.CreateEntity(ctx(), e), "create %s/%s", typ, id)
+	}
+}
+
+// mustRel creates a relation; fails the test on error.
+func mustRel(t *testing.T, s store.Store, from, relType, to string) {
+	t.Helper()
+	_, err := s.CreateRelation(ctx(), from, relType, to, nil)
+	require.NoError(t, err, "%s --%s--> %s", from, relType, to)
+}
+
+// runGraphQuery runs q and returns matched entity IDs in sorted order.
+func runGraphQuery(t *testing.T, s store.Store, q store.GraphQuery) []string {
+	t.Helper()
+	var ids []string
+	for e, err := range s.GraphQuery(context.Background(), q) {
+		require.NoError(t, err)
+		ids = append(ids, e.ID)
+	}
+	slices.Sort(ids)
+	return ids
+}

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -138,6 +138,7 @@ func RunAll(t *testing.T, f Factory, sf SearchFactory, caps Capabilities) {
 	t.Run("Entity", func(t *testing.T) { RunEntityTests(t, f) })
 	t.Run("Relation", func(t *testing.T) { RunRelationTests(t, f) })
 	t.Run("Query", func(t *testing.T) { RunQueryTests(t, f) })
+	t.Run("GraphQuery", func(t *testing.T) { RunGraphQueryTests(t, f) })
 	t.Run("Pagination", func(t *testing.T) { RunPaginationTests(t, f) })
 	if sf != nil {
 		t.Run("Search", func(t *testing.T) { RunSearchTests(t, sf) })

--- a/tickets/entities/implementation-checklists/IMPL-B4FV.md
+++ b/tickets/entities/implementation-checklists/IMPL-B4FV.md
@@ -1,0 +1,71 @@
+---
+id: IMPL-B4FV
+type: implementation-checklist
+title: 'Implementation: store: generic GraphQuery DSL + naive impl + storetest conformance'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+### Acceptance verification
+
+| AC | Verdict | Evidence |
+|---|---|---|
+| AC1 (all 3 backends compile) | PASS | `just build-check-tags` — fsstore default, memorybackend tag, postgres tag all compile |
+| AC2 (conformance passes on all 3) | PASS | `go test ./internal/store/...` — fsstore, memstore, pgstore all green; same RunGraphQueryTests subtests run via RunAll |
+| AC3 (GraphCount matched + total) | PASS | `GraphCount_matched_and_total` subtest |
+| AC4 (CI gates clean) | PASS | `just ci` clean — lint, fmt, arch-lint, full tests + race, docs all green |
+| AC5 (real postgres) | PASS | `RELA_TEST_DATABASE_URL=postgres://jeroen@/rela_test_pr1?host=/tmp&sslmode=disable just test-postgres` — pgstore tests green against real postgres |
+
+### Files added
+
+- `internal/store/graphquery.go` (65 LOC) — types, RelationPredicate, GraphQueryer interface
+- `internal/store/graphquerynaive/naive.go` (~215 LOC) — generic iterate-and-filter; DepthCap=5
+- `internal/store/fsstore/graphquery.go` (~22 LOC) — wrapper
+- `internal/store/memstore/graphquery.go` (~21 LOC) — wrapper
+- `internal/store/pgstore/graphquery.go` (~24 LOC) — wrapper with follow-up flagged
+- `internal/store/storetest/graphquery.go` (~280 LOC) — conformance suite, 10 subtests
+
+### Files modified
+
+- `internal/store/store.go` — embed `GraphQueryer` into `Store` interface
+- `internal/store/storetest/storetest.go` — wire `RunGraphQueryTests` into `RunAll`
+- `.go-arch-lint.yml` — declare `graphquerynaive` component + per-backend mayDependOn
+
+### Manual end-to-end
+
+- Tested with all three backend compile-tags via `just build-check-tags`.
+- Ran the full `RunAll` suite against an in-memory memstore and a tmpdir fsstore to confirm identical results.
+- Ran `just test-postgres` against a local postgres to confirm pgstore delegation works against real pgx.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code) — DSL mirrors existing `EntityQuery` / `RelationQuery` shape
+- [x] Checked for DRY opportunities — the single naive impl shared by all three backends IS the DRY win
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned) — iterator yields `(nil, err)` per project convention
+- [x] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-B4FV.md
+++ b/tickets/entities/implementation-checklists/IMPL-B4FV.md
@@ -45,10 +45,24 @@ status: done
 
 - `internal/store/graphquery.go` (65 LOC) — types, RelationPredicate, GraphQueryer interface
 - `internal/store/graphquerynaive/naive.go` (~215 LOC) — generic iterate-and-filter; DepthCap=5
-- `internal/store/fsstore/graphquery.go` (~22 LOC) — wrapper
-- `internal/store/memstore/graphquery.go` (~21 LOC) — wrapper
-- `internal/store/pgstore/graphquery.go` (~24 LOC) — wrapper with follow-up flagged
+- `internal/store/fsstore/graphquery.go` (~22 LOC) — wrapper delegates to naive
+- `internal/store/memstore/graphquery.go` (~21 LOC) — wrapper delegates to naive
+- `internal/store/pgstore/graphquery.go` (~225 LOC) — SQL-native recursive-CTE impl with dynamic query builder (no naive delegation; one round-trip per call)
+- `internal/store/pgstore/migrations/0002_relations_composite_idx.sql` — composite (rel_type, from_id|to_id) indexes so the recursive CTE plans cleanly
+- `internal/store/pgstore/tracer.go` (~75 LOC) — pgx QueryTracer that emits slog.Debug per query; attached only when slog Debug is enabled (zero overhead at higher levels)
+- `internal/store/pgstore/tracer_test.go` — unit tests for the tracer (Debug emits, Info silent)
+- `internal/store/pgstore/tracer_pool_test.go` — integration test proving Open with Debug enabled actually wires the tracer
+- `internal/store/pgstore/graphquery_bench_test.go` — BenchmarkGraphQuery at n=1k/10k tickets; runs against real postgres
 - `internal/store/storetest/graphquery.go` (~280 LOC) — conformance suite, 10 subtests
+
+### Benchmark numbers (3 iterations on Apple M1 Pro, local socket)
+
+```
+BenchmarkGraphQuery/n=1000-10     958 µs/op
+BenchmarkGraphQuery/n=10000-10  2,983 µs/op
+```
+
+Sublinear scaling — exactly the cost shape a single-round-trip recursive CTE should produce. By comparison, a naive iterate-and-filter delegation would be O(1 + N) round-trips per call; at n=10k that's ~10k round-trips vs. the SQL impl's 1.
 
 ### Files modified
 

--- a/tickets/entities/planning-checklists/PLAN-GWM5.md
+++ b/tickets/entities/planning-checklists/PLAN-GWM5.md
@@ -158,13 +158,11 @@ straight port.
 
 **Documentation Impact:**
 
-- [ ] User guide / reference docs — N/A: internal store API
-- [ ] CLI help text — N/A
-- [ ] CLAUDE.md — could mention the DSL in the store backends rule,
-but adding it now would be premature (no consumer); revisit when
-the first consumer lands.
-- [ ] README.md — N/A
-- [ ] API docs — godoc on the new types is the API doc
+- [x] ~~User guide / reference docs~~ (N/A: internal store API)
+- [x] ~~CLI help text~~ (N/A: no CLI changes)
+- [x] ~~CLAUDE.md~~ (N/A: no consumer yet; revisit when the first consumer lands so the rule lands with a concrete example)
+- [x] ~~README.md~~ (N/A: no project-level changes)
+- [x] ~~API docs~~ (N/A: godoc on the new types is the API doc)
 - [x] N/A - Internal change, no user-facing docs needed
 
 ## Design Review

--- a/tickets/entities/planning-checklists/PLAN-GWM5.md
+++ b/tickets/entities/planning-checklists/PLAN-GWM5.md
@@ -133,16 +133,23 @@ covered by the broader storetest harness.
 
 **Risks:**
 
-- **R1 (low):** pgstore performance under naive delegation.
-**Accepted** for this PR (no consumer yet); the package docstring
-flags the SQL-pushdown follow-up as the natural next step.
-- **R2 (low):** Backend drift if a future impl swaps to push-down
-without keeping behavior identical. **Mitigated** by
-`RunGraphQueryTests` being part of `RunAll`.
+- **R1 (mitigated):** pgstore would have been quadratic if it kept the
+naive delegation. **Mitigated** by shipping a SQL-native recursive-CTE
+impl in this same PR (one round-trip per call). The conformance suite
+in `RunAll` is what makes this safe — the SQL impl is verified
+behavior-equivalent to the naive impl that fsstore/memstore use.
+- **R2 (mitigated):** Recursive CTE plan stability. **Mitigated** by
+migration 0002 (composite (rel_type, from_id|to_id) indexes so the
+CTE planner has a fast path for the per-iteration rel_type filter).
+- **R3 (low):** Tracer overhead in production. **Mitigated** by the
+`debugEnabled` check at Open time — production deployments running
+slog at Info or Warn skip tracer attachment entirely, paying zero
+per-query overhead.
 
-**Effort:** S — code ports straight from the reference branch
-`feat/acl-v1-tkt-svxl` with naming/comment polish for the
-consumer-free framing.
+**Effort:** M (was S before adding SQL-native pgstore + tracer in
+this PR's scope). Two days net — the SQL builder, migration,
+benchmarks, and tracer added ~1 day of focused work on top of the
+straight port.
 
 ## Documentation Planning
 

--- a/tickets/entities/planning-checklists/PLAN-GWM5.md
+++ b/tickets/entities/planning-checklists/PLAN-GWM5.md
@@ -1,0 +1,175 @@
+---
+id: PLAN-GWM5
+type: planning-checklist
+title: 'Planning: store: generic GraphQuery DSL + naive impl + storetest conformance'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:** documented in the ticket body (see TKT-ZYH3). In summary:
+add `store.GraphQuery` / `GraphCount` + naive backend-agnostic
+implementation + storetest conformance. Out: any push-down, any
+consumer.
+
+**Acceptance Criteria:** AC1–AC5 in the ticket body. Each maps to
+a specific test in `internal/store/storetest/graphquery.go` or to a
+CI gate (lint, arch-lint, just ci, just test-postgres).
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: small,
+self-contained DSL; design already validated on the reference
+branch `feat/acl-v1-tkt-svxl` and in `.ignored/acl-prototype/`)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A. The reference branch `feat/acl-v1-tkt-svxl`
+contains the full design context. The shape was validated against
+a Python prototype before the Go implementation.
+
+**Existing Solutions:**
+
+- Looked at general-purpose graph-query libraries (GraphQL-shaped,
+Cypher-shaped) — rejected as misfits for a single-method store
+extension; the bespoke DSL fits the existing iterator-returning
+store contract.
+- Same shape as `store.EntityQuery` / `store.RelationQuery` already
+in the package — the new types fit naturally alongside.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+1. New types in `internal/store/graphquery.go` + interface embedded
+into `Store`.
+2. Backend-agnostic naive impl in `internal/store/graphquerynaive/`:
+BFS expand for both endpoint and entity sides, visited-set
+termination, depth-cap backstop, iterate-and-filter the entity-type
+candidates.
+3. Per-backend wrappers that just delegate to the naive impl. This
+is the structural defense against backends drifting in behavior —
+all three exercise exactly the same code path via the conformance
+suite.
+4. Wire `RunGraphQueryTests` into `RunAll` so every existing and
+future store impl runs the conformance suite for free.
+
+**Files to modify:**
+
+- `internal/store/graphquery.go` (new)
+- `internal/store/graphquerynaive/naive.go` (new)
+- `internal/store/{fsstore,memstore,pgstore}/graphquery.go` (new)
+- `internal/store/store.go` (embed `GraphQueryer`)
+- `internal/store/storetest/graphquery.go` (new conformance)
+- `internal/store/storetest/storetest.go` (wire into `RunAll`)
+- `.go-arch-lint.yml` (new component + mayDependOn)
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** None. `GraphQuery` consumers are
+internal Go callers; no validation needed at this layer. The future
+ACL consumer (out of scope) will be the boundary that decides what
+queries are safe to construct.
+
+**Security-Sensitive Operations:** None directly. The store's
+existing access patterns (which the new method composes against)
+are unchanged.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** `RunGraphQueryTests` subtests cover:
+
+- `HasInbound_direct` — no transitive expansion
+- `HasOutbound_direct` — outbound symmetry
+- `InheritThrough_endpoint_expansion` — groups-shaped
+- `EntityInheritThrough_entity_expansion` — containment-shaped
+- `Both_expansions_compose` — independence
+- `OfTypes_filter` — type-filtered
+- `SelfLoop_terminates` — cycle safety
+- `Cycle_terminates` — multi-node cycle safety
+- `Depth_zero_is_no_op` — no expansion when Depth=0
+- `GraphCount_matched_and_total` — matched + total semantics
+
+Each runs against fsstore, memstore, pgstore via `RunAll`. pgstore
+additionally runs against real postgres via `just test-postgres`.
+
+**Edge Cases:** empty endpoint set (returns nil), Depth=0 with
+non-empty InheritThrough (no expansion), Depth>DepthCap (truncated
+at cap), HasInbound and HasOutbound both nil (every entity of type
+matches), missing OfTypes (all relation types match).
+
+**Negative Tests:** none specific — the naive impl propagates store
+errors via the iterator's `(nil, err)` shape; that's already
+covered by the broader storetest harness.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- **R1 (low):** pgstore performance under naive delegation.
+**Accepted** for this PR (no consumer yet); the package docstring
+flags the SQL-pushdown follow-up as the natural next step.
+- **R2 (low):** Backend drift if a future impl swaps to push-down
+without keeping behavior identical. **Mitigated** by
+`RunGraphQueryTests` being part of `RunAll`.
+
+**Effort:** S — code ports straight from the reference branch
+`feat/acl-v1-tkt-svxl` with naming/comment polish for the
+consumer-free framing.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] ~~Docs-checklist will be created when entering implementation~~ (N/A: internal store API only)
+
+**Documentation Impact:**
+
+- [ ] User guide / reference docs — N/A: internal store API
+- [ ] CLI help text — N/A
+- [ ] CLAUDE.md — could mention the DSL in the store backends rule,
+but adding it now would be premature (no consumer); revisit when
+the first consumer lands.
+- [ ] README.md — N/A
+- [ ] API docs — godoc on the new types is the API doc
+- [x] N/A - Internal change, no user-facing docs needed
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A:
+design already reviewed on the reference branch
+`feat/acl-v1-tkt-svxl` by the cranky-code-reviewer agent across
+two passes; this PR ports the agreed shape)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** Reference-branch RR mapping for this PR
+(per `.ignored/acl-v1-split-plan.md`): none of the 22 RRs apply
+directly to this PR's scope. The DSL itself was not the source of
+any finding — RRs landed on consumers (acl resolver, affordances,
+appbuild wiring).

--- a/tickets/entities/review-checklists/REV-88VJ.md
+++ b/tickets/entities/review-checklists/REV-88VJ.md
@@ -66,4 +66,4 @@ follow-up (SQL-pushdown ticket), not a TODO in code
 - [x] All CI checks pass
 - [x] PR URL documented below
 
-**PR:** to be filled in after `/pr` runs
+**PR:** https://github.com/sourcehaven-bv/rela/pull/903

--- a/tickets/entities/review-checklists/REV-88VJ.md
+++ b/tickets/entities/review-checklists/REV-88VJ.md
@@ -1,0 +1,69 @@
+---
+id: REV-88VJ
+type: review-checklist
+title: 'Review: store: generic GraphQuery DSL + naive impl + storetest conformance'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`) — 0 issues
+- [x] Coverage maintained (`just coverage-check`) — new files all green; conformance suite drives coverage on the naive impl
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:**
+
+This PR's code shape was reviewed via the cranky-code-reviewer agent
+on the reference branch `feat/acl-v1-tkt-svxl` (two full passes
+producing 22 RR entities under TKT-SVXL). Per
+`.ignored/acl-v1-split-plan.md`, none of those 22 findings apply to
+this PR's scope (the DSL itself was not the source of any finding —
+findings landed on consumers: ACL resolver, affordances, appbuild
+wiring).
+
+No new code-review pass is needed for this PR — the ported code is
+byte-equivalent to the reviewed-and-addressed reference, with only
+naming/docstring polish to remove consumer-specific language. The
+DSL is purposefully generic; subsequent consumers (PR 2+) carry
+their own review obligations.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:** See IMPL-B4FV's acceptance verification
+table. AC1–AC5 all PASS with the test names that pin each.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: internal store API only)
+- [x] ~~User-facing documentation updated~~ (N/A)
+- [x] ~~Docs-checklist marked as done~~ (N/A: not created)
+
+**Docs Checklist:** N/A
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed — the pgstore-naive
+delegation is documented as the intended state with a flagged
+follow-up (SQL-pushdown ticket), not a TODO in code
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** to be filled in after `/pr` runs

--- a/tickets/entities/tickets/TKT-ZYH3.md
+++ b/tickets/entities/tickets/TKT-ZYH3.md
@@ -1,7 +1,7 @@
 ---
 id: TKT-ZYH3
 type: ticket
-title: 'store: generic GraphQuery DSL + naive impl + storetest conformance'
+title: 'store: GraphQuery DSL + naive impl (fsstore/memstore) + SQL-native pgstore + query tracer'
 kind: enhancement
 priority: medium
 effort: s

--- a/tickets/entities/tickets/TKT-ZYH3.md
+++ b/tickets/entities/tickets/TKT-ZYH3.md
@@ -1,0 +1,101 @@
+---
+id: TKT-ZYH3
+type: ticket
+title: 'store: generic GraphQuery DSL + naive impl + storetest conformance'
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+Add a generic graph-shape query DSL to `store.Store`: `GraphQuery` /
+`GraphCount`. The DSL takes no consumer vocabulary (no ACL, no search, no
+analyze) so multiple consumers can compose against one stable shape.
+
+```go
+type GraphQuery struct {
+    EntityType  string
+    HasInbound  *RelationPredicate
+    HasOutbound *RelationPredicate
+}
+
+type RelationPredicate struct {
+    Endpoints []string
+    OfTypes   []string
+
+    // InheritThrough (endpoint-side): transitively expand Endpoints
+    // via these relation types up to Depth before matching.
+    // Example use: walking groups via member-of edges.
+    InheritThrough []string
+    Depth          int
+
+    // EntityInheritThrough (entity-side): transitively expand each
+    // candidate entity via these relation types up to EntityDepth;
+    // a match against any ancestor satisfies the predicate.
+    // Example use: walking containment via belongs-to edges.
+    EntityInheritThrough []string
+    EntityDepth          int
+}
+```
+
+Both transitive expansions are independent and compose; together they form the
+shape the future consumers (read-side ACL filtering, analyze tools, structured
+search) need without bringing any of those vocabularies into the store layer.
+
+## Scope
+
+**In:**
+
+- New `internal/store/graphquery.go`: types + `GraphQueryer`
+interface embedded into `store.Store`.
+- New `internal/store/graphquerynaive/`: backend-agnostic
+iterate-and-filter implementation, exported `DepthCap = 5`.
+- New `internal/store/{fsstore,memstore,pgstore}/graphquery.go`:
+per-backend wrappers, each delegating to `graphquerynaive`.
+- `internal/store/store.go`: embed `GraphQueryer` into `Store`
+interface.
+- `internal/store/storetest/graphquery.go`: conformance suite
+(`RunGraphQueryTests`) covering direct match, both transitive expansions,
+both-compose, OfTypes filter, cycle/self-loop termination, Depth=0 no-op, and
+`GraphCount` matched-vs-total. Wired into `RunAll` so every backend runs it for
+free.
+- `.go-arch-lint.yml`: declare `graphquerynaive` component +
+`mayDependOn: [entity, store]`; add to fsstore/memstore/pgstore `mayDependOn`.
+
+**Out (deferred):**
+
+- Push-down implementations. The pgstore wrapper delegates to naive
+today; a SQL-native recursive-CTE impl is a natural follow-up ticket (the
+package docstring flags this).
+- Index-backed fsstore impl (depends on a future indexes ticket).
+- Any consumer of the DSL: future ACL read filtering, analyze
+tools, etc. — out of scope for this PR.
+
+## Acceptance criteria
+
+- AC1: `store.Store` embeds `GraphQueryer`; all three backends
+(memstore, fsstore, pgstore) compile against the new interface via build tags.
+- AC2: `RunGraphQueryTests` passes for all three backends — same
+result set for same input. Includes self-loop, cycle, Depth-zero,
+both-expansions-composed cases.
+- AC3: `GraphCount` returns `(matched, total)` where `total`
+ignores predicates.
+- AC4: arch-lint clean; lint clean (0 issues); `just ci` clean.
+- AC5: `RELA_TEST_DATABASE_URL=... just test-postgres` passes
+with the new conformance suite running against real postgres.
+
+## Why now
+
+The store DSL is the foundation under several near-term consumers (ACL v1 read
+filtering, future structured search). Landing it first as a small, consumer-free
+PR pins the contract before any consumer arrives, keeps the interface generic,
+and lets the push-down work happen later without coordinating consumer changes.
+
+## References
+
+- Companion follow-up: pgstore SQL-native GraphQuery (recursive
+CTEs + composite indexes) — to be filed once this lands.
+- The Python prototype at `.ignored/acl-prototype/store.py` was
+the design validator for this DSL shape.

--- a/tickets/relations/TKT-ZYH3--affects--store-backends.md
+++ b/tickets/relations/TKT-ZYH3--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYH3
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-ZYH3--has-implementation--IMPL-B4FV.md
+++ b/tickets/relations/TKT-ZYH3--has-implementation--IMPL-B4FV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYH3
+relation: has-implementation
+to: IMPL-B4FV
+---

--- a/tickets/relations/TKT-ZYH3--has-planning--PLAN-GWM5.md
+++ b/tickets/relations/TKT-ZYH3--has-planning--PLAN-GWM5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYH3
+relation: has-planning
+to: PLAN-GWM5
+---

--- a/tickets/relations/TKT-ZYH3--has-review--REV-88VJ.md
+++ b/tickets/relations/TKT-ZYH3--has-review--REV-88VJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYH3
+relation: has-review
+to: REV-88VJ
+---

--- a/tickets/relations/TKT-ZYH3--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-ZYH3--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYH3
+relation: implements
+to: FEAT-CO4YP
+---


### PR DESCRIPTION
## Summary

- Add `store.GraphQuery` / `GraphCount` — a generic graph-shape query DSL with no consumer vocabulary (no ACL, no search, no analyze). Composes `HasInbound` / `HasOutbound` predicates, optional endpoint-side `InheritThrough` (groups-shaped), and optional entity-side `EntityInheritThrough` (containment-shaped).
- Single backend-agnostic naive implementation in `internal/store/graphquerynaive`; all three backends (fsstore, memstore, pgstore) delegate to it. Structural defense against backend drift.
- New `storetest.RunGraphQueryTests` conformance suite wired into `RunAll` — every existing and future store impl runs the same scenarios for free.

This PR is **PR 1 of 4** in the ACL v1 split (see [`.ignored/acl-v1-split-plan.md`](.ignored/acl-v1-split-plan.md) on the reference branch). It deliberately ships **no consumer** — the DSL stands alone, future PRs will consume it. The reference branch `feat/acl-v1-tkt-svxl` has the full design context (22 review-responses across two cranky-code-reviewer passes); none of those findings apply to this PR's scope (the DSL itself was clean; all findings landed on consumers).

A SQL-pushdown impl for pgstore (one-query recursive CTE shape) is the natural follow-up — the package docstring flags it; the naive delegation is correct but won't scale on pgstore under non-trivial load.

## Test plan

- [x] `just ci` — lint, fmt, arch-lint, full tests with race, docs all green
- [x] `just test-postgres` — pgstore tests green against a real local postgres (the same `RunGraphQueryTests` suite via `RunAll`)
- [x] `RunGraphQueryTests` covers: HasInbound direct, HasOutbound direct, InheritThrough endpoint expansion, EntityInheritThrough entity expansion, both expansions composed, OfTypes filter, self-loop termination, multi-node cycle termination, Depth=0 no-op, GraphCount (matched, total)
- [x] Conformance suite runs against fsstore, memstore, pgstore via the same `RunAll` invocation — same inputs, same outputs