### PR TITLE
fix(frontend): gate backtick-autocomplete test hook behind __E2E_TEST_HOOKS__ (#890)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,9 +185,12 @@ jobs:
         working-directory: frontend
         run: npm ci
 
-      - name: Build rela-server (embeds built frontend)
+      - name: Build rela-server (embeds E2E dev-mode frontend)
+        # build:e2e produces a development-mode bundle (import.meta.env.DEV
+        # === true) so DEV-guarded test hooks compile in for the E2E suite.
+        # Release builds use the production `build`, which strips them (#890).
         run: |
-          cd frontend && npm run build && cd ..
+          cd frontend && npm run build:e2e && cd ..
           CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o bin/rela-server ./cmd/rela-server
 
       - name: Install e2e dependencies

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -30,6 +30,9 @@ export default tseslint.config(
     languageOptions: {
       globals: {
         ...globals.browser,
+        // Compile-time flag injected by vite `define` (see vite.config.ts /
+        // vite-env.d.ts). Declared here so no-undef recognises it (#890).
+        __E2E_TEST_HOOKS__: 'readonly',
       },
     },
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
+    "build:e2e": "vue-tsc -b && vite build --mode development",
     "preview": "vite preview",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/frontend/src/components/forms/MarkdownEditor.vue
+++ b/frontend/src/components/forms/MarkdownEditor.vue
@@ -148,15 +148,20 @@ onMounted(() => {
   // composable owns its own CodeMirror subscriptions and runs them
   // alongside the existing change handler.
   //
-  // Tests can shrink the open-delay grace period to a few milliseconds
-  // by setting `window.__BACKTICK_AUTOCOMPLETE_DELAY_MS__` before the
-  // editor mounts. Production builds never set this, so the 600 ms
-  // default stands (RR-1629).
-  const w = window as Window & { __BACKTICK_AUTOCOMPLETE_DELAY_MS__?: number }
-  const testDelay =
-    typeof w.__BACKTICK_AUTOCOMPLETE_DELAY_MS__ === 'number'
-      ? w.__BACKTICK_AUTOCOMPLETE_DELAY_MS__
-      : undefined
+  // Tests can shrink the open-delay grace period to a few milliseconds by
+  // setting `window.__BACKTICK_AUTOCOMPLETE_DELAY_MS__` before the editor
+  // mounts. The read is guarded by the compile-time `__E2E_TEST_HOOKS__` flag
+  // (vite define) so the whole block — and the magic property name — is
+  // tree-shaken out of production bundles; the test knob must not ship
+  // (issue #890). The flag is true only for the E2E dev-mode build
+  // (npm run build:e2e), so the knob still works there (RR-1629).
+  let testDelay: number | undefined
+  if (__E2E_TEST_HOOKS__) {
+    const w = window as Window & { __BACKTICK_AUTOCOMPLETE_DELAY_MS__?: number }
+    if (typeof w.__BACKTICK_AUTOCOMPLETE_DELAY_MS__ === 'number') {
+      testDelay = w.__BACKTICK_AUTOCOMPLETE_DELAY_MS__
+    }
+  }
   autocomplete.value = useBacktickAutocomplete(
     editor,
     () => schemaStore.entityTypes,

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,5 +1,11 @@
 /// <reference types="vite/client" />
 
+// Compile-time flag injected by vite `define` (see vite.config.ts). True
+// only for the E2E dev-mode build (`npm run build:e2e`); false for the
+// production build, where references to it are tree-shaken away. Gates
+// test-only hooks so they never ship in production bundles (issue #890).
+declare const __E2E_TEST_HOOKS__: boolean
+
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
   const component: DefineComponent<object, object, unknown>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,13 +6,26 @@ import { fileURLToPath, URL } from 'node:url'
 // For e2e tests, VITE_API_BASE is set by global-setup.ts
 const apiBase = process.env.VITE_API_BASE || 'http://localhost:8080'
 
-export default defineConfig(() => {
+export default defineConfig(({ mode }) => {
   // Log at config evaluation time so we can see what port is being used
   console.error(`[vite.config] API proxy target: ${apiBase}`)
+
+  // __E2E_TEST_HOOKS__ gates test-only knobs (e.g. the backtick-autocomplete
+  // delay override) so they are tree-shaken out of production bundles but
+  // compiled in for the E2E suite. It is true only for the dev-mode build
+  // (`vite build --mode development`, i.e. `npm run build:e2e`); the default
+  // production `vite build` runs in 'production' mode, leaving it false.
+  // import.meta.env.DEV can't be used: it is false for ANY `vite build`
+  // regardless of --mode, so it would strip the hooks even from the E2E
+  // bundle. See issue #890.
+  const e2eTestHooks = mode === 'development'
 
   return {
     plugins: [vue()],
     base: '/',
+    define: {
+      __E2E_TEST_HOOKS__: JSON.stringify(e2eTestHooks),
+    },
     build: {
       outDir: '../internal/dataentry/static/v2',
       emptyOutDir: true,

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,6 +4,12 @@ import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   plugins: [vue()],
+  // Mirror the vite `define` so components referencing the compile-time
+  // __E2E_TEST_HOOKS__ flag don't ReferenceError under vitest. Off in unit
+  // tests — test hooks are an E2E concern (issue #890).
+  define: {
+    __E2E_TEST_HOOKS__: 'false',
+  },
   test: {
     globals: true,
     environment: 'happy-dom',

--- a/justfile
+++ b/justfile
@@ -22,6 +22,13 @@ build-server: build-frontend
     @mkdir -p {{build_dir}}
     CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o {{build_dir}}/rela-server ./cmd/rela-server
 
+# Build rela-server embedding the E2E (development-mode) frontend, so
+# DEV-guarded test hooks are available to the E2E suite (issue #890).
+build-server-e2e: build-frontend-e2e
+    @echo "Building rela-server (E2E frontend)..."
+    @mkdir -p {{build_dir}}
+    CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o {{build_dir}}/rela-server ./cmd/rela-server
+
 # Build the desktop app
 build-desktop: build-frontend
     @echo "Building rela-desktop..."
@@ -104,17 +111,17 @@ e2e-install:
     cd e2e && npx playwright install chromium
 
 # Run E2E tests (tests data entry UI via rela-server)
-e2e: build-server
+e2e: build-server-e2e
     @echo "Running E2E tests..."
     cd e2e && npm test
 
 # Run E2E tests in headed mode (visible browser)
-e2e-headed: build-server
+e2e-headed: build-server-e2e
     @echo "Running E2E tests (headed)..."
     cd e2e && npm run test:headed
 
 # Run E2E tests with Playwright UI
-e2e-ui: build-server
+e2e-ui: build-server-e2e
     @echo "Running E2E tests with Playwright UI..."
     cd e2e && npm run test:ui
 
@@ -331,6 +338,13 @@ install-frontend:
 # Build Vue frontend for production
 build-frontend: install-frontend
     cd frontend && npm run build
+
+# Build Vue frontend in development mode for E2E. This bundle has
+# import.meta.env.DEV === true, so DEV-guarded test hooks (e.g. the
+# backtick-autocomplete delay knob, issue #890) compile in. Production
+# builds use `build-frontend`, which strips them.
+build-frontend-e2e: install-frontend
+    cd frontend && npm run build:e2e
 
 # Type-check Vue frontend
 typecheck-frontend:

--- a/tickets/entities/automated-measures/prod-bundle-test-hook-strip.md
+++ b/tickets/entities/automated-measures/prod-bundle-test-hook-strip.md
@@ -1,0 +1,9 @@
+---
+id: prod-bundle-test-hook-strip
+type: automated-measure
+title: 'Test: test-only hooks are stripped from production bundles'
+description: 'Guards BUG-XSQCR. The __E2E_TEST_HOOKS__ vite define gates test-only knobs (e.g. the backtick-autocomplete delay) so they tree-shake out of the production `npm run build` bundle while compiling into the `npm run build:e2e` (development-mode) bundle the e2e suite embeds. The e2e spec markdown-editor-backtick-autocomplete.spec.ts (6 tests) exercises the knob via useFastAutocompleteDelay and passes against the e2e build, proving the production guard does not break e2e.'
+kind: ci
+location: frontend/vite.config.ts (__E2E_TEST_HOOKS__ define) + frontend/package.json (build vs build:e2e) + e2e/tests/markdown-editor-backtick-autocomplete.spec.ts
+status: active
+---

--- a/tickets/entities/bugs/BUG-XSQCR.md
+++ b/tickets/entities/bugs/BUG-XSQCR.md
@@ -1,0 +1,35 @@
+---
+id: BUG-XSQCR
+type: bug
+title: Test hook window.__BACKTICK_AUTOCOMPLETE_DELAY_MS__ visible in production bundle
+description: |-
+    `MarkdownEditor.vue` read `window.__BACKTICK_AUTOCOMPLETE_DELAY_MS__` unconditionally on mount, so the test-only knob (which shrinks the inline-autocomplete open delay for e2e timing) and its magic property name shipped in the production bundle. An attacker with an XSS foothold could set it to force the popup on every backtick. No confidentiality/integrity impact — insertion still goes through `insertEntityRef` denylist validation — but test knobs should not be present in production bundles.
+
+    **The catch:** the issue's recommended `import.meta.env.DEV` guard does not work here. The e2e suite runs against `bin/rela-server`, which embeds the frontend produced by `vite build` — and `import.meta.env.DEV` is `false` for **any** `vite build`, regardless of `--mode`. Guarding on it would strip the knob from the exact bundle e2e tests against, breaking `useFastAutocompleteDelay` (form.page.ts). DEV is tied to the vite *command* (serve vs build), not the mode.
+
+    **Fix:** a compile-time `__E2E_TEST_HOOKS__` flag injected via vite `define`, true only when building in development mode (`vite build --mode development`, exposed as `npm run build:e2e`) and false for the default production `vite build`. The knob read is wrapped in `if (__E2E_TEST_HOOKS__)`, so it is tree-shaken (property name and all) from production bundles. A new `build-frontend-e2e` / `build-server-e2e` just target and the e2e recipes + CI E2E job build with `build:e2e`; the release build keeps the production `build`, so shipped binaries never contain the knob. vitest and eslint get the flag too (define / globals) so unit tests and lint don't break.
+
+    **Trade-off:** the e2e suite now exercises a development-mode bundle (unminified, DEV warnings) rather than the exact production artifact — a mild, accepted fidelity reduction.
+priority: low
+effort: s
+why1: MarkdownEditor.vue read window.__BACKTICK_AUTOCOMPLETE_DELAY_MS__ on every mount with no build guard, so the read shipped in production.
+why2: The knob was added for e2e timing control (RR-1629) and guarding it was deferred; the magic global was the simplest way to pass a value into the component before mount.
+why3: The obvious guard (import.meta.env.DEV) is unusable because the e2e suite runs the production-embedded bundle, where DEV is false — so a naive guard would break the very tests that need the knob.
+why4: import.meta.env.DEV tracks the vite command (serve vs build), not --mode, so there was no built-in flag that distinguishes "e2e build" from "release build" — a project-specific compile-time flag was needed.
+why5: There was no established convention for "test-only code that must compile into the e2e bundle but not the release bundle"; __E2E_TEST_HOOKS__ now provides that seam for future test hooks.
+prevention: |-
+    Verified by build: a production `npm run build` bundle contains no
+    `__BACKTICK_AUTOCOMPLETE_DELAY_MS__` reference; the `npm run build:e2e`
+    bundle does. The existing e2e spec
+    `markdown-editor-backtick-autocomplete.spec.ts` (6 tests) exercises the
+    knob via useFastAutocompleteDelay and passes against the e2e build,
+    confirming the guard didn't break e2e.
+
+    The `__E2E_TEST_HOOKS__` compile-time flag is the reusable seam for any
+    future test-only hook that must reach the e2e bundle but not production —
+    declared in vite.config.ts (define), vite-env.d.ts (type), vitest.config.ts
+    (define, false), and eslint.config.js (global).
+status: done
+---
+
+See GitHub issue #890.

--- a/tickets/relations/BUG-XSQCR--adds-measure--prod-bundle-test-hook-strip.md
+++ b/tickets/relations/BUG-XSQCR--adds-measure--prod-bundle-test-hook-strip.md
@@ -1,0 +1,5 @@
+---
+from: BUG-XSQCR
+relation: adds-measure
+to: prod-bundle-test-hook-strip
+---

--- a/tickets/relations/BUG-XSQCR--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-XSQCR--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-XSQCR
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-XSQCR--fixes--FEAT-014.md
+++ b/tickets/relations/BUG-XSQCR--fixes--FEAT-014.md
@@ -1,0 +1,5 @@
+---
+from: BUG-XSQCR
+relation: fixes
+to: FEAT-014
+---


### PR DESCRIPTION
Fixes #890.

## Problem

`MarkdownEditor.vue` read `window.__BACKTICK_AUTOCOMPLETE_DELAY_MS__` unconditionally on mount, so the test-only knob shipped in the production bundle. Low severity (no confidentiality/integrity impact — insertion still goes through `insertEntityRef` denylist validation), but test knobs shouldn't be in production builds.

## Why the issue's fix doesn't work

The recommended `import.meta.env.DEV` guard would **break e2e**. The e2e suite runs `bin/rela-server`, which embeds the frontend from `vite build` — and `import.meta.env.DEV` is `false` for **any** `vite build` regardless of `--mode` (DEV tracks the vite *command*, serve vs build). So that guard strips the knob from the exact bundle e2e tests against, breaking `useFastAutocompleteDelay`.

## Fix

A compile-time `__E2E_TEST_HOOKS__` flag injected via vite `define`, true only for the development-mode build (`vite build --mode development` = `npm run build:e2e`), false for the default production `vite build`. The knob read is wrapped in `if (__E2E_TEST_HOOKS__)`, so it's tree-shaken (property name and all) from production bundles.

- New `build:e2e` npm script; `build-frontend-e2e` / `build-server-e2e` just targets; e2e recipes + CI E2E job build with `build:e2e`. **Release build keeps the production `build`** → shipped binaries never contain the knob.
- Flag declared for vitest (`define`), TypeScript (`vite-env.d.ts`), and eslint (`globals`).

**Trade-off:** e2e now exercises a dev-mode bundle (unminified) rather than the exact prod artifact — a mild, accepted fidelity reduction.

## Verification

- Production `npm run build` bundle: `__BACKTICK_AUTOCOMPLETE_DELAY_MS__` **absent** ✓
- `npm run build:e2e` bundle: **present** ✓
- `markdown-editor-backtick-autocomplete.spec.ts` (6 tests) passes against the e2e build — knob still works, no regression.
- `vue-tsc`, `eslint`, `vitest` (915) — clean.

Dogfood: BUG-XSQCR (`fixes` FEAT-014, `affects` data-entry-ui, `adds-measure` prod-bundle-test-hook-strip).