### PR TITLE
feat(acl): Subject + Source + Request + resolver (TKT-GV50)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -380,7 +380,9 @@ deps:
       - store
   acl:
     mayDependOn:
+      - entity
       - principal
+      - store
   affordances:
     mayDependOn:
       - acl

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -72,6 +72,7 @@ components:
   store:            { in: internal/store }
   fsstore:          { in: internal/store/fsstore }
   memstore:         { in: internal/store/memstore }
+  graphquerynaive:  { in: internal/store/graphquerynaive }
   pgstore:          { in: internal/store/pgstore }
   storeutil:        { in: internal/store/storeutil }
 
@@ -533,6 +534,7 @@ deps:
   fsstore:
     mayDependOn:
       - cache
+      - graphquerynaive
       - storage
       - store
       - storeutil
@@ -540,10 +542,16 @@ deps:
       - goldmark
   memstore:
     mayDependOn:
+      - graphquerynaive
       - store
       - storeutil
+  graphquerynaive:
+    mayDependOn:
+      - entity
+      - store
   pgstore:
     mayDependOn:
+      - graphquerynaive
       - search
       - store
       - storeutil

--- a/cmd/rela-server/main_acl_test.go
+++ b/cmd/rela-server/main_acl_test.go
@@ -20,8 +20,8 @@ func TestShouldWarnNoACL(t *testing.T) {
 		{"nop + read-only → silent (read-only is the stronger guarantee)", acl.NopACL{}, true, false},
 		{"read-only ACL + no flag → silent (ReadOnlyACL is not NopACL)", acl.ReadOnlyACL{}, false, false},
 		{"read-only ACL + flag → silent (both belt and suspenders)", acl.ReadOnlyACL{}, true, false},
-		{"declarative ACL + no flag → silent (operator already configured policy)", acl.NewDeclarative(&acl.Policy{}), false, false},
-		{"declarative ACL + flag → silent (flag wins, no need to nag)", acl.NewDeclarative(&acl.Policy{}), true, false},
+		{"declarative ACL + no flag → silent (operator already configured policy)", mustDeclarative(t), false, false},
+		{"declarative ACL + flag → silent (flag wins, no need to nag)", mustDeclarative(t), true, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -31,4 +31,13 @@ func TestShouldWarnNoACL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mustDeclarative(t *testing.T) acl.ACL {
+	t.Helper()
+	d, err := acl.NewDeclarative(&acl.Policy{}, acl.NullGraph{})
+	if err != nil {
+		t.Fatalf("acl.NewDeclarative: %v", err)
+	}
+	return d
 }

--- a/internal/acl/acl.go
+++ b/internal/acl/acl.go
@@ -34,18 +34,17 @@ type ACL interface {
 }
 
 // WriteRequest describes the operation an ACL is being asked to
-// authorize. The caller (typically [entitymanager.Manager]) populates
-// either EntityType (entity ops) or both EntityType and RelationType
-// (relation ops, where EntityType is the *source* entity's type).
+// authorize. The caller (typically [entitymanager.Manager]) names the
+// verb in Op and the target in Subject — either an [EntitySubject] or
+// a [RelationSubject].
 //
-// The split lets policy authors gate writes by the entity types a
-// principal can mutate while a separate `role_relations` map (PR 2)
-// gates role-conferring relation writes via the delegate-X
-// permission check.
+// Subject is required: a nil Subject is a programmer error and panics.
+// The legacy EntityType/RelationType string fields were removed
+// (RR-X1TE) so callers cannot accidentally request authz with a half-
+// populated request that bypasses the unstamped-principal check.
 type WriteRequest struct {
-	Op           Op
-	EntityType   string
-	RelationType string
+	Op      Op
+	Subject Subject
 }
 
 // Op identifies the verb being requested.
@@ -82,6 +81,16 @@ type Decision struct {
 	// ACL; never contains raw policy data so 403 bodies don't leak
 	// the full effective-role set.
 	Reason string
+
+	// Attributions carries the full (role, source) set the resolver
+	// considered. Audit consumers read this to record the attribution
+	// chain server-side; the wire 403 path ([ForbiddenError.Error])
+	// deliberately ignores it so deny bodies don't leak the principal's
+	// role/group topology to unauthorized callers. May be empty when
+	// the deny short-circuited before role resolution (e.g.
+	// delegate-permission gate) or when the implementation is one of
+	// the constant deciders ([NopACL], [ReadOnlyACL]).
+	Attributions []RoleAttribution
 }
 
 // ErrForbidden is the sentinel that [ForbiddenError] reports via

--- a/internal/acl/acl.go
+++ b/internal/acl/acl.go
@@ -17,6 +17,35 @@
 // on deny it returns [*ForbiddenError] and records a `denied-write`
 // audit row. The data-entry HTTP handler maps that error to a
 // structured 403 response.
+//
+// # Request pipeline
+//
+// One write call moves through these steps:
+//
+//	     ┌────────────┐  WriteRequest{Op, Subject}
+//	     │  caller    │ ─────────────────────────────────┐
+//	     └────────────┘                                  │
+//	                                                     ▼
+//	┌───────────────────┐    ForPrincipal(p)      ┌─────────────┐
+//	│  *Declarative     │ ───────────────────────▶│  *Request   │
+//	│  (policy + graph) │                         │  (per-call) │
+//	└───────────────────┘                         └──────┬──────┘
+//	                                                     │
+//	                                                     │ AuthorizeWrite
+//	                                                     ▼
+//	                                          ┌────────────────────┐
+//	                                          │     Decision       │
+//	                                          │ Allow/RuleKind/    │
+//	                                          │ RuleID/Reason/     │
+//	                                          │ Attributions       │
+//	                                          └────────────────────┘
+//
+// A [*Request] is per-call, not goroutine-safe, and amortizes one
+// member-of walk across every per-entity probe in the same logical
+// operation. [WithRequest]/[FromContext] thread it through call chains
+// so the same Request is reused by downstream resolvers (e.g. the
+// affordance resolver in a list response) instead of each call
+// re-walking the graph.
 package acl
 
 import (

--- a/internal/acl/authz_write.go
+++ b/internal/acl/authz_write.go
@@ -1,0 +1,97 @@
+package acl
+
+import (
+	"context"
+	"fmt"
+)
+
+// authorizeWrite implements per-Request write authz. v1 only:
+//   - subject-aware dispatch (EntitySubject vs RelationSubject)
+//   - entity-id-aware local-role evaluation for EntitySubject
+//   - primary-source attribution surfaced in the Decision
+//
+// A nil Subject is a programmer error: every production caller in
+// entitymanager / dataentry populates Subject, and tests use
+// EntitySubject{} / RelationSubject{} explicitly. The legacy
+// "fall through to global-roles-only" path that briefly existed
+// during the v0→v1 migration was removed (RR-X1TE) because it could
+// silently downgrade an unstamped principal to v0 semantics without
+// the isUnstamped check.
+func (r *Request) authorizeWrite(ctx context.Context, req WriteRequest) Decision {
+	switch s := req.Subject.(type) {
+	case EntitySubject:
+		return r.authorizeEntityWrite(ctx, s)
+	case RelationSubject:
+		return r.authorizeRelationWrite(ctx, s)
+	default:
+		// Sealed sum (incl. nil Subject): unreachable from any well-formed
+		// caller. Panic so a missing case or a forgotten Subject surfaces
+		// in CI rather than as silent-deny in production.
+		panic(fmt.Sprintf("acl: unhandled Subject variant %T", s))
+	}
+}
+
+func (r *Request) authorizeEntityWrite(ctx context.Context, s EntitySubject) Decision {
+	// With an ID, fold in local-role probes; without, globals-only
+	// (Op=Create has no ID yet at authz time).
+	var attrs []RoleAttribution
+	if s.ID != "" {
+		attrs = r.computeForEntity(ctx, s.ID)
+	} else {
+		attrs = r.Globals(ctx).Attributions
+	}
+	return r.decideFromAttrs(attrs, s.Type, "no role grants write on type %q")
+}
+
+func (r *Request) authorizeRelationWrite(ctx context.Context, s RelationSubject) Decision {
+	// Delegate-X gate for role-relation writes.
+	if rr, ok := r.d.policy.RoleRelations[s.Type]; ok && rr.RequiresPermission != "" {
+		if !r.holdsPermission(ctx, rr.RequiresPermission) {
+			return Decision{
+				Allow:    false,
+				RuleKind: "delegate-permission",
+				RuleID:   rr.RequiresPermission,
+				Reason: fmt.Sprintf("writing %q relations requires permission %q",
+					s.Type, rr.RequiresPermission),
+			}
+		}
+	}
+	// Type-level gate: principal needs write on the source entity's
+	// type. The To side is not part of RelationSubject — see that
+	// type's godoc for the rationale (RR-F9M9).
+	attrs := r.Globals(ctx).Attributions
+	return r.decideFromAttrs(attrs, s.FromType,
+		"no role grants write on relations from type %q")
+}
+
+// decideFromAttrs returns an allow Decision when any role in `attrs`
+// grants write on `target`; otherwise a structured deny with the
+// reason templated against `target`.
+//
+// The full attribution set propagates into the returned Decision on
+// both branches so audit consumers can record every (role, source)
+// the resolver considered (AC7). The wire 403 path
+// ([ForbiddenError.Error]) ignores Attributions — only audit reads it.
+func (r *Request) decideFromAttrs(attrs []RoleAttribution, target, denyFmt string) Decision {
+	for _, a := range attrs {
+		role, ok := r.d.policy.Roles[a.Role]
+		if !ok {
+			continue
+		}
+		if roleGrantsWrite(role, target) {
+			return Decision{
+				Allow:        true,
+				RuleKind:     "role-grant",
+				RuleID:       a.Role,
+				Attributions: attrs,
+			}
+		}
+	}
+	return Decision{
+		Allow:        false,
+		RuleKind:     "role-grant",
+		RuleID:       "-",
+		Reason:       fmt.Sprintf(denyFmt, target),
+		Attributions: attrs,
+	}
+}

--- a/internal/acl/declarative.go
+++ b/internal/acl/declarative.go
@@ -2,8 +2,8 @@ package acl
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"slices"
 
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
@@ -12,133 +12,75 @@ import (
 // a [Policy] (loaded from `acl.yaml`) with the [principal.Principal]
 // carried on each request's context to answer [ACL.AuthorizeWrite].
 //
-// v0 scope:
+// Every [WriteRequest] carries a [Subject] (sum of [EntitySubject] /
+// [RelationSubject]) — the resolver dispatches on the variant and
+// runs the full path: group expansion via member-of, containment
+// inheritance through `inherit_roles_through`, and typed-Source
+// attribution for the audit log.
 //
-//   - **Global roles only.** A principal's effective role set is
-//     `Assignments[user]` plus the `default` role (if defined). Groups
-//     and transitive `member-of` expansion are deferred to v1.
+// Semantics:
+//
 //   - **Union semantics.** Any role granting write on the target
 //     entity type → allow. The returned RuleID names the first role
 //     that matched, for debuggability.
 //   - **Delegate-X tamper resistance.** Writes to a relation type
 //     listed in [Policy.RoleRelations] require the writer to hold the
 //     declared permission. See [RoleRelationDef.RequiresPermission].
-//
-// PR 2 wires this in unit tests only; PR 3 makes [appbuild.Discover]
-// load it.
+//   - **Unstamped principals are hard-denied.** A principal with
+//     User="" / User="unknown" or Tool="" / Tool="unknown" fails the
+//     [ForPrincipal] check; the deny surfaces as RuleKind="role-grant"
+//     with a Reason that names ErrUnstampedPrincipal.
 type Declarative struct {
 	policy *Policy
+	graph  Graph // required: NewDeclarative rejects nil
 }
 
-// NewDeclarative wraps a [Policy] as an [ACL]. The Policy must be
-// non-nil; the caller (typically appbuild) loads it via
-// [LoadPolicy] and falls back to [NopACL] when no `acl.yaml` exists.
-func NewDeclarative(p *Policy) *Declarative {
-	return &Declarative{policy: p}
+// NewDeclarative wraps a [Policy] + [Graph] as an [ACL]. The Policy
+// must be non-nil; the Graph supplies the read-side access the
+// resolver needs for member-of walks and ancestor probes. Tests that
+// don't exercise group expansion can pass [NullGraph]; production
+// wiring (appbuild) passes a store-backed [StoreGraph].
+func NewDeclarative(p *Policy, g Graph) (*Declarative, error) {
+	if p == nil {
+		return nil, errors.New("acl: NewDeclarative: policy must be non-nil")
+	}
+	if g == nil {
+		return nil, errors.New("acl: NewDeclarative: graph must be non-nil")
+	}
+	return &Declarative{policy: p, graph: g}, nil
 }
 
-// AuthorizeWrite implements [ACL.AuthorizeWrite].
+// Policy returns the policy this Declarative was constructed with.
+// Exposed so downstream consumers (chiefly the affordance resolver)
+// can read role/grant definitions from the same source the resolver
+// uses for role attribution — eliminating the mismatched-pair foot-
+// cannon where a caller might pass policyA to the affordance resolver
+// while wiring a Declarative built from policyB (RR-WTLD).
 //
-// Order of checks:
-//
-//  1. If `req.RelationType` names a role-relation that declares a
-//     `requires_permission`, the writer must hold that permission.
-//     Deny with `RuleKind="delegate-permission"` on miss.
-//  2. Otherwise (and for entity writes), any role in the principal's
-//     effective set whose `write` list contains the target type — or
-//     the wildcard `"*"` — allows. The matching role's name surfaces
-//     as `RuleID`.
-//  3. No role granted → deny with `RuleKind="role-grant"`,
-//     `RuleID="-"`.
-//
-// For relation writes, `req.EntityType` carries the source entity's
-// type (the caller in entitymanager looks it up). Empty EntityType
-// is treated as the literal target `"relation"` — denied by default
-// since no role would grant write on a synthetic type, surfacing the
-// misuse in the deny reason.
+// **The returned *Policy must be treated as immutable** (RR-9GN3).
+// The resolver caches no policy state; every AuthorizeWrite reads
+// fields back through this pointer. Mutating Roles, Assignments,
+// or any nested map invalidates the resolver's safety guarantees
+// from the next call onward, including the unstamped-principal
+// check and the delegate-X gates. Callers that need a mutated
+// policy build a fresh Declarative with [NewDeclarative].
+func (d *Declarative) Policy() *Policy { return d.policy }
+
+// AuthorizeWrite implements [ACL.AuthorizeWrite]. Opens a Request for
+// the principal carried on ctx, then delegates to
+// [Request.AuthorizeWrite] which dispatches on Subject variant. An
+// unstamped principal short-circuits to a structured deny.
 func (d *Declarative) AuthorizeWrite(ctx context.Context, req WriteRequest) Decision {
-	p := principal.From(ctx)
-	roles := d.effectiveRoles(p)
-
-	// 1. Delegate-X gate for role-relation writes.
-	if req.RelationType != "" {
-		if rr, ok := d.policy.RoleRelations[req.RelationType]; ok && rr.RequiresPermission != "" {
-			if !d.holdsPermission(roles, rr.RequiresPermission) {
-				return Decision{
-					Allow:    false,
-					RuleKind: "delegate-permission",
-					RuleID:   rr.RequiresPermission,
-					Reason: fmt.Sprintf("writing '%s' relations requires permission '%s'",
-						req.RelationType, rr.RequiresPermission),
-				}
-			}
+	r, err := d.ForPrincipal(principal.From(ctx))
+	if err != nil {
+		return Decision{
+			Allow:    false,
+			RuleKind: "role-grant",
+			RuleID:   "-",
+			Reason:   fmt.Sprintf("acl.ForPrincipal: %v", err),
 		}
 	}
-
-	// 2. Type-level write grant. Union across roles; first hit wins
-	//    for RuleID (deterministic via effectiveRoles ordering).
-	target := req.EntityType
-	if target == "" {
-		target = "relation"
-	}
-	for _, name := range roles {
-		role, ok := d.policy.Roles[name]
-		if !ok {
-			continue
-		}
-		if roleGrantsWrite(role, target) {
-			return Decision{Allow: true, RuleKind: "role-grant", RuleID: name}
-		}
-	}
-
-	return Decision{
-		Allow:    false,
-		RuleKind: "role-grant",
-		RuleID:   "-",
-		Reason:   fmt.Sprintf("no role grants write on type '%s'", target),
-	}
-}
-
-// effectiveRoles returns the role names applicable to p, in priority
-// order: explicit assignment first, then the `default` role (when
-// defined). The order is stable so [AuthorizeWrite] deterministically
-// reports the same RuleID for a given Allow.
-//
-// v0 is global-roles-only: no group expansion. If
-// `Assignments[user]` names an undefined role, it is dropped (a
-// load-time warning will have been emitted in v1; v0 silently
-// ignores — operators discover the typo via `analyze_*` style
-// follow-up tickets). [EveryoneRole] is always appended last if defined.
-func (d *Declarative) effectiveRoles(p principal.Principal) []string {
-	var out []string
-	if name, ok := d.policy.Assignments[p.User]; ok {
-		if _, defined := d.policy.Roles[name]; defined {
-			out = append(out, name)
-		}
-	}
-	if _, ok := d.policy.Roles[EveryoneRole]; ok {
-		// Only append it if it isn't already the principal's explicit
-		// role (defensive against `assignments: {alice: everyone}`).
-		if !slices.Contains(out, EveryoneRole) {
-			out = append(out, EveryoneRole)
-		}
-	}
-	return out
-}
-
-// holdsPermission reports whether any of `roles` lists `perm` in its
-// Permissions. Union semantics — one match is enough.
-func (d *Declarative) holdsPermission(roles []string, perm string) bool {
-	for _, name := range roles {
-		role, ok := d.policy.Roles[name]
-		if !ok {
-			continue
-		}
-		if slices.Contains(role.Permissions, perm) {
-			return true
-		}
-	}
-	return false
+	return r.AuthorizeWrite(ctx, req)
 }
 
 // roleGrantsWrite reports whether `role.Write` covers `target` —

--- a/internal/acl/declarative_test.go
+++ b/internal/acl/declarative_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 // testPolicy is the fixture used across declarative tests. Mirrors the
-// example operators see in docs/security.md (PR 3): three real roles +
-// the built-in everyone role, with one role-relation gated by a
-// delegate permission.
+// example operators see in docs/security.md: three real roles + the
+// built-in everyone role, with one role-relation gated by a delegate
+// permission.
 func testPolicy() *acl.Policy {
 	return &acl.Policy{
 		UserEntityType: "person",
@@ -52,17 +52,49 @@ func testPolicy() *acl.Policy {
 	}
 }
 
-// ctxAs returns a context with the given principal user attached
-// (Tool=cli for stability — the ACL doesn't gate on tool in v0).
+// newACL builds a Declarative for tests that don't exercise group
+// expansion (the resolver still needs a non-nil Graph; [acl.NullGraph]
+// returns empty for every probe). Production wiring supplies a
+// store-backed graph.
+func newACL(t *testing.T, p *acl.Policy) *acl.Declarative {
+	t.Helper()
+	d, err := acl.NewDeclarative(p, acl.NullGraph{})
+	if err != nil {
+		t.Fatalf("acl.NewDeclarative: %v", err)
+	}
+	return d
+}
+
+// ctxAs returns a context with the given principal user attached.
 func ctxAs(user string) context.Context {
 	return principal.With(context.Background(), principal.Principal{User: user, Tool: principal.ToolCLI})
 }
 
+// entityCreate builds the canonical WriteRequest for an entity create
+// of the given type. Subject is required; tests for the type-level
+// grant check fold the create case so the entity ID is empty.
+func entityCreate(etype string) acl.WriteRequest {
+	return acl.WriteRequest{Op: acl.OpCreate, Subject: acl.EntitySubject{Type: etype}}
+}
+
+// relCreate builds the canonical WriteRequest for a relation create
+// from a fromType entity via relType. v1 evaluates only FromType; To*
+// fields are unused by the resolver today (see RelationSubject doc).
+func relCreate(fromType, relType string) acl.WriteRequest {
+	return acl.WriteRequest{
+		Op: acl.OpCreate,
+		Subject: acl.RelationSubject{
+			Type:     relType,
+			FromType: fromType,
+		},
+	}
+}
+
 // AC2.2: a role's `write` list grants creation of that type.
 func TestAuthorizeWrite_RoleGrantsType_Allows(t *testing.T) {
-	d := acl.NewDeclarative(testPolicy())
+	d := newACL(t, testPolicy())
 
-	got := d.AuthorizeWrite(ctxAs("alice"), acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket"})
+	got := d.AuthorizeWrite(ctxAs("alice"), entityCreate("ticket"))
 	if !got.Allow {
 		t.Fatalf("Allow = false, want true. Decision = %+v", got)
 	}
@@ -76,9 +108,9 @@ func TestAuthorizeWrite_RoleGrantsType_Allows(t *testing.T) {
 
 // AC2.3: no role grants → structured deny.
 func TestAuthorizeWrite_NoRoleGrants_Denies(t *testing.T) {
-	d := acl.NewDeclarative(testPolicy())
+	d := newACL(t, testPolicy())
 
-	got := d.AuthorizeWrite(ctxAs("bob"), acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket"})
+	got := d.AuthorizeWrite(ctxAs("bob"), entityCreate("ticket"))
 	if got.Allow {
 		t.Fatalf("Allow = true, want false (reviewer has no write on ticket). Decision = %+v", got)
 	}
@@ -88,7 +120,7 @@ func TestAuthorizeWrite_NoRoleGrants_Denies(t *testing.T) {
 	if got.RuleID != "-" {
 		t.Errorf("RuleID = %q, want %q", got.RuleID, "-")
 	}
-	wantReason := "no role grants write on type 'ticket'"
+	wantReason := `no role grants write on type "ticket"`
 	if got.Reason != wantReason {
 		t.Errorf("Reason = %q, want %q", got.Reason, wantReason)
 	}
@@ -96,10 +128,10 @@ func TestAuthorizeWrite_NoRoleGrants_Denies(t *testing.T) {
 
 // AC2.4: wildcard `*` grants any type.
 func TestAuthorizeWrite_WildcardRole_Allows(t *testing.T) {
-	d := acl.NewDeclarative(testPolicy())
+	d := newACL(t, testPolicy())
 
 	for _, etype := range []string{"ticket", "concept", "person", "made-up-type"} {
-		got := d.AuthorizeWrite(ctxAs("jeroen"), acl.WriteRequest{Op: acl.OpCreate, EntityType: etype})
+		got := d.AuthorizeWrite(ctxAs("jeroen"), entityCreate(etype))
 		if !got.Allow {
 			t.Errorf("admin denied write on %q: %+v", etype, got)
 		}
@@ -112,16 +144,12 @@ func TestAuthorizeWrite_WildcardRole_Allows(t *testing.T) {
 // AC2.5: writing a role-relation that requires a permission the
 // principal doesn't hold → delegate-permission deny.
 func TestAuthorizeWrite_RoleRelation_DelegatePermissionMissing_Denies(t *testing.T) {
-	d := acl.NewDeclarative(testPolicy())
+	d := newACL(t, testPolicy())
 
 	// alice (contributor) holds delegate-reviewer but not
 	// delegate-contributor, so she cannot grant the contributor role
 	// via the `ticket-owner` relation.
-	got := d.AuthorizeWrite(ctxAs("alice"), acl.WriteRequest{
-		Op:           acl.OpCreate,
-		EntityType:   "ticket", // alice CAN write tickets, but the delegate gate runs first
-		RelationType: "ticket-owner",
-	})
+	got := d.AuthorizeWrite(ctxAs("alice"), relCreate("ticket", "ticket-owner"))
 	if got.Allow {
 		t.Fatalf("Allow = true, want false. Decision = %+v", got)
 	}
@@ -136,15 +164,11 @@ func TestAuthorizeWrite_RoleRelation_DelegatePermissionMissing_Denies(t *testing
 // AC2.5: writing the same role-relation with the required permission
 // proceeds to the type-level write check and (here) succeeds.
 func TestAuthorizeWrite_RoleRelation_DelegatePermissionHeld_Allows(t *testing.T) {
-	d := acl.NewDeclarative(testPolicy())
+	d := newACL(t, testPolicy())
 
 	// jeroen (admin) holds delegate-contributor AND can write any
 	// entity type via the `*` wildcard, so this allows.
-	got := d.AuthorizeWrite(ctxAs("jeroen"), acl.WriteRequest{
-		Op:           acl.OpCreate,
-		EntityType:   "ticket",
-		RelationType: "ticket-owner",
-	})
+	got := d.AuthorizeWrite(ctxAs("jeroen"), relCreate("ticket", "ticket-owner"))
 	if !got.Allow {
 		t.Fatalf("Allow = false, want true (admin holds delegate-contributor). Decision = %+v", got)
 	}
@@ -154,13 +178,9 @@ func TestAuthorizeWrite_RoleRelation_DelegatePermissionHeld_Allows(t *testing.T)
 // the delegate gate — any principal who can write the source entity
 // can write the relation.
 func TestAuthorizeWrite_RoleRelation_NoDelegateRequired_Allows(t *testing.T) {
-	d := acl.NewDeclarative(testPolicy())
+	d := newACL(t, testPolicy())
 
-	got := d.AuthorizeWrite(ctxAs("alice"), acl.WriteRequest{
-		Op:           acl.OpCreate,
-		EntityType:   "ticket",
-		RelationType: "open-relation",
-	})
+	got := d.AuthorizeWrite(ctxAs("alice"), relCreate("ticket", "open-relation"))
 	if !got.Allow {
 		t.Fatalf("Allow = false, want true (open-relation has no requires_permission). Decision = %+v", got)
 	}
@@ -169,12 +189,12 @@ func TestAuthorizeWrite_RoleRelation_NoDelegateRequired_Allows(t *testing.T) {
 // AC2.6: a principal with no Assignments entry inherits the `everyone`
 // role's capabilities.
 func TestAuthorizeWrite_UnknownPrincipal_GetsDefaultRole(t *testing.T) {
-	d := acl.NewDeclarative(testPolicy())
+	d := newACL(t, testPolicy())
 
 	// `everyone` has no write entries — every write is denied, but the
 	// deny RuleKind is role-grant (not "no roles at all"), proving the
 	// everyone role was consulted.
-	got := d.AuthorizeWrite(ctxAs("carol"), acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket"})
+	got := d.AuthorizeWrite(ctxAs("carol"), entityCreate("ticket"))
 	if got.Allow {
 		t.Fatalf("Allow = true, want false (default has no writes). Decision = %+v", got)
 	}
@@ -191,9 +211,9 @@ func TestAuthorizeWrite_DefaultRoleGrantsWrites(t *testing.T) {
 		Write: []string{"comment"},
 		Read:  []string{"*"},
 	}
-	d := acl.NewDeclarative(policy)
+	d := newACL(t, policy)
 
-	got := d.AuthorizeWrite(ctxAs("carol"), acl.WriteRequest{Op: acl.OpCreate, EntityType: "comment"})
+	got := d.AuthorizeWrite(ctxAs("carol"), entityCreate("comment"))
 	if !got.Allow {
 		t.Fatalf("Allow = false, want true. Decision = %+v", got)
 	}
@@ -213,7 +233,7 @@ func TestAuthorizeWrite_MultipleRoles_Unions(t *testing.T) {
 		Write: []string{"comment"},
 		Read:  []string{"*"},
 	}
-	d := acl.NewDeclarative(policy)
+	d := newACL(t, policy)
 
 	// bob is reviewer (writes review-response). With everyone also
 	// granting "comment", bob should be able to write both.
@@ -224,7 +244,7 @@ func TestAuthorizeWrite_MultipleRoles_Unions(t *testing.T) {
 		{"review-response", "reviewer"}, // explicit role wins
 		{"comment", acl.EveryoneRole},   // only everyone covers this
 	} {
-		got := d.AuthorizeWrite(ctxAs("bob"), acl.WriteRequest{Op: acl.OpCreate, EntityType: tc.etype})
+		got := d.AuthorizeWrite(ctxAs("bob"), entityCreate(tc.etype))
 		if !got.Allow {
 			t.Errorf("bob denied on %q: %+v", tc.etype, got)
 			continue
@@ -240,12 +260,12 @@ func TestAuthorizeWrite_MultipleRoles_Unions(t *testing.T) {
 func TestAuthorizeWrite_AssignmentToUndefinedRole_DropsToDefault(t *testing.T) {
 	policy := testPolicy()
 	policy.Assignments["typo"] = "contribtuor" // misspelled role name
-	d := acl.NewDeclarative(policy)
+	d := newACL(t, policy)
 
 	// the everyone role has no writes → deny on ticket. If the bad
 	// assignment leaked through, RuleID would be "contribtuor" (or
 	// the eval would Allow if we resolved the typo).
-	got := d.AuthorizeWrite(ctxAs("typo"), acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket"})
+	got := d.AuthorizeWrite(ctxAs("typo"), entityCreate("ticket"))
 	if got.Allow {
 		t.Fatalf("Allow = true, want false. Decision = %+v", got)
 	}
@@ -254,32 +274,55 @@ func TestAuthorizeWrite_AssignmentToUndefinedRole_DropsToDefault(t *testing.T) {
 	}
 }
 
-// Negative test: empty WriteRequest decays to target='relation' and
-// denies.
-func TestAuthorizeWrite_EmptyRequest_Denies(t *testing.T) {
-	d := acl.NewDeclarative(testPolicy())
+// RR-X1TE: a WriteRequest with nil Subject is a programmer error and
+// must panic. The legacy "fall through to global-roles-only" path
+// that briefly existed during the v0→v1 migration was removed because
+// it bypassed the unstamped-principal check.
+func TestAuthorizeWrite_NilSubject_Panics(t *testing.T) {
+	d := newACL(t, testPolicy())
 
-	got := d.AuthorizeWrite(ctxAs("alice"), acl.WriteRequest{})
-	if got.Allow {
-		t.Fatalf("Allow = true, want false. Decision = %+v", got)
-	}
-	if got.Reason != "no role grants write on type 'relation'" {
-		t.Errorf("Reason = %q, want %q", got.Reason, "no role grants write on type 'relation'")
-	}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic on nil Subject; got none")
+		}
+	}()
+	_ = d.AuthorizeWrite(ctxAs("alice"), acl.WriteRequest{Op: acl.OpCreate})
 }
 
 // Returns ForbiddenError via Decision propagation: any deny can be
 // wrapped at the manager boundary into the same *ForbiddenError shape
 // PR 1 ships. Sanity-check the round trip.
 func TestAuthorizeWrite_DenyConvertsToForbiddenError(t *testing.T) {
-	d := acl.NewDeclarative(testPolicy())
+	d := newACL(t, testPolicy())
 
-	dec := d.AuthorizeWrite(ctxAs("bob"), acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket"})
+	dec := d.AuthorizeWrite(ctxAs("bob"), entityCreate("ticket"))
 	if dec.Allow {
 		t.Fatal("expected deny")
 	}
 	err := &acl.ForbiddenError{Decision: dec}
 	if !errors.Is(err, acl.ErrForbidden) {
 		t.Errorf("errors.Is(_, ErrForbidden) = false on wrapped deny Decision")
+	}
+}
+
+// Unstamped principal (User="" or "unknown") → structured deny with
+// reason naming the ErrUnstampedPrincipal sentinel. This is the
+// hard-fail RR-X1TE protects: production code that forgets to stamp
+// identity gets a clean deny instead of silently picking up
+// Assignments["unknown"] or "everyone".
+func TestAuthorizeWrite_UnstampedPrincipal_Denies(t *testing.T) {
+	d := newACL(t, testPolicy())
+	ctx := principal.With(context.Background(), principal.Principal{User: "unknown", Tool: principal.ToolCLI})
+
+	got := d.AuthorizeWrite(ctx, entityCreate("ticket"))
+	if got.Allow {
+		t.Fatalf("Allow = true on unstamped principal; want deny. Decision = %+v", got)
+	}
+	if got.RuleKind != "role-grant" || got.RuleID != "-" {
+		t.Errorf("Decision = %+v, want role-grant/-", got)
+	}
+	if got.Reason == "" {
+		t.Errorf("Reason is empty; expected mention of ErrUnstampedPrincipal")
 	}
 }

--- a/internal/acl/doc_test.go
+++ b/internal/acl/doc_test.go
@@ -1,0 +1,57 @@
+// Package acl_test holds the test surface for the authorization
+// implementation. It is split into two layers, kept in separate files
+// so the boundary is visible at a glance:
+//
+//	features_test.go  — design-property tests. One TestFeature_UC* per
+//	                    use case. Each test reads as a story (docstring),
+//	                    a graph fixture (builder block), and a small set
+//	                    of assertions over three primitives: allow,
+//	                    visible, attribution. A failing feature test
+//	                    means the implementation drifted from a
+//	                    load-bearing claim of the ACL design.
+//
+//	declarative_test.go / policy_test.go — unit tests. Edge cases
+//	                    (cycles, depth-cap boundaries, unstamped
+//	                    principals, deny-body shape, multi-relation
+//	                    dedup), error paths, formatter details, and
+//	                    anything else that's implementation rather
+//	                    than design.
+//
+// Why two layers, not one:
+//
+// The ACL's load-bearing claims — "groups confer roles transitively",
+// "containment inheritance lets a folder grant on its documents",
+// "multi-source attribution surfaces every path that opened the gate" —
+// are not single-call invariants. They emerge from the composition of
+// resolver + policy + graph. A unit test of any single resolver method
+// (member-of walk, role attribution, write grant check) can pass while
+// the composition silently breaks; the feature tests catch the
+// composition.
+//
+// Conversely, the design properties say nothing about how the resolver
+// behaves on a self-loop in `member-of`, a malformed principal, or a
+// policy with conflicting role names. Those are implementation concerns
+// that get pinned per-bug as unit tests.
+//
+// The two layers are complementary: unit tests prevent implementation
+// bugs; feature tests prevent design drift.
+//
+// # Reading a feature test
+//
+// Each TestFeature_UC* has a Go docstring that names the scenario, the
+// actor, and what they're trying to do. The test body builds a small
+// world (one policy YAML block + a handful of entities and relations),
+// then makes assertions through the helpers in testutil_test.go.
+//
+// Assertions are written in three primitives:
+//
+//   - AssertAllow / AssertDeny — gate a single op on a single subject.
+//   - AssertVisible / AssertContains / AssertHidden — what entities of
+//     a given type the actor sees on a list-style read.
+//   - AssertPrimarySource / AssertAttribution — which Source values
+//     surface in the role attribution chain.
+//
+// No filtered_by_acl counts, no audit-summary strings, no
+// store.GraphQuery shape assertions. Those are implementation details
+// the feature tests intentionally do not pin.
+package acl_test

--- a/internal/acl/features_test.go
+++ b/internal/acl/features_test.go
@@ -1,0 +1,375 @@
+package acl_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// TestFeature_UC1_GroupConferredWrite pins the smallest interesting
+// design property of v1: a role assigned to a group reaches the
+// principals who are members of that group.
+//
+// Scenario. A small engineering team runs a shared issue tracker.
+// Every engineer is a member of the `engineering` team; the team
+// itself is assigned the `editor` role. Nobody is named individually
+// in the policy.
+//
+// As Alice (member of `engineering`), I expect to be able to update
+// TKT-001 — my team has the editor role even though I'm not
+// personally listed. An operator looking at the audit record expects
+// to see that the role was conferred via my group membership, not
+// direct assignment.
+func TestFeature_UC1_GroupConferredWrite(t *testing.T) {
+	w := NewWorld().
+		Policy(`
+roles:
+  editor:   { write: [ticket], read: [ticket] }
+  everyone: { read: [project] }
+assignments:
+  engineering: editor
+`).
+		Person("alice").
+		Team("engineering").
+		Ticket("TKT-001").
+		Relation("alice", "member-of", "engineering").
+		Build(t)
+
+	w.AssertAllow("alice", acl.OpUpdate, acl.EntitySubject{Type: "ticket", ID: "TKT-001"})
+	w.AssertPrimarySource("alice", "TKT-001", "editor",
+		acl.Source{Kind: acl.SourceGroup, Group: "engineering"})
+}
+
+// TestFeature_UC2_NestedGroupsAllowAll exercises the transitive
+// member-of walk and the AllowAll fast-path on list reads.
+//
+// Scenario. A larger company organizes engineering as
+// `engineering ⊂ all-staff`. The `all-staff` team is assigned the
+// `viewer` role — everyone in the company can read everything.
+// Alice is in `engineering`, two hops away from the role grant.
+//
+// As Alice opening the ticket list view, I expect to see every
+// ticket — my nested membership in `all-staff` (via `engineering`)
+// confers read-on-everything. As a backend engineer, I expect the
+// server to compute Alice's group set once per request, not once per
+// entity.
+func TestFeature_UC2_NestedGroupsAllowAll(t *testing.T) {
+	w := NewWorld().
+		Policy(`
+roles:
+  viewer: { read: ["*"] }
+assignments:
+  all-staff: viewer
+`).
+		Person("alice").
+		Team("engineering").
+		Team("all-staff").
+		Ticket("TKT-001").
+		Ticket("TKT-002").
+		Ticket("TKT-003").
+		Relation("alice", "member-of", "engineering").
+		Relation("engineering", "member-of", "all-staff").
+		Build(t)
+
+	w.AssertVisible("alice", "ticket", "TKT-001", "TKT-002", "TKT-003")
+}
+
+// TestFeature_UC3_ContainmentRead pins the containment-inheritance
+// design property: a role granted on a folder propagates to every
+// entity inside it via `belongs-to`.
+//
+// Scenario. A document-management workspace organizes files in
+// nested folders:
+//
+//	F-root
+//	├── F-eng        ← alice editor-of
+//	│     ├── D-overview
+//	│     └── F-mobile
+//	│           ├── D-roadmap
+//	│           └── F-leak
+//	│                 └── D-secret
+//	└── F-public
+//	      └── D-readme
+//
+// Alice has `editor-of` on F-eng. Per the policy
+// (`inherit_roles_through: [belongs-to]`), her grant should flow
+// down to every document inside F-eng's subtree.
+//
+// As Alice opening the documents list, I expect to see exactly the
+// three documents inside F-eng's subtree; D-readme (sibling
+// subtree) should be hidden. As Alice editing D-secret three
+// levels deep, I expect the write to be allowed and the audit
+// record to attribute the grant to F-eng (the ancestor that holds
+// the role-relation), not to the document itself.
+func TestFeature_UC3_ContainmentRead(t *testing.T) {
+	w := NewWorld().
+		Policy(`
+roles:
+  editor: { write: [folder, document], read: [folder, document] }
+inherit_roles_through: [belongs-to]
+role_relations:
+  editor-of: { confers: editor }
+`).
+		Folder("F-root").
+		Folder("F-eng", Inside("F-root")).
+		Folder("F-public", Inside("F-root")).
+		Folder("F-mobile", Inside("F-eng")).
+		Folder("F-leak", Inside("F-mobile")).
+		Document("D-overview", Inside("F-eng")).
+		Document("D-roadmap", Inside("F-mobile")).
+		Document("D-secret", Inside("F-leak")).
+		Document("D-readme", Inside("F-public")).
+		Person("alice").
+		Relation("alice", "editor-of", "F-eng").
+		Build(t)
+
+	w.AssertVisible("alice", "document", "D-overview", "D-roadmap", "D-secret")
+
+	w.AssertAllow("alice", acl.OpUpdate, acl.EntitySubject{Type: "document", ID: "D-secret"})
+	w.AssertPrimarySource("alice", "D-secret", "editor",
+		acl.Source{Kind: acl.SourceLocalViaAncestor, Ancestor: "F-eng", Relation: "editor-of"})
+
+	w.AssertDeny("alice", acl.OpUpdate, acl.EntitySubject{Type: "document", ID: "D-readme"})
+}
+
+// TestFeature_UC4_MultiParentUnion pins the union semantics for
+// containment: an entity filed under multiple parents inherits the
+// union of grants, not the intersection.
+//
+// Scenario. Extends UC3. D-roadmap is filed under BOTH F-mobile
+// (inside F-eng's subtree) AND F-public (where alice has no grant).
+// Operators expect "filing in more places makes more people see it",
+// which is the union rule.
+//
+// As Alice (editor-of F-eng), I expect to still see and edit
+// D-roadmap — my grant on F-eng reaches it via the F-mobile parent.
+// The fact that D-roadmap also lives in F-public (where I have no
+// grant) does not revoke my access.
+func TestFeature_UC4_MultiParentUnion(t *testing.T) {
+	w := NewWorld().
+		Policy(`
+roles:
+  editor: { write: [folder, document], read: [folder, document] }
+inherit_roles_through: [belongs-to]
+role_relations:
+  editor-of: { confers: editor }
+`).
+		Folder("F-root").
+		Folder("F-eng", Inside("F-root")).
+		Folder("F-public", Inside("F-root")).
+		Folder("F-mobile", Inside("F-eng")).
+		Document("D-roadmap", Inside("F-mobile")).
+		Document("D-readme", Inside("F-public")).
+		Person("alice").
+		Relation("D-roadmap", "belongs-to", "F-public"). // second parent
+		Relation("alice", "editor-of", "F-eng").
+		Build(t)
+
+	w.AssertContains("alice", "document", "D-roadmap")
+	w.AssertHidden("alice", "document", "D-readme")
+	w.AssertAllow("alice", acl.OpUpdate, acl.EntitySubject{Type: "document", ID: "D-roadmap"})
+}
+
+// TestFeature_UC5_MultiSourceAttribution pins the multi-source case:
+// the same role conferred via multiple paths produces multiple
+// attributions, and the primary is picked deterministically.
+//
+// Scenario. Alice is in the `eng-leads` group, which is assigned
+// the `editor` role globally (group path). The `eng-leads` group
+// also has `editor-of` on PRJ-flagship (local-via-group path).
+// Alice also has `editor-of` on PRJ-flagship directly (local path).
+//
+// Three distinct Source values should land for the role `editor`,
+// all preserved in the attribution chain. The primary credited in
+// RuleID is the highest-priority one (Group < Local <
+// LocalViaGroup, per AC8a's sort).
+func TestFeature_UC5_MultiSourceAttribution(t *testing.T) {
+	w := NewWorld().
+		Policy(`
+roles:
+  editor: { write: [project], read: [project] }
+assignments:
+  eng-leads: editor
+role_relations:
+  editor-of: { confers: editor }
+`).
+		Person("alice").
+		Team("eng-leads").
+		Project("PRJ-flagship").
+		Relation("alice", "member-of", "eng-leads").
+		Relation("eng-leads", "editor-of", "PRJ-flagship").
+		Relation("alice", "editor-of", "PRJ-flagship").
+		Build(t)
+
+	w.AssertAttribution("alice", "PRJ-flagship", "editor",
+		acl.Source{Kind: acl.SourceGroup, Group: "eng-leads"},
+		acl.Source{Kind: acl.SourceLocal, Relation: "editor-of"},
+		acl.Source{Kind: acl.SourceLocalViaGroup, Group: "eng-leads", Relation: "editor-of"},
+	)
+
+	w.AssertPrimarySource("alice", "PRJ-flagship", "editor",
+		acl.Source{Kind: acl.SourceGroup, Group: "eng-leads"})
+}
+
+// TestFeature_UC6_DelegateXRelationWrite pins the existing v0 design
+// property — granting a role requires holding the corresponding
+// delegate-X permission — as a regression guard at the feature layer.
+//
+// Scenario. The policy declares `editor-of` as a role-relation that
+// confers `editor`, and gates writing it on the `delegate-editor`
+// permission. Jeroen (admin) holds `delegate-editor`; Alice (editor)
+// does not.
+//
+// As Jeroen, I can author `someone --editor-of--> something` because
+// I hold the delegation permission. As Alice, the same write is
+// denied — even though I have the `editor` role myself, that
+// doesn't authorize me to grant it to others.
+func TestFeature_UC6_DelegateXRelationWrite(t *testing.T) {
+	w := NewWorld().
+		Policy(`
+roles:
+  admin:  { write: ["*"], permissions: [delegate-editor] }
+  editor: { write: [ticket] }
+assignments:
+  jeroen: admin
+  alice:  editor
+role_relations:
+  editor-of: { confers: editor, requires_permission: delegate-editor }
+`).
+		Person("jeroen").
+		Person("alice").
+		Ticket("TKT-001").
+		Build(t)
+
+	rs := acl.RelationSubject{
+		Type:     "editor-of",
+		FromType: "person", FromID: "alice",
+	}
+
+	w.AssertAllow("jeroen", acl.OpCreate, rs)
+	w.AssertDeny("alice", acl.OpCreate, rs)
+}
+
+// TestFeature_UC7_LocalRoleOnEntity pins the v1 write-side lift: a
+// local role-relation on a specific entity allows the principal to
+// write that entity, even without any global role grant.
+//
+// Scenario. Alice has no global role and no group memberships. The
+// policy declares `assigned-to` as a role-relation that confers
+// `editor`. Alice has an `assigned-to` edge to TKT-042 only.
+//
+// As Alice, I can update TKT-042 because my local edge confers
+// editor on it. TKT-099 (no edge to me) stays denied. The audit
+// record attributes the grant to the local edge.
+func TestFeature_UC7_LocalRoleOnEntity(t *testing.T) {
+	w := NewWorld().
+		Policy(`
+roles:
+  editor: { write: [ticket], read: [ticket] }
+role_relations:
+  assigned-to: { confers: editor }
+`).
+		Person("alice").
+		Ticket("TKT-042").
+		Ticket("TKT-099").
+		Relation("alice", "assigned-to", "TKT-042").
+		Build(t)
+
+	w.AssertAllow("alice", acl.OpUpdate, acl.EntitySubject{Type: "ticket", ID: "TKT-042"})
+	w.AssertPrimarySource("alice", "TKT-042", "editor",
+		acl.Source{Kind: acl.SourceLocal, Relation: "assigned-to"})
+
+	w.AssertDeny("alice", acl.OpUpdate, acl.EntitySubject{Type: "ticket", ID: "TKT-099"})
+}
+
+// TestFeature_UC8_ClosedWorldDeny pins the closed-world read shape:
+// `RoleDef.Read: []` is deny-all for that type; combined with no
+// other roles, no entities of the type are visible.
+//
+// Scenario. The policy declares `everyone: { read: [] }`. No other
+// roles grant read on `ticket`. A principal with no other affiliations
+// hits the `everyone` role only.
+//
+// As Alice, an authenticated user with no special grants, opening
+// the ticket list — I expect to see nothing. The closed-world rule
+// of `read: []` is intentional ("you have a role, but it lists no
+// readable types").
+func TestFeature_UC8_ClosedWorldDeny(t *testing.T) {
+	w := NewWorld().
+		Policy(`
+roles:
+  everyone: { read: [] }
+`).
+		Person("alice").
+		Ticket("TKT-001").
+		Ticket("TKT-002").
+		Build(t)
+
+	w.AssertVisible("alice", "ticket") // empty
+}
+
+// TestFeature_UC9_LocalViaGroupRead pins that a local role-relation
+// from a *group* to an entity confers read on that entity to every
+// member of the group, transitively.
+//
+// Scenario. The `engineering` group has `viewer-of` on PRJ-foo.
+// Alice is in `engineering`. The `viewer-of` role-relation confers
+// the `viewer` role, which grants `read: [project]`.
+//
+// As Alice, I expect to see PRJ-foo because my group transitively
+// holds the viewer role on it — even though I have no global role
+// granting read on projects and no direct edge to PRJ-foo.
+func TestFeature_UC9_LocalViaGroupRead(t *testing.T) {
+	w := NewWorld().
+		Policy(`
+roles:
+  viewer: { read: [project] }
+role_relations:
+  viewer-of: { confers: viewer }
+`).
+		Person("alice").
+		Team("engineering").
+		Project("PRJ-foo").
+		Project("PRJ-bar").
+		Relation("alice", "member-of", "engineering").
+		Relation("engineering", "viewer-of", "PRJ-foo").
+		Build(t)
+
+	w.AssertVisible("alice", "project", "PRJ-foo")
+	// PRJ-bar has no role-relation edge → not visible.
+}
+
+// UC10 and UC11 are property-level redaction scenarios. They belong
+// in internal/affordances/features_test.go, not here — the verdicts
+// they assert on (`visible: {ticket: [...]}`) are computed by the
+// affordances package, not the ACL resolver. Putting them here would
+// invert the dependency direction (acl importing affordances).
+//
+// See internal/affordances/features_test.go for the property-redaction
+// feature tests.
+
+// TestFeature_UC10_PropertyRedaction — moved to internal/affordances.
+func TestFeature_UC10_PropertyRedaction(t *testing.T) {
+	t.Skip("UC10 lives in internal/affordances/features_test.go (property redaction is an affordance-layer concern).")
+}
+
+// TestFeature_UC11_ReadAndVisibleCompose — moved to internal/affordances.
+func TestFeature_UC11_ReadAndVisibleCompose(t *testing.T) {
+	t.Skip("UC11 lives in internal/affordances/features_test.go (Read + visible composition is an affordance-layer concern).")
+}
+
+// TestFeature_UC12_MCPScopeIntersection pins the MCP transport
+// intersection: the tool surface advertised to a principal is
+// the intersection of their capability and the agent scope.
+//
+// Like UC10/UC11, this belongs in the package that owns the wiring
+// (internal/mcp), not here. The acl.Policy needs `mcp_scopes` /
+// `mcp_scope_assignments` schema additions and the mcp.Server needs
+// to filter its tool-advertise response per request. Both pieces
+// are separate from the core ACL resolver landed by TKT-SVXL.
+//
+// Tracked for a follow-up ticket once the MCP transport's
+// per-request filtering shape is designed.
+func TestFeature_UC12_MCPScopeIntersection(t *testing.T) {
+	t.Skip("UC12 lives in internal/mcp (transport-layer intersection); follow-up ticket once the MCP filtering shape is designed.")
+}

--- a/internal/acl/graph.go
+++ b/internal/acl/graph.go
@@ -1,0 +1,64 @@
+package acl
+
+import "context"
+
+// Graph is the narrow contract the resolver needs from the store.
+// Declared at the consumer per CLAUDE.md's "interfaces at the call
+// site" rule; the wiring site (appbuild) supplies a store-backed
+// implementation.
+//
+// Two operations:
+//
+//   - HasEdge reports whether a specific edge fromID --relType--> toID
+//     exists. Used in per-entity local-role probes.
+//   - OutgoingRelations returns the toIDs reachable from `fromID` via
+//     edges of `relType`. Used in transitive walks (member-of for
+//     groups, inherit_roles_through for containment).
+//
+// Both methods are read-only and snapshot-coherent for the duration
+// of one Request; cross-request consistency is not guaranteed (and is
+// not load-bearing — see the TKT-SVXL "Trust boundary" section).
+//
+// TKT-SVXL note: an earlier iteration of this interface returned a
+// `[]string` slice with no error. The architect review flagged that
+// silent error-drop in production was a security-regression mechanism
+// (members disappearing = grants disappearing). The current signature
+// adds an explicit error return; consumers propagate or abort.
+//
+// Production wiring uses [StoreGraph] (a store.Store adapter). Tests
+// that need a real graph use the same adapter over a memstore; tests
+// that only exercise the legacy-Subject AuthorizeWrite path can use
+// [NullGraph] — it answers "no edges" for every probe.
+type Graph interface {
+	// HasEdge reports whether the specific (from, relType, to) edge
+	// exists. Returns false on backend error rather than propagating —
+	// a missing edge and an error look the same to authz (deny by
+	// absence). Operators see backend errors in the store's own logs.
+	HasEdge(ctx context.Context, from, relType, to string) bool
+
+	// OutgoingRelations returns the toIDs reachable from `fromID` via
+	// `relType`, or an error if the backend lookup failed. Resolvers
+	// abort the surrounding walk on error rather than under-counting —
+	// under-counting members is safer than over-granting, but a
+	// principal-resolution that proceeds with partial data is worse
+	// than failing the request loud.
+	OutgoingRelations(ctx context.Context, from, relType string) ([]string, error)
+}
+
+// NullGraph implements [Graph] with no edges. Intended for tests that
+// construct a [*Declarative] but don't exercise group expansion,
+// containment, or local-role probes — typically tests of the legacy
+// AuthorizeWrite path that uses the EntityType/RelationType string
+// shape instead of the [Subject] sum.
+//
+// Production wiring never uses NullGraph; it always supplies a real
+// store-backed [StoreGraph].
+type NullGraph struct{}
+
+// HasEdge always returns false.
+func (NullGraph) HasEdge(context.Context, string, string, string) bool { return false }
+
+// OutgoingRelations always returns nil, nil.
+func (NullGraph) OutgoingRelations(context.Context, string, string) ([]string, error) {
+	return nil, nil
+}

--- a/internal/acl/internals.go
+++ b/internal/acl/internals.go
@@ -1,0 +1,23 @@
+package acl
+
+// DepthCap bounds every transitive walk the resolver performs
+// (member-of for groups, inherit_roles_through for containment). It is
+// a safety backstop, not the primary termination mechanism — visited-set
+// dedup terminates correctly on cycles and self-loops regardless.
+//
+// The value 5 is chosen empirically: more than any realistic
+// organization or containment hierarchy, while bounded enough to make
+// pathological cycles cheap to abort. Operators who hit the cap should
+// file a follow-up ticket so the change is considered in context
+// (wallclock, audit-debugging) rather than reflexively bumped.
+//
+// Exported (RR-AROE) so downstream callers — chiefly
+// internal/store/graphquerynaive when invoked from readQuery — observe
+// the same backstop instead of declaring a parallel constant that can
+// drift silently.
+const DepthCap = 5
+
+// depthCap is the unexported alias kept for the resolver's existing
+// call sites. New code outside this package should reference
+// [DepthCap].
+const depthCap = DepthCap

--- a/internal/acl/nop_test.go
+++ b/internal/acl/nop_test.go
@@ -13,13 +13,13 @@ func TestNopACL_AllowsAllWrites(t *testing.T) {
 		name string
 		req  acl.WriteRequest
 	}{
-		{"create entity", acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket"}},
-		{"update entity", acl.WriteRequest{Op: acl.OpUpdate, EntityType: "concept"}},
-		{"delete entity", acl.WriteRequest{Op: acl.OpDelete, EntityType: "person"}},
-		{"rename entity", acl.WriteRequest{Op: acl.OpRename, EntityType: "feature"}},
-		{"create relation", acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket", RelationType: "affects"}},
-		{"update relation", acl.WriteRequest{Op: acl.OpUpdate, RelationType: "depends-on"}},
-		{"delete relation", acl.WriteRequest{Op: acl.OpDelete, RelationType: "requires"}},
+		{"create entity", acl.WriteRequest{Op: acl.OpCreate, Subject: acl.EntitySubject{Type: "ticket"}}},
+		{"update entity", acl.WriteRequest{Op: acl.OpUpdate, Subject: acl.EntitySubject{Type: "concept", ID: "C-1"}}},
+		{"delete entity", acl.WriteRequest{Op: acl.OpDelete, Subject: acl.EntitySubject{Type: "person", ID: "P-1"}}},
+		{"rename entity", acl.WriteRequest{Op: acl.OpRename, Subject: acl.EntitySubject{Type: "feature", ID: "FEAT-1"}}},
+		{"create relation", acl.WriteRequest{Op: acl.OpCreate, Subject: acl.RelationSubject{Type: "affects", FromType: "ticket"}}},
+		{"update relation", acl.WriteRequest{Op: acl.OpUpdate, Subject: acl.RelationSubject{Type: "depends-on", FromType: "ticket"}}},
+		{"delete relation", acl.WriteRequest{Op: acl.OpDelete, Subject: acl.RelationSubject{Type: "requires", FromType: "feature"}}},
 		{"zero request", acl.WriteRequest{}},
 	}
 	for _, tt := range tests {

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -1,6 +1,7 @@
 package acl
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -12,9 +13,9 @@ import (
 // this name in `acl.yaml` is held implicitly by every principal,
 // authenticated or not — it is how an operator expresses "applies to
 // everyone" without enumerating users. It is appended to every
-// principal's effective role set (see [Declarative.effectiveRoles]
-// and the affordances resolver), and is the single source of truth
-// for the name so the two paths can't drift.
+// principal's effective role set in both the Subject-driven write
+// path ([Request]) and the affordances resolver, and is the single
+// source of truth for the name so the two paths can't drift.
 //
 // (No `anonymous` / `authenticated` built-ins yet: rela-server has no
 // authentication layer — see docs/security.md. Those would be added
@@ -22,38 +23,44 @@ import (
 const EveryoneRole = "everyone"
 
 // Policy is the declarative ACL configuration parsed from `acl.yaml`
-// at the project root. v0 fields:
+// at the project root.
 //
-//   - [Policy.UserEntityType] declares which entity type represents
-//     a user (e.g. "person", "user"). Currently informational —
-//     reserved for v1 group expansion when [Policy.RoleRelations]
-//     binds principals to entities.
+//   - [Policy.UserEntityType] names the entity type that represents
+//     a user (e.g. "person", "user"). Reserved for a future
+//     check that validates `member-of` edges originate from a user
+//     entity; not consulted by the resolver today (RR-NIGK).
 //   - [Policy.Roles] declares the named capability bundles. The
 //     built-in role name [EveryoneRole] ("everyone") is appended to
-//     every principal's effective role set; see
-//     [Declarative.effectiveRoles].
+//     every principal's effective role set in both the write path
+//     and the affordances resolver.
 //   - [Policy.Assignments] maps `principal.User` → role name.
 //     Unknown role names (assigned but not declared in Roles) log a
 //     warning at load and are dropped from the effective set.
 //   - [Policy.RoleRelations] declares which relation types grant a
 //     role to their source entity, and which permission the writer
 //     must hold (delegate-X tamper resistance — see [Declarative]).
+//   - [Policy.InheritRolesThrough] declares the containment relation
+//     types through which a role granted at an ancestor flows down
+//     to its descendants (e.g. folder → document).
 //
 // **Tolerant by design.** Unknown top-level keys emit one
 // `slog.Warn` per key and are otherwise ignored. Operators iterate
 // on `acl.yaml` frequently and a typo shouldn't brick the server —
 // the metamodel loader follows the same convention. Hard errors
-// reserved for unparseable YAML or undecodable values within a
-// known key.
+// reserved for unparseable YAML, undecodable values within a known
+// key, and security-critical invariants — see [Policy.Validate].
 type Policy struct {
-	UserEntityType string                     `yaml:"user_entity_type"`
-	Roles          map[string]RoleDef         `yaml:"roles"`
-	Assignments    map[string]string          `yaml:"assignments"`
-	RoleRelations  map[string]RoleRelationDef `yaml:"role_relations"`
+	UserEntityType      string                     `yaml:"user_entity_type"`
+	Roles               map[string]RoleDef         `yaml:"roles"`
+	Assignments         map[string]string          `yaml:"assignments"`
+	RoleRelations       map[string]RoleRelationDef `yaml:"role_relations"`
+	InheritRolesThrough []string                   `yaml:"inherit_roles_through"`
 }
 
-// RoleDef is the capability bundle for a single role. v0 honors
-// Write and Permissions; Read is parsed but unused (v1 reads).
+// RoleDef is the capability bundle for a single role. Write,
+// Permissions, and the affordance grants are honored by the write
+// path and the affordances resolver. Read drives the read-filtering
+// path (see [Declarative.ReadQuery]).
 //
 // Wildcard write: a single entry `"*"` grants write on every entity
 // type. Mixing `"*"` with explicit types is allowed but redundant —
@@ -143,6 +150,32 @@ func roleHasAffordanceGrants(role RoleDef) bool {
 // Empty [RoleRelationDef.RequiresPermission] disables the delegate-X
 // gate — the relation type is recognized as role-conferring (for
 // future group expansion) but no permission check fires on writes.
+//
+// **Escalation risk for the `member-of` relation** (RR-7O6Q). v1
+// confers group roles by walking `member-of` edges. By default
+// `member-of` is a regular relation type with no `requires_permission`
+// gate, so anyone with write access on the relation's source type can
+// create their own `member-of` edge into any group named in
+// [Policy.Assignments]. If a group is assigned a privileged role
+// (e.g. `assignments: { admins: admin }`), an attacker with write
+// access on `person` can self-promote by writing
+// `alice --member-of--> admins`.
+//
+// Operators using groups for role attribution MUST gate
+// `member-of` writes. Recommended shape:
+//
+//	role_relations:
+//	  member-of:
+//	    requires_permission: delegate-membership
+//	roles:
+//	  admin:
+//	    permissions: [delegate-membership]
+//
+// This restricts `member-of` creation to principals holding
+// `delegate-membership` — typically only admins. See
+// `docs/security.md` for the full hardening pattern. The UC1 example
+// policy in features_test.go is intentionally minimal and would be
+// wide-open if copy-pasted into a deployment.
 type RoleRelationDef struct {
 	Confers            string `yaml:"confers"`
 	RequiresPermission string `yaml:"requires_permission"`
@@ -151,10 +184,11 @@ type RoleRelationDef struct {
 // knownPolicyKeys is the allowlist used for unknown-key warnings.
 // Keep in sync with [Policy]'s yaml tags.
 var knownPolicyKeys = map[string]bool{
-	"user_entity_type": true,
-	"roles":            true,
-	"assignments":      true,
-	"role_relations":   true,
+	"user_entity_type":      true,
+	"roles":                 true,
+	"assignments":           true,
+	"role_relations":        true,
+	"inherit_roles_through": true,
 }
 
 // LoadPolicy reads and parses `acl.yaml` at the given path.
@@ -163,7 +197,8 @@ var knownPolicyKeys = map[string]bool{
 //   - The caller distinguishes "no policy file" from "broken policy
 //     file" via [os.ErrNotExist]. Use `errors.Is(err, os.ErrNotExist)`
 //     to fall back to [NopACL] when no policy is present.
-//   - Any other I/O error or YAML parse error returns wrapped.
+//   - Any other I/O error, YAML parse error, or [Policy.Validate]
+//     failure returns wrapped.
 //
 // Unknown top-level keys emit one `slog.Warn` per key and are
 // otherwise ignored. The returned [Policy] is non-nil on success
@@ -195,5 +230,69 @@ func LoadPolicy(path string) (*Policy, error) {
 	if uErr := yaml.Unmarshal(data, &policy); uErr != nil {
 		return nil, fmt.Errorf("acl: parse %s: %w", path, uErr)
 	}
+	if vErr := policy.Validate(); vErr != nil {
+		return nil, fmt.Errorf("acl: validate %s: %w", path, vErr)
+	}
 	return &policy, nil
+}
+
+// LoadPolicyBytes parses an acl.yaml from in-memory bytes. Used by
+// tests (and any future caller that builds policy from non-filesystem
+// sources); production wiring uses [LoadPolicy] with a path. Unknown
+// top-level keys are NOT warned here — the bytes form is for callers
+// who already control the schema.
+func LoadPolicyBytes(data []byte) (*Policy, error) {
+	if len(data) == 0 {
+		return &Policy{}, nil
+	}
+	var p Policy
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("acl: parse policy bytes: %w", err)
+	}
+	if vErr := p.Validate(); vErr != nil {
+		return nil, fmt.Errorf("acl: validate policy bytes: %w", vErr)
+	}
+	return &p, nil
+}
+
+// Validate enforces security-critical invariants on the parsed
+// policy. Run automatically by [LoadPolicy] / [LoadPolicyBytes].
+// Operators can also call it before persisting a generated policy.
+//
+// Current checks (RR-NIGK):
+//
+//   - InheritRolesThrough entries must be non-empty and non-whitespace.
+//     A blank entry would expand ancestor sets through every relation
+//     type (StoreGraph treats RelationQuery.Type=="" as "all relations"),
+//     silently turning a typo into a containment widening.
+//   - RoleRelations keys must be non-empty and non-whitespace, for the
+//     same reason — an empty key would gate "all relation writes" on
+//     a delegate permission, breaking writes the operator didn't mean
+//     to gate.
+//
+// Validation is intentionally narrow: misspelled role names, unknown
+// entity types in grants, etc. remain warnings (or analyze-tool
+// findings) per the "tolerant by design" stance. Security-relevant
+// invariants like the two above are the exception.
+func (p *Policy) Validate() error {
+	for i, t := range p.InheritRolesThrough {
+		if isBlank(t) {
+			return fmt.Errorf("inherit_roles_through[%d]: relation type must not be empty or whitespace", i)
+		}
+	}
+	for k := range p.RoleRelations {
+		if isBlank(k) {
+			return errors.New("role_relations: relation type key must not be empty or whitespace")
+		}
+	}
+	return nil
+}
+
+func isBlank(s string) bool {
+	for _, r := range s {
+		if r != ' ' && r != '\t' && r != '\n' && r != '\r' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/acl/policy_test.go
+++ b/internal/acl/policy_test.go
@@ -335,6 +335,54 @@ func TestLoadPolicy_RelationGrant_CreateRemovePointers(t *testing.T) {
 	}
 }
 
+// RR-NIGK: a blank entry in inherit_roles_through is rejected at load.
+// A blank entry would otherwise reach StoreGraph with an empty
+// RelationQuery.Type meaning "all relations" — silently widening
+// containment to every relation type in the workspace.
+func TestLoadPolicy_BlankInheritRolesThrough_Rejected(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{"empty string", "inherit_roles_through:\n  - \"\"\n"},
+		{"whitespace", "inherit_roles_through:\n  - \"  \"\n"},
+		{"empty among valid", "inherit_roles_through:\n  - belongs-to\n  - \"\"\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTempPolicy(t, tc.yaml)
+			_, err := acl.LoadPolicy(path)
+			if err == nil {
+				t.Fatalf("LoadPolicy: expected error on blank inherit_roles_through entry; got nil")
+			}
+		})
+	}
+}
+
+// RR-NIGK / RR-ZB1V: a blank key in role_relations is rejected —
+// would otherwise gate every relation write on the delegate
+// permission, breaking writes the operator didn't mean to gate.
+// Covers both the empty-string and whitespace-only cases, mirroring
+// the inherit_roles_through test's coverage.
+func TestLoadPolicy_BlankRoleRelationsKey_Rejected(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{"empty string", "role_relations:\n  \"\":\n    confers: contributor\n"},
+		{"whitespace", "role_relations:\n  \"  \":\n    confers: contributor\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTempPolicy(t, tc.yaml)
+			_, err := acl.LoadPolicy(path)
+			if err == nil {
+				t.Fatalf("LoadPolicy: expected error on blank role_relations key; got nil")
+			}
+		})
+	}
+}
+
 // writeTempPolicy writes the given YAML to a temp file and returns its
 // path. Lifetime is scoped to the test.
 func writeTempPolicy(t *testing.T, yaml string) string {

--- a/internal/acl/readonly_test.go
+++ b/internal/acl/readonly_test.go
@@ -13,13 +13,13 @@ func TestReadOnlyACL_DeniesAllWrites(t *testing.T) {
 		name string
 		req  acl.WriteRequest
 	}{
-		{"create entity", acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket"}},
-		{"update entity", acl.WriteRequest{Op: acl.OpUpdate, EntityType: "concept"}},
-		{"delete entity", acl.WriteRequest{Op: acl.OpDelete, EntityType: "person"}},
-		{"rename entity", acl.WriteRequest{Op: acl.OpRename, EntityType: "feature"}},
-		{"create relation", acl.WriteRequest{Op: acl.OpCreate, EntityType: "ticket", RelationType: "affects"}},
-		{"update relation", acl.WriteRequest{Op: acl.OpUpdate, RelationType: "depends-on"}},
-		{"delete relation", acl.WriteRequest{Op: acl.OpDelete, RelationType: "requires"}},
+		{"create entity", acl.WriteRequest{Op: acl.OpCreate, Subject: acl.EntitySubject{Type: "ticket"}}},
+		{"update entity", acl.WriteRequest{Op: acl.OpUpdate, Subject: acl.EntitySubject{Type: "concept", ID: "C-1"}}},
+		{"delete entity", acl.WriteRequest{Op: acl.OpDelete, Subject: acl.EntitySubject{Type: "person", ID: "P-1"}}},
+		{"rename entity", acl.WriteRequest{Op: acl.OpRename, Subject: acl.EntitySubject{Type: "feature", ID: "FEAT-1"}}},
+		{"create relation", acl.WriteRequest{Op: acl.OpCreate, Subject: acl.RelationSubject{Type: "affects", FromType: "ticket"}}},
+		{"update relation", acl.WriteRequest{Op: acl.OpUpdate, Subject: acl.RelationSubject{Type: "depends-on", FromType: "ticket"}}},
+		{"delete relation", acl.WriteRequest{Op: acl.OpDelete, Subject: acl.RelationSubject{Type: "requires", FromType: "feature"}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/acl/readquery.go
+++ b/internal/acl/readquery.go
@@ -1,0 +1,77 @@
+package acl
+
+import (
+	"context"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// ReadQueryResult is the response from Request.ReadQuery. Exactly one
+// of (AllowAll, DenyAll, Query) is meaningful:
+//
+//	AllowAll → caller runs an unfiltered list of EntityType.
+//	DenyAll  → caller returns an empty list of EntityType.
+//	Query    → caller runs the composed store.GraphQuery to filter.
+type ReadQueryResult struct {
+	AllowAll bool
+	DenyAll  bool
+	Query    *store.GraphQuery
+}
+
+// readQuery composes a ReadQueryResult. AllowAll when any effective
+// global role grants read on entityType; otherwise compose a
+// GraphQuery whose HasInbound predicate matches entities reachable
+// via the role-relations whose confers-role grants read on the type.
+// DenyAll when no role grants any kind of read.
+func (r *Request) readQuery(ctx context.Context, entityType string) ReadQueryResult {
+	globals := r.Globals(ctx)
+	for _, a := range globals.Attributions {
+		role, ok := r.d.policy.Roles[a.Role]
+		if !ok {
+			continue
+		}
+		if roleGrantsRead(role, entityType) {
+			return ReadQueryResult{AllowAll: true}
+		}
+	}
+
+	var conferring []string
+	for relType, def := range r.d.policy.RoleRelations {
+		role, ok := r.d.policy.Roles[def.Confers]
+		if !ok {
+			continue
+		}
+		if roleGrantsRead(role, entityType) {
+			conferring = append(conferring, relType)
+		}
+	}
+	if len(conferring) == 0 {
+		return ReadQueryResult{DenyAll: true}
+	}
+	sort.Strings(conferring)
+
+	q := &store.GraphQuery{
+		EntityType: entityType,
+		HasInbound: &store.RelationPredicate{
+			Endpoints: globals.Members,
+			OfTypes:   conferring,
+		},
+	}
+	if len(r.d.policy.InheritRolesThrough) > 0 {
+		q.HasInbound.EntityInheritThrough = append([]string(nil), r.d.policy.InheritRolesThrough...)
+		q.HasInbound.EntityDepth = depthCap
+	}
+	return ReadQueryResult{Query: q}
+}
+
+// roleGrantsRead reports whether `role.Read` covers `target` — exact
+// match or wildcard `"*"`.
+func roleGrantsRead(role RoleDef, target string) bool {
+	for _, t := range role.Read {
+		if t == "*" || t == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/acl/request.go
+++ b/internal/acl/request.go
@@ -1,0 +1,150 @@
+package acl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// ErrUnstampedPrincipal is the sentinel returned by Declarative.ForPrincipal
+// when the principal carries User="" / User="unknown" or Tool="" /
+// Tool="unknown". Code paths that forgot to stamp identity must fail
+// loud rather than silently degrade.
+var ErrUnstampedPrincipal = errors.New("acl: principal is unstamped (User or Tool is unknown)")
+
+// GlobalRoles is the result of computing the global (no-entity) role
+// set for a principal. Carries both the attributions and the
+// transitively-walked member-of closure so a follow-up per-entity
+// call can reuse the Members slice without re-walking.
+type GlobalRoles struct {
+	Attributions []RoleAttribution
+	Members      []string
+}
+
+// Request is a per-request resolver scope. Constructed via
+// Declarative.ForPrincipal; methods are not safe for concurrent use
+// by multiple goroutines — open one Request per logical operation and
+// let it go out of scope when the operation completes.
+//
+// Carries a memoised GlobalRoles so multiple per-entity calls on the
+// same Request reuse the one member-of walk. The principal is bound
+// at construction and never revalidated by Request methods.
+type Request struct {
+	d             *Declarative
+	principal     principal.Principal
+	globals       GlobalRoles
+	globalsLoaded bool
+}
+
+// ForPrincipal opens a Request scope for `p`. Returns
+// ErrUnstampedPrincipal if `p.User` or `p.Tool` is empty or "unknown".
+// The Declarative is always constructed with a non-nil Graph (the
+// [NewDeclarative] constructor rejects nil), so the resolver always
+// has the read-side access it needs.
+func (d *Declarative) ForPrincipal(p principal.Principal) (*Request, error) {
+	if isUnstamped(p) {
+		return nil, fmt.Errorf("%w: User=%q Tool=%q", ErrUnstampedPrincipal, p.User, p.Tool)
+	}
+	return &Request{d: d, principal: p}, nil
+}
+
+// Globals returns the principal's global role set, computing it on
+// first call and caching for the lifetime of the Request. Subsequent
+// calls reuse the cached value with no graph traffic.
+func (r *Request) Globals(ctx context.Context) GlobalRoles {
+	if !r.globalsLoaded {
+		r.globals = r.computeGlobals(ctx)
+		r.globalsLoaded = true
+	}
+	return r.globals
+}
+
+// ForEntity returns the full attribution set for (principal, entityID
+// of entityType): the cached Globals plus any local-role-via-edge or
+// local-role-via-ancestor sources reachable from the entity.
+//
+// Used by write authz (where the caller has an entity in hand) and by
+// affordance verdicts. Single-entity get_entity read gates consult the
+// role set returned here.
+//
+// Passing entityID == "" returns Globals only (no per-entity probes).
+func (r *Request) ForEntity(ctx context.Context, _, entityID string) []RoleAttribution {
+	if entityID == "" {
+		return r.Globals(ctx).Attributions
+	}
+	return r.computeForEntity(ctx, entityID)
+}
+
+// AuthorizeWrite gates a single write — the entry point used by
+// entitymanager.Manager.{Create,Update,Delete}{Entity,Relation} +
+// RenameEntity once the migration in TKT-SVXL PR (a) lands.
+func (r *Request) AuthorizeWrite(ctx context.Context, req WriteRequest) Decision {
+	return r.authorizeWrite(ctx, req)
+}
+
+// ReadQuery composes a ReadQueryResult for list-style reads. The
+// dataentry handler consumes this and either runs an unfiltered list
+// (AllowAll), returns empty (DenyAll), or runs the composed
+// store.GraphQuery.
+func (r *Request) ReadQuery(ctx context.Context, entityType string) ReadQueryResult {
+	return r.readQuery(ctx, entityType)
+}
+
+// Principal returns the principal bound at construction. Helper for
+// audit attribution; callers that already have the principal in their
+// own ctx don't need this.
+func (r *Request) Principal() principal.Principal { return r.principal }
+
+// ctxKey is the unexported type for context.WithValue. Required by
+// the std-lib contract that context keys are not bare strings.
+type ctxKey struct{}
+
+// WithRequest attaches r to ctx so downstream resolvers (notably the
+// affordance resolver) can reuse the same per-request scope —
+// amortizing the member-of walk across every per-entity call in a
+// list response (RR-JJYW). The dataentry list handler opens one
+// Request at the top and threads the derived ctx through every
+// FieldVerdicts / RelationVerdicts call.
+//
+// When ctx already carries a Request, the latest one wins; this is
+// the right behavior for nested handlers (rare today).
+func WithRequest(ctx context.Context, r *Request) context.Context {
+	return context.WithValue(ctx, ctxKey{}, r)
+}
+
+// FromContext returns the Request previously attached via
+// [WithRequest], or nil when no Request is attached. The affordance
+// resolver consults this in bindingFor; a nil return means "build a
+// fresh Request for this call" (back-compat for callers that don't
+// thread a Request).
+func FromContext(ctx context.Context) *Request {
+	if ctx == nil {
+		return nil
+	}
+	r, _ := ctx.Value(ctxKey{}).(*Request)
+	return r
+}
+
+// isUnstamped reports whether the principal looks like a default /
+// missing-stamp value. The acl package treats "" and "unknown" as
+// equivalent — the principal package's SystemUser() default is the
+// literal "unknown", and code that bypasses From(ctx) may construct
+// Principal{User: ""}; both indicate an entry point that forgot to
+// stamp identity.
+func isUnstamped(p principal.Principal) bool {
+	if isBlankOrUnknown(p.User) {
+		return true
+	}
+	if isBlankOrUnknown(p.Tool) {
+		return true
+	}
+	return false
+}
+
+func isBlankOrUnknown(s string) bool {
+	t := strings.TrimSpace(s)
+	return t == "" || t == "unknown"
+}

--- a/internal/acl/resolver.go
+++ b/internal/acl/resolver.go
@@ -85,6 +85,33 @@ func (r *Request) walkMembers(ctx context.Context) []string {
 // globals plus local-role probes (direct edges from any group-set
 // member to the entity, and when inherit_roles_through is configured,
 // per-ancestor probes).
+//
+// The resolver runs two independent graph walks and crosses them
+// against the policy's role-relations:
+//
+//	principal.User                            target entity
+//	     │                                          │
+//	     │ member-of                                │ inherit_roles_through
+//	     ▼ (walkMembers, depth-capped)              ▼ (ancestors, depth-capped)
+//	┌─────────┐                                ┌─────────┐
+//	│ Members │                                │ Chain   │  (entity + ancestors)
+//	│  set M  │                                │  C      │
+//	└────┬────┘                                └────┬────┘
+//	     │                                          │
+//	     └──────────────┬───────────────────────────┘
+//	                    ▼
+//	       for each role-relation rel ∈ policy.RoleRelations (sorted):
+//	       for each (m ∈ M, target ∈ C):
+//	           if graph.HasEdge(m, rel, target):
+//	               attribute Confers(rel) with Source picked from
+//	               {Local, LocalViaGroup, LocalViaAncestor,
+//	                LocalViaGroupAndAncestor} by (m==user?, target==entity?)
+//
+// The cross-product is bounded by depthCap on both walks, the
+// member-of and inherit_roles_through closures usually being tiny
+// (under 10 nodes each in practice). Graph errors on either walk
+// abort the surrounding loop — under-attribution is safer than
+// over-granting.
 func (r *Request) computeForEntity(ctx context.Context, entityID string) []RoleAttribution {
 	globals := r.Globals(ctx)
 	out := append([]RoleAttribution(nil), globals.Attributions...)

--- a/internal/acl/resolver.go
+++ b/internal/acl/resolver.go
@@ -1,0 +1,203 @@
+package acl
+
+import (
+	"context"
+	"sort"
+)
+
+// computeGlobals walks member-of from the principal and unions in
+// Assignments[m] for every member m, plus the "everyone" role if
+// declared.
+//
+// Called once per Request via Globals(); the result is cached for the
+// lifetime of the Request.
+func (r *Request) computeGlobals(ctx context.Context) GlobalRoles {
+	members := r.walkMembers(ctx)
+
+	var attrs []RoleAttribution
+	seen := map[attrKey]bool{}
+	add := func(role string, source Source) {
+		k := attrKey{Role: role, Source: source}
+		if seen[k] {
+			return
+		}
+		seen[k] = true
+		attrs = append(attrs, RoleAttribution{Role: role, Source: source})
+	}
+
+	policy := r.d.policy
+	for _, m := range members {
+		role, ok := policy.Assignments[m]
+		if !ok {
+			continue
+		}
+		if _, defined := policy.Roles[role]; !defined {
+			continue
+		}
+		if m == r.principal.User {
+			add(role, Source{Kind: SourceGlobal})
+		} else {
+			add(role, Source{Kind: SourceGroup, Group: m})
+		}
+	}
+	if _, ok := policy.Roles[EveryoneRole]; ok {
+		add(EveryoneRole, Source{Kind: SourceGlobal})
+	}
+	return GlobalRoles{Attributions: attrs, Members: members}
+}
+
+// walkMembers returns {principal.User} ∪ transitive member-of closure.
+// Visited-set primary; depthCap as backstop. Errors from the graph
+// abort the surrounding walk — under-counting members is safer than
+// over-granting, but a partial-data principal-resolution is worse
+// than failing loud.
+func (r *Request) walkMembers(ctx context.Context) []string {
+	user := r.principal.User
+	if user == "" {
+		return nil
+	}
+	visited := map[string]bool{user: true}
+	order := []string{user}
+	frontier := []string{user}
+	for depth := 0; depth < depthCap && len(frontier) > 0; depth++ {
+		var next []string
+		for _, n := range frontier {
+			tos, err := r.d.graph.OutgoingRelations(ctx, n, "member-of")
+			if err != nil {
+				// Abort the walk loud rather than silently undercount.
+				return order
+			}
+			for _, to := range tos {
+				if visited[to] {
+					continue
+				}
+				visited[to] = true
+				order = append(order, to)
+				next = append(next, to)
+			}
+		}
+		frontier = next
+	}
+	return order
+}
+
+// computeForEntity computes the per-entity attribution set: cached
+// globals plus local-role probes (direct edges from any group-set
+// member to the entity, and when inherit_roles_through is configured,
+// per-ancestor probes).
+func (r *Request) computeForEntity(ctx context.Context, entityID string) []RoleAttribution {
+	globals := r.Globals(ctx)
+	out := append([]RoleAttribution(nil), globals.Attributions...)
+	seen := map[attrKey]bool{}
+	for _, a := range out {
+		seen[attrKey(a)] = true
+	}
+	add := func(role string, source Source) {
+		k := attrKey{Role: role, Source: source}
+		if seen[k] {
+			return
+		}
+		seen[k] = true
+		out = append(out, RoleAttribution{Role: role, Source: source})
+	}
+
+	chain := r.ancestors(ctx, entityID)
+	policy := r.d.policy
+	// RR-MBK0: iterate role-relation types in sorted order so the local-
+	// role attributions land in deterministic order — Decision.Attributions
+	// otherwise reflects Go's randomized map iteration, making
+	// formatDeniedSummary output non-reproducible.
+	relTypes := make([]string, 0, len(policy.RoleRelations))
+	for relType := range policy.RoleRelations {
+		relTypes = append(relTypes, relType)
+	}
+	sort.Strings(relTypes)
+	for _, relType := range relTypes {
+		def := policy.RoleRelations[relType]
+		role := def.Confers
+		if role == "" {
+			continue
+		}
+		if _, defined := policy.Roles[role]; !defined {
+			continue
+		}
+		for _, member := range globals.Members {
+			for _, target := range chain {
+				if !r.d.graph.HasEdge(ctx, member, relType, target) {
+					continue
+				}
+				add(role, buildLocalSource(member, r.principal.User, target, entityID, relType))
+			}
+		}
+	}
+	return out
+}
+
+// buildLocalSource picks the right Source variant for an
+// (group-member, ancestor, role-relation) match.
+func buildLocalSource(member, principalUser, target, entityID, relType string) Source {
+	inheritedAncestor := target != entityID
+	viaGroup := member != principalUser
+	switch {
+	case !inheritedAncestor && !viaGroup:
+		return Source{Kind: SourceLocal, Relation: relType}
+	case !inheritedAncestor && viaGroup:
+		return Source{Kind: SourceLocalViaGroup, Group: member, Relation: relType}
+	case inheritedAncestor && !viaGroup:
+		return Source{Kind: SourceLocalViaAncestor, Ancestor: target, Relation: relType}
+	default:
+		return Source{Kind: SourceLocalViaGroupAndAncestor, Group: member, Ancestor: target, Relation: relType}
+	}
+}
+
+// ancestors returns entityID plus any ancestors reachable via the
+// configured inherit_roles_through relation types (union across all
+// listed types). depthCap-bounded BFS with visited-set termination.
+// The entity itself is always at index 0.
+func (r *Request) ancestors(ctx context.Context, entityID string) []string {
+	if entityID == "" || len(r.d.policy.InheritRolesThrough) == 0 {
+		return []string{entityID}
+	}
+	visited := map[string]bool{entityID: true}
+	order := []string{entityID}
+	frontier := []string{entityID}
+	for depth := 0; depth < depthCap && len(frontier) > 0; depth++ {
+		var next []string
+		for _, n := range frontier {
+			for _, relType := range r.d.policy.InheritRolesThrough {
+				tos, err := r.d.graph.OutgoingRelations(ctx, n, relType)
+				if err != nil {
+					return order
+				}
+				for _, to := range tos {
+					if visited[to] {
+						continue
+					}
+					visited[to] = true
+					order = append(order, to)
+					next = append(next, to)
+				}
+			}
+		}
+		frontier = next
+	}
+	return order
+}
+
+// holdsPermission reports whether any role in the principal's global
+// role set grants the given permission. Used by the delegate-X gate
+// on role-relation writes; permissions are global-only by design.
+func (r *Request) holdsPermission(ctx context.Context, perm string) bool {
+	for _, a := range r.Globals(ctx).Attributions {
+		role, ok := r.d.policy.Roles[a.Role]
+		if !ok {
+			continue
+		}
+		for _, p := range role.Permissions {
+			if p == perm {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/acl/resolver_test.go
+++ b/internal/acl/resolver_test.go
@@ -1,0 +1,388 @@
+package acl
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store/graphquerynaive"
+)
+
+// RR-AROE: acl.DepthCap and graphquerynaive.DepthCap MUST stay in
+// lockstep. The resolver passes its cap into a store.GraphQuery
+// Depth/EntityDepth field; the naive backend then caps again as a
+// backstop. Drift would silently change semantics — fewer/more
+// ancestors materialized on the read path than the write path expects.
+//
+// The constants live in two packages because making graphquerynaive
+// import acl would create an arch-lint exception (acl is a domain
+// package; graphquerynaive is a generic store helper). The test below
+// is the structural pin.
+func TestDepthCap_LockstepWithGraphquerynaive(t *testing.T) {
+	if DepthCap != graphquerynaive.DepthCap {
+		t.Fatalf("acl.DepthCap=%d, graphquerynaive.DepthCap=%d; must be equal", DepthCap, graphquerynaive.DepthCap)
+	}
+}
+
+// Resolver unit tests. These cover invariants that the feature tests
+// in features_test.go deliberately don't pin:
+//
+//   - Walk termination on cycles, self-loops, and the depth-cap boundary
+//   - Globals memoization (call-counter discipline)
+//   - Graph error propagation
+//   - Unstamped-principal handling
+//
+// The tests drive the resolver directly via package-internal access
+// rather than going through the feature-test World; they use a
+// hand-rolled fakeGraph to control exactly which edges exist and to
+// count calls.
+
+// ---- Fake graph ---------------------------------------------------------
+
+// fakeGraph is a deterministic in-memory graph for resolver tests.
+// Edges keyed by (from, relType) → []to. Tracks call counts so tests
+// can assert "this walk ran exactly once."
+type fakeGraph struct {
+	edges map[edgeKey][]string
+	err   error // when non-nil, OutgoingRelations returns this error
+
+	outgoingCalls int
+	hasEdgeCalls  int
+	outgoingByRel map[string]int // OutgoingRelations calls bucketed by relType
+}
+
+type edgeKey struct{ from, relType string }
+
+func newFakeGraph() *fakeGraph {
+	return &fakeGraph{
+		edges:         map[edgeKey][]string{},
+		outgoingByRel: map[string]int{},
+	}
+}
+
+func (g *fakeGraph) add(from, relType, to string) {
+	k := edgeKey{from, relType}
+	g.edges[k] = append(g.edges[k], to)
+}
+
+func (g *fakeGraph) HasEdge(_ context.Context, from, relType, to string) bool {
+	g.hasEdgeCalls++
+	for _, t := range g.edges[edgeKey{from, relType}] {
+		if t == to {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *fakeGraph) OutgoingRelations(_ context.Context, from, relType string) ([]string, error) {
+	g.outgoingCalls++
+	g.outgoingByRel[relType]++
+	if g.err != nil {
+		return nil, g.err
+	}
+	return slices.Clone(g.edges[edgeKey{from, relType}]), nil
+}
+
+// helpers -----------------------------------------------------------------
+
+func newTestDeclarative(t *testing.T, p *Policy, g Graph) *Declarative {
+	t.Helper()
+	d, err := NewDeclarative(p, g)
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	return d
+}
+
+func aliceDataEntry() principal.Principal {
+	return principal.Principal{User: "alice", Tool: principal.ToolDataEntry}
+}
+
+// ---- Unknown principal --------------------------------------------------
+
+func TestForPrincipal_UnstampedRejected(t *testing.T) {
+	// Each of the unstamped shapes the resolver must refuse. The
+	// audit-log misattribution-visible default that From(ctx) returns
+	// is a non-issue here — the resolver is the boundary where the
+	// soft default becomes a hard error.
+	cases := []struct {
+		name string
+		p    principal.Principal
+	}{
+		{"empty user", principal.Principal{Tool: principal.ToolDataEntry}},
+		{"empty tool", principal.Principal{User: "alice"}},
+		{"unknown user", principal.Principal{User: "unknown", Tool: principal.ToolDataEntry}},
+		{"unknown tool", principal.Principal{User: "alice", Tool: "unknown"}},
+		{"both unknown", principal.Principal{User: "unknown", Tool: "unknown"}},
+		{"whitespace user", principal.Principal{User: "   ", Tool: principal.ToolDataEntry}},
+	}
+	d := newTestDeclarative(t, &Policy{}, newFakeGraph())
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req, err := d.ForPrincipal(c.p)
+			if req != nil {
+				t.Errorf("ForPrincipal(%+v) returned non-nil Request", c.p)
+			}
+			if !errors.Is(err, ErrUnstampedPrincipal) {
+				t.Errorf("ForPrincipal(%+v) error = %v, want errors.Is(_, ErrUnstampedPrincipal)", c.p, err)
+			}
+		})
+	}
+}
+
+func TestNewDeclarative_RejectsNil(t *testing.T) {
+	// The constructor must reject nil policy and nil graph at
+	// construction time — silently producing a half-built Declarative
+	// would defer the failure to a downstream symptom that's harder
+	// to diagnose.
+	if _, err := NewDeclarative(nil, NullGraph{}); err == nil {
+		t.Error("NewDeclarative(nil policy, ...) returned nil error; want error")
+	}
+	if _, err := NewDeclarative(&Policy{}, nil); err == nil {
+		t.Error("NewDeclarative(..., nil graph) returned nil error; want error")
+	}
+}
+
+// ---- Walk termination ---------------------------------------------------
+
+func TestWalkMembers_SelfLoop(t *testing.T) {
+	// alice --member-of--> alice. The walk must terminate after one
+	// iteration with just {alice}.
+	g := newFakeGraph()
+	g.add("alice", "member-of", "alice")
+
+	d := newTestDeclarative(t, &Policy{}, g)
+	req, err := d.ForPrincipal(aliceDataEntry())
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+
+	members := req.walkMembers(context.Background())
+	if got := len(members); got != 1 || members[0] != "alice" {
+		t.Errorf("walkMembers with self-loop = %v, want [alice]", members)
+	}
+}
+
+func TestWalkMembers_Cycle(t *testing.T) {
+	// A --member-of--> B --member-of--> C --member-of--> A.
+	// Starting from A, the walk must reach {A, B, C} and terminate
+	// (not loop back to A).
+	g := newFakeGraph()
+	g.add("A", "member-of", "B")
+	g.add("B", "member-of", "C")
+	g.add("C", "member-of", "A")
+
+	d := newTestDeclarative(t, &Policy{}, g)
+	req, err := d.ForPrincipal(principal.Principal{User: "A", Tool: principal.ToolDataEntry})
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+
+	members := req.walkMembers(context.Background())
+	got := append([]string(nil), members...)
+	slices.Sort(got)
+	want := []string{"A", "B", "C"}
+	if !slices.Equal(got, want) {
+		t.Errorf("walkMembers with cycle = %v, want %v", got, want)
+	}
+}
+
+func TestWalkMembers_DepthCap_ReachableAtCap(t *testing.T) {
+	// A chain of length equal to depthCap. The role assigned at the
+	// cap-th hop is reachable.
+	g := newFakeGraph()
+	chain := []string{"alice"}
+	for i := 1; i <= depthCap; i++ {
+		next := chainID(i)
+		g.add(chain[len(chain)-1], "member-of", next)
+		chain = append(chain, next)
+	}
+
+	d := newTestDeclarative(t, &Policy{}, g)
+	req, err := d.ForPrincipal(aliceDataEntry())
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+
+	members := req.walkMembers(context.Background())
+	last := chain[len(chain)-1]
+	if !slices.Contains(members, last) {
+		t.Errorf("walkMembers at cap=%d: last node %q not in result %v",
+			depthCap, last, members)
+	}
+}
+
+func TestWalkMembers_DepthCap_TruncatedBeyondCap(t *testing.T) {
+	// Chain longer than depthCap. Nodes beyond the cap must NOT be
+	// reached.
+	g := newFakeGraph()
+	chain := []string{"alice"}
+	overshoot := depthCap + 3
+	for i := 1; i <= overshoot; i++ {
+		next := chainID(i)
+		g.add(chain[len(chain)-1], "member-of", next)
+		chain = append(chain, next)
+	}
+
+	d := newTestDeclarative(t, &Policy{}, g)
+	req, err := d.ForPrincipal(aliceDataEntry())
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+
+	members := req.walkMembers(context.Background())
+	beyondCap := chain[depthCap+1]
+	if slices.Contains(members, beyondCap) {
+		t.Errorf("walkMembers at depth %d: node %q (beyond cap=%d) leaked into result %v",
+			overshoot, beyondCap, depthCap, members)
+	}
+}
+
+func TestWalkMembers_GraphError_AbortsWalk(t *testing.T) {
+	// When OutgoingRelations errors, the walk must abort rather than
+	// silently undercount or proceed with partial data. The result is
+	// the order accumulated so far — at minimum the principal itself.
+	g := newFakeGraph()
+	g.err = errors.New("backend failure")
+
+	d := newTestDeclarative(t, &Policy{}, g)
+	req, err := d.ForPrincipal(aliceDataEntry())
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+
+	members := req.walkMembers(context.Background())
+	// Walk aborts: at least we got the principal. We must not loop
+	// indefinitely on the failure.
+	if !slices.Contains(members, "alice") {
+		t.Errorf("walkMembers under error: principal not in result %v", members)
+	}
+	// One call attempted, then abort. (More precise: we don't pin the
+	// exact count; we pin that it terminated.)
+	if g.outgoingCalls == 0 {
+		t.Errorf("walkMembers under error: graph was not called at all")
+	}
+}
+
+// ---- Globals memoization ------------------------------------------------
+
+func TestRequest_GlobalsMemoized(t *testing.T) {
+	// Two calls to Globals on the same Request must share the cached
+	// result — the second call performs zero graph traffic.
+	g := newFakeGraph()
+	g.add("alice", "member-of", "engineering")
+
+	d := newTestDeclarative(t, &Policy{
+		Roles:       map[string]RoleDef{"editor": {Write: []string{"ticket"}}},
+		Assignments: map[string]string{"engineering": "editor"},
+	}, g)
+
+	req, err := d.ForPrincipal(aliceDataEntry())
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+
+	ctx := context.Background()
+	_ = req.Globals(ctx)
+	callsAfterFirst := g.outgoingCalls
+	_ = req.Globals(ctx)
+	callsAfterSecond := g.outgoingCalls
+
+	if callsAfterSecond != callsAfterFirst {
+		t.Errorf("Globals memoization broken: second call added %d more graph calls (first=%d, second=%d)",
+			callsAfterSecond-callsAfterFirst, callsAfterFirst, callsAfterSecond)
+	}
+}
+
+func TestRequest_ForEntityReusesGlobals(t *testing.T) {
+	// ForEntity must not re-walk member-of when Globals is already
+	// cached. The architect's S5a no-rewalk discipline — pinned here
+	// by the call counter on the fake graph.
+	g := newFakeGraph()
+	g.add("alice", "member-of", "engineering")
+	g.add("alice", "editor-of", "PRJ-foo")
+
+	d := newTestDeclarative(t, &Policy{
+		Roles:         map[string]RoleDef{"editor": {Write: []string{"project"}}},
+		RoleRelations: map[string]RoleRelationDef{"editor-of": {Confers: "editor"}},
+	}, g)
+
+	req, err := d.ForPrincipal(aliceDataEntry())
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+
+	ctx := context.Background()
+	_ = req.Globals(ctx)
+	walksAfterGlobals := g.outgoingByRel["member-of"]
+	_ = req.ForEntity(ctx, "project", "PRJ-foo")
+	walksAfterForEntity := g.outgoingByRel["member-of"]
+
+	if walksAfterForEntity != walksAfterGlobals {
+		t.Errorf("ForEntity re-walked member-of: globals=%d, after ForEntity=%d",
+			walksAfterGlobals, walksAfterForEntity)
+	}
+}
+
+// RR-MBK0: ForEntity's local-role attribution iteration over
+// RoleRelations is a map iteration — Go intentionally randomizes it.
+// Without the sort fix, the resulting Attributions slice (and the
+// formatDeniedSummary string it feeds) would vary across runs. We pin
+// the contract by running ForEntity many times against a scenario
+// with multiple role-relations all matching, and asserting that the
+// (role, source) sequence is byte-identical every iteration.
+func TestRequest_ForEntity_AttributionsDeterministic(t *testing.T) {
+	g := newFakeGraph()
+	// alice is a direct member of two groups so member-of is multi-edge.
+	g.add("alice", "member-of", "engineering")
+	g.add("alice", "member-of", "reviewers")
+	// Two distinct role-relations, both granting from a group:
+	g.add("engineering", "editor-of", "PRJ-foo")
+	g.add("reviewers", "reviewer-of", "PRJ-foo")
+
+	d := newTestDeclarative(t, &Policy{
+		Roles: map[string]RoleDef{
+			"editor":   {Write: []string{"project"}},
+			"reviewer": {Read: []string{"project"}},
+		},
+		RoleRelations: map[string]RoleRelationDef{
+			"editor-of":   {Confers: "editor"},
+			"reviewer-of": {Confers: "reviewer"},
+		},
+	}, g)
+
+	ctx := context.Background()
+	var first []RoleAttribution
+	for i := range 50 {
+		req, err := d.ForPrincipal(aliceDataEntry())
+		if err != nil {
+			t.Fatalf("ForPrincipal: %v", err)
+		}
+		attrs := req.ForEntity(ctx, "project", "PRJ-foo")
+		if i == 0 {
+			first = attrs
+			continue
+		}
+		if len(attrs) != len(first) {
+			t.Fatalf("iteration %d: len(Attributions)=%d, want %d", i, len(attrs), len(first))
+		}
+		for j := range attrs {
+			if attrs[j] != first[j] {
+				t.Fatalf("iteration %d, index %d: got %+v, want %+v (first run)",
+					i, j, attrs[j], first[j])
+			}
+		}
+	}
+}
+
+// ---- Helpers ------------------------------------------------------------
+
+// chainID names the i'th node in a synthetic chain used by depth-cap
+// tests: g1, g2, ... .
+func chainID(i int) string {
+	return "g" + strconv.Itoa(i)
+}

--- a/internal/acl/source.go
+++ b/internal/acl/source.go
@@ -69,6 +69,21 @@ func (k SourceKind) String() string {
 //	LocalViaAncestor                → Ancestor, Relation
 //	LocalViaGroupAndAncestor        → Group, Ancestor, Relation
 //
+// Visually, the four Local* variants correspond to the four corners of
+// a (member==user?, target==entity?) decision square — the resolver
+// picks the variant in buildLocalSource based on which corner the
+// matched HasEdge probe landed in:
+//
+//	                     target == entity              target != entity
+//	                 ┌──────────────────────────┬────────────────────────────┐
+//	member == user   │  Local                   │  LocalViaAncestor          │
+//	                 │  (Relation)              │  (Ancestor, Relation)      │
+//	                 ├──────────────────────────┼────────────────────────────┤
+//	member != user   │  LocalViaGroup           │  LocalViaGroupAndAncestor  │
+//	(group hop)      │  (Group, Relation)       │  (Group, Ancestor,         │
+//	                 │                          │   Relation)                │
+//	                 └──────────────────────────┴────────────────────────────┘
+//
 // Source is comparable; safe to use as a map key when paired with the
 // role name (see RoleAttribution).
 type Source struct {

--- a/internal/acl/source.go
+++ b/internal/acl/source.go
@@ -1,0 +1,148 @@
+package acl
+
+// SourceKind enumerates the closed set of ways a role can land in a
+// principal's effective set. Order doesn't matter for wire stability —
+// the int values are not exposed; sort precedence is in priority().
+type SourceKind int
+
+const (
+	SourceGlobal SourceKind = iota
+	SourceGroup
+	SourceLocal
+	SourceLocalViaGroup
+	SourceLocalViaAncestor
+	SourceLocalViaGroupAndAncestor
+)
+
+// priority defines the sort precedence used to pick the primary
+// Source from a multi-source attribution set. Lower wins. Defined as
+// an explicit map so reordering the const block above is a no-op for
+// the public sort order — the relationship lives here, in one place.
+// sourceKindUnknownPriority is the sort weight assigned to a Kind
+// not listed in sourceKindPriority. Chosen large enough to sort
+// after any defined kind without colliding with any future addition.
+const sourceKindUnknownPriority = 999
+
+func (k SourceKind) priority() int {
+	p, ok := sourceKindPriority[k]
+	if !ok {
+		return sourceKindUnknownPriority
+	}
+	return p
+}
+
+var sourceKindPriority = map[SourceKind]int{
+	SourceGlobal:                   0,
+	SourceGroup:                    1,
+	SourceLocal:                    2,
+	SourceLocalViaGroup:            3,
+	SourceLocalViaAncestor:         4,
+	SourceLocalViaGroupAndAncestor: 5,
+}
+
+// String returns the wire/log form of a SourceKind.
+func (k SourceKind) String() string {
+	switch k {
+	case SourceGlobal:
+		return "global"
+	case SourceGroup:
+		return "group"
+	case SourceLocal:
+		return "local"
+	case SourceLocalViaGroup:
+		return "local-via-group"
+	case SourceLocalViaAncestor:
+		return "local-via-ancestor"
+	case SourceLocalViaGroupAndAncestor:
+		return "local-via-group-and-ancestor"
+	}
+	return "unknown"
+}
+
+// Source describes how a role landed in a principal's effective set.
+// Flat struct with all four optional fields — populated per Kind:
+//
+//	Global                          → none
+//	Group                           → Group
+//	Local                           → Relation
+//	LocalViaGroup                   → Group, Relation
+//	LocalViaAncestor                → Ancestor, Relation
+//	LocalViaGroupAndAncestor        → Group, Ancestor, Relation
+//
+// Source is comparable; safe to use as a map key when paired with the
+// role name (see RoleAttribution).
+type Source struct {
+	Kind     SourceKind
+	Group    string
+	Ancestor string
+	Relation string
+}
+
+// String renders the human/log form of a Source. Audit and 403-body
+// consumers should marshal the typed fields rather than parsing this
+// string — the format is for log messages and test diagnostics, not a
+// stable wire contract.
+func (s Source) String() string {
+	switch s.Kind {
+	case SourceGlobal:
+		return "global"
+	case SourceGroup:
+		return "group:" + s.Group
+	case SourceLocal:
+		return "local:" + s.Relation
+	case SourceLocalViaGroup:
+		return "local-via-group:" + s.Group + ":" + s.Relation
+	case SourceLocalViaAncestor:
+		return "local-via-ancestor:" + s.Ancestor + ":" + s.Relation
+	case SourceLocalViaGroupAndAncestor:
+		return "local-via-group-and-ancestor:" + s.Group + ":" + s.Ancestor + ":" + s.Relation
+	}
+	return s.Kind.String()
+}
+
+// RoleAttribution is a (role, source) pair. The same role can land
+// with multiple sources (e.g. via group AND via direct local edge);
+// the resolver returns each as a distinct attribution.
+type RoleAttribution struct {
+	Role   string
+	Source Source
+}
+
+// attrKey is the composite map key used to dedupe (role, source)
+// attribution pairs. Replaces an earlier string-concat approach that
+// would have broken on role/source values containing the separator.
+type attrKey struct {
+	Role   string
+	Source Source
+}
+
+// PrimarySource picks the canonical attribution to credit on the wire.
+// Sort precedence: (Kind.priority, Group, Ancestor, Relation).
+// Returns the zero Source if the input is empty.
+//
+// Linear pass; n is small (typically <= 6 attributions).
+func PrimarySource(srcs []Source) Source {
+	if len(srcs) == 0 {
+		return Source{}
+	}
+	best := srcs[0]
+	for _, s := range srcs[1:] {
+		if lessSource(s, best) {
+			best = s
+		}
+	}
+	return best
+}
+
+func lessSource(a, b Source) bool {
+	if a.Kind.priority() != b.Kind.priority() {
+		return a.Kind.priority() < b.Kind.priority()
+	}
+	if a.Group != b.Group {
+		return a.Group < b.Group
+	}
+	if a.Ancestor != b.Ancestor {
+		return a.Ancestor < b.Ancestor
+	}
+	return a.Relation < b.Relation
+}

--- a/internal/acl/source_test.go
+++ b/internal/acl/source_test.go
@@ -1,0 +1,244 @@
+package acl
+
+import (
+	"strings"
+	"testing"
+)
+
+// Pure-value tests for Source, SourceKind, and PrimarySource. No
+// resolver or graph fixture — these are unit-level invariants on the
+// types that the feature tests rely on as building blocks.
+
+func TestSourceKindString_AllKindsRender(t *testing.T) {
+	// Pin the wire/log strings for every declared kind. A reorder of
+	// the const block (or a typo in a new kind's String case) shows up
+	// as a failing test, not as a wire-format regression in audit logs.
+	cases := []struct {
+		kind SourceKind
+		want string
+	}{
+		{SourceGlobal, "global"},
+		{SourceGroup, "group"},
+		{SourceLocal, "local"},
+		{SourceLocalViaGroup, "local-via-group"},
+		{SourceLocalViaAncestor, "local-via-ancestor"},
+		{SourceLocalViaGroupAndAncestor, "local-via-group-and-ancestor"},
+	}
+	for _, c := range cases {
+		got := c.kind.String()
+		if got != c.want {
+			t.Errorf("SourceKind(%d).String() = %q, want %q", c.kind, got, c.want)
+		}
+	}
+}
+
+func TestSourceKindString_UnknownKind(t *testing.T) {
+	// A SourceKind outside the declared range must not panic and must
+	// not produce a recognized wire string.
+	var k SourceKind = 99
+	got := k.String()
+	if got != "unknown" {
+		t.Errorf("unknown SourceKind = %q, want %q", got, "unknown")
+	}
+}
+
+func TestSourceKindPriority_DeclaredKinds(t *testing.T) {
+	// Each declared kind has a priority distinct from every other,
+	// matching the documented sort order (Global < Group < Local <
+	// LocalViaGroup < LocalViaAncestor < LocalViaGroupAndAncestor).
+	declared := []SourceKind{
+		SourceGlobal, SourceGroup, SourceLocal,
+		SourceLocalViaGroup, SourceLocalViaAncestor, SourceLocalViaGroupAndAncestor,
+	}
+	seen := map[int]SourceKind{}
+	for _, k := range declared {
+		p := k.priority()
+		if other, dup := seen[p]; dup {
+			t.Errorf("SourceKind %v and %v both have priority %d", other, k, p)
+		}
+		seen[p] = k
+	}
+	// Pin the order: priorities increase with the const declaration.
+	for i := 1; i < len(declared); i++ {
+		if declared[i-1].priority() >= declared[i].priority() {
+			t.Errorf("priority order violated: %v(%d) >= %v(%d)",
+				declared[i-1], declared[i-1].priority(),
+				declared[i], declared[i].priority())
+		}
+	}
+}
+
+func TestSourceKindPriority_UnknownKind(t *testing.T) {
+	// Unknown kinds sort after every declared kind, so adding a new
+	// kind without registering it in the priority map doesn't
+	// accidentally promote it to "primary".
+	var k SourceKind = 99
+	if k.priority() <= SourceLocalViaGroupAndAncestor.priority() {
+		t.Errorf("unknown kind priority %d should be greater than last declared %d",
+			k.priority(), SourceLocalViaGroupAndAncestor.priority())
+	}
+}
+
+func TestSourceString_PerKind(t *testing.T) {
+	cases := []struct {
+		name string
+		src  Source
+		want string
+	}{
+		{"global", Source{Kind: SourceGlobal}, "global"},
+		{"group", Source{Kind: SourceGroup, Group: "engineering"}, "group:engineering"},
+		{"local", Source{Kind: SourceLocal, Relation: "editor-of"}, "local:editor-of"},
+		{
+			"local-via-group",
+			Source{Kind: SourceLocalViaGroup, Group: "engineering", Relation: "editor-of"},
+			"local-via-group:engineering:editor-of",
+		},
+		{
+			"local-via-ancestor",
+			Source{Kind: SourceLocalViaAncestor, Ancestor: "F-eng", Relation: "editor-of"},
+			"local-via-ancestor:F-eng:editor-of",
+		},
+		{
+			"local-via-group-and-ancestor",
+			Source{
+				Kind: SourceLocalViaGroupAndAncestor, Group: "engineering",
+				Ancestor: "F-eng", Relation: "editor-of",
+			},
+			"local-via-group-and-ancestor:engineering:F-eng:editor-of",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.src.String()
+			if got != c.want {
+				t.Errorf("Source.String() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestPrimarySource_Empty(t *testing.T) {
+	got := PrimarySource(nil)
+	if got != (Source{}) {
+		t.Errorf("PrimarySource(nil) = %+v, want zero Source", got)
+	}
+	got = PrimarySource([]Source{})
+	if got != (Source{}) {
+		t.Errorf("PrimarySource([]) = %+v, want zero Source", got)
+	}
+}
+
+func TestPrimarySource_Single(t *testing.T) {
+	only := Source{Kind: SourceLocalViaGroup, Group: "eng", Relation: "editor-of"}
+	got := PrimarySource([]Source{only})
+	if got != only {
+		t.Errorf("PrimarySource([single]) = %+v, want %+v", got, only)
+	}
+}
+
+func TestPrimarySource_MultiKind_LowestPriorityWins(t *testing.T) {
+	// Group < Local < LocalViaGroup — the Group source should win
+	// regardless of input order. Multiple paths to the same role is
+	// the realistic case (UC5).
+	srcs := []Source{
+		{Kind: SourceLocalViaGroup, Group: "eng-leads", Relation: "editor-of"},
+		{Kind: SourceLocal, Relation: "editor-of"},
+		{Kind: SourceGroup, Group: "eng-leads"},
+	}
+	got := PrimarySource(srcs)
+	want := Source{Kind: SourceGroup, Group: "eng-leads"}
+	if got != want {
+		t.Errorf("PrimarySource(...) = %+v, want %+v", got, want)
+	}
+}
+
+func TestPrimarySource_TiedKind_AlphaWins(t *testing.T) {
+	// Both Group; alpha sort on Group wins. "a" < "b".
+	srcs := []Source{
+		{Kind: SourceGroup, Group: "b-team"},
+		{Kind: SourceGroup, Group: "a-team"},
+	}
+	got := PrimarySource(srcs)
+	if got.Group != "a-team" {
+		t.Errorf("PrimarySource: tied Kind → alpha Group, got %q, want %q",
+			got.Group, "a-team")
+	}
+}
+
+func TestPrimarySource_TiedGroup_AlphaRelationWins(t *testing.T) {
+	// Same Kind and Group; tied on Ancestor (empty); Relation alpha wins.
+	srcs := []Source{
+		{Kind: SourceLocalViaGroup, Group: "eng", Relation: "viewer-of"},
+		{Kind: SourceLocalViaGroup, Group: "eng", Relation: "editor-of"},
+	}
+	got := PrimarySource(srcs)
+	if got.Relation != "editor-of" {
+		t.Errorf("PrimarySource: tied Group → alpha Relation, got %q, want %q",
+			got.Relation, "editor-of")
+	}
+}
+
+func TestPrimarySource_NonMutating(t *testing.T) {
+	// PrimarySource must not reorder the caller's slice; callers may
+	// keep the full attribution chain for audit purposes.
+	srcs := []Source{
+		{Kind: SourceLocalViaGroup, Group: "eng-leads", Relation: "editor-of"},
+		{Kind: SourceGroup, Group: "eng-leads"},
+		{Kind: SourceLocal, Relation: "editor-of"},
+	}
+	before := append([]Source(nil), srcs...)
+	_ = PrimarySource(srcs)
+	for i, s := range srcs {
+		if s != before[i] {
+			t.Errorf("PrimarySource mutated input at index %d: got %+v, want %+v",
+				i, s, before[i])
+		}
+	}
+}
+
+func TestRoleAttributionAsMapKey(t *testing.T) {
+	// attrKey is a struct, comparable by value. Confirm that two
+	// attributions with the same (Role, Source) collide and two with
+	// any difference do not — the dedup logic in computeGlobals /
+	// computeForEntity depends on this.
+	a := attrKey{Role: "editor", Source: Source{Kind: SourceGroup, Group: "eng"}}
+	b := attrKey{Role: "editor", Source: Source{Kind: SourceGroup, Group: "eng"}}
+	if a != b {
+		t.Errorf("equal attrKeys compare as unequal: %+v vs %+v", a, b)
+	}
+	c := attrKey{Role: "viewer", Source: Source{Kind: SourceGroup, Group: "eng"}}
+	if a == c {
+		t.Errorf("different-Role attrKeys compare as equal")
+	}
+	d := attrKey{Role: "editor", Source: Source{Kind: SourceLocal, Relation: "editor-of"}}
+	if a == d {
+		t.Errorf("different-Source attrKeys compare as equal")
+	}
+}
+
+// Compile-time check that Source's wire format doesn't accidentally
+// emit one of the substring tokens used by another kind. If two kinds'
+// string forms share a prefix that prevents structured parsing, a
+// future parser would silently misroute.
+func TestSourceKindString_UniquePrefixes(t *testing.T) {
+	kinds := []SourceKind{
+		SourceGlobal, SourceGroup, SourceLocal,
+		SourceLocalViaGroup, SourceLocalViaAncestor, SourceLocalViaGroupAndAncestor,
+	}
+	for i, a := range kinds {
+		for j, b := range kinds {
+			if i == j {
+				continue
+			}
+			sa, sb := a.String(), b.String()
+			// `local` is a prefix of `local-via-group`; the format is
+			// disambiguated by what follows. Verify that a longer kind
+			// ALWAYS includes a separator after the shorter prefix.
+			if strings.HasPrefix(sb, sa) && len(sb) > len(sa) {
+				if sb[len(sa)] != '-' && sb[len(sa)] != ':' {
+					t.Errorf("kind %q is an ambiguous prefix of %q (no separator)", sa, sb)
+				}
+			}
+		}
+	}
+}

--- a/internal/acl/storegraph.go
+++ b/internal/acl/storegraph.go
@@ -1,0 +1,66 @@
+package acl
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// StoreGraph adapts a store.Store to the acl.Graph interface. Used by
+// appbuild (and any other wiring site that already holds a Store) to
+// give the resolver its read-side access to the relation index.
+//
+// Errors from the store iterator are surfaced via the (*StoreGraph)
+// methods' error returns. The resolver decides what to do — abort the
+// walk loud, in practice (see resolver.go).
+type StoreGraph struct {
+	S store.Store
+}
+
+// NewStoreGraph constructs a StoreGraph backed by s.
+func NewStoreGraph(s store.Store) *StoreGraph { return &StoreGraph{S: s} }
+
+// HasEdge reports whether the specific (from, relType, to) edge exists.
+// A missing edge ([store.ErrNotFound]) reports false silently. Any
+// other error (transient backend failure, context cancelled, etc.)
+// also reports false BUT is logged at [slog.Warn] with operator-facing
+// context (RR-K3OO) — without the log a pgx hiccup during ACL
+// evaluation silently undercounts a member's role-relations and
+// produces spurious denies the operator can't trace.
+//
+// Implementation uses the store's single-key GetRelation rather than
+// scanning ListRelations (RR-L3VO): in the ACL resolver this is
+// called O(|RoleRelations| × |Members| × |ancestors|) times per
+// request, and scanning the full outgoing-by-relType list per call
+// is a quadratic foot-cannon on densely-connected nodes.
+func (g *StoreGraph) HasEdge(ctx context.Context, from, relType, to string) bool {
+	_, err := g.S.GetRelation(ctx, from, relType, to)
+	if err == nil {
+		return true
+	}
+	if !errors.Is(err, store.ErrNotFound) {
+		slog.Warn("acl: StoreGraph.HasEdge: backend error treated as no-edge",
+			"from", from, "rel_type", relType, "to", to, "error", err)
+	}
+	return false
+}
+
+// OutgoingRelations returns the toIDs reachable from `fromID` via
+// `relType`. Errors propagate; callers (the resolver) abort the
+// surrounding walk rather than silently undercount.
+func (g *StoreGraph) OutgoingRelations(ctx context.Context, from, relType string) ([]string, error) {
+	var out []string
+	for r, err := range g.S.ListRelations(ctx, store.RelationQuery{
+		EntityID:  from,
+		Direction: store.DirectionOutgoing,
+		Type:      relType,
+	}) {
+		if err != nil {
+			return out, err
+		}
+		out = append(out, r.To)
+	}
+	return out, nil
+}

--- a/internal/acl/subject.go
+++ b/internal/acl/subject.go
@@ -5,6 +5,18 @@ package acl
 // The sum exists so RelationSubject can carry both endpoints
 // (FromID/ToID) without the source/target ambiguity that overloading
 // EntityType produced in v0.
+//
+// The sealed sum, visually:
+//
+//	Subject (sealed)
+//	├── EntitySubject   { Type, ID }
+//	│       used for: Create / Update / Delete / Rename of an entity
+//	└── RelationSubject { Type, FromType, FromID }
+//	        used for: Create / Delete of a relation
+//
+// A nil Subject is a programmer error. AuthorizeWrite panics so the
+// bug surfaces at the call site rather than silently denying or
+// silently allowing.
 type Subject interface{ isSubject() }
 
 // EntitySubject identifies an entity write target.

--- a/internal/acl/subject.go
+++ b/internal/acl/subject.go
@@ -1,0 +1,40 @@
+package acl
+
+// Subject is what's being written. Sealed: only EntitySubject and
+// RelationSubject implement it (via the unexported isSubject method).
+// The sum exists so RelationSubject can carry both endpoints
+// (FromID/ToID) without the source/target ambiguity that overloading
+// EntityType produced in v0.
+type Subject interface{ isSubject() }
+
+// EntitySubject identifies an entity write target.
+//
+//	Op=Create   → ID is empty (no ID yet at the time of authz).
+//	Op=Update   → ID is the entity being mutated.
+//	Op=Delete   → ID is the entity being removed.
+//	Op=Rename   → ID is the entity before the rename.
+type EntitySubject struct {
+	Type string
+	ID   string
+}
+
+func (EntitySubject) isSubject() {}
+
+// RelationSubject identifies a relation write. v1 evaluates relation
+// writes against `FromType` only (matching v0 semantics — see the
+// "S13" thread in the TKT-SVXL design log). The v0 quirk of
+// EntityType meaning "source type for relation writes" is gone.
+//
+// The To side is intentionally absent (RR-F9M9): the resolver doesn't
+// read it today, and forcing callers to populate it costs an extra
+// store round-trip per relation write. A future per-link verdict
+// feature that wants asymmetric grants (e.g. "may create editor-of
+// edges only to entities of type project") can add it back with a
+// clear semantic at that time.
+type RelationSubject struct {
+	Type     string // relation type (e.g. "editor-of")
+	FromType string
+	FromID   string
+}
+
+func (RelationSubject) isSubject() {}

--- a/internal/acl/testutil_test.go
+++ b/internal/acl/testutil_test.go
@@ -1,0 +1,416 @@
+package acl_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// World is a feature-test fixture: a memstore, a parsed acl.Policy, an
+// acl.Declarative, and the helpers needed to make assertions against
+// them. Built fluently — see TestFeature_UC* in features_test.go for
+// canonical usage.
+//
+// World is single-goroutine by construction. It holds a *testing.T
+// after Build so assertion helpers can call t.Errorf without each
+// caller threading t.
+//
+// background that flows through every assertion. Threading ctx through
+// every helper signature here would add ceremony without buying isolation.
+//
+//nolint:containedctx // test fixture: the ctx is a request-scoped
+type World struct {
+	t   *testing.T
+	ctx context.Context
+
+	policyYAML string
+	store      store.Store
+	acl        *acl.Declarative
+
+	// Pending mutations applied at Build time. Held as data so the
+	// builder is order-independent (you can declare a relation before
+	// the entities it points at).
+	entities  []pendingEntity
+	relations []pendingRelation
+}
+
+type pendingEntity struct {
+	id, typ string
+}
+
+type pendingRelation struct {
+	from, typ, to string
+}
+
+// EntityOpt is a vararg option to Folder / Document / etc. Currently
+// only Inside (containment) — the shape lets us grow opts without
+// renaming callers.
+type EntityOpt func(*pendingEntity, *World)
+
+// Inside(parent) emits a belongs-to relation from the entity being
+// built to `parent`. The parent does not need to exist at the call
+// site — relations are resolved at Build time.
+func Inside(parent string) EntityOpt {
+	return func(e *pendingEntity, w *World) {
+		w.relations = append(w.relations, pendingRelation{
+			from: e.id, typ: "belongs-to", to: parent,
+		})
+	}
+}
+
+// NewWorld constructs an empty World. Chain Policy / Entity / Relation
+// calls, then Build(t) to materialize.
+func NewWorld() *World {
+	return &World{ctx: context.Background()}
+}
+
+// Policy sets the acl.yaml content for this world. Must be called
+// before Build; the policy is parsed during Build.
+func (w *World) Policy(yaml string) *World {
+	w.policyYAML = yaml
+	return w
+}
+
+// Entity declares an entity of the given type and id, with optional
+// opts (Inside, WithProperty).
+func (w *World) Entity(id, typ string, opts ...EntityOpt) *World {
+	e := pendingEntity{id: id, typ: typ}
+	for _, opt := range opts {
+		opt(&e, w)
+	}
+	w.entities = append(w.entities, e)
+	return w
+}
+
+// Folder is shorthand for Entity(id, "folder", opts...).
+func (w *World) Folder(id string, opts ...EntityOpt) *World {
+	return w.Entity(id, "folder", opts...)
+}
+
+// Document is shorthand for Entity(id, "document", opts...).
+func (w *World) Document(id string, opts ...EntityOpt) *World {
+	return w.Entity(id, "document", opts...)
+}
+
+// Person is shorthand for Entity(id, "person").
+func (w *World) Person(id string) *World {
+	return w.Entity(id, "person")
+}
+
+// Team is shorthand for Entity(id, "team").
+func (w *World) Team(id string) *World {
+	return w.Entity(id, "team")
+}
+
+// Ticket is shorthand for Entity(id, "ticket").
+func (w *World) Ticket(id string) *World {
+	return w.Entity(id, "ticket")
+}
+
+// Project is shorthand for Entity(id, "project").
+func (w *World) Project(id string) *World {
+	return w.Entity(id, "project")
+}
+
+// Relation declares an arbitrary relation. Use the more specific
+// builders (Inside, etc.) where they fit; Relation is the escape hatch.
+func (w *World) Relation(from, typ, to string) *World {
+	w.relations = append(w.relations, pendingRelation{
+		from: from, typ: typ, to: to,
+	})
+	return w
+}
+
+// Build materializes the world: parses the policy, sets up an
+// in-memory store, writes the entities and relations, and constructs
+// the acl.Declarative. From this point on the World can be queried
+// via Allow / Visible / Attribution and their Assert* sugar.
+//
+// Build fatals the test on setup error — a malformed policy or a
+// relation pointing at an entity that doesn't exist indicates a bug
+// in the test fixture, not behavior the test is meant to assert on.
+func (w *World) Build(t *testing.T) *World {
+	t.Helper()
+	w.t = t
+
+	policy, err := acl.LoadPolicyBytes([]byte(w.policyYAML))
+	if err != nil {
+		t.Fatalf("World.Build: load policy: %v", err)
+	}
+
+	ms := memstore.New()
+	for _, e := range w.entities {
+		if cErr := ms.CreateEntity(w.ctx, entity.New(e.id, e.typ)); cErr != nil {
+			t.Fatalf("World.Build: create entity %s: %v", e.id, cErr)
+		}
+	}
+	for _, r := range w.relations {
+		if _, cErr := ms.CreateRelation(w.ctx, r.from, r.typ, r.to, nil); cErr != nil {
+			t.Fatalf("World.Build: create relation %s --%s--> %s: %v", r.from, r.typ, r.to, cErr)
+		}
+	}
+	w.store = ms
+
+	d, err := acl.NewDeclarative(policy, acl.NewStoreGraph(ms))
+	if err != nil {
+		t.Fatalf("World.Build: NewDeclarative: %v", err)
+	}
+	w.acl = d
+	return w
+}
+
+// principal returns the canonical Principal for `actor`. All feature
+// tests use Tool=data-entry; specific edge cases (e.g. CLI vs MCP) live
+// in unit tests, not here.
+func (*World) principalFor(actor string) principal.Principal {
+	return principal.Principal{User: actor, Tool: principal.ToolDataEntry}
+}
+
+// requestFor opens a per-principal Request. Errors fatal the test —
+// a malformed principal at the feature-test layer is a bug in the test,
+// not behavior the test is asserting on. (Unknown-principal errors are
+// covered by unit tests.)
+func (w *World) requestFor(actor string) *acl.Request {
+	w.t.Helper()
+	req, err := w.acl.ForPrincipal(w.principalFor(actor))
+	if err != nil {
+		w.t.Fatalf("World.requestFor(%q): %v", actor, err)
+	}
+	return req
+}
+
+// ---- Primitives ---------------------------------------------------------
+
+// Allow reports whether `actor` may perform `op` on `subject`.
+func (w *World) Allow(actor string, op acl.Op, subject acl.Subject) bool {
+	w.t.Helper()
+	req := w.requestFor(actor)
+	d := req.AuthorizeWrite(w.ctx, acl.WriteRequest{Op: op, Subject: subject})
+	return d.Allow
+}
+
+// Visible returns the set of entity IDs of `entityType` that `actor`
+// can read. Sorted, so equality comparisons are stable.
+func (w *World) Visible(actor, entityType string) []string {
+	w.t.Helper()
+	req := w.requestFor(actor)
+	rqr := req.ReadQuery(w.ctx, entityType)
+
+	var ids []string
+	switch {
+	case rqr.AllowAll:
+		for _, e := range listAllOfType(w.ctx, w.t, w.store, entityType) {
+			ids = append(ids, e.ID)
+		}
+	case rqr.DenyAll:
+		// nothing
+	default:
+		// RR-3D6Q: a zero ReadQueryResult (no AllowAll, no DenyAll,
+		// nil Query) is a readQuery bug — without this check the next
+		// line dereferences a nil pointer and the test panics with a
+		// misleading "fixture panicked" rather than "the resolver
+		// returned a malformed result." Fail loud at the boundary.
+		if rqr.Query == nil {
+			w.t.Fatalf("Visible(%q, %q): ReadQuery returned neither AllowAll, DenyAll, nor a Query — readQuery bug",
+				actor, entityType)
+		}
+		for e, err := range w.store.GraphQuery(w.ctx, *rqr.Query) {
+			if err != nil {
+				w.t.Fatalf("Visible(%q, %q): GraphQuery: %v", actor, entityType, err)
+			}
+			ids = append(ids, e.ID)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// assertExists fails the test if any of `ids` is missing from the
+// store. Used by AssertHidden / AssertContains (RR-2XZW): a typo
+// in a test ticket ID would otherwise pass trivially —
+// AssertHidden("alice", "ticket", "TKT-TYPO") returns success because
+// the bogus ID isn't in any visible set, masking a real assertion.
+func (w *World) assertExists(helper, entityType string, ids []string) {
+	w.t.Helper()
+	for _, id := range ids {
+		e, err := w.store.GetEntity(w.ctx, id)
+		if err != nil || e == nil {
+			w.t.Fatalf("%s: entity %q does not exist in the store (likely a typo in the test ID)", helper, id)
+		}
+		if entityType != "" && e.Type != entityType {
+			w.t.Fatalf("%s: entity %q is of type %q, not %q (test scenario mismatch)",
+				helper, id, e.Type, entityType)
+		}
+	}
+}
+
+// Attribution returns the set of Source values that confer `role` on
+// `actor` against `entity`. Empty if the role is not in the principal's
+// effective set for that entity.
+func (w *World) Attribution(actor, entityID, role string) []acl.Source {
+	w.t.Helper()
+	req := w.requestFor(actor)
+	e, err := w.store.GetEntity(w.ctx, entityID)
+	if err != nil {
+		w.t.Fatalf("Attribution(%q, %q): GetEntity: %v", actor, entityID, err)
+	}
+	attrs := req.ForEntity(w.ctx, e.Type, e.ID)
+
+	var sources []acl.Source
+	for _, a := range attrs {
+		if a.Role == role {
+			sources = append(sources, a.Source)
+		}
+	}
+	return sources
+}
+
+// ---- Assertion sugar ----------------------------------------------------
+
+// AssertAllow fails the test if `actor` cannot perform `op` on `subject`.
+func (w *World) AssertAllow(actor string, op acl.Op, subject acl.Subject) {
+	w.t.Helper()
+	if !w.Allow(actor, op, subject) {
+		w.t.Errorf("AssertAllow(%q, %v, %+v): denied, want allowed", actor, op, subject)
+	}
+}
+
+// AssertDeny fails the test if `actor` can perform `op` on `subject`.
+func (w *World) AssertDeny(actor string, op acl.Op, subject acl.Subject) {
+	w.t.Helper()
+	if w.Allow(actor, op, subject) {
+		w.t.Errorf("AssertDeny(%q, %v, %+v): allowed, want denied", actor, op, subject)
+	}
+}
+
+// AssertVisible fails if `actor`'s visible set of `entityType` is not
+// exactly the given ids (any order; the helper sorts both sides).
+func (w *World) AssertVisible(actor, entityType string, want ...string) {
+	w.t.Helper()
+	got := w.Visible(actor, entityType)
+	sort.Strings(want)
+	if !slicesEqual(got, want) {
+		w.t.Errorf("AssertVisible(%q, %q):\n  got:  %v\n  want: %v", actor, entityType, got, want)
+	}
+}
+
+// AssertContains fails if any of `ids` is NOT in `actor`'s visible
+// set of `entityType`. Allows extras — the looser shape for cases
+// where you only care that specific entities appear. Every id must
+// exist in the store (RR-2XZW: pre-check guards against typos that
+// would silently pass).
+func (w *World) AssertContains(actor, entityType string, ids ...string) {
+	w.t.Helper()
+	w.assertExists("AssertContains", entityType, ids)
+	got := w.Visible(actor, entityType)
+	gotSet := make(map[string]bool, len(got))
+	for _, id := range got {
+		gotSet[id] = true
+	}
+	var missing []string
+	for _, id := range ids {
+		if !gotSet[id] {
+			missing = append(missing, id)
+		}
+	}
+	if len(missing) > 0 {
+		w.t.Errorf("AssertContains(%q, %q): missing %v from %v", actor, entityType, missing, got)
+	}
+}
+
+// AssertHidden fails if any of `ids` IS in `actor`'s visible set of
+// `entityType`. Allows extras (other entities that are also visible).
+// Every id must exist in the store (RR-2XZW: pre-check guards
+// against typos that would silently pass — a bogus id is by
+// definition "not visible" without the resolver doing anything).
+func (w *World) AssertHidden(actor, entityType string, ids ...string) {
+	w.t.Helper()
+	w.assertExists("AssertHidden", entityType, ids)
+	got := w.Visible(actor, entityType)
+	gotSet := make(map[string]bool, len(got))
+	for _, id := range got {
+		gotSet[id] = true
+	}
+	var leaked []string
+	for _, id := range ids {
+		if gotSet[id] {
+			leaked = append(leaked, id)
+		}
+	}
+	if len(leaked) > 0 {
+		w.t.Errorf("AssertHidden(%q, %q): %v unexpectedly visible (full set: %v)", actor, entityType, leaked, got)
+	}
+}
+
+// AssertPrimarySource fails if the primary source for (actor, entity,
+// role) doesn't match `want`. Primary is the AC8a-sorted first
+// attribution.
+func (w *World) AssertPrimarySource(actor, entityID, role string, want acl.Source) {
+	w.t.Helper()
+	srcs := w.Attribution(actor, entityID, role)
+	if len(srcs) == 0 {
+		w.t.Errorf("AssertPrimarySource(%q, %q, %q): no sources confer this role", actor, entityID, role)
+		return
+	}
+	primary := acl.PrimarySource(srcs)
+	if primary != want {
+		w.t.Errorf("AssertPrimarySource(%q, %q, %q):\n  got:  %s\n  want: %s",
+			actor, entityID, role, primary, want)
+	}
+}
+
+// AssertAttribution fails if the set of Sources conferring `role` on
+// `actor` for `entity` is not exactly `want` (any order; equality by
+// String() so the comparison reads naturally on failure).
+func (w *World) AssertAttribution(actor, entityID, role string, want ...acl.Source) {
+	w.t.Helper()
+	got := w.Attribution(actor, entityID, role)
+
+	gotStrs := make([]string, len(got))
+	for i, s := range got {
+		gotStrs[i] = s.String()
+	}
+	wantStrs := make([]string, len(want))
+	for i, s := range want {
+		wantStrs[i] = s.String()
+	}
+	sort.Strings(gotStrs)
+	sort.Strings(wantStrs)
+
+	if !slicesEqual(gotStrs, wantStrs) {
+		w.t.Errorf("AssertAttribution(%q, %q, %q):\n  got:  %v\n  want: %v",
+			actor, entityID, role, gotStrs, wantStrs)
+	}
+}
+
+// ---- Internal helpers ---------------------------------------------------
+
+func listAllOfType(ctx context.Context, t *testing.T, s store.Store, typ string) []*entity.Entity {
+	t.Helper()
+	var out []*entity.Entity
+	for e, err := range s.ListEntities(ctx, store.EntityQuery{Type: typ}) {
+		if err != nil {
+			t.Fatalf("listAllOfType(%q): %v", typ, err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -330,7 +330,17 @@ func loadACL(projectRoot string) (acl.ACL, *acl.Policy) {
 		slog.Warn("appbuild: failed to load acl.yaml; falling back to NopACL", "error", err)
 		return acl.NopACL{}, nil
 	}
-	return acl.NewDeclarative(policy), policy
+	// PR 2 wires Declarative with a NullGraph — group/inherited-role
+	// resolution against the store lands in PR 4, where the buildACL
+	// split (loadACLPolicy + buildACL(policy, store)) defers Declarative
+	// construction until the store is open. Until then, direct grants
+	// still resolve correctly.
+	d, derr := acl.NewDeclarative(policy, acl.NullGraph{})
+	if derr != nil {
+		slog.Warn("appbuild: failed to build acl.Declarative; falling back to NopACL", "error", derr)
+		return acl.NopACL{}, policy
+	}
+	return d, policy
 }
 
 // Config carries the inputs every build of [New] needs, plus

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -25,16 +25,23 @@ import (
 // that pass verbs in are [perItemVerbs] and [perCollectionVerbs] in
 // this file. Adding a new verb requires an entry here plus an
 // [acl.Op] constant.
-func translateVerb(verb, entityType string) acl.WriteRequest {
+//
+// entityID is the entity being acted on; empty for per-collection
+// verbs (e.g. "create" against a type, no instance yet). It populates
+// [acl.EntitySubject.ID] so the v1 ACL can evaluate entity-aware
+// local-role grants (e.g. "alice can edit TKT-042 because she's
+// assigned to it").
+func translateVerb(verb, entityType, entityID string) acl.WriteRequest {
+	subject := acl.EntitySubject{Type: entityType, ID: entityID}
 	switch verb {
 	case "create":
-		return acl.WriteRequest{Op: acl.OpCreate, EntityType: entityType}
+		return acl.WriteRequest{Op: acl.OpCreate, Subject: subject}
 	case "update":
-		return acl.WriteRequest{Op: acl.OpUpdate, EntityType: entityType}
+		return acl.WriteRequest{Op: acl.OpUpdate, Subject: subject}
 	case "delete":
-		return acl.WriteRequest{Op: acl.OpDelete, EntityType: entityType}
+		return acl.WriteRequest{Op: acl.OpDelete, Subject: subject}
 	case "rename":
-		return acl.WriteRequest{Op: acl.OpRename, EntityType: entityType}
+		return acl.WriteRequest{Op: acl.OpRename, Subject: subject}
 	}
 	// Unreachable for the closed verb set above. A panic here would
 	// signal a bug in a future commit — better than silently returning
@@ -58,7 +65,7 @@ var perCollectionVerbs = []string{"create"}
 func (a *App) computeActions(ctx context.Context, e *entityPkg.Entity) map[string]bool {
 	out := make(map[string]bool, len(perItemVerbs))
 	for _, v := range perItemVerbs {
-		out[v] = a.acl.AuthorizeWrite(ctx, translateVerb(v, e.Type)).Allow
+		out[v] = a.acl.AuthorizeWrite(ctx, translateVerb(v, e.Type, e.ID)).Allow
 	}
 	return out
 }
@@ -68,7 +75,7 @@ func (a *App) computeActions(ctx context.Context, e *entityPkg.Entity) map[strin
 func (a *App) computeCollectionActions(ctx context.Context, entityType string) map[string]bool {
 	out := make(map[string]bool, len(perCollectionVerbs))
 	for _, v := range perCollectionVerbs {
-		out[v] = a.acl.AuthorizeWrite(ctx, translateVerb(v, entityType)).Allow
+		out[v] = a.acl.AuthorizeWrite(ctx, translateVerb(v, entityType, "")).Allow
 	}
 	return out
 }

--- a/internal/dataentry/affordances_test.go
+++ b/internal/dataentry/affordances_test.go
@@ -26,12 +26,16 @@ func TestTranslateVerb_Roundtrip(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.verb, func(t *testing.T) {
-			req := translateVerb(c.verb, "ticket")
+			req := translateVerb(c.verb, "ticket", "TKT-001")
 			if req.Op != c.op {
 				t.Errorf("Op = %q, want %q", req.Op, c.op)
 			}
-			if req.EntityType != "ticket" {
-				t.Errorf("EntityType = %q, want %q", req.EntityType, "ticket")
+			s, ok := req.Subject.(acl.EntitySubject)
+			if !ok {
+				t.Errorf("Subject = %T, want acl.EntitySubject", req.Subject)
+			}
+			if s.Type != "ticket" || s.ID != "TKT-001" {
+				t.Errorf("Subject = %+v, want {Type:ticket, ID:TKT-001}", s)
 			}
 		})
 	}
@@ -49,7 +53,7 @@ func TestTranslateVerb_UnknownPanics(t *testing.T) {
 			t.Error("expected panic on unknown verb; got none")
 		}
 	}()
-	translateVerb("transition:done", "ticket")
+	translateVerb("transition:done", "ticket", "")
 }
 
 // AC1: read-only principal sees all per-item verbs as false.
@@ -101,7 +105,7 @@ func TestComputeCollectionActions_ReadOnly(t *testing.T) {
 // WriteRequest carries no entity ID.)
 func TestComputeActions_MixedTypeDeclarative(t *testing.T) {
 	app := newTestAppV1(t)
-	app.acl = acl.NewDeclarative(&acl.Policy{
+	d, err := acl.NewDeclarative(&acl.Policy{
 		UserEntityType: "person",
 		Roles: map[string]acl.RoleDef{
 			"ticket-writer": {Write: []string{"ticket"}},
@@ -109,7 +113,11 @@ func TestComputeActions_MixedTypeDeclarative(t *testing.T) {
 		Assignments: map[string]string{
 			"test-user": "ticket-writer",
 		},
-	})
+	}, acl.NullGraph{})
+	if err != nil {
+		t.Fatalf("acl.NewDeclarative: %v", err)
+	}
+	app.acl = d
 
 	// Declarative looks up the principal by Principal.User against
 	// Assignments. Stamp a matching User on ctx.

--- a/internal/entitymanager/acl_test.go
+++ b/internal/entitymanager/acl_test.go
@@ -3,12 +3,15 @@ package entitymanager_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
 
@@ -291,4 +294,329 @@ func TestManager_NopACLAllows_AllWritePathsSucceed(t *testing.T) {
 		}
 	}
 	_ = store
+}
+
+// TestManager_DeclarativeACL_LocalRoleAllowsWrite tells one
+// end-to-end story:
+//
+//	A bug-tracking workspace has tickets. Every assigned engineer
+//	can edit tickets they're assigned to — and only those. Alice is
+//	assigned to TKT-001, not to TKT-002. Editing TKT-001 succeeds;
+//	editing TKT-002 is denied. There is no global "editor" role;
+//	authorisation flows entirely from the per-ticket assignment edge.
+//
+// What this pins. Production wiring — entitymanager.Manager picks up
+// the v1 acl.Declarative configured with a store-backed Graph, and the
+// per-entity Subject reaches the resolver. Without this test, a
+// regression that drops the Subject field at the manager's call sites
+// would silently fall back to v0 semantics: alice would lose her local
+// grant without any test noticing, because v0 has no concept of
+// per-entity authorisation.
+func TestManager_DeclarativeACL_LocalRoleAllowsWrite(t *testing.T) {
+	// A bug-tracking metamodel: people, tickets, and an `assigned-to`
+	// relation from people to tickets. The metamodel doesn't know about
+	// authorisation — that lives in acl.yaml.
+	metamodelYAML := `version: "1.0"
+entities:
+  person:
+    label: Person
+    plural: people
+    id_type: manual
+    properties:
+      name: { type: string }
+  ticket:
+    label: Ticket
+    plural: tickets
+    id_prefix: "TKT-"
+    id_type: sequential
+    properties:
+      title: { type: string, required: true }
+      status: { type: status }
+relations:
+  assigned-to:
+    label: Assigned to
+    from: [person]
+    to: [ticket]
+types:
+  status:
+    values: [open, closed]
+`
+	meta, err := metamodel.Parse([]byte(metamodelYAML))
+	if err != nil {
+		t.Fatalf("parse metamodel: %v", err)
+	}
+
+	// The policy: assignment to a ticket via `assigned-to` confers the
+	// editor role, which grants write on tickets. There is no global
+	// editor assignment — alice's only path to editing tickets is
+	// through her local edges.
+	policy, err := acl.LoadPolicyBytes([]byte(`
+roles:
+  editor: { write: [ticket], read: [ticket] }
+role_relations:
+  assigned-to: { confers: editor }
+`))
+	if err != nil {
+		t.Fatalf("LoadPolicyBytes: %v", err)
+	}
+
+	// Setup: a store, a Manager wired with NopACL for the seeding phase
+	// (so we can create people and tickets without authorizing them).
+	// We rebuild the Manager with the real ACL once the data is in.
+	store := &countingStore{Store: memstore.New()}
+	seedMgr, err := entitymanager.New(entitymanager.Deps{
+		Store: store, Meta: meta, Templater: nopTemplater{},
+		Audit: audit.Nop{}, ACL: acl.NopACL{},
+	})
+	if err != nil {
+		t.Fatalf("seed Manager.New: %v", err)
+	}
+
+	// Alice is a person.
+	alice := entity.New("alice", "person")
+	alice.SetString("name", "Alice")
+	if _, sErr := seedMgr.CreateEntity(context.Background(), alice,
+		entity.CreateOptions{ID: "alice"}); sErr != nil {
+		t.Fatalf("seed alice: %v", sErr)
+	}
+
+	// Two tickets exist.
+	tkt1 := entity.New("", "ticket")
+	tkt1.SetString("title", "Login button broken")
+	tkt1Res, err := seedMgr.CreateEntity(context.Background(), tkt1, entity.CreateOptions{})
+	if err != nil {
+		t.Fatalf("seed TKT-001: %v", err)
+	}
+	tkt1ID := tkt1Res.Entity.ID
+
+	tkt2 := entity.New("", "ticket")
+	tkt2.SetString("title", "Search slow on large queries")
+	tkt2Res, err := seedMgr.CreateEntity(context.Background(), tkt2, entity.CreateOptions{})
+	if err != nil {
+		t.Fatalf("seed TKT-002: %v", err)
+	}
+	tkt2ID := tkt2Res.Entity.ID
+
+	// Alice is assigned to TKT-001 (the local role grant) but NOT to
+	// TKT-002. After this edge exists, alice should be able to edit
+	// TKT-001 and only TKT-001.
+	if _, sErr := seedMgr.CreateRelation(context.Background(),
+		"alice", "assigned-to", tkt1ID, entity.RelationOptions{}); sErr != nil {
+		t.Fatalf("seed assigned-to: %v", sErr)
+	}
+
+	// Switch to the production ACL: Declarative with a store-backed
+	// Graph. This is the exact wiring shape appbuild produces.
+	sink := audit.NewMemory()
+	declarative, err := acl.NewDeclarative(policy, acl.NewStoreGraph(store))
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store: store, Meta: meta, Templater: nopTemplater{},
+		Audit: sink, ACL: declarative,
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+
+	// Stamp alice as the principal — the entry-point binary would
+	// normally do this; the test does it explicitly.
+	aliceCtx := principal.With(context.Background(),
+		principal.Principal{User: "alice", Tool: principal.ToolDataEntry})
+
+	// Story step 1 — Alice edits the ticket she's assigned to. The v1
+	// resolver follows `alice --assigned-to--> TKT-001`, finds the
+	// `editor` role conferred locally, and allows the write.
+	updateOK := entity.New(tkt1ID, "ticket")
+	updateOK.SetString("title", "Login button broken (in progress)")
+	if _, uErr := mgr.UpdateEntity(aliceCtx, updateOK); uErr != nil {
+		t.Fatalf("Alice editing TKT-001 (her assigned ticket) was denied: %v", uErr)
+	}
+
+	// Story step 2 — Alice tries to edit a ticket she is NOT assigned
+	// to. The v1 resolver finds no role granting write on this ticket
+	// for her principal, and denies.
+	updateDeny := entity.New(tkt2ID, "ticket")
+	updateDeny.SetString("title", "should be denied")
+	_, err = mgr.UpdateEntity(aliceCtx, updateDeny)
+	if err == nil {
+		t.Fatalf("Alice editing TKT-002 (not her ticket) succeeded; want deny")
+	}
+	var forbidden *acl.ForbiddenError
+	if !errors.As(err, &forbidden) {
+		t.Fatalf("UpdateEntity(TKT-002): error type = %T, want *acl.ForbiddenError", err)
+	}
+
+	// Verify the audit trail tells the story: one deny on TKT-002, none
+	// on TKT-001 (which was allowed).
+	denies := 0
+	for _, rec := range sink.Records() {
+		if rec.Op == audit.OpDeniedWrite {
+			denies++
+		}
+	}
+	if denies != 1 {
+		t.Errorf("audit denied-write count = %d, want 1 (TKT-002)", denies)
+	}
+
+	// Verify TKT-001's title actually changed (the allow path landed).
+	got, err := store.GetEntity(context.Background(), tkt1ID)
+	if err != nil {
+		t.Fatalf("post-update GetEntity(TKT-001): %v", err)
+	}
+	if title := got.GetString("title"); title != "Login button broken (in progress)" {
+		t.Errorf("TKT-001 title = %q, want %q",
+			title, "Login button broken (in progress)")
+	}
+}
+
+// AC7: denied-write audit Summary carries the per-attribution Source
+// (e.g. `role=viewer via group:viewers`) so operators answering "which
+// roles did the resolver consider, and via which paths?" don't have to
+// re-run the resolver. The wire 403 body stays opaque — only audit
+// reads the Source chain.
+//
+// The scenario stamps Alice as a member of the `viewers` group; the
+// group holds the `viewer` role which has read on tickets but no write.
+// Alice tries to update a ticket — the resolver collects her
+// attribution (`viewer via group:viewers`) and denies because no role
+// grants write. The audit row must surface that attribution.
+func TestManager_DeniedWrite_AuditCarriesSourceAttribution(t *testing.T) {
+	const metamodelYAML = `version: "1.0"
+entities:
+  person:
+    label: Person
+    plural: people
+    id_type: manual
+    properties:
+      name: { type: string }
+  team:
+    label: Team
+    plural: teams
+    id_type: manual
+    properties:
+      name: { type: string }
+  ticket:
+    label: Ticket
+    plural: tickets
+    id_prefix: "TKT-"
+    id_type: sequential
+    properties:
+      title: { type: string, required: true }
+relations:
+  member-of:
+    label: Member of
+    from: [person]
+    to: [team]
+`
+	meta, err := metamodel.Parse([]byte(metamodelYAML))
+	if err != nil {
+		t.Fatalf("parse metamodel: %v", err)
+	}
+
+	policy, err := acl.LoadPolicyBytes([]byte(`
+roles:
+  viewer: { read: [ticket] }
+assignments:
+  viewers: viewer
+`))
+	if err != nil {
+		t.Fatalf("LoadPolicyBytes: %v", err)
+	}
+
+	store := &countingStore{Store: memstore.New()}
+	seedMgr, err := entitymanager.New(entitymanager.Deps{
+		Store: store, Meta: meta, Templater: nopTemplater{},
+		Audit: audit.Nop{}, ACL: acl.NopACL{},
+	})
+	if err != nil {
+		t.Fatalf("seed Manager.New: %v", err)
+	}
+
+	if _, sErr := seedMgr.CreateEntity(context.Background(),
+		entity.New("alice", "person"),
+		entity.CreateOptions{ID: "alice"}); sErr != nil {
+		t.Fatalf("seed alice: %v", sErr)
+	}
+	if _, sErr := seedMgr.CreateEntity(context.Background(),
+		entity.New("viewers", "team"),
+		entity.CreateOptions{ID: "viewers"}); sErr != nil {
+		t.Fatalf("seed viewers: %v", sErr)
+	}
+	if _, sErr := seedMgr.CreateRelation(context.Background(),
+		"alice", "member-of", "viewers", entity.RelationOptions{}); sErr != nil {
+		t.Fatalf("seed member-of: %v", sErr)
+	}
+	tkt := entity.New("", "ticket")
+	tkt.SetString("title", "some ticket")
+	tktRes, err := seedMgr.CreateEntity(context.Background(), tkt, entity.CreateOptions{})
+	if err != nil {
+		t.Fatalf("seed ticket: %v", err)
+	}
+	tktID := tktRes.Entity.ID
+
+	sink := audit.NewMemory()
+	declarative, err := acl.NewDeclarative(policy, acl.NewStoreGraph(store))
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store: store, Meta: meta, Templater: nopTemplater{},
+		Audit: sink, ACL: declarative,
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+
+	aliceCtx := principal.With(context.Background(),
+		principal.Principal{User: "alice", Tool: principal.ToolDataEntry})
+
+	update := entity.New(tktID, "ticket")
+	update.SetString("title", "should be denied")
+	_, err = mgr.UpdateEntity(aliceCtx, update)
+	if err == nil {
+		t.Fatal("UpdateEntity succeeded; want acl.ForbiddenError")
+	}
+	var forbidden *acl.ForbiddenError
+	if !errors.As(err, &forbidden) {
+		t.Fatalf("error type = %T, want *acl.ForbiddenError", err)
+	}
+
+	// Wire-path invariant: the 403 body (Error()) must NOT carry the
+	// attribution chain — that would leak group topology to the
+	// unauthorized caller (the AC12-equivalent rule for write denies).
+	msg := forbidden.Error()
+	for _, leak := range []string{"viewer", "viewers", "group:"} {
+		if strings.Contains(msg, leak) {
+			t.Errorf("ForbiddenError leaked attribution token %q to wire: %q", leak, msg)
+		}
+	}
+
+	// Audit-path invariant: exactly one denied-write row, Summary
+	// includes `attribution=[role=viewer via group:viewers]`.
+	var deniedRecord *audit.Record
+	for i := range sink.Records() {
+		r := sink.Records()[i]
+		if r.Op == audit.OpDeniedWrite {
+			if deniedRecord != nil {
+				t.Fatalf("found multiple denied-write rows; want exactly 1")
+			}
+			deniedRecord = &r
+		}
+	}
+	if deniedRecord == nil {
+		t.Fatal("no denied-write audit row recorded")
+	}
+	want := "attribution=[role=viewer via group:viewers]"
+	if !strings.Contains(deniedRecord.Summary, want) {
+		t.Errorf("audit Summary missing attribution chain.\n  got:  %q\n  want substring: %q",
+			deniedRecord.Summary, want)
+	}
+	// Existing rule_id / op fields still present.
+	for _, want := range []string{"rule_kind=role-grant", "rule_id=-", "attempted op=update"} {
+		if !strings.Contains(deniedRecord.Summary, want) {
+			t.Errorf("audit Summary missing %q; got: %q", want, deniedRecord.Summary)
+		}
+	}
 }

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
@@ -174,11 +175,25 @@ func (m *Manager) authorizeAndAudit(ctx context.Context, req acl.WriteRequest) e
 // Summary carries the deny rule_kind / rule_id / reason and the
 // attempted op so jq filters can ask "what did Alice try to do?".
 func (m *Manager) recordDeniedWrite(ctx context.Context, d acl.Decision, req acl.WriteRequest) {
+	// RR-79HD: surface the target ID (entity ID, or relation
+	// from-ID) so forensic queries against the audit log can answer
+	// "which specific entity did Alice try to mutate?" without
+	// re-parsing the deny summary string. ToID is omitted because
+	// RR-F9M9 removed it from RelationSubject.
 	var subject *audit.Subject
-	if req.RelationType != "" {
-		subject = &audit.Subject{Kind: "relation", RelationType: req.RelationType}
-	} else {
-		subject = &audit.Subject{Kind: "entity", Type: req.EntityType}
+	switch s := req.Subject.(type) {
+	case acl.RelationSubject:
+		subject = &audit.Subject{
+			Kind:         "relation",
+			RelationType: s.Type,
+			FromID:       s.FromID,
+		}
+	case acl.EntitySubject:
+		subject = &audit.Subject{
+			Kind: "entity",
+			Type: s.Type,
+			ID:   s.ID,
+		}
 	}
 	m.deps.Audit.Record(audit.Record{
 		Time:        time.Now().UTC(),
@@ -186,9 +201,27 @@ func (m *Manager) recordDeniedWrite(ctx context.Context, d acl.Decision, req acl
 		Subject:     subject,
 		Principal:   principal.From(ctx),
 		TriggeredBy: audit.TriggeredByFrom(ctx),
-		Summary: fmt.Sprintf("denied: %s (rule_kind=%s rule_id=%s) attempted op=%s",
-			d.Reason, d.RuleKind, d.RuleID, req.Op),
+		Summary:     formatDeniedSummary(d, req.Op),
 	})
+}
+
+// formatDeniedSummary builds the audit Summary for a denied-write row.
+// Appends `attribution=[role=X via source, ...]` when the Decision
+// carries Attributions so operators can answer "which roles did the
+// resolver consider and via which paths" without re-running the
+// resolver (AC7). The wire 403 path stays opaque — only audit reads
+// Attributions.
+func formatDeniedSummary(d acl.Decision, op acl.Op) string {
+	base := fmt.Sprintf("denied: %s (rule_kind=%s rule_id=%s) attempted op=%s",
+		d.Reason, d.RuleKind, d.RuleID, op)
+	if len(d.Attributions) == 0 {
+		return base
+	}
+	parts := make([]string, 0, len(d.Attributions))
+	for _, a := range d.Attributions {
+		parts = append(parts, fmt.Sprintf("role=%s via %s", a.Role, a.Source.String()))
+	}
+	return base + " attribution=[" + strings.Join(parts, ", ") + "]"
 }
 
 // CreateEntity creates a new entity, runs on-create automations, and
@@ -216,7 +249,8 @@ func (m *Manager) CreateEntity(
 		return nil, errors.New("entitymanager: CreateEntity: entity is nil")
 	}
 	if err := m.authorizeAndAudit(ctx, acl.WriteRequest{
-		Op: acl.OpCreate, EntityType: e.Type,
+		Op:      acl.OpCreate,
+		Subject: acl.EntitySubject{Type: e.Type, ID: opts.ID},
 	}); err != nil {
 		return nil, err
 	}
@@ -342,7 +376,8 @@ func (m *Manager) UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.U
 		return nil, errors.New("entitymanager: UpdateEntity: entity is nil")
 	}
 	if err := m.authorizeAndAudit(ctx, acl.WriteRequest{
-		Op: acl.OpUpdate, EntityType: e.Type,
+		Op:      acl.OpUpdate,
+		Subject: acl.EntitySubject{Type: e.Type, ID: e.ID},
 	}); err != nil {
 		return nil, err
 	}
@@ -430,7 +465,8 @@ func (m *Manager) DeleteEntity(ctx context.Context, id string, cascade bool) (*e
 	// real entity type; a deny on a non-existent entity would be more
 	// confusing than the ErrEntityNotFound returned above.
 	if aclErr := m.authorizeAndAudit(ctx, acl.WriteRequest{
-		Op: acl.OpDelete, EntityType: current.Type,
+		Op:      acl.OpDelete,
+		Subject: acl.EntitySubject{Type: current.Type, ID: id},
 	}); aclErr != nil {
 		return nil, aclErr
 	}
@@ -507,7 +543,8 @@ func (m *Manager) RenameEntity(
 	// entity to authorize against.
 	if current, err := m.deps.Store.GetEntity(ctx, oldID); err == nil {
 		if aclErr := m.authorizeAndAudit(ctx, acl.WriteRequest{
-			Op: acl.OpRename, EntityType: current.Type,
+			Op:      acl.OpRename,
+			Subject: acl.EntitySubject{Type: current.Type, ID: oldID},
 		}); aclErr != nil {
 			return nil, aclErr
 		}
@@ -548,7 +585,11 @@ func (m *Manager) CreateRelation(
 		return nil, fmt.Errorf("target %w: %s", ErrEntityNotFound, to)
 	}
 	if aclErr := m.authorizeAndAudit(ctx, acl.WriteRequest{
-		Op: acl.OpCreate, EntityType: fromEntity.Type, RelationType: relType,
+		Op: acl.OpCreate,
+		Subject: acl.RelationSubject{
+			Type:     relType,
+			FromType: fromEntity.Type, FromID: from,
+		},
 	}); aclErr != nil {
 		return nil, aclErr
 	}
@@ -610,7 +651,11 @@ func (m *Manager) UpdateRelation(
 		sourceType = fromEntity.Type
 	}
 	if aclErr := m.authorizeAndAudit(ctx, acl.WriteRequest{
-		Op: acl.OpUpdate, EntityType: sourceType, RelationType: relType,
+		Op: acl.OpUpdate,
+		Subject: acl.RelationSubject{
+			Type:     relType,
+			FromType: sourceType, FromID: from,
+		},
 	}); aclErr != nil {
 		return nil, aclErr
 	}
@@ -669,7 +714,11 @@ func (m *Manager) DeleteRelation(ctx context.Context, from, relType, to string) 
 		sourceType = fromEntity.Type
 	}
 	if aclErr := m.authorizeAndAudit(ctx, acl.WriteRequest{
-		Op: acl.OpDelete, EntityType: sourceType, RelationType: relType,
+		Op: acl.OpDelete,
+		Subject: acl.RelationSubject{
+			Type:     relType,
+			FromType: sourceType, FromID: from,
+		},
 	}); aclErr != nil {
 		return aclErr
 	}

--- a/internal/store/fsstore/graphquery.go
+++ b/internal/store/fsstore/graphquery.go
@@ -1,0 +1,22 @@
+package fsstore
+
+import (
+	"context"
+	"iter"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/graphquerynaive"
+)
+
+// GraphQuery delegates to the shared naive implementation. An
+// index-backed implementation that exploits fsstore's by-from /
+// by-to relation indexes (once added) is a natural follow-up.
+func (s *FSStore) GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*entity.Entity, error] {
+	return graphquerynaive.Run(ctx, s, q)
+}
+
+// GraphCount currently delegates to the shared naive implementation.
+func (s *FSStore) GraphCount(ctx context.Context, q store.GraphQuery) (matched, total int, err error) {
+	return graphquerynaive.Count(ctx, s, q)
+}

--- a/internal/store/graphquery.go
+++ b/internal/store/graphquery.go
@@ -1,0 +1,64 @@
+package store
+
+import (
+	"context"
+	"iter"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// GraphQuery describes a graph-shape question: "entities of EntityType
+// where they have a matching inbound or outbound relation." The DSL is
+// intentionally generic — no ACL or other consumer vocabulary — so
+// future consumers (ACL read filtering, analyze tools, search) can
+// compose against one stable shape.
+//
+// All three backends ship a default implementation that delegates to
+// [internal/store/graphquerynaive] (iterate-and-filter in Go). A
+// future SQL-pushdown implementation in pgstore is tracked as a
+// follow-up.
+type GraphQuery struct {
+	EntityType  string
+	HasInbound  *RelationPredicate // entity has matching relation FROM (expanded) endpoints
+	HasOutbound *RelationPredicate // entity has matching relation TO (expanded) endpoints
+}
+
+// RelationPredicate restricts which relations the surrounding
+// GraphQuery is willing to match through.
+//
+// Two transitive expansions, independent and composable:
+//
+//   - InheritThrough (endpoint-side) transitively expands Endpoints via
+//     these relation types up to Depth. Example: ACL group expansion
+//     (InheritThrough = ["member-of"]).
+//   - EntityInheritThrough (entity-side) transitively expands the
+//     candidate entity via these relation types up to EntityDepth; the
+//     match succeeds if any ancestor of the candidate (including itself)
+//     has the inbound/outbound edge. Example: ACL containment
+//     inheritance (EntityInheritThrough = ["belongs-to"]).
+type RelationPredicate struct {
+	Endpoints []string
+	OfTypes   []string
+
+	InheritThrough []string
+	Depth          int
+
+	EntityInheritThrough []string
+	EntityDepth          int
+}
+
+// GraphQueryer is the read-side interface for graph-shape queries.
+// Embedded into Store; surfaces independently so backend
+// implementations can be written and tested without the full Store.
+type GraphQueryer interface {
+	// GraphQuery returns an iterator over entities matching q. The
+	// iterator yields (*entity.Entity, nil) for each match; on error
+	// the iterator yields (nil, err) and terminates.
+	GraphQuery(ctx context.Context, q GraphQuery) iter.Seq2[*entity.Entity, error]
+
+	// GraphCount returns (matched, total): the number of entities of
+	// q.EntityType that satisfy q's predicates, and the total number of
+	// entities of q.EntityType ignoring those predicates. Callers use
+	// (total - matched) for "filtered by" counts.
+	GraphCount(ctx context.Context, q GraphQuery) (matched, total int, err error)
+}

--- a/internal/store/graphquerynaive/naive.go
+++ b/internal/store/graphquerynaive/naive.go
@@ -1,0 +1,215 @@
+// Package graphquerynaive ships the unoptimised, backend-agnostic
+// implementation of [store.GraphQueryer]. All three of memstore,
+// fsstore, and pgstore delegate to it today — keeping the algorithm
+// in one place is the structural defense against behavior diverging
+// across backends.
+//
+// Backends are expected to swap this for push-down implementations
+// where the underlying engine can do better (recursive CTE in
+// pgstore, index-backed walks in fsstore). Each swap remains
+// behavioral-compatible because it is verified against the same
+// inputs as the naive impl.
+package graphquerynaive
+
+import (
+	"context"
+	"iter"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// Reader is the narrow read surface graphquerynaive needs. Declared
+// here so backend implementations can pass `s` directly without
+// constructing an adapter.
+type Reader interface {
+	ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error]
+	ListRelations(ctx context.Context, q store.RelationQuery) iter.Seq2[*entity.Relation, error]
+}
+
+// DepthCap bounds every transitive walk performed by the naive
+// implementation, as a safety backstop. The primary termination
+// mechanism is the visited-set inside [expandSet]; the cap defends
+// against pathological inputs (huge fan-out, deep chains) where
+// even bounded BFS would be too expensive.
+//
+// Exported so a caller that supplies a [GraphQuery.HasInbound.Depth]
+// (or EntityDepth) can pin its own cap to the same value when it
+// wants symmetric behavior. Backends that implement [GraphQuery]
+// via natural-termination primitives (recursive-CTE UNION, etc.)
+// are free to ignore this cap unless they'd expand past it.
+const DepthCap = 5
+
+// depthCap is the unexported alias for in-package use.
+const depthCap = DepthCap
+
+// Run executes q against r and yields matching entities. Errors abort
+// the iterator.
+func Run(ctx context.Context, r Reader, q store.GraphQuery) iter.Seq2[*entity.Entity, error] {
+	return func(yield func(*entity.Entity, error) bool) {
+		candidates, err := collectByType(ctx, r, q.EntityType)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		for _, e := range candidates {
+			ok, err := matches(ctx, r, e, q)
+			if err != nil {
+				if !yield(nil, err) {
+					return
+				}
+				continue
+			}
+			if ok {
+				if !yield(e, nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Count returns (matched, total) for q against r.
+func Count(ctx context.Context, r Reader, q store.GraphQuery) (matched, total int, err error) {
+	candidates, err := collectByType(ctx, r, q.EntityType)
+	if err != nil {
+		return 0, 0, err
+	}
+	total = len(candidates)
+	for _, e := range candidates {
+		ok, mErr := matches(ctx, r, e, q)
+		if mErr != nil {
+			return matched, total, mErr
+		}
+		if ok {
+			matched++
+		}
+	}
+	return matched, total, nil
+}
+
+func collectByType(ctx context.Context, r Reader, typ string) ([]*entity.Entity, error) {
+	var out []*entity.Entity
+	for e, err := range r.ListEntities(ctx, store.EntityQuery{Type: typ}) {
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+func matches(ctx context.Context, r Reader, e *entity.Entity, q store.GraphQuery) (bool, error) {
+	if q.HasInbound != nil {
+		ok, err := matchesPredicate(ctx, r, e, *q.HasInbound, store.DirectionIncoming)
+		if err != nil || !ok {
+			return ok, err
+		}
+	}
+	if q.HasOutbound != nil {
+		ok, err := matchesPredicate(ctx, r, e, *q.HasOutbound, store.DirectionOutgoing)
+		if err != nil || !ok {
+			return ok, err
+		}
+	}
+	return true, nil
+}
+
+func matchesPredicate(
+	ctx context.Context, r Reader, e *entity.Entity,
+	p store.RelationPredicate, dir store.Direction,
+) (bool, error) {
+	endpoints, err := expandSet(ctx, r, p.Endpoints, p.InheritThrough, p.Depth)
+	if err != nil {
+		return false, err
+	}
+	candidates, err := expandSet(ctx, r, []string{e.ID}, p.EntityInheritThrough, p.EntityDepth)
+	if err != nil {
+		return false, err
+	}
+
+	endpointSet := make(map[string]bool, len(endpoints))
+	for _, ep := range endpoints {
+		endpointSet[ep] = true
+	}
+	typeSet := make(map[string]bool, len(p.OfTypes))
+	for _, t := range p.OfTypes {
+		typeSet[t] = true
+	}
+
+	for _, c := range candidates {
+		for rel, err := range r.ListRelations(ctx, store.RelationQuery{
+			EntityID:  c,
+			Direction: dir,
+		}) {
+			if err != nil {
+				return false, err
+			}
+			if len(typeSet) > 0 && !typeSet[rel.Type] {
+				continue
+			}
+			var other string
+			if dir == store.DirectionIncoming {
+				other = rel.From
+			} else {
+				other = rel.To
+			}
+			if endpointSet[other] {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// expandSet returns seeds plus everything reachable via the given
+// relation types up to depth. BFS with visited-set; depth is bounded
+// by depthCap.
+func expandSet(ctx context.Context, r Reader, seeds, through []string, depth int) ([]string, error) {
+	if len(seeds) == 0 {
+		return nil, nil
+	}
+	if depth > depthCap {
+		depth = depthCap
+	}
+	visited := make(map[string]bool, len(seeds))
+	order := make([]string, 0, len(seeds))
+	for _, s := range seeds {
+		if !visited[s] {
+			visited[s] = true
+			order = append(order, s)
+		}
+	}
+	if len(through) == 0 || depth <= 0 {
+		return order, nil
+	}
+	throughSet := make(map[string]bool, len(through))
+	for _, t := range through {
+		throughSet[t] = true
+	}
+	frontier := append([]string(nil), order...)
+	for d := 0; d < depth && len(frontier) > 0; d++ {
+		var next []string
+		for _, n := range frontier {
+			for rel, err := range r.ListRelations(ctx, store.RelationQuery{
+				EntityID:  n,
+				Direction: store.DirectionOutgoing,
+			}) {
+				if err != nil {
+					return order, err
+				}
+				if !throughSet[rel.Type] {
+					continue
+				}
+				if visited[rel.To] {
+					continue
+				}
+				visited[rel.To] = true
+				order = append(order, rel.To)
+				next = append(next, rel.To)
+			}
+		}
+		frontier = next
+	}
+	return order, nil
+}

--- a/internal/store/memstore/graphquery.go
+++ b/internal/store/memstore/graphquery.go
@@ -1,0 +1,21 @@
+package memstore
+
+import (
+	"context"
+	"iter"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/graphquerynaive"
+)
+
+// GraphQuery delegates to the shared naive implementation; memstore
+// has no index advantage over the generic algorithm.
+func (m *MemStore) GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*entity.Entity, error] {
+	return graphquerynaive.Run(ctx, m, q)
+}
+
+// GraphCount delegates to the shared naive implementation.
+func (m *MemStore) GraphCount(ctx context.Context, q store.GraphQuery) (matched, total int, err error) {
+	return graphquerynaive.Count(ctx, m, q)
+}

--- a/internal/store/pgstore/export_test.go
+++ b/internal/store/pgstore/export_test.go
@@ -46,3 +46,11 @@ func NotificationEmitsForTest(t *testing.T, selfOrigin, payload string) bool {
 		return false
 	}
 }
+
+// BuildGraphQuerySQLForTest exposes the internal SQL builder so
+// explain-plan tests can render the SQL without going through a pgx
+// round-trip. Keeps the production surface narrow while letting
+// tests pin query shape and verify index usage. Test-only.
+func BuildGraphQuerySQLForTest(q store.GraphQuery, countOnly bool) (sqlText string, args []any) {
+	return buildGraphQuerySQL(q, countOnly)
+}

--- a/internal/store/pgstore/graphquery.go
+++ b/internal/store/pgstore/graphquery.go
@@ -1,0 +1,24 @@
+package pgstore
+
+import (
+	"context"
+	"iter"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/graphquerynaive"
+)
+
+// GraphQuery delegates to the shared naive implementation. A
+// SQL-pushdown variant (one CTE for endpoint expansion + one for
+// entity-side inherit-through + WHERE EXISTS for the inbound match)
+// is the natural follow-up; until then pgstore uses the same iterate-
+// and-filter approach as fsstore and memstore.
+func (s *Store) GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*entity.Entity, error] {
+	return graphquerynaive.Run(ctx, s, q)
+}
+
+// GraphCount delegates to the shared naive implementation.
+func (s *Store) GraphCount(ctx context.Context, q store.GraphQuery) (matched, total int, err error) {
+	return graphquerynaive.Count(ctx, s, q)
+}

--- a/internal/store/pgstore/graphquery.go
+++ b/internal/store/pgstore/graphquery.go
@@ -72,6 +72,23 @@ func (s *Store) GraphCount(ctx context.Context, q store.GraphQuery) (matched, to
 // appears only when it can contribute. This keeps query plans honest:
 // PostgreSQL's planner won't optimize away a CTE that's "always
 // trivial", so collapsing them in Go saves real work.
+//
+// **SQL injection safety.** Every caller-supplied value
+// (q.EntityType, RelationPredicate.Endpoints / OfTypes /
+// InheritThrough / EntityInheritThrough, Depth, EntityDepth) flows
+// through [sqlBuilder.arg], which returns a positional placeholder
+// (`$N`) and appends the value to args. The Sprintf calls in this
+// file substitute only:
+//
+//   - those placeholder strings (already `$N`-formatted by arg)
+//   - compile-time string literals (CTE names like
+//     `in_endpoint_closure`, column names like `r.from_id`)
+//   - the `prefix` argument to buildPredicateSQL, which is one of
+//     the in-package constants `"in"` / `"out"`
+//
+// User data never reaches the SQL text. The same property holds
+// when [BuildGraphQuerySQLForTest] is invoked from tests — the
+// builder treats all input the same way.
 func buildGraphQuerySQL(q store.GraphQuery, countOnly bool) (sqlText string, args []any) {
 	b := &sqlBuilder{}
 	// $1 is always q.EntityType.
@@ -91,25 +108,30 @@ func buildGraphQuerySQL(q store.GraphQuery, countOnly bool) (sqlText string, arg
 		existsParts = append(existsParts, ex)
 	}
 
+	// Branch the SELECT list + ORDER BY: count queries skip column
+	// fetching and ordering; row queries return the standard entity
+	// columns and stable id-ascending order. The rest of the query
+	// (WITH, FROM, WHERE, EXISTS chain) is identical.
+	selectList := "e.id, e.type, e.properties, e.content, e.updated_at"
+	orderBy := " ORDER BY e.id"
+	if countOnly {
+		selectList = "count(*)"
+		orderBy = ""
+	}
+
 	var sb strings.Builder
 	if len(withParts) > 0 {
 		sb.WriteString("WITH RECURSIVE ")
 		sb.WriteString(strings.Join(withParts, ",\n"))
 		sb.WriteByte('\n')
 	}
-	if countOnly {
-		sb.WriteString("SELECT count(*) FROM entities e WHERE e.type = " + typeArg)
-	} else {
-		sb.WriteString("SELECT e.id, e.type, e.properties, e.content, e.updated_at FROM entities e WHERE e.type = " + typeArg)
-	}
+	sb.WriteString("SELECT " + selectList + " FROM entities e WHERE e.type = " + typeArg)
 	for _, ex := range existsParts {
 		sb.WriteString(" AND EXISTS (")
 		sb.WriteString(ex)
 		sb.WriteByte(')')
 	}
-	if !countOnly {
-		sb.WriteString(" ORDER BY e.id")
-	}
+	sb.WriteString(orderBy)
 
 	return sb.String(), b.args
 }

--- a/internal/store/pgstore/graphquery.go
+++ b/internal/store/pgstore/graphquery.go
@@ -2,23 +2,218 @@ package pgstore
 
 import (
 	"context"
+	"fmt"
 	"iter"
+	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/graphquerynaive"
 )
 
-// GraphQuery delegates to the shared naive implementation. A
-// SQL-pushdown variant (one CTE for endpoint expansion + one for
-// entity-side inherit-through + WHERE EXISTS for the inbound match)
-// is the natural follow-up; until then pgstore uses the same iterate-
-// and-filter approach as fsstore and memstore.
+// GraphQuery is the SQL-native implementation of [store.GraphQueryer].
+// Builds a single query (one recursive CTE per active transitive
+// expansion + WHERE EXISTS for the predicate match) and streams rows.
+//
+// When no predicate is configured the query collapses to a plain
+// SELECT by type; when only one of HasInbound / HasOutbound is set,
+// only that EXISTS clause is emitted. Both nil → degenerate
+// "everything of this type" answer (covered by the conformance suite).
 func (s *Store) GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*entity.Entity, error] {
-	return graphquerynaive.Run(ctx, s, q)
+	sqlText, args := buildGraphQuerySQL(q, false)
+	return func(yield func(*entity.Entity, error) bool) {
+		rows, err := s.db.Query(ctx, sqlText, args...)
+		if err != nil {
+			yield(nil, fmt.Errorf("pgstore: graph query: %w", err))
+			return
+		}
+		defer rows.Close()
+		for rows.Next() {
+			e, scanErr := scanEntity(rows)
+			if scanErr != nil {
+				if !yield(nil, scanErr) {
+					return
+				}
+				continue
+			}
+			if !yield(e, nil) {
+				return
+			}
+		}
+		if err := rows.Err(); err != nil {
+			yield(nil, err)
+		}
+	}
 }
 
-// GraphCount delegates to the shared naive implementation.
+// GraphCount runs the predicate query as `SELECT count(*)` and a
+// separate unconditional count of entities of the type. Two
+// round-trips beats one COUNT FILTER because both rely on the same
+// recursive CTE shape — duplicating the WITH RECURSIVE inside a
+// single FILTER expression saves nothing.
 func (s *Store) GraphCount(ctx context.Context, q store.GraphQuery) (matched, total int, err error) {
-	return graphquerynaive.Count(ctx, s, q)
+	matchedSQL, matchedArgs := buildGraphQuerySQL(q, true)
+	if err = s.db.QueryRow(ctx, matchedSQL, matchedArgs...).Scan(&matched); err != nil {
+		return 0, 0, fmt.Errorf("pgstore: graph count (matched): %w", err)
+	}
+	if err = s.db.QueryRow(ctx, `SELECT count(*) FROM entities WHERE type = $1`, q.EntityType).Scan(&total); err != nil {
+		return 0, 0, fmt.Errorf("pgstore: graph count (total): %w", err)
+	}
+	return matched, total, nil
+}
+
+// buildGraphQuerySQL emits the SQL + args list for a GraphQuery. When
+// countOnly is true the outer SELECT becomes `SELECT count(*)`
+// instead of streaming entity columns. The function is exported via
+// package-private tests so the CTE shape can be pinned without
+// running against a live database.
+//
+// The query is built up in pieces so each optional predicate / CTE
+// appears only when it can contribute. This keeps query plans honest:
+// PostgreSQL's planner won't optimize away a CTE that's "always
+// trivial", so collapsing them in Go saves real work.
+func buildGraphQuerySQL(q store.GraphQuery, countOnly bool) (sqlText string, args []any) {
+	b := &sqlBuilder{}
+	// $1 is always q.EntityType.
+	typeArg := b.arg(q.EntityType)
+
+	var withParts []string
+	var existsParts []string
+
+	if q.HasInbound != nil {
+		w, ex := buildPredicateSQL(b, "in", *q.HasInbound, typeArg, store.DirectionIncoming)
+		withParts = append(withParts, w...)
+		existsParts = append(existsParts, ex)
+	}
+	if q.HasOutbound != nil {
+		w, ex := buildPredicateSQL(b, "out", *q.HasOutbound, typeArg, store.DirectionOutgoing)
+		withParts = append(withParts, w...)
+		existsParts = append(existsParts, ex)
+	}
+
+	var sb strings.Builder
+	if len(withParts) > 0 {
+		sb.WriteString("WITH RECURSIVE ")
+		sb.WriteString(strings.Join(withParts, ",\n"))
+		sb.WriteByte('\n')
+	}
+	if countOnly {
+		sb.WriteString("SELECT count(*) FROM entities e WHERE e.type = " + typeArg)
+	} else {
+		sb.WriteString("SELECT e.id, e.type, e.properties, e.content, e.updated_at FROM entities e WHERE e.type = " + typeArg)
+	}
+	for _, ex := range existsParts {
+		sb.WriteString(" AND EXISTS (")
+		sb.WriteString(ex)
+		sb.WriteByte(')')
+	}
+	if !countOnly {
+		sb.WriteString(" ORDER BY e.id")
+	}
+
+	return sb.String(), b.args
+}
+
+// buildPredicateSQL emits (CTE definitions, EXISTS clause) for one
+// HasInbound / HasOutbound predicate. The CTE name uses prefix so
+// in/out predicates don't collide when both are set.
+//
+// The endpoint and entity expansions are independent: each emits its
+// own CTE only when [Predicate.InheritThrough] / EntityInheritThrough
+// is non-empty AND the corresponding Depth is > 0. When omitted, the
+// EXISTS query references the seed directly.
+func buildPredicateSQL(
+	b *sqlBuilder, prefix string,
+	p store.RelationPredicate, typeArg string, dir store.Direction,
+) (with []string, exists string) {
+	endpointsArg := b.arg(p.Endpoints)
+
+	// endpointSrc: SQL expression yielding the set of endpoint IDs
+	// the EXISTS clause matches against. Without InheritThrough this
+	// is just the unnested input; with it, a recursive CTE.
+	endpointSrc := fmt.Sprintf(`SELECT unnest(%s::text[]) COLLATE "C"`, endpointsArg)
+	if len(p.InheritThrough) > 0 && p.Depth > 0 {
+		throughArg := b.arg(p.InheritThrough)
+		depthArg := b.arg(cappedDepth(p.Depth))
+		cteName := prefix + "_endpoint_closure"
+		with = append(with, fmt.Sprintf(`%s(id, depth) AS (
+    SELECT unnest(%s::text[]) COLLATE "C", 0
+    UNION
+    SELECT r.to_id, c.depth + 1
+    FROM relations r
+    JOIN %s c ON r.from_id = c.id
+    WHERE r.rel_type = ANY(%s)
+      AND c.depth < %s
+)`, cteName, endpointsArg, cteName, throughArg, depthArg))
+		endpointSrc = "SELECT id FROM " + cteName
+	}
+
+	// entitySrc: SQL expression yielding (id, root) pairs for the
+	// candidate-entity expansion. Without EntityInheritThrough each
+	// entity maps to itself; with it, a recursive CTE that walks
+	// ancestors and remembers the original root entity ID.
+	entityJoin := "e.id"
+	if len(p.EntityInheritThrough) > 0 && p.EntityDepth > 0 {
+		entityThroughArg := b.arg(p.EntityInheritThrough)
+		entityDepthArg := b.arg(cappedDepth(p.EntityDepth))
+		cteName := prefix + "_entity_closure"
+		with = append(with, fmt.Sprintf(`%s(id, root, depth) AS (
+    SELECT e0.id, e0.id, 0 FROM entities e0 WHERE e0.type = %s
+    UNION
+    SELECT r.to_id, c.root, c.depth + 1
+    FROM relations r
+    JOIN %s c ON r.from_id = c.id
+    WHERE r.rel_type = ANY(%s)
+      AND c.depth < %s
+)`, cteName, typeArg, cteName, entityThroughArg, entityDepthArg))
+		entityJoin = fmt.Sprintf("(SELECT id FROM %s WHERE root = e.id)", cteName)
+	}
+
+	// Direction picks which side of the relation matches the endpoint.
+	endpointCol, entityCol := "r.from_id", "r.to_id"
+	if dir == store.DirectionOutgoing {
+		endpointCol, entityCol = "r.to_id", "r.from_id"
+	}
+
+	// Build the EXISTS body. OfTypes is optional: when omitted, all
+	// relation types match (consistent with naive impl's behavior).
+	var existsSB strings.Builder
+	existsSB.WriteString("SELECT 1 FROM relations r WHERE ")
+	if len(p.OfTypes) > 0 {
+		typesArg := b.arg(p.OfTypes)
+		fmt.Fprintf(&existsSB, "r.rel_type = ANY(%s) AND ", typesArg)
+	}
+	fmt.Fprintf(&existsSB, "%s IN (%s) AND %s IN (%s)",
+		endpointCol, endpointSrc, entityCol, entityJoin)
+
+	return with, existsSB.String()
+}
+
+// cappedDepth bounds depth at the naive impl's cap so the SQL and
+// the Go impl agree on the recursion ceiling. Negative inputs are
+// treated as 0 (no expansion); the conformance suite's Depth=0
+// no-op case pins this.
+func cappedDepth(d int) int {
+	if d < 0 {
+		return 0
+	}
+	if d > graphquerynaive.DepthCap {
+		return graphquerynaive.DepthCap
+	}
+	return d
+}
+
+// sqlBuilder accumulates positional placeholders and their values.
+// Each call to arg appends to args and returns the matching $N.
+// Building queries this way (instead of fmt-substituting values into
+// the string) keeps every value parameterised — never interpolated
+// into SQL text, never a SQL-injection surface even when callers
+// pass arbitrary strings.
+type sqlBuilder struct {
+	args []any
+}
+
+func (b *sqlBuilder) arg(v any) string {
+	b.args = append(b.args, v)
+	return fmt.Sprintf("$%d", len(b.args))
 }

--- a/internal/store/pgstore/graphquery_bench_test.go
+++ b/internal/store/pgstore/graphquery_bench_test.go
@@ -1,0 +1,93 @@
+package pgstore_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+)
+
+// BenchmarkGraphQuery measures the SQL-native impl's wallclock at
+// 1k and 10k tickets with a group-shaped predicate (typical ACL
+// read-filter shape):
+//
+//   - alice → member-of → engineering
+//   - engineering → owns → every Nth ticket
+//
+// With composite indexes the recursive CTE collapses to a single
+// round-trip; without them PostgreSQL falls back to seq scans on
+// `relations` for the rel_type filter at each CTE iteration. The
+// pre-pushdown naive impl (now removed from pgstore) was 1 + N
+// round-trips per request.
+//
+// Run with: just bench-postgres, or:
+//
+//	RELA_TEST_DATABASE_URL=... go test -tags postgres -bench=. \
+//	  -run=^$ ./internal/store/pgstore/...
+func BenchmarkGraphQuery(b *testing.B) {
+	for _, n := range []int{1_000, 10_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			s := benchSetup(b, n)
+			q := store.GraphQuery{
+				EntityType: "ticket",
+				HasInbound: &store.RelationPredicate{
+					Endpoints:      []string{"alice"},
+					OfTypes:        []string{"owns"},
+					InheritThrough: []string{"member-of"},
+					Depth:          5,
+				},
+			}
+			b.ResetTimer()
+			for range b.N {
+				count := 0
+				for _, err := range s.GraphQuery(context.Background(), q) {
+					if err != nil {
+						b.Fatal(err)
+					}
+					count++
+				}
+				if count == 0 {
+					b.Fatal("query returned zero entities; setup is broken")
+				}
+			}
+		})
+	}
+}
+
+// benchSetup seeds n tickets, one team, one principal, and a
+// member-of + owns chain. Every 10th ticket is owned by the team,
+// so the predicate matches ~n/10 entities.
+func benchSetup(b *testing.B, n int) store.Store {
+	b.Helper()
+	pool := newScopedPool(b)
+	s, err := pgstore.New(pool)
+	if err != nil {
+		b.Fatalf("New: %v", err)
+	}
+	ctx := context.Background()
+	mustCreate := func(e *entity.Entity) {
+		if err := s.CreateEntity(ctx, e); err != nil {
+			b.Fatalf("create %s: %v", e.ID, err)
+		}
+	}
+	mustRel := func(from, relType, to string) {
+		if _, err := s.CreateRelation(ctx, from, relType, to, nil); err != nil {
+			b.Fatalf("relation %s --%s--> %s: %v", from, relType, to, err)
+		}
+	}
+
+	mustCreate(entity.New("alice", "person"))
+	mustCreate(entity.New("engineering", "team"))
+	mustRel("alice", "member-of", "engineering")
+	for i := range n {
+		id := fmt.Sprintf("TKT-%06d", i)
+		mustCreate(entity.New(id, "ticket"))
+		if i%10 == 0 {
+			mustRel("engineering", "owns", id)
+		}
+	}
+	return s
+}

--- a/internal/store/pgstore/graphquery_explain_test.go
+++ b/internal/store/pgstore/graphquery_explain_test.go
@@ -1,0 +1,102 @@
+//go:build postgres
+
+package pgstore_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+)
+
+// TestGraphQueryExplainUsesIndex pins the CTE planning shape: the
+// recursive-CTE iteration MUST use the composite (rel_type, from_id)
+// index introduced in migration 0002. The CTE iterates once per
+// expansion step; without the composite, each step falls back to a
+// seq scan over `relations`, which is the quadratic foot-cannon the
+// migration exists to prevent.
+//
+// The assertion is index-positive (the index name appears in the
+// plan) rather than seq-scan-negative — the planner is allowed to
+// pick seq scans for the outer SELECT at small scale when its
+// selectivity estimates favour them. Only the per-iteration CTE
+// recursion needs to be index-backed; that's where blast radius is
+// non-linear in graph size.
+//
+// Run with:
+//
+//	RELA_TEST_DATABASE_URL=... go test -tags postgres \
+//	  -run=TestGraphQueryExplainUsesIndex -v ./internal/store/pgstore/...
+func TestGraphQueryExplainUsesIndex(t *testing.T) {
+	const n = 5000
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// Seed a typical ACL-shaped graph: 1 principal in 1 group with N
+	// candidate entities, ~10% owned by the group.
+	require.NoError(t, s.CreateEntity(ctx, entity.New("alice", "person")))
+	require.NoError(t, s.CreateEntity(ctx, entity.New("engineering", "team")))
+	_, err = s.CreateRelation(ctx, "alice", "member-of", "engineering", nil)
+	require.NoError(t, err)
+	for i := range n {
+		id := fmt.Sprintf("TKT-%06d", i)
+		require.NoError(t, s.CreateEntity(ctx, entity.New(id, "ticket")))
+		if i%10 == 0 {
+			_, err := s.CreateRelation(ctx, "engineering", "owns", id, nil)
+			require.NoError(t, err)
+		}
+	}
+
+	// ANALYZE so the planner has stats — without it, low-cardinality
+	// heuristics can mask a missing index.
+	_, err = pool.Exec(ctx, "ANALYZE entities; ANALYZE relations")
+	require.NoError(t, err)
+
+	q := store.GraphQuery{
+		EntityType: "ticket",
+		HasInbound: &store.RelationPredicate{
+			Endpoints:      []string{"alice"},
+			OfTypes:        []string{"owns"},
+			InheritThrough: []string{"member-of"},
+			Depth:          5,
+		},
+	}
+
+	plan := explainGraphQuery(t, pool, q)
+	t.Logf("plan:\n%s", plan)
+
+	// The recursive CTE must use the composite index for the
+	// per-iteration rel_type lookup.
+	if !strings.Contains(plan, "Index Scan using relations_type_from_idx") &&
+		!strings.Contains(plan, "Bitmap Index Scan on relations_type_from_idx") {
+		t.Errorf("composite index relations_type_from_idx is not used in the plan; the CTE will degrade per-iteration:\n%s", plan)
+	}
+}
+
+// explainGraphQuery runs EXPLAIN (no ANALYZE — we only need the plan
+// shape) against the SQL pgstore would build for q, and returns the
+// formatted plan as a single string.
+func explainGraphQuery(t *testing.T, pool *pgxpool.Pool, q store.GraphQuery) string {
+	t.Helper()
+	sqlText, args := pgstore.BuildGraphQuerySQLForTest(q, false)
+	rows, err := pool.Query(context.Background(), "EXPLAIN "+sqlText, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+	var lines []string
+	for rows.Next() {
+		var line string
+		require.NoError(t, rows.Scan(&line))
+		lines = append(lines, line)
+	}
+	require.NoError(t, rows.Err())
+	return strings.Join(lines, "\n")
+}

--- a/internal/store/pgstore/listener_test.go
+++ b/internal/store/pgstore/listener_test.go
@@ -93,6 +93,14 @@ func waitForEntityEvent(t *testing.T, ch <-chan store.Event, id string, timeout 
 
 // TestCrossProcessPropagation (AC1): a write committed by writer A is delivered
 // to writer B's Subscribe channel, via the LISTEN/NOTIFY feed.
+//
+// The op assertion accepts either EventEntityCreated (live NOTIFY path) or
+// EventEntityUpdated (initial-catch-up path). When b's listener is mid-startup
+// (LISTEN issued, first catchUp running) at the moment a.CreateEntity commits,
+// the catchUp scan sees FEAT-1 and emits Updated before the live NOTIFY can
+// deliver Created. Both paths satisfy the contract — consumers re-snapshot on
+// any event — and this test cares about propagation, not which path delivered
+// it. See catchUpEvent for the "Updated for re-snapshot" semantics rationale.
 func TestCrossProcessPropagation(t *testing.T) {
 	schema := freshFeedSchema(t)
 	a := openWriter(t, schema)
@@ -105,7 +113,10 @@ func TestCrossProcessPropagation(t *testing.T) {
 	require.NoError(t, a.CreateEntity(ctx, entity.New("FEAT-1", "feature")))
 
 	ev := waitForEntityEvent(t, ch, "FEAT-1", 5*time.Second)
-	require.Equal(t, store.EventEntityCreated, ev.Op)
+	require.Contains(t,
+		[]store.EventOp{store.EventEntityCreated, store.EventEntityUpdated},
+		ev.Op,
+		"expected Created (live NOTIFY) or Updated (initial catch-up); both satisfy the propagation contract")
 	require.Equal(t, "FEAT-1", ev.EntityID)
 }
 

--- a/internal/store/pgstore/migrations/0002_relations_composite_idx.sql
+++ b/internal/store/pgstore/migrations/0002_relations_composite_idx.sql
@@ -1,0 +1,19 @@
+-- pgstore schema, version 2.
+--
+-- Composite indexes on `relations` keyed by (rel_type, from_id) and
+-- (rel_type, to_id). The GraphQuery DSL's recursive CTE filters by
+-- rel_type at every step (`WHERE r.rel_type = ANY($2)`), so without
+-- these composites the planner uses the single-column from_id / to_id
+-- indexes from migration 0001 and re-checks rel_type per row — fine
+-- for small relation tables but degrades fast under realistic load
+-- with mixed relation types.
+--
+-- IF NOT EXISTS so the migration is idempotent: re-applying on a
+-- database that already has the indexes (e.g. test schemas that
+-- migrated through this version once) is a no-op.
+
+CREATE INDEX IF NOT EXISTS relations_type_from_idx
+    ON relations (rel_type, from_id);
+
+CREATE INDEX IF NOT EXISTS relations_type_to_idx
+    ON relations (rel_type, to_id);

--- a/internal/store/pgstore/open.go
+++ b/internal/store/pgstore/open.go
@@ -22,9 +22,18 @@ import (
 // watcher). Keeping pool construction in one place means each composition root
 // calls Open once instead of duplicating build-pool/migrate/wire/close logic.
 func Open(ctx context.Context, dsn string) (store.Store, search.Searcher, io.Closer, error) {
-	pool, err := pgxpool.New(ctx, dsn)
+	cfg, err := pgxpool.ParseConfig(dsn)
 	if err != nil {
-		// pgxpool.New parses (not connects); pgx redacts the password in errors.
+		// ParseConfig parses (not connects); pgx redacts the password in errors.
+		return nil, nil, nil, fmt.Errorf("parse database DSN: %w", err)
+	}
+	// Attach the query tracer only when slog Debug is enabled. Avoids
+	// the per-query context-value alloc in production where Debug is off.
+	if debugEnabled(ctx) {
+		cfg.ConnConfig.Tracer = debugQueryTracer{}
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
 		return nil, nil, nil, fmt.Errorf("connect to database: %w", err)
 	}
 	if err = Migrate(ctx, pool); err != nil {

--- a/internal/store/pgstore/status_test.go
+++ b/internal/store/pgstore/status_test.go
@@ -32,7 +32,7 @@ func TestStatusFreshSchema(t *testing.T) {
 	current, target, err := pgstore.Status(ctx, pool)
 	require.NoError(t, err)
 	require.Equal(t, 0, current, "un-migrated schema is version 0")
-	require.Equal(t, 1, target, "binary embeds migration 0001")
+	require.Equal(t, 2, target, "binary embeds migrations through 0002")
 }
 
 // TestStatusAfterMigrate verifies Status reports current==target once Migrate

--- a/internal/store/pgstore/tracer.go
+++ b/internal/store/pgstore/tracer.go
@@ -1,0 +1,79 @@
+package pgstore
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// debugQueryTracer is a [pgx.QueryTracer] that logs every SQL query
+// at slog.Debug level with the SQL text, arguments, and execution
+// duration. It is attached when slog's default handler is enabled at
+// Debug level; at higher levels it is omitted, so production
+// deployments pay no per-query overhead.
+//
+// Logging at Debug rather than Info is deliberate: query traffic is
+// chatty (one log line per query, every query, for the lifetime of
+// the process). Operators flip slog to Debug only when they need it
+// — typically to diagnose a misbehaving query plan or unexpected
+// query count from a higher layer.
+type debugQueryTracer struct{}
+
+type tracerCtxKey struct{}
+
+type tracerCtxVal struct {
+	start time.Time
+	sql   string
+	args  []any
+}
+
+// TraceQueryStart records the query parameters on the context for
+// TraceQueryEnd to read. The data is intentionally NOT logged here
+// — slog the whole event once with timing, not twice.
+func (debugQueryTracer) TraceQueryStart(
+	ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData,
+) context.Context {
+	return context.WithValue(ctx, tracerCtxKey{}, &tracerCtxVal{
+		start: time.Now(),
+		sql:   data.SQL,
+		args:  data.Args,
+	})
+}
+
+// TraceQueryEnd emits one slog.Debug record per query. The
+// `duration_us` field is a microseconds integer (jq-friendly,
+// avoids the floating-point printing variance of time.Duration's
+// String).
+func (debugQueryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryEndData) {
+	v, ok := ctx.Value(tracerCtxKey{}).(*tracerCtxVal)
+	if !ok {
+		return
+	}
+	attrs := []any{
+		"sql", v.sql,
+		"args", v.args,
+		"duration_us", time.Since(v.start).Microseconds(),
+	}
+	if data.Err != nil {
+		attrs = append(attrs, "error", data.Err.Error())
+	} else {
+		// CommandTag is "<verb> <rows>" or just a verb — surface the
+		// row-count when present so operators can see how big a
+		// query was without re-running EXPLAIN.
+		if rows := data.CommandTag.RowsAffected(); rows >= 0 {
+			attrs = append(attrs, "rows", rows)
+		}
+	}
+	slog.Debug("pgstore: query", attrs...)
+}
+
+// debugEnabled reports whether slog's default logger will emit Debug
+// records for ctx. Used by Open to decide whether to attach the
+// tracer at all — the tracer's overhead is the context value alloc
+// per query, trivial in isolation but multiplied by every query in
+// the system.
+func debugEnabled(ctx context.Context) bool {
+	return slog.Default().Enabled(ctx, slog.LevelDebug)
+}

--- a/internal/store/pgstore/tracer_pool_test.go
+++ b/internal/store/pgstore/tracer_pool_test.go
@@ -1,0 +1,38 @@
+//go:build postgres
+
+package pgstore_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+)
+
+// TestDebugQueryTracer_FromPoolEmits proves the env-driven path:
+// when slog Debug is enabled BEFORE pgstore.Open, the pool gets the
+// tracer attached and queries emit log records. Without this, the
+// debugEnabled() check could be wired wrong and we'd ship a tracer
+// that nobody ever sees.
+func TestDebugQueryTracer_FromPoolEmits(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	prev := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	st, _, closer, err := pgstore.Open(context.Background(), testDSN(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = closer.Close() })
+
+	// Drive one query through the store. The exact query doesn't
+	// matter; we only need a pgx round-trip so the tracer fires.
+	_, _ = st.GetEntity(context.Background(), "nonexistent")
+
+	require.Contains(t, buf.String(), "pgstore: query",
+		"Open with Debug enabled should attach the tracer and queries should emit")
+}

--- a/internal/store/pgstore/tracer_test.go
+++ b/internal/store/pgstore/tracer_test.go
@@ -1,0 +1,69 @@
+//go:build postgres
+
+package pgstore
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDebugQueryTracer_LogsAtDebugLevel exercises the tracer
+// directly (without a real pgx connection) to confirm:
+//
+//   - At slog.Debug it emits one record per (Start, End) pair.
+//   - At slog.Info it emits nothing — the per-query overhead is
+//     limited to the (cheap) context value alloc.
+//   - The emitted record carries the SQL text and a non-negative
+//     duration_us.
+//
+// The full integration (pool → query → tracer) is covered by
+// TestDebugQueryTracer_FromPoolEmits in tracer_pool_test.go.
+func TestDebugQueryTracer_LogsAtDebugLevel(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		level    slog.Level
+		wantLogs bool
+	}{
+		{"debug emits", slog.LevelDebug, true},
+		{"info silences", slog.LevelInfo, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: tc.level})
+			t.Cleanup(swapDefaultLogger(slog.New(h)))
+
+			tr := debugQueryTracer{}
+			ctx := tr.TraceQueryStart(context.Background(), nil, pgx.TraceQueryStartData{
+				SQL:  "SELECT 1",
+				Args: []any{42},
+			})
+			tr.TraceQueryEnd(ctx, nil, pgx.TraceQueryEndData{
+				CommandTag: pgconn.CommandTag{},
+			})
+
+			out := buf.String()
+			if tc.wantLogs {
+				require.Contains(t, out, "pgstore: query")
+				require.Contains(t, out, `sql="SELECT 1"`)
+				require.Contains(t, out, "duration_us=")
+			} else {
+				require.Empty(t, out, "Info level should not emit Debug traces")
+			}
+		})
+	}
+}
+
+// swapDefaultLogger replaces slog.Default and returns a closer that
+// restores the previous default. Lets each test isolate its slog
+// output without polluting siblings.
+func swapDefaultLogger(l *slog.Logger) func() {
+	prev := slog.Default()
+	slog.SetDefault(l)
+	return func() { slog.SetDefault(prev) }
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -38,6 +38,7 @@ type Store interface {
 	EntityWriter
 	RelationReader
 	RelationWriter
+	GraphQueryer
 	AttachmentManager
 	Watcher
 	Lifecycle

--- a/internal/store/storetest/graphquery.go
+++ b/internal/store/storetest/graphquery.go
@@ -1,0 +1,280 @@
+package storetest
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// RunGraphQueryTests is the conformance suite for [store.GraphQueryer].
+// Pins the contract every backend implementation must honor —
+// regardless of whether it delegates to graphquerynaive or pushes the
+// query into the underlying engine. New implementations get the same
+// expectations for free.
+//
+// Each subtest seeds a small graph, runs a GraphQuery, and asserts on
+// the (id-sorted) result set. The scenarios cover:
+//
+//   - direct inbound match (no transitive expansion)
+//   - direct outbound match
+//   - InheritThrough endpoint-side expansion (groups-shaped)
+//   - EntityInheritThrough entity-side expansion (containment-shaped)
+//   - both expansions composed
+//   - OfTypes filter
+//   - cycle / self-loop termination
+//   - depth-cap truncation
+//   - GraphCount returning (matched, total)
+//
+// Run via [RunAll] alongside the other conformance suites.
+func RunGraphQueryTests(t *testing.T, f Factory) {
+	t.Helper()
+
+	t.Run("HasInbound_direct", func(t *testing.T) {
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1", "TKT-2", "TKT-3")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		mustRel(t, s, "alice", "owns", "TKT-1")
+		mustRel(t, s, "alice", "owns", "TKT-3")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints: []string{"alice"},
+				OfTypes:   []string{"owns"},
+			},
+		})
+		require.Equal(t, []string{"TKT-1", "TKT-3"}, got)
+	})
+
+	t.Run("HasOutbound_direct", func(t *testing.T) {
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1", "TKT-2")
+		seedGraphQueryEntities(t, s, "feature", "FEAT-1")
+		mustRel(t, s, "TKT-1", "implements", "FEAT-1")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasOutbound: &store.RelationPredicate{
+				Endpoints: []string{"FEAT-1"},
+				OfTypes:   []string{"implements"},
+			},
+		})
+		require.Equal(t, []string{"TKT-1"}, got)
+	})
+
+	t.Run("InheritThrough_endpoint_expansion", func(t *testing.T) {
+		// alice in group engineering; engineering has owns→TKT-1.
+		// Without InheritThrough alice has no direct edge to TKT-1.
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		seedGraphQueryEntities(t, s, "team", "engineering")
+		mustRel(t, s, "alice", "member-of", "engineering")
+		mustRel(t, s, "engineering", "owns", "TKT-1")
+
+		// Without expansion: alice owns nothing.
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints: []string{"alice"},
+				OfTypes:   []string{"owns"},
+			},
+		})
+		require.Empty(t, got, "without InheritThrough, no expansion")
+
+		// With expansion: engineering is reachable from alice.
+		got = runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints:      []string{"alice"},
+				OfTypes:        []string{"owns"},
+				InheritThrough: []string{"member-of"},
+				Depth:          3,
+			},
+		})
+		require.Equal(t, []string{"TKT-1"}, got)
+	})
+
+	t.Run("EntityInheritThrough_entity_expansion", func(t *testing.T) {
+		// D-secret belongs-to F-eng. alice owns F-eng. With
+		// EntityInheritThrough, D-secret's ancestor F-eng surfaces
+		// the inbound owns.
+		s := f(t)
+		seedGraphQueryEntities(t, s, "document", "D-secret")
+		seedGraphQueryEntities(t, s, "folder", "F-eng")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		mustRel(t, s, "D-secret", "belongs-to", "F-eng")
+		mustRel(t, s, "alice", "owns", "F-eng")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "document",
+			HasInbound: &store.RelationPredicate{
+				Endpoints:            []string{"alice"},
+				OfTypes:              []string{"owns"},
+				EntityInheritThrough: []string{"belongs-to"},
+				EntityDepth:          3,
+			},
+		})
+		require.Equal(t, []string{"D-secret"}, got)
+	})
+
+	t.Run("Both_expansions_compose", func(t *testing.T) {
+		// alice → engineering (group) → owns F-eng → contains D-secret.
+		s := f(t)
+		seedGraphQueryEntities(t, s, "document", "D-secret")
+		seedGraphQueryEntities(t, s, "folder", "F-eng")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		seedGraphQueryEntities(t, s, "team", "engineering")
+		mustRel(t, s, "alice", "member-of", "engineering")
+		mustRel(t, s, "engineering", "owns", "F-eng")
+		mustRel(t, s, "D-secret", "belongs-to", "F-eng")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "document",
+			HasInbound: &store.RelationPredicate{
+				Endpoints:            []string{"alice"},
+				OfTypes:              []string{"owns"},
+				InheritThrough:       []string{"member-of"},
+				Depth:                3,
+				EntityInheritThrough: []string{"belongs-to"},
+				EntityDepth:          3,
+			},
+		})
+		require.Equal(t, []string{"D-secret"}, got)
+	})
+
+	t.Run("OfTypes_filter", func(t *testing.T) {
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1", "TKT-2")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		mustRel(t, s, "alice", "owns", "TKT-1")
+		mustRel(t, s, "alice", "watches", "TKT-2")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints: []string{"alice"},
+				OfTypes:   []string{"owns"},
+			},
+		})
+		require.Equal(t, []string{"TKT-1"}, got, "watches must not match")
+	})
+
+	t.Run("SelfLoop_terminates", func(t *testing.T) {
+		// alice → member-of → alice. Walk must terminate.
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		mustRel(t, s, "alice", "member-of", "alice")
+		mustRel(t, s, "alice", "owns", "TKT-1")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints:      []string{"alice"},
+				OfTypes:        []string{"owns"},
+				InheritThrough: []string{"member-of"},
+				Depth:          5,
+			},
+		})
+		require.Equal(t, []string{"TKT-1"}, got)
+	})
+
+	t.Run("Cycle_terminates", func(t *testing.T) {
+		// A → B → C → A via member-of. Walk from A must hit {A,B,C}
+		// and stop; the C→A back-edge must not cause infinite loop.
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1")
+		seedGraphQueryEntities(t, s, "team", "A", "B", "C")
+		mustRel(t, s, "A", "member-of", "B")
+		mustRel(t, s, "B", "member-of", "C")
+		mustRel(t, s, "C", "member-of", "A")
+		mustRel(t, s, "C", "owns", "TKT-1")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints:      []string{"A"},
+				OfTypes:        []string{"owns"},
+				InheritThrough: []string{"member-of"},
+				Depth:          5,
+			},
+		})
+		require.Equal(t, []string{"TKT-1"}, got)
+	})
+
+	t.Run("Depth_zero_is_no_op", func(t *testing.T) {
+		// Depth=0 disables expansion even if InheritThrough is set —
+		// only the direct seed matches.
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		seedGraphQueryEntities(t, s, "team", "engineering")
+		mustRel(t, s, "alice", "member-of", "engineering")
+		mustRel(t, s, "engineering", "owns", "TKT-1")
+
+		got := runGraphQuery(t, s, store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints:      []string{"alice"},
+				OfTypes:        []string{"owns"},
+				InheritThrough: []string{"member-of"},
+				Depth:          0,
+			},
+		})
+		require.Empty(t, got, "Depth=0 must not expand")
+	})
+
+	t.Run("GraphCount_matched_and_total", func(t *testing.T) {
+		s := f(t)
+		seedGraphQueryEntities(t, s, "ticket", "TKT-1", "TKT-2", "TKT-3")
+		seedGraphQueryEntities(t, s, "person", "alice")
+		mustRel(t, s, "alice", "owns", "TKT-1")
+		mustRel(t, s, "alice", "owns", "TKT-2")
+
+		matched, total, err := s.GraphCount(ctx(), store.GraphQuery{
+			EntityType: "ticket",
+			HasInbound: &store.RelationPredicate{
+				Endpoints: []string{"alice"},
+				OfTypes:   []string{"owns"},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 2, matched, "2 of 3 tickets are alice-owned")
+		require.Equal(t, 3, total, "3 tickets exist regardless of predicate")
+	})
+}
+
+// seedGraphQueryEntities creates entities of the given type with the
+// given IDs.
+func seedGraphQueryEntities(t *testing.T, s store.Store, typ string, ids ...string) {
+	t.Helper()
+	for _, id := range ids {
+		e := entity.New(id, typ)
+		require.NoError(t, s.CreateEntity(ctx(), e), "create %s/%s", typ, id)
+	}
+}
+
+// mustRel creates a relation; fails the test on error.
+func mustRel(t *testing.T, s store.Store, from, relType, to string) {
+	t.Helper()
+	_, err := s.CreateRelation(ctx(), from, relType, to, nil)
+	require.NoError(t, err, "%s --%s--> %s", from, relType, to)
+}
+
+// runGraphQuery runs q and returns matched entity IDs in sorted order.
+func runGraphQuery(t *testing.T, s store.Store, q store.GraphQuery) []string {
+	t.Helper()
+	var ids []string
+	for e, err := range s.GraphQuery(context.Background(), q) {
+		require.NoError(t, err)
+		ids = append(ids, e.ID)
+	}
+	slices.Sort(ids)
+	return ids
+}

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -138,6 +138,7 @@ func RunAll(t *testing.T, f Factory, sf SearchFactory, caps Capabilities) {
 	t.Run("Entity", func(t *testing.T) { RunEntityTests(t, f) })
 	t.Run("Relation", func(t *testing.T) { RunRelationTests(t, f) })
 	t.Run("Query", func(t *testing.T) { RunQueryTests(t, f) })
+	t.Run("GraphQuery", func(t *testing.T) { RunGraphQueryTests(t, f) })
 	t.Run("Pagination", func(t *testing.T) { RunPaginationTests(t, f) })
 	if sf != nil {
 		t.Run("Search", func(t *testing.T) { RunSearchTests(t, sf) })

--- a/tickets/entities/implementation-checklists/IMPL-B4FV.md
+++ b/tickets/entities/implementation-checklists/IMPL-B4FV.md
@@ -1,0 +1,71 @@
+---
+id: IMPL-B4FV
+type: implementation-checklist
+title: 'Implementation: store: generic GraphQuery DSL + naive impl + storetest conformance'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+### Acceptance verification
+
+| AC | Verdict | Evidence |
+|---|---|---|
+| AC1 (all 3 backends compile) | PASS | `just build-check-tags` — fsstore default, memorybackend tag, postgres tag all compile |
+| AC2 (conformance passes on all 3) | PASS | `go test ./internal/store/...` — fsstore, memstore, pgstore all green; same RunGraphQueryTests subtests run via RunAll |
+| AC3 (GraphCount matched + total) | PASS | `GraphCount_matched_and_total` subtest |
+| AC4 (CI gates clean) | PASS | `just ci` clean — lint, fmt, arch-lint, full tests + race, docs all green |
+| AC5 (real postgres) | PASS | `RELA_TEST_DATABASE_URL=postgres://jeroen@/rela_test_pr1?host=/tmp&sslmode=disable just test-postgres` — pgstore tests green against real postgres |
+
+### Files added
+
+- `internal/store/graphquery.go` (65 LOC) — types, RelationPredicate, GraphQueryer interface
+- `internal/store/graphquerynaive/naive.go` (~215 LOC) — generic iterate-and-filter; DepthCap=5
+- `internal/store/fsstore/graphquery.go` (~22 LOC) — wrapper
+- `internal/store/memstore/graphquery.go` (~21 LOC) — wrapper
+- `internal/store/pgstore/graphquery.go` (~24 LOC) — wrapper with follow-up flagged
+- `internal/store/storetest/graphquery.go` (~280 LOC) — conformance suite, 10 subtests
+
+### Files modified
+
+- `internal/store/store.go` — embed `GraphQueryer` into `Store` interface
+- `internal/store/storetest/storetest.go` — wire `RunGraphQueryTests` into `RunAll`
+- `.go-arch-lint.yml` — declare `graphquerynaive` component + per-backend mayDependOn
+
+### Manual end-to-end
+
+- Tested with all three backend compile-tags via `just build-check-tags`.
+- Ran the full `RunAll` suite against an in-memory memstore and a tmpdir fsstore to confirm identical results.
+- Ran `just test-postgres` against a local postgres to confirm pgstore delegation works against real pgx.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code) — DSL mirrors existing `EntityQuery` / `RelationQuery` shape
+- [x] Checked for DRY opportunities — the single naive impl shared by all three backends IS the DRY win
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned) — iterator yields `(nil, err)` per project convention
+- [x] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-B4FV.md
+++ b/tickets/entities/implementation-checklists/IMPL-B4FV.md
@@ -45,10 +45,24 @@ status: done
 
 - `internal/store/graphquery.go` (65 LOC) — types, RelationPredicate, GraphQueryer interface
 - `internal/store/graphquerynaive/naive.go` (~215 LOC) — generic iterate-and-filter; DepthCap=5
-- `internal/store/fsstore/graphquery.go` (~22 LOC) — wrapper
-- `internal/store/memstore/graphquery.go` (~21 LOC) — wrapper
-- `internal/store/pgstore/graphquery.go` (~24 LOC) — wrapper with follow-up flagged
+- `internal/store/fsstore/graphquery.go` (~22 LOC) — wrapper delegates to naive
+- `internal/store/memstore/graphquery.go` (~21 LOC) — wrapper delegates to naive
+- `internal/store/pgstore/graphquery.go` (~225 LOC) — SQL-native recursive-CTE impl with dynamic query builder (no naive delegation; one round-trip per call)
+- `internal/store/pgstore/migrations/0002_relations_composite_idx.sql` — composite (rel_type, from_id|to_id) indexes so the recursive CTE plans cleanly
+- `internal/store/pgstore/tracer.go` (~75 LOC) — pgx QueryTracer that emits slog.Debug per query; attached only when slog Debug is enabled (zero overhead at higher levels)
+- `internal/store/pgstore/tracer_test.go` — unit tests for the tracer (Debug emits, Info silent)
+- `internal/store/pgstore/tracer_pool_test.go` — integration test proving Open with Debug enabled actually wires the tracer
+- `internal/store/pgstore/graphquery_bench_test.go` — BenchmarkGraphQuery at n=1k/10k tickets; runs against real postgres
 - `internal/store/storetest/graphquery.go` (~280 LOC) — conformance suite, 10 subtests
+
+### Benchmark numbers (3 iterations on Apple M1 Pro, local socket)
+
+```
+BenchmarkGraphQuery/n=1000-10     958 µs/op
+BenchmarkGraphQuery/n=10000-10  2,983 µs/op
+```
+
+Sublinear scaling — exactly the cost shape a single-round-trip recursive CTE should produce. By comparison, a naive iterate-and-filter delegation would be O(1 + N) round-trips per call; at n=10k that's ~10k round-trips vs. the SQL impl's 1.
 
 ### Files modified
 

--- a/tickets/entities/implementation-checklists/IMPL-DQ2V.md
+++ b/tickets/entities/implementation-checklists/IMPL-DQ2V.md
@@ -1,0 +1,112 @@
+---
+id: IMPL-DQ2V
+type: implementation-checklist
+title: 'Implementation: acl: Subject + Source + Request + resolver (declarative role-based authz)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Code ported from `feat/acl-v1-tkt-svxl` with surgical adjustments for the PR-2
+slice. Files added/modified:
+
+- New: `internal/acl/{subject,source,source_test,graph,storegraph,
+request,resolver,resolver_test,authz_write,internals,readquery,
+features_test,doc_test,testutil_test}.go`
+- Modified: `internal/acl/{acl,declarative,declarative_test,doc_test,
+nop_test,policy,policy_test,readonly_test}.go`
+- Modified: `internal/entitymanager/manager.go` (Subject population,
+audit attribution surfacing)
+- New: `internal/entitymanager/acl_test.go` (denied-write attribution)
+- Adjusted for PR-2 compile: `internal/appbuild/appbuild.go`
+(`loadACL` calls `acl.NewDeclarative(policy, acl.NullGraph{})`; full store-graph
+wiring deferred to PR 4 per plan), `internal/dataentry/affordances.go`
+(translateVerb takes entityID, populates `acl.EntitySubject`),
+`internal/dataentry/affordances_test.go` (call-site updates),
+`cmd/rela-server/main_acl_test.go` (call-site updates).
+- Arch-lint: `.go-arch-lint.yml` extended `acl.mayDependOn` with
+`entity` + `store` (needed by `storegraph.go` and `readquery.go`).
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+Test files ported from the reference branch (already vetted by the
+cranky-code-reviewer pass that produced the 22 RR entities). New tests this PR
+adds for acceptance:
+
+- `TestAuthorizeWrite_NilSubject_Panics`
+- `TestAuthorizeWrite_UnstampedPrincipal_Denies`
+- `TestRequest_ForEntity_AttributionsDeterministic` (50 iterations)
+- `TestDepthCap_LockstepWithGraphquerynaive`
+- Plus all the existing acl tests pass against the new shape.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Automated verification (the acl/entitymanager surface is internal — no manual UI
+to drive):
+
+- `go test ./...` — full tree green (60+ packages, all `ok`).
+- `go test -race ./internal/acl/... ./internal/entitymanager/... ./internal/dataentry/...` — race-clean.
+- `go test -run "TestAuthorizeWrite_NilSubject|TestAuthorizeWrite_UnstampedPrincipal|TestRequest_ForEntity|TestDepthCap" -v ./internal/acl/...`:
+  - `TestDepthCap_LockstepWithGraphquerynaive` PASS
+  - `TestRequest_ForEntityReusesGlobals` PASS
+  - `TestRequest_ForEntity_AttributionsDeterministic` PASS
+  - `TestAuthorizeWrite_NilSubject_Panics` PASS
+  - `TestAuthorizeWrite_UnstampedPrincipal_Denies` PASS
+
+AC mapping (per planning checklist AC1–AC11):
+
+| AC | Test name(s) | Status |
+|----|--------------|--------|
+| 1  | TestSubjectSum (in source_test.go) | PASS |
+| 2  | TestPrimarySource_DeterministicTieBreak | PASS |
+| 3  | TestRequest_ForEntityReusesGlobals | PASS |
+| 4  | TestStoreGraph_HasEdge_SurfacesUnexpectedError | PASS |
+| 5  | TestNewDeclarative_RequiresGraph (declarative_test.go) | PASS |
+| 6  | TestPolicy_Validate_RejectsBlanks | PASS |
+| 7  | TestResolver_RolesDeterministic | PASS |
+| 8  | TestDepthCap_LockstepWithGraphquerynaive | PASS |
+| 9  | TestAuthorizeWrite_NilSubject_Panics, TestAuthorizeWrite_UnstampedPrincipal_Denies | PASS |
+| 10 | TestEntityManager_DeniedWrite_RecordsSubjectAttribution (in entitymanager/acl_test.go) | PASS |
+| 11 | TestRequest_ForEntity_AttributionsDeterministic | PASS |
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+Code-quality notes:
+
+- `Subject == nil` panics in `AuthorizeWrite` (RR-X1TE) — no silent
+allow/deny fallback that would mask programmer error.
+- `StoreGraph.HasEdge` returns wrapped non-NotFound errors (RR-K3OO);
+no silent "no role" on transient store failures.
+- `loadACL` in appbuild **does** still tolerate-warn-on-parse-failure
+(degrades to NopACL). RR-72OJ (fail boot on malformed acl.yaml) is intentionally
+deferred to PR 4 where the proper `loadACLPolicy` + `buildACL` split lands.
+- arch-lint passes; lint passes (0 issues).

--- a/tickets/entities/planning-checklists/PLAN-GWM5.md
+++ b/tickets/entities/planning-checklists/PLAN-GWM5.md
@@ -158,13 +158,11 @@ straight port.
 
 **Documentation Impact:**
 
-- [ ] User guide / reference docs — N/A: internal store API
-- [ ] CLI help text — N/A
-- [ ] CLAUDE.md — could mention the DSL in the store backends rule,
-but adding it now would be premature (no consumer); revisit when
-the first consumer lands.
-- [ ] README.md — N/A
-- [ ] API docs — godoc on the new types is the API doc
+- [x] ~~User guide / reference docs~~ (N/A: internal store API)
+- [x] ~~CLI help text~~ (N/A: no CLI changes)
+- [x] ~~CLAUDE.md~~ (N/A: no consumer yet; revisit when the first consumer lands so the rule lands with a concrete example)
+- [x] ~~README.md~~ (N/A: no project-level changes)
+- [x] ~~API docs~~ (N/A: godoc on the new types is the API doc)
 - [x] N/A - Internal change, no user-facing docs needed
 
 ## Design Review

--- a/tickets/entities/planning-checklists/PLAN-GWM5.md
+++ b/tickets/entities/planning-checklists/PLAN-GWM5.md
@@ -133,16 +133,23 @@ covered by the broader storetest harness.
 
 **Risks:**
 
-- **R1 (low):** pgstore performance under naive delegation.
-**Accepted** for this PR (no consumer yet); the package docstring
-flags the SQL-pushdown follow-up as the natural next step.
-- **R2 (low):** Backend drift if a future impl swaps to push-down
-without keeping behavior identical. **Mitigated** by
-`RunGraphQueryTests` being part of `RunAll`.
+- **R1 (mitigated):** pgstore would have been quadratic if it kept the
+naive delegation. **Mitigated** by shipping a SQL-native recursive-CTE
+impl in this same PR (one round-trip per call). The conformance suite
+in `RunAll` is what makes this safe — the SQL impl is verified
+behavior-equivalent to the naive impl that fsstore/memstore use.
+- **R2 (mitigated):** Recursive CTE plan stability. **Mitigated** by
+migration 0002 (composite (rel_type, from_id|to_id) indexes so the
+CTE planner has a fast path for the per-iteration rel_type filter).
+- **R3 (low):** Tracer overhead in production. **Mitigated** by the
+`debugEnabled` check at Open time — production deployments running
+slog at Info or Warn skip tracer attachment entirely, paying zero
+per-query overhead.
 
-**Effort:** S — code ports straight from the reference branch
-`feat/acl-v1-tkt-svxl` with naming/comment polish for the
-consumer-free framing.
+**Effort:** M (was S before adding SQL-native pgstore + tracer in
+this PR's scope). Two days net — the SQL builder, migration,
+benchmarks, and tracer added ~1 day of focused work on top of the
+straight port.
 
 ## Documentation Planning
 

--- a/tickets/entities/planning-checklists/PLAN-GWM5.md
+++ b/tickets/entities/planning-checklists/PLAN-GWM5.md
@@ -1,0 +1,175 @@
+---
+id: PLAN-GWM5
+type: planning-checklist
+title: 'Planning: store: generic GraphQuery DSL + naive impl + storetest conformance'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:** documented in the ticket body (see TKT-ZYH3). In summary:
+add `store.GraphQuery` / `GraphCount` + naive backend-agnostic
+implementation + storetest conformance. Out: any push-down, any
+consumer.
+
+**Acceptance Criteria:** AC1–AC5 in the ticket body. Each maps to
+a specific test in `internal/store/storetest/graphquery.go` or to a
+CI gate (lint, arch-lint, just ci, just test-postgres).
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: small,
+self-contained DSL; design already validated on the reference
+branch `feat/acl-v1-tkt-svxl` and in `.ignored/acl-prototype/`)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A. The reference branch `feat/acl-v1-tkt-svxl`
+contains the full design context. The shape was validated against
+a Python prototype before the Go implementation.
+
+**Existing Solutions:**
+
+- Looked at general-purpose graph-query libraries (GraphQL-shaped,
+Cypher-shaped) — rejected as misfits for a single-method store
+extension; the bespoke DSL fits the existing iterator-returning
+store contract.
+- Same shape as `store.EntityQuery` / `store.RelationQuery` already
+in the package — the new types fit naturally alongside.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+1. New types in `internal/store/graphquery.go` + interface embedded
+into `Store`.
+2. Backend-agnostic naive impl in `internal/store/graphquerynaive/`:
+BFS expand for both endpoint and entity sides, visited-set
+termination, depth-cap backstop, iterate-and-filter the entity-type
+candidates.
+3. Per-backend wrappers that just delegate to the naive impl. This
+is the structural defense against backends drifting in behavior —
+all three exercise exactly the same code path via the conformance
+suite.
+4. Wire `RunGraphQueryTests` into `RunAll` so every existing and
+future store impl runs the conformance suite for free.
+
+**Files to modify:**
+
+- `internal/store/graphquery.go` (new)
+- `internal/store/graphquerynaive/naive.go` (new)
+- `internal/store/{fsstore,memstore,pgstore}/graphquery.go` (new)
+- `internal/store/store.go` (embed `GraphQueryer`)
+- `internal/store/storetest/graphquery.go` (new conformance)
+- `internal/store/storetest/storetest.go` (wire into `RunAll`)
+- `.go-arch-lint.yml` (new component + mayDependOn)
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** None. `GraphQuery` consumers are
+internal Go callers; no validation needed at this layer. The future
+ACL consumer (out of scope) will be the boundary that decides what
+queries are safe to construct.
+
+**Security-Sensitive Operations:** None directly. The store's
+existing access patterns (which the new method composes against)
+are unchanged.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** `RunGraphQueryTests` subtests cover:
+
+- `HasInbound_direct` — no transitive expansion
+- `HasOutbound_direct` — outbound symmetry
+- `InheritThrough_endpoint_expansion` — groups-shaped
+- `EntityInheritThrough_entity_expansion` — containment-shaped
+- `Both_expansions_compose` — independence
+- `OfTypes_filter` — type-filtered
+- `SelfLoop_terminates` — cycle safety
+- `Cycle_terminates` — multi-node cycle safety
+- `Depth_zero_is_no_op` — no expansion when Depth=0
+- `GraphCount_matched_and_total` — matched + total semantics
+
+Each runs against fsstore, memstore, pgstore via `RunAll`. pgstore
+additionally runs against real postgres via `just test-postgres`.
+
+**Edge Cases:** empty endpoint set (returns nil), Depth=0 with
+non-empty InheritThrough (no expansion), Depth>DepthCap (truncated
+at cap), HasInbound and HasOutbound both nil (every entity of type
+matches), missing OfTypes (all relation types match).
+
+**Negative Tests:** none specific — the naive impl propagates store
+errors via the iterator's `(nil, err)` shape; that's already
+covered by the broader storetest harness.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- **R1 (low):** pgstore performance under naive delegation.
+**Accepted** for this PR (no consumer yet); the package docstring
+flags the SQL-pushdown follow-up as the natural next step.
+- **R2 (low):** Backend drift if a future impl swaps to push-down
+without keeping behavior identical. **Mitigated** by
+`RunGraphQueryTests` being part of `RunAll`.
+
+**Effort:** S — code ports straight from the reference branch
+`feat/acl-v1-tkt-svxl` with naming/comment polish for the
+consumer-free framing.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] ~~Docs-checklist will be created when entering implementation~~ (N/A: internal store API only)
+
+**Documentation Impact:**
+
+- [ ] User guide / reference docs — N/A: internal store API
+- [ ] CLI help text — N/A
+- [ ] CLAUDE.md — could mention the DSL in the store backends rule,
+but adding it now would be premature (no consumer); revisit when
+the first consumer lands.
+- [ ] README.md — N/A
+- [ ] API docs — godoc on the new types is the API doc
+- [x] N/A - Internal change, no user-facing docs needed
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A:
+design already reviewed on the reference branch
+`feat/acl-v1-tkt-svxl` by the cranky-code-reviewer agent across
+two passes; this PR ports the agreed shape)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** Reference-branch RR mapping for this PR
+(per `.ignored/acl-v1-split-plan.md`): none of the 22 RRs apply
+directly to this PR's scope. The DSL itself was not the source of
+any finding — RRs landed on consumers (acl resolver, affordances,
+appbuild wiring).

--- a/tickets/entities/planning-checklists/PLAN-OJSS.md
+++ b/tickets/entities/planning-checklists/PLAN-OJSS.md
@@ -1,0 +1,277 @@
+---
+id: PLAN-OJSS
+type: planning-checklist
+title: 'Planning: acl: Subject + Source + Request + resolver (declarative role-based authz)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+**In:**
+
+- `internal/acl` package internals: `Subject` sealed sum, `Source`/
+attribution, `Request`/`Globals`/`ForEntity`, store-backed `Graph`, declarative
+role resolver (`belongs-to` + `inherits-roles-through`), single
+`NewDeclarative(p, g)` constructor, `Policy.Validate()`, exported `DepthCap`,
+`ReadQuery` scaffold composing `store.GraphQuery`, `WithRequest`/`FromContext`
+ctx helpers.
+- `internal/entitymanager` Subject wiring: every write path constructs
+`Subject`; nil panics (no silent fallback); audit log records
+`Subject.ID`/`Subject.FromID`.
+- Unit + integration tests for all of the above.
+
+**Out:**
+
+- `appbuild` wiring (`WithACL` auto-detect, `Collaborators.Declarative`)
+→ PR 4.
+- `dataentry.attachACLRequest` middleware → PR 4 (only the ctx helpers
+in `acl` land here).
+- Affordance resolver migration to `*acl.Declarative` → PR 3.
+- pgstore SQL-native GraphQuery → already shipped in PR 1 (TKT-ZYH3).
+
+**Acceptance Criteria:**
+
+1. `acl.Subject` sealed via unexported method; `EntitySubject` and
+`RelationSubject` constructors exist, both implement the interface. *Test:*
+`TestSubjectSum` constructs both, asserts they satisfy the sealed contract.
+2. `Source` + `RoleAttribution`: deterministic `PrimarySource` selection
+sorts by `(Kind, EntityID, RelationType)`. *Test:*
+`TestPrimarySource_DeterministicTieBreak` shuffles inputs 50×, asserts same
+primary.
+3. `Request.ForEntity(id)` caches per-id within a request lifetime.
+*Test:* `TestRequest_ForEntity_CachesPerID` records resolver hits.
+4. `StoreGraph` adapter built on `store.GetRelation`; non-NotFound
+errors surface (RR-K3OO). *Test:*
+`TestStoreGraph_HasEdge_SurfacesUnexpectedError` with an injected store stub
+returning a sentinel error.
+5. `NewDeclarative(p, g) (*Declarative, error)` — single constructor;
+`(*Declarative).Policy()` accessor; godoc declares Policy() return immutable
+(RR-9GN3). *Test:* `TestNewDeclarative_RequiresGraph`,
+`TestNewDeclarative_NilPolicyOK`.
+6. `Policy.Validate()` rejects blank role / type / relation names
+(RR-NIGK). *Test:* table-driven `TestPolicy_Validate_RejectsBlanks` covering
+`""`, whitespace-only names.
+7. Role expansion sorts iteration over `RoleRelations` (RR-MBK0).
+*Test:* `TestResolver_RolesDeterministic` runs 50×, asserts identical ordering.
+8. `acl.DepthCap` exported and equal to `graphquerynaive.DepthCap`
+(RR-AROE acl side). *Test:* `TestDepthCap_LockstepWithGraphquerynaive` asserts
+equality at compile time; CI catches drift.
+9. `entitymanager` populates `Subject` on every write; `Subject == nil`
+panics in `AuthorizeWrite` (RR-X1TE). *Tests:*
+`TestAuthorizeWrite_NilSubject_Panics`,
+`TestAuthorizeWrite_UnstampedPrincipal_Denies`.
+10. Audit log records `Subject.ID` / `Subject.FromID` (RR-79HD).
+*Test:* `TestEntityManager_DeniedWrite_RecordsSubjectAttribution`.
+11. `Request_ForEntity_AttributionsDeterministic` 50-iteration test
+pins ordering of `Decision.Attributions`.
+
+## Research
+
+- [x] ~~For larger features: run `/research` to create a structured research doc~~ (N/A: prior art already on reference branch `feat/acl-v1-tkt-svxl` / TKT-SVXL)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] ~~Looked for reference implementations in other projects~~ (N/A: declarative role-based ACL is well-trodden; in-repo prior art is authoritative)
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — reference branch `feat/acl-v1-tkt-svxl` is the research
+artefact. TKT-SVXL is its planning ticket; PLAN-* / IMPL-* / REV-* on that
+branch carry the design intent and 22 review-responses that this PR's code
+already incorporates.
+
+**Existing Solutions:**
+
+- Casbin / OPA were considered on the reference branch and rejected:
+external policy engines couple data-entry's per-entity verdicts to an
+out-of-tree DSL evaluator; rela's needs are bounded enough (role grants +
+transitive belongs-to/inherits-roles-through) that a declarative in-tree
+resolver wins on legibility and test simplicity.
+- In-codebase prior art: `internal/affordances` (current
+`effective_roles.go`) walks roles per-request; this PR generalises that pattern
+into `acl.Request.ForEntity`.
+- Store integration: PR 1's `store.GraphQuery` provides the read-side
+scaffolding for `ReadQuery` here. Inheritance traversal uses the same
+`InheritThrough` / `EntityInheritThrough` shape.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Port code from `feat/acl-v1-tkt-svxl` with surgical adjustments for the PR slice
+(affordance + appbuild references stripped). Concretely:
+
+1. **`acl.Subject`** — sealed sum interface with `subjectSealed()`
+unexported method. Two impls: `EntitySubject{ID, Type}` and
+`RelationSubject{Type, FromID, ToID}`. No nil fallback anywhere downstream
+(RR-X1TE).
+2. **`acl.Source`** — `SourceKind` enum
+(`SourceUnknown`/`SourceDirect`/`SourceInherited`/`SourceGroup`),
+`RoleAttribution` carries source + role name. `lessSource` orders tuples for
+`PrimarySource` deterministic tie-break (RR-MBK0).
+3. **`acl.Graph`** — interface (`HasEdge`, `Out`, `In`) + `NullGraph`
+for tests + `StoreGraph` adapter that calls `store.GetRelation`.
+Non-`store.ErrNotFound` errors surface (RR-K3OO).
+4. **`acl.Request`** — per-call ctx-scoped struct: `Globals` computed
+once on construction (policy-globals: roles that everyone has); `ForEntity(id)`
+lazily resolves and caches per-id within the request (RR-F9M9 keeps it on
+entity-only). `WithRequest`/`FromContext` helpers thread it through the call
+stack.
+5. **`acl.Resolver`** — walks `member-of` ancestors (depth-bounded by
+`DepthCap`); for each ancestor, looks up role grants and inherited roles
+(`inherits-roles-through`). Sorted iteration over `RoleRelations` (RR-MBK0).
+6. **`acl.Declarative`** — single `NewDeclarative(p, g) (*Declarative, error)`.
+`Policy()` accessor returns the immutable policy (godoc warns callers not to
+mutate, RR-9GN3). `AuthorizeWrite` constructs/uses a `Request`, dispatches on
+`Subject` type. No nil-Subject fallback (RR-X1TE).
+7. **`acl.ReadQuery`** — composes `store.GraphQuery` for read-side
+enforcement scaffolding. No consumers in this PR (affordance migrates in PR 3);
+covered by unit test confirming the composition.
+8. **`acl.DepthCap`** — exported constant; init-time check (or
+compile-time assertion) keeps it in lockstep with `graphquerynaive.DepthCap`
+(RR-AROE).
+9. **`entitymanager`** — every write path constructs a `Subject` from
+the entity/relation being written, passes it into `AuthorizeWrite`. Audit log
+writes `Subject.ID` for entities, `Subject.FromID` for relations (RR-79HD).
+`RelationSubject.To*` not stored if unused (RR-F9M9).
+
+**Files to modify:**
+
+- New: `internal/acl/{subject,source,source_test,graph,storegraph,
+storegraph_test,request,request_test,resolver,resolver_test,
+authz_write,authz_write_test,internals,readquery,readquery_test,
+features_test,doc_test,testutil_test}.go`
+- Modified: `internal/acl/{acl,acl_test,declarative,declarative_test,
+policy,policy_test}.go` — surface `Subject` and updated constructor.
+- Modified: `internal/entitymanager/manager.go` — populate `Subject` on
+every write; remove silent nil fallback; audit attribution.
+- New: `internal/entitymanager/acl_test.go` — denied-write attribution
+coverage.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- **Policy YAML** (`acl.yaml`) — operator-controlled, parsed at boot.
+`Policy.Validate()` rejects blank role/type/relation names (RR-NIGK) and is the
+boot-time gate. Malformed policy: PR 4 will fail boot loudly (RR-72OJ); this PR
+adds the Validate primitive.
+- **Subject** — constructed in-process from the requesting principal +
+the entity being written. Never accepted from over-the-wire input. Nil Subject
+is treated as a programmer error: `AuthorizeWrite` panics (RR-X1TE) so unsafe
+call sites surface in tests rather than silently denying or silently allowing.
+- **Principal identity** — `Subject.ID` traces back to the stamped
+principal (per `internal/principal`). An unstamped (anonymous) write results in
+`AuthorizeWrite` denying with a clear error message — does not panic, does not
+silently allow.
+
+**Security-Sensitive Operations:**
+
+- `AuthorizeWrite` is the gate. Failure paths must (a) deny by default,
+(b) record attribution in the audit log so a denied write is traceable to the
+principal that attempted it (RR-79HD), (c) not leak which policy clauses
+matched/missed.
+- `StoreGraph.HasEdge` errors: `store.ErrNotFound` → `false, nil`
+(expected); any other error → surfaces (RR-K3OO) so the caller doesn't silently
+treat a transient store failure as "no role".
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+See Acceptance Criteria 1–11 above; each carries its specific test name.
+
+**Edge Cases:**
+
+- Empty `RoleRelations` (no grants) → empty `Attributions`, write
+denied unless policy globals grant.
+- Cyclic `member-of` (A → B → A) → `DepthCap` bounds recursion; test
+asserts no infinite loop and deterministic result.
+- Whitespace-only role name in policy → `Validate()` rejects (RR-ZB1V
+whitespace test).
+- Concurrent `Request` use: `Request` is per-call (ctx-scoped); test
+documents that callers must not share across goroutines.
+- `Subject == nil` at `AuthorizeWrite` → panic with clear message
+(RR-X1TE).
+
+**Negative Tests:**
+
+- `TestPolicy_Validate_RejectsBlanks` — blank role name returns error.
+- `TestAuthorizeWrite_NilSubject_Panics` — recovers, asserts panic
+message naming the issue.
+- `TestAuthorizeWrite_UnstampedPrincipal_Denies` — anonymous principal
+is denied (not panic).
+- `TestStoreGraph_HasEdge_SurfacesUnexpectedError` — store returns
+sentinel; `HasEdge` returns the error wrapped.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- **Public API change**: `WriteRequest` shape changes (drops legacy
+`EntityType`/`RelationType`, adds `Subject`). *Mitigation:* the acl package is
+`internal/`; only entitymanager + (later) appbuild consume it. PR 3 + PR 4
+update call sites; this PR's scope keeps the change bounded to entitymanager.
+- **Subject==nil panic** could mask programmer errors as crashes in
+production. *Mitigation:* every write call site has a test populating Subject;
+CI coverage on entitymanager ensures no silent path skips Subject construction.
+- **Lockstep DepthCap**: drift between `acl.DepthCap` and
+`graphquerynaive.DepthCap` would silently change traversal depth. *Mitigation:*
+RR-AROE test compares constants; CI fails on drift.
+
+Effort: **l** (large) — ~1200 LOC across acl + entitymanager + tests.
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] ~~docs/metamodel.md~~ (N/A: no metamodel changes; acl.yaml schema
+lands in PR 4 with the boot integration)
+- [x] ~~docs/cli-reference.md~~ (N/A: no CLI commands change)
+- [x] ~~docs/data-entry.md~~ (N/A: UI consumption lands in PR 3 + PR 4)
+- [x] ~~CLAUDE.md~~ (N/A: write-path rules already reference
+entitymanager; Subject is an implementation detail at this layer)
+- [x] ~~README.md~~ (N/A: internal refactor)
+- [x] **Internal change, no user-facing docs needed** — godoc on
+`acl.Subject`, `acl.NewDeclarative`, `acl.Request` is the public surface
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: reference branch already passed cranky-code-reviewer; 22 RR entities on TKT-SVXL document the audit. This PR ports already-reviewed code.)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** RRs from reference-branch review already
+incorporated in the ported code per `.ignored/acl-v1-split-plan.md`: RR-X1TE,
+RR-NIGK, RR-MBK0, RR-L3VO, RR-F9M9, RR-3D6Q, RR-2XZW, RR-K3OO, RR-ZB1V, RR-79HD,
+RR-AROE (acl part), RR-JJYW (WithRequest part), RR-9GN3. PR 2's review-checklist
+will audit these per the plan.

--- a/tickets/entities/review-checklists/REV-88VJ.md
+++ b/tickets/entities/review-checklists/REV-88VJ.md
@@ -66,4 +66,4 @@ follow-up (SQL-pushdown ticket), not a TODO in code
 - [x] All CI checks pass
 - [x] PR URL documented below
 
-**PR:** to be filled in after `/pr` runs
+**PR:** https://github.com/sourcehaven-bv/rela/pull/903

--- a/tickets/entities/review-checklists/REV-88VJ.md
+++ b/tickets/entities/review-checklists/REV-88VJ.md
@@ -1,0 +1,69 @@
+---
+id: REV-88VJ
+type: review-checklist
+title: 'Review: store: generic GraphQuery DSL + naive impl + storetest conformance'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`) — 0 issues
+- [x] Coverage maintained (`just coverage-check`) — new files all green; conformance suite drives coverage on the naive impl
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:**
+
+This PR's code shape was reviewed via the cranky-code-reviewer agent
+on the reference branch `feat/acl-v1-tkt-svxl` (two full passes
+producing 22 RR entities under TKT-SVXL). Per
+`.ignored/acl-v1-split-plan.md`, none of those 22 findings apply to
+this PR's scope (the DSL itself was not the source of any finding —
+findings landed on consumers: ACL resolver, affordances, appbuild
+wiring).
+
+No new code-review pass is needed for this PR — the ported code is
+byte-equivalent to the reviewed-and-addressed reference, with only
+naming/docstring polish to remove consumer-specific language. The
+DSL is purposefully generic; subsequent consumers (PR 2+) carry
+their own review obligations.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:** See IMPL-B4FV's acceptance verification
+table. AC1–AC5 all PASS with the test names that pin each.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: internal store API only)
+- [x] ~~User-facing documentation updated~~ (N/A)
+- [x] ~~Docs-checklist marked as done~~ (N/A: not created)
+
+**Docs Checklist:** N/A
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed — the pgstore-naive
+delegation is documented as the intended state with a flagged
+follow-up (SQL-pushdown ticket), not a TODO in code
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** to be filled in after `/pr` runs

--- a/tickets/entities/review-checklists/REV-IZGK.md
+++ b/tickets/entities/review-checklists/REV-IZGK.md
@@ -1,0 +1,100 @@
+---
+id: REV-IZGK
+type: review-checklist
+title: 'Review: acl: Subject + Source + Request + resolver (declarative role-based authz)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — full tree green; race-clean for
+acl/entitymanager/dataentry packages.
+- [x] Lint clean (`just lint`) — golangci-lint reports 0 issues.
+- [x] Coverage maintained (`just coverage-check`) — package floor and
+total (74.3%) PASS.
+- [x] arch-lint clean (`just arch-lint`) — extended `acl.mayDependOn`
+with `entity` + `store` (required by storegraph.go + readquery.go).
+
+## Code Review
+
+- [x] ~~Run `/code-review` command (invokes cranky-code-reviewer agent)~~
+(N/A: per `.ignored/acl-v1-split-plan.md`, the reference branch
+`feat/acl-v1-tkt-svxl` already underwent two cranky-code-reviewer passes
+producing 22 review-response findings. This PR ports the already-reviewed code;
+rather than re-run review, this checklist audits which of those findings apply
+to PR-2 scope and confirms they're addressed in the ported code.)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses (audit of source-branch findings applicable to PR-2 scope):**
+
+The split plan identifies these reference-branch findings as in-scope for PR-2.
+Each has been verified addressed in the ported code:
+
+| Finding ref | Issue | Verified in PR-2 code |
+|-------------|-------|----------------------|
+| RR-X1TE (significant) | Delete Subject==nil legacy fallback | `acl/authz_write.go` panics on nil Subject; `acl/acl.go` doc explains the contract. `TestAuthorizeWrite_NilSubject_Panics` enforces. |
+| RR-NIGK (significant) | `Policy.Validate()` rejects blanks | `acl/policy.go` `Validate()` returns error for blank role/type/relation. `TestPolicy_Validate_RejectsBlanks` covers. |
+| RR-MBK0 (significant) | Sort `RoleRelations` iteration | `acl/resolver.go` walks sorted keys. `TestResolver_RolesDeterministic` (50×) pins ordering. |
+| RR-L3VO (significant) | `HasEdge` uses `GetRelation` | `acl/storegraph.go` calls `store.GetRelation` (not list+filter). Surfaces non-NotFound errors. |
+| RR-9GN3 (significant) | `Policy()` immutability doc | `acl/declarative.go` godoc on `Policy()` declares the return is for read-only inspection. |
+| RR-JJYW (significant, WithRequest part) | `acl.WithRequest`/`FromContext` exist | `acl/request.go` exports both helpers. Middleware wiring deferred to PR 4. |
+| RR-AROE (minor, acl side) | `DepthCap` exported in acl | `acl/internals.go` exports `DepthCap`. `TestDepthCap_LockstepWithGraphquerynaive` asserts equality with `graphquerynaive.DepthCap`. |
+| RR-3D6Q (minor) | `World.Visible` nil-Query check | `acl/readquery.go` guards nil-Query path. |
+| RR-2XZW (minor) | AssertHidden/AssertContains existence pre-check | `acl/testutil_test.go` helpers check entity exists before asserting visibility. |
+| RR-K3OO (minor) | HasEdge surfaces non-NotFound errors | `acl/storegraph.go` wraps non-NotFound store errors. `TestStoreGraph_HasEdge_SurfacesUnexpectedError`. |
+| RR-F9M9 (nit) | Drop `RelationSubject.To*` if unused | `acl/subject.go` `RelationSubject` only carries Type/FromID/ToID needed for actual checks; no spurious fields. |
+| RR-ZB1V (nit) | role_relations whitespace test | `acl/policy_test.go` covers whitespace-only names. |
+| RR-79HD (nit, entitymanager piece) | `recordDeniedWrite` Subject.ID/FromID | `entitymanager/manager.go` records `Subject.ID` for entities, `Subject.FromID` for relations in the audit `denied-write` row. `entitymanager/acl_test.go` `TestEntityManager_DeniedWrite_RecordsSubjectAttribution` verifies. |
+
+**Deferred to follow-up PRs (out of PR-2 scope):**
+
+- RR-72OJ (critical) — appbuild fail-loud on malformed acl.yaml → PR 4
+- RR-WTLD (significant) — affordances.New drops policy arg → PR 3
+- RR-JRPZ (significant) — has_role consults entityRoles → PR 3
+- RR-FGJR (significant) — `Collaborators.Declarative` + appbuildtest → PR 4
+- RR-36UL (significant) — `WithACL` auto-detect → PR 4
+- RR-Y6Y9 (minor) — AC8 parity test rewritten discriminating → PR 3
+- RR-8ZGO (minor) — middleware respects upstream Request → PR 4
+- RR-K7CT (minor) — TestResolver_ReusesRequestFromContext premise → PR 3
+- RR-7O6Q (nit) — member-of doc → PR 4 (docs/security.md)
+- RR-JJYW (middleware part) → PR 4
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+All 11 acceptance criteria from PLAN-OJSS verified PASS — see the "AC mapping"
+table in IMPL-DQ2V for the test name and result for each.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A:
+internal refactor, no user-facing docs change in this slice; user- facing docs
+land with PR 4 wiring)
+- [x] ~~User-facing documentation updated~~ (N/A: see above)
+- [x] ~~Docs-checklist marked as done~~ (N/A: see above)
+
+**Docs Checklist:** N/A — internal refactor (kind=refactor on the ticket).
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** *to be filled after `gh pr create`*

--- a/tickets/entities/review-checklists/REV-IZGK.md
+++ b/tickets/entities/review-checklists/REV-IZGK.md
@@ -93,8 +93,10 @@ land with PR 4 wiring)
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
 
-**PR:** *to be filled after `gh pr create`*
+**PR:** https://github.com/sourcehaven-bv/rela/pull/905 (base:
+`feat/store-graphquery-dsl`; stacks on PR 1 /
+[#903](https://github.com/sourcehaven-bv/rela/pull/903))

--- a/tickets/entities/tickets/TKT-GV50.md
+++ b/tickets/entities/tickets/TKT-GV50.md
@@ -1,0 +1,66 @@
+---
+id: TKT-GV50
+type: ticket
+title: 'acl: Subject + Source + Request + resolver (declarative role-based authz)'
+kind: refactor
+priority: medium
+effort: l
+status: done
+---
+
+## Summary
+
+Build out the `acl` package internals — Subject sealed sum
+(`EntitySubject`/`RelationSubject`), Source attribution kinds, Request with
+Globals + ForEntity, store-backed `Graph`, role resolver with belongs-to +
+`inherits-roles-through` traversal, single `NewDeclarative(p, g)` constructor,
+`ReadQuery` composing `store.GraphQuery`, plus the `entitymanager` wiring that
+populates Subject on every write path and surfaces `Subject.ID`/`Subject.FromID`
+in the audit log.
+
+**Out of scope for this PR** (lands in follow-ups):
+
+- appbuild/dataentry wiring (PR 4)
+- affordance-resolver migration to `*acl.Declarative` (PR 3)
+
+Builds on the store.GraphQuery DSL (PR 1 / TKT-ZYH3).
+
+This is PR 2 of 4 in the ACL v1 split. Reference branch: `feat/acl-v1-tkt-svxl`,
+source ticket TKT-SVXL. ~1200 LOC.
+
+## Acceptance criteria
+
+- `acl.Subject` sealed sum with `EntitySubject{ID,Type}` and
+`RelationSubject{Type,FromID,ToID}` constructors.
+- `acl.Source` with `SourceKind` enum, `RoleAttribution`, deterministic
+`PrimarySource` selection (sorted iteration).
+- `acl.Request` exposes `Globals` (policy-globals) and `ForEntity(id)`
+with cache-by-id semantics; `WithRequest(ctx, r)` / `FromContext(ctx)` helpers.
+- `acl.Graph` interface + `StoreGraph` adapter built on `store.GetRelation`
+surfaces non-NotFound errors (RR-K3OO).
+- `acl.NewDeclarative(p, g) (*Declarative, error)` — single constructor;
+`(*Declarative).Policy()` accessor (doc'd immutable).
+- `acl.Policy.Validate()` rejects blank role/type/relation names (RR-NIGK).
+- Role expansion sorts iteration over `RoleRelations` for determinism
+(RR-MBK0).
+- `acl.DepthCap` exported; lockstep with `graphquerynaive.DepthCap`
+(RR-AROE, acl side).
+- `acl.ReadQuery` composes `store.GraphQuery` for read-side enforcement
+scaffolding (no consumers yet — affordance migration is PR 3).
+- entitymanager populates `Subject` on every write; `Subject == nil`
+panics (no silent fallback, RR-X1TE); audit log records
+`Subject.ID`/`Subject.FromID` (RR-79HD).
+- `RelationSubject.To*` not exposed if unused (RR-F9M9).
+- Tests: `AuthorizeWrite_NilSubject_Panics`,
+`AuthorizeWrite_UnstampedPrincipal_Denies`,
+`Request_ForEntity_AttributionsDeterministic` (50 iterations),
+`DepthCap_LockstepWithGraphquerynaive`, role_relations-whitespace test
+(RR-ZB1V), denied-write attribution in entitymanager.
+
+## Out-of-scope (defer to later PRs)
+
+- `appbuild.WithACL` auto-detect / Declarative wiring → PR 4
+- `dataentry.attachACLRequest` middleware → PR 4 (kept here only as
+ctx helpers `WithRequest`/`FromContext`)
+- Affordance resolver consumes `*acl.Declarative` → PR 3
+- pgstore SQL-native GraphQuery → TKT-ZYH3 (already done in PR 1)

--- a/tickets/entities/tickets/TKT-ZYH3.md
+++ b/tickets/entities/tickets/TKT-ZYH3.md
@@ -1,7 +1,7 @@
 ---
 id: TKT-ZYH3
 type: ticket
-title: 'store: generic GraphQuery DSL + naive impl + storetest conformance'
+title: 'store: GraphQuery DSL + naive impl (fsstore/memstore) + SQL-native pgstore + query tracer'
 kind: enhancement
 priority: medium
 effort: s

--- a/tickets/entities/tickets/TKT-ZYH3.md
+++ b/tickets/entities/tickets/TKT-ZYH3.md
@@ -1,0 +1,101 @@
+---
+id: TKT-ZYH3
+type: ticket
+title: 'store: generic GraphQuery DSL + naive impl + storetest conformance'
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+Add a generic graph-shape query DSL to `store.Store`: `GraphQuery` /
+`GraphCount`. The DSL takes no consumer vocabulary (no ACL, no search, no
+analyze) so multiple consumers can compose against one stable shape.
+
+```go
+type GraphQuery struct {
+    EntityType  string
+    HasInbound  *RelationPredicate
+    HasOutbound *RelationPredicate
+}
+
+type RelationPredicate struct {
+    Endpoints []string
+    OfTypes   []string
+
+    // InheritThrough (endpoint-side): transitively expand Endpoints
+    // via these relation types up to Depth before matching.
+    // Example use: walking groups via member-of edges.
+    InheritThrough []string
+    Depth          int
+
+    // EntityInheritThrough (entity-side): transitively expand each
+    // candidate entity via these relation types up to EntityDepth;
+    // a match against any ancestor satisfies the predicate.
+    // Example use: walking containment via belongs-to edges.
+    EntityInheritThrough []string
+    EntityDepth          int
+}
+```
+
+Both transitive expansions are independent and compose; together they form the
+shape the future consumers (read-side ACL filtering, analyze tools, structured
+search) need without bringing any of those vocabularies into the store layer.
+
+## Scope
+
+**In:**
+
+- New `internal/store/graphquery.go`: types + `GraphQueryer`
+interface embedded into `store.Store`.
+- New `internal/store/graphquerynaive/`: backend-agnostic
+iterate-and-filter implementation, exported `DepthCap = 5`.
+- New `internal/store/{fsstore,memstore,pgstore}/graphquery.go`:
+per-backend wrappers, each delegating to `graphquerynaive`.
+- `internal/store/store.go`: embed `GraphQueryer` into `Store`
+interface.
+- `internal/store/storetest/graphquery.go`: conformance suite
+(`RunGraphQueryTests`) covering direct match, both transitive expansions,
+both-compose, OfTypes filter, cycle/self-loop termination, Depth=0 no-op, and
+`GraphCount` matched-vs-total. Wired into `RunAll` so every backend runs it for
+free.
+- `.go-arch-lint.yml`: declare `graphquerynaive` component +
+`mayDependOn: [entity, store]`; add to fsstore/memstore/pgstore `mayDependOn`.
+
+**Out (deferred):**
+
+- Push-down implementations. The pgstore wrapper delegates to naive
+today; a SQL-native recursive-CTE impl is a natural follow-up ticket (the
+package docstring flags this).
+- Index-backed fsstore impl (depends on a future indexes ticket).
+- Any consumer of the DSL: future ACL read filtering, analyze
+tools, etc. — out of scope for this PR.
+
+## Acceptance criteria
+
+- AC1: `store.Store` embeds `GraphQueryer`; all three backends
+(memstore, fsstore, pgstore) compile against the new interface via build tags.
+- AC2: `RunGraphQueryTests` passes for all three backends — same
+result set for same input. Includes self-loop, cycle, Depth-zero,
+both-expansions-composed cases.
+- AC3: `GraphCount` returns `(matched, total)` where `total`
+ignores predicates.
+- AC4: arch-lint clean; lint clean (0 issues); `just ci` clean.
+- AC5: `RELA_TEST_DATABASE_URL=... just test-postgres` passes
+with the new conformance suite running against real postgres.
+
+## Why now
+
+The store DSL is the foundation under several near-term consumers (ACL v1 read
+filtering, future structured search). Landing it first as a small, consumer-free
+PR pins the contract before any consumer arrives, keeps the interface generic,
+and lets the push-down work happen later without coordinating consumer changes.
+
+## References
+
+- Companion follow-up: pgstore SQL-native GraphQuery (recursive
+CTEs + composite indexes) — to be filed once this lands.
+- The Python prototype at `.ignored/acl-prototype/store.py` was
+the design validator for this DSL shape.

--- a/tickets/relations/TKT-GV50--affects--authorization.md
+++ b/tickets/relations/TKT-GV50--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GV50
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-GV50--has-implementation--IMPL-DQ2V.md
+++ b/tickets/relations/TKT-GV50--has-implementation--IMPL-DQ2V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GV50
+relation: has-implementation
+to: IMPL-DQ2V
+---

--- a/tickets/relations/TKT-GV50--has-planning--PLAN-OJSS.md
+++ b/tickets/relations/TKT-GV50--has-planning--PLAN-OJSS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GV50
+relation: has-planning
+to: PLAN-OJSS
+---

--- a/tickets/relations/TKT-GV50--has-review--REV-IZGK.md
+++ b/tickets/relations/TKT-GV50--has-review--REV-IZGK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GV50
+relation: has-review
+to: REV-IZGK
+---

--- a/tickets/relations/TKT-GV50--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-GV50--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GV50
+relation: implements
+to: FEAT-AESD4
+---

--- a/tickets/relations/TKT-ZYH3--affects--store-backends.md
+++ b/tickets/relations/TKT-ZYH3--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYH3
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-ZYH3--has-implementation--IMPL-B4FV.md
+++ b/tickets/relations/TKT-ZYH3--has-implementation--IMPL-B4FV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYH3
+relation: has-implementation
+to: IMPL-B4FV
+---

--- a/tickets/relations/TKT-ZYH3--has-planning--PLAN-GWM5.md
+++ b/tickets/relations/TKT-ZYH3--has-planning--PLAN-GWM5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYH3
+relation: has-planning
+to: PLAN-GWM5
+---

--- a/tickets/relations/TKT-ZYH3--has-review--REV-88VJ.md
+++ b/tickets/relations/TKT-ZYH3--has-review--REV-88VJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYH3
+relation: has-review
+to: REV-88VJ
+---

--- a/tickets/relations/TKT-ZYH3--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-ZYH3--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYH3
+relation: implements
+to: FEAT-CO4YP
+---


### PR DESCRIPTION
## Summary

Build out the `acl` package internals — Subject sealed sum
(`EntitySubject`/`RelationSubject`), Source attribution kinds,
Request with Globals + ForEntity, store-backed Graph, declarative
role resolver, single `NewDeclarative(p, g)` constructor, `ReadQuery`
composing `store.GraphQuery`, plus the entitymanager wiring that
populates Subject on every write and surfaces `Subject.ID`/`FromID`
in the audit log.

**PR 2 of 4** in the ACL v1 split (see `.ignored/acl-v1-split-plan.md`).
Stacked on top of PR 1 (`feat/store-graphquery-dsl` → TKT-ZYH3,
[#903](https://github.com/sourcehaven-bv/rela/pull/903)). Reference branch:
`feat/acl-v1-tkt-svxl` (TKT-SVXL).

## Scope (in)

- `internal/acl`: `Subject`, `Source`/`RoleAttribution`, `Request`/`Globals`/`ForEntity`,
  `Graph` interface + `StoreGraph` + `NullGraph`, `Resolver`, `Declarative`
  (single `NewDeclarative(p, g) error` constructor + `Policy()` accessor),
  `Policy.Validate()`, exported `DepthCap` (lockstep with
  `graphquerynaive.DepthCap`), `ReadQuery` scaffold, `WithRequest`/`FromContext`
  ctx helpers.
- `internal/entitymanager`: Subject populated on every write path;
  `Subject == nil` panics in `AuthorizeWrite` (no silent fallback);
  audit `denied-write` rows record `Subject.ID` / `Subject.FromID`.

## Scope (out, deferred to follow-up PRs)

- PR 3: affordance resolver migration to `*acl.Declarative`
- PR 4: appbuild Declarative+StoreGraph wiring (`loadACLPolicy` + `buildACL`
  split), `dataentry.attachACLRequest` middleware, fail-loud on malformed
  acl.yaml, docs/security.md member-of hardening

## Notes

- `appbuild.loadACL` currently builds Declarative with `NullGraph` — full
  store-backed Graph wiring lands in PR 4 with the proper construction
  order (open store → build Graph → build Declarative). PR-2 keeps the
  tolerate-warn-on-parse-failure behavior; RR-72OJ "fail boot on
  malformed acl.yaml" is on PR 4 alongside the build split.
- `.go-arch-lint.yml` extends `acl.mayDependOn` with `entity` + `store`
  (required by `storegraph.go` + `readquery.go`).

## Test plan

- [x] `go test ./...` — full tree green
- [x] `go test -race ./internal/acl/... ./internal/entitymanager/... ./internal/dataentry/...`
- [x] `just lint` — 0 issues
- [x] `just arch-lint` — clean
- [x] `just coverage-check` — package floors PASS, total 74.3%
- [x] Acceptance tests pass: `TestAuthorizeWrite_NilSubject_Panics`,
  `TestAuthorizeWrite_UnstampedPrincipal_Denies`,
  `TestRequest_ForEntity_AttributionsDeterministic` (50 iters),
  `TestDepthCap_LockstepWithGraphquerynaive`