### PR TITLE
test(pgstore): isolate live-feed and catch-up paths (TKT-WZYWM9)

### DIFF
--- a/internal/store/pgstore/export_test.go
+++ b/internal/store/pgstore/export_test.go
@@ -10,14 +10,26 @@ import (
 )
 
 // SetCatchUpIntervalForTest shortens the listener's safety-net catch-up poll so
-// tests don't wait the production 30s, restoring it on cleanup. Test-only.
-// catchUpInterval is an atomic, so this is safe vs the listener goroutines that
-// read it concurrently.
+// tests don't wait the production 30s, restoring it on cleanup. A non-positive
+// d disables the poll entirely (the listener blocks on the live notification
+// alone) — used to isolate the live feed. Test-only. catchUpInterval is an
+// atomic, so this is safe vs the listener goroutines that read it concurrently.
 func SetCatchUpIntervalForTest(t *testing.T, d time.Duration) {
 	t.Helper()
 	prev := catchUpInterval.Load()
 	catchUpInterval.Store(int64(d))
 	t.Cleanup(func() { catchUpInterval.Store(prev) })
+}
+
+// SetNotifyDisabledForTest suppresses the producer's pg_notify for the test's
+// duration (restored on cleanup), so an ordinary write commits without a live
+// notification and the seq-watermark catch-up is the only delivery channel.
+// Test-only. notifyDisabled is an atomic; the listener tests that use it run
+// sequentially (no t.Parallel).
+func SetNotifyDisabledForTest(t *testing.T, disabled bool) {
+	t.Helper()
+	prev := notifyDisabled.Swap(disabled)
+	t.Cleanup(func() { notifyDisabled.Store(prev) })
 }
 
 // FeedPayloadForTest builds a NOTIFY payload for an entity event with the given

--- a/internal/store/pgstore/feed.go
+++ b/internal/store/pgstore/feed.go
@@ -6,9 +6,17 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"sync/atomic"
 
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
+
+// notifyDisabled suppresses the producer's pg_notify when set, so a test can
+// commit an ordinary write whose live notification never fires and assert that
+// the seq-watermark catch-up still recovers it. Production never sets it. An
+// atomic so it's safe vs. the writer goroutines that read it; the listener
+// tests that flip it run sequentially (no t.Parallel), like catchUpInterval.
+var notifyDisabled atomic.Bool
 
 // The cross-process change feed (TKT-WZYWM9). Writes emit a PostgreSQL
 // NOTIFY carrying the changed identity; a listener in another process turns
@@ -178,6 +186,9 @@ func feedOp(kind, op string) (store.EventOp, bool) {
 func (s *Store) notify(ctx context.Context, q DBTX, ev store.Event) {
 	if s.channel == "" {
 		return
+	}
+	if notifyDisabled.Load() {
+		return // test hook: force the catch-up path to be the only delivery channel
 	}
 	// pg_notify takes (text, text), both bound parameters — no injection surface.
 	_, _ = q.Exec(ctx, `SELECT pg_notify($1, $2)`, s.channel, notifyPayload(s.originID, ev))

--- a/internal/store/pgstore/listener.go
+++ b/internal/store/pgstore/listener.go
@@ -34,6 +34,8 @@ const defaultCatchUpInterval = 30 * time.Second
 // listener self-heals within this interval by re-running the catch-up query.
 // An atomic so tests can shorten it (SetCatchUpIntervalForTest) without racing
 // the listener goroutines that read it. Holds a time.Duration as an int64.
+// A non-positive value disables the poll entirely (the listener blocks on the
+// live notification alone) — used only by tests that isolate the live feed.
 var catchUpInterval atomic.Int64
 
 func init() { catchUpInterval.Store(int64(defaultCatchUpInterval)) }
@@ -136,8 +138,15 @@ func (l *listener) run(ctx context.Context, conn *pgx.Conn) {
 		// triggers the safety-net catch-up. Stays here until the connection
 		// breaks (then the outer loop reconnects) or ctx is cancelled.
 		for {
+			// A non-positive interval disables the safety-net poll: wait on ctx
+			// alone so only a live notification (or shutdown) wakes the loop. Used
+			// by tests that must prove the live feed in isolation; production always
+			// holds a positive interval.
 			interval := time.Duration(catchUpInterval.Load())
-			waitCtx, cancel := context.WithTimeout(ctx, interval)
+			waitCtx, cancel := ctx, func() {}
+			if interval > 0 {
+				waitCtx, cancel = context.WithTimeout(ctx, interval)
+			}
 			n, err := conn.WaitForNotification(waitCtx)
 			cancel()
 

--- a/internal/store/pgstore/listener_test.go
+++ b/internal/store/pgstore/listener_test.go
@@ -95,6 +95,9 @@ func waitForEntityEvent(t *testing.T, ch <-chan store.Event, id string, timeout 
 // to writer B's Subscribe channel, via the LISTEN/NOTIFY feed.
 func TestCrossProcessPropagation(t *testing.T) {
 	schema := freshFeedSchema(t)
+	// Disable the safety-net catch-up so this proves the LIVE LISTEN/NOTIFY path
+	// in isolation — if the notification is ever dropped, nothing else can mask it.
+	pgstore.SetCatchUpIntervalForTest(t, -1)
 	a := openWriter(t, schema)
 	b := openWriter(t, schema)
 
@@ -109,24 +112,26 @@ func TestCrossProcessPropagation(t *testing.T) {
 	require.Equal(t, "FEAT-1", ev.EntityID)
 }
 
-// TestCatchUpRecoversMissedEvents (AC2): a committed write whose live
-// notification was MISSED (simulated by inserting a row directly, bypassing the
-// Go producer's pg_notify) is still recovered by the seq-watermark catch-up that
-// runs on the safety ticker. Uses a short ticker via the test hook.
+// TestCatchUpRecoversMissedEvents (AC2): an ORDINARY committed write whose live
+// notification was suppressed (SetNotifyDisabledForTest — the real producer path
+// runs, just without pg_notify) is still recovered by the seq-watermark catch-up
+// that runs on the safety ticker. This exercises recovery of a genuine write
+// (entity persisted by the Go store, seq assigned by the normal path), not a
+// hand-inserted row — so it proves the catch-up reconciles against real writer
+// state when the live feed drops a notification. Uses a short ticker.
 func TestCatchUpRecoversMissedEvents(t *testing.T) {
 	schema := freshFeedSchema(t)
 	pgstore.SetCatchUpIntervalForTest(t, 200*time.Millisecond)
+	// Suppress the live notification so the catch-up query is the ONLY way B can
+	// learn of the write — isolates the recovery path from the live feed.
+	pgstore.SetNotifyDisabledForTest(t, true)
 
+	a := openWriter(t, schema)
 	b := openWriter(t, schema)
 	ch, cancel := b.Subscribe(16)
 	defer cancel()
 
-	// Insert a row DIRECTLY (no pg_notify) so the only way B learns of it is the
-	// catch-up query — this isolates the recovery path from the live feed.
-	admin := adminConn(t)
-	_, err := admin.Exec(context.Background(),
-		"INSERT INTO "+pgQuoteIdent(schema)+".entities (id, type) VALUES ('REQ-9', 'requirement')")
-	require.NoError(t, err)
+	require.NoError(t, a.CreateEntity(context.Background(), entity.New("REQ-9", "requirement")))
 
 	// The ticker catch-up (200ms) should find and emit REQ-9 within a second or two.
 	ev := waitForEntityEvent(t, ch, "REQ-9", 5*time.Second)
@@ -250,9 +255,9 @@ func TestListenerReconnects(t *testing.T) {
 // not only after the 30s ticker.
 func TestMalformedNotificationTriggersCatchUp(t *testing.T) {
 	schema := freshFeedSchema(t)
-	// Long ticker: if recovery happens it MUST be via the parse-failure
-	// immediate catch-up, not the safety poll.
-	pgstore.SetCatchUpIntervalForTest(t, time.Hour)
+	// Disable the safety poll: if recovery happens it MUST be via the
+	// parse-failure immediate catch-up that the garbage NOTIFY triggers.
+	pgstore.SetCatchUpIntervalForTest(t, -1)
 	b := openWriter(t, schema)
 
 	ch, cancel := b.Subscribe(16)

--- a/tickets/entities/tickets/TKT-WZYWM9.md
+++ b/tickets/entities/tickets/TKT-WZYWM9.md
@@ -75,3 +75,16 @@ trade-offs (`/research` candidate; the approach isn't obvious).
 - Interaction with the in-DB search backend (does it need its own catch-up, or
 does it query live so it's always current?).
 - Connection budget: a dedicated long-lived LISTEN connection per process.
+
+## Post-merge follow-up (#909)
+
+After #898 merged, the pgstore listener tests were hardened so each proves a
+single delivery path in isolation rather than relying on a long timeout to mask
+the other:
+
+- A `notifyDisabled` test hook in the producer suppresses the live `pg_notify`,
+  so the catch-up test recovers a real write through the seq-watermark path
+  (was a hand-inserted row).
+- A non-positive `catchUpInterval` now disables the safety-net poll outright
+  (the listener blocks on the live notification alone), so the live-feed test
+  proves the notification path with no catch-up fallback.


### PR DESCRIPTION
Follow-up to #898. Makes the pgstore listener tests prove one delivery path each, instead of relying on a long timeout to mask the other.

- `notifyDisabled` atomic + `SetNotifyDisabledForTest` hook in the producer (`feed.go`): suppress the live `pg_notify` so the seq-watermark catch-up is the only delivery channel.
- Non-positive `catchUpInterval` now disables the safety-net poll (listener blocks on the live notification alone) instead of hot-spinning an already-expired context.
- `TestCrossProcessPropagation` → live feed in isolation (catch-up off via `-1`).
- `TestCatchUpRecoversMissedEvents` → catch-up in isolation, recovering a *real* `CreateEntity` write with NOTIFY suppressed (was a hand-inserted admin row).
- `TestMalformedNotificationTriggersCatchUp` → `-1` sentinel so recovery must come from the parse-failure immediate catch-up.

Verified: vet clean; affected tests + goroutine-leak test pass; 15x race-clean stress; mutation check (disabling catch-up while NOTIFY suppressed makes the catch-up test fail as expected).