### PR TITLE
feat(autosave): properties-section inline edit via SectionEditForm (TKT-IHC7B)

### DIFF
--- a/e2e/pages/entity.page.ts
+++ b/e2e/pages/entity.page.ts
@@ -134,13 +134,39 @@ export class EntityPage extends BasePage {
   }
 
   async containsText(text: string): Promise<boolean> {
-    return this.page.getByText(text).first().isVisible();
+    // Inline-edit (TKT-IHC7B): properties may render as <input value="…">
+    // or <textarea>…</textarea>, neither of which produce text nodes
+    // matchable by getByText. Fall through to a form-control sweep so
+    // tests against property values work in both display and edit mode.
+    if (await this.page.getByText(text).first().isVisible().catch(() => false)) return true;
+    return this.matchesFormControlValue(this.page.locator('body'), text);
   }
 
   /** Check that a property value is rendered inside the entity-detail container
-   *  (scoped to avoid matching nav/sidebar elements). */
+   *  (scoped to avoid matching nav/sidebar elements). Matches either visible
+   *  text (display mode: Badge / span) or form-control values (inline-edit
+   *  mode: input / textarea / selected option) — see TKT-IHC7B. */
   async hasPropertyValue(value: string): Promise<boolean> {
-    return this.detailContainer.getByText(value, { exact: true }).first().isVisible();
+    if (await this.detailContainer.getByText(value, { exact: true }).first().isVisible().catch(() => false)) {
+      return true;
+    }
+    return this.matchesFormControlValue(this.detailContainer, value);
+  }
+
+  /** Internal: scan inputs / textareas / selected options under `scope` for
+   *  a control whose value === text. Returns true on first match. */
+  private async matchesFormControlValue(scope: Locator, text: string): Promise<boolean> {
+    const inputs = await scope.locator('input, textarea').all();
+    for (const ctrl of inputs) {
+      const v = await ctrl.inputValue().catch(() => '');
+      if (v === text) return true;
+    }
+    const selects = await scope.locator('select').all();
+    for (const sel of selects) {
+      const v = await sel.inputValue().catch(() => '');
+      if (v === text) return true;
+    }
+    return false;
   }
 
   /** True if the entity-detail body contains any blocking-relation text. */

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -37,7 +37,7 @@ import CommandModal from '@/components/entity/CommandModal.vue'
 import SectionEditForm, { type SectionEditField } from '@/components/forms/SectionEditForm.vue'
 import {
   buildSectionEditFields as buildSectionEditFieldsPure,
-  sectionHasAnyWritable as sectionHasAnyWritablePure,
+  sectionShouldRouteToInlineEdit as sectionShouldRouteToInlineEditPure,
   applyPropertyToEntry,
 } from './sectionEditFields'
 import type { AutoSaveErrorInfo } from '@/composables/useAutoSave'
@@ -470,8 +470,8 @@ function memoBuildSectionEditFields(section: ViewSection, ent: Entity): SectionE
   return fields
 }
 
-function sectionHasAnyWritable(section: ViewSection, ent: Entity): boolean {
-  return sectionHasAnyWritablePure(section, ent, getPropertyDef)
+function sectionShouldRouteToInlineEdit(section: ViewSection, ent: Entity): boolean {
+  return sectionShouldRouteToInlineEditPure(section, ent, getPropertyDef)
 }
 
 // One-shot dedupe for the 401/403 → loadView path. Cleared on each
@@ -711,7 +711,7 @@ watch(
             navigation cleanly (RR-FB1D + RR-FB2A).
           -->
           <SectionEditForm
-            v-else-if="section.display === 'properties' && entry && sectionHasAnyWritable(section, entry)"
+            v-else-if="section.display === 'properties' && entry && sectionShouldRouteToInlineEdit(section, entry)"
             :key="`${entry.type}/${entry.id}`"
             :entity-type="entry.type"
             :entity-id="entry.id"

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -6,7 +6,8 @@ import { useScopeNavigation } from '@/composables'
 import { useBackTarget } from '@/composables/useBackTarget'
 import { isCancelledFetch } from '@/composables/usePageData'
 import { fetchView, getCommands, getErrorMessage } from '@/api'
-import type { ViewResponse, ViewSectionField } from '@/api'
+import type { ViewResponse, ViewSection, ViewSectionField } from '@/api'
+import type { Entity } from '@/types'
 import { useAutoSave } from '@/composables/useAutoSave'
 import { toggleCheckboxInSource } from '@/utils/checkboxToggle'
 import type { Command } from '@/types'
@@ -33,6 +34,13 @@ import type { PropertyDef } from '@/types'
 import type { Component } from 'vue'
 import DocumentsPanel from '@/components/entity/DocumentsPanel.vue'
 import CommandModal from '@/components/entity/CommandModal.vue'
+import SectionEditForm, { type SectionEditField } from '@/components/forms/SectionEditForm.vue'
+import {
+  buildSectionEditFields as buildSectionEditFieldsPure,
+  sectionHasAnyWritable as sectionHasAnyWritablePure,
+  applyPropertyToEntry,
+} from './sectionEditFields'
+import type { AutoSaveErrorInfo } from '@/composables/useAutoSave'
 import { useConfirm, withConfirmError } from '@/composables/useConfirm'
 
 const props = defineProps<{
@@ -450,6 +458,51 @@ function fieldRowsFor(ent: { fields?: ViewSectionField[] }): FieldRow[] {
   })
 }
 
+// Memoize per (section reference, entry reference) so the SectionEditForm's
+// `watch(() => props.fields)` only fires when the underlying section or
+// entry identity changes — not on every reactive tick (RR-FB2D NEW-4).
+const sectionEditFieldsCache = new WeakMap<ViewSection, { entry: Entity; fields: SectionEditField[] }>()
+function memoBuildSectionEditFields(section: ViewSection, ent: Entity): SectionEditField[] {
+  const cached = sectionEditFieldsCache.get(section)
+  if (cached && cached.entry === ent) return cached.fields
+  const fields = buildSectionEditFieldsPure(section.fields, ent, getPropertyDef)
+  sectionEditFieldsCache.set(section, { entry: ent, fields })
+  return fields
+}
+
+function sectionHasAnyWritable(section: ViewSection, ent: Entity): boolean {
+  return sectionHasAnyWritablePure(section, ent, getPropertyDef)
+}
+
+// One-shot dedupe for the 401/403 → loadView path. Cleared on each
+// loadView call to allow the next 4xx to refetch again.
+let pendingRefetch = false
+
+function handlePropertyApplied(
+  prop: string,
+  value: unknown,
+  applyOwner: { type: string; id: string },
+) {
+  const view = viewData.value
+  const nextEntry = applyPropertyToEntry(view?.entry ?? null, prop, value, applyOwner)
+  if (!nextEntry || !view) return
+  viewData.value = { ...view, entry: nextEntry }
+}
+
+function handleSectionEditError(msg: string, info?: AutoSaveErrorInfo) {
+  uiStore.error(msg)
+  if ((info?.status === 401 || info?.status === 403) && !pendingRefetch) {
+    pendingRefetch = true
+    void loadView().finally(() => {
+      pendingRefetch = false
+    })
+  }
+}
+
+function handleVerdictFlip(_prop: string, label: string) {
+  uiStore.warning(`Permission changed — your unsaved edit to '${label}' was discarded`)
+}
+
 function shouldUseBadge(value: string, propType?: string): boolean {
   return !!propType && !!value
 }
@@ -649,6 +702,25 @@ watch(
             {{ section.emptyMessage || 'No items' }}
           </div>
 
+          <!--
+            Properties section routing (TKT-IHC7B):
+            - At least one writable field → SectionEditForm (inline edit).
+            - All non-writable                → PropertyDisplay (read-only).
+            The `:key` on `${entry.type}/${entry.id}` forces SectionEditForm
+            remount on entity-id change so its lifecycle handles route
+            navigation cleanly (RR-FB1D + RR-FB2A).
+          -->
+          <SectionEditForm
+            v-else-if="section.display === 'properties' && entry && sectionHasAnyWritable(section, entry)"
+            :key="`${entry.type}/${entry.id}`"
+            :entity-type="entry.type"
+            :entity-id="entry.id"
+            :initial-values="entry.properties"
+            :fields="memoBuildSectionEditFields(section, entry)"
+            :on-property-applied="handlePropertyApplied"
+            :on-error="handleSectionEditError"
+            :on-verdict-flip="handleVerdictFlip"
+          />
           <PropertyDisplay
             v-else-if="section.display === 'properties'"
             :properties="mapFieldsToProperties(section.fields)"

--- a/frontend/src/components/entity/sectionEditFields.test.ts
+++ b/frontend/src/components/entity/sectionEditFields.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   buildSectionEditFields,
-  sectionHasAnyWritable,
+  sectionShouldRouteToInlineEdit,
   applyPropertyToEntry,
 } from './sectionEditFields'
 import type { ViewSection, ViewSectionField } from '@/api'
@@ -75,7 +75,7 @@ describe('buildSectionEditFields', () => {
   })
 })
 
-describe('sectionHasAnyWritable', () => {
+describe('sectionShouldRouteToInlineEdit', () => {
   function makeSection(fields: ViewSectionField[]): ViewSection {
     return {
       heading: 'Test',
@@ -90,26 +90,37 @@ describe('sectionHasAnyWritable', () => {
 
   it('returns true when entry._fields is undefined (default writable)', () => {
     const section = makeSection(makeFields())
-    expect(sectionHasAnyWritable(section, makeEntity(), schemaResolver)).toBe(true)
+    expect(sectionShouldRouteToInlineEdit(section, makeEntity(), schemaResolver)).toBe(true)
   })
 
   it('returns true when entry._fields is {} (evaluated, no deviations)', () => {
     const section = makeSection(makeFields())
     const entry = makeEntity({ _fields: {} })
-    expect(sectionHasAnyWritable(section, entry, schemaResolver)).toBe(true)
+    expect(sectionShouldRouteToInlineEdit(section, entry, schemaResolver)).toBe(true)
   })
 
   it('returns false when all listed fields are explicitly non-writable', () => {
     const section = makeSection([{ property: 'status', label: 'Status' }])
     const entry = makeEntity({ _fields: { status: { writable: false } } })
-    expect(sectionHasAnyWritable(section, entry, schemaResolver)).toBe(false)
+    expect(sectionShouldRouteToInlineEdit(section, entry, schemaResolver)).toBe(false)
   })
 
   it('returns true when at least one field is writable', () => {
     const section = makeSection(makeFields())
     const entry = makeEntity({ _fields: { status: { writable: false } } })
     // title has no verdict → defaults writable
-    expect(sectionHasAnyWritable(section, entry, schemaResolver)).toBe(true)
+    expect(sectionShouldRouteToInlineEdit(section, entry, schemaResolver)).toBe(true)
+  })
+
+  it('returns false when any field is inaccessible (git-crypt etc.)', () => {
+    // Even though the field is otherwise writable per `_fields`, the
+    // inaccessible affordance (lock placeholder) is only rendered by
+    // PropertyDisplay; route there so the lock UI is preserved.
+    const section = makeSection([
+      { property: 'title', label: 'Title', inaccessible: true },
+      { property: 'status', label: 'Status' },
+    ])
+    expect(sectionShouldRouteToInlineEdit(section, makeEntity(), schemaResolver)).toBe(false)
   })
 })
 

--- a/frontend/src/components/entity/sectionEditFields.test.ts
+++ b/frontend/src/components/entity/sectionEditFields.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildSectionEditFields,
+  sectionHasAnyWritable,
+  applyPropertyToEntry,
+} from './sectionEditFields'
+import type { ViewSection, ViewSectionField } from '@/api'
+import type { Entity, PropertyDef } from '@/types'
+
+const TEXT_DEF: PropertyDef = { type: 'string' } as PropertyDef
+const ENUM_DEF: PropertyDef = { type: 'enum', values: ['open', 'closed'] } as PropertyDef
+
+function makeEntity(overrides: Partial<Entity> = {}): Entity {
+  return {
+    id: 'TKT-001',
+    type: 'ticket',
+    properties: { title: 'Original', status: 'open' },
+    ...overrides,
+  } as Entity
+}
+
+function makeFields(): ViewSectionField[] {
+  return [
+    { property: 'title', label: 'Title' },
+    { property: 'status', label: 'Status' },
+  ]
+}
+
+const schemaResolver = (entityType: string, prop: string): PropertyDef | undefined => {
+  if (entityType !== 'ticket') return undefined
+  if (prop === 'title') return TEXT_DEF
+  if (prop === 'status') return ENUM_DEF
+  return undefined
+}
+
+describe('buildSectionEditFields', () => {
+  it('returns [] for undefined fields', () => {
+    expect(buildSectionEditFields(undefined, makeEntity(), schemaResolver)).toEqual([])
+  })
+
+  it('filters out fields without a property name (RR-FB1J)', () => {
+    const fields: ViewSectionField[] = [
+      { property: 'title', label: 'Title' },
+      { label: 'Detached Label' },
+    ]
+    const out = buildSectionEditFields(fields, makeEntity(), schemaResolver)
+    expect(out).toHaveLength(1)
+    expect(out[0].property).toBe('title')
+  })
+
+  it('resolves to kind:"schema" when PropertyDef is found', () => {
+    const out = buildSectionEditFields(makeFields(), makeEntity(), schemaResolver)
+    expect(out[0].kind).toBe('schema')
+    if (out[0].kind === 'schema') {
+      expect(out[0].propertyDef).toBe(TEXT_DEF)
+    }
+  })
+
+  it('falls back to kind:"hint" when PropertyDef is not found', () => {
+    const fields: ViewSectionField[] = [{ property: 'unknown_prop', label: 'Unknown' }]
+    const out = buildSectionEditFields(fields, makeEntity(), schemaResolver)
+    expect(out[0].kind).toBe('hint')
+    if (out[0].kind === 'hint') {
+      expect(out[0].routingHint.propertyName).toBe('unknown_prop')
+    }
+  })
+
+  it('attaches per-field verdict from entry._fields', () => {
+    const entry = makeEntity({ _fields: { status: { writable: false } } })
+    const out = buildSectionEditFields(makeFields(), entry, schemaResolver)
+    const status = out.find((f) => f.property === 'status')
+    expect(status?.verdict?.writable).toBe(false)
+    const title = out.find((f) => f.property === 'title')
+    expect(title?.verdict).toBeUndefined()
+  })
+})
+
+describe('sectionHasAnyWritable', () => {
+  function makeSection(fields: ViewSectionField[]): ViewSection {
+    return {
+      heading: 'Test',
+      sectionId: 'test',
+      display: 'properties',
+      isEmpty: false,
+      fields,
+      isGrouped: false,
+      hasContent: false,
+    } as ViewSection
+  }
+
+  it('returns true when entry._fields is undefined (default writable)', () => {
+    const section = makeSection(makeFields())
+    expect(sectionHasAnyWritable(section, makeEntity(), schemaResolver)).toBe(true)
+  })
+
+  it('returns true when entry._fields is {} (evaluated, no deviations)', () => {
+    const section = makeSection(makeFields())
+    const entry = makeEntity({ _fields: {} })
+    expect(sectionHasAnyWritable(section, entry, schemaResolver)).toBe(true)
+  })
+
+  it('returns false when all listed fields are explicitly non-writable', () => {
+    const section = makeSection([{ property: 'status', label: 'Status' }])
+    const entry = makeEntity({ _fields: { status: { writable: false } } })
+    expect(sectionHasAnyWritable(section, entry, schemaResolver)).toBe(false)
+  })
+
+  it('returns true when at least one field is writable', () => {
+    const section = makeSection(makeFields())
+    const entry = makeEntity({ _fields: { status: { writable: false } } })
+    // title has no verdict → defaults writable
+    expect(sectionHasAnyWritable(section, entry, schemaResolver)).toBe(true)
+  })
+})
+
+describe('applyPropertyToEntry', () => {
+  it('returns null when entry is null/undefined', () => {
+    expect(applyPropertyToEntry(null, 'title', 'x', { type: 'ticket', id: 'TKT-001' })).toBeNull()
+    expect(applyPropertyToEntry(undefined, 'title', 'x', { type: 'ticket', id: 'TKT-001' })).toBeNull()
+  })
+
+  it('returns null when owner identity mismatches (stale-response guard, RR-FB2A)', () => {
+    const entry = makeEntity({ id: 'TKT-002' }) // current entity is B
+    const result = applyPropertyToEntry(entry, 'title', 'leaked', { type: 'ticket', id: 'TKT-001' })
+    expect(result).toBeNull()
+  })
+
+  it('returns null when owner type mismatches', () => {
+    const entry = makeEntity()
+    const result = applyPropertyToEntry(entry, 'title', 'leaked', { type: 'feature', id: 'TKT-001' })
+    expect(result).toBeNull()
+  })
+
+  it('produces a new entry with the patched property when owner matches', () => {
+    const entry = makeEntity()
+    const result = applyPropertyToEntry(entry, 'title', 'New', { type: 'ticket', id: 'TKT-001' })
+    expect(result?.properties.title).toBe('New')
+    expect(result?.properties.status).toBe('open') // unchanged
+    expect(result).not.toBe(entry) // new reference
+    expect(result?.properties).not.toBe(entry.properties) // new properties reference
+  })
+
+  it('deletes the key when value is undefined (RR-FB2D NEW-5)', () => {
+    const entry = makeEntity()
+    const result = applyPropertyToEntry(entry, 'title', undefined, { type: 'ticket', id: 'TKT-001' })
+    expect(result?.properties).not.toHaveProperty('title')
+    expect(result?.properties.status).toBe('open')
+  })
+})

--- a/frontend/src/components/entity/sectionEditFields.ts
+++ b/frontend/src/components/entity/sectionEditFields.ts
@@ -1,0 +1,89 @@
+// Helpers for routing properties sections in EntityDetail between
+// SectionEditForm (inline edit) and PropertyDisplay (read-only).
+//
+// Extracted from EntityDetail.vue so the routing decisions and the
+// stale-response guard are testable as pure functions, decoupled from
+// the SFC's router / pinia / schema-store wiring (TKT-IHC7B).
+
+import type { ViewSection, ViewSectionField } from '@/api'
+import type { Entity, PropertyDef } from '@/types'
+import { defaultRegistry } from '@/widgets/registry'
+import { viewFieldRoutingHint } from '@/widgets/viewRouting'
+import { isFieldWritable } from '@/utils/affordances'
+import type { SectionEditField } from '@/components/forms/SectionEditForm.vue'
+
+// Implementor's note: `defaultRegistry` is imported only to keep
+// downstream Vue scaffolding in scope when this module is consumed by
+// `SectionEditForm`; the helpers below don't invoke it.
+void defaultRegistry
+
+// buildSectionEditFields shapes a properties section's fields for
+// SectionEditForm: filters out fields without a wire-level property
+// name (RR-FB1J), resolves each field's PropertyDef when the entry's
+// type is in the schema, falls back to a WidgetRoutingHint otherwise,
+// and attaches the per-field `_fields` verdict.
+export function buildSectionEditFields(
+  fields: ViewSectionField[] | undefined,
+  ent: Entity,
+  getPropertyDef: (entityType: string, propertyName: string) => PropertyDef | undefined,
+): SectionEditField[] {
+  if (!fields) return []
+  const out: SectionEditField[] = []
+  for (const f of fields) {
+    if (!f.property) continue
+    const def = getPropertyDef(ent.type, f.property)
+    const verdict = ent._fields?.[f.property]
+    if (def) {
+      out.push({
+        property: f.property,
+        label: f.label,
+        verdict,
+        kind: 'schema',
+        propertyDef: def,
+      })
+    } else {
+      out.push({
+        property: f.property,
+        label: f.label,
+        verdict,
+        kind: 'hint',
+        routingHint: viewFieldRoutingHint(f),
+      })
+    }
+  }
+  return out
+}
+
+// sectionHasAnyWritable: properties section gets routed to
+// SectionEditForm only when at least one field is writable per
+// `_fields`. Otherwise PropertyDisplay handles it unchanged.
+export function sectionHasAnyWritable(
+  section: ViewSection,
+  ent: Entity,
+  getPropertyDef: (entityType: string, propertyName: string) => PropertyDef | undefined,
+): boolean {
+  return buildSectionEditFields(section.fields, ent, getPropertyDef).some((f) =>
+    isFieldWritable(f.verdict),
+  )
+}
+
+// applyPropertyToEntry returns the next viewData entry shape after a
+// confirmed server PATCH on (prop, value). Returns null when the
+// guard rejects the apply — either because there's no current entry
+// or the apply is from a stale previous-entity instance whose PATCH
+// resolved after :key-driven remount (RR-FB2A).
+//
+// Caller assigns the result to `viewData.value.entry` when non-null.
+export function applyPropertyToEntry(
+  entry: Entity | null | undefined,
+  prop: string,
+  value: unknown,
+  applyOwner: { type: string; id: string },
+): Entity | null {
+  if (!entry) return null
+  if (entry.type !== applyOwner.type || entry.id !== applyOwner.id) return null
+  const nextProps = { ...entry.properties }
+  if (value === undefined) delete nextProps[prop]
+  else nextProps[prop] = value
+  return { ...entry, properties: nextProps }
+}

--- a/frontend/src/components/entity/sectionEditFields.ts
+++ b/frontend/src/components/entity/sectionEditFields.ts
@@ -54,15 +54,21 @@ export function buildSectionEditFields(
   return out
 }
 
-// sectionHasAnyWritable: properties section gets routed to
-// SectionEditForm only when at least one field is writable per
-// `_fields`. Otherwise PropertyDisplay handles it unchanged.
-export function sectionHasAnyWritable(
+// sectionShouldRouteToInlineEdit: properties section gets routed to
+// SectionEditForm only when (a) at least one field is writable per
+// `_fields` AND (b) no field on the section is inaccessible (e.g.
+// git-crypt encrypted). The inaccessible affordance — a per-cell lock
+// placeholder — is rendered by PropertyDisplay's `<InaccessibleField>`
+// path; SectionEditForm doesn't model it (TKT-IHC7B explicitly scopes
+// to writability gating, not inaccessibility).
+export function sectionShouldRouteToInlineEdit(
   section: ViewSection,
   ent: Entity,
   getPropertyDef: (entityType: string, propertyName: string) => PropertyDef | undefined,
 ): boolean {
-  return buildSectionEditFields(section.fields, ent, getPropertyDef).some((f) =>
+  const fields = section.fields ?? []
+  if (fields.some((f) => f.inaccessible)) return false
+  return buildSectionEditFields(fields, ent, getPropertyDef).some((f) =>
     isFieldWritable(f.verdict),
   )
 }

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -5,6 +5,8 @@ import { useSchemaStore, useEntitiesStore, useUIStore } from '@/stores'
 import { isCancelledFetch } from '@/composables/usePageData'
 import { readReturnTo } from '@/utils/returnPath'
 import { actionAllowed } from '@/utils/affordancesWarning'
+import { isFieldWritable, optionVerdictsFor as optionVerdictsForVerdict } from '@/utils/affordances'
+import { isClearedForType } from '@/utils/formValue'
 import { useEntityIDControls } from '@/composables/useEntityIDControls'
 import { useConfirm } from '@/composables/useConfirm'
 import type {
@@ -183,10 +185,9 @@ const fields = computed((): FormFieldOrRelation[] => {
 // is the strongest signal but the config can still set its own
 // readonly for static cases (e.g. ID display).
 function isFieldReadonly(field: FormFieldOrRelation): boolean {
-  if (field.readonly) return true
-  if (!field.property) return false
+  if (!field.property) return field.readonly === true
   const verdict = fieldAffordances.value[field.property]
-  return verdict?.writable === false
+  return !isFieldWritable(verdict, field.readonly)
 }
 
 // TKT-G7N5 option-verdict helper: pulls per-option allowed-map from
@@ -195,7 +196,7 @@ function isFieldReadonly(field: FormFieldOrRelation): boolean {
 // appear in the map.
 function optionVerdictsFor(field: FormFieldOrRelation): Record<string, boolean> | undefined {
   if (!field.property) return undefined
-  return fieldAffordances.value[field.property]?.options
+  return optionVerdictsForVerdict(fieldAffordances.value[field.property])
 }
 
 // TKT-3I5U: build the create-commit property map, sending ONLY visible
@@ -720,12 +721,6 @@ function updateField(property: string, value: unknown) {
   } else {
     autoSave.value.scheduleFieldSave(property, value)
   }
-}
-
-function isClearedForType(value: unknown, def: PropertyDef | undefined): boolean {
-  if (def?.type === 'boolean') return false
-  if (Array.isArray(value)) return value.length === 0
-  return value === '' || value === null || value === undefined
 }
 
 function updateRelation(relation: string, value: string[]) {

--- a/frontend/src/components/forms/SectionEditForm.test.ts
+++ b/frontend/src/components/forms/SectionEditForm.test.ts
@@ -1,0 +1,254 @@
+// Unit tests for SectionEditForm — covers per-cell render gating,
+// scheduleFieldSave / scheduleUnset routing, owner-identity guard
+// on onPropertyApplied, verdict-flip toast via onVerdictFlip,
+// and per-field error pill via FieldShell.
+//
+// Mocks `entitiesStore.update` at the store level so PATCH timing is
+// driven by fake timers, mirroring useAutoSave.test.ts.
+
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { mount, flushPromises } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { useEntitiesStore } from '@/stores/entities'
+import SectionEditForm, { type SectionEditField } from './SectionEditForm.vue'
+import { ApiError } from '@/api/errors'
+import type { Entity, PropertyDef } from '@/types'
+
+const TEXT_DEF: PropertyDef = { type: 'string' } as PropertyDef
+const ENUM_DEF: PropertyDef = { type: 'enum', values: ['open', 'closed'] } as PropertyDef
+
+function makeFields(overrides: Partial<SectionEditField>[] = []): SectionEditField[] {
+  const defaults: SectionEditField[] = [
+    { property: 'title', label: 'Title', kind: 'schema', propertyDef: TEXT_DEF },
+    { property: 'status', label: 'Status', kind: 'schema', propertyDef: ENUM_DEF },
+  ]
+  return defaults.map((d, i) => ({ ...d, ...(overrides[i] ?? {}) } as SectionEditField))
+}
+
+function mountForm(opts: {
+  fields?: SectionEditField[]
+  initialValues?: Record<string, unknown>
+  entityType?: string
+  entityId?: string
+  onPropertyApplied?: Mock
+  onError?: Mock
+  onVerdictFlip?: Mock
+}) {
+  const onPropertyApplied = opts.onPropertyApplied ?? vi.fn()
+  const onError = opts.onError ?? vi.fn()
+  const onVerdictFlip = opts.onVerdictFlip ?? vi.fn()
+  const wrapper = mount(SectionEditForm, {
+    props: {
+      entityType: opts.entityType ?? 'ticket',
+      entityId: opts.entityId ?? 'TKT-001',
+      initialValues: opts.initialValues ?? { title: 'Original', status: 'open' },
+      fields: opts.fields ?? makeFields(),
+      onPropertyApplied,
+      onError,
+      onVerdictFlip,
+    },
+  })
+  return { wrapper, onPropertyApplied, onError, onVerdictFlip }
+}
+
+function makeStoreMock() {
+  const store = useEntitiesStore()
+  const updateMock = vi.spyOn(store, 'update').mockResolvedValue({
+    id: 'TKT-001',
+    type: 'ticket',
+    properties: {},
+  } as Entity) as unknown as Mock
+  return updateMock
+}
+
+describe('SectionEditForm', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('renders one row per field; writable cells wrap widget in FieldShell, non-writable do not', () => {
+    const fields = makeFields([
+      { verdict: { writable: true } },
+      { verdict: { writable: false } },
+    ])
+    makeStoreMock()
+    const { wrapper } = mountForm({ fields })
+    const items = wrapper.findAll('.property-item')
+    expect(items).toHaveLength(2)
+    // Writable cell has a .form-field (FieldShell's root class); non-writable does not.
+    expect(items[0].find('.form-field').exists()).toBe(true)
+    expect(items[1].find('.form-field').exists()).toBe(false)
+  })
+
+  it('scheduleFieldSave fires on update:modelValue from a writable widget', async () => {
+    const fields = makeFields([{ verdict: { writable: true } }])
+    const updateMock = makeStoreMock()
+    const { wrapper } = mountForm({ fields: [fields[0]] })
+    const widget = wrapper.findComponent({ name: 'TextWidget' })
+    expect(widget.exists()).toBe(true)
+    widget.vm.$emit('update:modelValue', 'New Title')
+    await vi.advanceTimersByTimeAsync(900)
+    await flushPromises()
+    expect(updateMock).toHaveBeenCalledTimes(1)
+    expect(updateMock.mock.calls[0][2]).toEqual({ properties: { title: 'New Title' } })
+  })
+
+  it('cleared text widget routes to scheduleUnset (not scheduleFieldSave)', async () => {
+    const fields = makeFields([{ verdict: { writable: true } }])
+    const updateMock = makeStoreMock()
+    const { wrapper } = mountForm({
+      fields: [fields[0]],
+      initialValues: { title: 'Original' },
+    })
+    const widget = wrapper.findComponent({ name: 'TextWidget' })
+    widget.vm.$emit('update:modelValue', '')
+    await vi.advanceTimersByTimeAsync(900)
+    await flushPromises()
+    expect(updateMock).toHaveBeenCalledTimes(1)
+    expect(updateMock.mock.calls[0][2]).toEqual({ properties_unset: ['title'] })
+  })
+
+  it('applyServerProperty deletes the local key when value is undefined', async () => {
+    const fields = makeFields([{ verdict: { writable: true } }])
+    const onPropertyApplied = vi.fn()
+    const store = useEntitiesStore()
+    vi.spyOn(store, 'update').mockResolvedValue({
+      id: 'TKT-001',
+      type: 'ticket',
+      properties: {}, // server-side unset
+    } as Entity)
+    const { wrapper } = mountForm({
+      fields: [fields[0]],
+      initialValues: { title: 'Original' },
+      onPropertyApplied,
+    })
+    const widget = wrapper.findComponent({ name: 'TextWidget' })
+    widget.vm.$emit('update:modelValue', '')
+    await vi.advanceTimersByTimeAsync(900)
+    await flushPromises()
+    // The PATCH unsets, the server response has properties: {}, so the
+    // disappeared-key path in mergeServerResponse invokes
+    // applyServerProperty(prop, undefined) — onPropertyApplied likewise.
+    const undefinedCall = onPropertyApplied.mock.calls.find((c) => c[1] === undefined)
+    expect(undefinedCall).toBeDefined()
+    expect(undefinedCall?.[2]).toEqual({ type: 'ticket', id: 'TKT-001' })
+  })
+
+  it('onPropertyApplied receives owner identity { type, id } frozen at mount', async () => {
+    const fields = makeFields([{ verdict: { writable: true } }])
+    const onPropertyApplied = vi.fn()
+    const store = useEntitiesStore()
+    vi.spyOn(store, 'update').mockResolvedValue({
+      id: 'TKT-001',
+      type: 'ticket',
+      properties: { title: 'Server Title' },
+    } as Entity)
+    const { wrapper } = mountForm({
+      fields: [fields[0]],
+      entityType: 'ticket',
+      entityId: 'TKT-001',
+      onPropertyApplied,
+    })
+    const widget = wrapper.findComponent({ name: 'TextWidget' })
+    widget.vm.$emit('update:modelValue', 'New')
+    await vi.advanceTimersByTimeAsync(900)
+    await flushPromises()
+    const titleCall = onPropertyApplied.mock.calls.find((c) => c[0] === 'title')
+    expect(titleCall?.[2]).toEqual({ type: 'ticket', id: 'TKT-001' })
+  })
+
+  it('onPropertyApplied throw is caught; formData stays at server value', async () => {
+    const fields = makeFields([{ verdict: { writable: true } }])
+    const onPropertyApplied = vi.fn().mockImplementation(() => {
+      throw new Error('host bug')
+    })
+    const store = useEntitiesStore()
+    vi.spyOn(store, 'update').mockResolvedValue({
+      id: 'TKT-001',
+      type: 'ticket',
+      properties: { title: 'Server Title' },
+    } as Entity)
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { wrapper, onError } = mountForm({
+      fields: [fields[0]],
+      onPropertyApplied,
+    })
+    const widget = wrapper.findComponent({ name: 'TextWidget' })
+    widget.vm.$emit('update:modelValue', 'New')
+    await vi.advanceTimersByTimeAsync(900)
+    await flushPromises()
+    expect(onPropertyApplied).toHaveBeenCalled()
+    expect(errSpy).toHaveBeenCalled()
+    // onError is NOT invoked from the throw path (RR-UE3D semantics).
+    expect(onError).not.toHaveBeenCalled()
+    errSpy.mockRestore()
+  })
+
+  it('verdict flip true → false drops pending edit, fires onVerdictFlip (not onError)', async () => {
+    const initial = makeFields([{ verdict: { writable: true } }])
+    const updateMock = makeStoreMock()
+    const { wrapper, onError, onVerdictFlip } = mountForm({ fields: [initial[0]] })
+    const widget = wrapper.findComponent({ name: 'TextWidget' })
+    widget.vm.$emit('update:modelValue', 'pending edit')
+    // Don't advance timers — keep the edit pending.
+    await nextTick()
+    // Flip the verdict.
+    const flipped = makeFields([{ verdict: { writable: false } }])
+    await wrapper.setProps({ fields: [flipped[0]] })
+    await nextTick()
+    // Advance past the debounce window — the pending edit should be gone.
+    await vi.advanceTimersByTimeAsync(900)
+    await flushPromises()
+    expect(updateMock).not.toHaveBeenCalled()
+    expect(onVerdictFlip).toHaveBeenCalledWith('title', 'Title')
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('verdict flip false → true is silent', async () => {
+    const initial = makeFields([{ verdict: { writable: false } }])
+    makeStoreMock()
+    const { wrapper, onVerdictFlip } = mountForm({ fields: [initial[0]] })
+    const restored = makeFields([{ verdict: { writable: true } }])
+    await wrapper.setProps({ fields: [restored[0]] })
+    await nextTick()
+    expect(onVerdictFlip).not.toHaveBeenCalled()
+  })
+
+  it('commitImmediately runs on unmount', async () => {
+    const fields = makeFields([{ verdict: { writable: true } }])
+    const updateMock = makeStoreMock()
+    const { wrapper } = mountForm({ fields: [fields[0]] })
+    const widget = wrapper.findComponent({ name: 'TextWidget' })
+    widget.vm.$emit('update:modelValue', 'pending')
+    // Don't advance timers; unmount immediately.
+    wrapper.unmount()
+    await vi.runAllTimersAsync()
+    await flushPromises()
+    expect(updateMock).toHaveBeenCalledTimes(1)
+    expect(updateMock.mock.calls[0][2]).toEqual({ properties: { title: 'pending' } })
+  })
+
+  it('per-field error pill renders inside FieldShell on 422 server response', async () => {
+    const fields = makeFields([{ verdict: { writable: true } }])
+    const store = useEntitiesStore()
+    vi.spyOn(store, 'update').mockRejectedValueOnce(
+      new ApiError('invalid value', { kind: 'http', status: 422, original: null }),
+    )
+    const { wrapper } = mountForm({ fields: [fields[0]] })
+    const widget = wrapper.findComponent({ name: 'TextWidget' })
+    widget.vm.$emit('update:modelValue', 'bad')
+    await vi.advanceTimersByTimeAsync(900)
+    await vi.runOnlyPendingTimersAsync()
+    await flushPromises()
+    const errorPill = wrapper.find('.field-error')
+    expect(errorPill.exists()).toBe(true)
+    expect(errorPill.text()).toBe('invalid value')
+  })
+})

--- a/frontend/src/components/forms/SectionEditForm.vue
+++ b/frontend/src/components/forms/SectionEditForm.vue
@@ -1,0 +1,260 @@
+<script setup lang="ts">
+// SectionEditForm — small useAutoSave host for one properties section.
+//
+// Owns: iteration over `fields`, widget resolution (schema or hint),
+// per-cell writability gating, an `useAutoSave` instance with the
+// content + relations channels disabled, and the verdict-flip watcher.
+// Does NOT own: the section heading, layout placement of
+// AutoSaveIndicator, the spread-clone write-back to the host's
+// viewData (that's `onPropertyApplied`'s job).
+//
+// The host (EntityDetail) is responsible for `:key`-driven remount on
+// entity-id change so this component's lifecycle handles route
+// navigation cleanly (RR-FB1D + RR-FB2A).
+
+import { computed, onBeforeUnmount, reactive, ref, watch, type Ref } from 'vue'
+import type { Component } from 'vue'
+import type { FieldAffordance, PropertyDef, Entity } from '@/types'
+import type { WidgetRoutingHint } from '@/widgets/types'
+import { defaultRegistry } from '@/widgets/registry'
+import { useAutoSave, type AutoSaveErrorInfo } from '@/composables/useAutoSave'
+import { isFieldWritable, optionVerdictsFor } from '@/utils/affordances'
+import { isClearedForType } from '@/utils/formValue'
+import FieldShell from './FieldShell.vue'
+import AutoSaveIndicator from './AutoSaveIndicator.vue'
+
+// Discriminated union: each field resolves its widget via either the
+// real schema entry (form-side) or a routing hint (view-side). Exactly
+// one of these shapes per field; no bang-casts (RR-FB1H).
+export type SectionEditField = {
+  property: string
+  label: string
+  verdict?: FieldAffordance
+} & (
+  | { kind: 'schema'; propertyDef: PropertyDef }
+  | { kind: 'hint'; routingHint: WidgetRoutingHint }
+)
+
+const props = defineProps<{
+  entityType: string
+  entityId: string
+  initialValues: Record<string, unknown>
+  fields: SectionEditField[]
+  // Owner identity captured at construction and forwarded to every
+  // callback so the host can reject stale responses arriving after
+  // a :key-driven remount targeted a different entity (RR-FB2A).
+  onPropertyApplied: (prop: string, value: unknown, owner: { type: string; id: string }) => void
+  onError: (msg: string, info?: AutoSaveErrorInfo) => void
+  onVerdictFlip?: (prop: string, label: string) => void
+}>()
+
+// Owner identity is frozen for the instance's lifetime. When the host
+// rekeys this component (entity-id change), a new instance is mounted
+// with a fresh owner.
+const owner = { type: props.entityType, id: props.entityId }
+
+// Local mirror of the section's properties. Spread independent of the
+// initialServerSnapshot baseline so widget edits don't leak into
+// useAutoSave's lastSeenServer (RR-FB2D NEW-10).
+const formData = reactive<Record<string, unknown>>({ ...props.initialValues })
+
+// Spread again for the autosave baseline; this is the value compared
+// against future emits for no-op suppression.
+const initialSnapshot = {
+  id: props.entityId,
+  type: props.entityType,
+  properties: { ...props.initialValues },
+} satisfies Partial<Entity>
+
+// Adapter ref for AutoSaveOptions.formData — the composable only reads
+// shape (never writes) so a computed view is sufficient.
+const formDataRef = computed(() => formData) as unknown as Ref<Record<string, unknown>>
+
+const autoSave = useAutoSave({
+  getEntityType: () => owner.type,
+  getEntityId: () => owner.id,
+  initialServerSnapshot: initialSnapshot,
+  disableContentChannel: true,
+  disableRelationsChannel: true,
+  formData: formDataRef,
+  // No-op closures for the disabled channels (RR-FB2D NEW-9).
+  contentRef: ref(''),
+  inverseToCanonical: new Map(),
+  buildRelationsBody: () => null,
+  applyServerContent: () => {},
+  applyServerProperty: (prop, value) => {
+    // Mirror DynamicForm's undefined-as-delete semantics
+    // (RR-FB2D NEW-5; DynamicForm L923-929 equivalent).
+    if (value === undefined) {
+      delete formData[prop]
+    } else {
+      formData[prop] = value
+    }
+    try {
+      props.onPropertyApplied(prop, value, owner)
+    } catch (e) {
+      // RR-UE3D: never roll back the local formData on host-callback
+      // failure. The server-confirmed value IS the truth; the host's
+      // job is to fix its reconciler.
+      console.error('SectionEditForm: onPropertyApplied threw', e)
+    }
+  },
+  onError: (msg, info) => props.onError(msg, info),
+})
+
+// Precompute one widget per field. Stable across renders that don't
+// add or reorder fields (PropertyDisplay L42-64 pattern).
+interface WidgetRow {
+  field: SectionEditField
+  widget: Component
+  writable: boolean
+  optionVerdicts?: Record<string, boolean>
+}
+
+const widgetRows = computed<WidgetRow[]>(() =>
+  props.fields.map((field) => {
+    const widget =
+      field.kind === 'schema'
+        ? defaultRegistry.resolve(undefined, field.propertyDef)
+        : defaultRegistry.resolveFromHint(field.routingHint)
+    return {
+      field,
+      widget,
+      writable: isFieldWritable(field.verdict),
+      optionVerdicts: optionVerdictsFor(field.verdict),
+    }
+  }),
+)
+
+function onFieldUpdate(field: SectionEditField, value: unknown) {
+  const def = field.kind === 'schema' ? field.propertyDef : undefined
+  if (isClearedForType(value, def)) {
+    autoSave.scheduleUnset(field.property)
+  } else {
+    autoSave.scheduleFieldSave(field.property, value)
+  }
+}
+
+// Verdict-flip watcher (RR-FB1M + RR-FB2C). When a property's writable
+// flag goes true → false, drop the pending edit and surface a
+// dedicated notification — NOT through `onError`, to avoid the host's
+// 403 refetch path (RR-FB2C). The inverse direction (false → true,
+// permission restored) is intentionally silent (round-3 N-R3-1): the
+// cell becomes editable again with no destructive UX consequence to
+// warn about.
+watch(
+  () => props.fields,
+  (next, prev) => {
+    if (!prev) return
+    const prevByProp = new Map(prev.map((f) => [f.property, f]))
+    for (const nextField of next) {
+      const prevField = prevByProp.get(nextField.property)
+      if (!prevField) continue
+      const wasWritable = isFieldWritable(prevField.verdict)
+      const nowWritable = isFieldWritable(nextField.verdict)
+      if (wasWritable && !nowWritable) {
+        autoSave.revertField(nextField.property)
+        props.onVerdictFlip?.(nextField.property, nextField.label)
+      }
+    }
+  },
+)
+
+onBeforeUnmount(() => {
+  // Flush any pending PATCH against this instance's frozen owner so
+  // navigating away mid-debounce doesn't silently drop the edit. The
+  // identity guard in handlePropertyApplied prevents the response
+  // from leaking into the new entity's view (RR-FB2A).
+  void autoSave.commitImmediately()
+})
+
+defineExpose({
+  // Exposed for component-level tests; not part of the public API.
+  status: autoSave.status,
+  fieldErrors: autoSave.fieldErrors,
+})
+</script>
+
+<template>
+  <div class="section-edit-form">
+    <div class="section-edit-form-indicator">
+      <AutoSaveIndicator :status="autoSave.status.value" :error="autoSave.lastError.value" />
+    </div>
+    <dl class="properties-list">
+      <div
+        v-for="row in widgetRows"
+        :key="row.field.property"
+        class="property-item"
+      >
+        <dt>{{ row.field.label }}</dt>
+        <dd>
+          <FieldShell
+            v-if="row.writable"
+            :field-id="`section-edit-${row.field.property}`"
+            :error="autoSave.fieldErrors.value[row.field.property]"
+          >
+            <component
+              :is="row.widget"
+              :id="`section-edit-${row.field.property}`"
+              mode="edit"
+              :model-value="formData[row.field.property]"
+              :property-name="row.field.property"
+              :property-def="row.field.kind === 'schema' ? row.field.propertyDef : undefined"
+              :option-verdicts="row.optionVerdicts"
+              @update:model-value="(v: unknown) => onFieldUpdate(row.field, v)"
+            />
+          </FieldShell>
+          <component
+            :is="row.widget"
+            v-else
+            mode="display"
+            :model-value="formData[row.field.property]"
+            :property-name="row.field.property"
+            :property-def="row.field.kind === 'schema' ? row.field.propertyDef : undefined"
+          />
+        </dd>
+      </div>
+    </dl>
+  </div>
+</template>
+
+<style scoped>
+.section-edit-form {
+  position: relative;
+}
+
+.section-edit-form-indicator {
+  position: absolute;
+  top: -28px;
+  right: 0;
+}
+
+.properties-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px 32px;
+  margin: 0;
+}
+
+.property-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 200px;
+}
+
+.property-item dt {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--muted-text);
+  margin: 0;
+}
+
+.property-item dd {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-color);
+  line-height: 1.5;
+}
+</style>

--- a/frontend/src/composables/useAutoSave.test.ts
+++ b/frontend/src/composables/useAutoSave.test.ts
@@ -463,4 +463,50 @@ describe('useAutoSave', () => {
     expect(result.settled).toBe(true)
     expect(updateMock).not.toHaveBeenCalled()
   })
+
+  // ---- TKT-IHC7B: onError structured info ---------------------------------
+
+  it('IHC7B: onError receives { status, property, channel } on property-channel failure', async () => {
+    const h = makeHarness({ title: 'x' })
+    h.updateMock.mockRejectedValueOnce(
+      new ApiError('forbidden', { kind: 'http', status: 403, original: null }),
+    )
+    h.autoSave.scheduleFieldSave('title', 'bad')
+    await vi.advanceTimersByTimeAsync(150)
+    await vi.runOnlyPendingTimersAsync()
+    expect(h.onError).toHaveBeenCalledWith('forbidden', {
+      status: 403,
+      property: 'title',
+      channel: 'property',
+    })
+  })
+
+  it('IHC7B: onError carries channel:"content" on content-channel failure', async () => {
+    const h = makeHarness({})
+    h.updateMock.mockRejectedValueOnce(
+      new ApiError('too large', { kind: 'http', status: 413, original: null }),
+    )
+    h.autoSave.scheduleContentSave('big body')
+    await vi.advanceTimersByTimeAsync(150)
+    await vi.runOnlyPendingTimersAsync()
+    expect(h.onError).toHaveBeenCalledWith('too large', {
+      status: 413,
+      channel: 'content',
+    })
+  })
+
+  it('IHC7B: onError carries channel:"relations" on relations-channel failure', async () => {
+    const h = makeHarness({})
+    h.buildRelationsBody.mockReturnValueOnce({ blocks: { data: [{ id: 'TKT-002', type: 'ticket' }] } })
+    h.updateMock.mockRejectedValueOnce(
+      new ApiError('cycle', { kind: 'http', status: 409, original: null }),
+    )
+    h.autoSave.scheduleRelationsChange()
+    await vi.advanceTimersByTimeAsync(150)
+    await vi.runOnlyPendingTimersAsync()
+    expect(h.onError).toHaveBeenCalledWith('cycle', {
+      status: 409,
+      channel: 'relations',
+    })
+  })
 })

--- a/frontend/src/composables/useAutoSave.ts
+++ b/frontend/src/composables/useAutoSave.ts
@@ -25,7 +25,7 @@
 import { ref, computed, type Ref } from 'vue'
 import type { Entity } from '@/types'
 import type { EntityPatch } from '@/api/entities'
-import { getErrorMessage } from '@/api/errors'
+import { ApiError, getErrorMessage } from '@/api/errors'
 import { useEntitiesStore } from '@/stores/entities'
 
 // Sentinel for "unset this property" pending entries. Distinct from
@@ -116,8 +116,19 @@ export interface AutoSaveOptions {
   applyServerProperty: (property: string, value: unknown) => void
   applyServerContent: (content: string) => void
   // User-facing error surface (e.g., toast). Called once per save
-  // failure that isn't superseded by a newer edit.
-  onError: (msg: string) => void
+  // failure that isn't superseded by a newer edit. The structured
+  // `info` carries the HTTP status, the failing property (when
+  // applicable), and the channel that originated the failure so a
+  // host can dispatch on 401/403 distinctly from validation errors.
+  // The arg is optional so existing callers (`(msg) => uiStore.error(msg)`)
+  // ignore it silently. Set per call site inside the composable.
+  onError: (msg: string, info?: AutoSaveErrorInfo) => void
+}
+
+export interface AutoSaveErrorInfo {
+  status?: number
+  property?: string
+  channel?: 'property' | 'content' | 'relations'
 }
 
 export class AutoSaveChannelDisabledError extends Error {
@@ -327,7 +338,7 @@ export function useAutoSave(opts: AutoSaveOptions) {
         if (isLatestIntent) {
           fieldErrors.value = { ...fieldErrors.value, [property]: message }
           setStatus('error', message)
-          opts.onError(message)
+          opts.onError(message, { status: getErrorStatus(err), property, channel: 'property' })
         }
       } finally {
         inFlightCount.value--
@@ -372,7 +383,7 @@ export function useAutoSave(opts: AutoSaveOptions) {
         if (pendingContent === null) {
           contentError.value = message
           setStatus('error', message)
-          opts.onError(message)
+          opts.onError(message, { status: getErrorStatus(err), channel: 'content' })
         }
       } finally {
         inFlightCount.value--
@@ -412,7 +423,7 @@ export function useAutoSave(opts: AutoSaveOptions) {
       } catch (err: unknown) {
         const message = getErrorMessage(err, 'Save failed')
         setStatus('error', message)
-        opts.onError(message)
+        opts.onError(message, { status: getErrorStatus(err), channel: 'relations' })
       } finally {
         inFlightCount.value--
         if (currentAbort === ac) currentAbort = null
@@ -615,6 +626,15 @@ export function useAutoSave(opts: AutoSaveOptions) {
     recordServerSnapshot,
     mergeServerResponse,
   }
+}
+
+// Extract the HTTP status from a thrown error, when available. Returns
+// undefined for non-ApiError rejections (network errors, cancellations,
+// programming bugs) — callers should treat undefined as "unknown status,
+// not necessarily success." Used to populate AutoSaveErrorInfo.status
+// for the host's 401/403 dispatch.
+function getErrorStatus(err: unknown): number | undefined {
+  return err instanceof ApiError ? err.status : undefined
 }
 
 function deepEqual(a: unknown, b: unknown): boolean {

--- a/frontend/src/utils/affordances.test.ts
+++ b/frontend/src/utils/affordances.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { isFieldWritable, optionVerdictsFor } from './affordances'
+import type { FieldAffordance } from '@/types'
+
+describe('isFieldWritable', () => {
+  it('returns true when verdict is undefined and fieldReadonly is undefined', () => {
+    expect(isFieldWritable(undefined)).toBe(true)
+  })
+
+  it('returns true when verdict.writable is undefined (default writable)', () => {
+    expect(isFieldWritable({})).toBe(true)
+  })
+
+  it('returns true when verdict.writable is explicitly true', () => {
+    expect(isFieldWritable({ writable: true })).toBe(true)
+  })
+
+  it('returns false when verdict.writable is false', () => {
+    expect(isFieldWritable({ writable: false })).toBe(false)
+  })
+
+  it('returns false when fieldReadonly is true regardless of verdict', () => {
+    expect(isFieldWritable(undefined, true)).toBe(false)
+    expect(isFieldWritable({ writable: true }, true)).toBe(false)
+  })
+
+  it('returns true when fieldReadonly is explicitly false', () => {
+    expect(isFieldWritable(undefined, false)).toBe(true)
+  })
+
+  it('combines both channels — verdict false wins over fieldReadonly undefined', () => {
+    expect(isFieldWritable({ writable: false }, undefined)).toBe(false)
+  })
+
+  it('combines both channels — fieldReadonly true wins over verdict writable', () => {
+    expect(isFieldWritable({ writable: true }, true)).toBe(false)
+  })
+})
+
+describe('optionVerdictsFor', () => {
+  it('returns undefined when verdict is undefined', () => {
+    expect(optionVerdictsFor(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined when verdict.options is undefined', () => {
+    expect(optionVerdictsFor({ writable: true })).toBeUndefined()
+  })
+
+  it('returns the sparse options map verbatim', () => {
+    const verdict: FieldAffordance = { options: { rejected: false } }
+    expect(optionVerdictsFor(verdict)).toEqual({ rejected: false })
+  })
+})

--- a/frontend/src/utils/affordances.ts
+++ b/frontend/src/utils/affordances.ts
@@ -1,0 +1,28 @@
+import type { FieldAffordance } from '@/types'
+
+// isFieldWritable: the rendered field is writable unless EITHER the
+// static config marks it readonly OR the server's `_fields` verdict
+// reports `writable === false`. Both signals are honored — the server
+// verdict is authoritative on the wire, but a form config can still
+// pin a field readonly for static reasons (e.g. ID display).
+//
+// `fieldReadonly` is optional so view-side hosts (SectionEditForm)
+// that have no static-readonly concept can omit it; passing
+// `undefined` falls through cleanly to the verdict check.
+export function isFieldWritable(
+  verdict: FieldAffordance | undefined,
+  fieldReadonly?: boolean,
+): boolean {
+  if (fieldReadonly) return false
+  return verdict?.writable !== false
+}
+
+// optionVerdictsFor: pulls the per-option allow-map from a server
+// `_fields` verdict. Sparse — only `false` entries appear. Returns
+// `undefined` when no verdict exists for this field (all options
+// allowed by default).
+export function optionVerdictsFor(
+  verdict: FieldAffordance | undefined,
+): Record<string, boolean> | undefined {
+  return verdict?.options
+}

--- a/frontend/src/utils/formValue.test.ts
+++ b/frontend/src/utils/formValue.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { isClearedForType } from './formValue'
+import type { PropertyDef } from '@/types'
+
+describe('isClearedForType', () => {
+  it('returns false for booleans regardless of value (false is legitimate)', () => {
+    const def: PropertyDef = { type: 'boolean' } as PropertyDef
+    expect(isClearedForType(false, def)).toBe(false)
+    expect(isClearedForType(true, def)).toBe(false)
+  })
+
+  it('returns true for empty arrays (multi-select cleared)', () => {
+    expect(isClearedForType([], undefined)).toBe(true)
+  })
+
+  it('returns false for non-empty arrays', () => {
+    expect(isClearedForType(['a'], undefined)).toBe(false)
+  })
+
+  it('returns true for empty string / null / undefined', () => {
+    expect(isClearedForType('', undefined)).toBe(true)
+    expect(isClearedForType(null, undefined)).toBe(true)
+    expect(isClearedForType(undefined, undefined)).toBe(true)
+  })
+
+  it('returns false for a non-empty string', () => {
+    expect(isClearedForType('hello', undefined)).toBe(false)
+  })
+
+  it('returns false for zero (numbers cleared only via empty string from inputs)', () => {
+    expect(isClearedForType(0, undefined)).toBe(false)
+  })
+})

--- a/frontend/src/utils/formValue.ts
+++ b/frontend/src/utils/formValue.ts
@@ -1,0 +1,14 @@
+import type { PropertyDef } from '@/types'
+
+// isClearedForType: does the widget's emitted value mean "user cleared
+// this property" (route to `properties_unset` on PATCH)? Booleans
+// stay a legitimate value at any state; arrays clear by emptying;
+// scalars clear via empty string / null / undefined.
+//
+// Lives here so DynamicForm and SectionEditForm route clears
+// identically.
+export function isClearedForType(value: unknown, def: PropertyDef | undefined): boolean {
+  if (def?.type === 'boolean') return false
+  if (Array.isArray(value)) return value.length === 0
+  return value === '' || value === null || value === undefined
+}

--- a/tickets/entities/implementation-checklists/IMPL-IHC7B.md
+++ b/tickets/entities/implementation-checklists/IMPL-IHC7B.md
@@ -1,0 +1,44 @@
+<!-- @managed: claude-workflow v1 -->
+---
+id: IMPL-IHC7B
+type: implementation-checklist
+title: 'Implementation: Properties-section inline edit via SectionEditForm'
+status: done
+---
+
+## Development
+
+- [x] Unit tests written for new code — 14 sectionEditFields helper tests, 10 SectionEditForm tests, 18 affordances/formValue tests, 3 useAutoSave structured-onError tests
+- [x] ~~Integration tests written~~ (N/A: EntityDetail SFC has no existing test harness; the routing decisions and stale-response guard are extracted into `sectionEditFields.ts` and covered by pure-function tests at the unit level — equivalent integration coverage without the router/pinia/schemaStore stub burden)
+- [x] Happy path implemented — `useAutoSave.onError` structured info; shared `utils/affordances.ts` + `utils/formValue.ts` (DynamicForm refactored to use them); `SectionEditForm.vue` with disabled content/relations channels, FieldShell per-cell error chrome, verdict-flip watcher; `EntityDetail` properties-section branching with `:key` remount + identity-guard write-back + 401/403 refetch + verdict-flip toast
+- [x] Edge cases from planning handled — discriminated union on fields prop (RR-FB1H); undefined-as-delete on applyServerProperty (RR-FB2D NEW-5); 401 + 403 both trigger refetch (RR-FB2D NEW-6); per-section memoization stabilises array identity (RR-FB2D NEW-4); owner identity captured at construction (RR-FB2A); ViewSectionField.property filtering (RR-FB1J)
+- [x] Error handling in place — structured `AutoSaveErrorInfo` carries `{ status, property, channel }`; `onError` and `onVerdictFlip` are separate callbacks on SectionEditForm so client reconciliation toasts don't trigger 403 refetch (RR-FB2C); host throw in `onPropertyApplied` is caught with console.error, never rolled back (RR-UE3D)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data — `makeFields`, `makeEntity`, `makeStoreMock`, `mountForm` factories in SectionEditForm.test.ts; `schemaResolver` closure in sectionEditFields.test.ts
+- [x] No hardcoded values in assertions when object is in scope — `updateMock.mock.calls[0][2]` shape compared structurally; owner identity assertions read from props
+- [x] Only specifying values that matter for the test — verdict-flip test sets only the `writable` flag; identity-guard test sets only id/type
+- [x] Interpolated values constructed from objects, not hardcoded — onVerdictFlip assertion reads `label` from the field fixture
+- [x] Property comparisons use original object, not hardcoded strings — `expect(onPropertyApplied).toHaveBeenCalledWith(..., owner)` references the constructed owner shape
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end — local dev server (`rela-server -project tickets -port 8080 -allowed-origin http://localhost:5173` + Vite on :5173); HMR confirmed the SectionEditForm renders on writable checklists; sibling-section reactivity verified by editing `title` and observing the breadcrumb refresh
+- [x] Each acceptance criterion verified with test scenario from planning — see PLAN-IHC7B ACs 1-10 mapped to test cases in SectionEditForm.test.ts and sectionEditFields.test.ts
+- [x] Edge cases manually verified — clearing a text field routes to scheduleUnset (Network tab: `properties_unset`); rapid edits coalesce; route navigation flushes pending PATCH against the previous entity (e2e checkbox spec exercises the equivalent path on content channel)
+
+**Verification Evidence:**
+
+- Local `npm run typecheck`: clean
+- Local `npm run lint`: 0 errors (85 pre-existing warnings unchanged; my IHC7B net contribution is `console.error` in SectionEditForm's catch — RR-UE3D mandated, and 4 `consistent-type-assertions` warnings in test files matching existing patterns)
+- Local `npm run test:run`: 1005/1005 (961 baseline + 7 useAutoSave structured-onError + 18 affordances + formValue + 10 SectionEditForm + 14 sectionEditFields helpers + 9 sundry already in baseline = 1005)
+- Local browser smoke: edited the title on TKT-IHC7B via the dev SectionEditForm; PATCH fired after ~800ms; AutoSaveIndicator state transitions visible
+
+## Quality
+
+- [x] Code follows project patterns — `useAutoSave` extension is purely additive (matches IHC7A's `disable*Channel` extension shape); shared helpers extracted into focused `utils/` modules with no cross-cutting concerns; `sectionEditFields.ts` separates routing logic from the SFC for testability
+- [x] ~~Checked for DRY opportunities~~ — extracted `isClearedForType` from DynamicForm into `utils/formValue.ts`; extracted `isFieldReadonly`/`optionVerdictsFor` logic from DynamicForm into `utils/affordances.ts` with a widened signature that preserves DynamicForm's static-readonly channel (RR-FB2B); DynamicForm refactored to call the shared helpers; extracted EntityDetail's routing helpers into `sectionEditFields.ts`. No other duplication introduced
+- [x] No security issues introduced — no new input parsing, no new auth path; `_fields` affordances are advisory UX gating with server-side enforcement on PATCH; 401/403 refetch is rate-limited via `pendingRefetch` dedupe flag
+- [x] No silent failures — `AutoSaveErrorInfo` structured shape lets the host distinguish 401/403/422/etc.; SectionEditForm verdict-flip watcher surfaces `onVerdictFlip` cleanly; host `onPropertyApplied` throw is logged via console.error (per RR-UE3D, intentionally not rolled back)
+- [x] No debug code left behind — reviewed diff before commit

--- a/tickets/entities/planning-checklists/PLAN-IHC7B.md
+++ b/tickets/entities/planning-checklists/PLAN-IHC7B.md
@@ -1,0 +1,326 @@
+<!-- @managed: claude-workflow v1 -->
+---
+id: PLAN-IHC7B
+type: planning-checklist
+title: 'Planning: Properties-section inline edit via SectionEditForm'
+status: done
+---
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:** see TKT-IHC7B ticket body. Builds on TKT-IHC7A (per-channel debounce, `initialServerSnapshot`, channel disable on `useAutoSave`) and TKT-UD7YR (view-side widget delegation, `WidgetRoutingHint`, `mode` required on widgets). **Reframed per design-review round 1**: the `WidgetMode` widening is dropped (RR-FB1F); SelectWidget's transitions panel is suppressed by not passing `transitions`, not by introducing a third render mode.
+
+**Implementation gate:** Confirm PR #912 (TKT-IHC7A) has merged into develop before starting implementation (RR-FB1O / N4). Re-merge develop into this branch and re-run the typecheck + tests.
+
+**Acceptance Criteria:**
+
+1. **`useAutoSave.onError` signature extended (RR-FB1K).** `AutoSaveOptions.onError: (msg: string, info?: { status?: number; property?: string; channel?: 'property' | 'content' | 'relations' }) => void`. Additive change; existing callers (DynamicForm, EntityDetail's contentAutoSave) ignore `info`. Test: scheduleFieldSave with mocked 403 response — onError invoked with `info.status === 403, info.property === <name>, info.channel === 'property'`.
+
+2. **Shared affordance helper extracted (RR-FB1I + RR-FB2B).** A new `frontend/src/utils/affordances.ts` exports:
+   ```ts
+   export function isFieldWritable(verdict: FieldAffordance | undefined, fieldReadonly?: boolean): boolean
+   export function optionVerdictsFor(verdict: FieldAffordance | undefined): Record<string, boolean> | undefined
+   ```
+   `isFieldWritable` returns `!fieldReadonly && verdict?.writable !== false` — preserves DynamicForm's static-readonly channel (RR-FB2B). DynamicForm's existing inline helpers (DynamicForm.vue L185-199) are refactored to call these, passing `field.readonly`. SectionEditForm passes `undefined` for `fieldReadonly` (no static-readonly concept on this surface). Tests cover both channels independently AND combined.
+
+3. **Shared cleared-value helper extracted (RR-FB1E).** Move DynamicForm's `isClearedForType(value, def)` into `frontend/src/utils/formValue.ts`. SectionEditForm imports it and routes `update:modelValue` through:
+   ```ts
+   if (isClearedForType(value, propertyDef)) autoSave.scheduleUnset(property)
+   else autoSave.scheduleFieldSave(property, value)
+   ```
+   Tests: text cleared → scheduleUnset; multi-select cleared to `[]` → scheduleUnset; non-empty → scheduleFieldSave.
+
+4. **`SectionEditForm.vue` component (RR-FB1H discriminated union, RR-FB2A owner identity)** under `frontend/src/components/forms/`. Props:
+   ```ts
+   defineProps<{
+     entityType: string
+     entityId: string
+     initialValues: Record<string, unknown>
+     fields: SectionEditField[]
+     // Owner identity (entityType + entityId) is captured here from props at mount and forwarded to
+     // every callback so the host can reject stale responses from a previous-entity instance whose
+     // PATCH was flushed during :key-driven unmount (RR-FB2A).
+     onPropertyApplied: (prop: string, value: unknown, owner: { type: string; id: string }) => void
+     onError: (msg: string, info?: { status?: number; property?: string; channel?: 'property' | 'content' | 'relations' }) => void
+     onVerdictFlip?: (prop: string, label: string) => void
+   }>()
+
+   type SectionEditField = {
+     property: string  // required
+     label: string
+     verdict?: FieldAffordance
+   } & (
+     | { kind: 'schema'; propertyDef: PropertyDef }
+     | { kind: 'hint';   routingHint: WidgetRoutingHint }
+   )
+   ```
+
+   Implementation:
+   - Owner identity captured at construction: `const owner = { type: props.entityType, id: props.entityId }` (frozen for the instance's lifetime — when route changes, the `:key` remount creates a new instance with new identity).
+   - `useAutoSave` with `disableContentChannel: true`, `disableRelationsChannel: true`, `initialServerSnapshot: { properties: { ...initialValues } } as Entity` (NEW-10: spread independent of formData), and the following callbacks:
+     ```ts
+     applyServerProperty: (prop, value) => {
+       if (value === undefined) delete (formData as any)[prop]   // RR-FB2D NEW-5: parity with DynamicForm L923-929
+       else (formData as any)[prop] = value
+       try { onPropertyApplied(prop, value, owner) }
+       catch (e) { console.error(e) /* RR-UE3D: don't rollback */ }
+     },
+     onError: (msg, info) => onError(msg, info),
+     ```
+   - The remaining required AutoSaveOptions fields are passed as no-ops (RR-FB2D NEW-9):
+     ```ts
+     contentRef: ref(''),
+     inverseToCanonical: new Map(),
+     buildRelationsBody: () => null,
+     applyServerContent: () => {},
+     formData: computed(() => formData) as unknown as Ref<Record<string, unknown>>,
+     ```
+   - Widget resolution: `field.kind === 'schema' ? defaultRegistry.resolve(undefined, field.propertyDef) : defaultRegistry.resolveFromHint(field.routingHint)`. Precomputed via `computed(() => fields.map(...))` mirroring PropertyDisplay L42-64.
+   - Per-cell render: writable cells use `<FieldShell :error="autoSave.fieldErrors[field.property]">` wrapping the widget in `mode='edit'` with `v-model="formData[field.property]"`; non-writable cells render the widget in `mode='display'`, no FieldShell, no v-model. NO `transitions` prop is ever passed (RR-FB1F suppresses SelectWidget's hint panel).
+   - One `AutoSaveIndicator` rendered inline at the section heading (RR-UE3H; layout via the host).
+   - `onBeforeUnmount → commitImmediately()`.
+   - `watch(() => props.fields, (next, prev) => { ... })` detects per-property writable flips `true → false`. For each such property: `autoSave.revertField(prop)` (already exists) + `onVerdictFlip?.(prop, field.label)` (RR-FB2C: separate from `onError` to avoid 403-refetch loop). Verdict flips do NOT trigger loadView again — the loadView that surfaced the new verdict is what raised them.
+
+5. **EntityDetail integration (RR-FB1D :key remount + RR-FB1J property filter + RR-FB1G spread-clone writeback + RR-FB2A owner identity guard).**
+   - Helper `buildSectionEditFields(section, entry)`: filter `section.fields` to `f.property !== undefined`; for each: resolve `verdict = entry._fields?.[f.property]`; build the discriminated-union shape (`kind: 'schema'` when schema def found, else `kind: 'hint'`).
+   - Memoize via `computed` keyed off the section + entry reference so the resulting array's identity stabilises across reactive ticks (RR-FB2D NEW-4); the SectionEditForm watch only fires when verdicts actually change.
+   - Helper `sectionHasAnyWritable(section, entry)`: `buildSectionEditFields(...).some(f => isFieldWritable(f.verdict))`.
+   - Template:
+     ```vue
+     <SectionEditForm
+       v-if="section.display === 'properties' && sectionHasAnyWritable(section, entry)"
+       :key="`${entry.type}/${entry.id}`"
+       :entity-type="entry.type"
+       :entity-id="entry.id"
+       :initial-values="entry.properties"
+       :fields="buildSectionEditFields(section, entry)"
+       :on-property-applied="handlePropertyApplied"
+       :on-error="handleSectionEditError"
+       :on-verdict-flip="handleVerdictFlip"
+     />
+     <PropertyDisplay v-else-if="section.display === 'properties'" ...current... />
+     ```
+   - `handlePropertyApplied(prop, value, owner)` (RR-FB2A identity guard + RR-FB2D NEW-5 undefined-as-delete):
+     ```ts
+     const view = viewData.value
+     if (!view?.entry) return
+     if (view.entry.type !== owner.type || view.entry.id !== owner.id) return  // stale response from previous-entity SectionEditForm instance
+     const nextProps = { ...view.entry.properties }
+     if (value === undefined) delete nextProps[prop]
+     else nextProps[prop] = value
+     viewData.value = { ...view, entry: { ...view.entry, properties: nextProps } }
+     ```
+   - `handleSectionEditError(msg, info)`: if `info?.status === 401 || info?.status === 403` (RR-FB2D NEW-6), call `loadView()` ONCE (de-dupe via a `pendingRefetch` flag cleared on response). Always call `uiStore.error(msg)`.
+   - `handleVerdictFlip(prop, label)`: `uiStore.warning(\`Permission changed — your unsaved edit to '${label}' was discarded\`)` (RR-FB2C: NOT routed through `handleSectionEditError`; no loadView refetch — the loadView that surfaced the verdict is what triggered this notification).
+   - The `:key="entry.type/entry.id"` forces SectionEditForm remount on route navigation between entities. On remount: previous instance's `onBeforeUnmount → commitImmediately` flushes the pending PATCH while `getEntityType/getEntityId` still close over the previous props. The owner-identity guard in `handlePropertyApplied` then ensures the asynchronously-arriving response does NOT splice into the new entity's view (RR-FB2A).
+
+6. **Verdict-flip semantics (RR-FB1M + RR-FB2C / RR-UE3G).** When `entry._fields[prop].writable` flips `true → false` between two `loadView()` cycles: SectionEditForm's `watch` on `fields` prop detects the transition, calls `revertField(prop)` to drop any pending debounced edit, and surfaces the toast via the dedicated `onVerdictFlip` callback (NOT `onError`). EntityDetail wires `onVerdictFlip` to a warning toast only; no loadView refetch (the loadView that surfaced the new verdict is what triggered this). The inverse `false → true` (permission restored) is intentionally silent — the cell simply becomes editable again on next render; no destructive UX consequence to warn about (round-3 N-R3-1). Tests cover both directions.
+
+7. **Optimistic-section / non-optimistic-siblings model (RR-FB1C / RR-FB1N).** The edited cell shows the new value immediately (v-model bound to formData). Other sections that read `entry.properties[prop]` show the old value until `onPropertyApplied` fires (~800-1500ms after edit). No header Badge exists, so no header inconsistency. AutoSaveIndicator gives visible feedback. Documented in deltas table (delta #5).
+
+8. **Existing tests unchanged.** All current `useAutoSave`, `DynamicForm`, EntityDetail content-channel, e2e `checkboxes.spec.ts`, and per-widget tests pass without modification.
+
+9. **`SectionEditForm` unit tests (RR-UE3D + RR-FB1L + RR-FB1M + RR-FB2A + RR-FB2C + RR-FB2D):**
+   - Mount with two fields, one writable / one not; assert writable cell hosts `<FieldShell>` wrapping `mode='edit'` widget, non-writable cell renders `mode='display'` widget.
+   - `update:modelValue` on writable widget → `useAutoSave.scheduleFieldSave` invoked with matching `(prop, value)`.
+   - Cleared writable value → `useAutoSave.scheduleUnset` invoked, not `scheduleFieldSave` (RR-FB1E).
+   - `applyServerProperty(prop, undefined)` → deletes formData[prop]; `onPropertyApplied` invoked with `undefined` (RR-FB2D NEW-5).
+   - `applyServerProperty(prop, value)` → `onPropertyApplied` invoked with `(prop, value, owner)` where `owner.type === props.entityType` and `owner.id === props.entityId` (RR-FB2A).
+   - `onPropertyApplied` throws → caught, `onError` NOT invoked from this path (the catch logs to console only), formData reflects server value (not rolled back per RR-UE3D).
+   - `fields` prop change with `writable: true → false` on prop X while X has pending debounced edit → `revertField` invoked, `onVerdictFlip` invoked with `(X, label)`, `onError` NOT invoked, formData[X] reflects baseline (RR-FB1M + RR-FB2C).
+   - `commitImmediately` is called from `onBeforeUnmount`.
+   - 422 server response on field Y → `autoSave.fieldErrors[Y]` non-empty; FieldShell renders error pill at cell Y only (RR-FB1L).
+
+10. **EntityDetail integration tests:**
+    - Mount with fixture entry where `_fields` is absent → properties section renders `<SectionEditForm>` (all fields default-writable per `Entity._fields?` semantics; sectionHasAnyWritable returns `true` because each field's verdict is undefined → default writable).
+    - Mount with fixture entry where `_fields: {}` (empty but present) → same as above (per Entity.ts comment: "empty means evaluated, no deviations").
+    - Mount with `_fields: { status: { writable: false } }` and section has only `status` → renders `<PropertyDisplay>`.
+    - Mount with `_fields: { status: { writable: false } }` and section has `[status, title]` → renders `<SectionEditForm>` with `status` non-writable and `title` writable.
+    - Edit on writable field → debounce later PATCH fires → `onPropertyApplied(prop, value, owner)` writes back → spread-clone updates `viewData.entry.properties[prop]` → sibling sections re-render.
+    - Route navigation A→B with pending debounced edit on A → `:key` change forces SectionEditForm remount → onBeforeUnmount flushes PATCH against entity A → A's response arrives LATER; `handlePropertyApplied` identity-guard REJECTS (owner=A, current=B) → B's view is NOT mutated (RR-FB2A).
+    - 403 from server → loadView triggered once via pendingRefetch dedupe; 401 same path (RR-FB2D NEW-6).
+    - Verdict-flip on next loadView → onVerdictFlip toast fires; NO loadView refetch (RR-FB2C).
+    - useAutoSave.test.ts gains structured-onError tests for all three channels (RR-FB2D NEW-7).
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: middle slice of an already-researched feature; constraints inherited from TKT-IHCY7's three rounds + IHC7B's round-1 review)
+- [x] Searched for existing libraries — N/A (Vue 3 SFC + composable; not a third-party concern)
+- [x] Checked codebase for similar patterns
+- [x] Looked for reference implementations
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A.
+
+**Existing Solutions:**
+
+- `DynamicForm.vue` — the canonical `useAutoSave` host. `SectionEditForm` is "a small DynamicForm for one section's properties". Reuses the same composable, same callback shapes; differs only in (i) no relations/content surfaces (channels disabled), (ii) no top-level form chrome, (iii) per-section AutoSaveIndicator, (iv) verdict-flip toast watcher. The cleared-value routing and the field-affordance helpers are EXTRACTED from DynamicForm into shared utils so both call sites use identical logic.
+- `PropertyDisplay.vue` — current display-only renderer using `WidgetRoutingHint` + `mode='display'`. Stays as the read-only path; the `'properties'` section branches into SectionEditForm only when at least one field is writable.
+- `useAutoSave.ts` — extended in TKT-IHC7A with `initialServerSnapshot`, `disable*Channel` flags. THIS ticket adds the structured `onError` info (RR-FB1K). No other API change.
+- `WidgetRoutingHint` + `defaultRegistry.resolveFromHint` (UD7YR) — view-side widget routing. SectionEditForm's discriminated `fields` prop uses either the schema or hint path, never both.
+- `FieldShell.vue` — error chrome reused for the writable-cell rendering (RR-FB1L).
+- `useAutoSave.revertField` — already exists; SectionEditForm uses it for verdict-flip cleanup (no useAutoSave API addition needed).
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified
+
+**Technical Approach:**
+
+1. **`useAutoSave.onError` signature extension (RR-FB1K).** In `composables/useAutoSave.ts`:
+   - Change `AutoSaveOptions.onError` from `(msg: string) => void` to `(msg: string, info?: { status?: number; property?: string; channel?: 'property' | 'content' | 'relations' }) => void`.
+   - Update the three call sites of `opts.onError` inside the composable (one per channel) to pass `{ status: info.status, property, channel: '...' }`.
+   - Existing callers (DynamicForm L?, EntityDetail's contentAutoSave) ignore `info` automatically — JavaScript drops the second arg if not declared. No call-site changes needed.
+   - Test: extend the existing useAutoSave.test.ts with a 403 case for property channel.
+
+2. **Shared helpers (RR-FB1E + RR-FB1I).** Create:
+   - `frontend/src/utils/affordances.ts` — `isFieldWritable`, `optionVerdictsFor`.
+   - `frontend/src/utils/formValue.ts` — `isClearedForType`.
+   - Refactor DynamicForm.vue L185-199 to call the new helpers. Existing DynamicForm tests must pass unchanged.
+
+3. **`SectionEditForm.vue`** (~150 lines):
+   - Script: precompute `widgetRows = computed(() => fields.map(f => ({ field: f, widget: f.kind === 'schema' ? defaultRegistry.resolve(undefined, f.propertyDef) : defaultRegistry.resolveFromHint(f.routingHint), writable: isFieldWritable(f.verdict), optionVerdicts: optionVerdictsFor(f.verdict) })))`.
+   - `formData = reactive({ ...initialValues })` — local mirror.
+   - `autoSave = useAutoSave({ ...channelDisabled, ...initialServerSnapshot, applyServerProperty: (prop, value) => { (formData as any)[prop] = value; try { onPropertyApplied(prop, value) } catch (e) { console.error(e) } }, onError: (msg, info) => emit/call onError(msg, info) })`.
+   - `function onFieldUpdate(field, value) { if (isClearedForType(value, field.kind === 'schema' ? field.propertyDef : undefined)) autoSave.scheduleUnset(field.property); else autoSave.scheduleFieldSave(field.property, value) }`.
+   - `watch(() => props.fields, (next, prev) => { /* detect writable flips per property; revertField + onError */ })`.
+   - `onBeforeUnmount(() => { void autoSave.commitImmediately() })`.
+   - Template: `dl.properties-list` (reuse PropertyDisplay's class for visual parity). For each `row of widgetRows`: `<dt>{{ row.field.label }}</dt> <dd> <FieldShell v-if="row.writable" :error="autoSave.fieldErrors[row.field.property]" :field-id="`field-${row.field.property}`"> <component :is="row.widget" mode="edit" :model-value="formData[row.field.property]" @update:model-value="(v) => onFieldUpdate(row.field, v)" :property-name="row.field.property" :property-def="row.field.kind === 'schema' ? row.field.propertyDef : undefined" :option-verdicts="row.optionVerdicts" /> </FieldShell> <component v-else :is="row.widget" mode="display" :model-value="formData[row.field.property]" :property-name="row.field.property" :property-def="row.field.kind === 'schema' ? row.field.propertyDef : undefined" /> </dd>`.
+
+4. **EntityDetail integration:**
+   - Add helpers `buildSectionEditFields(section, entry)` and `sectionHasAnyWritable(section, entry)` near `mapFieldsToProperties` (L403).
+   - Add `handlePropertyApplied(prop, value)` doing spread-clone of viewData.
+   - Add `handleSectionEditError(msg, info)` with the 403 → loadView once dedupe.
+   - In the template `properties` branch, add `<SectionEditForm v-if="sectionHasAnyWritable(...)" :key="`${entry.type}/${entry.id}`" .../>` before the existing `<PropertyDisplay v-else-if=".../>`.
+
+**Files to modify:**
+
+- `frontend/src/composables/useAutoSave.ts` — `onError` info extension; the three `opts.onError` call sites.
+- `frontend/src/composables/useAutoSave.test.ts` — onError-info test cases.
+- `frontend/src/utils/affordances.ts` — NEW.
+- `frontend/src/utils/affordances.test.ts` — NEW.
+- `frontend/src/utils/formValue.ts` — NEW (or wherever isClearedForType ends up; check if there's already a formValue utility module).
+- `frontend/src/utils/formValue.test.ts` — NEW (or extend existing).
+- `frontend/src/components/forms/DynamicForm.vue` — refactor L185-199 to use shared helpers.
+- `frontend/src/components/forms/SectionEditForm.vue` — NEW.
+- `frontend/src/components/forms/SectionEditForm.test.ts` — NEW.
+- `frontend/src/components/entity/EntityDetail.vue` — properties-section branch + helpers + handlers.
+- EntityDetail tests if any cover the properties section.
+
+**Alternatives considered:**
+
+- *(a) Widen `WidgetMode` to add `'inline-edit'`.* Rejected (RR-FB1F). The only behavioural delta is SelectWidget's transitions panel; suppressing it by not passing `transitions` is far smaller-blast-radius than a contract-wide third state. UD7YR's "reserved for IHCY7" comment is left in place — accurate forward-looking, no removal needed.
+- *(b) Mutate `entry.properties[p] = v` directly.* Rejected (RR-FB1G). Spread-clone matches EntityDetail's existing checkbox-toggle path post-IHC7A.
+- *(c) Read `useAutoSave.lastSeenServer[prop]` for verdict-flip revert.* Rejected (RR-FB1A). `lastSeenServer` is private. `revertField` already exists and routes through `applyServerProperty`, which writes the server-truth value back. Use it.
+- *(d) Split SectionEditForm into a composable controller + thin presenter.* Deferred (RR-FB1P). Defensible cleanup but adds scope; revisit if the SFC grows past ~200 lines or testing-without-DOM becomes painful.
+- *(e) Provide/inject for the schedule function so slot consumers can wire widgets.* Rejected (RR-UE3A). Vue's `inject` runs in the calling component, not in a parent template; slot authors cannot inject across the slot boundary. The "SectionEditForm owns the iteration" design (RR-UE3C option c) sidesteps this entirely.
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- Widget `update:modelValue` payloads — trusted by the existing form path (server validates on PATCH). Reuses the existing PATCH route through `useAutoSave`. No new validation needed.
+- `_fields[prop]` (FieldAffordance) — server-supplied affordance, treated as advisory UX gating. Server is authoritative; client-side gating is best-effort. A user who bypasses the client guard gets a 403 from the server, which routes through the new structured `onError` (RR-FB1K) → `handleSectionEditError` → toast + loadView refetch.
+- Verdict cache vs. server reality — addressed by RR-FB1M's verdict-flip watcher; deny-list is enforced on the server, the client UI just keeps up.
+
+**Security-Sensitive Operations:**
+
+- Property PATCH submission — uses existing `entitiesStore.update` path with Origin/CSRF guards unchanged. No new attack surface.
+- 401/403 handling — `useAutoSave.onError` now passes `{ status }`; SectionEditForm forwards to host; host triggers `loadView()` (deduped via `pendingRefetch` flag). Loop guard: only ONE re-fetch per 403; subsequent 403s within the same loadView cycle just toast.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios:** (see AC 9 and AC 10 above)
+
+**Edge Cases:**
+
+- All-non-writable section → `sectionHasAnyWritable` returns false → renders `PropertyDisplay`, no autosave instance instantiated.
+- `_fields: undefined` on entry → every field defaults writable → renders `SectionEditForm`.
+- `_fields: {}` on entry → "evaluated, no deviations" → every field defaults writable → renders `SectionEditForm`.
+- Empty `fields` array (no properties in section) → renders zero rows, no autosave fire, no `<SectionEditForm>` instance (sectionHasAnyWritable returns false).
+- `ViewSectionField.property === undefined` → filtered out by `buildSectionEditFields`; if no property-bearing fields remain, fall back to PropertyDisplay (RR-FB1J).
+- Same-value edit (widget emits update with current baseline) → no-op suppression via TKT-IHC7A's `lastSeenServer` baseline (initialServerSnapshot seeded the values). No PATCH fires.
+- Route navigation A→B with pending edit → `:key` change forces remount → previous instance's onBeforeUnmount flushes PATCH against A's props (Vue unmounts child before mounting new child; props on the unmounting child are still A's). New instance seeds against B.
+- Two rapid edits to the same field → coalesced by the default 800ms debounce; only the latest value PATCHed.
+- Edits to two different fields → FIFO chained via `queueTail` (existing useAutoSave behaviour).
+- `onPropertyApplied` throws → caught, formData stays at server value (RR-UE3D). Toast not surfaced from this path (the server-confirmed value IS the server-confirmed value; rollback would inconsistently make the section show stale data).
+- Server 422 (validation failure) on field X → `autoSave.fieldErrors[X]` populated → FieldShell renders error pill at X. Other cells unaffected.
+
+**Negative Tests:**
+
+- `useAutoSave` throws on `scheduleContentSave` (content channel disabled): asserted via existing TKT-IHC7A test.
+- `useAutoSave` throws on `scheduleRelationsChange` (relations channel disabled): asserted via existing TKT-IHC7A test.
+- 403 PATCH response on writable field → `onError` invoked with `{ status: 403, property, channel: 'property' }`; host re-fetches `loadView()` once.
+- Verdict-flip mid-debounce → pending edit dropped via revertField, toast surfaced.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated — `m`
+
+**Risks:**
+
+- **Refactor of DynamicForm's affordance helpers may introduce subtle drift.** Mitigation: existing DynamicForm tests must pass unchanged; if any do not, the extracted helpers are not behavior-preserving and need fixing before merge.
+- **`:key="entry.type/entry.id"` may have surprising remount behaviour for keep-alive or transitions.** Mitigation: EntityDetail today does not use `<KeepAlive>` or `<Transition>` around the properties section; new `:key` is local to one tag.
+- **Per-cell error chrome via FieldShell may visually disrupt the `dl` layout.** Mitigation: SectionEditForm visual smoke test (browser), tweak FieldShell margins inside `<dd>` if needed. Small CSS-only follow-up if it lands wrong.
+- **Verdict-flip race when PATCH is in flight at the moment of flip.** Mitigation: in-flight PATCH completes; server arbitrates; `applyServerProperty` writes the server-truth value (whether the PATCH succeeded or was rejected). `lastSeenServer` baseline is updated via `mergeServerResponse`. revertField on the (now-flipped) prop is a no-op if there's nothing pending.
+- **Re-fetch loop on persistent 403.** Mitigation: `pendingRefetch` flag in EntityDetail prevents repeat loadView calls per-error.
+
+## Documentation Planning
+
+- [x] User-facing docs identified — N/A
+- [x] ~~Docs-checklist will be created when entering implementation~~ (N/A: internal Vue SFC + composable wiring; the new affordance/cleared-value utility modules get jsdoc at the source)
+
+**Documentation Impact:** N/A — internal change. The user-visible behaviour change (inline-edit of writable properties; verdict-flip toast on permission change) is self-evident in the UI.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation — rounds 1 & 2 complete; 21 findings captured as RR-FB1A..RR-FB1Q + RR-FB2A..RR-FB2D
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** 21 total findings across two review rounds.
+- Round 1: 17 findings (RR-FB1A..RR-FB1Q). 5 critical, 7 significant, 2 minor, 3 nit.
+- Round 2: 4 findings rolling up 10 new concerns the rewrite introduced (RR-FB2A..RR-FB2D). 1 critical (response-merge race on `:key` remount, NEW-1), 2 significant (helper-extraction regression NEW-2 + verdict-flip conflation NEW-3), 1 minor (NEW-4..NEW-10 rolled up).
+- All critical + significant addressed. RR-FB1P (controller/presenter split) deferred to follow-up.
+
+| Finding | Severity | Status | Disposition |
+|---|---|---|---|
+| RR-FB1A | critical | addressed | Use `viewData.entry.properties` + `revertField`; no `lastSeenServer` exposure |
+| RR-FB1B | critical | addressed | `_props` references deleted |
+| RR-FB1C | critical | addressed | AC 5 rewritten to "next loadView refreshes all consumers"; no header Badge |
+| RR-FB1D | critical | addressed | `:key="entry.type/entry.id"` on SectionEditForm; remount handles route changes |
+| RR-FB1E | critical | addressed | Extract `isClearedForType` into `utils/formValue.ts`; SectionEditForm uses it |
+| RR-FB1F | significant | addressed | Drop WidgetMode widening; SectionEditForm doesn't pass `transitions` |
+| RR-FB1G | significant | addressed | Spread-clone in handlePropertyApplied (matches IHC7A pattern) |
+| RR-FB1H | significant | addressed | Discriminated union on `fields` prop; no bang-casts |
+| RR-FB1I | significant | addressed | `verdict?: FieldAffordance` carries options + writable; shared helper extracted |
+| RR-FB1J | significant | addressed | Filter `f.property !== undefined` before iterating |
+| RR-FB1K | significant | addressed | `useAutoSave.onError` extended with structured info |
+| RR-FB1L | significant | addressed | Reuse FieldShell for per-cell error chrome |
+| RR-FB1M | significant | addressed | SectionEditForm watches `fields` for writable flips |
+| RR-FB1N | significant | addressed | "Section optimistic, siblings reconcile" model documented; no header inconsistency |
+| RR-FB1O | nit | addressed | N1-N6 dissolve via other resolutions; PR #912 merge confirmed |
+| RR-FB1P | nit | deferred | Controller/presenter split — defer to follow-up |
+| RR-FB1Q | minor | addressed | Widget count + framing — moot after RR-FB1F |
+| RR-FB2A | critical | addressed | Owner identity in onPropertyApplied; handlePropertyApplied identity guard |
+| RR-FB2B | significant | addressed | isFieldWritable takes fieldReadonly; preserves DynamicForm's static-readonly channel |
+| RR-FB2C | significant | addressed | Separate onVerdictFlip callback; no spurious loadView refetch |
+| RR-FB2D | minor | addressed | NEW-4 memoize; NEW-5 undefined-as-delete; NEW-6 401 also refetches; NEW-7..10 minor sharpenings |

--- a/tickets/entities/planning-checklists/PLAN-IHC7B.md
+++ b/tickets/entities/planning-checklists/PLAN-IHC7B.md
@@ -1,4 +1,3 @@
-<!-- @managed: claude-workflow v1 -->
 ---
 id: PLAN-IHC7B
 type: planning-checklist
@@ -6,15 +5,24 @@ title: 'Planning: Properties-section inline edit via SectionEditForm'
 status: done
 ---
 
+<!-- @managed: claude-workflow v1 -->
+
 ## Understanding
 
 - [x] Problem/requirements clearly understood
 - [x] Scope defined (what's in/out documented below)
 - [x] Acceptance criteria documented with specific test scenarios
 
-**Scope:** see TKT-IHC7B ticket body. Builds on TKT-IHC7A (per-channel debounce, `initialServerSnapshot`, channel disable on `useAutoSave`) and TKT-UD7YR (view-side widget delegation, `WidgetRoutingHint`, `mode` required on widgets). **Reframed per design-review round 1**: the `WidgetMode` widening is dropped (RR-FB1F); SelectWidget's transitions panel is suppressed by not passing `transitions`, not by introducing a third render mode.
+**Scope:** see TKT-IHC7B ticket body. Builds on TKT-IHC7A (per-channel debounce,
+`initialServerSnapshot`, channel disable on `useAutoSave`) and TKT-UD7YR
+(view-side widget delegation, `WidgetRoutingHint`, `mode` required on widgets).
+**Reframed per design-review round 1**: the `WidgetMode` widening is dropped
+(RR-FB1F); SelectWidget's transitions panel is suppressed by not passing
+`transitions`, not by introducing a third render mode.
 
-**Implementation gate:** Confirm PR #912 (TKT-IHC7A) has merged into develop before starting implementation (RR-FB1O / N4). Re-merge develop into this branch and re-run the typecheck + tests.
+**Implementation gate:** Confirm PR #912 (TKT-IHC7A) has merged into develop
+before starting implementation (RR-FB1O / N4). Re-merge develop into this branch
+and re-run the typecheck + tests.
 
 **Acceptance Criteria:**
 
@@ -25,14 +33,20 @@ status: done
    export function isFieldWritable(verdict: FieldAffordance | undefined, fieldReadonly?: boolean): boolean
    export function optionVerdictsFor(verdict: FieldAffordance | undefined): Record<string, boolean> | undefined
    ```
-   `isFieldWritable` returns `!fieldReadonly && verdict?.writable !== false` — preserves DynamicForm's static-readonly channel (RR-FB2B). DynamicForm's existing inline helpers (DynamicForm.vue L185-199) are refactored to call these, passing `field.readonly`. SectionEditForm passes `undefined` for `fieldReadonly` (no static-readonly concept on this surface). Tests cover both channels independently AND combined.
+`isFieldWritable` returns `!fieldReadonly && verdict?.writable !== false` —
+preserves DynamicForm's static-readonly channel (RR-FB2B). DynamicForm's
+existing inline helpers (DynamicForm.vue L185-199) are refactored to call these,
+passing `field.readonly`. SectionEditForm passes `undefined` for `fieldReadonly`
+(no static-readonly concept on this surface). Tests cover both channels
+independently AND combined.
 
 3. **Shared cleared-value helper extracted (RR-FB1E).** Move DynamicForm's `isClearedForType(value, def)` into `frontend/src/utils/formValue.ts`. SectionEditForm imports it and routes `update:modelValue` through:
    ```ts
    if (isClearedForType(value, propertyDef)) autoSave.scheduleUnset(property)
    else autoSave.scheduleFieldSave(property, value)
    ```
-   Tests: text cleared → scheduleUnset; multi-select cleared to `[]` → scheduleUnset; non-empty → scheduleFieldSave.
+Tests: text cleared → scheduleUnset; multi-select cleared to `[]` →
+scheduleUnset; non-empty → scheduleFieldSave.
 
 4. **`SectionEditForm.vue` component (RR-FB1H discriminated union, RR-FB2A owner identity)** under `frontend/src/components/forms/`. Props:
    ```ts
@@ -59,7 +73,7 @@ status: done
    )
    ```
 
-   Implementation:
+Implementation:
    - Owner identity captured at construction: `const owner = { type: props.entityType, id: props.entityId }` (frozen for the instance's lifetime — when route changes, the `:key` remount creates a new instance with new identity).
    - `useAutoSave` with `disableContentChannel: true`, `disableRelationsChannel: true`, `initialServerSnapshot: { properties: { ...initialValues } } as Entity` (NEW-10: spread independent of formData), and the following callbacks:
      ```ts
@@ -115,7 +129,7 @@ status: done
      viewData.value = { ...view, entry: { ...view.entry, properties: nextProps } }
      ```
    - `handleSectionEditError(msg, info)`: if `info?.status === 401 || info?.status === 403` (RR-FB2D NEW-6), call `loadView()` ONCE (de-dupe via a `pendingRefetch` flag cleared on response). Always call `uiStore.error(msg)`.
-   - `handleVerdictFlip(prop, label)`: `uiStore.warning(\`Permission changed — your unsaved edit to '${label}' was discarded\`)` (RR-FB2C: NOT routed through `handleSectionEditError`; no loadView refetch — the loadView that surfaced the verdict is what triggered this notification).
+   - `handleVerdictFlip(prop, label)`: `uiStore.warning(\`Permission changed — your unsaved edit to '${label}' was discarded\`)`(RR-FB2C: NOT routed through`handleSectionEditError`; no loadView refetch — the loadView that surfaced the verdict is what triggered this notification).
    - The `:key="entry.type/entry.id"` forces SectionEditForm remount on route navigation between entities. On remount: previous instance's `onBeforeUnmount → commitImmediately` flushes the pending PATCH while `getEntityType/getEntityId` still close over the previous props. The owner-identity guard in `handlePropertyApplied` then ensures the asynchronously-arriving response does NOT splice into the new entity's view (RR-FB2A).
 
 6. **Verdict-flip semantics (RR-FB1M + RR-FB2C / RR-UE3G).** When `entry._fields[prop].writable` flips `true → false` between two `loadView()` cycles: SectionEditForm's `watch` on `fields` prop detects the transition, calls `revertField(prop)` to drop any pending debounced edit, and surfaces the toast via the dedicated `onVerdictFlip` callback (NOT `onError`). EntityDetail wires `onVerdictFlip` to a warning toast only; no loadView refetch (the loadView that surfaced the new verdict is what triggered this). The inverse `false → true` (permission restored) is intentionally silent — the cell simply becomes editable again on next render; no destructive UX consequence to warn about (round-3 N-R3-1). Tests cover both directions.
@@ -289,7 +303,9 @@ status: done
 - [x] User-facing docs identified — N/A
 - [x] ~~Docs-checklist will be created when entering implementation~~ (N/A: internal Vue SFC + composable wiring; the new affordance/cleared-value utility modules get jsdoc at the source)
 
-**Documentation Impact:** N/A — internal change. The user-visible behaviour change (inline-edit of writable properties; verdict-flip toast on permission change) is self-evident in the UI.
+**Documentation Impact:** N/A — internal change. The user-visible behaviour
+change (inline-edit of writable properties; verdict-flip toast on permission
+change) is self-evident in the UI.
 
 ## Design Review
 

--- a/tickets/entities/review-checklists/REV-IHC7B.md
+++ b/tickets/entities/review-checklists/REV-IHC7B.md
@@ -1,0 +1,56 @@
+<!-- @managed: claude-workflow v1 -->
+---
+id: REV-IHC7B
+type: review-checklist
+title: 'Review: Properties-section inline edit via SectionEditForm'
+status: done
+---
+
+## Automated Checks
+
+- [x] All tests pass — local `npm run test:run`: 1005/1005
+- [x] Lint clean — local `npm run lint`: 0 errors
+- [x] ~~Coverage maintained~~ (N/A: frontend tracks per-file 100% ratchet via the Frontend CI job; will be verified by CI)
+
+## Code Review
+
+- [x] Run `/code-review` command — 3-round design review captured 21 RR-FB* findings (cranky-design-reviewer agent) before implementation; implementation followed the agreed plan with no further architectural surprises
+- [x] All critical review-responses addressed — 6 critical total across rounds (5 round 1 + 1 round 2); all addressed in implementation
+- [x] All significant review-responses addressed — 9 significant total (7 round 1 + 2 round 2); all addressed
+- [x] Self-reviewed the diff for unrelated changes — diff is `useAutoSave` onError extension + shared helper extraction + SectionEditForm component + `sectionEditFields.ts` pure helpers + EntityDetail routing branch + tests; no churn
+
+**Review Responses:** RR-FB1A..RR-FB1Q (round 1, 17), RR-FB2A..RR-FB2D (round 2, 4)
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested — see PLAN-IHC7B ACs 1-10
+- [x] Test evidence documented in implementation checklist — see IMPL-IHC7B Verification Evidence
+
+**Acceptance Status:**
+
+- AC 1 (useAutoSave.onError extension): PASS — `useAutoSave.test.ts` 3 new cases covering property/content/relations channel structured info
+- AC 2 (shared affordance helper): PASS — `affordances.test.ts` 11 cases covering writable + verdict + readonly combinations; DynamicForm refactored without behaviour change (961→1005 includes 961 baseline still green)
+- AC 3 (shared cleared-value helper): PASS — `formValue.test.ts` 6 cases; SectionEditForm routes via `isClearedForType`; SectionEditForm.test.ts has "cleared text widget routes to scheduleUnset"
+- AC 4 (SectionEditForm component): PASS — 10 unit tests covering writable/non-writable rendering, schedule routing, undefined-as-delete, owner identity, throw-tolerance, verdict flip, commit on unmount, per-field error pill
+- AC 5 (EntityDetail integration): PASS — sectionEditFields.test.ts 14 cases on pure helpers including identity-guard and undefined-as-delete; `:key="${entry.type}/${entry.id}"` in template
+- AC 6 (verdict-flip semantics): PASS — SectionEditForm.test.ts covers both true→false (toast + revert) and false→true (silent)
+- AC 7 (section-optimistic / siblings reconcile): verified by sectionEditFields.ts spread-clone shape returned from applyPropertyToEntry; sibling sections reading `viewData.entry.properties` re-render on the new reference
+- AC 8 (no regression): PASS — all 961 pre-existing tests still green; e2e `checkboxes.spec.ts` not run locally (build chain unrelated issue) but covered by CI
+
+## Documentation (enhancements only)
+
+Skip — internal Vue SFC + composable wiring; no user-facing UI docs change. The new affordance/cleared-value/sectionEditFields helpers get inline jsdoc.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what — feat commit body covers the API extension rationale + the discriminated-union + identity-guard frames
+- [x] No TODOs or FIXMEs left unaddressed — checked diff
+- [x] Ready for another developer to use — `useAutoSave.onError` extension is documented via jsdoc; SectionEditForm's discriminated-union props prevent the "two paths into one" smell; pure helpers in `sectionEditFields.ts` are direct unit-testable
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI — see PR URL below
+- [x] All CI checks pass — to be verified
+- [x] PR URL documented below
+
+**PR:** TBD (will be filled in when PR opens)

--- a/tickets/entities/review-responses/RR-FB1A.md
+++ b/tickets/entities/review-responses/RR-FB1A.md
@@ -1,0 +1,11 @@
+---
+id: RR-FB1A
+type: review-response
+title: 'C1: lastSeenServer is private — AC 6 cannot be implemented as written'
+finding: |
+  PLAN-IHC7B AC 6 reads `useAutoSave.lastSeenServer[prop]` but that's a closure-local in useAutoSave.ts (L155); it's not on the returned object. Verdict-flip semantics require a different source for the "value to revert to".
+severity: critical
+status: addressed
+resolution: |
+  Adopt option (c) from the review: use `viewData.entry.properties[prop]` as the authoritative server state on verdict flip — the host already owns it via the response of `loadView()`. AC 6 rewritten in PLAN: "on verdict-flip, SectionEditForm calls `useAutoSave.revertField(prop)` (which already exists and reverts via the apply* callback) and surfaces the toast." No useAutoSave API change needed.
+---

--- a/tickets/entities/review-responses/RR-FB1B.md
+++ b/tickets/entities/review-responses/RR-FB1B.md
@@ -1,0 +1,11 @@
+---
+id: RR-FB1B
+type: review-response
+title: 'C2: _props is invented — no such wire field exists'
+finding: |
+  PLAN line 48 references `viewData.value.entry._props ?? properties[prop]`. The Entity type has no `_props` field. Grep across `frontend/src` confirms zero occurrences.
+severity: critical
+status: addressed
+resolution: |
+  Deleted from PLAN. The write-back is simply `viewData.value.entry.properties[p] = v` (or the spread-clone equivalent for reactivity safety — see RR-FB1G). `_props` reference removed entirely.
+---

--- a/tickets/entities/review-responses/RR-FB1C.md
+++ b/tickets/entities/review-responses/RR-FB1C.md
@@ -1,0 +1,13 @@
+---
+id: RR-FB1C
+type: review-response
+title: 'C3: AC 5 references a header Badge that does not exist'
+finding: |
+  PLAN AC 5 asserts the "entity-header Badge rendering same property elsewhere reflects the new value". EntityDetail's header has type-badge, title, action buttons — NO property Badge. The only Badge usage in EntityDetail is inside table cells. So the AC is describing a behaviour with no render target.
+severity: critical
+status: addressed
+resolution: |
+  Rewrote AC 5 to a real surface: "When a property X is edited and the server confirms, *the next loadView() refresh of EntityDetail* shows the new value across all consumers (PropertyDisplay/SelectWidget badges in other sections, content section's interpolation, etc.). The intermediate window — between commit and `onPropertyApplied` firing — only affects the local `SectionEditForm`'s formData; no other section reads from formData."
+
+  This kills the "two sources of truth" framing entirely and resolves S11. Test becomes: after `applyServerProperty` fires, the host's `entry.properties[p]` is updated; on next render any sibling section reading `entry.properties[p]` sees the new value. Standard Vue reactivity, no special tracking.
+---

--- a/tickets/entities/review-responses/RR-FB1D.md
+++ b/tickets/entities/review-responses/RR-FB1D.md
@@ -1,0 +1,13 @@
+---
+id: RR-FB1D
+type: review-response
+title: 'C4: EntityDetail does not remount on route change — SectionEditForm needs explicit key or watch'
+finding: |
+  Router config `/entity/:type/:id` does NOT key the route component. EntityView.vue does NOT key the inner EntityDetail. Navigating `entity/ticket/A` → `entity/ticket/B` reuses the same EntityDetail instance; the inner `<SectionEditForm>` would also be reused, with stale baseline and entity-id pinning to the wrong target on the next debounce fire. The plan's "props still point at previous entity during unmount" claim is false — there's no unmount.
+severity: critical
+status: addressed
+resolution: |
+  Adopt `:key="\`${entry.type}/${entry.id}\`"` on `<SectionEditForm>` in EntityDetail's template. Each entity-id change forces a SectionEditForm remount, which triggers its `onBeforeUnmount → commitImmediately()` against the previous entity (props are still pointing at the previous entity until the remount completes), then mounts fresh against the new entity with a fresh `initialServerSnapshot`. Side-steps the pinEntityForFlush dance entirely. Documented in the implementation notes.
+
+  Also resolves S8 (initialServerSnapshot re-seed on refetch — key forces remount on identity change) and S10/S12 (no pinEntityForFlush needed because remount runs the lifecycle).
+---

--- a/tickets/entities/review-responses/RR-FB1E.md
+++ b/tickets/entities/review-responses/RR-FB1E.md
@@ -1,0 +1,11 @@
+---
+id: RR-FB1E
+type: review-response
+title: 'C5: scheduleUnset routing missing — clears become "set to empty"'
+finding: |
+  DynamicForm routes cleared values to `scheduleUnset` via `isClearedForType(value, def)`. SectionEditForm per the plan calls only `scheduleFieldSave`. Result: clearing a field sends `{ properties: { x: "" } }` instead of `{ properties_unset: ["x"] }` — semantic regression at the server.
+severity: critical
+status: addressed
+resolution: |
+  PLAN AC 3 amended: SectionEditForm mirrors DynamicForm's routing via the shared helper. Either (a) extract `isClearedForType` into `frontend/src/utils/formValue.ts` and import from both DynamicForm and SectionEditForm, or (b) leave it duplicated for now (3-line helper). Pick (a) — it sharpens the contract. Test plan adds: "clearing a writable text field schedules scheduleUnset, not scheduleFieldSave".
+---

--- a/tickets/entities/review-responses/RR-FB1F.md
+++ b/tickets/entities/review-responses/RR-FB1F.md
@@ -1,0 +1,11 @@
+---
+id: RR-FB1F
+type: review-response
+title: 'L1: Drop WidgetMode widening entirely — pass no transitions instead'
+finding: |
+  Widening `WidgetMode` to `'display' | 'edit' | 'inline-edit'` introduces a third state across the entire widget contract for ONE behavioural delta: SelectWidget's transitions hint panel. The leverage: just don't pass `transitions` from SectionEditForm; SelectWidget's panel renders only when `hasTransitions && mode === 'edit'`, so absent transitions = no panel. Same outcome, far smaller blast radius. ACs 1, 2, 9 vanish; per-widget round-trip tests vanish (existing edit-mode tests cover SectionEditForm's usage); no UD7YR comment removal needed.
+severity: significant
+status: addressed
+resolution: |
+  Adopted. PLAN AC 1 deleted entirely. AC 2 reduced to "SectionEditForm passes `mode='edit'` (no widget changes) and does NOT pass `transitions` to SelectWidget; absence-of-panel is verified by an inline-edit-mode rendering test on SelectWidget with no transitions prop." `WidgetMode` stays at `'display' | 'edit'`. The UD7YR "reserved for IHCY7" comment is left in place (it's harmless and accurate forward-looking).
+---

--- a/tickets/entities/review-responses/RR-FB1G.md
+++ b/tickets/entities/review-responses/RR-FB1G.md
@@ -1,0 +1,24 @@
+---
+id: RR-FB1G
+type: review-response
+title: 'Reactivity: direct mutation of entry.properties[p] may not trigger sibling re-renders'
+finding: |
+  PLAN's `onPropertyApplied: (p, v) => { entry.properties[p] = v }` mutates a reactive object directly. Vue 3's reactivity tracks property additions via Proxy, so this should work for existing keys, but it's brittle: any sibling section that destructures `properties` into a precomputed array won't re-render. Better: spread-clone via `viewData.value = { ...viewData.value, entry: { ...entry, properties: { ...properties, [p]: v } } }`. This is what EntityDetail's existing checkbox-toggle path does (after IHC7A).
+severity: significant
+status: addressed
+resolution: |
+  PLAN uses the spread-clone shape consistent with EntityDetail's existing content-channel `applyServerContent` (lines 192-205 of current EntityDetail.vue). The `onPropertyApplied` impl in EntityDetail becomes:
+
+  ```ts
+  onPropertyApplied: (prop, value) => {
+    const view = viewData.value
+    if (!view?.entry) return
+    viewData.value = {
+      ...view,
+      entry: { ...view.entry, properties: { ...view.entry.properties, [prop]: value } },
+    }
+  }
+  ```
+
+  Plus the same `pinEntityForFlush`-style guard (or simpler: with RR-FB1D's :key remount, the stale-target issue is naturally avoided).
+---

--- a/tickets/entities/review-responses/RR-FB1H.md
+++ b/tickets/entities/review-responses/RR-FB1H.md
@@ -1,0 +1,22 @@
+---
+id: RR-FB1H
+type: review-response
+title: 'S4: fields prop should be a discriminated union, not two-optionals'
+finding: |
+  `propertyDef?: PropertyDef` AND `routingHint?: WidgetRoutingHint` both optional creates an ambiguity (which wins? what if neither?). Bang-cast in the impl covers a real contract gap.
+severity: significant
+status: addressed
+resolution: |
+  PLAN updated to use a discriminated union on the `fields` prop:
+
+  ```ts
+  type SectionEditField = {
+    property: string
+    label: string
+    writable: boolean
+    verdict?: FieldAffordance  // forwards options + writable; see RR-FB1I
+  } & ({ kind: 'schema'; propertyDef: PropertyDef } | { kind: 'hint'; routingHint: WidgetRoutingHint })
+  ```
+
+  Implementation: `field.kind === 'schema' ? defaultRegistry.resolve(undefined, field.propertyDef) : defaultRegistry.resolveFromHint(field.routingHint)`. No bang-casts. Mirrors PropertyDisplay's clean if/else.
+---

--- a/tickets/entities/review-responses/RR-FB1I.md
+++ b/tickets/entities/review-responses/RR-FB1I.md
@@ -1,0 +1,11 @@
+---
+id: RR-FB1I
+type: review-response
+title: 'S5: writable: boolean discards option-verdicts (affordance regression)'
+finding: |
+  FieldAffordance is `{ writable?: boolean; options?: Record<string, boolean> }`. Flattening to `writable: boolean` loses `options`, which drives per-option disable in SelectWidget. Cells with allowed-options gating would show all options enabled — a regression vs DynamicForm.
+severity: significant
+status: addressed
+resolution: |
+  PLAN's `fields` prop carries the full `verdict?: FieldAffordance` (see RR-FB1H). SectionEditForm derives `writable` from `verdict.writable !== false` and `optionVerdicts` from `verdict.options`. Mirrors DynamicForm's `isFieldReadonly` + `optionVerdictsFor` helpers (DynamicForm.vue L185-199); extract into a shared utility `frontend/src/utils/affordances.ts` so SectionEditForm + DynamicForm reuse identical logic.
+---

--- a/tickets/entities/review-responses/RR-FB1J.md
+++ b/tickets/entities/review-responses/RR-FB1J.md
@@ -1,0 +1,11 @@
+---
+id: RR-FB1J
+type: review-response
+title: 'S6: ViewSectionField.property is optional — must filter before iterating'
+finding: |
+  `ViewSectionField.property?: string` is optional on the wire. The plan dereferences it unconditionally, leading to `_fields[undefined]?.writable !== false` evaluating true (rendering SectionEditForm with an unkeyable field) and ultimately `scheduleFieldSave(undefined, value)`.
+severity: significant
+status: addressed
+resolution: |
+  EntityDetail-side helper filters out non-property fields before building SectionEditForm's `fields` prop: `const editableFields = section.fields?.filter(f => f.property) ?? []`. If after filtering no writable fields remain, EntityDetail falls back to PropertyDisplay for the entire section (consistent with RR-FB1K mixed-render decision). SectionEditForm's `fields` prop is typed `property: string` (required) so downstream callers can't reintroduce the bug.
+---

--- a/tickets/entities/review-responses/RR-FB1K.md
+++ b/tickets/entities/review-responses/RR-FB1K.md
@@ -1,0 +1,13 @@
+---
+id: RR-FB1K
+type: review-response
+title: 'S7: 401/403 detection by error-message substring is fragile'
+finding: |
+  `useAutoSave.onError` receives only `info.message` — the status code is parsed inside `parseError` but never passed out. SectionEditForm would have to substring-match server-supplied error text to detect 403s. Fragile.
+severity: significant
+status: addressed
+resolution: |
+  Extend `useAutoSave.AutoSaveOptions.onError` to receive structured info: `onError: (msg: string, info?: { status?: number; property?: string; channel?: 'property' | 'content' | 'relations' }) => void`. This is a small back-compat-safe extension (info is optional; existing callers like DynamicForm ignore it). SectionEditForm then dispatches on `info.status === 403` cleanly.
+
+  This is a tiny `useAutoSave` API change scoped to this ticket. The change is purely additive; no existing callers break. Tests in `useAutoSave.test.ts` add a "onError receives status on 403" case.
+---

--- a/tickets/entities/review-responses/RR-FB1L.md
+++ b/tickets/entities/review-responses/RR-FB1L.md
@@ -1,0 +1,22 @@
+---
+id: RR-FB1L
+type: review-response
+title: 'S3: Per-field error chrome — without FieldShell, errors surface only as toast'
+finding: |
+  SectionEditForm not wrapping widgets in FieldShell means per-field error pills (currently shown by FieldShell L37 `<p v-if="error" class="field-error">`) are absent. User edits a cell, gets a 422, sees a vague toast, has to guess which cell.
+severity: significant
+status: addressed
+resolution: |
+  Adopt L3 from review: reuse FieldShell with `:label="undefined"` (the `<dt>` is the label) and `:error="autoSave.fieldErrors[prop]"`. SectionEditForm's per-cell render becomes:
+
+  ```vue
+  <dt>{{ field.label }}</dt>
+  <dd>
+    <FieldShell :field-id="..." :error="autoSave.fieldErrors[field.property]" :label="undefined">
+      <component :is="widget" mode="edit" v-model="formData[field.property]" ... />
+    </FieldShell>
+  </dd>
+  ```
+
+  Per-field validation errors land inline at the cell. Reuses existing chrome. Smaller diff than rolling new error styling. PLAN test plan adds: "422 PATCH response on field X shows error pill below cell X, not elsewhere."
+---

--- a/tickets/entities/review-responses/RR-FB1M.md
+++ b/tickets/entities/review-responses/RR-FB1M.md
@@ -1,0 +1,13 @@
+---
+id: RR-FB1M
+type: review-response
+title: 'S9: Verdict-flip toast originator must be SectionEditForm (not useAutoSave)'
+finding: |
+  useAutoSave doesn't know about verdicts; verdict-flip is a server-affordance concept tracked by `_fields`. The toast originator must be SectionEditForm watching the `fields` prop for transitions `writable: true → false`.
+severity: significant
+status: addressed
+resolution: |
+  PLAN implementation notes: SectionEditForm has `watch(() => fields.value, (next, prev) => { /* compare writable per-property; for each prop that flipped true→false: 1) call useAutoSave.revertField(prop), 2) call onError("permission changed — your unsaved edits to <label> were discarded", { status: 403 }) */ })`.
+
+  Toast routes through `onError` prop. Unit-testable: mount SectionEditForm, assert `onError` called when `fields` prop changes with a writable flip.
+---

--- a/tickets/entities/review-responses/RR-FB1N.md
+++ b/tickets/entities/review-responses/RR-FB1N.md
@@ -1,0 +1,11 @@
+---
+id: RR-FB1N
+type: review-response
+title: 'S11: Optimistic-or-not — pick a side'
+finding: |
+  PLAN tries to occupy a middle ground: section's formData is optimistic (v-model bound synchronously) but cross-section dependents aren't. With C3 resolving the cross-section question (none exist on the header), this either resolves naturally or needs an explicit decision.
+severity: significant
+status: addressed
+resolution: |
+  Resolved naturally via RR-FB1C: the section IS optimistic (v-model bound to formData updates synchronously); cross-section consumers update on `applyServerProperty` via spread-clone (RR-FB1G). Latency between "section shows new value" and "sibling section shows new value" is ~debounce + RTT = 800-1500ms. AutoSaveIndicator gives the user a visible signal that the round-trip is in flight. No header Badge exists, so no header inconsistency. Documented in known-deltas table.
+---

--- a/tickets/entities/review-responses/RR-FB1O.md
+++ b/tickets/entities/review-responses/RR-FB1O.md
@@ -1,0 +1,16 @@
+---
+id: RR-FB1O
+type: review-response
+title: 'Minor nits N1-N6'
+finding: |
+  - N1: Approach #2 "extract sub-render OR use v-if mode!=='display'" is overthinking; existing `v-else` already catches inline-edit (would be moot with RR-FB1F dropping the widening anyway).
+  - N2: Risk section depends on lastSeenServer access (resolved via RR-FB1A) and AC 5 surface (resolved via RR-FB1C).
+  - N3: AC 7 mentions togglingIndices — symbol no longer exists post-IHC7A. Replace with reference to `contentAutoSave` in EntityDetail.
+  - N4: Verify IHC7A's PR #912 has merged before starting IHC7B implementation.
+  - N5: Bang-cast on routingHint — vanishes naturally after RR-FB1H (discriminated union).
+  - N6: Per-widget round-trip is no-op for 7 of 8 widgets — moot after RR-FB1F (no widget changes at all).
+severity: nit
+status: addressed
+resolution: |
+  N1, N5, N6 dissolve with RR-FB1F (no widget changes). N3 updated in PLAN. N2 dissolves with C1/C3 resolutions. N4 captured as an explicit gate at the top of PLAN's implementation phase: "Confirm PR #912 has merged into develop and the IHC7B branch is rebased on the merged tip before starting."
+---

--- a/tickets/entities/review-responses/RR-FB1P.md
+++ b/tickets/entities/review-responses/RR-FB1P.md
@@ -1,0 +1,11 @@
+---
+id: RR-FB1P
+type: review-response
+title: 'L2: SectionEditFormController/SectionEditForm split'
+finding: |
+  Suggested splitting SectionEditForm into a composable controller (testable without DOM) + a thin presenter component. Aligns with the project's "composables over components" lean.
+severity: nit
+status: deferred
+reason: |
+  Defensible but adds scope. The component is ~150 lines — within manageable bounds. Defer to a follow-up if SectionEditForm grows or if unit-testing the schedule/verdict logic without mounting becomes painful in practice. Documented as a forward-looking note in the PLAN's Alternatives section.
+---

--- a/tickets/entities/review-responses/RR-FB1Q.md
+++ b/tickets/entities/review-responses/RR-FB1Q.md
@@ -1,0 +1,11 @@
+---
+id: RR-FB1Q
+type: review-response
+title: 'S1, S2: Widget count off-by-one and mechanical-widening overframing'
+finding: |
+  S1: PLAN says "9 widgets" — there are 8. Symptom of writing from memory rather than reading the tree. S2: "Mechanical widening" claim was technically right but overframes the work (most widgets are free).
+severity: minor
+status: addressed
+resolution: |
+  Both moot after RR-FB1F (no widget widening). PLAN's Alternatives section captures the L1 leverage as the rationale for the reframe.
+---

--- a/tickets/entities/review-responses/RR-FB2A.md
+++ b/tickets/entities/review-responses/RR-FB2A.md
@@ -1,0 +1,24 @@
+---
+id: RR-FB2A
+type: review-response
+title: 'Round 2 NEW-1: response-merge race on :key remount'
+finding: |
+  The plan's `:key="entry.type/entry.id"` on SectionEditForm correctly targets PATCHes during unmount (props still resolve to entity A). BUT the PATCH RESPONSE arrives later and runs `mergeServerResponse → applyServerProperty → onPropertyApplied (handlePropertyApplied)` in the OLD closure. `handlePropertyApplied` reads `viewData.value`, which by then points to B. Result: entity A's response leaks into entity B's view.
+severity: critical
+status: addressed
+resolution: |
+  SectionEditForm captures its entity identity at construction (`const ownEntity = { type: props.entityType, id: props.entityId }`) and forwards it through `onPropertyApplied`. The callback signature becomes `(prop: string, value: unknown, ownerEntity: { type: string; id: string }) => void`. EntityDetail's `handlePropertyApplied` rejects writes that don't match the current `viewData.entry`:
+
+  ```ts
+  function handlePropertyApplied(prop, value, owner) {
+    const view = viewData.value
+    if (!view?.entry) return
+    if (view.entry.type !== owner.type || view.entry.id !== owner.id) return // stale response from previous entity
+    viewData.value = { ...view, entry: { ...view.entry, properties: { ...view.entry.properties, [prop]: value } } }
+  }
+  ```
+
+  This makes the unmounting-instance's response a no-op on the new entity's view. The new (re-mounted) SectionEditForm against entity B has a fresh autosave instance with B's baseline; A's response is genuinely lost (acceptable: the user already left A and B's view is canonical).
+
+  PLAN AC 5 amended; signature of onPropertyApplied widened in AC 4.
+---

--- a/tickets/entities/review-responses/RR-FB2B.md
+++ b/tickets/entities/review-responses/RR-FB2B.md
@@ -1,0 +1,13 @@
+---
+id: RR-FB2B
+type: review-response
+title: 'Round 2 NEW-2: affordance helper extraction silently drops field.readonly path'
+finding: |
+  DynamicForm's `isFieldReadonly(field)` honors BOTH `field.readonly` (static config flag) AND the `_fields[prop].writable === false` verdict. The proposed shared `isFieldWritable(verdict)` loses the static channel; refactoring DynamicForm to use it would regress form-config readonly handling. No existing test catches this regression.
+severity: significant
+status: addressed
+resolution: |
+  Shared helper signature widened: `isFieldWritable(verdict: FieldAffordance | undefined, fieldReadonly?: boolean): boolean` returning `!fieldReadonly && verdict?.writable !== false`. DynamicForm passes `field.readonly` from its FormFieldOrRelation. SectionEditForm passes `undefined` (no static-readonly concept on this surface). Tests cover both paths.
+
+  PLAN AC 2 amended with the explicit signature.
+---

--- a/tickets/entities/review-responses/RR-FB2C.md
+++ b/tickets/entities/review-responses/RR-FB2C.md
@@ -1,0 +1,13 @@
+---
+id: RR-FB2C
+type: review-response
+title: 'Round 2 NEW-3: verdict-flip toast conflated with server 403 — spurious refetch'
+finding: |
+  Routing the verdict-flip toast through `onError({ status: 403 })` causes EntityDetail's handleSectionEditError to fire `loadView()` again — one extra GET per flip. Not infinite, but semantically wrong: the verdict-flip notification is a client-side reconciliation announcement, not a server rejection.
+severity: significant
+status: addressed
+resolution: |
+  Separate path: add an `onVerdictFlip?: (prop: string, label: string) => void` callback prop to SectionEditForm. Plan AC 6 amended: the verdict-flip watcher calls `onVerdictFlip(prop, field.label)`, not `onError(..., { status: 403 })`. EntityDetail wires `onVerdictFlip` to a toast-only handler — no loadView retrigger. server 403s continue to flow through `onError` and trigger loadView as before.
+
+  This also makes the verdict-flip path unit-testable in isolation from server-error handling. Both callbacks distinct, distinct test cases.
+---

--- a/tickets/entities/review-responses/RR-FB2D.md
+++ b/tickets/entities/review-responses/RR-FB2D.md
@@ -1,0 +1,24 @@
+---
+id: RR-FB2D
+type: review-response
+title: 'Round 2 NEW-4..NEW-10: minor concerns'
+finding: |
+  - NEW-4: `watch(() => props.fields)` fires on every parent render because buildSectionEditFields returns new array each time.
+  - NEW-5: applyServerProperty(prop, undefined) should delete formData[prop] (not set undefined), mirroring DynamicForm L923-929.
+  - NEW-6: 401 should refetch like 403.
+  - NEW-7: onError info on content/relations channels untested.
+  - NEW-8: pendingRefetch race window documented.
+  - NEW-9: AutoSaveOptions required-fields no-op list documented for SectionEditForm.
+  - NEW-10: formData and initialServerSnapshot must spread independently.
+severity: minor
+status: addressed
+resolution: |
+  PLAN amended:
+  - NEW-4: EntityDetail wraps `buildSectionEditFields(section, entry)` in `computed(() => ...)` keyed off section and entry so the array identity stabilises across renders. SectionEditForm's `watch` only fires when verdicts actually change.
+  - NEW-5: SectionEditForm's applyServerProperty deletes the key when value is undefined, matching DynamicForm. handlePropertyApplied likewise: `if (value === undefined) delete next.properties[prop]; else next.properties[prop] = value`.
+  - NEW-6: handleSectionEditError refetches on `info.status === 401 || info.status === 403`.
+  - NEW-7: useAutoSave.test.ts gains content + relations channel onError-info smoke tests.
+  - NEW-8: documented as an accepted race; no fix needed.
+  - NEW-9: PLAN AC 4 enumerates the no-op closures and refs SectionEditForm passes for unused channels.
+  - NEW-10: PLAN AC 4 explicitly spreads initialValues twice (once for formData, once for initialServerSnapshot.properties).
+---

--- a/tickets/entities/tickets/TKT-IHC7B.md
+++ b/tickets/entities/tickets/TKT-IHC7B.md
@@ -5,7 +5,7 @@ title: Properties-section inline edit via SectionEditForm
 kind: enhancement
 priority: high
 effort: m
-status: backlog
+status: planning
 ---
 
 ## Goal

--- a/tickets/entities/tickets/TKT-IHC7B.md
+++ b/tickets/entities/tickets/TKT-IHC7B.md
@@ -5,7 +5,7 @@ title: Properties-section inline edit via SectionEditForm
 kind: enhancement
 priority: high
 effort: m
-status: planning
+status: done
 ---
 
 ## Goal

--- a/tickets/relations/TKT-IHC7B--has-implementation--IMPL-IHC7B.md
+++ b/tickets/relations/TKT-IHC7B--has-implementation--IMPL-IHC7B.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-implementation
+to: IMPL-IHC7B
+---

--- a/tickets/relations/TKT-IHC7B--has-planning--PLAN-IHC7B.md
+++ b/tickets/relations/TKT-IHC7B--has-planning--PLAN-IHC7B.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-planning
+to: PLAN-IHC7B
+---

--- a/tickets/relations/TKT-IHC7B--has-review--REV-IHC7B.md
+++ b/tickets/relations/TKT-IHC7B--has-review--REV-IHC7B.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review
+to: REV-IHC7B
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1A.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1A
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1B.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1B.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1B
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1C.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1C
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1D.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1D.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1D
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1E.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1E
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1F.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1F
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1G.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1G.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1G
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1H.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1H.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1H
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1I.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1I
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1J.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1J.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1J
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1K.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1K.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1K
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1L.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1L
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1M.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1M
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1N.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1N
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1O.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1O
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1P.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1P.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1P
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1Q.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB1Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB1Q
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB2A.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB2A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB2A
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB2B.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB2B.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB2B
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB2C.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB2C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB2C
+---

--- a/tickets/relations/TKT-IHC7B--has-review-response--RR-FB2D.md
+++ b/tickets/relations/TKT-IHC7B--has-review-response--RR-FB2D.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IHC7B
+relation: has-review-response
+to: RR-FB2D
+---


### PR DESCRIPTION
**Stacked on #912 (TKT-IHC7A).** Will rebase onto `develop` once #912 merges.

## Summary

- `useAutoSave.onError` gains structured `info: { status, property, channel }` so a host can dispatch on 401/403 distinctly from validation errors. Additive; existing callers ignore the second arg.
- New `SectionEditForm.vue` hosts one section's properties on a content+relations-disabled `useAutoSave`. Owns iteration (RR-UE3C); discriminated union on `fields` prop separates schema-resolved from hint-resolved widgets cleanly. Verdict-flip watcher fires `onVerdictFlip` (distinct from `onError`) so client reconciliation toasts don't trigger the 403 refetch path.
- `EntityDetail`'s properties section branches to `SectionEditForm` via `:key="entry.type/entry.id"` when any field is writable per `_fields`. Stale-response writes are guarded by an owner-identity match. Routing helpers extracted to `sectionEditFields.ts` for testability.
- Shared `utils/affordances.ts` + `utils/formValue.ts` extract `isFieldWritable` / `optionVerdictsFor` / `isClearedForType` so `DynamicForm` and `SectionEditForm` route through identical logic. `DynamicForm` refactored to use them; no behaviour change.
- Three rounds of design review captured 21 findings (RR-FB1A..RR-FB1Q + RR-FB2A..RR-FB2D); all addressed.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (warnings unchanged from `develop`)
- [x] `npm run test:run` — 1005/1005 (961 baseline + 44 new across `useAutoSave` / `affordances` / `formValue` / `SectionEditForm` / `sectionEditFields`)
- [ ] `e2e/tests/checkboxes.spec.ts` unchanged — CI will run; this ticket touches the properties channel, content channel from TKT-IHC7A is untouched