### PR TITLE
test: replace sleep-based sync with deterministic signals in watcher/SSE tests

### DIFF
--- a/internal/dataentry/router_security_test.go
+++ b/internal/dataentry/router_security_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 )
 
 // newSecuredTestApp returns an app with the security middlewares wired up
@@ -124,17 +123,18 @@ func TestSecuredRouter_AllowsSameOriginSSE(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/api/events", http.NoBody)
 	r.Host = "127.0.0.1:8080"
 	r.Header.Set("Origin", "http://127.0.0.1:8080")
-	// Cancel the context quickly so the long-lived handler returns.
+	// Cancel the context once the handler has flushed its keepalive so
+	// the long-lived handler returns.
 	ctx, cancel := context.WithCancel(r.Context())
 	r = r.WithContext(ctx)
-	w := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+	w := newFlusherRecorder()
 
 	done := make(chan struct{})
 	go func() {
 		h.ServeHTTP(w, r)
 		close(done)
 	}()
-	time.Sleep(20 * time.Millisecond)
+	w.awaitFlush(t)
 	cancel()
 	<-done
 

--- a/internal/dataentry/router_test.go
+++ b/internal/dataentry/router_test.go
@@ -1,6 +1,7 @@
 package dataentry
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -87,12 +88,9 @@ func TestNewRouterSSEEndpoint(t *testing.T) {
 	handler := app.NewRouter()
 
 	// SSE endpoint should respond with event-stream content type
-	r := httptest.NewRequest(http.MethodGet, "/api/events", http.NoBody)
-	w := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
-	// We need to cancel the context to prevent the handler from blocking forever
-	ctx, cancel := r.Context(), func() {}
-	_ = ctx
-	r = r.WithContext(r.Context())
+	ctx, cancel := context.WithCancel(context.Background())
+	r := httptest.NewRequest(http.MethodGet, "/api/events", http.NoBody).WithContext(ctx)
+	w := newFlusherRecorder()
 
 	done := make(chan struct{})
 	go func() {
@@ -100,16 +98,12 @@ func TestNewRouterSSEEndpoint(t *testing.T) {
 		close(done)
 	}()
 
-	// Wait briefly for initial response
-	select {
-	case <-done:
-		// Handler returned, check response
-	default:
-		// Handler is still running (expected for SSE), cancel it
-		cancel()
-	}
+	// Wait for the initial keepalive flush, then end the long-lived handler.
+	w.awaitFlush(t)
+	cancel()
+	<-done
 
-	// The SSE handler may not finish immediately in this test setup
-	// since httptest.NewRecorder's Flush implementation differs,
-	// but we verify the endpoint is registered and reachable.
+	if ct := w.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("expected Content-Type text/event-stream, got %q", ct)
+	}
 }

--- a/internal/dataentry/watcher_test.go
+++ b/internal/dataentry/watcher_test.go
@@ -309,14 +309,40 @@ func TestReloadBadConfigKeepsPrevious(t *testing.T) {
 // --- handleSSE tests ---
 
 // flusherRecorder wraps httptest.ResponseRecorder to implement http.Flusher.
+// Each Flush is signaled on the flushes channel so tests can wait for the
+// SSE handler to reach a known point (subscribed + keepalive written, event
+// written) instead of sleeping.
 type flusherRecorder struct {
 	*httptest.ResponseRecorder
-	flushed int
+	flushes chan struct{}
+}
+
+func newFlusherRecorder() *flusherRecorder {
+	return &flusherRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		flushes:          make(chan struct{}, 16),
+	}
 }
 
 func (f *flusherRecorder) Flush() {
-	f.flushed++
 	f.ResponseRecorder.Flush()
+	if f.flushes == nil {
+		return
+	}
+	select {
+	case f.flushes <- struct{}{}:
+	default: // a full buffer already signals "flushed"; never block the handler
+	}
+}
+
+// awaitFlush blocks until the handler's next Flush call.
+func (f *flusherRecorder) awaitFlush(t *testing.T) {
+	t.Helper()
+	select {
+	case <-f.flushes:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for SSE flush")
+	}
 }
 
 func TestHandleSSEHeaders(t *testing.T) {
@@ -324,7 +350,7 @@ func TestHandleSSEHeaders(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	r := httptest.NewRequest(http.MethodGet, "/api/events", http.NoBody).WithContext(ctx)
-	w := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+	w := newFlusherRecorder()
 
 	// Run handler in goroutine since it blocks until context is cancelled
 	done := make(chan struct{})
@@ -333,8 +359,8 @@ func TestHandleSSEHeaders(t *testing.T) {
 		close(done)
 	}()
 
-	// Give handler time to write headers and initial keepalive
-	time.Sleep(50 * time.Millisecond)
+	// The first flush means headers and the initial keepalive are written.
+	w.awaitFlush(t)
 	cancel()
 	<-done
 
@@ -364,7 +390,7 @@ func TestHandleSSEReceivesEvent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	r := httptest.NewRequest(http.MethodGet, "/api/events", http.NoBody).WithContext(ctx)
-	w := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+	w := newFlusherRecorder()
 
 	done := make(chan struct{})
 	go func() {
@@ -372,14 +398,15 @@ func TestHandleSSEReceivesEvent(t *testing.T) {
 		close(done)
 	}()
 
-	// Wait for handler to subscribe
-	time.Sleep(50 * time.Millisecond)
+	// The keepalive flush happens after the handler subscribes, so the
+	// broadcast below is guaranteed to reach its channel.
+	w.awaitFlush(t)
 
 	// Broadcast an event
 	app.broker.broadcast("refresh")
 
-	// Wait for event to be written
-	time.Sleep(50 * time.Millisecond)
+	// Wait for the event to be written
+	w.awaitFlush(t)
 	cancel()
 	<-done
 

--- a/internal/storage/watcher_test.go
+++ b/internal/storage/watcher_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -211,6 +212,21 @@ func TestChangeOp_String(t *testing.T) {
 	}
 }
 
+// waitWatched polls until path shows up in the watch list, failing the
+// test after a generous deadline. Used where the event loop registers
+// watches asynchronously (auto-watching newly created directories).
+func waitWatched(t *testing.T, w *Watcher, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if slices.Contains(w.WatchList(), path) {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %s to be watched", path)
+}
+
 func TestWatcher_FileChangeEvents(t *testing.T) {
 	dir := t.TempDir()
 
@@ -231,8 +247,8 @@ func TestWatcher_FileChangeEvents(t *testing.T) {
 	go w.Start()
 	defer w.Stop()
 
-	// Give the watcher time to start
-	time.Sleep(100 * time.Millisecond)
+	// No startup wait needed: NewWatcher registers the fsnotify watches
+	// synchronously, and events queue until Start drains them.
 
 	// Create a file
 	testFile := filepath.Join(dir, "test.md")
@@ -281,26 +297,35 @@ func TestWatcher_IgnoresNonMatchingExtensions(t *testing.T) {
 	go w.Start()
 	defer w.Stop()
 
-	// Give the watcher time to start
-	time.Sleep(100 * time.Millisecond)
-
-	// Create a non-matching file
-	testFile := filepath.Join(dir, "test.txt")
-	if err := os.WriteFile(testFile, []byte("hello"), 0o644); err != nil {
+	// Create a non-matching file, then a matching sentinel. The sentinel's
+	// arrival proves the watcher already processed (and filtered) the .txt
+	// event — no quiet-window sleep needed.
+	txtFile := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(txtFile, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mdFile := filepath.Join(dir, "sentinel.md")
+	if err := os.WriteFile(mdFile, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	// Should not receive event for .txt file
-	select {
-	case events := <-eventsChan:
-		// Check if any event is for our .txt file (shouldn't be)
-		for _, e := range events {
-			if e.Path == testFile {
-				t.Errorf("should not receive event for non-matching extension: %v", e)
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case events := <-eventsChan:
+			for _, e := range events {
+				if e.Path == txtFile {
+					t.Errorf("should not receive event for non-matching extension: %v", e)
+				}
 			}
+			for _, e := range events {
+				if e.Path == mdFile {
+					return // sentinel arrived; .txt was filtered
+				}
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for sentinel .md event")
 		}
-	case <-time.After(200 * time.Millisecond):
-		// Expected: no event for non-matching extension
 	}
 }
 
@@ -324,17 +349,15 @@ func TestWatcher_AutoWatchesNewDirectories(t *testing.T) {
 	go w.Start()
 	defer w.Stop()
 
-	// Give the watcher time to start
-	time.Sleep(100 * time.Millisecond)
-
 	// Create a new subdirectory
 	subDir := filepath.Join(dir, "subdir")
 	if err := os.Mkdir(subDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	// Give time for the directory to be watched
-	time.Sleep(150 * time.Millisecond)
+	// The event loop auto-watches new directories asynchronously; wait
+	// until the watch is actually registered before writing into it.
+	waitWatched(t, w, subDir)
 
 	// Create a file in the new subdirectory
 	testFile := filepath.Join(subDir, "test.md")
@@ -385,9 +408,6 @@ func TestWatcher_FileModifyAndDelete(t *testing.T) {
 
 	go w.Start()
 	defer w.Stop()
-
-	// Give the watcher time to start
-	time.Sleep(100 * time.Millisecond)
 
 	// Modify the file
 	if err := os.WriteFile(testFile, []byte("modified"), 0o644); err != nil {

--- a/tickets/entities/tickets/TKT-ZYM0B6.md
+++ b/tickets/entities/tickets/TKT-ZYM0B6.md
@@ -1,0 +1,43 @@
+---
+id: TKT-ZYM0B6
+type: ticket
+title: Replace sleep-based sync with deterministic signals in watcher/SSE tests
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Goal
+
+A test-quality review identified the sleep-based synchronization in the fsnotify
+watcher and SSE tests as the repo's main CI flake risk. Replace the fixed sleeps
+with deterministic synchronization.
+
+## Scope
+
+### internal/storage/watcher_test.go
+
+- Drop the three 100ms "give the watcher time to start" sleeps: `NewWatcher` registers all fsnotify watches synchronously, so events occurring after it returns are queued and delivered once `Start` drains them.
+- `TestWatcher_AutoWatchesNewDirectories`: the event loop auto-watches new directories asynchronously — wait for the watch via a `waitWatched` poll-with-deadline helper on `WatchList()` instead of a fixed 150ms sleep.
+- `TestWatcher_IgnoresNonMatchingExtensions`: convert from negative evidence (200ms quiet window) to positive evidence — write the non-matching `.txt`, then a matching `.md` sentinel; the sentinel's arrival proves the `.txt` event was processed and filtered.
+
+### internal/dataentry SSE tests
+
+- `flusherRecorder` signals each `Flush` on a channel with an `awaitFlush(t)` helper. The SSE handler flushes after subscribing + writing the keepalive and after each event, so flushes are exact synchronization points.
+- `TestHandleSSEHeaders`, `TestHandleSSEReceivesEvent`, `TestSecuredRouter_AllowsSameOriginSSE`: replace 50ms/20ms sleeps with `awaitFlush`.
+- `TestNewRouterSSEEndpoint` was broken (no-op cancel, leaked handler goroutine, asserted nothing) — rewritten to wait for the keepalive flush, cancel, join the goroutine, and assert the `text/event-stream` content type.
+
+## Out of scope
+
+- The 100ms quiet window in `sse_audit_isolation_test.go` — inherent to its assert-nothing-happens confidentiality guard.
+- The 200ms bounded stress duration in `TestConcurrentReadDuringOnReload` — a stress budget, not a sync sleep.
+- Deliberate server-handler delays in timeout tests (`lua/http_test.go`, `ai/openai_test.go`).
+
+## Verification
+
+- `go test -race -count=10 -run TestWatcher ./internal/storage/` passes.
+- `go test -race -count=3` on the dataentry SSE/broker tests passes.
+- Full `just ci` green.
+
+PR: https://github.com/sourcehaven-bv/rela/pull/945

--- a/tickets/relations/TKT-ZYM0B6--affects--test-isolation.md
+++ b/tickets/relations/TKT-ZYM0B6--affects--test-isolation.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYM0B6
+relation: affects
+to: test-isolation
+---

--- a/tickets/relations/TKT-ZYM0B6--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-ZYM0B6--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYM0B6
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Removes the fixed-sleep synchronization that made the fsnotify watcher and SSE tests the main CI flake risk (identified in a test-quality review).

## internal/storage/watcher_test.go

- Dropped the three 100ms "give the watcher time to start" sleeps: `NewWatcher` registers all fsnotify watches synchronously, so events occurring after it returns are queued and delivered once `Start` drains them — no startup wait is needed.
- `TestWatcher_AutoWatchesNewDirectories`: the only real race (the event loop auto-watches new directories asynchronously) is now handled by `waitWatched`, a poll-with-deadline helper on `WatchList()`, instead of a fixed 150ms sleep.
- `TestWatcher_IgnoresNonMatchingExtensions`: converted from negative evidence (200ms quiet window) to positive evidence — write the non-matching `.txt`, then a matching `.md` sentinel; the sentinel's arrival proves the `.txt` event was processed and filtered. Deterministic and faster.

## internal/dataentry (SSE tests)

- `flusherRecorder` now signals each `Flush` on a channel, with an `awaitFlush(t)` helper. The SSE handler flushes after subscribing + writing the keepalive and after each event, so flushes are exact sync points.
- `TestHandleSSEHeaders`, `TestHandleSSEReceivesEvent`, `TestSecuredRouter_AllowsSameOriginSSE`: 50ms/20ms sleeps replaced with `awaitFlush`.
- `TestNewRouterSSEEndpoint` was previously broken — its `cancel` was a no-op `func(){}`, it leaked the handler goroutine, and asserted nothing. Now it waits for the keepalive flush, cancels, joins the goroutine, and asserts the `text/event-stream` content type.

Left intentionally untouched: the 100ms quiet window in `sse_audit_isolation_test.go` (inherent to its assert-nothing-happens confidentiality guard) and the 200ms bounded stress duration in `TestConcurrentReadDuringOnReload`.

Verified: `go test -race -count=10 -run TestWatcher ./internal/storage/` and `-count=3` on the dataentry SSE/broker tests pass; full `just ci` green.