### PR TITLE
fix(frontend): three quick fixes from the Vue review

### DIFF
--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -755,6 +755,9 @@ const autoSave = computed(() => {
 })
 // Lazy holder so we construct the composable once per (entityId, formId).
 const _autoSaveInstance = ref<ReturnType<typeof useAutoSave> | null>(null)
+// Dirty-registry cleanup, assigned in onMounted (after awaits) and run
+// from the top-level onBeforeUnmount.
+let unregisterDirtyForm: (() => void) | null = null
 
 function buildAutoSaveRelationsBody(): ModernRelationsField | null {
   // Mirror handleSubmit's body assembly. Two sources of relation
@@ -932,11 +935,13 @@ onMounted(async () => {
     })
     // Register with the dirty registry so SSE-driven re-fetches in
     // other forms on the same entity preserve this form's dirty state.
-    const unregister = registerForm(
+    // The cleanup runs from the top-level onBeforeUnmount below —
+    // registering a lifecycle hook after an `await` has no active
+    // instance, so Vue would silently drop it and leak the registration.
+    unregisterDirtyForm = registerForm(
       props.entityId,
       (property) => _autoSaveInstance.value?.isDirty(property) ?? false,
     )
-    onBeforeUnmount(unregister)
   }
 
   // TKT-GFQK pre-flight: a `direction: incoming` widget on a relation
@@ -961,6 +966,8 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   window.removeEventListener('beforeunload', handleBeforeUnload)
   document.removeEventListener('keydown', handleKeydown)
+  unregisterDirtyForm?.()
+  unregisterDirtyForm = null
   // TKT-3I5U: cancel any pending / in-flight staged dry-run, and mark
   // the component as gone so a response that has already arrived (but
   // is awaiting the microtask queue) doesn't write to dead refs

--- a/frontend/src/components/forms/dirtyFormRegistry.test.ts
+++ b/frontend/src/components/forms/dirtyFormRegistry.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
+import { defineComponent, h, onBeforeUnmount, onMounted } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
 import { registerForm, anyFormDirty, _registrySize, _registryClear } from './dirtyFormRegistry'
 
 describe('dirtyFormRegistry', () => {
@@ -57,6 +59,35 @@ describe('dirtyFormRegistry', () => {
       u1()
       u2()
     }
+    expect(_registrySize()).toBe(0)
+  })
+
+  it('unregisters when registration happens after an await in onMounted', async () => {
+    // Replicates DynamicForm's lifecycle: registration runs inside async
+    // onMounted after an await, where calling onBeforeUnmount(unregister)
+    // has no active instance and Vue silently drops the hook. The fixed
+    // pattern stores the unregister fn and calls it from a top-level
+    // onBeforeUnmount registered synchronously during setup.
+    const Harness = defineComponent({
+      setup() {
+        let unregister: (() => void) | null = null
+        onBeforeUnmount(() => {
+          unregister?.()
+          unregister = null
+        })
+        onMounted(async () => {
+          await Promise.resolve()
+          unregister = registerForm('TKT-001', () => true)
+        })
+        return () => h('div')
+      },
+    })
+
+    const wrapper = mount(Harness)
+    await flushPromises()
+    expect(_registrySize()).toBe(1)
+
+    wrapper.unmount()
     expect(_registrySize()).toBe(0)
   })
 })

--- a/frontend/src/components/ui/HelpModal.vue
+++ b/frontend/src/components/ui/HelpModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
 import axios from 'axios'
+import DOMPurify from 'dompurify'
 import { isCancelledFetch } from '@/composables/usePageData'
 
 const props = defineProps<{
@@ -25,7 +26,10 @@ async function loadHelp() {
 
   try {
     const response = await axios.get(`/api/help/${props.entityType}`)
-    helpContent.value = response.data
+    // The server renders metamodel descriptions with goldmark in unsafe
+    // mode (raw HTML passes through), so sanitize at the sink like every
+    // other v-html consumer (utils/markdown.ts, DocumentView).
+    helpContent.value = DOMPurify.sanitize(response.data)
   } catch (err) {
     // Suppress cancellation errors from rapid navigation in Firefox
     // (see BUG-6C3V and src/composables/usePageData.ts).

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { useSchemaStore, useEntitiesStore } from '@/stores'
+import { useSchemaStore, useEntitiesStore, useUIStore } from '@/stores'
 import { listEntities, updateEntity } from '@/api'
 import type { Entity, KanbanConfig } from '@/types'
 import Badge from '@/components/common/Badge.vue'
@@ -16,6 +16,7 @@ const props = defineProps<{
 const router = useRouter()
 const schemaStore = useSchemaStore()
 const entitiesStore = useEntitiesStore()
+const uiStore = useUIStore()
 
 // Back affordance — renders when ?return_to= or ?from= is present.
 const backTarget = useBackTarget()
@@ -293,6 +294,10 @@ async function onDrop(event: DragEvent, columnValue: string, swimlaneValue?: str
       entity.properties[prop] = val
     }
     console.error('Failed to update entity:', err)
+    // The API interceptor rejects with a raw ProblemDetail object, not
+    // an Error — read its fields directly so the server message survives.
+    const problem = err as { detail?: string; title?: string } | null
+    uiStore.error(problem?.detail || problem?.title || 'Failed to move card')
   }
 
   draggedCard.value = null
@@ -452,7 +457,7 @@ watch(() => entitiesStore.cacheVersion, () => {
             v-for="entity in entitiesByCell[column.value]?.[swimlane.value] || []"
             :key="entity.id"
             class="kanban-card"
-            draggable="true"
+            :draggable="canUpdate(entity) ? 'true' : 'false'"
             @dragstart="onDragStart($event, entity)"
             @dragend="onDragEnd"
             @click="openCard(entity)"

--- a/tickets/entities/automated-measures/dirty-registry-async-unmount-test.md
+++ b/tickets/entities/automated-measures/dirty-registry-async-unmount-test.md
@@ -1,0 +1,9 @@
+---
+id: dirty-registry-async-unmount-test
+type: automated-measure
+title: 'Regression test: dirty-registry unregisters when registration happens after an await in onMounted'
+description: Vitest component test mounting a harness that replicates DynamicForm's lifecycle (registration inside async onMounted after an await, cleanup via a synchronously registered top-level onBeforeUnmount) and asserting the registry empties on unmount.
+kind: test
+location: frontend/src/components/forms/dirtyFormRegistry.test.ts
+status: active
+---

--- a/tickets/entities/bugs/BUG-DTE2FF.md
+++ b/tickets/entities/bugs/BUG-DTE2FF.md
@@ -1,0 +1,19 @@
+---
+id: BUG-DTE2FF
+type: bug
+title: DynamicForm dirty-registry cleanup never runs (onBeforeUnmount after await)
+description: 'Every edit-form mount leaked its DirtyCheck closure into dirtyFormRegistry: the onBeforeUnmount(unregister) call sat inside async onMounted after several awaits, where Vue has no active component instance, so the hook was silently dropped. A form unmounted while a property was dirty would permanently report that property dirty for its entity, suppressing the SSE merge path the registry exists to control (TKT-18JS6). Fixed in PR #946 by storing the unregister fn at setup scope and calling it from the existing top-level onBeforeUnmount. The PR bundles two further quick fixes from the frontend review: HelpModal now sanitizes /api/help HTML with DOMPurify like every other v-html sink, and Kanban swimlane cards gate draggable on canUpdate() like the simple board (failed drops now toast the server message).'
+priority: medium
+effort: s
+why1: onBeforeUnmount(unregister) was invoked inside async onMounted after awaits; Vue can only associate lifecycle hooks with an instance during synchronous execution, so the hook was silently dropped (dev-only console warning).
+why2: The registration depends on values produced by the awaited loads (entityId, formConfig, the autosave instance), so it was written inline at the point those values exist, without realizing hook registration itself must stay synchronous with setup.
+why3: No test exercised a mount/unmount cycle of an edit form against the registry, and vue/no-lifecycle-after-await only flags awaits at setup() top level, not inside an onMounted callback — so neither CI nor lint caught it.
+why4: The registry's consumer side (anyFormDirty in the SSE merge path) was never wired up, so the leak had no observable symptom that would have surfaced it in use.
+why5: Cross-cutting mechanisms landed half-built (registry without consumer, ETag plumbing without population) fail invisibly; landing mechanism and consumer together — or tracking the missing half as an explicit ticket — removes the class.
+prevention: Regression test in dirtyFormRegistry.test.ts replicates the async-onMounted registration pattern and asserts the registry empties on unmount. Comment at the registration site documents why cleanup must route through the top-level onBeforeUnmount. The unwired consumer side (SSE merge / anyFormDirty) is recorded in the frontend review as an explicit follow-up so the half-built mechanism is tracked rather than latent.
+status: done
+---
+
+Found during the 2026-06-09 frontend architecture review. Fixed in PR #946
+together with two sibling review findings (HelpModal v-html sanitization, Kanban
+swimlane affordance gate).

--- a/tickets/relations/BUG-DTE2FF--adds-measure--dirty-registry-async-unmount-test.md
+++ b/tickets/relations/BUG-DTE2FF--adds-measure--dirty-registry-async-unmount-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-DTE2FF
+relation: adds-measure
+to: dirty-registry-async-unmount-test
+---

--- a/tickets/relations/BUG-DTE2FF--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-DTE2FF--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-DTE2FF
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-DTE2FF--fixes--FEAT-XN6JX.md
+++ b/tickets/relations/BUG-DTE2FF--fixes--FEAT-XN6JX.md
@@ -1,0 +1,5 @@
+---
+from: BUG-DTE2FF
+relation: fixes
+to: FEAT-XN6JX
+---


### PR DESCRIPTION
Three small fixes from the frontend review:

**HelpModal: sanitize server HTML before `v-html`** — `/api/help/<type>` renders metamodel descriptions through goldmark with `html.WithUnsafe()` (raw HTML passes through), and HelpModal was the only `v-html` sink not running DOMPurify. Now sanitized at the sink, consistent with `utils/markdown.ts`, DocumentView, and DocumentsPanel.

**KanbanView: swimlane cards now respect the update affordance** — the swimlane board hardcoded `draggable="true"` while the simple board gates on `canUpdate(entity)`; copy-paste drift. Also: a failed drop now shows a toast with the server's ProblemDetail message instead of silently snapping the card back with only a `console.error`.

**DynamicForm: dirty-registry no longer leaks on unmount** — `onBeforeUnmount(unregister)` was registered after `await`s inside async `onMounted`, where there is no active instance, so Vue silently dropped the hook and every edit-form mount leaked its `DirtyCheck` into `dirtyFormRegistry` (a form unmounted while dirty would permanently report that property dirty, suppressing SSE merges — TKT-18JS6). The unregister fn is now stored and called from the existing top-level `onBeforeUnmount`. Regression test added replicating the lifecycle pattern.

Typecheck, lint, and all 962 unit tests pass.