### PR TITLE
fix(dataentry): contain conflict endpoint paths + ACL/audit on resolve

### DIFF
--- a/internal/conflict/resolve.go
+++ b/internal/conflict/resolve.go
@@ -132,28 +132,31 @@ func resolveRelation(cf *ConflictedFile, resolution *Resolution) *entity.Relatio
 	return resolved
 }
 
+// ValidateResolved checks a resolved entity against the metamodel.
+// Relations carry no metamodel validation on this path. A nil entity
+// or metamodel validates trivially.
+func ValidateResolved(e *entity.Entity, meta *metamodel.Metamodel) error {
+	if e == nil || meta == nil {
+		return nil
+	}
+	if errs := meta.ValidateEntity(e.ID, e.Type, e.Properties); len(errs) > 0 {
+		return fmt.Errorf("validation failed: %w", errs[0])
+	}
+	return nil
+}
+
 // ResolveAndWrite resolves a conflict and writes the result to disk.
+// Callers that need to gate the write (e.g. on an ACL decision) should
+// compose [Resolve], [ValidateResolved], and [WriteResolved] instead.
 func ResolveAndWrite(cf *ConflictedFile, resolution *Resolution, meta *metamodel.Metamodel) error {
 	e, relation, err := Resolve(cf, resolution)
 	if err != nil {
 		return err
 	}
-
-	if e != nil {
-		// Validate entity before writing
-		if meta != nil {
-			if errs := meta.ValidateEntity(e.ID, e.Type, e.Properties); len(errs) > 0 {
-				return fmt.Errorf("validation failed: %w", errs[0])
-			}
-		}
-		return writeEntityFile(cf.Path, e)
+	if err := ValidateResolved(e, meta); err != nil {
+		return err
 	}
-
-	if relation != nil {
-		return writeRelationFile(cf.Path, relation)
-	}
-
-	return errors.New("nothing to write")
+	return WriteResolved(cf.Path, e, relation)
 }
 
 // AcceptOurs resolves a conflict by accepting all values from "ours" (HEAD).

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -49,6 +49,21 @@ func translateVerb(verb, entityType, entityID string) acl.WriteRequest {
 	panic("dataentry.translateVerb: unknown verb: " + verb)
 }
 
+// translateRelationWrite maps a relation write to the [acl.WriteRequest]
+// that authorizes it, mirroring how entitymanager gates relation
+// updates: Op=update with a [acl.RelationSubject] evaluated against the
+// source entity's type. It lives here so the lint_test
+// single-construction-site invariant covers relation writes too; the
+// only caller today is the conflict-resolve handler, whose write is
+// file-level and cannot route through entitymanager.
+func translateRelationWrite(relType, fromType, fromID string) acl.WriteRequest {
+	return acl.WriteRequest{Op: acl.OpUpdate, Subject: acl.RelationSubject{
+		Type:     relType,
+		FromType: fromType,
+		FromID:   fromID,
+	}}
+}
+
 // perItemVerbs are the verbs computed per entity instance.
 var perItemVerbs = []string{"update", "delete", "rename"}
 

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -13,7 +13,10 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/conflict"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
@@ -21,6 +24,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
@@ -2488,9 +2492,12 @@ func (a *App) handleV1ConflictRoutes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get conflict details
-	ctx := a.paths
-	absPath := filepath.Join(ctx.Root, path)
+	// Get conflict details. The path is caller-supplied — contain it to
+	// the project root before any filesystem access.
+	absPath, ok := a.resolveConflictPath(w, r, path)
+	if !ok {
+		return
+	}
 
 	cf, err := conflict.ParseConflictedFile(absPath, a.State().Meta)
 	if err != nil {
@@ -2536,10 +2543,19 @@ func (a *App) handleV1ConflictResolve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := a.paths
-	absPath := filepath.Join(ctx.Root, req.Path)
+	// The path is caller-supplied — contain it to the project root
+	// before any filesystem access.
+	absPath, ok := a.resolveConflictPath(w, r, req.Path)
+	if !ok {
+		return
+	}
 
-	cf, err := conflict.ParseConflictedFile(absPath, a.State().Meta)
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
+
+	st := a.State()
+
+	cf, err := conflict.ParseConflictedFile(absPath, st.Meta)
 	if err != nil {
 		writeV1Error(w, r, http.StatusInternalServerError, "parse_failed", "Failed to parse conflict", err.Error())
 		return
@@ -2568,14 +2584,121 @@ func (a *App) handleV1ConflictResolve(w http.ResponseWriter, r *http.Request) {
 		resolution.ContentChoice = conflict.SideOurs
 	}
 
-	if err := conflict.ResolveAndWrite(cf, resolution, a.State().Meta); err != nil {
+	// Resolve first so the ACL gate evaluates the actual write target
+	// (entity vs relation, post-choice identity), then authorize, then
+	// write. The write is file-level marker removal and cannot route
+	// through entitymanager — the store can't parse a file that still
+	// contains conflict markers — so this handler re-authorizes and
+	// audits explicitly. The store's file watcher picks the change up
+	// as an external edit, keeping index/SSE consumers in sync.
+	resolvedEntity, resolvedRelation, err := conflict.Resolve(cf, resolution)
+	if err != nil {
 		writeV1Error(w, r, http.StatusInternalServerError, "resolve_failed", "Failed to resolve", err.Error())
 		return
 	}
+	if !a.authorizeConflictResolve(r.Context(), w, resolvedEntity, resolvedRelation) {
+		return
+	}
+	if err := conflict.ValidateResolved(resolvedEntity, st.Meta); err != nil {
+		writeV1Error(w, r, http.StatusInternalServerError, "resolve_failed", "Failed to resolve", err.Error())
+		return
+	}
+	if err := conflict.WriteResolved(absPath, resolvedEntity, resolvedRelation); err != nil {
+		writeV1Error(w, r, http.StatusInternalServerError, "resolve_failed", "Failed to resolve", err.Error())
+		return
+	}
+	a.recordConflictResolveAudit(r.Context(), req.Path, resolvedEntity, resolvedRelation)
 
 	writeV1JSON(w, http.StatusOK, map[string]interface{}{
 		"success": true,
 		"path":    req.Path,
+	})
+}
+
+// resolveConflictPath contains the caller-supplied conflict-file path
+// to the project root. On failure it writes the error response (404
+// when the path is inside the project but missing, 403 when it escapes
+// the root) and returns ok=false.
+func (a *App) resolveConflictPath(w http.ResponseWriter, r *http.Request, p string) (string, bool) {
+	resolved, err := containedProjectPath(a.paths.Root, p)
+	switch {
+	case errors.Is(err, errPathNotFound):
+		writeV1Error(w, r, http.StatusNotFound, "conflict_not_found", "Conflicted file not found", "")
+		return "", false
+	case err != nil:
+		writeV1Error(w, r, http.StatusForbidden, "path_outside_project", "Path is outside the project root", "")
+		return "", false
+	}
+	return resolved, true
+}
+
+// conflictAuditSubject derives the audit subject for a resolved
+// conflict write. Exactly one of e / rel is non-nil ([conflict.Resolve]
+// errors otherwise).
+func conflictAuditSubject(e *entityPkg.Entity, rel *entityPkg.Relation) *audit.Subject {
+	if rel != nil {
+		return &audit.Subject{
+			Kind:         "relation",
+			RelationType: rel.Type,
+			FromID:       rel.From,
+			ToID:         rel.To,
+		}
+	}
+	return &audit.Subject{Kind: "entity", Type: e.Type, ID: e.ID}
+}
+
+// authorizeConflictResolve re-authorizes the write a conflict
+// resolution performs. Conflict resolution bypasses entitymanager, so
+// the gate the manager would normally apply lives here: entity files
+// gate like an entity update; relation files gate like a relation
+// update (source-entity type, mirroring entitymanager.UpdateRelation —
+// type left empty when the source entity can't be loaded, the same
+// fallback the manager uses). A deny records a `denied-write` audit
+// row and writes the standard 403 body; returns true when the write
+// may proceed.
+func (a *App) authorizeConflictResolve(ctx context.Context, w http.ResponseWriter, e *entityPkg.Entity, rel *entityPkg.Relation) bool {
+	var aclReq acl.WriteRequest
+	if rel != nil {
+		var fromType string
+		if fromEntity, ok := a.getEntity(ctx, rel.From); ok {
+			fromType = fromEntity.Type
+		}
+		aclReq = translateRelationWrite(rel.Type, fromType, rel.From)
+	} else {
+		aclReq = translateVerb("update", e.Type, e.ID)
+	}
+	decision := a.acl.AuthorizeWrite(ctx, aclReq)
+	if decision.Allow {
+		return true
+	}
+	a.auditSink.Record(audit.Record{
+		Time:        time.Now().UTC(),
+		Op:          audit.OpDeniedWrite,
+		Subject:     conflictAuditSubject(e, rel),
+		Principal:   principal.From(ctx),
+		TriggeredBy: audit.TriggeredByFrom(ctx),
+		Summary: fmt.Sprintf("denied: %s (rule_kind=%s rule_id=%s op=conflict-resolve)",
+			decision.Reason, decision.RuleKind, decision.RuleID),
+	})
+	writeForbiddenIfACLDenied(w, &acl.ForbiddenError{Decision: decision})
+	return false
+}
+
+// recordConflictResolveAudit emits the audit row for a successful
+// conflict resolution — the direct-file-write counterpart of the
+// records entitymanager emits for manager-routed writes.
+func (a *App) recordConflictResolveAudit(ctx context.Context, relPath string, e *entityPkg.Entity, rel *entityPkg.Relation) {
+	op := audit.OpUpdateEntity
+	if rel != nil {
+		op = audit.OpUpdateRelation
+	}
+	a.auditSink.Record(audit.Record{
+		Time:        time.Now().UTC(),
+		Op:          op,
+		Subject:     conflictAuditSubject(e, rel),
+		Principal:   principal.From(ctx),
+		TriggeredBy: audit.TriggeredByFrom(ctx),
+		Summary:     "resolved git conflict in " + relPath,
 	})
 }
 

--- a/internal/dataentry/conflicts_api_test.go
+++ b/internal/dataentry/conflicts_api_test.go
@@ -1,0 +1,261 @@
+package dataentry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+)
+
+const conflictedTicket = `<<<<<<< HEAD
+---
+id: TKT-001
+type: ticket
+title: Ours
+---
+=======
+---
+id: TKT-001
+type: ticket
+title: Theirs
+---
+>>>>>>> incoming
+Body text.
+`
+
+const conflictedRelation = `<<<<<<< HEAD
+---
+from: TKT-001
+relation: blocks
+to: TKT-002
+note: ours
+---
+=======
+---
+from: TKT-001
+relation: blocks
+to: TKT-002
+note: theirs
+---
+>>>>>>> incoming
+`
+
+// newConflictTestApp builds an app bound to a real on-disk project root
+// — the conflict endpoints read and write project files directly.
+func newConflictTestApp(t *testing.T) (app *App, root string) {
+	t.Helper()
+	app = newTestAppV1(t)
+	root = t.TempDir()
+	bindRepo(app, root)
+	return app, root
+}
+
+func writeProjectFile(t *testing.T, root, rel, content string) string {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+func postConflictResolve(app *App, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/_conflicts/resolve", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	app.handleV1ConflictResolve(rec, req)
+	return rec
+}
+
+func TestV1ConflictDetailPathTraversal(t *testing.T) {
+	app, root := newConflictTestApp(t)
+	// A file outside the project root that a traversal could read.
+	secret := filepath.Join(filepath.Dir(root), "secret.md")
+	if err := os.WriteFile(secret, []byte("top secret"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"relative traversal to existing file", "../secret.md"},
+		{"relative traversal to missing file", "../../nope.md"},
+		{"absolute path", "/etc/passwd"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/_conflicts/"+tc.path, http.NoBody)
+			rec := httptest.NewRecorder()
+			app.handleV1ConflictRoutes(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if strings.Contains(rec.Body.String(), "top secret") {
+				t.Error("response leaked file content from outside the project")
+			}
+		})
+	}
+}
+
+func TestV1ConflictDetailContainedPath(t *testing.T) {
+	app, root := newConflictTestApp(t)
+	writeProjectFile(t, root, "entities/ticket/TKT-001.md", conflictedTicket)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_conflicts/entities/ticket/TKT-001.md", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1ConflictRoutes(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "TKT-001") {
+		t.Errorf("expected detail for TKT-001, got: %s", rec.Body.String())
+	}
+}
+
+func TestV1ConflictDetailMissingFile(t *testing.T) {
+	app, _ := newConflictTestApp(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_conflicts/entities/ticket/MISSING.md", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1ConflictRoutes(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestV1ConflictResolvePathTraversal(t *testing.T) {
+	app, root := newConflictTestApp(t)
+	// An existing conflicted file outside the project root: without
+	// containment the resolve endpoint would happily rewrite it.
+	outside := filepath.Join(filepath.Dir(root), "outside.md")
+	if err := os.WriteFile(outside, []byte(conflictedTicket), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	rec := postConflictResolve(app, `{"path":"../outside.md","content_choice":"theirs"}`)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != conflictedTicket {
+		t.Error("file outside the project root was modified")
+	}
+}
+
+func TestV1ConflictResolveACLDenied(t *testing.T) {
+	app, root := newConflictTestApp(t)
+	path := writeProjectFile(t, root, "entities/ticket/TKT-001.md", conflictedTicket)
+	app.acl = acl.ReadOnlyACL{}
+	sink := audit.NewMemory()
+	app.auditSink = sink
+
+	rec := postConflictResolve(app, `{"path":"entities/ticket/TKT-001.md","content_choice":"ours"}`)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "read-only-acl") {
+		t.Errorf("expected structured ACL deny body, got: %s", rec.Body.String())
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != conflictedTicket {
+		t.Error("denied resolve still modified the file")
+	}
+
+	var denied bool
+	for _, r := range sink.Records() {
+		if r.Op == audit.OpDeniedWrite && r.Subject != nil && r.Subject.ID == "TKT-001" {
+			denied = true
+		}
+	}
+	if !denied {
+		t.Errorf("expected a denied-write audit record for TKT-001, got %+v", sink.Records())
+	}
+}
+
+func TestV1ConflictResolveEntityWritesAndAudits(t *testing.T) {
+	app, root := newConflictTestApp(t)
+	path := writeProjectFile(t, root, "entities/ticket/TKT-001.md", conflictedTicket)
+	sink := audit.NewMemory()
+	app.auditSink = sink
+
+	rec := postConflictResolve(app,
+		`{"path":"entities/ticket/TKT-001.md","property_choices":{"title":"theirs"},"content_choice":"theirs"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(got), "<<<<<<<") {
+		t.Errorf("resolved file still contains conflict markers:\n%s", got)
+	}
+	if !strings.Contains(string(got), "Theirs") {
+		t.Errorf("expected theirs-side title in resolved file, got:\n%s", got)
+	}
+
+	var audited bool
+	for _, r := range sink.Records() {
+		if r.Op == audit.OpUpdateEntity && r.Subject != nil &&
+			r.Subject.Kind == "entity" && r.Subject.ID == "TKT-001" {
+
+			audited = true
+		}
+	}
+	if !audited {
+		t.Errorf("expected an update-entity audit record for TKT-001, got %+v", sink.Records())
+	}
+}
+
+func TestV1ConflictResolveRelationWritesAndAudits(t *testing.T) {
+	app, root := newConflictTestApp(t)
+	path := writeProjectFile(t, root, "relations/TKT-001--blocks--TKT-002.md", conflictedRelation)
+	sink := audit.NewMemory()
+	app.auditSink = sink
+
+	rec := postConflictResolve(app,
+		`{"path":"relations/TKT-001--blocks--TKT-002.md","content_choice":"ours"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(got), "<<<<<<<") {
+		t.Errorf("resolved file still contains conflict markers:\n%s", got)
+	}
+
+	var audited bool
+	for _, r := range sink.Records() {
+		if r.Op == audit.OpUpdateRelation && r.Subject != nil &&
+			r.Subject.Kind == "relation" && r.Subject.RelationType == "blocks" {
+
+			audited = true
+		}
+	}
+	if !audited {
+		t.Errorf("expected an update-relation audit record, got %+v", sink.Records())
+	}
+}

--- a/tickets/entities/automated-measures/conflict-endpoint-containment-test.md
+++ b/tickets/entities/automated-measures/conflict-endpoint-containment-test.md
@@ -1,0 +1,9 @@
+---
+id: conflict-endpoint-containment-test
+type: automated-measure
+title: 'Test: conflict endpoints contain paths and re-authorize writes'
+description: 'Regression tests for BUG-JME1DI: GET/POST conflict endpoints reject relative, deep-relative, and absolute path traversal (403, no content leak, no write outside the project root); a denied resolve returns the structured 403 ACL body, leaves the file untouched, and records a denied-write audit row; successful entity and relation resolves remove markers and record update-entity/update-relation audit rows.'
+kind: test
+location: internal/dataentry/conflicts_api_test.go (TestV1ConflictDetailPathTraversal, TestV1ConflictResolvePathTraversal, TestV1ConflictResolveACLDenied, TestV1ConflictResolveEntityWritesAndAudits, TestV1ConflictResolveRelationWritesAndAudits) + internal/dataentry/lint_test.go (TestNoStrayWriteRequestConstruction covers translateRelationWrite)
+status: active
+---

--- a/tickets/entities/bugs/BUG-JME1DI.md
+++ b/tickets/entities/bugs/BUG-JME1DI.md
@@ -1,0 +1,32 @@
+---
+id: BUG-JME1DI
+type: bug
+title: Conflict endpoints allow path traversal and bypass ACL/audit
+description: GET /api/v1/_conflicts/{path} and POST /api/v1/_conflicts/resolve joined the caller-supplied path onto the project root without containment, allowing reads and writes outside the project. The resolve write also bypassed ACL re-authorization and the audit log entirely (direct os.WriteFile).
+priority: high
+why1: The conflict handlers joined user-supplied paths with filepath.Join(root, path) and conflict.ResolveAndWrite wrote files directly, with no containment check, no ACL gate, and no audit record.
+why2: The conflict endpoints predate the containedProjectPath helper and the ACL/affordances arc; they were never swept when those gates were introduced for the other write handlers.
+why3: There is no structural enforcement that every dataentry mutation surface routes through the ACL gate — the affordances contract test covers entity CRUD handlers but not file-level endpoints like conflict resolve.
+why4: Conflict resolution cannot route through entitymanager (the store cannot parse marker-laden files), so it sat outside the manager-centric write-path rules that guarantee ACL+audit.
+why5: Write surfaces that bypass the Manager have no checklist or lint that forces them to re-implement the gate explicitly.
+prevention: 'Backend review sweep ticketed: enumerate every mutation surface and require each to be ACL-gated and audited or documented as an exemption (review doc theme A). translateRelationWrite now lives in affordances.go under the lint-test single-construction-site invariant, and regression tests pin traversal rejection, the 403 deny body, and the audit rows.'
+status: done
+---
+
+## Bug
+
+Found in a full backend code review (2026-06-09). Two independent review passes
+converged on the `_conflicts` endpoints:
+
+- **Path traversal, read and write.** `GET /api/v1/_conflicts/../../secret` read any file the process could read; `POST /api/v1/_conflicts/resolve` with `"path": "../..."` wrote attacker-controlled bytes outside the project root. `requireSameOrigin` blocked cross-origin browsers, but same-origin XSS or any non-browser loopback client reached this.
+- **Write-path bypass.** `conflict.ResolveAndWrite` did a raw `os.WriteFile` — no ACL re-authorization (violates the dataentry rule "the write endpoint must re-authorize"), no audit record.
+
+## Fix (PR #947)
+
+- Both endpoints contain the caller-supplied path via `containedProjectPath` (403 outside root, 404 missing).
+- Resolve authorizes against the resolved write target before writing: entity files via `translateVerb("update", ...)`, relation files via the new `translateRelationWrite` (mirrors `entitymanager.UpdateRelation` semantics).
+- `denied-write` audit row on deny; `update-entity` / `update-relation` row on success.
+- Handler serializes under `writeMu` like every other mutation handler.
+- `conflict.ResolveAndWrite` split into `Resolve` → `ValidateResolved` → `WriteResolved` so the gate fits between resolve and write; the write stays file-level because the store cannot parse a marker-laden file, and the store's file watcher propagates the change to index/SSE.
+
+Seven regression tests in `internal/dataentry/conflicts_api_test.go`.

--- a/tickets/relations/BUG-JME1DI--adds-measure--conflict-endpoint-containment-test.md
+++ b/tickets/relations/BUG-JME1DI--adds-measure--conflict-endpoint-containment-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-JME1DI
+relation: adds-measure
+to: conflict-endpoint-containment-test
+---

--- a/tickets/relations/BUG-JME1DI--affects--audit-log.md
+++ b/tickets/relations/BUG-JME1DI--affects--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: BUG-JME1DI
+relation: affects
+to: audit-log
+---

--- a/tickets/relations/BUG-JME1DI--affects--authorization.md
+++ b/tickets/relations/BUG-JME1DI--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: BUG-JME1DI
+relation: affects
+to: authorization
+---

--- a/tickets/relations/BUG-JME1DI--affects--data-entry-server.md
+++ b/tickets/relations/BUG-JME1DI--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: BUG-JME1DI
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/BUG-JME1DI--fixes--FEAT-001.md
+++ b/tickets/relations/BUG-JME1DI--fixes--FEAT-001.md
@@ -1,0 +1,5 @@
+---
+from: BUG-JME1DI
+relation: fixes
+to: FEAT-001
+---

--- a/tickets/relations/conflict-endpoint-containment-test--protects--data-entry-server.md
+++ b/tickets/relations/conflict-endpoint-containment-test--protects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: conflict-endpoint-containment-test
+relation: protects
+to: data-entry-server
+---


### PR DESCRIPTION
## Summary

Fixes the critical finding from the backend review: the `_conflicts` endpoints joined caller-supplied paths onto the project root with no containment check, and the resolve endpoint wrote files with no re-authorization or audit trail.

- **Path traversal (read + write).** `GET /api/v1/_conflicts/{path}` and `POST /api/v1/_conflicts/resolve` now run the caller-supplied path through the existing `containedProjectPath` helper before any filesystem access — 403 when the path escapes the project root, 404 when it's inside but missing. Previously `../../...` could read any file the process can read and write attacker-controlled bytes outside the project.
- **ACL re-authorization.** Resolve now gates on the resolved write target: entity files authorize like an entity update (`translateVerb`), relation files like a relation update (new `translateRelationWrite` in `affordances.go`, mirroring `entitymanager.UpdateRelation`'s `RelationSubject`/source-type semantics). The lint test's single-construction-site invariant still holds.
- **Audit.** Denials record a `denied-write` row; successful resolutions record `update-entity`/`update-relation` — the direct-file-write counterpart of the records entitymanager emits.
- **Write serialization.** The resolve handler now takes `writeMu` like every other mutation handler.

The write stays file-level (split `conflict.ResolveAndWrite` into `Resolve` → `ValidateResolved` → `WriteResolved` so the ACL gate fits between resolve and write) because the store cannot parse a file that still contains conflict markers; the store's file watcher picks the change up as an external edit, keeping index/SSE consumers in sync.

## Tests

- Traversal rejected on GET detail (relative, deep-relative, absolute) without leaking content
- Traversal rejected on resolve; file outside root left untouched
- ACL deny → 403 with structured body, file unchanged, `denied-write` audit row
- Entity + relation resolve success → markers removed, audit rows emitted
- Contained-path GET and missing-file 404 still behave

`go test ./...`, `golangci-lint`, and `just arch-lint` all pass.