### PR TITLE
chore: align golangci-lint v2 in justfile with CI, pin go-arch-lint (TKT-QRTE6G)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,8 @@ jobs:
           go-version: '1.26'
 
       - name: Install go-arch-lint
-        run: go install github.com/fe3dback/go-arch-lint@latest
+        # Keep in sync with go_arch_lint_version in the justfile.
+        run: go install github.com/fe3dback/go-arch-lint@v1.15.0
 
       - name: Check architecture
         run: go-arch-lint check

--- a/justfile
+++ b/justfile
@@ -2,7 +2,9 @@
 
 # Variables
 build_dir := "bin"
-golangci_lint_version := "v1.62.2"
+# Keep these in sync with .github/workflows/ci.yml (lint and arch-lint jobs).
+golangci_lint_version := "v2.11.4"
+go_arch_lint_version := "v1.15.0"
 go_packages := "$(go list ./... | grep -v /frontend/node_modules/)"
 
 # Default recipe
@@ -234,14 +236,14 @@ ci: check coverage-check build docs-check
 # Install development tools
 install-tools:
     @echo "Installing development tools..."
-    @echo "Installing golangci-lint {{golangci_lint_version}}..."
-    @curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin {{golangci_lint_version}}
+    @echo "Installing golangci-lint {{golangci_lint_version}} (same install path as CI)..."
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@{{golangci_lint_version}}
     @echo "Installing goimports..."
     go install golang.org/x/tools/cmd/goimports@latest
     @echo "Installing go-test-coverage..."
     go install github.com/vladopajic/go-test-coverage/v2@latest
-    @echo "Installing go-arch-lint..."
-    go install github.com/fe3dback/go-arch-lint@latest
+    @echo "Installing go-arch-lint {{go_arch_lint_version}}..."
+    go install github.com/fe3dback/go-arch-lint@{{go_arch_lint_version}}
     @echo "Done!"
 
 # Install git hooks

--- a/tickets/entities/tickets/TKT-QRTE6G.md
+++ b/tickets/entities/tickets/TKT-QRTE6G.md
@@ -1,0 +1,39 @@
+---
+id: TKT-QRTE6G
+type: ticket
+title: 'Align local lint tooling with CI: golangci-lint v2, pinned go-arch-lint'
+kind: chore
+priority: medium
+effort: xs
+status: done
+---
+
+## Problem
+
+A test/tooling-quality review found two version drifts between local tooling and
+CI:
+
+1. `justfile` `install-tools` installs **golangci-lint v1.62.2** via the v1 install script, but `.golangci.yml` is `version: "2"` format and CI installs **v2.11.4** (`go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4`). A fresh local setup gets a linter that cannot read the project config.
+2. CI installs `go-arch-lint@latest` — an upstream release can break CI unrelated to any change in this repo (go-test-coverage and golangci-lint are already pinned).
+
+## Fix
+
+- `justfile`: install golangci-lint v2.11.4 via the same `go install` path CI uses (single version variable, matching CI).
+- `justfile` + `.github/workflows/ci.yml`: pin go-arch-lint to v1.15.0 (the current latest, i.e. what `@latest` resolves to today).
+
+## Verification
+
+- `just lint` and `just arch-lint` pass with the pinned versions.
+- CI green on the PR.
+
+## Why (5-whys, abbreviated)
+
+- why1: `install-tools` still referenced the v1 version pin after the repo's `.golangci.yml` migrated to the v2 config format.
+- why2: the config migration updated CI but not the local bootstrap recipe — two installation paths, no single source of truth.
+- why3: nothing exercises `install-tools` in CI, so the drift was invisible until a fresh machine ran it.
+
+## Prevention
+
+Local bootstrap now uses the identical `go install` command as CI with one
+pinned version per tool, so the next version bump is a single-line change
+visible in both contexts.

--- a/tickets/relations/TKT-QRTE6G--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-QRTE6G--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-QRTE6G
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-QRTE6G--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-QRTE6G--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-QRTE6G
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Fixes two tool-version drifts between local tooling and CI (found in the test/tooling-quality review, ticket TKT-QRTE6G).

## golangci-lint: justfile installed v1 against a v2 config

`just install-tools` installed **golangci-lint v1.62.2** via the v1 install script, but `.golangci.yml` is `version: "2"` format and CI installs **v2.11.4**. A fresh local setup got a linter that cannot read the project config.

Fix: the justfile now uses the identical `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4` path as CI, with the version in one justfile variable and a keep-in-sync comment on both sides.

## go-arch-lint: unpinned `@latest` in CI

The arch-lint CI job installed `go-arch-lint@latest`, so an upstream release could break CI unrelated to any change here (go-test-coverage and golangci-lint are already pinned). Now pinned to **v1.15.0** (what `@latest` resolves to today) in both `ci.yml` and the justfile.

## Verification

- `go install github.com/fe3dback/go-arch-lint@v1.15.0` + `just arch-lint`: OK, no warnings.
- `just lint` with golangci-lint 2.11.4: 0 issues.