### PR TITLE
feat(acl): list/sidebar read gates + pagination parity (TKT-VMD8)

### DIFF
--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -169,6 +169,9 @@ func main() {
 		dataentry.EnvPrincipalResolver(),
 		dataentry.HeaderPrincipalResolver(f.principalHeader),
 	))
+	// Vary on the identity header: under ACL, API responses are
+	// per-principal (TKT-VMD8). No-op when the flag is empty.
+	app.SetPrincipalHeader(f.principalHeader)
 
 	srv := newHTTPServer(addr, app.NewRouter())
 

--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -203,7 +203,12 @@ with the list it links to.
   role with `write: [x]` but no covering `read` entry at boot
   (structured error naming the role and type). Downstream affordance
   logic may therefore assume "writable ⇒ readable" — a DenyAll list
-  response always carries `_actions.create == false`.
+  response always carries `_actions.create == false`. The invariant
+  covers the `write:` list, which is the only field that authorizes
+  writes; the affordance grant maps (`fields:` / `options:` /
+  `relations:`) restrict surfaces within an authorized write and
+  never confer writability by themselves, so they are intentionally
+  outside the check.
 
 ### Caching: per-principal responses
 
@@ -254,8 +259,10 @@ The `attachACLRequest` middleware:
 
 ## What still leaks (deferred)
 
-- **`/api/v1/_position` per-id semantics** — `_position` shares the
-  gated list pipeline, so ordinals are already computed within the
+- **`/api/v1/_position` per-id semantics** — `_position` is gated on
+  both scope sources: list scopes share the gated list pipeline, and
+  search scopes filter the search result through the read gate before
+  computing ordinals, so totals and prev/next always come from the
   principal's visible subset. What remains scoped to the follow-up
   ticket: the per-id gate on the *requested* id and the
   neighbor-disclosure analysis (a visible neighbor's id confirms a

--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -107,9 +107,20 @@ attribution chain. This is by design:
 If you're debugging "why was alice denied X?" — read the audit log
 on the server, not the response body in the browser.
 
-## Read-path gating: per-entity responses
+## Read-path gating
 
-ACL v1 (TKT-VQGN) gates every per-entity-response code path:
+Read-side enforcement landed in two PRs with deliberately different
+deny models:
+
+- **Per-entity responses** (TKT-VQGN): deny is shaped exactly like
+  not-found — a 404 indistinguishable from a nonexistent id.
+- **Aggregates** (TKT-VMD8): lists, sidebar counts, and pagination
+  metadata are shaped exactly like "the hidden entities don't exist" —
+  filtered sets, filtered totals, no cardinality residue.
+
+### Per-entity responses (TKT-VQGN)
+
+ACL v1 gates every per-entity-response code path:
 
 | Surface | Hidden-target behaviour |
 |---|---|
@@ -146,6 +157,83 @@ operator debugging.
   surfaces (e.g. nested includes in a list response) MUST go through
   the same gate.
 
+### Lists, sidebar counts, pagination (TKT-VMD8)
+
+Anything that enumerates entities of a type returns only the visible
+subset, with no leak surface revealing hidden cardinality. The list
+pipeline (`scopedSortedEntities`, shared by `GET /api/v1/<plural>` and
+`/api/v1/_position`) resolves the read scope **first**:
+
+- **AllowAll** — a global role grants read on the type; the pre-ACL
+  load path runs unchanged.
+- **DenyAll** — no role grants any read; the pipeline returns empty
+  **before** the search backend, structured filters, or sort run. A
+  denied principal cannot probe backend latency (or induce index
+  load) through `?q=`.
+- **Query** — read is conferred via role-relations; a composed
+  `store.GraphQuery` selects the visible subset, and search / filter /
+  sort operate on that filtered slice only.
+
+Every pagination surface derives from the post-filter total:
+`data.length`, `meta.total`, `meta.has_more`, `X-Total-Count`,
+`X-Page`, `X-Per-Page`, and the `Link` header rels — `rel="next"` is
+absent when no *visible* next page exists, even when hidden pages
+exist after it.
+
+Sidebar counts go through the same gate, single-mode: there is no
+"ACL off" code branch (a count path that only runs under ACL is a
+count path that silently drifts). `listCount` / `kanbanCount` always
+resolve the read scope, then `GraphCount` (no config filters) or
+GraphQuery-then-filter (with config filters). Ordering is always
+ACL → config filter → count, so a sidebar badge can never disagree
+with the list it links to.
+
+### Invariants downstream maintainers MUST preserve (aggregates)
+
+- **The DenyAll short-circuit precedes the search backend.** A
+  regression test pins the searcher at zero calls on the deny path.
+  New work in the list pipeline must keep the scope resolution first.
+- **Search runs after ACL, on the filtered slice.** This ordering is
+  the contract the future `/_search` ticket builds on; a mock-asserted
+  test pins GraphQuery-before-search.
+- **No count from an unfiltered source.** Any new aggregate (badge,
+  dashboard card, export count) must derive from the gated set, never
+  from `Store.CountEntities` on a principal-reachable path.
+- **Write grants imply read grants.** The policy loader rejects a
+  role with `write: [x]` but no covering `read` entry at boot
+  (structured error naming the role and type). Downstream affordance
+  logic may therefore assume "writable ⇒ readable" — a DenyAll list
+  response always carries `_actions.create == false`.
+
+### Caching: per-principal responses
+
+Under ACL, `/api/` responses differ per principal. Two layers keep
+caches from leaking one principal's view to another:
+
+- All `/api/` responses already carry
+  `Cache-Control: no-cache, no-store, must-revalidate`.
+- When `--principal-header` is configured, responses also carry
+  `Vary: <that header>` — defense in depth for any cache layer that
+  ignores `no-store`.
+
+### Sidebar menu structure is principal-independent
+
+The sidebar's *structure* (groups, labels, links) reveals metamodel
+shape, not data shape, and is served identically to every principal —
+only the *counts* are gated. Hiding whole menu entries per principal
+is a possible future tightening, deliberately not done here: the
+metamodel is not a secret (it's served by `/api/v1/_schema`), and a
+divergent menu per principal complicates SPA caching for no
+confidentiality gain today.
+
+### Sidebar config-filter performance caveat
+
+A sidebar list with `filters:` evaluates them in-memory after the ACL
+GraphQuery — cost scales with the principal's visible-set size. For
+visible sets beyond ~10k entities per type, prefer narrowing the nav
+entry to a dedicated entity type, or file the follow-up that pushes
+config filters down into GraphQuery.
+
 ## ACL fail-loud and middleware scope
 
 The `attachACLRequest` middleware:
@@ -166,25 +254,24 @@ The `attachACLRequest` middleware:
 
 ## What still leaks (deferred)
 
-- **List endpoints** (`GET /api/v1/<plural>`) — every principal
-  with reach to the URL sees every entity of the type, regardless
-  of role grant. TKT-VMD8 (PR 2/2) closes this with the same
-  composable `Request.ReadQuery` infrastructure the per-entity
-  path uses.
-- **Sidebar counts** (`listCount`, `kanbanCount`) — same; TKT-VMD8.
-- **`/api/v1/_position`** — takes an `id` but resolves a scope walk,
-  so it's list-derived. A hidden id appears in the scope today and
-  the response leaks its ordinal. Scoped to a follow-up after
-  TKT-VMD8 lands.
+- **`/api/v1/_position` per-id semantics** — `_position` shares the
+  gated list pipeline, so ordinals are already computed within the
+  principal's visible subset. What remains scoped to the follow-up
+  ticket: the per-id gate on the *requested* id and the
+  neighbor-disclosure analysis (a visible neighbor's id confirms a
+  visible entity, but gap analysis around hidden entities needs its
+  own treatment).
 - **`/_search`** — the bleve / pgstore search backends need their
-  own query-rewrite. Separate ticket.
+  own query-rewrite. Separate ticket; it builds on the
+  search-after-ACL ordering contract pinned above.
 - **SSE `/api/v1/_events`** — the broker today fans `{type, id}` to
   every subscriber. Per-subscriber filtering is its own ticket.
 - **MCP transport** — tracked as TKT-G3PPD.
 
-For threat-modelling purposes today: assume any principal with API
-reach can enumerate every entity via the LIST endpoint (PR 2 closes
-this). Per-entity GET, write, and include channels are tight.
+For threat-modelling purposes today: per-entity GET, write, include,
+list, sidebar, and pagination channels are tight. The global search
+endpoint and the SSE event stream still reveal `{type, id}`-level
+existence to any connected principal.
 
 ## Where to read next
 

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -101,9 +101,20 @@ attribution chain. This is by design:
 If you're debugging "why was alice denied X?" — read the audit log
 on the server, not the response body in the browser.
 
-## Read-path gating: per-entity responses
+## Read-path gating
 
-ACL v1 (TKT-VQGN) gates every per-entity-response code path:
+Read-side enforcement landed in two PRs with deliberately different
+deny models:
+
+- **Per-entity responses** (TKT-VQGN): deny is shaped exactly like
+  not-found — a 404 indistinguishable from a nonexistent id.
+- **Aggregates** (TKT-VMD8): lists, sidebar counts, and pagination
+  metadata are shaped exactly like "the hidden entities don't exist" —
+  filtered sets, filtered totals, no cardinality residue.
+
+### Per-entity responses (TKT-VQGN)
+
+ACL v1 gates every per-entity-response code path:
 
 | Surface | Hidden-target behaviour |
 |---|---|
@@ -140,6 +151,83 @@ operator debugging.
   surfaces (e.g. nested includes in a list response) MUST go through
   the same gate.
 
+### Lists, sidebar counts, pagination (TKT-VMD8)
+
+Anything that enumerates entities of a type returns only the visible
+subset, with no leak surface revealing hidden cardinality. The list
+pipeline (`scopedSortedEntities`, shared by `GET /api/v1/<plural>` and
+`/api/v1/_position`) resolves the read scope **first**:
+
+- **AllowAll** — a global role grants read on the type; the pre-ACL
+  load path runs unchanged.
+- **DenyAll** — no role grants any read; the pipeline returns empty
+  **before** the search backend, structured filters, or sort run. A
+  denied principal cannot probe backend latency (or induce index
+  load) through `?q=`.
+- **Query** — read is conferred via role-relations; a composed
+  `store.GraphQuery` selects the visible subset, and search / filter /
+  sort operate on that filtered slice only.
+
+Every pagination surface derives from the post-filter total:
+`data.length`, `meta.total`, `meta.has_more`, `X-Total-Count`,
+`X-Page`, `X-Per-Page`, and the `Link` header rels — `rel="next"` is
+absent when no *visible* next page exists, even when hidden pages
+exist after it.
+
+Sidebar counts go through the same gate, single-mode: there is no
+"ACL off" code branch (a count path that only runs under ACL is a
+count path that silently drifts). `listCount` / `kanbanCount` always
+resolve the read scope, then `GraphCount` (no config filters) or
+GraphQuery-then-filter (with config filters). Ordering is always
+ACL → config filter → count, so a sidebar badge can never disagree
+with the list it links to.
+
+### Invariants downstream maintainers MUST preserve (aggregates)
+
+- **The DenyAll short-circuit precedes the search backend.** A
+  regression test pins the searcher at zero calls on the deny path.
+  New work in the list pipeline must keep the scope resolution first.
+- **Search runs after ACL, on the filtered slice.** This ordering is
+  the contract the future `/_search` ticket builds on; a mock-asserted
+  test pins GraphQuery-before-search.
+- **No count from an unfiltered source.** Any new aggregate (badge,
+  dashboard card, export count) must derive from the gated set, never
+  from `Store.CountEntities` on a principal-reachable path.
+- **Write grants imply read grants.** The policy loader rejects a
+  role with `write: [x]` but no covering `read` entry at boot
+  (structured error naming the role and type). Downstream affordance
+  logic may therefore assume "writable ⇒ readable" — a DenyAll list
+  response always carries `_actions.create == false`.
+
+### Caching: per-principal responses
+
+Under ACL, `/api/` responses differ per principal. Two layers keep
+caches from leaking one principal's view to another:
+
+- All `/api/` responses already carry
+  `Cache-Control: no-cache, no-store, must-revalidate`.
+- When `--principal-header` is configured, responses also carry
+  `Vary: <that header>` — defense in depth for any cache layer that
+  ignores `no-store`.
+
+### Sidebar menu structure is principal-independent
+
+The sidebar's *structure* (groups, labels, links) reveals metamodel
+shape, not data shape, and is served identically to every principal —
+only the *counts* are gated. Hiding whole menu entries per principal
+is a possible future tightening, deliberately not done here: the
+metamodel is not a secret (it's served by `/api/v1/_schema`), and a
+divergent menu per principal complicates SPA caching for no
+confidentiality gain today.
+
+### Sidebar config-filter performance caveat
+
+A sidebar list with `filters:` evaluates them in-memory after the ACL
+GraphQuery — cost scales with the principal's visible-set size. For
+visible sets beyond ~10k entities per type, prefer narrowing the nav
+entry to a dedicated entity type, or file the follow-up that pushes
+config filters down into GraphQuery.
+
 ## ACL fail-loud and middleware scope
 
 The `attachACLRequest` middleware:
@@ -160,25 +248,24 @@ The `attachACLRequest` middleware:
 
 ## What still leaks (deferred)
 
-- **List endpoints** (`GET /api/v1/<plural>`) — every principal
-  with reach to the URL sees every entity of the type, regardless
-  of role grant. TKT-VMD8 (PR 2/2) closes this with the same
-  composable `Request.ReadQuery` infrastructure the per-entity
-  path uses.
-- **Sidebar counts** (`listCount`, `kanbanCount`) — same; TKT-VMD8.
-- **`/api/v1/_position`** — takes an `id` but resolves a scope walk,
-  so it's list-derived. A hidden id appears in the scope today and
-  the response leaks its ordinal. Scoped to a follow-up after
-  TKT-VMD8 lands.
+- **`/api/v1/_position` per-id semantics** — `_position` shares the
+  gated list pipeline, so ordinals are already computed within the
+  principal's visible subset. What remains scoped to the follow-up
+  ticket: the per-id gate on the *requested* id and the
+  neighbor-disclosure analysis (a visible neighbor's id confirms a
+  visible entity, but gap analysis around hidden entities needs its
+  own treatment).
 - **`/_search`** — the bleve / pgstore search backends need their
-  own query-rewrite. Separate ticket.
+  own query-rewrite. Separate ticket; it builds on the
+  search-after-ACL ordering contract pinned above.
 - **SSE `/api/v1/_events`** — the broker today fans `{type, id}` to
   every subscriber. Per-subscriber filtering is its own ticket.
 - **MCP transport** — tracked as TKT-G3PPD.
 
-For threat-modelling purposes today: assume any principal with API
-reach can enumerate every entity via the LIST endpoint (PR 2 closes
-this). Per-entity GET, write, and include channels are tight.
+For threat-modelling purposes today: per-entity GET, write, include,
+list, sidebar, and pagination channels are tight. The global search
+endpoint and the SSE event stream still reveal `{type, id}`-level
+existence to any connected principal.
 
 ## Where to read next
 

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -197,7 +197,12 @@ with the list it links to.
   role with `write: [x]` but no covering `read` entry at boot
   (structured error naming the role and type). Downstream affordance
   logic may therefore assume "writable ⇒ readable" — a DenyAll list
-  response always carries `_actions.create == false`.
+  response always carries `_actions.create == false`. The invariant
+  covers the `write:` list, which is the only field that authorizes
+  writes; the affordance grant maps (`fields:` / `options:` /
+  `relations:`) restrict surfaces within an authorized write and
+  never confer writability by themselves, so they are intentionally
+  outside the check.
 
 ### Caching: per-principal responses
 
@@ -248,8 +253,10 @@ The `attachACLRequest` middleware:
 
 ## What still leaks (deferred)
 
-- **`/api/v1/_position` per-id semantics** — `_position` shares the
-  gated list pipeline, so ordinals are already computed within the
+- **`/api/v1/_position` per-id semantics** — `_position` is gated on
+  both scope sources: list scopes share the gated list pipeline, and
+  search scopes filter the search result through the read gate before
+  computing ordinals, so totals and prev/next always come from the
   principal's visible subset. What remains scoped to the follow-up
   ticket: the per-id gate on the *requested* id and the
   neighbor-disclosure analysis (a visible neighbor's id confirms a

--- a/docs/security.md
+++ b/docs/security.md
@@ -168,7 +168,7 @@ The policy lives at `acl.yaml` at the project root (alongside
 |---|---|---|
 | **Open** (default) | No `acl.yaml` present | Every authenticated request can write. Reads have no filtering. Suitable for single-user local projects. |
 | **Read-only** | `rela-server --read-only` or `RELA_READ_ONLY=1` | Every write returns HTTP 403; reads unaffected. Useful for demos, maintenance, observe-only deployments. Wins over `acl.yaml` — explicit flag overrides policy. |
-| **Policy** | `acl.yaml` present | Writes are gated by role assignments and delegate permissions. Reads are unaffected in v0; read filtering arrives with v1. |
+| **Policy** | `acl.yaml` present | Writes are gated by role assignments and delegate permissions. Reads are filtered: per-entity GETs 404 like not-found for hidden entities, and lists / sidebar counts / pagination return only the visible subset (see `docs/acl-security.md`). |
 
 A startup warning fires when the server binds **beyond loopback**
 (`--bind` non-loopback) **without** `acl.yaml` AND **without**
@@ -229,6 +229,12 @@ role_relations:
   simply delete `acl.yaml` (which falls back to `NopACL`).
 - **Unknown top-level keys produce warnings, not errors.** Typos
   surface in the server log; the rest of the policy still loads.
+- **Write grants require covering read grants.** A role with
+  `write: [ticket]` but no `read: [ticket]` (or `read: ["*"]`) is
+  rejected at boot with an error naming the role and type. A
+  principal who can write a type it cannot read would see an empty
+  list with a working Create button; the loader rules the
+  combination out so the UI affordances stay coherent.
 
 ### Delegate-X tamper resistance
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -234,7 +234,10 @@ role_relations:
   rejected at boot with an error naming the role and type. A
   principal who can write a type it cannot read would see an empty
   list with a working Create button; the loader rules the
-  combination out so the UI affordances stay coherent.
+  combination out so the UI affordances stay coherent. The check
+  covers the `write:` list only — affordance grants (`fields:`,
+  `options:`, `relations:`) restrict surfaces within an authorized
+  write and never authorize writes by themselves.
 
 ### Delegate-X tamper resistance
 

--- a/internal/acl/features_test.go
+++ b/internal/acl/features_test.go
@@ -234,8 +234,8 @@ func TestFeature_UC6_DelegateXRelationWrite(t *testing.T) {
 	w := NewWorld().
 		Policy(`
 roles:
-  admin:  { write: ["*"], permissions: [delegate-editor] }
-  editor: { write: [ticket] }
+  admin:  { write: ["*"], read: ["*"], permissions: [delegate-editor] }
+  editor: { write: [ticket], read: [ticket] }
 assignments:
   jeroen: admin
   alice:  editor

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -265,16 +265,27 @@ func LoadPolicyBytes(data []byte) (*Policy, error) {
 //     A blank entry would expand ancestor sets through every relation
 //     type (StoreGraph treats RelationQuery.Type=="" as "all relations"),
 //     silently turning a typo into a containment widening.
+//
 //   - RoleRelations keys must be non-empty and non-whitespace, for the
 //     same reason — an empty key would gate "all relation writes" on
 //     a delegate permission, breaking writes the operator didn't mean
 //     to gate.
+//
 //   - Every role's write grants must be covered by its read grants
 //     (write ⊆ read, wildcard-aware). A role that can create or update
 //     a type it cannot read produces incoherent UX (empty list with a
 //     working Create button) and would force every affordance consumer
 //     to handle the combination. Rejecting it at load lets downstream
 //     read-side logic assume "writable implies readable" (RR-W2J6).
+//
+//     Scope: the invariant covers [RoleDef.Write] — the only field
+//     that authorizes writes (both entity and relation authz resolve
+//     through decideFromAttrs against Write). The affordance grant
+//     maps (Fields / Options / Relations) are deliberately NOT
+//     checked: they restrict field/option/relation surfaces *within*
+//     a write the Write list already authorized and never confer
+//     writability by themselves, so a fields-only role without read
+//     grants is inert, not incoherent.
 //
 // Validation is intentionally narrow: misspelled role names, unknown
 // entity types in grants, etc. remain warnings (or analyze-tool

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -259,7 +259,7 @@ func LoadPolicyBytes(data []byte) (*Policy, error) {
 // policy. Run automatically by [LoadPolicy] / [LoadPolicyBytes].
 // Operators can also call it before persisting a generated policy.
 //
-// Current checks (RR-NIGK):
+// Current checks (RR-NIGK, RR-W2J6):
 //
 //   - InheritRolesThrough entries must be non-empty and non-whitespace.
 //     A blank entry would expand ancestor sets through every relation
@@ -269,11 +269,17 @@ func LoadPolicyBytes(data []byte) (*Policy, error) {
 //     same reason — an empty key would gate "all relation writes" on
 //     a delegate permission, breaking writes the operator didn't mean
 //     to gate.
+//   - Every role's write grants must be covered by its read grants
+//     (write ⊆ read, wildcard-aware). A role that can create or update
+//     a type it cannot read produces incoherent UX (empty list with a
+//     working Create button) and would force every affordance consumer
+//     to handle the combination. Rejecting it at load lets downstream
+//     read-side logic assume "writable implies readable" (RR-W2J6).
 //
 // Validation is intentionally narrow: misspelled role names, unknown
 // entity types in grants, etc. remain warnings (or analyze-tool
 // findings) per the "tolerant by design" stance. Security-relevant
-// invariants like the two above are the exception.
+// invariants like the ones above are the exception.
 func (p *Policy) Validate() error {
 	for i, t := range p.InheritRolesThrough {
 		if isBlank(t) {
@@ -283,6 +289,20 @@ func (p *Policy) Validate() error {
 	for k := range p.RoleRelations {
 		if isBlank(k) {
 			return errors.New("role_relations: relation type key must not be empty or whitespace")
+		}
+	}
+	for name, role := range p.Roles {
+		for _, w := range role.Write {
+			if !roleGrantsRead(role, w) {
+				hint := fmt.Sprintf("add %q (or \"*\")", w)
+				if w == "*" {
+					hint = `add "*"`
+				}
+				return fmt.Errorf(
+					"roles.%s: grants write on %q without a covering read grant; "+
+						"%s to the role's read list — a principal must "+
+						"be able to read every type it can write", name, w, hint)
+			}
 		}
 	}
 	return nil

--- a/internal/acl/policy_test.go
+++ b/internal/acl/policy_test.go
@@ -93,6 +93,7 @@ func TestLoadPolicy_UnknownKey_LogsWarning(t *testing.T) {
 roles:
   admin:
     write: ["*"]
+    read: ["*"]
 unknown_top_level: oops
 also_unknown:
   nested: true
@@ -160,6 +161,7 @@ func TestLoadPolicy_AffordanceGrants(t *testing.T) {
 roles:
   triager:
     write: [ticket]
+    read: [ticket]
     fields:
       ticket:
         - field: status
@@ -295,7 +297,7 @@ func TestLoadPolicy_AffordanceGrants_OptInIsKeyPresence(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			yaml := "roles:\n  triager:\n    write: [ticket]\n" + tc.fieldsBlock
+			yaml := "roles:\n  triager:\n    write: [ticket]\n    read: [ticket]\n" + tc.fieldsBlock
 			p, err := acl.LoadPolicy(writeTempPolicy(t, yaml))
 			if err != nil {
 				t.Fatalf("LoadPolicy: %v", err)
@@ -395,6 +397,79 @@ func TestLoadPolicy_BlankRoleRelationsKey_Rejected(t *testing.T) {
 			_, err := acl.LoadPolicy(path)
 			if err == nil {
 				t.Fatalf("LoadPolicy: expected error on blank role_relations key; got nil")
+			}
+		})
+	}
+}
+
+// TKT-VMD8 AC8: a role granting write on a type it cannot read is
+// rejected at load with a structured error naming the role and type.
+// The invariant lets every downstream read-side consumer assume
+// "writable implies readable" — without it a principal gets an empty
+// list with a working Create button (RR-W2J6).
+func TestLoadPolicy_WriteWithoutRead_Rejected(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+		// substrings the error must carry so the operator can find
+		// the offending role without reading source code.
+		wantInErr []string
+	}{
+		{
+			name:      "write without read rejected",
+			yaml:      "roles:\n  triager:\n    write: [ticket]\n",
+			wantErr:   true,
+			wantInErr: []string{"triager", "ticket", "read"},
+		},
+		{
+			name:      "wildcard write without wildcard read rejected",
+			yaml:      "roles:\n  admin:\n    write: [\"*\"]\n    read: [ticket]\n",
+			wantErr:   true,
+			wantInErr: []string{"admin", "read"},
+		},
+		{
+			name:    "write covered by exact read ok",
+			yaml:    "roles:\n  editor:\n    write: [ticket]\n    read: [ticket]\n",
+			wantErr: false,
+		},
+		{
+			name:    "write covered by wildcard read ok",
+			yaml:    "roles:\n  editor:\n    write: [ticket]\n    read: [\"*\"]\n",
+			wantErr: false,
+		},
+		{
+			name:    "wildcard write covered by wildcard read ok",
+			yaml:    "roles:\n  admin:\n    write: [\"*\"]\n    read: [\"*\"]\n",
+			wantErr: false,
+		},
+		{
+			name:    "read-only role ok",
+			yaml:    "roles:\n  viewer:\n    read: [ticket]\n",
+			wantErr: false,
+		},
+		{
+			name:    "empty role ok",
+			yaml:    "roles:\n  nobody: {}\n",
+			wantErr: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := acl.LoadPolicy(writeTempPolicy(t, tc.yaml))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("LoadPolicy: expected write-without-read rejection; got nil")
+				}
+				for _, want := range tc.wantInErr {
+					if !contains(err.Error(), want) {
+						t.Errorf("error %q missing substring %q", err, want)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadPolicy: unexpected error: %v", err)
 			}
 		})
 	}

--- a/internal/acl/policy_test.go
+++ b/internal/acl/policy_test.go
@@ -453,6 +453,16 @@ func TestLoadPolicy_WriteWithoutRead_Rejected(t *testing.T) {
 			yaml:    "roles:\n  nobody: {}\n",
 			wantErr: false,
 		},
+		{
+			// Affordance grants restrict surfaces within a write the
+			// Write list authorized; they never authorize by
+			// themselves, so they are intentionally outside the
+			// write⊆read invariant (see Validate godoc).
+			name: "affordance-only role without read ok",
+			yaml: "roles:\n  shaper:\n    fields:\n      ticket:\n        - field: status\n" +
+				"    relations:\n      ticket:\n        - relation: implements\n          create: true\n",
+			wantErr: false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/appbuild/appbuild_acl_test.go
+++ b/internal/appbuild/appbuild_acl_test.go
@@ -38,6 +38,7 @@ func TestDiscover_ACLPresent_LoadsDeclarative(t *testing.T) {
 	writePolicy(t, root, `roles:
   admin:
     write: ["*"]
+    read: ["*"]
 assignments:
   jeroen: admin
 `)
@@ -79,6 +80,7 @@ func TestWithACL_OverridesLoadedPolicy(t *testing.T) {
 	writePolicy(t, root, `roles:
   admin:
     write: ["*"]
+    read: ["*"]
 assignments:
   jeroen: admin
 `)

--- a/internal/dataentry/acl_get_test.go
+++ b/internal/dataentry/acl_get_test.go
@@ -254,6 +254,10 @@ func (g fakeGate) PermitsReadMany(_ context.Context, _ string, ids []string) (ma
 	return m, nil
 }
 
+func (g fakeGate) ReadQuery(context.Context, string) acl.ReadQueryResult {
+	return acl.ReadQueryResult{DenyAll: true}
+}
+
 // principalCtx returns a context carrying a stamped data-entry
 // principal for `user`. RR-MILH: replaces the previous parameterless
 // `aliceCtx()` helper so tests that want a different principal

--- a/internal/dataentry/acl_list_regression_test.go
+++ b/internal/dataentry/acl_list_regression_test.go
@@ -1,0 +1,78 @@
+package dataentry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// TestACLListRegression_NopACL_ListUnchanged pins TKT-VMD8 AC11 for
+// the list endpoint: with no ACL configured (nopReadGate via the ctx
+// fallback → AllowAll → the pre-ACL listFromStoreByTypes path), the
+// response carries exactly today's shape — full data set, full
+// totals, full pagination headers, Link header, _actions present.
+func TestACLListRegression_NopACL_ListUnchanged(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	seedEntity(app, &entity.Entity{ID: "TKT-002", Type: "ticket", Properties: map[string]any{"title": "T2"}})
+	seedEntity(app, &entity.Entity{ID: "TKT-003", Type: "ticket", Properties: map[string]any{"title": "T3"}})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?per_page=2&page=1", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1ListEntities(rec, req, "ticket", "tickets")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("NopACL list: got %d, want 200; body=%s", rec.Code, rec.Body)
+	}
+
+	var resp V1ListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, rec.Body)
+	}
+	if len(resp.Data) != 2 {
+		t.Errorf("data.length = %d, want 2", len(resp.Data))
+	}
+	if resp.Meta.Total != 3 || !resp.Meta.HasMore || resp.Meta.Page != 1 || resp.Meta.PerPage != 2 {
+		t.Errorf("meta = %+v, want {Total:3 Page:1 PerPage:2 HasMore:true}", resp.Meta)
+	}
+	if got := rec.Header().Get("X-Total-Count"); got != "3" {
+		t.Errorf("X-Total-Count = %q, want 3", got)
+	}
+	link := rec.Header().Get("Link")
+	if !strings.Contains(link, `rel="next"`) || !strings.Contains(link, `rel="last"`) {
+		t.Errorf("Link header lost pagination rels: %s", link)
+	}
+	if resp.Actions == nil {
+		t.Error("_actions absent from NopACL list response")
+	} else if create, ok := resp.Actions["create"]; !ok || !create {
+		t.Errorf("_actions.create = %v (present=%v), want true under NopACL", create, ok)
+	}
+}
+
+// TestACLListRegression_NopACL_FreeTextStillWorks pins that the ?q=
+// pipeline (search intersection) is untouched on the AllowAll path —
+// the gate resolves before search but must not perturb it.
+func TestACLListRegression_NopACL_FreeTextStillWorks(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "alpha match"}})
+	seedEntity(app, &entity.Entity{ID: "TKT-002", Type: "ticket", Properties: map[string]any{"title": "beta other"}})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?q=alpha", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1ListEntities(rec, req, "ticket", "tickets")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("NopACL list q=: got %d, want 200; body=%s", rec.Code, rec.Body)
+	}
+	var resp V1ListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].ID != "TKT-001" {
+		t.Errorf("free-text filter broken under NopACL: got %+v, want [TKT-001]", resp.Data)
+	}
+}

--- a/internal/dataentry/acl_list_test.go
+++ b/internal/dataentry/acl_list_test.go
@@ -311,6 +311,9 @@ func TestACLList_QueryErrorMapping(t *testing.T) {
 	if strings.Contains(rec.Body.String(), "search_failed") {
 		t.Errorf("ACL failure mislabeled as search_failed: %s", rec.Body)
 	}
+	if strings.Contains(rec.Body.String(), "synthetic graph query failure") {
+		t.Errorf("raw backend error leaked into response body: %s", rec.Body)
+	}
 }
 
 // TestACLPosition_SearchScopeGated pins the CRIT finding from the
@@ -378,6 +381,9 @@ func TestACLList_AllowAllLoadErrorSurfaces(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "list_load_failed") {
 		t.Errorf("body missing list_load_failed: %s", rec.Body)
+	}
+	if strings.Contains(rec.Body.String(), "synthetic list failure") {
+		t.Errorf("raw backend error leaked into response body: %s", rec.Body)
 	}
 }
 

--- a/internal/dataentry/acl_list_test.go
+++ b/internal/dataentry/acl_list_test.go
@@ -1,0 +1,419 @@
+package dataentry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/search"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// TestACLList_TypeLevelReadGrant pins TKT-VMD8 AC1: a role with
+// `read: [ticket]` sees every ticket via the list endpoint and an
+// empty list for any type without a grant.
+func TestACLList_TypeLevelReadGrant(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	seedEntity(app, &entity.Entity{ID: "TKT-002", Type: "ticket", Properties: map[string]any{"title": "T2"}})
+	seedEntity(app, &entity.Entity{ID: "FEAT-001", Type: "feature", Properties: map[string]any{"title": "F1"}})
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	resp, rec := listEntitiesAs(aliceCtx(), t, app, d, "ticket", "tickets", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET tickets: %d %s", rec.Code, rec.Body)
+	}
+	if len(resp.Data) != 2 || resp.Meta.Total != 2 {
+		t.Errorf("tickets: got %d entities (total %d), want 2", len(resp.Data), resp.Meta.Total)
+	}
+
+	resp, rec = listEntitiesAs(aliceCtx(), t, app, d, "feature", "features", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET features: %d %s", rec.Code, rec.Body)
+	}
+	if len(resp.Data) != 0 || resp.Meta.Total != 0 {
+		t.Errorf("features (no grant): got %d entities (total %d), want 0", len(resp.Data), resp.Meta.Total)
+	}
+}
+
+// TestACLList_RoleRelationInheritance pins TKT-VMD8 AC2: an
+// `editor-of` relation confers read on tickets reachable through
+// `belongs-to` containment — the list returns only the visible subset.
+func TestACLList_RoleRelationInheritance(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "alice", Type: "person", Properties: map[string]any{"title": "Alice"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-42", Type: "project", Properties: map[string]any{"title": "Granted"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-9", Type: "project", Properties: map[string]any{"title": "Hidden"}})
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "Visible"}})
+	seedEntity(app, &entity.Entity{ID: "TKT-002", Type: "ticket", Properties: map[string]any{"title": "Hidden"}})
+	seedRelation(app, entity.NewRelation("alice", "editor-of", "PRJ-42"))
+	seedRelation(app, entity.NewRelation("TKT-001", "belongs-to", "PRJ-42"))
+	seedRelation(app, entity.NewRelation("TKT-002", "belongs-to", "PRJ-9"))
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles: map[string]acl.RoleDef{"editor": {Read: []string{"ticket"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{
+			"editor-of": {Confers: "editor"},
+		},
+		InheritRolesThrough: []string{"belongs-to"},
+	}, app.store)
+	app.acl = d
+
+	resp, rec := listEntitiesAs(aliceCtx(), t, app, d, "ticket", "tickets", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET tickets: %d %s", rec.Code, rec.Body)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].ID != "TKT-001" {
+		t.Errorf("expected exactly [TKT-001], got %+v", resp.Data)
+	}
+	if resp.Meta.Total != 1 {
+		t.Errorf("meta.total = %d, want 1", resp.Meta.Total)
+	}
+}
+
+// TestACLList_PaginationLeakSurfaces pins TKT-VMD8 AC3: with 5
+// visible + 5 hidden tickets and per_page=3&page=2, every pagination
+// surface reflects the post-filter count of 5 — and the hidden total
+// of 10 appears nowhere in the response (RR-KNGC + RR-VDTW).
+func TestACLList_PaginationLeakSurfaces(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "alice", Type: "person", Properties: map[string]any{"title": "Alice"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-42", Type: "project", Properties: map[string]any{"title": "Granted"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-9", Type: "project", Properties: map[string]any{"title": "Hidden"}})
+	seedRelation(app, entity.NewRelation("alice", "editor-of", "PRJ-42"))
+	for i := 1; i <= 5; i++ {
+		id := fmt.Sprintf("TKT-V%02d", i)
+		seedEntity(app, &entity.Entity{ID: id, Type: "ticket", Properties: map[string]any{"title": id}})
+		seedRelation(app, entity.NewRelation(id, "belongs-to", "PRJ-42"))
+	}
+	for i := 1; i <= 5; i++ {
+		id := fmt.Sprintf("TKT-H%02d", i)
+		seedEntity(app, &entity.Entity{ID: id, Type: "ticket", Properties: map[string]any{"title": id}})
+		seedRelation(app, entity.NewRelation(id, "belongs-to", "PRJ-9"))
+	}
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles: map[string]acl.RoleDef{"editor": {Read: []string{"ticket"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{
+			"editor-of": {Confers: "editor"},
+		},
+		InheritRolesThrough: []string{"belongs-to"},
+	}, app.store)
+	app.acl = d
+
+	resp, rec := listEntitiesAs(aliceCtx(), t, app, d, "ticket", "tickets", "per_page=3&page=2")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET tickets: %d %s", rec.Code, rec.Body)
+	}
+
+	if len(resp.Data) != 2 {
+		t.Errorf("data.length = %d, want 2", len(resp.Data))
+	}
+	if resp.Meta.Total != 5 {
+		t.Errorf("meta.total = %d, want 5", resp.Meta.Total)
+	}
+	if resp.Meta.HasMore {
+		t.Error("meta.has_more = true, want false")
+	}
+	if got := rec.Header().Get("X-Total-Count"); got != "5" {
+		t.Errorf("X-Total-Count = %q, want 5", got)
+	}
+	if got := rec.Header().Get("X-Page"); got != "2" {
+		t.Errorf("X-Page = %q, want 2", got)
+	}
+	if got := rec.Header().Get("X-Per-Page"); got != "3" {
+		t.Errorf("X-Per-Page = %q, want 3", got)
+	}
+	link := rec.Header().Get("Link")
+	if strings.Contains(link, `rel="next"`) {
+		t.Errorf(`Link carries rel="next" beyond the last visible page: %s`, link)
+	}
+	if !strings.Contains(link, `page=2&per_page=3>; rel="last"`) {
+		t.Errorf(`Link rel="last" should point at page=2: %s`, link)
+	}
+
+	// The hidden total (10) must not be derivable from any surface:
+	// not the body, not a header. "1" alone is fine; the literal "10"
+	// anywhere is the leak.
+	if strings.Contains(rec.Body.String(), "10") {
+		t.Errorf("body mentions the hidden total 10: %s", rec.Body)
+	}
+	for name, vals := range rec.Header() {
+		for _, v := range vals {
+			if strings.Contains(v, "10") {
+				t.Errorf("header %s mentions the hidden total 10: %s", name, v)
+			}
+		}
+	}
+}
+
+// TestACLList_DenyAllShape pins TKT-VMD8 AC4: a principal with no
+// read grant gets the empty-list shape — zero data, zero totals,
+// zeroed pagination headers, and `_actions.create == false` (the
+// policy-load invariant guarantees no write grant exists either).
+func TestACLList_DenyAllShape(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"feature"}}},
+		Assignments: map[string]string{"mallory": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	resp, rec := listEntitiesAs(principalCtx("mallory"), t, app, d, "ticket", "tickets", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET tickets (deny): %d %s", rec.Code, rec.Body)
+	}
+	if len(resp.Data) != 0 || resp.Meta.Total != 0 {
+		t.Errorf("deny-all: got %d entities (total %d), want 0", len(resp.Data), resp.Meta.Total)
+	}
+	if got := rec.Header().Get("X-Total-Count"); got != "0" {
+		t.Errorf("X-Total-Count = %q, want 0", got)
+	}
+	if create, ok := resp.Actions["create"]; !ok || create {
+		t.Errorf("_actions.create = %v (present=%v), want false", create, ok)
+	}
+}
+
+// TestACLList_DenyAllSearchShortCircuit pins TKT-VMD8 AC5 (RR-X56H):
+// the DenyAll verdict resolves BEFORE the search backend runs, so a
+// denied principal cannot probe backend latency (or induce load)
+// through ?q=. Asserted via a recording searcher: zero calls.
+func TestACLList_DenyAllSearchShortCircuit(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "alpha"}})
+
+	var calls []string
+	app.searcher = recordingSearcher{log: &calls}
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"feature"}}},
+		Assignments: map[string]string{"mallory": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	resp, rec := listEntitiesAs(principalCtx("mallory"), t, app, d, "ticket", "tickets", "q=alpha")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET tickets (deny, q=): %d %s", rec.Code, rec.Body)
+	}
+	if len(resp.Data) != 0 {
+		t.Errorf("deny-all with q=: got %d entities, want 0", len(resp.Data))
+	}
+	if len(calls) != 0 {
+		t.Errorf("search backend invoked %d times on DenyAll path, want 0 (calls: %v)", len(calls), calls)
+	}
+}
+
+// TestACLList_SearchAfterACLOrdering pins TKT-VMD8 AC9 (RR-WX77 +
+// RR-3IO2): on the composed-Query path the ACL GraphQuery executes
+// BEFORE the free-text searcher, so search only ever intersects the
+// visible subset. Call order is recorded by wrapping both the store
+// and the searcher with the same log.
+func TestACLList_SearchAfterACLOrdering(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "alice", Type: "person", Properties: map[string]any{"title": "Alice"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-42", Type: "project", Properties: map[string]any{"title": "Granted"}})
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "alpha one"}})
+	seedRelation(app, entity.NewRelation("alice", "editor-of", "PRJ-42"))
+	seedRelation(app, entity.NewRelation("TKT-001", "belongs-to", "PRJ-42"))
+
+	var calls []string
+	app.store = orderRecordingStore{Store: app.store, log: &calls}
+	app.searcher = recordingSearcher{log: &calls, hits: []string{"TKT-001"}}
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles: map[string]acl.RoleDef{"editor": {Read: []string{"ticket"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{
+			"editor-of": {Confers: "editor"},
+		},
+		InheritRolesThrough: []string{"belongs-to"},
+	}, app.store)
+	app.acl = d
+
+	resp, rec := listEntitiesAs(aliceCtx(), t, app, d, "ticket", "tickets", "q=alpha")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET tickets: %d %s", rec.Code, rec.Body)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].ID != "TKT-001" {
+		t.Errorf("expected [TKT-001], got %+v", resp.Data)
+	}
+
+	gqIdx, searchIdx := -1, -1
+	for i, c := range calls {
+		switch c {
+		case "graphquery":
+			if gqIdx == -1 {
+				gqIdx = i
+			}
+		case "search":
+			if searchIdx == -1 {
+				searchIdx = i
+			}
+		}
+	}
+	if gqIdx == -1 || searchIdx == -1 {
+		t.Fatalf("expected both graphquery and search calls, got %v", calls)
+	}
+	if gqIdx > searchIdx {
+		t.Errorf("search ran before the ACL GraphQuery: %v", calls)
+	}
+}
+
+// TestACLList_QueryErrorMapping pins the errACLListQuery routing: a
+// failing ACL GraphQuery surfaces as 500 acl_query_failed via
+// writeGateError, not as the misleading search_failed shape.
+func TestACLList_QueryErrorMapping(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "alice", Type: "person", Properties: map[string]any{"title": "Alice"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-42", Type: "project", Properties: map[string]any{"title": "Granted"}})
+	seedRelation(app, entity.NewRelation("alice", "editor-of", "PRJ-42"))
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles: map[string]acl.RoleDef{"editor": {Read: []string{"ticket"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{
+			"editor-of": {Confers: "editor"},
+		},
+	}, app.store)
+	app.acl = d
+
+	// The gate context is built from the REAL store (so the ACL
+	// resolver works), then the app's store is swapped for a failing
+	// one — only the list-path GraphQuery sees the failure.
+	ctx := gateCtxFor(aliceCtx(), t, d)
+	app.store = failingGraphQueryStore{Store: app.store}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	app.handleV1ListEntities(rec, req, "ticket", "tickets")
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "acl_query_failed") {
+		t.Errorf("body missing acl_query_failed: %s", rec.Body)
+	}
+	if strings.Contains(rec.Body.String(), "search_failed") {
+		t.Errorf("ACL failure mislabeled as search_failed: %s", rec.Body)
+	}
+}
+
+// TestACLList_VaryHeader pins TKT-VMD8 AC10 (RR-VDTW): when a
+// principal header is configured, /api/ responses carry both the
+// no-store Cache-Control and `Vary: <header>` so no cache layer can
+// serve principal A's filtered response to principal B.
+func TestACLList_VaryHeader(t *testing.T) {
+	app := newTestAppV1(t)
+	app.SetPrincipalHeader("X-Forwarded-User")
+
+	probe := app.noCacheMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody)
+	rec := httptest.NewRecorder()
+	probe.ServeHTTP(rec, req)
+
+	if cc := rec.Header().Get("Cache-Control"); !strings.Contains(cc, "no-store") {
+		t.Errorf("Cache-Control = %q, want no-store directive", cc)
+	}
+	if vary := rec.Header().Get("Vary"); vary != "X-Forwarded-User" {
+		t.Errorf("Vary = %q, want X-Forwarded-User", vary)
+	}
+
+	// Without a configured header no Vary is emitted — the pre-ACL
+	// wire shape stays untouched for single-user deployments.
+	app2 := newTestAppV1(t)
+	rec2 := httptest.NewRecorder()
+	app2.noCacheMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody))
+	if vary := rec2.Header().Get("Vary"); vary != "" {
+		t.Errorf("Vary without configured header = %q, want empty", vary)
+	}
+}
+
+// ---- helpers ----
+
+// listEntitiesAs performs a list request through handleV1ListEntities
+// with the readGate + acl.Request attached, mirroring the production
+// middleware. Returns the decoded response plus the raw recorder for
+// header asserts.
+func listEntitiesAs(ctx context.Context, t *testing.T, app *App, d *acl.Declarative,
+	typeName, plural, rawQuery string,
+) (V1ListResponse, *httptest.ResponseRecorder) {
+	t.Helper()
+	url := "/api/v1/" + plural
+	if rawQuery != "" {
+		url += "?" + rawQuery
+	}
+	req := httptest.NewRequest(http.MethodGet, url, http.NoBody)
+	req = req.WithContext(gateCtxFor(ctx, t, d))
+	rec := httptest.NewRecorder()
+	app.handleV1ListEntities(rec, req, typeName, plural)
+
+	var resp V1ListResponse
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode list response: %v\nbody: %s", err, rec.Body)
+		}
+	}
+	return resp, rec
+}
+
+// recordingSearcher logs every Search call and yields the configured
+// hits. Used to pin the DenyAll short-circuit (zero calls) and the
+// search-after-ACL ordering.
+type recordingSearcher struct {
+	log  *[]string
+	hits []string
+}
+
+func (s recordingSearcher) Search(context.Context, search.Query) iter.Seq2[search.Hit, error] {
+	*s.log = append(*s.log, "search")
+	return func(yield func(search.Hit, error) bool) {
+		for _, id := range s.hits {
+			if !yield(search.Hit{ID: id}, nil) {
+				return
+			}
+		}
+	}
+}
+
+// orderRecordingStore wraps a store.Store and logs GraphQuery calls
+// into the shared log so call ordering against the searcher can be
+// asserted.
+type orderRecordingStore struct {
+	store.Store
+	log *[]string
+}
+
+func (s orderRecordingStore) GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*entity.Entity, error] {
+	*s.log = append(*s.log, "graphquery")
+	return s.Store.GraphQuery(ctx, q)
+}
+
+// failingGraphQueryStore wraps a store.Store with a GraphQuery that
+// yields an immediate error — drives the errACLListQuery mapping.
+type failingGraphQueryStore struct {
+	store.Store
+}
+
+func (s failingGraphQueryStore) GraphQuery(context.Context, store.GraphQuery) iter.Seq2[*entity.Entity, error] {
+	return func(yield func(*entity.Entity, error) bool) {
+		yield(nil, errors.New("synthetic graph query failure"))
+	}
+}

--- a/internal/dataentry/acl_list_test.go
+++ b/internal/dataentry/acl_list_test.go
@@ -8,6 +8,7 @@ import (
 	"iter"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -312,6 +313,74 @@ func TestACLList_QueryErrorMapping(t *testing.T) {
 	}
 }
 
+// TestACLPosition_SearchScopeGated pins the CRIT finding from the
+// TKT-VMD8 code review: `_position` with `source=search` runs
+// executeQuery, which is itself ungated — without the readableSubset
+// filter a denied principal reads hidden cardinality from `total`
+// and harvests hidden {id, type} pairs from prev/next.
+func TestACLPosition_SearchScopeGated(t *testing.T) {
+	app := newTestAppV1(t)
+	// Both entities match the free-text query "alpha"; only the
+	// ticket is readable by alice.
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "alpha ticket"}})
+	seedEntity(app, &entity.Entity{ID: "FEAT-001", Type: "feature", Properties: map[string]any{"title": "alpha feature"}})
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	scope := url.QueryEscape(`{"source":"search","q":"alpha"}`)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_position?id=TKT-001&scope="+scope, http.NoBody)
+	req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
+	rec := httptest.NewRecorder()
+	app.handleV1EntityPosition(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("position: %d %s", rec.Code, rec.Body)
+	}
+	var pos V1Position
+	if err := json.Unmarshal(rec.Body.Bytes(), &pos); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if pos.Total != 1 {
+		t.Errorf("total = %d, want 1 (hidden FEAT-001 must not count)", pos.Total)
+	}
+	if pos.Prev != nil || pos.Next != nil {
+		t.Errorf("prev/next leak hidden neighbors: prev=%+v next=%+v", pos.Prev, pos.Next)
+	}
+
+	// The hidden id itself must 404 out of the scope entirely.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/_position?id=FEAT-001&scope="+scope, http.NoBody)
+	req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
+	rec = httptest.NewRecorder()
+	app.handleV1EntityPosition(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("hidden id in search scope: got %d, want 404 not_in_scope", rec.Code)
+	}
+}
+
+// TestACLList_AllowAllLoadErrorSurfaces pins the errListLoad mapping:
+// a mid-stream store failure on the AllowAll path surfaces as 500
+// list_load_failed rather than a silently truncated 200.
+func TestACLList_AllowAllLoadErrorSurfaces(t *testing.T) {
+	app := newTestAppV1(t)
+	app.store = failingListStore{Store: app.store}
+
+	// No gate on ctx → nopReadGate → AllowAll path.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1ListEntities(rec, req, "ticket", "tickets")
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "list_load_failed") {
+		t.Errorf("body missing list_load_failed: %s", rec.Body)
+	}
+}
+
 // TestACLList_VaryHeader pins TKT-VMD8 AC10 (RR-VDTW): when a
 // principal header is configured, /api/ responses carry both the
 // no-store Cache-Control and `Vary: <header>` so no cache layer can
@@ -415,5 +484,18 @@ type failingGraphQueryStore struct {
 func (s failingGraphQueryStore) GraphQuery(context.Context, store.GraphQuery) iter.Seq2[*entity.Entity, error] {
 	return func(yield func(*entity.Entity, error) bool) {
 		yield(nil, errors.New("synthetic graph query failure"))
+	}
+}
+
+// failingListStore wraps a store.Store with a ListEntities that
+// yields an immediate error — drives the errListLoad mapping on the
+// AllowAll path.
+type failingListStore struct {
+	store.Store
+}
+
+func (s failingListStore) ListEntities(context.Context, store.EntityQuery) iter.Seq2[*entity.Entity, error] {
+	return func(yield func(*entity.Entity, error) bool) {
+		yield(nil, errors.New("synthetic list failure"))
 	}
 }

--- a/internal/dataentry/acl_sidebar_test.go
+++ b/internal/dataentry/acl_sidebar_test.go
@@ -1,0 +1,184 @@
+package dataentry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// seedSidebarWorld seeds 10 tickets — 5 visible to alice (belongs-to
+// PRJ-42, which she is editor-of), 5 hidden (belongs-to PRJ-9). Of the
+// visible 5, 3 are status=open; of the hidden 5, 2 are status=open.
+func seedSidebarWorld(app *App) {
+	seedEntity(app, &entity.Entity{ID: "alice", Type: "person", Properties: map[string]any{"title": "Alice"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-42", Type: "project", Properties: map[string]any{"title": "Granted"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-9", Type: "project", Properties: map[string]any{"title": "Hidden"}})
+	seedRelation(app, entity.NewRelation("alice", "editor-of", "PRJ-42"))
+	for i := 1; i <= 5; i++ {
+		status := "closed"
+		if i <= 3 {
+			status = "open"
+		}
+		id := fmt.Sprintf("TKT-V%02d", i)
+		seedEntity(app, &entity.Entity{ID: id, Type: "ticket",
+			Properties: map[string]any{"title": id, "status": status}})
+		seedRelation(app, entity.NewRelation(id, "belongs-to", "PRJ-42"))
+	}
+	for i := 1; i <= 5; i++ {
+		status := "closed"
+		if i <= 2 {
+			status = "open"
+		}
+		id := fmt.Sprintf("TKT-H%02d", i)
+		seedEntity(app, &entity.Entity{ID: id, Type: "ticket",
+			Properties: map[string]any{"title": id, "status": status}})
+		seedRelation(app, entity.NewRelation(id, "belongs-to", "PRJ-9"))
+	}
+}
+
+// sidebarPolicy grants read on ticket via editor-of + belongs-to
+// containment — the same shape the list tests use, so sidebar and
+// list verdicts are directly comparable.
+func sidebarPolicy() *acl.Policy {
+	return &acl.Policy{
+		Roles: map[string]acl.RoleDef{"editor": {Read: []string{"ticket"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{
+			"editor-of": {Confers: "editor"},
+		},
+		InheritRolesThrough: []string{"belongs-to"},
+	}
+}
+
+// installSidebarConfig publishes a Config snapshot carrying one plain
+// list, one filtered list, and one kanban over tickets.
+func installSidebarConfig(app *App) {
+	app.mutateState(func(s *AppState) {
+		cfg := *s.Cfg
+		cfg.Lists = map[string]dataentryconfig.List{
+			"all-tickets": {EntityType: "ticket", Title: "All"},
+			"open-tickets": {EntityType: "ticket", Title: "Open",
+				Filters: []dataentryconfig.FilterConfig{{Property: "status", Operator: "=", Value: "open"}}},
+		}
+		cfg.Kanbans = map[string]dataentryconfig.Kanban{
+			"board": {EntityType: "ticket", ColumnProperty: "status"},
+		}
+		cfg.Navigation = []dataentryconfig.NavigationEntry{
+			{Label: "All", List: "all-tickets"},
+			{Label: "Open", List: "open-tickets"},
+			{Label: "Board", Kanban: "board"},
+		}
+		s.Cfg = &cfg
+	})
+}
+
+// sidebarCountsByLabel performs a sidebar request and returns the
+// label → count map for top-level items.
+func sidebarCountsByLabel(ctx context.Context, t *testing.T, app *App) map[string]int {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_sidebar", http.NoBody)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	app.handleV1Sidebar(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET _sidebar: %d %s", rec.Code, rec.Body)
+	}
+	var resp V1SidebarResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode sidebar: %v\nbody: %s", err, rec.Body)
+	}
+	out := make(map[string]int)
+	for _, group := range resp.Navigation {
+		for _, item := range group.Items {
+			if item.Count != nil {
+				out[item.Label] = *item.Count
+			}
+		}
+	}
+	return out
+}
+
+// TestACLSidebar_CountsMatchList pins TKT-VMD8 AC6: sidebar list and
+// kanban counts reflect the principal's visible subset (5 of 10), so
+// the sidebar can never disagree with the list it links to.
+func TestACLSidebar_CountsMatchList(t *testing.T) {
+	app := newTestAppV1(t)
+	seedSidebarWorld(app)
+	installSidebarConfig(app)
+
+	d := mustNewACL(t, sidebarPolicy(), app.store)
+	app.acl = d
+
+	counts := sidebarCountsByLabel(gateCtxFor(aliceCtx(), t, d), t, app)
+	if counts["All"] != 5 {
+		t.Errorf("list count = %d, want 5 (visible subset of 10)", counts["All"])
+	}
+	if counts["Board"] != 5 {
+		t.Errorf("kanban count = %d, want 5 (visible subset of 10)", counts["Board"])
+	}
+}
+
+// TestACLSidebar_ConfigFilterIntersection pins TKT-VMD8 AC7: a
+// config-filtered list counts the intersection visible ∩ filter —
+// ACL runs first, the config filter applies in-memory after.
+func TestACLSidebar_ConfigFilterIntersection(t *testing.T) {
+	app := newTestAppV1(t)
+	seedSidebarWorld(app)
+	installSidebarConfig(app)
+
+	d := mustNewACL(t, sidebarPolicy(), app.store)
+	app.acl = d
+
+	counts := sidebarCountsByLabel(gateCtxFor(aliceCtx(), t, d), t, app)
+	// 5 visible, 3 of them open. The 2 hidden-but-open tickets must
+	// not count.
+	if counts["Open"] != 3 {
+		t.Errorf("filtered list count = %d, want 3 (visible ∩ open)", counts["Open"])
+	}
+}
+
+// TestACLSidebar_DenyAllZeroCounts: a principal with no grant sees
+// zero counts everywhere — cardinality of hidden types does not leak
+// through the sidebar.
+func TestACLSidebar_DenyAllZeroCounts(t *testing.T) {
+	app := newTestAppV1(t)
+	seedSidebarWorld(app)
+	installSidebarConfig(app)
+
+	d := mustNewACL(t, sidebarPolicy(), app.store)
+	app.acl = d
+
+	counts := sidebarCountsByLabel(gateCtxFor(principalCtx("mallory"), t, d), t, app)
+	for _, label := range []string{"All", "Open", "Board"} {
+		if counts[label] != 0 {
+			t.Errorf("%s count = %d for deny-all principal, want 0", label, counts[label])
+		}
+	}
+}
+
+// TestACLSidebar_NopACLFullCounts pins the single-mode invariant
+// (RR-2O27): without ACL the same code path yields the full counts —
+// there is no separate "ACL off" branch to drift.
+func TestACLSidebar_NopACLFullCounts(t *testing.T) {
+	app := newTestAppV1(t)
+	seedSidebarWorld(app)
+	installSidebarConfig(app)
+
+	// No gate on ctx → nopReadGate → AllowAll.
+	counts := sidebarCountsByLabel(context.Background(), t, app)
+	if counts["All"] != 10 {
+		t.Errorf("list count = %d, want 10", counts["All"])
+	}
+	if counts["Open"] != 5 {
+		t.Errorf("filtered list count = %d, want 5 (all open)", counts["Open"])
+	}
+	if counts["Board"] != 10 {
+		t.Errorf("kanban count = %d, want 10", counts["Board"])
+	}
+}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -373,6 +373,15 @@ func (a *App) handleV1EntityCollection(w http.ResponseWriter, r *http.Request, t
 // it as a free-text search failure.
 var errACLListQuery = errors.New("acl list query failed")
 
+// errListLoad wraps a store iterator failure while loading the
+// unfiltered (AllowAll) list. Surfaced as 500 list_load_failed at the
+// call sites: before TKT-VMD8 a mid-stream error silently truncated
+// the result, which under ACL would make the AllowAll and Query paths
+// observably asymmetric (truncated-200 vs 500) for the same backend
+// fault — and a truncated list with authoritative-looking pagination
+// is worse than an error either way.
+var errListLoad = errors.New("list load failed")
+
 // scopedSortedEntities runs the shared list pipeline — ACL read scope,
 // load, free-text intersection (?q=), structured filters (filter[...]),
 // then the configured sort — and returns the fully ordered result set
@@ -401,7 +410,15 @@ func (a *App) scopedSortedEntities(ctx context.Context, typeName string, query m
 	case rqr.DenyAll:
 		return []*entityPkg.Entity{}, nil
 	case rqr.AllowAll:
-		entities = listFromStoreByTypes(ctx, a.Services(), []string{typeName})
+		// Inline iteration rather than listFromStoreByTypes: that
+		// helper swallows iterator errors into a partial slice, and
+		// the list pipeline must fail loud on both verdict paths.
+		for e, err := range a.Services().Store.ListEntities(ctx, store.EntityQuery{Type: typeName}) {
+			if err != nil {
+				return nil, fmt.Errorf("%w: %w", errListLoad, err)
+			}
+			entities = append(entities, e)
+		}
 	case rqr.Query == nil:
 		// Defensive: a zero ReadQueryResult would otherwise alias
 		// AllowAll. Fail loud instead of silently widening the list.
@@ -453,11 +470,7 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 
 	entities, err := a.scopedSortedEntities(r.Context(), typeName, query)
 	if err != nil {
-		if errors.Is(err, errACLListQuery) {
-			writeGateError(w, r, err)
-			return
-		}
-		writeV1Error(w, r, http.StatusInternalServerError, "search_failed", "Free-text search failed", err.Error())
+		writeListPipelineError(w, r, err)
 		return
 	}
 
@@ -832,6 +845,23 @@ func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName
 	}
 
 	writeV1JSON(w, http.StatusOK, result)
+}
+
+// writeListPipelineError maps a scopedSortedEntities / resolveScope
+// error to the right HTTP shape: ACL query failures route through
+// writeGateError, store-load failures surface as list_load_failed,
+// and anything else is the free-text search failure the pipeline
+// always surfaced. Shared by the list and _position handlers so the
+// two consumers of the pipeline can't drift.
+func writeListPipelineError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, errACLListQuery):
+		writeGateError(w, r, err)
+	case errors.Is(err, errListLoad):
+		writeV1Error(w, r, http.StatusInternalServerError, "list_load_failed", "Loading entities failed", err.Error())
+	default:
+		writeV1Error(w, r, http.StatusInternalServerError, "search_failed", "Free-text search failed", err.Error())
+	}
 }
 
 // writeGateError maps a readGate.PermitsRead / PermitsReadMany error
@@ -2573,6 +2603,13 @@ func (c *sidebarCounts) kanbanCount(ctx context.Context, kanbanID string, kanban
 // Backend errors degrade to 0 with a warning — parity with the old
 // CountEntities error path: a broken sidebar count must not take the
 // whole sidebar down, and the list endpoint surfaces the real error.
+//
+// ReadQuery (one member-of walk reuse via the request-scoped
+// acl.Request) and the GraphQuery/GraphCount run once per nav item —
+// two lists over the same type recompute rather than share. Accepted:
+// filterCache keys on list/kanban id, not (type, filters); a
+// (type, filters)-keyed memo is the obvious upgrade if sidebar
+// latency ever warrants it.
 func (c *sidebarCounts) countWithFilters(ctx context.Context, entityType string, filters []dataentryconfig.FilterConfig) int {
 	rqr := readGateFromContext(ctx).ReadQuery(ctx, entityType)
 	if rqr.DenyAll {

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -853,14 +853,24 @@ func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName
 // and anything else is the free-text search failure the pipeline
 // always surfaced. Shared by the list and _position handlers so the
 // two consumers of the pipeline can't drift.
+//
+// All branches log the raw error server-side and keep it out of the
+// response body (RR-372L / IB-review PR939 #1): a store or search
+// backend error string can name tables, columns, or index paths.
 func writeListPipelineError(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
 	case errors.Is(err, errACLListQuery):
 		writeGateError(w, r, err)
 	case errors.Is(err, errListLoad):
-		writeV1Error(w, r, http.StatusInternalServerError, "list_load_failed", "Loading entities failed", err.Error())
+		slog.Warn("dataentry: list load failed",
+			"err", err, "path", r.URL.Path, "method", r.Method)
+		writeV1Error(w, r, http.StatusInternalServerError, "list_load_failed",
+			"Loading entities failed", "check server logs")
 	default:
-		writeV1Error(w, r, http.StatusInternalServerError, "search_failed", "Free-text search failed", err.Error())
+		slog.Warn("dataentry: list free-text search failed",
+			"err", err, "path", r.URL.Path, "method", r.Method)
+		writeV1Error(w, r, http.StatusInternalServerError, "search_failed",
+			"Free-text search failed", "check server logs")
 	}
 }
 

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -367,16 +367,53 @@ func (a *App) handleV1EntityCollection(w http.ResponseWriter, r *http.Request, t
 	}
 }
 
-// scopedSortedEntities runs the shared list pipeline — load-by-type,
-// free-text intersection (?q=), structured filters (filter[...]), then the
-// configured sort — and returns the fully ordered result set *before*
-// pagination. Both handleV1ListEntities and handleV1EntityPosition call this,
-// so a list and its scope navigator are guaranteed to observe identical
-// ordering. The only error returned is a free-text search failure (HTTP 500
-// at the call site); everything else degrades to an empty/whole set as the
-// list endpoint always did.
+// errACLListQuery wraps a store.GraphQuery failure during ACL list
+// filtering so call sites can route it through writeGateError (500
+// acl_query_failed / 504 / silent-on-cancel) instead of mislabeling
+// it as a free-text search failure.
+var errACLListQuery = errors.New("acl list query failed")
+
+// scopedSortedEntities runs the shared list pipeline — ACL read scope,
+// load, free-text intersection (?q=), structured filters (filter[...]),
+// then the configured sort — and returns the fully ordered result set
+// *before* pagination. Both handleV1ListEntities and
+// handleV1EntityPosition call this, so a list and its scope navigator
+// are guaranteed to observe identical ordering (under ACL both operate
+// on the same visible subset — hidden entities don't occupy ordinals).
+//
+// ACL ordering contract (TKT-VMD8, RR-X56H + RR-3IO2): the read-scope
+// verdict resolves FIRST. DenyAll returns before the search backend,
+// filters, or sort run — a denied principal must not be able to probe
+// backend latency through ?q=. A composed Query loads the visible
+// subset via store.GraphQuery; search/filter/sort then operate on that
+// filtered slice only (search-after-ACL). AllowAll keeps the pre-ACL
+// load path byte-identical.
+//
+// Errors: free-text search failures surface verbatim (HTTP 500
+// search_failed at the call site); ACL query failures are wrapped in
+// errACLListQuery so call sites map them via writeGateError. Everything
+// else degrades to an empty/whole set as the list endpoint always did.
 func (a *App) scopedSortedEntities(ctx context.Context, typeName string, query map[string][]string) ([]*entityPkg.Entity, error) {
-	entities := listFromStoreByTypes(ctx, a.Services(), []string{typeName})
+	rqr := readGateFromContext(ctx).ReadQuery(ctx, typeName)
+
+	var entities []*entityPkg.Entity
+	switch {
+	case rqr.DenyAll:
+		return []*entityPkg.Entity{}, nil
+	case rqr.AllowAll:
+		entities = listFromStoreByTypes(ctx, a.Services(), []string{typeName})
+	case rqr.Query == nil:
+		// Defensive: a zero ReadQueryResult would otherwise alias
+		// AllowAll. Fail loud instead of silently widening the list.
+		return nil, fmt.Errorf("%w: zero ReadQueryResult for type %q", errACLListQuery, typeName)
+	default:
+		for e, err := range a.Services().Store.GraphQuery(ctx, *rqr.Query) {
+			if err != nil {
+				return nil, fmt.Errorf("%w: %w", errACLListQuery, err)
+			}
+			entities = append(entities, e)
+		}
+	}
 
 	// Free-text search: intersect with hits from the searcher when ?q=... is
 	// present. Bleve scores are discarded — the list's configured sort wins
@@ -416,6 +453,10 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 
 	entities, err := a.scopedSortedEntities(r.Context(), typeName, query)
 	if err != nil {
+		if errors.Is(err, errACLListQuery) {
+			writeGateError(w, r, err)
+			return
+		}
 		writeV1Error(w, r, http.StatusInternalServerError, "search_failed", "Free-text search failed", err.Error())
 		return
 	}
@@ -2439,21 +2480,8 @@ func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s := a.State()
-	svc := a.Services()
-
-	// Build entity type counts as a fallback for items without filters.
-	typeCounts := make(map[string]int)
-	for _, entityType := range s.Meta.EntityTypes() {
-		n, err := svc.Store.CountEntities(r.Context(), store.EntityQuery{Type: entityType})
-		if err != nil {
-			typeCounts[entityType] = 0
-			continue
-		}
-		typeCounts[entityType] = n
-	}
 
 	counts := sidebarCounts{
-		typeCounts:  typeCounts,
 		filterCache: make(map[string]int),
 		app:         a,
 	}
@@ -2495,10 +2523,14 @@ func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 }
 
 // sidebarCounts caches sidebar entity counts, applying list- or kanban-
-// level filters when present. Unfiltered views fall back to the
-// type-level total.
+// level filters when present. Every count flows through the ACL read
+// scope (TKT-VMD8) — one code path regardless of NopACL vs. Declarative
+// (RR-2O27), so the sidebar can never disagree with the list it links
+// to. filterCache is a within-request memo keyed by list/kanban id; it
+// is safe precisely because a sidebarCounts value lives for one request
+// (one principal) — a longer-lived cache would alias counts across
+// principals (RR-BZ4M).
 type sidebarCounts struct {
-	typeCounts  map[string]int
 	filterCache map[string]int // key: "list:<id>" or "kanban:<id>"
 	app         *App
 }
@@ -2528,13 +2560,48 @@ func (c *sidebarCounts) kanbanCount(ctx context.Context, kanbanID string, kanban
 }
 
 // countWithFilters returns the count of entities of the given type that
-// pass the supplied filters. When filters is empty, the precomputed
-// type total is returned directly.
+// are visible to the requesting principal AND pass the supplied config
+// filters. Ordering is ACL → config filter → count (TKT-VMD8 AC7).
+//
+// Without config filters the count comes straight from GraphCount —
+// identical cost to the old Store.CountEntities for the AllowAll case.
+// With config filters the visible entities are loaded and filtered
+// in-memory; performance scales with the visible-set size (RR-REQW —
+// for visible sets >10k prefer pre-filtering via entity_type in nav
+// config, or file the follow-up that pushes filters into GraphQuery).
+//
+// Backend errors degrade to 0 with a warning — parity with the old
+// CountEntities error path: a broken sidebar count must not take the
+// whole sidebar down, and the list endpoint surfaces the real error.
 func (c *sidebarCounts) countWithFilters(ctx context.Context, entityType string, filters []dataentryconfig.FilterConfig) int {
-	if len(filters) == 0 {
-		return c.typeCounts[entityType]
+	rqr := readGateFromContext(ctx).ReadQuery(ctx, entityType)
+	if rqr.DenyAll {
+		return 0
 	}
-	entities := listFromStoreByTypes(ctx, c.app.Services(), []string{entityType})
+	q := store.GraphQuery{EntityType: entityType}
+	if rqr.Query != nil {
+		q = *rqr.Query
+	}
+
+	if len(filters) == 0 {
+		matched, _, err := c.app.Services().Store.GraphCount(ctx, q)
+		if err != nil {
+			slog.Warn("sidebar: GraphCount failed; count degraded to 0",
+				"entity_type", entityType, "error", err)
+			return 0
+		}
+		return matched
+	}
+
+	var entities []*entityPkg.Entity
+	for e, err := range c.app.Services().Store.GraphQuery(ctx, q) {
+		if err != nil {
+			slog.Warn("sidebar: GraphQuery failed; count degraded to 0",
+				"entity_type", entityType, "error", err)
+			return 0
+		}
+		entities = append(entities, e)
+	}
 	return len(applyFilters(entities, filters))
 }
 

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -162,6 +162,16 @@ type App struct {
 	// here when --principal-header is set.
 	principalResolver PrincipalResolver
 
+	// principalHeader is the name of the HTTP header that carries the
+	// principal identity (the --principal-header flag value), or ""
+	// when no header is configured. Used by noCacheMiddleware to emit
+	// `Vary: <header>` on /api/ responses — under ACL those responses
+	// are per-principal, and a shared cache keyed only on the URL
+	// would serve principal A's filtered list to principal B
+	// (TKT-VMD8 AC10, RR-VDTW). Set via SetPrincipalHeader before
+	// NewRouter.
+	principalHeader string
+
 	// fieldResolver decides per-entity field, option, and
 	// relation-meta affordances surfaced as `_fields` / `_relations`
 	// on the wire and enforced on writes. Required (never nil) —
@@ -268,6 +278,14 @@ func (a *App) SetSecurityConfig(cfg SecurityConfig) error {
 // [defaultPrincipalResolver] behavior.
 func (a *App) SetPrincipalResolver(r PrincipalResolver) {
 	a.principalResolver = r
+}
+
+// SetPrincipalHeader records the name of the HTTP header that carries
+// the principal identity so API responses can declare `Vary` on it.
+// Call alongside [App.SetPrincipalResolver] (before [App.NewRouter])
+// when wiring a [HeaderPrincipalResolver]; leave unset otherwise.
+func (a *App) SetPrincipalHeader(name string) {
+	a.principalHeader = name
 }
 
 // NewApp creates and initializes an App. Callers pass in the

--- a/internal/dataentry/readgate.go
+++ b/internal/dataentry/readgate.go
@@ -14,17 +14,21 @@ import (
 // boolean rather than threading `acl.FromContext(ctx)` plus a
 // nil-check plus a per-call switch through each handler.
 //
-// Two flavors of decision, both phrased as ACL permission questions:
+// Three flavors of decision, all phrased as ACL permission questions:
 //
 //   - PermitsRead(ctx, type, id) — single-entity probe. Used by GET,
 //     write paths, and per-id include checks.
 //   - PermitsReadMany(ctx, type, ids) — batched probe returning a
 //     permission map. Used by the ?include= filter and any future
 //     list consumer.
+//   - ReadQuery(ctx, type) — list-scope verdict. Used by the list
+//     pipeline (scopedSortedEntities) and the sidebar counts to decide
+//     between unfiltered (AllowAll), empty (DenyAll), and a composed
+//     store.GraphQuery that selects the visible subset (TKT-VMD8).
 //
-// Neither method verifies existence — they answer "the policy permits
-// reading this id IF it exists". Callers that need existence follow
-// up with getEntity.
+// None of the methods verify existence — they answer "the policy
+// permits reading this id IF it exists". Callers that need existence
+// follow up with getEntity.
 //
 // The production impl (aclReadGate) wraps a per-request *acl.Request;
 // the no-op impl (nopReadGate) is what handlers get when no ACL is
@@ -32,6 +36,7 @@ import (
 type readGate interface {
 	PermitsRead(ctx context.Context, entityType, entityID string) (bool, error)
 	PermitsReadMany(ctx context.Context, entityType string, ids []string) (map[string]bool, error)
+	ReadQuery(ctx context.Context, entityType string) acl.ReadQueryResult
 }
 
 // aclReadGate is the production implementation of readGate. Wraps a
@@ -61,6 +66,10 @@ func (g aclReadGate) PermitsReadMany(ctx context.Context, entityType string, ids
 	return g.req.PermitsReadMany(ctx, entityType, ids)
 }
 
+func (g aclReadGate) ReadQuery(ctx context.Context, entityType string) acl.ReadQueryResult {
+	return g.req.ReadQuery(ctx, entityType)
+}
+
 // nopReadGate answers "permitted" for every probe. It's the gate the
 // handlers see under NopACL / ReadOnlyACL — the wire response shape
 // is then byte-identical to today's pre-ACL behavior, which is what
@@ -77,6 +86,10 @@ func (nopReadGate) PermitsReadMany(_ context.Context, _ string, ids []string) (m
 		m[id] = true
 	}
 	return m, nil
+}
+
+func (nopReadGate) ReadQuery(context.Context, string) acl.ReadQueryResult {
+	return acl.ReadQueryResult{AllowAll: true}
 }
 
 // readGateCtxKey is the unexported type for context.WithValue. The

--- a/internal/dataentry/scope.go
+++ b/internal/dataentry/scope.go
@@ -3,6 +3,7 @@ package dataentry
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -189,6 +190,10 @@ func (a *App) handleV1EntityPosition(w http.ResponseWriter, r *http.Request) {
 
 	entities, err := a.resolveScope(r.Context(), scope)
 	if err != nil {
+		if errors.Is(err, errACLListQuery) {
+			writeGateError(w, r, err)
+			return
+		}
 		writeV1Error(w, r, http.StatusInternalServerError, "search_failed", "Free-text search failed", err.Error())
 		return
 	}

--- a/internal/dataentry/scope.go
+++ b/internal/dataentry/scope.go
@@ -3,7 +3,7 @@ package dataentry
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -95,6 +95,14 @@ func scopeFromParam(raw string, meta entityTypeChecker) (scope ScopeDescriptor, 
 // narrows to Type when one was supplied. Routing search through executeQuery
 // (not scopedSortedEntities) is what makes prev/next correct across mixed-type
 // search results: position is found within the exact set the user saw.
+//
+// Both branches end gated: the list pipeline resolves the read scope
+// internally; the search branch filters through readableSubset because
+// executeQuery itself is ungated (its other consumer, the search view,
+// is the deferred /_search ticket). Without the filter a denied
+// principal reads hidden cardinality from Total and harvests hidden
+// {ID, Type} pairs from prev/next — the exact leak shape TKT-VMD8
+// closes on the list path (CRIT finding, TKT-VMD8 review).
 func (a *App) resolveScope(ctx context.Context, scope ScopeDescriptor) ([]*entityPkg.Entity, error) {
 	switch scope.Source {
 	case "search":
@@ -108,10 +116,45 @@ func (a *App) resolveScope(ctx context.Context, scope ScopeDescriptor) ([]*entit
 			}
 			entities = filtered
 		}
-		return entities, nil
+		return a.readableSubset(ctx, entities)
 	default:
 		return a.scopedSortedEntities(ctx, scope.Type, scope.toQuery())
 	}
+}
+
+// readableSubset drops entities the ctx principal may not read,
+// preserving order. Gate probes are batched per entity type
+// (PermitsReadMany), mirroring the include-filter batching rule from
+// TKT-VQGN. Errors wrap errACLListQuery so the position handler maps
+// them via writeGateError.
+func (a *App) readableSubset(ctx context.Context, entities []*entityPkg.Entity) ([]*entityPkg.Entity, error) {
+	if len(entities) == 0 {
+		return entities, nil
+	}
+	gate := readGateFromContext(ctx)
+	byType := make(map[string][]string)
+	for _, e := range entities {
+		byType[e.Type] = append(byType[e.Type], e.ID)
+	}
+	allowed := make(map[string]bool, len(entities))
+	for typ, ids := range byType {
+		m, err := gate.PermitsReadMany(ctx, typ, ids)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", errACLListQuery, err)
+		}
+		for id, ok := range m {
+			if ok {
+				allowed[id] = true
+			}
+		}
+	}
+	out := entities[:0]
+	for _, e := range entities {
+		if allowed[e.ID] {
+			out = append(out, e)
+		}
+	}
+	return out, nil
 }
 
 // entityTypeChecker is the narrow capability scopeFromParam needs: confirm a
@@ -190,11 +233,7 @@ func (a *App) handleV1EntityPosition(w http.ResponseWriter, r *http.Request) {
 
 	entities, err := a.resolveScope(r.Context(), scope)
 	if err != nil {
-		if errors.Is(err, errACLListQuery) {
-			writeGateError(w, r, err)
-			return
-		}
-		writeV1Error(w, r, http.StatusInternalServerError, "search_failed", "Free-text search failed", err.Error())
+		writeListPipelineError(w, r, err)
 		return
 	}
 

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -350,9 +350,18 @@ func (a *App) handleSSE(w http.ResponseWriter, r *http.Request) {
 //
 // Static files (/static/*) are served separately and bypass this
 // middleware, so they retain normal caching behavior.
+//
+// Under ACL, API responses are additionally per-principal: when a
+// principal header is configured (SetPrincipalHeader), `Vary` names it
+// so any cache that ignores the no-store directive still keys on the
+// identity header instead of serving principal A's filtered response
+// to principal B (TKT-VMD8 AC10, RR-VDTW).
 func (a *App) noCacheMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		if a.principalHeader != "" {
+			w.Header().Add("Vary", a.principalHeader)
+		}
 		next.ServeHTTP(w, r)
 	})
 }

--- a/tickets/entities/docs-checklists/DOCS-X1K2FE.md
+++ b/tickets/entities/docs-checklists/DOCS-X1K2FE.md
@@ -1,0 +1,24 @@
+---
+id: DOCS-X1K2FE
+type: docs-checklist
+title: 'Docs: ACL read-side (PR 2/2): list endpoints + sidebar counts + pagination headers'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — scopedSortedEntities ACL ordering contract, errACLListQuery/errListLoad sentinels, sidebarCounts single-mode rationale (RR-2O27/RR-BZ4M), readableSubset batching, noCacheMiddleware Vary, Policy.Validate write⊆read scope
+- [x] Function/type docs if public API — `App.SetPrincipalHeader`, `Policy.Validate` godoc extended
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: no project-level changes)
+- [x] ~~CLAUDE.md updated~~ (N/A: no new patterns — consumer-side interface + capability rules already cover readGate.ReadQuery)
+- [x] ~~Help text accurate~~ (N/A: no CLI flag changes — --principal-header text unchanged)
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: project has no changelog file; release notes derive from PR titles)
+- [x] API docs updated — `GUIDE-acl-security` read-path rewrite (both gates, search-after-ACL contract, write⊆read invariant + scope, caching/Vary, sidebar menu decision, config-filter perf caveat, _position status); `docs/acl-security.md` regenerated via `just docs`; `docs/security.md` policy-mode row + write⊆read semantics bullet

--- a/tickets/entities/implementation-checklists/IMPL-TZHZOE.md
+++ b/tickets/entities/implementation-checklists/IMPL-TZHZOE.md
@@ -1,0 +1,77 @@
+---
+id: IMPL-TZHZOE
+type: implementation-checklist
+title: 'Implementation: ACL read-side (PR 2/2): list endpoints + sidebar counts + pagination headers'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Tests: `internal/acl/policy_test.go`
+(`TestLoadPolicy_WriteWithoutRead_Rejected`, 7 cases incl. wildcard
+combinations), `internal/dataentry/acl_list_test.go`
+(AC1/AC2/AC3/AC4/AC5/AC9/AC10 + `TestACLList_QueryErrorMapping` for the
+errACLListQuery → writeGateError routing),
+`internal/dataentry/acl_sidebar_test.go` (AC6/AC7 + DenyAll-zero + NopACL-full
+single-mode), `internal/dataentry/acl_list_regression_test.go` (AC11 list shape
++ free-text untouched under NopACL). Error handling: ACL GraphQuery failures
+wrap `errACLListQuery` and route through `writeGateError` (500
+`acl_query_failed` / 504 / silent-on-cancel) instead of mislabeling as
+`search_failed`; sidebar counts degrade to 0 with `slog.Warn` (parity with the
+old CountEntities error path).
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+Reused PR-1 harness (`mustNewACL`, `gateCtxFor`, `principalCtx`); shared
+`seedSidebarWorld`/`sidebarPolicy`/`installSidebarConfig` builders; recording
+doubles (`recordingSearcher`, `orderRecordingStore`, `failingGraphQueryStore`)
+for ordering/short-circuit asserts.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Live `rela-server` against a scratch project (10 tickets: 5 belongs-to PRJ-42
+which alice is editor-of, 5 hidden; `inherit_roles_through: [belongs-to]`;
+`--principal-header X-Rela-User`):
+
+- alice `GET /api/v1/tickets?per_page=3&page=2&sort=title` → data `[TKT-V04, TKT-V05]`, meta `{total:5, page:2, per_page:3, has_more:false}`, `X-Total-Count: 5`, `Link` rel="last"→page=2, **no rel="next"**, `_actions.create: false`, `Cache-Control: no-cache, no-store, must-revalidate`, `Vary: X-Rela-User`. The hidden total 10 appears nowhere. (AC1/AC2/AC3/AC10)
+- bob (no grants) → `data: []`, total 0, `X-Total-Count: 0`, `_actions.create: false`. (AC4)
+- alice `?q=Hidden` → `[]` (search intersects post-ACL). (AC5/AC9)
+- Sidebar alice: All Tickets=5, Open Tickets=3 (visible∩open); bob: 0/0. (AC6/AC7)
+- Per-entity parity intact: hidden TKT-H01 → 404, visible TKT-V01 → 200.
+- `_position` for TKT-V02 → `{current:2, total:5}`, prev/next within visible subset only.
+- Boot with `write: [ticket]` no-read role → exits 1: `roles.weird: grants write on "ticket" without a covering read grant…`. (AC8)
+- Unstamped principal on /api/ → 500 (fail-loud invariant preserved).
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — readGate gained `ReadQuery` (one seam for list + sidebar) instead of duplicating verdict switches per consumer; error mapping reuses `writeGateError`
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+`just lint`, `just arch-lint`, `just coverage-check` (74.5% total, thresholds
+pass), `go test ./internal/...` all green. Docs: GUIDE-acl-security read-path
+rewrite (both gates, search-ordering contract, policy invariant, caching, menu
+decision, perf caveat, _position deferral), `docs/acl-security.md` regenerated,
+`docs/security.md` policy-mode row + write⊆read semantics bullet updated.

--- a/tickets/entities/planning-checklists/PLAN-SQSTM7.md
+++ b/tickets/entities/planning-checklists/PLAN-SQSTM7.md
@@ -1,0 +1,169 @@
+---
+id: PLAN-SQSTM7
+type: planning-checklist
+title: 'Planning: ACL read-side (PR 2/2): list endpoints + sidebar counts + pagination headers'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+In scope (verbatim from the ticket, verified against the code as TKT-VQGN landed
+it):
+
+- Gate `scopedSortedEntities` (api_v1.go:371) through the readGate: DenyAll short-circuits to empty BEFORE `freeTextIDsForType` / `applyV1Filters` / `applyV1Sorting`; Query path collects from `Store.GraphQuery` then runs search/filter/sort on the filtered slice; AllowAll keeps today's `listFromStoreByTypes` path byte-identical.
+- All pagination leak surfaces (`meta.*`, `X-Total-Count`, `X-Page`, `X-Per-Page`, `Link` rel next/last) derive from post-filter `total` — automatic once scopedSortedEntities filters; pinned by AC3 tests.
+- `sidebarCounts` single-mode collapse: drop the `typeCounts` precompute in `handleV1Sidebar` (api_v1.go:2430-2445); `countWithFilters` always goes through `gate.ReadQuery` + `GraphCount`/`GraphQuery`. `filterCache` stays.
+- `acl.Policy.Validate` rejects read-deny + write-grant roles at load (write entry without covering read entry, wildcard-aware).
+- Per-principal caching: existing `noCacheMiddleware` already sets `Cache-Control: no-cache, no-store, must-revalidate` on all `/api/` (covers the no-store requirement); add `Vary: <principal-header>` when `--principal-header` is configured (new `App.SetPrincipalHeader` + cmd/rela-server wiring).
+- DenyAll list `_actions.create == false` — already structurally true via `computeCollectionActions` (write-path verdict) + the new policy invariant; pinned by AC4 test.
+- Docs: GUIDE-acl-security read-path rewrite covering both PRs.
+
+Out of scope: `_position` per-id semantics (RR-NDMN/RR-37IY/RR-ATSO follow-up —
+note `_position` shares `scopedSortedEntities` so it inherits visible-subset
+filtering implicitly, which keeps list/position coherent), `/_search` filtering,
+SSE per-subscriber visibility, MCP transport, property redaction.
+
+**Acceptance Criteria:** AC1–AC12 as documented on TKT-VMD8 (each maps to a test
+in the Test Plan below).
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: approach fully specified by the ticket, which is itself the output of multi-round design review with 16 RRs)
+- [x] ~~Searched for existing libraries~~ (N/A: internal feature, no external library surface)
+- [x] Checked codebase for similar patterns or reusable code
+- [x] ~~Looked for reference implementations in other projects~~ (N/A: pattern established in-repo by TKT-VQGN PR 1)
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — TKT-VQGN's planning + RES round covered the two-PR
+series.
+
+**Existing Solutions:**
+
+- `acl.Request.ReadQuery(ctx, type) ReadQueryResult` already exists (internal/acl/request.go:92) — errorless, returns AllowAll/DenyAll/Query. The dataentry `readGate` interface (readgate.go:32) just doesn't expose it yet; adding a third method follows the consumer-side-interface rule.
+- `store.GraphQueryer.GraphCount(ctx, q) (matched, total, err)` (store/graphquery.go:63) is exactly the sidebar count shape; graphquerynaive backs all three backends.
+- Test harness reuse: `mustNewACL`, `gateCtxFor`, `principalCtx` from acl_get_test.go; `stripInstance` comparator pattern from PR 1.
+- Error mapping reuse: `writeGateError` (api_v1.go:794) for ACL-query failures on the list path.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+1. `readgate.go`: add `ReadQuery(ctx, entityType) acl.ReadQueryResult` to the `readGate` interface. `aclReadGate` delegates to `req.ReadQuery`; `nopReadGate` returns `{AllowAll: true}`.
+2. `scopedSortedEntities`: resolve `rqr := readGateFromContext(ctx).ReadQuery(ctx, typeName)` first. DenyAll → return empty immediately (search backend untouched). Query → collect `Store.GraphQuery(ctx, *rqr.Query)`; iterator error wrapped in a sentinel (`errACLListQuery`) so call sites route it through `writeGateError` instead of the `search_failed` 500. AllowAll → existing path unchanged. Search/filter/sort run after, on the (possibly filtered) slice — pins search-after-ACL ordering.
+3. `handleV1ListEntities` + `handleV1EntityPosition` call sites: distinguish sentinel-wrapped ACL errors (→ `writeGateError`) from search errors (→ existing `search_failed`).
+4. Sidebar: delete `typeCounts` precompute; `countWithFilters` becomes gate-aware: DenyAll → 0; no config filters → `GraphCount` (AllowAll uses bare `GraphQuery{EntityType: t}`, Query uses `*rqr.Query`), matched count; with config filters → collect entities (GraphQuery), `applyFilters`, `len`. Errors degrade to 0 (parity with today's CountEntities error path) with `slog.Warn`.
+5. `acl/policy.go` `Validate()`: for each role, every `Write` entry must be covered by `Read` (exact or `*`; `write: ["*"]` requires `read: ["*"]`). Structured error names the role and type.
+6. `App.principalHeader` field + `SetPrincipalHeader`; `noCacheMiddleware` adds `Vary` when set; cmd/rela-server wires the flag value.
+
+**Files to modify:** as listed on the ticket; plus
+`internal/dataentry/readgate.go` (interface), `internal/dataentry/watcher.go`
+(noCacheMiddleware Vary), `internal/dataentry/app.go` (SetPrincipalHeader),
+`cmd/rela-server/main.go` (wiring), `internal/dataentry/acl_get_test.go`
+(fakeGate gains ReadQuery).
+
+**Alternatives rejected:**
+- Exposing `Globals`/role internals to dataentry instead of `ReadQuery` — leaks policy vocabulary across the boundary; ReadQueryResult is the designed seam.
+- Filtering after load via `PermitsReadMany` on the full id list — O(N) MatchingIDs work duplicating what GraphQuery does in one pass, and leaves the search backend running pre-ACL.
+- `Cache-Control: private` addition — redundant: `no-store` (already set by noCacheMiddleware) is strictly stronger; only `Vary` adds defense.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+- Query params (page/per_page/q/filter/sort): unchanged, already clamped; they now operate on the post-ACL slice only.
+- `acl.yaml`: new load-time invariant (write⊆read) is an allowlist-shaped check; structured error names role+type, no data leak.
+- Principal header: already sanitized (sanitizeUser); only its NAME (operator config, not request data) goes into `Vary`.
+
+**Security-Sensitive Operations:**
+- Cardinality leak surfaces: every count/header derives from one post-filter `total`; AC3 enumerates all eight.
+- Timing side-channel (RR-X56H): DenyAll returns before the search backend is touched — pinned by mock-searcher call-count test.
+- Cache cross-principal leak (RR-VDTW): no-store already global on /api/; Vary added when principal header configured.
+- Fail-loud preserved: ACL query errors surface via writeGateError (500/504), never silently as empty list — an empty-on-error list would be deny-shaped but masks outages.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** (files per ticket: acl_list_test.go, acl_sidebar_test.go,
+acl_list_regression_test.go, acl/policy_test.go)
+- AC1: viewer role read:[ticket] → GET /api/v1/tickets lists all tickets; GET /api/v1/features → data:[].
+- AC2: role-relation `editor-of` confers read via inherit_roles_through:[belongs-to]; only TKT linked under the granted project returned.
+- AC3: 5 visible + 5 hidden, per_page=3&page=2 → data.length=2, meta.total=5, has_more=false, X-Total-Count=5, X-Page=2, X-Per-Page=3, Link last→page=2, no rel="next"; assert "10" appears nowhere.
+- AC4: no-read principal → data:[], meta.total=0, headers 0, `_actions.create == false`.
+- AC5: recording searcher injected; DenyAll list request → searcher call count 0.
+- AC6/AC7: sidebar counts = visible subset; with config filter = visible∩filter; same path with and without acl.yaml (single-mode).
+- AC8: policy fixture write:[ticket] without read → LoadPolicyBytes error naming role+type; wildcard cases (write:* + read:* ok, write:* + read:[ticket] rejected).
+- AC9: wrapper store records GraphQuery call; recording searcher records search call; assert order GraphQuery < search and search input scoped to filtered slice.
+- AC10: router-level test with principal header configured: response has Cache-Control no-store + Vary: <header>.
+- AC11: NopACL (no acl.yaml): list + sidebar responses carry full expected JSON (golden-style assert), proving no shape drift.
+- AC12: docs review item in the docs checklist.
+
+**Edge Cases:**
+- Empty type (0 entities) under each verdict — counts 0, no Link next, last→page=1.
+- page beyond last visible page → empty data, correct headers.
+- GraphQuery iterator error mid-stream → 500 acl_query_failed (not partial list).
+- ctx.Canceled during ACL query → no response written (writeGateError parity).
+- Role with write:[] and read:[] (empty both) → valid policy, DenyAll.
+- Sidebar list config referencing unknown list id → existing behavior unchanged (no count).
+- per_page=100 cap, page=0 floor — unchanged, now post-ACL.
+
+**Negative Tests:** AC5 (searcher must NOT be called), AC8 (policy load must
+fail), AC3 (rel="next" must be absent; "10" must not appear in any header/body
+field).
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+- Base PR 939 not yet merged — branch stacks on feat/acl-readside-tkt-vqgn; if review forces changes to PR 1, rebase this branch (cherry-pick pattern already proven twice in this stack).
+- `_position` behavior changes implicitly (visible-subset ordinals). Mitigation: this is the coherent choice (same pipeline as list); documented in PR + ticket; per-id gate semantics remain the follow-up's scope.
+- Policy-load invariant may reject existing operator policies that relied on write-without-read. Mitigation: structured error tells the operator exactly which role/type to fix; documented in GUIDE-acl-security; this rejection is the designed outcome of RR-W2J6.
+- Sidebar perf on large visible sets with config filters (RR-REQW): documented caveat only, no code change; follow-up ticket named.
+
+Effort: m (matches ticket).
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- GUIDE-acl-security (docs-project) — full read-path section rewrite (AC12).
+- docs/acl-security.md — regenerated from the guide.
+- docs/security.md — note the write⊆read policy invariant if it documents role grants.
+- N/A: metamodel.md, cli-reference.md (no command changes).
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** This ticket's scope IS the output of the
+TKT-VQGN/TKT-VMD8 multi-round design review: RR-X56H, RR-W2J6, RR-VDTW, RR-REQW
+(deferred from PR 1 to here), RR-2O27, RR-3IO2, RR-BZ4M, RR-FF7Q, RR-KNGC,
+RR-WX77, RR-Q5LH all have their resolutions baked into the Scope/AC text above.
+RR-NDMN, RR-37IY, RR-ATSO carry to the _position follow-up. No new design review
+round needed — re-running it on the same reviewed text would be circular.

--- a/tickets/entities/review-checklists/REV-WZF7GI.md
+++ b/tickets/entities/review-checklists/REV-WZF7GI.md
@@ -1,0 +1,74 @@
+---
+id: REV-WZF7GI
+type: review-checklist
+title: 'Review: ACL read-side (PR 2/2): list endpoints + sidebar counts + pagination headers'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — full `go test ./internal/... ./cmd/...` green (race detector via CI)
+- [x] Lint clean (`just lint`) — 0 issues after `just lint-fix` (one gofmt nit)
+- [x] Coverage maintained (`just coverage-check`) — 74.5% total, all package floors pass; `just arch-lint` pass
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-TLT9CR (critical — `_position` source=search gate
+bypass; fixed via `readableSubset`), RR-HPJYYX (significant — write⊆read
+invariant overstated; verified affordance grants never authorize writes,
+narrowed docs, added pinning test), RR-4KBP7W (significant — AllowAll silent
+truncation; `errListLoad` + `writeListPipelineError`), RR-BW2Y8J (minor — raw
+error echo in `acl_query_failed`; deferred to a cross-cutting 5xx-detail
+hardening follow-up, consistent with RR-89XK), RR-OBXBWL (nit — sidebar per-item
+recompute; documented, accepted). All fixes in commit 622b6cf7.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+| AC | Status | Evidence |
+|---|---|---|
+| AC1 type-level read grant on list | PASS | TestACLList_TypeLevelReadGrant + live curl |
+| AC2 role-relation + inheritance on list | PASS | TestACLList_RoleRelationInheritance + live curl (alice editor-of PRJ-42) |
+| AC3 eight pagination leak surfaces | PASS | TestACLList_PaginationLeakSurfaces (asserts "10" appears in no body/header) + live headers |
+| AC4 DenyAll shape + _actions.create=false | PASS | TestACLList_DenyAllShape + live bob curl |
+| AC5 DenyAll search short-circuit | PASS | TestACLList_DenyAllSearchShortCircuit (recording searcher, 0 calls) |
+| AC6 sidebar counts match list | PASS | TestACLSidebar_CountsMatchList (5 of 10) + live sidebar |
+| AC7 sidebar count under config filter | PASS | TestACLSidebar_ConfigFilterIntersection (visible∩open = 3) + live |
+| AC8 policy-load rejects write-without-read | PASS | TestLoadPolicy_WriteWithoutRead_Rejected (7 cases) + live boot failure |
+| AC9 search-after-ACL ordering | PASS | TestACLList_SearchAfterACLOrdering (order-recording store + searcher) |
+| AC10 per-principal caching headers | PASS | TestACLList_VaryHeader + live `Vary: X-Rela-User` |
+| AC11 NopACL regression | PASS | acl_list_regression_test.go + TestACLSidebar_NopACLFullCounts |
+| AC12 GUIDE-acl-security updated | PASS | read-path rewrite; docs/acl-security.md regenerated |
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-X1K2FE
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass — monitored after push; stacked PR, base feat/acl-readside-tkt-vqgn (#939)
+- [x] PR URL documented below
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/949

--- a/tickets/entities/review-responses/RR-4KBP7W.md
+++ b/tickets/entities/review-responses/RR-4KBP7W.md
@@ -1,0 +1,9 @@
+---
+id: RR-4KBP7W
+type: review-response
+title: 'AllowAll vs Query store-error asymmetry: silent truncation on the AllowAll list path'
+finding: scopedSortedEntities propagated mid-stream GraphQuery errors (Query path → 500) but the AllowAll branch used listFromStoreByTypes, which swallows iterator errors into a partial slice — under the same backend fault an AllowAll principal got a silently-truncated 200 with authoritative-looking pagination while a Query principal got a clean 500.
+severity: significant
+resolution: AllowAll branch now iterates Store.ListEntities inline and wraps mid-stream errors in the new errListLoad sentinel; both pipeline consumers (handleV1ListEntities, handleV1EntityPosition) route errors through the shared writeListPipelineError helper (errACLListQuery → writeGateError, errListLoad → 500 list_load_failed, else search_failed). Pinned by TestACLList_AllowAllLoadErrorSurfaces. listFromStoreByTypes itself is unchanged — its other consumers (views, commands, mentions) keep their historical degrade behavior. Commit 622b6cf7.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-BW2Y8J.md
+++ b/tickets/entities/review-responses/RR-BW2Y8J.md
@@ -4,6 +4,6 @@ type: review-response
 title: acl_query_failed response echoes raw backend error string
 finding: writeGateError passes err.Error() as the V1Error detail, which can surface store/pg internals (table names, occasionally connection details in driver errors) to the client. Mirrors the pre-existing search_failed path so not a regression, but the ACL path is a new disclosure surface.
 severity: minor
-reason: 'Deferred: writeGateError''s shape is TKT-VQGN (PR 1) surface, decided there under RR-89XK, and the identical err.Error()-as-detail convention is used by search_failed, list_load_failed, and other v1 error paths — sanitizing only the ACL branch would be inconsistent and incomplete. The right fix is a one-pass hardening ticket that logs details server-side and returns generic wire details across all v1 5xx paths; tracked as a follow-up to file when TKT-VMD8 lands. rela-server''s threat model (loopback-default, trusted-proxy deployments) keeps the immediate exposure low.'
-status: deferred
+resolution: 'Originally deferred, then upgraded to fix-now by the CISO IB review on PR 939 (finding #1, RR-A5QEUX on TKT-VQGN). writeGateError was hardened on the base branch (constant detail "check server logs" + slog.Warn with path/method); after rebasing this branch onto that fix, writeListPipelineError received the same treatment for its list_load_failed and search_failed branches. Tests assert the synthetic backend error strings are absent from response bodies (TestACLList_QueryErrorMapping, TestACLList_AllowAllLoadErrorSurfaces, TestACLGet_WriteGateErrorMapping with a pg-shaped error).'
+status: addressed
 ---

--- a/tickets/entities/review-responses/RR-BW2Y8J.md
+++ b/tickets/entities/review-responses/RR-BW2Y8J.md
@@ -1,0 +1,9 @@
+---
+id: RR-BW2Y8J
+type: review-response
+title: acl_query_failed response echoes raw backend error string
+finding: writeGateError passes err.Error() as the V1Error detail, which can surface store/pg internals (table names, occasionally connection details in driver errors) to the client. Mirrors the pre-existing search_failed path so not a regression, but the ACL path is a new disclosure surface.
+severity: minor
+reason: 'Deferred: writeGateError''s shape is TKT-VQGN (PR 1) surface, decided there under RR-89XK, and the identical err.Error()-as-detail convention is used by search_failed, list_load_failed, and other v1 error paths — sanitizing only the ACL branch would be inconsistent and incomplete. The right fix is a one-pass hardening ticket that logs details server-side and returns generic wire details across all v1 5xx paths; tracked as a follow-up to file when TKT-VMD8 lands. rela-server''s threat model (loopback-default, trusted-proxy deployments) keeps the immediate exposure low.'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-HPJYYX.md
+++ b/tickets/entities/review-responses/RR-HPJYYX.md
@@ -1,0 +1,9 @@
+---
+id: RR-HPJYYX
+type: review-response
+title: write⊆read validation ignores affordance-based grants — invariant overstated
+finding: 'Policy.Validate''s new write⊆read check iterates only role.Write; a role with fields:/options:/relations: grants for a type but no read grant passes validation, while the godoc and docs claimed downstream logic ''may assume writable ⇒ readable'' without qualification — over-trusting code could treat affordance-grant types as readable.'
+severity: significant
+resolution: 'Verified in code that affordance grants never confer write authorization: both authorizeEntityWrite and authorizeRelationWrite resolve through decideFromAttrs against role.Write only; fields/options/relations grants restrict surfaces WITHIN an already-authorized write, so an affordance-only role is inert, not incoherent. Narrowed the documented invariant accordingly (Validate godoc ''Scope:'' paragraph, GUIDE-acl-security, docs/security.md) and added the ''affordance-only role without read ok'' case to TestLoadPolicy_WriteWithoutRead_Rejected pinning that the pass is intentional. Commit 622b6cf7.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OBXBWL.md
+++ b/tickets/entities/review-responses/RR-OBXBWL.md
@@ -1,0 +1,9 @@
+---
+id: RR-OBXBWL
+type: review-response
+title: Sidebar re-resolves ReadQuery + GraphQuery per nav item without (type, filters) memo
+finding: Two sidebar lists over the same entity type with identical filters each recompute ReadQuery and run a full GraphQuery; filterCache keys on list/kanban id, not (type, filters). Missed reuse only — the request-scoped cache itself is correct per RR-BZ4M.
+severity: nit
+resolution: 'Documented in the countWithFilters godoc: per-nav-item recompute is accepted (the member-of walk is already memoized on the request-scoped acl.Request), and a (type, filters)-keyed memo is named as the obvious upgrade if sidebar latency ever warrants it. No code change — typical sidebars have a handful of nav items. Commit 622b6cf7.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-TLT9CR.md
+++ b/tickets/entities/review-responses/RR-TLT9CR.md
@@ -1,0 +1,9 @@
+---
+id: RR-TLT9CR
+type: review-response
+title: _position source=search bypasses the read gate — leaks hidden total + neighbor IDs/types
+finding: 'resolveScope''s source=search branch called executeQuery (ungated) directly: handleV1EntityPosition then served Total from the unfiltered set and shipped hidden {ID, Type} pairs in prev/next, letting a denied principal walk the hidden set neighbor-by-neighbor and read exact hidden cardinality — the precise leak shape TKT-VMD8 closes on the list path. Also made the docs claim (''_position shares the gated list pipeline'') false for search scopes.'
+severity: critical
+resolution: 'Added App.readableSubset (scope.go): filters the search result through the readGate before returning, batching PermitsReadMany per entity type (mirrors the TKT-VQGN include-filter batching rule); gate errors wrap errACLListQuery and route through writeGateError. Pinned by TestACLPosition_SearchScopeGated: hidden FEAT must not count in total, must not appear in prev/next, and a hidden id 404s out of the scope. GUIDE-acl-security updated to state both scope sources are gated. Commit 622b6cf7.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-VMD8.md
+++ b/tickets/entities/tickets/TKT-VMD8.md
@@ -5,7 +5,7 @@ title: 'ACL read-side (PR 2/2): list endpoints + sidebar counts + pagination hea
 kind: enhancement
 priority: medium
 effort: m
-status: ready
+status: done
 ---
 
 Second of a two-PR read-side ACL series. Builds on the per-entity gate landed in

--- a/tickets/relations/TKT-VMD8--has-docs--DOCS-X1K2FE.md
+++ b/tickets/relations/TKT-VMD8--has-docs--DOCS-X1K2FE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VMD8
+relation: has-docs
+to: DOCS-X1K2FE
+---

--- a/tickets/relations/TKT-VMD8--has-implementation--IMPL-TZHZOE.md
+++ b/tickets/relations/TKT-VMD8--has-implementation--IMPL-TZHZOE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VMD8
+relation: has-implementation
+to: IMPL-TZHZOE
+---

--- a/tickets/relations/TKT-VMD8--has-planning--PLAN-SQSTM7.md
+++ b/tickets/relations/TKT-VMD8--has-planning--PLAN-SQSTM7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VMD8
+relation: has-planning
+to: PLAN-SQSTM7
+---

--- a/tickets/relations/TKT-VMD8--has-review--REV-WZF7GI.md
+++ b/tickets/relations/TKT-VMD8--has-review--REV-WZF7GI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VMD8
+relation: has-review
+to: REV-WZF7GI
+---

--- a/tickets/relations/TKT-VMD8--has-review-response--RR-4KBP7W.md
+++ b/tickets/relations/TKT-VMD8--has-review-response--RR-4KBP7W.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VMD8
+relation: has-review-response
+to: RR-4KBP7W
+---

--- a/tickets/relations/TKT-VMD8--has-review-response--RR-BW2Y8J.md
+++ b/tickets/relations/TKT-VMD8--has-review-response--RR-BW2Y8J.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VMD8
+relation: has-review-response
+to: RR-BW2Y8J
+---

--- a/tickets/relations/TKT-VMD8--has-review-response--RR-HPJYYX.md
+++ b/tickets/relations/TKT-VMD8--has-review-response--RR-HPJYYX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VMD8
+relation: has-review-response
+to: RR-HPJYYX
+---

--- a/tickets/relations/TKT-VMD8--has-review-response--RR-OBXBWL.md
+++ b/tickets/relations/TKT-VMD8--has-review-response--RR-OBXBWL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VMD8
+relation: has-review-response
+to: RR-OBXBWL
+---

--- a/tickets/relations/TKT-VMD8--has-review-response--RR-TLT9CR.md
+++ b/tickets/relations/TKT-VMD8--has-review-response--RR-TLT9CR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VMD8
+relation: has-review-response
+to: RR-TLT9CR
+---


### PR DESCRIPTION
## Summary

PR 2/2 of the read-side ACL series (stacks on #939 / TKT-VQGN). Anything that enumerates entities of a type now returns only the visible subset, with no leak surface revealing hidden cardinality.

- **List pipeline gated** (`scopedSortedEntities`, shared by lists and `_position`): read scope resolves first — DenyAll short-circuits to empty *before* the search backend runs (timing side-channel, RR-X56H); composed-Query scopes load via `store.GraphQuery` and search/filter/sort operate on the filtered slice (search-after-ACL contract, RR-WX77/RR-3IO2); AllowAll keeps the pre-ACL path byte-identical.
- **All pagination surfaces** (`meta.*`, `X-Total-Count`, `X-Page`, `X-Per-Page`, `Link` rels) derive from the post-filter total; `rel="next"` absent when no *visible* next page exists (RR-KNGC/RR-VDTW).
- **Sidebar single-mode collapse** (RR-2O27/RR-BZ4M): dropped the `typeCounts` precompute; `listCount`/`kanbanCount` always go through the gate (`GraphCount` unfiltered, GraphQuery + `applyFilters` with config filters). Ordering: ACL → config filter → count.
- **Policy invariant** (RR-W2J6): loader rejects roles granting write on a type without a covering read grant (wildcard-aware, structured error). Downstream may assume "write-listed ⇒ readable"; affordance grants are documented out of scope (they never authorize writes).
- **Per-principal caching** (RR-VDTW): `Vary: <principal header>` on `/api/` when `--principal-header` is set, on top of the existing `no-store`.
- **Review round 1 fixes**: `_position` `source=search` now filters through the read gate (was a full bypass leaking hidden totals + neighbor IDs — CRIT); AllowAll list path surfaces mid-stream store errors as 500 `list_load_failed` instead of silently truncating.
- Docs: `GUIDE-acl-security` read-path rewrite covering both PRs; `docs/acl-security.md` regenerated; `docs/security.md` updated.

Deferred (follow-up tickets named in TKT-VMD8): `_position` per-id semantics, `/_search` filtering, SSE per-subscriber visibility.

## Test plan

- 12 ACs from TKT-VMD8 covered by `acl_list_test.go`, `acl_sidebar_test.go`, `acl_list_regression_test.go`, `policy_test.go` (incl. mock-asserted DenyAll search short-circuit and GraphQuery-before-search ordering).
- NopACL regressions pin the unchanged wire shape without `acl.yaml`.
- Manually verified end-to-end against a live `rela-server` with role-relation + containment inheritance (evidence in IMPL-TZHZOE).