### PR TITLE
fix(entitymanager): audit durable entity write before cascade

### DIFF
--- a/internal/entitymanager/audit_durability_test.go
+++ b/internal/entitymanager/audit_durability_test.go
@@ -1,0 +1,130 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/autocascade"
+	"github.com/Sourcehaven-BV/rela/internal/automation"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// failingUpdateStore wraps a store and forces every UpdateEntity call to
+// return a sentinel error. The initial CreateEntity still lands, so this
+// models a transient write failure on the post-automation re-write: the
+// entity is durably on disk but the second persist fails.
+type failingUpdateStore struct {
+	store.Store
+	err error
+}
+
+func (s *failingUpdateStore) UpdateEntity(_ context.Context, _ *entity.Entity) error {
+	return s.err
+}
+
+func newManagerWithStoreAndAudit(
+	t *testing.T, st store.Store, sink audit.Audit, automations []automation.Automation,
+) *entitymanager.Manager {
+	t.Helper()
+	deps := entitymanager.Deps{
+		Store:     st,
+		Meta:      parseMeta(t),
+		Templater: nopTemplater{},
+		Audit:     sink,
+		ACL:       acl.NopACL{},
+	}
+	if automations != nil {
+		engine := automation.NewEngine(automations)
+		runner, err := autocascade.New(autocascade.Deps{Engine: engine})
+		if err != nil {
+			t.Fatalf("autocascade.New: %v", err)
+		}
+		deps.Automations = engine
+		deps.Cascade = runner
+	}
+	mgr, err := entitymanager.New(deps)
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	return mgr
+}
+
+// TestCreate_AuditsDurableWriteWhenPostAutomationUpsertFails pins that
+// the audit record reflects the entity createCore durably persisted,
+// even when the post-automation re-write fails. Previously the audit was
+// recorded only after the cascade, so a failure in the second persist
+// returned an error and left the on-disk entity unaudited.
+func TestCreate_AuditsDurableWriteWhenPostAutomationUpsertFails(t *testing.T) {
+	sentinel := errors.New("boom: transient write failure")
+	st := &failingUpdateStore{Store: memstore.New(), err: sentinel}
+	mem := audit.NewMemory()
+
+	// An automation that sets a property forces the second persist
+	// (Create→conflict→Update), which this store fails.
+	auto := automation.Automation{
+		Name: "set-status-on-create",
+		On:   automation.Trigger{Entity: []string{"requirement"}, Created: true},
+		Do:   []automation.Action{{Set: "status", Value: "proposed"}},
+	}
+	mgr := newManagerWithStoreAndAudit(t, st, mem, []automation.Automation{auto})
+
+	e := entity.New("", "requirement")
+	e.SetString("title", "durable but second-write fails")
+	_, err := mgr.CreateEntity(context.Background(), e, entity.CreateOptions{})
+	if err == nil {
+		t.Fatal("expected the post-automation write failure to surface as an error")
+	}
+
+	records := mem.Records()
+	if len(records) != 1 {
+		t.Fatalf("want exactly 1 audit record for the durable create, got %d", len(records))
+	}
+	if records[0].Op != audit.OpCreateEntity {
+		t.Errorf("Op = %q, want %q", records[0].Op, audit.OpCreateEntity)
+	}
+	if records[0].Subject == nil || records[0].Subject.Type != "requirement" {
+		t.Errorf("Subject = %+v, want an entity subject of type requirement", records[0].Subject)
+	}
+}
+
+// TestUpdate_AuditsBeforeCascade pins that the update audit record is
+// emitted once the entity is persisted, on the cascade-enabled path —
+// the record must not be gated on cascade success.
+func TestUpdate_AuditsBeforeCascade(t *testing.T) {
+	mem := audit.NewMemory()
+	auto := automation.Automation{
+		Name: "noop-on-title-change",
+		On:   automation.Trigger{Entity: []string{"requirement"}, Property: "title"},
+		Do:   []automation.Action{{Set: "status", Value: "accepted"}},
+	}
+	mgr := newManagerWithAudit(t, mem, []automation.Automation{auto})
+
+	e := entity.New("", "requirement")
+	e.SetString("title", "to be updated")
+	created, err := mgr.CreateEntity(context.Background(), e, entity.CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	updated := created.Entity
+	updated.SetString("title", "updated title")
+	if _, err := mgr.UpdateEntity(context.Background(), updated); err != nil {
+		t.Fatalf("UpdateEntity: %v", err)
+	}
+
+	var updates int
+	for _, r := range mem.Records() {
+		if r.Op == audit.OpUpdateEntity {
+			updates++
+		}
+	}
+	if updates != 1 {
+		t.Fatalf("want exactly 1 update-entity audit record, got %d", updates)
+	}
+}

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -276,9 +276,16 @@ func (m *Manager) CreateEntity(
 
 	result := &entity.CreateResult{Entity: created, Warnings: warnings}
 
+	// Audit the durable write now, before automation re-writes or the
+	// cascade run. createCore has already persisted the entity; if a
+	// later step fails (the post-automation upsert, or a cascade that
+	// hard-errors) the entity is still on disk, so the audit log must
+	// already reflect it. Recording after the cascade left a window
+	// where a committed write produced no audit record.
+	m.recordEntityAudit(ctx, audit.OpCreateEntity, created, "created")
+
 	runAutomation := m.deps.Automations != nil && !opts.SkipAutomation
 	if !runAutomation {
-		m.recordEntityAudit(ctx, audit.OpCreateEntity, created, "created")
 		return result, nil
 	}
 
@@ -318,7 +325,6 @@ func (m *Manager) CreateEntity(
 	result.AutomationErrors = append(result.AutomationErrors, outcome.Errors...)
 	result.AutomationWarnings = append(result.AutomationWarnings, outcome.Warnings...)
 
-	m.recordEntityAudit(ctx, audit.OpCreateEntity, created, "created")
 	return result, nil
 }
 
@@ -426,10 +432,12 @@ func (m *Manager) UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.U
 		return nil, fmt.Errorf("write entity: %w", err)
 	}
 
-	updateSummary := updateEntitySummary(oldEntity, e)
+	// Audit the durable write now, before the cascade run. The entity
+	// is already persisted; gating the audit on cascade success left a
+	// window where a committed write produced no audit record.
+	m.recordEntityAudit(ctx, audit.OpUpdateEntity, e, updateEntitySummary(oldEntity, e))
 
 	if !runAutomation {
-		m.recordEntityAudit(ctx, audit.OpUpdateEntity, e, updateSummary)
 		return result, nil
 	}
 
@@ -448,7 +456,6 @@ func (m *Manager) UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.U
 	result.AutomationErrors = append(result.AutomationErrors, outcome.Errors...)
 	result.AutomationWarnings = append(result.AutomationWarnings, outcome.Warnings...)
 
-	m.recordEntityAudit(ctx, audit.OpUpdateEntity, e, updateSummary)
 	return result, nil
 }
 

--- a/tickets/entities/automated-measures/audit-durable-write-before-cascade-test.md
+++ b/tickets/entities/automated-measures/audit-durable-write-before-cascade-test.md
@@ -1,0 +1,9 @@
+---
+id: audit-durable-write-before-cascade-test
+type: automated-measure
+title: 'Test: entity audit reflects durable write even when cascade/upsert fails'
+description: 'Regression for BUG-WXFZO6: a failingUpdateStore forces the post-automation re-write to error after the initial durable create; the test asserts exactly one create-entity audit record is still emitted. Fails if recordEntityAudit is moved back after Cascade.Process.'
+kind: test
+location: internal/entitymanager/audit_durability_test.go (TestCreate_AuditsDurableWriteWhenPostAutomationUpsertFails, TestUpdate_AuditsBeforeCascade)
+status: active
+---

--- a/tickets/entities/bugs/BUG-WXFZO6.md
+++ b/tickets/entities/bugs/BUG-WXFZO6.md
@@ -1,0 +1,37 @@
+---
+id: BUG-WXFZO6
+type: bug
+title: Entity audit record skipped when post-write step (cascade/upsert) fails
+description: Manager.CreateEntity and UpdateEntity recorded the entity audit row only after the automation cascade ran. A failure between the durable store write and that point — a failed post-automation re-write (reachable via any transient store error) or a cascade hard-error (latent) — left a committed on-disk entity with no audit record, breaking the 'every successful write is audited' invariant.
+priority: medium
+why1: recordEntityAudit was called after Cascade.Process and after the post-automation upsert, so an error in either returned early before the audit was written.
+why2: The audit call was placed at the end of the happy path during the workspace-decomposition refactor, treating audit as a final step rather than a consequence of the durable write.
+why3: Audit-ordering relative to the persisting write was never pinned by a test; existing audit tests only exercised the success path where ordering is invisible.
+why4: The audit log's 'every successful write is audited' invariant was documented as a rule but had no failure-path regression guarding it.
+why5: Write-path side effects (audit, events) that must be tied to durability have no structural pattern forcing them to be emitted at the persistence point rather than at function end.
+prevention: Audit is now recorded immediately after the persisting store write succeeds, before any automation re-write or cascade. A regression test (failingUpdateStore) forces the post-automation re-write to fail and asserts the durable create is still audited; the test fails without the fix.
+status: done
+---
+
+## Bug
+
+Found in the 2026-06-09 backend review (write-path theme B1).
+
+`Manager.CreateEntity` (`manager.go:306-322`) and `Manager.UpdateEntity`
+(`:436-452`) recorded the entity audit row only *after* `Cascade.Process`. Two
+failure windows left a durable, committed write unaudited:
+
+- **Reachable:** on create, `createCore` persists the entity, then automation that sets a property triggers a second `upsertEntity`. If that second write hits a transient store error, the call returns an error while the entity is already on disk — and the audit row was never written.
+- **Latent:** if the cascade ever grows a hard-error return (today `autocascade.Runner.Process` only hard-errors on a nil trigger, which the Manager never passes), the same gap appears for both create and update.
+
+## Fix (PR pending)
+
+Record `recordEntityAudit` immediately after the persisting write succeeds,
+before the automation re-write / cascade. Audit rows carry no property values,
+so recording before the post-automation rewrite loses nothing. The two later
+audit calls are removed.
+
+Regression test `TestCreate_AuditsDurableWriteWhenPostAutomationUpsertFails`
+uses a `failingUpdateStore` to fail the second persist and asserts the create is
+still audited (fails without the fix); `TestUpdate_AuditsBeforeCascade` pins the
+update path on the cascade-enabled branch.

--- a/tickets/relations/BUG-WXFZO6--adds-measure--audit-durable-write-before-cascade-test.md
+++ b/tickets/relations/BUG-WXFZO6--adds-measure--audit-durable-write-before-cascade-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-WXFZO6
+relation: adds-measure
+to: audit-durable-write-before-cascade-test
+---

--- a/tickets/relations/BUG-WXFZO6--affects--audit-log.md
+++ b/tickets/relations/BUG-WXFZO6--affects--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: BUG-WXFZO6
+relation: affects
+to: audit-log
+---

--- a/tickets/relations/BUG-WXFZO6--fixes--FEAT-831A.md
+++ b/tickets/relations/BUG-WXFZO6--fixes--FEAT-831A.md
@@ -1,0 +1,5 @@
+---
+from: BUG-WXFZO6
+relation: fixes
+to: FEAT-831A
+---

--- a/tickets/relations/audit-durable-write-before-cascade-test--protects--audit-log.md
+++ b/tickets/relations/audit-durable-write-before-cascade-test--protects--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: audit-durable-write-before-cascade-test
+relation: protects
+to: audit-log
+---


### PR DESCRIPTION
## Summary

Fixes write-path finding B1 from the backend review (BUG-WXFZO6): `Manager.CreateEntity` and `UpdateEntity` recorded the entity audit row only *after* the automation cascade, so a failure between the durable store write and that point left a committed on-disk entity with no audit record — breaking the "every successful write is audited" invariant.

- **Reachable case:** on create, `createCore` persists the entity, then automation that sets a property triggers a second `upsertEntity`. A transient error on that second write returned early, leaving the already-durable entity unaudited.
- **Latent case:** if the cascade ever grows a hard-error return (today `autocascade.Runner.Process` only hard-errors on a nil trigger, which the Manager never passes), the same gap would appear for both create and update.

## Fix

Record `recordEntityAudit` immediately after the persisting store write succeeds, before the automation re-write / cascade run. Audit rows carry no property values, so recording before the post-automation rewrite loses nothing. The two later audit calls are removed.

## Tests

- `TestCreate_AuditsDurableWriteWhenPostAutomationUpsertFails` — a `failingUpdateStore` forces the post-automation re-write to error after the durable create; asserts exactly one `create-entity` audit record still lands. Verified it **fails without the fix** (0 records).
- `TestUpdate_AuditsBeforeCascade` — pins the update path on the cascade-enabled branch.

`go test ./...` (entitymanager + downstream write-path consumers), `golangci-lint`, and `just arch-lint` all pass.