### PR TITLE
fix(entitymanager): fail closed when rename ACL pre-fetch errors

### DIFF
--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -524,17 +524,26 @@ func (m *Manager) DeleteEntity(ctx context.Context, id string, cascade bool) (*e
 func (m *Manager) RenameEntity(
 	ctx context.Context, oldID, newID string, opts entity.RenameOptions,
 ) (*entity.RenameResult, error) {
-	// ACL needs the entity type, so we fetch first. If the entity
-	// doesn't exist, renameEntity below returns the same error with
-	// a clearer message; we only consult the ACL when there's an
-	// entity to authorize against.
-	if current, err := m.deps.Store.GetEntity(ctx, oldID); err == nil {
+	// ACL needs the entity type, so we fetch first. Distinguish the two
+	// failure modes:
+	//   - not-found: skip ACL and fall through; renameEntity below
+	//     returns ErrEntityNotFound with a clearer message, and there is
+	//     nothing to authorize against.
+	//   - any other error (transient I/O, backend hiccup): fail closed.
+	//     Proceeding would run the rename with NO authorization at all —
+	//     a store read that flakes must not turn an ACL-gated operation
+	//     into an ungated one.
+	current, getErr := m.deps.Store.GetEntity(ctx, oldID)
+	switch {
+	case getErr == nil:
 		if aclErr := m.authorizeAndAudit(ctx, acl.WriteRequest{
 			Op:      acl.OpRename,
 			Subject: acl.EntitySubject{Type: current.Type, ID: oldID},
 		}); aclErr != nil {
 			return nil, aclErr
 		}
+	case !errors.Is(getErr, store.ErrNotFound):
+		return nil, fmt.Errorf("rename: load entity %q: %w", oldID, getErr)
 	}
 	res, err := renameEntity(ctx, m.deps.Store, oldID, newID, opts)
 	if err != nil || opts.DryRun {

--- a/internal/entitymanager/rename_acl_test.go
+++ b/internal/entitymanager/rename_acl_test.go
@@ -1,0 +1,86 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// flakyGetStore returns a non-not-found error from GetEntity and counts
+// mutating store calls, so a test can assert that a rename gated behind
+// a failed pre-fetch never reaches the actual rename writes.
+type flakyGetStore struct {
+	store.Store
+	err     error
+	deletes atomic.Int32
+	creates atomic.Int32
+}
+
+func (s *flakyGetStore) GetEntity(_ context.Context, _ string) (*entity.Entity, error) {
+	return nil, s.err
+}
+
+func (s *flakyGetStore) DeleteEntity(ctx context.Context, id string, cascade bool) (*store.DeleteResult, error) {
+	s.deletes.Add(1)
+	return s.Store.DeleteEntity(ctx, id, cascade)
+}
+
+func (s *flakyGetStore) CreateEntity(ctx context.Context, e *entity.Entity) error {
+	s.creates.Add(1)
+	return s.Store.CreateEntity(ctx, e)
+}
+
+// TestRename_FailsClosedOnNonNotFoundFetchError pins that a transient
+// GetEntity error during RenameEntity's ACL pre-fetch fails closed: the
+// error surfaces and the rename never runs. Previously the ACL block was
+// gated on `err == nil`, so any non-not-found error skipped authorization
+// entirely and proceeded to rename — a store hiccup turned an ACL-gated
+// operation into an ungated one.
+func TestRename_FailsClosedOnNonNotFoundFetchError(t *testing.T) {
+	sentinel := errors.New("boom: transient backend error")
+	st := &flakyGetStore{Store: memstore.New(), err: sentinel}
+
+	// Deny-all ACL: if the gate were skipped (the bug), the rename would
+	// proceed without ever consulting the ACL. With the fix the fetch
+	// error short-circuits before either the ACL or the rename run.
+	deps := entitymanager.Deps{
+		Store:     st,
+		Meta:      parseMeta(t),
+		Templater: nopTemplater{},
+		Audit:     audit.Nop{},
+		ACL:       acl.ReadOnlyACL{},
+	}
+	mgr, err := entitymanager.New(deps)
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+
+	_, err = mgr.RenameEntity(context.Background(), "REQ-1", "REQ-2", entity.RenameOptions{})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected the underlying fetch error to surface, got %v", err)
+	}
+	if got := st.deletes.Load() + st.creates.Load(); got != 0 {
+		t.Errorf("rename mutated the store despite a failed pre-fetch: %d write calls", got)
+	}
+}
+
+// TestRename_NotFoundStillReturnsTypedError pins that a genuine
+// not-found during the pre-fetch still falls through to renameEntity's
+// ErrEntityNotFound — the fail-closed change must not break the
+// not-found path.
+func TestRename_NotFoundStillReturnsTypedError(t *testing.T) {
+	mgr := newManagerWithAudit(t, audit.Nop{}, nil)
+
+	_, err := mgr.RenameEntity(context.Background(), "REQ-MISSING", "REQ-NEW", entity.RenameOptions{})
+	if !errors.Is(err, entitymanager.ErrEntityNotFound) {
+		t.Fatalf("expected ErrEntityNotFound, got %v", err)
+	}
+}

--- a/tickets/entities/automated-measures/rename-acl-fail-closed-test.md
+++ b/tickets/entities/automated-measures/rename-acl-fail-closed-test.md
@@ -1,0 +1,9 @@
+---
+id: rename-acl-fail-closed-test
+type: automated-measure
+title: 'Test: RenameEntity fails closed when ACL pre-fetch errors'
+description: 'Regression for BUG-RIM0CT: a flakyGetStore returns a non-not-found error from GetEntity under a deny-all ACL; the test asserts RenameEntity surfaces the error and performs zero store writes (no ACL bypass). A companion test pins that a genuine not-found still returns ErrEntityNotFound. Fails if the rename pre-fetch reverts to skipping ACL on any non-nil error.'
+kind: test
+location: internal/entitymanager/rename_acl_test.go (TestRename_FailsClosedOnNonNotFoundFetchError, TestRename_NotFoundStillReturnsTypedError)
+status: active
+---

--- a/tickets/entities/bugs/BUG-RIM0CT.md
+++ b/tickets/entities/bugs/BUG-RIM0CT.md
@@ -1,0 +1,48 @@
+---
+id: BUG-RIM0CT
+type: bug
+title: RenameEntity skips ACL when the pre-fetch returns a non-not-found error
+description: Manager.RenameEntity nested its ACL check inside `if current, err := Store.GetEntity(oldID); err == nil`. Any GetEntity error other than not-found (transient I/O, backend hiccup) skipped authorization entirely and proceeded to rename — fail-open on an authorization gate. A flaky store read could turn an ACL-gated rename into an ungated one.
+priority: high
+why1: The ACL block was guarded by `err == nil`, so every non-nil GetEntity error — not just not-found — fell through to the unauthorized rename.
+why2: The guard's comment assumed the only failure mode worth handling was not-found ('only consult ACL when there's an entity to authorize against'), conflating 'no entity' with 'fetch failed'.
+why3: GetEntity's error contract (returns store.ErrNotFound for missing, other errors for I/O/backend failures) was not distinguished at this call site.
+why4: Authorization gates had no established fail-closed convention for collaborator errors; the default fell through to the action.
+why5: Fail-open vs fail-closed for a flaky dependency on an authz path is a security-critical default that no lint or review checklist enforces.
+prevention: 'The pre-fetch now classifies the error: skip ACL only on errors.Is(err, store.ErrNotFound); fail closed (return the wrapped error, no rename) on any other error. A regression test (flakyGetStore returning a non-not-found error under a deny-all ACL) asserts the error surfaces and zero store writes happen; it fails without the fix.'
+status: done
+---
+
+## Bug
+
+Found in the 2026-06-09 backend review (write-path theme A2 — ACL enforcement
+consistency).
+
+`Manager.RenameEntity` (`manager.go:531-538`):
+
+```go
+if current, err := m.deps.Store.GetEntity(ctx, oldID); err == nil {
+    // ... ACL check ...
+}
+res, err := renameEntity(...)  // runs regardless
+```
+
+The ACL check is inside `err == nil`. `GetEntity` returns `store.ErrNotFound`
+for a missing entity but *other* errors for transient I/O or backend failures.
+On any non-not-found error the ACL block is skipped and `renameEntity` runs with
+**no authorization** — fail-open on an authz gate.
+
+## Fix (PR pending)
+
+Classify the fetch error:
+
+- `err == nil` → run the ACL check as before.
+- `errors.Is(err, store.ErrNotFound)` → skip ACL, fall through (renameEntity returns `ErrEntityNotFound`; nothing to authorize).
+- any other error → fail closed, return the wrapped error without renaming.
+
+Regression test `TestRename_FailsClosedOnNonNotFoundFetchError` uses a
+`flakyGetStore` returning a non-not-found error under a deny-all ACL: asserts
+the underlying error surfaces and zero store writes occur. Verified it fails
+without the fix (the masked error became `entity not found` from rename's own
+second fetch, proving the rename ran).
+`TestRename_NotFoundStillReturnsTypedError` pins the not-found path.

--- a/tickets/relations/BUG-RIM0CT--adds-measure--rename-acl-fail-closed-test.md
+++ b/tickets/relations/BUG-RIM0CT--adds-measure--rename-acl-fail-closed-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-RIM0CT
+relation: adds-measure
+to: rename-acl-fail-closed-test
+---

--- a/tickets/relations/BUG-RIM0CT--affects--authorization.md
+++ b/tickets/relations/BUG-RIM0CT--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: BUG-RIM0CT
+relation: affects
+to: authorization
+---

--- a/tickets/relations/BUG-RIM0CT--fixes--FEAT-AESD4.md
+++ b/tickets/relations/BUG-RIM0CT--fixes--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: BUG-RIM0CT
+relation: fixes
+to: FEAT-AESD4
+---

--- a/tickets/relations/rename-acl-fail-closed-test--protects--authorization.md
+++ b/tickets/relations/rename-acl-fail-closed-test--protects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: rename-acl-fail-closed-test
+relation: protects
+to: authorization
+---


### PR DESCRIPTION
## Summary

Fixes write-path finding A2 from the backend review (BUG-RIM0CT). `Manager.RenameEntity` nested its ACL check inside `if current, err := Store.GetEntity(oldID); err == nil`. `GetEntity` returns `store.ErrNotFound` for a missing entity but other errors for transient I/O / backend failures — and on any non-not-found error the ACL block was skipped and the rename proceeded with **no authorization**. A flaky store read turned an ACL-gated rename into an ungated one (fail-open on an authz gate).

## Fix

Classify the fetch error:

- `err == nil` → run the ACL check as before.
- `errors.Is(err, store.ErrNotFound)` → skip ACL, fall through (`renameEntity` returns `ErrEntityNotFound`; nothing to authorize).
- any other error → **fail closed**: return the wrapped error without renaming.

## Tests

- `TestRename_FailsClosedOnNonNotFoundFetchError` — a `flakyGetStore` returns a non-not-found error from `GetEntity` under a deny-all ACL; asserts the underlying error surfaces and zero store writes occur. Verified it **fails without the fix** (the masked error became `entity not found` from rename's own second fetch, proving the rename ran past the ungated gate).
- `TestRename_NotFoundStillReturnsTypedError` — pins that a genuine not-found still returns `ErrEntityNotFound`.

`go test ./...` (entitymanager + downstream), `golangci-lint`, and `just arch-lint` all pass.