### PR TITLE
fix(entitymanager): fail on iterator errors in ID-gen and delete-safety scans

### DIFF
--- a/internal/entitymanager/cascadehost.go
+++ b/internal/entitymanager/cascadehost.go
@@ -113,8 +113,14 @@ func (h *cascadeHost) DeleteEntity(ctx context.Context, _, id string, cascade bo
 		return fmt.Errorf("%w: %s", ErrEntityNotFound, id)
 	}
 
-	incoming := collectIncidentRelations(ctx, h.deps.Store, id, store.DirectionIncoming)
-	outgoing := collectIncidentRelations(ctx, h.deps.Store, id, store.DirectionOutgoing)
+	incoming, err := collectIncidentRelations(ctx, h.deps.Store, id, store.DirectionIncoming)
+	if err != nil {
+		return fmt.Errorf("collect incoming relations for %q: %w", id, err)
+	}
+	outgoing, err := collectIncidentRelations(ctx, h.deps.Store, id, store.DirectionOutgoing)
+	if err != nil {
+		return fmt.Errorf("collect outgoing relations for %q: %w", id, err)
+	}
 	if (len(incoming)+len(outgoing)) > 0 && !cascade {
 		return ErrHasRelations
 	}

--- a/internal/entitymanager/collect_errors_test.go
+++ b/internal/entitymanager/collect_errors_test.go
@@ -1,0 +1,111 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// listEntitiesErrStore yields the wrapped store's entities, then a
+// terminal error — modeling a scan that fails partway through. ID
+// generation must not run on this partial list.
+type listEntitiesErrStore struct {
+	store.Store
+	err error
+}
+
+func (s *listEntitiesErrStore) ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error] {
+	inner := s.Store.ListEntities(ctx, q)
+	return func(yield func(*entity.Entity, error) bool) {
+		for e, err := range inner {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !yield(e, nil) {
+				return
+			}
+		}
+		yield(nil, s.err)
+	}
+}
+
+// listRelationsErrStore yields a terminal error from ListRelations,
+// modeling a relation scan that fails before the full incident set is
+// counted. The delete-safety gate must not run on partial data.
+type listRelationsErrStore struct {
+	store.Store
+	err error
+}
+
+func (s *listRelationsErrStore) ListRelations(_ context.Context, _ store.RelationQuery) iter.Seq2[*entity.Relation, error] {
+	return func(yield func(*entity.Relation, error) bool) {
+		yield(nil, s.err)
+	}
+}
+
+func newManagerOver(t *testing.T, st store.Store) *entitymanager.Manager {
+	t.Helper()
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:     st,
+		Meta:      parseMeta(t),
+		Templater: nopTemplater{},
+		Audit:     audit.Nop{},
+		ACL:       acl.NopACL{},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	return mgr
+}
+
+// TestCreate_FailsWhenIDScanErrors pins that auto-ID create surfaces an
+// entity-scan error instead of generating an ID from a partial list. A
+// truncated scan can hide a high-numbered existing ID, so generating
+// from it risks a collision that upsertEntity would turn into an
+// overwrite of the existing entity.
+func TestCreate_FailsWhenIDScanErrors(t *testing.T) {
+	sentinel := errors.New("boom: entity scan failed mid-stream")
+	st := &listEntitiesErrStore{Store: memstore.New(), err: sentinel}
+	mgr := newManagerOver(t, st)
+
+	e := entity.New("", "requirement") // auto-ID path → triggers collectAllIDs
+	e.SetString("title", "needs an id")
+	_, err := mgr.CreateEntity(context.Background(), e, entity.CreateOptions{})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected the entity-scan error to surface, got %v", err)
+	}
+}
+
+// TestDelete_FailsWhenRelationScanErrors pins that DeleteEntity refuses
+// to proceed when the incident-relation scan errors, rather than
+// under-counting and deleting an entity that may still have relations
+// (the orphan class issue #888 closed at the deletion step).
+func TestDelete_FailsWhenRelationScanErrors(t *testing.T) {
+	sentinel := errors.New("boom: relation scan failed")
+
+	// Seed the entity in the underlying store so the GetEntity lookup
+	// and ACL check pass; the relation scan is what fails.
+	mem := memstore.New()
+	target := entity.New("REQ-1", "requirement")
+	target.SetString("title", "has relations on disk")
+	if err := mem.CreateEntity(context.Background(), target); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	st := &listRelationsErrStore{Store: mem, err: sentinel}
+	mgr := newManagerOver(t, st)
+
+	_, err := mgr.DeleteEntity(context.Background(), "REQ-1", false)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected the relation-scan error to surface, got %v", err)
+	}
+}

--- a/internal/entitymanager/core.go
+++ b/internal/entitymanager/core.go
@@ -179,7 +179,10 @@ func generateID(ctx context.Context, deps Deps, entityType, prefix string) (stri
 		prefix = prefixes[0]
 	}
 
-	existingIDs := collectAllIDs(ctx, deps.Store)
+	existingIDs, err := collectAllIDs(ctx, deps.Store)
+	if err != nil {
+		return "", fmt.Errorf("collect existing IDs: %w", err)
+	}
 	if entityDef.IsShortID() {
 		return entity.GenerateShortID(existingIDs, prefix, len(existingIDs), entityDef.GetIDCaps()), nil
 	}
@@ -187,36 +190,40 @@ func generateID(ctx context.Context, deps Deps, entityType, prefix string) (stri
 }
 
 // collectAllIDs returns every entity ID currently in the store.
-// Errors from the iterator are swallowed — a partial result is
-// preferable to failing ID generation outright.
-func collectAllIDs(ctx context.Context, st store.Store) []string {
+// A partial scan must not feed ID generation: a truncated list can hide
+// a high-numbered existing ID, so the generator would mint one that
+// already exists and (via upsertEntity's create-then-update fallback)
+// overwrite that entity. Fail loudly instead.
+func collectAllIDs(ctx context.Context, st store.Store) ([]string, error) {
 	ids := make([]string, 0)
 	for e, err := range st.ListEntities(ctx, store.EntityQuery{}) {
 		if err != nil {
-			return ids
+			return nil, err
 		}
 		ids = append(ids, e.ID)
 	}
-	return ids
+	return ids, nil
 }
 
 // collectIncidentRelations gathers a store's relations in the given
-// direction for the given entity. Errors from the iterator are
-// swallowed — partial results are preferable to a failing cascade.
+// direction for the given entity. The result gates the delete-safety
+// check (refuse a non-cascade delete that would orphan relations), so a
+// partial scan must not silently under-count — propagate the error and
+// let the caller refuse the delete rather than proceed on partial data.
 func collectIncidentRelations(
 	ctx context.Context, st store.Store, id string, dir store.Direction,
-) []*entity.Relation {
+) ([]*entity.Relation, error) {
 	out := make([]*entity.Relation, 0)
 	for r, err := range st.ListRelations(ctx, store.RelationQuery{
 		EntityID:  id,
 		Direction: dir,
 	}) {
 		if err != nil {
-			continue
+			return nil, err
 		}
 		out = append(out, r)
 	}
-	return out
+	return out, nil
 }
 
 // findExistingRelationTarget locates an existing target entity of the

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -471,8 +471,14 @@ func (m *Manager) DeleteEntity(ctx context.Context, id string, cascade bool) (*e
 		return nil, aclErr
 	}
 
-	incoming := collectIncidentRelations(ctx, m.deps.Store, id, store.DirectionIncoming)
-	outgoing := collectIncidentRelations(ctx, m.deps.Store, id, store.DirectionOutgoing)
+	incoming, err := collectIncidentRelations(ctx, m.deps.Store, id, store.DirectionIncoming)
+	if err != nil {
+		return nil, fmt.Errorf("collect incoming relations for %q: %w", id, err)
+	}
+	outgoing, err := collectIncidentRelations(ctx, m.deps.Store, id, store.DirectionOutgoing)
+	if err != nil {
+		return nil, fmt.Errorf("collect outgoing relations for %q: %w", id, err)
+	}
 	totalRelations := len(incoming) + len(outgoing)
 
 	if totalRelations > 0 && !cascade {

--- a/tickets/entities/automated-measures/collect-iterator-errors-test.md
+++ b/tickets/entities/automated-measures/collect-iterator-errors-test.md
@@ -1,0 +1,9 @@
+---
+id: collect-iterator-errors-test
+type: automated-measure
+title: 'Test: ID-gen and delete-safety scans fail on iterator errors'
+description: 'Regression for BUG-R8ELTO: store stubs inject a terminal error into the ListEntities / ListRelations iterators. The tests assert auto-ID CreateEntity surfaces the entity-scan error (instead of minting a possibly-colliding ID) and DeleteEntity surfaces the relation-scan error (instead of under-counting the delete-safety gate). Both fail if collectAllIDs / collectIncidentRelations revert to swallowing iterator errors.'
+kind: test
+location: internal/entitymanager/collect_errors_test.go (TestCreate_FailsWhenIDScanErrors, TestDelete_FailsWhenRelationScanErrors)
+status: active
+---

--- a/tickets/entities/bugs/BUG-R8ELTO.md
+++ b/tickets/entities/bugs/BUG-R8ELTO.md
@@ -1,0 +1,39 @@
+---
+id: BUG-R8ELTO
+type: bug
+title: ID generation and delete-safety gate run on partial store-scan data
+description: 'collectAllIDs and collectIncidentRelations in entitymanager swallowed iterator errors and returned partial slices. A truncated entity scan let GenerateNextID/GenerateShortID mint an already-existing ID, which upsertEntity''s create-then-update fallback then overwrote. A truncated relation scan let DeleteEntity''s ''has relations?'' gate under-count, allowing a non-cascade delete to orphan relations (the class issue #888 closed at the deletion step, reintroduced at the counting step).'
+priority: high
+why1: collectAllIDs returned `ids` on iterator error and collectIncidentRelations `continue`d past per-item errors, so both fed safety-critical decisions from silently-incomplete data.
+why2: The helpers were written to prefer a partial result over a failure, treating ID generation and the delete gate as best-effort when they are integrity-critical.
+why3: The cost of partial data (ID collision/overwrite; orphaned relations) was not weighed against the cost of a hard error when the helpers were written.
+why4: Iterator error handling had no convention distinguishing best-effort reads (dedup lookups) from integrity-critical reads (ID allocation, delete gates).
+why5: Range-over-func iterators make it easy to drop the error leg silently; nothing flags a swallowed iterator error on a path whose result gates a write.
+prevention: collectAllIDs and collectIncidentRelations now return ([]T, error) and propagate iterator errors; generateID and both DeleteEntity callers fail the operation rather than proceed on partial data. Regression tests inject a terminal iterator error and assert create / delete fail loudly; they fail without the fix. findExistingRelationTarget intentionally stays best-effort (cascade dedup, not a safety gate).
+status: done
+---
+
+## Bug
+
+Found in the 2026-06-09 backend review (write-path theme B3).
+
+Two helpers in `internal/entitymanager/core.go` swallowed `iter.Seq2` errors and
+returned partial slices, each feeding a safety-critical decision:
+
+- **`collectAllIDs`** (`core.go:192`) returned whatever it had collected on an iterator error. That partial list feeds `GenerateNextID`/`GenerateShortID` (`core.go:182`) — a truncated scan that misses a high-numbered existing ID makes the generator mint an ID that already exists, and `upsertEntity`'s create-then-update-on-conflict fallback then **overwrites** the existing entity.
+- **`collectIncidentRelations`** (`core.go:206`) `continue`d past per-item errors. It feeds `DeleteEntity`'s `totalRelations > 0 && !cascade` gate (`manager.go:474`, `cascadehost.go:116`) — under-counting lets a non-cascade delete proceed and **orphan** the missed relations (issue #888's class, reintroduced at the count step).
+
+## Fix (PR pending)
+
+Both helpers now return `([]T, error)` and propagate the iterator error.
+`generateID` fails on an ID-scan error rather than minting a possibly-colliding
+ID; both `DeleteEntity` callers return the error before the delete-safety gate
+rather than proceeding on partial data.
+
+`findExistingRelationTarget` deliberately stays best-effort (it backs
+`if_exists` cascade dedup, not a safety gate) — out of scope.
+
+Regression tests `TestCreate_FailsWhenIDScanErrors` and
+`TestDelete_FailsWhenRelationScanErrors` inject a terminal iterator error; both
+verified to fail without the fix (create silently succeeded, delete silently
+proceeded).

--- a/tickets/relations/BUG-R8ELTO--adds-measure--collect-iterator-errors-test.md
+++ b/tickets/relations/BUG-R8ELTO--adds-measure--collect-iterator-errors-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R8ELTO
+relation: adds-measure
+to: collect-iterator-errors-test
+---

--- a/tickets/relations/BUG-R8ELTO--affects--store-backends.md
+++ b/tickets/relations/BUG-R8ELTO--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R8ELTO
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-R8ELTO--fixes--FEAT-013.md
+++ b/tickets/relations/BUG-R8ELTO--fixes--FEAT-013.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R8ELTO
+relation: fixes
+to: FEAT-013
+---

--- a/tickets/relations/collect-iterator-errors-test--protects--store-backends.md
+++ b/tickets/relations/collect-iterator-errors-test--protects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: collect-iterator-errors-test
+relation: protects
+to: store-backends
+---


### PR DESCRIPTION
## Summary

Fixes write-path finding B3 from the backend review (BUG-R8ELTO). Two helpers in `core.go` swallowed `iter.Seq2` errors and returned partial slices, each feeding a safety-critical decision:

- **`collectAllIDs`** → `generateID`. A truncated entity scan that misses a high-numbered existing ID makes `GenerateNextID`/`GenerateShortID` mint an ID that already exists; `upsertEntity`'s create-then-update-on-conflict fallback then **overwrites** the existing entity.
- **`collectIncidentRelations`** → `DeleteEntity`'s `totalRelations > 0 && !cascade` gate (both the `Manager` and `cascadeHost` callers). Under-counting lets a non-cascade delete proceed and **orphan** the missed relations — the class issue #888 closed at the deletion step, reintroduced at the counting step.

## Fix

Both helpers now return `([]T, error)` and propagate the iterator error. `generateID` fails on an ID-scan error instead of minting a possibly-colliding ID; both `DeleteEntity` callers return the wrapped error before the delete-safety gate rather than deciding on partial data.

`findExistingRelationTarget` deliberately stays best-effort — it backs `if_exists` cascade dedup, not a safety gate, so a missed edge there only loses a dedup opportunity. Out of scope.

## Tests

- `TestCreate_FailsWhenIDScanErrors` — entity iterator yields a terminal error; auto-ID create must surface it (not collide).
- `TestDelete_FailsWhenRelationScanErrors` — relation iterator errors; `DeleteEntity` must surface it (not under-count).

Both verified to **fail without the fix** (create silently succeeded, delete silently proceeded). `go test ./...`, `golangci-lint`, and `just arch-lint` all pass.