### PR TITLE
fix(entitymanager): create never falls through to update on conflict

### DIFF
--- a/internal/entitymanager/core.go
+++ b/internal/entitymanager/core.go
@@ -94,7 +94,16 @@ func createCore(
 		return nil, nil, err
 	}
 
-	if err := upsertEntity(ctx, deps.Store, e); err != nil {
+	// A create must never fall through to an update — that would
+	// overwrite a colliding entity (a racing create, or a stale-scan
+	// duplicate ID). Write with a direct CreateEntity and surface a
+	// conflict as ErrEntityAlreadyExists. upsertEntity's
+	// create-then-update fallback is only for write-back-existing
+	// callers, never the create path.
+	if err := deps.Store.CreateEntity(ctx, e); err != nil {
+		if errors.Is(err, store.ErrConflict) {
+			return nil, nil, fmt.Errorf("%w: %s", ErrEntityAlreadyExists, e.ID)
+		}
 		return nil, nil, fmt.Errorf("write entity: %w", err)
 	}
 

--- a/internal/entitymanager/create_conflict_test.go
+++ b/internal/entitymanager/create_conflict_test.go
@@ -1,0 +1,72 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// conflictOnCreateStore forces CreateEntity to return store.ErrConflict
+// (modeling a racing create / duplicate ID landing between any
+// pre-check and the write) and counts UpdateEntity calls so a test can
+// prove the create path never falls through to an overwrite.
+type conflictOnCreateStore struct {
+	store.Store
+	updateCalls atomic.Int32
+}
+
+func (s *conflictOnCreateStore) CreateEntity(_ context.Context, _ *entity.Entity) error {
+	return store.ErrConflict
+}
+
+func (s *conflictOnCreateStore) UpdateEntity(ctx context.Context, e *entity.Entity) error {
+	s.updateCalls.Add(1)
+	return s.Store.UpdateEntity(ctx, e)
+}
+
+func newManagerOverStore(t *testing.T, st store.Store) *entitymanager.Manager {
+	t.Helper()
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:     st,
+		Meta:      parseMeta(t),
+		Templater: nopTemplater{},
+		Audit:     audit.Nop{},
+		ACL:       acl.NopACL{},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	return mgr
+}
+
+// TestCreate_ConflictDoesNotOverwrite pins that a create whose store
+// write conflicts (a racing create / duplicate ID landing on the write)
+// is reported as ErrEntityAlreadyExists and never falls through to an
+// UpdateEntity. Previously createCore went through upsertEntity
+// (Create→conflict→Update), so a racing create silently overwrote the
+// other writer's entity. The triggering entity uses an auto-generated
+// ID — the conflict-on-write is what matters, independent of how the ID
+// was chosen.
+func TestCreate_ConflictDoesNotOverwrite(t *testing.T) {
+	st := &conflictOnCreateStore{Store: memstore.New()}
+	mgr := newManagerOverStore(t, st)
+
+	e := entity.New("", "requirement")
+	e.SetString("title", "collides on write")
+	_, err := mgr.CreateEntity(context.Background(), e, entity.CreateOptions{})
+
+	if !errors.Is(err, entitymanager.ErrEntityAlreadyExists) {
+		t.Fatalf("expected ErrEntityAlreadyExists, got %v", err)
+	}
+	if got := st.updateCalls.Load(); got != 0 {
+		t.Errorf("create fell through to UpdateEntity %d time(s) — must never overwrite on a create", got)
+	}
+}

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -258,9 +258,11 @@ func (m *Manager) CreateEntity(
 		if def, ok := m.deps.Meta.GetEntityDef(e.Type); ok && !def.IsManualID() {
 			return nil, customIDNotAllowedError(e.Type, def, opts.ID)
 		}
-		if _, err := m.deps.Store.GetEntity(ctx, opts.ID); err == nil {
-			return nil, fmt.Errorf("%w: %s", ErrEntityAlreadyExists, opts.ID)
-		}
+		// No GetEntity pre-check: it was a TOCTOU duplicate of the
+		// store's atomic uniqueness guarantee. createCore now writes
+		// with a direct CreateEntity and surfaces a conflict as
+		// ErrEntityAlreadyExists, so a racing create can't slip past a
+		// passed pre-check and become an overwrite.
 	}
 
 	created, warnings, err := createCore(ctx, m.deps, e.Type, createCoreOpts{

--- a/internal/entitymanager/manager_test.go
+++ b/internal/entitymanager/manager_test.go
@@ -418,12 +418,13 @@ func TestCreate_WritesTwiceWithAutomationProperty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateEntity: %v", err)
 	}
-	// upsertEntity tries Create first then Update on conflict. Second
-	// persist therefore runs Create→conflict→Update. Both counts pin
-	// the shape: a future change that switches to "check-then-write"
-	// would flip creates from 2 to 1 without changing updates.
+	// The initial create is a direct CreateEntity (no upsert fallback —
+	// a create must never become an update). The post-automation
+	// re-write goes through upsertEntity, which runs
+	// Create→conflict→Update. So creates=2 (initial + upsert probe),
+	// updates=1 (the upsert fallback).
 	if got := cs.creates.Load(); got != 2 {
-		t.Errorf("CreateEntity calls = %d, want 2 (initial + upsert probe)", got)
+		t.Errorf("CreateEntity calls = %d, want 2 (initial create + upsert probe)", got)
 	}
 	if got := cs.updates.Load(); got != 1 {
 		t.Errorf("UpdateEntity calls = %d, want 1", got)

--- a/tickets/entities/automated-measures/create-no-overwrite-test.md
+++ b/tickets/entities/automated-measures/create-no-overwrite-test.md
@@ -1,0 +1,9 @@
+---
+id: create-no-overwrite-test
+type: automated-measure
+title: 'Test: entity create never overwrites on ID conflict'
+description: 'Regression for BUG-R2PV8G: a conflictOnCreateStore returns store.ErrConflict from CreateEntity and counts UpdateEntity calls. The test asserts CreateEntity returns ErrEntityAlreadyExists with zero UpdateEntity calls — proving the create path never falls through to an overwrite. Fails if createCore reverts to writing through upsertEntity.'
+kind: test
+location: internal/entitymanager/create_conflict_test.go (TestCreate_ConflictDoesNotOverwrite)
+status: active
+---

--- a/tickets/entities/bugs/BUG-R2PV8G.md
+++ b/tickets/entities/bugs/BUG-R2PV8G.md
@@ -1,0 +1,43 @@
+---
+id: BUG-R2PV8G
+type: bug
+title: Create silently becomes an overwrite-update on ID conflict
+description: Manager.CreateEntity wrote through upsertEntity, which does CreateEntity then falls back to UpdateEntity on store.ErrConflict. So a create whose ID collided (a racing create slipping past the GetEntity pre-check, or a duplicate ID from a stale scan) silently overwrote the existing entity instead of failing. The explicit GetEntity 'already exists' pre-check was a TOCTOU that gave false atomicity.
+priority: high
+why1: createCore persisted via upsertEntity, whose create-then-update-on-conflict fallback turned a conflicting create into an update of the colliding entity.
+why2: A single shared upsert helper was used for both the create path and the legitimate write-back-existing paths, so the create path inherited update-on-conflict semantics it must never have.
+why3: The duplicate-ID guard was a check-then-act (GetEntity then write) rather than relying on the store's atomic create, leaving a TOCTOU window a concurrent create could exploit.
+why4: '''A create must never become an update'' was an implicit invariant with no code or test enforcing it at the persistence step.'
+why5: Convenience upsert helpers blur create vs update intent; nothing flagged that the create path was using an update-tolerant write.
+prevention: createCore now writes with a direct Store.CreateEntity and maps store.ErrConflict to ErrEntityAlreadyExists — never falling through to update. The redundant TOCTOU GetEntity pre-check is removed; the store's atomic create is the uniqueness guard. upsertEntity stays for the three write-back-existing callers (post-automation rewrite, UpdateEntity, cascade WriteEntity). A regression test forces ErrConflict on write and asserts ErrEntityAlreadyExists with zero UpdateEntity calls; it fails without the fix.
+status: done
+---
+
+## Bug
+
+Found in the 2026-06-09 backend review (write-path theme B4).
+
+`Manager.CreateEntity` persisted through `upsertEntity` (`core.go:259`), which
+does `CreateEntity` and, on `store.ErrConflict`, **falls back to
+`UpdateEntity`**. The create path therefore had update-on-conflict semantics it
+must never have: a create whose ID collided — a concurrent create landing
+between the `GetEntity` pre-check (`manager.go:257-264`) and the write, or a
+duplicate ID from a truncated scan — silently **overwrote** the existing entity
+instead of failing with "already exists".
+
+The explicit `GetEntity` "already exists" pre-check was a check-then-act TOCTOU
+that gave a false sense of atomicity; under a race it passed, and the upsert
+fallback then clobbered.
+
+## Fix (PR pending)
+
+The principle: **a create must never fall through to an update.**
+
+- `createCore` writes with a direct `Store.CreateEntity` and maps `store.ErrConflict` → `ErrEntityAlreadyExists`. No fallback.
+- The redundant `GetEntity` pre-check in `CreateEntity` is removed — the store's atomic create is now the uniqueness guard, closing the TOCTOU. (The `IsManualID` check stays; it's a separate validation.)
+- `upsertEntity` is untouched and still serves its three legitimate write-back-existing callers: the post-automation rewrite (`manager.go:293`), `UpdateEntity` (`:425`), and `cascadeHost.WriteEntity` (`:76`).
+
+Regression test `TestCreate_ConflictDoesNotOverwrite` forces `store.ErrConflict`
+on write and asserts `ErrEntityAlreadyExists` with **zero** `UpdateEntity`
+calls. Verified it fails without the fix (the old upsert fell through to
+UpdateEntity).

--- a/tickets/relations/BUG-R2PV8G--adds-measure--create-no-overwrite-test.md
+++ b/tickets/relations/BUG-R2PV8G--adds-measure--create-no-overwrite-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R2PV8G
+relation: adds-measure
+to: create-no-overwrite-test
+---

--- a/tickets/relations/BUG-R2PV8G--affects--store-backends.md
+++ b/tickets/relations/BUG-R2PV8G--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R2PV8G
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-R2PV8G--fixes--FEAT-016.md
+++ b/tickets/relations/BUG-R2PV8G--fixes--FEAT-016.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R2PV8G
+relation: fixes
+to: FEAT-016
+---

--- a/tickets/relations/create-no-overwrite-test--protects--store-backends.md
+++ b/tickets/relations/create-no-overwrite-test--protects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: create-no-overwrite-test
+relation: protects
+to: store-backends
+---


### PR DESCRIPTION
## Summary

Fixes write-path finding B4 from the backend review (BUG-R2PV8G). `Manager.CreateEntity` persisted through `upsertEntity`, which does `CreateEntity` and falls back to `UpdateEntity` on `store.ErrConflict`. The create path thus had update-on-conflict semantics it must never have: a create whose ID collided — a concurrent create landing between the `GetEntity` pre-check and the write, or a duplicate ID from a truncated scan — silently **overwrote** the existing entity instead of failing.

The explicit `GetEntity` "already exists" pre-check was a check-then-act TOCTOU that gave false atomicity; under a race it passed and the upsert fallback then clobbered.

## Fix

The principle: **a create must never fall through to an update.**

- `createCore` writes with a direct `Store.CreateEntity` and maps `store.ErrConflict` → `ErrEntityAlreadyExists`. No fallback.
- The redundant `GetEntity` pre-check in `CreateEntity` is removed — the store's atomic create is now the uniqueness guard, closing the TOCTOU. (The `IsManualID` validation stays.)
- `upsertEntity` is untouched and still serves its three legitimate write-back-existing callers: the post-automation rewrite, `UpdateEntity`, and `cascadeHost.WriteEntity`.

## Tests

- `TestCreate_ConflictDoesNotOverwrite` — a store stub returns `store.ErrConflict` from `CreateEntity`; asserts `ErrEntityAlreadyExists` with **zero** `UpdateEntity` calls. Verified it **fails without the fix** (the old upsert fell through to `UpdateEntity`).
- Updated the stale comment on `TestCreate_WritesTwiceWithAutomationProperty` (the initial persist is now a direct create, not an upsert probe; the post-automation rewrite still upserts, so the 2/1 write shape is unchanged).

`go test ./...`, `golangci-lint`, and `just arch-lint` all pass.