### PR TITLE
fix(frontmatter): extract split into leaf package, fix 64KB line cap

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -64,6 +64,7 @@ components:
   metamodel:        { in: internal/metamodel }
   migration:        { in: internal/migration }
   markdown:         { in: internal/markdown }
+  frontmatter:      { in: internal/frontmatter }
   filter:           { in: internal/filter }
   pattern:          { in: internal/pattern }
   search:           { in: internal/search }
@@ -478,6 +479,8 @@ deps:
     mayDependOn:
       - storage
   markdown:
+    mayDependOn:
+      - frontmatter
     canUse:
       - goldmark
   filter:
@@ -536,6 +539,7 @@ deps:
   fsstore:
     mayDependOn:
       - cache
+      - frontmatter
       - graphquerynaive
       - storage
       - store

--- a/internal/frontmatter/frontmatter.go
+++ b/internal/frontmatter/frontmatter.go
@@ -1,0 +1,80 @@
+// Package frontmatter splits a YAML-frontmatter markdown document into
+// its raw frontmatter block and body. It is a dependency-free leaf: it
+// returns only strings — no YAML parsing, no domain types — so both
+// internal/markdown (the general parser) and internal/store/fsstore
+// (the storage backend, which deliberately does not import
+// internal/markdown) can share one implementation without coupling.
+//
+// rela's on-disk format is a YAML block fenced by "---" delimiters
+// followed by a markdown body:
+//
+//	---
+//	id: REQ-001
+//	type: requirement
+//	---
+//	# Body
+//
+// Callers own yaml.Unmarshal of the returned frontmatter block and any
+// higher-level concerns (git-conflict-marker detection, type mapping).
+package frontmatter
+
+import "strings"
+
+// Delimiter is the fence that opens and closes a frontmatter block.
+const Delimiter = "---"
+
+// Split separates the YAML frontmatter block from the markdown body.
+//
+// The first run of a delimiter-only line opens the block and the next
+// closes it; everything before the opening delimiter and after the
+// closing one is body. A document with no opening delimiter is all
+// body (frontmatter == "").
+//
+// Lines are split on "\n" — NOT via bufio.Scanner, which caps a single
+// line at bufio.MaxScanTokenSize (64 KB) and errors past it. A markdown
+// file with one long line (a base64 data: URI, a minified blob, a
+// pasted log) must round-trip: writable AND readable. Splitting on "\n"
+// has no per-line limit. A trailing "\r" on any line is stripped (CRLF
+// tolerance), matching the scanner's previous behavior; a trailing
+// newline does not yield a final empty body line.
+func Split(content string) (frontmatter, body string) {
+	var bodyLines, fmLines []string
+	inFrontmatter := false
+	frontmatterEnded := false
+
+	for _, line := range splitLines(content) {
+		if !inFrontmatter && !frontmatterEnded && strings.TrimSpace(line) == Delimiter {
+			inFrontmatter = true
+			continue
+		}
+		if inFrontmatter && strings.TrimSpace(line) == Delimiter {
+			inFrontmatter = false
+			frontmatterEnded = true
+			continue
+		}
+		if inFrontmatter {
+			fmLines = append(fmLines, line)
+		} else {
+			bodyLines = append(bodyLines, line)
+		}
+	}
+
+	frontmatter = strings.Join(fmLines, "\n")
+	body = strings.TrimPrefix(strings.Join(bodyLines, "\n"), "\n")
+	return frontmatter, body
+}
+
+// splitLines splits content into lines with the same observable
+// semantics bufio.Scanner had — trailing "\r" stripped per line, no
+// final empty line from a trailing "\n" — but with no per-line size cap.
+func splitLines(content string) []string {
+	if content == "" {
+		return nil
+	}
+	content = strings.TrimSuffix(content, "\n")
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSuffix(line, "\r")
+	}
+	return lines
+}

--- a/internal/frontmatter/frontmatter_test.go
+++ b/internal/frontmatter/frontmatter_test.go
@@ -1,0 +1,91 @@
+package frontmatter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSplit(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantFM   string
+		wantBody string
+	}{
+		{
+			name:     "frontmatter and body",
+			content:  "---\nid: REQ-001\ntype: requirement\n---\n\n# Heading\n\nContent here.\n",
+			wantFM:   "id: REQ-001\ntype: requirement",
+			wantBody: "# Heading\n\nContent here.",
+		},
+		{
+			name:     "no frontmatter is all body",
+			content:  "# Just a heading\n\nSome content.\n",
+			wantFM:   "",
+			wantBody: "# Just a heading\n\nSome content.",
+		},
+		{
+			name:     "empty content",
+			content:  "",
+			wantFM:   "",
+			wantBody: "",
+		},
+		{
+			name:     "only frontmatter",
+			content:  "---\nid: REQ-001\n---\n",
+			wantFM:   "id: REQ-001",
+			wantBody: "",
+		},
+		{
+			name:     "CRLF line endings are normalized",
+			content:  "---\r\nid: REQ-001\r\n---\r\n\r\nBody line\r\n",
+			wantFM:   "id: REQ-001",
+			wantBody: "Body line",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fm, body := Split(tc.content)
+			if fm != tc.wantFM {
+				t.Errorf("frontmatter = %q, want %q", fm, tc.wantFM)
+			}
+			if body != tc.wantBody {
+				t.Errorf("body = %q, want %q", body, tc.wantBody)
+			}
+		})
+	}
+}
+
+// TestSplit_LongLineDoesNotFail is the BUG-* regression: a single line
+// far larger than bufio.MaxScanTokenSize (64 KB) must split cleanly. The
+// previous bufio.Scanner implementation returned bufio.ErrTooLong here,
+// making such a file writable but unreadable.
+func TestSplit_LongLineExceeds64KB(t *testing.T) {
+	const bigLineSize = 256 * 1024 // 4x the scanner's 64 KB cap
+	bigValue := strings.Repeat("x", bigLineSize)
+	content := "---\nid: REQ-001\n---\n\n" + bigValue + "\n"
+
+	fm, body := Split(content)
+	if fm != "id: REQ-001" {
+		t.Errorf("frontmatter = %q, want id: REQ-001", fm)
+	}
+	if body != bigValue {
+		t.Errorf("body length = %d, want %d (long line was truncated or dropped)", len(body), bigLineSize)
+	}
+}
+
+// TestSplit_LongLineInFrontmatter covers the same cap on the
+// frontmatter side (e.g. a long base64 property value).
+func TestSplit_LongLineInFrontmatter(t *testing.T) {
+	const bigLineSize = 128 * 1024
+	bigValue := strings.Repeat("y", bigLineSize)
+	content := "---\nimage: " + bigValue + "\n---\nBody\n"
+
+	fm, body := Split(content)
+	if !strings.HasPrefix(fm, "image: ") || len(fm) < bigLineSize {
+		t.Errorf("frontmatter length = %d, want >= %d", len(fm), bigLineSize)
+	}
+	if body != "Body" {
+		t.Errorf("body = %q, want Body", body)
+	}
+}

--- a/internal/frontmatter/fuzz_test.go
+++ b/internal/frontmatter/fuzz_test.go
@@ -1,0 +1,29 @@
+package frontmatter
+
+import "testing"
+
+// FuzzSplit asserts Split never panics and never invents content: the
+// combined frontmatter + body length stays within a small constant of
+// the input (accounting for join overhead).
+func FuzzSplit(f *testing.F) {
+	seeds := []string{
+		"---\nkey: value\n---\nbody",
+		"",
+		"no frontmatter",
+		"---\n---\n",
+		"---\nunclosed",
+		"body\n---\nkey: value\n---\nmore body",
+		"---\r\nkey: value\r\n---\r\nbody",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		fm, body := Split(input)
+		if len(fm)+len(body) > len(input)+100 {
+			t.Errorf("output larger than input: fm=%d, body=%d, input=%d",
+				len(fm), len(body), len(input))
+		}
+	})
+}

--- a/internal/markdown/parser.go
+++ b/internal/markdown/parser.go
@@ -1,7 +1,6 @@
 package markdown
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -9,12 +8,14 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/frontmatter"
 )
 
 // ErrConflictedFile is returned when a file has unresolved git conflict markers.
 var ErrConflictedFile = errors.New("file has unresolved git conflicts")
 
-const frontmatterDelimiter = "---"
+const frontmatterDelimiter = frontmatter.Delimiter
 
 // conflictMarkerStart is the canonical opening-marker pattern Git
 // writes when a merge produces a conflict (`<<<<<<< <ref>`).
@@ -77,14 +78,11 @@ func ParseDocument(content string) (*Document, error) {
 		return nil, ErrConflictedFile
 	}
 
-	frontmatter, body, err := splitFrontmatter(content)
-	if err != nil {
-		return nil, err
-	}
+	fmBlock, body := frontmatter.Split(content)
 
 	var fm map[string]interface{}
-	if frontmatter != "" {
-		if err := yaml.Unmarshal([]byte(frontmatter), &fm); err != nil {
+	if fmBlock != "" {
+		if err := yaml.Unmarshal([]byte(fmBlock), &fm); err != nil {
 			return nil, fmt.Errorf("failed to parse frontmatter: %w", err)
 		}
 	}
@@ -93,45 +91,6 @@ func ParseDocument(content string) (*Document, error) {
 		Frontmatter: fm,
 		Content:     body,
 	}, nil
-}
-
-// splitFrontmatter separates YAML frontmatter from markdown content
-func splitFrontmatter(content string) (frontmatter, body string, err error) {
-	scanner := bufio.NewScanner(strings.NewReader(content))
-	var lines []string
-	inFrontmatter := false
-	frontmatterEnded := false
-	frontmatterLines := []string{}
-
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		if !inFrontmatter && !frontmatterEnded && strings.TrimSpace(line) == frontmatterDelimiter {
-			inFrontmatter = true
-			continue
-		}
-
-		if inFrontmatter && strings.TrimSpace(line) == frontmatterDelimiter {
-			inFrontmatter = false
-			frontmatterEnded = true
-			continue
-		}
-
-		if inFrontmatter {
-			frontmatterLines = append(frontmatterLines, line)
-		} else if frontmatterEnded || !inFrontmatter {
-			lines = append(lines, line)
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return "", "", err
-	}
-
-	frontmatter = strings.Join(frontmatterLines, "\n")
-	body = strings.TrimPrefix(strings.Join(lines, "\n"), "\n")
-
-	return frontmatter, body, nil
 }
 
 // FormatDocument formats a document back to markdown with YAML frontmatter.

--- a/internal/markdown/parser_fuzz_test.go
+++ b/internal/markdown/parser_fuzz_test.go
@@ -76,37 +76,8 @@ func FuzzParseDocument(f *testing.F) {
 	})
 }
 
-// FuzzSplitFrontmatter tests the frontmatter splitting logic
-func FuzzSplitFrontmatter(f *testing.F) {
-	seeds := []string{
-		"---\nkey: value\n---\nbody",
-		"",
-		"no frontmatter",
-		"---\n---\n",
-		"---\nunclosed",
-		"body\n---\nkey: value\n---\nmore body",
-	}
-
-	for _, seed := range seeds {
-		f.Add(seed)
-	}
-
-	f.Fuzz(func(t *testing.T, input string) {
-		// Should never panic
-		fm, body, err := splitFrontmatter(input)
-
-		if err != nil {
-			return
-		}
-
-		// Basic sanity: returned strings should not be longer than input
-		// (allowing for some overhead from joining)
-		if len(fm)+len(body) > len(input)+100 {
-			t.Errorf("output larger than input: fm=%d, body=%d, input=%d",
-				len(fm), len(body), len(input))
-		}
-	})
-}
+// The frontmatter-split fuzz test moved to internal/frontmatter
+// (FuzzSplit) along with the split implementation.
 
 // FuzzFormatDocument tests the document formatter
 func FuzzFormatDocument(f *testing.F) {

--- a/internal/markdown/parser_test.go
+++ b/internal/markdown/parser_test.go
@@ -294,67 +294,9 @@ func TestDocumentGetStringSlice_NilFrontmatter(t *testing.T) {
 	}
 }
 
-func TestSplitFrontmatter(t *testing.T) {
-	content := `---
-id: REQ-001
-type: requirement
----
-
-# Heading
-
-Content here.
-`
-
-	frontmatter, body, err := splitFrontmatter(content)
-	testutil.AssertNoError(t, err)
-
-	testutil.AssertStringContains(t, frontmatter, "id: REQ-001")
-	testutil.AssertStringContains(t, frontmatter, "type: requirement")
-
-	testutil.AssertStringContains(t, body, "# Heading")
-	testutil.AssertStringContains(t, body, "Content here")
-
-	// Body should not contain frontmatter delimiters
-	testutil.AssertStringNotContains(t, body, "---")
-}
-
-func TestSplitFrontmatter_NoFrontmatter(t *testing.T) {
-	content := `# Just a heading
-
-Some content.
-`
-
-	frontmatter, body, err := splitFrontmatter(content)
-	testutil.AssertNoError(t, err)
-
-	testutil.AssertEqual(t, frontmatter, "")
-
-	testutil.AssertStringContains(t, body, "# Just a heading")
-}
-
-func TestSplitFrontmatter_EmptyContent(t *testing.T) {
-	content := ""
-
-	frontmatter, body, err := splitFrontmatter(content)
-	testutil.AssertNoError(t, err)
-
-	testutil.AssertEqual(t, frontmatter, "")
-	testutil.AssertEqual(t, body, "")
-}
-
-func TestSplitFrontmatter_OnlyFrontmatter(t *testing.T) {
-	content := `---
-id: REQ-001
----
-`
-
-	frontmatter, body, err := splitFrontmatter(content)
-	testutil.AssertNoError(t, err)
-
-	testutil.AssertStringContains(t, frontmatter, "id: REQ-001")
-
-	testutil.AssertEqual(t, body, "")
-}
+// Frontmatter-split unit tests moved to internal/frontmatter
+// (TestSplit) along with the split implementation. The tests below
+// still exercise the split end-to-end via ParseDocument.
 
 func TestHasConflictMarkers(t *testing.T) {
 	tests := []struct {

--- a/internal/store/fsstore/longline_test.go
+++ b/internal/store/fsstore/longline_test.go
@@ -1,0 +1,46 @@
+package fsstore_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// TestLongLine_WriteThenReadBack is the store-level regression for the
+// 64 KB frontmatter-split cap: an entity whose body contains a single
+// line larger than bufio.MaxScanTokenSize (a base64 data: URI, a pasted
+// log, a minified blob) must round-trip. The old bufio.Scanner-based
+// split wrote the file fine but returned bufio.ErrTooLong on read,
+// making the entity writable-but-unreadable.
+func TestLongLine_WriteThenReadBack(t *testing.T) {
+	fs := storage.NewMemFS()
+	ctx := context.Background()
+
+	const bigLineSize = 256 * 1024 // 4x the scanner's 64 KB cap
+	bigLine := strings.Repeat("x", bigLineSize)
+
+	s1 := openStore(t, fs)
+	e := entity.New("REQ-1", "requirement")
+	e.Properties["title"] = "Has a very long body line"
+	e.Content = "Before\n" + bigLine + "\nAfter"
+	require.NoError(t, s1.CreateEntity(ctx, e))
+
+	// Read back from the same store instance...
+	got, err := s1.GetEntity(ctx, "REQ-1")
+	require.NoError(t, err, "entity with a >64KB line must be readable")
+	assert.Contains(t, got.Content, bigLine, "the long line must survive the round-trip")
+	require.NoError(t, s1.Close())
+
+	// ...and after reopening from disk (the cold-read path).
+	s2 := openStore(t, fs)
+	defer s2.Close()
+	got2, err := s2.GetEntity(ctx, "REQ-1")
+	require.NoError(t, err, "entity with a >64KB line must be readable after reopen")
+	assert.Contains(t, got2.Content, bigLine)
+}

--- a/internal/store/fsstore/markdown.go
+++ b/internal/store/fsstore/markdown.go
@@ -1,7 +1,6 @@
 package fsstore
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -16,13 +15,14 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/frontmatter"
 )
 
 // errConflictedFile is returned when a file has unresolved git conflict markers.
 var errConflictedFile = errors.New("file has unresolved git conflicts")
 
 const (
-	frontmatterDelimiter = "---"
+	frontmatterDelimiter = frontmatter.Delimiter
 	defaultLineWidth     = 80
 )
 
@@ -87,10 +87,7 @@ func parseDocument(raw string) (*document, error) {
 		return nil, errConflictedFile
 	}
 
-	fm, body, err := splitFrontmatter(raw)
-	if err != nil {
-		return nil, err
-	}
+	fm, body := frontmatter.Split(raw)
 
 	var parsed map[string]interface{}
 	if fm != "" {
@@ -100,44 +97,6 @@ func parseDocument(raw string) (*document, error) {
 	}
 
 	return &document{frontmatter: parsed, content: body}, nil
-}
-
-func splitFrontmatter(content string) (frontmatter, body string, err error) {
-	scanner := bufio.NewScanner(strings.NewReader(content))
-	var lines []string
-	inFrontmatter := false
-	frontmatterEnded := false
-	var frontmatterLines []string
-
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		if !inFrontmatter && !frontmatterEnded && strings.TrimSpace(line) == frontmatterDelimiter {
-			inFrontmatter = true
-			continue
-		}
-
-		if inFrontmatter && strings.TrimSpace(line) == frontmatterDelimiter {
-			inFrontmatter = false
-			frontmatterEnded = true
-			continue
-		}
-
-		if inFrontmatter {
-			frontmatterLines = append(frontmatterLines, line)
-		} else if frontmatterEnded || !inFrontmatter {
-			lines = append(lines, line)
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return "", "", err
-	}
-
-	frontmatter = strings.Join(frontmatterLines, "\n")
-	body = strings.TrimPrefix(strings.Join(lines, "\n"), "\n")
-
-	return frontmatter, body, nil
 }
 
 // --- document formatting ---

--- a/tickets/entities/automated-measures/frontmatter-long-line-test.md
+++ b/tickets/entities/automated-measures/frontmatter-long-line-test.md
@@ -1,0 +1,9 @@
+---
+id: frontmatter-long-line-test
+type: automated-measure
+title: 'Test: frontmatter split handles lines over 64KB (round-trip)'
+description: 'Regression for BUG-LSBFD1: the leaf-package tests split >64KB lines in body and frontmatter without error; the fsstore test writes an entity with a 256KB body line and reads it back (same instance + after reopen). Fails if the split reverts to a size-capped bufio.Scanner (bufio.Scanner: token too long).'
+kind: test
+location: internal/frontmatter/frontmatter_test.go (TestSplit_LongLineExceeds64KB, TestSplit_LongLineInFrontmatter, FuzzSplit) + internal/store/fsstore/longline_test.go (TestLongLine_WriteThenReadBack)
+status: active
+---

--- a/tickets/entities/bugs/BUG-LSBFD1.md
+++ b/tickets/entities/bugs/BUG-LSBFD1.md
@@ -1,0 +1,49 @@
+---
+id: BUG-LSBFD1
+type: bug
+title: Entity markdown with a line over 64KB is writable but unreadable
+description: 'splitFrontmatter (duplicated in internal/markdown and internal/store/fsstore) used bufio.Scanner, which caps a single line at bufio.MaxScanTokenSize (64KB) and returns bufio.ErrTooLong past it. The write path does not use the scanner, so the store happily wrote an entity whose body or a property had a >64KB line (a base64 data: URI, a minified blob, a pasted log) but then failed to read it back: GetEntity returned an I/O error and ListEntities/index rebuild aborted on it.'
+priority: high
+why1: splitFrontmatter scanned lines with bufio.Scanner, whose default token cap is 64KB; a longer line made scanner.Err() return bufio.ErrTooLong, failing the parse.
+why2: The read path used a size-capped line scanner while the write path used plain string joins, so writes and reads had asymmetric limits — a file could be produced that could never be re-read.
+why3: The frontmatter split was hand-rolled and duplicated in two packages, so the cap existed in two places and neither had a long-line test.
+why4: There was no round-trip property test (write an entity, read it back) covering large single-line content, so the asymmetry went unnoticed.
+why5: Low-level .md framing logic had no single owner; duplicated across markdown and fsstore, it accumulated a latent cap with no shared test surface.
+prevention: 'Extracted the split into a dependency-free leaf package internal/frontmatter (returns only strings, satisfies the no-leak rule) shared by both markdown and fsstore; it splits on newlines with no per-line cap. Added unit + fuzz tests in the leaf package (incl. >64KB cases) and an fsstore-level write-then-read-back regression that fails without the fix (bufio.Scanner: token too long).'
+status: done
+---
+
+## Bug
+
+Found in the 2026-06-09 backend review (C4).
+
+`splitFrontmatter` — hand-rolled and **duplicated** in
+`internal/markdown/parser.go` and `internal/store/fsstore/markdown.go` — used
+`bufio.Scanner`, whose default token cap is `bufio.MaxScanTokenSize` (64 KB). A
+single line ≥ 64 KB makes `scanner.Err()` return `bufio.ErrTooLong`, so the
+parse fails.
+
+The asymmetry is the trap: the **write** path (`FormatDocumentOrdered`) uses
+plain string joins with no cap, so the store writes such an entity fine, but
+**read** (`GetEntity` → `parseDocument` → `splitFrontmatter`) then errors.
+`ListEntities` and the search-index rebuild abort on it too. Realistic triggers:
+a base64 `data:` image URI, a minified JSON/CSV blob, a long table row, a pasted
+log line.
+
+## Fix (PR pending)
+
+Extracted the frontmatter split into a new dependency-free leaf package,
+**`internal/frontmatter`**, exposing `Split(content) (frontmatter, body
+string)`. It returns only strings (no YAML, no domain types — satisfies the
+CLAUDE.md "don't leak parsing types" rule), so both `internal/markdown` and
+`internal/store/fsstore` (which deliberately doesn't import `internal/markdown`)
+share one implementation. The split is on `"\n"` with no per-line cap;
+CRLF-tolerant, preserving the scanner's previous observable semantics.
+
+Both hand-rolled `splitFrontmatter` copies are deleted. arch-lint updated to
+declare the leaf component and allow `markdown`/`fsstore` → `frontmatter`.
+
+## Tests
+
+- `internal/frontmatter`: `TestSplit` (frontmatter/body, none, empty, only-frontmatter, CRLF), `TestSplit_LongLineExceeds64KB`, `TestSplit_LongLineInFrontmatter`, and `FuzzSplit` (moved from markdown).
+- `internal/store/fsstore`: `TestLongLine_WriteThenReadBack` — writes an entity with a 256 KB body line and reads it back (same instance + after reopen). Verified it **fails without the fix** (`bufio.Scanner: token too long`).

--- a/tickets/relations/BUG-LSBFD1--adds-measure--frontmatter-long-line-test.md
+++ b/tickets/relations/BUG-LSBFD1--adds-measure--frontmatter-long-line-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-LSBFD1
+relation: adds-measure
+to: frontmatter-long-line-test
+---

--- a/tickets/relations/BUG-LSBFD1--affects--store-backends.md
+++ b/tickets/relations/BUG-LSBFD1--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-LSBFD1
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-LSBFD1--fixes--FEAT-fmt.md
+++ b/tickets/relations/BUG-LSBFD1--fixes--FEAT-fmt.md
@@ -1,0 +1,5 @@
+---
+from: BUG-LSBFD1
+relation: fixes
+to: FEAT-fmt
+---

--- a/tickets/relations/frontmatter-long-line-test--protects--store-backends.md
+++ b/tickets/relations/frontmatter-long-line-test--protects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: frontmatter-long-line-test
+relation: protects
+to: store-backends
+---


### PR DESCRIPTION
## Summary

Fixes review finding C4 (BUG-LSBFD1). `splitFrontmatter` — hand-rolled and **duplicated** in `internal/markdown` and `internal/store/fsstore` — used `bufio.Scanner`, whose default token cap is 64 KB (`bufio.MaxScanTokenSize`). A single line ≥ 64 KB returns `bufio.ErrTooLong`, failing the parse.

The trap is the asymmetry: the **write** path uses plain string joins (no cap), so the store writes such an entity fine, but **read** (`GetEntity` → `parseDocument` → `splitFrontmatter`) then errors — and `ListEntities` / search-index rebuild abort on it. Realistic triggers: a base64 `data:` image URI, a minified blob, a pasted log line.

## Fix — extract a shared leaf package

Per discussion, rather than patching the cap in two places, the frontmatter split is now a single dependency-free leaf package, **`internal/frontmatter`**:

```go
func Split(content string) (frontmatter, body string)
```

It returns only strings — no YAML, no domain types — so it satisfies the "don't leak parsing types" rule and can be imported by **both** `internal/markdown` and `internal/store/fsstore` (which deliberately doesn't import `internal/markdown`). The split is on `"\n"` with **no per-line cap**; CRLF-tolerant, preserving the scanner's previous observable line semantics.

Both hand-rolled `splitFrontmatter` copies are deleted; `yaml.v3` still does the actual YAML parse, and fsstore's git-conflict-marker detection is untouched. `.go-arch-lint.yml` declares the new leaf component and allows `markdown`/`fsstore` → `frontmatter`.

(We considered using goldmark's frontmatter extension — goldmark is already a dep — but it's a render-time extension that would mean a full CommonMark parse per entity read on the hottest store path, and it can't reach the fsstore copy anyway. The hand-rolled split is the right tool for the read path; it just needed to not be size-capped, and to exist once.)

## Tests

- `internal/frontmatter`: `TestSplit` (frontmatter/body, none, empty, only-frontmatter, CRLF), `TestSplit_LongLineExceeds64KB`, `TestSplit_LongLineInFrontmatter`, and `FuzzSplit` (moved from markdown; 5s/2.2M-exec run clean).
- `internal/store/fsstore`: `TestLongLine_WriteThenReadBack` — writes an entity with a 256 KB body line and reads it back (same instance + after reopen). Verified it **fails without the fix** (`bufio.Scanner: token too long`).

`go test ./...`, `golangci-lint`, and `just arch-lint` all pass.