### PR TITLE
fix(search): deterministic LinearSearch order; sort then truncate

### DIFF
--- a/internal/search/linearsearch.go
+++ b/internal/search/linearsearch.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/natsort"
 )
 
 // LinearSearch is a SearchIndex that performs brute-force substring matching.
@@ -55,6 +56,14 @@ func (l *LinearSearch) advanceLastModified(t time.Time) {
 	}
 }
 
+// Search returns the IDs of entities whose indexed text matches.
+//
+// LinearSearch has no relevance scoring (it is brute-force substring
+// matching), so the contract's "ordered by relevance" cannot apply;
+// results are returned in natural-sort ID order instead — stable and
+// deterministic across calls. All matches are collected before sorting
+// and truncating, so a limit returns the first-N of that defined order
+// rather than an arbitrary subset of the map's randomized iteration.
 func (l *LinearSearch) Search(text string, limit int) ([]string, error) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -63,10 +72,11 @@ func (l *LinearSearch) Search(text string, limit int) ([]string, error) {
 	for _, e := range l.entities {
 		if MatchText(e, text) {
 			ids = append(ids, e.ID)
-			if limit > 0 && len(ids) >= limit {
-				break
-			}
 		}
+	}
+	natsort.Strings(ids)
+	if limit > 0 && len(ids) > limit {
+		ids = ids[:limit]
 	}
 	return ids, nil
 }

--- a/internal/search/linearsearch_test.go
+++ b/internal/search/linearsearch_test.go
@@ -1,0 +1,74 @@
+package search
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// seedLinear builds a LinearSearch whose entities all match the query
+// "match" via a shared content substring, with natural-sort-significant
+// IDs (REQ-2 must sort before REQ-10).
+func seedLinear(t *testing.T) *LinearSearch {
+	t.Helper()
+	l := NewLinearSearch()
+	for _, id := range []string{"REQ-10", "REQ-2", "REQ-1", "REQ-21", "REQ-3"} {
+		e := entity.New(id, "requirement")
+		e.Content = "this is a match"
+		if err := l.EntityPut(e); err != nil {
+			t.Fatalf("EntityPut(%s): %v", id, err)
+		}
+	}
+	return l
+}
+
+// TestLinearSearch_DeterministicOrder pins that repeated identical
+// queries return the same, natural-sort-ordered result — not an
+// arbitrary permutation of the backing map's randomized iteration.
+func TestLinearSearch_DeterministicOrder(t *testing.T) {
+	l := seedLinear(t)
+	want := []string{"REQ-1", "REQ-2", "REQ-3", "REQ-10", "REQ-21"}
+
+	// Run many times: map iteration order is randomized per range, so a
+	// non-deterministic implementation would diverge within a few runs.
+	for i := range 50 {
+		got, err := l.Search("match", 0)
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("run %d: got %v, want %v (natural-sort order, stable)", i, got, want)
+		}
+	}
+}
+
+// TestLinearSearch_LimitReturnsFirstN pins that a limit returns the
+// first-N of the defined order, deterministically — not an arbitrary
+// subset truncated mid-iteration over the map.
+func TestLinearSearch_LimitReturnsFirstN(t *testing.T) {
+	l := seedLinear(t)
+	want := []string{"REQ-1", "REQ-2", "REQ-3"}
+
+	for i := range 50 {
+		got, err := l.Search("match", 3)
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("run %d: got %v, want %v (first 3 in natural-sort order)", i, got, want)
+		}
+	}
+}
+
+// TestLinearSearch_NoMatchesEmpty pins the empty-result shape.
+func TestLinearSearch_NoMatchesEmpty(t *testing.T) {
+	l := seedLinear(t)
+	got, err := l.Search("nonexistent-term", 0)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want no results", got)
+	}
+}

--- a/tickets/entities/automated-measures/linearsearch-determinism-test.md
+++ b/tickets/entities/automated-measures/linearsearch-determinism-test.md
@@ -1,0 +1,9 @@
+---
+id: linearsearch-determinism-test
+type: automated-measure
+title: 'Test: LinearSearch returns a deterministic, sorted result set'
+description: 'Regression for BUG-ULU7X6: asserts repeated identical queries return the same natural-sort-ordered IDs (50 runs), a limit returns the first-N of that order, and natural-sort places REQ-2 before REQ-10. Fails if LinearSearch.Search reverts to ranging the map without sorting or truncates mid-iteration.'
+kind: test
+location: internal/search/linearsearch_test.go (TestLinearSearch_DeterministicOrder, TestLinearSearch_LimitReturnsFirstN, TestLinearSearch_NoMatchesEmpty)
+status: active
+---

--- a/tickets/entities/bugs/BUG-ULU7X6.md
+++ b/tickets/entities/bugs/BUG-ULU7X6.md
@@ -1,0 +1,58 @@
+---
+id: BUG-ULU7X6
+type: bug
+title: LinearSearch returns a nondeterministic, arbitrarily-truncated result set
+description: LinearSearch.Search ranged over its backing map (randomized Go iteration order) and broke mid-loop at the limit. So the same query returned a different ordering each call, and with a limit a different arbitrary subset. The Service wrapper always calls the backend with limit=0 then applies its own q.Limit over the returned order, so the unstable order still fed pagination; tests on the memorybackend build (where LinearSearch is the live backend) saw flakiness.
+priority: medium
+why1: Search appended IDs while ranging over a map and truncated with a mid-loop break at limit, so both order and limited-subset depended on Go's randomized map iteration.
+why2: The backend had no relevance scoring and no fallback deterministic ordering, so 'collect then order' was never established.
+why3: Truncation happened during iteration rather than after collecting all matches, conflating 'which match' with 'iteration order'.
+why4: The Search contract promised relevance ordering that a brute-force substring backend cannot provide, and no substitute ordering (ID) was specified.
+why5: No test asserted determinism or limit semantics for LinearSearch, so the randomized behavior went unnoticed on the memorybackend path.
+prevention: Search now collects all matches, sorts by natural-sort ID order (natsort.Strings), then truncates — so the order is stable across calls and a limit returns the first-N of a defined order. Documented that LinearSearch (no scoring) returns ID order, not relevance. Regression tests assert repeated-query stability, natural-sort order (REQ-2 before REQ-10), and deterministic limit subsets; they fail without the fix on the first run.
+status: done
+---
+
+## Bug
+
+Found in the 2026-06-09 backend review (C3).
+
+`LinearSearch.Search` (`internal/search/linearsearch.go`):
+
+```go
+for _, e := range l.entities {        // map: randomized iteration order
+    if MatchText(e, text) {
+        ids = append(ids, e.ID)
+        if limit > 0 && len(ids) >= limit { break }  // arbitrary subset
+    }
+}
+```
+
+Two defects:
+
+1. **Nondeterministic order** — the same query returns a different ordering on each call (Go randomizes map iteration). The `Service` wrapper (`index.go:35`) always calls `backend.Search(text, 0)` and applies `q.Limit` itself over the returned order, so the unstable order feeds pagination; the `memorybackend` build (where LinearSearch is the active backend) sees test flakiness.
+2. **Truncate-during-iteration** — the mid-loop `break` at `limit` picks an arbitrary subset rather than the first-N of any defined order.
+
+## Fix (PR pending)
+
+Collect all matches, sort by natural-sort ID order, then truncate:
+
+```go
+for _, e := range l.entities {
+    if MatchText(e, text) { ids = append(ids, e.ID) }
+}
+natsort.Strings(ids)
+if limit > 0 && len(ids) > limit { ids = ids[:limit] }
+```
+
+LinearSearch is brute-force substring matching with no relevance scoring, so the
+contract's "ordered by relevance" cannot apply — ID order is the honest, stable
+substitute (documented in the godoc). `natsort` (already a common component)
+gives `REQ-2 < REQ-10`, matching the codebase's ID-ordering convention.
+
+## Tests
+
+`internal/search/linearsearch_test.go`: `TestLinearSearch_DeterministicOrder`
+(50 runs, identical natural-sort order), `TestLinearSearch_LimitReturnsFirstN`
+(first-N deterministic), `TestLinearSearch_NoMatchesEmpty`. Verified they **fail
+without the fix** on the first run (randomized order / arbitrary subset).

--- a/tickets/relations/BUG-ULU7X6--adds-measure--linearsearch-determinism-test.md
+++ b/tickets/relations/BUG-ULU7X6--adds-measure--linearsearch-determinism-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ULU7X6
+relation: adds-measure
+to: linearsearch-determinism-test
+---

--- a/tickets/relations/BUG-ULU7X6--affects--store-backends.md
+++ b/tickets/relations/BUG-ULU7X6--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ULU7X6
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-ULU7X6--fixes--FEAT-y6g5.md
+++ b/tickets/relations/BUG-ULU7X6--fixes--FEAT-y6g5.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ULU7X6
+relation: fixes
+to: FEAT-y6g5
+---

--- a/tickets/relations/linearsearch-determinism-test--protects--store-backends.md
+++ b/tickets/relations/linearsearch-determinism-test--protects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: linearsearch-determinism-test
+relation: protects
+to: store-backends
+---


### PR DESCRIPTION
## Summary

Fixes review finding C3 (BUG-ULU7X6). `LinearSearch.Search` ranged over its backing map (randomized Go iteration order) and broke mid-loop at the limit:

```go
for _, e := range l.entities {        // randomized order
    if MatchText(e, text) {
        ids = append(ids, e.ID)
        if limit > 0 && len(ids) >= limit { break }  // arbitrary subset
    }
}
```

Two defects: (1) the same query returns a **different ordering** every call, and (2) a limit truncates **mid-iteration**, yielding an arbitrary subset. The `Service` wrapper always calls `backend.Search(text, 0)` and applies `q.Limit` itself over the returned order, so the unstable order still feeds pagination; the `memorybackend` build (where LinearSearch is the live backend) sees test flakiness.

## Fix

Collect all matches, sort by natural-sort ID order, then truncate:

```go
for _, e := range l.entities {
    if MatchText(e, text) { ids = append(ids, e.ID) }
}
natsort.Strings(ids)
if limit > 0 && len(ids) > limit { ids = ids[:limit] }
```

LinearSearch is brute-force substring matching with no relevance scoring, so the contract's "ordered by relevance" can't apply — ID order is the honest, stable substitute (documented in the godoc). `natsort` (already a common component) gives `REQ-2 < REQ-10`, matching the codebase's ID-ordering convention.

## Tests

`internal/search/linearsearch_test.go`: `TestLinearSearch_DeterministicOrder` (50 runs, identical natural-sort order), `TestLinearSearch_LimitReturnsFirstN` (first-N deterministic), `TestLinearSearch_NoMatchesEmpty`. Verified they **fail without the fix** on the first run (e.g. randomized `[REQ-1 REQ-21 REQ-3 REQ-10 REQ-2]`, arbitrary limit subset `[REQ-21 REQ-3 REQ-10]`).

`go test ./...` (default + `-tags memorybackend`), `golangci-lint`, and `just arch-lint` all pass.