### PR TITLE
test: fixture consolidation — mcp on appbuildtest, validation dedup, testutil fixes (TKT-R2KBG6)

### DIFF
--- a/internal/mcp/test_helpers_test.go
+++ b/internal/mcp/test_helpers_test.go
@@ -1,137 +1,48 @@
 package mcp
 
 import (
-	"context"
-	"errors"
 	"testing"
 
-	"github.com/Sourcehaven-BV/rela/internal/acl"
-	"github.com/Sourcehaven-BV/rela/internal/audit"
-	"github.com/Sourcehaven-BV/rela/internal/autocascade"
-	"github.com/Sourcehaven-BV/rela/internal/automation"
-	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
-	"github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
-	"github.com/Sourcehaven-BV/rela/internal/search"
-	"github.com/Sourcehaven-BV/rela/internal/search/bleveindex"
 	"github.com/Sourcehaven-BV/rela/internal/store"
-	"github.com/Sourcehaven-BV/rela/internal/templating"
-	"github.com/Sourcehaven-BV/rela/internal/tracer"
-	"github.com/Sourcehaven-BV/rela/internal/validator"
 )
 
-// newTestDeps wires the focused services MCP tools exercise around a
-// caller-supplied store and returns the [Deps] the server consumes.
-// Mirrors the production cli.mcpServices wiring but without project
-// discovery, fsstore, or the Lua engine. The store is hooked to a
-// fresh bleve search backend via observer wiring so writes through
-// the store reach the index synchronously.
+// newTestDeps assembles the [Deps] the server consumes from an
+// appbuildtest services bundle, so the test wiring is single-sourced
+// with the rest of the repo instead of hand-mirroring the production
+// cli.mcpServices graph (TKT-R2KBG6 — the previous hand-rolled wiring
+// is where the nil-templater booby trap of TKT-TLQ94B lived).
 //
-// Callers that want to seed entities before the bleve observer is
-// installed should call backfill manually after seeding.
+// The bundle wires an in-memory bleve backend and backfills it from
+// the caller-supplied store, so entities seeded before construction
+// are searchable; writes during the test do not reach the index
+// (same semantics as the previous fixture).
 func newTestDeps(t *testing.T, meta *metamodel.Metamodel, st store.Store) Deps {
 	t.Helper()
 
-	backend, err := bleveindex.NewMem()
-	if err != nil {
-		t.Fatalf("bleveindex.NewMem: %v", err)
-	}
-	t.Cleanup(func() { _ = backend.Close() })
-
-	// Backfill any entities already in the store (the test fixture
-	// seeds before constructing services).
-	ctx := context.Background()
-	for e, err := range st.ListEntities(ctx, store.EntityQuery{}) {
-		if err != nil {
-			continue
-		}
-		_ = backend.EntityPut(e)
-	}
-
-	tr := tracer.New(st)
-	srch := search.New(st, backend)
-	val := validator.New(st, meta, lua.ReadDeps{
-		Store:    st,
-		Tracer:   tr,
-		Searcher: srch,
-		Meta:     meta,
-	})
-
-	// Wire autocascade if the metamodel declares automations; mirrors
-	// the production wiring in cli.newMCPServices so tests that add
-	// automations to their metamodel still exercise the full cascade
-	// pipeline.
-	var autoEngine *automation.Engine
-	var cascadeRunner *autocascade.Runner
-	if len(meta.Automations) > 0 {
-		autoEngine = automation.NewEngineFromMetamodel(meta.Automations)
-		r, rerr := autocascade.New(autocascade.Deps{Engine: autoEngine})
-		if rerr != nil {
-			t.Fatalf("autocascade.New: %v", rerr)
-		}
-		cascadeRunner = r
-	}
-	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:       st,
-		Meta:        meta,
-		Templater:   nopTemplater{},
-		Audit:       audit.Nop{},
-		ACL:         acl.NopACL{},
-		Automations: autoEngine,
-		Cascade:     cascadeRunner,
-	})
-	if err != nil {
-		t.Fatalf("entitymanager.New: %v", err)
-	}
+	svc := appbuildtest.New(meta, appbuildtest.WithStore(st))
+	t.Cleanup(func() { _ = svc.Close() })
 
 	return Deps{
-		Store:         st,
+		Store:         svc.Store(),
 		Meta:          meta,
-		Tracer:        tr,
-		Searcher:      srch,
-		Validator:     val,
-		EntityManager: mgr,
-		Config:        nopConfigLoader{},
-		LuaWriteDeps: lua.WriteDeps{
-			ReadDeps: lua.ReadDeps{
-				Store:    st,
-				Tracer:   tr,
-				Searcher: srch,
-				Meta:     meta,
-			},
-			EntityManager: mgr,
-		},
-		Watcher:     nopWatcher{},
-		ProjectRoot: t.TempDir(),
+		Tracer:        svc.Tracer(),
+		Searcher:      svc.Searcher(),
+		Validator:     svc.Validator(),
+		EntityManager: svc.EntityManager(),
+		Config:        svc.Config(),
+		LuaWriteDeps:  svc.LuaWriteDeps(),
+		Watcher:       nopWatcher{},
+		ProjectRoot:   t.TempDir(),
 	}
 }
 
-// --- stub helpers ---
-
-// nopTemplater satisfies the narrow [entitymanager.TemplateLoader]
-// interface with template misses. The previous fixture used
-// templating.NewFSTemplater(nil, nil), which panics on a nil
-// *project.Context the moment a create actually runs — caught by the
-// dispatch tests (TKT-TLQ94B), which exercise the full create path.
-type nopTemplater struct{}
-
-func (nopTemplater) EntityTemplate(_ context.Context, _, _ string) (*templating.Template, error) {
-	return nil, nil //nolint:nilnil // miss is not an error at this layer
-}
-
-func (nopTemplater) RelationTemplate(_ context.Context, _ string) (*templating.Template, error) {
-	return nil, nil //nolint:nilnil // miss is not an error at this layer
-}
-
+// nopWatcher satisfies the narrow watcher interface MCP consumes;
+// tests never exercise file watching.
 type nopWatcher struct{}
 
 func (nopWatcher) Start(func()) error { return nil }
 func (nopWatcher) Stop()              {}
 func (nopWatcher) Pause()             {}
 func (nopWatcher) Resume()            {}
-
-type nopConfigLoader struct{}
-
-func (nopConfigLoader) Load(context.Context, string) ([]byte, error) {
-	return nil, errors.New("test: no config loader")
-}

--- a/internal/mcp/test_helpers_test.go
+++ b/internal/mcp/test_helpers_test.go
@@ -34,7 +34,12 @@ func newTestDeps(t *testing.T, meta *metamodel.Metamodel, st store.Store) Deps {
 		Config:        svc.Config(),
 		LuaWriteDeps:  svc.LuaWriteDeps(),
 		Watcher:       nopWatcher{},
-		ProjectRoot:   t.TempDir(),
+		// Note: this real empty dir (what lua_list/lua_run walk) is
+		// intentionally distinct from LuaWriteDeps' ProjectRoot, which
+		// points at the fixture's in-memory /project. No current test
+		// resolves a Lua write relative to that root; align the two if
+		// one ever does.
+		ProjectRoot: t.TempDir(),
 	}
 }
 

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -395,6 +395,15 @@ func (b *MetamodelBuilder) WithEntityProperty(entityName, propName, propType str
 	return b
 }
 
+// WithValidation appends a validation rule to the metamodel. Use for
+// tests whose subject is the rule itself (when/then or Lua) — the rule
+// stays at the call site while the entity-shape boilerplate comes from
+// the builder.
+func (b *MetamodelBuilder) WithValidation(rule metamodel.ValidationRule) *MetamodelBuilder {
+	b.meta.Validations = append(b.meta.Validations, rule)
+	return b
+}
+
 // WithRelation adds a relation definition to the metamodel.
 func (b *MetamodelBuilder) WithRelation(name, label string, from, to []string) *MetamodelBuilder {
 	b.meta.Relations[name] = metamodel.RelationDef{

--- a/internal/testutil/fixtures_test.go
+++ b/internal/testutil/fixtures_test.go
@@ -270,20 +270,31 @@ func TestRelation_Build_PanicsOnMissingTo(t *testing.T) {
 }
 
 func TestMetamodelBuilder_WithValidation(t *testing.T) {
-	rule := metamodel.ValidationRule{
+	first := metamodel.ValidationRule{
 		Name:       "status-not-empty",
 		EntityType: "ticket",
 		Severity:   "error",
 	}
+	second := metamodel.ValidationRule{
+		Name:       "owner-required",
+		EntityType: "ticket",
+		Severity:   "warning",
+	}
 	meta := NewMetamodel().
 		WithEntity("ticket", "Ticket", nil).
-		WithValidation(rule).
+		WithValidation(first).
+		WithValidation(second).
 		Build()
 
-	if len(meta.Validations) != 1 {
-		t.Fatalf("got %d validations, want 1", len(meta.Validations))
+	// Appends preserve call order — callers loop over rule slices and
+	// rule evaluation order is observable.
+	if len(meta.Validations) != 2 {
+		t.Fatalf("got %d validations, want 2", len(meta.Validations))
 	}
-	if meta.Validations[0].Name != rule.Name {
-		t.Errorf("rule name = %q, want %q", meta.Validations[0].Name, rule.Name)
+	if meta.Validations[0].Name != first.Name {
+		t.Errorf("rule[0] = %q, want %q", meta.Validations[0].Name, first.Name)
+	}
+	if meta.Validations[1].Name != second.Name {
+		t.Errorf("rule[1] = %q, want %q", meta.Validations[1].Name, second.Name)
 	}
 }

--- a/internal/testutil/fixtures_test.go
+++ b/internal/testutil/fixtures_test.go
@@ -268,3 +268,22 @@ func TestRelation_Build_PanicsOnMissingTo(t *testing.T) {
 	}()
 	Relation("test").From("A").Build()
 }
+
+func TestMetamodelBuilder_WithValidation(t *testing.T) {
+	rule := metamodel.ValidationRule{
+		Name:       "status-not-empty",
+		EntityType: "ticket",
+		Severity:   "error",
+	}
+	meta := NewMetamodel().
+		WithEntity("ticket", "Ticket", nil).
+		WithValidation(rule).
+		Build()
+
+	if len(meta.Validations) != 1 {
+		t.Fatalf("got %d validations, want 1", len(meta.Validations))
+	}
+	if meta.Validations[0].Name != rule.Name {
+		t.Errorf("rule name = %q, want %q", meta.Validations[0].Name, rule.Name)
+	}
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -3,6 +3,8 @@ package testutil
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -76,21 +78,23 @@ func AssertError(t *testing.T, err error) {
 	}
 }
 
-// AssertEqual checks that two values are equal.
+// AssertEqual checks that two values are deeply equal. DeepEqual (not
+// ==) so that slices, maps, and other uncomparable types diff instead
+// of panicking.
 func AssertEqual(t *testing.T, got, want interface{}) {
 	t.Helper()
 
-	if got != want {
-		t.Errorf("got %v, want %v", got, want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
 	}
 }
 
-// AssertNotEqual checks that two values are not equal.
+// AssertNotEqual checks that two values are not deeply equal.
 func AssertNotEqual(t *testing.T, got, notWant interface{}) {
 	t.Helper()
 
-	if got == notWant {
-		t.Errorf("got %v, expected different value", got)
+	if reflect.DeepEqual(got, notWant) {
+		t.Errorf("got %#v, expected different value", got)
 	}
 }
 
@@ -98,21 +102,7 @@ func AssertNotEqual(t *testing.T, got, notWant interface{}) {
 func AssertStringContains(t *testing.T, s, substr string) {
 	t.Helper()
 
-	if s == "" && substr != "" {
-		t.Errorf("string is empty, expected to contain %q", substr)
-		return
-	}
-
-	// Simple substring check
-	found := false
-	for i := 0; i+len(substr) <= len(s); i++ {
-		if s[i:i+len(substr)] == substr {
-			found = true
-			break
-		}
-	}
-
-	if !found {
+	if !strings.Contains(s, substr) {
 		t.Errorf("string %q does not contain %q", s, substr)
 	}
 }
@@ -121,16 +111,7 @@ func AssertStringContains(t *testing.T, s, substr string) {
 func AssertStringNotContains(t *testing.T, s, substr string) {
 	t.Helper()
 
-	// Simple substring check
-	found := false
-	for i := 0; i+len(substr) <= len(s); i++ {
-		if s[i:i+len(substr)] == substr {
-			found = true
-			break
-		}
-	}
-
-	if found {
+	if strings.Contains(s, substr) {
 		t.Errorf("string %q unexpectedly contains %q", s, substr)
 	}
 }

--- a/internal/validation/lua_test.go
+++ b/internal/validation/lua_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+	"github.com/Sourcehaven-BV/rela/internal/testutil"
 	"github.com/Sourcehaven-BV/rela/internal/tracer"
 )
 
@@ -79,33 +80,41 @@ func (m *mockWorkspace) services(projectRoot string) lua.ReadDeps {
 	}
 }
 
+// ticketMeta builds the single-entity-type metamodel these tests
+// share: a "ticket" with the given string properties and the
+// validation rules under test. The rules — the actual subject of each
+// test — stay at the call site; only the entity-shape boilerplate is
+// consolidated (TKT-R2KBG6; this file previously inlined the same
+// ~30-line metamodel literal in every test).
+func ticketMeta(rules []metamodel.ValidationRule, props ...string) *metamodel.Metamodel {
+	b := testutil.NewMetamodel().WithEntity("ticket", "Ticket", nil)
+	for _, p := range props {
+		b = b.WithEntityProperty("ticket", p, "string", false)
+	}
+	for _, r := range rules {
+		b = b.WithValidation(r)
+	}
+	return b.Build()
+}
+
 func TestLuaValidation_SingleViolation(t *testing.T) {
 	t.Parallel()
 	ws := newMockWorkspace()
-	meta := &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"ticket": {
-				Properties: map[string]metamodel.PropertyDef{
-					"status": {Type: "string"},
-				},
-			},
+	meta := ticketMeta([]metamodel.ValidationRule{
+		{
+			Name:        "status-not-empty",
+			Description: "Status must not be empty",
+			EntityType:  "ticket",
+			Lua: `
+			local status = entity.properties.status
+			if status == nil or status == "" then
+				return { message = "Status is required" }
+			end
+			return nil
+		`,
+			Severity: "error",
 		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:        "status-not-empty",
-				Description: "Status must not be empty",
-				EntityType:  "ticket",
-				Lua: `
-					local status = entity.properties.status
-					if status == nil or status == "" then
-						return { message = "Status is required" }
-					end
-					return nil
-				`,
-				Severity: "error",
-			},
-		},
-	}
+	}, "status")
 
 	entities := []*entity.Entity{
 		{
@@ -137,37 +146,27 @@ func TestLuaValidation_SingleViolation(t *testing.T) {
 func TestLuaValidation_MultipleViolations(t *testing.T) {
 	t.Parallel()
 	ws := newMockWorkspace()
-	meta := &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"ticket": {
-				Properties: map[string]metamodel.PropertyDef{
-					"status": {Type: "string"},
-					"owner":  {Type: "string"},
-				},
-			},
+	meta := ticketMeta([]metamodel.ValidationRule{
+		{
+			Name:        "required-fields",
+			Description: "Required fields check",
+			EntityType:  "ticket",
+			Lua: `
+			local issues = {}
+			if entity.properties.status == nil or entity.properties.status == "" then
+				table.insert(issues, { message = "Status is required", severity = "error" })
+			end
+			if entity.properties.owner == nil or entity.properties.owner == "" then
+				table.insert(issues, { message = "Owner is required", severity = "warning" })
+			end
+			if #issues > 0 then
+				return issues
+			end
+			return nil
+		`,
+			Severity: "error",
 		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:        "required-fields",
-				Description: "Required fields check",
-				EntityType:  "ticket",
-				Lua: `
-					local issues = {}
-					if entity.properties.status == nil or entity.properties.status == "" then
-						table.insert(issues, { message = "Status is required", severity = "error" })
-					end
-					if entity.properties.owner == nil or entity.properties.owner == "" then
-						table.insert(issues, { message = "Owner is required", severity = "warning" })
-					end
-					if #issues > 0 then
-						return issues
-					end
-					return nil
-				`,
-				Severity: "error",
-			},
-		},
-	}
+	}, "status", "owner")
 
 	entities := []*entity.Entity{
 		{
@@ -205,19 +204,14 @@ func TestLuaValidation_MultipleViolations(t *testing.T) {
 func TestLuaValidation_SeverityOverride(t *testing.T) {
 	t.Parallel()
 	ws := newMockWorkspace()
-	meta := &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"ticket": {Properties: map[string]metamodel.PropertyDef{}},
+	meta := ticketMeta([]metamodel.ValidationRule{
+		{
+			Name:       "test-rule",
+			EntityType: "ticket",
+			Lua:        `return { message = "Custom warning", severity = "warning" }`,
+			Severity:   "error", // default is error, but Lua overrides to warning
 		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:       "test-rule",
-				EntityType: "ticket",
-				Lua:        `return { message = "Custom warning", severity = "warning" }`,
-				Severity:   "error", // default is error, but Lua overrides to warning
-			},
-		},
-	}
+	})
 
 	entities := []*entity.Entity{
 		{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{}},
@@ -237,19 +231,14 @@ func TestLuaValidation_SeverityOverride(t *testing.T) {
 func TestLuaValidation_SeverityDefault(t *testing.T) {
 	t.Parallel()
 	ws := newMockWorkspace()
-	meta := &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"ticket": {Properties: map[string]metamodel.PropertyDef{}},
+	meta := ticketMeta([]metamodel.ValidationRule{
+		{
+			Name:       "test-rule",
+			EntityType: "ticket",
+			Lua:        `return { message = "Uses default severity" }`, // no severity specified
+			Severity:   "warning",
 		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:       "test-rule",
-				EntityType: "ticket",
-				Lua:        `return { message = "Uses default severity" }`, // no severity specified
-				Severity:   "warning",
-			},
-		},
-	}
+	})
 
 	entities := []*entity.Entity{
 		{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{}},
@@ -315,18 +304,13 @@ func TestLuaValidation_ReturnValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			meta := &metamodel.Metamodel{
-				Entities: map[string]metamodel.EntityDef{
-					"ticket": {Properties: map[string]metamodel.PropertyDef{}},
+			meta := ticketMeta([]metamodel.ValidationRule{
+				{
+					Name:       "test-rule",
+					EntityType: "ticket",
+					Lua:        tt.lua,
 				},
-				Validations: []metamodel.ValidationRule{
-					{
-						Name:       "test-rule",
-						EntityType: "ticket",
-						Lua:        tt.lua,
-					},
-				},
-			}
+			})
 
 			entities := []*entity.Entity{
 				{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{}},
@@ -346,43 +330,33 @@ func TestLuaValidation_ReturnValues(t *testing.T) {
 func TestLuaValidation_EntityContext(t *testing.T) {
 	t.Parallel()
 	ws := newMockWorkspace()
-	meta := &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"ticket": {
-				Properties: map[string]metamodel.PropertyDef{
-					"title":  {Type: "string"},
-					"status": {Type: "string"},
-				},
-			},
+	meta := ticketMeta([]metamodel.ValidationRule{
+		{
+			Name:       "check-entity-context",
+			EntityType: "ticket",
+			Lua: `
+			-- Check entity.id and entity.type are available
+			if entity.id ~= "TKT-001" then
+				return { message = "entity.id mismatch" }
+			end
+			if entity.type ~= "ticket" then
+				return { message = "entity.type mismatch" }
+			end
+			-- Check prop() method works
+			if entity:prop("title") ~= "Test Ticket" then
+				return { message = "title mismatch" }
+			end
+			if entity:prop("status") ~= "open" then
+				return { message = "status mismatch" }
+			end
+			-- Check prop() with default
+			if entity:prop("missing", "default") ~= "default" then
+				return { message = "default value mismatch" }
+			end
+			return nil
+		`,
 		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:       "check-entity-context",
-				EntityType: "ticket",
-				Lua: `
-					-- Check entity.id and entity.type are available
-					if entity.id ~= "TKT-001" then
-						return { message = "entity.id mismatch" }
-					end
-					if entity.type ~= "ticket" then
-						return { message = "entity.type mismatch" }
-					end
-					-- Check prop() method works
-					if entity:prop("title") ~= "Test Ticket" then
-						return { message = "title mismatch" }
-					end
-					if entity:prop("status") ~= "open" then
-						return { message = "status mismatch" }
-					end
-					-- Check prop() with default
-					if entity:prop("missing", "default") ~= "default" then
-						return { message = "default value mismatch" }
-					end
-					return nil
-				`,
-			},
-		},
-	}
+	}, "title", "status")
 
 	entities := []*entity.Entity{
 		{
@@ -406,28 +380,23 @@ func TestLuaValidation_EntityContext(t *testing.T) {
 func TestLuaValidation_ReadOnlyWorkspace(t *testing.T) {
 	t.Parallel()
 	ws := newMockWorkspace()
-	meta := &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"ticket": {Properties: map[string]metamodel.PropertyDef{}},
+	meta := ticketMeta([]metamodel.ValidationRule{
+		{
+			Name:       "cross-entity-lookup",
+			EntityType: "ticket",
+			Lua: `
+			-- Can look up other entities
+			local other = rela.get_entity("PARENT-001")
+			if not other then
+				return { message = "get_entity failed" }
+			end
+			if other:prop("status") ~= "approved" then
+				return { message = "status mismatch" }
+			end
+			return nil
+		`,
 		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:       "cross-entity-lookup",
-				EntityType: "ticket",
-				Lua: `
-					-- Can look up other entities
-					local other = rela.get_entity("PARENT-001")
-					if not other then
-						return { message = "get_entity failed" }
-					end
-					if other:prop("status") ~= "approved" then
-						return { message = "status mismatch" }
-					end
-					return nil
-				`,
-			},
-		},
-	}
+	})
 
 	entities := []*entity.Entity{
 		{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{}},
@@ -444,27 +413,22 @@ func TestLuaValidation_ReadOnlyWorkspace(t *testing.T) {
 func TestLuaValidation_MutationsBlocked(t *testing.T) {
 	t.Parallel()
 	ws := newMockWorkspace()
-	meta := &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"ticket": {Properties: map[string]metamodel.PropertyDef{}},
+	meta := ticketMeta([]metamodel.ValidationRule{
+		{
+			Name:       "try-create",
+			EntityType: "ticket",
+			Lua: `
+			local ok, err = pcall(function()
+				rela.create_entity("ticket", {title = "New"})
+			end)
+			-- Should fail, if it succeeded that's a problem
+			if ok then
+				return { message = "mutation should have been blocked" }
+			end
+			return nil
+		`,
 		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:       "try-create",
-				EntityType: "ticket",
-				Lua: `
-					local ok, err = pcall(function()
-						rela.create_entity("ticket", {title = "New"})
-					end)
-					-- Should fail, if it succeeded that's a problem
-					if ok then
-						return { message = "mutation should have been blocked" }
-					end
-					return nil
-				`,
-			},
-		},
-	}
+	})
 
 	entities := []*entity.Entity{
 		{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{}},
@@ -481,30 +445,20 @@ func TestLuaValidation_MutationsBlocked(t *testing.T) {
 func TestLuaValidation_CombinedWithWhenThen(t *testing.T) {
 	t.Parallel()
 	ws := newMockWorkspace()
-	meta := &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"ticket": {
-				Properties: map[string]metamodel.PropertyDef{
-					"status":   {Type: "string"},
-					"priority": {Type: "string"},
-				},
-			},
+	meta := ticketMeta([]metamodel.ValidationRule{
+		{
+			Name:       "ready-needs-priority-and-lua-check",
+			EntityType: "ticket",
+			When:       []string{"status=ready"},
+			Then:       []string{"priority!="},
+			Lua: `
+			if entity:prop("priority") == "invalid" then
+				return { message = "Priority cannot be 'invalid'" }
+			end
+			return nil
+		`,
 		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:       "ready-needs-priority-and-lua-check",
-				EntityType: "ticket",
-				When:       []string{"status=ready"},
-				Then:       []string{"priority!="},
-				Lua: `
-					if entity:prop("priority") == "invalid" then
-						return { message = "Priority cannot be 'invalid'" }
-					end
-					return nil
-				`,
-			},
-		},
-	}
+	}, "status", "priority")
 
 	entities := []*entity.Entity{
 		// Passes both when/then and Lua
@@ -540,18 +494,13 @@ func TestLuaValidation_CombinedWithWhenThen(t *testing.T) {
 func TestLuaValidation_SyntaxError(t *testing.T) {
 	t.Parallel()
 	ws := newMockWorkspace()
-	meta := &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"ticket": {Properties: map[string]metamodel.PropertyDef{}},
+	meta := ticketMeta([]metamodel.ValidationRule{
+		{
+			Name:       "syntax-error",
+			EntityType: "ticket",
+			Lua:        `this is not valid lua!!!`,
 		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:       "syntax-error",
-				EntityType: "ticket",
-				Lua:        `this is not valid lua!!!`,
-			},
-		},
-	}
+	})
 
 	entities := []*entity.Entity{
 		{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{}},
@@ -569,18 +518,13 @@ func TestLuaValidation_SyntaxError(t *testing.T) {
 func TestLuaValidation_RuntimeError(t *testing.T) {
 	t.Parallel()
 	ws := newMockWorkspace()
-	meta := &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"ticket": {Properties: map[string]metamodel.PropertyDef{}},
+	meta := ticketMeta([]metamodel.ValidationRule{
+		{
+			Name:       "runtime-error",
+			EntityType: "ticket",
+			Lua:        `return nil_variable.property`,
 		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:       "runtime-error",
-				EntityType: "ticket",
-				Lua:        `return nil_variable.property`,
-			},
-		},
-	}
+	})
 
 	entities := []*entity.Entity{
 		{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{}},
@@ -617,22 +561,13 @@ func TestLuaValidation_ScriptFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	meta := &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"ticket": {
-				Properties: map[string]metamodel.PropertyDef{
-					"status": {Type: "string"},
-				},
-			},
+	meta := ticketMeta([]metamodel.ValidationRule{
+		{
+			Name:       "status-valid",
+			EntityType: "ticket",
+			LuaFile:    "validate-status.lua",
 		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:       "status-valid",
-				EntityType: "ticket",
-				LuaFile:    "validate-status.lua",
-			},
-		},
-	}
+	}, "status")
 
 	entities := []*entity.Entity{
 		{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{"status": "valid"}},
@@ -664,18 +599,13 @@ func TestLuaValidation_ScriptFileNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	meta := &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"ticket": {Properties: map[string]metamodel.PropertyDef{}},
+	meta := ticketMeta([]metamodel.ValidationRule{
+		{
+			Name:       "missing-script",
+			EntityType: "ticket",
+			LuaFile:    "nonexistent.lua",
 		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:       "missing-script",
-				EntityType: "ticket",
-				LuaFile:    "nonexistent.lua",
-			},
-		},
-	}
+	})
 
 	entities := []*entity.Entity{
 		{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{}},
@@ -693,39 +623,30 @@ func TestLuaValidation_ScriptFileNotFound(t *testing.T) {
 func TestLuaValidation_CrossEntityValidation(t *testing.T) {
 	t.Parallel()
 	ws := newMockWorkspace()
-	meta := &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"ticket": {
-				Properties: map[string]metamodel.PropertyDef{
-					"status": {Type: "string"},
-				},
-			},
-		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:        "parent-must-be-approved",
-				Description: "If ticket has parent, parent must be approved",
-				EntityType:  "ticket",
-				Lua: `
-					-- Get relations where this entity is "from" with type "child-of"
-					local rels = rela.get_relations({from = entity.id, type = "child-of"})
-					if #rels == 0 then
-						return nil -- no parent, OK
-					end
+	meta := ticketMeta([]metamodel.ValidationRule{
+		{
+			Name:        "parent-must-be-approved",
+			Description: "If ticket has parent, parent must be approved",
+			EntityType:  "ticket",
+			Lua: `
+			-- Get relations where this entity is "from" with type "child-of"
+			local rels = rela.get_relations({from = entity.id, type = "child-of"})
+			if #rels == 0 then
+				return nil -- no parent, OK
+			end
 
-					local parent = rela.get_entity(rels[1].to)
-					if not parent then
-						return nil -- parent doesn't exist, OK (shouldn't happen)
-					end
+			local parent = rela.get_entity(rels[1].to)
+			if not parent then
+				return nil -- parent doesn't exist, OK (shouldn't happen)
+			end
 
-					if parent:prop("status") ~= "approved" then
-						return { message = "Parent ticket must be approved" }
-					end
-					return nil
-				`,
-			},
+			if parent:prop("status") ~= "approved" then
+				return { message = "Parent ticket must be approved" }
+			end
+			return nil
+		`,
 		},
-	}
+	}, "status")
 
 	// TKT-001 has a parent (PARENT-001) which is approved - should pass
 	// TKT-002 has no parent - should pass
@@ -745,19 +666,14 @@ func TestLuaValidation_CrossEntityValidation(t *testing.T) {
 func TestLuaValidation_Timeout(t *testing.T) {
 	t.Parallel()
 	ws := newMockWorkspace()
-	meta := &metamodel.Metamodel{
-		Entities: map[string]metamodel.EntityDef{
-			"ticket": {Properties: map[string]metamodel.PropertyDef{}},
+	meta := ticketMeta([]metamodel.ValidationRule{
+		{
+			Name:       "infinite-loop",
+			EntityType: "ticket",
+			// This would run forever without timeout
+			Lua: `while true do end`,
 		},
-		Validations: []metamodel.ValidationRule{
-			{
-				Name:       "infinite-loop",
-				EntityType: "ticket",
-				// This would run forever without timeout
-				Lua: `while true do end`,
-			},
-		},
-	}
+	})
 
 	entities := []*entity.Entity{
 		{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{}},
@@ -828,18 +744,13 @@ func TestLuaValidation_PathTraversal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			meta := &metamodel.Metamodel{
-				Entities: map[string]metamodel.EntityDef{
-					"ticket": {Properties: map[string]metamodel.PropertyDef{}},
+			meta := ticketMeta([]metamodel.ValidationRule{
+				{
+					Name:       "test-rule",
+					EntityType: "ticket",
+					LuaFile:    tt.luaFile,
 				},
-				Validations: []metamodel.ValidationRule{
-					{
-						Name:       "test-rule",
-						EntityType: "ticket",
-						LuaFile:    tt.luaFile,
-					},
-				},
-			}
+			})
 
 			entities := []*entity.Entity{
 				{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{}},

--- a/tickets/entities/implementation-checklists/IMPL-QRAIMK.md
+++ b/tickets/entities/implementation-checklists/IMPL-QRAIMK.md
@@ -1,0 +1,46 @@
+---
+id: IMPL-QRAIMK
+type: implementation-checklist
+title: 'Implementation: Fixture consolidation: mcp on appbuildtest, validation metamodel dedup, testutil fixes'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (WithValidation builder self-test incl. append ordering)
+- [x] Integration tests written — existing mcp/validation suites are the coverage; they run on the consolidated fixtures
+- [x] Happy path implemented (all three parts of TKT-R2KBG6)
+- [x] Edge cases from planning handled (Config loader delta verified inert — loadDataEntryConfig swallows both error shapes; templater miss path verified equivalent)
+- [x] Error handling in place
+
+## Test Quality
+
+- [x] Using fixture builders or factories (the point of the ticket)
+- [x] No hardcoded values in assertions
+- [x] Only specifying values that matter (ticketMeta keeps rules at call sites)
+- [x] Interpolated values constructed from objects
+- [x] Property comparisons use original object
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+- mcp: test_helpers_test.go 139 → ~48 lines; the whole hand-rolled service graph (incl. the nopTemplater workaround and nopConfigLoader) replaced by appbuildtest accessors. mcp green under `-race -count=2 -shuffle=on`; dispatch tests (TKT-TLQ94B) still build via NewServer.
+- validation: 16 of 17 inline metamodel literals migrated to ticketMeta (script with per-site safety checks: single ticket type, string-only props, no extra metamodel fields; 1 site skipped — no Validations section). Reviewer diffed migrated sites against the previous revision: semantically identical.
+- testutil: AssertEqual/AssertNotEqual → reflect.DeepEqual (reviewer verified all 26 existing callers compare scalars where == and DeepEqual agree — no behavior flips); AssertStringContains/NotContains → strings.Contains (empty-string edge cases verified equivalent).
+- Code review: 0 critical, 0 significant, 2 nits (both fixed: ProjectRoot-split comment, ordering test). Reviewer independently verified no semantic drift on all four flagged axes (search backfill, templater miss path, config loader, autocascade gating) and noted backfill failures are now intentionally louder (panic on bad seed data).
+- Full `just ci` green.
+
+## Quality
+
+- [x] Code follows project patterns (appbuildtest is the established fixture seam)
+- [x] DRY — that's the ticket
+- [x] No security issues introduced
+- [x] No silent failures (backfill strictness improved)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-NASDVM.md
+++ b/tickets/entities/planning-checklists/PLAN-NASDVM.md
@@ -1,0 +1,48 @@
+---
+id: PLAN-NASDVM
+type: planning-checklist
+title: 'Planning: Fixture consolidation'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined — see TKT-R2KBG6 body; CLAUDE.md update dropped at reviewer request
+- [x] Acceptance criteria: (1) mcp test wiring single-sourced via appbuildtest, no hand-rolled service graph remains; (2) validation/lua_test.go has one metamodel fixture instead of ~20 literals, tests semantically unchanged; (3) testutil.AssertEqual handles uncomparable types via reflect.DeepEqual, AssertStringContains uses strings.Contains; (4) all affected packages green under -race -count=2 -shuffle=on
+
+## Research
+
+- [x] ~~/research~~ (N/A: test-only consolidation)
+- [x] Verified appbuildtest covers mcp's needs before committing to the approach: in-memory bleve + backfill for caller-supplied stores (fixture.go:186-194), `Services.LuaWriteDeps()` accessor exists, templater is a real FSTemplater over the fixture FS (strictly better than the nopTemplater workaround)
+- [x] Checked the WithStore caveat (no observer auto-wiring → post-construction writes don't reach the index) — matches the current mcp fixture's behavior exactly, so no test semantics change
+
+## Approach
+
+- [x] Replace newTestDeps body with appbuildtest.New + accessor mapping; keep nopWatcher stub; keep Deps.ProjectRoot = t.TempDir() (lua_run path semantics)
+- [x] validation/lua_test.go: one package fixture (testutil.MetamodelBuilder + EntityBuilder) + per-test deltas
+- [x] testutil fixes with their existing self-tests extended
+- [x] Alternatives: merging mockWorkspace types rejected (consumer-side stubs per CLAUDE.md); adding observer wiring to WithStore rejected (out of scope, current semantics preserved)
+
+## Security Considerations
+
+- [x] N/A — test-only
+
+## Test Plan
+
+- [x] -race -count=2 -shuffle=on on mcp, validation, testutil; full just ci
+- [x] Dispatch tests (TKT-TLQ94B) must stay on NewServer — they are the canary that the ported wiring still satisfies NewServer's nil checks
+
+## Risk Assessment
+
+- [x] Effort s. Risks: config loader behavior delta (nopConfigLoader errors vs FSLoader not-found — both error; verify no test pins the nop message); search-index timing differences (none expected, same backfill shape)
+
+## Documentation Planning
+
+- [x] N/A (test-only)
+
+## Design Review
+
+- [x] ~~/design-review~~ (N/A-with-substitute: approach discussed and amended in working session 2026-06-10 — CLAUDE.md item dropped, mockWorkspace merge explicitly rejected)

--- a/tickets/entities/review-checklists/REV-C5PVPZ.md
+++ b/tickets/entities/review-checklists/REV-C5PVPZ.md
@@ -24,4 +24,4 @@ status: done
 
 - [x] First `just ci` run failed on exactly the race the reviewer predicted — fix verified by 4 consecutive shuffled race runs and a clean second `just ci`
 
-**PR:** (added once created)
+**PR:** https://github.com/sourcehaven-bv/rela/pull/958 (stacked on #956)

--- a/tickets/entities/review-checklists/REV-XF3L7I.md
+++ b/tickets/entities/review-checklists/REV-XF3L7I.md
@@ -1,0 +1,26 @@
+---
+id: REV-XF3L7I
+type: review-checklist
+title: 'Review: Fixture consolidation'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] `-race -count=2 -shuffle=on` green on mcp, validation, testutil
+- [x] `golangci-lint run` — 0 issues
+- [x] Full `just ci` green
+
+## Code Review
+
+- [x] `/code-review` run (cranky-code-reviewer on the consolidation diff with explicit drift-hunting instructions)
+- [x] Findings: 0 critical, 0 significant, 2 nits — RR-K2WMDB (ProjectRoot split comment), RR-ZE10ZG (ordering test), both addressed
+- [x] Reviewer independently verified no semantic drift: templater miss path equivalent (and the TKT-TLQ94B panic class structurally prevented), config loader delta inert, search backfill semantics identical, autocascade gating identical, ticketMeta migration faithful per-site, AssertEqual change safe for all 26 callers
+
+## Verification
+
+- [x] mcp dispatch tests (the NewServer canary) green on the consolidated wiring
+
+**PR:** (added once created)

--- a/tickets/entities/review-checklists/REV-XF3L7I.md
+++ b/tickets/entities/review-checklists/REV-XF3L7I.md
@@ -23,4 +23,4 @@ status: done
 
 - [x] mcp dispatch tests (the NewServer canary) green on the consolidated wiring
 
-**PR:** (added once created)
+**PR:** https://github.com/sourcehaven-bv/rela/pull/963 (stacked on #958)

--- a/tickets/entities/review-responses/RR-K2WMDB.md
+++ b/tickets/entities/review-responses/RR-K2WMDB.md
@@ -1,0 +1,9 @@
+---
+id: RR-K2WMDB
+type: review-response
+title: ProjectRoot split between Deps and LuaWriteDeps undocumented
+finding: mcp Deps.ProjectRoot is a real t.TempDir() while svc.LuaWriteDeps().ReadDeps.ProjectRoot is the fixture's in-memory /project — inert today but a tripwire for future Lua-write MCP tests.
+severity: nit
+resolution: Comment added on the ProjectRoot field documenting the intentional split and when to align the two.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ZE10ZG.md
+++ b/tickets/entities/review-responses/RR-ZE10ZG.md
@@ -1,0 +1,9 @@
+---
+id: RR-ZE10ZG
+type: review-response
+title: WithValidation self-test missed append-ordering contract
+finding: Single-rule test didn't exercise the order-preserving accumulation that ticketMeta relies on.
+severity: nit
+resolution: Test extended to two rules asserting Validations[0]/[1] order.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-R2KBG6.md
+++ b/tickets/entities/tickets/TKT-R2KBG6.md
@@ -1,0 +1,33 @@
+---
+id: TKT-R2KBG6
+type: ticket
+title: 'Fixture consolidation: mcp on appbuildtest, validation metamodel dedup, testutil fixes'
+kind: test
+priority: medium
+effort: s
+status: done
+---
+
+## Problem
+
+Test-fixture sprawl identified in the test-quality review:
+
+1. `internal/mcp/test_helpers_test.go` `newTestDeps` hand-duplicates ~75 lines of production service wiring (tracer, bleve index + backfill, validator, autocascade, entitymanager) with a self-acknowledged drift risk. The nil-templater booby trap found by TKT-TLQ94B lived in exactly this hand-rolled wiring. `appbuildtest` exists to prevent this and is already used by dataentry/cli.
+2. `validation/lua_test.go` inlines a ~30-line metamodel + entity literal ~20 times; a schema-shape change touches all of them. `internal/testutil` has metamodel-aware builders that nobody there uses.
+3. `testutil` itself has sharp edges: `AssertEqual` compares `interface{}` with `!=` (panics on uncomparable types, weak failure output); `AssertStringContains` hand-rolls a byte loop instead of `strings.Contains`.
+
+## Approach (agreed with reviewer in session)
+
+1. Port `mcp.newTestDeps` to `appbuildtest.New(meta, WithStore(st))` — Services exposes everything mcp.Deps needs incl. `LuaWriteDeps()`; bleve + backfill semantics match the current fixture. Keep the package-local `nopWatcher` (consumer-side stub, idiomatic).
+2. Do NOT merge the three `mockWorkspace` types (consumer-side stubs stay per CLAUDE.md); deduplicate the shared metamodel + seeded-store construction instead.
+3. Demonstration migration: `validation/lua_test.go` inline metamodel literals → one canned fixture + per-test deltas via testutil builders.
+4. Fix testutil sharp edges (`reflect.DeepEqual`, `strings.Contains`).
+
+Dropped from the original proposal at reviewer request: the CLAUDE.md
+test-conventions update (direction is a future all-stdlib rewrite; don't
+enshrine a mixed convention).
+
+## Verification
+
+- mcp + validation + testutil packages green under `-race -count=2 -shuffle=on`; full `just ci` green; CI green on PR.
+- The mcp port must not weaken the dispatch tests (TKT-TLQ94B) — they keep building via NewServer.

--- a/tickets/relations/TKT-R2KBG6--affects--test-fixtures.md
+++ b/tickets/relations/TKT-R2KBG6--affects--test-fixtures.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R2KBG6
+relation: affects
+to: test-fixtures
+---

--- a/tickets/relations/TKT-R2KBG6--has-implementation--IMPL-QRAIMK.md
+++ b/tickets/relations/TKT-R2KBG6--has-implementation--IMPL-QRAIMK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R2KBG6
+relation: has-implementation
+to: IMPL-QRAIMK
+---

--- a/tickets/relations/TKT-R2KBG6--has-planning--PLAN-NASDVM.md
+++ b/tickets/relations/TKT-R2KBG6--has-planning--PLAN-NASDVM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R2KBG6
+relation: has-planning
+to: PLAN-NASDVM
+---

--- a/tickets/relations/TKT-R2KBG6--has-review--REV-XF3L7I.md
+++ b/tickets/relations/TKT-R2KBG6--has-review--REV-XF3L7I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R2KBG6
+relation: has-review
+to: REV-XF3L7I
+---

--- a/tickets/relations/TKT-R2KBG6--has-review-response--RR-K2WMDB.md
+++ b/tickets/relations/TKT-R2KBG6--has-review-response--RR-K2WMDB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R2KBG6
+relation: has-review-response
+to: RR-K2WMDB
+---

--- a/tickets/relations/TKT-R2KBG6--has-review-response--RR-ZE10ZG.md
+++ b/tickets/relations/TKT-R2KBG6--has-review-response--RR-ZE10ZG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R2KBG6
+relation: has-review-response
+to: RR-ZE10ZG
+---

--- a/tickets/relations/TKT-R2KBG6--implements--FEAT-testutil.md
+++ b/tickets/relations/TKT-R2KBG6--implements--FEAT-testutil.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R2KBG6
+relation: implements
+to: FEAT-testutil
+---


### PR DESCRIPTION
**Stacked on #958** (`test/parallel-wave`) — retargets to develop as the stack merges. Full ticket flow in tickets/ (TKT-R2KBG6).

## mcp test wiring single-sourced (`internal/mcp/test_helpers_test.go`, 139 → 48 lines)

`newTestDeps` hand-mirrored ~75 lines of the production `cli.mcpServices` graph (tracer, bleve + backfill, validator, autocascade, entitymanager) with a self-acknowledged drift risk — the nil-templater booby trap TKT-TLQ94B caught lived exactly there. Now: `appbuildtest.New(meta, WithStore(st))` + `Services` accessors (incl. `LuaWriteDeps()`), `svc.Close()` via `t.Cleanup`. The `nopTemplater`/`nopConfigLoader` stubs are gone (appbuildtest supplies a real FSTemplater whose template-miss path is equivalent, and a real config loader whose not-found error lands in the same swallow as the old nop's error). Dispatch tests keep building through `NewServer` — they remain the wiring canary.

## validation metamodel dedup (`internal/validation/lua_test.go`)

16 of 17 inline ~30-line metamodel literals replaced by a `ticketMeta` helper built on a new `testutil.MetamodelBuilder.WithValidation` (with self-test incl. append ordering). The Lua rules — each test's actual subject — stay at the call sites; only the entity-shape shell is consolidated. Migration was scripted with per-site safety checks (single ticket type, string-only props, no extra metamodel fields); the one non-conforming site was left untouched.

## testutil sharp edges

- `AssertEqual`/`AssertNotEqual`: `!=` on `interface{}` (panicked on uncomparable types) → `reflect.DeepEqual` with `%#v` output. All 26 existing callers compare scalars where the two agree — verified no behavior flips.
- `AssertStringContains`/`NotContains`: hand-rolled byte loops → `strings.Contains` (edge cases verified equivalent).

Dropped from the original proposal per reviewer: the CLAUDE.md test-conventions update (direction is a future all-stdlib rewrite).

## Review

Cranky review with explicit drift-hunting instructions: **0 critical, 0 significant**, 2 nits (both fixed — RR-K2WMDB, RR-ZE10ZG). Reviewer independently verified all four drift axes clean (templater miss path, config loader, search backfill, autocascade gating), the migration faithful per-site, and noted backfill failures are now intentionally louder.

## Verification

`-race -count=2 -shuffle=on` green on mcp/validation/testutil; full `just ci` green.