### PR TITLE
ci: weekly fuzz sweep over all targets with auto-filed issues (TKT-PCLGGL)

### DIFF
--- a/.github/workflows/fuzz-sweep.yml
+++ b/.github/workflows/fuzz-sweep.yml
@@ -1,0 +1,96 @@
+name: Fuzz Sweep
+
+# Weekly sweep over every fuzz target in the repo (the per-PR fuzz job
+# in ci.yml runs only a 3-target smoke). Targets are discovered by
+# scripts/fuzz-all.sh, so new Fuzz* functions are swept automatically.
+#
+# On failure: the crashing inputs are uploaded as an artifact and a
+# GitHub issue is filed (or an existing open one gets a comment) so
+# findings don't silently rot in the Actions tab.
+#
+# Note: the pgstore fuzz targets self-skip without
+# RELA_TEST_DATABASE_URL; wiring a postgres service into this sweep is
+# a known follow-up.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC, before the weekly security scan
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  fuzz-sweep:
+    name: Fuzz all targets
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: Run all fuzz targets
+        run: FUZZTIME=25s scripts/fuzz-all.sh
+
+      - name: Upload failing inputs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-failing-inputs
+          path: |
+            internal/**/testdata/fuzz/**
+            fuzz-failures.txt
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: File or update fuzz-failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Config/setup errors (script exit 2 — bad FUZZTIME, broken
+          # build, zero targets) produce no summary file and should fail
+          # the run without filing a "fuzz found a bug" issue.
+          if [ ! -f fuzz-failures.txt ]; then
+            echo "No target-failure summary — setup error, not filing an issue."
+            exit 0
+          fi
+          gh label create fuzz-failure \
+            --description "Filed automatically by the weekly fuzz sweep" \
+            --color D93F0B --force
+
+          {
+            echo "The weekly fuzz sweep failed."
+            echo ""
+            echo "Failed targets (package, target, kind — fuzz-crash means a"
+            echo "crashing input was found; error means the target failed for"
+            echo "an infrastructure reason, e.g. a seed-corpus regression):"
+            echo '```'
+            cat fuzz-failures.txt 2>/dev/null || echo "(summary missing — see run log)"
+            echo '```'
+            echo ""
+            echo "Run: ${RUN_URL}"
+            echo ""
+            echo "The crashing inputs are attached to the run as the **fuzz-failing-inputs** artifact."
+            echo "To reproduce locally: copy the artifact's \`testdata/fuzz/<Target>/\` files into the"
+            echo "package directory, then \`go test -run='^Fuzz<Target>\$' ./<pkg>\` — the failing input"
+            echo "now runs as a regular regression test. Once fixed, commit the input as a seed."
+          } > issue-body.md
+
+          existing="$(gh issue list --label fuzz-failure --state open \
+            --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file issue-body.md
+          else
+            gh issue create \
+              --title "Weekly fuzz sweep found failures" \
+              --label fuzz-failure \
+              --body-file issue-body.md
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bin/
 /rela-server
 /rela-desktop
 coverage.out
+fuzz-failures.txt
 coverage_test.out
 coverage.txt
 coverage.html

--- a/internal/store/fsstore/relation.go
+++ b/internal/store/fsstore/relation.go
@@ -2,10 +2,7 @@ package fsstore
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"iter"
-	"strings"
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -127,11 +124,8 @@ func (s *FSStore) CreateRelation(
 			return nil, err
 		}
 	}
-	if strings.Contains(relType, "--") {
-		return nil, fmt.Errorf("store: relation type %q contains consecutive dashes", relType)
-	}
-	if relType == "" {
-		return nil, errors.New("store: empty relation type")
+	if err := storeutil.ValidateRelationType(relType); err != nil {
+		return nil, err
 	}
 
 	s.mu.Lock()

--- a/internal/store/fsstore/testdata/fuzz/FuzzAttachmentKeyCollision/0cd11935bf92a044
+++ b/internal/store/fsstore/testdata/fuzz/FuzzAttachmentKeyCollision/0cd11935bf92a044
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("\x00")
+string("0")

--- a/internal/store/fsstore/testdata/fuzz/FuzzAttachmentKeyCollision/2289f44c04f5ed07
+++ b/internal/store/fsstore/testdata/fuzz/FuzzAttachmentKeyCollision/2289f44c04f5ed07
@@ -1,0 +1,3 @@
+go test fuzz v1
+string(":")
+string("0")

--- a/internal/store/fsstore/testdata/fuzz/FuzzRelationKeyCollision/2da5aa149625a656
+++ b/internal/store/fsstore/testdata/fuzz/FuzzRelationKeyCollision/2da5aa149625a656
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("0")
+string("0")
+string("\x7f")

--- a/internal/store/fsstore/testdata/fuzz/FuzzRelationKeyCollision/6783c161c940a194
+++ b/internal/store/fsstore/testdata/fuzz/FuzzRelationKeyCollision/6783c161c940a194
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("0")
+string("0")
+string(":")

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -21,7 +21,6 @@ package memstore
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"iter"
@@ -562,16 +561,12 @@ func (m *MemStore) CreateRelation(
 			return nil, err
 		}
 	}
-	if strings.Contains(relType, "--") {
-		return nil, fmt.Errorf("store: relation type %q contains consecutive dashes", relType)
+	if err := storeutil.ValidateRelationType(relType); err != nil {
+		return nil, err
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-
-	if relType == "" {
-		return nil, errors.New("store: empty relation type")
-	}
 
 	r := entity.NewRelation(from, relType, to)
 	r.UpdatedAt = time.Now()

--- a/internal/store/memstore/testdata/fuzz/FuzzAttachmentKeyCollision/c71b43c7d4cf81d1
+++ b/internal/store/memstore/testdata/fuzz/FuzzAttachmentKeyCollision/c71b43c7d4cf81d1
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("\x02")
+string("0")

--- a/internal/store/memstore/testdata/fuzz/FuzzRelationKeyCollision/b4f07851bc9f00cf
+++ b/internal/store/memstore/testdata/fuzz/FuzzRelationKeyCollision/b4f07851bc9f00cf
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("\x00")
+string("0")
+string("0")

--- a/internal/store/pgstore/relation.go
+++ b/internal/store/pgstore/relation.go
@@ -125,11 +125,8 @@ func (s *Store) CreateRelation(
 			return nil, err
 		}
 	}
-	if relType == "" {
-		return nil, errors.New("store: empty relation type")
-	}
-	if strings.Contains(relType, "--") {
-		return nil, fmt.Errorf("store: relation type %q contains consecutive dashes", relType)
+	if err := storeutil.ValidateRelationType(relType); err != nil {
+		return nil, err
 	}
 
 	var props map[string]interface{}

--- a/internal/store/storetest/fuzz.go
+++ b/internal/store/storetest/fuzz.go
@@ -12,10 +12,33 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/storeutil"
 )
 
 // FuzzFactory returns a fresh store without needing *testing.T (for use inside f.Fuzz).
 type FuzzFactory func() store.Store
+
+// createEntityOrSkip applies the directional validity oracle for an
+// entity ID (TKT-PCLGGL): anything the shared storeutil.ValidateID
+// rejects MUST be rejected by the store; anything it accepts MAY still
+// be rejected by a stricter backend (fsstore rejects ':' for Windows
+// compat) — only an accepted write proceeds to round-trip assertions.
+// Returns true when the entity was created.
+//
+// Vacuity anchor: a backend that rejected every write would pass these
+// fuzz targets trivially, but the conformance suite (storetest.RunAll's
+// Entity tests) asserts plain creates succeed, and every backend runs
+// both. These fuzz targets only chase key-collision and round-trip
+// divergence; over-rejection fails loudly in the conformance suite.
+func createEntityOrSkip(t *testing.T, s store.Store, id string) bool {
+	t.Helper()
+	err := s.CreateEntity(context.Background(), entity.New(id, "t"))
+	if storeutil.ValidateID(id) != nil {
+		assert.Error(t, err)
+		return false
+	}
+	return err == nil
+}
 
 // FuzzRelationKeyCollision verifies that relation key construction never
 // causes collisions or round-trip failures.
@@ -31,24 +54,18 @@ func FuzzRelationKeyCollision(f *testing.F, factory FuzzFactory) {
 		s := factory()
 		bg := context.Background()
 
-		err1 := s.CreateEntity(bg, entity.New(from, "t"))
-		if from == "" || strings.Contains(from, "--") {
-			assert.Error(t, err1)
+		// Directional oracle — see createEntityOrSkip. The previous
+		// hand-modeled ""/"--" checks went stale when control-character
+		// rejection was added and produced false fuzz failures.
+		if !createEntityOrSkip(t, s, from) {
 			return
 		}
-		require.NoError(t, err1)
-
-		if from != to {
-			err2 := s.CreateEntity(bg, entity.New(to, "t"))
-			if to == "" || strings.Contains(to, "--") {
-				assert.Error(t, err2)
-				return
-			}
-			require.NoError(t, err2)
+		if from != to && !createEntityOrSkip(t, s, to) {
+			return
 		}
 
 		r, err := s.CreateRelation(bg, from, relType, to, nil)
-		if relType == "" || strings.Contains(relType, "--") {
+		if storeutil.ValidateRelationType(relType) != nil {
 			assert.Error(t, err)
 			return
 		}
@@ -75,15 +92,13 @@ func FuzzAttachmentKeyCollision(f *testing.F, factory FuzzFactory) {
 		s := factory()
 		bg := context.Background()
 
-		err := s.CreateEntity(bg, entity.New(entityID, "t"))
-		if entityID == "" || strings.Contains(entityID, "--") {
-			assert.Error(t, err)
+		// Directional oracle — see createEntityOrSkip.
+		if !createEntityOrSkip(t, s, entityID) {
 			return
 		}
-		require.NoError(t, err)
 
-		err = s.AttachFile(bg, entityID, prop, "f.txt", strings.NewReader("data"))
-		if prop == "" || strings.Contains(prop, "/") {
+		err := s.AttachFile(bg, entityID, prop, "f.txt", strings.NewReader("data"))
+		if storeutil.ValidateProperty(prop) != nil {
 			assert.Error(t, err)
 			return
 		}

--- a/internal/store/storeutil/storeutil.go
+++ b/internal/store/storeutil/storeutil.go
@@ -43,6 +43,34 @@ func ValidateID(id string) error {
 	return nil
 }
 
+// ValidateRelationType rejects relation types that would cause
+// relation-key collisions or storage hazards. The rules mirror
+// [ValidateID]: relation types are embedded in the same
+// from--type--to key format (so `--` collides), become path segments
+// in fsstore relation filenames (so separators nest directories), and
+// appear in the pgstore change-feed payload whose field separator is
+// a control character (internal/store/pgstore/feed.go already
+// documents that assumption). Previously each backend hand-rolled a
+// subset of these checks inline; the shared rule is also the validity
+// oracle for the storetest fuzz harness (TKT-PCLGGL).
+func ValidateRelationType(relType string) error {
+	if relType == "" {
+		return errors.New("store: empty relation type")
+	}
+	if strings.Contains(relType, "--") {
+		return fmt.Errorf("store: relation type %q contains consecutive dashes", relType)
+	}
+	if strings.ContainsAny(relType, "/\\") {
+		return fmt.Errorf("store: relation type %q contains path separator", relType)
+	}
+	for i := range len(relType) {
+		if relType[i] < 0x20 || relType[i] == 0x7f {
+			return fmt.Errorf("store: relation type %q contains control character", relType)
+		}
+	}
+	return nil
+}
+
 // ValidateProperty rejects property names that would cause
 // attachment key collisions in the entityID/property format.
 func ValidateProperty(prop string) error {

--- a/justfile
+++ b/justfile
@@ -160,6 +160,13 @@ fuzz-short:
     go test -run='^$$' -fuzz='^FuzzParseEntityID$$' -fuzztime=5s ./internal/entity/
     go test -run='^$$' -fuzz='^FuzzValidateID$$' -fuzztime=5s ./internal/entity/
 
+# Run EVERY fuzz target briefly (discovery-based; the weekly CI sweep
+# runs this with the default budget). KNOWN RED until BUG-RHFHTH is
+# fixed: FuzzGenerateShortID reliably finds the GenerateShortID
+# prefix-validation bug.
+fuzz-all fuzztime="25s":
+    FUZZTIME='{{fuzztime}}' scripts/fuzz-all.sh
+
 # ── Lint & Format ──
 
 # Run Go linter

--- a/scripts/fuzz-all.sh
+++ b/scripts/fuzz-all.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# fuzz-all.sh — run every Go fuzz target in the repo for a short budget.
+#
+# Discovers targets by scanning test files, so newly added Fuzz*
+# functions are swept automatically — no hand-maintained list to go
+# stale. Used by the weekly fuzz-sweep workflow and `just fuzz-all`.
+#
+# Usage:
+#   FUZZTIME=25s scripts/fuzz-all.sh        # default budget per target
+#   FUZZTIME=2s  scripts/fuzz-all.sh        # quick local smoke
+#
+# Behavior:
+#   - Each target runs in isolation (`go test -fuzz` allows one target
+#     per invocation).
+#   - A failing target does not stop the sweep; failures are collected
+#     and the script exits non-zero at the end.
+#   - Failed targets are listed in fuzz-failures.txt (consumed by the
+#     workflow's issue-filing step). Crashing inputs land in the
+#     package's testdata/fuzz/<Target>/ directory as usual.
+#   - Targets that skip themselves (e.g. pgstore without
+#     RELA_TEST_DATABASE_URL) pass trivially.
+#
+# The discovery pattern matches `func FuzzX(f *testing.F)` exactly —
+# one parameter — so shared fuzz helpers that take extra arguments
+# (internal/store/storetest/fuzz.go) are not treated as targets; the
+# per-backend wrappers that call them are.
+
+# Exit codes:
+#   0 — sweep clean
+#   1 — at least one target failed (fuzz crash or test error; see summary)
+#   2 — configuration/setup error (bad FUZZTIME, broken build, zero
+#       targets discovered) — the workflow does NOT file an issue for
+#       these, it just fails the run.
+
+set -uo pipefail
+
+FUZZTIME="${FUZZTIME:-25s}"
+SUMMARY="fuzz-failures.txt"
+rm -f "$SUMMARY"
+
+if ! [[ "$FUZZTIME" =~ ^[0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h)$ ]]; then
+  echo "ERROR: invalid FUZZTIME ${FUZZTIME@Q} (want a Go duration like 25s)"
+  exit 2
+fi
+
+# Build gate: a broken tree must fail fast and unambiguously, not
+# masquerade as 39 "fuzz failures" in the filed issue.
+echo "==> build gate"
+if ! go build ./...; then
+  echo "ERROR: build broken — fix the tree before fuzzing"
+  exit 2
+fi
+
+failed=0
+total=0
+
+while read -r file target; do
+  pkg="./$(dirname "$file")"
+  total=$((total + 1))
+  echo ""
+  echo "==> ${pkg} ${target} (${FUZZTIME})"
+  out="$(go test -run='^$' -fuzz="^${target}\$" -fuzztime="$FUZZTIME" "$pkg" 2>&1)"
+  status=$?
+  echo "$out"
+  if [ "$status" -ne 0 ]; then
+    # Classify so the filed issue distinguishes a crashing input
+    # (corpus file written) from an infrastructure/test error.
+    kind="error"
+    if grep -qE 'Failing input written to|--- FAIL: Fuzz' <<<"$out"; then
+      kind="fuzz-crash"
+    fi
+    echo "${pkg} ${target} [${kind}]" >>"$SUMMARY"
+    failed=$((failed + 1))
+  fi
+done < <(grep -rEH '^func Fuzz[A-Za-z0-9_]+\(f \*testing\.F\)' \
+  --include='*_test.go' internal/ |
+  sed -E 's|^([^:]+):func (Fuzz[A-Za-z0-9_]+)\(.*|\1 \2|' |
+  sort)
+
+echo ""
+if [ "$total" -eq 0 ]; then
+  echo "ERROR: no fuzz targets discovered — discovery pattern broken?"
+  exit 2
+fi
+if [ "$failed" -gt 0 ]; then
+  echo "FUZZ SWEEP FAILED: ${failed}/${total} targets"
+  cat "$SUMMARY"
+  exit 1
+fi
+echo "Fuzz sweep OK: ${total} targets, ${FUZZTIME} each."

--- a/tickets/entities/automated-measures/weekly-fuzz-sweep.md
+++ b/tickets/entities/automated-measures/weekly-fuzz-sweep.md
@@ -2,6 +2,7 @@
 id: weekly-fuzz-sweep
 type: automated-measure
 title: Weekly fuzz sweep over all fuzz targets
+description: Scheduled weekly CI workflow that discovers and fuzzes every Fuzz* target for 25s each; failures upload crashing inputs as artifacts and auto-file a deduped GitHub issue (label fuzz-failure). Guards against fuzz-reachable bugs that the per-PR 3-target smoke job never exercises.
 kind: ci
 location: .github/workflows/fuzz-sweep.yml
 status: active

--- a/tickets/entities/automated-measures/weekly-fuzz-sweep.md
+++ b/tickets/entities/automated-measures/weekly-fuzz-sweep.md
@@ -1,0 +1,21 @@
+---
+id: weekly-fuzz-sweep
+type: automated-measure
+title: Weekly fuzz sweep over all fuzz targets
+kind: ci
+location: .github/workflows/fuzz-sweep.yml
+status: active
+---
+
+Scheduled CI workflow (`.github/workflows/fuzz-sweep.yml`, Mondays 06:00 UTC)
+that discovers and runs every `Fuzz*` target in the repo for 25s each via
+`scripts/fuzz-all.sh`. Failures upload the crashing inputs as artifacts and
+auto-file a deduped GitHub issue (label `fuzz-failure`).
+
+Introduced by TKT-PCLGGL. Two seconds of its first local run found five failing
+targets: four stale fuzz-harness oracles (fixed in the same PR — the storetest
+collision harnesses now delegate ID validity to `storeutil.ValidateID`
+directionally) and one real production bug (BUG-RHFHTH, GenerateShortID emitting
+validator-rejected IDs).
+
+Local equivalent: `just fuzz-all` (or `just fuzz-all fuzztime=5s`).

--- a/tickets/entities/bugs/BUG-RHFHTH.md
+++ b/tickets/entities/bugs/BUG-RHFHTH.md
@@ -1,0 +1,53 @@
+---
+id: BUG-RHFHTH
+type: bug
+title: GenerateShortID can emit IDs its own validator rejects (pathological prefixes)
+description: Fuzzing found GenerateShortID(prefix="--") returns "--9HHF", which entity.ValidateID rejects (consecutive dashes). The generator treats the prefix as opaque, so invalid prefixes flow into emitted IDs.
+priority: low
+effort: xs
+status: ready
+---
+
+## Found by
+
+The weekly fuzz sweep work (TKT-PCLGGL): 2 seconds of fuzzing
+`FuzzGenerateShortID` — a target the per-PR fuzz job never runs — produced a
+failing input.
+
+## Reproduction
+
+```text
+go test fuzz v1
+string("--")
+string("0")
+int(10)
+string("0")
+```
+
+`GenerateShortID(existingIDs=["0"], prefix="--", entityCount=10, caps="0")`
+returns `"--9HHF"`, which `entity.ValidateID` rejects: `consecutive dashes not
+allowed in entity ID: --9HHF`.
+
+(The failing input is deliberately NOT committed to
+`internal/entity/testdata/fuzz/` — as a seed it would fail every `go test` run
+until this is fixed. Re-find it with `go test -run='^$'
+-fuzz='^FuzzGenerateShortID$' -fuzztime=30s ./internal/entity/`, or paste the
+corpus block above into a file under `testdata/fuzz/FuzzGenerateShortID/` while
+fixing.)
+
+## Analysis (starting point)
+
+`GenerateShortID` (internal/entity/id.go:219) treats the prefix as opaque: it
+trims a trailing `-` and appends `-<base36>`. A prefix that itself violates ID
+rules (`--`, control chars, path separators) flows straight into the result, so
+the generator can produce IDs that `entity.ValidateID` — and the stores via
+`storeutil.ValidateID` — reject. In practice prefixes come from the metamodel
+(`id_prefix`), so hitting this requires a broken metamodel; check whether
+`metamodel.Parse` already rejects malformed prefixes.
+
+## Suggested direction
+
+Either make `GenerateShortID` defensive (validate/sanitize the prefix; invalid
+prefix is a programming/config error), or enforce prefix validity at metamodel
+load and narrow the fuzz harness to metamodel-legal prefixes. Decide based on
+what `metamodel` already guarantees.

--- a/tickets/entities/implementation-checklists/IMPL-ZGIVEQ.md
+++ b/tickets/entities/implementation-checklists/IMPL-ZGIVEQ.md
@@ -1,0 +1,45 @@
+---
+id: IMPL-ZGIVEQ
+type: implementation-checklist
+title: 'Implementation: Weekly fuzz sweep over all targets with auto-filed issues'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code — committed regression seeds (4 control-char inputs in memstore/fsstore testdata); script failure paths verified by injection
+- [x] Integration tests written — the sweep itself ran locally end-to-end
+- [x] Happy path implemented (script, workflow, recipe)
+- [x] Edge cases handled (bad FUZZTIME → exit 2; broken build → gate, exit 2; zero targets → exit 2; failure classification fuzz-crash vs error; issue dedupe; setup errors don't file issues)
+- [x] Error handling in place
+
+## Test Quality
+
+- [x] Discovery-based (no stale hand-list) — same loud-failure principle as the TKT-TLQ94B inventory tests
+- [x] Oracle delegated to the shared production contract (storeutil.ValidateID/ValidateRelationType/ValidateProperty), directional, with documented vacuity anchor
+- [x] No hardcoded values in assertions — n/a
+- [x] Only specifying what matters — n/a
+- [x] Property comparisons — n/a
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+- First local 2s sweep over all 39 discovered targets immediately found **5 failures**: 4 stale fuzz-harness oracles (storetest collision harnesses hand-modeled ID validity, went stale when control-char rejection was added) and **1 real production bug** (GenerateShortID emits validator-rejected IDs for pathological prefixes → BUG-RHFHTH filed with full repro; its crashing input deliberately not committed).
+- Harness fix: directional oracle via `createEntityOrSkip` + new `storeutil.ValidateRelationType` used by all three backends (also fixes pgstore feed.go's documented-but-unenforced control-char assumption and fsstore's `/`-in-relType directory hazard). The 4 crash inputs are now committed regression seeds — verified passing on both backends.
+- Re-fuzz after fixes: all four collision targets clean at 6–8s budgets; full store packages + entitymanager + dataentry green under `-race`; lint 0 issues.
+- Failure-path verification: deliberate failing target → recorded + exit 1; `FUZZTIME=banana` → exit 2 without issue-summary; classification verified (`fuzz-crash` tag on the known-red GenerateShortID target).
+
+## Quality
+
+- [x] Code follows project patterns (scripts/ precedent, security.yml cron pattern, minimal workflow permissions)
+- [x] DRY — oracle helper, shared validator
+- [x] No security issues (no untrusted input in workflow run blocks; --body-file for issue content)
+- [x] No silent failures (exit-code split: 1 = findings, 2 = setup; issues filed only for findings)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-T5BPYR.md
+++ b/tickets/entities/planning-checklists/PLAN-T5BPYR.md
@@ -1,0 +1,46 @@
+---
+id: PLAN-T5BPYR
+type: planning-checklist
+title: 'Planning: Weekly fuzz sweep'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined — see TKT-PCLGGL (script + weekly workflow + issue automation + just recipe; per-PR job untouched)
+- [x] Acceptance criteria: discovery-based (no hand-list), every target gets fuzz time, failures upload artifacts AND auto-file/append a deduped GitHub issue with reproduction instructions
+
+## Research
+
+- [x] ~~/research~~ (N/A: CI plumbing)
+- [x] Checked patterns: security.yml weekly cron ("0 9 * * 1") — fuzz scheduled before it; govulncheck-filtered.sh is the existing scripts/ precedent
+- [x] Verified discovery regex excludes the storetest shared fuzz helpers (they take extra params beyond *testing.F, so they're not targets; the per-backend wrappers are)
+
+## Approach
+
+- [x] grep-based discovery (file scan, no per-package compile); `go test -run='^$' -fuzz='^Name$' -fuzztime=$FUZZTIME` per target; continue-on-failure with summary file
+- [x] Issue dedupe: comment on existing open `fuzz-failure`-labeled issue, else create (label created idempotently)
+- [x] Alternatives: `go test -list` discovery rejected (compiles every package twice); auto-committing regression corpus rejected (write-permission + review concerns — artifacts + issue instead)
+
+## Security Considerations
+
+- [x] Workflow permissions minimal: contents read + issues write; no untrusted input interpolated into run blocks (summary file is repo-generated)
+
+## Test Plan
+
+- [x] Local run with short FUZZTIME across all targets; deliberate-failure injection to verify summary + exit code
+
+## Risk Assessment
+
+- [x] Effort s. Risks: long-tail wall time (39 × 25s + compiles ≈ 25-30 min — under the 60 min job timeout); pgstore targets silently skipping (documented, follow-up noted)
+
+## Documentation Planning
+
+- [x] N/A (CI-internal; script self-documents)
+
+## Design Review
+
+- [x] ~~/design-review~~ (N/A-with-substitute: approach incl. issue automation requested and shaped by reviewer in session 2026-06-10)

--- a/tickets/entities/review-checklists/REV-0Z31B3.md
+++ b/tickets/entities/review-checklists/REV-0Z31B3.md
@@ -1,0 +1,26 @@
+---
+id: REV-0Z31B3
+type: review-checklist
+title: 'Review: Weekly fuzz sweep'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] Store packages + consumers green under `-race` after the ValidateRelationType extraction
+- [x] `golangci-lint` 0 issues; gofmt clean
+- [x] Full `just ci` green (pre-review-fix run; re-run after fixes before PR)
+
+## Code Review
+
+- [x] `/code-review` run (cranky-code-reviewer)
+- [x] Findings: 0 critical, 4 significant (ALL addressed: failure classification + build gate; oracle vacuity anchored; relType oracle extracted to storeutil.ValidateRelationType across all 3 backends; known-red documented), 1 minor batch (addressed), 1 nit (wont-fix with reason) — RR-WW7L59, RR-P59UTD, RR-T4VKMV, RR-FGL95I, RR-YA3PRX, RR-MCWQ6S
+- [x] Reviewer verified: discovery correctness (39 targets, helpers excluded), workflow injection surfaces clean, issue dedupe + label idempotence correct, cron timing, timeout adequacy, committed seeds pass both backends
+
+## Verification
+
+- [x] The sweep found 5 real failures in its first 2-second run (4 harness-oracle bugs fixed here; 1 production bug filed as BUG-RHFHTH with the weekly-fuzz-sweep measure entity linked)
+
+**PR:** (added once created)

--- a/tickets/entities/review-checklists/REV-0Z31B3.md
+++ b/tickets/entities/review-checklists/REV-0Z31B3.md
@@ -11,7 +11,7 @@ status: done
 
 - [x] Store packages + consumers green under `-race` after the ValidateRelationType extraction
 - [x] `golangci-lint` 0 issues; gofmt clean
-- [x] Full `just ci` green (pre-review-fix run; re-run after fixes before PR)
+- [x] Full `just ci` green after review fixes
 
 ## Code Review
 
@@ -23,4 +23,4 @@ status: done
 
 - [x] The sweep found 5 real failures in its first 2-second run (4 harness-oracle bugs fixed here; 1 production bug filed as BUG-RHFHTH with the weekly-fuzz-sweep measure entity linked)
 
-**PR:** (added once created)
+**PR:** https://github.com/sourcehaven-bv/rela/pull/964

--- a/tickets/entities/review-responses/RR-FGL95I.md
+++ b/tickets/entities/review-responses/RR-FGL95I.md
@@ -1,0 +1,9 @@
+---
+id: RR-FGL95I
+type: review-response
+title: just fuzz-all red-by-default until BUG-RHFHTH fixed
+finding: FuzzGenerateShortID reliably fails, so the new recipe and the first weekly run are guaranteed red with no warning — erodes trust in the harness on day one.
+severity: significant
+resolution: Known-red state documented on the recipe (naming BUG-RHFHTH); the first scheduled run filing an issue for it is the system working as designed. Fixing the bug itself is the next PR (BUG-RHFHTH is ready with full repro).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MCWQ6S.md
+++ b/tickets/entities/review-responses/RR-MCWQ6S.md
@@ -1,0 +1,9 @@
+---
+id: RR-MCWQ6S
+type: review-response
+title: Artifact glob uploads committed seeds alongside new crashers
+finding: internal/**/testdata/fuzz/** doesn't distinguish the 12 committed regression seeds from new crashing inputs.
+severity: nit
+reason: 12 files of noise at current scale; the issue body's kind tags identify which targets actually crashed. Revisit if the corpus grows large.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-P59UTD.md
+++ b/tickets/entities/review-responses/RR-P59UTD.md
@@ -1,0 +1,9 @@
+---
+id: RR-P59UTD
+type: review-response
+title: Directional oracle vacuity — reject-everything backend would pass
+finding: Unconditional return on rejected creates means a backend rejecting all writes passes the collision fuzz targets trivially.
+severity: significant
+resolution: 'Deduped into createEntityOrSkip with a documented vacuity anchor: storetest.RunAll''s Entity conformance suite asserts plain creates succeed and every backend runs both — over-rejection fails loudly there; the fuzz targets chase collision/round-trip divergence only.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-T4VKMV.md
+++ b/tickets/entities/review-responses/RR-T4VKMV.md
@@ -1,0 +1,9 @@
+---
+id: RR-T4VKMV
+type: review-response
+title: relType oracle still hand-modeled — same staleness class just fixed for IDs
+finding: The relType validity check remained the inline ""/-- model while backends validate inline; the next tightening would produce false fuzz failures again. pgstore's feed.go even documents an assumption (no control chars in relation types) the validation didn't enforce.
+severity: significant
+resolution: 'Extracted storeutil.ValidateRelationType (ID-equivalent rules: empty, --, path separators, control chars); all three backends now use it, fixing the latent feed.go assumption and the fsstore ''/''-in-relType directory hazard; the fuzz oracle delegates to it directionally.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-WW7L59.md
+++ b/tickets/entities/review-responses/RR-WW7L59.md
@@ -1,0 +1,9 @@
+---
+id: RR-WW7L59
+type: review-response
+title: Compile errors laundered into fuzz failures
+finding: Any non-zero go test exit (compile error, vet, bad flag) landed in fuzz-failures.txt identically to a crashing input, producing misleading auto-filed issues.
+severity: significant
+resolution: Build gate before the sweep (exit 2, no issue filed); per-target output captured and classified [fuzz-crash] vs [error] in the summary; issue body explains the kinds; workflow skips issue-filing when no summary exists (setup errors).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YA3PRX.md
+++ b/tickets/entities/review-responses/RR-YA3PRX.md
@@ -1,0 +1,9 @@
+---
+id: RR-YA3PRX
+type: review-response
+title: 'Script/recipe hygiene: gitignore, FUZZTIME validation, unquoted arg'
+finding: fuzz-failures.txt not gitignored; FUZZTIME unvalidated (typo → 39 confusing failures); justfile arg interpolated unquoted.
+severity: minor
+resolution: 'All three fixed: .gitignore entry, duration-regex validation with exit 2, quoted interpolation.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-PCLGGL.md
+++ b/tickets/entities/tickets/TKT-PCLGGL.md
@@ -1,0 +1,31 @@
+---
+id: TKT-PCLGGL
+type: ticket
+title: Weekly fuzz sweep over all targets with auto-filed issues
+kind: test
+priority: medium
+effort: s
+status: done
+---
+
+## Problem
+
+The repo has 39 fuzz targets — including the differential store fuzzer and 18
+cross-backend conformance targets — but the per-PR CI fuzz job runs 3 of them
+for 10s each. The other 36 only execute their seed corpora as regular tests; the
+best bug-finding machinery in the repo gets no fuzz time.
+
+## Approach (agreed with reviewer in session)
+
+1. `scripts/fuzz-all.sh`: discovers `Fuzz*` targets by scanning test files (new targets are swept automatically — no stale hand-list), runs each for `$FUZZTIME` (default 25s), collects failures into `fuzz-failures.txt`, exits non-zero if any failed. pgstore targets self-skip without `RELA_TEST_DATABASE_URL` (postgres-service wiring is a noted follow-up).
+2. `.github/workflows/fuzz-sweep.yml`: weekly cron (Mondays 06:00 UTC, before the security scan) + `workflow_dispatch`; on failure uploads the failing corpus inputs as an artifact and **auto-files a GitHub issue** (label `fuzz-failure`) with the failed targets, run link, and reproduction instructions — deduped by commenting on an existing open `fuzz-failure` issue instead of creating a new one each week.
+3. `just fuzz-all` recipe for local runs.
+4. The per-PR fuzz job stays as-is (fast smoke).
+
+Per session decision: separate PR (one of three split out of the original
+combined task 4).
+
+## Verification
+
+- Script run locally with a short FUZZTIME completes across all discovered targets and reports failures correctly (verified by injecting a deliberate failure).
+- Workflow lint-clean (actionlint via CI's Analyze (actions) job); CI green on PR.

--- a/tickets/relations/BUG-RHFHTH--adds-measure--weekly-fuzz-sweep.md
+++ b/tickets/relations/BUG-RHFHTH--adds-measure--weekly-fuzz-sweep.md
@@ -1,0 +1,5 @@
+---
+from: BUG-RHFHTH
+relation: adds-measure
+to: weekly-fuzz-sweep
+---

--- a/tickets/relations/BUG-RHFHTH--affects--metamodel-types.md
+++ b/tickets/relations/BUG-RHFHTH--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: BUG-RHFHTH
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/BUG-RHFHTH--fixes--FEAT-016.md
+++ b/tickets/relations/BUG-RHFHTH--fixes--FEAT-016.md
@@ -1,0 +1,5 @@
+---
+from: BUG-RHFHTH
+relation: fixes
+to: FEAT-016
+---

--- a/tickets/relations/TKT-PCLGGL--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-PCLGGL--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PCLGGL
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-PCLGGL--has-implementation--IMPL-ZGIVEQ.md
+++ b/tickets/relations/TKT-PCLGGL--has-implementation--IMPL-ZGIVEQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PCLGGL
+relation: has-implementation
+to: IMPL-ZGIVEQ
+---

--- a/tickets/relations/TKT-PCLGGL--has-planning--PLAN-T5BPYR.md
+++ b/tickets/relations/TKT-PCLGGL--has-planning--PLAN-T5BPYR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PCLGGL
+relation: has-planning
+to: PLAN-T5BPYR
+---

--- a/tickets/relations/TKT-PCLGGL--has-review--REV-0Z31B3.md
+++ b/tickets/relations/TKT-PCLGGL--has-review--REV-0Z31B3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PCLGGL
+relation: has-review
+to: REV-0Z31B3
+---

--- a/tickets/relations/TKT-PCLGGL--has-review-response--RR-FGL95I.md
+++ b/tickets/relations/TKT-PCLGGL--has-review-response--RR-FGL95I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PCLGGL
+relation: has-review-response
+to: RR-FGL95I
+---

--- a/tickets/relations/TKT-PCLGGL--has-review-response--RR-MCWQ6S.md
+++ b/tickets/relations/TKT-PCLGGL--has-review-response--RR-MCWQ6S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PCLGGL
+relation: has-review-response
+to: RR-MCWQ6S
+---

--- a/tickets/relations/TKT-PCLGGL--has-review-response--RR-P59UTD.md
+++ b/tickets/relations/TKT-PCLGGL--has-review-response--RR-P59UTD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PCLGGL
+relation: has-review-response
+to: RR-P59UTD
+---

--- a/tickets/relations/TKT-PCLGGL--has-review-response--RR-T4VKMV.md
+++ b/tickets/relations/TKT-PCLGGL--has-review-response--RR-T4VKMV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PCLGGL
+relation: has-review-response
+to: RR-T4VKMV
+---

--- a/tickets/relations/TKT-PCLGGL--has-review-response--RR-WW7L59.md
+++ b/tickets/relations/TKT-PCLGGL--has-review-response--RR-WW7L59.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PCLGGL
+relation: has-review-response
+to: RR-WW7L59
+---

--- a/tickets/relations/TKT-PCLGGL--has-review-response--RR-YA3PRX.md
+++ b/tickets/relations/TKT-PCLGGL--has-review-response--RR-YA3PRX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PCLGGL
+relation: has-review-response
+to: RR-YA3PRX
+---

--- a/tickets/relations/TKT-PCLGGL--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-PCLGGL--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PCLGGL
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/weekly-fuzz-sweep--protects--ci-pipeline.md
+++ b/tickets/relations/weekly-fuzz-sweep--protects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: weekly-fuzz-sweep
+relation: protects
+to: ci-pipeline
+---


### PR DESCRIPTION
First of three PRs split from the CI-quality task (full ticket flow in tickets/, TKT-PCLGGL). Branches off develop — independent of the test-PR stack.

## What

The repo has 39 fuzz targets but the per-PR fuzz job runs 3 of them for 10s each — the other 36 (including the differential store fuzzer) never get fuzz time.

- **`scripts/fuzz-all.sh`**: discovers every `Fuzz*` target by scanning test files (new targets swept automatically), runs each for `$FUZZTIME` (default 25s). Build gate up front; failures classified `[fuzz-crash]` vs `[error]` in `fuzz-failures.txt`; exit 1 = findings, exit 2 = setup error.
- **`.github/workflows/fuzz-sweep.yml`**: weekly (Mon 06:00 UTC) + manual dispatch. On failure: uploads crashing inputs as an artifact and **auto-files a GitHub issue** (label `fuzz-failure`, created idempotently) with the classified target list, run link, and reproduction instructions — deduped by commenting on an existing open issue. Setup errors fail the run without filing an issue.
- **`just fuzz-all [fuzztime]`** for local runs. Per-PR fuzz job unchanged (fast smoke).

## It paid for itself before shipping

The first **2-second** local sweep found 5 failures:

- **4 stale fuzz-harness oracles** (fixed here): the storetest collision harnesses hand-modeled ID validity (`""`/`--`) and went stale when control-character rejection was added. Now a directional oracle delegating to the shared contract: shared-invalid must error; shared-valid may be rejected by stricter backends (fsstore's `:` rule); accepted writes must round-trip. Vacuity is anchored by the conformance suite (documented). The 4 crashing inputs are committed as passing regression seeds.
- **1 real production bug** (filed as **BUG-RHFHTH**, not fixed here): `GenerateShortID` emits IDs its own validator rejects for pathological prefixes. Its crashing input is deliberately not committed (it would fail every test run); full repro is in the bug. **Note: `just fuzz-all` and the first weekly run are red until BUG-RHFHTH is fixed — documented on the recipe; the auto-filed issue will be the system working.**
- Bonus from the review: relType validation was hand-rolled inline in all three backends — extracted to **`storeutil.ValidateRelationType`** (ID-equivalent rules), which also fixes a latent inconsistency pgstore's feed.go documented but nothing enforced (control chars in relation types would corrupt the NOTIFY payload; `/` in relTypes would nest fsstore directories).

## Review

Cranky review: 0 critical, 4 significant (all addressed: failure classification + build gate, vacuity anchor, relType extraction, known-red documentation), minors fixed, 1 nit wont-fix with reason. Six RRs linked to the ticket.

## Verification

Store packages + entitymanager + dataentry green under `-race` after the relType tightening; collision targets re-fuzzed clean; failure paths verified by injection (`FUZZTIME=banana` → exit 2 no issue; deliberate crash → classified + exit 1); full `just ci` green.