### PR TITLE
ci: default package coverage floor 50 + first tests for internal/config (TKT-EXL94Y)

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -8,14 +8,29 @@
 profile: coverage.out
 
 # Minimum coverage thresholds (floor — packages must not drop below these)
+#
+# The default package floor (50) is what catches "new untested package
+# added" — the stated purpose of floors. Packages legitimately below it
+# get an explicit override (~5pp below current, the file's convention)
+# so the gap stays visible instead of silently unenforced.
 threshold:
   file: 0
-  package: 0
+  package: 50
   total: 65
 
 # Per-package minimum thresholds.
 # Set ~5pp below current measured coverage to give refactor headroom.
 override:
+  # Below the default floor — explicit lower floors so the gap is
+  # visible. Raise these as tests are added; don't lower without reason.
+  - path: ^internal/git$
+    threshold: 30
+  - path: ^internal/cli$
+    threshold: 30
+  - path: ^internal/search$
+    threshold: 20 # the Searcher facade; most logic lives in search/bleveindex and the backends
+  - path: ^internal/config$
+    threshold: 0 # TODO: genuinely untested production loader (27 stmts) — needs tests
   - path: ^internal/entity$
     threshold: 80
   - path: ^internal/errors$
@@ -46,6 +61,8 @@ exclude:
     - ^internal/testutil       # test helpers
     - ^internal/store/storetest # shared conformance test kit (exercised via backends)
     - ^internal/store/pgstore  # covered by the dedicated postgres CI job (needs a live DB; skipped without RELA_TEST_DATABASE_URL)
+    - ^internal/entitymanager/entitymanagertest # shared test doubles (PanicOnUse etc.), exercised via consumers
+    - ^internal/store/graphquerynaive # exercised through every backend's graphquery tests; cross-package coverage isn't attributed without -coverpkg, so its own number reads 0
     - ^frontend/node_modules   # Go files in npm dependencies
 
 # Require coverage-ignore annotations to have explanatory comments

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -29,8 +29,12 @@ override:
     threshold: 30
   - path: ^internal/search$
     threshold: 20 # the Searcher facade; most logic lives in search/bleveindex and the backends
+  # Close to the default floor — explicit so proximity is documented,
+  # not discovered by a surprise CI failure (currently ~56%).
+  - path: ^internal/mcp$
+    threshold: 50
   - path: ^internal/config$
-    threshold: 0 # TODO: genuinely untested production loader (27 stmts) — needs tests
+    threshold: 87
   - path: ^internal/entity$
     threshold: 80
   - path: ^internal/errors$

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,114 @@
+package config_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/config"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+func TestFSLoader_Load_RoundTrip(t *testing.T) {
+	t.Parallel()
+	fs := storage.NewMemFS()
+	if err := fs.MkdirAll("/project/sub", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := []byte("app:\n  name: Test\n")
+	if err := fs.WriteFile("/project/data-entry.yaml", want, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.WriteFile("/project/sub/nested.yaml", []byte("x: 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	l := config.NewFSLoader(fs, "/project")
+
+	got, err := l.Load(context.Background(), "data-entry.yaml")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("Load = %q, want %q", got, want)
+	}
+
+	// Relative subdirectory paths are allowed.
+	if _, err := l.Load(context.Background(), "sub/nested.yaml"); err != nil {
+		t.Errorf("Load(sub/nested.yaml): %v", err)
+	}
+}
+
+func TestFSLoader_Load_MissingFileIsNotExist(t *testing.T) {
+	t.Parallel()
+	l := config.NewFSLoader(storage.NewMemFS(), "/project")
+
+	_, err := l.Load(context.Background(), "absent.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	// The Loader contract promises an os.IsNotExist-compatible error so
+	// consumers (dataentry, mcp) can treat absence as "no config".
+	if !os.IsNotExist(err) {
+		t.Errorf("error %v is not os.IsNotExist-compatible", err)
+	}
+}
+
+func TestFSLoader_Load_RejectsUnsafeNames(t *testing.T) {
+	t.Parallel()
+	fs := storage.NewMemFS()
+	if err := fs.WriteFile("/secret.yaml", []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	l := config.NewFSLoader(fs, "/project")
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"NUL", "a\x00b.yaml"},
+		{"control character", "a\x1fb.yaml"},
+		{"backslash", `sub\file.yaml`},
+		{"absolute", "/secret.yaml"},
+		{"parent traversal", "../secret.yaml"},
+		{"embedded traversal", "sub/../../secret.yaml"},
+		{"dot segment", "./file.yaml"},
+		{"empty segment", "sub//file.yaml"},
+		{"drive letter", `C:secret.yaml`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := l.Load(context.Background(), tt.input); err == nil {
+				t.Errorf("Load(%q) should be rejected", tt.input)
+			}
+		})
+	}
+}
+
+func TestFSLoader_Subscribe(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data-entry.yaml")
+	if err := os.WriteFile(path, []byte("a: 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	l := config.NewFSLoader(storage.NewSafeFS(storage.NewOsFS()), dir)
+
+	// Unsafe names are rejected before any watcher is created.
+	if _, err := l.Subscribe(context.Background(), "../x.yaml", func() {}); err == nil {
+		t.Error("Subscribe with traversal name should be rejected")
+	}
+
+	// A valid subscription returns a working stop function. Event
+	// delivery itself is the watcher's contract, tested in
+	// internal/storage — no sleeps here.
+	stop, err := l.Subscribe(context.Background(), "data-entry.yaml", func() {})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	stop()
+}

--- a/tickets/entities/implementation-checklists/IMPL-22LOE7.md
+++ b/tickets/entities/implementation-checklists/IMPL-22LOE7.md
@@ -2,43 +2,32 @@
 id: IMPL-22LOE7
 type: implementation-checklist
 title: 'Implementation: Default package coverage floor so new untested packages fail CI'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] Unit tests written for new code — internal/config gained its first test file (92.6% coverage; round-trip, os.IsNotExist contract, 10-case unsafe-name table, Subscribe validation) per review finding RR-R375DS
+- [x] Integration tests — n/a (config change)
+- [x] Happy path implemented (default floor 50; overrides git 30, cli 30, search 20, mcp 50, config 87; exclusions entitymanagertest + graphquerynaive with rationale comments)
+- [x] Edge cases handled (regex anchoring verified — ^internal/search$ doesn't mask bleveindex/searchparser)
+- [x] Error handling — n/a
 
 ## Test Quality
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- [x] New config tests: parallel, table-driven, external test package, no sleeps (event delivery left to the watcher's own tests)
+- [x] No hardcoded values / only what matters / object-derived comparisons — followed
 
 ## Manual Verification
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
-
-**Verification Evidence:**
-<!-- Document what you tested and the results -->
+- [x] `go-test-coverage --config` PASS on regenerated profile (total 75.4%)
+- [x] Negative check: scratch package with untested function fails the 50 floor with a clear violation line (probe removed)
+- [x] Reviewer independently re-measured all override numbers against the profile — exact matches
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
-patterns extracted to a helper / constant / type where it sharpens the contract
-(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
-premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] Follows the file's existing conventions (anchored regexes, ~5pp headroom, visible-not-silent gaps)
+- [x] No security issues; the new config tests pin the validateName traversal guards
+- [x] No silent failures; no debug code

--- a/tickets/entities/implementation-checklists/IMPL-22LOE7.md
+++ b/tickets/entities/implementation-checklists/IMPL-22LOE7.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-22LOE7
+type: implementation-checklist
+title: 'Implementation: Default package coverage floor so new untested packages fail CI'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-TLZ8QU.md
+++ b/tickets/entities/planning-checklists/PLAN-TLZ8QU.md
@@ -1,0 +1,43 @@
+---
+id: PLAN-TLZ8QU
+type: planning-checklist
+title: 'Planning: Default package coverage floor'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood — `threshold.package: 0` defeats the file's own stated purpose
+- [x] Scope defined — config-only change to .testcoverage.yml
+- [x] Acceptance criteria: default package floor 50; no currently-passing package starts failing (overrides ~5pp below current per the file's convention); helper packages excluded; a scratch untested package fails the check (negative verification)
+
+## Research
+
+- [x] ~~/research~~ (N/A: config change)
+- [x] Measured per-package coverage on the branch before setting numbers
+
+## Approach
+
+- [x] Default 50 + explicit lower overrides + exclusions; alternatives (ratchet, per-file floors) rejected — the repo explicitly documents floors-not-ratchet in CLAUDE.md
+
+## Security Considerations
+
+- [x] N/A
+
+## Test Plan
+
+- [x] `just coverage-check` green; scratch-package negative check
+
+## Risk Assessment
+
+- [x] Effort xs. Risk: a package hovering just above its floor flakes on coverage noise — mitigated by the 5pp headroom convention
+
+## Documentation Planning
+
+- [x] N/A (.testcoverage.yml is self-documenting; CLAUDE.md's coverage section already describes floors)
+
+## Design Review
+
+- [x] ~~/design-review~~ (N/A-with-substitute: approach agreed in session 2026-06-10)

--- a/tickets/entities/review-checklists/REV-8UFVYT.md
+++ b/tickets/entities/review-checklists/REV-8UFVYT.md
@@ -1,0 +1,25 @@
+---
+id: REV-8UFVYT
+type: review-checklist
+title: 'Review: Default package coverage floor'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] `go-test-coverage` PASS on regenerated profile; lint 0 issues on the new config tests
+- [x] Full `just ci` green (pre-review commit; floors re-verified after review changes)
+
+## Code Review
+
+- [x] `/code-review` run (cranky-code-reviewer; independently re-measured every override number)
+- [x] Findings: 0 critical, 1 significant (mcp proximity — addressed with explicit override), 1 minor (config 0-floor — addressed by writing the tests, 92.6%, floor 87), 1 nit (wont-fix with reason), plus confirmations of the graphquerynaive rationale and regex anchoring — RR-TFOEDA, RR-R375DS, RR-N18BKF
+- [x] All critical/significant findings addressed
+
+## Verification
+
+- [x] Negative check: untested scratch package fails the floor; removed after verification
+
+**PR:** (added once created)

--- a/tickets/entities/review-checklists/REV-8UFVYT.md
+++ b/tickets/entities/review-checklists/REV-8UFVYT.md
@@ -22,4 +22,4 @@ status: done
 
 - [x] Negative check: untested scratch package fails the floor; removed after verification
 
-**PR:** (added once created)
+**PR:** https://github.com/sourcehaven-bv/rela/pull/966

--- a/tickets/entities/review-responses/RR-N18BKF.md
+++ b/tickets/entities/review-responses/RR-N18BKF.md
@@ -1,0 +1,9 @@
+---
+id: RR-N18BKF
+type: review-response
+title: Override-block comment says ~5pp but cli is 7pp below current
+finding: cli floor 30 vs measured 37.0 is ~7pp headroom, slightly more than the comment's ~5pp convention.
+severity: nit
+reason: Erring toward more headroom is harmless; the comment says approximately. Reviewer marked it not worth a respin.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-R375DS.md
+++ b/tickets/entities/review-responses/RR-R375DS.md
@@ -1,0 +1,9 @@
+---
+id: RR-R375DS
+type: review-response
+title: config 0-floor TODO had no enforcement pressure
+finding: A 0-floor override with a TODO comment can never fail and would rot indefinitely; internal/config is real production code (validateName guards attacker-controllable file names) with zero tests.
+severity: minor
+resolution: 'Took the reviewer''s option (b): wrote the loader test in this PR (round-trip, os.IsNotExist contract, 10-case unsafe-name table incl. NUL/traversal/drive-letter, Subscribe validation) — 92.6% coverage; floor set to 87.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-TFOEDA.md
+++ b/tickets/entities/review-responses/RR-TFOEDA.md
@@ -1,0 +1,9 @@
+---
+id: RR-TFOEDA
+type: review-response
+title: internal/mcp 5.7pp from default floor with no visible marker
+finding: Raising the default floor to 50 silently put mcp (55.7%, large and churny) closest to failing, with nothing in the config documenting the proximity.
+severity: significant
+resolution: Explicit ^internal/mcp$ override at 50 with a comment documenting the ~56% proximity, per the file's stated visible-not-silent philosophy.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-EXL94Y.md
+++ b/tickets/entities/tickets/TKT-EXL94Y.md
@@ -5,7 +5,7 @@ title: Default package coverage floor so new untested packages fail CI
 kind: chore
 priority: medium
 effort: xs
-status: in-progress
+status: done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-EXL94Y.md
+++ b/tickets/entities/tickets/TKT-EXL94Y.md
@@ -1,0 +1,33 @@
+---
+id: TKT-EXL94Y
+type: ticket
+title: Default package coverage floor so new untested packages fail CI
+kind: chore
+priority: medium
+effort: xs
+status: in-progress
+---
+
+## Problem
+
+`.testcoverage.yml` declares its purpose as "floors exist to catch new untested
+packages added and core packages silently losing tests" — but
+`threshold.package: 0` means only the 11 explicitly-overridden packages and the
+65% total are enforced. A brand-new package with zero tests sails through CI;
+the total threshold dilutes too slowly to catch it.
+
+## Approach (agreed with reviewer in session)
+
+1. Measure current per-package coverage on develop.
+2. Set the default package floor to 50.
+3. Add explicit lower overrides for the known sub-50 packages, set ~5pp below current (the file's existing convention) so nothing currently passing starts failing.
+4. Exclude genuine helper packages (e.g. entitymanagertest) where coverage is meaningless.
+5. Verify `just coverage-check` green locally.
+
+Per session decision: separate PR (2 of 3 split from the original combined
+CI-quality task).
+
+## Verification
+
+- `just coverage-check` green on the branch.
+- Negative check: a scratch package with an untested function fails the check (verified locally, then removed).

--- a/tickets/relations/TKT-EXL94Y--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-EXL94Y--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EXL94Y
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-EXL94Y--has-implementation--IMPL-22LOE7.md
+++ b/tickets/relations/TKT-EXL94Y--has-implementation--IMPL-22LOE7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EXL94Y
+relation: has-implementation
+to: IMPL-22LOE7
+---

--- a/tickets/relations/TKT-EXL94Y--has-planning--PLAN-TLZ8QU.md
+++ b/tickets/relations/TKT-EXL94Y--has-planning--PLAN-TLZ8QU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EXL94Y
+relation: has-planning
+to: PLAN-TLZ8QU
+---

--- a/tickets/relations/TKT-EXL94Y--has-review--REV-8UFVYT.md
+++ b/tickets/relations/TKT-EXL94Y--has-review--REV-8UFVYT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EXL94Y
+relation: has-review
+to: REV-8UFVYT
+---

--- a/tickets/relations/TKT-EXL94Y--has-review-response--RR-N18BKF.md
+++ b/tickets/relations/TKT-EXL94Y--has-review-response--RR-N18BKF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EXL94Y
+relation: has-review-response
+to: RR-N18BKF
+---

--- a/tickets/relations/TKT-EXL94Y--has-review-response--RR-R375DS.md
+++ b/tickets/relations/TKT-EXL94Y--has-review-response--RR-R375DS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EXL94Y
+relation: has-review-response
+to: RR-R375DS
+---

--- a/tickets/relations/TKT-EXL94Y--has-review-response--RR-TFOEDA.md
+++ b/tickets/relations/TKT-EXL94Y--has-review-response--RR-TFOEDA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EXL94Y
+relation: has-review-response
+to: RR-TFOEDA
+---

--- a/tickets/relations/TKT-EXL94Y--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-EXL94Y--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EXL94Y
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Second of three PRs split from the CI-quality task (full ticket flow in tickets/, TKT-EXL94Y). Independent of the other open PRs.

## What

`.testcoverage.yml` documented its floors as existing "to catch new untested packages" — but the default package floor was 0, so only the 11 overridden packages were enforced and a brand-new untested package sailed through CI.

- **Default package floor: 0 → 50.** Verified negatively: a scratch package with one untested function fails the check with a clear violation line.
- **Explicit overrides for sub-50 packages** (~5pp below measured, the file's convention — nothing currently passing starts failing): git 30, cli 30, search 20 (facade; the logic lives in bleveindex/searchparser, both >84%).
- **`internal/mcp` pinned explicitly at 50** (review finding): it sits at ~56%, the only package within 6pp of the default floor — now documented rather than a surprise CI failure waiting in a churny package.
- **Exclusions with rationale**: `entitymanagertest` (test-double kit), `graphquerynaive` (production code all three backends delegate to, exercised through their graphquery tests — its own number reads 0 because cross-package coverage isn't attributed without `-coverpkg`).
- **`internal/config` got its first tests instead of a toothless 0-floor TODO** (review finding): the loader's `validateName` guards attacker-controllable filenames, so the new table covers NUL/control chars, backslash, absolute paths, `..` traversal, empty/dot segments, and drive letters, plus the `os.IsNotExist` contract and Subscribe validation. 0% → **92.6%**, floor set at 87.

## Review

Cranky review independently re-measured every override number against the profile (exact matches) and confirmed the exclusion rationales and regex anchoring. 1 significant + 1 minor (both addressed as above), 1 nit wont-fix. RRs linked to the ticket.

## Verification

`go-test-coverage` PASS on the regenerated profile (total 75.4%); `just ci` green; new config tests parallel + race-clean.