### PR TITLE
fix(search): reject ordered property filters instead of lexicographic compare

### DIFF
--- a/internal/search/filter.go
+++ b/internal/search/filter.go
@@ -1,14 +1,42 @@
 package search
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 )
 
+// ErrOrderedFilterUnsupported is returned when a [Query] uses an ordered
+// property filter (FilterGt/Lt/Gte/Lte). The search backend matches on
+// raw stringified attribute values and has no property-type context, so
+// an ordered comparison here could only be lexicographic — "10" < "9" —
+// which is silently wrong for integer/date properties. Callers that need
+// typed ordering must use the metamodel-aware filter path
+// (internal/filter.Match), not search property filters.
+var ErrOrderedFilterUnsupported = errors.New(
+	"search: ordered property filters (>, <, >=, <=) are unsupported; " +
+		"use the metamodel-typed filter path for typed comparison")
+
+// ValidateFilters rejects filters the search backend cannot evaluate
+// correctly. Today that is the ordered operators, which would be
+// lexicographic-only (see [ErrOrderedFilterUnsupported]). Callers
+// validate once up front rather than discovering the problem per-entity.
+func ValidateFilters(filters []PropertyFilter) error {
+	for _, f := range filters {
+		switch f.Op {
+		case FilterGt, FilterLt, FilterGte, FilterLte:
+			return ErrOrderedFilterUnsupported
+		default:
+		}
+	}
+	return nil
+}
+
 // MatchFilters returns true if an entity matches all property filters.
-//
-//nolint:gocognit // filter evaluation is a dense switch over operator cases; splitting hurts readability
+// Ordered operators are NOT handled here — they are rejected up front by
+// [ValidateFilters]; if one reaches this function it is treated as a
+// non-match (defensive: the Service validates before iterating).
 func MatchFilters(e *entity.Entity, filters []PropertyFilter) bool {
 	for _, f := range filters {
 		val := e.GetAttributeString(f.Property)
@@ -25,22 +53,10 @@ func MatchFilters(e *entity.Entity, filters []PropertyFilter) bool {
 			if !strings.Contains(strings.ToLower(val), strings.ToLower(f.Value)) {
 				return false
 			}
-		case FilterGt:
-			if val <= f.Value {
-				return false
-			}
-		case FilterLt:
-			if val >= f.Value {
-				return false
-			}
-		case FilterGte:
-			if val < f.Value {
-				return false
-			}
-		case FilterLte:
-			if val > f.Value {
-				return false
-			}
+		case FilterGt, FilterLt, FilterGte, FilterLte:
+			// Unsupported (see ValidateFilters / ErrOrderedFilterUnsupported).
+			// Defensive non-match in case validation was bypassed.
+			return false
 		case FilterIn:
 			found := false
 			for _, v := range strings.Split(f.Value, ",") {

--- a/internal/search/filter_ordered_test.go
+++ b/internal/search/filter_ordered_test.go
@@ -1,0 +1,38 @@
+package search
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+func TestValidateFilters_RejectsOrderedOps(t *testing.T) {
+	ordered := []FilterOp{FilterGt, FilterLt, FilterGte, FilterLte}
+	for _, op := range ordered {
+		err := ValidateFilters([]PropertyFilter{{Property: "count", Value: "9", Op: op}})
+		if !errors.Is(err, ErrOrderedFilterUnsupported) {
+			t.Errorf("op %v: expected ErrOrderedFilterUnsupported, got %v", op, err)
+		}
+	}
+}
+
+func TestValidateFilters_AllowsSupportedOps(t *testing.T) {
+	supported := []FilterOp{FilterEq, FilterNe, FilterContains, FilterIn, FilterExists, FilterNotExists}
+	for _, op := range supported {
+		if err := ValidateFilters([]PropertyFilter{{Property: "status", Value: "open", Op: op}}); err != nil {
+			t.Errorf("op %v: unexpected error %v", op, err)
+		}
+	}
+}
+
+// TestMatchFilters_OrderedOpIsNonMatch pins the defensive behavior: if
+// an ordered op bypasses ValidateFilters and reaches MatchFilters, it is
+// a non-match rather than a silent lexicographic comparison.
+func TestMatchFilters_OrderedOpIsNonMatch(t *testing.T) {
+	e := entity.New("REQ-1", "requirement")
+	e.SetString("count", "10")
+	if MatchFilters(e, []PropertyFilter{{Property: "count", Value: "9", Op: FilterGt}}) {
+		t.Error("ordered op should not match (no silent lexicographic comparison)")
+	}
+}

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -28,6 +28,12 @@ func New(reader store.EntityReader, backend Backend) *Service {
 }
 
 func (s *Service) Search(ctx context.Context, q Query) iter.Seq2[Hit, error] {
+	if err := ValidateFilters(q.Filters); err != nil {
+		return func(yield func(Hit, error) bool) {
+			yield(Hit{}, err)
+		}
+	}
+
 	if q.Text == "" {
 		return s.listAll(ctx, q)
 	}

--- a/internal/store/storetest/search.go
+++ b/internal/store/storetest/search.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 )
 
@@ -193,73 +192,31 @@ func RunSearchTests(t *testing.T, sf SearchFactory) {
 		assert.Empty(t, results)
 	})
 
-	t.Run("FilterGt", func(t *testing.T) {
-		s, searcher := sf(t)
-		seedSearchData(t, s)
+	// Ordered property filters are unsupported on the search backend: it
+	// matches raw stringified values with no property-type context, so an
+	// ordered comparison could only be lexicographic ("10" < "9"), which
+	// is silently wrong for integer/date properties. The contract is now
+	// "reject up front" rather than "compare lexicographically". Typed
+	// ordering belongs on the metamodel-aware filter path.
+	for _, op := range []struct {
+		name string
+		op   search.FilterOp
+	}{
+		{"FilterGt", search.FilterGt},
+		{"FilterGte", search.FilterGte},
+		{"FilterLt", search.FilterLt},
+		{"FilterLte", search.FilterLte},
+	} {
+		t.Run("OrderedFilterUnsupported/"+op.name, func(t *testing.T) {
+			s, searcher := sf(t)
+			seedSearchData(t, s)
 
-		results := collectHits(t, searcher.Search(ctx(), search.Query{
-			Filters: []search.PropertyFilter{
-				{Property: "priority", Value: "high", Op: search.FilterGt},
-			},
-		}))
-		// "low" > "high" lexicographically
-		assert.Len(t, results, 1)
-		assert.Equal(t, "FEAT-002", results[0].ID)
-	})
-
-	t.Run("FilterGte", func(t *testing.T) {
-		s, searcher := sf(t)
-		seedSearchData(t, s)
-
-		results := collectHits(t, searcher.Search(ctx(), search.Query{
-			Filters: []search.PropertyFilter{
-				{Property: "priority", Value: "high", Op: search.FilterGte},
-			},
-		}))
-		assert.Len(t, results, 2)
-	})
-
-	t.Run("FilterLtExcludesEqual", func(t *testing.T) {
-		s, searcher := sf(t)
-		e1 := entity.New("A", "t")
-		e1.SetString("score", "5")
-		e2 := entity.New("B", "t")
-		e2.SetString("score", "3")
-		e3 := entity.New("C", "t")
-		e3.SetString("score", "5")
-		require.NoError(t, s.CreateEntity(ctx(), e1))
-		require.NoError(t, s.CreateEntity(ctx(), e2))
-		require.NoError(t, s.CreateEntity(ctx(), e3))
-
-		results := collectHits(t, searcher.Search(ctx(), search.Query{
-			Filters: []search.PropertyFilter{
-				{Property: "score", Value: "5", Op: search.FilterLt},
-			},
-		}))
-		assert.Len(t, results, 1)
-		assert.Equal(t, "B", results[0].ID)
-	})
-
-	t.Run("FilterLteIncludesEqual", func(t *testing.T) {
-		s, searcher := sf(t)
-		e1 := entity.New("A", "t")
-		e1.SetString("score", "5")
-		e2 := entity.New("B", "t")
-		e2.SetString("score", "3")
-		e3 := entity.New("C", "t")
-		e3.SetString("score", "7")
-		require.NoError(t, s.CreateEntity(ctx(), e1))
-		require.NoError(t, s.CreateEntity(ctx(), e2))
-		require.NoError(t, s.CreateEntity(ctx(), e3))
-
-		results := collectHits(t, searcher.Search(ctx(), search.Query{
-			Filters: []search.PropertyFilter{
-				{Property: "score", Value: "5", Op: search.FilterLte},
-			},
-		}))
-		assert.Len(t, results, 2)
-		ids := []string{results[0].ID, results[1].ID}
-		assert.Contains(t, ids, "A")
-		assert.Contains(t, ids, "B")
-	})
+			err := searchError(searcher.Search(ctx(), search.Query{
+				Filters: []search.PropertyFilter{
+					{Property: "priority", Value: "high", Op: op.op},
+				},
+			}))
+			require.ErrorIs(t, err, search.ErrOrderedFilterUnsupported)
+		})
+	}
 }

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -120,6 +120,18 @@ func collectHits(t *testing.T, it iter.Seq2[search.Hit, error]) []search.Hit {
 	return results
 }
 
+// searchError drains a search iterator and returns the first error it
+// yields (nil if the search succeeded). Used by conformance cases that
+// assert a query is rejected rather than asserting on hits.
+func searchError(it iter.Seq2[search.Hit, error]) error {
+	for _, err := range it {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // countRelations counts relations matching a query.
 func countRelations(t *testing.T, s store.Store) int {
 	t.Helper()

--- a/tickets/entities/automated-measures/search-ordered-filter-rejected-test.md
+++ b/tickets/entities/automated-measures/search-ordered-filter-rejected-test.md
@@ -1,0 +1,9 @@
+---
+id: search-ordered-filter-rejected-test
+type: automated-measure
+title: 'Test: search ordered property filters are rejected, not lexicographic'
+description: 'Regression for BUG-20IGWM: asserts search.ValidateFilters rejects FilterGt/Lt/Gte/Lte with ErrOrderedFilterUnsupported (and allows eq/ne/contains/in/exists), MatchFilters defensive-non-matches an ordered op, and the store search conformance suite surfaces ErrOrderedFilterUnsupported for every backend. Fails if ordered ops revert to lexicographic comparison.'
+kind: test
+location: internal/search/filter_ordered_test.go (TestValidateFilters_RejectsOrderedOps, TestValidateFilters_AllowsSupportedOps, TestMatchFilters_OrderedOpIsNonMatch) + internal/store/storetest/search.go (Search/OrderedFilterUnsupported/*)
+status: active
+---

--- a/tickets/entities/bugs/BUG-20IGWM.md
+++ b/tickets/entities/bugs/BUG-20IGWM.md
@@ -1,0 +1,52 @@
+---
+id: BUG-20IGWM
+type: bug
+title: Search ordered property filters compare lexicographically (silently wrong)
+description: search.MatchFilters evaluated FilterGt/Lt/Gte/Lte by comparing raw stringified attribute values with Go's string operators, so an integer/date property filter compared lexicographically ('10' < '9'). The search backend has no property-type context (it imports neither metamodel nor filter), so it cannot compare these correctly. The store search conformance suite even pinned the lexicographic behavior ('low > high lexicographically'). No application code populates Query.Filters today, so the bug was latent — but the ordered ops were a foot-gun waiting for the first caller.
+priority: medium
+why1: MatchFilters used val <= f.Value etc. on GetAttributeString output, which is byte-order comparison, not typed comparison.
+why2: The search backend matches raw stringified values and has no property-type context to parse integers/dates before comparing.
+why3: Ordered operators were added to the search filter API without a way to compare correctly, then pinned as lexicographic by the conformance suite rather than rejected.
+why4: Research RES-6PK0S3 established that typed comparison belongs on the metamodel-aware filter.Match path, not search property filters — but the search API still offered ordered ops that could only be wrong.
+why5: No application used Query.Filters ordered ops, so the silently-wrong comparison was never exercised and never caught.
+prevention: search.ValidateFilters now rejects FilterGt/Lt/Gte/Lte with ErrOrderedFilterUnsupported, checked once up front in Service.Search; MatchFilters treats them as a defensive non-match. The store search conformance suite asserts the error instead of lexicographic results. Typed ordering is documented to belong on filter.Match (RES-6PK0S3, step 2).
+status: done
+---
+
+## Bug
+
+Found in the 2026-06-09 backend review (C2) and scoped by research
+**RES-6PK0S3** as step 2 (option D2).
+
+`search.MatchFilters` evaluated `FilterGt/Lt/Gte/Lte` with Go string operators
+on `GetAttributeString` output:
+
+```go
+case FilterGt:
+    if val <= f.Value { return false }   // "10" <= "9" is true → wrong
+```
+
+So an integer/date property filter compared **lexicographically** (`"10" <
+"9"`). The search backend imports neither `metamodel` nor `filter`, so it has no
+property-type context and *cannot* compare these correctly. The store search
+conformance suite (`storetest/search.go`) even pinned the lexicographic result
+with the comment "low > high lexicographically".
+
+No application code populates `Query.Filters` today (only `storetest`), so the
+bug was **latent** — but the ordered ops were a foot-gun for the first real
+caller.
+
+## Fix (PR pending)
+
+Per RES-6PK0S3 (typed comparison belongs on the metamodel-aware `filter.Match`,
+not search property filters):
+
+- `search.ValidateFilters` rejects `FilterGt/Lt/Gte/Lte` with the new `ErrOrderedFilterUnsupported`, checked once up front in `Service.Search` (surfaced through the result iterator). `MatchFilters` treats them as a defensive non-match if validation is bypassed.
+- The store search **conformance contract** changes: the four ordered-op cases now assert `ErrOrderedFilterUnsupported` instead of lexicographic hit-sets. This is an intended contract change (the old behavior was silently-wrong).
+
+The equality / contains / in / exists ops are unaffected.
+
+## Tests
+
+- `internal/search/filter_ordered_test.go`: `ValidateFilters` rejects all four ordered ops and allows the supported ones; `MatchFilters` defensive-non-matches an ordered op.
+- `storetest/search.go`: `OrderedFilterUnsupported/{FilterGt,Gte,Lt,Lte}` assert `ErrOrderedFilterUnsupported` across every store backend (fsstore/memstore/pgstore).

--- a/tickets/relations/BUG-20IGWM--adds-measure--search-ordered-filter-rejected-test.md
+++ b/tickets/relations/BUG-20IGWM--adds-measure--search-ordered-filter-rejected-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-20IGWM
+relation: adds-measure
+to: search-ordered-filter-rejected-test
+---

--- a/tickets/relations/BUG-20IGWM--affects--store-backends.md
+++ b/tickets/relations/BUG-20IGWM--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-20IGWM
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-20IGWM--fixes--FEAT-y6g5.md
+++ b/tickets/relations/BUG-20IGWM--fixes--FEAT-y6g5.md
@@ -1,0 +1,5 @@
+---
+from: BUG-20IGWM
+relation: fixes
+to: FEAT-y6g5
+---

--- a/tickets/relations/search-ordered-filter-rejected-test--protects--store-backends.md
+++ b/tickets/relations/search-ordered-filter-rejected-test--protects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: search-ordered-filter-rejected-test
+relation: protects
+to: store-backends
+---


### PR DESCRIPTION
## Summary

Fixes review finding **C2**, step 2 (option D2 from research **RES-6PK0S3**). `search.MatchFilters` evaluated `FilterGt/Lt/Gte/Lte` with Go string operators on stringified attribute values, so an integer/date property filter compared **lexicographically** (`"10" < "9"`). The search backend imports neither `metamodel` nor `filter`, so it has no property-type context and *cannot* compare these correctly — the conformance suite even pinned the wrong behavior ("low > high lexicographically").

No application code populates `Query.Filters` today (only `storetest`), so the bug was latent — but the ordered ops were a foot-gun for the first real caller.

## Fix

Per the research conclusion (typed comparison belongs on the metamodel-aware `filter.Match`, not search property filters):

- New `search.ValidateFilters` rejects `FilterGt/Lt/Gte/Lte` with `ErrOrderedFilterUnsupported`, checked once up front in `Service.Search` and surfaced through the result iterator. `MatchFilters` treats an ordered op as a defensive non-match if validation is somehow bypassed.
- **Contract change:** the four ordered-op store-search conformance cases now assert `ErrOrderedFilterUnsupported` instead of lexicographic hit-sets. This is intended — the old behavior was silently wrong, and no app relied on it.
- Equality / contains / in / exists ops are unchanged.

## Tests

- `internal/search/filter_ordered_test.go`: `ValidateFilters` rejects all four ordered ops and allows the supported ones; `MatchFilters` defensive-non-matches an ordered op.
- `storetest/search.go`: `Search/OrderedFilterUnsupported/{FilterGt,Gte,Lt,Lte}` assert the error across every store backend (verified default + `-tags memorybackend`).

`go test ./...`, `golangci-lint`, and `just arch-lint` all pass.