### PR TITLE
perf: hot-path benchmarks + alloc-ceiling contract test (TKT-9Y4ZWS)

### DIFF
--- a/internal/affordances/bench_test.go
+++ b/internal/affordances/bench_test.go
@@ -110,8 +110,7 @@ assignments:
 
 	b.ReportAllocs()
 	for b.Loop() {
-		fv := resolver.FieldVerdicts(pctx, tkt)
-		rv := resolver.RelationVerdicts(pctx, tkt)
-		_, _ = fv, rv
+		_ = resolver.FieldVerdicts(pctx, tkt)
+		_ = resolver.RelationVerdicts(pctx, tkt)
 	}
 }

--- a/internal/affordances/bench_test.go
+++ b/internal/affordances/bench_test.go
@@ -1,0 +1,117 @@
+package affordances_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// BenchmarkVerdicts pins the per-entity affordance resolution cost
+// (TKT-9Y4ZWS): every data-entry response carries `_fields` and
+// relation verdicts, so this path runs once per entity per request.
+// The fixture mirrors the UC10 feature-test shape — a real Declarative
+// with a group-conferred role (member-of walk through the store graph)
+// and predicate-gated grants, so the number includes the role walk and
+// predicate evaluation, not just map lookups.
+//
+// Note: this is the per-call path without a ctx-cached acl.Request —
+// the production router attaches one per HTTP request to amortize the
+// member-of walk (see TestResolver_ReusesRequestFromContext). This
+// benchmark is the uncached upper bound.
+func BenchmarkVerdicts(b *testing.B) {
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Properties: map[string]metamodel.PropertyDef{
+					"title":          {Type: metamodel.PropertyTypeString},
+					"status":         {Type: metamodel.PropertyTypeString},
+					"internal_notes": {Type: metamodel.PropertyTypeString},
+				},
+			},
+			"person": {},
+			"team":   {},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"depends-on": {From: []string{"ticket"}, To: []string{"ticket"}},
+		},
+	}
+
+	policy, err := acl.LoadPolicyBytes([]byte(`
+roles:
+  editor:
+    write: [ticket]
+    fields:
+      ticket:
+        - field: status
+          when: "entity.status == 'open'"
+        - field: title
+    visible:
+      ticket:
+        - field: title
+        - field: status
+    relations:
+      ticket:
+        - relation: depends-on
+          when: "entity.status == 'open'"
+assignments:
+  editors: editor
+`))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	ms := memstore.New()
+	ctx := context.Background()
+	seed := func(id, typ string) {
+		if seedErr := ms.CreateEntity(ctx, entity.New(id, typ)); seedErr != nil {
+			b.Fatalf("seed %s: %v", id, seedErr)
+		}
+	}
+	seed("alice", "person")
+	seed("editors", "team")
+	if _, relErr := ms.CreateRelation(ctx, "alice", "member-of", "editors", nil); relErr != nil {
+		b.Fatal(relErr)
+	}
+	for i := range 200 {
+		seed(fmt.Sprintf("TKT-%03d", i), "ticket")
+	}
+	// Some outgoing edges so OutgoingCounts has work to do.
+	for i := range 50 {
+		from := fmt.Sprintf("TKT-%03d", i)
+		to := fmt.Sprintf("TKT-%03d", i+100)
+		if _, relErr := ms.CreateRelation(ctx, from, "depends-on", to, nil); relErr != nil {
+			b.Fatal(relErr)
+		}
+	}
+
+	declarative, err := acl.NewDeclarative(policy, acl.NewStoreGraph(ms))
+	if err != nil {
+		b.Fatal(err)
+	}
+	resolver, err := affordances.New(meta, storeRelationLookup{ms}, declarative)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	tkt := entity.New("TKT-007", "ticket")
+	tkt.SetString("title", "broken login")
+	tkt.SetString("status", "open")
+	tkt.SetString("internal_notes", "do not leak")
+
+	pctx := principal.With(context.Background(),
+		principal.Principal{User: "alice", Tool: principal.ToolDataEntry})
+
+	b.ReportAllocs()
+	for b.Loop() {
+		fv := resolver.FieldVerdicts(pctx, tkt)
+		rv := resolver.RelationVerdicts(pctx, tkt)
+		_, _ = fv, rv
+	}
+}

--- a/internal/entitymanager/bench_test.go
+++ b/internal/entitymanager/bench_test.go
@@ -1,0 +1,56 @@
+package entitymanager_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// BenchmarkValidateCreate pins the dry-run validation hot path
+// (TKT-9Y4ZWS). The data-entry SPA calls ValidateCreate per keystroke,
+// and TestValidate_DryRunDoesNotScanStore pins that it must not scan
+// the store. The store is seeded with 1000 entities so a broken
+// no-scan contract is visible here too: ns/op tracking the seed count
+// means dry-run cost became O(store).
+func BenchmarkValidateCreate(b *testing.B) {
+	meta, err := metamodel.Parse([]byte(testMetamodelYAML))
+	if err != nil {
+		b.Fatal(err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:     memstore.New(),
+		Meta:      meta,
+		Templater: nopTemplater{},
+		Audit:     audit.Nop{},
+		ACL:       acl.NopACL{},
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	ctx := context.Background()
+	for i := range 1000 {
+		e := entity.New("", "requirement")
+		e.SetString("title", fmt.Sprintf("seed requirement %d", i))
+		if _, err := mgr.CreateEntity(ctx, e, entity.CreateOptions{}); err != nil {
+			b.Fatalf("seed %d: %v", i, err)
+		}
+	}
+
+	candidate := entity.New("", "requirement")
+	candidate.SetString("title", "draft being typed")
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, _, err := mgr.ValidateCreate(ctx, candidate, entity.CreateOptions{}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/entitymanager/bench_test.go
+++ b/internal/entitymanager/bench_test.go
@@ -15,10 +15,12 @@ import (
 
 // BenchmarkValidateCreate pins the dry-run validation hot path
 // (TKT-9Y4ZWS). The data-entry SPA calls ValidateCreate per keystroke,
-// and TestValidate_DryRunDoesNotScanStore pins that it must not scan
-// the store. The store is seeded with 1000 entities so a broken
-// no-scan contract is visible here too: ns/op tracking the seed count
-// means dry-run cost became O(store).
+// and TestValidateCreate_SkipsIDGeneration (RR-8I07) pins that it must
+// not scan the store. The store is seeded with 1000 entities so a
+// broken no-scan contract is visible here too: ns/op tracking the seed
+// count means dry-run cost became O(store).
+// TestValidateCreate_AllocCeiling enforces the allocation contract in
+// regular CI runs.
 func BenchmarkValidateCreate(b *testing.B) {
 	meta, err := metamodel.Parse([]byte(testMetamodelYAML))
 	if err != nil {
@@ -52,5 +54,49 @@ func BenchmarkValidateCreate(b *testing.B) {
 		if _, _, err := mgr.ValidateCreate(ctx, candidate, entity.CreateOptions{}); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+// TestValidateCreate_AllocCeiling turns the benchmark's allocation
+// measurement into an enforced contract: ns/op is machine-dependent
+// and can't gate CI, but allocs/op is deterministic. Measured ~7
+// allocs; the ceiling leaves headroom for Go-version drift while still
+// catching an accidental O(store) regression (which would show up as
+// hundreds of allocations from list iteration).
+//
+// NOT parallel: testing.AllocsPerRun panics inside parallel tests
+// (concurrent allocations would corrupt the measurement).
+func TestValidateCreate_AllocCeiling(t *testing.T) {
+	meta, err := metamodel.Parse([]byte(testMetamodelYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:     memstore.New(),
+		Meta:      meta,
+		Templater: nopTemplater{},
+		Audit:     audit.Nop{},
+		ACL:       acl.NopACL{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	for i := range 200 {
+		e := entity.New("", "requirement")
+		e.SetString("title", fmt.Sprintf("seed %d", i))
+		if _, err := mgr.CreateEntity(ctx, e, entity.CreateOptions{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	candidate := entity.New("", "requirement")
+	candidate.SetString("title", "draft being typed")
+
+	avg := testing.AllocsPerRun(100, func() {
+		_, _, _ = mgr.ValidateCreate(ctx, candidate, entity.CreateOptions{})
+	})
+	if avg > 20 {
+		t.Fatalf("ValidateCreate allocations regressed: %.0f allocs/op, ceiling 20 (measured ~7; "+
+			"a jump usually means the dry-run path started scanning the store)", avg)
 	}
 }

--- a/internal/search/bench_test.go
+++ b/internal/search/bench_test.go
@@ -1,0 +1,52 @@
+package search_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/search"
+	"github.com/Sourcehaven-BV/rela/internal/search/bleveindex"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// BenchmarkSearch pins the full-text search path the data-entry
+// _search endpoint and the MCP search_entities tool sit on
+// (TKT-9Y4ZWS): a bleve text query plus store hydration of the hits,
+// against a 1000-entity index with a 20-hit limit.
+func BenchmarkSearch(b *testing.B) {
+	idx, err := bleveindex.NewMem()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = idx.Close() }()
+
+	st := memstore.New(memstore.WithObserver(idx))
+	ctx := context.Background()
+	for i := range 1000 {
+		e := entity.New(fmt.Sprintf("TKT-%04d", i), "ticket")
+		// Vary the text so the query has both matches and misses to rank.
+		e.SetString("title", fmt.Sprintf("ticket %d: %s in widget %d",
+			i, []string{"login failure", "render glitch", "sync stall", "crash report"}[i%4], i%37))
+		if err := st.CreateEntity(ctx, e); err != nil {
+			b.Fatalf("seed %d: %v", i, err)
+		}
+	}
+
+	s := search.New(st, idx)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		hits := 0
+		for _, err := range s.Search(ctx, search.Query{Text: "login", Limit: 20}) {
+			if err != nil {
+				b.Fatal(err)
+			}
+			hits++
+		}
+		if hits == 0 {
+			b.Fatal("query matched nothing — fixture broken")
+		}
+	}
+}

--- a/internal/validation/bench_test.go
+++ b/internal/validation/bench_test.go
@@ -1,0 +1,84 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// Write-path validation runs on every entitymanager mutation, so its
+// cost is part of every create/update (TKT-9Y4ZWS). The two benchmarks
+// split the rule kinds: when/then rules are pure property checks; Lua
+// rules pay for a fresh sandboxed state per rule evaluation — that
+// per-write cost is exactly what these numbers make visible.
+
+func benchTicketMeta(rules ...metamodel.ValidationRule) *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Properties: map[string]metamodel.PropertyDef{
+					"status":   {Type: "string"},
+					"priority": {Type: "string"},
+				},
+			},
+		},
+		Validations: rules,
+	}
+}
+
+func benchTickets(n int) []*entity.Entity {
+	out := make([]*entity.Entity, 0, n)
+	for i := range n {
+		e := entity.New(fmt.Sprintf("TKT-%04d", i), "ticket")
+		e.SetString("status", []string{"ready", "draft"}[i%2])
+		if i%3 != 0 { // leave a third without priority so rules fire
+			e.SetString("priority", "high")
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func BenchmarkCheck_WhenThen(b *testing.B) {
+	meta := benchTicketMeta(metamodel.ValidationRule{
+		Name:        "ready-needs-priority",
+		Description: "Ready tickets must have priority",
+		EntityType:  "ticket",
+		When:        []string{"status=ready"},
+		Then:        []string{"priority!="},
+		Severity:    "error",
+	})
+	entities := benchTickets(100)
+	svc := New(meta, newMockWorkspace().services(b.TempDir()))
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = svc.Check(context.Background(), entities, nil)
+	}
+}
+
+func BenchmarkCheck_Lua(b *testing.B) {
+	meta := benchTicketMeta(metamodel.ValidationRule{
+		Name:        "ready-needs-priority-lua",
+		Description: "Ready tickets must have priority (Lua)",
+		EntityType:  "ticket",
+		Lua: `
+			if entity.properties.status == "ready" and
+				(entity.properties.priority == nil or entity.properties.priority == "") then
+				return { message = "priority required for ready tickets" }
+			end
+			return nil
+		`,
+		Severity: "error",
+	})
+	entities := benchTickets(100)
+	svc := New(meta, newMockWorkspace().services(b.TempDir()))
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = svc.Check(context.Background(), entities, nil)
+	}
+}

--- a/justfile
+++ b/justfile
@@ -154,7 +154,10 @@ fuzz:
     go test -run='^$$' -fuzz='^FuzzValidateID$$' -fuzztime=30s ./internal/entity/
 
 # Run the hot-path benchmarks (dry-run validation, affordance verdicts,
-# search, write-path validation, plus the pre-existing lua/pgstore ones)
+# search, write-path validation, plus the pre-existing markdown-parse
+# benchmark in internal/lua). The pgstore graphquery benchmark is
+# DB-gated and postgres-tagged — run it via:
+#   go test -tags postgres -run='^$' -bench=. ./internal/store/pgstore/
 bench:
     @echo "Running benchmarks..."
     go test -run='^$$' -bench=. -benchmem ./internal/entitymanager/ ./internal/affordances/ ./internal/search/ ./internal/validation/ ./internal/lua/

--- a/justfile
+++ b/justfile
@@ -153,6 +153,12 @@ fuzz:
     go test -run='^$$' -fuzz='^FuzzParseEntityID$$' -fuzztime=30s ./internal/entity/
     go test -run='^$$' -fuzz='^FuzzValidateID$$' -fuzztime=30s ./internal/entity/
 
+# Run the hot-path benchmarks (dry-run validation, affordance verdicts,
+# search, write-path validation, plus the pre-existing lua/pgstore ones)
+bench:
+    @echo "Running benchmarks..."
+    go test -run='^$$' -bench=. -benchmem ./internal/entitymanager/ ./internal/affordances/ ./internal/search/ ./internal/validation/ ./internal/lua/
+
 # Run quick fuzz tests (5 seconds each)
 fuzz-short:
     @echo "Running quick fuzz tests..."

--- a/tickets/entities/implementation-checklists/IMPL-1LOR30.md
+++ b/tickets/entities/implementation-checklists/IMPL-1LOR30.md
@@ -1,0 +1,33 @@
+---
+id: IMPL-1LOR30
+type: implementation-checklist
+title: 'Implementation: Hot-path benchmarks: dry-run validation, affordances, search, write validation'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written — TestValidateCreate_AllocCeiling (enforced contract from the review's leverage finding); benchmarks themselves are the deliverable
+- [x] Integration — benchmarks drive real service paths (Declarative member-of walk, bleve, fresh-LState Lua)
+- [x] Happy path implemented (4 benchmark files + just bench)
+- [x] Edge cases handled (hits==0 fixture guard in search; AllocsPerRun serial constraint documented)
+- [x] Error handling in place (b.Fatal on all setup errors)
+
+## Test Quality
+
+- [x] Fixtures reuse package conventions (UC10 shape, testMetamodelYAML, newMockWorkspace)
+- [x] Reviewer verified non-vacuity of all three suspicious paths: role walk resolves through member-of (not the no-roles early exit), search query matches 250 rows, ValidateCreate validates rather than failing fast and uses SkipIDGeneration (no ID scan)
+- [x] Setup outside b.Loop everywhere; b.ReportAllocs on all five; dead-code elimination not a hazard (interface dispatch + side effects)
+
+## Manual Verification
+
+- [x] All benchmarks smoke-run; numbers: ValidateCreate 1.4µs/7allocs, Verdicts 8.6µs/107allocs, Search 2.5ms, Check_WhenThen 16µs vs Check_Lua 2.5ms (~150× — the per-write fresh-LState cost, now a number)
+- [x] Reviewer reproduced the alloc counts exactly at -benchtime=20x
+- [x] just ci green; touched packages green under -race -count=2 -shuffle=on
+
+## Quality
+
+- [x] Follows existing benchmark conventions (pgstore/lua precedents)
+- [x] No security issues; no silent failures; no debug code

--- a/tickets/entities/planning-checklists/PLAN-XO6G10.md
+++ b/tickets/entities/planning-checklists/PLAN-XO6G10.md
@@ -1,0 +1,45 @@
+---
+id: PLAN-XO6G10
+type: planning-checklist
+title: 'Planning: Hot-path benchmarks'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem understood — performance contracts documented in prose, no numbers (2 benchmarks repo-wide)
+- [x] Scope — 4 bench files + just bench recipe; explicitly NO CI regression tracking
+- [x] Acceptance criteria: each benchmark exercises the real documented hot path (not a mock), reuses package fixtures, runs via just bench
+
+## Research
+
+- [x] ~~/research~~ (N/A)
+- [x] Verified API surfaces before writing: ValidateCreate, PolicyResolver.FieldVerdicts/RelationVerdicts (UC10 fixture shape with real Declarative + member-of walk), search.New + Query, validation.Service.Check
+- [x] Existing benchmarks reviewed (lua BenchmarkMdParse, pgstore BenchmarkGraphQuery) for conventions
+
+## Approach
+
+- [x] b.Loop() (modern), b.ReportAllocs, realistic seeds (1000-entity store/index; 100-entity validation batch; 200-ticket graph with member-of role walk)
+- [x] Alternatives: benchstat CI tracking rejected (own project); microbenchmarks of internals rejected (measure the documented contracts, not implementation details)
+
+## Security Considerations
+
+- [x] N/A (test-only)
+
+## Test Plan
+
+- [x] Smoke-run all benchmarks (-benchtime=10x); full test suites of touched packages still green
+
+## Risk Assessment
+
+- [x] Effort s. Risk: benchmarks rot if unused — mitigated by just bench discoverability and contract-anchored doc comments
+
+## Documentation Planning
+
+- [x] N/A
+
+## Design Review
+
+- [x] ~~/design-review~~ (N/A-with-substitute: scope agreed in session 2026-06-10; CI-tracking explicitly excluded by plan)

--- a/tickets/entities/review-checklists/REV-HV6Q2N.md
+++ b/tickets/entities/review-checklists/REV-HV6Q2N.md
@@ -1,0 +1,25 @@
+---
+id: REV-HV6Q2N
+type: review-checklist
+title: 'Review: Hot-path benchmarks'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] Touched packages green under `-race -count=2 -shuffle=on`; lint 0 issues; gofmt clean
+- [x] Full `just ci` green
+
+## Code Review
+
+- [x] `/code-review` run; reviewer traced all fixtures through the real resolution code and reproduced the alloc numbers exactly
+- [x] Findings: 0 critical, 0 significant, 2 minors (both addressed: stale test reference + recipe comment; nit folded in), 1 leverage finding ADOPTED — alloc-ceiling contract test now runs in regular CI (RR-Z0VN2X, RR-9ZB7ZO)
+- [x] Non-vacuity independently verified for all three benchmark fixtures
+
+## Verification
+
+- [x] First numbers on record: ValidateCreate 1.4µs (no-scan holds at 1000 entities), Verdicts 8.6µs uncached, Search 2.5ms, Lua validation ~150× when/then
+
+**PR:** (added once created)

--- a/tickets/entities/review-checklists/REV-HV6Q2N.md
+++ b/tickets/entities/review-checklists/REV-HV6Q2N.md
@@ -22,4 +22,4 @@ status: done
 
 - [x] First numbers on record: ValidateCreate 1.4µs (no-scan holds at 1000 entities), Verdicts 8.6µs uncached, Search 2.5ms, Lua validation ~150× when/then
 
-**PR:** (added once created)
+**PR:** https://github.com/sourcehaven-bv/rela/pull/969

--- a/tickets/entities/review-responses/RR-9ZB7ZO.md
+++ b/tickets/entities/review-responses/RR-9ZB7ZO.md
@@ -1,0 +1,9 @@
+---
+id: RR-9ZB7ZO
+type: review-response
+title: Stale test reference + misleading bench recipe comment
+finding: BenchmarkValidateCreate's comment referenced a nonexistent test (the real pin is TestValidateCreate_SkipsIDGeneration, RR-8I07); the just bench comment promised pgstore benchmarks the recipe doesn't run, and called the markdown-parse benchmark a 'lua' one.
+severity: minor
+resolution: Comment now points at the real test; recipe comment names the markdown-parse benchmark and documents the postgres-tagged command for the DB-gated pgstore benchmark (kept out of the default recipe — must not link pgx). Also simplified the _, _ = fv, rv nit.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Z0VN2X.md
+++ b/tickets/entities/review-responses/RR-Z0VN2X.md
@@ -1,0 +1,9 @@
+---
+id: RR-Z0VN2X
+type: review-response
+title: Benchmarks measured contracts but enforced nothing — alloc ceilings added
+finding: 'Reviewer leverage finding: ns/op can''t gate CI (machine-dependent) but allocs/op is deterministic; without a gate, a regressed no-scan contract is only visible if a human runs just bench.'
+severity: minor
+resolution: Added TestValidateCreate_AllocCeiling (ceiling 20 vs measured ~7; an O(store) regression shows as hundreds of allocs) running in regular CI. Serial — testing.AllocsPerRun panics in parallel tests.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-9Y4ZWS.md
+++ b/tickets/entities/tickets/TKT-9Y4ZWS.md
@@ -5,7 +5,7 @@ title: 'Hot-path benchmarks: dry-run validation, affordances, search, write vali
 kind: test
 priority: low
 effort: s
-status: planning
+status: done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-9Y4ZWS.md
+++ b/tickets/entities/tickets/TKT-9Y4ZWS.md
@@ -1,0 +1,36 @@
+---
+id: TKT-9Y4ZWS
+type: ticket
+title: 'Hot-path benchmarks: dry-run validation, affordances, search, write validation'
+kind: test
+priority: low
+effort: s
+status: planning
+---
+
+## Problem
+
+The repo has 2 benchmarks total while its own tests document performance
+contracts in prose: "dry-run validation must not scan the store — per-keystroke
+UI cost" (entitymanager), per-request affordance/`_actions` resolution with
+memoization (affordances), the search endpoint, and write-path validation (incl.
+fresh-Lua-state-per-rule cost). None of those contracts has a number; "is this
+slow?" has no measurable answer.
+
+## Approach (agreed with reviewer in session)
+
+Four benchmark files next to the code they measure, reusing the packages'
+existing test fixtures; `just bench` recipe. NO CI regression tracking
+(benchstat infra is its own project) — the goal is measurability.
+
+1. `entitymanager`: BenchmarkValidateCreate against a 1000-entity store — if ns/op ever tracks store size, the documented no-scan contract broke.
+2. `affordances`: field + relation verdicts through the real Declarative/member-of path (UC10 fixture shape).
+3. `search`: bleve text query + hydration over a 1000-entity index.
+4. `validation`: Check with when/then rules and with a Lua rule (the per-write fresh-LState cost), 100 entities.
+
+Per session decision: separate PR (3 of 3 split from the original combined
+CI-quality task).
+
+## Verification
+
+- Benchmarks run green via `just bench`; lint clean; `just ci` green (benchmarks don't run in CI tests but must compile).

--- a/tickets/relations/TKT-9Y4ZWS--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-9Y4ZWS--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9Y4ZWS
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-9Y4ZWS--has-implementation--IMPL-1LOR30.md
+++ b/tickets/relations/TKT-9Y4ZWS--has-implementation--IMPL-1LOR30.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9Y4ZWS
+relation: has-implementation
+to: IMPL-1LOR30
+---

--- a/tickets/relations/TKT-9Y4ZWS--has-planning--PLAN-XO6G10.md
+++ b/tickets/relations/TKT-9Y4ZWS--has-planning--PLAN-XO6G10.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9Y4ZWS
+relation: has-planning
+to: PLAN-XO6G10
+---

--- a/tickets/relations/TKT-9Y4ZWS--has-review--REV-HV6Q2N.md
+++ b/tickets/relations/TKT-9Y4ZWS--has-review--REV-HV6Q2N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9Y4ZWS
+relation: has-review
+to: REV-HV6Q2N
+---

--- a/tickets/relations/TKT-9Y4ZWS--has-review-response--RR-9ZB7ZO.md
+++ b/tickets/relations/TKT-9Y4ZWS--has-review-response--RR-9ZB7ZO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9Y4ZWS
+relation: has-review-response
+to: RR-9ZB7ZO
+---

--- a/tickets/relations/TKT-9Y4ZWS--has-review-response--RR-Z0VN2X.md
+++ b/tickets/relations/TKT-9Y4ZWS--has-review-response--RR-Z0VN2X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9Y4ZWS
+relation: has-review-response
+to: RR-Z0VN2X
+---

--- a/tickets/relations/TKT-9Y4ZWS--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-9Y4ZWS--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9Y4ZWS
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Third of three PRs split from the CI-quality task (full ticket flow in tickets/, TKT-9Y4ZWS). Independent of the other open PRs.

## What

The repo had 2 benchmarks while its tests documented performance contracts in prose only. Four new benchmarks pin those contracts with numbers, plus a `just bench` recipe:

| Benchmark | Path | First numbers (M1) |
|---|---|---|
| `BenchmarkValidateCreate` (entitymanager) | per-keystroke dry-run validation against a 1000-entity store | 1.4µs, 7 allocs — the no-scan contract holds |
| `BenchmarkVerdicts` (affordances) | `_fields`/relation verdicts through the real Declarative member-of walk + predicate grants (uncached upper bound) | 8.6µs, 107 allocs |
| `BenchmarkSearch` (search) | bleve text query + hydration, 1000-entity index, limit 20 | 2.5ms |
| `BenchmarkCheck_WhenThen` vs `BenchmarkCheck_Lua` (validation) | write-path validation, 100 entities | 16µs vs 2.5ms — the fresh-LState-per-rule cost is ~150×, now a number instead of folklore |

## From the review: a contract test, not just measurements

The reviewer's leverage finding: ns/op can't gate CI, but allocs/op is deterministic. `TestValidateCreate_AllocCeiling` now runs in regular CI (ceiling 20 vs measured ~7) — an accidental O(store) regression in the per-keystroke path shows up as hundreds of allocations and fails the build, instead of waiting for a human to eyeball `just bench`. (Serial by necessity: `testing.AllocsPerRun` panics in parallel tests.)

Reviewer also independently verified fixture non-vacuity: the role walk really resolves alice→member-of→editors→editor (not the no-roles early exit), the search query matches, and `ValidateCreate` validates without ID scanning (`SkipIDGeneration`). Remaining findings were comment/recipe fixes, all addressed (RR-Z0VN2X, RR-9ZB7ZO).

## Verification

All benchmarks smoke-run; touched packages green under `-race -count=2 -shuffle=on`; lint 0 issues; `just ci` green.