### PR TITLE
fix(metamodel): validate id_prefix at load (BUG-RHFHTH)

### DIFF
--- a/internal/entity/id.go
+++ b/internal/entity/id.go
@@ -216,6 +216,12 @@ const (
 // Length is adaptive based on entityCount to minimize collision probability.
 // The function retries with progressively longer IDs if collisions occur.
 // The caps parameter controls suffix capitalization: "upper" or "lower".
+//
+// Precondition: prefix must satisfy metamodel.ValidateIDPrefix, which
+// metamodel.Parse enforces at load time (BUG-RHFHTH) — prefixes come
+// from id_prefix/id_prefixes, so every caller receives a validated
+// value. A pathological prefix (e.g. "--") would otherwise flow into
+// IDs that ValidateID rejects.
 func GenerateShortID(existingIDs []string, prefix string, entityCount int, caps string) string {
 	// Build a set for fast lookup
 	existing := make(map[string]struct{}, len(existingIDs))

--- a/internal/entity/id_fuzz_test.go
+++ b/internal/entity/id_fuzz_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
 // FuzzParseEntityID tests the entity ID parser with arbitrary input
@@ -290,10 +292,12 @@ func FuzzGenerateShortID(f *testing.F) {
 		if prefix == "" || !utf8.ValidString(prefix) {
 			return
 		}
-		for _, c := range prefix {
-			if !isAllowedIDChar(c) {
-				return
-			}
+		// GenerateShortID's documented precondition is a load-validated
+		// prefix: metamodel.Parse rejects anything ValidateIDPrefix
+		// refuses (BUG-RHFHTH), so the fuzz domain mirrors that gate
+		// instead of hand-modeling the character rules.
+		if metamodel.ValidateIDPrefix(prefix) != nil {
+			return
 		}
 
 		// Limit entity count to reasonable values

--- a/internal/entity/testdata/fuzz/FuzzGenerateShortID/bug-rhfhth-double-dash-prefix
+++ b/internal/entity/testdata/fuzz/FuzzGenerateShortID/bug-rhfhth-double-dash-prefix
@@ -1,0 +1,5 @@
+go test fuzz v1
+string("--")
+string("0")
+int(10)
+string("0")

--- a/internal/metamodel/errors.go
+++ b/internal/metamodel/errors.go
@@ -72,6 +72,18 @@ func (e *ConflictingIDPrefixError) Error() string {
 	return "entity " + e.EntityType + " specifies both id_prefix and id_prefixes; use only one"
 }
 
+// InvalidIDPrefixError is returned when an id_prefix would generate
+// IDs that fail entity ID validation (BUG-RHFHTH).
+type InvalidIDPrefixError struct {
+	EntityType string
+	Prefix     string
+	Reason     string
+}
+
+func (e *InvalidIDPrefixError) Error() string {
+	return "entity " + e.EntityType + ": " + e.Reason
+}
+
 // ReservedTypeNameError is returned when a custom type name conflicts with a built-in type.
 type ReservedTypeNameError struct {
 	TypeName string

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -272,6 +272,11 @@ func validateEntityStructure(m *Metamodel) error {
 		if def.IDPrefix != "" && len(def.IDPrefixes) > 0 {
 			return &ConflictingIDPrefixError{EntityType: name}
 		}
+		for _, prefix := range def.GetIDPrefixes() {
+			if err := ValidateIDPrefix(prefix); err != nil {
+				return &InvalidIDPrefixError{EntityType: name, Prefix: prefix, Reason: err.Error()}
+			}
+		}
 
 		m.aliasMap[strings.ToLower(name)] = name
 		for _, alias := range def.Aliases {

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -2186,3 +2186,88 @@ relations:
 		t.Errorf("error %q does not mention the symmetric conflict", err.Error())
 	}
 }
+
+// TestParse_InvalidIDPrefixRejected pins the load-time gate for
+// id_prefix values whose generated IDs would fail entity ID validation
+// (BUG-RHFHTH: GenerateShortID("--", ...) emitted "--9HHF", which the
+// ID validator rejects — found by the weekly fuzz sweep). Prefixes are
+// only ever consumed after metamodel load, so the gate belongs here.
+func TestParse_InvalidIDPrefixRejected(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+	}{
+		{"double dash", "--"},
+		{"dash only", "-"},
+		{"embedded double dash", "A--B-"},
+		{"path separator", "a/b-"},
+		{"space", "a b-"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			yaml := `version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefix: "` + tc.prefix + `"
+    properties:
+      title:
+        type: string
+`
+			_, err := Parse([]byte(yaml))
+			assertError(t, err)
+
+			var prefixErr *InvalidIDPrefixError
+			if !errors.As(err, &prefixErr) {
+				t.Errorf("expected InvalidIDPrefixError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+// TestParse_InvalidIDPrefixRejected_ManualIDType pins a deliberate
+// scope decision: the gate applies to ALL declared prefixes, including
+// id_type: manual types that declare one purely for type-routing
+// (EntityDef.MatchesID). A routing prefix outside the ID charset could
+// never match a ValidateID-legal ID anyway, so rejecting it at load is
+// strictly more honest than letting it silently never match.
+func TestParse_InvalidIDPrefixRejected_ManualIDType(t *testing.T) {
+	yaml := `version: "1.0"
+entities:
+  task:
+    label: Task
+    id_type: manual
+    id_prefix: "auth--mod-"
+    properties:
+      title:
+        type: string
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+
+	var prefixErr *InvalidIDPrefixError
+	if !errors.As(err, &prefixErr) {
+		t.Errorf("expected InvalidIDPrefixError, got %T: %v", err, err)
+	}
+}
+
+// TestParse_InvalidIDPrefixRejected_Plural covers the id_prefixes
+// (list) form: one bad prefix among valid ones fails the load.
+func TestParse_InvalidIDPrefixRejected_Plural(t *testing.T) {
+	yaml := `version: "1.0"
+entities:
+  task:
+    label: Task
+    id_prefixes: ["TSK-", "A--B-"]
+    properties:
+      title:
+        type: string
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+
+	var prefixErr *InvalidIDPrefixError
+	if !errors.As(err, &prefixErr) {
+		t.Errorf("expected InvalidIDPrefixError, got %T: %v", err, err)
+	}
+}

--- a/internal/metamodel/validation.go
+++ b/internal/metamodel/validation.go
@@ -8,6 +8,38 @@ import (
 	"time"
 )
 
+// validIDPrefixBase matches a prefix after trimming one trailing dash:
+// the character set entity IDs allow. Dashes are permitted here — the
+// dash-run constraints (no "--", no trailing dash on the base) are
+// checked separately below so the non-dash case gets a more targeted
+// error message.
+var validIDPrefixBase = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// ValidateIDPrefix rejects id_prefix values whose generated IDs would
+// fail entity ID validation (BUG-RHFHTH). Generated short/sequential
+// IDs have the shape <base>-<suffix>, where base is the prefix with
+// one trailing dash trimmed — so the base must be non-empty, contain
+// only [A-Za-z0-9_-], and neither contain nor end in a dash run that
+// would re-create the forbidden "--" sequence (reserved as the
+// relation key separator). Enforced at metamodel load;
+// entity.GenerateShortID assumes a load-validated prefix.
+func ValidateIDPrefix(prefix string) error {
+	base := strings.TrimSuffix(prefix, "-")
+	if base == "" {
+		return fmt.Errorf("id_prefix %q has no characters besides %q", prefix, "-")
+	}
+	if !validIDPrefixBase.MatchString(base) {
+		return fmt.Errorf(
+			"id_prefix %q contains characters not allowed in entity IDs (allowed: A-Z a-z 0-9 _ -)", prefix)
+	}
+	if strings.Contains(base, "--") || strings.HasSuffix(base, "-") {
+		return fmt.Errorf(
+			"id_prefix %q would generate IDs with consecutive dashes (\"--\" is the relation key separator)",
+			prefix)
+	}
+	return nil
+}
+
 // ValidationErrorType indicates the kind of validation error.
 type ValidationErrorType string
 

--- a/internal/metamodel/validation_test.go
+++ b/internal/metamodel/validation_test.go
@@ -1070,3 +1070,32 @@ func TestValidationError_IsSoft(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateIDPrefix(t *testing.T) {
+	valid := []string{"TKT-", "TKT", "tkt-", "MY-TYPE-", "a_b-", "A1-", "_x-"}
+	for _, p := range valid {
+		if err := ValidateIDPrefix(p); err != nil {
+			t.Errorf("ValidateIDPrefix(%q) = %v, want nil", p, err)
+		}
+	}
+
+	invalid := []struct {
+		prefix string
+		why    string
+	}{
+		{"--", "double dash collapses to a dash-only base (BUG-RHFHTH repro)"},
+		{"-", "dash-only"},
+		{"A--B-", "embedded double dash"},
+		{"TKT--", "trailing double dash"},
+		{"a/b-", "path separator"},
+		{`a\b-`, "backslash"},
+		{"a b-", "space"},
+		{"héllo-", "non-ASCII"},
+		{"x\x00-", "control character"},
+	}
+	for _, tc := range invalid {
+		if err := ValidateIDPrefix(tc.prefix); err == nil {
+			t.Errorf("ValidateIDPrefix(%q) = nil, want error (%s)", tc.prefix, tc.why)
+		}
+	}
+}

--- a/tickets/entities/bug-analysis-checklists/BUGA-G4FER7.md
+++ b/tickets/entities/bug-analysis-checklists/BUGA-G4FER7.md
@@ -1,0 +1,25 @@
+---
+id: BUGA-G4FER7
+type: bug-analysis-checklist
+title: 'Analysis: GenerateShortID can emit IDs its own validator rejects (pathological prefixes)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Reproduction
+
+- [x] Bug reproduced locally — fuzz corpus input `("--", "0", 10, "0")`: `GenerateShortID` returns `"--9HHF"`, `entity.ValidateID` rejects it ("consecutive dashes not allowed")
+- [x] Reproduction is deterministic (the corpus input replays it; now committed as a regression seed since the fixed oracle passes it)
+
+## Root Cause
+
+- [x] Five-whys completed (on the bug entity)
+- [x] Root cause: no layer owned prefix validity. `GenerateShortID` treats the prefix as opaque (trims one trailing `-`, appends `-<base36>`), and `metamodel.Parse` validated prefix *declaration shape* (conflicting forms, presence) but never the *character contract* — so a prefix like `--` flowed through to generation. The generator and the validator (`entity.ValidateID`, `storeutil.ValidateID`) each enforced their half without a shared contract for the input between them.
+
+## Fix Plan
+
+- [x] Direction decided with reviewer (session 2026-06-12): validate at metamodel load — prefixes only enter the system via `id_prefix`/`id_prefixes`, so the load gate covers every caller, and a broken metamodel fails loudly at startup instead of producing broken IDs at write time
+- [x] `metamodel.ValidateIDPrefix` (exported) + `InvalidIDPrefixError` wired into `Parse`'s hard-error path next to the existing prefix checks
+- [x] `GenerateShortID` godoc documents the precondition; the fuzz oracle delegates to `ValidateIDPrefix` (no hand-modeled character rules — the same staleness class fixed in TKT-PCLGGL's harness work)
+- [x] Regression seed committed (`testdata/fuzz/FuzzGenerateShortID/bug-rhfhth-double-dash-prefix`)

--- a/tickets/entities/bugs/BUG-RHFHTH.md
+++ b/tickets/entities/bugs/BUG-RHFHTH.md
@@ -5,7 +5,13 @@ title: GenerateShortID can emit IDs its own validator rejects (pathological pref
 description: Fuzzing found GenerateShortID(prefix="--") returns "--9HHF", which entity.ValidateID rejects (consecutive dashes). The generator treats the prefix as opaque, so invalid prefixes flow into emitted IDs.
 priority: low
 effort: xs
-status: ready
+why1: 'GenerateShortID emitted "--9HHF" for prefix "--": it trims one trailing dash and appends "-<base36>" without checking what that produces.'
+why2: The generator treats the prefix as opaque because prefixes were assumed to be sane — they only enter the system via the metamodel's id_prefix/id_prefixes.
+why3: metamodel.Parse validated prefix declaration shape (conflicting forms, presence for short/sequential types) but never the character contract, so nothing between YAML and ID generation owned prefix validity.
+why4: The ID character rules lived only in the consumers (entity.ValidateID, storeutil.ValidateID); there was no producer-side contract for inputs to generation, and no test generated IDs from hostile prefixes — the fuzz target's oracle hand-modeled per-character validity and missed dash runs.
+why5: 'Systemic: contracts enforced only at the consuming edge let invalid values travel from config to the point of use before failing; the fuzz sweep (TKT-PCLGGL) exists precisely to surface such gaps, and this was its first catch.'
+prevention: 'Load-time gate: metamodel.ValidateIDPrefix enforced in Parse (typed InvalidIDPrefixError), so a broken metamodel fails at startup, not at write time. The fuzz oracle now delegates to the same exported contract instead of hand-modeling it (the staleness class from TKT-PCLGGL), the repro is a committed regression seed, and the weekly fuzz sweep (adds-measure: weekly-fuzz-sweep) keeps generating hostile inputs against the gate.'
+status: done
 ---
 
 ## Found by

--- a/tickets/entities/implementation-checklists/IMPL-DQQ26D.md
+++ b/tickets/entities/implementation-checklists/IMPL-DQQ26D.md
@@ -1,0 +1,34 @@
+---
+id: IMPL-DQQ26D
+type: implementation-checklist
+title: 'Implementation: GenerateShortID can emit IDs its own validator rejects (pathological prefixes)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written (TestValidateIDPrefix table; TestParse_InvalidIDPrefixRejected + _Plural + _ManualIDType loader tests)
+- [x] Integration — loader gate exercised through Parse; fuzz target re-run 45s clean with the new oracle
+- [x] Happy path implemented (metamodel.ValidateIDPrefix + InvalidIDPrefixError wired into Parse's hard-error path)
+- [x] Edge cases handled (id_prefixes plural form; manual id_type scope pinned deliberately; trailing-dash normalization)
+- [x] Error handling (typed error, errors.As-able, actionable message)
+
+## Test Quality
+
+- [x] Fuzz oracle delegates to the exported production contract — no hand-modeled character rules (the TKT-PCLGGL staleness class)
+- [x] Regression seed committed (testdata/fuzz/FuzzGenerateShortID/bug-rhfhth-double-dash-prefix) — passes under the fixed contract
+- [x] Reviewer brute-forced the completeness invariant: all prefixes ≤4 chars over a superset alphabet — zero gate-accepted prefixes whose generated IDs fail ValidateID
+
+## Manual Verification
+
+- [x] Repro confirmed fixed: 45s fuzz of FuzzGenerateShortID clean (was failing in 2s)
+- [x] All 6 shipped/prototype metamodels still load (TestLoad_AllShippedMetamodels)
+- [x] Sequential-ID path verified covered (same GetIDPrefixes gate; digit suffixes can't create "--")
+- [x] just ci green; arch-lint clean (entity→metamodel is test-only, no cycle)
+
+## Quality
+
+- [x] Follows package patterns (typed errors, hard-error path placement)
+- [x] No security issues; no silent failures; no debug code

--- a/tickets/entities/review-checklists/REV-30OPDP.md
+++ b/tickets/entities/review-checklists/REV-30OPDP.md
@@ -1,0 +1,24 @@
+---
+id: REV-30OPDP
+type: review-checklist
+title: 'Review: GenerateShortID prefix validation'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] metamodel + entity green; lint 0 issues; full `just ci` green
+- [x] 45s re-fuzz of the previously-failing target: clean
+
+## Code Review
+
+- [x] `/code-review` run; reviewer brute-force-verified the completeness invariant (zero gate-accepted prefixes producing invalid IDs), confirmed no shipped metamodel regresses, sequential path covered, no import cycle, fuzz coverage preserved
+- [x] Findings: 0 critical, 0 significant; the one substantive observation (manual-id_type scope expansion) pinned deliberately with a test — RR-AROH1G, RR-YCD3PB
+
+## Verification
+
+- [x] 5-whys (why1–why5) + prevention recorded on the bug; regression seed committed; adds-measure → weekly-fuzz-sweep (the measure that found it now guards it)
+
+**PR:** (added once created)

--- a/tickets/entities/review-checklists/REV-30OPDP.md
+++ b/tickets/entities/review-checklists/REV-30OPDP.md
@@ -21,4 +21,5 @@ status: done
 
 - [x] 5-whys (why1–why5) + prevention recorded on the bug; regression seed committed; adds-measure → weekly-fuzz-sweep (the measure that found it now guards it)
 
-**PR:** (added once created)
+**PR:** https://github.com/sourcehaven-bv/rela/pull/970 (auto-merge armed,
+tschmits requested)

--- a/tickets/entities/review-responses/RR-AROH1G.md
+++ b/tickets/entities/review-responses/RR-AROH1G.md
@@ -1,0 +1,9 @@
+---
+id: RR-AROH1G
+type: review-response
+title: Manual-id_type prefixes are now gated too — scope expansion pinned deliberately
+finding: 'The load gate applies to ALL declared prefixes, including id_type: manual types that declare one for type-routing only — a behavior change beyond the literal short-ID bug (reviewer leverage observation; the in-tree manual prefix MOD- passes).'
+severity: minor
+resolution: 'Decision made deliberate: a routing prefix outside the ID charset could never match a ValidateID-legal ID, so load rejection is strictly more honest. Pinned with TestParse_InvalidIDPrefixRejected_ManualIDType and documented in the bug entity.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YCD3PB.md
+++ b/tickets/entities/review-responses/RR-YCD3PB.md
@@ -1,0 +1,9 @@
+---
+id: RR-YCD3PB
+type: review-response
+title: Regex/dash-check indirection + unused Prefix field
+finding: validIDPrefixBase permits dashes (constrained two lines later) which reads indirect; InvalidIDPrefixError.Prefix is carried but not rendered (Reason embeds it).
+severity: nit
+resolution: Comment added explaining the split (targeted error messages). Prefix field kept as a structured field for programmatic inspection, mirroring the package's error style.
+status: addressed
+---

--- a/tickets/relations/BUG-RHFHTH--has-bug-analysis--BUGA-G4FER7.md
+++ b/tickets/relations/BUG-RHFHTH--has-bug-analysis--BUGA-G4FER7.md
@@ -1,0 +1,5 @@
+---
+from: BUG-RHFHTH
+relation: has-bug-analysis
+to: BUGA-G4FER7
+---

--- a/tickets/relations/BUG-RHFHTH--has-implementation--IMPL-DQQ26D.md
+++ b/tickets/relations/BUG-RHFHTH--has-implementation--IMPL-DQQ26D.md
@@ -1,0 +1,5 @@
+---
+from: BUG-RHFHTH
+relation: has-implementation
+to: IMPL-DQQ26D
+---

--- a/tickets/relations/BUG-RHFHTH--has-review--REV-30OPDP.md
+++ b/tickets/relations/BUG-RHFHTH--has-review--REV-30OPDP.md
@@ -1,0 +1,5 @@
+---
+from: BUG-RHFHTH
+relation: has-review
+to: REV-30OPDP
+---

--- a/tickets/relations/BUG-RHFHTH--has-review-response--RR-AROH1G.md
+++ b/tickets/relations/BUG-RHFHTH--has-review-response--RR-AROH1G.md
@@ -1,0 +1,5 @@
+---
+from: BUG-RHFHTH
+relation: has-review-response
+to: RR-AROH1G
+---

--- a/tickets/relations/BUG-RHFHTH--has-review-response--RR-YCD3PB.md
+++ b/tickets/relations/BUG-RHFHTH--has-review-response--RR-YCD3PB.md
@@ -1,0 +1,5 @@
+---
+from: BUG-RHFHTH
+relation: has-review-response
+to: RR-YCD3PB
+---


### PR DESCRIPTION
Fixes BUG-RHFHTH (full bug workflow with 5-whys + prevention in tickets/) — the weekly fuzz sweep's first catch: `GenerateShortID(prefix="--", …)` emitted `"--9HHF"`, which `entity.ValidateID` rejects. With this merged, the Monday fuzz sweep debuts green.

## Fix (direction per repo owner: validate at metamodel load)

- **`metamodel.ValidateIDPrefix`** (exported) — after trimming one trailing dash, the base must be non-empty, `[A-Za-z0-9_-]` only, and free of dash runs that would re-create `"--"` (the relation key separator) when the generated suffix is appended.
- Wired into **`Parse`'s hard-error path** (typed `InvalidIDPrefixError`, `errors.As`-able) for both `id_prefix` and `id_prefixes` — a broken metamodel now fails at startup instead of producing invalid IDs at write time.
- `GenerateShortID` godoc documents the load-validated-prefix precondition; the **fuzz oracle delegates to the same exported contract** instead of hand-modeling character rules (the staleness class TKT-PCLGGL fixed in the store harnesses).
- The fuzz repro is committed as a **regression seed** (`testdata/fuzz/FuzzGenerateShortID/bug-rhfhth-double-dash-prefix`) — it passes under the fixed contract.

## Scope note (deliberate, reviewer-flagged, test-pinned)

The gate covers ALL declared prefixes, including `id_type: manual` types that declare one purely for type-routing: a routing prefix outside the ID charset could never match a `ValidateID`-legal ID anyway, so load rejection is strictly more honest than a silently-never-matching prefix. Pinned by `TestParse_InvalidIDPrefixRejected_ManualIDType`.

## Review & verification

Cranky review: 0 critical/significant. The reviewer **brute-forced the completeness invariant** — every prefix up to length 4 over a superset alphabet: zero gate-accepted prefixes whose generated IDs fail `ValidateID`. Also verified: all 6 shipped/prototype metamodels still load, the sequential-ID path is covered by the same gate, fuzz input-domain coverage preserved, no import cycle (`entity→metamodel` is test-only; arch-lint clean).

45s re-fuzz of the previously-failing target: clean (was failing within 2s). Full `just ci` green.