### PR TITLE
feat(frontend): migrate EntityList to Pinia Colada (TKT-24QVHB, FEAT-XY2D1L slice 2)

### DIFF
--- a/frontend/src/api/dryRunCreate.test.ts
+++ b/frontend/src/api/dryRunCreate.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { setActivePinia, createPinia } from 'pinia'
-import { dryRunCreateEntity } from './entities'
+import { dryRunCreateEntity, _setEntityPluralForTest } from './entities'
 import { api } from './client'
-import { useSchemaStore } from '@/stores/schema'
 import type { Entity } from '@/types'
 
 vi.mock('./client', () => ({
@@ -12,14 +10,9 @@ vi.mock('./client', () => ({
 describe('dryRunCreateEntity (TKT-3I5U)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    setActivePinia(createPinia())
-    // Seed a plural so getPlural resolves ticket -> tickets.
-    const schema = useSchemaStore()
-    schema.entityTypes.set('ticket', {
-      name: 'ticket',
-      plural: 'tickets',
-      properties: {},
-    } as never)
+    // Register a plural so getPlural resolves ticket -> tickets. The API
+    // layer no longer reads the schema store (B1a).
+    _setEntityPluralForTest('ticket', 'tickets')
     vi.mocked(api.post).mockResolvedValue({
       id: '',
       type: 'ticket',

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -9,13 +9,34 @@ import type {
   RelationEntry,
   ModernRelationsField,
 } from '@/types'
-import { useSchemaStore } from '@/stores/schema'
 import { warnIfMissingActions } from '@/utils/affordancesWarning'
 
+// Type → URL-path-segment (plural) registry. The API layer is a pure HTTP
+// boundary; it must not import a Pinia store (the producer/consumer
+// inversion the project's CLAUDE.md warns against, BUG-style B1a). The
+// schema store calls registerEntityPlurals() once on load with the
+// metamodel's plurals, before any view fires an entity request.
+const pluralRegistry = new Map<string, string>()
+
+export function registerEntityPlurals(plurals: Map<string, string>): void {
+  pluralRegistry.clear()
+  for (const [type, plural] of plurals) pluralRegistry.set(type, plural)
+}
+
+// For tests that exercise the API layer without the schema store.
+export function _setEntityPluralForTest(type: string, plural: string): void {
+  pluralRegistry.set(type, plural)
+}
+
 function getPlural(type: string): string {
-  const schema = useSchemaStore()
-  const entityType = schema.entityTypes.get(type)
-  return entityType?.plural ?? type + 's'
+  const plural = pluralRegistry.get(type)
+  if (!plural) {
+    // Fail fast instead of fabricating a URL (`category` → `/categorys`
+    // would 404 confusingly). An unknown type here means the schema
+    // wasn't loaded or the caller passed a typo.
+    throw new Error(`unknown entity type "${type}" — no registered plural`)
+  }
+  return plural
 }
 
 export async function listEntities(

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -28,6 +28,10 @@ export function _setEntityPluralForTest(type: string, plural: string): void {
   pluralRegistry.set(type, plural)
 }
 
+export function _resetEntityPluralsForTest(): void {
+  pluralRegistry.clear()
+}
+
 function getPlural(type: string): string {
   const plural = pluralRegistry.get(type)
   if (!plural) {

--- a/frontend/src/api/entitiesPlural.test.ts
+++ b/frontend/src/api/entitiesPlural.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { listEntities, registerEntityPlurals, _setEntityPluralForTest } from './entities'
+import { api } from './client'
+
+vi.mock('./client', () => ({
+  api: { get: vi.fn().mockResolvedValue({ data: [], meta: {}, _actions: {} }) },
+}))
+
+// B1a: the API layer resolves type → URL plural from a registry the schema
+// store populates, NOT by importing the store. getPlural throws on an
+// unknown type instead of fabricating a wrong URL (`category` → /categorys).
+describe('entity plural resolution', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('uses the registered plural for the URL path', async () => {
+    registerEntityPlurals(new Map([['policy', 'policies']]))
+    await listEntities('policy')
+    expect(vi.mocked(api.get).mock.calls[0][0]).toBe('/policies')
+  })
+
+  it('throws a descriptive error for an unregistered type', async () => {
+    registerEntityPlurals(new Map())
+    await expect(listEntities('nope')).rejects.toThrow(/unknown entity type "nope"/)
+  })
+
+  it('registerEntityPlurals replaces the prior set', async () => {
+    _setEntityPluralForTest('ticket', 'tickets')
+    registerEntityPlurals(new Map([['risk', 'risks']]))
+    // ticket is gone after the replace.
+    await expect(listEntities('ticket')).rejects.toThrow(/unknown entity type/)
+    await listEntities('risk')
+    expect(vi.mocked(api.get).mock.calls[0][0]).toBe('/risks')
+  })
+})

--- a/frontend/src/components/lists/EntityList.test.ts
+++ b/frontend/src/components/lists/EntityList.test.ts
@@ -2,13 +2,24 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { defineComponent, h } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
+import { PiniaColada } from '@pinia/colada'
 import EntityList from './EntityList.vue'
 import ConfirmModal from '@/components/ui/ConfirmModal.vue'
 import { useSchemaStore } from '@/stores/schema'
-import { useEntitiesStore } from '@/stores/entities'
+import { _setEntityPluralForTest } from '@/api/entities'
 import { _resetModalStack } from '@/composables/modalStack'
 import { useConfirmHost, _resetConfirmForTest } from '@/composables/useConfirm'
-import type { Entity } from '@/types'
+import type { Entity, ListResponse } from '@/types'
+
+// EntityList fetches via the api layer (useQuery) and deletes via it
+// (useMutation), so mock the api functions, not the entities store.
+const listEntitiesMock = vi.fn()
+const deleteEntityMock = vi.fn()
+vi.mock('@/api', async (orig) => ({
+  ...(await orig<typeof import('@/api')>()),
+  listEntities: (...args: unknown[]) => listEntitiesMock(...args),
+  deleteEntity: (...args: unknown[]) => deleteEntityMock(...args),
+}))
 
 // Router stubs — EntityList reads both `useRouter` (for open/edit/create
 // navigation) and `useRoute` (for URL-filter sync). The delete flow uses a
@@ -60,17 +71,23 @@ describe('EntityList delete integration', () => {
     } as never)
   }
 
-  function seedEntities(entities: Entity[]) {
-    const entitiesStore = useEntitiesStore()
-    entitiesStore.fetchList = vi.fn().mockResolvedValue({
+  function seedEntities(entities: Entity[]): ListResponse<Entity> {
+    const response: ListResponse<Entity> = {
       data: entities,
       meta: { total: entities.length, page: 1, per_page: 25, has_more: false },
       included: {},
-    })
+    }
+    listEntitiesMock.mockResolvedValue(response)
+    return response
   }
 
+  let pinia: ReturnType<typeof createPinia>
   beforeEach(() => {
-    setActivePinia(createPinia())
+    pinia = createPinia()
+    setActivePinia(pinia)
+    _setEntityPluralForTest(entityType, 'tickets')
+    listEntitiesMock.mockReset()
+    deleteEntityMock.mockReset().mockResolvedValue(undefined)
     _resetModalStack()
     _resetConfirmForTest()
     routerPush.mockClear()
@@ -116,6 +133,7 @@ describe('EntityList delete integration', () => {
     const wrapper = mount(Host, {
       props: { listId },
       attachTo: document.body,
+      global: { plugins: [pinia, PiniaColada] },
     })
     await flushPromises()
     return wrapper
@@ -185,9 +203,6 @@ describe('EntityList delete integration', () => {
   it('Cancel button closes modal without deleting', async () => {
     const entities = [makeEntity('T-1')]
     const wrapper = await mountList(entities)
-    const entitiesStore = useEntitiesStore()
-    const removeSpy = vi.fn().mockResolvedValue(undefined)
-    entitiesStore.remove = removeSpy
 
     await wrapper.find('.delete-btn').trigger('click')
     await flushPromises()
@@ -196,18 +211,15 @@ describe('EntityList delete integration', () => {
     await flushPromises()
 
     expect(overlay()).toBeNull()
-    expect(removeSpy).not.toHaveBeenCalled()
+    expect(deleteEntityMock).not.toHaveBeenCalled()
     wrapper.unmount()
   })
 
-  it('Confirm button calls entitiesStore.remove with the pending entity', async () => {
+  it('Confirm button calls deleteEntity with the pending entity', async () => {
     const entities = [makeEntity('T-1'), makeEntity('T-2')]
     const wrapper = await mountList(entities)
-    const entitiesStore = useEntitiesStore()
-    const removeSpy = vi.fn().mockResolvedValue(undefined)
-    entitiesStore.remove = removeSpy
 
-    // Click delete on the SECOND row — the spy should receive that entity.
+    // Click delete on the SECOND row — the mutation should receive that entity.
     const deleteButtons = wrapper.findAll('.delete-btn')
     await deleteButtons[1].trigger('click')
     await flushPromises()
@@ -215,18 +227,17 @@ describe('EntityList delete integration', () => {
     modalButtons()[1].click()
     await flushPromises()
 
-    expect(removeSpy).toHaveBeenCalledTimes(1)
-    expect(removeSpy).toHaveBeenCalledWith(entities[1].type, entities[1].id)
+    expect(deleteEntityMock).toHaveBeenCalledTimes(1)
+    expect(deleteEntityMock).toHaveBeenCalledWith(entities[1].type, entities[1].id)
     wrapper.unmount()
   })
 
-  it('keeps modal open on error and clears busy state', async () => {
+  it('surfaces an error toast when delete fails', async () => {
     const entities = [makeEntity('T-1')]
     const wrapper = await mountList(entities)
-    const entitiesStore = useEntitiesStore()
-    entitiesStore.remove = vi.fn().mockRejectedValue(new Error('boom'))
-    // The component logs the error via console.error; silence it in the test
-    // so the output stays clean.
+    deleteEntityMock.mockRejectedValue(new Error('boom'))
+    // The mutation logs nothing, but rollback + toast fire; silence any
+    // incidental console noise.
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     await wrapper.find('.delete-btn').trigger('click')
@@ -235,10 +246,9 @@ describe('EntityList delete integration', () => {
     modalButtons()[1].click()
     await flushPromises()
 
-    // Modal stays open so the user can retry or cancel with context.
-    expect(overlay()).not.toBeNull()
-    // Confirm button is re-enabled after the failure.
-    expect(modalButtons()[1].disabled).toBe(false)
+    // The confirm modal closes (the mutation owns failure handling via
+    // rollback + toast, unlike the old withConfirmError stay-open path).
+    expect(deleteEntityMock).toHaveBeenCalledTimes(1)
     consoleSpy.mockRestore()
     wrapper.unmount()
   })
@@ -264,18 +274,20 @@ describe('EntityList search integration', () => {
   }
 
   function fakeFetchList() {
-    const entitiesStore = useEntitiesStore()
-    const fetchList = vi.fn().mockResolvedValue({
+    listEntitiesMock.mockReset().mockResolvedValue({
       data: [],
       meta: { total: 0, page: 1, per_page: 25, has_more: false },
       included: {},
     })
-    entitiesStore.fetchList = fetchList
-    return fetchList
+    return listEntitiesMock
   }
 
+  let pinia: ReturnType<typeof createPinia>
   beforeEach(() => {
-    setActivePinia(createPinia())
+    pinia = createPinia()
+    setActivePinia(pinia)
+    _setEntityPluralForTest(entityType, 'tickets')
+    deleteEntityMock.mockReset().mockResolvedValue(undefined)
     _resetModalStack()
     routerPush.mockClear()
     routerReplace.mockClear()
@@ -294,7 +306,7 @@ describe('EntityList search integration', () => {
     fakeFetchList()
     mockRoute.query = { q: 'foo' }
 
-    const wrapper = mount(EntityList, { props: { listId }, attachTo: document.body })
+    const wrapper = mount(EntityList, { props: { listId }, attachTo: document.body, global: { plugins: [pinia, PiniaColada] } })
     await flushPromises()
 
     const input = wrapper.find<HTMLInputElement>('.search-box input[type="search"]')
@@ -305,7 +317,7 @@ describe('EntityList search integration', () => {
   it('AC2: typing fires exactly one fetch after the debounce window', async () => {
     seedSchema()
     const fetchList = fakeFetchList()
-    const wrapper = mount(EntityList, { props: { listId }, attachTo: document.body })
+    const wrapper = mount(EntityList, { props: { listId }, attachTo: document.body, global: { plugins: [pinia, PiniaColada] } })
     await flushPromises()
 
     // Initial mount fetch already happened.
@@ -338,7 +350,7 @@ describe('EntityList search integration', () => {
     const fetchList = fakeFetchList()
     mockRoute.query = { q: 'foo' }
 
-    const wrapper = mount(EntityList, { props: { listId }, attachTo: document.body })
+    const wrapper = mount(EntityList, { props: { listId }, attachTo: document.body, global: { plugins: [pinia, PiniaColada] } })
     await flushPromises()
 
     // Sanity: initial fetch carries q=foo.

--- a/frontend/src/components/lists/EntityList.test.ts
+++ b/frontend/src/components/lists/EntityList.test.ts
@@ -6,6 +6,7 @@ import { PiniaColada } from '@pinia/colada'
 import EntityList from './EntityList.vue'
 import ConfirmModal from '@/components/ui/ConfirmModal.vue'
 import { useSchemaStore } from '@/stores/schema'
+import { useUIStore } from '@/stores/ui'
 import { _setEntityPluralForTest } from '@/api/entities'
 import { _resetModalStack } from '@/composables/modalStack'
 import { useConfirmHost, _resetConfirmForTest } from '@/composables/useConfirm'
@@ -232,12 +233,36 @@ describe('EntityList delete integration', () => {
     wrapper.unmount()
   })
 
-  it('surfaces an error toast when delete fails', async () => {
+  it('rolls back the row and toasts when delete fails (onError wiring)', async () => {
+    const entities = [makeEntity('T-1'), makeEntity('T-2')]
+    const wrapper = await mountList(entities)
+    deleteEntityMock.mockRejectedValue(new Error('boom'))
+    const uiStore = useUIStore()
+    const errorSpy = vi.spyOn(uiStore, 'error')
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Confirm deletion of the second row.
+    const deleteButtons = wrapper.findAll('.delete-btn')
+    await deleteButtons[1].trigger('click')
+    await flushPromises()
+    modalButtons()[1].click()
+    await flushPromises()
+
+    // After the mutation rejects, onError rolls the optimistic removal back
+    // (the row is present again) and toasts the failure. This fails if the
+    // onError handler is dropped — pinning the optimistic+rollback wiring.
+    expect(deleteEntityMock).toHaveBeenCalledTimes(1)
+    expect(wrapper.text()).toContain('Title T-2')
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    errorSpy.mockRestore()
+    consoleSpy.mockRestore()
+    wrapper.unmount()
+  })
+
+  it('closes the confirm modal after a failed delete', async () => {
     const entities = [makeEntity('T-1')]
     const wrapper = await mountList(entities)
     deleteEntityMock.mockRejectedValue(new Error('boom'))
-    // The mutation logs nothing, but rollback + toast fire; silence any
-    // incidental console noise.
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     await wrapper.find('.delete-btn').trigger('click')

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -71,8 +71,10 @@ const meta = computed<ListMeta>(
       has_more: false,
     }
 )
-// Spinner only on the first load (no data yet); background refetches keep
-// the current rows via placeholderData.
+// `isPending` is true while a query key has no resolved data. Same-key SSE
+// refetches keep the entry `success` (placeholderData holds the rows, no
+// spinner — the liveness win). A param change (page/filter/sort) swaps to a
+// new key that starts pending, so the spinner shows then, as before.
 const loading = computed(() => listQueryRef.value?.isPending.value ?? true)
 const loadError = computed(() => {
   const err = listQueryRef.value?.error.value
@@ -569,6 +571,19 @@ async function requestDelete(entity: Entity) {
   if (!ok) return
   deleteEntityMutation({ entity })
 }
+
+// Reconcile input `page` with the server's returned page. If the backend
+// clamps an out-of-range page (e.g. requested 5, only 3 exist), adopt the
+// server's value so the query key, keyboard nav, and Pagination controls
+// all agree on one page-of-truth.
+watch(
+  () => listQuery.data.value?.meta.page,
+  (serverPage) => {
+    if (serverPage !== undefined && serverPage !== page.value) {
+      page.value = serverPage
+    }
+  }
+)
 
 // Reset paging/sort/selection on list switch. The query reacts to the
 // input changes — no manual fetch trigger needed.

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -1,17 +1,20 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, shallowRef, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { useSchemaStore, useEntitiesStore, useUIStore } from '@/stores'
+import { useQuery, useMutation, useQueryCache } from '@pinia/colada'
+import { useSchemaStore, useUIStore } from '@/stores'
 import { useListKeyboard } from '@/composables/useListKeyboard'
 import { useListSelection } from '@/composables/useListSelection'
 import { useListActions } from '@/composables/useListActions'
 import { useUrlFilterSync } from '@/composables/useUrlFilterSync'
-import { isCancelledFetch } from '@/composables/usePageData'
+import { listEntities, deleteEntity, getErrorMessage } from '@/api'
+import { entityKeys } from '@/queries/entities'
+import { beginOptimisticRemove, rollbackOptimistic } from '@/queries/optimisticList'
 import { toApiOperator, filterStateToApiParams } from '@/utils/filters'
 import { entityDetailHref } from '@/utils/entityRoute'
 import { actionAllowed } from '@/utils/affordancesWarning'
 import { getCellValue, formatCellValue, isEnumPropertyDef, asArray } from '@/utils/format'
-import type { Entity, ListMeta, ListParams, FilterState } from '@/types'
+import type { Entity, ListMeta, ListParams, ListResponse, FilterState } from '@/types'
 import FilterBar from './FilterBar.vue'
 import Pagination from './Pagination.vue'
 import SearchBox from './SearchBox.vue'
@@ -19,7 +22,7 @@ import AdHocFilterMenu from './AdHocFilterMenu.vue'
 import Badge from '@/components/common/Badge.vue'
 import BackButton from '@/components/common/BackButton.vue'
 import { useBackTarget } from '@/composables/useBackTarget'
-import { useConfirm, withConfirmError } from '@/composables/useConfirm'
+import { useConfirm } from '@/composables/useConfirm'
 
 const props = defineProps<{
   listId: string
@@ -28,7 +31,6 @@ const props = defineProps<{
 const route = useRoute()
 const router = useRouter()
 const schemaStore = useSchemaStore()
-const entitiesStore = useEntitiesStore()
 const uiStore = useUIStore()
 const { confirm } = useConfirm()
 
@@ -43,15 +45,49 @@ onMounted(() => { mobileQuery?.addEventListener('change', onMediaChange) })
 onUnmounted(() => { mobileQuery?.removeEventListener('change', onMediaChange) })
 
 // State
-const entities = ref<Entity[]>([])
-const meta = ref<ListMeta>({ total: 0, page: 1, per_page: 25, has_more: false })
-const loading = ref(true)
-const includedEntities = ref<Record<string, Entity>>({})
+//
+// Page is the only piece of list state the client owns directly; it feeds
+// the query key (input). Everything else below is derived from the query
+// result (output). Splitting page-as-input from meta-as-output removes the
+// read/write cycle the old single `meta.page` had.
+//
+// The actual useQuery() call lives lower (after queryParams is defined,
+// since its `enabled` is evaluated synchronously during setup) and assigns
+// into this holder. The derived computeds here read it lazily, so they can
+// be declared up top where useListActions / useListKeyboard need them.
+const page = ref(1)
+const queryCache = useQueryCache()
+
+type ListQuery = ReturnType<typeof useQuery<ListResponse<Entity>>>
+const listQueryRef = shallowRef<ListQuery>()
+
+const entities = computed<Entity[]>(() => listQueryRef.value?.data.value?.data ?? [])
+const meta = computed<ListMeta>(
+  () =>
+    listQueryRef.value?.data.value?.meta ?? {
+      total: 0,
+      page: page.value,
+      per_page: listConfig.value?.page_size || 25,
+      has_more: false,
+    }
+)
+// Spinner only on the first load (no data yet); background refetches keep
+// the current rows via placeholderData.
+const loading = computed(() => listQueryRef.value?.isPending.value ?? true)
+const loadError = computed(() => {
+  const err = listQueryRef.value?.error.value
+  return err ? getErrorMessage(err, 'Failed to load entities') : null
+})
+const includedEntities = computed<Record<string, Entity>>(
+  () => listQueryRef.value?.data.value?.included ?? {}
+)
 // Collection-scope verb verdicts (e.g. {create: true|false}). Always
 // emitted by the data-entry server; absent only for non-data-entry
 // callers, in which case affordances render defensively (the server
 // still 403s on click). See `_actions` in api-reference.md.
-const collectionActions = ref<Record<string, boolean> | undefined>(undefined)
+const collectionActions = computed<Record<string, boolean> | undefined>(
+  () => listQueryRef.value?.data.value?._actions
+)
 
 // Affordance gates: `_actions` map from the server. `false` → hide;
 // anything else → render. Helper keeps the contract DRY across
@@ -93,7 +129,11 @@ const { resolvedActions, processing: actionProcessing, executeAction, triggerAct
   onRequestConfirm: (action, actionId, triggerEl) => {
     void requestActionConfirm(action, actionId, triggerEl)
   },
-  onComplete: () => scheduleFetch(),
+  // Bulk actions mutate entities server-side; invalidate the list so it
+  // refetches the post-action state.
+  onComplete: () => {
+    void queryCache.invalidateQueries({ key: entityKeys.list(listConfig.value?.entity ?? '') })
+  },
 })
 
 // Bulk action confirm. We don't pass executeAction as onConfirm because it
@@ -141,8 +181,8 @@ const sortSpecs = ref<SortSpec[]>([])
 
 // Computed for keyboard navigation
 const itemCount = computed(() => entities.value.length)
-const hasPrevPage = computed(() => meta.value.page > 1)
-const hasNextPage = computed(() => meta.value.has_more || meta.value.page * meta.value.per_page < meta.value.total)
+const hasPrevPage = computed(() => page.value > 1)
+const hasNextPage = computed(() => meta.value.has_more || page.value * meta.value.per_page < meta.value.total)
 
 // Keyboard navigation
 const { selectedIndex, clearSelection } = useListKeyboard({
@@ -183,12 +223,12 @@ const { selectedIndex, clearSelection } = useListKeyboard({
   },
   onPrevPage: () => {
     if (hasPrevPage.value) {
-      handlePageChange(meta.value.page - 1)
+      handlePageChange(page.value - 1)
     }
   },
   onNextPage: () => {
     if (hasNextPage.value) {
-      handlePageChange(meta.value.page + 1)
+      handlePageChange(page.value + 1)
     }
   },
   onFocusSearch: () => {
@@ -218,10 +258,11 @@ const hasRelationColumns = computed(() => {
 
 const hasActions = computed(() => resolvedActions.value.length > 0)
 
-// Build query params
+// Build query params. Reads `page` (input state), never `meta` (query
+// output) — otherwise the query key would depend on its own result.
 const queryParams = computed((): ListParams => {
   const params: ListParams = {
-    page: meta.value.page,
+    page: page.value,
     per_page: listConfig.value?.page_size || 25,
   }
 
@@ -272,64 +313,28 @@ const queryParams = computed((): ListParams => {
   return params
 })
 
-// Generation counter for stale-response protection. Every call to
-// loadEntities captures the current generation; when the fetch resolves, we
-// drop the result if the generation has advanced (meaning a newer fetch was
-// triggered by a list switch, filter change, sort, etc.). Without this, a
-// slow fetch for list A can resolve AFTER a fast fetch for list B and
-// overwrite B's UI state.
-let fetchGeneration = 0
-
-// Coalesce multiple synchronous triggers (list switch + filter reseed + sort)
-// into a single fetch per microtask. Every trigger sets the flag; the next
-// microtask fires one loadEntities() and the generation counter above drops
-// anything already in flight.
-let fetchPending = false
-function scheduleFetch() {
-  if (fetchPending) return
-  fetchPending = true
-  nextTick(() => {
-    fetchPending = false
-    loadEntities()
-  })
-}
-
-// Methods
-async function loadEntities() {
-  if (!listConfig.value) return
-
-  const myGeneration = ++fetchGeneration
-  const requestedListEntity = listConfig.value.entity
-  loading.value = true
-  try {
-    const result = await entitiesStore.fetchList(
-      requestedListEntity,
-      queryParams.value
-    )
-    // Drop stale responses: if another fetch was started while we were
-    // awaiting, this result is for a previous filter/list/sort state.
-    if (myGeneration !== fetchGeneration) return
-    entities.value = result.data
-    meta.value = result.meta
-    // Store included entities for relation column rendering
-    includedEntities.value = result.included || {}
-    // Collection-scope `_actions` (e.g. `create`). Undefined when the
-    // server didn't emit them; consumers fall back to "show all."
-    collectionActions.value = result._actions
-  } catch (err) {
-    // Drop stale responses (a newer fetch superseded us).
-    if (myGeneration !== fetchGeneration) return
-    // Suppress cancellation errors from rapid navigation in Firefox
-    // (see BUG-6C3V and src/composables/usePageData.ts).
-    if (isCancelledFetch(err)) return
-    uiStore.error('Failed to load entities')
-    console.error(err)
-  } finally {
-    if (myGeneration === fetchGeneration) {
-      loading.value = false
-    }
-  }
-}
+// The list query (FEAT-XY2D1L). Declared here — after queryParams /
+// listConfig — because Pinia Colada evaluates `enabled` synchronously
+// during setup; the derived computeds up in the State block read it
+// through `listQueryRef`. Keyed on the canonicalized params, so
+// page/filter/sort/search changes swap cache entries automatically — the
+// reactive key coalesces synchronous trigger bursts and drops stale
+// responses, replacing the old generation counter + scheduleFetch
+// microtask. useEvents' SSE invalidation on ['entities', <type>] marks it
+// stale and background-refetches while mounted, so lists go live (they
+// never reacted to SSE before). placeholderData keeps the previous rows
+// visible during a param change instead of flashing the spinner.
+const listQuery = useQuery({
+  key: () => entityKeys.listParams(listConfig.value?.entity ?? '', queryParams.value),
+  query: () => {
+    const config = listConfig.value
+    if (!config) throw new Error(`unknown list: ${props.listId}`)
+    return listEntities(config.entity, queryParams.value)
+  },
+  enabled: () => !!listConfig.value,
+  placeholderData: (prev) => prev,
+})
+listQueryRef.value = listQuery
 
 function handleSort(field: string, event: MouseEvent) {
   const existingIndex = sortSpecs.value.findIndex((s) => s.property === field)
@@ -360,8 +365,8 @@ function handleSort(field: string, event: MouseEvent) {
     }
   }
 
-  meta.value.page = 1
-  scheduleFetch()
+  // Sort changed → reset to page 1; the query reacts to both inputs.
+  page.value = 1
 }
 
 // Helper to get sort index and direction for a field
@@ -420,9 +425,8 @@ const adHocFilterChips = computed(() => {
     .map(([property, fv]) => ({ property, value: fv.value }))
 })
 
-function handlePageChange(page: number) {
-  meta.value.page = page
-  scheduleFetch()
+function handlePageChange(newPage: number) {
+  page.value = newPage
 }
 
 // Resolve a link configuration value to a path (mirrors backend resolveLinkTarget)
@@ -528,60 +532,70 @@ function handleDelete(entity: Entity, event: Event) {
   void requestDelete(entity)
 }
 
+// Delete as an optimistic mutation: the row vanishes immediately, rolls
+// back on failure, and the list prefix is invalidated on settle so every
+// param variant (other pages/filters where the entity might appear)
+// refetches and reconciles with the server.
+const { mutate: deleteEntityMutation } = useMutation({
+  mutation: ({ entity }: { entity: Entity }) => deleteEntity(entity.type, entity.id),
+  onMutate({ entity }: { entity: Entity }) {
+    return beginOptimisticRemove(
+      queryCache,
+      entityKeys.listParams(entity.type, queryParams.value),
+      entity.id
+    )
+  },
+  onError(err, _vars, context) {
+    rollbackOptimistic(queryCache, context)
+    uiStore.error(getErrorMessage(err, 'Failed to delete entity'))
+  },
+  onSuccess(_data, { entity }) {
+    uiStore.success(`Deleted ${entity.id}`)
+  },
+  async onSettled(_data, _err, { entity }) {
+    // Invalidate the whole list (all param variants), not just the
+    // visible page — the deleted entity may appear under other filters.
+    await queryCache.invalidateQueries({ key: entityKeys.list(entity.type) })
+  },
+})
+
 async function requestDelete(entity: Entity) {
   const ok = await confirm({
     title: 'Delete Entity?',
     message: `Are you sure you want to delete '${entity.id}'? This action cannot be undone.`,
     confirmLabel: 'Delete',
     danger: true,
-    onConfirm: withConfirmError(
-      () => entitiesStore.remove(entity.type, entity.id),
-      'Failed to delete entity',
-      uiStore,
-    ),
   })
   if (!ok) return
-  uiStore.success(`Deleted ${entity.id}`)
-  scheduleFetch()
+  deleteEntityMutation({ entity })
 }
 
-// Watchers — all three converge on scheduleFetch(), which coalesces into a
-// single fetch per microtask (with stale-response protection via the
-// generation counter above). This is how we avoid a double-fetch when a list
-// switch ALSO changes the filter state: both watchers set fetchPending, but
-// only one loadEntities() runs on the next tick.
+// Reset paging/sort/selection on list switch. The query reacts to the
+// input changes — no manual fetch trigger needed.
 watch(() => props.listId, () => {
   sortSpecs.value = []
-  meta.value.page = 1
+  page.value = 1
   clearSelection()
   clearActionSelection()
-  scheduleFetch()
 })
 
-// Clear selection when entities change
+// Clear selection when the visible entities change (incl. background
+// SSE-driven refetches).
 watch(entities, () => {
   clearSelection()
   clearActionSelection()
 })
 
-// Re-fetch when filters change (covers both user edits via writeToQuery and
-// external nav like back/forward that the URL sync composable picks up).
+// Reset to page 1 when filters or free-text search change (covers user
+// edits via writeToQuery and back/forward nav the URL sync picks up). The
+// query re-keys off page + filters + search together, so a simultaneous
+// filter+search edit still produces one fetch.
 watch(filters, () => {
-  meta.value.page = 1
-  scheduleFetch()
+  page.value = 1
 }, { deep: true })
 
-// Re-fetch on free-text search changes. Same coalescing path as filters; the
-// scheduleFetch microtask debounces a search-edit + filter-edit pair into a
-// single network call.
 watch(searchQuery, () => {
-  meta.value.page = 1
-  scheduleFetch()
-})
-
-// Lifecycle
-onMounted(() => {
-  scheduleFetch()
+  page.value = 1
 })
 </script>
 
@@ -656,6 +670,13 @@ onMounted(() => {
       <div v-if="loading" class="loading-state">
         <div class="spinner"/>
         <span>Loading...</span>
+      </div>
+
+      <div v-else-if="loadError" class="empty-state load-error">
+        <p>{{ loadError }}</p>
+        <button type="button" class="btn btn-secondary" @click="listQuery.refetch()">
+          Retry
+        </button>
       </div>
 
       <div v-else-if="entities.length === 0" class="empty-state">

--- a/frontend/src/queries/entities.test.ts
+++ b/frontend/src/queries/entities.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { entityKeys, canonicalListParams } from './entities'
+import type { ListParams } from '@/types'
+
+describe('canonicalListParams', () => {
+  it('is order-insensitive (the param-order cache-key bug)', () => {
+    const a: ListParams = { page: 1, per_page: 25, sort: 'title' }
+    const b: ListParams = { sort: 'title', per_page: 25, page: 1 }
+    expect(canonicalListParams(a)).toBe(canonicalListParams(b))
+  })
+
+  it('drops undefined and empty values so they do not split the cache', () => {
+    expect(canonicalListParams({ page: 1, q: '' } as ListParams)).toBe('page=1')
+    expect(canonicalListParams({ page: 1, sort: undefined } as ListParams)).toBe('page=1')
+  })
+
+  it('returns empty string for no params', () => {
+    expect(canonicalListParams()).toBe('')
+  })
+
+  it('distinguishes different param sets', () => {
+    expect(canonicalListParams({ page: 1 } as ListParams)).not.toBe(
+      canonicalListParams({ page: 2 } as ListParams)
+    )
+  })
+})
+
+describe('entityKeys', () => {
+  it('list is a prefix of every listParams variant (so it invalidates all)', () => {
+    const base = entityKeys.list('ticket')
+    const withParams = entityKeys.listParams('ticket', { page: 2 } as ListParams)
+    expect(withParams.slice(0, base.length)).toEqual([...base])
+  })
+
+  it('type is a prefix of list and detail (SSE invalidation by type)', () => {
+    const type = entityKeys.type('ticket')
+    expect(entityKeys.list('ticket').slice(0, type.length)).toEqual([...type])
+    expect(entityKeys.detail('ticket', 'T-1').slice(0, type.length)).toEqual([...type])
+  })
+})

--- a/frontend/src/queries/entities.test.ts
+++ b/frontend/src/queries/entities.test.ts
@@ -10,12 +10,21 @@ describe('canonicalListParams', () => {
   })
 
   it('drops undefined and empty values so they do not split the cache', () => {
-    expect(canonicalListParams({ page: 1, q: '' } as ListParams)).toBe('page=1')
-    expect(canonicalListParams({ page: 1, sort: undefined } as ListParams)).toBe('page=1')
+    const bare = canonicalListParams({ page: 1 } as ListParams)
+    expect(canonicalListParams({ page: 1, q: '' } as ListParams)).toBe(bare)
+    expect(canonicalListParams({ page: 1, sort: undefined } as ListParams)).toBe(bare)
   })
 
   it('returns empty string for no params', () => {
     expect(canonicalListParams()).toBe('')
+    expect(canonicalListParams({} as ListParams)).toBe('')
+  })
+
+  it('does not collide when a value contains & or = (the delimiter bug)', () => {
+    // Two distinct filter sets that a naive k=v&... join would conflate.
+    const a = canonicalListParams({ 'filter[a]': 'x', 'filter[b]': 'y' } as ListParams)
+    const b = canonicalListParams({ 'filter[a]': 'x&filter[b]=y' } as ListParams)
+    expect(a).not.toBe(b)
   })
 
   it('distinguishes different param sets', () => {

--- a/frontend/src/queries/entities.ts
+++ b/frontend/src/queries/entities.ts
@@ -1,11 +1,14 @@
+import type { ListParams } from '@/types'
+
 // Query-key factory for entity data (Pinia Colada).
 //
 // Keys are hierarchical so SSE invalidation can target by prefix match:
 //
-//   ['entities']                      — every entity query
-//   ['entities', type]                — all queries for one entity type
-//   ['entities', type, 'list']       — the type's list queries
-//   ['entities', type, 'detail', id] — a single entity
+//   ['entities']                         — every entity query
+//   ['entities', type]                   — all queries for one entity type
+//   ['entities', type, 'list']          — the type's list queries (all params)
+//   ['entities', type, 'list', '<params>'] — one parameterized list query
+//   ['entities', type, 'detail', id]    — a single entity
 //
 // useEvents maps SSE entity events ({type, id}) onto these prefixes;
 // views subscribe via useQuery with the same keys, so an invalidation
@@ -14,9 +17,32 @@
 //
 // This replaces the entities-store TTL cache view by view; see
 // FEAT-XY2D1L. Unmigrated views still rely on entitiesStore.invalidateAll().
+
+// canonicalListParams produces a stable string for a list query's params,
+// so two callers building the same filters/sort/page in different property
+// order resolve to the same cache entry (the param-order cache-key bug from
+// the frontend review). undefined/empty values are dropped.
+export function canonicalListParams(params?: ListParams): string {
+  if (!params) return ''
+  const record = params as Record<string, unknown>
+  const pairs = Object.keys(record)
+    .sort()
+    .filter((k) => record[k] !== undefined && record[k] !== '')
+    .map((k) => `${k}=${String(record[k])}`)
+  return pairs.join('&')
+}
+
 export const entityKeys = {
   root: ['entities'] as const,
   type: (type: string) => ['entities', type] as const,
+  // Base list key (prefix) — invalidating this hits every parameter
+  // variant for the type. Kanban uses this param-free form (one board =
+  // one list query).
   list: (type: string) => ['entities', type, 'list'] as const,
+  // Parameterized list key — one cache entry per distinct param set.
+  // EntityList keys on this so page/filter/sort/search each cache apart
+  // while still sharing the `list(type)` invalidation prefix.
+  listParams: (type: string, params?: ListParams) =>
+    ['entities', type, 'list', canonicalListParams(params)] as const,
   detail: (type: string, id: string) => ['entities', type, 'detail', id] as const,
 }

--- a/frontend/src/queries/entities.ts
+++ b/frontend/src/queries/entities.ts
@@ -22,14 +22,20 @@ import type { ListParams } from '@/types'
 // so two callers building the same filters/sort/page in different property
 // order resolve to the same cache entry (the param-order cache-key bug from
 // the frontend review). undefined/empty values are dropped.
+//
+// Uses JSON of sorted [key, value] pairs rather than `k=v&...` joining: a
+// filter value containing `&` or `=` (both legal in a `contains` filter)
+// would otherwise let two distinct param sets collapse to the same key and
+// serve the wrong cached list — the same false-negative class that
+// utils/filters.ts:stringifyFilterQuery documents and avoids.
 export function canonicalListParams(params?: ListParams): string {
   if (!params) return ''
   const record = params as Record<string, unknown>
   const pairs = Object.keys(record)
     .sort()
     .filter((k) => record[k] !== undefined && record[k] !== '')
-    .map((k) => `${k}=${String(record[k])}`)
-  return pairs.join('&')
+    .map((k) => [k, record[k]] as const)
+  return pairs.length ? JSON.stringify(pairs) : ''
 }
 
 export const entityKeys = {

--- a/frontend/src/queries/optimisticList.test.ts
+++ b/frontend/src/queries/optimisticList.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  beginOptimistic,
+  beginOptimisticRemove,
+  rollbackOptimistic,
+  settleOptimistic,
+} from './optimisticList'
+import type { Entity, ListResponse } from '@/types'
+
+// A minimal in-memory stand-in for Pinia Colada's QueryCache: enough surface
+// (get/set/cancel/invalidate keyed by a stringified key) to exercise the
+// optimistic mechanics without the real runtime. The identity semantics that
+// matter — getQueryData returns the same object reference setQueryData stored
+// — are preserved, which is exactly what the rollback check depends on.
+function makeFakeCache(initial?: ListResponse<Entity>) {
+  const store = new Map<string, unknown>()
+  const cancelled: string[] = []
+  const invalidated: string[] = []
+  const k = (key: readonly string[]) => key.join('|')
+  if (initial) store.set(k(['entities', 'ticket', 'list']), initial)
+  return {
+    cancelled,
+    invalidated,
+    getQueryData: vi.fn((key: readonly string[]) => store.get(k(key))),
+    setQueryData: vi.fn((key: readonly string[], data: unknown) => store.set(k(key), data)),
+    cancelQueries: vi.fn(({ key }: { key: readonly string[] }) => cancelled.push(k(key))),
+    invalidateQueries: vi.fn(({ key }: { key: readonly string[] }) => {
+      invalidated.push(k(key))
+      return Promise.resolve()
+    }),
+  }
+}
+
+const KEY = ['entities', 'ticket', 'list'] as const
+
+function makeList(...ids: string[]): ListResponse<Entity> {
+  return {
+    data: ids.map((id) => ({ id, type: 'ticket', properties: { status: 'open' } })),
+    meta: { total: ids.length, page: 1, per_page: 25, has_more: false },
+    included: {},
+  }
+}
+
+describe('optimisticList', () => {
+  describe('beginOptimistic (update)', () => {
+    it('cancels in-flight queries and applies a copy-on-write update', () => {
+      const initial = makeList('T-1', 'T-2')
+      const cache = makeFakeCache(initial)
+      const ctx = beginOptimistic(cache as never, KEY, 'T-2', (e) => ({
+        ...e,
+        properties: { ...e.properties, status: 'done' },
+      }))
+
+      expect(cache.cancelled).toEqual(['entities|ticket|list'])
+      expect(ctx.previous).toBe(initial)
+      // The cached value is a new object (not mutated in place).
+      expect(ctx.optimistic).not.toBe(initial)
+      expect(cache.getQueryData(KEY)).toBe(ctx.optimistic)
+      // Only the matching entity changed; the others are untouched refs.
+      expect(ctx.optimistic!.data[1].properties.status).toBe('done')
+      expect(ctx.optimistic!.data[0]).toBe(initial.data[0])
+    })
+
+    it('no-ops the cache write when the list was not cached', () => {
+      const cache = makeFakeCache()
+      const ctx = beginOptimistic(cache as never, KEY, 'T-1', (e) => e)
+      expect(ctx.previous).toBeUndefined()
+      expect(ctx.optimistic).toBeUndefined()
+      expect(cache.setQueryData).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('beginOptimisticRemove (delete)', () => {
+    it('drops the matching entity from the cached list', () => {
+      const cache = makeFakeCache(makeList('T-1', 'T-2', 'T-3'))
+      const ctx = beginOptimisticRemove(cache as never, KEY, 'T-2')
+      expect(ctx.optimistic!.data.map((e) => e.id)).toEqual(['T-1', 'T-3'])
+      expect(cache.getQueryData(KEY)).toBe(ctx.optimistic)
+    })
+  })
+
+  // The three orderings RR-IVBO9K asked to pin.
+  describe('settle / rollback orderings', () => {
+    it('success: settle invalidates so the optimistic guess reconciles', async () => {
+      const cache = makeFakeCache(makeList('T-1'))
+      const ctx = beginOptimistic(cache as never, KEY, 'T-1', (e) => e)
+      await settleOptimistic(cache as never, ctx)
+      expect(cache.invalidated).toEqual(['entities|ticket|list'])
+    })
+
+    it('error with no intervening refetch: rollback restores previous', () => {
+      const initial = makeList('T-1', 'T-2')
+      const cache = makeFakeCache(initial)
+      const ctx = beginOptimisticRemove(cache as never, KEY, 'T-2')
+      // Cache currently holds the optimistic (T-2 removed) value.
+      expect(cache.getQueryData(KEY)).toBe(ctx.optimistic)
+
+      rollbackOptimistic(cache as never, ctx)
+      // Restored to the original two-row list.
+      expect(cache.getQueryData(KEY)).toBe(initial)
+    })
+
+    it('error after an intervening refetch: rollback is skipped', () => {
+      const initial = makeList('T-1', 'T-2')
+      const cache = makeFakeCache(initial)
+      const ctx = beginOptimisticRemove(cache as never, KEY, 'T-2')
+
+      // A background refetch resolves between onMutate and onError, writing
+      // newer server truth into the cache.
+      const fresh = makeList('T-1', 'T-2', 'T-9')
+      cache.setQueryData(KEY, fresh)
+
+      rollbackOptimistic(cache as never, ctx)
+      // The newer value survives — rollback must NOT stomp it.
+      expect(cache.getQueryData(KEY)).toBe(fresh)
+    })
+
+    it('rollback no-ops when nothing was written optimistically', () => {
+      const cache = makeFakeCache()
+      const ctx = beginOptimistic(cache as never, KEY, 'T-1', (e) => e)
+      rollbackOptimistic(cache as never, ctx)
+      expect(cache.setQueryData).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/queries/optimisticList.ts
+++ b/frontend/src/queries/optimisticList.ts
@@ -52,13 +52,19 @@ export function beginOptimisticRemove(
   key: readonly string[],
   matchId: string
 ): OptimisticListContext {
-  queryCache.cancelQueries({ key })
   const previous = queryCache.getQueryData<ListResponse<Entity>>(key)
-  const optimistic = previous && {
+  // If the row isn't on the visible page there's nothing to remove here —
+  // skip the cancel + churn; settle's prefix-invalidate still refetches the
+  // page(s) where it does live.
+  if (!previous || !previous.data.some((e) => e.id === matchId)) {
+    return { key, previous, optimistic: undefined }
+  }
+  queryCache.cancelQueries({ key })
+  const optimistic = {
     ...previous,
     data: previous.data.filter((e) => e.id !== matchId),
   }
-  if (optimistic) queryCache.setQueryData(key, optimistic)
+  queryCache.setQueryData(key, optimistic)
   return { key, previous, optimistic }
 }
 

--- a/frontend/src/queries/optimisticList.ts
+++ b/frontend/src/queries/optimisticList.ts
@@ -1,0 +1,91 @@
+import type { QueryCache } from '@pinia/colada'
+import type { Entity, ListResponse } from '@/types'
+
+// Optimistic-update cache mechanics for entity-list mutations, shared by
+// KanbanView's drag-drop and EntityList's delete (FEAT-XY2D1L, RR-IVBO9K).
+//
+// The three steps below are the cache half of a Pinia Colada useMutation:
+//   onMutate  → beginOptimistic(...)  (cancel + copy-on-write + snapshot)
+//   onError   → rollbackOptimistic(...) (revert iff still our value)
+//   onSettled → settleOptimistic(...)  (invalidate → reconcile with server)
+//
+// Pulling them out of the component keeps the rollback identity check (the
+// subtle bit — see below) in one unit-tested place instead of copied per
+// view. Cached list objects are never mutated in place; every change is a
+// shallow copy so other subscribers holding references are unaffected.
+
+export interface OptimisticListContext {
+  key: readonly string[]
+  // The pre-mutation cache value, restored on rollback. undefined when the
+  // list wasn't cached yet (nothing to roll back to).
+  previous: ListResponse<Entity> | undefined
+  // The exact object we wrote optimistically. Identity-compared on rollback
+  // so a background refetch that landed mid-mutation is not clobbered.
+  optimistic: ListResponse<Entity> | undefined
+}
+
+// beginOptimistic cancels any in-flight refetch (so it can't overwrite our
+// optimistic write), reads the current list, applies `update` to each
+// matching entity as a copy-on-write, writes it back, and returns the
+// context the error/settle steps need.
+export function beginOptimistic(
+  queryCache: QueryCache,
+  key: readonly string[],
+  matchId: string,
+  update: (entity: Entity) => Entity
+): OptimisticListContext {
+  queryCache.cancelQueries({ key })
+  const previous = queryCache.getQueryData<ListResponse<Entity>>(key)
+  const optimistic = previous && {
+    ...previous,
+    data: previous.data.map((e) => (e.id === matchId ? update(e) : e)),
+  }
+  if (optimistic) queryCache.setQueryData(key, optimistic)
+  return { key, previous, optimistic }
+}
+
+// beginOptimisticRemove is the delete counterpart: drops the matching
+// entity from the cached list (copy-on-write) so the row disappears
+// immediately, returning the same context shape for rollback/settle.
+export function beginOptimisticRemove(
+  queryCache: QueryCache,
+  key: readonly string[],
+  matchId: string
+): OptimisticListContext {
+  queryCache.cancelQueries({ key })
+  const previous = queryCache.getQueryData<ListResponse<Entity>>(key)
+  const optimistic = previous && {
+    ...previous,
+    data: previous.data.filter((e) => e.id !== matchId),
+  }
+  if (optimistic) queryCache.setQueryData(key, optimistic)
+  return { key, previous, optimistic }
+}
+
+// rollbackOptimistic restores `previous` — but ONLY if the cache still holds
+// the exact object we wrote. If a refetch resolved between onMutate and
+// onError, the cache holds newer server truth that we must not stomp.
+//
+// Accepts a Partial because Pinia Colada types a mutation's onError context
+// as partial: onMutate may not have run if the mutation rejected before it.
+export function rollbackOptimistic(
+  queryCache: QueryCache,
+  ctx: Partial<OptimisticListContext>
+): void {
+  if (!ctx.key || !ctx.optimistic) return
+  if (queryCache.getQueryData(ctx.key) === ctx.optimistic) {
+    queryCache.setQueryData(ctx.key, ctx.previous)
+  }
+}
+
+// settleOptimistic invalidates the list so it refetches and reconciles with
+// the server (on success this replaces the optimistic guess with the real
+// row; on a rolled-back error it confirms the reverted state). Awaitable so
+// the mutation can stay "loading" until the refetch lands.
+export function settleOptimistic(
+  queryCache: QueryCache,
+  ctx: Partial<OptimisticListContext>
+): Promise<unknown> {
+  if (!ctx.key) return Promise.resolve()
+  return queryCache.invalidateQueries({ key: ctx.key })
+}

--- a/frontend/src/stores/schema.ts
+++ b/frontend/src/stores/schema.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { getSchema, getConfig } from '@/api/schema'
+import { registerEntityPlurals } from '@/api/entities'
 import { getErrorMessage } from '@/api/errors'
 import type {
   EntityType,
@@ -103,6 +104,15 @@ export const useSchemaStore = defineStore('schema', () => {
       entityTypes.value = new Map(Object.entries(schemaData.entities || {}))
       relationTypes.value = new Map(Object.entries(schemaData.relations || {}))
       customTypes.value = new Map(Object.entries(schemaData.types || {}))
+
+      // Feed the API layer's plural registry so it doesn't have to import
+      // this store (B1a). Mirror the server's GetPlural fallback (type+'s')
+      // for entity types that don't declare an explicit plural.
+      const plurals = new Map<string, string>()
+      for (const [type, def] of entityTypes.value) {
+        plurals.set(type, def.plural || `${type}s`)
+      }
+      registerEntityPlurals(plurals)
 
       // Config
       app.value = configData.app || { name: 'rela' }

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -5,7 +5,8 @@ import { useQuery, useMutation, useQueryCache } from '@pinia/colada'
 import { useSchemaStore, useUIStore } from '@/stores'
 import { listEntities, updateEntity, getErrorMessage } from '@/api'
 import { entityKeys } from '@/queries/entities'
-import type { Entity, KanbanConfig, ListResponse } from '@/types'
+import { beginOptimistic, rollbackOptimistic, settleOptimistic } from '@/queries/optimisticList'
+import type { Entity, KanbanConfig } from '@/types'
 import Badge from '@/components/common/Badge.vue'
 import BackButton from '@/components/common/BackButton.vue'
 import { useBackTarget } from '@/composables/useBackTarget'
@@ -230,31 +231,20 @@ const { mutate: moveCard } = useMutation({
     return updateEntity(config.entity, entity.id, { properties: updates })
   },
   onMutate({ entity, updates }: MoveCardVars) {
-    const key = entityKeys.list(kanbanConfig.value?.entity ?? '')
-    // Stop an in-flight refetch from overwriting the optimistic state.
-    queryCache.cancelQueries({ key })
-    const previous = queryCache.getQueryData<ListResponse<Entity>>(key)
-    const optimistic = previous && {
-      ...previous,
-      data: previous.data.map((e) =>
-        e.id === entity.id ? { ...e, properties: { ...e.properties, ...updates } } : e
-      ),
-    }
-    if (optimistic) queryCache.setQueryData(key, optimistic)
-    return { key, previous, optimistic }
+    return beginOptimistic(
+      queryCache,
+      entityKeys.list(kanbanConfig.value?.entity ?? ''),
+      entity.id,
+      (e) => ({ ...e, properties: { ...e.properties, ...updates } })
+    )
   },
   onError(err, _vars, context) {
-    const { key, previous, optimistic } = context
-    // Roll back only if the cache still holds our optimistic value — a
-    // refetch that landed in between is newer than what we saved.
-    if (key && optimistic && queryCache.getQueryData(key) === optimistic) {
-      queryCache.setQueryData(key, previous)
-    }
+    rollbackOptimistic(queryCache, context)
     console.error('Failed to update entity:', err)
     uiStore.error(getErrorMessage(err, 'Failed to move card'))
   },
   async onSettled(_data, _err, _vars, context) {
-    if (context.key) await queryCache.invalidateQueries({ key: context.key })
+    await settleOptimistic(queryCache, context)
   },
 })
 

--- a/tickets/entities/automated-measures/optimistic-list-helper-test.md
+++ b/tickets/entities/automated-measures/optimistic-list-helper-test.md
@@ -1,0 +1,9 @@
+---
+id: optimistic-list-helper-test
+type: automated-measure
+title: 'Unit tests: shared optimistic-list cache helper (three orderings)'
+description: 'Vitest suite (frontend/src/queries/optimisticList.test.ts) covering beginOptimistic/beginOptimisticRemove/rollbackOptimistic/settleOptimistic against a fake QueryCache: copy-on-write update + remove, and the three RR-IVBO9K orderings — success (settle invalidates), error-with-no-refetch (rollback restores), error-after-intervening-refetch (rollback skipped via the identity check). Plus entities.test.ts for the canonicalListParams collision/order fix.'
+kind: test
+location: frontend/src/queries/optimisticList.test.ts
+status: active
+---

--- a/tickets/entities/review-checklists/REV-TIMGQ2.md
+++ b/tickets/entities/review-checklists/REV-TIMGQ2.md
@@ -1,0 +1,56 @@
+---
+id: REV-TIMGQ2
+type: review-checklist
+title: 'Review: EntityList migration to Pinia Colada (FEAT-XY2D1L slice 2)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (1050 unit tests, 66 files — incl. 7 optimistic-helper, 6 key/canonical, 3 plural; list+crud+keyboard E2E: 25 specs; kanban E2E: 15 specs, against the built rela-server)
+- [x] Lint clean (0 errors, 82-warning baseline — no regression; the 2 warnings in touched files are pre-existing max-lines on EntityList/KanbanView)
+- [x] ~~Coverage maintained~~ (N/A: frontend coverage ratchet removed in PR #944)
+
+## Code Review
+
+- [x] Run `/code-review` command (cranky-code-reviewer: 0 critical, 3 significant, 2 minor + leverage notes; it verified the listQueryRef forward-reference, delete race, SSE liveness, and registry boot-gating are all correct)
+- [x] All critical review-responses addressed (none found)
+- [x] All significant review-responses addressed (RR-RIMWZW key collision, RR-135F28 page resync, RR-Z7HYW7 test fidelity — all fixed)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-RIMWZW, RR-135F28, RR-Z7HYW7 (significant, addressed),
+RR-Q1CFXV (minor, addressed), RR-ENW3J4 (minor, wont-fix with reason — E2E owns
+the prefix contract)
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (useQuery replaces fetchGeneration/scheduleFetch/loading: list E2E; SSE liveness via ['entities',type] prefix: confirmed by reviewer + create-and-see E2E; optimistic delete + rollback + toast: component test + helper units; B1a plural registry + throw: entitiesPlural.test.ts; canonical key collision/order: entities.test.ts)
+- [x] Test evidence documented (this checklist + PR description)
+
+**Acceptance Status:** PASS — EntityList on a single useQuery with canonicalized
+param keys; page-input/meta-output split with server-clamp resync; delete via
+shared optimistic helper; Kanban refactored onto the same helper (RR-IVBO9K
+closed); api/entities.ts no longer imports a store. All unit + targeted E2E
+green.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist~~ (N/A: internal architecture migration; the arc is documented on FEAT-XY2D1L, and queries/*.ts headers document the key hierarchy + helper contract for the next slice)
+
+**Docs Checklist:** N/A
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use (the optimisticList helper + entityKeys.listParams are the reusable surface for the next migrations)
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (verified after push)
+- [x] PR URL documented below
+
+**PR:** (added after creation)

--- a/tickets/entities/review-checklists/REV-TIMGQ2.md
+++ b/tickets/entities/review-checklists/REV-TIMGQ2.md
@@ -9,35 +9,33 @@ status: done
 
 ## Automated Checks
 
-- [x] All tests pass (1050 unit tests, 66 files — incl. 7 optimistic-helper, 6 key/canonical, 3 plural; list+crud+keyboard E2E: 25 specs; kanban E2E: 15 specs, against the built rela-server)
-- [x] Lint clean (0 errors, 82-warning baseline — no regression; the 2 warnings in touched files are pre-existing max-lines on EntityList/KanbanView)
+- [x] All tests pass (1050 unit tests, 66 files; list+crud+keyboard E2E: 25; kanban E2E: 15, against the built rela-server)
+- [x] Lint clean (0 errors, 82-warning baseline — no regression)
 - [x] ~~Coverage maintained~~ (N/A: frontend coverage ratchet removed in PR #944)
 
 ## Code Review
 
-- [x] Run `/code-review` command (cranky-code-reviewer: 0 critical, 3 significant, 2 minor + leverage notes; it verified the listQueryRef forward-reference, delete race, SSE liveness, and registry boot-gating are all correct)
+- [x] Run `/code-review` command (cranky-code-reviewer: 0 critical, 3 significant, 2 minor; verified forward-reference, delete race, SSE liveness, registry boot-gating all correct)
 - [x] All critical review-responses addressed (none found)
-- [x] All significant review-responses addressed (RR-RIMWZW key collision, RR-135F28 page resync, RR-Z7HYW7 test fidelity — all fixed)
+- [x] All significant review-responses addressed (RR-RIMWZW, RR-135F28, RR-Z7HYW7 — all fixed)
 - [x] Self-reviewed the diff for unrelated changes
 
 **Review Responses:** RR-RIMWZW, RR-135F28, RR-Z7HYW7 (significant, addressed),
-RR-Q1CFXV (minor, addressed), RR-ENW3J4 (minor, wont-fix with reason — E2E owns
-the prefix contract)
+RR-Q1CFXV (minor, addressed), RR-ENW3J4 (minor, wont-fix with reason)
 
 ## Acceptance Verification
 
-- [x] Each acceptance criterion tested (useQuery replaces fetchGeneration/scheduleFetch/loading: list E2E; SSE liveness via ['entities',type] prefix: confirmed by reviewer + create-and-see E2E; optimistic delete + rollback + toast: component test + helper units; B1a plural registry + throw: entitiesPlural.test.ts; canonical key collision/order: entities.test.ts)
-- [x] Test evidence documented (this checklist + PR description)
+- [x] Each acceptance criterion tested (see PR description)
+- [x] Test evidence documented
 
-**Acceptance Status:** PASS — EntityList on a single useQuery with canonicalized
-param keys; page-input/meta-output split with server-clamp resync; delete via
-shared optimistic helper; Kanban refactored onto the same helper (RR-IVBO9K
-closed); api/entities.ts no longer imports a store. All unit + targeted E2E
-green.
+**Acceptance Status:** PASS — EntityList on useQuery with canonicalized keys;
+page-input/meta-output split with server-clamp resync; delete via shared
+optimistic helper; Kanban refactored onto it (RR-IVBO9K closed); api/entities.ts
+store-free.
 
 ## Documentation (enhancements only)
 
-- [x] ~~Docs-checklist~~ (N/A: internal architecture migration; the arc is documented on FEAT-XY2D1L, and queries/*.ts headers document the key hierarchy + helper contract for the next slice)
+- [x] ~~Docs-checklist~~ (N/A: internal architecture migration; documented on FEAT-XY2D1L + queries/*.ts headers)
 
 **Docs Checklist:** N/A
 
@@ -45,7 +43,7 @@ green.
 
 - [x] Commit message explains the why, not just what
 - [x] No TODOs or FIXMEs left unaddressed
-- [x] Ready for another developer to use (the optimisticList helper + entityKeys.listParams are the reusable surface for the next migrations)
+- [x] Ready for another developer to use
 
 ## Pull Request
 
@@ -53,4 +51,4 @@ green.
 - [x] All CI checks pass (verified after push)
 - [x] PR URL documented below
 
-**PR:** (added after creation)
+**PR:** https://github.com/sourcehaven-bv/rela/pull/971

--- a/tickets/entities/review-responses/RR-135F28.md
+++ b/tickets/entities/review-responses/RR-135F28.md
@@ -1,0 +1,9 @@
+---
+id: RR-135F28
+type: review-response
+title: Input page and server meta.page had no re-sync path after the split
+finding: 'Splitting page-as-input from meta-as-output created two page truths: input `page` drives the query key + keyboard nav, while Pagination renders off server `meta.page`. If the backend clamps an out-of-range page, they diverge with nothing reconciling them.'
+severity: significant
+resolution: Added a watcher that adopts the server's returned meta.page into the input `page` ref when they differ, so the query key, keyboard nav, and Pagination controls share one page-of-truth even when the server clamps.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ENW3J4.md
+++ b/tickets/entities/review-responses/RR-ENW3J4.md
@@ -1,0 +1,9 @@
+---
+id: RR-ENW3J4
+type: review-response
+title: Fake QueryCache models keys as exact strings, can't catch prefix-vs-exact regressions
+finding: optimisticList.test.ts's fake cache uses exact string-join keys, so a regression narrowing settleOptimistic to an exact key (defeating invalidate-all-param-variants) would pass.
+severity: minor
+reason: The unit under test only forwards keys verbatim to the cache; the exact-vs-prefix contract is owned by Pinia Colada's real cache and exercised end-to-end by the list+kanban E2E specs (create/delete reconcile across pages). Modeling isSubsetOf in the fake would test the fake, not the helper. Left as-is; the E2E layer is the right guard for the prefix contract.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-IVBO9K.md
+++ b/tickets/entities/review-responses/RR-IVBO9K.md
@@ -4,6 +4,7 @@ type: review-response
 title: KanbanView optimistic-mutation cache logic has no unit coverage
 finding: The copy-on-write onMutate, the getQueryData(key) === optimistic rollback identity check, and onSettled invalidation are only exercised by E2E, which rarely hits the error-with-intervening-refetch ordering.
 severity: minor
+resolution: 'Closed by TKT-24QVHB: the optimistic-update cache logic was extracted into src/queries/optimisticList.ts (beginOptimistic/beginOptimisticRemove/rollbackOptimistic/settleOptimistic) and unit-tested for the three orderings (success / rollback / refetch-superseded). KanbanView''s moveCard now uses it, and EntityList''s new delete mutation shares it.'
 reason: 'Deferred to the EntityList migration slice of FEAT-XY2D1L: the optimistic-update cache logic will be extracted into a shared pure helper in src/queries/ (needed by the second consumer anyway) and unit-tested there for the three orderings (success, rollback, refetch-superseded-rollback).'
-status: deferred
+status: addressed
 ---

--- a/tickets/entities/review-responses/RR-Q1CFXV.md
+++ b/tickets/entities/review-responses/RR-Q1CFXV.md
@@ -1,0 +1,9 @@
+---
+id: RR-Q1CFXV
+type: review-response
+title: 'Minor cleanups: optimistic-remove early-return, plural test-reset, loading comment'
+finding: (#5) beginOptimisticRemove cancelled the query and wrote a copy even when the row wasn't on the visible page; (#6) _setEntityPluralForTest had no reset helper, risking cross-test registry pollution; (#4) the loading comment implied placeholderData keeps rows visible during pagination, which it doesn't (param change = new key = pending).
+severity: minor
+resolution: beginOptimisticRemove now early-returns (undefined optimistic) when no row matches — no cancel/churn, settle's prefix-invalidate still covers other pages. Added _resetEntityPluralsForTest(). Corrected the loading comment to distinguish same-key SSE refetch (no spinner) from param-change (spinner, as before).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-RIMWZW.md
+++ b/tickets/entities/review-responses/RR-RIMWZW.md
@@ -1,0 +1,9 @@
+---
+id: RR-RIMWZW
+type: review-response
+title: canonicalListParams k=v join could collide on values containing & or =
+finding: The cache-key serializer joined sorted pairs as `k=v&...`, so two distinct filter sets could collapse to the same key when a filter value contained & or = (both legal in a contains-filter), serving the wrong cached list — the same false-negative class utils/filters.ts:stringifyFilterQuery documents and avoids.
+severity: significant
+resolution: Switched to JSON.stringify of sorted [key,value] pairs (collision-proof, also future-proofs array/object values). Added a regression test asserting filter[a]=x,filter[b]=y does not collide with filter[a]=x&filter[b]=y.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Z7HYW7.md
+++ b/tickets/entities/review-responses/RR-Z7HYW7.md
@@ -1,0 +1,9 @@
+---
+id: RR-Z7HYW7
+type: review-response
+title: Delete-failure test didn't assert optimistic-remove/rollback/toast
+finding: The rewritten failure test only checked deleteEntity was called and the modal closed — the headline optimistic-remove + rollback + toast behavior had no component-level assertion; dropping the onError handler would have kept it green.
+severity: significant
+resolution: Strengthened the test to assert the row is restored after the rejected mutation settles (rollback) and uiStore.error fired (toast). The fleeting synchronous optimistic-removed frame was deliberately not asserted (non-deterministic to observe); the rollback+toast assertions still pin the onError wiring. Split modal-close into its own case.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-24QVHB.md
+++ b/tickets/entities/tickets/TKT-24QVHB.md
@@ -1,0 +1,27 @@
+---
+id: TKT-24QVHB
+type: ticket
+title: EntityList migration to Pinia Colada (FEAT-XY2D1L slice 2)
+kind: enhancement
+priority: high
+effort: m
+status: in-progress
+---
+
+Second slice of the query-cache migration (FEAT-XY2D1L), after the KanbanView
+proof-of-pattern (#953).
+
+**EntityList migration**
+- Extend `entityKeys.list(type, params?)` with a canonicalized (sorted-key) params dimension so EntityList's per-page/filter/sort/search queries each key distinctly; Kanban's existing param-free `list(type)` call stays valid. Also fixes the param-order-sensitive cache-key bug from the review.
+- Split local `page` (input → query key) from `meta` (output ← query data) to break the read/write cycle the old `meta.value.page` had.
+- Replace `fetchGeneration` + `scheduleFetch`/`fetchPending` microtask coalescing + manual `loading` + `loadEntities` with one `useQuery` keyed on `queryParams`, `placeholderData: previous` to keep rows visible across param changes. SSE liveness comes free from the `['entities', <type>]` invalidation wired in #953 — EntityList previously never reacted to SSE at all.
+- Delete becomes a `useMutation`; list load errors use `getErrorMessage` + inline error state (consistent with migrated Kanban).
+
+**Shared optimistic helper (closes RR-IVBO9K)**
+- Extract `src/queries/optimisticList.ts`: cancel → copy-on-write set → rollback-with-identity-check → invalidate-on-settle, unit-tested for the three orderings (success / rollback / refetch-superseded-rollback). Refactor KanbanView's `moveCard` onto it.
+
+**B1a folded in**
+- `api/entities.ts` gets a plural registry populated by the schema store; delete the `useSchemaStore` import from the API layer (layering inversion); `getPlural` throws on unknown type instead of fabricating a URL.
+
+Scope excludes EntityDetail / Dashboard / Search / Analyze and the eventual
+deletion of the entities-store TTL cache.

--- a/tickets/entities/tickets/TKT-24QVHB.md
+++ b/tickets/entities/tickets/TKT-24QVHB.md
@@ -5,7 +5,7 @@ title: EntityList migration to Pinia Colada (FEAT-XY2D1L slice 2)
 kind: enhancement
 priority: high
 effort: m
-status: in-progress
+status: done
 ---
 
 Second slice of the query-cache migration (FEAT-XY2D1L), after the KanbanView

--- a/tickets/relations/TKT-24QVHB--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-24QVHB--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-24QVHB
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-24QVHB--has-review--REV-TIMGQ2.md
+++ b/tickets/relations/TKT-24QVHB--has-review--REV-TIMGQ2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-24QVHB
+relation: has-review
+to: REV-TIMGQ2
+---

--- a/tickets/relations/TKT-24QVHB--has-review-response--RR-135F28.md
+++ b/tickets/relations/TKT-24QVHB--has-review-response--RR-135F28.md
@@ -1,0 +1,5 @@
+---
+from: TKT-24QVHB
+relation: has-review-response
+to: RR-135F28
+---

--- a/tickets/relations/TKT-24QVHB--has-review-response--RR-ENW3J4.md
+++ b/tickets/relations/TKT-24QVHB--has-review-response--RR-ENW3J4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-24QVHB
+relation: has-review-response
+to: RR-ENW3J4
+---

--- a/tickets/relations/TKT-24QVHB--has-review-response--RR-Q1CFXV.md
+++ b/tickets/relations/TKT-24QVHB--has-review-response--RR-Q1CFXV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-24QVHB
+relation: has-review-response
+to: RR-Q1CFXV
+---

--- a/tickets/relations/TKT-24QVHB--has-review-response--RR-RIMWZW.md
+++ b/tickets/relations/TKT-24QVHB--has-review-response--RR-RIMWZW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-24QVHB
+relation: has-review-response
+to: RR-RIMWZW
+---

--- a/tickets/relations/TKT-24QVHB--has-review-response--RR-Z7HYW7.md
+++ b/tickets/relations/TKT-24QVHB--has-review-response--RR-Z7HYW7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-24QVHB
+relation: has-review-response
+to: RR-Z7HYW7
+---

--- a/tickets/relations/TKT-24QVHB--implements--FEAT-XY2D1L.md
+++ b/tickets/relations/TKT-24QVHB--implements--FEAT-XY2D1L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-24QVHB
+relation: implements
+to: FEAT-XY2D1L
+---

--- a/tickets/relations/optimistic-list-helper-test--protects--data-entry-ui.md
+++ b/tickets/relations/optimistic-list-helper-test--protects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: optimistic-list-helper-test
+relation: protects
+to: data-entry-ui
+---


### PR DESCRIPTION
Second slice of the query-cache migration (FEAT-XY2D1L), after the merged KanbanView proof-of-pattern (#953). EntityList is the most-used view and previously **never reacted to SSE at all** — this makes config-driven lists live and deletes ~80 lines of bespoke fetch machinery.

**EntityList → useQuery**
- One `useQuery` keyed on canonicalized params replaces the `fetchGeneration` stale-response counter, the `scheduleFetch`/`fetchPending` microtask coalescer, the manual `loading` flag, and `loadEntities`. The reactive key coalesces trigger bursts and drops stale responses natively.
- **SSE liveness (the headline win):** `useEvents`' `['entities', <type>]` invalidation now reaches lists — an entity event background-refetches the visible list while mounted, no spinner (the entry stays `success`, placeholderData holds the rows).
- Split `page` (input → query key) from `meta` (output ← query data) to break the old read/write cycle; a watcher adopts the server's `meta.page` back into the input ref if the backend ever clamps, so query key / keyboard nav / Pagination share one page-of-truth.
- Delete is now a `useMutation` with optimistic row removal + rollback + toast; load failures render an inline error+Retry state instead of the generic toast (and never show "no results" on a 500).

**Shared optimistic helper — `src/queries/optimisticList.ts` (closes RR-IVBO9K)**
- Extracts the optimistic cache mechanics (`beginOptimistic`/`beginOptimisticRemove`/`rollbackOptimistic`/`settleOptimistic`) with the rollback identity check. Unit-tested for the three orderings: success, error-with-no-refetch (rollback), error-after-intervening-refetch (rollback skipped). KanbanView's `moveCard` refactored onto it.

**B1a — API layer no longer imports a store**
- `api/entities.ts` resolves type→plural from a registry the schema store populates on load (`registerEntityPlurals`); the `useSchemaStore` import is gone, and `getPlural` throws on an unknown type instead of fabricating `/categorys`. Boot-gated: App.vue awaits schema load before any list renders.

**Key factory** — `entityKeys.listParams(type, params)` + `canonicalListParams` (JSON of sorted pairs, collision-proof against `&`/`=` in filter values — fixes the review's param-order cache-key bug). `entityKeys.list(type)` stays a valid prefix for invalidation; Kanban's param-free call is unchanged.

**Review:** cranky-code-reviewer — 0 critical, 3 significant (all fixed: key collision RR-RIMWZW, page resync RR-135F28, delete-test fidelity RR-Z7HYW7), 2 minor (1 fixed, 1 wont-fix with reason). It independently verified the `listQueryRef` forward-reference, the delete race, SSE liveness, and registry boot-gating are all correct.

**Verification:** 1050 unit tests (66 files; +16 new across optimisticList/entities/entitiesPlural), typecheck clean, lint at baseline. E2E against the built server: 25 list+crud+keyboard specs and 15 kanban specs pass (create-and-see exercises SSE→invalidation→background-refetch; drag and delete exercise the shared optimistic helper).

Migration remaining (separate slices): EntityDetail → Dashboard/Search/Analyze → delete the entities-store TTL cache + usePageData.