### PR TITLE
feat(acl): /_search visibility — VisibleSearcher seam, generic + pgstore-native impls, conformance suite (TKT-BA8BSX)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,9 @@ Rules when touching this:
 - Prefer table-driven tests with `t.Run(tc.name, ...)` subtests.
 - Use `t.Helper()` on assertion helpers.
 - `internal/store/storetest` provides the store conformance harness — any
-  new `store.Store` implementation must pass it.
+  new `store.Store` implementation must pass it. Likewise any new
+  `search.VisibleSearcher` implementation must pass
+  `storetest.RunVisibleSearchTests` (the ACL-scoped search contract).
 - Race detector is on in CI; don't add `//go:build !race` tags.
 
 ## Coverage

--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -169,7 +169,7 @@ func (d *Desktop) LoadProject(dir string) string {
 
 	app, err := dataentry.NewApp(
 		fs, projCtx, svc.Meta(), svc.Store(),
-		svc.EntityManager(), svc.Searcher(), svc.ACL(),
+		svc.EntityManager(), svc.Searcher(), svc.VisibleSearcher(), svc.ACL(),
 		fieldResolver,
 		svc.Audit(),
 	)

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -127,7 +127,7 @@ func main() {
 
 	app, err := dataentry.NewApp(
 		svc.FS(), svc.Paths(), svc.Meta(), svc.Store(),
-		svc.EntityManager(), svc.Searcher(), svc.ACL(),
+		svc.EntityManager(), svc.Searcher(), svc.VisibleSearcher(), svc.ACL(),
 		fieldResolver,
 		svc.Audit(),
 	)

--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -194,8 +194,9 @@ with the list it links to.
   regression test pins the searcher at zero calls on the deny path.
   New work in the list pipeline must keep the scope resolution first.
 - **Search runs after ACL, on the filtered slice.** This ordering is
-  the contract the future `/_search` ticket builds on; a mock-asserted
-  test pins GraphQuery-before-search.
+  the contract the `/_search` gate (TKT-BA8BSX, below) generalized to
+  mixed-type search; a mock-asserted test pins
+  GraphQuery-before-search on the list pipeline.
 - **No count from an unfiltered source.** Any new aggregate (badge,
   dashboard card, export count) must derive from the gated set, never
   from `Store.CountEntities` on a principal-reachable path.
@@ -209,6 +210,57 @@ with the list it links to.
   `relations:`) restrict surfaces within an authorized write and
   never confer writability by themselves, so they are intentionally
   outside the check.
+
+### Global search (`/_search`, TKT-BA8BSX)
+
+The search view runs through `search.VisibleSearcher` — a seam that
+executes a free-text query restricted to a per-type visibility scope.
+The dataentry layer resolves the principal's `ReadQuery` verdict for
+every metamodel type into a scope map; the searcher guarantees no hit
+outside that scope is ever yielded. The conformance suite
+(`storetest.RunVisibleSearchTests`) pins the contract for every
+implementation: any new searcher must pass it.
+
+Key properties:
+
+- **Scope lookup is fail-closed.** Exact type entry → reserved `"*"`
+  wildcard entry → deny. With no ACL configured the gate supplies
+  `{"*": allow-all}`, so entities whose type is absent from the
+  metamodel stay searchable exactly as before ACL existed. Under a
+  policy, no wildcard is emitted — an off-metamodel type (removed
+  from `metamodel.yaml` while its files remain) is hidden from
+  search rather than leaked.
+- **The result limit applies after visibility.** `/_search` returns
+  up to 1000 results; the bound counts *visible* hits. A
+  pre-visibility cap would starve restricted principals — the top
+  candidates may all be hidden while their own matches rank below.
+  Both gate placement and limit placement are pinned by conformance
+  cases on every backend.
+- **Two implementations, one contract.** The fs/memory builds wrap
+  the regular searcher in a generic filter (`search.NewVisible`,
+  batched `MatchingIDs` probes — in-process, cheap). The postgres
+  build composes visibility into the search SQL itself
+  (`pgstore.SearchVisible`): hidden rows never leave the database,
+  the `LIMIT` is post-visibility, and there is no hidden-row work to
+  measure through timing.
+- **Candidate-window caveat (bleve only).** The bleve backend caps
+  candidate retrieval at 10000 hits; on the default build, "true
+  top-1000 of the visible corpus" holds within that window. The
+  linear and postgres backends have no such window.
+- **Deny short-circuit.** An all-denied principal gets `data: []`
+  without the search backend being invoked at all (no latency
+  probe); a recording-searcher test pins zero calls — and exactly
+  one call for a granted search.
+- **Visible hits don't expose hidden neighbors.** Search results
+  serialize without relation maps (`includeRelations=false`, pinned
+  by test): a visible hit that relates to a hidden entity exposes no
+  hidden ID or title through any field of its body.
+- **Errors carry constant detail.** A visibility-evaluation failure
+  maps to `500 acl_query_failed` / `504` / silent-on-cancel exactly
+  like the list pipeline; a plain backend failure maps to
+  `500 search_failed`. Raw backend error strings go to the server
+  log only. (Previously these errors were silently swallowed into
+  empty results.)
 
 ### Caching: per-principal responses
 
@@ -268,17 +320,14 @@ The `attachACLRequest` middleware:
   neighbor-disclosure analysis (a visible neighbor's id confirms a
   visible entity, but gap analysis around hidden entities needs its
   own treatment).
-- **`/_search`** — the bleve / pgstore search backends need their
-  own query-rewrite. Separate ticket; it builds on the
-  search-after-ACL ordering contract pinned above.
 - **SSE `/api/v1/_events`** — the broker today fans `{type, id}` to
   every subscriber. Per-subscriber filtering is its own ticket.
 - **MCP transport** — tracked as TKT-G3PPD.
 
 For threat-modelling purposes today: per-entity GET, write, include,
-list, sidebar, and pagination channels are tight. The global search
-endpoint and the SSE event stream still reveal `{type, id}`-level
-existence to any connected principal.
+list, sidebar, pagination, and global-search channels are tight. The
+SSE event stream still reveals `{type, id}`-level existence to any
+connected principal.
 
 ## Where to read next
 

--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -246,7 +246,12 @@ Key properties:
 - **Candidate-window caveat (bleve only).** The bleve backend caps
   candidate retrieval at 10000 hits; on the default build, "true
   top-1000 of the visible corpus" holds within that window. The
-  linear and postgres backends have no such window.
+  linear and postgres backends have no such window. Related load
+  note: a free-text query that also carries property filters defers
+  all truncation until after the filters, so the generic path may
+  load up to the candidate window's worth of entity bodies for one
+  request — in-process on the local backends, but worth knowing
+  when diagnosing search latency on very large projects.
 - **Deny short-circuit.** An all-denied principal gets `data: []`
   without the search backend being invoked at all (no latency
   probe); a recording-searcher test pins zero calls — and exactly

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -240,7 +240,12 @@ Key properties:
 - **Candidate-window caveat (bleve only).** The bleve backend caps
   candidate retrieval at 10000 hits; on the default build, "true
   top-1000 of the visible corpus" holds within that window. The
-  linear and postgres backends have no such window.
+  linear and postgres backends have no such window. Related load
+  note: a free-text query that also carries property filters defers
+  all truncation until after the filters, so the generic path may
+  load up to the candidate window's worth of entity bodies for one
+  request — in-process on the local backends, but worth knowing
+  when diagnosing search latency on very large projects.
 - **Deny short-circuit.** An all-denied principal gets `data: []`
   without the search backend being invoked at all (no latency
   probe); a recording-searcher test pins zero calls — and exactly

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -188,8 +188,9 @@ with the list it links to.
   regression test pins the searcher at zero calls on the deny path.
   New work in the list pipeline must keep the scope resolution first.
 - **Search runs after ACL, on the filtered slice.** This ordering is
-  the contract the future `/_search` ticket builds on; a mock-asserted
-  test pins GraphQuery-before-search.
+  the contract the `/_search` gate (TKT-BA8BSX, below) generalized to
+  mixed-type search; a mock-asserted test pins
+  GraphQuery-before-search on the list pipeline.
 - **No count from an unfiltered source.** Any new aggregate (badge,
   dashboard card, export count) must derive from the gated set, never
   from `Store.CountEntities` on a principal-reachable path.
@@ -203,6 +204,57 @@ with the list it links to.
   `relations:`) restrict surfaces within an authorized write and
   never confer writability by themselves, so they are intentionally
   outside the check.
+
+### Global search (`/_search`, TKT-BA8BSX)
+
+The search view runs through `search.VisibleSearcher` — a seam that
+executes a free-text query restricted to a per-type visibility scope.
+The dataentry layer resolves the principal's `ReadQuery` verdict for
+every metamodel type into a scope map; the searcher guarantees no hit
+outside that scope is ever yielded. The conformance suite
+(`storetest.RunVisibleSearchTests`) pins the contract for every
+implementation: any new searcher must pass it.
+
+Key properties:
+
+- **Scope lookup is fail-closed.** Exact type entry → reserved `"*"`
+  wildcard entry → deny. With no ACL configured the gate supplies
+  `{"*": allow-all}`, so entities whose type is absent from the
+  metamodel stay searchable exactly as before ACL existed. Under a
+  policy, no wildcard is emitted — an off-metamodel type (removed
+  from `metamodel.yaml` while its files remain) is hidden from
+  search rather than leaked.
+- **The result limit applies after visibility.** `/_search` returns
+  up to 1000 results; the bound counts *visible* hits. A
+  pre-visibility cap would starve restricted principals — the top
+  candidates may all be hidden while their own matches rank below.
+  Both gate placement and limit placement are pinned by conformance
+  cases on every backend.
+- **Two implementations, one contract.** The fs/memory builds wrap
+  the regular searcher in a generic filter (`search.NewVisible`,
+  batched `MatchingIDs` probes — in-process, cheap). The postgres
+  build composes visibility into the search SQL itself
+  (`pgstore.SearchVisible`): hidden rows never leave the database,
+  the `LIMIT` is post-visibility, and there is no hidden-row work to
+  measure through timing.
+- **Candidate-window caveat (bleve only).** The bleve backend caps
+  candidate retrieval at 10000 hits; on the default build, "true
+  top-1000 of the visible corpus" holds within that window. The
+  linear and postgres backends have no such window.
+- **Deny short-circuit.** An all-denied principal gets `data: []`
+  without the search backend being invoked at all (no latency
+  probe); a recording-searcher test pins zero calls — and exactly
+  one call for a granted search.
+- **Visible hits don't expose hidden neighbors.** Search results
+  serialize without relation maps (`includeRelations=false`, pinned
+  by test): a visible hit that relates to a hidden entity exposes no
+  hidden ID or title through any field of its body.
+- **Errors carry constant detail.** A visibility-evaluation failure
+  maps to `500 acl_query_failed` / `504` / silent-on-cancel exactly
+  like the list pipeline; a plain backend failure maps to
+  `500 search_failed`. Raw backend error strings go to the server
+  log only. (Previously these errors were silently swallowed into
+  empty results.)
 
 ### Caching: per-principal responses
 
@@ -262,17 +314,14 @@ The `attachACLRequest` middleware:
   neighbor-disclosure analysis (a visible neighbor's id confirms a
   visible entity, but gap analysis around hidden entities needs its
   own treatment).
-- **`/_search`** — the bleve / pgstore search backends need their
-  own query-rewrite. Separate ticket; it builds on the
-  search-after-ACL ordering contract pinned above.
 - **SSE `/api/v1/_events`** — the broker today fans `{type, id}` to
   every subscriber. Per-subscriber filtering is its own ticket.
 - **MCP transport** — tracked as TKT-G3PPD.
 
 For threat-modelling purposes today: per-entity GET, write, include,
-list, sidebar, and pagination channels are tight. The global search
-endpoint and the SSE event stream still reveal `{type, id}`-level
-existence to any connected principal.
+list, sidebar, pagination, and global-search channels are tight. The
+SSE event stream still reveals `{type, id}`-level existence to any
+connected principal.
 
 ## Where to read next
 

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -57,20 +57,24 @@ import (
 // constructor inputs — through structural typing, without adapters
 // at the wiring site.
 type Services struct {
-	fs            storage.FS
-	paths         *project.Context
-	meta          *metamodel.Metamodel
-	store         store.Store
-	searcher      search.Searcher
-	entityManager entitymanager.EntityManager
-	tracer        tracer.Tracer
-	validator     validator.Validator
-	templater     templating.Templater
-	cfgLoader     config.Loader
-	stateKV       state.KV
-	scriptEngine  *script.Engine
-	searchCloser  io.Closer
-	acl           acl.ACL
+	fs       storage.FS
+	paths    *project.Context
+	meta     *metamodel.Metamodel
+	store    store.Store
+	searcher search.Searcher
+	// visibleSearcher is the ACL-scoped search seam (TKT-BA8BSX):
+	// the generic search.NewVisible wrapper on the fs/memory builds,
+	// the pgstore-native implementation on the postgres build.
+	visibleSearcher search.VisibleSearcher
+	entityManager   entitymanager.EntityManager
+	tracer          tracer.Tracer
+	validator       validator.Validator
+	templater       templating.Templater
+	cfgLoader       config.Loader
+	stateKV         state.KV
+	scriptEngine    *script.Engine
+	searchCloser    io.Closer
+	acl             acl.ACL
 	// aclDeclarative is set when buildACL constructs a Declarative; nil
 	// for NopACL, ReadOnlyACL, or when Declarative construction fails.
 	aclDeclarative *acl.Declarative
@@ -96,6 +100,11 @@ func (s *Services) Store() store.Store { return s.store }
 // Searcher returns the search service (a sentinel error-searcher when
 // the search backend failed to construct).
 func (s *Services) Searcher() search.Searcher { return s.searcher }
+
+// VisibleSearcher returns the ACL-scoped search seam. Per-backend: the
+// generic scope-filter wrapper on the fs/memory builds, the native
+// SQL-composed implementation on the postgres build.
+func (s *Services) VisibleSearcher() search.VisibleSearcher { return s.visibleSearcher }
 
 // EntityManager returns the production write path.
 func (s *Services) EntityManager() entitymanager.EntityManager { return s.entityManager }
@@ -198,20 +207,25 @@ func (s *Services) LuaWriteDeps() lua.WriteDeps {
 // does not own a closable resource (the error-Searcher placeholder
 // has nothing to close).
 type Collaborators struct {
-	FS            storage.FS
-	Paths         *project.Context
-	Meta          *metamodel.Metamodel
-	Store         store.Store
-	Searcher      search.Searcher
-	EntityManager entitymanager.EntityManager
-	Tracer        tracer.Tracer
-	Validator     validator.Validator
-	Templater     templating.Templater
-	CfgLoader     config.Loader
-	StateKV       state.KV
-	ScriptEngine  *script.Engine
-	ACL           acl.ACL
-	Audit         audit.Audit
+	FS       storage.FS
+	Paths    *project.Context
+	Meta     *metamodel.Metamodel
+	Store    store.Store
+	Searcher search.Searcher
+	// VisibleSearcher may be nil: the constructor then derives the
+	// generic search.NewVisible(Searcher, Store) wrapper, which is the
+	// correct implementation for every in-process store. Only wire it
+	// explicitly to exercise a native implementation.
+	VisibleSearcher search.VisibleSearcher
+	EntityManager   entitymanager.EntityManager
+	Tracer          tracer.Tracer
+	Validator       validator.Validator
+	Templater       templating.Templater
+	CfgLoader       config.Loader
+	StateKV         state.KV
+	ScriptEngine    *script.Engine
+	ACL             acl.ACL
+	Audit           audit.Audit
 
 	// Declarative is the optional concrete *acl.Declarative the test
 	// is wiring. When non-nil, [Services.ACLDeclarative] returns it;
@@ -286,24 +300,33 @@ func NewFromCollaborators(c Collaborators) (*Services, error) {
 	if c.Declarative != nil {
 		aclPolicy = c.Declarative.Policy()
 	}
+	visible := c.VisibleSearcher
+	if visible == nil {
+		v, err := search.NewVisible(c.Searcher, c.Store)
+		if err != nil {
+			return nil, fmt.Errorf("appbuild.NewFromCollaborators: derive VisibleSearcher: %w", err)
+		}
+		visible = v
+	}
 	return &Services{
-		fs:             c.FS,
-		paths:          c.Paths,
-		meta:           c.Meta,
-		store:          c.Store,
-		searcher:       c.Searcher,
-		entityManager:  c.EntityManager,
-		tracer:         c.Tracer,
-		validator:      c.Validator,
-		templater:      c.Templater,
-		cfgLoader:      c.CfgLoader,
-		stateKV:        c.StateKV,
-		scriptEngine:   c.ScriptEngine,
-		searchCloser:   c.SearchCloser,
-		acl:            c.ACL,
-		aclDeclarative: c.Declarative,
-		aclPolicy:      aclPolicy,
-		audit:          c.Audit,
+		fs:              c.FS,
+		paths:           c.Paths,
+		meta:            c.Meta,
+		store:           c.Store,
+		searcher:        c.Searcher,
+		visibleSearcher: visible,
+		entityManager:   c.EntityManager,
+		tracer:          c.Tracer,
+		validator:       c.Validator,
+		templater:       c.Templater,
+		cfgLoader:       c.CfgLoader,
+		stateKV:         c.StateKV,
+		scriptEngine:    c.ScriptEngine,
+		searchCloser:    c.SearchCloser,
+		acl:             c.ACL,
+		aclDeclarative:  c.Declarative,
+		aclPolicy:       aclPolicy,
+		audit:           c.Audit,
 	}, nil
 }
 
@@ -546,8 +569,24 @@ func prepare(cfg Config, opts []Option) (*buildBase, error) {
 // Keeping this shared is the invariant that prevents the three New
 // recipes from drifting: a recipe may CHOOSE and ORDER backend steps,
 // but build-agnostic wiring lives here and nowhere else.
-func assemble(base *buildBase, st store.Store, searcher search.Searcher, searchCloser io.Closer) (*Services, error) {
+//
+// visible may be nil: assemble then derives the generic
+// search.NewVisible(searcher, st) wrapper, the correct ACL-scoped
+// search implementation for every in-process store. The postgres
+// recipe passes its native implementation instead.
+func assemble(
+	base *buildBase, st store.Store, searcher search.Searcher,
+	visible search.VisibleSearcher, searchCloser io.Closer,
+) (*Services, error) {
 	cfg := base.cfg
+
+	if visible == nil {
+		v, err := search.NewVisible(searcher, st)
+		if err != nil {
+			return nil, fmt.Errorf("appbuild: derive VisibleSearcher: %w", err)
+		}
+		visible = v
+	}
 
 	// Now the store is open: build the Declarative ACL with a
 	// store-backed Graph. This is deferred from prepare because
@@ -613,23 +652,24 @@ func assemble(base *buildBase, st store.Store, searcher search.Searcher, searchC
 	}
 
 	return &Services{
-		fs:             cfg.FS,
-		paths:          cfg.Paths,
-		meta:           base.meta,
-		store:          st,
-		searcher:       searcher,
-		entityManager:  mgr,
-		tracer:         tr,
-		validator:      val,
-		templater:      templater,
-		cfgLoader:      cfgLoader,
-		stateKV:        stateKV,
-		scriptEngine:   cfg.ScriptEngine,
-		searchCloser:   searchCloser,
-		acl:            resolvedACL,
-		aclDeclarative: aclDeclarative,
-		aclPolicy:      base.aclPolicy,
-		audit:          cfg.Audit,
+		fs:              cfg.FS,
+		paths:           cfg.Paths,
+		meta:            base.meta,
+		store:           st,
+		searcher:        searcher,
+		visibleSearcher: visible,
+		entityManager:   mgr,
+		tracer:          tr,
+		validator:       val,
+		templater:       templater,
+		cfgLoader:       cfgLoader,
+		stateKV:         stateKV,
+		scriptEngine:    cfg.ScriptEngine,
+		searchCloser:    searchCloser,
+		acl:             resolvedACL,
+		aclDeclarative:  aclDeclarative,
+		aclPolicy:       base.aclPolicy,
+		audit:           cfg.Audit,
 	}, nil
 }
 

--- a/internal/appbuild/appbuild_fs.go
+++ b/internal/appbuild/appbuild_fs.go
@@ -30,7 +30,10 @@ func New(cfg Config, opts ...Option) (*Services, error) {
 	if err != nil {
 		return nil, err
 	}
-	return assemble(base, st, searcher, closer)
+	// nil VisibleSearcher → assemble derives the generic
+	// search.NewVisible wrapper (TKT-BA8BSX); only the postgres
+	// recipe wires a native implementation.
+	return assemble(base, st, searcher, nil, closer)
 }
 
 // openBackend opens the fsstore and the bleve-backed searcher. The bleve

--- a/internal/appbuild/appbuild_memory.go
+++ b/internal/appbuild/appbuild_memory.go
@@ -25,7 +25,10 @@ func New(cfg Config, opts ...Option) (*Services, error) {
 	if err != nil {
 		return nil, err
 	}
-	return assemble(base, st, searcher, closer)
+	// nil VisibleSearcher → assemble derives the generic
+	// search.NewVisible wrapper (TKT-BA8BSX); only the postgres
+	// recipe wires a native implementation.
+	return assemble(base, st, searcher, nil, closer)
 }
 
 // openBackend opens a memstore with a LinearSearch index wired as a

--- a/internal/appbuild/appbuild_postgres.go
+++ b/internal/appbuild/appbuild_postgres.go
@@ -30,10 +30,15 @@ func New(cfg Config, opts ...Option) (*Services, error) {
 	if err != nil {
 		return nil, err
 	}
-	// nil VisibleSearcher → assemble derives the generic
-	// search.NewVisible wrapper; the pgstore-native implementation
-	// replaces it in the follow-up commit (TKT-BA8BSX).
-	return assemble(base, st, searcher, nil, closer)
+	// The postgres store implements search.VisibleSearcher natively
+	// (visibility composed into the search SQL — pgstore.SearchVisible,
+	// TKT-BA8BSX). Assert loudly rather than silently falling back to
+	// the generic wrapper: a fallback would hide a wiring regression.
+	visible, ok := st.(search.VisibleSearcher)
+	if !ok {
+		return nil, errors.New("appbuild: postgres store does not implement search.VisibleSearcher")
+	}
+	return assemble(base, st, searcher, visible, closer)
 }
 
 // openBackend delegates pool construction, migration, and store+search wiring

--- a/internal/appbuild/appbuild_postgres.go
+++ b/internal/appbuild/appbuild_postgres.go
@@ -30,7 +30,10 @@ func New(cfg Config, opts ...Option) (*Services, error) {
 	if err != nil {
 		return nil, err
 	}
-	return assemble(base, st, searcher, closer)
+	// nil VisibleSearcher → assemble derives the generic
+	// search.NewVisible wrapper; the pgstore-native implementation
+	// replaces it in the follow-up commit (TKT-BA8BSX).
+	return assemble(base, st, searcher, nil, closer)
 }
 
 // openBackend delegates pool construction, migration, and store+search wiring

--- a/internal/dataentry/acl_get_test.go
+++ b/internal/dataentry/acl_get_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -256,6 +257,10 @@ func (g fakeGate) PermitsReadMany(_ context.Context, _ string, ids []string) (ma
 
 func (g fakeGate) ReadQuery(context.Context, string) acl.ReadQueryResult {
 	return acl.ReadQueryResult{DenyAll: true}
+}
+
+func (g fakeGate) SearchScope(context.Context, []string) map[string]search.TypeScope {
+	return nil // all-deny, matching ReadQuery above
 }
 
 // principalCtx returns a context carrying a stamped data-entry

--- a/internal/dataentry/acl_search_test.go
+++ b/internal/dataentry/acl_search_test.go
@@ -1,0 +1,367 @@
+package dataentry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/search"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// searchAs performs GET /api/v1/_search?q=<q> with the readGate +
+// acl.Request attached, mirroring listEntitiesAs for the search view.
+func searchAs(ctx context.Context, t *testing.T, app *App, d *acl.Declarative, q string) (V1ListResponse, *httptest.ResponseRecorder) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_search?q="+q, http.NoBody)
+	req = req.WithContext(gateCtxFor(ctx, t, d))
+	rec := httptest.NewRecorder()
+	app.handleV1Search(rec, req)
+
+	var resp V1ListResponse
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode search response: %v\nbody: %s", err, rec.Body)
+		}
+	}
+	return resp, rec
+}
+
+// TestACLSearch_TypeLevelGrant pins TKT-BA8BSX AC1 + AC3: a role with
+// `read: [ticket]` sees matching tickets through /_search and nothing
+// else — the raw body carries no hidden ID, title, or property value.
+// A principal with no grants at all gets the empty shape.
+func TestACLSearch_TypeLevelGrant(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "alpha rocket"}})
+	seedEntity(app, &entity.Entity{ID: "TKT-002", Type: "ticket", Properties: map[string]any{"title": "alpha lander"}})
+	seedEntity(app, &entity.Entity{ID: "FEAT-001", Type: "feature", Properties: map[string]any{
+		"title": "alpha hidden-feature-title", "status": "secret-status-value",
+	}})
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	resp, rec := searchAs(aliceCtx(), t, app, d, "alpha")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /_search: %d %s", rec.Code, rec.Body)
+	}
+	if len(resp.Data) != 2 || resp.Meta.Total != 2 {
+		t.Errorf("got %d hits (total %d), want the 2 tickets", len(resp.Data), resp.Meta.Total)
+	}
+	for _, leak := range []string{"FEAT-001", "hidden-feature-title", "secret-status-value"} {
+		if strings.Contains(rec.Body.String(), leak) {
+			t.Errorf("hidden value %q leaked into the search body", leak)
+		}
+	}
+
+	// bob has no assignment → no roles → every type DenyAll.
+	resp, rec = searchAs(principalCtx("bob"), t, app, d, "alpha")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /_search as bob: %d %s", rec.Code, rec.Body)
+	}
+	if len(resp.Data) != 0 || resp.Meta.Total != 0 {
+		t.Errorf("denied principal: got %d hits (total %d), want 0", len(resp.Data), resp.Meta.Total)
+	}
+}
+
+// TestACLSearch_RoleRelationInheritance pins TKT-BA8BSX AC2: the
+// editor-of / belongs-to world — search returns the PRJ-42 ticket and
+// never the PRJ-9 one, even though both match the text.
+func TestACLSearch_RoleRelationInheritance(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "alice", Type: "person", Properties: map[string]any{"title": "Alice"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-42", Type: "project", Properties: map[string]any{"title": "Granted"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-9", Type: "project", Properties: map[string]any{"title": "Hidden"}})
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "alpha visible"}})
+	seedEntity(app, &entity.Entity{ID: "TKT-002", Type: "ticket", Properties: map[string]any{"title": "alpha covert-ticket-title"}})
+	seedRelation(app, entity.NewRelation("alice", "editor-of", "PRJ-42"))
+	seedRelation(app, entity.NewRelation("TKT-001", "belongs-to", "PRJ-42"))
+	seedRelation(app, entity.NewRelation("TKT-002", "belongs-to", "PRJ-9"))
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles: map[string]acl.RoleDef{"editor": {Read: []string{"ticket"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{
+			"editor-of": {Confers: "editor"},
+		},
+		InheritRolesThrough: []string{"belongs-to"},
+	}, app.store)
+	app.acl = d
+
+	resp, rec := searchAs(aliceCtx(), t, app, d, "alpha")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /_search: %d %s", rec.Code, rec.Body)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].ID != "TKT-001" {
+		t.Fatalf("expected exactly [TKT-001], got %+v", resp.Data)
+	}
+	for _, leak := range []string{"TKT-002", "covert-ticket-title"} {
+		if strings.Contains(rec.Body.String(), leak) {
+			t.Errorf("hidden value %q leaked into the search body", leak)
+		}
+	}
+}
+
+// TestACLSearch_VisibleHitRelatedToHidden pins TKT-BA8BSX AC3b
+// (RR-QO01XY): a VISIBLE search hit that relates to a HIDDEN entity
+// must not expose the hidden entity's ID or title through any field
+// of its serialized body. This is the serializer-level half of the
+// no-leak guarantee — the conformance suite can't see it because it
+// asserts on search.Hit, not on the wire shape. The invariant rests
+// on handleV1Search keeping includeRelations=false; if that flips,
+// this test fails before a leak ships.
+func TestACLSearch_VisibleHitRelatedToHidden(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "alpha visible"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-SECRET", Type: "project", Properties: map[string]any{"title": "ultra-hidden-project"}})
+	seedRelation(app, entity.NewRelation("TKT-001", "belongs-to", "PRJ-SECRET"))
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	resp, rec := searchAs(aliceCtx(), t, app, d, "alpha")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /_search: %d %s", rec.Code, rec.Body)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].ID != "TKT-001" {
+		t.Fatalf("expected the visible ticket, got %+v", resp.Data)
+	}
+	for _, leak := range []string{"PRJ-SECRET", "ultra-hidden-project"} {
+		if strings.Contains(rec.Body.String(), leak) {
+			t.Errorf("related hidden entity value %q leaked through a visible hit", leak)
+		}
+	}
+}
+
+// TestACLSearch_DenyAllShortCircuit pins TKT-BA8BSX AC4 (RR-599CLE):
+// an all-effective-DenyAll scope returns before the search backend is
+// touched (no timing probe), and — the positive control — a single
+// granted type invokes the backend exactly once.
+func TestACLSearch_DenyAllShortCircuit(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "alpha"}})
+
+	var calls []string
+	app.searcher = recordingSearcher{log: &calls}
+	rebindVisibleSearcher(t, app)
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	// bob: no roles → empty scope → short-circuit before the backend.
+	_, rec := searchAs(principalCtx("bob"), t, app, d, "anything")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /_search as bob: %d %s", rec.Code, rec.Body)
+	}
+	if len(calls) != 0 {
+		t.Errorf("search backend invoked %d times on the DenyAll path, want 0 (calls: %v)", len(calls), calls)
+	}
+
+	// alice: one granted type → the backend runs exactly once.
+	_, rec = searchAs(aliceCtx(), t, app, d, "alpha")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /_search as alice: %d %s", rec.Code, rec.Body)
+	}
+	if got := len(calls); got != 1 {
+		t.Errorf("search backend invoked %d times for a granted search, want exactly 1 (calls: %v)", got, calls)
+	}
+}
+
+// failingMatchingIDsStore makes every MatchingIDs call fail with a
+// synthetic backend error, simulating an ACL scope-evaluation failure
+// inside the visible-search pipeline.
+type failingMatchingIDsStore struct {
+	store.Store
+	err error
+}
+
+func (s failingMatchingIDsStore) MatchingIDs(context.Context, store.GraphQuery, []string) (map[string]bool, error) {
+	return nil, s.err
+}
+
+// typedHitSearcher yields fully-typed hits so the visible wrapper has
+// something to probe MatchingIDs with.
+type typedHitSearcher struct{ hits []search.Hit }
+
+func (s typedHitSearcher) Search(context.Context, search.Query) iter.Seq2[search.Hit, error] {
+	return func(yield func(search.Hit, error) bool) {
+		for _, h := range s.hits {
+			if !yield(h, nil) {
+				return
+			}
+		}
+	}
+}
+
+// aclSearchQueryVerdictWorld builds the editor-of world where alice's
+// ticket verdict is a composed Query (not AllowAll), so the visible
+// wrapper must call MatchingIDs.
+func aclSearchQueryVerdictWorld(t *testing.T, app *App) *acl.Declarative {
+	t.Helper()
+	seedEntity(app, &entity.Entity{ID: "alice", Type: "person", Properties: map[string]any{"title": "Alice"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-42", Type: "project", Properties: map[string]any{"title": "Granted"}})
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "alpha"}})
+	seedRelation(app, entity.NewRelation("alice", "editor-of", "PRJ-42"))
+	seedRelation(app, entity.NewRelation("TKT-001", "belongs-to", "PRJ-42"))
+	d := mustNewACL(t, &acl.Policy{
+		Roles: map[string]acl.RoleDef{"editor": {Read: []string{"ticket"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{
+			"editor-of": {Confers: "editor"},
+		},
+		InheritRolesThrough: []string{"belongs-to"},
+	}, app.store)
+	app.acl = d
+	return d
+}
+
+// TestACLSearch_ScopeErrorMapping pins TKT-BA8BSX AC7 + AC7b for the
+// visibility-failure class: a MatchingIDs error surfaces as 500
+// acl_query_failed with the constant detail — the raw backend string
+// (which can name tables/columns) never reaches the wire — and the
+// executeQuery error wraps errACLListQuery so the _position consumer
+// keeps the writeGateError mapping.
+func TestACLSearch_ScopeErrorMapping(t *testing.T) {
+	app := newTestAppV1(t)
+	d := aclSearchQueryVerdictWorld(t, app)
+
+	const synthetic = `pq: relation "secret_internal_acl_table" does not exist`
+	failing := failingMatchingIDsStore{Store: app.store, err: errors.New(synthetic)}
+	app.searcher = typedHitSearcher{hits: []search.Hit{{ID: "TKT-001", Type: "ticket", Title: "alpha"}}}
+	v, err := search.NewVisible(app.searcher, failing)
+	if err != nil {
+		t.Fatalf("NewVisible: %v", err)
+	}
+	app.visibleSearcher = v
+
+	// Wire-level mapping (AC7).
+	_, rec := searchAs(aliceCtx(), t, app, d, "alpha")
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 on scope failure, got %d (body: %s)", rec.Code, rec.Body)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "acl_query_failed") {
+		t.Errorf("expected acl_query_failed code, body: %s", body)
+	}
+	if !strings.Contains(body, "check server logs") {
+		t.Errorf("expected constant detail, body: %s", body)
+	}
+	if strings.Contains(body, "secret_internal_acl_table") || strings.Contains(body, "pq:") {
+		t.Errorf("raw backend error leaked to the wire: %s", body)
+	}
+
+	// Sentinel wrapping (AC7b): the _position consumer relies on it.
+	_, qErr := app.executeQuery(gateCtxFor(aliceCtx(), t, d), "alpha")
+	if !errors.Is(qErr, errACLListQuery) {
+		t.Errorf("executeQuery scope error = %v, want errACLListQuery wrap", qErr)
+	}
+}
+
+// TestACLSearch_CanceledScopeStaysSilent pins the AC7b cancel branch:
+// a context.Canceled surfacing through the visibility pipeline writes
+// NO response body on /_position?scope=search (client is gone — same
+// behavior readableSubset had before it was retired).
+func TestACLSearch_CanceledScopeStaysSilent(t *testing.T) {
+	app := newTestAppV1(t)
+	d := aclSearchQueryVerdictWorld(t, app)
+
+	failing := failingMatchingIDsStore{Store: app.store, err: context.Canceled}
+	app.searcher = typedHitSearcher{hits: []search.Hit{{ID: "TKT-001", Type: "ticket", Title: "alpha"}}}
+	v, err := search.NewVisible(app.searcher, failing)
+	if err != nil {
+		t.Fatalf("NewVisible: %v", err)
+	}
+	app.visibleSearcher = v
+
+	req := httptest.NewRequest(http.MethodGet,
+		positionURL(t, "TKT-001", ScopeDescriptor{Source: "search", Q: "alpha"}), http.NoBody)
+	req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
+	rec := httptest.NewRecorder()
+	app.handleV1EntityPosition(rec, req)
+
+	if rec.Body.Len() != 0 {
+		t.Errorf("canceled scope error must stay silent, got body: %s", rec.Body)
+	}
+}
+
+// TestACLSearch_BackendErrorMapping pins the OTHER error class of AC7:
+// a plain search-backend failure (not scope evaluation) maps to 500
+// search_failed — still constant-detail, still no echo — and does NOT
+// wrap errACLListQuery.
+func TestACLSearch_BackendErrorMapping(t *testing.T) {
+	app := newTestAppV1(t)
+	const synthetic = "bleve: index file /var/secret/path corrupt"
+	app.searcher = &fakeSearcher{err: errors.New(synthetic)}
+	rebindVisibleSearcher(t, app)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_search?q=alpha", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1Search(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 on backend failure, got %d (body: %s)", rec.Code, rec.Body)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "search_failed") {
+		t.Errorf("expected search_failed code, body: %s", body)
+	}
+	if strings.Contains(body, "/var/secret/path") {
+		t.Errorf("raw backend error leaked to the wire: %s", body)
+	}
+
+	_, qErr := app.executeQuery(context.Background(), "alpha")
+	if qErr == nil || errors.Is(qErr, errACLListQuery) {
+		t.Errorf("backend error = %v, want non-nil and NOT errACLListQuery", qErr)
+	}
+}
+
+// TestACLSearchRegression_NopACL pins TKT-BA8BSX AC9: with no ACL
+// configured, /_search behaves exactly as before the gate existed —
+// every matching entity comes back, INCLUDING entities whose type is
+// not in the metamodel (permissive storage; the nop gate's wildcard
+// scope is what keeps them visible — RR-SOU82P).
+func TestACLSearchRegression_NopACL(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "alpha rocket"}})
+	seedEntity(app, &entity.Entity{ID: "FEAT-001", Type: "feature", Properties: map[string]any{"title": "alpha feature"}})
+	seedEntity(app, &entity.Entity{ID: "GHOST-001", Type: "ghost", Properties: map[string]any{"title": "alpha off-metamodel"}})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_search?q=alpha", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1Search(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /_search: %d %s", rec.Code, rec.Body)
+	}
+	var resp V1ListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, rec.Body)
+	}
+	got := make(map[string]bool, len(resp.Data))
+	for _, e := range resp.Data {
+		got[e.ID] = true
+	}
+	for _, id := range []string{"TKT-001", "FEAT-001", "GHOST-001"} {
+		if !got[id] {
+			t.Errorf("NopACL search lost %s (off-metamodel types must stay visible without ACL)", id)
+		}
+	}
+	if resp.Meta.Total != 3 || resp.Meta.Page != 1 || resp.Meta.PerPage != 3 {
+		t.Errorf("meta = %+v, want {Total:3 Page:1 PerPage:3}", resp.Meta)
+	}
+}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -1764,7 +1764,14 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entities := a.executeQuery(r.Context(), query)
+	// executeQuery is read-gated (TKT-BA8BSX): only entities the
+	// request principal may read come back, and gate/load/search
+	// failures surface instead of silently truncating.
+	entities, err := a.executeQuery(r.Context(), query)
+	if err != nil {
+		writeListPipelineError(w, r, err)
+		return
+	}
 
 	// Apply type filter if provided
 	if typeFilter := r.URL.Query().Get("type"); typeFilter != "" {
@@ -1782,6 +1789,11 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 	for _, e := range entities {
 		entityDef := meta.Entities[e.Type]
 		plural := entityDef.GetPlural(e.Type)
+		// includeRelations stays false on search results: the read gate
+		// covers root entities only, and a relation map would expose
+		// {ID, Title} of related entities this principal may not read.
+		// Flipping this requires per-target gating first (RR-QO01XY) —
+		// TestACLSearch_VisibleHitRelatedToHidden pins the invariant.
 		data = append(data, a.serializeRelatedEntityForWire(r.Context(), e, plural, false))
 	}
 

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -109,12 +109,19 @@ type App struct {
 	store         store.Store
 	entityManager entitymanager.EntityManager
 	searcher      search.Searcher
-	tracer        tracer.Tracer
-	validator     validator.Validator
-	templater     templating.Templater
-	cfgLoader     config.Loader
-	kv            state.KV
-	acl           acl.ACL
+	// visibleSearcher is the ACL-scoped search seam (TKT-BA8BSX):
+	// executeQuery routes free-text searches through it so /_search
+	// and the _position search scope only ever see hits the request
+	// principal may read. Per-backend wiring: search.NewVisible over
+	// the regular searcher on fs/memory builds, pgstore-native on the
+	// postgres build.
+	visibleSearcher search.VisibleSearcher
+	tracer          tracer.Tracer
+	validator       validator.Validator
+	templater       templating.Templater
+	cfgLoader       config.Loader
+	kv              state.KV
+	acl             acl.ACL
 
 	// documents renders and caches documents. Created once in NewApp so
 	// singleflight deduplication is stable across requests.
@@ -306,6 +313,7 @@ func NewApp(
 	st store.Store,
 	em entitymanager.EntityManager,
 	searcher search.Searcher,
+	visibleSearcher search.VisibleSearcher,
 	aclImpl acl.ACL,
 	fieldResolver FieldVerdictResolver,
 	auditSink audit.Audit,
@@ -326,6 +334,9 @@ func NewApp(
 	}
 	if searcher == nil {
 		return nil, errors.New("dataentry.NewApp: searcher is required")
+	}
+	if visibleSearcher == nil {
+		return nil, errors.New("dataentry.NewApp: visibleSearcher is required (wire appbuild's Services.VisibleSearcher)")
 	}
 	if aclImpl == nil {
 		return nil, errors.New("dataentry.NewApp: acl is required (use acl.NopACL{} to opt out)")
@@ -412,21 +423,22 @@ func NewApp(
 
 	scriptEngine := script.NewEngine()
 	app := &App{
-		fs:            fs,
-		paths:         paths,
-		store:         st,
-		entityManager: em,
-		searcher:      searcher,
-		tracer:        trc,
-		validator:     val,
-		templater:     templater,
-		cfgLoader:     cfgLoader,
-		kv:            kv,
-		acl:           aclImpl,
-		broker:        newEventBroker(),
-		scriptEngine:  scriptEngine,
-		fieldResolver: fieldResolver,
-		auditSink:     auditSink,
+		fs:              fs,
+		paths:           paths,
+		store:           st,
+		entityManager:   em,
+		searcher:        searcher,
+		visibleSearcher: visibleSearcher,
+		tracer:          trc,
+		validator:       val,
+		templater:       templater,
+		cfgLoader:       cfgLoader,
+		kv:              kv,
+		acl:             aclImpl,
+		broker:          newEventBroker(),
+		scriptEngine:    scriptEngine,
+		fieldResolver:   fieldResolver,
+		auditSink:       auditSink,
 	}
 	// documentService needs scriptEngine (for Lua renders) and a closure
 	// that yields fresh lua.WriteDeps (so metamodel reloads propagate).

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"html/template"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -390,20 +392,59 @@ func addCheckboxIndices(s string) string {
 // It supports the same query syntax as the search page: type:, prop:, status:,
 // and free text. Free-text words use OR logic with fuzzy matching via Bleve;
 // results are ranked by score.
-func (a *App) executeQuery(ctx context.Context, query string) []*entity.Entity {
+// executeQuery runs the search-view pipeline under the ctx principal's
+// read scope (TKT-BA8BSX). Both consumers — handleV1Search and the
+// _position search scope (resolveScope) — inherit the gate from here,
+// so no future consumer can run an ungated search by accident.
+//
+// Ordering of the gate: the scope resolves FIRST, and an
+// all-effective-DenyAll scope returns before any backend work — a
+// denied principal must not be able to probe search-backend latency
+// (RR-X56H pattern, pinned with a recording searcher in
+// acl_search_test.go). The free-text branch then runs through
+// search.VisibleSearcher so hidden hits never have their bodies
+// loaded; the type-listing branch resolves the per-type verdict
+// against the store directly.
+//
+// The maxFreeTextSearchResults bound counts entities that survived
+// BOTH visibility and property filters (post-visibility truncation —
+// a pre-visibility cap starves restricted principals; a pre-filter
+// cap would starve filtered queries the same way).
+//
+// Errors: visibility-scope failures wrap errACLListQuery (mapped by
+// writeGateError: cancel-silent / 504 / 500 acl_query_failed with
+// constant detail), store-load failures wrap errListLoad, and plain
+// search-backend failures pass through (500 search_failed). The
+// pre-TKT-BA8BSX version swallowed both error classes into silently
+// truncated results.
+func (a *App) executeQuery(ctx context.Context, query string) ([]*entity.Entity, error) {
 	sq := searchparser.ParseQuery(query)
 	if sq.IsEmpty() {
-		return nil
+		return nil, nil
 	}
 
 	svc := a.Services()
+	typeNames := make([]string, 0, len(svc.Meta.Entities))
+	for name := range svc.Meta.Entities {
+		typeNames = append(typeNames, name)
+	}
+	slices.Sort(typeNames)
+	scope := readGateFromContext(ctx).SearchScope(ctx, typeNames)
+	if len(scope) == 0 {
+		return []*entity.Entity{}, nil
+	}
+
 	var candidates []*entity.Entity
+	var err error
 	if sq.HasFreeText() {
-		// Searcher returns entities in relevance order. Scores are dropped
-		// because executeQuery never sorted by them.
-		candidates, _ = runFreeTextSearchE(ctx, svc, sq, maxFreeTextSearchResults)
+		// Hits arrive in relevance order. Scores are dropped because
+		// executeQuery never sorted by them.
+		candidates, err = a.runVisibleFreeTextSearch(ctx, svc, sq, scope)
 	} else {
-		candidates = listFromStoreByTypes(ctx, svc, sq.EntityTypes)
+		candidates, err = visibleListByTypes(ctx, svc, sq.EntityTypes, scope)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	results := make([]*entity.Entity, 0, len(candidates))
@@ -412,14 +453,115 @@ func (a *App) executeQuery(ctx context.Context, query string) []*entity.Entity {
 			continue
 		}
 		results = append(results, e)
+		if sq.HasFreeText() && len(results) >= maxFreeTextSearchResults {
+			break
+		}
 	}
 
-	// Apply sort from query syntax (Bleve results are already ranked by relevance)
+	// Apply sort from query syntax (free-text results are already ranked by relevance)
 	if sq.HasSort() {
 		a.sortEntitiesMulti(results, sq.SortClauses)
 	}
 
-	return results
+	return results, nil
+}
+
+// runVisibleFreeTextSearch is executeQuery's free-text branch: the
+// same phrase re-quoting as runFreeTextSearchE, routed through the
+// ACL-scoped searcher. The backend-side limit is only set when no
+// property filters remain — with Go-side filters pending, truncation
+// happens in executeQuery after them, or the filter gap would re-open
+// the starvation the post-visibility limit closes.
+func (a *App) runVisibleFreeTextSearch(
+	ctx context.Context, svc Services, sq *searchparser.SearchQuery, scope map[string]search.TypeScope,
+) ([]*entity.Entity, error) {
+	parts := make([]string, 0, len(sq.FreeTextWords)+len(sq.FreeTextPhrases))
+	parts = append(parts, sq.FreeTextWords...)
+	for _, p := range sq.FreeTextPhrases {
+		parts = append(parts, `"`+p+`"`)
+	}
+	limit := 0
+	if len(sq.PropertyFilters) == 0 {
+		limit = maxFreeTextSearchResults
+	}
+	q := search.Query{
+		Text:  strings.Join(parts, " "),
+		Types: sq.EntityTypes,
+		Limit: limit,
+	}
+	out := make([]*entity.Entity, 0)
+	for hit, err := range a.visibleSearcher.SearchVisible(ctx, q, scope) {
+		if err != nil {
+			if errors.Is(err, search.ErrScope) {
+				return nil, fmt.Errorf("%w: %w", errACLListQuery, err)
+			}
+			return nil, fmt.Errorf("free-text search: %w", err)
+		}
+		e, getErr := svc.Store.GetEntity(ctx, hit.ID)
+		if getErr != nil {
+			// Stale index hit (entity deleted between index query and
+			// store read). Skip silently — the result stays a coherent
+			// set of currently-existing entities.
+			continue
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// visibleListByTypes is executeQuery's no-free-text branch: load
+// entities by type under the per-type scope verdict. Unlike
+// listFromStoreByTypes (which other, ungated consumers still use and
+// which swallows iterator errors), this fails loud on both verdict
+// paths — same rationale as scopedSortedEntities.
+func visibleListByTypes(
+	ctx context.Context, svc Services, types []string, scope map[string]search.TypeScope,
+) ([]*entity.Entity, error) {
+	if len(types) == 0 {
+		if _, wildcard := scope[search.WildcardType]; wildcard {
+			// Wildcard-allow (no ACL): every entity, any type — the
+			// pre-ACL listAll shape, with iterator errors surfaced.
+			out := make([]*entity.Entity, 0)
+			for e, err := range svc.Store.ListEntities(ctx, store.EntityQuery{}) {
+				if err != nil {
+					return nil, fmt.Errorf("%w: %w", errListLoad, err)
+				}
+				out = append(out, e)
+			}
+			return out, nil
+		}
+		// Under ACL, "all types" means "all granted types":
+		// deterministic order over the scope's entries.
+		types = make([]string, 0, len(scope))
+		for typ := range scope {
+			types = append(types, typ)
+		}
+		slices.Sort(types)
+	}
+
+	var out []*entity.Entity
+	for _, typ := range types {
+		ts, ok := search.ResolveTypeScope(scope, typ)
+		if !ok {
+			continue // denied type
+		}
+		if ts.AllowAll {
+			for e, err := range svc.Store.ListEntities(ctx, store.EntityQuery{Type: typ}) {
+				if err != nil {
+					return nil, fmt.Errorf("%w: %w", errListLoad, err)
+				}
+				out = append(out, e)
+			}
+			continue
+		}
+		for e, err := range svc.Store.GraphQuery(ctx, *ts.Query) {
+			if err != nil {
+				return nil, fmt.Errorf("%w: %w", errACLListQuery, err)
+			}
+			out = append(out, e)
+		}
+	}
+	return out, nil
 }
 
 // freeTextIDsForTypeResult is what freeTextIDsForType returns: the set of

--- a/internal/dataentry/readgate.go
+++ b/internal/dataentry/readgate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/search"
 )
 
 // readGate is the dataentry-package consumer-side interface for ACL
@@ -25,6 +26,13 @@ import (
 //     pipeline (scopedSortedEntities) and the sidebar counts to decide
 //     between unfiltered (AllowAll), empty (DenyAll), and a composed
 //     store.GraphQuery that selects the visible subset (TKT-VMD8).
+//   - SearchScope(ctx, types) — the mixed-type search scope: ReadQuery
+//     resolved over every metamodel type, shaped for
+//     search.VisibleSearcher (TKT-BA8BSX). The gate owns the nop/ACL
+//     distinction: the nop gate returns the wildcard-allow scope so
+//     off-metamodel entities stay visible exactly as before ACL
+//     existed, while the ACL gate emits per-type entries only — an
+//     entity type the metamodel doesn't know fails closed.
 //
 // None of the methods verify existence — they answer "the policy
 // permits reading this id IF it exists". Callers that need existence
@@ -37,6 +45,7 @@ type readGate interface {
 	PermitsRead(ctx context.Context, entityType, entityID string) (bool, error)
 	PermitsReadMany(ctx context.Context, entityType string, ids []string) (map[string]bool, error)
 	ReadQuery(ctx context.Context, entityType string) acl.ReadQueryResult
+	SearchScope(ctx context.Context, types []string) map[string]search.TypeScope
 }
 
 // aclReadGate is the production implementation of readGate. Wraps a
@@ -70,6 +79,26 @@ func (g aclReadGate) ReadQuery(ctx context.Context, entityType string) acl.ReadQ
 	return g.req.ReadQuery(ctx, entityType)
 }
 
+// SearchScope maps per-type ReadQuery verdicts onto the
+// search.TypeScope shape: AllowAll and Query verdicts become entries,
+// DenyAll types are simply absent (absence IS the deny in the seam's
+// fail-closed lookup), and no wildcard is ever emitted — an entity
+// type outside the metamodel cannot be granted by a policy, so it
+// must not be visible through search either.
+func (g aclReadGate) SearchScope(ctx context.Context, types []string) map[string]search.TypeScope {
+	scope := make(map[string]search.TypeScope, len(types))
+	for _, typ := range types {
+		rqr := g.req.ReadQuery(ctx, typ)
+		switch {
+		case rqr.AllowAll:
+			scope[typ] = search.TypeScope{AllowAll: true}
+		case rqr.Query != nil:
+			scope[typ] = search.TypeScope{Query: rqr.Query}
+		}
+	}
+	return scope
+}
+
 // nopReadGate answers "permitted" for every probe. It's the gate the
 // handlers see under NopACL / ReadOnlyACL — the wire response shape
 // is then byte-identical to today's pre-ACL behavior, which is what
@@ -90,6 +119,15 @@ func (nopReadGate) PermitsReadMany(_ context.Context, _ string, ids []string) (m
 
 func (nopReadGate) ReadQuery(context.Context, string) acl.ReadQueryResult {
 	return acl.ReadQueryResult{AllowAll: true}
+}
+
+// SearchScope under no ACL is the wildcard-allow scope — NOT one
+// AllowAll entry per metamodel type. The difference is entities whose
+// type is absent from the metamodel (permissive storage tolerates
+// them): they were searchable before ACL existed and must stay so
+// when no policy is configured (NopACL byte-parity, TKT-BA8BSX AC9).
+func (nopReadGate) SearchScope(context.Context, []string) map[string]search.TypeScope {
+	return map[string]search.TypeScope{search.WildcardType: {AllowAll: true}}
 }
 
 // readGateCtxKey is the unexported type for context.WithValue. The

--- a/internal/dataentry/scope.go
+++ b/internal/dataentry/scope.go
@@ -3,7 +3,6 @@ package dataentry
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -97,16 +96,20 @@ func scopeFromParam(raw string, meta entityTypeChecker) (scope ScopeDescriptor, 
 // search results: position is found within the exact set the user saw.
 //
 // Both branches end gated: the list pipeline resolves the read scope
-// internally; the search branch filters through readableSubset because
-// executeQuery itself is ungated (its other consumer, the search view,
-// is the deferred /_search ticket). Without the filter a denied
-// principal reads hidden cardinality from Total and harvests hidden
-// {ID, Type} pairs from prev/next — the exact leak shape TKT-VMD8
-// closes on the list path (CRIT finding, TKT-VMD8 review).
+// internally, and executeQuery gates the search pipeline internally
+// since TKT-BA8BSX (it routes through search.VisibleSearcher; the
+// external readableSubset patch this branch used in the interim is
+// retired). Without the gate a denied principal reads hidden
+// cardinality from Total and harvests hidden {ID, Type} pairs from
+// prev/next — the exact leak shape TKT-VMD8 closes on the list path
+// (CRIT finding, TKT-VMD8 review).
 func (a *App) resolveScope(ctx context.Context, scope ScopeDescriptor) ([]*entityPkg.Entity, error) {
 	switch scope.Source {
 	case "search":
-		entities := a.executeQuery(ctx, scope.Q)
+		entities, err := a.executeQuery(ctx, scope.Q)
+		if err != nil {
+			return nil, err
+		}
 		if scope.Type != "" {
 			filtered := entities[:0]
 			for _, e := range entities {
@@ -116,45 +119,10 @@ func (a *App) resolveScope(ctx context.Context, scope ScopeDescriptor) ([]*entit
 			}
 			entities = filtered
 		}
-		return a.readableSubset(ctx, entities)
+		return entities, nil
 	default:
 		return a.scopedSortedEntities(ctx, scope.Type, scope.toQuery())
 	}
-}
-
-// readableSubset drops entities the ctx principal may not read,
-// preserving order. Gate probes are batched per entity type
-// (PermitsReadMany), mirroring the include-filter batching rule from
-// TKT-VQGN. Errors wrap errACLListQuery so the position handler maps
-// them via writeGateError.
-func (a *App) readableSubset(ctx context.Context, entities []*entityPkg.Entity) ([]*entityPkg.Entity, error) {
-	if len(entities) == 0 {
-		return entities, nil
-	}
-	gate := readGateFromContext(ctx)
-	byType := make(map[string][]string)
-	for _, e := range entities {
-		byType[e.Type] = append(byType[e.Type], e.ID)
-	}
-	allowed := make(map[string]bool, len(entities))
-	for typ, ids := range byType {
-		m, err := gate.PermitsReadMany(ctx, typ, ids)
-		if err != nil {
-			return nil, fmt.Errorf("%w: %w", errACLListQuery, err)
-		}
-		for id, ok := range m {
-			if ok {
-				allowed[id] = true
-			}
-		}
-	}
-	out := entities[:0]
-	for _, e := range entities {
-		if allowed[e.ID] {
-			out = append(out, e)
-		}
-	}
-	return out, nil
 }
 
 // entityTypeChecker is the narrow capability scopeFromParam needs: confirm a

--- a/internal/dataentry/scope_test.go
+++ b/internal/dataentry/scope_test.go
@@ -135,6 +135,7 @@ func TestV1Position(t *testing.T) {
 			{ID: "TKT-001", Type: "ticket"},
 			{ID: "TKT-003", Type: "ticket"},
 		}}
+		rebindVisibleSearcher(t, app)
 
 		scope := ScopeDescriptor{Source: "search", Q: "ticket"}
 		_, pos := getPosition(t, app, "TKT-001", scope)
@@ -161,6 +162,7 @@ func TestV1Position(t *testing.T) {
 			{ID: "FEAT-001", Type: "feature"},
 			{ID: "TKT-003", Type: "ticket"},
 		}}
+		rebindVisibleSearcher(t, app)
 
 		scope := ScopeDescriptor{Source: "search", Q: "anything"}
 		_, pos := getPosition(t, app, "FEAT-001", scope)
@@ -192,6 +194,7 @@ func TestV1Position(t *testing.T) {
 			{ID: "FEAT-001", Type: "feature"},
 			{ID: "TKT-003", Type: "ticket"},
 		}}
+		rebindVisibleSearcher(t, app)
 
 		// type=ticket drops FEAT-001, leaving [TKT-001, TKT-003].
 		scope := ScopeDescriptor{Source: "search", Type: "ticket", Q: "anything"}

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/openapi"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/script"
+	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/state"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -126,6 +127,7 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	app.store = svc.Store()
 	app.entityManager = svc.EntityManager()
 	app.searcher = svc.Searcher()
+	app.visibleSearcher = svc.VisibleSearcher()
 	app.tracer = svc.Tracer()
 	app.validator = svc.Validator()
 	app.templater = svc.Templater()
@@ -139,6 +141,23 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	if app.scriptEngine != nil {
 		app.documents = newDocumentService(app.store, app.kv, "/", app.scriptEngine, app.luaWriteDeps)
 	}
+}
+
+// rebindVisibleSearcher re-derives the generic visible-search wrapper
+// over the app's CURRENT searcher+store pair. Tests that inject a fake
+// via `app.searcher = ...` and exercise an executeQuery consumer
+// (/_search, _position search scope) must call this afterwards —
+// executeQuery routes through app.visibleSearcher (TKT-BA8BSX), which
+// otherwise still wraps the searcher from construction time. Tests
+// that only hit the list pipeline (?q= on list endpoints) don't need
+// it: that path reads app.searcher directly.
+func rebindVisibleSearcher(t *testing.T, app *App) {
+	t.Helper()
+	v, err := search.NewVisible(app.searcher, app.store)
+	if err != nil {
+		t.Fatalf("rebindVisibleSearcher: %v", err)
+	}
+	app.visibleSearcher = v
 }
 
 // reseedStore copies every entity and relation from src into dst.

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"errors"
 	"iter"
 
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -35,6 +36,83 @@ type Backend interface {
 	// limit ≤ 0 means no limit.
 	Search(text string, limit int) ([]string, error)
 }
+
+// WildcardType is the reserved scope-map key that supplies the default
+// verdict for entity types without an explicit entry. It cannot collide
+// with a real entity type: metamodel type names are identifiers.
+const WildcardType = "*"
+
+// TypeScope is one per-type visibility verdict inside a SearchVisible
+// scope map. Exactly one meaning applies:
+//
+//   - AllowAll true → every entity of the type is visible.
+//   - Query non-nil → only entities matching the GraphQuery are visible.
+//     The query's EntityType must equal the scope-map key it is stored
+//     under; the consumer constructing the scope owns that consistency.
+//   - zero value → deny the type (an explicit deny entry is equivalent
+//     to the type being absent from the map).
+//
+// The scope map is server-derived (from ACL policy verdicts), never
+// wire-supplied.
+type TypeScope struct {
+	AllowAll bool
+	Query    *store.GraphQuery
+}
+
+// ResolveTypeScope applies the scope lookup rule shared by every
+// VisibleSearcher implementation: the exact type entry wins, else the
+// reserved [WildcardType] entry, else deny (fail-closed). The second
+// return reports whether any entry applied — false means the type is
+// denied outright.
+//
+// Fail-closed is the load-bearing property: a nil or empty scope map
+// denies everything, and an entity type the scope builder never saw
+// (e.g. removed from the metamodel while its files remain on disk) is
+// hidden rather than leaked.
+func ResolveTypeScope(scope map[string]TypeScope, entityType string) (TypeScope, bool) {
+	if ts, ok := scope[entityType]; ok {
+		return ts, ts.AllowAll || ts.Query != nil
+	}
+	if ts, ok := scope[WildcardType]; ok {
+		return ts, ts.AllowAll || ts.Query != nil
+	}
+	return TypeScope{}, false
+}
+
+// VisibleSearcher executes a search restricted to a per-type visibility
+// scope. It is the read-side ACL seam for search: the consumer resolves
+// ACL verdicts into the scope map (ACL stays at the call site — this
+// package never sees a principal or a policy) and the implementation
+// guarantees no hit outside the scope is ever yielded, on any backend.
+//
+// Contract, pinned by storetest.RunVisibleSearchTests (any new
+// implementation must pass it):
+//
+//   - Scope lookup follows [ResolveTypeScope]: exact → "*" → deny.
+//   - q.Limit bounds the number of VISIBLE hits — it is applied after
+//     visibility filtering, never before. (A pre-visibility limit
+//     starves restricted principals: the top-K candidates may all be
+//     hidden while visible matches rank below them.)
+//   - Relative order of visible hits equals the order the ungated
+//     search on the same backend would yield them in.
+//   - A [WildcardType] entry carrying a Query is invalid (a GraphQuery
+//     targets one entity type) and yields an error.
+//   - q.Sort is ignored, matching [Service.Search].
+//
+// Service plus this package's generic wrapper (NewVisible) serve the
+// simple backends; smart backends (pgstore) implement it natively by
+// composing visibility into the search query itself.
+type VisibleSearcher interface {
+	SearchVisible(ctx context.Context, q Query, scope map[string]TypeScope) iter.Seq2[Hit, error]
+}
+
+// ErrScope marks a SearchVisible failure that occurred while evaluating
+// the visibility scope (GraphQuery/MatchingIDs execution), as opposed
+// to a plain search-backend failure. Consumers route ErrScope failures
+// through their ACL-error path. Implementations that cannot separate
+// the two phases (pgstore runs one combined statement) wrap the whole
+// failure in ErrScope — the query is the gate there.
+var ErrScope = errors.New("search: visibility scope evaluation failed")
 
 // Query describes a search request.
 type Query struct {

--- a/internal/search/visible.go
+++ b/internal/search/visible.go
@@ -67,6 +67,12 @@ func (v *Visible) SearchVisible(
 // because visibility probes are batched per type, which needs the hits
 // grouped before any MatchingIDs call.
 func (v *Visible) visibleHits(ctx context.Context, q Query, scope map[string]TypeScope) ([]Hit, error) {
+	// Validate up front for parity with the pgstore-native impl: both
+	// implementations reject an unsupported filter with the same
+	// sentinel before any backend or scope work (conformance-pinned).
+	if err := ValidateFilters(q.Filters); err != nil {
+		return nil, err
+	}
 	if len(scope) == 0 {
 		return nil, nil // nothing is visible; do not touch the backend
 	}

--- a/internal/search/visible.go
+++ b/internal/search/visible.go
@@ -1,0 +1,132 @@
+package search
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// Visible is the generic VisibleSearcher: it wraps any Searcher and
+// filters its hits through a store.GraphQueryer. This is the
+// implementation for the simple backends (bleve, LinearSearch), which
+// only ever pair with in-process stores where MatchingIDs is cheap.
+//
+// Candidates are fetched UNCAPPED (inner Limit 0) and q.Limit is
+// applied after visibility filtering, per the VisibleSearcher
+// contract. Note the bleve backend maps limit ≤ 0 to a practical
+// 10000-candidate ceiling — within that window restricted principals
+// get their true top-K; beyond it the bound is documented in the ACL
+// security guide.
+type Visible struct {
+	inner Searcher
+	gq    store.GraphQueryer
+}
+
+// compile-time check
+var _ VisibleSearcher = (*Visible)(nil)
+
+// NewVisible builds the generic scope-filtering wrapper around an
+// existing searcher and the store's graph-query capability.
+func NewVisible(inner Searcher, gq store.GraphQueryer) (*Visible, error) {
+	if inner == nil {
+		return nil, errors.New("search.NewVisible: inner Searcher is required")
+	}
+	if gq == nil {
+		return nil, errors.New("search.NewVisible: GraphQueryer is required")
+	}
+	return &Visible{inner: inner, gq: gq}, nil
+}
+
+func (v *Visible) SearchVisible(
+	ctx context.Context, q Query, scope map[string]TypeScope,
+) iter.Seq2[Hit, error] {
+	return func(yield func(Hit, error) bool) {
+		hits, err := v.visibleHits(ctx, q, scope)
+		if err != nil {
+			yield(Hit{}, err)
+			return
+		}
+		emitted := 0
+		for _, h := range hits {
+			if q.Limit > 0 && emitted >= q.Limit {
+				return
+			}
+			if !yield(h, nil) {
+				return
+			}
+			emitted++
+		}
+	}
+}
+
+// visibleHits collects the full candidate stream and drops every hit
+// the scope denies, preserving backend order. Collected (not streamed)
+// because visibility probes are batched per type, which needs the hits
+// grouped before any MatchingIDs call.
+func (v *Visible) visibleHits(ctx context.Context, q Query, scope map[string]TypeScope) ([]Hit, error) {
+	if len(scope) == 0 {
+		return nil, nil // nothing is visible; do not touch the backend
+	}
+	if ts, ok := scope[WildcardType]; ok && ts.Query != nil {
+		return nil, fmt.Errorf("%w: wildcard scope entry cannot carry a GraphQuery", ErrScope)
+	}
+
+	inner := q
+	inner.Limit = 0
+	var hits []Hit
+	for h, err := range v.inner.Search(ctx, inner) {
+		if err != nil {
+			// Plain search failure — deliberately NOT ErrScope.
+			return nil, err
+		}
+		hits = append(hits, h)
+	}
+
+	allowed, err := v.allowedIDs(ctx, hits, scope)
+	if err != nil {
+		return nil, err
+	}
+	visible := hits[:0]
+	for _, h := range hits {
+		if allowed[h.ID] {
+			visible = append(visible, h)
+		}
+	}
+	return visible, nil
+}
+
+// allowedIDs resolves the scope verdict for every hit, batching
+// MatchingIDs probes per entity type.
+func (v *Visible) allowedIDs(ctx context.Context, hits []Hit, scope map[string]TypeScope) (map[string]bool, error) {
+	byType := make(map[string][]string)
+	for _, h := range hits {
+		byType[h.Type] = append(byType[h.Type], h.ID)
+	}
+
+	allowed := make(map[string]bool, len(hits))
+	for typ, ids := range byType {
+		ts, ok := ResolveTypeScope(scope, typ)
+		if !ok {
+			continue // denied type: drop its hits
+		}
+		if ts.AllowAll {
+			for _, id := range ids {
+				allowed[id] = true
+			}
+			continue
+		}
+		m, err := v.gq.MatchingIDs(ctx, *ts.Query, ids)
+		if err != nil {
+			return nil, fmt.Errorf("%w: type %q: %w", ErrScope, typ, err)
+		}
+		for id, ok := range m {
+			if ok {
+				allowed[id] = true
+			}
+		}
+	}
+	return allowed, nil
+}

--- a/internal/search/visible_test.go
+++ b/internal/search/visible_test.go
@@ -1,0 +1,44 @@
+package search_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/search"
+	"github.com/Sourcehaven-BV/rela/internal/search/bleveindex"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+	"github.com/Sourcehaven-BV/rela/internal/store/storetest"
+)
+
+// TestVisibleConformance_Bleve runs the VisibleSearcher conformance
+// suite over the generic wrapper with the bleve backend — the
+// combination the default (fsstore) build ships. The linear-backend
+// runs live in the memstore/fsstore conformance tests; pgstore's
+// native implementation has its own DB-gated run.
+func TestVisibleConformance_Bleve(t *testing.T) {
+	storetest.RunVisibleSearchTests(t, func(t *testing.T) (store.Store, search.Searcher, search.VisibleSearcher) {
+		t.Helper()
+		idx, err := bleveindex.NewMem()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = idx.Close() })
+		s := memstore.New(memstore.WithObserver(idx))
+		searcher := search.New(s, idx)
+		v, err := search.NewVisible(searcher, s)
+		require.NoError(t, err)
+		return s, searcher, v
+	})
+}
+
+func TestNewVisible_RejectsNil(t *testing.T) {
+	s := memstore.New()
+	searcher := search.New(s, search.NewLinearSearch())
+
+	if _, err := search.NewVisible(nil, s); err == nil {
+		t.Error("nil inner Searcher accepted")
+	}
+	if _, err := search.NewVisible(searcher, nil); err == nil {
+		t.Error("nil GraphQueryer accepted")
+	}
+}

--- a/internal/store/fsstore/conformance_test.go
+++ b/internal/store/fsstore/conformance_test.go
@@ -37,8 +37,19 @@ func searchFactory(t *testing.T) (store.Store, search.Searcher) {
 	return s, search.New(s, idx)
 }
 
+// visibleSearchFactory derives the generic scope-filtering wrapper from
+// the same store+searcher pair, per the TKT-BA8BSX wiring rule: simple
+// backends get search.NewVisible, smart backends implement natively.
+func visibleSearchFactory(t *testing.T) (store.Store, search.Searcher, search.VisibleSearcher) {
+	t.Helper()
+	s, searcher := searchFactory(t)
+	v, err := search.NewVisible(searcher, s)
+	require.NoError(t, err)
+	return s, searcher, v
+}
+
 func TestConformance(t *testing.T) {
-	storetest.RunAll(t, factory, searchFactory, storetest.Capabilities{Attachments: true})
+	storetest.RunAll(t, factory, searchFactory, visibleSearchFactory, storetest.Capabilities{Attachments: true})
 }
 
 func FuzzRelationKeyCollision(f *testing.F) {

--- a/internal/store/memstore/conformance_test.go
+++ b/internal/store/memstore/conformance_test.go
@@ -21,12 +21,25 @@ func searchFactory(t *testing.T) (store.Store, search.Searcher) {
 	return s, search.New(s, idx)
 }
 
+// visibleSearchFactory derives the generic scope-filtering wrapper from
+// the same store+searcher pair, per the TKT-BA8BSX wiring rule: simple
+// backends get search.NewVisible, smart backends implement natively.
+func visibleSearchFactory(t *testing.T) (store.Store, search.Searcher, search.VisibleSearcher) {
+	t.Helper()
+	s, searcher := searchFactory(t)
+	v, err := search.NewVisible(searcher, s)
+	if err != nil {
+		t.Fatalf("NewVisible: %v", err)
+	}
+	return s, searcher, v
+}
+
 func fuzzFactory() store.Store {
 	return memstore.New()
 }
 
 func TestConformance(t *testing.T) {
-	storetest.RunAll(t, factory, searchFactory, storetest.Capabilities{Attachments: true})
+	storetest.RunAll(t, factory, searchFactory, visibleSearchFactory, storetest.Capabilities{Attachments: true})
 }
 
 func FuzzRelationKeyCollision(f *testing.F) {

--- a/internal/store/pgstore/conformance_test.go
+++ b/internal/store/pgstore/conformance_test.go
@@ -10,7 +10,7 @@ import (
 // and searchFactory live in testdb_test.go (they provision an isolated schema
 // per call). The whole suite is skipped when RELA_TEST_DATABASE_URL is unset.
 func TestConformance(t *testing.T) {
-	storetest.RunAll(t, factory, searchFactory, storetest.Capabilities{Attachments: true})
+	storetest.RunAll(t, factory, searchFactory, nil, storetest.Capabilities{Attachments: true})
 }
 
 func FuzzRelationKeyCollision(f *testing.F) {

--- a/internal/store/pgstore/conformance_test.go
+++ b/internal/store/pgstore/conformance_test.go
@@ -10,7 +10,7 @@ import (
 // and searchFactory live in testdb_test.go (they provision an isolated schema
 // per call). The whole suite is skipped when RELA_TEST_DATABASE_URL is unset.
 func TestConformance(t *testing.T) {
-	storetest.RunAll(t, factory, searchFactory, nil, storetest.Capabilities{Attachments: true})
+	storetest.RunAll(t, factory, searchFactory, visibleSearchFactory, storetest.Capabilities{Attachments: true})
 }
 
 func FuzzRelationKeyCollision(f *testing.F) {

--- a/internal/store/pgstore/testdb_test.go
+++ b/internal/store/pgstore/testdb_test.go
@@ -163,6 +163,19 @@ func searchFactory(t *testing.T) (store.Store, search.Searcher) {
 	return s, search.New(s, backend)
 }
 
+// visibleSearchFactory exercises the NATIVE implementation: the store
+// itself is the search.VisibleSearcher (visibility composed into the
+// SQL), with the generic Service as the ungated parity baseline.
+func visibleSearchFactory(t *testing.T) (store.Store, search.Searcher, search.VisibleSearcher) {
+	t.Helper()
+	pool := newScopedPool(t)
+	backend := pgstore.NewSearchBackend(pool)
+	s, err := pgstore.New(pool, pgstore.WithObserver(backend))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s, search.New(s, backend), s
+}
+
 // fuzzFactory adapts the per-schema helper to storetest.FuzzFactory.
 //
 // The FuzzFactory signature takes no testing handle and runs inside f.Fuzz

--- a/internal/store/pgstore/visiblesearch.go
+++ b/internal/store/pgstore/visiblesearch.go
@@ -1,0 +1,198 @@
+package pgstore
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"slices"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/search"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// compile-time check: the postgres store is a native VisibleSearcher
+// (the appbuild postgres recipe wires the store itself; simple backends
+// use search.NewVisible instead).
+var _ search.VisibleSearcher = (*Store)(nil)
+
+// SearchVisible is the native postgres implementation of
+// [search.VisibleSearcher]: visibility is composed into the search
+// statement itself, so hidden rows are never returned, the LIMIT
+// applies post-visibility (no cap starvation), and there is no
+// per-type MatchingIDs round trip.
+//
+// Shape: the trgm-accelerated LIKE from [SearchBackend.Search] ANDed
+// with a per-type visibility disjunction — a bare type test for
+// AllowAll entries, the [buildPredicateSQL] EXISTS chain (with
+// per-type CTE prefixes) for Query entries, denied types omitted. A
+// wildcard-allow scope drops the disjunction entirely. Ordering
+// matches the ungated backend (`similarity DESC, id ASC`; plain id
+// order for empty text) so the gated stream is the ungated stream
+// minus hidden rows — the conformance suite's ordered-subsequence
+// invariant.
+//
+// Because search and visibility execute as one statement, any query
+// failure is wrapped in [search.ErrScope]: the statement IS the gate
+// here, and consumers route ErrScope through their ACL-error path
+// (cancel-silent / deadline-504 mapping included — ctx is threaded
+// into the query, unlike the legacy ctx-less Backend.Search).
+//
+// Go-side residue: q.Filters cannot be pushed down, so when filters
+// are present the SQL LIMIT is omitted and the limit is enforced after
+// filtering — a SQL LIMIT before Go-side filters would re-open the
+// starvation gap the post-visibility contract closes.
+func (s *Store) SearchVisible(
+	ctx context.Context, q search.Query, scope map[string]search.TypeScope,
+) iter.Seq2[search.Hit, error] {
+	return func(yield func(search.Hit, error) bool) {
+		if err := search.ValidateFilters(q.Filters); err != nil {
+			yield(search.Hit{}, err)
+			return
+		}
+		if ws, ok := scope[search.WildcardType]; ok && ws.Query != nil {
+			yield(search.Hit{}, fmt.Errorf("%w: wildcard scope entry cannot carry a GraphQuery", search.ErrScope))
+			return
+		}
+
+		sqlText, args, anyVisible := buildVisibleSearchSQL(q, scope)
+		if !anyVisible {
+			return // empty effective scope: deny everything, skip the query
+		}
+
+		rows, err := s.db.Query(ctx, sqlText, args...)
+		if err != nil {
+			yield(search.Hit{}, fmt.Errorf("%w: pgstore visible search: %w", search.ErrScope, err))
+			return
+		}
+		defer rows.Close()
+
+		emitted := 0
+		for rows.Next() {
+			e, scanErr := scanEntity(rows)
+			if scanErr != nil {
+				yield(search.Hit{}, fmt.Errorf("%w: pgstore visible search scan: %w", search.ErrScope, scanErr))
+				return
+			}
+			if !search.MatchFilters(e, q.Filters) {
+				continue
+			}
+			if q.Limit > 0 && emitted >= q.Limit {
+				return
+			}
+			if !yield(search.Hit{ID: e.ID, Type: e.Type, Title: e.Title()}, nil) {
+				return
+			}
+			emitted++
+		}
+		if err := rows.Err(); err != nil {
+			yield(search.Hit{}, fmt.Errorf("%w: pgstore visible search: %w", search.ErrScope, err))
+		}
+	}
+}
+
+// buildVisibleSearchSQL emits the combined search+visibility statement.
+// The third return is false when the scope admits nothing — the caller
+// must not run a query at all in that case.
+//
+// Scope keys are visited in sorted order so the SQL text and arg list
+// are deterministic for a given scope (map iteration order must never
+// reach the wire). Every value flows through [sqlBuilder.arg]; the only
+// interpolated strings are placeholder names and the compile-time CTE
+// prefixes ("v<i>_in"/"v<i>_out") — same injection-safety property as
+// buildGraphQuerySQL.
+func buildVisibleSearchSQL(
+	q search.Query, scope map[string]search.TypeScope,
+) (sqlText string, args []any, anyVisible bool) {
+	b := &sqlBuilder{}
+
+	wildcardAllow := false
+	if ws, ok := scope[search.WildcardType]; ok && ws.AllowAll {
+		wildcardAllow = true
+	}
+
+	var withParts, visParts []string
+	if !wildcardAllow {
+		withParts, visParts = buildVisibilityDisjunction(b, scope)
+		if len(visParts) == 0 {
+			return "", nil, false
+		}
+	}
+
+	var sb strings.Builder
+	if len(withParts) > 0 {
+		sb.WriteString("WITH RECURSIVE ")
+		sb.WriteString(strings.Join(withParts, ",\n"))
+		sb.WriteByte('\n')
+	}
+	sb.WriteString("SELECT e.id, e.type, e.properties, e.content, e.updated_at FROM entities e WHERE TRUE")
+
+	// Text match + ordering mirror SearchBackend.Search exactly:
+	// escaped needle for LIKE, raw lowercased needle for similarity,
+	// id ASC ties — the parity baseline orders by the same expressions.
+	orderBy := " ORDER BY e.id ASC"
+	if q.Text != "" {
+		needle := strings.ToLower(q.Text)
+		sb.WriteString(" AND e.search_text LIKE '%' || " + b.arg(escapeLike(needle)) + ` || '%' ESCAPE '\'`)
+		orderBy = " ORDER BY similarity(e.search_text, " + b.arg(needle) + ") DESC, e.id ASC"
+	}
+	if len(q.Types) > 0 {
+		sb.WriteString(" AND e.type = ANY(" + b.arg(q.Types) + ")")
+	}
+	if !wildcardAllow {
+		sb.WriteString(" AND (" + strings.Join(visParts, " OR ") + ")")
+	}
+	sb.WriteString(orderBy)
+	if q.Limit > 0 && len(q.Filters) == 0 {
+		// With Go-side filters pending, the limit moves above them —
+		// see the method godoc.
+		sb.WriteString(" LIMIT " + b.arg(q.Limit))
+	}
+	return sb.String(), b.args, true
+}
+
+// buildVisibilityDisjunction emits the per-type OR-parts of the
+// visibility clause: a bare type test for AllowAll entries, type test
+// + EXISTS chain for Query entries, nothing for deny entries. Scope
+// keys are visited in sorted order; CTE names get per-type prefixes
+// ("v<i>_in"/"v<i>_out") so two Query verdicts can't collide.
+func buildVisibilityDisjunction(b *sqlBuilder, scope map[string]search.TypeScope) (withParts, visParts []string) {
+	types := make([]string, 0, len(scope))
+	for typ := range scope {
+		if typ != search.WildcardType {
+			types = append(types, typ)
+		}
+	}
+	slices.Sort(types)
+
+	for i, typ := range types {
+		ts := scope[typ]
+		switch {
+		case ts.AllowAll:
+			visParts = append(visParts, "e.type = "+b.arg(typ))
+		case ts.Query != nil:
+			// The scope-map key, not ts.Query.EntityType, drives the
+			// type test: the seam contract makes the consumer keep
+			// them equal, and keying on the map entry means a
+			// mismatched Query can only ever narrow its own type.
+			typeArg := b.arg(typ)
+			var part strings.Builder
+			part.WriteString("(e.type = " + typeArg)
+			if ts.Query.HasInbound != nil {
+				w, ex := buildPredicateSQL(b, fmt.Sprintf("v%d_in", i), *ts.Query.HasInbound, typeArg, store.DirectionIncoming)
+				withParts = append(withParts, w...)
+				part.WriteString(" AND EXISTS (" + ex + ")")
+			}
+			if ts.Query.HasOutbound != nil {
+				w, ex := buildPredicateSQL(b, fmt.Sprintf("v%d_out", i), *ts.Query.HasOutbound, typeArg, store.DirectionOutgoing)
+				withParts = append(withParts, w...)
+				part.WriteString(" AND EXISTS (" + ex + ")")
+			}
+			part.WriteByte(')')
+			visParts = append(visParts, part.String())
+		default:
+			// zero-value entry: explicit deny, same as absence.
+		}
+	}
+	return withParts, visParts
+}

--- a/internal/store/pgstore/visiblesearch_sql_test.go
+++ b/internal/store/pgstore/visiblesearch_sql_test.go
@@ -1,0 +1,104 @@
+package pgstore
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/search"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// TestBuildVisibleSearchSQL_LimitPlacement pins the load-bearing LIMIT
+// rule deterministically (no database): with Go-side q.Filters pending,
+// the SQL LIMIT must be omitted — a LIMIT below the filter would spend
+// the row budget on rows MatchFilters is about to drop, re-opening the
+// starvation gap the post-visibility contract closes. Without filters,
+// the LIMIT is pushed down.
+func TestBuildVisibleSearchSQL_LimitPlacement(t *testing.T) {
+	scope := map[string]search.TypeScope{"ticket": {AllowAll: true}}
+
+	t.Run("no filters: LIMIT pushed into SQL", func(t *testing.T) {
+		sqlText, args, ok := buildVisibleSearchSQL(search.Query{Text: "alpha", Limit: 7}, scope)
+		if !ok {
+			t.Fatal("expected a query")
+		}
+		if !strings.Contains(sqlText, " LIMIT ") {
+			t.Errorf("LIMIT missing from SQL: %s", sqlText)
+		}
+		if args[len(args)-1] != 7 {
+			t.Errorf("last arg = %v, want the limit 7", args[len(args)-1])
+		}
+	})
+
+	t.Run("with filters: LIMIT stays above MatchFilters", func(t *testing.T) {
+		q := search.Query{
+			Text:    "alpha",
+			Limit:   7,
+			Filters: []search.PropertyFilter{{Property: "status", Value: "open", Op: search.FilterEq}},
+		}
+		sqlText, _, ok := buildVisibleSearchSQL(q, scope)
+		if !ok {
+			t.Fatal("expected a query")
+		}
+		if strings.Contains(sqlText, " LIMIT ") {
+			t.Errorf("SQL LIMIT must be omitted when Go-side filters remain: %s", sqlText)
+		}
+	})
+}
+
+// TestBuildVisibleSearchSQL_Shape pins structural properties of the
+// composed statement that the DB-gated conformance run can't assert
+// textually: deny-everything yields no query at all, the wildcard-allow
+// scope drops the visibility disjunction, and two Query verdicts get
+// distinct CTE prefixes.
+func TestBuildVisibleSearchSQL_Shape(t *testing.T) {
+	pred := func() *store.GraphQuery {
+		return &store.GraphQuery{
+			EntityType: "ticket",
+			HasOutbound: &store.RelationPredicate{
+				Endpoints: []string{"PRJ-1"}, OfTypes: []string{"belongs-to"},
+				InheritThrough: []string{"member-of"}, Depth: 2,
+			},
+		}
+	}
+
+	t.Run("empty scope: no query", func(t *testing.T) {
+		if _, _, ok := buildVisibleSearchSQL(search.Query{Text: "x"}, nil); ok {
+			t.Error("nil scope must not produce a query")
+		}
+		deny := map[string]search.TypeScope{"ticket": {}}
+		if _, _, ok := buildVisibleSearchSQL(search.Query{Text: "x"}, deny); ok {
+			t.Error("zero-value-only scope must not produce a query")
+		}
+	})
+
+	t.Run("wildcard allow: no visibility clause", func(t *testing.T) {
+		scope := map[string]search.TypeScope{search.WildcardType: {AllowAll: true}}
+		sqlText, _, ok := buildVisibleSearchSQL(search.Query{Text: "x"}, scope)
+		if !ok {
+			t.Fatal("expected a query")
+		}
+		if strings.Contains(sqlText, "e.type =") {
+			t.Errorf("wildcard-allow must not emit type restrictions: %s", sqlText)
+		}
+	})
+
+	t.Run("two Query verdicts: distinct CTE prefixes", func(t *testing.T) {
+		docPred := pred()
+		docPred.EntityType = "doc"
+		scope := map[string]search.TypeScope{
+			"doc":    {Query: docPred},
+			"ticket": {Query: pred()},
+		}
+		sqlText, _, ok := buildVisibleSearchSQL(search.Query{Text: "x"}, scope)
+		if !ok {
+			t.Fatal("expected a query")
+		}
+		// Sorted scope keys: doc → v0, ticket → v1.
+		for _, cte := range []string{"v0_out_endpoint_closure", "v1_out_endpoint_closure"} {
+			if !strings.Contains(sqlText, cte) {
+				t.Errorf("expected CTE %s in SQL: %s", cte, sqlText)
+			}
+		}
+	})
+}

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -145,8 +145,9 @@ func countRelations(t *testing.T, s store.Store) int {
 
 // RunAll runs the full conformance suite.
 // The optional SearchFactory is used for search tests; if nil, search tests are skipped.
+// The optional VisibleSearchFactory is used for ACL-scoped search tests; if nil, they are skipped.
 // Capabilities gates optional feature tests (e.g. attachments).
-func RunAll(t *testing.T, f Factory, sf SearchFactory, caps Capabilities) {
+func RunAll(t *testing.T, f Factory, sf SearchFactory, vsf VisibleSearchFactory, caps Capabilities) {
 	t.Run("Entity", func(t *testing.T) { RunEntityTests(t, f) })
 	t.Run("Relation", func(t *testing.T) { RunRelationTests(t, f) })
 	t.Run("Query", func(t *testing.T) { RunQueryTests(t, f) })
@@ -154,6 +155,9 @@ func RunAll(t *testing.T, f Factory, sf SearchFactory, caps Capabilities) {
 	t.Run("Pagination", func(t *testing.T) { RunPaginationTests(t, f) })
 	if sf != nil {
 		t.Run("Search", func(t *testing.T) { RunSearchTests(t, sf) })
+	}
+	if vsf != nil {
+		t.Run("VisibleSearch", func(t *testing.T) { RunVisibleSearchTests(t, vsf) })
 	}
 	if caps.Attachments {
 		t.Run("Attachment", func(t *testing.T) { RunAttachmentTests(t, f) })

--- a/internal/store/storetest/visiblesearch.go
+++ b/internal/store/storetest/visiblesearch.go
@@ -217,6 +217,80 @@ func RunVisibleSearchTests(t *testing.T, vsf VisibleSearchFactory) {
 		require.True(t, errors.Is(streamErr, search.ErrScope), "must wrap search.ErrScope, got: %v", streamErr)
 	})
 
+	t.Run("FiltersThenLimit", func(t *testing.T) {
+		// RR (code review): pins the q.Filters dimension of the
+		// contract — residual property filters apply BEFORE the limit,
+		// on every backend. A backend that pushes the limit below the
+		// filter (e.g. SQL LIMIT before Go-side MatchFilters) would
+		// spend the budget on filtered-out hits and under-fill.
+		s, ungated, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		scope := map[string]search.TypeScope{"ticket": allow}
+		q := search.Query{
+			Text:    "alpha",
+			Filters: []search.PropertyFilter{{Property: "status", Value: "open", Op: search.FilterEq}},
+		}
+
+		// Expected: the first Limit hits of the OPEN-filtered ungated
+		// ticket stream — i.e. the filter consumed no limit budget. A
+		// limit-before-filter implementation under-fills whenever the
+		// closed ticket outranks an open one (true on the linear and
+		// bleve runs; pgstore's SQL-side LIMIT placement is pinned
+		// deterministically by its own builder unit test).
+		base := collectHits(t, ungated.Search(ctx(), search.Query{Text: "alpha", Types: []string{"ticket"}}))
+		require.GreaterOrEqual(t, len(base), 3, "fixture sanity: all three tickets must match")
+		var want []string
+		for _, h := range base {
+			if h.ID != "TKT-1" { // TKT-1 is the closed one
+				want = append(want, h.ID)
+			}
+		}
+		q.Limit = 2
+		want = want[:2]
+		got := collectHits(t, vs.SearchVisible(ctx(), q, scope))
+		require.Equal(t, want, hitIDs(got),
+			"filters must apply before the limit, in backend order")
+	})
+
+	t.Run("InvalidFilterRejectedIdentically", func(t *testing.T) {
+		// Both implementations must reject an unsupported (ordered)
+		// filter with the same sentinel, before yielding any hit —
+		// the Filters dimension of the contract is shared, not
+		// implementation-defined.
+		s, _, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		scope := map[string]search.TypeScope{"ticket": allow}
+		q := search.Query{
+			Text:    "alpha",
+			Filters: []search.PropertyFilter{{Property: "status", Value: "1", Op: search.FilterGt}},
+		}
+		var hits int
+		var streamErr error
+		for _, err := range vs.SearchVisible(ctx(), q, scope) {
+			if err != nil {
+				streamErr = err
+				break
+			}
+			hits++
+		}
+		require.Zero(t, hits, "no hit may precede the validation error")
+		require.ErrorIs(t, streamErr, search.ErrOrderedFilterUnsupported)
+	})
+
+	t.Run("SortIsIgnored", func(t *testing.T) {
+		// The contract says q.Sort is ignored (matching Service.Search);
+		// prove no backend accidentally honors it.
+		s, _, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		scope := map[string]search.TypeScope{"ticket": allow}
+		plain := collectHits(t, vs.SearchVisible(ctx(), search.Query{Text: "alpha"}, scope))
+		sorted := collectHits(t, vs.SearchVisible(ctx(), search.Query{
+			Text: "alpha",
+			Sort: []search.SortClause{{Field: "title", Direction: search.SortDesc}},
+		}, scope))
+		require.Equal(t, plain, sorted, "q.Sort must be ignored by every implementation")
+	})
+
 	t.Run("EmptyTextListsVisible", func(t *testing.T) {
 		s, ungated, vs := vsf(t)
 		seedVisibleSearchWorld(t, s)
@@ -255,9 +329,15 @@ func seedVisibleSearchWorld(t *testing.T, s store.Store) {
 	seed("PRJ-1", "project", "Apollo program")
 	seed("PRJ-2", "project", "Artemis program")
 	seed("EPIC-1", "epic", "Epic One")
-	seed("TKT-1", "ticket", "alpha rocket")
-	seed("TKT-2", "ticket", "alpha lander")
-	seed("TKT-3", "ticket", "alpha probe")
+	seedStatus := func(id, typ, title, status string) {
+		e := entity.New(id, typ)
+		e.SetString("title", title)
+		e.SetString("status", status)
+		require.NoError(t, s.CreateEntity(ctx(), e), "create %s", id)
+	}
+	seedStatus("TKT-1", "ticket", "alpha rocket", "closed")
+	seedStatus("TKT-2", "ticket", "alpha lander", "open")
+	seedStatus("TKT-3", "ticket", "alpha probe", "open")
 	seed("DOC-1", "doc", "alpha handbook")
 	seed("MEMO-1", "memo", "alpha secret")
 	seed("GHOST-1", "ghost", "alpha ghost")

--- a/internal/store/storetest/visiblesearch.go
+++ b/internal/store/storetest/visiblesearch.go
@@ -1,0 +1,313 @@
+package storetest
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/search"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// VisibleSearchFactory returns a fresh store, the ungated searcher over
+// it (the per-backend parity baseline), and the VisibleSearcher under
+// test. The two searchers must share the backend: the suite's
+// ordered-subsequence invariant compares the gated stream against the
+// ungated stream of the SAME backend — cross-backend rankers
+// legitimately differ, so order is never compared across
+// implementations, only within one.
+type VisibleSearchFactory func(t *testing.T) (store.Store, search.Searcher, search.VisibleSearcher)
+
+// RunVisibleSearchTests is the conformance suite for
+// [search.VisibleSearcher]. Any implementation — the generic
+// scope-filter wrapper or a backend-native one — must pass it
+// (TKT-BA8BSX).
+//
+// Every case asserts two invariants on top of its specific expectation:
+//
+//   - no-leak: every yielded hit is in the case's allowed set;
+//   - ordered-subsequence: the visible stream equals the ungated
+//     stream of the same backend with disallowed hits deleted, order
+//     preserved.
+//
+// Fixture corpora stay far below every backend's candidate bound, so
+// truncation never confounds the subsequence check; the post-visibility
+// limit contract is pinned separately (LimitPostVisibility).
+func RunVisibleSearchTests(t *testing.T, vsf VisibleSearchFactory) {
+	t.Helper()
+
+	allow := search.TypeScope{AllowAll: true}
+
+	// ticketsInPRJ1 admits tickets with a direct belongs-to edge to
+	// PRJ-1: TKT-1 only.
+	ticketsInPRJ1 := func() *store.GraphQuery {
+		return &store.GraphQuery{
+			EntityType: "ticket",
+			HasOutbound: &store.RelationPredicate{
+				Endpoints: []string{"PRJ-1"},
+				OfTypes:   []string{"belongs-to"},
+			},
+		}
+	}
+	// ticketsInPRJ1Transitive additionally walks the ticket's own
+	// belongs-to ancestors: TKT-3 → EPIC-1 → PRJ-1 brings TKT-3 in.
+	ticketsInPRJ1Transitive := func() *store.GraphQuery {
+		return &store.GraphQuery{
+			EntityType: "ticket",
+			HasOutbound: &store.RelationPredicate{
+				Endpoints:            []string{"PRJ-1"},
+				OfTypes:              []string{"belongs-to"},
+				EntityInheritThrough: []string{"belongs-to"},
+				EntityDepth:          3,
+			},
+		}
+	}
+
+	t.Run("AllowAllParity", func(t *testing.T) {
+		s, ungated, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		scope := map[string]search.TypeScope{
+			"project": allow, "epic": allow, "ticket": allow,
+			"doc": allow, "memo": allow, "ghost": allow,
+		}
+		q := search.Query{Text: "alpha"}
+		base := collectHits(t, ungated.Search(ctx(), q))
+		got := collectHits(t, vs.SearchVisible(ctx(), q, scope))
+		require.Equal(t, base, got, "fully-open scope must be invisible")
+		require.NotEmpty(t, got, "fixture sanity: the query must match")
+	})
+
+	t.Run("DenyAllByAbsence", func(t *testing.T) {
+		s, ungated, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		scope := map[string]search.TypeScope{"ticket": allow}
+		q := search.Query{Text: "alpha"}
+		base := collectHits(t, ungated.Search(ctx(), q))
+		got := collectHits(t, vs.SearchVisible(ctx(), q, scope))
+		requireVisibleSubset(t, base, got, "TKT-1", "TKT-2", "TKT-3")
+		for _, h := range got {
+			require.NotEqual(t, "MEMO-1", h.ID, "type absent from scope must never hit")
+		}
+	})
+
+	t.Run("QueryVerdict", func(t *testing.T) {
+		s, ungated, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		scope := map[string]search.TypeScope{"ticket": {Query: ticketsInPRJ1()}}
+		q := search.Query{Text: "alpha"}
+		base := collectHits(t, ungated.Search(ctx(), q))
+		got := collectHits(t, vs.SearchVisible(ctx(), q, scope))
+		requireVisibleSubset(t, base, got, "TKT-1")
+		require.Len(t, got, 1)
+	})
+
+	t.Run("MixedScope", func(t *testing.T) {
+		s, ungated, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		scope := map[string]search.TypeScope{
+			"doc":    allow,
+			"ticket": {Query: ticketsInPRJ1()},
+			// memo, ghost: denied by absence
+		}
+		q := search.Query{Text: "alpha"}
+		base := collectHits(t, ungated.Search(ctx(), q))
+		got := collectHits(t, vs.SearchVisible(ctx(), q, scope))
+		requireVisibleSubset(t, base, got, "DOC-1", "TKT-1")
+		require.Len(t, got, 2)
+	})
+
+	t.Run("LimitPostVisibility", func(t *testing.T) {
+		s, ungated, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		scope := map[string]search.TypeScope{"ticket": {Query: ticketsInPRJ1()}}
+		q := search.Query{Text: "alpha"}
+
+		// Precondition: the backend's top-ranked hit for this query is
+		// hidden under the scope. If a ranking change ever makes TKT-1
+		// the global best match, this case would stop proving anything
+		// — fail loudly instead of passing vacuously.
+		base := collectHits(t, ungated.Search(ctx(), q))
+		require.NotEmpty(t, base)
+		require.NotEqual(t, "TKT-1", base[0].ID,
+			"fixture precondition: top ungated hit must be hidden under the scope")
+
+		q.Limit = 1
+		got := collectHits(t, vs.SearchVisible(ctx(), q, scope))
+		require.Len(t, got, 1, "limit must count VISIBLE hits, not candidates")
+		require.Equal(t, "TKT-1", got[0].ID,
+			"a pre-visibility limit would have spent the budget on hidden hits")
+	})
+
+	t.Run("TransitivePredicate", func(t *testing.T) {
+		s, ungated, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		scope := map[string]search.TypeScope{"ticket": {Query: ticketsInPRJ1Transitive()}}
+		q := search.Query{Text: "alpha"}
+		base := collectHits(t, ungated.Search(ctx(), q))
+		got := collectHits(t, vs.SearchVisible(ctx(), q, scope))
+		requireVisibleSubset(t, base, got, "TKT-1", "TKT-3")
+		require.Len(t, got, 2)
+	})
+
+	t.Run("TypesIntersectScope", func(t *testing.T) {
+		s, ungated, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		scope := map[string]search.TypeScope{"doc": allow, "ticket": allow}
+		q := search.Query{Text: "alpha", Types: []string{"memo", "doc"}}
+		base := collectHits(t, ungated.Search(ctx(), q))
+		got := collectHits(t, vs.SearchVisible(ctx(), q, scope))
+		// memo is in Types but not in scope; ticket is in scope but
+		// not in Types. Only doc survives the intersection.
+		requireVisibleSubset(t, base, got, "DOC-1")
+		require.Len(t, got, 1)
+	})
+
+	t.Run("WildcardAdmitsUnknownTypes", func(t *testing.T) {
+		s, ungated, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		scope := map[string]search.TypeScope{search.WildcardType: allow}
+		q := search.Query{Text: "alpha"}
+		base := collectHits(t, ungated.Search(ctx(), q))
+		got := collectHits(t, vs.SearchVisible(ctx(), q, scope))
+		require.Equal(t, base, got, "wildcard-allow must behave as fully open")
+		require.True(t, slices.ContainsFunc(got, func(h search.Hit) bool { return h.ID == "GHOST-1" }),
+			"fixture sanity: the off-scope-builder type must be in the corpus")
+	})
+
+	t.Run("FailClosedWithoutWildcard", func(t *testing.T) {
+		s, ungated, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		scope := map[string]search.TypeScope{"ticket": allow}
+		q := search.Query{Text: "alpha"}
+		base := collectHits(t, ungated.Search(ctx(), q))
+		got := collectHits(t, vs.SearchVisible(ctx(), q, scope))
+		requireVisibleSubset(t, base, got, "TKT-1", "TKT-2", "TKT-3")
+		for _, h := range got {
+			require.NotEqual(t, "GHOST-1", h.ID,
+				"a type without a scope entry must fail closed")
+		}
+	})
+
+	t.Run("EmptyScopeDeniesEverything", func(t *testing.T) {
+		s, _, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		got := collectHits(t, vs.SearchVisible(ctx(), search.Query{Text: "alpha"}, nil))
+		require.Empty(t, got, "nil scope must deny everything (fail-closed)")
+		got = collectHits(t, vs.SearchVisible(ctx(), search.Query{Text: "alpha"}, map[string]search.TypeScope{}))
+		require.Empty(t, got, "empty scope must deny everything (fail-closed)")
+	})
+
+	t.Run("WildcardQueryIsInvalid", func(t *testing.T) {
+		s, _, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		scope := map[string]search.TypeScope{
+			search.WildcardType: {Query: ticketsInPRJ1()},
+		}
+		var streamErr error
+		for _, err := range vs.SearchVisible(ctx(), search.Query{Text: "alpha"}, scope) {
+			if err != nil {
+				streamErr = err
+				break
+			}
+		}
+		require.Error(t, streamErr, "wildcard entry carrying a GraphQuery must be rejected")
+		require.True(t, errors.Is(streamErr, search.ErrScope), "must wrap search.ErrScope, got: %v", streamErr)
+	})
+
+	t.Run("EmptyTextListsVisible", func(t *testing.T) {
+		s, ungated, vs := vsf(t)
+		seedVisibleSearchWorld(t, s)
+		scope := map[string]search.TypeScope{"ticket": allow}
+		q := search.Query{Text: ""}
+		base := collectHits(t, ungated.Search(ctx(), q))
+		got := collectHits(t, vs.SearchVisible(ctx(), q, scope))
+		// Empty-text listing order is backend-defined; pin membership
+		// (sorted) rather than order for this case only.
+		requireSameIDSet(t, []string{"TKT-1", "TKT-2", "TKT-3"}, got)
+		for _, h := range got {
+			require.True(t, hitInSet(base, h.ID), "visible hit missing from ungated baseline")
+		}
+	})
+}
+
+// seedVisibleSearchWorld builds the shared fixture graph:
+//
+//	PRJ-1 "Apollo program"      PRJ-2 "Artemis program"
+//	  ▲ belongs-to                ▲ belongs-to
+//	EPIC-1 "Epic One" ◄─ TKT-3   TKT-2 "alpha lander"
+//	  ▲ belongs-to (TKT-3 "alpha probe")
+//	TKT-1 "alpha rocket"
+//	DOC-1 "alpha handbook"  MEMO-1 "alpha secret"  GHOST-1 "alpha ghost"
+//
+// "alpha" matches every ticket, the doc, the memo, and the ghost. The
+// ghost's type never appears in any non-wildcard scope, standing in
+// for an entity type the scope builder doesn't know about.
+func seedVisibleSearchWorld(t *testing.T, s store.Store) {
+	t.Helper()
+	seed := func(id, typ, title string) {
+		e := entity.New(id, typ)
+		e.SetString("title", title)
+		require.NoError(t, s.CreateEntity(ctx(), e), "create %s", id)
+	}
+	seed("PRJ-1", "project", "Apollo program")
+	seed("PRJ-2", "project", "Artemis program")
+	seed("EPIC-1", "epic", "Epic One")
+	seed("TKT-1", "ticket", "alpha rocket")
+	seed("TKT-2", "ticket", "alpha lander")
+	seed("TKT-3", "ticket", "alpha probe")
+	seed("DOC-1", "doc", "alpha handbook")
+	seed("MEMO-1", "memo", "alpha secret")
+	seed("GHOST-1", "ghost", "alpha ghost")
+	mustRel(t, s, "TKT-1", "belongs-to", "PRJ-1")
+	mustRel(t, s, "TKT-2", "belongs-to", "PRJ-2")
+	mustRel(t, s, "TKT-3", "belongs-to", "EPIC-1")
+	mustRel(t, s, "EPIC-1", "belongs-to", "PRJ-1")
+}
+
+// requireVisibleSubset asserts the suite's two cross-case invariants:
+// no hit outside allowedIDs (no-leak), and the visible stream equal to
+// the same-backend ungated stream with disallowed hits deleted
+// (ordered-subsequence).
+func requireVisibleSubset(t *testing.T, ungated, visible []search.Hit, allowedIDs ...string) {
+	t.Helper()
+	allowed := make(map[string]bool, len(allowedIDs))
+	for _, id := range allowedIDs {
+		allowed[id] = true
+	}
+	for _, h := range visible {
+		require.True(t, allowed[h.ID], "no-leak violated: hit %s (%s) outside allowed set", h.ID, h.Type)
+	}
+	want := make([]string, 0, len(visible))
+	for _, h := range ungated {
+		if allowed[h.ID] {
+			want = append(want, h.ID)
+		}
+	}
+	require.Equal(t, want, hitIDs(visible),
+		"ordered-subsequence violated: visible stream must equal the ungated stream minus hidden hits")
+}
+
+// requireSameIDSet asserts hit IDs equal want, ignoring order.
+func requireSameIDSet(t *testing.T, want []string, hits []search.Hit) {
+	t.Helper()
+	got := hitIDs(hits)
+	slices.Sort(got)
+	want = slices.Clone(want)
+	slices.Sort(want)
+	require.Equal(t, want, got)
+}
+
+func hitIDs(hits []search.Hit) []string {
+	ids := make([]string, 0, len(hits))
+	for _, h := range hits {
+		ids = append(ids, h.ID)
+	}
+	return ids
+}
+
+func hitInSet(hits []search.Hit, id string) bool {
+	return slices.ContainsFunc(hits, func(h search.Hit) bool { return h.ID == id })
+}

--- a/tickets/entities/docs-checklists/DOCS-C09N2R.md
+++ b/tickets/entities/docs-checklists/DOCS-C09N2R.md
@@ -1,0 +1,24 @@
+---
+id: DOCS-C09N2R
+type: docs-checklist
+title: 'Docs: ACL read-side: /_search visibility — VisibleSearcher seam, generic + pgstore-native impls, conformance suite'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on all new exported symbols: `search.TypeScope`, `search.WildcardType`, `search.ResolveTypeScope`, `search.VisibleSearcher` (full contract incl. lookup rule, post-visibility limit, per-backend ordering), `search.ErrScope`, `search.NewVisible`, `pgstore.SearchVisible` (SQL shape, ErrScope rationale, LIMIT rule), `storetest.VisibleSearchFactory`, `storetest.RunVisibleSearchTests`
+- [x] readGate godoc extended with the SearchScope flavor + nop/ACL wildcard distinction
+- [x] executeQuery godoc rewritten: gate ordering, cap model, error taxonomy, the two fixed silent failures
+
+## Project Documentation
+
+- [x] GUIDE-acl-security (docs-project): new "Global search (`/_search`, TKT-BA8BSX)" section — scope lookup rule, post-visibility limit contract, generic-vs-native split, bleve 10k candidate window + load-amplification note, deny short-circuit, serializer invariant, error semantics; `_search` removed from "What still leaks"; threat-model summary updated
+- [x] docs/acl-security.md regenerated via `just docs`
+- [x] CLAUDE.md tests section: new VisibleSearcher implementations must pass storetest.RunVisibleSearchTests
+
+## External Docs
+
+- [x] ~~docs/metamodel.md / cli-reference.md / data-entry.md / README.md~~ (N/A: no metamodel, CLI, or UI surface change — the SPA search view consumes the same response shape, just correctly filtered)

--- a/tickets/entities/implementation-checklists/IMPL-Y3CEK5.md
+++ b/tickets/entities/implementation-checklists/IMPL-Y3CEK5.md
@@ -1,0 +1,51 @@
+---
+id: IMPL-Y3CEK5
+type: implementation-checklist
+title: 'Implementation: ACL read-side: /_search visibility — VisibleSearcher seam, generic + pgstore-native impls, conformance suite'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Commits 9a3f04eb (seam + generic + conformance + dataentry gate) and 5bea3431
+(pgstore native), branch feat/acl-search-tkt-ba8bsx stacked on PR 949.
+
+- **Conformance (AC5/AC6)**: `storetest.RunVisibleSearchTests` — 12 cases (the planned 8 plus EmptyScope, WildcardQueryInvalid, EmptyText, and per-case no-leak + ordered-subsequence invariants) — green on FOUR combinations: generic+memstore/linear, generic+fsstore/linear, generic+memstore/bleve (`TestVisibleConformance_Bleve`), pgstore-native against a real database (`RELA_TEST_DATABASE_URL=...rela_test go test -tags postgres ./internal/store/pgstore/ -run TestConformance/VisibleSearch` → PASS 12/12, first run).
+- **Dataentry HTTP tests (AC1–4, 3b, 7, 7b, 9)**: `acl_search_test.go` — 8 tests, all green: type-level grant + denied-principal empty shape + raw-body leak assertions; editor-of/belongs-to inheritance; visible-hit-related-to-hidden (serializer leak, includeRelations=false pin); DenyAll short-circuit (0 backend calls) + positive control (exactly 1); scope-error mapping (500 acl_query_failed, constant detail, synthetic `pq: relation "secret_internal_acl_table"` asserted absent, errors.Is(errACLListQuery)); canceled-ctx silent on `_position?scope=search`; backend-error mapping (500 search_failed, path string not echoed, NOT errACLListQuery); NopACL regression incl. off-metamodel `ghost` type staying visible (wildcard scope).
+- **AC8**: pre-existing `TestACLPosition_SearchScopeGated` green unchanged after `readableSubset` retirement; full dataentry suite green (no regressions).
+- **Live end-to-end (real server, real acl.yaml, .ignored/vmd8-verify, --principal-header X-Rela-User)**: alice (editor-of PRJ-42) `GET /_search?q=Hidden` → `[] total 0` (all 5 matching tickets belong to PRJ-9); `q=Visible` → exactly [TKT-V01..V05] total 5; mallory (no roles) `q=Visible` → `[] total 0`; mallory raw body for `q=Hidden` contains zero `TKT-H` occurrences.
+- **Builds**: default, `-tags memorybackend`, `-tags postgres` all compile; commit 1 verified buildable standalone (postgres recipe derives generic until commit 2 flips native).
+- **`just ci`**: lint + arch-lint + tests + coverage green (single failure: `e2e/node_modules/flatted/...` 0% — a node_modules artifact in the local checkout, gitignored, absent in CI).
+- **Docs (AC10)**: GUIDE-acl-security gained "Global search (/_search, TKT-BA8BSX)" section (scope lookup, post-visibility limit, generic-vs-native, bleve 10k caveat, deny short-circuit, serializer invariant, error semantics); `_search` removed from "What still leaks"; `docs/acl-security.md` regenerated via `just docs`; CLAUDE.md tests section points new VisibleSearcher impls at the conformance suite.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — `ResolveTypeScope` shared by both impls; `buildPredicateSQL` reused (not duplicated) for the native SQL; error-sentinel taxonomy reused from VMD8 rather than new codes
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned — and two PRE-EXISTING silent failures fixed: swallowed `runFreeTextSearchE` error and dropped iterator error on executeQuery's non-free-text branch)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-ELIA7T.md
+++ b/tickets/entities/planning-checklists/PLAN-ELIA7T.md
@@ -1,0 +1,167 @@
+---
+id: PLAN-ELIA7T
+type: planning-checklist
+title: 'Planning: ACL read-side: /_search visibility — VisibleSearcher seam, generic + pgstore-native impls, conformance suite'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: `search.VisibleSearcher` seam + neutral `TypeScope` type with
+exact→`"*"`→DenyAll lookup rule; generic hit-filter implementation
+(`search.NewVisible`: backend Limit:0 candidates → MatchingIDs batch filter →
+post-filter truncation to Query.Limit); pgstore-native `(*Store).SearchVisible`
+combined-SQL implementation; `storetest.RunVisibleSearchTests` conformance suite
+(cases 1–8, per-backend invariants, 3 backends); gate internalized in
+`executeQuery` (error return preserving errACLListQuery/errListLoad taxonomy);
+`handleV1Search` error mapping + includeRelations=false pin; `resolveScope`
+retires `readableSubset`; appbuild VisibleSearcher slot per recipe; docs.
+
+OUT: SSE per-subscriber visibility; `_position` per-id gate
+(RR-NDMN/RR-37IY/RR-ATSO); legacy `Backend.Search` ctx threading;
+property-filter SQL pushdown; sidebar config-filter pushdown;
+`listFromStoreByTypes` error refactor for its other 3 callers (RR-FCVX69).
+
+**Acceptance Criteria:** AC1–AC10 (rev 2, incl. 3b/7b) in TKT-BA8BSX body, each
+with concrete test scenario (see Test Plan below).
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: design settled in a full interactive discussion 2026-06-12 covering options, tradeoffs, and recommendation — the ticket body IS the research record; spinning a RES would duplicate it)
+- [x] ~~Searched for existing libraries~~ (N/A: in-tree seam; no external library applies to per-principal graph-ACL search filtering)
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A (ticket body carries the full design rationale +
+discussion provenance)
+
+**Existing Solutions:**
+
+- `storetest` conformance pattern: `internal/store/storetest/storetest.go` (Factory/SearchFactory, RunAll, nil-skippable suites) — directly extended, not reinvented.
+- "Smart backend" split anticipated by `search.Searcher` godoc (`internal/search/types.go:17`) — this ticket is the first instance of that promise.
+- Hit-filter batching: `readableSubset` (`internal/dataentry/scope.go:130`) from TKT-VMD8 — same shape, moved to hits-before-body-load.
+- SQL composition: `buildGraphQuerySQL`/`buildPredicateSQL`/`buildMatchingIDsSQL` (`internal/store/pgstore/graphquery.go`) — reused in-package for the EXISTS chains; per-type CTE prefixing is new.
+- Search-after-ACL ordering contract: TKT-VMD8 AC9 + `TestACLList_SearchAfterACLOrdering`.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:** Full design in TKT-BA8BSX body §Design (rev 2). Summary:
+consumer (dataentry) resolves per-type `ReadQuery` verdicts over `meta.Entities`
+into `map[string]search.TypeScope` (NopACL → `{"*": AllowAll}`); `SearchVisible`
+executes the scope. Generic impl filters hits via `MatchingIDs` (candidates at
+backend Limit:0, bleve 10k floor accepted), truncates post-filter. pgstore impl
+is a method on `*pgstore.Store` composing visibility into the trgm statement
+(per-type disjunction, LIMIT post-visibility, ctx threaded). Cap model: 1000
+stays the final /_search bound, applied post-visibility (NopACL byte-parity
+preserved). Conformance suite with scope literals pins all implementations.
+
+**Alternatives rejected:**
+- Handler-level post-filter (patch `handleV1Search` with `readableSubset`): leaves `executeQuery` ungated for future consumers, keeps cap starvation, loads hidden bodies. Rejected — closes the hole, not the class.
+- `search → acl` import (pass `acl.ReadQueryResult` directly): new arch edge for no benefit; neutral `TypeScope` mirrors it with store types search already imports.
+- Optional capability interface + type-assert at consumer: violates the no-back-channel rule; recipe wiring is explicit and fits the documented appbuild pattern.
+- bleve doc-ID filter pushdown: requires building the allowed-ID set per request anyway, defeating the point; local MatchingIDs is already cheap.
+- Exporting pgstore SQL builders for an out-of-package native impl: rejected in favor of a method on `*pgstore.Store` (RR-1LFQA5).
+
+**Files to modify:** listed in TKT-BA8BSX §Files (rev 2).
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+- `q` query param (user-controlled free text): parsed by existing `searchparser.ParseQuery`; reaches SQL only via `sqlBuilder.arg` positional placeholders + `escapeLike` (existing, reused). No new injection surface.
+- `type` query param: validated against metamodel (existing behavior).
+- Scope map: server-derived from policy, never wire-supplied. Fail-closed by construction: exact → `"*"` → DenyAll; the dangerous failure mode (nil map) denies everything rather than allowing it.
+
+**Security-Sensitive Operations:**
+- Visibility filtering (the point of the ticket): deny-by-default lookup; conformance no-leak invariant on every case; serializer-level leak (AC3b) covered at the dataentry layer since the seam suite can't see it (RR-QO01XY).
+- Error responses: constant detail + slog.Warn per POLICY-015; AC7 asserts synthetic error strings absent from bodies; AC7b preserves the canceled→silent / deadline→504 mapping.
+- Timing side channel: all-effective-DenyAll short-circuits before backend (AC4); pgstore-native does no hidden-row work; generic path's residual local timing signal accepted + documented.
+- DoS bound (RR-BDYTP5): candidate set capped per backend; MatchingIDs batched per type over the bounded set.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+- AC1/AC2/AC3/AC3b: `acl_search_test.go` HTTP-level tests reusing VMD8 world seeders + raw-body leak assertions (incl. visible-hit-related-to-hidden-entity case; includeRelations=false pin).
+- AC4: recording-searcher — zero calls under all-DenyAll, exactly one under single-allowed-type.
+- AC5/AC6: `storetest.RunVisibleSearchTests` ×3 (generic+memstore/linear, generic+fsstore/bleve in search package tests; pgstore-native in conformance_test.go, DB-gated, `just test-postgres`).
+- AC7/AC7b: failing GraphQueryer + failing searcher fakes → 5xx constant detail, body free of synthetic string; `errors.Is` asserts on sentinel wrapping; canceled/deadline mapping on `_position?scope=search`.
+- AC8: existing `TestACLPosition_SearchScopeGated` unchanged and green.
+- AC9: NopACL JSON-canonical compare on `/_search`.
+- AC10: docs review + `just docs` regeneration.
+
+**Edge Cases:**
+- Nil/empty scope map → deny everything, no backend call.
+- Empty `q` → existing early-return preserved.
+- Hit type absent from scope and no `"*"` → dropped (fail-closed, conformance case 8).
+- Limit smaller than visible count with hidden entries ranked above → conformance case 5.
+- `Query.Types` requesting a DenyAll type → empty for that type, others unaffected (case 7).
+- Type in scope but absent from corpus → no hits, no error.
+- Stale index hit (deleted between search and store read): existing skip-silently behavior preserved.
+- One type's MatchingIDs errors in a mixed-type result → whole request 5xx (no partial leak-prone response).
+
+**Negative Tests:** AC4 (short-circuit), AC7/7b (error mapping + non-leak),
+conformance cases 2 and 8.
+
+**Integration approach:** conformance suite is store+search integration by
+construction; dataentry tests are full HTTP handler integration; pgstore path
+runs against a real database via `just test-postgres`.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+- 3-deep stack rework (939 re-review may force cascading rebases): **accepted explicitly by user 2026-06-12**; mitigated by new-file-dominant diff.
+- appbuild plumbing for the VisibleSearcher slot touches all three recipes + cmd wiring: contained by the recipe pattern; arch-lint pins boundaries.
+- pgstore plan quality (recursive CTE fences + trgm): precedent in `graphquery_explain_test.go` / `graphquery_bench_test.go`; conformance catches correctness.
+- Behavioral drift generic vs native: conformance suite + per-backend invariants ARE the mitigation; differential fuzz is the stretch backstop.
+- `executeQuery` signature change ripples: exactly two consumers, both updated in this PR; `listFromStoreByTypes` untouched (RR-FCVX69).
+
+**Effort:** m
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] GUIDE-acl-security (docs-project) — `_search` deferred→gated, seam + scope-lookup rule, post-visibility limit contract, off-metamodel fail-closed note, generic-vs-native split, bleve 10k caveat
+- [x] docs/acl-security.md — regenerated via `just docs`
+- [x] storetest godoc — new implementations must pass RunVisibleSearchTests
+- [x] ~~docs/metamodel.md, cli-reference.md, data-entry.md, CLAUDE.md, README.md~~ (N/A: no metamodel/CLI/UI surface change)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** 13 findings via cranky-code-reviewer (2026-06-12),
+all `addressed` in plan rev 2: RR-1LFQA5 (critical, pgstore wiring), RR-QO01XY
+(critical, serializer leak layer), RR-SOU82P, RR-FCVX69, RR-Z65PWC, RR-ODIXVI,
+RR-BDYTP5, RR-DLFCHR (significant), RR-AJ0QD8, RR-1R9X50, RR-2LGO3L, RR-X1A3FW,
+RR-599CLE (minor).

--- a/tickets/entities/review-checklists/REV-4Z4TWV.md
+++ b/tickets/entities/review-checklists/REV-4Z4TWV.md
@@ -72,9 +72,9 @@ surfaces, short-circuit condition, _position deny behavior. Design-review round
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (local `just ci` green; stacked-PR CI subset monitored — full suite re-fires on retarget to develop after #949 merges, same flow as PR 949 itself)
+- [x] PR URL documented below
 
-**PR:** <!-- pending: created stacked on feat/acl-listside-tkt-vmd8 after ticket
-reaches done -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/972 (base:
+feat/acl-listside-tkt-vmd8 — 3rd PR of the read-side stack)

--- a/tickets/entities/review-checklists/REV-4Z4TWV.md
+++ b/tickets/entities/review-checklists/REV-4Z4TWV.md
@@ -1,0 +1,80 @@
+---
+id: REV-4Z4TWV
+type: review-checklist
+title: 'Review: ACL read-side: /_search visibility — VisibleSearcher seam, generic + pgstore-native impls, conformance suite'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`) — sole failure is `e2e/node_modules/flatted/...`, a gitignored local node_modules artifact absent from CI checkouts; all real packages above floors, total 75.9%
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed (none found)
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** Code review (cranky-code-reviewer, full diff vs
+origin/feat/acl-listside-tkt-vmd8): 0 critical, 2 significant — RR-A3V2FK
+(untested pgstore Filters path → FiltersThenLimit conformance case +
+deterministic SQL-shape unit tests), RR-L0ZGRI (filter-validation asymmetry →
+ValidateFilters hoisted into generic impl + InvalidFilterRejectedIdentically
+case) — both addressed; 3 minor — RR-PEZTM0 (SortIsIgnored case), RR-QGZG72
+(no-DB SQL builder tests), RR-2ZS7ZT (GUIDE load note) — all addressed; 1 nit —
+RR-EKUNMX (CTE prefix derivation) — wont-fix with justification (positional
+uniqueness structurally guaranteed + now test-pinned). Reviewer explicitly
+verified and cleared: SQL injection safety, filter-in-place aliasing,
+MatchingIDs fail-closed semantics, wiring nil-paths, handleV1Search leak
+surfaces, short-circuit condition, _position deny behavior. Design-review round
+(13 RRs, RR-1LFQA5…RR-599CLE) closed in planning.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+| AC | Status | Evidence |
+|----|--------|----------|
+| 1 denied principal empty | PASS | TestACLSearch_TypeLevelGrant + live (mallory → [] total 0) |
+| 2 role-relation inheritance | PASS | TestACLSearch_RoleRelationInheritance + live (alice q=Hidden → 0, q=Visible → 5/5) |
+| 3 no-leak on wire | PASS | raw-body assertions in AC1/AC2 tests (IDs, titles, property values) |
+| 3b related-hidden no-leak | PASS | TestACLSearch_VisibleHitRelatedToHidden (includeRelations=false pinned) |
+| 4 short-circuit + positive | PASS | TestACLSearch_DenyAllShortCircuit (0 calls denied / exactly 1 granted) |
+| 5 conformance ×3 impls | PASS | 15 cases green on 4 combos: generic+memstore/linear, generic+fsstore/linear, generic+memstore/bleve, pgstore-native (real DB) |
+| 6 cap starvation fixed | PASS | LimitPostVisibility + FiltersThenLimit cases; SQL LIMIT placement unit-pinned |
+| 7 error semantics | PASS | TestACLSearch_ScopeErrorMapping (constant detail, no echo) + BackendErrorMapping |
+| 7b sentinel wrapping + cancel | PASS | errors.Is asserts + TestACLSearch_CanceledScopeStaysSilent (empty body) |
+| 8 resolveScope parity | PASS | TestACLPosition_SearchScopeGated green unchanged after readableSubset retirement |
+| 9 NopACL regression | PASS | TestACLSearchRegression_NopACL incl. off-metamodel ghost type visible |
+| 10 docs | PASS | GUIDE section + regenerated docs/acl-security.md + CLAUDE.md storetest line |
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-C09N2R
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- pending: created stacked on feat/acl-listside-tkt-vmd8 after ticket
+reaches done -->

--- a/tickets/entities/review-responses/RR-1LFQA5.md
+++ b/tickets/entities/review-responses/RR-1LFQA5.md
@@ -1,0 +1,9 @@
+---
+id: RR-1LFQA5
+type: review-response
+title: pgstore-native VisibleSearcher unreachable through planned wiring
+finding: 'pgstore.Open returns search.New(st, backend) — the generic *search.Service — as a plain search.Searcher; SearchBackend has no visibility method and buildPredicateSQL/escapeLike are unexported. ''postgres recipe wires native'' has nothing to wire: no native VisibleSearcher value flows from pgstore to the App, and the App cannot downcast. Plumbing (new appbuild slot, constructor param, nil-check) was unbudgeted and would force a day-one redesign of the second commit.'
+severity: critical
+resolution: 'Plan rev 2: pgstore-native impl is a method on *pgstore.Store (in-package access to buildPredicateSQL/escapeLike/sqlBuilder, nothing exported). New VisibleSearcher collaborator slot threaded appbuild → cmd wiring → dataentry.App: fs/memory recipes wire search.NewVisible(searcher, st); postgres recipe wires the *pgstore.Store itself. dataentry.NewApp validates non-nil per constructor rule.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-1R9X50.md
+++ b/tickets/entities/review-responses/RR-1R9X50.md
@@ -1,0 +1,9 @@
+---
+id: RR-1R9X50
+type: review-response
+title: SearchVisible must thread ctx into pgstore SQL (don't inherit the context-less wart)
+finding: Legacy Backend.Search uses context.Background() (pgstore/search.go:76). SearchVisible is new code and must pass ctx to db.Query so the gated search is cancellable — otherwise writeGateError's DeadlineExceeded/Canceled branches are dead code for /_search on postgres.
+severity: minor
+resolution: 'Plan rev 2: SearchVisible takes ctx and the pgstore-native impl threads it into db.Query(ctx, …). Only the legacy Backend.Search keeps the background-ctx wart (tracked separately).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-2LGO3L.md
+++ b/tickets/entities/review-responses/RR-2LGO3L.md
@@ -1,0 +1,9 @@
+---
+id: RR-2LGO3L
+type: review-response
+title: NopACL nil/empty scope map inverts to DenyAll-everything; needs explicit all-allow contract
+finding: With 'absent = DenyAll', a nil map under NopACL means empty results for the no-ACL case (fail-closed inversion breaking AC9). The NopACL contract needs either a sentinel all-allow mechanism or guaranteed full enumeration of types including unknown ones.
+severity: minor
+resolution: 'Plan rev 2: reserved "*" wildcard scope entry. NopACL → {"*": AllowAll} (explicit all-allow, no enumeration needed, no fail-closed inversion). Lookup rule exact → "*" → DenyAll pinned in the seam godoc and conformance case 8.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-2ZS7ZT.md
+++ b/tickets/entities/review-responses/RR-2ZS7ZT.md
@@ -1,0 +1,9 @@
+---
+id: RR-2ZS7ZT
+type: review-response
+title: Filtered free-text search loads up to the candidate window of entity bodies per request
+finding: With property filters present, runVisibleFreeTextSearch passes limit 0; on bleve up to 10k visible hits each get a GetEntity body load before the 1000 cap applies. In-process and tolerable, but the load amplification was undocumented — the kind of thing that surfaces as a latency complaint later.
+severity: minor
+resolution: 'GUIDE-acl-security candidate-window bullet extended with the load note: filtered free-text defers truncation past the filters, so the generic path may load up to the candidate window of entity bodies per request — named explicitly as a search-latency diagnosis hint. docs/acl-security.md regenerated.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-599CLE.md
+++ b/tickets/entities/review-responses/RR-599CLE.md
@@ -1,0 +1,9 @@
+---
+id: RR-599CLE
+type: review-response
+title: AC4 short-circuit needs a defined decision point and a positive assertion
+finding: 'All-DenyAll determination requires having computed the scope map (ReadQuery per type) — fine, but the AC should pin where the short-circuit happens and also assert the positive: a single-allowed-type query DOES invoke the searcher exactly once. As written AC4 only pins the negative.'
+severity: minor
+resolution: 'Plan rev 2 AC4: short-circuit decision point pinned (after scope construction, before any backend call) and positive control added — single-allowed-type query invokes the searcher exactly once.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-A3V2FK.md
+++ b/tickets/entities/review-responses/RR-A3V2FK.md
@@ -1,0 +1,9 @@
+---
+id: RR-A3V2FK
+type: review-response
+title: pgstore q.Filters path untested and unreachable from production — dead complexity with real risk
+finding: The native impl's filter handling (ValidateFilters, MatchFilters skip, LIMIT-omission-when-filters) had zero test coverage and zero production exercise — the only caller constructs Query without Filters. The load-bearing 'omit SQL LIMIT below Go-side filters' rule was unproven.
+severity: significant
+resolution: 'Conformance case FiltersThenLimit (all 4 backend combos) pins filters-before-limit semantically, and a new deterministic no-DB unit test (pgstore/visiblesearch_sql_test.go TestBuildVisibleSearchSQL_LimitPlacement) pins the SQL shape directly: LIMIT pushed down without filters, omitted when Go-side filters remain. TestBuildVisibleSearchSQL_Shape additionally pins empty-scope-no-query, wildcard-no-disjunction, and distinct CTE prefixes without needing a database.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-AJ0QD8.md
+++ b/tickets/entities/review-responses/RR-AJ0QD8.md
@@ -1,0 +1,9 @@
+---
+id: RR-AJ0QD8
+type: review-response
+title: Bleve Limit:0 maps to a 10000 floor, not truly uncapped
+finding: bleveindex.go:221 maps limit ≤0 to req.Size = 10000. The generic path silently caps candidates at 10000 before filtering on the fs/bleve backend, re-introducing the cap-starvation class at a higher bound. Plan should acknowledge and accept explicitly rather than claim 'uncapped'.
+severity: minor
+resolution: 'Plan rev 2: bleve''s 10000 floor explicitly acknowledged and accepted — cap starvation fixed within a 10k-candidate window on bleve, fully on linear/pgstore. Documented in GUIDE-acl-security (AC10) instead of claiming ''uncapped''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-BDYTP5.md
+++ b/tickets/entities/review-responses/RR-BDYTP5.md
@@ -1,0 +1,9 @@
+---
+id: RR-BDYTP5
+type: review-response
+title: /_search has no limit param; 'truncate to requested limit' undefined and unbounded post-ACL scan is a DoS amplifier
+finding: handleV1Search serializes all results (Meta.PerPage = len(data)); there is no limit query param, so step 2's 'truncates to requested limit' has no defined source for the /_search consumer. If unbounded, a broad query forces an uncapped candidate scan + per-type MatchingIDs over the whole corpus — 'MatchingIDs is cheap' per call does not bound an unbounded candidate set.
+severity: significant
+resolution: 'Plan rev 2: /_search keeps no user limit param; the ''requested limit'' is the existing maxFreeTextSearchResults=1000, passed as Query.Limit to SearchVisible and applied post-visibility. DoS bound: candidate set capped by backend (bleve 10k floor / linear corpus / pgstore SQL LIMIT); MatchingIDs batched per type over the bounded candidate set. Non-free-text queries stay unbounded (matches today''s list-endpoint semantics), now gated.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DLFCHR.md
+++ b/tickets/entities/review-responses/RR-DLFCHR.md
@@ -1,0 +1,9 @@
+---
+id: RR-DLFCHR
+type: review-response
+title: errACLListQuery wrapping / writeGateError mapping preservation for _position not pinned by AC8
+finding: readableSubset wraps gate errors in errACLListQuery so handleV1EntityPosition's writeGateError mapping (canceled→silent, deadline→504) fires. AC8 only pins filtering behavior via TestACLPosition_SearchScopeGated, not the error mapping; the new gated executeQuery must preserve the exact wrapping or a cancellation on /_position?scope=search starts emitting a 500 body where it used to emit nothing.
+severity: significant
+resolution: 'Plan rev 2 AC7b: executeQuery preserves errACLListQuery/errListLoad wrapping (unit-assert errors.Is); canceled-context on /_position?scope=search stays silent, deadline → 504. writeGateError mapping fires identically for both consumers.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-EKUNMX.md
+++ b/tickets/entities/review-responses/RR-EKUNMX.md
@@ -1,0 +1,9 @@
+---
+id: RR-EKUNMX
+type: review-response
+title: CTE prefix uniqueness derived from loop index is correct but fragile to refactor
+finding: 'buildVisibilityDisjunction derives CTE-name uniqueness from the positional index over sorted scope types. Correct today, but the invariant is emergent from loop structure rather than local; a future refactor reusing the builder or reordering could collide silently. Suggestion: derive the prefix from the (sanitized) type name.'
+severity: nit
+reason: Positional-index uniqueness is structurally guaranteed by the single sorted loop; deriving prefixes from type names would require sanitizing arbitrary metamodel type strings into SQL identifiers, reintroducing exactly the collision class being avoided (two types sanitizing to the same identifier). The distinct-prefix invariant is now pinned by TestBuildVisibleSearchSQL_Shape, so a refactor that breaks it fails a no-DB unit test rather than corrupting results silently.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-FCVX69.md
+++ b/tickets/entities/review-responses/RR-FCVX69.md
@@ -1,0 +1,9 @@
+---
+id: RR-FCVX69
+type: review-response
+title: listFromStoreByTypes error refactor ripples to 3 unplanned callers
+finding: The plan conflates 'executeQuery gains error' with 'listFromStoreByTypes gains error'. listFromStoreByTypes has four callers (app.go:519, commands.go:322, handlers_api.go:861, helpers.go:406); a signature change ripples to three the plan ignores, and without it the dropped iterator error remains on executeQuery's non-free-text branch.
+severity: significant
+resolution: 'Plan rev 2: listFromStoreByTypes is NOT refactored — its 4 callers stay untouched. executeQuery''s non-free-text branch gets its own inline error-surfacing iteration (mirroring the VMD8 AllowAll fix). Other 3 callers explicitly listed as out of scope.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-L0ZGRI.md
+++ b/tickets/entities/review-responses/RR-L0ZGRI.md
@@ -1,0 +1,9 @@
+---
+id: RR-L0ZGRI
+type: review-response
+title: Generic impl missing ValidateFilters — filter-rejection asymmetry between implementations
+finding: pgstore.SearchVisible validates filters up front; the generic Visible forwarded them to the inner Service, which rejects via a different path. The Filters dimension of the VisibleSearcher contract was effectively unspecified — the conformance suite never asserted filter-validation behavior.
+severity: significant
+resolution: ValidateFilters hoisted into the generic impl (visible.go visibleHits, before any backend/scope work) for parity; new conformance case InvalidFilterRejectedIdentically asserts BOTH impls reject an ordered filter with the same sentinel (search.ErrOrderedFilterUnsupported) and yield zero hits before the error.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ODIXVI.md
+++ b/tickets/entities/review-responses/RR-ODIXVI.md
@@ -1,0 +1,9 @@
+---
+id: RR-ODIXVI
+type: review-response
+title: AC6 (lift cap) and AC9 (NopACL byte-parity) are contradictory as written
+finding: NopACL → all-AllowAll → uncapped search returns more than 1000 results where today's /_search returns ≤1000 for a large corpus, so the JSON-canonical regression cannot be byte-identical. Both ACs cannot be green simultaneously on a corpus >1000 matching entities; the plan must pick a cap model.
+severity: significant
+resolution: 'Plan rev 2 cap model: maxFreeTextSearchResults=1000 stays as the FINAL /_search result bound but moves from pre-ACL candidate cap to post-visibility truncation. NopACL/all-AllowAll: no-op filter + unchanged ranker → top-1000 byte-identical to today, AC9 holds. Restricted principals get the true top-1000 of their visible corpus. Contradiction dissolved.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-PEZTM0.md
+++ b/tickets/entities/review-responses/RR-PEZTM0.md
@@ -1,0 +1,9 @@
+---
+id: RR-PEZTM0
+type: review-response
+title: q.Sort claimed ignored but not pinned by any test
+finding: The VisibleSearcher godoc states q.Sort is ignored, but neither implementation was tested for it — a backend accidentally honoring Sort would violate the cross-backend ordering contract invisibly.
+severity: minor
+resolution: 'New conformance case SortIsIgnored: identical result stream with and without q.Sort, on every backend.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QGZG72.md
+++ b/tickets/entities/review-responses/RR-QGZG72.md
@@ -1,0 +1,9 @@
+---
+id: RR-QGZG72
+type: review-response
+title: pgstore empty-text SQL path only covered by the DB-gated conformance run
+finding: Production callers can never reach Text=="" in SearchVisible (handleV1Search early-returns, scopeFromParam requires q, executeQuery bails on empty). The ORDER BY e.id path ships unexercised in any CI lane without RELA_TEST_DATABASE_URL.
+severity: minor
+resolution: TestBuildVisibleSearchSQL (no-DB unit tests in the pgstore package) now exercises the SQL builder including structural shape on every CI lane; the empty-text execution path remains covered by the DB-gated EmptyTextListsVisible conformance case, which the CI postgres job runs. Combination accepted as sufficient.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QO01XY.md
+++ b/tickets/entities/review-responses/RR-QO01XY.md
@@ -1,0 +1,9 @@
+---
+id: RR-QO01XY
+type: review-response
+title: serializeRelatedEntityForWire relation leak not covered by hit filter; conformance suite tests wrong layer for AC1/AC3
+finding: The hit filter only decides which root entities survive. entityToV1 populates Relations (relation-type → target IDs) when includeRelations=true; handleV1Search currently passes false but the plan never pins that invariant, and the storetest conformance suite operates on search.Hit{ID,Type,Title} only — it structurally cannot catch a visible hit exposing a hidden entity's ID/title through its serialized body. AC1/AC3 are dataentry-serializer guarantees assigned to the wrong test layer.
+severity: critical
+resolution: 'Plan rev 2: includeRelations=false pinned by comment + test (no longer convention). New AC3b: visible hit relating to a hidden entity exposes no hidden ID/title/property through any serialized field (raw-body assertion in dataentry handler test). AC1/AC3 verification explicitly assigned to dataentry handler tests; conformance suite scoped to Hit-level seam only.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SOU82P.md
+++ b/tickets/entities/review-responses/RR-SOU82P.md
@@ -1,0 +1,9 @@
+---
+id: RR-SOU82P
+type: review-response
+title: Scope-map construction rule and unknown-type fail-closed semantics unspecified
+finding: 'Who enumerates ''all metamodel types'' is unstated, and entities whose type is absent from the metamodel (permissive storage: removed/typo types are storable states) hit ''absent = DenyAll'' silently. Under NopACL that would HIDE unknown-type entities that are visible today, breaking the NopACL regression. The construction rule (which type set drives the map) and deterministic fail-closed lookup for unknown hit types must be pinned.'
+severity: significant
+resolution: 'Plan rev 2: scope lookup rule pinned — exact type entry → reserved "*" wildcard entry → DenyAll (fail-closed). Construction rule: dataentry iterates meta.Entities calling ReadQuery per type; under ACL no "*" is emitted so off-metamodel types fail closed (documented); NopACL emits {"*": AllowAll} preserving today''s unknown-type visibility. Conformance case 8 pins both wildcard admission and fail-closed denial.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-X1A3FW.md
+++ b/tickets/entities/review-responses/RR-X1A3FW.md
@@ -1,0 +1,9 @@
+---
+id: RR-X1A3FW
+type: review-response
+title: Conformance suite cannot exercise the dataentry serializer (duplicate angle of the serializer-leak critical)
+finding: Cases 1-7 assert on search.Hit; none exercises serializeRelatedEntityForWire / stripHiddenProperties. AC1/AC3 verification must be explicitly assigned to dataentry handler tests against the real handleV1Search, separate from storetest.
+severity: minor
+resolution: 'Plan rev 2: AC1/AC3/AC3b explicitly assigned to dataentry handler tests against the real handleV1Search (acl_search_test.go); storetest conformance suite scoped to the Hit-level seam only.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Z65PWC.md
+++ b/tickets/entities/review-responses/RR-Z65PWC.md
@@ -1,0 +1,9 @@
+---
+id: RR-Z65PWC
+type: review-response
+title: Ordered-subsequence invariant only holds per-backend; parity baseline undefined
+finding: Bleve and trgm are different rankers; pgstore's visible order cannot be asserted a subsequence of bleve's ungated order. The invariant is only valid within one backend (gated-of-backend-X ⊆ ungated-of-backend-X). Conformance case 1 'parity with ungated Search' must define which ungated query (capped vs uncapped) is the baseline.
+severity: significant
+resolution: 'Plan rev 2: invariants restated per-backend (gated-of-X ⊆ ungated-of-X); parity baseline defined as same backend + same Query incl. limit; fixture corpora stay below all candidate bounds so truncation never confounds the subsequence check (truncation pinned separately by case 5).'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-BA8BSX.md
+++ b/tickets/entities/tickets/TKT-BA8BSX.md
@@ -1,0 +1,190 @@
+---
+id: TKT-BA8BSX
+type: ticket
+title: 'ACL read-side: /_search visibility — VisibleSearcher seam, generic + pgstore-native impls, conformance suite'
+kind: enhancement
+priority: high
+effort: m
+status: done
+---
+
+Follow-up named by TKT-VMD8 ("/_search ACL filtering for bleve and pgstore
+backends"). Stacks on TKT-VMD8's PR 949 (accepted rework risk: 3-deep stack
+while PR 939 awaits re-review). Design-reviewed 2026-06-12: 13 findings
+(RR-1LFQA5 … RR-599CLE), all addressed in this revision.
+
+## Problem
+
+After TKT-VQGN + TKT-VMD8, every read surface is gated except `/api/v1/_search`.
+`handleV1Search` calls `executeQuery` with zero gate interaction — a denied
+principal can free-text search and receive **full serialized entity bodies**.
+The `_position` search scope already patches this externally via
+`readableSubset`; the search view itself is the deferred hole (named in
+`scope.go` comment).
+
+## Design (rev 2, post design-review)
+
+### Seam
+
+New `search.VisibleSearcher` interface + neutral scope type (no `search → acl`
+import edge):
+
+```go
+type TypeScope struct {
+    AllowAll bool
+    Query    *store.GraphQuery
+}
+// Scope lookup rule (RR-SOU82P / RR-2LGO3L): exact type entry → else the
+// reserved "*" wildcard entry → else DenyAll (fail-closed).
+type VisibleSearcher interface {
+    SearchVisible(ctx context.Context, q Query, scope map[string]TypeScope) iter.Seq2[Hit, error]
+}
+```
+
+- `Query.Limit` contract: max **visible** hits returned — applied post-visibility (this is the seam-level cap-starvation fix; conformance case 5 exercises it directly with a small explicit limit).
+- dataentry builds the scope from `readGate.ReadQuery` over **metamodel types** (`meta.Entities`); `nopReadGate` → `{"*": {AllowAll: true}}` (preserves today's visibility of off-metamodel entities → AC9 safe). Under ACL, no `"*"` entry is emitted, so off-metamodel types (permissive storage: removed/typo types) fail **closed** — documented behavior, pinned by conformance case 8.
+- ACL resolution stays at the consumer; `SearchVisible` only executes a scope.
+
+### Generic implementation (bleve + linear)
+
+`search.NewVisible(searcher Searcher, gq store.GraphQueryer)` wrapping the
+existing service: fetch candidates with backend `Limit: 0` (**note RR-AJ0QD8:
+bleve maps ≤0 to a 10000 floor — accepted and documented**: cap starvation is
+fixed within a 10k-candidate window on bleve, fully on linear/pgstore), group
+hits by type, batch via `MatchingIDs`, truncate to `Query.Limit` **after**
+filtering. Local backends pair only with fsstore/memstore, so `MatchingIDs` is
+in-process (graphquerynaive); candidate set bounded by the backend (10k bleve /
+corpus linear) bounds the DoS surface (RR-BDYTP5).
+
+### pgstore-native implementation (second commit)
+
+**Method on `*pgstore.Store`** (RR-1LFQA5 resolution — in-package access to
+`buildPredicateSQL`/`escapeLike`/`sqlBuilder`; no export of SQL internals): `(s
+*Store) SearchVisible(ctx, q, scope)` builds one statement — trgm `LIKE` ANDed
+with per-type visibility disjunction (bare `e.type=$n` for AllowAll incl. `"*"`
+handling as no type-restriction clause, EXISTS chains for Query verdicts with
+**per-type CTE prefixes**, DenyAll omitted), `ORDER BY similarity` then `LIMIT`
+**post-visibility**. ctx threads into `db.Query(ctx, …)` (RR-1R9X50 — new code
+is cancellable; the legacy `Backend.Search` background-ctx wart stays tracked
+separately).
+
+### Wiring (RR-1LFQA5)
+
+New collaborator slot threaded `appbuild` → cmd wiring → `dataentry.App`: fs +
+memory recipes wire `search.NewVisible(searcher, st)`; postgres recipe wires the
+`*pgstore.Store` itself (it already implements `GraphQueryer`; now also
+`VisibleSearcher`). `dataentry.NewApp` validates non-nil per the constructor
+rule. No build-agnostic code branches on backend.
+
+### Cap model (RR-ODIXVI / RR-Z65PWC resolution — dissolves the AC6↔AC9 contradiction)
+
+`maxFreeTextSearchResults = 1000` **stays** as the final `/_search` result
+bound, but moves from pre-ACL candidate cap to post-visibility truncation
+(dataentry passes `Limit: 1000` to `SearchVisible`). All-AllowAll / NopACL:
+filter is a no-op and the ranker is unchanged, so the top-1000 is byte-identical
+to today → NopACL JSON-canonical regression holds. Restricted principals:
+top-1000 of **their** visible corpus (within backend candidate bounds).
+Non-free-text queries (`type:x` only): unbounded today, stays unbounded (matches
+list-endpoint semantics), now gated.
+
+### Gate placement
+
+Inside `executeQuery`: signature gains `error`. Scope construction happens
+first; **all-effective-DenyAll short-circuits after scope construction, before
+any backend call** (RR-599CLE: decision point pinned; positive case also pinned
+— one allowed type ⇒ exactly one searcher invocation). Error wrapping preserves
+the existing sentinel taxonomy (RR-DLFCHR): gate/scope errors wrap
+`errACLListQuery`, load errors wrap `errListLoad`, so
+`writeListPipelineError`/`writeGateError` mappings (canceled→silent,
+deadline→504, constant detail + slog.Warn per POLICY-015) fire identically for
+both consumers. `resolveScope` retires `readableSubset`.
+
+**`listFromStoreByTypes` is NOT refactored** (RR-FCVX69: 4 callers — app.go:519,
+commands.go:322, handlers_api.go:861, helpers.go:406). executeQuery's
+non-free-text branch gets its own inline error-surfacing iteration (mirrors the
+VMD8 AllowAll fix); the other three callers are untouched and out of scope.
+
+### Serializer leak surface (RR-QO01XY / RR-X1A3FW)
+
+The hit filter governs root-entity survival only. `handleV1Search` keeps
+`includeRelations=false` — now pinned by comment + test, not convention. New
+dataentry-level AC: a **visible** hit that relates to a **hidden** entity
+exposes no hidden ID/title/property through any field of its serialized body
+(raw-body assertion). AC1/AC3 verification is explicitly assigned to dataentry
+handler tests against the real `handleV1Search`; the storetest conformance suite
+covers the seam (Hit-level) only.
+
+### Limit vs Go-side property filters
+
+When `sq.PropertyFilters` remain after the search, the 1000 truncation applies
+after them (no early truncation) — starvation must not sneak back through the
+filter gap.
+
+### Conformance suite
+
+`storetest.RunVisibleSearchTests` + `VisibleSearchFactory func(t) (store.Store,
+search.VisibleSearcher)`, next to `SearchFactory`/`RunSearchTests`. Scope
+**literals**, not acl.Policy. Run for generic+memstore/linear,
+generic+fsstore/bleve, pgstore-native (DB-gated on RELA_TEST_DATABASE_URL). No
+capability flag.
+
+Cases: (1) all-AllowAll parity with ungated Search — **same backend, same Query
+incl. limit** (RR-Z65PWC: baseline defined per-backend); (2) DenyAll-by-absence
+never hits even on best text match; (3) Query verdict filters by predicate; (4)
+mixed AllowAll+Query+DenyAll scope in one query; (5) **limit is
+post-visibility** — small explicit `Query.Limit`, top-ranked candidates hidden,
+visible below still fill the result; (6) transitive predicate
+(InheritThrough/depth) exercising pgstore's recursive-CTE composition; (7)
+`Query.Types` ∩ scope composes (incl. Types requesting a DenyAll type); (8)
+**wildcard + fail-closed lookup**: `{"*": AllowAll}` admits unknown types; map
+without `"*"` denies a type absent from it.
+
+Invariants asserted in every case, **per-backend** (RR-Z65PWC): **no-leak**
+(every hit ID ∈ allowed set) and **ordered-subsequence** (visible result ==
+same-backend ungated result with hidden entries deleted, order preserved;
+fixture corpora stay below all candidate bounds so truncation never confounds it
+— truncation itself is pinned separately by case 5).
+
+Out of the suite (dataentry handler tests instead): serializer-level leaks
+(AC3/AC3b), DenyAll-skips-backend recording assertions, error-path mapping.
+
+Stretch (droppable to follow-up): differential check — random corpus + random
+scope, generic-over-memstore ≡ pgstore visible **sets**.
+
+## Out of scope
+
+- SSE `/api/v1/_events` per-subscriber visibility (separate named follow-up)
+- `_position` per-id gate (carries RR-NDMN/RR-37IY/RR-ATSO; separate follow-up)
+- `Backend.Search` ctx threading for the legacy method
+- Property-filter pushdown into SQL; `listFromStoreByTypes` error refactor for its other 3 callers
+
+## Acceptance criteria (rev 2)
+
+1. **Denied principal gets nothing from /_search.** No read grants: `GET /api/v1/_search?q=<matching text>` → `data: []`, total 0. With per-type grants: only visible entities, full bodies only for those.
+2. **Role-relation inheritance on search.** alice/editor-of/PRJ-42 world: search matching TKT-001 (visible) and TKT-002 (hidden) returns only TKT-001.
+3. **No-leak on the wire** (dataentry handler test, raw body): hidden IDs/titles/property values absent in AC1/AC2 responses. **3b (RR-QO01XY):** a visible hit relating to a hidden entity exposes no hidden ID/title/property through any serialized field; `includeRelations=false` pinned by test.
+4. **Short-circuit + positive control (RR-599CLE).** Recording-searcher: all-effective-DenyAll scope → zero backend calls; single-allowed-type query → exactly one backend call.
+5. **Conformance suite green on three implementations** (cases 1–8 + per-backend invariants): generic+memstore/linear, generic+fsstore/bleve, pgstore-native (DB-gated).
+6. **Cap starvation fixed at the seam**: conformance case 5; `/_search` passes Limit 1000 post-visibility (bleve 10k candidate floor documented as accepted bound).
+7. **Error semantics**: gate/store failure → 5xx constant detail ("check server logs"), raw error only in slog; synthetic error string asserted absent from body. **7b (RR-DLFCHR):** executeQuery preserves `errACLListQuery`/`errListLoad` wrapping — unit-assert `errors.Is`; canceled-context on `/_position?scope=search` stays silent, deadline → 504.
+8. **`resolveScope` parity**: TestACLPosition_SearchScopeGated green after `readableSubset` retirement.
+9. **NopACL regression**: without acl.yaml, `/_search` response JSON-canonically identical to today (holds by cap model: no-op filter + unchanged ranker + same final 1000 bound; NopACL scope = `{"*": AllowAll}`).
+10. **Docs**: GUIDE-acl-security — `_search` deferred→gated, seam + scope-lookup rule, post-visibility limit contract, off-metamodel fail-closed note, generic-vs-native split, bleve 10k caveat; `docs/acl-security.md` regenerated; storetest godoc points new implementations at RunVisibleSearchTests.
+
+## Files (rev 2)
+
+- `internal/search/types.go` — `TypeScope`, `VisibleSearcher`, scope-lookup rule godoc
+- `internal/search/visible.go` (new) — `NewVisible` generic implementation
+- `internal/store/pgstore/visiblesearch.go` (new) — `(*Store).SearchVisible`; `graphquery.go` — per-type CTE prefix support
+- `internal/store/storetest/visiblesearch.go` (new) — conformance suite; `storetest.go` — `VisibleSearchFactory`
+- `internal/store/pgstore/conformance_test.go`, search-package tests — wire suite ×3
+- `internal/appbuild/appbuild_{fs,memory,postgres}.go` + cmd/mcp wiring — new VisibleSearcher slot, nil-validated at `dataentry.NewApp`
+- `internal/dataentry/helpers.go` — `executeQuery` gate + error return + inline non-free-text iteration; `api_v1.go` — `handleV1Search` error mapping + includeRelations pin; `scope.go` — retire `readableSubset`
+- `internal/dataentry/acl_search_test.go` (new) — AC1–4, 3b, 7, 7b, 9
+- docs as AC10
+
+## Stack
+
+Branch from `feat/acl-listside-tkt-vmd8` (PR 949). Rework risk from the 3-deep
+stack accepted explicitly (2026-06-12). When 939/949 merge, rebase/retarget per
+the established cherry-pick pattern.

--- a/tickets/relations/TKT-BA8BSX--affects--authorization.md
+++ b/tickets/relations/TKT-BA8BSX--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-BA8BSX--affects--data-entry-server.md
+++ b/tickets/relations/TKT-BA8BSX--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-BA8BSX--has-docs--DOCS-C09N2R.md
+++ b/tickets/relations/TKT-BA8BSX--has-docs--DOCS-C09N2R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-docs
+to: DOCS-C09N2R
+---

--- a/tickets/relations/TKT-BA8BSX--has-implementation--IMPL-Y3CEK5.md
+++ b/tickets/relations/TKT-BA8BSX--has-implementation--IMPL-Y3CEK5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-implementation
+to: IMPL-Y3CEK5
+---

--- a/tickets/relations/TKT-BA8BSX--has-planning--PLAN-ELIA7T.md
+++ b/tickets/relations/TKT-BA8BSX--has-planning--PLAN-ELIA7T.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-planning
+to: PLAN-ELIA7T
+---

--- a/tickets/relations/TKT-BA8BSX--has-review--REV-4Z4TWV.md
+++ b/tickets/relations/TKT-BA8BSX--has-review--REV-4Z4TWV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review
+to: REV-4Z4TWV
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-1LFQA5.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-1LFQA5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-1LFQA5
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-1R9X50.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-1R9X50.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-1R9X50
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-2LGO3L.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-2LGO3L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-2LGO3L
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-2ZS7ZT.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-2ZS7ZT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-2ZS7ZT
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-599CLE.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-599CLE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-599CLE
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-A3V2FK.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-A3V2FK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-A3V2FK
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-AJ0QD8.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-AJ0QD8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-AJ0QD8
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-BDYTP5.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-BDYTP5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-BDYTP5
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-DLFCHR.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-DLFCHR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-DLFCHR
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-EKUNMX.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-EKUNMX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-EKUNMX
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-FCVX69.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-FCVX69.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-FCVX69
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-L0ZGRI.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-L0ZGRI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-L0ZGRI
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-ODIXVI.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-ODIXVI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-ODIXVI
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-PEZTM0.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-PEZTM0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-PEZTM0
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-QGZG72.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-QGZG72.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-QGZG72
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-QO01XY.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-QO01XY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-QO01XY
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-SOU82P.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-SOU82P.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-SOU82P
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-X1A3FW.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-X1A3FW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-X1A3FW
+---

--- a/tickets/relations/TKT-BA8BSX--has-review-response--RR-Z65PWC.md
+++ b/tickets/relations/TKT-BA8BSX--has-review-response--RR-Z65PWC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: has-review-response
+to: RR-Z65PWC
+---

--- a/tickets/relations/TKT-BA8BSX--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-BA8BSX--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BA8BSX
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
Closes the last ungated read surface: `/api/v1/_search` returned full serialized entity bodies to denied principals. Third PR of the ACL read-side stack — **stacks on #949** (which stacks on #939); will be retargeted to `develop` after the stack beneath it merges.

## What

- **`search.VisibleSearcher` seam** — executes a free-text search restricted to a per-type visibility scope (`TypeScope`; fail-closed lookup: exact type → reserved `"*"` wildcard → deny). ACL resolution stays at the consumer; the searcher guarantees no hit outside the scope is ever yielded, on any backend. `Query.Limit` counts **visible** hits (applied post-visibility — fixes cap starvation, where a restricted principal's matches rank below hidden candidates that used to eat the cap).
- **Generic implementation** (`search.NewVisible`, fs/memory builds): uncapped candidate fetch (bleve's 10k floor documented as the accepted window), per-type batched `MatchingIDs`, post-visibility truncation.
- **pgstore-native implementation** (`(*Store).SearchVisible`, postgres build): visibility composed into one SQL statement — trgm `LIKE` ANDed with a per-type disjunction reusing `buildPredicateSQL` EXISTS chains (per-type CTE prefixes), `ORDER BY similarity` and `LIMIT` post-visibility, ctx threaded. Hidden rows never leave the database; no timing side-channel from hidden-corpus work.
- **Conformance suite** (`storetest.RunVisibleSearchTests`): 15 cases + two invariants pinned on every case — *no-leak* (every hit ∈ allowed set) and *ordered-subsequence* (gated stream == same-backend ungated stream minus hidden hits). Run on 4 combos: generic+memstore/linear, generic+fsstore/linear, generic+memstore/bleve, pgstore-native (DB-gated). Any new implementation must pass it.
- **Gate internalized in `executeQuery`** (now returns `error`): both consumers — `handleV1Search` and the `_position` search scope — inherit it; the interim `readableSubset` patch is retired. All-DenyAll short-circuits before the backend. Fixes two pre-existing silent failures (swallowed search-backend error, dropped iterator error). Error taxonomy preserved: scope failures → `acl_query_failed` (cancel-silent/504/500, constant detail per POLICY-015), backend failures → `search_failed`; raw errors go to slog only.
- **NopACL parity**: the nop gate supplies `{"*": allow}`, so without `acl.yaml` the response is unchanged — including entities whose type is off-metamodel. Under a policy those fail closed.
- Wiring per appbuild recipe (`assemble` derives the generic wrapper; postgres recipe asserts the native seam); `dataentry.NewApp` validates the new collaborator.

## Review trail (rela tickets, TKT-BA8BSX)

- Design review: 13 findings (2 critical — pgstore wiring reachability, serializer-level relation leak), all addressed in plan rev 2 before implementation.
- Code review: 0 critical, 2 significant (untested `q.Filters` dimension; filter-validation asymmetry) — fixed with new conformance cases + deterministic SQL-shape unit tests; 3 minor addressed; 1 nit wont-fix with justification.
- Live verification against a real server + acl.yaml: alice (editor-of PRJ-42) `q=Hidden` → 0 results despite 5 text matches; mallory (no roles) → empty with zero hidden IDs in the raw body.

## Docs

GUIDE-acl-security: new "Global search" section; `_search` removed from "What still leaks". `docs/acl-security.md` regenerated.