### PR TITLE
fix(lua): preserve integers Lua->Go; whole-string numeric sort

### DIFF
--- a/internal/lua/numeric_test.go
+++ b/internal/lua/numeric_test.go
@@ -1,0 +1,110 @@
+package lua
+
+import (
+	"math"
+	"testing"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+// TestLuaNumberToGo_PreservesIntegers pins that an integral Lua number
+// converts to a Go int64 (not float64), so large integer IDs survive a
+// Lua→Go round-trip without precision loss. A non-integral value stays
+// float64.
+func TestLuaNumberToGo_PreservesIntegers(t *testing.T) {
+	tests := []struct {
+		name string
+		in   lua.LNumber
+		want interface{}
+	}{
+		{"small int", lua.LNumber(42), int64(42)},
+		{"zero", lua.LNumber(0), int64(0)},
+		{"negative int", lua.LNumber(-7), int64(-7)},
+		// Largest integer exactly representable as float64 (2^53). Beyond
+		// this, gopher-lua's float64-backed LNumber cannot hold an integer
+		// faithfully at all — the precision is lost before conversion —
+		// so this is the practical ceiling for int64 preservation.
+		{"max exact int (2^53)", lua.LNumber(1 << 53), int64(1 << 53)},
+		{"fractional stays float", lua.LNumber(3.5), 3.5},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := luaNumberToGo(tc.in)
+			if got != tc.want {
+				t.Errorf("luaNumberToGo(%v) = %#v (%T), want %#v (%T)", float64(tc.in), got, got, tc.want, tc.want)
+			}
+		})
+	}
+}
+
+// TestLuaValueToGo_IntegerNotFloat pins the integration point: a numeric
+// LValue routed through luaValueToGo yields an int64 for integral values.
+func TestLuaValueToGo_IntegerNotFloat(t *testing.T) {
+	got := luaValueToGo(lua.LNumber(100))
+	if got != int64(100) {
+		t.Errorf("luaValueToGo(100) = %#v (%T), want int64(100)", got, got)
+	}
+}
+
+// TestLuaValueToSortable_OnlyWholeStringsAreNumeric pins that a string
+// is treated as numeric only when it parses entirely as a number — so
+// "1.2.0" and "3 blind mice" sort lexicographically rather than being
+// reduced to their numeric prefix (the old Sscanf("%f") behavior).
+func TestLuaValueToSortable_OnlyWholeStringsAreNumeric(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		wantIsNum bool
+		wantNum   float64
+	}{
+		{"pure integer", "42", true, 42},
+		{"pure float", "3.14", true, 3.14},
+		{"negative", "-5", true, -5},
+		{"whitespace padded", "  7  ", true, 7},
+		{"version string", "1.2.0", false, 0},
+		{"numeric prefix only", "3 blind mice", false, 0},
+		{"empty", "", false, 0},
+		{"trailing junk", "10px", false, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, num, isNum := luaValueToSortable(lua.LString(tc.in))
+			if isNum != tc.wantIsNum {
+				t.Errorf("luaValueToSortable(%q): isNum = %v, want %v", tc.in, isNum, tc.wantIsNum)
+			}
+			if isNum && num != tc.wantNum {
+				t.Errorf("luaValueToSortable(%q): num = %v, want %v", tc.in, num, tc.wantNum)
+			}
+		})
+	}
+}
+
+// TestSortEntries_VersionStringsAreLexicographic pins that version-like
+// strings (which the old Sscanf path mis-sorted as their integer prefix)
+// now sort lexicographically, end to end through sortEntries.
+func TestSortEntries_VersionStringsAreLexicographic(t *testing.T) {
+	entries := []sortableEntry{
+		{prop: lua.LString("1.10.0")},
+		{prop: lua.LString("1.2.0")},
+		{prop: lua.LString("1.9.0")},
+	}
+	sortEntries(entries, false)
+
+	// Lexicographic: "1.10.0" < "1.2.0" < "1.9.0" (since '1' < '2' < '9'
+	// at the char after "1."). The old numeric-prefix path would have
+	// treated all three as 1 and left them in input order.
+	want := []string{"1.10.0", "1.2.0", "1.9.0"}
+	for i, w := range want {
+		if got := entries[i].prop.String(); got != w {
+			t.Errorf("at %d: got %q, want %q", i, got, w)
+		}
+	}
+}
+
+func TestLuaNumberToGo_OutOfInt64RangeStaysFloat(t *testing.T) {
+	// A value larger than MaxInt64 cannot be an int64; must stay float64.
+	big := lua.LNumber(math.MaxFloat64)
+	if got := luaNumberToGo(big); got != math.MaxFloat64 {
+		t.Errorf("luaNumberToGo(MaxFloat64) = %#v (%T), want float64", got, got)
+	}
+}

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -17,6 +17,8 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1154,12 +1156,29 @@ func luaValueToGo(lv lua.LValue) interface{} {
 	return luaValueToGoSeen(lv, make(map[*lua.LTable]bool))
 }
 
+// luaNumberToGo converts a Lua number to the most faithful Go type.
+// gopher-lua has a single float64-backed number type, but a value that
+// is integral and fits in int64 round-trips better as an int64 — an
+// entity ID, a ticket number, or epoch-nanos would otherwise lose its
+// integer type (and re-serialize in exponential / trailing-.0 form). The
+// reverse direction (GoToLuaValue) already preserves int/int64, so this
+// closes the lossy leg. Non-integral or out-of-int64-range values stay
+// float64. (Integers beyond 2^53 can't be held by the float64 LNumber in
+// the first place, so this is type-faithful up to that ceiling.)
+func luaNumberToGo(n lua.LNumber) interface{} {
+	f := float64(n)
+	if f == math.Trunc(f) && f >= math.MinInt64 && f <= math.MaxInt64 {
+		return int64(f)
+	}
+	return f
+}
+
 func luaValueToGoSeen(lv lua.LValue, seen map[*lua.LTable]bool) interface{} {
 	switch v := lv.(type) {
 	case lua.LBool:
 		return bool(v)
 	case lua.LNumber:
-		return float64(v)
+		return luaNumberToGo(v)
 	case lua.LString:
 		return string(v)
 	case *lua.LTable:
@@ -1631,45 +1650,41 @@ func (r *Runtime) luaSortEntities(ls *lua.LState) int {
 	return 1
 }
 
-// sortEntries sorts entity entries by their property value using bubble sort.
+// sortEntries sorts entity entries by their property value. Stable so
+// entries with equal sort keys keep their input order.
 func sortEntries(entries []sortableEntry, descending bool) {
-	for i := range len(entries) - 1 {
-		for j := range len(entries) - i - 1 {
-			if shouldSwapEntries(entries[j].prop, entries[j+1].prop, descending) {
-				entries[j], entries[j+1] = entries[j+1], entries[j]
-			}
+	sort.SliceStable(entries, func(i, j int) bool {
+		if descending {
+			return entryLess(entries[j].prop, entries[i].prop)
 		}
-	}
+		return entryLess(entries[i].prop, entries[j].prop)
+	})
 }
 
-// shouldSwapEntries returns true if entries should be swapped for the desired order.
-func shouldSwapEntries(a, b lua.LValue, descending bool) bool {
+// entryLess reports whether a sorts before b. Two numeric values compare
+// numerically; otherwise both compare as strings.
+func entryLess(a, b lua.LValue) bool {
 	aStr, aNum, aIsNum := luaValueToSortable(a)
 	bStr, bNum, bIsNum := luaValueToSortable(b)
-
-	var aLess bool
 	if aIsNum && bIsNum {
-		aLess = aNum < bNum
-	} else {
-		aLess = aStr < bStr
+		return aNum < bNum
 	}
-
-	if descending {
-		return aLess // swap if a < b (we want larger first)
-	}
-	return !aLess && (aStr != bStr || aNum != bNum) // swap if a > b
+	return aStr < bStr
 }
 
-// luaValueToSortable converts a Lua value to sortable string and number representations.
+// luaValueToSortable converts a Lua value to sortable string and number
+// representations. A string is treated as numeric only when it parses
+// *entirely* as a number — strconv.ParseFloat over the trimmed value —
+// so "1.2.0" or "3 blind mice" sort lexicographically rather than being
+// silently reduced to their numeric prefix (1 and 3), which the old
+// fmt.Sscanf("%f") accepted.
 func luaValueToSortable(v lua.LValue) (str string, num float64, isNum bool) {
 	switch val := v.(type) {
 	case lua.LNumber:
 		return "", float64(val), true
 	case lua.LString:
 		s := string(val)
-		// Try to parse as number for numeric sorting
-		var n float64
-		if _, err := fmt.Sscanf(s, "%f", &n); err == nil {
+		if n, err := strconv.ParseFloat(strings.TrimSpace(s), 64); err == nil {
 			return s, n, true
 		}
 		return s, 0, false

--- a/tickets/entities/automated-measures/lua-numeric-fidelity-test.md
+++ b/tickets/entities/automated-measures/lua-numeric-fidelity-test.md
@@ -1,0 +1,9 @@
+---
+id: lua-numeric-fidelity-test
+type: automated-measure
+title: 'Test: Lua numeric type fidelity and whole-string sort'
+description: 'Regression for BUG-C97E5C: asserts integral Lua numbers convert to int64 (up to 2^53; out-of-range stays float64), and luaValueToSortable treats a string as numeric only when it parses entirely (so ''1.2.0''/''3 blind mice'' sort lexicographically). Fails if conversion reverts to always-float64 or sortable reverts to Sscanf prefix parsing.'
+kind: test
+location: internal/lua/numeric_test.go (TestLuaNumberToGo_PreservesIntegers, TestLuaValueToGo_IntegerNotFloat, TestLuaValueToSortable_OnlyWholeStringsAreNumeric, TestSortEntries_VersionStringsAreLexicographic, TestLuaNumberToGo_OutOfInt64RangeStaysFloat)
+status: active
+---

--- a/tickets/entities/bugs/BUG-C97E5C.md
+++ b/tickets/entities/bugs/BUG-C97E5C.md
@@ -1,0 +1,38 @@
+---
+id: BUG-C97E5C
+type: bug
+title: 'Lua numeric handling: integers lost to float64, version strings mis-sorted'
+description: Two latent numeric bugs in internal/lua/runtime.go. (1) luaValueToGo converted every Lua number to float64, so an integer value (entity ID, ticket number) lost its integer type on the Lua->Go boundary and re-serialized in trailing-.0 / exponential form; the reverse direction already preserved int/int64. (2) luaValueToSortable used fmt.Sscanf('%f'), which accepts a numeric *prefix*, so 'rela.sort_entities' treated version-like strings ('1.2.0') and 'numeric-prefix' strings ('3 blind mice') as their leading number (1, 3) and mis-sorted them. The sort also used a hand-rolled O(n^2) bubble sort.
+priority: medium
+why1: luaValueToGo had a single LNumber->float64 case, and luaValueToSortable used Sscanf which stops at the first non-numeric character.
+why2: gopher-lua's number type is float64-backed, so 'just cast to float64' looked correct, and Sscanf looked like a convenient numeric-parse without considering trailing junk.
+why3: The Lua<->Go conversion was written for the common case (round-tripping small floats/strings) without a round-trip test for integer-type fidelity or whole-string numeric parsing.
+why4: No test compared a version-like string sort or asserted integer type survived the boundary, so both stayed latent.
+why5: Numeric type fidelity across an embedded-language boundary has no single owner or convention; each conversion site decided ad hoc.
+prevention: luaValueToGo now converts an integral, in-int64-range Lua number to int64 (preserving integer type up to 2^53, the float64 integer ceiling) and keeps non-integral/out-of-range values as float64. luaValueToSortable uses strconv.ParseFloat over the trimmed whole string, so only fully-numeric strings sort numerically. The bubble sort is replaced with sort.SliceStable. Unit tests pin integer preservation, whole-string-only numeric detection, and lexicographic version-string ordering; the sortable cases fail without the fix.
+status: done
+---
+
+## Bug
+
+Found in the 2026-06-09 backend review (Minor / Lua-AI-scheduler). Two latent
+numeric bugs in `internal/lua/runtime.go`:
+
+1. **Integers collapse to float64 on Lua→Go** (`luaValueToGo`). The `LNumber` case did `return float64(v)`, so an integer property (entity ID, ticket number, epoch value) lost its integer *type* crossing the boundary and could re-serialize as `42.0` or in exponential form. `GoToLuaValue` already preserves `int`/`int64`, so only the reverse leg was lossy.
+
+2. **`luaValueToSortable` parses a numeric prefix, not the whole string** (`rela.sort_entities`). `fmt.Sscanf(s, "%f", &n)` succeeds on any string *starting* with a number, so `"1.2.0"` → `1` and `"3 blind mice"` → `3`. Version-like and prefix-numeric strings were sorted by their leading number instead of lexicographically. The sort itself was a hand-rolled O(n²) bubble sort.
+
+## Fix (PR pending)
+
+- `luaNumberToGo`: convert an integral, in-`int64`-range Lua number to `int64`; keep non-integral or out-of-range values as `float64`. This preserves integer type up to 2^53 (the float64 integer ceiling — beyond that gopher-lua's `LNumber` can't hold an integer faithfully anyway). No downstream code asserts `float64` on converted values; JSON marshals `int64` cleanly.
+- `luaValueToSortable`: `strconv.ParseFloat(strings.TrimSpace(s), 64)` — numeric only when the *whole* trimmed string parses. `"1.2.0"`/`"3 blind mice"` now sort lexicographically.
+- `sortEntries`: `sort.SliceStable` replaces the bubble sort (stable, O(n log n)).
+
+## Tests
+
+`internal/lua/numeric_test.go`: integer preservation (incl. 2^53 ceiling and
+out-of-range→float fallback), whole-string-only numeric detection
+(version/prefix/junk cases), and end-to-end lexicographic version-string
+ordering through `sortEntries`. The sortable cases verified to **fail without
+the fix**. Existing `TestSortEntities_*` (numeric, string, descending) still
+pass.

--- a/tickets/relations/BUG-C97E5C--adds-measure--lua-numeric-fidelity-test.md
+++ b/tickets/relations/BUG-C97E5C--adds-measure--lua-numeric-fidelity-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-C97E5C
+relation: adds-measure
+to: lua-numeric-fidelity-test
+---

--- a/tickets/relations/BUG-C97E5C--affects--lua-scripting.md
+++ b/tickets/relations/BUG-C97E5C--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: BUG-C97E5C
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/BUG-C97E5C--fixes--FEAT-i5ji.md
+++ b/tickets/relations/BUG-C97E5C--fixes--FEAT-i5ji.md
@@ -1,0 +1,5 @@
+---
+from: BUG-C97E5C
+relation: fixes
+to: FEAT-i5ji
+---

--- a/tickets/relations/lua-numeric-fidelity-test--protects--lua-scripting.md
+++ b/tickets/relations/lua-numeric-fidelity-test--protects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: lua-numeric-fidelity-test
+relation: protects
+to: lua-scripting
+---


### PR DESCRIPTION
## Summary

Two latent numeric bugs in `internal/lua/runtime.go` (review Minor batch):

1. **Integers collapse to float64 on Lua→Go.** `luaValueToGo`'s `LNumber` case did `return float64(v)`, so an integer property (entity ID, ticket number, epoch value) lost its integer type crossing the boundary and could re-serialize as `42.0` / exponential form. `GoToLuaValue` already preserves `int`/`int64` — only the reverse leg was lossy.
2. **`luaValueToSortable` parses a numeric *prefix*.** `fmt.Sscanf(s, "%f", &n)` succeeds on any string starting with a number, so `rela.sort_entities` sorted `"1.2.0"` as `1` and `"3 blind mice"` as `3`. The sort was also a hand-rolled O(n²) bubble sort.

## Fix

- `luaNumberToGo`: integral, in-`int64`-range Lua numbers → `int64`; non-integral or out-of-range → `float64`. Preserves integer type up to 2^53 (the float64 integer ceiling — beyond that gopher-lua's float64-backed `LNumber` can't hold an integer faithfully anyway, so the test documents that as the practical limit). No downstream code asserts `float64` on converted values; JSON marshals `int64` cleanly.
- `luaValueToSortable`: `strconv.ParseFloat(strings.TrimSpace(s), 64)` — numeric only when the *whole* string parses, so version/prefix strings sort lexicographically.
- `sortEntries`: `sort.SliceStable` replaces the bubble sort.

## Tests

`internal/lua/numeric_test.go`: integer preservation (2^53 ceiling, out-of-range→float fallback), whole-string-only numeric detection (version/prefix/junk), and end-to-end lexicographic version-string ordering. Sortable cases verified to **fail without the fix**; existing `TestSortEntities_*` still pass.

`go test ./...`, `golangci-lint`, and `just arch-lint` all pass.