### PR TITLE
fix(metamodel): reject fractional integers and empty relation from/to

### DIFF
--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -458,6 +458,18 @@ func validateRelationReferences(m *Metamodel) []string {
 	relNames := sortedKeys(m.Relations)
 	for _, name := range relNames {
 		rel := m.Relations[name]
+		// A relation with no 'from' or no 'to' types is meaningless: no
+		// entity can ever be a valid source/target, so any cardinality
+		// constraint on it is a silent no-op. Reject at load (likely a
+		// typo or an omitted field) rather than letting it pass quietly.
+		if len(rel.From) == 0 {
+			errs = append(errs, fmt.Sprintf(
+				"relation %q: must declare at least one 'from' entity type", name))
+		}
+		if len(rel.To) == 0 {
+			errs = append(errs, fmt.Sprintf(
+				"relation %q: must declare at least one 'to' entity type", name))
+		}
 		for _, fromType := range rel.From {
 			if _, ok := m.Entities[fromType]; !ok {
 				errs = append(errs, fmt.Sprintf(

--- a/internal/metamodel/validation.go
+++ b/internal/metamodel/validation.go
@@ -2,6 +2,7 @@ package metamodel
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -244,8 +245,20 @@ func (m *Metamodel) validatePropertyValue(propName string, propDef *PropertyDef,
 
 	case PropertyTypeInteger:
 		switch v := val.(type) {
-		case int, int64, float64:
-			// OK - YAML may parse integers as these types
+		case int, int64:
+			// OK
+		case float64:
+			// YAML parses bare integers (count: 3) as int, but a value
+			// with a fractional part (count: 3.5) arrives as float64.
+			// Accept only when it is integral — silently truncating 3.5
+			// to 3 would corrupt the value on a hand-edit typo.
+			if v != math.Trunc(v) {
+				return &ValidationError{
+					Type:     ValidationErrorInvalidValue,
+					Property: propName,
+					Message:  fmt.Sprintf("Invalid integer %v (must not have a fractional part)", v),
+				}
+			}
 		case string:
 			if _, err := strconv.Atoi(v); err != nil {
 				return &ValidationError{
@@ -542,7 +555,10 @@ func ParseDateValue(s string, propDef *PropertyDef) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("parsing time %q: cannot parse with format %q or common fallbacks", s, format)
 }
 
-// ParseIntegerValue parses an integer from various input types
+// ParseIntegerValue parses an integer from various input types. A
+// float64 is accepted only when it has no fractional part — truncating
+// 3.5 to 3 would silently corrupt the value (matching the integer
+// property-validation rule).
 func ParseIntegerValue(val interface{}) (int, error) {
 	switch v := val.(type) {
 	case int:
@@ -550,6 +566,9 @@ func ParseIntegerValue(val interface{}) (int, error) {
 	case int64:
 		return int(v), nil
 	case float64:
+		if v != math.Trunc(v) {
+			return 0, fmt.Errorf("invalid integer %v (must not have a fractional part)", v)
+		}
 		return int(v), nil
 	case string:
 		return strconv.Atoi(v)

--- a/internal/metamodel/validation_gaps_test.go
+++ b/internal/metamodel/validation_gaps_test.go
@@ -1,0 +1,95 @@
+package metamodel
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidatePropertyValue_IntegerRejectsFractional pins that an
+// integer property rejects a float with a fractional part rather than
+// silently truncating it (count: 3.5 must error, not become 3). An
+// integral float (3.0) is still accepted — YAML emits whole numbers as
+// int but a hand-edited "3.0" arrives as float64.
+func TestValidatePropertyValue_IntegerRejectsFractional(t *testing.T) {
+	meta := &Metamodel{}
+	propDef := &PropertyDef{Type: PropertyTypeInteger}
+
+	if err := meta.ValidatePropertyValue("count", propDef, 3.5); err == nil {
+		t.Error("expected error for fractional float 3.5 on an integer property")
+	}
+	if err := meta.ValidatePropertyValue("count", propDef, 3.0); err != nil {
+		t.Errorf("integral float 3.0 should be accepted, got: %v", err)
+	}
+}
+
+// TestParseIntegerValue_RejectsFractional pins the same rule at the
+// parse helper used by filter sort/match — a fractional float errors
+// rather than truncating.
+func TestParseIntegerValue_RejectsFractional(t *testing.T) {
+	if _, err := ParseIntegerValue(3.5); err == nil {
+		t.Error("expected error parsing fractional 3.5 as integer")
+	}
+	got, err := ParseIntegerValue(7.0)
+	if err != nil || got != 7 {
+		t.Errorf("ParseIntegerValue(7.0) = (%d, %v), want (7, nil)", got, err)
+	}
+}
+
+// TestValidateRelationReferences_RejectsEmptyFromTo pins that a relation
+// declaring no 'from' or no 'to' entity types is a load error — such a
+// relation is meaningless (no entity can be a valid endpoint) and any
+// cardinality constraint on it would be a silent no-op.
+func TestValidateRelationReferences_RejectsEmptyFromTo(t *testing.T) {
+	tests := []struct {
+		name    string
+		rel     RelationDef
+		wantSub string
+	}{
+		{
+			name:    "empty from",
+			rel:     RelationDef{From: nil, To: []string{"feature"}},
+			wantSub: "'from'",
+		},
+		{
+			name:    "empty to",
+			rel:     RelationDef{From: []string{"ticket"}, To: nil},
+			wantSub: "'to'",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Metamodel{
+				Entities: map[string]EntityDef{
+					"ticket":  {},
+					"feature": {},
+				},
+				Relations: map[string]RelationDef{"rel": tc.rel},
+			}
+			errs := validateRelationReferences(m)
+			found := false
+			for _, e := range errs {
+				if strings.Contains(e, "at least one") && strings.Contains(e, tc.wantSub) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected an 'at least one %s' error, got: %v", tc.wantSub, errs)
+			}
+		})
+	}
+}
+
+// TestValidateRelationReferences_AllowsPopulatedFromTo guards against
+// over-rejection: a relation with both endpoints declared (and existing)
+// produces no error.
+func TestValidateRelationReferences_AllowsPopulatedFromTo(t *testing.T) {
+	m := &Metamodel{
+		Entities: map[string]EntityDef{"ticket": {}, "feature": {}},
+		Relations: map[string]RelationDef{
+			"implements": {From: []string{"ticket"}, To: []string{"feature"}},
+		},
+	}
+	if errs := validateRelationReferences(m); len(errs) != 0 {
+		t.Errorf("a fully-populated relation should produce no errors, got: %v", errs)
+	}
+}

--- a/tickets/entities/automated-measures/metamodel-validation-gaps-test.md
+++ b/tickets/entities/automated-measures/metamodel-validation-gaps-test.md
@@ -1,0 +1,9 @@
+---
+id: metamodel-validation-gaps-test
+type: automated-measure
+title: 'Test: metamodel rejects fractional integers and empty relation from/to'
+description: 'Regression for BUG-70YIIU: asserts an integer property and ParseIntegerValue reject a fractional float (3.5) while accepting integral floats (3.0/7.0), and validateRelationReferences rejects a relation with empty from: or to: while allowing fully-populated relations. Fails if integer validation reverts to accepting any float64 or the relation check stops requiring non-empty from/to.'
+kind: test
+location: internal/metamodel/validation_gaps_test.go (TestValidatePropertyValue_IntegerRejectsFractional, TestParseIntegerValue_RejectsFractional, TestValidateRelationReferences_RejectsEmptyFromTo, TestValidateRelationReferences_AllowsPopulatedFromTo)
+status: active
+---

--- a/tickets/entities/bugs/BUG-70YIIU.md
+++ b/tickets/entities/bugs/BUG-70YIIU.md
@@ -1,0 +1,38 @@
+---
+id: BUG-70YIIU
+type: bug
+title: 'Metamodel validation: fractional integers truncated, empty relation from/to allowed'
+description: 'Two metamodel validation gaps. (1) An integer property accepted any float64 unconditionally and ParseIntegerValue did int(v), so a hand-edited ''count: 3.5'' validated and silently truncated to 3 instead of erroring. (2) validateRelationReferences only checked that listed from/to types exist, so a relation declaring empty from: or to: loaded cleanly — making any min/max cardinality constraint on it a silent no-op (a typo''d or half-written relation passes).'
+priority: medium
+why1: The integer validation switch had a bare 'case int, int64, float64' with no integral check, and ParseIntegerValue truncated via int(v); validateRelationReferences never checked len(rel.From)/len(rel.To).
+why2: YAML parses bare integers as int but a fractional literal as float64, and the float64 case was added to tolerate that without distinguishing 3.0 from 3.5; the relation check focused on unknown-type references and didn't consider the empty case.
+why3: Both validators handled the present/known cases and silently accepted the malformed-but-parseable ones rather than rejecting them.
+why4: No test fed a fractional integer or an empty-from/to relation, so both gaps stayed latent.
+why5: Schema validation had no convention of 'reject malformed-but-parseable at load' — each rule decided how strict to be ad hoc.
+prevention: Integer validation and ParseIntegerValue now reject a float64 with a fractional part (v != math.Trunc(v)); integral floats (3.0) still accepted. validateRelationReferences rejects a relation with len(from)==0 or len(to)==0 at load. Regression tests pin fractional rejection (validation + parse helper) and empty-from/to rejection (with a populated-relation guard against over-rejection); all fail without the fix. Full suite confirms no in-tree metamodel relied on either gap.
+status: done
+---
+
+## Bug
+
+Found in the 2026-06-09 backend review (Minor / Read-query). Two metamodel
+validation gaps:
+
+1. **Fractional integers silently truncate.** The integer property-type case (`validation.go`) accepted `float64` unconditionally, and `ParseIntegerValue` did `int(v)`. A hand-edited `count: 3.5` (YAML parses a fractional literal as `float64`) validated as integer **3** instead of erroring — silent data corruption on a typo.
+
+2. **Empty relation `from:`/`to:` allowed.** `validateRelationReferences` (`loader.go`) only checked that *listed* from/to types exist. A relation with `from: []` (or an omitted field) loaded cleanly, but no entity can ever be a valid endpoint — so any `min_outgoing`/`max_outgoing` cardinality constraint on it is a silent no-op. A typo'd or half-written relation passed validation.
+
+## Fix (PR pending)
+
+- Integer validation + `ParseIntegerValue`: reject a `float64` with a fractional part (`v != math.Trunc(v)`) with a clear message; integral floats (`3.0`) still accepted.
+- `validateRelationReferences`: reject a relation with `len(from)==0` or `len(to)==0` at load time.
+
+The full test suite confirms no in-tree metamodel (`tickets/`, `docs-project/`,
+fixtures) relied on either gap, so neither change breaks existing projects.
+
+## Tests
+
+`internal/metamodel/validation_gaps_test.go`: fractional rejection at both the
+property validator and the parse helper (with `3.0`/`7.0` accepted), and
+empty-`from`/empty-`to` rejection (plus a fully-populated-relation guard against
+over-rejection). All verified to **fail without the fix**.

--- a/tickets/relations/BUG-70YIIU--adds-measure--metamodel-validation-gaps-test.md
+++ b/tickets/relations/BUG-70YIIU--adds-measure--metamodel-validation-gaps-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-70YIIU
+relation: adds-measure
+to: metamodel-validation-gaps-test
+---

--- a/tickets/relations/BUG-70YIIU--affects--metamodel-types.md
+++ b/tickets/relations/BUG-70YIIU--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: BUG-70YIIU
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/BUG-70YIIU--fixes--FEAT-57oh.md
+++ b/tickets/relations/BUG-70YIIU--fixes--FEAT-57oh.md
@@ -1,0 +1,5 @@
+---
+from: BUG-70YIIU
+relation: fixes
+to: FEAT-57oh
+---

--- a/tickets/relations/metamodel-validation-gaps-test--protects--metamodel-types.md
+++ b/tickets/relations/metamodel-validation-gaps-test--protects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: metamodel-validation-gaps-test
+relation: protects
+to: metamodel-types
+---


### PR DESCRIPTION
## Summary

Two metamodel validation gaps (review Minor batch):

1. **Fractional integers silently truncate.** The integer property-type case accepted `float64` unconditionally and `ParseIntegerValue` did `int(v)`, so a hand-edited `count: 3.5` (YAML parses a fractional literal as `float64`) validated as integer **3** instead of erroring — silent data corruption on a typo.
2. **Empty relation `from:`/`to:` allowed.** `validateRelationReferences` only checked that *listed* from/to types exist. A relation with `from: []` (or an omitted field) loaded cleanly, but no entity can be a valid endpoint — so any `min_outgoing`/`max_outgoing` cardinality constraint on it is a silent no-op.

## Fix

- Integer validation + `ParseIntegerValue`: reject a `float64` with a fractional part (`v != math.Trunc(v)`); integral floats (`3.0`) still accepted.
- `validateRelationReferences`: reject a relation with `len(from)==0` or `len(to)==0` at load.

The full test suite confirms no in-tree metamodel (`tickets/`, `docs-project/`, fixtures) relied on either gap, so neither change breaks existing projects.

## Tests

`internal/metamodel/validation_gaps_test.go`: fractional rejection at the property validator and the parse helper (with `3.0`/`7.0` accepted), empty-`from`/empty-`to` rejection, and a fully-populated-relation guard against over-rejection. All verified to **fail without the fix**.

`go test ./...`, `golangci-lint`, and `just arch-lint` all pass.