### PR TITLE
test: hygiene batch — pin vacuous tests, git skip guard, fast timeout handlers (TKT-LR5HLB)

### DIFF
--- a/internal/ai/openai_test.go
+++ b/internal/ai/openai_test.go
@@ -361,8 +361,11 @@ func TestProvider_Chat_NetworkError(t *testing.T) {
 
 func TestProvider_Chat_Timeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Out-wait the client timeout, returning as soon as the client
-		// gives up so server.Close doesn't block on this handler.
+		// Out-wait the client's 50ms ctx deadline. The deadline only
+		// abandons the request (the keep-alive socket stays open), so
+		// r.Context() does NOT cancel when the client gives up — the
+		// cleanup below force-closes connections to unblock this select
+		// before server.Close.
 		select {
 		case <-time.After(500 * time.Millisecond):
 		case <-r.Context().Done():
@@ -371,7 +374,13 @@ func TestProvider_Chat_Timeout(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(canonicalSuccessBody))
 	}))
-	t.Cleanup(server.Close)
+	t.Cleanup(func() {
+		// CloseClientConnections cancels in-flight request contexts so
+		// the handler returns immediately; otherwise Close would wait
+		// out the 500ms timer.
+		server.CloseClientConnections()
+		server.Close()
+	})
 
 	cfg := &Config{
 		BaseURL:        server.URL + "/v1",

--- a/internal/ai/openai_test.go
+++ b/internal/ai/openai_test.go
@@ -360,8 +360,14 @@ func TestProvider_Chat_NetworkError(t *testing.T) {
 }
 
 func TestProvider_Chat_Timeout(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(500 * time.Millisecond)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Out-wait the client timeout, returning as soon as the client
+		// gives up so server.Close doesn't block on this handler.
+		select {
+		case <-time.After(500 * time.Millisecond):
+		case <-r.Context().Done():
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(canonicalSuccessBody))
 	}))

--- a/internal/entitymanager/manager_test.go
+++ b/internal/entitymanager/manager_test.go
@@ -535,24 +535,15 @@ func TestCreate_CascadeNoRecursion(t *testing.T) {
 		On:   automation.Trigger{Entity: []string{"checklist"}, Created: true},
 		Do:   []automation.Action{{Set: "status", Value: onRequirementMarker}},
 	}
-	mgr, _ := newManager(t, []automation.Automation{parentAuto, childAuto})
+	mgr, cs := newManager(t, []automation.Automation{parentAuto, childAuto})
 
 	// NOTE: childAuto WILL fire here, because the cascade's own
 	// Runner.Process re-evaluates the engine for cascade-created
 	// entities at the runner level — that's intentional (the
 	// recursion limit is MaxDepth). We're testing the *Manager-level*
 	// no-recursion: the cascade's createEntity does NOT loop back
-	// through Manager.CreateEntity, which would double-fire
-	// automation. To assert that, we count how many times the
-	// "set-status" action ran. With the bug, it would have fired
-	// twice (once via cascade's engine eval, once via Manager's), so
-	// updates would be higher.
-	//
-	// The simpler way to pin the Manager-level invariant: assert that
-	// the cascade-created entity arrived via createCore (which
-	// validates and writes once) — which means exactly one
-	// CreateEntity call per cascade-spawned entity. If Manager were
-	// recursively invoked, we'd see additional Create+Update pairs.
+	// through Manager.CreateEntity, which would re-dispatch the
+	// automation engine and double-fire childAuto.
 	e := entity.New("", "requirement")
 	e.SetString("title", "Parent")
 	result, err := mgr.CreateEntity(context.Background(), e, entity.CreateOptions{})
@@ -562,12 +553,20 @@ func TestCreate_CascadeNoRecursion(t *testing.T) {
 	if len(result.EntitiesCreated) != 1 {
 		t.Fatalf("EntitiesCreated len = %d, want 1", len(result.EntitiesCreated))
 	}
-	// The trigger entity is "requirement" — childAuto fires on the
-	// cascade-created checklist exactly once (through Runner), and
-	// updates that checklist's status. We tolerate that. The
-	// no-Manager-recursion invariant is that the test completes
-	// without exceeding MaxDepth (which would happen if Manager
-	// re-entered itself recursively).
+
+	// Pin the invariant through store-call counts. Single-dispatch
+	// shape: requirement create (1) + cascade checklist create (1) +
+	// childAuto's Set writing via the Create→conflict→Update upsert
+	// (1 create attempt + 1 update) = 3 creates, 1 update. If the
+	// cascade re-entered Manager.CreateEntity, childAuto would be
+	// dispatched a second time, adding another conflict-create +
+	// update pair (4/2).
+	if got := cs.creates.Load(); got != 3 {
+		t.Errorf("store CreateEntity calls = %d, want 3 (recursion would add a 4th)", got)
+	}
+	if got := cs.updates.Load(); got != 1 {
+		t.Errorf("store UpdateEntity calls = %d, want 1 (recursion would double-fire childAuto)", got)
+	}
 }
 
 // recordingScripts captures the mutator passed to Run so tests can

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -9,10 +9,21 @@ import (
 	"testing"
 )
 
+// requireGit skips the test when no git binary is on PATH — these
+// tests shell out to the real git, and failing instead of skipping
+// turns a missing tool into a false test failure.
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not found in PATH")
+	}
+}
+
 // setupTestRepo creates a temporary git repository for testing.
 // Uses t.TempDir() for automatic cleanup.
 func setupTestRepo(t *testing.T) string {
 	t.Helper()
+	requireGit(t)
 
 	dir := t.TempDir()
 
@@ -58,6 +69,7 @@ func setupTestRepo(t *testing.T) string {
 //nolint:unparam // remoteDir is returned for potential future use
 func setupTestRepoWithRemote(t *testing.T) (localDir, remoteDir string) {
 	t.Helper()
+	requireGit(t)
 
 	// Create "remote" (bare repo)
 	remoteDir = t.TempDir()

--- a/internal/lua/http_test.go
+++ b/internal/lua/http_test.go
@@ -247,8 +247,16 @@ func TestLuaHTTP_ConvenienceWithOpts(t *testing.T) {
 
 func TestLuaHTTP_TimeoutError(t *testing.T) {
 	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(2 * time.Second)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Out-wait the client's 0.1s timeout, but return as soon as
+		// the client gives up: server.Close blocks on in-flight
+		// handlers, so a fixed sleep here costs ~2s of wall time per
+		// run for nothing.
+		select {
+		case <-time.After(2 * time.Second):
+		case <-r.Context().Done():
+			return
+		}
 		_, _ = w.Write([]byte("too late"))
 	}))
 	t.Cleanup(server.Close)

--- a/internal/markdown/parser_test.go
+++ b/internal/markdown/parser_test.go
@@ -104,18 +104,14 @@ id: REQ-001
 This content should be part of body since frontmatter was never closed.
 `
 
+	// Unclosed frontmatter is a parse error: the body text gets
+	// consumed as (invalid) YAML. Previously this test accepted
+	// either outcome and pinned nothing.
 	doc, err := ParseDocument(content)
-	// The parser will attempt to parse unclosed frontmatter as YAML
-	// which will fail if it's not valid YAML
-	if err != nil {
-		// Error is expected since unclosed frontmatter with invalid YAML fails
-		return
+	if err == nil {
+		t.Fatalf("unclosed frontmatter must fail to parse, got doc %+v", doc)
 	}
-
-	// If it succeeds, verify the result
-	if doc == nil {
-		t.Fatal("doc should not be nil")
-	}
+	testutil.AssertStringContains(t, err.Error(), "frontmatter")
 }
 
 func TestFormatDocument(t *testing.T) {

--- a/internal/markdown/parser_test.go
+++ b/internal/markdown/parser_test.go
@@ -97,19 +97,22 @@ type: requirement
 	testutil.AssertEqual(t, doc.Content, "")
 }
 
-func TestParseDocument_UnclosedFrontmatter(t *testing.T) {
+func TestParseDocument_UnclosedFrontmatter_BodyIsInvalidYAML(t *testing.T) {
 	content := `---
 id: REQ-001
 
 This content should be part of body since frontmatter was never closed.
 `
 
-	// Unclosed frontmatter is a parse error: the body text gets
-	// consumed as (invalid) YAML. Previously this test accepted
-	// either outcome and pinned nothing.
+	// Without a closing ---, the splitter absorbs the whole document
+	// into the YAML block, so the prose body makes the YAML invalid
+	// and parsing fails. NOTE: this is not a general unclosed-
+	// frontmatter guarantee — an unclosed block whose remainder is
+	// all key:value lines parses cleanly. Previously this test
+	// accepted either outcome and pinned nothing.
 	doc, err := ParseDocument(content)
 	if err == nil {
-		t.Fatalf("unclosed frontmatter must fail to parse, got doc %+v", doc)
+		t.Fatalf("unclosed frontmatter with prose body must fail to parse, got doc %+v", doc)
 	}
 	testutil.AssertStringContains(t, err.Error(), "frontmatter")
 }

--- a/tickets/entities/implementation-checklists/IMPL-7P4MR2.md
+++ b/tickets/entities/implementation-checklists/IMPL-7P4MR2.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-7P4MR2
+type: implementation-checklist
+title: 'Implementation: Test hygiene batch: pin vacuous tests, git skip guard, context-aware timeout handlers'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-7P4MR2.md
+++ b/tickets/entities/implementation-checklists/IMPL-7P4MR2.md
@@ -2,43 +2,28 @@
 id: IMPL-7P4MR2
 type: implementation-checklist
 title: 'Implementation: Test hygiene batch: pin vacuous tests, git skip guard, context-aware timeout handlers'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] All four hygiene items implemented (cascade-count pin, frontmatter pin, requireGit guard, ctx-aware timeout handlers)
+- [x] Edge cases: AI ctx-deadline-vs-keepalive mechanics handled via CloseClientConnections (review finding); frontmatter boundary stated honestly
+- [x] Error handling — n/a (test-only)
 
 ## Test Quality
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- [x] Pins probed empirically before asserting (cascade 3/1 write counts; frontmatter deterministic error)
+- [x] Reviewer traced the cascade shape through the manager/cascade/upsert code paths and confirmed both the 3/1 pin and the 4/2 failure mode; coupling to the upsert shape matches existing house style (TestCreate_AutomationSetsStatus)
+- [x] requireGit completeness verified by reviewer: runCmd is the only binary exec, reachable only via the two guarded helpers; library-backed tests correctly unguarded; gitless-PATH simulation skips
 
 ## Manual Verification
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
-
-**Verification Evidence:**
-<!-- Document what you tested and the results -->
+- [x] Five packages green under `-race -count=2 -shuffle=on`; lint 0 issues; full `just ci` green
+- [x] Wall-time: lua timeout handler unblocks in µs on client close (verified by reviewer); AI handler unblocks via CloseClientConnections (timing verified post-fix)
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
-patterns extracted to a helper / constant / type where it sharpens the contract
-(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
-premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] No security issues; no silent failures; no debug code; probes removed

--- a/tickets/entities/planning-checklists/PLAN-G9GIMW.md
+++ b/tickets/entities/planning-checklists/PLAN-G9GIMW.md
@@ -1,0 +1,42 @@
+---
+id: PLAN-G9GIMW
+type: planning-checklist
+title: 'Planning: Test hygiene batch'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem understood — four review residues, all itemized in TKT-LR5HLB
+- [x] Scope defined; acceptance criteria: each weak test pins real behavior (probed first, not guessed), git suite skips cleanly without the binary, timeout handlers return on client cancellation
+
+## Research
+
+- [x] ~~/research~~ (N/A: xs hygiene)
+- [x] Probed before pinning: cascade write counts (3/1 via countingStore), unclosed-frontmatter outcome (deterministic error)
+
+## Approach
+
+- [x] Documented in ticket; alternatives: deleting the cascade test rejected — the invariant is real, the assertions were just missing
+
+## Security Considerations
+
+- [x] N/A (test-only)
+
+## Test Plan
+
+- [x] Five packages under `-race -count=2 -shuffle=on`; full `just ci` before PR
+
+## Risk Assessment
+
+- [x] Effort xs. Risk: pinned write-counts couple to the upsert pipeline shape — accepted; that coupling is the point (same pattern as the existing no-scan pin) and the comment explains the breakdown
+
+## Documentation Planning
+
+- [x] N/A
+
+## Design Review
+
+- [x] ~~/design-review~~ (N/A-with-substitute: items and approach enumerated and approved in session reviews)

--- a/tickets/entities/review-checklists/REV-3SZLUY.md
+++ b/tickets/entities/review-checklists/REV-3SZLUY.md
@@ -21,4 +21,5 @@ status: done
 
 - [x] Cascade 3/1 pin and 4/2 failure mode independently traced; requireGit completeness verified; lua handler unblock measured in µs
 
-**PR:** (added once created)
+**PR:** https://github.com/sourcehaven-bv/rela/pull/978 (auto-merge armed,
+tschmits requested)

--- a/tickets/entities/review-checklists/REV-3SZLUY.md
+++ b/tickets/entities/review-checklists/REV-3SZLUY.md
@@ -1,0 +1,24 @@
+---
+id: REV-3SZLUY
+type: review-checklist
+title: 'Review: Test hygiene batch'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] Five packages green under `-race -count=2 -shuffle=on`; lint 0 issues; full `just ci` green
+
+## Code Review
+
+- [x] `/code-review` run; reviewer traced the cascade pipeline, simulated a gitless PATH, instrumented both timeout handlers
+- [x] Findings: 0 critical, 1 significant (AI ctx branch was dead code due to ctx-deadline-vs-keepalive mechanics — fixed via CloseClientConnections, instrumented before and after), 1 minor (frontmatter name overpromised — renamed with boundary documented) — RR-ZLDVOY, RR-2M9QDD
+- [x] All critical/significant findings addressed
+
+## Verification
+
+- [x] Cascade 3/1 pin and 4/2 failure mode independently traced; requireGit completeness verified; lua handler unblock measured in µs
+
+**PR:** (added once created)

--- a/tickets/entities/review-responses/RR-2M9QDD.md
+++ b/tickets/entities/review-responses/RR-2M9QDD.md
@@ -1,0 +1,9 @@
+---
+id: RR-2M9QDD
+type: review-response
+title: Frontmatter test name overpromised a general guarantee
+finding: 'Reviewer probed: an unclosed frontmatter block whose remainder is all key:value lines parses cleanly — the failure is specific to a prose body making the absorbed YAML invalid, not a general unclosed-frontmatter property.'
+severity: minor
+resolution: Renamed to TestParseDocument_UnclosedFrontmatter_BodyIsInvalidYAML with a comment stating the boundary explicitly.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ZLDVOY.md
+++ b/tickets/entities/review-responses/RR-ZLDVOY.md
@@ -1,0 +1,9 @@
+---
+id: RR-ZLDVOY
+type: review-response
+title: AI timeout handler's ctx branch was dead code — comment claimed a win it didn't deliver
+finding: 'Reviewer instrumented it: the AI test''s client gives up via a 50ms context deadline, which abandons the request but leaves the keep-alive socket open — r.Context() never cancels, so the select arm was unreachable and server.Close still waited out the timer (verified with a 30s timer: blocked 29.95s). The lua test''s mechanism (client Timeout) genuinely closes the connection and was fine.'
+severity: significant
+resolution: Cleanup now calls server.CloseClientConnections() before Close — force-closing cancels in-flight request contexts, making the select branch live regardless of how the client gave up. Handler comment rewritten to state the actual mechanics. Timing verified.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-LR5HLB.md
+++ b/tickets/entities/tickets/TKT-LR5HLB.md
@@ -5,7 +5,7 @@ title: 'Test hygiene batch: pin vacuous tests, git skip guard, context-aware tim
 kind: test
 priority: low
 effort: xs
-status: in-progress
+status: done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-LR5HLB.md
+++ b/tickets/entities/tickets/TKT-LR5HLB.md
@@ -1,0 +1,30 @@
+---
+id: TKT-LR5HLB
+type: ticket
+title: 'Test hygiene batch: pin vacuous tests, git skip guard, context-aware timeout handlers'
+kind: test
+priority: low
+effort: xs
+status: in-progress
+---
+
+## Problem
+
+Four small residues from the test-quality review:
+
+1. `TestCreate_CascadeNoRecursion` (entitymanager) contained a long comment walking back its own assertion strategy and pinned almost nothing beyond "completes without error".
+2. `TestParseDocument_UnclosedFrontmatter` (markdown) accepted *either* error or success — it pinned no behavior at all.
+3. `internal/git` tests fail (rather than skip) on machines without a `git` binary.
+4. Two timeout tests waste ~2.5s of wall time per run: their `httptest` handlers sleep a fixed duration, and `server.Close` blocks on the in-flight handler long after the client under test has timed out.
+
+## Approach (agreed with reviewer in session)
+
+1. Cascade test: pin the no-Manager-recursion invariant through `countingStore` call counts — single-dispatch shape is exactly 3 creates / 1 update (requirement + cascade checklist + childAuto's Set via the Create→conflict→Update upsert); Manager re-entry would add a conflict-create+update pair (4/2). Counts probed empirically before pinning.
+2. Unclosed frontmatter: deterministic parse error (probed) — assert error containing "frontmatter".
+3. `requireGit(t)` LookPath guard in both repo-setup helpers → skip, not fail.
+4. Handlers select on `r.Context().Done()` alongside the timer — return as soon as the client gives up, so `server.Close` doesn't block.
+
+## Verification
+
+- All five touched packages green under `-race -count=2 -shuffle=on`; lint 0 issues.
+- Timeout test packages: lua 0.8s / ai 0.9s for the targeted runs (was ~2s+ extra in Close).

--- a/tickets/relations/TKT-LR5HLB--affects--test-isolation.md
+++ b/tickets/relations/TKT-LR5HLB--affects--test-isolation.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5HLB
+relation: affects
+to: test-isolation
+---

--- a/tickets/relations/TKT-LR5HLB--has-implementation--IMPL-7P4MR2.md
+++ b/tickets/relations/TKT-LR5HLB--has-implementation--IMPL-7P4MR2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5HLB
+relation: has-implementation
+to: IMPL-7P4MR2
+---

--- a/tickets/relations/TKT-LR5HLB--has-planning--PLAN-G9GIMW.md
+++ b/tickets/relations/TKT-LR5HLB--has-planning--PLAN-G9GIMW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5HLB
+relation: has-planning
+to: PLAN-G9GIMW
+---

--- a/tickets/relations/TKT-LR5HLB--has-review--REV-3SZLUY.md
+++ b/tickets/relations/TKT-LR5HLB--has-review--REV-3SZLUY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5HLB
+relation: has-review
+to: REV-3SZLUY
+---

--- a/tickets/relations/TKT-LR5HLB--has-review-response--RR-2M9QDD.md
+++ b/tickets/relations/TKT-LR5HLB--has-review-response--RR-2M9QDD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5HLB
+relation: has-review-response
+to: RR-2M9QDD
+---

--- a/tickets/relations/TKT-LR5HLB--has-review-response--RR-ZLDVOY.md
+++ b/tickets/relations/TKT-LR5HLB--has-review-response--RR-ZLDVOY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5HLB
+relation: has-review-response
+to: RR-ZLDVOY
+---

--- a/tickets/relations/TKT-LR5HLB--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-LR5HLB--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LR5HLB
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Last item from the test-quality review queue (full ticket flow in tickets/, TKT-LR5HLB). Four small fixes:

1. **`TestCreate_CascadeNoRecursion` actually asserts something now.** It carried a comment walking back its own strategy and pinned little beyond "completes". Now pins the no-Manager-recursion invariant via `countingStore`: single-dispatch is exactly 3 creates / 1 update (requirement + cascade checklist + childAuto's Set through the Create→conflict→Update upsert); Manager re-entry would double-dispatch → 4/2. Counts probed empirically; reviewer independently traced the pipeline and confirmed both shapes.
2. **`TestParseDocument_UnclosedFrontmatter` pinned nothing** (accepted error *or* success). Now pins the deterministic parse error — renamed `..._BodyIsInvalidYAML` after the reviewer probed the boundary: an unclosed block whose remainder is all `key: value` lines parses cleanly, so the general claim would overpromise. The comment states the boundary.
3. **`internal/git` skips instead of failing without a git binary** (`requireGit` LookPath guard in both setup helpers; reviewer verified `runCmd` is the only binary exec and simulated a gitless PATH — clean skips, and the go-git-library tests correctly stay unguarded).
4. **Timeout tests stop burning wall time in `server.Close`.** The lua handler now returns the instant the client's timeout closes the connection (measured in µs). The AI case was subtler — the review caught that its ctx-aware branch was *dead code*: a client context deadline abandons the request but leaves the keep-alive socket open, so `r.Context()` never cancels (instrumented: a 30s timer blocked Close for 29.95s). Fixed by `CloseClientConnections()` in cleanup, which cancels in-flight request contexts regardless of how the client gave up.

## Review

Cranky review: 0 critical, 1 significant (the dead ctx branch — fixed and re-instrumented), 1 minor (test rename). RR-ZLDVOY, RR-2M9QDD linked.

## Verification

Five touched packages green under `-race -count=2 -shuffle=on`; lint 0 issues; full `just ci` green.