### PR TITLE
tickets: validation-mode decision (DEC-OYV2AK) + A7 re-scope

### DIFF
--- a/tickets/entities/decisions/DEC-OYV2AK.md
+++ b/tickets/entities/decisions/DEC-OYV2AK.md
@@ -1,0 +1,42 @@
+---
+id: DEC-OYV2AK
+type: decision
+title: 'Per-deployment validation mode: advisory (default) vs strict (opt-in, blocks on error)'
+context: |-
+    DEC-HWZHA established that write APIs tolerate temporarily invalid data: soft conditions (required-missing, type mismatch, invalid enum, target-type mismatch, unknown meta keys) ride along as 200+warnings rather than 422, because the filesystem store is edited freely by git/editors/scripts and the API rejecting a state the filesystem tolerates is a hostile asymmetry. That reasoning is correct *for the filesystem deployment model*.
+
+    Two newer capabilities change the calculus for a subset of deployments: (1) the postgres backend removes the filesystem hand-edit channel, and (2) ACL adds real server-side gating. For a managed/networked deployment where the data-entry write path is the mandatory chokepoint (confirmed: internal/entitymanager/CLAUDE.md mandates all writes go through Manager; Lua/MCP/automations all call Manager.{Create,Update,...}), a hard block on validation errors buys a *real* invariant rather than a false one. Such deployments want typical web-form behavior: block on error, show warning.
+
+    The naive move — tie blocking to the postgres build tag — is wrong: it bakes a deployment assumption into a compile-time flag, and a postgres instance could still have non-UI writers. Blocking must be an explicit per-deployment policy, not a per-backend behavior.
+consequences: |-
+    ## The mode
+
+    A deployment-level config `validation: advisory | strict` (default `advisory`). It shifts where entitymanager's existing hard/soft partition line sits — it does NOT introduce a new mechanism.
+
+    - **advisory** (default): unchanged from DEC-HWZHA. Only structural-impossibility is hard (422); required-missing / type-mismatch / invalid-enum / analyze-style conditions ride as 200+warnings. Filesystem and dogfooding deployments stay here.
+    - **strict** (opt-in): error-severity validation failures join the `hard` partition → the existing `newValidationError` → 422 path that structural errors already use. Warning-severity conditions still ride as 200+warnings.
+
+    ## Severity rule (which property-level failures are 'error' in strict mode)
+
+    Guiding principle: **if the data-entry UI's own controls make a state unreachable through normal use, that state arriving on a write is an error in strict mode** (it implies a non-UI writer or a stale client). By that rule:
+    - ERROR (block in strict): required-missing, type-mismatch, invalid-enum. An out-of-enum value is impossible to produce via a `<select>`, so its presence is a defect, not an in-progress edit.
+    - WARNING (ride along, both modes): the analyze-only relational conditions DEC-HWZHA enumerates — target-type mismatch, missing target, unknown/required-unset meta keys — because the UI *can* legitimately produce them mid-edit.
+
+    ## Relationship to DEC-HWZHA
+
+    This AMENDS, not reverses, DEC-HWZHA. advisory mode IS DEC-HWZHA verbatim and stays the default. DEC-HWZHA's caution that 'auto-save per-field feedback crept into the wire layer instead of staying a UI concern' is honored: warnings remain a UI concern in both modes; only error-severity blocking moves to the wire, and only when a deployment explicitly opts in.
+
+    ## Mechanism already exists
+
+    The 422 → ProblemDetail.errors[] → SPA path is how structural errors surface today (entitymanager/core.go partitionValidationErrors → newValidationError; dataentry ProblemDetail; SPA ApiError.validationErrors from PR #960). Strict mode routes more failures down the existing chute; the backend change is localized to the partition function + a config key + the property-severity semantics.
+
+    ## Frontend is mode-agnostic and can ship first
+
+    The SPA work (render warnings amber/non-blocking + clearing on clean save; render 422 validation errors as per-field blocking errors that prevent the green saved-state) is identical whether or not strict mode is ever built — it just renders the severity the server sends. Doing it now makes the SPA forward-compatible; the backend strict-mode work is a separate ticket on its own timeline.
+
+    ## Out of scope
+
+    Multi-tenant per-project mode (this is per-deployment), and making advisory deployments any stricter. ACL gating is orthogonal and already hard.
+date: "2026-06-13"
+status: accepted
+---

--- a/tickets/entities/features/FEAT-13863O.md
+++ b/tickets/entities/features/FEAT-13863O.md
@@ -1,0 +1,7 @@
+---
+id: FEAT-13863O
+type: feature
+title: Validation severity surfacing + opt-in strict (blocking) mode
+description: 'Surface validation severity correctly on the data-entry write path and let a deployment opt into blocking on errors. Two pieces with a clean seam (the 422 ProblemDetail contract): (1) frontend renders warnings amber/non-blocking and 422 validation errors as per-field blocking errors — model-agnostic, ships first; (2) backend `validation: advisory|strict` config that shifts entitymanager''s hard/soft partition so error-severity failures 422 in strict mode. Implements DEC-OYV2AK (which amends DEC-HWZHA).'
+status: in-progress
+---

--- a/tickets/entities/tickets/TKT-1ARGYN.md
+++ b/tickets/entities/tickets/TKT-1ARGYN.md
@@ -1,0 +1,26 @@
+---
+id: TKT-1ARGYN
+type: ticket
+title: 'Frontend: surface autosave validation warnings + 422 errors per-field (A7)'
+kind: enhancement
+priority: medium
+effort: m
+status: ready
+---
+
+Re-scoped A7 (was "surface autosave validation warnings"). Model-agnostic
+frontend half of FEAT-13863O / DEC-OYV2AK — renders the severity the server
+sends, forward-compatible with strict mode without depending on it.
+
+**Warnings (amber, non-blocking) — needed in all modes**
+- `useAutoSave` already routes server 200+warnings into `fieldWarnings` / `contentWarning` / `relationWarnings` (computeds, exported) but NOTHING renders them — the soft-validation contract is dark on the main edit path.
+- LIVE BUG: `categorizeWarnings` early-returns on an empty warnings array (core path src/composables/useAutoSave.ts:454), so a clean follow-up save never clears a stale warning. Fix: reset the relevant channel's warnings each successful save.
+- FieldShell gains a `warning?: string` prop rendered amber (no `has-error` red border); FieldRenderer passes it through; DynamicForm binds `autoSave.fieldWarnings[prop]`. Content warning under MarkdownEditor; relation warnings on the RelationCards/RelationPicker widget headers via the existing widgetId keys.
+- Precedence: client/server error wins the prominent slot; warning shows only when no error.
+
+**Errors (red, blocking) — makes the SPA strict-mode-ready**
+- A 422 already flows through ApiError.validationErrors (PR #960). Bind it to the per-field error slot so a strict-mode 422 shows as a blocking per-field error and prevents the green saved-state on the autosave path (a 422 means the keystroke did NOT persist).
+- RR-K4AU69 reversal: KEEP and WIRE DynamicForm's `validationErrors` branch (earlier deferred as 'dead'). It becomes live under strict mode — ProblemDetail.errors[] IS populated when strict 422s.
+
+Worth running the app to tune the amber visual rather than shipping on tests
+alone. Independent of the Colada migration arc (touches forms, not lists).

--- a/tickets/entities/tickets/TKT-TXTMB0.md
+++ b/tickets/entities/tickets/TKT-TXTMB0.md
@@ -1,0 +1,27 @@
+---
+id: TKT-TXTMB0
+type: ticket
+title: 'Backend: validation: advisory|strict config that blocks on error-severity (DEC-OYV2AK)'
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+Backend half of FEAT-13863O / DEC-OYV2AK. Opt-in per-deployment `validation:
+advisory|strict` (default advisory = today's DEC-HWZHA behavior verbatim).
+
+**Mechanism (localized)**
+- entitymanager/core.go already does `hard, soft := partitionValidationErrors(errs); if len(hard) > 0 { return newValidationError(hard) }; warnings = soft`. Strict mode moves error-severity property failures into the `hard` partition so they hit the existing 422 → ProblemDetail.errors[] path that structural errors already use. No new mechanism.
+- New deployment config key `validation: advisory|strict`. NOT tied to the postgres build tag (a postgres instance can still have non-UI writers; blocking is a deployment policy, not a backend behavior).
+
+**Property-severity semantics (the real decision, per DEC-OYV2AK)**
+- Rule: a state the data-entry UI's controls can't produce through normal use is ERROR in strict mode.
+- ERROR (block in strict): required-missing, type-mismatch, invalid-enum (a `<select>` can't emit out-of-enum).
+- WARNING (ride along, both modes): the analyze-only relational conditions DEC-HWZHA enumerates (target-type mismatch, missing target, unknown/required-unset meta keys).
+- Note: write-path checks (Meta.ValidateEntity) don't currently carry a severity tag the way custom rules do — this ticket adds/derives that classification.
+
+**Out of scope:** the frontend rendering (separate A7 ticket, ships first and is
+mode-agnostic); per-project mode; touching advisory deployments. Blocked-by the
+frontend ticket only in the sense that shipping strict without the UI rendering
+422s would be a poor experience — but they're independently mergeable.

--- a/tickets/relations/DEC-OYV2AK--decides--data-entry-server.md
+++ b/tickets/relations/DEC-OYV2AK--decides--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: DEC-OYV2AK
+relation: decides
+to: data-entry-server
+---

--- a/tickets/relations/FEAT-13863O--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-13863O--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-13863O
+relation: requires
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-1ARGYN--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-1ARGYN--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1ARGYN
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-1ARGYN--implements--FEAT-13863O.md
+++ b/tickets/relations/TKT-1ARGYN--implements--FEAT-13863O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1ARGYN
+relation: implements
+to: FEAT-13863O
+---

--- a/tickets/relations/TKT-TXTMB0--affects--data-entry-server.md
+++ b/tickets/relations/TKT-TXTMB0--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TXTMB0
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-TXTMB0--depends-on--TKT-1ARGYN.md
+++ b/tickets/relations/TKT-TXTMB0--depends-on--TKT-1ARGYN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TXTMB0
+relation: depends-on
+to: TKT-1ARGYN
+---

--- a/tickets/relations/TKT-TXTMB0--implements--FEAT-13863O.md
+++ b/tickets/relations/TKT-TXTMB0--implements--FEAT-13863O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TXTMB0
+relation: implements
+to: FEAT-13863O
+---


### PR DESCRIPTION
Planning/design entities from the A7 discussion — no code, just the tickets graph for the validation-severity work.

**DEC-OYV2AK** — *Per-deployment validation mode: advisory (default) vs strict (opt-in, blocks on error)*. Amends (does not reverse) DEC-HWZHA: advisory mode is DEC-HWZHA verbatim and stays default; a deployment may opt into `strict` where error-severity validation failures 422 via entitymanager's existing hard/soft partition. Severity rule: a state the data-entry UI can't produce through normal use (required-missing, type-mismatch, invalid-enum) is an error in strict mode; analyze-only relational conditions stay warnings. Motivated by the postgres+ACL networked model having a single confirmed write chokepoint (entitymanager), so a hard block buys a real invariant. Decision deliberately ties blocking to a config key, not the postgres build tag.

**FEAT-13863O** — the capability, split at the 422 ProblemDetail seam.

**TKT-1ARGYN** (ready) — frontend half (re-scoped A7): render warnings amber/non-blocking + clear-on-clean-save (fixes the `categorizeWarnings` early-return bug), and bind 422 `validationErrors` to a per-field blocking error slot. Model-agnostic — renders whatever severity the server sends, so it's forward-compatible with strict mode without depending on it. Reverses RR-K4AU69 (the "dead" branch becomes live under strict). Ships first.

**TKT-TXTMB0** (backlog, depends-on TKT-1ARGYN) — backend half: `validation: advisory|strict` config shifting the partition line + property-severity classification. Its own ticket on its own timeline.

Implements the analysis from the session discussion; the full rationale (including why blocking-per-build-tag is wrong and why the chokepoint check matters) is in DEC-OYV2AK's context/consequences.