### PR TITLE
fix(acl): gate _views read path (TKT-BNX2PN)

### DIFF
--- a/internal/dataentry/acl_views_test.go
+++ b/internal/dataentry/acl_views_test.go
@@ -1,0 +1,72 @@
+package dataentry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// viewsAs drives handleV1Views directly with a gated context, mirroring
+// getEntityAs (the GET-entity equivalent). The middleware is bypassed in
+// unit tests, so gateCtxFor attaches the readGate the handler reads.
+func viewsAs(ctx context.Context, t *testing.T, app *App, d *acl.Declarative,
+	entityType, entityID string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/_views/"+entityType+"/"+entityID, http.NoBody)
+	req = req.WithContext(gateCtxFor(ctx, t, d))
+	rec := httptest.NewRecorder()
+	app.handleV1Views(rec, req)
+	return rec
+}
+
+// TestACLViews_GatesHiddenEntity pins TKT-BNX2PN: _views is an entity-read
+// chokepoint and MUST respect the per-entity read gate. A principal who can
+// read tickets sees the view; one who cannot gets 404 with the same not_found
+// shape as a missing id — never the title or content body of a hidden entity.
+func TestACLViews_GatesHiddenEntity(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-001", Type: "ticket",
+		Properties: map[string]any{"title": "secret ticket"},
+		Content:    "confidential body",
+	})
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	// Visible: alice may read tickets.
+	rec := viewsAs(aliceCtx(), t, app, d, "ticket", "TKT-001")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("alice _views: got %d, want 200; body=%s", rec.Code, rec.Body)
+	}
+
+	// Denied: bob holds no role → DenyAll on ticket. Must 404, and the body
+	// must NOT leak the title or content body.
+	rec = viewsAs(principalCtx("bob"), t, app, d, "ticket", "TKT-001")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("bob _views (denied): got %d, want 404; body=%s", rec.Code, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), "/errors/not_found") {
+		t.Errorf("deny body missing not_found error code: %s", rec.Body)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "secret ticket") || strings.Contains(body, "confidential body") {
+		t.Errorf("LEAK: denied _views response exposed entity title/content: %s", body)
+	}
+
+	// A denied id is indistinguishable from a hidden one (404 not_found); the
+	// gate runs BEFORE executeView so the denied principal never reaches the
+	// view pipeline (which would otherwise 422 on a missing entity and leak a
+	// different shape). For an *allowed* type the existing missing-entity path
+	// (executeView → 422) is unchanged and out of scope for this gate.
+}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -3432,6 +3432,15 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ACL gate (TKT-BNX2PN): _views is an entity-read chokepoint just like
+	// GET /{plural}/{id} — it serves _title, properties, and content body via
+	// executeView + serializeEntityForWire. Gate BEFORE executeView so a hidden
+	// id is indistinguishable from a missing one (404, no oracle) and the view
+	// pipeline never runs for a denied principal.
+	if !a.gateReadOrNotFound(w, r, entityType, entityID) {
+		return
+	}
+
 	viewCfg, ok := findViewByEntityType(s.Cfg.Views, entityType)
 	if !ok {
 		viewCfg, ok = buildDefaultViewConfig(s.Meta, entityType)

--- a/tickets/entities/implementation-checklists/IMPL-WXAUMB.md
+++ b/tickets/entities/implementation-checklists/IMPL-WXAUMB.md
@@ -1,0 +1,43 @@
+---
+id: IMPL-WXAUMB
+type: implementation-checklist
+title: 'Implementation: Gate _views read path through the ACL read gate (TKT-VQGN follow-through)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (TestACLViews_GatesHiddenEntity)
+- [x] Integration tests written — the test drives handleV1Views end-to-end through the gated context
+- [x] Happy path implemented (gateReadOrNotFound before executeView)
+- [x] ~~Edge cases from planning handled~~ (N/A: speed-run refactor, no planning phase; the gate's own edge cases — denied/missing/visible — are covered in the test)
+- [x] Error handling in place (deny → 404, store failure → writeGateError — same as handleV1GetEntity)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data (seedEntity, mustNewACL)
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] ~~Interpolated values constructed from objects~~ (N/A: assertions check a fixed not_found code + leak markers)
+- [x] ~~Property comparisons use original object~~ (N/A: test asserts absence of leaked title/content, not property equality)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (live pen-test `.ignored/acl-pentest`: mallory `_views` → 404 after fix; full disclosure before)
+- [x] Each acceptance criterion verified with test scenario
+- [x] Edge cases manually verified (visible→200, denied→404 no leak)
+
+**Verification Evidence:**
+Before fix: `GET /api/v1/_views/ticket/TKT-1` as a zero-grant principal returned
+the full entity incl. content body. After fix: 404 not_found, no title/content
+in the body. Confirmed against the live Caddy-fronted server and the unit test.
+
+## Quality
+
+- [x] Code follows project patterns (reuses gateReadOrNotFound, the established read-chokepoint helper)
+- [x] ~~DRY opportunities~~ (N/A: the shared helper already exists; this calls it)
+- [x] No security issues introduced (this closes one)
+- [x] No silent failures (deny → explicit 404; store error → writeGateError)
+- [x] No debug code left behind

--- a/tickets/entities/review-checklists/REV-SQ3WRH.md
+++ b/tickets/entities/review-checklists/REV-SQ3WRH.md
@@ -1,0 +1,55 @@
+---
+id: REV-SQ3WRH
+type: review-checklist
+title: 'Review: Gate _views read path through the ACL read gate (TKT-VQGN follow-through)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — dataentry package green incl. new test
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [x] ~~Run `/code-review`~~ (N/A: speed-run; self-reviewed — one-line gate call mirroring 8 existing gateReadOrNotFound chokepoints)
+- [x] ~~All critical review-responses addressed~~ (N/A: none raised)
+- [x] ~~All significant review-responses addressed~~ (N/A: none raised)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** none
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (denied→404 no leak; visible→200)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:** PASS — TestACLViews_GatesHiddenEntity asserts a denied
+principal gets 404 with no title/content, and a permitted one gets 200.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created~~ (N/A: internal refactor, kind=refactor)
+- [x] ~~User-facing documentation updated~~ (N/A: no user-facing change)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+**Docs Checklist:** N/A (refactor)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` flow to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** _(filled in the PR-recording commit)_

--- a/tickets/entities/tickets/TKT-BNX2PN.md
+++ b/tickets/entities/tickets/TKT-BNX2PN.md
@@ -1,0 +1,23 @@
+---
+id: TKT-BNX2PN
+type: ticket
+title: Gate _views read path through the ACL read gate (TKT-VQGN follow-through)
+kind: refactor
+priority: high
+effort: s
+status: done
+---
+
+handleV1Views (GET /api/v1/_views/{type}/{id}) serves the full entity —
+`_title`, properties, and **content body** — via executeView +
+serializeEntityForWire with NO read-gate check, so any authenticated principal
+reads any entity by id regardless of ACL. This is read-side coverage TKT-VQGN
+established for handleV1GetEntity (gateReadOrNotFound) but never extended to the
+auxiliary `_views` endpoint.
+
+Confirmed in a live pen-test: a zero-grant principal read TKT-1's title and
+content body via `_views` while GET /tickets/TKT-1 correctly 404'd.
+
+**Fix:** call `gateReadOrNotFound(w, r, entityType, entityID)` after the
+entity-type check, before executeView. Add a read-gate test asserting a hidden
+id returns 404. Highest severity of the four findings (full content disclosure).

--- a/tickets/relations/TKT-BNX2PN--affects--authorization.md
+++ b/tickets/relations/TKT-BNX2PN--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BNX2PN
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-BNX2PN--has-implementation--IMPL-WXAUMB.md
+++ b/tickets/relations/TKT-BNX2PN--has-implementation--IMPL-WXAUMB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BNX2PN
+relation: has-implementation
+to: IMPL-WXAUMB
+---

--- a/tickets/relations/TKT-BNX2PN--has-review--REV-SQ3WRH.md
+++ b/tickets/relations/TKT-BNX2PN--has-review--REV-SQ3WRH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BNX2PN
+relation: has-review
+to: REV-SQ3WRH
+---

--- a/tickets/relations/TKT-BNX2PN--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-BNX2PN--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BNX2PN
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
## What

`GET /api/v1/_views/{type}/{id}` (`handleV1Views`) served the full entity — `_title`, properties, and **content body** — via `executeView` + `serializeEntityForWire` with **no read-gate check**. Any authenticated principal could read any entity by id regardless of ACL.

Found by a full-API-surface pen-test (`.ignored/acl-pentest`): a zero-grant principal read a hidden ticket's title and content body via `_views`, while `GET /tickets/{id}` correctly returned 404.

## Fix

Route `_views` through the existing `gateReadOrNotFound` helper (the same chokepoint guard TKT-VQGN added for `handleV1GetEntity`), placed **before** `executeView` so a hidden id is indistinguishable from a missing one and the view pipeline never runs for a denied principal.

## Test

`TestACLViews_GatesHiddenEntity`: visible→200, denied→404 with no title/content leak.

## Stack

First of 4 stacked PRs closing the same bug class on the auxiliary read endpoints (`_views` → `_sidepanel` → `_documents` → `_analyze`). Ticket TKT-BNX2PN.

Closes the highest-severity finding (full content disclosure).