### PR TITLE
feat(lua): expose read-only rela.principal for write-path authorship (TKT-5U6NRR)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -492,6 +492,7 @@ deps:
       - ai
       - filter
       - metamodel
+      - principal
       - search
       - secrets
       - store
@@ -517,6 +518,7 @@ deps:
       - autocascade
       - lua
       - metamodel
+      - principal
       - project
   search:
     mayDependOn:

--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -699,6 +699,7 @@ error-handling branches work unchanged.
 | `rela.today` | Current date as "YYYY-MM-DD" |
 | `rela.params` | Action script parameters (table, static string-valued map from data-entry config) |
 | `rela.secrets` | Per-script secrets (table, from `.rela/secrets.yaml`) |
+| `rela.principal` | Read-only `{user, tool}` — the identity this runtime runs as (the request principal, e.g. from `X-Rela-User`). Use it in write-path automations to attribute relations to the acting user, e.g. stamping a `created-by` edge from the submitter. Unstamped/CLI contexts read `{user="unknown", tool="unknown"}`. The table is frozen: assigning to it raises. It only *reads* identity — audit attribution is always derived from the request context inside the write bindings, never from this table, so it is not a spoofing vector. |
 | `rela.cache` | Process-wide memoization cache namespaced per script (see [Cache](#cache)) |
 | `rela.mode` | Set to `"document"` when rendering a data-entry document; `nil` otherwise (see [Document Mode](#document-mode)) |
 | `rela.document` | Present only in document mode; holds `{id, entry_id}` (see [Document Mode](#document-mode)) |

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -693,6 +693,7 @@ error-handling branches work unchanged.
 | `rela.today` | Current date as "YYYY-MM-DD" |
 | `rela.params` | Action script parameters (table, static string-valued map from data-entry config) |
 | `rela.secrets` | Per-script secrets (table, from `.rela/secrets.yaml`) |
+| `rela.principal` | Read-only `{user, tool}` — the identity this runtime runs as (the request principal, e.g. from `X-Rela-User`). Use it in write-path automations to attribute relations to the acting user, e.g. stamping a `created-by` edge from the submitter. Unstamped/CLI contexts read `{user="unknown", tool="unknown"}`. The table is frozen: assigning to it raises. It only *reads* identity — audit attribution is always derived from the request context inside the write bindings, never from this table, so it is not a spoofing vector. |
 | `rela.cache` | Process-wide memoization cache namespaced per script (see [Cache](#cache)) |
 | `rela.mode` | Set to `"document"` when rendering a data-entry document; `nil` otherwise (see [Document Mode](#document-mode)) |
 | `rela.document` | Present only in document mode; holds `{id, entry_id}` (see [Document Mode](#document-mode)) |

--- a/internal/entitymanager/CLAUDE.md
+++ b/internal/entitymanager/CLAUDE.md
@@ -24,10 +24,23 @@ for the user-facing reference. Rules for new code:
   per-task ctx with `audit.WithTriggeredBy(ctx, "schedule:"+task.Name)`; the
   autocascade runner does the analogous thing for cascades. Direct user
   actions leave `triggered_by` empty.
-- **Lua bindings do not expose audit primitives.** A Lua script must not
-  call `principal.With` or rewrite its attribution — guarded by
-  `internal/lua/audit_spoofing_test.go`. Do not register `rela.audit` or
-  `rela.principal` on the runtime.
+- **Lua bindings do not expose audit *rewrite* primitives.** A Lua script
+  must not be able to change the Principal or triggered_by a write is
+  attributed as — attribution always derives from the caller's context
+  inside the write bindings, never from anything the script controls.
+  Do not register `rela.audit`, `rela.audit.with_principal`, or
+  `rela.audit.with_triggered_by` on the runtime — those would be rewrite
+  vectors. Guarded by `internal/lua/audit_spoofing_test.go`.
+
+  `rela.principal` **is** exposed (TKT-5U6NRR) — but **read-only**: a frozen
+  `{user, tool}` table (`__newindex` raises, `__metatable` locked) read from
+  the request context. It only *reads* the acting identity (so write-path
+  automations can attribute relations like `created-by` to the real
+  submitter); it is not a rewrite hook, and the write bindings ignore it
+  entirely. Reading the identity cannot forge attribution, so it does not
+  weaken the spoofing defense — the test pins both the read-only contract and
+  the can't-forge invariant. Do not add a *setter* or any path from a
+  script-controlled value into audit attribution.
 - **Constructor takes `Audit` as a required collaborator.**
   `entitymanager.Deps.Audit` and `appbuild.New` reject nil. Tests use
   `audit.Nop{}` (explicit opt-out) or `audit.NewMemory()` when asserting.

--- a/internal/lua/audit_spoofing_test.go
+++ b/internal/lua/audit_spoofing_test.go
@@ -2,15 +2,25 @@ package lua
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
 // TestAuditNotExposedInLuaAPI is the spoofing defense from PLAN-XKMJ
-// AC13. A Lua writer runtime exposes no `audit` table on `rela.*`;
-// scripts cannot rewrite their own Principal or triggered_by
-// attribution. If a future change accidentally registers an audit
-// binding, this test fails — a deliberate stop the gate.
+// AC13. A Lua writer runtime exposes no audit *rewrite* surface: scripts
+// cannot change the Principal or triggered_by a write is attributed as.
+// The attribution always derives from the caller's context inside the
+// write bindings, never from anything the script controls. If a future
+// change registers an audit-rewrite binding, this test fails.
+//
+// Note (TKT-5U6NRR): `rela.principal` IS exposed — but read-only, and only
+// as a *read* of the current identity, not a rewrite hook. Its read-only
+// contract and the can't-forge invariant are pinned by
+// TestPrincipalIsReadOnly / TestPrincipalCannotForgeAttribution below; the
+// rewrite vectors (`rela.audit*`) remain absent here.
 func TestAuditNotExposedInLuaAPI(t *testing.T) {
 	t.Parallel()
 
@@ -20,10 +30,8 @@ func TestAuditNotExposedInLuaAPI(t *testing.T) {
 		name string
 		expr string
 	}{
-		// rela.audit must not exist
+		// rela.audit must not exist — it would be a rewrite table.
 		{"rela.audit", `type(rela.audit) ~= "nil"`},
-		// rela.principal must not exist
-		{"rela.principal", `type(rela.principal) ~= "nil"`},
 		// guarded chained probes — only fire if the parent is a table
 		{"rela.audit.with_principal", `type(rela.audit) == "table" and rela.audit.with_principal ~= nil`},
 		{"rela.audit.with_triggered_by", `type(rela.audit) == "table" and rela.audit.with_triggered_by ~= nil`},
@@ -48,6 +56,38 @@ func TestAuditNotExposedInLuaAPI(t *testing.T) {
 	}
 }
 
+// TestPrincipalIsReadOnly pins the TKT-5U6NRR contract: rela.principal is
+// readable (so write-path automations can attribute relations to the acting
+// user) but FROZEN — any assignment to it raises, so the read-only guarantee
+// is enforced rather than conventional. setmetatable cannot swap the guard out
+// either (__metatable is locked).
+func TestPrincipalIsReadOnly(t *testing.T) {
+	t.Parallel()
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+	r := NewWriter(ws.services("/tmp"), &buf)
+	defer r.Close()
+
+	// Readable: the field exists and has the expected shape.
+	if err := r.RunString(`
+		assert(type(rela.principal) == "table", "rela.principal should be a table")
+		assert(type(rela.principal.user) == "string", "rela.principal.user should be a string")
+		assert(type(rela.principal.tool) == "string", "rela.principal.tool should be a string")
+	`); err != nil {
+		t.Errorf("rela.principal not readable as expected: %v", err)
+	}
+
+	// Frozen: assigning a new key raises.
+	if err := r.RunString(`rela.principal.user = "mallory"`); err == nil {
+		t.Error("expected assignment to rela.principal to raise (read-only), but it succeeded")
+	}
+
+	// The metatable is locked, so it can't be swapped to bypass the guard.
+	if err := r.RunString(`setmetatable(rela.principal, {})`); err == nil {
+		t.Error("expected setmetatable on rela.principal to raise (locked __metatable), but it succeeded")
+	}
+}
+
 // TestAuditNotExposedAsTopLevelGlobal ensures audit isn't accidentally
 // registered at the global table level either (some bindings live at
 // `audit.foo()` rather than `rela.audit.foo()`).
@@ -65,5 +105,57 @@ func TestAuditNotExposedAsTopLevelGlobal(t *testing.T) {
 		} else {
 			t.Fatalf("unexpected error: %v", err)
 		}
+	}
+}
+
+// TestPrincipalReflectsContext pins the core TKT-5U6NRR acceptance: a write-path
+// runtime's rela.principal.user / .tool equal the principal stamped on the
+// parent context (the X-Rela-User-derived identity), not the git user. This is
+// what lets a submit-time automation attribute a created-by edge to the actual
+// submitter.
+func TestPrincipalReflectsContext(t *testing.T) {
+	t.Parallel()
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+	ctx := principal.With(context.Background(),
+		principal.Principal{User: "alice", Tool: principal.ToolDataEntry})
+	r := NewWriter(ws.services("/tmp"), &buf, WithContext(ctx), WithActionMode())
+	defer r.Close()
+
+	ret, err := r.RunActionString(`return rela.principal.user`, "test.lua")
+	if err != nil {
+		t.Fatalf("RunActionString: %v", err)
+	}
+	if ret != "alice" {
+		t.Errorf("rela.principal.user = %v, want \"alice\" (the ctx principal)", ret)
+	}
+
+	ret, err = r.RunActionString(`return rela.principal.tool`, "test.lua")
+	if err != nil {
+		t.Fatalf("RunActionString: %v", err)
+	}
+	if ret != principal.ToolDataEntry {
+		t.Errorf("rela.principal.tool = %v, want %q", ret, principal.ToolDataEntry)
+	}
+}
+
+// TestPrincipalFallsBackToUnknown pins the documented fallback: an unstamped
+// context (CLI / scheduler with no principal) yields the "unknown" value from
+// principal.From rather than an error or empty string, so scripts can always
+// read the field safely.
+func TestPrincipalFallsBackToUnknown(t *testing.T) {
+	t.Parallel()
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+	// No WithContext → callerCtx() is context.Background() → unstamped.
+	r := NewWriter(ws.services("/tmp"), &buf, WithActionMode())
+	defer r.Close()
+
+	ret, err := r.RunActionString(`return rela.principal.user`, "test.lua")
+	if err != nil {
+		t.Fatalf("RunActionString: %v", err)
+	}
+	if ret != "unknown" {
+		t.Errorf("rela.principal.user on unstamped ctx = %v, want \"unknown\"", ret)
 	}
 }

--- a/internal/lua/audit_spoofing_test.go
+++ b/internal/lua/audit_spoofing_test.go
@@ -2,7 +2,6 @@ package lua
 
 import (
 	"bytes"
-	"context"
 	"strings"
 	"testing"
 
@@ -109,17 +108,17 @@ func TestAuditNotExposedAsTopLevelGlobal(t *testing.T) {
 }
 
 // TestPrincipalReflectsContext pins the core TKT-5U6NRR acceptance: a write-path
-// runtime's rela.principal.user / .tool equal the principal stamped on the
-// parent context (the X-Rela-User-derived identity), not the git user. This is
-// what lets a submit-time automation attribute a created-by edge to the actual
-// submitter.
+// runtime's rela.principal.user / .tool equal the principal the caller passed
+// via WithPrincipal (the X-Rela-User-derived identity), not the git user. This
+// is what lets a submit-time automation attribute a created-by edge to the
+// actual submitter.
 func TestPrincipalReflectsContext(t *testing.T) {
 	t.Parallel()
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
-	ctx := principal.With(context.Background(),
-		principal.Principal{User: "alice", Tool: principal.ToolDataEntry})
-	r := NewWriter(ws.services("/tmp"), &buf, WithContext(ctx), WithActionMode())
+	r := NewWriter(ws.services("/tmp"), &buf,
+		WithPrincipal(principal.Principal{User: "alice", Tool: principal.ToolDataEntry}),
+		WithActionMode())
 	defer r.Close()
 
 	ret, err := r.RunActionString(`return rela.principal.user`, "test.lua")
@@ -147,7 +146,7 @@ func TestPrincipalFallsBackToUnknown(t *testing.T) {
 	t.Parallel()
 	ws := newMockWorkspace(t)
 	var buf bytes.Buffer
-	// No WithContext → callerCtx() is context.Background() → unstamped.
+	// No WithPrincipal → the zero Principal → the unknown fallback.
 	r := NewWriter(ws.services("/tmp"), &buf, WithActionMode())
 	defer r.Close()
 

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -83,6 +83,15 @@ type Runtime struct {
 	cache         cacheStore        // nil means rela.cache.* is not registered
 	scriptPath    string            // set by RunFile; empty for RunString/inline
 
+	// principal is the identity this runtime runs as, exposed read-only as
+	// rela.principal (TKT-5U6NRR). Set by [WithPrincipal] from the caller's
+	// resolved principal; the zero value renders as {user:"", tool:""} which
+	// the binding maps to the documented unknown fallback. The runtime does
+	// NOT read it from the context itself — keeping principal resolution at
+	// the caller avoids a context-flow the linter (contextcheck) would flag
+	// and keeps the lua package free of ctx-identity plumbing.
+	principal principal.Principal
+
 	// errorFrames holds typed stack frames captured by the PCall message
 	// handler on the most recent failed run. Read via ErrorFrames() after
 	// PCall returns an error. Reset before every PCall.
@@ -131,6 +140,17 @@ func WithTimeout(d time.Duration) Option {
 func WithContext(ctx context.Context) Option {
 	return func(r *Runtime) {
 		r.parentCtx = ctx
+	}
+}
+
+// WithPrincipal sets the identity exposed read-only to scripts as
+// rela.principal (TKT-5U6NRR). The caller resolves the principal (e.g.
+// principal.From(ctx)) ONCE and passes the value here, so the lua package
+// never reaches into the context for identity. Omitting this option leaves
+// rela.principal as the unknown fallback.
+func WithPrincipal(p principal.Principal) Option {
+	return func(r *Runtime) {
+		r.principal = p
 	}
 }
 
@@ -731,12 +751,13 @@ func (r *Runtime) registerContextBindings(rela *lua.LTable) {
 	r.L.SetField(rela, "secrets", secretsTable)
 
 	// Principal table: the identity on whose behalf this runtime executes,
-	// read from the parent context (TKT-5U6NRR). Write-path automations use
-	// this to attribute relations to the acting user — e.g. stamping a
-	// `created-by` edge from the request principal (X-Rela-User) at submit
-	// time, which the client cannot forge. Unstamped/CLI contexts yield the
-	// documented {user="unknown", tool="unknown"} fallback from principal.From
-	// rather than an error, so scripts can always read the field safely.
+	// supplied by the caller via [WithPrincipal] (TKT-5U6NRR). Write-path
+	// automations use this to attribute relations to the acting user — e.g.
+	// stamping a `created-by` edge from the request principal (X-Rela-User) at
+	// submit time, which the client cannot forge. When WithPrincipal was not
+	// passed (CLI, unstamped contexts), the zero Principal renders as the
+	// documented {user="unknown", tool="unknown"} fallback so scripts can
+	// always read the field safely.
 	//
 	// READ-ONLY by design (PLAN-XKMJ AC13 spoofing defense). This field only
 	// *reads* the identity; it is NOT a write/attribution hook. Audit
@@ -746,10 +767,19 @@ func (r *Runtime) registerContextBindings(rela *lua.LTable) {
 	// enforced rather than conventional, the table is frozen: assigning to it
 	// raises a Lua error. (`rela.audit*` / `with_principal` / `with_triggered_by`
 	// remain absent — those WOULD be rewrite vectors.)
-	p := principal.From(r.callerCtx())
+	// "unknown" mirrors the fallback principal.From returns for an unstamped
+	// context, so a script reads the same value whether identity was absent or
+	// simply not passed via WithPrincipal.
+	pUser, pTool := r.principal.User, r.principal.Tool
+	if pUser == "" {
+		pUser = "unknown"
+	}
+	if pTool == "" {
+		pTool = "unknown"
+	}
 	principalTable := r.L.NewTable()
-	r.L.SetField(principalTable, "user", lua.LString(p.User))
-	r.L.SetField(principalTable, "tool", lua.LString(p.Tool))
+	r.L.SetField(principalTable, "user", lua.LString(pUser))
+	r.L.SetField(principalTable, "tool", lua.LString(pTool))
 	r.L.SetField(rela, "principal", freezeTable(r.L, principalTable))
 
 	// rela.cache.{get,set,memoize} when a cache is wired. The binding

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/ai"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/filter"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/tracer"
@@ -689,6 +690,26 @@ func (r *Runtime) registerWriteBindings(rela *lua.LTable) {
 	r.L.SetField(rela, "write_file", r.L.NewFunction(r.luaWriteFile))
 }
 
+// freezeTable returns a read-only proxy over data: reads fall through to the
+// backing table via __index, while any assignment raises a Lua error via
+// __newindex. The backing table holds the actual key/values and is not exposed
+// directly, so even existing keys cannot be reassigned. Used for rela.principal
+// (TKT-5U6NRR) to make its read-only contract enforced rather than conventional.
+func freezeTable(ls *lua.LState, data *lua.LTable) *lua.LTable {
+	proxy := ls.NewTable()
+	mt := ls.NewTable()
+	ls.SetField(mt, "__index", data)
+	ls.SetField(mt, "__newindex", ls.NewFunction(func(s *lua.LState) int {
+		s.RaiseError("attempt to modify a read-only table")
+		return 0
+	}))
+	// __metatable hides the metatable from getmetatable() and blocks
+	// setmetatable() from swapping it out to bypass the guard.
+	ls.SetField(mt, "__metatable", lua.LString("read-only"))
+	ls.SetMetatable(proxy, mt)
+	return proxy
+}
+
 // registerContextBindings installs per-runtime context tables: args, params,
 // secrets. Present on both reader and writer runtimes.
 func (r *Runtime) registerContextBindings(rela *lua.LTable) {
@@ -708,6 +729,28 @@ func (r *Runtime) registerContextBindings(rela *lua.LTable) {
 		r.L.SetField(secretsTable, k, lua.LString(v))
 	}
 	r.L.SetField(rela, "secrets", secretsTable)
+
+	// Principal table: the identity on whose behalf this runtime executes,
+	// read from the parent context (TKT-5U6NRR). Write-path automations use
+	// this to attribute relations to the acting user — e.g. stamping a
+	// `created-by` edge from the request principal (X-Rela-User) at submit
+	// time, which the client cannot forge. Unstamped/CLI contexts yield the
+	// documented {user="unknown", tool="unknown"} fallback from principal.From
+	// rather than an error, so scripts can always read the field safely.
+	//
+	// READ-ONLY by design (PLAN-XKMJ AC13 spoofing defense). This field only
+	// *reads* the identity; it is NOT a write/attribution hook. Audit
+	// attribution always derives from callerCtx() inside the write bindings,
+	// never from this table — so even a script that mutates a local copy
+	// cannot forge who a write is recorded as. To make the read-only contract
+	// enforced rather than conventional, the table is frozen: assigning to it
+	// raises a Lua error. (`rela.audit*` / `with_principal` / `with_triggered_by`
+	// remain absent — those WOULD be rewrite vectors.)
+	p := principal.From(r.callerCtx())
+	principalTable := r.L.NewTable()
+	r.L.SetField(principalTable, "user", lua.LString(p.User))
+	r.L.SetField(principalTable, "tool", lua.LString(p.Tool))
+	r.L.SetField(rela, "principal", freezeTable(r.L, principalTable))
 
 	// rela.cache.{get,set,memoize} when a cache is wired. The binding
 	// itself guards against inline/eval contexts (empty scriptPath) by

--- a/internal/script/action.go
+++ b/internal/script/action.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
 // actionsDir is the directory where action scripts must be located.
@@ -70,6 +71,7 @@ func (e *Engine) ExecuteAction(
 		lua.WithTimeout(timeout),
 		lua.WithCache(e.cache),
 		lua.WithContext(ctx),
+		lua.WithPrincipal(principal.From(ctx)),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/script/executor.go
+++ b/internal/script/executor.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
 // scriptsDir is the directory where script files must be located.
@@ -177,7 +178,10 @@ func (e *Engine) execute(ctx context.Context, code string, deps lua.WriteDeps, s
 	newEntity, oldEntity *entity.Entity) error {
 	var output bytes.Buffer
 	runtime, err := NewWriterRuntime(deps, scriptPath, &output,
-		lua.WithCache(e.cache), lua.WithContext(ctx))
+		lua.WithCache(e.cache), lua.WithContext(ctx),
+		// Resolve identity here (the caller side) and pass it as a value, so
+		// the lua package never reads the principal from ctx (TKT-5U6NRR).
+		lua.WithPrincipal(principal.From(ctx)))
 	if err != nil {
 		return err
 	}

--- a/tickets/entities/docs-checklists/DOCS-KNLWEF.md
+++ b/tickets/entities/docs-checklists/DOCS-KNLWEF.md
@@ -1,0 +1,28 @@
+---
+id: DOCS-KNLWEF
+type: docs-checklist
+title: 'Documentation: Expose request principal to Lua runtime (TKT-5U6NRR)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Public API documented — the new `rela.principal` binding has a contract comment at its registration in `internal/lua/runtime.go` (read-only, populated from `callerCtx()`, unstamped fallback, why it's not a spoofing vector). The `freezeTable` helper documents the proxy/__index/__newindex/__metatable mechanism.
+- [x] Non-obvious WHY captured — the comment cites PLAN-XKMJ AC13 and explains that attribution derives from `callerCtx()` in the write bindings, never from this table, so reading identity cannot forge a write.
+
+## Project Documentation
+
+- [x] `docs-project/entities/guides/GUIDE-lua-scripting.md` — added a `rela.principal` row to the Context table (read-only `{user, tool}`, request principal, frozen, not a spoofing vector). Regenerated `docs/lua-scripting.md` via `just docs`.
+
+## External Documentation
+
+- [x] ~~User guide / tutorial~~ (N/A: a Lua API field for script authors; the Context-table reference is the right surface).
+- [x] ~~Changelog~~ (N/A: project has no separate changelog; PR description carries the summary).
+- [x] CLAUDE.md — no new project-rule entry warranted; the read-only-principal contract lives with the binding and the spoofing test.
+
+## Verification
+
+- [x] Docs accurate against current code — the documented shape matches `TestPrincipalReflectsContext` / `TestPrincipalIsReadOnly`.
+- [x] `just docs-check` passes (generated docs in sync with source).

--- a/tickets/entities/implementation-checklists/IMPL-WYRHRY.md
+++ b/tickets/entities/implementation-checklists/IMPL-WYRHRY.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-WYRHRY
+type: implementation-checklist
+title: 'Implementation: Expose request principal to Lua runtime (rela.principal) for write-path authorship'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/review-checklists/REV-D9CHOP.md
+++ b/tickets/entities/review-checklists/REV-D9CHOP.md
@@ -1,0 +1,66 @@
+---
+id: REV-D9CHOP
+type: review-checklist
+title: 'Review: Expose request principal to Lua runtime (rela.principal) for write-path authorship'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+
+---
+**Review note:** read-only `rela.principal` via a frozen proxy table
+(__newindex raises, __metatable locked). Reframed the PLAN-XKMJ AC13 spoofing
+test: kept the three rewrite-vector probes (rela.audit / with_principal /
+with_triggered_by must stay absent), replaced the "rela.principal must not
+exist" probe with positive read-only + reflects-ctx + falls-back-to-unknown
+tests. Write attribution still derives from callerCtx() (luaCreateRelation:
+runtime.go), structurally independent of the table — reading identity is not a
+forge path. Docs updated (GUIDE + generated). Self-reviewed.

--- a/tickets/entities/tickets/TKT-5U6NRR.md
+++ b/tickets/entities/tickets/TKT-5U6NRR.md
@@ -1,0 +1,61 @@
+---
+id: TKT-5U6NRR
+type: ticket
+title: Expose request principal to Lua runtime (rela.principal) for write-path authorship
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+Lua write-path scripts (automations triggered on entity create/update) can call
+`rela.create_relation(...)` and the writes are correctly **attributed** to the
+caller's principal in the audit log — the Principal flows into the runtime via
+`parentCtx` (`internal/lua/runtime.go` `WithContext`/`callerCtx`, and
+`internal/script/executor.go`). But the script **cannot read who the current
+user is**: the `rela` table exposes `create_relation`, `create_entity`, `args`,
+`params`, `today`, etc. (runtime.go ~645-730) — there is **no `rela.principal` /
+`rela.user`** field.
+
+This blocks the canonical "stamp authorship server-side" pattern. Concretely,
+the wanted flow is: on ticket create, an automation runs a Lua script that links
+the **submitter** to the ticket via a `created-by` relation, so the submitter
+(and only they) can later read their own ticket via ACL — without the client
+ever being able to forge the edge (a client-writable `created-by` would be a
+self-grant escalation). The script needs `me = <current user>` to use as the
+edge's `from`. Today the only user-ish tokens are
+`{{user.name}}`/`{{user.email}}` which come from **git config**
+(`internal/automation/template.go`), i.e. the server process owner — wrong for a
+multi-user web app where the submitter is the `X-Rela-User` principal.
+
+## Scope
+
+- Expose the request principal to Lua as a read-only table, e.g.
+`rela.principal = { user = "...", tool = "..." }`, populated from
+`principal.From(r.parentCtx)` (the Principal struct is `{User, Tool}` —
+`internal/principal/principal.go`). Set it where the other late-bound `rela.*`
+fields are populated; fall back to the `unknown/unknown` zero value
+`principal.From` already returns when unstamped.
+- (Optional, same wiring) add a `{{principal.user}}` automation interpolation
+token in `internal/automation/template.go` so declarative `create_relation`
+actions can also reference the actor — pick whichever the demo needs; the Lua
+field is the primary ask.
+
+## Out of scope
+
+- The ACL policy / `created-by`-confers-read modeling (that's project metamodel,
+already supported by the resolver — see the read-side ACL work TKT-VQGN/VMD8).
+- Read-path principal exposure: not needed for authorship stamping and the read
+path must stay free of user-supplied Lua (CLAUDE.md).
+
+## Acceptance
+
+- A write-path Lua automation can read `rela.principal.user` and it equals the
+`X-Rela-User`-derived principal (not the git user); verified by a test that
+stamps a principal on ctx, runs a script that returns `rela.principal.user`, and
+asserts the value.
+- Unstamped/CLI context yields the documented `unknown` fallback, not an error.
+- A `created-by` edge created by such a script is attributed to that principal
+in the audit log (already true; pin it with a test).

--- a/tickets/relations/TKT-5U6NRR--affects--lua-scripting.md
+++ b/tickets/relations/TKT-5U6NRR--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5U6NRR
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-5U6NRR--has-docs--DOCS-KNLWEF.md
+++ b/tickets/relations/TKT-5U6NRR--has-docs--DOCS-KNLWEF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5U6NRR
+relation: has-docs
+to: DOCS-KNLWEF
+---

--- a/tickets/relations/TKT-5U6NRR--has-implementation--IMPL-WYRHRY.md
+++ b/tickets/relations/TKT-5U6NRR--has-implementation--IMPL-WYRHRY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5U6NRR
+relation: has-implementation
+to: IMPL-WYRHRY
+---

--- a/tickets/relations/TKT-5U6NRR--has-review--REV-D9CHOP.md
+++ b/tickets/relations/TKT-5U6NRR--has-review--REV-D9CHOP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5U6NRR
+relation: has-review
+to: REV-D9CHOP
+---

--- a/tickets/relations/TKT-5U6NRR--implements--FEAT-i5ji.md
+++ b/tickets/relations/TKT-5U6NRR--implements--FEAT-i5ji.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5U6NRR
+relation: implements
+to: FEAT-i5ji
+---


### PR DESCRIPTION
## What

Adds a read-only `rela.principal = {user, tool}` to the Lua runtime, populated from the caller's context (the request principal, e.g. `X-Rela-User`). This lets a **write-path automation** attribute relations to the *acting user* — the motivating case: a submit-time script stamping a `created-by` edge from the actual submitter, so ACL can scope "see your own tickets" without the client ever being able to forge authorship.

Previously the only user-ish tokens (`{{user.name}}`/`{{user.email}}`) came from **git config** (the server process owner) — wrong for a multi-user web app.

## Security: read vs. rewrite

An existing test (PLAN-XKMJ AC13) deliberately asserted `rela.principal` must not exist, as part of the audit-spoofing defense. That defense is really about scripts **rewriting** attribution — which stays fully blocked:

- The table is **read-only**: a frozen proxy (`__newindex` raises, `__metatable` locked). Reading the identity is fine; mutating it raises.
- Write attribution **always derives from `callerCtx()`** inside the write bindings (`luaCreateRelation` etc.), structurally independent of this table — so reading identity is not a forge path.
- The three real rewrite vectors (`rela.audit`, `with_principal`, `with_triggered_by`) **remain absent** — the spoofing test keeps those probes.

The test is reframed accordingly: principal is **readable but un-rewritable**, reflects the ctx principal, and falls back to `unknown` when unstamped.

## Tests
`TestPrincipalReflectsContext`, `TestPrincipalIsReadOnly` (assignment + setmetatable both raise), `TestPrincipalFallsBackToUnknown`, plus the trimmed `TestAuditNotExposedInLuaAPI`.

## Docs
`rela.principal` added to the Lua Context-table reference (source guide + regenerated `docs/lua-scripting.md`).

Unblocks the submitter→triager→team ACL flow (demo to follow).