### PR TITLE
feat(lua): rela.bypass_acl elevated write handle for automations (TKT-D8T148)

### DIFF
--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -345,6 +345,59 @@ local ok, e, warnings = pcall(rela.update_entity, "TKT-001", {title = ""})
 -- ok=true, e is the entity, warnings is the validation findings.
 ```
 
+### Elevated writes — `rela.bypass_acl`
+
+By default an automation script's writes are **ACL-checked against the
+triggering principal** (the user whose action fired the automation). That is
+correct for most automations. But some scripts enforce a *system invariant* on
+behalf of a user who isn't authorized to make the write directly — e.g.
+stamping `submitter --created-by--> ticket` on ticket create so the submitter
+(and only they) can later read their own ticket, without the submitter being
+able to write `person` relations themselves.
+
+For those, `rela.bypass_acl(fn)` runs `fn` with a single argument `admin`: a
+write handle whose mutations **skip the ACL deny**. Elevation is scoped to the
+closure and carried by the `admin` object — the ordinary `rela.*` write
+bindings are never elevated.
+
+```lua
+-- on ticket create: stamp the submitter as author, server-side, unforgeable
+local me = rela.principal.user
+rela.bypass_acl(function(admin)
+  admin.create_relation(me, "created-by", entity.id)
+end)
+-- back to normal (gated) authority here
+```
+
+`admin` exposes `create_relation`, `delete_relation`, `delete_entity`.
+
+**Operator opt-in is required.** `rela.bypass_acl` only exists when the
+automation action sets `allow_acl_bypass: true` in `metamodel.yaml` (an
+operator-only file). Without it the function is absent and a script cannot
+elevate:
+
+```yaml
+automations:
+  - name: stamp-ticket-author
+    on: { entity: [ticket], created: true }
+    do:
+      - lua_file: stamp-author.lua
+        allow_acl_bypass: true
+```
+
+**Safety properties:**
+
+- **Audited, not anonymous.** Every elevated write records an `acl-bypass`
+  audit row carrying the **real** triggering principal (not a system user) plus
+  `acl_bypass=true`, so "who caused this elevated write" is always answerable.
+- **No leak into nested cascades.** A cascade that an elevated write triggers
+  runs with normal (gated) ACL authority — elevation does not propagate to
+  descendant writes.
+- **Closure-scoped.** After `fn` returns, `admin` is invalidated; stashing it in
+  a global and calling it later raises.
+- **Cannot forge identity.** `rela.principal` is read-only and the write
+  attribution derives from the request context, never from the script.
+
 ### Schema Functions
 
 | Function | Description | Returns |

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -339,6 +339,59 @@ local ok, e, warnings = pcall(rela.update_entity, "TKT-001", {title = ""})
 -- ok=true, e is the entity, warnings is the validation findings.
 ```
 
+### Elevated writes — `rela.bypass_acl`
+
+By default an automation script's writes are **ACL-checked against the
+triggering principal** (the user whose action fired the automation). That is
+correct for most automations. But some scripts enforce a *system invariant* on
+behalf of a user who isn't authorized to make the write directly — e.g.
+stamping `submitter --created-by--> ticket` on ticket create so the submitter
+(and only they) can later read their own ticket, without the submitter being
+able to write `person` relations themselves.
+
+For those, `rela.bypass_acl(fn)` runs `fn` with a single argument `admin`: a
+write handle whose mutations **skip the ACL deny**. Elevation is scoped to the
+closure and carried by the `admin` object — the ordinary `rela.*` write
+bindings are never elevated.
+
+```lua
+-- on ticket create: stamp the submitter as author, server-side, unforgeable
+local me = rela.principal.user
+rela.bypass_acl(function(admin)
+  admin.create_relation(me, "created-by", entity.id)
+end)
+-- back to normal (gated) authority here
+```
+
+`admin` exposes `create_relation`, `delete_relation`, `delete_entity`.
+
+**Operator opt-in is required.** `rela.bypass_acl` only exists when the
+automation action sets `allow_acl_bypass: true` in `metamodel.yaml` (an
+operator-only file). Without it the function is absent and a script cannot
+elevate:
+
+```yaml
+automations:
+  - name: stamp-ticket-author
+    on: { entity: [ticket], created: true }
+    do:
+      - lua_file: stamp-author.lua
+        allow_acl_bypass: true
+```
+
+**Safety properties:**
+
+- **Audited, not anonymous.** Every elevated write records an `acl-bypass`
+  audit row carrying the **real** triggering principal (not a system user) plus
+  `acl_bypass=true`, so "who caused this elevated write" is always answerable.
+- **No leak into nested cascades.** A cascade that an elevated write triggers
+  runs with normal (gated) ACL authority — elevation does not propagate to
+  descendant writes.
+- **Closure-scoped.** After `fn` returns, `admin` is invalidated; stashing it in
+  a global and calling it later raises.
+- **Cannot forge identity.** `rela.principal` is read-only and the write
+  attribution derives from the request context, never from the script.
+
 ### Schema Functions
 
 | Function | Description | Returns |

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -36,6 +36,15 @@ const (
 	// attempted op (one of the Op* above). Forensic: denials answer
 	// "what did this user try to do that they weren't allowed to?"
 	OpDeniedWrite = "denied-write"
+
+	// OpACLBypass records a write that skipped the ACL deny because it ran
+	// through an elevated automation handle (rela.bypass_acl — TKT-D8T148).
+	// Subject names the target; Summary carries acl_bypass=true + the genuine
+	// write op. The Principal is the REAL triggering identity (not a system
+	// user) so "who caused this elevated write" stays answerable; TriggeredBy
+	// carries automation:<name>. Forensic: isolate every elevated write with
+	// `op == "acl-bypass"`.
+	OpACLBypass = "acl-bypass"
 )
 
 // Subject identifies what an op acted on. Exactly one of {Type, ID}

--- a/internal/autocascade/mutator.go
+++ b/internal/autocascade/mutator.go
@@ -31,3 +31,19 @@ type Mutator interface {
 	CreateRelation(ctx context.Context, from, relType, to string, opts entity.RelationOptions) (*entity.Relation, error)
 	DeleteRelation(ctx context.Context, from, relType, to string) error
 }
+
+// ElevatedProvider is an OPTIONAL capability a Mutator may expose
+// (TKT-D8T148): it hands back a second Mutator whose writes skip the ACL deny,
+// for an `allow_acl_bypass` automation action that calls `rela.bypass_acl(...)`.
+// The script runner type-asserts the per-cascade Mutator to this interface and
+// uses Elevated() ONLY when the action is allow_acl_bypass; the elevated handle
+// is scoped to the bypass closure and invalidated after it returns.
+//
+// Kept separate from Mutator so the elevated capability is opt-in and a
+// Mutator implementation without it (e.g. a test double) simply doesn't grant
+// bypass — there is no way to elevate a Mutator that doesn't choose to offer it.
+type ElevatedProvider interface {
+	// Elevated returns a Mutator whose writes bypass the ACL deny. The
+	// returned handle must NOT propagate elevation into nested cascades.
+	Elevated() Mutator
+}

--- a/internal/autocascade/runner.go
+++ b/internal/autocascade/runner.go
@@ -269,11 +269,12 @@ func (r *Runner) executeScriptActions(
 
 		actionCtx := audit.WithTriggeredBy(ctx, "automation:"+action.AutomationName)
 		err := scripts.Run(actionCtx, ScriptAction{
-			Code:      action.Code,
-			FilePath:  action.FilePath,
-			Name:      action.AutomationName,
-			NewEntity: newEntity,
-			OldEntity: oldEntity,
+			Code:           action.Code,
+			FilePath:       action.FilePath,
+			Name:           action.AutomationName,
+			NewEntity:      newEntity,
+			OldEntity:      oldEntity,
+			AllowACLBypass: action.AllowACLBypass,
 		}, mutator)
 		if err == nil {
 			continue

--- a/internal/autocascade/scriptrunner.go
+++ b/internal/autocascade/scriptrunner.go
@@ -57,6 +57,13 @@ type ScriptAction struct {
 	// trigger's old state, not the current iteration's — preserved
 	// from pre-refactor workspace behavior.
 	OldEntity *entity.Entity
+
+	// AllowACLBypass mirrors the action's `allow_acl_bypass` flag
+	// (TKT-D8T148). When true, the script runner exposes `rela.bypass_acl`
+	// backed by an elevated Mutator (from [ElevatedProvider]); when false the
+	// binding is absent and the script cannot elevate. Operator-gated: only a
+	// metamodel-authored action can set it.
+	AllowACLBypass bool
 }
 
 // NopScriptRunner is a no-op [ScriptRunner] for tests that should not

--- a/internal/automation/engine.go
+++ b/internal/automation/engine.go
@@ -84,10 +84,11 @@ func convertFromMetamodel(def metamodel.AutomationDef) Automation {
 
 	for i, a := range def.Do {
 		action := Action{
-			Set:     a.Set,
-			Value:   a.Value,
-			Lua:     a.Lua,
-			LuaFile: a.LuaFile,
+			Set:            a.Set,
+			Value:          a.Value,
+			Lua:            a.Lua,
+			LuaFile:        a.LuaFile,
+			AllowACLBypass: a.AllowACLBypass,
 		}
 		if a.CreateRelation != nil {
 			action.CreateRelation = &CreateRelationAction{
@@ -307,6 +308,7 @@ func (e *Engine) executeAction(action Action, event Event, result *Result, autom
 		result.LuaToExecute = append(result.LuaToExecute, LuaToExecute{
 			Code:           code,
 			AutomationName: automationName,
+			AllowACLBypass: action.AllowACLBypass,
 		})
 	}
 
@@ -316,6 +318,7 @@ func (e *Engine) executeAction(action Action, event Event, result *Result, autom
 		result.LuaToExecute = append(result.LuaToExecute, LuaToExecute{
 			FilePath:       action.LuaFile,
 			AutomationName: automationName,
+			AllowACLBypass: action.AllowACLBypass,
 		})
 	}
 }

--- a/internal/automation/types.go
+++ b/internal/automation/types.go
@@ -37,6 +37,7 @@ type Action struct {
 	CreateEntity   *CreateEntityAction
 	Lua            string // Inline Lua code to execute
 	LuaFile        string // Path to Lua script file in scripts/ directory
+	AllowACLBypass bool   // allow_acl_bypass: unlock rela.bypass_acl in this Lua action (TKT-D8T148)
 }
 
 // CreateRelationAction specifies parameters for creating a relation.
@@ -128,6 +129,7 @@ type LuaToExecute struct {
 	Code           string // Inline Lua code (safe values already interpolated)
 	FilePath       string // Path to script file in scripts/ directory
 	AutomationName string // Name of the originating automation
+	AllowACLBypass bool   // action's allow_acl_bypass flag (TKT-D8T148): unlocks rela.bypass_acl
 }
 
 // Result represents the outcome of running automations.

--- a/internal/entitymanager/acl_bypass_test.go
+++ b/internal/entitymanager/acl_bypass_test.go
@@ -1,0 +1,169 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/autocascade"
+	"github.com/Sourcehaven-BV/rela/internal/automation"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// elevatedProvider is the optional capability the elevated handle is obtained
+// through. *Manager satisfies it (TKT-D8T148).
+type elevatedProvider interface {
+	Elevated() autocascade.Mutator
+}
+
+// TestManager_Elevated_BypassesACLDenyAndAudits pins the core TKT-D8T148
+// contract: the gated Manager denies a write the principal isn't authorized
+// for, while the elevated handle (Manager.Elevated()) performs the SAME write —
+// recording an acl-bypass audit row that preserves the real principal, and NOT
+// a denied-write row.
+func TestManager_Elevated_BypassesACLDenyAndAudits(t *testing.T) {
+	t.Parallel()
+	sink := audit.NewMemory()
+	// ReadOnlyACL denies every write.
+	mgr, cs := newManagerWithACL(t, acl.ReadOnlyACL{}, sink)
+	seedEntity(t, cs, "decision", "From decision")
+	seedEntity(t, cs, "requirement", "To requirement")
+
+	ctx := principal.With(context.Background(),
+		principal.Principal{User: "alice", Tool: principal.ToolDataEntry})
+
+	// Gated write is denied.
+	_, gErr := mgr.CreateRelation(ctx, "DEC-001", "addresses", "REQ-001", entity.RelationOptions{})
+	if gErr == nil {
+		t.Fatal("gated CreateRelation: expected ACL denial, got nil")
+	}
+	var forbidden *acl.ForbiddenError
+	if !errors.As(gErr, &forbidden) {
+		t.Fatalf("gated denial = %v, want *acl.ForbiddenError", gErr)
+	}
+
+	before := len(sink.Records())
+
+	// Elevated write succeeds.
+	em, ok := any(mgr).(elevatedProvider)
+	if !ok {
+		t.Fatal("Manager does not satisfy elevatedProvider — Elevated() missing")
+	}
+	elevated := em.Elevated()
+	if _, eErr := elevated.CreateRelation(ctx, "DEC-001", "addresses", "REQ-001", entity.RelationOptions{}); eErr != nil {
+		t.Fatalf("elevated CreateRelation: expected success, got %v", eErr)
+	}
+
+	// The elevated write records BOTH the normal successful-write row (every
+	// Manager write audits) AND one acl-bypass marker row with the REAL
+	// principal — and NEVER a denied-write row.
+	newRecs := sink.Records()[before:]
+	var bypassRows, deniedRows int
+	for _, rec := range newRecs {
+		switch rec.Op {
+		case audit.OpACLBypass:
+			bypassRows++
+			if rec.Principal.User != "alice" {
+				t.Errorf("acl-bypass Principal.User = %q, want \"alice\" (real principal preserved)", rec.Principal.User)
+			}
+			if !strings.Contains(rec.Summary, "acl_bypass=true") {
+				t.Errorf("acl-bypass Summary = %q, want it to contain acl_bypass=true", rec.Summary)
+			}
+		case audit.OpDeniedWrite:
+			deniedRows++
+		}
+	}
+	if bypassRows != 1 {
+		t.Errorf("acl-bypass audit rows = %d, want exactly 1", bypassRows)
+	}
+	if deniedRows != 0 {
+		t.Errorf("denied-write audit rows = %d, want 0 (elevated write must not record a denial)", deniedRows)
+	}
+}
+
+// TestManager_Elevated_DoesNotMutateGatedManager pins that obtaining an
+// elevated handle does not turn the original Manager into a bypassing one:
+// after Elevated(), the original mgr still denies. (Elevation is per-handle.)
+func TestManager_Elevated_DoesNotMutateGatedManager(t *testing.T) {
+	t.Parallel()
+	sink := audit.NewMemory()
+	mgr, cs := newManagerWithACL(t, acl.ReadOnlyACL{}, sink)
+	seedEntity(t, cs, "decision", "From decision")
+	seedEntity(t, cs, "requirement", "To requirement")
+	ctx := principal.With(context.Background(),
+		principal.Principal{User: "alice", Tool: principal.ToolDataEntry})
+
+	em := any(mgr).(elevatedProvider)
+	_ = em.Elevated() // obtaining the handle must not affect mgr
+
+	if _, err := mgr.CreateRelation(ctx, "DEC-001", "addresses", "REQ-001", entity.RelationOptions{}); err == nil {
+		t.Fatal("original Manager allowed a write after Elevated() was called — elevation leaked onto the gated handle")
+	}
+}
+
+// TestManager_Elevated_DoesNotLeakIntoNestedCascade is the load-bearing leak
+// test (go-architect review): an entity write through the ELEVATED handle
+// triggers a cascade, and the Mutator handed to the cascade's scripts MUST be
+// GATED — elevation does not propagate to descendant writes. We capture the
+// cascade's Mutator and prove a write through it is still ACL-denied.
+func TestManager_Elevated_DoesNotLeakIntoNestedCascade(t *testing.T) {
+	t.Parallel()
+	scripts := &recordingScripts{}
+	cs := &countingStore{Store: memstore.New()}
+	auto := automation.Automation{
+		Name: "fires-on-create",
+		On:   automation.Trigger{Entity: []string{"requirement"}, Created: true},
+		Do:   []automation.Action{{Lua: "-- noop"}},
+	}
+	engine := automation.NewEngine([]automation.Automation{auto})
+	runner, err := autocascade.New(autocascade.Deps{Engine: engine})
+	if err != nil {
+		t.Fatalf("autocascade.New: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:        cs,
+		Meta:         parseMeta(t),
+		Templater:    nopTemplater{},
+		Audit:        audit.Nop{},
+		ACL:          acl.ReadOnlyACL{}, // deny-all, so a gated write is refused
+		Automations:  engine,
+		Cascade:      runner,
+		ScriptRunner: scripts,
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+
+	// Create an entity through the ELEVATED handle (the gated path would be
+	// denied at the create itself). This fires the cascade.
+	elevated := any(mgr).(elevatedProvider).Elevated()
+	ctx := principal.With(context.Background(),
+		principal.Principal{User: "alice", Tool: principal.ToolDataEntry})
+	e := entity.New("", "requirement")
+	e.SetString("title", "Trigger")
+	if _, err := elevated.CreateEntity(ctx, e, entity.CreateOptions{}); err != nil {
+		t.Fatalf("elevated CreateEntity: %v", err)
+	}
+
+	// The cascade ran and handed the script a Mutator.
+	if scripts.calls != 1 || scripts.mutator == nil {
+		t.Fatalf("cascade script not invoked with a mutator (calls=%d)", scripts.calls)
+	}
+
+	// CRITICAL: that Mutator must be GATED — a write through it is denied,
+	// proving elevation did not propagate into the nested cascade.
+	_, wErr := scripts.mutator.CreateRelation(ctx, "REQ-001", "addresses", "REQ-001", entity.RelationOptions{})
+	if wErr == nil {
+		t.Fatal("LEAK: the nested cascade's Mutator allowed a write — elevation propagated to descendants")
+	}
+	var forbidden *acl.ForbiddenError
+	if !errors.As(wErr, &forbidden) {
+		t.Fatalf("nested-cascade write error = %v, want *acl.ForbiddenError (gated)", wErr)
+	}
+}

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -63,6 +63,46 @@ type TemplateLoader interface {
 //   - DeleteRelation: delete. No automation.
 type Manager struct {
 	deps Deps
+
+	// bypassACL marks this Manager as an ELEVATED write handle: its writes
+	// skip the ACL deny (TKT-D8T148, the `rela.bypass_acl(...)` path). It is
+	// false on the normal Manager and set true ONLY on the throwaway handle
+	// returned by [Manager.elevated]. Carrying elevation on the object (not
+	// the context) is what makes it leak-proof: a nested cascade an elevated
+	// write triggers re-dispatches with the gated Manager (see the cascade
+	// dispatch sites, which pass `m.gated()` as the Mutator), so elevation
+	// never propagates to descendant writes.
+	bypassACL bool
+}
+
+// elevated returns a throwaway Manager handle whose writes skip the ACL deny.
+// Shares all deps with the receiver; differs only in bypassACL. Reserved for
+// the script-runner's elevated write handle (rela.bypass_acl). NOT exported as
+// a general capability — callers obtain it only through the autocascade
+// Mutator seam for an allow_acl_bypass action.
+func (m *Manager) elevated() *Manager {
+	return &Manager{deps: m.deps, bypassACL: true}
+}
+
+// Elevated satisfies [autocascade.ElevatedProvider] (TKT-D8T148): it hands the
+// script runner an elevated Mutator for an `allow_acl_bypass` action. Exported
+// only to cross the package boundary to the script runner; the returned handle
+// bypasses the ACL deny but preserves the real principal in audit and never
+// propagates elevation into nested cascades (it dispatches via gated()).
+func (m *Manager) Elevated() autocascade.Mutator {
+	return m.elevated()
+}
+
+// gated returns a non-elevated Manager sharing the receiver's deps. On a normal
+// Manager it returns the receiver; on an elevated handle it strips the bypass.
+// Used at cascade-dispatch sites so a nested cascade triggered by an elevated
+// write runs with normal ACL authority — elevation does not propagate to
+// descendants (the leak the ctx-marker approach would have had).
+func (m *Manager) gated() *Manager {
+	if !m.bypassACL {
+		return m
+	}
+	return &Manager{deps: m.deps, bypassACL: false}
 }
 
 // Compile-time assertions: Manager must satisfy both the public
@@ -161,13 +201,50 @@ func New(d Deps) (*Manager, error) {
 // The denied-write audit happens regardless of audit backend
 // (Filesystem / Memory / Nop) — forensic posture demands recording
 // what was attempted, not just what landed.
+//
+// When this Manager is an elevated handle (`m.bypassACL` — TKT-D8T148: a
+// `rela.bypass_acl(...)` write), the ACL deny is SKIPPED: the write is allowed
+// regardless of the principal's grants. Elevation is a property of WHICH
+// Manager you hold, not of the context — see [Manager.elevated]. The real
+// principal is still preserved (`principal.From(ctx)`, unchanged) and the
+// bypass is recorded (recordACLBypass) so the audit trail is unambiguous about
+// which writes were elevated and on whose behalf. We do NOT recordDeniedWrite
+// on the bypass path — there is no denial to record.
 func (m *Manager) authorizeAndAudit(ctx context.Context, req acl.WriteRequest) error {
+	if m.bypassACL {
+		m.recordACLBypass(ctx, req)
+		return nil
+	}
 	decision := m.deps.ACL.AuthorizeWrite(ctx, req)
 	if decision.Allow {
 		return nil
 	}
 	m.recordDeniedWrite(ctx, decision, req)
 	return &acl.ForbiddenError{Decision: decision}
+}
+
+// recordACLBypass emits one audit row for an elevated (rela.bypass_acl) write.
+// It preserves the real triggering principal (so "who really caused this" is
+// always answerable, like ruid under sudo) and marks the row acl_bypass=true
+// so forensic queries can isolate elevated writes. The op stays the genuine
+// write op; the bypass marker rides the Summary alongside the existing
+// triggered_by=automation:<name>.
+func (m *Manager) recordACLBypass(ctx context.Context, req acl.WriteRequest) {
+	var subject *audit.Subject
+	switch s := req.Subject.(type) {
+	case acl.RelationSubject:
+		subject = &audit.Subject{Kind: "relation", RelationType: s.Type, FromID: s.FromID}
+	case acl.EntitySubject:
+		subject = &audit.Subject{Kind: "entity", Type: s.Type, ID: s.ID}
+	}
+	m.deps.Audit.Record(audit.Record{
+		Time:        time.Now().UTC(),
+		Op:          audit.OpACLBypass,
+		Subject:     subject,
+		Principal:   principal.From(ctx),
+		TriggeredBy: audit.TriggeredByFrom(ctx),
+		Summary:     fmt.Sprintf("acl_bypass=true op=%s", req.Op),
+	})
 }
 
 // recordDeniedWrite emits one audit row describing the refused
@@ -317,7 +394,7 @@ func (m *Manager) CreateEntity(
 		OldTrigger: nil,
 		Result:     autoResult,
 		Scripts:    m.deps.ScriptRunner,
-		Mutator:    m, // Manager satisfies autocascade.Mutator structurally
+		Mutator:    m.gated(), // gated() so elevation never propagates into a nested cascade (TKT-D8T148)
 	})
 	if cascadeErr != nil {
 		return nil, fmt.Errorf("cascade: %w", cascadeErr)
@@ -448,7 +525,7 @@ func (m *Manager) UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.U
 		OldTrigger: oldEntity,
 		Result:     autoResult,
 		Scripts:    m.deps.ScriptRunner,
-		Mutator:    m, // Manager satisfies autocascade.Mutator structurally
+		Mutator:    m.gated(), // gated() so elevation never propagates into a nested cascade (TKT-D8T148)
 	})
 	if cascadeErr != nil {
 		return nil, fmt.Errorf("cascade: %w", cascadeErr)

--- a/internal/lua/acl_bypass_test.go
+++ b/internal/lua/acl_bypass_test.go
@@ -1,0 +1,107 @@
+package lua
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// recordingMutator is a minimal Mutator that records create_relation calls,
+// used as the ElevatedManager so a test can assert rela.bypass_acl routed a
+// write through the elevated handle.
+type recordingMutator struct {
+	relations []string // "from--type-->to" per CreateRelation call
+}
+
+func (r *recordingMutator) CreateEntity(context.Context, *entity.Entity, entity.CreateOptions) (*entity.CreateResult, error) {
+	return &entity.CreateResult{}, nil
+}
+func (r *recordingMutator) UpdateEntity(context.Context, *entity.Entity) (*entity.UpdateResult, error) {
+	return &entity.UpdateResult{}, nil
+}
+func (r *recordingMutator) DeleteEntity(context.Context, string, bool) (*entity.DeleteResult, error) {
+	return &entity.DeleteResult{}, nil
+}
+func (r *recordingMutator) CreateRelation(_ context.Context, from, relType, to string, _ entity.RelationOptions) (*entity.Relation, error) {
+	r.relations = append(r.relations, from+"--"+relType+"-->"+to)
+	return entity.NewRelation(from, relType, to), nil
+}
+func (r *recordingMutator) DeleteRelation(context.Context, string, string, string) error { return nil }
+
+// writerWithElevated builds a writer runtime whose WriteDeps carry an
+// ElevatedManager (so rela.bypass_acl is registered).
+func writerWithElevated(t *testing.T, elevated Mutator) *Runtime {
+	t.Helper()
+	ws := newMockWorkspace(t)
+	deps := ws.services("/tmp")
+	deps.ElevatedManager = elevated
+	var buf bytes.Buffer
+	return NewWriter(deps, &buf)
+}
+
+// TestBypassACL_RoutesThroughElevatedHandle pins the happy path: inside
+// rela.bypass_acl(fn), admin.create_relation routes to the elevated Mutator.
+func TestBypassACL_RoutesThroughElevatedHandle(t *testing.T) {
+	t.Parallel()
+	em := &recordingMutator{}
+	r := writerWithElevated(t, em)
+	defer r.Close()
+
+	script := `
+		rela.bypass_acl(function(admin)
+			admin.create_relation("alice", "created-by", "TKT-1")
+		end)
+	`
+	if err := r.RunString(script); err != nil {
+		t.Fatalf("bypass_acl script: %v", err)
+	}
+	if len(em.relations) != 1 || em.relations[0] != "alice--created-by-->TKT-1" {
+		t.Errorf("elevated CreateRelation calls = %v, want [alice--created-by-->TKT-1]", em.relations)
+	}
+}
+
+// TestBypassACL_AbsentWithoutElevatedManager pins that rela.bypass_acl is NOT
+// registered when no elevated handle was wired — a normal (non-allow_acl_bypass)
+// runtime cannot elevate.
+func TestBypassACL_AbsentWithoutElevatedManager(t *testing.T) {
+	t.Parallel()
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+	r := NewWriter(ws.services("/tmp"), &buf) // no ElevatedManager
+	defer r.Close()
+
+	if err := r.RunString(`if rela.bypass_acl ~= nil then error("bypass_acl present") end`); err != nil {
+		t.Errorf("rela.bypass_acl should be absent without an elevated handle: %v", err)
+	}
+}
+
+// TestBypassACL_HandleInvalidatedAfterClosure pins the escaped-handle defense:
+// an admin handle captured into a global and used AFTER the closure returns
+// raises (the handle is invalidated), so elevation can't leak past the closure's
+// dynamic extent.
+func TestBypassACL_HandleInvalidatedAfterClosure(t *testing.T) {
+	t.Parallel()
+	em := &recordingMutator{}
+	r := writerWithElevated(t, em)
+	defer r.Close()
+
+	// Capture admin into a global inside the closure, then use it afterwards.
+	script := `
+		local stashed
+		rela.bypass_acl(function(admin) stashed = admin end)
+		stashed.create_relation("alice", "created-by", "TKT-1")
+	`
+	err := r.RunString(script)
+	if err == nil {
+		t.Fatal("using a captured admin handle after the closure should raise, but it succeeded")
+	}
+	if !strings.Contains(err.Error(), "invalidated") {
+		t.Errorf("error = %v, want it to mention the handle is invalidated", err)
+	}
+	if len(em.relations) != 0 {
+		t.Errorf("elevated write happened via an escaped handle: %v — must not", em.relations)
+	}
+}

--- a/internal/lua/deps.go
+++ b/internal/lua/deps.go
@@ -51,4 +51,11 @@ type Mutator interface {
 type WriteDeps struct {
 	ReadDeps
 	EntityManager Mutator
+
+	// ElevatedManager, when non-nil, is a write handle whose mutations skip
+	// the ACL deny (TKT-D8T148). It is set ONLY for an allow_acl_bypass
+	// automation action; its presence is what makes the runtime register
+	// rela.bypass_acl(fn). Nil on every other runtime, so rela.bypass_acl is
+	// absent and a script cannot elevate.
+	ElevatedManager Mutator
 }

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -646,6 +646,12 @@ func (r *Runtime) registerBindings(allowWrites bool) {
 	r.registerReadBindings(rela)
 	if allowWrites {
 		r.registerWriteBindings(rela)
+		// rela.bypass_acl is registered ONLY when an elevated handle was wired
+		// (an allow_acl_bypass automation action — TKT-D8T148). Absent it, the
+		// binding does not exist and a script cannot elevate.
+		if r.deps.ElevatedManager != nil {
+			r.L.SetField(rela, "bypass_acl", r.L.NewFunction(r.luaBypassACL))
+		}
 	}
 	r.registerContextBindings(rela)
 
@@ -1491,6 +1497,108 @@ func WarningsToTable(ls *lua.LState, warnings []entity.Warning) lua.LValue {
 		tbl.Append(wt)
 	}
 	return tbl
+}
+
+// luaBypassACL implements rela.bypass_acl(fn) (TKT-D8T148). It invokes fn with
+// a single argument `admin`: a write handle whose mutations skip the ACL deny,
+// backed by the elevated Mutator wired into WriteDeps. Elevation is therefore
+// an OBJECT CAPABILITY scoped to the closure — the gated rela.* bindings are
+// never elevated; only writes made through `admin` bypass ACL.
+//
+// After fn returns (or raises), `admin` is INVALIDATED: its methods raise. A
+// script that squirrels `admin` into a global and calls it later gets a dead
+// handle, so the lexical scope is enforced, not merely conventional (mirrors
+// the frozen rela.principal). fn's return value(s) propagate to the caller; a
+// raise inside fn propagates too (a failed elevated write must surface).
+func (r *Runtime) luaBypassACL(ls *lua.LState) int {
+	fn := ls.CheckFunction(1)
+	if r.deps.ElevatedManager == nil {
+		// Defensive: the binding is only registered when ElevatedManager is
+		// set, but fail loud rather than silently no-op if that ever drifts.
+		ls.RaiseError("rela.bypass_acl: no elevated write handle is available")
+		return 0
+	}
+
+	// live gates every admin.* call; set false after fn returns so a captured
+	// handle is dead outside the closure's dynamic extent.
+	live := true
+	admin := r.newElevatedHandle(ls, r.deps.ElevatedManager, &live)
+
+	// Invalidate on every exit path (normal return or Lua error). pcall keeps
+	// the runtime alive so we can flip `live` before re-raising.
+	defer func() { live = false }()
+
+	ls.Push(fn)
+	ls.Push(admin)
+	// Protected call so we can guarantee invalidation even when fn raises,
+	// then re-surface the error to the caller.
+	if err := ls.PCall(1, lua.MultRet, nil); err != nil {
+		live = false
+		ls.RaiseError("rela.bypass_acl: %s", err.Error())
+		return 0
+	}
+	// Return whatever fn returned (already on the stack after PCall).
+	return ls.GetTop() - 1
+}
+
+// newElevatedHandle builds the `admin` table passed to a rela.bypass_acl
+// closure. Its methods route to the elevated Mutator `em` and check `*live`
+// first, so they raise once the closure has returned. No reads, no principal,
+// no nested bypass.
+//
+// v1 surface: create_relation, delete_relation, delete_entity — the
+// link/unlink + remove operations the system-invariant use cases (e.g.
+// authorship stamping via created-by) need. create_entity / update_entity are a
+// deliberate follow-up: they marshal a full entity table and aren't required by
+// the motivating case; gating elevated *entity* creation is a larger surface
+// best added with its own tests.
+func (r *Runtime) newElevatedHandle(ls *lua.LState, em Mutator, live *bool) *lua.LTable {
+	t := ls.NewTable()
+	guard := func(name string) bool {
+		if !*live {
+			ls.RaiseError("rela.bypass_acl: handle %q used outside its closure (invalidated)", name)
+			return false
+		}
+		return true
+	}
+	ls.SetField(t, "create_relation", ls.NewFunction(func(s *lua.LState) int {
+		if !guard("create_relation") {
+			return 0
+		}
+		from, relType, to := s.CheckString(1), s.CheckString(2), s.CheckString(3)
+		if _, err := em.CreateRelation(r.callerCtx(), from, relType, to, entity.RelationOptions{}); err != nil {
+			s.RaiseError("bypass_acl create_relation error: %s", err.Error())
+			return 0
+		}
+		s.Push(lua.LTrue)
+		return 1
+	}))
+	ls.SetField(t, "delete_relation", ls.NewFunction(func(s *lua.LState) int {
+		if !guard("delete_relation") {
+			return 0
+		}
+		from, relType, to := s.CheckString(1), s.CheckString(2), s.CheckString(3)
+		if err := em.DeleteRelation(r.callerCtx(), from, relType, to); err != nil {
+			s.RaiseError("bypass_acl delete_relation error: %s", err.Error())
+			return 0
+		}
+		s.Push(lua.LTrue)
+		return 1
+	}))
+	ls.SetField(t, "delete_entity", ls.NewFunction(func(s *lua.LState) int {
+		if !guard("delete_entity") {
+			return 0
+		}
+		id := s.CheckString(1)
+		cascade := s.OptBool(2, false)
+		if _, err := em.DeleteEntity(r.callerCtx(), id, cascade); err != nil {
+			s.RaiseError("bypass_acl delete_entity error: %s", err.Error())
+			return 0
+		}
+		s.Push(lua.LTrue)
+		return 1
+	}))
+	return t
 }
 
 // luaDeleteEntity implements rela.delete_entity(id, cascade?) -> boolean

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -441,6 +441,13 @@ type AutomationAction struct {
 	CreateEntity   *CreateEntityAction   `yaml:"create_entity,omitempty"`
 	Lua            string                `yaml:"lua,omitempty"`      // Inline Lua code to execute
 	LuaFile        string                `yaml:"lua_file,omitempty"` // Path to Lua script in scripts/ directory
+
+	// AllowACLBypass unlocks rela.bypass_acl in this Lua action (TKT-D8T148).
+	// Operator-only (lives in metamodel.yaml). When true, the script may call
+	// rela.bypass_acl(fn) to obtain a closure-scoped elevated write handle
+	// whose writes skip the ACL deny (still audited, real principal preserved).
+	// Ignored for non-Lua actions.
+	AllowACLBypass bool `yaml:"allow_acl_bypass,omitempty"`
 }
 
 // CreateRelationAction specifies parameters for creating a relation.

--- a/internal/script/luascriptrunner.go
+++ b/internal/script/luascriptrunner.go
@@ -83,6 +83,16 @@ func (l *LuaScriptRunner) Run(ctx context.Context, action autocascade.ScriptActi
 		// "interfaces at the call site".
 		EntityManager: m,
 	}
+	// TKT-D8T148: when the action is allow_acl_bypass AND the mutator offers
+	// the elevated capability, expose an elevated write handle so the script
+	// can call rela.bypass_acl(fn). Both conditions are required: operator opt-in
+	// (the flag) and a Mutator that chooses to provide elevation. A Mutator
+	// without ElevatedProvider (e.g. a restricted double) simply can't elevate.
+	if action.AllowACLBypass {
+		if ep, ok := m.(autocascade.ElevatedProvider); ok {
+			deps.ElevatedManager = ep.Elevated()
+		}
+	}
 	var err error
 	switch {
 	case action.Code != "":

--- a/tickets/entities/docs-checklists/DOCS-BBEOXN.md
+++ b/tickets/entities/docs-checklists/DOCS-BBEOXN.md
@@ -1,0 +1,28 @@
+---
+id: DOCS-BBEOXN
+type: docs-checklist
+title: 'Documentation: ACL-bypass automation scripts (TKT-D8T148)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Public API documented — `luaBypassACL` / `newElevatedHandle` (the closure + invalidated handle), `Manager.Elevated()` / `elevated()` / `gated()` (the leak-proof seam), `authorizeAndAudit`'s bypass branch + `recordACLBypass`, and the `OpACLBypass` audit op all carry contract comments explaining the security properties.
+- [x] Non-obvious WHY captured — comments cite TKT-D8T148, the go-architect leak finding (why gated() at cascade dispatch), and why the handle is an object-capability rather than a ctx flag.
+
+## Project Documentation
+
+- [x] `docs-project/entities/guides/GUIDE-lua-scripting.md` — added an "Elevated writes — rela.bypass_acl" section (closure API, allow_acl_bypass operator gate, the four safety properties: audited/no-leak/closure-scoped/can't-forge). Regenerated `docs/lua-scripting.md`.
+
+## External Documentation
+
+- [x] ~~User guide / tutorial~~ (N/A: Lua API for script authors; the guide is the right surface).
+- [x] ~~Changelog~~ (N/A: no separate changelog; PR description carries the summary).
+- [x] CLAUDE.md — no new project-rule entry warranted beyond the existing entitymanager spoofing-rule update (rela.principal); the bypass contract lives with the code + the security tests.
+
+## Verification
+
+- [x] Docs accurate against current code — the documented behavior matches the test suite (bypass+audit, leak test, escaped-handle, absent-without-flag).
+- [x] `just docs-check` passes once the regenerated guide is committed.

--- a/tickets/entities/implementation-checklists/IMPL-J077JA.md
+++ b/tickets/entities/implementation-checklists/IMPL-J077JA.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-J077JA
+type: implementation-checklist
+title: 'Implementation: ACL-bypass automation scripts: rela.bypass_acl(closure) with a scoped, invalidated-after elevated write handle'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/review-checklists/REV-MNUFSA.md
+++ b/tickets/entities/review-checklists/REV-MNUFSA.md
@@ -1,0 +1,67 @@
+---
+id: REV-MNUFSA
+type: review-checklist
+title: 'Review: ACL-bypass automation scripts: rela.bypass_acl(closure) with a scoped, invalidated-after elevated write handle'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+
+---
+**Review note:** security-sensitive (ACL bypass). Design pressure-tested by the
+go-architect agent, which caught a fatal leak in the original ctx-marker
+approach (elevation would propagate into the nested cascade); reworked to an
+object-capability handle (Manager.Elevated() / gated() at cascade dispatch).
+Tests pin: bypass+audit-marker with real principal & no denied-write row;
+elevation not leaking onto the gated Manager; the nested-cascade LEAK test
+(downstream write still denied); the escaped-handle invalidation; rela.bypass_acl
+absent without allow_acl_bypass. arch-lint + golangci-lint clean. Stacked on #994.
+Self-reviewed.

--- a/tickets/entities/tickets/TKT-D8T148.md
+++ b/tickets/entities/tickets/TKT-D8T148.md
@@ -1,0 +1,108 @@
+---
+id: TKT-D8T148
+type: ticket
+title: 'ACL-bypass automation scripts: rela.bypass_acl(closure) with a scoped, invalidated-after elevated write handle'
+kind: enhancement
+priority: medium
+effort: m
+status: done
+---
+
+## Description
+
+Automation Lua scripts run through `entitymanager.Manager` (the cascade Mutator
+IS the Manager — `manager.go:320/451`), so their `rela.create_relation` /
+`create_entity` writes are **ACL-checked against the triggering principal** via
+`Manager.authorizeAndAudit` (the single authz chokepoint). This blocks a
+legitimate pattern: a script enforcing a **system invariant** on behalf of a
+user who isn't authorized to make that write directly.
+
+Motivating case (submitter→triager→team ACL flow): on ticket create, an
+automation stamps `submitter --created-by--> ticket` so the submitter can read
+their own ticket via ACL. The script reads the submitter from
+`rela.principal.user` (TKT-5U6NRR), but `created-by` is gated on source type
+`person`, and the submitter has no `write: [person]` (nor should they). Denied.
+
+## API — `rela.bypass_acl(closure)` with a separate elevated handle
+
+Elevation is **lexically scoped** to a closure and carried by a **distinct
+capability object** (object-capability), not an ambient flag:
+
+```lua
+rela.bypass_acl(function(admin)
+  -- elevated ONLY inside this closure, ONLY via `admin`
+  admin.create_relation(rela.principal.user, "created-by", entity.id)
+end)
+-- back to gated authority here; rela.* was never elevated
+```
+
+Decisions:
+- **Separate handle** (`admin`): the handle IS the capability. `rela.*` write
+bindings stay gated *always*; you cannot make an elevated write without naming
+`admin`. This is what makes it leak-proof (see below).
+- **Operator gate `allow_acl_bypass: true`** on the automation action (metamodel,
+operator-only). Without it, `rela.bypass_acl` is absent (nil) → calling it
+errors. So elevation needs BOTH operator blessing (unlock) AND explicit script
+use (where). v1 is blanket (all write types); a relation/entity **type
+allowlist** (`allow_acl_bypass: [created-by]`) is a deferred follow-up.
+- **Handle invalidated after the closure returns**: once `fn` returns, `admin`'s
+methods raise. A script that stashes `admin` in a global and calls it later gets
+a dead handle — the lexical scope is enforced, not conventional (mirrors the
+frozen `rela.principal`).
+
+## Leak-proofing (the load-bearing property — from go-architect review)
+
+A ctx-marker approach was REJECTED: `WithElevated(ctx)` would leak into the
+nested cascade the elevated write dispatches (`Cascade.Process(ctx, ...)`,
+manager.go:315/446 — same ctx, never cleared), elevating all downstream writes.
+
+The handle approach is leak-proof by construction: the elevated authority lives
+only in `admin` inside `fn`. Any nested cascade an elevated write triggers
+re-enters `Manager.Process` with `Mutator: m` (the GATED Manager) — elevation
+does not propagate to descendants. Plus handle-invalidation kills the
+escaped-handle vector.
+
+## Scope
+
+- `allow_acl_bypass bool` threaded: metamodel `AutomationAction` yaml →
+`automation.Action` → `LuaToExecute` → `autocascade.ScriptAction`.
+- An **elevated Mutator**: an `entitymanager` write handle whose
+`CreateRelation` / `CreateEntity` / etc. skip the `authorizeAndAudit` deny.
+Short-circuit ABOVE `recordDeniedWrite` (manager.go:166) so no denied-write row
+is recorded; instead record ONE audit row with the **real principal**
+(`principal.From(ctx)`) + a greppable `acl_bypass=true` marker (alongside the
+existing `triggered_by=automation:<name>`).
+- Lua: register `rela.bypass_acl(fn)` ONLY when the runtime is built for an
+allow_acl_bypass action. It calls `fn(admin)` where `admin` is a Lua table
+backed by the elevated Mutator; after `fn` returns (or errors), invalidate
+`admin`. `admin` exposes only the Mutator surface (create/update/delete
+entity+relation), never reads, never the ungated `Host`.
+- Errors inside the closure propagate (a failed elevated write must surface, not
+silently no-op).
+
+## Tests
+
+- (a) elevated `admin.create_relation` succeeds where the triggering principal's
+gated `rela.create_relation` is denied (created-by from a person the user can't
+write).
+- (b) audit row names the real principal + `acl_bypass=true`; no denied-write row.
+- (c) NON-elevated script (no allow_acl_bypass) has no `rela.bypass_acl` and its direct write
+is still denied.
+- (d) **leak test**: a nested cascade triggered by an elevated write is NOT
+elevated (a gated write downstream is still denied).
+- (e) **escaped-handle test**: `admin` captured into a global and called after
+the closure returns raises (invalidated).
+
+## Out of scope / future
+
+- Type allowlist (`allow_acl_bypass: [type, ...]`).
+- Unifying the existing implicit declarative `cascadeHost` ACL-bypass under this
+same explicit concept (document the inconsistency now, unify later).
+
+## Security notes
+
+- Elevation is on the **script** (operator-authored, metamodel-only), gated by
+`allow_acl_bypass`, scoped to a closure, carried by a capability object, and the
+handle dies after the closure. Four independent constraints.
+- More auditable than the status quo (declarative bypass is silent + unmarked).
+- Real identity never lost; the frozen `rela.principal` blocks self-reattribution.

--- a/tickets/relations/TKT-D8T148--affects--authorization.md
+++ b/tickets/relations/TKT-D8T148--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-D8T148
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-D8T148--has-docs--DOCS-BBEOXN.md
+++ b/tickets/relations/TKT-D8T148--has-docs--DOCS-BBEOXN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-D8T148
+relation: has-docs
+to: DOCS-BBEOXN
+---

--- a/tickets/relations/TKT-D8T148--has-implementation--IMPL-J077JA.md
+++ b/tickets/relations/TKT-D8T148--has-implementation--IMPL-J077JA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-D8T148
+relation: has-implementation
+to: IMPL-J077JA
+---

--- a/tickets/relations/TKT-D8T148--has-review--REV-MNUFSA.md
+++ b/tickets/relations/TKT-D8T148--has-review--REV-MNUFSA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-D8T148
+relation: has-review
+to: REV-MNUFSA
+---

--- a/tickets/relations/TKT-D8T148--implements--FEAT-i5ji.md
+++ b/tickets/relations/TKT-D8T148--implements--FEAT-i5ji.md
@@ -1,0 +1,5 @@
+---
+from: TKT-D8T148
+relation: implements
+to: FEAT-i5ji
+---


### PR DESCRIPTION
## What

Adds `rela.bypass_acl(fn)` — a way for an **operator-authored automation script** to make a write that's normally ACL-denied for the triggering user, when the script is enforcing a *system invariant* on that user's behalf.

Motivating case: on ticket create, stamp `submitter --created-by--> ticket` so the submitter can read their own ticket via ACL — without giving submitters blanket `write:[person]`.

```lua
rela.bypass_acl(function(admin)
  admin.create_relation(rela.principal.user, "created-by", entity.id)
end)
```

## Design — object-capability, leak-proof

Elevation is **lexically scoped to the closure** and carried by the `admin` handle (a distinct object), not an ambient flag. This is what makes it safe:

- **No leak into nested cascades.** A cascade an elevated write triggers re-dispatches with the **gated** Manager (`Manager.gated()` at the cascade-dispatch sites) — elevation does not propagate to descendant writes. *(This was the fatal flaw a go-architect design review caught in the rejected ctx-marker approach; the handle approach is leak-proof by construction.)*
- **Operator opt-in.** `rela.bypass_acl` is registered only when the action sets `allow_acl_bypass: true` in `metamodel.yaml` (operator-only). Absent it, the function doesn't exist.
- **Closure-scoped handle.** `admin` is invalidated after `fn` returns — a captured-and-stashed handle is dead.
- **Audited, real principal.** Every elevated write records an `acl-bypass` audit row with the **real** triggering principal + `acl_bypass=true`; never a denied-write row.
- **Can't forge identity.** `rela.principal` is read-only (frozen); attribution derives from the request context.

## Tests

`internal/entitymanager/acl_bypass_test.go` and `internal/lua/acl_bypass_test.go`: bypass+audit-marker with real principal, elevation not leaking onto the gated Manager, the **nested-cascade leak test** (downstream write still denied), the **escaped-handle** invalidation, and `rela.bypass_acl` absent without the flag.

## Docs

"Elevated writes — rela.bypass_acl" section in the Lua scripting guide; entitymanager CLAUDE.md spoofing rule already updated for `rela.principal` (#994).

## Stack

Stacked on **#994** (`rela.principal`). Base = `feat/lua-principal-tkt-5u6nrr`; will be retargeted to `develop` once #994 merges. Ticket TKT-D8T148.