### PR TITLE
fix(data-entry): use _title in RelationCards picker (titles missing in rel picker)

### DIFF
--- a/frontend/src/components/forms/RelationCards.test.ts
+++ b/frontend/src/components/forms/RelationCards.test.ts
@@ -24,10 +24,11 @@ vi.mock('@/api', async () => {
     ...actual,
     getEntityRelations: vi.fn(),
     getEntity: vi.fn(),
+    searchEntities: vi.fn(),
   }
 })
 
-import { getEntityRelations, getEntity } from '@/api'
+import { getEntityRelations, getEntity, searchEntities } from '@/api'
 
 function seedSchema() {
   const schemaStore = useSchemaStore()
@@ -156,6 +157,40 @@ describe('RelationCards affordance plumbing', () => {
     const metaInput = wrapper.find('input.inline-edit')
     expect(metaInput.exists()).toBe(true)
     expect(metaInput.attributes('disabled')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  // Regression: the search dropdown must render the backend's
+  // metamodel-aware `_title`, NOT `properties.title`. For any project
+  // whose `display_property` is not literally `title` (e.g. `naam`),
+  // `properties.title` is empty and the row would otherwise show the
+  // bare ID. `_title` is always populated by the backend.
+  it('search result renders _title, not properties.title', async () => {
+    ;(searchEntities as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: [
+        {
+          id: 'FEAT-DO-1',
+          type: 'feature',
+          // display_property is `naam`-style: no `title` key here.
+          properties: { naam: 'Pseudoniem API' },
+          _title: 'Pseudoniem API',
+        },
+      ],
+    })
+    const wrapper = await mountCards({})
+
+    // Open the add picker and type a query to trigger the search.
+    await wrapper.find('button.add-btn').trigger('click')
+    const input = wrapper.find('input.search-input')
+    await input.setValue('pseud')
+    // The watcher debounces 200ms before calling doSearch.
+    await new Promise((r) => setTimeout(r, 250))
+    await flushPromises()
+
+    const row = wrapper.find('.search-result .result-title')
+    expect(row.exists()).toBe(true)
+    expect(row.text()).toBe('Pseudoniem API')
+    expect(row.text()).not.toBe('FEAT-DO-1')
     wrapper.unmount()
   })
 })

--- a/frontend/src/components/forms/RelationCards.vue
+++ b/frontend/src/components/forms/RelationCards.vue
@@ -566,7 +566,7 @@ function onDragEnd() {
             @click="selectTarget(entity)"
           >
             <span class="result-id">{{ entity.id }}</span>
-            <span class="result-title">{{ entity.properties.title || entity.id }}</span>
+            <span class="result-title">{{ entity._title }}</span>
             <span class="result-type">{{ entity.type }}</span>
           </div>
         </div>
@@ -580,7 +580,7 @@ function onDragEnd() {
       <div v-if="selectedTarget" class="new-relation-form">
         <div class="selected-target">
           Linking to: <strong>{{ selectedTarget.id }}</strong>
-          {{ selectedTarget.properties.title ? `- ${selectedTarget.properties.title}` : '' }}
+          {{ selectedTarget._title ? `- ${selectedTarget._title}` : '' }}
         </div>
 
         <div v-if="fieldProperties.length" class="new-meta-fields">

--- a/tickets/entities/automated-measures/relationcards-title-display-test.md
+++ b/tickets/entities/automated-measures/relationcards-title-display-test.md
@@ -1,0 +1,32 @@
+---
+id: relationcards-title-display-test
+type: automated-measure
+title: RelationCards renders _title not properties.title
+description: 'Vitest unit test in RelationCards.test.ts that seeds a search result with only _title set and no properties.title (mirroring a metamodel whose display_property is not literally "title", e.g. "naam"), opens the add picker, types a query, and asserts the rendered .result-title equals _title and is not the entity ID. Guards the class of bug where a frontend render site reads properties.title directly and silently shows bare IDs for any project whose display_property differs from "title".'
+kind: test
+location: frontend/src/components/forms/RelationCards.test.ts
+status: active
+---
+
+## Purpose
+
+Close the test gap that let BUG-1P88YM ship: the existing RelationCards fixtures
+always seeded `properties: { title: id }`, so a render site reading
+`properties.title` looked correct in CI even though it shows bare IDs for any
+real project whose `display_property` is not literally `title`.
+
+## What it covers
+
+- Seeds a `searchEntities` result with `_title: 'Pseudoniem API'` and
+  `properties: { naam: ... }` — deliberately **no** `title` property.
+- Drives the add-picker search and asserts the `.result-title` row renders
+  `_title`, not the entity ID.
+- Verified to fail on the pre-fix code (`properties.title || id` → renders the
+  ID) and pass after the fix (`_title`).
+
+## Limitation
+
+This guards `RelationCards.vue` specifically. The durable class-wide guard is a
+shared `entityDisplayTitle()` helper plus an ESLint rule banning
+`.properties.title` in display code, and a shared non-`title` fixture — tracked
+as follow-up.

--- a/tickets/entities/bugs/BUG-1P88YM.md
+++ b/tickets/entities/bugs/BUG-1P88YM.md
@@ -1,0 +1,59 @@
+---
+id: BUG-1P88YM
+type: bug
+title: Rel picker in data-entry shows IDs instead of titles when display_property is not 'title'
+description: 'The RelationCards relation widget (used for relations with editable per-edge metadata) rendered entity.properties.title in its search dropdown and "Linking to:" label. For any project whose metamodel display_property is not literally "title" (e.g. the generiekefuncties-architectuur project, which uses "naam"), properties.title is empty, so every search result and the link label fell back to the bare entity ID. The sibling RelationPicker.vue and this file''s own getEntityTitle() already use the backend''s metamodel-aware _title; only these two render sites in RelationCards.vue bypassed it. Reported against /form/applicatiefunctie/... where the data-objecten picker showed "PRS-DO-DKSN PRS-DO-DKSN dataobject" instead of the entity name.'
+priority: medium
+effort: s
+why1: 'RelationCards.vue rendered entity.properties.title, which is empty for any project whose display_property is not literally "title" (this project uses "naam"), so the search dropdown fell back to the entity ID.'
+why2: 'The component hardcoded the conventional property name "title" instead of using the metamodel-aware _title the backend already computes from display_property (via entityToV1 -> Meta.DisplayTitle, which is total and never empty).'
+why3: 'There is no single shared "display an entity''s title" helper on the frontend — each picker/card/list/search row re-derives the display name, so they drift. RelationPicker.vue used _title; RelationCards.vue''s two render sites did not.'
+why4: 'Tests and CI did not catch it because the test fixtures and the in-repo example projects all use a property literally named "title" (the RelationCards test fixture seeds properties title: id). The _title-vs-properties.title divergence is only observable when display_property differs from "title", which no fixture exercised.'
+why5: 'Systemic: entity display-name resolution is duplicated across the frontend with no canonical helper, AND the test fixtures never exercise a non-"title" display_property, so the metamodel display contract is not enforced on the client. The two together let a render site silently disagree with the backend.'
+prevention: 'This fix adds a regression test that seeds a search result with only _title set (no properties.title), so any RelationCards render site that bypasses _title fails CI. The durable fix for the class is to extract a single entityDisplayTitle(entity) helper and route every picker/card/list/search row through it, plus add at least one shared test fixture whose display_property is not "title" so client components that ignore _title regress visibly. Filed as follow-up.'
+status: ready
+---
+
+## Symptom
+
+In the data-entry SPA, the relation **rel picker** showed entity **IDs instead
+of titles**. Reproduced on `/form/applicatiefunctie/...` in the
+`generiekefuncties-architectuur` project: the "Gebruikt data-objecten" picker's
+search dropdown rendered rows like `PRS-DO-DKSN  PRS-DO-DKSN  dataobject`
+instead of the entity name (`Persoonsnummer`, `Audit log`, …).
+
+Confusingly, **most** pickers on the same form worked, and even within the
+data-objecten widget the **already-selected cards** showed correct titles —
+only the search dropdown and the "Linking to:" label were affected.
+
+## Root cause
+
+The widget for the affected relation is `RelationCards.vue` (relations with
+editable per-edge metadata), distinct from the plain `RelationPicker.vue`. Two
+render sites used `entity.properties.title || entity.id`:
+
+- the search dropdown row (`.result-title`)
+- the "Linking to:" selected-target label
+
+`properties.title` is empty whenever the metamodel `display_property` is not
+literally `title`. This project uses `naam`, so both sites fell back to the ID.
+
+The backend already serializes the correct display name into `_title`
+(`entityToV1` → `Meta.DisplayTitle`, which resolves `display_property` and is
+total — it returns the resolved value or the entity ID, never empty).
+`RelationPicker.vue` and `RelationCards.vue`'s own `getEntityTitle()` use
+`_title`; only these two sites diverged.
+
+## Fix
+
+Render `entity._title` directly at both sites. Since `_title` is always
+backend-populated and non-empty, no `properties.title`/`id` fallback is needed.
+
+Added a regression test in `RelationCards.test.ts` that seeds a search result
+with only `_title` set (no `properties.title`) — it fails on the old code
+(renders the ID) and passes with the fix.
+
+## Fixed by
+
+PR sourcehaven-bv/rela#1002 — `fix(data-entry): use _title in RelationCards
+picker`.

--- a/tickets/relations/BUG-1P88YM--adds-measure--relationcards-title-display-test.md
+++ b/tickets/relations/BUG-1P88YM--adds-measure--relationcards-title-display-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-1P88YM
+relation: adds-measure
+to: relationcards-title-display-test
+---

--- a/tickets/relations/BUG-1P88YM--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-1P88YM--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-1P88YM
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-1P88YM--fixes--FEAT-9J42V.md
+++ b/tickets/relations/BUG-1P88YM--fixes--FEAT-9J42V.md
@@ -1,0 +1,5 @@
+---
+from: BUG-1P88YM
+relation: fixes
+to: FEAT-9J42V
+---


### PR DESCRIPTION
## Problem

The relation **rel picker** in data-entry showed entity **IDs instead of titles**. Reported on `/form/applicatiefunctie/...` in the `generiekefuncties-architectuur` project, where the data-objecten picker rendered `PRS-DO-DKSN  PRS-DO-DKSN  dataobject` instead of the entity name.

## Root cause

The bug is isolated to `RelationCards.vue` (the widget used for relations with editable per-edge metadata — distinct from the plain `RelationPicker.vue`). Its search dropdown and "Linking to:" label rendered:

```vue
{{ entity.properties.title || entity.id }}
```

This hardcodes the conventional property name `title`. For any project whose `display_property` is **not literally `title`** (this project uses `naam`), `properties.title` is empty, so every row fell back to the bare ID.

The backend already computes the correct, metamodel-aware display name into `_title` (`entityToV1` → `Meta.DisplayTitle`, which resolves `display_property` and is total — it never returns empty, falling back to the ID at worst). The sibling `RelationPicker.vue` and this file's own `getEntityTitle()` use `_title`; only these two render sites bypassed it.

## Fix

Use `_title` directly at both sites (search result + selected-target label). Since `_title` is always backend-populated and non-empty, no further fallback is needed.

```diff
- <span class="result-title">{{ entity.properties.title || entity.id }}</span>
+ <span class="result-title">{{ entity._title }}</span>
```

## Verification

- Reproduced live against `generiekefuncties-architectuur` (`main-vad`): data-objecten search showed bare IDs.
- After fix: search renders "Persoonsnummer", "Versleutelde DigiD SAML-assertion", "Organisatiesleutel omkeerbaar", etc.
- Added a regression test seeding a search result with only `_title` (no `properties.title`). Confirmed it **fails on the old code** (renders the ID) and **passes with the fix**.
- `npm run typecheck` clean; RelationCards suite green (7/7).

## 5-Whys: how this reached the repo, and prevention

1. **Why did the picker show IDs?** `RelationCards.vue` rendered `properties.title`, empty when `display_property` ≠ `title`.
2. **Why `properties.title` and not `_title`?** The author hardcoded the conventional property name instead of the backend's metamodel-aware `_title`.
3. **Why only this component, when siblings use `_title`?** There is no single shared "display an entity's title" helper — each picker/card/list re-derives it, so they drift.
4. **Why didn't tests/CI catch it?** Test fixtures and the in-repo example projects all use a `title` property (the test fixture literally seeds `properties: { title: id }`), so `properties.title` is always populated — the `_title` vs `properties.title` divergence is invisible unless `display_property` is something else.
5. **Systemic root cause:** entity display-name resolution is **duplicated across the frontend with no canonical helper**, and **fixtures never exercise a non-`title` `display_property`**, so the metamodel's display contract isn't enforced on the client.

**Prevention (this PR):** the regression test now exercises a non-`title` display name, so any render site that bypasses `_title` fails CI.

**Follow-up (suggested, not in this PR):** extract a single `entityDisplayTitle(entity)` helper and route every picker/card/list/search row through it, eliminating the drift class entirely. Happy to file a ticket.
