### PR TITLE
refactor(data-entry): canonical entityDisplayTitle helper + lint guard (kill BUG-1P88YM class)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -119,6 +119,34 @@ export default tseslint.config(
     },
   },
 
+  // Ban reading `.properties.title` for display. The backend serializes a
+  // metamodel-aware `_title` (honoring each type's `display_property`);
+  // reading the literal `title` property only works when display_property
+  // happens to be `title` and otherwise renders bare IDs (BUG-1P88YM).
+  // Use entityDisplayTitle() from @/utils/entityDisplay instead. The helper
+  // and its test are exempt (they own the `properties.title` reference).
+  {
+    files: ['**/*.vue', '**/*.ts', '**/*.tsx'],
+    ignores: ['src/utils/entityDisplay.ts', '**/*.test.ts', '**/*.spec.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "MemberExpression[property.name='title'] > MemberExpression[property.name='properties']",
+          message:
+            'Do not read `.properties.title` for display — it shows bare IDs when display_property is not "title" (BUG-1P88YM). Use entityDisplayTitle() from @/utils/entityDisplay.',
+        },
+        {
+          selector:
+            "MemberExpression[computed=true][property.value='title'] > MemberExpression[property.name='properties']",
+          message:
+            "Do not read `.properties['title']` for display — use entityDisplayTitle() from @/utils/entityDisplay (BUG-1P88YM).",
+        },
+      ],
+    },
+  },
+
   // Test files - relaxed rules
   {
     files: ['**/*.test.ts', '**/*.spec.ts', '**/test/**/*.ts'],

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -8,6 +8,7 @@ import { isCancelledFetch } from '@/composables/usePageData'
 import { fetchView, getCommands, getErrorMessage } from '@/api'
 import type { ViewEntity, ViewResponse, ViewSection, ViewSectionField } from '@/api'
 import type { Entity } from '@/types'
+import { entityDisplayTitle } from '@/utils/entityDisplay'
 import { useAutoSave } from '@/composables/useAutoSave'
 import { toggleCheckboxInSource } from '@/utils/checkboxToggle'
 import type { Command } from '@/types'
@@ -80,7 +81,7 @@ const editFormId = computed(() => getEditFormId(schemaStore, props.entityType))
 const entry = computed(() => viewData.value?.entry || null)
 const entryTitle = computed(() => {
   if (!entry.value) return props.entityId
-  return (entry.value.properties.title as string) || entry.value.id
+  return entityDisplayTitle(entry.value)
 })
 
 // inaccessibleByName maps each inaccessible field's name to its reason

--- a/frontend/src/components/forms/BacktickAutocompletePopup.vue
+++ b/frontend/src/components/forms/BacktickAutocompletePopup.vue
@@ -22,6 +22,7 @@
  * overlay, so the popup stays above EasyMDE's fullscreen layer (9999).
  */
 import { computed } from 'vue'
+import { entityDisplayTitle } from '@/utils/entityDisplay'
 import type {
   Phase,
   PrefixItem,
@@ -83,10 +84,7 @@ function isPrefixItem(item: RowItem): item is DisplayPrefix {
 }
 
 function entityLabel(e: DisplayEntity): string {
-  if (typeof e._title === 'string' && e._title !== '') return e._title
-  const t = e.properties?.title
-  if (typeof t === 'string' && t !== '') return t
-  return e.id
+  return entityDisplayTitle(e)
 }
 
 function hintText(phase: Phase, resolved: PrefixItem | null): string {

--- a/frontend/src/components/forms/EntityPickerModal.vue
+++ b/frontend/src/components/forms/EntityPickerModal.vue
@@ -17,6 +17,7 @@
  */
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import { searchEntities } from '@/api'
+import { entityDisplayTitle } from '@/utils/entityDisplay'
 import { useSchemaStore } from '@/stores'
 import { useModalStack } from '@/composables/modalStack'
 import { isCancelledFetch } from '@/composables/usePageData'
@@ -137,10 +138,7 @@ onBeforeUnmount(() => {
 })
 
 function entityLabel(entity: Entity): string {
-  if (typeof entity._title === 'string' && entity._title !== '') return entity._title
-  const t = entity.properties?.title
-  if (typeof t === 'string' && t !== '') return t
-  return entity.id
+  return entityDisplayTitle(entity)
 }
 
 function entityTypeLabel(type: string): string {

--- a/frontend/src/components/forms/RelationCards.test.ts
+++ b/frontend/src/components/forms/RelationCards.test.ts
@@ -160,30 +160,28 @@ describe('RelationCards affordance plumbing', () => {
     wrapper.unmount()
   })
 
-  // Regression: the search dropdown must render the backend's
-  // metamodel-aware `_title`, NOT `properties.title`. For any project
-  // whose `display_property` is not literally `title` (e.g. `naam`),
-  // `properties.title` is empty and the row would otherwise show the
-  // bare ID. `_title` is always populated by the backend.
+  // Regression (BUG-1P88YM): the search dropdown must render the backend's
+  // metamodel-aware _title, NOT properties.title. For any project whose
+  // display_property is not literally "title" (e.g. "naam"),
+  // properties.title is empty and the row would otherwise show the bare ID.
+  // This fixture deliberately seeds only _title (no `title` property).
   it('search result renders _title, not properties.title', async () => {
     ;(searchEntities as ReturnType<typeof vi.fn>).mockResolvedValue({
       data: [
         {
           id: 'FEAT-DO-1',
           type: 'feature',
-          // display_property is `naam`-style: no `title` key here.
-          properties: { naam: 'Pseudoniem API' },
+          properties: { naam: 'Pseudoniem API' }, // display_property is naam
           _title: 'Pseudoniem API',
         },
       ],
     })
     const wrapper = await mountCards({})
 
-    // Open the add picker and type a query to trigger the search.
     await wrapper.find('button.add-btn').trigger('click')
     const input = wrapper.find('input.search-input')
     await input.setValue('pseud')
-    // The watcher debounces 200ms before calling doSearch.
+    // The searchQuery watcher debounces 200ms before calling doSearch.
     await new Promise((r) => setTimeout(r, 250))
     await flushPromises()
 

--- a/frontend/src/components/forms/RelationCards.vue
+++ b/frontend/src/components/forms/RelationCards.vue
@@ -10,6 +10,7 @@ import {
   getEntity,
   getErrorMessage,
 } from '@/api'
+import { entityDisplayTitle } from '@/utils/entityDisplay'
 import type { FormFieldOrRelation, RelationProperty } from '@/types/config'
 import type { RelationEntry, Entity } from '@/types/entity'
 import type { PropertyDef } from '@/types/schema'
@@ -126,10 +127,13 @@ async function loadRelations() {
     // Use entry.type (populated since TKT-ZEKO4) so the URL resolves the
     // correct plural — passing '' here builds `/api/v1/s/<id>` which 404s
     // and leaves the title cache empty, surfacing as a bare ID in the UI.
+    // We only need the display name: `_title` is always serialized by the
+    // backend (metamodel-aware), so request just id/type and let
+    // entityDisplayTitle read `_title`.
     const uncached = loaded.filter((entry) => !entityCache.value.has(entry.id))
     const results = await Promise.allSettled(
       uncached.map((entry) =>
-        getEntity(entry.type ?? '', entry.id, { fields: 'id,type,properties.title' }).then((entity) => ({
+        getEntity(entry.type ?? '', entry.id, { fields: 'id,type' }).then((entity) => ({
           id: entry.id,
           entity,
         }))
@@ -150,7 +154,7 @@ async function loadRelations() {
 function getEntityTitle(id: string): string {
   const entity = entityCache.value.get(id)
   if (!entity) return id
-  return String(entity.properties.title || entity._title || id)
+  return entityDisplayTitle(entity)
 }
 
 function navigateToEntity(id: string) {
@@ -566,7 +570,7 @@ function onDragEnd() {
             @click="selectTarget(entity)"
           >
             <span class="result-id">{{ entity.id }}</span>
-            <span class="result-title">{{ entity._title }}</span>
+            <span class="result-title">{{ entityDisplayTitle(entity) }}</span>
             <span class="result-type">{{ entity.type }}</span>
           </div>
         </div>
@@ -580,7 +584,11 @@ function onDragEnd() {
       <div v-if="selectedTarget" class="new-relation-form">
         <div class="selected-target">
           Linking to: <strong>{{ selectedTarget.id }}</strong>
-          {{ selectedTarget._title ? `- ${selectedTarget._title}` : '' }}
+          {{
+            entityDisplayTitle(selectedTarget) !== selectedTarget.id
+              ? `- ${entityDisplayTitle(selectedTarget)}`
+              : ''
+          }}
         </div>
 
         <div v-if="fieldProperties.length" class="new-meta-fields">

--- a/frontend/src/components/forms/RelationPicker.vue
+++ b/frontend/src/components/forms/RelationPicker.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useSchemaStore, useEntitiesStore } from '@/stores'
 import { isCancelledFetch } from '@/composables/usePageData'
 import { getEntityRelations } from '@/api'
+import { entityDisplayTitleWithId } from '@/utils/entityDisplay'
 import type { FormFieldOrRelation, Entity, RelationEntry, RelationAffordance } from '@/types'
 import InlineCreateModal from './InlineCreateModal.vue'
 
@@ -245,12 +246,9 @@ function removeEntity(entityId: string) {
 }
 
 function formatEntityLabel(entity: Entity): string {
-  // _title is the metamodel-aware display title from the API, falling back to id
-  // when the entity type has no display property set. Matches EntityDetail.vue.
-  if (entity._title && entity._title !== entity.id) {
-    return `${entity._title} (${entity.id})`
-  }
-  return entity.id
+  // _title is the metamodel-aware display title from the API, falling back
+  // to id when the entity type has no display property set.
+  return entityDisplayTitleWithId(entity)
 }
 
 function openCreateModal(targetType: string) {

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -12,6 +12,7 @@ import { entityKeys } from '@/queries/entities'
 import { beginOptimisticRemove, rollbackOptimistic } from '@/queries/optimisticList'
 import { toApiOperator, filterStateToApiParams } from '@/utils/filters'
 import { entityDetailHref } from '@/utils/entityRoute'
+import { entityDisplayTitle } from '@/utils/entityDisplay'
 import { actionAllowed } from '@/utils/affordancesWarning'
 import { getCellValue, formatCellValue, isEnumPropertyDef, asArray } from '@/utils/format'
 import type { Entity, ListMeta, ListParams, ListResponse, FilterState } from '@/types'
@@ -520,7 +521,7 @@ function getFormattedCellValue(entity: Entity, column: { property?: string; rela
     const relationIds = entity.relations?.[column.relation] || []
     const titles = relationIds.map((id) => {
       const included = includedEntities.value[id]
-      return included?._title || included?.properties?.title || id
+      return included ? entityDisplayTitle(included) : id
     })
     return titles.join(', ')
   }

--- a/frontend/src/components/ui/CommandPaletteModal.test.ts
+++ b/frontend/src/components/ui/CommandPaletteModal.test.ts
@@ -172,13 +172,17 @@ describe('CommandPaletteModal', () => {
       expect(opts[0].textContent).toContain('Ticket')
     })
 
-    it('falls back to properties.title when _title missing', async () => {
-      const entity = makeEntity({ properties: { title: 'Legacy title' } })
+    it('ignores properties.title and falls back to id when _title missing', async () => {
+      // properties.title is NOT a display source — only the backend's
+      // metamodel-aware _title is. An entity with a `title` property but no
+      // _title must render its ID, not the property (BUG-1P88YM).
+      const entity = makeEntity({ id: 'T-9', properties: { title: 'Legacy title' } })
       searchSpy.mockResolvedValueOnce(listResponse([entity]))
       factory()
       await typeQuery('leg')
 
-      expect(options()[0].textContent).toContain(entity.properties.title as string)
+      expect(options()[0].textContent).toContain('T-9')
+      expect(options()[0].textContent).not.toContain('Legacy title')
     })
 
     it('falls back to id when both title fields missing', async () => {

--- a/frontend/src/components/ui/CommandPaletteModal.vue
+++ b/frontend/src/components/ui/CommandPaletteModal.vue
@@ -17,6 +17,7 @@
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { searchEntities } from '@/api'
+import { entityDisplayTitle } from '@/utils/entityDisplay'
 import { useSchemaStore } from '@/stores'
 import { useModalStack } from '@/composables/modalStack'
 import { isCancelledFetch } from '@/composables/usePageData'
@@ -146,10 +147,7 @@ onBeforeUnmount(() => {
 })
 
 function entityLabel(entity: Entity): string {
-  if (typeof entity._title === 'string' && entity._title !== '') return entity._title
-  const t = entity.properties?.title
-  if (typeof t === 'string' && t !== '') return t
-  return entity.id
+  return entityDisplayTitle(entity)
 }
 
 function entityTypeLabel(type: string): string {

--- a/frontend/src/utils/entityDisplay.test.ts
+++ b/frontend/src/utils/entityDisplay.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { entityDisplayTitle, entityDisplayTitleWithId } from './entityDisplay'
+
+describe('entityDisplayTitle', () => {
+  it('returns _title when present', () => {
+    expect(entityDisplayTitle({ id: 'PRS-DO-1', _title: 'Audit log' })).toBe('Audit log')
+  })
+
+  it('falls back to id when _title is absent', () => {
+    expect(entityDisplayTitle({ id: 'PRS-DO-1' })).toBe('PRS-DO-1')
+  })
+
+  it('falls back to id when _title is empty', () => {
+    expect(entityDisplayTitle({ id: 'PRS-DO-1', _title: '' })).toBe('PRS-DO-1')
+  })
+
+  it('returns _title even when it equals the id', () => {
+    expect(entityDisplayTitle({ id: 'X', _title: 'X' })).toBe('X')
+  })
+})
+
+describe('entityDisplayTitleWithId', () => {
+  it('formats "Title (ID)" when title differs from id', () => {
+    expect(entityDisplayTitleWithId({ id: 'PRS-DO-1', _title: 'Audit log' })).toBe(
+      'Audit log (PRS-DO-1)',
+    )
+  })
+
+  it('returns just the id when title equals id', () => {
+    expect(entityDisplayTitleWithId({ id: 'PRS-DO-1', _title: 'PRS-DO-1' })).toBe('PRS-DO-1')
+  })
+
+  it('returns just the id when title is absent', () => {
+    expect(entityDisplayTitleWithId({ id: 'PRS-DO-1' })).toBe('PRS-DO-1')
+  })
+})

--- a/frontend/src/utils/entityDisplay.ts
+++ b/frontend/src/utils/entityDisplay.ts
@@ -1,0 +1,35 @@
+// Canonical helpers for displaying an entity's name in the SPA.
+//
+// The backend computes a metamodel-aware display name into `_title`
+// (api_v1.go entityToV1 -> metamodel.DisplayTitle), honoring each entity
+// type's `display_property`. `_title` is total: it is the resolved
+// display value, or the entity ID as a floor — never empty for an
+// API-sourced entity.
+//
+// Components MUST render `_title` rather than reaching into
+// `properties.title`. The literal property name `title` is only correct
+// for types whose `display_property` happens to be `title`; for any other
+// (e.g. `naam`), `properties.title` is empty and the UI falls back to the
+// bare ID. That divergence was BUG-1P88YM. An ESLint guard
+// (no-restricted-syntax) bans `.properties.title` in display code to keep
+// every render site funneled through here.
+
+export interface EntityDisplayLike {
+  id: string
+  _title?: string
+}
+
+// entityDisplayTitle returns the entity's display name: `_title` when the
+// backend supplied one, else the ID. Use this everywhere an entity name
+// is shown (pickers, cards, lists, search rows, detail headings).
+export function entityDisplayTitle(entity: EntityDisplayLike): string {
+  return entity._title && entity._title !== '' ? entity._title : entity.id
+}
+
+// entityDisplayTitleWithId returns "Title (ID)" when the title differs
+// from the ID, else just the ID. Used by widgets that show both the
+// human name and the raw ID (e.g. RelationPicker chips/options).
+export function entityDisplayTitleWithId(entity: EntityDisplayLike): string {
+  const title = entityDisplayTitle(entity)
+  return title !== entity.id ? `${title} (${entity.id})` : entity.id
+}

--- a/frontend/src/views/SearchView.vue
+++ b/frontend/src/views/SearchView.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { searchEntities } from '@/api'
 import { useSchemaStore } from '@/stores'
 import { parseFilterQueryParams } from '@/utils/filters'
+import { entityDisplayTitle } from '@/utils/entityDisplay'
 import { useBackTarget } from '@/composables/useBackTarget'
 import BackButton from '@/components/common/BackButton.vue'
 import AdHocFilterMenu from '@/components/lists/AdHocFilterMenu.vue'
@@ -152,7 +153,7 @@ function clearAllFilters() {
 }
 
 function getEntityLabel(entity: Entity): string {
-  return String(entity.properties.title || entity.id)
+  return entityDisplayTitle(entity)
 }
 
 function getEntityTypeLabel(type: string): string {

--- a/tickets/entities/features/FEAT-CXH3OA.md
+++ b/tickets/entities/features/FEAT-CXH3OA.md
@@ -1,0 +1,35 @@
+---
+id: FEAT-CXH3OA
+type: feature
+title: Canonical entityDisplayTitle helper + lint guard
+summary: A single frontend helper for an entity's display name plus an ESLint guard banning .properties.title, so no render site can diverge from the backend's metamodel-aware _title.
+description: 'Entity display-name resolution was duplicated across ~10 frontend components (pickers, cards, lists, search rows, detail heading), each re-deriving "how to show an entity name". Some used the backend''s metamodel-aware _title (correct); some read properties.title directly, which is empty whenever a project''s display_property is not literally "title" and so rendered bare IDs (BUG-1P88YM, and two latent instances in SearchView.vue and EntityDetail.vue). This feature introduces src/utils/entityDisplay.ts (entityDisplayTitle / entityDisplayTitleWithId), migrates every render site onto it, and adds an ESLint no-restricted-syntax rule that bans reading .properties.title (and properties[''title'']) in display code outside the helper. A non-"title" test fixture guards the contract so any component ignoring _title regresses in CI.'
+priority: medium
+status: in-progress
+---
+
+## Problem
+
+`title` is re-derived per component. The literal `properties.title` is only
+correct when a type's `display_property` is `title`; for any other (e.g.
+`naam`) it is empty and the UI shows bare IDs. That divergence shipped as
+BUG-1P88YM and sat latent in two more components.
+
+## Approach
+
+1. `src/utils/entityDisplay.ts` — `entityDisplayTitle(entity)` returns
+   `_title || id`; `entityDisplayTitleWithId(entity)` returns `Title (ID)`.
+2. Migrate all render sites: RelationCards, RelationPicker, EntityPickerModal,
+   CommandPaletteModal, BacktickAutocompletePopup, EntityList, SearchView,
+   EntityDetail.
+3. ESLint `no-restricted-syntax` rule bans `.properties.title` /
+   `.properties['title']` outside the helper and tests, with a message pointing
+   at the helper.
+4. Tests: helper unit tests; a RelationCards search fixture with only `_title`
+   (no `properties.title`); corrected the CommandPalette test that previously
+   asserted the buggy `properties.title` fallback.
+
+## Outcome
+
+Reading `properties.title` for display is now impossible without tripping the
+lint guard, and the metamodel display contract is enforced on the client.

--- a/tickets/relations/FEAT-CXH3OA--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-CXH3OA--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-CXH3OA
+relation: requires
+to: data-entry-ui
+---


### PR DESCRIPTION
## Why

Follow-up to #1002 (which fixed BUG-1P88YM in `RelationCards.vue`). That bug was not a one-off: **"how to display an entity's name" is re-implemented in ~10 frontend components**, and several read `entity.properties.title` directly. `properties.title` is empty for any project whose metamodel `display_property` is not literally `title` (this surfaced in `generiekefuncties-architectuur`, which uses `naam`), so those sites render **bare IDs**. A grep turned up **two more latent instances** of the exact same bug.

This PR removes the class.

## What

**Canonical helper** — `src/utils/entityDisplay.ts`:
- `entityDisplayTitle(entity)` → `entity._title || entity.id` (the backend's `_title` is metamodel-aware and total)
- `entityDisplayTitleWithId(entity)` → `"Title (ID)"` for widgets that show both

**Migrated every render site** onto the helper:
`RelationCards`, `RelationPicker`, `EntityPickerModal`, `CommandPaletteModal`, `BacktickAutocompletePopup`, `EntityList`, `SearchView`, `EntityDetail`.

**Fixed two latent bugs** (same root cause, currently shipping bare IDs):
- `SearchView.vue:155` — global search results
- `EntityDetail.vue:83` — entity detail page heading

**Lint guard** — ESLint `no-restricted-syntax` bans `.properties.title` and `.properties['title']` in display code (helper + tests exempt), with a message pointing at the helper. Verified it errors on both forms.

**Tests:**
- `entityDisplay.test.ts` — helper unit tests
- `RelationCards.test.ts` — a search fixture with **only `_title`** (no `properties.title`), mirroring a non-`title` `display_property`; fails on the old code, passes on the new
- Corrected the `CommandPaletteModal` test that previously asserted the **buggy** `properties.title` fallback as desired behavior — it now asserts the ID fallback

## Prevention rationale (5-whys close-out)

The systemic root cause from BUG-1P88YM was: display-title logic duplicated with no canonical helper, **and** test fixtures that always set `properties.title`, so the divergence was invisible in CI. This PR addresses both halves — one helper (removes drift), a lint guard (prevents reintroduction), and a non-`title` fixture (makes the gap fail loudly).

## Notes

- Implements `FEAT-CXH3OA` (ticket entity included for the Rela Tickets gate).
- Based on `develop`. It touches the same `RelationCards.vue` lines as #1002; if #1002 merges first, the merge of this branch resolves trivially in favor of the helper (the helper expression supersedes the `_title` literal). Happy to rebase onto #1002 instead if preferred.
- `npm run typecheck` clean; `npm run lint` 0 errors; full suite 1076/1076.
