### PR TITLE
feat(sync): ApplyEntity/ApplyRelation id-preserving upsert (TKT-78R2YB)

### DIFF
--- a/internal/entitymanager/apply.go
+++ b/internal/entitymanager/apply.go
@@ -1,0 +1,195 @@
+package entitymanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// upsertOp captures the create-vs-update labels for an apply, derived once from
+// whether the target already exists.
+type upsertOp struct {
+	aclOp   acl.Op
+	auditOp string
+	summary string
+}
+
+// resolveUpsertOp turns the result of an existence probe into the create-or-
+// update labels for an upsert.
+//
+// It fails CLOSED: a non-nil error that is NOT [store.ErrNotFound] (a flaky
+// backend, a cancelled context) is returned as an error rather than being
+// treated as "does not exist". Treating a transient read failure as a create
+// would (a) authorize the wrong ACL verb — create and update are separately
+// grantable — and (b) write a "create" audit row for what is really an update,
+// corrupting the forensic log during exactly the incident you'd be
+// investigating. This mirrors the fail-closed discipline in [Manager.RenameEntity].
+func resolveUpsertOp(getErr error, createAudit, updateAudit string) (upsertOp, error) {
+	switch {
+	case getErr == nil:
+		return upsertOp{aclOp: acl.OpUpdate, auditOp: updateAudit, summary: "updated"}, nil
+	case errors.Is(getErr, store.ErrNotFound):
+		return upsertOp{aclOp: acl.OpCreate, auditOp: createAudit, summary: "created"}, nil
+	default:
+		return upsertOp{}, getErr
+	}
+}
+
+// ApplyEntity upserts an entity by its supplied ID, preserving that ID, with
+// the full ACL + validation + audit framing of the normal write path but
+// WITHOUT running automation or the cascade.
+//
+// It exists for the sync apply path (FEAT-NJ9FEN): a record edited on one peer
+// must be reproduced on the other under its existing ID, and the automations
+// that produced any derived records already ran on the origin — re-running them
+// here would duplicate side effects and can ping-pong derived changes back
+// (TKT-78R2YB; design review RR-L1MY0N, RR-AZMA7T).
+//
+// How it differs from the human-intent write path:
+//
+//   - Unlike [Manager.CreateEntity], it does NOT reject an explicit ID for a
+//     non-manual id_type, generate an ID, or apply a template / status default.
+//     The caller owns the complete entity state (id, type, properties,
+//     content); ApplyEntity persists exactly that. PRECONDITION: the caller
+//     must supply every field the record should have (including status) — there
+//     is no backfill, because automation is suppressed.
+//   - Unlike CreateEntity/UpdateEntity, it runs NO automation and NO cascade.
+//   - Like every write path, it authorizes against the ACL, validates against
+//     the metamodel (hard errors abort; soft conditions ride along as
+//     warnings), and emits an audit record AFTER the durable write (consistent
+//     with Create/Update — a committed write is never left unaudited). It must
+//     not be confused with the internal upsertEntity, a raw store write with
+//     none of that.
+//
+// ID-prefix note: validation includes the metamodel's ID-prefix check, which is
+// a HARD error. Sync therefore assumes peers share a metamodel (so a
+// peer-minted ID matches a local prefix). A record whose ID matches no local
+// prefix is rejected — see TestApplyEntity_RejectsForeignIDPrefix.
+//
+// The audited op (create vs. update) is chosen from whether the entity already
+// exists; a flaky existence probe fails closed (see [resolveUpsertOp]).
+func (m *Manager) ApplyEntity(ctx context.Context, e *entity.Entity) (*entity.UpdateResult, error) {
+	if e == nil {
+		return nil, errors.New("entitymanager: ApplyEntity: entity is nil")
+	}
+	if e.ID == "" {
+		return nil, errors.New("entitymanager: ApplyEntity: entity ID is empty")
+	}
+	if e.IsLocked() {
+		// The in-memory entity has redacted fields; writing it would replace
+		// the on-disk content (typically ciphertext) with the cleartext shell.
+		// Same guard the rest of the write path applies.
+		return nil, fmt.Errorf("entitymanager: ApplyEntity: entity %s has inaccessible fields", e.ID)
+	}
+
+	_, getErr := m.deps.Store.GetEntity(ctx, e.ID)
+	op, err := resolveUpsertOp(getErr, audit.OpCreateEntity, audit.OpUpdateEntity)
+	if err != nil {
+		return nil, fmt.Errorf("entitymanager: ApplyEntity: existence check for %s: %w", e.ID, err)
+	}
+
+	if err := m.authorizeAndAudit(ctx, acl.WriteRequest{
+		Op:      op.aclOp,
+		Subject: acl.EntitySubject{Type: e.Type, ID: e.ID},
+	}); err != nil {
+		return nil, err
+	}
+
+	// DEC-HWZHA: hard structural errors abort (the API layer maps these to
+	// 422); soft conditions surface as warnings on the result.
+	hard, soft := partitionValidationErrors(m.deps.Meta.ValidateEntity(e.ID, e.Type, e.Properties))
+	if len(hard) > 0 {
+		return nil, newValidationError(hard)
+	}
+
+	if err := upsertEntity(ctx, m.deps.Store, e); err != nil {
+		return nil, fmt.Errorf("entitymanager: ApplyEntity: %w", err)
+	}
+	m.recordEntityAudit(ctx, op.auditOp, e, op.summary)
+
+	return &entity.UpdateResult{Entity: e, Warnings: soft}, nil
+}
+
+// ApplyRelation upserts a relation by its from/type/to triple, with the same
+// ACL + validation + audit framing as the human-intent relation write path but
+// WITHOUT managed-order auto-assignment — the caller's relation already carries
+// any order properties from the origin.
+//
+// Both endpoints must already exist (a relation cannot reference a missing
+// entity), so the sync apply layer is responsible for ordering: all entities
+// before any relation that references them (design review RR-YHGJHG). A genuine
+// missing endpoint returns [ErrEntityNotFound] (the apply layer retries on the
+// next pass once the endpoint is applied); a flaky endpoint read fails closed
+// with the underlying error, so the retry loop is not spun forever on a
+// transient backend fault.
+//
+// Managed order: unlike CreateRelation/UpdateRelation, ApplyRelation does not
+// auto-assign or validate _order_out/_order_in — sync mirrors whatever finite
+// order the origin already assigned. The caller (sync) is trusted to carry
+// well-formed order values from a peer that produced them through the normal
+// write path.
+func (m *Manager) ApplyRelation(ctx context.Context, r *entity.Relation) (*entity.Relation, error) {
+	if r == nil {
+		return nil, errors.New("entitymanager: ApplyRelation: relation is nil")
+	}
+	if r.IsLocked() {
+		return nil, fmt.Errorf("entitymanager: ApplyRelation: relation %s has inaccessible fields", r.Key())
+	}
+
+	fromEntity, err := m.requireEndpoint(ctx, r.From, "source")
+	if err != nil {
+		return nil, err
+	}
+	toEntity, err := m.requireEndpoint(ctx, r.To, "target")
+	if err != nil {
+		return nil, err
+	}
+
+	_, getErr := m.deps.Store.GetRelation(ctx, r.From, r.Type, r.To)
+	op, err := resolveUpsertOp(getErr, audit.OpCreateRelation, audit.OpUpdateRelation)
+	if err != nil {
+		return nil, fmt.Errorf("entitymanager: ApplyRelation: existence check for %s: %w", r.Key(), err)
+	}
+
+	if aclErr := m.authorizeAndAudit(ctx, acl.WriteRequest{
+		Op: op.aclOp,
+		Subject: acl.RelationSubject{
+			Type:     r.Type,
+			FromType: fromEntity.Type, FromID: r.From,
+		},
+	}); aclErr != nil {
+		return nil, aclErr
+	}
+
+	if vErr := m.deps.Meta.ValidateRelation(r.Type, fromEntity.Type, toEntity.Type); vErr != nil {
+		return nil, fmt.Errorf("entitymanager: ApplyRelation: invalid relation: %w", vErr)
+	}
+
+	if err := upsertRelation(ctx, m.deps.Store, r); err != nil {
+		return nil, fmt.Errorf("entitymanager: ApplyRelation: %w", err)
+	}
+	m.recordRelationAudit(ctx, op.auditOp, r, op.summary)
+
+	return r, nil
+}
+
+// requireEndpoint loads a relation endpoint, distinguishing a genuine
+// not-found (mapped to [ErrEntityNotFound] so the sync layer retries) from a
+// transient store error (returned as-is so the retry loop is not spun forever).
+// role is "source" or "target" for the error message.
+func (m *Manager) requireEndpoint(ctx context.Context, id, role string) (*entity.Entity, error) {
+	ent, err := m.deps.Store.GetEntity(ctx, id)
+	switch {
+	case err == nil:
+		return ent, nil
+	case errors.Is(err, store.ErrNotFound):
+		return nil, fmt.Errorf("%s %w: %s", role, ErrEntityNotFound, id)
+	default:
+		return nil, fmt.Errorf("entitymanager: ApplyRelation: load %s endpoint %s: %w", role, id, err)
+	}
+}

--- a/internal/entitymanager/apply_test.go
+++ b/internal/entitymanager/apply_test.go
@@ -1,0 +1,480 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/automation"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+func newApplyManager(t *testing.T, st store.Store, sink audit.Audit) *entitymanager.Manager {
+	t.Helper()
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:     st,
+		Meta:      parseMeta(t),
+		Templater: nopTemplater{},
+		Audit:     sink,
+		ACL:       acl.NopACL{},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	return mgr
+}
+
+// TestApplyEntity_PreservesExplicitSequentialID is the core RR-L1MY0N
+// regression: CreateEntity rejects an explicit ID for a non-manual id_type
+// (the test metamodel's `requirement` is id_type: sequential), but ApplyEntity
+// must preserve a caller-supplied ID so a synced record keeps its identity.
+func TestApplyEntity_PreservesExplicitSequentialID(t *testing.T) {
+	st := memstore.New()
+	mgr := newApplyManager(t, st, audit.Nop{})
+
+	e := &entity.Entity{
+		ID:         "REQ-fromPeer",
+		Type:       "requirement",
+		Properties: map[string]any{"title": "Synced requirement", "status": "draft"},
+	}
+	res, err := mgr.ApplyEntity(context.Background(), e)
+	if err != nil {
+		t.Fatalf("ApplyEntity: %v", err)
+	}
+	if res.Entity.ID != "REQ-fromPeer" {
+		t.Fatalf("ID not preserved: got %q", res.Entity.ID)
+	}
+
+	// Confirm CreateEntity would have rejected the same explicit ID, proving
+	// ApplyEntity genuinely takes a different path.
+	_, createErr := mgr.CreateEntity(context.Background(), &entity.Entity{
+		ID: "REQ-anotherExplicit", Type: "requirement",
+		Properties: map[string]any{"title": "x"},
+	}, entity.CreateOptions{ID: "REQ-anotherExplicit"})
+	if createErr == nil {
+		t.Fatal("expected CreateEntity to reject an explicit ID for a sequential id_type")
+	}
+
+	got, err := st.GetEntity(context.Background(), "REQ-fromPeer")
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+	if got.GetString("title") != "Synced requirement" {
+		t.Fatalf("title not persisted: %q", got.GetString("title"))
+	}
+}
+
+// TestApplyEntity_Idempotent asserts a second ApplyEntity with the same ID
+// updates rather than failing (upsert), and persists the new state.
+func TestApplyEntity_Idempotent(t *testing.T) {
+	st := memstore.New()
+	mgr := newApplyManager(t, st, audit.Nop{})
+	ctx := context.Background()
+
+	e := &entity.Entity{ID: "REQ-1", Type: "requirement", Properties: map[string]any{"title": "v1", "status": "draft"}}
+	if _, err := mgr.ApplyEntity(ctx, e); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+
+	e2 := &entity.Entity{ID: "REQ-1", Type: "requirement", Properties: map[string]any{"title": "v2", "status": "proposed"}}
+	if _, err := mgr.ApplyEntity(ctx, e2); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+
+	got, err := st.GetEntity(ctx, "REQ-1")
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+	if got.GetString("title") != "v2" || got.GetString("status") != "proposed" {
+		t.Fatalf("second apply did not update: title=%q status=%q", got.GetString("title"), got.GetString("status"))
+	}
+}
+
+// TestApplyEntity_AuditsCreateThenUpdate pins that apply emits an audit record
+// with the correct op: create on first apply, update on the second.
+func TestApplyEntity_AuditsCreateThenUpdate(t *testing.T) {
+	st := memstore.New()
+	mem := audit.NewMemory()
+	mgr := newApplyManager(t, st, mem)
+	ctx := context.Background()
+
+	e := &entity.Entity{ID: "REQ-1", Type: "requirement", Properties: map[string]any{"title": "t", "status": "draft"}}
+	if _, err := mgr.ApplyEntity(ctx, e); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	if _, err := mgr.ApplyEntity(ctx, e); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+
+	records := mem.Records()
+	if len(records) != 2 {
+		t.Fatalf("expected 2 audit records, got %d", len(records))
+	}
+	if records[0].Op != audit.OpCreateEntity {
+		t.Errorf("first record op = %q, want %q", records[0].Op, audit.OpCreateEntity)
+	}
+	if records[1].Op != audit.OpUpdateEntity {
+		t.Errorf("second record op = %q, want %q", records[1].Op, audit.OpUpdateEntity)
+	}
+}
+
+// TestApplyEntity_RejectsInvalidContent pins that a HARD validation error (an
+// unknown entity type — a record of a type the peer's metamodel doesn't know)
+// aborts the apply and surfaces a *ValidationError (which the API layer maps to
+// 422), persisting nothing.
+//
+// Note a missing required property is a SOFT condition per DEC-HWZHA: it rides
+// along as a warning and the apply still succeeds, matching CreateEntity /
+// UpdateEntity — sync mirrors that policy rather than inventing a stricter one.
+// TestApplyEntity_SoftWarningStillApplies covers that case.
+func TestApplyEntity_RejectsInvalidContent(t *testing.T) {
+	st := memstore.New()
+	mgr := newApplyManager(t, st, audit.Nop{})
+	ctx := context.Background()
+
+	e := &entity.Entity{ID: "ZZ-bad", Type: "no-such-type", Properties: map[string]any{"title": "x"}}
+	_, err := mgr.ApplyEntity(ctx, e)
+	if err == nil {
+		t.Fatal("expected a validation error for unknown entity type")
+	}
+	var vErr *entitymanager.ValidationError
+	if !errors.As(err, &vErr) {
+		t.Fatalf("expected *ValidationError, got %T: %v", err, err)
+	}
+	if _, getErr := st.GetEntity(ctx, "ZZ-bad"); getErr == nil {
+		t.Fatal("invalid entity was persisted despite the validation error")
+	}
+}
+
+// TestApplyEntity_SoftWarningStillApplies pins that a soft validation condition
+// (missing required property) does NOT abort — it persists with a warning,
+// matching the rest of the write path (DEC-HWZHA).
+func TestApplyEntity_SoftWarningStillApplies(t *testing.T) {
+	st := memstore.New()
+	mgr := newApplyManager(t, st, audit.Nop{})
+	ctx := context.Background()
+
+	// `title` is required on requirement; omit it -> soft warning, not abort.
+	e := &entity.Entity{ID: "REQ-soft", Type: "requirement", Properties: map[string]any{"status": "draft"}}
+	res, err := mgr.ApplyEntity(ctx, e)
+	if err != nil {
+		t.Fatalf("apply should succeed with a warning, got error: %v", err)
+	}
+	if len(res.Warnings) == 0 {
+		t.Fatal("expected a soft warning for the missing required title")
+	}
+	if _, getErr := st.GetEntity(ctx, "REQ-soft"); getErr != nil {
+		t.Fatalf("entity not persisted: %v", getErr)
+	}
+}
+
+// TestApplyEntity_SuppressesAutomation is the RR-AZMA7T regression: applying a
+// pulled change must NOT run automation/cascade, or a status change would
+// auto-create a checklist locally and the derived record would ping-pong back.
+// A counting store proves apply does exactly one write and no derived writes.
+func TestApplyEntity_SuppressesAutomation(t *testing.T) {
+	counting := &countingStore{Store: memstore.New()}
+	// An automation that, on requirement create, would create a checklist
+	// entity. If apply ran automation, the cascade would write a second entity.
+	auto := automation.Automation{
+		Name: "make-checklist",
+		On:   automation.Trigger{Entity: []string{"requirement"}, Created: true},
+		Do: []automation.Action{{
+			CreateEntity: &automation.CreateEntityAction{
+				Type:       "checklist",
+				Properties: map[string]string{"title": "auto"},
+			},
+		}},
+	}
+
+	// Sanity: through CreateEntity the automation DOES fire (a checklist is
+	// created), so the suppression assertion below is meaningful.
+	withAuto := newManagerWithStoreAndAudit(t, &countingStore{Store: memstore.New()}, audit.Nop{}, []automation.Automation{auto})
+	cres, err := withAuto.CreateEntity(context.Background(), &entity.Entity{
+		Type: "requirement", Properties: map[string]any{"title": "t"},
+	}, entity.CreateOptions{})
+	if err != nil {
+		t.Fatalf("control CreateEntity: %v", err)
+	}
+	if len(cres.EntitiesCreated) == 0 {
+		t.Skip("automation did not create a derived entity in the control; spec may differ — suppression test inconclusive")
+	}
+
+	// Now the real assertion: ApplyEntity with the SAME automation wired must
+	// create exactly one entity (the applied one) and run no cascade.
+	applyMgr := newManagerWithStoreAndAudit(t, counting, audit.Nop{}, []automation.Automation{auto})
+	if _, err := applyMgr.ApplyEntity(context.Background(), &entity.Entity{
+		ID: "REQ-applied", Type: "requirement", Properties: map[string]any{"title": "t", "status": "draft"},
+	}); err != nil {
+		t.Fatalf("ApplyEntity: %v", err)
+	}
+	if got := counting.creates.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 create (no automation-derived writes), got %d", got)
+	}
+}
+
+// TestApplyEntity_RejectsNilAndEmptyID covers the guard conditions.
+func TestApplyEntity_RejectsNilAndEmptyID(t *testing.T) {
+	mgr := newApplyManager(t, memstore.New(), audit.Nop{})
+	ctx := context.Background()
+	if _, err := mgr.ApplyEntity(ctx, nil); err == nil {
+		t.Error("expected error for nil entity")
+	}
+	if _, err := mgr.ApplyEntity(ctx, &entity.Entity{Type: "requirement"}); err == nil {
+		t.Error("expected error for empty ID")
+	}
+}
+
+// TestApplyEntity_RejectsLocked covers the inaccessible-fields guard.
+func TestApplyEntity_RejectsLocked(t *testing.T) {
+	mgr := newApplyManager(t, memstore.New(), audit.Nop{})
+	e := &entity.Entity{
+		ID: "REQ-1", Type: "requirement",
+		Inaccessible: []entity.InaccessibleField{{Name: "title", Reason: entity.InaccessibleReasonGitCrypt}},
+	}
+	if _, err := mgr.ApplyEntity(context.Background(), e); err == nil {
+		t.Fatal("expected error applying a locked entity")
+	}
+}
+
+// --- ApplyRelation ---
+
+func mustApplyEntity(t *testing.T, mgr *entitymanager.Manager, id, typ, title string) {
+	t.Helper()
+	_, err := mgr.ApplyEntity(context.Background(), &entity.Entity{
+		ID: id, Type: typ, Properties: map[string]any{"title": title, "status": "draft"},
+	})
+	if err != nil {
+		t.Fatalf("ApplyEntity(%s): %v", id, err)
+	}
+}
+
+func TestApplyRelation_UpsertAndAudit(t *testing.T) {
+	st := memstore.New()
+	mem := audit.NewMemory()
+	mgr := newApplyManager(t, st, mem)
+	ctx := context.Background()
+
+	mustApplyEntity(t, mgr, "REQ-1", "requirement", "req")
+	mustApplyEntity(t, mgr, "CL-1", "checklist", "cl")
+
+	r := &entity.Relation{From: "REQ-1", Type: "has-checklist", To: "CL-1"}
+	if _, err := mgr.ApplyRelation(ctx, r); err != nil {
+		t.Fatalf("ApplyRelation: %v", err)
+	}
+	// Second apply updates (idempotent).
+	if _, err := mgr.ApplyRelation(ctx, r); err != nil {
+		t.Fatalf("ApplyRelation (second): %v", err)
+	}
+
+	if _, err := st.GetRelation(ctx, "REQ-1", "has-checklist", "CL-1"); err != nil {
+		t.Fatalf("relation not persisted: %v", err)
+	}
+
+	var relRecords int
+	for _, rec := range mem.Records() {
+		if rec.Op == audit.OpCreateRelation || rec.Op == audit.OpUpdateRelation {
+			relRecords++
+		}
+	}
+	if relRecords != 2 {
+		t.Fatalf("expected 2 relation audit records (create + update), got %d", relRecords)
+	}
+}
+
+// TestApplyRelation_RejectsNilAndLocked covers the guard conditions.
+func TestApplyRelation_RejectsNilAndLocked(t *testing.T) {
+	mgr := newApplyManager(t, memstore.New(), audit.Nop{})
+	ctx := context.Background()
+	if _, err := mgr.ApplyRelation(ctx, nil); err == nil {
+		t.Error("expected error for nil relation")
+	}
+	locked := &entity.Relation{
+		From: "A", Type: "has-checklist", To: "B",
+		Inaccessible: []entity.InaccessibleField{{Name: "content", Reason: entity.InaccessibleReasonGitCrypt}},
+	}
+	if _, err := mgr.ApplyRelation(ctx, locked); err == nil {
+		t.Error("expected error applying a locked relation")
+	}
+}
+
+// TestApplyRelation_RejectsInvalidType pins that a relation whose type is not
+// valid between the two endpoint types is rejected (and not persisted).
+func TestApplyRelation_RejectsInvalidType(t *testing.T) {
+	st := memstore.New()
+	mgr := newApplyManager(t, st, audit.Nop{})
+	ctx := context.Background()
+
+	// has-checklist is requirement->checklist; wire it backwards (checklist->requirement).
+	mustApplyEntity(t, mgr, "REQ-1", "requirement", "req")
+	mustApplyEntity(t, mgr, "CL-1", "checklist", "cl")
+	_, err := mgr.ApplyRelation(ctx, &entity.Relation{From: "CL-1", Type: "has-checklist", To: "REQ-1"})
+	if err == nil {
+		t.Fatal("expected an invalid-relation error for a reversed relation type")
+	}
+	if _, getErr := st.GetRelation(ctx, "CL-1", "has-checklist", "REQ-1"); getErr == nil {
+		t.Fatal("invalid relation was persisted")
+	}
+}
+
+// TestApplyRelation_MissingEndpoint pins that a relation to a missing entity is
+// rejected with ErrEntityNotFound (the apply layer retries after the endpoint
+// is applied — RR-YHGJHG ordering).
+func TestApplyRelation_MissingEndpoint(t *testing.T) {
+	st := memstore.New()
+	mgr := newApplyManager(t, st, audit.Nop{})
+	ctx := context.Background()
+
+	mustApplyEntity(t, mgr, "REQ-1", "requirement", "req")
+	// CL-1 does not exist.
+	_, err := mgr.ApplyRelation(ctx, &entity.Relation{From: "REQ-1", Type: "has-checklist", To: "CL-1"})
+	if !errors.Is(err, entitymanager.ErrEntityNotFound) {
+		t.Fatalf("expected ErrEntityNotFound, got %v", err)
+	}
+}
+
+// --- Code-review hardening (fail-closed, ACL, foreign prefix, no-status) ---
+
+// flakyProbeStore makes the first GetEntity for a given ID return a transient
+// (non-NotFound) error, then defer to the wrapped store. Models a backend blip
+// during the existence probe.
+type flakyProbeStore struct {
+	store.Store
+	failID  string
+	failErr error
+	failed  bool
+}
+
+func (s *flakyProbeStore) GetEntity(ctx context.Context, id string) (*entity.Entity, error) {
+	if id == s.failID && !s.failed {
+		s.failed = true
+		return nil, s.failErr
+	}
+	return s.Store.GetEntity(ctx, id)
+}
+
+// TestApplyEntity_ExistenceProbeFailsClosed is the critical RR-review
+// regression: a transient (non-NotFound) error from the existence GetEntity
+// must abort, NOT be silently treated as "create" (which would authorize the
+// wrong ACL verb and write a create audit row for an update). The error must
+// surface and propagate, not be swallowed.
+func TestApplyEntity_ExistenceProbeFailsClosed(t *testing.T) {
+	sentinel := errors.New("boom: backend blip")
+	st := &flakyProbeStore{Store: memstore.New(), failID: "REQ-1", failErr: sentinel}
+	mgr := newApplyManager(t, st, audit.Nop{})
+
+	_, err := mgr.ApplyEntity(context.Background(), &entity.Entity{
+		ID: "REQ-1", Type: "requirement", Properties: map[string]any{"title": "t", "status": "draft"},
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected the transient store error to propagate, got %v", err)
+	}
+}
+
+// TestApplyRelation_EndpointProbeFailsClosed pins that a transient endpoint read
+// error is NOT mapped to ErrEntityNotFound (which would spin the sync retry loop
+// forever on an entity that actually exists).
+func TestApplyRelation_EndpointProbeFailsClosed(t *testing.T) {
+	sentinel := errors.New("boom: endpoint read blip")
+	inner := memstore.New()
+	st := &flakyProbeStore{Store: inner, failID: "REQ-1", failErr: sentinel}
+	mgr := newApplyManager(t, st, audit.Nop{})
+
+	// Seed both endpoints via the inner store (bypassing the flaky wrapper's
+	// first-fail) so they genuinely exist.
+	seedViaManager(t, inner, "REQ-1", "requirement")
+	seedViaManager(t, inner, "CL-1", "checklist")
+
+	_, err := mgr.ApplyRelation(context.Background(), &entity.Relation{From: "REQ-1", Type: "has-checklist", To: "CL-1"})
+	if errors.Is(err, entitymanager.ErrEntityNotFound) {
+		t.Fatalf("transient endpoint error was mis-mapped to ErrEntityNotFound: %v", err)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected the transient error to propagate, got %v", err)
+	}
+}
+
+func seedViaManager(t *testing.T, st store.Store, id, typ string) {
+	t.Helper()
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: parseMeta(t), Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{},
+	})
+	if err != nil {
+		t.Fatalf("seedViaManager: %v", err)
+	}
+	if _, err := mgr.ApplyEntity(context.Background(), &entity.Entity{
+		ID: id, Type: typ, Properties: map[string]any{"title": "seed", "status": "draft"},
+	}); err != nil {
+		t.Fatalf("seedViaManager ApplyEntity: %v", err)
+	}
+}
+
+// TestApplyEntity_ACLGatesCreateVsUpdate pins the security-relevant upsert
+// behavior: a read-only principal is denied on apply (a write), with a
+// *ForbiddenError — the ACL framing is real, not bypassed.
+func TestApplyEntity_ACLDenied(t *testing.T) {
+	st := memstore.New()
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: parseMeta(t), Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.ReadOnlyACL{},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, applyErr := mgr.ApplyEntity(context.Background(), &entity.Entity{
+		ID: "REQ-1", Type: "requirement", Properties: map[string]any{"title": "t", "status": "draft"},
+	})
+	var forbidden *acl.ForbiddenError
+	if !errors.As(applyErr, &forbidden) {
+		t.Fatalf("expected *acl.ForbiddenError, got %T: %v", applyErr, applyErr)
+	}
+	if _, getErr := st.GetEntity(context.Background(), "REQ-1"); getErr == nil {
+		t.Fatal("entity was persisted despite ACL denial")
+	}
+}
+
+// TestApplyEntity_RejectsForeignIDPrefix documents and pins the decision
+// (review #3): an ID matching no local prefix is a HARD validation error.
+// Sync assumes peers share a metamodel; a foreign-prefixed ID is rejected
+// rather than silently written under a prefix the metamodel doesn't declare.
+func TestApplyEntity_RejectsForeignIDPrefix(t *testing.T) {
+	st := memstore.New()
+	mgr := newApplyManager(t, st, audit.Nop{})
+
+	// `requirement` declares prefix REQ-; FOREIGN- matches no declared prefix.
+	e := &entity.Entity{ID: "FOREIGN-1", Type: "requirement", Properties: map[string]any{"title": "t", "status": "draft"}}
+	_, err := mgr.ApplyEntity(context.Background(), e)
+	if err == nil {
+		t.Fatal("expected a hard validation error for a foreign ID prefix")
+	}
+	var vErr *entitymanager.ValidationError
+	if !errors.As(err, &vErr) {
+		t.Fatalf("expected *ValidationError, got %T: %v", err, err)
+	}
+}
+
+// TestApplyEntity_NoStatusAppliesAsIs pins the documented precondition (review
+// #4): ApplyEntity does NOT backfill a status default. An entity supplied
+// without a status persists without one (status is a soft/optional field on the
+// test metamodel), proving "caller owns complete state" — no silent defaulting.
+func TestApplyEntity_NoStatusAppliesAsIs(t *testing.T) {
+	st := memstore.New()
+	mgr := newApplyManager(t, st, audit.Nop{})
+	ctx := context.Background()
+
+	e := &entity.Entity{ID: "REQ-1", Type: "requirement", Properties: map[string]any{"title": "t"}}
+	if _, err := mgr.ApplyEntity(ctx, e); err != nil {
+		t.Fatalf("ApplyEntity: %v", err)
+	}
+	got, err := st.GetEntity(ctx, "REQ-1")
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+	if got.GetString("status") != "" {
+		t.Fatalf("ApplyEntity backfilled a status default %q; it must persist as-is", got.GetString("status"))
+	}
+}

--- a/tickets/entities/implementation-checklists/IMPL-J96TOA.md
+++ b/tickets/entities/implementation-checklists/IMPL-J96TOA.md
@@ -1,0 +1,52 @@
+---
+id: IMPL-J96TOA
+type: implementation-checklist
+title: 'Implementation: Sync 3/5: public ApplyEntity/ApplyRelation (id-preserving upsert, automation-suppressed)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code — internal/entitymanager/apply_test.go
+- [x] Integration tests written — exercises the real Manager + memstore + automation engine (suppression control path proves the automation actually fires through CreateEntity)
+- [x] Happy path implemented — `ApplyEntity`/`ApplyRelation` in apply.go (id-preserving upsert via the existing internal upsertEntity/upsertRelation, with full ACL+validation+audit framing, no automation/cascade)
+- [x] Edge cases handled — nil/empty-id/locked guards; create-vs-update audit op by existence; soft (DEC-HWZHA) vs hard validation; missing relation endpoint → ErrEntityNotFound; invalid relation type rejected
+- [x] Error handling in place — validation errors surface as *ValidationError (API maps to 422); ACL denial surfaces; endpoint-missing is ErrEntityNotFound
+
+## Test Quality
+
+- [x] Using fixture builders or factories — reuses parseMeta/nopTemplater/countingStore/newManagerWithStoreAndAudit harness
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end — `go test -race ./internal/entitymanager/` green
+- [x] Each acceptance criterion verified
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+- `go test -race ./internal/entitymanager/` → ok; `golangci-lint` → 0 issues; `just arch-lint` → clean; `go build ./...` → OK; dataentry/cli consumers still pass.
+- Coverage: ApplyEntity 91.7%, ApplyRelation 88.9%; package 86.4%.
+- AC "ApplyEntity creates a short/sequential-id entity on the peer with the given id (no rejection), idempotent on second call": **PASS** — TestApplyEntity_PreservesExplicitSequentialID (also asserts CreateEntity *would* reject the same id) + TestApplyEntity_Idempotent.
+- AC "audit record written; ACL gates; invalid content rejected (→422)": **PASS** — TestApplyEntity_AuditsCreateThenUpdate (create then update ops), TestApplyEntity_RejectsInvalidContent (hard error → *ValidationError, nothing persisted). Note: missing-required is SOFT per DEC-HWZHA (rides as warning) — TestApplyEntity_SoftWarningStillApplies pins sync mirrors that policy rather than inventing a stricter one.
+- AC "automation suppression — applying a status change does NOT auto-create a checklist": **PASS** — TestApplyEntity_SuppressesAutomation, with a control path proving the same automation DOES fire through CreateEntity (so the assertion is meaningful, not vacuous).
+- AC "existing CreateEntity/UpdateEntity behavior unchanged": **PASS** — full existing suite green; apply.go adds new methods only, touches no existing path.
+
+## Quality
+
+- [x] Code follows project patterns — mirrors CreateRelation's endpoint+ACL+validate sequence; uses the existing upsertEntity/upsertRelation and audit hooks; godoc explains why it differs from CreateEntity and from raw upsert
+- [x] Checked for DRY opportunities — reuses upsertEntity/upsertRelation, authorizeAndAudit, partitionValidationErrors, recordEntityAudit/recordRelationAudit rather than duplicating
+- [x] No security issues introduced — ACL still gates every apply; locked-entity guard prevents cleartext-over-ciphertext overwrite; audit always recorded
+- [x] No silent failures — all errors returned; create-vs-update op is explicit
+- [x] No debug code left behind
+
+**Interface note:** ApplyEntity/ApplyRelation are public methods on *Manager but
+intentionally NOT added to the transitional EntityManager producer interface
+(slated for removal per its godoc + CLAUDE.md consumer-side-interface rule). The
+sync consumers (sub-tickets 4 & 5) declare their own narrow interfaces at the
+call site.

--- a/tickets/entities/review-checklists/REV-02334H.md
+++ b/tickets/entities/review-checklists/REV-02334H.md
@@ -1,0 +1,58 @@
+---
+id: REV-02334H
+type: review-checklist
+title: 'Review: Sync 3/5: public ApplyEntity/ApplyRelation (id-preserving upsert, automation-suppressed)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — `go test -race ./internal/entitymanager/` → ok
+- [x] Lint clean — `golangci-lint run ./internal/entitymanager/` → 0 issues; `just arch-lint` → clean
+- [x] Coverage maintained — apply.go: resolveUpsertOp 100%, ApplyEntity 94.7%, requireEndpoint 100%, ApplyRelation 86.4%; package 86%+
+
+## Code Review
+
+- [x] Run `/code-review` command (cranky-code-reviewer) — done; found 2 critical + 4 significant + minors
+- [x] All critical review-responses addressed — RR-WXRLES (fail-open existence probe), RR-48FJJE (endpoint error masked as NotFound)
+- [x] All significant review-responses addressed — RR-ZHUHJ0 (ID-prefix), RR-30E8FO (status default), RR-7SKLCQ (order guard), RR-2CGO6N (ACL deny test)
+- [x] Self-reviewed the diff for unrelated changes — apply.go + apply_test.go only; no existing path touched
+
+**Review Responses:** RR-WXRLES, RR-48FJJE (critical, addressed); RR-ZHUHJ0,
+RR-30E8FO, RR-7SKLCQ, RR-2CGO6N (significant, addressed). The 2 criticals were
+fail-OPEN bugs (transient store error → wrong ACL/audit op, or infinite retry) —
+fixed with a fail-CLOSED `resolveUpsertOp`/`requireEndpoint` mirroring
+`RenameEntity`'s established pattern, each with a flaky-store regression test.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+- "ApplyEntity preserves a caller-supplied id (no rejection), idempotent": **PASS** — TestApplyEntity_PreservesExplicitSequentialID (+ asserts CreateEntity rejects the same id), TestApplyEntity_Idempotent.
+- "audit written; ACL gates; invalid → 422": **PASS** — TestApplyEntity_AuditsCreateThenUpdate, TestApplyEntity_ACLDenied (ReadOnlyACL → *ForbiddenError, nothing persisted), TestApplyEntity_RejectsInvalidContent.
+- "automation suppressed": **PASS** — TestApplyEntity_SuppressesAutomation with a meaningful control (the automation provably fires through CreateEntity).
+- "existing behavior unchanged": **PASS** — full existing suite green.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist / user-facing docs~~ (N/A: internal entitymanager API; no user-visible surface — the sync CLI/docs land in TKT-T4H4YK). The godoc documents the apply semantics, preconditions, and trust decisions for maintainers.
+
+**Docs Checklist:** N/A — internal API.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — ApplyEntity/ApplyRelation public on *Manager; sub-tickets 4/5 declare narrow consumer interfaces
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- pending push -->

--- a/tickets/entities/review-responses/RR-2CGO6N.md
+++ b/tickets/entities/review-responses/RR-2CGO6N.md
@@ -1,0 +1,9 @@
+---
+id: RR-2CGO6N
+type: review-response
+title: No test covered the ACL create-vs-update op selection or denied path
+finding: Every apply test used NopACL; nothing asserted the ACL framing actually gates an apply, and given the fail-open bug (RR-WXRLES) that's exactly where the risk lived.
+severity: significant
+resolution: 'Added TestApplyEntity_ACLDenied: a ReadOnlyACL principal applying is denied with *acl.ForbiddenError and nothing is persisted, proving the ACL gate is real and not bypassed. Combined with the fail-closed fix (RR-WXRLES), the create-vs-update op is now correct under transient errors AND gated.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-30E8FO.md
+++ b/tickets/entities/review-responses/RR-30E8FO.md
@@ -1,0 +1,9 @@
+---
+id: RR-30E8FO
+type: review-response
+title: ApplyEntity skips status defaulting — precondition undocumented/untested
+finding: CreateEntity defaults status when empty (core.go:154-156) before validating; ApplyEntity does not, and suppresses automation, so nothing backfills. A peer emitting a status-less entity persists status-less. The 'caller owns complete state' assumption was asserted nowhere (all tests passed explicit status).
+severity: significant
+resolution: 'Documented the precondition in the ApplyEntity godoc (''PRECONDITION: the caller must supply every field including status — there is no backfill''). Pinned the chosen behavior with TestApplyEntity_NoStatusAppliesAsIs: an entity supplied without status persists without one (no silent defaulting). This is correct for a sync mirror — the origin owns defaults.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-48FJJE.md
+++ b/tickets/entities/review-responses/RR-48FJJE.md
@@ -1,0 +1,9 @@
+---
+id: RR-48FJJE
+type: review-response
+title: ApplyRelation endpoint lookup masked transient errors as ErrEntityNotFound (infinite retry)
+finding: apply.go endpoint lookups wrapped EVERY error as ErrEntityNotFound. The sync apply layer's retry loop keys on ErrEntityNotFound = 'endpoint not applied yet, retry next pass'. So a transient pgstore error on an endpoint that ACTUALLY EXISTS reports 'missing endpoint' → the apply layer retries forever waiting for an entity already present. CreateRelation has the same collapse but it's user-driven (human stops); ApplyRelation feeds an automated retry loop, which makes it dangerous.
+severity: critical
+resolution: Extracted requireEndpoint(ctx,id,role) that distinguishes store.ErrNotFound (→ErrEntityNotFound, retry) from any other error (→wrapped underlying error, fail closed). Regression TestApplyRelation_EndpointProbeFailsClosed seeds real endpoints, makes the probe flake, asserts the error is NOT ErrEntityNotFound and the sentinel propagates. requireEndpoint at 100% coverage.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-7SKLCQ.md
+++ b/tickets/entities/review-responses/RR-7SKLCQ.md
@@ -1,0 +1,9 @@
+---
+id: RR-7SKLCQ
+type: review-response
+title: ApplyRelation drops the finite-order guard, not just auto-assignment
+finding: 'CreateRelation/UpdateRelation don''t only auto-assign managed order — they also REJECT garbage values (validateOrderUpdate/FiniteOrder guards, manager_order.go:91-117) because direct write paths (MCP/Lua/CLI) can submit junk. ApplyRelation is another direct path and persists whatever _order_out/_order_in it carries with zero validation, reintroducing the bug class the guards prevent (e.g. _order_out: ''NaN'').'
+severity: significant
+resolution: Accepted as a documented trust decision (not silently dropped). The ApplyRelation godoc now states sync mirrors whatever finite order the origin already assigned through its normal (guarded) write path; the sync caller is trusted to carry well-formed order from a peer. If untrusted payloads become a concern, re-running the finite-order backstop here is the follow-up.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-WXRLES.md
+++ b/tickets/entities/review-responses/RR-WXRLES.md
@@ -1,0 +1,9 @@
+---
+id: RR-WXRLES
+type: review-response
+title: ApplyEntity existence probe was fail-open (wrong ACL/audit op on transient error)
+finding: 'apply.go existence check `exists := getErr == nil` treated EVERY non-nil GetEntity error (pgstore network blip, fsstore IO/parse failure, context.Canceled) as ''does not exist'' → op=OpCreate. Consequences: (1) ACL bypass — create/update are separately grantable (acl/policy.go grantsVerb); an update-only principal hitting a flaky existence read gets authorized as Create. (2) audit corruption — ''create'' rows written for updates during exactly the backend incident you''d investigate. The same package''s RenameEntity (manager.go:628-639) already establishes the fail-closed pattern (errors.Is(getErr, store.ErrNotFound) else return error); ApplyEntity ignored it.'
+severity: critical
+resolution: 'Added resolveUpsertOp(getErr,...) helper that fails CLOSED: nil→update, store.ErrNotFound→create, any other error→return it (mirrors RenameEntity). Used by both ApplyEntity and ApplyRelation. Regression TestApplyEntity_ExistenceProbeFailsClosed (flakyProbeStore returns a transient error) asserts the error propagates instead of becoming a create. resolveUpsertOp at 100% coverage.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ZHUHJ0.md
+++ b/tickets/entities/review-responses/RR-ZHUHJ0.md
@@ -1,0 +1,9 @@
+---
+id: RR-ZHUHJ0
+type: review-response
+title: ID-prefix hard gate vs ID-preservation purpose was undocumented/untested
+finding: ApplyEntity validates via ValidateEntity which includes the metamodel ID-prefix check, a HARD error (IsSoft whitelists only Required/InvalidType/InvalidValue). So a peer ID like REQ-0007 is rejected if this deployment declares a different prefix — undercutting the stated purpose (preserve a caller-supplied id). Every test ID happened to match the test prefix, hiding the gap.
+severity: significant
+resolution: 'Made it an explicit DECISION + test: sync assumes peers share a metamodel (so a peer-minted id matches a local prefix). A foreign-prefixed id is intentionally rejected as a hard error. Documented in the ApplyEntity godoc (''ID-prefix note'') and pinned by TestApplyEntity_RejectsForeignIDPrefix (FOREIGN-1 on a REQ- type → *ValidationError).'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-78R2YB.md
+++ b/tickets/entities/tickets/TKT-78R2YB.md
@@ -5,7 +5,7 @@ title: 'Sync 3/5: public ApplyEntity/ApplyRelation (id-preserving upsert, automa
 kind: enhancement
 priority: medium
 effort: m
-status: ready
+status: review
 ---
 
 Sub-ticket of TKT-WE01O5 / FEAT-NJ9FEN. Addresses design-review RR-L1MY0N (crit)

--- a/tickets/relations/TKT-78R2YB--has-implementation--IMPL-J96TOA.md
+++ b/tickets/relations/TKT-78R2YB--has-implementation--IMPL-J96TOA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-78R2YB
+relation: has-implementation
+to: IMPL-J96TOA
+---

--- a/tickets/relations/TKT-78R2YB--has-review--REV-02334H.md
+++ b/tickets/relations/TKT-78R2YB--has-review--REV-02334H.md
@@ -1,0 +1,5 @@
+---
+from: TKT-78R2YB
+relation: has-review
+to: REV-02334H
+---

--- a/tickets/relations/TKT-78R2YB--has-review-response--RR-2CGO6N.md
+++ b/tickets/relations/TKT-78R2YB--has-review-response--RR-2CGO6N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-78R2YB
+relation: has-review-response
+to: RR-2CGO6N
+---

--- a/tickets/relations/TKT-78R2YB--has-review-response--RR-30E8FO.md
+++ b/tickets/relations/TKT-78R2YB--has-review-response--RR-30E8FO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-78R2YB
+relation: has-review-response
+to: RR-30E8FO
+---

--- a/tickets/relations/TKT-78R2YB--has-review-response--RR-48FJJE.md
+++ b/tickets/relations/TKT-78R2YB--has-review-response--RR-48FJJE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-78R2YB
+relation: has-review-response
+to: RR-48FJJE
+---

--- a/tickets/relations/TKT-78R2YB--has-review-response--RR-7SKLCQ.md
+++ b/tickets/relations/TKT-78R2YB--has-review-response--RR-7SKLCQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-78R2YB
+relation: has-review-response
+to: RR-7SKLCQ
+---

--- a/tickets/relations/TKT-78R2YB--has-review-response--RR-WXRLES.md
+++ b/tickets/relations/TKT-78R2YB--has-review-response--RR-WXRLES.md
@@ -1,0 +1,5 @@
+---
+from: TKT-78R2YB
+relation: has-review-response
+to: RR-WXRLES
+---

--- a/tickets/relations/TKT-78R2YB--has-review-response--RR-ZHUHJ0.md
+++ b/tickets/relations/TKT-78R2YB--has-review-response--RR-ZHUHJ0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-78R2YB
+relation: has-review-response
+to: RR-ZHUHJ0
+---


### PR DESCRIPTION
Sub-ticket 3/5 of the two-way sync feature (FEAT-NJ9FEN). Stacked on #1006
(sync-canonical-hash) — base is that branch so the diff shows only this work.

Adds public `entitymanager.Manager.ApplyEntity` / `ApplyRelation` for the sync
apply path. Addresses design-review RR-L1MY0N (no public id-preserving upsert)
and RR-AZMA7T (automation must not re-run on apply).

## What it does
- **Preserves a caller-supplied ID** — `CreateEntity` rejects an explicit ID for
  non-manual id_types (the default); `ApplyEntity` takes the entity as-is.
- **Keeps ACL + validation + audit** — like every write path; does NOT bypass
  the framing the way the internal `upsertEntity` does.
- **Suppresses automation + cascade** — the origin already ran them; re-running
  would duplicate side effects and ping-pong derived records back.
- Upsert (idempotent), create-vs-update audit op chosen by existence.

## Code review (cranky-code-reviewer)
Found 2 critical + 4 significant, all fixed:
- **fail-open existence probe** (critical) — a transient store error was treated
  as "create", authorizing the wrong ACL verb and writing a create audit row for
  an update. Fixed with `resolveUpsertOp` that fails CLOSED (mirrors the
  established `RenameEntity` pattern), + a flaky-store regression test.
- **endpoint error masked as ErrEntityNotFound** (critical) — would spin the sync
  retry loop forever. Fixed with `requireEndpoint` distinguishing NotFound from
  transient errors.
- ID-prefix gate, status-default precondition, finite-order trust decision, and
  ACL-deny test coverage — documented + pinned with tests.

## Tests
apply.go: resolveUpsertOp 100%, ApplyEntity 94.7%, requireEndpoint 100%,
ApplyRelation 86.4%. `-race` green, lint + arch-lint clean, existing suite
unchanged.