### PR TITLE
fix(markdown): make FormatMarkdown idempotent for all callers

### DIFF
--- a/internal/canonical/canonical.go
+++ b/internal/canonical/canonical.go
@@ -118,34 +118,17 @@ func (w *writer) field(key, value string) {
 	w.str(value)
 }
 
-// body writes the markdown body after normalizing it to a formatting fixed
-// point, so fsstore's reflowed body and pgstore's raw content converge.
+// body writes the markdown body after normalizing it through the shared
+// formatter, so fsstore's reflowed body and pgstore's raw content converge.
+//
+// This relies on [markdown.FormatMarkdown] being idempotent — fsstore stores
+// FormatMarkdown(raw) and pgstore stores raw, so the hash re-formats both and
+// they must land on identical bytes. FormatMarkdown guarantees that (it
+// iterates to a fixed point internally); markdown's FuzzFormatMarkdownIdempotent
+// and TestBodyConvergence here guard it.
 func (w *writer) body(content string) {
 	w.str("body")
-	w.str(canonicalBody(content))
-}
-
-// canonicalBody reduces a markdown body to a formatting fixed point.
-//
-// fsstore stores FormatMarkdown(raw); pgstore stores raw. Re-running
-// FormatMarkdown on read is supposed to converge them, but FormatMarkdown is
-// not idempotent for every input (e.g. "0) \n\n0" formats to "\n0\n" then to
-// "0\n"), so a single pass can leave fs one step ahead of pg. Iterating to a
-// fixed point makes the result independent of how many passes either side has
-// already applied. Convergence is fast (≤2 steps observed); the bound is a
-// safety net against a pathological non-converging input — if hit, the
-// last value is still deterministic for a given input.
-func canonicalBody(content string) string {
-	const maxPasses = 8
-	s := markdown.FormatMarkdown(content)
-	for range maxPasses {
-		next := markdown.FormatMarkdown(s)
-		if next == s {
-			return s
-		}
-		s = next
-	}
-	return s
+	w.str(markdown.FormatMarkdown(content))
 }
 
 // properties writes every property in sorted-key order. The count is written

--- a/internal/canonical/roundtrip_test.go
+++ b/internal/canonical/roundtrip_test.go
@@ -154,7 +154,8 @@ func TestBodyConvergence(t *testing.T) {
 	bodies := []string{
 		"",
 		"# Title\n\nA paragraph.\n",
-		"0) \n\n0", // FormatMarkdown is non-idempotent here
+		"0) \n\n0", // FormatMarkdown leaves then strips a leading blank line
+		"**\n*",    // goldmark re-parses its own output ("** *" -> "---")
 		"- a\n\n- b\n",
 		"```\ncode\n```\n",
 		"a very long line of prose that the formatter will wrap somewhere near the eighty column mark when it normalizes the body into canonical form for hashing",
@@ -176,7 +177,7 @@ func TestBodyConvergence(t *testing.T) {
 // once-formatted (fs) must hash identically, regardless of FormatMarkdown's
 // idempotency.
 func FuzzBodyConvergence(f *testing.F) {
-	for _, s := range []string{"", "# h\n\ntext\n", "0) \n\n0", "- a\n- b\n", "```\nx\n```\n"} {
+	for _, s := range []string{"", "# h\n\ntext\n", "0) \n\n0", "**\n*", "- a\n- b\n", "```\nx\n```\n"} {
 		f.Add(s)
 	}
 	f.Fuzz(func(t *testing.T, body string) {

--- a/internal/markdown/format.go
+++ b/internal/markdown/format.go
@@ -16,6 +16,12 @@ var orderedListPattern = regexp.MustCompile(`^\d+\.\s`)
 // DefaultLineWidth is the default line width for paragraph wrapping.
 const DefaultLineWidth = 80
 
+// maxFormatPasses bounds the fixed-point iteration in
+// [FormatMarkdownWithWidth]. Convergence is fast in practice (≤2 passes across
+// the fuzz corpus); the bound is a backstop against a pathological input that
+// never settles, in which case the last pass is still returned deterministically.
+const maxFormatPasses = 8
+
 // FormatMarkdown normalizes markdown content using consistent formatting rules:
 // - ATX-style headings (#)
 // - Consistent list markers
@@ -23,18 +29,42 @@ const DefaultLineWidth = 80
 // - Consistent code fence style
 // - Paragraph text wrapped at 80 characters
 //
+// The result is idempotent: FormatMarkdown(FormatMarkdown(x)) == FormatMarkdown(x).
 // Returns the formatted content, or the original content if formatting fails.
 func FormatMarkdown(content string) string {
 	return FormatMarkdownWithWidth(content, DefaultLineWidth)
 }
 
-// FormatMarkdownWithWidth normalizes markdown content with a specific line width.
+// FormatMarkdownWithWidth normalizes markdown content with a specific line
+// width, iterating to a formatting fixed point so the result is idempotent.
+//
+// A single goldmark round-trip is NOT idempotent for every input — goldmark can
+// re-parse its own output into a different document (e.g. "**\n*" renders to
+// "** *", which on the next pass parses as a thematic break "---"). Callers that
+// re-normalize already-formatted content rely on idempotency: the canonical
+// content hash (internal/canonical) re-formats both fsstore's reflowed body and
+// pgstore's raw body, and they must converge in one call. Iterating here makes
+// that hold for every caller rather than pushing the loop onto each one.
 func FormatMarkdownWithWidth(content string, lineWidth int) string {
 	if content == "" {
 		return ""
 	}
+	result := content
+	for range maxFormatPasses {
+		next := formatOnce(result, lineWidth)
+		if next == result {
+			break
+		}
+		result = next
+	}
+	return result
+}
 
-	// Trim trailing whitespace but preserve structure
+// formatOnce applies one pass of markdown normalization (goldmark render +
+// paragraph wrap + blank-line trim). It is not necessarily idempotent on its
+// own; [FormatMarkdownWithWidth] iterates it to a fixed point.
+func formatOnce(content string, lineWidth int) string {
+	// Trim trailing whitespace but preserve structure.
 	content = strings.TrimRight(content, " \t")
 
 	r := markdown.NewRenderer(
@@ -46,19 +76,16 @@ func FormatMarkdownWithWidth(content string, lineWidth int) string {
 
 	var buf bytes.Buffer
 	if err := md.Convert([]byte(content), &buf); err != nil {
-		// If formatting fails, return original content
+		// If formatting fails, return original content.
 		return content
 	}
 
-	result := buf.String()
+	result := wrapParagraphs(buf.String(), lineWidth)
 
-	// Post-process: wrap paragraphs at line width
-	result = wrapParagraphs(result, lineWidth)
-
-	// Ensure single trailing newline
-	result = strings.TrimRight(result, "\n") + "\n"
-
-	return result
+	// Normalize surrounding blank lines to a single trailing newline. Trimming
+	// the leading newline (not just the trailing) is part of what lets the
+	// iteration converge: goldmark can emit a leading blank line for some inputs.
+	return strings.Trim(result, "\n") + "\n"
 }
 
 // wrapParagraphs wraps paragraph text while preserving code blocks, lists, headings, etc.

--- a/internal/markdown/parser_fuzz_test.go
+++ b/internal/markdown/parser_fuzz_test.go
@@ -167,3 +167,27 @@ func trimContent(s string) string {
 	}
 	return s
 }
+
+// FuzzFormatMarkdownIdempotent guards the formatter's idempotency contract:
+// FormatMarkdown(FormatMarkdown(x)) == FormatMarkdown(x). FormatMarkdownWithWidth
+// iterates a single goldmark pass to a fixed point precisely so this holds (a
+// single pass is not idempotent — goldmark can re-parse its own output, e.g.
+// "**\n*" -> "** *" -> "---"). The canonical content hash relies on this so a
+// body stored raw (pgstore) and stored once-formatted (fsstore) converge.
+//
+// Run with: go test -fuzz=FuzzFormatMarkdownIdempotent -fuzztime=30s ./internal/markdown/
+func FuzzFormatMarkdownIdempotent(f *testing.F) {
+	for _, s := range []string{
+		"", "# H\n\ntext\n", "- a\n- b\n", "1. one\n2. two\n", "```\ncode\n```\n",
+		"> quote\n", "0) \n\n0", "**\n*", "|\n|", "\n\n\nx\n\n\n", "<!-- c -->\n",
+	} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, body string) {
+		once := FormatMarkdown(body)
+		twice := FormatMarkdown(once)
+		if once != twice {
+			t.Fatalf("FormatMarkdown not idempotent:\n once=%q\n twice=%q", once, twice)
+		}
+	})
+}

--- a/tickets/entities/tickets/TKT-H857QO.md
+++ b/tickets/entities/tickets/TKT-H857QO.md
@@ -1,0 +1,49 @@
+---
+id: TKT-H857QO
+type: ticket
+title: FormatMarkdown is not idempotent (re-formatting can change content)
+kind: refactor
+priority: medium
+effort: s
+status: done
+---
+
+## Problem
+
+`markdown.FormatMarkdown` is not idempotent: a single goldmark render+wrap pass
+can produce output that re-parses to a DIFFERENT document. E.g. `**\n*` formats
+to `** *` (our `wrapParagraphs` joins the two lines), and `** *` then parses as
+a thematic break `---`. The fuzzer also finds intrinsic render→reparse cases
+independent of our wrap step.
+
+This was surfaced by the sync canonical content hash (TKT-8FSBGB / FEAT-NJ9FEN):
+the hash re-formats both fsstore's reflowed body and pgstore's raw body, which
+must converge to identical bytes — broken if FormatMarkdown isn't a fixed point.
+
+Discovered during crit review of #1006; the fix shipped as a follow-up PR.
+
+## Fix
+
+- `FormatMarkdownWithWidth` extracts a single `formatOnce` pass and iterates it
+to a fixed point, so `FormatMarkdown(FormatMarkdown(x)) == FormatMarkdown(x)`
+for EVERY caller (fsstore writes, data-entry rendering, the canonical hash) —
+not just the hash. Convergence is ≤2 passes in practice; `maxFormatPasses` is a
+backstop.
+- Removed the equivalent loop from `canonical.canonicalBody`; the hash's
+`body()` is now a plain `FormatMarkdown` call.
+- Restored `FuzzFormatMarkdownIdempotent` as a now-TRUE invariant (passes 453k
+execs; failed in seconds before the fix). `**\n*` and `0) ` pinned as seeds.
+
+## Acceptance
+
+- `FormatMarkdown(FormatMarkdown(x)) == FormatMarkdown(x)` for arbitrary input
+(fuzz-verified).
+- No behavior change for normal content; only degenerate inputs settle to a
+stable form.
+- All formatter consumers (store, dataentry, conflict) unchanged and green.
+
+## Notes
+
+Considered handling `**\n*` directly instead of iterating, but the fuzzer proved
+the goldmark round-trip is intrinsically non-idempotent (a class, not one case),
+so iteration to a fixed point is the complete fix. See PR #1008 + crit thread.

--- a/tickets/relations/TKT-H857QO--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-H857QO--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-H857QO
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-H857QO--affects--store-backends.md
+++ b/tickets/relations/TKT-H857QO--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-H857QO
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-H857QO--implements--FEAT-NJ9FEN.md
+++ b/tickets/relations/TKT-H857QO--implements--FEAT-NJ9FEN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-H857QO
+relation: implements
+to: FEAT-NJ9FEN
+---


### PR DESCRIPTION
Crit-review follow-up to #1006 (which merged before the review changes landed).

`FormatMarkdown` was not idempotent — a single goldmark round-trip can re-parse
its own output into a different document (`**\n*` → `** *` → `---`, plus
intrinsic cases the fuzzer finds). The canonical content hash (internal/canonical)
relies on idempotency: it re-formats both fsstore's reflowed body and pgstore's
raw body, which must converge.

## Change
- `FormatMarkdownWithWidth` now extracts a single `formatOnce` pass and iterates
  it to a fixed point, so idempotency holds for **every** caller (fsstore writes,
  data-entry rendering, the hash) — not just the canonical package.
- Removed the equivalent loop from `canonical.canonicalBody`; `body()` is now a
  plain `FormatMarkdown` call.
- Restored `FuzzFormatMarkdownIdempotent` as a now-true invariant (passes 453k
  execs; failed in seconds before the fix). `**\n*` and `0) ` pinned as seeds.

No behavior change for normal content — only degenerate inputs settle to a stable
form. Convergence is ≤2 passes in practice.

Reviewed via crit (approved). Build + all formatter consumers (store, dataentry,
conflict) green.