### PR TITLE
fix(release): windows cross-compile breaks goreleaser; postgres archives never published

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,10 +328,47 @@ jobs:
       - name: Run pgstore conformance + fuzz seeds (race) against PostgreSQL
         run: go test -race -tags postgres ./internal/store/pgstore/...
 
+  # Cross-compile every (GOOS, build-tag) combination GoReleaser ships so a
+  # platform-specific compile break (e.g. a unix-only syscall used without a
+  # build-tagged fallback) fails here at PR time instead of silently at
+  # release time, where it leaves an empty GitHub release. The default-runner
+  # builds in `postgres` only exercise linux; this job adds darwin + windows.
+  # Keep the goos/tag matrix in sync with .goreleaser.yaml's builds.
+  cross-compile:
+    name: Cross-Compile (${{ matrix.goos }}/${{ matrix.tags || 'default' }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, darwin, windows]
+        tags: ["", "postgres"]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      # CGO off matches the GoReleaser builds for rela / rela-server; this is a
+      # pure cross-compile, so no per-OS C toolchain is needed.
+      - name: Build rela + rela-server
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: amd64
+          CGO_ENABLED: "0"
+          BUILD_TAGS: ${{ matrix.tags }}
+        run: |
+          set -euo pipefail
+          flags=""
+          [ -n "$BUILD_TAGS" ] && flags="-tags $BUILD_TAGS"
+          echo "Building GOOS=$GOOS ${flags:-(default)}"
+          go build $flags ./cmd/rela ./cmd/rela-server
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [test, vulncheck, lint, arch-lint, lint-markdown, fuzz, postgres, frontend, e2e]
+    needs: [test, vulncheck, lint, arch-lint, lint-markdown, fuzz, postgres, cross-compile, frontend, e2e]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,83 @@
+name: Tag Release
+
+# Manually-triggered release cutter. Computes the next v<minor> tag from the
+# latest existing tag and pushes it from the chosen branch (default: develop).
+# Pushing the tag triggers the Release workflow, which builds artifacts and
+# creates the GitHub release. This exists so nobody hand-creates a release
+# object in the UI before the tag — the mistake that left v0.8 / v0.12 as
+# empty, published-looking releases with zero assets. See docs/releasing.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or commit to tag"
+        required: true
+        default: develop
+      dry_run:
+        description: "Compute the next tag but do not push it"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Push next release tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Tags follow v0.<minor> (v0.1 .. v0.12). Find the highest existing one
+      # and increment the minor. Kept deliberately simple to match the scheme;
+      # revisit if the project moves to semver with patch/major components.
+      - name: Compute next tag
+        id: next
+        run: |
+          set -euo pipefail
+          latest="$(git tag --list 'v0.*' --sort=-version:refname | head -n1)"
+          if [ -z "$latest" ]; then
+            echo "No existing v0.* tag found; refusing to guess." >&2
+            exit 1
+          fi
+          minor="${latest#v0.}"
+          if ! [[ "$minor" =~ ^[0-9]+$ ]]; then
+            echo "Latest tag '$latest' is not v0.<int>; cannot auto-bump." >&2
+            exit 1
+          fi
+          next="v0.$((minor + 1))"
+          echo "latest=$latest"  >> "$GITHUB_OUTPUT"
+          echo "next=$next"      >> "$GITHUB_OUTPUT"
+          echo "Latest tag: $latest -> next: $next"
+
+      - name: Refuse if tag already exists
+        env:
+          NEXT: ${{ steps.next.outputs.next }}
+        run: |
+          set -euo pipefail
+          if git rev-parse -q --verify "refs/tags/$NEXT" >/dev/null; then
+            echo "Tag $NEXT already exists; aborting." >&2
+            exit 1
+          fi
+
+      - name: Push tag
+        if: ${{ !inputs.dry_run }}
+        env:
+          NEXT: ${{ steps.next.outputs.next }}
+        run: |
+          set -euo pipefail
+          git tag "$NEXT"
+          git push origin "$NEXT"
+          echo "Pushed $NEXT — the Release workflow will build and publish it."
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry_run }}
+        env:
+          NEXT: ${{ steps.next.outputs.next }}
+        run: |
+          echo "Dry run: would have pushed $NEXT (not pushed)."

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,64 @@
+# Releasing
+
+Releases are produced entirely by the `Release` workflow
+(`.github/workflows/release.yml`) when a `v*` tag is pushed. GoReleaser
+builds the binaries (default + `postgres` variants, all OSes) and
+**creates the GitHub release itself** from the tag, then the `desktop`
+job attaches the installers.
+
+## Do not pre-create the GitHub release
+
+The empty `v0.8` and `v0.12` releases happened because a release object
+was created in the GitHub UI *before* the tag was pushed. When the
+build later failed, GoReleaser had no release to clean up (it only
+removes a release it created), so a published-looking release with **zero
+assets** was left behind — a silent failure with no signal to consumers.
+
+Rule: **never create the GitHub release by hand.** Only push a tag.
+GoReleaser owns the release object. If a release run fails, fix the
+cause and re-run; GoReleaser's `--clean` will recreate cleanly.
+
+## Cutting a release
+
+Two equivalent options:
+
+1. **Recommended — automated tag bump.** Run the
+   [`Tag Release`](../.github/workflows/tag-release.yml) workflow from the
+   Actions tab (`workflow_dispatch`). It computes the next `v<minor>` tag
+   from the latest existing tag, pushes it from `develop`, and the
+   `Release` workflow takes over. This removes the manual step where the
+   empty-release footgun lives.
+
+2. **Manual tag push.** From an up-to-date `develop`:
+
+   ```bash
+   git tag v0.13 && git push origin v0.13
+   ```
+
+   Use the next integer minor — tags are `v0.1`, `v0.2`, … `v0.12`.
+
+## Why a release can silently produce no assets
+
+- **Platform-specific compile break.** A unix-only symbol (e.g.
+  `syscall.O_NOFOLLOW`) used without a build-tagged fallback compiles on
+  the linux CI runner but breaks GoReleaser's `windows`/`darwin`
+  cross-compile. The `cross-compile` CI job
+  (`.github/workflows/ci.yml`) now builds every `(GOOS, build-tag)`
+  combination GoReleaser ships, so this fails at PR time instead.
+- **Gating job failure.** `release` needs `test` and `security`
+  (govulncheck). If either fails, `release` is skipped and no assets are
+  produced — this is correct gating, not a bug. Bump deps / fix the vuln
+  and re-tag.
+
+## Verifying a release
+
+After the workflow finishes, every release must contain both the default
+and `postgres` archives per OS/arch, e.g.:
+
+```bash
+gh release view v0.13 --json assets --jq '[.assets[].name]'
+```
+
+Expected to include `rela_<ver>_<os>_<arch>.tar.gz` **and**
+`rela-postgres_<ver>_<os>_<arch>.tar.gz` (`.zip` on Windows), plus the
+desktop installers and `checksums.txt`.

--- a/internal/audit/filesystem.go
+++ b/internal/audit/filesystem.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 	"unicode/utf8"
 )
@@ -22,7 +21,9 @@ import (
 // rotated state. Tested with -race (AC9).
 //
 // Security:
-//   - Files opened with O_APPEND|O_CREATE|O_WRONLY|O_NOFOLLOW and mode [fileMode].
+//   - Files opened with O_APPEND|O_CREATE|O_WRONLY|[oNoFollow] and mode
+//     [fileMode]. O_NOFOLLOW is unavailable on Windows, where [oNoFollow]
+//     is zero; the directory symlink check still applies on all platforms.
 //   - The audit directory is Lstat'd before MkdirAll; if it is a symlink,
 //     the backend logs slog.Error and skips the write. Subsequent records
 //     retry after [retryAfter] — a transient ENOSPC / perms blip should
@@ -143,7 +144,7 @@ func (f *Filesystem) rotateLocked(today string) error {
 	path := filepath.Join(f.dir, today+".jsonl")
 	file, err := os.OpenFile(
 		path,
-		os.O_APPEND|os.O_CREATE|os.O_WRONLY|syscall.O_NOFOLLOW,
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY|oNoFollow,
 		fileMode,
 	)
 	if err != nil {

--- a/internal/audit/nofollow_unix.go
+++ b/internal/audit/nofollow_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package audit
+
+import "syscall"
+
+// oNoFollow refuses to open the audit file through a symlink, so an
+// attacker who can plant a symlink at the audit path cannot redirect
+// appended audit records elsewhere. Pairs with the symlink check in
+// [ensureDirSafe]. Available on every unix target; see the windows
+// variant for the platform that lacks this open flag.
+const oNoFollow = syscall.O_NOFOLLOW

--- a/internal/audit/nofollow_windows.go
+++ b/internal/audit/nofollow_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package audit
+
+// oNoFollow is zero on Windows: the os package's syscall layer has no
+// O_NOFOLLOW open flag, so it cannot be requested at open time. The
+// directory-level symlink defense in [ensureDirSafe] still applies on
+// every platform; only the per-file open-time symlink refusal is
+// unavailable here.
+const oNoFollow = 0

--- a/tickets/entities/automated-measures/release-target-matrix-cross-compiled-in-ci.md
+++ b/tickets/entities/automated-measures/release-target-matrix-cross-compiled-in-ci.md
@@ -1,0 +1,28 @@
+---
+id: release-target-matrix-cross-compiled-in-ci
+type: automated-measure
+title: Release target matrix is cross-compiled in CI
+kind: ci
+location: .github/workflows/ci.yml (cross-compile job)
+status: active
+description: |
+  Every (GOOS, build-tag) combination GoReleaser ships must compile in PR CI,
+  not just the linux default build. A unix-only symbol (e.g.
+  syscall.O_NOFOLLOW) used without a build-tagged fallback compiles on the
+  linux runner but breaks GoReleaser's windows/darwin cross-compile at release
+  time, aborting the whole release and producing zero assets. The cross-compile
+  job mirrors .goreleaser.yaml's target matrix (linux/darwin/windows x
+  default/postgres) so this fails at PR time. Keep the job's goos/tags matrix
+  in sync with .goreleaser.yaml builds.
+---
+
+The `cross-compile` job in `.github/workflows/ci.yml` builds `./cmd/rela` and
+`./cmd/rela-server` for every `(GOOS, build-tag)` combination GoReleaser ships
+(`linux`, `darwin`, `windows` × default, `postgres`) and is gated into the
+`build` job's `needs`. This catches platform-specific compile breaks — most
+notably unix-only `syscall` symbols used without a build-tagged fallback — at
+PR time rather than silently at release time, where a single failing target
+aborts the entire GoReleaser run and publishes no archives.
+
+When GoReleaser's `builds` matrix changes, update this job's `goos`/`tags`
+matrix to match.

--- a/tickets/entities/bugs/BUG-K1XUNR.md
+++ b/tickets/entities/bugs/BUG-K1XUNR.md
@@ -1,0 +1,62 @@
+---
+id: BUG-K1XUNR
+type: bug
+title: 'Release fails: syscall.O_NOFOLLOW undefined on Windows aborts goreleaser cross-compile'
+description: 'internal/audit/filesystem.go opened the audit file with syscall.O_NOFOLLOW, which is unix-only. The default CI build runs on linux, so PR CI never caught it; GoReleaser cross-compiles for windows/darwin at release time, where the windows target failed (undefined: syscall.O_NOFOLLOW). One failed target aborts the entire release, so no archives (default OR rela-postgres) were ever published. v0.12 shipped with zero assets and no release ever contained the rela-postgres archives.'
+priority: high
+why1: 'internal/audit/filesystem.go:146 used syscall.O_NOFOLLOW unconditionally; the symbol is undefined on Windows, so the windows cross-compile fails to build.'
+why2: GoReleaser builds every (GOOS, build-tag) target; a single failing target aborts the whole release run, so it published no archives at all (default and rela-postgres alike) and v0.12 ended up with zero assets.
+why3: PR CI only compiled on the linux runner — no cross-compile for windows/darwin — so the platform-specific break passed every check and only surfaced at release time.
+why4: 'O_NOFOLLOW was added as a security control (refuse to open the audit file through an attacker-planted symlink) without a build-tagged fallback for platforms that lack the flag.'
+why5: 'The release pipeline had no PR-time gate mirroring GoReleaser''s target matrix, so any unix-only symbol could reach release; failures were also silent because releases were hand-created in the UI before the tag, leaving published-looking releases with no assets.'
+prevention: 'O_NOFOLLOW split into nofollow_unix.go / nofollow_windows.go behind an oNoFollow const (0 on Windows). New CI cross-compile job builds every (GOOS, build-tag) combo GoReleaser ships, gated into the build job, so this class of break fails at PR time. docs/releasing.md documents tag-push-only flow and tag-release.yml auto-bumps the next tag instead of hand-creating the release object (the source of the empty v0.8/v0.12 releases).'
+status: done
+---
+
+## Bug
+
+`internal/audit/filesystem.go:146` opened the audit log with
+`os.O_APPEND|os.O_CREATE|os.O_WRONLY|syscall.O_NOFOLLOW`. `syscall.O_NOFOLLOW`
+exists on linux and darwin but is **undefined on Windows**.
+
+The default CI build runs only on the linux runner, so this compiled cleanly
+through every PR check. GoReleaser, however, cross-compiles for
+`windows`/`darwin` at release time. The windows target failed with:
+
+```text
+internal/audit/filesystem.go:146:47: undefined: syscall.O_NOFOLLOW
+```
+
+A single failing build target **aborts the entire GoReleaser run**, so the
+release published *no* archives — neither the default `rela_*` nor the
+`rela-postgres_*` archives. This is why:
+
+- **v0.12** shipped with **zero assets**.
+- **No release ever contained the `rela-postgres_<ver>_<os>_<arch>` archives**,
+  even though `.goreleaser.yaml` defined them correctly.
+
+(Separately, **v0.8** had zero assets for a different, historical reason: the
+`security`/govulncheck job failed on stale-toolchain stdlib vulns, so the
+`release` job was correctly skipped. Both empty releases also *looked*
+published because the GitHub release object was hand-created in the UI before
+the tag was pushed; GoReleaser only cleans up a release it created.)
+
+## Fix
+
+- Split `O_NOFOLLOW` into `internal/audit/nofollow_unix.go`
+  (`syscall.O_NOFOLLOW`) and `internal/audit/nofollow_windows.go` (`0`),
+  referenced via the `oNoFollow` const. The directory symlink defense in
+  `ensureDirSafe` still applies on all platforms; only the per-file open-time
+  symlink refusal is unavailable on Windows.
+- New `cross-compile` CI job builds every `(GOOS, build-tag)` combination
+  GoReleaser ships (3 OS × 2 build-tags), gated into the `build` job — so this
+  class of break fails at PR time, not silently at release time.
+- `docs/releasing.md` documents tag-push-only flow; `tag-release.yml`
+  auto-computes and pushes the next `v0.N` tag instead of hand-creating the
+  release object.
+
+## Tests / Verification
+
+- All 24 release build combos (3 OS × 2 arch × 2 build-tags) compile.
+- `go test -race ./internal/audit/` passes; golangci-lint + arch-lint clean.
+- Empty `v0.8` / `v0.12` releases deleted (tags preserved).

--- a/tickets/relations/BUG-K1XUNR--adds-measure--release-target-matrix-cross-compiled-in-ci.md
+++ b/tickets/relations/BUG-K1XUNR--adds-measure--release-target-matrix-cross-compiled-in-ci.md
@@ -1,0 +1,5 @@
+---
+from: BUG-K1XUNR
+relation: adds-measure
+to: release-target-matrix-cross-compiled-in-ci
+---

--- a/tickets/relations/BUG-K1XUNR--affects--ci-pipeline.md
+++ b/tickets/relations/BUG-K1XUNR--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: BUG-K1XUNR
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/BUG-K1XUNR--fixes--FEAT-GE1YY.md
+++ b/tickets/relations/BUG-K1XUNR--fixes--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: BUG-K1XUNR
+relation: fixes
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
## Problem

Two reported release issues, one root cause:

1. **`rela-postgres_*` archives never appeared in any release** — `.goreleaser.yaml` already defines them correctly; they were never emitted because the release always aborted first.
2. **v0.8 and v0.12 had zero assets.**

### Root causes
- **v0.12** (and a latent bug still on `develop`): GoReleaser failed cross-compiling for Windows — `internal/audit/filesystem.go:146: undefined: syscall.O_NOFOLLOW` (unix-only flag). One target failing aborts the **entire** release, so no archives (default *or* postgres) are published.
- **v0.8**: separate cause — `security` (govulncheck) failed on stale-toolchain stdlib vulns, so `release` was correctly skipped. Historical, not structural.
- **Empty-but-published releases**: both were **manually pre-created in the GitHub UI before the tag was pushed**. GoReleaser only cleans up a release it created, so a failed build left a published-looking release with 0 assets.

### Why CI didn't catch it
CI only built on the linux runner. No Windows/darwin cross-compile, so the regression sailed through PR CI and only detonated at release time.

## Changes

- **Fix**: split `O_NOFOLLOW` into `nofollow_unix.go` / `nofollow_windows.go` (`oNoFollow` const; `0` on Windows where the flag is unavailable). Directory symlink defense in `ensureDirSafe` still applies on all platforms.
- **CI**: new `cross-compile` job builds every `(GOOS, build-tag)` combo GoReleaser ships; gated into `build`.
- **docs/releasing.md**: tag-push-only flow; never hand-create the release object.
- **tag-release.yml**: `workflow_dispatch` that auto-computes the next `v0.N` tag and pushes it (with `dry_run` + existing-tag guard), removing the manual pre-create footgun.

## Verification
- All **24** release build combos (3 OS × 2 arch × 2 build-tags) compile.
- `go test -race ./internal/audit/` passes; golangci-lint + arch-lint clean.
- Empty `v0.8`/`v0.12` releases deleted (tags preserved).