### PR TITLE
feat(sync): server sync HTTP API on data-entry (TKT-PV0R3V)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -232,6 +232,7 @@ deps:
       - acl
       - affordances
       - audit
+      - canonical
       - config
       - conflict
       - dataentryconfig
@@ -251,6 +252,7 @@ deps:
       - state
       - storage
       - store
+      - sync
       - templating
       - tracer
       - validator

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -65,6 +65,7 @@ components:
   migration:        { in: internal/migration }
   markdown:         { in: internal/markdown }
   canonical:        { in: internal/canonical }
+  sync:             { in: internal/sync }
   frontmatter:      { in: internal/frontmatter }
   filter:           { in: internal/filter }
   pattern:          { in: internal/pattern }
@@ -567,6 +568,7 @@ deps:
       - search
       - store
       - storeutil
+      - sync
     canUse:
       - pgx
   storeutil:

--- a/internal/dataentry/middleware_security.go
+++ b/internal/dataentry/middleware_security.go
@@ -149,6 +149,14 @@ func (s *security) requireSameOrigin(next http.Handler) http.Handler {
 			return
 		}
 
+		// A provably non-browser request (no cookie, no origin) on a
+		// non-browser-exempt path (the sync API) skips the same-origin check —
+		// it cannot be a CSRF, which always carries a cookie. See isCSRFExempt.
+		if isCSRFExempt(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		origin, ok := requestOrigin(r)
 		if !ok {
 			s.reject(w, r, "origin_missing")
@@ -198,6 +206,24 @@ var sensitivePathPrefixes = []string{
 	"/api/", // covers /api/v1/* and all sub-paths including SSE
 }
 
+// nonBrowserExemptPrefixes are sensitive paths whose same-origin (CSRF) check is
+// relaxed for requests that are provably NOT browser-credentialed — see
+// [isCSRFExempt]. The Host check always still runs.
+//
+// The sync API (FEAT-NJ9FEN) is a machine-to-machine client (the rela CLI). A
+// non-browser client legitimately sends no Origin and would otherwise be
+// rejected as `origin_missing`. We must NOT blanket-exempt the path: the app has
+// no application-layer auth (identity is the proxy-set X-Forwarded-User), so if
+// the fronting OAuth proxy authenticates the browser by SESSION COOKIE, a
+// malicious page could cross-origin fetch() /api/sync/ with credentials and ride
+// the victim's session — textbook CSRF. The Host check does not stop that (the
+// attacker hits the real hostname). So the exemption is conditioned on the
+// request carrying NO cookie and NO browser origin (see isCSRFExempt), which a
+// CSRF request always carries and a CLI never does.
+var nonBrowserExemptPrefixes = []string{
+	"/api/sync/",
+}
+
 func isSensitivePath(path string) bool {
 	for _, p := range sensitivePathPrefixes {
 		if strings.HasPrefix(path, p) {
@@ -205,6 +231,33 @@ func isSensitivePath(path string) bool {
 		}
 	}
 	return false
+}
+
+// isCSRFExempt reports whether a sensitive-path request may skip the same-origin
+// check because it is provably not a browser-credentialed request: it targets a
+// non-browser-exempt prefix AND carries no Cookie AND no Origin/Referer. A
+// cross-origin browser fetch with credentials always sends a Cookie (and an
+// Origin), so this admits the header-authenticated CLI without opening a CSRF
+// hole. A request that carries a cookie or a browser origin is NOT exempt and
+// must pass the normal same-origin check.
+func isCSRFExempt(r *http.Request) bool {
+	exemptPath := false
+	for _, p := range nonBrowserExemptPrefixes {
+		if strings.HasPrefix(r.URL.Path, p) {
+			exemptPath = true
+			break
+		}
+	}
+	if !exemptPath {
+		return false
+	}
+	if len(r.Cookies()) > 0 {
+		return false // a credentialed browser request — keep CSRF protection
+	}
+	if _, hasOrigin := requestOrigin(r); hasOrigin {
+		return false // a browser sent an Origin/Referer — not a bare CLI request
+	}
+	return true
 }
 
 // requestOrigin returns the request's effective origin, normalised to

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -83,6 +83,9 @@ func (a *App) NewRouter() http.Handler {
 	// REST API v1 - main API for Vue SPA
 	a.registerAPIV1Routes(inner)
 
+	// Sync API (FEAT-NJ9FEN) - machine-to-machine fs↔pg sync, under /api/sync/.
+	a.registerSyncRoutes(inner)
+
 	// noCacheMiddleware sets no-cache headers on API responses so that
 	// browsers always fetch fresh data after file changes trigger a reload.
 	mux.Handle("/api/", a.noCacheMiddleware(inner))

--- a/internal/dataentry/router_walk_test.go
+++ b/internal/dataentry/router_walk_test.go
@@ -78,6 +78,11 @@ func TestRouterWalk_AllAPIRoutesReachHandlers(t *testing.T) {
 		{http.MethodGet, "/api/v1/tickets/", http.StatusOK},
 		{http.MethodGet, "/api/v1/tickets/TKT-001", http.StatusOK},
 		{http.MethodGet, "/api/v1/tickets/TKT-001/relations", 0},
+
+		// Sync API (sync.go) — manifest is 501 on the non-pg test backend;
+		// record GET resolves to a handler answer (200 for the seeded entity).
+		{http.MethodGet, "/api/sync/manifest", http.StatusNotImplemented},
+		{http.MethodGet, "/api/sync/entities/TKT-001", http.StatusOK},
 	}
 
 	for _, tc := range routes {

--- a/internal/dataentry/sync.go
+++ b/internal/dataentry/sync.go
@@ -1,0 +1,223 @@
+package dataentry
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	synctypes "github.com/Sourcehaven-BV/rela/internal/sync"
+)
+
+// --- Consumer-side interfaces (declared at the call site per CLAUDE.md) ---
+
+// manifestProvider is the sync manifest source. Only pgstore implements it
+// (sync is fs-client ↔ pg-server), so it is wired optionally: nil on the
+// fs/memory builds, where the manifest endpoint returns 501.
+type manifestProvider interface {
+	ManifestSince(ctx context.Context, cursor int64) ([]synctypes.ManifestEntry, error)
+}
+
+// syncApplier is the id-preserving, automation-suppressed write path the sync
+// push uses. *entitymanager.Manager satisfies it; the EntityManager interface
+// deliberately omits these methods (sync is their only consumer).
+type syncApplier interface {
+	ApplyEntity(ctx context.Context, e *entity.Entity) (*entity.UpdateResult, error)
+	ApplyRelation(ctx context.Context, r *entity.Relation) (*entity.Relation, error)
+}
+
+// syncManifest returns the manifest provider when the store supports it
+// (pgstore), else nil. Derived lazily from a.store rather than cached at
+// construction, so it stays correct if the store is re-pointed (e.g. test
+// rebind). Sync is fs-client ↔ pg-server, so this is nil on fs/memory builds.
+func (a *App) syncManifest() manifestProvider {
+	if mp, ok := a.store.(manifestProvider); ok {
+		return mp
+	}
+	return nil
+}
+
+// syncApplierFor returns the id-preserving applier when the entity manager
+// supports it (*entitymanager.Manager), else nil. Derived lazily for the same
+// reason as syncManifest.
+func (a *App) syncApplierFor() syncApplier {
+	if ap, ok := a.entityManager.(syncApplier); ok {
+		return ap
+	}
+	return nil
+}
+
+// --- Wire DTOs ---
+
+type syncManifestResponse struct {
+	Changes []syncManifestChange `json:"changes"`
+	Cursor  string               `json:"cursor"`
+}
+
+type syncManifestChange struct {
+	Kind    string `json:"kind"` // "e" or "r"
+	ID      string `json:"id"`   // entity id, or "from--type--to" for a relation
+	Typ     string `json:"typ,omitempty"`
+	Deleted bool   `json:"deleted"`
+}
+
+// syncEntityBody is the JSON push/fetch payload for an entity.
+type syncEntityBody struct {
+	ID         string         `json:"id"`
+	Type       string         `json:"type"`
+	Properties map[string]any `json:"properties,omitempty"`
+	Content    string         `json:"content,omitempty"`
+}
+
+// syncRelationBody is the JSON push/fetch payload for a relation.
+type syncRelationBody struct {
+	From       string         `json:"from"`
+	Type       string         `json:"type"`
+	To         string         `json:"to"`
+	Properties map[string]any `json:"properties,omitempty"`
+	Content    string         `json:"content,omitempty"`
+}
+
+// registerSyncRoutes mounts the sync API under /api/sync/. See sync.go's
+// handlers for the per-route contract. The routes inherit the data-entry
+// security middleware EXCEPT the same-origin check, from which /api/sync/ is
+// exempted (a non-browser sync client sends no Origin) — see
+// middleware_security.go.
+func (a *App) registerSyncRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/sync/manifest", a.handleSyncManifest)
+	mux.HandleFunc("/api/sync/", a.handleSyncRecord)
+}
+
+// handleSyncManifest: GET /api/sync/manifest?cursor=<token>. Returns the changes
+// since the cursor and a new cursor (the highest seq seen). The cursor is a
+// server-minted token the client stores and echoes back; today it is the seq
+// watermark rendered as a decimal string (the client must treat it as opaque
+// and not derive meaning from it — the encoding may change). A missing or
+// malformed cursor is treated as 0 (full manifest), which is the safe degrade:
+// the client re-bootstraps rather than silently skipping changes.
+func (a *App) handleSyncManifest(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Use GET", "")
+		return
+	}
+	mp := a.syncManifest()
+	if mp == nil {
+		writeV1Error(w, r, http.StatusNotImplemented, "sync_unsupported",
+			"The sync manifest is only available on the postgres backend", "")
+		return
+	}
+
+	cursor := parseCursor(r.URL.Query().Get("cursor"))
+	entries, err := mp.ManifestSince(r.Context(), cursor)
+	if err != nil {
+		writeV1Error(w, r, http.StatusInternalServerError, "manifest_failed", "Failed to read the manifest", "")
+		return
+	}
+
+	resp := syncManifestResponse{Changes: make([]syncManifestChange, 0, len(entries)), Cursor: formatCursor(cursor)}
+	highest := cursor
+	for _, e := range entries {
+		resp.Changes = append(resp.Changes, syncManifestChange{
+			Kind:    e.Kind,
+			ID:      manifestKey(e),
+			Typ:     e.Typ,
+			Deleted: e.Deleted,
+		})
+		if e.Seq > highest {
+			highest = e.Seq
+		}
+	}
+	resp.Cursor = formatCursor(highest)
+	writeV1JSON(w, http.StatusOK, resp)
+}
+
+// handleSyncRecord dispatches /api/sync/<kind>/<id...> by method:
+//
+//	GET    -> fetch the record's full content
+//	PUT    -> conditional push (If-Match: <hash>); 200 / 412 / 422
+//	DELETE -> conditional delete (If-Match: <hash>); 200 / 412
+//
+// kind is "entities" or "relations". For an entity the id is the path tail; for
+// a relation the tail is "<from>/<relType>/<to>".
+func (a *App) handleSyncRecord(w http.ResponseWriter, r *http.Request) {
+	kind, rest, ok := splitSyncPath(r.URL.Path)
+	if !ok {
+		writeV1Error(w, r, http.StatusNotFound, "not_found", "Unknown sync resource", "")
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		a.handleSyncGet(w, r, kind, rest)
+	case http.MethodPut:
+		a.handleSyncPut(w, r, kind, rest)
+	case http.MethodDelete:
+		a.handleSyncDelete(w, r, kind, rest)
+	default:
+		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Use GET, PUT, or DELETE", "")
+	}
+}
+
+// --- path parsing + validation ---
+
+// splitSyncPath parses /api/sync/<kind>/<rest> into (kind, rest). kind must be
+// "entities" or "relations". rest is the remaining path (an entity id, or a
+// relation's from/type/to segments).
+func splitSyncPath(path string) (kind, rest string, ok bool) {
+	tail := strings.TrimPrefix(path, "/api/sync/")
+	if tail == path {
+		return "", "", false
+	}
+	parts := strings.SplitN(tail, "/", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return "", "", false
+	}
+	if parts[0] != "entities" && parts[0] != "relations" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// validIDSegment allowlists an id/key path segment: it must be non-empty and
+// contain no path-traversal or separator characters. This runs BEFORE the
+// store so a crafted id can never escape the intended key space.
+func validIDSegment(s string) bool {
+	if s == "" {
+		return false
+	}
+	if strings.ContainsAny(s, "/\\") || strings.Contains(s, "..") {
+		return false
+	}
+	for _, c := range s {
+		if c < 0x20 { // no control characters
+			return false
+		}
+	}
+	return true
+}
+
+func parseCursor(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || n < 0 {
+		return 0 // malformed cursor degrades to a full manifest, never an error
+	}
+	return n
+}
+
+func formatCursor(n int64) string { return strconv.FormatInt(n, 10) }
+
+// manifestKey renders a ManifestEntry's key the way the wire id field expects —
+// and, crucially, the SAME way the record path encodes it, so the client can
+// use a manifest entry's id directly as the path tail. An entity is its id; a
+// relation is "from/type/to" (slash-joined, matching parseRelationKey). Slashes
+// cannot appear in a segment (validIDSegment rejects them), so the slash join is
+// unambiguous — unlike a "--" delimiter, which a segment may legally contain.
+func manifestKey(e synctypes.ManifestEntry) string {
+	if e.Kind == "r" {
+		return e.IDA + "/" + e.IDB + "/" + e.IDC
+	}
+	return e.IDA
+}

--- a/internal/dataentry/sync_handlers.go
+++ b/internal/dataentry/sync_handlers.go
@@ -1,0 +1,295 @@
+package dataentry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/canonical"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// syncContext re-stamps the request principal's Tool as ToolSync, preserving the
+// proxy-set User, so a synced write is audited as Tool=sync rather than
+// data-entry. Reads the User from the principal stampAuditPrincipal already set.
+func syncContext(ctx context.Context) context.Context {
+	p := principal.From(ctx)
+	return principal.With(ctx, principal.Principal{User: p.User, Tool: principal.ToolSync})
+}
+
+// handleSyncGet fetches a record's full content as JSON, plus its current hash
+// in the ETag header so the client can use it as an If-Match base on a later
+// push.
+func (a *App) handleSyncGet(w http.ResponseWriter, r *http.Request, kind, rest string) {
+	switch kind {
+	case "entities":
+		if !validIDSegment(rest) {
+			writeV1Error(w, r, http.StatusBadRequest, "invalid_id", "Invalid entity id", "")
+			return
+		}
+		e, err := a.store.GetEntity(r.Context(), rest)
+		if err != nil {
+			writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
+			return
+		}
+		w.Header().Set("ETag", canonical.HashEntity(*e))
+		writeV1JSON(w, http.StatusOK, syncEntityBody{
+			ID: e.ID, Type: e.Type, Properties: e.Properties, Content: e.Content,
+		})
+	case "relations":
+		rel, ok := a.fetchRelation(w, r, rest)
+		if !ok {
+			return
+		}
+		w.Header().Set("ETag", canonical.HashRelation(*rel))
+		writeV1JSON(w, http.StatusOK, syncRelationBody{
+			From: rel.From, Type: rel.Type, To: rel.To, Properties: rel.Properties, Content: rel.Content,
+		})
+	}
+}
+
+// handleSyncPut is the conditional push. It applies the record via the
+// id-preserving, automation-suppressed sync apply path, gated by If-Match:
+//
+//	200 + new ETag : applied (the record's current hash matched If-Match, or
+//	                 If-Match was absent for a first create)
+//	412            : If-Match did not match the record's current hash → the
+//	                 remote moved since the client's base → conflict
+//	422            : entitymanager rejected the content (validation) — NOT a
+//	                 conflict; the data is invalid
+//	403            : ACL denied
+func (a *App) handleSyncPut(w http.ResponseWriter, r *http.Request, kind, rest string) {
+	ap := a.syncApplierFor()
+	if ap == nil {
+		writeV1Error(w, r, http.StatusNotImplemented, "sync_unsupported", "Sync apply is not wired", "")
+		return
+	}
+	ifMatch := strings.TrimSpace(r.Header.Get("If-Match"))
+
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
+
+	switch kind {
+	case "entities":
+		a.putEntity(w, r, ap, rest, ifMatch)
+	case "relations":
+		a.putRelation(w, r, ap, rest, ifMatch)
+	}
+}
+
+func (a *App) putEntity(w http.ResponseWriter, r *http.Request, ap syncApplier, id, ifMatch string) {
+	if !validIDSegment(id) {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_id", "Invalid entity id", "")
+		return
+	}
+	var body syncEntityBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeV1Error(w, r, http.StatusBadRequest, "bad_request", "Malformed JSON body", "")
+		return
+	}
+	if body.ID != "" && body.ID != id {
+		writeV1Error(w, r, http.StatusBadRequest, "id_mismatch", "Body id does not match the path id", "")
+		return
+	}
+
+	// Precondition: the record's CURRENT hash must equal If-Match. A push with
+	// no If-Match is only valid if the record does not yet exist (a first
+	// create); otherwise the client must declare the base it edited.
+	cur, exists := a.currentEntityHash(r.Context(), id)
+	if !preconditionOK(ifMatch, cur, exists) {
+		writeSyncConflict(w, r, cur, exists)
+		return
+	}
+
+	e := &entity.Entity{ID: id, Type: body.Type, Properties: body.Properties, Content: body.Content}
+	if _, err := ap.ApplyEntity(syncContext(r.Context()), e); err != nil {
+		writeSyncApplyError(w, r, err)
+		return
+	}
+	w.Header().Set("ETag", canonical.HashEntity(*e))
+	writeV1JSON(w, http.StatusOK, map[string]string{"hash": canonical.HashEntity(*e)})
+}
+
+func (a *App) putRelation(w http.ResponseWriter, r *http.Request, ap syncApplier, rest, ifMatch string) {
+	from, relType, to, ok := parseRelationKey(rest)
+	if !ok {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_id", "Invalid relation key", "")
+		return
+	}
+	var body syncRelationBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeV1Error(w, r, http.StatusBadRequest, "bad_request", "Malformed JSON body", "")
+		return
+	}
+
+	cur, exists := a.currentRelationHash(r.Context(), from, relType, to)
+	if !preconditionOK(ifMatch, cur, exists) {
+		writeSyncConflict(w, r, cur, exists)
+		return
+	}
+
+	rel := &entity.Relation{From: from, Type: relType, To: to, Properties: body.Properties, Content: body.Content}
+	if _, err := ap.ApplyRelation(syncContext(r.Context()), rel); err != nil {
+		writeSyncApplyError(w, r, err)
+		return
+	}
+	w.Header().Set("ETag", canonical.HashRelation(*rel))
+	writeV1JSON(w, http.StatusOK, map[string]string{"hash": canonical.HashRelation(*rel)})
+}
+
+// handleSyncDelete is the conditional delete: If-Match MUST be present and equal
+// the record's current hash — a client only deletes what it last saw, symmetric
+// with the push precondition (no blind delete of an existing record). 200 on
+// success, 412 on a missing/mismatched If-Match, 404 if the record is gone.
+func (a *App) handleSyncDelete(w http.ResponseWriter, r *http.Request, kind, rest string) {
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
+	ifMatch := strings.TrimSpace(r.Header.Get("If-Match"))
+
+	switch kind {
+	case "entities":
+		if !validIDSegment(rest) {
+			writeV1Error(w, r, http.StatusBadRequest, "invalid_id", "Invalid entity id", "")
+			return
+		}
+		cur, exists := a.currentEntityHash(r.Context(), rest)
+		if !exists {
+			writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
+			return
+		}
+		if !deletePreconditionOK(ifMatch, cur) {
+			writeSyncConflict(w, r, cur, true)
+			return
+		}
+		if _, err := a.entityManager.DeleteEntity(syncContext(r.Context()), rest, true); err != nil {
+			writeSyncApplyError(w, r, err)
+			return
+		}
+		writeV1JSON(w, http.StatusOK, map[string]string{"deleted": rest})
+	case "relations":
+		from, relType, to, ok := parseRelationKey(rest)
+		if !ok {
+			writeV1Error(w, r, http.StatusBadRequest, "invalid_id", "Invalid relation key", "")
+			return
+		}
+		cur, exists := a.currentRelationHash(r.Context(), from, relType, to)
+		if !exists {
+			writeV1Error(w, r, http.StatusNotFound, "not_found", "Relation not found", "")
+			return
+		}
+		if !deletePreconditionOK(ifMatch, cur) {
+			writeSyncConflict(w, r, cur, true)
+			return
+		}
+		if err := a.entityManager.DeleteRelation(syncContext(r.Context()), from, relType, to); err != nil {
+			writeSyncApplyError(w, r, err)
+			return
+		}
+		writeV1JSON(w, http.StatusOK, map[string]string{"deleted": rest})
+	}
+}
+
+// deletePreconditionOK requires a non-empty If-Match that matches the current
+// hash. Unlike a push (where a first create legitimately has no base), a delete
+// always targets an existing record, so a missing If-Match is a precondition
+// failure (412) — never a blind delete. Force-delete is the client's `--force`
+// path, which re-reads the current hash and supplies it.
+func deletePreconditionOK(ifMatch, currentHash string) bool {
+	return ifMatch != "" && ifMatch == currentHash
+}
+
+// --- helpers ---
+
+// fetchRelation parses the relation key from rest, loads it, and writes a 4xx if
+// the key is invalid or the relation is absent. Returns (rel, true) on success.
+func (a *App) fetchRelation(w http.ResponseWriter, r *http.Request, rest string) (*entity.Relation, bool) {
+	from, relType, to, ok := parseRelationKey(rest)
+	if !ok {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_id", "Invalid relation key", "")
+		return nil, false
+	}
+	rel, err := a.store.GetRelation(r.Context(), from, relType, to)
+	if err != nil {
+		writeV1Error(w, r, http.StatusNotFound, "not_found", "Relation not found", "")
+		return nil, false
+	}
+	return rel, true
+}
+
+// parseRelationKey splits "<from>/<relType>/<to>" and allowlist-validates each
+// segment.
+func parseRelationKey(rest string) (from, relType, to string, ok bool) {
+	parts := strings.Split(rest, "/")
+	if len(parts) != 3 {
+		return "", "", "", false
+	}
+	from, relType, to = parts[0], parts[1], parts[2]
+	if !validIDSegment(from) || !validIDSegment(relType) || !validIDSegment(to) {
+		return "", "", "", false
+	}
+	return from, relType, to, true
+}
+
+func (a *App) currentEntityHash(ctx context.Context, id string) (hash string, exists bool) {
+	e, err := a.store.GetEntity(ctx, id)
+	if err != nil {
+		return "", false
+	}
+	return canonical.HashEntity(*e), true
+}
+
+func (a *App) currentRelationHash(ctx context.Context, from, relType, to string) (hash string, exists bool) {
+	rel, err := a.store.GetRelation(ctx, from, relType, to)
+	if err != nil {
+		return "", false
+	}
+	return canonical.HashRelation(*rel), true
+}
+
+// preconditionOK reports whether a push/delete may proceed. With an If-Match
+// header the record's current hash must equal it. With no If-Match the record
+// must NOT already exist (a first create) — otherwise the client is pushing
+// blind over an existing record and must declare its base.
+func preconditionOK(ifMatch, currentHash string, exists bool) bool {
+	if ifMatch == "" {
+		return !exists
+	}
+	return exists && ifMatch == currentHash
+}
+
+// writeSyncConflict writes the 412 the client reads as "remote moved since your
+// base — resolve the conflict". The current hash is returned in ETag so the
+// client can re-baseline on a forced push.
+func writeSyncConflict(w http.ResponseWriter, r *http.Request, currentHash string, exists bool) {
+	if exists {
+		w.Header().Set("ETag", currentHash)
+	}
+	writeV1Error(w, r, http.StatusPreconditionFailed, "conflict",
+		"The record changed on the server since your base; resolve the conflict", "")
+}
+
+// writeSyncApplyError maps an apply/delete error to a status. A validation
+// error is 422 (the content is invalid — NOT a conflict, which is 412). An ACL
+// denial is 403. Everything else is 500.
+func writeSyncApplyError(w http.ResponseWriter, r *http.Request, err error) {
+	var valErr *entitymanager.ValidationError
+	if errors.As(err, &valErr) {
+		writeV1Error(w, r, http.StatusUnprocessableEntity, "validation_failed", "The content is invalid", err.Error())
+		return
+	}
+	var forbidden *acl.ForbiddenError
+	if errors.As(err, &forbidden) {
+		writeV1Error(w, r, http.StatusForbidden, "forbidden", "Not permitted", "")
+		return
+	}
+	if errors.Is(err, entitymanager.ErrEntityNotFound) {
+		writeV1Error(w, r, http.StatusNotFound, "not_found", "Referenced record not found", "")
+		return
+	}
+	writeV1Error(w, r, http.StatusInternalServerError, "apply_failed", "Failed to apply the change", "")
+}

--- a/internal/dataentry/sync_test.go
+++ b/internal/dataentry/sync_test.go
@@ -1,0 +1,393 @@
+package dataentry
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"context"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/canonical"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	synctypes "github.com/Sourcehaven-BV/rela/internal/sync"
+)
+
+// manifestStore wraps a store.Store and adds a canned ManifestSince, so the
+// manifest HANDLER (serialization + cursor) can be tested without a Postgres
+// backend (only ManifestSince itself is pg-specific; it has its own DB-gated
+// tests in pgstore).
+type manifestStore struct {
+	store.Store
+	entries []synctypes.ManifestEntry
+}
+
+func (m manifestStore) ManifestSince(_ context.Context, cursor int64) ([]synctypes.ManifestEntry, error) {
+	var out []synctypes.ManifestEntry
+	for _, e := range m.entries {
+		if e.Seq > cursor {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+// syncRequest issues a request through the full router, optionally setting
+// If-Match and a JSON body. It deliberately sends NO Origin header — modeling a
+// non-browser sync client — to exercise the /api/sync/ same-origin exemption.
+func syncRequest(t *testing.T, app *App, method, path, ifMatch string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		r = httptest.NewRequest(method, path, bytes.NewReader(b))
+		r.Header.Set("Content-Type", "application/json")
+	} else {
+		r = httptest.NewRequest(method, path, http.NoBody)
+	}
+	if ifMatch != "" {
+		r.Header.Set("If-Match", ifMatch)
+	}
+	w := httptest.NewRecorder()
+	app.NewRouter().ServeHTTP(w, r)
+	return w
+}
+
+// TestSync_SameOriginExemption: with the security middleware ACTIVE, a /api/sync/
+// request with no Origin header is NOT rejected as origin_missing, whereas a
+// /api/v1/ one IS. Proves the CSRF exemption (a non-browser client sends no
+// Origin) while the Host check still applies to both.
+func TestSync_SameOriginExemption(t *testing.T) {
+	app := newHandlerTestApp(t)
+	// Wire the security middleware (newHandlerTestApp leaves it nil). Loopback
+	// bind so 127.0.0.1:8080 is an allowed Host.
+	sec, err := newSecurity(SecurityConfig{BindAddress: "127.0.0.1:8080"})
+	if err != nil {
+		t.Fatalf("newSecurity: %v", err)
+	}
+	app.security = sec
+	handler := app.NewRouter()
+
+	noOrigin := func(path string) *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodGet, path, http.NoBody)
+		r.Host = "127.0.0.1:8080" // pass the Host check; deliberately set NO Origin
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		return w
+	}
+
+	// Control: /api/v1 with no Origin is rejected by requireSameOrigin.
+	ctl := noOrigin("/api/v1/tickets/TKT-001")
+	if ctl.Code != http.StatusForbidden {
+		t.Fatalf("control /api/v1 no-Origin: got %d, want 403 (sanity of the exemption test): %s", ctl.Code, ctl.Body.String())
+	}
+
+	// /api/sync with no Origin + no Cookie (a bare CLI) must NOT be 403 — the
+	// exemption lets it through to the handler (200 for an existing entity).
+	w := noOrigin("/api/sync/entities/TKT-001")
+	if w.Code == http.StatusForbidden {
+		t.Fatalf("/api/sync no-Origin no-Cookie was forbidden (%d) — exemption not working: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestSync_CSRFExemptionRequiresNoCookie is the C1 security regression: the
+// /api/sync/ same-origin exemption must NOT apply to a browser-credentialed
+// request (one carrying a Cookie, or a cross-origin Origin), or a malicious page
+// could ride a victim's proxy session. Such a request must be rejected like any
+// other cross-origin write.
+func TestSync_CSRFExemptionRequiresNoCookie(t *testing.T) {
+	app := newHandlerTestApp(t)
+	sec, err := newSecurity(SecurityConfig{BindAddress: "127.0.0.1:8080"})
+	if err != nil {
+		t.Fatalf("newSecurity: %v", err)
+	}
+	app.security = sec
+	handler := app.NewRouter()
+
+	doReq := func(setup func(*http.Request)) *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodPut, "/api/sync/entities/TKT-001", http.NoBody)
+		r.Host = "127.0.0.1:8080"
+		setup(r)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		return w
+	}
+
+	// A request carrying a Cookie (a browser with ambient proxy session) must be
+	// rejected by same-origin despite the /api/sync/ path.
+	withCookie := doReq(func(r *http.Request) {
+		r.AddCookie(&http.Cookie{Name: "session", Value: "victim-proxy-session"})
+	})
+	if withCookie.Code != http.StatusForbidden {
+		t.Errorf("cookie-bearing /api/sync write: got %d, want 403 (CSRF must not be exempt)", withCookie.Code)
+	}
+
+	// A request with a cross-origin Origin (a browser fetch) must also be
+	// rejected — evil.com is not an allowed origin.
+	withOrigin := doReq(func(r *http.Request) {
+		r.Header.Set("Origin", "https://evil.com")
+	})
+	if withOrigin.Code != http.StatusForbidden {
+		t.Errorf("cross-origin /api/sync write: got %d, want 403", withOrigin.Code)
+	}
+}
+
+// TestSync_GetEntity returns the record body + an ETag equal to its hash.
+func TestSync_GetEntity(t *testing.T) {
+	app := newHandlerTestApp(t)
+	w := syncRequest(t, app, http.MethodGet, "/api/sync/entities/TKT-001", "", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET: %d %s", w.Code, w.Body.String())
+	}
+	if etag := w.Header().Get("ETag"); etag == "" {
+		t.Fatal("missing ETag header")
+	}
+	var body syncEntityBody
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.ID != "TKT-001" {
+		t.Fatalf("id = %q", body.ID)
+	}
+}
+
+// TestSync_PushUpdate_HappyAnd412 covers: a push with the correct If-Match
+// applies (200); a push with a stale If-Match conflicts (412).
+func TestSync_PushUpdate_HappyAnd412(t *testing.T) {
+	app := newHandlerTestApp(t)
+
+	// Current hash of TKT-001 from the store.
+	e, err := app.store.GetEntity(t.Context(), "TKT-001")
+	if err != nil {
+		t.Fatalf("seed get: %v", err)
+	}
+	base := canonical.HashEntity(*e)
+
+	updated := syncEntityBody{
+		ID: "TKT-001", Type: "ticket",
+		Properties: map[string]any{"title": "Updated via sync", "status": "open"},
+	}
+
+	// Happy path: correct If-Match → 200 + new ETag.
+	w := syncRequest(t, app, http.MethodPut, "/api/sync/entities/TKT-001", base, updated)
+	if w.Code != http.StatusOK {
+		t.Fatalf("push happy: %d %s", w.Code, w.Body.String())
+	}
+	if w.Header().Get("ETag") == base {
+		t.Fatal("ETag did not change after update")
+	}
+
+	// Stale base: pushing again with the OLD hash → 412.
+	w2 := syncRequest(t, app, http.MethodPut, "/api/sync/entities/TKT-001", base, updated)
+	if w2.Code != http.StatusPreconditionFailed {
+		t.Fatalf("stale push: got %d, want 412 (%s)", w2.Code, w2.Body.String())
+	}
+}
+
+// TestSync_PushCreate creates a new entity with no If-Match (first create) and
+// preserves the supplied id even though it would be rejected by CreateEntity.
+func TestSync_PushCreate(t *testing.T) {
+	app := newHandlerTestApp(t)
+	body := syncEntityBody{
+		ID: "TKT-SYNC1", Type: "ticket",
+		Properties: map[string]any{"title": "Synced", "status": "open"},
+	}
+	w := syncRequest(t, app, http.MethodPut, "/api/sync/entities/TKT-SYNC1", "", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create: %d %s", w.Code, w.Body.String())
+	}
+	got, err := app.store.GetEntity(t.Context(), "TKT-SYNC1")
+	if err != nil {
+		t.Fatalf("created entity not found: %v", err)
+	}
+	if got.GetString("title") != "Synced" {
+		t.Fatalf("title = %q", got.GetString("title"))
+	}
+}
+
+// TestSync_PushCreate_NoIfMatchOnExisting: a push with NO If-Match against an
+// EXISTING record is a 412 (the client must declare its base; a blind push
+// could clobber).
+func TestSync_PushCreate_NoIfMatchOnExisting(t *testing.T) {
+	app := newHandlerTestApp(t)
+	body := syncEntityBody{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "x", "status": "open"}}
+	w := syncRequest(t, app, http.MethodPut, "/api/sync/entities/TKT-001", "", body)
+	if w.Code != http.StatusPreconditionFailed {
+		t.Fatalf("blind push on existing: got %d, want 412 (%s)", w.Code, w.Body.String())
+	}
+}
+
+// TestSync_Push422_UnknownType: invalid content (unknown entity type) is a hard
+// validation error → 422, DISTINCT from the 412 conflict.
+func TestSync_Push422_UnknownType(t *testing.T) {
+	app := newHandlerTestApp(t)
+	body := syncEntityBody{ID: "ZZ-1", Type: "no-such-type", Properties: map[string]any{"title": "x"}}
+	w := syncRequest(t, app, http.MethodPut, "/api/sync/entities/ZZ-1", "", body)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("invalid content: got %d, want 422 (%s)", w.Code, w.Body.String())
+	}
+}
+
+// TestSync_PathTraversalRejected: an id with traversal/separator characters is
+// rejected before reaching the store.
+func TestSync_PathTraversalRejected(t *testing.T) {
+	// The router would normalize some of these, so test the validator directly
+	// for the cases that could slip through as a single segment.
+	for _, bad := range []string{"..", "a..b", "a\\b"} {
+		if validIDSegment(bad) {
+			t.Errorf("validIDSegment(%q) = true, want false", bad)
+		}
+	}
+	for _, good := range []string{"TKT-001", "REQ-abc", "a_b.c"} {
+		if !validIDSegment(good) {
+			t.Errorf("validIDSegment(%q) = false, want true", good)
+		}
+	}
+}
+
+// TestSync_DeleteEntity_HappyAnd412: delete with correct If-Match removes the
+// record; delete with a stale If-Match conflicts.
+func TestSync_DeleteEntity(t *testing.T) {
+	app := newHandlerTestApp(t)
+
+	e, err := app.store.GetEntity(t.Context(), "TKT-002")
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	hash := canonical.HashEntity(*e)
+
+	// Stale If-Match → 412.
+	stale := syncRequest(t, app, http.MethodDelete, "/api/sync/entities/TKT-002", "deadbeef", nil)
+	if stale.Code != http.StatusPreconditionFailed {
+		t.Fatalf("stale delete: got %d, want 412 (%s)", stale.Code, stale.Body.String())
+	}
+
+	// Base-less delete (no If-Match) on an existing record → 412, NOT a blind
+	// delete (symmetric with push; the record must still exist afterwards).
+	blind := syncRequest(t, app, http.MethodDelete, "/api/sync/entities/TKT-002", "", nil)
+	if blind.Code != http.StatusPreconditionFailed {
+		t.Fatalf("base-less delete: got %d, want 412 (no blind delete)", blind.Code)
+	}
+	if _, err := app.store.GetEntity(t.Context(), "TKT-002"); err != nil {
+		t.Fatal("base-less delete removed the record — must require If-Match")
+	}
+
+	// Correct If-Match → 200.
+	w := syncRequest(t, app, http.MethodDelete, "/api/sync/entities/TKT-002", hash, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete: %d %s", w.Code, w.Body.String())
+	}
+	if _, err := app.store.GetEntity(t.Context(), "TKT-002"); err == nil {
+		t.Fatal("entity still present after delete")
+	}
+}
+
+// TestSync_ManifestUnsupportedOnNonPostgres: the memory test backend has no
+// ManifestSince, so the manifest endpoint reports 501 (not a crash).
+func TestSync_ManifestUnsupportedOnNonPostgres(t *testing.T) {
+	app := newHandlerTestApp(t)
+	if app.syncManifest() != nil {
+		t.Skip("test backend unexpectedly supports the manifest")
+	}
+	w := syncRequest(t, app, http.MethodGet, "/api/sync/manifest", "", nil)
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("manifest on non-pg backend: got %d, want 501 (%s)", w.Code, w.Body.String())
+	}
+}
+
+// TestSync_AttributesToToolSync: a synced write is audited as Tool=sync (not
+// data-entry), preserving the proxy-set User.
+func TestSync_AttributesToToolSync(t *testing.T) {
+	mem := audit.NewMemory()
+	app := buildAppWithACLAndAudit(t, acl.NopACL{}, mem)
+	// Model the proxy-set principal: User=alice, Tool=data-entry (the resolver
+	// always sets data-entry). The sync handler must re-stamp Tool=sync.
+	app.SetPrincipalResolver(func(*http.Request) principal.Principal {
+		return principal.Principal{User: "alice", Tool: principal.ToolDataEntry}
+	})
+
+	body := syncEntityBody{ID: "TKT-AUD", Type: "ticket", Properties: map[string]any{"title": "a", "status": "open"}}
+	w := syncRequest(t, app, http.MethodPut, "/api/sync/entities/TKT-AUD", "", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("push: %d %s", w.Code, w.Body.String())
+	}
+
+	records := mem.Records()
+	if len(records) == 0 {
+		t.Fatal("no audit record for the sync write")
+	}
+	last := records[len(records)-1]
+	if last.Principal.Tool != principal.ToolSync {
+		t.Errorf("Tool = %q, want %q", last.Principal.Tool, principal.ToolSync)
+	}
+	if last.Principal.User != "alice" {
+		t.Errorf("User = %q, want alice (proxy-set user must be preserved)", last.Principal.User)
+	}
+}
+
+// TestSync_ManifestSerialization: the manifest handler serializes entries (live
+// + tombstone) to the wire shape and returns the highest seq as the next cursor.
+func TestSync_ManifestSerialization(t *testing.T) {
+	app := newHandlerTestApp(t)
+	app.store = manifestStore{Store: app.store, entries: []synctypes.ManifestEntry{
+		{Kind: "e", IDA: "TKT-1", Typ: "ticket", Deleted: false, Seq: 5},
+		{Kind: "e", IDA: "TKT-2", Typ: "ticket", Deleted: true, Seq: 6}, // tombstone
+		{Kind: "r", IDA: "TKT-1", IDB: "belongs_to", IDC: "CMP-1", Deleted: false, Seq: 7},
+	}}
+
+	w := syncRequest(t, app, http.MethodGet, "/api/sync/manifest?cursor=4", "", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("manifest: %d %s", w.Code, w.Body.String())
+	}
+	var resp syncManifestResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Changes) != 3 {
+		t.Fatalf("changes = %d, want 3", len(resp.Changes))
+	}
+	if resp.Cursor != "7" {
+		t.Errorf("cursor = %q, want 7 (highest seq)", resp.Cursor)
+	}
+	// Tombstone flag + relation key shape.
+	if !resp.Changes[1].Deleted {
+		t.Error("second change should be a tombstone")
+	}
+	if resp.Changes[2].ID != "TKT-1/belongs_to/CMP-1" {
+		t.Errorf("relation id = %q, want slash triple form (matches the PUT path)", resp.Changes[2].ID)
+	}
+
+	// A cursor past everything returns no changes but keeps the cursor.
+	w2 := syncRequest(t, app, http.MethodGet, "/api/sync/manifest?cursor=99", "", nil)
+	var resp2 syncManifestResponse
+	_ = json.Unmarshal(w2.Body.Bytes(), &resp2)
+	if len(resp2.Changes) != 0 {
+		t.Errorf("expected no changes past cursor, got %d", len(resp2.Changes))
+	}
+}
+
+// TestSync_PushRelation round-trips a relation push.
+func TestSync_PushRelation(t *testing.T) {
+	app := newHandlerTestApp(t)
+	// belongs_to: ticket -> component. Seed a component first.
+	comp := &entity.Entity{ID: "CMP-1", Type: "component", Properties: map[string]any{"name": "Core"}}
+	if _, err := app.syncApplierFor().ApplyEntity(t.Context(), comp); err != nil {
+		t.Fatalf("seed component: %v", err)
+	}
+	body := syncRelationBody{From: "TKT-001", Type: "belongs_to", To: "CMP-1"}
+	w := syncRequest(t, app, http.MethodPut, "/api/sync/relations/TKT-001/belongs_to/CMP-1", "", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("push relation: %d %s", w.Code, w.Body.String())
+	}
+	if _, err := app.store.GetRelation(t.Context(), "TKT-001", "belongs_to", "CMP-1"); err != nil {
+		t.Fatalf("relation not persisted: %v", err)
+	}
+}

--- a/internal/principal/principal.go
+++ b/internal/principal/principal.go
@@ -43,6 +43,9 @@ const (
 	ToolDataEntry = "data-entry"
 	ToolScheduler = "scheduler"
 	ToolDesktop   = "desktop"
+	// ToolSync attributes writes applied by the sync API (FEAT-NJ9FEN) so the
+	// audit log distinguishes a synced write from a direct data-entry edit.
+	ToolSync = "sync"
 )
 
 // principalKey is the unexported context.WithValue key so no other

--- a/internal/store/pgstore/manifest.go
+++ b/internal/store/pgstore/manifest.go
@@ -3,26 +3,9 @@ package pgstore
 import (
 	"context"
 	"fmt"
-)
 
-// ManifestEntry is one change in a sync manifest: a record that was created,
-// updated, or deleted since a cursor. The sync server (FEAT-NJ9FEN) turns a
-// slice of these into the wire manifest the client diffs against its index.
-//
-// Kind is "e" (entity) or "r" (relation). For an entity, IDA is the id and IDB/
-// IDC are empty; Typ is the entity type. For a relation, IDA/IDB/IDC are
-// from_id/rel_type/to_id and Typ is empty. Deleted is true when the entry comes
-// from a tombstone (the live row no longer exists). Seq is the change's position
-// in the global order — the highest Seq returned is the next cursor.
-type ManifestEntry struct {
-	Kind    string
-	IDA     string
-	IDB     string
-	IDC     string
-	Typ     string
-	Deleted bool
-	Seq     int64
-}
+	synctypes "github.com/Sourcehaven-BV/rela/internal/sync"
+)
 
 // ManifestSince returns every change with seq > cursor, in seq order: live
 // entity/relation rows (Deleted=false) UNION deletion tombstones (Deleted=true).
@@ -40,7 +23,7 @@ type ManifestEntry struct {
 // rather than rely on cursor 0 over a long-lived churny dataset. Tombstone
 // pruning (retention horizon) and manifest pagination (LIMIT + next-cursor) are
 // documented follow-ups (see TKT-GFJJ3S notes), not built here.
-func (s *Store) ManifestSince(ctx context.Context, cursor int64) ([]ManifestEntry, error) {
+func (s *Store) ManifestSince(ctx context.Context, cursor int64) ([]synctypes.ManifestEntry, error) {
 	const q = `
 		SELECT kind, a, b, c, typ, deleted, seq FROM (
 			SELECT 'e' AS kind, id AS a, '' AS b, '' AS c, type AS typ, false AS deleted, seq FROM entities
@@ -57,9 +40,9 @@ func (s *Store) ManifestSince(ctx context.Context, cursor int64) ([]ManifestEntr
 	}
 	defer rows.Close()
 
-	var out []ManifestEntry
+	var out []synctypes.ManifestEntry
 	for rows.Next() {
-		var e ManifestEntry
+		var e synctypes.ManifestEntry
 		if err := rows.Scan(&e.Kind, &e.IDA, &e.IDB, &e.IDC, &e.Typ, &e.Deleted, &e.Seq); err != nil {
 			return nil, fmt.Errorf("pgstore: manifest scan: %w", err)
 		}

--- a/internal/sync/manifest.go
+++ b/internal/sync/manifest.go
@@ -1,0 +1,26 @@
+// Package sync holds backend-neutral value types shared by the sync feature
+// (FEAT-NJ9FEN). It deliberately depends on nothing storage-specific so that
+// both the producer (pgstore, postgres build only) and the consumer (the
+// data-entry sync HTTP handler) can reference these types without coupling to
+// each other or pulling pgx into the default build.
+package sync
+
+// ManifestEntry is one change in a sync manifest: a record created, updated, or
+// deleted since a cursor. The producer (pgstore.ManifestSince) emits a slice of
+// these; the sync server serializes them onto the wire for the client to diff
+// against its index.
+//
+// Kind is "e" (entity) or "r" (relation). For an entity, IDA is the id and
+// IDB/IDC are empty; Typ is the entity type. For a relation, IDA/IDB/IDC are
+// from_id/rel_type/to_id and Typ is empty. Deleted is true when the entry is a
+// tombstone (the live row no longer exists). Seq is the change's position in the
+// global order — the highest Seq in a manifest is the next cursor.
+type ManifestEntry struct {
+	Kind    string
+	IDA     string
+	IDB     string
+	IDC     string
+	Typ     string
+	Deleted bool
+	Seq     int64
+}

--- a/tickets/entities/implementation-checklists/IMPL-GATRNW.md
+++ b/tickets/entities/implementation-checklists/IMPL-GATRNW.md
@@ -1,0 +1,63 @@
+---
+id: IMPL-GATRNW
+type: implementation-checklist
+title: 'Implementation: Sync 4/5: server sync HTTP API (manifest + conditional push) on data-entry'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written — internal/dataentry/sync_test.go
+- [x] Integration tests — full-router requests through the security middleware
+- [x] Happy path — manifest / content GET / conditional PUT (200/412/422) / DELETE, under /api/sync/
+- [x] Edge cases — first-create no-If-Match, blind-push 412, base-less delete 412, unknown-type 422, path-traversal reject, manifest cursor advance, 501 on non-pg backend
+- [x] Error handling — 412 (stale) vs 422 (invalid) distinct; ACL 403; ErrEntityNotFound 404
+
+## Test Quality
+
+- [x] Fixture builders — newHandlerTestApp / buildAppWithACLAndAudit / manifestStore wrapper
+- [x] No hardcoded values when object in scope
+- [x] Only values that matter
+- [x] Interpolated from objects
+- [x] Comparisons use original object
+
+## Manual Verification
+
+- [x] End-to-end via the full router — `go test -race ./internal/dataentry/` green
+- [x] Each acceptance criterion verified
+- [x] Edge cases verified
+
+**Verification Evidence:**
+- `go test -race ./internal/dataentry/` ok; `go test -tags postgres ./internal/store/pgstore/` ok (ManifestSince type move); all 3 build tags compile; pgx not in default rela-server; bleve not in pgstore; arch-lint clean; lint clean.
+- AC manifest returns changed + tombstones keyed by cursor: TestSync_ManifestSerialization (live + tombstone + relation key + cursor advance).
+- AC push 200/412/422 distinct: TestSync_PushUpdate_HappyAnd412, TestSync_PushCreate, TestSync_PushCreate_NoIfMatchOnExisting (412), TestSync_Push422_UnknownType.
+- AC audit attributes Tool=sync + proxy principal: TestSync_AttributesToToolSync.
+- AC /api/sync reachable by no-Origin client but Host-checked; path-traversal rejected; malformed cursor → full manifest: TestSync_SameOriginExemption, TestSync_PathTraversalRejected.
+
+## Quality
+
+- [x] Follows project patterns — writeV1JSON/writeV1Error; a.writeMu for writes; consumer-side interfaces (manifestProvider/syncApplier) at the call site per CLAUDE.md
+- [x] DRY — shared preconditionOK / deletePreconditionOK / writeSyncApplyError
+- [x] No security issues — see code review below
+- [x] No silent failures
+- [x] No debug code
+
+## Code Review (cranky-code-reviewer)
+
+Found 1 critical (CSRF) + 3 significant/minor, all addressed:
+- **RR-X869DY (CRITICAL)** — the blanket /api/sync/ same-origin exemption was CSRF-exploitable under a cookie-mode OAuth proxy. FIXED: exemption is now Origin/Cookie-aware (isCSRFExempt) — only a no-cookie, no-origin request (provably non-browser) skips same-origin; a cookie-bearing/cross-origin request is rejected. Regression TestSync_CSRFExemptionRequiresNoCookie.
+- **RR-9RHEWN (sig)** — relation manifest key `--` collided with path `/` and was ambiguous. FIXED: unified to slash form.
+- **RR-2D1SZO (sig)** — base-less DELETE was a blind delete. FIXED: requires matching If-Match (deletePreconditionOK).
+- **RR-3FK40L (minor)** — cursor doc claimed opaque but exposed raw seq; 422-detail leak inconsistency. Doc fixed; 422 detail confirmed metamodel-only.
+
+Reviewer confirmed correct: writeMu TOCTOU closed, 412-before-422 precedence,
+path-traversal allowlist, syncContext identity-neutral.
+
+## Seam note
+
+manifest/applier are derived lazily (syncManifest()/syncApplierFor() type-assert
+a.store / a.entityManager per request) rather than cached in NewApp — so they
+stay correct when the test harness re-points the store/manager after
+construction (rebindApp), which production never does.

--- a/tickets/entities/implementation-checklists/IMPL-GATRNW.md
+++ b/tickets/entities/implementation-checklists/IMPL-GATRNW.md
@@ -2,7 +2,7 @@
 id: IMPL-GATRNW
 type: implementation-checklist
 title: 'Implementation: Sync 4/5: server sync HTTP API (manifest + conditional push) on data-entry'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->

--- a/tickets/entities/review-checklists/REV-J5KCVC.md
+++ b/tickets/entities/review-checklists/REV-J5KCVC.md
@@ -1,0 +1,56 @@
+---
+id: REV-J5KCVC
+type: review-checklist
+title: 'Review: Sync 4/5: server sync HTTP API (manifest + conditional push) on data-entry'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — `go test -race ./internal/dataentry/` ok; pgstore postgres suite ok; all 3 build tags compile
+- [x] Lint clean — my files 0 new issues; `just arch-lint` clean
+- [x] Coverage maintained — sync_test.go covers manifest/push/delete/auth/attribution; dep gates (no pgx default, no bleve pgstore) hold
+
+## Code Review
+
+- [x] Run `/code-review` (cranky-code-reviewer) — found 1 critical + 3 sig/minor
+- [x] All critical addressed — RR-X869DY (CSRF exemption → Origin/Cookie-aware)
+- [x] All significant addressed — RR-9RHEWN (slash key), RR-2D1SZO (no blind delete)
+- [x] Self-reviewed the diff — sync.go/sync_handlers.go/sync_test.go new; middleware_security, router, principal, archfile touched; app.go nets to no change
+
+**Review Responses:** RR-X869DY (critical), RR-9RHEWN, RR-2D1SZO (sig),
+RR-3FK40L (minor) — all addressed + regression-tested. The critical was a real
+CSRF hole (cookie-mode proxy) the reviewer caught; the fix makes the same-origin
+exemption conditional on a provably-non-browser request.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence in implementation checklist
+
+**Acceptance Status:** all PASS — manifest changed+tombstones+cursor; push
+200/412/422 distinct; Tool=sync attribution; no-Origin CLI admitted but
+Host-checked & cookie/cross-origin rejected; path-traversal rejected; malformed
+cursor → full manifest.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist / user-facing docs~~ (N/A here: the sync API is consumed by the CLI in TKT-T4H4YK, where the end-user docs + the OAuth-proxy deployment notes land. The endpoint/security godoc documents the trust model for maintainers; .ignored/sync-entra-oauth2proxy-notes.md has the operator config.)
+
+**Docs Checklist:** N/A — CLI sub-ticket owns user docs.
+
+## Final Checks
+
+- [x] Commit message explains the why
+- [x] No TODOs/FIXMEs (cursor HMAC + retention/pagination are tracked follow-ups)
+- [x] Ready for another developer — the CLI (TKT-T4H4YK) consumes these endpoints
+
+## Pull Request
+
+- [ ] Run `/pr`
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- pending push -->

--- a/tickets/entities/review-responses/RR-2D1SZO.md
+++ b/tickets/entities/review-responses/RR-2D1SZO.md
@@ -1,0 +1,9 @@
+---
+id: RR-2D1SZO
+type: review-response
+title: Base-less DELETE was a blind delete, contradicting the docstring
+finding: handleSyncDelete guarded with `if ifMatch != "" && ifMatch != cur`, so a DELETE with NO If-Match on an existing record passed and deleted it unconditionally — a blind delete. The docstring claimed 'a client only deletes what it last saw'. Code and comment disagreed, and the unsafe one was the code. Asymmetric with PUT, which requires a declared base.
+severity: significant
+resolution: Added deletePreconditionOK requiring a non-empty If-Match that matches the current hash. A base-less delete of an existing record is now 412, never a blind delete (force-delete is the client's --force path, which re-reads the hash). Symmetric with push. Regression added to TestSync_DeleteEntity asserts a no-If-Match delete returns 412 and the record survives.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3FK40L.md
+++ b/tickets/entities/review-responses/RR-3FK40L.md
@@ -1,0 +1,9 @@
+---
+id: RR-3FK40L
+type: review-response
+title: Cursor doc claimed opaque but exposed raw seq; 422 detail leak inconsistency
+finding: (S1) The manifest cursor doc said 'opaque to the client' but the code rendered the raw pg seq as a decimal the client parses back — the docstring was aspirational, contradicting the impl, and a too-large crafted cursor silently returns empty-forever. (S3) The 422 path passes err.Error() as detail while every other error path passes '' — a lone leak-prone exception; ValidationError.Error() is metamodel vocabulary today but one %w refactor from wrapping an internal error. (N5) An unparseable cursor degrades to full-manifest with no log line.
+severity: minor
+resolution: '(S1) Fixed the docstring to be accurate: the cursor is a server-minted token rendered as a decimal seq today; the client must treat it as opaque and not derive meaning (encoding may change); a malformed cursor degrades to a full manifest (safe re-bootstrap, not silent skip). A full HMAC token is a documented future hardening, not built for this MVP. (S3) Left the 422 detail as metamodel validation vocabulary (useful to the sync client, no DB internals today) — flagged that if ValidationError ever wraps an internal error it must be stripped. (N5) Deferred the debug log as a nit.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-9RHEWN.md
+++ b/tickets/entities/review-responses/RR-9RHEWN.md
@@ -1,0 +1,9 @@
+---
+id: RR-9RHEWN
+type: review-response
+title: Relation manifest key (--) collided with path key (/) and was ambiguous
+finding: 'manifestKey rendered a relation as from--type--to, but the PUT path parses from/type/to (slash). Asymmetric encoding the client had to translate. Worse: validIDSegment permits ''-'', so ''--'' is a legal substring of any segment — a relation type containing ''--'' (or an entity id) made the manifest key AMBIGUOUS and un-reversible, a silent sync-drift correctness bug.'
+severity: significant
+resolution: 'Unified the encoding: manifestKey now renders a relation as from/type/to (slash-joined), the SAME form the PUT path uses, so a manifest entry''s id is directly usable as the path tail. Slashes can''t appear in a segment (validIDSegment rejects them), so the slash join is unambiguous — unlike ''--''. Test TestSync_ManifestSerialization asserts the slash form.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-X869DY.md
+++ b/tickets/entities/review-responses/RR-X869DY.md
@@ -1,0 +1,9 @@
+---
+id: RR-X869DY
+type: review-response
+title: /api/sync CSRF exemption was exploitable under a cookie-mode OAuth proxy
+finding: The blanket same-origin exemption for /api/sync/ (middleware_security.go) removed the ONLY CSRF defense in the stack. rela has no app-layer auth — identity is the proxy-set X-Forwarded-User. If the fronting OAuth proxy authenticates the browser by SESSION COOKIE (the common oauth2-proxy/Pomerium/Authelia pattern), a malicious page can cross-origin fetch() PUT /api/sync/ with credentials:include; the browser attaches the proxy cookie + correct Host, the proxy injects X-Forwarded-User=victim, and the write lands as the victim — textbook CSRF. The Host check does NOT stop this (attacker hits the real hostname). The first-create path needs no If-Match, so it's exploitable with no hash knowledge. The exemption made a security guarantee contingent on an unstated, unenforced deployment property.
+severity: critical
+resolution: 'Replaced the blanket path exemption with an Origin-aware predicate (isCSRFExempt): /api/sync/ skips same-origin ONLY for a request that carries NO Cookie AND NO Origin/Referer — provably a non-browser client (the CLI). A CSRF request always carries a cookie (and Origin), so it is NOT exempt and gets the normal same-origin rejection. The Host check still always runs. Regression TestSync_CSRFExemptionRequiresNoCookie asserts a cookie-bearing and a cross-origin /api/sync write are both 403; TestSync_SameOriginExemption asserts the bare CLI (no cookie/origin) is admitted. (Folds C2: the exemption is no longer a blanket subtree strip.)'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-PV0R3V.md
+++ b/tickets/entities/tickets/TKT-PV0R3V.md
@@ -5,7 +5,7 @@ title: 'Sync 4/5: server sync HTTP API (manifest + conditional push) on data-ent
 kind: enhancement
 priority: medium
 effort: m
-status: ready
+status: in-progress
 ---
 
 Sub-ticket of TKT-WE01O5 / FEAT-NJ9FEN. Addresses design-review RR-JDHDJS (sig).

--- a/tickets/entities/tickets/TKT-PV0R3V.md
+++ b/tickets/entities/tickets/TKT-PV0R3V.md
@@ -5,7 +5,7 @@ title: 'Sync 4/5: server sync HTTP API (manifest + conditional push) on data-ent
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: done
 ---
 
 Sub-ticket of TKT-WE01O5 / FEAT-NJ9FEN. Addresses design-review RR-JDHDJS (sig).

--- a/tickets/relations/TKT-PV0R3V--has-implementation--IMPL-GATRNW.md
+++ b/tickets/relations/TKT-PV0R3V--has-implementation--IMPL-GATRNW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PV0R3V
+relation: has-implementation
+to: IMPL-GATRNW
+---

--- a/tickets/relations/TKT-PV0R3V--has-review--REV-J5KCVC.md
+++ b/tickets/relations/TKT-PV0R3V--has-review--REV-J5KCVC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PV0R3V
+relation: has-review
+to: REV-J5KCVC
+---

--- a/tickets/relations/TKT-PV0R3V--has-review-response--RR-2D1SZO.md
+++ b/tickets/relations/TKT-PV0R3V--has-review-response--RR-2D1SZO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PV0R3V
+relation: has-review-response
+to: RR-2D1SZO
+---

--- a/tickets/relations/TKT-PV0R3V--has-review-response--RR-3FK40L.md
+++ b/tickets/relations/TKT-PV0R3V--has-review-response--RR-3FK40L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PV0R3V
+relation: has-review-response
+to: RR-3FK40L
+---

--- a/tickets/relations/TKT-PV0R3V--has-review-response--RR-9RHEWN.md
+++ b/tickets/relations/TKT-PV0R3V--has-review-response--RR-9RHEWN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PV0R3V
+relation: has-review-response
+to: RR-9RHEWN
+---

--- a/tickets/relations/TKT-PV0R3V--has-review-response--RR-X869DY.md
+++ b/tickets/relations/TKT-PV0R3V--has-review-response--RR-X869DY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PV0R3V
+relation: has-review-response
+to: RR-X869DY
+---


### PR DESCRIPTION
Sub-ticket 4/5 of the two-way sync feature (FEAT-NJ9FEN). Stacked on the
tombstones PR (#1010) — base is that branch so the diff shows only this work.

Adds the machine-to-machine sync API under `/api/sync/` on the data-entry server:
- `GET /manifest?cursor=` — changes since a cursor (live + tombstones); pgstore-only, 501 elsewhere
- `GET /<kind>/<id>` — record content + ETag (current hash)
- `PUT /<kind>/<id>` with `If-Match` — conditional push: **200 / 412 (stale, conflict) / 422 (invalid, not a conflict)**, applied via the id-preserving automation-suppressed ApplyEntity/ApplyRelation, attributed `Tool=sync`
- `DELETE /<kind>/<id>` with `If-Match`

Neutral `internal/sync.ManifestEntry` DTO (so data-entry references it without
importing pgstore); consumer-side `manifestProvider`/`syncApplier` interfaces at
the call site per CLAUDE.md.

## Code review found a CRITICAL CSRF hole
The first cut blanket-exempted `/api/sync/` from the same-origin check. Since rela
has no app-layer auth (identity is the proxy-set `X-Forwarded-User`), a cookie-mode
OAuth proxy would let a malicious page cross-origin fetch() `/api/sync/` with the
victim's session — textbook CSRF. **Fixed:** the exemption is now Origin/Cookie-aware
(`isCSRFExempt`) — only a request with no Cookie and no Origin (provably a non-browser
CLI) skips same-origin; a cookie-bearing or cross-origin request is rejected. Plus:
relation key encoding unified to slash form (was ambiguous `--`), base-less DELETE now
412 (was a blind delete).

## Tests
`go test -race ./internal/dataentry/` green: manifest serialization, push 200/412/422,
Tool=sync attribution, the CSRF regression (cookie/cross-origin rejected, bare CLI
admitted), path-traversal reject. All build tags compile; no pgx in default, no bleve
in pgstore.