### PR TITLE
feat: attachment web UI, multi-file, ACL, CLI

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -234,6 +234,7 @@ deps:
     mayDependOn:
       - acl
       - affordances
+      - attachment
       - audit
       - config
       - conflict

--- a/docs-project/entities/guides/GUIDE-cli-reference.md
+++ b/docs-project/entities/guides/GUIDE-cli-reference.md
@@ -344,8 +344,13 @@ rela attach <entity-id> <file>... [flags]
 ```
 
 Each file is stored at `attachments/<entity-id>/<property>/<filename>`.
-Each file-type property holds at most one attachment; re-running `attach`
-replaces the existing file.
+A file-type property holds one attachment by default; set `max` above 1 on
+the property (see the metamodel reference) to allow several.
+
+> **Note:** for a single-attachment property (`max: 1`), re-running `attach`
+> **replaces** the existing file. For a multi-attachment property (`max > 1`),
+> `attach` **appends** up to the cap, auto-suffixing a duplicate name
+> (`report.pdf` → `report (1).pdf`) and erroring when full.
 
 **Arguments:**
 
@@ -395,26 +400,34 @@ rela attachments DEC-007
 
 ### rela detach
 
-Remove the attachment from an entity property.
+Remove an attachment from an entity property.
 
 ```bash
-rela detach <entity-id> <property>
+rela detach <entity-id> <property> [--file <name>]
 ```
 
-Clears the property on the entity and deletes the underlying file from the
-attachment store. Each file-type property holds at most one attachment, so no
-further disambiguation is needed.
+Deletes the underlying file from the attachment store and re-stamps the
+property. When the property holds a single attachment, `--file` may be
+omitted. When it holds several (a `file` property with `max > 1`), pass
+`--file` to select which one — `rela attachments <entity-id>` lists the
+names.
 
 **Arguments:**
 
 - `entity-id` - Entity ID
 - `property` - Property name containing the attachment
 
+**Flags:**
+
+| Flag           | Description                                            |
+| -------------- | ----------------------------------------------------- |
+| `-f, --file`   | File name to detach (required when more than one)     |
+
 **Examples:**
 
 ```bash
 rela detach BUG-042 screenshot
-rela detach DEC-007 supporting-docs
+rela detach DEC-007 supporting-docs --file spec.pdf
 ```
 
 ---

--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -458,7 +458,7 @@ entities:
 | `integer`  | Whole number                            | `=`, `!=`, `<`, `<=`, `>`, `>=`     |
 | `boolean`  | True or false                           | `=`, `!=`                           |
 | `enum`     | Inline enum with `values`               | `=`, `!=`                           |
-| `file`     | File attachment (stored in `.rela/attachments/`) | N/A                          |
+| `file`     | File attachment (stored under `attachments/`)    | N/A                          |
 | `<custom>` | Reference to a type defined in `types:` | `=`, `!=`                           |
 
 ### Property Options
@@ -470,6 +470,25 @@ entities:
 | `format`         | Date format (Go layout string, e.g., `2006-01-02`)   |
 | `description`    | Documentation for the property                       |
 | `list: true`     | Allow multiple values (multi-select for enum types)  |
+| `max`            | For `file` properties: max attachments (default 1)   |
+
+### File attachments and `max`
+
+A `file` property holds an attachment. By default it holds **one** file
+(`max` unset or `1`): uploading a new file replaces the existing one. Set
+`max` above 1 to allow several files on the same property:
+
+```yaml
+supporting_docs:
+  type: file
+  max: 5            # up to 5 files on this property
+```
+
+With `max > 1` the property value is a **list** of attachment paths, the
+data-entry UI shows a multi-file picker (add up to `max`, remove
+individually), and uploading a file whose name already exists auto-suffixes
+it (`report.pdf` → `report (1).pdf`). `max` must be `>= 1` and only applies
+to `file` properties.
 
 ### Date Formats
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -338,8 +338,13 @@ rela attach <entity-id> <file>... [flags]
 ```
 
 Each file is stored at `attachments/<entity-id>/<property>/<filename>`.
-Each file-type property holds at most one attachment; re-running `attach`
-replaces the existing file.
+A file-type property holds one attachment by default; set `max` above 1 on
+the property (see the metamodel reference) to allow several.
+
+> **Note:** for a single-attachment property (`max: 1`), re-running `attach`
+> **replaces** the existing file. For a multi-attachment property (`max > 1`),
+> `attach` **appends** up to the cap, auto-suffixing a duplicate name
+> (`report.pdf` → `report (1).pdf`) and erroring when full.
 
 **Arguments:**
 
@@ -389,26 +394,34 @@ rela attachments DEC-007
 
 ### rela detach
 
-Remove the attachment from an entity property.
+Remove an attachment from an entity property.
 
 ```bash
-rela detach <entity-id> <property>
+rela detach <entity-id> <property> [--file <name>]
 ```
 
-Clears the property on the entity and deletes the underlying file from the
-attachment store. Each file-type property holds at most one attachment, so no
-further disambiguation is needed.
+Deletes the underlying file from the attachment store and re-stamps the
+property. When the property holds a single attachment, `--file` may be
+omitted. When it holds several (a `file` property with `max > 1`), pass
+`--file` to select which one — `rela attachments <entity-id>` lists the
+names.
 
 **Arguments:**
 
 - `entity-id` - Entity ID
 - `property` - Property name containing the attachment
 
+**Flags:**
+
+| Flag           | Description                                            |
+| -------------- | ----------------------------------------------------- |
+| `-f, --file`   | File name to detach (required when more than one)     |
+
 **Examples:**
 
 ```bash
 rela detach BUG-042 screenshot
-rela detach DEC-007 supporting-docs
+rela detach DEC-007 supporting-docs --file spec.pdf
 ```
 
 ---

--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -603,3 +603,131 @@ GET /api/v1/_apps/ticket-counter/_rela.js    → the bridge SDK (reserved path)
 
 There is **no new ACL verb** for apps: an app inherits the logged-in user's
 permissions, so its reads/writes are gated exactly as the SPA's own.
+
+---
+
+## Attachments (`_attachments`)
+
+A `file`-type property holds a binary attachment (image, PDF, …). The
+bytes are stored by the backend keyed to `(entity id, property)`; the
+property value in `properties` is the stored path string, which clients
+should treat as opaque — use `_attachments` and the download endpoint
+instead.
+
+A `file` property can hold one attachment (the default) or several, when
+its metamodel `max` is set above 1 (see `docs/metamodel.md`).
+
+### Metadata on per-entity GET
+
+Per-entity responses carry an `_attachments` map keyed by property name.
+The value is **always a list** — even a single-attachment property reports
+a one-element array, matching how `list:` properties and `_relations` are
+always arrays. Only `file` properties that actually carry a file appear.
+Same closed-world / pointer semantics as `_fields` / `_relations`: present
+(possibly empty) on every per-entity response (GET, PATCH, POST create,
+clone), absent on list rows.
+
+```json
+{
+  "id": "TKT-001",
+  "type": "ticket",
+  "properties": {
+    "screenshot": "attachments/TKT-001/screenshot/shot.png",
+    "docs": [
+      "attachments/TKT-001/docs/a.pdf",
+      "attachments/TKT-001/docs/b.pdf"
+    ]
+  },
+  "_attachments": {
+    "screenshot": [
+      { "id": "shot.png", "filename": "shot.png", "size": 20480,
+        "contentType": "image/png",
+        "href": "/api/v1/tickets/TKT-001/_attachments/screenshot/shot.png" }
+    ],
+    "docs": [
+      { "id": "a.pdf", "filename": "a.pdf", "size": 1024,
+        "contentType": "application/pdf",
+        "href": "/api/v1/tickets/TKT-001/_attachments/docs/a.pdf" },
+      { "id": "b.pdf", "filename": "b.pdf", "size": 2048,
+        "contentType": "application/pdf",
+        "href": "/api/v1/tickets/TKT-001/_attachments/docs/b.pdf" }
+    ]
+  }
+}
+```
+
+`id` is the file's identifier within the property (its normalized file
+name) — used to build the per-file download/delete URL. `contentType` is
+inferred from the filename extension (the store does not persist it on
+every backend). `size` is in bytes. The `properties` value is a scalar
+path for a single-cap property and a list of paths for a multi-cap one;
+treat both as opaque and use `_attachments` instead.
+
+### Download endpoint
+
+Clients fetch the bytes via the `href` from each `_attachments` entry —
+treat it as opaque. The URL shape below documents what the server emits;
+do **not** hand-build it from the property path string or `(id, property,
+fileName)`.
+
+```text
+GET <_attachments[property][i].href>
+  == GET /api/v1/{plural}/{id}/_attachments/{property}/{fileName}
+```
+
+Streams one attachment's bytes. **Access inherits the owning entity's read
+permission** — a caller who cannot read the entity gets `404` (never
+`403`, and byte-identical to a genuinely missing attachment, so existence
+is not leaked). The bytes resolve from `(id, property, fileName)` only; no
+caller-supplied path reaches the filesystem (the store rejects separators
+in the file name), so there is no path-traversal surface and a renamed
+entity resolves by its current id.
+
+Response headers: `Content-Type` (inferred from the filename),
+`Content-Disposition: inline; filename="…"` (sanitized), plus
+`X-Content-Type-Options: nosniff` and a `Content-Security-Policy: sandbox`
+so user-supplied bytes (e.g. an SVG/HTML payload) cannot execute as stored
+XSS in the app origin.
+
+### Upload endpoint
+
+```text
+PUT  /api/v1/{plural}/{id}/_attachments/{property}
+POST /api/v1/{plural}/{id}/_attachments/{property}
+```
+
+`multipart/form-data` with a single `file` field. The response is the
+updated entity (its `_attachments` reflects the new file). Behavior depends
+on the property's `max`:
+
+- **`max == 1`** (default): the upload **replaces** the existing file.
+- **`max > 1`**: the upload **appends**, up to `max`. A file whose
+  (normalized) name already exists is **auto-suffixed** (`report.pdf` →
+  `report (1).pdf`) so it never overwrites a sibling. Uploading past the cap
+  returns `409 attachment_limit`.
+
+**Access inherits the owning entity's `update` permission** — an
+attachment write mutates the entity, so it is authorized as an `update`,
+re-checked server-side **before any bytes are written** (a deny never
+orphans a file). A caller who cannot read the entity gets the same uniform
+`404` as the read path; a caller who can read but not update gets `403`.
+
+Size limits: the request is capped at ingress (`413 attachment_too_large`,
+`application/problem+json`) by a default of 64 MiB, overridable per
+deployment via the data-entry config key `app.max_attachment_bytes`. Every
+store backend also enforces `store.MaxAttachmentBytes` as a backstop, so no
+storage path is ever unbounded. Other failures: `400` for a malformed
+multipart body or a missing `file` field; `422` for a validation failure
+when persisting the property.
+
+### Delete endpoint
+
+```text
+DELETE /api/v1/{plural}/{id}/_attachments/{property}/{fileName}
+```
+
+Removes one file and re-stamps the property from the remaining files;
+returns `204`. Idempotent (deleting a missing file still re-stamps and
+succeeds). Same `update`-permission inheritance as upload. The bytes are
+removed, then the property is persisted, so a persist failure leaves
+orphaned bytes rather than a property pointing at a missing file.

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -452,7 +452,7 @@ entities:
 | `integer`  | Whole number                            | `=`, `!=`, `<`, `<=`, `>`, `>=`     |
 | `boolean`  | True or false                           | `=`, `!=`                           |
 | `enum`     | Inline enum with `values`               | `=`, `!=`                           |
-| `file`     | File attachment (stored in `.rela/attachments/`) | N/A                          |
+| `file`     | File attachment (stored under `attachments/`)    | N/A                          |
 | `<custom>` | Reference to a type defined in `types:` | `=`, `!=`                           |
 
 ### Property Options
@@ -464,6 +464,25 @@ entities:
 | `format`         | Date format (Go layout string, e.g., `2006-01-02`)   |
 | `description`    | Documentation for the property                       |
 | `list: true`     | Allow multiple values (multi-select for enum types)  |
+| `max`            | For `file` properties: max attachments (default 1)   |
+
+### File attachments and `max`
+
+A `file` property holds an attachment. By default it holds **one** file
+(`max` unset or `1`): uploading a new file replaces the existing one. Set
+`max` above 1 to allow several files on the same property:
+
+```yaml
+supporting_docs:
+  type: file
+  max: 5            # up to 5 files on this property
+```
+
+With `max > 1` the property value is a **list** of attachment paths, the
+data-entry UI shows a multi-file picker (add up to `max`, remove
+individually), and uploading a file whose name already exists auto-suffixes
+it (`report.pdf` → `report (1).pdf`). `max` must be `>= 1` and only applies
+to `file` properties.
 
 ### Date Formats
 

--- a/frontend/src/api/attachments.ts
+++ b/frontend/src/api/attachments.ts
@@ -1,0 +1,75 @@
+// Attachment API: upload / delete the files bound to a `file`-type entity
+// property. The bytes are served from, and written to, an ACL-gated
+// endpoint that inherits the owning entity's permission. Uses axios
+// directly (the shared client is JSON-oriented) so multipart uploads can
+// report progress via onUploadProgress.
+import axios from 'axios'
+import { getPlural } from './entities'
+import type { Entity } from '@/types'
+
+function propertyUrl(entityType: string, entityId: string, property: string): string {
+  return `/api/v1/${getPlural(entityType)}/${encodeURIComponent(entityId)}/_attachments/${encodeURIComponent(property)}`
+}
+
+// AttachmentError carries the HTTP status so callers can distinguish a
+// 413 (too large) / 409 (at max) from a 403/422 and render the right
+// inline message.
+export class AttachmentError extends Error {
+  status: number
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = 'AttachmentError'
+    this.status = status
+  }
+}
+
+interface ProblemBody {
+  detail?: string
+  title?: string
+}
+
+function toAttachmentError(err: unknown): AttachmentError {
+  if (axios.isAxiosError(err) && err.response) {
+    const body = err.response.data as ProblemBody | undefined
+    const detail = body?.detail || body?.title || err.response.statusText
+    return new AttachmentError(detail, err.response.status)
+  }
+  return new AttachmentError('Request failed', 0)
+}
+
+/** Upload (append, or replace at max:1) a file on a property. `onProgress`
+ *  receives a 0..1 fraction. Returns the updated entity (its
+ *  `_attachments` reflects the new file). Throws AttachmentError on a
+ *  non-2xx response. */
+export async function uploadAttachment(
+  entityType: string,
+  entityId: string,
+  property: string,
+  file: File,
+  onProgress?: (fraction: number) => void
+): Promise<Entity> {
+  const form = new FormData()
+  form.append('file', file)
+  try {
+    const res = await axios.put<Entity>(propertyUrl(entityType, entityId, property), form, {
+      onUploadProgress: (e) => {
+        if (onProgress && e.total) onProgress(e.loaded / e.total)
+      },
+    })
+    return res.data
+  } catch (err) {
+    throw toAttachmentError(err)
+  }
+}
+
+/** Remove one file from a property, given the server-provided per-file
+ *  `href` (the same URL serves GET and DELETE). Using the href verbatim
+ *  avoids re-escaping the filename, so there's a single escaper. Idempotent.
+ *  Throws AttachmentError on a non-2xx (non-204) response. */
+export async function deleteAttachment(href: string): Promise<void> {
+  try {
+    await axios.delete(href)
+  } catch (err) {
+    throw toAttachmentError(err)
+  }
+}

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -32,7 +32,7 @@ export function _resetEntityPluralsForTest(): void {
   pluralRegistry.clear()
 }
 
-function getPlural(type: string): string {
+export function getPlural(type: string): string {
   const plural = pluralRegistry.get(type)
   if (!plural) {
     // Fail fast instead of fabricating a URL (`category` → `/categorys`

--- a/frontend/src/components/common/PropertyDisplay.vue
+++ b/frontend/src/components/common/PropertyDisplay.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 import type { Component } from 'vue'
 import InaccessibleField from './InaccessibleField.vue'
 import { defaultRegistry } from '@/widgets/registry'
-import type { EntityType, PropertyDef } from '@/types'
+import type { AttachmentInfo, EntityType, PropertyDef } from '@/types'
 
 export interface PropertyItem {
   name: string
@@ -19,6 +19,11 @@ export interface PropertyItem {
   isLongText?: boolean
   inaccessible?: boolean // Property exists but value is unreadable (e.g. encrypted)
   inaccessibleReason?: string // Reason marker (e.g. "git-crypt") shown in tooltip
+  // Attachment LIST for a `file`-type property, supplied by callers from
+  // the entity's `_attachments` map, plus the property's `max`. Forwarded
+  // to the file widget.
+  attachments?: AttachmentInfo[]
+  max?: number
 }
 
 const props = defineProps<{
@@ -91,6 +96,8 @@ function isLong(prop: PropertyItem): boolean {
           :mode="'display'"
           :property-def="row.propertyDef"
           :property-name="row.propertyName"
+          :attachments="row.prop.attachments"
+          :max="row.prop.max"
         />
       </dd>
     </div>

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -435,6 +435,8 @@ function mapFieldsToProperties(fields: ViewSectionField[] | undefined): Property
       propertyDef: def,
       inaccessible: field.inaccessible ?? false,
       inaccessibleReason: field.property ? inaccessibleByName.value.get(field.property) : undefined,
+      attachments: field.property ? entry.value?._attachments?.[field.property] : undefined,
+      max: def?.max,
     }
   })
 }
@@ -811,10 +813,12 @@ watch(
             :entity-type="entry.type"
             :entity-id="entry.id"
             :initial-values="entry.properties"
+            :attachments="entry._attachments"
             :fields="memoBuildSectionEditFields(section, entry)"
             :on-property-applied="handlePropertyApplied"
             :on-error="handleSectionEditError"
             :on-verdict-flip="handleVerdictFlip"
+            :on-attachment-changed="loadView"
           />
           <PropertyDisplay
             v-else-if="section.display === 'properties'"

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -16,6 +16,7 @@ import type {
   ModernRelationsField,
   FieldAffordance,
   RelationAffordance,
+  AttachmentInfo,
 } from '@/types'
 import { getTemplates, createRelation, dryRunCreateEntity, ApiError, getErrorMessage } from '@/api'
 import type { RelationCardState } from './RelationCards.vue'
@@ -68,6 +69,9 @@ const fieldAffordances = ref<Record<string, FieldAffordance>>({})
 // Same for relation affordances. Drives RelationCards' +Add / x button
 // visibility and meta-field disable.
 const relationAffordances = ref<Record<string, RelationAffordance>>({})
+// Per-`file`-property attachment metadata from the loaded entity, passed
+// to the file widget so it can show the current file + drive upload/remove.
+const attachments = ref<Record<string, AttachmentInfo[]>>({})
 // TKT-3I5U: in create mode the form models a staged `++new++` entity
 // and re-derives affordances from the server's dry-run (no persist) as
 // the user types. `stagedVisibleProps` holds the property keys the
@@ -243,13 +247,14 @@ function getTypeFromId(entityId: string): string | undefined {
 }
 
 // Methods
-async function loadEntity() {
+async function loadEntity(force = false) {
   if (!props.entityId || !formConfig.value) return
 
   try {
     const entity = await entitiesStore.fetchEntity(
       formConfig.value.entity,
-      props.entityId
+      props.entityId,
+      force
     )
     // Route-guard: if the server says this entity is not updatable,
     // render an inline "not editable" message instead of the form.
@@ -265,6 +270,7 @@ async function loadEntity() {
     // can treat absence as "default everything".
     fieldAffordances.value = entity._fields ?? {}
     relationAffordances.value = entity._relations ?? {}
+    attachments.value = entity._attachments ?? {}
     originalData.value = JSON.stringify({ formData: formData.value, relations: relations.value, content: content.value })
   } catch (err) {
     // Suppress cancellation errors from rapid navigation in Firefox
@@ -273,6 +279,14 @@ async function loadEntity() {
     uiStore.error('Failed to load entity')
     console.error(err)
   }
+}
+
+// onAttachmentChanged fires after a file widget uploads or removes an
+// attachment (already persisted server-side via the attachment endpoint).
+// Reload the entity so the stamped property value and _attachments
+// refresh. Cache-bust the entity first so the SSE-less refetch is fresh.
+async function onAttachmentChanged() {
+  await loadEntity(true)
 }
 
 // Read return_to from the query eagerly — needed in both create and
@@ -1095,7 +1109,12 @@ onBeforeRouteLeave(async () => {
                   :error="errors[field.property]"
                   :readonly="isFieldReadonly(field)"
                   :option-verdicts="optionVerdictsFor(field)"
+                  :entity-type="formConfig.entity"
+                  :entity-id="entityId"
+                  :attachments="attachments[field.property]"
+                  :max="getPropertyDef(field.property)?.max"
                   @update="updateField(field.property!, $event)"
+                  @attachment-changed="onAttachmentChanged"
                 />
                 <RelationCards
                   v-else-if="field.relation && field.widget === 'cards' && entityId"
@@ -1133,7 +1152,12 @@ onBeforeRouteLeave(async () => {
               :error="errors[field.property]"
               :readonly="isFieldReadonly(field)"
               :option-verdicts="optionVerdictsFor(field)"
+              :entity-type="formConfig.entity"
+              :entity-id="entityId"
+              :attachments="attachments[field.property]"
+              :max="getPropertyDef(field.property)?.max"
               @update="updateField(field.property!, $event)"
+              @attachment-changed="onAttachmentChanged"
             />
             <RelationCards
               v-else-if="field.relation && field.widget === 'cards' && entityId"

--- a/frontend/src/components/forms/FieldRenderer.vue
+++ b/frontend/src/components/forms/FieldRenderer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { FormFieldOrRelation, PropertyDef } from '@/types'
+import type { FormFieldOrRelation, PropertyDef, AttachmentInfo } from '@/types'
 import { defaultRegistry, defaultWidgetFor } from '@/widgets/registry'
 import FieldShell from './FieldShell.vue'
 
@@ -15,10 +15,18 @@ const props = defineProps<{
   // map denies it or the existing transition rules deny it — the two
   // signals are independent and either one is sufficient.
   optionVerdicts?: Record<string, boolean>
+  // File-widget context: the owning entity identity + current attachment
+  // LIST + the property's `max`, forwarded so the file widget can
+  // upload/preview/remove. Only the file-property edit path supplies these.
+  entityType?: string
+  entityId?: string
+  attachments?: AttachmentInfo[]
+  max?: number
 }>()
 
 const emit = defineEmits<{
   update: [value: unknown]
+  'attachment-changed': []
 }>()
 
 const fieldId = computed(() => `field-${props.field.property}`)
@@ -63,7 +71,12 @@ const isCheckbox = computed(() => resolvedWidgetName.value === 'checkbox')
       :help="help"
       :option-verdicts="optionVerdicts"
       :transitions="field.transitions"
+      :attachments="attachments"
+      :max="max"
+      :entity-type="entityType"
+      :entity-id="entityId"
       @update:model-value="emit('update', $event)"
+      @attachment-changed="emit('attachment-changed')"
     />
   </FieldShell>
 </template>

--- a/frontend/src/components/forms/SectionEditForm.test.ts
+++ b/frontend/src/components/forms/SectionEditForm.test.ts
@@ -13,7 +13,7 @@ import { nextTick } from 'vue'
 import { useEntitiesStore } from '@/stores/entities'
 import SectionEditForm, { type SectionEditField } from './SectionEditForm.vue'
 import { ApiError } from '@/api/errors'
-import type { Entity, PropertyDef } from '@/types'
+import type { Entity, PropertyDef, AttachmentInfo } from '@/types'
 
 const TEXT_DEF: PropertyDef = { type: 'string' } as PropertyDef
 const ENUM_DEF: PropertyDef = { type: 'enum', values: ['open', 'closed'] } as PropertyDef
@@ -31,6 +31,7 @@ function mountForm(opts: {
   initialValues?: Record<string, unknown>
   entityType?: string
   entityId?: string
+  attachments?: Record<string, AttachmentInfo[]>
   onPropertyApplied?: Mock
   onError?: Mock
   onVerdictFlip?: Mock
@@ -44,6 +45,7 @@ function mountForm(opts: {
       entityId: opts.entityId ?? 'TKT-001',
       initialValues: opts.initialValues ?? { title: 'Original', status: 'open' },
       fields: opts.fields ?? makeFields(),
+      attachments: opts.attachments,
       onPropertyApplied,
       onError,
       onVerdictFlip,
@@ -250,5 +252,36 @@ describe('SectionEditForm', () => {
     const errorPill = wrapper.find('.field-error')
     expect(errorPill.exists()).toBe(true)
     expect(errorPill.text()).toBe('invalid value')
+  })
+
+  // Regression: the inline-edit display path must forward _attachments to
+  // the file widget. Previously SectionEditForm dropped the attachment, so
+  // a `file` property on a writable entity showed no preview even though
+  // the entity GET / view payload carried _attachments.
+  it('forwards attachment metadata to the file widget for a file property', () => {
+    const FILE_DEF: PropertyDef = { type: 'file' } as PropertyDef
+    const fields: SectionEditField[] = [
+      { property: 'photo', label: 'Photo', kind: 'schema', propertyDef: FILE_DEF, verdict: { writable: true } },
+    ]
+    const att: AttachmentInfo = {
+      id: 'shot.png',
+      filename: 'shot.png',
+      size: 2048,
+      contentType: 'image/png',
+      href: '/api/v1/tickets/TKT-001/_attachments/photo/shot.png',
+    }
+    makeStoreMock()
+    const { wrapper } = mountForm({
+      fields,
+      initialValues: { photo: 'attachments/TKT-001/photo/shot.png' },
+      attachments: { photo: [att] },
+    })
+    const widget = wrapper.findComponent({ name: 'FileWidget' })
+    expect(widget.exists()).toBe(true)
+    expect(widget.props('attachments')).toEqual([att])
+    expect(widget.props('entityType')).toBe('ticket')
+    expect(widget.props('entityId')).toBe('TKT-001')
+    // The preview renders from the forwarded metadata.
+    expect(wrapper.find('img.file-preview').exists()).toBe(true)
   })
 })

--- a/frontend/src/components/forms/SectionEditForm.vue
+++ b/frontend/src/components/forms/SectionEditForm.vue
@@ -14,7 +14,7 @@
 
 import { computed, onBeforeUnmount, reactive, ref, watch, type Ref } from 'vue'
 import type { Component } from 'vue'
-import type { FieldAffordance, PropertyDef, Entity } from '@/types'
+import type { FieldAffordance, PropertyDef, Entity, AttachmentInfo } from '@/types'
 import type { WidgetRoutingHint } from '@/widgets/types'
 import { defaultRegistry } from '@/widgets/registry'
 import { useAutoSave, type AutoSaveErrorInfo } from '@/composables/useAutoSave'
@@ -40,12 +40,19 @@ const props = defineProps<{
   entityId: string
   initialValues: Record<string, unknown>
   fields: SectionEditField[]
+  // Per-`file`-property attachment LISTS for the entity, so the file
+  // widget can show the current files and drive upload/remove on the
+  // inline-edit path. Keyed by property name.
+  attachments?: Record<string, AttachmentInfo[]>
   // Owner identity captured at construction and forwarded to every
   // callback so the host can reject stale responses arriving after
   // a :key-driven remount targeted a different entity (RR-FB2A).
   onPropertyApplied: (prop: string, value: unknown, owner: { type: string; id: string }) => void
   onError: (msg: string, info?: AutoSaveErrorInfo) => void
   onVerdictFlip?: (prop: string, label: string) => void
+  // Called after the file widget uploads/removes an attachment so the
+  // host can refresh the entity (property value + _attachments changed).
+  onAttachmentChanged?: () => void
 }>()
 
 // Owner identity is frozen for the instance's lifetime. When the host
@@ -209,7 +216,12 @@ defineExpose({
               :property-name="row.field.property"
               :property-def="row.field.kind === 'schema' ? row.field.propertyDef : undefined"
               :option-verdicts="row.optionVerdicts"
+              :attachments="props.attachments?.[row.field.property]"
+              :max="row.field.kind === 'schema' ? row.field.propertyDef?.max : undefined"
+              :entity-type="entityType"
+              :entity-id="entityId"
               @update:model-value="(v: unknown) => onFieldUpdate(row.field, v)"
+              @attachment-changed="onAttachmentChanged?.()"
             />
           </FieldShell>
           <component
@@ -219,6 +231,8 @@ defineExpose({
             :model-value="formData[row.field.property]"
             :property-name="row.field.property"
             :property-def="row.field.kind === 'schema' ? row.field.propertyDef : undefined"
+            :attachments="props.attachments?.[row.field.property]"
+            :max="row.field.kind === 'schema' ? row.field.propertyDef?.max : undefined"
           />
         </dd>
       </div>

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -25,6 +25,14 @@ export interface Entity {
   // sparse / closed-world semantics as _fields. Per-relation-type
   // uniform — per-link verdicts are predicate territory (deferred).
   _relations?: Record<string, RelationAffordance>
+  // Per-`file`-property attachment metadata on per-entity responses.
+  // Keyed by property name; the value is always a LIST (a property may
+  // hold several files when its metamodel `max` > 1, and a single file is
+  // a 1-element list). Only properties that carry a file appear. Same
+  // closed-world semantics as _fields/_relations: present (possibly empty)
+  // on every per-entity response (GET, PATCH, POST, clone), absent on list
+  // rows. The file widget reads this to render download links / previews.
+  _attachments?: Record<string, AttachmentInfo[]>
   inaccessible?: InaccessibleField[]
   // Soft-validation findings on mutation responses (DEC-HWZHA).
   // Present on PATCH/POST results; absent on GETs.
@@ -48,6 +56,20 @@ export interface RelationAffordance {
   creatable?: boolean
   removable?: boolean
   fields?: Record<string, FieldAffordance>
+}
+
+// AttachmentInfo describes one file attached to a `file`-type property,
+// as surfaced in Entity._attachments. `id` identifies the file within the
+// property (its normalized name) and is used to build the per-file
+// download/delete URL. `href` is the ACL-gated download URL (inherits the
+// entity's read permission). `contentType` is inferred from the filename
+// by the backend.
+export interface AttachmentInfo {
+  id: string
+  filename: string
+  size: number
+  contentType: string
+  href: string
 }
 
 // Warning is a soft validation finding returned alongside a successful

--- a/frontend/src/types/schema.ts
+++ b/frontend/src/types/schema.ts
@@ -26,6 +26,9 @@ export interface PropertyDef {
   description?: string
   format?: string
   list?: boolean
+  // For `file` properties: maximum attachments (default 1). Above 1 the
+  // property holds several files and the widget switches to add-mode.
+  max?: number
 }
 
 export interface RelationType {

--- a/frontend/src/widgets/FileWidget.vue
+++ b/frontend/src/widgets/FileWidget.vue
@@ -1,0 +1,313 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { WidgetProps } from './types'
+import type { AttachmentInfo } from '@/types'
+import { uploadAttachment, deleteAttachment, AttachmentError } from '@/api/attachments'
+
+const props = defineProps<WidgetProps>()
+
+const emit = defineEmits<{
+  // Fired after a successful upload or delete so the parent can refresh
+  // the entity (the property value and _attachments changed server-side).
+  'attachment-changed': []
+}>()
+
+const files = computed<AttachmentInfo[]>(() => props.attachments ?? [])
+const maxCount = computed(() => props.max ?? 1)
+const isSingle = computed(() => maxCount.value <= 1)
+const atCapacity = computed(() => files.value.length >= maxCount.value)
+
+// Edit mode can mutate only when the widget knows the owning entity and
+// isn't disabled by ACL.
+const canEdit = computed(
+  () => props.mode === 'edit' && !props.disabled && !!props.entityType && !!props.entityId
+)
+// The add control shows when editing and there's room (single-cap: shows
+// as "Replace" once a file exists; multi-cap: hidden at capacity).
+const canAdd = computed(() => canEdit.value && (isSingle.value || !atCapacity.value))
+
+const busy = ref(false)
+const progress = ref(0)
+const uploadError = ref('')
+
+function isImage(att: AttachmentInfo): boolean {
+  return att.contentType?.startsWith('image/') ?? false
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+async function doUpload(file: File) {
+  if (!props.entityType || !props.entityId || busy.value) return
+  busy.value = true
+  progress.value = 0
+  uploadError.value = ''
+  try {
+    await uploadAttachment(props.entityType, props.entityId, props.propertyName, file, (f) => {
+      progress.value = f
+    })
+    emit('attachment-changed')
+  } catch (err) {
+    uploadError.value = uploadErrorMessage(err)
+  } finally {
+    busy.value = false
+  }
+}
+
+function uploadErrorMessage(err: unknown): string {
+  if (err instanceof AttachmentError) {
+    if (err.status === 413) return 'File is too large.'
+    if (err.status === 409) return 'This field already holds the maximum number of files.'
+    return err.message
+  }
+  return 'Upload failed.'
+}
+
+async function doDelete(att: AttachmentInfo) {
+  if (busy.value) return
+  busy.value = true
+  uploadError.value = ''
+  try {
+    await deleteAttachment(att.href)
+    emit('attachment-changed')
+  } catch (err) {
+    uploadError.value = err instanceof AttachmentError ? err.message : 'Delete failed.'
+  } finally {
+    busy.value = false
+  }
+}
+
+function onFileInput(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (file) void doUpload(file)
+  input.value = '' // allow re-selecting the same file
+}
+
+const dragOver = ref(false)
+function onDrop(event: DragEvent) {
+  dragOver.value = false
+  if (!canAdd.value) return
+  const file = event.dataTransfer?.files?.[0]
+  if (file) void doUpload(file)
+}
+</script>
+
+<template>
+  <div class="file-widget">
+    <!-- The current files (display in any mode). -->
+    <ul v-if="files.length" class="file-list">
+      <li v-for="att in files" :key="att.id" class="file-item">
+        <a
+          v-if="isImage(att)"
+          :href="att.href"
+          target="_blank"
+          rel="noopener"
+          class="file-preview-link"
+        >
+          <img :src="att.href" :alt="att.filename" class="file-preview" />
+        </a>
+        <div class="file-meta">
+          <a :href="att.href" :download="att.filename" class="file-name">{{ att.filename }}</a>
+          <span class="file-size">{{ formatSize(att.size) }}</span>
+          <button
+            v-if="canEdit"
+            type="button"
+            class="file-remove"
+            :disabled="busy"
+            @click="doDelete(att)"
+          >
+            Remove
+          </button>
+        </div>
+      </li>
+    </ul>
+
+    <span v-else-if="mode !== 'edit'" class="file-empty">No file attached</span>
+
+    <!-- Add / replace control (edit mode, with room). -->
+    <div
+      v-if="canAdd"
+      class="file-dropzone"
+      :class="{ 'is-dragover': dragOver, 'is-busy': busy }"
+      @dragover.prevent="dragOver = true"
+      @dragleave.prevent="dragOver = false"
+      @drop.prevent="onDrop"
+    >
+      <label class="file-pick">
+        <input type="file" :disabled="busy" @change="onFileInput" />
+        <span>{{ isSingle && files.length ? 'Replace file' : 'Add a file' }}</span>
+      </label>
+      <span class="file-hint">or drag &amp; drop</span>
+      <span v-if="!isSingle" class="file-count">{{ files.length }} / {{ maxCount }}</span>
+    </div>
+
+    <!-- At capacity in multi mode: explain why no add control. -->
+    <p v-else-if="canEdit && !isSingle && atCapacity" class="file-edit-note">
+      Maximum of {{ maxCount }} files reached — remove one to add another.
+    </p>
+
+    <!-- Edit mode but the widget can't mutate (no entity context / ACL). -->
+    <p v-else-if="mode === 'edit' && !canEdit" class="file-edit-note">
+      {{ disabled ? 'Editing this attachment is not permitted.' : 'Attachment editing unavailable.' }}
+    </p>
+
+    <!-- Upload progress. -->
+    <div v-if="busy && progress > 0" class="file-progress">
+      <div class="file-progress-bar" :style="{ width: Math.round(progress * 100) + '%' }" />
+    </div>
+
+    <p v-if="uploadError" class="file-error">{{ uploadError }}</p>
+  </div>
+</template>
+
+<style scoped>
+.file-widget {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.file-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.file-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.file-preview-link {
+  display: inline-block;
+  max-width: 320px;
+}
+
+.file-preview {
+  max-width: 320px;
+  max-height: 240px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  object-fit: contain;
+}
+
+.file-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.file-name {
+  color: var(--accent-color, #6366f1);
+  text-decoration: none;
+  font-size: 14px;
+}
+
+.file-name:hover {
+  text-decoration: underline;
+}
+
+.file-size {
+  color: var(--text-muted, #6b7280);
+  font-size: 12px;
+}
+
+.file-remove {
+  margin-left: auto;
+  border: none;
+  background: none;
+  color: var(--error-color, #ef4444);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.file-remove:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.file-empty {
+  color: var(--text-muted, #6b7280);
+  font-size: 14px;
+  font-style: italic;
+}
+
+.file-edit-note {
+  margin: 0;
+  color: var(--text-muted, #6b7280);
+  font-size: 12px;
+}
+
+.file-dropzone {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px dashed var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+}
+
+.file-dropzone.is-dragover {
+  border-color: var(--accent-color, #6366f1);
+  background: rgba(99, 102, 241, 0.06);
+}
+
+.file-dropzone.is-busy {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.file-pick {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.file-pick input[type='file'] {
+  display: none;
+}
+
+.file-pick span {
+  color: var(--accent-color, #6366f1);
+  font-size: 14px;
+}
+
+.file-hint {
+  color: var(--text-muted, #6b7280);
+  font-size: 12px;
+}
+
+.file-count {
+  margin-left: auto;
+  color: var(--text-muted, #6b7280);
+  font-size: 12px;
+}
+
+.file-progress {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--hover-bg, #e5e7eb);
+  overflow: hidden;
+}
+
+.file-progress-bar {
+  height: 100%;
+  background: var(--accent-color, #6366f1);
+  transition: width 0.1s linear;
+}
+
+.file-error {
+  margin: 0;
+  color: var(--error-color, #ef4444);
+  font-size: 12px;
+}
+</style>

--- a/frontend/src/widgets/registry.test.ts
+++ b/frontend/src/widgets/registry.test.ts
@@ -21,7 +21,7 @@ describe('defaultWidgetFor', () => {
   it.each<[string, PropertyDef | undefined, string]>([
     ['undefined propertyDef', undefined, 'text'],
     ['plain string', { type: 'string' }, 'text'],
-    ['file', { type: 'file' }, 'text'],
+    ['file', { type: 'file' }, 'file'],
     ['boolean', { type: 'boolean' }, 'checkbox'],
     ['date', { type: 'date' }, 'date'],
     ['integer', { type: 'integer' }, 'number'],

--- a/frontend/src/widgets/registry.ts
+++ b/frontend/src/widgets/registry.ts
@@ -8,6 +8,7 @@ import DateWidget from './DateWidget.vue'
 import SelectWidget from './SelectWidget.vue'
 import MultiSelectWidget from './MultiSelectWidget.vue'
 import RruleWidget from './RruleWidget.vue'
+import FileWidget from './FileWidget.vue'
 
 // defaultWidgetFor reproduces FieldRenderer's historical dispatch order
 // exactly (RR-0Z1P6). Order matters: `list` wins over `values`, which
@@ -20,6 +21,7 @@ export function defaultWidgetFor(propertyDef?: PropertyDef): string {
   if (propertyDef?.type === 'date') return 'date'
   if (propertyDef?.type === 'integer') return 'number'
   if (propertyDef?.type === 'rrule') return 'rrule'
+  if (propertyDef?.type === 'file') return 'file'
   return 'text'
 }
 
@@ -97,7 +99,7 @@ export function defineWidgetRegistry(): WidgetRegistry {
 
 function buildDefaultRegistry(): WidgetRegistry {
   const r = defineWidgetRegistry()
-  r.register('text', { component: TextWidget, supportedPropertyTypes: ['string', 'file'] })
+  r.register('text', { component: TextWidget, supportedPropertyTypes: ['string'] })
   r.register('textarea', { component: TextareaWidget, supportedPropertyTypes: ['string'] })
   r.register('number', { component: NumberWidget, supportedPropertyTypes: ['integer'] })
   r.register('checkbox', { component: CheckboxWidget, supportedPropertyTypes: ['boolean'] })
@@ -108,6 +110,7 @@ function buildDefaultRegistry(): WidgetRegistry {
     supportedPropertyTypes: ['enum', 'string'],
   })
   r.register('rrule', { component: RruleWidget, supportedPropertyTypes: ['rrule'] })
+  r.register('file', { component: FileWidget, supportedPropertyTypes: ['file'] })
   return r
 }
 

--- a/frontend/src/widgets/types.ts
+++ b/frontend/src/widgets/types.ts
@@ -1,5 +1,5 @@
 import type { Component } from 'vue'
-import type { PropertyDef } from '@/types'
+import type { PropertyDef, AttachmentInfo } from '@/types'
 
 // PropertyType mirrors PropertyDef['type'] from the metamodel schema.
 // Kept as a named alias so widget entries can declare which property
@@ -46,6 +46,20 @@ export interface WidgetProps<T = unknown> {
   optionVerdicts?: Record<string, boolean>
   // Allowed status transitions keyed by current value (select only).
   transitions?: Record<string, string[]>
+  // Attachment metadata for a `file`-type property, sourced from the
+  // entity's `_attachments` map. The LIST of files currently on the
+  // property (a property may hold several when `max` > 1); empty/absent
+  // when none. The file widget renders download links / previews from it.
+  // Ignored by non-file widgets.
+  attachments?: AttachmentInfo[]
+  // The property's attachment cap (metamodel `max`, default 1). Drives the
+  // file widget's mode: replace at 1, add-up-to-max above.
+  max?: number
+  // Owning entity identity, supplied to the file widget so it can build
+  // the upload/delete URL in edit mode. Optional — present only on the
+  // file-property edit path; other widgets ignore it.
+  entityType?: string
+  entityId?: string
 }
 
 // WidgetRoutingHint is a lightweight description used by the view-side

--- a/frontend/src/widgets/widgets.test.ts
+++ b/frontend/src/widgets/widgets.test.ts
@@ -1,11 +1,38 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import TextWidget from './TextWidget.vue'
 import TextareaWidget from './TextareaWidget.vue'
 import NumberWidget from './NumberWidget.vue'
 import CheckboxWidget from './CheckboxWidget.vue'
 import DateWidget from './DateWidget.vue'
 import SelectWidget from './SelectWidget.vue'
+import FileWidget from './FileWidget.vue'
+
+import type { AttachmentInfo } from '@/types'
+
+// Mock the attachment API. vi.mock is hoisted, so the mock fns and the
+// MockAttachmentError class are defined via vi.hoisted to be available
+// at hoist time. MockAttachmentError mirrors the real AttachmentError
+// (carries an HTTP status) so the widget's `instanceof` branch fires.
+const { mockUpload, mockDelete, MockAttachmentError } = vi.hoisted(() => {
+  class MockAttachmentError extends Error {
+    status: number
+    constructor(message: string, status: number) {
+      super(message)
+      this.status = status
+    }
+  }
+  return {
+    mockUpload: vi.fn().mockResolvedValue({}),
+    mockDelete: vi.fn().mockResolvedValue(undefined),
+    MockAttachmentError,
+  }
+})
+vi.mock('@/api/attachments', () => ({
+  uploadAttachment: mockUpload,
+  deleteAttachment: mockDelete,
+  AttachmentError: MockAttachmentError,
+}))
 
 describe('TextWidget', () => {
   it('renders the value and emits update:modelValue on input', async () => {
@@ -280,5 +307,166 @@ describe('SelectWidget (display)', () => {
     expect(w.findComponent({ name: 'Badge' }).props('value')).toBe('open')
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('[SelectWidget]'))
     warn.mockRestore()
+  })
+})
+
+describe('FileWidget', () => {
+  const att: AttachmentInfo = {
+    id: 'shot.png',
+    filename: 'shot.png',
+    size: 2048,
+    contentType: 'image/png',
+    href: '/api/v1/tickets/TKT-1/_attachments/screenshot/shot.png',
+  }
+
+  it('renders an image preview and a download link for an image attachment', () => {
+    const w = mount(FileWidget, {
+      props: { modelValue: '', mode: 'display' as const, propertyName: 'screenshot', attachments: [att] },
+    })
+    const img = w.find('img.file-preview')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toBe(att.href)
+    const link = w.find('a.file-name')
+    expect(link.attributes('href')).toBe(att.href)
+    expect(link.attributes('download')).toBe('shot.png')
+    expect(w.text()).toContain('shot.png')
+    expect(w.text()).toContain('2.0 KB')
+  })
+
+  it('renders a download link without preview for a non-image attachment', () => {
+    const pdf: AttachmentInfo = { id: 'doc.pdf', filename: 'doc.pdf', size: 500, contentType: 'application/pdf', href: '/h' }
+    const w = mount(FileWidget, {
+      props: { modelValue: '', mode: 'display' as const, propertyName: 'doc', attachments: [pdf] },
+    })
+    expect(w.find('img.file-preview').exists()).toBe(false)
+    expect(w.find('a.file-name').attributes('href')).toBe('/h')
+    expect(w.text()).toContain('doc.pdf')
+    expect(w.text()).toContain('500 B')
+  })
+
+  it('renders all files of a multi-attachment property', () => {
+    const a: AttachmentInfo = { id: 'a.pdf', filename: 'a.pdf', size: 1, contentType: 'application/pdf', href: '/a' }
+    const b: AttachmentInfo = { id: 'b.pdf', filename: 'b.pdf', size: 2, contentType: 'application/pdf', href: '/b' }
+    const w = mount(FileWidget, {
+      props: { modelValue: '', mode: 'display' as const, propertyName: 'docs', attachments: [a, b], max: 3 },
+    })
+    expect(w.findAll('.file-item')).toHaveLength(2)
+    expect(w.text()).toContain('a.pdf')
+    expect(w.text()).toContain('b.pdf')
+  })
+
+  it('shows an empty-state when there are no files in display mode', () => {
+    const w = mount(FileWidget, {
+      props: { modelValue: '', mode: 'display' as const, propertyName: 'p' },
+    })
+    expect(w.text()).toContain('No file attached')
+  })
+
+  it('shows a note (no upload control) in edit mode without entity context', () => {
+    const w = mount(FileWidget, {
+      props: { modelValue: '', mode: 'edit' as const, propertyName: 'screenshot', attachments: [att] },
+    })
+    expect(w.find('.file-dropzone').exists()).toBe(false)
+    expect(w.find('.file-edit-note').exists()).toBe(true)
+    expect(w.text()).toContain('shot.png')
+  })
+
+  it('shows a Replace control for a single-cap property in edit mode', () => {
+    const w = mount(FileWidget, {
+      props: {
+        modelValue: '', mode: 'edit' as const, propertyName: 'screenshot',
+        attachments: [att], max: 1, entityType: 'ticket', entityId: 'TKT-1',
+      },
+    })
+    expect(w.find('.file-dropzone').exists()).toBe(true)
+    expect(w.text()).toContain('Replace file')
+  })
+
+  it('hides the add control at capacity for a multi-cap property', () => {
+    const a: AttachmentInfo = { id: 'a.pdf', filename: 'a.pdf', size: 1, contentType: 'application/pdf', href: '/a' }
+    const b: AttachmentInfo = { id: 'b.pdf', filename: 'b.pdf', size: 2, contentType: 'application/pdf', href: '/b' }
+    const w = mount(FileWidget, {
+      props: {
+        modelValue: '', mode: 'edit' as const, propertyName: 'docs',
+        attachments: [a, b], max: 2, entityType: 'ticket', entityId: 'TKT-1',
+      },
+    })
+    expect(w.find('.file-dropzone').exists()).toBe(false)
+    expect(w.find('.file-edit-note').text()).toContain('Maximum of 2')
+  })
+
+  it('shows the add control with room for a multi-cap property', () => {
+    const a: AttachmentInfo = { id: 'a.pdf', filename: 'a.pdf', size: 1, contentType: 'application/pdf', href: '/a' }
+    const w = mount(FileWidget, {
+      props: {
+        modelValue: '', mode: 'edit' as const, propertyName: 'docs',
+        attachments: [a], max: 3, entityType: 'ticket', entityId: 'TKT-1',
+      },
+    })
+    expect(w.find('.file-dropzone').exists()).toBe(true)
+    expect(w.text()).toContain('Add a file')
+    expect(w.text()).toContain('1 / 3')
+  })
+
+  it('shows a permission note in edit mode when disabled (ACL)', () => {
+    const w = mount(FileWidget, {
+      props: {
+        modelValue: '', mode: 'edit' as const, propertyName: 'screenshot',
+        entityType: 'ticket', entityId: 'TKT-1', disabled: true,
+      },
+    })
+    expect(w.find('.file-dropzone').exists()).toBe(false)
+    expect(w.find('.file-edit-note').text()).toContain('not permitted')
+  })
+})
+
+describe('FileWidget upload', () => {
+  it('uploads a chosen file and emits attachment-changed', async () => {
+    const file = new File(['data'], 'pic.png', { type: 'image/png' })
+    const w = mount(FileWidget, {
+      props: {
+        modelValue: '', mode: 'edit' as const, propertyName: 'screenshot',
+        entityType: 'ticket', entityId: 'TKT-1', max: 1,
+      },
+    })
+    const input = w.find('input[type="file"]')
+    Object.defineProperty(input.element, 'files', { value: [file] })
+    await input.trigger('change')
+    await flushPromises()
+
+    expect(mockUpload).toHaveBeenCalledWith('ticket', 'TKT-1', 'screenshot', file, expect.any(Function))
+    expect(w.emitted('attachment-changed')).toBeTruthy()
+  })
+
+  it('shows an error message and does not emit when upload is rejected', async () => {
+    mockUpload.mockRejectedValueOnce(new MockAttachmentError('File is too large.', 413))
+    const w = mount(FileWidget, {
+      props: {
+        modelValue: '', mode: 'edit' as const, propertyName: 'screenshot',
+        entityType: 'ticket', entityId: 'TKT-1', max: 1,
+      },
+    })
+    const input = w.find('input[type="file"]')
+    Object.defineProperty(input.element, 'files', { value: [new File(['x'], 'big.bin')] })
+    await input.trigger('change')
+    await flushPromises()
+
+    expect(w.find('.file-error').text()).toContain('too large')
+    expect(w.emitted('attachment-changed')).toBeFalsy()
+  })
+
+  it('removes a file and emits attachment-changed', async () => {
+    const w = mount(FileWidget, {
+      props: {
+        modelValue: '', mode: 'edit' as const, propertyName: 'screenshot',
+        attachments: [{ id: 'shot.png', filename: 'shot.png', size: 1, contentType: 'image/png', href: '/h' }],
+        max: 1, entityType: 'ticket', entityId: 'TKT-1',
+      },
+    })
+    await w.find('.file-remove').trigger('click')
+    await flushPromises()
+    // Deletes via the server-provided per-file href (single escaper).
+    expect(mockDelete).toHaveBeenCalledWith('/h')
+    expect(w.emitted('attachment-changed')).toBeTruthy()
   })
 })

--- a/internal/attachment/attachment.go
+++ b/internal/attachment/attachment.go
@@ -8,9 +8,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -62,10 +66,11 @@ func New(d Deps) (*Service, error) {
 }
 
 // Attach streams the file at filePath into the store at
-// `attachments/<entityID>/<property>/<base(filePath)>` and records
-// the path on the entity's property. The stored file overwrites any
-// existing attachment at the same path — file-type properties hold
-// at most one attachment.
+// `attachments/<entityID>/<property>/<fileName>` and records the path(s)
+// on the entity's property. Behavior depends on the property's `max`: at
+// max==1 (the default) the upload replaces the single attachment; above 1
+// it appends up to the cap, auto-suffixing the name on collision and
+// erroring when full.
 //
 // If property is empty, the first file-type property declared on the
 // entity type (in alphabetical order — see [findFileProperty]) is
@@ -103,13 +108,72 @@ func (s *Service) Attach(ctx context.Context, entityID, filePath, property strin
 	}
 	defer src.Close()
 
-	fileName := filepath.Base(filePath)
-	if err := s.deps.Store.AttachFile(ctx, entityID, propName, fileName, src); err != nil {
+	return s.WriteAttachment(ctx, e, propDef, propName, filepath.Base(filePath), src)
+}
+
+// ErrAtCapacity is returned by [Service.WriteAttachment] when a multi-file
+// property already holds its `max` attachments. Callers (the HTTP handler)
+// map it to a 409.
+var ErrAtCapacity = errors.New("attachment: property already holds the maximum number of attachments")
+
+// WriteAttachment is the shared write-path policy used by both the CLI
+// (Attach) and the data-entry HTTP upload handler, so the cap/suffix/
+// stamp rules live in exactly one place. The entity, its property def, and
+// the (already-gated) property name are passed in; r supplies the bytes.
+//
+// Ordering is deliberate to avoid data loss: the new file is written
+// FIRST, and only after it lands are superseded files removed (at max==1,
+// the other files on the property). A store failure mid-write therefore
+// leaves the existing attachment intact.
+//
+// Cap enforcement (the `max` ceiling) reads the current file set then
+// writes, which is not atomic — it assumes writers to a given
+// (entity, property) are serialized. The HTTP path holds a per-App write
+// mutex; concurrent CLI invocations against the same property could race
+// and overshoot the cap. That's acceptable for the single-writer CLI use.
+func (s *Service) WriteAttachment(
+	ctx context.Context, e *entity.Entity, propDef metamodel.PropertyDef, propName, rawFileName string, r io.Reader,
+) (*Result, error) {
+	maxCount := propDef.FileMax()
+
+	existing, err := s.attachmentFileNames(ctx, e.ID, propName)
+	if err != nil {
+		return nil, fmt.Errorf("list attachments: %w", err)
+	}
+
+	fileName, err := resolveAttachName(rawFileName, existing, maxCount)
+	if err != nil {
+		return nil, err
+	}
+
+	// Write the new bytes first. On failure the existing files are untouched.
+	if err := s.deps.Store.AttachFile(ctx, e.ID, propName, fileName, r); err != nil {
 		return nil, fmt.Errorf("store attachment: %w", err)
 	}
 
-	key := filepath.ToSlash(filepath.Join("attachments", entityID, propName, fileName))
-	e.SetString(propName, key)
+	// Compute the post-write file set without a second ListAttachments: at
+	// max==1 it's just the new file (and we delete the rest); above 1 it's
+	// the prior set plus the new name (a same-name upload replaced in place,
+	// so dedupe).
+	var names []string
+	if maxCount <= 1 {
+		for _, old := range existing {
+			if old == fileName {
+				continue
+			}
+			_ = s.deps.Store.DeleteAttachment(ctx, e.ID, propName, old)
+		}
+		names = []string{fileName}
+	} else {
+		names = append(names, existing...)
+		if !slices.Contains(names, fileName) {
+			names = append(names, fileName)
+		}
+		sort.Strings(names)
+	}
+
+	stampPropertyNames(e, propName, maxCount, names)
+	key := attachPath(e.ID, propName, fileName)
 	if _, err := s.deps.EntityManager.UpdateEntity(ctx, e); err != nil {
 		// The file landed on disk before UpdateEntity ran, so a failure
 		// here leaves an orphan. CleanupOrphanedTempFiles (analysis
@@ -119,6 +183,143 @@ func (s *Service) Attach(ctx context.Context, entityID, filePath, property strin
 	}
 
 	return &Result{Path: key, FileName: fileName}, nil
+}
+
+// DeleteAttachment removes one file from a property and re-stamps it,
+// shared with the HTTP delete handler. The caller is responsible for ACL
+// gating; this performs the store delete + property re-stamp + persist.
+func (s *Service) DeleteAttachment(
+	ctx context.Context, e *entity.Entity, propDef metamodel.PropertyDef, propName, fileName string,
+) error {
+	err := s.deps.Store.DeleteAttachment(ctx, e.ID, propName, fileName)
+	if err != nil && !errors.Is(err, store.ErrNotFound) {
+		return fmt.Errorf("delete attachment: %w", err)
+	}
+	if err := s.stampProperty(ctx, e, propName, propDef.FileMax()); err != nil {
+		return err
+	}
+	if _, err := s.deps.EntityManager.UpdateEntity(ctx, e); err != nil {
+		return fmt.Errorf("update entity: %w", err)
+	}
+	return nil
+}
+
+// Detach removes one attachment from a file-type property. If fileName is
+// empty and the property holds exactly one file, that file is removed; if
+// it holds several, an error asks the caller to disambiguate. The property
+// is re-stamped from the store's remaining files and persisted.
+func (s *Service) Detach(ctx context.Context, entityID, property, fileName string) error {
+	e, err := s.deps.Store.GetEntity(ctx, entityID)
+	if err != nil {
+		return fmt.Errorf("get entity %s: %w", entityID, err)
+	}
+	entityDef, ok := s.deps.Meta.GetEntityDef(e.Type)
+	if !ok {
+		return fmt.Errorf("unknown entity type: %s", e.Type)
+	}
+	propDef, ok := entityDef.Properties[property]
+	if !ok {
+		return fmt.Errorf("property %q not defined for entity type %s", property, e.Type)
+	}
+	if propDef.Type != metamodel.PropertyTypeFile {
+		return fmt.Errorf("property %q is not a file type (is %s)", property, propDef.Type)
+	}
+
+	existing, err := s.attachmentFileNames(ctx, entityID, property)
+	if err != nil {
+		return fmt.Errorf("list attachments: %w", err)
+	}
+	if len(existing) == 0 {
+		return fmt.Errorf("property %q has no attachment", property)
+	}
+	target := fileName
+	if target == "" {
+		if len(existing) > 1 {
+			return fmt.Errorf("property %q holds %d files; specify which to detach: %v",
+				property, len(existing), existing)
+		}
+		target = existing[0]
+	}
+
+	return s.DeleteAttachment(ctx, e, propDef, property, target)
+}
+
+// attachmentFileNames lists the file names currently on the property, in
+// stable order. A real store error is returned (not swallowed) because the
+// write path makes cap / replace decisions from this list — acting on a
+// degraded view could overshoot the cap or skip the replace-delete.
+func (s *Service) attachmentFileNames(ctx context.Context, entityID, property string) ([]string, error) {
+	infos, err := s.deps.Store.ListAttachments(ctx, entityID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var names []string
+	for _, info := range infos {
+		if info.Property == property {
+			names = append(names, info.FileName)
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// stampProperty re-reads the store's current files for the property and
+// stamps them. Used by the delete path, where the post-delete set is the
+// store's truth. The write path uses stampPropertyNames with the set it
+// already computed, to avoid a redundant ListAttachments.
+func (s *Service) stampProperty(ctx context.Context, e *entity.Entity, property string, maxCount int) error {
+	names, err := s.attachmentFileNames(ctx, e.ID, property)
+	if err != nil {
+		return fmt.Errorf("list attachments: %w", err)
+	}
+	stampPropertyNames(e, property, maxCount, names)
+	return nil
+}
+
+// stampPropertyNames writes the property value from a known set of file
+// names: a scalar path for a single-cap property (empty when none), a list
+// of paths for a multi-cap property.
+func stampPropertyNames(e *entity.Entity, property string, maxCount int, names []string) {
+	if maxCount <= 1 {
+		if len(names) == 0 {
+			e.SetString(property, "")
+			return
+		}
+		e.SetString(property, attachPath(e.ID, property, names[0]))
+		return
+	}
+	paths := make([]string, 0, len(names))
+	for _, n := range names {
+		paths = append(paths, attachPath(e.ID, property, n))
+	}
+	e.Properties[property] = paths
+}
+
+func attachPath(entityID, property, fileName string) string {
+	return filepath.ToSlash(filepath.Join("attachments", entityID, property, fileName))
+}
+
+// resolveAttachName applies the filename policy for an attach: normalize
+// (NormalizeFileName always yields a usable name, never ""), then at max>1
+// auto-suffix on collision and return ErrAtCapacity when full. At max==1
+// the name is whatever was uploaded (the caller replaces).
+func resolveAttachName(rawName string, existing []string, maxCount int) (string, error) {
+	name := store.NormalizeFileName(rawName)
+	if maxCount <= 1 {
+		return name, nil
+	}
+	if len(existing) >= maxCount {
+		return "", ErrAtCapacity
+	}
+	have := make(map[string]bool, len(existing))
+	for _, f := range existing {
+		have[f] = true
+	}
+	// Auto-suffix on collision so a duplicate upload adds a distinct file.
+	return store.SuffixOnCollision(name, func(c string) bool { return have[c] }), nil
 }
 
 // List returns all attachments for an entity. Content type is

--- a/internal/attachment/attachment_test.go
+++ b/internal/attachment/attachment_test.go
@@ -3,6 +3,7 @@ package attachment_test
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,6 +38,9 @@ entities:
         type: string
       spec:
         type: file
+      gallery:
+        type: file
+        max: 3
 `
 
 // attachmentFixture is the bundle setupAttachmentService returns so
@@ -229,3 +233,76 @@ func TestService_New_RejectsNilDeps(t *testing.T) {
 // in New so the subsequent Meta / EntityManager nil-checks can be
 // exercised. Never invoked.
 type storeStub struct{ store.Store }
+
+// failingReader yields some bytes then errors, to force AttachFile to fail
+// AFTER a prior attachment exists — exercising the data-loss ordering.
+type failingReader struct{ n int }
+
+func (f *failingReader) Read(p []byte) (int, error) {
+	if f.n > 0 {
+		f.n--
+		p[0] = 'x'
+		return 1, nil
+	}
+	return 0, errors.New("simulated mid-stream read error")
+}
+
+// TestService_ReplaceFailureKeepsExisting pins RR-N96YV0: at max==1, if the
+// new AttachFile fails, the existing attachment must survive (attach-first,
+// then delete-old ordering — not delete-then-attach).
+func TestService_ReplaceFailureKeepsExisting(t *testing.T) {
+	f := setupAttachmentService(t)
+	ctx := context.Background()
+	e := entity.New("T-1", "ticket")
+	require := func(err error, msg string) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("%s: %v", msg, err)
+		}
+	}
+	require(f.st.CreateEntity(ctx, e), "create entity")
+
+	def := metamodel.PropertyDef{Type: metamodel.PropertyTypeFile} // max:1
+	// Attach a valid original.
+	_, err := f.svc.WriteAttachment(ctx, e, def, "spec", "ok.pdf", strings.NewReader("original"))
+	require(err, "initial attach")
+
+	// Replace with a different name whose reader fails mid-stream.
+	_, err = f.svc.WriteAttachment(ctx, e, def, "spec", "new.pdf", &failingReader{n: 2})
+	if err == nil {
+		t.Fatal("expected the failing replace to error")
+	}
+
+	// The original must still be present and readable.
+	rc, readErr := f.st.ReadAttachment(ctx, "T-1", "spec", "ok.pdf")
+	if readErr != nil {
+		t.Fatalf("original attachment was destroyed by a failed replace: %v", readErr)
+	}
+	data, _ := io.ReadAll(rc)
+	rc.Close()
+	if string(data) != "original" {
+		t.Errorf("original bytes = %q, want %q", data, "original")
+	}
+}
+
+// TestService_MultiAppendAndCap pins append-up-to-max + auto-suffix + the
+// ErrAtCapacity sentinel on a max:3 property.
+func TestService_MultiAppendAndCap(t *testing.T) {
+	f := setupAttachmentService(t)
+	ctx := context.Background()
+	e := entity.New("T-1", "ticket")
+	if err := f.st.CreateEntity(ctx, e); err != nil {
+		t.Fatalf("create entity: %v", err)
+	}
+	def := metamodel.PropertyDef{Type: metamodel.PropertyTypeFile, Max: 3}
+
+	for _, n := range []string{"a.pdf", "b.pdf", "c.pdf"} {
+		if _, err := f.svc.WriteAttachment(ctx, e, def, "gallery", n, strings.NewReader(n)); err != nil {
+			t.Fatalf("append %s: %v", n, err)
+		}
+	}
+	// Duplicate name auto-suffixes (this would exceed 3 → at-capacity first).
+	if _, err := f.svc.WriteAttachment(ctx, e, def, "gallery", "d.pdf", strings.NewReader("d")); !errors.Is(err, attachment.ErrAtCapacity) {
+		t.Errorf("4th append: err = %v, want ErrAtCapacity", err)
+	}
+}

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+
+	"github.com/Sourcehaven-BV/rela/internal/attachment"
 )
 
 // AttachCmd attaches one or more files to an entity property.
@@ -32,6 +34,10 @@ func (c *AttachCmd) Run(ctx context.Context, svc *cliServices) error {
 			}
 			result, err := svc.AttachFile(ctx, c.EntityID, absPath, c.Property)
 			if err != nil {
+				if errors.Is(err, attachment.ErrAtCapacity) {
+					return fmt.Errorf("cannot attach %q: property is full — detach a file first (rela attachments %s)",
+						match, c.EntityID)
+				}
 				return fmt.Errorf("failed to attach %q: %w", match, err)
 			}
 			out.WriteSuccess("Attached %s → %s", filepath.Base(match), result.Path)

--- a/internal/cli/cli_wiring.go
+++ b/internal/cli/cli_wiring.go
@@ -116,6 +116,10 @@ func (s *cliServices) AttachFile(ctx context.Context, entityID, filePath, proper
 	return s.attachment.Attach(ctx, entityID, filePath, property)
 }
 
+func (s *cliServices) DetachFile(ctx context.Context, entityID, property, fileName string) error {
+	return s.attachment.Detach(ctx, entityID, property, fileName)
+}
+
 func (s *cliServices) ListAttachments(ctx context.Context, entityID string) ([]attachment.Info, error) {
 	return s.attachment.List(ctx, entityID)
 }

--- a/internal/cli/detach.go
+++ b/internal/cli/detach.go
@@ -2,45 +2,25 @@ package cli
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
-// DetachCmd removes the attachment from an entity property.
+// DetachCmd removes an attachment from an entity property. When the
+// property holds several attachments, --file selects which one.
 type DetachCmd struct {
+	File     string `short:"f" help:"File name to detach (required when the property holds more than one)."`
 	EntityID string `arg:"" name:"entity-id" help:"Target entity ID."`
 	Property string `arg:"" help:"Property name."`
 }
 
-// Run dispatches `rela detach <entity-id> <property>`.
+// Run dispatches `rela detach <entity-id> <property> [--file <name>]`.
 func (c *DetachCmd) Run(ctx context.Context, svc *cliServices) error {
-	e, err := svc.Store().GetEntity(ctx, c.EntityID)
-	if err != nil {
-		return fmt.Errorf("entity not found: %s", c.EntityID)
+	if err := svc.DetachFile(ctx, c.EntityID, c.Property, c.File); err != nil {
+		return err
 	}
-	entityDef, ok := svc.Meta().GetEntityDef(e.Type)
-	if !ok {
-		return fmt.Errorf("unknown entity type: %s", e.Type)
+	if c.File != "" {
+		out.WriteSuccess("Detached %s from %s.%s", c.File, c.EntityID, c.Property)
+	} else {
+		out.WriteSuccess("Detached attachment from %s.%s", c.EntityID, c.Property)
 	}
-	propDef, ok := entityDef.Properties[c.Property]
-	if !ok {
-		return fmt.Errorf("property %q not defined for entity type %s", c.Property, e.Type)
-	}
-	if propDef.Type != metamodel.PropertyTypeFile {
-		return fmt.Errorf("property %q is not a file type (is %s)", c.Property, propDef.Type)
-	}
-	val, ok := e.Properties[c.Property]
-	if !ok || val == nil || val == "" {
-		return fmt.Errorf("property %q has no attachment", c.Property)
-	}
-	if err := svc.Store().DeleteAttachment(ctx, c.EntityID, c.Property); err != nil {
-		return fmt.Errorf("delete attachment: %w", err)
-	}
-	delete(e.Properties, c.Property)
-	if _, err := svc.EntityManager().UpdateEntity(ctx, e); err != nil {
-		return fmt.Errorf("update entity: %w", err)
-	}
-	out.WriteSuccess("Detached attachment from %s.%s", c.EntityID, c.Property)
 	return nil
 }

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -3,8 +3,11 @@ package dataentry
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
@@ -12,6 +15,7 @@ import (
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
 // translateVerb maps a wire-format verb to the [acl.WriteRequest] that
@@ -625,7 +629,13 @@ func (a *App) validateRelationMetaWrite(ctx context.Context, e *entityPkg.Entity
 // is consistent: `_fields: {}` under the nop resolver, sparse entries
 // under any other.
 func (a *App) computeFieldAffordances(ctx context.Context, e *entityPkg.Entity) map[string]V1FieldAffordance {
-	v := a.fieldResolver.FieldVerdicts(ctx, e)
+	return computeFieldAffordancesFrom(a.fieldResolver.FieldVerdicts(ctx, e))
+}
+
+// computeFieldAffordancesFrom is computeFieldAffordances given an
+// already-resolved verdict set, so callers that need the verdicts for more
+// than one thing (e.g. _fields + _attachments) resolve them once.
+func computeFieldAffordancesFrom(v FieldVerdicts) map[string]V1FieldAffordance {
 	out := make(map[string]V1FieldAffordance)
 
 	// writable=false entries
@@ -822,10 +832,68 @@ func (a *App) stripHiddenProperties(ctx context.Context, e *entityPkg.Entity, re
 // per-entity response (GET, PATCH, POST, clone, action) — list rows
 // and includes get [App.stripHiddenProperties] only.
 func (a *App) attachEntityAffordances(ctx context.Context, e *entityPkg.Entity, result *V1Entity) {
-	fields := a.computeFieldAffordances(ctx, e)
+	verdicts := a.fieldResolver.FieldVerdicts(ctx, e)
+	fields := computeFieldAffordancesFrom(verdicts)
 	relations := a.computeRelationAffordances(ctx, e)
 	result.FieldAffordances = &fields
 	result.RelationAffordances = &relations
+	// Pass the same verdicts so a policy-hidden `file` property's attachments
+	// are omitted from `_attachments` — otherwise the hidden-field boundary
+	// the rest of the response maintains would leak the file's metadata and a
+	// working download href.
+	attachments := a.computeAttachments(ctx, e, result.Self, verdicts)
+	result.Attachments = &attachments
+}
+
+// computeAttachments returns the per-property attachment metadata for an
+// entity, keyed by `file`-type property name. Only properties that carry
+// a file appear; an empty map means "no attachments". Rides every
+// per-entity V1Entity response (GET, PATCH, POST, clone) alongside
+// `_fields` / `_relations`, never on list rows — same closed-world shape.
+//
+// selfHref is the entity's `_self` link (`/api/v1/{plural}/{id}`); each
+// file's download href is that plus `/_attachments/{property}/{fileName}`.
+// `_self` is always set by entityToV1 before this runs, so the
+// empty-selfHref guard is pure defense — when it can't build a valid href
+// it omits the entry rather than emit a broken relative link.
+//
+// The value per property is a LIST: a property may hold several files, and
+// even a single file is reported as a 1-element list (always-array wire
+// shape).
+func (a *App) computeAttachments(ctx context.Context, e *entityPkg.Entity, selfHref string, verdicts FieldVerdicts) map[string][]V1Attachment {
+	out := make(map[string][]V1Attachment)
+	if selfHref == "" {
+		return out
+	}
+	infos, err := a.store.ListAttachments(ctx, e.ID)
+	if err != nil {
+		// Treat a list failure as "no attachments" rather than failing the
+		// whole entity response — the bytes endpoint still gates and serves
+		// correctly; this map is only a UI hint. But a real backend fault
+		// (not just a missing entity) is logged so operators aren't blind to
+		// an outage that silently empties every entity's _attachments.
+		if !errors.Is(err, store.ErrNotFound) {
+			slog.Warn("dataentry: list attachments for serialization failed",
+				"err", err, "entity", e.ID)
+		}
+		return out
+	}
+	for _, info := range infos {
+		// A property hidden from this viewer by field-visibility policy must
+		// not leak its files (metadata or a working download href) — mirror
+		// the hidden-field boundary the rest of the response maintains.
+		if !verdicts.IsVisible(info.Property) {
+			continue
+		}
+		out[info.Property] = append(out[info.Property], V1Attachment{
+			ID:          info.FileName,
+			FileName:    info.FileName,
+			Size:        info.Size,
+			ContentType: contentTypeForFilename(info.FileName),
+			Href:        selfHref + "/_attachments/" + info.Property + "/" + url.PathEscape(info.FileName),
+		})
+	}
+	return out
 }
 
 // serializeEntityForWire is the single entry-point every handler that

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -56,6 +56,18 @@ type V1Entity struct {
 	// per-entity GET responses. Same pointer / closed-world semantics
 	// as FieldAffordances.
 	RelationAffordances *map[string]V1RelationAffordance `json:"_relations,omitempty"`
+	// Attachments maps a `file`-type property name to the LIST of files
+	// currently attached to it (a property may hold several when its
+	// metamodel `max` > 1). The value is always an array — even a
+	// single-attachment property reports a 1-element list — matching how
+	// rela's `list:` properties and `_relations` are always arrays. Only
+	// properties that actually carry a file appear. Same pointer /
+	// closed-world semantics as FieldAffordances: present (possibly empty)
+	// on every per-entity response (GET, PATCH, POST create, clone — the
+	// ones that run serializeEntityForWire), nil on list rows and other
+	// non-per-entity shapes. The SPA's file widget reads this to render the
+	// download links / previews instead of the raw stored path string(s).
+	Attachments *map[string][]V1Attachment `json:"_attachments,omitempty"`
 	// Warnings lists soft-condition findings surfaced by the write
 	// path. Populated only by mutation responses (PATCH); read paths
 	// leave it nil. Each warning has a stable `code`, an RFC 6901
@@ -81,6 +93,21 @@ type V1RelationAffordance struct {
 	Creatable *bool                        `json:"creatable,omitempty"`
 	Removable *bool                        `json:"removable,omitempty"`
 	Fields    map[string]V1FieldAffordance `json:"fields,omitempty"`
+}
+
+// V1Attachment describes one file attached to a `file`-type property, as
+// surfaced on a per-entity GET response. ID is the file's identifier
+// within the property (its normalized file name) — used to build the
+// per-file download/delete URL. Href is the download URL for the bytes (an
+// ACL-gated endpoint that inherits the owning entity's read permission).
+// ContentType is inferred from the filename — the store does not persist
+// it on every backend.
+type V1Attachment struct {
+	ID          string `json:"id"`
+	FileName    string `json:"filename"`
+	Size        int64  `json:"size"`
+	ContentType string `json:"contentType"`
+	Href        string `json:"href"`
 }
 
 // V1InaccessibleField describes a property that is known to exist but
@@ -133,6 +160,10 @@ type V1PropertyDef struct {
 	Values      []string `json:"values,omitempty"`
 	Description string   `json:"description,omitempty"`
 	List        bool     `json:"list,omitempty"`
+	// Max is the attachment cap for a `file` property (default 1). The SPA's
+	// file widget reads it to switch between replace-mode and multi-file
+	// add-mode. Omitted unless set above 1.
+	Max int `json:"max,omitempty"`
 }
 
 func (a *App) toV1PropertyDef(meta *metamodel.Metamodel, propDef metamodel.PropertyDef) V1PropertyDef {
@@ -142,6 +173,7 @@ func (a *App) toV1PropertyDef(meta *metamodel.Metamodel, propDef metamodel.Prope
 		Default:     propDef.Default,
 		Description: propDef.Description,
 		List:        propDef.List,
+		Max:         propDef.Max,
 	}
 	if ct, ok := meta.Types[propDef.Type]; ok {
 		pd.Values = ct.Values
@@ -334,20 +366,27 @@ func (a *App) handleV1DynamicRoutes(w http.ResponseWriter, r *http.Request) {
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Resource not found", "")
 		}
 	case 4:
-		// /{plural}/{id}/relations/{relType} or /{plural}/{id}/_actions/{action}
+		// /{plural}/{id}/relations/{relType}, /{plural}/{id}/_actions/{action},
+		// or /{plural}/{id}/_attachments/{property}
 		switch parts[2] {
 		case "relations":
 			a.handleV1EntityRelationType(w, r, typeName, parts[1], parts[3])
 		case "_actions":
 			a.handleV1EntityAction(w, r, typeName, parts[1], parts[3])
+		case "_attachments":
+			a.handleV1AttachmentRoute(w, r, typeName, plural, parts[1], parts[3])
 		default:
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Resource not found", "")
 		}
 	case 5:
-		// /{plural}/{id}/relations/{relType}/{targetId}
-		if parts[2] == "relations" {
+		// /{plural}/{id}/relations/{relType}/{targetId} or
+		// /{plural}/{id}/_attachments/{property}/{fileName}
+		switch parts[2] {
+		case "relations":
 			a.handleV1RelationTarget(w, r, typeName, parts[1], parts[3], parts[4])
-		} else {
+		case "_attachments":
+			a.handleV1AttachmentFileRoute(w, r, typeName, parts[1], parts[3], parts[4])
+		default:
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Resource not found", "")
 		}
 	default:
@@ -803,6 +842,14 @@ func (a *App) handleV1SingleEntity(w http.ResponseWriter, r *http.Request, typeN
 // clone, relations CRUD) handles the deny branch the same way — a
 // future divergence in error code, body shape, or ETag suppression
 // would otherwise be a per-handler oracle leak (RR-NGMI).
+// entityNotFoundTitle is the title for EVERY read-path 404 — the ACL
+// deny path (gateReadOrNotFound), a genuinely missing entity, and a
+// missing attachment all share it so a denied read is byte-identical to
+// a nonexistent one (the RR-NGMI indistinguishability invariant). Any
+// handler that 404s on the read path MUST use this const, not a fresh
+// literal, or the bodies drift and existence leaks.
+const entityNotFoundTitle = "Entity not found"
+
 func (a *App) gateReadOrNotFound(w http.ResponseWriter, r *http.Request, typeName, entityID string) bool {
 	ok, err := readGateFromContext(r.Context()).PermitsRead(r.Context(), typeName, entityID)
 	if err != nil {
@@ -810,7 +857,7 @@ func (a *App) gateReadOrNotFound(w http.ResponseWriter, r *http.Request, typeNam
 		return false
 	}
 	if !ok {
-		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
+		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
 		return false
 	}
 	return true
@@ -830,7 +877,7 @@ func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName
 
 	entity, found := a.getEntity(ctx, entityID)
 	if !found || entity.Type != typeName {
-		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
+		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
 		return
 	}
 
@@ -1700,15 +1747,7 @@ func (a *App) handleV1SchemaRoutes(w http.ResponseWriter, r *http.Request) {
 			et.IDPrefixes = prefixes
 		}
 		for propName, propDef := range def.Properties {
-			pd := V1PropertyDef{
-				Type:     propDef.Type,
-				Required: propDef.Required,
-				Default:  propDef.Default,
-			}
-			if ct, ok := s.Meta.Types[propDef.Type]; ok {
-				pd.Values = ct.Values
-			}
-			et.Properties[propName] = pd
+			et.Properties[propName] = a.toV1PropertyDef(s.Meta, propDef)
 		}
 		writeV1JSON(w, http.StatusOK, et)
 

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -46,8 +46,17 @@ func TestV1SchemaEndpoint(t *testing.T) {
 		t.Errorf("expected 2 entity types, got %d", len(schema.Entities))
 	}
 
-	if _, ok := schema.Entities["ticket"]; !ok {
-		t.Error("expected 'ticket' entity type in schema")
+	ticket, ok := schema.Entities["ticket"]
+	if !ok {
+		t.Fatal("expected 'ticket' entity type in schema")
+	}
+	// The `docs` file property has max:3 — the schema must surface it so the
+	// SPA's file widget knows to use multi-file (add) mode, not replace mode.
+	if got := ticket.Properties["docs"].Max; got != 3 {
+		t.Errorf("docs.max = %d, want 3 (multi-file widget depends on this)", got)
+	}
+	if got := ticket.Properties["screenshot"].Max; got != 0 {
+		t.Errorf("screenshot.max = %d, want 0 (single-file, omitted)", got)
 	}
 }
 
@@ -2171,6 +2180,15 @@ func TestV1SchemaTypesSpecific(t *testing.T) {
 	if entityType.Label != "Ticket" {
 		t.Errorf("expected label 'Ticket', got %q", entityType.Label)
 	}
+	// This endpoint shares toV1PropertyDef with /_schema, so it must surface
+	// the same fields — in particular `max` for file properties (the multi-
+	// file widget depends on it) so the two schema endpoints can't drift.
+	if got := entityType.Properties["docs"].Max; got != 3 {
+		t.Errorf("docs.max = %d, want 3 (file widget multi-file mode)", got)
+	}
+	if got := entityType.Properties["screenshot"].Max; got != 0 {
+		t.Errorf("screenshot.max = %d, want 0 (single-file, omitted)", got)
+	}
 }
 
 func TestV1GetEntityIncludeIncoming(t *testing.T) {
@@ -2656,13 +2674,15 @@ func newTestAppV1(t *testing.T) *App {
 				Label:    "Ticket",
 				IDPrefix: "TKT-",
 				Properties: map[string]metamodel.PropertyDef{
-					"title":  {Type: "string", Required: true},
-					"status": {Type: "string"},
+					"title":      {Type: "string", Required: true},
+					"status":     {Type: "string"},
+					"screenshot": {Type: "file"},
+					"docs":       {Type: "file", Max: 3},
 				},
 				// PropertyOrder is populated at YAML-load time in
 				// production; set it explicitly here so tests exercise
 				// the same code paths the runtime hits.
-				PropertyOrder: []string{"title", "status"},
+				PropertyOrder: []string{"title", "status", "screenshot", "docs"},
 			},
 			"feature": {
 				Label:    "Feature",

--- a/internal/dataentry/handlers_attachment.go
+++ b/internal/dataentry/handlers_attachment.go
@@ -1,0 +1,449 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/attachment"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// DefaultMaxAttachmentBytes is the product-wide default cap on a single
+// attachment, applied at the HTTP upload ingress. It is generously sized
+// for the expected use (screenshots, PDFs, office docs), not media. A
+// deployment can override it via dataentryconfig; the store backends also
+// enforce their own backstop guard so no path is ever unbounded.
+const DefaultMaxAttachmentBytes = 64 << 20 // 64 MiB
+
+// maxAttachmentUploadHeadroom is added to the content cap for the
+// multipart envelope (boundaries, headers), mirroring the theme upload
+// path's maxLogoUploadBytes margin.
+const maxAttachmentUploadHeadroom = 16 * 1024
+
+// handleV1AttachmentRoute dispatches the property-level route
+// /api/v1/{plural}/{id}/_attachments/{property}: PUT/POST uploads a file
+// (appending up to the property's `max`), GET is not used at this level
+// (the entity's `_attachments` map already lists the files; downloads use
+// the per-file route below). Writes inherit the entity's `update`
+// permission.
+func (a *App) handleV1AttachmentRoute(w http.ResponseWriter, r *http.Request, typeName, plural, entityID, property string) {
+	switch r.Method {
+	case http.MethodPut, http.MethodPost:
+		a.handleV1PutAttachment(w, r, typeName, plural, entityID, property)
+	default:
+		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
+	}
+}
+
+// handleV1AttachmentFileRoute dispatches the per-file route
+// /api/v1/{plural}/{id}/_attachments/{property}/{fileName}: GET downloads
+// that file's bytes, DELETE detaches it. Reads inherit the entity's read
+// permission, deletes inherit `update`.
+func (a *App) handleV1AttachmentFileRoute(w http.ResponseWriter, r *http.Request, typeName, entityID, property, fileName string) {
+	switch r.Method {
+	case http.MethodGet:
+		a.handleV1GetAttachment(w, r, typeName, entityID, property, fileName)
+	case http.MethodDelete:
+		a.handleV1DeleteAttachment(w, r, typeName, entityID, property, fileName)
+	default:
+		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
+	}
+}
+
+// handleV1GetAttachment streams one file attached to a `file`-type
+// property of an entity:
+//
+//	GET /api/v1/{plural}/{id}/_attachments/{property}/{fileName}
+//
+// Access inherits the owning entity's read permission — a caller who
+// cannot read the entity cannot read its attachment. The gate runs
+// BEFORE any store lookup so a hidden id and a nonexistent id are
+// indistinguishable (404, no body difference, no timing side channel —
+// same RR-NGMI invariant as handleV1GetEntity).
+//
+// The bytes are resolved from (entityID, property, fileName) only; the
+// path string stored in the entity's frontmatter is never parsed or
+// trusted, so a renamed entity resolves correctly by its current id and
+// there is no caller-supplied-path traversal surface. The fileName comes
+// from the URL but is only ever a store key (never a filesystem path the
+// handler builds), and the store's ValidateFileName rejects separators.
+func (a *App) handleV1GetAttachment(w http.ResponseWriter, r *http.Request, typeName, entityID, property, fileName string) {
+	ctx := r.Context()
+
+	// ACL gate first — before any store access (see handleV1GetEntity).
+	if !a.gateReadOrNotFound(w, r, typeName, entityID) {
+		return
+	}
+
+	entity, found := a.getEntity(ctx, entityID)
+	if !found || entity.Type != typeName {
+		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
+		return
+	}
+
+	// The property must be a declared `file`-type property on this entity
+	// type, and visible to this viewer. Anything else 404s — we never reveal
+	// whether some other (or hidden) property or path exists.
+	if !a.isFileProperty(typeName, property) || a.isPropertyHidden(ctx, entity, property) {
+		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
+		return
+	}
+
+	rc, err := a.store.ReadAttachment(ctx, entityID, property, fileName)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
+			return
+		}
+		// Don't leak backend error strings (table/column/path names) —
+		// same rationale as writeGateError. Log server-side, 500 client-side.
+		slog.Warn("dataentry: read attachment failed",
+			"err", err, "entity", entityID, "property", property)
+		writeV1Error(w, r, http.StatusInternalServerError, "attachment_read_failed",
+			"Reading the attachment failed", "check server logs")
+		return
+	}
+	defer rc.Close()
+
+	// Serve user-supplied bytes defensively: never let the browser sniff a
+	// different (e.g. text/html) type, sandbox any active content, and
+	// send Content-Disposition with a sanitized filename so an SVG/HTML
+	// payload can't execute as stored XSS in the app's origin. Mirrors the
+	// theme-logo serve path.
+	h := w.Header()
+	h.Set("Content-Type", contentTypeForFilename(fileName))
+	h.Set("X-Content-Type-Options", "nosniff")
+	h.Set("Content-Security-Policy", "sandbox; default-src 'none'")
+	h.Set("Content-Disposition", `inline; filename="`+safeAttachmentFilename(fileName)+`"`)
+
+	if _, err := io.Copy(w, rc); err != nil {
+		// Headers (and likely some bytes) are already written; we can't
+		// change the status now. Log and move on.
+		slog.Warn("dataentry: streaming attachment failed",
+			"err", err, "entity", entityID, "property", property)
+	}
+}
+
+// handleV1PutAttachment uploads (or replaces) the file attached to a
+// `file`-type property:
+//
+//	PUT|POST /api/v1/{plural}/{id}/_attachments/{property}   (multipart, field "file")
+//
+// Writing an attachment mutates the owning entity's property, so it
+// inherits the entity's `update` permission. The write is authorized
+// up front (before any bytes are written) to avoid orphaning a file on a
+// late deny — see attachment.Service.Attach's orphan note.
+func (a *App) handleV1PutAttachment(w http.ResponseWriter, r *http.Request, typeName, plural, entityID, property string) {
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
+	ctx := r.Context()
+	// Capture the state snapshot once: the cap the handler enforces and the
+	// cap the attachment service enforces must come from the same metamodel
+	// (CLAUDE.md "capture state once per operation").
+	s := a.State()
+	limit := maxAttachmentBytes(s)
+
+	entity, ok := a.attachmentWritePreflight(w, r, typeName, entityID, property)
+	if !ok {
+		return
+	}
+
+	// Cap the request body at ingress: MaxBytesReader makes ParseMultipartForm
+	// and the FormFile read fail with *http.MaxBytesError once the limit is
+	// crossed, which we map to 413. The store backends enforce their own cap
+	// as a backstop, but this rejects an oversize upload before buffering it.
+	r.Body = http.MaxBytesReader(w, r.Body, limit+maxAttachmentUploadHeadroom)
+	if err := r.ParseMultipartForm(limit + maxAttachmentUploadHeadroom); err != nil {
+		if isMaxBytesError(err) {
+			a.writeAttachmentTooLarge(w, r, limit)
+			return
+		}
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_multipart",
+			"Invalid multipart body", err.Error())
+		return
+	}
+
+	// Clean up any on-disk temp files the multipart parser spilled past its
+	// in-memory threshold. Go's server removes them when the request body
+	// closes, but for a 64 MiB upload path being explicit is cheap insurance.
+	defer func() {
+		if r.MultipartForm != nil {
+			_ = r.MultipartForm.RemoveAll()
+		}
+	}()
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		writeV1Error(w, r, http.StatusBadRequest, "missing_file",
+			"Missing form field \"file\"", "")
+		return
+	}
+	defer file.Close()
+
+	// The ingress MaxBytesReader bounds the whole multipart request, but its
+	// envelope headroom means it doesn't precisely cap the file *content*.
+	// header.Size is the part's declared length — reject early when it's over.
+	if header.Size > limit {
+		a.writeAttachmentTooLarge(w, r, limit)
+		return
+	}
+
+	// Delegate the cap / suffix / write-order / re-stamp policy to the
+	// shared attachment service so the HTTP and CLI paths apply identical
+	// rules (and the same data-loss-safe attach-then-delete ordering).
+	// Cap the reader at the configured limit (which clamps ≤ the store
+	// backstop) so an under-declared multipart part still can't exceed it.
+	svc, err := a.attachmentService(s)
+	if err != nil {
+		slog.Warn("dataentry: attachment service unavailable", "err", err)
+		writeV1Error(w, r, http.StatusInternalServerError, "attachment_write_failed",
+			"Writing the attachment failed", "check server logs")
+		return
+	}
+	propDef := filePropertyDef(s, typeName, property)
+	capped := store.CapAttachmentReader(file, limit)
+	if _, err := svc.WriteAttachment(ctx, entity, propDef, property, header.Filename, capped); err != nil {
+		a.writeAttachmentWriteError(w, r, limit, err)
+		return
+	}
+
+	result := a.serializeEntityForWire(ctx, entity, plural, true)
+	writeV1JSON(w, http.StatusOK, result)
+}
+
+// writeAttachmentWriteError maps a Service.WriteAttachment failure to the
+// right HTTP status: 413 (size), 409 (at capacity), 403 (ACL deny from the
+// entity update), or 422 (validation / other).
+func (a *App) writeAttachmentWriteError(w http.ResponseWriter, r *http.Request, limit int64, err error) {
+	if isAttachmentTooLarge(err) {
+		a.writeAttachmentTooLarge(w, r, limit)
+		return
+	}
+	if errors.Is(err, attachment.ErrAtCapacity) {
+		writeV1Error(w, r, http.StatusConflict, "attachment_limit",
+			"Property already holds the maximum number of attachments", "")
+		return
+	}
+	if writeForbiddenIfACLDenied(w, err) {
+		return
+	}
+	slog.Warn("dataentry: attachment write failed", "err", err, "path", r.URL.Path)
+	writeV1Error(w, r, http.StatusUnprocessableEntity, "validation_failed",
+		"Validation failed", err.Error())
+}
+
+// attachmentService builds the shared attachment write-policy service from
+// the App's dependencies and the GIVEN state snapshot. Cheap (a struct
+// wrapper). Takes the snapshot explicitly so the service enforces the same
+// metamodel the handler gated on — see "capture state once per operation".
+func (a *App) attachmentService(s *AppState) (*attachment.Service, error) {
+	return attachment.New(attachment.Deps{
+		Store:         a.store,
+		Meta:          s.Meta,
+		EntityManager: a.entityManager,
+	})
+}
+
+// filePropertyDef returns the metamodel def for a property from the given
+// snapshot (callers gate on isFileProperty first, so a file def is expected).
+func filePropertyDef(s *AppState, typeName, property string) metamodel.PropertyDef {
+	if def, ok := s.Meta.GetEntityDef(typeName); ok {
+		return def.Properties[property]
+	}
+	return metamodel.PropertyDef{}
+}
+
+// handleV1DeleteAttachment detaches one file from a `file`-type property:
+//
+//	DELETE /api/v1/{plural}/{id}/_attachments/{property}/{fileName}
+//
+// Inherits the entity's `update` permission (a deny is handled up front in
+// attachmentWritePreflight, before anything is touched). The bytes are
+// removed, then the property is re-stamped from the store's remaining
+// files and persisted. Idempotent: deleting a missing file still
+// re-stamps and returns 204.
+func (a *App) handleV1DeleteAttachment(w http.ResponseWriter, r *http.Request, typeName, entityID, property, fileName string) {
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
+	ctx := r.Context()
+	s := a.State()
+
+	entity, ok := a.attachmentWritePreflight(w, r, typeName, entityID, property)
+	if !ok {
+		return
+	}
+
+	svc, err := a.attachmentService(s)
+	if err != nil {
+		slog.Warn("dataentry: attachment service unavailable", "err", err)
+		writeV1Error(w, r, http.StatusInternalServerError, "attachment_delete_failed",
+			"Deleting the attachment failed", "check server logs")
+		return
+	}
+	propDef := filePropertyDef(s, typeName, property)
+	if err := svc.DeleteAttachment(ctx, entity, propDef, property, fileName); err != nil {
+		if writeForbiddenIfACLDenied(w, err) {
+			return
+		}
+		slog.Warn("dataentry: delete attachment failed", "err", err, "path", r.URL.Path)
+		writeV1Error(w, r, http.StatusUnprocessableEntity, "validation_failed",
+			"Validation failed", err.Error())
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// attachmentWritePreflight runs the shared front matter for an attachment
+// write: read-gate (uniform 404), load the entity, validate the property
+// is a declared `file` type, reject a locked (inaccessible) entity, and
+// authorize the `update` write UP FRONT so a deny never reaches the store.
+// Returns the loaded entity and true when the write may proceed.
+func (a *App) attachmentWritePreflight(w http.ResponseWriter, r *http.Request, typeName, entityID, property string) (*entityPkg.Entity, bool) {
+	ctx := r.Context()
+
+	// Read-gate first: a hidden or nonexistent id yields a uniform 404
+	// (RR-NGMI), the same as the read path.
+	if !a.gateReadOrNotFound(w, r, typeName, entityID) {
+		return nil, false
+	}
+
+	entity, found := a.getEntity(ctx, entityID)
+	if !found || entity.Type != typeName {
+		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
+		return nil, false
+	}
+	if !a.isFileProperty(typeName, property) || a.isPropertyHidden(ctx, entity, property) {
+		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
+		return nil, false
+	}
+	if entity.IsLocked() {
+		writeV1Error(w, r, http.StatusUnprocessableEntity, "encrypted_inaccessible",
+			"Cannot edit an inaccessible entity", "File is git-crypt encrypted; run `git-crypt unlock` first.")
+		return nil, false
+	}
+
+	// Authorize the `update` write up front (mirrors authorizeConflictResolve)
+	// so an ACL deny happens before any bytes are written to the store.
+	decision := a.acl.AuthorizeWrite(ctx, translateVerb("update", entity.Type, entity.ID))
+	if !decision.Allow {
+		a.auditSink.Record(audit.Record{
+			Time:        time.Now().UTC(),
+			Op:          audit.OpDeniedWrite,
+			Subject:     &audit.Subject{Kind: "entity", Type: entity.Type, ID: entity.ID},
+			Principal:   principal.From(ctx),
+			TriggeredBy: audit.TriggeredByFrom(ctx),
+			Summary: fmt.Sprintf("denied: %s (rule_kind=%s rule_id=%s op=attachment-write)",
+				decision.Reason, decision.RuleKind, decision.RuleID),
+		})
+		writeForbiddenIfACLDenied(w, &acl.ForbiddenError{Decision: decision})
+		return nil, false
+	}
+	return entity, true
+}
+
+// maxAttachmentBytes returns the effective per-attachment cap for the
+// given app state: the configured override (or the product default),
+// clamped to the store backstop. Clamping guarantees the 413 detail never
+// promises a ceiling higher than the store will actually accept — a
+// misconfigured `max_attachment_bytes` above store.MaxAttachmentBytes
+// can't make the error message lie.
+func maxAttachmentBytes(s *AppState) int64 {
+	limit := int64(DefaultMaxAttachmentBytes)
+	if n := s.Cfg.App.MaxAttachmentBytes; n > 0 {
+		limit = n
+	}
+	if limit > store.MaxAttachmentBytes {
+		limit = store.MaxAttachmentBytes
+	}
+	return limit
+}
+
+// writeAttachmentTooLarge emits the 413 problem+json body for an
+// over-cap upload.
+func (a *App) writeAttachmentTooLarge(w http.ResponseWriter, r *http.Request, limit int64) {
+	writeV1Error(w, r, http.StatusRequestEntityTooLarge, "attachment_too_large",
+		"Attachment too large", fmt.Sprintf("maximum size is %d bytes", limit))
+}
+
+// isMaxBytesError reports whether err is (or wraps) an *http.MaxBytesError.
+func isMaxBytesError(err error) bool {
+	var maxErr *http.MaxBytesError
+	return errors.As(err, &maxErr)
+}
+
+// isAttachmentTooLarge reports whether a store AttachFile error is the
+// backend's own size-cap rejection (the per-store backstop).
+func isAttachmentTooLarge(err error) bool {
+	return errors.Is(err, store.ErrAttachmentTooLarge)
+}
+
+// isFileProperty reports whether property is a declared `file`-type
+// property on the given entity type.
+func (a *App) isFileProperty(typeName, property string) bool {
+	def, ok := a.State().Meta.GetEntityDef(typeName)
+	if !ok {
+		return false
+	}
+	pd, ok := def.Properties[property]
+	return ok && pd.Type == metamodel.PropertyTypeFile
+}
+
+// isPropertyHidden reports whether property is hidden from the current
+// viewer by field-visibility policy. Attachment read/write endpoints 404
+// on a hidden property so its files (and download URLs) never leak — the
+// same boundary stripHiddenProperties / `_fields` enforce on the entity
+// response.
+func (a *App) isPropertyHidden(ctx context.Context, e *entityPkg.Entity, property string) bool {
+	return !a.fieldResolver.FieldVerdicts(ctx, e).IsVisible(property)
+}
+
+// contentTypeForFilename infers a MIME type from a filename extension,
+// defaulting to application/octet-stream (browsers prompt a download for
+// that, the right default for an unknown type). The store does not
+// persist content type on every backend, so we always derive it here.
+func contentTypeForFilename(name string) string {
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext == "" {
+		return "application/octet-stream"
+	}
+	if mt := mime.TypeByExtension(ext); mt != "" {
+		return mt
+	}
+	return "application/octet-stream"
+}
+
+// safeAttachmentFilename strips characters that could break out of the
+// Content-Disposition filename token (quotes, control chars, path
+// separators) while preserving the extension so the downloaded file
+// keeps a sensible name. The stem and extension are sanitized separately
+// with the theme filename allowlist (which collapses `.`), then rejoined
+// with a single dot.
+func safeAttachmentFilename(name string) string {
+	base := filepath.Base(name)
+	ext := filepath.Ext(base)
+	stem := strings.TrimSuffix(base, ext)
+
+	cleanStem := strings.Trim(unsafeFilenameRe.ReplaceAllString(stem, "_"), "_")
+	if cleanStem == "" {
+		cleanStem = "attachment"
+	}
+	cleanExt := strings.Trim(unsafeFilenameRe.ReplaceAllString(strings.TrimPrefix(ext, "."), "_"), "_")
+	if cleanExt == "" {
+		return cleanStem
+	}
+	return cleanStem + "." + cleanExt
+}

--- a/internal/dataentry/handlers_attachment_test.go
+++ b/internal/dataentry/handlers_attachment_test.go
@@ -1,0 +1,351 @@
+package dataentry
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// getAttachmentAs invokes the per-file attachment download handler
+// directly, attaching the read gate the way the production middleware
+// would. fileName selects which file on the property to download.
+func getAttachmentAs(ctx context.Context, t *testing.T, app *App, d *acl.Declarative,
+	typeName, plural, entityID, property, fileName string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	url := "/api/v1/" + plural + "/" + entityID + "/_attachments/" + property + "/" + fileName
+	req := httptest.NewRequest(http.MethodGet, url, http.NoBody)
+	req = req.WithContext(gateCtxFor(ctx, t, d))
+	rec := httptest.NewRecorder()
+	app.handleV1GetAttachment(rec, req, typeName, entityID, property, fileName)
+	return rec
+}
+
+// seedAttachment writes attachment bytes for (entityID, "screenshot")
+// via the store, mirroring what `rela attach` does at the storage layer.
+// `screenshot` is the only file property the test fixture declares (see
+// newTestAppV1). entityID is kept explicit (not hardcoded) so seed calls
+// read alongside their matching getAttachmentAs(... entityID ...).
+//
+//nolint:unparam // entityID happens to always be the fixture's TKT-001.
+func seedAttachment(t *testing.T, app *App, entityID, fileName string, data []byte) {
+	t.Helper()
+	const property = "screenshot"
+	if err := app.store.AttachFile(context.Background(), entityID, property, fileName, bytes.NewReader(data)); err != nil {
+		t.Fatalf("AttachFile(%s, %s): %v", entityID, property, err)
+	}
+}
+
+func nopACL(t *testing.T, app *App) *acl.Declarative {
+	t.Helper()
+	// A policy that grants alice read on ticket but nothing on feature,
+	// reused across the allow/deny cases.
+	return mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+}
+
+// TestAttachment_AllowedReturnsBytes pins AC1: a reader of the entity
+// gets the attachment bytes with the right headers.
+func TestAttachment_AllowedReturnsBytes(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	seedAttachment(t, app, "TKT-001", "shot.png", []byte("\x89PNGfakebytes"))
+
+	d := nopACL(t, app)
+	app.acl = d
+
+	rec := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "screenshot", "shot.png")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body=%s", rec.Code, rec.Body)
+	}
+	if got := rec.Body.String(); got != "\x89PNGfakebytes" {
+		t.Errorf("body = %q, want the seeded bytes", got)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "image/png") {
+		t.Errorf("Content-Type = %q, want image/png", ct)
+	}
+	if rec.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Errorf("missing X-Content-Type-Options: nosniff")
+	}
+	if csp := rec.Header().Get("Content-Security-Policy"); !strings.Contains(csp, "sandbox") {
+		t.Errorf("Content-Security-Policy = %q, want a sandbox directive", csp)
+	}
+	if cd := rec.Header().Get("Content-Disposition"); !strings.Contains(cd, `filename="shot.png"`) {
+		t.Errorf("Content-Disposition = %q, want filename=\"shot.png\"", cd)
+	}
+}
+
+// TestAttachment_DeniedIsNotFound pins AC2: a caller who cannot read the
+// entity gets 404 (never 403), byte-identical to a nonexistent
+// attachment, and no ETag.
+func TestAttachment_DeniedIsNotFound(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "FEAT-001", Type: "feature", Properties: map[string]any{"title": "F1"}})
+	// feature has no file property in the fixture, but the gate fires
+	// before that ever matters — the point is the deny path.
+	d := nopACL(t, app)
+	app.acl = d
+
+	// alice has no read on feature → denied.
+	rec := getAttachmentAs(aliceCtx(), t, app, d, "feature", "features", "FEAT-001", "logo", "x.png")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("denied: got %d, want 404", rec.Code)
+	}
+	if rec.Header().Get("ETag") != "" {
+		t.Errorf("deny path must not emit an ETag")
+	}
+	if !strings.Contains(rec.Body.String(), "/errors/not_found") {
+		t.Errorf("deny body missing not_found code: %s", rec.Body)
+	}
+
+	// Parity: a readable type with a nonexistent attachment yields the
+	// same 404 shape.
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	recNX := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "screenshot", "shot.png")
+	if recNX.Code != http.StatusNotFound {
+		t.Fatalf("nonexistent attachment: got %d, want 404", recNX.Code)
+	}
+	if stripInstance(t, rec.Body.String()) != stripInstance(t, recNX.Body.String()) {
+		t.Errorf("denied vs nonexistent body differ:\n denied: %s\n nonexistent: %s", rec.Body, recNX.Body)
+	}
+}
+
+// TestAttachment_UnknownOrNonFileProperty pins that a property that
+// isn't a declared file property 404s without leaking which case it was.
+func TestAttachment_UnknownOrNonFileProperty(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	d := nopACL(t, app)
+	app.acl = d
+
+	for _, prop := range []string{"title" /* string, not file */, "nope" /* undeclared */} {
+		rec := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", prop, "x.png")
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("property %q: got %d, want 404", prop, rec.Code)
+		}
+	}
+}
+
+// TestAttachment_MethodNotAllowed pins that an unsupported method (not
+// GET/PUT/POST/DELETE) 405s. The route now dispatches GET→download,
+// PUT/POST→upload, DELETE→detach; anything else is method-not-allowed.
+func TestAttachment_MethodNotAllowed(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	d := nopACL(t, app)
+	app.acl = d
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/TKT-001/_attachments/screenshot", http.NoBody)
+	req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
+	rec := httptest.NewRecorder()
+	app.handleV1AttachmentRoute(rec, req, "ticket", "tickets", "TKT-001", "screenshot")
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("got %d, want 405", rec.Code)
+	}
+}
+
+// TestAttachment_ResolvesByCurrentIDAfterRename pins AC4: after an entity
+// is renamed, the attachment is reachable by the new id and gone from the
+// old id — i.e. access resolves by the canonical current id, not the path
+// string frozen in frontmatter.
+func TestAttachment_ResolvesByCurrentIDAfterRename(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	seedAttachment(t, app, "TKT-001", "shot.png", []byte("bytes"))
+
+	if _, err := app.store.RenameEntity(context.Background(), "TKT-001", "TKT-999"); err != nil {
+		t.Fatalf("RenameEntity: %v", err)
+	}
+
+	d := nopACL(t, app)
+	app.acl = d
+
+	// New id serves the bytes.
+	rec := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-999", "screenshot", "shot.png")
+	if rec.Code != http.StatusOK || rec.Body.String() != "bytes" {
+		t.Fatalf("after rename, GET new id: got %d body=%q, want 200 \"bytes\"", rec.Code, rec.Body)
+	}
+
+	// Old id no longer resolves.
+	recOld := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "screenshot", "shot.png")
+	if recOld.Code != http.StatusNotFound {
+		t.Errorf("after rename, GET old id: got %d, want 404", recOld.Code)
+	}
+}
+
+// TestAttachment_MetadataOnEntityGET pins AC: the per-entity GET payload
+// carries `_attachments` for properties that have a file, with a
+// well-formed download href, and omits properties that don't.
+func TestAttachment_MetadataOnEntityGET(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	seedAttachment(t, app, "TKT-001", "shot.png", []byte("bytes"))
+
+	result := app.serializeEntityForWire(context.Background(), mustGet(t, app, "TKT-001"), "tickets", true)
+	if result.Attachments == nil {
+		t.Fatalf("_attachments map must be present on per-entity GET")
+	}
+	list, ok := (*result.Attachments)["screenshot"]
+	if !ok || len(list) != 1 {
+		t.Fatalf("_attachments[screenshot] must be a 1-element list; got %+v", *result.Attachments)
+	}
+	att := list[0]
+	if att.ID != "shot.png" || att.FileName != "shot.png" || att.Size != int64(len("bytes")) {
+		t.Errorf("attachment meta = %+v, want id/filename=shot.png size=5", att)
+	}
+	if att.Href != "/api/v1/tickets/TKT-001/_attachments/screenshot/shot.png" {
+		t.Errorf("href = %q, want the per-file download path", att.Href)
+	}
+	if !strings.HasPrefix(att.ContentType, "image/png") {
+		t.Errorf("contentType = %q, want image/png", att.ContentType)
+	}
+
+	// A list-row serialization must NOT carry the map (closed-world: it
+	// rides on per-entity responses only).
+	row := app.serializeRelatedEntityForWire(context.Background(), mustGet(t, app, "TKT-001"), "tickets", false)
+	if row.Attachments != nil {
+		t.Errorf("_attachments must be nil on list-row serialization; got %+v", *row.Attachments)
+	}
+}
+
+// mustGet loads an entity or fails the test.
+func mustGet(t *testing.T, app *App, id string) *entity.Entity {
+	t.Helper()
+	e, ok := app.getEntity(context.Background(), id)
+	if !ok {
+		t.Fatalf("getEntity(%s) not found", id)
+	}
+	return e
+}
+
+// TestAttachment_DeceptiveExtensionServesTypeFromName pins the core XSS
+// defense: a file whose BYTES are HTML but whose NAME ends in .png is
+// served as image/png with nosniff — the browser must not sniff it back
+// to text/html and execute it. This is the whole reason the endpoint sets
+// these headers; assert it directly.
+func TestAttachment_DeceptiveExtensionServesTypeFromName(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	seedAttachment(t, app, "TKT-001", "evil.png", []byte("<script>alert(1)</script>"))
+
+	d := nopACL(t, app)
+	app.acl = d
+
+	rec := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "screenshot", "evil.png")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "image/png") {
+		t.Errorf("Content-Type = %q, want image/png (from name, not sniffed from HTML bytes)", ct)
+	}
+	if rec.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Errorf("missing nosniff — browser could sniff the HTML bytes and execute them")
+	}
+}
+
+// TestAttachment_SvgIsSandboxed pins that an SVG (which can carry inline
+// script) is served with the sandbox CSP and inline disposition. The
+// sandbox (no allow-scripts) is what makes `inline` safe for SVG/HTML
+// content in the app origin; if this header is ever dropped the endpoint
+// becomes a stored-XSS vector.
+func TestAttachment_SvgIsSandboxed(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	seedAttachment(t, app, "TKT-001", "pic.svg",
+		[]byte(`<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`))
+
+	d := nopACL(t, app)
+	app.acl = d
+
+	rec := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "screenshot", "pic.svg")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", rec.Code)
+	}
+	csp := rec.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "sandbox") || !strings.Contains(csp, "default-src 'none'") {
+		t.Errorf("CSP = %q, want sandbox + default-src 'none'", csp)
+	}
+	if cd := rec.Header().Get("Content-Disposition"); !strings.HasPrefix(cd, "inline;") {
+		t.Errorf("Content-Disposition = %q, want inline", cd)
+	}
+}
+
+// TestAttachment_DenyBodyMatchesGate pins that the handler's 404 body is
+// byte-identical (modulo instance URL) to the gate's own deny body —
+// guards the shared entityNotFoundTitle invariant against either side
+// drifting (RR-601TJD). We compare a hidden-entity attachment 404 against
+// a hidden-entity GET 404 produced by gateReadOrNotFound.
+func TestAttachment_DenyBodyMatchesGate(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "FEAT-001", Type: "feature", Properties: map[string]any{"title": "F1"}})
+	d := nopACL(t, app)
+	app.acl = d
+
+	attRec := getAttachmentAs(aliceCtx(), t, app, d, "feature", "features", "FEAT-001", "logo", "x.png")
+	gateRec := getEntityAs(aliceCtx(), t, app, d, "feature", "features", "FEAT-001", "")
+	if attRec.Code != http.StatusNotFound || gateRec.Code != http.StatusNotFound {
+		t.Fatalf("both must 404; att=%d gate=%d", attRec.Code, gateRec.Code)
+	}
+	if stripInstance(t, attRec.Body.String()) != stripInstance(t, gateRec.Body.String()) {
+		t.Errorf("attachment deny body must match gate deny body:\n att:  %s\n gate: %s",
+			attRec.Body, gateRec.Body)
+	}
+}
+
+// TestAttachment_MetadataOnMutationResponse pins that `_attachments`
+// rides per-entity mutation responses too (not just GET) — the
+// closed-world map ships on every serializeEntityForWire output, matching
+// `_fields`/`_relations` (RR-FKJYMC). We assert via the serializer the
+// PATCH/POST handlers use.
+func TestAttachment_MetadataOnMutationResponse(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	seedAttachment(t, app, "TKT-001", "shot.png", []byte("bytes"))
+
+	// serializeEntityForWire is the shared per-entity serializer for GET,
+	// PATCH, POST create, and clone. If it carries _attachments, every one
+	// of those responses does.
+	result := app.serializeEntityForWire(context.Background(), mustGet(t, app, "TKT-001"), "tickets", true)
+	if result.Attachments == nil {
+		t.Fatalf("_attachments must be present on every per-entity response, including mutations")
+	}
+	if _, ok := (*result.Attachments)["screenshot"]; !ok {
+		t.Errorf("_attachments missing screenshot; got %+v", *result.Attachments)
+	}
+}
+
+// TestAttachment_HiddenPropertyNotLeaked pins RR-ROF51F: a `file` property
+// hidden from the viewer by field-visibility policy must not appear in
+// `_attachments`, and its per-file download must 404 — otherwise the
+// hidden-field boundary leaks the file's bytes via a guessable URL.
+func TestAttachment_HiddenPropertyNotLeaked(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	seedAttachment(t, app, "TKT-001", "secret.png", []byte("classified"))
+	d := nopACL(t, app)
+	app.acl = d
+	// Hide the `screenshot` file property for everyone.
+	app.fieldResolver = fakeResolver{fv: FieldVerdicts{Visible: map[string]bool{"screenshot": false}}}
+
+	// _attachments omits the hidden property entirely.
+	result := app.serializeEntityForWire(context.Background(), mustGet(t, app, "TKT-001"), "tickets", true)
+	if result.Attachments != nil {
+		if _, present := (*result.Attachments)["screenshot"]; present {
+			t.Errorf("hidden property leaked into _attachments: %+v", *result.Attachments)
+		}
+	}
+
+	// The per-file download 404s (not 200) for the hidden property.
+	rec := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "screenshot", "secret.png")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("download of a hidden property's file: got %d, want 404 (must not leak bytes)", rec.Code)
+	}
+}

--- a/internal/dataentry/handlers_attachment_write_test.go
+++ b/internal/dataentry/handlers_attachment_write_test.go
@@ -1,0 +1,398 @@
+package dataentry
+
+import (
+	"bytes"
+	"context"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// multipartBody builds a multipart/form-data body with a single "file"
+// field and returns the body plus its Content-Type header.
+func multipartBody(t *testing.T, fileName string, data []byte) (body *bytes.Buffer, contentType string) {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", fileName)
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := fw.Write(data); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close multipart: %v", err)
+	}
+	return &buf, mw.FormDataContentType()
+}
+
+// putAttachmentAs invokes the upload handler directly with the gate ctx.
+// Type/plural are the fixture's "ticket"/"tickets" (newTestAppV1).
+//
+//nolint:unparam // entityID is conceptually variable; tests use one fixture.
+func putAttachmentAs(ctx context.Context, t *testing.T, app *App, d *acl.Declarative,
+	entityID, property, fileName string, data []byte,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	body, contentType := multipartBody(t, fileName, data)
+	url := "/api/v1/tickets/" + entityID + "/_attachments/" + property
+	req := httptest.NewRequest(http.MethodPut, url, body)
+	req.Header.Set("Content-Type", contentType)
+	req = req.WithContext(gateCtxFor(ctx, t, d))
+	rec := httptest.NewRecorder()
+	app.handleV1AttachmentRoute(rec, req, "ticket", "tickets", entityID, property)
+	return rec
+}
+
+func deleteAttachmentAs(ctx context.Context, t *testing.T, app *App, d *acl.Declarative,
+	entityID, property, fileName string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	url := "/api/v1/tickets/" + entityID + "/_attachments/" + property + "/" + fileName
+	req := httptest.NewRequest(http.MethodDelete, url, http.NoBody)
+	req = req.WithContext(gateCtxFor(ctx, t, d))
+	rec := httptest.NewRecorder()
+	app.handleV1AttachmentFileRoute(rec, req, "ticket", entityID, property, fileName)
+	return rec
+}
+
+// writeACL grants alice read+update on ticket and denies bob everything.
+// An attachment write authorizes as OpUpdate (it mutates the owning
+// entity's property), so the role needs Read + Update.
+func writeACL(t *testing.T, app *App) *acl.Declarative {
+	t.Helper()
+	return mustNewACL(t, &acl.Policy{
+		Roles: map[string]acl.RoleDef{
+			"editor": {Read: []string{"ticket"}, Update: []string{"ticket"}},
+			"none":   {},
+		},
+		Assignments: map[string]string{"alice": "editor", "bob": "none"},
+	}, app.store)
+}
+
+func bobCtx() context.Context {
+	return principal.With(context.Background(), principal.Principal{User: "bob", Tool: principal.ToolDataEntry})
+}
+
+// TestAttachmentUpload_RoundTrips pins AC1: an authorized upload persists
+// the bytes (readable back via GET) and stamps the property; the response
+// carries the new _attachments entry.
+func TestAttachmentUpload_RoundTrips(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	d := writeACL(t, app)
+	app.acl = d
+
+	rec := putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "screenshot", "shot.png", []byte("PNGDATA"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("upload: got %d, want 200; body=%s", rec.Code, rec.Body)
+	}
+
+	// Bytes readable via GET.
+	get := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "screenshot", "shot.png")
+	if get.Code != http.StatusOK || get.Body.String() != "PNGDATA" {
+		t.Fatalf("GET after upload: got %d body=%q, want 200 \"PNGDATA\"", get.Code, get.Body)
+	}
+
+	// Property stamped on the entity.
+	e := mustGet(t, app, "TKT-001")
+	if got := e.GetString("screenshot"); got != "attachments/TKT-001/screenshot/shot.png" {
+		t.Errorf("property = %q, want the stamped attachment path", got)
+	}
+}
+
+// TestAttachmentUpload_Replaces pins that a second upload overwrites the
+// first.
+func TestAttachmentUpload_Replaces(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	d := writeACL(t, app)
+	app.acl = d
+
+	putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "screenshot", "a.png", []byte("first"))
+	putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "screenshot", "b.png", []byte("second"))
+
+	get := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "screenshot", "b.png")
+	if get.Body.String() != "second" {
+		t.Errorf("after replace, body = %q, want \"second\"", get.Body)
+	}
+}
+
+// TestAttachmentDelete_RemovesBytesAndProperty pins AC1 delete: detach
+// clears the property and the bytes are gone.
+func TestAttachmentDelete_RemovesBytesAndProperty(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	d := writeACL(t, app)
+	app.acl = d
+	putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "screenshot", "a.png", []byte("data"))
+
+	del := deleteAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "screenshot", "a.png")
+	if del.Code != http.StatusNoContent {
+		t.Fatalf("delete: got %d, want 204; body=%s", del.Code, del.Body)
+	}
+
+	get := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "screenshot", "a.png")
+	if get.Code != http.StatusNotFound {
+		t.Errorf("GET after delete: got %d, want 404", get.Code)
+	}
+	if e := mustGet(t, app, "TKT-001"); e.GetString("screenshot") != "" {
+		t.Errorf("property not cleared after delete: %q", e.GetString("screenshot"))
+	}
+}
+
+// TestAttachmentWrite_DeniedBeforeBytes pins AC3: a principal without
+// write access is denied (403), and crucially NO bytes are written — the
+// authorize runs before AttachFile.
+func TestAttachmentWrite_DeniedBeforeBytes(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	d := writeACL(t, app)
+	app.acl = d
+
+	// bob can't read ticket → upload 404s at the read gate (no existence
+	// leak, no bytes).
+	rec := putAttachmentAs(bobCtx(), t, app, d, "TKT-001", "screenshot", "x.png", []byte("data"))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("bob (no read) upload: got %d, want 404", rec.Code)
+	}
+
+	// alice can read but suppose a write-only deny: use a role that reads
+	// ticket but writes nothing.
+	d2 := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"reader": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"carol": "reader"},
+	}, app.store)
+	app.acl = d2
+	carol := principal.With(context.Background(), principal.Principal{User: "carol", Tool: principal.ToolDataEntry})
+	rec = putAttachmentAs(carol, t, app, d2, "TKT-001", "screenshot", "x.png", []byte("data"))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("carol (read, no write) upload: got %d, want 403; body=%s", rec.Code, rec.Body)
+	}
+
+	// No bytes were written by either denied attempt.
+	app.acl = d
+	get := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "screenshot", "x.png")
+	if get.Code != http.StatusNotFound {
+		t.Errorf("a denied upload must not write bytes; GET got %d, want 404", get.Code)
+	}
+}
+
+// TestAttachmentUpload_TooLarge pins AC2: an over-cap upload is rejected
+// with 413, on the ingress path, before any bytes persist.
+func TestAttachmentUpload_TooLarge(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	// Tighten the cap via config so the test stays small.
+	app.State().Cfg.App.MaxAttachmentBytes = 8
+	d := writeACL(t, app)
+	app.acl = d
+
+	rec := putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "screenshot", "big.bin", []byte("waytoolarge"))
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversize upload: got %d, want 413; body=%s", rec.Code, rec.Body)
+	}
+
+	get := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "screenshot", "big.bin")
+	if get.Code != http.StatusNotFound {
+		t.Errorf("oversize upload must not persist; GET got %d, want 404", get.Code)
+	}
+}
+
+// TestAttachmentUpload_MissingFieldOrBadProperty covers the 400 (no file
+// field) and 404 (non-file property) negative cases.
+func TestAttachmentUpload_MissingFieldOrBadProperty(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	d := writeACL(t, app)
+	app.acl = d
+
+	// Wrong form field name → 400.
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, _ := mw.CreateFormFile("notfile", "x.png")
+	_, _ = fw.Write([]byte("data"))
+	_ = mw.Close()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tickets/TKT-001/_attachments/screenshot", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
+	rec := httptest.NewRecorder()
+	app.handleV1AttachmentRoute(rec, req, "ticket", "tickets", "TKT-001", "screenshot")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("missing file field: got %d, want 400; body=%s", rec.Code, rec.Body)
+	}
+
+	// Non-file property → 404 (no oracle).
+	rec = putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "title", "x.png", []byte("data"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("upload to non-file property: got %d, want 404", rec.Code)
+	}
+}
+
+// TestMaxAttachmentBytes_ClampsToStoreCap pins RR-81XSCY: a configured
+// limit above the store backstop is clamped, so the 413 ceiling can never
+// promise more than the store will accept.
+func TestMaxAttachmentBytes_ClampsToStoreCap(t *testing.T) {
+	app := newTestAppV1(t)
+
+	// Unset → product default.
+	if got := maxAttachmentBytes(app.State()); got != DefaultMaxAttachmentBytes {
+		t.Errorf("default: got %d, want %d", got, DefaultMaxAttachmentBytes)
+	}
+	// Lower override honored.
+	app.State().Cfg.App.MaxAttachmentBytes = 1024
+	if got := maxAttachmentBytes(app.State()); got != 1024 {
+		t.Errorf("override: got %d, want 1024", got)
+	}
+	// Above the store cap → clamped to the store cap.
+	app.State().Cfg.App.MaxAttachmentBytes = store.MaxAttachmentBytes * 2
+	if got := maxAttachmentBytes(app.State()); got != store.MaxAttachmentBytes {
+		t.Errorf("over-cap: got %d, want clamp to %d", got, store.MaxAttachmentBytes)
+	}
+}
+
+// TestAttachmentDelete_IdempotentWhenNoAttachment pins that deleting a
+// property with no attachment still succeeds (204) and clears the
+// property (RR-JIRLLU / S5).
+func TestAttachmentDelete_IdempotentWhenNoAttachment(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	d := writeACL(t, app)
+	app.acl = d
+
+	del := deleteAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "screenshot", "gone.png")
+	if del.Code != http.StatusNoContent {
+		t.Fatalf("delete with no attachment: got %d, want 204; body=%s", del.Code, del.Body)
+	}
+	if e := mustGet(t, app, "TKT-001"); e.GetString("screenshot") != "" {
+		t.Errorf("property should remain empty: %q", e.GetString("screenshot"))
+	}
+}
+
+// TestAttachmentUpload_ReplaceOversizeKeepsExisting pins (at the HTTP
+// layer) the RR-EISJTE fix: a failed oversize replace must not destroy
+// the existing valid attachment.
+func TestAttachmentUpload_ReplaceOversizeKeepsExisting(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	d := writeACL(t, app)
+	app.acl = d
+
+	// Upload a valid file, then attempt an oversize replace (cap tightened).
+	putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "screenshot", "ok.png", []byte("good"))
+	app.State().Cfg.App.MaxAttachmentBytes = 4
+	rec := putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "screenshot", "huge.bin", []byte("waytoobig"))
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversize replace: got %d, want 413", rec.Code)
+	}
+
+	// The original must still be downloadable.
+	get := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "screenshot", "ok.png")
+	if get.Code != http.StatusOK || get.Body.String() != "good" {
+		t.Errorf("failed replace destroyed the original: GET got %d body=%q, want 200 \"good\"", get.Code, get.Body)
+	}
+}
+
+// attachmentsFor returns the _attachments list for a property on a freshly
+// serialized entity.
+//
+//nolint:unparam // entityID is conceptually variable; tests use one fixture.
+func attachmentsFor(t *testing.T, app *App, entityID, property string) []V1Attachment {
+	t.Helper()
+	result := app.serializeEntityForWire(context.Background(), mustGet(t, app, entityID), "tickets", true)
+	if result.Attachments == nil {
+		return nil
+	}
+	return (*result.Attachments)[property]
+}
+
+// TestAttachmentUpload_MultiAppendsUpToMax pins the max>1 behavior on the
+// `docs` property (max:3): files with different names accumulate, and the
+// 4th is rejected with 409. The _attachments wire value is always a list.
+func TestAttachmentUpload_MultiAppendsUpToMax(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	d := writeACL(t, app)
+	app.acl = d
+
+	for _, name := range []string{"a.pdf", "b.pdf", "c.pdf"} {
+		rec := putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "docs", name, []byte(name))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("upload %s: got %d, want 200; body=%s", name, rec.Code, rec.Body)
+		}
+	}
+	if got := attachmentsFor(t, app, "TKT-001", "docs"); len(got) != 3 {
+		t.Fatalf("docs should hold 3 files; got %d", len(got))
+	}
+
+	// 4th over the cap → 409.
+	rec := putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "docs", "d.pdf", []byte("d"))
+	if rec.Code != http.StatusConflict {
+		t.Errorf("upload past max: got %d, want 409; body=%s", rec.Code, rec.Body)
+	}
+	if got := attachmentsFor(t, app, "TKT-001", "docs"); len(got) != 3 {
+		t.Errorf("rejected upload must not add a file; got %d", len(got))
+	}
+
+	// The property is stamped as a LIST of paths.
+	e := mustGet(t, app, "TKT-001")
+	paths, _ := e.Properties["docs"].([]string)
+	if len(paths) != 3 {
+		t.Errorf("docs property should be a 3-element list; got %#v", e.Properties["docs"])
+	}
+}
+
+// TestAttachmentUpload_MultiAutoSuffix pins that uploading a duplicate name
+// to a multi-file property auto-suffixes rather than overwriting.
+func TestAttachmentUpload_MultiAutoSuffix(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	d := writeACL(t, app)
+	app.acl = d
+
+	putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "docs", "report.pdf", []byte("one"))
+	putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "docs", "report.pdf", []byte("two"))
+
+	got := attachmentsFor(t, app, "TKT-001", "docs")
+	if len(got) != 2 {
+		t.Fatalf("duplicate name should auto-suffix into 2 files; got %d: %+v", len(got), got)
+	}
+	names := map[string]bool{got[0].FileName: true, got[1].FileName: true}
+	if !names["report.pdf"] || !names["report (1).pdf"] {
+		t.Errorf("expected report.pdf + report (1).pdf; got %v", names)
+	}
+}
+
+// TestAttachmentDelete_MultiLeavesSiblings pins that deleting one file from
+// a multi-file property leaves the others, and re-stamps the list.
+func TestAttachmentDelete_MultiLeavesSiblings(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	d := writeACL(t, app)
+	app.acl = d
+
+	putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "docs", "a.pdf", []byte("a"))
+	putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "docs", "b.pdf", []byte("b"))
+
+	del := deleteAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "docs", "a.pdf")
+	if del.Code != http.StatusNoContent {
+		t.Fatalf("delete one of many: got %d, want 204", del.Code)
+	}
+
+	got := attachmentsFor(t, app, "TKT-001", "docs")
+	if len(got) != 1 || got[0].FileName != "b.pdf" {
+		t.Errorf("after deleting a.pdf, expected only b.pdf; got %+v", got)
+	}
+	// b.pdf still downloads.
+	g := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "docs", "b.pdf")
+	if g.Code != http.StatusOK || g.Body.String() != "b" {
+		t.Errorf("sibling b.pdf must survive; GET got %d body=%q", g.Code, g.Body)
+	}
+}

--- a/internal/dataentry/router_walk_test.go
+++ b/internal/dataentry/router_walk_test.go
@@ -79,6 +79,11 @@ func TestRouterWalk_AllAPIRoutesReachHandlers(t *testing.T) {
 		{http.MethodGet, "/api/v1/tickets/", http.StatusOK},
 		{http.MethodGet, "/api/v1/tickets/TKT-001", http.StatusOK},
 		{http.MethodGet, "/api/v1/tickets/TKT-001/relations", 0},
+		// Attachment download route. Probe with POST so the handler answers
+		// 405 (a JSON error) rather than a 404 — a GET against the fixture
+		// (no attachment seeded) would emit a handler http.NotFound that the
+		// oracle cannot distinguish from an unregistered route.
+		{http.MethodPost, "/api/v1/tickets/TKT-001/_attachments/screenshot", 0},
 	}
 
 	for _, tc := range routes {

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -109,6 +109,12 @@ type Action struct {
 type AppConfig struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description"`
+	// MaxAttachmentBytes optionally overrides the product-wide default
+	// per-attachment upload cap (see dataentry.DefaultMaxAttachmentBytes).
+	// Zero or unset means use the default. Set this lower for
+	// semi-untrusted deployments. The store backends also enforce their
+	// own backstop guard independent of this value.
+	MaxAttachmentBytes int64 `yaml:"max_attachment_bytes,omitempty" json:"max_attachment_bytes,omitempty"`
 }
 
 // Form defines a create/edit form for an entity type.

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -660,6 +660,17 @@ func validatePropertyDefs(
 			errs = append(errs, fmt.Sprintf(
 				"%s: property %q is type \"enum\" but has no 'values' list", schemaName, propName))
 		}
+
+		// `max` only applies to file properties and must be >= 1 when set.
+		if propDef.Max < 0 {
+			errs = append(errs, fmt.Sprintf(
+				"%s: property %q has max %d; must be >= 1", schemaName, propName, propDef.Max))
+		}
+		if propDef.Max != 0 && propDef.Type != PropertyTypeFile {
+			errs = append(errs, fmt.Sprintf(
+				"%s: property %q sets 'max' but is type %q; 'max' only applies to type \"file\"",
+				schemaName, propName, propDef.Type))
+		}
 	}
 
 	return errs

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -182,6 +182,22 @@ type PropertyDef struct {
 	Description string   `yaml:"description,omitempty"` // Documentation for the property
 	Format      string   `yaml:"format,omitempty"`      // Date format (Go layout, e.g., "2006-01-02")
 	List        bool     `yaml:"list,omitempty"`        // True for multi-select properties (allows multiple values)
+	// Max caps how many attachments a `file`-type property may hold.
+	// Zero/unset means 1 (the default, single-attachment). When > 1 the
+	// property holds a list of attachment paths and the data-entry UI
+	// switches from replace-mode to multi-file add-mode. Only meaningful
+	// for `type: file`.
+	Max int `yaml:"max,omitempty"`
+}
+
+// FileMax returns the effective attachment cap for a file property:
+// Max when set (>0), otherwise 1. Callers should use this rather than
+// reading Max directly so the unset-means-one default lives in one place.
+func (p PropertyDef) FileMax() int {
+	if p.Max > 0 {
+		return p.Max
+	}
+	return 1
 }
 
 // Built-in property types

--- a/internal/metamodel/validation.go
+++ b/internal/metamodel/validation.go
@@ -339,18 +339,12 @@ func (m *Metamodel) validatePropertyValue(propName string, propDef *PropertyDef,
 		}
 
 	case PropertyTypeFile:
-		// File-type properties hold a string path (repo-relative)
-		// pointing at a blob in the attachment store. Structural
-		// validation is just "it's a string"; content-level checks
-		// (file exists, hash matches) are the attachment store's
-		// concern.
-		if _, ok := val.(string); !ok {
-			return &ValidationError{
-				Type:     ValidationErrorInvalidType,
-				Property: propName,
-				Message:  "Must be a string (attachment path)",
-			}
-		}
+		// File-type properties hold attachment path string(s) pointing at
+		// blobs in the attachment store. With the default cap (1) the value
+		// is a single string; with max > 1 it is a list of strings.
+		// Structural validation is just "string(s)"; content-level checks
+		// (file exists, hash matches) are the attachment store's concern.
+		return validateFileValue(propName, propDef, val)
 
 	default:
 		// Custom type (enum defined in types section)
@@ -370,6 +364,53 @@ func (m *Metamodel) validatePropertyValue(propName string, propDef *PropertyDef,
 // validateCustomTypeValue validates a value against a custom type's allowed values and regex validations.
 // Supports both single string values and []string (multi-select).
 // Returns an error combining all validation failures.
+// validateFileValue checks a `file`-type property value. The value may be
+// a single string path or a list of string paths regardless of the cap
+// (a 1-element list is tolerated even at FileMax()==1, consistent with
+// rela's permissive-storage philosophy); the list length must not exceed
+// the cap. Content-level checks (the blob exists, hash matches) are the
+// attachment store's concern, not this.
+func validateFileValue(propName string, propDef *PropertyDef, val interface{}) *ValidationError {
+	maxCount := propDef.FileMax()
+
+	// Coerce to a list of paths regardless of scalar/list shape so the
+	// count check and item-type check share one path.
+	var paths []string
+	switch v := val.(type) {
+	case string:
+		paths = []string{v}
+	case []string:
+		paths = v
+	case []interface{}:
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return &ValidationError{
+					Type:     ValidationErrorInvalidType,
+					Property: propName,
+					Message:  fmt.Sprintf("item[%d]: must be a string (attachment path)", i),
+				}
+			}
+			paths = append(paths, s)
+		}
+	default:
+		return &ValidationError{
+			Type:     ValidationErrorInvalidType,
+			Property: propName,
+			Message:  "Must be a string or list of strings (attachment path)",
+		}
+	}
+
+	if len(paths) > maxCount {
+		return &ValidationError{
+			Type:     ValidationErrorInvalidValue,
+			Property: propName,
+			Message:  fmt.Sprintf("at most %d attachment(s) allowed, got %d", maxCount, len(paths)),
+		}
+	}
+	return nil
+}
+
 func validateCustomTypeValue(propName string, customType CustomType, val interface{}) *ValidationError {
 	hasEnumValues := len(customType.Values) > 0
 	hasValidations := len(customType.Validations) > 0

--- a/internal/metamodel/validation_test.go
+++ b/internal/metamodel/validation_test.go
@@ -490,6 +490,46 @@ func TestValidatePropertyValue_File(t *testing.T) {
 	}
 }
 
+func TestValidatePropertyValue_FileMax(t *testing.T) {
+	meta := &Metamodel{}
+
+	t.Run("default cap is 1; list rejected when over", func(t *testing.T) {
+		single := &PropertyDef{Type: PropertyTypeFile}
+		if single.FileMax() != 1 {
+			t.Fatalf("FileMax default = %d, want 1", single.FileMax())
+		}
+		// A single string is fine.
+		if err := meta.ValidatePropertyValue("doc", single, "attachments/X/doc/a.pdf"); err != nil {
+			t.Errorf("single path rejected: %v", err)
+		}
+		// Two files in a max:1 property is too many.
+		if err := meta.ValidatePropertyValue("doc", single, []string{"a.pdf", "b.pdf"}); err == nil {
+			t.Error("2 files in a max:1 property should be rejected")
+		}
+	})
+
+	t.Run("max:3 accepts up to 3, rejects 4", func(t *testing.T) {
+		multi := &PropertyDef{Type: PropertyTypeFile, Max: 3}
+		if multi.FileMax() != 3 {
+			t.Fatalf("FileMax = %d, want 3", multi.FileMax())
+		}
+		if err := meta.ValidatePropertyValue("docs", multi, []string{"a", "b", "c"}); err != nil {
+			t.Errorf("3 files in a max:3 property rejected: %v", err)
+		}
+		if err := meta.ValidatePropertyValue("docs", multi, []string{"a", "b", "c", "d"}); err == nil {
+			t.Error("4 files in a max:3 property should be rejected")
+		}
+		// []interface{} of strings (form/JSON shape) also accepted.
+		if err := meta.ValidatePropertyValue("docs", multi, []interface{}{"a", "b"}); err != nil {
+			t.Errorf("[]interface{} of strings rejected: %v", err)
+		}
+		// Non-string item rejected.
+		if err := meta.ValidatePropertyValue("docs", multi, []interface{}{"a", 7}); err == nil {
+			t.Error("non-string list item should be rejected")
+		}
+	})
+}
+
 func TestValidatePropertyValue_Enum(t *testing.T) {
 	meta := &Metamodel{}
 	propDef := &PropertyDef{

--- a/internal/store/attachment_reader_test.go
+++ b/internal/store/attachment_reader_test.go
@@ -1,0 +1,117 @@
+package store_test
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// constReader yields an endless stream of one byte, for feeding an
+// oversize payload without allocating it.
+type constReader byte
+
+func (c constReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = byte(c)
+	}
+	return len(p), nil
+}
+
+func TestCapAttachmentReader(t *testing.T) {
+	t.Run("under the limit reads fully", func(t *testing.T) {
+		r := store.CapAttachmentReader(strings.NewReader("hello"), 10)
+		data, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		if string(data) != "hello" {
+			t.Errorf("data = %q, want %q", data, "hello")
+		}
+	})
+
+	t.Run("exactly at the limit succeeds", func(t *testing.T) {
+		r := store.CapAttachmentReader(strings.NewReader("12345"), 5)
+		data, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("ReadAll at limit: %v", err)
+		}
+		if len(data) != 5 {
+			t.Errorf("len = %d, want 5", len(data))
+		}
+	})
+
+	t.Run("one byte over the limit errors", func(t *testing.T) {
+		r := store.CapAttachmentReader(strings.NewReader("123456"), 5)
+		_, err := io.ReadAll(r)
+		if !errors.Is(err, store.ErrAttachmentTooLarge) {
+			t.Errorf("err = %v, want ErrAttachmentTooLarge", err)
+		}
+	})
+
+	t.Run("unbounded source trips the cap", func(t *testing.T) {
+		r := store.CapAttachmentReader(constReader('a'), 1024)
+		_, err := io.ReadAll(r)
+		if !errors.Is(err, store.ErrAttachmentTooLarge) {
+			t.Errorf("err = %v, want ErrAttachmentTooLarge", err)
+		}
+	})
+
+	t.Run("zero limit rejects any content", func(t *testing.T) {
+		r := store.CapAttachmentReader(strings.NewReader("x"), 0)
+		_, err := io.ReadAll(r)
+		if !errors.Is(err, store.ErrAttachmentTooLarge) {
+			t.Errorf("err = %v, want ErrAttachmentTooLarge", err)
+		}
+	})
+}
+
+func TestValidateFileName(t *testing.T) {
+	ok := []string{"a.txt", "report (1).pdf", "图片.png", "no-ext"}
+	for _, n := range ok {
+		if err := store.ValidateFileName(n); err != nil {
+			t.Errorf("ValidateFileName(%q) = %v, want nil", n, err)
+		}
+	}
+	bad := []string{"", "a/b.txt", "a\\b.txt", "a\x00b", ".", ".."}
+	for _, n := range bad {
+		if err := store.ValidateFileName(n); err == nil {
+			t.Errorf("ValidateFileName(%q) = nil, want error", n)
+		}
+	}
+}
+
+func TestNormalizeFileName(t *testing.T) {
+	cases := map[string]string{
+		"report.pdf":     "report.pdf",
+		"dir/report.pdf": "report.pdf", // strips path
+		"a\\b.png":       "b.png",      // strips windows path
+		"a\x01b.txt":     "a_b.txt",    // control char replaced
+		"  spaced.txt  ": "spaced.txt", // trims spaces
+		"":               "file",       // empty → fallback
+		"..":             "file",       // traversal → fallback
+		".":              "file",       // fallback
+	}
+	for in, want := range cases {
+		if got := store.NormalizeFileName(in); got != want {
+			t.Errorf("NormalizeFileName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSuffixOnCollision(t *testing.T) {
+	taken := map[string]bool{"report.pdf": true, "report (1).pdf": true, "noext": true}
+	exists := func(n string) bool { return taken[n] }
+
+	if got := store.SuffixOnCollision("fresh.pdf", exists); got != "fresh.pdf" {
+		t.Errorf("no collision: got %q, want fresh.pdf", got)
+	}
+	if got := store.SuffixOnCollision("report.pdf", exists); got != "report (2).pdf" {
+		t.Errorf("collision: got %q, want report (2).pdf", got)
+	}
+	if got := store.SuffixOnCollision("noext", exists); got != "noext (1)" {
+		t.Errorf("no-extension collision: got %q, want \"noext (1)\"", got)
+	}
+}

--- a/internal/store/fsstore/attachment.go
+++ b/internal/store/fsstore/attachment.go
@@ -21,8 +21,22 @@ import (
 // If an attachment already exists at this (entityID, property) under a
 // different filename, the old file is removed first (1:1 ownership per
 // property).
+// attachTempPrefix marks an in-progress attachment temp file. A real
+// stored attachment name can never start with a dot (store.NormalizeFileName
+// trims leading dots), so this prefix is collision-proof; the index loader
+// skips files carrying it.
+const attachTempPrefix = ".rela-attach-tmp-"
+
+// attachmentKey is the per-file index key: (entityID, property, fileName).
+func attachmentKey(entityID, property, fileName string) string {
+	return entityID + "/" + property + "/" + fileName
+}
+
 func (s *FSStore) AttachFile(_ context.Context, entityID, property, fileName string, r io.Reader) error {
 	if err := storeutil.ValidateProperty(property); err != nil {
+		return err
+	}
+	if err := store.ValidateFileName(fileName); err != nil {
 		return err
 	}
 
@@ -38,14 +52,33 @@ func (s *FSStore) AttachFile(_ context.Context, entityID, property, fileName str
 		return err
 	}
 
-	key := entityID + "/" + property
-	if old, exists := s.attachments[key]; exists && old.fileName != fileName {
-		_ = s.rooted.Remove(path.Join(dirKey, old.fileName))
-	}
-
+	key := attachmentKey(entityID, property, fileName)
 	fileKey := path.Join(dirKey, fileName)
-	n, err := s.writeAttachment(fileKey, r)
+
+	// Append: each (entityID, property, fileName) is its own slot. A
+	// same-name re-attach replaces only that one file; sibling files on the
+	// property are untouched. Cap/suffix policy lives in the write path.
+	//
+	// Write to a temp file first, then swap, so a failed write (e.g. the
+	// backstop size guard tripping) never destroys an existing same-named
+	// file — the old bytes and index entry stay intact until the new bytes
+	// are fully written.
+	//
+	// The temp name carries a leading-dot prefix (attachTempPrefix). A stored
+	// attachment name can never start with a dot — store.NormalizeFileName
+	// trims leading dots — so this marker can never collide with a real
+	// upload, and the index loader skips it by that prefix. (A plain ".new"
+	// suffix would clash with a legitimate upload literally named "x.new".)
+	tmpKey := path.Join(dirKey, attachTempPrefix+fileName)
+	// Backstop size guard: cap reads at MaxAttachmentBytes so no caller can
+	// write an unbounded attachment (the API layer also caps at ingress).
+	n, err := s.writeAttachment(tmpKey, storeutil.LimitAttachmentReader(r))
 	if err != nil {
+		_ = s.rooted.Remove(tmpKey) // remove the failed partial; old file intact
+		return err
+	}
+	if err := s.rooted.Rename(tmpKey, fileKey); err != nil {
+		_ = s.rooted.Remove(tmpKey)
 		return err
 	}
 
@@ -87,10 +120,9 @@ func (s *FSStore) writeAttachment(key string, r io.Reader) (int64, error) {
 
 // ReadAttachment returns a streaming reader over the attachment's
 // bytes. Callers MUST Close the returned reader.
-func (s *FSStore) ReadAttachment(_ context.Context, entityID, property string) (io.ReadCloser, error) {
+func (s *FSStore) ReadAttachment(_ context.Context, entityID, property, fileName string) (io.ReadCloser, error) {
 	s.mu.RLock()
-	key := entityID + "/" + property
-	a, ok := s.attachments[key]
+	a, ok := s.attachments[attachmentKey(entityID, property, fileName)]
 	s.mu.RUnlock()
 
 	if !ok {
@@ -101,11 +133,11 @@ func (s *FSStore) ReadAttachment(_ context.Context, entityID, property string) (
 	return s.rooted.Open(fileKey)
 }
 
-func (s *FSStore) DeleteAttachment(_ context.Context, entityID, property string) error {
+func (s *FSStore) DeleteAttachment(_ context.Context, entityID, property, fileName string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	key := entityID + "/" + property
+	key := attachmentKey(entityID, property, fileName)
 	a, ok := s.attachments[key]
 	if !ok {
 		return store.ErrNotFound
@@ -226,7 +258,7 @@ func (s *FSStore) renameAttachmentDir(oldID, newID string) error {
 		}
 		delete(s.attachments, key)
 		a.entityID = newID
-		reKey[newID+"/"+a.property] = a
+		reKey[attachmentKey(newID, a.property, a.fileName)] = a
 	}
 	for k, v := range reKey {
 		s.attachments[k] = v

--- a/internal/store/fsstore/fsstore.go
+++ b/internal/store/fsstore/fsstore.go
@@ -261,28 +261,39 @@ func (s *FSStore) loadAttachmentsIndex() {
 			if !propEntry.IsDir() {
 				continue
 			}
-			prop := propEntry.Name()
-			fileEntries, err := s.rooted.ReadDir(path.Join(s.attachKey, entityID, prop))
-			if err != nil {
-				continue
-			}
-			for _, fileEntry := range fileEntries {
-				if fileEntry.IsDir() {
-					continue
-				}
-				info, err := fileEntry.Info()
-				if err != nil {
-					continue
-				}
-				key := entityID + "/" + prop
-				s.attachments[key] = attachMeta{
-					entityID: entityID,
-					property: prop,
-					fileName: fileEntry.Name(),
-					size:     info.Size(),
-				}
-				break // one file per property
-			}
+			s.loadPropertyAttachments(entityID, propEntry.Name())
+		}
+	}
+}
+
+// loadPropertyAttachments indexes every attachment file under one
+// entity/property directory. A property may hold multiple files; each is
+// keyed by (entityID, property, fileName). Leftover temp files from an
+// interrupted write (attachTempPrefix) are skipped — that marker can't
+// collide with a real attachment name (which never starts with a dot).
+// Must be called with s.mu held.
+func (s *FSStore) loadPropertyAttachments(entityID, prop string) {
+	fileEntries, err := s.rooted.ReadDir(path.Join(s.attachKey, entityID, prop))
+	if err != nil {
+		return
+	}
+	for _, fileEntry := range fileEntries {
+		if fileEntry.IsDir() {
+			continue
+		}
+		name := fileEntry.Name()
+		if strings.HasPrefix(name, attachTempPrefix) {
+			continue
+		}
+		info, err := fileEntry.Info()
+		if err != nil {
+			continue
+		}
+		s.attachments[attachmentKey(entityID, prop, name)] = attachMeta{
+			entityID: entityID,
+			property: prop,
+			fileName: name,
+			size:     info.Size(),
 		}
 	}
 }

--- a/internal/store/fsstore/persistence_test.go
+++ b/internal/store/fsstore/persistence_test.go
@@ -117,16 +117,26 @@ func TestPersistence_AttachmentsSurviveReopen(t *testing.T) {
 	s1 := openStore(t, fs)
 	require.NoError(t, s1.CreateEntity(ctx, entity.New("DOC-1", "document")))
 	require.NoError(t, s1.AttachFile(ctx, "DOC-1", "diagram", "arch.png", bytes.NewReader([]byte("PNG-DATA"))))
+	// A file literally named "*.new" must survive the reopen — the index
+	// loader must not mistake it for an interrupted-write temp file
+	// (RR-BN2MDO).
+	require.NoError(t, s1.AttachFile(ctx, "DOC-1", "diagram", "notes.new", bytes.NewReader([]byte("NEW-DATA"))))
 	require.NoError(t, s1.Close())
 
 	s2 := openStore(t, fs)
 	defer s2.Close()
 
-	rc, err := s2.ReadAttachment(ctx, "DOC-1", "diagram")
+	rc, err := s2.ReadAttachment(ctx, "DOC-1", "diagram", "arch.png")
 	require.NoError(t, err)
 	data, _ := io.ReadAll(rc)
 	rc.Close()
 	assert.Equal(t, "PNG-DATA", string(data))
+
+	rcNew, err := s2.ReadAttachment(ctx, "DOC-1", "diagram", "notes.new")
+	require.NoError(t, err, `a "*.new"-named attachment must survive a store reopen`)
+	dataNew, _ := io.ReadAll(rcNew)
+	rcNew.Close()
+	assert.Equal(t, "NEW-DATA", string(dataNew))
 }
 
 func TestPersistence_PropertyCacheSurvivesReopen(t *testing.T) {

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -472,7 +472,7 @@ func (m *MemStore) RenameEntity(_ context.Context, oldID, newID string) (*store.
 		}
 		delete(m.attachments, key)
 		a.entityID = newID
-		reKey[newID+"/"+a.property] = a
+		reKey[attachmentKey(newID, a.property, a.fileName)] = a
 	}
 	for k, v := range reKey {
 		m.attachments[k] = v
@@ -661,12 +661,23 @@ func (m *MemStore) DeleteRelation(_ context.Context, from, relType, to string) e
 
 // --- Attachments ---
 
+// attachmentKey is the per-file index key: (entityID, property, fileName).
+func attachmentKey(entityID, property, fileName string) string {
+	return entityID + "/" + property + "/" + fileName
+}
+
 func (m *MemStore) AttachFile(_ context.Context, entityID, property, fileName string, r io.Reader) error {
 	if err := validateProperty(property); err != nil {
 		return err
 	}
+	if err := store.ValidateFileName(fileName); err != nil {
+		return err
+	}
 
-	data, err := io.ReadAll(r)
+	// Backstop size guard (shared with fsstore): reject oversize bytes so
+	// the in-memory backend is never unbounded. The API layer also caps
+	// at ingress.
+	data, err := io.ReadAll(storeutil.LimitAttachmentReader(r))
 	if err != nil {
 		return err
 	}
@@ -678,8 +689,10 @@ func (m *MemStore) AttachFile(_ context.Context, entityID, property, fileName st
 		return store.ErrNotFound
 	}
 
-	key := entityID + "/" + property
-	m.attachments[key] = &attachment{
+	// Append: key by (entityID, property, fileName). A same-name re-attach
+	// replaces only that one file; sibling files on the property are
+	// untouched. Cap/suffix policy lives in the write path, not here.
+	m.attachments[attachmentKey(entityID, property, fileName)] = &attachment{
 		entityID: entityID,
 		property: property,
 		fileName: fileName,
@@ -688,23 +701,22 @@ func (m *MemStore) AttachFile(_ context.Context, entityID, property, fileName st
 	return nil
 }
 
-func (m *MemStore) ReadAttachment(_ context.Context, entityID, property string) (io.ReadCloser, error) {
+func (m *MemStore) ReadAttachment(_ context.Context, entityID, property, fileName string) (io.ReadCloser, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	key := entityID + "/" + property
-	a, ok := m.attachments[key]
+	a, ok := m.attachments[attachmentKey(entityID, property, fileName)]
 	if !ok {
 		return nil, store.ErrNotFound
 	}
 	return io.NopCloser(bytes.NewReader(a.data)), nil
 }
 
-func (m *MemStore) DeleteAttachment(_ context.Context, entityID, property string) error {
+func (m *MemStore) DeleteAttachment(_ context.Context, entityID, property, fileName string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	key := entityID + "/" + property
+	key := attachmentKey(entityID, property, fileName)
 	if _, ok := m.attachments[key]; !ok {
 		return store.ErrNotFound
 	}

--- a/internal/store/pgstore/attachment.go
+++ b/internal/store/pgstore/attachment.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/jackc/pgx/v5"
@@ -12,32 +11,27 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
-// maxAttachmentBytes caps a single attachment stored in the database. The bytes
-// are buffered in memory and written as one BYTEA value, so an unbounded upload
-// would risk OOMing the process and bloating a single row (PostgreSQL caps BYTEA
-// at ~1GB). 64 MiB comfortably covers the expected use (office documents, PDFs,
-// images) with headroom. This is a defensive guard specific to the in-database
-// backend, not a product-wide policy — the API layer caps uploads at its own
-// ingress, and a consistent cross-backend limit is a separate concern.
-const maxAttachmentBytes = 64 << 20 // 64 MiB
-
 // AttachFile stores (or replaces) a file attachment on an entity. The entity
 // must exist (store.ErrNotFound otherwise). The reader is fully consumed into
-// memory and persisted as BYTEA, matching memstore's behavior, up to
-// maxAttachmentBytes. A single (entity_id, property) holds one attachment;
-// re-attaching overwrites it.
+// memory and persisted as BYTEA, matching memstore's behavior, up to the shared
+// store.MaxAttachmentBytes backstop (the same cap every backend enforces so no
+// backend is ever unbounded; the API layer caps at its own ingress). A single
+// (entity_id, property) holds one attachment; re-attaching overwrites it.
 func (s *Store) AttachFile(ctx context.Context, entityID, property, fileName string, r io.Reader) error {
 	if err := validateProperty(property); err != nil {
 		return err
 	}
-	// Read at most maxAttachmentBytes+1 so we can detect an over-limit upload
-	// without buffering the entire (potentially huge) reader.
-	data, err := io.ReadAll(io.LimitReader(r, maxAttachmentBytes+1))
+	if err := store.ValidateFileName(fileName); err != nil {
+		return err
+	}
+	// Read at most the cap +1 so we can detect an over-limit upload without
+	// buffering the entire (potentially huge) reader.
+	data, err := io.ReadAll(io.LimitReader(r, store.MaxAttachmentBytes+1))
 	if err != nil {
 		return err
 	}
-	if len(data) > maxAttachmentBytes {
-		return fmt.Errorf("store: attachment exceeds the %d-byte limit", maxAttachmentBytes)
+	if int64(len(data)) > store.MaxAttachmentBytes {
+		return store.ErrAttachmentTooLarge
 	}
 
 	tx, err := s.db.Begin(ctx)
@@ -54,11 +48,17 @@ func (s *Store) AttachFile(ctx context.Context, entityID, property, fileName str
 		return err
 	}
 
+	// Append: keyed by (entity_id, property, file_name). A same-name
+	// re-attach replaces only that one row; sibling files are untouched.
+	// content_type is intentionally left at its '' default: content type is
+	// derived from the file name at the service layer (attachment.Service.List
+	// via contentTypeForName), so the column is never written. ListAttachments
+	// selects it for forward-compatibility but callers should not rely on it.
 	const q = `
 		INSERT INTO attachments (entity_id, property, file_name, bytes, updated_at)
 		VALUES ($1, $2, $3, $4, now())
-		ON CONFLICT (entity_id, property)
-		DO UPDATE SET file_name = excluded.file_name, bytes = excluded.bytes,
+		ON CONFLICT (entity_id, property, file_name)
+		DO UPDATE SET bytes = excluded.bytes,
 		             updated_at = now(), seq = nextval('rela_seq')`
 	if _, err := tx.Exec(ctx, q, entityID, property, fileName, data); err != nil {
 		return err
@@ -67,10 +67,10 @@ func (s *Store) AttachFile(ctx context.Context, entityID, property, fileName str
 }
 
 // ReadAttachment returns a reader over the stored bytes, or store.ErrNotFound.
-func (s *Store) ReadAttachment(ctx context.Context, entityID, property string) (io.ReadCloser, error) {
-	const q = `SELECT bytes FROM attachments WHERE entity_id = $1 AND property = $2`
+func (s *Store) ReadAttachment(ctx context.Context, entityID, property, fileName string) (io.ReadCloser, error) {
+	const q = `SELECT bytes FROM attachments WHERE entity_id = $1 AND property = $2 AND file_name = $3`
 	var data []byte
-	err := s.db.QueryRow(ctx, q, entityID, property).Scan(&data)
+	err := s.db.QueryRow(ctx, q, entityID, property, fileName).Scan(&data)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
@@ -81,9 +81,9 @@ func (s *Store) ReadAttachment(ctx context.Context, entityID, property string) (
 }
 
 // DeleteAttachment removes an attachment. Returns store.ErrNotFound if absent.
-func (s *Store) DeleteAttachment(ctx context.Context, entityID, property string) error {
-	const q = `DELETE FROM attachments WHERE entity_id = $1 AND property = $2`
-	tag, err := s.db.Exec(ctx, q, entityID, property)
+func (s *Store) DeleteAttachment(ctx context.Context, entityID, property, fileName string) error {
+	const q = `DELETE FROM attachments WHERE entity_id = $1 AND property = $2 AND file_name = $3`
+	tag, err := s.db.Exec(ctx, q, entityID, property, fileName)
 	if err != nil {
 		return err
 	}
@@ -105,8 +105,11 @@ func (s *Store) ListAttachments(ctx context.Context, entityID string) ([]store.A
 		return nil, err
 	}
 
+	// content_type is always '' here — it is never written (see AttachFile); the
+	// service layer derives content type from the file name. Selected for
+	// forward-compatibility only.
 	const q = `SELECT entity_id, property, file_name, content_type, octet_length(bytes)
-	           FROM attachments WHERE entity_id = $1 ORDER BY property ASC`
+	           FROM attachments WHERE entity_id = $1 ORDER BY property ASC, file_name ASC`
 	rows, err := s.db.Query(ctx, q, entityID)
 	if err != nil {
 		return nil, err

--- a/internal/store/pgstore/attachment_test.go
+++ b/internal/store/pgstore/attachment_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
 // maxAttachmentBytes mirrors the unexported pgstore constant; kept in sync by
@@ -32,10 +33,9 @@ func TestAttachFileSizeCap(t *testing.T) {
 	// Over the limit: rejected, without the store buffering the whole thing.
 	over := io.MultiReader(bytes.NewReader(atLimit), strings.NewReader("y"))
 	err := s.AttachFile(ctx, "E-1", "blob2", "too-big.bin", over)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "limit")
+	require.ErrorIs(t, err, store.ErrAttachmentTooLarge)
 
 	// The over-limit attachment was not stored.
-	_, err = s.ReadAttachment(ctx, "E-1", "blob2")
+	_, err = s.ReadAttachment(ctx, "E-1", "blob2", "too-big.bin")
 	require.Error(t, err)
 }

--- a/internal/store/pgstore/migrations/0003_attachments_per_file_pk.sql
+++ b/internal/store/pgstore/migrations/0003_attachments_per_file_pk.sql
@@ -1,0 +1,19 @@
+-- Multi-attachment per property (TKT-WLLRO7).
+--
+-- A `file` property can now hold several attachments, each identified by its
+-- (normalized) file name. The primary key moves from (entity_id, property) to
+-- (entity_id, property, file_name), so a property is no longer limited to one
+-- attachment. The file_name DEFAULT '' is dropped — an empty file name can no
+-- longer be a valid key (the store layer rejects it via ValidateFileName).
+--
+-- Forward-only. The DDL itself is not re-runnable (DROP CONSTRAINT has no IF
+-- EXISTS); it is applied exactly once by the migration runner, which tracks
+-- schema_version and skips already-applied files. Existing single-attachment
+-- rows already carry a real file_name and simply gain it as a key component.
+-- (Any legacy row with an empty file_name would need a backfill, but the store
+-- never wrote '' as a file name in practice — AttachFile has always received a
+-- base name.)
+
+ALTER TABLE attachments DROP CONSTRAINT attachments_pkey;
+ALTER TABLE attachments ALTER COLUMN file_name DROP DEFAULT;
+ALTER TABLE attachments ADD PRIMARY KEY (entity_id, property, file_name);

--- a/internal/store/pgstore/status_test.go
+++ b/internal/store/pgstore/status_test.go
@@ -32,7 +32,7 @@ func TestStatusFreshSchema(t *testing.T) {
 	current, target, err := pgstore.Status(ctx, pool)
 	require.NoError(t, err)
 	require.Equal(t, 0, current, "un-migrated schema is version 0")
-	require.Equal(t, 2, target, "binary embeds migrations through 0002")
+	require.Equal(t, 3, target, "binary embeds migrations through 0003")
 }
 
 // TestStatusAfterMigrate verifies Status reports current==target once Migrate

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,8 +11,10 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"iter"
+	"strings"
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -23,7 +25,138 @@ var (
 	ErrNotFound     = errors.New("store: not found")
 	ErrConflict     = errors.New("store: already exists")
 	ErrHasRelations = errors.New("store: entity has relations")
+	// ErrAttachmentTooLarge is returned by AttachFile when the supplied
+	// bytes exceed MaxAttachmentBytes. Every backend enforces this as a
+	// backstop so no storage path is ever unbounded; the HTTP/API layer
+	// caps at its own ingress for a clean 413 before reaching the store.
+	ErrAttachmentTooLarge = errors.New("store: attachment too large")
 )
+
+// MaxAttachmentBytes is the backstop cap every store backend enforces on
+// a single attachment's bytes. It is a defense-in-depth guard, not the
+// product policy limit — the API layer caps uploads at its own (usually
+// equal or lower) ingress. 64 MiB comfortably covers the expected use
+// (images, PDFs, office documents); PostgreSQL also caps BYTEA near 1 GB.
+const MaxAttachmentBytes = 64 << 20
+
+// CapAttachmentReader wraps r so reads fail with ErrAttachmentTooLarge
+// once they exceed `limit` bytes. It is the single shared bounded-reader
+// behind both the store backstop (every backend, at MaxAttachmentBytes)
+// and the API layer's per-request cap (at the configured upload limit),
+// so the off-by-one lives in one place. Unlike io.LimitReader (which
+// reports io.EOF at the boundary, indistinguishable from a genuine short
+// file), this surfaces an explicit error so callers can map it to a 413
+// and clean up any partial write. The too-large error deliberately wins
+// over any underlying read error at the boundary.
+func CapAttachmentReader(r io.Reader, limit int64) io.Reader {
+	return &cappedAttachmentReader{r: r, remaining: limit}
+}
+
+type cappedAttachmentReader struct {
+	r         io.Reader
+	remaining int64
+}
+
+func (l *cappedAttachmentReader) Read(p []byte) (int, error) {
+	if l.remaining < 0 {
+		return 0, ErrAttachmentTooLarge
+	}
+	// Allow reading one extra byte past the cap so a file exactly at the
+	// limit succeeds but anything larger trips on the next read.
+	if int64(len(p)) > l.remaining+1 {
+		p = p[:l.remaining+1]
+	}
+	n, err := l.r.Read(p)
+	l.remaining -= int64(n)
+	if l.remaining < 0 {
+		return n, ErrAttachmentTooLarge
+	}
+	return n, err
+}
+
+// ValidateFileName rejects attachment file names that would corrupt the
+// per-file storage key / path. The file name is a key segment (and an
+// on-disk path leaf in fsstore), so it must not be empty, contain a path
+// separator or NUL, or be a directory-traversal token. Callers should
+// normalize with [NormalizeFileName] before storing; this is the hard gate
+// every backend's AttachFile applies.
+func ValidateFileName(name string) error {
+	if name == "" {
+		return errors.New("store: empty attachment file name")
+	}
+	if strings.ContainsRune(name, '/') || strings.ContainsRune(name, '\\') {
+		return fmt.Errorf("store: attachment file name %q contains a path separator", name)
+	}
+	if strings.ContainsRune(name, 0) {
+		return fmt.Errorf("store: attachment file name %q contains a NUL byte", name)
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("store: attachment file name %q is a directory reference", name)
+	}
+	return nil
+}
+
+// NormalizeFileName reduces an arbitrary upload name to a safe storage
+// key: it takes the base name (stripping any path), replaces path
+// separators and control characters, and trims surrounding dots/spaces. It
+// preserves the extension and the human-readable stem so the stored name
+// still resembles what the user uploaded. Returns "file" if nothing usable
+// remains.
+func NormalizeFileName(name string) string {
+	if i := strings.LastIndexAny(name, `/\`); i >= 0 {
+		name = name[i+1:]
+	}
+	const firstPrintable = 0x20 // chars below this are ASCII control codes
+	var b strings.Builder
+	for _, r := range name {
+		if r == '/' || r == '\\' || r == 0 || r < firstPrintable {
+			b.WriteRune('_')
+			continue
+		}
+		b.WriteRune(r)
+	}
+	cleaned := strings.Trim(b.String(), " .")
+	if cleaned == "" || cleaned == "." || cleaned == ".." {
+		return "file"
+	}
+	return cleaned
+}
+
+// SuffixOnCollision returns name unchanged if exists(name) is false;
+// otherwise it appends a " (n)" counter before the extension until it
+// finds a free name (report.pdf -> "report (1).pdf" -> "report (2).pdf"),
+// mirroring how a file manager handles duplicate drops so a multi-file
+// upload never silently overwrites a same-named file.
+func SuffixOnCollision(name string, exists func(string) bool) string {
+	if !exists(name) {
+		return name
+	}
+	ext := attachmentExt(name)
+	stem := name[:len(name)-len(ext)]
+	// Terminates in practice: callers only suffix when the property is under
+	// its (small, validated) `max` cap, so at most `max` names are taken.
+	for n := 1; ; n++ {
+		candidate := fmt.Sprintf("%s (%d)%s", stem, n, ext)
+		if !exists(candidate) {
+			return candidate
+		}
+	}
+}
+
+// attachmentExt returns the trailing extension (including the dot), or ""
+// — like filepath.Ext but treating a leading-dot name (".bashrc") as
+// having no extension.
+func attachmentExt(name string) string {
+	for i := len(name) - 1; i >= 0 && name[i] != '/'; i-- {
+		if name[i] == '.' {
+			if i == 0 {
+				return ""
+			}
+			return name[i:]
+		}
+	}
+	return ""
+}
 
 // Store is the primary storage abstraction. All mutations are atomic:
 // the index is always consistent with the persisted state.
@@ -215,11 +348,16 @@ type AttachmentInfo struct {
 	Size        int64
 }
 
-// AttachmentManager provides file attachment operations.
+// AttachmentManager provides file attachment operations. A property can
+// hold multiple attachments, each keyed by its (normalized) file name —
+// so reads and deletes target a specific (entityID, property, fileName).
+// AttachFile appends; it does not overwrite other files on the property.
+// Enforcing a per-property cap (the metamodel `max`) and replace-at-1
+// semantics is the write path's job, not the store's.
 type AttachmentManager interface {
 	AttachFile(ctx context.Context, entityID, property, fileName string, r io.Reader) error
-	ReadAttachment(ctx context.Context, entityID, property string) (io.ReadCloser, error)
-	DeleteAttachment(ctx context.Context, entityID, property string) error
+	ReadAttachment(ctx context.Context, entityID, property, fileName string) (io.ReadCloser, error)
+	DeleteAttachment(ctx context.Context, entityID, property, fileName string) error
 	ListAttachments(ctx context.Context, entityID string) ([]AttachmentInfo, error)
 }
 

--- a/internal/store/storetest/attachment.go
+++ b/internal/store/storetest/attachment.go
@@ -19,6 +19,18 @@ func (f *failReader) Read([]byte) (int, error) {
 	return 0, errors.New("read failed")
 }
 
+// constReader yields an endless stream of the same byte. Used (with
+// io.LimitReader) to feed an oversize attachment without allocating the
+// full payload in the test.
+type constReader byte
+
+func (c constReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = byte(c)
+	}
+	return len(p), nil
+}
+
 // RunAttachmentTests runs attachment conformance tests.
 func RunAttachmentTests(t *testing.T, f Factory) {
 	t.Run("AttachAndRead", func(t *testing.T) {
@@ -28,7 +40,7 @@ func RunAttachmentTests(t *testing.T, f Factory) {
 		err := s.AttachFile(ctx(), "T-1", "screenshot", "bug.png", strings.NewReader("image data"))
 		require.NoError(t, err)
 
-		rc, err := s.ReadAttachment(ctx(), "T-1", "screenshot")
+		rc, err := s.ReadAttachment(ctx(), "T-1", "screenshot", "bug.png")
 		require.NoError(t, err)
 		defer rc.Close()
 
@@ -47,7 +59,7 @@ func RunAttachmentTests(t *testing.T, f Factory) {
 		s := f(t)
 		require.NoError(t, s.CreateEntity(ctx(), entity.New("T-1", "ticket")))
 
-		_, err := s.ReadAttachment(ctx(), "T-1", "noprop")
+		_, err := s.ReadAttachment(ctx(), "T-1", "noprop", "x")
 		assert.ErrorIs(t, err, store.ErrNotFound)
 	})
 
@@ -56,16 +68,16 @@ func RunAttachmentTests(t *testing.T, f Factory) {
 		require.NoError(t, s.CreateEntity(ctx(), entity.New("T-1", "ticket")))
 		require.NoError(t, s.AttachFile(ctx(), "T-1", "screenshot", "bug.png", strings.NewReader("data")))
 
-		err := s.DeleteAttachment(ctx(), "T-1", "screenshot")
+		err := s.DeleteAttachment(ctx(), "T-1", "screenshot", "bug.png")
 		require.NoError(t, err)
 
-		_, err = s.ReadAttachment(ctx(), "T-1", "screenshot")
+		_, err = s.ReadAttachment(ctx(), "T-1", "screenshot", "bug.png")
 		assert.ErrorIs(t, err, store.ErrNotFound)
 	})
 
 	t.Run("DeleteNotFound", func(t *testing.T) {
 		s := f(t)
-		err := s.DeleteAttachment(ctx(), "T-1", "noprop")
+		err := s.DeleteAttachment(ctx(), "T-1", "noprop", "x")
 		assert.ErrorIs(t, err, store.ErrNotFound)
 	})
 
@@ -135,27 +147,140 @@ func RunAttachmentTests(t *testing.T, f Factory) {
 		assert.ErrorIs(t, err, store.ErrNotFound)
 	})
 
-	t.Run("OverwritesExisting", func(t *testing.T) {
+	t.Run("RejectsOversize", func(t *testing.T) {
+		// Every backend enforces store.MaxAttachmentBytes as a backstop so
+		// no storage path is ever unbounded. Feed just over the cap via a
+		// constant reader (no multi-MiB allocation in the test) and assert
+		// the shared sentinel.
+		s := f(t)
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("T-1", "ticket")))
+
+		oversize := io.LimitReader(constReader('a'), store.MaxAttachmentBytes+1)
+		err := s.AttachFile(ctx(), "T-1", "screenshot", "big.bin", oversize)
+		assert.ErrorIs(t, err, store.ErrAttachmentTooLarge)
+
+		// The rejected write must not leave a half-attachment behind.
+		infos, listErr := s.ListAttachments(ctx(), "T-1")
+		require.NoError(t, listErr)
+		assert.Empty(t, infos, "oversize attach must not persist a partial attachment")
+	})
+
+	t.Run("OversizeReplaceKeepsExisting", func(t *testing.T) {
+		// A failed (oversize) replace must NOT destroy the existing valid
+		// attachment — the new bytes are written to the side and only
+		// swapped in on success.
+		s := f(t)
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("T-1", "ticket")))
+		require.NoError(t, s.AttachFile(ctx(), "T-1", "screenshot", "ok.png", strings.NewReader("original")))
+
+		// Same property, oversize — must be rejected.
+		oversize := io.LimitReader(constReader('a'), store.MaxAttachmentBytes+1)
+		err := s.AttachFile(ctx(), "T-1", "screenshot", "huge.bin", oversize)
+		assert.ErrorIs(t, err, store.ErrAttachmentTooLarge)
+
+		// The original attachment must still be intact and readable.
+		rc, readErr := s.ReadAttachment(ctx(), "T-1", "screenshot", "ok.png")
+		require.NoError(t, readErr)
+		defer rc.Close()
+		data, _ := io.ReadAll(rc)
+		assert.Equal(t, "original", string(data), "failed replace must not destroy the existing attachment")
+	})
+
+	t.Run("AppendsMultipleFilesPerProperty", func(t *testing.T) {
+		// Two DIFFERENT file names on the same property now COEXIST (the
+		// store appends; it no longer overwrites by property). Per-file
+		// cap/replace policy lives in the write path, not the store.
 		s := f(t)
 		require.NoError(t, s.CreateEntity(ctx(), entity.New("T-1", "ticket")))
 		require.NoError(t, s.AttachFile(ctx(), "T-1", "doc", "v1.txt", strings.NewReader("version 1")))
 		require.NoError(t, s.AttachFile(ctx(), "T-1", "doc", "v2.txt", strings.NewReader("version 2")))
 
-		rc, err := s.ReadAttachment(ctx(), "T-1", "doc")
+		infos, _ := s.ListAttachments(ctx(), "T-1")
+		assert.Len(t, infos, 2, "two differently-named files on one property must coexist")
+
+		// Each is readable by its own filename.
+		for name, want := range map[string]string{"v1.txt": "version 1", "v2.txt": "version 2"} {
+			rc, err := s.ReadAttachment(ctx(), "T-1", "doc", name)
+			require.NoError(t, err)
+			data, _ := io.ReadAll(rc)
+			rc.Close()
+			assert.Equal(t, want, string(data))
+		}
+	})
+
+	t.Run("SameNameReplacesOnlyThatFile", func(t *testing.T) {
+		// Re-attaching the SAME file name replaces just that one file;
+		// sibling files on the property are untouched.
+		s := f(t)
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("T-1", "ticket")))
+		require.NoError(t, s.AttachFile(ctx(), "T-1", "doc", "a.txt", strings.NewReader("a1")))
+		require.NoError(t, s.AttachFile(ctx(), "T-1", "doc", "b.txt", strings.NewReader("b1")))
+		require.NoError(t, s.AttachFile(ctx(), "T-1", "doc", "a.txt", strings.NewReader("a2"))) // replace a
+
+		infos, _ := s.ListAttachments(ctx(), "T-1")
+		assert.Len(t, infos, 2, "same-name re-attach must not add a row")
+
+		rcA, _ := s.ReadAttachment(ctx(), "T-1", "doc", "a.txt")
+		dataA, _ := io.ReadAll(rcA)
+		rcA.Close()
+		assert.Equal(t, "a2", string(dataA), "a.txt should be replaced")
+
+		rcB, _ := s.ReadAttachment(ctx(), "T-1", "doc", "b.txt")
+		dataB, _ := io.ReadAll(rcB)
+		rcB.Close()
+		assert.Equal(t, "b1", string(dataB), "b.txt must be untouched")
+	})
+
+	t.Run("PerFileDeleteLeavesSiblings", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("T-1", "ticket")))
+		require.NoError(t, s.AttachFile(ctx(), "T-1", "doc", "a.txt", strings.NewReader("a")))
+		require.NoError(t, s.AttachFile(ctx(), "T-1", "doc", "b.txt", strings.NewReader("b")))
+
+		require.NoError(t, s.DeleteAttachment(ctx(), "T-1", "doc", "a.txt"))
+
+		_, err := s.ReadAttachment(ctx(), "T-1", "doc", "a.txt")
+		assert.ErrorIs(t, err, store.ErrNotFound)
+		rc, err := s.ReadAttachment(ctx(), "T-1", "doc", "b.txt")
+		require.NoError(t, err, "deleting one file must leave its siblings")
+		rc.Close()
+	})
+
+	t.Run("RejectsBadFileName", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("T-1", "ticket")))
+
+		for _, bad := range []string{"", "a/b.txt", "a\\b.txt", "a\x00b", "..", "."} {
+			err := s.AttachFile(ctx(), "T-1", "doc", bad, strings.NewReader("x"))
+			assert.Error(t, err, "file name %q should be rejected", bad)
+		}
+		// A clean name still works.
+		require.NoError(t, s.AttachFile(ctx(), "T-1", "doc", "ok.txt", strings.NewReader("x")))
+	})
+
+	t.Run("FileNameEndingInNewRoundTrips", func(t *testing.T) {
+		// A file literally named "*.new" must store and read back — the temp
+		// marker must not collide with a valid user filename (RR-BN2MDO).
+		s := f(t)
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("T-1", "ticket")))
+		require.NoError(t, s.AttachFile(ctx(), "T-1", "doc", "report.new", strings.NewReader("payload")))
+
+		rc, err := s.ReadAttachment(ctx(), "T-1", "doc", "report.new")
 		require.NoError(t, err)
 		defer rc.Close()
 		data, _ := io.ReadAll(rc)
-		assert.Equal(t, "version 2", string(data))
+		assert.Equal(t, "payload", string(data))
 
 		infos, _ := s.ListAttachments(ctx(), "T-1")
-		assert.Len(t, infos, 1)
-		assert.Equal(t, "v2.txt", infos[0].FileName)
+		require.Len(t, infos, 1)
+		assert.Equal(t, "report.new", infos[0].FileName)
 	})
 
 	t.Run("RenameMovesAttachments", func(t *testing.T) {
 		s := f(t)
 		require.NoError(t, s.CreateEntity(ctx(), entity.New("T-1", "ticket")))
 		require.NoError(t, s.AttachFile(ctx(), "T-1", "spec", "doc.pdf", strings.NewReader("pdf bytes")))
+		require.NoError(t, s.AttachFile(ctx(), "T-1", "spec", "extra.txt", strings.NewReader("extra")))
 
 		_, err := s.RenameEntity(ctx(), "T-1", "T-2")
 		require.NoError(t, err)
@@ -165,10 +290,9 @@ func RunAttachmentTests(t *testing.T, f Factory) {
 
 		infos, err := s.ListAttachments(ctx(), "T-2")
 		require.NoError(t, err)
-		require.Len(t, infos, 1)
-		assert.Equal(t, "doc.pdf", infos[0].FileName)
+		require.Len(t, infos, 2, "all files on the property move with the rename")
 
-		rc, err := s.ReadAttachment(ctx(), "T-2", "spec")
+		rc, err := s.ReadAttachment(ctx(), "T-2", "spec", "doc.pdf")
 		require.NoError(t, err)
 		defer rc.Close()
 		got, _ := io.ReadAll(rc)

--- a/internal/store/storetest/differential_test.go
+++ b/internal/store/storetest/differential_test.go
@@ -202,8 +202,8 @@ func FuzzDifferential(f *testing.F) {
 				err2 := fss.AttachFile(bg, "E-1", "diagram", "pic.png", strings.NewReader(data))
 				assertSameError(t, err1, err2, "AttachFile")
 				if err1 == nil {
-					rc1, e1 := mem.ReadAttachment(bg, "E-1", "diagram")
-					rc2, e2 := fss.ReadAttachment(bg, "E-1", "diagram")
+					rc1, e1 := mem.ReadAttachment(bg, "E-1", "diagram", "pic.png")
+					rc2, e2 := fss.ReadAttachment(bg, "E-1", "diagram", "pic.png")
 					assertSameError(t, e1, e2, "ReadAttachment")
 					if e1 == nil {
 						d1, _ := io.ReadAll(rc1)

--- a/internal/store/storetest/fuzz.go
+++ b/internal/store/storetest/fuzz.go
@@ -106,7 +106,7 @@ func FuzzAttachmentKeyCollision(f *testing.F, factory FuzzFactory) {
 			return
 		}
 
-		rc, err := s.ReadAttachment(bg, entityID, prop)
+		rc, err := s.ReadAttachment(bg, entityID, prop, "f.txt")
 		require.NoError(t, err)
 		rc.Close()
 	})

--- a/internal/store/storeutil/storeutil.go
+++ b/internal/store/storeutil/storeutil.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 
@@ -199,4 +200,13 @@ func MatchRelation(r *entity.Relation, q store.RelationQuery) bool {
 		}
 	}
 	return true
+}
+
+// LimitAttachmentReader wraps r so reads fail with
+// store.ErrAttachmentTooLarge once they exceed store.MaxAttachmentBytes.
+// This is the shared backstop guard every store backend applies to
+// AttachFile, so no backend is ever unbounded regardless of caller.
+// Thin alias over store.CapAttachmentReader at the backstop cap.
+func LimitAttachmentReader(r io.Reader) io.Reader {
+	return store.CapAttachmentReader(r, store.MaxAttachmentBytes)
 }

--- a/tickets/entities/docs-checklists/DOCS-372ZRT.md
+++ b/tickets/entities/docs-checklists/DOCS-372ZRT.md
@@ -1,0 +1,25 @@
+---
+id: DOCS-372ZRT
+type: docs-checklist
+title: 'Docs: Multi-attachment per property'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on the new surface — `PropertyDef.Max`/`FileMax()`, store `ValidateFileName`/`NormalizeFileName`/`SuffixOnCollision`, `attachment.Service.WriteAttachment`/`DeleteAttachment`/`ErrAtCapacity`, the per-file handler routes, `V1Attachment.id`, the always-list `_attachments`
+
+## Project Documentation
+
+- [x] `docs/metamodel.md` — `max` property option + "File attachments and `max`" section (single vs multi, list value, auto-suffix)
+- [x] `docs/data-entry/api-reference.md` — Attachments section rewritten for the always-list `_attachments` shape (+ id), per-file download/delete routes (`/_attachments/{property}/{fileName}`), upload max-behavior (replace at 1 / append+suffix+409 at N)
+- [x] `docs/cli-reference.md` — `rela attach` max-aware note + `rela detach --file` flag
+
+## External Documentation
+
+- [x] ~~README~~ (N/A: covered by metamodel + API + CLI references)
+
+**Docs verified:** the api-reference list shape, per-file URLs, and
+409/auto-suffix behavior match the implementation and the live smoke test.

--- a/tickets/entities/docs-checklists/DOCS-KU30G9.md
+++ b/tickets/entities/docs-checklists/DOCS-KU30G9.md
@@ -1,0 +1,26 @@
+---
+id: DOCS-KU30G9
+type: docs-checklist
+title: 'Docs: Attachment web read path'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on the new handler (`handleV1GetAttachment`), helpers, and the `V1Attachment` DTO / `_attachments` field — including the ACL-inheritance, entity-first-resolution, and serve-defensive-bytes rationale
+- [x] ~~CLAUDE.md pattern update~~ (N/A: reuses existing patterns — `_actions` route case, closed-world DTO, gate-before-load — no new convention)
+
+## Project Documentation
+
+- [x] `docs/data-entry/api-reference.md` — added the **Attachments (`_attachments`)** section: metadata shape on per-entity responses, the `GET /{plural}/{id}/_attachments/{property}` download endpoint, ACL-inheritance + 404-not-403 behavior, and the security headers (nosniff / CSP sandbox / Content-Disposition)
+- [x] Documented closed-world semantics (rides every per-entity response, absent on list rows) consistent with `_fields`/`_relations`
+
+## External Documentation
+
+- [x] ~~README / external docs~~ (N/A: internal API surface, covered by the API reference)
+
+**Docs verified:** the api-reference Attachments section matches the implemented
+endpoint path, headers, and payload field names
+(`filename`/`size`/`contentType`/`href`).

--- a/tickets/entities/docs-checklists/DOCS-SXKF2O.md
+++ b/tickets/entities/docs-checklists/DOCS-SXKF2O.md
@@ -1,0 +1,26 @@
+---
+id: DOCS-SXKF2O
+type: docs-checklist
+title: 'Docs: Attachment web write path'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on the new handlers (upload/delete/preflight), the shared `store.CapAttachmentReader`, the `ErrAttachmentTooLarge`/`MaxAttachmentBytes` sentinels, and `AppConfig.MaxAttachmentBytes` — including ACL/orphan-ordering and size-cap rationale
+- [x] ~~CLAUDE.md pattern update~~ (N/A: reuses existing write patterns — translateVerb authorize, multipart, closed-world DTO)
+
+## Project Documentation
+
+- [x] `docs/data-entry/api-reference.md` — Attachments section extended with the **Upload** (PUT/POST multipart) and **Delete** (DELETE) endpoints: `update`-permission inheritance, authorize-before-bytes, 413 size limit + the `app.max_attachment_bytes` config key + per-store backstop, 400/422 error cases
+- [x] Documented orphan-avoidance ordering (delete clears property before bytes)
+
+## External Documentation
+
+- [x] ~~README / external docs~~ (N/A: internal API surface, covered by the API reference)
+
+**Docs verified:** api-reference upload/delete sections match the implemented
+methods, field name (`file`), status codes, and the config key name
+(`app.max_attachment_bytes`).

--- a/tickets/entities/features/FEAT-870YCY.md
+++ b/tickets/entities/features/FEAT-870YCY.md
@@ -1,0 +1,43 @@
+---
+id: FEAT-870YCY
+type: feature
+title: Attachments as a first-class product feature
+summary: 'Build the product surface on top of the existing attachment storage layer: web upload/download/preview (primary), MCP tool and CLI fixes (secondary), entity-inherited ACL, configurable per-property file count + sane default size limit, and file metadata exposed to Lua.'
+description: 'Build the product surface on top of rela''s existing attachment storage layer. The storage layer (store.AttachmentManager, fsstore/memstore/pgstore backends, cascade-on-delete, CLI) is solid, but nothing a user touches exists: the web app renders file properties as plain text path strings, there is no upload/download HTTP endpoint (attachments are unreachable on postgres), no MCP tool, no ACL gating (NopACL), inconsistent/unbounded size limits, and a 1:1-per-property model that contradicts the CLI''s multi-file wording. Delivered via child tickets: web read path (primary, ships first), web write path (primary), configurable per-property file count, MCP tool (secondary), and CLI/docs cleanup (secondary). Cross-cutting decisions: attachments inherit the owning entity''s ACL; a sane default size limit is enforced in the shared write path for all backends; file metadata (name/size/content-type) is exposed to Lua as an escape hatch.'
+priority: medium
+status: proposed
+---
+
+## Problem
+
+rela has a complete, well-factored attachment **storage** layer —
+`store.AttachmentManager`
+(`AttachFile`/`ReadAttachment`/`DeleteAttachment`/`ListAttachments`), three
+backends (fsstore streaming, memstore, pgstore BYTEA), cascade-on-delete/rename,
+and a CLI (`rela attach`/`attachments`/`detach`). What it lacks is **everything
+a user touches**. Attachments are a file bound to a `file`-type entity property,
+keyed 1:1 by `(entityID, property)`; the stored path string is stamped onto the
+property value.
+
+## Gaps this feature addresses
+
+1. **No web path (primary).** The data-entry SPA renders a `file` property with a plain `TextWidget` (`frontend/src/widgets/registry.ts:100`) — the user sees the *path string as editable text*. No file picker, upload, download link, or preview. There is no HTTP endpoint for attachment upload/download. For a **postgres deployment the bytes live in the DB and are unreachable through the product** — this is the single highest-leverage gap.
+2. **No MCP tool (secondary).** Agents cannot attach, list, or fetch files (`internal/mcp/` has nothing).
+3. **No ACL (security).** Attachments are wired with `acl.NopACL{}` (`internal/attachment/attachment_test.go:92`). Entities/relations/search are ACL-gated in dataentry; attachment read/write is not. **Decision: an attachment inherits the ACL of its owning entity** (matches the 1:1 model, no new policy surface).
+4. **Inconsistent size limits.** Only pgstore caps (64 MiB, `internal/store/pgstore/attachment.go:22`, self-described as backend-specific); fsstore/memstore are **unbounded**. **Decision: a sane product-wide default limit** enforced in the shared write path for all backends, sized for screenshots/PDFs (not movies). Tighter limits matter mainly for semi-untrusted users.
+5. **Multi-file model mismatch.** CLI globs and says "Attach file(s)" but the model is 1:1 per property, so multiple files overwrite. **Decision: `file` properties gain a `max` setting (1..N)** — configurable count per property; store key scheme, metamodel, and backends change accordingly.
+6. **Lua escape hatch.** Expose attachment file info (name, size, content-type) to Lua so users can implement their own constraints/policy via the existing write-veto hooks.
+7. **CLI/doc cleanup.** Misleading multi-file wording; orphan window in `Service.Attach` (file written before `UpdateEntity`; `rela gc --temp-files` recovers); doc drift (`docs/metamodel.md:455` says `.rela/attachments/`, code uses root `attachments/`).
+
+## Child tickets
+
+- **Web read path** (ships first, independently useful): ACL-gated HTTP download/serve + inline preview / file widget replacing TextWidget. Unblocks *viewing* existing attachments, including postgres.
+- **Web write path**: multipart upload endpoint + file-picker/drag-drop widget + default size limit in the shared write path + file info to Lua.
+- **Configurable per-property file count (`max`)**: metamodel `file` property gains `max`; store key scheme + 3 backends + CLI move from 1:1 to N-per-property.
+- **MCP attachment tool** (secondary): attach/list/read so agents participate, ACL-gated.
+- **CLI + docs cleanup** (secondary): fix multi-file wording, document the model, orphan-window note, `.rela/attachments` doc drift.
+
+## Out of scope
+
+Magic-byte sniffing / MIME allowlist beyond what the size limit + Lua hook cover
+(can be a follow-up if semi-untrusted multi-tenant lands).

--- a/tickets/entities/implementation-checklists/IMPL-7ZS0SC.md
+++ b/tickets/entities/implementation-checklists/IMPL-7ZS0SC.md
@@ -1,0 +1,41 @@
+---
+id: IMPL-7ZS0SC
+type: implementation-checklist
+title: 'Implementation: Configurable per-property attachment count: file property `max` setting (1..N)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests for new code across all layers — metamodel (FileMax + list validation), storetest conformance (append/same-name-replace/per-file-delete/suffix-key/rename-all/oversize-replace), handler (multi-append/409-cap/auto-suffix/per-file-delete/list-shape), widget (list render/replace-vs-add/at-cap/remove/upload/progress)
+- [x] Integration: live end-to-end smoke on the demo app (3-upload+409, auto-suffix, per-file download/delete, single-cap scalar)
+- [x] Happy path + edge cases (cap, collision, rename, oversize-replace) + error handling
+
+## Test Quality
+
+- [x] Fixture builders; multi-file fixture (`docs` max:3) added to newTestAppV1; no hardcoded values where object in scope
+
+## Manual Verification
+
+**Verification Evidence (live, demo app NOTE-001):**
+- gallery (max:3): 3 uploads → 200; 4th → 409; `_attachments.gallery` is a 3-element list with per-file ids+hrefs; `properties.gallery` is a list.
+- Auto-suffix: re-uploading `g1.png` → stored as `g1 (1).png` (no overwrite).
+- Per-file delete (204) + per-file download (correct bytes).
+- attachment (max:1): replace mode, `properties.attachment` stays a scalar string, `_attachments` is a 1-element list.
+- Backend: `go build` default+postgres; `go test ./...` green; `golangci-lint ./internal/...` 0; `just arch-lint` OK.
+- Frontend: `npm run test:run` 1089 passed; `vue-tsc` clean; `npm run lint` 0 errors.
+
+## Quality
+
+- [x] Follows patterns — store key extended like the existing index key; filename helpers moved to `store` (not storeutil) to respect the dataentry→store arch boundary; always-list matches `_relations`/`list:` convention; write-path max enforcement mirrors the read/write ticket structure
+- [x] DRY — single `store.CapAttachmentReader`/`NormalizeFileName`/`SuffixOnCollision`/`ValidateFileName`; shared resolve/stamp logic in handler + service
+- [x] No security issues — entity-ACL gate preserved on per-file routes; `ValidateFileName` rejects path separators in the new key segment; auto-suffix prevents silent loss
+- [x] No silent failures; no debug code
+
+## Decisions (user + research)
+Filename-as-key (UUID rejected — no security benefit given the entity ACL);
+auto-suffix on collision; always-list wire shape; store stays max-agnostic (max
+enforced in write path); widget max-aware (replace at 1 / add at N); progress
+via axios onUploadProgress (no lib).

--- a/tickets/entities/implementation-checklists/IMPL-RF6G6C.md
+++ b/tickets/entities/implementation-checklists/IMPL-RF6G6C.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-RF6G6C
+type: implementation-checklist
+title: 'Implementation: Attachment web read path: ACL-gated download endpoint + file widget/preview'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code — `handlers_attachment_test.go` (6 backend cases); `widgets.test.ts` FileWidget (4 cases) + updated registry case
+- [x] Integration tests written — handler-level tests invoke through the gate ctx (package convention); router_walk probe pins route registration
+- [x] Happy path implemented — GET bytes, `_attachments` metadata, FileWidget display + image preview
+- [x] Edge cases handled — denied(404)/missing/wrong-property/non-file/rename/method-not-allowed; widget fallback to raw path + empty-state
+- [x] Error handling in place — store/gate errors mapped via writeV1Error/writeGateError, logged server-side, not leaked
+
+## Test Quality
+
+- [x] Fixture builders used (`seedEntity`, `seedAttachment`, `mustNewACL`, shared `newTestAppV1`)
+- [x] No hardcoded values where object in scope (e.g. `att.Size` compared to `len("bytes")`)
+- [x] Only test-relevant values specified
+- [x] Interpolated values constructed from objects
+- [x] Property comparisons use the seeded object
+
+## Manual Verification
+
+**Verification Evidence:**
+- Backend: `go test ./internal/dataentry/` green; full store suite green; `go build` default+postgres OK; `golangci-lint` 0 issues; `just arch-lint` OK.
+- Frontend: `npm run test:run` 1080 passed; `vue-tsc` typecheck clean; `npm run lint` 0 errors (warnings all pre-existing, none in changed files).
+- AC1 (allowed→bytes+headers): `TestAttachment_AllowedReturnsBytes` PASS.
+- AC2 (denied→404 parity, no ETag): `TestAttachment_DeniedIsNotFound` PASS — required aligning all handler 404s to the gate's "Entity not found" title (RR-NGMI indistinguishability); captured as `notFoundTitle` const with a comment.
+- AC3 (missing/unknown/non-file→404): `TestAttachment_UnknownOrNonFileProperty` + nonexistent case PASS.
+- AC4 (rename resolves by current id): `TestAttachment_ResolvesByCurrentIDAfterRename` PASS.
+- AC5 (SPA preview/download): FileWidget unit tests PASS (image preview, non-image download, raw-path fallback, empty-state). Live SPA smoke deferred to review.
+- `_attachments` present on per-entity GET, absent on list rows: `TestAttachment_MetadataOnEntityGET` PASS.
+
+## Quality
+
+- [x] Follows project patterns — mirrors `_actions` route case, theme serve-bytes headers, `_fields`/`_relations` closed-world DTO, acl_get_test harness
+- [x] DRY — `notFoundTitle` const; `contentTypeForFilename`/`safeAttachmentFilename` helpers; reuses `unsafeFilenameRe`. Did not over-extract.
+- [x] No security issues — ACL gate before store touch; nosniff+CSP sandbox+Content-Disposition on user bytes; filename sanitized; entity-first resolution (no path traversal); no error-string leak
+- [x] No silent failures — list-attachments failure in the metadata path degrades to "no attachments" (UI hint only); the bytes endpoint still gates+serves correctly
+- [x] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-ZFW3F0.md
+++ b/tickets/entities/implementation-checklists/IMPL-ZFW3F0.md
@@ -1,0 +1,46 @@
+---
+id: IMPL-ZFW3F0
+type: implementation-checklist
+title: 'Implementation: Attachment web write path: upload endpoint + drag-drop widget + default size limit + Lua file info'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests for new code — `handlers_attachment_write_test.go` (upload/replace/delete/denied/oversize/bad-field); storetest `RejectsOversize` conformance (all backends); frontend FileWidget upload + error tests
+- [x] Integration tests — handler-level via gate ctx; round-trip upload→GET; router_walk probe
+- [x] Happy path — upload (PUT/POST), delete (DELETE), drag-drop/picker widget, configurable size cap
+- [x] Edge cases — missing file field (400), non-file property (404), oversize (413), locked entity (422), idempotent delete
+- [x] Error handling — store/gate errors mapped, logged, not leaked
+
+## Test Quality
+
+- [x] Fixture builders (newTestAppV1, seedEntity, multipartBody, writeACL)
+- [x] No hardcoded values where object in scope
+- [x] Only test-relevant values specified
+- [x] Property comparisons use seeded objects
+
+## Manual Verification
+
+**Verification Evidence:**
+- Backend: `go test ./internal/dataentry/ ./internal/store/... ./internal/dataentryconfig/ ./internal/attachment/` green; `go build` default+postgres; `golangci-lint` 0 issues; `just arch-lint` OK; coverage PASS.
+- Frontend: `npm run test:run` 1086 passed; `vue-tsc` clean; `npm run lint` 0 errors.
+- AC1 upload/replace/view/delete: `TestAttachmentUpload_RoundTrips`/`_Replaces`/`TestAttachmentDelete_RemovesBytesAndProperty` PASS (fsstore; pgstore conformance via storetest).
+- AC2 over-limit all backends: handler `TestAttachmentUpload_TooLarge` (413) + storetest `RejectsOversize` (fs/mem/pg, sentinel + no partial) PASS.
+- AC3 no-update-access denied before bytes: `TestAttachmentWrite_DeniedBeforeBytes` (bob→404 read-gate, carol→403, no bytes written) PASS.
+- AC4 orphan window closed: authorize-before-write (preflight) + delete clears property first; covered by the denied-before-bytes assertion.
+
+## Quality
+
+- [x] Follows patterns — mirrors authorizeConflictResolve (translateVerb, no direct WriteRequest → lint_test green), theme multipart, writeV1Error problem+json, closed-world DTO
+- [x] DRY — shared `attachmentWritePreflight`; shared `storeutil.LimitAttachmentReader` across fs/mem + `store.MaxAttachmentBytes`/`ErrAttachmentTooLarge` sentinel across all 3 backends
+- [x] No security issues — update-ACL re-authorized server-side before bytes; ingress + per-store size caps; uniform 404; content-cap reader independent of multipart envelope; no error leak
+- [x] No silent failures — errors logged AND returned
+- [x] No debug code left behind
+
+## Scope change (recorded)
+The "Lua file-info veto" was split to **TKT-40PZ15** (net-new write-veto
+mechanism, not a binding addition — established by research). Size-limit seam =
+ingress + per-store backstop (user decision).

--- a/tickets/entities/planning-checklists/PLAN-89DEDP.md
+++ b/tickets/entities/planning-checklists/PLAN-89DEDP.md
@@ -1,0 +1,125 @@
+---
+id: PLAN-89DEDP
+type: planning-checklist
+title: 'Planning: Attachment web write path: upload endpoint + drag-drop widget + default size limit + Lua file info'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements understood
+- [x] Scope defined (below)
+- [x] Acceptance criteria with test scenarios
+
+**Scope:** IN: web upload (PUT) + delete (DELETE) on the `_attachments` route;
+up-front `update`-ACL re-authorization; product-wide default size limit (ingress
+`http.MaxBytesReader` 413 + fsstore/memstore backstop guards + configurable
+default); drag-drop/file-picker on FileWidget gated on `_actions.update`. OUT:
+Lua file-info veto (split to TKT-40PZ15), multi-file `max` (TKT-WLLRO7).
+
+**Acceptance Criteria:**
+1. Upload/replace/view/delete end-to-end on fsstore + pgstore.
+2. Over-limit rejected on ALL backends — handler 413 + per-store guard rejects (unit-tested fs/mem/pg).
+3. No `update` access → upload/delete denied BEFORE bytes written (acl test).
+4. Orphan window closed for web path: deny/validation-fail leaves no orphan bytes.
+
+## Research
+
+- [x] Codebase patterns checked (two research passes)
+
+**Prior art (file:line):**
+- Method-dispatch the `_attachments` route case (api_v1.go ~354) on `r.Method`: GET→existing read handler, PUT→upload, DELETE→delete.
+- Write-ACL: `translateVerb("update", type, id)` (affordances.go:34) + `a.acl.AuthorizeWrite`; deny→`writeForbiddenIfACLDenied` (handlers_api.go:354) + audit `OpDeniedWrite`. Mirror `authorizeConflictResolve` (api_v1.go:3080). MUST NOT construct `acl.WriteRequest{Op:` directly (lint_test.go grep; only affordances.go allowed).
+- Multipart: `http.MaxBytesReader` + `ParseMultipartForm` + `FormFile` + `*http.MaxBytesError`→413 (handlers_theme.go:71-110). But emit 413 via `writeV1Error` (problem+json), not the theme's ad-hoc shape.
+- Write/persist: `a.store.AttachFile` then `e.SetString(prop, key)` + `a.entityManager.UpdateEntity` under `a.writeMu.Lock()` (mirrors attachment.Service.Attach attachment.go:107-119 and handleV1UpdateEntity api_v1.go:1059).
+- Size guard: pgstore `maxAttachmentBytes=64<<20` (pgstore/attachment.go:22); fsstore (writeAttachment 67-86) + memstore (669) unbounded → add backstop. Config home: dataentryconfig.Config (no limit field today).
+- Store: `AttachmentManager` (store.go:218); `App.store` + `App.entityManager` (app.go:109).
+- router_walk_test + lint_test enforcement understood.
+
+**Research Doc:** N/A
+
+## Approach
+
+- [x] Chosen, builds on patterns, alternatives considered
+
+**Technical Approach:** *Route.* Replace the straight `_attachments`→GET
+dispatch with a method switch → `handleV1AttachmentRoute` that fans to
+get/put/delete. *Upload (`handleV1PutAttachment`).* writeMu.Lock →
+gateReadOrNotFound → load entity + isFileProperty (404 else) →
+**AuthorizeWrite(translateVerb("update",…)) up front** (deny→403 before bytes,
+audit) → `http.MaxBytesReader(maxAttachmentUploadBytes)` + ParseMultipartForm +
+FormFile("file") → MaxBytesError→413 via writeV1Error → `a.store.AttachFile` →
+`e.SetString(prop, key)` + `a.entityManager.UpdateEntity` (validation→422 via
+writeForbiddenIfACLDenied then writeV1Error) → 200 with the V1Entity (so
+`_attachments` reflects the new file). *Delete (`handleV1DeleteAttachment`).*
+same gate+authorize → clear property via UpdateEntity FIRST → then
+`a.store.DeleteAttachment` (idempotent) → 204. Property-first so a
+validation/deny failure leaves bytes, not a dangling ref. *Size limit.* New
+const `DefaultMaxAttachmentBytes` (start 64 MiB) + optional `dataentryconfig`
+override; handler caps at ingress. Add `maxAttachmentBytes` guard
+(io.LimitReader+length check, mirroring pgstore) to fsstore.AttachFile and
+memstore.AttachFile so the store rejects oversize regardless of caller — store
+returns a sentinel/error the handler maps. *Frontend.* Extend FileWidget: in
+edit mode render a file `<input>` + drag-drop dropzone (replace the read-only
+note), POST multipart to the href, show progress, replace/remove (DELETE). Gate
+on `_actions.update`. New `api/attachments.ts` client. Inline 413/422 errors.
+
+**Files:** handlers_attachment.go (+put/delete/dispatch), api_v1.go (route
+line), dataentryconfig/config.go (limit field), store/fsstore/attachment.go +
+store/memstore/memstore.go (guards) + store/storetest (conformance for the cap),
+handlers_attachment_test.go (+upload/delete/acl/size), router_walk_test.go
+(PUT/DELETE probes); frontend FileWidget.vue, api/attachments.ts (new), tests;
+docs/data-entry/api-reference.md.
+
+**Alternatives rejected:** enforce only in attachment.Service (doesn't cover
+web, which bypasses the service); store-only (opaque error at HTTP boundary).
+Chose ingress+backstop per decision.
+
+## Security Considerations
+
+- [x] Inputs, validation, sensitive ops, error-leak
+
+**Inputs/validation:** multipart file (capped at ingress + store backstop;
+filename sanitized for storage key via existing storeutil/property checks);
+property validated against declared `file` props (allowlist→404). entityID is a
+store key, never an FS path. **Sensitive ops:** write gated by `update` ACL
+re-authorized server-side BEFORE bytes; deny audited. No `_actions` trust
+(server re-authorizes). Orphan-avoidance ordering (authorize-before-write;
+delete clears property first). 413/422 via problem+json; backend errors logged
+not leaked.
+
+## Test Plan
+
+- [x] Scenarios, edge cases, negatives, integration
+
+**Scenarios:** upload→200 + bytes round-trip via GET; replace overwrites;
+delete→204 + GET 404; over-limit→413 (handler) + per-backend store-guard unit
+test (fs/mem/pg); no-update-access→403 before any AttachFile (assert no bytes);
+validation-fail→422; method probes. Frontend: widget upload/replace/remove,
+gated on _actions, inline error on 413. **Edge:** empty file; missing form
+field→400; non-file property→404; concurrent (writeMu). **Negatives:** oversize,
+denied, malformed multipart.
+
+## Risk Assessment
+
+- [x] Risks + effort
+
+**Risks:** store-guard change must pass storetest conformance (add a case).
+Orphan ordering — mitigated by authorize-before-write. Frontend multipart
+progress — keep simple (no chunking). Effort: l.
+
+## Documentation Planning
+
+- [x] Docs identified
+
+- [x] docs/data-entry/api-reference.md — document upload/delete methods + 413/size limit on the Attachments section. Docs-checklist at review.
+- [x] Configurable limit → note in config docs if present.
+
+## Design Review
+
+- [x] ~~/design-review~~ (N/A: extends the just-reviewed read-path patterns; the one genuinely new design call — Lua veto scope + size-limit seam — was decided with the user up front. Cranky /code-review at review stage covers implementation.)
+
+**Design Review Findings:** scoping decisions made with user (Lua veto →
+TKT-40PZ15; size limit → ingress+backstop).

--- a/tickets/entities/planning-checklists/PLAN-TCHUKN.md
+++ b/tickets/entities/planning-checklists/PLAN-TCHUKN.md
@@ -1,0 +1,122 @@
+---
+id: PLAN-TCHUKN
+type: planning-checklist
+title: 'Planning: Attachment web read path: ACL-gated download endpoint + file widget/preview'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (below)
+- [x] Acceptance criteria documented with test scenarios
+
+**Scope:** IN: (1) GET attachment-bytes endpoint, ACL-gated, entity-first
+resolution; (2) `_attachments` metadata on per-entity payloads so the SPA knows
+which file properties have a file; (3) a read-capable file widget replacing
+TextWidget for `file` properties (filename, size, download link, inline image
+preview). OUT: upload/delete (TKT-RXFD5B), multi-file `max` (TKT-WLLRO7), MCP
+tool (TKT-R6U15C), the deeper fsstore rename re-stamp fix (the endpoint resolves
+by current entity ID so it is *correct* regardless; the stale frontmatter string
+is a separate store bug).
+
+**Acceptance Criteria:**
+1. Allowed user GETs an entity's attachment → 200 + bytes + headers.
+2. Denied user → 404 (NOT 403), byte-identical to nonexistent, no ETag (RR-NGMI).
+3. Missing attachment / missing entity / wrong property → 404.
+4. Renamed entity: attachment reachable by current id, gone from old id.
+5. SPA shows filename/size + download + image preview; non-image → download; edit mode read-only.
+
+## Research
+
+- [x] Checked codebase for similar patterns
+- [x] Reviewed prior art
+
+**Existing Solutions / prior art:** Route dispatch `handleV1DynamicRoutes`
+(api_v1.go:279), `_actions` case mirrored for `_attachments`. ACL gate
+`gateReadOrNotFound` (api_v1.go:794) reused verbatim. Serve-bytes precedent:
+theme logo (nosniff+CSP) / theme export
+(Content-Disposition+`safeThemeFilename`). Closed-world DTO
+`_fields`/`_relations`. Store `AttachmentManager` (ReadAttachment→io.ReadCloser,
+ErrNotFound→404). Test harness `acl_get_test.go`. Frontend registry +
+`WidgetProps` + `Entity._fields?`.
+
+**Research Doc:** N/A (small, well-patterned change)
+
+## Approach
+
+- [x] Approach chosen, builds on existing patterns, alternatives considered, deps identified
+
+**Technical Approach:** Sub-resource `case "_attachments"` in route dispatch →
+`handleV1GetAttachment` (gate→load→validate file-property→ReadAttachment→stream
+with defensive headers). `V1Attachment` DTO + `_attachments` on `V1Entity`,
+populated in `serializeEntityForWire` (every per-entity response, like the
+affordance maps). FileWidget.vue (display + image preview; read-only note in
+edit mode), registered for `file`; `_attachments` threaded via
+`PropertyItem`→`PropertyDisplay`→widget, populated in EntityDetail's
+`mapFieldsToProperties`.
+
+**Files modified:** handlers_attachment.go (new), api_v1.go, affordances.go,
+handlers_attachment_test.go (new), router_walk_test.go, api_v1_test.go
+(fixture); FileWidget.vue (new), registry.ts, widgets/types.ts, types/entity.ts,
+PropertyDisplay.vue, EntityDetail.vue, widgets.test.ts, registry.test.ts;
+docs/data-entry/api-reference.md.
+
+**Alternatives rejected:** dedicated system route (duplicates plural→type
+resolution); `http.ServeContent` Range support (no precedent; defer).
+
+## Security Considerations
+
+- [x] Input sources, validation, sensitive ops, error-leak handling identified
+
+**Input Sources & Validation:** entityID/property/plural from URL. plural→type
+via resolver (unknown→404). property validated against declared `file`
+properties (allowlist→404). Bytes resolved from `(entityID, property)` only —
+never the stored path string; no caller-supplied path reaches the FS (no `../`
+surface).
+
+**Security-Sensitive Operations:** gate before store touch (no existence
+side-channel; deny=404=nonexistent, body matches gate via shared
+`entityNotFoundTitle`). User bytes served with nosniff + CSP `sandbox;
+default-src 'none'` + `Content-Disposition: inline` + sanitized filename
+(stored-XSS + header-injection guard). Store/gate errors mapped, logged
+server-side, never leaked.
+
+## Test Plan
+
+- [x] Scenarios per criterion, edge cases, negatives, integration approach
+
+**Test Scenarios:** allowed→bytes+headers; denied→404 parity+no ETag+matches
+gate body; missing/unknown/non-file→404; rename→new-id 200/old-id 404; deceptive
+.png→image/png+nosniff; .svg→sandbox CSP+inline; `_attachments` on per-entity
+GET+mutation, absent on list rows; FileWidget edit-mode read-only. **Edge
+Cases:** empty/missing property; filename with quotes/`..`/unicode (sanitized);
+image vs non-image; hidden-by-ACL. **Negatives:** gate error→504/500 no leak;
+property with `/` rejected upstream.
+
+## Risk Assessment
+
+- [x] Technical + security risks assessed; effort estimated
+
+**Risks:** ListAttachments ContentType empty on fsstore → derive from filename
+(mitigated). Stale frontmatter post-rename → endpoint resolves by current id
+(correct); underlying re-stamp a follow-up. Inline malicious bytes → nosniff+CSP
+sandbox (mitigated, now tested). Effort: m (confirmed).
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+
+**Documentation Impact:**
+- [x] docs/data-entry/api-reference.md — new `_attachments` endpoint + payload. Docs-checklist DOCS-KU30G9 created at review.
+- [x] N/A for metamodel/CLI (no schema or command change).
+
+## Design Review
+
+- [x] ~~Run `/design-review` before implementation~~ (N/A: small single-pattern change — mirrors `_actions` + theme-serve + closed-world DTO — and the security-sensitive ACL invariant is pinned by the existing test contract reused verbatim. The cranky `/code-review` at review stage covered it and surfaced 4 findings, all addressed.)
+- [x] All critical/significant findings addressed in plan — surfaced at code-review instead: RR-FKJYMC/SQE8VA/XB5738/601TJD all addressed.
+
+**Design Review Findings:** deferred to code-review (RR-FKJYMC, RR-SQE8VA,
+RR-XB5738, RR-601TJD).

--- a/tickets/entities/planning-checklists/PLAN-ZFQPKQ.md
+++ b/tickets/entities/planning-checklists/PLAN-ZFQPKQ.md
@@ -1,0 +1,51 @@
+---
+id: PLAN-ZFQPKQ
+type: planning-checklist
+title: 'Planning: Configurable per-property attachment count: file property `max` setting (1..N)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/scope/acceptance — see ticket. N-per-property via metamodel `max`; locked design below.
+
+**Locked decisions (user + research):**
+- **Filename-as-key** `(entityID, property, fileName)` — research: opaque/UUID id buys no security (entity ACL gates access), worse migration. Normalization required.
+- **Auto-suffix** on same-name collision (`file.png`→`file (1).png`).
+- **Always-list** wire shape (`_attachments[property]: []V1Attachment` with `id`), matching rela's `list:`/`_relations` convention.
+- **Store stays max-agnostic**: pure append + per-file delete. **Max-enforcement in the write path**: `max==1` → delete-then-attach (replace); `max>1` → append up to max, 409 at cap.
+- **Widget max-aware**: `max==1` replace mode; `max>1` add/list mode.
+- **Upload progress** via axios `onUploadProgress` (existing dep, no lib).
+
+## Research / blast radius (from sub-agent map)
+
+- `store.AttachmentManager`: `ReadAttachment` + `DeleteAttachment` gain `fileName` param (store.go:268-269). `AttachFile` already has it but stops overwriting-by-property. `ListAttachments`/`AttachmentInfo` already per-file.
+- Backends: fsstore index key `entityID+"/"+property` → +`/"+fileName` (attachment.go:41/108/124 + renameAttachmentDir re-key:245); memstore same (684/698/710 + rename:475); pgstore PK `(entity_id,property)`→`(entity_id,property,file_name)` via new migration `0003_*.sql`, `ON CONFLICT` + 2 WHERE clauses (55/66/80), drop `file_name DEFAULT ''`. Cascade (removeAttachmentDir/DeleteEntity loops) is key-agnostic — OK.
+- Entity: no `SetStringList`; assign `[]string` directly to `e.Properties[prop]` (entity.go) or add a setter. Stamp list of filenames/paths.
+- Metamodel: add `Max int yaml:"max,omitempty"` to PropertyDef (types.go:177); validation.go:341 file case grows a list branch gated on List/Max; validatePropertyDefs rejects Max<1.
+- Shared filename normalize + collision-suffix helper → `internal/store/storeutil` (already imported by all 3 backends); add `ValidateFileName`.
+- Call sites: dataentry handlers_attachment.go (108/218/230/265/275), affordances.go computeAttachments (852-871 → append per file), cli/detach.go (37-40), attachment/attachment.go (107-112).
+- storetest: rewrite `OverwritesExisting`→append, `OversizeReplaceKeepsExisting`, add filename arg everywhere; new cases: N-per-property, suffix-on-collision, per-file delete, ValidateFileName. Also differential_test.go:201, fuzz.go:100/109, pgstore/fsstore backend tests.
+- Frontend consumers of `_attachments` (single→array): entity.ts:34 type, EntityDetail:438/815, DynamicForm:273/1114/1156, SectionEditForm:46/219/233, FieldRenderer:23, PropertyDisplay:24/97, widgets/types.ts:54, FileWidget. Plus widget tests.
+- Progress: api/attachments.ts uses fetch (no progress) → switch to axios client (`onUploadProgress`).
+
+## Approach (layered)
+
+1. **Metamodel**: `Max int` on PropertyDef; validate `max>=1`; file validation accepts list when max>1; docs/metamodel.md.
+2. **Store**: storeutil normalize+suffix+`ValidateFileName`; `ReadAttachment`/`DeleteAttachment` gain fileName; 3 backends per-file key; pg migration `0003`; rewrite storetest + backend tests.
+3. **Service/handlers**: write-path max enforcement (delete-then-attach at 1, append+suffix+409 at N); per-file routes `GET|DELETE /_attachments/{property}/{fileName}`; affordances appends per file; stamp list property.
+4. **API DTO**: `_attachments[property]: []V1Attachment` + `id`; docs.
+5. **CLI**: attach append-up-to-max; detach by filename.
+6. **Frontend**: array type + thread through 4 layers; max-aware FileWidget (replace vs add/list, per-file remove, add disabled at max); axios upload + progress bar; tests.
+
+## Security / Test / Risk
+
+- Security: same entity-ACL gate (per-file routes keep up-front authorize + uniform 404). `ValidateFileName` closes path-key injection (filename now a storage-key segment). Auto-suffix prevents silent loss.
+- Tests: storetest conformance (all backends incl pg migration idempotent), handler upload/replace/append/max-cap/suffix/per-file-delete, widget max==1 vs max>1, progress.
+- Risks: pg migration over existing `DEFAULT ''` rows — migration must handle; storetest semantics inversion (overwrite→append) — rewrite carefully; broad frontend thread — array everywhere, one shape.
+
+## Design Review
+
+- [x] ~~/design-review~~ (N/A: design researched + user-decided on every fork: id scheme, suffix, wire shape, max-enforcement location, widget mode, progress. Cranky /code-review at review stage.)

--- a/tickets/entities/review-checklists/REV-0O5MG3.md
+++ b/tickets/entities/review-checklists/REV-0O5MG3.md
@@ -1,0 +1,56 @@
+---
+id: REV-0O5MG3
+type: review-checklist
+title: 'Review: Attachment CLI + docs cleanup: multi-file wording, orphan window, doc drift'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — `go test ./internal/attachment/ ./internal/store/fsstore/` ok; full `just coverage-check` suite green
+- [x] Lint clean — `golangci-lint run --build-tags postgres ./internal/store/pgstore/...`: changed file `attachment.go` clean (the 3 flagged issues are in `graphquery_explain_test.go`, pre-existing, not touched by this ticket)
+- [x] Coverage maintained — `just coverage-check`: total 76.7%, all package + total floors PASS (docs/comments change adds no statements)
+
+## Code Review
+
+- [x] ~~Run `/code-review` (cranky-code-reviewer)~~ (N/A: docs + code-comment only change, no behavioral diff; self-review sufficient)
+- [x] ~~All critical review-responses addressed~~ (N/A: no review-responses created)
+- [x] ~~All significant review-responses addressed~~ (N/A: no review-responses created)
+- [x] Self-reviewed the diff for unrelated changes — diff limited to the 4 in-scope items across `docs/cli-reference.md`, `docs/metamodel.md`, `internal/store/pgstore/attachment.go`
+
+**Review Responses:** none (no findings)
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested:
+  - CLI help / `docs/cli-reference.md` accurately describe per-property model — PASS (overwrite note added under `rela attach`)
+  - Orphan-recovery behavior documented — PASS (`rela gc --temp-files` note under `rela attach`)
+  - `docs/metamodel.md` attachment path matches code — PASS (`.rela/attachments/` → `attachments/`; grep confirms no remaining stale refs in `docs/`)
+  - content_type dead column — PASS (documented at write + read sites in `attachment.go`; `go build -tags postgres` passes)
+- [x] Test evidence documented (above + in ticket Resolution section)
+
+**Acceptance Status:** ALL PASS
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: this ticket *is* the docs work; kind=docs, not an enhancement with separate user docs)
+- [x] User-facing documentation updated — `docs/cli-reference.md`, `docs/metamodel.md`
+- [x] ~~Docs-checklist marked as done~~ (N/A: none created)
+
+**Docs Checklist:** none (kind=docs ticket)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what — pending commit (user controls commit timing)
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] ~~Run `/pr` command~~ (deferred: user controls commit/PR timing per project convention; changes staged in working tree)
+- [x] ~~All CI checks pass~~ (deferred to PR)
+- [x] ~~PR URL documented~~ (deferred to PR)
+
+**PR:** pending — changes staged, not yet committed/pushed

--- a/tickets/entities/review-checklists/REV-2E21NL.md
+++ b/tickets/entities/review-checklists/REV-2E21NL.md
@@ -1,0 +1,59 @@
+---
+id: REV-2E21NL
+type: review-checklist
+title: 'Review: Configurable per-property attachment count: file property `max` setting (1..N)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — `go test ./...` exit 0; frontend `npm run test:run` 1089 passed
+- [x] Lint clean — `golangci-lint ./internal/...` 0; `vue-tsc` clean; frontend lint 0 errors; `just arch-lint` OK
+- [x] Coverage maintained — `just coverage-check` PASS
+- [x] Build default + postgres OK
+
+## Code Review
+
+Two review rounds. Round 1 (per-ticket): caught the max==1 delete-before-attach
+data-loss bug + policy duplication. Round 2 (`/code-review`, integrated final
+pass): caught a **critical read-path ACL bypass** that only became reachable
+once `_attachments` joined the response.
+
+- [x] All critical addressed — RR-N96YV0 (data-loss reorder), **RR-ROF51F (hidden-property leak: skip in computeAttachments + 404 in GET/preflight)**
+- [x] All significant addressed — RR-CIH3TZ (consolidate), RR-P5EFFT (capture-state-once), RR-BN2MDO (`.new` temp-marker collision)
+- [x] Self-reviewed the diff
+
+**Review Responses:** RR-N96YV0, RR-CIH3TZ, RR-1BS5FH (round 1) + RR-ROF51F
+(critical), RR-P5EFFT, RR-BN2MDO, RR-ZR1FYI (round 2) — all `addressed`.
+
+## Acceptance Verification
+
+- [x] Each criterion tested + verified live; round-2 fixes added these tests:
+  - **Hidden file property** → omitted from `_attachments` AND per-file download 404s (`TestAttachment_HiddenPropertyNotLeaked`)
+  - **`*.new`-named attachment** survives a store reopen (`TestPersistence_AttachmentsSurviveReopen` + storetest `FileNameEndingInNewRoundTrips` all backends)
+  - **schema `max`** emitted by both `/_schema` and `/_schema/types/{type}` (`TestV1SchemaEndpoint` + `TestV1SchemaTypesSpecific`)
+  - Snapshot-once threading; one-fewer ListAttachments per upload
+  - Multi-file gallery + single-cap replace re-verified live (non-regressive)
+- [x] Test evidence documented
+
+**Acceptance Status:** ALL PASS
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created + linked via `has-docs` — DOCS-372ZRT
+- [x] User-facing docs updated — metamodel.md, data-entry/api-reference.md, cli-reference.md
+- [x] Docs-checklist marked done — DOCS-372ZRT
+
+**Docs Checklist:** DOCS-372ZRT
+
+## Final Checks
+
+- [x] No TODOs/FIXMEs left; reverted the stray catalog/metamodel.yaml leftover; ready for another developer
+
+## Pull Request
+
+- [x] ~~/pr~~ (deferred: user controls commit/PR timing; full local CI surrogate green)
+
+**PR:** pending — changes staged, not yet committed/pushed

--- a/tickets/entities/review-checklists/REV-6UULOC.md
+++ b/tickets/entities/review-checklists/REV-6UULOC.md
@@ -1,0 +1,60 @@
+---
+id: REV-6UULOC
+type: review-checklist
+title: 'Review: Attachment web read path: ACL-gated download endpoint + file widget/preview'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — `go test ./internal/dataentry/ ./internal/store/...` green; frontend `npm run test:run` 1082 passed
+- [x] Lint clean — `golangci-lint run ./internal/dataentry/` 0 issues; frontend `npm run lint` 0 errors (warnings all pre-existing, none in changed files); `vue-tsc` typecheck clean; `just arch-lint` OK
+- [x] Coverage maintained — `just coverage-check` PASS; dataentry 77.8%
+
+## Code Review
+
+- [x] Ran code review (cranky-code-reviewer agent) — thorough, security-focused
+- [x] All critical review-responses addressed — RR-FKJYMC (addressed)
+- [x] All significant review-responses addressed — RR-SQE8VA, RR-XB5738 (addressed)
+- [x] Self-reviewed the diff for unrelated changes — scoped to the read-path; the shared `entityNotFoundTitle` hoist touches gate/entity-GET 404 literals (intentional, pins the indistinguishability invariant)
+
+**Review Responses:** RR-FKJYMC (critical), RR-SQE8VA (significant), RR-XB5738
+(significant), RR-601TJD (minor) — all `addressed`.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested:
+  - AC1 allowed→bytes+headers: `TestAttachment_AllowedReturnsBytes` PASS
+  - AC2 denied→404 parity, no ETag, matches gate body: `TestAttachment_DeniedIsNotFound` + `TestAttachment_DenyBodyMatchesGate` PASS
+  - AC3 missing/unknown/non-file→404: `TestAttachment_UnknownOrNonFileProperty` PASS
+  - AC4 rename resolves by current id: `TestAttachment_ResolvesByCurrentIDAfterRename` PASS
+  - AC5 SPA preview/download + edit-mode read-only: FileWidget tests PASS
+  - XSS defenses: `TestAttachment_DeceptiveExtensionServesTypeFromName` + `TestAttachment_SvgIsSandboxed` PASS
+  - `_attachments` on per-entity GET + mutation, absent on list rows: `TestAttachment_MetadataOnEntityGET` + `TestAttachment_MetadataOnMutationResponse` PASS
+- [x] Test evidence documented (implementation checklist + above)
+
+**Acceptance Status:** ALL PASS
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs` — DOCS-KU30G9
+- [x] User-facing documentation updated — `docs/data-entry/api-reference.md` Attachments section
+- [x] Docs-checklist marked as done — DOCS-KU30G9 `done`
+
+**Docs Checklist:** DOCS-KU30G9
+
+## Final Checks
+
+- [x] Commit message explains the why — pending commit (user controls timing)
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] ~~Run `/pr`~~ (deferred: user controls commit/PR timing; changes staged in working tree)
+- [x] ~~CI checks pass~~ (deferred to PR — full local CI surrogate green: build default+postgres, lint, tests, coverage, arch-lint)
+- [x] ~~PR URL~~ (deferred)
+
+**PR:** pending — changes staged, not yet committed/pushed

--- a/tickets/entities/review-checklists/REV-EIEPNM.md
+++ b/tickets/entities/review-checklists/REV-EIEPNM.md
@@ -1,0 +1,58 @@
+---
+id: REV-EIEPNM
+type: review-checklist
+title: 'Review: Attachment web write path: upload endpoint + drag-drop widget + default size limit + Lua file info'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — `go test ./internal/dataentry/ ./internal/store/... ./internal/attachment/ ./internal/dataentryconfig/` green; frontend `npm run test:run` 1086 passed
+- [x] Lint clean — `golangci-lint run ./internal/dataentry/ ./internal/store/...` 0 issues; frontend lint 0 errors; `vue-tsc` clean; `just arch-lint` OK (incl. the dataentry→store boundary for the moved reader)
+- [x] Coverage maintained — `just coverage-check` PASS (added a `store` package test for `CapAttachmentReader`, which had introduced 10 uncovered statements; store now 90%)
+
+## Code Review
+
+- [x] Ran code review (cranky-code-reviewer) — found a **critical data-loss bug** (C1) the first pass missed
+- [x] All critical review-responses addressed — RR-EISJTE (fsstore replace+oversize data loss) fixed + test
+- [x] All significant review-responses addressed — RR-81XSCY (clamp), RR-AFMZ9S (log)
+- [x] Self-reviewed the diff for unrelated changes — scoped; the `CapAttachmentReader` lives in `internal/store` (not storeutil) to respect arch boundaries
+
+**Review Responses:** RR-EISJTE (critical), RR-81XSCY (significant), RR-AFMZ9S
+(significant), RR-JIRLLU (minor) — all `addressed`.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested:
+  - AC1 upload/replace/view/delete e2e (fs; pg via storetest): `TestAttachmentUpload_RoundTrips`/`_Replaces`/`TestAttachmentDelete_RemovesBytesAndProperty` PASS
+  - AC2 over-limit all backends: `TestAttachmentUpload_TooLarge` (413) + storetest `RejectsOversize`/`OversizeReplaceKeepsExisting` (fs/mem/pg) + `TestCapAttachmentReader` PASS
+  - AC3 no-update-access denied before bytes: `TestAttachmentWrite_DeniedBeforeBytes` PASS
+  - AC4 orphan window closed + no data loss on failed replace: `TestAttachmentUpload_ReplaceOversizeKeepsExisting` + storetest case PASS
+  - Frontend upload/drag-drop/remove + error: FileWidget tests PASS
+- [x] Test evidence documented (implementation checklist + above)
+
+**Acceptance Status:** ALL PASS
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs` — DOCS-SXKF2O
+- [x] User-facing documentation updated — `docs/data-entry/api-reference.md` upload/delete + size limit
+- [x] Docs-checklist marked as done — DOCS-SXKF2O `done`
+
+**Docs Checklist:** DOCS-SXKF2O
+
+## Final Checks
+
+- [x] Commit message explains the why — pending commit (user controls timing)
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] ~~Run `/pr`~~ (deferred: user controls commit/PR timing; changes staged)
+- [x] ~~CI checks pass~~ (deferred to PR — full local CI surrogate green)
+- [x] ~~PR URL~~ (deferred)
+
+**PR:** pending — changes staged, not yet committed/pushed

--- a/tickets/entities/review-responses/RR-1BS5FH.md
+++ b/tickets/entities/review-responses/RR-1BS5FH.md
@@ -1,0 +1,9 @@
+---
+id: RR-1BS5FH
+type: review-response
+title: 'Minor: storetest bad-name gaps, validateFileValue comment, dead branch, write-path error swallow, deleteHref'
+finding: '(#3) storetest RejectsBadFileName table omits backslash and NUL though ValidateFileName rejects them — add ''a\b.txt'' and ''a\x00b''. (#4) validateFileValue comment says max==1 must be a single string but the code also accepts a 1-element list — fix the comment. (#5) resolveUploadFileName''s name=='''' branch is unreachable (NormalizeFileName returns ''file'', never '''') — remove or justify (CLI omits it). (#7) attachmentFileNames swallows a real list error as empty slice on the WRITE path, so the capacity check can pass when full / replace-delete does nothing — prefer failing the op on the decision path. (#6) frontend encodeURIComponent vs backend url.PathEscape: emit a server deleteHref and have the client use it verbatim rather than reconstruct from att.id. Nit: comment SuffixOnCollision''s caller-cap termination guarantee.'
+severity: minor
+resolution: '(#3) storetest RejectsBadFileName now includes ''a\\b.txt'' and ''a\x00b''; added store-package unit tests TestValidateFileName/TestNormalizeFileName/TestSuffixOnCollision (store coverage 19.6%→95.7%). (#4) validateFileValue comment corrected to say a 1-element list is tolerated even at max==1. (#5) the dead name=='''' branch is gone with the handler-helper removal; the shared resolveAttachName documents that NormalizeFileName never returns ''''. (#7) attachmentFileNames now returns an error and the write path fails the op on a real list error (only ErrNotFound degrades to empty). (#6) backend keeps url.PathEscape for the href; the frontend now DELETEs the server-provided per-file href verbatim (deleteAttachment(href)) instead of reconstructing with encodeURIComponent — single escaper, verified live. Nit: added the SuffixOnCollision caller-cap termination comment.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-601TJD.md
+++ b/tickets/entities/review-responses/RR-601TJD.md
@@ -1,0 +1,9 @@
+---
+id: RR-601TJD
+type: review-response
+title: notFoundTitle duplicates gate literal; href empty-branch; silent ListAttachments error
+finding: 'Cluster of minor correctness items: (a) notFoundTitle const and gateReadOrNotFound both hardcode ''Entity not found'' as independent literals linked only by a comment — no test asserts the two 404 bodies are byte-equal; (b) attachmentHref returns '''' when Self empty, producing a silently-wrong link — build from e.ID+plural directly instead; (c) attachmentFileName swallows ListAttachments errors as 404 on the byte-serving path, masking a backend outage — log before returning false. Plus nits: bytes.NewReader over string round-trip in test, ?.contentType?. optional chain.'
+severity: minor
+resolution: '(a) Hoisted a shared entityNotFoundTitle const in api_v1.go used by gateReadOrNotFound, handleV1GetEntity, and the attachment handler; added TestAttachment_DenyBodyMatchesGate asserting the attachment 404 body equals the gate''s 404 body (modulo instance). (b) computeAttachments builds the href from the canonical selfHref and now omits entries entirely if selfHref is empty (no broken-link branch). (c) attachmentFileName logs non-NotFound ListAttachments errors before returning false, so a backend outage on the byte-serving path isn''t silent. Plus nits: bytes.NewReader in the seed helper, ?.contentType?. optional chain in FileWidget. Also documented the ListAttachments+ReadAttachment TOCTOU window in the handler (harmless; collapse needs a store API change — separate ticket).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-81XSCY.md
+++ b/tickets/entities/review-responses/RR-81XSCY.md
@@ -1,0 +1,9 @@
+---
+id: RR-81XSCY
+type: review-response
+title: Config limit above store backstop makes the 413 detail lie
+finding: 'If app.max_attachment_bytes is configured ABOVE store.MaxAttachmentBytes (64MiB), a file in (64MiB, configuredLimit] passes the handler''s limitedContentReader but trips the store backstop, surfacing a 413 whose detail says ''maximum size is <configuredLimit> bytes'' — a lie; the real ceiling was 64MiB. Fix: clamp maxAttachmentBytes() to store.MaxAttachmentBytes so the configured limit can never exceed the backstop.'
+severity: significant
+resolution: maxAttachmentBytes() now clamps the configured/default limit to store.MaxAttachmentBytes, so the 413 detail can never promise a ceiling the store would reject. Added TestMaxAttachmentBytes_ClampsToStoreCap (default, lower-override, over-cap-clamped).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-AFMZ9S.md
+++ b/tickets/entities/review-responses/RR-AFMZ9S.md
@@ -1,0 +1,9 @@
+---
+id: RR-AFMZ9S
+type: review-response
+title: computeAttachments silently swallows ListAttachments backend error
+finding: 'computeAttachments returns an empty map on a ListAttachments error with no log, while the sibling attachmentFileName (handler) correctly logs a non-ErrNotFound failure. Inconsistent: on the serialize path a backend fault silently reports ''no attachments'' with zero operator signal. Fix: log a non-ErrNotFound error before degrading to empty.'
+severity: significant
+resolution: computeAttachments now logs a non-ErrNotFound ListAttachments error via slog.Warn before degrading to an empty map, consistent with the sibling attachmentFileName. A backend fault on the serialize path is no longer silent.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-BN2MDO.md
+++ b/tickets/entities/review-responses/RR-BN2MDO.md
@@ -1,0 +1,9 @@
+---
+id: RR-BN2MDO
+type: review-response
+title: fsstore loses an attachment named *.new on restart (temp suffix collision)
+finding: 'loadPropertyAttachments skips strings.HasSuffix(name, ''.new''), but ''.new'' is also the live temp-write suffix AND a valid user filename: NormalizeFileName(''report.new'') -> ''report.new'' (only end dots/spaces trimmed) and ValidateFileName accepts it. So a user can upload report.new; it stores/reads fine in-process, but after restart the index loader skips it — file on disk, invisible to the store, stamped property points at a ''missing'' file, cap accounting wrong. multi-cap suffixing can also yield ''x (1).new''. Fix: use a temp marker a normalized name can never equal (leading-dot prefix, e.g. ''.<name>.new-<rand>'') and skip by that prefix, not the user-facing .new suffix.'
+severity: significant
+resolution: fsstore temp file now uses a leading-dot prefix marker (attachTempPrefix = '.rela-attach-tmp-') instead of the '.new' suffix. A stored attachment name can never start with a dot (store.NormalizeFileName trims leading dots), so the marker is collision-proof; loadPropertyAttachments skips by that prefix. Added storetest FileNameEndingInNewRoundTrips (all backends) + extended fsstore TestPersistence_AttachmentsSurviveReopen to attach a 'notes.new' file and assert it survives a store reopen.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CIH3TZ.md
+++ b/tickets/entities/review-responses/RR-CIH3TZ.md
@@ -1,0 +1,9 @@
+---
+id: RR-CIH3TZ
+type: review-response
+title: Handler and CLI duplicate the whole max-policy (already drifting)
+finding: resolveUploadFileName vs resolveAttachName; stampAttachmentProperty vs stampProperty; attachmentFileNames in both dataentry and attachment packages; two path-builders (attachmentKey vs attachPath) computing the same string. Two copies of security-relevant policy (cap enforcement, suffixing, scalar-vs-list stamping). Already diverged (the handler has a dead name=='' check the CLI omits). A future change to the stamping rule will update one and miss the other. Consolidate into the attachment package (which has the store dep) and have the handler call it.
+severity: significant
+resolution: 'Consolidated the entire max-policy into attachment.Service: WriteAttachment (cap/suffix/attach-then-delete/stamp) and DeleteAttachment (per-file delete + re-stamp). The HTTP handler now builds the service on demand (a.attachmentService(), cheap struct wrapper over a.store/a.entityManager/a.State().Meta) and delegates; the CLI Attach/Detach already call the same methods. Removed the duplicated handler helpers (resolveUploadFileName, stampAttachmentProperty, attachmentFileNames, filePropertyMax, attachmentKey, the uploadResolveCode enum). Single source of truth for the policy. Added attachment to dataentry''s allowed deps in .go-arch-lint.yml (peer of entitymanager); arch-lint passes.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-EISJTE.md
+++ b/tickets/entities/review-responses/RR-EISJTE.md
@@ -1,0 +1,9 @@
+---
+id: RR-EISJTE
+type: review-response
+title: fsstore replace+oversize destroys existing valid attachment (data loss)
+finding: 'fsstore.AttachFile removes the OLD file before streaming the new one. If the new upload trips the backstop cap, the partial new file is cleaned up but the old (valid) attachment is already gone and the in-memory index points at a now-missing file → next ReadAttachment fails. Same-filename case truncates-in-place then deletes. The storetest RejectsOversize case doesn''t catch it (fresh property only). Fix: write new file first, only remove old after the streamed write succeeds. Add a replace-then-oversize conformance case asserting the original is still readable.'
+severity: critical
+resolution: Reordered fsstore.AttachFile to write the new bytes to a temp key (fileKey+'.new') FIRST, and only after a successful write remove the superseded old file and Rename temp into place. A failed write (e.g. backstop cap trip) now removes only the temp partial — the existing attachment and in-memory index are untouched. Fixes both the different-filename and same-filename (truncate-in-place) data-loss cases. Added storetest OversizeReplaceKeepsExisting (all backends) + dataentry TestAttachmentUpload_ReplaceOversizeKeepsExisting asserting the original is still readable after a failed oversize replace.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-FKJYMC.md
+++ b/tickets/entities/review-responses/RR-FKJYMC.md
@@ -1,0 +1,9 @@
+---
+id: RR-FKJYMC
+type: review-response
+title: _attachments leaks onto mutation responses; docs claim GET-only
+finding: computeAttachments runs in attachEntityAffordances, which serializeEntityForWire calls for PATCH/POST/clone/dry-run create/custom-view — not just GET. But the V1Entity.Attachments comment, docs/data-entry/api-reference.md, and frontend Entity._attachments comment all assert 'absent on mutation responses'. Contract violation + a wasted ListAttachments roundtrip per dry-run keystroke. The pinning test only checks list-row omission, never a mutation response — false confidence.
+severity: critical
+resolution: 'Chose the consistent option: _attachments rides every per-entity response (GET/PATCH/POST/clone) like _fields/_relations, rather than restricting to GET. Fixed all three doc/comment sites (V1Entity.Attachments godoc, frontend Entity._attachments comment, docs/data-entry/api-reference.md) to state this accurately. Added TestAttachment_MetadataOnMutationResponse asserting the shared serializeEntityForWire output carries the map. Also added an early-return in computeAttachments when selfHref is empty so dry-run/odd shapes can''t emit a broken href.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-JIRLLU.md
+++ b/tickets/entities/review-responses/RR-JIRLLU.md
@@ -1,0 +1,9 @@
+---
+id: RR-JIRLLU
+type: review-response
+title: 'Missing tests: content-cap reader path, idempotent delete; misleading delete comment; cleanup nits'
+finding: 'S1: no test where header.Size under-declares and limitedContentReader.exceeded trips (dead-untested branch). S5: no idempotent-delete test (204 + property empty when no attachment); delete comment lists ''deny'' as an orphan cause but deny is handled in preflight before UpdateEntity. N1: handleV1DeleteAttachment threads a dead `plural` param (''_ = plural''). N3: maxAttachmentBytes() does its own a.State() load instead of snapshotting once. N2: multipart temp files not explicitly RemoveAll''d. S3/L1: two parallel limit-reader implementations (limitedContentReader + storeutil.attachmentLimitReader) with different off-by-one styles — consolidate.'
+severity: minor
+resolution: 'S1: the content-cap path is now the shared store.CapAttachmentReader, covered by store-package unit tests (TestCapAttachmentReader: at-limit, over-limit, unbounded, zero) + storetest oversize cases. S5: added TestAttachmentDelete_IdempotentWhenNoAttachment (204 + property empty); corrected the delete doc comment (deny is handled in preflight, only a validation failure orphans bytes). N1: dropped the dead `plural` param from handleV1DeleteAttachment + its dispatch. N3: handler snapshots a.State() once and maxAttachmentBytes takes *AppState. N2: added a defer r.MultipartForm.RemoveAll(). S3/L1: consolidated the two limit-readers into a single store.CapAttachmentReader(r, limit) — storeutil.LimitAttachmentReader and the handler both delegate to it; removed the duplicate limitedContentReader. (Reader lives in internal/store, not storeutil, to respect the dataentry→store arch boundary.)'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-N96YV0.md
+++ b/tickets/entities/review-responses/RR-N96YV0.md
@@ -1,0 +1,9 @@
+---
+id: RR-N96YV0
+type: review-response
+title: max==1 replace deletes old file before attaching new (data-loss window)
+finding: 'At max==1 the upload handler (and CLI Service.Attach) DeleteAttachment(old) THEN AttachFile(new). If AttachFile fails for any reason other than the early header.Size guard (store I/O error, disk full, mid-stream read error, streaming cap on an under-declared part), the old bytes are gone and the new never land — original lost, frontmatter stale. fsstore temp-then-swap only protects same-name overwrite, not a different-name replace (two separate store ops). TestAttachmentUpload_ReplaceOversizeKeepsExisting gives false confidence: its 413 short-circuits at header.Size BEFORE the delete block, so the hazard is never exercised. Fix: AttachFile first, then delete siblings whose name != new name, then re-stamp — in BOTH the handler and the CLI service. Add a test that fails AttachFile via a store error (not the size guard) and asserts the original survives.'
+severity: critical
+resolution: Reordered to attach-first-then-delete-siblings in the shared attachment.Service.WriteAttachment (used by both the HTTP handler and CLI). The new file is written FIRST; only after it lands are the other files removed (at max==1). A store/read failure mid-write now leaves the existing attachment intact. Added TestService_ReplaceFailureKeepsExisting using a failingReader that errors mid-stream (NOT the size guard) and asserts the original survives — the test that actually exercises the hazard. Verified live (upload+delete-by-href round-trip).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-P5EFFT.md
+++ b/tickets/entities/review-responses/RR-P5EFFT.md
@@ -1,0 +1,9 @@
+---
+id: RR-P5EFFT
+type: review-response
+title: Attachment handlers load a.State() 4x — snapshot-drift on metamodel reload
+finding: 'handleV1PutAttachment calls a.State() separately in maxAttachmentBytes, attachmentWritePreflight->isFileProperty, attachmentService (Meta: a.State().Meta), and filePropertyDef. CLAUDE.md ''capture state once per operation'' — a reload mid-handler can make the handler gate on one snapshot''s PropertyDef while the on-demand Service re-reads a different snapshot''s FileMax(), so the cap the handler enforces and the cap the service enforces disagree. Fix: capture s := a.State() once at the top and thread it (or the resolved Meta + propDef) into all four.'
+severity: significant
+resolution: 'handleV1PutAttachment/handleV1DeleteAttachment now capture s := a.State() once and thread it: maxAttachmentBytes(s), filePropertyDef(s, ...) (now a package func taking the snapshot), and attachmentService(s) (Meta from the same snapshot). The handler''s gating def and the service''s FileMax() now come from one metamodel snapshot, so a mid-handler reload can''t make them disagree.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ROF51F.md
+++ b/tickets/entities/review-responses/RR-ROF51F.md
@@ -1,0 +1,9 @@
+---
+id: RR-ROF51F
+type: review-response
+title: _attachments leaks files of policy-hidden file properties (read-path ACL bypass)
+finding: 'computeAttachments iterates store.ListAttachments directly and emits every property''s files with working download hrefs, ignoring the field-visibility verdicts (FieldVerdicts.Visible) that stripHiddenProperties/_fields enforce. handleV1GetAttachment gates only on entity-read + isFileProperty, never on Visible. So in an ACL deployment with field-level hide policy, a viewer who can read the entity but for whom a file property is hidden still sees the file in _attachments AND can download its bytes via the per-file URL. Only became reachable when _attachments joined the response next to the existing hidden-field machinery. Fix: compute field verdicts once; skip hidden props in computeAttachments AND 404 them in handleV1GetAttachment + the write preflight (both ends — hiding from the map alone leaves the guessable URL downloadable).'
+severity: critical
+resolution: 'Both ends now enforce field visibility. attachEntityAffordances resolves FieldVerdicts once and passes them to computeAttachments, which skips any property where !IsVisible(prop) (so a hidden file property''s files never appear in _attachments). handleV1GetAttachment and attachmentWritePreflight now call a.isPropertyHidden(ctx, entity, property) and 404 a hidden property (so the guessable per-file URL can''t download it either). Added TestAttachment_HiddenPropertyNotLeaked: with a fakeResolver hiding ''screenshot'', _attachments omits it AND the per-file download 404s.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SQE8VA.md
+++ b/tickets/entities/review-responses/RR-SQE8VA.md
@@ -1,0 +1,9 @@
+---
+id: RR-SQE8VA
+type: review-response
+title: FileWidget is inert in edit forms (phantom editable field)
+finding: registry routes file->FileWidget for all modes. FieldRenderer renders with mode='edit' and wires @update:model-value, but FileWidget ignores mode, never emits update, and isn't passed the attachment prop in forms. A file property in a form is now a non-interactive dead control where TextWidget previously let the path string be edited. Upload is a separate ticket, but the widget should render an explicit read-only/disabled affordance in edit mode, with a test.
+severity: significant
+resolution: 'FileWidget now renders an explicit read-only note (''Uploading attachments isn''t available here yet'') in edit mode instead of a phantom editable control, while still showing the current attachment for context. Added two widget tests: edit-mode renders the note + no <input>, and display-mode does not render the note. Upload remains TKT-RXFD5B.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-XB5738.md
+++ b/tickets/entities/review-responses/RR-XB5738.md
@@ -1,0 +1,9 @@
+---
+id: RR-XB5738
+type: review-response
+title: XSS defenses (content-type sniff, SVG sandbox) untested
+finding: 'The endpoint''s whole purpose is safely serving user bytes, but no test exercises the defenses: a deceptive evil.png containing HTML must still serve as image/png + nosniff; an .svg must carry the sandbox CSP + inline disposition. Only the happy shot.png->image/png case is covered. Add negative content-type tests so the load-bearing nosniff/CSP isn''t silently removed later.'
+severity: significant
+resolution: 'Added two negative tests: TestAttachment_DeceptiveExtensionServesTypeFromName (evil.png containing <script> serves as image/png + nosniff) and TestAttachment_SvgIsSandboxed (.svg carries sandbox + default-src ''none'' CSP and inline disposition). These pin the load-bearing XSS defenses so the headers can''t be silently removed.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ZR1FYI.md
+++ b/tickets/entities/review-responses/RR-ZR1FYI.md
@@ -1,0 +1,9 @@
+---
+id: RR-ZR1FYI
+type: review-response
+title: Three ListAttachments per upload under writeMu; minors (schema test, CLI msg, concurrent-cap, stale comment)
+finding: '(#4) WriteAttachment lists for the cap check, stampProperty lists again, then serializeEntityForWire->computeAttachments lists a third time — 3 pgstore round-trips while a.writeMu is held. Fix: pass `existing` into stampProperty (it knows the new name + replace/append) to drop one. (#5) the _schema/{type} single-type endpoint now shares toV1PropertyDef (also emits Description/List/Max) but TestV1SchemaTypesSpecific only asserts Label — add a max/field assertion so the two schema endpoints can''t drift. (#6) CLI Attach/Detach surface ErrAtCapacity as a raw error — map to a friendlier ''remove one first'' message. (#7) cap enforcement assumes serialized writers per entity/property (HTTP via writeMu; concurrent CLI could overshoot) — note it in WriteAttachment''s doc. Nits: stale ''attachmentFileName returns...'' comment above contentTypeForFilename; migration 0003 ''idempotent'' wording (DROP CONSTRAINT not re-runnable — idempotency is the runner''s).'
+severity: minor
+resolution: '(#4) WriteAttachment now computes the post-write file set from the `existing` it already listed (via new pure stampPropertyNames) instead of re-listing in stampProperty — one fewer ListAttachments per upload. (#5) added max/field assertions to TestV1SchemaTypesSpecific (docs.max==3, screenshot.max==0) so the two schema endpoints can''t drift. (#6) CLI attach maps ErrAtCapacity to a friendly ''property is full — detach a file first'' message. (#7) documented the serialized-writer cap assumption in WriteAttachment''s doc. Nits: removed the stale attachmentFileName comment; reworded migration 0003 ''idempotent'' to ''applied exactly once by the runner''.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-40PZ15.md
+++ b/tickets/entities/tickets/TKT-40PZ15.md
@@ -1,0 +1,45 @@
+---
+id: TKT-40PZ15
+type: ticket
+title: 'Pre-attach Lua veto hook: expose file info (name/size/content-type) to a write hook that can reject'
+kind: enhancement
+priority: low
+effort: l
+status: backlog
+---
+
+## Description
+
+Give users a Lua escape hatch to **reject an attachment upload** based on the
+incoming file's metadata (filename, size, content-type) — e.g. enforce a
+per-property MIME allowlist or a tighter size cap for semi-untrusted users,
+beyond the product-wide default limit.
+
+Split out of TKT-RXFD5B after the read-path code review (TKT-Q85275) established
+this is **net-new mechanism**, not a small binding addition.
+
+## Why it's its own ticket (findings)
+
+- **rela has no write-veto hook today.** Write-time Lua runs only via the automation engine, which fires **after** the entity is already persisted (`entitymanager/manager.go`: `upsertEntity` precedes `Cascade.Process`), and is explicitly fire-and-forget — `autocascade/runner.go`: "one bad script does not abort the cascade." Script errors land in `UpdateResult.AutomationErrors`, which **no write path consumes as a hard failure**. So there is no existing hook to extend; a veto is new behavior.
+- **File size/content-type never reach the entity write path.** `attachment.Service.Attach` calls `Store.AttachFile(reader)` then stamps a **path string** onto the property and calls `UpdateEntity`. The entity carries only the path string; size isn't computed and content-type isn't persisted (both are re-derived from the filename on read). So the automation Lua sees `entity.properties.<prop>` = path string, never the bytes/size/content-type.
+- **The only place that holds filename + reader before commit** is inside `attachment.Service.Attach` (between opening the file and `AttachFile`/`UpdateEntity`). A pre-attach veto must be invoked **there**, with a new Lua surface (a file-info table) and a new abort path.
+
+## Scope
+
+- A new **pre-attach hook** invoked from `attachment.Service.Attach` (covers CLI) and the new web upload handler (TKT-RXFD5B), *before* bytes are written, that:
+  - exposes a Lua file-info table: `{ filename, size, content_type, property, entity_id, entity_type }`
+  - lets the script reject (abort the attach with a clear error → 422/4xx on the web path)
+- Respect `internal/dataentry/CLAUDE.md` "tolerate temporarily invalid data": this is an **explicit opt-in gate**, not a tightening of general validation.
+- Decide the binding surface consistent with `ReadDeps`/`WriteDeps` (`internal/lua/deps.go`) and the "Lua only at write time" rule.
+
+## Acceptance
+
+- A project can declare a Lua hook that inspects an incoming attachment and rejects it; the reject surfaces as a clear error on both `rela attach` and the web upload, and **no bytes are persisted** on reject.
+- Allow-path is unaffected; no hook declared → no behavior change.
+
+## Notes
+
+- Depends on TKT-RXFD5B (the web upload handler is one of the two host sites).
+- The product-wide default size limit (TKT-RXFD5B) already covers the common "too big" case; this hook is for richer per-project policy.
+
+Parent: FEAT-870YCY.

--- a/tickets/entities/tickets/TKT-C1ZVTT.md
+++ b/tickets/entities/tickets/TKT-C1ZVTT.md
@@ -1,0 +1,37 @@
+---
+id: TKT-C1ZVTT
+type: ticket
+title: 'Attachment CLI + docs cleanup: multi-file wording, orphan window, doc drift'
+kind: docs
+priority: low
+effort: s
+status: done
+---
+
+## Description
+
+Small correctness/clarity fixes around the existing attachment CLI and docs.
+These are independent of the larger web/MCP work and can land any time.
+
+### Items
+- **Multi-file wording.** `rela attach` accepts a glob and says "Attach file(s)" (`docs/cli-reference.md:315`), but with the current 1:1 model multiple files silently overwrite one slot. Until TKT-WLLRO7 (`max`) lands, make the CLI either reject >1 file for a `max: 1` property with a clear message, or document the overwrite behavior explicitly. After `max` lands, this wording becomes correct — coordinate.
+- **Orphan window note.** `attachment.Service.Attach` writes the file before `UpdateEntity` (`internal/attachment/attachment.go:113`); a failed update orphans the file and the error tells the operator to run `rela gc --temp-files`. Document this in the CLI reference (and ideally tighten the ordering, but at minimum make the behavior discoverable). Note: the web write-path ticket should avoid reintroducing this.
+- **Doc drift.** `docs/metamodel.md:455` says file attachments live in `.rela/attachments/`; the code uses root-relative `attachments/` (`internal/app/factory.go:71` `AttachmentsKey: "attachments"`). Fix the doc.
+- **content_type dead column.** pgstore has a `content_type` column that `AttachFile` never populates (always `''`); content type is inferred at the service `List` layer from the extension. Either populate it on write or note it as intentionally derived. Low priority — capture as a code comment/decision.
+
+### Acceptance
+- CLI help and `docs/cli-reference.md` accurately describe the per-property attachment model.
+- Orphan-recovery behavior is documented.
+- `docs/metamodel.md` attachment path matches the code.
+
+## Resolution (done)
+
+Chose the documentation route for the multi-file item (the behavioral
+`max`/reject change belongs to TKT-WLLRO7, which rewrites this CLI code anyway).
+
+- **Multi-file wording** — `docs/cli-reference.md`: added an explicit note that passing multiple files/globs attaches them to the *same* property in sequence, each overwriting the last, with a forward-pointer to the `max` work (TKT-WLLRO7). CLI behavior left unchanged.
+- **Orphan window** — `docs/cli-reference.md`: documented under `rela attach` that the file is written before the property update and a failed update leaves an orphan recoverable via `rela gc --temp-files`.
+- **Doc drift** — `docs/metamodel.md:455`: `.rela/attachments/` → `attachments/`. Verified no other `.rela/attachments` references remain in `docs/`.
+- **content_type dead column** — `internal/store/pgstore/attachment.go`: added comments at both the write site (column intentionally left at `''` default) and the read site (always `''`, content type derived at the service layer via `contentTypeForName`; selected for forward-compat only). Chose to document rather than populate, since deriving at write time would duplicate the service-layer logic. `go build -tags postgres ./internal/store/pgstore/` passes.
+
+Parent: FEAT-870YCY.

--- a/tickets/entities/tickets/TKT-Q85275.md
+++ b/tickets/entities/tickets/TKT-Q85275.md
@@ -1,0 +1,48 @@
+---
+id: TKT-Q85275
+type: ticket
+title: 'Attachment web read path: ACL-gated download endpoint + file widget/preview'
+kind: enhancement
+priority: high
+effort: m
+status: done
+---
+
+## Description
+
+Make attached files **viewable through the data-entry web app**. This is the
+highest-leverage gap: today a `file` property renders as a plain text input
+showing the stored path string (`frontend/src/widgets/registry.ts:100`), and
+there is no HTTP endpoint that serves attachment bytes — so for a **postgres
+deployment, attached files are completely unreachable** (bytes live in `BYTEA`).
+
+Ships first and is independently useful: it lets users *view* attachments that
+already exist before upload UX lands.
+
+### Backend
+- New data-entry HTTP endpoint to serve an attachment's bytes for `(entityID, property)` via `store.ReadAttachment`, streaming, with correct `Content-Type` (inferred from filename — see `internal/attachment/filename.go:contentTypeForName`) and `Content-Disposition`.
+- **ACL: the attachment inherits the owning entity's ACL.** Gate the endpoint with the same visibility check used for entity reads in dataentry (the `acl_*_test.go` suite is the contract). A caller who cannot read the entity must not read its attachment. Replace the `acl.NopACL{}` wiring on the read path.
+- List endpoint (or extend the entity GET payload) so the frontend knows which properties have attachments + filename/size/content-type.
+
+### ACL soundness — entity-first resolution (critical)
+
+The storage layer already keys attachments under the entity ID (fsstore path
+`attachments/<entityID>/<property>/...` and index key `entityID/property`;
+pgstore PK `(entity_id, property)`; `AttachFile` rejects writes for a
+non-existent entity). ACL inheritance relies on that, but the **endpoint must
+not trust the stored path string** as the access key:
+
+- The route carries `(entityID, property)`; resolve **entity → ACL check → bytes** in that order. Derive the entity ID from the request, **never** parse/serve the `attachments/...` path string stamped in frontmatter, and never serve a caller-supplied path verbatim (path-traversal / `../` surface, and would let a caller reach a file whose entity they can't read).
+- **Rename consistency.** `renameAttachmentDir` (`internal/store/fsstore/attachment.go:206`) moves the directory and re-keys the in-memory index, but does **not** re-stamp the entity's `property` value, which still holds the old `attachments/<oldID>/...` string. That stale pointer is both a latent correctness bug (frontmatter points at a moved path) and an ACL-soundness hazard (file associated with a historical ID). The access path must resolve via the **canonical current entity ID**; either re-stamp the property on rename or have the read path ignore the literal stored string and reconstruct from `(currentEntityID, property)`. Add a rename test.
+
+### Frontend
+- Replace `TextWidget` for `file`-type properties with a read-capable file widget: show filename + size, a download link, and inline preview for images (and ideally PDFs). Falls back to a download affordance for other types.
+- Register in `frontend/src/widgets/registry.ts` for `supportedPropertyTypes: ['file']`.
+
+### Acceptance
+- Viewing an entity with an attachment shows the file (preview for images) and a working download, on both fsstore and pgstore builds.
+- A user without read access to the entity gets 403/404 on the attachment endpoint (covered by an `acl_*` test).
+- Attachment access resolves by current entity ID; a renamed entity's attachment is still reachable and still ACL-gated (rename test).
+- No regression to the existing CLI attach/detach/list.
+
+Parent: FEAT-870YCY. Pairs with the web write-path ticket.

--- a/tickets/entities/tickets/TKT-R6U15C.md
+++ b/tickets/entities/tickets/TKT-R6U15C.md
@@ -1,0 +1,30 @@
+---
+id: TKT-R6U15C
+type: ticket
+title: 'MCP attachment tool: attach/list/read for agents, ACL-gated'
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+## Description
+
+Give MCP agents the ability to work with attachments. Today `internal/mcp/` has
+no attachment tool, so an agent can create/update entities but can neither
+attach a file nor read one back.
+
+### Scope
+- MCP tool(s) over the existing `store.AttachmentManager` / `attachment.Service`: list attachments for an entity, read an attachment's bytes (or a reference the client can fetch), and attach a file. Follow the consumer-side `mcp.Services` interface pattern (CLAUDE.md) rather than widening a god interface.
+- **ACL: inherit the owning entity's ACL** — consistent with the web and CLI paths. An agent that can't read the entity can't read its attachment.
+- Respect the default size limit (shared write-path enforcement from TKT-RXFD5B).
+
+### Acceptance
+- An agent can list, attach, and read attachments through MCP.
+- ACL is enforced (test).
+- Honors `max` once TKT-WLLRO7 lands (build the tool tolerant of N-per-property).
+
+### Notes
+- Secondary priority — sequence after the web path. Reading binary bytes over MCP may warrant returning a fetchable reference rather than inlining large blobs; decide during planning.
+
+Parent: FEAT-870YCY.

--- a/tickets/entities/tickets/TKT-RXFD5B.md
+++ b/tickets/entities/tickets/TKT-RXFD5B.md
@@ -1,0 +1,41 @@
+---
+id: TKT-RXFD5B
+type: ticket
+title: 'Attachment web write path: upload endpoint + drag-drop widget + default size limit + Lua file info'
+kind: enhancement
+priority: high
+effort: l
+status: done
+---
+
+## Description
+
+Let users **attach and remove files through the data-entry web app**, and fix
+the inconsistent/unbounded size limits while doing it. Builds on the read-path
+ticket (TKT-Q85275).
+
+**Scope note:** the "expose file info to Lua" item was **split out to
+TKT-40PZ15** after the TKT-Q85275 review established it's a net-new write-veto
+mechanism (rela has no pre-write Lua veto; file size/content-type never reach
+the entity write path), not a small binding. The product-wide default size limit
+below covers the common case.
+
+### Backend
+- New data-entry **upload** (PUT/POST) and **delete** (DELETE) handling on the existing `_attachments` route, method-dispatched alongside the GET read handler. Upload writes via `store.AttachFile` then stamps the property + persists via `entitymanager.UpdateEntity` (mirrors `attachment.Service.Attach`); delete clears the property then `store.DeleteAttachment`.
+- **ACL: inherit the owning entity's `update` permission.** Re-authorize **up front** via `translateVerb("update", type, id)` + `a.acl.AuthorizeWrite` (mirrors `authorizeConflictResolve`) so a deny happens *before* any bytes are written — avoids the orphan window. Read-gate first (uniform 404). Cover with an `acl_*` test. (Do not construct `acl.WriteRequest` directly — `lint_test.go` forbids it outside `affordances.go`; go through `translateVerb`.)
+- **Sane default size limit, enforced ingress + per-store backstop** (decision): cap at the handler via `http.MaxBytesReader` (clean 413 as `application/problem+json` via `writeV1Error`), AND add a `maxAttachmentBytes` guard to fsstore + memstore so **no backend is ever unbounded** (pgstore already has one at `internal/store/pgstore/attachment.go:22`). Default ~screenshots/PDFs sized (start from pgstore's 64 MiB), made configurable via `dataentryconfig.Config` with a Go-constant default.
+
+### Frontend
+- File-picker + drag-drop on the file widget (extends the read-only `FileWidget` from TKT-Q85275): upload, show progress, replace/remove. Gate the controls on `entity._actions?.update !== false` (the SPA affordance convention). Surface server-side size/validation errors inline (reuse the 422/problem+json rendering).
+
+### Acceptance
+- Upload, view, replace, and delete an attachment end-to-end in the web app on fsstore and pgstore.
+- A file over the default limit is rejected with a clear error on **all** backends (fsstore/memstore/pgstore), not just pgstore — handler returns 413, and the store guard rejects too (unit-tested per backend).
+- A user without entity `update` access cannot upload/delete (acl test) — denied before any bytes are written.
+- Orphan window closed for the web path: an ACL deny or validation failure on upload leaves no orphaned bytes.
+
+### Notes / dependencies
+- Multi-file (`max`) is a separate ticket (TKT-WLLRO7); build the widget/endpoint so adding N-per-property later is not a rewrite.
+- Lua file-info veto: TKT-40PZ15 (depends on this ticket's upload handler as a host site).
+
+Parent: FEAT-870YCY.

--- a/tickets/entities/tickets/TKT-WLLRO7.md
+++ b/tickets/entities/tickets/TKT-WLLRO7.md
@@ -1,0 +1,76 @@
+---
+id: TKT-WLLRO7
+type: ticket
+title: 'Configurable per-property attachment count: file property `max` setting (1..N)'
+kind: enhancement
+priority: medium
+effort: l
+status: done
+---
+
+## Description
+
+Move attachments from **1:1 per property** to **configurable N-per-property**
+via a `max` setting on the metamodel `file` property. Use cases like "a few
+supporting PDFs on a decision" need N-per-property. Sequenced **before** the
+feature ships externally so the wire contract is locked once (nothing is
+committed yet — no back-compat constraint).
+
+## Locked design (research-backed — see RES findings on the ticket)
+
+**Identifier = filename-as-key.** Store key `(entityID, property, fileName)`.
+The research established that an opaque/UUID id buys **no security** here —
+access is gated by the *owning entity's* read permission (re-checked on every
+byte request, with the RR-NGMI indistinguishability invariant), so a guessable
+attachment id leaks nothing you weren't already handed in `_attachments` and
+can't reach an entity you can't read. Filename-as-key also gives the cheapest
+migration (filename is already the on-disk leaf + the pgstore `file_name` column
+→ migration is "add file_name to the PK", forward-only/idempotent).
+
+**Normalization + auto-suffix.** Filenames are normalized to a safe key
+(reuse/extend `safeAttachmentFilename` + `storeutil`). On collision within a
+property (same normalized name, under `max`), **auto-suffix** like a file
+manager: `file.png` → `file (1).png` → `file (2).png`. Never lose a file.
+Consequence: there is no separate "replace" verb — every upload adds (suffixing
+on collision) or hits the `max` ceiling; "replace" in the UI = remove-then-add.
+
+**Wire shape = always-list.** `_attachments[property]` becomes an **array** of
+`V1Attachment` even for `max:1` (a 1-element array). This matches rela's
+established convention (`list: true` properties and `_relations` are always
+arrays, never scalar-when-one) and avoids the polymorphic `Array.isArray` branch
+at all 8+ frontend consumer sites + the shape-flip footgun when `max` changes.
+`V1Attachment` gains an `id` field (the normalized filename) so per-file
+URLs/delete can target it.
+
+### Metamodel
+- `file` property gains optional `max` (default 1). Validate `max >= 1`. Document in `docs/metamodel.md`.
+
+### Store (3 backends + pg migration)
+- Key `(entityID, property, fileName)`. fsstore: `attachments/<id>/<prop>/<fileName>` (already the layout — index key gains the filename). memstore: map key `entityID/property/fileName`. pgstore: PRIMARY KEY → `(entity_id, property, file_name)`, forward-only migration.
+- New/updated `AttachmentManager` surface: `AttachFile` appends (no longer overwrites by property); add the ability to read/delete a **specific** `(entityID, property, fileName)`; `ListAttachments` already returns per-file rows. Keep cascade-on-delete/rename working. Pass `internal/store/storetest` (new cases: N-per-property, suffix-on-collision, per-file delete, cascade).
+- The entity property value becomes a **list** of filenames (or paths) when populated. Decide the exact stored representation in planning (list of filenames vs list of path strings) — keep it consistent with `entity.SetString`/list handling.
+
+### API (always-list + per-file ops)
+- `_attachments[property]: []V1Attachment` with `id` (normalized filename). `computeAttachments` appends per file.
+- Upload `PUT/POST /_attachments/{property}` appends up to `max` (auto-suffix on name collision); rejects with a clear error (409/422) when at `max`.
+- Per-file download + delete: `GET|DELETE /_attachments/{property}/{fileName}`. Bare `/_attachments/{property}` GET can 404 or list; delete of a specific file by id. Keep the up-front `update`-authorize + read-gate + uniform-404 invariants from TKT-RXFD5B.
+- Update `docs/data-entry/api-reference.md`.
+
+### CLI
+- `rela attach` appends up to `max` (auto-suffix on collision); errors when over. `rela detach` disambiguates by filename when a property holds more than one.
+
+### Frontend (multi-file widget)
+- FileWidget renders a **list**: per-file preview (images)/download/remove; an add control (picker + drag-drop) disabled at `max`. Thread the array through PropertyDisplay / FieldRenderer / SectionEditForm / DynamicForm (all currently single-`AttachmentInfo`). Update widget + form tests.
+
+### Acceptance
+- A `file` property with `max: 3` holds up to 3 files; the 4th is rejected clearly. Uploading a duplicate name auto-suffixes.
+- `max: 1` (default) behaves like today except the wire is a 1-element array.
+- storetest conformance passes on all backends; pg migration forward-only + idempotent; existing single-attachment data migrates cleanly.
+- Web: add/preview/download/remove multiple files; add disabled at max.
+
+### Decisions (user)
+- Filename-as-key (not UUID — no security benefit given the entity ACL). Normalization required.
+- Auto-suffix on same-name collision.
+- Always-list wire shape.
+
+Parent: FEAT-870YCY.

--- a/tickets/relations/FEAT-870YCY--requires--authorization.md
+++ b/tickets/relations/FEAT-870YCY--requires--authorization.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-870YCY
+relation: requires
+to: authorization
+---

--- a/tickets/relations/FEAT-870YCY--requires--data-entry-server.md
+++ b/tickets/relations/FEAT-870YCY--requires--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-870YCY
+relation: requires
+to: data-entry-server
+---

--- a/tickets/relations/FEAT-870YCY--requires--store-backends.md
+++ b/tickets/relations/FEAT-870YCY--requires--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-870YCY
+relation: requires
+to: store-backends
+---

--- a/tickets/relations/TKT-40PZ15--affects--lua-scripting.md
+++ b/tickets/relations/TKT-40PZ15--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-40PZ15
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-40PZ15--implements--FEAT-870YCY.md
+++ b/tickets/relations/TKT-40PZ15--implements--FEAT-870YCY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-40PZ15
+relation: implements
+to: FEAT-870YCY
+---

--- a/tickets/relations/TKT-C1ZVTT--affects--cli-flags.md
+++ b/tickets/relations/TKT-C1ZVTT--affects--cli-flags.md
@@ -1,0 +1,5 @@
+---
+from: TKT-C1ZVTT
+relation: affects
+to: cli-flags
+---

--- a/tickets/relations/TKT-C1ZVTT--has-review--REV-0O5MG3.md
+++ b/tickets/relations/TKT-C1ZVTT--has-review--REV-0O5MG3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-C1ZVTT
+relation: has-review
+to: REV-0O5MG3
+---

--- a/tickets/relations/TKT-C1ZVTT--implements--FEAT-870YCY.md
+++ b/tickets/relations/TKT-C1ZVTT--implements--FEAT-870YCY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-C1ZVTT
+relation: implements
+to: FEAT-870YCY
+---

--- a/tickets/relations/TKT-Q85275--affects--authorization.md
+++ b/tickets/relations/TKT-Q85275--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q85275
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-Q85275--affects--data-entry-server.md
+++ b/tickets/relations/TKT-Q85275--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q85275
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-Q85275--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-Q85275--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q85275
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-Q85275--has-docs--DOCS-KU30G9.md
+++ b/tickets/relations/TKT-Q85275--has-docs--DOCS-KU30G9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q85275
+relation: has-docs
+to: DOCS-KU30G9
+---

--- a/tickets/relations/TKT-Q85275--has-implementation--IMPL-RF6G6C.md
+++ b/tickets/relations/TKT-Q85275--has-implementation--IMPL-RF6G6C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q85275
+relation: has-implementation
+to: IMPL-RF6G6C
+---

--- a/tickets/relations/TKT-Q85275--has-planning--PLAN-TCHUKN.md
+++ b/tickets/relations/TKT-Q85275--has-planning--PLAN-TCHUKN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q85275
+relation: has-planning
+to: PLAN-TCHUKN
+---

--- a/tickets/relations/TKT-Q85275--has-review--REV-6UULOC.md
+++ b/tickets/relations/TKT-Q85275--has-review--REV-6UULOC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q85275
+relation: has-review
+to: REV-6UULOC
+---

--- a/tickets/relations/TKT-Q85275--has-review-response--RR-601TJD.md
+++ b/tickets/relations/TKT-Q85275--has-review-response--RR-601TJD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q85275
+relation: has-review-response
+to: RR-601TJD
+---

--- a/tickets/relations/TKT-Q85275--has-review-response--RR-FKJYMC.md
+++ b/tickets/relations/TKT-Q85275--has-review-response--RR-FKJYMC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q85275
+relation: has-review-response
+to: RR-FKJYMC
+---

--- a/tickets/relations/TKT-Q85275--has-review-response--RR-SQE8VA.md
+++ b/tickets/relations/TKT-Q85275--has-review-response--RR-SQE8VA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q85275
+relation: has-review-response
+to: RR-SQE8VA
+---

--- a/tickets/relations/TKT-Q85275--has-review-response--RR-XB5738.md
+++ b/tickets/relations/TKT-Q85275--has-review-response--RR-XB5738.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q85275
+relation: has-review-response
+to: RR-XB5738
+---

--- a/tickets/relations/TKT-Q85275--implements--FEAT-870YCY.md
+++ b/tickets/relations/TKT-Q85275--implements--FEAT-870YCY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Q85275
+relation: implements
+to: FEAT-870YCY
+---

--- a/tickets/relations/TKT-R6U15C--affects--authorization.md
+++ b/tickets/relations/TKT-R6U15C--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R6U15C
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-R6U15C--affects--mcp-api.md
+++ b/tickets/relations/TKT-R6U15C--affects--mcp-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R6U15C
+relation: affects
+to: mcp-api
+---

--- a/tickets/relations/TKT-R6U15C--implements--FEAT-870YCY.md
+++ b/tickets/relations/TKT-R6U15C--implements--FEAT-870YCY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R6U15C
+relation: implements
+to: FEAT-870YCY
+---

--- a/tickets/relations/TKT-RXFD5B--affects--data-entry-server.md
+++ b/tickets/relations/TKT-RXFD5B--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RXFD5B
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-RXFD5B--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-RXFD5B--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RXFD5B
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-RXFD5B--affects--store-backends.md
+++ b/tickets/relations/TKT-RXFD5B--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RXFD5B
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-RXFD5B--has-docs--DOCS-SXKF2O.md
+++ b/tickets/relations/TKT-RXFD5B--has-docs--DOCS-SXKF2O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RXFD5B
+relation: has-docs
+to: DOCS-SXKF2O
+---

--- a/tickets/relations/TKT-RXFD5B--has-implementation--IMPL-ZFW3F0.md
+++ b/tickets/relations/TKT-RXFD5B--has-implementation--IMPL-ZFW3F0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RXFD5B
+relation: has-implementation
+to: IMPL-ZFW3F0
+---

--- a/tickets/relations/TKT-RXFD5B--has-planning--PLAN-89DEDP.md
+++ b/tickets/relations/TKT-RXFD5B--has-planning--PLAN-89DEDP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RXFD5B
+relation: has-planning
+to: PLAN-89DEDP
+---

--- a/tickets/relations/TKT-RXFD5B--has-review--REV-EIEPNM.md
+++ b/tickets/relations/TKT-RXFD5B--has-review--REV-EIEPNM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RXFD5B
+relation: has-review
+to: REV-EIEPNM
+---

--- a/tickets/relations/TKT-RXFD5B--has-review-response--RR-81XSCY.md
+++ b/tickets/relations/TKT-RXFD5B--has-review-response--RR-81XSCY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RXFD5B
+relation: has-review-response
+to: RR-81XSCY
+---

--- a/tickets/relations/TKT-RXFD5B--has-review-response--RR-AFMZ9S.md
+++ b/tickets/relations/TKT-RXFD5B--has-review-response--RR-AFMZ9S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RXFD5B
+relation: has-review-response
+to: RR-AFMZ9S
+---

--- a/tickets/relations/TKT-RXFD5B--has-review-response--RR-EISJTE.md
+++ b/tickets/relations/TKT-RXFD5B--has-review-response--RR-EISJTE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RXFD5B
+relation: has-review-response
+to: RR-EISJTE
+---

--- a/tickets/relations/TKT-RXFD5B--has-review-response--RR-JIRLLU.md
+++ b/tickets/relations/TKT-RXFD5B--has-review-response--RR-JIRLLU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RXFD5B
+relation: has-review-response
+to: RR-JIRLLU
+---

--- a/tickets/relations/TKT-RXFD5B--implements--FEAT-870YCY.md
+++ b/tickets/relations/TKT-RXFD5B--implements--FEAT-870YCY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RXFD5B
+relation: implements
+to: FEAT-870YCY
+---

--- a/tickets/relations/TKT-WLLRO7--affects--metamodel-types.md
+++ b/tickets/relations/TKT-WLLRO7--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WLLRO7
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-WLLRO7--affects--store-backends.md
+++ b/tickets/relations/TKT-WLLRO7--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WLLRO7
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-WLLRO7--has-docs--DOCS-372ZRT.md
+++ b/tickets/relations/TKT-WLLRO7--has-docs--DOCS-372ZRT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WLLRO7
+relation: has-docs
+to: DOCS-372ZRT
+---

--- a/tickets/relations/TKT-WLLRO7--has-implementation--IMPL-7ZS0SC.md
+++ b/tickets/relations/TKT-WLLRO7--has-implementation--IMPL-7ZS0SC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WLLRO7
+relation: has-implementation
+to: IMPL-7ZS0SC
+---

--- a/tickets/relations/TKT-WLLRO7--has-planning--PLAN-ZFQPKQ.md
+++ b/tickets/relations/TKT-WLLRO7--has-planning--PLAN-ZFQPKQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WLLRO7
+relation: has-planning
+to: PLAN-ZFQPKQ
+---

--- a/tickets/relations/TKT-WLLRO7--has-review--REV-2E21NL.md
+++ b/tickets/relations/TKT-WLLRO7--has-review--REV-2E21NL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WLLRO7
+relation: has-review
+to: REV-2E21NL
+---

--- a/tickets/relations/TKT-WLLRO7--has-review-response--RR-1BS5FH.md
+++ b/tickets/relations/TKT-WLLRO7--has-review-response--RR-1BS5FH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WLLRO7
+relation: has-review-response
+to: RR-1BS5FH
+---

--- a/tickets/relations/TKT-WLLRO7--has-review-response--RR-BN2MDO.md
+++ b/tickets/relations/TKT-WLLRO7--has-review-response--RR-BN2MDO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WLLRO7
+relation: has-review-response
+to: RR-BN2MDO
+---

--- a/tickets/relations/TKT-WLLRO7--has-review-response--RR-CIH3TZ.md
+++ b/tickets/relations/TKT-WLLRO7--has-review-response--RR-CIH3TZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WLLRO7
+relation: has-review-response
+to: RR-CIH3TZ
+---

--- a/tickets/relations/TKT-WLLRO7--has-review-response--RR-N96YV0.md
+++ b/tickets/relations/TKT-WLLRO7--has-review-response--RR-N96YV0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WLLRO7
+relation: has-review-response
+to: RR-N96YV0
+---

--- a/tickets/relations/TKT-WLLRO7--has-review-response--RR-P5EFFT.md
+++ b/tickets/relations/TKT-WLLRO7--has-review-response--RR-P5EFFT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WLLRO7
+relation: has-review-response
+to: RR-P5EFFT
+---

--- a/tickets/relations/TKT-WLLRO7--has-review-response--RR-ROF51F.md
+++ b/tickets/relations/TKT-WLLRO7--has-review-response--RR-ROF51F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WLLRO7
+relation: has-review-response
+to: RR-ROF51F
+---

--- a/tickets/relations/TKT-WLLRO7--has-review-response--RR-ZR1FYI.md
+++ b/tickets/relations/TKT-WLLRO7--has-review-response--RR-ZR1FYI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WLLRO7
+relation: has-review-response
+to: RR-ZR1FYI
+---

--- a/tickets/relations/TKT-WLLRO7--implements--FEAT-870YCY.md
+++ b/tickets/relations/TKT-WLLRO7--implements--FEAT-870YCY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WLLRO7
+relation: implements
+to: FEAT-870YCY
+---


### PR DESCRIPTION
## Summary

Implements the attachment product feature (FEAT-870YCY): a full read/write path for file attachments across the web UI, multi-file-per-property support, ACL enforcement, and CLI. Closes the gaps found in the initial attachment-support audit.

## What's included

- **Web read path** — `_attachments` affordance on entity responses + per-file download routes; `FileWidget` renders attachments with download links.
- **Web write path** — upload (PUT/POST) and per-file delete routes; axios-based upload with a progress bar (works on network deployments). Shared write policy in `internal/attachment` uses **attach-first-then-delete** ordering so a failed write never loses the existing file.
- **Multi-attachment per property** — new `max` property option (`FileMax()`, default 1). Always-list wire shape (`_attachments[property]` is `[]V1Attachment`, matching `_relations`). Attachment key migrated `(entityID, property)` → `(entityID, property, fileName)` across fsstore / memstore / pgstore (+ migration `0003`). filename-as-key with normalization + auto-suffix on collision (`report.pdf` → `report (1).pdf`).
- **Widget UX** — `max == 1` switches to replace mode; `max > 1` shows an add-list with per-file remove.
- **ACL** — read-gate + up-front `update`-authorize on writes; field-visibility filtering so policy-hidden file properties never leak download URLs (`computeAttachments` skips hidden, GET/write handlers 404 hidden).
- **Size limits** — server-enforced `MaxAttachmentBytes` (64 MiB) via `CapAttachmentReader` at the write path.
- **CLI** — `attach` is max-aware (replace vs append, friendly at-capacity message); `detach --file <name>` for per-file removal.

## Tests

New coverage for the write-policy data-loss guards (`TestService_ReplaceFailureKeepsExisting`), the ACL leak (`TestAttachment_HiddenPropertyNotLeaked`), schema `max` exposure, and per-file store conformance. Race detector clean.

## Notes

Docs regenerated from source guides (`just docs`). Remaining backlog (not in this PR): MCP attachment tool (TKT-R6U15C), Lua write-veto hook (TKT-40PZ15).
