### PR TITLE
fix: entity-reference picker backspace recovery + ID-first search ranking

### DIFF
--- a/frontend/src/composables/useBacktickAutocomplete.test.ts
+++ b/frontend/src/composables/useBacktickAutocomplete.test.ts
@@ -3,6 +3,7 @@ import { searchEntities, listEntities } from '@/api'
 import type { Entity, EntityType, ListResponse } from '@/types'
 import {
   buildPrefixList,
+  rankByIdMatch,
   useBacktickAutocomplete,
   type EasyMdeLike,
   OPEN_DELAY_MS,
@@ -199,6 +200,53 @@ describe('buildPrefixList', () => {
   })
 })
 
+describe('rankByIdMatch', () => {
+  const ent = (id: string): Entity => ({ id, type: 'actor', properties: {} })
+
+  it('sorts id-prefix matches ahead of title-only (backend) matches', () => {
+    // Mirrors the reported `VAD-ACT-` case: Bleve returns title-scored
+    // junk (PRS-ACT-*) before the entities whose ID actually starts with
+    // the typed prefix.
+    const backendOrder = [
+      ent('PRS-ACT-BPHC'), // title match only ("Handelende organisatie")
+      ent('PRS-ACT-DWPM'),
+      ent('VAD-ACT-6P4X'), // id-prefix matches — should lead
+      ent('VAD-ACT-CV83'),
+    ]
+    const ranked = rankByIdMatch(backendOrder, 'VAD-ACT-', '')
+    expect(ranked.map((e) => e.id)).toEqual([
+      'VAD-ACT-6P4X',
+      'VAD-ACT-CV83',
+      'PRS-ACT-BPHC',
+      'PRS-ACT-DWPM',
+    ])
+  })
+
+  it('puts an exact id match first', () => {
+    const ranked = rankByIdMatch(
+      [ent('TKT-12'), ent('TKT-1'), ent('TKT-100')],
+      'TKT-',
+      '1',
+    )
+    expect(ranked[0].id).toBe('TKT-1')
+  })
+
+  it('is stable within a rank tier (preserves backend relevance order)', () => {
+    const ranked = rankByIdMatch(
+      [ent('VAD-ACT-B'), ent('VAD-ACT-A')],
+      'VAD-ACT-',
+      '',
+    )
+    // Both are id-prefix matches; original order is kept.
+    expect(ranked.map((e) => e.id)).toEqual(['VAD-ACT-B', 'VAD-ACT-A'])
+  })
+
+  it('ranks id-substring matches ahead of title-only matches', () => {
+    const ranked = rankByIdMatch([ent('PRS-ACT-9'), ent('PRS-XYZ-9')], '', '9')
+    expect(ranked[0].id).toBe('PRS-ACT-9')
+  })
+})
+
 describe('useBacktickAutocomplete', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -374,6 +422,40 @@ describe('useBacktickAutocomplete', () => {
       const [q, type] = searchSpy.mock.calls[0]
       expect(q).toBe('1')
       expect(type).toBe('ticket')
+      ctl.dispose()
+    })
+
+    it('recovers to phase prefix when backspacing across the prefix boundary', async () => {
+      // Regression: once in phase id, backspacing back into the prefix
+      // (e.g. TKT-1 → TKT → TK) left the session stuck in phase id,
+      // feeding the partial prefix into searchEntities as free text. It
+      // should hand control back to the prefix machine — "backspace kills
+      // completion" report.
+      const fake = makeFakeEditor({
+        text: '`',
+        cursor: { line: 0, ch: 1 },
+        tokenAt: () => ({ type: 'formatting formatting-code comment', string: '`' }),
+      })
+      const ctl = useBacktickAutocomplete(fake.editor, () => makeEntityTypes())
+      fake.fire('inputRead', null, { text: ['`'], from: { line: 0, ch: 0 } })
+      vi.advanceTimersByTime(OPEN_DELAY_MS + 10)
+      // Type into the id body.
+      fake.setText('`TKT-1')
+      fake.setCursor({ line: 0, ch: 6 })
+      fake.fire('change')
+      expect(ctl.state.phase).toBe('id')
+      // Backspace across the prefix boundary: TKT-1 → TK.
+      fake.setText('`TK')
+      fake.setCursor({ line: 0, ch: 3 })
+      fake.fire('change')
+      expect(ctl.state.phase).toBe('prefix')
+      // The prefix list is re-derived and filtered to TKT- by "TK".
+      expect(ctl.state.prefixItems.map((p) => p.prefix)).toEqual(['TKT-'])
+      // Re-typing the full prefix re-enters phase id (forward path intact).
+      fake.setText('`TKT-')
+      fake.setCursor({ line: 0, ch: 5 })
+      fake.fire('change')
+      expect(ctl.state.phase).toBe('id')
       ctl.dispose()
     })
 

--- a/frontend/src/composables/useBacktickAutocomplete.ts
+++ b/frontend/src/composables/useBacktickAutocomplete.ts
@@ -212,6 +212,33 @@ export function buildPrefixList(entityTypes: Map<string, EntityType>): PrefixIte
   return items
 }
 
+/** Rank-tier an entity by how its ID relates to what the user typed.
+ *  Lower is better. The query is the id-body partial (prefix already
+ *  stripped by the caller); we reconstruct the full typed id as
+ *  `prefix + query` to test against each entity's ID. */
+function idMatchRank(id: string, prefix: string, query: string): number {
+  const upperId = id.toUpperCase()
+  const typedId = (prefix + query).toUpperCase()
+  if (query !== '' && upperId === typedId) return 0 // exact id
+  if (typedId !== '' && upperId.startsWith(typedId)) return 1 // id-prefix match
+  if (query !== '' && upperId.includes(query.toUpperCase())) return 2 // id substring
+  return 3 // title-only match (backend relevance)
+}
+
+/** Re-rank entity search results so ID matches lead while preserving the
+ *  backend's relevance order within each tier (stable sort). Exported for
+ *  unit testing. See `runSearch` for why this is client-side. */
+export function rankByIdMatch(
+  entities: Entity[],
+  prefix: string,
+  query: string,
+): Entity[] {
+  return entities
+    .map((e, i) => ({ e, i, rank: idMatchRank(e.id, prefix, query) }))
+    .sort((a, b) => a.rank - b.rank || a.i - b.i)
+    .map((x) => x.e)
+}
+
 /** Driver. Wires the session to a live EasyMDE instance and returns a
  *  controller the parent component (popup + MarkdownEditor) consumes. */
 export function useBacktickAutocomplete(
@@ -400,7 +427,14 @@ export function useBacktickAutocomplete(
         query.length >= MIN_SEARCH_LEN
           ? await searchEntities(query, type, abort.signal)
           : await listEntities(type, { per_page: MAX_RESULTS })
-      state.entityItems = resp.data.slice(0, MAX_RESULTS)
+      // Bleve scores by title-token relevance, so for an id-prefix query
+      // like `VAD-ACT-` the entities the user is clearly targeting (whose
+      // ID starts with that prefix) get buried under loose title matches.
+      // The user has already committed to a type; re-rank client-side so
+      // ID matches lead. Stable within a rank tier preserves the
+      // backend's relevance order as the tie-breaker.
+      const ranked = rankByIdMatch(resp.data, state.resolvedPrefix.prefix, query)
+      state.entityItems = ranked.slice(0, MAX_RESULTS)
       state.errorMsg = ''
       state.highlightedIndex = 0
     } catch (err: unknown) {
@@ -467,13 +501,42 @@ export function useBacktickAutocomplete(
     }, openDelay)
   }
 
+  /** True when `typed` still begins with the resolved prefix (the
+   *  conventional `<PREFIX>-<id>` shape), i.e. the user is genuinely in
+   *  the id-body of that type. Used to detect a backspace that has
+   *  retreated across the prefix boundary so we can hand control back to
+   *  the prefix machine. */
+  function typedStillMatchesResolved(typed: string): boolean {
+    const prefix = state.resolvedPrefix?.prefix ?? ''
+    if (prefix === '') return true // manual type: no prefix to retreat across
+    return typed.toUpperCase().startsWith(prefix.toUpperCase())
+  }
+
   /** Re-evaluate the phase machine given the current typed-after-trigger
    *  text. Single source of truth for "the user typed something; now
    *  what does the popup show?" — called both from the open-delay timer
    *  (to handle prefix text typed while the popup was pending) and from
    *  the `change` event handler. Idempotent: safe to call when phase is
-   *  idle (no-op). */
+   *  idle (no-op).
+   *
+   *  Symmetric on backspace: when the user deletes back across the
+   *  resolved prefix boundary (e.g. `VAD-ACT-X` → `VAD-AC`), phase `id`
+   *  hands control back to the prefix machine instead of feeding the
+   *  now-partial prefix into the entity search as free text (which
+   *  returned title-scored noise — the "backspace kills completion"
+   *  report). */
   function applyTypedToPhase(typed: string): void {
+    if (state.phase === 'id' && !typedStillMatchesResolved(typed)) {
+      // Backspaced out of the id body. Rebuild the prefix list and let
+      // the prefix path below re-resolve (it may immediately re-enter
+      // phase id if `typed` is still an exact/longer prefix match).
+      state.phase = 'prefix'
+      state.resolvedPrefix = null
+      state.entityItems = []
+      allPrefixes = buildPrefixList(entityTypes())
+      state.prefixItems = allPrefixes
+      state.highlightedIndex = 0
+    }
     if (state.phase === 'prefix') {
       filterPrefixList(typed)
       if (state.phase !== 'prefix') return // filterPrefixList may have closed us

--- a/internal/search/bleveindex/bleveindex.go
+++ b/internal/search/bleveindex/bleveindex.go
@@ -27,7 +27,8 @@ var _ search.Backend = (*Index)(nil)
 
 // Field boost weights for search ranking.
 const (
-	boostID         = 5.0
+	boostIDExact    = 8.0
+	boostIDPrefix   = 6.0
 	boostPrimary    = 3.0
 	boostProperties = 2.0
 	boostContent    = 1.0
@@ -197,12 +198,15 @@ func (idx *Index) bumpLastModified(t time.Time) error {
 	return idx.index.SetInternal(lastModifiedKey, data)
 }
 
-// boostedFields defines the fields to search with their boost weights.
+// boostedFields defines the text fields searched per word with their
+// boost weights. The keyword `id` field is intentionally absent: it is
+// case-sensitive and unanalyzed, so a lower-cased per-word fuzzy query
+// never matches it. ID matching is handled by the dedicated exact-term
+// and prefix queries in Search.
 var boostedFields = []struct {
 	field string
 	boost float64
 }{
-	{"id", boostID},
 	{"primary", boostPrimary},
 	{"properties", boostProperties},
 	{"content", boostContent},
@@ -216,13 +220,30 @@ func (idx *Index) Search(text string, limit int) ([]string, error) {
 		return nil, nil
 	}
 
-	queries := make([]query.Query, 0, len(words)+1)
+	queries := make([]query.Query, 0, len(words)+2)
 
-	// Exact ID match (keyword field) — boosted highest.
-	idQuery := bleve.NewTermQuery(text)
-	idQuery.SetField("id")
-	idQuery.SetBoost(boostID)
-	queries = append(queries, idQuery)
+	// The `id` field is keyword-analyzed (whole ID stored as one
+	// case-sensitive token), so ID matching is driven by these two
+	// queries rather than the per-word fuzzy pass — which tokenizes a
+	// dashed ID like `VAD-ACT-6P4X` into `vad`/`act`/`6p4x` and can't
+	// bridge a partial-ID query back to the original token.
+	idText := strings.TrimSpace(text)
+
+	// Exact ID match — boosted highest.
+	idExact := bleve.NewTermQuery(idText)
+	idExact.SetField("id")
+	idExact.SetBoost(boostIDExact)
+	queries = append(queries, idExact)
+
+	// Partial ID (prefix) match. Case-sensitive against the stored token,
+	// so feed the original-case text — IDs are upper-case and lower-casing
+	// here would match nothing. This is what makes typing `VAD-ACT-` in
+	// the entity-reference picker surface every `VAD-ACT-*` entity instead
+	// of title-scored noise.
+	idPrefix := bleve.NewPrefixQuery(idText)
+	idPrefix.SetField("id")
+	idPrefix.SetBoost(boostIDPrefix)
+	queries = append(queries, idPrefix)
 
 	for _, word := range words {
 		queries = append(queries, buildBoostedWordQuery(strings.ToLower(word)))

--- a/internal/search/bleveindex/bleveindex_test.go
+++ b/internal/search/bleveindex/bleveindex_test.go
@@ -70,6 +70,56 @@ func TestIndex_SearchByID(t *testing.T) {
 	assert.Contains(t, ids, "FEAT-42")
 }
 
+func TestIndex_SearchByIDPrefix(t *testing.T) {
+	// A partial ID like `VAD-ACT-` must match every `VAD-ACT-*` entity and
+	// rank them above entities that only match incidentally via their
+	// title. Before the id-prefix query was added, the keyword `id` field
+	// only answered exact full-ID term queries, so this query returned
+	// title-scored noise (or nothing) — the rel-picker relevance report.
+	idx := newTestIndex(t)
+
+	seed := []struct{ id, title string }{
+		{"PRS-ACT-BPHC", "Handelende organisatie"},
+		{"PRS-ACT-DWPM", "Afnemende organisatie"},
+		{"VAD-ACT-6P4X", "Gegevensuitwisselingspartners"},
+		{"VAD-ACT-CV83", "VAD-realisator-burger-authenticatie"},
+		{"VAD-ACT-F7A4", "VAD-realisator-beveiligd"},
+	}
+	for _, s := range seed {
+		e := entity.New(s.id, "actor")
+		e.SetString("title", s.title)
+		require.NoError(t, idx.EntityPut(e))
+	}
+
+	ids, err := idx.Search("VAD-ACT-", 20)
+	require.NoError(t, err)
+
+	// All three VAD-ACT-* entities are found...
+	assert.Subset(t, ids, []string{"VAD-ACT-6P4X", "VAD-ACT-CV83", "VAD-ACT-F7A4"})
+	// ...and rank ahead of any PRS-ACT-* that only matched on title tokens.
+	// The first three hits are exactly the id-prefix matches, in some order.
+	require.GreaterOrEqual(t, len(ids), 3)
+	assert.ElementsMatch(t,
+		[]string{"VAD-ACT-6P4X", "VAD-ACT-CV83", "VAD-ACT-F7A4"},
+		ids[:3],
+		"id-prefix matches must occupy the top ranks, got %v", ids)
+}
+
+func TestIndex_SearchByIDPrefix_CaseSensitiveToken(t *testing.T) {
+	// The prefix query runs against the unanalyzed (case-sensitive)
+	// keyword token, but real callers may type lower-case. Guard that the
+	// common upper-case ID prefix path works; lower-case partial-ID search
+	// is a known limitation handled by the caller, not asserted here.
+	idx := newTestIndex(t)
+	e := entity.New("TKT-ABCD", "ticket")
+	e.SetString("title", "Example")
+	require.NoError(t, idx.EntityPut(e))
+
+	ids, err := idx.Search("TKT-", 10)
+	require.NoError(t, err)
+	assert.Contains(t, ids, "TKT-ABCD")
+}
+
 func TestIndex_SearchByProperty(t *testing.T) {
 	idx := newTestIndex(t)
 

--- a/tickets/entities/automated-measures/bleve-id-prefix-ranking-test.md
+++ b/tickets/entities/automated-measures/bleve-id-prefix-ranking-test.md
@@ -1,0 +1,20 @@
+---
+id: bleve-id-prefix-ranking-test
+type: automated-measure
+title: Bleve id-prefix ranking regression test
+description: TestIndex_SearchByIDPrefix in internal/search/bleveindex/bleveindex_test.go seeds PRS-ACT-* (title-only) and VAD-ACT-* (id-prefix) entities, searches 'VAD-ACT-', and asserts the id-prefix matches occupy the top ranks. Fails CI if the bleve id-field exact/prefix boosting regresses. Paired with a backspace-across-prefix recovery test in useBacktickAutocomplete.test.ts on the frontend layer.
+kind: test
+location: internal/search/bleveindex/bleveindex_test.go
+status: active
+---
+
+## What it guards
+
+The entity-reference picker relevance fix (BUG-O09QUC): typing an ID prefix must
+rank ID-prefix matches above incidental title matches.
+
+## Test
+
+`TestIndex_SearchByIDPrefix` (`internal/search/bleveindex/bleveindex_test.go`)
+reproduces the reported `VAD-ACT-` scenario and asserts the three `VAD-ACT-*`
+entities occupy the top three ranks ahead of `PRS-ACT-*` title-only matches.

--- a/tickets/entities/bugs/BUG-O09QUC.md
+++ b/tickets/entities/bugs/BUG-O09QUC.md
@@ -1,0 +1,52 @@
+---
+id: BUG-O09QUC
+type: bug
+title: 'Inline entity-reference picker: backspace kills completion + ID-prefix search ranking is poor'
+description: 'The markdown editor''s backtick-triggered entity-reference autocomplete (BacktickAutocompletePopup / useBacktickAutocomplete) had two issues. (1) Backspace killed completion: once the picker resolved an ID prefix and entered phase ''id'', backspacing back across the prefix boundary left the session stuck in phase ''id'', feeding the now-partial prefix into the entity search as free text instead of handing control back to the prefix machine. (2) Poor relevancy: typing an ID prefix like ''VAD-ACT-'' surfaced loosely-matching titles above the entities whose IDs actually start with that prefix. Verified against the live tickets/ corpus — before the fix a ''BUG-'' search returned zero BUG-* entities in the top 8 (all RR-* whose titles contain the word ''bug'').'
+priority: medium
+effort: s
+why1: Once in phase 'id', useBacktickAutocomplete only advanced the phase machine forward; backspacing across the resolved-prefix boundary never returned control to the prefix machine, so the partial prefix was searched as free text.
+why2: applyTypedToPhase only handled the prefix→id transition, not the symmetric id→prefix retreat, so the backspace direction was unhandled. Separately, the bleve 'id' field is keyword-analyzed (whole ID = one token) but the only ID query was an exact term query, so a partial prefix matched nothing and fuzzy title tokens dominated ranking.
+why3: The phase machine was written for the forward typing path only, and the search backend had no prefix query on the id field — partial-ID matching was never a modeled case for either layer.
+why4: Tests exercised forward typing and exact full-ID search (TestIndex_SearchByID), but neither a backspace-across-prefix sequence nor a partial-ID-prefix ranking case, so the gap was invisible in CI.
+why5: 'Systemic: incremental-search UIs need symmetric edit handling (every forward transition needs its reverse) and ID-prefix relevance is a first-class query shape, not an afterthought — both layers modeled only the happy path and lacked tests for the inverse/partial cases.'
+prevention: 'Added regression tests on both layers: a backspace-across-prefix recovery test in useBacktickAutocomplete.test.ts and TestIndex_SearchByIDPrefix in bleveindex_test.go (reproducing the exact VAD-ACT- scenario, asserting id-prefix matches occupy the top ranks). The durable guard is the bleveindex id-prefix test, which fails CI if id-prefix ranking regresses.'
+status: ready
+---
+
+## Symptom
+
+Two complaints about the markdown editor's  ` -triggered entity-reference picker
+(the "Entities matching VAD-ACT-…" popup):
+
+1. **Backspace kills search completion** — after the picker resolves a prefix,
+backspacing a character makes the dropdown go empty / stop completing.
+2. **Poor search relevancy** — typing an ID prefix like `VAD-ACT- ` ranks
+loosely-matching titles above the entities whose IDs start with the prefix.
+
+## Root cause
+
+- **Frontend** (`useBacktickAutocomplete.ts `): the phase machine
+(`prefix → id `) only moved forward. Once in phase `id `, backspacing back
+across the prefix boundary never handed control back to the prefix machine, so
+the partial prefix was fed into entity search as free text.
+- **Backend** (`bleveindex.go `): the `id ` field is keyword-analyzed (whole ID
+is one token), but the only ID query was an **exact term** query. A partial
+prefix matched nothing, so fuzzy title tokens dominated. Probed against the real
+`tickets/ ` repo, a `BUG- ` search returned **zero `BUG-* ` entities in the top
+8** — all `RR-* ` whose titles contain the word "bug".
+
+## Fix
+
+- Symmetric backspace: phase `id ` hands control back to the prefix machine when
+typed text retreats across the prefix boundary.
+- `rankByIdMatch `: client-side tier ranking (exact ID → ID-prefix → substring →
+title-only), backend-agnostic — the autocomplete sends a prefix-stripped body
+query and the three backends each rank differently.
+- Bleve: added a **prefix query** on the `id ` field (boost 6.0) + split the
+exact-ID boost to 8.0; helps full-prefix callers (card picker, command palette,
+raw `/_search `).
+
+## Fixed by
+
+PR sourcehaven-bv/rela#1031.

--- a/tickets/relations/BUG-O09QUC--adds-measure--bleve-id-prefix-ranking-test.md
+++ b/tickets/relations/BUG-O09QUC--adds-measure--bleve-id-prefix-ranking-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-O09QUC
+relation: adds-measure
+to: bleve-id-prefix-ranking-test
+---

--- a/tickets/relations/BUG-O09QUC--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-O09QUC--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-O09QUC
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-O09QUC--fixes--FEAT-014.md
+++ b/tickets/relations/BUG-O09QUC--fixes--FEAT-014.md
@@ -1,0 +1,5 @@
+---
+from: BUG-O09QUC
+relation: fixes
+to: FEAT-014
+---


### PR DESCRIPTION
## Problem

A user reported that the markdown editor's `` ` ``-triggered entity-reference picker (the "Entities matching VAD-ACT-…" popup) had two issues:

1. **Backspace kills search completion** — backspacing back across the resolved prefix boundary left the picker stuck, feeding the partial prefix into search as free text.
2. **Poor relevancy** — typing an ID prefix like `VAD-ACT-` surfaced loosely-matching titles above the entities whose IDs actually start with that prefix.

## Root causes

- **Frontend** (`useBacktickAutocomplete.ts`): the phase machine (`prefix → id`) only moved forward. Once in phase `id`, backspacing across the prefix boundary never handed control back to the prefix machine.
- **Backend** (`bleveindex.go`): the `id` field is keyword-analyzed (whole ID = one token), but the only ID query was an **exact term** query. A partial prefix like `VAD-ACT-` matched nothing; the per-word fuzzy queries then scored loose title tokens. Probed against the real `tickets/` repo, a `BUG-` search returned **zero `BUG-*` entities in the top 8** — all `RR-*` whose titles contain the word "bug".

## Changes

**Frontend** — `frontend/src/composables/useBacktickAutocomplete.ts`
- Symmetric backspace: phase `id` hands control back to the prefix machine when typed text retreats across the prefix boundary.
- `rankByIdMatch`: re-ranks results into tiers (exact ID → ID-prefix → ID-substring → title-only), stable within each tier. This is backend-agnostic — the autocomplete sends a *prefix-stripped* body query (`q=G7N5`, not `TKT-G7N5`), so the backend boost can't apply, and the three search backends (bleve / LinearSearch / pgstore) each rank differently.

**Backend** — `internal/search/bleveindex/bleveindex.go`
- Added a **prefix query** on the `id` field (boost 6.0, case-preserved) and split the exact-ID boost to 8.0. Dropped `id` from the per-word fuzzy fields (dead weight on a case-sensitive keyword field).
- Helps callers that send the full prefix: card picker, command palette, raw `/_search`.

## Verification

- New unit tests both sides, incl. `TestIndex_SearchByIDPrefix` reproducing the exact `VAD-ACT-` scenario.
- Probed against the live `tickets/` corpus (212 tickets, 40 bugs, …): before → `BUG-` top 8 all `RR-*`; after → all `BUG-*`. Same for `REV-`, `TKT-`, `TKT-G`, `FEAT-9`.
- Full frontend suite (1103 tests), Go search + appbuild suites, arch-lint, lint, typecheck all green.