### PR TITLE
refactor(dataentry): ACL-bounded visibleReader read seam (TKT-N26KLB, M5.0b)

### DIFF
--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -866,16 +866,18 @@ func (a *App) gateReadOrNotFound(w http.ResponseWriter, r *http.Request, typeNam
 func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName, plural, entityID string) {
 	ctx := r.Context()
 
-	// ACL gate (TKT-VQGN). Runs BEFORE getEntity so a hidden id and a
-	// nonexistent id spend the same MatchingIDs roundtrip — otherwise
-	// the timing difference (in-memory lookup ~1µs vs. DB roundtrip
-	// ~1ms) is an id-enumeration side channel that defeats the
-	// indistinguishable-404-body invariant (RR-NGMI).
-	if !a.gateReadOrNotFound(w, r, typeName, entityID) {
+	// ACL gate (TKT-VQGN). visibleReader.getVisible applies PermitsRead
+	// BEFORE the store read so a hidden id and a nonexistent id spend the
+	// same MatchingIDs roundtrip — otherwise the timing difference
+	// (in-memory lookup ~1µs vs. DB roundtrip ~1ms) is an id-enumeration
+	// side channel that defeats the indistinguishable-404-body invariant
+	// (RR-NGMI). A gate error surfaces via writeGateError; a deny is
+	// returned as (nil,false,nil), indistinguishable from a real miss.
+	entity, found, err := a.visibleReader.getVisible(ctx, typeName, entityID)
+	if err != nil {
+		writeGateError(w, r, err)
 		return
 	}
-
-	entity, found := a.getEntity(ctx, entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
 		return
@@ -2095,51 +2097,7 @@ func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, i
 // effort" affordance; the explicit GET / list endpoints are the
 // authoritative read surface.
 func (a *App) filterVisibleIncludes(ctx context.Context, candidates []*entityPkg.Entity) []*entityPkg.Entity {
-	if len(candidates) == 0 {
-		return nil
-	}
-	gate := readGateFromContext(ctx)
-	byType := make(map[string][]*entityPkg.Entity)
-	for _, c := range candidates {
-		byType[c.Type] = append(byType[c.Type], c)
-	}
-	allowed := make(map[string]bool, len(candidates))
-	for typeName, group := range byType {
-		ids := make([]string, 0, len(group))
-		for _, c := range group {
-			ids = append(ids, c.ID)
-		}
-		perm, err := gate.PermitsReadMany(ctx, typeName, ids)
-		if err != nil {
-			// Fail-closed on gate error (RR-7TIU): drop the whole
-			// type's candidates rather than surface a partial subset
-			// the policy may actually deny. Log loud so operators see
-			// the underlying failure (SIG-3 from the cranky review:
-			// silent drops surface as "missing includes" support
-			// tickets with no signal on the cause).
-			slog.Warn("dataentry: filterVisibleIncludes: PermitsReadMany failed; dropping type",
-				"type", typeName,
-				"candidates", len(ids),
-				"err", err)
-			continue
-		}
-		for id, ok := range perm {
-			if ok {
-				allowed[id] = true
-			}
-		}
-	}
-	// Preserve original candidate order so the response is stable.
-	// Allocate a fresh slice (RR-I2SI) — aliasing candidates' storage
-	// works today but is a non-obvious invariant that a future
-	// refactor retaining `candidates` would silently corrupt.
-	out := make([]*entityPkg.Entity, 0, len(candidates))
-	for _, c := range candidates {
-		if allowed[c.ID] {
-			out = append(out, c)
-		}
-	}
-	return out
+	return a.visibleReader.filterVisible(ctx, candidates)
 }
 
 func (a *App) applyV1Filters(entities []*entityPkg.Entity, query map[string][]string, _ string) []*entityPkg.Entity {

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -122,12 +122,18 @@ type App struct {
 	// the regular searcher on fs/memory builds, pgstore-native on the
 	// postgres build.
 	visibleSearcher search.VisibleSearcher
-	tracer          tracer.Tracer
-	validator       validator.Validator
-	templater       templating.Templater
-	cfgLoader       config.Loader
-	kv              state.KV
-	acl             acl.ACL
+	// visibleReader is the ACL-bounded entity-read seam (TKT-N26KLB): the
+	// entity-read analog of visibleSearcher. Read handlers gate single-GET
+	// and include-filtering through it so the read gate is applied
+	// structurally rather than by per-call-site convention. Wraps the same
+	// `store` handle; the gate is resolved per-request from the context.
+	visibleReader visibleReader
+	tracer        tracer.Tracer
+	validator     validator.Validator
+	templater     templating.Templater
+	cfgLoader     config.Loader
+	kv            state.KV
+	acl           acl.ACL
 
 	// documents renders and caches documents. Created once in NewApp so
 	// singleflight deduplication is stable across requests.
@@ -435,6 +441,7 @@ func NewApp(
 		entityManager:   em,
 		searcher:        searcher,
 		visibleSearcher: visibleSearcher,
+		visibleReader:   newVisibleReader(st),
 		tracer:          trc,
 		validator:       val,
 		templater:       templater,

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -125,6 +125,7 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	app.fs = fs
 	app.paths = paths
 	app.store = svc.Store()
+	app.visibleReader = newVisibleReader(svc.Store())
 	app.entityManager = svc.EntityManager()
 	app.searcher = svc.Searcher()
 	app.visibleSearcher = svc.VisibleSearcher()

--- a/internal/dataentry/visiblereader.go
+++ b/internal/dataentry/visiblereader.go
@@ -1,0 +1,127 @@
+package dataentry
+
+import (
+	"context"
+	"log/slog"
+
+	entitypkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// visibleReader is the ACL-bounded entity-read seam for the data-entry
+// handlers. It composes a raw [store.Store] with the per-request read gate
+// ([readGate]) so that every read it exposes is filtered by the principal's
+// read-ACL. It is the entity-read analog of [search.VisibleSearcher]: the
+// gate produces a per-type scope/verdict, and the reader consumes (store
+// handle + verdict) to emit only visible rows — never a raw, ungated entity.
+//
+// Why a dedicated type rather than ad-hoc gate calls at each handler: the read
+// gate already exists ([readGateFromContext]) but is applied by *convention* —
+// a handler can reach `a.store.GetEntity` directly and forget to gate. That
+// "gate by convention" is the read-ACL bug class (TKT-N26KLB, #1010). A type
+// that holds the store privately and exposes only gated reads makes the gating
+// structural: a consumer that takes a visibleReader cannot bypass it.
+//
+// The gate is resolved from the request context at call time (not held on the
+// struct) so it keeps the per-request binding that [attachACLRequest] sets up.
+// Under no ACL, [readGateFromContext] returns the permit-all [nopReadGate], so
+// behavior is byte-identical to the pre-ACL path.
+//
+// Scope (TKT-N26KLB M5.0b): this type absorbs the *already-gated* read paths
+// (single-entity GET, list-with-verdict, include-filtering). Ungated reads that
+// the audit surfaced (e.g. nav badge counts, BUG-ZM7SBI) are deliberately NOT
+// migrated here yet — closing those changes ACL behavior and is tracked
+// separately.
+type visibleReader struct {
+	store store.Store
+}
+
+// newVisibleReader constructs a visibleReader over s. s must be non-nil; the
+// data-entry composition root always has a store, so a nil here is a wiring
+// bug, not a runtime condition.
+func newVisibleReader(s store.Store) visibleReader {
+	return visibleReader{store: s}
+}
+
+// getVisible looks up an entity by ID, applying the read gate FIRST so a
+// hidden id and a nonexistent id are indistinguishable (same MatchingIDs
+// roundtrip, no existence side channel — the RR-NGMI invariant). It returns:
+//
+//   - (entity, true, nil)  — readable and present
+//   - (nil, false, nil)    — denied OR absent (caller cannot tell which, by design)
+//   - (nil, false, err)    — the gate itself failed (caller surfaces via writeGateError)
+//
+// This mirrors the gate-then-read ordering of the former gateReadOrNotFound +
+// getEntity pair: callers translate (nil,false,nil) into the same not-found
+// wire response a genuinely-missing entity produces.
+func (vr visibleReader) getVisible(ctx context.Context, entityType, id string) (*entitypkg.Entity, bool, error) {
+	ok, err := readGateFromContext(ctx).PermitsRead(ctx, entityType, id)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	e, gerr := vr.store.GetEntity(ctx, id)
+	if gerr != nil {
+		// A store miss is treated as not-found, matching the former
+		// App.getEntity contract (err -> not found). The store error is
+		// deliberately not surfaced as the gate error: callers map
+		// (nil,false,nil) to the same indistinguishable 404 a real miss
+		// produces. Only a *gate* error (above) is propagated.
+		return nil, false, nil //nolint:nilerr // store miss == not-found, by design
+	}
+	return e, true, nil
+}
+
+// filterVisible drops every candidate the principal cannot read, batching the
+// gate probe by entity type — one PermitsReadMany per distinct type, turning a
+// worst case of O(N) per-id probes into O(distinct-types) (RR-FRK1). Order is
+// preserved and a fresh slice is returned (RR-I2SI). On a gate error for a
+// type, that whole type is dropped fail-closed (RR-7TIU) — a read-ACL failure
+// must never widen visibility — and logged loud so operators see the cause
+// rather than a silently-empty include block.
+//
+// This is the extraction of the former App.filterVisibleIncludes; behavior is
+// preserved, including the nil return for empty input.
+func (vr visibleReader) filterVisible(ctx context.Context, candidates []*entitypkg.Entity) []*entitypkg.Entity {
+	if len(candidates) == 0 {
+		return nil
+	}
+	gate := readGateFromContext(ctx)
+
+	byType := make(map[string][]*entitypkg.Entity)
+	for _, c := range candidates {
+		byType[c.Type] = append(byType[c.Type], c)
+	}
+
+	allowed := make(map[string]bool, len(candidates))
+	for typeName, group := range byType {
+		ids := make([]string, 0, len(group))
+		for _, c := range group {
+			ids = append(ids, c.ID)
+		}
+		perm, err := gate.PermitsReadMany(ctx, typeName, ids)
+		if err != nil {
+			slog.Warn("dataentry: visibleReader.filterVisible: PermitsReadMany failed; dropping type",
+				"type", typeName,
+				"candidates", len(ids),
+				"err", err)
+			continue
+		}
+		for id, ok := range perm {
+			if ok {
+				allowed[id] = true
+			}
+		}
+	}
+
+	// Preserve original candidate order; allocate a fresh slice.
+	out := make([]*entitypkg.Entity, 0, len(candidates))
+	for _, c := range candidates {
+		if allowed[c.ID] {
+			out = append(out, c)
+		}
+	}
+	return out
+}

--- a/internal/dataentry/visiblereader_test.go
+++ b/internal/dataentry/visiblereader_test.go
@@ -1,0 +1,163 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/search"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// configGate is a configurable readGate test double for visibleReader unit
+// tests: permits is the per-id verdict; err (if set) is returned from every
+// probe to exercise the fail-closed paths.
+type configGate struct {
+	permits map[string]bool
+	err     error
+}
+
+func (g configGate) PermitsRead(_ context.Context, _ /*entityType*/, id string) (bool, error) {
+	if g.err != nil {
+		return false, g.err
+	}
+	return g.permits[id], nil
+}
+
+func (g configGate) PermitsReadMany(_ context.Context, _ string, ids []string) (map[string]bool, error) {
+	if g.err != nil {
+		return nil, g.err
+	}
+	m := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		m[id] = g.permits[id]
+	}
+	return m, nil
+}
+
+func (configGate) ReadQuery(context.Context, string) acl.ReadQueryResult {
+	return acl.ReadQueryResult{AllowAll: true}
+}
+
+func (configGate) SearchScope(context.Context, []string) map[string]search.TypeScope {
+	return map[string]search.TypeScope{search.WildcardType: {AllowAll: true}}
+}
+
+func seedReader(t *testing.T) visibleReader {
+	t.Helper()
+	st := memstore.New()
+	ctx := context.Background()
+	for _, e := range []*entity.Entity{
+		{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}},
+		{ID: "TKT-002", Type: "ticket", Properties: map[string]any{"title": "T2"}},
+		{ID: "FEAT-001", Type: "feature", Properties: map[string]any{"title": "F1"}},
+	} {
+		if err := st.CreateEntity(ctx, e); err != nil {
+			t.Fatalf("seed %s: %v", e.ID, err)
+		}
+	}
+	return newVisibleReader(st)
+}
+
+func TestVisibleReader_GetVisible(t *testing.T) {
+	vr := seedReader(t)
+
+	t.Run("permitted and present", func(t *testing.T) {
+		ctx := withReadGate(context.Background(), configGate{permits: map[string]bool{"TKT-001": true}})
+		e, found, err := vr.getVisible(ctx, "ticket", "TKT-001")
+		if err != nil || !found || e == nil || e.ID != "TKT-001" {
+			t.Fatalf("got (%v, %v, %v), want (TKT-001, true, nil)", e, found, err)
+		}
+	})
+
+	t.Run("denied is indistinguishable from absent", func(t *testing.T) {
+		ctx := withReadGate(context.Background(), configGate{permits: map[string]bool{"TKT-001": false}})
+		e, found, err := vr.getVisible(ctx, "ticket", "TKT-001")
+		if err != nil || found || e != nil {
+			t.Fatalf("denied: got (%v, %v, %v), want (nil, false, nil)", e, found, err)
+		}
+	})
+
+	t.Run("absent entity that is permitted", func(t *testing.T) {
+		ctx := withReadGate(context.Background(), configGate{permits: map[string]bool{"TKT-999": true}})
+		e, found, err := vr.getVisible(ctx, "ticket", "TKT-999")
+		if err != nil || found || e != nil {
+			t.Fatalf("absent: got (%v, %v, %v), want (nil, false, nil)", e, found, err)
+		}
+	})
+
+	t.Run("gate error surfaces (not a deny)", func(t *testing.T) {
+		sentinel := errors.New("gate boom")
+		ctx := withReadGate(context.Background(), configGate{err: sentinel})
+		e, found, err := vr.getVisible(ctx, "ticket", "TKT-001")
+		if !errors.Is(err, sentinel) || found || e != nil {
+			t.Fatalf("gate error: got (%v, %v, %v), want (nil, false, sentinel)", e, found, err)
+		}
+	})
+
+	t.Run("the store read happens only after the gate allows", func(t *testing.T) {
+		// A deny must NOT touch the store — verified indirectly: a denied
+		// read of an absent id returns the same (nil,false,nil) as a denied
+		// read of a present id, so no existence signal leaks.
+		ctx := withReadGate(context.Background(), configGate{permits: map[string]bool{}})
+		ePresent, fp, _ := vr.getVisible(ctx, "ticket", "TKT-001")
+		eAbsent, fa, _ := vr.getVisible(ctx, "ticket", "TKT-999")
+		if fp || fa || ePresent != nil || eAbsent != nil {
+			t.Fatalf("denied present vs absent must be identical: present=(%v,%v) absent=(%v,%v)",
+				ePresent, fp, eAbsent, fa)
+		}
+	})
+}
+
+func TestVisibleReader_FilterVisible(t *testing.T) {
+	vr := seedReader(t)
+	candidates := []*entity.Entity{
+		{ID: "TKT-001", Type: "ticket"},
+		{ID: "TKT-002", Type: "ticket"},
+		{ID: "FEAT-001", Type: "feature"},
+	}
+
+	t.Run("drops non-permitted, preserves order", func(t *testing.T) {
+		ctx := withReadGate(context.Background(), configGate{permits: map[string]bool{
+			"TKT-001": true, "TKT-002": false, "FEAT-001": true,
+		}})
+		got := vr.filterVisible(ctx, candidates)
+		if len(got) != 2 || got[0].ID != "TKT-001" || got[1].ID != "FEAT-001" {
+			t.Fatalf("got %v, want [TKT-001 FEAT-001] in order", ids(got))
+		}
+	})
+
+	t.Run("empty input returns nil", func(t *testing.T) {
+		if got := vr.filterVisible(context.Background(), nil); got != nil {
+			t.Fatalf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("gate error fails closed (drops the whole type)", func(t *testing.T) {
+		ctx := withReadGate(context.Background(), configGate{err: errors.New("gate down")})
+		got := vr.filterVisible(ctx, candidates)
+		if len(got) != 0 {
+			t.Fatalf("gate error must drop everything fail-closed, got %v", ids(got))
+		}
+	})
+
+	t.Run("fresh slice, candidates not aliased", func(t *testing.T) {
+		ctx := withReadGate(context.Background(), configGate{permits: map[string]bool{
+			"TKT-001": true, "TKT-002": true, "FEAT-001": true,
+		}})
+		got := vr.filterVisible(ctx, candidates)
+		if len(got) == 0 || &got[0] == &candidates[0] {
+			t.Fatal("filterVisible must return a fresh slice, not alias candidates")
+		}
+	})
+}
+
+func ids(es []*entity.Entity) []string {
+	out := make([]string, len(es))
+	for i, e := range es {
+		out[i] = e.ID
+	}
+	return out
+}

--- a/tickets/entities/bugs/BUG-ZM7SBI.md
+++ b/tickets/entities/bugs/BUG-ZM7SBI.md
@@ -1,0 +1,48 @@
+---
+id: BUG-ZM7SBI
+type: bug
+title: Nav badge counts leak existence of ACL-hidden entities (ungated enrichNavEntry)
+description: 'Nav sidebar badge counts are computed via raw ungated listFromStoreByTypes (enrichNavEntry, app.go:537), so they count entities the principal cannot read under ACL — leaking hidden-entity cardinality. A parallel gated count path (sidebarCounts.countWithFilters) already exists, proving the inconsistency. Same read-ACL ''gate by convention'' class as #1010.'
+priority: medium
+why1: enrichNavEntry (internal/dataentry/app.go:537) computes item.Count from a raw, ungated listFromStoreByTypes — it counts every entity of the type regardless of the principal's read-ACL.
+why2: The navigation count path was written independently of the sidebar count path (sidebarCounts.countWithFilters, api_v1.go:2771), which DOES gate via readGate.ReadQuery/DenyAll. Two parallel count implementations diverged.
+why3: 'Read-ACL gating is applied by convention per-call-site rather than enforced structurally — a handler can read raw store data without the gate and nothing flags it (same root pattern as the #1010 sync read-ACL bug).'
+status: backlog
+---
+
+## Summary
+
+The navigation sidebar badge count (`enrichNavEntry`,
+`internal/dataentry/app.go:537`) is computed from a **raw, ungated**
+`listFromStoreByTypes(ctx, a.Services(), …)` followed by `applyFilters` +
+`len()`. Under an ACL where the principal cannot read some entities of a type,
+the badge still counts them — leaking the existence/quantity of hidden entities.
+
+## Evidence
+
+A **parallel, correctly-gated** count path exists for the sidebar:
+`sidebarCounts.countWithFilters` (`internal/dataentry/api_v1.go:2771`) resolves
+`readGateFromContext(ctx).ReadQuery(ctx, entityType)`, short-circuits `DenyAll →
+0`, and scopes via `rqr.Query`. The nav path does none of this. No test asserts
+nav counts under ACL.
+
+## Impact
+
+Information disclosure: a user who cannot read entities of type X still sees an
+accurate count of them in the nav badge. Low-to-medium severity (count
+cardinality, not contents), but it's the same read-ACL "gate by convention"
+class as #1010.
+
+## Fix direction
+
+Route `enrichNavEntry`'s count through the gated path — ideally the same
+`ReadQuery`-based count the sidebar uses, or the forthcoming `visibleReader`
+(TKT-N26KLB M5.0b+). When the App decomposition reaches the nav handler, this
+should fall out naturally; filed now so it's tracked rather than lost.
+
+## Discovery
+
+Surfaced during the read-path audit for the `dataentry.App` decomposition
+(TKT-N26KLB). The relation-peer-ID exposure considered alongside it is **by
+design** (TKT-VQGN: the source-entity gate is the intended boundary) and is NOT
+a bug.

--- a/tickets/relations/BUG-ZM7SBI--affects--authorization.md
+++ b/tickets/relations/BUG-ZM7SBI--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZM7SBI
+relation: affects
+to: authorization
+---

--- a/tickets/relations/BUG-ZM7SBI--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-ZM7SBI--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZM7SBI
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-ZM7SBI--fixes--FEAT-AESD4.md
+++ b/tickets/relations/BUG-ZM7SBI--fixes--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZM7SBI
+relation: fixes
+to: FEAT-AESD4
+---


### PR DESCRIPTION
Second step of the `dataentry.App` decomposition (**TKT-N26KLB**). Stacked on #1030.

## Why

The read-ACL gate (`readGate`) exists but is applied by **convention** — a handler can read `a.store.GetEntity` directly and forget to gate. That "gate by convention" is the read-ACL bug class (#1010). This introduces the structural fix.

## What

A new **`visibleReader`** type (`visiblereader.go`) composes `store.Store` + the per-request `readGate`, holding the store **privately** and exposing only ACL-gated reads. A consumer that takes a `visibleReader` *cannot* reach raw `GetEntity` — gating becomes structural. It is the entity-read analog of the existing `visibleSearcher`.

Two methods, both extracted from existing gated paths (behavior-preserving):

- `getVisible(ctx, type, id)` — applies `PermitsRead` **before** the store read (preserves the 404/timing parity invariant RR-NGMI: a denied id is indistinguishable from a missing one). Gate error → propagated; deny or miss → `(nil,false,nil)`.
- `filterVisible(ctx, candidates)` — the extraction of `filterVisibleIncludes`, kept byte-equivalent (same ID-keyed allow-map, nil-on-empty, fail-closed-by-type logging RR-7TIU/RR-FRK1/RR-I2SI).

Migrations (no behavior change):
- `handleV1GetEntity`: `gateReadOrNotFound`+`getEntity` → `getVisible`
- `filterVisibleIncludes` → delegates to `visibleReader.filterVisible`

## Scope

Per the agreed plan, M5.0b migrates **only already-gated reads** — it adds the seam without changing ACL behavior. App method count is unchanged (209); reduction comes in M5.1 when read handlers are extracted onto this seam.

## Audit finding

The read-path audit that informed this seam surfaced an **ungated nav-badge count leak** (`enrichNavEntry` counts ACL-hidden entities) — a real read-ACL leak, filed as **BUG-ZM7SBI** (with 5-whys reaching the same "gate by convention" root). The relation-peer-ID exposure considered alongside it is **by design** (TKT-VQGN); not a bug. Both are out of scope here.

## Verification

New direct unit tests (`visiblereader_test.go`): permitted/denied/absent/gate-error/order-preservation/fail-closed. `go build ./...`, `go test -race ./internal/dataentry/` (full suite incl. all ACL tests), `golangci-lint` (0 issues), `just arch-lint`, `plimsoll ./...` (exit 0) all green.