### PR TITLE
feat(data-entry): PlantUML diagram rendering via remote server (TKT-THG2JL)

### DIFF
--- a/frontend/src/components/entity/DocumentsPanel.vue
+++ b/frontend/src/components/entity/DocumentsPanel.vue
@@ -6,7 +6,7 @@ import { useScriptErrorStore } from '@/stores/scriptError'
 import { renderDocument } from '@/api/documents'
 import { useEvents } from '@/composables/useEvents'
 import { createDocumentClickHandler } from '@/composables/useDocumentClicks'
-import { renderMermaidDiagrams } from '@/utils/markdown'
+import { renderMermaidDiagrams, renderPlantUMLDiagrams } from '@/utils/markdown'
 import type { DocumentConfig } from '@/types'
 import { getErrorMessage, getScriptError } from '@/api/errors'
 import DOMPurify from 'dompurify'
@@ -45,6 +45,7 @@ watch(sanitizedContent, async () => {
   await nextTick()
   if (docBody.value) {
     await renderMermaidDiagrams(docBody.value)
+    renderPlantUMLDiagrams(docBody.value, schemaStore.app?.plantuml_server_url)
   }
 })
 

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -20,6 +20,7 @@ import { isAnyModalOpen } from '@/composables/modalStack'
 import {
   renderMarkdown,
   renderMermaidDiagrams,
+  renderPlantUMLDiagrams,
   getCheckboxStats,
   type EntityRefResolver,
 } from '@/utils/markdown'
@@ -166,6 +167,7 @@ watch(
   async () => {
     if (contentRef.value) {
       await renderMermaidDiagrams(contentRef.value)
+      renderPlantUMLDiagrams(contentRef.value, schemaStore.app?.plantuml_server_url)
     }
   },
   { flush: 'post' },

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -167,6 +167,8 @@ function scrollToAnchorWhenReady(hash: string, abort: () => boolean) {
     mo.observe(container, { childList: true, subtree: true, characterData: true })
 
     container.addEventListener('rela:mermaid-rendered', reScroll)
+    // PlantUML <img>s shift layout when they (lazily) load; same re-settle.
+    container.addEventListener('rela:plantuml-rendered', reScroll)
     const deadline = window.setTimeout(cleanup, SETTLE_TIMEOUT_MS)
     const abortTick = window.setInterval(() => {
       if (abort()) cleanup()
@@ -178,6 +180,7 @@ function scrollToAnchorWhenReady(hash: string, abort: () => boolean) {
     function cleanup() {
       mo.disconnect()
       container.removeEventListener('rela:mermaid-rendered', reScroll)
+      container.removeEventListener('rela:plantuml-rendered', reScroll)
       window.clearTimeout(deadline)
       window.clearInterval(abortTick)
       window.removeEventListener('wheel', onUserScroll)

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -42,6 +42,14 @@ export interface ActionConfig {
 export interface AppConfig {
   name: string
   description?: string
+  /**
+   * Base URL of the configured PlantUML rendering server, or absent/empty
+   * when PlantUML rendering is disabled. A non-empty value is the on switch
+   * for ```plantuml diagram rendering (see renderPlantUMLDiagrams). The key
+   * is snake_case to match the server's JSON tag verbatim — there is no
+   * client-side casing transform.
+   */
+  plantuml_server_url?: string
 }
 
 export interface FormConfig {

--- a/frontend/src/utils/markdown.test.ts
+++ b/frontend/src/utils/markdown.test.ts
@@ -7,7 +7,13 @@
 // browsers (and the E2E suite) render correctly. jsdom matches browser
 // serialization, so this file opts into it. See BUG-SQSV6V.
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderMarkdown, getCheckboxStats, renderMermaidDiagrams } from './markdown'
+import {
+  renderMarkdown,
+  getCheckboxStats,
+  renderMermaidDiagrams,
+  renderPlantUMLDiagrams,
+  encodePlantUMLHex,
+} from './markdown'
 
 describe('markdown', () => {
   describe('renderMarkdown', () => {
@@ -490,6 +496,141 @@ describe('markdown', () => {
       expect(renderSpy.mock.calls[0][1]).toBe('graph TD\nA-->B')
       expect(container.querySelector('.mermaid-diagram')).toBeTruthy()
       expect(container.querySelector('pre.mermaid')).toBeNull()
+    })
+  })
+
+  describe('encodePlantUMLHex', () => {
+    it('hex-encodes UTF-8 bytes with a ~h prefix', () => {
+      // "AB" -> 0x41 0x42
+      expect(encodePlantUMLHex('AB')).toBe('~h4142')
+    })
+
+    it('zero-pads single-digit bytes', () => {
+      // newline is 0x0a, must be "0a" not "a"
+      expect(encodePlantUMLHex('\n')).toBe('~h0a')
+    })
+
+    it('encodes multi-byte UTF-8 characters by byte', () => {
+      // "é" is U+00E9 -> UTF-8 0xc3 0xa9
+      expect(encodePlantUMLHex('é')).toBe('~hc3a9')
+    })
+  })
+
+  describe('renderPlantUMLDiagrams', () => {
+    const SERVER = 'https://plantuml.example.com'
+
+    it('is a no-op when no server URL is configured (undefined)', () => {
+      const container = document.createElement('div')
+      container.innerHTML = '<pre><code class="language-plantuml">@startuml\nA->B\n@enduml</code></pre>'
+
+      const count = renderPlantUMLDiagrams(container, undefined)
+
+      // Block left untouched: degrades to a plain code block, no <img>.
+      expect(count).toBe(0)
+      expect(container.querySelector('img.plantuml-diagram')).toBeNull()
+      expect(container.querySelector('code.language-plantuml')).toBeTruthy()
+    })
+
+    it('is a no-op for the empty-string server URL (YAML-disabled value)', () => {
+      const container = document.createElement('div')
+      container.innerHTML = '<pre class="plantuml">@startuml</pre>'
+
+      // `plantuml_server_url: ""` deserializes to '' — the real disabled value.
+      expect(renderPlantUMLDiagrams(container, '')).toBe(0)
+      expect(container.querySelector('img.plantuml-diagram')).toBeNull()
+      expect(container.querySelector('pre.plantuml')).toBeTruthy()
+    })
+
+    it('leaves the block as code when the server URL is unsafe (non-http scheme)', () => {
+      const container = document.createElement('div')
+      container.innerHTML = '<pre class="plantuml">@startuml</pre>'
+
+      // A javascript: scheme must never reach img.src.
+      expect(renderPlantUMLDiagrams(container, 'javascript:alert(1)')).toBe(0)
+      expect(container.querySelector('img.plantuml-diagram')).toBeNull()
+      expect(container.querySelector('pre.plantuml')).toBeTruthy()
+    })
+
+    it('sets no-referrer on the diagram image', () => {
+      const container = document.createElement('div')
+      container.innerHTML = '<pre class="plantuml">@startuml</pre>'
+
+      renderPlantUMLDiagrams(container, SERVER)
+
+      const img = container.querySelector('img.plantuml-diagram') as HTMLImageElement
+      expect(img.referrerPolicy).toBe('no-referrer')
+    })
+
+    it('restores a code block when the image fails to load', () => {
+      const container = document.createElement('div')
+      container.innerHTML = '<pre class="plantuml">@startuml\nA->B\n@enduml</pre>'
+
+      renderPlantUMLDiagrams(container, SERVER)
+      const img = container.querySelector('img.plantuml-diagram') as HTMLImageElement
+      expect(img).toBeTruthy()
+
+      // Simulate the server being unreachable.
+      img.dispatchEvent(new Event('error'))
+
+      expect(container.querySelector('img.plantuml-diagram')).toBeNull()
+      const code = container.querySelector('pre > code.language-plantuml')
+      expect(code).toBeTruthy()
+      // Source is preserved, not lost to a broken-image glyph.
+      expect(code?.textContent).toBe('@startuml\nA->B\n@enduml')
+    })
+
+    it('replaces a marked.js fenced block with an <img> to the server', () => {
+      const container = document.createElement('div')
+      container.innerHTML = '<pre><code class="language-plantuml">@startuml</code></pre>'
+
+      renderPlantUMLDiagrams(container, SERVER)
+
+      const img = container.querySelector('img.plantuml-diagram') as HTMLImageElement
+      expect(img).toBeTruthy()
+      expect(img.src).toBe(`${SERVER}/svg/${encodePlantUMLHex('@startuml')}`)
+      expect(container.querySelector('code.language-plantuml')).toBeNull()
+    })
+
+    it('handles the server-rewritten pre.plantuml form', () => {
+      const container = document.createElement('div')
+      // textContent decoding: &gt; becomes > before we read it.
+      container.innerHTML = '<pre class="plantuml">@startuml\nA--&gt;B\n@enduml</pre>'
+
+      renderPlantUMLDiagrams(container, SERVER)
+
+      const img = container.querySelector('img.plantuml-diagram') as HTMLImageElement
+      expect(img).toBeTruthy()
+      expect(img.src).toBe(`${SERVER}/svg/${encodePlantUMLHex('@startuml\nA-->B\n@enduml')}`)
+      expect(container.querySelector('pre.plantuml')).toBeNull()
+    })
+
+    it('does not double the slash when the server URL has a trailing slash', () => {
+      const container = document.createElement('div')
+      container.innerHTML = '<pre class="plantuml">@startuml</pre>'
+
+      renderPlantUMLDiagrams(container, `${SERVER}/`)
+
+      const img = container.querySelector('img.plantuml-diagram') as HTMLImageElement
+      expect(img.src).toBe(`${SERVER}/svg/${encodePlantUMLHex('@startuml')}`)
+    })
+
+    it('skips empty blocks', () => {
+      const container = document.createElement('div')
+      container.innerHTML = '<pre class="plantuml">   </pre>'
+
+      renderPlantUMLDiagrams(container, SERVER)
+
+      expect(container.querySelector('img.plantuml-diagram')).toBeNull()
+    })
+
+    it('leaves mermaid blocks alone', () => {
+      const container = document.createElement('div')
+      container.innerHTML = '<pre class="mermaid">graph TD</pre>'
+
+      renderPlantUMLDiagrams(container, SERVER)
+
+      expect(container.querySelector('img.plantuml-diagram')).toBeNull()
+      expect(container.querySelector('pre.mermaid')).toBeTruthy()
     })
   })
 })

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -241,3 +241,128 @@ export async function renderMermaidDiagrams(container: HTMLElement): Promise<voi
     )
   }
 }
+
+/**
+ * Encode PlantUML source for a server `~h` (hex) request.
+ *
+ * PlantUML servers accept three transfer encodings; we use the hex form
+ * (`~h<hex>`) because it needs no deflate/compression library — the diagram
+ * source's UTF-8 bytes are simply lowercased-hex encoded. URLs are longer than
+ * the deflate form but require zero extra frontend dependencies and stay well
+ * within typical URL limits for hand-authored diagrams.
+ */
+export function encodePlantUMLHex(source: string): string {
+  const bytes = new TextEncoder().encode(source)
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+  return `~h${hex}`
+}
+
+/**
+ * Build the diagram URL for a PlantUML server and encoded source, or null when
+ * the configured base URL is unsafe to use as an <img src>.
+ *
+ * The server URL is validated server-side at config load (see
+ * dataentryconfig.validateApp), but we re-check the scheme here as defense in
+ * depth: this value becomes a live `img.src` with no CSP backstop on the SPA,
+ * so a non-http(s) scheme that somehow reaches the client must never be
+ * emitted. Joins without doubling the slash regardless of a trailing slash on
+ * the base URL.
+ */
+function plantUMLImageURL(serverURL: string, source: string): string | null {
+  let parsed: URL
+  try {
+    parsed = new URL(serverURL)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+  const base = serverURL.replace(/\/+$/, '')
+  return `${base}/svg/${encodePlantUMLHex(source)}`
+}
+
+/**
+ * Render PlantUML diagrams by replacing fenced ```plantuml blocks with an
+ * <img> pointed at the configured PlantUML server. Mirrors
+ * renderMermaidDiagrams: call it after the markdown HTML is mounted, and it
+ * handles the same two source forms —
+ * - `<pre><code class="language-plantuml">…</code></pre>` (marked.js, client
+ *   render of entity/section content), and
+ * - `<pre class="plantuml">…</pre>` (rela-server documents, goldmark +
+ *   htmlutil.ConvertPlantUMLBlocks).
+ *
+ * `serverURL` is the operator-configured `app.plantuml_server_url`. When it is
+ * empty/undefined the function is a no-op: blocks are left as plain code, no
+ * diagram source leaves the browser, and no network request is made. Presence
+ * of the URL is therefore the on/off switch for the whole feature.
+ *
+ * Unlike mermaid, rendering happens on the server behind `serverURL`, so this
+ * pass only constructs the <img> element; the browser fetches the SVG lazily.
+ *
+ * Returns the number of blocks replaced (0 when disabled or none found).
+ */
+export function renderPlantUMLDiagrams(
+  container: HTMLElement,
+  serverURL: string | undefined | null,
+): number {
+  if (!serverURL) return 0
+
+  type Target = { pre: Element; source: string }
+  const targets: Target[] = []
+
+  // Form 1: marked.js-style fenced blocks.
+  for (const codeBlock of container.querySelectorAll('pre > code.language-plantuml')) {
+    const pre = codeBlock.parentElement
+    if (pre) targets.push({ pre, source: codeBlock.textContent || '' })
+  }
+
+  // Form 2: rela-server's pre-rewritten blocks. The `code` child can never be
+  // present here (goldmark emits Form 1, the server rewrite produces a bare
+  // <pre class="plantuml">, and the two don't co-occur), but the guard keeps
+  // Form 2 from re-wrapping a node Form 1 already claimed if that invariant
+  // ever changes.
+  for (const pre of container.querySelectorAll('pre.plantuml')) {
+    if (pre.querySelector('code.language-plantuml')) continue
+    targets.push({ pre, source: pre.textContent || '' })
+  }
+
+  let rendered = 0
+  for (const { pre, source } of targets) {
+    const trimmed = source.trim()
+    if (!trimmed) continue
+    const url = plantUMLImageURL(serverURL, trimmed)
+    if (!url) continue // unsafe server URL — leave the block as plain code.
+
+    const img = document.createElement('img')
+    img.className = 'plantuml-diagram'
+    img.loading = 'lazy'
+    img.alt = 'PlantUML diagram'
+    // Stateless render request: never leak the rela page URL to the server.
+    img.referrerPolicy = 'no-referrer'
+    // On any load failure (server down, 414 from an oversized hex URL,
+    // non-image response) restore a readable code block instead of leaving a
+    // broken-image glyph with the source gone. Mirrors renderMermaidDiagrams'
+    // "leave the source on error" resilience.
+    img.addEventListener('error', () => {
+      const fallback = document.createElement('pre')
+      const code = document.createElement('code')
+      code.className = 'language-plantuml'
+      code.textContent = trimmed
+      fallback.appendChild(code)
+      img.closest('.plantuml-diagram-wrapper')?.replaceWith(fallback)
+    })
+    // Layout shifts when the (lazy) image actually loads; signal scroll-settle
+    // listeners the same way mermaid does after its SVG injection.
+    img.addEventListener('load', () => {
+      container.dispatchEvent(new CustomEvent('rela:plantuml-rendered', { bubbles: true }))
+    })
+    img.src = url
+
+    const wrapper = document.createElement('div')
+    wrapper.className = 'plantuml-diagram-wrapper'
+    wrapper.appendChild(img)
+    pre.replaceWith(wrapper)
+    rendered++
+  }
+
+  return rendered
+}

--- a/frontend/src/views/DocumentView.vue
+++ b/frontend/src/views/DocumentView.vue
@@ -7,7 +7,7 @@ import { renderDocument } from '@/api/documents'
 import { useEvents } from '@/composables/useEvents'
 import { createDocumentClickHandler } from '@/composables/useDocumentClicks'
 import { useBackTarget } from '@/composables/useBackTarget'
-import { renderMermaidDiagrams } from '@/utils/markdown'
+import { renderMermaidDiagrams, renderPlantUMLDiagrams } from '@/utils/markdown'
 import { buildReturnTo } from '@/utils/returnPath'
 import { getErrorMessage, getScriptError } from '@/api/errors'
 import BackButton from '@/components/common/BackButton.vue'
@@ -43,6 +43,7 @@ watch(sanitizedContent, async () => {
   await nextTick()
   if (docBody.value) {
     await renderMermaidDiagrams(docBody.value)
+    renderPlantUMLDiagrams(docBody.value, schemaStore.app?.plantuml_server_url)
   }
 })
 

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -253,6 +253,10 @@ type V1App struct {
 type V1AppConfig struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	// PlantUMLServerURL is the configured PlantUML server base URL, or empty
+	// when PlantUML rendering is disabled. The SPA treats a non-empty value as
+	// the on switch for ```plantuml diagram rendering.
+	PlantUMLServerURL string `json:"plantuml_server_url,omitempty"`
 }
 
 // V1Error is an RFC 7807 Problem Details response.
@@ -1784,8 +1788,9 @@ func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
 
 	config := V1Config{
 		App: V1AppConfig{
-			Name:        s.Cfg.App.Name,
-			Description: s.Cfg.App.Description,
+			Name:              s.Cfg.App.Name,
+			Description:       s.Cfg.App.Description,
+			PlantUMLServerURL: s.Cfg.App.PlantUMLServerURL,
 		},
 		Styles:      s.StyleMap,
 		Forms:       forms,

--- a/internal/dataentry/document.go
+++ b/internal/dataentry/document.go
@@ -352,8 +352,9 @@ func markdownToHTML(markdown string) (string, error) {
 
 	result := buf.String()
 
-	// Post-process: convert mermaid code blocks to mermaid-ready pre elements.
-	result = htmlutil.ConvertMermaidBlocks(result)
+	// Post-process: convert diagram code blocks (mermaid, plantuml) to the
+	// pre elements the SPA upgrades client-side.
+	result = htmlutil.ConvertDiagramBlocks(result)
 
 	return result, nil
 }

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -366,8 +366,8 @@ func simpleMarkdownToHTML(md string) template.HTML {
 	// Post-process: add md-table class to tables
 	result = strings.ReplaceAll(result, "<table>", `<table class="md-table">`)
 
-	// Post-process: convert mermaid code blocks
-	result = htmlutil.ConvertMermaidBlocks(result)
+	// Post-process: convert diagram code blocks (mermaid, plantuml)
+	result = htmlutil.ConvertDiagramBlocks(result)
 
 	// Post-process: add checkbox indices for interactive toggling
 	result = addCheckboxIndices(result)

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -115,6 +115,15 @@ type AppConfig struct {
 	// semi-untrusted deployments. The store backends also enforce their
 	// own backstop guard independent of this value.
 	MaxAttachmentBytes int64 `yaml:"max_attachment_bytes,omitempty" json:"max_attachment_bytes,omitempty"`
+	// PlantUMLServerURL is the base URL of a PlantUML rendering server (e.g.
+	// "https://plantuml.internal.example.com"). When set, the SPA renders
+	// ```plantuml fenced code blocks as diagrams by pointing an <img> at
+	// "<url>/svg/<encoded>". Empty (the default) disables PlantUML rendering
+	// entirely — blocks degrade to plain code, and no diagram source ever
+	// leaves the browser. Deliberately not defaulted to the public
+	// plantuml.com server: that would silently publish private diagram source
+	// to a third party. Operators opt in by configuring a server they trust.
+	PlantUMLServerURL string `yaml:"plantuml_server_url,omitempty" json:"plantuml_server_url,omitempty"`
 }
 
 // Form defines a create/edit form for an entity type.

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -2,6 +2,7 @@ package dataentryconfig
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -122,6 +123,7 @@ func ValidateConfig(data []byte, cfg *Config, meta *metamodel.Metamodel) error {
 	errs = append(errs, validateDashboard(cfg, meta)...)
 	errs = append(errs, validateCommands(cfg, meta)...)
 	errs = append(errs, validateActions(cfg, meta)...)
+	errs = append(errs, validateApp(cfg)...)
 	errs = append(errs, validateDocuments(cfg)...)
 	errs = append(errs, validateStyles(cfg, meta)...)
 	errs = append(errs, validateCrossReferences(cfg)...)
@@ -1079,6 +1081,28 @@ func validateCommands(cfg *Config, meta *metamodel.Metamodel) []string {
 
 // validateDocuments validates document configurations.
 //
+// validateApp validates app-level settings. PlantUMLServerURL, when set,
+// must be an absolute http/https URL with a host: the SPA feeds it straight
+// into an <img src>, so a malformed or non-http scheme (e.g. javascript:,
+// data:, protocol-relative //host, or a bare host) is rejected at load time
+// rather than reaching a user's browser. Empty is valid (PlantUML disabled).
+func validateApp(cfg *Config) []string {
+	var errs []string
+	if raw := cfg.App.PlantUMLServerURL; raw != "" {
+		u, err := url.Parse(raw)
+		switch {
+		case err != nil:
+			errs = append(errs, fmt.Sprintf("app.plantuml_server_url: not a valid URL: %v", err))
+		case u.Scheme != "http" && u.Scheme != "https":
+			errs = append(errs, fmt.Sprintf(
+				"app.plantuml_server_url: scheme must be http or https, got %q", u.Scheme))
+		case u.Host == "":
+			errs = append(errs, "app.plantuml_server_url: must include a host")
+		}
+	}
+	return errs
+}
+
 // Invariant: every document must have entity_type set, and exactly one of
 // {command, script} must be non-empty. entity_type is enforced at the HTTP
 // handler layer to reject cross-type render requests; the mutual exclusion

--- a/internal/dataentryconfig/validate_test.go
+++ b/internal/dataentryconfig/validate_test.go
@@ -1776,3 +1776,40 @@ views:
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+func TestValidateApp_PlantUMLServerURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr string // substring; "" means valid
+	}{
+		{name: "empty is valid (disabled)", url: "", wantErr: ""},
+		{name: "https is valid", url: "https://plantuml.example.com", wantErr: ""},
+		{name: "http is valid", url: "http://localhost:8080", wantErr: ""},
+		{name: "https with path is valid", url: "https://example.com/plantuml", wantErr: ""},
+		{name: "javascript scheme rejected", url: "javascript:alert(1)", wantErr: "scheme must be http or https"},
+		{name: "data scheme rejected", url: "data:text/html,x", wantErr: "scheme must be http or https"},
+		{name: "protocol-relative rejected", url: "//evil.example", wantErr: "scheme must be http or https"},
+		{name: "bare host rejected", url: "evil.example/x", wantErr: "scheme must be http or https"},
+		{name: "scheme without host rejected", url: "https://", wantErr: "must include a host"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{App: AppConfig{PlantUMLServerURL: tt.url}}
+			errs := validateApp(cfg)
+			if tt.wantErr == "" {
+				if len(errs) != 0 {
+					t.Fatalf("validateApp(%q) = %v, want no errors", tt.url, errs)
+				}
+				return
+			}
+			if len(errs) == 0 {
+				t.Fatalf("validateApp(%q) = no errors, want error containing %q", tt.url, tt.wantErr)
+			}
+			if !strings.Contains(errs[0], tt.wantErr) {
+				t.Errorf("validateApp(%q) = %q, want substring %q", tt.url, errs[0], tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/htmlutil/mermaid.go
+++ b/internal/htmlutil/mermaid.go
@@ -8,7 +8,31 @@ import "regexp"
 // Mermaid.js expects: <pre class="mermaid">...</pre>
 var MermaidBlockRe = regexp.MustCompile(`<pre><code class="language-mermaid">([\s\S]*?)</code></pre>`)
 
+// PlantUMLBlockRe matches goldmark's output for plantuml fenced code blocks.
+// Goldmark outputs: <pre><code class="language-plantuml">...</code></pre>
+// The SPA's renderPlantUMLDiagrams pass expects: <pre class="plantuml">...</pre>
+// (the same shape as the mermaid rewrite — the frontend then turns it into an
+// <img> pointed at the configured PlantUML server).
+var PlantUMLBlockRe = regexp.MustCompile(`<pre><code class="language-plantuml">([\s\S]*?)</code></pre>`)
+
 // ConvertMermaidBlocks transforms goldmark mermaid code blocks to mermaid.js format.
 func ConvertMermaidBlocks(html string) string {
 	return MermaidBlockRe.ReplaceAllString(html, `<pre class="mermaid">$1</pre>`)
+}
+
+// ConvertPlantUMLBlocks transforms goldmark plantuml code blocks to the
+// <pre class="plantuml"> shape the SPA upgrades into a server-rendered diagram.
+func ConvertPlantUMLBlocks(html string) string {
+	return PlantUMLBlockRe.ReplaceAllString(html, `<pre class="plantuml">$1</pre>`)
+}
+
+// ConvertDiagramBlocks runs every diagram fence rewrite (mermaid, plantuml) in
+// one call. Server-side markdown pipelines should call this rather than the
+// individual converters so a newly added diagram type is picked up everywhere
+// at once — the two-call-site drift this previously invited is the reason it
+// exists.
+func ConvertDiagramBlocks(html string) string {
+	html = ConvertMermaidBlocks(html)
+	html = ConvertPlantUMLBlocks(html)
+	return html
 }

--- a/internal/htmlutil/mermaid_test.go
+++ b/internal/htmlutil/mermaid_test.go
@@ -44,3 +44,54 @@ func TestConvertMermaidBlocks(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertPlantUMLBlocks(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "basic plantuml block",
+			input:    `<pre><code class="language-plantuml">@startuml A--&gt;B @enduml</code></pre>`,
+			expected: `<pre class="plantuml">@startuml A--&gt;B @enduml</pre>`,
+		},
+		{
+			name:     "multiline plantuml",
+			input:    "<pre><code class=\"language-plantuml\">@startuml\nA->B\n@enduml</code></pre>",
+			expected: "<pre class=\"plantuml\">@startuml\nA->B\n@enduml</pre>",
+		},
+		{
+			name:     "leaves mermaid untouched",
+			input:    `<pre><code class="language-mermaid">graph TD</code></pre>`,
+			expected: `<pre><code class="language-mermaid">graph TD</code></pre>`,
+		},
+		{
+			name:     "no plantuml blocks",
+			input:    `<pre><code class="language-go">x</code></pre>`,
+			expected: `<pre><code class="language-go">x</code></pre>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertPlantUMLBlocks(tt.input)
+			if result != tt.expected {
+				t.Errorf("ConvertPlantUMLBlocks() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConvertDiagramBlocks(t *testing.T) {
+	// Both rewrites apply in a single pass; an unrelated code block is untouched.
+	input := `<pre><code class="language-mermaid">graph TD</code></pre>` +
+		`<pre><code class="language-plantuml">@startuml</code></pre>` +
+		`<pre><code class="language-go">x</code></pre>`
+	want := `<pre class="mermaid">graph TD</pre>` +
+		`<pre class="plantuml">@startuml</pre>` +
+		`<pre><code class="language-go">x</code></pre>`
+	if got := ConvertDiagramBlocks(input); got != want {
+		t.Errorf("ConvertDiagramBlocks() = %q, want %q", got, want)
+	}
+}

--- a/tickets/entities/features/FEAT-M37NWU.md
+++ b/tickets/entities/features/FEAT-M37NWU.md
@@ -1,0 +1,9 @@
+---
+id: FEAT-M37NWU
+type: feature
+title: PlantUML diagram rendering in data-entry
+summary: Render ```plantuml fenced code blocks as diagrams in the data-entry UI, mirroring the existing mermaid integration. Rendering is delegated to an operator-configured remote PlantUML server (empty = disabled), so no Java runtime or large WASM bundle is added.
+description: 'Adds PlantUML support alongside the existing client-side mermaid rendering. Because PlantUML has no pure-browser renderer, diagrams are rendered by a remote PlantUML server whose base URL is set per-deployment in data-entry.yaml (app.plantuml_server_url). When the URL is empty/absent the feature is disabled and plantuml blocks degrade to plain fenced code. The URL is published to the SPA via the existing /api/v1/_config endpoint; the frontend deflate+base64-encodes diagram source and points an <img> at <server>/svg/<encoded>. Two surfaces: client-rendered markdown (entity/section bodies via marked) handled purely in JS, and server-rendered documents (goldmark) which need a fence-class rewrite analogous to htmlutil.ConvertMermaidBlocks.'
+priority: medium
+status: proposed
+---

--- a/tickets/entities/review-checklists/REV-40KNQQ.md
+++ b/tickets/entities/review-checklists/REV-40KNQQ.md
@@ -2,55 +2,57 @@
 id: REV-40KNQQ
 type: review-checklist
 title: 'Review: PlantUML diagram rendering in data-entry (remote server)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`just test`) — Go htmlutil/dataentry/dataentryconfig + 62 frontend unit tests
+- [x] Lint clean (`just lint`) — frontend 0 errors; `go vet` clean; `just arch-lint` OK
+- [x] Coverage maintained (`just coverage-check`) — new code covered by added Go + frontend tests
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed — none remain critical (RR-F6XG58 downgraded to minor after analysis, addressed)
+- [x] All significant review-responses addressed — RR-CIAI73, RR-3OY8XW, RR-Q3U5YW all addressed
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** RR-F6XG58 (addressed), RR-CIAI73 (addressed), RR-3OY8XW
+(addressed), RR-Q3U5YW (addressed), RR-V0X7FJ (addressed), RR-JTBTUU
+(addressed), RR-21O6D4 (deferred — proxy follow-up), RR-PT28IE (deferred —
+pipeline convergence)
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+- AC1 (URL set → diagram renders in entity body, sections, documents): PASS — `renderPlantUMLDiagrams` wired into EntityDetail/DocumentView/DocumentsPanel; unit tests assert `<img>` emitted for both source forms.
+- AC2 (URL empty/absent → plain code block, no network call): PASS — disabled/empty-string/unsafe-scheme no-op tests assert no `<img>` and the source block left intact.
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: feature is config + render parity with mermaid; no user-facing docs written this PR — `app.plantuml_server_url` documented inline in config godoc)
+- [x] ~~User-facing documentation updated~~ (N/A: see above)
+- [x] ~~Docs-checklist marked as done~~ (N/A: no docs-checklist)
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** none (deferred — mermaid itself has no dedicated user doc;
+parity maintained)
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass — all code/build/test/lint green; the Rela Tickets gate clears once this checklist + the ticket move to done
+- [x] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1034

--- a/tickets/entities/review-checklists/REV-40KNQQ.md
+++ b/tickets/entities/review-checklists/REV-40KNQQ.md
@@ -1,0 +1,56 @@
+---
+id: REV-40KNQQ
+type: review-checklist
+title: 'Review: PlantUML diagram rendering in data-entry (remote server)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-21O6D4.md
+++ b/tickets/entities/review-responses/RR-21O6D4.md
@@ -1,0 +1,9 @@
+---
+id: RR-21O6D4
+type: review-response
+title: Consider server-side proxy instead of direct browser->render-server <img>
+finding: Direct browser->render-server <img> means the render-server URL, the page referrer, and URL-length limits are all browser-side concerns. A server-side proxy (/api/v1/_plantuml/<encoded>) would centralize trust, validation, caching and referrer control.
+severity: minor
+reason: 'Architecturally the clean answer to URL validation, referrer leakage, and URL-length limits at once: SPA hits /api/v1/_plantuml/<encoded>, Go validates+forwards to the trusted server, returns SVG, sets caching/referrer/CSP. The browser never learns the render-server URL. Deferred as a larger design change; the v1 direct-img approach (with URL validation + scheme guard + no-referrer + onerror fallback) is an acceptable, contained first cut. Tracked for a follow-up ticket.'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-3OY8XW.md
+++ b/tickets/entities/review-responses/RR-3OY8XW.md
@@ -1,0 +1,9 @@
+---
+id: RR-3OY8XW
+type: review-response
+title: No referrer policy on diagram <img> leaks page URL to render server
+finding: 'The diagram <img> sets no referrerPolicy, so the default strict-origin-when-cross-origin sends the rela origin to the cross-origin render server on every fetch. A stateless render request has no need for the referrer. Fix: img.referrerPolicy = ''no-referrer''.'
+severity: significant
+resolution: 'img.referrerPolicy = ''no-referrer'' on the diagram image. Test: ''sets no-referrer on the diagram image''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CIAI73.md
+++ b/tickets/entities/review-responses/RR-CIAI73.md
@@ -1,0 +1,9 @@
+---
+id: RR-CIAI73
+type: review-response
+title: No <img> onerror handling — failure destroys the source block
+finding: 'renderPlantUMLDiagrams replaces the <pre> with an <img> before any load succeeds. If the server is down/misconfigured/414s/returns non-image, the user sees a broken-image glyph and the source markdown is gone from the DOM. This is strictly worse than renderMermaidDiagrams, which console.errors and leaves the source block intact on failure. Fix: add img.onerror that restores a readable fallback (a <pre> with the source).'
+severity: significant
+resolution: 'Added img.onerror handler that replaces the wrapper with a <pre><code class=language-plantuml> carrying the original source, so server-down/414/non-image failures degrade to readable code instead of a broken-image glyph with the source lost. Test: ''restores a code block when the image fails to load''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-F6XG58.md
+++ b/tickets/entities/review-responses/RR-F6XG58.md
@@ -1,0 +1,9 @@
+---
+id: RR-F6XG58
+type: review-response
+title: PlantUMLServerURL not validated at config load
+finding: 'renderPlantUMLDiagrams sets img.src from schemaStore.app.plantuml_server_url verbatim, and dataentryconfig.ValidateConfig never validated App.PlantUMLServerURL. This is a config-validation gap, not a security hole: pointing the URL at a malicious host requires write access to data-entry.yaml, which is a trusted checked-in file (anyone who can edit it can already do worse via command:/script: documents). The real value of validation is catching misconfiguration — a typo, a wrong scheme, or pasting the public plantuml.com server unintentionally — and failing fast at startup. (Original review framed this as a critical ''exfil primitive''; downgraded to minor after analysis: the <img src> exfil mechanism is real but there is nothing to enforce against beyond the existing data-entry.yaml trust boundary.) Fix: validate at config load (absolute http/https + host); a server-side proxy that hides the render host from the browser is the genuinely security-shaped option, deferred as RR-21O6D4.'
+severity: minor
+resolution: 'Added validateApp in internal/dataentryconfig/validate.go (rejects non-http(s) scheme, missing host, malformed URL), wired into ValidateConfig. Added client-side defense-in-depth: plantUMLImageURL parses the URL and returns null for non-http(s) schemes, so renderPlantUMLDiagrams leaves the block as plain code. Tests: TestValidateApp_PlantUMLServerURL (9 cases) + frontend ''unsafe scheme'' no-op test.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-JTBTUU.md
+++ b/tickets/entities/review-responses/RR-JTBTUU.md
@@ -1,0 +1,9 @@
+---
+id: RR-JTBTUU
+type: review-response
+title: 'Nits: hex loop concat, empty-string test, dead double-process guard'
+finding: (8) encodePlantUMLHex string-concats in a loop — use Array.from(...).join(''). (9) add a test asserting serverURL='' (empty string, the actual YAML-disabled value) is a no-op. (7) the Form-2 'won't happen' guard comment cargo-cults mermaid — keep but justify, or drop.
+severity: nit
+resolution: (8) encodePlantUMLHex now uses Array.from(bytes, ...).join(''). (9) added empty-string ('') no-op test. (7) Form-2 guard comment rewritten to explain the invariant (goldmark=Form1, server-rewrite=Form2, don't co-occur) rather than 'won't happen'.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-PT28IE.md
+++ b/tickets/entities/review-responses/RR-PT28IE.md
@@ -1,0 +1,9 @@
+---
+id: RR-PT28IE
+type: review-response
+title: Two markdownToHTML pipelines (document.go, helpers.go) still diverge
+finding: document.go markdownToHTML and helpers.go simpleMarkdownToHTML run different post-processing sequences; ConvertDiagramBlocks unifies only the diagram step, not the rest.
+severity: minor
+reason: 'Pre-existing tech debt unrelated to this ticket: helpers.go adds md-table class + checkbox indices, document.go doesn''t. ConvertDiagramBlocks fixes the diagram-block drift but the broader pipeline convergence is out of scope here. Follow-up ticket.'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-Q3U5YW.md
+++ b/tickets/entities/review-responses/RR-Q3U5YW.md
@@ -1,0 +1,9 @@
+---
+id: RR-Q3U5YW
+type: review-response
+title: Lazy <img> with no dimensions shifts layout and dispatches no rendered event
+finding: 'renderMermaidDiagrams dispatches rela:mermaid-rendered so scroll-to-anchor re-settles after layout shift. The plantuml path injects <img loading=lazy> with no width/height and dispatches nothing, so it shifts layout (asynchronously, on lazy load) with no signal — deep-link anchors land wrong. Fix: dispatch an analogous event on img load (and/or reserve space via CSS).'
+severity: significant
+resolution: img 'load' listener dispatches rela:plantuml-rendered (bubbling); router/index.ts scroll-settle now listens for it alongside rela:mermaid-rendered (added + removed in cleanup). Re-settles scroll-to-anchor after the lazy image shifts layout.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-V0X7FJ.md
+++ b/tickets/entities/review-responses/RR-V0X7FJ.md
@@ -1,0 +1,9 @@
+---
+id: RR-V0X7FJ
+type: review-response
+title: Hex encoding doubles URL size; large diagrams 414 silently
+finding: ~h hex encoding doubles byte count; PlantUML servers/proxies cap URLs ~4-8KB, so a modest diagram silently 414s (broken img). Partially mitigated by the onerror fallback (RR-CIAI73) which restores the source on any failure including 414. A proactive size guard that degrades before emitting a doomed request is the cleaner fix; deferred together with the proxy approach (RR-proxy).
+severity: minor
+resolution: 'Mitigated by the onerror fallback (RR-CIAI73): an oversized hex URL that 414s now restores the source code block rather than showing a broken image. A proactive pre-request size guard is folded into the deferred proxy follow-up (RR-21O6D4), where a real error body can be returned.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-THG2JL.md
+++ b/tickets/entities/tickets/TKT-THG2JL.md
@@ -5,7 +5,7 @@ title: PlantUML diagram rendering in data-entry (remote server)
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 ## Description

--- a/tickets/entities/tickets/TKT-THG2JL.md
+++ b/tickets/entities/tickets/TKT-THG2JL.md
@@ -1,0 +1,44 @@
+---
+id: TKT-THG2JL
+type: ticket
+title: PlantUML diagram rendering in data-entry (remote server)
+kind: enhancement
+priority: medium
+effort: m
+status: review
+---
+
+## Description
+
+Add PlantUML diagram rendering to the data-entry UI, mirroring the existing
+client-side mermaid integration. PlantUML has no pure-browser renderer (it is a
+Java program), so rendering is delegated to a **remote PlantUML server**
+configured per-deployment. Presence of the URL is the on/off switch —
+**empty/absent = disabled**, blocks degrade to plain fenced code.
+
+## Config & wiring
+
+1. **Server config**: add `PlantUMLServerURL string` to `AppConfig` (`internal/dataentryconfig/config.go`, yaml `plantuml_server_url`), beside `MaxAttachmentBytes`.
+2. **Publish to SPA** via existing `/api/v1/_config`: add field to `V1AppConfig` (`internal/dataentry/api_v1.go:253`) and set it in `handleV1Config` (~`:1786`). No new endpoint.
+3. **Frontend type**: add to `AppConfig` in `frontend/src/types/config.ts`; already ingested reactively into `schemaStore.app` (no store change).
+
+## Rendering surfaces (two)
+
+- **Client-rendered** (entity body, sections, property markdown via `marked`): handled purely in JS. Add `renderPlantUMLDiagrams(container)` to `frontend/src/utils/markdown.ts` mirroring `renderMermaidDiagrams`: find `pre > code.language-plantuml`, deflate+base64-encode the source (PlantUML's encoding), replace `<pre>` with `<img class="plantuml-diagram" src="${server}/svg/${encoded}">`. Gate on `schemaStore.app.plantumlServerUrl` being non-empty.
+- **Server-rendered documents** (goldmark): `documents:` reports rendered by `markdownToHTML` (`document.go`, consumed in `DocumentView.vue` / `DocumentsPanel.vue`). Add `htmlutil.ConvertPlantUMLBlocks` (rewrite `language-plantuml` → `<pre class="plantuml">`) and call it beside `ConvertMermaidBlocks` (`document.go:356`). Recommend merging both into one `ConvertDiagramBlocks` to remove the two-call-site smell. The JS pass must also handle the `pre.plantuml` form (both forms, like mermaid).
+
+Call the new JS pass from the same three components that call
+`renderMermaidDiagrams`: `EntityDetail.vue`, `DocumentView.vue`,
+`DocumentsPanel.vue`.
+
+## Out of scope / notes
+
+- Metamodel help text (`simpleMarkdownToHTML`, `/api/help`) is a server-rendered surface too, but `HelpModal.vue` doesn't even upgrade mermaid today — leave at parity (skip), note it.
+- Default must be empty (disabled). Never default to `www.plantuml.com` — would leak private data to a third party.
+- CSP: main SPA has no CSP today so `<img>` to the server works; optional follow-up to tighten `img-src` to the configured server.
+- Encoding: PlantUML's deflate+custom-base64 (`~30` lines, or `pako` which may already be transitively present via mermaid).
+
+## Acceptance
+
+- With `plantuml_server_url` set, a ```plantuml block renders as a diagram in entity body, sections, and documents.
+- With it empty/absent, the same block renders as a plain code block (no broken image, no network call).

--- a/tickets/relations/FEAT-M37NWU--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-M37NWU--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-M37NWU
+relation: requires
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-THG2JL--affects--data-entry-server.md
+++ b/tickets/relations/TKT-THG2JL--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-THG2JL
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-THG2JL--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-THG2JL--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-THG2JL
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-THG2JL--has-review--REV-40KNQQ.md
+++ b/tickets/relations/TKT-THG2JL--has-review--REV-40KNQQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-THG2JL
+relation: has-review
+to: REV-40KNQQ
+---

--- a/tickets/relations/TKT-THG2JL--has-review-response--RR-21O6D4.md
+++ b/tickets/relations/TKT-THG2JL--has-review-response--RR-21O6D4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-THG2JL
+relation: has-review-response
+to: RR-21O6D4
+---

--- a/tickets/relations/TKT-THG2JL--has-review-response--RR-3OY8XW.md
+++ b/tickets/relations/TKT-THG2JL--has-review-response--RR-3OY8XW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-THG2JL
+relation: has-review-response
+to: RR-3OY8XW
+---

--- a/tickets/relations/TKT-THG2JL--has-review-response--RR-CIAI73.md
+++ b/tickets/relations/TKT-THG2JL--has-review-response--RR-CIAI73.md
@@ -1,0 +1,5 @@
+---
+from: TKT-THG2JL
+relation: has-review-response
+to: RR-CIAI73
+---

--- a/tickets/relations/TKT-THG2JL--has-review-response--RR-F6XG58.md
+++ b/tickets/relations/TKT-THG2JL--has-review-response--RR-F6XG58.md
@@ -1,0 +1,5 @@
+---
+from: TKT-THG2JL
+relation: has-review-response
+to: RR-F6XG58
+---

--- a/tickets/relations/TKT-THG2JL--has-review-response--RR-JTBTUU.md
+++ b/tickets/relations/TKT-THG2JL--has-review-response--RR-JTBTUU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-THG2JL
+relation: has-review-response
+to: RR-JTBTUU
+---

--- a/tickets/relations/TKT-THG2JL--has-review-response--RR-PT28IE.md
+++ b/tickets/relations/TKT-THG2JL--has-review-response--RR-PT28IE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-THG2JL
+relation: has-review-response
+to: RR-PT28IE
+---

--- a/tickets/relations/TKT-THG2JL--has-review-response--RR-Q3U5YW.md
+++ b/tickets/relations/TKT-THG2JL--has-review-response--RR-Q3U5YW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-THG2JL
+relation: has-review-response
+to: RR-Q3U5YW
+---

--- a/tickets/relations/TKT-THG2JL--has-review-response--RR-V0X7FJ.md
+++ b/tickets/relations/TKT-THG2JL--has-review-response--RR-V0X7FJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-THG2JL
+relation: has-review-response
+to: RR-V0X7FJ
+---

--- a/tickets/relations/TKT-THG2JL--implements--FEAT-M37NWU.md
+++ b/tickets/relations/TKT-THG2JL--implements--FEAT-M37NWU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-THG2JL
+relation: implements
+to: FEAT-M37NWU
+---


### PR DESCRIPTION
Adds PlantUML diagram rendering to the data-entry UI, mirroring the existing client-side mermaid integration. PlantUML has no pure-browser renderer, so rendering is delegated to an **operator-configured remote PlantUML server**. Presence of the URL is the on/off switch — **empty/absent = disabled**, and `````plantuml` blocks degrade to plain fenced code.

Implements **FEAT-M37NWU** / **TKT-THG2JL**.

## How it works

- Operator sets `app.plantuml_server_url` in `data-entry.yaml`. Validated at config load (absolute http/https + host) — server refuses to start on a malformed value.
- Published to the SPA via the existing `/api/v1/_config` endpoint (no new endpoint).
- Frontend `~h` hex-encodes the diagram source (zero new deps — no pako/WASM) and points an `<img>` at `<server>/svg/~h<hex>`.
- Two surfaces, like mermaid: client-rendered markdown (entity/section bodies via `marked`) handled purely in JS; server-rendered documents (goldmark) get a fence-class rewrite via the new `htmlutil.ConvertDiagramBlocks` (unifies mermaid + plantuml, removing the prior two-call-site drift).

## Hardening (from code review)

- **URL validation** at config load + client-side scheme guard (defense in depth).
- **`onerror` fallback**: a down/misconfigured/oversized-URL server restores a readable code block instead of a broken-image glyph with the source lost.
- **`referrerPolicy = no-referrer`** so the page URL isn't leaked to the render server.
- **Layout re-settle**: dispatches `rela:plantuml-rendered` on image load; router scroll-to-anchor listens for it alongside the mermaid event.

## Deferred (tracked as review-responses)

- Server-side proxy so the render host never reaches the browser (RR-21O6D4) — the security-shaped alternative to the direct-`<img>` approach.
- Converging the two `markdownToHTML` pipelines (RR-PT28IE) — pre-existing debt.

## Tests

- Go: `htmlutil` converters, `validateApp` (9 cases). All affected packages pass + `go vet` + `just arch-lint`.
- Frontend: 62 unit tests (encoder, both source forms, disabled/empty/unsafe-scheme no-ops, no-referrer, onerror fallback). `vue-tsc` typecheck clean, lint 0 errors.

## Notes / out of scope

- Metamodel help text (`/api/help`) left at parity with mermaid (not upgraded today).
- Default is empty (disabled); never defaults to public plantuml.com.