### PR TITLE
refactor(dataentry): extract analyzeService from App (TKT-N26KLB, M5.1)

### DIFF
--- a/internal/dataentry/analyze.go
+++ b/internal/dataentry/analyze.go
@@ -8,9 +8,26 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/natsort"
 	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/tracer"
+	"github.com/Sourcehaven-BV/rela/internal/validator"
 )
+
+// analyzeService runs the read-only graph-analysis checks (orphans,
+// duplicates, gaps, cardinality, properties, validations). Extracted from App
+// (TKT-N26KLB M5.1): it depends only on the stable read services, and each
+// method takes the per-request metamodel snapshot explicitly (capture-once,
+// per the project's snapshot rule) rather than reaching back into App.
+//
+// The whole-graph scans are intentionally ungated; visibility is applied to
+// the resulting issues at the HTTP boundary (see visibleAnalysisIssues).
+type analyzeService struct {
+	store     store.Store
+	tracer    tracer.Tracer
+	validator validator.Validator
+}
 
 // AnalysisIssue represents a single validation issue, optionally linked to an entity.
 type AnalysisIssue struct {
@@ -67,14 +84,14 @@ type AnalysisResult struct {
 }
 
 // runAnalysis executes all analysis checks and returns a combined result.
-func (a *App) runAnalysis(ctx context.Context) AnalysisResult {
+func (svc analyzeService) runAnalysis(ctx context.Context, meta *metamodel.Metamodel) AnalysisResult {
 	sections := []AnalysisSection{
-		a.analyzeProperties(ctx),
-		a.analyzeCardinality(ctx),
-		a.analyzeValidations(ctx),
-		a.analyzeOrphans(ctx),
-		a.analyzeDuplicates(ctx),
-		a.analyzeGaps(ctx),
+		svc.analyzeProperties(ctx, meta),
+		svc.analyzeCardinality(ctx, meta),
+		svc.analyzeValidations(ctx, meta),
+		svc.analyzeOrphans(ctx, meta),
+		svc.analyzeDuplicates(ctx, meta),
+		svc.analyzeGaps(ctx, meta),
 	}
 
 	var errors, warnings int
@@ -92,23 +109,22 @@ func (a *App) runAnalysis(ctx context.Context) AnalysisResult {
 
 // analysisIssueCounts returns just the total error and warning counts
 // without building the full issue details. Used by the dashboard.
-func (a *App) analysisIssueCounts(ctx context.Context) (errors, warnings int) {
-	result := a.runAnalysis(ctx)
+func (svc analyzeService) analysisIssueCounts(ctx context.Context, meta *metamodel.Metamodel) (errors, warnings int) {
+	result := svc.runAnalysis(ctx, meta)
 	return result.ErrorCount, result.WarningCount
 }
 
 // analyzeOrphans finds entities with no connections.
-func (a *App) analyzeOrphans(ctx context.Context) AnalysisSection {
-	s := a.State()
+func (svc analyzeService) analyzeOrphans(ctx context.Context, meta *metamodel.Metamodel) AnalysisSection {
 	section := AnalysisSection{
 		Name:        "Orphans",
 		Description: "Entities with no incoming or outgoing relations",
 	}
 
-	orphanIDs, _ := a.tracer.FindOrphans(ctx)
+	orphanIDs, _ := svc.tracer.FindOrphans(ctx)
 
 	var orphans []*entity.Entity
-	st := a.store
+	st := svc.store
 	for _, id := range orphanIDs {
 		if e, err := st.GetEntity(ctx, id); err == nil {
 			orphans = append(orphans, e)
@@ -120,7 +136,7 @@ func (a *App) analyzeOrphans(ctx context.Context) AnalysisSection {
 		section.Issues = append(section.Issues, AnalysisIssue{
 			EntityID:   e.ID,
 			EntityType: e.Type,
-			Title:      s.Meta.DisplayTitle(e.ID, e.Type, e.Properties),
+			Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
 			Message:    "No relations",
 			Severity:   "warning",
 		})
@@ -130,19 +146,18 @@ func (a *App) analyzeOrphans(ctx context.Context) AnalysisSection {
 }
 
 // analyzeDuplicates finds entities with identical normalized titles.
-func (a *App) analyzeDuplicates(ctx context.Context) AnalysisSection {
-	s := a.State()
+func (svc analyzeService) analyzeDuplicates(ctx context.Context, meta *metamodel.Metamodel) AnalysisSection {
 	section := AnalysisSection{
 		Name:        "Duplicates",
 		Description: "Entities with identical titles",
 	}
 
 	titleGroups := make(map[string][]*entity.Entity)
-	for e, err := range a.store.ListEntities(ctx, store.EntityQuery{}) {
+	for e, err := range svc.store.ListEntities(ctx, store.EntityQuery{}) {
 		if err != nil {
 			break
 		}
-		title := normalizeTitle(s.Meta.DisplayTitle(e.ID, e.Type, e.Properties))
+		title := normalizeTitle(meta.DisplayTitle(e.ID, e.Type, e.Properties))
 		if title != "" {
 			titleGroups[title] = append(titleGroups[title], e)
 		}
@@ -168,7 +183,7 @@ func (a *App) analyzeDuplicates(ctx context.Context) AnalysisSection {
 			section.Issues = append(section.Issues, AnalysisIssue{
 				EntityID:   e.ID,
 				EntityType: e.Type,
-				Title:      s.Meta.DisplayTitle(e.ID, e.Type, e.Properties),
+				Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
 				Message:    fmt.Sprintf("Duplicate title (shared by %s)", strings.Join(ids, ", ")),
 				Severity:   "warning",
 			})
@@ -179,8 +194,7 @@ func (a *App) analyzeDuplicates(ctx context.Context) AnalysisSection {
 }
 
 // analyzeGaps finds gaps in ID sequences for auto-numbered entity types.
-func (a *App) analyzeGaps(ctx context.Context) AnalysisSection {
-	s := a.State()
+func (svc analyzeService) analyzeGaps(ctx context.Context, meta *metamodel.Metamodel) AnalysisSection {
 	section := AnalysisSection{
 		Name:        "ID Gaps",
 		Description: "Missing numbers in auto-generated ID sequences",
@@ -190,7 +204,7 @@ func (a *App) analyzeGaps(ctx context.Context) AnalysisSection {
 	// in a single pass over the metamodel.
 	manualPrefixes := make(map[string]bool)
 	typeByPrefix := make(map[string]string)
-	for typeName, entityDef := range s.Meta.Entities {
+	for typeName, entityDef := range meta.Entities {
 		for _, idPrefix := range entityDef.GetIDPrefixes() {
 			trimmed := strings.TrimSuffix(idPrefix, "-")
 			if entityDef.IsManualID() {
@@ -203,7 +217,7 @@ func (a *App) analyzeGaps(ctx context.Context) AnalysisSection {
 
 	// Group IDs by prefix
 	prefixGroups := make(map[string][]int)
-	for e, err := range a.store.ListEntities(ctx, store.EntityQuery{}) {
+	for e, err := range svc.store.ListEntities(ctx, store.EntityQuery{}) {
 		if err != nil {
 			break
 		}
@@ -254,18 +268,17 @@ func (a *App) analyzeGaps(ctx context.Context) AnalysisSection {
 }
 
 // analyzeCardinality checks relation cardinality constraints.
-func (a *App) analyzeCardinality(ctx context.Context) AnalysisSection {
-	s := a.State()
+func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamodel.Metamodel) AnalysisSection {
 	section := AnalysisSection{
 		Name:        "Cardinality",
 		Description: "Relation cardinality constraint violations",
 	}
 
-	st := a.store
+	st := svc.store
 
 	// Sort relation names for deterministic output
-	relNames := make([]string, 0, len(s.Meta.Relations))
-	for name := range s.Meta.Relations {
+	relNames := make([]string, 0, len(meta.Relations))
+	for name := range meta.Relations {
 		relNames = append(relNames, name)
 	}
 	natsort.Strings(relNames)
@@ -292,7 +305,7 @@ func (a *App) analyzeCardinality(ctx context.Context) AnalysisSection {
 	}
 
 	for _, relName := range relNames {
-		relDef := s.Meta.Relations[relName]
+		relDef := meta.Relations[relName]
 
 		// Check min_outgoing
 		if relDef.MinOutgoing != nil && *relDef.MinOutgoing > 0 {
@@ -303,7 +316,7 @@ func (a *App) analyzeCardinality(ctx context.Context) AnalysisSection {
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      s.Meta.DisplayTitle(e.ID, e.Type, e.Properties),
+							Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
 							Message:    fmt.Sprintf("Must have at least %d '%s' relation(s), has %d", *relDef.MinOutgoing, relName, count),
 							Severity:   "error",
 						})
@@ -321,7 +334,7 @@ func (a *App) analyzeCardinality(ctx context.Context) AnalysisSection {
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      s.Meta.DisplayTitle(e.ID, e.Type, e.Properties),
+							Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
 							Message:    fmt.Sprintf("Has more than %d '%s' relation(s): %d", *relDef.MaxOutgoing, relName, count),
 							Severity:   "error",
 						})
@@ -343,7 +356,7 @@ func (a *App) analyzeCardinality(ctx context.Context) AnalysisSection {
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      s.Meta.DisplayTitle(e.ID, e.Type, e.Properties),
+							Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
 							Message:    fmt.Sprintf("Must have at least %d '%s' relation(s), has %d", *relDef.MinIncoming, relLabel, count),
 							Severity:   "error",
 						})
@@ -365,7 +378,7 @@ func (a *App) analyzeCardinality(ctx context.Context) AnalysisSection {
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      s.Meta.DisplayTitle(e.ID, e.Type, e.Properties),
+							Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
 							Message:    fmt.Sprintf("Has more than %d '%s' relation(s): %d", *relDef.MaxIncoming, relLabel, count),
 							Severity:   "error",
 						})
@@ -379,15 +392,14 @@ func (a *App) analyzeCardinality(ctx context.Context) AnalysisSection {
 }
 
 // analyzeProperties validates all entity properties against the metamodel.
-func (a *App) analyzeProperties(ctx context.Context) AnalysisSection {
-	s := a.State()
+func (svc analyzeService) analyzeProperties(ctx context.Context, meta *metamodel.Metamodel) AnalysisSection {
 	section := AnalysisSection{
 		Name:        "Properties",
 		Description: "Property validation errors (required fields, invalid values, ID patterns)",
 	}
 
 	entities := make([]*entity.Entity, 0)
-	for e, err := range a.store.ListEntities(ctx, store.EntityQuery{}) {
+	for e, err := range svc.store.ListEntities(ctx, store.EntityQuery{}) {
 		if err != nil {
 			break
 		}
@@ -396,12 +408,12 @@ func (a *App) analyzeProperties(ctx context.Context) AnalysisSection {
 	sortStoreEntitiesByID(entities)
 
 	for _, e := range entities {
-		errs := s.Meta.ValidateEntity(e.ID, e.Type, e.Properties)
+		errs := meta.ValidateEntity(e.ID, e.Type, e.Properties)
 		for _, err := range errs {
 			section.Issues = append(section.Issues, AnalysisIssue{
 				EntityID:   e.ID,
 				EntityType: e.Type,
-				Title:      s.Meta.DisplayTitle(e.ID, e.Type, e.Properties),
+				Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
 				Message:    err.Error(),
 				Severity:   "error",
 			})
@@ -418,17 +430,16 @@ func (a *App) analyzeProperties(ctx context.Context) AnalysisSection {
 // (lua_file: missing, traversal-rejected) appear as error issues
 // alongside per-entity violations. Without this, broken Lua rules
 // would vanish silently from the data-entry analyze view.
-func (a *App) analyzeValidations(ctx context.Context) AnalysisSection {
-	s := a.State()
+func (svc analyzeService) analyzeValidations(ctx context.Context, meta *metamodel.Metamodel) AnalysisSection {
 	section := AnalysisSection{
 		Name:        "Validations",
 		Description: "Custom validation rules defined in the metamodel",
 	}
 
-	st := a.store
-	validator := a.validator
+	st := svc.store
+	validator := svc.validator
 
-	for _, rule := range s.Meta.Validations {
+	for _, rule := range meta.Validations {
 		full, err := validator.CheckRuleFull(ctx, rule)
 		if err != nil {
 			continue
@@ -442,7 +453,7 @@ func (a *App) analyzeValidations(ctx context.Context) AnalysisSection {
 			section.Issues = append(section.Issues, AnalysisIssue{
 				EntityID:   e.ID,
 				EntityType: e.Type,
-				Title:      s.Meta.DisplayTitle(e.ID, e.Type, e.Properties),
+				Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
 				Message:    rule.Description,
 				Severity:   severity,
 			})

--- a/internal/dataentry/analyze_test.go
+++ b/internal/dataentry/analyze_test.go
@@ -6,13 +6,27 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
-// newTestApp creates a minimal App with the given fixture and metamodel for testing.
-func newTestApp(f *fixture, meta *metamodel.Metamodel) *App {
-	return newAppFromParts(&Config{}, meta, f)
+// newAnalyzeService builds an analyzeService directly from a fixture + meta,
+// with no App. Since the extraction (TKT-N26KLB M5.1) made analyzeService
+// depend only on {store, tracer, validator} plus a per-call meta, the analysis
+// tests construct it in isolation rather than standing up a whole App.
+func newAnalyzeService(t *testing.T, f *fixture, meta *metamodel.Metamodel) analyzeService {
+	t.Helper()
+	fs := storage.NewMemFS()
+	ctx := &project.Context{Root: "/project", CacheDir: "/project/.rela"}
+	if err := fs.MkdirAll(ctx.CacheDir, 0o755); err != nil {
+		t.Fatalf("newAnalyzeService: mkdir: %v", err)
+	}
+	svc := appbuildtest.New(meta, appbuildtest.WithFS(fs, ctx))
+	seedFromFixture(svc.Store(), f)
+	return analyzeService{store: svc.Store(), tracer: svc.Tracer(), validator: svc.Validator()}
 }
 
 func TestAnalyzeOrphans(t *testing.T) {
@@ -30,8 +44,8 @@ func TestAnalyzeOrphans(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "T-003", Type: "ticket", Properties: map[string]interface{}{"title": "Connected B"}})
 	g.AddEdge(&entity.Relation{From: "T-002", Type: "blocks", To: "T-003"})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeOrphans(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeOrphans(context.Background(), meta)
 
 	if section.Name != "Orphans" {
 		t.Errorf("expected section name 'Orphans', got %q", section.Name)
@@ -59,8 +73,8 @@ func TestAnalyzeOrphans_NoOrphans(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{}})
 	g.AddEdge(&entity.Relation{From: "T-001", Type: "blocks", To: "T-002"})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeOrphans(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeOrphans(context.Background(), meta)
 
 	if len(section.Issues) != 0 {
 		t.Errorf("expected 0 orphans, got %d", len(section.Issues))
@@ -81,8 +95,8 @@ func TestAnalyzeDuplicates(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{"title": "setup ci"}})
 	g.AddNode(&entity.Entity{ID: "T-003", Type: "ticket", Properties: map[string]interface{}{"title": "Unique"}})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeDuplicates(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeDuplicates(context.Background(), meta)
 
 	if len(section.Issues) != 2 {
 		t.Fatalf("expected 2 duplicate issues (for the pair), got %d", len(section.Issues))
@@ -107,8 +121,8 @@ func TestAnalyzeDuplicates_NoDuplicates(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{"title": "Alpha"}})
 	g.AddNode(&entity.Entity{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{"title": "Beta"}})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeDuplicates(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeDuplicates(context.Background(), meta)
 
 	if len(section.Issues) != 0 {
 		t.Errorf("expected 0 duplicate issues, got %d", len(section.Issues))
@@ -127,8 +141,8 @@ func TestAnalyzeGaps(t *testing.T) {
 	// T-002 missing
 	g.AddNode(&entity.Entity{ID: "T-003", Type: "ticket", Properties: map[string]interface{}{}})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeGaps(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeGaps(context.Background(), meta)
 
 	if len(section.Issues) != 1 {
 		t.Fatalf("expected 1 gap issue, got %d", len(section.Issues))
@@ -160,8 +174,8 @@ func TestAnalyzeGaps_ManualIDsSkipped(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "C-001", Type: "component", Properties: map[string]interface{}{}})
 	g.AddNode(&entity.Entity{ID: "C-005", Type: "component", Properties: map[string]interface{}{}})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeGaps(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeGaps(context.Background(), meta)
 
 	if len(section.Issues) != 0 {
 		t.Errorf("expected 0 gap issues for manual ID type, got %d", len(section.Issues))
@@ -185,8 +199,8 @@ func TestAnalyzeGaps_MultiplePrefixes(t *testing.T) {
 	// FEAT-002 missing
 	g.AddNode(&entity.Entity{ID: "FEAT-003", Type: "feature", Properties: map[string]interface{}{}})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeGaps(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeGaps(context.Background(), meta)
 
 	if len(section.Issues) != 1 {
 		t.Fatalf("expected 1 gap issue, got %d", len(section.Issues))
@@ -223,8 +237,8 @@ func TestAnalyzeCardinality(t *testing.T) {
 	// Only T-001 implements C-001; T-002 has no implements relation
 	g.AddEdge(&entity.Relation{From: "T-001", Type: "implements", To: "C-001"})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeCardinality(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeCardinality(context.Background(), meta)
 
 	if len(section.Issues) != 1 {
 		t.Fatalf("expected 1 cardinality violation, got %d", len(section.Issues))
@@ -258,8 +272,8 @@ func TestAnalyzeCardinality_AllSatisfied(t *testing.T) {
 	g.AddNode(&entity.Entity{ID: "C-001", Type: "component", Properties: map[string]interface{}{}})
 	g.AddEdge(&entity.Relation{From: "T-001", Type: "implements", To: "C-001"})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeCardinality(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeCardinality(context.Background(), meta)
 
 	if len(section.Issues) != 0 {
 		t.Errorf("expected 0 violations, got %d", len(section.Issues))
@@ -285,8 +299,8 @@ func TestAnalyzeProperties(t *testing.T) {
 	// Valid entity
 	g.AddNode(&entity.Entity{ID: "T-002", Type: "ticket", Properties: map[string]interface{}{"title": "Good", "status": "open"}})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeProperties(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeProperties(context.Background(), meta)
 
 	if len(section.Issues) < 2 {
 		t.Fatalf("expected at least 2 property errors (missing title + invalid enum), got %d", len(section.Issues))
@@ -317,8 +331,8 @@ func TestAnalyzeProperties_AllValid(t *testing.T) {
 
 	g.AddNode(&entity.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{"title": "Valid"}})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeProperties(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeProperties(context.Background(), meta)
 
 	if len(section.Issues) != 0 {
 		t.Errorf("expected 0 property issues, got %d", len(section.Issues))
@@ -353,8 +367,8 @@ func TestAnalyzeValidations(t *testing.T) {
 	// Draft — rule doesn't apply
 	g.AddNode(&entity.Entity{ID: "T-003", Type: "ticket", Properties: map[string]interface{}{"status": "draft"}})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeValidations(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeValidations(context.Background(), meta)
 
 	if len(section.Issues) != 1 {
 		t.Fatalf("expected 1 validation issue, got %d", len(section.Issues))
@@ -388,8 +402,8 @@ func TestAnalyzeValidations_SurfacesScriptError(t *testing.T) {
 	}
 	g.AddNode(&entity.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{}})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeValidations(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeValidations(context.Background(), meta)
 
 	if len(section.Issues) == 0 {
 		t.Fatal("expected the script error to surface as an analysis issue, got 0 issues")
@@ -433,8 +447,8 @@ func TestAnalyzeValidations_SurfacesLoadError(t *testing.T) {
 	}
 	g.AddNode(&entity.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{}})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeValidations(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeValidations(context.Background(), meta)
 
 	if len(section.Issues) == 0 {
 		t.Fatal("expected the load error to surface as an analysis issue, got 0 issues")
@@ -467,8 +481,8 @@ func TestAnalyzeValidations_NoRules(t *testing.T) {
 		},
 	}
 
-	app := newTestApp(g, meta)
-	section := app.analyzeValidations(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeValidations(context.Background(), meta)
 
 	if len(section.Issues) != 0 {
 		t.Errorf("expected 0 issues with no rules, got %d", len(section.Issues))
@@ -491,8 +505,8 @@ func TestRunAnalysis(t *testing.T) {
 	// Orphan with missing required property
 	g.AddNode(&entity.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{}})
 
-	app := newTestApp(g, meta)
-	result := app.runAnalysis(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	result := svc.runAnalysis(context.Background(), meta)
 
 	if len(result.Sections) != 6 {
 		t.Errorf("expected 6 sections, got %d", len(result.Sections))
@@ -512,8 +526,8 @@ func TestRunAnalysis_EmptyGraph(t *testing.T) {
 		Entities: map[string]metamodel.EntityDef{},
 	}
 
-	app := newTestApp(g, meta)
-	result := app.runAnalysis(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	result := svc.runAnalysis(context.Background(), meta)
 
 	if result.ErrorCount != 0 {
 		t.Errorf("expected 0 errors for empty graph, got %d", result.ErrorCount)
@@ -558,8 +572,8 @@ func TestAnalysisIssueCounts(t *testing.T) {
 	// Orphan (warning) + missing required title (error)
 	g.AddNode(&entity.Entity{ID: "T-001", Type: "ticket", Properties: map[string]interface{}{}})
 
-	app := newTestApp(g, meta)
-	errors, warnings := app.analysisIssueCounts(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	errors, warnings := svc.analysisIssueCounts(context.Background(), meta)
 
 	if errors < 1 {
 		t.Errorf("expected at least 1 error, got %d", errors)
@@ -634,8 +648,8 @@ func TestAnalyzeValidationsWithContentRules(t *testing.T) {
 		Content:    "# Draft decision",
 	})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeValidations(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeValidations(context.Background(), meta)
 
 	if len(section.Issues) != 1 {
 		t.Fatalf("expected 1 content validation issue, got %d", len(section.Issues))
@@ -697,8 +711,8 @@ func TestAnalyzeValidationsWithCombinedRules(t *testing.T) {
 		Content:    "# Decision\n## Context\nAll good",
 	})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeValidations(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeValidations(context.Background(), meta)
 
 	if len(section.Issues) != 2 {
 		t.Fatalf("expected 2 violations (DEC-001 and DEC-002), got %d", len(section.Issues))
@@ -764,8 +778,8 @@ func TestAnalyzeValidationsWithChecklistRule(t *testing.T) {
 		Content:    "- [ ] Not started",
 	})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeValidations(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeValidations(context.Background(), meta)
 
 	if len(section.Issues) != 1 {
 		t.Fatalf("expected 1 checklist validation issue, got %d", len(section.Issues))
@@ -819,8 +833,8 @@ func TestAnalyzeValidationsWithChecklistAllowSkipped(t *testing.T) {
 		Content:    "- [x] Done item\n- [ ] Not done, not skipped",
 	})
 
-	app := newTestApp(g, meta)
-	section := app.analyzeValidations(context.Background())
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeValidations(context.Background(), meta)
 
 	if len(section.Issues) != 1 {
 		t.Fatalf("expected 1 checklist validation issue, got %d", len(section.Issues))
@@ -838,8 +852,9 @@ func TestAnalyzeValidationsWithChecklistAllowSkipped(t *testing.T) {
 // Renaming a section here without updating both consumers silently
 // regresses the GH#785 hidden-card bug.
 func TestRunAnalysisSectionNames(t *testing.T) {
-	app := newTestApp(newFixture(), &metamodel.Metamodel{})
-	result := app.runAnalysis(context.Background())
+	meta := &metamodel.Metamodel{}
+	svc := newAnalyzeService(t, newFixture(), meta)
+	result := svc.runAnalysis(context.Background(), meta)
 	got := make([]string, len(result.Sections))
 	for i, s := range result.Sections {
 		got[i] = s.Name

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -1869,7 +1869,7 @@ func (a *App) handleV1Analyze(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	analysisResult := a.runAnalysis(r.Context())
+	analysisResult := a.analyze.runAnalysis(r.Context(), a.State().Meta)
 
 	// ACL gate (TKT-QU7REX): runAnalysis walks the WHOLE graph, so every issue
 	// carries an entityId/entityType/title that would leak existence + title to

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -99,11 +99,11 @@ const userPaletteFile = "palette.yaml"
 // readers — readers go through state.Load(). The workspace's internal
 // reloadMu coordinates the reload itself with the mutation path.
 //
-// TODO(TKT-N26KLB): App is a god-object (209 methods). Decompose toward the
+// TODO(TKT-N26KLB): App is a god-object (201 methods). Decompose toward the
 // 40-method load line — extract the API/serialization/relation services into
 // their own types. Ratchet this number DOWN as methods move out; never up.
 //
-//plimsoll:max-methods=209
+//plimsoll:max-methods=201
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -130,10 +130,14 @@ type App struct {
 	visibleReader visibleReader
 	tracer        tracer.Tracer
 	validator     validator.Validator
-	templater     templating.Templater
-	cfgLoader     config.Loader
-	kv            state.KV
-	acl           acl.ACL
+	// analyze runs the read-only graph-analysis checks. Extracted from App
+	// (TKT-N26KLB M5.1); holds its own {store, tracer, validator} and takes
+	// the metamodel snapshot per call.
+	analyze   analyzeService
+	templater templating.Templater
+	cfgLoader config.Loader
+	kv        state.KV
+	acl       acl.ACL
 
 	// documents renders and caches documents. Created once in NewApp so
 	// singleflight deduplication is stable across requests.
@@ -444,6 +448,7 @@ func NewApp(
 		visibleReader:   newVisibleReader(st),
 		tracer:          trc,
 		validator:       val,
+		analyze:         analyzeService{store: st, tracer: trc, validator: val},
 		templater:       templater,
 		cfgLoader:       cfgLoader,
 		kv:              kv,

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -131,6 +131,7 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	app.visibleSearcher = svc.VisibleSearcher()
 	app.tracer = svc.Tracer()
 	app.validator = svc.Validator()
+	app.analyze = analyzeService{store: svc.Store(), tracer: svc.Tracer(), validator: svc.Validator()}
 	app.templater = svc.Templater()
 	app.cfgLoader = svc.Config()
 	app.kv = svc.State()


### PR DESCRIPTION
Third step of the `dataentry.App` decomposition (**TKT-N26KLB**). Stacked on #1032. **First step that reduces App's method count.**

## What

Move the 8 read-only graph-analysis methods off `App` into a focused **`analyzeService`** holding its own `{store, tracer, validator}`:

`runAnalysis`, `analysisIssueCounts`, `analyzeOrphans`, `analyzeDuplicates`, `analyzeGaps`, `analyzeCardinality`, `analyzeProperties`, `analyzeValidations`.

Each method now takes the metamodel snapshot **explicitly** (`meta *metamodel.Metamodel`) instead of reaching back into `a.State()` — the cluster only ever used `s.Meta`, so the param is all it needs. `handleV1Analyze` captures the snapshot once (`a.State().Meta`) and passes it in. This is the snapshot-as-param template for the remaining read-handler extractions.

## Design note: why raw store, not visibleReader

The analyze scans are **intentionally ungated**. `runAnalysis` walks the whole graph; visibility is applied to the resulting *issues* at the HTTP boundary (`visibleAnalysisIssues`). Gating the scan would make aggregation wrong — e.g. a cardinality check must count relations to hidden entities to know whether a *visible* entity violates its minimum. Documented on the type.

## Tests

The analysis tests now construct `analyzeService` directly via a new `newAnalyzeService(t, f, meta)` helper — **no App** — concretely demonstrating the decoupling the extraction bought (and faster, skipping App wiring). The now-unused `newTestApp` helper is removed. (Per crit review feedback.)

## Result

`App`: **209 → 201 methods**; plimsoll directive ratcheted. Behavior-preserving.

## Verification

`go build ./...`, `go test -race ./internal/dataentry/` (full suite incl. all analyze + ACL tests), `golangci-lint` (0 issues), `just arch-lint`, `plimsoll ./...` (exit 0) all green.