### PR TITLE
refactor(dataentry): extract affordanceService from App (TKT-N26KLB, M5.2)

### DIFF
--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -68,6 +68,44 @@ func translateRelationWrite(relType, fromType, fromID string) acl.WriteRequest {
 	}}
 }
 
+// affordanceService computes the read-time affordance maps (_actions,
+// per-field/relation verdicts) and runs the write-time affordance validation
+// that gates field and relation writes. Extracted from App (TKT-N26KLB M5.2):
+// it is the shared write-authorization seam every data-entry write funnels
+// through.
+//
+// It holds the ACL and the field-verdict resolver, plus a per-request
+// metamodel accessor (meta) — the metamodel can change on reload, so it MUST
+// be fetched per call, never captured. The two relation-graph reads it needs
+// (getEntity, currentEdgesByPeer) are injected as callbacks rather than pulling
+// the relation plumbing in.
+//
+// IMPORTANT — two invariants this type must preserve:
+//   - It shares the SAME acl.ACL instance as the write path
+//     (entitymanager). affordances_contract_test.go pins the
+//     "_actions[v]==false ⇒ 403 on the write" contract against that shared
+//     instance; a divergent ACL here silently breaks it.
+//   - acl.WriteRequest is constructed ONLY via the package-level translateVerb
+//     / translateRelationWrite in this file (affordances.go); lint_test.go
+//     greps this exact filename. Do not methodize those constructors or move
+//     them to another file.
+type affordanceService struct {
+	// acl and resolver are per-call accessors (not captured values): both can be
+	// swapped on App after construction (tests do `app.acl = …` /
+	// `app.fieldResolver = …`), so a captured copy would go stale. Reading acl
+	// live from App is also what structurally guarantees the affordance service
+	// uses the SAME acl as the write path — the contract-test invariant.
+	acl      func() acl.ACL
+	resolver func() FieldVerdictResolver
+	store    store.Store
+	meta     func() *metamodel.Metamodel
+	// getEntity resolves an entity by ID for relation-source attribution.
+	getEntity func(ctx context.Context, id string) (*entityPkg.Entity, bool)
+	// currentEdgesByPeer returns the current edges of entityID for a relation
+	// type/direction, keyed by peer ID. Used to diff desired-vs-current edges.
+	currentEdgesByPeer func(ctx context.Context, entityID, canonical string, incoming bool) map[string]*entityPkg.Relation
+}
+
 // perItemVerbs are the verbs computed per entity instance.
 var perItemVerbs = []string{"update", "delete", "rename"}
 
@@ -81,20 +119,20 @@ var perCollectionVerbs = []string{"create"}
 // callers) get the same `{verb: bool}` shape evaluated against
 // whatever Principal is on ctx, defaulting to `principal.From`'s
 // "unknown" sentinel.
-func (a *App) computeActions(ctx context.Context, e *entityPkg.Entity) map[string]bool {
+func (svc affordanceService) computeActions(ctx context.Context, e *entityPkg.Entity) map[string]bool {
 	out := make(map[string]bool, len(perItemVerbs))
 	for _, v := range perItemVerbs {
-		out[v] = a.acl.AuthorizeWrite(ctx, translateVerb(v, e.Type, e.ID)).Allow
+		out[v] = svc.acl().AuthorizeWrite(ctx, translateVerb(v, e.Type, e.ID)).Allow
 	}
 	return out
 }
 
 // computeCollectionActions returns the collection-scope verb verdict
 // map for an entity type — currently just `create`.
-func (a *App) computeCollectionActions(ctx context.Context, entityType string) map[string]bool {
+func (svc affordanceService) computeCollectionActions(ctx context.Context, entityType string) map[string]bool {
 	out := make(map[string]bool, len(perCollectionVerbs))
 	for _, v := range perCollectionVerbs {
-		out[v] = a.acl.AuthorizeWrite(ctx, translateVerb(v, entityType, "")).Allow
+		out[v] = svc.acl().AuthorizeWrite(ctx, translateVerb(v, entityType, "")).Allow
 	}
 	return out
 }
@@ -241,12 +279,12 @@ func (d AffordanceDenialError) Error() string {
 // Values are required only for the enum-filter check; pass the
 // requested value for each key in setValues. Unknown values default
 // to allowed (an option entry of `nil` means "no override").
-func (a *App) validateFieldWrite(ctx context.Context, e *entityPkg.Entity, setKeys map[string]interface{}, unsetKeys []string) *AffordanceDenialError {
+func (svc affordanceService) validateFieldWrite(ctx context.Context, e *entityPkg.Entity, setKeys map[string]interface{}, unsetKeys []string) *AffordanceDenialError {
 	if e == nil {
 		return nil
 	}
-	v := a.fieldResolver.FieldVerdicts(ctx, e)
-	declared := declaredProperties(a.State().Meta, e.Type)
+	v := svc.resolver().FieldVerdicts(ctx, e)
+	declared := declaredProperties(svc.meta(), e.Type)
 
 	check := func(key string, value interface{}, present bool) *AffordanceDenialError {
 		// Unknown field (not in metamodel, not in resolver overrides) →
@@ -453,13 +491,13 @@ const (
 //
 // Returns the path entity when the peer can't be found locally (404
 // upstream — should not happen in practice; safe-fail).
-func (a *App) relationSourceEntity(
+func (svc affordanceService) relationSourceEntity(
 	ctx context.Context, pathEntity *entityPkg.Entity, peerID, direction string,
 ) *entityPkg.Entity {
 	if direction != string(DirectionIncoming) {
 		return pathEntity
 	}
-	peer, ok := a.getEntity(ctx, peerID)
+	peer, ok := svc.getEntity(ctx, peerID)
 	if !ok {
 		return pathEntity
 	}
@@ -471,11 +509,11 @@ func (a *App) relationSourceEntity(
 // `relType` is the canonical relation type; `op` selects between
 // create / remove. The verdict is per-relation-type uniform —
 // per-link affordances are predicate territory.
-func (a *App) validateRelationOp(ctx context.Context, e *entityPkg.Entity, relType string, op RelationOp) *AffordanceDenialError {
+func (svc affordanceService) validateRelationOp(ctx context.Context, e *entityPkg.Entity, relType string, op RelationOp) *AffordanceDenialError {
 	if e == nil {
 		return nil
 	}
-	v := a.fieldResolver.RelationVerdicts(ctx, e)
+	v := svc.resolver().RelationVerdicts(ctx, e)
 	rv, ok := v.Types[relType]
 	if !ok {
 		return nil // default-permissive
@@ -512,14 +550,14 @@ func (a *App) validateRelationOp(ctx context.Context, e *entityPkg.Entity, relTy
 // Called from the unified PATCH handler before
 // [App.applyRelationsModern]. Returns nil when every relation
 // operation is permitted.
-func (a *App) validateRelationsModernAffordances(
+func (svc affordanceService) validateRelationsModernAffordances(
 	ctx context.Context, entityID string, e *entityPkg.Entity,
 	desired map[string]V1RelationsUpdate,
 ) *AffordanceDenialError {
 	if e == nil || len(desired) == 0 {
 		return nil
 	}
-	meta := a.State().Meta
+	meta := svc.meta()
 	for bodyKey, upd := range desired {
 		if !upd.DataPresent {
 			continue
@@ -533,7 +571,7 @@ func (a *App) validateRelationsModernAffordances(
 		for _, ref := range upd.Data {
 			desiredByID[ref.ID] = ref
 		}
-		current := a.currentEdgesByPeer(ctx, entityID, canonical, incoming)
+		current := svc.currentEdgesByPeer(ctx, entityID, canonical, incoming)
 
 		// For incoming-direction body keys the SOURCE of every edge is
 		// the peer entity, not the path entity. Verdicts are evaluated
@@ -546,18 +584,18 @@ func (a *App) validateRelationsModernAffordances(
 
 		// Adds: any desired edge whose peer isn't currently linked.
 		for _, ref := range upd.Data {
-			source := a.relationSourceEntity(ctx, e, ref.ID, direction)
+			source := svc.relationSourceEntity(ctx, e, ref.ID, direction)
 			if _, exists := current[ref.ID]; exists {
 				// Upsert path: not a create, but the meta may change.
-				if denial := a.validateRelationMetaWrite(ctx, source, canonical, ref.Meta, ref.MetaUnset); denial != nil {
+				if denial := svc.validateRelationMetaWrite(ctx, source, canonical, ref.Meta, ref.MetaUnset); denial != nil {
 					return denial
 				}
 				continue
 			}
-			if denial := a.validateRelationOp(ctx, source, canonical, RelationOpCreate); denial != nil {
+			if denial := svc.validateRelationOp(ctx, source, canonical, RelationOpCreate); denial != nil {
 				return denial
 			}
-			if denial := a.validateRelationMetaWrite(ctx, source, canonical, ref.Meta, ref.MetaUnset); denial != nil {
+			if denial := svc.validateRelationMetaWrite(ctx, source, canonical, ref.Meta, ref.MetaUnset); denial != nil {
 				return denial
 			}
 		}
@@ -567,8 +605,8 @@ func (a *App) validateRelationsModernAffordances(
 			if _, kept := desiredByID[peerID]; kept {
 				continue
 			}
-			source := a.relationSourceEntity(ctx, e, peerID, direction)
-			if denial := a.validateRelationOp(ctx, source, canonical, RelationOpRemove); denial != nil {
+			source := svc.relationSourceEntity(ctx, e, peerID, direction)
+			if denial := svc.validateRelationOp(ctx, source, canonical, RelationOpRemove); denial != nil {
 				return denial
 			}
 		}
@@ -586,11 +624,11 @@ func (a *App) validateRelationsModernAffordances(
 // rejected here — they're a separate concern handled by the existing
 // relation validation. The affordance check focuses on rejecting
 // keys explicitly marked non-writable.
-func (a *App) validateRelationMetaWrite(ctx context.Context, e *entityPkg.Entity, relType string, meta map[string]interface{}, metaUnset []string) *AffordanceDenialError {
+func (svc affordanceService) validateRelationMetaWrite(ctx context.Context, e *entityPkg.Entity, relType string, meta map[string]interface{}, metaUnset []string) *AffordanceDenialError {
 	if e == nil {
 		return nil
 	}
-	v := a.fieldResolver.RelationVerdicts(ctx, e)
+	v := svc.resolver().RelationVerdicts(ctx, e)
 	rv, ok := v.Types[relType]
 	if !ok || rv.Fields == nil {
 		return nil
@@ -628,8 +666,8 @@ func (a *App) validateRelationMetaWrite(ctx context.Context, e *entityPkg.Entity
 // Empty input verdicts yield an empty (non-nil) map so the wire shape
 // is consistent: `_fields: {}` under the nop resolver, sparse entries
 // under any other.
-func (a *App) computeFieldAffordances(ctx context.Context, e *entityPkg.Entity) map[string]V1FieldAffordance {
-	return computeFieldAffordancesFrom(a.fieldResolver.FieldVerdicts(ctx, e))
+func (svc affordanceService) computeFieldAffordances(ctx context.Context, e *entityPkg.Entity) map[string]V1FieldAffordance {
+	return computeFieldAffordancesFrom(svc.resolver().FieldVerdicts(ctx, e))
 }
 
 // computeFieldAffordancesFrom is computeFieldAffordances given an
@@ -716,8 +754,8 @@ func (v FieldVerdicts) isHidden(name string) bool { return !v.IsVisible(name) }
 // hiddenProperties returns the set of property names that should be
 // stripped from V1Entity.Properties before serialization. Caller uses
 // this to enforce the omit-on-hidden invariant.
-func (a *App) hiddenProperties(ctx context.Context, e *entityPkg.Entity) map[string]struct{} {
-	v := a.fieldResolver.FieldVerdicts(ctx, e)
+func (svc affordanceService) hiddenProperties(ctx context.Context, e *entityPkg.Entity) map[string]struct{} {
+	v := svc.resolver().FieldVerdicts(ctx, e)
 	if len(v.Visible) == 0 {
 		return nil
 	}
@@ -735,8 +773,8 @@ func (a *App) hiddenProperties(ctx context.Context, e *entityPkg.Entity) map[str
 // (creatable=false, removable=false, or any meta-field writable=false)
 // appear in the map. Default-permissive types are absent — the SPA's
 // "no entry = default" path handles them.
-func (a *App) computeRelationAffordances(ctx context.Context, e *entityPkg.Entity) map[string]V1RelationAffordance {
-	v := a.fieldResolver.RelationVerdicts(ctx, e)
+func (svc affordanceService) computeRelationAffordances(ctx context.Context, e *entityPkg.Entity) map[string]V1RelationAffordance {
+	v := svc.resolver().RelationVerdicts(ctx, e)
 	out := make(map[string]V1RelationAffordance)
 	for relType, rv := range v.Types {
 		var entry V1RelationAffordance
@@ -784,8 +822,8 @@ func (a *App) computeRelationAffordances(ctx context.Context, e *entityPkg.Entit
 // a new map instead of mutating an existing V1Entity — the per-row
 // case never goes through V1Entity, so the in-place strip pattern
 // doesn't fit.
-func (a *App) copyVisibleProperties(ctx context.Context, e *entityPkg.Entity) map[string]any {
-	hidden := a.hiddenProperties(ctx, e)
+func (svc affordanceService) copyVisibleProperties(ctx context.Context, e *entityPkg.Entity) map[string]any {
+	hidden := svc.hiddenProperties(ctx, e)
 	out := make(map[string]any, len(e.Properties))
 	for k, v := range e.Properties {
 		if _, h := hidden[k]; h {
@@ -804,15 +842,15 @@ func (a *App) copyVisibleProperties(ctx context.Context, e *entityPkg.Entity) ma
 // Also rewrites `_title` to the entity ID when the entity-type's
 // display property is hidden — otherwise the display title would leak
 // the hidden value through the wire's secondary channel.
-func (a *App) stripHiddenProperties(ctx context.Context, e *entityPkg.Entity, result *V1Entity) {
-	hidden := a.hiddenProperties(ctx, e)
+func (svc affordanceService) stripHiddenProperties(ctx context.Context, e *entityPkg.Entity, result *V1Entity) {
+	hidden := svc.hiddenProperties(ctx, e)
 	for name := range hidden {
 		delete(result.Properties, name)
 	}
 	if len(hidden) == 0 {
 		return
 	}
-	def, ok := a.State().Meta.Entities[e.Type]
+	def, ok := svc.meta().Entities[e.Type]
 	if !ok {
 		return
 	}
@@ -831,17 +869,17 @@ func (a *App) stripHiddenProperties(ctx context.Context, e *entityPkg.Entity, re
 // `_relations` wire maps onto result. Called by paths that return a
 // per-entity response (GET, PATCH, POST, clone, action) — list rows
 // and includes get [App.stripHiddenProperties] only.
-func (a *App) attachEntityAffordances(ctx context.Context, e *entityPkg.Entity, result *V1Entity) {
-	verdicts := a.fieldResolver.FieldVerdicts(ctx, e)
+func (svc affordanceService) attachEntityAffordances(ctx context.Context, e *entityPkg.Entity, result *V1Entity) {
+	verdicts := svc.resolver().FieldVerdicts(ctx, e)
 	fields := computeFieldAffordancesFrom(verdicts)
-	relations := a.computeRelationAffordances(ctx, e)
+	relations := svc.computeRelationAffordances(ctx, e)
 	result.FieldAffordances = &fields
 	result.RelationAffordances = &relations
 	// Pass the same verdicts so a policy-hidden `file` property's attachments
 	// are omitted from `_attachments` — otherwise the hidden-field boundary
 	// the rest of the response maintains would leak the file's metadata and a
 	// working download href.
-	attachments := a.computeAttachments(ctx, e, result.Self, verdicts)
+	attachments := svc.computeAttachments(ctx, e, result.Self, verdicts)
 	result.Attachments = &attachments
 }
 
@@ -860,12 +898,12 @@ func (a *App) attachEntityAffordances(ctx context.Context, e *entityPkg.Entity, 
 // The value per property is a LIST: a property may hold several files, and
 // even a single file is reported as a 1-element list (always-array wire
 // shape).
-func (a *App) computeAttachments(ctx context.Context, e *entityPkg.Entity, selfHref string, verdicts FieldVerdicts) map[string][]V1Attachment {
+func (svc affordanceService) computeAttachments(ctx context.Context, e *entityPkg.Entity, selfHref string, verdicts FieldVerdicts) map[string][]V1Attachment {
 	out := make(map[string][]V1Attachment)
 	if selfHref == "" {
 		return out
 	}
-	infos, err := a.store.ListAttachments(ctx, e.ID)
+	infos, err := svc.store.ListAttachments(ctx, e.ID)
 	if err != nil {
 		// Treat a list failure as "no attachments" rather than failing the
 		// whole entity response — the bytes endpoint still gates and serves
@@ -903,8 +941,8 @@ func (a *App) computeAttachments(ctx context.Context, e *entityPkg.Entity, selfH
 // list rows or under `included` (no affordance maps, but still strip).
 func (a *App) serializeEntityForWire(ctx context.Context, e *entityPkg.Entity, plural string, includeRelations bool) V1Entity {
 	result := a.entityToV1(ctx, e, plural, includeRelations)
-	a.stripHiddenProperties(ctx, e, &result)
-	a.attachEntityAffordances(ctx, e, &result)
+	a.affordances.stripHiddenProperties(ctx, e, &result)
+	a.affordances.attachEntityAffordances(ctx, e, &result)
 	return result
 }
 
@@ -917,6 +955,6 @@ func (a *App) serializeEntityForWire(ctx context.Context, e *entityPkg.Entity, p
 // of which response shape they ride in."
 func (a *App) serializeRelatedEntityForWire(ctx context.Context, e *entityPkg.Entity, plural string, includeRelations bool) V1Entity {
 	result := a.entityToV1(ctx, e, plural, includeRelations)
-	a.stripHiddenProperties(ctx, e, &result)
+	a.affordances.stripHiddenProperties(ctx, e, &result)
 	return result
 }

--- a/internal/dataentry/affordances_test.go
+++ b/internal/dataentry/affordances_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
@@ -62,7 +63,7 @@ func TestComputeActions_ReadOnly(t *testing.T) {
 	app.acl = acl.ReadOnlyACL{}
 
 	e := &entity.Entity{ID: "TKT-001", Type: "ticket"}
-	got := app.computeActions(t.Context(), e)
+	got := app.affordances.computeActions(t.Context(), e)
 
 	for _, v := range []string{"update", "delete", "rename"} {
 		if got[v] {
@@ -77,7 +78,7 @@ func TestComputeActions_NopACL(t *testing.T) {
 	// app.acl is already acl.NopACL via the test fixture wiring.
 
 	e := &entity.Entity{ID: "TKT-001", Type: "ticket"}
-	got := app.computeActions(t.Context(), e)
+	got := app.affordances.computeActions(t.Context(), e)
 
 	for _, v := range []string{"update", "delete", "rename"} {
 		if !got[v] {
@@ -91,7 +92,7 @@ func TestComputeCollectionActions_ReadOnly(t *testing.T) {
 	app := newTestAppV1(t)
 	app.acl = acl.ReadOnlyACL{}
 
-	got := app.computeCollectionActions(t.Context(), "ticket")
+	got := app.affordances.computeCollectionActions(t.Context(), "ticket")
 	if got["create"] {
 		t.Errorf("_actions.create = true under ReadOnlyACL, want false")
 	}
@@ -127,7 +128,7 @@ func TestComputeActions_MixedTypeDeclarative(t *testing.T) {
 	})
 
 	ticket := &entity.Entity{ID: "TKT-001", Type: "ticket"}
-	got := app.computeActions(ctx, ticket)
+	got := app.affordances.computeActions(ctx, ticket)
 	for _, v := range []string{"update", "delete", "rename"} {
 		if !got[v] {
 			t.Errorf("ticket _actions[%q] = false under ticket-writer role, want true", v)
@@ -135,7 +136,7 @@ func TestComputeActions_MixedTypeDeclarative(t *testing.T) {
 	}
 
 	feature := &entity.Entity{ID: "FEAT-001", Type: "feature"}
-	got = app.computeActions(ctx, feature)
+	got = app.affordances.computeActions(ctx, feature)
 	for _, v := range []string{"update", "delete", "rename"} {
 		if got[v] {
 			t.Errorf("feature _actions[%q] = true under ticket-writer role, want false", v)
@@ -343,8 +344,16 @@ func (r byTypeResolver) RelationVerdicts(_ context.Context, e *entity.Entity) Re
 	return r.rvByType[e.Type]
 }
 
-func appWithResolver(r FieldVerdictResolver) *App {
-	return &App{fieldResolver: r}
+// affordanceServiceWithResolver builds a bare affordanceService over a fixed
+// resolver — no App. The resolver-driven affordance methods
+// (computeFieldAffordances, hiddenProperties, computeRelationAffordances)
+// depend only on the resolver and an (empty) metamodel, so these unit tests
+// construct the service directly rather than standing up an App.
+func affordanceServiceWithResolver(r FieldVerdictResolver) affordanceService {
+	return affordanceService{
+		resolver: func() FieldVerdictResolver { return r },
+		meta:     func() *metamodel.Metamodel { return &metamodel.Metamodel{} },
+	}
 }
 
 // verdictBuilder is a fluent helper for constructing fakeResolver
@@ -451,8 +460,8 @@ func (b *verdictBuilder) Build() fakeResolver {
 }
 
 func TestComputeFieldAffordances_NopResolver_EmitsEmptyMap(t *testing.T) {
-	a := appWithResolver(NopFieldVerdictResolver{})
-	got := a.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	svc := affordanceServiceWithResolver(NopFieldVerdictResolver{})
+	got := svc.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
 	if got == nil {
 		t.Fatal("got nil, want empty map")
 	}
@@ -464,7 +473,7 @@ func TestComputeFieldAffordances_NopResolver_EmitsEmptyMap(t *testing.T) {
 func TestComputeFieldAffordances_SparseWritable(t *testing.T) {
 	// title=true is the default (writable) and must NOT appear in
 	// output; kind=false deviates and must be emitted.
-	a := appWithResolver(fakeResolver{
+	svc := affordanceServiceWithResolver(fakeResolver{
 		fv: FieldVerdicts{
 			Writable: map[string]bool{
 				"title": true,
@@ -472,7 +481,7 @@ func TestComputeFieldAffordances_SparseWritable(t *testing.T) {
 			},
 		},
 	})
-	got := a.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	got := svc.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
 	if _, ok := got["title"]; ok {
 		t.Errorf("title should be absent (sparse: writable=true is default)")
 	}
@@ -486,14 +495,14 @@ func TestComputeFieldAffordances_SparseWritable(t *testing.T) {
 }
 
 func TestComputeFieldAffordances_HiddenFieldsOmittedFromMap(t *testing.T) {
-	a := appWithResolver(fakeResolver{
+	svc := affordanceServiceWithResolver(fakeResolver{
 		fv: FieldVerdicts{
 			Writable: map[string]bool{"priority": false}, // also marked read-only
 			Visible:  map[string]bool{"priority": false}, // but hidden takes precedence
 			Options:  map[string]map[string]bool{"priority": {"high": false}},
 		},
 	})
-	got := a.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	got := svc.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
 	if _, ok := got["priority"]; ok {
 		t.Errorf("hidden field must NOT appear in _fields (closed-world); got %+v", got)
 	}
@@ -502,7 +511,7 @@ func TestComputeFieldAffordances_HiddenFieldsOmittedFromMap(t *testing.T) {
 func TestComputeFieldAffordances_SparseOptions(t *testing.T) {
 	// allowed values (backlog, in-progress) are the default and must
 	// be absent from output; done=false deviates and must be emitted.
-	a := appWithResolver(fakeResolver{
+	svc := affordanceServiceWithResolver(fakeResolver{
 		fv: FieldVerdicts{
 			Options: map[string]map[string]bool{
 				"status": {
@@ -513,7 +522,7 @@ func TestComputeFieldAffordances_SparseOptions(t *testing.T) {
 			},
 		},
 	})
-	got := a.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	got := svc.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
 	status, ok := got["status"]
 	if !ok {
 		t.Fatalf("status should be present")
@@ -527,14 +536,14 @@ func TestComputeFieldAffordances_SparseOptions(t *testing.T) {
 }
 
 func TestComputeFieldAffordances_OptionsWithoutWritableEntry(t *testing.T) {
-	a := appWithResolver(fakeResolver{
+	svc := affordanceServiceWithResolver(fakeResolver{
 		fv: FieldVerdicts{
 			Options: map[string]map[string]bool{
 				"effort": {"l": false, "xl": false},
 			},
 		},
 	})
-	got := a.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	got := svc.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
 	effort, ok := got["effort"]
 	if !ok {
 		t.Fatalf("effort should be present")
@@ -548,28 +557,28 @@ func TestComputeFieldAffordances_OptionsWithoutWritableEntry(t *testing.T) {
 }
 
 func TestComputeFieldAffordances_AllOptionsAllowed_NoEntry(t *testing.T) {
-	a := appWithResolver(fakeResolver{
+	svc := affordanceServiceWithResolver(fakeResolver{
 		fv: FieldVerdicts{
 			Options: map[string]map[string]bool{
 				"status": {"backlog": true, "ready": true},
 			},
 		},
 	})
-	got := a.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	got := svc.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
 	if _, ok := got["status"]; ok {
 		t.Errorf("status should be absent when all options allowed")
 	}
 }
 
 func TestHiddenProperties_NopResolver_ReturnsNil(t *testing.T) {
-	a := appWithResolver(NopFieldVerdictResolver{})
-	if got := a.hiddenProperties(context.Background(), &entity.Entity{Type: "ticket"}); got != nil {
+	svc := affordanceServiceWithResolver(NopFieldVerdictResolver{})
+	if got := svc.hiddenProperties(context.Background(), &entity.Entity{Type: "ticket"}); got != nil {
 		t.Errorf("got %v, want nil", got)
 	}
 }
 
 func TestHiddenProperties_OnlyHiddenEntries(t *testing.T) {
-	a := appWithResolver(fakeResolver{
+	svc := affordanceServiceWithResolver(fakeResolver{
 		fv: FieldVerdicts{
 			Visible: map[string]bool{
 				"title":    true,
@@ -577,7 +586,7 @@ func TestHiddenProperties_OnlyHiddenEntries(t *testing.T) {
 			},
 		},
 	})
-	got := a.hiddenProperties(context.Background(), &entity.Entity{Type: "ticket"})
+	got := svc.hiddenProperties(context.Background(), &entity.Entity{Type: "ticket"})
 	if _, ok := got["priority"]; !ok {
 		t.Errorf("priority should be in hidden set: %v", got)
 	}
@@ -587,8 +596,8 @@ func TestHiddenProperties_OnlyHiddenEntries(t *testing.T) {
 }
 
 func TestComputeRelationAffordances_NopResolver_EmitsEmptyMap(t *testing.T) {
-	a := appWithResolver(NopFieldVerdictResolver{})
-	got := a.computeRelationAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	svc := affordanceServiceWithResolver(NopFieldVerdictResolver{})
+	got := svc.computeRelationAffordances(context.Background(), &entity.Entity{Type: "ticket"})
 	if got == nil {
 		t.Fatal("got nil, want empty map")
 	}
@@ -598,7 +607,7 @@ func TestComputeRelationAffordances_NopResolver_EmitsEmptyMap(t *testing.T) {
 }
 
 func TestComputeRelationAffordances_SparseCreatableRemovable(t *testing.T) {
-	a := appWithResolver(fakeResolver{
+	svc := affordanceServiceWithResolver(fakeResolver{
 		rv: RelationVerdicts{
 			Types: map[string]RelationVerdict{
 				"affects":    {Creatable: false, Removable: true},
@@ -607,7 +616,7 @@ func TestComputeRelationAffordances_SparseCreatableRemovable(t *testing.T) {
 			},
 		},
 	})
-	got := a.computeRelationAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	got := svc.computeRelationAffordances(context.Background(), &entity.Entity{Type: "ticket"})
 
 	if _, ok := got["depends-on"]; ok {
 		t.Errorf("depends-on should be absent (all defaults)")
@@ -637,7 +646,7 @@ func TestComputeRelationAffordances_SparseCreatableRemovable(t *testing.T) {
 }
 
 func TestComputeRelationAffordances_MetaFieldOverrides(t *testing.T) {
-	a := appWithResolver(fakeResolver{
+	svc := affordanceServiceWithResolver(fakeResolver{
 		rv: RelationVerdicts{
 			Types: map[string]RelationVerdict{
 				"has-planning": {
@@ -651,7 +660,7 @@ func TestComputeRelationAffordances_MetaFieldOverrides(t *testing.T) {
 			},
 		},
 	})
-	got := a.computeRelationAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	got := svc.computeRelationAffordances(context.Background(), &entity.Entity{Type: "ticket"})
 	hp, ok := got["has-planning"]
 	if !ok {
 		t.Fatalf("has-planning should be present (meta-field deviation)")

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -565,7 +565,7 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 			PerPage: perPage,
 			HasMore: end < total,
 		},
-		Actions: a.computeCollectionActions(r.Context(), typeName),
+		Actions: a.affordances.computeCollectionActions(r.Context(), typeName),
 	}
 
 	// Add Link header for pagination (RFC 5988)
@@ -642,7 +642,7 @@ func (a *App) handleV1CreateEntity(w http.ResponseWriter, r *http.Request, typeN
 	// grants apply at create. Collection-level create authorization is
 	// enforced separately inside CreateEntity (acl.OpCreate).
 	candidate := &entityPkg.Entity{Type: typeName, Properties: req.Properties}
-	if denial := a.validateFieldWrite(r.Context(), candidate, req.Properties, nil); denial != nil {
+	if denial := a.affordances.validateFieldWrite(r.Context(), candidate, req.Properties, nil); denial != nil {
 		a.denyAffordance(r.Context(), w, candidate, *denial)
 		return
 	}
@@ -1026,12 +1026,12 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 	// what the resolver would have surfaced on GET. Runs before any
 	// other validation so the failure mode is identical regardless of
 	// what else the PATCH body would have triggered.
-	if denial := a.validateFieldWrite(r.Context(), entity, req.Properties, req.PropertiesUnset); denial != nil {
+	if denial := a.affordances.validateFieldWrite(r.Context(), entity, req.Properties, req.PropertiesUnset); denial != nil {
 		a.denyAffordance(r.Context(), w, entity, *denial)
 		return
 	}
 	if req.Relations.Modern != nil {
-		if denial := a.validateRelationsModernAffordances(r.Context(), entityID, entity, req.Relations.Modern); denial != nil {
+		if denial := a.affordances.validateRelationsModernAffordances(r.Context(), entityID, entity, req.Relations.Modern); denial != nil {
 			a.denyAffordance(r.Context(), w, entity, *denial)
 			return
 		}
@@ -1414,14 +1414,14 @@ func (a *App) handleV1CreateRelation(w http.ResponseWriter, r *http.Request, typ
 	// Affordance gates: creatable + meta-writable, evaluated against
 	// the SOURCE of the new edge (not necessarily the path entity —
 	// for incoming-direction creates the path entity is the target).
-	source := a.relationSourceEntity(r.Context(), entity, req.ID, req.Direction)
+	source := a.affordances.relationSourceEntity(r.Context(), entity, req.ID, req.Direction)
 	// Audit subject is the source of the new edge, matching the
 	// entity whose policy gated the write.
-	if denial := a.validateRelationOp(r.Context(), source, relType, RelationOpCreate); denial != nil {
+	if denial := a.affordances.validateRelationOp(r.Context(), source, relType, RelationOpCreate); denial != nil {
 		a.denyAffordance(r.Context(), w, source, *denial)
 		return
 	}
-	if denial := a.validateRelationMetaWrite(r.Context(), source, relType, req.Meta, nil); denial != nil {
+	if denial := a.affordances.validateRelationMetaWrite(r.Context(), source, relType, req.Meta, nil); denial != nil {
 		a.denyAffordance(r.Context(), w, source, *denial)
 		return
 	}
@@ -1480,8 +1480,8 @@ func (a *App) handleV1UpdateRelation(w http.ResponseWriter, r *http.Request, typ
 	// the edge (the path entity for outgoing; the peer for incoming).
 	// The edge already exists (PATCH is meta-only), so the create /
 	// remove gates don't apply.
-	source := a.relationSourceEntity(r.Context(), entity, targetID, req.Direction)
-	if denial := a.validateRelationMetaWrite(r.Context(), source, relType, req.Meta, nil); denial != nil {
+	source := a.affordances.relationSourceEntity(r.Context(), entity, targetID, req.Direction)
+	if denial := a.affordances.validateRelationMetaWrite(r.Context(), source, relType, req.Meta, nil); denial != nil {
 		a.denyAffordance(r.Context(), w, source, *denial)
 		return
 	}
@@ -1553,8 +1553,8 @@ func (a *App) handleV1DeleteRelation(w http.ResponseWriter, r *http.Request, typ
 	// incoming). Per-relation-type uniform — a removable=false
 	// verdict applies to every link of this type.
 	direction := r.URL.Query().Get("direction")
-	source := a.relationSourceEntity(r.Context(), entity, targetID, direction)
-	if denial := a.validateRelationOp(r.Context(), source, relType, RelationOpRemove); denial != nil {
+	source := a.affordances.relationSourceEntity(r.Context(), entity, targetID, direction)
+	if denial := a.affordances.validateRelationOp(r.Context(), source, relType, RelationOpRemove); denial != nil {
 		a.denyAffordance(r.Context(), w, source, *denial)
 		return
 	}
@@ -1992,7 +1992,7 @@ func (a *App) entityToV1(ctx context.Context, e *entityPkg.Entity, plural string
 		Properties: make(map[string]interface{}),
 		Content:    e.Content,
 		Self:       fmt.Sprintf("/api/v1/%s/%s", plural, e.ID),
-		Actions:    a.computeActions(ctx, e),
+		Actions:    a.affordances.computeActions(ctx, e),
 	}
 
 	for k, v := range e.Properties {

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -99,11 +99,11 @@ const userPaletteFile = "palette.yaml"
 // readers — readers go through state.Load(). The workspace's internal
 // reloadMu coordinates the reload itself with the mutation path.
 //
-// TODO(TKT-N26KLB): App is a god-object (201 methods). Decompose toward the
+// TODO(TKT-N26KLB): App is a god-object (187 methods). Decompose toward the
 // 40-method load line — extract the API/serialization/relation services into
 // their own types. Ratchet this number DOWN as methods move out; never up.
 //
-//plimsoll:max-methods=201
+//plimsoll:max-methods=187
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -133,11 +133,15 @@ type App struct {
 	// analyze runs the read-only graph-analysis checks. Extracted from App
 	// (TKT-N26KLB M5.1); holds its own {store, tracer, validator} and takes
 	// the metamodel snapshot per call.
-	analyze   analyzeService
-	templater templating.Templater
-	cfgLoader config.Loader
-	kv        state.KV
-	acl       acl.ACL
+	analyze analyzeService
+	// affordances computes the _actions/field/relation affordance maps and runs
+	// write-time affordance validation. Extracted from App (TKT-N26KLB M5.2);
+	// shares the same acl.ACL as the write path (contract-test invariant).
+	affordances affordanceService
+	templater   templating.Templater
+	cfgLoader   config.Loader
+	kv          state.KV
+	acl         acl.ACL
 
 	// documents renders and caches documents. Created once in NewApp so
 	// singleflight deduplication is stable across requests.
@@ -462,6 +466,19 @@ func NewApp(
 	// that yields fresh lua.WriteDeps (so metamodel reloads propagate).
 	// Constructed after app because luaWriteDeps is a method on App.
 	app.documents = newDocumentService(st, kv, paths.Root, scriptEngine, app.luaWriteDeps)
+
+	// affordanceService shares the App's acl/fieldResolver/store and takes the
+	// metamodel per-request via app.State(). The two relation-graph reads are
+	// App methods, so it's wired after the struct literal. It MUST share the
+	// same acl instance as the write path (contract-test invariant).
+	app.affordances = affordanceService{
+		acl:                func() acl.ACL { return app.acl },
+		resolver:           func() FieldVerdictResolver { return app.fieldResolver },
+		store:              st,
+		meta:               func() *metamodel.Metamodel { return app.State().Meta },
+		getEntity:          app.getEntity,
+		currentEdgesByPeer: app.currentEdgesByPeer,
+	}
 
 	userDefaults := app.loadUserDefaults()
 	userPalette, paletteErr := app.loadUserPalette()

--- a/internal/dataentry/sections.go
+++ b/internal/dataentry/sections.go
@@ -165,8 +165,8 @@ func (a *App) buildSectionEntityData(ctx context.Context, e *entity.Entity, secF
 		Title:         s.Meta.DisplayTitle(e.ID, e.Type, e.Properties),
 		Type:          e.Type,
 		EditFormID:    a.editFormForType(e.Type),
-		Props:         a.copyVisibleProperties(ctx, e),
-		FieldVerdicts: a.computeFieldAffordances(ctx, e),
+		Props:         a.affordances.copyVisibleProperties(ctx, e),
+		FieldVerdicts: a.affordances.computeFieldAffordances(ctx, e),
 	}
 	for _, f := range secFields {
 		values := propertyToStrings(e.Properties[f.Property])

--- a/internal/dataentry/sections_ihc7d_test.go
+++ b/internal/dataentry/sections_ihc7d_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestCopyVisibleProperties_HiddenStripped(t *testing.T) {
-	a := appWithResolver((&verdictBuilder{}).Hidden("priority").Build())
+	svc := affordanceServiceWithResolver((&verdictBuilder{}).Hidden("priority").Build())
 	e := &entity.Entity{
 		Type: "ticket",
 		Properties: map[string]any{
@@ -28,7 +28,7 @@ func TestCopyVisibleProperties_HiddenStripped(t *testing.T) {
 			"priority": "high", // hidden — must not appear
 		},
 	}
-	got := a.copyVisibleProperties(context.Background(), e)
+	got := svc.copyVisibleProperties(context.Background(), e)
 	if _, ok := got["priority"]; ok {
 		t.Errorf("hidden 'priority' must not appear in _props; got %+v", got)
 	}
@@ -44,10 +44,10 @@ func TestCopyVisibleProperties_FreshMap(t *testing.T) {
 	// Defensive copy: the returned map must not share its backing
 	// pointer with e.Properties so future maintainers can't accidentally
 	// alias the entity's property map into a long-lived response.
-	a := appWithResolver(NopFieldVerdictResolver{})
+	svc := affordanceServiceWithResolver(NopFieldVerdictResolver{})
 	original := map[string]any{"title": "x", "status": "open"}
 	e := &entity.Entity{Type: "ticket", Properties: original}
-	got := a.copyVisibleProperties(context.Background(), e)
+	got := svc.copyVisibleProperties(context.Background(), e)
 	if reflect.ValueOf(got).Pointer() == reflect.ValueOf(original).Pointer() {
 		t.Fatal("copyVisibleProperties returned the same map pointer as e.Properties; expected a fresh map")
 	}
@@ -59,12 +59,12 @@ func TestCopyVisibleProperties_FreshMap(t *testing.T) {
 }
 
 func TestCopyVisibleProperties_EmptyHidden(t *testing.T) {
-	a := appWithResolver(NopFieldVerdictResolver{})
+	svc := affordanceServiceWithResolver(NopFieldVerdictResolver{})
 	e := &entity.Entity{
 		Type:       "ticket",
 		Properties: map[string]any{"title": "x"},
 	}
-	got := a.copyVisibleProperties(context.Background(), e)
+	got := svc.copyVisibleProperties(context.Background(), e)
 	if got["title"] != "x" {
 		t.Errorf("title: got %v, want 'x'", got["title"])
 	}
@@ -145,7 +145,7 @@ func TestBuildSectionEntityData_KeySetInvariant(t *testing.T) {
 	eDef, _ := st.Meta.GetEntityDef(e.Type)
 	sed := app.buildSectionEntityData(context.Background(), e, nil, eDef)
 
-	hidden := app.hiddenProperties(context.Background(), e)
+	hidden := app.affordances.hiddenProperties(context.Background(), e)
 	for k := range sed.Props {
 		if _, h := hidden[k]; h {
 			t.Errorf("Props has hidden key %q (invariant: keys(Props) ∩ hidden == ∅)", k)

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/appbuild"
 	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
@@ -142,6 +143,14 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	// configs will need to seed scripts on disk).
 	if app.scriptEngine != nil {
 		app.documents = newDocumentService(app.store, app.kv, "/", app.scriptEngine, app.luaWriteDeps)
+	}
+	app.affordances = affordanceService{
+		acl:                func() acl.ACL { return app.acl },
+		resolver:           func() FieldVerdictResolver { return app.fieldResolver },
+		store:              svc.Store(),
+		meta:               func() *metamodel.Metamodel { return app.State().Meta },
+		getEntity:          app.getEntity,
+		currentEdgesByPeer: app.currentEdgesByPeer,
 	}
 }
 


### PR DESCRIPTION
Fourth step of the `dataentry.App` decomposition (**TKT-N26KLB**). Stacked on #1035. The shared write-authorization seam — the architecturally central cluster.

## What

Move 14 affordance methods off `App` into a focused **`affordanceService`**: `computeActions`/`computeCollectionActions`, the field/relation write validators (`validateFieldWrite`, `validateRelationOp`, `validateRelationsModernAffordances`, `validateRelationMetaWrite`, `relationSourceEntity`), the affordance-map computers (`computeFieldAffordances`, `hiddenProperties`, `computeRelationAffordances`), and `copyVisibleProperties`/`stripHiddenProperties`/`computeAttachments`/`attachEntityAffordances`.

## Design: live func accessors, not captured copies

`acl` and `resolver` are held as **`func() acl.ACL` / `func() FieldVerdictResolver`**, read per-call — not captured values. Two reasons:

1. **Correctness/staleness:** tests (and the reload path) swap `app.acl` / `app.fieldResolver` after construction. A captured copy goes stale — the affordance **contract test caught exactly this** (a write returned 200 instead of 403 because the service held the old permissive acl).
2. **Invariant by construction:** reading `acl` live from `App` *structurally guarantees* the affordance service uses the **same** acl as the write path (`entitymanager`) — which is precisely what `affordances_contract_test.go` exists to pin. `meta` is per-call for the analogous reload reason; the two relation-graph reads (`getEntity`, `currentEdgesByPeer`) are injected callbacks.

## Constraints preserved

- `translateVerb` / `translateRelationWrite` stay **package-level in `affordances.go`** — `lint_test.go` greps that exact filename for the only-allowed `acl.WriteRequest{Op:` site. Verified: that literal appears only in `affordances.go`.
- `denyAffordance` (HTTP 403 + audit) and `serialize*ForWire` ×2 stay on `App` — HTTP/audit coupling; avoids dragging the entangled `entityToV1` into the new type.

## Tests

Resolver-driven affordance unit tests now build the service directly via `affordanceServiceWithResolver` — **no App** (per crit review). The acl-contract tests intentionally stay integration-shaped (they exercise acl-driven behavior wired through App).

## Result

`App`: **201 → 187 methods**; plimsoll directive ratcheted. Behavior-preserving.

## Verification

`go build ./...`, `go test -race ./internal/dataentry/` (full suite incl. the affordance contract + lint tests), `golangci-lint` (0 issues), `just arch-lint`, `plimsoll ./...` (exit 0) all green.