### PR TITLE
refactor(dataentry): extract userStateStore from App (TKT-N26KLB, M5.3)

### DIFF
--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -2,13 +2,11 @@ package dataentry
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -99,11 +97,11 @@ const userPaletteFile = "palette.yaml"
 // readers — readers go through state.Load(). The workspace's internal
 // reloadMu coordinates the reload itself with the mutation path.
 //
-// TODO(TKT-N26KLB): App is a god-object (187 methods). Decompose toward the
+// TODO(TKT-N26KLB): App is a god-object (178 methods). Decompose toward the
 // 40-method load line — extract the API/serialization/relation services into
 // their own types. Ratchet this number DOWN as methods move out; never up.
 //
-//plimsoll:max-methods=187
+//plimsoll:max-methods=178
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -138,10 +136,13 @@ type App struct {
 	// write-time affordance validation. Extracted from App (TKT-N26KLB M5.2);
 	// shares the same acl.ACL as the write path (contract-test invariant).
 	affordances affordanceService
-	templater   templating.Templater
-	cfgLoader   config.Loader
-	kv          state.KV
-	acl         acl.ACL
+	// userState persists per-user UI state (logo, UI state, defaults, palette)
+	// to the .rela/ KV store. Extracted from App (TKT-N26KLB M5.3).
+	userState userStateStore
+	templater templating.Templater
+	cfgLoader config.Loader
+	kv        state.KV
+	acl       acl.ACL
 
 	// documents renders and caches documents. Created once in NewApp so
 	// singleflight deduplication is stable across requests.
@@ -456,6 +457,7 @@ func NewApp(
 		templater:       templater,
 		cfgLoader:       cfgLoader,
 		kv:              kv,
+		userState:       userStateStore{kv: kv},
 		acl:             aclImpl,
 		broker:          newEventBroker(),
 		scriptEngine:    scriptEngine,
@@ -480,8 +482,8 @@ func NewApp(
 		currentEdgesByPeer: app.currentEdgesByPeer,
 	}
 
-	userDefaults := app.loadUserDefaults()
-	userPalette, paletteErr := app.loadUserPalette()
+	userDefaults := app.userState.loadUserDefaults()
+	userPalette, paletteErr := app.userState.loadUserPalette()
 	if paletteErr != nil {
 		// Surface the error so users notice their palette is broken
 		// rather than silently falling back to defaults (which would
@@ -489,7 +491,7 @@ func NewApp(
 		return nil, fmt.Errorf("load user palette: %w", paletteErr)
 	}
 
-	logoBytes, logoExt, logoErr := app.loadUserLogo()
+	logoBytes, logoExt, logoErr := app.userState.loadUserLogo()
 	if logoErr != nil {
 		// Same policy as palette: surface read errors so a corrupt
 		// .rela/theme/ doesn't get silently overwritten on next save.
@@ -573,7 +575,7 @@ func (a *App) enrichNavEntry(ctx context.Context, nav NavigationEntry) NavItem {
 // navElements returns the navigation structure with groups and items resolved.
 // The activeList parameter is used to auto-expand the group containing the active item.
 func (a *App) navElements(ctx context.Context, activeList string) []NavElement {
-	uiState := a.loadUIState(ctx)
+	uiState := a.userState.loadUIState(ctx)
 	cfgNav := a.State().Cfg.Navigation
 	elements := make([]NavElement, 0, len(cfgNav))
 	for _, nav := range cfgNav {
@@ -602,109 +604,7 @@ func (a *App) navElements(ctx context.Context, activeList string) []NavElement {
 	return elements
 }
 
-// loadUIState reads .rela/ui-state.json and returns the persisted state.
-// Returns an empty UIState if the file doesn't exist or can't be parsed.
-func (a *App) loadUIState(ctx context.Context) UIState {
-	st := UIState{CollapsedGroups: make(map[string]bool)}
-	if a.kv == nil {
-		return st
-	}
-	data, err := a.kv.Get(ctx, uiStateFile)
-	if err != nil {
-		return st
-	}
-	if err := json.Unmarshal(data, &st); err != nil {
-		return UIState{CollapsedGroups: make(map[string]bool)}
-	}
-	if st.CollapsedGroups == nil {
-		st.CollapsedGroups = make(map[string]bool)
-	}
-	return st
-}
-
-// saveUIState writes the UI state to .rela/ui-state.json.
-func (a *App) saveUIState(st UIState) error {
-	if a.kv == nil {
-		return nil
-	}
-	data, err := json.MarshalIndent(st, "", "  ")
-	if err != nil {
-		return err
-	}
-	return a.kv.Put(context.Background(), uiStateFile, data)
-}
-
-// loadUserDefaults reads .rela/user-defaults.yaml and returns the parsed defaults.
-// Returns nil if the file doesn't exist or can't be parsed.
-func (a *App) loadUserDefaults() *UserDefaults {
-	if a.kv == nil {
-		return nil
-	}
-	data, err := a.kv.Get(context.Background(), userDefaultsFile)
-	if err != nil {
-		return nil
-	}
-	var ud UserDefaults
-	if err := yaml.Unmarshal(data, &ud); err != nil {
-		return nil
-	}
-	return &ud
-}
-
-// saveUserDefaults writes the user defaults to .rela/user-defaults.yaml.
-func (a *App) saveUserDefaults(ctx context.Context, ud *UserDefaults) error {
-	if a.kv == nil {
-		return nil
-	}
-	data, err := yaml.Marshal(ud)
-	if err != nil {
-		return err
-	}
-	return a.kv.Put(ctx, userDefaultsFile, data)
-}
-
 // coverage-ignore: requires running workspace, tested via e2e
-
-// loadUserPalette reads .rela/palette.yaml and returns the parsed
-// palette. Returns (nil, nil) when the file does not exist (clean
-// "no user palette" state — matches how ResolvePalette consumes a
-// nil user palette pointer; a sentinel error or three-return shape
-// would be more confusing for the only two callers). Returns a
-// non-nil error if the file exists but cannot be read or parsed —
-// callers MUST surface this instead of silently falling back to
-// defaults, otherwise a subsequent save would silently overwrite
-// the user's palette with framework defaults (RR-OA4A).
-//
-//nolint:nilnil // see comment above
-func (a *App) loadUserPalette() (*PaletteConfig, error) {
-	if a.kv == nil {
-		return nil, nil
-	}
-	data, err := a.kv.Get(context.Background(), userPaletteFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read %s: %w", userPaletteFile, err)
-	}
-	var p PaletteConfig
-	if err := yaml.Unmarshal(data, &p); err != nil {
-		return nil, fmt.Errorf("parse %s: %w (legacy `dark: auto` is no longer supported — remove the `dark` line or set it to `false` or an explicit object)", userPaletteFile, err)
-	}
-	return &p, nil
-}
-
-// saveUserPalette writes the user palette to .rela/palette.yaml.
-func (a *App) saveUserPalette(ctx context.Context, p *PaletteConfig) error {
-	if a.kv == nil {
-		return nil
-	}
-	data, err := yaml.Marshal(p)
-	if err != nil {
-		return err
-	}
-	return a.kv.Put(ctx, userPaletteFile, data)
-}
 
 // firstNavTarget returns the first navigable item from the navigation config,
 // walking into groups as needed.

--- a/internal/dataentry/app_test.go
+++ b/internal/dataentry/app_test.go
@@ -711,7 +711,7 @@ func TestUIStateLoadSave(t *testing.T) {
 	bindRepoWithFS(app, fs, ctx)
 
 	t.Run("load returns defaults when file missing", func(t *testing.T) {
-		state := app.loadUIState(context.Background())
+		state := app.userState.loadUIState(context.Background())
 		if len(state.CollapsedGroups) != 0 {
 			t.Errorf("expected empty collapsed groups, got %v", state.CollapsedGroups)
 		}
@@ -719,10 +719,10 @@ func TestUIStateLoadSave(t *testing.T) {
 
 	t.Run("save and load round-trip", func(t *testing.T) {
 		state := UIState{CollapsedGroups: map[string]bool{"Tickets": true}}
-		if err := app.saveUIState(state); err != nil {
+		if err := app.userState.saveUIState(state); err != nil {
 			t.Fatalf("save error: %v", err)
 		}
-		loaded := app.loadUIState(context.Background())
+		loaded := app.userState.loadUIState(context.Background())
 		if !loaded.CollapsedGroups["Tickets"] {
 			t.Error("expected Tickets to be collapsed after load")
 		}
@@ -742,7 +742,7 @@ func TestUIStateLoadSave(t *testing.T) {
 		}
 		// UIState says collapsed
 		state := UIState{CollapsedGroups: map[string]bool{"Tickets": true}}
-		if err := app2.saveUIState(state); err != nil {
+		if err := app2.userState.saveUIState(state); err != nil {
 			t.Fatalf("save error: %v", err)
 		}
 		elements := app2.navElements(context.Background(), "")
@@ -757,11 +757,11 @@ func TestUIStateLoadSave(t *testing.T) {
 	t.Run("nil kv is safe", func(t *testing.T) {
 		app2, _ := testAppInstance()
 		app2.kv = nil
-		state := app2.loadUIState(context.Background())
+		state := app2.userState.loadUIState(context.Background())
 		if len(state.CollapsedGroups) != 0 {
 			t.Error("expected empty state")
 		}
-		if err := app2.saveUIState(state); err != nil {
+		if err := app2.userState.saveUIState(state); err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
 	})
@@ -779,7 +779,7 @@ func TestUserDefaultsLoadSave(t *testing.T) {
 	bindRepoWithFS(app, fs, ctx)
 
 	t.Run("load returns nil when file missing", func(t *testing.T) {
-		ud := app.loadUserDefaults()
+		ud := app.userState.loadUserDefaults()
 		if ud != nil {
 			t.Errorf("expected nil, got %+v", ud)
 		}
@@ -797,10 +797,10 @@ func TestUserDefaultsLoadSave(t *testing.T) {
 				},
 			},
 		}
-		if err := app.saveUserDefaults(context.Background(), ud); err != nil {
+		if err := app.userState.saveUserDefaults(context.Background(), ud); err != nil {
 			t.Fatalf("save error: %v", err)
 		}
-		loaded := app.loadUserDefaults()
+		loaded := app.userState.loadUserDefaults()
 		if loaded == nil {
 			t.Fatal("expected non-nil loaded defaults")
 		}
@@ -824,11 +824,11 @@ func TestUserDefaultsLoadSave(t *testing.T) {
 	t.Run("nil kv is safe", func(t *testing.T) {
 		app2, _ := testAppInstance()
 		app2.kv = nil
-		ud := app2.loadUserDefaults()
+		ud := app2.userState.loadUserDefaults()
 		if ud != nil {
 			t.Errorf("expected nil, got %+v", ud)
 		}
-		if err := app2.saveUserDefaults(context.Background(), &UserDefaults{}); err != nil {
+		if err := app2.userState.saveUserDefaults(context.Background(), &UserDefaults{}); err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
 	})

--- a/internal/dataentry/handlers_theme.go
+++ b/internal/dataentry/handlers_theme.go
@@ -122,7 +122,7 @@ func (a *App) handleAPIPutThemeLogo(w http.ResponseWriter, r *http.Request) {
 	var saveErr error
 	ctx := r.Context()
 	a.mutateState(func(s *AppState) {
-		if err := a.saveUserLogo(ctx, bytes, ext); err != nil {
+		if err := a.userState.saveUserLogo(ctx, bytes, ext); err != nil {
 			// On failure the snapshot copy is left untouched and
 			// mutateState republishes a bytewise-identical pointer.
 			// Cheap (one struct copy) and keeps the path simple — do
@@ -153,7 +153,7 @@ func (a *App) handleAPIDeleteThemeLogo(w http.ResponseWriter, r *http.Request) {
 	var deleteErr error
 	ctx := r.Context()
 	a.mutateState(func(s *AppState) {
-		if err := a.deleteUserLogo(ctx); err != nil {
+		if err := a.userState.deleteUserLogo(ctx); err != nil {
 			deleteErr = err
 			return
 		}

--- a/internal/dataentry/handlers_theme_package.go
+++ b/internal/dataentry/handlers_theme_package.go
@@ -104,7 +104,7 @@ func (a *App) handleAPIThemeImport(w http.ResponseWriter, r *http.Request) {
 		var saveErr error
 		ctx := r.Context()
 		a.mutateState(func(s *AppState) {
-			if err := a.saveUserLogo(ctx, pkg.Logo.Bytes, pkg.Logo.Ext); err != nil {
+			if err := a.userState.saveUserLogo(ctx, pkg.Logo.Bytes, pkg.Logo.Ext); err != nil {
 				saveErr = err
 				return
 			}

--- a/internal/dataentry/settings_handlers.go
+++ b/internal/dataentry/settings_handlers.go
@@ -281,7 +281,7 @@ func (a *App) handleAPISaveSettings(w http.ResponseWriter, r *http.Request) {
 	var saveErr error
 	ctx := r.Context()
 	a.mutateState(func(s *AppState) {
-		if err := a.saveUserDefaults(ctx, &ud); err != nil {
+		if err := a.userState.saveUserDefaults(ctx, &ud); err != nil {
 			saveErr = err
 			return
 		}
@@ -337,7 +337,7 @@ func (a *App) handleAPISavePalette(w http.ResponseWriter, r *http.Request) {
 	var saveErr error
 	ctx := r.Context()
 	a.mutateState(func(s *AppState) {
-		if err := a.saveUserPalette(ctx, &input); err != nil {
+		if err := a.userState.saveUserPalette(ctx, &input); err != nil {
 			saveErr = err
 			return
 		}

--- a/internal/dataentry/settings_handlers_test.go
+++ b/internal/dataentry/settings_handlers_test.go
@@ -84,7 +84,7 @@ func TestWriteJSON(t *testing.T) {
 func TestLoadUserPalette(t *testing.T) {
 	t.Run("missing file returns nil with no error", func(t *testing.T) {
 		app := newHandlerTestApp(t)
-		p, err := app.loadUserPalette()
+		p, err := app.userState.loadUserPalette()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -103,7 +103,7 @@ func TestLoadUserPalette(t *testing.T) {
 		if err != nil {
 			t.Fatalf("write fixture: %v", err)
 		}
-		p, perr := app.loadUserPalette()
+		p, perr := app.userState.loadUserPalette()
 		if perr == nil {
 			t.Fatal("expected error for legacy `dark: auto`, got nil")
 		}
@@ -121,7 +121,7 @@ func TestLoadUserPalette(t *testing.T) {
 		if err != nil {
 			t.Fatalf("write fixture: %v", err)
 		}
-		p, perr := app.loadUserPalette()
+		p, perr := app.userState.loadUserPalette()
 		if perr != nil {
 			t.Fatalf("unexpected error: %v", perr)
 		}

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -136,6 +136,7 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	app.templater = svc.Templater()
 	app.cfgLoader = svc.Config()
 	app.kv = svc.State()
+	app.userState = userStateStore{kv: svc.State()}
 	app.acl = svc.ACL()
 	app.auditSink = svc.Audit()
 	// Wire a minimal documentService for tests that hit the documents

--- a/internal/dataentry/theme_logo.go
+++ b/internal/dataentry/theme_logo.go
@@ -1,12 +1,8 @@
 package dataentry
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
-	"fmt"
-	"os"
 )
 
 // User-uploaded theme assets are stored under .rela/theme/. The bytes
@@ -89,88 +85,4 @@ func (s *AppState) LogoURL() *string {
 	}
 	u := logoURLForHash(s.UserLogoHash)
 	return &u
-}
-
-// loadUserLogo reads the persisted logo bytes and extension. Returns
-// (nil, "", nil) when no logo is set. A sidecar file present without
-// matching bytes (or vice versa) is treated as "no logo set" so a
-// half-written state during a crash doesn't trip up the boot path.
-//
-// Returns a non-nil error only when the kv layer reports an unexpected
-// failure (corrupt filesystem, permission denied) — callers should
-// surface those instead of silently masking them.
-//
-// Concurrency: NOT safe to call in parallel with saveUserLogo or
-// deleteUserLogo (the bytes/sidecar pair is read non-atomically). Boot
-// path calls this before publishing the App; future reload paths must
-// hold writeMu (i.e. invoke from inside mutateState).
-//
-//nolint:gocritic // unnamedResult: handler-style (bytes, ext, err) is clearer than naming for two callers
-func (a *App) loadUserLogo() ([]byte, string, error) {
-	if a.kv == nil {
-		return nil, "", nil
-	}
-	ctx := context.Background()
-
-	logoBytes, err := a.kv.Get(ctx, userLogoFile)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) || os.IsNotExist(err) {
-			return nil, "", nil
-		}
-		return nil, "", fmt.Errorf("read %s: %w", userLogoFile, err)
-	}
-
-	extBytes, err := a.kv.Get(ctx, userLogoExtFile)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) || os.IsNotExist(err) {
-			// Bytes present but sidecar missing — treat as not-set.
-			// The user can re-upload to recover; we don't proactively
-			// clean up so a future fix can recover the bytes.
-			return nil, "", nil
-		}
-		return nil, "", fmt.Errorf("read %s: %w", userLogoExtFile, err)
-	}
-
-	ext := string(extBytes)
-	if _, ok := allowedLogoExts[ext]; !ok {
-		// Sidecar contains an unknown extension — treat as not-set.
-		// Same reasoning as the missing-sidecar case.
-		return nil, "", nil
-	}
-
-	return logoBytes, ext, nil
-}
-
-// saveUserLogo persists the bytes and extension. Caller must hold
-// writeMu (i.e. invoke from inside mutateState) so the bytes/sidecar
-// pair cannot be observed half-written by a concurrent reload.
-func (a *App) saveUserLogo(ctx context.Context, bytes []byte, ext string) error {
-	if a.kv == nil {
-		return errors.New("kv not configured")
-	}
-	if _, ok := allowedLogoExts[ext]; !ok {
-		return fmt.Errorf("invalid logo extension %q", ext)
-	}
-	if err := a.kv.Put(ctx, userLogoFile, bytes); err != nil {
-		return fmt.Errorf("write %s: %w", userLogoFile, err)
-	}
-	if err := a.kv.Put(ctx, userLogoExtFile, []byte(ext)); err != nil {
-		return fmt.Errorf("write %s: %w", userLogoExtFile, err)
-	}
-	return nil
-}
-
-// deleteUserLogo removes both the bytes file and the sidecar. Idempotent;
-// missing files are not errors.
-func (a *App) deleteUserLogo(ctx context.Context) error {
-	if a.kv == nil {
-		return nil
-	}
-	if err := a.kv.Delete(ctx, userLogoFile); err != nil {
-		return fmt.Errorf("delete %s: %w", userLogoFile, err)
-	}
-	if err := a.kv.Delete(ctx, userLogoExtFile); err != nil {
-		return fmt.Errorf("delete %s: %w", userLogoExtFile, err)
-	}
-	return nil
 }

--- a/internal/dataentry/userstate.go
+++ b/internal/dataentry/userstate.go
@@ -1,0 +1,212 @@
+package dataentry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/state"
+)
+
+// userStateStore persists per-user UI state to the project's `.rela/` KV store:
+// the sidebar logo, UI state (expanded groups, active list), user defaults, and
+// the user palette override. Extracted from App (TKT-N26KLB M5.3): every method
+// is a load/save pair over the KV store and touches nothing else, so they form
+// a cohesive store with a single dependency.
+//
+// These are NOT the entity store — they're the per-user customization layer
+// that rides alongside it (gitignored `.rela/` files). Writes here do not go
+// through entitymanager; they are local UI preferences, not graph mutations.
+type userStateStore struct {
+	kv state.KV
+}
+
+// loadUIState reads .rela/ui-state.json and returns the persisted state.
+// Returns an empty UIState if the file doesn't exist or can't be parsed.
+func (s userStateStore) loadUIState(ctx context.Context) UIState {
+	st := UIState{CollapsedGroups: make(map[string]bool)}
+	if s.kv == nil {
+		return st
+	}
+	data, err := s.kv.Get(ctx, uiStateFile)
+	if err != nil {
+		return st
+	}
+	if err := json.Unmarshal(data, &st); err != nil {
+		return UIState{CollapsedGroups: make(map[string]bool)}
+	}
+	if st.CollapsedGroups == nil {
+		st.CollapsedGroups = make(map[string]bool)
+	}
+	return st
+}
+
+// saveUIState writes the UI state to .rela/ui-state.json.
+func (s userStateStore) saveUIState(st UIState) error {
+	if s.kv == nil {
+		return nil
+	}
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+	return s.kv.Put(context.Background(), uiStateFile, data)
+}
+
+// loadUserDefaults reads .rela/user-defaults.yaml and returns the parsed defaults.
+// Returns nil if the file doesn't exist or can't be parsed.
+func (s userStateStore) loadUserDefaults() *UserDefaults {
+	if s.kv == nil {
+		return nil
+	}
+	data, err := s.kv.Get(context.Background(), userDefaultsFile)
+	if err != nil {
+		return nil
+	}
+	var ud UserDefaults
+	if err := yaml.Unmarshal(data, &ud); err != nil {
+		return nil
+	}
+	return &ud
+}
+
+// saveUserDefaults writes the user defaults to .rela/user-defaults.yaml.
+func (s userStateStore) saveUserDefaults(ctx context.Context, ud *UserDefaults) error {
+	if s.kv == nil {
+		return nil
+	}
+	data, err := yaml.Marshal(ud)
+	if err != nil {
+		return err
+	}
+	return s.kv.Put(ctx, userDefaultsFile, data)
+}
+
+// loadUserPalette reads .rela/palette.yaml and returns the parsed
+// palette. Returns (nil, nil) when the file does not exist (clean
+// "no user palette" state — matches how ResolvePalette consumes a
+// nil user palette pointer; a sentinel error or three-return shape
+// would be more confusing for the only two callers). Returns a
+// non-nil error if the file exists but cannot be read or parsed —
+// callers MUST surface this instead of silently falling back to
+// defaults, otherwise a subsequent save would silently overwrite
+// the user's palette with framework defaults (RR-OA4A).
+//
+//nolint:nilnil // see comment above
+func (s userStateStore) loadUserPalette() (*PaletteConfig, error) {
+	if s.kv == nil {
+		return nil, nil
+	}
+	data, err := s.kv.Get(context.Background(), userPaletteFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", userPaletteFile, err)
+	}
+	var p PaletteConfig
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parse %s: %w (legacy `dark: auto` is no longer supported — remove the `dark` line or set it to `false` or an explicit object)", userPaletteFile, err)
+	}
+	return &p, nil
+}
+
+// saveUserPalette writes the user palette to .rela/palette.yaml.
+func (s userStateStore) saveUserPalette(ctx context.Context, p *PaletteConfig) error {
+	if s.kv == nil {
+		return nil
+	}
+	data, err := yaml.Marshal(p)
+	if err != nil {
+		return err
+	}
+	return s.kv.Put(ctx, userPaletteFile, data)
+}
+
+// loadUserLogo reads the persisted logo bytes and extension. Returns
+// (nil, "", nil) when no logo is set. A sidecar file present without
+// matching bytes (or vice versa) is treated as "no logo set" so a
+// half-written state during a crash doesn't trip up the boot path.
+//
+// Returns a non-nil error only when the kv layer reports an unexpected
+// failure (corrupt filesystem, permission denied) — callers should
+// surface those instead of silently masking them.
+//
+// Concurrency: NOT safe to call in parallel with saveUserLogo or
+// deleteUserLogo (the bytes/sidecar pair is read non-atomically). Boot
+// path calls this before publishing the App; future reload paths must
+// hold writeMu (i.e. invoke from inside mutateState).
+//
+//nolint:gocritic // unnamedResult: handler-style (bytes, ext, err) is clearer than naming for two callers
+func (s userStateStore) loadUserLogo() ([]byte, string, error) {
+	if s.kv == nil {
+		return nil, "", nil
+	}
+	ctx := context.Background()
+
+	logoBytes, err := s.kv.Get(ctx, userLogoFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) || os.IsNotExist(err) {
+			return nil, "", nil
+		}
+		return nil, "", fmt.Errorf("read %s: %w", userLogoFile, err)
+	}
+
+	extBytes, err := s.kv.Get(ctx, userLogoExtFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) || os.IsNotExist(err) {
+			// Bytes present but sidecar missing — treat as not-set.
+			// The user can re-upload to recover; we don't proactively
+			// clean up so a future fix can recover the bytes.
+			return nil, "", nil
+		}
+		return nil, "", fmt.Errorf("read %s: %w", userLogoExtFile, err)
+	}
+
+	ext := string(extBytes)
+	if _, ok := allowedLogoExts[ext]; !ok {
+		// Sidecar contains an unknown extension — treat as not-set.
+		// Same reasoning as the missing-sidecar case.
+		return nil, "", nil
+	}
+
+	return logoBytes, ext, nil
+}
+
+// saveUserLogo persists the bytes and extension. Caller must hold
+// writeMu (i.e. invoke from inside mutateState) so the bytes/sidecar
+// pair cannot be observed half-written by a concurrent reload.
+func (s userStateStore) saveUserLogo(ctx context.Context, bytes []byte, ext string) error {
+	if s.kv == nil {
+		return errors.New("kv not configured")
+	}
+	if _, ok := allowedLogoExts[ext]; !ok {
+		return fmt.Errorf("invalid logo extension %q", ext)
+	}
+	if err := s.kv.Put(ctx, userLogoFile, bytes); err != nil {
+		return fmt.Errorf("write %s: %w", userLogoFile, err)
+	}
+	if err := s.kv.Put(ctx, userLogoExtFile, []byte(ext)); err != nil {
+		return fmt.Errorf("write %s: %w", userLogoExtFile, err)
+	}
+	return nil
+}
+
+// deleteUserLogo removes both the bytes file and the sidecar. Idempotent;
+// missing files are not errors.
+func (s userStateStore) deleteUserLogo(ctx context.Context) error {
+	if s.kv == nil {
+		return nil
+	}
+	if err := s.kv.Delete(ctx, userLogoFile); err != nil {
+		return fmt.Errorf("delete %s: %w", userLogoFile, err)
+	}
+	if err := s.kv.Delete(ctx, userLogoExtFile); err != nil {
+		return fmt.Errorf("delete %s: %w", userLogoExtFile, err)
+	}
+	return nil
+}

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -311,7 +311,7 @@ func (a *App) rebuildState(configChanged, metaChanged bool) {
 		newStyleMap, newStyledTypes = buildStyleMap(newCfg, newMeta)
 		// On reload, keep the previous palette if the new file is
 		// broken — better to show stale colors than crash or wipe.
-		if up, err := a.loadUserPalette(); err != nil {
+		if up, err := a.userState.loadUserPalette(); err != nil {
 			slog.Warn("watcher: keeping previous user palette",
 				"file", userPaletteFile, "error", err)
 		} else {


### PR DESCRIPTION
Fifth step of the `dataentry.App` decomposition (**TKT-N26KLB**). Stacked on #1036.

## What

Move the 9 per-user UI-state persistence methods off `App` into a focused **`userStateStore`** (new `userstate.go`):

- logo: `loadUserLogo` / `saveUserLogo` / `deleteUserLogo`
- UI state: `loadUIState` / `saveUIState`
- user defaults: `loadUserDefaults` / `saveUserDefaults`
- user palette: `loadUserPalette` / `saveUserPalette`

Every method is a load/save pair over the `.rela/` KV store and touches nothing but `kv` — a genuinely single-dependency, cohesive cluster.

## Why these belong together

They are the per-user *customization* layer (gitignored `.rela/` files: `ui-state.json`, `user-defaults.yaml`, `palette.yaml`, the logo). Distinct from the entity store — writes here do **not** go through `entitymanager` (they are local UI preferences, not graph mutations). The HTTP handlers and the `mutateState` closures stay on `App` and call `a.userState.X`.

All 9 methods live in `userstate.go` with the type (per crit review — the type and its methods belong in one file, not scattered across app.go/theme_logo.go).

## Result

`App`: **187 → 178 methods**; plimsoll directive ratcheted. Behavior-preserving.

## Verification

`go build ./...`, `go test -race ./internal/dataentry/` (full suite), `golangci-lint` (0 issues), `just arch-lint`, `plimsoll ./...` (exit 0) all green.