### PR TITLE
refactor(dataentry): extract pure entitySerializer from App (TKT-N26KLB)

### DIFF
--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -933,28 +933,3 @@ func (svc affordanceService) computeAttachments(ctx context.Context, e *entityPk
 	}
 	return out
 }
-
-// serializeEntityForWire is the single entry-point every handler that
-// returns a per-entity V1Entity should use. It calls entityToV1, strips
-// hidden properties, and attaches the affordance maps. Use
-// [App.serializeRelatedEntityForWire] for entities that appear as
-// list rows or under `included` (no affordance maps, but still strip).
-func (a *App) serializeEntityForWire(ctx context.Context, e *entityPkg.Entity, plural string, includeRelations bool) V1Entity {
-	result := a.entityToV1(ctx, e, plural, includeRelations)
-	a.affordances.stripHiddenProperties(ctx, e, &result)
-	a.affordances.attachEntityAffordances(ctx, e, &result)
-	return result
-}
-
-// serializeRelatedEntityForWire renders an entity that is NOT the
-// per-entity response root — used for list rows, `?include=*` peers,
-// and the search-result include map. Strips hidden properties but
-// omits the `_fields` / `_relations` maps (they ride on per-entity
-// responses only). Hidden-field stripping still applies because the
-// wire contract is "hidden values never reach the client, regardless
-// of which response shape they ride in."
-func (a *App) serializeRelatedEntityForWire(ctx context.Context, e *entityPkg.Entity, plural string, includeRelations bool) V1Entity {
-	result := a.entityToV1(ctx, e, plural, includeRelations)
-	a.affordances.stripHiddenProperties(ctx, e, &result)
-	return result
-}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -546,7 +546,7 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 	data := make([]V1Entity, 0, len(entities))
 	included := make(map[string]V1Entity)
 	for _, e := range entities {
-		v1Entity := a.serializeRelatedEntityForWire(r.Context(), e, plural, true)
+		v1Entity := a.serializer.forWireRelated(r.Context(), e, a.outgoingRelations(r.Context(), e.ID), a.Meta(), plural)
 		data = append(data, v1Entity)
 
 		// Resolve includes if requested
@@ -687,7 +687,7 @@ func (a *App) handleV1CreateEntity(w http.ResponseWriter, r *http.Request, typeN
 		}
 	}
 
-	result := a.serializeEntityForWire(r.Context(), created, plural, true)
+	result := a.serializer.forWire(r.Context(), created, a.outgoingRelations(r.Context(), created.ID), a.Meta(), plural)
 	if len(relWarnings) > 0 {
 		result.Warnings = append(result.Warnings, relWarnings...)
 	}
@@ -799,7 +799,7 @@ func (a *App) handleV1DryRunCreate(w http.ResponseWriter, r *http.Request, typeN
 	// value-dependent predicates (e.g. field B read-only when A == x)
 	// re-derive as the form changes. includeRelations=false: no edges
 	// exist for an unsaved entity.
-	result := a.serializeEntityForWire(r.Context(), candidate, plural, false)
+	result := a.serializer.forWire(r.Context(), candidate, nil, a.Meta(), plural)
 	if idWarning != nil {
 		result.Warnings = append(result.Warnings, *idWarning)
 	}
@@ -884,11 +884,10 @@ func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName
 	}
 
 	query := r.URL.Query()
-	includeRelations := true
 
 	// Single per-entity serialization: strips hidden + attaches
 	// `_fields` / `_relations` per docs/data-entry/api-reference.md.
-	result := a.serializeEntityForWire(ctx, entity, plural, includeRelations)
+	result := a.serializer.forWire(ctx, entity, a.outgoingRelations(ctx, entity.ID), a.Meta(), plural)
 
 	// Handle includes for related entities
 	if includes := query.Get("include"); includes != "" {
@@ -1111,7 +1110,7 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 		}
 	}
 
-	result := a.serializeEntityForWire(r.Context(), entity, plural, true)
+	result := a.serializer.forWire(r.Context(), entity, a.outgoingRelations(r.Context(), entity.ID), a.Meta(), plural)
 	if len(warnings) > 0 {
 		result.Warnings = warnings
 	}
@@ -1633,7 +1632,7 @@ func (a *App) handleV1CloneEntity(w http.ResponseWriter, r *http.Request, typeNa
 
 	entityDef := s.Meta.Entities[typeName]
 	plural := entityDef.GetPlural(typeName)
-	result := a.serializeEntityForWire(r.Context(), newEntity, plural, false)
+	result := a.serializer.forWire(r.Context(), newEntity, nil, a.Meta(), plural)
 
 	w.Header().Set("Location", fmt.Sprintf("/api/v1/%s/%s", plural, newEntity.ID))
 	writeV1JSON(w, http.StatusCreated, result)
@@ -1848,7 +1847,7 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 		// {ID, Title} of related entities this principal may not read.
 		// Flipping this requires per-target gating first (RR-QO01XY) —
 		// TestACLSearch_VisibleHitRelatedToHidden pins the invariant.
-		data = append(data, a.serializeRelatedEntityForWire(r.Context(), e, plural, false))
+		data = append(data, a.serializer.forWireRelated(r.Context(), e, nil, a.Meta(), plural))
 	}
 
 	resp := V1ListResponse{
@@ -1983,42 +1982,6 @@ func (a *App) visibleAnalysisIssues(ctx context.Context, sections []AnalysisSect
 
 // --- Helper Functions ---
 
-func (a *App) entityToV1(ctx context.Context, e *entityPkg.Entity, plural string, includeRelations bool) V1Entity {
-	s := a.State()
-	v1 := V1Entity{
-		ID:         e.ID,
-		Type:       e.Type,
-		Title:      s.Meta.DisplayTitle(e.ID, e.Type, e.Properties),
-		Properties: make(map[string]interface{}),
-		Content:    e.Content,
-		Self:       fmt.Sprintf("/api/v1/%s/%s", plural, e.ID),
-		Actions:    a.affordances.computeActions(ctx, e),
-	}
-
-	for k, v := range e.Properties {
-		v1.Properties[k] = v
-	}
-
-	if e.IsLocked() {
-		v1.Inaccessible = make([]V1InaccessibleField, 0, len(e.Inaccessible))
-		for _, f := range e.Inaccessible {
-			v1.Inaccessible = append(v1.Inaccessible, V1InaccessibleField{
-				Name:   f.Name,
-				Reason: string(f.Reason),
-			})
-		}
-	}
-
-	if includeRelations {
-		v1.Relations = make(map[string][]string)
-		for _, edge := range a.outgoingRelations(ctx, e.ID) {
-			v1.Relations[edge.Type] = append(v1.Relations[edge.Type], edge.To)
-		}
-	}
-
-	return v1
-}
-
 func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, includes string) map[string]V1Entity {
 	s := a.State()
 	included := make(map[string]V1Entity)
@@ -2075,7 +2038,7 @@ func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, i
 	for _, target := range visible {
 		entityDef := s.Meta.Entities[target.Type]
 		plural := entityDef.GetPlural(target.Type)
-		included[target.ID] = a.serializeRelatedEntityForWire(ctx, target, plural, false)
+		included[target.ID] = a.serializer.forWireRelated(ctx, target, nil, a.Meta(), plural)
 
 		if nested, ok := nestedFor[target.ID]; ok {
 			for k, v := range a.resolveV1Includes(ctx, target, nested) {
@@ -3578,7 +3541,7 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 	plural := entityDef.GetPlural(result.Entry.Type)
 
 	resp := V1ViewResponse{
-		Entry:    a.serializeEntityForWire(r.Context(), result.Entry, plural, true),
+		Entry:    a.serializer.forWire(r.Context(), result.Entry, a.outgoingRelations(r.Context(), result.Entry.ID), a.Meta(), plural),
 		Sections: make([]V1ViewSection, 0, len(sections)),
 	}
 

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -97,11 +97,11 @@ const userPaletteFile = "palette.yaml"
 // readers — readers go through state.Load(). The workspace's internal
 // reloadMu coordinates the reload itself with the mutation path.
 //
-// TODO(TKT-N26KLB): App is a god-object (175 methods). Decompose toward the
+// TODO(TKT-N26KLB): App is a god-object (172 methods). Decompose toward the
 // 40-method load line — extract the API/serialization/relation services into
 // their own types. Ratchet this number DOWN as methods move out; never up.
 //
-//plimsoll:max-methods=175
+//plimsoll:max-methods=172
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -136,6 +136,10 @@ type App struct {
 	// write-time affordance validation. Extracted from App (TKT-N26KLB M5.2);
 	// shares the same acl.ACL as the write path (contract-test invariant).
 	affordances affordanceService
+	// serializer renders an entity into its V1Entity wire shape. Extracted from
+	// App (TKT-N26KLB); pure transform — handlers pass the entity's already-
+	// loaded outgoing relations, the serializer does no loading.
+	serializer entitySerializer
 	// userState persists per-user UI state (logo, UI state, defaults, palette)
 	// to the .rela/ KV store. Extracted from App (TKT-N26KLB M5.3).
 	userState userStateStore
@@ -481,6 +485,8 @@ func NewApp(
 		getEntity:          app.getEntity,
 		currentEdgesByPeer: app.currentEdgesByPeer,
 	}
+
+	app.serializer = entitySerializer{affordances: app.affordances}
 
 	userDefaults := app.userState.loadUserDefaults()
 	userPalette, paletteErr := app.userState.loadUserPalette()

--- a/internal/dataentry/entityserializer.go
+++ b/internal/dataentry/entityserializer.go
@@ -1,0 +1,81 @@
+package dataentry
+
+import (
+	"context"
+	"fmt"
+
+	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// entitySerializer renders an entity into its V1Entity wire shape. Extracted
+// from App (TKT-N26KLB). It does NO loading and holds no snapshot — the caller
+// passes everything the transform needs as values: the entity, its already-
+// loaded outgoing relations (nil to omit the relations map), and the metamodel
+// snapshot (for DisplayTitle). Loading and snapshotting are the handler's job
+// (it already holds both); serialization is a pure transform. The only field is
+// the affordance service, which computes the per-request _actions / _fields /
+// _relations maps and strips hidden fields (ACL-evaluated, hence the ctx).
+type entitySerializer struct {
+	affordances affordanceService
+}
+
+// toV1 builds the base V1Entity. meta is the request's metamodel snapshot;
+// outgoing is the entity's outgoing relations, already loaded by the caller
+// (nil omits the relations map — the former includeRelations=false shape).
+func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) V1Entity {
+	v1 := V1Entity{
+		ID:         e.ID,
+		Type:       e.Type,
+		Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
+		Properties: make(map[string]interface{}),
+		Content:    e.Content,
+		Self:       fmt.Sprintf("/api/v1/%s/%s", plural, e.ID),
+		Actions:    s.affordances.computeActions(ctx, e),
+	}
+
+	for k, v := range e.Properties {
+		v1.Properties[k] = v
+	}
+
+	if e.IsLocked() {
+		v1.Inaccessible = make([]V1InaccessibleField, 0, len(e.Inaccessible))
+		for _, f := range e.Inaccessible {
+			v1.Inaccessible = append(v1.Inaccessible, V1InaccessibleField{
+				Name:   f.Name,
+				Reason: string(f.Reason),
+			})
+		}
+	}
+
+	if outgoing != nil {
+		v1.Relations = make(map[string][]string)
+		for _, edge := range outgoing {
+			v1.Relations[edge.Type] = append(v1.Relations[edge.Type], edge.To)
+		}
+	}
+
+	return v1
+}
+
+// forWire is the single entry-point every handler that returns a per-entity
+// V1Entity should use: toV1 + strip hidden properties + attach the affordance
+// maps. Use forWireRelated for entities that appear as list rows or under
+// `included` (no affordance maps, but still strip).
+func (s entitySerializer) forWire(ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) V1Entity {
+	result := s.toV1(ctx, e, outgoing, meta, plural)
+	s.affordances.stripHiddenProperties(ctx, e, &result)
+	s.affordances.attachEntityAffordances(ctx, e, &result)
+	return result
+}
+
+// forWireRelated renders an entity that is NOT the per-entity response root —
+// list rows, `?include=*` peers, search-result include map. Strips hidden
+// properties but omits the `_fields` / `_relations` maps (those ride on
+// per-entity responses only). Hidden-field stripping still applies: the wire
+// contract is "hidden values never reach the client, regardless of shape."
+func (s entitySerializer) forWireRelated(ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) V1Entity {
+	result := s.toV1(ctx, e, outgoing, meta, plural)
+	s.affordances.stripHiddenProperties(ctx, e, &result)
+	return result
+}

--- a/internal/dataentry/handlers_attachment.go
+++ b/internal/dataentry/handlers_attachment.go
@@ -220,7 +220,7 @@ func (a *App) handleV1PutAttachment(w http.ResponseWriter, r *http.Request, type
 		return
 	}
 
-	result := a.serializeEntityForWire(ctx, entity, plural, true)
+	result := a.serializer.forWire(ctx, entity, a.outgoingRelations(ctx, entity.ID), a.Meta(), plural)
 	writeV1JSON(w, http.StatusOK, result)
 }
 

--- a/internal/dataentry/handlers_attachment_test.go
+++ b/internal/dataentry/handlers_attachment_test.go
@@ -189,7 +189,7 @@ func TestAttachment_MetadataOnEntityGET(t *testing.T) {
 	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
 	seedAttachment(t, app, "TKT-001", "shot.png", []byte("bytes"))
 
-	result := app.serializeEntityForWire(context.Background(), mustGet(t, app, "TKT-001"), "tickets", true)
+	result := app.serializer.forWire(context.Background(), mustGet(t, app, "TKT-001"), app.outgoingRelations(context.Background(), "TKT-001"), app.Meta(), "tickets")
 	if result.Attachments == nil {
 		t.Fatalf("_attachments map must be present on per-entity GET")
 	}
@@ -210,7 +210,7 @@ func TestAttachment_MetadataOnEntityGET(t *testing.T) {
 
 	// A list-row serialization must NOT carry the map (closed-world: it
 	// rides on per-entity responses only).
-	row := app.serializeRelatedEntityForWire(context.Background(), mustGet(t, app, "TKT-001"), "tickets", false)
+	row := app.serializer.forWireRelated(context.Background(), mustGet(t, app, "TKT-001"), nil, app.Meta(), "tickets")
 	if row.Attachments != nil {
 		t.Errorf("_attachments must be nil on list-row serialization; got %+v", *row.Attachments)
 	}
@@ -313,7 +313,7 @@ func TestAttachment_MetadataOnMutationResponse(t *testing.T) {
 	// serializeEntityForWire is the shared per-entity serializer for GET,
 	// PATCH, POST create, and clone. If it carries _attachments, every one
 	// of those responses does.
-	result := app.serializeEntityForWire(context.Background(), mustGet(t, app, "TKT-001"), "tickets", true)
+	result := app.serializer.forWire(context.Background(), mustGet(t, app, "TKT-001"), app.outgoingRelations(context.Background(), "TKT-001"), app.Meta(), "tickets")
 	if result.Attachments == nil {
 		t.Fatalf("_attachments must be present on every per-entity response, including mutations")
 	}
@@ -336,7 +336,7 @@ func TestAttachment_HiddenPropertyNotLeaked(t *testing.T) {
 	app.fieldResolver = fakeResolver{fv: FieldVerdicts{Visible: map[string]bool{"screenshot": false}}}
 
 	// _attachments omits the hidden property entirely.
-	result := app.serializeEntityForWire(context.Background(), mustGet(t, app, "TKT-001"), "tickets", true)
+	result := app.serializer.forWire(context.Background(), mustGet(t, app, "TKT-001"), app.outgoingRelations(context.Background(), "TKT-001"), app.Meta(), "tickets")
 	if result.Attachments != nil {
 		if _, present := (*result.Attachments)["screenshot"]; present {
 			t.Errorf("hidden property leaked into _attachments: %+v", *result.Attachments)

--- a/internal/dataentry/handlers_attachment_write_test.go
+++ b/internal/dataentry/handlers_attachment_write_test.go
@@ -306,7 +306,7 @@ func TestAttachmentUpload_ReplaceOversizeKeepsExisting(t *testing.T) {
 //nolint:unparam // entityID is conceptually variable; tests use one fixture.
 func attachmentsFor(t *testing.T, app *App, entityID, property string) []V1Attachment {
 	t.Helper()
-	result := app.serializeEntityForWire(context.Background(), mustGet(t, app, entityID), "tickets", true)
+	result := app.serializer.forWire(context.Background(), mustGet(t, app, entityID), app.outgoingRelations(context.Background(), entityID), app.Meta(), "tickets")
 	if result.Attachments == nil {
 		return nil
 	}

--- a/internal/dataentry/inaccessible_test.go
+++ b/internal/dataentry/inaccessible_test.go
@@ -32,7 +32,7 @@ func lockedTicket(inaccessibleFields ...string) *entity.Entity {
 func TestEntityToV1_PropagatesInaccessible(t *testing.T) {
 	app := newTestAppV1(t)
 	e := lockedTicket("title", "status")
-	v1 := app.entityToV1(t.Context(), e, "tickets", false)
+	v1 := app.serializer.toV1(t.Context(), e, nil, app.Meta(), "tickets")
 
 	if v1.ID != "TKT-LOCKED" {
 		t.Errorf("ID = %q, want TKT-LOCKED", v1.ID)
@@ -110,7 +110,7 @@ func TestEntityToV1_OmitsInaccessibleWhenEmpty(t *testing.T) {
 		},
 	}
 
-	v1 := app.entityToV1(t.Context(), e, "tickets", false)
+	v1 := app.serializer.toV1(t.Context(), e, nil, app.Meta(), "tickets")
 	if len(v1.Inaccessible) != 0 {
 		t.Errorf("Inaccessible non-empty for normal entity: %v", v1.Inaccessible)
 	}

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -153,6 +153,7 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 		getEntity:          app.getEntity,
 		currentEdgesByPeer: app.currentEdgesByPeer,
 	}
+	app.serializer = entitySerializer{affordances: app.affordances}
 }
 
 // rebindVisibleSearcher re-derives the generic visible-search wrapper


### PR DESCRIPTION
Extracts entity→V1Entity serialization off `App` into a pure `entitySerializer`. Stacked on the base (#1038-merged).

## What

Move `entityToV1` + `serializeEntityForWire` + `serializeRelatedEntityForWire` off `App` into a focused `entitySerializer`.

## The design point: a serializer that does not load

Previously `entityToV1` fetched the entity's outgoing relations **mid-serialization** — a "serializer that loads" smell. Now:

- The serializer does **no loading** and holds **no snapshot**. The handler — which already holds the entity — loads its outgoing relations and passes them, plus the metamodel snapshot, as **value params**. The `includeRelations bool` becomes "pass rels, or nil to omit".
- `entitySerializer` is therefore a single-field type (`affordances`) — a pure transform. No store, no App, no closure, no fetch.

This is deliberate layering: loading/snapshotting is the handler's job; serialization is a leaf with no upward dependency on App. It is the foundation a later write-handler extraction sits **on** (load via the read seam → serialize), which avoids the App↔writer cycle a naive write extraction hits.

## Result

`App`: **175 → 172 methods**; plimsoll directive ratcheted. Behavior-preserving.

## Verification

`go build ./...`, `go test -race ./internal/dataentry/` (full suite incl. serialization/attachment/inaccessible/ACL), `golangci-lint` (0 issues), `just arch-lint`, `plimsoll ./...` (exit 0) all green.