### PR TITLE
refactor(dataentry): extract entityReader from App (TKT-N26KLB)

### DIFF
--- a/internal/dataentry/acl_write_test.go
+++ b/internal/dataentry/acl_write_test.go
@@ -73,7 +73,7 @@ func TestACLWrite_PatchOnHiddenIs404(t *testing.T) {
 // test models would obtain the ETag through a side channel).
 func computeETagForTest(t *testing.T, app *App, entityID string) string {
 	t.Helper()
-	e, found := app.getEntity(t.Context(), entityID)
+	e, found := app.reader.getEntity(t.Context(), entityID)
 	if !found {
 		t.Fatalf("computeETagForTest: %s not in store", entityID)
 	}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -546,7 +546,7 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 	data := make([]V1Entity, 0, len(entities))
 	included := make(map[string]V1Entity)
 	for _, e := range entities {
-		v1Entity := a.serializer.forWireRelated(r.Context(), e, a.outgoingRelations(r.Context(), e.ID), a.Meta(), plural)
+		v1Entity := a.serializer.forWireRelated(r.Context(), e, a.reader.outgoingRelations(r.Context(), e.ID), a.Meta(), plural)
 		data = append(data, v1Entity)
 
 		// Resolve includes if requested
@@ -687,7 +687,7 @@ func (a *App) handleV1CreateEntity(w http.ResponseWriter, r *http.Request, typeN
 		}
 	}
 
-	result := a.serializer.forWire(r.Context(), created, a.outgoingRelations(r.Context(), created.ID), a.Meta(), plural)
+	result := a.serializer.forWire(r.Context(), created, a.reader.outgoingRelations(r.Context(), created.ID), a.Meta(), plural)
 	if len(relWarnings) > 0 {
 		result.Warnings = append(result.Warnings, relWarnings...)
 	}
@@ -887,7 +887,7 @@ func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName
 
 	// Single per-entity serialization: strips hidden + attaches
 	// `_fields` / `_relations` per docs/data-entry/api-reference.md.
-	result := a.serializer.forWire(ctx, entity, a.outgoingRelations(ctx, entity.ID), a.Meta(), plural)
+	result := a.serializer.forWire(ctx, entity, a.reader.outgoingRelations(ctx, entity.ID), a.Meta(), plural)
 
 	// Handle includes for related entities
 	if includes := query.Get("include"); includes != "" {
@@ -975,7 +975,7 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 		return
 	}
 
-	entity, found := a.getEntity(r.Context(), entityID)
+	entity, found := a.reader.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -1110,7 +1110,7 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 		}
 	}
 
-	result := a.serializer.forWire(r.Context(), entity, a.outgoingRelations(r.Context(), entity.ID), a.Meta(), plural)
+	result := a.serializer.forWire(r.Context(), entity, a.reader.outgoingRelations(r.Context(), entity.ID), a.Meta(), plural)
 	if len(warnings) > 0 {
 		result.Warnings = warnings
 	}
@@ -1170,7 +1170,7 @@ func (a *App) handleV1DeleteEntity(w http.ResponseWriter, r *http.Request, typeN
 		return
 	}
 
-	entity, found := a.getEntity(r.Context(), entityID)
+	entity, found := a.reader.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -1204,14 +1204,14 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 	}
 
 	s := a.State()
-	entity, found := a.getEntity(r.Context(), entityID)
+	entity, found := a.reader.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
 	}
 
-	outgoing := a.outgoingRelations(r.Context(), entityID)
-	incoming := a.incomingRelations(r.Context(), entityID)
+	outgoing := a.reader.outgoingRelations(r.Context(), entityID)
+	incoming := a.reader.incomingRelations(r.Context(), entityID)
 
 	relations := make(map[string][]map[string]interface{})
 
@@ -1222,7 +1222,7 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 	for _, edge := range outgoing {
 		rel := map[string]interface{}{
 			"id":        edge.To,
-			"type":      a.peerType(r.Context(), edge.To),
+			"type":      a.reader.entityType(r.Context(), edge.To),
 			"direction": "outgoing",
 		}
 		if len(edge.Properties) > 0 {
@@ -1247,7 +1247,7 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 		}
 		rel := map[string]interface{}{
 			"id":        edge.From,
-			"type":      a.peerType(r.Context(), edge.From),
+			"type":      a.reader.entityType(r.Context(), edge.From),
 			"direction": "incoming",
 		}
 		if len(edge.Properties) > 0 {
@@ -1325,7 +1325,7 @@ func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, ty
 		return
 	}
 
-	entity, found := a.getEntity(r.Context(), entityID)
+	entity, found := a.reader.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -1335,9 +1335,9 @@ func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, ty
 
 	var edges []*entityPkg.Relation
 	if incoming {
-		edges = a.incomingRelations(r.Context(), entityID)
+		edges = a.reader.incomingRelations(r.Context(), entityID)
 	} else {
-		edges = a.outgoingRelations(r.Context(), entityID)
+		edges = a.reader.outgoingRelations(r.Context(), entityID)
 	}
 
 	relations := make([]map[string]interface{}, 0, len(edges))
@@ -1352,7 +1352,7 @@ func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, ty
 		}
 		rel := map[string]interface{}{
 			"id":   peerID,
-			"type": a.peerType(r.Context(), peerID),
+			"type": a.reader.entityType(r.Context(), peerID),
 		}
 		if len(edge.Properties) > 0 {
 			rel["meta"] = edge.Properties
@@ -1388,7 +1388,7 @@ func (a *App) handleV1CreateRelation(w http.ResponseWriter, r *http.Request, typ
 		return
 	}
 
-	entity, found := a.getEntity(r.Context(), entityID)
+	entity, found := a.reader.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -1460,7 +1460,7 @@ func (a *App) handleV1UpdateRelation(w http.ResponseWriter, r *http.Request, typ
 		return
 	}
 
-	entity, found := a.getEntity(r.Context(), entityID)
+	entity, found := a.reader.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -1541,7 +1541,7 @@ func (a *App) handleV1DeleteRelation(w http.ResponseWriter, r *http.Request, typ
 		return
 	}
 
-	entity, found := a.getEntity(r.Context(), entityID)
+	entity, found := a.reader.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -1601,7 +1601,7 @@ func (a *App) handleV1CloneEntity(w http.ResponseWriter, r *http.Request, typeNa
 		return
 	}
 
-	entity, found := a.getEntity(r.Context(), entityID)
+	entity, found := a.reader.getEntity(r.Context(), entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 		return
@@ -2000,13 +2000,13 @@ func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, i
 	nestedFor := make(map[string]string)
 
 	if includes == "*" {
-		for _, edge := range a.outgoingRelations(ctx, entity.ID) {
-			if target, found := a.getEntity(ctx, edge.To); found {
+		for _, edge := range a.reader.outgoingRelations(ctx, entity.ID) {
+			if target, found := a.reader.getEntity(ctx, edge.To); found {
 				candidates = append(candidates, target)
 			}
 		}
-		for _, edge := range a.incomingRelations(ctx, entity.ID) {
-			if source, found := a.getEntity(ctx, edge.From); found {
+		for _, edge := range a.reader.incomingRelations(ctx, entity.ID) {
+			if source, found := a.reader.getEntity(ctx, edge.From); found {
 				candidates = append(candidates, source)
 			}
 		}
@@ -2018,11 +2018,11 @@ func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, i
 			}
 			relParts := strings.SplitN(part, ".", 2)
 			relType := relParts[0]
-			for _, edge := range a.outgoingRelations(ctx, entity.ID) {
+			for _, edge := range a.reader.outgoingRelations(ctx, entity.ID) {
 				if edge.Type != relType {
 					continue
 				}
-				target, found := a.getEntity(ctx, edge.To)
+				target, found := a.reader.getEntity(ctx, edge.To)
 				if !found {
 					continue
 				}
@@ -2316,7 +2316,7 @@ func (a *App) computeEntityETag(ctx context.Context, e *entityPkg.Entity) string
 	// Fold outgoing relations into the hash so PATCHes that only change
 	// edges also change the ETag — otherwise If-Match / If-None-Match
 	// round-trips poison client caches.
-	edges := a.outgoingRelations(ctx, e.ID)
+	edges := a.reader.outgoingRelations(ctx, e.ID)
 	edgeKeys := make([]string, 0, len(edges))
 	for _, edge := range edges {
 		edgeKeys = append(edgeKeys, edge.Type+"|"+edge.To)
@@ -2480,7 +2480,7 @@ func (a *App) handleV1SidePanel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the entry entity
-	entry, found := a.getEntity(r.Context(), entityID)
+	entry, found := a.reader.getEntity(r.Context(), entityID)
 	if !found {
 		writeV1Error(w, r, http.StatusNotFound, "entity_not_found", "Entity not found", "")
 		return
@@ -3027,7 +3027,7 @@ func (a *App) authorizeConflictResolve(ctx context.Context, w http.ResponseWrite
 	var aclReq acl.WriteRequest
 	if rel != nil {
 		var fromType string
-		if fromEntity, ok := a.getEntity(ctx, rel.From); ok {
+		if fromEntity, ok := a.reader.getEntity(ctx, rel.From); ok {
 			fromType = fromEntity.Type
 		}
 		aclReq = translateRelationWrite(rel.Type, fromType, rel.From)
@@ -3541,7 +3541,7 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 	plural := entityDef.GetPlural(result.Entry.Type)
 
 	resp := V1ViewResponse{
-		Entry:    a.serializer.forWire(r.Context(), result.Entry, a.outgoingRelations(r.Context(), result.Entry.ID), a.Meta(), plural),
+		Entry:    a.serializer.forWire(r.Context(), result.Entry, a.reader.outgoingRelations(r.Context(), result.Entry.ID), a.Meta(), plural),
 		Sections: make([]V1ViewSection, 0, len(sections)),
 	}
 

--- a/internal/dataentry/api_v1_properties_unset_test.go
+++ b/internal/dataentry/api_v1_properties_unset_test.go
@@ -187,7 +187,7 @@ func TestV1UpdateEntity_PropertiesUnsetAndRelations_Together(t *testing.T) {
 		t.Error("status not removed")
 	}
 	// Relation written
-	edges := app.outgoingRelations(context.Background(), "TKT-001")
+	edges := app.reader.outgoingRelations(context.Background(), "TKT-001")
 	if len(edges) != 1 || edges[0].Type != "blocks" || edges[0].To != "FEAT-001" {
 		t.Errorf("expected one blocks→FEAT-001 edge, got %+v", edges)
 	}

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -2981,7 +2981,7 @@ func TestV1UpdateEntityInvalidJSON(t *testing.T) {
 // edges for entityID, used to keep the relation-save tests concise.
 func implementsTargets(app *App, entityID string) map[string]bool {
 	out := map[string]bool{}
-	for _, r := range app.outgoingRelations(context.Background(), entityID) {
+	for _, r := range app.reader.outgoingRelations(context.Background(), entityID) {
 		if r.Type == "implements" {
 			out[r.To] = true
 		}
@@ -3146,7 +3146,7 @@ func TestV1UpdateEntity_Relations_ScopedToTypesInPayload(t *testing.T) {
 
 	impls := map[string]bool{}
 	blocks := map[string]bool{}
-	for _, r := range app.outgoingRelations(context.Background(), "TKT-001") {
+	for _, r := range app.reader.outgoingRelations(context.Background(), "TKT-001") {
 		switch r.Type {
 		case "implements":
 			impls[r.To] = true
@@ -3182,7 +3182,7 @@ func TestV1UpdateEntity_Relations_MultiType(t *testing.T) {
 	}
 
 	types := map[string]bool{}
-	for _, r := range app.outgoingRelations(context.Background(), "TKT-001") {
+	for _, r := range app.reader.outgoingRelations(context.Background(), "TKT-001") {
 		types[r.Type+"->"+r.To] = true
 	}
 	if !types["implements->FEAT-001"] || !types["blocks->TKT-002"] || len(types) != 2 {
@@ -3210,7 +3210,7 @@ func TestV1UpdateEntity_Relations_UnknownType(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), "unknown_relation_type") || !strings.Contains(rec.Body.String(), "bogus") {
 		t.Fatalf("detail missing structured reason/type, got: %s", rec.Body.String())
 	}
-	if len(app.outgoingRelations(context.Background(), "TKT-001")) != 0 {
+	if len(app.reader.outgoingRelations(context.Background(), "TKT-001")) != 0 {
 		t.Fatalf("no edges should have been written on a rejected type")
 	}
 }
@@ -3280,7 +3280,7 @@ func TestV1UpdateEntity_Relations_OnlyPATCH_ETagChangesButEntityStable(t *testin
 	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]interface{}{"title": "T"}})
 	seedEntity(app, &entity.Entity{ID: "FEAT-001", Type: "feature", Properties: map[string]interface{}{"title": "F"}})
 
-	entityBefore, _ := app.getEntity(context.Background(), "TKT-001")
+	entityBefore, _ := app.reader.getEntity(context.Background(), "TKT-001")
 	etagBefore := app.computeEntityETag(context.Background(), entityBefore)
 
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/TKT-001",
@@ -3291,7 +3291,7 @@ func TestV1UpdateEntity_Relations_OnlyPATCH_ETagChangesButEntityStable(t *testin
 		t.Fatalf("PATCH returned %d: %s", rec.Code, rec.Body.String())
 	}
 
-	entityAfter, _ := app.getEntity(context.Background(), "TKT-001")
+	entityAfter, _ := app.reader.getEntity(context.Background(), "TKT-001")
 	// Entity fields (id/type/props/content) should be byte-identical.
 	if entityAfter.Content != entityBefore.Content ||
 		len(entityAfter.Properties) != len(entityBefore.Properties) {
@@ -4498,7 +4498,7 @@ func TestV1Affordance_PatchReadOnlyField_Forbidden(t *testing.T) {
 			t.Fatalf("got %d, want 403; body=%s", code, body)
 		}
 		// Verify title was NOT updated.
-		e, _ := app.getEntity(context.Background(), "TKT-001")
+		e, _ := app.reader.getEntity(context.Background(), "TKT-001")
 		if e.Properties["title"] != "Original" {
 			t.Errorf("title must not be applied when status fails: got %v", e.Properties["title"])
 		}

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -97,11 +97,11 @@ const userPaletteFile = "palette.yaml"
 // readers — readers go through state.Load(). The workspace's internal
 // reloadMu coordinates the reload itself with the mutation path.
 //
-// TODO(TKT-N26KLB): App is a god-object (172 methods). Decompose toward the
+// TODO(TKT-N26KLB): App is a god-object (167 methods). Decompose toward the
 // 40-method load line — extract the API/serialization/relation services into
 // their own types. Ratchet this number DOWN as methods move out; never up.
 //
-//plimsoll:max-methods=172
+//plimsoll:max-methods=167
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -126,8 +126,12 @@ type App struct {
 	// structurally rather than by per-call-site convention. Wraps the same
 	// `store` handle; the gate is resolved per-request from the context.
 	visibleReader visibleReader
-	tracer        tracer.Tracer
-	validator     validator.Validator
+	// reader is the ungated entity/relation read seam over the store. Extracted
+	// from App (TKT-N26KLB); a single-dep leaf shared by read/write/affordance
+	// paths. ACL scoping lives in visibleReader, not here.
+	reader    entityReader
+	tracer    tracer.Tracer
+	validator validator.Validator
 	// analyze runs the read-only graph-analysis checks. Extracted from App
 	// (TKT-N26KLB M5.1); holds its own {store, tracer, validator} and takes
 	// the metamodel snapshot per call.
@@ -455,6 +459,7 @@ func NewApp(
 		searcher:        searcher,
 		visibleSearcher: visibleSearcher,
 		visibleReader:   newVisibleReader(st),
+		reader:          entityReader{store: st},
 		tracer:          trc,
 		validator:       val,
 		analyze:         analyzeService{store: st, tracer: trc, validator: val},
@@ -482,7 +487,7 @@ func NewApp(
 		resolver:           func() FieldVerdictResolver { return app.fieldResolver },
 		store:              st,
 		meta:               func() *metamodel.Metamodel { return app.State().Meta },
-		getEntity:          app.getEntity,
+		getEntity:          app.reader.getEntity,
 		currentEdgesByPeer: app.currentEdgesByPeer,
 	}
 

--- a/internal/dataentry/entityreader.go
+++ b/internal/dataentry/entityreader.go
@@ -1,0 +1,70 @@
+package dataentry
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// entityReader is the ungated entity/relation read seam over the store.
+// Extracted from App (TKT-N26KLB): a single-dependency leaf shared by the read
+// handlers, the affordance service, the relation handlers, and (eventually) the
+// write handlers. It is deliberately UNGATED — ACL scoping is applied elsewhere
+// (visibleReader for the gated single-GET / include-filter path; the analyze
+// gate at the issue boundary). These helpers are the raw store reads those
+// gated paths and the internal machinery build on.
+type entityReader struct {
+	store store.Store
+}
+
+// getEntity looks up an entity by ID via the store.
+func (er entityReader) getEntity(ctx context.Context, id string) (*entity.Entity, bool) {
+	e, err := er.store.GetEntity(ctx, id)
+	if err != nil {
+		return nil, false
+	}
+	return e, true
+}
+
+// entityType returns the type of the entity with the given ID, or empty
+// string if it can't be resolved. The relation GET handlers call it on a
+// relation endpoint's ID to emit a `type` field per edge, so SPA clients can
+// construct JSON:API §9 resource identifiers without guessing — but the
+// operation is just "look up an entity, return its type", nothing
+// relation-specific.
+func (er entityReader) entityType(ctx context.Context, id string) string {
+	if e, ok := er.getEntity(ctx, id); ok {
+		return e.Type
+	}
+	return ""
+}
+
+// outgoingRelations returns all outgoing relations for id.
+//
+// A store error truncates the slice to what was read before the failure. The
+// callers are response-serialization paths where a partial relations map is
+// degraded-but-usable and a hard failure would 500 the whole entity; we log
+// the error (so it isn't invisible) rather than propagate it. TODO(TKT-N26KLB):
+// the relations map silently dropping edges on a store error is a latent
+// correctness gap inherited from App — revisit whether these paths should
+// surface a partial-result warning.
+func (er entityReader) outgoingRelations(ctx context.Context, id string) []*entity.Relation {
+	return er.relations(ctx, id, store.DirectionOutgoing)
+}
+
+// incomingRelations returns all incoming relations for id. Same error handling
+// as outgoingRelations.
+func (er entityReader) incomingRelations(ctx context.Context, id string) []*entity.Relation {
+	return er.relations(ctx, id, store.DirectionIncoming)
+}
+
+func (er entityReader) relations(ctx context.Context, id string, dir store.Direction) []*entity.Relation {
+	rels, err := listRelationsCtx(ctx, er.store, store.RelationQuery{EntityID: id, Direction: dir})
+	if err != nil {
+		slog.Warn("dataentry: entityReader: listing relations failed; result truncated",
+			"entity", id, "direction", dir, "err", err)
+	}
+	return rels
+}

--- a/internal/dataentry/handlers_attachment.go
+++ b/internal/dataentry/handlers_attachment.go
@@ -88,7 +88,7 @@ func (a *App) handleV1GetAttachment(w http.ResponseWriter, r *http.Request, type
 		return
 	}
 
-	entity, found := a.getEntity(ctx, entityID)
+	entity, found := a.reader.getEntity(ctx, entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
 		return
@@ -220,7 +220,7 @@ func (a *App) handleV1PutAttachment(w http.ResponseWriter, r *http.Request, type
 		return
 	}
 
-	result := a.serializer.forWire(ctx, entity, a.outgoingRelations(ctx, entity.ID), a.Meta(), plural)
+	result := a.serializer.forWire(ctx, entity, a.reader.outgoingRelations(ctx, entity.ID), a.Meta(), plural)
 	writeV1JSON(w, http.StatusOK, result)
 }
 
@@ -321,7 +321,7 @@ func (a *App) attachmentWritePreflight(w http.ResponseWriter, r *http.Request, t
 		return nil, false
 	}
 
-	entity, found := a.getEntity(ctx, entityID)
+	entity, found := a.reader.getEntity(ctx, entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
 		return nil, false

--- a/internal/dataentry/handlers_attachment_test.go
+++ b/internal/dataentry/handlers_attachment_test.go
@@ -189,7 +189,7 @@ func TestAttachment_MetadataOnEntityGET(t *testing.T) {
 	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
 	seedAttachment(t, app, "TKT-001", "shot.png", []byte("bytes"))
 
-	result := app.serializer.forWire(context.Background(), mustGet(t, app, "TKT-001"), app.outgoingRelations(context.Background(), "TKT-001"), app.Meta(), "tickets")
+	result := app.serializer.forWire(context.Background(), mustGet(t, app, "TKT-001"), app.reader.outgoingRelations(context.Background(), "TKT-001"), app.Meta(), "tickets")
 	if result.Attachments == nil {
 		t.Fatalf("_attachments map must be present on per-entity GET")
 	}
@@ -219,7 +219,7 @@ func TestAttachment_MetadataOnEntityGET(t *testing.T) {
 // mustGet loads an entity or fails the test.
 func mustGet(t *testing.T, app *App, id string) *entity.Entity {
 	t.Helper()
-	e, ok := app.getEntity(context.Background(), id)
+	e, ok := app.reader.getEntity(context.Background(), id)
 	if !ok {
 		t.Fatalf("getEntity(%s) not found", id)
 	}
@@ -313,7 +313,7 @@ func TestAttachment_MetadataOnMutationResponse(t *testing.T) {
 	// serializeEntityForWire is the shared per-entity serializer for GET,
 	// PATCH, POST create, and clone. If it carries _attachments, every one
 	// of those responses does.
-	result := app.serializer.forWire(context.Background(), mustGet(t, app, "TKT-001"), app.outgoingRelations(context.Background(), "TKT-001"), app.Meta(), "tickets")
+	result := app.serializer.forWire(context.Background(), mustGet(t, app, "TKT-001"), app.reader.outgoingRelations(context.Background(), "TKT-001"), app.Meta(), "tickets")
 	if result.Attachments == nil {
 		t.Fatalf("_attachments must be present on every per-entity response, including mutations")
 	}
@@ -336,7 +336,7 @@ func TestAttachment_HiddenPropertyNotLeaked(t *testing.T) {
 	app.fieldResolver = fakeResolver{fv: FieldVerdicts{Visible: map[string]bool{"screenshot": false}}}
 
 	// _attachments omits the hidden property entirely.
-	result := app.serializer.forWire(context.Background(), mustGet(t, app, "TKT-001"), app.outgoingRelations(context.Background(), "TKT-001"), app.Meta(), "tickets")
+	result := app.serializer.forWire(context.Background(), mustGet(t, app, "TKT-001"), app.reader.outgoingRelations(context.Background(), "TKT-001"), app.Meta(), "tickets")
 	if result.Attachments != nil {
 		if _, present := (*result.Attachments)["screenshot"]; present {
 			t.Errorf("hidden property leaked into _attachments: %+v", *result.Attachments)

--- a/internal/dataentry/handlers_attachment_write_test.go
+++ b/internal/dataentry/handlers_attachment_write_test.go
@@ -306,7 +306,7 @@ func TestAttachmentUpload_ReplaceOversizeKeepsExisting(t *testing.T) {
 //nolint:unparam // entityID is conceptually variable; tests use one fixture.
 func attachmentsFor(t *testing.T, app *App, entityID, property string) []V1Attachment {
 	t.Helper()
-	result := app.serializer.forWire(context.Background(), mustGet(t, app, entityID), app.outgoingRelations(context.Background(), entityID), app.Meta(), "tickets")
+	result := app.serializer.forWire(context.Background(), mustGet(t, app, entityID), app.reader.outgoingRelations(context.Background(), entityID), app.Meta(), "tickets")
 	if result.Attachments == nil {
 		return nil
 	}

--- a/internal/dataentry/relations_direction.go
+++ b/internal/dataentry/relations_direction.go
@@ -168,9 +168,9 @@ func (a *App) currentEdgesByPeer(
 	current := map[string]*entity.Relation{}
 	var edges []*entity.Relation
 	if incoming {
-		edges = a.incomingRelations(ctx, entityID)
+		edges = a.reader.incomingRelations(ctx, entityID)
 	} else {
-		edges = a.outgoingRelations(ctx, entityID)
+		edges = a.reader.outgoingRelations(ctx, entityID)
 	}
 	for _, edge := range edges {
 		if edge.Type != canonical {

--- a/internal/dataentry/relations_modern_direction_test.go
+++ b/internal/dataentry/relations_modern_direction_test.go
@@ -96,7 +96,7 @@ func TestApplyRelationsModern_IncomingBodyKey_BothEndpoints(t *testing.T) {
 	}
 
 	// outgoingRelations(source) must include the edge.
-	outEdges := app.outgoingRelations(context.Background(), sourceID)
+	outEdges := app.reader.outgoingRelations(context.Background(), sourceID)
 	if len(outEdges) != 1 {
 		t.Fatalf("expected 1 outgoing edge from %s, got %d", sourceID, len(outEdges))
 	}
@@ -110,7 +110,7 @@ func TestApplyRelationsModern_IncomingBodyKey_BothEndpoints(t *testing.T) {
 	}
 
 	// incomingRelations(target) must include the SAME edge.
-	inEdges := app.incomingRelations(context.Background(), targetID)
+	inEdges := app.reader.incomingRelations(context.Background(), targetID)
 	if len(inEdges) != 1 {
 		t.Fatalf("expected 1 incoming edge to %s, got %d", targetID, len(inEdges))
 	}
@@ -135,10 +135,10 @@ func TestApplyRelationsModern_IncomingDelete(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	if got := len(app.outgoingRelations(context.Background(), sourceID)); got != 0 {
+	if got := len(app.reader.outgoingRelations(context.Background(), sourceID)); got != 0 {
 		t.Errorf("expected 0 outgoing from %s after delete, got %d", sourceID, got)
 	}
-	if got := len(app.incomingRelations(context.Background(), targetID)); got != 0 {
+	if got := len(app.reader.incomingRelations(context.Background(), targetID)); got != 0 {
 		t.Errorf("expected 0 incoming to %s after delete, got %d", targetID, got)
 	}
 }
@@ -150,7 +150,7 @@ func TestApplyRelationsModern_IncomingNoOp(t *testing.T) {
 	app := newDirectionTestApp(t)
 	sourceID, targetID := seedDirectionFixture(t, app)
 
-	preEdge := app.outgoingRelations(context.Background(), sourceID)[0]
+	preEdge := app.reader.outgoingRelations(context.Background(), sourceID)[0]
 	body := `{"relations":{"blockedBy":{"data":[{"type":"feature","id":"` + sourceID + `","meta":{"reason":"test block"}}]}}}`
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/features/"+targetID, strings.NewReader(body))
 	rec := httptest.NewRecorder()
@@ -159,7 +159,7 @@ func TestApplyRelationsModern_IncomingNoOp(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	postEdge := app.outgoingRelations(context.Background(), sourceID)[0]
+	postEdge := app.reader.outgoingRelations(context.Background(), sourceID)[0]
 	// No new edge, no property drift.
 	if postEdge.Properties["reason"] != preEdge.Properties["reason"] {
 		t.Errorf("no-op should not change properties: before=%v after=%v",
@@ -229,12 +229,12 @@ func TestApplyRelationsModern_MixedCanonicalAndInverse(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 	// FEAT-A → FEAT-B (outgoing)
-	outA := app.outgoingRelations(context.Background(), "FEAT-A")
+	outA := app.reader.outgoingRelations(context.Background(), "FEAT-A")
 	if len(outA) != 1 || outA[0].To != "FEAT-B" {
 		t.Errorf("FEAT-A should have 1 outgoing to FEAT-B, got %+v", outA)
 	}
 	// FEAT-C → FEAT-A (incoming view from FEAT-A's perspective)
-	inA := app.incomingRelations(context.Background(), "FEAT-A")
+	inA := app.reader.incomingRelations(context.Background(), "FEAT-A")
 	if len(inA) != 1 || inA[0].From != "FEAT-C" {
 		t.Errorf("FEAT-A should have 1 incoming from FEAT-C, got %+v", inA)
 	}

--- a/internal/dataentry/services.go
+++ b/internal/dataentry/services.go
@@ -43,51 +43,9 @@ func (a *App) Services() Services {
 	}
 }
 
-// getEntity looks up an entity by ID via the store.
-func (a *App) getEntity(ctx context.Context, id string) (*entity.Entity, bool) {
-	e, err := a.store.GetEntity(ctx, id)
-	if err != nil {
-		return nil, false
-	}
-	return e, true
-}
-
-// peerType returns the entity type for the peer ID on the other end of
-// a relation edge, or empty string if the peer can't be resolved. Used
-// by the relation GET handlers to emit a `type` field per edge so SPA
-// clients can construct JSON:API §9 resource identifiers without
-// guessing.
-func (a *App) peerType(ctx context.Context, id string) string {
-	if e, ok := a.getEntity(ctx, id); ok {
-		return e.Type
-	}
-	return ""
-}
-
-// outgoingRelations returns all outgoing relations for id. Iterator
-// errors are swallowed; use outgoingRelationsCtx to surface them.
-func (a *App) outgoingRelations(ctx context.Context, id string) []*entity.Relation {
-	rels, _ := a.outgoingRelationsCtx(ctx, id)
-	return rels
-}
-
-// outgoingRelationsCtx returns all outgoing relations for id and surfaces
-// iterator errors rather than silently truncating the slice.
-func (a *App) outgoingRelationsCtx(ctx context.Context, id string) ([]*entity.Relation, error) {
-	return listRelationsCtx(ctx, a.store, store.RelationQuery{
-		EntityID:  id,
-		Direction: store.DirectionOutgoing,
-	})
-}
-
-// incomingRelations returns all incoming relations for id.
-func (a *App) incomingRelations(ctx context.Context, id string) []*entity.Relation {
-	rels, _ := listRelationsCtx(ctx, a.store, store.RelationQuery{
-		EntityID:  id,
-		Direction: store.DirectionIncoming,
-	})
-	return rels
-}
+// The ungated entity/relation read helpers (getEntity, entityType,
+// outgoing/incomingRelations) moved to entityReader (entityreader.go,
+// TKT-N26KLB). App reaches them via a.reader.X.
 
 func listRelationsCtx(ctx context.Context, s store.Store, q store.RelationQuery) ([]*entity.Relation, error) {
 	out := make([]*entity.Relation, 0)

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -127,6 +127,7 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	app.paths = paths
 	app.store = svc.Store()
 	app.visibleReader = newVisibleReader(svc.Store())
+	app.reader = entityReader{store: svc.Store()}
 	app.entityManager = svc.EntityManager()
 	app.searcher = svc.Searcher()
 	app.visibleSearcher = svc.VisibleSearcher()
@@ -150,7 +151,7 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 		resolver:           func() FieldVerdictResolver { return app.fieldResolver },
 		store:              svc.Store(),
 		meta:               func() *metamodel.Metamodel { return app.State().Meta },
-		getEntity:          app.getEntity,
+		getEntity:          app.reader.getEntity,
 		currentEdgesByPeer: app.currentEdgesByPeer,
 	}
 	app.serializer = entitySerializer{affordances: app.affordances}


### PR DESCRIPTION
Extracts the ungated entity/relation read seam off `App` into a focused `entityReader{store}`. Stacked on the base (#1039-merged).

## What

Move the 5 ungated store-read helpers — `getEntity`, `entityType` (was `peerType`), `outgoingRelations`, `incomingRelations` — off `App` into `entityReader{store}`, a single-dependency leaf shared by read handlers, the affordance service, the relation handlers, and the write paths.

## Design

- **Deliberately ungated.** These are raw store reads. ACL scoping lives in `visibleReader` (the gated single-GET / include-filter seam), NOT here. Keeping the raw read seam separate from the gated one keeps each honest — `visibleReader`’s whole point is ACL-scoping; folding ungated reads in would muddy it.
- Together with the (already-extracted) `entitySerializer`, this is the **peer layer the write handlers will sit on**: load via `a.reader`, serialize via `a.serializer` — both leaves, no reach-back into App, no cycle.

## Review fixes (from crit)

- `peerType` → **`entityType`**: it just looks up an entity and returns its `.Type`; nothing relation-specific (the relation framing was only how it’s called). Renamed + doc clarified.
- The dead err-returning variant (`outgoingRelationsCtx`, 0 callers) removed; `outgoing`/`incomingRelations` now share one `relations(dir)` helper that **logs** on a store error instead of silently dropping it. A `TODO(TKT-N26KLB)` flags the deeper latent gap (relations-map truncation on store error is pre-existing App behavior; surfacing it as a partial-result warning is a separate behavior change).

## Result

`App`: **172 → 167 methods**; plimsoll directive ratcheted. Behavior-preserving.

## Verification

`go build ./...`, `go test -race ./internal/dataentry/`, `golangci-lint` (0 issues), `just arch-lint`, `plimsoll ./...` (exit 0) all green.