### PR TITLE
refactor: extract apiwire/v1 package + enforce its boundary (TKT-N26KLB)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -58,6 +58,10 @@ components:
 
   # Core domain
   entity:           { in: internal/entity }
+  # API wire contract — the v1 data-entry API vocabulary. A pure leaf:
+  # depends only on entity (+ dataentryconfig), NEVER on dataentry. Both the
+  # data-entry server and a future native bridge consume it.
+  apiwire:          { in: internal/apiwire/** }
   lua:              { in: internal/lua }
   scheduler:        { in: internal/scheduler }
   script:           { in: internal/script }
@@ -231,10 +235,21 @@ deps:
       - tablewriter
 
   # Web / UI layer
+  # apiwire is a leaf: it may use the domain types and the data-entry config
+  # types, but MUST NOT depend on dataentry (the contract can't depend on the
+  # server that serializes to it). No `dataentry` here is the whole point —
+  # arch-lint fails if anyone adds that import.
+  apiwire:
+    # entity/errors are commonComponents (importable by all), so only the
+    # data-entry config types need listing. Critically: NO `dataentry` — the
+    # contract must not depend on the server that serializes to it.
+    mayDependOn:
+      - dataentryconfig
   dataentry:
     mayDependOn:
       - acl
       - affordances
+      - apiwire
       - attachment
       - audit
       - canonical

--- a/internal/apiwire/v1/relations.go
+++ b/internal/apiwire/v1/relations.go
@@ -1,4 +1,9 @@
-package dataentry
+// Package v1 holds the v1 data-entry API wire vocabulary: the JSON-shaped
+// request/response types the server serializes to and that an in-process native
+// bridge can consume directly. It is a pure CONTRACT package — it depends only
+// on stdlib and the domain types, never on the data-entry server package.
+// A future API version lives in a sibling package (apiwire/v2).
+package v1
 
 import (
 	"bytes"
@@ -9,7 +14,7 @@ import (
 	"unicode"
 )
 
-// V1RelationsField is the top-level value of the `relations` key in a
+// RelationsField is the top-level value of the `relations` key in a
 // PATCH /api/v1/{plural}/{id} or POST /api/v1/{plural} request body.
 // Every relation type's value must be the JSON:API §9-shaped wrapper:
 // `{"data": [{type, id, meta?, meta_unset?, content?}, ...]}`.
@@ -18,19 +23,19 @@ import (
 // is rejected at unmarshal time with a stable `legacy_shape_unsupported`
 // error. The SPA emits modern shape exclusively; external clients should
 // follow suit.
-type V1RelationsField struct {
+type RelationsField struct {
 	// Modern holds the JSON:API §9-shaped form, the only shape the
 	// wire accepts.
-	Modern map[string]V1RelationsUpdate
+	Modern map[string]RelationsUpdate
 }
 
 // IsEmpty reports whether the relations field was absent or `{}` in the
 // request body.
-func (f V1RelationsField) IsEmpty() bool {
+func (f RelationsField) IsEmpty() bool {
 	return len(f.Modern) == 0
 }
 
-// V1RelationsUpdate is the JSON:API §9 wrapper for one relation type's
+// RelationsUpdate is the JSON:API §9 wrapper for one relation type's
 // desired state. The wrapper has exactly one field, `data`, which is the
 // full desired set of edges of this relation type.
 //
@@ -43,15 +48,15 @@ func (f V1RelationsField) IsEmpty() bool {
 // Sending `data: []` removes every edge of this relation type from the
 // entity. See docs/data-entry/api-reference.md for the full footgun
 // callout.
-type V1RelationsUpdate struct {
-	Data        []V1ResourceIdentifier
+type RelationsUpdate struct {
+	Data        []ResourceIdentifier
 	DataPresent bool
 }
 
-// V1ResourceIdentifier is the per-edge resource identifier in a JSON:API
+// ResourceIdentifier is the per-edge resource identifier in a JSON:API
 // §9-shaped relation update. `Type` and `ID` identify the target;
 // `Meta`, `MetaUnset`, and `Content` carry per-edge upsert data.
-type V1ResourceIdentifier struct {
+type ResourceIdentifier struct {
 	Type      string                 `json:"type"`
 	ID        string                 `json:"id"`
 	Meta      map[string]interface{} `json:"meta,omitempty"`
@@ -61,16 +66,16 @@ type V1ResourceIdentifier struct {
 	Content *string `json:"content,omitempty"`
 }
 
-// wireError is the structured error returned from V1RelationsField's
+// WireError is the structured error returned from RelationsField's
 // unmarshal. Code is stable for clients; Path is an RFC 6901 JSON
 // Pointer; Detail is human-readable.
-type wireError struct {
+type WireError struct {
 	Code   string
 	Path   string
 	Detail string
 }
 
-func (e *wireError) Error() string {
+func (e *WireError) Error() string {
 	if e.Path != "" {
 		return fmt.Sprintf("%s: %s (path: %s)", e.Code, e.Detail, e.Path)
 	}
@@ -82,28 +87,28 @@ func (e *wireError) Error() string {
 // (the legacy IDs-only form) are rejected with `legacy_shape_unsupported`
 // so callers see a clear "update your client" error rather than a
 // generic JSON decode failure.
-func (f *V1RelationsField) UnmarshalJSON(b []byte) error {
+func (f *RelationsField) UnmarshalJSON(b []byte) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
 
-	modern := make(map[string]V1RelationsUpdate)
+	modern := make(map[string]RelationsUpdate)
 
 	for relType, val := range raw {
 		trimmed := bytes.TrimLeftFunc(val, unicode.IsSpace)
 		if len(trimmed) == 0 {
-			return &wireError{
+			return &WireError{
 				Code:   "relation_value_invalid",
-				Path:   "/relations/" + jsonPointerEscape(relType),
+				Path:   "/relations/" + JSONPointerEscape(relType),
 				Detail: "relation type value is empty",
 			}
 		}
 		switch trimmed[0] {
 		case '[':
-			return &wireError{
+			return &WireError{
 				Code: "legacy_shape_unsupported",
-				Path: "/relations/" + jsonPointerEscape(relType),
+				Path: "/relations/" + JSONPointerEscape(relType),
 				Detail: "legacy IDs-only relation shape (`[\"<id>\", ...]`) is no longer accepted; " +
 					"use the JSON:API §9 wrapper `{\"data\": [{\"type\": \"...\", \"id\": \"...\"}, ...]}`",
 			}
@@ -115,21 +120,21 @@ func (f *V1RelationsField) UnmarshalJSON(b []byte) error {
 			modern[relType] = update
 		case 'n':
 			if string(trimmed) == "null" {
-				return &wireError{
+				return &WireError{
 					Code:   "relation_value_null",
-					Path:   "/relations/" + jsonPointerEscape(relType),
+					Path:   "/relations/" + JSONPointerEscape(relType),
 					Detail: "relation type value cannot be null; use \"data\": [] to clear all edges",
 				}
 			}
-			return &wireError{
+			return &WireError{
 				Code:   "relation_value_invalid",
-				Path:   "/relations/" + jsonPointerEscape(relType),
+				Path:   "/relations/" + JSONPointerEscape(relType),
 				Detail: "relation type value must be the JSON:API §9 wrapper `{\"data\": [...]}`",
 			}
 		default:
-			return &wireError{
+			return &WireError{
 				Code:   "relation_value_invalid",
-				Path:   "/relations/" + jsonPointerEscape(relType),
+				Path:   "/relations/" + JSONPointerEscape(relType),
 				Detail: "relation type value must be the JSON:API §9 wrapper `{\"data\": [...]}`",
 			}
 		}
@@ -142,22 +147,22 @@ func (f *V1RelationsField) UnmarshalJSON(b []byte) error {
 }
 
 // decodeRelationsUpdate handles the modern `{"data": [...]}` wrapper.
-// Returns a wireError on any malformed input.
-func decodeRelationsUpdate(relType string, raw json.RawMessage) (V1RelationsUpdate, error) {
+// Returns a WireError on any malformed input.
+func decodeRelationsUpdate(relType string, raw json.RawMessage) (RelationsUpdate, error) {
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &fields); err != nil {
-		return V1RelationsUpdate{}, &wireError{
+		return RelationsUpdate{}, &WireError{
 			Code:   "wrapper_invalid",
-			Path:   "/relations/" + jsonPointerEscape(relType),
+			Path:   "/relations/" + JSONPointerEscape(relType),
 			Detail: "wrapper must be a JSON object with a `data` array",
 		}
 	}
 
 	for k := range fields {
 		if k != "data" {
-			return V1RelationsUpdate{}, &wireError{
+			return RelationsUpdate{}, &WireError{
 				Code:   "unknown_field",
-				Path:   "/relations/" + jsonPointerEscape(relType) + "/" + jsonPointerEscape(k),
+				Path:   "/relations/" + JSONPointerEscape(relType) + "/" + JSONPointerEscape(k),
 				Detail: fmt.Sprintf("unknown field %q on relation wrapper (only `data` is allowed)", k),
 			}
 		}
@@ -165,29 +170,29 @@ func decodeRelationsUpdate(relType string, raw json.RawMessage) (V1RelationsUpda
 
 	dataRaw, present := fields["data"]
 	if !present {
-		return V1RelationsUpdate{DataPresent: false}, nil
+		return RelationsUpdate{DataPresent: false}, nil
 	}
 
 	trimmed := bytes.TrimLeftFunc(dataRaw, unicode.IsSpace)
 	if len(trimmed) == 0 {
-		return V1RelationsUpdate{}, &wireError{
+		return RelationsUpdate{}, &WireError{
 			Code:   "data_required",
-			Path:   "/relations/" + jsonPointerEscape(relType) + "/data",
+			Path:   "/relations/" + JSONPointerEscape(relType) + "/data",
 			Detail: "`data` must be an array",
 		}
 	}
 	if string(trimmed) == "null" {
 		// Treated identically to the data-absent case (per RR-UZ8LX).
-		return V1RelationsUpdate{}, &wireError{
+		return RelationsUpdate{}, &WireError{
 			Code:   "data_required",
-			Path:   "/relations/" + jsonPointerEscape(relType) + "/data",
+			Path:   "/relations/" + JSONPointerEscape(relType) + "/data",
 			Detail: "`data` cannot be null; use [] to clear all edges of this type",
 		}
 	}
 	if trimmed[0] != '[' {
-		return V1RelationsUpdate{}, &wireError{
+		return RelationsUpdate{}, &WireError{
 			Code:   "data_invalid_type",
-			Path:   "/relations/" + jsonPointerEscape(relType) + "/data",
+			Path:   "/relations/" + JSONPointerEscape(relType) + "/data",
 			Detail: "`data` must be an array of resource identifiers",
 		}
 	}
@@ -197,34 +202,34 @@ func decodeRelationsUpdate(relType string, raw json.RawMessage) (V1RelationsUpda
 	// empty string when decoding `[]string`, masking what should be
 	// a wire-format error.
 	if err := validateMetaUnsetElements(relType, dataRaw); err != nil {
-		return V1RelationsUpdate{}, err
+		return RelationsUpdate{}, err
 	}
 
-	var refs []V1ResourceIdentifier
+	var refs []ResourceIdentifier
 	dec := json.NewDecoder(bytes.NewReader(dataRaw))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&refs); err != nil {
-		return V1RelationsUpdate{}, translateRefDecodeError(relType, dataRaw, err)
+		return RelationsUpdate{}, translateRefDecodeError(relType, dataRaw, err)
 	}
 
 	for i, ref := range refs {
 		if ref.Type == "" {
-			return V1RelationsUpdate{}, &wireError{
+			return RelationsUpdate{}, &WireError{
 				Code:   "field_required",
-				Path:   fmt.Sprintf("/relations/%s/data/%d/type", jsonPointerEscape(relType), i),
+				Path:   fmt.Sprintf("/relations/%s/data/%d/type", JSONPointerEscape(relType), i),
 				Detail: "`type` is required on each resource identifier",
 			}
 		}
 		if ref.ID == "" {
-			return V1RelationsUpdate{}, &wireError{
+			return RelationsUpdate{}, &WireError{
 				Code:   "field_required",
-				Path:   fmt.Sprintf("/relations/%s/data/%d/id", jsonPointerEscape(relType), i),
+				Path:   fmt.Sprintf("/relations/%s/data/%d/id", JSONPointerEscape(relType), i),
 				Detail: "`id` is required on each resource identifier",
 			}
 		}
 	}
 
-	return V1RelationsUpdate{Data: refs, DataPresent: true}, nil
+	return RelationsUpdate{Data: refs, DataPresent: true}, nil
 }
 
 // validateMetaUnsetElements scans the raw JSON for the data array and
@@ -236,7 +241,7 @@ func validateMetaUnsetElements(relType string, dataRaw json.RawMessage) error {
 	var rawRefs []json.RawMessage
 	if err := json.Unmarshal(dataRaw, &rawRefs); err != nil {
 		// Not an array — the main decoder will surface the right error
-		// in a wireError shape; we deliberately swallow this one to
+		// in a WireError shape; we deliberately swallow this one to
 		// avoid double-reporting.
 		return nil //nolint:nilerr // see comment
 	}
@@ -254,27 +259,27 @@ func validateMetaUnsetElements(relType string, dataRaw json.RawMessage) error {
 			continue // null/absent treated as absent
 		}
 		if trimmed[0] != '[' {
-			return &wireError{
+			return &WireError{
 				Code:   "meta_unset_invalid",
-				Path:   fmt.Sprintf("/relations/%s/data/%d/meta_unset", jsonPointerEscape(relType), i),
+				Path:   fmt.Sprintf("/relations/%s/data/%d/meta_unset", JSONPointerEscape(relType), i),
 				Detail: "`meta_unset` must be an array of strings",
 			}
 		}
 		var elems []json.RawMessage
 		if err := json.Unmarshal(muRaw, &elems); err != nil {
-			return &wireError{
+			return &WireError{
 				Code:   "meta_unset_invalid",
-				Path:   fmt.Sprintf("/relations/%s/data/%d/meta_unset", jsonPointerEscape(relType), i),
+				Path:   fmt.Sprintf("/relations/%s/data/%d/meta_unset", JSONPointerEscape(relType), i),
 				Detail: err.Error(),
 			}
 		}
 		for j, e := range elems {
 			t := bytes.TrimLeftFunc(e, unicode.IsSpace)
 			if len(t) == 0 || t[0] != '"' {
-				return &wireError{
+				return &WireError{
 					Code: "meta_unset_invalid",
 					Path: fmt.Sprintf("/relations/%s/data/%d/meta_unset/%d",
-						jsonPointerEscape(relType), i, j),
+						JSONPointerEscape(relType), i, j),
 					Detail: "`meta_unset` elements must be strings",
 				}
 			}
@@ -284,7 +289,7 @@ func validateMetaUnsetElements(relType string, dataRaw json.RawMessage) error {
 }
 
 // translateRefDecodeError maps json.Decoder errors on a resource
-// identifier slice into a structured wireError. Covers unknown-field
+// identifier slice into a structured WireError. Covers unknown-field
 // rejection and the most common malformed-shape cases.
 func translateRefDecodeError(relType string, dataRaw json.RawMessage, err error) error {
 	msg := err.Error()
@@ -292,19 +297,19 @@ func translateRefDecodeError(relType string, dataRaw json.RawMessage, err error)
 	// field, the message names which one. We don't get a stable
 	// element index, so we cite the array generically.
 	if strings.Contains(msg, "unknown field") {
-		return &wireError{
+		return &WireError{
 			Code:   "unknown_field",
-			Path:   "/relations/" + jsonPointerEscape(relType) + "/data",
+			Path:   "/relations/" + JSONPointerEscape(relType) + "/data",
 			Detail: msg,
 		}
 	}
 	// Best-effort: catch the meta_unset non-string element case, which
 	// json reports as "cannot unmarshal X into Go struct field
-	// V1ResourceIdentifier.meta_unset of type string".
+	// ResourceIdentifier.meta_unset of type string".
 	if strings.Contains(msg, ".meta_unset of type string") {
-		return &wireError{
+		return &WireError{
 			Code:   "meta_unset_invalid",
-			Path:   "/relations/" + jsonPointerEscape(relType) + "/data",
+			Path:   "/relations/" + JSONPointerEscape(relType) + "/data",
 			Detail: "`meta_unset` must contain only strings",
 		}
 	}
@@ -312,23 +317,23 @@ func translateRefDecodeError(relType string, dataRaw json.RawMessage, err error)
 	_ = dataRaw // reserved for future richer parsing
 	var jsonErr *json.UnmarshalTypeError
 	if errors.As(err, &jsonErr) {
-		return &wireError{
+		return &WireError{
 			Code:   "field_invalid_type",
-			Path:   "/relations/" + jsonPointerEscape(relType) + "/data/" + jsonErr.Field,
+			Path:   "/relations/" + JSONPointerEscape(relType) + "/data/" + jsonErr.Field,
 			Detail: msg,
 		}
 	}
-	return &wireError{
+	return &WireError{
 		Code:   "data_invalid",
-		Path:   "/relations/" + jsonPointerEscape(relType) + "/data",
+		Path:   "/relations/" + JSONPointerEscape(relType) + "/data",
 		Detail: msg,
 	}
 }
 
-// jsonPointerEscape applies RFC 6901 JSON Pointer escaping to a single
+// JSONPointerEscape applies RFC 6901 JSON Pointer escaping to a single
 // reference token: `~` is encoded as `~0` and `/` as `~1`. The
 // substitutions are NOT commutative — `~` must be replaced before `/`.
-func jsonPointerEscape(s string) string {
+func JSONPointerEscape(s string) string {
 	s = strings.ReplaceAll(s, "~", "~0")
 	s = strings.ReplaceAll(s, "/", "~1")
 	return s

--- a/internal/apiwire/v1/relations_test.go
+++ b/internal/apiwire/v1/relations_test.go
@@ -1,4 +1,4 @@
-package dataentry
+package v1
 
 import (
 	"encoding/json"
@@ -12,14 +12,14 @@ func TestV1RelationsField_LegacyShape_Rejected(t *testing.T) {
 	// §9 wrapper. The first occurrence wins so the error path is
 	// deterministic.
 	body := `{"tagged": ["L-001", "L-002"]}`
-	var f V1RelationsField
+	var f RelationsField
 	err := json.Unmarshal([]byte(body), &f)
 	if err == nil {
 		t.Fatal("expected error for legacy shape")
 	}
-	var werr *wireError
+	var werr *WireError
 	if !errors.As(err, &werr) {
-		t.Fatalf("error is not *wireError: %v", err)
+		t.Fatalf("error is not *WireError: %v", err)
 	}
 	if werr.Code != "legacy_shape_unsupported" {
 		t.Errorf("code=%s, want legacy_shape_unsupported", werr.Code)
@@ -36,7 +36,7 @@ func TestV1RelationsField_ModernShape(t *testing.T) {
 			{"type": "label", "id": "L-002"}
 		]}
 	}`
-	var f V1RelationsField
+	var f RelationsField
 	if err := json.Unmarshal([]byte(body), &f); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestV1RelationsField_DataAbsent_ReturnsDataRequiredAtCallSite(t *testing.T)
 	// and the caller (handler) emits the 400. This test asserts the
 	// state propagated correctly.
 	body := `{"tagged": {}}`
-	var f V1RelationsField
+	var f RelationsField
 	if err := json.Unmarshal([]byte(body), &f); err != nil {
 		t.Fatalf("unmarshal should not error at this layer: %v", err)
 	}
@@ -84,14 +84,14 @@ func TestV1RelationsField_DataAbsent_ReturnsDataRequiredAtCallSite(t *testing.T)
 
 func TestV1RelationsField_DataNull_Rejected(t *testing.T) {
 	body := `{"tagged": {"data": null}}`
-	var f V1RelationsField
+	var f RelationsField
 	err := json.Unmarshal([]byte(body), &f)
 	if err == nil {
 		t.Fatalf("expected error for data: null")
 	}
-	var werr *wireError
+	var werr *WireError
 	if !errors.As(err, &werr) {
-		t.Fatalf("error is not *wireError: %v", err)
+		t.Fatalf("error is not *WireError: %v", err)
 	}
 	if werr.Code != "data_required" {
 		t.Errorf("code=%s, want data_required", werr.Code)
@@ -100,14 +100,14 @@ func TestV1RelationsField_DataNull_Rejected(t *testing.T) {
 
 func TestV1RelationsField_DataNonArray_Rejected(t *testing.T) {
 	body := `{"tagged": {"data": "L-001"}}`
-	var f V1RelationsField
+	var f RelationsField
 	err := json.Unmarshal([]byte(body), &f)
 	if err == nil {
 		t.Fatalf("expected error for data: scalar")
 	}
-	var werr *wireError
+	var werr *WireError
 	if !errors.As(err, &werr) {
-		t.Fatalf("error is not *wireError: %v", err)
+		t.Fatalf("error is not *WireError: %v", err)
 	}
 	if werr.Code != "data_invalid_type" {
 		t.Errorf("code=%s, want data_invalid_type", werr.Code)
@@ -116,14 +116,14 @@ func TestV1RelationsField_DataNonArray_Rejected(t *testing.T) {
 
 func TestV1RelationsField_RelationValueNull_Rejected(t *testing.T) {
 	body := `{"tagged": null}`
-	var f V1RelationsField
+	var f RelationsField
 	err := json.Unmarshal([]byte(body), &f)
 	if err == nil {
 		t.Fatalf("expected error for null relation value")
 	}
-	var werr *wireError
+	var werr *WireError
 	if !errors.As(err, &werr) {
-		t.Fatalf("error is not *wireError: %v", err)
+		t.Fatalf("error is not *WireError: %v", err)
 	}
 	if werr.Code != "relation_value_null" {
 		t.Errorf("code=%s, want relation_value_null", werr.Code)
@@ -137,15 +137,15 @@ func TestV1RelationsField_RelationValueScalar_Rejected(t *testing.T) {
 		`{"tagged": true}`,
 	}
 	for _, body := range cases {
-		var f V1RelationsField
+		var f RelationsField
 		err := json.Unmarshal([]byte(body), &f)
 		if err == nil {
 			t.Errorf("body=%s: expected error", body)
 			continue
 		}
-		var werr *wireError
+		var werr *WireError
 		if !errors.As(err, &werr) {
-			t.Errorf("body=%s: error is not *wireError: %v", body, err)
+			t.Errorf("body=%s: error is not *WireError: %v", body, err)
 			continue
 		}
 		if werr.Code != "relation_value_invalid" {
@@ -156,14 +156,14 @@ func TestV1RelationsField_RelationValueScalar_Rejected(t *testing.T) {
 
 func TestV1RelationsField_UnknownSiblingKey_Rejected(t *testing.T) {
 	body := `{"tagged": {"datas": [{"type":"label","id":"L-001"}]}}`
-	var f V1RelationsField
+	var f RelationsField
 	err := json.Unmarshal([]byte(body), &f)
 	if err == nil {
 		t.Fatalf("expected error for unknown sibling key")
 	}
-	var werr *wireError
+	var werr *WireError
 	if !errors.As(err, &werr) {
-		t.Fatalf("error is not *wireError: %v", err)
+		t.Fatalf("error is not *WireError: %v", err)
 	}
 	if werr.Code != "unknown_field" {
 		t.Errorf("code=%s, want unknown_field", werr.Code)
@@ -179,15 +179,15 @@ func TestV1RelationsField_MissingTypeOrID_Rejected(t *testing.T) {
 		{`{"tagged": {"data": [{"type": "label"}]}}`, "id"},
 	}
 	for _, tc := range cases {
-		var f V1RelationsField
+		var f RelationsField
 		err := json.Unmarshal([]byte(tc.body), &f)
 		if err == nil {
 			t.Errorf("body=%s: expected error", tc.body)
 			continue
 		}
-		var werr *wireError
+		var werr *WireError
 		if !errors.As(err, &werr) {
-			t.Errorf("body=%s: error is not *wireError: %v", tc.body, err)
+			t.Errorf("body=%s: error is not *WireError: %v", tc.body, err)
 			continue
 		}
 		if werr.Code != "field_required" {
@@ -202,15 +202,15 @@ func TestV1RelationsField_NonStringInMetaUnset_Rejected(t *testing.T) {
 		`{"tagged": {"data": [{"type":"label","id":"L-001","meta_unset":["x", 5]}]}}`,
 	}
 	for _, body := range cases {
-		var f V1RelationsField
+		var f RelationsField
 		err := json.Unmarshal([]byte(body), &f)
 		if err == nil {
 			t.Errorf("body=%s: expected error", body)
 			continue
 		}
-		var werr *wireError
+		var werr *WireError
 		if !errors.As(err, &werr) {
-			t.Errorf("body=%s: error is not *wireError: %v", body, err)
+			t.Errorf("body=%s: error is not *WireError: %v", body, err)
 			continue
 		}
 		if werr.Code != "meta_unset_invalid" && werr.Code != "field_invalid_type" {
@@ -221,7 +221,7 @@ func TestV1RelationsField_NonStringInMetaUnset_Rejected(t *testing.T) {
 
 func TestV1RelationsField_MetaNull_TreatedAsAbsent(t *testing.T) {
 	body := `{"tagged": {"data": [{"type":"label","id":"L-001","meta":null}]}}`
-	var f V1RelationsField
+	var f RelationsField
 	if err := json.Unmarshal([]byte(body), &f); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestV1RelationsField_MetaNull_TreatedAsAbsent(t *testing.T) {
 
 func TestV1RelationsField_ContentNull_TreatedAsAbsent(t *testing.T) {
 	body := `{"tagged": {"data": [{"type":"label","id":"L-001","content":null}]}}`
-	var f V1RelationsField
+	var f RelationsField
 	if err := json.Unmarshal([]byte(body), &f); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestV1RelationsField_ContentNull_TreatedAsAbsent(t *testing.T) {
 
 func TestV1RelationsField_ContentEmptyString_PointerNotNil(t *testing.T) {
 	body := `{"tagged": {"data": [{"type":"label","id":"L-001","content":""}]}}`
-	var f V1RelationsField
+	var f RelationsField
 	if err := json.Unmarshal([]byte(body), &f); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestV1RelationsField_ContentEmptyString_PointerNotNil(t *testing.T) {
 
 func TestV1RelationsField_EmptyDataMeansRemoveAll(t *testing.T) {
 	body := `{"tagged": {"data": []}}`
-	var f V1RelationsField
+	var f RelationsField
 	if err := json.Unmarshal([]byte(body), &f); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -272,11 +272,11 @@ func TestV1RelationsField_EmptyDataMeansRemoveAll(t *testing.T) {
 }
 
 func TestV1RelationsField_IsEmpty(t *testing.T) {
-	var f V1RelationsField
+	var f RelationsField
 	if !f.IsEmpty() {
 		t.Error("zero-value should be empty")
 	}
-	f.Modern = map[string]V1RelationsUpdate{"a": {Data: []V1ResourceIdentifier{{Type: "x", ID: "y"}}, DataPresent: true}}
+	f.Modern = map[string]RelationsUpdate{"a": {Data: []ResourceIdentifier{{Type: "x", ID: "y"}}, DataPresent: true}}
 	if f.IsEmpty() {
 		t.Error("modern populated should not be empty")
 	}
@@ -294,8 +294,8 @@ func TestJSONPointerEscape(t *testing.T) {
 		{"", ""},
 	}
 	for _, tc := range cases {
-		if got := jsonPointerEscape(tc.in); got != tc.want {
-			t.Errorf("jsonPointerEscape(%q) = %q, want %q", tc.in, got, tc.want)
+		if got := JSONPointerEscape(tc.in); got != tc.want {
+			t.Errorf("JSONPointerEscape(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -552,7 +553,7 @@ func (svc affordanceService) validateRelationOp(ctx context.Context, e *entityPk
 // operation is permitted.
 func (svc affordanceService) validateRelationsModernAffordances(
 	ctx context.Context, entityID string, e *entityPkg.Entity,
-	desired map[string]V1RelationsUpdate,
+	desired map[string]v1.RelationsUpdate,
 ) *AffordanceDenialError {
 	if e == nil || len(desired) == 0 {
 		return nil
@@ -567,7 +568,7 @@ func (svc affordanceService) validateRelationsModernAffordances(
 			continue // structural error surfaces via the existing validator
 		}
 
-		desiredByID := make(map[string]V1ResourceIdentifier, len(upd.Data))
+		desiredByID := make(map[string]v1.ResourceIdentifier, len(upd.Data))
 		for _, ref := range upd.Data {
 			desiredByID[ref.ID] = ref
 		}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/conflict"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
@@ -607,11 +608,11 @@ func (a *App) handleV1CreateEntity(w http.ResponseWriter, r *http.Request, typeN
 		Prefix     string                 `json:"prefix,omitempty"`
 		Properties map[string]interface{} `json:"properties"`
 		Content    string                 `json:"content,omitempty"`
-		Relations  V1RelationsField       `json:"relations,omitempty"`
+		Relations  v1.RelationsField      `json:"relations,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		var werr *wireError
+		var werr *v1.WireError
 		if errors.As(err, &werr) {
 			writeV1Error(w, r, http.StatusBadRequest, werr.Code, werr.Detail, werr.Path)
 			return
@@ -1005,13 +1006,13 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 		Properties      map[string]interface{} `json:"properties,omitempty"`
 		PropertiesUnset []string               `json:"properties_unset,omitempty"`
 		Content         *string                `json:"content,omitempty"`
-		Relations       V1RelationsField       `json:"relations,omitempty"`
+		Relations       v1.RelationsField      `json:"relations,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		// V1RelationsField's UnmarshalJSON returns *wireError for
+		// v1.RelationsField's UnmarshalJSON returns *v1.WireError for
 		// shape errors; surface them as 400 with the structured code.
-		var werr *wireError
+		var werr *v1.WireError
 		if errors.As(err, &werr) {
 			writeV1Error(w, r, http.StatusBadRequest, werr.Code,
 				werr.Detail, werr.Path)
@@ -1127,10 +1128,10 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 }
 
 // writeRelationsValidationError maps a Phase A validation error from
-// the modern reconciler to the corresponding HTTP response. wireError
+// the modern reconciler to the corresponding HTTP response. v1.WireError
 // → 400 (caller bug); structuralError → 422 (storage can't represent).
 func (a *App) writeRelationsValidationError(w http.ResponseWriter, r *http.Request, err error) {
-	var werr *wireError
+	var werr *v1.WireError
 	if errors.As(err, &werr) {
 		writeV1Error(w, r, http.StatusBadRequest, werr.Code, werr.Detail, werr.Path)
 		return

--- a/internal/dataentry/relations_direction.go
+++ b/internal/dataentry/relations_direction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
@@ -78,7 +79,7 @@ func edgeEndpoints(entityID, peerID string, incoming bool) (from, to string) {
 // are exempt: a symmetric self-loop is just a single edge regardless
 // of how it's named.
 func detectSelfLoopShapeConflict(
-	meta *metamodel.Metamodel, entityID string, desired map[string]V1RelationsUpdate,
+	meta *metamodel.Metamodel, entityID string, desired map[string]v1.RelationsUpdate,
 ) error {
 	// Group body keys by the canonical relation they resolve to,
 	// collecting whether they were submitted as canonical or inverse.
@@ -122,9 +123,9 @@ func detectSelfLoopShapeConflict(
 		// entity — that's the only collision surface.
 		conflictKeys := []string{u.canonicalKeys[0], u.inverseKeys[0]}
 		if pathEntityInBothSets(entityID, conflictKeys, desired) {
-			return &wireError{
+			return &v1.WireError{
 				Code: "shape_conflict",
-				Path: "/relations/" + jsonPointerEscape(conflictKeys[0]),
+				Path: "/relations/" + v1.JSONPointerEscape(conflictKeys[0]),
 				Detail: fmt.Sprintf(
 					"relation %q is referenced via both %q and its inverse %q with the path entity on both sides — "+
 						"the body refers to the same self-loop edge twice; remove one of the keys",
@@ -137,7 +138,7 @@ func detectSelfLoopShapeConflict(
 
 // pathEntityInBothSets returns true when entityID appears in the
 // desired-set of every body key in keys.
-func pathEntityInBothSets(entityID string, keys []string, desired map[string]V1RelationsUpdate) bool {
+func pathEntityInBothSets(entityID string, keys []string, desired map[string]v1.RelationsUpdate) bool {
 	for _, k := range keys {
 		upd, ok := desired[k]
 		if !ok {

--- a/internal/dataentry/relations_modern.go
+++ b/internal/dataentry/relations_modern.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -30,7 +31,7 @@ type Warning = entity.Warning
 // entity is updated, so a structural relation problem doesn't leave
 // the entity half-written.
 func (a *App) validateRelationsModern(
-	ctx context.Context, entityID string, pathEntityType string, desired map[string]V1RelationsUpdate,
+	ctx context.Context, entityID string, pathEntityType string, desired map[string]v1.RelationsUpdate,
 ) ([]Warning, error) {
 	if len(desired) == 0 {
 		return nil, nil
@@ -49,9 +50,9 @@ func (a *App) validateRelationsModern(
 
 	for bodyKey, upd := range desired {
 		if !upd.DataPresent {
-			return nil, &wireError{
+			return nil, &v1.WireError{
 				Code:   "data_required",
-				Path:   "/relations/" + jsonPointerEscape(bodyKey) + "/data",
+				Path:   "/relations/" + v1.JSONPointerEscape(bodyKey) + "/data",
 				Detail: "`data` field is required when a relation wrapper appears",
 			}
 		}
@@ -60,7 +61,7 @@ func (a *App) validateRelationsModern(
 		if !ok {
 			return nil, &structuralError{
 				Code:   "unknown_relation_type",
-				Path:   "/relations/" + jsonPointerEscape(bodyKey),
+				Path:   "/relations/" + v1.JSONPointerEscape(bodyKey),
 				Detail: fmt.Sprintf("relation type %q is not defined in the metamodel", bodyKey),
 			}
 		}
@@ -78,14 +79,14 @@ func (a *App) validateRelationsModern(
 		if !containsString(allowedPathTypes, pathEntityType) {
 			warnings = append(warnings, Warning{
 				Code:      warningCode,
-				Path:      "/relations/" + jsonPointerEscape(bodyKey),
+				Path:      "/relations/" + v1.JSONPointerEscape(bodyKey),
 				Detail:    fmt.Sprintf("relation %q does not declare %q as an allowed %s type", canonical, pathEntityType, sideLabel(incoming, true)),
 				Direction: directionLabel(incoming),
 			})
 		}
 
 		for i, ref := range upd.Data {
-			edgePath := fmt.Sprintf("/relations/%s/data/%d", jsonPointerEscape(bodyKey), i)
+			edgePath := fmt.Sprintf("/relations/%s/data/%d", v1.JSONPointerEscape(bodyKey), i)
 
 			// Content on a non-content-bearing relation type is a
 			// structural impossibility — the file format can't hold
@@ -142,7 +143,7 @@ func sideLabel(incoming, pathSide bool) string {
 // code keeps working; the `Direction` field disambiguates.
 func (a *App) collectEdgeWarnings(
 	ctx context.Context, relType string, relDef *metamodel.RelationDef,
-	ref V1ResourceIdentifier, edgePath string, incoming bool,
+	ref v1.ResourceIdentifier, edgePath string, incoming bool,
 ) []Warning {
 	var warnings []Warning
 	meta := a.State().Meta
@@ -199,7 +200,7 @@ func (a *App) collectEdgeWarnings(
 		if _, known := relDef.Properties[k]; !known {
 			warnings = append(warnings, Warning{
 				Code:      "unknown_meta_key",
-				Path:      edgePath + "/meta/" + jsonPointerEscape(k),
+				Path:      edgePath + "/meta/" + v1.JSONPointerEscape(k),
 				Detail:    fmt.Sprintf("relation type %q does not declare meta property %q", relType, k),
 				Direction: direction,
 			})
@@ -228,7 +229,7 @@ func (a *App) collectEdgeWarnings(
 		if err := meta.ValidatePropertyValue(k, &propDef, v); err != nil {
 			warnings = append(warnings, Warning{
 				Code:      "meta_type_mismatch",
-				Path:      edgePath + "/meta/" + jsonPointerEscape(k),
+				Path:      edgePath + "/meta/" + v1.JSONPointerEscape(k),
 				Detail:    err.Error(),
 				Direction: direction,
 			})
@@ -257,7 +258,7 @@ func (a *App) collectEdgeWarnings(
 // already written stay written — the caller treats this as the
 // documented atomicity gap.
 func (a *App) applyRelationsModern(
-	ctx context.Context, entityID string, desired map[string]V1RelationsUpdate,
+	ctx context.Context, entityID string, desired map[string]v1.RelationsUpdate,
 ) ([]Warning, error) {
 	if len(desired) == 0 {
 		return nil, nil
@@ -272,7 +273,7 @@ func (a *App) applyRelationsModern(
 			// validateRelationsModern already screened this; defensive.
 			return warnings, &structuralError{
 				Code:   "unknown_relation_type",
-				Path:   "/relations/" + jsonPointerEscape(bodyKey),
+				Path:   "/relations/" + v1.JSONPointerEscape(bodyKey),
 				Detail: fmt.Sprintf("relation type %q is not defined in the metamodel", bodyKey),
 			}
 		}
@@ -283,7 +284,7 @@ func (a *App) applyRelationsModern(
 		// collapse to a single edge — matches the legacy IDs-only
 		// reconciler's set semantics and is what callers expect when
 		// e.g. a picker re-emits the same selection twice.
-		desiredByID := make(map[string]V1ResourceIdentifier, len(upd.Data))
+		desiredByID := make(map[string]v1.ResourceIdentifier, len(upd.Data))
 		desiredOrder := make([]string, 0, len(upd.Data))
 		for _, ref := range upd.Data {
 			if _, dup := desiredByID[ref.ID]; !dup {
@@ -300,7 +301,7 @@ func (a *App) applyRelationsModern(
 			finalProps, finalContent, contentSet := mergeEdgeMeta(current[ref.ID], ref)
 
 			ws := requiredMetaWarnings(canonical, &relDef, ref, finalProps,
-				fmt.Sprintf("/relations/%s/data", jsonPointerEscape(bodyKey)), direction)
+				fmt.Sprintf("/relations/%s/data", v1.JSONPointerEscape(bodyKey)), direction)
 			warnings = append(warnings, ws...)
 
 			from, to := edgeEndpoints(entityID, ref.ID, incoming)
@@ -347,7 +348,7 @@ func (a *App) applyRelationsModern(
 // this function does not consult direction. `ref.ID` is the peer ID
 // (which is `to` for outgoing edges and `from` for incoming).
 func (a *App) writeCreateRelation(
-	ctx context.Context, from, to, relType string, ref V1ResourceIdentifier,
+	ctx context.Context, from, to, relType string, ref v1.ResourceIdentifier,
 	finalProps map[string]interface{}, finalContent string,
 ) error {
 	opts := entity.RelationOptions{
@@ -382,7 +383,7 @@ func (a *App) writeCreateRelation(
 //
 // `from` and `to` are pre-resolved by the caller via edgeEndpoints.
 func (a *App) writeUpdateRelation(
-	ctx context.Context, from, to, relType string, ref V1ResourceIdentifier,
+	ctx context.Context, from, to, relType string, ref v1.ResourceIdentifier,
 ) error {
 	opts := entity.RelationOptions{
 		Properties: ref.Meta,
@@ -439,7 +440,7 @@ func isSoftCondition(err error) bool {
 // for an edge, given the existing relation (or nil for new edges) and
 // the desired ref. contentSet reports whether ref.Content was non-nil
 // (so the caller can distinguish "leave alone" from "set to value").
-func mergeEdgeMeta(existing *entity.Relation, ref V1ResourceIdentifier) (
+func mergeEdgeMeta(existing *entity.Relation, ref v1.ResourceIdentifier) (
 	props map[string]interface{}, content string, contentSet bool,
 ) {
 	props = make(map[string]interface{})
@@ -467,7 +468,7 @@ func mergeEdgeMeta(existing *entity.Relation, ref V1ResourceIdentifier) (
 // re-PATCHing a form that hasn't changed performs zero writes.
 func isEdgeNoOp(
 	existing *entity.Relation, finalProps map[string]interface{},
-	finalContent string, contentSet bool, ref V1ResourceIdentifier,
+	finalContent string, contentSet bool, ref v1.ResourceIdentifier,
 ) bool {
 	// If the request has no per-edge upsert fields at all and the
 	// edge already exists, it's trivially a no-op. (Strict subset of
@@ -505,7 +506,7 @@ func mapsEqual(a, b map[string]interface{}) bool {
 // relation-type-scoped (not per-direction), so direction does not
 // affect WHICH keys are required — it only labels the output.
 func requiredMetaWarnings(
-	relType string, relDef *metamodel.RelationDef, ref V1ResourceIdentifier,
+	relType string, relDef *metamodel.RelationDef, ref v1.ResourceIdentifier,
 	finalProps map[string]interface{}, dataPath, direction string,
 ) []Warning {
 	var ws []Warning
@@ -516,7 +517,7 @@ func requiredMetaWarnings(
 		if _, ok := finalProps[k]; !ok {
 			ws = append(ws, Warning{
 				Code:      "required_meta_unset",
-				Path:      fmt.Sprintf("%s[id=%s]/meta/%s", dataPath, jsonPointerEscape(ref.ID), jsonPointerEscape(k)),
+				Path:      fmt.Sprintf("%s[id=%s]/meta/%s", dataPath, v1.JSONPointerEscape(ref.ID), v1.JSONPointerEscape(k)),
 				Detail:    fmt.Sprintf("relation type %q requires meta property %q", relType, k),
 				Direction: direction,
 			})
@@ -529,7 +530,7 @@ func requiredMetaWarnings(
 // order properties (_order_out / _order_in) are finite numeric. Non-finite
 // or non-numeric values are wire-format violations (400) — the engine's
 // midpoint and sort logic depends on finite float64 values.
-func validateManagedOrderMeta(relType string, ref V1ResourceIdentifier, edgePath string, relDef *metamodel.RelationDef) error {
+func validateManagedOrderMeta(relType string, ref v1.ResourceIdentifier, edgePath string, relDef *metamodel.RelationDef) error {
 	check := func(prop string) error {
 		v, present := ref.Meta[prop]
 		if !present {
@@ -538,9 +539,9 @@ func validateManagedOrderMeta(relType string, ref V1ResourceIdentifier, edgePath
 		if _, ok := entitymanager.FiniteOrder(v); ok {
 			return nil
 		}
-		return &wireError{
+		return &v1.WireError{
 			Code:   "order_value_invalid",
-			Path:   edgePath + "/meta/" + jsonPointerEscape(prop),
+			Path:   edgePath + "/meta/" + v1.JSONPointerEscape(prop),
 			Detail: fmt.Sprintf("relation type %q managed order property %q must be a finite number", relType, prop),
 		}
 	}

--- a/internal/dataentry/relations_orderable_test.go
+++ b/internal/dataentry/relations_orderable_test.go
@@ -109,7 +109,7 @@ func TestOrderable_PatchRejectsNonFiniteOrder(t *testing.T) {
 			}
 			// The "overflows to infinity" case is rejected by Go's
 			// JSON decoder before our validateManagedOrderMeta runs
-			// (1e500 → field_invalid_type during V1ResourceIdentifier
+			// (1e500 → field_invalid_type during v1.ResourceIdentifier
 			// decode). The string and boolean cases reach our check.
 			// Either way the request must 400 — we accept both codes.
 			var problem struct {


### PR DESCRIPTION
Introduces `internal/apiwire/v1` — the v1 data-entry API wire contract as a real package — **with an arch-lint rule that enforces its boundary**. Stacked on the base (#1041-merged).

## Why

The dataentry extractions so far (serializer, affordances, entityReader, …) live in `package dataentry`, so their contracts are *convention, not enforcement* — any of dataentry’s 100+ files can reach their unexported fields. Reducing App’s method count ≠ real boundaries. This is the keystone that makes the boundaries **compiler/CI-enforced**: once the shared V1 wire vocabulary has its own package, the serializer/affordances/handlers can later move to packages that import `apiwire` (not `dataentry`), with no cycle.

## Slice 1 (this PR)

Moves the self-contained relations-wire cluster — the one part that isn’t pure data (it carries the request parser), handled first so the remaining pure-type move is uniform:

- `RelationsField` / `RelationsUpdate` / `ResourceIdentifier` (were `V1RelationsField` …)
- the JSON:API §9 parser (`UnmarshalJSON` + `decodeRelationsUpdate` + validators)
- `WireError` (was unexported `wireError`) + `JSONPointerEscape` — the structured wire-error vocabulary shared across the relation-write machinery

The parser travels with its types (correct — it parses them), and the whole cluster was already stdlib-only. `dataentry` now imports `apiwire/v1` (the allowed direction) and uses `v1.WireError` / `v1.JSONPointerEscape` from the relation-write code.

## Design

- **Top-level, not nested under dataentry** — a future native/desktop bridge consumes this contract in-process (no HTTP); it’s shared between the web serializer and that bridge, not dataentry’s privates.
- **Version-as-package** (`v1.Entity`, not `apiwire.V1Entity`) — a v2 API is a sibling package `apiwire/v2`, k8s-style.

## Enforcement (the payoff)

arch-lint: `apiwire mayDependOn {dataentryconfig}` (entity/errors are commonComponents) and **NOT** `dataentry`. Verified: a deliberate `apiwire → dataentry` import **fails** arch-lint (exit 1, clear message); a probe subpackage `apiwire/probe2` (stand-in for v2) is also caught, so the `**` glob constrains future siblings; passes clean otherwise.

## Result

Behavior-preserving. App method count unchanged (167) — correctly, since this is about *boundaries*, not count. ~47 pure response types follow in slice 2.

## Verification

`go build ./...`, `go test -race ./internal/dataentry/ ./internal/apiwire/v1/`, `golangci-lint` (0 issues), `just arch-lint` (enforces the boundary), `plimsoll ./...` (exit 0) all green.