### PR TITLE
feat(apps): serve project palette in _rela.css (TKT-XGXLZH)

### DIFF
--- a/internal/dataentry/apps_css.go
+++ b/internal/dataentry/apps_css.go
@@ -1,6 +1,10 @@
 package dataentry
 
-import _ "embed"
+import (
+	_ "embed"
+	"sort"
+	"strings"
+)
 
 // appTokensCSS is the rela theme-token stylesheet (:root / :root.dark custom
 // properties), embedded from a copy of the SPA's source of truth
@@ -8,6 +12,10 @@ import _ "embed"
 // TestAppTokensCSSInSyncWithFrontend so the SPA and the app stylesheet can
 // never drift. Do not hand-edit apps_tokens.css; edit the frontend source and
 // re-copy.
+//
+// This embed is the FALLBACK only: appCSSSource renders the project's resolved
+// palette when one is supplied (the common case), and falls back to these
+// default tokens when palette is nil.
 //
 //go:embed apps_tokens.css
 var appTokensCSS string
@@ -64,10 +72,55 @@ const appBaseControlsCSS = `
 `
 
 // appCSSSource returns the full stylesheet served at the reserved per-app path
-// /api/v1/_apps/<id>/_rela.css: the shared theme tokens plus the base controls.
+// /api/v1/_apps/<id>/_rela.css: the theme tokens followed by the base controls.
 // An app opts in with <link rel="stylesheet" href="_rela.css">; theme follows
 // the host because the SDK toggles `dark` on the app's <html> (the tokens use
 // the same `:root.dark` selector as the SPA).
-func appCSSSource() string {
-	return appTokensCSS + "\n" + appBaseControlsCSS
+//
+// When palette is non-nil, the :root / :root.dark token blocks are rendered
+// from the PROJECT's resolved palette — the same 21 CSS variables the SPA
+// derives (dataentryconfig.deriveTheme) and serves at /_palette — so an app
+// matches the host's actual theme rather than the framework defaults. This is
+// what keeps every custom app from having to re-derive the palette itself.
+// When palette is nil, the embedded default tokens (apps_tokens.css) are used.
+func appCSSSource(palette *ResolvedPalette) string {
+	var b strings.Builder
+	if palette != nil && len(palette.Light) > 0 {
+		b.WriteString(renderTokenBlock(":root", palette.Light))
+		if !palette.DarkDisabled && len(palette.Dark) > 0 {
+			b.WriteString("\n")
+			b.WriteString(renderTokenBlock(":root.dark", palette.Dark))
+		}
+	} else {
+		// No resolved palette — fall back to the embedded default tokens.
+		b.WriteString(appTokensCSS)
+	}
+	b.WriteString("\n")
+	b.WriteString(appBaseControlsCSS)
+	return b.String()
+}
+
+// renderTokenBlock formats a `selector { --var: value; ... }` block with the
+// custom properties sorted by name, so the output is deterministic (stable
+// across reloads and testable). Values come from the resolved palette and are
+// already validated hex strings.
+func renderTokenBlock(selector string, vars map[string]string) string {
+	keys := make([]string, 0, len(vars))
+	for k := range vars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	b.WriteString(selector)
+	b.WriteString(" {\n")
+	for _, k := range keys {
+		b.WriteString("  ")
+		b.WriteString(k)
+		b.WriteString(": ")
+		b.WriteString(vars[k])
+		b.WriteString(";\n")
+	}
+	b.WriteString("}\n")
+	return b.String()
 }

--- a/internal/dataentry/apps_handler.go
+++ b/internal/dataentry/apps_handler.go
@@ -132,7 +132,7 @@ func (a *App) handleV1App(w http.ResponseWriter, r *http.Request) {
 	}
 	if entry == appCSSEntry {
 		h.Set("Content-Type", "text/css; charset=utf-8")
-		_, _ = w.Write([]byte(appCSSSource()))
+		_, _ = w.Write([]byte(appCSSSource(a.State().Palette)))
 		return
 	}
 

--- a/internal/dataentry/apps_test.go
+++ b/internal/dataentry/apps_test.go
@@ -125,10 +125,12 @@ func TestAppTokensCSSInSyncWithFrontend(t *testing.T) {
 }
 
 func TestAppCSSSource(t *testing.T) {
-	css := appCSSSource()
-	for _, want := range []string{"--text-color", ":root.dark", ".btn", ".btn-primary", ".input", ".card"} {
+	// nil palette → fall back to the embedded default tokens. The embed
+	// carries a :root.dark block, so it must be present here.
+	css := appCSSSource(nil)
+	for _, want := range []string{"--text-color", ":root", ":root.dark", ".btn", ".btn-primary", ".input", ".card"} {
 		if !strings.Contains(css, want) {
-			t.Errorf("appCSSSource missing %q", want)
+			t.Errorf("appCSSSource(nil) missing %q", want)
 		}
 	}
 	// Stays tokens + atomic controls — must NOT smuggle in component-shaped
@@ -136,6 +138,49 @@ func TestAppCSSSource(t *testing.T) {
 	for _, unwanted := range []string{".table", ".modal", ".select", ".dropdown"} {
 		if strings.Contains(css, unwanted) {
 			t.Errorf("appCSSSource should not include component-shaped %q", unwanted)
+		}
+	}
+}
+
+// TestAppCSSSourceUsesResolvedPalette verifies that a configured project
+// palette is reflected in the served _rela.css — the whole point of TKT-XGXLZH.
+// An app must receive the host's actual theme colors, not the framework
+// defaults, so it can't drift from the SPA shell it's embedded in.
+func TestAppCSSSourceUsesResolvedPalette(t *testing.T) {
+	// A project palette with a distinctive cream surface + amber accent
+	// (the same shape the PIM project uses). ResolvePalette derives the full
+	// 21-var maps the SPA serves at /_palette.
+	project := &PaletteConfig{
+		PaletteColors: PaletteColors{
+			Base:    "#1f0e1c",
+			Surface: "#f5edba",
+			Accent:  "#e4943a",
+			Text:    "#3e2137",
+			Success: "#34859d",
+			Error:   "#d26471",
+			Warning: "#c0c741",
+			Info:    "#17434b",
+		},
+	}
+	resolved := ResolvePalette(project, nil)
+	css := appCSSSource(resolved)
+
+	// The project's surface/accent/text must appear in the :root block
+	// (not the framework default cream #f3f2ef / blue #4772fb).
+	for _, want := range []string{"--bg-color: #f5edba", "--accent-color: #e4943a", "--text-color: #3e2137"} {
+		if !strings.Contains(css, want) {
+			t.Errorf("appCSSSource(resolved) missing project token %q\n--- css ---\n%s", want, css)
+		}
+	}
+	// The framework default surface must NOT leak through.
+	if strings.Contains(css, "#f3f2ef") {
+		t.Errorf("appCSSSource(resolved) leaked the default surface #f3f2ef instead of the project palette")
+	}
+	// Dark mode is on by default → a :root.dark block is present, and the
+	// atomic controls are always appended.
+	for _, want := range []string{":root {", ":root.dark {", ".btn-primary"} {
+		if !strings.Contains(css, want) {
+			t.Errorf("appCSSSource(resolved) missing %q", want)
 		}
 	}
 }

--- a/tickets/entities/tickets/TKT-XGXLZH.md
+++ b/tickets/entities/tickets/TKT-XGXLZH.md
@@ -1,0 +1,43 @@
+---
+id: TKT-XGXLZH
+type: ticket
+title: Serve the resolved project palette in _rela.css (not framework defaults)
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+The per-app stylesheet served at `/api/v1/_apps/<id>/_rela.css` (`appCSSSource`)
+emitted rela's **default** theme tokens (the embedded `apps_tokens.css`
+`:root`/`:root.dark` blocks), ignoring the project's resolved palette
+(`.rela/palette.yaml`). A custom app that opts in with
+`<link href="_rela.css">` therefore rendered with framework default colors
+(cream `#f3f2ef`, blue accent) instead of the host project's actual theme.
+
+The SPA derives 21 CSS vars from the 8 palette colors
+(`dataentryconfig.deriveTheme`), so the app *shell* looked right but embedded
+apps drifted. The only app-side workaround was to port `deriveTheme` into the
+app's JS — ~80 lines duplicating `frontend/src/utils/palette.ts`, exactly the
+frozen-contract drift `internal/dataentry/CLAUDE.md` warns against.
+
+Follow-up to TKT-F5FDEQ (which shipped `_rela.css`); implements FEAT-BFDB9Q.
+
+## Fix
+
+**STATUS: done.** `appCSSSource(palette *ResolvedPalette)` now renders `:root`
+from `palette.Light` and `:root.dark` from `palette.Dark` (deterministic, sorted
+keys), then appends the unchanged atomic controls. `handleV1App` passes
+`a.State().Palette`. Falls back to the embedded default tokens when
+`palette == nil` — and because `deriveTheme`'s output keys are exactly the 21
+vars in `apps_tokens.css`, a `nil`/default palette is value-equivalent to the
+previous embed.
+
+## Tests
+
+- `TestAppTokensCSSInSyncWithFrontend` unchanged — still pins the embedded
+  fallback to the SPA source of truth.
+- `TestAppCSSSource(nil)` — fallback path still carries `:root`, `:root.dark`,
+  and the atomic controls; still rejects component-shaped classes.
+- `TestAppCSSSourceUsesResolvedPalette` (new) — a configured project palette
+  appears in the served CSS and the default surface `#f3f2ef` does not leak.

--- a/tickets/relations/TKT-XGXLZH--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-XGXLZH--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XGXLZH
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-XGXLZH--depends-on--TKT-F5FDEQ.md
+++ b/tickets/relations/TKT-XGXLZH--depends-on--TKT-F5FDEQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XGXLZH
+relation: depends-on
+to: TKT-F5FDEQ
+---

--- a/tickets/relations/TKT-XGXLZH--implements--FEAT-BFDB9Q.md
+++ b/tickets/relations/TKT-XGXLZH--implements--FEAT-BFDB9Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XGXLZH
+relation: implements
+to: FEAT-BFDB9Q
+---


### PR DESCRIPTION
## Problem

The per-app stylesheet served at `/api/v1/_apps/<id>/_rela.css` (`appCSSSource`) emitted rela's **default** theme tokens (the embedded `apps_tokens.css` `:root`/`:root.dark` blocks), ignoring the project's resolved palette (`.rela/palette.yaml`). A custom app that opts in with `<link href="_rela.css">` therefore rendered with framework default colors (cream `#f3f2ef`, blue accent) instead of the host project's actual theme — e.g. a project's cream `#f5edba` surface + amber accent.

The SPA derives 21 CSS vars from the 8 palette colors (`dataentryconfig.deriveTheme`, surfaced as `ResolvedPalette{Light,Dark}` and returned by `/_config` + `/_palette`), so the app *shell* looked right but embedded apps drifted. The only app-side workaround was to port `deriveTheme` into the app's JS — ~80 lines duplicating `frontend/src/utils/palette.ts`, exactly the frozen-contract drift `internal/dataentry/CLAUDE.md` warns against.

## Fix

`appCSSSource(palette *ResolvedPalette)` now renders `:root` from `palette.Light` and `:root.dark` from `palette.Dark` (deterministic, sorted keys), then appends the unchanged atomic controls. `handleV1App` passes `a.State().Palette`. Falls back to the embedded default tokens when `palette == nil`.

`deriveTheme`'s output keys are exactly the 21 vars in `apps_tokens.css`, so a `nil`/default palette is value-equivalent to the previous embed.

Benefits **every** custom app.

## Tests

- `TestAppTokensCSSInSyncWithFrontend` unchanged — still pins the embedded fallback to the SPA source of truth.
- `TestAppCSSSource(nil)` — fallback path still carries `:root`, `:root.dark`, and the atomic controls; still rejects component-shaped classes.
- `TestAppCSSSourceUsesResolvedPalette` (new) — a configured project palette appears in the served CSS (`--bg-color: #f5edba`, `--accent-color: #e4943a`, …) and the default surface `#f3f2ef` does **not** leak.

Verified live: `_rela.css` serves the project palette; a custom "Today" app inherits the host theme with zero JS. `just arch-lint` clean.

Ticket: TKT-XGXLZH (implements FEAT-BFDB9Q, depends-on TKT-F5FDEQ).