### PR TITLE
ci: default PR reviews to @sourcehaven-bv/maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default reviewers for every change. GitHub auto-requests this team on each PR
+# (the PR author is skipped). Manage membership at:
+# https://github.com/orgs/sourcehaven-bv/teams/maintainers
+* @sourcehaven-bv/maintainers


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning every PR to the `@sourcehaven-bv/maintainers` team (vloothuis + tschmits), so reviews are auto-requested. No branch-protection changes.