### PR TITLE
refactor: move v1 response types into apiwire/v1 (TKT-N26KLB)

### DIFF
--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -1,0 +1,563 @@
+package v1
+
+import (
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// Warning is the wire alias for a domain soft-validation warning, surfaced on
+// mutation responses (DEC-HWZHA write-with-warnings).
+type Warning = entity.Warning
+
+// Entity is the JSON representation of an entity for API v1.
+type Entity struct {
+	ID           string                 `json:"id"`
+	Type         string                 `json:"type"`
+	Title        string                 `json:"_title,omitempty"`
+	Properties   map[string]interface{} `json:"properties"`
+	Content      string                 `json:"content,omitempty"`
+	Relations    map[string][]string    `json:"relations,omitempty"`
+	Included     map[string]Entity      `json:"included,omitempty"`
+	Self         string                 `json:"_self,omitempty"`
+	Actions      map[string]bool        `json:"_actions,omitempty"`
+	Inaccessible []InaccessibleField    `json:"inaccessible,omitempty"`
+	// FieldAffordances carries per-field write affordances on per-entity
+	// GET responses. Sparse: only fields whose verdict deviates from the
+	// permissive default appear. Hidden fields are omitted from
+	// `Properties` AND from this map entirely. Pointer semantics
+	// distinguish "absent on the wire" (nil pointer; list / mutation
+	// responses) from "present and empty" (`{}`; per-entity GET with no
+	// deviations under nop resolver — closed-world signal matching the
+	// `_actions` precedent).
+	FieldAffordances *map[string]FieldAffordance `json:"_fields,omitempty"`
+	// RelationAffordances carries per-relation-type affordances on
+	// per-entity GET responses. Same pointer / closed-world semantics
+	// as FieldAffordances.
+	RelationAffordances *map[string]RelationAffordance `json:"_relations,omitempty"`
+	// Attachments maps a `file`-type property name to the LIST of files
+	// currently attached to it (a property may hold several when its
+	// metamodel `max` > 1). The value is always an array — even a
+	// single-attachment property reports a 1-element list — matching how
+	// rela's `list:` properties and `_relations` are always arrays. Only
+	// properties that actually carry a file appear. Same pointer /
+	// closed-world semantics as FieldAffordances: present (possibly empty)
+	// on every per-entity response (GET, PATCH, POST create, clone — the
+	// ones that run serializeEntityForWire), nil on list rows and other
+	// non-per-entity shapes. The SPA's file widget reads this to render the
+	// download links / previews instead of the raw stored path string(s).
+	Attachments *map[string][]Attachment `json:"_attachments,omitempty"`
+	// Warnings lists soft-condition findings surfaced by the write
+	// path. Populated only by mutation responses (PATCH); read paths
+	// leave it nil. Each warning has a stable `code`, an RFC 6901
+	// JSON Pointer `path`, and a human-readable `detail`.
+	Warnings []Warning `json:"warnings,omitempty"`
+}
+
+// FieldAffordance describes per-field write / option affordances on
+// the wire. Sparse: `Writable` is nil when the default (writable)
+// holds; `Options` lists only the false entries (allowed options are
+// implicit via the metamodel). See the closed-world contract in
+// docs/data-entry/api-reference.md.
+type FieldAffordance struct {
+	Writable *bool           `json:"writable,omitempty"`
+	Options  map[string]bool `json:"options,omitempty"`
+}
+
+// RelationAffordance describes per-relation-type affordances on the
+// wire. Sparse: `Creatable` and `Removable` are nil when the default
+// (true) holds. `Fields` lists meta-field writability overrides, also
+// sparse.
+type RelationAffordance struct {
+	Creatable *bool                      `json:"creatable,omitempty"`
+	Removable *bool                      `json:"removable,omitempty"`
+	Fields    map[string]FieldAffordance `json:"fields,omitempty"`
+}
+
+// Attachment describes one file attached to a `file`-type property, as
+// surfaced on a per-entity GET response. ID is the file's identifier
+// within the property (its normalized file name) — used to build the
+// per-file download/delete URL. Href is the download URL for the bytes (an
+// ACL-gated endpoint that inherits the owning entity's read permission).
+// ContentType is inferred from the filename — the store does not persist
+// it on every backend.
+type Attachment struct {
+	ID          string `json:"id"`
+	FileName    string `json:"filename"`
+	Size        int64  `json:"size"`
+	ContentType string `json:"contentType"`
+	Href        string `json:"href"`
+}
+
+// InaccessibleField describes a property that is known to exist but
+// whose value is unreadable by the holder of the entity (e.g. the file
+// is git-crypt encrypted and the key is not present locally).
+type InaccessibleField struct {
+	Name   string `json:"name"`
+	Reason string `json:"reason"`
+}
+
+// ListResponse is the response for listing entities.
+type ListResponse struct {
+	Data    []Entity        `json:"data"`
+	Meta    ListMeta        `json:"meta"`
+	Actions map[string]bool `json:"_actions,omitempty"`
+}
+
+// ListMeta contains pagination metadata.
+type ListMeta struct {
+	Total   int  `json:"total"`
+	Page    int  `json:"page"`
+	PerPage int  `json:"per_page"`
+	HasMore bool `json:"has_more"`
+}
+
+// Schema is the JSON representation of the metamodel.
+type Schema struct {
+	Entities  map[string]EntityType   `json:"entities"`
+	Relations map[string]RelationType `json:"relations"`
+	Types     map[string]CustomType   `json:"types,omitempty"`
+}
+
+// EntityType is the JSON representation of an entity type.
+type EntityType struct {
+	Label       string                 `json:"label"`
+	Plural      string                 `json:"plural"`
+	Description string                 `json:"description,omitempty"`
+	Primary     string                 `json:"primary,omitempty"`
+	IDType      string                 `json:"id_type,omitempty"`
+	IDPrefix    string                 `json:"id_prefix,omitempty"`
+	IDPrefixes  []string               `json:"id_prefixes,omitempty"`
+	Properties  map[string]PropertyDef `json:"properties"`
+}
+
+// PropertyDef is the JSON representation of a property definition.
+type PropertyDef struct {
+	Type        string   `json:"type"`
+	Required    bool     `json:"required"`
+	Default     string   `json:"default,omitempty"`
+	Values      []string `json:"values,omitempty"`
+	Description string   `json:"description,omitempty"`
+	List        bool     `json:"list,omitempty"`
+	// Max is the attachment cap for a `file` property (default 1). The SPA's
+	// file widget reads it to switch between replace-mode and multi-file
+	// add-mode. Omitted unless set above 1.
+	Max int `json:"max,omitempty"`
+}
+
+// RelationType is the JSON representation of a relation type.
+type RelationType struct {
+	Label       string                 `json:"label"`
+	Description string                 `json:"description,omitempty"`
+	From        []string               `json:"from"`
+	To          []string               `json:"to"`
+	Inverse     *InverseDef            `json:"inverse,omitempty"`
+	Symmetric   bool                   `json:"symmetric,omitempty"`
+	MinOutgoing *int                   `json:"min_outgoing,omitempty"`
+	MaxOutgoing *int                   `json:"max_outgoing,omitempty"`
+	MinIncoming *int                   `json:"min_incoming,omitempty"`
+	MaxIncoming *int                   `json:"max_incoming,omitempty"`
+	Properties  map[string]PropertyDef `json:"properties,omitempty"`
+	// Orderable, when set, declares that the frontend may offer drag-to-reorder
+	// controls on the corresponding side. The managed property names are
+	// always the reserved `_order_out` (outgoing) and `_order_in` (incoming).
+	Orderable *RelationOrderable `json:"orderable,omitempty"`
+}
+
+// RelationOrderable describes per-side orderability for a relation type.
+type RelationOrderable struct {
+	Outgoing bool `json:"outgoing,omitempty"`
+	Incoming bool `json:"incoming,omitempty"`
+}
+
+// InverseDef mirrors metamodel.InverseDef on the wire. The SPA reads
+// `inverse.id` to find the inverse body key for incoming-direction
+// edits routed through the unified PATCH (TKT-GFQK).
+type InverseDef struct {
+	ID    string `json:"id"`
+	Label string `json:"label,omitempty"`
+}
+
+// CustomType is the JSON representation of a custom type.
+type CustomType struct {
+	Values  []string `json:"values"`
+	Default string   `json:"default,omitempty"`
+}
+
+// Config is the JSON representation of the UI config.
+type Config struct {
+	App         AppConfig                                   `json:"app"`
+	Styles      map[string]map[string]string                `json:"styles"`
+	Forms       map[string]dataentryconfig.Form             `json:"forms"`
+	Lists       map[string]dataentryconfig.List             `json:"lists"`
+	Views       map[string]dataentryconfig.ViewConfig       `json:"views"`
+	EntityViews map[string]dataentryconfig.EntityViewConfig `json:"entity_views,omitempty"`
+	Kanbans     map[string]dataentryconfig.Kanban           `json:"kanbans"`
+	Dashboard   *dataentryconfig.DashboardConfig            `json:"dashboard,omitempty"`
+	Actions     map[string]dataentryconfig.Action           `json:"actions,omitempty"`
+	Navigation  []dataentryconfig.NavigationEntry           `json:"navigation"`
+	Documents   map[string]dataentryconfig.DocumentConfig   `json:"documents,omitempty"`
+	Apps        map[string]App                              `json:"apps,omitempty"`
+	Palette     *dataentryconfig.ResolvedPalette            `json:"palette,omitempty"`
+}
+
+// App is the client-facing view of a custom app. It deliberately omits the
+// on-disk File path and the csp_origins allow-list — the SPA only needs enough
+// to render a sidebar entry and route to /app/{id}; the HTML is fetched from
+// GET /api/v1/_apps/{id}.
+type App struct {
+	Title       string `json:"title,omitempty"`
+	Label       string `json:"label,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// AppConfig is the JSON representation of the app config.
+type AppConfig struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	// PlantUMLServerURL is the configured PlantUML server base URL, or empty
+	// when PlantUML rendering is disabled. The SPA treats a non-empty value as
+	// the on switch for ```plantuml diagram rendering.
+	PlantUMLServerURL string `json:"plantuml_server_url,omitempty"`
+}
+
+// Error is an RFC 7807 Problem Details response.
+type Error struct {
+	Type     string       `json:"type"`
+	Title    string       `json:"title"`
+	Status   int          `json:"status"`
+	Detail   string       `json:"detail,omitempty"`
+	Instance string       `json:"instance,omitempty"`
+	Errors   []FieldError `json:"errors,omitempty"`
+}
+
+// FieldError represents a validation error on a specific field.
+type FieldError struct {
+	Source ErrorSource `json:"source"`
+	Code   string      `json:"code"`
+	Detail string      `json:"detail"`
+}
+
+// ErrorSource points to the location of an error.
+type ErrorSource struct {
+	Pointer string `json:"pointer"`
+}
+
+// SidePanelSection represents a section in the side panel response.
+type SidePanelSection struct {
+	Heading      string            `json:"heading"`
+	SectionID    string            `json:"sectionId"`
+	Display      string            `json:"display"`
+	IsEmpty      bool              `json:"isEmpty"`
+	EmptyMessage string            `json:"emptyMessage,omitempty"`
+	Fields       []SectionField    `json:"fields,omitempty"`
+	Entities     []SidePanelEntity `json:"entities,omitempty"`
+	AddInfo      *ViewAddInfo      `json:"addInfo,omitempty"`
+	LinkInfo     *ViewLinkInfo     `json:"linkInfo,omitempty"`
+}
+
+// SectionField represents a field in a side panel section.
+// Values is always an array so that list-typed properties retain per-item
+// structure; scalar properties become a one-element array. Empty fields emit
+// an empty array (omitted via omitempty when nil).
+//
+// Property carries the raw property name so consumers can correlate the
+// field with metamodel data (e.g. inaccessibility lookup); Label is the
+// human-readable rendering. Inaccessible is true when the underlying entity
+// is git-crypt encrypted — the field is known to exist in the schema but
+// its value cannot be read.
+type SectionField struct {
+	Property     string   `json:"property,omitempty"`
+	Label        string   `json:"label"`
+	Values       []string `json:"values,omitempty"`
+	PropType     string   `json:"propType,omitempty"`
+	Inaccessible bool     `json:"inaccessible,omitempty"`
+}
+
+// SidePanelEntity represents an entity in a side panel section.
+type SidePanelEntity struct {
+	ID         string         `json:"id"`
+	Title      string         `json:"title"`
+	Type       string         `json:"type"`
+	EditFormID string         `json:"editFormId,omitempty"`
+	Fields     []SectionField `json:"fields,omitempty"`
+	Content    string         `json:"content,omitempty"`
+	HasContent bool           `json:"hasContent"`
+}
+
+// SidebarItem represents a navigation item with count.
+type SidebarItem struct {
+	Label  string `json:"label"`
+	Href   string `json:"href"`
+	Icon   string `json:"icon,omitempty"`
+	Count  *int   `json:"count,omitempty"`
+	Action string `json:"action,omitempty"`
+}
+
+// SidebarGroup represents a navigation group with items.
+type SidebarGroup struct {
+	Group     string        `json:"group,omitempty"`
+	Collapsed bool          `json:"collapsed,omitempty"`
+	Items     []SidebarItem `json:"items"`
+}
+
+// SidebarResponse contains the sidebar data with app info and navigation.
+type SidebarResponse struct {
+	App        AppConfig      `json:"app"`
+	Navigation []SidebarGroup `json:"navigation"`
+	// LogoURL is the cache-busted URL of the user-uploaded sidebar logo,
+	// or nil when no logo is set. Included here (rather than in
+	// `_settings`) so the SPA can render the logo on first paint without
+	// blocking on a settings fetch.
+	LogoURL *string `json:"logoUrl,omitempty"`
+}
+
+// ConflictItem represents a conflicted file.
+type ConflictItem struct {
+	Path        string `json:"path"`
+	EntityType  string `json:"entity_type,omitempty"`
+	EntityID    string `json:"entity_id,omitempty"`
+	MarkerCount int    `json:"marker_count"`
+}
+
+// ConflictsResponse contains the list of conflicts.
+type ConflictsResponse struct {
+	Conflicts []ConflictItem `json:"conflicts"`
+	Count     int            `json:"count"`
+}
+
+// PropertyDiff represents a property difference.
+type PropertyDiff struct {
+	Property    string `json:"property"`
+	OursValue   string `json:"ours_value"`
+	TheirsValue string `json:"theirs_value"`
+	IsSame      bool   `json:"is_same"`
+}
+
+// ConflictDetail contains detailed info for resolving a conflict.
+type ConflictDetail struct {
+	Path          string         `json:"path"`
+	EntityType    string         `json:"entity_type,omitempty"`
+	EntityID      string         `json:"entity_id,omitempty"`
+	PropertyDiffs []PropertyDiff `json:"property_diffs"`
+	ContentSame   bool           `json:"content_same"`
+	ContentOurs   string         `json:"content_ours,omitempty"`
+	ContentTheirs string         `json:"content_theirs,omitempty"`
+}
+
+// ConflictResolveRequest contains the resolution choices.
+type ConflictResolveRequest struct {
+	Path            string            `json:"path"`
+	PropertyChoices map[string]string `json:"property_choices"`
+	ContentChoice   string            `json:"content_choice"`
+	ManualContent   string            `json:"manual_content,omitempty"`
+}
+
+// DocumentResponse contains the rendered document content.
+type DocumentResponse struct {
+	HTML      string   `json:"html"`
+	Cached    bool     `json:"cached"`
+	EntityIDs []string `json:"entity_ids"` // IDs of entities involved in this document (for SSE filtering)
+}
+
+// Command is the JSON representation of an available command.
+type Command struct {
+	ID       string `json:"id"`
+	Label    string `json:"label"`
+	Confirm  string `json:"confirm,omitempty"`
+	Context  string `json:"context"`
+	AutoOpen *bool  `json:"auto_open,omitempty"`
+}
+
+// Template represents a template for API responses.
+type Template struct {
+	Name       string                 `json:"name"`
+	Properties map[string]interface{} `json:"properties"`
+	Content    string                 `json:"content"`
+	Relations  []TemplateRelation     `json:"relations"`
+}
+
+// TemplateRelation represents a pre-filled relation in a template.
+type TemplateRelation struct {
+	Relation string `json:"relation"`
+	Target   string `json:"target"`
+}
+
+// ViewResponse contains the executed view data.
+//
+// Mentions carries the implicit-relation set discovered by scanning the
+// entry and section markdown contents for bare-content entity-ID code
+// spans (see collectMentions). The SPA's markdown renderer consumes this
+// map to rewrite those code spans into titled in-app links. Mirrors the
+// Lua-side `rela.md.entity_refs` shape (TKT-LXYHQ) for SPA consumers
+// that don't go through the Lua document path.
+//
+// Wire stability: `mentions` is part of the public v1 API. The set of
+// `inaccessible_reason` values may grow as new locking mechanisms are
+// added (today: `git-crypt`); clients must treat unknown reasons as
+// opaque rather than enumerating them.
+type ViewResponse struct {
+	Entry    Entity             `json:"entry"`
+	Sections []ViewSection      `json:"sections"`
+	Mentions map[string]Mention `json:"mentions,omitempty"`
+}
+
+// ViewSection represents a section with resolved data.
+type ViewSection struct {
+	Heading      string         `json:"heading"`
+	SectionID    string         `json:"sectionId"`
+	Display      string         `json:"display"`
+	IsEmpty      bool           `json:"isEmpty"`
+	EmptyMessage string         `json:"emptyMessage,omitempty"`
+	Fields       []SectionField `json:"fields,omitempty"`
+	Entities     []ViewEntity   `json:"entities,omitempty"`
+	Columns      []ViewColumn   `json:"columns,omitempty"`
+	Rows         []ViewRow      `json:"rows,omitempty"`
+	Groups       []ViewGroup    `json:"groups,omitempty"`
+	IsGrouped    bool           `json:"isGrouped"`
+	Content      string         `json:"content,omitempty"`
+	HasContent   bool           `json:"hasContent"`
+}
+
+// ViewEntity represents an entity in a view section.
+//
+// Props and FieldAffordances (TKT-IHC7D) carry the typed property
+// values and per-cell writability verdict that inline-edit hosts on
+// cards/list view sections consume. Both are hidden-property-stripped
+// — the consumer can assume:
+//
+//   - `keys(Props) ∩ hidden(e) == ∅` (hidden properties never leak via
+//     this surface)
+//   - `keys(FieldAffordances) ∩ hidden(e) == ∅` (same for the verdict)
+//   - `FieldAffordances` may have keys absent from `Props` when the
+//     property has no stored value but a non-default verdict (e.g.
+//     `writable: false` on an unset field)
+//
+// The pointer-to-map idiom on `FieldAffordances` mirrors
+// `Entity.FieldAffordances`: `nil` means "absent on the wire"
+// (table rows / non-cards paths), `&{}` means "evaluated, no
+// deviations" (closed-world signal matching `_actions`).
+//
+// `Props` is a plain map with `omitempty`: presence/absence is
+// sufficient, no closed-world semantic is needed.
+type ViewEntity struct {
+	ID               string                      `json:"id"`
+	Title            string                      `json:"title"`
+	Type             string                      `json:"type"`
+	EditFormID       string                      `json:"editFormId,omitempty"`
+	Fields           []SectionField              `json:"fields,omitempty"`
+	Content          string                      `json:"content,omitempty"`
+	HasContent       bool                        `json:"hasContent"`
+	Props            map[string]any              `json:"_props,omitempty"`
+	FieldAffordances *map[string]FieldAffordance `json:"_fields,omitempty"`
+}
+
+// ViewColumn represents a column definition.
+type ViewColumn struct {
+	Property string `json:"property,omitempty"`
+	Label    string `json:"label,omitempty"`
+	Relation string `json:"relation,omitempty"`
+	Link     string `json:"link,omitempty"`
+}
+
+// ViewRow represents a table row.
+type ViewRow struct {
+	EntityID   string     `json:"entityId"`
+	EntityType string     `json:"entityType"`
+	EditFormID string     `json:"editFormId,omitempty"`
+	Cells      []ViewCell `json:"cells"`
+	Content    string     `json:"content,omitempty"`
+}
+
+// ViewCell represents a table cell.
+type ViewCell struct {
+	Values     []string `json:"values"`
+	PropType   string   `json:"propType,omitempty"`
+	Widget     string   `json:"widget,omitempty"`
+	Link       string   `json:"link,omitempty"`
+	EntityID   string   `json:"entityId,omitempty"`
+	EntityType string   `json:"entityType,omitempty"`
+}
+
+// ViewGroup represents a group of rows.
+type ViewGroup struct {
+	GroupName string       `json:"groupName"`
+	Rows      []ViewRow    `json:"rows,omitempty"`
+	Entities  []ViewEntity `json:"entities,omitempty"`
+}
+
+// ViewAddInfo describes an add button configuration. Despite the "View"
+// prefix this is now used only by SidePanelSection — see TKT-6ETQ for
+// the rename to V1SidePanelAddInfo. Do not reach for this type from a new
+// view-related response: the read-only-view invariant established by
+// TKT-651W means no view section should carry add affordances.
+type ViewAddInfo struct {
+	Relation string          `json:"relation"`
+	LinkAs   string          `json:"linkAs"`
+	PeerID   string          `json:"peerId"`
+	Targets  []ViewAddTarget `json:"targets"`
+}
+
+// ViewAddTarget represents a possible target for add action.
+// Side-panel-only post TKT-651W; see TKT-6ETQ for the rename plan.
+type ViewAddTarget struct {
+	EntityType string `json:"entityType"`
+	FormID     string `json:"formId"`
+	Label      string `json:"label"`
+}
+
+// ViewLinkInfo describes a link existing button configuration.
+// Side-panel-only post TKT-651W; see TKT-6ETQ for the rename plan.
+type ViewLinkInfo struct {
+	Relation    string   `json:"relation"`
+	LinkAs      string   `json:"linkAs"`
+	PeerID      string   `json:"peerId"`
+	EntityTypes []string `json:"entityTypes"`
+}
+
+// PositionRef identifies a neighboring entity in a scope. Type is included
+// because a scope (notably a search scope) can span entity types, so the SPA
+// must build the target's detail route from *its* type, not the current
+// entity's. ID alone would break cross-type prev/next.
+type PositionRef struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+// Position is the scope-navigator payload: the neighbors plus the counter
+// the SPA needs, with no entity bodies shipped. current is 1-based; prev/next
+// are nil at the ends of the set.
+type Position struct {
+	Prev    *PositionRef `json:"prev"`
+	Next    *PositionRef `json:"next"`
+	Current int          `json:"current"`
+	Total   int          `json:"total"`
+}
+
+// ActionResponse mirrors script.ActionResponse for API JSON output.
+// Has both successful response fields and error fields with correlation ID.
+type ActionResponse struct {
+	Redirect      string `json:"redirect,omitempty"`
+	Message       string `json:"message,omitempty"`
+	MessageType   string `json:"message_type,omitempty"`
+	Error         string `json:"error,omitempty"`
+	CorrelationID string `json:"correlation_id,omitempty"`
+}
+
+// Mention is the resolved target of an entity-ID code span found in
+// markdown content. Mirrors the Lua-side `rela.md.entity_refs`/`resolve_refs`
+// semantics (TKT-LXYHQ): only bare-content code spans whose entire text is
+// an entity ID are collected; the data-entry SPA uses this map to rewrite
+// those code spans into titled in-app links.
+//
+// `Inaccessible` is true when the entity's display title is unreadable
+// (e.g. the file is git-crypt encrypted) — the SPA renders such links
+// with a lock affordance using the same tooltip copy as inaccessible
+// properties. `InaccessibleReason` carries the matching
+// `entity.InaccessibleReason` value as a string so the wire shape stays
+// stable across reason-enum additions.
+type Mention struct {
+	Type               string `json:"type"`
+	Title              string `json:"title"`
+	Inaccessible       bool   `json:"inaccessible,omitempty"`
+	InaccessibleReason string `json:"inaccessible_reason,omitempty"`
+}

--- a/internal/dataentry/acl_get_test.go
+++ b/internal/dataentry/acl_get_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/search"
@@ -70,11 +71,11 @@ func TestACLGet_TypeLevelReadGrant(t *testing.T) {
 // own URL); other fields must match.
 //
 // Parsing + re-encoding (instead of string slicing — RR-QLQW) makes
-// the comparator robust against future V1Error field additions and
+// the comparator robust against future v1.Error field additions and
 // against JSON-encoder reordering quirks.
 func stripInstance(t *testing.T, s string) string {
 	t.Helper()
-	var v V1Error
+	var v v1.Error
 	if err := json.Unmarshal([]byte(s), &v); err != nil {
 		t.Fatalf("stripInstance: invalid JSON %q: %v", s, err)
 	}

--- a/internal/dataentry/acl_list_regression_test.go
+++ b/internal/dataentry/acl_list_regression_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 )
 
@@ -29,7 +30,7 @@ func TestACLListRegression_NopACL_ListUnchanged(t *testing.T) {
 		t.Fatalf("NopACL list: got %d, want 200; body=%s", rec.Code, rec.Body)
 	}
 
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v\nbody: %s", err, rec.Body)
 	}
@@ -68,7 +69,7 @@ func TestACLListRegression_NopACL_FreeTextStillWorks(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("NopACL list q=: got %d, want 200; body=%s", rec.Code, rec.Body)
 	}
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}

--- a/internal/dataentry/acl_list_test.go
+++ b/internal/dataentry/acl_list_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -343,7 +344,7 @@ func TestACLPosition_SearchScopeGated(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("position: %d %s", rec.Code, rec.Body)
 	}
-	var pos V1Position
+	var pos v1.Position
 	if err := json.Unmarshal(rec.Body.Bytes(), &pos); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -429,7 +430,7 @@ func TestACLList_VaryHeader(t *testing.T) {
 // header asserts.
 func listEntitiesAs(ctx context.Context, t *testing.T, app *App, d *acl.Declarative,
 	typeName, plural, rawQuery string,
-) (V1ListResponse, *httptest.ResponseRecorder) {
+) (v1.ListResponse, *httptest.ResponseRecorder) {
 	t.Helper()
 	url := "/api/v1/" + plural
 	if rawQuery != "" {
@@ -440,7 +441,7 @@ func listEntitiesAs(ctx context.Context, t *testing.T, app *App, d *acl.Declarat
 	rec := httptest.NewRecorder()
 	app.handleV1ListEntities(rec, req, typeName, plural)
 
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if rec.Code == http.StatusOK {
 		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 			t.Fatalf("decode list response: %v\nbody: %s", err, rec.Body)

--- a/internal/dataentry/acl_search_test.go
+++ b/internal/dataentry/acl_search_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -18,14 +19,14 @@ import (
 
 // searchAs performs GET /api/v1/_search?q=<q> with the readGate +
 // acl.Request attached, mirroring listEntitiesAs for the search view.
-func searchAs(ctx context.Context, t *testing.T, app *App, d *acl.Declarative, q string) (V1ListResponse, *httptest.ResponseRecorder) {
+func searchAs(ctx context.Context, t *testing.T, app *App, d *acl.Declarative, q string) (v1.ListResponse, *httptest.ResponseRecorder) {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/_search?q="+q, http.NoBody)
 	req = req.WithContext(gateCtxFor(ctx, t, d))
 	rec := httptest.NewRecorder()
 	app.handleV1Search(rec, req)
 
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if rec.Code == http.StatusOK {
 		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 			t.Fatalf("decode search response: %v\nbody: %s", err, rec.Body)
@@ -348,7 +349,7 @@ func TestACLSearchRegression_NopACL(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /_search: %d %s", rec.Code, rec.Body)
 	}
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v\nbody: %s", err, rec.Body)
 	}

--- a/internal/dataentry/acl_sidebar_test.go
+++ b/internal/dataentry/acl_sidebar_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 )
@@ -89,7 +90,7 @@ func sidebarCountsByLabel(ctx context.Context, t *testing.T, app *App) map[strin
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET _sidebar: %d %s", rec.Code, rec.Body)
 	}
-	var resp V1SidebarResponse
+	var resp v1.SidebarResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode sidebar: %v\nbody: %s", err, rec.Body)
 	}

--- a/internal/dataentry/actions.go
+++ b/internal/dataentry/actions.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 )
@@ -23,16 +24,6 @@ var actionIDRegex = regexp.MustCompile(`^[a-z0-9_-]{1,64}$`)
 // Tighter than the default Lua timeout because the action handler holds
 // writeMu for the entire script execution, blocking other mutations.
 const actionTimeout = 5 * time.Second
-
-// V1ActionResponse mirrors script.ActionResponse for API JSON output.
-// Has both successful response fields and error fields with correlation ID.
-type V1ActionResponse struct {
-	Redirect      string `json:"redirect,omitempty"`
-	Message       string `json:"message,omitempty"`
-	MessageType   string `json:"message_type,omitempty"`
-	Error         string `json:"error,omitempty"`
-	CorrelationID string `json:"correlation_id,omitempty"`
-}
 
 // v1ActionRequest is the optional JSON body for action invocation.
 // When entity_id is provided, the script context includes the entity.
@@ -112,7 +103,7 @@ func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 		// Non-Lua failure (script-not-found, contract failure from
 		// parseActionResponse, redirect validation, etc.) — keep the
 		// existing minimal-detail shape.
-		writeV1JSON(w, http.StatusInternalServerError, V1ActionResponse{
+		writeV1JSON(w, http.StatusInternalServerError, v1.ActionResponse{
 			Error:         "action_failed",
 			Message:       "Action failed",
 			CorrelationID: correlationID,
@@ -125,7 +116,7 @@ func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeV1JSON(w, http.StatusOK, V1ActionResponse{
+	writeV1JSON(w, http.StatusOK, v1.ActionResponse{
 		Redirect:    resp.Redirect,
 		Message:     resp.Message,
 		MessageType: resp.MessageType,

--- a/internal/dataentry/actions_test.go
+++ b/internal/dataentry/actions_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 )
 
@@ -67,7 +68,7 @@ func TestHandleV1Action_Success(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var resp V1ActionResponse
+	var resp v1.ActionResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode failed: %v", err)
 	}
@@ -256,7 +257,7 @@ func TestHandleV1Action_ParamsPassed(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var resp V1ActionResponse
+	var resp v1.ActionResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode failed: %v", err)
 	}

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -667,15 +667,15 @@ func (svc affordanceService) validateRelationMetaWrite(ctx context.Context, e *e
 // Empty input verdicts yield an empty (non-nil) map so the wire shape
 // is consistent: `_fields: {}` under the nop resolver, sparse entries
 // under any other.
-func (svc affordanceService) computeFieldAffordances(ctx context.Context, e *entityPkg.Entity) map[string]V1FieldAffordance {
+func (svc affordanceService) computeFieldAffordances(ctx context.Context, e *entityPkg.Entity) map[string]v1.FieldAffordance {
 	return computeFieldAffordancesFrom(svc.resolver().FieldVerdicts(ctx, e))
 }
 
 // computeFieldAffordancesFrom is computeFieldAffordances given an
 // already-resolved verdict set, so callers that need the verdicts for more
 // than one thing (e.g. _fields + _attachments) resolve them once.
-func computeFieldAffordancesFrom(v FieldVerdicts) map[string]V1FieldAffordance {
-	out := make(map[string]V1FieldAffordance)
+func computeFieldAffordancesFrom(v FieldVerdicts) map[string]v1.FieldAffordance {
+	out := make(map[string]v1.FieldAffordance)
 
 	// writable=false entries
 	for name, writable := range v.Writable {
@@ -753,7 +753,7 @@ func (v FieldVerdicts) IsOptionAllowed(name, opt string) bool {
 func (v FieldVerdicts) isHidden(name string) bool { return !v.IsVisible(name) }
 
 // hiddenProperties returns the set of property names that should be
-// stripped from V1Entity.Properties before serialization. Caller uses
+// stripped from v1.Entity.Properties before serialization. Caller uses
 // this to enforce the omit-on-hidden invariant.
 func (svc affordanceService) hiddenProperties(ctx context.Context, e *entityPkg.Entity) map[string]struct{} {
 	v := svc.resolver().FieldVerdicts(ctx, e)
@@ -774,11 +774,11 @@ func (svc affordanceService) hiddenProperties(ctx context.Context, e *entityPkg.
 // (creatable=false, removable=false, or any meta-field writable=false)
 // appear in the map. Default-permissive types are absent — the SPA's
 // "no entry = default" path handles them.
-func (svc affordanceService) computeRelationAffordances(ctx context.Context, e *entityPkg.Entity) map[string]V1RelationAffordance {
+func (svc affordanceService) computeRelationAffordances(ctx context.Context, e *entityPkg.Entity) map[string]v1.RelationAffordance {
 	v := svc.resolver().RelationVerdicts(ctx, e)
-	out := make(map[string]V1RelationAffordance)
+	out := make(map[string]v1.RelationAffordance)
 	for relType, rv := range v.Types {
-		var entry V1RelationAffordance
+		var entry v1.RelationAffordance
 		emit := false
 		if !rv.Creatable {
 			f := false
@@ -790,16 +790,16 @@ func (svc affordanceService) computeRelationAffordances(ctx context.Context, e *
 			entry.Removable = &f
 			emit = true
 		}
-		var fields map[string]V1FieldAffordance
+		var fields map[string]v1.FieldAffordance
 		for metaField, writable := range rv.Fields {
 			if writable {
 				continue
 			}
 			if fields == nil {
-				fields = make(map[string]V1FieldAffordance)
+				fields = make(map[string]v1.FieldAffordance)
 			}
 			f := false
-			fields[metaField] = V1FieldAffordance{Writable: &f}
+			fields[metaField] = v1.FieldAffordance{Writable: &f}
 		}
 		if fields != nil {
 			entry.Fields = fields
@@ -814,14 +814,14 @@ func (svc affordanceService) computeRelationAffordances(ctx context.Context, e *
 
 // copyVisibleProperties returns a fresh map of the entity's properties
 // with hidden names filtered out, ready to ship on a per-row wire
-// surface (cards/list rows in V1ViewEntity._props). Shallow copy: each
+// surface (cards/list rows in v1.ViewEntity._props). Shallow copy: each
 // value points at the same underlying object as e.Properties[k], which
 // is fine because the response is JSON-marshaled before the caller can
 // alias anything (TKT-IHC7D).
 //
 // Mirrors stripHiddenProperties's hidden-property contract but returns
-// a new map instead of mutating an existing V1Entity — the per-row
-// case never goes through V1Entity, so the in-place strip pattern
+// a new map instead of mutating an existing v1.Entity — the per-row
+// case never goes through v1.Entity, so the in-place strip pattern
 // doesn't fit.
 func (svc affordanceService) copyVisibleProperties(ctx context.Context, e *entityPkg.Entity) map[string]any {
 	hidden := svc.hiddenProperties(ctx, e)
@@ -843,7 +843,7 @@ func (svc affordanceService) copyVisibleProperties(ctx context.Context, e *entit
 // Also rewrites `_title` to the entity ID when the entity-type's
 // display property is hidden — otherwise the display title would leak
 // the hidden value through the wire's secondary channel.
-func (svc affordanceService) stripHiddenProperties(ctx context.Context, e *entityPkg.Entity, result *V1Entity) {
+func (svc affordanceService) stripHiddenProperties(ctx context.Context, e *entityPkg.Entity, result *v1.Entity) {
 	hidden := svc.hiddenProperties(ctx, e)
 	for name := range hidden {
 		delete(result.Properties, name)
@@ -870,7 +870,7 @@ func (svc affordanceService) stripHiddenProperties(ctx context.Context, e *entit
 // `_relations` wire maps onto result. Called by paths that return a
 // per-entity response (GET, PATCH, POST, clone, action) — list rows
 // and includes get [App.stripHiddenProperties] only.
-func (svc affordanceService) attachEntityAffordances(ctx context.Context, e *entityPkg.Entity, result *V1Entity) {
+func (svc affordanceService) attachEntityAffordances(ctx context.Context, e *entityPkg.Entity, result *v1.Entity) {
 	verdicts := svc.resolver().FieldVerdicts(ctx, e)
 	fields := computeFieldAffordancesFrom(verdicts)
 	relations := svc.computeRelationAffordances(ctx, e)
@@ -887,7 +887,7 @@ func (svc affordanceService) attachEntityAffordances(ctx context.Context, e *ent
 // computeAttachments returns the per-property attachment metadata for an
 // entity, keyed by `file`-type property name. Only properties that carry
 // a file appear; an empty map means "no attachments". Rides every
-// per-entity V1Entity response (GET, PATCH, POST, clone) alongside
+// per-entity v1.Entity response (GET, PATCH, POST, clone) alongside
 // `_fields` / `_relations`, never on list rows — same closed-world shape.
 //
 // selfHref is the entity's `_self` link (`/api/v1/{plural}/{id}`); each
@@ -899,8 +899,8 @@ func (svc affordanceService) attachEntityAffordances(ctx context.Context, e *ent
 // The value per property is a LIST: a property may hold several files, and
 // even a single file is reported as a 1-element list (always-array wire
 // shape).
-func (svc affordanceService) computeAttachments(ctx context.Context, e *entityPkg.Entity, selfHref string, verdicts FieldVerdicts) map[string][]V1Attachment {
-	out := make(map[string][]V1Attachment)
+func (svc affordanceService) computeAttachments(ctx context.Context, e *entityPkg.Entity, selfHref string, verdicts FieldVerdicts) map[string][]v1.Attachment {
+	out := make(map[string][]v1.Attachment)
 	if selfHref == "" {
 		return out
 	}
@@ -924,7 +924,7 @@ func (svc affordanceService) computeAttachments(ctx context.Context, e *entityPk
 		if !verdicts.IsVisible(info.Property) {
 			continue
 		}
-		out[info.Property] = append(out[info.Property], V1Attachment{
+		out[info.Property] = append(out[info.Property], v1.Attachment{
 			ID:          info.FileName,
 			FileName:    info.FileName,
 			Size:        info.Size,

--- a/internal/dataentry/affordances_contract_test.go
+++ b/internal/dataentry/affordances_contract_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -108,7 +109,7 @@ func fetchActions(t *testing.T, app *App, typeName, plural, id string) map[strin
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET %s returned %d: %s", id, rec.Code, rec.Body.String())
 	}
-	var e V1Entity
+	var e v1.Entity
 	if err := json.NewDecoder(rec.Body).Decode(&e); err != nil {
 		t.Fatalf("decode GET: %v", err)
 	}

--- a/internal/dataentry/affordances_policy_test.go
+++ b/internal/dataentry/affordances_policy_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/affordances"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
@@ -52,7 +53,7 @@ func patchAs(t *testing.T, app *App, user, id, body string) (status int, respBod
 	return rec.Code, rec.Body.String()
 }
 
-func getAs(t *testing.T, app *App, user, id string) V1Entity {
+func getAs(t *testing.T, app *App, user, id string) v1.Entity {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/"+id, http.NoBody)
 	req = req.WithContext(principal.With(req.Context(),
@@ -62,7 +63,7 @@ func getAs(t *testing.T, app *App, user, id string) V1Entity {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET %s: got %d, want 200; body=%s", id, rec.Code, rec.Body.String())
 	}
-	var e V1Entity
+	var e v1.Entity
 	if err := json.NewDecoder(rec.Body).Decode(&e); err != nil {
 		t.Fatalf("decode GET: %v", err)
 	}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -32,143 +32,8 @@ import (
 
 // --- API v1 Types ---
 
-// V1Entity is the JSON representation of an entity for API v1.
-type V1Entity struct {
-	ID           string                 `json:"id"`
-	Type         string                 `json:"type"`
-	Title        string                 `json:"_title,omitempty"`
-	Properties   map[string]interface{} `json:"properties"`
-	Content      string                 `json:"content,omitempty"`
-	Relations    map[string][]string    `json:"relations,omitempty"`
-	Included     map[string]V1Entity    `json:"included,omitempty"`
-	Self         string                 `json:"_self,omitempty"`
-	Actions      map[string]bool        `json:"_actions,omitempty"`
-	Inaccessible []V1InaccessibleField  `json:"inaccessible,omitempty"`
-	// FieldAffordances carries per-field write affordances on per-entity
-	// GET responses. Sparse: only fields whose verdict deviates from the
-	// permissive default appear. Hidden fields are omitted from
-	// `Properties` AND from this map entirely. Pointer semantics
-	// distinguish "absent on the wire" (nil pointer; list / mutation
-	// responses) from "present and empty" (`{}`; per-entity GET with no
-	// deviations under nop resolver — closed-world signal matching the
-	// `_actions` precedent).
-	FieldAffordances *map[string]V1FieldAffordance `json:"_fields,omitempty"`
-	// RelationAffordances carries per-relation-type affordances on
-	// per-entity GET responses. Same pointer / closed-world semantics
-	// as FieldAffordances.
-	RelationAffordances *map[string]V1RelationAffordance `json:"_relations,omitempty"`
-	// Attachments maps a `file`-type property name to the LIST of files
-	// currently attached to it (a property may hold several when its
-	// metamodel `max` > 1). The value is always an array — even a
-	// single-attachment property reports a 1-element list — matching how
-	// rela's `list:` properties and `_relations` are always arrays. Only
-	// properties that actually carry a file appear. Same pointer /
-	// closed-world semantics as FieldAffordances: present (possibly empty)
-	// on every per-entity response (GET, PATCH, POST create, clone — the
-	// ones that run serializeEntityForWire), nil on list rows and other
-	// non-per-entity shapes. The SPA's file widget reads this to render the
-	// download links / previews instead of the raw stored path string(s).
-	Attachments *map[string][]V1Attachment `json:"_attachments,omitempty"`
-	// Warnings lists soft-condition findings surfaced by the write
-	// path. Populated only by mutation responses (PATCH); read paths
-	// leave it nil. Each warning has a stable `code`, an RFC 6901
-	// JSON Pointer `path`, and a human-readable `detail`.
-	Warnings []Warning `json:"warnings,omitempty"`
-}
-
-// V1FieldAffordance describes per-field write / option affordances on
-// the wire. Sparse: `Writable` is nil when the default (writable)
-// holds; `Options` lists only the false entries (allowed options are
-// implicit via the metamodel). See the closed-world contract in
-// docs/data-entry/api-reference.md.
-type V1FieldAffordance struct {
-	Writable *bool           `json:"writable,omitempty"`
-	Options  map[string]bool `json:"options,omitempty"`
-}
-
-// V1RelationAffordance describes per-relation-type affordances on the
-// wire. Sparse: `Creatable` and `Removable` are nil when the default
-// (true) holds. `Fields` lists meta-field writability overrides, also
-// sparse.
-type V1RelationAffordance struct {
-	Creatable *bool                        `json:"creatable,omitempty"`
-	Removable *bool                        `json:"removable,omitempty"`
-	Fields    map[string]V1FieldAffordance `json:"fields,omitempty"`
-}
-
-// V1Attachment describes one file attached to a `file`-type property, as
-// surfaced on a per-entity GET response. ID is the file's identifier
-// within the property (its normalized file name) — used to build the
-// per-file download/delete URL. Href is the download URL for the bytes (an
-// ACL-gated endpoint that inherits the owning entity's read permission).
-// ContentType is inferred from the filename — the store does not persist
-// it on every backend.
-type V1Attachment struct {
-	ID          string `json:"id"`
-	FileName    string `json:"filename"`
-	Size        int64  `json:"size"`
-	ContentType string `json:"contentType"`
-	Href        string `json:"href"`
-}
-
-// V1InaccessibleField describes a property that is known to exist but
-// whose value is unreadable by the holder of the entity (e.g. the file
-// is git-crypt encrypted and the key is not present locally).
-type V1InaccessibleField struct {
-	Name   string `json:"name"`
-	Reason string `json:"reason"`
-}
-
-// V1ListResponse is the response for listing entities.
-type V1ListResponse struct {
-	Data    []V1Entity      `json:"data"`
-	Meta    V1ListMeta      `json:"meta"`
-	Actions map[string]bool `json:"_actions,omitempty"`
-}
-
-// V1ListMeta contains pagination metadata.
-type V1ListMeta struct {
-	Total   int  `json:"total"`
-	Page    int  `json:"page"`
-	PerPage int  `json:"per_page"`
-	HasMore bool `json:"has_more"`
-}
-
-// V1Schema is the JSON representation of the metamodel.
-type V1Schema struct {
-	Entities  map[string]V1EntityType   `json:"entities"`
-	Relations map[string]V1RelationType `json:"relations"`
-	Types     map[string]V1CustomType   `json:"types,omitempty"`
-}
-
-// V1EntityType is the JSON representation of an entity type.
-type V1EntityType struct {
-	Label       string                   `json:"label"`
-	Plural      string                   `json:"plural"`
-	Description string                   `json:"description,omitempty"`
-	Primary     string                   `json:"primary,omitempty"`
-	IDType      string                   `json:"id_type,omitempty"`
-	IDPrefix    string                   `json:"id_prefix,omitempty"`
-	IDPrefixes  []string                 `json:"id_prefixes,omitempty"`
-	Properties  map[string]V1PropertyDef `json:"properties"`
-}
-
-// V1PropertyDef is the JSON representation of a property definition.
-type V1PropertyDef struct {
-	Type        string   `json:"type"`
-	Required    bool     `json:"required"`
-	Default     string   `json:"default,omitempty"`
-	Values      []string `json:"values,omitempty"`
-	Description string   `json:"description,omitempty"`
-	List        bool     `json:"list,omitempty"`
-	// Max is the attachment cap for a `file` property (default 1). The SPA's
-	// file widget reads it to switch between replace-mode and multi-file
-	// add-mode. Omitted unless set above 1.
-	Max int `json:"max,omitempty"`
-}
-
-func (a *App) toV1PropertyDef(meta *metamodel.Metamodel, propDef metamodel.PropertyDef) V1PropertyDef {
-	pd := V1PropertyDef{
+func (a *App) toV1PropertyDef(meta *metamodel.Metamodel, propDef metamodel.PropertyDef) v1.PropertyDef {
+	pd := v1.PropertyDef{
 		Type:        propDef.Type,
 		Required:    propDef.Required,
 		Default:     propDef.Default,
@@ -182,104 +47,6 @@ func (a *App) toV1PropertyDef(meta *metamodel.Metamodel, propDef metamodel.Prope
 		pd.Values = propDef.Values
 	}
 	return pd
-}
-
-// V1RelationType is the JSON representation of a relation type.
-type V1RelationType struct {
-	Label       string                   `json:"label"`
-	Description string                   `json:"description,omitempty"`
-	From        []string                 `json:"from"`
-	To          []string                 `json:"to"`
-	Inverse     *V1InverseDef            `json:"inverse,omitempty"`
-	Symmetric   bool                     `json:"symmetric,omitempty"`
-	MinOutgoing *int                     `json:"min_outgoing,omitempty"`
-	MaxOutgoing *int                     `json:"max_outgoing,omitempty"`
-	MinIncoming *int                     `json:"min_incoming,omitempty"`
-	MaxIncoming *int                     `json:"max_incoming,omitempty"`
-	Properties  map[string]V1PropertyDef `json:"properties,omitempty"`
-	// Orderable, when set, declares that the frontend may offer drag-to-reorder
-	// controls on the corresponding side. The managed property names are
-	// always the reserved `_order_out` (outgoing) and `_order_in` (incoming).
-	Orderable *V1RelationOrderable `json:"orderable,omitempty"`
-}
-
-// V1RelationOrderable describes per-side orderability for a relation type.
-type V1RelationOrderable struct {
-	Outgoing bool `json:"outgoing,omitempty"`
-	Incoming bool `json:"incoming,omitempty"`
-}
-
-// V1InverseDef mirrors metamodel.InverseDef on the wire. The SPA reads
-// `inverse.id` to find the inverse body key for incoming-direction
-// edits routed through the unified PATCH (TKT-GFQK).
-type V1InverseDef struct {
-	ID    string `json:"id"`
-	Label string `json:"label,omitempty"`
-}
-
-// V1CustomType is the JSON representation of a custom type.
-type V1CustomType struct {
-	Values  []string `json:"values"`
-	Default string   `json:"default,omitempty"`
-}
-
-// V1Config is the JSON representation of the UI config.
-type V1Config struct {
-	App         V1AppConfig                                 `json:"app"`
-	Styles      map[string]map[string]string                `json:"styles"`
-	Forms       map[string]dataentryconfig.Form             `json:"forms"`
-	Lists       map[string]dataentryconfig.List             `json:"lists"`
-	Views       map[string]dataentryconfig.ViewConfig       `json:"views"`
-	EntityViews map[string]dataentryconfig.EntityViewConfig `json:"entity_views,omitempty"`
-	Kanbans     map[string]dataentryconfig.Kanban           `json:"kanbans"`
-	Dashboard   *dataentryconfig.DashboardConfig            `json:"dashboard,omitempty"`
-	Actions     map[string]dataentryconfig.Action           `json:"actions,omitempty"`
-	Navigation  []dataentryconfig.NavigationEntry           `json:"navigation"`
-	Documents   map[string]dataentryconfig.DocumentConfig   `json:"documents,omitempty"`
-	Apps        map[string]V1App                            `json:"apps,omitempty"`
-	Palette     *dataentryconfig.ResolvedPalette            `json:"palette,omitempty"`
-}
-
-// V1App is the client-facing view of a custom app. It deliberately omits the
-// on-disk File path and the csp_origins allow-list — the SPA only needs enough
-// to render a sidebar entry and route to /app/{id}; the HTML is fetched from
-// GET /api/v1/_apps/{id}.
-type V1App struct {
-	Title       string `json:"title,omitempty"`
-	Label       string `json:"label,omitempty"`
-	Description string `json:"description,omitempty"`
-}
-
-// V1AppConfig is the JSON representation of the app config.
-type V1AppConfig struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	// PlantUMLServerURL is the configured PlantUML server base URL, or empty
-	// when PlantUML rendering is disabled. The SPA treats a non-empty value as
-	// the on switch for ```plantuml diagram rendering.
-	PlantUMLServerURL string `json:"plantuml_server_url,omitempty"`
-}
-
-// V1Error is an RFC 7807 Problem Details response.
-type V1Error struct {
-	Type     string         `json:"type"`
-	Title    string         `json:"title"`
-	Status   int            `json:"status"`
-	Detail   string         `json:"detail,omitempty"`
-	Instance string         `json:"instance,omitempty"`
-	Errors   []V1FieldError `json:"errors,omitempty"`
-}
-
-// V1FieldError represents a validation error on a specific field.
-type V1FieldError struct {
-	Source V1ErrorSource `json:"source"`
-	Code   string        `json:"code"`
-	Detail string        `json:"detail"`
-}
-
-// V1ErrorSource points to the location of an error.
-type V1ErrorSource struct {
-	Pointer string `json:"pointer"`
 }
 
 // --- API v1 Router ---
@@ -548,8 +315,8 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 	wantIncludes := includes != ""
 
 	// Build response - always include relations for relation column support
-	data := make([]V1Entity, 0, len(entities))
-	included := make(map[string]V1Entity)
+	data := make([]v1.Entity, 0, len(entities))
+	included := make(map[string]v1.Entity)
 	for _, e := range entities {
 		v1Entity := a.serializer.forWireRelated(r.Context(), e, a.reader.outgoingRelations(r.Context(), e.ID), a.Meta(), plural)
 		data = append(data, v1Entity)
@@ -562,9 +329,9 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 		}
 	}
 
-	resp := V1ListResponse{
+	resp := v1.ListResponse{
 		Data: data,
-		Meta: V1ListMeta{
+		Meta: v1.ListMeta{
 			Total:   total,
 			Page:    page,
 			PerPage: perPage,
@@ -585,10 +352,10 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 		// For list responses with includes, we need a different response structure
 		// Encode as JSON with additional "included" field
 		type listWithIncludes struct {
-			Data     []V1Entity          `json:"data"`
-			Meta     V1ListMeta          `json:"meta"`
-			Included map[string]V1Entity `json:"included,omitempty"`
-			Actions  map[string]bool     `json:"_actions,omitempty"`
+			Data     []v1.Entity          `json:"data"`
+			Meta     v1.ListMeta          `json:"meta"`
+			Included map[string]v1.Entity `json:"included,omitempty"`
+			Actions  map[string]bool      `json:"_actions,omitempty"`
 		}
 		writeV1JSON(w, http.StatusOK, listWithIncludes{
 			Data:     resp.Data,
@@ -1652,20 +1419,20 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s := a.State()
-	schema := V1Schema{
-		Entities:  make(map[string]V1EntityType),
-		Relations: make(map[string]V1RelationType),
-		Types:     make(map[string]V1CustomType),
+	schema := v1.Schema{
+		Entities:  make(map[string]v1.EntityType),
+		Relations: make(map[string]v1.RelationType),
+		Types:     make(map[string]v1.CustomType),
 	}
 
 	for name, def := range s.Meta.Entities {
-		et := V1EntityType{
+		et := v1.EntityType{
 			Label:       def.Label,
 			Plural:      def.GetPlural(name),
 			Description: def.Description,
 			Primary:     def.GetPrimaryProperty(),
 			IDType:      def.GetIDType(),
-			Properties:  make(map[string]V1PropertyDef),
+			Properties:  make(map[string]v1.PropertyDef),
 		}
 		prefixes := def.GetIDPrefixes()
 		if len(prefixes) > 0 {
@@ -1679,7 +1446,7 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for name, def := range s.Meta.Relations {
-		rt := V1RelationType{
+		rt := v1.RelationType{
 			Label:       def.Label,
 			Description: def.Description,
 			From:        def.From,
@@ -1691,16 +1458,16 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 			MaxIncoming: def.MaxIncoming,
 		}
 		if def.Inverse != nil && def.Inverse.ID != "" {
-			rt.Inverse = &V1InverseDef{ID: def.Inverse.ID, Label: def.Inverse.Label}
+			rt.Inverse = &v1.InverseDef{ID: def.Inverse.ID, Label: def.Inverse.Label}
 		}
 		if len(def.Properties) > 0 {
-			rt.Properties = make(map[string]V1PropertyDef, len(def.Properties))
+			rt.Properties = make(map[string]v1.PropertyDef, len(def.Properties))
 			for propName, propDef := range def.Properties {
 				rt.Properties[propName] = a.toV1PropertyDef(s.Meta, propDef)
 			}
 		}
 		if def.OutgoingOrderProperty() != "" || def.IncomingOrderProperty() != "" {
-			rt.Orderable = &V1RelationOrderable{
+			rt.Orderable = &v1.RelationOrderable{
 				Outgoing: def.OutgoingOrderProperty() != "",
 				Incoming: def.IncomingOrderProperty() != "",
 			}
@@ -1709,7 +1476,7 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for name, def := range s.Meta.Types {
-		schema.Types[name] = V1CustomType{
+		schema.Types[name] = v1.CustomType{
 			Values:  def.Values,
 			Default: def.Default,
 		}
@@ -1740,13 +1507,13 @@ func (a *App) handleV1SchemaRoutes(w http.ResponseWriter, r *http.Request) {
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity type not found", "")
 			return
 		}
-		et := V1EntityType{
+		et := v1.EntityType{
 			Label:       def.Label,
 			Plural:      def.GetPlural(typeName),
 			Description: def.Description,
 			Primary:     def.GetPrimaryProperty(),
 			IDType:      def.GetIDType(),
-			Properties:  make(map[string]V1PropertyDef),
+			Properties:  make(map[string]v1.PropertyDef),
 		}
 		if prefixes := def.GetIDPrefixes(); len(prefixes) > 0 {
 			et.IDPrefix = prefixes[0]
@@ -1788,8 +1555,8 @@ func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
 		forms[id] = f
 	}
 
-	config := V1Config{
-		App: V1AppConfig{
+	config := v1.Config{
+		App: v1.AppConfig{
 			Name:              s.Cfg.App.Name,
 			Description:       s.Cfg.App.Description,
 			PlantUMLServerURL: s.Cfg.App.PlantUMLServerURL,
@@ -1819,7 +1586,7 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 
 	query := r.URL.Query().Get("q")
 	if query == "" {
-		writeV1JSON(w, http.StatusOK, V1ListResponse{Data: []V1Entity{}, Meta: V1ListMeta{}})
+		writeV1JSON(w, http.StatusOK, v1.ListResponse{Data: []v1.Entity{}, Meta: v1.ListMeta{}})
 		return
 	}
 
@@ -1844,7 +1611,7 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 	}
 
 	meta := a.State().Meta
-	data := make([]V1Entity, 0, len(entities))
+	data := make([]v1.Entity, 0, len(entities))
 	for _, e := range entities {
 		entityDef := meta.Entities[e.Type]
 		plural := entityDef.GetPlural(e.Type)
@@ -1856,9 +1623,9 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 		data = append(data, a.serializer.forWireRelated(r.Context(), e, nil, a.Meta(), plural))
 	}
 
-	resp := V1ListResponse{
+	resp := v1.ListResponse{
 		Data: data,
-		Meta: V1ListMeta{
+		Meta: v1.ListMeta{
 			Total:   len(data),
 			Page:    1,
 			PerPage: len(data),
@@ -1988,9 +1755,9 @@ func (a *App) visibleAnalysisIssues(ctx context.Context, sections []AnalysisSect
 
 // --- Helper Functions ---
 
-func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, includes string) map[string]V1Entity {
+func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, includes string) map[string]v1.Entity {
 	s := a.State()
-	included := make(map[string]V1Entity)
+	included := make(map[string]v1.Entity)
 
 	// Collect candidate target entities first; filter via the ACL
 	// gate per-type (batched), then serialize the survivors. The
@@ -2392,7 +2159,7 @@ func writeV1Error(w http.ResponseWriter, r *http.Request, status int, errType, t
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(status)
 
-	err := V1Error{
+	err := v1.Error{
 		Type:     "https://rela.dev/errors/" + errType,
 		Title:    title,
 		Status:   status,
@@ -2404,48 +2171,6 @@ func writeV1Error(w http.ResponseWriter, r *http.Request, status int, errType, t
 }
 
 // --- Side Panel API ---
-
-// V1SidePanelSection represents a section in the side panel response.
-type V1SidePanelSection struct {
-	Heading      string              `json:"heading"`
-	SectionID    string              `json:"sectionId"`
-	Display      string              `json:"display"`
-	IsEmpty      bool                `json:"isEmpty"`
-	EmptyMessage string              `json:"emptyMessage,omitempty"`
-	Fields       []V1SectionField    `json:"fields,omitempty"`
-	Entities     []V1SidePanelEntity `json:"entities,omitempty"`
-	AddInfo      *V1ViewAddInfo      `json:"addInfo,omitempty"`
-	LinkInfo     *V1ViewLinkInfo     `json:"linkInfo,omitempty"`
-}
-
-// V1SectionField represents a field in a side panel section.
-// Values is always an array so that list-typed properties retain per-item
-// structure; scalar properties become a one-element array. Empty fields emit
-// an empty array (omitted via omitempty when nil).
-//
-// Property carries the raw property name so consumers can correlate the
-// field with metamodel data (e.g. inaccessibility lookup); Label is the
-// human-readable rendering. Inaccessible is true when the underlying entity
-// is git-crypt encrypted — the field is known to exist in the schema but
-// its value cannot be read.
-type V1SectionField struct {
-	Property     string   `json:"property,omitempty"`
-	Label        string   `json:"label"`
-	Values       []string `json:"values,omitempty"`
-	PropType     string   `json:"propType,omitempty"`
-	Inaccessible bool     `json:"inaccessible,omitempty"`
-}
-
-// V1SidePanelEntity represents an entity in a side panel section.
-type V1SidePanelEntity struct {
-	ID         string           `json:"id"`
-	Title      string           `json:"title"`
-	Type       string           `json:"type"`
-	EditFormID string           `json:"editFormId,omitempty"`
-	Fields     []V1SectionField `json:"fields,omitempty"`
-	Content    string           `json:"content,omitempty"`
-	HasContent bool             `json:"hasContent"`
-}
 
 // handleV1SidePanel handles GET /api/v1/_sidepanel/{formId}/{entityId}.
 func (a *App) handleV1SidePanel(w http.ResponseWriter, r *http.Request) {
@@ -2473,7 +2198,7 @@ func (a *App) handleV1SidePanel(w http.ResponseWriter, r *http.Request) {
 
 	// Check if form has side panel
 	if form.SidePanel == nil {
-		writeV1JSON(w, http.StatusOK, []V1SidePanelSection{})
+		writeV1JSON(w, http.StatusOK, []v1.SidePanelSection{})
 		return
 	}
 
@@ -2495,7 +2220,7 @@ func (a *App) handleV1SidePanel(w http.ResponseWriter, r *http.Request) {
 	// Execute side panel traversal
 	sections := a.executeSidePanel(r.Context(), form.SidePanel, entityID, form.EntityType)
 	if sections == nil {
-		writeV1JSON(w, http.StatusOK, []V1SidePanelSection{})
+		writeV1JSON(w, http.StatusOK, []v1.SidePanelSection{})
 		return
 	}
 
@@ -2508,9 +2233,9 @@ func (a *App) handleV1SidePanel(w http.ResponseWriter, r *http.Request) {
 	a.resolveSectionButtonsWithTraverse(viewConfig, sections, entry)
 
 	// Convert to API response format
-	result := make([]V1SidePanelSection, 0, len(sections))
+	result := make([]v1.SidePanelSection, 0, len(sections))
 	for _, sec := range sections {
-		apiSec := V1SidePanelSection{
+		apiSec := v1.SidePanelSection{
 			Heading:      sec.Heading,
 			SectionID:    sec.SectionID,
 			Display:      sec.Display,
@@ -2520,12 +2245,12 @@ func (a *App) handleV1SidePanel(w http.ResponseWriter, r *http.Request) {
 
 		// Convert fields
 		for _, f := range sec.Fields {
-			apiSec.Fields = append(apiSec.Fields, V1SectionField(f))
+			apiSec.Fields = append(apiSec.Fields, v1.SectionField(f))
 		}
 
 		// Convert entities
 		for _, e := range sec.Entities {
-			apiEnt := V1SidePanelEntity{
+			apiEnt := v1.SidePanelEntity{
 				ID:         e.ID,
 				Title:      e.Title,
 				Type:       e.Type,
@@ -2534,24 +2259,24 @@ func (a *App) handleV1SidePanel(w http.ResponseWriter, r *http.Request) {
 				HasContent: e.HasContent,
 			}
 			for _, f := range e.Fields {
-				apiEnt.Fields = append(apiEnt.Fields, V1SectionField(f))
+				apiEnt.Fields = append(apiEnt.Fields, v1.SectionField(f))
 			}
 			apiSec.Entities = append(apiSec.Entities, apiEnt)
 		}
 
 		// Convert add/link info
 		if sec.AddInfo != nil {
-			apiSec.AddInfo = &V1ViewAddInfo{
+			apiSec.AddInfo = &v1.ViewAddInfo{
 				Relation: sec.AddInfo.Relation,
 				LinkAs:   sec.AddInfo.LinkAs,
 				PeerID:   sec.AddInfo.PeerID,
 			}
 			for _, t := range sec.AddInfo.Targets {
-				apiSec.AddInfo.Targets = append(apiSec.AddInfo.Targets, V1ViewAddTarget(t))
+				apiSec.AddInfo.Targets = append(apiSec.AddInfo.Targets, v1.ViewAddTarget(t))
 			}
 		}
 		if sec.LinkInfo != nil {
-			apiSec.LinkInfo = &V1ViewLinkInfo{
+			apiSec.LinkInfo = &v1.ViewLinkInfo{
 				Relation:    sec.LinkInfo.Relation,
 				LinkAs:      sec.LinkInfo.LinkAs,
 				PeerID:      sec.LinkInfo.PeerID,
@@ -2567,33 +2292,6 @@ func (a *App) handleV1SidePanel(w http.ResponseWriter, r *http.Request) {
 
 // --- Sidebar API ---
 
-// V1SidebarItem represents a navigation item with count.
-type V1SidebarItem struct {
-	Label  string `json:"label"`
-	Href   string `json:"href"`
-	Icon   string `json:"icon,omitempty"`
-	Count  *int   `json:"count,omitempty"`
-	Action string `json:"action,omitempty"`
-}
-
-// V1SidebarGroup represents a navigation group with items.
-type V1SidebarGroup struct {
-	Group     string          `json:"group,omitempty"`
-	Collapsed bool            `json:"collapsed,omitempty"`
-	Items     []V1SidebarItem `json:"items"`
-}
-
-// V1SidebarResponse contains the sidebar data with app info and navigation.
-type V1SidebarResponse struct {
-	App        V1AppConfig      `json:"app"`
-	Navigation []V1SidebarGroup `json:"navigation"`
-	// LogoURL is the cache-busted URL of the user-uploaded sidebar logo,
-	// or nil when no logo is set. Included here (rather than in
-	// `_settings`) so the SPA can render the logo on first paint without
-	// blocking on a settings fetch.
-	LogoURL *string `json:"logoUrl,omitempty"`
-}
-
 // handleV1Sidebar returns denormalized sidebar data with entity counts.
 func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -2608,14 +2306,14 @@ func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build navigation with counts
-	navigation := make([]V1SidebarGroup, 0)
+	navigation := make([]v1.SidebarGroup, 0)
 
 	for _, entry := range s.Cfg.Navigation {
 		if entry.IsGroup() {
-			group := V1SidebarGroup{
+			group := v1.SidebarGroup{
 				Group:     entry.Group,
 				Collapsed: entry.Collapsed,
-				Items:     make([]V1SidebarItem, 0),
+				Items:     make([]v1.SidebarItem, 0),
 			}
 			for _, item := range entry.Items {
 				sidebarItem := a.navEntryToSidebarItem(r.Context(), item, counts)
@@ -2625,14 +2323,14 @@ func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 		} else {
 			// Top-level item without group
 			item := a.navEntryToSidebarItem(r.Context(), entry, counts)
-			navigation = append(navigation, V1SidebarGroup{
-				Items: []V1SidebarItem{item},
+			navigation = append(navigation, v1.SidebarGroup{
+				Items: []v1.SidebarItem{item},
 			})
 		}
 	}
 
-	resp := V1SidebarResponse{
-		App: V1AppConfig{
+	resp := v1.SidebarResponse{
+		App: v1.AppConfig{
 			Name:        s.Cfg.App.Name,
 			Description: s.Cfg.App.Description,
 		},
@@ -2734,9 +2432,9 @@ func (c *sidebarCounts) countWithFilters(ctx context.Context, entityType string,
 }
 
 // navEntryToSidebarItem converts a navigation entry to a sidebar item with count.
-func (a *App) navEntryToSidebarItem(ctx context.Context, entry dataentryconfig.NavigationEntry, counts sidebarCounts) V1SidebarItem {
+func (a *App) navEntryToSidebarItem(ctx context.Context, entry dataentryconfig.NavigationEntry, counts sidebarCounts) v1.SidebarItem {
 	s := a.State()
-	item := V1SidebarItem{
+	item := v1.SidebarItem{
 		Label: entry.Label,
 	}
 
@@ -2774,47 +2472,6 @@ func (a *App) navEntryToSidebarItem(ctx context.Context, entry dataentryconfig.N
 
 // --- Conflicts API ---
 
-// V1ConflictItem represents a conflicted file.
-type V1ConflictItem struct {
-	Path        string `json:"path"`
-	EntityType  string `json:"entity_type,omitempty"`
-	EntityID    string `json:"entity_id,omitempty"`
-	MarkerCount int    `json:"marker_count"`
-}
-
-// V1ConflictsResponse contains the list of conflicts.
-type V1ConflictsResponse struct {
-	Conflicts []V1ConflictItem `json:"conflicts"`
-	Count     int              `json:"count"`
-}
-
-// V1PropertyDiff represents a property difference.
-type V1PropertyDiff struct {
-	Property    string `json:"property"`
-	OursValue   string `json:"ours_value"`
-	TheirsValue string `json:"theirs_value"`
-	IsSame      bool   `json:"is_same"`
-}
-
-// V1ConflictDetail contains detailed info for resolving a conflict.
-type V1ConflictDetail struct {
-	Path          string           `json:"path"`
-	EntityType    string           `json:"entity_type,omitempty"`
-	EntityID      string           `json:"entity_id,omitempty"`
-	PropertyDiffs []V1PropertyDiff `json:"property_diffs"`
-	ContentSame   bool             `json:"content_same"`
-	ContentOurs   string           `json:"content_ours,omitempty"`
-	ContentTheirs string           `json:"content_theirs,omitempty"`
-}
-
-// V1ConflictResolveRequest contains the resolution choices.
-type V1ConflictResolveRequest struct {
-	Path            string            `json:"path"`
-	PropertyChoices map[string]string `json:"property_choices"`
-	ContentChoice   string            `json:"content_choice"`
-	ManualContent   string            `json:"manual_content,omitempty"`
-}
-
 // handleV1Conflicts returns the list of conflicted files as JSON.
 func (a *App) handleV1Conflicts(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -2834,10 +2491,10 @@ func (a *App) handleV1Conflicts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := make([]V1ConflictItem, 0, len(result.Files))
+	items := make([]v1.ConflictItem, 0, len(result.Files))
 	for _, cf := range result.Files {
 		relPath, _ := filepath.Rel(ctx.Root, cf.Path)
-		items = append(items, V1ConflictItem{
+		items = append(items, v1.ConflictItem{
 			Path:        relPath,
 			EntityType:  cf.EntityType,
 			EntityID:    cf.EntityID,
@@ -2845,7 +2502,7 @@ func (a *App) handleV1Conflicts(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	writeV1JSON(w, http.StatusOK, V1ConflictsResponse{
+	writeV1JSON(w, http.StatusOK, v1.ConflictsResponse{
 		Conflicts: items,
 		Count:     len(items),
 	})
@@ -2880,9 +2537,9 @@ func (a *App) handleV1ConflictRoutes(w http.ResponseWriter, r *http.Request) {
 
 	info := conflict.AnalyzeConflict(cf)
 
-	diffs := make([]V1PropertyDiff, 0, len(info.PropertyDiffs))
+	diffs := make([]v1.PropertyDiff, 0, len(info.PropertyDiffs))
 	for _, d := range info.PropertyDiffs {
-		diffs = append(diffs, V1PropertyDiff{
+		diffs = append(diffs, v1.PropertyDiff{
 			Property:    d.Property,
 			OursValue:   fmt.Sprintf("%v", d.OursValue),
 			TheirsValue: fmt.Sprintf("%v", d.TheirsValue),
@@ -2890,7 +2547,7 @@ func (a *App) handleV1ConflictRoutes(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	detail := V1ConflictDetail{
+	detail := v1.ConflictDetail{
 		Path:          path,
 		EntityType:    cf.EntityType,
 		EntityID:      cf.EntityID,
@@ -2905,7 +2562,7 @@ func (a *App) handleV1ConflictRoutes(w http.ResponseWriter, r *http.Request) {
 
 // handleV1ConflictResolve applies a conflict resolution.
 func (a *App) handleV1ConflictResolve(w http.ResponseWriter, r *http.Request) {
-	var req V1ConflictResolveRequest
+	var req v1.ConflictResolveRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeV1Error(w, r, http.StatusBadRequest, "invalid_request", "Invalid JSON", err.Error())
 		return
@@ -3077,13 +2734,6 @@ func (a *App) recordConflictResolveAudit(ctx context.Context, relPath string, e 
 
 // --- Documents API ---
 
-// V1DocumentResponse contains the rendered document content.
-type V1DocumentResponse struct {
-	HTML      string   `json:"html"`
-	Cached    bool     `json:"cached"`
-	EntityIDs []string `json:"entity_ids"` // IDs of entities involved in this document (for SSE filtering)
-}
-
 // handleV1Documents handles GET /api/v1/_documents/{docName}/{entityId}.
 // Returns JSON with rendered HTML content for Vue SPA consumption.
 func (a *App) handleV1Documents(w http.ResponseWriter, r *http.Request) {
@@ -3167,7 +2817,7 @@ func (a *App) handleV1Documents(w http.ResponseWriter, r *http.Request) {
 		result := a.documents.GetCached(r.Context(), entityID)
 		if result != nil {
 			html := RewriteDocumentLinks(result.HTML, returnPath, nil)
-			writeV1JSON(w, http.StatusOK, V1DocumentResponse{
+			writeV1JSON(w, http.StatusOK, v1.DocumentResponse{
 				HTML:      html,
 				Cached:    true,
 				EntityIDs: extractEntityIDs(result.Entities),
@@ -3193,7 +2843,7 @@ func (a *App) handleV1Documents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	html := RewriteDocumentLinks(result.HTML, returnPath, nil)
-	writeV1JSON(w, http.StatusOK, V1DocumentResponse{
+	writeV1JSON(w, http.StatusOK, v1.DocumentResponse{
 		HTML:      html,
 		Cached:    false,
 		EntityIDs: extractEntityIDs(result.Entities),
@@ -3210,15 +2860,6 @@ func extractEntityIDs(entities []*entityPkg.Entity) []string {
 }
 
 // --- Commands API ---
-
-// V1Command is the JSON representation of an available command.
-type V1Command struct {
-	ID       string `json:"id"`
-	Label    string `json:"label"`
-	Confirm  string `json:"confirm,omitempty"`
-	Context  string `json:"context"`
-	AutoOpen *bool  `json:"auto_open,omitempty"`
-}
 
 // handleV1Commands returns available commands for a given page context.
 // Query params:
@@ -3238,26 +2879,12 @@ func (a *App) handleV1Commands(w http.ResponseWriter, r *http.Request) {
 
 	resolved := a.resolveCommands(pageType, qualifier, entityType)
 
-	commands := make([]V1Command, 0, len(resolved))
+	commands := make([]v1.Command, 0, len(resolved))
 	for _, cmd := range resolved {
-		commands = append(commands, V1Command(cmd))
+		commands = append(commands, v1.Command(cmd))
 	}
 
 	writeV1JSON(w, http.StatusOK, commands)
-}
-
-// V1Template represents a template for API responses.
-type V1Template struct {
-	Name       string                 `json:"name"`
-	Properties map[string]interface{} `json:"properties"`
-	Content    string                 `json:"content"`
-	Relations  []V1TemplateRelation   `json:"relations"`
-}
-
-// V1TemplateRelation represents a pre-filled relation in a template.
-type V1TemplateRelation struct {
-	Relation string `json:"relation"`
-	Target   string `json:"target"`
 }
 
 // handleV1Templates returns templates for an entity type.
@@ -3283,17 +2910,17 @@ func (a *App) handleV1Templates(w http.ResponseWriter, r *http.Request) {
 	}
 
 	templates, _ := a.templater.EntityTemplates(r.Context(), entityType)
-	result := make([]V1Template, 0, len(templates))
+	result := make([]v1.Template, 0, len(templates))
 
 	for _, t := range templates {
-		relations := make([]V1TemplateRelation, 0, len(t.Relations))
+		relations := make([]v1.TemplateRelation, 0, len(t.Relations))
 		for _, rel := range t.Relations {
-			relations = append(relations, V1TemplateRelation{
+			relations = append(relations, v1.TemplateRelation{
 				Relation: rel.Type,
 				Target:   rel.Target,
 			})
 		}
-		result = append(result, V1Template{
+		result = append(result, v1.Template{
 			Name:       t.Name,
 			Properties: t.Properties,
 			Content:    t.Content,
@@ -3326,82 +2953,13 @@ func (a *App) handleV1OpenAPI(w http.ResponseWriter, r *http.Request) {
 
 // --- Views API ---
 
-// V1ViewResponse contains the executed view data.
-//
-// Mentions carries the implicit-relation set discovered by scanning the
-// entry and section markdown contents for bare-content entity-ID code
-// spans (see collectMentions). The SPA's markdown renderer consumes this
-// map to rewrite those code spans into titled in-app links. Mirrors the
-// Lua-side `rela.md.entity_refs` shape (TKT-LXYHQ) for SPA consumers
-// that don't go through the Lua document path.
-//
-// Wire stability: `mentions` is part of the public v1 API. The set of
-// `inaccessible_reason` values may grow as new locking mechanisms are
-// added (today: `git-crypt`); clients must treat unknown reasons as
-// opaque rather than enumerating them.
-type V1ViewResponse struct {
-	Entry    V1Entity           `json:"entry"`
-	Sections []V1ViewSection    `json:"sections"`
-	Mentions map[string]Mention `json:"mentions,omitempty"`
-}
-
-// V1ViewSection represents a section with resolved data.
-type V1ViewSection struct {
-	Heading      string           `json:"heading"`
-	SectionID    string           `json:"sectionId"`
-	Display      string           `json:"display"`
-	IsEmpty      bool             `json:"isEmpty"`
-	EmptyMessage string           `json:"emptyMessage,omitempty"`
-	Fields       []V1SectionField `json:"fields,omitempty"`
-	Entities     []V1ViewEntity   `json:"entities,omitempty"`
-	Columns      []V1ViewColumn   `json:"columns,omitempty"`
-	Rows         []V1ViewRow      `json:"rows,omitempty"`
-	Groups       []V1ViewGroup    `json:"groups,omitempty"`
-	IsGrouped    bool             `json:"isGrouped"`
-	Content      string           `json:"content,omitempty"`
-	HasContent   bool             `json:"hasContent"`
-}
-
-// V1ViewEntity represents an entity in a view section.
-//
-// Props and FieldAffordances (TKT-IHC7D) carry the typed property
-// values and per-cell writability verdict that inline-edit hosts on
-// cards/list view sections consume. Both are hidden-property-stripped
-// — the consumer can assume:
-//
-//   - `keys(Props) ∩ hidden(e) == ∅` (hidden properties never leak via
-//     this surface)
-//   - `keys(FieldAffordances) ∩ hidden(e) == ∅` (same for the verdict)
-//   - `FieldAffordances` may have keys absent from `Props` when the
-//     property has no stored value but a non-default verdict (e.g.
-//     `writable: false` on an unset field)
-//
-// The pointer-to-map idiom on `FieldAffordances` mirrors
-// `V1Entity.FieldAffordances`: `nil` means "absent on the wire"
-// (table rows / non-cards paths), `&{}` means "evaluated, no
-// deviations" (closed-world signal matching `_actions`).
-//
-// `Props` is a plain map with `omitempty`: presence/absence is
-// sufficient, no closed-world semantic is needed.
-type V1ViewEntity struct {
-	ID               string                        `json:"id"`
-	Title            string                        `json:"title"`
-	Type             string                        `json:"type"`
-	EditFormID       string                        `json:"editFormId,omitempty"`
-	Fields           []V1SectionField              `json:"fields,omitempty"`
-	Content          string                        `json:"content,omitempty"`
-	HasContent       bool                          `json:"hasContent"`
-	Props            map[string]any                `json:"_props,omitempty"`
-	FieldAffordances *map[string]V1FieldAffordance `json:"_fields,omitempty"`
-}
-
 // sectionEntityToV1 lifts a section's row entity (template-side data)
-// onto the wire shape. Centralizes the `V1ViewEntity` construction so
+// onto the wire shape. Centralizes the `v1.ViewEntity` construction so
 // the typed `_props` and per-row `_fields` (TKT-IHC7D) stay consistent
 // across both the top-level entities path and the (currently dormant)
 // grouped-card entities path.
-func sectionEntityToV1(e SectionEntityData) V1ViewEntity {
-	v1Ent := V1ViewEntity{
+func sectionEntityToV1(e SectionEntityData) v1.ViewEntity {
+	v1Ent := v1.ViewEntity{
 		ID:         e.ID,
 		Title:      e.Title,
 		Type:       e.Type,
@@ -3411,76 +2969,13 @@ func sectionEntityToV1(e SectionEntityData) V1ViewEntity {
 		Props:      e.Props,
 	}
 	for _, f := range e.Fields {
-		v1Ent.Fields = append(v1Ent.Fields, V1SectionField(f))
+		v1Ent.Fields = append(v1Ent.Fields, v1.SectionField(f))
 	}
 	if e.FieldVerdicts != nil {
 		fa := e.FieldVerdicts
 		v1Ent.FieldAffordances = &fa
 	}
 	return v1Ent
-}
-
-// V1ViewColumn represents a column definition.
-type V1ViewColumn struct {
-	Property string `json:"property,omitempty"`
-	Label    string `json:"label,omitempty"`
-	Relation string `json:"relation,omitempty"`
-	Link     string `json:"link,omitempty"`
-}
-
-// V1ViewRow represents a table row.
-type V1ViewRow struct {
-	EntityID   string       `json:"entityId"`
-	EntityType string       `json:"entityType"`
-	EditFormID string       `json:"editFormId,omitempty"`
-	Cells      []V1ViewCell `json:"cells"`
-	Content    string       `json:"content,omitempty"`
-}
-
-// V1ViewCell represents a table cell.
-type V1ViewCell struct {
-	Values     []string `json:"values"`
-	PropType   string   `json:"propType,omitempty"`
-	Widget     string   `json:"widget,omitempty"`
-	Link       string   `json:"link,omitempty"`
-	EntityID   string   `json:"entityId,omitempty"`
-	EntityType string   `json:"entityType,omitempty"`
-}
-
-// V1ViewGroup represents a group of rows.
-type V1ViewGroup struct {
-	GroupName string         `json:"groupName"`
-	Rows      []V1ViewRow    `json:"rows,omitempty"`
-	Entities  []V1ViewEntity `json:"entities,omitempty"`
-}
-
-// V1ViewAddInfo describes an add button configuration. Despite the "View"
-// prefix this is now used only by V1SidePanelSection — see TKT-6ETQ for
-// the rename to V1SidePanelAddInfo. Do not reach for this type from a new
-// view-related response: the read-only-view invariant established by
-// TKT-651W means no view section should carry add affordances.
-type V1ViewAddInfo struct {
-	Relation string            `json:"relation"`
-	LinkAs   string            `json:"linkAs"`
-	PeerID   string            `json:"peerId"`
-	Targets  []V1ViewAddTarget `json:"targets"`
-}
-
-// V1ViewAddTarget represents a possible target for add action.
-// Side-panel-only post TKT-651W; see TKT-6ETQ for the rename plan.
-type V1ViewAddTarget struct {
-	EntityType string `json:"entityType"`
-	FormID     string `json:"formId"`
-	Label      string `json:"label"`
-}
-
-// V1ViewLinkInfo describes a link existing button configuration.
-// Side-panel-only post TKT-651W; see TKT-6ETQ for the rename plan.
-type V1ViewLinkInfo struct {
-	Relation    string   `json:"relation"`
-	LinkAs      string   `json:"linkAs"`
-	PeerID      string   `json:"peerId"`
-	EntityTypes []string `json:"entityTypes"`
 }
 
 // handleV1Views handles GET /api/v1/_views/{entityType}/{entityId}.
@@ -3546,13 +3041,13 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 	entityDef := s.Meta.Entities[result.Entry.Type]
 	plural := entityDef.GetPlural(result.Entry.Type)
 
-	resp := V1ViewResponse{
+	resp := v1.ViewResponse{
 		Entry:    a.serializer.forWire(r.Context(), result.Entry, a.reader.outgoingRelations(r.Context(), result.Entry.ID), a.Meta(), plural),
-		Sections: make([]V1ViewSection, 0, len(sections)),
+		Sections: make([]v1.ViewSection, 0, len(sections)),
 	}
 
 	for _, sec := range sections {
-		v1Sec := V1ViewSection{
+		v1Sec := v1.ViewSection{
 			Heading:      sec.Heading,
 			SectionID:    sec.SectionID,
 			Display:      sec.Display,
@@ -3565,7 +3060,7 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 
 		// Convert fields
 		for _, f := range sec.Fields {
-			v1Sec.Fields = append(v1Sec.Fields, V1SectionField(f))
+			v1Sec.Fields = append(v1Sec.Fields, v1.SectionField(f))
 		}
 
 		// Convert entities
@@ -3575,7 +3070,7 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 
 		// Convert columns
 		for _, col := range sec.Columns {
-			v1Sec.Columns = append(v1Sec.Columns, V1ViewColumn{
+			v1Sec.Columns = append(v1Sec.Columns, v1.ViewColumn{
 				Property: col.Property,
 				Label:    col.Label,
 				Relation: col.Relation,
@@ -3585,32 +3080,32 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 
 		// Convert rows
 		for _, row := range sec.Rows {
-			v1Row := V1ViewRow{
+			v1Row := v1.ViewRow{
 				EntityID:   row.EntityID,
 				EntityType: row.EntityType,
 				EditFormID: row.EditFormID,
 				Content:    row.Content,
 			}
 			for _, cell := range row.Cells {
-				v1Row.Cells = append(v1Row.Cells, V1ViewCell(cell))
+				v1Row.Cells = append(v1Row.Cells, v1.ViewCell(cell))
 			}
 			v1Sec.Rows = append(v1Sec.Rows, v1Row)
 		}
 
 		// Convert groups
 		for _, grp := range sec.Groups {
-			v1Grp := V1ViewGroup{
+			v1Grp := v1.ViewGroup{
 				GroupName: grp.GroupName,
 			}
 			for _, row := range grp.Rows {
-				v1Row := V1ViewRow{
+				v1Row := v1.ViewRow{
 					EntityID:   row.EntityID,
 					EntityType: row.EntityType,
 					EditFormID: row.EditFormID,
 					Content:    row.Content,
 				}
 				for _, cell := range row.Cells {
-					v1Row.Cells = append(v1Row.Cells, V1ViewCell(cell))
+					v1Row.Cells = append(v1Row.Cells, v1.ViewCell(cell))
 				}
 				v1Grp.Rows = append(v1Grp.Rows, v1Row)
 			}

--- a/internal/dataentry/api_v1_orderable_test.go
+++ b/internal/dataentry/api_v1_orderable_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -160,7 +161,7 @@ func TestV1Schema_AdvertisesOrderableFlag(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 	var schema struct {
-		Relations map[string]V1RelationType `json:"relations"`
+		Relations map[string]v1.RelationType `json:"relations"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &schema); err != nil {
 		t.Fatalf("decode: %v", err)

--- a/internal/dataentry/api_v1_properties_unset_test.go
+++ b/internal/dataentry/api_v1_properties_unset_test.go
@@ -40,7 +40,7 @@ func patchTicketJSON(t *testing.T, app *App, body string) (int, updateResponse) 
 }
 
 // patchTicketRaw returns the raw response body for assertions that
-// need to inspect non-V1Entity-shaped responses (e.g. 403 affordance
+// need to inspect non-v1.Entity-shaped responses (e.g. 403 affordance
 // denials).
 func patchTicketRaw(t *testing.T, app *App, body string) (code int, respBody string) {
 	t.Helper()

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -37,7 +38,7 @@ func TestV1SchemaEndpoint(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var schema V1Schema
+	var schema v1.Schema
 	if err := json.NewDecoder(rec.Body).Decode(&schema); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -72,7 +73,7 @@ func TestV1ConfigEndpoint(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var config V1Config
+	var config v1.Config
 	if err := json.NewDecoder(rec.Body).Decode(&config); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -119,7 +120,7 @@ func TestV1ConfigEndpoint_IncludesActions(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", rec.Code)
 	}
 
-	var config V1Config
+	var config v1.Config
 	if err := json.NewDecoder(rec.Body).Decode(&config); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -159,7 +160,7 @@ func TestV1ListEntities(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -203,7 +204,7 @@ func TestV1GetEntity(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var entity V1Entity
+	var entity v1.Entity
 	if err := json.NewDecoder(rec.Body).Decode(&entity); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -302,7 +303,7 @@ func TestV1Filtering(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -361,7 +362,7 @@ func TestV1FilteringNEMultipleValues(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -433,7 +434,7 @@ func TestV1ListEntitiesSearchQuery(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status: got %d", rec.Code)
 		}
-		var resp V1ListResponse
+		var resp v1.ListResponse
 		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 			t.Fatal(err)
 		}
@@ -463,7 +464,7 @@ func TestV1ListEntitiesSearchQuery(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status: got %d", rec.Code)
 		}
-		var resp V1ListResponse
+		var resp v1.ListResponse
 		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 			t.Fatal(err)
 		}
@@ -485,7 +486,7 @@ func TestV1ListEntitiesSearchQuery(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?q=needle", http.NoBody)
 		rec := httptest.NewRecorder()
 		app.handleV1ListEntities(rec, req, "ticket", "tickets")
-		var resp V1ListResponse
+		var resp v1.ListResponse
 		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 			t.Fatal(err)
 		}
@@ -510,7 +511,7 @@ func TestV1ListEntitiesSearchQuery(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?q=ticket&filter[status]=open", http.NoBody)
 		rec := httptest.NewRecorder()
 		app.handleV1ListEntities(rec, req, "ticket", "tickets")
-		var resp V1ListResponse
+		var resp v1.ListResponse
 		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 			t.Fatal(err)
 		}
@@ -530,7 +531,7 @@ func TestV1ListEntitiesSearchQuery(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?q=%20%20", http.NoBody)
 		rec := httptest.NewRecorder()
 		app.handleV1ListEntities(rec, req, "ticket", "tickets")
-		var resp V1ListResponse
+		var resp v1.ListResponse
 		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 			t.Fatal(err)
 		}
@@ -560,7 +561,7 @@ func TestV1ListEntitiesSearchQuery(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?q=type%3Afoo", http.NoBody)
 		rec := httptest.NewRecorder()
 		app.handleV1ListEntities(rec, req, "ticket", "tickets")
-		var resp V1ListResponse
+		var resp v1.ListResponse
 		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 			t.Fatal(err)
 		}
@@ -618,7 +619,7 @@ func TestV1ListEntitiesSearchQuery(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?q=hit&page=2&per_page=3", http.NoBody)
 		rec := httptest.NewRecorder()
 		app.handleV1ListEntities(rec, req, "ticket", "tickets")
-		var resp V1ListResponse
+		var resp v1.ListResponse
 		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 			t.Fatal(err)
 		}
@@ -651,7 +652,7 @@ func TestV1ListEntitiesSearchQuery(t *testing.T) {
 	})
 }
 
-func responseIDs(r V1ListResponse) []string {
+func responseIDs(r v1.ListResponse) []string {
 	out := make([]string, 0, len(r.Data))
 	for _, e := range r.Data {
 		out = append(out, e.ID)
@@ -681,7 +682,7 @@ func TestV1Sorting(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?sort=title", http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -713,7 +714,7 @@ func TestV1Pagination(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?page=2&per_page=10", http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -809,7 +810,7 @@ func TestV1SearchEmptyQuery(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -865,7 +866,7 @@ func TestV1SearchWithTypeFilter(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -961,7 +962,7 @@ func TestV1GetEntityWithIncludesAll(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var entity V1Entity
+	var entity v1.Entity
 	if err := json.NewDecoder(rec.Body).Decode(&entity); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1001,7 +1002,7 @@ func TestV1GetEntityWithIncludesSpecific(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var entity V1Entity
+	var entity v1.Entity
 	if err := json.NewDecoder(rec.Body).Decode(&entity); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1070,7 +1071,7 @@ func TestV1GetEntityWithActions(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var entity V1Entity
+	var entity v1.Entity
 	if err := json.NewDecoder(rec.Body).Decode(&entity); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1136,7 +1137,7 @@ func TestV1ListEntitiesEmpty(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1167,7 +1168,7 @@ func TestV1ListEntitiesDescendingSort(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?sort=-title", http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1203,7 +1204,7 @@ func TestV1FilteringContains(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?filter[title][contains]=Bug", http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1245,7 +1246,7 @@ func TestV1FilteringIn(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?filter[status][in]=open,in_progress", http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1348,7 +1349,7 @@ func runListFilter(t *testing.T, app *App, query string) []string {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?"+query, http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode failed: %v", err)
 	}
@@ -1551,7 +1552,7 @@ func TestV1MultipleSort(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?sort=status,title", http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1610,7 +1611,7 @@ func TestV1GetEntityWithNestedIncludes(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var entity V1Entity
+	var entity v1.Entity
 	if err := json.NewDecoder(rec.Body).Decode(&entity); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1651,7 +1652,7 @@ func TestV1ComputeEntityActionsWithIncomingRelations(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/features/FEA-001", http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1GetEntity(rec, req, "feature", "features", "FEA-001")
-	var entity V1Entity
+	var entity v1.Entity
 	if err := json.NewDecoder(rec.Body).Decode(&entity); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1790,7 +1791,7 @@ func TestV1SchemaWithCustomTypes(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var schema V1Schema
+	var schema v1.Schema
 	if err := json.NewDecoder(rec.Body).Decode(&schema); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1915,7 +1916,7 @@ func TestV1SidebarWithNavigation(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var resp V1SidebarResponse
+	var resp v1.SidebarResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1971,7 +1972,7 @@ func TestV1SidebarAppliesListFilters(t *testing.T) {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
 
-	var resp V1SidebarResponse
+	var resp v1.SidebarResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -2028,7 +2029,7 @@ func TestV1SidebarAppliesKanbanFilters(t *testing.T) {
 	rec := httptest.NewRecorder()
 	app.handleV1Sidebar(rec, req)
 
-	var resp V1SidebarResponse
+	var resp v1.SidebarResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -2073,7 +2074,7 @@ func TestV1ComputeEntityActions_VerbVocabulary(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
-	var entity V1Entity
+	var entity v1.Entity
 	if err := json.NewDecoder(rec.Body).Decode(&entity); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -2172,7 +2173,7 @@ func TestV1SchemaTypesSpecific(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var entityType V1EntityType
+	var entityType v1.EntityType
 	if err := json.NewDecoder(rec.Body).Decode(&entityType); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -2223,7 +2224,7 @@ func TestV1GetEntityIncludeIncoming(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var entity V1Entity
+	var entity v1.Entity
 	if err := json.NewDecoder(rec.Body).Decode(&entity); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -2272,7 +2273,7 @@ func TestV1PaginationEdgeCases(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?page=100&per_page=10", http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -2525,7 +2526,7 @@ func TestV1SchemaWithRelationCardinality(t *testing.T) {
 
 	app.handleV1Schema(rec, req)
 
-	var schema V1Schema
+	var schema v1.Schema
 	if err := json.NewDecoder(rec.Body).Decode(&schema); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -2555,7 +2556,7 @@ func TestV1EntityToV1WithoutRelations(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	var resp V1ListResponse
+	var resp v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -3024,7 +3025,7 @@ func TestV1CreateEntity_SavesRelations(t *testing.T) {
 	}
 
 	// The ticket was auto-assigned a short ID; read it from the response body.
-	var created V1Entity
+	var created v1.Entity
 	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
 		t.Fatalf("decode response: %v; body: %s", err, rec.Body.String())
 	}
@@ -3615,7 +3616,7 @@ func TestV1Schema_MultiPrefix(t *testing.T) {
 	rec := httptest.NewRecorder()
 	app.handleV1Schema(rec, req)
 
-	var schema V1Schema
+	var schema v1.Schema
 	if err := json.NewDecoder(rec.Body).Decode(&schema); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -3641,7 +3642,7 @@ func TestV1Schema_SinglePrefix_Compat(t *testing.T) {
 	rec := httptest.NewRecorder()
 	app.handleV1Schema(rec, req)
 
-	var schema V1Schema
+	var schema v1.Schema
 	if err := json.NewDecoder(rec.Body).Decode(&schema); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -3674,7 +3675,7 @@ func TestV1CreateEntity_PrefixOverride(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 	}
-	var got V1Entity
+	var got v1.Entity
 	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -3690,7 +3691,7 @@ func TestV1CreateEntity_EmptyPrefixUsesFirst(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 	}
-	var got V1Entity
+	var got v1.Entity
 	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -3745,7 +3746,7 @@ func TestV1CreateEntity_ManualAcceptsID(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 	}
-	var got V1Entity
+	var got v1.Entity
 	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -3841,7 +3842,7 @@ func TestV1Views_DefaultViewForUnconfiguredType(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: want 200, got %d (body: %s)", rec.Code, rec.Body.String())
 	}
-	var resp V1ViewResponse
+	var resp v1.ViewResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -3886,7 +3887,7 @@ func TestV1Views_ConfiguredViewForType(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: want 200, got %d (body: %s)", rec.Code, rec.Body.String())
 	}
-	var resp V1ViewResponse
+	var resp v1.ViewResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -3923,7 +3924,7 @@ func assertViewSectionsLackKeys(t *testing.T, body []byte, keys ...string) {
 
 // View responses must not carry add/link affordances. The view path is
 // strictly read-only; mutations live on the form/side-panel path. This guards
-// against re-introducing addInfo / linkInfo on V1ViewSection across every
+// against re-introducing addInfo / linkInfo on v1.ViewSection across every
 // shape that historically emitted them: outgoing/incoming traversals,
 // cards/list/table displays, and the variant where the target type has no
 // create-form configured (which previously emitted only linkInfo).
@@ -4091,7 +4092,7 @@ func TestV1Views_MentionsPopulated(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: want 200, got %d (body: %s)", rec.Code, rec.Body.String())
 	}
-	var resp V1ViewResponse
+	var resp v1.ViewResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -4158,7 +4159,7 @@ func TestV1Affordance_PerEntityGet_NoneProfile(t *testing.T) {
 
 	raw := rec.Body.String()
 
-	var got V1Entity
+	var got v1.Entity
 	if err := json.NewDecoder(strings.NewReader(raw)).Decode(&got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -4186,7 +4187,7 @@ func TestV1Affordance_PerEntityGet_NoneProfile(t *testing.T) {
 	// Wire format: both keys must appear in the raw JSON as `{}` so
 	// the SPA distinguishes "anonymous fallback" (absent) from
 	// "evaluated with no deviations" (present-empty). Round-tripping
-	// V1Entity through omitempty proves this for pointer fields.
+	// v1.Entity through omitempty proves this for pointer fields.
 	if !strings.Contains(raw, `"_fields":{}`) {
 		t.Errorf("raw body should contain \"_fields\":{}; got: %s", raw)
 	}
@@ -4238,7 +4239,7 @@ func TestV1Affordance_PerEntityGet_DemoFixture(t *testing.T) {
 		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
 
-	var got V1Entity
+	var got v1.Entity
 	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -4794,7 +4795,7 @@ func TestHandleV1DryRunCreate_Affordances(t *testing.T) {
 		if code != http.StatusOK {
 			t.Fatalf("got %d, want 200; body=%s", code, rec.Body.String())
 		}
-		var v V1Entity
+		var v v1.Entity
 		if err := json.Unmarshal(rec.Body.Bytes(), &v); err != nil {
 			t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
 		}
@@ -4818,7 +4819,7 @@ func TestHandleV1DryRunCreate_Affordances(t *testing.T) {
 			t.Fatalf("got %d, want 200; body=%s", code, rec.Body.String())
 		}
 		body := rec.Body.String()
-		var v V1Entity
+		var v v1.Entity
 		if err := json.Unmarshal(rec.Body.Bytes(), &v); err != nil {
 			t.Fatalf("decode: %v; body=%s", err, body)
 		}
@@ -4842,7 +4843,7 @@ func TestHandleV1DryRunCreate_Affordances(t *testing.T) {
 		if code != http.StatusOK {
 			t.Fatalf("got %d, want 200; body=%s", code, rec.Body.String())
 		}
-		var v V1Entity
+		var v v1.Entity
 		_ = json.Unmarshal(rec.Body.Bytes(), &v)
 		if v.FieldAffordances == nil || (*v.FieldAffordances)["status"].Options["done"] {
 			t.Errorf("_fields.status.options.done must be false; body=%s", rec.Body.String())
@@ -4896,7 +4897,7 @@ func TestHandleV1DryRunCreate_SoftWarnings(t *testing.T) {
 	if code != http.StatusOK {
 		t.Fatalf("got %d, want 200; body=%s", code, rec.Body.String())
 	}
-	var v V1Entity
+	var v v1.Entity
 	if err := json.Unmarshal(rec.Body.Bytes(), &v); err != nil {
 		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
 	}
@@ -4930,7 +4931,7 @@ func TestHandleV1DryRunCreate_ResponseIncludesAllVisibleDeclaredProps(t *testing
 	if code != http.StatusOK {
 		t.Fatalf("got %d, want 200; body=%s", code, rec.Body.String())
 	}
-	var v V1Entity
+	var v v1.Entity
 	if err := json.Unmarshal(rec.Body.Bytes(), &v); err != nil {
 		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
 	}

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -140,7 +140,7 @@ type App struct {
 	// write-time affordance validation. Extracted from App (TKT-N26KLB M5.2);
 	// shares the same acl.ACL as the write path (contract-test invariant).
 	affordances affordanceService
-	// serializer renders an entity into its V1Entity wire shape. Extracted from
+	// serializer renders an entity into its v1.Entity wire shape. Extracted from
 	// App (TKT-N26KLB); pure transform — handlers pass the entity's already-
 	// loaded outgoing relations, the serializer does no loading.
 	serializer entitySerializer

--- a/internal/dataentry/apps_handler.go
+++ b/internal/dataentry/apps_handler.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 )
 
@@ -170,13 +171,13 @@ func (a *App) handleV1App(w http.ResponseWriter, r *http.Request) {
 
 // appsToV1 projects the scanned apps to the client-facing view. Returns nil for
 // an empty list so the JSON omits the "apps" key entirely.
-func appsToV1(apps []appInfo) map[string]V1App {
+func appsToV1(apps []appInfo) map[string]v1.App {
 	if len(apps) == 0 {
 		return nil
 	}
-	out := make(map[string]V1App, len(apps))
+	out := make(map[string]v1.App, len(apps))
 	for _, app := range apps {
-		out[app.ID] = V1App{
+		out[app.ID] = v1.App{
 			Title:       app.Title,
 			Label:       app.Label,
 			Description: app.Description,

--- a/internal/dataentry/entityserializer.go
+++ b/internal/dataentry/entityserializer.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
-// entitySerializer renders an entity into its V1Entity wire shape. Extracted
+// entitySerializer renders an entity into its v1.Entity wire shape. Extracted
 // from App (TKT-N26KLB). It does NO loading and holds no snapshot — the caller
 // passes everything the transform needs as values: the entity, its already-
 // loaded outgoing relations (nil to omit the relations map), and the metamodel
@@ -20,11 +21,11 @@ type entitySerializer struct {
 	affordances affordanceService
 }
 
-// toV1 builds the base V1Entity. meta is the request's metamodel snapshot;
+// toV1 builds the base v1.Entity. meta is the request's metamodel snapshot;
 // outgoing is the entity's outgoing relations, already loaded by the caller
 // (nil omits the relations map — the former includeRelations=false shape).
-func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) V1Entity {
-	v1 := V1Entity{
+func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) v1.Entity {
+	out := v1.Entity{
 		ID:         e.ID,
 		Type:       e.Type,
 		Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
@@ -35,13 +36,13 @@ func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoin
 	}
 
 	for k, v := range e.Properties {
-		v1.Properties[k] = v
+		out.Properties[k] = v
 	}
 
 	if e.IsLocked() {
-		v1.Inaccessible = make([]V1InaccessibleField, 0, len(e.Inaccessible))
+		out.Inaccessible = make([]v1.InaccessibleField, 0, len(e.Inaccessible))
 		for _, f := range e.Inaccessible {
-			v1.Inaccessible = append(v1.Inaccessible, V1InaccessibleField{
+			out.Inaccessible = append(out.Inaccessible, v1.InaccessibleField{
 				Name:   f.Name,
 				Reason: string(f.Reason),
 			})
@@ -49,20 +50,20 @@ func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoin
 	}
 
 	if outgoing != nil {
-		v1.Relations = make(map[string][]string)
+		out.Relations = make(map[string][]string)
 		for _, edge := range outgoing {
-			v1.Relations[edge.Type] = append(v1.Relations[edge.Type], edge.To)
+			out.Relations[edge.Type] = append(out.Relations[edge.Type], edge.To)
 		}
 	}
 
-	return v1
+	return out
 }
 
 // forWire is the single entry-point every handler that returns a per-entity
-// V1Entity should use: toV1 + strip hidden properties + attach the affordance
+// v1.Entity should use: toV1 + strip hidden properties + attach the affordance
 // maps. Use forWireRelated for entities that appear as list rows or under
 // `included` (no affordance maps, but still strip).
-func (s entitySerializer) forWire(ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) V1Entity {
+func (s entitySerializer) forWire(ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) v1.Entity {
 	result := s.toV1(ctx, e, outgoing, meta, plural)
 	s.affordances.stripHiddenProperties(ctx, e, &result)
 	s.affordances.attachEntityAffordances(ctx, e, &result)
@@ -74,7 +75,7 @@ func (s entitySerializer) forWire(ctx context.Context, e *entityPkg.Entity, outg
 // properties but omits the `_fields` / `_relations` maps (those ride on
 // per-entity responses only). Hidden-field stripping still applies: the wire
 // contract is "hidden values never reach the client, regardless of shape."
-func (s entitySerializer) forWireRelated(ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) V1Entity {
+func (s entitySerializer) forWireRelated(ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) v1.Entity {
 	result := s.toV1(ctx, e, outgoing, meta, plural)
 	s.affordances.stripHiddenProperties(ctx, e, &result)
 	return result

--- a/internal/dataentry/handlers_attachment_write_test.go
+++ b/internal/dataentry/handlers_attachment_write_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -304,7 +305,7 @@ func TestAttachmentUpload_ReplaceOversizeKeepsExisting(t *testing.T) {
 // serialized entity.
 //
 //nolint:unparam // entityID is conceptually variable; tests use one fixture.
-func attachmentsFor(t *testing.T, app *App, entityID, property string) []V1Attachment {
+func attachmentsFor(t *testing.T, app *App, entityID, property string) []v1.Attachment {
 	t.Helper()
 	result := app.serializer.forWire(context.Background(), mustGet(t, app, entityID), app.reader.outgoingRelations(context.Background(), entityID), app.Meta(), "tickets")
 	if result.Attachments == nil {

--- a/internal/dataentry/inaccessible_test.go
+++ b/internal/dataentry/inaccessible_test.go
@@ -27,7 +27,7 @@ func lockedTicket(inaccessibleFields ...string) *entity.Entity {
 
 // TestEntityToV1_PropagatesInaccessible verifies that the wire-format
 // serialization carries [entity.Entity.Inaccessible] through to
-// [V1Entity.Inaccessible]. Encrypted entities loaded from fsstore have
+// [v1.Entity.Inaccessible]. Encrypted entities loaded from fsstore have
 // this field populated; the SPA branches on it to render lock indicators.
 func TestEntityToV1_PropagatesInaccessible(t *testing.T) {
 	app := newTestAppV1(t)

--- a/internal/dataentry/mentions.go
+++ b/internal/dataentry/mentions.go
@@ -10,29 +10,11 @@ import (
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/text"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
-
-// Mention is the resolved target of an entity-ID code span found in
-// markdown content. Mirrors the Lua-side `rela.md.entity_refs`/`resolve_refs`
-// semantics (TKT-LXYHQ): only bare-content code spans whose entire text is
-// an entity ID are collected; the data-entry SPA uses this map to rewrite
-// those code spans into titled in-app links.
-//
-// `Inaccessible` is true when the entity's display title is unreadable
-// (e.g. the file is git-crypt encrypted) — the SPA renders such links
-// with a lock affordance using the same tooltip copy as inaccessible
-// properties. `InaccessibleReason` carries the matching
-// `entity.InaccessibleReason` value as a string so the wire shape stays
-// stable across reason-enum additions.
-type Mention struct {
-	Type               string `json:"type"`
-	Title              string `json:"title"`
-	Inaccessible       bool   `json:"inaccessible,omitempty"`
-	InaccessibleReason string `json:"inaccessible_reason,omitempty"`
-}
 
 // collectMentions scans the supplied markdown blobs for inline code spans
 // whose entire content is an entity ID known to the store, and returns a
@@ -47,12 +29,12 @@ type Mention struct {
 // unknown-ID UX. Context cancellation is honored — callers (HTTP handlers)
 // have already bound the request context and abandoning further lookups
 // after the client disconnects saves wasted work.
-func collectMentions(ctx context.Context, s store.EntityReader, meta *metamodel.Metamodel, contents ...string) map[string]Mention {
+func collectMentions(ctx context.Context, s store.EntityReader, meta *metamodel.Metamodel, contents ...string) map[string]v1.Mention {
 	candidates := scanCodeSpanCandidates(contents...)
 	if len(candidates) == 0 {
 		return nil
 	}
-	out := make(map[string]Mention, len(candidates))
+	out := make(map[string]v1.Mention, len(candidates))
 	for id := range candidates {
 		if err := ctx.Err(); err != nil {
 			if len(out) == 0 {
@@ -77,14 +59,14 @@ func collectMentions(ctx context.Context, s store.EntityReader, meta *metamodel.
 	return out
 }
 
-// buildMention turns a resolved entity into a wire-shape Mention. Title
+// buildMention turns a resolved entity into a wire-shape v1.Mention. Title
 // uses the metamodel's DisplayTitle so entity types whose primary
 // property is something other than `title` (e.g. concept's `name`)
 // still produce readable link text. Inaccessibility flips on only when
 // the display-title source is itself unreadable — a partial lock on an
 // unrelated property must not turn a link into a lock affordance.
-func buildMention(e *entityPkg.Entity, meta *metamodel.Metamodel) Mention {
-	m := Mention{Type: e.Type}
+func buildMention(e *entityPkg.Entity, meta *metamodel.Metamodel) v1.Mention {
+	m := v1.Mention{Type: e.Type}
 	if meta != nil {
 		m.Title = meta.DisplayTitle(e.ID, e.Type, e.Properties)
 	} else {

--- a/internal/dataentry/mentions_test.go
+++ b/internal/dataentry/mentions_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -32,19 +33,19 @@ func TestCollectMentions(t *testing.T) {
 	tests := []struct {
 		name     string
 		contents []string
-		want     map[string]Mention
+		want     map[string]v1.Mention
 	}{
 		{
 			name:     "known short-ID code span resolves",
 			contents: []string{"see `TKT-LXYHQ` for context"},
-			want: map[string]Mention{
+			want: map[string]v1.Mention{
 				"TKT-LXYHQ": {Type: "ticket", Title: "Resolve entity-ID references"},
 			},
 		},
 		{
 			name:     "manual-ID concept resolves via DisplayTitle (name)",
 			contents: []string{"covered by `data-entry-ui`"},
-			want: map[string]Mention{
+			want: map[string]v1.Mention{
 				// concept's primary property is `name` per its metamodel;
 				// the title comes from there, not the `title` property
 				// (which the seed never sets for concept).
@@ -79,7 +80,7 @@ func TestCollectMentions(t *testing.T) {
 		{
 			name:     "multiple distinct mentions are deduplicated across blobs",
 			contents: []string{"`TKT-LXYHQ` and `FEAT-010`", "again: `TKT-LXYHQ`"},
-			want: map[string]Mention{
+			want: map[string]v1.Mention{
 				"TKT-LXYHQ": {Type: "ticket", Title: "Resolve entity-ID references"},
 				"FEAT-010":  {Type: "feature", Title: "Use goldmark for markdown rendering"},
 			},
@@ -87,7 +88,7 @@ func TestCollectMentions(t *testing.T) {
 		{
 			name:     "inaccessible target carries inaccessible + reason",
 			contents: []string{"locked: `TKT-LOCKED`"},
-			want: map[string]Mention{
+			want: map[string]v1.Mention{
 				"TKT-LOCKED": {
 					Type:               "ticket",
 					Title:              "TKT-LOCKED",
@@ -99,21 +100,21 @@ func TestCollectMentions(t *testing.T) {
 		{
 			name:     "partially-locked entity keeps its readable title and is NOT inaccessible",
 			contents: []string{"partial: `TKT-PARTIAL`"},
-			want: map[string]Mention{
+			want: map[string]v1.Mention{
 				"TKT-PARTIAL": {Type: "ticket", Title: "Mostly Readable"},
 			},
 		},
 		{
 			name:     "code span inside list item is collected",
 			contents: []string{"- see `TKT-LXYHQ` here\n"},
-			want: map[string]Mention{
+			want: map[string]v1.Mention{
 				"TKT-LXYHQ": {Type: "ticket", Title: "Resolve entity-ID references"},
 			},
 		},
 		{
 			name:     "code span inside blockquote is collected",
 			contents: []string{"> quoted: `TKT-LXYHQ`\n"},
-			want: map[string]Mention{
+			want: map[string]v1.Mention{
 				"TKT-LXYHQ": {Type: "ticket", Title: "Resolve entity-ID references"},
 			},
 		},
@@ -122,7 +123,7 @@ func TestCollectMentions(t *testing.T) {
 			contents: []string{
 				"| col |\n| --- |\n| `TKT-LXYHQ` |\n",
 			},
-			want: map[string]Mention{
+			want: map[string]v1.Mention{
 				"TKT-LXYHQ": {Type: "ticket", Title: "Resolve entity-ID references"},
 			},
 		},
@@ -161,7 +162,7 @@ func TestCollectMentions_SelfReference(t *testing.T) {
 	}
 
 	got := collectMentions(context.Background(), st, meta, "see `TKT-SELF` for the recursion")
-	want := map[string]Mention{
+	want := map[string]v1.Mention{
 		"TKT-SELF": {Type: self.Type, Title: self.Title()},
 	}
 	assertMentionsEqual(t, want, got)
@@ -200,7 +201,7 @@ func TestCollectMentions_StoreErrorIsLoggedAndSkipped(t *testing.T) {
 	}
 
 	got := collectMentions(context.Background(), flaky, meta, "`TKT-FAIL` then `TKT-OK`")
-	want := map[string]Mention{
+	want := map[string]v1.Mention{
 		"TKT-OK": {Type: "ticket", Title: "Resolves fine"},
 	}
 	assertMentionsEqual(t, want, got)
@@ -221,7 +222,7 @@ func TestCollectMentions_ConcurrentScanIsSafe(t *testing.T) {
 	const n = 64
 	var wg sync.WaitGroup
 	wg.Add(n)
-	results := make([]map[string]Mention, n)
+	results := make([]map[string]v1.Mention, n)
 	for i := range n {
 		go func(idx int) {
 			defer wg.Done()
@@ -230,7 +231,7 @@ func TestCollectMentions_ConcurrentScanIsSafe(t *testing.T) {
 	}
 	wg.Wait()
 
-	want := map[string]Mention{"TKT-CONC": {Type: "ticket", Title: "Concurrent"}}
+	want := map[string]v1.Mention{"TKT-CONC": {Type: "ticket", Title: "Concurrent"}}
 	for i, got := range results {
 		if len(got) != 1 || got["TKT-CONC"] != want["TKT-CONC"] {
 			t.Fatalf("goroutine %d: want %+v, got %+v", i, want, got)
@@ -299,7 +300,7 @@ func lockedEntity(id, typeName string, reason entity.InaccessibleReason) *entity
 }
 
 // entityWithLockedProperty produces an entity whose `title` is readable
-// but some unrelated property is locked. The wire-shape Mention should
+// but some unrelated property is locked. The wire-shape v1.Mention should
 // keep `Inaccessible == false` because the displayed link text comes
 // from a readable source.
 func entityWithLockedProperty(id, typeName, title, lockedProp string) *entity.Entity {
@@ -311,7 +312,7 @@ func entityWithLockedProperty(id, typeName, title, lockedProp string) *entity.En
 	return e
 }
 
-func assertMentionsEqual(t *testing.T, want, got map[string]Mention) {
+func assertMentionsEqual(t *testing.T, want, got map[string]v1.Mention) {
 	t.Helper()
 	if len(want) != len(got) {
 		t.Fatalf("mention count mismatch: want %d, got %d (want=%v got=%v)",

--- a/internal/dataentry/relations_modern_test.go
+++ b/internal/dataentry/relations_modern_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -127,9 +128,9 @@ func patch(t *testing.T, app *App, plural, id, body string, headers ...string) *
 	return rec
 }
 
-func decodeV1(t *testing.T, body []byte) V1Entity {
+func decodeV1(t *testing.T, body []byte) v1.Entity {
 	t.Helper()
-	var got V1Entity
+	var got v1.Entity
 	if err := json.Unmarshal(body, &got); err != nil {
 		t.Fatalf("decode response: %v\nbody: %s", err, body)
 	}

--- a/internal/dataentry/scope.go
+++ b/internal/dataentry/scope.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
 )
 
@@ -149,25 +150,6 @@ func (d ScopeDescriptor) toQuery() url.Values {
 	return q
 }
 
-// V1PositionRef identifies a neighboring entity in a scope. Type is included
-// because a scope (notably a search scope) can span entity types, so the SPA
-// must build the target's detail route from *its* type, not the current
-// entity's. ID alone would break cross-type prev/next.
-type V1PositionRef struct {
-	ID   string `json:"id"`
-	Type string `json:"type"`
-}
-
-// V1Position is the scope-navigator payload: the neighbors plus the counter
-// the SPA needs, with no entity bodies shipped. current is 1-based; prev/next
-// are nil at the ends of the set.
-type V1Position struct {
-	Prev    *V1PositionRef `json:"prev"`
-	Next    *V1PositionRef `json:"next"`
-	Current int            `json:"current"`
-	Total   int            `json:"total"`
-}
-
 // handleV1EntityPosition resolves an entity's position within a scope. It
 // reproduces the scope's ordered set via resolveScope (the list pipeline for
 // source=list, the search pipeline for source=search) then locates the id,
@@ -217,12 +199,12 @@ func (a *App) handleV1EntityPosition(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	pos := V1Position{Current: idx + 1, Total: len(entities)}
+	pos := v1.Position{Current: idx + 1, Total: len(entities)}
 	if idx > 0 {
-		pos.Prev = &V1PositionRef{ID: entities[idx-1].ID, Type: entities[idx-1].Type}
+		pos.Prev = &v1.PositionRef{ID: entities[idx-1].ID, Type: entities[idx-1].Type}
 	}
 	if idx < len(entities)-1 {
-		pos.Next = &V1PositionRef{ID: entities[idx+1].ID, Type: entities[idx+1].Type}
+		pos.Next = &v1.PositionRef{ID: entities[idx+1].ID, Type: entities[idx+1].Type}
 	}
 
 	writeV1JSON(w, http.StatusOK, pos)

--- a/internal/dataentry/scope_test.go
+++ b/internal/dataentry/scope_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"testing"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 )
@@ -24,12 +25,12 @@ func positionURL(t *testing.T, id string, scope ScopeDescriptor) string {
 	return "/api/v1/_position?" + q.Encode()
 }
 
-func getPosition(t *testing.T, app *App, id string, scope ScopeDescriptor) (*httptest.ResponseRecorder, V1Position) {
+func getPosition(t *testing.T, app *App, id string, scope ScopeDescriptor) (*httptest.ResponseRecorder, v1.Position) {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, positionURL(t, id, scope), http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1EntityPosition(rec, req)
-	var pos V1Position
+	var pos v1.Position
 	if rec.Code == http.StatusOK {
 		if err := json.NewDecoder(rec.Body).Decode(&pos); err != nil {
 			t.Fatalf("decode position: %v", err)
@@ -295,7 +296,7 @@ func TestV1PositionMatchesListOrdering(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets?sort=title", http.NoBody)
 	rec := httptest.NewRecorder()
 	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	var list V1ListResponse
+	var list v1.ListResponse
 	if err := json.NewDecoder(rec.Body).Decode(&list); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/dataentry/sections.go
+++ b/internal/dataentry/sections.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
@@ -65,8 +66,8 @@ type SectionFieldData struct {
 // `Props` and `FieldVerdicts` (TKT-IHC7D) carry the typed property
 // values and per-cell writability verdicts for inline-edit hosts on
 // cards/list view sections. Both are hidden-property-stripped. The
-// wire converter dumb-copies them into V1ViewEntity._props and
-// V1ViewEntity._fields respectively. They are nil for code paths that
+// wire converter dumb-copies them into v1.ViewEntity._props and
+// v1.ViewEntity._fields respectively. They are nil for code paths that
 // don't compute them (notably the entry-source branch and table rows);
 // the wire converter's nil-checks gate emission.
 type SectionEntityData struct {
@@ -78,7 +79,7 @@ type SectionEntityData struct {
 	Content       string
 	HasContent    bool
 	Props         map[string]any
-	FieldVerdicts map[string]V1FieldAffordance
+	FieldVerdicts map[string]v1.FieldAffordance
 }
 
 // SectionColumnData holds a resolved table cell for template rendering.

--- a/internal/dataentry/sections_ihc7d_test.go
+++ b/internal/dataentry/sections_ihc7d_test.go
@@ -2,7 +2,7 @@
 // view sections. Covers:
 //   - copyVisibleProperties hidden-stripping (AC 5 + RR-FD1A)
 //   - buildSectionEntityData populates Props + FieldVerdicts (AC 3)
-//   - sectionEntityToV1 wire conversion at the V1ViewEntity level (AC 4)
+//   - sectionEntityToV1 wire conversion at the v1.ViewEntity level (AC 4)
 //   - Key-set invariant between _props and _fields (RR-FD1B)
 //   - Both properties/list AND content/cards branches produce the
 //     same wire shape (RR-FD1C)
@@ -15,6 +15,7 @@ import (
 	"reflect"
 	"testing"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 )
 
@@ -160,8 +161,8 @@ func TestBuildSectionEntityData_KeySetInvariant(t *testing.T) {
 
 func TestSectionEntityToV1_WiresPropsAndFields(t *testing.T) {
 	// AC 4: the wire converter dumb-copies Props and FieldVerdicts off
-	// SectionEntityData into V1ViewEntity._props and ._fields.
-	verdict := map[string]V1FieldAffordance{
+	// SectionEntityData into v1.ViewEntity._props and ._fields.
+	verdict := map[string]v1.FieldAffordance{
 		"status": {Writable: ptrTo(false)},
 	}
 	sed := SectionEntityData{
@@ -206,7 +207,7 @@ func TestSectionEntityToV1_EmptyFieldVerdicts_EmitsPresentButEmpty(t *testing.T)
 	sed := SectionEntityData{
 		ID:            "TKT-001",
 		Type:          "ticket",
-		FieldVerdicts: map[string]V1FieldAffordance{},
+		FieldVerdicts: map[string]v1.FieldAffordance{},
 	}
 	got := sectionEntityToV1(sed)
 	if got.FieldAffordances == nil {

--- a/tickets/entities/tickets/TKT-I5TDVY.md
+++ b/tickets/entities/tickets/TKT-I5TDVY.md
@@ -1,0 +1,41 @@
+---
+id: TKT-I5TDVY
+type: ticket
+title: Extract v1 API wire types into an enforced apiwire package
+kind: refactor
+priority: medium
+effort: m
+status: done
+---
+
+Give the v1 data-entry API wire vocabulary its own package
+(`internal/apiwire/v1`) with an **arch-lint-enforced** boundary, so the
+dataentry decomposition contracts become compiler/CI-enforced rather than
+same-package convention.
+
+## Why
+
+The dataentry service extractions (visibleReader, affordanceService,
+entitySerializer, entityReader) live in `package dataentry`, so their contracts
+are convention — any of dataentry's 100+ files can reach their unexported
+fields. Reducing App's method count ≠ real boundaries. Giving the shared V1 wire
+vocabulary its own package is the keystone: once it exists,
+serializer/affordances/handlers can later move to packages that import `apiwire`
+(not dataentry), with no cycle.
+
+## Design
+
+- **Top-level `internal/apiwire/v1`** (not nested under dataentry): a future native/desktop bridge will consume the contract in-process (no HTTP), so it's shared between the web serializer and that bridge — not dataentry's privates.
+- **Version-as-package** (`v1.Entity`, not `apiwire.V1Entity`): a v2 API is a sibling `apiwire/v2`, k8s-style.
+- **Enforced leaf**: arch-lint rule `apiwire mayDependOn {dataentryconfig}` (entity is a commonComponent) and NOT dataentry. Verified a deliberate apiwire→dataentry probe fails arch-lint.
+
+## Slices
+
+- **Slice 1** (merged): the relations-wire cluster (RelationsField/Update/ResourceIdentifier + parser + WireError + JSONPointerEscape) — the one methoded cluster, handled first.
+- **Slice 2** (this): the ~48 pure-data response types (Entity, ListResponse, Schema, Config, Sidebar/Conflict/View families, + Mention). apiwire/v1 is now the complete v1 wire contract (54 types).
+
+## Follow-up
+
+Moving serializer/affordances/handlers themselves into apiwire-importing
+packages — making those contracts enforced too — is future work (tracked
+separately).

--- a/tickets/relations/TKT-I5TDVY--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-I5TDVY--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-I5TDVY
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-I5TDVY--affects--rest-api.md
+++ b/tickets/relations/TKT-I5TDVY--affects--rest-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-I5TDVY
+relation: affects
+to: rest-api
+---

--- a/tickets/relations/TKT-I5TDVY--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-I5TDVY--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-I5TDVY
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Completes the `apiwire/v1` extraction: moves the ~48 remaining V1 wire **response** types into the package, so it now holds the full v1 API wire vocabulary with an arch-lint-enforced boundary.

Follows the merged apiwire slice 1 (the relations-wire cluster). Now targets `develop` directly since the decomposition stack has landed.

## What

Move the ~48 pure-data V1 response types — `Entity`, `ListResponse`, `Schema`, `Config`, the `Sidebar*`/`Conflict*`/`View*` families, `EntityType`/`PropertyDef`/`RelationType`, `App`/`Command`/`Template`/`Document`, … — plus `Mention` into `internal/apiwire/v1`, dropping the `V1` prefix (`v1.Entity` etc.; the package carries the version).

All ~48 are pure structs (zero methods — the only methoded cluster, the relations parser, went in slice 1), so this is a uniform struct move + reference repoint across 27 files. The **builders** (the `toV1*` constructors, `collectMentions`/`buildMention`) stay in `dataentry` and import `apiwire` — `dataentry → apiwire` is the allowed direction. `Warning` is re-aliased in apiwire (`= entity.Warning`).

## Rebase note (conflict resolution)

Rebasing onto current `develop` surfaced a 3-way conflict where develop had added `PlantUMLServerURL` to `V1AppConfig`. Resolved by **keeping develop’s new field** — ported it into apiwire’s `AppConfig` and the config builder — so the PlantUML feature is preserved, not reverted. (Config tests pass.)

## Result

`internal/apiwire/v1` is now the complete v1 wire contract (54 types). arch-lint enforces it imports only `{entity, dataentryconfig}`, never `dataentry`. App method count unchanged — this is about boundaries, not count.

## Verification

`go build ./...`, `go test -race ./internal/dataentry/ ./internal/apiwire/v1/`, `golangci-lint` (0 issues), `just arch-lint` (boundary enforced), `plimsoll ./...` (exit 0) all green.