### PR TITLE
feat(apps): <rela-editor> markdown editor element for custom apps (TKT-5F9V56, TKT-D2JML7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ frontend/playwright-report/
 internal/dataentry/static/v2/
 prototypes/data-entry/remote.git/
 .claude/
+
+# Editor element build artifacts (TKT-5F9V56); rebuilt by npm run build
+internal/dataentry/app_editor_dist/*
+!internal/dataentry/app_editor_dist/.gitkeep

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc -b && vite build",
-    "build:e2e": "vue-tsc -b && vite build --mode development",
+    "build": "vue-tsc -b && vite build && npm run build:editor",
+    "build:e2e": "vue-tsc -b && vite build --mode development && npm run build:editor",
+    "build:editor": "vite build --config vite.editor.config.ts",
     "preview": "vite preview",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/frontend/src/app-editor/relaBacktick.test.ts
+++ b/frontend/src/app-editor/relaBacktick.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { attachBacktickAutocomplete } from './relaBacktick'
+
+// A minimal fake CodeMirror 5 + EasyMDE wrapper that models a single-line
+// buffer and the events the backtick controller subscribes to. The real flow
+// is verified end-to-end in-browser (puppeteer); these tests pin the state
+// machine (trigger → prefix → id → insert) and the bridge wiring in CI.
+
+interface Pos {
+  line: number
+  ch: number
+}
+
+function makeFakeEditor() {
+  let text = ''
+  let cursor: Pos = { line: 0, ch: 0 }
+  const handlers: Record<string, Array<(...a: unknown[]) => void>> = {}
+  // token type returned by getTokenAt — tests set this to steer the gate.
+  let afterTokenType: string | null = 'formatting formatting-code comment'
+  let beforeTokenType: string | null = null
+
+  const cm = {
+    on: (ev: string, fn: (...a: unknown[]) => void) => {
+      ;(handlers[ev] ||= []).push(fn)
+    },
+    off: (ev: string, fn: (...a: unknown[]) => void) => {
+      handlers[ev] = (handlers[ev] || []).filter((f) => f !== fn)
+    },
+    getCursor: (_side?: string) => ({ ...cursor }),
+    getRange: (a: Pos, b: Pos) => text.slice(a.ch, b.ch),
+    getTokenAt: (pos: Pos) => ({
+      type: pos.ch > cursor.ch - 1 ? afterTokenType : beforeTokenType,
+      string: '`',
+    }),
+    charCoords: () => ({ left: 10, top: 20, bottom: 36 }),
+    replaceSelection: (t: string) => {
+      text = text.slice(0, cursor.ch) + t + text.slice(cursor.ch)
+      cursor = { line: 0, ch: cursor.ch + t.length }
+    },
+    replaceRange: (t: string, from: Pos, to?: Pos) => {
+      const end = to ? to.ch : from.ch
+      text = text.slice(0, from.ch) + t + text.slice(end)
+      cursor = { line: 0, ch: from.ch + t.length }
+    },
+    focus: vi.fn(),
+    // test helpers
+    _setText: (t: string, ch: number) => {
+      text = t
+      cursor = { line: 0, ch }
+    },
+    _getText: () => text,
+    _setTokenTypes: (after: string | null, before: string | null) => {
+      afterTokenType = after
+      beforeTokenType = before
+    },
+    _emit: (ev: string, ...args: unknown[]) => {
+      ;(handlers[ev] || []).forEach((f) => f(...args))
+    },
+  }
+  return { codemirror: cm } as unknown as Parameters<typeof attachBacktickAutocomplete>[0] & {
+    codemirror: typeof cm
+  }
+}
+
+function makeBridge() {
+  return {
+    schema: vi.fn(async () => ({
+      entities: {
+        ticket: { label: 'Ticket', id_prefix: 'TKT-', id_type: 'short' },
+        feature: { label: 'Feature', id_prefix: 'FEAT-', id_type: 'short' },
+      },
+    })),
+    list: vi.fn(async () => ({ data: [{ id: 'TKT-AAAA', _title: 'Alpha' }, { id: 'TKT-BBBB', _title: 'Beta' }] })),
+    search: vi.fn(async ({ query }: { query: string }) => ({ data: [{ id: 'TKT-AAAA', _title: 'Alpha ' + query }] })),
+  }
+}
+
+// Fire the inputRead the way CM5 does when a backtick is typed at `ch`.
+function typeBacktick(ed: ReturnType<typeof makeFakeEditor>, before: string) {
+  const cm = ed.codemirror
+  cm._setText(before + '`', before.length + 1)
+  cm._emit('inputRead', cm, { from: { line: 0, ch: before.length }, to: { line: 0, ch: before.length }, text: ['`'], origin: '+input' })
+}
+
+const flushTimers = () => new Promise((r) => setTimeout(r, 350))
+
+describe('attachBacktickAutocomplete', () => {
+  let ed: ReturnType<typeof makeFakeEditor>
+  let bridge: ReturnType<typeof makeBridge>
+  let popup: () => HTMLElement | null
+
+  beforeEach(() => {
+    document.body.replaceChildren()
+    ed = makeFakeEditor()
+    bridge = makeBridge()
+    popup = () => document.querySelector('.rela-bt-popup')
+  })
+
+  it('warms the prefix cache from the bridge schema', async () => {
+    attachBacktickAutocomplete(ed, bridge)
+    await Promise.resolve()
+    expect(bridge.schema).toHaveBeenCalled()
+  })
+
+  it('shows the prefix popup after typing a backtick in inline text', async () => {
+    attachBacktickAutocomplete(ed, bridge)
+    await flushTimers() // let the schema cache warm
+    typeBacktick(ed, 'see ')
+    await flushTimers() // past the open delay
+    const p = popup()!
+    expect(p.style.display).toBe('block')
+    const opts = [...p.querySelectorAll('.rela-bt-option')].map((o) => o.textContent)
+    expect(opts.length).toBe(2)
+    expect(opts.join(' ')).toContain('Feature')
+    expect(opts.join(' ')).toContain('Ticket')
+  })
+
+  it('does NOT open inside a non-inline context (e.g. a code/comment token before)', async () => {
+    attachBacktickAutocomplete(ed, bridge)
+    await flushTimers()
+    ed.codemirror._setTokenTypes('formatting formatting-code comment', 'comment')
+    typeBacktick(ed, 'x')
+    await flushTimers()
+    expect(popup()!.style.display).toBe('none')
+  })
+
+  it('picks a prefix → id phase → inserts `<id>` and closes', async () => {
+    attachBacktickAutocomplete(ed, bridge)
+    await flushTimers()
+    typeBacktick(ed, 'see ')
+    await flushTimers()
+    // click "Ticket"
+    const ticket = [...popup()!.querySelectorAll('.rela-bt-option')].find((o) =>
+      o.textContent?.includes('Ticket'),
+    ) as HTMLElement
+    ticket.click()
+    await flushTimers() // debounced list fetch
+    expect(bridge.list).toHaveBeenCalled()
+    const entOpts = [...popup()!.querySelectorAll('.rela-bt-option')]
+    expect(entOpts.length).toBeGreaterThan(0)
+    ;(entOpts[0] as HTMLElement).click()
+    await Promise.resolve()
+    expect(ed.codemirror._getText()).toBe('see `TKT-AAAA`')
+    expect(popup()!.style.display).toBe('none')
+  })
+
+  it('destroy() removes the popup and unsubscribes', async () => {
+    const ctrl = attachBacktickAutocomplete(ed, bridge)
+    await flushTimers()
+    ctrl.destroy()
+    expect(popup()).toBeNull()
+    // a post-destroy backtick must not resurrect the popup
+    typeBacktick(ed, 'a ')
+    await flushTimers()
+    expect(popup()).toBeNull()
+  })
+})

--- a/frontend/src/app-editor/relaBacktick.test.ts
+++ b/frontend/src/app-editor/relaBacktick.test.ts
@@ -144,6 +144,63 @@ describe('attachBacktickAutocomplete', () => {
     expect(popup()!.style.display).toBe('none')
   })
 
+  it('keyboard nav (ArrowDown/Up) moves the highlight and keeps the popup open', async () => {
+    attachBacktickAutocomplete(ed, bridge)
+    await flushTimers()
+    typeBacktick(ed, 'see ')
+    await flushTimers()
+    const p = popup()!
+    const activeIdx = () => [...p.querySelectorAll('.rela-bt-option')].findIndex((o) => o.classList.contains('active'))
+    expect(activeIdx()).toBe(0)
+    // CM delivers keydown via the 'keydown' event with (cm, KeyboardEvent).
+    const fire = (key: string) => {
+      const ev = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+      ed.codemirror._emit('keydown', ed.codemirror, ev)
+      return ev
+    }
+    fire('ArrowDown')
+    expect(activeIdx()).toBe(1)
+    expect(p.style.display).toBe('block') // MUST stay open (regression: cursorActivity closed it)
+    fire('ArrowUp')
+    expect(activeIdx()).toBe(0)
+    expect(p.style.display).toBe('block')
+    // Arrow keys must preventDefault so CM doesn't move the caret instead.
+    expect(fire('ArrowDown').defaultPrevented).toBe(true)
+  })
+
+  it('a tolerant cursorActivity does not close the popup on in-place caret moves', async () => {
+    attachBacktickAutocomplete(ed, bridge)
+    await flushTimers()
+    typeBacktick(ed, 'see ')
+    await flushTimers()
+    expect(popup()!.style.display).toBe('block')
+    // cursorActivity while the caret is still after the trigger → stays open.
+    ed.codemirror._emit('cursorActivity')
+    expect(popup()!.style.display).toBe('block')
+  })
+
+  it('Enter selects the highlighted item (no newline) in the id phase', async () => {
+    attachBacktickAutocomplete(ed, bridge)
+    await flushTimers()
+    typeBacktick(ed, 'see ')
+    await flushTimers()
+    const fire = (key: string) => {
+      const ev = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+      ed.codemirror._emit('keydown', ed.codemirror, ev)
+      return ev
+    }
+    // highlight "Ticket" then Enter → id phase
+    const labels = () => [...popup()!.querySelectorAll('.rela-bt-title')].map((o) => o.textContent)
+    const tIdx = labels().indexOf('Ticket')
+    for (let i = 0; i < tIdx; i++) fire('ArrowDown')
+    fire('Enter')
+    await flushTimers()
+    // Enter on the first entity inserts it, no newline.
+    fire('Enter')
+    await Promise.resolve()
+    expect(ed.codemirror._getText()).toBe('see `TKT-AAAA`')
+  })
+
   it('destroy() removes the popup and unsubscribes', async () => {
     const ctrl = attachBacktickAutocomplete(ed, bridge)
     await flushTimers()

--- a/frontend/src/app-editor/relaBacktick.ts
+++ b/frontend/src/app-editor/relaBacktick.ts
@@ -374,6 +374,18 @@ export function attachBacktickAutocomplete(editor: EasyMDE, bridge: Bridge): Bac
     applyTyped(typed)
   }
 
+  // cursorActivity is SEPARATE from change and must be tolerant: arrow-key
+  // navigation in the popup must NOT close the session. Only close when the
+  // caret leaves the trigger's line or retreats to/before the trigger (e.g. a
+  // click elsewhere). We intentionally do NOT re-run applyTyped here (that's
+  // the change handler's job) — doing so on every caret move is what closed the
+  // popup on ArrowUp/Down. (TKT-D2JML7)
+  function onCursorActivity(): void {
+    if (phase === 'idle') return
+    const cur = cm.getCursor()
+    if (!triggerPos || cur.line !== triggerPos.line || cur.ch <= triggerPos.ch) reset()
+  }
+
   function onKeyDown(_cm: unknown, ev: KeyboardEvent): void {
     if (phase !== 'prefix' && phase !== 'id') return
     const count = phase === 'prefix' ? prefixItems.length : entityItems.length
@@ -394,11 +406,13 @@ export function attachBacktickAutocomplete(editor: EasyMDE, bridge: Bridge): Bac
   // Warm the prefix cache so the first trigger is instant.
   void ensurePrefixes().then((p) => { cachedPrefixes = p })
 
+  const onBlur = (): void => { setTimeout(reset, 150) } // let a popup click land first
+
   cm.on('inputRead', onInputRead as (...a: unknown[]) => void)
   cm.on('change', onChange)
   cm.on('keydown', onKeyDown as (...a: unknown[]) => void)
-  cm.on('cursorActivity', onChange) // close/re-eval on caret moves
-  cm.on('blur', () => setTimeout(reset, 100)) // let a click on the popup land first
+  cm.on('cursorActivity', onCursorActivity)
+  cm.on('blur', onBlur)
 
   return {
     destroy() {
@@ -406,7 +420,8 @@ export function attachBacktickAutocomplete(editor: EasyMDE, bridge: Bridge): Bac
       cm.off('inputRead', onInputRead as (...a: unknown[]) => void)
       cm.off('change', onChange)
       cm.off('keydown', onKeyDown as (...a: unknown[]) => void)
-      cm.off('cursorActivity', onChange)
+      cm.off('cursorActivity', onCursorActivity)
+      cm.off('blur', onBlur)
       if (popup.parentNode) popup.parentNode.removeChild(popup)
     },
   }

--- a/frontend/src/app-editor/relaBacktick.ts
+++ b/frontend/src/app-editor/relaBacktick.ts
@@ -1,0 +1,413 @@
+// Inline backtick-triggered entity-reference autocomplete for <rela-editor>
+// (TKT-D2JML7). A plain-DOM, framework-free, bridge-fed port of the SPA's
+// useBacktickAutocomplete (TKT-2RCP): type `` ` `` → pick a type prefix
+// (TKT-, FEAT-, …) → pick an entity → inserts `` `<ID>` `` at the cursor.
+//
+// Differences from the SPA version (by necessity / scope):
+//   - Data comes through the bridge (window.rela.schema/search/list), NOT axios
+//     — the app iframe has `connect-src 'none'` so it cannot fetch directly.
+//   - The popup is plain DOM (no Vue), themed via _rela.css tokens.
+//   - Insertion reuses the same `` `<id>` `` + adjacency-padding rule as
+//     insertEntityRef.ts (kept in sync; see that file for the rationale).
+//
+// The state machine mirrors the SPA: idle → pending(open-delay) → prefix → id.
+
+import type EasyMDE from 'easymde'
+
+const OPEN_DELAY_MS = 250
+const SEARCH_DEBOUNCE_MS = 150
+const MAX_RESULTS = 50
+const MIN_SEARCH_LEN = 1
+// Typing any of these ends the trigger window (can't be part of an entity ID).
+const NON_ID_CHAR = /[\s`(){}[\]<>,;:!?"'\\]/
+
+// --- bridge surface this module needs (the app injects window.rela) ---
+interface Bridge {
+  schema(): Promise<SchemaResponse>
+  search(p: { query: string; type?: string }): Promise<{ data?: EntityRow[] }>
+  list(p: { type: string; params?: Record<string, unknown> }): Promise<{ data?: EntityRow[] }>
+}
+interface SchemaResponse {
+  entities: Record<string, SchemaEntity>
+}
+interface SchemaEntity {
+  label?: string
+  id_prefix?: string
+  id_type?: string
+}
+interface EntityRow {
+  id: string
+  // _title is the server-computed display title (honours the type's
+  // display_property), so we use it directly rather than reading
+  // properties.title (which would show bare IDs for non-title display props —
+  // BUG-1P88YM). The SPA's entityDisplayTitle() util isn't importable into this
+  // standalone IIFE, but _title already encodes the same decision server-side.
+  _title?: string
+}
+
+interface PrefixItem {
+  prefix: string // "" for manual types
+  type: string
+  label: string
+  isManual: boolean
+}
+
+type Phase = 'idle' | 'pending' | 'prefix' | 'id'
+
+// Minimal CodeMirror 5 surface used here (EasyMDE's editor.codemirror).
+interface CM {
+  on(ev: string, fn: (...a: unknown[]) => void): void
+  off(ev: string, fn: (...a: unknown[]) => void): void
+  getCursor(side?: string): { line: number; ch: number }
+  getRange(a: { line: number; ch: number }, b: { line: number; ch: number }): string
+  getTokenAt(pos: { line: number; ch: number }, precise?: boolean): { type: string | null; string: string }
+  charCoords(pos: { line: number; ch: number }, mode: string): { left: number; top: number; bottom: number }
+  replaceSelection(text: string, select?: string): void
+  replaceRange(text: string, from: { line: number; ch: number }, to?: { line: number; ch: number }): void
+  focus(): void
+}
+
+// --- id validation: mirror insertEntityRef.ts's isValidId ---
+const MAX_ID_BYTES = 1024
+function isValidId(id: string): boolean {
+  if (typeof id !== 'string' || id === '' || id.length > MAX_ID_BYTES) return false
+  if (id.includes('--')) return false
+  for (let i = 0; i < id.length; i++) {
+    const c = id.charCodeAt(i)
+    if (c < 0x20 || c === 0x7f) return false
+    if (c === 0x2f || c === 0x5c || c === 0x60 || c === 0x20) return false
+  }
+  return true
+}
+
+// Insert `` `<id>` `` at the cursor with adjacency padding (mirror of
+// insertEntityRef). The trigger backtick + typed text are first removed.
+function insertRef(cm: CM, id: string): void {
+  if (!isValidId(id)) return
+  const from = cm.getCursor('from')
+  const to = cm.getCursor('to')
+  const left = from.ch === 0 ? '' : cm.getRange({ line: from.line, ch: from.ch - 1 }, from)
+  const right = cm.getRange(to, { line: to.line, ch: to.ch + 1 })
+  const leftPad = left === '`' ? ' ' : ''
+  const rightPad = right === '`' ? ' ' : ''
+  cm.replaceSelection(`${leftPad}\`${id}\`${rightPad}`, 'end')
+}
+
+// --- token-context rules (mirror of the SPA's two-side classification) ---
+// hasFormatting: the token AFTER the trigger must itself be a CM "formatting"
+// token (the backtick that opens a code span), so we only open when the `` ` ``
+// actually starts inline code — not inside a fenced block, URL, etc. The token
+// type is a space-joined class list like "formatting formatting-code comment".
+function hasFormatting(tok: { type: string | null } | null): boolean {
+  return !!(tok && tok.type && tok.type.indexOf('formatting') !== -1)
+}
+// isInlineTextContext: the token BEFORE the trigger must not be one of these
+// non-inline-text contexts (we'd be inside a comment/code/link/etc.).
+const SUPPRESS_TYPES = ['comment', 'code', 'link', 'url', 'string', 'meta', 'tag']
+function isInlineTextContext(tok: { type: string | null } | null): boolean {
+  if (!tok || !tok.type) return true
+  for (const bad of SUPPRESS_TYPES) {
+    if (tok.type.indexOf(bad) !== -1) return false
+  }
+  return true
+}
+
+function entityTitle(e: EntityRow): string {
+  return e._title || e.id
+}
+
+export interface BacktickController {
+  destroy(): void
+}
+
+export function attachBacktickAutocomplete(editor: EasyMDE, bridge: Bridge): BacktickController {
+  const cm = editor.codemirror as unknown as CM
+
+  let phase: Phase = 'idle'
+  let triggerPos: { line: number; ch: number } | null = null
+  let prefixItems: PrefixItem[] = []
+  let entityItems: EntityRow[] = []
+  let highlighted = 0
+  let resolvedPrefix: PrefixItem | null = null
+  let allPrefixes: PrefixItem[] = []
+  let openTimer: ReturnType<typeof setTimeout> | null = null
+  let searchTimer: ReturnType<typeof setTimeout> | null = null
+  let searchSeq = 0
+  let cachedPrefixes: PrefixItem[] | null = null
+
+  // --- popup DOM ---
+  const popup = document.createElement('div')
+  popup.className = 'rela-bt-popup'
+  popup.setAttribute('role', 'listbox')
+  popup.style.display = 'none'
+  // mousedown must not steal focus from the editor's textarea
+  popup.addEventListener('mousedown', (e) => e.preventDefault())
+  document.body.appendChild(popup)
+
+  function buildPrefixList(schema: SchemaResponse): PrefixItem[] {
+    const items: PrefixItem[] = []
+    for (const [type, def] of Object.entries(schema.entities || {})) {
+      const label = def.label || type
+      const prefix = def.id_prefix || ''
+      const isManual = def.id_type === 'manual' || prefix === ''
+      items.push({ prefix, type, label, isManual })
+    }
+    items.sort((a, b) => a.label.localeCompare(b.label))
+    return items
+  }
+
+  async function ensurePrefixes(): Promise<PrefixItem[]> {
+    if (cachedPrefixes) return cachedPrefixes
+    try {
+      const schema = await bridge.schema()
+      cachedPrefixes = buildPrefixList(schema)
+    } catch {
+      cachedPrefixes = []
+    }
+    return cachedPrefixes
+  }
+
+  function reset(): void {
+    if (openTimer) { clearTimeout(openTimer); openTimer = null }
+    if (searchTimer) { clearTimeout(searchTimer); searchTimer = null }
+    phase = 'idle'
+    triggerPos = null
+    prefixItems = []
+    entityItems = []
+    highlighted = 0
+    resolvedPrefix = null
+    popup.style.display = 'none'
+  }
+
+  function typedAfterTrigger(): string {
+    if (!triggerPos) return ''
+    const cur = cm.getCursor()
+    if (cur.line !== triggerPos.line || cur.ch <= triggerPos.ch) return ''
+    return cm.getRange({ line: triggerPos.line, ch: triggerPos.ch + 1 }, cur)
+  }
+
+  function position(): void {
+    if (!triggerPos) return
+    const c = cm.charCoords({ line: triggerPos.line, ch: triggerPos.ch }, 'window')
+    popup.style.left = `${Math.round(c.left)}px`
+    popup.style.top = `${Math.round(c.bottom + 2)}px`
+  }
+
+  function render(): void {
+    const rows: Array<{ label: string; sub: string }> =
+      phase === 'prefix'
+        ? prefixItems.map((p) => ({ label: p.label, sub: p.isManual ? '(manual)' : `${p.prefix}*` }))
+        : entityItems.map((e) => ({ label: entityTitle(e), sub: e.id }))
+
+    if (rows.length === 0) {
+      popup.style.display = 'none'
+      return
+    }
+    if (highlighted >= rows.length) highlighted = rows.length - 1
+    if (highlighted < 0) highlighted = 0
+
+    popup.replaceChildren()
+    rows.forEach((r, idx) => {
+      const li = document.createElement('div')
+      li.className = 'rela-bt-option' + (idx === highlighted ? ' active' : '')
+      li.setAttribute('role', 'option')
+      const title = document.createElement('span')
+      title.className = 'rela-bt-title'
+      title.textContent = r.label
+      const sub = document.createElement('span')
+      sub.className = 'rela-bt-sub'
+      sub.textContent = r.sub
+      li.append(title, sub)
+      li.addEventListener('mouseenter', () => { highlighted = idx; render() })
+      li.addEventListener('click', () => choose(idx))
+      popup.appendChild(li)
+    })
+    position()
+    popup.style.display = 'block'
+  }
+
+  function filterPrefix(typed: string): void {
+    const upper = typed.toUpperCase()
+    const lower = typed.toLowerCase()
+    prefixItems = allPrefixes.filter((p) =>
+      p.isManual
+        ? p.label.toLowerCase().startsWith(lower)
+        : p.prefix.toUpperCase().startsWith(upper) || upper.startsWith(p.prefix.toUpperCase()),
+    )
+    if (prefixItems.length === 0) { reset(); return }
+  }
+
+  function exactPrefix(typed: string): PrefixItem | null {
+    const upper = typed.toUpperCase()
+    let best: PrefixItem | null = null
+    for (const p of prefixItems) {
+      if (p.isManual || p.prefix.length === 0) continue
+      const pu = p.prefix.toUpperCase()
+      const startsWith = upper.startsWith(pu) && upper.length >= pu.length
+      const startsWithDash = !pu.endsWith('-') && upper.startsWith(pu + '-')
+      if (!startsWith && !startsWithDash) continue
+      if (best === null || p.prefix.length > best.prefix.length) best = p
+    }
+    return best
+  }
+
+  function toIdPhase(prefix: PrefixItem): void {
+    phase = 'id'
+    resolvedPrefix = prefix
+    entityItems = []
+    highlighted = 0
+    scheduleSearch('')
+  }
+
+  function scheduleSearch(query: string): void {
+    if (searchTimer) clearTimeout(searchTimer)
+    searchTimer = setTimeout(() => void runSearch(query), SEARCH_DEBOUNCE_MS)
+  }
+
+  async function runSearch(query: string): Promise<void> {
+    if (!resolvedPrefix) return
+    const type = resolvedPrefix.type
+    const seq = ++searchSeq
+    try {
+      const resp =
+        query.length >= MIN_SEARCH_LEN
+          ? await bridge.search({ query, type })
+          : await bridge.list({ type, params: { per_page: MAX_RESULTS } })
+      if (seq !== searchSeq || phase !== 'id') return // superseded / closed
+      entityItems = (resp.data || []).slice(0, MAX_RESULTS)
+      highlighted = 0
+      render()
+    } catch {
+      if (seq !== searchSeq) return
+      entityItems = []
+      render()
+    }
+  }
+
+  function applyTyped(typed: string): void {
+    if (phase === 'id' && resolvedPrefix && resolvedPrefix.prefix) {
+      if (!typed.toUpperCase().startsWith(resolvedPrefix.prefix.toUpperCase())) {
+        // backspaced out of the id body → back to prefix phase
+        phase = 'prefix'
+        resolvedPrefix = null
+        prefixItems = allPrefixes
+      }
+    }
+    if (phase === 'prefix') {
+      filterPrefix(typed)
+      if (phase !== 'prefix') return
+      const exact = exactPrefix(typed)
+      if (exact) { toIdPhase(exact); return }
+      render()
+    } else if (phase === 'id') {
+      const prefix = resolvedPrefix?.prefix ?? ''
+      let partial = typed.toUpperCase().startsWith(prefix.toUpperCase()) ? typed.slice(prefix.length) : typed
+      if (partial.startsWith('-')) partial = partial.slice(1)
+      scheduleSearch(partial)
+    }
+  }
+
+  function choose(idx: number): void {
+    const trig = triggerPos
+    if (!trig) return
+    if (phase === 'prefix') {
+      const item = prefixItems[idx]
+      if (!item) return
+      // Replace the typed-so-far with the prefix text, then go to id phase.
+      const cur = cm.getCursor()
+      cm.replaceRange(item.prefix, { line: trig.line, ch: trig.ch + 1 }, cur)
+      phase = 'prefix' // applyTyped will move to id
+      filterPrefix(item.prefix)
+      const exact = exactPrefix(item.prefix)
+      if (exact) toIdPhase(exact)
+      else render()
+      cm.focus()
+      return
+    }
+    if (phase === 'id') {
+      const ent = entityItems[idx]
+      if (!ent) return
+      // Remove the trigger backtick + everything typed after it, then insert
+      // the proper `<id>` code span.
+      const cur = cm.getCursor()
+      cm.replaceRange('', { line: trig.line, ch: trig.ch }, cur)
+      insertRef(cm, ent.id)
+      reset()
+      cm.focus()
+    }
+  }
+
+  // --- CM event handlers ---
+  function onInputRead(_cm: unknown, change: { text: string[]; from: { line: number; ch: number } }): void {
+    if (phase !== 'idle') return
+    if (change.text.length !== 1 || change.text[0] !== '`') return
+    const line = change.from.line
+    const ch = change.from.ch
+    const after = cm.getTokenAt({ line, ch: ch + 1 }, true)
+    const before = ch > 0 ? cm.getTokenAt({ line, ch: ch - 1 }, true) : null
+    if (!hasFormatting(after)) return
+    if (before && !isInlineTextContext(before)) return
+
+    triggerPos = { line, ch }
+    phase = 'pending'
+    openTimer = setTimeout(() => {
+      openTimer = null
+      if (phase !== 'pending') return
+      const typed = typedAfterTrigger()
+      if (NON_ID_CHAR.test(typed)) { reset(); return }
+      phase = 'prefix'
+      allPrefixes = cachedPrefixes || []
+      prefixItems = allPrefixes
+      highlighted = 0
+      render()
+      if (typed.length > 0) applyTyped(typed)
+    }, OPEN_DELAY_MS)
+  }
+
+  function onChange(): void {
+    if (phase === 'idle') return
+    const cur = cm.getCursor()
+    if (!triggerPos || cur.line !== triggerPos.line || cur.ch <= triggerPos.ch) { reset(); return }
+    const typed = typedAfterTrigger()
+    if (NON_ID_CHAR.test(typed)) { reset(); return }
+    if (phase === 'pending') return
+    applyTyped(typed)
+  }
+
+  function onKeyDown(_cm: unknown, ev: KeyboardEvent): void {
+    if (phase !== 'prefix' && phase !== 'id') return
+    const count = phase === 'prefix' ? prefixItems.length : entityItems.length
+    if (count === 0) return
+    switch (ev.key) {
+      case 'ArrowDown':
+        ev.preventDefault(); highlighted = (highlighted + 1) % count; render(); break
+      case 'ArrowUp':
+        ev.preventDefault(); highlighted = (highlighted - 1 + count) % count; render(); break
+      case 'Enter':
+      case 'Tab':
+        ev.preventDefault(); choose(highlighted); break
+      case 'Escape':
+        ev.preventDefault(); reset(); break
+    }
+  }
+
+  // Warm the prefix cache so the first trigger is instant.
+  void ensurePrefixes().then((p) => { cachedPrefixes = p })
+
+  cm.on('inputRead', onInputRead as (...a: unknown[]) => void)
+  cm.on('change', onChange)
+  cm.on('keydown', onKeyDown as (...a: unknown[]) => void)
+  cm.on('cursorActivity', onChange) // close/re-eval on caret moves
+  cm.on('blur', () => setTimeout(reset, 100)) // let a click on the popup land first
+
+  return {
+    destroy() {
+      reset()
+      cm.off('inputRead', onInputRead as (...a: unknown[]) => void)
+      cm.off('change', onChange)
+      cm.off('keydown', onKeyDown as (...a: unknown[]) => void)
+      cm.off('cursorActivity', onChange)
+      if (popup.parentNode) popup.parentNode.removeChild(popup)
+    },
+  }
+}

--- a/frontend/src/app-editor/relaEditor.test.ts
+++ b/frontend/src/app-editor/relaEditor.test.ts
@@ -44,7 +44,12 @@ function makeFakeEasyMDE(opts: { initialValue?: string }): FakeEasyMDE {
   const editor: FakeEasyMDE = {
     codemirror: cm,
     value: (v?: string) => {
-      if (v !== undefined) val = v
+      if (v !== undefined) {
+        val = v
+        // Real EasyMDE.value(v) drives CodeMirror's 'change' handler; mirror
+        // that so the element's programmatic-set suppression is exercised.
+        cm._emit('change')
+      }
       return val
     },
     toTextArea: vi.fn(),
@@ -73,6 +78,11 @@ function makeEditor(): HTMLElement & { value: string } {
   return document.createElement('rela-editor') as HTMLElement & { value: string }
 }
 
+// connectedCallback defers the EasyMDE mount to a microtask (so it doesn't
+// block the parse path). flush() awaits that microtask so tests observe the
+// mounted editor.
+const flush = () => Promise.resolve()
+
 describe('<rela-editor> contract', () => {
   beforeEach(() => {
     lastEditor = null
@@ -83,32 +93,54 @@ describe('<rela-editor> contract', () => {
     expect(customElements.get('rela-editor')).toBeTruthy()
   })
 
-  it('flushes a value set BEFORE connection into the editor', () => {
+  it('flushes a value set BEFORE connection into the editor', async () => {
     const ed = makeEditor()
     ed.value = '# Before connect'
     document.body.appendChild(ed)
+    await flush()
     expect(ed.value).toBe('# Before connect')
     expect(lastEditor!.value()).toBe('# Before connect')
   })
 
-  it('round-trips value set AFTER connection', () => {
+  it('round-trips value set AFTER connection', async () => {
     const ed = makeEditor()
     document.body.appendChild(ed)
+    await flush()
     ed.value = '## After'
     expect(ed.value).toBe('## After')
   })
 
-  it('preserves whitespace-sensitive markdown exactly', () => {
+  it('preserves whitespace-sensitive markdown exactly', async () => {
     const ed = makeEditor()
     document.body.appendChild(ed)
+    await flush()
     const md = '- a\n    indented code\n\n\ttab line\n'
     ed.value = md
     expect(ed.value).toBe(md)
   })
 
-  it('dispatches input on CodeMirror change and change on blur', () => {
+  it('does NOT emit input when value is set programmatically', async () => {
+    // A native <textarea>.value setter is silent; <rela-editor> must match,
+    // else loading content into the editor triggers autosave loops in
+    // consumers (the bug that froze the Today app's goals load). The fake's
+    // value() emits a CodeMirror 'change' like EasyMDE, so the suppression
+    // path is exercised.
     const ed = makeEditor()
     document.body.appendChild(ed)
+    await flush()
+    const onInput = vi.fn()
+    ed.addEventListener('input', onInput)
+    ed.value = 'programmatic content'
+    expect(onInput).not.toHaveBeenCalled()
+    // But a genuine user edit (cm change OUTSIDE the setter) still fires input.
+    lastEditor!.codemirror._emit('change')
+    expect(onInput).toHaveBeenCalledOnce()
+  })
+
+  it('dispatches input on CodeMirror change and change on blur', async () => {
+    const ed = makeEditor()
+    document.body.appendChild(ed)
+    await flush()
     const onInput = vi.fn()
     const onChange = vi.fn()
     ed.addEventListener('input', onInput)
@@ -119,25 +151,28 @@ describe('<rela-editor> contract', () => {
     expect(onChange).toHaveBeenCalledOnce()
   })
 
-  it('applies readonly via attribute at mount and on change', () => {
+  it('applies readonly via attribute at mount and on change', async () => {
     const ed = makeEditor()
     ed.setAttribute('readonly', '')
     document.body.appendChild(ed)
+    await flush()
     expect(lastEditor!.codemirror.setOption).toHaveBeenCalledWith('readOnly', true)
     ed.removeAttribute('readonly')
     expect(lastEditor!.codemirror.setOption).toHaveBeenCalledWith('readOnly', false)
   })
 
-  it('focus() delegates to the editor', () => {
+  it('focus() delegates to the editor', async () => {
     const ed = makeEditor()
     document.body.appendChild(ed)
+    await flush()
     ed.focus()
     expect(lastEditor!.codemirror.focus).toHaveBeenCalledOnce()
   })
 
-  it('tears down EasyMDE on disconnect and preserves value across re-connect', () => {
+  it('tears down EasyMDE on disconnect and preserves value across re-connect', async () => {
     const ed = makeEditor()
     document.body.appendChild(ed)
+    await flush()
     ed.value = 'keep me'
     const first = lastEditor!
     ed.remove()
@@ -145,6 +180,7 @@ describe('<rela-editor> contract', () => {
     expect(first.cleanup).toHaveBeenCalledOnce()
     // Re-connect: a fresh editor seeded with the preserved value.
     document.body.appendChild(ed)
+    await flush()
     expect(ed.value).toBe('keep me')
     expect(lastEditor!.value()).toBe('keep me')
   })

--- a/frontend/src/app-editor/relaEditor.test.ts
+++ b/frontend/src/app-editor/relaEditor.test.ts
@@ -64,6 +64,7 @@ vi.mock('easymde', () => ({ default: FakeEasyMDE }))
 vi.mock('easymde/dist/easymde.min.css?inline', () => ({ default: '' }))
 vi.mock('font-awesome/css/font-awesome.min.css?inline', () => ({ default: '' }))
 vi.mock('./relaEditorFont.css?inline', () => ({ default: '' }))
+vi.mock('./relaEditorTheme.css?inline', () => ({ default: '' }))
 
 // Import after mocks so customElements.define runs against the fake.
 await import('./relaEditor')

--- a/frontend/src/app-editor/relaEditor.test.ts
+++ b/frontend/src/app-editor/relaEditor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 
 // The <rela-editor> element wraps EasyMDE, which needs real layout (CodeMirror 5)
 // and doesn't mount under happy-dom. We mock EasyMDE so these tests exercise the
@@ -10,8 +10,11 @@ interface FakeCM {
   on(ev: string, fn: () => void): void
   off(ev: string, fn: () => void): void
   focus: ReturnType<typeof vi.fn>
-  setOption: ReturnType<typeof vi.fn>
+  setOption: Mock
+  getOption(name: string): unknown
   _emit(ev: string): void
+  _setValue(v: string): void // simulate a USER edit (no setter suppression)
+  _options: Record<string, unknown>
 }
 
 interface FakeEasyMDE {
@@ -22,12 +25,14 @@ interface FakeEasyMDE {
 }
 
 let lastEditor: FakeEasyMDE | null = null
+const toggleFullScreenSpy = vi.fn()
 
 // Built with closures (no `this`) so the handler registry and value are
 // captured locally — keeps eslint's no-this-alias happy and the fake simple.
 function makeFakeEasyMDE(opts: { initialValue?: string }): FakeEasyMDE {
   let val = opts.initialValue ?? ''
   const handlers: Record<string, Array<() => void>> = {}
+  const options: Record<string, unknown> = {}
   const cm: FakeCM = {
     on: (ev, fn) => {
       ;(handlers[ev] ||= []).push(fn)
@@ -36,10 +41,18 @@ function makeFakeEasyMDE(opts: { initialValue?: string }): FakeEasyMDE {
       handlers[ev] = (handlers[ev] || []).filter((f) => f !== fn)
     },
     focus: vi.fn(),
-    setOption: vi.fn(),
+    setOption: vi.fn((name: string, v: unknown) => {
+      options[name] = v
+    }),
+    getOption: (name: string) => options[name],
     _emit: (ev) => {
       ;(handlers[ev] || []).forEach((f) => f())
     },
+    _setValue: (v: string) => {
+      val = v
+      cm._emit('change')
+    },
+    _options: options,
   }
   const editor: FakeEasyMDE = {
     codemirror: cm,
@@ -59,10 +72,17 @@ function makeFakeEasyMDE(opts: { initialValue?: string }): FakeEasyMDE {
   return editor
 }
 
-// EasyMDE is used as `new EasyMDE(opts)`; wrap the factory so `new` works.
+// EasyMDE is used as `new EasyMDE(opts)` with a static `toggleFullScreen`.
 const FakeEasyMDE = function (this: unknown, opts: { initialValue?: string }) {
   return makeFakeEasyMDE(opts)
-} as unknown as new (opts: { initialValue?: string }) => FakeEasyMDE
+} as unknown as (new (opts: { initialValue?: string }) => FakeEasyMDE) & {
+  toggleFullScreen: (e: FakeEasyMDE) => void
+}
+FakeEasyMDE.toggleFullScreen = (e: FakeEasyMDE) => {
+  toggleFullScreenSpy(e)
+  // mirror EasyMDE: flips the cm fullScreen option
+  e.codemirror.setOption('fullScreen', !e.codemirror.getOption('fullScreen'))
+}
 
 vi.mock('easymde', () => ({ default: FakeEasyMDE }))
 // The ?inline CSS imports return strings; stub them so the module loads.
@@ -86,6 +106,7 @@ const flush = () => Promise.resolve()
 describe('<rela-editor> contract', () => {
   beforeEach(() => {
     lastEditor = null
+    toggleFullScreenSpy.mockClear()
     document.body.replaceChildren()
   })
 
@@ -137,7 +158,7 @@ describe('<rela-editor> contract', () => {
     expect(onInput).toHaveBeenCalledOnce()
   })
 
-  it('dispatches input on CodeMirror change and change on blur', async () => {
+  it('dispatches input on CodeMirror change, and change on blur after an edit', async () => {
     const ed = makeEditor()
     document.body.appendChild(ed)
     await flush()
@@ -145,10 +166,24 @@ describe('<rela-editor> contract', () => {
     const onChange = vi.fn()
     ed.addEventListener('input', onInput)
     ed.addEventListener('change', onChange)
-    lastEditor!.codemirror._emit('change')
+    lastEditor!.codemirror._emit('focus') // snapshot value at focus
+    lastEditor!.codemirror._setValue('user typed this') // a real edit
     lastEditor!.codemirror._emit('blur')
     expect(onInput).toHaveBeenCalledOnce()
     expect(onChange).toHaveBeenCalledOnce()
+  })
+
+  it('does NOT dispatch change on blur when nothing was edited (native textarea semantics)', async () => {
+    const ed = makeEditor()
+    document.body.appendChild(ed)
+    await flush()
+    const onChange = vi.fn()
+    ed.addEventListener('change', onChange)
+    // Focus then blur with no edit in between → no change event (a click-away
+    // must not trigger autosave).
+    lastEditor!.codemirror._emit('focus')
+    lastEditor!.codemirror._emit('blur')
+    expect(onChange).not.toHaveBeenCalled()
   })
 
   it('applies readonly via attribute at mount and on change', async () => {
@@ -183,5 +218,25 @@ describe('<rela-editor> contract', () => {
     await flush()
     expect(ed.value).toBe('keep me')
     expect(lastEditor!.value()).toBe('keep me')
+  })
+
+  it('exits fullscreen on teardown so the host page is not left unscrollable', async () => {
+    const ed = makeEditor()
+    document.body.appendChild(ed)
+    await flush()
+    // Simulate the user entering fullscreen (EasyMDE sets the cm option).
+    lastEditor!.codemirror.setOption('fullScreen', true)
+    ed.remove()
+    // Teardown must have toggled fullscreen back off (which restores
+    // document.body.style.overflow in real EasyMDE).
+    expect(toggleFullScreenSpy).toHaveBeenCalledOnce()
+  })
+
+  it('does not toggle fullscreen on teardown when not fullscreen', async () => {
+    const ed = makeEditor()
+    document.body.appendChild(ed)
+    await flush()
+    ed.remove()
+    expect(toggleFullScreenSpy).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/app-editor/relaEditor.test.ts
+++ b/frontend/src/app-editor/relaEditor.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// The <rela-editor> element wraps EasyMDE, which needs real layout (CodeMirror 5)
+// and doesn't mount under happy-dom. We mock EasyMDE so these tests exercise the
+// ELEMENT's public contract — the swap seam (value/placeholder/readonly/events/
+// focus/teardown) — independent of the editor implementation. A real-browser
+// mount is covered by the manual app smoke test; here we pin the contract.
+
+interface FakeCM {
+  on(ev: string, fn: () => void): void
+  off(ev: string, fn: () => void): void
+  focus: ReturnType<typeof vi.fn>
+  setOption: ReturnType<typeof vi.fn>
+  _emit(ev: string): void
+}
+
+interface FakeEasyMDE {
+  codemirror: FakeCM
+  value(v?: string): string
+  toTextArea: ReturnType<typeof vi.fn>
+  cleanup: ReturnType<typeof vi.fn>
+}
+
+let lastEditor: FakeEasyMDE | null = null
+
+// Built with closures (no `this`) so the handler registry and value are
+// captured locally — keeps eslint's no-this-alias happy and the fake simple.
+function makeFakeEasyMDE(opts: { initialValue?: string }): FakeEasyMDE {
+  let val = opts.initialValue ?? ''
+  const handlers: Record<string, Array<() => void>> = {}
+  const cm: FakeCM = {
+    on: (ev, fn) => {
+      ;(handlers[ev] ||= []).push(fn)
+    },
+    off: (ev, fn) => {
+      handlers[ev] = (handlers[ev] || []).filter((f) => f !== fn)
+    },
+    focus: vi.fn(),
+    setOption: vi.fn(),
+    _emit: (ev) => {
+      ;(handlers[ev] || []).forEach((f) => f())
+    },
+  }
+  const editor: FakeEasyMDE = {
+    codemirror: cm,
+    value: (v?: string) => {
+      if (v !== undefined) val = v
+      return val
+    },
+    toTextArea: vi.fn(),
+    cleanup: vi.fn(),
+  }
+  lastEditor = editor
+  return editor
+}
+
+// EasyMDE is used as `new EasyMDE(opts)`; wrap the factory so `new` works.
+const FakeEasyMDE = function (this: unknown, opts: { initialValue?: string }) {
+  return makeFakeEasyMDE(opts)
+} as unknown as new (opts: { initialValue?: string }) => FakeEasyMDE
+
+vi.mock('easymde', () => ({ default: FakeEasyMDE }))
+// The ?inline CSS imports return strings; stub them so the module loads.
+vi.mock('easymde/dist/easymde.min.css?inline', () => ({ default: '' }))
+vi.mock('font-awesome/css/font-awesome.min.css?inline', () => ({ default: '' }))
+vi.mock('./relaEditorFont.css?inline', () => ({ default: '' }))
+
+// Import after mocks so customElements.define runs against the fake.
+await import('./relaEditor')
+
+function makeEditor(): HTMLElement & { value: string } {
+  return document.createElement('rela-editor') as HTMLElement & { value: string }
+}
+
+describe('<rela-editor> contract', () => {
+  beforeEach(() => {
+    lastEditor = null
+    document.body.replaceChildren()
+  })
+
+  it('registers the custom element', () => {
+    expect(customElements.get('rela-editor')).toBeTruthy()
+  })
+
+  it('flushes a value set BEFORE connection into the editor', () => {
+    const ed = makeEditor()
+    ed.value = '# Before connect'
+    document.body.appendChild(ed)
+    expect(ed.value).toBe('# Before connect')
+    expect(lastEditor!.value()).toBe('# Before connect')
+  })
+
+  it('round-trips value set AFTER connection', () => {
+    const ed = makeEditor()
+    document.body.appendChild(ed)
+    ed.value = '## After'
+    expect(ed.value).toBe('## After')
+  })
+
+  it('preserves whitespace-sensitive markdown exactly', () => {
+    const ed = makeEditor()
+    document.body.appendChild(ed)
+    const md = '- a\n    indented code\n\n\ttab line\n'
+    ed.value = md
+    expect(ed.value).toBe(md)
+  })
+
+  it('dispatches input on CodeMirror change and change on blur', () => {
+    const ed = makeEditor()
+    document.body.appendChild(ed)
+    const onInput = vi.fn()
+    const onChange = vi.fn()
+    ed.addEventListener('input', onInput)
+    ed.addEventListener('change', onChange)
+    lastEditor!.codemirror._emit('change')
+    lastEditor!.codemirror._emit('blur')
+    expect(onInput).toHaveBeenCalledOnce()
+    expect(onChange).toHaveBeenCalledOnce()
+  })
+
+  it('applies readonly via attribute at mount and on change', () => {
+    const ed = makeEditor()
+    ed.setAttribute('readonly', '')
+    document.body.appendChild(ed)
+    expect(lastEditor!.codemirror.setOption).toHaveBeenCalledWith('readOnly', true)
+    ed.removeAttribute('readonly')
+    expect(lastEditor!.codemirror.setOption).toHaveBeenCalledWith('readOnly', false)
+  })
+
+  it('focus() delegates to the editor', () => {
+    const ed = makeEditor()
+    document.body.appendChild(ed)
+    ed.focus()
+    expect(lastEditor!.codemirror.focus).toHaveBeenCalledOnce()
+  })
+
+  it('tears down EasyMDE on disconnect and preserves value across re-connect', () => {
+    const ed = makeEditor()
+    document.body.appendChild(ed)
+    ed.value = 'keep me'
+    const first = lastEditor!
+    ed.remove()
+    expect(first.toTextArea).toHaveBeenCalledOnce()
+    expect(first.cleanup).toHaveBeenCalledOnce()
+    // Re-connect: a fresh editor seeded with the preserved value.
+    document.body.appendChild(ed)
+    expect(ed.value).toBe('keep me')
+    expect(lastEditor!.value()).toBe('keep me')
+  })
+})

--- a/frontend/src/app-editor/relaEditor.ts
+++ b/frontend/src/app-editor/relaEditor.ts
@@ -30,6 +30,15 @@ import fontOverrideCSS from './relaEditorFont.css?inline'
 // the editor follows the host light/dark theme. Injected LAST so it wins over
 // EasyMDE's own CSS.
 import themeCSS from './relaEditorTheme.css?inline'
+import { attachBacktickAutocomplete, type BacktickController } from './relaBacktick'
+
+// The bridge SDK (_rela.js) exposes window.rela. The backtick autocomplete only
+// needs three read methods; declare the minimal shape we consume.
+interface RelaBridge {
+  schema(): Promise<{ entities: Record<string, { label?: string; id_prefix?: string; id_type?: string }> }>
+  search(p: { query: string; type?: string }): Promise<{ data?: Array<{ id: string }> }>
+  list(p: { type: string; params?: Record<string, unknown> }): Promise<{ data?: Array<{ id: string }> }>
+}
 
 const TAG = 'rela-editor'
 const STYLE_ID = 'rela-editor-styles'
@@ -51,6 +60,8 @@ class RelaEditorElement extends HTMLElement {
   // Set only when EasyMDE construction failed and we fell back to the raw
   // <textarea>. When non-null, the value/focus contract routes through it.
   private _fallbackTextarea: HTMLTextAreaElement | null = null
+  // Backtick entity-reference autocomplete, attached when window.rela is present.
+  private _backtick: BacktickController | null = null
   // Holds the value set via the property before the element is connected (and
   // before EasyMDE exists). Flushed into the editor on connect.
   private _pendingValue = ''
@@ -237,9 +248,25 @@ class RelaEditorElement extends HTMLElement {
     // meaningful while _editor is null (the getter/setter both check _editor
     // first); _unmount repopulates it from the live value on teardown.
     this._pendingValue = ''
+
+    // Attach backtick entity-reference autocomplete when the bridge is present.
+    // The app sets window.rela via _rela.js; if it's absent (editor used without
+    // the bridge) we just skip completion — the editor still works.
+    const bridge = (window as unknown as { rela?: RelaBridge }).rela
+    if (bridge && typeof bridge.schema === 'function') {
+      try {
+        this._backtick = attachBacktickAutocomplete(editor, bridge)
+      } catch (err) {
+        console.error('[rela-editor] backtick autocomplete failed to attach', err)
+      }
+    }
   }
 
   private _unmount(): void {
+    if (this._backtick) {
+      this._backtick.destroy()
+      this._backtick = null
+    }
     if (this._editor) {
       if (this._onCmChange) this._editor.codemirror.off('change', this._onCmChange)
       if (this._onCmFocus) this._editor.codemirror.off('focus', this._onCmFocus)

--- a/frontend/src/app-editor/relaEditor.ts
+++ b/frontend/src/app-editor/relaEditor.ts
@@ -26,6 +26,10 @@ import fontAwesomeCSS from 'font-awesome/css/font-awesome.min.css?inline'
 // path (_rela-editor.woff2), permitted by the app CSP's `font-src <base>`.
 // Injected AFTER fontAwesomeCSS so it wins.
 import fontOverrideCSS from './relaEditorFont.css?inline'
+// Theme override: re-skins EasyMDE's hardcoded light chrome with rela tokens so
+// the editor follows the host light/dark theme. Injected LAST so it wins over
+// EasyMDE's own CSS.
+import themeCSS from './relaEditorTheme.css?inline'
 
 const TAG = 'rela-editor'
 const STYLE_ID = 'rela-editor-styles'
@@ -37,7 +41,7 @@ function ensureStylesInjected(): void {
   if (document.getElementById(STYLE_ID)) return
   const style = document.createElement('style')
   style.id = STYLE_ID
-  style.textContent = [fontAwesomeCSS, fontOverrideCSS, easymdeCSS].join('\n')
+  style.textContent = [fontAwesomeCSS, fontOverrideCSS, easymdeCSS, themeCSS].join('\n')
   document.head.appendChild(style)
 }
 

--- a/frontend/src/app-editor/relaEditor.ts
+++ b/frontend/src/app-editor/relaEditor.ts
@@ -1,0 +1,178 @@
+// <rela-editor> — a self-contained markdown editor Custom Element for custom
+// apps (TKT-5F9V56). Bundled into a standalone IIFE (vite.editor.config.ts) and
+// served at the reserved per-app path /api/v1/_apps/<id>/_rela-editor.js.
+//
+// PUBLIC CONTRACT (the swap seam — this and nothing else is supported):
+//   - property  `value`       get/set markdown text, whitespace-exact
+//   - attribute `placeholder` plain-text placeholder
+//   - attribute `readonly`    boolean
+//   - event     `input`       dispatched on every change (per keystroke)
+//   - event     `change`      dispatched on blur/commit
+//   - method    `focus()`
+//
+// Everything else (that it's EasyMDE/CodeMirror underneath, the toolbar, the
+// generated DOM) is an UNSUPPORTED implementation detail. The element renders
+// into its own LIGHT DOM (not shadow DOM) because EasyMDE is built on
+// CodeMirror 5, which misbehaves inside a shadow root. The narrow API above is
+// what lets the editor be swapped later without touching plugins.
+
+import EasyMDE from 'easymde'
+// CSS is imported with ?inline so Vite returns it as a STRING (not an emitted
+// sibling file), letting the build stay a single self-contained IIFE. The
+// strings are injected into <head> once, on first element mount.
+import easymdeCSS from 'easymde/dist/easymde.min.css?inline'
+import fontAwesomeCSS from 'font-awesome/css/font-awesome.min.css?inline'
+// Font-face override: points FA's glyph webfont at the app-relative reserved
+// path (_rela-editor.woff2), permitted by the app CSP's `font-src <base>`.
+// Injected AFTER fontAwesomeCSS so it wins.
+import fontOverrideCSS from './relaEditorFont.css?inline'
+
+const TAG = 'rela-editor'
+const STYLE_ID = 'rela-editor-styles'
+
+// Inject the editor's stylesheets into the document head exactly once,
+// regardless of how many <rela-editor> elements mount. Order matters: FA base,
+// then the font-face override, then EasyMDE's own CSS.
+function ensureStylesInjected(): void {
+  if (document.getElementById(STYLE_ID)) return
+  const style = document.createElement('style')
+  style.id = STYLE_ID
+  style.textContent = [fontAwesomeCSS, fontOverrideCSS, easymdeCSS].join('\n')
+  document.head.appendChild(style)
+}
+
+class RelaEditorElement extends HTMLElement {
+  private _editor: EasyMDE | null = null
+  private _textarea: HTMLTextAreaElement | null = null
+  // Holds the value set via the property before the element is connected (and
+  // before EasyMDE exists). Flushed into the editor on connect.
+  private _pendingValue = ''
+  private _onCmChange: (() => void) | null = null
+  private _onCmBlur: (() => void) | null = null
+
+  static get observedAttributes(): string[] {
+    return ['placeholder', 'readonly']
+  }
+
+  connectedCallback(): void {
+    if (this._editor) return // already mounted (re-connect)
+    this._mount()
+  }
+
+  disconnectedCallback(): void {
+    this._unmount()
+  }
+
+  attributeChangedCallback(name: string): void {
+    if (!this._editor) return
+    if (name === 'readonly') {
+      this._editor.codemirror.setOption('readOnly', this.hasAttribute('readonly'))
+    }
+    // EasyMDE has no live placeholder setter; placeholder is read at mount.
+    // Changing it after mount is not part of the supported contract.
+  }
+
+  // --- public property: value (markdown text, whitespace-exact) ---
+  get value(): string {
+    return this._editor ? this._editor.value() : this._pendingValue
+  }
+
+  set value(v: string) {
+    const next = v == null ? '' : String(v)
+    if (this._editor) {
+      // Only replace if different, so setting the same value doesn't reset
+      // the cursor/scroll.
+      if (this._editor.value() !== next) this._editor.value(next)
+    } else {
+      this._pendingValue = next
+    }
+  }
+
+  // --- public method: focus() ---
+  override focus(): void {
+    if (this._editor) this._editor.codemirror.focus()
+    else super.focus()
+  }
+
+  private _mount(): void {
+    ensureStylesInjected()
+    const ta = document.createElement('textarea')
+    // Seed EasyMDE with the pending value via the textarea so the initial
+    // content is exact (EasyMDE reads the textarea on construction).
+    ta.value = this._pendingValue
+    this.appendChild(ta)
+    this._textarea = ta
+
+    const editor = new EasyMDE({
+      element: ta,
+      initialValue: this._pendingValue,
+      placeholder: this.getAttribute('placeholder') || '',
+      spellChecker: false,
+      autofocus: false,
+      status: false,
+      // Suppress EasyMDE's runtime <link> to the FA CDN — the glyphs are
+      // bundled (and the font is served same-origin under the app base).
+      autoDownloadFontAwesome: false,
+      toolbar: [
+        'bold',
+        'italic',
+        'heading',
+        '|',
+        'unordered-list',
+        'ordered-list',
+        '|',
+        'link',
+        'code',
+        'quote',
+        '|',
+        'preview',
+        'side-by-side',
+        'fullscreen',
+        '|',
+        'guide',
+      ],
+      minHeight: '200px',
+    } satisfies EasyMDE.Options)
+
+    if (this.hasAttribute('readonly')) {
+      editor.codemirror.setOption('readOnly', true)
+    }
+
+    // Re-dispatch CodeMirror events as native element events so plugins use
+    // standard addEventListener('input'/'change').
+    this._onCmChange = () => {
+      this.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+    this._onCmBlur = () => {
+      this.dispatchEvent(new Event('change', { bubbles: true }))
+    }
+    editor.codemirror.on('change', this._onCmChange)
+    editor.codemirror.on('blur', this._onCmBlur)
+
+    this._editor = editor
+  }
+
+  private _unmount(): void {
+    if (this._editor) {
+      if (this._onCmChange) this._editor.codemirror.off('change', this._onCmChange)
+      if (this._onCmBlur) this._editor.codemirror.off('blur', this._onCmBlur)
+      // Capture the current value back to _pendingValue so a disconnect →
+      // reconnect round-trip preserves content.
+      this._pendingValue = this._editor.value()
+      // toTextArea() restores the original <textarea> and tears down CM.
+      this._editor.toTextArea()
+      this._editor.cleanup()
+      this._editor = null
+    }
+    this._onCmChange = null
+    this._onCmBlur = null
+    if (this._textarea && this._textarea.parentNode === this) {
+      this.removeChild(this._textarea)
+    }
+    this._textarea = null
+  }
+}
+
+if (!customElements.get(TAG)) {
+  customElements.define(TAG, RelaEditorElement)
+}

--- a/frontend/src/app-editor/relaEditor.ts
+++ b/frontend/src/app-editor/relaEditor.ts
@@ -53,14 +53,29 @@ class RelaEditorElement extends HTMLElement {
   private _pendingValue = ''
   private _onCmChange: (() => void) | null = null
   private _onCmBlur: (() => void) | null = null
+  // True while the .value setter is writing to EasyMDE, so the re-dispatched
+  // input event is suppressed (programmatic sets are silent, like a textarea).
+  private _settingValue = false
+  // True between connectedCallback and the deferred mount running.
+  private _mountScheduled = false
 
   static get observedAttributes(): string[] {
     return ['placeholder', 'readonly']
   }
 
   connectedCallback(): void {
-    if (this._editor) return // already mounted (re-connect)
-    this._mount()
+    if (this._editor || this._mountScheduled) return // already mounted/scheduled
+    // Defer the (heavy) EasyMDE mount off the synchronous parse/upgrade path.
+    // Building CodeMirror during HTML parsing blocks the main thread long
+    // enough that a host message (e.g. the bridge's rela:port reply, which
+    // fires rela:ready) can be processed before the page's own end-of-body
+    // scripts register their listeners — making apps miss rela:ready. A
+    // microtask lets the current parse/script finish first, then we mount.
+    this._mountScheduled = true
+    queueMicrotask(() => {
+      this._mountScheduled = false
+      if (this.isConnected && !this._editor) this._mount()
+    })
   }
 
   disconnectedCallback(): void {
@@ -86,7 +101,17 @@ class RelaEditorElement extends HTMLElement {
     if (this._editor) {
       // Only replace if different, so setting the same value doesn't reset
       // the cursor/scroll.
-      if (this._editor.value() !== next) this._editor.value(next)
+      if (this._editor.value() !== next) {
+        // Programmatic set MUST NOT emit input/change — same as a native
+        // <textarea>/<input>, whose .value setter is silent. EasyMDE's
+        // value() drives CodeMirror's change handler, so guard the dispatch.
+        this._settingValue = true
+        try {
+          this._editor.value(next)
+        } finally {
+          this._settingValue = false
+        }
+      }
     } else {
       this._pendingValue = next
     }
@@ -143,8 +168,12 @@ class RelaEditorElement extends HTMLElement {
     }
 
     // Re-dispatch CodeMirror events as native element events so plugins use
-    // standard addEventListener('input'/'change').
+    // standard addEventListener('input'/'change'). Programmatic value sets
+    // (the .value setter) are suppressed via _settingValue so they stay
+    // silent like a native <textarea> — otherwise loading content into the
+    // editor would spuriously fire input and trigger autosave loops.
     this._onCmChange = () => {
+      if (this._settingValue) return
       this.dispatchEvent(new Event('input', { bubbles: true }))
     }
     this._onCmBlur = () => {

--- a/frontend/src/app-editor/relaEditor.ts
+++ b/frontend/src/app-editor/relaEditor.ts
@@ -48,29 +48,39 @@ function ensureStylesInjected(): void {
 class RelaEditorElement extends HTMLElement {
   private _editor: EasyMDE | null = null
   private _textarea: HTMLTextAreaElement | null = null
+  // Set only when EasyMDE construction failed and we fell back to the raw
+  // <textarea>. When non-null, the value/focus contract routes through it.
+  private _fallbackTextarea: HTMLTextAreaElement | null = null
   // Holds the value set via the property before the element is connected (and
   // before EasyMDE exists). Flushed into the editor on connect.
   private _pendingValue = ''
   private _onCmChange: (() => void) | null = null
   private _onCmBlur: (() => void) | null = null
+  private _onCmFocus: (() => void) | null = null
   // True while the .value setter is writing to EasyMDE, so the re-dispatched
   // input event is suppressed (programmatic sets are silent, like a textarea).
   private _settingValue = false
   // True between connectedCallback and the deferred mount running.
   private _mountScheduled = false
+  // Value snapshot at focus, so `change` fires on blur ONLY when the content
+  // actually changed — matching native <textarea>, not on every focus-out.
+  private _valueAtFocus = ''
 
+  // `placeholder` is intentionally NOT observed: EasyMDE reads it once at mount
+  // and has no live setter, so observing it would invite a "set it reactively,
+  // it silently no-ops after mount" footgun. It is a mount-time-only attribute.
   static get observedAttributes(): string[] {
-    return ['placeholder', 'readonly']
+    return ['readonly']
   }
 
   connectedCallback(): void {
     if (this._editor || this._mountScheduled) return // already mounted/scheduled
-    // Defer the (heavy) EasyMDE mount off the synchronous parse/upgrade path.
-    // Building CodeMirror during HTML parsing blocks the main thread long
-    // enough that a host message (e.g. the bridge's rela:port reply, which
-    // fires rela:ready) can be processed before the page's own end-of-body
-    // scripts register their listeners — making apps miss rela:ready. A
-    // microtask lets the current parse/script finish first, then we mount.
+    // Defer the (heavy) EasyMDE/CodeMirror mount off the synchronous parse/
+    // upgrade path so it doesn't block the main thread while the page is still
+    // parsing (responsiveness). NOTE: this is a PERF measure, not a correctness
+    // fix for the bridge handshake — readiness is made not-missable by the
+    // SDK's replayable rela.ready/whenReady (see apps_sdk.go); do not rely on
+    // this defer for that.
     this._mountScheduled = true
     queueMicrotask(() => {
       this._mountScheduled = false
@@ -87,13 +97,13 @@ class RelaEditorElement extends HTMLElement {
     if (name === 'readonly') {
       this._editor.codemirror.setOption('readOnly', this.hasAttribute('readonly'))
     }
-    // EasyMDE has no live placeholder setter; placeholder is read at mount.
-    // Changing it after mount is not part of the supported contract.
   }
 
   // --- public property: value (markdown text, whitespace-exact) ---
   get value(): string {
-    return this._editor ? this._editor.value() : this._pendingValue
+    if (this._editor) return this._editor.value()
+    if (this._fallbackTextarea) return this._fallbackTextarea.value
+    return this._pendingValue
   }
 
   set value(v: string) {
@@ -112,6 +122,9 @@ class RelaEditorElement extends HTMLElement {
           this._settingValue = false
         }
       }
+    } else if (this._fallbackTextarea) {
+      // Native textarea .value is already silent — no dispatch guard needed.
+      this._fallbackTextarea.value = next
     } else {
       this._pendingValue = next
     }
@@ -120,6 +133,7 @@ class RelaEditorElement extends HTMLElement {
   // --- public method: focus() ---
   override focus(): void {
     if (this._editor) this._editor.codemirror.focus()
+    else if (this._fallbackTextarea) this._fallbackTextarea.focus()
     else super.focus()
   }
 
@@ -132,36 +146,62 @@ class RelaEditorElement extends HTMLElement {
     this.appendChild(ta)
     this._textarea = ta
 
-    const editor = new EasyMDE({
-      element: ta,
-      initialValue: this._pendingValue,
-      placeholder: this.getAttribute('placeholder') || '',
-      spellChecker: false,
-      autofocus: false,
-      status: false,
-      // Suppress EasyMDE's runtime <link> to the FA CDN — the glyphs are
-      // bundled (and the font is served same-origin under the app base).
-      autoDownloadFontAwesome: false,
-      toolbar: [
-        'bold',
-        'italic',
-        'heading',
-        '|',
-        'unordered-list',
-        'ordered-list',
-        '|',
-        'link',
-        'code',
-        'quote',
-        '|',
-        'preview',
-        'side-by-side',
-        'fullscreen',
-        '|',
-        'guide',
-      ],
-      minHeight: '200px',
-    } satisfies EasyMDE.Options)
+    let editor: EasyMDE
+    try {
+      editor = new EasyMDE({
+        element: ta,
+        initialValue: this._pendingValue,
+        placeholder: this.getAttribute('placeholder') || '',
+        spellChecker: false,
+        autofocus: false,
+        status: false,
+        // Suppress EasyMDE's runtime <link> to the FA CDN — the glyphs are
+        // bundled (and the font is served same-origin under the app base).
+        autoDownloadFontAwesome: false,
+        // NOTE: this toolbar/options config is intentionally kept close to the
+        // SPA editor's (frontend/src/components/forms/MarkdownEditor.vue) so the
+        // two editors feel the same. They are NOT yet shared (this is a plain
+        // IIFE with no Vue). If you change one, change the other — or do the
+        // extraction tracked in TKT-D2JML7 (shared core). The app editor omits
+        // the SPA's entity-ref toolbar button (it needs the schema store).
+        toolbar: [
+          'bold',
+          'italic',
+          'heading',
+          '|',
+          'unordered-list',
+          'ordered-list',
+          '|',
+          'link',
+          'code',
+          'quote',
+          '|',
+          'preview',
+          'side-by-side',
+          'fullscreen',
+          '|',
+          'guide',
+        ],
+        minHeight: '200px',
+      } satisfies EasyMDE.Options)
+    } catch (err) {
+      // Degraded fallback: if EasyMDE fails to construct (e.g. CM5 in an
+      // unexpected DOM state), keep the raw <textarea> — it already holds the
+      // seeded value — and route the value/focus/event contract through it so
+      // the app still has a working (plain) editor rather than a dead element.
+      console.error('[rela-editor] editor failed to initialize; falling back to a plain textarea', err)
+      ta.placeholder = this.getAttribute('placeholder') || ''
+      ta.readOnly = this.hasAttribute('readonly')
+      ta.style.cssText = 'width:100%;min-height:200px;box-sizing:border-box'
+      ta.addEventListener('input', () => {
+        if (!this._settingValue) this.dispatchEvent(new Event('input', { bubbles: true }))
+      })
+      ta.addEventListener('change', () => this.dispatchEvent(new Event('change', { bubbles: true })))
+      this._fallbackTextarea = ta
+      // Keep _pendingValue in sync so the getter (which checks _fallbackTextarea)
+      // and a later re-read are consistent.
+      return
+    }
 
     if (this.hasAttribute('readonly')) {
       editor.codemirror.setOption('readOnly', true)
@@ -176,19 +216,45 @@ class RelaEditorElement extends HTMLElement {
       if (this._settingValue) return
       this.dispatchEvent(new Event('input', { bubbles: true }))
     }
+    // `change` matches native <textarea> semantics: fire on blur ONLY when the
+    // value changed since focus, so consumers wiring autosave/dirty-tracking to
+    // `change` don't get a spurious save on every click-away.
+    this._onCmFocus = () => {
+      this._valueAtFocus = editor.value()
+    }
     this._onCmBlur = () => {
-      this.dispatchEvent(new Event('change', { bubbles: true }))
+      if (editor.value() !== this._valueAtFocus) {
+        this.dispatchEvent(new Event('change', { bubbles: true }))
+      }
     }
     editor.codemirror.on('change', this._onCmChange)
+    editor.codemirror.on('focus', this._onCmFocus)
     editor.codemirror.on('blur', this._onCmBlur)
 
     this._editor = editor
+    // _pendingValue's job is done (EasyMDE now owns the content); clear it so a
+    // large initial document isn't held twice. Invariant: _pendingValue is only
+    // meaningful while _editor is null (the getter/setter both check _editor
+    // first); _unmount repopulates it from the live value on teardown.
+    this._pendingValue = ''
   }
 
   private _unmount(): void {
     if (this._editor) {
       if (this._onCmChange) this._editor.codemirror.off('change', this._onCmChange)
+      if (this._onCmFocus) this._editor.codemirror.off('focus', this._onCmFocus)
       if (this._onCmBlur) this._editor.codemirror.off('blur', this._onCmBlur)
+      // Exit fullscreen BEFORE teardown. EasyMDE's fullscreen sets
+      // document.body.style.overflow='hidden' and only restores it on toggle-
+      // off; toTextArea()/cleanup() don't. Tearing down while fullscreen would
+      // leave the host page permanently unscrollable with no editor to fix it.
+      // `fullScreen` is a runtime CodeMirror option added by EasyMDE's
+      // fullscreen addon (not in CM's typed EditorConfiguration); toggleFullScreen
+      // is exposed statically.
+      const cm = this._editor.codemirror as unknown as { getOption(name: string): unknown }
+      if (cm.getOption('fullScreen')) {
+        EasyMDE.toggleFullScreen(this._editor)
+      }
       // Capture the current value back to _pendingValue so a disconnect →
       // reconnect round-trip preserves content.
       this._pendingValue = this._editor.value()
@@ -198,7 +264,13 @@ class RelaEditorElement extends HTMLElement {
       this._editor = null
     }
     this._onCmChange = null
+    this._onCmFocus = null
     this._onCmBlur = null
+    // Preserve content across a fallback disconnect → reconnect too.
+    if (this._fallbackTextarea) {
+      this._pendingValue = this._fallbackTextarea.value
+      this._fallbackTextarea = null
+    }
     if (this._textarea && this._textarea.parentNode === this) {
       this.removeChild(this._textarea)
     }

--- a/frontend/src/app-editor/relaEditorFont.css
+++ b/frontend/src/app-editor/relaEditorFont.css
@@ -1,0 +1,12 @@
+/* Override Font Awesome's @font-face so the glyph webfont loads from the
+ * app's OWN base path (_rela-editor.woff2), which the app CSP's
+ * `font-src <base>` permits — no CSP widening, no dependency on the SPA's
+ * hash-named /assets/ font. Imported AFTER font-awesome.min.css so this
+ * @font-face wins. woff2 only (every browser that can run a custom app
+ * supports it). */
+@font-face {
+  font-family: 'FontAwesome';
+  src: url('_rela-editor.woff2') format('woff2');
+  font-weight: normal;
+  font-style: normal;
+}

--- a/frontend/src/app-editor/relaEditorTheme.css
+++ b/frontend/src/app-editor/relaEditorTheme.css
@@ -5,7 +5,11 @@
  * generated classes directly). The tokens themselves come from _rela.css,
  * which the app links; this only maps them onto EasyMDE's elements.
  *
- * Injected AFTER easymde.min.css so these win the cascade. */
+ * Injected AFTER easymde.min.css so these win the cascade.
+ *
+ * DRIFT: this is a hand-ported copy of MarkdownEditor.vue's scoped EasyMDE
+ * overrides (de-scoped + plain CSS). Keep them in sync; the eventual shared
+ * core is tracked in TKT-D2JML7. */
 
 .EasyMDEContainer {
   width: 100%;

--- a/frontend/src/app-editor/relaEditorTheme.css
+++ b/frontend/src/app-editor/relaEditorTheme.css
@@ -85,3 +85,63 @@
 .EasyMDEContainer.fullscreen {
   z-index: 9999 !important;
 }
+
+/* Fullscreen mode: EasyMDE hardcodes #fff on the fixed-position toolbar and
+   editor (and #fff fade gradients at the toolbar edges, #ddd on the side
+   preview border). Re-skin them with tokens so fullscreen matches the host
+   theme like the inline editor does. */
+.editor-toolbar.fullscreen {
+  background: var(--card-bg);
+}
+.editor-toolbar.fullscreen::before {
+  background: linear-gradient(to right, var(--card-bg) 0, transparent 100%);
+}
+.editor-toolbar.fullscreen::after {
+  background: linear-gradient(to left, var(--card-bg) 0, transparent 100%);
+}
+.CodeMirror-fullscreen {
+  background: var(--input-bg);
+}
+.editor-preview-side {
+  border-color: var(--border-color);
+}
+
+/* Backtick entity-reference autocomplete popup (relaBacktick.ts). Anchored at
+   the trigger backtick; rendered in light DOM at document.body, so styled with
+   the same rela tokens. z-index above EasyMDE's fullscreen layer (9999). */
+.rela-bt-popup {
+  position: fixed;
+  z-index: 10000;
+  min-width: 220px;
+  max-width: 420px;
+  max-height: 240px;
+  overflow-y: auto;
+  background: var(--card-bg);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  font-size: 0.9rem;
+}
+.rela-bt-option {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  padding: 0.4rem 0.7rem;
+  cursor: pointer;
+}
+.rela-bt-option.active {
+  background: var(--hover-bg);
+}
+.rela-bt-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rela-bt-sub {
+  flex: 0 0 auto;
+  color: var(--muted-text);
+  font-size: 0.8rem;
+}

--- a/frontend/src/app-editor/relaEditorTheme.css
+++ b/frontend/src/app-editor/relaEditorTheme.css
@@ -1,0 +1,83 @@
+/* Re-skin EasyMDE's hardcoded light chrome with rela theme tokens so the
+ * <rela-editor> follows the host theme (light/dark) instead of EasyMDE's
+ * built-in white. Ported from the SPA's MarkdownEditor.vue token overrides,
+ * de-scoped (the element renders in light DOM, so these target EasyMDE's
+ * generated classes directly). The tokens themselves come from _rela.css,
+ * which the app links; this only maps them onto EasyMDE's elements.
+ *
+ * Injected AFTER easymde.min.css so these win the cascade. */
+
+.EasyMDEContainer {
+  width: 100%;
+}
+
+.EasyMDEContainer .CodeMirror {
+  border: 1px solid var(--border-color);
+  border-radius: 0 0 6px 6px;
+  font-family: monospace;
+  font-size: 14px;
+  background: var(--input-bg);
+  color: var(--text-color);
+}
+
+.EasyMDEContainer .CodeMirror-cursor {
+  border-left-color: var(--text-color);
+}
+
+.EasyMDEContainer .CodeMirror-selected {
+  background: var(--accent-color) !important;
+  opacity: 0.3;
+}
+
+.EasyMDEContainer .CodeMirror-focused {
+  border-color: var(--accent-color);
+}
+
+.editor-toolbar {
+  border: 1px solid var(--border-color);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+  background: var(--card-bg);
+}
+
+.editor-toolbar button {
+  color: var(--muted-text) !important;
+}
+
+.editor-toolbar button:hover {
+  background: var(--hover-bg);
+}
+
+.editor-toolbar button.active {
+  background: var(--border-color);
+}
+
+.editor-toolbar i.separator {
+  border-left-color: var(--border-color);
+  border-right-color: var(--border-color);
+}
+
+.editor-preview,
+.editor-preview-side {
+  padding: 16px;
+  background: var(--card-bg);
+  color: var(--text-color);
+}
+
+.editor-preview-side {
+  border: 1px solid var(--border-color);
+  border-left: none;
+}
+
+.CodeMirror-gutters {
+  background: var(--hover-bg);
+  border-right-color: var(--border-color);
+}
+
+.CodeMirror-linenumber {
+  color: var(--muted-text);
+}
+
+.EasyMDEContainer.fullscreen {
+  z-index: 9999 !important;
+}

--- a/frontend/src/components/forms/MarkdownEditor.vue
+++ b/frontend/src/components/forms/MarkdownEditor.vue
@@ -261,6 +261,10 @@ function onPopupHover(idx: number): void {
   position: relative;
 }
 
+/* DRIFT: these EasyMDE token overrides are mirrored (de-scoped, plain CSS) in
+   the sandboxed-app editor at frontend/src/app-editor/relaEditorTheme.css, and
+   the toolbar/options config is mirrored in relaEditor.ts. Keep them in sync;
+   the eventual shared core is tracked in TKT-D2JML7. */
 .markdown-editor :deep(.EasyMDEContainer) {
   width: 100%;
 }

--- a/frontend/vite.editor.config.ts
+++ b/frontend/vite.editor.config.ts
@@ -16,8 +16,19 @@ function stripFontAwesomeFontFace(): Plugin {
       // query suffix means .endsWith('.css') won't match — check includes).
       if (!id.includes('font-awesome') || !id.includes('.css')) return null
       // FA ships exactly one @font-face{...} block listing eot/ttf/woff/woff2/
-      // svg sources; remove it so Vite doesn't base64-inline all five.
+      // svg sources; remove it so Vite doesn't base64-inline all five. The
+      // [^}]* match relies on FA's block having no nested braces (true for 4.7).
       const stripped = code.replace(/@font-face\s*\{[^}]*\}/g, '')
+      // Fail loud if nothing was stripped: a silent no-op (FA restructured its
+      // CSS, or this matched the wrong module) would ship ~1.5MB of base64 fonts
+      // unnoticed. The override @font-face in relaEditorFont.css is what we keep.
+      if (stripped === code) {
+        throw new Error(
+          'strip-fontawesome-fontface: expected an @font-face block in ' +
+            id +
+            ' but found none — Font Awesome CSS structure changed; verify the strip.',
+        )
+      }
       return { code: stripped, map: null }
     },
   }
@@ -43,9 +54,20 @@ function emitEditorFont(): Plugin {
   return {
     name: 'emit-editor-font',
     async generateBundle() {
-      const fontPath = fileURLToPath(
-        new URL('./node_modules/font-awesome/fonts/fontawesome-webfont.woff2', import.meta.url),
-      )
+      // Resolve via package resolution rather than a hardcoded ./node_modules
+      // path, so it survives hoisting / pnpm / monorepo layouts. Fail loudly
+      // with a clear message if the font can't be found.
+      const { createRequire } = await import('node:module')
+      const require = createRequire(import.meta.url)
+      let fontPath: string
+      try {
+        fontPath = require.resolve('font-awesome/fonts/fontawesome-webfont.woff2')
+      } catch {
+        throw new Error(
+          'emit-editor-font: could not resolve font-awesome/fonts/fontawesome-webfont.woff2 — ' +
+            'is the font-awesome dependency installed?',
+        )
+      }
       const { readFile } = await import('node:fs/promises')
       this.emitFile({
         type: 'asset',

--- a/frontend/vite.editor.config.ts
+++ b/frontend/vite.editor.config.ts
@@ -1,0 +1,94 @@
+import { defineConfig, type Plugin } from 'vite'
+import { fileURLToPath, URL } from 'node:url'
+
+// Strip Font Awesome's bundled @font-face rule (which lists eot/ttf/woff/woff2/
+// svg sources) from the inlined FA CSS. Without this, Vite base64-inlines all
+// five fallback font files into the bundle (~1.5MB of waste). We supply our own
+// single woff2 @font-face via relaEditorFont.css pointing at the reserved app
+// path, so FA's own @font-face is dead weight. Runs before Vite's CSS asset
+// handling so the url()s never get inlined.
+function stripFontAwesomeFontFace(): Plugin {
+  return {
+    name: 'strip-fontawesome-fontface',
+    enforce: 'pre',
+    transform(code, id) {
+      // Match the FA stylesheet whether imported plain or with ?inline (the
+      // query suffix means .endsWith('.css') won't match — check includes).
+      if (!id.includes('font-awesome') || !id.includes('.css')) return null
+      // FA ships exactly one @font-face{...} block listing eot/ttf/woff/woff2/
+      // svg sources; remove it so Vite doesn't base64-inline all five.
+      const stripped = code.replace(/@font-face\s*\{[^}]*\}/g, '')
+      return { code: stripped, map: null }
+    },
+  }
+}
+
+// Standalone build for the <rela-editor> Custom Element (TKT-5F9V56).
+//
+// Produces ONE self-contained IIFE (JS with CSS inlined) served at the reserved
+// per-app path /api/v1/_apps/<id>/_rela-editor.js. Apps opt in with
+// <script src="_rela-editor.js">. Kept separate from the SPA build (and from
+// the tiny bridge _rela.js) so only apps that use the editor pay the bundle.
+//
+// Output goes to a dedicated dir that the Go side embeds (apps_editor.go).
+// The Font Awesome webfont is served separately under the same app base as
+// _rela-editor.woff2; the bundled @font-face is overridden (relaEditorFont.css)
+// to point there, so the app CSP's `font-src <base>` permits it with no widening.
+// Emit the Font Awesome glyph webfont (woff2 only) alongside the bundle, with a
+// stable name (rela-editor.woff2). The Go side serves it at the reserved app
+// path _rela-editor.woff2 that the bundle's @font-face points at. Reading from
+// node_modules keeps it in lockstep with the font-awesome version the bundle
+// was built against.
+function emitEditorFont(): Plugin {
+  return {
+    name: 'emit-editor-font',
+    async generateBundle() {
+      const fontPath = fileURLToPath(
+        new URL('./node_modules/font-awesome/fonts/fontawesome-webfont.woff2', import.meta.url),
+      )
+      const { readFile } = await import('node:fs/promises')
+      this.emitFile({
+        type: 'asset',
+        fileName: 'rela-editor.woff2',
+        source: await readFile(fontPath),
+      })
+    },
+  }
+}
+
+export default defineConfig({
+  plugins: [stripFontAwesomeFontFace(), emitEditorFont()],
+  // No public/ asset copying — this is a standalone lib build, not the SPA.
+  publicDir: false,
+  define: {
+    // The editor build must not pull in the SPA's E2E test-hook flag.
+    __E2E_TEST_HOOKS__: JSON.stringify(false),
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  build: {
+    outDir: '../internal/dataentry/app_editor_dist',
+    emptyOutDir: true,
+    // Inline all CSS/assets into the single JS file so the served
+    // _rela-editor.js is fully self-contained (no sibling chunks the app
+    // would have to also fetch). The FA font is the one intentional
+    // exception — it's served separately under the app base.
+    cssCodeSplit: false,
+    assetsInlineLimit: Number.MAX_SAFE_INTEGER,
+    lib: {
+      entry: fileURLToPath(new URL('./src/app-editor/relaEditor.ts', import.meta.url)),
+      name: 'RelaEditor',
+      formats: ['iife'],
+      fileName: () => 'rela-editor.js',
+    },
+    rollupOptions: {
+      output: {
+        // Single bundle; no code splitting.
+        inlineDynamicImports: true,
+      },
+    },
+  },
+})

--- a/frontend/vite.editor.config.ts
+++ b/frontend/vite.editor.config.ts
@@ -93,7 +93,13 @@ export default defineConfig({
   },
   build: {
     outDir: '../internal/dataentry/app_editor_dist',
-    emptyOutDir: true,
+    // Do NOT empty the dir: it contains the committed .gitkeep that keeps the
+    // Go glob-embed compiling on a clean checkout (the build artifacts
+    // themselves are gitignored). emptyOutDir:true would delete .gitkeep and
+    // leave the work tree dirty after `npm run build` (CI "work tree clean"
+    // gate). We only emit rela-editor.js + .woff2, which Vite overwrites in
+    // place, so emptying is unnecessary.
+    emptyOutDir: false,
     // Inline all CSS/assets into the single JS file so the served
     // _rela-editor.js is fully self-contained (no sibling chunks the app
     // would have to also fetch). The FA font is the one intentional

--- a/internal/dataentry/CLAUDE.md
+++ b/internal/dataentry/CLAUDE.md
@@ -102,6 +102,33 @@ User-authored apps served in a sandboxed iframe. An app is a **folder**
   reserved `/_apps/<id>/_rela.js`; apps include `<script src="_rela.js">`. The
   app cannot shadow `_rela.js` or serve any `_`-prefixed entry from its files.
   No server-side HTML rewriting of the app's index.
+- **Readiness is replayable; prefer `rela.ready` / `rela.whenReady(cb)` over the
+  `rela:ready` event.** The handshake can complete before an app's inline code
+  runs (e.g. a large `<script src="_rela-editor.js">` between `_rela.js` and the
+  app's listener delays it past the port arrival) — an `addEventListener('rela:ready')`
+  added that late never fires. The SDK resolves a `rela.ready` Promise on the
+  handshake (and `rela.whenReady(cb)`), which is not-missable. The event is kept
+  for back-compat only. `TestAppSDKReadiness` pins this. Don't add `ready`/
+  `whenReady`/`isReady` to `appSDKMethods` — they're local SDK helpers, not host
+  calls.
+- **Optional markdown editor: `<rela-editor>` from the reserved
+  `/_apps/<id>/_rela-editor.js`** (`appEditorSource()`), with its glyph webfont
+  at `/_apps/<id>/_rela-editor.woff2` (`appEditorFontSource()`, served with
+  `Access-Control-Allow-Origin: *` because the sandboxed iframe is null-origin so
+  the `@font-face` fetch is cross-origin). Both are embedded from
+  `app_editor_dist/` — a **build artifact** produced by `frontend/vite.editor.config.ts`
+  (`npm run build` runs it), gitignored like `static/v2`, with a committed
+  `.gitkeep` so the glob embed compiles on a clean checkout;
+  `TestAppEditorBundleEmbedded` skips when unbuilt and asserts the contract when
+  built. Separate from `_rela.js` so only apps that opt in pay the ~370KB bundle.
+  **The element's public contract is the swap seam — keep it minimal**: property
+  `value` (whitespace-exact), attributes `placeholder`/`readonly`, native
+  `input`/`change` events, `focus()`. Everything else (that it's EasyMDE/
+  CodeMirror, the toolbar, the generated DOM) is unsupported, so the editor can
+  be swapped later without breaking apps. Light DOM, not shadow DOM (CM5 misbehaves
+  in a shadow root); upgrades to enforced shadow encapsulation if the SPA moves
+  to CM6, without changing the contract. Programmatic `.value` sets are silent
+  (no `input`), matching a native `<textarea>`.
 - **Optional styling is served at the reserved `/_apps/<id>/_rela.css`**
   (`appCSSSource()` = theme tokens + the atomic `.btn`/`.input`/`.card`). The
   tokens are embedded from `apps_tokens.css`, a **byte-identical copy** of

--- a/internal/dataentry/apps.go
+++ b/internal/dataentry/apps.go
@@ -44,6 +44,18 @@ const appSDKEntry = "_rela.js"
 // href="_rela.css">. Reserved like _rela.js (underscore-prefixed).
 const appCSSEntry = "_rela.css"
 
+// appEditorEntry is the reserved per-app path that serves the <rela-editor>
+// markdown-editor Custom Element (TKT-5F9V56). Apps opt in with
+// <script src="_rela-editor.js"></script>. Separate from _rela.js so only apps
+// that use the editor pay its bundle. Reserved (underscore-prefixed).
+const appEditorEntry = "_rela-editor.js"
+
+// appEditorFontEntry is the reserved per-app path that serves the Font Awesome
+// glyph webfont the editor's toolbar uses. The bundle's @font-face points here
+// (a same-base URL), so the app CSP's `font-src <base>` permits it without
+// widening. Reserved (underscore-prefixed).
+const appEditorFontEntry = "_rela-editor.woff2"
+
 // maxAppFileBytes caps the size of any single served app file. Generous for a
 // single-page app's assets while bounding memory pressure from a pathological
 // file.

--- a/internal/dataentry/apps_editor.go
+++ b/internal/dataentry/apps_editor.go
@@ -1,8 +1,11 @@
 package dataentry
 
 import (
+	"crypto/sha256"
 	"embed"
+	"encoding/hex"
 	"io/fs"
+	"net/http"
 )
 
 // The <rela-editor> Custom Element bundle and its glyph webfont, built by the
@@ -35,10 +38,52 @@ func appEditorAsset(name string) []byte {
 	return b
 }
 
-// appEditorSource returns the <rela-editor> Custom Element IIFE bundle served at
-// /api/v1/_apps/<id>/_rela-editor.js.
-func appEditorSource() []byte { return appEditorAsset("rela-editor.js") }
+// appEditorSource / appEditorFontSource are package-level VARS (not funcs) so
+// tests can inject a fake bundle and exercise the serving path even when the
+// frontend build hasn't run (the CI `go test ./...` job doesn't build the
+// frontend — see withTestEditorAssets in apps_test.go). Production code never
+// reassigns them.
+var (
+	// appEditorSource returns the <rela-editor> IIFE bundle served at
+	// /api/v1/_apps/<id>/_rela-editor.js.
+	appEditorSource = func() []byte { return appEditorAsset("rela-editor.js") }
+	// appEditorFontSource returns the toolbar glyph webfont served at
+	// /api/v1/_apps/<id>/_rela-editor.woff2.
+	appEditorFontSource = func() []byte { return appEditorAsset("rela-editor.woff2") }
+)
 
-// appEditorFontSource returns the toolbar glyph webfont served at
-// /api/v1/_apps/<id>/_rela-editor.woff2.
-func appEditorFontSource() []byte { return appEditorAsset("rela-editor.woff2") }
+// ETags for the editor assets, computed lazily from the current bytes so a
+// test that swaps the source vars gets a matching ETag. The assets are
+// immutable for the process lifetime (embedded at build time), so a content
+// hash is a stable strong validator: a new build → new bytes → new ETag, which
+// can't serve a stale asset across deploys (unlike `immutable` max-age on an
+// unversioned URL). Empty when the asset isn't built.
+func appEditorJSETag() string   { return weakETagFor(appEditorSource()) }
+func appEditorFontETag() string { return weakETagFor(appEditorFontSource()) }
+
+func weakETagFor(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return `"` + hex.EncodeToString(sum[:16]) + `"`
+}
+
+// serveCachedAsset writes body with an ETag + must-revalidate caching so an app
+// iframe (which reloads on navigation / host remounts) revalidates with a cheap
+// 304 instead of re-transferring the full bundle every time, while still picking
+// up a new build immediately (the ETag changes with the bytes). Returns true if
+// it handled a 304 (caller should stop).
+func serveCachedAsset(w http.ResponseWriter, r *http.Request, contentType, etag string, body []byte) {
+	h := w.Header()
+	h.Set("Content-Type", contentType)
+	if etag != "" {
+		h.Set("ETag", etag)
+		h.Set("Cache-Control", "public, max-age=0, must-revalidate")
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+	}
+	_, _ = w.Write(body)
+}

--- a/internal/dataentry/apps_editor.go
+++ b/internal/dataentry/apps_editor.go
@@ -1,0 +1,44 @@
+package dataentry
+
+import (
+	"embed"
+	"io/fs"
+)
+
+// The <rela-editor> Custom Element bundle and its glyph webfont, built by the
+// standalone editor build (frontend/vite.editor.config.ts) into
+// frontend → ../internal/dataentry/app_editor_dist and embedded here. Served at
+// the reserved per-app paths _rela-editor.js / _rela-editor.woff2 (see apps.go
+// and apps_handler.go). TKT-5F9V56.
+//
+// Like the SPA bundle (static/v2), these are BUILD ARTIFACTS — gitignored and
+// produced by `npm run build` (frontend/package.json runs the editor build too).
+// The embed uses a glob with a committed .gitkeep placeholder so the package
+// still COMPILES on a clean checkout where the build hasn't run (the same reason
+// static.go embeds `static/*`, matched by a committed favicon, rather than a
+// specific file). On such a checkout appEditorSource() returns nil and
+// TestAppEditorBundleEmbedded fails loudly — the production build always runs
+// the frontend build first, so the real bytes are present in shipped binaries.
+//
+// Rebuild with:
+//
+//	cd frontend && npx vite build --config vite.editor.config.ts
+
+//go:embed all:app_editor_dist
+var appEditorDist embed.FS
+
+func appEditorAsset(name string) []byte {
+	b, err := fs.ReadFile(appEditorDist, "app_editor_dist/"+name)
+	if err != nil {
+		return nil // not built yet (clean checkout); guarded by a test
+	}
+	return b
+}
+
+// appEditorSource returns the <rela-editor> Custom Element IIFE bundle served at
+// /api/v1/_apps/<id>/_rela-editor.js.
+func appEditorSource() []byte { return appEditorAsset("rela-editor.js") }
+
+// appEditorFontSource returns the toolbar glyph webfont served at
+// /api/v1/_apps/<id>/_rela-editor.woff2.
+func appEditorFontSource() []byte { return appEditorAsset("rela-editor.woff2") }

--- a/internal/dataentry/apps_handler.go
+++ b/internal/dataentry/apps_handler.go
@@ -136,19 +136,20 @@ func (a *App) handleV1App(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if entry == appEditorEntry {
-		h.Set("Content-Type", "text/javascript; charset=utf-8")
-		_, _ = w.Write(appEditorSource())
+		// ETag + revalidate so the 372KB bundle isn't re-transferred on every
+		// iframe (re)load. appContentTypes[".js"] is the single source for the
+		// content-type so it can't drift.
+		serveCachedAsset(w, r, appContentTypes[".js"], appEditorJSETag(), appEditorSource())
 		return
 	}
 	if entry == appEditorFontEntry {
-		h.Set("Content-Type", "font/woff2")
 		// The app runs in a sandboxed iframe with an OPAQUE (null) origin, so an
 		// @font-face request for this font is cross-origin and the browser
 		// blocks it without CORS. Allow it: this is a static glyph webfont with
 		// no sensitive data (fonts are the canonical CORS-allowed cross-origin
 		// resource). Without this the editor toolbar renders as tofu boxes.
 		h.Set("Access-Control-Allow-Origin", "*")
-		_, _ = w.Write(appEditorFontSource())
+		serveCachedAsset(w, r, appContentTypes[".woff2"], appEditorFontETag(), appEditorFontSource())
 		return
 	}
 

--- a/internal/dataentry/apps_handler.go
+++ b/internal/dataentry/apps_handler.go
@@ -135,6 +135,16 @@ func (a *App) handleV1App(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(appCSSSource()))
 		return
 	}
+	if entry == appEditorEntry {
+		h.Set("Content-Type", "text/javascript; charset=utf-8")
+		_, _ = w.Write(appEditorSource())
+		return
+	}
+	if entry == appEditorFontEntry {
+		h.Set("Content-Type", "font/woff2")
+		_, _ = w.Write(appEditorFontSource())
+		return
+	}
 
 	if entry == "" {
 		entry = appIndexFile

--- a/internal/dataentry/apps_handler.go
+++ b/internal/dataentry/apps_handler.go
@@ -142,6 +142,12 @@ func (a *App) handleV1App(w http.ResponseWriter, r *http.Request) {
 	}
 	if entry == appEditorFontEntry {
 		h.Set("Content-Type", "font/woff2")
+		// The app runs in a sandboxed iframe with an OPAQUE (null) origin, so an
+		// @font-face request for this font is cross-origin and the browser
+		// blocks it without CORS. Allow it: this is a static glyph webfont with
+		// no sensitive data (fonts are the canonical CORS-allowed cross-origin
+		// resource). Without this the editor toolbar renders as tofu boxes.
+		h.Set("Access-Control-Allow-Origin", "*")
 		_, _ = w.Write(appEditorFontSource())
 		return
 	}

--- a/internal/dataentry/apps_sdk.go
+++ b/internal/dataentry/apps_sdk.go
@@ -39,6 +39,14 @@ func appSDKSource() string {
 	methods := `["` + strings.Join(appSDKMethods, `","`) + `"]`
 	return `(function () {
   var port = null, nextId = 1, pending = {}, queue = [];
+  // Replayable readiness: resolves when the bridge port arrives. Exposed as
+  // rela.ready (a Promise) and rela.whenReady(cb). This is the robust way for
+  // an app to run code on connect — unlike the 'rela:ready' EVENT, which a
+  // listener added AFTER the handshake (e.g. registered below a large
+  // <script src> that delayed the inline code) would miss. The event is kept
+  // for back-compat; new apps should prefer rela.ready / whenReady.
+  var isReady = false, resolveReady = null;
+  var readyPromise = new Promise(function (res) { resolveReady = res; });
   function send(method, params) {
     return new Promise(function (resolve, reject) {
       var id = nextId++;
@@ -77,6 +85,8 @@ func appSDKSource() string {
     port.start && port.start();
     for (var i = 0; i < queue.length; i++) port.postMessage(queue[i]);
     queue = [];
+    isReady = true;
+    if (resolveReady) resolveReady();
     window.dispatchEvent(new Event('rela:ready'));
   });
   // Iframe-initiated handshake: ask the host for a port. The host verifies our
@@ -99,6 +109,14 @@ func appSDKSource() string {
   }
   var rela = {};
   ` + methods + `.forEach(function (m) { rela[m] = function (params) { return send(m, params); }; });
+  // Replayable readiness — safe to call/await at any time, before or after the
+  // handshake completes (see readyPromise above).
+  rela.ready = readyPromise;
+  rela.whenReady = function (cb) {
+    if (typeof cb === 'function') { readyPromise.then(cb); return; }
+    return readyPromise;
+  };
+  Object.defineProperty(rela, 'isReady', { get: function () { return isReady; } });
   window.rela = rela;
 })();`
 }

--- a/internal/dataentry/apps_sdk.go
+++ b/internal/dataentry/apps_sdk.go
@@ -112,8 +112,10 @@ func appSDKSource() string {
   // Replayable readiness — safe to call/await at any time, before or after the
   // handshake completes (see readyPromise above).
   rela.ready = readyPromise;
+  // Always returns the promise (chainable) — whether or not a callback is given,
+  // so whenReady(cb).then(...) and whenReady().then(...) both work.
   rela.whenReady = function (cb) {
-    if (typeof cb === 'function') { readyPromise.then(cb); return; }
+    if (typeof cb === 'function') readyPromise.then(cb);
     return readyPromise;
   };
   Object.defineProperty(rela, 'isReady', { get: function () { return isReady; } });

--- a/internal/dataentry/apps_sdk_test.go
+++ b/internal/dataentry/apps_sdk_test.go
@@ -1,0 +1,47 @@
+package dataentry
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAppSDKReadiness pins the replayable-readiness contract added for
+// TKT-5F9V56. The 'rela:ready' EVENT can be missed when a large script (e.g.
+// _rela-editor.js) delays an app's inline code past the handshake; rela.ready
+// (a Promise) and rela.whenReady(cb) are not-missable and are the supported way
+// for an app to run code on connect. This froze the Today app until added, so
+// guard it.
+func TestAppSDKReadiness(t *testing.T) {
+	src := appSDKSource()
+
+	for _, want := range []string{
+		"rela.ready",     // replayable Promise
+		"rela.whenReady", // callback helper
+		"readyPromise",   // backing promise
+		"window.rela",    // still exposes the API object
+		"'rela:ready'",   // back-compat event still dispatched
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("SDK source missing %q (readiness contract)", want)
+		}
+	}
+
+	// The event must still be dispatched for back-compat, AND the promise must
+	// resolve on the same handshake. Both happen in the handshake branch.
+	if !strings.Contains(src, "resolveReady") {
+		t.Error("SDK must resolve the ready promise on handshake")
+	}
+}
+
+// TestAppSDKMethodsNotPollutedByReadiness ensures the readiness helpers are NOT
+// added to the bridge method allow-list (they are local SDK helpers, not host
+// calls). A method in appSDKMethods generates a send()-backed function; ready/
+// whenReady/isReady must stay off it.
+func TestAppSDKMethodsNotPollutedByReadiness(t *testing.T) {
+	for _, m := range appSDKMethods {
+		switch m {
+		case "ready", "whenReady", "isReady":
+			t.Errorf("%q must not be a bridge method (it's a local readiness helper)", m)
+		}
+	}
+}

--- a/internal/dataentry/apps_sdk_test.go
+++ b/internal/dataentry/apps_sdk_test.go
@@ -31,6 +31,13 @@ func TestAppSDKReadiness(t *testing.T) {
 	if !strings.Contains(src, "resolveReady") {
 		t.Error("SDK must resolve the ready promise on handshake")
 	}
+
+	// whenReady must ALWAYS return the promise (chainable) — i.e. there is a
+	// `return readyPromise` outside any conditional in the helper. Guard against
+	// regressing to the early-`return;` form that made whenReady(cb).then() throw.
+	if !strings.Contains(src, "return readyPromise;") {
+		t.Error("whenReady must always return readyPromise (chainable)")
+	}
 }
 
 // TestAppSDKMethodsNotPollutedByReadiness ensures the readiness helpers are NOT

--- a/internal/dataentry/apps_test.go
+++ b/internal/dataentry/apps_test.go
@@ -378,6 +378,71 @@ func TestHandleV1App(t *testing.T) {
 		}
 	})
 
+	t.Run("serves the reserved _rela-editor.js bundle", func(t *testing.T) {
+		if !editorBundleBuilt() {
+			t.Skip("editor bundle not built")
+		}
+		w := doRequest(t, app, http.MethodGet, "/api/v1/_apps/demo/_rela-editor.js")
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+		if w.Body.Len() == 0 {
+			t.Error("editor bundle is empty")
+		}
+		// The bundle defines the <rela-editor> custom element.
+		if !strings.Contains(w.Body.String(), "rela-editor") {
+			t.Errorf("editor bundle missing the custom element tag")
+		}
+		if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "javascript") {
+			t.Errorf("editor Content-Type = %q, want javascript", ct)
+		}
+		// Served from the app's own path → existing script-src <base> permits it.
+		csp := w.Header().Get("Content-Security-Policy")
+		if !strings.Contains(csp, "script-src ") || !strings.Contains(csp, "/api/v1/_apps/demo/") {
+			t.Errorf("script-src must path-scope the app (covers _rela-editor.js): %q", csp)
+		}
+	})
+
+	t.Run("serves the reserved _rela-editor.woff2 font", func(t *testing.T) {
+		if !editorBundleBuilt() {
+			t.Skip("editor bundle not built")
+		}
+		w := doRequest(t, app, http.MethodGet, "/api/v1/_apps/demo/_rela-editor.woff2")
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+		if w.Body.Len() == 0 {
+			t.Error("editor font is empty")
+		}
+		if ct := w.Header().Get("Content-Type"); ct != "font/woff2" {
+			t.Errorf("font Content-Type = %q, want font/woff2", ct)
+		}
+		// font-src <base> already permits the same-path font (no CSP widening).
+		csp := w.Header().Get("Content-Security-Policy")
+		if !strings.Contains(csp, "font-src ") || !strings.Contains(csp, "/api/v1/_apps/demo/") {
+			t.Errorf("font-src must path-scope the app (covers _rela-editor.woff2): %q", csp)
+		}
+	})
+
+	t.Run("an app cannot shadow _rela-editor.js / .woff2 with its own files", func(t *testing.T) {
+		if !editorBundleBuilt() {
+			t.Skip("editor bundle not built")
+		}
+		writeApp(t, root, "shadowed", map[string]string{
+			"index.html":         "<html></html>",
+			"_rela-editor.js":    "EVIL",
+			"_rela-editor.woff2": "EVIL",
+		})
+		js := doRequest(t, app, http.MethodGet, "/api/v1/_apps/shadowed/_rela-editor.js")
+		if js.Code != http.StatusOK || strings.Contains(js.Body.String(), "EVIL") {
+			t.Errorf("reserved _rela-editor.js must serve the real bundle: %.40s", js.Body.String())
+		}
+		font := doRequest(t, app, http.MethodGet, "/api/v1/_apps/shadowed/_rela-editor.woff2")
+		if font.Code != http.StatusOK || font.Body.String() == "EVIL" {
+			t.Errorf("reserved _rela-editor.woff2 must serve the real font, not the app file")
+		}
+	})
+
 	t.Run("bare /_apps/<id> redirects to trailing slash", func(t *testing.T) {
 		w := doRequest(t, app, http.MethodGet, "/api/v1/_apps/demo")
 		if w.Code != http.StatusMovedPermanently {
@@ -439,6 +504,32 @@ func TestHandleV1App(t *testing.T) {
 			t.Errorf("status = %d, want 422", w.Code)
 		}
 	})
+}
+
+// editorBundleBuilt reports whether the editor bundle has been built+embedded.
+// Like the SPA's static/v2, the editor dist is a gitignored build artifact, and
+// the CI `go test ./...` job runs WITHOUT building the frontend — so tests that
+// need the real bytes must skip when it's absent rather than fail. The
+// production/release build always runs the frontend build first.
+func editorBundleBuilt() bool { return len(appEditorSource()) > 0 }
+
+// TestAppEditorBundleEmbedded verifies the editor bundle + font, WHEN BUILT,
+// define the custom element and reference the same-path font. It skips on a
+// clean checkout where the frontend build hasn't run (see editorBundleBuilt).
+func TestAppEditorBundleEmbedded(t *testing.T) {
+	if !editorBundleBuilt() {
+		t.Skip("editor bundle not built (run: cd frontend && npx vite build --config vite.editor.config.ts)")
+	}
+	js := appEditorSource()
+	if !strings.Contains(string(js), "rela-editor") {
+		t.Error("editor bundle does not define the rela-editor custom element")
+	}
+	if !strings.Contains(string(js), appEditorFontEntry) {
+		t.Errorf("editor bundle must reference the reserved font path %q (its @font-face)", appEditorFontEntry)
+	}
+	if len(appEditorFontSource()) == 0 {
+		t.Fatal("editor woff2 font not embedded")
+	}
 }
 
 func TestValidateBridgeVersion(t *testing.T) {

--- a/internal/dataentry/apps_test.go
+++ b/internal/dataentry/apps_test.go
@@ -440,7 +440,7 @@ func TestHandleV1App(t *testing.T) {
 				t.Errorf("%s: Cache-Control = %q, want must-revalidate", entry, cc)
 			}
 			// Conditional request with the ETag → 304, empty body (not re-sent).
-			req := httptest.NewRequest(http.MethodGet, "/api/v1/_apps/demo/"+entry, nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/_apps/demo/"+entry, http.NoBody)
 			req.Host = "localhost"
 			req.Header.Set("If-None-Match", etag)
 			rec := httptest.NewRecorder()

--- a/internal/dataentry/apps_test.go
+++ b/internal/dataentry/apps_test.go
@@ -417,6 +417,13 @@ func TestHandleV1App(t *testing.T) {
 		if ct := w.Header().Get("Content-Type"); ct != "font/woff2" {
 			t.Errorf("font Content-Type = %q, want font/woff2", ct)
 		}
+		// The app iframe is sandboxed (opaque/null origin), so the @font-face
+		// request is cross-origin and the browser blocks it without CORS. The
+		// font MUST send Access-Control-Allow-Origin or the toolbar renders as
+		// tofu boxes (verified in-browser, TKT-5F9V56).
+		if acao := w.Header().Get("Access-Control-Allow-Origin"); acao != "*" {
+			t.Errorf("font Access-Control-Allow-Origin = %q, want * (sandboxed iframe is null-origin)", acao)
+		}
 		// font-src <base> already permits the same-path font (no CSP widening).
 		csp := w.Header().Get("Content-Security-Policy")
 		if !strings.Contains(csp, "font-src ") || !strings.Contains(csp, "/api/v1/_apps/demo/") {

--- a/internal/dataentry/apps_test.go
+++ b/internal/dataentry/apps_test.go
@@ -2,6 +2,7 @@ package dataentry
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -379,9 +380,7 @@ func TestHandleV1App(t *testing.T) {
 	})
 
 	t.Run("serves the reserved _rela-editor.js bundle", func(t *testing.T) {
-		if !editorBundleBuilt() {
-			t.Skip("editor bundle not built")
-		}
+		withTestEditorAssets(t)
 		w := doRequest(t, app, http.MethodGet, "/api/v1/_apps/demo/_rela-editor.js")
 		if w.Code != http.StatusOK {
 			t.Fatalf("status = %d, want 200", w.Code)
@@ -404,9 +403,7 @@ func TestHandleV1App(t *testing.T) {
 	})
 
 	t.Run("serves the reserved _rela-editor.woff2 font", func(t *testing.T) {
-		if !editorBundleBuilt() {
-			t.Skip("editor bundle not built")
-		}
+		withTestEditorAssets(t)
 		w := doRequest(t, app, http.MethodGet, "/api/v1/_apps/demo/_rela-editor.woff2")
 		if w.Code != http.StatusOK {
 			t.Fatalf("status = %d, want 200", w.Code)
@@ -431,10 +428,34 @@ func TestHandleV1App(t *testing.T) {
 		}
 	})
 
-	t.Run("an app cannot shadow _rela-editor.js / .woff2 with its own files", func(t *testing.T) {
-		if !editorBundleBuilt() {
-			t.Skip("editor bundle not built")
+	t.Run("editor assets carry an ETag and 304 on If-None-Match", func(t *testing.T) {
+		withTestEditorAssets(t)
+		for _, entry := range []string{"_rela-editor.js", "_rela-editor.woff2"} {
+			w := doRequest(t, app, http.MethodGet, "/api/v1/_apps/demo/"+entry)
+			etag := w.Header().Get("ETag")
+			if etag == "" {
+				t.Fatalf("%s: missing ETag (caching not applied)", entry)
+			}
+			if cc := w.Header().Get("Cache-Control"); !strings.Contains(cc, "must-revalidate") {
+				t.Errorf("%s: Cache-Control = %q, want must-revalidate", entry, cc)
+			}
+			// Conditional request with the ETag → 304, empty body (not re-sent).
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/_apps/demo/"+entry, nil)
+			req.Host = "localhost"
+			req.Header.Set("If-None-Match", etag)
+			rec := httptest.NewRecorder()
+			app.handleV1App(rec, req)
+			if rec.Code != http.StatusNotModified {
+				t.Errorf("%s: If-None-Match should 304, got %d", entry, rec.Code)
+			}
+			if rec.Body.Len() != 0 {
+				t.Errorf("%s: 304 body must be empty, got %d bytes", entry, rec.Body.Len())
+			}
 		}
+	})
+
+	t.Run("an app cannot shadow _rela-editor.js / .woff2 with its own files", func(t *testing.T) {
+		withTestEditorAssets(t)
 		writeApp(t, root, "shadowed", map[string]string{
 			"index.html":         "<html></html>",
 			"_rela-editor.js":    "EVIL",
@@ -519,6 +540,24 @@ func TestHandleV1App(t *testing.T) {
 // need the real bytes must skip when it's absent rather than fail. The
 // production/release build always runs the frontend build first.
 func editorBundleBuilt() bool { return len(appEditorSource()) > 0 }
+
+// withTestEditorAssets swaps the editor bundle/font source vars with fixed test
+// bytes for the duration of a test, restoring them after. This lets the serving
+// path (content-type, CORS, caching, shadowing) be exercised in CI even when the
+// frontend build hasn't run (the `go test ./...` job doesn't build it) — closing
+// the coverage hole where the new reserved-entry branches would otherwise only
+// run on a developer's machine. The fake JS deliberately contains the
+// "rela-editor" marker and the reserved font path so the same assertions hold.
+func withTestEditorAssets(t *testing.T) {
+	t.Helper()
+	const fakeJS = `(function(){customElements.define('rela-editor',class extends HTMLElement{});` +
+		`/* @font-face url(` + appEditorFontEntry + `) */})();`
+	fakeFont := []byte("wOF2-test-font-bytes")
+	origJS, origFont := appEditorSource, appEditorFontSource
+	appEditorSource = func() []byte { return []byte(fakeJS) }
+	appEditorFontSource = func() []byte { return fakeFont }
+	t.Cleanup(func() { appEditorSource, appEditorFontSource = origJS, origFont })
+}
 
 // TestAppEditorBundleEmbedded verifies the editor bundle + font, WHEN BUILT,
 // define the custom element and reference the same-path font. It skips on a

--- a/tickets/entities/review-responses/RR-0HFLQ5.md
+++ b/tickets/entities/review-responses/RR-0HFLQ5.md
@@ -1,0 +1,9 @@
+---
+id: RR-0HFLQ5
+type: review-response
+title: placeholder observed but silently no-op after mount
+finding: observedAttributes included 'placeholder' but attributeChangedCallback did nothing with it (EasyMDE has no live setter). Observing it invited a 'set it reactively, works at mount, silently fails after' footgun.
+severity: significant
+resolution: Removed 'placeholder' from observedAttributes so it's read-once-at-mount with no callback inviting the misconception. Documented as mount-time-only.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-9PTXV0.md
+++ b/tickets/entities/review-responses/RR-9PTXV0.md
@@ -1,0 +1,9 @@
+---
+id: RR-9PTXV0
+type: review-response
+title: _pendingValue never cleared after mount; toolbar/theme forked without drift guard
+finding: (1) _pendingValue held a duplicate of the document for the editor's whole lifetime after mount (invariant 'only meaningful while _editor==null' was undocumented/unenforced). (2) The toolbar config and theme CSS were hand-forked from MarkdownEditor.vue with no drift guard — the exact failure mode the tokens.css drift test exists to prevent, applied inconsistently.
+severity: significant
+resolution: (1) _pendingValue cleared at end of _mount with the invariant documented. (2) Added reciprocal DRIFT cross-reference comments in MarkdownEditor.vue, relaEditorTheme.css, and relaEditor.ts; full extraction tracked as TKT-D2JML7 (shared plain-TS core).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-E0BFFN.md
+++ b/tickets/entities/review-responses/RR-E0BFFN.md
@@ -1,0 +1,9 @@
+---
+id: RR-E0BFFN
+type: review-response
+title: Fullscreen leaves body overflow:hidden on teardown
+finding: EasyMDE's toggleFullScreen sets document.body.style.overflow='hidden' and only restores on toggle-off. The element's _unmount (toTextArea/cleanup) didn't exit fullscreen, so disconnecting while fullscreen left the host app's page permanently unscrollable with no editor to fix it.
+severity: critical
+resolution: _unmount now checks cm.getOption('fullScreen') and calls EasyMDE.toggleFullScreen(editor) before teardown. Covered by 'exits fullscreen on teardown' + 'does not toggle when not fullscreen' tests.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-EB1927.md
+++ b/tickets/entities/review-responses/RR-EB1927.md
@@ -1,0 +1,9 @@
+---
+id: RR-EB1927
+type: review-response
+title: 'Minor: whenReady return, strip-regex assert, font path resolution, comments'
+finding: 'Bundle of minor findings: whenReady returned undefined when given a callback (whenReady(cb).then() threw); strip-fontawesome regex could silently no-op shipping 1.5MB of fonts; emit-editor-font used a hardcoded node_modules path (fragile under hoisting/pnpm); duplicated font/woff2 literal vs appContentTypes; deferred-mount comment framed as the readiness fix; stale CSS injection-order comment.'
+severity: minor
+resolution: whenReady always returns the promise; strip plugin throws if nothing stripped; emit-editor-font uses require.resolve with a clear error; font content-type now references appContentTypes['.woff2']; deferred-mount comment reframed as perf with a pointer to the SDK rela.ready as the real readiness fix. (assetsInlineLimit footgun left as-is with intent comment — acceptable.)
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-IWZ16L.md
+++ b/tickets/entities/review-responses/RR-IWZ16L.md
@@ -1,0 +1,9 @@
+---
+id: RR-IWZ16L
+type: review-response
+title: CI never exercised the editor serving path (skip = coverage hole)
+finding: The handler subtests for _rela-editor.js/.woff2 serving, CORS, and shadowing all gated on editorBundleBuilt(), which is false in the `go test ./...` CI job (no frontend build). So the new reserved-entry branches + the security-relevant shadowing test never ran in CI.
+severity: significant
+resolution: Made appEditorSource/appEditorFontSource overridable vars and added withTestEditorAssets(t) which injects fixed fake bytes. The serving/CORS/ETag/shadowing subtests now run unconditionally (no skip). The 'is the real built bundle valid' test (TestAppEditorBundleEmbedded) still skips when unbuilt, which is correct.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-UECSPI.md
+++ b/tickets/entities/review-responses/RR-UECSPI.md
@@ -1,0 +1,9 @@
+---
+id: RR-UECSPI
+type: review-response
+title: change fired on every blur, not only on actual edit
+finding: The element dispatched 'change' on every CodeMirror blur, unlike a native <textarea> which fires change on blur only if the value changed since focus. Consumers wiring autosave/dirty-tracking to 'change' would get spurious saves on every click-away.
+severity: significant
+resolution: Added a focus snapshot (_valueAtFocus); blur dispatches 'change' only when editor.value() differs. Covered by 'does NOT dispatch change on blur when nothing was edited' + the positive edit test.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-XAZAO8.md
+++ b/tickets/entities/review-responses/RR-XAZAO8.md
@@ -1,0 +1,9 @@
+---
+id: RR-XAZAO8
+type: review-response
+title: No caching on 372KB editor bundle + font
+finding: _rela-editor.js (372KB) and _rela-editor.woff2 (77KB) were served with no Cache-Control/ETag, so they were re-transferred in full on every iframe (re)load (iframes reload on host navigation/v-if/remount).
+severity: critical
+resolution: 'Added serveCachedAsset: ETag (sha256 of bytes) + Cache-Control: public, max-age=0, must-revalidate, with an If-None-Match 304 path. Not ''immutable'' because the URL is unversioned (a new build changes the bytes->ETag, so caches revalidate and pick up new builds without staleness). Covered by ''editor assets carry an ETag and 304'' test.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-5F9V56.md
+++ b/tickets/entities/tickets/TKT-5F9V56.md
@@ -1,0 +1,91 @@
+---
+id: TKT-5F9V56
+type: ticket
+title: Expose a markdown editor to custom apps via a <rela-editor> custom element (_rela-editor.js)
+kind: enhancement
+priority: medium
+effort: m
+status: ready
+---
+
+Custom apps currently have to build their own `<textarea>` for editing markdown
+(the "Today" app's notes box is a plain textarea). There's no way to give a
+plugin rela's real markdown editing experience, and no high-level seam that
+would let us swap the underlying editor later without breaking plugins.
+
+## Goal
+
+A **high-level, minimal, swappable** markdown editor API for custom apps. The
+plugin-facing contract must be small enough that the underlying editor (today
+EasyMDE/CodeMirror 5) can be replaced later (e.g. CodeMirror 6) with **zero
+plugin changes**.
+
+## Design (converged with maintainer)
+
+Ship a **Custom Element** `<rela-editor>` from a new reserved per-app asset
+`_rela-editor.js` (separate from the tiny bridge `_rela.js` so only apps that
+opt in pay the ~150KB editor bundle).
+
+- **Custom Elements, NOT shadow DOM.** EasyMDE is built on CodeMirror 5, which has known shadow-DOM focus/selection/measurement bugs. The element renders EasyMDE into its own **light DOM** so CM5 behaves; encapsulation is by *convention* (documented narrow API; internals unsupported). The iframe sandbox already isolates apps from each other, so a plugin poking its own editor only hurts itself. Cleanly upgrades to enforced shadow-DOM encapsulation if/when the SPA moves to CM6 — **without changing the plugin-facing API**.
+
+- **Public contract (the swap seam) — this and nothing else:**
+  - property `value` (get/set markdown; whitespace-exact)
+  - attribute `placeholder` (plain text, attribute-safe)
+  - attribute `readonly` (boolean)
+  - native `input` event (per keystroke) and `change` event (on blur/commit), dispatched on the element
+  - `focus()`
+  - `connectedCallback` builds EasyMDE; `disconnectedCallback` destroys it + removes listeners (leak-safe even if the plugin removes the node)
+
+- **Initial value via the JS property only** (`ed.value = '...'`). No `value` attribute and no slotted text content — markdown is multiline and whitespace-sensitive; HTML attribute/text-content normalization would mangle it.
+
+- **Pure text editor.** Markdown in, markdown out. No entity binding, no autosave — the plugin wires `change` -> `rela.update()` itself.
+
+## Toolbar icons / font — RESOLVED
+
+Keep EasyMDE's real Font Awesome 4.7 toolbar, and **serve the FA webfont under
+the app's own base** as a reserved asset (e.g. `_rela-editor.woff2`). The editor
+bundle's `@font-face` points at that app-relative URL, which the EXISTING
+`font-src <base>` already permits — **no CSP change, no bright-line exception,
+no hash coupling.**
+
+Rationale for rejecting the alternatives:
+- *Widen `font-src` to `<base> /assets/`* to reuse the SPA's FA font: syntactically fine and **safe today** (CSP normalizes then prefix-matches, so no traversal; `/assets/` holds only public static build output, no API/entity data). Rejected only to preserve the "apps touch ONLY their own path" bright line (keeps the app CSP cheap to audit forever; avoids a future asset under `/assets/` silently inheriting app font-load permission) AND because the SPA's FA file is hash-named/rebuilt each `npm run build` (would need a manifest lookup). NOTE for the implementer: the security fear about traversal was investigated and is NOT real — the reason is maintainability/bright-line only.
+- *Inline SVG icons*: viable, but the FA-under-base option keeps the toolbar identical to the SPA with comparable effort now that the font is served same-path.
+
+The FA webfont is already in the build
+(`static/v2/assets/fontawesome-webfont-<hash>.woff2`, ~77KB woff2) but only as a
+hash-named, untracked build artifact, so it is not directly reusable. The
+editor's own build must emit a **stable-named** woff2 to embed + serve at the
+reserved path.
+
+## Implementation sketch
+
+- New frontend Vite **lib/IIFE build** (separate config) with entry `src/app-editor/relaEditor.ts` that bundles EasyMDE + CodeMirror 5 + EasyMDE CSS into a self-contained IIFE which `customElements.define('rela-editor', ...)`. Drops the SPA's entity-picker button + backtick-autocomplete (those need the schema store; the app editor is pure text). The bundled CSS `@font-face` for FA points at the app-relative reserved font path.
+- Emit a stable-named FA `woff2` from this build; embed both the JS bundle and the woff2 into the Go binary via `//go:embed` (same pattern as `apps_tokens.css`), each with a drift/sync test.
+- `apps.go`: add reserved constants `appEditorEntry = "_rela-editor.js"` and `appEditorFontEntry = "_rela-editor.woff2"`; `apps_handler.go`: serve the JS as `text/javascript` and the font as `font/woff2`, both under the app base (existing `script-src <base>` / `font-src <base>` already permit). Reserved-entry shadowing (apps can't serve `_`-prefixed files) already covers both.
+- App author usage:
+  ```html
+  <script src="_rela.js"></script>
+  <script src="_rela-editor.js"></script>
+  <link rel="stylesheet" href="_rela.css" />
+  ...
+  <rela-editor id="ed"></rela-editor>
+  <script>
+    window.addEventListener('rela:ready', async () => {
+      const note = await rela.get({type:'daily-note', id});
+      const ed = document.getElementById('ed');
+      ed.value = note.content || '';
+      ed.addEventListener('change', () => rela.update({type:'daily-note', id, patch:{content: ed.value}}));
+    });
+  </script>
+  ```
+- Docs: extend the custom-apps doc + `internal/dataentry/CLAUDE.md` (the `_rela-editor.js` / `_rela-editor.woff2` reserved assets and the `<rela-editor>` contract; value-API-is-the-contract / internals-unsupported rule, mirroring the `_rela.css` "tokens are the contract" note; and the explicit decision to serve the font under `<base>` rather than widening `font-src`).
+- Tests: served content-types + reserved-entry shadowing for both new assets; bundle + font drift guards; (frontend) a smoke test that `<rela-editor>` mounts, round-trips `value` whitespace-exact, and fires `change`.
+
+## Forward-compat note
+
+Because the contract is
+`value`/`input`/`change`/`focus`/`placeholder`/`readonly` only, swapping EasyMDE
+for CM6 (and tightening to a closed shadow root) is invisible to plugins. If a
+future change DOES alter the element contract, bump `currentBridgeVersion` and
+gate per declared app version (same seam as the bridge SDK).

--- a/tickets/relations/TKT-5F9V56--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-5F9V56--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5F9V56
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-5F9V56--depends-on--TKT-F5FDEQ.md
+++ b/tickets/relations/TKT-5F9V56--depends-on--TKT-F5FDEQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5F9V56
+relation: depends-on
+to: TKT-F5FDEQ
+---

--- a/tickets/relations/TKT-5F9V56--has-review-response--RR-0HFLQ5.md
+++ b/tickets/relations/TKT-5F9V56--has-review-response--RR-0HFLQ5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5F9V56
+relation: has-review-response
+to: RR-0HFLQ5
+---

--- a/tickets/relations/TKT-5F9V56--has-review-response--RR-9PTXV0.md
+++ b/tickets/relations/TKT-5F9V56--has-review-response--RR-9PTXV0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5F9V56
+relation: has-review-response
+to: RR-9PTXV0
+---

--- a/tickets/relations/TKT-5F9V56--has-review-response--RR-E0BFFN.md
+++ b/tickets/relations/TKT-5F9V56--has-review-response--RR-E0BFFN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5F9V56
+relation: has-review-response
+to: RR-E0BFFN
+---

--- a/tickets/relations/TKT-5F9V56--has-review-response--RR-EB1927.md
+++ b/tickets/relations/TKT-5F9V56--has-review-response--RR-EB1927.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5F9V56
+relation: has-review-response
+to: RR-EB1927
+---

--- a/tickets/relations/TKT-5F9V56--has-review-response--RR-IWZ16L.md
+++ b/tickets/relations/TKT-5F9V56--has-review-response--RR-IWZ16L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5F9V56
+relation: has-review-response
+to: RR-IWZ16L
+---

--- a/tickets/relations/TKT-5F9V56--has-review-response--RR-UECSPI.md
+++ b/tickets/relations/TKT-5F9V56--has-review-response--RR-UECSPI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5F9V56
+relation: has-review-response
+to: RR-UECSPI
+---

--- a/tickets/relations/TKT-5F9V56--has-review-response--RR-XAZAO8.md
+++ b/tickets/relations/TKT-5F9V56--has-review-response--RR-XAZAO8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5F9V56
+relation: has-review-response
+to: RR-XAZAO8
+---

--- a/tickets/relations/TKT-5F9V56--implements--FEAT-BFDB9Q.md
+++ b/tickets/relations/TKT-5F9V56--implements--FEAT-BFDB9Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5F9V56
+relation: implements
+to: FEAT-BFDB9Q
+---


### PR DESCRIPTION
## Summary

Adds a high-level, swappable **markdown editor** for custom apps as a Custom Element, `<rela-editor>`, served from a new opt-in reserved asset, plus inline backtick entity-reference autocomplete.

Implements **TKT-5F9V56** (the editor element) and the app-editor side of **TKT-D2JML7** (backtick completion).

## What's included

**`<rela-editor>` element** (`frontend/src/app-editor/`, built by `vite.editor.config.ts` into an embedded IIFE):
- Wraps EasyMDE (CodeMirror 5) in **light DOM** (CM5 misbehaves in shadow DOM).
- Minimal, swap-seam public contract: property `value` (whitespace-exact), attributes `placeholder`/`readonly`, native `input`/`change` events, `focus()`. Everything else is unsupported so the underlying editor can be replaced later without breaking apps.
- `change` fires on blur only when the value actually changed (native `<textarea>` semantics); programmatic `.value` sets are silent (no autosave loops).
- Themed via `_rela.css` tokens — follows host light/dark, including fullscreen chrome.
- Degraded plain-textarea fallback if EasyMDE construction throws.

**Served assets** (`internal/dataentry`):
- `_rela-editor.js` (~120KB gzip) and `_rela-editor.woff2`, served under the app base — existing `script-src <base>` / `font-src <base>` CSP already permit them (no widening). Font carries `Access-Control-Allow-Origin: *` because the sandboxed iframe is null-origin. ETag + `must-revalidate` so the bundle isn't re-transferred on every iframe load. Reserved-entry shadowing protection applies (apps can't override them).
- Gitignored build artifacts (like `static/v2`), embedded via a glob + committed `.gitkeep` so the package compiles on a clean checkout; `npm run build` produces them.

**Bridge SDK** (`apps_sdk.go`): replayable `rela.ready` Promise + `rela.whenReady(cb)` so apps don't miss the handshake when a large script (the editor bundle) delays their inline code. The `rela:ready` event is kept for back-compat.

**Backtick autocomplete** (`relaBacktick.ts`): plain-DOM, bridge-fed (`rela.schema/search/list` — no axios, CSP blocks fetch). Type `` ` `` → pick a type prefix → pick an entity → inserts `` `<ID>` ``. Keyboard nav (↑/↓/Enter/Tab/Esc) + click. Reuses the `insertEntityRef` adjacency/validation rule.

## Tests

- Go: serving + content-type + CORS + ETag/304 + reserved-entry shadowing (run unconditionally via injected test assets, not skipped when the bundle isn't built); SDK readiness contract; embed guard.
- Frontend: 20 app-editor unit tests (element contract incl. fullscreen-teardown + programmatic-set-silent; backtick state machine + keyboard nav + insertion).
- Verified end-to-end in a real browser (puppeteer): editor render, theming, fullscreen, full backtick flow with keyboard nav.

## Notes
- Came out of building a "Today" Smart-Check-style demo app; the editor is general-purpose.
- TKT-D2JML7's full goal (unify the SPA + app editor onto one shared completion core) remains a follow-up — this PR ships a separate plain-DOM impl for the app editor to avoid regressing the shipped SPA feature; drift-guard cross-reference comments added at both sites.
- Docs in `internal/dataentry/CLAUDE.md`.
- `just ci` passes locally (lint, arch-lint, plimsoll, tests, coverage 76.8%, build, docs-check); frontend lint/typecheck/1136 tests pass.