### PR TITLE
feat(apps): font tokens in _rela.css so apps inherit host typography

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -2358,13 +2358,20 @@ linking the served stylesheet:
 (`_rela.css` is a relative URL — it resolves against the app's own base,
 `/api/v1/_apps/<id>/`, same as your other sibling assets.)
 
-`_rela.css` provides two things:
+`_rela.css` provides three things:
 
 - **Theme tokens** — CSS custom properties for colors (`--text-color`,
   `--bg-color`, `--card-bg`, `--border-color`, `--accent-color`,
   `--error/success/warning/info-color`, the `--badge-*` set), surfaces, and
   borders. Use them in your own CSS (`color: var(--text-color)`) so the app
   matches the host palette.
+- **Typography** — `--font-family` (the host UI font) and a small size scale
+  (`--font-size-sm` / `--font-size-base` / `--font-size-lg` / `--font-size-xl`).
+  Linking `_rela.css` applies `--font-family` and `--font-size-base` on your
+  app's `<html>` automatically, so text matches the host instead of the
+  browser's default serif — a sandboxed app iframe is a separate document with
+  no inherited typography. Use `var(--font-size-lg)` etc. for headings; override
+  per-element whenever you like.
 - **Base controls** — three atomic classes: `.btn` / `.btn-primary` (buttons),
   `.input` (text inputs), `.card` (a bordered surface). These are deliberately
   minimal; build anything more structural (tables, selects, modals) yourself

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -2352,13 +2352,20 @@ linking the served stylesheet:
 (`_rela.css` is a relative URL — it resolves against the app's own base,
 `/api/v1/_apps/<id>/`, same as your other sibling assets.)
 
-`_rela.css` provides two things:
+`_rela.css` provides three things:
 
 - **Theme tokens** — CSS custom properties for colors (`--text-color`,
   `--bg-color`, `--card-bg`, `--border-color`, `--accent-color`,
   `--error/success/warning/info-color`, the `--badge-*` set), surfaces, and
   borders. Use them in your own CSS (`color: var(--text-color)`) so the app
   matches the host palette.
+- **Typography** — `--font-family` (the host UI font) and a small size scale
+  (`--font-size-sm` / `--font-size-base` / `--font-size-lg` / `--font-size-xl`).
+  Linking `_rela.css` applies `--font-family` and `--font-size-base` on your
+  app's `<html>` automatically, so text matches the host instead of the
+  browser's default serif — a sandboxed app iframe is a separate document with
+  no inherited typography. Use `var(--font-size-lg)` etc. for headings; override
+  per-element whenever you like.
 - **Base controls** — three atomic classes: `.btn` / `.btn-primary` (buttons),
   `.input` (text inputs), `.card` (a bordered surface). These are deliberately
   minimal; build anything more structural (tables, selects, modals) yourself

--- a/internal/dataentry/apps_css.go
+++ b/internal/dataentry/apps_css.go
@@ -71,6 +71,30 @@ const appBaseControlsCSS = `
 }
 `
 
+// appTypographyCSS defines the font tokens and applies them on the app document.
+// Unlike the color tokens, typography is palette-INDEPENDENT (it's the same for
+// every project), so it is emitted unconditionally by appCSSSource — the
+// per-project palette path only rewrites the color :root block and would
+// otherwise leave --font-family undefined. Applying family + base size on <html>
+// is what stops a linking app from falling back to the browser default serif at
+// 16px (a sandboxed app iframe is a separate document with no inherited
+// typography). Apps can override per-element. Font is app-only (the SPA sets its
+// own in App.vue), so it lives here rather than in the shared tokens.css.
+const appTypographyCSS = `
+/* --- rela typography (font tokens + application) --- */
+:root {
+  --font-family: 'Open Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-size-sm: 12px;
+  --font-size-base: 14px;
+  --font-size-lg: 18px;
+  --font-size-xl: 22px;
+}
+html {
+  font-family: var(--font-family);
+  font-size: var(--font-size-base);
+}
+`
+
 // appCSSSource returns the full stylesheet served at the reserved per-app path
 // /api/v1/_apps/<id>/_rela.css: the theme tokens followed by the base controls.
 // An app opts in with <link rel="stylesheet" href="_rela.css">; theme follows
@@ -95,6 +119,10 @@ func appCSSSource(palette *ResolvedPalette) string {
 		// No resolved palette — fall back to the embedded default tokens.
 		b.WriteString(appTokensCSS)
 	}
+	// Typography is palette-independent, so always emit it (the palette path
+	// only rewrites the color :root block).
+	b.WriteString("\n")
+	b.WriteString(appTypographyCSS)
 	b.WriteString("\n")
 	b.WriteString(appBaseControlsCSS)
 	return b.String()

--- a/internal/dataentry/apps_test.go
+++ b/internal/dataentry/apps_test.go
@@ -129,7 +129,11 @@ func TestAppCSSSource(t *testing.T) {
 	// nil palette → fall back to the embedded default tokens. The embed
 	// carries a :root.dark block, so it must be present here.
 	css := appCSSSource(nil)
-	for _, want := range []string{"--text-color", ":root", ":root.dark", ".btn", ".btn-primary", ".input", ".card"} {
+	for _, want := range []string{
+		"--text-color", ":root", ":root.dark", ".btn", ".btn-primary", ".input", ".card",
+		// Typography is always emitted (font tokens + applied on <html>).
+		"--font-family", "--font-size-base", "font-family: var(--font-family)",
+	} {
 		if !strings.Contains(css, want) {
 			t.Errorf("appCSSSource(nil) missing %q", want)
 		}
@@ -182,6 +186,15 @@ func TestAppCSSSourceUsesResolvedPalette(t *testing.T) {
 	for _, want := range []string{":root {", ":root.dark {", ".btn-primary"} {
 		if !strings.Contains(css, want) {
 			t.Errorf("appCSSSource(resolved) missing %q", want)
+		}
+	}
+	// Typography is palette-INDEPENDENT: the font tokens must still be emitted
+	// even when the color :root block comes from the resolved palette (the
+	// palette path only rewrites colors, so without the always-on typography
+	// block --font-family would be undefined).
+	for _, want := range []string{"--font-family", "--font-size-base", "font-family: var(--font-family)"} {
+		if !strings.Contains(css, want) {
+			t.Errorf("appCSSSource(resolved) missing typography %q", want)
 		}
 	}
 }

--- a/tickets/entities/tickets/TKT-PF4E6S.md
+++ b/tickets/entities/tickets/TKT-PF4E6S.md
@@ -1,0 +1,33 @@
+---
+id: TKT-PF4E6S
+type: ticket
+title: Font tokens in _rela.css so apps inherit host typography
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+Add typography tokens (`--font-family`, `--font-size-{sm,base,lg,xl}`) to the
+`_rela.css` served to custom apps, plus an `html` rule that applies the font
+family + base size. Without this, an app that links `_rela.css` for the color
+tokens still falls back to the browser default serif at 16px, so its text does
+not match the host UI.
+
+This is the typography sibling of the color palette (FEAT-4OEJ): the token
+*names* are the frozen app-facing contract; web serves SPA-matching values and
+the native client serves its own system-font values.
+
+Emitted from an always-present `appTypographyCSS` block (independent of the
+per-project palette introduced by the palette feature), so linking apps get the
+font tokens whether or not a resolved palette is present.
+
+## Acceptance criteria
+
+1. `_rela.css` served at `/api/v1/_apps/<id>/_rela.css` includes `--font-family`
+and the `--font-size-*` scale, plus an `html { font-family; font-size }` rule.
+2. The tokens are emitted on both the nil-palette and resolved-palette paths.
+3. Existing color tokens and `.btn`/`.input`/`.card` controls are unchanged.
+4. Docs (data-entry guide) note that `_rela.css` now also provides typography.

--- a/tickets/relations/TKT-PF4E6S--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-PF4E6S--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PF4E6S
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-PF4E6S--implements--FEAT-4OEJ.md
+++ b/tickets/relations/TKT-PF4E6S--implements--FEAT-4OEJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PF4E6S
+relation: implements
+to: FEAT-4OEJ
+---


### PR DESCRIPTION
## Problem

A custom app runs in a **sandboxed iframe** — a separate document with no inherited typography. An app that opts into `_rela.css` today gets the theme **colors** but no font, so it falls back to the browser default **serif at 16px**, visibly mismatched with the data-entry shell (and oversized).

`_rela.css` provides color tokens + atomic controls, but nothing for type.

## Change

Add an always-emitted **typography block** to the served `_rela.css`:

- `--font-family` (the host UI font) + a small scale `--font-size-{sm,base,lg,xl}`.
- An `html { font-family: var(--font-family); font-size: var(--font-size-base) }` rule so a linking app inherits the host font automatically. Apps can still override per-element.

### Notes

- **Palette-independent.** The recent per-project palette work (#1045) rewrites the color `:root` block from the resolved palette; the font tokens are the same for every project, so they're emitted **unconditionally** (otherwise `--font-family` would be undefined on the palette path). `TestAppCSSSource` / `TestAppCSSSourceUsesResolvedPalette` pin the typography block in **both** the nil-palette and resolved-palette cases.
- **App-only.** Font lives in the app sheet (`appTypographyCSS`), not the shared `tokens.css`, because the SPA already sets its own font in `App.vue`. So `tokens.css` / `apps_tokens.css` are untouched (stays color-only).
- The `--font-*` token **names** double as a cross-platform contract: non-browser clients (e.g. a native rela client hosting apps in a WebView) can supply the same names with their own values.

## Test plan

- `go test ./internal/dataentry/ ./internal/dataentryconfig/` — green.
- Extended `TestAppCSSSource` and `TestAppCSSSourceUsesResolvedPalette` to assert `--font-family`, `--font-size-base`, and the applied `html` rule are present with and without a project palette.
- Docs regenerated (`GUIDE-data-entry.md` → `docs/data-entry.md`): the `_rela.css` section now documents typography as a third thing it provides.