### PR TITLE
feat(dataentry): incoming relation columns in v1 lists + ACL neighbor gating (TKT-ODHV2D)

### DIFF
--- a/frontend/src/components/lists/EntityList.test.ts
+++ b/frontend/src/components/lists/EntityList.test.ts
@@ -399,3 +399,144 @@ describe('EntityList search integration', () => {
     wrapper.unmount()
   })
 })
+
+// TKT-ODHV2D: incoming relation columns. Verifies getFormattedCellValue is
+// direction-aware — an `direction: incoming` column reads the relation's
+// inverse key from entity.relations and resolves the source IDs via the
+// included map (exactly the same client-side ID→title path as outgoing
+// columns). Rendered through the DOM since the function is component-local.
+describe('EntityList incoming relation columns', () => {
+  const listId = 'taaks'
+  const entityType = 'taak'
+
+  // A taak list with an incoming relation column (verantwoordelijk_voor points
+  // persoon → taak; its inverse is verantwoordelijken).
+  function seedSchema() {
+    const schemaStore = useSchemaStore()
+    schemaStore.lists.set(listId, {
+      id: listId,
+      title: 'Taken',
+      entity: entityType,
+      columns: [
+        { property: 'title', label: 'Title' },
+        { relation: 'verantwoordelijk_voor', direction: 'incoming', label: 'Verantwoordelijken' },
+      ],
+    } as never)
+    schemaStore.entityTypes.set(entityType, {
+      name: entityType,
+      label: 'Taak',
+      properties: { title: { type: 'string', values: null } },
+    } as never)
+    // The relation type declares an explicit inverse, so getInverseName
+    // returns "verantwoordelijken" — the wire key the backend uses.
+    schemaStore.relationTypes.set('verantwoordelijk_voor', {
+      label: 'verantwoordelijk voor',
+      from: ['persoon'],
+      to: ['taak'],
+      inverse: { id: 'verantwoordelijken' },
+    } as never)
+  }
+
+  // Build a list response where the taak row carries incoming sources under
+  // the inverse key, and the included map holds those source persoons.
+  function seedIncomingResponse(sourceIds: string[]): ListResponse<Entity> {
+    const included: Record<string, Entity> = {}
+    for (const id of sourceIds) {
+      included[id] = { id, type: 'persoon', properties: { title: `Name ${id}` }, _title: `Name ${id}` }
+    }
+    const response: ListResponse<Entity> = {
+      data: [
+        {
+          id: 'TASK-1',
+          type: entityType,
+          properties: { title: 'Ship it' },
+          relations: { verantwoordelijken: sourceIds },
+        },
+      ],
+      meta: { total: 1, page: 1, per_page: 25, has_more: false },
+      included,
+    }
+    listEntitiesMock.mockResolvedValue(response)
+    return response
+  }
+
+  let pinia: ReturnType<typeof createPinia>
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    _setEntityPluralForTest(entityType, 'taaks')
+    listEntitiesMock.mockReset()
+    deleteEntityMock.mockReset().mockResolvedValue(undefined)
+    _resetModalStack()
+    routerPush.mockClear()
+    routerReplace.mockClear()
+    mockRoute.query = {}
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    _resetModalStack()
+  })
+
+  it('resolves a single incoming source to its title', async () => {
+    seedSchema()
+    seedIncomingResponse(['PERS-JV'])
+    const wrapper = mount(EntityList, {
+      props: { listId },
+      attachTo: document.body,
+      global: { plugins: [pinia, PiniaColada] },
+    })
+    await flushPromises()
+
+    // The second column cell renders the resolved persoon title.
+    const dataCells = wrapper.findAll('tbody tr td:not(.actions-cell):not(.select-cell)')
+    const relCell = dataCells[dataCells.length - 1]
+    expect(relCell.text()).toBe('Name PERS-JV')
+    wrapper.unmount()
+  })
+
+  it('resolves multiple incoming sources comma-separated', async () => {
+    seedSchema()
+    seedIncomingResponse(['PERS-JV', 'PERS-AB'])
+    const wrapper = mount(EntityList, {
+      props: { listId },
+      attachTo: document.body,
+      global: { plugins: [pinia, PiniaColada] },
+    })
+    await flushPromises()
+
+    const dataCells = wrapper.findAll('tbody tr td:not(.actions-cell):not(.select-cell)')
+    const relCell = dataCells[dataCells.length - 1]
+    expect(relCell.text()).toBe('Name PERS-JV, Name PERS-AB')
+    wrapper.unmount()
+  })
+
+  it('outgoing lookup key stays empty for an incoming column (no collision)', async () => {
+    seedSchema()
+    // Row carries edges ONLY under the outgoing relation type, none under the
+    // inverse. An incoming column must therefore render empty.
+    listEntitiesMock.mockResolvedValue({
+      data: [
+        {
+          id: 'TASK-1',
+          type: entityType,
+          properties: { title: 'Ship it' },
+          relations: { verantwoordelijk_voor: ['PERS-JV'] },
+        },
+      ],
+      meta: { total: 1, page: 1, per_page: 25, has_more: false },
+      included: { 'PERS-JV': { id: 'PERS-JV', type: 'persoon', properties: {}, _title: 'Name' } },
+    } as ListResponse<Entity>)
+    const wrapper = mount(EntityList, {
+      props: { listId },
+      attachTo: document.body,
+      global: { plugins: [pinia, PiniaColada] },
+    })
+    await flushPromises()
+
+    const dataCells = wrapper.findAll('tbody tr td:not(.actions-cell):not(.select-cell)')
+    const relCell = dataCells[dataCells.length - 1]
+    expect(relCell.text()).toBe('')
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -515,10 +515,31 @@ function isCellInaccessible(entity: Entity, column: { property?: string }): bool
   return entity.inaccessible.some((f) => f.name === column.property)
 }
 
-function getFormattedCellValue(entity: Entity, column: { property?: string; relation?: string }): string {
-  // For relation columns, resolve IDs to titles using included entities
+// relationCellKey returns the wire key in entity.relations that holds a
+// relation column's target IDs. Outgoing columns read the relation type
+// directly; incoming columns read the relation's inverse key — the declared
+// inverse name if the metamodel has one, else the `<relation>_inverse`
+// fallback. This mirrors the backend's inverseRelationKey (see MECHANISM.md);
+// the two must stay in lockstep.
+function relationCellKey(relation: string, direction?: 'outgoing' | 'incoming'): string {
+  if (direction === 'incoming') {
+    return schemaStore.getInverseName(relation) ?? `${relation}_inverse`
+  }
+  return relation
+}
+
+function getFormattedCellValue(
+  entity: Entity,
+  column: { property?: string; relation?: string; direction?: 'outgoing' | 'incoming' },
+): string {
+  // For relation columns, resolve IDs to titles using included entities.
+  // Outgoing edges are serialized under the relation type; incoming edges
+  // under the relation's INVERSE key (matching the backend serializer, see
+  // MECHANISM.md). The included map carries both target and source entities
+  // because the list is fetched with ?include=*.
   if (column.relation) {
-    const relationIds = entity.relations?.[column.relation] || []
+    const key = relationCellKey(column.relation, column.direction)
+    const relationIds = entity.relations?.[key] || []
     const titles = relationIds.map((id) => {
       const included = includedEntities.value[id]
       return included ? entityDisplayTitle(included) : id

--- a/internal/dataentry/acl_list_neighbor_test.go
+++ b/internal/dataentry/acl_list_neighbor_test.go
@@ -1,0 +1,107 @@
+package dataentry
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// TestACLList_HiddenNeighborExcludedFromRelations is the regression pin for
+// RR-HJV8CP: the per-row `relations` map must NOT carry the raw ID of a
+// neighbor the caller cannot read — for BOTH an outgoing target and an incoming
+// source. Before the fix, incomingRelations/outgoingRelations returned raw
+// edges with no neighbor gating, so a hidden neighbor's ID landed in
+// `relations[key]` while being absent from the visibility-filtered `included`
+// map; the SPA then rendered the raw hidden ID in the cell.
+//
+// Visibility is per-instance via editor-of/belongs-to inheritance: entities
+// reachable from PRJ-42 are visible to alice, entities reachable from PRJ-9 are
+// hidden. The test asserts the hidden neighbor is dropped AND the visible
+// neighbor is kept (the gate is not over-filtering).
+func TestACLList_HiddenNeighborExcludedFromRelations(t *testing.T) {
+	app := newTestAppV1(t)
+
+	// ACL scaffolding: alice is editor-of PRJ-42; the editor role reads
+	// tickets + features; the role is inherited through belongs-to. So
+	// anything belonging to PRJ-42 is visible; anything belonging to PRJ-9 is
+	// hidden.
+	seedEntity(app, &entity.Entity{ID: "alice", Type: "person", Properties: map[string]any{"title": "Alice"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-42", Type: "project", Properties: map[string]any{"title": "Granted"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-9", Type: "project", Properties: map[string]any{"title": "Hidden"}})
+	seedRelation(app, entity.NewRelation("alice", "editor-of", "PRJ-42"))
+
+	// Row entities (visible) and their neighbors (mixed visibility).
+	seedEntity(app, &entity.Entity{ID: "TKT-VIS", Type: "ticket", Properties: map[string]any{"title": "Visible ticket"}})
+	seedEntity(app, &entity.Entity{ID: "FEAT-VIS", Type: "feature", Properties: map[string]any{"title": "Visible feature"}})
+	seedEntity(app, &entity.Entity{ID: "FEAT-HIDDEN", Type: "feature", Properties: map[string]any{"title": "Hidden feature"}})
+	seedEntity(app, &entity.Entity{ID: "TKT-HIDDEN", Type: "ticket", Properties: map[string]any{"title": "Hidden ticket"}})
+
+	seedRelation(app, entity.NewRelation("TKT-VIS", "belongs-to", "PRJ-42"))
+	seedRelation(app, entity.NewRelation("FEAT-VIS", "belongs-to", "PRJ-42"))
+	seedRelation(app, entity.NewRelation("FEAT-HIDDEN", "belongs-to", "PRJ-9"))
+	seedRelation(app, entity.NewRelation("TKT-HIDDEN", "belongs-to", "PRJ-9"))
+
+	// Outgoing-target case (ticket row TKT-VIS): TKT-VIS implements a VISIBLE
+	// and a HIDDEN feature. FEAT-HIDDEN must not leak into relations[implements].
+	seedRelation(app, entity.NewRelation("TKT-VIS", "implements", "FEAT-HIDDEN"))
+
+	// Incoming-source case (feature row FEAT-VIS): FEAT-VIS is implemented by a
+	// VISIBLE ticket (TKT-VIS) and a HIDDEN ticket (TKT-HIDDEN). These land on
+	// the feature row under the implements inverse key (implements has no
+	// declared inverse -> synthetic implements_inverse). The TKT-VIS -> FEAT-VIS
+	// edge is the visible incoming source; TKT-HIDDEN -> FEAT-VIS is the hidden
+	// one that must not leak.
+	seedRelation(app, entity.NewRelation("TKT-VIS", "implements", "FEAT-VIS"))
+	seedRelation(app, entity.NewRelation("TKT-HIDDEN", "implements", "FEAT-VIS"))
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles: map[string]acl.RoleDef{"editor": {Read: []string{"ticket", "feature"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{
+			"editor-of": {Confers: "editor"},
+		},
+		InheritRolesThrough: []string{"belongs-to"},
+	}, app.store)
+	app.acl = d
+
+	t.Run("outgoing target hidden is excluded, visible kept", func(t *testing.T) {
+		resp, rec := listEntitiesAs(aliceCtx(), t, app, d, "ticket", "tickets", "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET tickets: %d %s", rec.Code, rec.Body)
+		}
+		row := findRow(t, resp.Data, "TKT-VIS")
+		impl := row.Relations["implements"]
+		if containsID(impl, "FEAT-HIDDEN") {
+			t.Errorf("relations[implements] leaks hidden target FEAT-HIDDEN: %v", impl)
+		}
+		if !containsID(impl, "FEAT-VIS") {
+			t.Errorf("relations[implements] over-filtered visible target FEAT-VIS: %v", impl)
+		}
+	})
+
+	t.Run("incoming source hidden is excluded, visible kept", func(t *testing.T) {
+		resp, rec := listEntitiesAs(aliceCtx(), t, app, d, "feature", "features", "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET features: %d %s", rec.Code, rec.Body)
+		}
+		row := findRow(t, resp.Data, "FEAT-VIS")
+		// implements has no declared inverse -> synthetic <type>_inverse key.
+		src := row.Relations["implements_inverse"]
+		if containsID(src, "TKT-HIDDEN") {
+			t.Errorf("relations[implements_inverse] leaks hidden source TKT-HIDDEN: %v", src)
+		}
+		if !containsID(src, "TKT-VIS") {
+			t.Errorf("relations[implements_inverse] over-filtered visible source TKT-VIS: %v", src)
+		}
+	})
+}
+
+func containsID(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -314,19 +314,37 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 	includes := query.Get("include")
 	wantIncludes := includes != ""
 
+	// Load each row's edges once. List rows carry BOTH outgoing edges (keyed
+	// by relation type) and incoming edges (keyed by the relation's inverse
+	// name) so that `direction: incoming` relation columns have a wire key to
+	// resolve against. The SPA computes the same inverse key and reads the
+	// source entities from the ?include=* peers. See MECHANISM.md.
+	outgoingByRow := make([][]*entityPkg.Relation, len(entities))
+	incomingByRow := make([][]*entityPkg.Relation, len(entities))
+	var pageNeighborIDs []string
+	for i, e := range entities {
+		outgoingByRow[i] = a.reader.outgoingRelations(r.Context(), e.ID)
+		incomingByRow[i] = a.reader.incomingRelations(r.Context(), e.ID)
+		pageNeighborIDs = append(pageNeighborIDs, neighborIDsOf(outgoingByRow[i], incomingByRow[i])...)
+	}
+
+	// Gate neighbor IDs for the WHOLE page in one type-batched pass
+	// (RR-HJV8CP + RR-FRK1): a neighbor's ID may appear in a row's relations
+	// map only if its entity is visible to the caller, so `relations` and the
+	// visibility-filtered `included` map can never disagree. Outgoing targets
+	// (edge.To) and incoming sources (edge.From) are gated together — an
+	// entity's visibility is direction-independent.
+	visibleNeighbors := visibleRelationIDs(r.Context(), a.reader, a.visibleReader, pageNeighborIDs)
+
 	// Build response - always include relations for relation column support
 	data := make([]v1.Entity, 0, len(entities))
 	included := make(map[string]v1.Entity)
-	for _, e := range entities {
-		// List rows carry BOTH outgoing edges (keyed by relation type) and
-		// incoming edges (keyed by the relation's inverse name) so that
-		// `direction: incoming` relation columns have a wire key to resolve
-		// against. The SPA computes the same inverse key and reads the source
-		// entities from the ?include=* peers. See MECHANISM.md.
+	for i, e := range entities {
 		v1Entity := a.serializer.forWireRelated(
 			r.Context(), e,
-			a.reader.outgoingRelations(r.Context(), e.ID),
-			a.reader.incomingRelations(r.Context(), e.ID),
+			outgoingByRow[i],
+			incomingByRow[i],
+			visibleNeighbors,
 			a.Meta(), plural,
 		)
 		data = append(data, v1Entity)
@@ -1627,7 +1645,7 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 		// {ID, Title} of related entities this principal may not read.
 		// Flipping this requires per-target gating first (RR-QO01XY) —
 		// TestACLSearch_VisibleHitRelatedToHidden pins the invariant.
-		data = append(data, a.serializer.forWireRelated(r.Context(), e, nil, nil, a.Meta(), plural))
+		data = append(data, a.serializer.forWireRelated(r.Context(), e, nil, nil, nil, a.Meta(), plural))
 	}
 
 	resp := v1.ListResponse{
@@ -1818,7 +1836,7 @@ func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, i
 	for _, target := range visible {
 		entityDef := s.Meta.Entities[target.Type]
 		plural := entityDef.GetPlural(target.Type)
-		included[target.ID] = a.serializer.forWireRelated(ctx, target, nil, nil, a.Meta(), plural)
+		included[target.ID] = a.serializer.forWireRelated(ctx, target, nil, nil, nil, a.Meta(), plural)
 
 		if nested, ok := nestedFor[target.ID]; ok {
 			for k, v := range a.resolveV1Includes(ctx, target, nested) {

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -318,7 +318,17 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 	data := make([]v1.Entity, 0, len(entities))
 	included := make(map[string]v1.Entity)
 	for _, e := range entities {
-		v1Entity := a.serializer.forWireRelated(r.Context(), e, a.reader.outgoingRelations(r.Context(), e.ID), a.Meta(), plural)
+		// List rows carry BOTH outgoing edges (keyed by relation type) and
+		// incoming edges (keyed by the relation's inverse name) so that
+		// `direction: incoming` relation columns have a wire key to resolve
+		// against. The SPA computes the same inverse key and reads the source
+		// entities from the ?include=* peers. See MECHANISM.md.
+		v1Entity := a.serializer.forWireRelated(
+			r.Context(), e,
+			a.reader.outgoingRelations(r.Context(), e.ID),
+			a.reader.incomingRelations(r.Context(), e.ID),
+			a.Meta(), plural,
+		)
 		data = append(data, v1Entity)
 
 		// Resolve includes if requested
@@ -1013,10 +1023,7 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 		if !ok {
 			continue
 		}
-		inverseName := edge.Type + "_inverse"
-		if relDef.Inverse != nil && relDef.Inverse.ID != "" {
-			inverseName = relDef.Inverse.ID
-		}
+		inverseName := inverseRelationKey(edge.Type, relDef)
 		rel := map[string]interface{}{
 			"id":        edge.From,
 			"type":      a.reader.entityType(r.Context(), edge.From),
@@ -1620,7 +1627,7 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 		// {ID, Title} of related entities this principal may not read.
 		// Flipping this requires per-target gating first (RR-QO01XY) —
 		// TestACLSearch_VisibleHitRelatedToHidden pins the invariant.
-		data = append(data, a.serializer.forWireRelated(r.Context(), e, nil, a.Meta(), plural))
+		data = append(data, a.serializer.forWireRelated(r.Context(), e, nil, nil, a.Meta(), plural))
 	}
 
 	resp := v1.ListResponse{
@@ -1811,7 +1818,7 @@ func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, i
 	for _, target := range visible {
 		entityDef := s.Meta.Entities[target.Type]
 		plural := entityDef.GetPlural(target.Type)
-		included[target.ID] = a.serializer.forWireRelated(ctx, target, nil, a.Meta(), plural)
+		included[target.ID] = a.serializer.forWireRelated(ctx, target, nil, nil, a.Meta(), plural)
 
 		if nested, ok := nestedFor[target.ID]; ok {
 			for k, v := range a.resolveV1Includes(ctx, target, nested) {

--- a/internal/dataentry/entityserializer.go
+++ b/internal/dataentry/entityserializer.go
@@ -31,7 +31,17 @@ type entitySerializer struct {
 // the identical key from the column's relation + the metamodel inverse — see
 // MECHANISM.md. Loading incoming edges is the caller's job; this stays a pure
 // transform.
-func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoing, incoming []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) v1.Entity {
+//
+// visibleNeighbors gates the neighbor IDs written into the relations map
+// (RR-HJV8CP): when non-nil, an outgoing target (edge.To) or incoming source
+// (edge.From) is emitted ONLY if visibleNeighbors[id] is true, so the wire's
+// `relations` map can never carry an ACL-hidden neighbor's raw ID (which would
+// leak past the `included` map that is already visibility-filtered). Passing
+// nil disables the filter — the per-entity / search / include shapes that
+// serialize their own already-gated edges keep byte-identical output. The set
+// is computed once per page by visibleRelationIDs (batched by type); this
+// transform only consults it.
+func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoing, incoming []*entityPkg.Relation, visibleNeighbors map[string]bool, meta *metamodel.Metamodel, plural string) v1.Entity {
 	out := v1.Entity{
 		ID:         e.ID,
 		Type:       e.Type,
@@ -57,8 +67,17 @@ func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoin
 	}
 
 	if outgoing != nil || incoming != nil {
+		// neighborVisible reports whether an edge endpoint may appear on the
+		// wire. When visibleNeighbors is nil the filter is off (caller passes
+		// already-gated edges); otherwise only IDs in the set survive.
+		neighborVisible := func(id string) bool {
+			return visibleNeighbors == nil || visibleNeighbors[id]
+		}
 		out.Relations = make(map[string][]string)
 		for _, edge := range outgoing {
+			if !neighborVisible(edge.To) {
+				continue
+			}
 			out.Relations[edge.Type] = append(out.Relations[edge.Type], edge.To)
 		}
 		// Incoming edges are keyed by the relation's inverse name so an
@@ -66,6 +85,9 @@ func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoin
 		// outgoing edges of the same relation. edge.From is the source
 		// entity ID (resolved to a title client-side via ?include=*).
 		for _, edge := range incoming {
+			if !neighborVisible(edge.From) {
+				continue
+			}
 			relDef, ok := meta.Relations[edge.Type]
 			if !ok {
 				continue
@@ -86,7 +108,7 @@ func (s entitySerializer) forWire(ctx context.Context, e *entityPkg.Entity, outg
 	// Per-entity responses carry outgoing edges only; incoming edges reach the
 	// SPA via the dedicated /relations endpoint, not the top-level relations
 	// map. Incoming list columns are served by forWireRelated (list rows).
-	result := s.toV1(ctx, e, outgoing, nil, meta, plural)
+	result := s.toV1(ctx, e, outgoing, nil, nil, meta, plural)
 	s.affordances.stripHiddenProperties(ctx, e, &result)
 	s.affordances.attachEntityAffordances(ctx, e, &result)
 	return result
@@ -99,8 +121,16 @@ func (s entitySerializer) forWire(ctx context.Context, e *entityPkg.Entity, outg
 // contract is "hidden values never reach the client, regardless of shape."
 // Pass incoming edges (nil to omit) so `direction: incoming` list columns can
 // resolve their source entities under the relation's inverse key.
-func (s entitySerializer) forWireRelated(ctx context.Context, e *entityPkg.Entity, outgoing, incoming []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) v1.Entity {
-	result := s.toV1(ctx, e, outgoing, incoming, meta, plural)
+//
+// visibleNeighbors gates the neighbor IDs (both outgoing targets and incoming
+// sources) written into the relations map so a hidden neighbor's ID never
+// leaks onto the wire (RR-HJV8CP). The list handler computes it once per page
+// via visibleRelationIDs (batched by type — no per-id gate calls) and
+// threads it here. Pass nil to disable filtering when the caller already
+// serializes only gated edges (e.g. the search/include shapes pass nil
+// relations anyway).
+func (s entitySerializer) forWireRelated(ctx context.Context, e *entityPkg.Entity, outgoing, incoming []*entityPkg.Relation, visibleNeighbors map[string]bool, meta *metamodel.Metamodel, plural string) v1.Entity {
+	result := s.toV1(ctx, e, outgoing, incoming, visibleNeighbors, meta, plural)
 	s.affordances.stripHiddenProperties(ctx, e, &result)
 	return result
 }

--- a/internal/dataentry/entityserializer.go
+++ b/internal/dataentry/entityserializer.go
@@ -24,7 +24,14 @@ type entitySerializer struct {
 // toV1 builds the base v1.Entity. meta is the request's metamodel snapshot;
 // outgoing is the entity's outgoing relations, already loaded by the caller
 // (nil omits the relations map — the former includeRelations=false shape).
-func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) v1.Entity {
+// incoming is the entity's incoming relations; when non-nil each incoming
+// edge is added to the relations map under its relation's INVERSE key
+// (inverseRelationKey), so an incoming list column has a distinct lookup key
+// that never collides with the same relation used outgoing. The SPA computes
+// the identical key from the column's relation + the metamodel inverse — see
+// MECHANISM.md. Loading incoming edges is the caller's job; this stays a pure
+// transform.
+func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoing, incoming []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) v1.Entity {
 	out := v1.Entity{
 		ID:         e.ID,
 		Type:       e.Type,
@@ -49,10 +56,22 @@ func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoin
 		}
 	}
 
-	if outgoing != nil {
+	if outgoing != nil || incoming != nil {
 		out.Relations = make(map[string][]string)
 		for _, edge := range outgoing {
 			out.Relations[edge.Type] = append(out.Relations[edge.Type], edge.To)
+		}
+		// Incoming edges are keyed by the relation's inverse name so an
+		// `direction: incoming` column looks them up without colliding with
+		// outgoing edges of the same relation. edge.From is the source
+		// entity ID (resolved to a title client-side via ?include=*).
+		for _, edge := range incoming {
+			relDef, ok := meta.Relations[edge.Type]
+			if !ok {
+				continue
+			}
+			key := inverseRelationKey(edge.Type, relDef)
+			out.Relations[key] = append(out.Relations[key], edge.From)
 		}
 	}
 
@@ -64,7 +83,10 @@ func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoin
 // maps. Use forWireRelated for entities that appear as list rows or under
 // `included` (no affordance maps, but still strip).
 func (s entitySerializer) forWire(ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) v1.Entity {
-	result := s.toV1(ctx, e, outgoing, meta, plural)
+	// Per-entity responses carry outgoing edges only; incoming edges reach the
+	// SPA via the dedicated /relations endpoint, not the top-level relations
+	// map. Incoming list columns are served by forWireRelated (list rows).
+	result := s.toV1(ctx, e, outgoing, nil, meta, plural)
 	s.affordances.stripHiddenProperties(ctx, e, &result)
 	s.affordances.attachEntityAffordances(ctx, e, &result)
 	return result
@@ -75,8 +97,10 @@ func (s entitySerializer) forWire(ctx context.Context, e *entityPkg.Entity, outg
 // properties but omits the `_fields` / `_relations` maps (those ride on
 // per-entity responses only). Hidden-field stripping still applies: the wire
 // contract is "hidden values never reach the client, regardless of shape."
-func (s entitySerializer) forWireRelated(ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) v1.Entity {
-	result := s.toV1(ctx, e, outgoing, meta, plural)
+// Pass incoming edges (nil to omit) so `direction: incoming` list columns can
+// resolve their source entities under the relation's inverse key.
+func (s entitySerializer) forWireRelated(ctx context.Context, e *entityPkg.Entity, outgoing, incoming []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) v1.Entity {
+	result := s.toV1(ctx, e, outgoing, incoming, meta, plural)
 	s.affordances.stripHiddenProperties(ctx, e, &result)
 	return result
 }

--- a/internal/dataentry/handlers_attachment_test.go
+++ b/internal/dataentry/handlers_attachment_test.go
@@ -210,7 +210,7 @@ func TestAttachment_MetadataOnEntityGET(t *testing.T) {
 
 	// A list-row serialization must NOT carry the map (closed-world: it
 	// rides on per-entity responses only).
-	row := app.serializer.forWireRelated(context.Background(), mustGet(t, app, "TKT-001"), nil, nil, app.Meta(), "tickets")
+	row := app.serializer.forWireRelated(context.Background(), mustGet(t, app, "TKT-001"), nil, nil, nil, app.Meta(), "tickets")
 	if row.Attachments != nil {
 		t.Errorf("_attachments must be nil on list-row serialization; got %+v", *row.Attachments)
 	}

--- a/internal/dataentry/handlers_attachment_test.go
+++ b/internal/dataentry/handlers_attachment_test.go
@@ -210,7 +210,7 @@ func TestAttachment_MetadataOnEntityGET(t *testing.T) {
 
 	// A list-row serialization must NOT carry the map (closed-world: it
 	// rides on per-entity responses only).
-	row := app.serializer.forWireRelated(context.Background(), mustGet(t, app, "TKT-001"), nil, app.Meta(), "tickets")
+	row := app.serializer.forWireRelated(context.Background(), mustGet(t, app, "TKT-001"), nil, nil, app.Meta(), "tickets")
 	if row.Attachments != nil {
 		t.Errorf("_attachments must be nil on list-row serialization; got %+v", *row.Attachments)
 	}

--- a/internal/dataentry/inaccessible_test.go
+++ b/internal/dataentry/inaccessible_test.go
@@ -32,7 +32,7 @@ func lockedTicket(inaccessibleFields ...string) *entity.Entity {
 func TestEntityToV1_PropagatesInaccessible(t *testing.T) {
 	app := newTestAppV1(t)
 	e := lockedTicket("title", "status")
-	v1 := app.serializer.toV1(t.Context(), e, nil, nil, app.Meta(), "tickets")
+	v1 := app.serializer.toV1(t.Context(), e, nil, nil, nil, app.Meta(), "tickets")
 
 	if v1.ID != "TKT-LOCKED" {
 		t.Errorf("ID = %q, want TKT-LOCKED", v1.ID)
@@ -110,7 +110,7 @@ func TestEntityToV1_OmitsInaccessibleWhenEmpty(t *testing.T) {
 		},
 	}
 
-	v1 := app.serializer.toV1(t.Context(), e, nil, nil, app.Meta(), "tickets")
+	v1 := app.serializer.toV1(t.Context(), e, nil, nil, nil, app.Meta(), "tickets")
 	if len(v1.Inaccessible) != 0 {
 		t.Errorf("Inaccessible non-empty for normal entity: %v", v1.Inaccessible)
 	}

--- a/internal/dataentry/inaccessible_test.go
+++ b/internal/dataentry/inaccessible_test.go
@@ -32,7 +32,7 @@ func lockedTicket(inaccessibleFields ...string) *entity.Entity {
 func TestEntityToV1_PropagatesInaccessible(t *testing.T) {
 	app := newTestAppV1(t)
 	e := lockedTicket("title", "status")
-	v1 := app.serializer.toV1(t.Context(), e, nil, app.Meta(), "tickets")
+	v1 := app.serializer.toV1(t.Context(), e, nil, nil, app.Meta(), "tickets")
 
 	if v1.ID != "TKT-LOCKED" {
 		t.Errorf("ID = %q, want TKT-LOCKED", v1.ID)
@@ -110,7 +110,7 @@ func TestEntityToV1_OmitsInaccessibleWhenEmpty(t *testing.T) {
 		},
 	}
 
-	v1 := app.serializer.toV1(t.Context(), e, nil, app.Meta(), "tickets")
+	v1 := app.serializer.toV1(t.Context(), e, nil, nil, app.Meta(), "tickets")
 	if len(v1.Inaccessible) != 0 {
 		t.Errorf("Inaccessible non-empty for normal entity: %v", v1.Inaccessible)
 	}

--- a/internal/dataentry/list_incoming_relation_test.go
+++ b/internal/dataentry/list_incoming_relation_test.go
@@ -1,0 +1,259 @@
+package dataentry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/openapi"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// incomingRelMeta builds a metamodel where a persoon points at a taak via
+// `verantwoordelijk_voor`, which declares an inverse `verantwoordelijken`.
+// This is the fixture for the TKT-ODHV2D incoming-relation-column mechanism.
+func incomingRelMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"persoon": {
+				Label:    "Persoon",
+				Plural:   "persoons",
+				IDPrefix: "PERS",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
+			},
+			"taak": {
+				Label:    "Taak",
+				Plural:   "taaks",
+				IDPrefix: "TASK",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
+			},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"verantwoordelijk_voor": {
+				Label:   "verantwoordelijk voor",
+				From:    []string{"persoon"},
+				To:      []string{"taak"},
+				Inverse: &metamodel.InverseDef{ID: "verantwoordelijken"},
+			},
+		},
+	}
+}
+
+// incomingRelConfig defines a taak list with an incoming relation column and a
+// persoon list with an outgoing relation column, so both directions are tested.
+func incomingRelConfig() *Config {
+	return &Config{
+		App: AppConfig{Name: "Incoming Rel Test"},
+		Lists: map[string]List{
+			"taaks": {
+				EntityType: "taak",
+				Title:      "Taken",
+				Columns: []ListColumn{
+					{Property: "title", Label: "Title"},
+					{Relation: "verantwoordelijk_voor", Direction: "incoming", Label: "Verantwoordelijken"},
+				},
+			},
+			"persoons": {
+				EntityType: "persoon",
+				Title:      "Personen",
+				Columns: []ListColumn{
+					{Property: "title", Label: "Title"},
+					{Relation: "verantwoordelijk_voor", Label: "Taken"},
+				},
+			},
+		},
+	}
+}
+
+// newIncomingRelApp wires an App over incomingRelMeta with the given entities
+// and relations seeded into the store.
+func newIncomingRelApp(t *testing.T, entities []*entity.Entity, relations []*entity.Relation) *App {
+	t.Helper()
+	meta := incomingRelMeta()
+	cfg := incomingRelConfig()
+
+	fs := storage.NewMemFS()
+	ctx := &project.Context{Root: "/project", CacheDir: "/project/.rela"}
+	if err := fs.MkdirAll(ctx.CacheDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	svc := appbuildtest.New(meta, appbuildtest.WithFS(fs, ctx))
+	f := &fixture{entities: entities, relations: relations}
+	seedFromFixture(svc.Store(), f)
+
+	app := &App{fieldResolver: NopFieldVerdictResolver{}}
+	rebindApp(app, fs, ctx, svc)
+	app.state.Store(&AppState{
+		Cfg:        cfg,
+		Meta:       meta,
+		Palette:    ResolvePalette(cfg.Palette, nil),
+		OpenAPIGen: openapi.New(meta, openapi.Config{Title: cfg.App.Name}),
+	})
+	return app
+}
+
+// listWithIncludesResponse mirrors the anonymous response shape emitted by
+// handleV1ListEntities when includes are requested.
+type listWithIncludesResponse struct {
+	Data     []v1.Entity          `json:"data"`
+	Meta     v1.ListMeta          `json:"meta"`
+	Included map[string]v1.Entity `json:"included"`
+}
+
+func decodeListWithIncludes(t *testing.T, w *httptest.ResponseRecorder) listWithIncludesResponse {
+	t.Helper()
+	var resp listWithIncludesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode list response: %v\nbody: %s", err, w.Body.String())
+	}
+	return resp
+}
+
+func findRow(t *testing.T, rows []v1.Entity, id string) v1.Entity {
+	t.Helper()
+	for _, r := range rows {
+		if r.ID == id {
+			return r
+		}
+	}
+	t.Fatalf("row %q not found in %d rows", id, len(rows))
+	return v1.Entity{}
+}
+
+// TestListIncomingRelationColumn verifies the shared wire mechanism from
+// TKT-ODHV2D: incoming edges reach the list wire under the relation's inverse
+// key, outgoing edges are unaffected, and multiple sources are all present.
+func TestListIncomingRelationColumn(t *testing.T) {
+	const (
+		taakID   = "TASK-VKZ2"
+		persAID  = "PERS-JV"
+		persBID  = "PERS-AB"
+		otherTID = "TASK-OTHER"
+	)
+
+	entities := []*entity.Entity{
+		{ID: taakID, Type: "taak", Properties: map[string]interface{}{"title": "Ship it"}},
+		{ID: otherTID, Type: "taak", Properties: map[string]interface{}{"title": "Other"}},
+		{ID: persAID, Type: "persoon", Properties: map[string]interface{}{"title": "Jeroen Vloothuis"}},
+		{ID: persBID, Type: "persoon", Properties: map[string]interface{}{"title": "Alice B"}},
+	}
+
+	t.Run("single incoming source keyed under inverse", func(t *testing.T) {
+		rels := []*entity.Relation{
+			entity.NewRelation(persAID, "verantwoordelijk_voor", taakID),
+		}
+		app := newIncomingRelApp(t, entities, rels)
+
+		w := doRequest(t, app, http.MethodGet, "/api/v1/taaks?include=*")
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+		}
+		resp := decodeListWithIncludes(t, w)
+
+		row := findRow(t, resp.Data, taakID)
+		// Incoming edge lives under the inverse key, NOT the relation type.
+		got := row.Relations["verantwoordelijken"]
+		if len(got) != 1 || got[0] != persAID {
+			t.Fatalf("row.Relations[verantwoordelijken] = %v, want [%s]", got, persAID)
+		}
+		if _, collides := row.Relations["verantwoordelijk_voor"]; collides {
+			t.Fatalf("outgoing key verantwoordelijk_voor must not appear on a taak row: %v", row.Relations)
+		}
+		// The include map carries the source persoon so the SPA can resolve
+		// the ID to a title.
+		inc, ok := resp.Included[persAID]
+		if !ok {
+			t.Fatalf("included map missing source %s; included=%v", persAID, resp.Included)
+		}
+		if inc.Title != "Jeroen Vloothuis" {
+			t.Fatalf("included[%s]._title = %q, want %q", persAID, inc.Title, "Jeroen Vloothuis")
+		}
+	})
+
+	t.Run("multiple incoming sources both present", func(t *testing.T) {
+		rels := []*entity.Relation{
+			entity.NewRelation(persAID, "verantwoordelijk_voor", taakID),
+			entity.NewRelation(persBID, "verantwoordelijk_voor", taakID),
+		}
+		app := newIncomingRelApp(t, entities, rels)
+
+		w := doRequest(t, app, http.MethodGet, "/api/v1/taaks?include=*")
+		resp := decodeListWithIncludes(t, w)
+		row := findRow(t, resp.Data, taakID)
+
+		got := row.Relations["verantwoordelijken"]
+		if len(got) != 2 {
+			t.Fatalf("want 2 incoming sources, got %v", got)
+		}
+		seen := map[string]bool{}
+		for _, id := range got {
+			seen[id] = true
+		}
+		if !seen[persAID] || !seen[persBID] {
+			t.Fatalf("incoming sources = %v, want both %s and %s", got, persAID, persBID)
+		}
+	})
+
+	t.Run("outgoing column unchanged for the source entity", func(t *testing.T) {
+		rels := []*entity.Relation{
+			entity.NewRelation(persAID, "verantwoordelijk_voor", taakID),
+		}
+		app := newIncomingRelApp(t, entities, rels)
+
+		w := doRequest(t, app, http.MethodGet, "/api/v1/persoons?include=*")
+		resp := decodeListWithIncludes(t, w)
+		row := findRow(t, resp.Data, persAID)
+
+		// Outgoing edge keyed under the relation type, exactly as before.
+		got := row.Relations["verantwoordelijk_voor"]
+		if len(got) != 1 || got[0] != taakID {
+			t.Fatalf("row.Relations[verantwoordelijk_voor] = %v, want [%s]", got, taakID)
+		}
+		if _, leaked := row.Relations["verantwoordelijken"]; leaked {
+			t.Fatalf("inverse key must not appear on a persoon row: %v", row.Relations)
+		}
+	})
+}
+
+// TestListOutgoingRelationsByteIdentical is the regression guard: a taak row
+// with NO incoming edges must serialize its relations map exactly as before
+// the incoming-edge change (i.e. an absent/empty relations map, never a
+// spurious inverse key).
+func TestListOutgoingRelationsByteIdentical(t *testing.T) {
+	const persID = "PERS-JV"
+	entities := []*entity.Entity{
+		{ID: persID, Type: "persoon", Properties: map[string]interface{}{"title": "Jeroen"}},
+	}
+	// One outgoing edge from the persoon to a taak.
+	taak := &entity.Entity{ID: "TASK-1", Type: "taak", Properties: map[string]interface{}{"title": "T"}}
+	entities = append(entities, taak)
+	rels := []*entity.Relation{entity.NewRelation(persID, "verantwoordelijk_voor", "TASK-1")}
+
+	app := newIncomingRelApp(t, entities, rels)
+	w := doRequest(t, app, http.MethodGet, "/api/v1/persoons?include=*")
+	resp := decodeListWithIncludes(t, w)
+	row := findRow(t, resp.Data, persID)
+
+	// The persoon row's relations map must contain ONLY the outgoing key.
+	if len(row.Relations) != 1 {
+		t.Fatalf("persoon row relations should have exactly the outgoing key, got %v", row.Relations)
+	}
+	got, err := json.Marshal(row.Relations)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"verantwoordelijk_voor":["TASK-1"]}`
+	if string(got) != want {
+		t.Fatalf("outgoing relations map = %s, want %s", got, want)
+	}
+}

--- a/internal/dataentry/list_incoming_relation_test.go
+++ b/internal/dataentry/list_incoming_relation_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
 	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/openapi"

--- a/internal/dataentry/relation_visibility.go
+++ b/internal/dataentry/relation_visibility.go
@@ -1,0 +1,83 @@
+package dataentry
+
+import (
+	"context"
+
+	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// neighborIDsOf collects the DISTINCT neighbor entity IDs referenced by a
+// page's relation edges: the target (edge.To) of every outgoing edge and the
+// source (edge.From) of every incoming edge. Empty IDs are skipped. This is the
+// input side of the neighbor-visibility gate — a row-agnostic set for the whole
+// page so the gate probe can be batched.
+func neighborIDsOf(outgoing, incoming []*entityPkg.Relation) []string {
+	seen := make(map[string]struct{}, len(outgoing)+len(incoming))
+	var ids []string
+	add := func(id string) {
+		if id == "" {
+			return
+		}
+		if _, dup := seen[id]; dup {
+			return
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	for _, edge := range outgoing {
+		add(edge.To)
+	}
+	for _, edge := range incoming {
+		add(edge.From)
+	}
+	return ids
+}
+
+// visibleRelationIDs computes the set of neighbor entity IDs (out of the given
+// candidate IDs) that the request principal may read. It is the ACL gate for
+// neighbor IDs on the list wire (RR-HJV8CP): a neighbor's ID may appear in a
+// row's `relations` map ONLY if its entity is visible to the caller, so
+// `relations` and the `included` map (already filtered by filterVisibleIncludes)
+// can never disagree — closing the leak where a hidden incoming source OR
+// outgoing target shipped its raw ID in the cell while being absent from
+// `included`.
+//
+// Reuse contract (TKT-5U7QBR, TKT-NC3D08 inherit this):
+//
+//   - Pass ALL neighbor IDs for the whole page at once (both directions, every
+//     row — see neighborIDsOf). The visibility probe is batched by entity type
+//     via visibleReader.filterVisible: ONE PermitsReadMany per distinct neighbor
+//     type for the entire page, NOT one gate call per id (RR-FRK1). Do NOT call
+//     this per-row or per-id inside a loop; collect the page's IDs first.
+//   - An entity's visibility is direction-independent, so one pass covers both
+//     outgoing targets and incoming sources.
+//   - The returned map contains only IDs that resolved to a loadable, readable
+//     entity. Missing IDs are treated as not-visible (fail-closed) — the
+//     serializer drops them from `relations`, matching how filterVisibleIncludes
+//     drops unloadable candidates from `included`.
+//
+// The returned map is then handed to the serializer (forWireRelated's
+// visibleNeighbors param); passing nil there disables filtering (the search /
+// per-entity / include shapes that already emit nil relations stay untouched —
+// RR-QO01XY).
+//
+// A free function (not an App method) taking the two read seams it needs, so it
+// stays off App's receiver (keeps App under its plimsoll method cap) while the
+// reuse contract above is unchanged.
+func visibleRelationIDs(
+	ctx context.Context, reader entityReader, visible visibleReader, neighborIDs []string,
+) map[string]bool {
+	candidates := make([]*entityPkg.Entity, 0, len(neighborIDs))
+	for _, id := range neighborIDs {
+		if e, found := reader.getEntity(ctx, id); found {
+			candidates = append(candidates, e)
+		}
+	}
+
+	vis := visible.filterVisible(ctx, candidates)
+	out := make(map[string]bool, len(vis))
+	for _, e := range vis {
+		out[e.ID] = true
+	}
+	return out
+}

--- a/internal/dataentry/relations_direction.go
+++ b/internal/dataentry/relations_direction.go
@@ -56,6 +56,23 @@ func resolveDirection(meta *metamodel.Metamodel, bodyKey string) (canonical stri
 	return owner, true, true
 }
 
+// inverseRelationKey returns the wire key under which INCOMING edges of a
+// relation type are serialized. Incoming edges are keyed by the relation's
+// inverse name so they never collide with the same relation used outgoing (a
+// row can carry both `implements` outgoing targets and `implements_inverse`
+// incoming sources). When the metamodel declares an explicit inverse
+// (`relDef.Inverse.ID`), that name is used; otherwise the synthetic
+// `<type>_inverse` fallback applies. This is the single source of truth for
+// the key — the per-entity relations handler (handleV1EntityRelations), the
+// list-row serializer (entitySerializer.toV1), and the SPA's
+// getFormattedCellValue must all agree on it. See MECHANISM.md.
+func inverseRelationKey(relType string, relDef metamodel.RelationDef) string {
+	if relDef.Inverse != nil && relDef.Inverse.ID != "" {
+		return relDef.Inverse.ID
+	}
+	return relType + "_inverse"
+}
+
 // edgeEndpoints resolves the (from, to) endpoints of an edge written
 // against `entityID`, given a peer ID and a direction flag. Centralizes
 // the source/target flip so callers don't repeat it inline.

--- a/tickets/entities/features/FEAT-BL2E2X.md
+++ b/tickets/entities/features/FEAT-BL2E2X.md
@@ -1,0 +1,35 @@
+---
+id: FEAT-BL2E2X
+type: feature
+title: Relation fields on kanban cards
+summary: Allow kanban card fields to render relation targets (incoming or outgoing), not just properties
+description: Kanban card fields currently support only entity properties (KanbanCard.Fields is []ViewSectionField, which carries only Property). Add support for rendering a relation target on a card, in either direction, so boards can show e.g. the responsible person per task.
+priority: medium
+status: proposed
+---
+
+## Use case
+
+A task kanban board wants each card to show the responsible person, where the
+edge runs `persoon --verantwoordelijk_voor--> taak` (i.e. incoming to the taak).
+Today card fields can only show scalar properties of the taak, so there is no
+way to surface the assignee on the card at all — incoming or outgoing.
+
+## Solution
+
+Introduce a dedicated `KanbanCardField` type (`Property`, `Relation`,
+`Direction`, `Label`) instead of widening the shared `ViewSectionField` (which
+is reused by form relations, side panels, and view sections). Render
+`Relation`-typed fields via the same direction-aware resolution used by
+list/section relation columns, and plumb the values to the SPA card renderer
+(`KanbanView.vue` `getCardFieldValue`), including the `?include=*` fetch the
+board does not currently request.
+
+Backward compatible: existing `- property: X` card fields parse and render
+unchanged.
+
+## Relation to existing work
+
+Depends on the mechanism chosen for restoring incoming relation columns in lists
+(the ID+`included` client-resolution path) so the two read surfaces share one
+approach rather than inventing a card-specific title map.

--- a/tickets/entities/tickets/TKT-5U7QBR.md
+++ b/tickets/entities/tickets/TKT-5U7QBR.md
@@ -1,0 +1,58 @@
+---
+id: TKT-5U7QBR
+type: ticket
+title: Restore relation filter controls on the v1 list pipeline + add direction:incoming
+kind: refactor
+priority: medium
+effort: m
+tags:
+    - regression
+status: ready
+---
+
+## Problem
+
+A `filter_control` on a relation returns zero rows. The incoming spec attributes
+this to `filterByRelation` hard-coding outgoing — but the reality is worse:
+**relation filtering is entirely absent from the live pipeline.**
+
+## Why (verified against develop tip)
+
+`FEAT-024` added `filterByRelation` and `resolveRelationFilterValues`
+(`helpers.go:707,722`) and wired them into the **old `handleList`** (added in
+#214). `handleList` was **removed in the Vue SPA migration `ebbcb5b6` (#230)**,
+orphaning both helpers — they now have **no non-test callers** (only
+`helpers_test.go`). The live path is:
+
+- SPA: relation filter control renders as a **plain text input** (`FilterBar.vue:44`, "use text input for now") and sends `filter[<relation>]=value` (`filters.ts:161`).
+- Server: `applyV1Filters` (`api_v1.go:1841`) filters **only** on `e.Properties[property]`. A `filter[verantwoordelijk_voor]` key reads `e.Properties["verantwoordelijk_voor"]`, finds nothing, and (eq/non-empty) returns zero rows. There is **no relation branch, outgoing or incoming.**
+
+`resolveScope` → `scopedSortedEntities` → `applyV1Filters` (scope nav) has the
+same gap.
+
+## Scope
+
+IN: relation filtering works on the live v1 pipeline for both outgoing and
+`direction: incoming`; add `Direction` to `FilterControl`; wire it into
+`applyV1Filters`/`scopedSortedEntities` so lists and scope nav agree. OUT:
+**populated relation-filter dropdown** UX (the SPA has none today —
+`FilterBar.vue` uses a text input). File separately if the "dropdown of all
+persoons" UX is wanted. `resolveRelationFilterValues` belongs to that follow-up.
+
+## Recommended approach
+
+1. `dataentryconfig`: add `Direction Direction` to `FilterControl` (default outgoing), matching `ListColumn`.
+2. Decide the wiring seam: `applyV1Filters` is a free function without ctx/svc. Either promote relation-filter handling into `scopedSortedEntities` (which has `a`/ctx) as a post-`applyV1Filters` pass, or give the relation branch access to `svc`. Reuse the direction-aware `resolveRelationColumnValues` + title match (retire the dead `filterByRelation`, or revive and call it with a direction param).
+3. Load-time validation: warn when `direction: incoming` references a relation whose `to:` excludes the list's `entity_type`.
+
+## Acceptance criteria
+
+- `filter_control {relation: verantwoordelijk_voor, direction: incoming}`; `filter[verantwoordelijk_voor]=Jeroen Vloothuis` filters the taak list to tasks whose incoming source titles to Jeroen.
+- Outgoing relation filter (default direction) also works (currently returns zero).
+- Scope prev/next navigation over a relation-filtered list matches the list ordering.
+
+## Test plan
+
+- Handler test: `filter[<rel>]` with incoming direction returns only matching rows; outgoing default likewise.
+- `_position` test: scope over a relation-filtered list yields consistent prev/next/total.
+- Load-validation test for the incoming/`to`-mismatch warning.

--- a/tickets/entities/tickets/TKT-NC3D08.md
+++ b/tickets/entities/tickets/TKT-NC3D08.md
@@ -1,0 +1,49 @@
+---
+id: TKT-NC3D08
+type: ticket
+title: Support relation fields (incoming/outgoing) on kanban cards
+kind: enhancement
+priority: medium
+effort: m
+status: ready
+---
+
+## Problem
+
+There is no way to render a relation target on a kanban card — incoming or
+outgoing. `KanbanCard.Fields` is `[]ViewSectionField` (`config.go:292`), and
+`ViewSectionField` (`config.go:436`) carries only `Property`. The SPA card
+renderer `getCardFieldValue` (`KanbanView.vue:256`) reads
+`entity.properties[field.property]` only.
+
+Unlike gaps 1 and 2, this is genuinely net-new — not a migration regression.
+
+## Scope
+
+IN: `card.fields` may reference a relation with a direction; the card renders
+the target titles. OUT: kanban relation **filter controls** (shares the gap-2
+fix; KanbanView option population at `KanbanView.vue:205` is property-only and
+would ride on TKT-5U7QBR).
+
+## Recommended approach
+
+1. Introduce a dedicated `KanbanCardField` type (`Property`, `Relation`, `Direction`, `Label`) rather than widening the shared `ViewSectionField` (reused by form relations, side panels, view sections — widening leaks card semantics into all of them). Change `KanbanCard.Fields` to `[]KanbanCardField`. Backward compatible: `- property: X` still parses.
+2. Reuse the **same wire mechanism chosen in TKT-ODHV2D** (ID + `included` client resolution), not a card-specific title map. KanbanView currently requests **no** `?include`, so add `include=*` when any card field is a relation.
+3. SPA: `getCardFieldValue`/`getCardFieldLabel` become relation- and direction-aware.
+
+## Dependencies
+
+Depends on TKT-ODHV2D landing the shared incoming-relation wire mechanism, so
+lists and cards share one approach.
+
+## Acceptance criteria
+
+- `card.fields: [{property: status}, {relation: verantwoordelijk_voor, direction: incoming}]` → card shows the status label and the responsible person's name.
+- Outgoing relation card field renders its target(s).
+- Existing property-only card configs render unchanged (schema loads, no breakage).
+
+## Test plan
+
+- Config parse test: old `- property: X` fields and new relation fields both unmarshal.
+- SPA unit test on `getCardFieldValue` for incoming + outgoing relation fields.
+- Board render test that a relation card field shows resolved titles via `included`.

--- a/tickets/entities/tickets/TKT-ODHV2D.md
+++ b/tickets/entities/tickets/TKT-ODHV2D.md
@@ -1,0 +1,66 @@
+---
+id: TKT-ODHV2D
+type: ticket
+title: Restore incoming/relation columns in v1 list handler (regressed in Vue SPA migration)
+kind: refactor
+priority: medium
+effort: s
+tags:
+    - regression
+status: ready
+---
+
+## Problem
+
+A list column `- relation: <rel>, direction: incoming` renders empty even when
+incoming edges exist. More broadly, relation columns on lists are resolved
+**client-side** from the wire `relations` map, which only carries **outgoing**
+target IDs.
+
+## Why this is a regression, not a new gap
+
+`FEAT-tr9f` / `FEAT-0c9l` shipped `direction: incoming` for list columns by
+adding `Direction` to `ListColumn` and making `resolveRelationColumnValues()`
+incoming-aware. That code still exists (`dataentryconfig/config.go:208`,
+`dataentry/helpers.go:679`). But the feature was wired into the **old
+server-rendered `handleList`**, which was **removed in the Vue SPA migration
+`ebbcb5b6` (#230)**. The current list path — `handleV1ListEntities`
+(`api_v1.go:291`) — serializes rows via `forWireRelated(...,
+a.reader.outgoingRelations(...))` (`api_v1.go:321`) and **never calls
+`resolveRelationColumnValues`**. Only `sections.go:257` (table sections) still
+does. So incoming list columns silently regressed.
+
+## Scope
+
+IN: incoming relation columns render correctly in `handleV1ListEntities` + SPA
+`EntityList.vue`. OUT: filter controls (separate ticket), kanban cards (separate
+ticket).
+
+## Recommended approach (verified against develop tip)
+
+Do **not** add a new `RelationColumns map[string][]string` title map (the
+incoming spec's suggestion). That would fork the rendering path. The existing
+mechanism already does client-side ID→title resolution:
+
+- Wire: `v1.Entity.Relations[relType] = [outgoing target IDs]` (`entityserializer.go:52`).
+- SPA: `?include=*` fetches peers; `getFormattedCellValue` (`EntityList.vue:518`) maps IDs → titles via the `included` map.
+
+Key fact: `resolveV1Includes` **already** collects incoming source entities into
+`included` when `include == "*"` (`api_v1.go:1781`). The only missing link is
+that the serialized `relations` map records outgoing `edge.To` only. Fix:
+
+1. For list rows, populate incoming edges into the serialized `relations` map keyed by the inverse relation name (mirroring `handleV1EntityRelations:1016`), so an incoming column has a lookup key without colliding with the same relation used outgoing.
+2. SPA: `EntityList.vue` — `hasRelationColumns` and `getFormattedCellValue` become direction-aware (look up the incoming key when `column.direction === 'incoming'`); the `?include=*` fetch already covers sources.
+
+## Acceptance criteria
+
+- `PERS-JV --verantwoordelijk_voor--> TASK-VKZ2`; taak list column `{relation: verantwoordelijk_voor, direction: incoming}` → cell shows "Jeroen Vloothuis".
+- Same column with `direction: outgoing` → empty cell.
+- Two persoons pointing at one taak → cell shows both, comma-separated.
+- Existing outgoing relation columns render byte-identically (no regression).
+
+## Test plan
+
+- Go handler test: list response for a taak carries the incoming source under the expected key; outgoing unaffected.
+- SPA unit test on `getFormattedCellValue` for incoming direction.
+- Regression assertion that outgoing columns are unchanged.

--- a/tickets/relations/FEAT-BL2E2X--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-BL2E2X--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-BL2E2X
+relation: requires
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-5U7QBR--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-5U7QBR--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5U7QBR
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-5U7QBR--implements--FEAT-024.md
+++ b/tickets/relations/TKT-5U7QBR--implements--FEAT-024.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5U7QBR
+relation: implements
+to: FEAT-024
+---

--- a/tickets/relations/TKT-NC3D08--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-NC3D08--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NC3D08
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-NC3D08--implements--FEAT-BL2E2X.md
+++ b/tickets/relations/TKT-NC3D08--implements--FEAT-BL2E2X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NC3D08
+relation: implements
+to: FEAT-BL2E2X
+---

--- a/tickets/relations/TKT-ODHV2D--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-ODHV2D--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ODHV2D
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-ODHV2D--implements--FEAT-tr9f.md
+++ b/tickets/relations/TKT-ODHV2D--implements--FEAT-tr9f.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ODHV2D
+relation: implements
+to: FEAT-tr9f
+---


### PR DESCRIPTION
## What

Restores **incoming relation columns** in the data-entry v1 list handler, and closes an ACL leak in how list rows serialize related-entity IDs.

A list column `- relation: <rel>, direction: incoming` now renders the entities that point *to* each row (e.g. the person responsible for a task, where the edge runs `persoon --verantwoordelijk_voor--> taak`). Implements **FEAT-tr9f**.

## Why this is a regression fix

`direction: incoming` for list columns shipped in FEAT-tr9f/FEAT-0c9l, wired into the old server-rendered `handleList`. That handler was **removed in the Vue SPA migration (#230)**; the current `handleV1ListEntities` only serialized *outgoing* edges, so incoming columns silently rendered empty. The config field (`ListColumn.Direction`) and `resolveRelationColumnValues` still existed and were incoming-aware — only the list wire path had regressed. This reconnects it.

## How

- Incoming edges are serialized into `v1.Entity.Relations` under the relation's **inverse key** (`inverseRelationKey` — `relDef.Inverse.ID`, or `<relType>_inverse` fallback), value = source IDs. Outgoing edges stay keyed under the relation type. The SPA resolves IDs → titles via the existing `?include=*` `included` map (`EntityList.vue` `getFormattedCellValue`, keyed via `schemaStore.getInverseName`). No new wire field, no forked rendering path.

## Security: ACL neighbor gating (RR-HJV8CP)

Code review found — and this PR fixes — that the row `relations` map shipped neighbor IDs **without the read gate**, while `included` is gated. A hidden incoming source (or, pre-existing, outgoing target) leaked its raw ID into the rendered cell, contradicting the search-path invariant `RR-QO01XY`.

Fix: `visibleRelationIDs` (new `relation_visibility.go`) gates neighbor IDs through the existing batched `filterVisible` — **one `PermitsReadMany` per neighbor type per page**, not per-id (honors RR-FRK1). The serializer drops edges whose neighbor isn't visible, so `relations` and `included` always agree. This also closes the **pre-existing outgoing** leak. Pinned by `TestACLList_HiddenNeighborExcludedFromRelations` (verified to fail without the fix).

## Tests

- `TestListIncomingRelationColumn` — incoming source rendered; multiple sources comma-joined; no key collision with outgoing.
- `TestListOutgoingRelationsByteIdentical` — outgoing wire shape unchanged.
- `TestACLList_HiddenNeighborExcludedFromRelations` — hidden incoming source AND outgoing target excluded; visible neighbors kept.
- SPA: `EntityList.test.ts` — direction-aware cell resolution (incoming single / multiple / empty-when-only-outgoing).

`just ci` green: lint, arch-lint, plimsoll, tests, coverage (76.8%), docs.

## Merge order

**Merge this first.** TKT-NC3D08 (kanban relation cards) reuses this PR's server-side incoming serialization + ACL gate via the same list endpoint — its incoming path is guarded behind a contract test that activates once this lands. TKT-5U7QBR (relation filters) is independent but shares the neighbor-gating pattern.

Part of the incoming-relation trio: **TKT-ODHV2D** (this) · TKT-5U7QBR · TKT-NC3D08.
