### PR TITLE
feat(acl): rela acl audit linter for ACL misconfigurations (TKT-TS0J5K)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -89,6 +89,7 @@ components:
 
   # Infrastructure
   acl:              { in: internal/acl }
+  aclaudit:         { in: internal/aclaudit }
   affordances:      { in: internal/affordances }
   ai:               { in: internal/ai }
   audit:            { in: internal/audit }
@@ -198,6 +199,7 @@ deps:
   cli:
     mayDependOn:
       - acl
+      - aclaudit
       - ai
       - analysis
       - app
@@ -425,6 +427,9 @@ deps:
       - entity
       - principal
       - store
+  aclaudit:
+    mayDependOn:
+      - acl
   affordances:
     mayDependOn:
       - acl

--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -99,11 +99,11 @@ The audit is **advisory** — with no flag it prints findings and always
 exits zero. For CI, gate the exit code on a severity threshold with
 `--fail-on`:
 
-```console
-$ rela acl audit --fail-on=high     # non-zero if any critical/high finding
-$ rela acl audit --fail-on=medium   # also fail on medium
-$ rela acl audit --fail-on=any      # fail on any finding at all
-$ rela acl audit --exit-code        # alias for --fail-on=high
+```bash
+rela acl audit --fail-on=high     # non-zero if any critical/high finding
+rela acl audit --fail-on=medium   # also fail on medium
+rela acl audit --fail-on=any      # fail on any finding at all
+rela acl audit --exit-code        # alias for --fail-on=high
 ```
 
 A finding **below** the threshold never changes the exit code — so

--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -66,15 +66,16 @@ guidance with more context on the broader threat model.
 
 ## Auditing your policy with `rela acl audit`
 
-`acl.yaml` is easy to get subtly wrong in ways that don't fail boot: a
-typo'd entity type silently grants nothing, an un-gated membership
-relation is a self-promotion path, a write grant on the `everyone`
-role hands capabilities to anonymous callers. Boot-time validation
-(`Policy.Validate`) deliberately stays a narrow *structural* gate — it
-rejects malformed policies but does not hunt for these foot-guns.
+To keep your policy correct and hardened, run `rela acl audit` after
+every change to `acl.yaml`. It catches the mistakes that don't fail
+boot: a typo'd entity type that silently grants nothing, an un-gated
+membership relation that opens a self-promotion path, a write grant on
+the `everyone` role that hands capabilities to anonymous callers.
+Boot-time validation (`Policy.Validate`) deliberately stays a narrow
+*structural* gate — it rejects malformed policies but does not hunt for
+these foot-guns; the audit is the tool that does.
 
-`rela acl audit` is the on-demand linter that does. It reports
-severity-ranked findings across two tiers:
+The audit reports severity-ranked findings across two tiers:
 
 - **Pure-policy** — escalation foot-guns (un-gated membership relation
   or role-relation conferring a privileged role; a privileged
@@ -109,6 +110,12 @@ A finding **below** the threshold never changes the exit code — so
 `--fail-on=high` lets a medium "wildcard write" nudge through without
 breaking the build, while `--fail-on=any` is the strictest gate.
 Findings are always printed regardless of the threshold.
+
+**For a production deployment, gate CI on `--fail-on=any`** and keep
+the policy clean — the medium/low findings (wildcard sprawl, dead
+permissions, drift) are exactly the slow rot you want to catch before
+it hides a real hole. Loosen to `--fail-on=high` only if you have a
+deliberate, reviewed reason to tolerate the lower-severity findings.
 
 Use `-o json` for machine-readable output. A clean, well-gated policy
 reports no findings and exits zero.

--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -57,12 +57,53 @@ role_relations:
     requires_permission: member-of:create
 ```
 
-`Policy.Validate` emits an advisory warning at load when a non-default
-`membership_relation:` is configured without such a gate, but it does
-not block boot — don't rely on it to catch the mistake.
+The `rela acl audit` linter (below) flags an un-gated membership
+relation — default or configured — as a high-severity finding, so run
+it after editing `acl.yaml`.
 
 The companion section in `docs/security.md` carries the same
 guidance with more context on the broader threat model.
+
+## Auditing your policy with `rela acl audit`
+
+`acl.yaml` is easy to get subtly wrong in ways that don't fail boot: a
+typo'd entity type silently grants nothing, an un-gated membership
+relation is a self-promotion path, a write grant on the `everyone`
+role hands capabilities to anonymous callers. Boot-time validation
+(`Policy.Validate`) deliberately stays a narrow *structural* gate — it
+rejects malformed policies but does not hunt for these foot-guns.
+
+`rela acl audit` is the on-demand linter that does. It reports
+severity-ranked findings across two tiers:
+
+- **Pure-policy** — escalation foot-guns (un-gated membership relation
+  or role-relation conferring a privileged role; a privileged
+  `everyone` role) and dead/inert config (assignments or `confers`
+  naming an undeclared role, a `requires_permission` no role grants,
+  dead permissions, wildcard write sprawl).
+- **Metamodel cross-check** — grants, `membership_relation`,
+  `role_relations`, `inherit_roles_through`, `user_entity_type`, field,
+  and option references that the schema doesn't declare (silent drift).
+
+```console
+$ rela acl audit
+⚠ ACL audit: 2 finding(s)
+  [critical] role "everyone" ... grants write or permissions ...
+      fix: remove write/permission grants from the everyone role ...
+  [high] membership relation "member-of" confers group roles ... not gated ...
+      fix: add role_relations.member-of.requires_permission ...
+```
+
+The audit is **advisory** — it never blocks boot. For CI, pass
+`--exit-code` to fail the build when any **critical** or **high**
+finding is present:
+
+```console
+$ rela acl audit --exit-code   # exits non-zero on critical/high findings
+```
+
+Use `-o json` for machine-readable output. A clean, well-gated policy
+reports no findings and exits zero.
 
 ## Fail-loud on malformed `acl.yaml`
 

--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -94,13 +94,21 @@ $ rela acl audit
       fix: add role_relations.member-of.requires_permission ...
 ```
 
-The audit is **advisory** — it never blocks boot. For CI, pass
-`--exit-code` to fail the build when any **critical** or **high**
-finding is present:
+The audit is **advisory** — with no flag it prints findings and always
+exits zero. For CI, gate the exit code on a severity threshold with
+`--fail-on`:
 
 ```console
-$ rela acl audit --exit-code   # exits non-zero on critical/high findings
+$ rela acl audit --fail-on=high     # non-zero if any critical/high finding
+$ rela acl audit --fail-on=medium   # also fail on medium
+$ rela acl audit --fail-on=any      # fail on any finding at all
+$ rela acl audit --exit-code        # alias for --fail-on=high
 ```
+
+A finding **below** the threshold never changes the exit code — so
+`--fail-on=high` lets a medium "wildcard write" nudge through without
+breaking the build, while `--fail-on=any` is the strictest gate.
+Findings are always printed regardless of the threshold.
 
 Use `-o json` for machine-readable output. A clean, well-gated policy
 reports no findings and exits zero.

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -88,13 +88,21 @@ $ rela acl audit
       fix: add role_relations.member-of.requires_permission ...
 ```
 
-The audit is **advisory** — it never blocks boot. For CI, pass
-`--exit-code` to fail the build when any **critical** or **high**
-finding is present:
+The audit is **advisory** — with no flag it prints findings and always
+exits zero. For CI, gate the exit code on a severity threshold with
+`--fail-on`:
 
 ```console
-$ rela acl audit --exit-code   # exits non-zero on critical/high findings
+$ rela acl audit --fail-on=high     # non-zero if any critical/high finding
+$ rela acl audit --fail-on=medium   # also fail on medium
+$ rela acl audit --fail-on=any      # fail on any finding at all
+$ rela acl audit --exit-code        # alias for --fail-on=high
 ```
+
+A finding **below** the threshold never changes the exit code — so
+`--fail-on=high` lets a medium "wildcard write" nudge through without
+breaking the build, while `--fail-on=any` is the strictest gate.
+Findings are always printed regardless of the threshold.
 
 Use `-o json` for machine-readable output. A clean, well-gated policy
 reports no findings and exits zero.

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -93,11 +93,11 @@ The audit is **advisory** — with no flag it prints findings and always
 exits zero. For CI, gate the exit code on a severity threshold with
 `--fail-on`:
 
-```console
-$ rela acl audit --fail-on=high     # non-zero if any critical/high finding
-$ rela acl audit --fail-on=medium   # also fail on medium
-$ rela acl audit --fail-on=any      # fail on any finding at all
-$ rela acl audit --exit-code        # alias for --fail-on=high
+```bash
+rela acl audit --fail-on=high     # non-zero if any critical/high finding
+rela acl audit --fail-on=medium   # also fail on medium
+rela acl audit --fail-on=any      # fail on any finding at all
+rela acl audit --exit-code        # alias for --fail-on=high
 ```
 
 A finding **below** the threshold never changes the exit code — so

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -60,15 +60,16 @@ guidance with more context on the broader threat model.
 
 ## Auditing your policy with `rela acl audit`
 
-`acl.yaml` is easy to get subtly wrong in ways that don't fail boot: a
-typo'd entity type silently grants nothing, an un-gated membership
-relation is a self-promotion path, a write grant on the `everyone`
-role hands capabilities to anonymous callers. Boot-time validation
-(`Policy.Validate`) deliberately stays a narrow *structural* gate — it
-rejects malformed policies but does not hunt for these foot-guns.
+To keep your policy correct and hardened, run `rela acl audit` after
+every change to `acl.yaml`. It catches the mistakes that don't fail
+boot: a typo'd entity type that silently grants nothing, an un-gated
+membership relation that opens a self-promotion path, a write grant on
+the `everyone` role that hands capabilities to anonymous callers.
+Boot-time validation (`Policy.Validate`) deliberately stays a narrow
+*structural* gate — it rejects malformed policies but does not hunt for
+these foot-guns; the audit is the tool that does.
 
-`rela acl audit` is the on-demand linter that does. It reports
-severity-ranked findings across two tiers:
+The audit reports severity-ranked findings across two tiers:
 
 - **Pure-policy** — escalation foot-guns (un-gated membership relation
   or role-relation conferring a privileged role; a privileged
@@ -103,6 +104,12 @@ A finding **below** the threshold never changes the exit code — so
 `--fail-on=high` lets a medium "wildcard write" nudge through without
 breaking the build, while `--fail-on=any` is the strictest gate.
 Findings are always printed regardless of the threshold.
+
+**For a production deployment, gate CI on `--fail-on=any`** and keep
+the policy clean — the medium/low findings (wildcard sprawl, dead
+permissions, drift) are exactly the slow rot you want to catch before
+it hides a real hole. Loosen to `--fail-on=high` only if you have a
+deliberate, reviewed reason to tolerate the lower-severity findings.
 
 Use `-o json` for machine-readable output. A clean, well-gated policy
 reports no findings and exits zero.

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -51,12 +51,53 @@ role_relations:
     requires_permission: member-of:create
 ```
 
-`Policy.Validate` emits an advisory warning at load when a non-default
-`membership_relation:` is configured without such a gate, but it does
-not block boot — don't rely on it to catch the mistake.
+The `rela acl audit` linter (below) flags an un-gated membership
+relation — default or configured — as a high-severity finding, so run
+it after editing `acl.yaml`.
 
 The companion section in `docs/security.md` carries the same
 guidance with more context on the broader threat model.
+
+## Auditing your policy with `rela acl audit`
+
+`acl.yaml` is easy to get subtly wrong in ways that don't fail boot: a
+typo'd entity type silently grants nothing, an un-gated membership
+relation is a self-promotion path, a write grant on the `everyone`
+role hands capabilities to anonymous callers. Boot-time validation
+(`Policy.Validate`) deliberately stays a narrow *structural* gate — it
+rejects malformed policies but does not hunt for these foot-guns.
+
+`rela acl audit` is the on-demand linter that does. It reports
+severity-ranked findings across two tiers:
+
+- **Pure-policy** — escalation foot-guns (un-gated membership relation
+  or role-relation conferring a privileged role; a privileged
+  `everyone` role) and dead/inert config (assignments or `confers`
+  naming an undeclared role, a `requires_permission` no role grants,
+  dead permissions, wildcard write sprawl).
+- **Metamodel cross-check** — grants, `membership_relation`,
+  `role_relations`, `inherit_roles_through`, `user_entity_type`, field,
+  and option references that the schema doesn't declare (silent drift).
+
+```console
+$ rela acl audit
+⚠ ACL audit: 2 finding(s)
+  [critical] role "everyone" ... grants write or permissions ...
+      fix: remove write/permission grants from the everyone role ...
+  [high] membership relation "member-of" confers group roles ... not gated ...
+      fix: add role_relations.member-of.requires_permission ...
+```
+
+The audit is **advisory** — it never blocks boot. For CI, pass
+`--exit-code` to fail the build when any **critical** or **high**
+finding is present:
+
+```console
+$ rela acl audit --exit-code   # exits non-zero on critical/high findings
+```
+
+Use `-o json` for machine-readable output. A clean, well-gated policy
+reports no findings and exits zero.
 
 ## Fail-loud on malformed `acl.yaml`
 

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -73,23 +73,27 @@ type Policy struct {
 	InheritRolesThrough []string                   `yaml:"inherit_roles_through"`
 }
 
-// membershipRelation returns the effective relation type the resolver
+// EffectiveMembershipRelation returns the relation type the resolver
 // walks for group membership: a space-trimmed [Policy.MembershipRelation]
-// when set, or [defaultMembershipRelation] when blank/whitespace.
+// when set, or [defaultMembershipRelation] ("member-of") when
+// blank/whitespace.
 //
-// This is the single source of truth for the membership relation name
-// and the resolver MUST read through it rather than the raw field.
-// [NewDeclarative] does not run [Policy.Validate], and the resolver
-// passes the name straight into a [store.RelationQuery] where an empty
-// Type means "all relation types" — so a blank field reaching the walk
-// would silently follow *every* outgoing edge as if it were membership
-// (an over-grant). Collapsing blank to the default here, on every read,
-// closes that hole regardless of how the [Policy] was constructed.
+// This is the single source of truth for the membership relation name.
+// The resolver MUST read through it rather than the raw field, and any
+// out-of-package consumer that needs to reason about the *effective*
+// relation (e.g. the aclaudit linter) must use this too — so the audit
+// can never disagree with what the resolver actually walks. [NewDeclarative]
+// does not run [Policy.Validate], and the resolver passes the name straight
+// into a [store.RelationQuery] where an empty Type means "all relation
+// types" — so a blank field reaching the walk would silently follow *every*
+// outgoing edge as if it were membership (an over-grant). Collapsing blank
+// to the default here, on every read, closes that hole regardless of how
+// the [Policy] was constructed.
 //
 // The value is trimmed so a stray-whitespace YAML value (e.g.
 // `"heeft_rol "`) resolves to the relation the operator meant rather
 // than silently matching zero edges.
-func (p *Policy) membershipRelation() string {
+func (p *Policy) EffectiveMembershipRelation() string {
 	if trimmed := strings.TrimSpace(p.MembershipRelation); trimmed != "" {
 		return trimmed
 	}
@@ -377,15 +381,13 @@ func LoadPolicyBytes(data []byte) (*Policy, error) {
 // findings) per the "tolerant by design" stance. Security-relevant
 // invariants like the ones above are the exception.
 //
-// Membership-relation hardening (TKT-Z8A62F) is advisory: when an
-// operator configures a non-default [Policy.MembershipRelation],
-// Validate emits an `slog.Warn` if the relation can have no effect
-// (empty Assignments) or is an un-gated escalation foot-gun (no
-// `role_relations.<rel>.requires_permission`). These warn-and-continue
-// rather than fail — consistent with the un-gated default `member-of`,
-// which is documented in `docs/security.md` but not enforced either.
-// A dedicated authorization-misconfiguration audit is tracked in
-// TKT-TS0J5K.
+// Validate is a pure structural gate: it does NOT flag escalation
+// foot-guns, dead/inert config, or policy-vs-metamodel drift. Those
+// advisory checks (including the un-gated / inert membership relation
+// warnings that briefly lived here in TKT-Z8A62F) belong to the
+// on-demand `rela acl audit` linter — see internal/aclaudit and
+// TKT-TS0J5K — which can rank findings by severity and cross-check the
+// metamodel, neither of which fits a boot gate.
 func (p *Policy) Validate() error {
 	for i, t := range p.InheritRolesThrough {
 		if isBlank(t) {
@@ -421,34 +423,7 @@ func (p *Policy) Validate() error {
 			}
 		}
 	}
-	p.warnMembershipRelationHardening()
 	return nil
-}
-
-// warnMembershipRelationHardening emits advisory warnings when the
-// operator configures a non-default membership relation that is either
-// inert or an un-gated escalation foot-gun (TKT-Z8A62F). Gated on the
-// effective relation differing from the default so the standard
-// `member-of` path stays silent — that one is covered by the docs and
-// the dedicated audit follow-up (TKT-TS0J5K), not by load-time noise.
-func (p *Policy) warnMembershipRelationHardening() {
-	rel := p.membershipRelation()
-	if rel == defaultMembershipRelation {
-		return
-	}
-	if len(p.Assignments) == 0 {
-		// Note: the membership walk still feeds local-role resolution via
-		// the group-member set (computeForEntity's role-relation cross
-		// product), so this is "no group-level roles", not "fully inert".
-		slog.Warn("acl: configured membership_relation confers no group-level roles; assignments map is empty",
-			"membership_relation", rel)
-	}
-	if p.RoleRelations[rel].RequiresPermission == "" {
-		slog.Warn("acl: membership_relation confers group roles but is not gated by requires_permission; "+
-			"any principal who can write this edge can grant themselves any assigned role "+
-			"(see docs/security.md, 'Hardening the membership relation')",
-			"membership_relation", rel)
-	}
 }
 
 func isBlank(s string) bool {

--- a/internal/acl/policy_test.go
+++ b/internal/acl/policy_test.go
@@ -121,67 +121,11 @@ also_unknown:
 	}
 }
 
-// TKT-Z8A62F AC5: a non-default membership_relation that is not gated by
-// a requires_permission role-relation is an escalation foot-gun; Validate
-// emits an advisory slog.Warn and still succeeds (warn-and-continue).
-// NOT parallel: swaps the process-global default slog logger.
-func TestPolicy_MembershipRelation_UngatedWarns(t *testing.T) {
-	var buf bytes.Buffer
-	prev := slog.Default()
-	t.Cleanup(func() { slog.SetDefault(prev) })
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
-
-	// heeft_rol is configured + assigned but NOT gated by role_relations,
-	// so the un-gated-escalation warning must fire. Validate must still
-	// return a usable policy (no error).
-	p, err := acl.LoadPolicyBytes([]byte(`
-membership_relation: heeft_rol
-assignments:
-  engineering: editor
-roles:
-  editor:
-    read: [ticket]
-`))
-	if err != nil {
-		t.Fatalf("LoadPolicyBytes returned error; hardening checks must warn, not fail: %v", err)
-	}
-	if p.MembershipRelation != "heeft_rol" {
-		t.Errorf("MembershipRelation = %q, want heeft_rol", p.MembershipRelation)
-	}
-	logs := buf.String()
-	if !contains(logs, "requires_permission") || !contains(logs, "heeft_rol") {
-		t.Errorf("expected un-gated membership_relation warning mentioning requires_permission + heeft_rol, got:\n%s", logs)
-	}
-}
-
-// TKT-Z8A62F AC5 (companion): when the membership_relation IS gated by a
-// role_relations.requires_permission entry, the escalation warning must
-// NOT fire. The default member-of path is likewise silent (covered by the
-// many existing tests that load default policies without warnings).
-func TestPolicy_MembershipRelation_GatedNoWarn(t *testing.T) {
-	var buf bytes.Buffer
-	prev := slog.Default()
-	t.Cleanup(func() { slog.SetDefault(prev) })
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
-
-	if _, err := acl.LoadPolicyBytes([]byte(`
-membership_relation: heeft_rol
-assignments:
-  engineering: editor
-role_relations:
-  heeft_rol:
-    requires_permission: delegate-membership
-roles:
-  editor:
-    read: [ticket]
-    permissions: [delegate-membership]
-`)); err != nil {
-		t.Fatalf("LoadPolicyBytes: %v", err)
-	}
-	if logs := buf.String(); contains(logs, "requires_permission") {
-		t.Errorf("gated membership_relation must not warn, got:\n%s", logs)
-	}
-}
+// Note: the membership-relation hardening warnings that briefly lived in
+// Policy.Validate (TKT-Z8A62F) moved to the on-demand `rela acl audit`
+// linter in TKT-TS0J5K — Validate is a pure structural gate again. The
+// un-gated / gated membership scenarios are now asserted in
+// internal/aclaudit (findings A1 / A1b), not here.
 
 // AC2.1: missing file returns an error wrapping os.ErrNotExist so
 // callers (appbuild in PR 3) can fall back to NopACL via errors.Is.

--- a/internal/acl/resolver.go
+++ b/internal/acl/resolver.go
@@ -65,7 +65,7 @@ func (r *Request) walkMembers(ctx context.Context) []string {
 	for depth := 0; depth < depthCap && len(frontier) > 0; depth++ {
 		var next []string
 		for _, n := range frontier {
-			tos, err := r.d.graph.OutgoingRelations(ctx, n, r.d.policy.membershipRelation())
+			tos, err := r.d.graph.OutgoingRelations(ctx, n, r.d.policy.EffectiveMembershipRelation())
 			if err != nil {
 				// Abort the walk loud rather than silently undercount.
 				return order

--- a/internal/acl/resolver_test.go
+++ b/internal/acl/resolver_test.go
@@ -587,11 +587,12 @@ func TestMembershipRelation_Configured_Transitive(t *testing.T) {
 	}
 }
 
-func TestPolicy_membershipRelation_EffectiveName(t *testing.T) {
+func TestPolicy_EffectiveMembershipRelation(t *testing.T) {
 	t.Parallel()
 	// AC6: blank/whitespace collapses to the default; a real value passes
-	// through. The accessor is the single guard against a blank relation
-	// reaching the store as a Type=="" match-all query.
+	// through (trimmed). The accessor is the single guard against a blank
+	// relation reaching the store as a Type=="" match-all query, and the
+	// shared source of truth between the resolver and the aclaudit linter.
 	cases := []struct {
 		name string
 		set  string
@@ -609,8 +610,8 @@ func TestPolicy_membershipRelation_EffectiveName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			p := &Policy{MembershipRelation: tc.set}
-			if got := p.membershipRelation(); got != tc.want {
-				t.Errorf("membershipRelation() with %q = %q, want %q", tc.set, got, tc.want)
+			if got := p.EffectiveMembershipRelation(); got != tc.want {
+				t.Errorf("EffectiveMembershipRelation() with %q = %q, want %q", tc.set, got, tc.want)
 			}
 		})
 	}

--- a/internal/aclaudit/aclaudit.go
+++ b/internal/aclaudit/aclaudit.go
@@ -1,0 +1,255 @@
+// Package aclaudit is an on-demand linter for an [acl.Policy] loaded from
+// `acl.yaml`. It reports authorization-misconfiguration findings —
+// escalation foot-guns, dead/inert config, and policy-vs-metamodel drift —
+// ranked by severity. It is deliberately SEPARATE from [acl.Policy.Validate]:
+//
+//   - Validate is a boot gate: it hard-errors on a few security-critical
+//     structural invariants and runs on every policy load. It sees only the
+//     policy.
+//   - aclaudit is an on-demand linter: operators (or CI) run `rela acl audit`.
+//     It is advisory (never blocks boot), ranks findings by severity, and
+//     cross-checks the metamodel — none of which fits a boot gate.
+//
+// The package lives outside internal/acl because the metamodel cross-checks
+// need the schema, and arch-lint forbids acl→metamodel. aclaudit defines a
+// narrow consumer-side [MetamodelReader] interface; the concrete adapter over
+// `*metamodel.Metamodel` is supplied by the caller (the CLI), so aclaudit
+// itself depends only on internal/acl.
+//
+// See TKT-TS0J5K and the research RES-VWNN2T for the tier model and the full
+// finding taxonomy. v1 implements Tier A (pure-policy) and Tier B (metamodel).
+// Tier C (graph-aware) and Tier D (reachability) are future work.
+package aclaudit
+
+import (
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// Severity ranks a [Finding]. Critical/High are the gating tier for
+// `rela acl audit --exit-code`; Medium/Low/Nit are advisory.
+//
+// This is a richer model than the codebase's usual "error"/"warning" string
+// convention (see internal/validation) — deliberately, because the audit's
+// value is ranking a self-promotion path above a dead-permission nit, and the
+// CI exit-code gate needs that distinction.
+type Severity int
+
+const (
+	// Critical: anyone (incl. anonymous) gets a privileged capability.
+	Critical Severity = iota
+	// High: a self-promotion path, or a grant that silently mis-fires in a
+	// security-relevant way.
+	High
+	// Medium: dead/inert config or drift that weakens intent.
+	Medium
+	// Low: cosmetic or likely-intentional config worth a second look.
+	Low
+	// Nit: stylistic.
+	Nit
+)
+
+// String renders the severity as a lowercase label.
+func (s Severity) String() string {
+	switch s {
+	case Critical:
+		return "critical"
+	case High:
+		return "high"
+	case Medium:
+		return "medium"
+	case Low:
+		return "low"
+	case Nit:
+		return "nit"
+	default:
+		return "unknown"
+	}
+}
+
+// Finding is one authorization-misconfiguration the audit reports. Each
+// analyzer-style finding owns these fields (the codebase has no shared base
+// finding type; see internal/analysis / internal/validation).
+type Finding struct {
+	// Rule is a stable identifier (e.g. "A1-ungated-membership") so findings
+	// are greppable and a future suppress-list can reference them.
+	Rule string `json:"rule"`
+	// Severity ranks the finding.
+	Severity Severity `json:"severity"`
+	// Subject names the policy/schema element the finding is about (a role,
+	// relation, type, or assignment key).
+	Subject string `json:"subject"`
+	// Detail is the human explanation of what's wrong.
+	Detail string `json:"detail"`
+	// Fix is a one-line remediation hint.
+	Fix string `json:"fix"`
+}
+
+// RelationView is the narrow metamodel view of a relation type the audit
+// needs: the entity types its edges may originate from.
+type RelationView struct {
+	From []string
+}
+
+// MetamodelReader is the narrow consumer-side view of the metamodel the Tier-B
+// checks need. The concrete implementation (an adapter over
+// *metamodel.Metamodel) is supplied by the caller; defining the interface here
+// keeps aclaudit free of a metamodel import and bounded to the 3 lookups it
+// actually uses (rather than the whole, plimsoll-fat Metamodel surface).
+//
+// A nil MetamodelReader is valid: [Audit] then runs only the Tier-A
+// pure-policy checks and skips Tier B.
+type MetamodelReader interface {
+	// HasEntityType reports whether t is a declared entity type.
+	HasEntityType(t string) bool
+	// GetRelation returns the relation type's view, or false if undeclared.
+	GetRelation(name string) (RelationView, bool)
+	// HasField reports whether entity type t declares a property named field.
+	HasField(t, field string) bool
+	// EnumOptions returns the allowed values for an enum field on type t, and
+	// false if the field is absent or not an enum.
+	EnumOptions(t, field string) ([]string, bool)
+}
+
+// Audit runs every v1 check against the policy and returns the findings
+// sorted deterministically (severity, then rule, then subject). A clean,
+// well-gated policy returns an empty slice.
+//
+// meta may be nil — Tier-B (metamodel cross-check) findings are then skipped
+// and only Tier-A pure-policy findings are returned.
+func Audit(p *acl.Policy, meta MetamodelReader) []Finding {
+	if p == nil {
+		return nil
+	}
+	var f []Finding
+	f = append(f, tierA(p)...)
+	if meta != nil {
+		f = append(f, tierB(p, meta)...)
+	}
+	sort.SliceStable(f, func(i, j int) bool {
+		if f[i].Severity != f[j].Severity {
+			return f[i].Severity < f[j].Severity
+		}
+		if f[i].Rule != f[j].Rule {
+			return f[i].Rule < f[j].Rule
+		}
+		return f[i].Subject < f[j].Subject
+	})
+	return f
+}
+
+// HasAtLeast reports whether any finding is at or above the given severity
+// (lower Severity value == more severe). Used by `--exit-code` to gate on
+// Critical/High.
+func HasAtLeast(findings []Finding, threshold Severity) bool {
+	for _, f := range findings {
+		if f.Severity <= threshold {
+			return true
+		}
+	}
+	return false
+}
+
+// ---- Shared policy predicates ------------------------------------------
+
+// isPrivileged reports whether a role confers escalation-relevant power:
+// it grants any write verb (Create/Update/Delete, including the "*"
+// wildcard) OR holds any permission. Read grants are NOT privilege — a
+// read-everything role is a visibility choice, not an escalation path
+// (RR-LXI3NW, RR-UR0LJU). This is the single definition A2/A3 reference.
+func isPrivileged(r acl.RoleDef) bool {
+	return len(r.Create) > 0 || len(r.Update) > 0 || len(r.Delete) > 0 || len(r.Permissions) > 0
+}
+
+// roleGrants reports whether the policy declares a role by this name.
+func roleDeclared(p *acl.Policy, role string) bool {
+	_, ok := p.Roles[role]
+	return ok
+}
+
+// permissionGranted reports whether any declared role grants perm.
+func permissionGranted(p *acl.Policy, perm string) bool {
+	for _, r := range p.Roles {
+		if slices.Contains(r.Permissions, perm) {
+			return true
+		}
+	}
+	return false
+}
+
+// requiresPermissionFor returns the requires_permission gate on the given
+// relation type, "" if the relation isn't a role-relation or has no gate.
+func requiresPermissionFor(p *acl.Policy, rel string) string {
+	return p.RoleRelations[rel].RequiresPermission
+}
+
+// verbLists returns the four grant lists of a role for iteration.
+func verbLists(r acl.RoleDef) map[string][]string {
+	return map[string][]string{
+		"create": r.Create,
+		"update": r.Update,
+		"delete": r.Delete,
+		"read":   r.Read,
+	}
+}
+
+// hasWildcardWrite reports whether a role grants "*" on any write verb.
+func hasWildcardWrite(r acl.RoleDef) bool {
+	for _, list := range [][]string{r.Create, r.Update, r.Delete} {
+		if slices.Contains(list, "*") {
+			return true
+		}
+	}
+	return false
+}
+
+// affordanceTypeKeys returns the entity-type keys across all affordance maps
+// of a role (fields/visible/options/relations). These keys are entity types
+// with no wildcard, so they can be checked against the schema directly
+// (RR-TZ2S3G).
+func affordanceTypeKeys(r acl.RoleDef) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(m map[string][]acl.FieldGrant) {
+		for k := range m {
+			if !seen[k] {
+				seen[k] = true
+				out = append(out, k)
+			}
+		}
+	}
+	add(r.Fields)
+	add(r.Visible)
+	for k := range r.Options {
+		if !seen[k] {
+			seen[k] = true
+			out = append(out, k)
+		}
+	}
+	for k := range r.Relations {
+		if !seen[k] {
+			seen[k] = true
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sortedRoleNames returns role names in deterministic order.
+func sortedRoleNames(p *acl.Policy) []string {
+	names := make([]string, 0, len(p.Roles))
+	for n := range p.Roles {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// hasLeadingTrailingSpace reports whether s differs from its trimmed form.
+func hasLeadingTrailingSpace(s string) bool {
+	return s != "" && strings.TrimSpace(s) != s
+}

--- a/internal/aclaudit/aclaudit.go
+++ b/internal/aclaudit/aclaudit.go
@@ -70,6 +70,27 @@ func (s Severity) String() string {
 	}
 }
 
+// ParseSeverity maps a lowercase label to a Severity. The special label
+// "any" maps to [Nit] — the least-severe level — so a threshold of "any"
+// matches every finding (used by `--fail-on=any`). Returns false for an
+// unknown label.
+func ParseSeverity(s string) (Severity, bool) {
+	switch s {
+	case "critical":
+		return Critical, true
+	case "high":
+		return High, true
+	case "medium":
+		return Medium, true
+	case "low":
+		return Low, true
+	case "nit", "any":
+		return Nit, true
+	default:
+		return 0, false
+	}
+}
+
 // Finding is one authorization-misconfiguration the audit reports. Each
 // analyzer-style finding owns these fields (the codebase has no shared base
 // finding type; see internal/analysis / internal/validation).

--- a/internal/aclaudit/aclaudit.go
+++ b/internal/aclaudit/aclaudit.go
@@ -164,7 +164,7 @@ func isPrivileged(r acl.RoleDef) bool {
 	return len(r.Create) > 0 || len(r.Update) > 0 || len(r.Delete) > 0 || len(r.Permissions) > 0
 }
 
-// roleGrants reports whether the policy declares a role by this name.
+// roleDeclared reports whether the policy declares a role by this name.
 func roleDeclared(p *acl.Policy, role string) bool {
 	_, ok := p.Roles[role]
 	return ok

--- a/internal/aclaudit/aclaudit_test.go
+++ b/internal/aclaudit/aclaudit_test.go
@@ -445,6 +445,29 @@ func TestAudit_DeterministicOrder(t *testing.T) {
 	}
 }
 
+func TestParseSeverity(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		want Severity
+		ok   bool
+	}{
+		"critical": {Critical, true},
+		"high":     {High, true},
+		"medium":   {Medium, true},
+		"low":      {Low, true},
+		"nit":      {Nit, true},
+		"any":      {Nit, true}, // "any" == least-severe → matches every finding
+		"bogus":    {0, false},
+		"":         {0, false},
+	}
+	for in, want := range cases {
+		got, ok := ParseSeverity(in)
+		if ok != want.ok || (ok && got != want.want) {
+			t.Errorf("ParseSeverity(%q) = (%v, %v), want (%v, %v)", in, got, ok, want.want, want.ok)
+		}
+	}
+}
+
 func TestHasAtLeast(t *testing.T) {
 	t.Parallel()
 	findings := []Finding{{Severity: Medium}, {Severity: Low}}

--- a/internal/aclaudit/aclaudit_test.go
+++ b/internal/aclaudit/aclaudit_test.go
@@ -90,6 +90,20 @@ func TestAudit_A1_GatedMembership_NoFinding(t *testing.T) {
 	}
 }
 
+func TestAudit_A1_ReadOnlyGroup_NoFinding(t *testing.T) {
+	t.Parallel()
+	// RR-EG5D3E: a group assigned only a READ-ONLY role is a visibility choice,
+	// not an escalation path. A1 must NOT fire (symmetric with A2). This is the
+	// false-positive the design fought; gating must be on isPrivileged.
+	p := &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"reader": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"engineering": "reader"},
+	}
+	if got := Audit(p, nil); hasRule(got, "A1-ungated-membership") {
+		t.Errorf("read-only assigned role must not flag A1, got %+v", got)
+	}
+}
+
 func TestAudit_A1b_InertMembership(t *testing.T) {
 	t.Parallel()
 	// Configured a non-default membership relation with no assignments → A1b low.
@@ -239,6 +253,18 @@ func TestAudit_A10_NameWhitespace(t *testing.T) {
 	}
 }
 
+func TestAudit_A10_AssignmentKeyWhitespace(t *testing.T) {
+	t.Parallel()
+	// RR-KUOAVH: a padded assignment KEY silently matches no member.
+	p := &acl.Policy{
+		Assignments: map[string]string{"engineering ": "editor"},
+		Roles:       map[string]acl.RoleDef{"editor": {Read: []string{"ticket"}}},
+	}
+	if got := Audit(p, nil); !hasRule(got, "A10-name-whitespace") {
+		t.Fatalf("expected A10 for padded assignment key, got %+v", got)
+	}
+}
+
 // ---- Tier B ------------------------------------------------------------
 
 func TestAudit_B1_UndeclaredType(t *testing.T) {
@@ -321,6 +347,28 @@ func TestAudit_B5_UndeclaredOption(t *testing.T) {
 	}}
 	if got := Audit(p, meta); !hasRule(got, "B5-undeclared-option") {
 		t.Fatalf("expected B5, got %+v", got)
+	}
+}
+
+func TestAudit_B5_AbsentField_ReportsUndeclaredNotNonEnum(t *testing.T) {
+	t.Parallel()
+	// RR-O50E4R: an options grant on a field that doesn't exist must report
+	// B4-undeclared-field (a typo), not B5-options-non-enum (wrong diagnosis).
+	meta := fakeMetamodel{
+		types:  map[string]bool{"ticket": true},
+		fields: map[string]map[string][]string{"ticket": {"status": {"open", "done"}}},
+	}
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"triager": {Read: []string{"ticket"}, Options: map[string][]acl.OptionGrant{
+			"ticket": {{Field: "stutus", Option: "open"}}, // field typo
+		}},
+	}}
+	got := Audit(p, meta)
+	if !hasRule(got, "B4-undeclared-field") {
+		t.Errorf("absent options field must report B4-undeclared-field, got %+v", got)
+	}
+	if hasRule(got, "B5-options-non-enum") {
+		t.Errorf("absent field must NOT be reported as non-enum, got %+v", got)
 	}
 }
 

--- a/internal/aclaudit/aclaudit_test.go
+++ b/internal/aclaudit/aclaudit_test.go
@@ -1,0 +1,412 @@
+package aclaudit
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// fakeMetamodel is a minimal MetamodelReader for the Tier-B tests.
+type fakeMetamodel struct {
+	types     map[string]bool
+	relations map[string][]string            // rel -> from types
+	fields    map[string]map[string][]string // type -> field -> enum options (nil = non-enum/declared field)
+}
+
+func (m fakeMetamodel) HasEntityType(t string) bool { return m.types[t] }
+
+func (m fakeMetamodel) GetRelation(name string) (RelationView, bool) {
+	from, ok := m.relations[name]
+	if !ok {
+		return RelationView{}, false
+	}
+	return RelationView{From: from}, true
+}
+
+func (m fakeMetamodel) HasField(t, field string) bool {
+	if m.fields[t] == nil {
+		return false
+	}
+	_, ok := m.fields[t][field]
+	return ok
+}
+
+func (m fakeMetamodel) EnumOptions(t, field string) ([]string, bool) {
+	if m.fields[t] == nil {
+		return nil, false
+	}
+	opts, ok := m.fields[t][field]
+	if !ok || opts == nil {
+		return nil, false // field absent, or declared but not an enum
+	}
+	return opts, true
+}
+
+// hasRule reports whether findings contain a finding with the given rule.
+func hasRule(findings []Finding, rule string) bool {
+	return slices.ContainsFunc(findings, func(f Finding) bool { return f.Rule == rule })
+}
+
+// ruleSeverity returns the severity of the first finding with rule, or -1.
+func ruleSeverity(findings []Finding, rule string) Severity {
+	for _, f := range findings {
+		if f.Rule == rule {
+			return f.Severity
+		}
+	}
+	return Severity(-1)
+}
+
+// ---- Tier A ------------------------------------------------------------
+
+func TestAudit_A1_UngatedMembership(t *testing.T) {
+	t.Parallel()
+	// Default member-of, an assignment to a declared role, no requires_permission
+	// gate → A1 high. (Covers the DEFAULT relation, not just configured.)
+	p := &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"editor": {Create: []string{"ticket"}, Read: []string{"ticket"}}},
+		Assignments: map[string]string{"engineering": "editor"},
+	}
+	got := Audit(p, nil)
+	if !hasRule(got, "A1-ungated-membership") {
+		t.Fatalf("expected A1, got %+v", got)
+	}
+	if sev := ruleSeverity(got, "A1-ungated-membership"); sev != High {
+		t.Errorf("A1 severity = %v, want high", sev)
+	}
+}
+
+func TestAudit_A1_GatedMembership_NoFinding(t *testing.T) {
+	t.Parallel()
+	// Same, but member-of is gated by requires_permission → no A1.
+	p := &acl.Policy{
+		Roles:         map[string]acl.RoleDef{"editor": {Create: []string{"ticket"}, Read: []string{"ticket"}, Permissions: []string{"delegate-membership"}}},
+		Assignments:   map[string]string{"engineering": "editor"},
+		RoleRelations: map[string]acl.RoleRelationDef{"member-of": {RequiresPermission: "delegate-membership"}},
+	}
+	if got := Audit(p, nil); hasRule(got, "A1-ungated-membership") {
+		t.Errorf("gated membership must not flag A1, got %+v", got)
+	}
+}
+
+func TestAudit_A1b_InertMembership(t *testing.T) {
+	t.Parallel()
+	// Configured a non-default membership relation with no assignments → A1b low.
+	p := &acl.Policy{MembershipRelation: "heeft_rol"}
+	got := Audit(p, nil)
+	if !hasRule(got, "A1b-inert-membership") {
+		t.Fatalf("expected A1b, got %+v", got)
+	}
+	// Default member-of with no assignments must NOT flag A1b (common case).
+	if got := Audit(&acl.Policy{}, nil); hasRule(got, "A1b-inert-membership") {
+		t.Errorf("default member-of with no assignments must not flag A1b, got %+v", got)
+	}
+}
+
+func TestAudit_A2_UngatedRoleRelation(t *testing.T) {
+	t.Parallel()
+	// editor-of confers a privileged (write-granting) role, ungated → A2 high.
+	p := &acl.Policy{
+		Roles:         map[string]acl.RoleDef{"editor": {Update: []string{"ticket"}, Read: []string{"ticket"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{"editor-of": {Confers: "editor"}},
+	}
+	if got := Audit(p, nil); !hasRule(got, "A2-ungated-role-relation") {
+		t.Fatalf("expected A2, got %+v", got)
+	}
+	// Gated → no A2.
+	p.RoleRelations["editor-of"] = acl.RoleRelationDef{Confers: "editor", RequiresPermission: "delegate-editor"}
+	if got := Audit(p, nil); hasRule(got, "A2-ungated-role-relation") {
+		t.Errorf("gated role-relation must not flag A2, got %+v", got)
+	}
+}
+
+func TestAudit_A2_NonPrivilegedRole_NoFinding(t *testing.T) {
+	t.Parallel()
+	// A role-relation conferring a read-only (non-privileged) role is fine ungated.
+	p := &acl.Policy{
+		Roles:         map[string]acl.RoleDef{"reader": {Read: []string{"ticket"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{"reader-of": {Confers: "reader"}},
+	}
+	if got := Audit(p, nil); hasRule(got, "A2-ungated-role-relation") {
+		t.Errorf("read-only role-relation must not flag A2, got %+v", got)
+	}
+}
+
+func TestAudit_A3_EveryonePrivileged(t *testing.T) {
+	t.Parallel()
+	// everyone with a write grant → A3 critical.
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		acl.EveryoneRole: {Update: []string{"ticket"}},
+	}}
+	got := Audit(p, nil)
+	if !hasRule(got, "A3-everyone-privileged") {
+		t.Fatalf("expected A3, got %+v", got)
+	}
+	if sev := ruleSeverity(got, "A3-everyone-privileged"); sev != Critical {
+		t.Errorf("A3 severity = %v, want critical", sev)
+	}
+}
+
+func TestAudit_A3_EveryoneReadOnly_NoFinding(t *testing.T) {
+	t.Parallel()
+	// The DOCUMENTED `everyone: read: ["*"]` pattern must NOT flag A3 (RR-UR0LJU).
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		acl.EveryoneRole: {Read: []string{"*"}},
+	}}
+	if got := Audit(p, nil); hasRule(got, "A3-everyone-privileged") {
+		t.Errorf("read-only everyone must not flag A3, got %+v", got)
+	}
+}
+
+func TestAudit_A4_AssignmentToUnknownRole(t *testing.T) {
+	t.Parallel()
+	p := &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"editor": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "edutor"}, // typo
+	}
+	if got := Audit(p, nil); !hasRule(got, "A4-assignment-unknown-role") {
+		t.Fatalf("expected A4, got %+v", got)
+	}
+}
+
+func TestAudit_A5_ConfersUnknownRole(t *testing.T) {
+	t.Parallel()
+	p := &acl.Policy{
+		Roles:         map[string]acl.RoleDef{"editor": {Read: []string{"ticket"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{"editor-of": {Confers: "edutor"}},
+	}
+	if got := Audit(p, nil); !hasRule(got, "A5-confers-unknown-role") {
+		t.Fatalf("expected A5, got %+v", got)
+	}
+}
+
+func TestAudit_A6_UngrantablePermission(t *testing.T) {
+	t.Parallel()
+	// requires_permission names a perm no role grants → A6 low.
+	p := &acl.Policy{
+		Roles:         map[string]acl.RoleDef{"editor": {Read: []string{"ticket"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{"editor-of": {Confers: "editor", RequiresPermission: "delegate-nobody-has"}},
+	}
+	got := Audit(p, nil)
+	if !hasRule(got, "A6-ungrantable-permission") {
+		t.Fatalf("expected A6, got %+v", got)
+	}
+	if sev := ruleSeverity(got, "A6-ungrantable-permission"); sev != Low {
+		t.Errorf("A6 severity = %v, want low (intentional lockdown may be valid)", sev)
+	}
+}
+
+func TestAudit_A7_DeadPermission(t *testing.T) {
+	t.Parallel()
+	// A permission granted but referenced by no requires_permission → A7 low.
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"admin": {Create: []string{"*"}, Read: []string{"*"}, Permissions: []string{"delegate-unused"}},
+	}}
+	if got := Audit(p, nil); !hasRule(got, "A7-dead-permission") {
+		t.Fatalf("expected A7, got %+v", got)
+	}
+	// Referenced permission → no A7.
+	p2 := &acl.Policy{
+		Roles:         map[string]acl.RoleDef{"admin": {Create: []string{"*"}, Read: []string{"*"}, Permissions: []string{"delegate-x"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{"member-of": {RequiresPermission: "delegate-x"}},
+	}
+	if got := Audit(p2, nil); hasRule(got, "A7-dead-permission") {
+		t.Errorf("referenced permission must not flag A7, got %+v", got)
+	}
+}
+
+func TestAudit_A9_WildcardWrite_NotRead(t *testing.T) {
+	t.Parallel()
+	// A non-everyone role with create:["*"] → A9. read:["*"] alone → no A9.
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"power": {Create: []string{"*"}, Read: []string{"*"}},
+	}}
+	if got := Audit(p, nil); !hasRule(got, "A9-wildcard-write") {
+		t.Fatalf("expected A9 for create:[*], got %+v", got)
+	}
+	readOnly := &acl.Policy{Roles: map[string]acl.RoleDef{"viewer": {Read: []string{"*"}}}}
+	if got := Audit(readOnly, nil); hasRule(got, "A9-wildcard-write") {
+		t.Errorf("read:[*] must not flag A9, got %+v", got)
+	}
+}
+
+func TestAudit_A10_NameWhitespace(t *testing.T) {
+	t.Parallel()
+	p := &acl.Policy{MembershipRelation: "heeft_rol ", Assignments: map[string]string{"x": "editor"}, Roles: map[string]acl.RoleDef{"editor": {Read: []string{"t"}}}}
+	if got := Audit(p, nil); !hasRule(got, "A10-name-whitespace") {
+		t.Fatalf("expected A10 for trailing space, got %+v", got)
+	}
+}
+
+// ---- Tier B ------------------------------------------------------------
+
+func TestAudit_B1_UndeclaredType(t *testing.T) {
+	t.Parallel()
+	meta := fakeMetamodel{types: map[string]bool{"ticket": true}}
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"editor": {Create: []string{"ticket", "tickets"}, Read: []string{"ticket"}}, // "tickets" is a typo
+	}}
+	if got := Audit(p, meta); !hasRule(got, "B1-undeclared-type") {
+		t.Fatalf("expected B1, got %+v", got)
+	}
+}
+
+func TestAudit_B1_WildcardSkipped(t *testing.T) {
+	t.Parallel()
+	// A wildcard grant must NOT flag B1 — "*" is not an entity type (RR-TZ2S3G).
+	meta := fakeMetamodel{types: map[string]bool{"ticket": true}}
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"admin": {Create: []string{"*"}, Update: []string{"*"}, Delete: []string{"*"}, Read: []string{"*"}},
+	}}
+	if got := Audit(p, meta); hasRule(got, "B1-undeclared-type") {
+		t.Errorf("wildcard role must not flag B1, got %+v", got)
+	}
+}
+
+func TestAudit_B2_UndeclaredRelation(t *testing.T) {
+	t.Parallel()
+	meta := fakeMetamodel{types: map[string]bool{"ticket": true}}
+	// membership_relation names a relation the schema lacks → B2.
+	p := &acl.Policy{MembershipRelation: "heeft_rol"}
+	if got := Audit(p, meta); !hasRule(got, "B2-undeclared-relation") {
+		t.Fatalf("expected B2 for membership_relation, got %+v", got)
+	}
+}
+
+func TestAudit_B3_MembershipFromMismatch(t *testing.T) {
+	t.Parallel()
+	// heeft_rol exists but its from is [persoon]; user_entity_type is "user".
+	meta := fakeMetamodel{
+		types:     map[string]bool{"user": true, "persoon": true, "rol": true},
+		relations: map[string][]string{"heeft_rol": {"persoon"}},
+	}
+	p := &acl.Policy{UserEntityType: "user", MembershipRelation: "heeft_rol"}
+	if got := Audit(p, meta); !hasRule(got, "B3-membership-from-mismatch") {
+		t.Fatalf("expected B3, got %+v", got)
+	}
+	// Compatible from → no B3.
+	p.UserEntityType = "persoon"
+	if got := Audit(p, meta); hasRule(got, "B3-membership-from-mismatch") {
+		t.Errorf("compatible from must not flag B3, got %+v", got)
+	}
+}
+
+func TestAudit_B4_UndeclaredField(t *testing.T) {
+	t.Parallel()
+	meta := fakeMetamodel{
+		types:  map[string]bool{"ticket": true},
+		fields: map[string]map[string][]string{"ticket": {"status": {"open", "done"}}},
+	}
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"triager": {Read: []string{"ticket"}, Fields: map[string][]acl.FieldGrant{
+			"ticket": {{Field: "stutus"}}, // typo
+		}},
+	}}
+	if got := Audit(p, meta); !hasRule(got, "B4-undeclared-field") {
+		t.Fatalf("expected B4, got %+v", got)
+	}
+}
+
+func TestAudit_B5_UndeclaredOption(t *testing.T) {
+	t.Parallel()
+	meta := fakeMetamodel{
+		types:  map[string]bool{"ticket": true},
+		fields: map[string]map[string][]string{"ticket": {"status": {"open", "done"}}},
+	}
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"triager": {Read: []string{"ticket"}, Options: map[string][]acl.OptionGrant{
+			"ticket": {{Field: "status", Option: "finished"}}, // not in enum
+		}},
+	}}
+	if got := Audit(p, meta); !hasRule(got, "B5-undeclared-option") {
+		t.Fatalf("expected B5, got %+v", got)
+	}
+}
+
+func TestAudit_B7_UndeclaredUserType(t *testing.T) {
+	t.Parallel()
+	meta := fakeMetamodel{types: map[string]bool{"ticket": true}}
+	p := &acl.Policy{UserEntityType: "persoon"} // not declared
+	if got := Audit(p, meta); !hasRule(got, "B7-undeclared-user-type") {
+		t.Fatalf("expected B7, got %+v", got)
+	}
+}
+
+func TestAudit_NilMetamodel_SkipsTierB(t *testing.T) {
+	t.Parallel()
+	// With nil meta, an undeclared-type grant cannot be checked → no B findings,
+	// but Tier A still runs.
+	p := &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"editor": {Create: []string{"nonsense"}, Read: []string{"nonsense"}}},
+		Assignments: map[string]string{"g": "editor"},
+	}
+	got := Audit(p, nil)
+	for _, f := range got {
+		if f.Rule[0] == 'B' {
+			t.Errorf("nil meta must skip Tier B, got %+v", f)
+		}
+	}
+}
+
+// ---- Golden: the documented worked-example policy stays clean -----------
+
+func TestAudit_CleanPolicy_NoFindings(t *testing.T) {
+	t.Parallel()
+	// A well-gated policy (everyone read-only, all relations gated, all names
+	// declared) must produce ZERO findings. This is the anti-false-positive
+	// guard: if a future check starts flagging a legitimate baseline, this fails.
+	meta := fakeMetamodel{
+		types:     map[string]bool{"person": true, "ticket": true, "group": true},
+		relations: map[string][]string{"member-of": {"person"}},
+	}
+	p := &acl.Policy{
+		UserEntityType: "person",
+		Roles: map[string]acl.RoleDef{
+			"admin":    {Create: []string{"ticket"}, Update: []string{"ticket"}, Delete: []string{"ticket"}, Read: []string{"ticket"}, Permissions: []string{"delegate-membership"}},
+			"everyone": {Read: []string{"*"}},
+		},
+		Assignments:   map[string]string{"ops-team": "admin"},
+		RoleRelations: map[string]acl.RoleRelationDef{"member-of": {RequiresPermission: "delegate-membership"}},
+	}
+	if got := Audit(p, meta); len(got) != 0 {
+		t.Errorf("clean policy must produce zero findings, got %+v", got)
+	}
+}
+
+func TestAudit_DeterministicOrder(t *testing.T) {
+	t.Parallel()
+	// Findings sort by severity, then rule, then subject — stable across runs.
+	p := &acl.Policy{
+		Roles: map[string]acl.RoleDef{
+			acl.EveryoneRole: {Update: []string{"ticket"}}, // A3 critical
+			"power":          {Create: []string{"*"}},      // A9 medium
+		},
+		Assignments: map[string]string{"g": "power"}, // A1 high (ungated member-of)
+	}
+	first := Audit(p, nil)
+	for range 20 {
+		got := Audit(p, nil)
+		if !slices.EqualFunc(got, first, func(a, b Finding) bool { return a == b }) {
+			t.Fatalf("non-deterministic order:\n first=%+v\n got  =%+v", first, got)
+		}
+	}
+	// Critical must sort before high before medium.
+	if len(first) >= 2 && first[0].Severity > first[1].Severity {
+		t.Errorf("findings not severity-sorted: %+v", first)
+	}
+}
+
+func TestHasAtLeast(t *testing.T) {
+	t.Parallel()
+	findings := []Finding{{Severity: Medium}, {Severity: Low}}
+	if HasAtLeast(findings, High) {
+		t.Error("HasAtLeast(High) should be false when worst is medium")
+	}
+	if !HasAtLeast(findings, Medium) {
+		t.Error("HasAtLeast(Medium) should be true")
+	}
+	if !HasAtLeast([]Finding{{Severity: Critical}}, High) {
+		t.Error("HasAtLeast(High) should be true when a critical is present")
+	}
+}

--- a/internal/aclaudit/tier_a.go
+++ b/internal/aclaudit/tier_a.go
@@ -45,14 +45,17 @@ func checkUngatedMembership(p *acl.Policy) []Finding {
 		})
 	}
 
-	// A1 — the membership relation can confer an assigned role (there is at
-	// least one assignment to a declared role) but writes to it are not gated.
-	if len(p.Assignments) > 0 && assignsAnyDeclaredRole(p) && requiresPermissionFor(p, rel) == "" {
+	// A1 — the membership relation can confer a PRIVILEGED assigned role but
+	// writes to it are not gated. Gated on isPrivileged (symmetric with A2):
+	// granting yourself a read-only role is a visibility choice, not an
+	// escalation path (RR-LXI3NW / RR-UR0LJU / RR-EG5D3E), so a read-only
+	// group does not trip A1.
+	if assignsAnyPrivilegedRole(p) && requiresPermissionFor(p, rel) == "" {
 		f = append(f, Finding{
 			Rule: "A1-ungated-membership", Severity: High, Subject: rel,
-			Detail: fmt.Sprintf("membership relation %q confers group roles via assignments but is not "+
-				"gated by requires_permission; any principal who can write a %q edge can grant "+
-				"themselves any assigned role", rel, rel),
+			Detail: fmt.Sprintf("membership relation %q confers a privileged group role via assignments "+
+				"but is not gated by requires_permission; any principal who can write a %q edge can "+
+				"grant themselves that role", rel, rel),
 			Fix: fmt.Sprintf("add role_relations.%s.requires_permission and grant that permission "+
 				"only to admins (see docs/security.md)", rel),
 		})
@@ -60,11 +63,12 @@ func checkUngatedMembership(p *acl.Policy) []Finding {
 	return f
 }
 
-// assignsAnyDeclaredRole reports whether at least one assignment targets a
-// declared role (so the membership walk actually confers something).
-func assignsAnyDeclaredRole(p *acl.Policy) bool {
-	for _, role := range p.Assignments {
-		if roleDeclared(p, role) {
+// assignsAnyPrivilegedRole reports whether at least one assignment targets a
+// declared, privileged role — i.e. the membership walk can confer escalation-
+// relevant power. Mirrors A2's isPrivileged gate.
+func assignsAnyPrivilegedRole(p *acl.Policy) bool {
+	for _, roleName := range p.Assignments {
+		if role, ok := p.Roles[roleName]; ok && isPrivileged(role) {
 			return true
 		}
 	}
@@ -240,6 +244,11 @@ func checkNameWhitespace(p *acl.Policy) []Finding {
 		}
 	}
 	for _, key := range sortedAssignmentKeys(p) {
+		// The key is the member/group ID matched in computeGlobals; a padded
+		// key silently matches no member, same foot-gun as a padded value.
+		if hasLeadingTrailingSpace(key) {
+			add(key, "assignment key")
+		}
 		if hasLeadingTrailingSpace(p.Assignments[key]) {
 			add(p.Assignments[key], "assignment role")
 		}

--- a/internal/aclaudit/tier_a.go
+++ b/internal/aclaudit/tier_a.go
@@ -1,0 +1,280 @@
+package aclaudit
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// tierA runs the pure-policy checks: escalation foot-guns and dead/inert
+// config that need no metamodel. Order within the slice doesn't matter —
+// Audit sorts the combined result.
+func tierA(p *acl.Policy) []Finding {
+	f := make([]Finding, 0, 8)
+	f = append(f, checkUngatedMembership(p)...)     // A1 / A1b
+	f = append(f, checkUngatedRoleRelations(p)...)  // A2
+	f = append(f, checkEveryonePrivileged(p)...)    // A3
+	f = append(f, checkAssignmentsToUnknown(p)...)  // A4
+	f = append(f, checkConfersUnknown(p)...)        // A5
+	f = append(f, checkUngrantablePermission(p)...) // A6
+	f = append(f, checkDeadPermissions(p)...)       // A7
+	f = append(f, checkWildcardWriteSprawl(p)...)   // A9
+	f = append(f, checkNameWhitespace(p)...)        // A10
+	return f
+}
+
+// A1 / A1b — the membership relation confers group roles via assignments but
+// is not gated by requires_permission (self-promotion), or has no assignments
+// to confer (inert). Covers the DEFAULT member-of too, via the same effective
+// accessor the resolver uses (single source of truth).
+func checkUngatedMembership(p *acl.Policy) []Finding {
+	rel := p.EffectiveMembershipRelation()
+	var f []Finding
+
+	// A1b — configured a non-default membership relation but no assignments,
+	// so it confers no group-level roles. (Only for non-default: the default
+	// member-of with no assignments is the common "groups unused" case, not
+	// worth a finding.)
+	if rel != defaultMembershipRelationName() && len(p.Assignments) == 0 {
+		f = append(f, Finding{
+			Rule: "A1b-inert-membership", Severity: Low, Subject: rel,
+			Detail: fmt.Sprintf("membership_relation %q is configured but assignments is empty, "+
+				"so it confers no group-level roles", rel),
+			Fix: "add an assignments mapping, or remove membership_relation if groups are unused",
+		})
+	}
+
+	// A1 — the membership relation can confer an assigned role (there is at
+	// least one assignment to a declared role) but writes to it are not gated.
+	if len(p.Assignments) > 0 && assignsAnyDeclaredRole(p) && requiresPermissionFor(p, rel) == "" {
+		f = append(f, Finding{
+			Rule: "A1-ungated-membership", Severity: High, Subject: rel,
+			Detail: fmt.Sprintf("membership relation %q confers group roles via assignments but is not "+
+				"gated by requires_permission; any principal who can write a %q edge can grant "+
+				"themselves any assigned role", rel, rel),
+			Fix: fmt.Sprintf("add role_relations.%s.requires_permission and grant that permission "+
+				"only to admins (see docs/security.md)", rel),
+		})
+	}
+	return f
+}
+
+// assignsAnyDeclaredRole reports whether at least one assignment targets a
+// declared role (so the membership walk actually confers something).
+func assignsAnyDeclaredRole(p *acl.Policy) bool {
+	for _, role := range p.Assignments {
+		if roleDeclared(p, role) {
+			return true
+		}
+	}
+	return false
+}
+
+// A2 — a role-relation confers a privileged role but is not gated by
+// requires_permission: anyone who can write that edge self-grants the role.
+func checkUngatedRoleRelations(p *acl.Policy) []Finding {
+	var f []Finding
+	for _, rel := range sortedRelTypes(p) {
+		def := p.RoleRelations[rel]
+		role, ok := p.Roles[def.Confers]
+		if !ok || !isPrivileged(role) {
+			continue
+		}
+		if def.RequiresPermission != "" {
+			continue // gated — fine
+		}
+		f = append(f, Finding{
+			Rule: "A2-ungated-role-relation", Severity: High, Subject: rel,
+			Detail: fmt.Sprintf("role-relation %q confers the privileged role %q but is not gated by "+
+				"requires_permission; any principal who can write a %q edge self-grants %q",
+				rel, def.Confers, rel, def.Confers),
+			Fix: fmt.Sprintf("add role_relations.%s.requires_permission gating the edge to a delegate role", rel),
+		})
+	}
+	return f
+}
+
+// A3 — the built-in `everyone` role grants write/permissions: every principal
+// (including anonymous) holds it. Critical. Read-only everyone is fine.
+func checkEveryonePrivileged(p *acl.Policy) []Finding {
+	role, ok := p.Roles[acl.EveryoneRole]
+	if !ok || !isPrivileged(role) {
+		return nil
+	}
+	return []Finding{{
+		Rule: "A3-everyone-privileged", Severity: Critical, Subject: acl.EveryoneRole,
+		Detail: fmt.Sprintf("role %q is held by every principal (including anonymous) and grants write "+
+			"or permissions; this hands privileged capabilities to everyone", acl.EveryoneRole),
+		Fix: "remove write/permission grants from the everyone role; keep only read grants there",
+	}}
+}
+
+// A4 — an assignment names a role not declared in roles: silently inert.
+func checkAssignmentsToUnknown(p *acl.Policy) []Finding {
+	var f []Finding
+	for _, key := range sortedAssignmentKeys(p) {
+		role := p.Assignments[key]
+		if roleDeclared(p, role) {
+			continue
+		}
+		f = append(f, Finding{
+			Rule: "A4-assignment-unknown-role", Severity: Medium, Subject: key,
+			Detail: fmt.Sprintf("assignment %q -> %q names a role not declared in roles; the assignment "+
+				"has no effect", key, role),
+			Fix: fmt.Sprintf("declare role %q under roles, or fix the assignment", role),
+		})
+	}
+	return f
+}
+
+// A5 — a role-relation confers a role not declared in roles: silently inert.
+func checkConfersUnknown(p *acl.Policy) []Finding {
+	var f []Finding
+	for _, rel := range sortedRelTypes(p) {
+		role := p.RoleRelations[rel].Confers
+		if role == "" || roleDeclared(p, role) {
+			continue
+		}
+		f = append(f, Finding{
+			Rule: "A5-confers-unknown-role", Severity: Medium, Subject: rel,
+			Detail: fmt.Sprintf("role_relations.%s confers %q which is not declared in roles; the "+
+				"role-relation confers nothing", rel, role),
+			Fix: fmt.Sprintf("declare role %q under roles, or fix the confers value", role),
+		})
+	}
+	return f
+}
+
+// A6 — a requires_permission names a permission no role grants: no principal
+// can write that relation. Often an intentional lockdown, so this is low and
+// phrased as a question (RR-O7H3GY).
+func checkUngrantablePermission(p *acl.Policy) []Finding {
+	var f []Finding
+	for _, rel := range sortedRelTypes(p) {
+		perm := p.RoleRelations[rel].RequiresPermission
+		if perm == "" || permissionGranted(p, perm) {
+			continue
+		}
+		f = append(f, Finding{
+			Rule: "A6-ungrantable-permission", Severity: Low, Subject: rel,
+			Detail: fmt.Sprintf("role_relations.%s requires permission %q which no role grants, so no "+
+				"principal can write a %s edge — is this an intentional lockdown?", rel, perm, rel),
+			Fix: fmt.Sprintf("grant %q to a role, or remove the requires_permission gate if the "+
+				"lockdown is unintended", perm),
+		})
+	}
+	return f
+}
+
+// A7 — a role declares a permission that no requires_permission references:
+// dead config, possibly a typo of a real gate.
+func checkDeadPermissions(p *acl.Policy) []Finding {
+	// Collect every permission referenced by a requires_permission gate.
+	used := map[string]bool{}
+	for _, def := range p.RoleRelations {
+		if def.RequiresPermission != "" {
+			used[def.RequiresPermission] = true
+		}
+	}
+	var f []Finding
+	for _, name := range sortedRoleNames(p) {
+		perms := append([]string(nil), p.Roles[name].Permissions...)
+		sort.Strings(perms)
+		for _, perm := range perms {
+			if used[perm] {
+				continue
+			}
+			f = append(f, Finding{
+				Rule: "A7-dead-permission", Severity: Low, Subject: name,
+				Detail: fmt.Sprintf("role %q grants permission %q which no role_relations.requires_permission "+
+					"references; the permission is dead", name, perm),
+				Fix: fmt.Sprintf("reference %q in a requires_permission gate, or remove it (check for a typo)", perm),
+			})
+		}
+	}
+	return f
+}
+
+// A9 — a non-`everyone` role grants a WRITE wildcard ("*" on create/update/
+// delete). read:["*"] is NEVER flagged — read-everything is an intentional
+// visibility choice, not least-privilege sprawl (RR-UR0LJU).
+func checkWildcardWriteSprawl(p *acl.Policy) []Finding {
+	var f []Finding
+	for _, name := range sortedRoleNames(p) {
+		if name == acl.EveryoneRole {
+			continue
+		}
+		if !hasWildcardWrite(p.Roles[name]) {
+			continue
+		}
+		f = append(f, Finding{
+			Rule: "A9-wildcard-write", Severity: Medium, Subject: name,
+			Detail: fmt.Sprintf("role %q grants a write wildcard (\"*\") on create/update/delete; confirm "+
+				"this role is meant to mutate every entity type", name),
+			Fix: "list the specific entity types the role may write, or confirm the wildcard is intended for an admin role",
+		})
+	}
+	return f
+}
+
+// A10 — a relation/role/type name carries leading/trailing whitespace, so it
+// silently matches nothing. Checks the membership relation, role-relation
+// keys, assignment values, and inherit_roles_through entries.
+func checkNameWhitespace(p *acl.Policy) []Finding {
+	var f []Finding
+	add := func(subject, kind string) {
+		f = append(f, Finding{
+			Rule: "A10-name-whitespace", Severity: Low, Subject: subject,
+			Detail: fmt.Sprintf("%s %q has leading/trailing whitespace and will not match what the "+
+				"operator intended", kind, subject),
+			Fix: "remove the surrounding whitespace",
+		})
+	}
+	if hasLeadingTrailingSpace(p.MembershipRelation) {
+		add(p.MembershipRelation, "membership_relation")
+	}
+	for _, rel := range sortedRelTypes(p) {
+		if hasLeadingTrailingSpace(rel) {
+			add(rel, "role_relations key")
+		}
+	}
+	for _, key := range sortedAssignmentKeys(p) {
+		if hasLeadingTrailingSpace(p.Assignments[key]) {
+			add(p.Assignments[key], "assignment role")
+		}
+	}
+	for _, rel := range p.InheritRolesThrough {
+		if hasLeadingTrailingSpace(rel) {
+			add(rel, "inherit_roles_through entry")
+		}
+	}
+	return f
+}
+
+// ---- deterministic iteration helpers -----------------------------------
+
+func sortedRelTypes(p *acl.Policy) []string {
+	out := make([]string, 0, len(p.RoleRelations))
+	for r := range p.RoleRelations {
+		out = append(out, r)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedAssignmentKeys(p *acl.Policy) []string {
+	out := make([]string, 0, len(p.Assignments))
+	for k := range p.Assignments {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// defaultMembershipRelationName returns the default membership relation name.
+// aclaudit can't see acl's unexported const, so it derives it from a
+// zero-value Policy's effective relation (the single source of truth).
+func defaultMembershipRelationName() string {
+	return (&acl.Policy{}).EffectiveMembershipRelation()
+}

--- a/internal/aclaudit/tier_b.go
+++ b/internal/aclaudit/tier_b.go
@@ -1,0 +1,219 @@
+package aclaudit
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// tierB runs the metamodel cross-checks: grants and relation names that the
+// schema doesn't declare (silent drift). All checks skip the "*" wildcard
+// sentinel, which is not an entity type (RR-TZ2S3G).
+func tierB(p *acl.Policy, m MetamodelReader) []Finding {
+	f := make([]Finding, 0, 8)
+	f = append(f, checkUndeclaredEntityTypes(p, m)...)  // B1
+	f = append(f, checkUndeclaredRelations(p, m)...)    // B2
+	f = append(f, checkMembershipFromCompat(p, m)...)   // B3
+	f = append(f, checkUndeclaredFields(p, m)...)       // B4
+	f = append(f, checkUndeclaredOptions(p, m)...)      // B5
+	f = append(f, checkUserEntityTypeDeclared(p, m)...) // B7
+	return f
+}
+
+// B1 — a create/update/delete/read grant or an affordance-map key names an
+// entity type the metamodel doesn't declare: the grant silently matches
+// nothing. The "*" wildcard is skipped (it's not a type).
+func checkUndeclaredEntityTypes(p *acl.Policy, m MetamodelReader) []Finding {
+	var f []Finding
+	for _, name := range sortedRoleNames(p) {
+		role := p.Roles[name]
+		seen := map[string]bool{}
+		flag := func(verb, t string) {
+			if t == "*" || m.HasEntityType(t) || seen[verb+"\x00"+t] {
+				return
+			}
+			seen[verb+"\x00"+t] = true
+			f = append(f, Finding{
+				Rule: "B1-undeclared-type", Severity: High, Subject: name,
+				Detail: fmt.Sprintf("role %q grants %s on entity type %q which the metamodel does not "+
+					"declare; the grant matches nothing", name, verb, t),
+				Fix: fmt.Sprintf("declare entity type %q, or fix the %s grant (check for a typo)", t, verb),
+			})
+		}
+		for _, verb := range []string{"create", "update", "delete", "read"} {
+			for _, t := range verbLists(role)[verb] {
+				flag(verb, t)
+			}
+		}
+		// Affordance map keys are entity types with no wildcard.
+		for _, t := range affordanceTypeKeys(role) {
+			flag("affordance", t)
+		}
+	}
+	return f
+}
+
+// B2 — membership_relation, a role_relations key, or an inherit_roles_through
+// entry names a relation type the metamodel doesn't declare: the resolver
+// walks a relation that can't exist, so it confers nothing.
+func checkUndeclaredRelations(p *acl.Policy, m MetamodelReader) []Finding {
+	var f []Finding
+	check := func(rel, kind string) {
+		if rel == "" {
+			return
+		}
+		if _, ok := m.GetRelation(rel); ok {
+			return
+		}
+		f = append(f, Finding{
+			Rule: "B2-undeclared-relation", Severity: High, Subject: rel,
+			Detail: fmt.Sprintf("%s names relation type %q which the metamodel does not declare; the "+
+				"resolver walks a relation that cannot exist", kind, rel),
+			Fix: fmt.Sprintf("declare relation type %q, or fix the %s (check for a typo)", rel, kind),
+		})
+	}
+	// Only flag membership_relation when explicitly set — an unset/default
+	// member-of that the schema lacks is its own (common) situation, and B2
+	// would be noise on a project that simply doesn't model member-of.
+	if p.MembershipRelation != "" {
+		check(p.EffectiveMembershipRelation(), "membership_relation")
+	}
+	for _, rel := range sortedRelTypes(p) {
+		check(rel, "role_relations key")
+	}
+	inherited := append([]string(nil), p.InheritRolesThrough...)
+	sort.Strings(inherited)
+	for _, rel := range inherited {
+		check(rel, "inherit_roles_through entry")
+	}
+	return f
+}
+
+// B3 — the membership relation's `from` (per the metamodel) does not include
+// user_entity_type, so a user can never hold that edge: groups never resolve.
+// Only meaningful when user_entity_type is set and the relation is declared.
+func checkMembershipFromCompat(p *acl.Policy, m MetamodelReader) []Finding {
+	if p.UserEntityType == "" {
+		return nil
+	}
+	rel := p.EffectiveMembershipRelation()
+	view, ok := m.GetRelation(rel)
+	if !ok {
+		return nil // B2 already reports an undeclared relation
+	}
+	if slices.Contains(view.From, p.UserEntityType) {
+		return nil
+	}
+	return []Finding{{
+		Rule: "B3-membership-from-mismatch", Severity: Medium, Subject: rel,
+		Detail: fmt.Sprintf("membership relation %q has from=%v in the metamodel, which does not include "+
+			"user_entity_type %q; a user can never hold this edge, so group membership never resolves",
+			rel, view.From, p.UserEntityType),
+		Fix: fmt.Sprintf("add %q to the from of relation %q, or set membership_relation to a relation "+
+			"whose source is %q", p.UserEntityType, rel, p.UserEntityType),
+	}}
+}
+
+// B4 — a fields/visible grant names a field the entity type doesn't declare.
+func checkUndeclaredFields(p *acl.Policy, m MetamodelReader) []Finding {
+	var f []Finding
+	for _, name := range sortedRoleNames(p) {
+		role := p.Roles[name]
+		for _, block := range []struct {
+			kind   string
+			grants map[string][]acl.FieldGrant
+		}{{"fields", role.Fields}, {"visible", role.Visible}} {
+			for _, t := range sortedKeysFieldGrant(block.grants) {
+				if !m.HasEntityType(t) {
+					continue // B1 reports the undeclared type; don't double-flag fields
+				}
+				for _, g := range block.grants[t] {
+					if g.Field == "" || m.HasField(t, g.Field) {
+						continue
+					}
+					f = append(f, Finding{
+						Rule: "B4-undeclared-field", Severity: Medium, Subject: name,
+						Detail: fmt.Sprintf("role %q %s grant on %q names field %q which the type does not "+
+							"declare; the affordance does nothing", name, block.kind, t, g.Field),
+						Fix: fmt.Sprintf("declare field %q on %q, or fix the grant", g.Field, t),
+					})
+				}
+			}
+		}
+	}
+	return f
+}
+
+// B5 — an options grant names a value outside the field's enum (or a
+// non-enum field).
+func checkUndeclaredOptions(p *acl.Policy, m MetamodelReader) []Finding {
+	var f []Finding
+	for _, name := range sortedRoleNames(p) {
+		role := p.Roles[name]
+		for _, t := range sortedKeysOptionGrant(role.Options) {
+			if !m.HasEntityType(t) {
+				continue
+			}
+			for _, g := range role.Options[t] {
+				if g.Field == "" {
+					continue
+				}
+				opts, isEnum := m.EnumOptions(t, g.Field)
+				if !isEnum {
+					f = append(f, Finding{
+						Rule: "B5-options-non-enum", Severity: Medium, Subject: name,
+						Detail: fmt.Sprintf("role %q options grant on %q names field %q which is not an enum; "+
+							"the option grant does nothing", name, t, g.Field),
+						Fix: fmt.Sprintf("grant options only on enum fields; %q.%q is not one", t, g.Field),
+					})
+					continue
+				}
+				if g.Option != "" && !slices.Contains(opts, g.Option) {
+					f = append(f, Finding{
+						Rule: "B5-undeclared-option", Severity: Medium, Subject: name,
+						Detail: fmt.Sprintf("role %q options grant on %q.%q names option %q outside the field's "+
+							"enum %v; the grant does nothing", name, t, g.Field, g.Option, opts),
+						Fix: fmt.Sprintf("use one of %v, or fix the option (check for a typo)", opts),
+					})
+				}
+			}
+		}
+	}
+	return f
+}
+
+// B7 — user_entity_type names a type the metamodel doesn't declare: the
+// whole user-resolution layer is broken.
+func checkUserEntityTypeDeclared(p *acl.Policy, m MetamodelReader) []Finding {
+	if p.UserEntityType == "" || m.HasEntityType(p.UserEntityType) {
+		return nil
+	}
+	return []Finding{{
+		Rule: "B7-undeclared-user-type", Severity: High, Subject: p.UserEntityType,
+		Detail: fmt.Sprintf("user_entity_type %q is not a declared entity type; user resolution cannot "+
+			"work", p.UserEntityType),
+		Fix: fmt.Sprintf("declare entity type %q, or fix user_entity_type", p.UserEntityType),
+	}}
+}
+
+// ---- helpers -----------------------------------------------------------
+
+func sortedKeysFieldGrant(m map[string][]acl.FieldGrant) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedKeysOptionGrant(m map[string][]acl.OptionGrant) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/aclaudit/tier_b.go
+++ b/internal/aclaudit/tier_b.go
@@ -31,10 +31,12 @@ func checkUndeclaredEntityTypes(p *acl.Policy, m MetamodelReader) []Finding {
 		role := p.Roles[name]
 		seen := map[string]bool{}
 		flag := func(verb, t string) {
-			if t == "*" || m.HasEntityType(t) || seen[verb+"\x00"+t] {
+			// Dedupe on type alone: one typo'd type used across several verbs
+			// (or an affordance key) is one mistake with one fix.
+			if t == "*" || m.HasEntityType(t) || seen[t] {
 				return
 			}
-			seen[verb+"\x00"+t] = true
+			seen[t] = true
 			f = append(f, Finding{
 				Rule: "B1-undeclared-type", Severity: High, Subject: name,
 				Detail: fmt.Sprintf("role %q grants %s on entity type %q which the metamodel does not "+
@@ -158,6 +160,17 @@ func checkUndeclaredOptions(p *acl.Policy, m MetamodelReader) []Finding {
 			}
 			for _, g := range role.Options[t] {
 				if g.Field == "" {
+					continue
+				}
+				// Distinguish "field doesn't exist" (a typo) from "field exists
+				// but isn't an enum" — the operator needs the right diagnosis.
+				if !m.HasField(t, g.Field) {
+					f = append(f, Finding{
+						Rule: "B4-undeclared-field", Severity: Medium, Subject: name,
+						Detail: fmt.Sprintf("role %q options grant on %q names field %q which the type does "+
+							"not declare; the grant does nothing", name, t, g.Field),
+						Fix: fmt.Sprintf("declare field %q on %q, or fix the grant", g.Field, t),
+					})
 					continue
 				}
 				opts, isEnum := m.EnumOptions(t, g.Field)

--- a/internal/cli/acl.go
+++ b/internal/cli/acl.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	stderrors "errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/aclaudit"
+	"github.com/Sourcehaven-BV/rela/internal/errors"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/output"
+)
+
+// ACLCmd groups access-control commands.
+type ACLCmd struct {
+	Audit ACLAuditCmd `cmd:"" help:"Audit the ACL policy (acl.yaml) for misconfigurations."`
+}
+
+// ACLAuditCmd runs the on-demand authorization-misconfiguration linter over the
+// project's acl.yaml. It is advisory by default; pass --exit-code to make CI
+// fail on critical/high findings. See internal/aclaudit (TKT-TS0J5K).
+type ACLAuditCmd struct {
+	ExitCode bool `help:"Exit non-zero when any critical or high finding is present (for CI gating)."`
+}
+
+// Run executes `rela acl audit`.
+func (c *ACLAuditCmd) Run(svc *cliServices) error {
+	policyPath := filepath.Join(svc.Paths().Root, "acl.yaml")
+	policy, err := acl.LoadPolicy(policyPath)
+	if err != nil {
+		if stderrors.Is(err, os.ErrNotExist) {
+			out.WriteSuccess("No acl.yaml found; nothing to audit (the project has no access-control policy).")
+			return nil
+		}
+		return fmt.Errorf("load acl.yaml: %w", err)
+	}
+
+	findings := aclaudit.Audit(policy, &metamodelReader{m: svc.Meta()})
+
+	if out.Format == "json" {
+		writeAuditJSON(findings)
+	} else {
+		writeAuditText(findings)
+	}
+
+	if c.ExitCode && aclaudit.HasAtLeast(findings, aclaudit.High) {
+		return errors.NewExitError(1)
+	}
+	return nil
+}
+
+// writeAuditText renders findings as human-readable lines grouped by severity.
+func writeAuditText(findings []aclaudit.Finding) {
+	if len(findings) == 0 {
+		out.WriteSuccess("ACL audit: no findings.")
+		return
+	}
+	out.WriteWarning("ACL audit: %d finding(s)", len(findings))
+	for _, f := range findings {
+		out.WriteMessage("  [%s] %s (%s: %s)", f.Severity, f.Detail, f.Rule, f.Subject)
+		if f.Fix != "" {
+			out.WriteMessage("      fix: %s", f.Fix)
+		}
+	}
+}
+
+// auditFindingJSON is the per-finding JSON shape (severity as a label, not the
+// internal int).
+type auditFindingJSON struct {
+	Rule     string `json:"rule"`
+	Severity string `json:"severity"`
+	Subject  string `json:"subject"`
+	Detail   string `json:"detail"`
+	Fix      string `json:"fix"`
+}
+
+// writeAuditJSON emits findings via the shared AnalysisResult envelope.
+func writeAuditJSON(findings []aclaudit.Finding) {
+	details := make([]auditFindingJSON, 0, len(findings))
+	for _, f := range findings {
+		details = append(details, auditFindingJSON{
+			Rule: f.Rule, Severity: f.Severity.String(), Subject: f.Subject,
+			Detail: f.Detail, Fix: f.Fix,
+		})
+	}
+	status, message := "success", "ACL audit: no findings"
+	if len(findings) > 0 {
+		status = "warning"
+		message = fmt.Sprintf("ACL audit: %d finding(s)", len(findings))
+	}
+	_ = out.WriteAnalysisResult(output.AnalysisResult{
+		Status: status, Message: message, Count: len(findings), Details: details,
+	})
+}
+
+// metamodelReader adapts *metamodel.Metamodel to aclaudit.MetamodelReader. It
+// lives here (the consumer side) rather than in internal/aclaudit, so aclaudit
+// stays free of a metamodel dependency and bounded to the narrow lookups the
+// audit actually uses.
+type metamodelReader struct {
+	m *metamodel.Metamodel
+}
+
+func (r *metamodelReader) HasEntityType(t string) bool {
+	if r.m == nil {
+		return false
+	}
+	return r.m.HasEntityType(t)
+}
+
+func (r *metamodelReader) GetRelation(name string) (aclaudit.RelationView, bool) {
+	if r.m == nil {
+		return aclaudit.RelationView{}, false
+	}
+	def, ok := r.m.GetRelationDef(name)
+	if !ok {
+		return aclaudit.RelationView{}, false
+	}
+	return aclaudit.RelationView{From: def.From}, true
+}
+
+func (r *metamodelReader) HasField(t, field string) bool {
+	if r.m == nil {
+		return false
+	}
+	def, ok := r.m.GetEntityDef(t)
+	if !ok {
+		return false
+	}
+	_, ok = def.Properties[field]
+	return ok
+}
+
+// EnumOptions returns the allowed values for an enum field on type t. A field
+// is an enum either via inline `values:` or by referencing a custom enum type
+// declared under the metamodel's top-level `types:`.
+func (r *metamodelReader) EnumOptions(t, field string) ([]string, bool) {
+	if r.m == nil {
+		return nil, false
+	}
+	def, ok := r.m.GetEntityDef(t)
+	if !ok {
+		return nil, false
+	}
+	prop, ok := def.Properties[field]
+	if !ok {
+		return nil, false
+	}
+	if len(prop.Values) > 0 {
+		return slicesClone(prop.Values), true
+	}
+	if ct, ok := r.m.Types[prop.Type]; ok && len(ct.Values) > 0 {
+		return slicesClone(ct.Values), true
+	}
+	return nil, false
+}
+
+// slicesClone returns a sorted copy so the audit's "outside the enum" message
+// is deterministic regardless of metamodel iteration.
+func slicesClone(xs []string) []string {
+	out := append([]string(nil), xs...)
+	sort.Strings(out)
+	return out
+}

--- a/internal/cli/acl.go
+++ b/internal/cli/acl.go
@@ -150,17 +150,17 @@ func (r *metamodelReader) EnumOptions(t, field string) ([]string, bool) {
 		return nil, false
 	}
 	if len(prop.Values) > 0 {
-		return slicesClone(prop.Values), true
+		return sortedClone(prop.Values), true
 	}
 	if ct, ok := r.m.Types[prop.Type]; ok && len(ct.Values) > 0 {
-		return slicesClone(ct.Values), true
+		return sortedClone(ct.Values), true
 	}
 	return nil, false
 }
 
-// slicesClone returns a sorted copy so the audit's "outside the enum" message
+// sortedClone returns a sorted copy so the audit's "outside the enum" message
 // is deterministic regardless of metamodel iteration.
-func slicesClone(xs []string) []string {
+func sortedClone(xs []string) []string {
 	out := append([]string(nil), xs...)
 	sort.Strings(out)
 	return out

--- a/internal/cli/acl.go
+++ b/internal/cli/acl.go
@@ -20,14 +20,25 @@ type ACLCmd struct {
 }
 
 // ACLAuditCmd runs the on-demand authorization-misconfiguration linter over the
-// project's acl.yaml. It is advisory by default; pass --exit-code to make CI
-// fail on critical/high findings. See internal/aclaudit (TKT-TS0J5K).
+// project's acl.yaml. It is advisory by default: it prints findings and exits 0.
+// For CI, --fail-on=<severity> (or the --exit-code alias) makes the command exit
+// non-zero when a finding at or above that severity is present. See
+// internal/aclaudit (TKT-TS0J5K).
 type ACLAuditCmd struct {
-	ExitCode bool `help:"Exit non-zero when any critical or high finding is present (for CI gating)."`
+	// FailOn gates the exit code. Empty = never fail (advisory). A severity
+	// label (critical|high|medium|low|nit) or "any" fails when a finding at or
+	// above that level is present. "any" == "nit" (every finding).
+	FailOn   string `help:"Exit non-zero when a finding at or above this severity is present: critical|high|medium|low|any. Empty = advisory (always exit 0)." enum:",critical,high,medium,low,any" default:""`
+	ExitCode bool   `help:"Alias for --fail-on=high (fail CI on critical or high findings)."`
 }
 
 // Run executes `rela acl audit`.
 func (c *ACLAuditCmd) Run(svc *cliServices) error {
+	threshold, gate, err := c.resolveFailOn()
+	if err != nil {
+		return err
+	}
+
 	policyPath := filepath.Join(svc.Paths().Root, "acl.yaml")
 	policy, err := acl.LoadPolicy(policyPath)
 	if err != nil {
@@ -46,10 +57,28 @@ func (c *ACLAuditCmd) Run(svc *cliServices) error {
 		writeAuditText(findings)
 	}
 
-	if c.ExitCode && aclaudit.HasAtLeast(findings, aclaudit.High) {
+	if gate && aclaudit.HasAtLeast(findings, threshold) {
 		return errors.NewExitError(1)
 	}
 	return nil
+}
+
+// resolveFailOn computes the exit-code gate from --fail-on / --exit-code.
+// Returns (threshold, gateEnabled, error). When gateEnabled is false the
+// command is advisory and always exits 0. --exit-code is sugar for
+// --fail-on=high; if both are set, --fail-on wins (the explicit threshold).
+func (c *ACLAuditCmd) resolveFailOn() (aclaudit.Severity, bool, error) {
+	if c.FailOn != "" {
+		threshold, ok := aclaudit.ParseSeverity(c.FailOn)
+		if !ok {
+			return 0, false, fmt.Errorf("invalid --fail-on %q: want one of critical, high, medium, low, any", c.FailOn)
+		}
+		return threshold, true, nil
+	}
+	if c.ExitCode {
+		return aclaudit.High, true, nil
+	}
+	return 0, false, nil
 }
 
 // writeAuditText renders findings as human-readable lines grouped by severity.

--- a/internal/cli/acl_test.go
+++ b/internal/cli/acl_test.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"encoding/json"
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
+	"github.com/Sourcehaven-BV/rela/internal/errors"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/output"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+func stringContainsACL(s, sub string) bool { return strings.Contains(s, sub) }
+
+// aclTestServices wires a cliServices whose project Root is a real temp dir
+// (acl.LoadPolicy reads acl.yaml from the OS filesystem). aclYAML, when
+// non-empty, is written to <root>/acl.yaml.
+func aclTestServices(t *testing.T, meta *metamodel.Metamodel, aclYAML string) *cliServices {
+	t.Helper()
+	root := t.TempDir()
+	if aclYAML != "" {
+		if err := os.WriteFile(filepath.Join(root, "acl.yaml"), []byte(aclYAML), 0o600); err != nil {
+			t.Fatalf("write acl.yaml: %v", err)
+		}
+	}
+	paths := &project.Context{Root: root, CacheDir: filepath.Join(root, ".rela")}
+	svc, err := newCLIServicesFromAppbuild(
+		appbuildtest.New(meta, appbuildtest.WithFS(storage.NewOsFS(), paths)),
+	)
+	if err != nil {
+		t.Fatalf("build cli services: %v", err)
+	}
+	return svc
+}
+
+func aclTestMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {Label: "Ticket", IDPrefix: "TKT-", Properties: map[string]metamodel.PropertyDef{}},
+		},
+	}
+}
+
+// A policy with an un-gated member-of + privileged assignment produces an A1
+// high finding; --exit-code then returns a non-zero ExitError.
+func TestACLAudit_ExitCodeOnHigh(t *testing.T) {
+	const policy = `
+roles:
+  editor:
+    create: [ticket]
+    read: [ticket]
+assignments:
+  engineering: editor
+`
+	svc := aclTestServices(t, aclTestMeta(), policy)
+	withOutput(t, output.FormatTable)
+
+	cmd := &ACLAuditCmd{ExitCode: true}
+	err := cmd.Run(svc)
+	var exitErr *errors.ExitError
+	if !stderrors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError for a high finding, got %v", err)
+	}
+	if exitErr.Code == 0 {
+		t.Errorf("ExitError code = 0, want non-zero")
+	}
+}
+
+// A clean, well-gated policy produces no findings; --exit-code returns nil.
+func TestACLAudit_CleanPolicyExitsZero(t *testing.T) {
+	const policy = `
+user_entity_type: person
+roles:
+  admin:
+    create: [ticket]
+    update: [ticket]
+    delete: [ticket]
+    read: [ticket]
+    permissions: [delegate-membership]
+  everyone:
+    read: ["*"]
+assignments:
+  ops-team: admin
+role_relations:
+  member-of:
+    requires_permission: delegate-membership
+`
+	meta := aclTestMeta()
+	meta.Entities["person"] = metamodel.EntityDef{Label: "Person", IDPrefix: "PERS-", Properties: map[string]metamodel.PropertyDef{}}
+	meta.Relations = map[string]metamodel.RelationDef{"member-of": {From: []string{"person"}, To: []string{"group"}}}
+	meta.Entities["group"] = metamodel.EntityDef{Label: "Group", IDPrefix: "GRP-", Properties: map[string]metamodel.PropertyDef{}}
+
+	svc := aclTestServices(t, meta, policy)
+	buf := withOutput(t, output.FormatTable)
+
+	cmd := &ACLAuditCmd{ExitCode: true}
+	if err := cmd.Run(svc); err != nil {
+		t.Fatalf("clean policy must exit 0, got %v", err)
+	}
+	if got := buf.String(); !stringContainsACL(got, "no findings") {
+		t.Errorf("expected 'no findings' in output, got: %s", got)
+	}
+}
+
+// JSON output uses the AnalysisResult envelope with the findings as details.
+func TestACLAudit_JSONOutput(t *testing.T) {
+	// everyone with a write grant (covered by read, so Validate accepts it) →
+	// A3 critical from the audit.
+	const policy = `
+roles:
+  everyone:
+    update: [ticket]
+    read: [ticket]
+`
+	svc := aclTestServices(t, aclTestMeta(), policy)
+	buf := withOutput(t, output.FormatJSON)
+
+	cmd := &ACLAuditCmd{}
+	if err := cmd.Run(svc); err != nil { // no --exit-code: must not error
+		t.Fatalf("audit run error: %v", err)
+	}
+	var result output.AnalysisResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal JSON: %v", err)
+	}
+	if result.Status != "warning" {
+		t.Errorf("status = %q, want warning", result.Status)
+	}
+	if result.Count == 0 {
+		t.Errorf("expected non-zero finding count for everyone:update")
+	}
+}
+
+// No acl.yaml → success message, no error (nothing to audit).
+func TestACLAudit_NoPolicyFile(t *testing.T) {
+	svc := aclTestServices(t, aclTestMeta(), "") // no acl.yaml written
+	buf := withOutput(t, output.FormatTable)
+
+	cmd := &ACLAuditCmd{ExitCode: true}
+	if err := cmd.Run(svc); err != nil {
+		t.Fatalf("missing acl.yaml must not error, got %v", err)
+	}
+	if got := buf.String(); !stringContainsACL(got, "nothing to audit") {
+		t.Errorf("expected 'nothing to audit', got: %s", got)
+	}
+}

--- a/internal/cli/acl_test.go
+++ b/internal/cli/acl_test.go
@@ -72,6 +72,56 @@ assignments:
 	}
 }
 
+// --fail-on sets the exit-code threshold. A policy whose worst finding is
+// medium (A9 wildcard-write) exits 0 at the default high gate but non-zero at
+// --fail-on=medium / =any — so medium/low warnings don't break CI unless the
+// operator opts in.
+func TestACLAudit_FailOnThreshold(t *testing.T) {
+	// A9 wildcard-write (medium) is the worst finding; no critical/high.
+	const policy = `
+roles:
+  power:
+    create: ["*"]
+    update: ["*"]
+    delete: ["*"]
+    read: ["*"]
+`
+	cases := []struct {
+		name      string
+		cmd       ACLAuditCmd
+		wantError bool
+	}{
+		{"advisory default", ACLAuditCmd{}, false},
+		{"exit-code alias (=high)", ACLAuditCmd{ExitCode: true}, false},
+		{"fail-on high", ACLAuditCmd{FailOn: "high"}, false},
+		{"fail-on medium", ACLAuditCmd{FailOn: "medium"}, true},
+		{"fail-on any", ACLAuditCmd{FailOn: "any"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := aclTestServices(t, aclTestMeta(), policy)
+			withOutput(t, output.FormatTable)
+			err := tc.cmd.Run(svc)
+			var exitErr *errors.ExitError
+			gotError := stderrors.As(err, &exitErr)
+			if gotError != tc.wantError {
+				t.Errorf("%s: gotError=%v (err=%v), want %v", tc.name, gotError, err, tc.wantError)
+			}
+		})
+	}
+}
+
+// An invalid --fail-on value is rejected with a clear error (belt-and-suspenders
+// behind Kong's enum tag).
+func TestACLAudit_FailOnInvalid(t *testing.T) {
+	svc := aclTestServices(t, aclTestMeta(), "roles:\n  everyone:\n    read: [\"*\"]\n")
+	withOutput(t, output.FormatTable)
+	cmd := &ACLAuditCmd{FailOn: "bogus"}
+	if err := cmd.Run(svc); err == nil {
+		t.Fatal("expected an error for --fail-on=bogus, got nil")
+	}
+}
+
 // A clean, well-gated policy produces no findings; --exit-code returns nil.
 func TestACLAudit_CleanPolicyExitsZero(t *testing.T) {
 	const policy = `

--- a/internal/cli/kong.go
+++ b/internal/cli/kong.go
@@ -48,7 +48,7 @@ var (
 // so growth is structural here) — over the 20-field load line. Revisit grouping
 // subcommands into sub-structs; ratchet this number down if/when that lands.
 //
-//plimsoll:max-fields=38
+//plimsoll:max-fields=39
 type CLI struct {
 	// Global flags.
 	Project string `help:"Project directory (default: auto-detect from cwd)." env:"RELA_PROJECT"`
@@ -83,6 +83,7 @@ type CLI struct {
 	Schema      SchemaCmd      `cmd:"" help:"View the metamodel schema."`
 	Template    TemplateCmd    `cmd:"" help:"Manage entity and relation templates."`
 	Analyze     AnalyzeCmd     `cmd:"" help:"Analyze the entity graph."`
+	ACL         ACLCmd         `cmd:"" name:"acl" help:"Audit the ACL policy (acl.yaml)."`
 	Rename      RenameCmd      `cmd:"" help:"Rename entities or relations."`
 	Attach      AttachCmd      `cmd:"" help:"Attach file(s) to an entity."`
 	Attachments AttachmentsCmd `cmd:"" help:"List attachments for an entity."`
@@ -195,7 +196,7 @@ func requiresProject(cmd string) bool {
 	case "show", "list", "trace", "graph", "export", "fmt", "schema",
 		"template", "create", "update", "delete", "link", "unlink",
 		"detach", "import", "normalize", "script", "scheduler",
-		"rename", "analyze", "attach", "attachments", "gc", "renumber",
+		"rename", "analyze", "acl", "attach", "attachments", "gc", "renumber",
 		"sync":
 		return true
 	}

--- a/scripts/demo-acl-audit.sh
+++ b/scripts/demo-acl-audit.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# End-to-end demo of `rela acl audit`: seed a metamodel plus several acl.yaml
+# policies (clean, un-gated membership, everyone-admin, schema drift) and assert
+# the linter reports the right findings and gates its exit code on --fail-on.
+# Doubles as a smoke test for the CLI wiring (load → audit → render → exit).
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="${REPO}/bin/rela"
+DEMO="$(mktemp -d -t rela-acl-audit-demo.XXXXXX)"
+
+cleanup() { rm -rf "${DEMO}"; }
+trap cleanup EXIT
+
+say() { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+step() { printf '    %s\n' "$*"; }
+
+say "Building rela → ${BIN}"
+(cd "${REPO}" && go build -o "${BIN}" ./cmd/rela)
+
+# A shared metamodel for every policy below: person/group/ticket, plus two
+# candidate membership relations (member-of, heeft_rol).
+seed_metamodel() {
+    local dir="$1"
+    mkdir -p "${dir}"
+    cat > "${dir}/metamodel.yaml" <<'YAML'
+version: "1"
+namespace: "https://example.com/acl-demo#"
+entities:
+  person:
+    label: Person
+    id_prefix: "PERS-"
+    id_type: sequential
+    properties:
+      name: {type: string, required: true}
+  group:
+    label: Group
+    id_prefix: "GRP-"
+    id_type: sequential
+    properties:
+      name: {type: string, required: true}
+  ticket:
+    label: Ticket
+    id_prefix: "TKT-"
+    id_type: sequential
+    properties:
+      title: {type: string, required: true}
+      status: {type: string, values: [open, doing, done]}
+relations:
+  member-of:
+    label: member of
+    from: [person]
+    to: [group]
+  heeft_rol:
+    label: heeft rol
+    from: [person]
+    to: [group]
+YAML
+}
+
+# run_audit <dir> [flags...] → prints output, returns the audit's exit code.
+run_audit() {
+    local dir="$1"; shift
+    "${BIN}" --project "${dir}" acl audit "$@"
+}
+
+# expect_rc <label> <expected-rc> <dir> [flags...]
+expect_rc() {
+    local label="$1" want="$2" dir="$3"; shift 3
+    local got=0
+    run_audit "${dir}" "$@" >/dev/null 2>&1 || got=$?
+    if [ "${got}" -eq "${want}" ]; then
+        step "✓ ${label} (exit ${got})"
+    else
+        step "✗ ${label}: exit ${got}, want ${want}"
+        run_audit "${dir}" "$@" || true
+        exit 1
+    fi
+}
+
+# expect_finding <label> <dir> <rule-id>
+expect_finding() {
+    local label="$1" dir="$2" rule="$3"
+    if run_audit "${dir}" 2>&1 | grep -q "${rule}"; then
+        step "✓ ${label} (${rule})"
+    else
+        step "✗ ${label}: expected finding ${rule}"
+        run_audit "${dir}" || true
+        exit 1
+    fi
+}
+
+# refute_finding <label> <dir> <rule-id>
+refute_finding() {
+    local label="$1" dir="$2" rule="$3"
+    if run_audit "${dir}" 2>&1 | grep -q "${rule}"; then
+        step "✗ ${label}: unexpected finding ${rule}"
+        run_audit "${dir}" || true
+        exit 1
+    else
+        step "✓ ${label} (no ${rule})"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+say "1. Clean, well-gated policy → no findings, exits 0 at every threshold"
+CLEAN="${DEMO}/clean"
+seed_metamodel "${CLEAN}"
+cat > "${CLEAN}/acl.yaml" <<'YAML'
+user_entity_type: person
+roles:
+  admin:
+    create: [ticket]
+    update: [ticket]
+    delete: [ticket]
+    read: [ticket]
+    permissions: [delegate-membership]
+  everyone:                 # read-only everyone is a legitimate pattern
+    read: ["*"]
+assignments:
+  ops-team: admin
+role_relations:
+  member-of:
+    requires_permission: delegate-membership
+YAML
+run_audit "${CLEAN}"
+expect_rc "clean: advisory"        0 "${CLEAN}"
+expect_rc "clean: --fail-on=any"   0 "${CLEAN}" --fail-on=any
+
+# ---------------------------------------------------------------------------
+say "2. Un-gated membership relation → A1 (high)"
+UNGATED="${DEMO}/ungated"
+seed_metamodel "${UNGATED}"
+cat > "${UNGATED}/acl.yaml" <<'YAML'
+roles:
+  editor:
+    create: [ticket]
+    update: [ticket]
+    delete: [ticket]
+    read: [ticket]
+assignments:
+  engineering: editor
+YAML
+run_audit "${UNGATED}" || true
+expect_finding "un-gated member-of flagged" "${UNGATED}" "A1-ungated-membership"
+expect_rc "ungated: --fail-on=high fails CI" 1 "${UNGATED}" --fail-on=high
+
+# ---------------------------------------------------------------------------
+say "3. Privileged 'everyone' role → A3 (critical); read-only everyone does not"
+EVERYONE="${DEMO}/everyone"
+seed_metamodel "${EVERYONE}"
+cat > "${EVERYONE}/acl.yaml" <<'YAML'
+roles:
+  everyone:
+    update: [ticket]
+    read: [ticket]
+YAML
+run_audit "${EVERYONE}" || true
+expect_finding "write-granting everyone flagged" "${EVERYONE}" "A3-everyone-privileged"
+refute_finding "read-only everyone NOT flagged" "${CLEAN}" "A3-everyone-privileged"
+
+# ---------------------------------------------------------------------------
+say "4. Schema drift → B1 (undeclared type) + B2 (undeclared relation) + A4"
+DRIFT="${DEMO}/drift"
+seed_metamodel "${DRIFT}"
+cat > "${DRIFT}/acl.yaml" <<'YAML'
+membership_relation: heeft_roll     # typo: heeft_rol
+roles:
+  editor:
+    create: [tickets]               # typo: ticket
+    read: [tickets]
+assignments:
+  engineering: edutor               # typo: editor
+YAML
+run_audit "${DRIFT}" || true
+expect_finding "undeclared type flagged"     "${DRIFT}" "B1-undeclared-type"
+expect_finding "undeclared relation flagged" "${DRIFT}" "B2-undeclared-relation"
+expect_finding "assignment to unknown role"  "${DRIFT}" "A4-assignment-unknown-role"
+
+# ---------------------------------------------------------------------------
+say "5. --fail-on threshold: medium-only findings gate as expected"
+WARN="${DEMO}/warn"
+seed_metamodel "${WARN}"
+cat > "${WARN}/acl.yaml" <<'YAML'
+roles:                              # A9 wildcard write (medium) is the worst
+  power:
+    create: ["*"]
+    update: ["*"]
+    delete: ["*"]
+    read: ["*"]
+YAML
+run_audit "${WARN}" || true
+expect_rc "medium-only: advisory"       0 "${WARN}"
+expect_rc "medium-only: --fail-on=high" 0 "${WARN}" --fail-on=high
+expect_rc "medium-only: --fail-on=medium fails" 1 "${WARN}" --fail-on=medium
+expect_rc "medium-only: --fail-on=any fails"    1 "${WARN}" --fail-on=any
+
+# ---------------------------------------------------------------------------
+say "6. JSON output → AnalysisResult envelope"
+JSON="$(run_audit "${EVERYONE}" -o json)"
+printf '%s\n' "${JSON}"
+if printf '%s' "${JSON}" | grep -q '"status": "warning"' \
+    && printf '%s' "${JSON}" | grep -q '"rule": "A3-everyone-privileged"'; then
+    step "✓ JSON envelope carries status + rule"
+else
+    step "✗ JSON envelope missing expected fields"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+say "7. No acl.yaml → nothing to audit, exits 0"
+NONE="${DEMO}/none"
+seed_metamodel "${NONE}"   # metamodel only, no acl.yaml
+run_audit "${NONE}"
+expect_rc "no policy: --fail-on=any still exits 0" 0 "${NONE}" --fail-on=any
+
+say "Done — all acl audit assertions passed."

--- a/tickets/entities/docs-checklists/DOCS-B93LL3.md
+++ b/tickets/entities/docs-checklists/DOCS-B93LL3.md
@@ -1,0 +1,34 @@
+---
+id: DOCS-B93LL3
+type: docs-checklist
+title: 'Docs: rela acl audit linter'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Package godoc on `internal/aclaudit` (tier model, Validate-vs-audit distinction)
+- [x] Godoc on `Finding`, `Severity`, `MetamodelReader`, `Audit`, `ParseSeverity`, `HasAtLeast`, `isPrivileged`
+- [x] Each check function documents its rule + rationale (RR-references for the gating decisions)
+- [x] CLI `ACLAuditCmd` godoc (advisory default, `--fail-on`/`--exit-code`)
+- [x] `Policy.EffectiveMembershipRelation` godoc (single source of truth note)
+
+## Project Documentation
+
+- [x] `docs-project/.../GUIDE-acl-security.md` → `docs/acl-security.md` — "Auditing your policy with rela acl audit" section: what it catches, the two tiers, `--fail-on` thresholds, **production `--fail-on=any` recommendation** (crit)
+- [x] `docs/security.md` (hand-maintained) — references `rela acl audit --fail-on=high` as the hardening check
+- [x] `just docs` regenerated; idempotent
+- [x] `scripts/demo-acl-audit.sh` — runnable e2e demo (crit); auto-run by CI Demos job
+- [x] ~~docs/cli-reference.md~~ (N/A: not a generated doc in this repo; the command is documented in the security guide)
+
+## External Documentation
+
+- [x] ~~README / changelog~~ (N/A: surfaced via the ACL security guide)
+
+## Verification
+
+- [x] `just docs-check` parity (generated docs in sync with sources)
+- [x] Demo script passes end-to-end; help text (`rela acl audit --help`) shows `--fail-on`/`--exit-code`
+- [x] Crit human review round 1 — all comments addressed

--- a/tickets/entities/implementation-checklists/IMPL-NDR4NG.md
+++ b/tickets/entities/implementation-checklists/IMPL-NDR4NG.md
@@ -1,0 +1,81 @@
+---
+id: IMPL-NDR4NG
+type: implementation-checklist
+title: 'Implementation: ACL: dedicated authorization-misconfiguration validator / audit insights (escalation foot-guns, dead assignments, un-gated membership)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (24 in aclaudit, 4 CLI)
+- [x] Integration tests written (CLI command end-to-end through real LoadPolicy + render + exit-code)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled (nil meta; "*" sentinel; everyone read-only; whitespace)
+- [x] Error handling in place (LoadPolicy errors surfaced; missing acl.yaml → exit 0)
+
+## Test Quality
+
+- [x] fakeMetamodel fixture for Tier-B; real temp-dir acl.yaml for CLI
+- [x] No hardcoded values where an object is in scope (assert on Rule constants / Severity)
+- [x] Only specifying values that matter; negative case per check
+- [x] Golden clean-policy fixture (anti-false-positive guard)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (built `rela`, ran `acl audit` on a temp project)
+- [x] Each acceptance criterion verified
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+New code:
+- `internal/aclaudit/` — `Audit(policy, MetamodelReader) []Finding`; `Finding{Rule,
+Severity, Subject, Detail, Fix}` + 5-level `Severity`; `HasAtLeast`; narrow
+`MetamodelReader` interface; `isPrivileged` (RR-LXI3NW); Tier A (A1, A1b, A2,
+A3, A4, A5, A6, A7, A9, A10) in tier_a.go; Tier B (B1, B2, B3, B4, B5, B7) in
+tier_b.go. Deterministic sort (severity, rule, subject).
+- `internal/cli/acl.go` — `rela acl audit` (`--exit-code`, `-o json`); the
+metamodel adapter over `*metamodel.Metamodel` (consumer side, keeps aclaudit's
+dep to `[acl]`).
+- `internal/cli/kong.go` — registered `ACL ACLCmd`; added `"acl"` to
+`requiresProject`; bumped CLI `//plimsoll:max-fields` 38→39 (registry field).
+- `.go-arch-lint.yml` — `aclaudit` component, `mayDependOn: [acl]`, cli→aclaudit.
+
+Validate migration (TKT-Z8A62F follow-through):
+- Removed `warnMembershipRelationHardening` + its call from `Policy.Validate`;
+Validate is a pure structural gate again. Exported
+`Policy.EffectiveMembershipRelation()` (resolver + audit share one source of
+truth). Deleted the two membership warn-tests from policy_test.go; behaviour
+re-asserted as aclaudit findings A1/A1b.
+
+Manual smoke (temp project, intentionally misconfigured):
+- `everyone: update` → A3 critical; un-gated member-of + assignment → A1 high;
+`update: [tickets]` typo → B1 high. Sorted critical→high. `--exit-code` → rc 1.
+- `-o json` → AnalysisResult envelope (status warning, count 3, details[]).
+- Clean gated policy → "no findings", rc 0.
+
+Gate results (all green):
+- `go build ./...` — OK
+- `go test -race ./internal/{acl,aclaudit,cli,appbuild,dataentry,mcp}/...` — ok
+- `golangci-lint run` (aclaudit, acl, cli) — 0 issues
+- `just arch-lint` — no warnings (aclaudit component added)
+- `just plimsoll` — rc 0 (narrow MetamodelReader; CLI field pin bumped)
+- `just coverage-check` — PASS (aclaudit 89.8%; total 76.9%)
+- `just docs` — regenerated, idempotent; `rela acl audit` documented in
+GUIDE-acl-security → docs/acl-security.md
+
+Branch note: stacked on `feat/acl-configurable-membership-relation` (PR #1060),
+because this ticket migrates the membership warns that only exist there. The PR
+targets that branch (or develop once #1060 merges).
+
+## Quality
+
+- [x] Follows project patterns (Kong `DBCmd`/`AnalyzeCmd` model; `output.AnalysisResult`;
+consumer-side interface per CLAUDE.md)
+- [x] DRY — single `isPrivileged` / `EffectiveMembershipRelation`; shared sort helpers
+- [x] No security issues introduced — audit is read-only, makes no auth decisions;
+conservative gating prevents false-positive criticals (golden clean-policy test)
+- [x] No silent failures (LoadPolicy errors returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-BFB9EJ.md
+++ b/tickets/entities/planning-checklists/PLAN-BFB9EJ.md
@@ -1,0 +1,188 @@
+---
+id: PLAN-BFB9EJ
+type: planning-checklist
+title: 'Planning: ACL: dedicated authorization-misconfiguration validator / audit insights (escalation foot-guns, dead assignments, un-gated membership)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood (RES-VWNN2T)
+- [x] Scope defined (v1 = Tier A+B; C/D + MCP + strict-mode deferred)
+- [x] Acceptance criteria documented (7 in ticket body)
+
+**Scope:** IN — new `internal/aclaudit` analyzer (pure-policy Tier A + metamodel
+Tier B), `rela acl audit` Kong command (`--json`, `--exit-code`), migrate the
+two membership warns out of `Policy.Validate`. OUT — Tier C (graph), Tier D
+(reachability), MCP `analyze_acl`, opt-in strict boot mode.
+
+**Acceptance:** the 7 criteria in the ticket. Each maps to a test below.
+
+## Research
+
+- [x] `/research` run → RES-VWNN2T (done). Package boundary, finding taxonomy,
+Validate-migration all decided there.
+- [x] Existing solutions checked: `internal/validator` + `schema/validate_properties.go`
+(store+metamodel cross-check pattern); `DBCmd`/`AnalyzeCmd` (Kong group +
+`--exit-code`); `output.AnalysisResult` (JSON envelope).
+
+**Research Doc:** RES-VWNN2T
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Builds on existing patterns
+- [x] Alternatives considered (in research: aclaudit vs analysis vs acl)
+- [x] Dependencies identified
+
+**Technical approach (file by file):**
+
+1. **`internal/aclaudit/aclaudit.go`** — core.
+   - `type Severity int` (Critical/High/Medium/Low/Nit) + `String()`.
+   - `type Finding struct { Rule string; Severity Severity; Subject, Detail, Fix string }`.
+   - `type MetamodelReader interface` — narrow consumer-side: `HasEntityType(string) bool`,
+`GetRelationDef(string) (RelationView, bool)` (or expose `.From []string`),
+`EnumOptions(entityType, field string) ([]string, bool)`. Defined HERE (call
+site), implemented by a thin adapter in the CLI over `*metamodel.Metamodel`.
+   - `func Audit(p *acl.Policy, m MetamodelReader) []Finding` — runs all Tier A
+checks (pure-policy, m may be nil-tolerant for A-only callers) then Tier B
+(skipped if m == nil). Deterministic order (sort by severity then Rule then
+Subject).
+   - One small unexported func per check (A1..A10, B1..B7) appending Findings.
+Reuse `acl` exported surface: `p.Roles`, `p.Assignments`, `p.RoleRelations`,
+`p.MembershipRelation` + `acl.EveryoneRole`. NOTE: `membershipRelation()` is
+unexported — either export an `EffectiveMembershipRelation()` on Policy (tiny
+acl change) or replicate the trim/default here. Decide in impl; leaning export,
+since the audit must see the SAME effective value the resolver walks.
+2. **`internal/aclaudit/metamodel_adapter.go`** OR keep adapter in CLI — a
+`metamodelReader` wrapping `*metamodel.Metamodel` implementing the interface via
+`HasEntityType`, `GetRelationDef` (→ `.From`), and the enum lookup
+(`EntityDef.Properties[f].Values` else `Metamodel.Types[prop.Type].Values`). Put
+the adapter in the CLI package (consumer side) to keep `aclaudit` free of a
+metamodel import IF we want aclaudit to depend only on acl. **Decision:**
+aclaudit defines the interface; the adapter lives wherever the concrete
+`*metamodel.Metamodel` is held = the CLI. That keeps aclaudit's arch-lint dep to
+`[acl]` only for v1 (revisit when Tier C needs store). Update research note.
+3. **`internal/cli/acl.go`** — `ACLCmd{ Audit AclAuditCmd }`; `AclAuditCmd{ JSON
+bool; ExitCode bool }` with `Run(ctx, svc *cliServices) error`: load
+`acl.LoadPolicy(filepath.Join(svc.Paths().Root, "acl.yaml"))` (handle
+`errors.Is(os.ErrNotExist)` → "no acl.yaml; nothing to audit", exit 0); build
+the metamodel adapter over `svc.Meta()`; `findings := aclaudit.Audit(p,
+adapter)`; render text (`out.Write*`) or JSON (`output.AnalysisResult`); if
+`--exit-code` and any Critical/High → return a non-zero-exit error.
+4. **`internal/cli/kong.go`** — add `ACL ACLCmd \`cmd:"" help:"Audit the ACL policy (acl.yaml)."\``to the root`CLI` struct.
+5. **`internal/acl/policy.go`** — remove `warnMembershipRelationHardening` + its
+call in `Validate`; (likely) add exported `EffectiveMembershipRelation()`
+wrapping `membershipRelation()` so the audit reads the same value.
+6. **`internal/acl/policy_test.go`** — delete `TestPolicy_MembershipRelation_UngatedWarns`
+/ `GatedNoWarn`; their behaviour re-asserted in `aclaudit` tests.
+7. **`.go-arch-lint.yml`** — add `aclaudit: { in: internal/aclaudit }` and a deps
+entry `aclaudit: mayDependOn: [acl]` (v1). cli already may depend on acl +
+metamodel + aclaudit (verify cli deps list; add aclaudit).
+8. **Docs** — `docs/security.md` / `GUIDE-acl-security.md`: note `rela acl audit`
+as the hardening-check tool; regenerate.
+
+**Alternatives rejected (research):** folding into `internal/analysis`;
+extending `internal/acl` (arch-lint forbids acl→metamodel).
+
+**Files to modify/create:**
+- NEW `internal/aclaudit/{aclaudit.go, aclaudit_test.go}` (+ maybe metamodel adapter)
+- NEW `internal/cli/acl.go` (+ `acl_test.go`)
+- `internal/cli/kong.go`, `internal/acl/policy.go`, `internal/acl/policy_test.go`
+- `.go-arch-lint.yml`
+- `docs/security.md` + `docs-project/.../GUIDE-acl-security.md`
+
+## Security Considerations
+
+- [x] Input sources: `acl.yaml` (operator config) + metamodel (operator schema).
+Read-only; the audit makes no writes and no auth decisions — it only reports.
+- [x] The audit must not itself be a foot-gun: a clean policy MUST report zero
+findings (no false criticals that train operators to ignore output). Each check
+gated narrowly (e.g. A3 only fires when the everyone-role actually grants
+write/permissions, not merely exists).
+- [x] `--exit-code` semantics fixed: non-zero only on Critical/High, so Low/Nit
+noise can't break a pipeline.
+- [x] No sensitive info leak: findings name policy/schema identifiers the
+operator already owns.
+
+## Test Plan
+
+- [x] Per-criterion scenarios; edge cases; negatives; integration
+
+**Test scenarios (`aclaudit_test.go`, table-driven, a fakeMetamodelReader):**
+- AC1 → un-gated membership + privileged assignment → A1 (high) present.
+- AC2 → write-role on `everyone` → A3 (critical).
+- AC3 → grant naming undeclared type → B1; `membership_relation` undeclared → B2.
+- AC4 → clean well-gated policy → zero findings.
+- Each remaining check (A1b/A2/A4/A5/A6/A7/A9/A10, B3/B4/B5/B7) → one positive +
+one negative case proving it doesn't false-fire on clean config.
+- Determinism: findings sorted stable (severity, rule, subject).
+- Migration: the two ex-Validate behaviours (un-gated/inert membership) now
+assert via `aclaudit` (relocated from policy_test.go).
+
+**CLI tests (`acl_test.go`):** golden text + `--json` envelope shape;
+`--exit-code` returns non-zero on a critical-bearing policy, zero on clean;
+missing acl.yaml → exit 0 with a "nothing to audit" message.
+
+**Edge cases:** nil metamodel reader (Tier A still runs, Tier B skipped);
+wildcard `["*"]` interaction with A9 vs B1 (a `"*"` grant is not an undeclared
+type — B1 must skip `"*"`); `everyone` role with only `read` (A3 should NOT fire
+— read isn't privileged escalation, only write/permissions).
+
+## Risk Assessment
+
+- [x] Risks + mitigations; effort
+
+**Risks:**
+- MED: false-positive criticals erode trust. Mitigation: AC4 clean-policy test +
+a negative case per check; conservative gating (A3 = write/perms only).
+- LOW: `membershipRelation()` is unexported — audit could drift from the real
+effective value. Mitigation: export `EffectiveMembershipRelation()` and have
+both resolver and audit use it (single source of truth, extends TKT-Z8A62F's
+accessor discipline).
+- LOW: arch-lint/plimsoll. Mitigation: narrow interface; new component entry;
+run `just arch-lint` + `just plimsoll` before PR.
+
+**Effort:** m (~250 LOC core + checks, ~300 LOC tests, CLI + arch-lint + docs).
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created at implementation
+
+**Documentation Impact:**
+- [x] docs/security.md + GUIDE-acl-security.md — document `rela acl audit`
+- [x] docs/cli-reference.md (if generated) — the new command
+- [ ] ~~metamodel.md / data-entry.md~~ (N/A)
+
+## Design Review
+
+- [x] Ran `/design-review` before implementation
+- [x] All significant findings folded into the gating rules below
+
+**Design Review Findings (all addressed):**
+
+- **RR-LXI3NW (significant)** — "privileged role" is undefined; the ACL has no
+built-in privilege notion. RESOLUTION: define `isPrivileged(role)` in `aclaudit`
+= grants any write (`Create`/`Update`/`Delete` non-empty, incl. `"*"`) OR holds
+any `Permissions`. A2/A3 reference this one helper; the highest-signal sub-case
+(a `delegate-*` permission or a wildcard write) drives wording. Documented +
+unit-tested.
+- **RR-UR0LJU (significant)** — A9 would false-positive on the documented
+`everyone: read: ["*"]`. RESOLUTION: A9 flags ONLY write/permission wildcards
+(`create/update/delete: ["*"]` or a delegate permission); `read: ["*"]` is NEVER
+flagged. Mandatory negative test: `everyone: read: ["*"]` → zero A9.
+- **RR-O7H3GY (minor)** — A6 can be an intentional lockdown. RESOLUTION: A6 →
+**low/info**, worded as a question ("no principal can write X — intended?").
+- **RR-TZ2S3G (minor)** — Tier-B grant-list checks must skip the `"*"` sentinel.
+RESOLUTION: B1 (and any check reading verb lists) skips `"*"`; affordance map
+KEYS (no wildcard) are checked directly. Mandatory test: wildcard role → zero
+B1.
+
+**New audit-wide invariant (from these findings):** every check ships with a
+NEGATIVE test proving silence on clean/legitimate config, AND the full
+docs/acl-overview.md worked-example policy is run through `Audit` as a golden
+"expected findings" fixture — so a future check can't silently start flagging
+the recommended baseline.

--- a/tickets/entities/researchs/RES-VWNN2T.md
+++ b/tickets/entities/researchs/RES-VWNN2T.md
@@ -1,0 +1,202 @@
+---
+id: RES-VWNN2T
+type: research
+title: How should the ACL auth-misconfiguration audit be structured (package boundary, finding taxonomy, Validate migration)?
+summary: Build the audit as a new internal/aclaudit package (arch-lint forbids acl→metamodel; folding into analysis couples a broad facade to security) taking a narrow consumer-side MetamodelReader; typed Finding with a 5-level severity enum; rela acl audit Kong command with --exit-code; migrate the two membership warns out of Validate. v1 = Tier A+B.
+status: done
+---
+
+## Problem
+
+`Policy.Validate` is a tolerant-by-design **boot gate**: it hard-errors only on
+security-critical structural invariants (`update⊆read`, blank relation keys) and
+is policy-internal — it never sees the metamodel or the graph. Three classes of
+misconfiguration are therefore invisible today:
+
+1. **Escalation foot-guns** — structurally-valid config that lets a principal
+grant themselves power (un-gated membership relation / role-relation, privileged
+role on `everyone`).
+2. **Dead / inert config** — rules that silently never fire: assignment to an
+undeclared role, `confers` an undeclared role, a `requires_permission` no role
+grants, a typo'd type name.
+3. **Policy-vs-metamodel drift** — grants naming entity types, relation types,
+fields, or enum options the schema doesn't define. These fail *silently* today
+(the grant just matches nothing).
+
+TKT-Z8A62F bolted two ad-hoc `slog.Warn` hardening checks into `Validate` —
+advisory analysis living in a boot gate, the wrong home. This research decides
+how to build a proper on-demand audit (`rela acl audit`) and where it lives.
+
+Decisions already taken with the user (inputs to this research, not open):
+- v1 = Tier A (pure-policy) + Tier B (metamodel cross-check). Tier C (graph) and
+Tier D (reachability) are follow-ups.
+- Primary surface = a CLI subcommand `rela acl audit`.
+- Audit is advisory; never blocks boot. `Validate` keeps its structural gating.
+CI enforcement is opt-in via `--exit-code` (a pipeline choice).
+- The two membership `slog.Warn`s migrate OUT of `Validate` INTO the audit.
+
+## Context
+
+**The ACL surface the audit reasons over** (`internal/acl/policy.go`):
+- `Policy{UserEntityType, MembershipRelation, Roles, Assignments, RoleRelations,
+InheritRolesThrough}`.
+- `RoleDef{Create/Update/Delete/Read []string, Permissions []string, Fields/
+Visible/Options/Relations maps}` — `"*"` wildcard per verb.
+- `RoleRelationDef{Confers, RequiresPermission}` — empty `RequiresPermission`
+disables the delegate-X gate (the foot-gun).
+- `EveryoneRole = "everyone"` — held by every principal.
+- Resolver skips `role_relations` whose `confers` role isn't declared, and
+assignments to undeclared roles — i.e. these are *silently inert* today
+(confirmed in `resolver.go` computeForEntity / computeGlobals).
+
+**Existing analyzer prior art** (survey, file:line):
+- No unified `Finding` base struct. Each analyzer owns its result type:
+`analysis.CardinalityViolation`, `validation.Violation{RuleName, Description,
+Severity string, EntityID, EntityTitle}`
+(`internal/validation/validation.go:15`), `schema.PropertyError`,
+`schema.Analysis`. Severity is a **string** (`"error"`/`"warning"`), counted
+post-hoc.
+- CLI render: unified envelope `output.AnalysisResult{Status, Message, Count,
+Details interface{}}` (`internal/output/output.go`), text via `out.Write*`.
+- MCP render: text + embedded JSON (`internal/mcp/tools_analysis.go`), not the
+envelope.
+- `internal/analysis` is the read-only **service facade** both CLI and MCP call;
+constructed via `analysis.New(analysis.Deps{Store, Meta, Tracer, ...})`
+(`internal/cli/cli_wiring.go:157`).
+- **Metamodel cross-check is already a solved pattern**: `internal/validator`
+(`New(store.EntityReader, *metamodel.Metamodel, lua.ReadDeps)`) and
+`internal/schema/validate_properties.go ValidateEntityProperties(ctx, store,
+*metamodel.Metamodel)` both take store + metamodel and cross-check.
+
+**Metamodel reader API the audit needs** (`internal/metamodel`, survey):
+- `HasEntityType(t) bool` / `GetEntityDef(t) (*EntityDef, bool)` / `EntityTypes()
+[]string`.
+- `GetRelationDef(r) (*RelationDef, bool)` → `.From []string`, `.To []string`,
+`.Inverse`. Plus `ValidateRelation(rel, from, to) error` — does the B3
+source-type-compatibility check in one call.
+- Enum options: `EntityDef.Properties[f].Values []string` (inline), or
+`Metamodel.Types[prop.Type].Values` (named custom type).
+- **Both `Metamodel` (30 exported methods) and `EntityDef` (23) are over the
+plimsoll line** — a consumer must take a NARROW interface, not `*Metamodel`.
+
+**Architecture boundaries** (`.go-arch-lint.yml`, confirmed):
+- `acl: mayDependOn [entity, principal, store]` — **acl may NOT import
+metamodel.** So the audit core (needs both Policy + schema) cannot live in
+`internal/acl`.
+- `metamodel: mayDependOn [migration, storage]` — leaf; safe to depend on from
+above.
+- `analysis: mayDependOn [lua, metamodel, project, schema, storage, store,
+tracer, validation]` — has metamodel but **NOT acl** today; does not import acl.
+
+**The Validate-migration behaviour change.** Removing the two `slog.Warn`s from
+`Validate` means boot no longer logs them; operators see those findings only by
+running `rela acl audit`. This is a (small) behaviour change shipped in
+TKT-Z8A62F's wake. It is the right move — `Validate` returns to a pure
+structural gate — but must be called out and the membership-warn tests in
+`policy_test.go` (`TestPolicy_MembershipRelation_UngatedWarns` / `GatedNoWarn`)
+must move to the audit's test suite.
+
+## Options
+
+### Q1 — Where does the audit core live?
+
+**Option A: new `internal/aclaudit` package.**
+- `aclaudit.Audit(policy *acl.Policy, meta MetamodelReader) []Finding`, where
+`MetamodelReader` is a narrow consumer-side interface (HasEntityType,
+GetRelationDef, enum-options lookup — 3-4 methods).
+- arch-lint: add `aclaudit: { in: internal/aclaudit }` +
+`mayDependOn: [acl, metamodel, store]`. No cycle (both below it).
+- Pros: security analyzer isolated and independently testable; pure function of
+(policy, schema) for Tier A+B (no store needed until Tier C); the narrow
+interface satisfies plimsoll and the CLAUDE.md consumer-side-interface rule;
+doesn't widen `analysis`'s already-broad dep set with a security concern.
+- Cons: one more package; CLI/MCP wiring must construct it (small).
+- Effort: S–M.
+
+**Option B: fold into `internal/analysis`.**
+- Add `acl` to `analysis.mayDependOn`; add `analysis.AuditACL()` reusing
+`analysis.Deps{Meta, Store, ...}` and the `AnalysisResult` render path.
+- Pros: reuses existing service wiring + JSON envelope + the CLI/MCP analyze
+plumbing; "all analyzers in one place" symmetry.
+- Cons: `analysis` becomes the first place that imports `acl`, coupling the
+broad analysis facade to the security subsystem; the audit inherits `analysis`'s
+heavy `Deps` even though Tier A+B only need policy + a narrow metamodel view;
+harder to unit-test in isolation; mixes a security-sensitive concern into a
+grab-bag facade (against the "scoped bundle" CLAUDE.md rule).
+- Effort: S.
+
+**Option C: extend `internal/acl` with a metamodel-taking method.** Rejected
+outright — violates the arch-lint `acl → metamodel` prohibition; would force a
+boundary exception on the security package. Not viable.
+
+### Q2 — Finding taxonomy & severity model
+
+**Option A: typed `Finding` with a severity enum (recommended).**
+```go
+type Severity int // Critical, High, Medium, Low, Nit
+type Finding struct {
+    Rule     string   // stable ID, e.g. "A1-ungated-membership"
+    Severity Severity
+    Subject  string   // role / relation / type name the finding is about
+    Detail   string   // human explanation
+    Fix      string   // one-line remediation
+}
+```
+
+- Pros: richer than the existing string severity (5 levels lets `--exit-code`
+gate on critical/high only); stable rule IDs make findings greppable and
+suppressDocumentable; `Fix` mirrors good linter UX.
+- Cons: introduces a 5-level enum where the rest of the codebase uses
+`"error"/"warning"` strings — minor inconsistency.
+
+**Option B: reuse the string `"error"/"warning"` convention.** Consistent with
+`validation.Violation`, but too coarse for "this is a critical self-promotion
+path" vs "this is a dead permission nit." The audit's whole value is ranking.
+Recommend A but document the divergence.
+
+### Q3 — Validate migration
+
+Single option, already decided: move the two membership warns into the audit as
+findings A1 (un-gated membership) / A1b (inert/empty assignments), delete them
+from `Validate`, relocate their tests. Confirm no other caller relies on the
+boot-time warning (grep: only `policy_test.go`).
+
+## Recommendation
+
+**Q1 → Option A (new `internal/aclaudit` package).** The arch-lint boundary
+makes `acl`-resident impossible (Option C) and folding into `analysis` (Option
+B) couples a broad facade to the security subsystem and drags in heavy deps the
+pure-policy/metamodel checks don't need. A dedicated `aclaudit` package taking a
+narrow `MetamodelReader` consumer-side interface is the CLAUDE.md-idiomatic
+choice: isolated, plimsoll-safe, unit-testable as a pure function of (policy,
+schema) for v1, and ready to take a `store` reader when Tier C lands. The CLI
+(`rela acl audit`) and a future MCP `analyze_acl` tool are thin frontends over
+it; reuse `output.AnalysisResult` for the CLI JSON envelope.
+
+**Q2 → Option A (typed Finding + 5-level severity enum).** The ranking *is* the
+product; `--exit-code` gates on Critical/High. Document the divergence from the
+`"error"/"warning"` string convention as deliberate.
+
+**Q3 →** migrate the two membership warns out of `Validate` into `aclaudit`
+findings; relocate their tests; note the boot-no-longer-logs behaviour change in
+the ticket.
+
+**Tradeoffs accepted:** one new package + a new arch-lint component; a severity
+enum that diverges from the codebase's string convention; and a small behaviour
+change (boot stops logging the two membership warns). All three are justified by
+keeping the security analyzer isolated, rankable, and properly homed.
+
+**v1 check set (for the implementing ticket):**
+- Tier A (pure-policy): A1 un-gated membership relation (incl. default
+member-of); A1b inert membership (empty assignments); A2 un-gated role-relation
+conferring a privileged role; A3 privileged role on `everyone`; A4 assignment→
+undeclared role; A5 `confers`→undeclared role; A6 `requires_permission` no role
+grants; A7 dead permission; A9 wildcard sprawl on a non-admin role; A10
+whitespace/casing in name fields.
+- Tier B (metamodel): B1 grant references undeclared entity type; B2
+membership/role/inherit relation undeclared; B3 membership relation `from`
+incompatible with `user_entity_type` (via `ValidateRelation`); B4 fields/visible
+grant names an undeclared field; B5 options grant outside the field's enum; B7
+`user_entity_type` undeclared.
+- Deferred: Tier C (graph: C1 membership relation has zero edges; C4 privileged
+group reachable by everyone) and Tier D (reachability model-check).

--- a/tickets/entities/review-checklists/REV-T7J4JV.md
+++ b/tickets/entities/review-checklists/REV-T7J4JV.md
@@ -1,0 +1,68 @@
+---
+id: REV-T7J4JV
+type: review-checklist
+title: 'Review: ACL: dedicated authorization-misconfiguration validator / audit insights (escalation foot-guns, dead assignments, un-gated membership)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — aclaudit + acl + cli + dependents green
+- [x] Lint clean (`just lint`) — 0 issues (aclaudit, acl, cli)
+- [x] Coverage maintained (`just coverage-check`) — aclaudit 90.3%; total 76.9%; floors PASS
+
+## Code Review
+
+- [x] Run `/code-review` (cranky-code-reviewer) + `/crit` (human, round 1 addressed)
+- [x] All critical review-responses addressed (0 critical)
+- [x] All significant review-responses addressed (RR-EG5D3E — the A1 read-only false positive)
+- [x] Self-reviewed the diff for unrelated changes (branch cleanly stacked on membership base; verified via `git diff feat/acl-configurable-membership-relation`)
+
+**Review Responses:** design-review RR-LXI3NW, RR-UR0LJU, RR-O7H3GY, RR-TZ2S3G;
+code-review RR-EG5D3E, RR-KUOAVH, RR-O50E4R, RR-4O11EZ. All addressed. Crit
+round-1 comments (positive framing, --fail-on=any production guidance,
+security.md clarification, e2e demo script) all addressed.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (planning checklist PLAN-BFB9EJ)
+- [x] Test evidence documented in implementation checklist (IMPL-NDR4NG)
+
+**Acceptance Status:**
+- AC1 un-gated membership + privileged assignment → A1 high, --fail-on non-zero → PASS (demo §2, unit)
+- AC2 write-role on everyone → A3 critical → PASS (demo §3, unit)
+- AC3 undeclared type → B1; membership undeclared → B2 → PASS (demo §4, unit)
+- AC4 clean policy (incl. everyone: read: ["*"]) → zero findings, exit 0 → PASS (demo §1)
+- AC5 --json → AnalysisResult envelope → PASS (demo §6, unit)
+- AC6 membership warns gone from Validate; reproduced as aclaudit; Validate still
+hard-errors structurally → PASS (unit; verified update⊆read still fires)
+- AC7 arch-lint + plimsoll pass → PASS
+- Bonus: --fail-on severity threshold (from user review) → PASS (demo §5, unit)
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs` (DOCS-B93LL3)
+- [x] User-facing documentation updated (acl-security guide, security.md, demo script)
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-B93LL3
+
+## Final Checks
+
+- [x] Commit messages explain the why (4 audit commits, each with rationale)
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use (demo script + guide)
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** *pending — TKT-TS0J5K is stacked on PR #1060 (membership). Per the
+agreed sequencing, wait for #1060 to merge to develop, then rebase this branch
+onto develop and open the audit PR. REV stays in-progress until the PR exists +
+CI passes (the "in-progress review checklist cannot be merged" CI guard is
+correct here).*

--- a/tickets/entities/review-checklists/REV-T7J4JV.md
+++ b/tickets/entities/review-checklists/REV-T7J4JV.md
@@ -2,15 +2,15 @@
 id: REV-T7J4JV
 type: review-checklist
 title: 'Review: ACL: dedicated authorization-misconfiguration validator / audit insights (escalation foot-guns, dead assignments, un-gated membership)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [x] All tests pass (`just test`) — aclaudit + acl + cli + dependents green
-- [x] Lint clean (`just lint`) — 0 issues (aclaudit, acl, cli)
+- [x] All tests pass (`just test`) — CI Test job green on PR #1067
+- [x] Lint clean (`just lint`) — 0 issues; CI Lint + God-object + Markdown green
 - [x] Coverage maintained (`just coverage-check`) — aclaudit 90.3%; total 76.9%; floors PASS
 
 ## Code Review
@@ -18,7 +18,7 @@ status: in-progress
 - [x] Run `/code-review` (cranky-code-reviewer) + `/crit` (human, round 1 addressed)
 - [x] All critical review-responses addressed (0 critical)
 - [x] All significant review-responses addressed (RR-EG5D3E — the A1 read-only false positive)
-- [x] Self-reviewed the diff for unrelated changes (branch cleanly stacked on membership base; verified via `git diff feat/acl-configurable-membership-relation`)
+- [x] Self-reviewed the diff for unrelated changes (branch rebased onto develop after #1060 merged; only the 5 audit commits + the MD014 fix remain)
 
 **Review Responses:** design-review RR-LXI3NW, RR-UR0LJU, RR-O7H3GY, RR-TZ2S3G;
 code-review RR-EG5D3E, RR-KUOAVH, RR-O50E4R, RR-4O11EZ. All addressed. Crit
@@ -37,32 +37,30 @@ security.md clarification, e2e demo script) all addressed.
 - AC4 clean policy (incl. everyone: read: ["*"]) → zero findings, exit 0 → PASS (demo §1)
 - AC5 --json → AnalysisResult envelope → PASS (demo §6, unit)
 - AC6 membership warns gone from Validate; reproduced as aclaudit; Validate still
-hard-errors structurally → PASS (unit; verified update⊆read still fires)
+hard-errors structurally → PASS (unit)
 - AC7 arch-lint + plimsoll pass → PASS
 - Bonus: --fail-on severity threshold (from user review) → PASS (demo §5, unit)
 
 ## Documentation (enhancements only)
 
 - [x] Docs-checklist created and linked via `has-docs` (DOCS-B93LL3)
-- [x] User-facing documentation updated (acl-security guide, security.md, demo script)
+- [x] User-facing documentation updated (acl-security guide, demo script)
 - [x] Docs-checklist marked as done
 
 **Docs Checklist:** DOCS-B93LL3
 
 ## Final Checks
 
-- [x] Commit messages explain the why (4 audit commits, each with rationale)
+- [x] Commit messages explain the why (5 audit commits + MD014 fix)
 - [x] No TODOs or FIXMEs left unaddressed
 - [x] Ready for another developer to use (demo script + guide)
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI — PR #1067
+- [x] All CI checks pass (23 pass, 1 skip; the only failure was the "Rela Tickets"
+guard flagging this checklist while in-progress — checking these boxes + marking
+done clears it, same as #1060)
+- [x] PR URL documented below
 
-**PR:** *pending — TKT-TS0J5K is stacked on PR #1060 (membership). Per the
-agreed sequencing, wait for #1060 to merge to develop, then rebase this branch
-onto develop and open the audit PR. REV stays in-progress until the PR exists +
-CI passes (the "in-progress review checklist cannot be merged" CI guard is
-correct here).*
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1067

--- a/tickets/entities/review-responses/RR-4O11EZ.md
+++ b/tickets/entities/review-responses/RR-4O11EZ.md
@@ -1,0 +1,9 @@
+---
+id: RR-4O11EZ
+type: review-response
+title: B1 double-flags a type used as both a verb grant and an affordance key; slicesClone misnamed; stale roleGrants comment
+finding: 'Three small ones: (a) B1''s seen map keys on verb+type, so a single typo''d type in both create: and fields: yields two findings for one mistake — dedupe on type alone for B1. (b) cli/acl.go slicesClone also sorts; rename to sortedClone so readers don''t assume order-preservation (shadows stdlib slices.Clone semantics). (c) aclaudit.go: the doc comment says ''roleGrants reports...'' above func roleDeclared — stale comment, fix the name.'
+severity: nit
+resolution: (a) B1 dedupe now keys on type alone (one typo'd type = one finding). (b) cli/acl.go slicesClone renamed to sortedClone. (c) roleDeclared doc comment fixed (was stale 'roleGrants').
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-EG5D3E.md
+++ b/tickets/entities/review-responses/RR-EG5D3E.md
@@ -1,0 +1,9 @@
+---
+id: RR-EG5D3E
+type: review-response
+title: A1 fires High on a read-only assigned role (false positive; asymmetric with A2)
+finding: 'A1 (tier_a.go:50) gates on assignsAnyDeclaredRole (ANY declared role), but A2 (tier_a.go:81) gates on isPrivileged. Per RR-LXI3NW/RR-UR0LJU, granting yourself a read-only role is a visibility choice, not escalation. So default member-of + assignments:{eng: reader} where reader is read-only fires A1 High (''self-promotion hole'') incorrectly — the exact trust-eroding false positive the design fought. The docs (acl-security.md:73-74) describe A1 as conferring ''a privileged role'', disagreeing with the code. The CLI/unit tests use ''editor'' which is privileged via Create, so the read-only case is never exercised. Fix: gate A1 on a new assignsAnyPrivilegedRole predicate (reuse isPrivileged), symmetric with A2; add a read-only-group negative test asserting zero A1.'
+severity: significant
+resolution: A1 now gates on assignsAnyPrivilegedRole (reuses isPrivileged), symmetric with A2 — a read-only assigned role no longer trips A1. Detail/docs updated to 'a privileged group role'. Added TestAudit_A1_ReadOnlyGroup_NoFinding asserting zero A1 for a read-only group.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-KUOAVH.md
+++ b/tickets/entities/review-responses/RR-KUOAVH.md
@@ -1,0 +1,9 @@
+---
+id: RR-KUOAVH
+type: review-response
+title: A10 checks assignment values but not assignment keys
+finding: A10 (tier_a.go) flags whitespace on p.Assignments[key] (the role name) but never on key itself. The key is the member/group ID matched in computeGlobals (policy.Assignments[m]). A key 'admins ' silently matches no member — the same silent foot-gun A10 exists to catch. Add a key whitespace check.
+severity: minor
+resolution: A10 now also checks assignment KEYS for whitespace (the member/group ID). Added TestAudit_A10_AssignmentKeyWhitespace.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-LXI3NW.md
+++ b/tickets/entities/review-responses/RR-LXI3NW.md
@@ -1,0 +1,9 @@
+---
+id: RR-LXI3NW
+type: review-response
+title: '"Privileged role" (A2/A3) is undefined; the ACL has no built-in privilege notion'
+finding: 'A2 and A3 fire on a ''privileged role'' but the ACL has no such concept (confirmed: resolver only knows grants + Permissions; holdsPermission matches exact permission strings). The plan must DEFINE privileged operationally or the checks are unimplementable / arbitrary. Proposed definition: a role is privileged if it grants any write (Create/Update/Delete non-empty or contains ''*'') OR holds any Permissions entry. Refinement: the highest-signal case is a role that holds a delegate-* permission (it can hand out access) or a wildcard write. Document this definition in aclaudit and reference it from A2/A3 so the gating is explicit and testable, not hand-wavy.'
+severity: significant
+resolution: Plan defines isPrivileged(role) in aclaudit = grants any write (Create/Update/Delete non-empty incl '*') OR holds any Permissions; A2/A3 reference it; delegate-*/wildcard-write is the highest-signal sub-case. Documented + unit-tested.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-O50E4R.md
+++ b/tickets/entities/review-responses/RR-O50E4R.md
@@ -1,0 +1,9 @@
+---
+id: RR-O50E4R
+type: review-response
+title: B5 reports 'not an enum' for a typo'd (absent) options field — misleading diagnosis
+finding: 'B4 only inspects Fields/Visible, not Options. So an options: grant naming a field that doesn''t exist on the type falls into B5''s !isEnum branch and reports ''names field X which is not an enum'' — when the field isn''t there at all. Wrong diagnosis. Fix: B5 should call m.HasField first and report an undeclared-field finding for an absent field, reserving ''not an enum'' for a real-but-non-enum field.'
+severity: minor
+resolution: 'B5 now calls m.HasField first: an absent options field reports B4-undeclared-field (typo), reserving B5-options-non-enum for a real-but-non-enum field. Added TestAudit_B5_AbsentField_ReportsUndeclaredNotNonEnum.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-O7H3GY.md
+++ b/tickets/entities/review-responses/RR-O7H3GY.md
@@ -1,0 +1,9 @@
+---
+id: RR-O7H3GY
+type: review-response
+title: A6 (requires_permission no role grants) can be an intentional lockdown, not a bug
+finding: 'A6 flags a requires_permission naming a permission no role grants. But that''s a legitimate hardening pattern: an operator deliberately gating a relation behind a permission NOBODY holds locks the relation entirely (no one can write it). Flagging it as medium could be a false positive on intentional config. Downgrade A6 to low/info and word it as a question (''relation X is gated by permission Y which no role grants; no principal can write X — intended?'') rather than an error. Same softening applies to A7 (dead permission) which is already low.'
+severity: minor
+resolution: A6 downgraded to low/info, worded as a question ('no principal can write X — intended?') rather than an error, since a deliberately ungranted requires_permission is a valid lockdown pattern.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-TZ2S3G.md
+++ b/tickets/entities/review-responses/RR-TZ2S3G.md
@@ -1,0 +1,9 @@
+---
+id: RR-TZ2S3G
+type: review-response
+title: B1/B-checks must skip the '*' wildcard sentinel (not an entity type)
+finding: 'B1 (grant references undeclared entity type) iterates create/update/delete/read lists, which legitimately contain ''*'' (the wildcard, handled by grantsVerb''s t=="*" branch). ''*'' is not an entity type — B1 must skip it or it false-positives on every wildcard role. The plan''s edge-cases note mentions this for B1; make it a hard requirement across ALL Tier-B checks that read grant lists (B1) and ensure the fakeMetamodelReader test includes a wildcard role asserting zero B1 findings. Also: affordance keys (fields/visible/options/relations maps) are keyed by entity type with NO wildcard — those keys CAN be checked against the schema directly.'
+severity: minor
+resolution: 'Plan now mandates B1 (and any verb-list check) skip the ''*'' sentinel; affordance map keys (no wildcard) checked directly. Mandatory test: wildcard role → zero B1 findings.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-UR0LJU.md
+++ b/tickets/entities/review-responses/RR-UR0LJU.md
@@ -1,0 +1,9 @@
+---
+id: RR-UR0LJU
+type: review-response
+title: 'A9 wildcard-sprawl would false-positive on the documented `everyone: read: ["*"]` example'
+finding: 'The canonical worked example in docs/acl-overview.md uses `everyone: read: ["*"]` — a legitimate, recommended pattern (everyone can read everything). If A9 flags any wildcard grant it fires on the docs'' own example, training operators to ignore the audit on first run. Fix the gating: A9 must only flag WRITE/permission wildcards (create/update/delete: ["*"] or a delegate permission) on NON-everyone roles, and never read:["*"]. Read-everything is an intentional visibility choice, not least-privilege sprawl. Add an explicit negative test: `everyone: read:["*"]` → zero A9 findings.'
+severity: significant
+resolution: 'A9 gating tightened: only write/permission wildcards flagged, never read:[''*'']. Mandatory negative test added (everyone: read:[''*''] → zero), plus the full docs worked-example policy as a golden zero/expected-findings fixture.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-TS0J5K.md
+++ b/tickets/entities/tickets/TKT-TS0J5K.md
@@ -5,7 +5,7 @@ title: 'ACL: dedicated authorization-misconfiguration validator / audit insights
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 Follow-up from TKT-Z8A62F. Design settled in RES-VWNN2T; design-review in

--- a/tickets/entities/tickets/TKT-TS0J5K.md
+++ b/tickets/entities/tickets/TKT-TS0J5K.md
@@ -3,38 +3,82 @@ id: TKT-TS0J5K
 type: ticket
 title: 'ACL: dedicated authorization-misconfiguration validator / audit insights (escalation foot-guns, dead assignments, un-gated membership)'
 kind: enhancement
-priority: low
-status: backlog
+priority: medium
+effort: m
+status: in-progress
 ---
 
-Follow-up from TKT-Z8A62F.
+Follow-up from TKT-Z8A62F. Design settled in RES-VWNN2T; design-review in
+RR-LXI3NW / RR-UR0LJU / RR-O7H3GY / RR-TZ2S3G.
 
-While making the membership relation configurable we added two ad-hoc
-`slog.Warn` hardening checks in `Policy.Validate` (un-gated membership relation,
-empty assignments). These are tolerant-by-design advisories, not a real
-analysis.
+## What
 
-Idea: a dedicated authorization-misconfiguration validator / audit surface that
-gives operators *insight* into escalation foot-guns and dead config, rather than
-scattering one-off warnings through `Validate`. Candidate findings:
+Build `rela acl audit` — an **on-demand** linter for `acl.yaml`, separate from
+the boot-time `Policy.Validate` gate. Reports escalation foot-guns, dead/inert
+config, and policy-vs-metamodel drift as **severity-ranked findings**. Advisory
+by default (never blocks boot); CI gating opt-in via `--exit-code`.
 
-- Membership relation (default `member-of` or configured) confers an assigned
-role but is not gated by `requires_permission` → self-promotion path. Should
-cover the **default** member-of too, not just the configured case.
-- A role-conferring relation grants a privileged role with no delegate gate.
-- Assignments referencing undeclared roles / groups (already warned at load, but
-collect into one report).
-- Roles that grant write on a type they can't read where no role-relation backs
-the read-back (likely-broken submitter pattern).
-- Privileged role assigned to `everyone`.
-- `membership_relation` set but no edges of that type exist in the graph
-(graph-aware check — needs the store, unlike Validate).
+## Architecture (RES-VWNN2T + design-review)
 
-Open questions:
-- Surface: a `rela acl lint` / `rela analyze` subcommand vs. an `analyze_*`
-MCP tool vs. a startup report. Graph-aware checks need store access, so this is
-more than a pure-policy `Validate`.
-- Severity model (info / warn / error) and whether any should be opt-in
-enforcement (load failure) for hardened deployments.
+- **New `internal/aclaudit` package.** arch-lint forbids `acl → metamodel`, so the
+audit (needs Policy + schema) cannot live in `internal/acl`. `aclaudit` defines
+a narrow consumer-side `MetamodelReader` interface; the concrete adapter over
+`*metamodel.Metamodel` lives in the CLI → `aclaudit` arch-lint dep = `[acl]`
+only for v1. (Required anyway: `Metamodel`/`EntityDef` are over the plimsoll
+line.)
+- **Typed `Finding{Rule, Severity, Subject, Detail, Fix}` + 5-level severity**
+(Critical/High/Medium/Low/Nit). `--exit-code` gates on Critical/High.
+- **`isPrivileged(role)`** (RR-LXI3NW) = grants any write (Create/Update/Delete
+non-empty incl `"*"`) OR holds any Permissions. A2/A3 reference it.
+- **CLI:** Kong `ACLCmd{ Audit }` → `rela acl audit`, `--json`
+(`output.AnalysisResult` envelope) + `--exit-code`.
 
-Out of scope of TKT-Z8A62F; tracked separately so the config change stays small.
+## Validate migration (behaviour change)
+
+Move the two membership `slog.Warn`s out of `Policy.Validate` into `aclaudit`
+(A1/A1b); `Validate` returns to a pure structural gate. Boot no longer logs
+them. Relocate `TestPolicy_MembershipRelation_UngatedWarns`/`GatedNoWarn` to the
+audit suite. Add exported `Policy.EffectiveMembershipRelation()` so audit +
+resolver share one source of truth.
+
+## v1 check set (gating per design-review)
+
+**Tier A (pure-policy):** A1 un-gated membership relation confers an assigned
+role (incl. default member-of) — **high**; A1b non-default membership +empty
+assignments — **low**; A2 un-gated role-relation conferring a privileged role —
+**high**; A3 privileged role on `everyone` — **critical**; A4 assignment→
+undeclared role — **medium**; A5 confers→undeclared role — **medium**; A6
+requires_permission no role grants (phrased as a question, lockdown may be
+intended) — **low**; A7 dead permission — **low**; A9 WRITE/permission wildcard
+on a non-everyone role (NEVER read:["*"]) — **medium**; A10 whitespace/case in a
+name field — **low**.
+
+**Tier B (metamodel, skip `"*"` sentinel):** B1 grant/affordance-key names an
+undeclared entity type — **high**; B2 membership/role/inherit relation
+undeclared — **high**; B3 membership relation `from` ∌ user_entity_type (via
+ValidateRelation) — **medium**; B4 fields/visible grant names an undeclared
+field — **medium**; B5 options grant outside the field's enum — **medium**; B7
+user_entity_type undeclared — **high**.
+
+**Audit-wide invariant:** every check ships a negative test; the full
+docs/acl-overview.md worked-example policy is a golden zero/expected-findings
+fixture (so no future check flags the recommended baseline).
+
+## Out of scope (follow-ups)
+
+Tier C (graph: membership relation has zero edges; privileged group reachable by
+everyone) — needs store; Tier D (reachability model-check); MCP `analyze_acl`;
+opt-in strict boot mode.
+
+## Acceptance
+
+1. Un-gated `member-of` + privileged assignment → A1 (high); `--exit-code`
+non-zero.
+2. Write-role on `everyone` → A3 (critical).
+3. Grant naming undeclared type → B1; `membership_relation` undeclared → B2.
+4. Clean well-gated policy → zero findings, exit 0 (incl. the docs example with
+`everyone: read: ["*"]`).
+5. `--json` emits via `output.AnalysisResult`.
+6. Membership warns gone from `Validate`; reproduced as aclaudit findings; tests
+relocated; `Validate` still hard-errors on structural invariants.
+7. `just arch-lint` + `just plimsoll` pass.

--- a/tickets/entities/tickets/TKT-TS0J5K.md
+++ b/tickets/entities/tickets/TKT-TS0J5K.md
@@ -5,7 +5,7 @@ title: 'ACL: dedicated authorization-misconfiguration validator / audit insights
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: review
 ---
 
 Follow-up from TKT-Z8A62F. Design settled in RES-VWNN2T; design-review in

--- a/tickets/relations/RES-VWNN2T--researches--authorization.md
+++ b/tickets/relations/RES-VWNN2T--researches--authorization.md
@@ -1,0 +1,5 @@
+---
+from: RES-VWNN2T
+relation: researches
+to: authorization
+---

--- a/tickets/relations/TKT-TS0J5K--has-docs--DOCS-B93LL3.md
+++ b/tickets/relations/TKT-TS0J5K--has-docs--DOCS-B93LL3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TS0J5K
+relation: has-docs
+to: DOCS-B93LL3
+---

--- a/tickets/relations/TKT-TS0J5K--has-implementation--IMPL-NDR4NG.md
+++ b/tickets/relations/TKT-TS0J5K--has-implementation--IMPL-NDR4NG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TS0J5K
+relation: has-implementation
+to: IMPL-NDR4NG
+---

--- a/tickets/relations/TKT-TS0J5K--has-planning--PLAN-BFB9EJ.md
+++ b/tickets/relations/TKT-TS0J5K--has-planning--PLAN-BFB9EJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TS0J5K
+relation: has-planning
+to: PLAN-BFB9EJ
+---

--- a/tickets/relations/TKT-TS0J5K--has-research--RES-VWNN2T.md
+++ b/tickets/relations/TKT-TS0J5K--has-research--RES-VWNN2T.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TS0J5K
+relation: has-research
+to: RES-VWNN2T
+---

--- a/tickets/relations/TKT-TS0J5K--has-review--REV-T7J4JV.md
+++ b/tickets/relations/TKT-TS0J5K--has-review--REV-T7J4JV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TS0J5K
+relation: has-review
+to: REV-T7J4JV
+---

--- a/tickets/relations/TKT-TS0J5K--has-review-response--RR-4O11EZ.md
+++ b/tickets/relations/TKT-TS0J5K--has-review-response--RR-4O11EZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TS0J5K
+relation: has-review-response
+to: RR-4O11EZ
+---

--- a/tickets/relations/TKT-TS0J5K--has-review-response--RR-EG5D3E.md
+++ b/tickets/relations/TKT-TS0J5K--has-review-response--RR-EG5D3E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TS0J5K
+relation: has-review-response
+to: RR-EG5D3E
+---

--- a/tickets/relations/TKT-TS0J5K--has-review-response--RR-KUOAVH.md
+++ b/tickets/relations/TKT-TS0J5K--has-review-response--RR-KUOAVH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TS0J5K
+relation: has-review-response
+to: RR-KUOAVH
+---

--- a/tickets/relations/TKT-TS0J5K--has-review-response--RR-LXI3NW.md
+++ b/tickets/relations/TKT-TS0J5K--has-review-response--RR-LXI3NW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TS0J5K
+relation: has-review-response
+to: RR-LXI3NW
+---

--- a/tickets/relations/TKT-TS0J5K--has-review-response--RR-O50E4R.md
+++ b/tickets/relations/TKT-TS0J5K--has-review-response--RR-O50E4R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TS0J5K
+relation: has-review-response
+to: RR-O50E4R
+---

--- a/tickets/relations/TKT-TS0J5K--has-review-response--RR-O7H3GY.md
+++ b/tickets/relations/TKT-TS0J5K--has-review-response--RR-O7H3GY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TS0J5K
+relation: has-review-response
+to: RR-O7H3GY
+---

--- a/tickets/relations/TKT-TS0J5K--has-review-response--RR-TZ2S3G.md
+++ b/tickets/relations/TKT-TS0J5K--has-review-response--RR-TZ2S3G.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TS0J5K
+relation: has-review-response
+to: RR-TZ2S3G
+---

--- a/tickets/relations/TKT-TS0J5K--has-review-response--RR-UR0LJU.md
+++ b/tickets/relations/TKT-TS0J5K--has-review-response--RR-UR0LJU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TS0J5K
+relation: has-review-response
+to: RR-UR0LJU
+---


### PR DESCRIPTION
## What

Adds `rela acl audit` — an **on-demand linter** over `acl.yaml` that reports authorization-misconfiguration findings, severity-ranked. It is deliberately separate from the boot-time `Policy.Validate` gate: Validate is a narrow structural gate (rejects malformed policies), the audit hunts for foot-guns and drift.

Closes TKT-TS0J5K. Follow-up to TKT-Z8A62F (#1060).

## Why

`acl.yaml` is easy to get subtly wrong in ways that don't fail boot: a typo'd entity type silently grants nothing, an un-gated membership relation opens a self-promotion path, a write grant on `everyone` hands capabilities to anonymous callers. Boot-time validation can't rank findings or cross-check the metamodel; the audit does both.

## How

- **New `internal/aclaudit` package** — `Audit(policy, MetamodelReader) []Finding`. arch-lint forbids `acl → metamodel`, so the audit takes a narrow consumer-side `MetamodelReader` interface (the concrete adapter over `*metamodel.Metamodel` lives in the CLI, keeping `aclaudit`'s dep to `[acl]` only). Typed `Finding{Rule, Severity, Subject, Detail, Fix}` with a 5-level severity.
- **16 checks:** Tier A pure-policy (un-gated membership/role-relation conferring a *privileged* role, privileged `everyone`, assignment/confers to undeclared roles, un-grantable/dead permissions, wildcard-write sprawl, name whitespace) + Tier B metamodel cross-check (undeclared type/relation/field/option references, membership `from`-vs-`user_entity_type` compatibility, undeclared `user_entity_type`).
- **CLI:** `rela acl audit` with `--fail-on=critical|high|medium|low|any` (default advisory, exits 0), `--exit-code` alias for `--fail-on=high`, and `-o json` (AnalysisResult envelope).
- **Validate migration:** moved the two membership hardening `slog.Warn`s out of `Policy.Validate` (now a pure structural gate) into the audit; exported `Policy.EffectiveMembershipRelation()` so the resolver and the audit share one source of truth.

## Design notes (from review)

- `isPrivileged` is the single definition A1/A2/A3 gate on — a **read-only** assigned role or a `read: ["*"]` on `everyone` is a visibility choice, not an escalation path, so it does **not** trip a finding (verified against the documented worked-example policy, which reports zero findings).
- A6 (un-grantable `requires_permission`) is Low and phrased as a question — an intentional lockdown is valid.
- `--fail-on` came out of review: warnings below the threshold don't change the exit code, so medium/low nits don't break CI unless opted in.

## Tests & verification

- 27 unit tests in `aclaudit` (every check has a positive + a negative case; a golden clean-policy fixture; determinism over 20 runs); CLI tests for `--fail-on` gating, JSON, and the no-policy path.
- `scripts/demo-acl-audit.sh` — end-to-end demo (auto-run by CI's Demos job) exercising findings, thresholds, JSON, and the no-policy path.
- Went through the full workflow: research (RES-VWNN2T) → design-review (4 findings) → cranky-code-review (5 findings) → crit human review. All findings addressed.

## Out of scope (follow-ups)

Tier C (graph-aware: membership relation with zero edges, privileged group reachable by `everyone`), Tier D (reachability model-check), an MCP `analyze_acl` tool, and an opt-in strict boot mode.