### PR TITLE
feat: inbound signed-webhook receiver + outbound request-signing primitives

### DIFF
--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -54,6 +54,12 @@ type serverFlags struct {
 	jwtAudience string
 	jwtJWKSURL  string
 	jwtHeader   string
+	// Inbound-IdP webhook: verify a signed-JWT webhook body (same JWKS/issuer as
+	// the identity JWT, but its OWN audience) and dispatch to a named action that
+	// provisions a person entity. Both must be set to enable; empty ⇒ disabled.
+	// Requires the JWT identity flags above (the webhook reuses that JWKS).
+	webhookAudience string
+	webhookAction   string
 }
 
 // coverage-ignore: flag wiring — exercised at startup, not in tests
@@ -92,6 +98,15 @@ func parseFlags() *serverFlags {
 	flag.StringVar(&f.jwtHeader, "jwt-header", envOr("RELA_JWT_HEADER", "X-Auth-Assertion"),
 		"Request header carrying the signed identity JWT (a leading 'Bearer ' is stripped). "+
 			"Point it at whatever your proxy injects, e.g. X-Pratique-Assertion or Authorization.")
+	// Inbound-IdP webhook flags (env fallbacks $RELA_WEBHOOK_*). Enable POST
+	// /webhooks/idp: a signed-JWT callback that provisions a user via an action.
+	flag.StringVar(&f.webhookAudience, "webhook-audience", os.Getenv("RELA_WEBHOOK_AUDIENCE"),
+		"Expected audience (aud) of an inbound IdP webhook JWT — distinct from -jwt-audience so an "+
+			"identity assertion can't be replayed as a webhook. Set with -webhook-action to enable "+
+			"POST /webhooks/idp. Reuses the -jwt-issuer/-jwt-jwks-url trust root.")
+	flag.StringVar(&f.webhookAction, "webhook-action", envOr("RELA_WEBHOOK_ACTION", ""),
+		"Name of the action a verified IdP webhook dispatches to (e.g. idp-sync). The action "+
+			"receives event/user_id/org_id as params and provisions the user.")
 	// Note: there is no --database-url flag. The postgres build reads the DSN
 	// from $RELA_DATABASE_URL only, so the credential never lands in process
 	// listings or shell history. See appbuild.Config.DatabaseURL.
@@ -129,8 +144,8 @@ func envOr(key, def string) string {
 // the plain header because it proves authenticity.
 //
 // coverage-ignore: startup wiring.
-func wirePrincipalResolvers(app *dataentry.App, f *serverFlags) {
-	jwtResolver, jwtHeader := buildJWTResolver(context.Background(), f)
+func wirePrincipalResolvers(app *dataentry.App, f *serverFlags, idv *jwtauth.Verifier) {
+	jwtResolver, jwtHeader := buildJWTResolver(idv, f)
 	if jwtHeader != "" && f.principalHeader != "" {
 		// Both a verified JWT and a plain trusted header are enabled. Because the
 		// JWT sits ahead of the plain header in the chain, a JWT verification
@@ -156,17 +171,17 @@ func wirePrincipalResolvers(app *dataentry.App, f *serverFlags) {
 	app.SetPrincipalHeader(varyHeader)
 }
 
-// buildJWTResolver builds the signed-JWT principal resolver from the flags,
-// returning it plus the header name it reads (empty when disabled). JWT identity
-// is enabled only when issuer, audience, and JWKS URL are all set. A build
-// failure — a bad config, a non-https JWKS URL, or an unreachable JWKS — is fatal
-// so identity never silently no-ops (jwtauth.New fetches the JWKS up front and
-// errors if it can't). Returns an inert resolver + "" header when disabled.
+// buildIdentityVerifier builds the shared signed-JWT verifier from the flags, or
+// returns nil when JWT identity is disabled (any of issuer/audience/jwks unset). A
+// build failure — a bad config, a non-https JWKS URL, or an unreachable JWKS — is
+// fatal so identity never silently no-ops (jwtauth.New fetches the JWKS up front
+// and errors if it can't). The one verifier is reused by both the principal
+// resolver and the webhook receiver, so the JWKS is fetched once.
 //
-// coverage-ignore: startup wiring — exercised via the resolver's own tests.
-func buildJWTResolver(ctx context.Context, f *serverFlags) (resolver dataentry.PrincipalResolver, header string) {
+// coverage-ignore: startup wiring — exercised via jwtauth's own tests.
+func buildIdentityVerifier(ctx context.Context, f *serverFlags) *jwtauth.Verifier {
 	if f.jwtIssuer == "" || f.jwtAudience == "" || f.jwtJWKSURL == "" {
-		return dataentry.JWTPrincipalResolver(nil, ""), ""
+		return nil
 	}
 	v, err := jwtauth.New(ctx, jwtauth.Config{
 		Issuer:   f.jwtIssuer,
@@ -178,7 +193,62 @@ func buildJWTResolver(ctx context.Context, f *serverFlags) (resolver dataentry.P
 		os.Exit(1)
 	}
 	slog.Info("jwt identity enabled", "issuer", f.jwtIssuer, "header", f.jwtHeader)
-	return dataentry.JWTPrincipalResolver(v, f.jwtHeader), f.jwtHeader
+	return v
+}
+
+// buildJWTResolver wraps the shared verifier into a principal resolver, returning
+// it plus the header name it reads. A nil verifier (JWT identity disabled) yields
+// an inert resolver + "" header.
+//
+// coverage-ignore: startup wiring — exercised via the resolver's own tests.
+func buildJWTResolver(idv *jwtauth.Verifier, f *serverFlags) (resolver dataentry.PrincipalResolver, header string) {
+	if idv == nil {
+		return dataentry.JWTPrincipalResolver(nil, ""), ""
+	}
+	return dataentry.JWTPrincipalResolver(idv, f.jwtHeader), f.jwtHeader
+}
+
+// wireWebhookReceiver enables POST /webhooks/idp when -webhook-audience and
+// -webhook-action are both set. It requires JWT identity (the webhook reuses that
+// verifier's JWKS/issuer); a webhook audience without JWT identity, or a build
+// failure, is fatal so a misconfiguration fails loud rather than silently leaving
+// the endpoint off.
+//
+// coverage-ignore: startup wiring — exercised via the shim + verifier tests.
+func wireWebhookReceiver(app *dataentry.App, f *serverFlags, idv *jwtauth.Verifier) {
+	if f.webhookAudience == "" && f.webhookAction == "" {
+		return // disabled
+	}
+	if f.webhookAudience == "" || f.webhookAction == "" {
+		slog.Error("webhook: both -webhook-audience and -webhook-action are required to enable POST /webhooks/idp")
+		os.Exit(1)
+	}
+	if idv == nil {
+		slog.Error("webhook: -webhook-* requires JWT identity (-jwt-issuer/-jwt-audience/-jwt-jwks-url); the webhook reuses that JWKS")
+		os.Exit(1)
+	}
+	wv, err := jwtauth.NewWebhookVerifier(idv, f.webhookAudience)
+	if err != nil {
+		slog.Error("webhook: failed to initialize verifier", "error", err)
+		os.Exit(1)
+	}
+	app.SetWebhookReceiver(webhookVerifierAdapter{wv}, f.webhookAction)
+	slog.Info("idp webhook enabled", "audience", f.webhookAudience, "action", f.webhookAction)
+}
+
+// webhookVerifierAdapter bridges the concrete jwtauth.WebhookVerifier to the
+// dataentry receiver's expected shape, translating jwtauth.WebhookClaims into
+// dataentry.WebhookClaims. This adapter lives in the wiring layer — the one place
+// allowed to import both packages — so dataentry needn't depend on jwtauth (the
+// inward-pointing layering rule, mirroring the JWTPrincipalResolver seam).
+type webhookVerifierAdapter struct{ v *jwtauth.WebhookVerifier }
+
+func (a webhookVerifierAdapter) VerifyWebhook(ctx context.Context, raw string) (dataentry.WebhookClaims, error) {
+	c, err := a.v.VerifyWebhook(ctx, raw)
+	if err != nil {
+		return dataentry.WebhookClaims{}, err
+	}
+	return dataentry.WebhookClaims{Event: c.Event, UserID: c.UserID, OrgID: c.OrgID, ID: c.ID}, nil
 }
 
 // coverage-ignore: main function - entry point
@@ -250,7 +320,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	wirePrincipalResolvers(app, f)
+	// Build the signed-JWT verifier once (nil when JWT identity is disabled) and
+	// share it between the principal resolver and the webhook receiver so the JWKS
+	// is fetched a single time.
+	idv := buildIdentityVerifier(context.Background(), f)
+	wirePrincipalResolvers(app, f, idv)
+	wireWebhookReceiver(app, f, idv)
 
 	srv := newHTTPServer(addr, app.NewRouter())
 

--- a/docs/idp-webhook-provisioning.md
+++ b/docs/idp-webhook-provisioning.md
@@ -1,0 +1,143 @@
+# Provisioning users from an identity proxy (webhooks)
+
+rela can auto-provision a `person` entity for each user of an upstream identity
+proxy, driven by the proxy's webhooks. This is the companion to the signed-JWT
+*identity* feature (see [server-security.md](server-security.md)): identity says
+*who is making this request*; provisioning says *keep a local record of every
+user, so ACLs and relations can point at it*.
+
+The flow is **thin-notify + fetch-details**, and it is **provider-agnostic**:
+
+1. The proxy sends rela a small **signed-JWT webhook** — "a membership changed
+   for user X in org Y" — to `POST /webhooks/idp`.
+2. rela **verifies** the webhook's signature (same JWKS/issuer as identity, its
+   own audience) in Go, then dispatches a named **Lua action** with the claims.
+3. The action **fetches** the user's authoritative data from the proxy's API and
+   **upserts** a `person` entity keyed on the stable subject (`sub`).
+
+Everything proxy-specific — which API to call, how to authenticate to it, which
+JSON fields to read — lives in the **Lua action and the secrets**, not in rela's
+Go. rela ships only generic building blocks (`crypto.*`, `http.*`); pointing at a
+different proxy is a script + config change, no rebuild.
+
+> User-provisioning is one *use* of two general features: the signed-webhook
+> receiver (`POST /webhooks/idp` verifies a signed-JWT body and dispatches a named
+> Lua action) and the `crypto.*` primitives (so an action can sign an
+> authenticated outbound request). Any webhook-driven action — not just
+> provisioning — is built the same way.
+
+The reference action below targets [Pratique](https://github.com/sourcehaven-bv/pratique),
+whose operator API is HMAC-signed. A different proxy would use a different action.
+
+## 1. Add a `person` type to your metamodel
+
+The action upserts a `person`, so the type must exist. Minimal shape:
+
+```yaml
+# metamodel.yaml
+entities:
+  person:
+    label: Person
+    id_prefix: "PSN-"
+    properties:
+      sub:
+        type: string
+        required: true   # the stable IdP subject — the match key
+      email:
+        type: string
+```
+
+Key on `sub`, not email: the subject is stable across email changes, so
+attribution and any ACLs targeting the person survive a rename.
+
+## 2. Add the `idp-sync` action
+
+Copy [`examples/idp-sync.lua`](../examples/idp-sync.lua) into your project's
+`actions/` directory, and register it:
+
+```yaml
+# data-entry.yaml
+actions:
+  idp-sync:
+    label: "Sync a user from the IdP"
+    script: idp-sync.lua
+```
+
+The action reads `rela.params.user_id` / `.org_id` (set by the webhook receiver
+from the verified claims) and `rela.secrets` (below). It signs a Pratique
+operator-API request using the generic `crypto.*` primitives — the
+Pratique-specific canonical string and `X-Pratique-*` header names live entirely
+in this script.
+
+## 3. Configure the operator credential
+
+The action fetches the user over Pratique's HMAC-signed operator API, so it needs
+the base URL and the shared HMAC key:
+
+```yaml
+# .rela/secrets.yaml   (gitignored)
+idp_operator_url: https://id.example.com
+idp_operator_key: <the operator HMAC secret>
+```
+
+The key never touches Lua as crypto material — the script passes it to
+`crypto.hmac_sha256_base64`, which signs in Go. Treat it like any other secret.
+
+## 4. Enable the webhook receiver
+
+Start rela with the webhook flags. They **require** the identity JWT flags
+(`-jwt-issuer` / `-jwt-jwks-url`) — the webhook reuses that JWKS as its trust
+root, and pins its **own** audience so an identity assertion can't be replayed as
+a webhook (and vice versa):
+
+```text
+rela-server \
+  -jwt-issuer   https://id.example.com \
+  -jwt-audience app://your-rela \
+  -jwt-jwks-url https://id.example.com/.well-known/pratique/jwks.json \
+  -webhook-audience app://your-rela-webhook \
+  -webhook-action  idp-sync
+```
+
+(Env fallbacks: `RELA_WEBHOOK_AUDIENCE`, `RELA_WEBHOOK_ACTION`.) With both
+webhook flags set, `POST /webhooks/idp` is mounted; leave them unset and the
+endpoint does not exist.
+
+### Why the endpoint is safe without a same-origin check
+
+`/webhooks/idp` authenticates itself by **verifying a signed JWT body** — not a
+proxy-set header, not a session cookie. A browser cannot forge an ES256
+signature, so the endpoint is CSRF-immune by construction. It therefore lives
+outside `/api/` and needs neither the same-origin gate nor the CSRF-exempt
+heuristic the [sync API](sync.md) relies on. A forged or unsigned body is
+rejected with 401 before any action runs.
+
+## 5. Point the proxy's webhook at rela
+
+Configure Pratique to send membership webhooks to `https://your-rela/webhooks/idp`
+with a JWT body whose:
+
+- `iss` matches `-jwt-issuer`,
+- `aud` matches `-webhook-audience`,
+- claims include `event`, `user_id`, and `org_id`,
+- and a `jti` (used for redelivery dedup — a retried webhook with the same `jti`
+  is acknowledged without re-running the action).
+
+## What you get
+
+On each membership change, the `person` materializes (or updates) with its `sub`
+and `email`. The action is idempotent, so redeliveries and repeated changes never
+duplicate. Those `person` entities are then ready for ACLs and relations —
+e.g. an incoming ACL feature can match the request principal's `sub` against the
+`person.sub` property so policy targets the readable entity, not a raw id.
+
+## Behavior reference
+
+| Situation | Result |
+|---|---|
+| Valid webhook, user is a member | `person` upserted; 200 |
+| Valid webhook, user not a member (operator API 404) | acknowledged, no `person`; 200 |
+| Bad / unsigned / wrong-audience body | 401, action not run |
+| Missing `user_id` claim | 400, action not run |
+| Redelivered webhook (same `jti`) | deduped, action not re-run; 200 |
+| Action fails (IdP fetch error, etc.) | 502, `jti` forgotten so a retry runs again |

--- a/examples/idp-sync.lua
+++ b/examples/idp-sync.lua
@@ -1,0 +1,89 @@
+-- idp-sync.lua — provision a person entity from an identity proxy on a webhook.
+--
+-- Invoked by rela's inbound-IdP webhook receiver (POST /webhooks/idp) after it
+-- has VERIFIED the webhook's signed JWT. This action does the "fetch details"
+-- half of a thin-notify + fetch flow: the webhook told us WHICH user changed;
+-- here we fetch that user's authoritative data from the IdP's API and upsert a
+-- `person` entity keyed on the stable subject (`sub`).
+--
+-- This file is the PROVIDER-SPECIFIC layer. Everything Pratique-shaped lives
+-- here — the operator-API path, the HMAC canonical string, the X-Pratique-*
+-- header names — assembled from rela's GENERIC crypto.* + http.* primitives.
+-- Point rela at a different IdP by editing this script (and the secrets); no
+-- rela rebuild. rela's Go core contains no Pratique-specific code.
+--
+-- Params (set by the webhook receiver from the verified JWT claims):
+--   rela.params.user_id  -- the subject the event concerns (the `sub`)
+--   rela.params.org_id   -- the tenant the event concerns
+--   rela.params.event    -- e.g. "membership.created"
+--
+-- Secrets (.rela/secrets.yaml):
+--   idp_operator_url  -- base URL of the operator API, e.g. https://id.example.com
+--   idp_operator_key  -- the shared HMAC secret the operator API verifies
+
+local base = rela.secrets["idp_operator_url"]
+local key = rela.secrets["idp_operator_key"]
+local uid = rela.params["user_id"]
+local org = rela.params["org_id"]
+
+if base == "" or key == "" then
+  return { message_type = "error", message = "idp-sync: operator url/key not configured in secrets" }
+end
+if uid == "" or org == "" then
+  return { message_type = "error", message = "idp-sync: missing user_id/org_id param" }
+end
+
+-- Build the Pratique operator-API request path and its HMAC signature. The
+-- canonical string + header names are Pratique's wire format (see its
+-- docs/04-architecture.md §operator API):
+--   canonical = METHOD \n PATH \n DATE \n hex(sha256(body))
+--   signature = base64( HMAC-SHA256(secret, canonical) )
+local path = "/api/v1/orgs/" .. org .. "/members/" .. uid
+-- rela.now_unix is the current time as unix seconds (the sandbox has no
+-- os.time()). string.format("%d", ...) renders it as an integer with no decimal
+-- point / exponent, matching the server's integer date parse.
+local date = string.format("%d", rela.now_unix)
+local body = "" -- GET, no body
+local canonical = "GET" .. "\n" .. path .. "\n" .. date .. "\n" .. crypto.sha256_hex(body)
+local sig = crypto.hmac_sha256_base64(key, canonical)
+
+local resp, err = http.get(base .. path, {
+  headers = {
+    ["X-Pratique-Date"] = date,
+    ["X-Pratique-Signature"] = sig,
+    ["Accept"] = "application/json",
+  },
+})
+if err ~= nil then
+  return { message_type = "error", message = "idp-sync: fetch failed: " .. (err.message or "unknown") }
+end
+if resp.status_code == 404 then
+  -- The membership no longer exists (e.g. removed before we processed the event).
+  -- Not an error the IdP should retry: acknowledge without provisioning.
+  return { message = "idp-sync: user " .. uid .. " not a member of " .. org .. "; skipped" }
+end
+if resp.status_code ~= 200 then
+  return { message_type = "error", message = "idp-sync: fetch returned " .. tostring(resp.status_code) }
+end
+
+local user, derr = rela.json.decode(resp.body)
+if derr ~= nil or user == nil then
+  return { message_type = "error", message = "idp-sync: bad JSON from operator API" }
+end
+
+-- Upsert the person, keyed on the stable subject. Idempotent: a redelivered
+-- webhook (or a later membership change) updates the same entity rather than
+-- duplicating it. The operator API returns { user_id, email, roles, status }.
+local props = {
+  sub = user.user_id,
+  email = user.email or "",
+}
+
+local found = rela.list_entities("person", "sub=" .. uid)
+if found ~= nil and #found > 0 then
+  rela.update_entity(found[1].id, props)
+  return { message = "idp-sync: updated person " .. uid }
+end
+
+rela.create_entity("person", props)
+return { message = "idp-sync: created person " .. uid }

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -102,7 +102,7 @@ const userPaletteFile = "palette.yaml"
 // 40-method load line — extract the API/serialization/relation services into
 // their own types. Ratchet this number DOWN as methods move out; never up.
 //
-//plimsoll:max-methods=167
+//plimsoll:max-methods=169
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -222,6 +222,12 @@ type App struct {
 	// implementations with a policy-driven resolver via the same
 	// interface.
 	fieldResolver FieldVerdictResolver
+
+	// webhook holds the inbound-IdP webhook receiver (verifier + target action +
+	// dedup). nil until SetWebhookReceiver is called, in which case the
+	// /webhooks/idp route is not mounted. Optional wiring, like security and
+	// principalResolver above.
+	webhook *webhookReceiver
 
 	// auditSink records short-circuit rejections (affordance gates)
 	// that never reach the entitymanager. ACL denials already get a

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -87,6 +87,12 @@ func (a *App) NewRouter() http.Handler {
 	// Sync API (FEAT-NJ9FEN) - machine-to-machine fs↔pg sync, under /api/sync/.
 	a.registerSyncRoutes(inner)
 
+	// Inbound-IdP webhook (POST /webhooks/idp) — mounted only when a receiver is
+	// configured (SetWebhookReceiver). It lives OUTSIDE /api/ because it
+	// authenticates itself by verifying a signed JWT body, not a proxy header or
+	// cookie, so it is CSRF-immune by construction and needs no same-origin gate.
+	a.registerWebhookRoutes(inner)
+
 	// noCacheMiddleware sets no-cache headers on API responses so that
 	// browsers always fetch fresh data after file changes trigger a reload.
 	mux.Handle("/api/", a.noCacheMiddleware(inner))

--- a/internal/dataentry/webhook.go
+++ b/internal/dataentry/webhook.go
@@ -1,0 +1,231 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// errWebhookActionMissing is returned when the configured provisioning action id
+// does not exist in the loaded config — an operator misconfiguration.
+var errWebhookActionMissing = errors.New("dataentry: configured webhook action not found")
+
+// WebhookClaims is the verified subset of an inbound webhook the receiver acts
+// on. It mirrors jwtauth.WebhookClaims but is declared HERE so the dataentry
+// package needn't import jwtauth (the inward-pointing layering rule — the same
+// reason JWTPrincipalResolver takes a local subjectVerifier interface). The
+// wiring layer, which may import both, adapts the concrete verifier to this
+// shape.
+type WebhookClaims struct {
+	Event  string // the event name, e.g. "membership.created"
+	UserID string // the subject the event concerns
+	OrgID  string // the tenant the event concerns
+	ID     string // the webhook id (jti), for replay dedup
+}
+
+// webhookMaxBody caps the JWT body the receiver reads before verifying it, so a
+// malicious oversized body can't exhaust memory pre-auth. A webhook JWT is a few
+// hundred bytes; 64 KiB is generous headroom.
+const webhookMaxBody = 64 << 10 // 64 KiB
+
+// webhookActionTimeout bounds the provisioning action (which fetches the user
+// from the IdP over HTTP, then upserts). Longer than the interactive
+// actionTimeout because the network round-trip to the IdP dominates.
+const webhookActionTimeout = 15 * time.Second
+
+// webhookDedupTTL is how long a processed webhook id is remembered so a redelivery
+// (IdPs retry on a slow/failed response) is a no-op rather than a duplicate
+// provision. The window need only exceed the IdP's retry span.
+const webhookDedupTTL = 10 * time.Minute
+
+// webhookVerifier verifies a signed webhook JWT and projects the claims the
+// receiver acts on. Declared at the call site (returning the local WebhookClaims
+// so this package doesn't import jwtauth) — the wiring layer adapts the concrete
+// *jwtauth.WebhookVerifier to it. Also lets the handler be tested with a stub.
+type webhookVerifier interface {
+	VerifyWebhook(ctx context.Context, raw string) (WebhookClaims, error)
+}
+
+// webhookReceiver holds the wiring for the inbound-IdP webhook: the verifier, the
+// action it dispatches to, and a small dedup cache. Nil on the App until
+// SetWebhookReceiver is called, in which case the route is not mounted.
+type webhookReceiver struct {
+	verify   webhookVerifier
+	actionID string
+	seen     *seenSet
+}
+
+// SetWebhookReceiver enables the POST /webhooks/idp endpoint: a verified IdP
+// callback that dispatches to the named action (which fetches authoritative user
+// data and upserts a person entity). Must be called before NewRouter. A nil
+// verifier or empty actionID leaves the receiver disabled and the route
+// unmounted — matching the inert-when-unconfigured shape of the other optional
+// wiring (SetPrincipalResolver, SetSecurityConfig).
+func (a *App) SetWebhookReceiver(v webhookVerifier, actionID string) {
+	if v == nil || actionID == "" {
+		return
+	}
+	a.webhook = &webhookReceiver{verify: v, actionID: actionID, seen: newSeenSet(webhookDedupTTL)}
+}
+
+// registerWebhookRoutes mounts the webhook endpoint when a receiver is
+// configured. Called from NewRouter. The route lives OUTSIDE /api/ on purpose:
+// it is not the browser API surface, and it authenticates itself by verifying a
+// signed JWT body rather than trusting a proxy header or a session cookie. That
+// makes it CSRF-immune by construction (a browser cannot forge an ES256
+// signature), so it needs neither the same-origin gate nor the CSRF-exempt
+// heuristic the sync API relies on.
+func (a *App) registerWebhookRoutes(mux *http.ServeMux) {
+	if a.webhook == nil {
+		return
+	}
+	// The handler lives on the receiver; the App only supplies the dispatch
+	// closure (which needs App internals: scriptEngine, State, writeMu). This
+	// keeps the HTTP-flow logic off the (already large) App type.
+	rec := a.webhook
+	mux.HandleFunc("POST /webhooks/idp", func(w http.ResponseWriter, r *http.Request) {
+		rec.handle(w, r, func(ctx context.Context, claims WebhookClaims) error {
+			return dispatchWebhookAction(ctx, a, rec.actionID, claims)
+		})
+	})
+}
+
+// handle verifies an inbound IdP webhook and dispatches it via dispatch. The
+// request body is the signed JWT (the IdP sends Content-Type: application/jwt).
+// On any verification failure it answers 401 and dispatch is never called. A
+// redelivered webhook (same id) is acknowledged with 200 without re-dispatching.
+func (rec *webhookReceiver) handle(w http.ResponseWriter, r *http.Request, dispatch func(context.Context, WebhookClaims) error) {
+	raw, err := io.ReadAll(io.LimitReader(r.Body, webhookMaxBody))
+	if err != nil {
+		http.Error(w, "read failed", http.StatusBadRequest)
+		return
+	}
+
+	claims, err := rec.verify.VerifyWebhook(r.Context(), string(raw))
+	if err != nil {
+		// Do not echo the reason — a probing client learns nothing beyond "rejected".
+		slog.Warn("idp webhook rejected", "error", err)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// A membership event with no subject is unusable — the action has nothing to
+	// fetch. Treat it as a bad request rather than dispatching a no-op.
+	if claims.UserID == "" {
+		http.Error(w, "missing user_id", http.StatusBadRequest)
+		return
+	}
+
+	// Dedup on the webhook id (jti). An id-less webhook can't be deduped, so it is
+	// always processed — at-least-once is acceptable because the action is
+	// idempotent (it upserts by sub).
+	if claims.ID != "" && !rec.seen.add(claims.ID) {
+		slog.Info("idp webhook deduped", "id", claims.ID, "event", claims.Event)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if err := dispatch(r.Context(), claims); err != nil {
+		// The action failed (IdP fetch error, script error, ...). Return 502 so the
+		// IdP retries; drop the id from the seen-set so the retry isn't deduped.
+		if claims.ID != "" {
+			rec.seen.forget(claims.ID)
+		}
+		slog.Warn("idp webhook action failed", "action", rec.actionID, "event", claims.Event, "error", err)
+		http.Error(w, "action failed", http.StatusBadGateway)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// dispatchWebhookAction runs the provisioning action with the webhook's claims as
+// params, under the webhook-receiver principal. Serialized against other
+// mutations via writeMu (the action upserts an entity), matching handleV1Action.
+// A free function (not an App method) to keep the App type's method count down;
+// it still needs App internals, so it takes *App explicitly.
+func dispatchWebhookAction(ctx context.Context, a *App, actionID string, claims WebhookClaims) error {
+	s := a.State()
+	action, ok := s.Cfg.Actions[actionID]
+	if !ok {
+		// Misconfiguration: the configured action id doesn't exist. Fail loud in
+		// the log; the 502 the caller sends will surface it operationally too.
+		slog.Error("idp webhook: configured action not found", "action", actionID)
+		return errWebhookActionMissing
+	}
+
+	// Stamp the webhook-receiver principal so the provisioned entity is attributed
+	// to the callback, not to the default data-entry "unknown". The action path
+	// reads principal.From(ctx).
+	ctx = principal.With(ctx, principal.Principal{
+		User: "webhook:" + claims.Event,
+		Tool: principal.ToolWebhookReceiver,
+	})
+
+	params := map[string]string{
+		"event":   claims.Event,
+		"user_id": claims.UserID,
+		"org_id":  claims.OrgID,
+	}
+
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
+
+	_, err := a.scriptEngine.ExecuteAction(ctx, action.Script, a.luaWriteDeps(),
+		nil, params, webhookActionTimeout, newCorrelationID())
+	return err
+}
+
+// --- dedup seen-set -------------------------------------------------------
+
+// seenSet is a small TTL set of recently-processed webhook ids. It bounds memory
+// by evicting expired entries on each add; the id space per window is tiny (one
+// per membership change), so no size cap is needed beyond the TTL sweep.
+type seenSet struct {
+	mu  sync.Mutex
+	ttl time.Duration
+	at  map[string]time.Time
+	// now is injectable for tests; nil ⇒ time.Now.
+	now func() time.Time
+}
+
+func newSeenSet(ttl time.Duration) *seenSet {
+	return &seenSet{ttl: ttl, at: make(map[string]time.Time)}
+}
+
+func (s *seenSet) clock() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+// add records id and reports whether it was NEW (true) or already present within
+// the TTL (false). Expired entries are swept on each call.
+func (s *seenSet) add(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.clock()
+	for k, t := range s.at {
+		if now.Sub(t) > s.ttl {
+			delete(s.at, k)
+		}
+	}
+	if t, ok := s.at[id]; ok && now.Sub(t) <= s.ttl {
+		return false
+	}
+	s.at[id] = now
+	return true
+}
+
+// forget drops id so a retried-after-failure webhook isn't deduped.
+func (s *seenSet) forget(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.at, id)
+}

--- a/internal/dataentry/webhook_test.go
+++ b/internal/dataentry/webhook_test.go
@@ -1,0 +1,173 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+)
+
+// errStubReject stands in for a verification failure in the shim test — the
+// handler only branches on err != nil, so the concrete error doesn't matter.
+var errStubReject = errors.New("stub: rejected")
+
+// stubWebhookVerifier returns a fixed result, so the shim test exercises the
+// dispatch/dedup/principal mechanics without a JWKS server (real verification is
+// covered in internal/jwtauth).
+type stubWebhookVerifier struct {
+	claims WebhookClaims
+	err    error
+}
+
+func (s stubWebhookVerifier) VerifyWebhook(context.Context, string) (WebhookClaims, error) {
+	return s.claims, s.err
+}
+
+// newWebhookTestApp wires an App with the given action script + a webhook
+// receiver backed by the stub verifier dispatching to action id "idp-sync".
+func newWebhookTestApp(t *testing.T, script string, v webhookVerifier) *App {
+	t.Helper()
+	app := newActionTestApp(t, map[string]string{"idp-sync.lua": script})
+	app.Cfg().Actions = map[string]dataentryconfig.Action{
+		"idp-sync": {Script: "idp-sync.lua"},
+	}
+	app.SetWebhookReceiver(v, "idp-sync")
+	return app
+}
+
+func postWebhook(app *App, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/idp", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	// Drive the receiver's handler with the same dispatch closure production wires
+	// in registerWebhookRoutes.
+	r := app.webhook
+	r.handle(rec, req, func(ctx context.Context, claims WebhookClaims) error {
+		return dispatchWebhookAction(ctx, app, r.actionID, claims)
+	})
+	return rec
+}
+
+// TestWebhook_DispatchesActionWithClaims: a verified webhook runs the action with
+// event/user_id/org_id as params. The action echoes user_id back in its message.
+func TestWebhook_DispatchesActionWithClaims(t *testing.T) {
+	script := `return { message = "synced " .. rela.params["user_id"] .. " in " .. rela.params["org_id"] }`
+	v := stubWebhookVerifier{claims: WebhookClaims{
+		Event: "membership.created", UserID: "usr_1", OrgID: "org_1", ID: "evt_1",
+	}}
+	app := newWebhookTestApp(t, script, v)
+
+	rec := postWebhook(app, "any.jwt.body")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestWebhook_DedupsByID: a redelivered webhook (same id) does not re-run the
+// action. The action increments a counter entity; after two deliveries the count
+// must be 1.
+func TestWebhook_DedupsByID(t *testing.T) {
+	// The action creates a ticket on each run; we count runs via list length.
+	script := `rela.create_entity("ticket", { title = "run" })
+	           return { message = "ok" }`
+	v := stubWebhookVerifier{claims: WebhookClaims{
+		Event: "membership.created", UserID: "usr_1", OrgID: "org_1", ID: "evt_dup",
+	}}
+	app := newWebhookTestApp(t, script, v)
+
+	if rec := postWebhook(app, "b1"); rec.Code != http.StatusOK {
+		t.Fatalf("first delivery status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if rec := postWebhook(app, "b2"); rec.Code != http.StatusOK {
+		t.Fatalf("redelivery status = %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	got := countEntities(t, app, "ticket")
+	if got != 1 {
+		t.Fatalf("action ran %d times; want 1 (redelivery must be deduped)", got)
+	}
+}
+
+// TestWebhook_RejectsBadSignature: a verification failure → 401 and the action
+// never runs.
+func TestWebhook_RejectsBadSignature(t *testing.T) {
+	script := `rela.create_entity("ticket", { title = "should-not-run" })
+	           return { message = "ok" }`
+	v := stubWebhookVerifier{err: errStubReject}
+	app := newWebhookTestApp(t, script, v)
+
+	rec := postWebhook(app, "forged")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if n := countEntities(t, app, "ticket"); n != 0 {
+		t.Fatalf("action ran on a rejected webhook (%d entities)", n)
+	}
+}
+
+// TestWebhook_MissingUserID: a verified webhook with no user_id → 400 (nothing to
+// provision), action not run.
+func TestWebhook_MissingUserID(t *testing.T) {
+	script := `rela.create_entity("ticket", { title = "x" }); return {}`
+	v := stubWebhookVerifier{claims: WebhookClaims{Event: "membership.created", ID: "evt_x"}}
+	app := newWebhookTestApp(t, script, v)
+
+	rec := postWebhook(app, "b")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if n := countEntities(t, app, "ticket"); n != 0 {
+		t.Fatalf("action ran despite missing user_id (%d entities)", n)
+	}
+}
+
+// TestWebhook_ActionFailureRetryable: when the action fails, the receiver answers
+// 502 AND forgets the id, so a retry (same id) is NOT deduped and runs again.
+func TestWebhook_ActionFailureRetryable(t *testing.T) {
+	// The action always fails. Both deliveries (same id) must reach it and 502 —
+	// proving a failed id is not remembered, so the IdP's retry runs again.
+	script := `error("boom")`
+	v := stubWebhookVerifier{claims: WebhookClaims{
+		Event: "membership.created", UserID: "usr_1", OrgID: "org_1", ID: "evt_retry",
+	}}
+	app := newWebhookTestApp(t, script, v)
+
+	if rec := postWebhook(app, "b1"); rec.Code != http.StatusBadGateway {
+		t.Fatalf("first failure status = %d, want 502 (%s)", rec.Code, rec.Body.String())
+	}
+	// If the failed id had been remembered, this would 200 (deduped). It must 502
+	// again — the retry reaches the action.
+	if rec := postWebhook(app, "b2"); rec.Code != http.StatusBadGateway {
+		t.Fatalf("retry after failure status = %d, want 502 (id must be forgotten on failure)", rec.Code)
+	}
+}
+
+// TestSeenSet_TTLExpiry: an id past the TTL is treated as new again.
+func TestSeenSet_TTLExpiry(t *testing.T) {
+	s := newSeenSet(time.Minute)
+	base := time.Unix(1_700_000_000, 0)
+	s.now = func() time.Time { return base }
+
+	if !s.add("a") {
+		t.Fatal("first add should be new")
+	}
+	if s.add("a") {
+		t.Fatal("immediate re-add should be a duplicate")
+	}
+	// Advance past the TTL.
+	s.now = func() time.Time { return base.Add(2 * time.Minute) }
+	if !s.add("a") {
+		t.Fatal("re-add after TTL should be new again")
+	}
+}
+
+// countEntities returns how many entities of the given type exist in the app's
+// store — used to count action runs.
+func countEntities(t *testing.T, app *App, typ string) int {
+	t.Helper()
+	return len(entitiesByType(app, typ))
+}

--- a/internal/jwtauth/verifier.go
+++ b/internal/jwtauth/verifier.go
@@ -98,6 +98,79 @@ func (v *Verifier) VerifySubject(ctx context.Context, raw string) (string, error
 	return sub, nil
 }
 
+// WebhookClaims is the subset of a verified webhook JWT the receiver acts on.
+// It is a typed projection — the package never leaks jwt.MapClaims across its
+// boundary — so a caller can't accidentally trust an unverified claim.
+type WebhookClaims struct {
+	Event  string // the "event" claim, e.g. "membership.created"
+	UserID string // the "user_id" claim — the subject the event concerns
+	OrgID  string // the "org_id" claim — the tenant the event concerns
+	ID     string // the "jti" claim, if present — used for replay dedup
+}
+
+// WebhookVerifier verifies signed webhook JWTs. It is DISTINCT from the identity
+// Verifier on purpose: a webhook is a server-to-server notification, not a
+// request assertion, so it carries its OWN audience (the value the IdP stamps on
+// callbacks, e.g. "rela-webhook"). Pinning that audience separately — rather than
+// relaxing the audience check — keeps the confused-deputy guard intact: an
+// identity assertion (aud = this server) can't be replayed as a webhook and vice
+// versa. Same JWKS + issuer + ES256 + required-expiry as the identity path.
+type WebhookVerifier struct {
+	kf   keyfunc.Keyfunc
+	opts []jwt.ParserOption
+}
+
+// NewWebhookVerifier builds a webhook verifier sharing an existing identity
+// Verifier's JWKS + issuer, but pinning webhookAudience instead of the identity
+// audience. Reusing the identity Verifier's already-fetched, auto-refreshing JWKS
+// means no second network fetch and one refresh cadence. webhookAudience is
+// required — an empty one would accept any audience, reopening the confused-
+// deputy hole this type exists to close.
+func NewWebhookVerifier(idv *Verifier, webhookAudience string) (*WebhookVerifier, error) {
+	if idv == nil {
+		return nil, errors.New("jwtauth: identity verifier is required")
+	}
+	if webhookAudience == "" {
+		return nil, errors.New("jwtauth: webhook audience is required")
+	}
+	opts := []jwt.ParserOption{
+		jwt.WithValidMethods([]string{"ES256"}),
+		jwt.WithIssuer(idv.cfg.Issuer),
+		jwt.WithAudience(webhookAudience),
+		jwt.WithExpirationRequired(),
+	}
+	return &WebhookVerifier{kf: idv.kf, opts: opts}, nil
+}
+
+// VerifyWebhook verifies a webhook JWT and projects the claims the receiver acts
+// on. Any signature/issuer/audience/expiry failure yields ErrInvalid. The event,
+// user_id, and org_id claims are read as strings; a missing one comes back "" and
+// the caller decides whether that's fatal (a membership event with no user_id is
+// unusable, for instance). ctx bounds any JWKS refresh a rare unknown-kid needs.
+func (v *WebhookVerifier) VerifyWebhook(ctx context.Context, raw string) (WebhookClaims, error) {
+	claims := jwt.MapClaims{}
+	if _, err := jwt.NewParser(v.opts...).ParseWithClaims(raw, claims, v.kf.KeyfuncCtx(ctx)); err != nil {
+		return WebhookClaims{}, fmt.Errorf("%w: %w", ErrInvalid, err)
+	}
+	return WebhookClaims{
+		Event:  stringClaim(claims, "event"),
+		UserID: stringClaim(claims, "user_id"),
+		OrgID:  stringClaim(claims, "org_id"),
+		ID:     stringClaim(claims, "jti"),
+	}, nil
+}
+
+// stringClaim reads a string claim, returning "" when absent or not a string.
+// Non-string is treated as absent rather than an error: a malformed claim is
+// indistinguishable from a missing one for the receiver's purposes (it acts on
+// the value only when non-empty).
+func stringClaim(claims jwt.MapClaims, key string) string {
+	if v, ok := claims[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
 // requireHTTPS rejects a JWKS URL that isn't https — the JWKS is the root of
 // trust for every signature, so fetching it over cleartext would let an on-path
 // attacker substitute their own signing key (a full auth bypass). A loopback

--- a/internal/jwtauth/verifier_test.go
+++ b/internal/jwtauth/verifier_test.go
@@ -162,6 +162,98 @@ func TestVerifySubject_RejectsRS256(t *testing.T) {
 
 func future() int64 { return time.Now().Add(time.Hour).Unix() }
 
+const testWebhookAud = "rela-webhook"
+
+// TestVerifyWebhook_Valid: a webhook JWT with the webhook audience verifies and
+// its event/user_id/org_id/jti claims are projected.
+func TestVerifyWebhook_Valid(t *testing.T) {
+	idv, mint, srv := testIssuer(t)
+	defer srv.Close()
+	wv, err := NewWebhookVerifier(idv, testWebhookAud)
+	if err != nil {
+		t.Fatalf("NewWebhookVerifier: %v", err)
+	}
+	tok := mint(jwt.MapClaims{
+		"iss": testIss, "aud": testWebhookAud, "exp": future(),
+		"event": "membership.created", "user_id": "usr_1", "org_id": "org_1", "jti": "evt_abc",
+	})
+	got, err := wv.VerifyWebhook(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("VerifyWebhook: %v", err)
+	}
+	if got.Event != "membership.created" || got.UserID != "usr_1" || got.OrgID != "org_1" || got.ID != "evt_abc" {
+		t.Fatalf("claims = %+v; want event/user/org/jti populated", got)
+	}
+}
+
+// TestVerifyWebhook_RejectsIdentityAudience is the confused-deputy guard: a token
+// minted for the IDENTITY audience must NOT verify as a webhook (and vice versa),
+// because the two verifiers pin different audiences.
+func TestVerifyWebhook_RejectsIdentityAudience(t *testing.T) {
+	idv, mint, srv := testIssuer(t)
+	defer srv.Close()
+	wv, err := NewWebhookVerifier(idv, testWebhookAud)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// aud = the identity audience, not the webhook one → must be rejected.
+	tok := mint(jwt.MapClaims{
+		"iss": testIss, "aud": testAud, "exp": future(),
+		"event": "membership.created", "user_id": "usr_1", "org_id": "org_1",
+	})
+	if _, err := wv.VerifyWebhook(context.Background(), tok); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("an identity-audience token must not verify as a webhook, got %v", err)
+	}
+}
+
+// TestVerifyWebhook_Rejects covers the same failure modes as the identity path:
+// wrong issuer, expired, missing expiry, alg:none, forged key.
+func TestVerifyWebhook_Rejects(t *testing.T) {
+	idv, mint, srv := testIssuer(t)
+	defer srv.Close()
+	wv, err := NewWebhookVerifier(idv, testWebhookAud)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name   string
+		claims jwt.MapClaims
+	}{
+		{"wrong issuer", jwt.MapClaims{"iss": "https://evil.test", "aud": testWebhookAud, "exp": future()}},
+		{"wrong audience", jwt.MapClaims{"iss": testIss, "aud": "something-else", "exp": future()}},
+		{"expired", jwt.MapClaims{"iss": testIss, "aud": testWebhookAud, "exp": time.Now().Add(-time.Hour).Unix()}},
+		{"no expiry", jwt.MapClaims{"iss": testIss, "aud": testWebhookAud}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := wv.VerifyWebhook(context.Background(), mint(c.claims)); !errors.Is(err, ErrInvalid) {
+				t.Errorf("expected ErrInvalid, got %v", err)
+			}
+		})
+	}
+
+	// alg:none must be rejected.
+	none := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
+		"iss": testIss, "aud": testWebhookAud, "exp": future(),
+	})
+	raw, _ := none.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if _, err := wv.VerifyWebhook(context.Background(), raw); !errors.Is(err, ErrInvalid) {
+		t.Errorf("alg:none must be rejected, got %v", err)
+	}
+}
+
+// TestNewWebhookVerifier_RequiresAudienceAndVerifier: both pins are mandatory.
+func TestNewWebhookVerifier_RequiresAudienceAndVerifier(t *testing.T) {
+	idv, _, srv := testIssuer(t)
+	defer srv.Close()
+	if _, err := NewWebhookVerifier(nil, testWebhookAud); err == nil {
+		t.Error("NewWebhookVerifier must require an identity verifier")
+	}
+	if _, err := NewWebhookVerifier(idv, ""); err == nil {
+		t.Error("NewWebhookVerifier must require a non-empty webhook audience")
+	}
+}
+
 // TestNew_FatalOnUnreachableJWKS pins the C1 contract: New MUST error when the
 // JWKS can't be fetched at startup, so the server fails loud instead of booting a
 // verifier that silently rejects every token. (keyfunc's default would swallow

--- a/internal/lua/crypto.go
+++ b/internal/lua/crypto.go
@@ -1,0 +1,70 @@
+// Lua bindings for the top-level crypto.* module.
+//
+// Generic, provider-neutral hashing primitives so a Lua action can assemble a
+// signed request for an upstream that authenticates with an HMAC signature (an
+// identity proxy's operator API, a webhook callback, ...). The PRIMITIVES live
+// here in Go; the provider-specific SHAPE — which canonical string to hash, which
+// header names to send — lives in the Lua action. That split is deliberate: it
+// lets rela sign requests for any HMAC-authenticated IdP without compiling in
+// support for any particular one (point the action at a different proxy and only
+// the script changes, not this package).
+//
+// Crypto is Go, not Lua, for the same reason http.get is: the primitive belongs
+// in the host where it can be reviewed and bounded. But note the ASYMMETRY with
+// verification — rela VERIFIES signed assertions entirely in Go (see
+// internal/jwtauth), because a verifier is a root of trust. These functions only
+// SIGN outbound requests with a key the operator already placed in secrets; they
+// are a hashing tool for the glue layer, not a trust boundary.
+//
+// Convention (matches json.encode): a hashing primitive cannot fail on a valid
+// string input, so these RAISE on a wrong-type argument (a programming error) and
+// otherwise always return a value — no (value, err) pair.
+//
+//	crypto.sha256_hex(data)             -> string  (lowercase hex of SHA-256)
+//	crypto.hmac_sha256_base64(key, msg) -> string  (std base64 of HMAC-SHA256)
+package lua
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+// registerCryptoModule installs the top-level `crypto` global. Always
+// registered; no configuration needed (matches http.*). A free function rather
+// than a *Runtime method to keep the Runtime type's method count flat (the type
+// is at its plimsoll load line; see the directive on Runtime).
+func registerCryptoModule(r *Runtime) {
+	tbl := r.L.NewTable()
+	r.L.SetField(tbl, "sha256_hex", r.L.NewFunction(luaSHA256Hex))
+	r.L.SetField(tbl, "hmac_sha256_base64", r.L.NewFunction(luaHMACSHA256Base64))
+	r.L.SetGlobal("crypto", tbl)
+}
+
+// luaSHA256Hex implements crypto.sha256_hex(data) -> lowercase-hex string.
+// Used to compute a body digest for a canonical signing string. Raises on a
+// non-string argument.
+func luaSHA256Hex(ls *lua.LState) int {
+	data := ls.CheckString(1)
+	sum := sha256.Sum256([]byte(data))
+	ls.Push(lua.LString(hex.EncodeToString(sum[:])))
+	return 1
+}
+
+// luaHMACSHA256Base64 implements crypto.hmac_sha256_base64(key, message) ->
+// std-base64 string. key and message are raw bytes carried as Lua strings (Lua
+// strings are byte strings, so a binary key round-trips intact). Raises on a
+// non-string argument. An empty key is accepted — HMAC is defined for it — and is
+// the caller's responsibility to avoid; a wrong/empty key simply produces a
+// signature the server rejects.
+func luaHMACSHA256Base64(ls *lua.LState) int {
+	key := ls.CheckString(1)
+	msg := ls.CheckString(2)
+	mac := hmac.New(sha256.New, []byte(key))
+	_, _ = mac.Write([]byte(msg))
+	ls.Push(lua.LString(base64.StdEncoding.EncodeToString(mac.Sum(nil))))
+	return 1
+}

--- a/internal/lua/crypto_test.go
+++ b/internal/lua/crypto_test.go
@@ -1,0 +1,111 @@
+package lua
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newCryptoTestRuntime(t *testing.T) (*Runtime, *strings.Builder) {
+	t.Helper()
+	var sb strings.Builder
+	rt := NewReader(ReadDeps{}, &sb)
+	return rt, &sb
+}
+
+// runCryptoString runs a script that outputs a single string and returns it.
+func runCryptoString(t *testing.T, script string) string {
+	t.Helper()
+	rt, buf := newCryptoTestRuntime(t)
+	defer rt.Close()
+	require.NoError(t, rt.RunString(script))
+	var out string
+	require.NoError(t, json.Unmarshal([]byte(buf.String()), &out))
+	return out
+}
+
+func TestSHA256Hex(t *testing.T) {
+	t.Parallel()
+	// Known vector: sha256("") = e3b0c442...b855.
+	got := runCryptoString(t, `rela.output(crypto.sha256_hex(""))`)
+	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", got)
+
+	// Cross-check an arbitrary input (with embedded newlines, built in Lua so the
+	// Go-side source stays a single line) against Go's own hasher.
+	const in = "GET\n/api/v1/orgs/org_1/members/usr_1\n1700000000\n"
+	sum := sha256.Sum256([]byte(in))
+	want := hex.EncodeToString(sum[:])
+	got = runCryptoString(t,
+		`rela.output(crypto.sha256_hex("GET" .. "\n" .. "/api/v1/orgs/org_1/members/usr_1" .. "\n" .. "1700000000" .. "\n"))`)
+	assert.Equal(t, want, got)
+}
+
+func TestHMACSHA256Base64(t *testing.T) {
+	t.Parallel()
+	const key = "dev-operator-secret"
+	const msg = "GET\n/api/v1/orgs/org_1/members/usr_1\n1700000000\nabc123"
+
+	// Cross-check the Lua binding against Go's own HMAC — the whole point is that
+	// a signature assembled in Lua is byte-identical to what an HMAC-verifying
+	// server (e.g. Pratique's operator API) recomputes.
+	mac := hmac.New(sha256.New, []byte(key))
+	_, _ = mac.Write([]byte(msg))
+	want := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	// Build msg in Lua via concatenation so the embedded newlines don't break the
+	// Go-side source string.
+	got := runCryptoString(t,
+		`local msg = "GET" .. "\n" .. "/api/v1/orgs/org_1/members/usr_1" .. "\n" .. "1700000000" .. "\n" .. "abc123"
+		 rela.output(crypto.hmac_sha256_base64("`+key+`", msg))`)
+	assert.Equal(t, want, got)
+}
+
+// TestCryptoSignsLikePratiqueOperator proves the end-to-end intent: a Lua action
+// can build the EXACT canonical string + signature Pratique's operator API
+// verifies (METHOD\nPATH\nDATE\nhex(sha256(body)), HMAC-SHA256, base64), using
+// only the generic crypto primitives. The canonical SHAPE lives in the script
+// (provider-specific); the primitives live in Go (generic).
+func TestCryptoSignsLikePratiqueOperator(t *testing.T) {
+	t.Parallel()
+	const (
+		key    = "shared-hmac-key"
+		method = "GET"
+		path   = "/api/v1/orgs/org_acme/members/usr_founder"
+		date   = "1700000000"
+		body   = "" // GET, empty body
+	)
+
+	script := `
+		local body_hash = crypto.sha256_hex("` + body + `")
+		local canonical = "` + method + `" .. "\n" .. "` + path + `" .. "\n" .. "` + date + `" .. "\n" .. body_hash
+		rela.output(crypto.hmac_sha256_base64("` + key + `", canonical))
+	`
+	got := runCryptoString(t, script)
+
+	// Recompute the same way Pratique's signOperator does (docs/04-architecture.md).
+	bodySum := sha256.Sum256([]byte(body))
+	canonical := method + "\n" + path + "\n" + date + "\n" + hex.EncodeToString(bodySum[:])
+	mac := hmac.New(sha256.New, []byte(key))
+	_, _ = mac.Write([]byte(canonical))
+	want := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	assert.Equal(t, want, got, "Lua-assembled operator signature must match the Go signer")
+}
+
+func TestCryptoRaisesOnNonString(t *testing.T) {
+	t.Parallel()
+	rt, _ := newCryptoTestRuntime(t)
+	defer rt.Close()
+	// A table where a string is required is a programming error → raise. (A
+	// number would be silently coerced by gopher-lua's CheckString, so use a
+	// value that genuinely cannot convert.)
+	err := rt.RunString(`crypto.sha256_hex({})`)
+	require.Error(t, err)
+}

--- a/internal/lua/idpsync_test.go
+++ b/internal/lua/idpsync_test.go
@@ -1,0 +1,165 @@
+package lua
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// TestIdpSyncAction runs the SHIPPED examples/idp-sync.lua end to end against a
+// stubbed operator API, proving the provider-specific glue works with the generic
+// crypto.* + http.* primitives: it signs a Pratique-shaped operator request, and
+// upserts a person keyed on sub (idempotently).
+func TestIdpSyncAction(t *testing.T) {
+	const (
+		orgID  = "org_acme"
+		userID = "usr_founder"
+		email  = "founder@acme.test"
+		hmacK  = "shared-hmac-key"
+	)
+
+	// A stub operator API that VERIFIES the incoming Pratique signature the way the
+	// real server does, then returns the member. Verifying here (not just checking
+	// presence) proves the Lua-assembled signature is byte-correct.
+	var sawPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawPath = r.URL.Path
+		date := r.Header.Get("X-Pratique-Date")
+		sig := r.Header.Get("X-Pratique-Signature")
+		if date == "" || sig == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// Recompute canonical = METHOD\nPATH\nDATE\nhex(sha256(body)); body is empty.
+		bodySum := sha256.Sum256(nil)
+		canonical := r.Method + "\n" + r.URL.Path + "\n" + date + "\n" + hex.EncodeToString(bodySum[:])
+		mac := hmac.New(sha256.New, []byte(hmacK))
+		_, _ = mac.Write([]byte(canonical))
+		want := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+		if sig != want {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"user_id":"` + userID + `","email":"` + email + `","roles":["founder"],"status":"active"}`))
+	}))
+	defer srv.Close()
+
+	ws := newMockWorkspaceWith(personMeta())
+	script := readExampleScript(t, "idp-sync.lua")
+	secrets := map[string]string{
+		"idp_operator_url": srv.URL,
+		"idp_operator_key": hmacK,
+	}
+	params := map[string]string{"user_id": userID, "org_id": orgID, "event": "membership.created"}
+
+	// --- first run: creates the person ---
+	runIdpSync(t, ws, script, secrets, params)
+
+	people := ws.entitiesOfType("person")
+	if len(people) != 1 {
+		t.Fatalf("after first run: %d person entities, want 1", len(people))
+	}
+	if got := people[0].Properties["sub"]; got != userID {
+		t.Errorf("person sub = %v, want %s", got, userID)
+	}
+	if got := people[0].Properties["email"]; got != email {
+		t.Errorf("person email = %v, want %s", got, email)
+	}
+	if sawPath != "/api/v1/orgs/"+orgID+"/members/"+userID {
+		t.Errorf("operator path = %q, want the org/member path", sawPath)
+	}
+
+	// --- second run: updates, no duplicate ---
+	runIdpSync(t, ws, script, secrets, params)
+	if n := len(ws.entitiesOfType("person")); n != 1 {
+		t.Fatalf("after second run: %d person entities, want 1 (idempotent upsert)", n)
+	}
+}
+
+// TestIdpSyncAction_SkipsOn404: a 404 from the operator API (membership gone) is
+// acknowledged without creating a person.
+func TestIdpSyncAction_SkipsOn404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	ws := newMockWorkspaceWith(personMeta())
+	script := readExampleScript(t, "idp-sync.lua")
+	secrets := map[string]string{"idp_operator_url": srv.URL, "idp_operator_key": "k"}
+	params := map[string]string{"user_id": "usr_gone", "org_id": "org_1"}
+
+	runIdpSync(t, ws, script, secrets, params)
+	if n := len(ws.entitiesOfType("person")); n != 0 {
+		t.Fatalf("a 404 must not provision a person, got %d", n)
+	}
+}
+
+// runIdpSync executes the action script with the given secrets + params against
+// the workspace's store.
+func runIdpSync(t *testing.T, ws *mockWorkspace, script string, secrets, params map[string]string) {
+	t.Helper()
+	var buf strings.Builder
+	rt := NewWriter(ws.services("/tmp"), &buf,
+		WithSecrets(secrets),
+		WithParams(params),
+		WithActionMode(),
+	)
+	defer rt.Close()
+	if _, err := rt.RunActionString(script, "idp-sync.lua"); err != nil {
+		t.Fatalf("idp-sync run failed: %v (output: %s)", err, buf.String())
+	}
+}
+
+// readExampleScript loads a script from the repo's examples/ directory. The test
+// runs from internal/lua, so examples/ is three levels up.
+func readExampleScript(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join("..", "..", "examples", name)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// personMeta is a metamodel with a person type (sub required + email), the shape
+// the idp-sync action provisions.
+func personMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"person": {
+				IDPrefix: "PSN",
+				Properties: map[string]metamodel.PropertyDef{
+					"sub":   {Type: "string", Required: true},
+					"email": {Type: "string"},
+				},
+			},
+		},
+	}
+}
+
+// entitiesOfType returns the mock workspace's entities of a given type.
+func (m *mockWorkspace) entitiesOfType(typ string) []*entity.Entity {
+	out := make([]*entity.Entity, 0)
+	for e, err := range m.store.ListEntities(context.Background(), store.EntityQuery{Type: typ}) {
+		if err != nil {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -668,6 +668,12 @@ func (r *Runtime) registerBindings(allowWrites bool) {
 
 	// Top-level http.* module (always registered; no configuration needed).
 	r.registerHTTPModule()
+
+	// Top-level crypto.* module — generic hashing primitives so a Lua action
+	// can sign an outbound request to an HMAC-authenticated upstream. Always
+	// registered; no configuration needed. Free function (see crypto.go) to keep
+	// the Runtime method count flat.
+	registerCryptoModule(r)
 }
 
 // registerReadBindings installs read-only bindings on the rela table: entity
@@ -697,6 +703,13 @@ func (r *Runtime) registerReadBindings(rela *lua.LTable) {
 	r.L.SetField(rela, "sort_entities", r.L.NewFunction(r.luaSortEntities))
 	r.L.SetField(rela, "days_since", r.L.NewFunction(luaDaysSince))
 	r.L.SetField(rela, "today", lua.LString(time.Now().Format("2006-01-02")))
+	// rela.now_unix: the current time as unix seconds, stamped once at runtime
+	// construction (like rela.today above). The Lua sandbox excludes the `os`
+	// library, so a script has no os.time(); this is the sanctioned way to read
+	// the current time — needed, e.g., to date an HMAC-signed outbound request
+	// (see examples/idp-sync.lua). An action runtime is built per invocation, so
+	// the value is fresh each run.
+	r.L.SetField(rela, "now_unix", lua.LNumber(time.Now().Unix()))
 
 	// Date and RRULE utility functions
 	registerDateHelpers(r.L, rela)

--- a/internal/principal/principal.go
+++ b/internal/principal/principal.go
@@ -46,6 +46,11 @@ const (
 	// ToolSync attributes writes applied by the sync API (FEAT-NJ9FEN) so the
 	// audit log distinguishes a synced write from a direct data-entry edit.
 	ToolSync = "sync"
+	// ToolWebhookReceiver attributes writes made by an inbound-webhook handler
+	// (e.g. an IdP membership event that provisions a person entity). It is a
+	// distinct entry point from data-entry: the write originates from a verified
+	// server-to-server callback, not a human at the UI.
+	ToolWebhookReceiver = "webhook-receiver"
 )
 
 // principalKey is the unexported context.WithValue key so no other

--- a/tickets/entities/features/FEAT-CN5L0X.md
+++ b/tickets/entities/features/FEAT-CN5L0X.md
@@ -1,0 +1,41 @@
+---
+id: FEAT-CN5L0X
+type: feature
+title: Inbound signed-webhook receiver and outbound request-signing primitives
+description: Two general capabilities — a signed-JWT webhook receiver that dispatches a named Lua action, and crypto primitives (HMAC/SHA) so an action can sign an authenticated outbound HTTP request. Both provider- and use-case-agnostic; IdP user-provisioning ships as an example Lua action, not in the core.
+status: proposed
+---
+
+Companion to the signed-JWT identity feature (FEAT-OQBYHD): that verifies identity
+on the *request* path; this adds a *webhook* path plus the crypto primitives a Lua
+action needs to call back out. Both additions are generic — nothing about users or
+any particular proxy is in the compiled core.
+
+**1. Inbound signed-webhook receiver.** `POST /webhooks/idp` verifies a signed-JWT
+webhook body, then dispatches a named Lua action with the verified claims. The
+receiver has no knowledge of what the action does.
+
+- `internal/jwtauth`: a `WebhookVerifier` reusing the identity verifier's JWKS +
+  issuer but pinning its OWN audience — a signed identity assertion can't be
+  replayed as a webhook and vice versa (confused-deputy guard).
+- `internal/dataentry` shim: verify -> dedup by jti -> dispatch under a
+  `webhook-receiver` principal. Outside `/api/`; CSRF-immune by construction (a
+  signed body, not a cookie), so no same-origin gate. A local `WebhookClaims` +
+  wiring-layer adapter keep `dataentry` from importing `jwtauth`.
+- `-webhook-audience` / `-webhook-action` flags (`$RELA_WEBHOOK_*`).
+
+**2. Outbound request-signing primitives.** A `crypto.*` Lua binding (`sha256_hex`
++ `hmac_sha256_base64`) plus a `rela.now_unix` value, so a Lua action can sign an
+authenticated outbound HTTP request to any HMAC-authenticated API — with no crypto
+in the scripting layer. Verification stays in Go (a root of trust); only
+client-side signing is exposed.
+
+**Example, not core:** `examples/idp-sync.lua` demonstrates both together — a
+verified membership webhook triggers an action that signs a Pratique operator-API
+request and upserts a `person` keyed on the stable `sub`. The whole
+person/Pratique-specific surface is those ~90 lines of Lua; swap the script to
+target a different proxy or task, no rebuild.
+
+Proven by a test that runs the shipped `idp-sync.lua` against a stub API which
+verifies the Lua-assembled signature byte-for-byte, plus crypto known-vectors and
+a Go-vs-Lua HMAC cross-check.

--- a/tickets/relations/FEAT-CN5L0X--requires--data-entry-server.md
+++ b/tickets/relations/FEAT-CN5L0X--requires--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-CN5L0X
+relation: requires
+to: data-entry-server
+---

--- a/tickets/relations/FEAT-CN5L0X--requires--lua-scripting.md
+++ b/tickets/relations/FEAT-CN5L0X--requires--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-CN5L0X
+relation: requires
+to: lua-scripting
+---


### PR DESCRIPTION
Two general, reusable capabilities — with IdP user-provisioning shipped as the
motivating **example**, not baked into the core. Companion to #1064 (signed-JWT
identity): that verifies identity on the *request* path; this adds a *webhook*
path and the crypto primitives a Lua action needs to call back out.

Everything in the Go core is provider- and use-case-agnostic. What's specific to
Pratique / to provisioning a person lives entirely in one example Lua script.

## 1. Inbound signed-webhook receiver (generic)

`POST /webhooks/idp` — verify a signed-JWT webhook body, then dispatch a **named
Lua action** with the verified claims as params. The receiver has no idea what the
action does; provisioning, notifying, syncing — all just actions.

- **`internal/jwtauth` `WebhookVerifier`**: verify *any* signed-JWT webhook. Reuses
  the identity verifier's JWKS + issuer but pins its **own** audience, so a signed
  identity assertion can't be replayed as a webhook and vice versa (confused-deputy
  guard). This is the `VerifyClaims` #1064's review deferred — now built with a
  strict per-purpose audience instead of the relaxed-audience path that was flagged.
- **`internal/dataentry` shim**: verify → dedup by `jti` → dispatch under a
  `webhook-receiver` principal. Lives **outside `/api/`**: it authenticates itself
  by verifying a signed body, so it's CSRF-immune by construction and needs no
  same-origin gate (the FEAT-ESLP shape). A local `WebhookClaims` type + a
  wiring-layer adapter keep `dataentry` from importing `jwtauth` (the inward
  layering rule, mirroring #1064's `subjectVerifier` seam).
- Flags `-webhook-audience` / `-webhook-action` (`$RELA_WEBHOOK_*`), reusing the
  identity JWKS (fetched once). `ToolWebhookReceiver` principal.

## 2. Outbound request-signing primitives (generic)

**`crypto.*` Lua binding** — `sha256_hex` + `hmac_sha256_base64`, plus a
`rela.now_unix` value (the sandbox has no `os` lib). These let a Lua action **sign
an authenticated outbound HTTP request** to any HMAC-authenticated API, with no
crypto in the scripting layer. *Verification* stays wholly in Go (a root of trust);
only client-side *signing* is exposed as a primitive.

## Example (not core): IdP user-provisioning

`examples/idp-sync.lua` demonstrates both capabilities together: a verified
membership webhook triggers an action that signs a Pratique operator-API request
(from the generic primitives) and upserts a `person` keyed on the stable `sub`.
It's a **sample action** — the whole person/Pratique-specific surface is these ~90
lines of Lua; the core knows nothing of it. Point at a different IdP or a different
task by editing/replacing the script; no rebuild.

## Tests

- `jwtauth`: webhook verify — valid, **confused-deputy reject**, wrong
  issuer/expired/no-exp/alg:none.
- `dataentry` shim: dispatch-with-claims, dedup-by-jti, 401-bad-sig,
  400-missing-user_id, 502-retryable (failed `jti` forgotten), TTL expiry.
- `lua/crypto_test.go`: known vectors + a cross-check that a Lua-assembled
  HMAC signature is byte-identical to Go's.
- `lua/idpsync_test.go` (example coverage): runs the shipped `idp-sync.lua` against
  an httptest API that **verifies the Lua-built signature byte-for-byte**, then
  asserts the upsert is idempotent and 404 skips cleanly.

## Notes

- The example action calls a Pratique-side `GET /api/v1/orgs/{id}/members/{uid}`
  single-member endpoint (tracked separately on the Pratique repo). The rela core
  doesn't depend on it — only the example does.
- Full gate green: build (default + postgres), `golangci-lint` 0, `go-arch-lint`
  OK, `plimsoll` 0, markdown 0, full test suite.

Feature entity: `FEAT-CN5L0X`.