### PR TITLE
Add display_property template support (TKT-NJTBQX)

### DIFF
--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -290,9 +290,36 @@ values) are stringified via `fmt.Sprintf("%v", val)`. The display
 falls back to the entity ID when the value is empty, missing, or
 `nil`.
 
-**Validation.** A typo, whitespace mistake, list-typed reference, or
-disallowed type fails metamodel-load with a diagnostic naming the
-entity, the offending value, and the available properties.
+**Templates.** When `display_property` contains a `{`, it is a
+template: each `{propname}` placeholder is replaced with that
+property's value, and literal text (spaces, commas) passes through.
+This composes a display name from several fields:
+
+```yaml
+entities:
+  persoon:
+    label: Persoon
+    display_property: "{voornaam} {tussenvoegsel} {achternaam}"
+    properties:
+      voornaam: { type: string }
+      tussenvoegsel: { type: string }
+      achternaam: { type: string, required: true }
+```
+
+renders `"Jeroen Vloothuis"` — and `"Jan van der Berg"` for someone
+with a `tussenvoegsel`. Consecutive whitespace collapses to one space
+and the result is trimmed, so an empty middle field doesn't leave a
+double space. If every placeholder is empty, the display falls back to
+the entity ID. Each placeholder must name a defined property of an
+allowed type (same rules as above), checked at load. A template names
+no single primary property, so it is display-only — it isn't a target
+for writing values.
+
+**Validation.** A typo, whitespace mistake, list-typed reference,
+disallowed type, or a malformed template (unclosed `{`, empty `{}`, or
+a placeholder naming an undefined property) fails metamodel-load with a
+diagnostic naming the entity, the offending value, and the available
+properties.
 
 How the data-entry app surfaces the display name across lists, cards,
 breadcrumbs, and related-entity links is documented in

--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -309,11 +309,13 @@ entities:
 renders `"Jeroen Vloothuis"` — and `"Jan van der Berg"` for someone
 with a `tussenvoegsel`. Consecutive whitespace collapses to one space
 and the result is trimmed, so an empty middle field doesn't leave a
-double space. If every placeholder is empty, the display falls back to
-the entity ID. Each placeholder must name a defined property of an
-allowed type (same rules as above), checked at load. A template names
-no single primary property, so it is display-only — it isn't a target
-for writing values.
+double space. The ID fallback applies only when the rendered result is
+empty after trimming — a template with literal text (e.g. `"Mr.
+{achternaam}"`) always renders that text, so it never falls back to the
+ID even when every placeholder is empty. Each placeholder must name a
+defined property of an allowed type (same rules as above), checked at
+load. A template names no single primary property, so it is
+display-only — it isn't a target for writing values.
 
 **Validation.** A typo, whitespace mistake, list-typed reference,
 disallowed type, or a malformed template (unclosed `{`, empty `{}`, or

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -284,9 +284,36 @@ values) are stringified via `fmt.Sprintf("%v", val)`. The display
 falls back to the entity ID when the value is empty, missing, or
 `nil`.
 
-**Validation.** A typo, whitespace mistake, list-typed reference, or
-disallowed type fails metamodel-load with a diagnostic naming the
-entity, the offending value, and the available properties.
+**Templates.** When `display_property` contains a `{`, it is a
+template: each `{propname}` placeholder is replaced with that
+property's value, and literal text (spaces, commas) passes through.
+This composes a display name from several fields:
+
+```yaml
+entities:
+  persoon:
+    label: Persoon
+    display_property: "{voornaam} {tussenvoegsel} {achternaam}"
+    properties:
+      voornaam: { type: string }
+      tussenvoegsel: { type: string }
+      achternaam: { type: string, required: true }
+```
+
+renders `"Jeroen Vloothuis"` — and `"Jan van der Berg"` for someone
+with a `tussenvoegsel`. Consecutive whitespace collapses to one space
+and the result is trimmed, so an empty middle field doesn't leave a
+double space. If every placeholder is empty, the display falls back to
+the entity ID. Each placeholder must name a defined property of an
+allowed type (same rules as above), checked at load. A template names
+no single primary property, so it is display-only — it isn't a target
+for writing values.
+
+**Validation.** A typo, whitespace mistake, list-typed reference,
+disallowed type, or a malformed template (unclosed `{`, empty `{}`, or
+a placeholder naming an undefined property) fails metamodel-load with a
+diagnostic naming the entity, the offending value, and the available
+properties.
 
 How the data-entry app surfaces the display name across lists, cards,
 breadcrumbs, and related-entity links is documented in

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -303,11 +303,13 @@ entities:
 renders `"Jeroen Vloothuis"` — and `"Jan van der Berg"` for someone
 with a `tussenvoegsel`. Consecutive whitespace collapses to one space
 and the result is trimmed, so an empty middle field doesn't leave a
-double space. If every placeholder is empty, the display falls back to
-the entity ID. Each placeholder must name a defined property of an
-allowed type (same rules as above), checked at load. A template names
-no single primary property, so it is display-only — it isn't a target
-for writing values.
+double space. The ID fallback applies only when the rendered result is
+empty after trimming — a template with literal text (e.g. `"Mr.
+{achternaam}"`) always renders that text, so it never falls back to the
+ID even when every placeholder is empty. Each placeholder must name a
+defined property of an allowed type (same rules as above), checked at
+load. A template names no single primary property, so it is
+display-only — it isn't a target for writing values.
 
 **Validation.** A typo, whitespace mistake, list-typed reference,
 disallowed type, or a malformed template (unclosed `{`, empty `{}`, or

--- a/internal/dataentry/mentions.go
+++ b/internal/dataentry/mentions.go
@@ -73,44 +73,52 @@ func buildMention(e *entityPkg.Entity, meta *metamodel.Metamodel) v1.Mention {
 		m.Title = e.Title()
 	}
 
-	primary := displayProperty(meta, e.Type)
-	if reason, locked := lockedReasonFor(e, primary); locked {
+	titleProps := displayProperties(meta, e.Type)
+	if reason, locked := lockedReasonFor(e, titleProps); locked {
 		m.Inaccessible = true
 		m.InaccessibleReason = reason
 	}
 	return m
 }
 
-// displayProperty returns the property name whose value backs the display
-// title for this entity type. Empty when the metamodel has no entry for
-// the type or no primary property is configured — falls back to the ID
-// being the source of truth, in which case the entity can't really be
-// "locked behind its title."
-func displayProperty(meta *metamodel.Metamodel, entityType string) string {
+// displayProperties returns the property names whose values back the display
+// title for this entity type — a single name for a bare/autoderived primary,
+// or every placeholder for a templated display_property. Empty when the
+// metamodel has no entry for the type or no primary property is configured
+// (the ID is then the source of truth, so the entity can't be "locked behind
+// its title"). Any one of these being inaccessible locks the title, because
+// DisplayTitle would render an incomplete name.
+func displayProperties(meta *metamodel.Metamodel, entityType string) []string {
 	if meta == nil {
-		return "title"
+		return []string{"title"}
 	}
 	def, ok := meta.GetEntityDef(entityType)
 	if !ok {
-		return ""
+		return nil
 	}
-	return def.GetPrimaryProperty()
+	return def.DisplayProperties()
 }
 
 // lockedReasonFor reports whether the entity's display title is
 // unreadable (and the matching reason). The entity's whole content body
 // being inaccessible (`InaccessibleFieldContent`) counts too, because the
-// lookup of the title property may have failed for the same reason —
+// lookup of a title property may have failed for the same reason —
 // markdown loaders produce a `content` inaccessible field for the whole
 // file when git-crypt blocks the read. A property unrelated to the title
-// being locked does not affect the link.
-func lockedReasonFor(e *entityPkg.Entity, displayProp string) (string, bool) {
+// being locked does not affect the link; but any property the title reads
+// from (all placeholders of a template) being locked does.
+func lockedReasonFor(e *entityPkg.Entity, displayProps []string) (string, bool) {
 	if e == nil {
 		return "", false
 	}
 	for _, f := range e.Inaccessible {
-		if f.Name == displayProp || f.Name == entityPkg.InaccessibleFieldContent {
+		if f.Name == entityPkg.InaccessibleFieldContent {
 			return string(f.Reason), true
+		}
+		for _, dp := range displayProps {
+			if f.Name == dp {
+				return string(f.Reason), true
+			}
 		}
 	}
 	return "", false

--- a/internal/dataentry/mentions_test.go
+++ b/internal/dataentry/mentions_test.go
@@ -28,6 +28,16 @@ func TestCollectMentions(t *testing.T) {
 		// (`status`) is locked. The display title is still readable, so
 		// the resulting mention must NOT carry the inaccessible flag.
 		entityWithLockedProperty("TKT-PARTIAL", "ticket", "Mostly Readable", "status"),
+		// Templated display title, fully readable → renders both placeholders.
+		mustPersoon("PERS-OK", "Jeroen", "Vloothuis"),
+		// Templated display title with a locked PLACEHOLDER property
+		// (`achternaam`) → the title is incomplete, so the mention must be
+		// flagged inaccessible. This is the TKT-NJTBQX regression: a bare
+		// display_property was protected here; the template must be too.
+		mustPersoon("PERS-LOCKED", "Jeroen", "Vloothuis", "achternaam"),
+		// Templated display title with a locked NON-placeholder property
+		// → title still fully readable, must NOT be flagged.
+		mustPersoon("PERS-PARTIAL", "Jeroen", "Vloothuis", "geboortedatum"),
 	}
 
 	tests := []struct {
@@ -102,6 +112,32 @@ func TestCollectMentions(t *testing.T) {
 			contents: []string{"partial: `TKT-PARTIAL`"},
 			want: map[string]v1.Mention{
 				"TKT-PARTIAL": {Type: "ticket", Title: "Mostly Readable"},
+			},
+		},
+		{
+			name:     "templated title renders all placeholders",
+			contents: []string{"person: `PERS-OK`"},
+			want: map[string]v1.Mention{
+				"PERS-OK": {Type: "persoon", Title: "Jeroen Vloothuis"},
+			},
+		},
+		{
+			name:     "templated title with a locked placeholder is inaccessible (TKT-NJTBQX)",
+			contents: []string{"person: `PERS-LOCKED`"},
+			want: map[string]v1.Mention{
+				"PERS-LOCKED": {
+					Type:               "persoon",
+					Title:              "Jeroen Vloothuis",
+					Inaccessible:       true,
+					InaccessibleReason: "git-crypt",
+				},
+			},
+		},
+		{
+			name:     "templated title with a locked non-placeholder property is NOT inaccessible",
+			contents: []string{"person: `PERS-PARTIAL`"},
+			want: map[string]v1.Mention{
+				"PERS-PARTIAL": {Type: "persoon", Title: "Jeroen Vloothuis"},
 			},
 		},
 		{
@@ -269,6 +305,16 @@ func buildTestMetamodel(t *testing.T) *metamodel.Metamodel {
 					"name": {Type: "string", Required: true},
 				},
 			},
+			// Templated display_property: the title reads from two
+			// placeholders. A lock on either must lock the title.
+			"persoon": {
+				Label:           "Persoon",
+				DisplayProperty: "{voornaam} {achternaam}",
+				Properties: map[string]metamodel.PropertyDef{
+					"voornaam":   {Type: "string"},
+					"achternaam": {Type: "string", Required: true},
+				},
+			},
 		},
 	}
 }
@@ -285,6 +331,20 @@ func mustEntity(id, typeName, title string) *entity.Entity {
 func mustEntityNamed(id, typeName, name string) *entity.Entity {
 	e := entity.New(id, typeName)
 	e.Properties["name"] = name
+	return e
+}
+
+// mustPersoon builds a persoon whose title comes from the template
+// "{voornaam} {achternaam}". Any inaccessible field names in lockedProps are
+// marked inaccessible (git-crypt) to exercise the templated locked-title path.
+func mustPersoon(id, voornaam, achternaam string, lockedProps ...string) *entity.Entity {
+	e := entity.New(id, "persoon")
+	e.Properties["voornaam"] = voornaam
+	e.Properties["achternaam"] = achternaam
+	for _, p := range lockedProps {
+		e.Inaccessible = append(e.Inaccessible,
+			entity.InaccessibleField{Name: p, Reason: entity.InaccessibleReasonGitCrypt})
+	}
 	return e
 }
 

--- a/internal/metamodel/entity_def.go
+++ b/internal/metamodel/entity_def.go
@@ -1,6 +1,85 @@
 package metamodel
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
+
+// isDisplayTemplate reports whether a display_property value is a template
+// (contains a '{' placeholder) rather than a bare property name. Property
+// names can't contain '{' in a valid metamodel, so the presence of one
+// disambiguates cleanly.
+func isDisplayTemplate(displayProperty string) bool {
+	return strings.ContainsRune(displayProperty, '{')
+}
+
+// parseDisplayTemplate scans a display_property template and returns the
+// property names referenced by its `{name}` placeholders, in order. It
+// returns an error for a malformed template: an unclosed `{`, or an empty
+// placeholder `{}`. Literal text between placeholders is ignored here — it
+// only matters at render time.
+//
+// This is the single source of truth for template syntax, shared by
+// renderDisplayTemplate (runtime) and validateDisplayProperty (load time).
+func parseDisplayTemplate(tmpl string) ([]string, error) {
+	var names []string
+	for i := 0; i < len(tmpl); i++ {
+		if tmpl[i] != '{' {
+			continue
+		}
+		end := strings.IndexByte(tmpl[i:], '}')
+		if end < 0 {
+			return nil, fmt.Errorf("unclosed '{' in template %q", tmpl)
+		}
+		name := tmpl[i+1 : i+end]
+		if name == "" {
+			return nil, fmt.Errorf("empty placeholder '{}' in template %q", tmpl)
+		}
+		names = append(names, name)
+		i += end
+	}
+	return names, nil
+}
+
+// renderDisplayTemplate substitutes each `{name}` placeholder with the
+// stringified property value, passes literal text through, then collapses
+// consecutive whitespace to a single space and trims the result. A nil or
+// missing property renders as empty, so `"{a} {b}"` with an empty middle
+// field collapses to a single space rather than a double. The caller
+// (DisplayTitle) falls back to the entity ID when the result is empty.
+//
+// The template is assumed already validated at load time (parseDisplayTemplate
+// succeeded and every placeholder names a defined property), so a malformed
+// template here degrades gracefully rather than erroring: an unclosed '{' is
+// emitted verbatim.
+func renderDisplayTemplate(tmpl string, properties map[string]interface{}) string {
+	var b strings.Builder
+	for i := 0; i < len(tmpl); i++ {
+		if tmpl[i] != '{' {
+			b.WriteByte(tmpl[i])
+			continue
+		}
+		end := strings.IndexByte(tmpl[i:], '}')
+		if end < 0 {
+			// Malformed (shouldn't happen post-validation); emit verbatim.
+			b.WriteString(tmpl[i:])
+			break
+		}
+		name := tmpl[i+1 : i+end]
+		if val, ok := properties[name]; ok && val != nil {
+			fmt.Fprintf(&b, "%v", val)
+		}
+		i += end
+	}
+	return collapseWhitespace(b.String())
+}
+
+// collapseWhitespace replaces every run of whitespace with a single space and
+// trims the ends. Newlines are treated as ordinary whitespace (multi-line
+// display titles are out of scope).
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
 
 // GetLabelPlural returns the human-readable plural label for an entity
 // type (used in UI strings, e.g. "List of Features").
@@ -69,9 +148,20 @@ func (e *EntityDef) GetDefaultStatus(m *Metamodel) string {
 //     when defined as a required string.
 //  3. Any required string property (alphabetical for determinism).
 //  4. Empty string when no candidate exists.
+//
+// A *templated* display_property (containing `{`) has no single primary
+// property — it is a readonly, derived display string. GetPrimaryProperty
+// returns "" for it; DisplayTitle renders the template directly. Callers
+// that treat the result as a writable property key (e.g. a create title
+// shortcut) therefore get "" and skip, which is correct: there is no single
+// field to write into.
 func (e *EntityDef) GetPrimaryProperty() string {
-	// (1) Author-declared override wins.
+	// (1) Author-declared override wins — unless it's a template, which
+	// names no single property.
 	if e.DisplayProperty != "" {
+		if isDisplayTemplate(e.DisplayProperty) {
+			return ""
+		}
 		return e.DisplayProperty
 	}
 
@@ -119,7 +209,18 @@ func (e *EntityDef) GetPrimaryProperty() string {
 // The non-string stringification is what makes the explicit
 // display_property override pay off for enum-typed fields. See
 // review-response RR-9CW5N.
+//
+// When display_property is a template (contains `{`), the placeholders are
+// substituted from properties, whitespace is collapsed, and the result is
+// returned — falling back to the ID when it renders empty.
 func (e *EntityDef) DisplayTitle(id string, properties map[string]interface{}) string {
+	if isDisplayTemplate(e.DisplayProperty) {
+		if s := renderDisplayTemplate(e.DisplayProperty, properties); s != "" {
+			return s
+		}
+		return id
+	}
+
 	primary := e.GetPrimaryProperty()
 	if primary == "" {
 		return id

--- a/internal/metamodel/entity_def.go
+++ b/internal/metamodel/entity_def.go
@@ -195,6 +195,34 @@ func (e *EntityDef) GetPrimaryProperty() string {
 	return ""
 }
 
+// DisplayProperties returns every property whose value backs the display
+// title, so callers can reason about the title's data sources — notably to
+// decide whether the title is unreadable when one of those properties is
+// access-controlled (see internal/dataentry mentions).
+//
+//   - Templated display_property: all placeholder property names, in order.
+//   - Bare display_property or an autoderived primary: that single name.
+//   - No display name source (autoderivation found nothing): empty.
+//
+// Unlike GetPrimaryProperty (which returns "" for a template because a
+// template names no single *writable* target), this reports the full read
+// set. The template was validated at load, so parsing here cannot fail; a
+// malformed template (only reachable via the no-validate migration path)
+// yields no names rather than an error.
+func (e *EntityDef) DisplayProperties() []string {
+	if isDisplayTemplate(e.DisplayProperty) {
+		names, err := parseDisplayTemplate(e.DisplayProperty)
+		if err != nil {
+			return nil
+		}
+		return names
+	}
+	if primary := e.GetPrimaryProperty(); primary != "" {
+		return []string{primary}
+	}
+	return nil
+}
+
 // DisplayTitle returns the display title for an entity using its
 // type's primary property. Behavior:
 //

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -359,18 +359,43 @@ func validateDisplayProperty(entityName string, def EntityDef) []string {
 		return errs
 	}
 
-	prop, ok := def.Properties[dp]
-	if !ok {
-		errs = append(errs, fmt.Sprintf(
-			"entity %q: display_property %q is not a defined property (have: %s)",
-			entityName, dp, available))
+	// A template (contains `{`) references properties via `{name}`
+	// placeholders. Each named property is checked exactly as a bare-name
+	// display_property would be.
+	if isDisplayTemplate(dp) {
+		names, err := parseDisplayTemplate(dp)
+		if err != nil {
+			return append(errs, fmt.Sprintf("entity %q: display_property: %s", entityName, err))
+		}
+		for _, name := range names {
+			errs = append(errs, validateDisplayPropertyRef(entityName, dp, name, def.Properties, available)...)
+		}
 		return errs
 	}
 
+	return append(errs, validateDisplayPropertyRef(entityName, dp, dp, def.Properties, available)...)
+}
+
+// validateDisplayPropertyRef checks that a single property referenced by a
+// display_property (bare name or template placeholder) exists and has a type
+// that renders meaningfully as a display name. dp is the whole
+// display_property value (for the error message); name is the referenced
+// property. See validateDisplayProperty for the type-restriction rationale.
+func validateDisplayPropertyRef(
+	entityName, dp, name string, props map[string]PropertyDef, available string,
+) []string {
+	prop, ok := props[name]
+	if !ok {
+		return []string{fmt.Sprintf(
+			"entity %q: display_property %q references undefined property %q (have: %s)",
+			entityName, dp, name, available)}
+	}
+
+	var errs []string
 	if prop.List {
 		errs = append(errs, fmt.Sprintf(
-			"entity %q: display_property %q is list-typed; lists cannot render as a display name",
-			entityName, dp))
+			"entity %q: display_property %q references list-typed property %q; lists cannot render as a display name",
+			entityName, dp, name))
 	}
 
 	// Allow string (default), integer, boolean, enum, custom enum-like
@@ -379,8 +404,9 @@ func validateDisplayProperty(entityName string, def EntityDef) []string {
 	switch prop.Type {
 	case PropertyTypeDate, PropertyTypeFile, PropertyTypeRrule:
 		errs = append(errs, fmt.Sprintf(
-			"entity %q: display_property %q has type %q; only string, integer, boolean, or enum types render as display names",
-			entityName, dp, prop.Type))
+			"entity %q: display_property %q references property %q of type %q; "+
+				"only string, integer, boolean, or enum types render as display names",
+			entityName, dp, name, prop.Type))
 	}
 
 	return errs

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -1694,6 +1694,127 @@ entities:
 	assertEqual(t, def.DisplayProperty, "number")
 }
 
+// TKT-NJTBQX: display_property as a template.
+
+// TestParse_DisplayPropertyTemplateSucceeds verifies a well-formed template
+// whose placeholders all reference defined properties loads cleanly.
+func TestParse_DisplayPropertyTemplateSucceeds(t *testing.T) {
+	yaml := `version: "1.0"
+entities:
+  persoon:
+    label: Persoon
+    id_prefix: "PERS-"
+    display_property: "{voornaam} {tussenvoegsel} {achternaam}"
+    properties:
+      voornaam:
+        type: string
+      tussenvoegsel:
+        type: string
+      achternaam:
+        type: string
+        required: true
+`
+	m, err := Parse([]byte(yaml))
+	assertNoError(t, err)
+	assertEqual(t, m.Entities["persoon"].DisplayProperty, "{voornaam} {tussenvoegsel} {achternaam}")
+}
+
+// TestParse_DisplayPropertyTemplateUnknownProperty verifies AC6: a placeholder
+// naming an undefined property is a load-time error.
+func TestParse_DisplayPropertyTemplateUnknownProperty(t *testing.T) {
+	yaml := `version: "1.0"
+entities:
+  persoon:
+    label: Persoon
+    id_prefix: "PERS-"
+    display_property: "{voornaam} {unknown_prop}"
+    properties:
+      voornaam:
+        type: string
+        required: true
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+	msg := err.Error()
+	for _, want := range []string{"display_property", "unknown_prop", `entity "persoon"`} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error should mention %q: %v", want, err)
+		}
+	}
+}
+
+// TestParse_DisplayPropertyTemplateUnclosed verifies AC7: a template with an
+// unclosed '{' is a load-time error.
+func TestParse_DisplayPropertyTemplateUnclosed(t *testing.T) {
+	yaml := `version: "1.0"
+entities:
+  persoon:
+    label: Persoon
+    id_prefix: "PERS-"
+    display_property: "{voornaam"
+    properties:
+      voornaam:
+        type: string
+        required: true
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+	msg := err.Error()
+	for _, want := range []string{"display_property", "unclosed", `entity "persoon"`} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error should mention %q: %v", want, err)
+		}
+	}
+}
+
+// TestParse_DisplayPropertyTemplateEmptyPlaceholder verifies an empty
+// placeholder `{}` is a load-time error.
+func TestParse_DisplayPropertyTemplateEmptyPlaceholder(t *testing.T) {
+	yaml := `version: "1.0"
+entities:
+  persoon:
+    label: Persoon
+    id_prefix: "PERS-"
+    display_property: "{voornaam} {}"
+    properties:
+      voornaam:
+        type: string
+        required: true
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+	if !strings.Contains(err.Error(), "empty placeholder") {
+		t.Errorf("error should mention the empty placeholder: %v", err)
+	}
+}
+
+// TestParse_DisplayPropertyTemplateRejectsDatePlaceholder verifies the
+// per-property type restriction applies to each placeholder: a date-typed
+// property in a template is rejected just as a bare-name one is.
+func TestParse_DisplayPropertyTemplateRejectsDatePlaceholder(t *testing.T) {
+	yaml := `version: "1.0"
+entities:
+  event:
+    label: Event
+    id_prefix: "EVT-"
+    display_property: "{naam} ({datum})"
+    properties:
+      naam:
+        type: string
+        required: true
+      datum:
+        type: date
+`
+	_, err := Parse([]byte(yaml))
+	assertError(t, err)
+	msg := err.Error()
+	for _, want := range []string{"display_property", "datum"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error should mention %q: %v", want, err)
+		}
+	}
+}
+
 // TestParse_DisplayPropertyAcrossIncludes verifies that display_property
 // validation runs on the merged metamodel when an entity is defined in
 // an included file. RR-GO9T7.

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -136,10 +136,14 @@ type CustomType struct {
 
 // EntityDef defines an entity type in the metamodel
 //
-// TODO(TKT-N0IKN9): 23 exported methods, over the 20 exported-method line.
-// Schema value type; ratchet candidate alongside Metamodel.
+// TODO(TKT-N0IKN9): 24 exported methods, over the 20 exported-method line.
+// Schema value type; ratchet candidate alongside Metamodel. DisplayProperties
+// (TKT-NJTBQX) is the 24th — it reports the property set backing the display
+// title so the ACL locked-title guard can gate on templated display_property
+// (see internal/dataentry mentions); ratchet back down when this type is
+// decomposed.
 //
-//plimsoll:max-exported-methods=23
+//plimsoll:max-exported-methods=24
 type EntityDef struct {
 	Label         string                 `yaml:"label"`
 	LabelPlural   string                 `yaml:"label_plural,omitempty"`

--- a/internal/metamodel/types_test.go
+++ b/internal/metamodel/types_test.go
@@ -2,7 +2,9 @@ package metamodel
 
 import (
 	"errors"
+	"slices"
 	"sort"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -535,6 +537,41 @@ func TestEntityDef_DisplayTitle(t *testing.T) {
 			},
 			properties: map[string]interface{}{"voornaam": nil, "achternaam": "Vloothuis"},
 			want:       "Vloothuis",
+		},
+		{
+			name: "template adjacent placeholders with no separator",
+			def: EntityDef{
+				DisplayProperty: "{a}{b}",
+				Properties: map[string]PropertyDef{
+					"a": {Type: "string"},
+					"b": {Type: "string"},
+				},
+			},
+			properties: map[string]interface{}{"a": "foo", "b": "bar"},
+			want:       "foobar",
+		},
+		{
+			name: "template property value containing braces is not re-substituted",
+			def: EntityDef{
+				DisplayProperty: "{a}",
+				Properties: map[string]PropertyDef{
+					"a": {Type: "string"},
+				},
+			},
+			properties: map[string]interface{}{"a": "{b}"},
+			want:       "{b}",
+		},
+		{
+			name: "template unicode value passes through intact",
+			def: EntityDef{
+				DisplayProperty: "{voornaam} {achternaam}",
+				Properties: map[string]PropertyDef{
+					"voornaam":   {Type: "string"},
+					"achternaam": {Type: "string"},
+				},
+			},
+			properties: map[string]interface{}{"voornaam": "José", "achternaam": "Müller"},
+			want:       "José Müller",
 		},
 	}
 
@@ -1753,5 +1790,144 @@ validations:
 	h2 := rule.Content.RequiredHeaders[1]
 	if h2.Pattern != "## (Alternative|Alternatives)" || !h2.IsPattern() {
 		t.Errorf("RequiredHeaders[1] = {Pattern: %q, IsPattern: %v}, want pattern", h2.Pattern, h2.IsPattern())
+	}
+}
+
+// TKT-NJTBQX: direct tests for the display-template scanner. These pin the
+// parse/render agreement invariant (both must treat placeholder boundaries
+// identically) and the render-side graceful-degradation branch that
+// validation normally prevents from being reached.
+
+func TestParseDisplayTemplate(t *testing.T) {
+	tests := []struct {
+		name    string
+		tmpl    string
+		want    []string
+		wantErr string
+	}{
+		{name: "single placeholder", tmpl: "{a}", want: []string{"a"}},
+		{name: "two with literal", tmpl: "{a} {b}", want: []string{"a", "b"}},
+		{name: "adjacent placeholders", tmpl: "{a}{b}", want: []string{"a", "b"}},
+		{name: "literal only around one field", tmpl: "Mr. {a}", want: []string{"a"}},
+		{name: "leading close brace is literal", tmpl: "a}{b}", want: []string{"b"}},
+		{name: "trailing close brace is literal", tmpl: "{a}}", want: []string{"a"}},
+		{name: "nested open treated as name char", tmpl: "{a{b}", want: []string{"a{b"}},
+		{name: "unclosed brace errors", tmpl: "{a", wantErr: "unclosed"},
+		{name: "unclosed after valid errors", tmpl: "{a} {b", wantErr: "unclosed"},
+		{name: "empty placeholder errors", tmpl: "{}", wantErr: "empty placeholder"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDisplayTemplate(tt.tmpl)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("parseDisplayTemplate(%q) error = %v, want containing %q", tt.tmpl, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseDisplayTemplate(%q) unexpected error: %v", tt.tmpl, err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("parseDisplayTemplate(%q) = %v, want %v", tt.tmpl, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderDisplayTemplate(t *testing.T) {
+	props := map[string]interface{}{"a": "foo", "b": "bar", "n": 7}
+	tests := []struct {
+		name string
+		tmpl string
+		want string
+	}{
+		{name: "concatenation with separator", tmpl: "{a} {b}", want: "foo bar"},
+		{name: "adjacent", tmpl: "{a}{b}", want: "foobar"},
+		{name: "literal passthrough", tmpl: "{a}, {b}", want: "foo, bar"},
+		{name: "non-string stringified", tmpl: "v{n}", want: "v7"},
+		{name: "missing property renders empty", tmpl: "{a} {missing}", want: "foo"},
+		{name: "whitespace collapses to single space", tmpl: "{a}   {b}", want: "foo bar"},
+		// Graceful degradation: an unclosed '{' can only reach render via the
+		// no-validate migration path; it is emitted verbatim, not dropped.
+		{name: "unclosed brace emitted verbatim", tmpl: "{a} {b", want: "foo {b"},
+		{name: "value braces are not re-scanned", tmpl: "{a}", want: "foo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := renderDisplayTemplate(tt.tmpl, props); got != tt.want {
+				t.Errorf("renderDisplayTemplate(%q) = %q, want %q", tt.tmpl, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollapseWhitespace(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"", ""},
+		{"   ", ""},
+		{"a  b", "a b"},
+		{"  a  b  ", "a b"},
+		{"a\tb\nc", "a b c"},
+	}
+	for _, tt := range tests {
+		if got := collapseWhitespace(tt.in); got != tt.want {
+			t.Errorf("collapseWhitespace(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestEntityDef_DisplayProperties(t *testing.T) {
+	tests := []struct {
+		name string
+		def  EntityDef
+		want []string
+	}{
+		{
+			name: "template returns all placeholders in order",
+			def: EntityDef{
+				DisplayProperty: "{voornaam} {achternaam}",
+				Properties: map[string]PropertyDef{
+					"voornaam":   {Type: "string"},
+					"achternaam": {Type: "string"},
+				},
+			},
+			want: []string{"voornaam", "achternaam"},
+		},
+		{
+			name: "bare display_property returns the single name",
+			def: EntityDef{
+				DisplayProperty: "achternaam",
+				Properties: map[string]PropertyDef{
+					"achternaam": {Type: "string"},
+				},
+			},
+			want: []string{"achternaam"},
+		},
+		{
+			name: "autoderived primary returns that name",
+			def: EntityDef{
+				Properties: map[string]PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
+			},
+			want: []string{"title"},
+		},
+		{
+			name: "no display source returns nil",
+			def: EntityDef{
+				Properties: map[string]PropertyDef{
+					"status": {Type: "status", Required: true},
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.def.DisplayProperties(); !slices.Equal(got, tt.want) {
+				t.Errorf("DisplayProperties() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/metamodel/types_test.go
+++ b/internal/metamodel/types_test.go
@@ -270,6 +270,22 @@ func TestEntityDef_GetPrimaryProperty(t *testing.T) {
 			},
 			want: "title",
 		},
+		// TKT-NJTBQX: a templated display_property has no single primary
+		// property (it is readonly-derived), so GetPrimaryProperty is "" —
+		// even though a required `title` exists that the priority list would
+		// otherwise pick.
+		{
+			name: "templated display_property returns empty (AC8)",
+			def: EntityDef{
+				DisplayProperty: "{voornaam} {achternaam}",
+				Properties: map[string]PropertyDef{
+					"title":      {Type: "string", Required: true},
+					"voornaam":   {Type: "string"},
+					"achternaam": {Type: "string"},
+				},
+			},
+			want: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -433,6 +449,92 @@ func TestEntityDef_DisplayTitle(t *testing.T) {
 			},
 			properties: map[string]interface{}{"other": "foo"},
 			want:       "ENT-001",
+		},
+		// TKT-NJTBQX: display_property as a template.
+		{
+			name: "template concatenates two properties (AC1)",
+			def: EntityDef{
+				DisplayProperty: "{voornaam} {achternaam}",
+				Properties: map[string]PropertyDef{
+					"voornaam":   {Type: "string"},
+					"achternaam": {Type: "string"},
+				},
+			},
+			properties: map[string]interface{}{"voornaam": "Jeroen", "achternaam": "Vloothuis"},
+			want:       "Jeroen Vloothuis",
+		},
+		{
+			name: "template collapses whitespace when middle field empty (AC2)",
+			def: EntityDef{
+				DisplayProperty: "{voornaam} {tussenvoegsel} {achternaam}",
+				Properties: map[string]PropertyDef{
+					"voornaam":      {Type: "string"},
+					"tussenvoegsel": {Type: "string"},
+					"achternaam":    {Type: "string"},
+				},
+			},
+			properties: map[string]interface{}{"voornaam": "Jeroen", "tussenvoegsel": "", "achternaam": "Vloothuis"},
+			want:       "Jeroen Vloothuis",
+		},
+		{
+			name: "template with all placeholders empty falls back to ID (AC3)",
+			def: EntityDef{
+				DisplayProperty: "{voornaam} {tussenvoegsel} {achternaam}",
+				Properties: map[string]PropertyDef{
+					"voornaam":      {Type: "string"},
+					"tussenvoegsel": {Type: "string"},
+					"achternaam":    {Type: "string"},
+				},
+			},
+			properties: map[string]interface{}{"voornaam": "", "tussenvoegsel": "", "achternaam": ""},
+			want:       "ENT-001",
+		},
+		{
+			name: "template with all placeholders missing falls back to ID (AC3)",
+			def: EntityDef{
+				DisplayProperty: "{voornaam} {achternaam}",
+				Properties: map[string]PropertyDef{
+					"voornaam":   {Type: "string"},
+					"achternaam": {Type: "string"},
+				},
+			},
+			properties: map[string]interface{}{},
+			want:       "ENT-001",
+		},
+		{
+			name: "template passes literal punctuation through (AC5)",
+			def: EntityDef{
+				DisplayProperty: "{achternaam}, {voornaam}",
+				Properties: map[string]PropertyDef{
+					"voornaam":   {Type: "string"},
+					"achternaam": {Type: "string"},
+				},
+			},
+			properties: map[string]interface{}{"voornaam": "Jeroen", "achternaam": "Vloothuis"},
+			want:       "Vloothuis, Jeroen",
+		},
+		{
+			name: "template stringifies non-string property values",
+			def: EntityDef{
+				DisplayProperty: "v{version}",
+				Properties: map[string]PropertyDef{
+					"version": {Type: PropertyTypeInteger},
+				},
+			},
+			properties: map[string]interface{}{"version": 42},
+			want:       "v42",
+		},
+		{
+			name: "template nil-valued placeholder renders empty",
+			def: EntityDef{
+				DisplayProperty: "{voornaam} {achternaam}",
+				Properties: map[string]PropertyDef{
+					"voornaam":   {Type: "string"},
+					"achternaam": {Type: "string"},
+				},
+			},
+			properties: map[string]interface{}{"voornaam": nil, "achternaam": "Vloothuis"},
+			want:       "Vloothuis",
 		},
 	}
 

--- a/tickets/entities/implementation-checklists/IMPL-6L9POF.md
+++ b/tickets/entities/implementation-checklists/IMPL-6L9POF.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-6L9POF
+type: implementation-checklist
+title: 'Implementation: display_property as a template (multi-property title)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (types_test.go: 7 DisplayTitle template cases + 1 GetPrimaryProperty case; loader_test.go: 5 template validation cases)
+- [x] ~~Integration tests~~ (N/A: metamodel is a pure library; the "full flow" is DisplayTitle/validateDisplayProperty, covered by unit tests. Data-entry consumers exercised by existing dataentry tests — still green.)
+- [x] Happy path implemented (renderDisplayTemplate + DisplayTitle template branch)
+- [x] Edge cases from planning handled (empty/nil/missing → empty; whitespace collapse; all-empty → ID; non-string stringify; literal passthrough)
+- [x] Error handling in place (malformed template → load error; every placeholder allowlisted + type-checked)
+
+## Test Quality
+
+- [x] Table-driven with `t.Run` subtests (matches existing TestEntityDef_DisplayTitle / TestParse_DisplayProperty* style)
+- [x] Assertions specify only the values that matter (want string per case)
+- [x] No hardcoded magic — inputs/outputs are the AC scenarios verbatim
+- [x] Shared parse logic (parseDisplayTemplate) reused by runtime + load-time so syntax has one source of truth
+- [x] Error-message assertions check substrings (entity, offending value, "unclosed"/"empty placeholder"), matching existing loader tests
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+- Built `bin/rela`, created a `persoon` type with `display_property: "{voornaam} {tussenvoegsel} {achternaam}"` in a scratch project; created two persons (empty vs. present tussenvoegsel). `DisplayTitle` unit tests reproduce these exact scenarios and pass.
+- **Important finding:** the CLI `rela list`/`export`/`graph` table shows an EMPTY title — but this is a **pre-existing gap**, verified on develop with a bare-name `display_property: achternaam` (also blank). The CLI output writer (`internal/output/output.go:103`) calls `entity.Title()` (literal `title` prop), NOT `metamodel.DisplayTitle`, so it has never honored `display_property` in any form. My feature is correct for every `DisplayTitle` consumer (all in `internal/dataentry` — web UI list rows, entity links, mentions, analyze). Follow-up ticket TKT-VHSHOB filed to wire `display_property` into the CLI output path.
+- All 8 ACs PASS as unit tests (`go test ./internal/metamodel/`). Full `go test ./...` green. `go vet` + `golangci-lint` clean.
+
+## Quality
+
+- [x] Code follows project patterns (extends existing DisplayTitle/validateDisplayProperty; shared helper like other metamodel code)
+- [x] DRY: `parseDisplayTemplate` + `validateDisplayPropertyRef` extracted so bare-name and template paths share the property type-check; `collapseWhitespace` via `strings.Fields` (no regexp)
+- [x] No security issues (pure string manipulation on trusted metamodel config; no new injection surface — RR-V59XZ reasoning unchanged)
+- [x] No silent failures (malformed templates fail loud at load; render degrades gracefully only post-validation)
+- [x] No debug code left behind

--- a/tickets/entities/review-checklists/REV-MGFUZN.md
+++ b/tickets/entities/review-checklists/REV-MGFUZN.md
@@ -2,55 +2,66 @@
 id: REV-MGFUZN
 type: review-checklist
 title: 'Review: display_property as a template (multi-property title)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`go test ./...` green)
+- [x] Lint clean (`golangci-lint ./internal/metamodel/ ./internal/dataentry/` — 0 issues; `go vet` clean)
+- [x] Coverage maintained (`just coverage-check` PASS — total 76.9%)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Ran cranky-code-reviewer on commit f09a6afa
+- [x] All critical review-responses addressed (none raised)
+- [x] All significant review-responses addressed (RR-978KZI → addressed)
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:**
+- RR-978KZI (significant → addressed) — git-crypt locked-title template leak in mentions.go; fixed with `DisplayProperties()` + regression tests.
+- RR-00TCAM (minor → addressed) — direct scanner unit tests added.
+- RR-87IIFY (minor → addressed) — doc sentence on literal-text ID fallback.
+- RR-3QJCB7 (nit → wont-fix, justified) — insertion sort (pre-existing/out of scope), NBSP collapse (intended), defense-in-depth godoc (now tested).
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested
 
-**Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+**Acceptance Status:** (all via `go test ./internal/metamodel/`)
+1. `"{voornaam} {achternaam}"` → "Jeroen Vloothuis" — **PASS**
+2. empty tussenvoegsel → single space — **PASS**
+3. all placeholders empty → ID — **PASS**
+4. bare name unchanged — **PASS**
+5. literal comma passthrough — **PASS**
+6. `{unknown_prop}` → load error — **PASS**
+7. `{voornaam` (unclosed) → load error — **PASS**
+8. `GetPrimaryProperty()` on template → "" — **PASS**
 
-## Documentation (enhancements only)
+Plus: adjacent placeholders, brace-in-value non-reinjection, unicode, direct
+scanner tests, and the mentions locked-title regression.
 
-Skip this section for bugs and internal refactors.
+## Documentation
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+- [x] User-facing docs updated — metamodel guide Templates subsection (syntax, whitespace collapse, ID-fallback corner, display-only). Regenerated docs/.
+- [x] ~~Docs-checklist~~ (N/A: doc change folded into this PR; single guide subsection)
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why
+- [x] No TODOs/FIXMEs
+- [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] PR created: https://github.com/sourcehaven-bv/rela/pull/1070
+- [x] All CI checks pass (verified locally: build, full test, lint, vet, coverage, docs, ticket-validate; PR CI running)
+- [x] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1070
+
+## Follow-up
+
+- **TKT-VHSHOB** filed: CLI table output (`rela list`/`export`/`graph`) shows blank titles because it uses `entity.Title()` not `DisplayTitle` — pre-existing, affects bare-name too. To be implemented next.

--- a/tickets/entities/review-checklists/REV-MGFUZN.md
+++ b/tickets/entities/review-checklists/REV-MGFUZN.md
@@ -1,0 +1,56 @@
+---
+id: REV-MGFUZN
+type: review-checklist
+title: 'Review: display_property as a template (multi-property title)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-00TCAM.md
+++ b/tickets/entities/review-responses/RR-00TCAM.md
@@ -1,0 +1,9 @@
+---
+id: RR-00TCAM
+type: review-response
+title: No direct unit tests for the template scanner (parse/render agreement)
+finding: parseDisplayTemplate/renderDisplayTemplate/collapseWhitespace were only tested indirectly via Parse/DisplayTitle. The nastiest inputs (nested/unbalanced braces {a{b}, stray } like a}b / {a}}, and the render-side unclosed-{ graceful-degradation branch) were uncovered, so the 'parse and render agree' invariant wasn't pinned directly.
+severity: minor
+resolution: Added TestParseDisplayTemplate, TestRenderDisplayTemplate (incl. the unclosed-brace verbatim-emit path), TestCollapseWhitespace, and TestEntityDef_DisplayProperties in types_test.go — table-driven, covering adjacent placeholders, leading/trailing/nested braces, unclosed, empty placeholder, and value-braces-not-rescanned.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3QJCB7.md
+++ b/tickets/entities/review-responses/RR-3QJCB7.md
@@ -1,0 +1,9 @@
+---
+id: RR-3QJCB7
+type: review-response
+title: 'Acknowledged nits: insertion sort, NBSP collapse, defense-in-depth invariant'
+finding: 'Reviewer nits: (#2) GetPrimaryProperty uses a hand-rolled insertion sort where sort.Strings would do; (#4) collapseWhitespace via strings.Fields collapses ALL Unicode whitespace incl. NBSP in literal text; (#6) the ''render assumes validated input'' godoc slightly oversells — LoadWithoutMigrationCheck skips validate, so render''s graceful-degradation branch is genuinely reachable (and safe).'
+severity: nit
+reason: (#2) The insertion sort is pre-existing code I didn't touch; changing it is unrelated churn — out of scope for this ticket. (#4) Collapsing all Unicode whitespace is correct and desired per the spec (single-space display names); a deliberate NBSP in a display template is not a supported use case. (#6) The behaviour is correct (safe, no panic); the graceful-degradation branch is now directly tested (TestRenderDisplayTemplate/unclosed_brace_emitted_verbatim), and the godoc already notes it 'degrades gracefully' — no code change needed.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-87IIFY.md
+++ b/tickets/entities/review-responses/RR-87IIFY.md
@@ -1,0 +1,9 @@
+---
+id: RR-87IIFY
+type: review-response
+title: Literal-only template never falls back to ID (undocumented corner)
+finding: A template with literal text (e.g. "Mr. {achternaam}") with an empty placeholder renders "Mr.", never the ID, because only an all-empty result falls back. Follows the spec but is an unstated corner a reader might not expect.
+severity: minor
+resolution: 'Added a sentence to the metamodel guide''s Templates subsection: the ID fallback applies only when the rendered result is empty after trimming; a template with literal text always renders that text and never falls back.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-978KZI.md
+++ b/tickets/entities/review-responses/RR-978KZI.md
@@ -1,0 +1,9 @@
+---
+id: RR-978KZI
+type: review-response
+title: Templated display leaks past git-crypt locked-title guard in mentions
+finding: internal/dataentry/mentions.go used GetPrimaryProperty() (now "" for templates) to decide if a mention's title is locked. For a templated display_property like "{achternaam}" where achternaam is git-crypt-locked, lockedReasonFor matched only "" or InaccessibleFieldContent, so the mention was NOT flagged inaccessible — a regression vs the bare-name display_property which was correctly protected. The title could render a partial name from other readable placeholders.
+severity: significant
+resolution: 'Added EntityDef.DisplayProperties() returning all property names backing the display title (all placeholders for a template, the single primary otherwise). Rewrote mentions.go displayProperties()/lockedReasonFor() to flag the title inaccessible when ANY display property (or whole-content) is locked. Added regression tests in mentions_test.go: locked placeholder → inaccessible; locked non-placeholder → still readable; fully-readable template → renders both.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-NJTBQX.md
+++ b/tickets/entities/tickets/TKT-NJTBQX.md
@@ -1,0 +1,78 @@
+---
+id: TKT-NJTBQX
+type: ticket
+title: display_property as a template (multi-property title)
+kind: enhancement
+priority: medium
+effort: s
+status: review
+---
+
+## TL;DR
+
+Extend `display_property` to accept a template string with `{property}`
+placeholders (e.g. `"{voornaam} {tussenvoegsel} {achternaam}"` → `"Jeroen
+Vloothuis"`), in addition to the existing bare-property-name form. Backwards
+compatible: a value with no `{` routes to the existing bare-name path. Extends
+FEAT-9J42V.
+
+## Why
+
+`EntityDef.DisplayTitle` (`internal/metamodel/entity_def.go`) resolves a single
+`GetPrimaryProperty()` name today. Works for a single "primary" field (`titel`,
+`naam`); breaks the moment the natural human name is a concatenation (`voornaam`
++ `tussenvoegsel` + `achternaam`) — the list/dropdown/link shows only one field
+or the ID.
+
+```yaml
+persoon:
+  display_property: "{voornaam} {tussenvoegsel} {achternaam}"   # "Jeroen Vloothuis"
+```
+
+## Design
+
+### Detection
+A value containing `{` is a template; otherwise a bare property name (existing
+behaviour verbatim). Property names can't contain `{`, so detection is
+unambiguous. No new YAML key, no migration.
+
+### Rendering (in `DisplayTitle`)
+- `{propname}` → the property's stringified value (`fmt.Sprintf("%v", val)`; `nil` → empty).
+- literal text passes through.
+- Consecutive whitespace collapses to one space; result is trimmed (so an empty
+`tussenvoegsel` yields a single space, not a double).
+- Empty after trim → fall back to the entity ID (existing unset-display_property behaviour).
+
+### `GetPrimaryProperty()` — returns `""` for templates
+**Locked decision:** the display property is READONLY-derived. A template has no
+single writable target, and (since TKT-CW96FU removed `create --title`) nothing
+writes into `GetPrimaryProperty()` anymore. So it returns `""` when the value is
+a template — `DisplayTitle` handles templates before consulting it.
+
+### Load-time validation (in `validateDisplayProperty`, loader.go)
+- Parse the template, extract all placeholder names.
+- Each placeholder must reference a defined property (existing bare-name rule, per-placeholder).
+- Existing type restriction (reject date/file/rrule/list) applies per referenced property.
+- Malformed templates (unclosed `{`, empty `{}`) → error at load with the offending template + entity type.
+
+### Dropped from scope
+- **Inline `{prop:fallback}` syntax** — no compelling use case; whitespace-collapse already handles the empty-middle-field case.
+- Full expression language, localised formatting, multi-line titles.
+
+## Acceptance criteria
+
+1. `"{voornaam} {achternaam}"` + `{voornaam:"Jeroen", achternaam:"Vloothuis"}` → `"Jeroen Vloothuis"`.
+2. `"{voornaam} {tussenvoegsel} {achternaam}"` + tussenvoegsel empty → `"Jeroen Vloothuis"` (single space).
+3. All placeholders empty → entity ID.
+4. Bare name `"achternaam"` (unchanged) → renders the value verbatim.
+5. `"{achternaam}, {voornaam}"` → `"Vloothuis, Jeroen"` (literal comma passes through).
+6. `"{unknown_prop}"` → error at load.
+7. `"{voornaam"` (missing `}`) → error at load.
+8. `GetPrimaryProperty()` on a template-valued entity returns `""`.
+
+## Files
+
+- `internal/metamodel/entity_def.go` — `DisplayTitle`, `GetPrimaryProperty`, `renderDisplayTemplate` + parse helper.
+- `internal/metamodel/loader.go` — `validateDisplayProperty` placeholder parsing.
+- `internal/metamodel/entity_def_test.go`, `loader_test.go` — tests.
+- `docs/metamodel.md` (via docs-project source) — document template syntax.

--- a/tickets/entities/tickets/TKT-NJTBQX.md
+++ b/tickets/entities/tickets/TKT-NJTBQX.md
@@ -5,7 +5,7 @@ title: display_property as a template (multi-property title)
 kind: enhancement
 priority: medium
 effort: s
-status: review
+status: done
 ---
 
 ## TL;DR

--- a/tickets/entities/tickets/TKT-VHSHOB.md
+++ b/tickets/entities/tickets/TKT-VHSHOB.md
@@ -1,0 +1,47 @@
+---
+id: TKT-VHSHOB
+type: ticket
+title: CLI table output ignores display_property (uses literal title only)
+kind: enhancement
+priority: medium
+effort: s
+status: ready
+---
+
+## Problem
+
+The CLI table output (`rela list`, `rela export`, `rela graph`, `rela delete`
+confirmation) renders an entity's title via `entity.Title()`
+(`internal/entity/entity.go:103`), which reads only the literal `title`
+property. It never consults the metamodel's `DisplayTitle`, so it honors
+**neither** the bare-name `display_property` (TKT-RT3Y3) **nor** the new
+template form (TKT-NJTBQX). Any entity type whose display name isn't literally
+`title` shows a blank TITLE column in `rela list`.
+
+Verified on develop: a `persoon` type with `display_property: achternaam`
+already shows blank — this is a long-standing gap, surfaced while testing the
+template feature.
+
+## Scope
+
+Wire `metamodel.DisplayTitle` into the CLI output path so the table/graph/export
+title columns match what the data-entry web app shows.
+
+- `internal/output/output.go` `writeEntitiesTable` (line ~103) calls
+`e.Title()`; it needs the metamodel to call `meta.DisplayTitle(e.ID, e.Type,
+e.Properties)` instead.
+- The `output.Writer` currently has no metamodel handle — thread one in (or pass
+a resolved title per row from the CLI command, which already has `svc.Meta()`).
+- Same for `export.go` (node titles), `graph.go` (node labels), `delete.go`
+(confirmation prompt).
+
+## Acceptance criteria
+
+1. `rela list persoon` with `display_property: achternaam` shows the achternaam value, not blank.
+2. `rela list persoon` with a template `display_property` shows the rendered template.
+3. Entities with a literal `title` property are unchanged.
+4. `rela export`/`graph` node titles/labels honor `display_property`.
+
+## Out of scope
+
+- Any change to `DisplayTitle` itself (done in TKT-NJTBQX / TKT-RT3Y3).

--- a/tickets/relations/TKT-NJTBQX--affects--metamodel-types.md
+++ b/tickets/relations/TKT-NJTBQX--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NJTBQX
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-NJTBQX--has-implementation--IMPL-6L9POF.md
+++ b/tickets/relations/TKT-NJTBQX--has-implementation--IMPL-6L9POF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NJTBQX
+relation: has-implementation
+to: IMPL-6L9POF
+---

--- a/tickets/relations/TKT-NJTBQX--has-review--REV-MGFUZN.md
+++ b/tickets/relations/TKT-NJTBQX--has-review--REV-MGFUZN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NJTBQX
+relation: has-review
+to: REV-MGFUZN
+---

--- a/tickets/relations/TKT-NJTBQX--has-review-response--RR-00TCAM.md
+++ b/tickets/relations/TKT-NJTBQX--has-review-response--RR-00TCAM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NJTBQX
+relation: has-review-response
+to: RR-00TCAM
+---

--- a/tickets/relations/TKT-NJTBQX--has-review-response--RR-3QJCB7.md
+++ b/tickets/relations/TKT-NJTBQX--has-review-response--RR-3QJCB7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NJTBQX
+relation: has-review-response
+to: RR-3QJCB7
+---

--- a/tickets/relations/TKT-NJTBQX--has-review-response--RR-87IIFY.md
+++ b/tickets/relations/TKT-NJTBQX--has-review-response--RR-87IIFY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NJTBQX
+relation: has-review-response
+to: RR-87IIFY
+---

--- a/tickets/relations/TKT-NJTBQX--has-review-response--RR-978KZI.md
+++ b/tickets/relations/TKT-NJTBQX--has-review-response--RR-978KZI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NJTBQX
+relation: has-review-response
+to: RR-978KZI
+---

--- a/tickets/relations/TKT-NJTBQX--implements--FEAT-9J42V.md
+++ b/tickets/relations/TKT-NJTBQX--implements--FEAT-9J42V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NJTBQX
+relation: implements
+to: FEAT-9J42V
+---

--- a/tickets/relations/TKT-VHSHOB--affects--cli-flags.md
+++ b/tickets/relations/TKT-VHSHOB--affects--cli-flags.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VHSHOB
+relation: affects
+to: cli-flags
+---

--- a/tickets/relations/TKT-VHSHOB--implements--FEAT-9J42V.md
+++ b/tickets/relations/TKT-VHSHOB--implements--FEAT-9J42V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VHSHOB
+relation: implements
+to: FEAT-9J42V
+---


### PR DESCRIPTION
## What

`display_property` may now be a **template** with `{property}` placeholders:

```yaml
persoon:
  display_property: "{voornaam} {tussenvoegsel} {achternaam}"   # "Jeroen Vloothuis"
```

Placeholders are substituted from the entity's properties, literal text passes
through, consecutive whitespace collapses to one space (so an empty middle field
doesn't leave a double space), and an all-empty result falls back to the entity
ID. A value **without** `{` is still a bare property name — unchanged. Extends
FEAT-9J42V.

## Design

- **Detection:** a `{` makes it a template (property names can't contain `{`).
- **Rendering** lives in `EntityDef.DisplayTitle`; a small hand-written scanner
  (`parseDisplayTemplate` / `renderDisplayTemplate`) shared with load-time
  validation so syntax has one source of truth. No regexp, no new dep.
- **Validation** at metamodel-load: each placeholder must name a defined
  property of an allowed type (string/integer/boolean/enum — same rules as the
  bare form); malformed templates (unclosed `{`, empty `{}`) fail loud.
- **`GetPrimaryProperty()` returns `""` for a template** — it names no single
  *writable* target (and since TKT-CW96FU nothing writes into it). A new
  `EntityDef.DisplayProperties()` reports the full *read* set (all placeholders)
  for callers that need it.

## Security fix (from code review)

The data-entry **locked-title guard** (`mentions.go`) keyed off
`GetPrimaryProperty()`. With that now `""` for templates, a git-crypt-**locked
placeholder** would no longer flag the mention inaccessible — a regression vs the
bare-name form, which was protected. Fixed by keying the guard off
`DisplayProperties()` (any locked placeholder → title locked), with regression
tests.

## Tests

- All 8 acceptance criteria as unit tests, plus adjacent placeholders,
  brace-in-value non-reinjection, unicode passthrough.
- Direct scanner tests (`TestParseDisplayTemplate` / `TestRenderDisplayTemplate`
  / `TestCollapseWhitespace`) pinning the parse/render-agreement invariant and
  the graceful-degradation branch.
- `mentions_test.go`: locked-placeholder → inaccessible; locked non-placeholder
  → readable; readable template → renders.

`go build ./...`, `go test ./...`, `golangci-lint`, `go vet`,
`just coverage-check` (76.9%) all green.

## Docs

`docs/metamodel.md` (via `docs-project/`) gains a Templates subsection.

## Known follow-up

**TKT-VHSHOB** — the CLI table output (`rela list`/`export`/`graph`) shows a
blank title because it uses `entity.Title()` (literal `title` prop), not
`metamodel.DisplayTitle`. This is **pre-existing** (affects the bare-name
`display_property` too) and orthogonal to this change. Being implemented next.