### PR TITLE
CLI output honors display_property (TKT-VHSHOB)

### DIFF
--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -38,7 +38,7 @@ func (c *DeleteCmd) Run(ctx context.Context, svc *cliServices) error {
 	}
 
 	if !c.Force {
-		fmt.Printf("Delete %s '%s'", entity.Type, entity.Title())
+		fmt.Printf("Delete %s '%s'", entity.Type, svc.Meta().DisplayTitle(entity.ID, entity.Type, entity.Properties))
 		if totalRelations > 0 {
 			fmt.Printf(" and %d relation(s)", totalRelations)
 		}

--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -204,7 +204,11 @@ func getEntityRelations(ctx context.Context, svc *cliServices, entityID string) 
 		}
 		target := RelationTarget{ID: rel.To}
 		if node, err := st.GetEntity(ctx, rel.To); err == nil {
-			target.Title = svc.Meta().DisplayTitle(node.ID, node.Type, node.Properties)
+			// Export is a data-interchange format: emit the raw title
+			// property (empty when absent), not a DisplayTitle that would
+			// echo the ID for titleless entities. Presentation-layer
+			// display_property resolution belongs in human-facing output.
+			target.Title = node.Title()
 		}
 		relations.Outgoing[rel.Type] = append(relations.Outgoing[rel.Type], target)
 	}
@@ -215,7 +219,8 @@ func getEntityRelations(ctx context.Context, svc *cliServices, entityID string) 
 		}
 		source := RelationTarget{ID: rel.From}
 		if node, err := st.GetEntity(ctx, rel.From); err == nil {
-			source.Title = svc.Meta().DisplayTitle(node.ID, node.Type, node.Properties)
+			// See the outgoing branch: export keeps the raw title property.
+			source.Title = node.Title()
 		}
 		relations.Incoming[rel.Type] = append(relations.Incoming[rel.Type], source)
 	}

--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -204,7 +204,7 @@ func getEntityRelations(ctx context.Context, svc *cliServices, entityID string) 
 		}
 		target := RelationTarget{ID: rel.To}
 		if node, err := st.GetEntity(ctx, rel.To); err == nil {
-			target.Title = node.Title()
+			target.Title = svc.Meta().DisplayTitle(node.ID, node.Type, node.Properties)
 		}
 		relations.Outgoing[rel.Type] = append(relations.Outgoing[rel.Type], target)
 	}
@@ -215,7 +215,7 @@ func getEntityRelations(ctx context.Context, svc *cliServices, entityID string) 
 		}
 		source := RelationTarget{ID: rel.From}
 		if node, err := st.GetEntity(ctx, rel.From); err == nil {
-			source.Title = node.Title()
+			source.Title = svc.Meta().DisplayTitle(node.ID, node.Type, node.Properties)
 		}
 		relations.Incoming[rel.Type] = append(relations.Incoming[rel.Type], source)
 	}

--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -115,8 +115,12 @@ func generateDOT(
 			color = def.Color
 		}
 		for _, e := range group {
-			label := escapeLabel(e.Title())
-			if label == "" {
+			// DisplayTitle honors display_property (bare or template); it
+			// falls back to the ID itself, so strip a title equal to the ID
+			// to avoid the redundant "ID\nID" label.
+			title := meta.DisplayTitle(e.ID, e.Type, e.Properties)
+			label := escapeLabel(title)
+			if label == "" || title == e.ID {
 				label = e.ID
 			} else {
 				label = e.ID + "\\n" + label

--- a/internal/cli/graph_test.go
+++ b/internal/cli/graph_test.go
@@ -21,11 +21,17 @@ func setupGraphTestGraph(t *testing.T) *cliServices {
 				Label:    "Requirement",
 				IDPrefix: "REQ-",
 				Color:    "#E3F2FD",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
 			},
 			"decision": {
 				Label:    "Decision",
 				IDPrefix: "DEC-",
 				Color:    "#FFF3E0",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
 			},
 		},
 		Relations: map[string]metamodel.RelationDef{

--- a/internal/cli/graph_test.go
+++ b/internal/cli/graph_test.go
@@ -144,6 +144,11 @@ func TestGenerateDOT_EntityWithoutTitle(t *testing.T) {
 	if !strings.Contains(dot, `label="CMP-001"`) {
 		t.Error("DOT should use entity ID as label when no title is set")
 	}
+	// The label guard must not duplicate the ID when DisplayTitle falls back
+	// to it (would otherwise render "CMP-001\nCMP-001").
+	if strings.Contains(dot, `CMP-001\nCMP-001`) {
+		t.Errorf("titleless label must not duplicate the ID, got:\n%s", dot)
+	}
 }
 
 // TestGenerateDOT_HyphenatedEntityType verifies that entity types

--- a/internal/cli/kong.go
+++ b/internal/cli/kong.go
@@ -156,10 +156,13 @@ func runKong() int {
 			fmt.Fprintln(os.Stderr, err)
 			return 1
 		}
-		// Resolve entity display titles through the metamodel so table,
-		// trace, and detail output honor display_property (bare name or
+		// Resolve entity display titles through the metamodel so the entity
+		// table and detail output honor display_property (bare name or
 		// template), matching the data-entry app. Without a project (no
 		// metamodel) the writer falls back to the literal `title` property.
+		// NOTE: trace/path output builds its own titles in internal/tracer
+		// (still literal `title`); honoring display_property there is
+		// tracked separately (TKT-VHSHOB follow-up).
 		out.Titles = cliSvc.Meta()
 	}
 

--- a/internal/cli/kong.go
+++ b/internal/cli/kong.go
@@ -156,6 +156,11 @@ func runKong() int {
 			fmt.Fprintln(os.Stderr, err)
 			return 1
 		}
+		// Resolve entity display titles through the metamodel so table,
+		// trace, and detail output honor display_property (bare name or
+		// template), matching the data-entry app. Without a project (no
+		// metamodel) the writer falls back to the literal `title` property.
+		out.Titles = cliSvc.Meta()
 	}
 
 	ktx.BindTo(ctx, (*context.Context)(nil))

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -51,6 +51,29 @@ type Writer struct {
 	Format  Format
 	Out     io.Writer
 	NoColor bool
+	// Titles resolves an entity's display title, honoring the metamodel's
+	// display_property (bare name or template). When nil, the writer falls
+	// back to the entity's literal `title` property. Consumer-side interface
+	// so output does not depend on the metamodel package. *metamodel.Metamodel
+	// satisfies it.
+	Titles TitleResolver
+}
+
+// TitleResolver resolves an entity's display title from its type and
+// properties. Implemented by *metamodel.Metamodel; the CLI wires it onto the
+// Writer once the project's metamodel is loaded.
+type TitleResolver interface {
+	DisplayTitle(id, entityType string, properties map[string]interface{}) string
+}
+
+// entityTitle returns the entity's display title via the resolver when one is
+// set, otherwise the literal `title` property. Centralizes the fallback so the
+// table and trace paths agree.
+func (w *Writer) entityTitle(e *entity.Entity) string {
+	if w.Titles != nil {
+		return w.Titles.DisplayTitle(e.ID, e.Type, e.Properties)
+	}
+	return e.Title()
 }
 
 // New creates a new output writer
@@ -100,7 +123,7 @@ func (w *Writer) writeEntitiesTable(entities []*entity.Entity, showSummary bool)
 		if err := table.Append([]string{
 			e.ID,
 			e.Type,
-			truncate(e.Title(), tableTitleMaxLen),
+			truncate(w.entityTitle(e), tableTitleMaxLen),
 			statusDisplay,
 		}); err != nil {
 			return err
@@ -170,7 +193,7 @@ func (w *Writer) WriteEntity(entity *entity.Entity, incoming, outgoing []*entity
 	fmt.Fprintln(w.Out, strings.Repeat("─", headerSeparatorLen))
 
 	// Properties
-	if title := entity.Title(); title != "" {
+	if title := w.entityTitle(entity); title != "" {
 		fmt.Fprintf(w.Out, "Title:  %s\n", title)
 	}
 	if status := entity.GetString("status"); status != "" {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -67,8 +67,9 @@ type TitleResolver interface {
 }
 
 // entityTitle returns the entity's display title via the resolver when one is
-// set, otherwise the literal `title` property. Centralizes the fallback so the
-// table and trace paths agree.
+// set, otherwise the literal `title` property. Centralizes the fallback for
+// the entity table and detail (WriteEntity) paths. (Trace output builds its
+// own node titles in internal/tracer and does not route through here yet.)
 func (w *Writer) entityTitle(e *entity.Entity) string {
 	if w.Titles != nil {
 		return w.Titles.DisplayTitle(e.ID, e.Type, e.Properties)

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1085,3 +1085,58 @@ func TestWriteSchemaRelationDetail(t *testing.T) {
 		t.Error("expected min_outgoing in output")
 	}
 }
+
+// fakeTitleResolver renders a fixed title, ignoring the entity, so the test
+// can distinguish "resolver was used" from "literal title property was read".
+type fakeTitleResolver struct{ title string }
+
+func (f fakeTitleResolver) DisplayTitle(_, _ string, _ map[string]interface{}) string {
+	return f.title
+}
+
+// TestWriter_TitleResolver verifies the entity table uses the injected
+// TitleResolver when set (honoring display_property) and falls back to the
+// literal `title` property when nil. TKT-VHSHOB.
+func TestWriter_TitleResolver(t *testing.T) {
+	// An entity whose display name is NOT in its `title` property — the case
+	// a bare/template display_property covers. Title() would return "".
+	e := &entity.Entity{
+		ID:   "PERS-1",
+		Type: "persoon",
+		Properties: map[string]interface{}{
+			"achternaam": "Vloothuis",
+			"status":     "draft",
+		},
+	}
+
+	t.Run("resolver set → uses resolved title", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		w := NewWithWriter(buf, FormatTable)
+		w.Titles = fakeTitleResolver{title: "Jeroen Vloothuis"}
+		if err := w.WriteEntities([]*entity.Entity{e}); err != nil {
+			t.Fatalf("WriteEntities: %v", err)
+		}
+		if !strings.Contains(buf.String(), "Jeroen Vloothuis") {
+			t.Errorf("expected resolved title in output, got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("resolver nil → falls back to literal title property", func(t *testing.T) {
+		withTitle := &entity.Entity{
+			ID:   "TKT-1",
+			Type: "ticket",
+			Properties: map[string]interface{}{
+				"title":  "Literal Title",
+				"status": "draft",
+			},
+		}
+		buf := &bytes.Buffer{}
+		w := NewWithWriter(buf, FormatTable) // Titles left nil
+		if err := w.WriteEntities([]*entity.Entity{withTitle}); err != nil {
+			t.Fatalf("WriteEntities: %v", err)
+		}
+		if !strings.Contains(buf.String(), "Literal Title") {
+			t.Errorf("expected literal title fallback in output, got:\n%s", buf.String())
+		}
+	})
+}

--- a/tickets/entities/implementation-checklists/IMPL-G0685K.md
+++ b/tickets/entities/implementation-checklists/IMPL-G0685K.md
@@ -1,0 +1,45 @@
+---
+id: IMPL-G0685K
+type: implementation-checklist
+title: 'Implementation: CLI table output ignores display_property (uses literal title only)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (`TestWriter_TitleResolver`: resolver-used + nil-fallback)
+- [x] Integration-ish: existing `TestGenerateDOT` + cli/output suites exercise the wired path end-to-end
+- [x] Happy path implemented (Writer.Titles resolver + entityTitle helper; graph/export/delete wired via svc.Meta())
+- [x] Edge cases handled (nil resolver → literal `title` fallback; graph ID==title → no redundant "ID\nID" label)
+- [x] Error handling: n/a (pure formatting; DisplayTitle already falls back to ID)
+
+## Test Quality
+
+- [x] Table-driven / subtests where it fits (TestWriter_TitleResolver uses t.Run)
+- [x] fakeTitleResolver distinguishes "resolver used" from "literal title read"
+- [x] Fixed the graph_test fixture to declare `title` as a required property (it relied on the old e.Title() shortcut that bypassed the metamodel) — realistic, matches real metamodels
+- [x] No hardcoded magic
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified
+- [x] Edge cases verified
+
+**Verification Evidence:**
+
+Built `bin/rela`, tested against scratch projects:
+- **AC2 (template):** `rela list persoon` with `display_property: "{voornaam} {tussenvoegsel} {achternaam}"` → TITLE column shows **"Jeroen Vloothuis"** / **"Jan van der Berg"** (was BLANK before this change).
+- **AC1 (bare name):** `rela list persoon` with `display_property: achternaam` → **"Vloothuis"** (was blank).
+- **AC3 (literal title unchanged):** `rela list ticket --project tickets` → titles render as before.
+- **AC4 (graph):** `rela graph -f dot` → `"PERS-JV" [label="PERS-JV\nJeroen Vloothuis", ...]` — label honors the template. Export relation targets use DisplayTitle too.
+
+## Quality
+
+- [x] Follows project patterns — consumer-side `TitleResolver` interface in `output` (no dependency on metamodel package); `*metamodel.Metamodel` satisfies it. Injected once in kong.go after the project loads.
+- [x] DRY — single `entityTitle` helper shared by table + detail (WriteEntity) paths.
+- [x] No god-object growth — `Writer` gained one field (no max-fields cap on it); plimsoll passes.
+- [x] No silent failures — nil resolver is an intentional, documented fallback (non-project commands).
+- [x] No debug code left behind

--- a/tickets/entities/review-checklists/REV-971FX0.md
+++ b/tickets/entities/review-checklists/REV-971FX0.md
@@ -2,55 +2,58 @@
 id: REV-971FX0
 type: review-checklist
 title: 'Review: CLI table output ignores display_property (uses literal title only)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`go test ./...` green)
+- [x] Lint clean (`golangci-lint` 0 issues; `go vet` clean; `just arch-lint` OK; `just plimsoll` OK)
+- [x] Coverage maintained (`just coverage-check` PASS — 77.1%)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Ran cranky-code-reviewer on commit 24772442
+- [x] All critical review-responses addressed (none raised)
+- [x] All significant review-responses addressed (RR-QM9CDV, RR-X3YE8K, RR-18E3PX)
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:**
+- RR-QM9CDV (significant → addressed) — misleading trace comments corrected; TKT-COZN2E filed.
+- RR-X3YE8K (significant → addressed) — export reverted to raw title (data-interchange); AC4 narrowed to graph.
+- RR-18E3PX (significant → addressed) — graph ID-fallback guard now tested.
+- RR-US77XX (minor → addressed) — guard operand, JSON asymmetry, fixture narrowing, Meta() cost, nil-path documented/justified.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested
 
-**Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+**Acceptance Status:** (manual + unit)
+1. bare-name `display_property: achternaam` → "Vloothuis" (was blank) — **PASS**
+2. template → "Jeroen Vloothuis" (was blank) — **PASS**
+3. literal-title tickets unchanged — **PASS**
+4. graph node labels honor display_property — **PASS** (`TestGenerateDOT`, manual DOT)
 
-## Documentation (enhancements only)
+Excluded by design (review): export stays raw data; trace deferred to
+TKT-COZN2E.
 
-Skip this section for bugs and internal refactors.
+## Documentation
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+- [x] ~~User-facing docs~~ (N/A: no new metamodel/CLI surface; behavior now matches the data-entry app and the already-documented display_property)
+- [x] ~~Docs-checklist~~ (N/A: internal wiring)
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit messages explain the why
+- [x] No TODOs/FIXMEs (trace gap tracked as a ticket, not a code TODO)
+- [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] PR created: https://github.com/sourcehaven-bv/rela/pull/1085
+- [x] All CI checks pass (verified locally: build, full test, lint, vet, arch-lint, plimsoll, coverage; PR CI running)
+- [x] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1085

--- a/tickets/entities/review-checklists/REV-971FX0.md
+++ b/tickets/entities/review-checklists/REV-971FX0.md
@@ -1,0 +1,56 @@
+---
+id: REV-971FX0
+type: review-checklist
+title: 'Review: CLI table output ignores display_property (uses literal title only)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-18E3PX.md
+++ b/tickets/entities/review-responses/RR-18E3PX.md
@@ -1,0 +1,9 @@
+---
+id: RR-18E3PX
+type: review-response
+title: graph ID-fallback label guard was untested
+finding: The graph.go `title == e.ID` guard (prevents a redundant 'ID\nID' label when DisplayTitle falls back to the ID) had no test — every graph_test fixture had a distinct title, so the branch never executed.
+severity: significant
+resolution: Strengthened the existing TestGenerateDOT_EntityWithoutTitle (which already sets up a titleless entity via testutil.Entity) to assert the label is the bare ID AND does not contain the duplicated 'CMP-001\nCMP-001' form. (An initial attempt to add a titleless REQ-003 via testutil.EntityFor failed because that helper auto-fills required properties with fake data — used testutil.Entity's existing no-fill fixture instead.)
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QM9CDV.md
+++ b/tickets/entities/review-responses/RR-QM9CDV.md
@@ -1,0 +1,9 @@
+---
+id: RR-QM9CDV
+type: review-response
+title: Comments falsely claim trace output honors display_property
+finding: kong.go and output.go (entityTitle godoc) claimed 'table, trace, and detail output honor display_property' / 'table and trace paths agree', but trace output builds its own node titles in internal/tracer via e.Title() and is NOT wired to the resolver. Misleading comment.
+severity: significant
+resolution: Corrected both comments to state only the table and detail (WriteEntity) paths are covered, and explicitly note that trace/path builds its own titles in internal/tracer and is tracked separately (TKT-COZN2E). Filed TKT-COZN2E to resolve trace at the output boundary without giving the pure-reader tracer a metamodel dependency.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-US77XX.md
+++ b/tickets/entities/review-responses/RR-US77XX.md
@@ -1,0 +1,9 @@
+---
+id: RR-US77XX
+type: review-response
+title: 'Minor/leverage notes: guard operand mismatch, JSON asymmetry, fixture narrowing, dead nil-path, Meta() cost'
+finding: 'Reviewer minor/leverage notes: (#4) graph guard compares raw title vs e.ID while label is escaped/truncated (latent trap if IDs gain special chars); (#5) list/show JSON stays raw while table shows resolved title (asymmetry); (#6) DisplayTitle only surfaces a title for a declared+required display property, a behavior narrowing vs old blind e.Title(); (#7) Meta() per-relation-loop is cheap - no concern; (#9) the nil-resolver fallback is effectively test-only since all entity-rendering commands require a project.'
+severity: minor
+resolution: '(#4) Left as-is: IDs are short/quote-free/newline-free so raw-vs-escaped can''t diverge today; documented the invariant intent in the guard comment. (#5) Deliberate: JSON is raw data, table is presentation - consistent with the export decision (RR-X3YE8K); no change. (#6) Documented in the ticket''s deliberate-exclusions; no in-tree metamodel declares a title-carrying type without declaring title required, so safe. (#7) No change - Meta() returns a cached field. (#9) Kept the nil fallback as a defensive default (also serves tests); comment no longer overclaims a live non-project path.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-X3YE8K.md
+++ b/tickets/entities/review-responses/RR-X3YE8K.md
@@ -1,0 +1,9 @@
+---
+id: RR-X3YE8K
+type: review-response
+title: export relation-target titles would echo ID for titleless entities
+finding: 'Wiring DisplayTitle into export.go relation targets changed the JSON/YAML semantics: RelationTarget.Title is `omitempty` and was empty for titleless entities; DisplayTitle falls back to the entity ID, so absent titles would serialize as title==id, breaking the ''no title'' signal for machine consumers.'
+severity: significant
+resolution: Reverted export.go to use node.Title() (raw property). Export is a data-interchange format; presentation-layer display_property resolution belongs only in human-facing output. Narrowed the ticket's AC4 to graph (visualization) and documented export-stays-raw as a deliberate exclusion. Added an explaining comment at both export call sites.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-COZN2E.md
+++ b/tickets/entities/tickets/TKT-COZN2E.md
@@ -1,0 +1,50 @@
+---
+id: TKT-COZN2E
+type: ticket
+title: rela trace/path output ignores display_property (tracer builds titles from literal title)
+kind: enhancement
+priority: low
+effort: s
+status: ready
+---
+
+## Problem
+
+`rela trace` / `rela path` render node titles that are built inside
+`internal/tracer/tracer.go` via `e.Title()` (the literal `title` property) at
+lines 98, 153, 192, 233, 259. So — like the CLI table before TKT-VHSHOB — trace
+output shows a blank title for any entity type whose display name isn't
+literally `title` (bare-name or template `display_property`).
+
+Surfaced during the TKT-VHSHOB code review: that ticket wired `DisplayTitle`
+into the `output.Writer` (list/show/detail) and into graph, but the tracer
+builds its own `TraceNode.Title` / `PathStep.Title` and does not route through
+the writer's resolver.
+
+## Constraint
+
+`tracer` is a **pure reader with no metamodel dependency** by design (see the
+architecture rules in CLAUDE.md — "tracer is a pure reader"). So we should NOT
+inject the metamodel into the tracer.
+
+## Preferred approach
+
+Resolve display titles at the **output boundary**, not in the tracer:
+- Stop populating `TraceNode.Title` / `PathStep.Title` with `e.Title()` in the
+tracer (leave the raw title, or carry `Type` + `Properties` on the node).
+- Have `output.WriteTrace` / the trace command resolve each node's title via the
+same `TitleResolver` the entity table uses (`entityTitle`), so table and trace
+agree.
+
+This makes the "table and trace paths agree" contract actually true and reuses
+the TKT-VHSHOB resolver.
+
+## Acceptance criteria
+
+1. `rela trace <id>` and `rela path <a> <b>` show the display_property-resolved title (bare name or template), matching `rela list`.
+2. Literal-`title` types unchanged.
+3. The tracer package gains no metamodel dependency (`just arch-lint` stays green).
+
+## Out of scope
+
+- Changing `DisplayTitle` itself (done in TKT-NJTBQX / TKT-RT3Y3).

--- a/tickets/entities/tickets/TKT-VHSHOB.md
+++ b/tickets/entities/tickets/TKT-VHSHOB.md
@@ -5,7 +5,7 @@ title: CLI table output ignores display_property (uses literal title only)
 kind: enhancement
 priority: medium
 effort: s
-status: ready
+status: in-progress
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-VHSHOB.md
+++ b/tickets/entities/tickets/TKT-VHSHOB.md
@@ -5,7 +5,7 @@ title: CLI table output ignores display_property (uses literal title only)
 kind: enhancement
 priority: medium
 effort: s
-status: review
+status: done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-VHSHOB.md
+++ b/tickets/entities/tickets/TKT-VHSHOB.md
@@ -5,13 +5,13 @@ title: CLI table output ignores display_property (uses literal title only)
 kind: enhancement
 priority: medium
 effort: s
-status: in-progress
+status: review
 ---
 
 ## Problem
 
-The CLI table output (`rela list`, `rela export`, `rela graph`, `rela delete`
-confirmation) renders an entity's title via `entity.Title()`
+The CLI table output (`rela list`, `rela graph`, `rela delete` confirmation,
+`rela show` detail) renders an entity's title via `entity.Title()`
 (`internal/entity/entity.go:103`), which reads only the literal `title`
 property. It never consults the metamodel's `DisplayTitle`, so it honors
 **neither** the bare-name `display_property` (TKT-RT3Y3) **nor** the new
@@ -24,23 +24,36 @@ template feature.
 
 ## Scope
 
-Wire `metamodel.DisplayTitle` into the CLI output path so the table/graph/export
-title columns match what the data-entry web app shows.
+Wire `metamodel.DisplayTitle` into the human-facing CLI output so title
+columns/labels match what the data-entry web app shows.
 
-- `internal/output/output.go` `writeEntitiesTable` (line ~103) calls
-`e.Title()`; it needs the metamodel to call `meta.DisplayTitle(e.ID, e.Type,
-e.Properties)` instead.
-- The `output.Writer` currently has no metamodel handle — thread one in (or pass
-a resolved title per row from the CLI command, which already has `svc.Meta()`).
-- Same for `export.go` (node titles), `graph.go` (node labels), `delete.go`
-(confirmation prompt).
+- `internal/output/output.go`: a consumer-side `TitleResolver` interface + a
+`Titles` field on `Writer`; `entityTitle` helper resolves via the metamodel when
+set, else falls back to the literal `title` property. Used by the entity table
+(`writeEntitiesTable`) and the detail view (`WriteEntity`).
+- `internal/cli/kong.go`: sets `out.Titles = cliSvc.Meta()` once the project's
+metamodel is loaded.
+- `internal/cli/graph.go`: node labels via `DisplayTitle` (with an ID-fallback
+guard so a titleless entity doesn't render `"ID\nID"`).
+- `internal/cli/delete.go`: confirmation prompt via `DisplayTitle`.
 
 ## Acceptance criteria
 
-1. `rela list persoon` with `display_property: achternaam` shows the achternaam value, not blank.
-2. `rela list persoon` with a template `display_property` shows the rendered template.
-3. Entities with a literal `title` property are unchanged.
-4. `rela export`/`graph` node titles/labels honor `display_property`.
+1. `rela list persoon` with `display_property: achternaam` shows the achternaam value, not blank. **DONE — verified.**
+2. `rela list persoon` with a template `display_property` shows the rendered template. **DONE — verified ("Jeroen Vloothuis").**
+3. Entities with a literal `title` property are unchanged. **DONE — verified.**
+4. `rela graph` node labels honor `display_property`. **DONE — verified (`label="ID\n<rendered>"`).**
+
+## Deliberate exclusions (decided during code review)
+
+- **`rela export` stays raw.** Export is a data-interchange format (JSON/CSV/YAML)
+with `title,omitempty`; resolving via `DisplayTitle` would echo the entity ID as
+the title for titleless entities, breaking the "absent title" signal that
+machine consumers rely on. Export keeps `node.Title()` (raw property).
+- **`rela trace`/`path` NOT covered here.** The tracer builds its own node
+titles (`internal/tracer`, a metamodel-free pure reader) and doesn't route
+through the writer's resolver. Fixing it cleanly means resolving at the output
+boundary — tracked separately as **TKT-COZN2E**.
 
 ## Out of scope
 

--- a/tickets/relations/TKT-COZN2E--affects--cli-flags.md
+++ b/tickets/relations/TKT-COZN2E--affects--cli-flags.md
@@ -1,0 +1,5 @@
+---
+from: TKT-COZN2E
+relation: affects
+to: cli-flags
+---

--- a/tickets/relations/TKT-COZN2E--implements--FEAT-9J42V.md
+++ b/tickets/relations/TKT-COZN2E--implements--FEAT-9J42V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-COZN2E
+relation: implements
+to: FEAT-9J42V
+---

--- a/tickets/relations/TKT-VHSHOB--has-implementation--IMPL-G0685K.md
+++ b/tickets/relations/TKT-VHSHOB--has-implementation--IMPL-G0685K.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VHSHOB
+relation: has-implementation
+to: IMPL-G0685K
+---

--- a/tickets/relations/TKT-VHSHOB--has-review--REV-971FX0.md
+++ b/tickets/relations/TKT-VHSHOB--has-review--REV-971FX0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VHSHOB
+relation: has-review
+to: REV-971FX0
+---

--- a/tickets/relations/TKT-VHSHOB--has-review-response--RR-18E3PX.md
+++ b/tickets/relations/TKT-VHSHOB--has-review-response--RR-18E3PX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VHSHOB
+relation: has-review-response
+to: RR-18E3PX
+---

--- a/tickets/relations/TKT-VHSHOB--has-review-response--RR-QM9CDV.md
+++ b/tickets/relations/TKT-VHSHOB--has-review-response--RR-QM9CDV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VHSHOB
+relation: has-review-response
+to: RR-QM9CDV
+---

--- a/tickets/relations/TKT-VHSHOB--has-review-response--RR-US77XX.md
+++ b/tickets/relations/TKT-VHSHOB--has-review-response--RR-US77XX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VHSHOB
+relation: has-review-response
+to: RR-US77XX
+---

--- a/tickets/relations/TKT-VHSHOB--has-review-response--RR-X3YE8K.md
+++ b/tickets/relations/TKT-VHSHOB--has-review-response--RR-X3YE8K.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VHSHOB
+relation: has-review-response
+to: RR-X3YE8K
+---


### PR DESCRIPTION
## What

`rela list`, `rela graph`, `rela show` (detail), and `rela delete` (confirmation)
now render entity titles via `metamodel.DisplayTitle`, so they honor
`display_property` — both the bare-name form (TKT-RT3Y3) and the template form
(TKT-NJTBQX). Previously they used `entity.Title()` (the literal `title`
property), so any type whose display name isn't `title` showed a **blank** title.

Before: `rela list persoon` → blank TITLE column.
After: `Jeroen Vloothuis` (template) / `Vloothuis` (bare name).

## How

- `internal/output/output.go` — a consumer-side `TitleResolver` interface + a
  `Titles` field on `Writer`; `entityTitle` resolves via the metamodel when set,
  else falls back to the literal `title`. Keeps `output` free of a `metamodel`
  dependency (per the call-site-interface rule). Used by the entity table and the
  detail view.
- `internal/cli/kong.go` — wires `out.Titles = cliSvc.Meta()` once the project's
  metamodel loads.
- `internal/cli/graph.go` — node labels via `DisplayTitle`, with an ID-fallback
  guard so a titleless entity renders `label="ID"`, not `"ID\nID"`.
- `internal/cli/delete.go` — confirmation prompt via `DisplayTitle`.

## Deliberate exclusions (from code review)

- **`rela export` stays raw** — it's a data-interchange format (`title,omitempty`);
  `DisplayTitle` would echo the ID for titleless entities, breaking the "no title"
  signal machine consumers rely on. Export keeps the raw property.
- **`rela trace`/`path` not covered** — the tracer builds its own node titles and
  is a metamodel-free pure reader by design. Resolving at the output boundary is
  tracked separately as **TKT-COZN2E**.

## Tests

- `TestWriter_TitleResolver` (resolver used vs. nil fallback).
- `TestGenerateDOT_EntityWithoutTitle` strengthened to cover the graph guard.
- `TestGenerateDOT` fixture updated to declare `title` as required (matches real
  metamodels; the old fixture relied on the pre-change blind `e.Title()`).

`go build`, `go test ./...`, `golangci-lint`, `go vet`, `arch-lint`, `plimsoll`,
`coverage-check` (77.1%) all green.

Depends on TKT-NJTBQX (`DisplayTitle` template support), merged in #1070.