### PR TITLE
docs: repoint dangling docs/security.md refs to server-security.md

### DIFF
--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -61,7 +61,7 @@ The `rela acl audit` linter (below) flags an un-gated membership
 relation — default or configured — as a high-severity finding, so run
 it after editing `acl.yaml`.
 
-The companion section in `docs/security.md` carries the same
+The companion section in `docs/server-security.md` carries the same
 guidance with more context on the broader threat model.
 
 ## Auditing your policy with `rela acl audit`
@@ -476,5 +476,5 @@ reach is tight.
 
 - [GUIDE-acl-overview] — operator's overview of the resolver.
 - [CON-authorization] — vocabulary and core concept.
-- `docs/security.md` — the broader `rela-server` threat model
+- `docs/server-security.md` — the broader `rela-server` threat model
   (CSRF, DNS rebinding, loopback binding, command allowlist).

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -55,7 +55,7 @@ The `rela acl audit` linter (below) flags an un-gated membership
 relation — default or configured — as a high-severity finding, so run
 it after editing `acl.yaml`.
 
-The companion section in `docs/security.md` carries the same
+The companion section in `docs/server-security.md` carries the same
 guidance with more context on the broader threat model.
 
 ## Auditing your policy with `rela acl audit`
@@ -470,5 +470,5 @@ reach is tight.
 
 - [GUIDE-acl-overview] — operator's overview of the resolver.
 - [CON-authorization] — vocabulary and core concept.
-- `docs/security.md` — the broader `rela-server` threat model
+- `docs/server-security.md` — the broader `rela-server` threat model
   (CSRF, DNS rebinding, loopback binding, command allowlist).

--- a/internal/aclaudit/tier_a.go
+++ b/internal/aclaudit/tier_a.go
@@ -57,7 +57,7 @@ func checkUngatedMembership(p *acl.Policy) []Finding {
 				"but is not gated by requires_permission; any principal who can write a %q edge can "+
 				"grant themselves that role", rel, rel),
 			Fix: fmt.Sprintf("add role_relations.%s.requires_permission and grant that permission "+
-				"only to admins (see docs/security.md)", rel),
+				"only to admins (see docs/server-security.md)", rel),
 		})
 	}
 	return f

--- a/tickets/entities/tickets/TKT-GGQ0JT.md
+++ b/tickets/entities/tickets/TKT-GGQ0JT.md
@@ -11,48 +11,125 @@ status: backlog
 ## Problem
 
 `/_search` already redacts the *body* of a `visible:`-hidden property, but the
-search index (`internal/search/filter.go` indexes every property value) still
-**matches** on the hidden field's text. A query whose only match is a hidden
-field still returns the entity as a hit — so the hit's *presence* confirms the
-hidden value even though its value is stripped from the response body. Example:
-searching a candidate postcode against a hidden `address` field turns search
-into a guess oracle. Entity-level gating (`executeQuery`) does not catch this —
-the entity itself is readable; only one of its properties is hidden.
+search backends **flatten all string properties into one searchable blob**:
 
-Established during RES-H5AB7S. Related deferred note: RR-WX77.
+- bleve: `entityToDoc` joins every string property into a single `properties`
+field + an `all` catch-all (`internal/search/bleveindex/bleveindex.go:302-326`).
+- pgstore: `search_text = "id\ncontent\n<string props>"` in one column,
+substring-matched (`internal/store/pgstore/entity.go:624`).
+- linear: `MatchText` loops `e.Properties` returning a bool
+(`internal/search/filter.go:86`).
 
-## Direction (from RES-H5AB7S, Option B1)
+So a query whose only match is a hidden field's text still returns the entity as
+a hit — its *presence* confirms the hidden value even though the value is
+stripped from the response body (postcode → hidden-address guess oracle).
+Entity-level gating (`executeQuery`) can't catch this: the entity is readable;
+only one of its properties is hidden.
 
-Close it at the `search.VisibleSearcher` seam: after entity-level scoping,
-determine the fields the principal may see for each surviving hit and drop the
-hit if its match set ⊆ hidden fields.
+**The root obstacle:** the concat destroys field provenance *before* the query
+runs, so at match time no backend can say *which field* produced the hit.
 
-- Generic impl (bleve + linear): re-check candidate field text in-process,
-bounded by the existing candidate window.
-- pgstore-native: build the visible-field projection into the trgm/tsvector
-predicate so the match is computed over visible columns only (column- projection
-pushdown) for the **static** (predicate-free) `visible:` case; fall back to
-bounded per-candidate evaluation where a `when:` predicate makes visibility
-entity-dependent. `log()` the fallback (mirror the bleve-10k-floor disclosure in
-TKT-BA8BSX).
+Established during RES-H5AB7S; related deferred note RR-WX77.
 
-## Conformance
+## Design: backend-reported match provenance + ACL intersection at the seam
+
+Rather than have the ACL seam re-implement text matching (which would forever
+chase each backend's analyzer and risk false drops), make **match provenance a
+`search.Backend` responsibility**. Extend the backend contract so a search can
+report, per hit, **which fields matched**. Each backend answers using its *own*
+matching machinery, so provenance stays faithful to the actual search operation.
+
+The seam then becomes a dumb, backend-agnostic set intersection:
+
+```
+hit, matchedFields := backend.<provenance op>(q)
+visibleFields      := redactor.VisibleFields(principal, hit)   // ACL verdict
+keep  <=>  (matchedFields intersect visibleFields) is non-empty
+```
+
+A hit that matched *only* on fields the principal cannot see is dropped.
+
+### Per-backend method
+
+Candidate generation stays coarse/fast; provenance is computed lazily, only on
+candidates, with the backend's own matcher.
+
+- **bleve** — keep the index as-is (do NOT split into per-property fields — that
+bloats a sparse, metamodel-open index and rebuilds ranking). Use the existing
+index for candidate generation (the fast full-text filter), then for each
+candidate **reuse bleve's own analyzer** (`index.Mapping().AnalyzeText` / the
+`standard` analyzer already imported) to compute per-field matches on the
+individual property values in-process. Same analysis the index used, no index
+change.
+- **pgstore** — a **two-stage query**: the tsvector/trgm full-text predicate
+narrows candidates cheaply (uses the index), then a second, deliberately
+inefficient per-field expression runs *only over that small candidate set* to
+report which fields matched. Postgres does the cheap indexed filter first, the
+precise per-field work last, over few rows.
+- **linear (memstore)** — trivial: `MatchText` already loops fields; return the
+set of matching field names instead of a bool. This is the ground-truth
+semantics the conformance suite pins against.
+
+### Interface sketch
+
+Extend `search.Backend` (currently just `Search(text, limit) []string`) with a
+provenance-returning form, e.g.:
+
+```
+// MatchedFields reports, per returned id, which logical fields the query
+// matched (e.g. "id", "content", "prop:<name>"). Backends compute this with
+// their own matcher so provenance == real match semantics.
+type ProvenanceBackend interface {
+    Backend
+    SearchWithFields(text string, limit int) ([]FieldHit, error) // {ID, Fields}
+}
+```
+
+`search.VisibleSearcher` consumes it: resolve `VisibleFields` per (principal,
+hit) from the affordance resolver, intersect, drop empties. A backend that
+doesn't implement the provenance form degrades to entity-level only (documented,
+fail-closed if a `visible:` block exists for the type).
+
+### Conformance
 
 Extend `storetest.RunVisibleSearchTests` with field-visibility cases: a hit
-matching only a hidden field is dropped; same no-leak + ordered-subsequence
-invariants, now over the visible-field projection. Run ×3 backends
-(generic+memstore, generic+bleve, pgstore-native DB-gated).
+matching only a hidden field is dropped; a hit matching a visible field (or
+id/content) survives even if it *also* matched a hidden one; same no-leak +
+ordered-subsequence invariants over the visible-field projection. Run x3
+(generic+memstore/linear = ground truth, generic+bleve, pgstore-native
+DB-gated). `MatchText`-over-visible-projection is the semantic oracle the
+backends are checked against.
 
-## Performance contract
+### Performance contract
 
-Redaction fieldset cached per (principal, type) per request (same memoisation
-shape as `acl.Request` GlobalRoles), except where a `when:` predicate forces
-per-entity evaluation. Pushdown applies only to the static-verdict case.
+`VisibleFields` verdict cached per (principal, type) per request (same
+memoisation shape as `acl.Request` GlobalRoles), except where a `when:`
+predicate makes visibility entity-dependent -> per-entity eval (already the
+affordance resolver's contract). Provenance is computed only over the bounded
+candidate set (bleve 10k floor / pg candidate rows), not the corpus. pgstore's
+second stage is inefficient by design but bounded — `log()` if the candidate set
+is large, mirroring the bleve-10k-floor disclosure in TKT-BA8BSX.
+
+## Open questions for implementation
+
+- Exact `FieldHit.Fields` vocabulary: `"prop:<name>"` vs bare property name; how
+`id`/`content`/`primary` are represented (they're never `visible:`-gated, so
+always in the "visible" set).
+- bleve: confirm `AnalyzeText` reproduces the per-word/prefix/ID query behavior
+closely enough that the per-field pass never rejects a candidate the index
+legitimately surfaced from a visible field (bias: a per-field pass that can't
+confirm keeps the hit — no false drops).
+- Whether the provenance op replaces `Backend.Search` or sits beside it (prefer
+beside + capability check, so non-provenance backends still compile).
 
 ## Reference files
 
-- `internal/search/types.go`, `internal/search/visible.go` — VisibleSearcher seam
-- `internal/store/pgstore/visiblesearch.go` — pgstore-native SearchVisible
+- `internal/search/types.go` — `Backend`, `VisibleSearcher`, `TypeScope`
+- `internal/search/bleveindex/bleveindex.go` — `entityToDoc`, `Search`, mapping
+- `internal/search/linearsearch.go`, `internal/search/filter.go` — `MatchText`
+- `internal/search/visible.go` — generic VisibleSearcher (entity-level today)
+- `internal/store/pgstore/search.go`, `entity.go:624` — `search_text` + backend
 - `internal/store/storetest/visiblesearch.go` — conformance suite
-- `internal/dataentry/helpers.go` (`executeQuery`), `api_v1.go` (`handleV1Search`)
+- `internal/dataentry/helpers.go` (`executeQuery`), `api_v1.go`
+(`handleV1Search`)
 - `internal/affordances/resolver.go` — the visible-field verdict source

--- a/tickets/entities/tickets/TKT-GGQ0JT.md
+++ b/tickets/entities/tickets/TKT-GGQ0JT.md
@@ -1,0 +1,58 @@
+---
+id: TKT-GGQ0JT
+type: ticket
+title: 'ACL read-side: close the /_search match-on-hidden-field oracle (drop hits matching only visible:-hidden fields)'
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+## Problem
+
+`/_search` already redacts the *body* of a `visible:`-hidden property, but the
+search index (`internal/search/filter.go` indexes every property value) still
+**matches** on the hidden field's text. A query whose only match is a hidden
+field still returns the entity as a hit — so the hit's *presence* confirms the
+hidden value even though its value is stripped from the response body. Example:
+searching a candidate postcode against a hidden `address` field turns search
+into a guess oracle. Entity-level gating (`executeQuery`) does not catch this —
+the entity itself is readable; only one of its properties is hidden.
+
+Established during RES-H5AB7S. Related deferred note: RR-WX77.
+
+## Direction (from RES-H5AB7S, Option B1)
+
+Close it at the `search.VisibleSearcher` seam: after entity-level scoping,
+determine the fields the principal may see for each surviving hit and drop the
+hit if its match set ⊆ hidden fields.
+
+- Generic impl (bleve + linear): re-check candidate field text in-process,
+bounded by the existing candidate window.
+- pgstore-native: build the visible-field projection into the trgm/tsvector
+predicate so the match is computed over visible columns only (column- projection
+pushdown) for the **static** (predicate-free) `visible:` case; fall back to
+bounded per-candidate evaluation where a `when:` predicate makes visibility
+entity-dependent. `log()` the fallback (mirror the bleve-10k-floor disclosure in
+TKT-BA8BSX).
+
+## Conformance
+
+Extend `storetest.RunVisibleSearchTests` with field-visibility cases: a hit
+matching only a hidden field is dropped; same no-leak + ordered-subsequence
+invariants, now over the visible-field projection. Run ×3 backends
+(generic+memstore, generic+bleve, pgstore-native DB-gated).
+
+## Performance contract
+
+Redaction fieldset cached per (principal, type) per request (same memoisation
+shape as `acl.Request` GlobalRoles), except where a `when:` predicate forces
+per-entity evaluation. Pushdown applies only to the static-verdict case.
+
+## Reference files
+
+- `internal/search/types.go`, `internal/search/visible.go` — VisibleSearcher seam
+- `internal/store/pgstore/visiblesearch.go` — pgstore-native SearchVisible
+- `internal/store/storetest/visiblesearch.go` — conformance suite
+- `internal/dataentry/helpers.go` (`executeQuery`), `api_v1.go` (`handleV1Search`)
+- `internal/affordances/resolver.go` — the visible-field verdict source

--- a/tickets/entities/tickets/TKT-GM3IQ7.md
+++ b/tickets/entities/tickets/TKT-GM3IQ7.md
@@ -1,0 +1,22 @@
+---
+id: TKT-GM3IQ7
+type: ticket
+title: Fix dangling docs/security.md references reintroduced after the server-security consolidation
+kind: docs
+priority: low
+effort: xs
+status: done
+---
+
+TKT-Q0TCW1 renamed `docs/security.md` → generated `docs/server-security.md`. A
+later PR (the `rela acl audit` linter work) was written against the
+pre-consolidation tree and reintroduced three references to the now-deleted
+path:
+
+- `docs-project/entities/guides/GUIDE-acl-security.md:64` and `:479`
+(regenerates into `docs/acl-security.md`)
+- `internal/aclaudit/tier_a.go:60` — an operator-facing audit *finding
+message* (the `Fix:` text) pointing at a nonexistent doc
+
+All three repointed to `docs/server-security.md`; docs regenerated. Follows up
+TKT-Q0TCW1.

--- a/tickets/relations/RES-H5AB7S--informs--TKT-GGQ0JT.md
+++ b/tickets/relations/RES-H5AB7S--informs--TKT-GGQ0JT.md
@@ -1,0 +1,5 @@
+---
+from: RES-H5AB7S
+relation: informs
+to: TKT-GGQ0JT
+---

--- a/tickets/relations/TKT-GGQ0JT--affects--authorization.md
+++ b/tickets/relations/TKT-GGQ0JT--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GGQ0JT
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-GGQ0JT--affects--data-entry-server.md
+++ b/tickets/relations/TKT-GGQ0JT--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GGQ0JT
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-GGQ0JT--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-GGQ0JT--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GGQ0JT
+relation: implements
+to: FEAT-AESD4
+---

--- a/tickets/relations/TKT-GM3IQ7--affects--authorization.md
+++ b/tickets/relations/TKT-GM3IQ7--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GM3IQ7
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-GM3IQ7--depends-on--TKT-Q0TCW1.md
+++ b/tickets/relations/TKT-GM3IQ7--depends-on--TKT-Q0TCW1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GM3IQ7
+relation: depends-on
+to: TKT-Q0TCW1
+---

--- a/tickets/relations/TKT-GM3IQ7--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-GM3IQ7--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GM3IQ7
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
## What

Follow-up cleanup to #1059 (which renamed `docs/security.md` → generated
`docs/server-security.md`). A PR that merged afterward — the `rela acl audit`
linter work — was written against the pre-consolidation tree and reintroduced
three references to the now-deleted path:

- `docs-project/entities/guides/GUIDE-acl-security.md:64` and `:479`
  (regenerates into `docs/acl-security.md`)
- `internal/aclaudit/tier_a.go:60` — an operator-facing audit **finding
  message** (`Fix:` text) pointing at a nonexistent doc

All three repointed to `docs/server-security.md`; docs regenerated.

## Verification

- `go build ./internal/aclaudit/` clean; no test pins the finding string
- `just lint-md` — 0 errors
- `just docs-check` — ✓ up to date

Ticket: TKT-GM3IQ7. Also files TKT-GGQ0JT (backlog) for the `/_search`
match-on-hidden-field oracle identified in RES-H5AB7S.