### PR TITLE
feat(acl): resolve principal to entity via principal_property + unique constraint (FEAT-OF2ZOL)

### DIFF
--- a/docs-project/entities/guides/GUIDE-acl-overview.md
+++ b/docs-project/entities/guides/GUIDE-acl-overview.md
@@ -155,6 +155,61 @@ exist — or one your data doesn't populate — the walk finds no edges and grou
 roles silently never resolve. There's no separate "is this a real relation"
 check; the relation simply has to be there.
 
+## Resolving the principal to a user entity
+
+By default `principal.User` is whatever the entry point stamped — for the
+data-entry server that is the reverse-proxy header value verbatim (e.g.
+`X-Forwarded-User: jvloothuis@sourcehaven.nl`). Assignments and membership
+walks then match on that raw string, which forces operators to either
+duplicate every human's identity in `acl.yaml` or rewrite headers in the
+proxy.
+
+When your graph already models people as entities (an ISMS `persoon`, a
+`user` type), set two coupled keys so the resolver consults the graph
+instead:
+
+```yaml
+user_entity_type: persoon
+principal_property: email      # persoon.email holds the header value
+membership_relation: heeft_rol
+assignments:
+  ROLE-MD: md
+```
+
+At the start of each request the resolver looks the raw principal up
+against `persoon.email`. On **exactly one** match it substitutes that
+entity's ID for `principal.User` for the rest of the request, so
+membership and local-role walks operate from a real entity:
+
+```text
+Header (jvloothuis@sourcehaven.nl)
+   └─ property lookup on persoon.email ─▶ PERS-JV
+         └─ walkMembers via heeft_rol ─▶ ROLE-MD ─▶ role md
+```
+
+Rules and fallbacks:
+
+- **Both keys required.** With `principal_property` unset, behaviour is
+  byte-for-byte identical to before — the raw string is used as-is.
+- **`principal_property` must be `unique: true`** on `user_entity_type`
+  in the metamodel (enforced at boot). A non-unique key admits duplicates,
+  which makes resolution ambiguous. See GUIDE-acl-security for how the
+  uniqueness constraint is enforced on writes.
+- **No match** keeps the raw principal — so an assignment keyed on the raw
+  UPN (`assignments: { jvloothuis@sourcehaven.nl: md }`) still works as a
+  break-glass escape hatch for identities not yet in the graph.
+- **Multiple matches** (a data-integrity failure) keeps the raw principal
+  and logs a warning; the resolver refuses to guess which entity is meant.
+- **Lookup errors** keep the raw principal (fail-open to pre-feature
+  behaviour) so a transient store hiccup never locks everyone out.
+
+The audit log records both identities: `user` is the resolved entity ID
+and `raw_user` is the original header value, so an operator can trace what
+authenticated and what it resolved to without a graph round-trip.
+
+For large user-entity sets, push the property equality into a backend
+index — see GUIDE-acl-security.
+
 Given the graph:
 
 ```text

--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -120,6 +120,80 @@ deliberate, reviewed reason to tolerate the lower-severity findings.
 Use `-o json` for machine-readable output. A clean, well-gated policy
 reports no findings and exits zero.
 
+## Resolving the principal by property (`principal_property`)
+
+When `user_entity_type` + `principal_property` are set, the resolver
+maps the raw authenticated identifier to a user entity by looking it up
+against that property (see GUIDE-acl-overview). Because the property is
+used as an **identity key**, a duplicate value is a security ambiguity,
+not just a data-quality issue — two `persoon` records with the same
+`email` would make "who is this principal?" unanswerable.
+
+Two layers keep that from happening:
+
+1. **The property must be declared `unique: true`** on the
+   `user_entity_type` in the metamodel. Boot fails if
+   `principal_property` names a property that does not exist or is not
+   unique. `unique: true` is a general metamodel constraint: no two
+   entities of the same type may carry the same non-empty value for that
+   property. It is enforced at write time — a create or update that would
+   introduce a duplicate is rejected as a validation error (422). Empty
+   values are exempt (a property is unique among the entities that set
+   it).
+
+2. **The resolver refuses to guess through a duplicate.** If, despite the
+   constraint, more than one entity matches (e.g. data predating the
+   constraint), the resolver keeps the raw principal, logs a warning, and
+   grants only what the raw string is assigned — it never silently picks
+   one of the duplicates.
+
+**Enforcement rigor by backend.** The write-time uniqueness check is
+exact on the single-writer backends (fsstore, memstore). On PostgreSQL,
+concurrent writers leave a narrow time-of-check/time-of-use window
+between the check and the durable write. Operators who need race-free
+enforcement add a partial unique index — which is also the recommended
+performance index for the lookup itself:
+
+```sql
+CREATE UNIQUE INDEX persoon_email_unique_idx
+  ON entities ((properties->>'email'))
+  WHERE type = 'persoon';
+```
+
+With the index in place a colliding write fails atomically in the
+database and surfaces as the same conflict the write path already
+reports.
+
+**The write-time check is not atomic.** It reads the existing entities
+of the type, then writes — two separate operations with no lock held
+across them. Under concurrent writers (the data-entry server runs one
+goroutine per request) two racing writes with the same value can both
+pass the check and both commit, on *any* backend, not just PostgreSQL.
+The window is small, and the resolver's multi-match fallback (keep-raw,
+above) is the runtime backstop for the identity-key case — but the only
+*race-free* enforcement is the store-level unique index. If you rely on
+uniqueness for correctness rather than as a data-quality guard, add the
+index.
+
+**Two operator notes for `principal_property`:**
+
+- **Case sensitivity.** The lookup and the uniqueness check are exact
+  byte comparisons. If your auth proxy emits `JV@x.com` but the persoon
+  stores `jv@x.com`, the lookup finds no match and the request silently
+  falls back to the raw principal (losing grants, never gaining them).
+  Normalise the property value on write (or configure the proxy to emit
+  a canonical form) — rela does not case-fold.
+
+- **Resolution is data-entry-only.** The `principal_property` lookup is
+  wired into the `/api/` data-entry path only. Writes via the CLI, MCP,
+  scheduler, or desktop entry points authorize against the raw stamped
+  principal and are NOT resolved to a `persoon`. A grant keyed on the
+  resolved entity ID therefore applies to data-entry writes but not to
+  the same person's CLI/MCP writes (which fall back to whatever the raw
+  identifier is assigned — typically `everyone` only). This is
+  fail-closed. Don't assume one `acl.yaml` grants the same authority on
+  every transport.
+
 ## Fail-loud on malformed `acl.yaml`
 
 A malformed `acl.yaml` fails boot. This is intentional: silently

--- a/docs/acl-overview.md
+++ b/docs/acl-overview.md
@@ -149,6 +149,61 @@ exist — or one your data doesn't populate — the walk finds no edges and grou
 roles silently never resolve. There's no separate "is this a real relation"
 check; the relation simply has to be there.
 
+## Resolving the principal to a user entity
+
+By default `principal.User` is whatever the entry point stamped — for the
+data-entry server that is the reverse-proxy header value verbatim (e.g.
+`X-Forwarded-User: jvloothuis@sourcehaven.nl`). Assignments and membership
+walks then match on that raw string, which forces operators to either
+duplicate every human's identity in `acl.yaml` or rewrite headers in the
+proxy.
+
+When your graph already models people as entities (an ISMS `persoon`, a
+`user` type), set two coupled keys so the resolver consults the graph
+instead:
+
+```yaml
+user_entity_type: persoon
+principal_property: email      # persoon.email holds the header value
+membership_relation: heeft_rol
+assignments:
+  ROLE-MD: md
+```
+
+At the start of each request the resolver looks the raw principal up
+against `persoon.email`. On **exactly one** match it substitutes that
+entity's ID for `principal.User` for the rest of the request, so
+membership and local-role walks operate from a real entity:
+
+```text
+Header (jvloothuis@sourcehaven.nl)
+   └─ property lookup on persoon.email ─▶ PERS-JV
+         └─ walkMembers via heeft_rol ─▶ ROLE-MD ─▶ role md
+```
+
+Rules and fallbacks:
+
+- **Both keys required.** With `principal_property` unset, behaviour is
+  byte-for-byte identical to before — the raw string is used as-is.
+- **`principal_property` must be `unique: true`** on `user_entity_type`
+  in the metamodel (enforced at boot). A non-unique key admits duplicates,
+  which makes resolution ambiguous. See GUIDE-acl-security for how the
+  uniqueness constraint is enforced on writes.
+- **No match** keeps the raw principal — so an assignment keyed on the raw
+  UPN (`assignments: { jvloothuis@sourcehaven.nl: md }`) still works as a
+  break-glass escape hatch for identities not yet in the graph.
+- **Multiple matches** (a data-integrity failure) keeps the raw principal
+  and logs a warning; the resolver refuses to guess which entity is meant.
+- **Lookup errors** keep the raw principal (fail-open to pre-feature
+  behaviour) so a transient store hiccup never locks everyone out.
+
+The audit log records both identities: `user` is the resolved entity ID
+and `raw_user` is the original header value, so an operator can trace what
+authenticated and what it resolved to without a graph round-trip.
+
+For large user-entity sets, push the property equality into a backend
+index — see GUIDE-acl-security.
+
 Given the graph:
 
 ```text

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -114,6 +114,80 @@ deliberate, reviewed reason to tolerate the lower-severity findings.
 Use `-o json` for machine-readable output. A clean, well-gated policy
 reports no findings and exits zero.
 
+## Resolving the principal by property (`principal_property`)
+
+When `user_entity_type` + `principal_property` are set, the resolver
+maps the raw authenticated identifier to a user entity by looking it up
+against that property (see GUIDE-acl-overview). Because the property is
+used as an **identity key**, a duplicate value is a security ambiguity,
+not just a data-quality issue — two `persoon` records with the same
+`email` would make "who is this principal?" unanswerable.
+
+Two layers keep that from happening:
+
+1. **The property must be declared `unique: true`** on the
+   `user_entity_type` in the metamodel. Boot fails if
+   `principal_property` names a property that does not exist or is not
+   unique. `unique: true` is a general metamodel constraint: no two
+   entities of the same type may carry the same non-empty value for that
+   property. It is enforced at write time — a create or update that would
+   introduce a duplicate is rejected as a validation error (422). Empty
+   values are exempt (a property is unique among the entities that set
+   it).
+
+2. **The resolver refuses to guess through a duplicate.** If, despite the
+   constraint, more than one entity matches (e.g. data predating the
+   constraint), the resolver keeps the raw principal, logs a warning, and
+   grants only what the raw string is assigned — it never silently picks
+   one of the duplicates.
+
+**Enforcement rigor by backend.** The write-time uniqueness check is
+exact on the single-writer backends (fsstore, memstore). On PostgreSQL,
+concurrent writers leave a narrow time-of-check/time-of-use window
+between the check and the durable write. Operators who need race-free
+enforcement add a partial unique index — which is also the recommended
+performance index for the lookup itself:
+
+```sql
+CREATE UNIQUE INDEX persoon_email_unique_idx
+  ON entities ((properties->>'email'))
+  WHERE type = 'persoon';
+```
+
+With the index in place a colliding write fails atomically in the
+database and surfaces as the same conflict the write path already
+reports.
+
+**The write-time check is not atomic.** It reads the existing entities
+of the type, then writes — two separate operations with no lock held
+across them. Under concurrent writers (the data-entry server runs one
+goroutine per request) two racing writes with the same value can both
+pass the check and both commit, on *any* backend, not just PostgreSQL.
+The window is small, and the resolver's multi-match fallback (keep-raw,
+above) is the runtime backstop for the identity-key case — but the only
+*race-free* enforcement is the store-level unique index. If you rely on
+uniqueness for correctness rather than as a data-quality guard, add the
+index.
+
+**Two operator notes for `principal_property`:**
+
+- **Case sensitivity.** The lookup and the uniqueness check are exact
+  byte comparisons. If your auth proxy emits `JV@x.com` but the persoon
+  stores `jv@x.com`, the lookup finds no match and the request silently
+  falls back to the raw principal (losing grants, never gaining them).
+  Normalise the property value on write (or configure the proxy to emit
+  a canonical form) — rela does not case-fold.
+
+- **Resolution is data-entry-only.** The `principal_property` lookup is
+  wired into the `/api/` data-entry path only. Writes via the CLI, MCP,
+  scheduler, or desktop entry points authorize against the raw stamped
+  principal and are NOT resolved to a `persoon`. A grant keyed on the
+  resolved entity ID therefore applies to data-entry writes but not to
+  the same person's CLI/MCP writes (which fall back to whatever the raw
+  identifier is assigned — typically `everyone` only). This is
+  fail-closed. Don't assume one `acl.yaml` grants the same authority on
+  every transport.
+
 ## Fail-loud on malformed `acl.yaml`
 
 A malformed `acl.yaml` fails boot. This is intentional: silently

--- a/internal/acl/declarative.go
+++ b/internal/acl/declarative.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -32,13 +33,28 @@ import (
 //     [ForPrincipal] check; the deny surfaces as RuleKind="role-grant"
 //     with a Reason that names ErrUnstampedPrincipal.
 type Declarative struct {
-	policy       *Policy
-	graph        Graph              // required: NewDeclarative rejects nil
-	graphQueryer store.GraphQueryer // required: needed by Request.PermitsRead / PermitsReadMany
+	policy          *Policy
+	graph           Graph              // required: NewDeclarative rejects nil
+	graphQueryer    store.GraphQueryer // required: needed by Request.PermitsRead / PermitsReadMany
+	principalLookup PrincipalLookup    // optional: required only when principal_property lookup is enabled
+}
+
+// DeclarativeOption configures optional [Declarative] collaborators.
+type DeclarativeOption func(*Declarative)
+
+// WithPrincipalLookup supplies the [PrincipalLookup] used to resolve the
+// raw principal to a user entity ID when the policy sets both
+// `user_entity_type` and `principal_property`. Wiring (appbuild) passes
+// [NewStorePrincipalLookup] over the store. When the policy enables the
+// lookup but no PrincipalLookup was supplied, [NewDeclarative] fails — a
+// silent no-op would degrade every authenticated user to the raw
+// principal without any signal (constructors-reject-nil rule).
+func WithPrincipalLookup(l PrincipalLookup) DeclarativeOption {
+	return func(d *Declarative) { d.principalLookup = l }
 }
 
 // NewDeclarative wraps a [Policy] + [Graph] + [store.GraphQueryer] as
-// an [ACL]. All three must be non-nil:
+// an [ACL]. The first three must be non-nil:
 //
 //   - Policy is the static role / assignment definitions.
 //   - Graph supplies the read-side access the resolver needs for
@@ -47,12 +63,16 @@ type Declarative struct {
 //     [Request.PermitsRead] / [Request.PermitsReadMany] for per-entity
 //     read gating.
 //
+// Optional collaborators are supplied via [DeclarativeOption]. When the
+// policy enables `principal_property` lookup, a [PrincipalLookup] MUST be
+// supplied via [WithPrincipalLookup] or construction fails.
+//
 // Tests that don't exercise group expansion can pass [NullGraph];
 // tests that don't exercise read gating can pass [NullGraphQueryer]
 // (returns false for every id probe). Production wiring (appbuild)
 // passes the store as both Graph (via [NewStoreGraph]) and as the
-// GraphQueryer.
-func NewDeclarative(p *Policy, g Graph, gq store.GraphQueryer) (*Declarative, error) {
+// GraphQueryer, and supplies [WithPrincipalLookup].
+func NewDeclarative(p *Policy, g Graph, gq store.GraphQueryer, opts ...DeclarativeOption) (*Declarative, error) {
 	if p == nil {
 		return nil, errors.New("acl: NewDeclarative: policy must be non-nil")
 	}
@@ -62,7 +82,71 @@ func NewDeclarative(p *Policy, g Graph, gq store.GraphQueryer) (*Declarative, er
 	if gq == nil {
 		return nil, errors.New("acl: NewDeclarative: graphQueryer must be non-nil")
 	}
-	return &Declarative{policy: p, graph: g, graphQueryer: gq}, nil
+	d := &Declarative{policy: p, graph: g, graphQueryer: gq}
+	for _, opt := range opts {
+		opt(d)
+	}
+	if p.principalPropertyLookupEnabled() && d.principalLookup == nil {
+		return nil, errors.New("acl: NewDeclarative: policy enables principal_property lookup " +
+			"but no PrincipalLookup was supplied (use WithPrincipalLookup)")
+	}
+	return d, nil
+}
+
+// ResolvePrincipal maps a raw principal identifier (e.g. the value of the
+// `X-Forwarded-User` header) to a user entity ID via the policy's
+// `principal_property` lookup. It returns:
+//
+//   - ("", nil)  when the lookup is disabled, rawUser is blank, or no
+//     entity matches — the caller keeps the raw principal.
+//   - (id, nil)  on exactly one match — the caller substitutes id.
+//   - ("", err)  when the lookup errored OR more than one entity matched
+//     (ambiguous natural key). The caller keeps the raw principal and
+//     logs; ambiguity is a data-integrity failure the resolver refuses
+//     to guess through.
+//
+// Substitution is performed by the wiring layer (the data-entry
+// attachACLRequest middleware) so the resolved ID reaches both the ACL
+// walk and the audit log; the resolver itself never mutates ctx.
+//
+// **Scope limitation — data-entry only (deliberate).** This method is
+// wired into exactly one caller: the `/api/` data-entry middleware. The
+// CLI, MCP, scheduler, and desktop entry points stamp their principal via
+// [principal.With] but do NOT call ResolvePrincipal, so a write over those
+// transports authorizes against the RAW principal, never the resolved
+// entity ID. Consequence: an `assignments`/`member-of`/`role_relations`
+// grant keyed on the resolved entity ID (e.g. `PERS-JV`) applies to
+// data-entry writes but not to the same human's CLI/MCP writes — those
+// fall back to whatever the raw identifier is assigned (typically
+// `everyone` only). This is fail-CLOSED (an unresolved principal loses
+// grants, never gains them — see the multi-match/no-match handling below),
+// and it matches the intended deployment: only the reverse-proxy
+// (`X-Forwarded-User`) path carries an identity worth resolving. If a
+// future entry point needs the same resolution, wire this in there too —
+// don't assume one `acl.yaml` means the same thing on every transport.
+func (d *Declarative) ResolvePrincipal(ctx context.Context, rawUser string) (string, error) {
+	if !d.policy.principalPropertyLookupEnabled() || strings.TrimSpace(rawUser) == "" {
+		return "", nil
+	}
+	if d.principalLookup == nil {
+		// Defense in depth: NewDeclarative rejects this combination, but a
+		// future direct construction path must not silently over-resolve.
+		return "", errors.New("acl: ResolvePrincipal: lookup enabled but no PrincipalLookup configured")
+	}
+	ids, err := d.principalLookup.LookupEntityByProperty(
+		ctx, d.policy.UserEntityType, d.policy.PrincipalProperty, rawUser)
+	if err != nil {
+		return "", err
+	}
+	switch len(ids) {
+	case 0:
+		return "", nil
+	case 1:
+		return ids[0], nil
+	default:
+		return "", fmt.Errorf("acl: principal %q matches %d %s entities on %q (ambiguous natural key)",
+			rawUser, len(ids), d.policy.UserEntityType, d.policy.PrincipalProperty)
+	}
 }
 
 // Policy returns the policy this Declarative was constructed with.

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -36,9 +36,19 @@ const EveryoneRole = "everyone"
 // at the project root.
 //
 //   - [Policy.UserEntityType] names the entity type that represents
-//     a user (e.g. "person", "user"). Reserved for a future
-//     check that validates membership edges originate from a user
-//     entity; not consulted by the resolver today (RR-NIGK).
+//     a user (e.g. "person", "user"). Consulted together with
+//     [Policy.PrincipalProperty] to resolve the raw principal to a user
+//     entity (see below); also the type a membership edge is expected to
+//     originate from.
+//   - [Policy.PrincipalProperty] names a property on [Policy.UserEntityType]
+//     whose value equals the authenticated principal's raw identifier
+//     (e.g. `email` holding the value of `X-Forwarded-User`). When both
+//     this and UserEntityType are set, the resolver looks the raw
+//     principal up against that property once per request and, on exactly
+//     one match, substitutes the matched entity's ID for `principal.User`
+//     so membership/local-role walks operate from a real entity. The
+//     referenced property MUST be declared `unique: true` in the metamodel
+//     (enforced at load, see [Policy.ValidateAgainstMetamodel]).
 //   - [Policy.MembershipRelation] names the relation type the resolver
 //     walks from a principal to resolve group membership (TKT-Z8A62F).
 //     Blank/whitespace means the default ("member-of") — read the
@@ -66,11 +76,23 @@ const EveryoneRole = "everyone"
 // key, and security-critical invariants — see [Policy.Validate].
 type Policy struct {
 	UserEntityType      string                     `yaml:"user_entity_type"`
+	PrincipalProperty   string                     `yaml:"principal_property"`
 	MembershipRelation  string                     `yaml:"membership_relation"`
 	Roles               map[string]RoleDef         `yaml:"roles"`
 	Assignments         map[string]string          `yaml:"assignments"`
 	RoleRelations       map[string]RoleRelationDef `yaml:"role_relations"`
 	InheritRolesThrough []string                   `yaml:"inherit_roles_through"`
+}
+
+// principalPropertyLookupEnabled reports whether the policy asks the
+// resolver to map the raw principal (e.g. an email from
+// `X-Forwarded-User`) to a user entity ID before role attribution. Both
+// [Policy.UserEntityType] AND [Policy.PrincipalProperty] must be set;
+// either blank leaves behavior byte-for-byte identical to a policy that
+// never declared them (assignments/membership match on the raw string).
+func (p *Policy) principalPropertyLookupEnabled() bool {
+	return strings.TrimSpace(p.UserEntityType) != "" &&
+		strings.TrimSpace(p.PrincipalProperty) != ""
 }
 
 // EffectiveMembershipRelation returns the relation type the resolver
@@ -271,6 +293,7 @@ type RoleRelationDef struct {
 // Keep in sync with [Policy]'s yaml tags.
 var knownPolicyKeys = map[string]bool{
 	"user_entity_type":      true,
+	"principal_property":    true,
 	"membership_relation":   true,
 	"roles":                 true,
 	"assignments":           true,
@@ -421,6 +444,88 @@ func (p *Policy) Validate() error {
 						name, verb.name, t, hint, verb.name)
 				}
 			}
+		}
+	}
+	return nil
+}
+
+// PropertyInfo describes a property to [Policy.ValidateAgainstMetamodel].
+// Exists is false when the type has no such property (in which case the
+// other fields are meaningless). A named struct instead of a tuple of
+// bools so the fields can't be transposed at the call site.
+type PropertyInfo struct {
+	Exists bool // the type declares this property
+	Unique bool // declared `unique: true`
+	List   bool // declared `list: true` (multi-valued)
+}
+
+// MetamodelView is the narrow, consumer-side contract
+// [Policy.ValidateAgainstMetamodel] needs from the metamodel. Declared
+// here (rather than importing internal/metamodel, which the acl package
+// deliberately does not depend on — see .go-arch-lint.yml) so the wiring
+// site supplies the schema without coupling the domain package to it.
+// *metamodel.Metamodel is adapted to this at the wiring site (appbuild).
+type MetamodelView interface {
+	// HasEntityType reports whether entityType is declared.
+	HasEntityType(entityType string) bool
+	// PropertyInfo describes property on entityType (existence, unique,
+	// list). A missing type or property yields PropertyInfo{Exists:false}.
+	PropertyInfo(entityType, property string) PropertyInfo
+}
+
+// ValidateAgainstMetamodel enforces the schema-dependent invariants that
+// [Policy.Validate] cannot check in isolation. It is run at the wiring
+// site (where the metamodel is available) after LoadPolicy. Errors are
+// hard — a policy that references a non-existent type/property, or a
+// principal_property that is not a unique natural key, is an operator
+// mistake that must fail loud at load rather than silently mis-resolve
+// identities at runtime.
+//
+// Checks (all gated on the relevant keys being set):
+//
+//   - principal_property set but user_entity_type empty → error.
+//   - user_entity_type not a declared entity type → error.
+//   - principal_property not a declared property on user_entity_type →
+//     error.
+//   - principal_property not declared `unique: true` → error. A
+//     non-unique identity key admits duplicates, which makes resolution
+//     ambiguous; requiring uniqueness is what makes the property a
+//     primary key (see internal/entitymanager checkUniqueProperties).
+//   - principal_property declared `list: true` → error. A multi-valued
+//     property can't be an identity key: the write-time unique check
+//     skips list properties and the lookup reads a scalar, so a list
+//     principal_property would silently resolve nobody. Fail loud at boot
+//     rather than ship a wired-but-inert lookup.
+//
+// user_entity_type set WITHOUT principal_property is NOT an error — it is
+// meaningful on its own (the type a membership edge originates from).
+func (p *Policy) ValidateAgainstMetamodel(meta MetamodelView) error {
+	if meta == nil {
+		return errors.New("acl: ValidateAgainstMetamodel: metamodel view must be non-nil")
+	}
+	prop := strings.TrimSpace(p.PrincipalProperty)
+	userType := strings.TrimSpace(p.UserEntityType)
+
+	if prop != "" && userType == "" {
+		return errors.New("acl: principal_property requires user_entity_type to be set")
+	}
+	if userType != "" && !meta.HasEntityType(userType) {
+		return fmt.Errorf("acl: user_entity_type %q is not a declared entity type", userType)
+	}
+	if prop != "" {
+		info := meta.PropertyInfo(userType, prop)
+		if !info.Exists {
+			return fmt.Errorf("acl: principal_property %q is not a declared property on %q",
+				prop, userType)
+		}
+		if info.List {
+			return fmt.Errorf("acl: principal_property %q on %q is declared `list: true`; "+
+				"a multi-valued property cannot be an identity key", prop, userType)
+		}
+		if !info.Unique {
+			return fmt.Errorf("acl: principal_property %q on %q must be declared `unique: true` "+
+				"(it is used as an identity key; a duplicate value makes resolution ambiguous)",
+				prop, userType)
 		}
 	}
 	return nil

--- a/internal/acl/principallookup.go
+++ b/internal/acl/principallookup.go
@@ -1,0 +1,68 @@
+package acl
+
+import (
+	"context"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// PrincipalLookup resolves the raw principal identifier to a user entity
+// by property equality. It is the narrow, consumer-side contract the
+// resolver needs for `principal_property` substitution — declared here
+// (not next to the store) per CLAUDE.md's "interfaces at the call site"
+// rule. The wiring site supplies a store-backed implementation
+// ([StorePrincipalLookup]).
+//
+// The method returns EVERY matching entity ID so the resolver can
+// distinguish the three outcomes it cares about: zero (no match — keep
+// the raw principal), one (substitute), and more than one (ambiguous —
+// a data-integrity failure the resolver refuses to guess through).
+type PrincipalLookup interface {
+	// LookupEntityByProperty returns the IDs of entities of entityType
+	// whose property equals value (exact string match). A blank value
+	// returns nil without querying — an empty principal never resolves.
+	// Backend errors propagate so the resolver can fail-open-to-raw and
+	// warn rather than silently drop a match.
+	LookupEntityByProperty(ctx context.Context, entityType, property, value string) ([]string, error)
+}
+
+// storePrincipalLookup adapts a store entity reader to [PrincipalLookup].
+// It scans the entities of the requested type and matches the property's
+// string value. Production wiring (appbuild) constructs it over the
+// store; the ACL resolver only ever sees the [PrincipalLookup] interface.
+//
+// The scan is O(entities of type) per lookup, run at most once per
+// request (upstream of the cached member-of walk). For large user-entity
+// sets operators can push the equality into a backend index (see
+// docs/security.md); this adapter is the portable default.
+type storePrincipalLookup struct {
+	s store.EntityReader
+}
+
+// NewStorePrincipalLookup constructs a store-backed [PrincipalLookup]
+// over s. Returned as the interface so callers depend on the contract,
+// not the adapter.
+func NewStorePrincipalLookup(s store.EntityReader) PrincipalLookup {
+	return &storePrincipalLookup{s: s}
+}
+
+// LookupEntityByProperty implements [PrincipalLookup] by scanning
+// entities of entityType and collecting those whose property equals
+// value.
+func (l *storePrincipalLookup) LookupEntityByProperty(
+	ctx context.Context, entityType, property, value string,
+) ([]string, error) {
+	if value == "" {
+		return nil, nil
+	}
+	var ids []string
+	for e, err := range l.s.ListEntities(ctx, store.EntityQuery{Type: entityType}) {
+		if err != nil {
+			return nil, err
+		}
+		if e.GetString(property) == value {
+			ids = append(ids, e.ID)
+		}
+	}
+	return ids, nil
+}

--- a/internal/acl/principallookup_test.go
+++ b/internal/acl/principallookup_test.go
@@ -1,0 +1,293 @@
+package acl
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// principalLookupPolicyYAML is the acceptance-test policy from the spec:
+// resolve the raw principal against persoon.email, walk heeft_rol for
+// group membership, and assign role `md` to the ROLE-MD group.
+const principalLookupPolicyYAML = `
+user_entity_type: persoon
+principal_property: email
+membership_relation: heeft_rol
+assignments:
+  ROLE-MD: md
+roles:
+  everyone:
+    read: ["*"]
+  md:
+    read: ["*"]
+    update: ["*"]
+`
+
+type personRow struct {
+	id    string
+	email string
+}
+
+// buildPrincipalLookupWorld constructs a memstore-backed Declarative with
+// the principal-property lookup enabled. persons carry an `email`
+// property; relations is a list of (from, type, to) triples.
+func buildPrincipalLookupWorld(
+	ctx context.Context, t *testing.T, policyYAML string, persons []personRow, relations [][3]string,
+) *Declarative {
+	t.Helper()
+	ms := memstore.New()
+	for _, p := range persons {
+		e := entity.New(p.id, "persoon")
+		if p.email != "" {
+			e.SetString("email", p.email)
+		}
+		if err := ms.CreateEntity(ctx, e); err != nil {
+			t.Fatalf("create persoon %s: %v", p.id, err)
+		}
+	}
+	// Ensure any role entities referenced by relations exist.
+	seen := map[string]bool{}
+	for _, p := range persons {
+		seen[p.id] = true
+	}
+	for _, r := range relations {
+		for _, id := range []string{r[0], r[2]} {
+			if seen[id] {
+				continue
+			}
+			seen[id] = true
+			typ := "rol"
+			if strings.HasPrefix(id, "PERS-") {
+				typ = "persoon"
+			}
+			if err := ms.CreateEntity(ctx, entity.New(id, typ)); err != nil {
+				t.Fatalf("create %s: %v", id, err)
+			}
+		}
+	}
+	for _, r := range relations {
+		if _, err := ms.CreateRelation(ctx, r[0], r[1], r[2], nil); err != nil {
+			t.Fatalf("create relation %s--%s-->%s: %v", r[0], r[1], r[2], err)
+		}
+	}
+
+	policy, err := LoadPolicyBytes([]byte(policyYAML))
+	if err != nil {
+		t.Fatalf("LoadPolicyBytes: %v", err)
+	}
+	d, err := NewDeclarative(policy, NewStoreGraph(ms), ms, WithPrincipalLookup(NewStorePrincipalLookup(ms)))
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	return d
+}
+
+// resolveAndAttribute resolves rawUser to an entity ID (falling back to
+// rawUser on empty/error, mirroring the wiring layer) and returns the
+// role names attributed to the resulting principal against entityID.
+func resolveAndAttribute(ctx context.Context, t *testing.T, d *Declarative, rawUser, entityID string) map[string]bool {
+	t.Helper()
+	effective := rawUser
+	if id, err := d.ResolvePrincipal(ctx, rawUser); err == nil && id != "" {
+		effective = id
+	}
+	req, err := d.ForPrincipal(principal.Principal{User: effective, Tool: principal.ToolDataEntry})
+	if err != nil {
+		t.Fatalf("ForPrincipal(%q): %v", effective, err)
+	}
+	roles := map[string]bool{}
+	for _, a := range req.ForEntity(ctx, "", entityID) {
+		roles[a.Role] = true
+	}
+	return roles
+}
+
+// ---- ResolvePrincipal unit behaviors -----------------------------------
+
+func TestResolvePrincipal(t *testing.T) {
+	ctx := context.Background()
+	persons := []personRow{
+		{id: "PERS-JV", email: "jvloothuis@sourcehaven.nl"},
+		{id: "PERS-TS", email: "tschmits@sourcehaven.nl"},
+	}
+	d := buildPrincipalLookupWorld(ctx, t, principalLookupPolicyYAML, persons, nil)
+
+	t.Run("single match returns id", func(t *testing.T) {
+		id, err := d.ResolvePrincipal(ctx, "jvloothuis@sourcehaven.nl")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if id != "PERS-JV" {
+			t.Fatalf("got %q, want PERS-JV", id)
+		}
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		id, err := d.ResolvePrincipal(ctx, "nobody@sourcehaven.nl")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if id != "" {
+			t.Fatalf("got %q, want empty", id)
+		}
+	})
+
+	t.Run("blank raw returns empty", func(t *testing.T) {
+		id, err := d.ResolvePrincipal(ctx, "   ")
+		if err != nil || id != "" {
+			t.Fatalf("got (%q,%v), want (\"\",nil)", id, err)
+		}
+	})
+
+	t.Run("multiple matches error", func(t *testing.T) {
+		dupPersons := []personRow{
+			{id: "PERS-A", email: "dup@sourcehaven.nl"},
+			{id: "PERS-B", email: "dup@sourcehaven.nl"},
+		}
+		dd := buildPrincipalLookupWorld(ctx, t, principalLookupPolicyYAML, dupPersons, nil)
+		id, err := dd.ResolvePrincipal(ctx, "dup@sourcehaven.nl")
+		if err == nil {
+			t.Fatal("expected ambiguity error, got nil")
+		}
+		if id != "" {
+			t.Fatalf("got id %q on ambiguity, want empty", id)
+		}
+	})
+
+	t.Run("disabled policy returns empty", func(t *testing.T) {
+		// Policy without principal_property → lookup disabled.
+		noLookup := "user_entity_type: persoon\nroles:\n  everyone:\n    read: [\"*\"]\n"
+		dd := buildPrincipalLookupWorld(ctx, t, noLookup, persons, nil)
+		id, err := dd.ResolvePrincipal(ctx, "jvloothuis@sourcehaven.nl")
+		if err != nil || id != "" {
+			t.Fatalf("disabled lookup: got (%q,%v), want (\"\",nil)", id, err)
+		}
+	})
+}
+
+// ---- The 6 spec acceptance cases ---------------------------------------
+
+func TestPrincipalProperty_AcceptanceCases(t *testing.T) {
+	ctx := context.Background()
+	persons := []personRow{
+		{id: "PERS-JV", email: "jvloothuis@sourcehaven.nl"},
+		{id: "PERS-TS", email: "tschmits@sourcehaven.nl"},
+	}
+	// PERS-JV --heeft_rol--> ROLE-MD ; assignments: ROLE-MD -> md.
+	rels := [][3]string{{"PERS-JV", "heeft_rol", "ROLE-MD"}}
+
+	t.Run("case1 happy path: email resolves and md via group", func(t *testing.T) {
+		d := buildPrincipalLookupWorld(ctx, t, principalLookupPolicyYAML, persons, rels)
+		roles := resolveAndAttribute(ctx, t, d, "jvloothuis@sourcehaven.nl", "PERS-TS")
+		if !roles["md"] {
+			t.Fatalf("expected md role via ROLE-MD group, got %v", roles)
+		}
+		if !roles["everyone"] {
+			t.Fatalf("expected everyone role, got %v", roles)
+		}
+	})
+
+	t.Run("case2 no graph match: everyone only", func(t *testing.T) {
+		d := buildPrincipalLookupWorld(ctx, t, principalLookupPolicyYAML, persons, rels)
+		roles := resolveAndAttribute(ctx, t, d, "nobody@sourcehaven.nl", "PERS-TS")
+		if roles["md"] {
+			t.Fatalf("unexpected md role for unknown principal, got %v", roles)
+		}
+		if !roles["everyone"] {
+			t.Fatalf("expected everyone role, got %v", roles)
+		}
+	})
+
+	t.Run("case3 multiple matches: fall back to raw, everyone only", func(t *testing.T) {
+		dupPersons := append([]personRow{
+			{id: "PERS-DUP1", email: "dup@sourcehaven.nl"},
+			{id: "PERS-DUP2", email: "dup@sourcehaven.nl"},
+		}, persons...)
+		d := buildPrincipalLookupWorld(ctx, t, principalLookupPolicyYAML, dupPersons, rels)
+		roles := resolveAndAttribute(ctx, t, d, "dup@sourcehaven.nl", "PERS-TS")
+		if roles["md"] {
+			t.Fatalf("ambiguous principal must not gain md, got %v", roles)
+		}
+		if !roles["everyone"] {
+			t.Fatalf("expected everyone role, got %v", roles)
+		}
+	})
+
+	t.Run("case4 raw-key assignment escape hatch", func(t *testing.T) {
+		// No persoon with this email; assignment keyed on the raw UPN.
+		rawPolicy := `
+user_entity_type: persoon
+principal_property: email
+membership_relation: heeft_rol
+assignments:
+  jvloothuis@sourcehaven.nl: md
+roles:
+  everyone:
+    read: ["*"]
+  md:
+    read: ["*"]
+    update: ["*"]
+`
+		noEmailPersons := []personRow{{id: "PERS-TS", email: "tschmits@sourcehaven.nl"}}
+		d := buildPrincipalLookupWorld(ctx, t, rawPolicy, noEmailPersons, nil)
+		roles := resolveAndAttribute(ctx, t, d, "jvloothuis@sourcehaven.nl", "PERS-TS")
+		if !roles["md"] {
+			t.Fatalf("expected md via raw-key assignment, got %v", roles)
+		}
+	})
+
+	t.Run("case6 missing principal_property: raw string used as-is", func(t *testing.T) {
+		// Policy without principal_property; assignment on the raw UPN
+		// must still fire (byte-for-byte pre-feature behavior).
+		rawPolicy := `
+user_entity_type: persoon
+membership_relation: heeft_rol
+assignments:
+  jvloothuis@sourcehaven.nl: md
+roles:
+  everyone:
+    read: ["*"]
+  md:
+    read: ["*"]
+    update: ["*"]
+`
+		d := buildPrincipalLookupWorld(ctx, t, rawPolicy, persons, rels)
+		roles := resolveAndAttribute(ctx, t, d, "jvloothuis@sourcehaven.nl", "PERS-TS")
+		if !roles["md"] {
+			t.Fatalf("expected md via raw-key assignment with lookup disabled, got %v", roles)
+		}
+	})
+}
+
+// case5: local role via role_relations, from the substituted entity ID.
+func TestPrincipalProperty_LocalRoleFromSubstitutedID(t *testing.T) {
+	ctx := context.Background()
+	policyYAML := `
+user_entity_type: persoon
+principal_property: email
+membership_relation: heeft_rol
+role_relations:
+  toegewezen_aan:
+    confers: assignee
+roles:
+  everyone:
+    read: ["*"]
+  assignee:
+    read: ["*"]
+    update: ["*"]
+`
+	persons := []personRow{{id: "PERS-JV", email: "jvloothuis@sourcehaven.nl"}}
+	// PERS-JV --toegewezen_aan--> ASSET-X (ASSET-X created as a rol-typed
+	// placeholder; type does not matter for the edge probe).
+	rels := [][3]string{{"PERS-JV", "toegewezen_aan", "ASSET-X"}}
+	d := buildPrincipalLookupWorld(ctx, t, policyYAML, persons, rels)
+
+	roles := resolveAndAttribute(ctx, t, d, "jvloothuis@sourcehaven.nl", "ASSET-X")
+	if !roles["assignee"] {
+		t.Fatalf("expected assignee local role from substituted PERS-JV, got %v", roles)
+	}
+}

--- a/internal/acl/validate_metamodel_test.go
+++ b/internal/acl/validate_metamodel_test.go
@@ -1,0 +1,112 @@
+package acl_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// fakeMeta is a minimal acl.MetamodelView for validation tests. types maps
+// entity type → property name → its PropertyInfo.
+type fakeMeta struct {
+	types map[string]map[string]acl.PropertyInfo
+}
+
+func (m fakeMeta) HasEntityType(t string) bool {
+	_, ok := m.types[t]
+	return ok
+}
+
+func (m fakeMeta) PropertyInfo(t, prop string) acl.PropertyInfo {
+	props, ok := m.types[t]
+	if !ok {
+		return acl.PropertyInfo{}
+	}
+	return props[prop] // zero value (Exists:false) when absent
+}
+
+func TestValidateAgainstMetamodel(t *testing.T) {
+	meta := fakeMeta{types: map[string]map[string]acl.PropertyInfo{
+		"persoon": {
+			"email":    {Exists: true, Unique: true},
+			"nickname": {Exists: true, Unique: false},
+			"aliases":  {Exists: true, Unique: true, List: true},
+		},
+	}}
+
+	cases := []struct {
+		name       string
+		policy     acl.Policy
+		wantErr    bool
+		wantSubstr string
+	}{
+		{
+			name:   "valid: unique property",
+			policy: acl.Policy{UserEntityType: "persoon", PrincipalProperty: "email"},
+		},
+		{
+			name:   "valid: user_entity_type alone (no principal_property)",
+			policy: acl.Policy{UserEntityType: "persoon"},
+		},
+		{
+			name:   "valid: neither set",
+			policy: acl.Policy{},
+		},
+		{
+			name:       "principal_property without user_entity_type",
+			policy:     acl.Policy{PrincipalProperty: "email"},
+			wantErr:    true,
+			wantSubstr: "requires user_entity_type",
+		},
+		{
+			name:       "unknown entity type",
+			policy:     acl.Policy{UserEntityType: "bogus", PrincipalProperty: "email"},
+			wantErr:    true,
+			wantSubstr: "not a declared entity type",
+		},
+		{
+			name:       "unknown property",
+			policy:     acl.Policy{UserEntityType: "persoon", PrincipalProperty: "ghost"},
+			wantErr:    true,
+			wantSubstr: "not a declared property",
+		},
+		{
+			name:       "non-unique property",
+			policy:     acl.Policy{UserEntityType: "persoon", PrincipalProperty: "nickname"},
+			wantErr:    true,
+			wantSubstr: "must be declared `unique: true`",
+		},
+		{
+			name:       "list property rejected even when unique",
+			policy:     acl.Policy{UserEntityType: "persoon", PrincipalProperty: "aliases"},
+			wantErr:    true,
+			wantSubstr: "list: true",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.policy.ValidateAgainstMetamodel(meta)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantSubstr)
+				}
+				if !strings.Contains(err.Error(), tc.wantSubstr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateAgainstMetamodel_NilView(t *testing.T) {
+	p := acl.Policy{UserEntityType: "persoon", PrincipalProperty: "email"}
+	if err := p.ValidateAgainstMetamodel(nil); err == nil {
+		t.Fatal("expected error for nil metamodel view")
+	}
+}

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -415,9 +415,41 @@ func loadACLPolicy(projectRoot string) (*acl.Policy, error) {
 // An error from [acl.NewDeclarative] is propagated, not downgraded:
 // the operator wrote a policy and the resolver couldn't accept it; the
 // server must fail to boot rather than silently allow-all.
-func buildACL(policy *acl.Policy, st store.Store) (acl.ACL, *acl.Declarative, error) {
+// metamodelView adapts *metamodel.Metamodel to acl.MetamodelView. The acl
+// package deliberately does not depend on internal/metamodel
+// (.go-arch-lint.yml), so it declares the narrow view it needs and the
+// wiring site — which imports both — supplies this adapter. Uniqueness is
+// computed from the already-exported EntityDef accessors, keeping it out
+// of Metamodel's public API (plimsoll load line).
+type metamodelView struct{ m *metamodel.Metamodel }
+
+func (v metamodelView) HasEntityType(entityType string) bool {
+	return v.m.HasEntityType(entityType)
+}
+
+func (v metamodelView) PropertyInfo(entityType, property string) acl.PropertyInfo {
+	def, ok := v.m.GetEntityDef(entityType)
+	if !ok {
+		return acl.PropertyInfo{}
+	}
+	pd, ok := def.PropertyDefs()[property]
+	if !ok {
+		return acl.PropertyInfo{}
+	}
+	return acl.PropertyInfo{Exists: true, Unique: pd.Unique, List: pd.List}
+}
+
+func buildACL(policy *acl.Policy, meta *metamodel.Metamodel, st store.Store) (acl.ACL, *acl.Declarative, error) {
 	if policy == nil {
 		return acl.NopACL{}, nil, nil
+	}
+	// Schema-dependent policy validation (principal_property references a
+	// real, unique property; user_entity_type is a declared type). Run
+	// here rather than in acl.LoadPolicy because the acl package
+	// deliberately does not depend on metamodel; a mistake must fail the
+	// boot, not silently mis-resolve identities at runtime.
+	if err := policy.ValidateAgainstMetamodel(metamodelView{meta}); err != nil {
+		return nil, nil, fmt.Errorf("appbuild: validate acl policy against metamodel: %w", err)
 	}
 	// `st` is passed twice: once via NewStoreGraph (the Graph
 	// adapter the resolver uses for member-of / ancestor walks), and
@@ -427,7 +459,12 @@ func buildACL(policy *acl.Policy, st store.Store) (acl.ACL, *acl.Declarative, er
 	// store-wrapping decorator (audit, metrics) MUST forward
 	// GraphQueryer or this compiles while the read gate silently uses
 	// the wrong store.
-	d, err := acl.NewDeclarative(policy, acl.NewStoreGraph(st), st)
+	//
+	// WithPrincipalLookup supplies the store-backed resolver for the
+	// `principal_property` substitution; NewDeclarative requires it iff
+	// the policy enables that lookup (else it is an inert dependency).
+	d, err := acl.NewDeclarative(policy, acl.NewStoreGraph(st), st,
+		acl.WithPrincipalLookup(acl.NewStorePrincipalLookup(st)))
 	if err != nil {
 		return nil, nil, fmt.Errorf("appbuild: build acl.Declarative: %w", err)
 	}
@@ -598,7 +635,7 @@ func assemble(
 	var aclDeclarative *acl.Declarative
 	if resolvedACL == nil {
 		var err error
-		resolvedACL, aclDeclarative, err = buildACL(base.aclPolicy, st)
+		resolvedACL, aclDeclarative, err = buildACL(base.aclPolicy, base.meta, st)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/appbuild/appbuild_acl_test.go
+++ b/internal/appbuild/appbuild_acl_test.go
@@ -120,14 +120,81 @@ func TestDiscover_MalformedACL_FailsBoot(t *testing.T) {
 	}
 }
 
+// principalPropertyMetamodel declares a persoon type with a unique email
+// and a non-unique nickname, for the principal_property boot checks.
+const principalPropertyMetamodel = `version: "1.0"
+entities:
+  persoon:
+    label: Persoon
+    plural: personen
+    id_type: manual
+    properties:
+      email:
+        type: string
+        unique: true
+      nickname:
+        type: string
+relations: {}
+`
+
+// principal_property referencing a non-unique property must fail boot —
+// a non-unique identity key admits duplicates and makes resolution
+// ambiguous (the ValidateAgainstMetamodel gate, wired via buildACL).
+func TestDiscover_PrincipalPropertyNotUnique_FailsBoot(t *testing.T) {
+	root := t.TempDir()
+	writeMetamodelBody(t, root, principalPropertyMetamodel)
+	writePolicy(t, root, "user_entity_type: persoon\nprincipal_property: nickname\n")
+
+	svc, err := appbuildOnDisk(t, root)
+	if err == nil {
+		svc.Close()
+		t.Fatalf("expected boot to fail on non-unique principal_property, got nil")
+	}
+	if !strings.Contains(err.Error(), "unique") {
+		t.Errorf("error should explain the uniqueness requirement; got %q", err.Error())
+	}
+}
+
+// principal_property referencing an unknown property must fail boot.
+func TestDiscover_PrincipalPropertyUnknown_FailsBoot(t *testing.T) {
+	root := t.TempDir()
+	writeMetamodelBody(t, root, principalPropertyMetamodel)
+	writePolicy(t, root, "user_entity_type: persoon\nprincipal_property: ghost\n")
+
+	svc, err := appbuildOnDisk(t, root)
+	if err == nil {
+		svc.Close()
+		t.Fatalf("expected boot to fail on unknown principal_property, got nil")
+	}
+}
+
+// principal_property referencing a unique property boots successfully.
+func TestDiscover_PrincipalPropertyUnique_Boots(t *testing.T) {
+	root := t.TempDir()
+	writeMetamodelBody(t, root, principalPropertyMetamodel)
+	writePolicy(t, root, "user_entity_type: persoon\nprincipal_property: email\n"+
+		"roles:\n  everyone:\n    read: [\"*\"]\n")
+
+	svc, err := appbuildOnDisk(t, root)
+	if err != nil {
+		t.Fatalf("expected boot to succeed with unique principal_property, got %v", err)
+	}
+	svc.Close()
+}
+
 // --- helpers ---
 
 func writeMetamodel(t *testing.T, root string) {
 	t.Helper()
+	writeMetamodelBody(t, root, minimalMetamodel)
+}
+
+func writeMetamodelBody(t *testing.T, root, body string) {
+	t.Helper()
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(root, "metamodel.yaml"), []byte(minimalMetamodel), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "metamodel.yaml"), []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.MkdirAll(filepath.Join(root, ".rela", "audit"), 0o700); err != nil {

--- a/internal/dataentry/principal_property_test.go
+++ b/internal/dataentry/principal_property_test.go
@@ -1,0 +1,113 @@
+package dataentry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+const principalPropertyPolicy = `
+user_entity_type: persoon
+principal_property: email
+membership_relation: heeft_rol
+assignments:
+  ROLE-MD: md
+roles:
+  everyone:
+    read: ["*"]
+  md:
+    read: ["*"]
+    update: ["*"]
+`
+
+// buildLookupACL creates a memstore with a persoon carrying an email and a
+// heeft_rol edge to ROLE-MD, plus a Declarative wired with the
+// principal_property lookup.
+func buildLookupACL(t *testing.T) *acl.Declarative {
+	t.Helper()
+	ctx := context.Background()
+	ms := memstore.New()
+	jv := entity.New("PERS-JV", "persoon")
+	jv.SetString("email", "jvloothuis@sourcehaven.nl")
+	if err := ms.CreateEntity(ctx, jv); err != nil {
+		t.Fatalf("create PERS-JV: %v", err)
+	}
+	if err := ms.CreateEntity(ctx, entity.New("ROLE-MD", "rol")); err != nil {
+		t.Fatalf("create ROLE-MD: %v", err)
+	}
+	if _, err := ms.CreateRelation(ctx, "PERS-JV", "heeft_rol", "ROLE-MD", nil); err != nil {
+		t.Fatalf("create heeft_rol: %v", err)
+	}
+
+	p, err := acl.LoadPolicyBytes([]byte(principalPropertyPolicy))
+	if err != nil {
+		t.Fatalf("LoadPolicyBytes: %v", err)
+	}
+	d, err := acl.NewDeclarative(p, acl.NewStoreGraph(ms), ms,
+		acl.WithPrincipalLookup(acl.NewStorePrincipalLookup(ms)))
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	return d
+}
+
+// TestPrincipalProperty_MiddlewareReStampsCtx verifies that the data-entry
+// ACL middleware resolves the raw principal (email) to the user entity ID
+// and re-stamps ctx so the resolved principal — carrying both the entity
+// ID (User) and the raw header (RawUser) — is what downstream handlers and
+// the audit writer see via principal.From(ctx).
+func TestPrincipalProperty_MiddlewareReStampsCtx(t *testing.T) {
+	d := buildLookupACL(t)
+
+	var seen principal.Principal
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = principal.From(r.Context())
+	})
+	handler := attachACLRequest(next, d)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody)
+	req = req.WithContext(principal.With(req.Context(),
+		principal.Principal{User: "jvloothuis@sourcehaven.nl", Tool: principal.ToolDataEntry}))
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seen.User != "PERS-JV" {
+		t.Errorf("resolved User = %q, want PERS-JV", seen.User)
+	}
+	if seen.RawUser != "jvloothuis@sourcehaven.nl" {
+		t.Errorf("RawUser = %q, want the original email", seen.RawUser)
+	}
+	if seen.Tool != principal.ToolDataEntry {
+		t.Errorf("Tool = %q, want data-entry", seen.Tool)
+	}
+}
+
+// TestPrincipalProperty_MiddlewareKeepsRawOnNoMatch verifies that a
+// principal with no matching persoon is left untouched (no RawUser, User
+// unchanged) — the fail-open-to-raw fallback.
+func TestPrincipalProperty_MiddlewareKeepsRawOnNoMatch(t *testing.T) {
+	d := buildLookupACL(t)
+
+	var seen principal.Principal
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = principal.From(r.Context())
+	})
+	handler := attachACLRequest(next, d)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody)
+	req = req.WithContext(principal.With(req.Context(),
+		principal.Principal{User: "nobody@sourcehaven.nl", Tool: principal.ToolDataEntry}))
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seen.User != "nobody@sourcehaven.nl" {
+		t.Errorf("User = %q, want the raw principal unchanged", seen.User)
+	}
+	if seen.RawUser != "" {
+		t.Errorf("RawUser = %q, want empty when no substitution happened", seen.RawUser)
+	}
+}

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -175,6 +175,14 @@ func attachACLRequest(next http.Handler, d *acl.Declarative) http.Handler {
 			// upstream layer attached a Request from a different
 			// identity); under that condition the gate would run
 			// against the wrong policy with no loud signal.
+			//
+			// Note: principal_property resolution (resolvePrincipalEntity
+			// below) has NOT run on this branch — it only applies when we
+			// open a fresh Request. So both sides here are the raw,
+			// pre-resolution principal and match in production (nothing
+			// upstream resolves). If a future upstream layer ever attaches
+			// a Request built from a *resolved* principal while ctx still
+			// holds the raw one, this correctly 500s as a genuine mismatch.
 			ctxPrin := principal.From(ctx)
 			if existing.Principal() != ctxPrin {
 				slog.Warn("acl: attachACLRequest: existing Request principal mismatch",
@@ -202,6 +210,16 @@ func attachACLRequest(next http.Handler, d *acl.Declarative) http.Handler {
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
+		// Resolve the raw principal to a user entity via the policy's
+		// `principal_property` lookup (a no-op unless both policy keys are
+		// set). On a single match we re-stamp ctx with the resolved ID so
+		// BOTH the ACL walk below and the audit writer (which re-reads
+		// principal.From(ctx)) attribute the write to the real entity while
+		// preserving the raw header value in RawUser. Any non-match /
+		// ambiguous / errored lookup keeps the raw principal (fail-open to
+		// pre-feature behavior) — see acl.Declarative.ResolvePrincipal.
+		ctx = resolvePrincipalEntity(ctx, d, r)
+
 		req, err := d.ForPrincipal(principal.From(ctx))
 		if err != nil {
 			// RR-372L: log the raw error server-side; never emit it
@@ -238,6 +256,30 @@ func attachACLRequest(next http.Handler, d *acl.Declarative) http.Handler {
 		ctx = withReadGate(ctx, gate)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// resolvePrincipalEntity applies the ACL policy's `principal_property`
+// lookup to the ctx principal. When the policy has the lookup enabled and
+// the raw principal resolves to exactly one user entity, it returns a ctx
+// carrying a principal whose User is the entity ID and whose RawUser is
+// the original identifier (so the audit log records both). In every other
+// case — lookup disabled, no match, ambiguous match, or backend error —
+// it returns ctx unchanged so the write falls back to the raw principal
+// (pre-feature behavior); ambiguity and errors are logged, a plain
+// no-match is not (a principal absent from the graph is expected, e.g. a
+// break-glass identity assigned by raw UPN).
+func resolvePrincipalEntity(ctx context.Context, d *acl.Declarative, r *http.Request) context.Context {
+	p := principal.From(ctx)
+	id, err := d.ResolvePrincipal(ctx, p.User)
+	if err != nil {
+		slog.Warn("acl: principal_property lookup failed; using raw principal",
+			"path", r.URL.Path, "method", r.Method, "err", err)
+		return ctx
+	}
+	if id == "" || id == p.User {
+		return ctx
+	}
+	return principal.With(ctx, principal.Principal{User: id, Tool: p.Tool, RawUser: p.User})
 }
 
 // PrincipalResolver maps an incoming HTTP request to the audit

--- a/internal/entitymanager/apply.go
+++ b/internal/entitymanager/apply.go
@@ -107,6 +107,12 @@ func (m *Manager) ApplyEntity(ctx context.Context, e *entity.Entity) (*entity.Up
 		return nil, newValidationError(hard)
 	}
 
+	// Enforce `unique: true` natural-key constraints, excluding this
+	// entity's own prior version (sync upserts an existing ID).
+	if err := checkUniqueProperties(ctx, m.deps, e, e.ID); err != nil {
+		return nil, err
+	}
+
 	if err := upsertEntity(ctx, m.deps.Store, e); err != nil {
 		return nil, fmt.Errorf("entitymanager: ApplyEntity: %w", err)
 	}

--- a/internal/entitymanager/core.go
+++ b/internal/entitymanager/core.go
@@ -94,6 +94,13 @@ func createCore(
 		return nil, nil, err
 	}
 
+	// Enforce `unique: true` natural-key constraints before the durable
+	// write. excludeSelfID is empty: on create there is no prior version
+	// of this entity to exclude.
+	if err := checkUniqueProperties(ctx, deps, e, ""); err != nil {
+		return nil, nil, err
+	}
+
 	// A create must never fall through to an update — that would
 	// overwrite a colliding entity (a racing create, or a stale-scan
 	// duplicate ID). Write with a direct CreateEntity and surface a

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -376,6 +376,16 @@ func (m *Manager) CreateEntity(
 		for prop, val := range autoResult.PropertiesSet {
 			created.SetString(prop, val)
 		}
+		// Re-enforce unique constraints against the POST-automation values:
+		// createCore's check ran before automations, so an automation that
+		// set a `unique` property could otherwise write a duplicate natural
+		// key that the update path would reject (the create path must not be
+		// the weaker one). excludeSelfID is created.ID — the entity is
+		// already persisted from createCore, so it must not collide with
+		// itself. A violation aborts before the duplicate is re-written.
+		if err := checkUniqueProperties(ctx, m.deps, created, created.ID); err != nil {
+			return nil, err
+		}
 		if writeErr := upsertEntity(ctx, m.deps.Store, created); writeErr != nil {
 			return nil, fmt.Errorf("write entity after automation: %w", writeErr)
 		}
@@ -505,6 +515,13 @@ func (m *Manager) UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.U
 		}
 		result.AutomationWarnings = autoResult.Warnings
 		result.AutomationErrors = autoResult.Errors
+	}
+
+	// Enforce `unique: true` natural-key constraints against the final
+	// (post-automation) property values, excluding this entity's own
+	// prior version so a re-save of an unchanged value does not collide.
+	if err := checkUniqueProperties(ctx, m.deps, e, e.ID); err != nil {
+		return nil, err
 	}
 
 	if err := upsertEntity(ctx, m.deps.Store, e); err != nil {

--- a/internal/entitymanager/unique.go
+++ b/internal/entitymanager/unique.go
@@ -1,0 +1,112 @@
+package entitymanager
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// checkUniqueProperties enforces the `unique: true` natural-key
+// constraint on e: for every property of e.Type declared unique, no other
+// entity of the same type may carry the same non-empty value.
+//
+// It is called at every entity-write choke point right after
+// [metamodel.Metamodel.ValidateEntity] — createCore (create), UpdateEntity
+// (update), and ApplyEntity (sync). excludeSelfID names the entity's own
+// ID so a re-save of an unchanged value does not collide with itself; pass
+// "" on the create path.
+//
+// The check queries other entities and so cannot live in the pure,
+// per-entity ValidateEntity. Violations are returned as
+// [metamodel.ValidationError]s of type [metamodel.ValidationErrorUnique]
+// (a HARD error) so the caller folds them into the same
+// [newValidationError] → 422 path as structural validation failures.
+//
+// Semantics and limits:
+//
+//   - Empty values are exempt — a property is unique among the entities
+//     that set it, matching the "email is unique for the people who have
+//     one" intent. `list` properties are skipped (a natural key is a
+//     scalar).
+//   - Comparison is on the string value (identity keys — email, UPN — are
+//     strings). Non-string property values are compared via their string
+//     form and in practice only strings carry unique keys.
+//   - This is a check-then-write, NOT an atomic constraint. The scan and
+//     the durable write are separate operations and no lock is held
+//     across them, so under concurrent writers (the data-entry server is
+//     one goroutine per request) two racing writes with the same value
+//     can both pass the scan and both commit — on every backend, not just
+//     pgstore. The window is small, and the ACL resolver's multi-match
+//     fallback (keep-raw) is the runtime backstop for the identity-key
+//     case. The only race-free enforcement is a store-level unique index
+//     (a partial unique index on pgstore), which surfaces a duplicate as
+//     [store.ErrConflict] on the write; operators who need atomicity add
+//     it. See docs/acl-security.md.
+func checkUniqueProperties(
+	ctx context.Context, deps Deps, e *entity.Entity, excludeSelfID string,
+) error {
+	def, ok := deps.Meta.GetEntityDef(e.Type)
+	if !ok {
+		return nil // unknown type is caught by ValidateEntity's own path
+	}
+
+	// Collect the unique, non-list properties this entity actually sets to
+	// a non-empty value. If none, skip the scan entirely — the common case
+	// for types without a natural key pays nothing.
+	type uniqueProp struct {
+		name  string
+		value string
+	}
+	var toCheck []uniqueProp
+	for name, pd := range def.PropertyDefs() {
+		if !pd.Unique || pd.List {
+			continue
+		}
+		if v := e.GetString(name); v != "" {
+			toCheck = append(toCheck, uniqueProp{name: name, value: v})
+		}
+	}
+	if len(toCheck) == 0 {
+		return nil
+	}
+
+	var violations []*metamodel.ValidationError
+	for other, err := range deps.Store.ListEntities(ctx, store.EntityQuery{Type: e.Type}) {
+		if err != nil {
+			// A partial scan cannot prove uniqueness — fail the write loud
+			// rather than admit a possible duplicate.
+			return fmt.Errorf("entitymanager: unique check for %s: %w", e.ID, err)
+		}
+		if other.ID == excludeSelfID {
+			continue
+		}
+		for _, up := range toCheck {
+			if other.GetString(up.name) == up.value {
+				// Client-facing message names only the property + type — NOT
+				// the colliding entity's ID or the value. For an identity key
+				// (e.g. persoon.email) leaking "PERS-X already has alice@corp"
+				// to whoever attempted the write is an enumeration oracle
+				// (confirms an entity/value is registered). The full detail is
+				// logged server-side instead, mirroring the RR-372L discipline.
+				slog.Warn("entitymanager: unique constraint violated",
+					"type", e.Type, "property", up.name,
+					"attempted_by", e.ID, "conflicts_with", other.ID)
+				violations = append(violations, &metamodel.ValidationError{
+					Type:     metamodel.ValidationErrorUnique,
+					Property: up.name,
+					Message: fmt.Sprintf(
+						"property %q must be unique for type %q; another entity already has this value",
+						up.name, e.Type),
+				})
+			}
+		}
+	}
+	if len(violations) > 0 {
+		return newValidationError(violations)
+	}
+	return nil
+}

--- a/internal/entitymanager/unique_test.go
+++ b/internal/entitymanager/unique_test.go
@@ -1,0 +1,223 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/autocascade"
+	"github.com/Sourcehaven-BV/rela/internal/automation"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// uniqueMetamodelYAML declares a `persoon` type with a unique `email`
+// property and a non-unique `nickname`, plus a manual-ID `account` type
+// used to prove uniqueness is scoped per entity type.
+const uniqueMetamodelYAML = `version: "1.0"
+entities:
+  persoon:
+    label: Persoon
+    plural: personen
+    id_type: manual
+    properties:
+      email:
+        type: string
+        unique: true
+      nickname:
+        type: string
+  account:
+    label: Account
+    plural: accounts
+    id_type: manual
+    properties:
+      email:
+        type: string
+        unique: true
+`
+
+func newUniqueManager(t *testing.T) *entitymanager.Manager {
+	t.Helper()
+	meta, err := metamodel.Parse([]byte(uniqueMetamodelYAML))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:     memstore.New(),
+		Meta:      meta,
+		Templater: nopTemplater{},
+		Audit:     audit.Nop{},
+		ACL:       acl.NopACL{},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	return mgr
+}
+
+// newUniqueManagerWithAutomation is like newUniqueManager but wires an
+// automation engine so on-create actions (e.g. Set email=...) run and the
+// post-automation uniqueness re-check is exercised.
+func newUniqueManagerWithAutomation(t *testing.T, autos []automation.Automation) *entitymanager.Manager {
+	t.Helper()
+	meta, err := metamodel.Parse([]byte(uniqueMetamodelYAML))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	engine := automation.NewEngine(autos)
+	runner, err := autocascade.New(autocascade.Deps{Engine: engine})
+	if err != nil {
+		t.Fatalf("autocascade.New: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:       memstore.New(),
+		Meta:        meta,
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Automations: engine,
+		Cascade:     runner,
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	return mgr
+}
+
+func createPersoon(t *testing.T, mgr *entitymanager.Manager, id, email string) error {
+	t.Helper()
+	e := entity.New(id, "persoon")
+	if email != "" {
+		e.SetString("email", email)
+	}
+	_, err := mgr.CreateEntity(context.Background(), e, entity.CreateOptions{ID: id})
+	return err
+}
+
+func isValidationError(err error) bool {
+	var ve *entitymanager.ValidationError
+	return errors.As(err, &ve)
+}
+
+func TestUnique_CreateRejectsDuplicate(t *testing.T) {
+	mgr := newUniqueManager(t)
+
+	if err := createPersoon(t, mgr, "PERS-JV", "jv@example.com"); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	err := createPersoon(t, mgr, "PERS-DUP", "jv@example.com")
+	if err == nil {
+		t.Fatal("expected duplicate-email create to be rejected, got nil")
+	}
+	if !isValidationError(err) {
+		t.Fatalf("expected *ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestUnique_CreateAllowsDistinctValues(t *testing.T) {
+	mgr := newUniqueManager(t)
+
+	if err := createPersoon(t, mgr, "PERS-JV", "jv@example.com"); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if err := createPersoon(t, mgr, "PERS-TS", "ts@example.com"); err != nil {
+		t.Fatalf("distinct-email create should succeed: %v", err)
+	}
+}
+
+func TestUnique_EmptyValuesAreExempt(t *testing.T) {
+	mgr := newUniqueManager(t)
+
+	// Two personen with no email must both be creatable — a unique
+	// property is unique only among the entities that set it.
+	if err := createPersoon(t, mgr, "PERS-A", ""); err != nil {
+		t.Fatalf("first empty-email create: %v", err)
+	}
+	if err := createPersoon(t, mgr, "PERS-B", ""); err != nil {
+		t.Fatalf("second empty-email create should succeed: %v", err)
+	}
+}
+
+func TestUnique_ScopedPerType(t *testing.T) {
+	mgr := newUniqueManager(t)
+
+	if err := createPersoon(t, mgr, "PERS-JV", "shared@example.com"); err != nil {
+		t.Fatalf("persoon create: %v", err)
+	}
+	// Same email on a different type must not collide.
+	acct := entity.New("ACC-1", "account")
+	acct.SetString("email", "shared@example.com")
+	if _, err := mgr.CreateEntity(context.Background(), acct, entity.CreateOptions{ID: "ACC-1"}); err != nil {
+		t.Fatalf("account create with same email (different type) should succeed: %v", err)
+	}
+}
+
+func TestUnique_UpdateSelfDoesNotCollide(t *testing.T) {
+	mgr := newUniqueManager(t)
+
+	if err := createPersoon(t, mgr, "PERS-JV", "jv@example.com"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Re-save the same entity keeping its own email — must not self-collide.
+	e := entity.New("PERS-JV", "persoon")
+	e.SetString("email", "jv@example.com")
+	e.SetString("nickname", "Jer")
+	if _, err := mgr.UpdateEntity(context.Background(), e); err != nil {
+		t.Fatalf("self-update should not collide: %v", err)
+	}
+}
+
+// TestUnique_CreateRejectsAutomationSetDuplicate pins C1: the create-path
+// uniqueness check must see POST-automation values. An automation that
+// sets a `unique` property to a colliding value must be rejected — the
+// create path must not be weaker than the update path.
+func TestUnique_CreateRejectsAutomationSetDuplicate(t *testing.T) {
+	// Every persoon create gets email forced to the same value by automation.
+	autos := []automation.Automation{{
+		Name: "force-email",
+		On:   automation.Trigger{Entity: []string{"persoon"}, Created: true},
+		Do:   []automation.Action{{Set: "email", Value: "forced@example.com"}},
+	}}
+	mgr := newUniqueManagerWithAutomation(t, autos)
+
+	// First create: automation sets email=forced@… — unique, succeeds.
+	if _, err := mgr.CreateEntity(context.Background(),
+		entity.New("PERS-A", "persoon"), entity.CreateOptions{ID: "PERS-A"}); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	// Second create: automation forces the SAME email → must be rejected,
+	// even though the caller supplied no email at all.
+	_, err := mgr.CreateEntity(context.Background(),
+		entity.New("PERS-B", "persoon"), entity.CreateOptions{ID: "PERS-B"})
+	if err == nil {
+		t.Fatal("expected automation-set duplicate email to be rejected on create, got nil")
+	}
+	if !isValidationError(err) {
+		t.Fatalf("expected *ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestUnique_UpdateRejectsCollisionWithOther(t *testing.T) {
+	mgr := newUniqueManager(t)
+
+	if err := createPersoon(t, mgr, "PERS-JV", "jv@example.com"); err != nil {
+		t.Fatalf("create JV: %v", err)
+	}
+	if err := createPersoon(t, mgr, "PERS-TS", "ts@example.com"); err != nil {
+		t.Fatalf("create TS: %v", err)
+	}
+	// Update TS to JV's email — must be rejected.
+	e := entity.New("PERS-TS", "persoon")
+	e.SetString("email", "jv@example.com")
+	_, err := mgr.UpdateEntity(context.Background(), e)
+	if err == nil {
+		t.Fatal("expected update-into-duplicate to be rejected, got nil")
+	}
+	if !isValidationError(err) {
+		t.Fatalf("expected *ValidationError, got %T: %v", err, err)
+	}
+}

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -202,6 +202,25 @@ type PropertyDef struct {
 	Description string   `yaml:"description,omitempty"` // Documentation for the property
 	Format      string   `yaml:"format,omitempty"`      // Date format (Go layout, e.g., "2006-01-02")
 	List        bool     `yaml:"list,omitempty"`        // True for multi-select properties (allows multiple values)
+	// Unique constrains the property to a natural key: no two entities of
+	// the same type may carry the same non-empty value. Enforced at write
+	// time by the entitymanager (a colliding create/update is rejected as
+	// a validation error → 422). Empty values are exempt (a property is
+	// unique among the entities that set it). Ignored on `list` properties
+	// (a natural key is a scalar).
+	//
+	// Guarantee level is not uniform across backends. The write-path check
+	// is a check-then-write, not an atomic constraint, so under concurrent
+	// writers two racing creates with the same value can both commit on
+	// ANY backend. For race-free enforcement an operator adds a store-level
+	// unique index (a partial unique index on pgstore), which is the only
+	// mechanism that makes the constraint atomic. Uniqueness is therefore
+	// NOT part of the store conformance contract — a new store.Store
+	// implementation is not required to enforce it. See
+	// `internal/entitymanager` checkUniqueProperties and the ACL
+	// `principal_property` gate, which requires the referenced property to
+	// be unique (and non-list).
+	Unique bool `yaml:"unique,omitempty"`
 	// Max caps how many attachments a `file`-type property may hold.
 	// Zero/unset means 1 (the default, single-attachment). When > 1 the
 	// property holds a list of attachment paths and the data-entry UI

--- a/internal/metamodel/validation.go
+++ b/internal/metamodel/validation.go
@@ -50,6 +50,14 @@ const (
 	ValidationErrorInvalidType  ValidationErrorType = "invalid_type"
 	ValidationErrorUnknownType  ValidationErrorType = "unknown_type"
 	ValidationErrorIDPrefix     ValidationErrorType = "id_prefix"
+	// ValidationErrorUnique reports a duplicate value for a property
+	// declared `unique: true`. It is a HARD error (IsSoft returns false):
+	// a natural-key collision is a constraint violation the write path
+	// must reject with a 422, not a tolerable hand-edit state. Unlike the
+	// other types, this one is raised by the entitymanager write path
+	// (which can query other entities), not by the pure per-entity
+	// [Metamodel.ValidateEntity].
+	ValidationErrorUnique ValidationErrorType = "unique"
 )
 
 // ValidationError represents a structured validation error with field information.

--- a/internal/principal/principal.go
+++ b/internal/principal/principal.go
@@ -26,12 +26,21 @@ import (
 )
 
 // Principal identifies who is making a write. User is the OS user
-// captured at process startup via [SystemUser]; data-entry will
-// later override per-request from an HTTP middleware. Tool identifies
-// the entry point — one of the Tool* constants below.
+// captured at process startup via [SystemUser]; data-entry overrides it
+// per-request from an HTTP middleware. Tool identifies the entry point —
+// one of the Tool* constants below.
+//
+// RawUser records the pre-resolution identifier when the ACL policy's
+// `principal_property` lookup substituted User with a graph entity ID
+// (e.g. the `X-Forwarded-User` email before it became a `PERS-…` ID). It
+// is empty when no substitution happened — the common case — and exists
+// so the audit log can record BOTH the identity that authenticated and
+// the entity it resolved to without a round-trip to the graph. Old audit
+// consumers ignore the `raw_user` key (omitempty).
 type Principal struct {
-	User string `json:"user"`
-	Tool string `json:"tool"`
+	User    string `json:"user"`
+	Tool    string `json:"tool"`
+	RawUser string `json:"raw_user,omitempty"`
 }
 
 // Tool constants — the values that may appear in [Principal.Tool].

--- a/tickets/entities/features/FEAT-OF2ZOL.md
+++ b/tickets/entities/features/FEAT-OF2ZOL.md
@@ -1,0 +1,9 @@
+---
+id: FEAT-OF2ZOL
+type: feature
+title: Resolve principal to entity via principal_property + unique constraint
+summary: ACL policy can resolve an authenticated principal (e.g. X-Forwarded-User email) to a user entity by property lookup, backed by a general unique property constraint.
+description: Adds two coupled acl.yaml keys (user_entity_type + principal_property). At request start, if both are set, rela looks up the raw principal against the named property (e.g. persoon.email) and, on exactly one match, substitutes principal.User with that entity's ID for the rest of the request so membership/local-role walks operate from a real entity. Backed by a new general PropertyDef.Unique constraint (enforced in the entitymanager write path) which principal_property must reference. The data-entry middleware re-stamps ctx with the resolved ID + RawUser so the audit log records both the raw header and the resolved entity. Stacked on TKT-Z8A62F (configurable membership_relation).
+priority: medium
+status: proposed
+---

--- a/tickets/relations/FEAT-OF2ZOL--requires--audit-log.md
+++ b/tickets/relations/FEAT-OF2ZOL--requires--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-OF2ZOL
+relation: requires
+to: audit-log
+---

--- a/tickets/relations/FEAT-OF2ZOL--requires--authorization.md
+++ b/tickets/relations/FEAT-OF2ZOL--requires--authorization.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-OF2ZOL
+relation: requires
+to: authorization
+---


### PR DESCRIPTION
# feat(acl): resolve principal to entity via `principal_property` + `unique` constraint

Ticket: **FEAT-OF2ZOL**. Builds on #1060 (configurable `membership_relation`,
now merged); rebased onto `develop`.

## What

Lets an `acl.yaml` resolve an authenticated principal (e.g. the `X-Forwarded-User`
email from a reverse proxy) to a user entity in the graph, so role attribution
operates from a real entity instead of a raw header string.

```yaml
user_entity_type: persoon
principal_property: email     # NEW: persoon.email holds the header value
membership_relation: heeft_rol
assignments:
  ROLE-MD: md
```

At request start, if both `user_entity_type` and `principal_property` are set,
rela looks the raw principal up against `persoon.email`. On exactly one match it
substitutes the entity ID for `principal.User`; membership/local-role walks then
run from `PERS-JV` instead of `jvloothuis@…`. No graph migration needed — the
`email` property already exists.

Backed by a general **`unique: true` property constraint** (new `PropertyDef`
field): `principal_property` must reference a `unique` property, enforced at boot.

## Why

The graph already knows the identity mapping (`persoon.email`). Without this,
operators must either duplicate every human in `acl.yaml` or rewrite headers
UPN→entity-ID in the reverse proxy (rots on every new hire). See the design
in `docs/acl-overview.md`.

## Changes

- **`metamodel.PropertyDef.Unique`** — general natural-key flag; enforced in the
  entitymanager write path (`checkUniqueProperties`) at all three entity-write
  choke points (create/update/sync), folded into the existing 422 validation path.
- **`acl.Policy.PrincipalProperty`** + `principalPropertyLookupEnabled()`; both
  keys required to activate (byte-for-byte unchanged behaviour otherwise).
- **`acl.PrincipalLookup`** consumer-side interface + `storePrincipalLookup`
  adapter (scan-by-type); `Declarative.ResolvePrincipal` (0/1/many semantics).
- **`NewDeclarative`** gains `WithPrincipalLookup` option, required only when the
  policy enables the lookup.
- **`Policy.ValidateAgainstMetamodel`** (via `MetamodelView` consumer-side
  interface, adapted at the appbuild wiring site — `acl` must not import
  `metamodel`) — hard-fails boot if `principal_property` is missing, non-unique,
  or a list property.
- **`principal.Principal.RawUser`** — the data-entry `attachACLRequest`
  middleware resolves + re-stamps ctx so the audit log records BOTH the raw
  header and the resolved entity ID.
- Docs: `acl-overview.md`, `acl-security.md` (generated from `docs-project/`).

## Scope / limitations (deliberate, documented)

- **Resolution is data-entry (`/api/`) only.** CLI/MCP/scheduler stamp principals
  but don't resolve — a grant keyed on the resolved ID applies to data-entry
  writes, not the same person's CLI writes (fail-closed). Documented at
  `ResolvePrincipal`'s godoc and in `acl-security.md`.
- **`unique` is a write-time check, not an atomic constraint** — a TOCTOU window
  exists on all backends under concurrent writers; race-free enforcement needs a
  store-level unique index (partial index on pgstore). The ACL multi-match
  fallback is the runtime backstop. Documented per-backend.
- Case-insensitive matching, multi-property lookup, and audit-log schema changes
  beyond `raw_user` are out of scope (see design doc).

## Reviews

Reviewed with crit (inline), cranky-code-reviewer, and go-architect.
- **cranky** found one critical bug (create-path automation could bypass the
  unique check) — **fixed** + regression test.
- **go-architect** validated 4/5 design decisions; the 5th (data-entry-only
  scope) is now explicitly documented rather than implicit.
- Minor findings (list-property boot rejection, error-message enumeration oracle,
  per-backend uniqueness doc) all addressed.

## Relationship to `feat/jwt-principal-resolver`

That branch adds a `JWTPrincipalResolver` that cryptographically verifies an
OIDC-proxy JWT and stamps the verified `sub` as `Principal.User` — the
*authentication* half. This PR resolves that `Principal.User` to a graph entity
— the *authorization* half. They compose: JWT establishes *who*, this resolves
*who → which entity*. Both touch `internal/dataentry/router.go` but in different
functions (JWT adds a resolver; this modifies `attachACLRequest`), so whichever
merges second is a mechanical merge, not a logic conflict.

## Tests / CI

`go test ./...` green (incl. `-race`), `golangci-lint` 0 issues, `arch-lint`
clean (`acl` still doesn't import `metamodel`), `plimsoll` passes, coverage floors
satisfied (76.8%). Acceptance tests cover the 6 spec cases + unique constraint
(create/update/self/scoped/automation-set) + metamodel validation + the
middleware re-stamp.
