### PR TITLE
feat(search): close /_search match-on-hidden-field oracle (TKT-GGQ0JT)

### DIFF
--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -512,6 +512,21 @@ write form. When the hidden field is the entity's display property, the
 through the title. See [GUIDE-acl-overview] for how `visible:` grants
 are written.
 
+**Search cannot be a hidden-field oracle.** Redacting the response body
+is not enough on its own: the full-text index still contains a hidden
+property's text, so a query that matched *only* that property would
+otherwise return the entity as a hit and confirm the value by its mere
+presence (search a candidate postcode against a hidden address field →
+guess oracle). `/_search` closes this at the `VisibleSearcher` seam: each
+backend reports which fields a query matched (bleve with its own analyzer,
+Postgres by re-matching the candidate rows per field, the linear backend
+by substring), and a hit is **dropped** when every field it matched is one
+the principal may not see. A hit that also matched a *visible* field — or
+the id or content, which are never property-gated — still surfaces, with
+the hidden property redacted from its body. The property-level conformance
+suite (`storetest.RunVisibleFieldSearchTests`) pins this across all
+backends.
+
 ## What still leaks (deferred)
 
 - **`/api/v1/_position` per-id semantics** — `_position` is gated on
@@ -523,15 +538,6 @@ are written.
   neighbor-disclosure analysis (a visible neighbor's id confirms a
   visible entity, but gap analysis around hidden entities needs its
   own treatment).
-- **Search match-on-hidden-field oracle** — `/_search` redacts the
-  *body* of a `visible:`-hidden property, but the search index still
-  matches on its text. A query whose only match is a hidden field still
-  returns the entity as a hit, so its presence in the results confirms
-  the hidden value (e.g. searching a candidate postcode against a hidden
-  address field turns search into a guess oracle). Closing this — dropping
-  hits that matched only on a hidden field, at the `VisibleSearcher` seam
-  — is a tracked follow-up. Treat `visible:` as hiding values from view,
-  not as making them unguessable via search.
 - **MCP transport** — tracked as TKT-G3PPD. MCP read tools
   (`show_entity`, `list_entities`, `search_entities`, trace) apply
   neither the entity-level read gate nor `visible:` redaction; they
@@ -540,11 +546,11 @@ are written.
 
 For threat-modelling purposes today: per-entity GET, write, include,
 list, sidebar, pagination, global-search, and the SSE event stream are
-all read-gated (the SSE feed per-type, see above), and `visible:`
-redaction applies to every data-entry HTTP read body. The remaining
-read-side gaps are the MCP transport (TKT-G3PPD) and the search-oracle
-above; within the data-entry server every read channel a browser can
-reach is tight.
+all read-gated (the SSE feed per-type, see above); `visible:` redaction
+applies to every data-entry HTTP read body; and `/_search` cannot be
+used as a hidden-field oracle. The remaining read-side gap is the MCP
+transport (TKT-G3PPD); within the data-entry server every read channel a
+browser can reach is tight.
 
 ## Where to read next
 

--- a/docs-project/entities/guides/GUIDE-server-security.md
+++ b/docs-project/entities/guides/GUIDE-server-security.md
@@ -291,6 +291,11 @@ defense** in the server threat model.
   form. When the hidden field is the display property, the title
   falls back to the entity ID so the redacted value can't leak
   through `_title`.
+- ✅ **`/_search` is not a hidden-field oracle.** A search whose only
+  match is a `visible:`-hidden property drops the hit rather than
+  confirming the value by returning the entity; a hit that also matched
+  a visible field (or id/content) still surfaces, body redacted. See
+  [GUIDE-acl-security].
 - ✅ Group expansion (`member-of`, transitive) and inherited local
   roles (containment, via `inherit_roles_through`). Direct local
   roles are honored as well.
@@ -301,13 +306,6 @@ defense** in the server threat model.
   accepted gap at this stage, tracked as a follow-up. Do not expose
   the MCP transport to an untrusted caller while relying on `visible:`
   for confidentiality.
-- ❌ **Search match-on-hidden-field oracle.** `/_search` redacts the
-  *body* of a hidden property but the search index still matches on
-  its text, so a hit can confirm a hidden value's presence by
-  appearing in results (e.g. searching a candidate postcode). Closing
-  this — dropping hits that matched only on a hidden field — is a
-  tracked follow-up. Treat `visible:` as hiding values from view, not
-  as making them unguessable via search.
 - ❌ MCP transport intersection (filtering the tool list per principal) — deferred to a follow-up.
 
 > **`_actions` is a UI hint, not an authorization layer.** The

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -506,6 +506,21 @@ write form. When the hidden field is the entity's display property, the
 through the title. See [GUIDE-acl-overview] for how `visible:` grants
 are written.
 
+**Search cannot be a hidden-field oracle.** Redacting the response body
+is not enough on its own: the full-text index still contains a hidden
+property's text, so a query that matched *only* that property would
+otherwise return the entity as a hit and confirm the value by its mere
+presence (search a candidate postcode against a hidden address field →
+guess oracle). `/_search` closes this at the `VisibleSearcher` seam: each
+backend reports which fields a query matched (bleve with its own analyzer,
+Postgres by re-matching the candidate rows per field, the linear backend
+by substring), and a hit is **dropped** when every field it matched is one
+the principal may not see. A hit that also matched a *visible* field — or
+the id or content, which are never property-gated — still surfaces, with
+the hidden property redacted from its body. The property-level conformance
+suite (`storetest.RunVisibleFieldSearchTests`) pins this across all
+backends.
+
 ## What still leaks (deferred)
 
 - **`/api/v1/_position` per-id semantics** — `_position` is gated on
@@ -517,15 +532,6 @@ are written.
   neighbor-disclosure analysis (a visible neighbor's id confirms a
   visible entity, but gap analysis around hidden entities needs its
   own treatment).
-- **Search match-on-hidden-field oracle** — `/_search` redacts the
-  *body* of a `visible:`-hidden property, but the search index still
-  matches on its text. A query whose only match is a hidden field still
-  returns the entity as a hit, so its presence in the results confirms
-  the hidden value (e.g. searching a candidate postcode against a hidden
-  address field turns search into a guess oracle). Closing this — dropping
-  hits that matched only on a hidden field, at the `VisibleSearcher` seam
-  — is a tracked follow-up. Treat `visible:` as hiding values from view,
-  not as making them unguessable via search.
 - **MCP transport** — tracked as TKT-G3PPD. MCP read tools
   (`show_entity`, `list_entities`, `search_entities`, trace) apply
   neither the entity-level read gate nor `visible:` redaction; they
@@ -534,11 +540,11 @@ are written.
 
 For threat-modelling purposes today: per-entity GET, write, include,
 list, sidebar, pagination, global-search, and the SSE event stream are
-all read-gated (the SSE feed per-type, see above), and `visible:`
-redaction applies to every data-entry HTTP read body. The remaining
-read-side gaps are the MCP transport (TKT-G3PPD) and the search-oracle
-above; within the data-entry server every read channel a browser can
-reach is tight.
+all read-gated (the SSE feed per-type, see above); `visible:` redaction
+applies to every data-entry HTTP read body; and `/_search` cannot be
+used as a hidden-field oracle. The remaining read-side gap is the MCP
+transport (TKT-G3PPD); within the data-entry server every read channel a
+browser can reach is tight.
 
 ## Where to read next
 

--- a/docs/server-security.md
+++ b/docs/server-security.md
@@ -285,6 +285,11 @@ defense** in the server threat model.
   form. When the hidden field is the display property, the title
   falls back to the entity ID so the redacted value can't leak
   through `_title`.
+- ✅ **`/_search` is not a hidden-field oracle.** A search whose only
+  match is a `visible:`-hidden property drops the hit rather than
+  confirming the value by returning the entity; a hit that also matched
+  a visible field (or id/content) still surfaces, body redacted. See
+  [GUIDE-acl-security].
 - ✅ Group expansion (`member-of`, transitive) and inherited local
   roles (containment, via `inherit_roles_through`). Direct local
   roles are honored as well.
@@ -295,13 +300,6 @@ defense** in the server threat model.
   accepted gap at this stage, tracked as a follow-up. Do not expose
   the MCP transport to an untrusted caller while relying on `visible:`
   for confidentiality.
-- ❌ **Search match-on-hidden-field oracle.** `/_search` redacts the
-  *body* of a hidden property but the search index still matches on
-  its text, so a hit can confirm a hidden value's presence by
-  appearing in results (e.g. searching a candidate postcode). Closing
-  this — dropping hits that matched only on a hidden field — is a
-  tracked follow-up. Treat `visible:` as hiding values from view, not
-  as making them unguessable via search.
 - ❌ MCP transport intersection (filtering the tool list per principal) — deferred to a follow-up.
 
 > **`_actions` is a UI hint, not an authorization layer.** The

--- a/internal/dataentry/acl_search_fields_test.go
+++ b/internal/dataentry/acl_search_fields_test.go
@@ -1,0 +1,122 @@
+package dataentry
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// buildFieldPolicyApp wires ONE acl.Declarative as both the read gate (so a
+// granted type is entity-level visible) and the field resolver (so a `visible:`
+// block redacts a property). This is the combination the search-oracle fix
+// needs: the entity is readable, but one of its properties is hidden.
+func buildFieldPolicyApp(t *testing.T, aclYAML string) (*App, *acl.Declarative) {
+	t.Helper()
+	app := newTestAppV1(t)
+
+	var policy acl.Policy
+	if err := yaml.Unmarshal([]byte(aclYAML), &policy); err != nil {
+		t.Fatalf("unmarshal acl.yaml: %v", err)
+	}
+	d, err := acl.NewDeclarative(&policy, acl.NewStoreGraph(app.store), app.store)
+	if err != nil {
+		t.Fatalf("acl.NewDeclarative: %v", err)
+	}
+	resolver, err := affordances.New(app.Meta(), storeRelationLookup{st: app.store}, d)
+	if err != nil {
+		t.Fatalf("affordances.New: %v", err)
+	}
+	app.acl = d
+	app.fieldResolver = &policyResolver{inner: resolver}
+	return app, d
+}
+
+// TestACLSearch_HiddenFieldOracleClosed is the end-to-end payoff for
+// TKT-GGQ0JT: a principal who may READ a ticket but whose role hides the
+// ticket's `status` property must NOT be able to confirm a hidden status value
+// by searching for it. A search whose only match is the hidden property returns
+// nothing; a search matching a visible field still returns the ticket (with the
+// hidden property redacted from the body).
+//
+// `visible: {ticket: [title]}` is closed-world: only `title` is visible;
+// `status` is hidden. The status value "zeta777status" appears in no other
+// field, so a search for it can match only via the hidden property.
+func TestACLSearch_HiddenFieldOracleClosed(t *testing.T) {
+	const aclYAML = `
+roles:
+  viewer:
+    read: [ticket]
+    visible:
+      ticket:
+        - field: title
+assignments:
+  alice: viewer
+`
+	app, d := buildFieldPolicyApp(t, aclYAML)
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "alpha rocket", "status": "zeta777status"},
+	})
+
+	// Oracle probe: searching the hidden status value returns nothing.
+	resp, rec := searchAs(aliceCtx(), t, app, d, "zeta777status")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /_search zeta777status: %d %s", rec.Code, rec.Body)
+	}
+	if len(resp.Data) != 0 || resp.Meta.Total != 0 {
+		t.Errorf("hidden-field oracle: got %d hits (total %d), want 0 — search leaked a hidden property",
+			len(resp.Data), resp.Meta.Total)
+	}
+	if strings.Contains(rec.Body.String(), "zeta777status") {
+		t.Errorf("hidden status value leaked into the search body")
+	}
+
+	// Control: searching a visible field still returns the ticket, status redacted.
+	resp, rec = searchAs(aliceCtx(), t, app, d, "alpha")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /_search alpha: %d %s", rec.Code, rec.Body)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].ID != "TKT-001" {
+		t.Fatalf("visible-field search: got %d hits, want the ticket", len(resp.Data))
+	}
+	if strings.Contains(rec.Body.String(), "zeta777status") {
+		t.Errorf("hidden `status` value leaked in a visible-field hit's body")
+	}
+}
+
+// TestACLSearch_HiddenFieldVisibleToPrivilegedRole is the negative control: a
+// role that does NOT declare a `visible:` block for ticket leaves all fields
+// visible, so the same "zeta777" search DOES return the ticket. This proves the
+// drop in the previous test is caused by the visibility policy, not a bug that
+// swallows property matches wholesale.
+func TestACLSearch_HiddenFieldVisibleToPrivilegedRole(t *testing.T) {
+	const aclYAML = `
+roles:
+  admin:
+    read: ["*"]
+assignments:
+  alice: admin
+`
+	app, d := buildFieldPolicyApp(t, aclYAML)
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "alpha rocket", "status": "zeta777status"},
+	})
+
+	resp, rec := searchAs(aliceCtx(), t, app, d, "zeta777status")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /_search zeta777status: %d %s", rec.Code, rec.Body)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].ID != "TKT-001" {
+		t.Errorf("no visible: block → property visible → search should return the ticket; got %d hits",
+			len(resp.Data))
+	}
+}

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -752,6 +752,16 @@ func (v FieldVerdicts) IsOptionAllowed(name, opt string) bool {
 // phrase the check in the negative form.
 func (v FieldVerdicts) isHidden(name string) bool { return !v.IsVisible(name) }
 
+// hidesAnyField reports whether the active resolver can ever hide a property.
+// The Nop resolver returns empty verdicts for every entity, so field-level
+// redaction is a provable no-op under it; a policy-backed resolver may hide.
+// Search uses this to decide whether the property-level filter needs to run at
+// all (and thus whether a non-provenance searcher is acceptable).
+func (svc affordanceService) hidesAnyField() bool {
+	_, isNop := svc.resolver().(NopFieldVerdictResolver)
+	return !isNop
+}
+
 // hiddenProperties returns the set of property names that should be
 // stripped from v1.Entity.Properties before serialization. Caller uses
 // this to enforce the omit-on-hidden invariant.

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -490,7 +490,7 @@ func (a *App) runVisibleFreeTextSearch(
 		Limit: limit,
 	}
 	out := make([]*entity.Entity, 0)
-	for hit, err := range searchVisibleHits(ctx, a.visibleSearcher, a.affordances, svc, q, scope) {
+	for hit, err := range searchVisibleHits(ctx, a.visibleSearcher, a.affordances, q, scope) {
 		if err != nil {
 			if errors.Is(err, search.ErrScope) {
 				return nil, fmt.Errorf("%w: %w", errACLListQuery, err)
@@ -518,34 +518,32 @@ func (a *App) runVisibleFreeTextSearch(
 //
 // Free function (not an App method) to keep App's method surface under the
 // god-object load line; it takes only the two collaborators it needs.
+//
+// The field filter is engaged only when the resolver can actually hide a
+// property (a policy-backed resolver); under the Nop resolver redaction is a
+// provable no-op, so the plain entity-level path runs — and a searcher that
+// isn't a FieldVisibleSearcher is fine there. When redaction IS in play but the
+// searcher can't do it, SearchVisibleFields fails closed (it does not silently
+// skip) — see search.Visible.SearchVisibleFields.
 func searchVisibleHits(
 	ctx context.Context, vs search.VisibleSearcher, aff affordanceService,
-	svc Services, q search.Query, scope map[string]search.TypeScope,
+	q search.Query, scope map[string]search.TypeScope,
 ) iter.Seq2[search.Hit, error] {
 	fvs, ok := vs.(search.FieldVisibleSearcher)
-	if !ok {
+	if !ok || !aff.hidesAnyField() {
 		return vs.SearchVisible(ctx, q, scope)
 	}
-	return fvs.SearchVisibleFields(ctx, q, scope, hiddenSearchFields(svc, aff))
+	return fvs.SearchVisibleFields(ctx, q, scope, hiddenSearchFields(aff))
 }
 
 // hiddenSearchFields builds the [search.HiddenFieldsFunc] that reports, per
-// hit, the property fields the request principal may not see — resolved
-// through the same affordance verdict source the serializer uses, then
-// qualified into the search field vocabulary (`prop:<name>`). It loads the hit
-// entity (the resolver's `when:` predicates evaluate against it) and fails
-// closed: a load error hides all of the entity's declared properties rather
-// than risk leaking a hidden-only match.
-func hiddenSearchFields(svc Services, aff affordanceService) search.HiddenFieldsFunc {
-	return func(ctx context.Context, h search.Hit) (map[string]struct{}, error) {
-		e, err := svc.Store.GetEntity(ctx, h.ID)
-		if err != nil {
-			// Stale hit — the entity vanished between index query and this
-			// read. The seam's own found=false path drops it (fail closed),
-			// and the caller's GetEntity re-check skips it too, so an empty
-			// set here is safe: this hit does not reach the result.
-			return nil, nil //nolint:nilerr // stale hit is dropped downstream; not a hidden-fields failure
-		}
+// hit, the property fields the request principal may not see — resolved through
+// the same affordance verdict source the serializer uses, then qualified into
+// the search field vocabulary (`prop:<name>`). The seam passes the already-
+// loaded entity, so the resolver's `when:` predicates evaluate against the same
+// snapshot the provenance check uses (no second load, no cross-snapshot race).
+func hiddenSearchFields(aff affordanceService) search.HiddenFieldsFunc {
+	return func(ctx context.Context, _ search.Hit, e *entity.Entity) (map[string]struct{}, error) {
 		hidden := aff.hiddenProperties(ctx, e)
 		if len(hidden) == 0 {
 			return nil, nil

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"iter"
 	"regexp"
 	"slices"
 	"strconv"
@@ -489,7 +490,7 @@ func (a *App) runVisibleFreeTextSearch(
 		Limit: limit,
 	}
 	out := make([]*entity.Entity, 0)
-	for hit, err := range a.visibleSearcher.SearchVisible(ctx, q, scope) {
+	for hit, err := range a.searchVisibleHits(ctx, svc, q, scope) {
 		if err != nil {
 			if errors.Is(err, search.ErrScope) {
 				return nil, fmt.Errorf("%w: %w", errACLListQuery, err)
@@ -506,6 +507,51 @@ func (a *App) runVisibleFreeTextSearch(
 		out = append(out, e)
 	}
 	return out, nil
+}
+
+// searchVisibleHits runs the ACL-scoped search with property-level redaction
+// when the wired searcher supports it ([search.FieldVisibleSearcher]), so a hit
+// that matched only a `visible:`-hidden property is dropped rather than
+// confirming that property's value by its presence (the match-on-hidden-field
+// oracle, TKT-GGQ0JT). If the searcher is entity-level only, it degrades to
+// SearchVisible — no field redaction, matching pre-existing behavior.
+func (a *App) searchVisibleHits(
+	ctx context.Context, svc Services, q search.Query, scope map[string]search.TypeScope,
+) iter.Seq2[search.Hit, error] {
+	fvs, ok := a.visibleSearcher.(search.FieldVisibleSearcher)
+	if !ok {
+		return a.visibleSearcher.SearchVisible(ctx, q, scope)
+	}
+	return fvs.SearchVisibleFields(ctx, q, scope, a.hiddenSearchFields(svc))
+}
+
+// hiddenSearchFields builds the [search.HiddenFieldsFunc] that reports, per
+// hit, the property fields the request principal may not see — resolved
+// through the same affordance verdict source the serializer uses, then
+// qualified into the search field vocabulary (`prop:<name>`). It loads the hit
+// entity (the resolver's `when:` predicates evaluate against it) and fails
+// closed: a load error hides all of the entity's declared properties rather
+// than risk leaking a hidden-only match.
+func (a *App) hiddenSearchFields(svc Services) search.HiddenFieldsFunc {
+	return func(ctx context.Context, h search.Hit) (map[string]struct{}, error) {
+		e, err := svc.Store.GetEntity(ctx, h.ID)
+		if err != nil {
+			// Stale hit — the entity vanished between index query and this
+			// read. The seam's own found=false path drops it (fail closed),
+			// and the caller's GetEntity re-check skips it too, so an empty
+			// set here is safe: this hit does not reach the result.
+			return nil, nil //nolint:nilerr // stale hit is dropped downstream; not a hidden-fields failure
+		}
+		hidden := a.affordances.hiddenProperties(ctx, e)
+		if len(hidden) == 0 {
+			return nil, nil
+		}
+		out := make(map[string]struct{}, len(hidden))
+		for name := range hidden {
+			out[search.PropFieldPrefix+name] = struct{}{}
+		}
+		return out, nil
+	}
 }
 
 // visibleListByTypes is executeQuery's no-free-text branch: load

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -490,7 +490,7 @@ func (a *App) runVisibleFreeTextSearch(
 		Limit: limit,
 	}
 	out := make([]*entity.Entity, 0)
-	for hit, err := range a.searchVisibleHits(ctx, svc, q, scope) {
+	for hit, err := range searchVisibleHits(ctx, a.visibleSearcher, a.affordances, svc, q, scope) {
 		if err != nil {
 			if errors.Is(err, search.ErrScope) {
 				return nil, fmt.Errorf("%w: %w", errACLListQuery, err)
@@ -515,14 +515,18 @@ func (a *App) runVisibleFreeTextSearch(
 // confirming that property's value by its presence (the match-on-hidden-field
 // oracle, TKT-GGQ0JT). If the searcher is entity-level only, it degrades to
 // SearchVisible — no field redaction, matching pre-existing behavior.
-func (a *App) searchVisibleHits(
-	ctx context.Context, svc Services, q search.Query, scope map[string]search.TypeScope,
+//
+// Free function (not an App method) to keep App's method surface under the
+// god-object load line; it takes only the two collaborators it needs.
+func searchVisibleHits(
+	ctx context.Context, vs search.VisibleSearcher, aff affordanceService,
+	svc Services, q search.Query, scope map[string]search.TypeScope,
 ) iter.Seq2[search.Hit, error] {
-	fvs, ok := a.visibleSearcher.(search.FieldVisibleSearcher)
+	fvs, ok := vs.(search.FieldVisibleSearcher)
 	if !ok {
-		return a.visibleSearcher.SearchVisible(ctx, q, scope)
+		return vs.SearchVisible(ctx, q, scope)
 	}
-	return fvs.SearchVisibleFields(ctx, q, scope, a.hiddenSearchFields(svc))
+	return fvs.SearchVisibleFields(ctx, q, scope, hiddenSearchFields(svc, aff))
 }
 
 // hiddenSearchFields builds the [search.HiddenFieldsFunc] that reports, per
@@ -532,7 +536,7 @@ func (a *App) searchVisibleHits(
 // entity (the resolver's `when:` predicates evaluate against it) and fails
 // closed: a load error hides all of the entity's declared properties rather
 // than risk leaking a hidden-only match.
-func (a *App) hiddenSearchFields(svc Services) search.HiddenFieldsFunc {
+func hiddenSearchFields(svc Services, aff affordanceService) search.HiddenFieldsFunc {
 	return func(ctx context.Context, h search.Hit) (map[string]struct{}, error) {
 		e, err := svc.Store.GetEntity(ctx, h.ID)
 		if err != nil {
@@ -542,7 +546,7 @@ func (a *App) hiddenSearchFields(svc Services) search.HiddenFieldsFunc {
 			// set here is safe: this hit does not reach the result.
 			return nil, nil //nolint:nilerr // stale hit is dropped downstream; not a hidden-fields failure
 		}
-		hidden := a.affordances.hiddenProperties(ctx, e)
+		hidden := aff.hiddenProperties(ctx, e)
 		if len(hidden) == 0 {
 			return nil, nil
 		}

--- a/internal/search/bleveindex/fieldmatch.go
+++ b/internal/search/bleveindex/fieldmatch.go
@@ -3,6 +3,7 @@ package bleveindex
 import (
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/blevesearch/bleve/v2/analysis"
 	"github.com/blevesearch/bleve/v2/analysis/analyzer/standard"
@@ -77,16 +78,23 @@ func (idx *Index) MatchedFields(e *entity.Entity, text string) map[string]struct
 	return normalizeEmpty(out)
 }
 
-// textAnalyzer returns the standard analyzer used by the text fields in the
-// index mapping (see buildMapping). Nil if the registry cannot provide it —
-// callers fall back to the substring floor.
-func (idx *Index) textAnalyzer() analysis.Analyzer {
-	cache := registry.NewCache()
-	a, err := cache.AnalyzerNamed(standard.Name)
+// cachedStandardAnalyzer resolves the standard analyzer once for the process.
+// The standard analyzer is stateless and safe to share across goroutines, and
+// MatchedFields runs once per surviving hit — building a fresh registry cache
+// per call (the previous shape) was needless hot-path allocation. Nil when the
+// registry cannot provide it; callers fall back to the substring floor.
+var cachedStandardAnalyzer = sync.OnceValue(func() analysis.Analyzer {
+	a, err := registry.NewCache().AnalyzerNamed(standard.Name)
 	if err != nil {
 		return nil
 	}
 	return a
+})
+
+// textAnalyzer returns the standard analyzer used by the text fields in the
+// index mapping (see buildMapping).
+func (idx *Index) textAnalyzer() analysis.Analyzer {
+	return cachedStandardAnalyzer()
 }
 
 // analyzeTerms tokenizes text with the analyzer, lower-cased token terms.

--- a/internal/search/bleveindex/fieldmatch.go
+++ b/internal/search/bleveindex/fieldmatch.go
@@ -1,0 +1,173 @@
+package bleveindex
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/blevesearch/bleve/v2/analysis"
+	"github.com/blevesearch/bleve/v2/analysis/analyzer/standard"
+	"github.com/blevesearch/bleve/v2/registry"
+	blevesearch "github.com/blevesearch/bleve/v2/search"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/search"
+)
+
+// compile-time check: Index provides match provenance.
+var _ search.FieldMatcher = (*Index)(nil)
+
+// searchFuzziness mirrors the FuzzyQuery fuzziness used by Index.Search
+// (buildBoostedWordQuery). Keep the two in sync: a MatchedFields pass that is
+// LESS permissive than the query would drop a hit the query legitimately
+// surfaced from a visible field (a false drop). More permissive is safe.
+const searchFuzziness = 1
+
+// MatchedFields reports which logical fields of e the query text matched, using
+// the same standard analyzer and fuzzy/wildcard/prefix rules as Index.Search,
+// so the provenance is faithful to what the index would match. It answers per
+// field (id / content / prop:<name>) rather than over the concatenated blob,
+// which is what lets the ACL seam distinguish a visible-field hit from a
+// hidden-field hit within the same entity.
+//
+// Superset-safety: the result is UNIONED with a plain case-insensitive
+// substring pass ([search.MatchTextFields]) so it can never under-report
+// relative to the simplest possible match — the fuzzy/analyzer path only ever
+// ADDS fields. This upholds the FieldMatcher "never omit a matched field"
+// contract (no false drops), at the cost of occasionally reporting an extra
+// field (which only ever KEEPS a hit — safe).
+func (idx *Index) MatchedFields(e *entity.Entity, text string) map[string]struct{} {
+	if text == "" {
+		return nil
+	}
+
+	// Base: exact substring per field — the guaranteed floor.
+	out := search.MatchTextFields(e, text)
+	if out == nil {
+		out = make(map[string]struct{})
+	}
+
+	analyzer := idx.textAnalyzer()
+	if analyzer == nil {
+		return normalizeEmpty(out) // analyzer unavailable: substring floor only
+	}
+
+	queryTokens := analyzeTerms(analyzer, text)
+	rawTerms := strings.Fields(strings.ToLower(text))
+
+	// content
+	if fieldTextMatches(analyzer, e.Content, queryTokens, rawTerms) {
+		out[search.FieldContent] = struct{}{}
+	}
+	// id: keyword-analyzed in the index (case-sensitive prefix/exact), so match
+	// the raw id against the raw query, mirroring the idExact/idPrefix queries.
+	if idMatches(e.ID, strings.TrimSpace(text)) {
+		out[search.FieldID] = struct{}{}
+	}
+	// properties: per-property, so a hidden prop's match is distinguishable.
+	for name, v := range e.Properties {
+		s, ok := v.(string)
+		if !ok || s == "" {
+			continue
+		}
+		if fieldTextMatches(analyzer, s, queryTokens, rawTerms) {
+			out[search.PropFieldPrefix+name] = struct{}{}
+		}
+	}
+
+	return normalizeEmpty(out)
+}
+
+// textAnalyzer returns the standard analyzer used by the text fields in the
+// index mapping (see buildMapping). Nil if the registry cannot provide it —
+// callers fall back to the substring floor.
+func (idx *Index) textAnalyzer() analysis.Analyzer {
+	cache := registry.NewCache()
+	a, err := cache.AnalyzerNamed(standard.Name)
+	if err != nil {
+		return nil
+	}
+	return a
+}
+
+// analyzeTerms tokenizes text with the analyzer, lower-cased token terms.
+func analyzeTerms(a analysis.Analyzer, text string) []string {
+	stream := a.Analyze([]byte(text))
+	terms := make([]string, 0, len(stream))
+	for _, tok := range stream {
+		terms = append(terms, string(tok.Term))
+	}
+	return terms
+}
+
+// fieldTextMatches reports whether the field value matches the query under the
+// same rules Index.Search applies to text fields: a fuzzy (edit-distance
+// searchFuzziness) or wildcard token match. rawTerms carries the un-analyzed
+// query words for wildcard handling (wildcards aren't analyzer tokens).
+func fieldTextMatches(a analysis.Analyzer, fieldValue string, queryTokens, rawTerms []string) bool {
+	fieldTokens := analyzeTerms(a, fieldValue)
+	if len(fieldTokens) == 0 {
+		return false
+	}
+	fieldSet := make(map[string]struct{}, len(fieldTokens))
+	for _, ft := range fieldTokens {
+		fieldSet[ft] = struct{}{}
+	}
+
+	for _, qt := range queryTokens {
+		if _, exact := fieldSet[qt]; exact {
+			return true
+		}
+		for ft := range fieldSet {
+			if withinEditDistance(qt, ft, searchFuzziness) {
+				return true
+			}
+		}
+	}
+	// Wildcards operate on the raw (pre-analysis) term against field tokens.
+	for _, rt := range rawTerms {
+		if !strings.ContainsAny(rt, "*?") {
+			continue
+		}
+		for ft := range fieldSet {
+			if wildcardMatch(rt, ft) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// idMatches mirrors the keyword-analyzed id field: case-sensitive exact or
+// prefix match of the raw query against the raw id.
+func idMatches(id, rawQuery string) bool {
+	if rawQuery == "" {
+		return false
+	}
+	return id == rawQuery || strings.HasPrefix(id, rawQuery)
+}
+
+// withinEditDistance reports whether a and b are within max edits, using
+// bleve's own Levenshtein so the fuzzy match agrees with the index FuzzyQuery.
+//
+// LevenshteinDistanceMax returns (distance, exceededMax): the bool is true when
+// the computation short-circuited because the distance is GREATER than max, so
+// "within" means NOT exceeded and distance ≤ max.
+func withinEditDistance(a, b string, maxDist int) bool {
+	dist, exceeded := blevesearch.LevenshteinDistanceMax(a, b, maxDist)
+	return !exceeded && dist <= maxDist
+}
+
+// wildcardMatch reports whether a `*`/`?` pattern matches a token, mirroring
+// the index WildcardQuery. filepath.Match's glob semantics (`*` any run, `?`
+// one char) match bleve's wildcard operators for the single-token case.
+func wildcardMatch(pattern, token string) bool {
+	ok, err := filepath.Match(pattern, token)
+	return err == nil && ok
+}
+
+func normalizeEmpty(m map[string]struct{}) map[string]struct{} {
+	if len(m) == 0 {
+		return nil
+	}
+	return m
+}

--- a/internal/search/filter.go
+++ b/internal/search/filter.go
@@ -81,6 +81,23 @@ func MatchFilters(e *entity.Entity, filters []PropertyFilter) bool {
 	return true
 }
 
+// Logical field names reported by match-provenance (see [MatchTextFields]).
+// These form the vocabulary a [VisibleSearcher] intersects against a
+// principal's visible-field set to close the match-on-hidden-field oracle.
+//
+//   - FieldID / FieldContent name the entity ID and body. Neither is ever
+//     property-visibility-gated (only declared properties carry a `visible:`
+//     grant), so a hit that matched on either always survives.
+//   - PropFieldPrefix + the property name identifies a property match, e.g.
+//     "prop:internal_notes". The suffix is the raw property key — the same
+//     key space the affordance resolver's Visible map uses — so the consumer
+//     can intersect the two sets directly.
+const (
+	FieldID         = "id"
+	FieldContent    = "content"
+	PropFieldPrefix = "prop:"
+)
+
 // MatchText returns true if any of the entity's ID, content, or string
 // properties contain the search text (case-insensitive).
 func MatchText(e *entity.Entity, text string) bool {
@@ -97,4 +114,37 @@ func MatchText(e *entity.Entity, text string) bool {
 		}
 	}
 	return false
+}
+
+// MatchTextFields reports which logical fields of e the search text matches,
+// using the same case-insensitive substring rule as [MatchText]. It is the
+// ground-truth provenance implementation: the [FieldMatcher] every backend
+// exposes must agree with it on the visible-field projection (pinned by
+// storetest.RunVisibleSearchTests).
+//
+// Field names follow the [FieldID] / [FieldContent] / [PropFieldPrefix]
+// vocabulary. The returned set is nil when nothing matches (mirroring
+// MatchText returning false). Non-string properties never match (only string
+// values are indexed), matching MatchText and both native backends.
+func MatchTextFields(e *entity.Entity, text string) map[string]struct{} {
+	lower := strings.ToLower(text)
+	var fields map[string]struct{}
+	add := func(name string) {
+		if fields == nil {
+			fields = make(map[string]struct{})
+		}
+		fields[name] = struct{}{}
+	}
+	if strings.Contains(strings.ToLower(e.ID), lower) {
+		add(FieldID)
+	}
+	if strings.Contains(strings.ToLower(e.Content), lower) {
+		add(FieldContent)
+	}
+	for name, v := range e.Properties {
+		if s, ok := v.(string); ok && strings.Contains(strings.ToLower(s), lower) {
+			add(PropFieldPrefix + name)
+		}
+	}
+	return fields
 }

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"iter"
 
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -27,29 +28,24 @@ func New(reader store.EntityReader, backend Backend) *Service {
 	return &Service{reader: reader, backend: backend}
 }
 
-// MatchedFields reports which logical fields of the entity with the given id
-// the query text matched, in the [FieldID] / [FieldContent] / [PropFieldPrefix]
+// MatchedFields reports which logical fields of the already-loaded entity the
+// query text matched, in the [FieldID] / [FieldContent] / [PropFieldPrefix]
 // vocabulary. It delegates to the backend's [FieldMatcher] when the backend
 // implements one, so provenance is computed with the same matcher the backend
-// searched with; otherwise it falls back to the ground-truth [MatchTextFields]
-// over the loaded entity.
+// searched with; otherwise it falls back to the ground-truth [MatchTextFields].
 //
-// The (found=false) return means the entity could not be loaded (deleted since
-// indexing) — the caller treats that as "no provenance available". An empty
-// text query matches everything and has no field provenance, so it returns an
-// empty set with found=true.
-func (s *Service) MatchedFields(ctx context.Context, id, text string) (fields map[string]struct{}, found bool) {
-	e, err := s.reader.GetEntity(ctx, id)
-	if err != nil {
-		return nil, false
-	}
-	if text == "" {
-		return nil, true
+// It takes the entity rather than loading it so the seam can thread a single
+// snapshot through both provenance and the hidden-field verdict (no
+// re-load, no cross-snapshot race). An empty text query has no provenance and
+// returns nil.
+func (s *Service) MatchedFields(e *entity.Entity, text string) map[string]struct{} {
+	if e == nil || text == "" {
+		return nil
 	}
 	if fm, ok := s.backend.(FieldMatcher); ok {
-		return fm.MatchedFields(e, text), true
+		return fm.MatchedFields(e, text)
 	}
-	return MatchTextFields(e, text), true
+	return MatchTextFields(e, text)
 }
 
 func (s *Service) Search(ctx context.Context, q Query) iter.Seq2[Hit, error] {

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -27,6 +27,31 @@ func New(reader store.EntityReader, backend Backend) *Service {
 	return &Service{reader: reader, backend: backend}
 }
 
+// MatchedFields reports which logical fields of the entity with the given id
+// the query text matched, in the [FieldID] / [FieldContent] / [PropFieldPrefix]
+// vocabulary. It delegates to the backend's [FieldMatcher] when the backend
+// implements one, so provenance is computed with the same matcher the backend
+// searched with; otherwise it falls back to the ground-truth [MatchTextFields]
+// over the loaded entity.
+//
+// The (found=false) return means the entity could not be loaded (deleted since
+// indexing) — the caller treats that as "no provenance available". An empty
+// text query matches everything and has no field provenance, so it returns an
+// empty set with found=true.
+func (s *Service) MatchedFields(ctx context.Context, id, text string) (fields map[string]struct{}, found bool) {
+	e, err := s.reader.GetEntity(ctx, id)
+	if err != nil {
+		return nil, false
+	}
+	if text == "" {
+		return nil, true
+	}
+	if fm, ok := s.backend.(FieldMatcher); ok {
+		return fm.MatchedFields(e, text), true
+	}
+	return MatchTextFields(e, text), true
+}
+
 func (s *Service) Search(ctx context.Context, q Query) iter.Seq2[Hit, error] {
 	if err := ValidateFilters(q.Filters); err != nil {
 		return func(yield func(Hit, error) bool) {

--- a/internal/search/linearsearch.go
+++ b/internal/search/linearsearch.go
@@ -93,6 +93,17 @@ func (l *LinearSearch) Search(text string, limit int) ([]string, error) {
 	return ids, nil
 }
 
+// MatchedFields reports which logical fields of e the query text matched.
+// LinearSearch's matcher IS [MatchTextFields] (plain case-insensitive
+// substring), so this is the ground-truth provenance the conformance suite
+// checks the other backends against.
+func (l *LinearSearch) MatchedFields(e *entity.Entity, text string) map[string]struct{} {
+	return MatchTextFields(e, text)
+}
+
+// compile-time check: LinearSearch reports match provenance.
+var _ FieldMatcher = (*LinearSearch)(nil)
+
 func (l *LinearSearch) Close() error {
 	return nil
 }

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -66,11 +66,16 @@ type FieldMatcher interface {
 // or a policy, exactly as with the scope map). A nil func, or a func that
 // returns an empty set, disables field-level filtering for that hit.
 //
-// It receives the Hit (ID + Type), not the full entity: the consumer holds
-// the store and the affordance resolver and loads what it needs. Returning an
-// error fails closed — the hit is dropped and the error surfaced — so an ACL
-// resolution failure can never widen visibility.
-type HiddenFieldsFunc func(ctx context.Context, h Hit) (map[string]struct{}, error)
+// It receives the ALREADY-LOADED entity, not just the Hit: the seam loads the
+// entity once and threads that single snapshot through both the hidden-field
+// computation and the match-provenance computation, so a concurrent write
+// cannot make the two observe different states (the fail-closed decision is
+// snapshot-consistent — CLAUDE.md "capture state once per operation"). The
+// consumer resolves its ACL verdict against this exact entity (the resolver's
+// `when:` predicates evaluate against it). Returning an error fails closed —
+// the hit is dropped and the error surfaced — so an ACL resolution failure can
+// never widen visibility.
+type HiddenFieldsFunc func(ctx context.Context, h Hit, e *entity.Entity) (map[string]struct{}, error)
 
 // WildcardType is the reserved scope-map key that supplies the default
 // verdict for entity types without an explicit entry. It cannot collide

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"iter"
 
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -36,6 +37,40 @@ type Backend interface {
 	// limit ≤ 0 means no limit.
 	Search(text string, limit int) ([]string, error)
 }
+
+// FieldMatcher is the optional match-provenance capability a Backend may
+// implement. MatchedFields reports, for a single already-loaded entity and
+// the same query text, which logical fields the match came from — using the
+// [FieldID] / [FieldContent] / [PropFieldPrefix] vocabulary and the backend's
+// OWN matcher, so provenance stays faithful to what Search actually matched.
+//
+// It answers per-entity (not per-corpus) because it runs only over the
+// candidate set the coarse Search already produced: the seam re-asks "which
+// fields?" for each surviving hit. A backend that cannot cheaply reproduce its
+// own per-field matching may leave this unimplemented; the field-visibility
+// filter then degrades (see [Visible.SearchVisibleFields]).
+//
+// The returned set must be a SUPERSET-safe approximation of the true match:
+// it may report an extra field, but must not omit a field the coarse Search
+// genuinely matched on — omitting one could drop a hit the principal was
+// entitled to see (a false drop). When in doubt, report the field.
+type FieldMatcher interface {
+	Backend
+	MatchedFields(e *entity.Entity, text string) map[string]struct{}
+}
+
+// HiddenFieldsFunc reports, for one hit, the set of property fields the
+// requesting principal may NOT see — in the [PropFieldPrefix]-qualified
+// vocabulary (e.g. "prop:internal_notes"). It is supplied by the consumer,
+// which resolves the ACL verdict (the search package never sees a principal
+// or a policy, exactly as with the scope map). A nil func, or a func that
+// returns an empty set, disables field-level filtering for that hit.
+//
+// It receives the Hit (ID + Type), not the full entity: the consumer holds
+// the store and the affordance resolver and loads what it needs. Returning an
+// error fails closed — the hit is dropped and the error surfaced — so an ACL
+// resolution failure can never widen visibility.
+type HiddenFieldsFunc func(ctx context.Context, h Hit) (map[string]struct{}, error)
 
 // WildcardType is the reserved scope-map key that supplies the default
 // verdict for entity types without an explicit entry. It cannot collide
@@ -104,6 +139,24 @@ func ResolveTypeScope(scope map[string]TypeScope, entityType string) (TypeScope,
 // composing visibility into the search query itself.
 type VisibleSearcher interface {
 	SearchVisible(ctx context.Context, q Query, scope map[string]TypeScope) iter.Seq2[Hit, error]
+}
+
+// FieldVisibleSearcher is VisibleSearcher extended with property-level
+// redaction: SearchVisibleFields additionally drops any hit whose text matched
+// ONLY fields the principal may not see (per the consumer's HiddenFieldsFunc),
+// closing the match-on-hidden-field oracle. A hit that matched a visible
+// property — or the id/content, never property-gated — always survives.
+//
+// It layers on top of SearchVisible's entity-level scope: entity-level
+// filtering runs first, then the field filter over the survivors. Both the
+// generic wrapper ([Visible]) and the pgstore-native store implement it. A
+// consumer that needs field redaction for confidentiality must wire a
+// FieldVisibleSearcher, not a bare VisibleSearcher.
+type FieldVisibleSearcher interface {
+	VisibleSearcher
+	SearchVisibleFields(
+		ctx context.Context, q Query, scope map[string]TypeScope, hidden HiddenFieldsFunc,
+	) iter.Seq2[Hit, error]
 }
 
 // ErrScope marks a SearchVisible failure that occurred while evaluating

--- a/internal/search/visible.go
+++ b/internal/search/visible.go
@@ -9,6 +9,14 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
+// fieldProvenance reports which logical fields the query text matched for a
+// given hit id. [Service] implements it; Visible takes the narrow interface so
+// it stays decoupled from the concrete searcher. (found=false → the entity
+// could not be loaded; treat as no provenance.)
+type fieldProvenance interface {
+	MatchedFields(ctx context.Context, id, text string) (fields map[string]struct{}, found bool)
+}
+
 // Visible is the generic VisibleSearcher: it wraps any Searcher and
 // filters its hits through a store.GraphQueryer. This is the
 // implementation for the simple backends (bleve, LinearSearch), which
@@ -23,13 +31,23 @@ import (
 type Visible struct {
 	inner Searcher
 	gq    store.GraphQueryer
+	// prov is the optional match-provenance source used by
+	// SearchVisibleFields; nil disables field-level filtering (entity-level
+	// only). Set when inner also satisfies fieldProvenance (the Service case).
+	prov fieldProvenance
 }
 
-// compile-time check
-var _ VisibleSearcher = (*Visible)(nil)
+// compile-time checks
+var (
+	_ VisibleSearcher      = (*Visible)(nil)
+	_ FieldVisibleSearcher = (*Visible)(nil)
+)
 
 // NewVisible builds the generic scope-filtering wrapper around an
-// existing searcher and the store's graph-query capability.
+// existing searcher and the store's graph-query capability. When inner also
+// reports match provenance (a *Service does), the field-visibility filter in
+// SearchVisibleFields is enabled; otherwise that method degrades to
+// entity-level filtering only.
 func NewVisible(inner Searcher, gq store.GraphQueryer) (*Visible, error) {
 	if inner == nil {
 		return nil, errors.New("search.NewVisible: inner Searcher is required")
@@ -37,7 +55,11 @@ func NewVisible(inner Searcher, gq store.GraphQueryer) (*Visible, error) {
 	if gq == nil {
 		return nil, errors.New("search.NewVisible: GraphQueryer is required")
 	}
-	return &Visible{inner: inner, gq: gq}, nil
+	v := &Visible{inner: inner, gq: gq}
+	if p, ok := inner.(fieldProvenance); ok {
+		v.prov = p
+	}
+	return v, nil
 }
 
 func (v *Visible) SearchVisible(
@@ -60,6 +82,88 @@ func (v *Visible) SearchVisible(
 			emitted++
 		}
 	}
+}
+
+// SearchVisibleFields is SearchVisible plus property-level redaction of the
+// search oracle: after entity-level scoping, a hit is dropped when every field
+// its text matched is one the principal may not see (hidden per the consumer's
+// HiddenFieldsFunc). A hit that matched a visible property — or matched the id
+// or content, which are never property-gated — always survives. This closes
+// the match-on-hidden-field oracle (a search that matched only a redacted
+// property must not confirm that property's value by returning the entity).
+//
+// hidden is supplied by the consumer (the search package never sees a
+// principal). A nil hidden func, or one returning an empty set, leaves the hit
+// unaffected. Errors from hidden fail closed: the hit is dropped and the error
+// surfaced, so an ACL resolution failure never widens visibility.
+//
+// When this Visible has no provenance source (inner is not a *Service), the
+// field filter cannot run; the method degrades to entity-level SearchVisible.
+// Callers that rely on field redaction for confidentiality must wire a
+// provenance-capable searcher — enforced at the composition root, documented
+// in the ACL security guide.
+func (v *Visible) SearchVisibleFields(
+	ctx context.Context, q Query, scope map[string]TypeScope, hidden HiddenFieldsFunc,
+) iter.Seq2[Hit, error] {
+	return func(yield func(Hit, error) bool) {
+		hits, err := v.visibleHits(ctx, q, scope)
+		if err != nil {
+			yield(Hit{}, err)
+			return
+		}
+		emitted := 0
+		for _, h := range hits {
+			if q.Limit > 0 && emitted >= q.Limit {
+				return
+			}
+			keep, err := v.fieldVisible(ctx, q, h, hidden)
+			if err != nil {
+				yield(Hit{}, err)
+				return
+			}
+			if !keep {
+				continue // matched only on hidden fields — drop (oracle closed)
+			}
+			if !yield(h, nil) {
+				return
+			}
+			emitted++
+		}
+	}
+}
+
+// fieldVisible decides whether hit h survives the property-level filter. It
+// returns true (keep) when field filtering does not apply — no hidden func, no
+// provenance source, no text query, or an empty hidden set — and otherwise
+// keeps the hit only if at least one matched field is NOT hidden.
+//
+// Fail-closed points: a hidden-func error drops the hit (returns the error);
+// and if the principal hides some fields but provenance is unavailable (entity
+// vanished, or a non-provenance backend), the hit is dropped rather than
+// risk leaking a hidden-only match.
+func (v *Visible) fieldVisible(ctx context.Context, q Query, h Hit, hidden HiddenFieldsFunc) (bool, error) {
+	if hidden == nil || v.prov == nil || q.Text == "" {
+		return true, nil
+	}
+	hiddenFields, err := hidden(ctx, h)
+	if err != nil {
+		return false, fmt.Errorf("%w: hidden-fields for %q: %w", ErrScope, h.ID, err)
+	}
+	if len(hiddenFields) == 0 {
+		return true, nil // nothing hidden for this principal on this hit
+	}
+	matched, found := v.prov.MatchedFields(ctx, h.ID, q.Text)
+	if !found {
+		// Entity unavailable: cannot prove the match came from a visible
+		// field, so fail closed rather than leak a possible hidden-only match.
+		return false, nil
+	}
+	for f := range matched {
+		if _, isHidden := hiddenFields[f]; !isHidden {
+			return true, nil // at least one visible field matched — keep
+		}
+	}
+	return false, nil // every matched field is hidden — drop
 }
 
 // visibleHits collects the full candidate stream and drops every hit

--- a/internal/search/visible.go
+++ b/internal/search/visible.go
@@ -6,15 +6,17 @@ import (
 	"fmt"
 	"iter"
 
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
-// fieldProvenance reports which logical fields the query text matched for a
-// given hit id. [Service] implements it; Visible takes the narrow interface so
-// it stays decoupled from the concrete searcher. (found=false → the entity
-// could not be loaded; treat as no provenance.)
-type fieldProvenance interface {
-	MatchedFields(ctx context.Context, id, text string) (fields map[string]struct{}, found bool)
+// fieldMatchProvenance reports which logical fields the query text matched for
+// an ALREADY-LOADED entity. [Service] implements it (delegating to the backend
+// FieldMatcher, else the ground-truth substring matcher). Taking the entity —
+// not an id — means the seam loads it once and both the provenance and the
+// hidden-field verdict see the same snapshot.
+type fieldMatchProvenance interface {
+	MatchedFields(e *entity.Entity, text string) map[string]struct{}
 }
 
 // Visible is the generic VisibleSearcher: it wraps any Searcher and
@@ -29,12 +31,15 @@ type fieldProvenance interface {
 // get their true top-K; beyond it the bound is documented in the ACL
 // security guide.
 type Visible struct {
-	inner Searcher
-	gq    store.GraphQueryer
-	// prov is the optional match-provenance source used by
-	// SearchVisibleFields; nil disables field-level filtering (entity-level
-	// only). Set when inner also satisfies fieldProvenance (the Service case).
-	prov fieldProvenance
+	inner  Searcher
+	gq     store.GraphQueryer
+	reader store.EntityReader
+	// prov is the match-provenance source used by SearchVisibleFields; set
+	// when inner satisfies fieldMatchProvenance (the Service case). When nil,
+	// SearchVisibleFields FAILS CLOSED (yields ErrScope) rather than silently
+	// skipping field redaction — a missing provenance source is a wiring bug,
+	// not a reason to leak.
+	prov fieldMatchProvenance
 }
 
 // compile-time checks
@@ -44,10 +49,15 @@ var (
 )
 
 // NewVisible builds the generic scope-filtering wrapper around an
-// existing searcher and the store's graph-query capability. When inner also
-// reports match provenance (a *Service does), the field-visibility filter in
-// SearchVisibleFields is enabled; otherwise that method degrades to
-// entity-level filtering only.
+// existing searcher and the store's graph-query capability. inner must also
+// satisfy [store.EntityReader] and (for the field-visibility filter) report
+// match provenance — a *Service does both. A non-provenance inner does not
+// disable field redaction silently: SearchVisibleFields fails closed on it (a
+// consumer that never calls SearchVisibleFields is unaffected).
+//
+// The reader defaults to inner when inner is a store.EntityReader; pass a
+// distinct reader only in tests. Requiring the reader here means the single
+// snapshot load lives at the seam, not in each consumer.
 func NewVisible(inner Searcher, gq store.GraphQueryer) (*Visible, error) {
 	if inner == nil {
 		return nil, errors.New("search.NewVisible: inner Searcher is required")
@@ -55,8 +65,12 @@ func NewVisible(inner Searcher, gq store.GraphQueryer) (*Visible, error) {
 	if gq == nil {
 		return nil, errors.New("search.NewVisible: GraphQueryer is required")
 	}
-	v := &Visible{inner: inner, gq: gq}
-	if p, ok := inner.(fieldProvenance); ok {
+	reader, ok := gq.(store.EntityReader)
+	if !ok {
+		return nil, errors.New("search.NewVisible: GraphQueryer must also be a store.EntityReader")
+	}
+	v := &Visible{inner: inner, gq: gq, reader: reader}
+	if p, ok := inner.(fieldMatchProvenance); ok {
 		v.prov = p
 	}
 	return v, nil
@@ -97,15 +111,20 @@ func (v *Visible) SearchVisible(
 // unaffected. Errors from hidden fail closed: the hit is dropped and the error
 // surfaced, so an ACL resolution failure never widens visibility.
 //
-// When this Visible has no provenance source (inner is not a *Service), the
-// field filter cannot run; the method degrades to entity-level SearchVisible.
-// Callers that rely on field redaction for confidentiality must wire a
-// provenance-capable searcher — enforced at the composition root, documented
-// in the ACL security guide.
+// If a hidden func is supplied but this Visible has no provenance source
+// (inner is not a *Service), the method FAILS CLOSED — it yields ErrScope
+// rather than silently returning un-redacted hits. A missing provenance source
+// is a wiring bug (a Searcher wrapped so the type assertion in NewVisible
+// misses), and silently skipping redaction is exactly the oracle this closes.
 func (v *Visible) SearchVisibleFields(
 	ctx context.Context, q Query, scope map[string]TypeScope, hidden HiddenFieldsFunc,
 ) iter.Seq2[Hit, error] {
 	return func(yield func(Hit, error) bool) {
+		if hidden != nil && q.Text != "" && v.prov == nil {
+			yield(Hit{}, fmt.Errorf(
+				"%w: field-visibility requested but the searcher reports no match provenance", ErrScope))
+			return
+		}
 		hits, err := v.visibleHits(ctx, q, scope)
 		if err != nil {
 			yield(Hit{}, err)
@@ -133,37 +152,56 @@ func (v *Visible) SearchVisibleFields(
 }
 
 // fieldVisible decides whether hit h survives the property-level filter. It
-// returns true (keep) when field filtering does not apply — no hidden func, no
-// provenance source, no text query, or an empty hidden set — and otherwise
-// keeps the hit only if at least one matched field is NOT hidden.
+// returns true (keep) when field filtering does not apply — no hidden func or
+// no text query — and otherwise keeps the hit only if at least one matched
+// field is NOT hidden.
 //
-// Fail-closed points: a hidden-func error drops the hit (returns the error);
-// and if the principal hides some fields but provenance is unavailable (entity
-// vanished, or a non-provenance backend), the hit is dropped rather than
-// risk leaking a hidden-only match.
+// The entity is loaded ONCE here and threaded through BOTH the hidden-field
+// verdict and the match-provenance computation, so a concurrent write cannot
+// make the two observe different snapshots (fail-closed stays snapshot-
+// consistent). Fail-closed points: a stale/missing entity drops the hit (a
+// deleted-but-still-indexed candidate cannot prove a visible-field match); a
+// hidden-func error drops the hit and surfaces the error.
 func (v *Visible) fieldVisible(ctx context.Context, q Query, h Hit, hidden HiddenFieldsFunc) (bool, error) {
-	if hidden == nil || v.prov == nil || q.Text == "" {
+	if hidden == nil || q.Text == "" {
 		return true, nil
 	}
-	hiddenFields, err := hidden(ctx, h)
+	e, err := v.reader.GetEntity(ctx, h.ID)
 	if err != nil {
-		return false, fmt.Errorf("%w: hidden-fields for %q: %w", ErrScope, h.ID, err)
+		// Stale hit: entity vanished between indexing and now. Cannot prove the
+		// match came from a visible field → drop (fail closed).
+		return false, nil //nolint:nilerr // stale index hit is dropped, not an error
+	}
+	hiddenFields, herr := hidden(ctx, h, e)
+	if herr != nil {
+		return false, fmt.Errorf("%w: hidden-fields for %q: %w", ErrScope, h.ID, herr)
 	}
 	if len(hiddenFields) == 0 {
 		return true, nil // nothing hidden for this principal on this hit
 	}
-	matched, found := v.prov.MatchedFields(ctx, h.ID, q.Text)
-	if !found {
-		// Entity unavailable: cannot prove the match came from a visible
-		// field, so fail closed rather than leak a possible hidden-only match.
-		return false, nil
-	}
+	matched := v.prov.MatchedFields(e, q.Text)
+	return MatchHasVisibleField(matched, hiddenFields), nil
+}
+
+// MatchHasVisibleField reports whether at least one matched field is NOT in the
+// hidden set — i.e. the hit matched something the principal may see, so it must
+// survive. [FieldID] and [FieldContent] are never property-gated, so a match on
+// either always counts as visible regardless of the hidden set: this guards the
+// documented never-gated invariant even if a caller mis-supplies "id"/"content"
+// in the hidden set (a false drop would silently vanish an entity from search).
+//
+// Shared by the generic and pgstore-native filters so both apply the invariant
+// identically (conformance-pinned).
+func MatchHasVisibleField(matched, hidden map[string]struct{}) bool {
 	for f := range matched {
-		if _, isHidden := hiddenFields[f]; !isHidden {
-			return true, nil // at least one visible field matched — keep
+		if f == FieldID || f == FieldContent {
+			return true
+		}
+		if _, isHidden := hidden[f]; !isHidden {
+			return true
 		}
 	}
-	return false, nil // every matched field is hidden — drop
+	return false
 }
 
 // visibleHits collects the full candidate stream and drops every hit

--- a/internal/search/visible_test.go
+++ b/internal/search/visible_test.go
@@ -1,10 +1,14 @@
 package search_test
 
 import (
+	"context"
+	"errors"
+	"iter"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/search/bleveindex"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -72,5 +76,60 @@ func TestNewVisible_RejectsNil(t *testing.T) {
 	}
 	if _, err := search.NewVisible(searcher, nil); err == nil {
 		t.Error("nil GraphQueryer accepted")
+	}
+}
+
+// nonProvenanceSearcher wraps a Searcher WITHOUT forwarding match provenance —
+// standing in for any decorator (metrics, caching, tracing) that a future
+// refactor might slip between the Service and NewVisible. It must NOT satisfy
+// the unexported fieldMatchProvenance interface.
+type nonProvenanceSearcher struct{ inner search.Searcher }
+
+func (n nonProvenanceSearcher) Search(ctx context.Context, q search.Query) iter.Seq2[search.Hit, error] {
+	return n.inner.Search(ctx, q)
+}
+
+// TestSearchVisibleFields_FailsClosedWithoutProvenance is the regression guard
+// for the reviewer's finding #1: if the wired searcher can't report match
+// provenance, SearchVisibleFields must FAIL CLOSED (yield ErrScope), never
+// silently return un-redacted hits. A wrapped Service loses the provenance
+// type assertion — this proves that path errors instead of leaking.
+func TestSearchVisibleFields_FailsClosedWithoutProvenance(t *testing.T) {
+	s := memstore.New()
+	e := entity.New("TKT-1", "ticket")
+	e.SetString("title", "alpha rocket")
+	e.SetString("code", "zeta777")
+	if err := s.CreateEntity(context.Background(), e); err != nil {
+		t.Fatal(err)
+	}
+	ls := search.NewLinearSearch()
+	_ = ls.EntityPut(e)
+
+	wrapped := nonProvenanceSearcher{inner: search.New(s, ls)}
+	v, err := search.NewVisible(wrapped, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hide := func(_ context.Context, _ search.Hit, _ *entity.Entity) (map[string]struct{}, error) {
+		return map[string]struct{}{search.PropFieldPrefix + "code": {}}, nil
+	}
+	scope := map[string]search.TypeScope{"ticket": {AllowAll: true}}
+
+	var streamErr error
+	hits := 0
+	for _, iterErr := range v.SearchVisibleFields(
+		context.Background(), search.Query{Text: "zeta777"}, scope, hide) {
+		if iterErr != nil {
+			streamErr = iterErr
+			break
+		}
+		hits++
+	}
+	if hits != 0 {
+		t.Errorf("leak: %d hits returned without provenance; want fail-closed", hits)
+	}
+	if !errors.Is(streamErr, search.ErrScope) {
+		t.Errorf("want ErrScope on missing provenance, got %v", streamErr)
 	}
 }

--- a/internal/search/visible_test.go
+++ b/internal/search/visible_test.go
@@ -31,6 +31,38 @@ func TestVisibleConformance_Bleve(t *testing.T) {
 	})
 }
 
+// TestVisibleFieldConformance_Bleve runs the property-level (match-on-hidden-
+// field) suite over the generic wrapper + bleve backend, exercising bleve's
+// own MatchedFields provenance path (TKT-GGQ0JT).
+func TestVisibleFieldConformance_Bleve(t *testing.T) {
+	storetest.RunVisibleFieldSearchTests(t, func(t *testing.T) (store.Store, search.Searcher, search.FieldVisibleSearcher) {
+		t.Helper()
+		idx, err := bleveindex.NewMem()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = idx.Close() })
+		s := memstore.New(memstore.WithObserver(idx))
+		searcher := search.New(s, idx)
+		v, err := search.NewVisible(searcher, s)
+		require.NoError(t, err)
+		return s, searcher, v
+	})
+}
+
+// TestVisibleFieldConformance_Linear runs the property-level suite over the
+// generic wrapper + LinearSearch backend — the ground-truth matcher the other
+// backends are checked against.
+func TestVisibleFieldConformance_Linear(t *testing.T) {
+	storetest.RunVisibleFieldSearchTests(t, func(t *testing.T) (store.Store, search.Searcher, search.FieldVisibleSearcher) {
+		t.Helper()
+		ls := search.NewLinearSearch()
+		s := memstore.New(memstore.WithObserver(ls))
+		searcher := search.New(s, ls)
+		v, err := search.NewVisible(searcher, s)
+		require.NoError(t, err)
+		return s, searcher, v
+	})
+}
+
 func TestNewVisible_RejectsNil(t *testing.T) {
 	s := memstore.New()
 	searcher := search.New(s, search.NewLinearSearch())

--- a/internal/store/pgstore/conformance_test.go
+++ b/internal/store/pgstore/conformance_test.go
@@ -13,6 +13,13 @@ func TestConformance(t *testing.T) {
 	storetest.RunAll(t, factory, searchFactory, visibleSearchFactory, storetest.Capabilities{Attachments: true})
 }
 
+// TestVisibleFieldConformance runs the property-level (match-on-hidden-field)
+// suite against the pgstore-native FieldVisibleSearcher (TKT-GGQ0JT).
+// DB-gated on RELA_TEST_DATABASE_URL like the rest of the suite.
+func TestVisibleFieldConformance(t *testing.T) {
+	storetest.RunVisibleFieldSearchTests(t, fieldVisibleSearchFactory)
+}
+
 func FuzzRelationKeyCollision(f *testing.F) {
 	storetest.FuzzRelationKeyCollision(f, fuzzFactory(f))
 }

--- a/internal/store/pgstore/pgstore.go
+++ b/internal/store/pgstore/pgstore.go
@@ -66,7 +66,7 @@ type DBTX interface {
 // interface, which consumers depend on directly by design. Required-interface
 // exception — tracks the interface size, not accreted public API.
 //
-//plimsoll:max-exported-methods=29
+//plimsoll:max-exported-methods=30
 type Store struct {
 	db        DBTX
 	observers []store.EntityObserver // notified synchronously after committed entity writes

--- a/internal/store/pgstore/testdb_test.go
+++ b/internal/store/pgstore/testdb_test.go
@@ -176,6 +176,18 @@ func visibleSearchFactory(t *testing.T) (store.Store, search.Searcher, search.Vi
 	return s, search.New(s, backend), s
 }
 
+// fieldVisibleSearchFactory builds the pgstore-native FieldVisibleSearcher for
+// the property-level conformance suite (TKT-GGQ0JT).
+func fieldVisibleSearchFactory(t *testing.T) (store.Store, search.Searcher, search.FieldVisibleSearcher) {
+	t.Helper()
+	pool := newScopedPool(t)
+	backend := pgstore.NewSearchBackend(pool)
+	s, err := pgstore.New(pool, pgstore.WithObserver(backend))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s, search.New(s, backend), s
+}
+
 // fuzzFactory adapts the per-schema helper to storetest.FuzzFactory.
 //
 // The FuzzFactory signature takes no testing handle and runs inside f.Fuzz

--- a/internal/store/pgstore/visiblesearch.go
+++ b/internal/store/pgstore/visiblesearch.go
@@ -191,7 +191,7 @@ func fieldVisibleForEntity(
 	if hidden == nil || q.Text == "" {
 		return true, nil
 	}
-	hiddenFields, err := hidden(ctx, h)
+	hiddenFields, err := hidden(ctx, h, e)
 	if err != nil {
 		return false, fmt.Errorf("%w: hidden-fields for %q: %w", search.ErrScope, h.ID, err)
 	}
@@ -199,12 +199,7 @@ func fieldVisibleForEntity(
 		return true, nil
 	}
 	matched := search.MatchTextFields(e, q.Text)
-	for f := range matched {
-		if _, isHidden := hiddenFields[f]; !isHidden {
-			return true, nil
-		}
-	}
-	return false, nil
+	return search.MatchHasVisibleField(matched, hiddenFields), nil
 }
 
 // buildVisibleSearchSQL emits the combined search+visibility statement.

--- a/internal/store/pgstore/visiblesearch.go
+++ b/internal/store/pgstore/visiblesearch.go
@@ -7,6 +7,9 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
@@ -89,6 +92,119 @@ func (s *Store) SearchVisible(
 			yield(search.Hit{}, fmt.Errorf("%w: pgstore visible search: %w", search.ErrScope, err))
 		}
 	}
+}
+
+// compile-time check: the postgres store also filters at the property level.
+var _ search.FieldVisibleSearcher = (*Store)(nil)
+
+// SearchVisibleFields is [SearchVisible] plus property-level redaction of the
+// match-on-hidden-field oracle. A hit whose text matched only fields the
+// principal may not see (per hidden) is dropped, so a search cannot confirm a
+// redacted property's value by returning its entity.
+//
+// The per-field match is computed in Go over the already-scanned entity with
+// [search.MatchTextFields] — the same ground-truth matcher the generic backend
+// uses — so pgstore and the simple backends agree. This does NOT push the
+// field projection into SQL; the entity is already in hand from the visibility
+// scan, so the filter is a cheap in-memory pass over the candidate rows. A SQL
+// pushdown (matching per-column server-side) is a tracked performance
+// follow-up, not a correctness gap.
+func (s *Store) SearchVisibleFields(
+	ctx context.Context, q search.Query, scope map[string]search.TypeScope, hidden search.HiddenFieldsFunc,
+) iter.Seq2[search.Hit, error] {
+	return func(yield func(search.Hit, error) bool) {
+		if err := search.ValidateFilters(q.Filters); err != nil {
+			yield(search.Hit{}, err)
+			return
+		}
+		if ws, ok := scope[search.WildcardType]; ok && ws.Query != nil {
+			yield(search.Hit{}, fmt.Errorf("%w: wildcard scope entry cannot carry a GraphQuery", search.ErrScope))
+			return
+		}
+
+		sqlText, args, anyVisible := buildVisibleSearchSQL(q, scope)
+		if !anyVisible {
+			return
+		}
+
+		rows, err := s.db.Query(ctx, sqlText, args...)
+		if err != nil {
+			yield(search.Hit{}, fmt.Errorf("%w: pgstore visible search: %w", search.ErrScope, err))
+			return
+		}
+		defer rows.Close()
+
+		emitFieldVisibleRows(ctx, rows, q, hidden, yield)
+	}
+}
+
+// emitFieldVisibleRows scans the visible-search rows, applies the Go-side
+// property filter and the property-level (hidden-field) drop, and yields the
+// survivors up to q.Limit. Any scan/row/hidden-func error is yielded and stops
+// iteration. Extracted from SearchVisibleFields to keep that closure's
+// branching within the complexity budget.
+func emitFieldVisibleRows(
+	ctx context.Context, rows pgx.Rows, q search.Query, hidden search.HiddenFieldsFunc,
+	yield func(search.Hit, error) bool,
+) {
+	emitted := 0
+	for rows.Next() {
+		e, scanErr := scanEntity(rows)
+		if scanErr != nil {
+			yield(search.Hit{}, fmt.Errorf("%w: pgstore visible search scan: %w", search.ErrScope, scanErr))
+			return
+		}
+		if !search.MatchFilters(e, q.Filters) {
+			continue
+		}
+		hit := search.Hit{ID: e.ID, Type: e.Type, Title: e.Title()}
+		keep, ferr := fieldVisibleForEntity(ctx, q, hit, e, hidden)
+		if ferr != nil {
+			yield(search.Hit{}, ferr)
+			return
+		}
+		if !keep {
+			continue
+		}
+		if q.Limit > 0 && emitted >= q.Limit {
+			return
+		}
+		if !yield(hit, nil) {
+			return
+		}
+		emitted++
+	}
+	if err := rows.Err(); err != nil {
+		yield(search.Hit{}, fmt.Errorf("%w: pgstore visible search: %w", search.ErrScope, err))
+	}
+}
+
+// fieldVisibleForEntity decides whether a hit survives the property-level
+// filter, given the already-loaded entity. Mirrors search.Visible.fieldVisible
+// but computes provenance directly with [search.MatchTextFields] (the entity is
+// in hand, no reader round-trip). Keeps the hit when field filtering does not
+// apply (no hidden func, no text) or an empty hidden set; otherwise keeps only
+// if a non-hidden field matched. A hidden-func error fails closed.
+func fieldVisibleForEntity(
+	ctx context.Context, q search.Query, h search.Hit, e *entity.Entity, hidden search.HiddenFieldsFunc,
+) (bool, error) {
+	if hidden == nil || q.Text == "" {
+		return true, nil
+	}
+	hiddenFields, err := hidden(ctx, h)
+	if err != nil {
+		return false, fmt.Errorf("%w: hidden-fields for %q: %w", search.ErrScope, h.ID, err)
+	}
+	if len(hiddenFields) == 0 {
+		return true, nil
+	}
+	matched := search.MatchTextFields(e, q.Text)
+	for f := range matched {
+		if _, isHidden := hiddenFields[f]; !isHidden {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // buildVisibleSearchSQL emits the combined search+visibility statement.

--- a/internal/store/storetest/visiblesearch.go
+++ b/internal/store/storetest/visiblesearch.go
@@ -330,7 +330,7 @@ func RunVisibleFieldSearchTests(t *testing.T, vsf VisibleFieldSearchFactory) {
 
 	// hideCode hides the `code` property (search vocabulary "prop:code") for
 	// every hit — the common closed-world case.
-	hideCode := func(_ context.Context, _ search.Hit) (map[string]struct{}, error) {
+	hideCode := func(_ context.Context, _ search.Hit, _ *entity.Entity) (map[string]struct{}, error) {
 		return map[string]struct{}{search.PropFieldPrefix + "code": {}}, nil
 	}
 
@@ -378,7 +378,7 @@ func RunVisibleFieldSearchTests(t *testing.T, vsf VisibleFieldSearchFactory) {
 	t.Run("FailClosedOnHiddenFuncError", func(t *testing.T) {
 		s, _, vs := vsf(t)
 		seedVisibleFieldWorld(t, s)
-		boom := func(_ context.Context, _ search.Hit) (map[string]struct{}, error) {
+		boom := func(_ context.Context, _ search.Hit, _ *entity.Entity) (map[string]struct{}, error) {
 			return nil, errors.New("acl resolution boom")
 		}
 		q := search.Query{Text: "zeta777"}
@@ -402,6 +402,39 @@ func RunVisibleFieldSearchTests(t *testing.T, vsf VisibleFieldSearchFactory) {
 		q := search.Query{Text: "zeta777"}
 		got := collectHits(t, vs.SearchVisibleFields(ctx(), q, map[string]search.TypeScope{}, nil))
 		require.Empty(t, got, "empty scope denies everything before field filtering")
+	})
+
+	t.Run("ContentMatchSurvivesHiddenProperty", func(t *testing.T) {
+		s, _, vs := vsf(t)
+		e := entity.New("TKT-9", "ticket")
+		e.SetString("title", "gamma orbiter")
+		e.SetString("code", "zeta777")
+		e.Content = "uniquebodytoken operational notes"
+		require.NoError(t, s.CreateEntity(ctx(), e), "create TKT-9")
+		// The query matches the entity body (content), which is never
+		// property-gated, so hiding `code` must not drop it.
+		q := search.Query{Text: "uniquebodytoken"}
+		got := collectHits(t, vs.SearchVisibleFields(ctx(), q, allowTickets, hideCode))
+		require.True(t, hitInSet(got, "TKT-9"),
+			"a content match must survive: content is never property-gated")
+	})
+
+	t.Run("CallerCannotFalseDropViaIDOrContent", func(t *testing.T) {
+		s, _, vs := vsf(t)
+		e := entity.New("TKT-9", "ticket")
+		e.SetString("title", "delta probe")
+		e.Content = "singularcontentword"
+		require.NoError(t, s.CreateEntity(ctx(), e), "create TKT-9")
+		// A buggy HiddenFieldsFunc that (wrongly) lists id/content must NOT be
+		// able to drop a hit that matched id/content — the seam guards the
+		// never-gated invariant (MatchHasVisibleField special-cases them).
+		hideIDAndContent := func(_ context.Context, _ search.Hit, _ *entity.Entity) (map[string]struct{}, error) {
+			return map[string]struct{}{search.FieldID: {}, search.FieldContent: {}}, nil
+		}
+		q := search.Query{Text: "singularcontentword"}
+		got := collectHits(t, vs.SearchVisibleFields(ctx(), q, allowTickets, hideIDAndContent))
+		require.True(t, hitInSet(got, "TKT-9"),
+			"id/content are never property-gated even if a caller mis-lists them")
 	})
 }
 

--- a/internal/store/storetest/visiblesearch.go
+++ b/internal/store/storetest/visiblesearch.go
@@ -1,6 +1,7 @@
 package storetest
 
 import (
+	"context"
 	"errors"
 	"slices"
 	"testing"
@@ -305,6 +306,119 @@ func RunVisibleSearchTests(t *testing.T, vsf VisibleSearchFactory) {
 			require.True(t, hitInSet(base, h.ID), "visible hit missing from ungated baseline")
 		}
 	})
+}
+
+// VisibleFieldSearchFactory returns a fresh store, the ungated searcher, and
+// the FieldVisibleSearcher under test. Mirrors [VisibleSearchFactory] but for
+// the property-level seam (TKT-GGQ0JT).
+type VisibleFieldSearchFactory func(t *testing.T) (store.Store, search.Searcher, search.FieldVisibleSearcher)
+
+// RunVisibleFieldSearchTests is the conformance suite for the property-level
+// filter [search.FieldVisibleSearcher.SearchVisibleFields]. It pins the
+// match-on-hidden-field oracle closure: a hit whose text matched ONLY fields
+// the principal may not see is dropped, while a hit that matched a visible
+// field (or id/content, never property-gated) survives.
+//
+// The fixture adds a `code` property carrying a value ("zeta777") that appears
+// in NO title, so a search for it can only match via the property — making the
+// hidden-only case unambiguous. Every backend's own matcher must agree with
+// the ground-truth (search.MatchTextFields over the visible projection).
+func RunVisibleFieldSearchTests(t *testing.T, vsf VisibleFieldSearchFactory) {
+	t.Helper()
+
+	allowTickets := map[string]search.TypeScope{"ticket": {AllowAll: true}}
+
+	// hideCode hides the `code` property (search vocabulary "prop:code") for
+	// every hit — the common closed-world case.
+	hideCode := func(_ context.Context, _ search.Hit) (map[string]struct{}, error) {
+		return map[string]struct{}{search.PropFieldPrefix + "code": {}}, nil
+	}
+
+	t.Run("HiddenOnlyMatchDropped", func(t *testing.T) {
+		s, _, vs := vsf(t)
+		seedVisibleFieldWorld(t, s)
+		// "zeta777" lives only in TKT-1's hidden `code` property.
+		q := search.Query{Text: "zeta777"}
+		got := collectHits(t, vs.SearchVisibleFields(ctx(), q, allowTickets, hideCode))
+		require.Empty(t, got, "a hit matching only a hidden field must be dropped (oracle closed)")
+	})
+
+	t.Run("HiddenOnlyMatchSurvivesWhenVisible", func(t *testing.T) {
+		s, _, vs := vsf(t)
+		seedVisibleFieldWorld(t, s)
+		q := search.Query{Text: "zeta777"}
+		// No hidden fields: the property is visible, so the hit stands.
+		got := collectHits(t, vs.SearchVisibleFields(ctx(), q, allowTickets, nil))
+		requireSameIDSet(t, []string{"TKT-1"}, got)
+	})
+
+	t.Run("VisibleFieldMatchKeptDespiteHiddenField", func(t *testing.T) {
+		s, _, vs := vsf(t)
+		seedVisibleFieldWorld(t, s)
+		// "alpha" matches TKT-1's visible title AND (hypothetically) other
+		// fields; with `code` hidden the title match alone keeps the hit.
+		q := search.Query{Text: "alpha"}
+		got := collectHits(t, vs.SearchVisibleFields(ctx(), q, allowTickets, hideCode))
+		require.True(t, hitInSet(got, "TKT-1"),
+			"a hit matching a visible field must survive even when another matched field is hidden")
+	})
+
+	t.Run("IDMatchSurvivesHiddenProperty", func(t *testing.T) {
+		s, _, vs := vsf(t)
+		seedVisibleFieldWorld(t, s)
+		// The consumer only ever hides declared PROPERTIES ("prop:<name>"), so
+		// id/content are never in the hidden set. A hit that matches by id
+		// survives even though its `code` property is hidden — id is never
+		// property-gated by construction of the hidden set.
+		q := search.Query{Text: "TKT-1"}
+		got := collectHits(t, vs.SearchVisibleFields(ctx(), q, allowTickets, hideCode))
+		require.True(t, hitInSet(got, "TKT-1"), "an id match must survive: id is never property-gated")
+	})
+
+	t.Run("FailClosedOnHiddenFuncError", func(t *testing.T) {
+		s, _, vs := vsf(t)
+		seedVisibleFieldWorld(t, s)
+		boom := func(_ context.Context, _ search.Hit) (map[string]struct{}, error) {
+			return nil, errors.New("acl resolution boom")
+		}
+		q := search.Query{Text: "zeta777"}
+		var streamErr error
+		hits := 0
+		for _, err := range vs.SearchVisibleFields(ctx(), q, allowTickets, boom) {
+			if err != nil {
+				streamErr = err
+				break
+			}
+			hits++
+		}
+		require.Zero(t, hits, "no hit may survive a hidden-fields resolution failure")
+		require.ErrorIs(t, streamErr, search.ErrScope, "hidden-func errors fail closed via ErrScope")
+	})
+
+	t.Run("EntityLevelStillApplies", func(t *testing.T) {
+		s, _, vs := vsf(t)
+		seedVisibleFieldWorld(t, s)
+		// Scope denies tickets entirely: field filter never even runs.
+		q := search.Query{Text: "zeta777"}
+		got := collectHits(t, vs.SearchVisibleFields(ctx(), q, map[string]search.TypeScope{}, nil))
+		require.Empty(t, got, "empty scope denies everything before field filtering")
+	})
+}
+
+// seedVisibleFieldWorld builds a small fixture for the property-level suite:
+// TKT-1 carries a visible title ("alpha rocket") and a `code` property whose
+// value ("zeta777") appears nowhere else, so a search for it matches ONLY via
+// that property.
+func seedVisibleFieldWorld(t *testing.T, s store.Store) {
+	t.Helper()
+	e := entity.New("TKT-1", "ticket")
+	e.SetString("title", "alpha rocket")
+	e.SetString("code", "zeta777")
+	require.NoError(t, s.CreateEntity(ctx(), e), "create TKT-1")
+
+	e2 := entity.New("TKT-2", "ticket")
+	e2.SetString("title", "beta lander")
+	require.NoError(t, s.CreateEntity(ctx(), e2), "create TKT-2")
 }
 
 // seedVisibleSearchWorld builds the shared fixture graph:

--- a/tickets/entities/implementation-checklists/IMPL-DUJ8YL.md
+++ b/tickets/entities/implementation-checklists/IMPL-DUJ8YL.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-DUJ8YL
+type: implementation-checklist
+title: 'Implementation: ACL read-side: close the /_search match-on-hidden-field oracle (drop hits matching only visible:-hidden fields)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-DUJ8YL.md
+++ b/tickets/entities/implementation-checklists/IMPL-DUJ8YL.md
@@ -2,43 +2,43 @@
 id: IMPL-DUJ8YL
 type: implementation-checklist
 title: 'Implementation: ACL read-side: close the /_search match-on-hidden-field oracle (drop hits matching only visible:-hidden fields)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] Unit tests written (MatchTextFields, bleve MatchedFields, MatchHasVisibleField)
+- [x] Integration tests (conformance suite ×3 backends + e2e handler test)
+- [x] Happy path implemented (backend provenance → seam intersection → drop)
+- [x] Edge cases handled (id/content never-gated, empty scope, stale entity, missing provenance)
+- [x] Error handling in place (ErrScope fail-closed on hidden-func error and missing provenance)
 
 ## Test Quality
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- [x] Fixture builders used (entity.New + seedVisibleFieldWorld)
+- [x] No hardcoded values where object in scope
+- [x] Only test-relevant values specified
+- [x] Interpolated values from objects
+- [x] Property comparisons use search vocabulary constants, not raw strings
 
 ## Manual Verification
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
+- [x] Feature verified end-to-end via `handleV1Search` test with policy resolver
+- [x] Each acceptance criterion verified (see review checklist)
+- [x] Edge cases verified (fail-closed, false-drop guard)
 
-**Verification Evidence:**
-<!-- Document what you tested and the results -->
+**Verification Evidence:** `go test -race` green across search / store /
+storetest / dataentry / mcp / appbuild. Conformance `RunVisibleFieldSearchTests`
+green on bleve + linear (pgstore DB-gated, runs in CI). E2e
+`TestACLSearch_HiddenFieldOracleClosed` + control pass. Fail-closed pinned by
+`TestSearchVisibleFields_FailsClosedWithoutProvenance`.
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
-patterns extracted to a helper / constant / type where it sharpens the contract
-(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
-premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] Follows project patterns (VisibleSearcher seam, consumer-side interfaces, single-snapshot rule)
+- [x] DRY: shared `MatchHasVisibleField`, `MatchTextFields` ground truth reused across backends
+- [x] No security issues introduced (fail-closed everywhere; conformance-pinned)
+- [x] No silent failures (ErrScope surfaced + returned)
+- [x] No debug code left behind

--- a/tickets/entities/review-checklists/REV-12O3U2.md
+++ b/tickets/entities/review-checklists/REV-12O3U2.md
@@ -2,55 +2,53 @@
 id: REV-12O3U2
 type: review-checklist
 title: 'Review: ACL read-side: close the /_search match-on-hidden-field oracle (drop hits matching only visible:-hidden fields)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`go test -race` green: search, store, dataentry, mcp, appbuild)
+- [x] Lint clean (`golangci-lint` 0 issues, default + postgres tags; `just plimsoll`, `just arch-lint` OK)
+- [x] Coverage maintained (new code covered by conformance suite + handler + fail-closed tests)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` (cranky-code-reviewer agent) — completed
+- [x] All critical review-responses addressed (none critical)
+- [x] All significant review-responses addressed (RR-8W40EW, RR-DILMO4, RR-DH2IPR)
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** RR-8W40EW, RR-DILMO4, RR-DH2IPR (significant, addressed);
+RR-6757U2, RR-P1ID4S (minor, addressed); RR-T80MJ1 (nit, addressed).
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Oracle closed: hit matching only a hidden field dropped — conformance
+`HiddenOnlyMatchDropped` (bleve+linear+pg) + e2e
+`TestACLSearch_HiddenFieldOracleClosed`.
+- [x] Visible-field / id / content match survives — conformance + e2e control.
+- [x] Fail-closed on missing provenance and on hidden-func error — pinned tests.
 
-**Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+**Acceptance Status:** PASS — all criteria have automated evidence.
 
-## Documentation (enhancements only)
+## Documentation (enhancement)
 
-Skip this section for bugs and internal refactors.
-
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+- [x] ~~Docs-checklist created~~ (N/A: docs updated inline in this ticket's scope)
+- [x] User-facing documentation updated (GUIDE-acl-security + GUIDE-server-security: oracle marked closed; regenerated; `just docs-check` green)
+- [x] ~~Docs-checklist marked done~~ (N/A: no separate docs-checklist)
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit messages explain the why
+- [x] No TODOs/FIXMEs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] PR created and CI monitored
+- [x] All CI checks pass (except the `review`-status ticket gate, cleared on done)
+- [x] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1089

--- a/tickets/entities/review-checklists/REV-12O3U2.md
+++ b/tickets/entities/review-checklists/REV-12O3U2.md
@@ -1,0 +1,56 @@
+---
+id: REV-12O3U2
+type: review-checklist
+title: 'Review: ACL read-side: close the /_search match-on-hidden-field oracle (drop hits matching only visible:-hidden fields)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-6757U2.md
+++ b/tickets/entities/review-responses/RR-6757U2.md
@@ -1,0 +1,9 @@
+---
+id: RR-6757U2
+type: review-response
+title: id/content never-gated invariant asserted but not enforced at the seam
+finding: fieldVisible/fieldVisibleForEntity did a raw intersection with no special-casing of FieldID/FieldContent; a consumer HiddenFieldsFunc emitting 'id'/'content' would false-drop an id/content-only match (entity silently vanishes from search).
+severity: minor
+resolution: Added search.MatchHasVisibleField which special-cases FieldID/FieldContent as always-visible; shared by generic + pgstore filters. New conformance case CallerCannotFalseDropViaIDOrContent pins it.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-8W40EW.md
+++ b/tickets/entities/review-responses/RR-8W40EW.md
@@ -1,0 +1,9 @@
+---
+id: RR-8W40EW
+type: review-response
+title: Degrade-to-entity-level path silently leaked (no provenance = no redaction)
+finding: search.Visible.SearchVisibleFields silently skipped field redaction when the wrapped searcher didn't satisfy the (unexported) provenance interface — the 'enforced at composition root' claim was false, so any decorator (metrics/caching/tracing) between the Service and NewVisible would reopen the oracle with no error.
+severity: significant
+resolution: 'SearchVisibleFields now FAILS CLOSED: when a hidden func is supplied but prov==nil it yields search.ErrScope instead of returning un-redacted hits. Added regression test TestSearchVisibleFields_FailsClosedWithoutProvenance wiring a non-provenance decorator and asserting ErrScope + zero hits. searchVisibleHits engages the field path only under a policy-backed resolver so the guard can''t misfire on NopACL.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DH2IPR.md
+++ b/tickets/entities/review-responses/RR-DH2IPR.md
@@ -1,0 +1,9 @@
+---
+id: RR-DH2IPR
+type: review-response
+title: hiddenSearchFields stale-branch comment misdescribed why it was safe
+finding: 'The GetEntity-failure ''return nil,nil'' claimed the seam''s found=false path drops the hit, but that path was never reached: len(hiddenFields)==0 short-circuits before MatchedFields runs. The real safety net was an undocumented cross-consumer contract (every caller must re-load and drop).'
+severity: significant
+resolution: 'Made moot by RR-DILMO4: the seam loads once and its own GetEntity-failure branch (in fieldVisible) drops the hit fail-closed with a correct comment. The consumer callback no longer loads, so there is no misdescribed branch left.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DILMO4.md
+++ b/tickets/entities/review-responses/RR-DILMO4.md
@@ -1,0 +1,9 @@
+---
+id: RR-DILMO4
+type: review-response
+title: Three entity loads per field-visibility decision — concurrent-write snapshot race
+finding: The generic path loaded the hit entity 3x (hidden-fields callback, Service.MatchedFields, body load), each a fresh atomic.Pointer snapshot. A concurrent edit to the matched property between loads could make the hidden-set load observe a state where a when:-predicate no longer marks it hidden, defeating fail-closed. Violates CLAUDE.md 'capture state once per operation.'
+severity: significant
+resolution: The seam now loads the entity ONCE in fieldVisible and threads that single snapshot into both the HiddenFieldsFunc (signature gained *entity.Entity) and prov.MatchedFields (now takes the entity, not an id). pgstore already reused its scanned row; the generic path matches it. hiddenSearchFields no longer loads.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-P1ID4S.md
+++ b/tickets/entities/review-responses/RR-P1ID4S.md
@@ -1,0 +1,9 @@
+---
+id: RR-P1ID4S
+type: review-response
+title: Conformance suite missing content-only and false-drop cases
+finding: RunVisibleFieldSearchTests covered happy paths + hidden-func-error but not a content-match-survives case nor a caller-false-drop case.
+severity: minor
+resolution: Added ContentMatchSurvivesHiddenProperty and CallerCannotFalseDropViaIDOrContent. The stale-entity found=false path is exercised by the fail-closed code structure + the dataentry-level flow; it can't be desynced through the public store/observer API at the conformance layer (documented).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-T80MJ1.md
+++ b/tickets/entities/review-responses/RR-T80MJ1.md
@@ -1,0 +1,9 @@
+---
+id: RR-T80MJ1
+type: review-response
+title: bleve textAnalyzer allocated a fresh registry.NewCache per MatchedFields call
+finding: fieldmatch.go built a new registry cache and re-looked-up the standard analyzer once per surviving hit per query — avoidable hot-path allocation.
+severity: nit
+resolution: Cached via package-level sync.OnceValue(cachedStandardAnalyzer); the standard analyzer is stateless and goroutine-safe.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-GGQ0JT.md
+++ b/tickets/entities/tickets/TKT-GGQ0JT.md
@@ -5,7 +5,7 @@ title: 'ACL read-side: close the /_search match-on-hidden-field oracle (drop hit
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-GGQ0JT.md
+++ b/tickets/entities/tickets/TKT-GGQ0JT.md
@@ -5,7 +5,7 @@ title: 'ACL read-side: close the /_search match-on-hidden-field oracle (drop hit
 kind: enhancement
 priority: medium
 effort: m
-status: backlog
+status: review
 ---
 
 ## Problem

--- a/tickets/relations/TKT-GGQ0JT--has-implementation--IMPL-DUJ8YL.md
+++ b/tickets/relations/TKT-GGQ0JT--has-implementation--IMPL-DUJ8YL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GGQ0JT
+relation: has-implementation
+to: IMPL-DUJ8YL
+---

--- a/tickets/relations/TKT-GGQ0JT--has-review--REV-12O3U2.md
+++ b/tickets/relations/TKT-GGQ0JT--has-review--REV-12O3U2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GGQ0JT
+relation: has-review
+to: REV-12O3U2
+---

--- a/tickets/relations/TKT-GGQ0JT--has-review-response--RR-6757U2.md
+++ b/tickets/relations/TKT-GGQ0JT--has-review-response--RR-6757U2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GGQ0JT
+relation: has-review-response
+to: RR-6757U2
+---

--- a/tickets/relations/TKT-GGQ0JT--has-review-response--RR-8W40EW.md
+++ b/tickets/relations/TKT-GGQ0JT--has-review-response--RR-8W40EW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GGQ0JT
+relation: has-review-response
+to: RR-8W40EW
+---

--- a/tickets/relations/TKT-GGQ0JT--has-review-response--RR-DH2IPR.md
+++ b/tickets/relations/TKT-GGQ0JT--has-review-response--RR-DH2IPR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GGQ0JT
+relation: has-review-response
+to: RR-DH2IPR
+---

--- a/tickets/relations/TKT-GGQ0JT--has-review-response--RR-DILMO4.md
+++ b/tickets/relations/TKT-GGQ0JT--has-review-response--RR-DILMO4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GGQ0JT
+relation: has-review-response
+to: RR-DILMO4
+---

--- a/tickets/relations/TKT-GGQ0JT--has-review-response--RR-P1ID4S.md
+++ b/tickets/relations/TKT-GGQ0JT--has-review-response--RR-P1ID4S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GGQ0JT
+relation: has-review-response
+to: RR-P1ID4S
+---

--- a/tickets/relations/TKT-GGQ0JT--has-review-response--RR-T80MJ1.md
+++ b/tickets/relations/TKT-GGQ0JT--has-review-response--RR-T80MJ1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GGQ0JT
+relation: has-review-response
+to: RR-T80MJ1
+---


### PR DESCRIPTION
## What

Closes the `/_search` match-on-hidden-field oracle (TKT-GGQ0JT, from research
RES-H5AB7S). Property-level `visible:` redaction already stripped hidden values
from response *bodies*, but the full-text index still *matched* on hidden-field
text — so a query whose only match was a hidden property still returned the
entity, confirming the value by its presence (postcode → hidden-address oracle).

## Approach

Backend-reported match provenance + ACL intersection at the `VisibleSearcher`
seam. Each backend reports **which fields** a query matched, using its own
matcher; the seam drops a hit when every matched field is principal-hidden. A
hit that also matched a visible field — or id/content, never property-gated —
survives, body redacted.

- **linear** — `MatchTextFields` (substring); the ground-truth matcher.
- **bleve** — reuses its own analyzer + fuzzy/wildcard/prefix rules on the
  candidate entity per field (no index change; unioned with a substring floor so
  it can never under-report → no false drops).
- **pgstore** — the existing visibility scan already has the row in hand; the
  per-field re-match runs in Go over candidates (`MatchTextFields`). SQL
  column-projection pushdown is a tracked perf follow-up, not a correctness gap.
- **dataentry** — `handleV1Search` passes a `HiddenFieldsFunc` resolved from the
  same affordance verdict source the serializer uses.

## Tests

- `storetest.RunVisibleFieldSearchTests` — new conformance suite, run over
  bleve, linear, and pgstore-native (DB-gated). It caught a real inverted-return
  bug in bleve's Levenshtein use during development.
- End-to-end `handleV1Search` test proving the oracle is closed through the real
  handler + policy resolver, with a negative control.
- Docs updated (ACL + server security guides): oracle now marked closed.

## Verification

- `go build ./...` (default + postgres tags) clean
- `go test -race` green across search / store / dataentry / mcp
- `golangci-lint`, `just arch-lint`, `just lint-md`, `just docs-check` clean