### PR TITLE
Consistent markdown styling across data-entry render surfaces (TKT-YYZRGW)

### DIFF
--- a/frontend/src/app-editor/relaEditorTheme.css
+++ b/frontend/src/app-editor/relaEditorTheme.css
@@ -73,6 +73,151 @@
   border-left: none;
 }
 
+/* Live-preview markdown element styling. This sandboxed app-editor bundle
+   inlines its own CSS and does NOT load the SPA's styles/markdown-content.css,
+   so the `.editor-preview` rules there are mirrored here. Keep the two in
+   sync (same values, both re-skin EasyMDE's hardcoded light-theme defaults to
+   theme tokens). Tracked with the other editor DRIFT in TKT-D2JML7. */
+.EasyMDEContainer .editor-preview h1,
+.EasyMDEContainer .editor-preview h2,
+.EasyMDEContainer .editor-preview h3,
+.EasyMDEContainer .editor-preview h4,
+.EasyMDEContainer .editor-preview h5,
+.EasyMDEContainer .editor-preview h6 {
+  margin: 24px 0 12px;
+  color: var(--text-color);
+  line-height: 1.3;
+  font-weight: 600;
+}
+.EasyMDEContainer .editor-preview > :first-child {
+  margin-top: 0;
+}
+.EasyMDEContainer .editor-preview h1 {
+  font-size: 26px;
+}
+.EasyMDEContainer .editor-preview h2 {
+  font-size: 21px;
+}
+.EasyMDEContainer .editor-preview h3 {
+  font-size: 17px;
+}
+.EasyMDEContainer .editor-preview h4 {
+  font-size: 15px;
+}
+.EasyMDEContainer .editor-preview h5,
+.EasyMDEContainer .editor-preview h6 {
+  font-size: 14px;
+  color: var(--muted-text);
+}
+.EasyMDEContainer .editor-preview {
+  /* Mirrors --md-list-pad from markdown-content.css: couples list indent to
+     the task-list checkbox pull-back below. */
+  --md-list-pad: 26px;
+  overflow-wrap: anywhere;
+}
+.EasyMDEContainer .editor-preview p {
+  margin: 0 0 14px;
+}
+.EasyMDEContainer .editor-preview ul,
+.EasyMDEContainer .editor-preview ol {
+  margin: 0 0 14px;
+  padding-left: var(--md-list-pad);
+}
+.EasyMDEContainer .editor-preview ul {
+  list-style: disc outside;
+}
+.EasyMDEContainer .editor-preview ol {
+  list-style: decimal outside;
+}
+.EasyMDEContainer .editor-preview ul ul {
+  list-style-type: circle;
+}
+.EasyMDEContainer .editor-preview ul ul ul {
+  list-style-type: square;
+}
+.EasyMDEContainer .editor-preview li {
+  margin-bottom: 4px;
+  line-height: 1.6;
+}
+.EasyMDEContainer .editor-preview li > ul,
+.EasyMDEContainer .editor-preview li > ol {
+  margin: 4px 0 0;
+}
+.EasyMDEContainer .editor-preview li::marker {
+  color: var(--muted-text);
+}
+.EasyMDEContainer .editor-preview li:has(> input[type='checkbox']:first-child),
+.EasyMDEContainer .editor-preview li:has(> p:first-child > input[type='checkbox']:first-child) {
+  list-style: none;
+  margin-left: calc(-1 * var(--md-list-pad) + 4px);
+}
+.EasyMDEContainer .editor-preview li > p:first-child:has(> input[type='checkbox']:first-child) {
+  margin-bottom: 0;
+  display: inline;
+}
+.EasyMDEContainer .editor-preview code {
+  background: var(--hover-bg);
+  color: var(--text-color);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 13px;
+}
+.EasyMDEContainer .editor-preview pre {
+  background: var(--hover-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 14px 16px;
+  overflow-x: auto;
+  font-size: 13px;
+  margin: 0 0 14px;
+}
+.EasyMDEContainer .editor-preview pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+.EasyMDEContainer .editor-preview blockquote {
+  margin: 0 0 14px;
+  padding: 8px 16px;
+  background: var(--hover-bg);
+  border-left: 4px solid var(--accent-color);
+  color: var(--muted-text);
+  border-radius: 0 4px 4px 0;
+}
+.EasyMDEContainer .editor-preview blockquote > :last-child {
+  margin-bottom: 0;
+}
+.EasyMDEContainer .editor-preview hr {
+  border: none;
+  border-top: 1px solid var(--border-color);
+  margin: 28px 0;
+}
+.EasyMDEContainer .editor-preview img {
+  max-width: 100%;
+  height: auto;
+}
+.EasyMDEContainer .editor-preview a {
+  color: var(--accent-color);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.EasyMDEContainer .editor-preview table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 14px;
+}
+.EasyMDEContainer .editor-preview th,
+.EasyMDEContainer .editor-preview td {
+  padding: 8px 12px;
+  text-align: left;
+  border: 1px solid var(--border-color);
+}
+.EasyMDEContainer .editor-preview th {
+  background: var(--hover-bg);
+  font-weight: 600;
+}
+
 .CodeMirror-gutters {
   background: var(--hover-bg);
   border-right-color: var(--border-color);

--- a/frontend/src/components/entity/DocumentsPanel.vue
+++ b/frontend/src/components/entity/DocumentsPanel.vue
@@ -183,7 +183,7 @@ function getDocTitle(name: string, config: DocumentConfig): string {
 
     <div v-else-if="docContent" class="document-content">
       <div v-if="isCached" class="cached-badge">cached</div>
-      <div ref="docBody" class="document-body" @click="handleContentClick" v-html="sanitizedContent" />
+      <div ref="docBody" class="document-body md-body" @click="handleContentClick" v-html="sanitizedContent" />
     </div>
 
     <div v-else class="empty-state">
@@ -319,117 +319,8 @@ function getDocTitle(name: string, config: DocumentConfig): string {
   text-transform: uppercase;
 }
 
-.document-body {
-  font-size: 15px;
-  line-height: 1.7;
-  color: var(--text-color);
-}
-
-/* Style injected HTML content */
-.document-body :deep(h1),
-.document-body :deep(h2),
-.document-body :deep(h3) {
-  margin: 24px 0 12px;
-  color: var(--text-color);
-}
-
-.document-body :deep(h1:first-child),
-.document-body :deep(h2:first-child),
-.document-body :deep(h3:first-child) {
-  margin-top: 0;
-}
-
-.document-body :deep(h1) {
-  font-size: 24px;
-}
-
-.document-body :deep(h2) {
-  font-size: 20px;
-}
-
-.document-body :deep(h3) {
-  font-size: 16px;
-}
-
-.document-body :deep(p) {
-  margin: 0 0 12px;
-}
-
-.document-body :deep(ul),
-.document-body :deep(ol) {
-  margin: 0 0 12px;
-  padding-left: 24px;
-}
-
-.document-body :deep(li) {
-  margin-bottom: 4px;
-}
-
-.document-body :deep(pre) {
-  background: var(--hover-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  padding: 12px;
-  overflow-x: auto;
-  font-size: 13px;
-}
-
-.document-body :deep(code) {
-  background: var(--hover-bg);
-  color: var(--text-color);
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
-}
-
-.document-body :deep(pre code) {
-  background: none;
-  padding: 0;
-}
-
-.document-body :deep(table) {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 12px 0;
-}
-
-.document-body :deep(th),
-.document-body :deep(td) {
-  padding: 8px 12px;
-  text-align: left;
-  border: 1px solid var(--border-color);
-}
-
-.document-body :deep(th) {
-  background: var(--hover-bg);
-  font-weight: 600;
-}
-
-.document-body :deep(hr) {
-  border: none;
-  border-top: 1px solid var(--border-color);
-  margin: 24px 0;
-}
-
-.document-body :deep(blockquote) {
-  margin: 12px 0;
-  padding: 12px 16px;
-  background: var(--hover-bg);
-  border-left: 4px solid var(--accent-color);
-  color: var(--muted-text);
-}
-
-.document-body :deep(img) {
-  max-width: 100%;
-  height: auto;
-}
-
-.document-body :deep(a) {
-  color: var(--accent-color);
-  text-decoration: none;
-}
-
-.document-body :deep(a:hover) {
-  text-decoration: underline;
-}
+/* All rendered-markdown element styling (headings, paragraphs, lists, code,
+   pre, blockquote, hr, img, links, tables) is shared across every markdown
+   surface via the `.md-body` class on the `.document-body` container — see
+   styles/markdown-content.css. */
 </style>

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -858,14 +858,14 @@ watch(
           <div
             v-else-if="section === entryContentSection"
             :ref="(el) => { contentRef = el as HTMLElement | null }"
-            class="content-body"
+            class="content-body md-body"
             @click="contentClick"
             v-html="renderedEntryContent"
           />
 
           <!-- Other content sections (e.g. content cards from a configured view). -->
           <div v-else-if="section.display === 'content' && section.hasContent" class="content-block">
-            <div class="markdown-content" v-html="renderMarkdown(section.content || '', refResolver)"/>
+            <div class="markdown-content md-body" v-html="renderMarkdown(section.content || '', refResolver)"/>
           </div>
 
           <div v-else-if="section.display === 'content' && section.entities?.length" class="content-cards">
@@ -880,7 +880,7 @@ watch(
                 <span class="entity-title">{{ ent.title }}</span>
                 <span class="entity-id">{{ ent.id }}</span>
               </header>
-              <div v-if="ent.hasContent" class="markdown-content" v-html="renderMarkdown(ent.content || '', refResolver)"/>
+              <div v-if="ent.hasContent" class="markdown-content md-body" v-html="renderMarkdown(ent.content || '', refResolver)"/>
             </article>
           </div>
 
@@ -1389,74 +1389,12 @@ watch(
   font-style: italic;
 }
 
-/* Entry content body — fuller markdown styling for interactive checkboxes
- * and mermaid diagrams. Generic .markdown-content (used by content-card
- * snippets) gets a tighter treatment. */
-.content-body {
-  font-size: 15px;
-  line-height: 1.7;
-  color: var(--text-color);
-}
-
-.content-body :deep(h1),
-.content-body :deep(h2),
-.content-body :deep(h3) {
-  margin: 24px 0 12px;
-  color: var(--text-color);
-}
-
-.content-body :deep(h1) { font-size: 24px; }
-.content-body :deep(h2) { font-size: 20px; }
-.content-body :deep(h3) { font-size: 16px; }
-
-.content-body :deep(p) {
-  margin: 0 0 12px;
-}
-
-.content-body :deep(ul),
-.content-body :deep(ol) {
-  margin: 0 0 16px;
-  padding-left: 28px;
-}
-
-.content-body :deep(ol) {
-  list-style-type: decimal;
-}
-
-.content-body :deep(li) {
-  margin-bottom: 6px;
-  line-height: 1.6;
-}
-
-.content-body :deep(li::marker) {
-  color: var(--muted-text);
-  font-weight: 500;
-}
-
-.content-body :deep(code) {
-  background: var(--hover-bg);
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
-  color: var(--text-color);
-}
-
-.content-body :deep(a),
-.markdown-content :deep(a) {
-  color: var(--accent-color);
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-
-.content-body :deep(a:hover),
-.markdown-content :deep(a:hover) {
-  text-decoration-thickness: 2px;
-}
-
-.content-body :deep(input[type="checkbox"]) {
-  margin-right: 8px;
-  cursor: pointer;
-}
+/* Rendered-markdown element styling (headings, lists, code, links, tables,
+   blockquotes, line-height, …) is shared across all markdown surfaces via the
+   `.md-body` class on the container — see styles/markdown-content.css. Both
+   `.content-body` and `.markdown-content` carry that class, so neither
+   redefines those properties here (an earlier `.markdown-content` line-height
+   override silently beat the shared value and reintroduced drift). */
 
 /* Generic content (collected entities, configured-view content sections). */
 .content-block {
@@ -1464,10 +1402,6 @@ watch(
   background: var(--card-bg);
   border: 1px solid var(--border-color);
   border-radius: 6px;
-}
-
-.markdown-content {
-  line-height: 1.6;
 }
 
 .content-cards {

--- a/frontend/src/components/forms/MarkdownEditor.vue
+++ b/frontend/src/components/forms/MarkdownEditor.vue
@@ -328,6 +328,10 @@ function onPopupHover(idx: number): void {
   justify-content: center;
 }
 
+/* Container chrome only (padding/background/color). The markdown *element*
+   styling inside the preview (headings, lists, code, blockquote, tables, …)
+   comes from the shared global stylesheet's `.editor-preview` alias — see
+   styles/markdown-content.css — so it matches the entity view exactly. */
 .markdown-editor :deep(.editor-preview) {
   padding: 16px;
   background: var(--card-bg);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -9,6 +9,7 @@ import '@fontsource/open-sans/500.css'
 import '@fontsource/open-sans/600.css'
 import '@fontsource/open-sans/700.css'
 import './styles/back-button.css'
+import './styles/markdown-content.css'
 
 const app = createApp(App)
 

--- a/frontend/src/styles/markdown-content.css
+++ b/frontend/src/styles/markdown-content.css
@@ -1,0 +1,412 @@
+/*
+ * Shared styling for rendered markdown bodies — the single source of truth.
+ *
+ * Every surface that renders markdown into a `v-html` container carries the
+ * `.md-body` marker class and gets identical styling from this one global
+ * stylesheet (loaded once from main.ts):
+ *   - EntityDetail  `.content-body` / `.markdown-content` (client renderMarkdown)
+ *   - DocumentView  `.document-body`  (server goldmark HTML)
+ *   - DocumentsPanel `.document-body` (server goldmark HTML)
+ *   - MarkdownEditor `.editor-preview` (EasyMDE live preview) — re-skinned to
+ *     match; see the `.editor-preview` block at the bottom.
+ *
+ * Before this file these rules were copy-pasted into each component's scoped
+ * `<style>` and had silently drifted (h1 was 24px in one place, 28px in
+ * another; EntityDetail had no blockquote/pre/hr/img rules at all; the EasyMDE
+ * preview used the library's hardcoded #ddd/5px table defaults). One shared
+ * sheet keyed on `.md-body` keeps them from diverging again.
+ *
+ * Global, not scoped: markdown HTML is injected via v-html, so rules must not
+ * be namespaced to a component's scope hash. Selectors stay under `.md-body`
+ * (or `.editor-preview`) so they only touch rendered markdown, never the
+ * app's own layout tables/lists (kanban, analyze, conflicts, dashboard).
+ *
+ * All colors come from theme tokens (tokens.css), so light and dark modes
+ * work without a per-theme override.
+ */
+
+.md-body {
+  /* --md-list-pad drives both the list indent and the negative margin that
+     pulls task-list checkboxes back to the body edge; keep them coupled. */
+  --md-list-pad: 26px;
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--text-color);
+  /* A long unbroken token (URL, inline code) must wrap rather than trip the
+     container's horizontal scroll (see the overflow-x note in the Tables
+     section) and drag a scrollbar across the whole body. */
+  overflow-wrap: anywhere;
+}
+
+/* ── Headings ───────────────────────────────────────────────────────────── */
+
+.md-body h1,
+.md-body h2,
+.md-body h3,
+.md-body h4,
+.md-body h5,
+.md-body h6 {
+  margin: 24px 0 12px;
+  color: var(--text-color);
+  line-height: 1.3;
+  font-weight: 600;
+}
+
+/* The first heading shouldn't push the body down with a leading margin. */
+.md-body > :first-child {
+  margin-top: 0;
+}
+
+.md-body h1 {
+  font-size: 26px;
+}
+.md-body h2 {
+  font-size: 21px;
+}
+.md-body h3 {
+  font-size: 17px;
+}
+.md-body h4 {
+  font-size: 15px;
+}
+.md-body h5,
+.md-body h6 {
+  font-size: 14px;
+  color: var(--muted-text);
+}
+
+/* ── Text blocks ────────────────────────────────────────────────────────── */
+
+.md-body p {
+  margin: 0 0 14px;
+}
+
+/* ── Lists ──────────────────────────────────────────────────────────────── */
+
+.md-body ul,
+.md-body ol {
+  margin: 0 0 14px;
+  padding-left: var(--md-list-pad);
+}
+
+/* Restore list markers: EasyMDE's preview and some resets strip them. Nested
+   lists get the conventional disc → circle → square / decimal cascade. */
+.md-body ul {
+  list-style: disc outside;
+}
+.md-body ol {
+  list-style: decimal outside;
+}
+.md-body ul ul {
+  list-style-type: circle;
+}
+.md-body ul ul ul {
+  list-style-type: square;
+}
+
+.md-body li {
+  margin-bottom: 4px;
+  line-height: 1.6;
+}
+
+/* Tighten spacing between a list item and a nested sub-list. */
+.md-body li > ul,
+.md-body li > ol {
+  margin: 4px 0 0;
+}
+
+.md-body li::marker {
+  color: var(--muted-text);
+}
+
+/* Task-list items (GFM `- [ ]`) render a checkbox + text; drop the bullet so
+   the checkbox is the only marker, and pull the row back by the list indent
+   (minus the checkbox's own width) so it aligns with the body edge. Requires
+   :has() (Baseline 2023); older browsers just keep the bulleted checkbox row.
+   Two shapes to match: a "tight" list emits `<li><input> text`, a "loose"
+   one (blank lines between items) wraps it as `<li><p><input> text</p>`.
+   Both marked (client) and goldmark (server) put the checkbox first within
+   that wrapper, so match a leading checkbox at either depth. */
+.md-body li:has(> input[type='checkbox']:first-child),
+.md-body li:has(> p:first-child > input[type='checkbox']:first-child) {
+  list-style: none;
+  margin-left: calc(-1 * var(--md-list-pad) + 4px);
+}
+
+/* A loose task item's inner <p> shouldn't add its own paragraph gap. */
+.md-body li > p:first-child:has(> input[type='checkbox']:first-child) {
+  margin-bottom: 0;
+  display: inline;
+}
+
+.md-body input[type='checkbox'] {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+/* ── Code ───────────────────────────────────────────────────────────────── */
+
+.md-body code {
+  background: var(--hover-bg);
+  color: var(--text-color);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.md-body pre {
+  background: var(--hover-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 14px 16px;
+  overflow-x: auto;
+  font-size: 13px;
+  margin: 0 0 14px;
+}
+
+/* Inside a <pre> the code shouldn't get its own inline chip background. */
+.md-body pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+
+/* ── Blockquote ─────────────────────────────────────────────────────────── */
+
+.md-body blockquote {
+  margin: 0 0 14px;
+  padding: 8px 16px;
+  background: var(--hover-bg);
+  border-left: 4px solid var(--accent-color);
+  color: var(--muted-text);
+  border-radius: 0 4px 4px 0;
+}
+
+/* A blockquote's own paragraphs shouldn't add a second trailing gap. */
+.md-body blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+/* ── Rule / images / links ──────────────────────────────────────────────── */
+
+.md-body hr {
+  border: none;
+  border-top: 1px solid var(--border-color);
+  margin: 28px 0;
+}
+
+.md-body img {
+  max-width: 100%;
+  height: auto;
+}
+
+.md-body a {
+  color: var(--accent-color);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.md-body a:hover {
+  text-decoration-thickness: 2px;
+}
+
+/* ── Tables ─────────────────────────────────────────────────────────────── */
+
+/*
+ * `overflow-x: auto` lives on the *container*, not the table, so the table
+ * keeps `display: table; width: 100%` and fills the body when it fits, while
+ * a table wider than the container scrolls horizontally instead of pushing
+ * the page. The container only grows a scrollbar when a child actually
+ * overflows on the x-axis.
+ *
+ * Caveat: per the overflow spec, setting overflow-x to a non-visible value
+ * forces the y-axis to `auto` too and makes `.md-body` a block formatting
+ * context. That's fine here (nothing constrains the body's height, so the
+ * y-axis never actually scrolls), but it means a long inline token would
+ * scroll the whole body — hence the `overflow-wrap: anywhere` on `.md-body`
+ * above. If a future ancestor sets a max-height on the body, expect an inner
+ * vertical scrollbar and revisit this.
+ */
+.md-body {
+  overflow-x: auto;
+}
+
+.md-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 14px;
+}
+
+.md-body th,
+.md-body td {
+  padding: 8px 12px;
+  text-align: left;
+  border: 1px solid var(--border-color);
+}
+
+.md-body th {
+  background: var(--hover-bg);
+  font-weight: 600;
+}
+
+/* ── Keyboard ───────────────────────────────────────────────────────────── */
+
+.md-body kbd {
+  padding: 2px 6px;
+  background: var(--hover-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: inherit;
+}
+
+/*
+ * EasyMDE live-preview pane (MarkdownEditor.vue). EasyMDE renders the preview
+ * into `.editor-preview`, which is created by the library and can't take the
+ * `.md-body` class, so we alias it here to the same rules. This makes the
+ * preview show what the entity view will actually render — EasyMDE otherwise
+ * ships hardcoded, light-theme-only, header-less table/quote/list defaults.
+ * The container padding/background/color come from the component's scoped
+ * `.editor-preview` rule; everything below inherits the `.md-body` element
+ * styling above.
+ */
+.EasyMDEContainer .editor-preview h1,
+.EasyMDEContainer .editor-preview h2,
+.EasyMDEContainer .editor-preview h3,
+.EasyMDEContainer .editor-preview h4,
+.EasyMDEContainer .editor-preview h5,
+.EasyMDEContainer .editor-preview h6 {
+  margin: 24px 0 12px;
+  color: var(--text-color);
+  line-height: 1.3;
+  font-weight: 600;
+}
+.EasyMDEContainer .editor-preview > :first-child {
+  margin-top: 0;
+}
+.EasyMDEContainer .editor-preview h1 {
+  font-size: 26px;
+}
+.EasyMDEContainer .editor-preview h2 {
+  font-size: 21px;
+}
+.EasyMDEContainer .editor-preview h3 {
+  font-size: 17px;
+}
+.EasyMDEContainer .editor-preview h4 {
+  font-size: 15px;
+}
+.EasyMDEContainer .editor-preview h5,
+.EasyMDEContainer .editor-preview h6 {
+  font-size: 14px;
+  color: var(--muted-text);
+}
+.EasyMDEContainer .editor-preview {
+  /* Mirrors --md-list-pad from `.md-body`: couples list indent to the
+     task-list checkbox pull-back below. */
+  --md-list-pad: 26px;
+  overflow-wrap: anywhere;
+}
+.EasyMDEContainer .editor-preview p {
+  margin: 0 0 14px;
+}
+.EasyMDEContainer .editor-preview ul,
+.EasyMDEContainer .editor-preview ol {
+  margin: 0 0 14px;
+  padding-left: var(--md-list-pad);
+}
+.EasyMDEContainer .editor-preview ul {
+  list-style: disc outside;
+}
+.EasyMDEContainer .editor-preview ol {
+  list-style: decimal outside;
+}
+.EasyMDEContainer .editor-preview ul ul {
+  list-style-type: circle;
+}
+.EasyMDEContainer .editor-preview ul ul ul {
+  list-style-type: square;
+}
+.EasyMDEContainer .editor-preview li {
+  margin-bottom: 4px;
+  line-height: 1.6;
+}
+.EasyMDEContainer .editor-preview li > ul,
+.EasyMDEContainer .editor-preview li > ol {
+  margin: 4px 0 0;
+}
+.EasyMDEContainer .editor-preview li::marker {
+  color: var(--muted-text);
+}
+.EasyMDEContainer .editor-preview li:has(> input[type='checkbox']:first-child),
+.EasyMDEContainer .editor-preview li:has(> p:first-child > input[type='checkbox']:first-child) {
+  list-style: none;
+  margin-left: calc(-1 * var(--md-list-pad) + 4px);
+}
+.EasyMDEContainer .editor-preview li > p:first-child:has(> input[type='checkbox']:first-child) {
+  margin-bottom: 0;
+  display: inline;
+}
+.EasyMDEContainer .editor-preview code {
+  background: var(--hover-bg);
+  color: var(--text-color);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 13px;
+}
+.EasyMDEContainer .editor-preview pre {
+  background: var(--hover-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 14px 16px;
+  overflow-x: auto;
+  font-size: 13px;
+  margin: 0 0 14px;
+}
+.EasyMDEContainer .editor-preview pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+.EasyMDEContainer .editor-preview blockquote {
+  margin: 0 0 14px;
+  padding: 8px 16px;
+  background: var(--hover-bg);
+  border-left: 4px solid var(--accent-color);
+  color: var(--muted-text);
+  border-radius: 0 4px 4px 0;
+}
+.EasyMDEContainer .editor-preview blockquote > :last-child {
+  margin-bottom: 0;
+}
+.EasyMDEContainer .editor-preview hr {
+  border: none;
+  border-top: 1px solid var(--border-color);
+  margin: 28px 0;
+}
+.EasyMDEContainer .editor-preview img {
+  max-width: 100%;
+  height: auto;
+}
+.EasyMDEContainer .editor-preview a {
+  color: var(--accent-color);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.EasyMDEContainer .editor-preview table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 14px;
+}
+.EasyMDEContainer .editor-preview th,
+.EasyMDEContainer .editor-preview td {
+  padding: 8px 12px;
+  text-align: left;
+  border: 1px solid var(--border-color);
+}
+.EasyMDEContainer .editor-preview th {
+  background: var(--hover-bg);
+  font-weight: 600;
+}

--- a/frontend/src/styles/markdownContentMirror.test.ts
+++ b/frontend/src/styles/markdownContentMirror.test.ts
@@ -1,0 +1,72 @@
+/// <reference types="node" />
+// This test runs in Node (vitest) and needs node:fs / node:url. The project
+// tsconfig scopes `types` to vitest/globals, so pull in node types file-locally
+// rather than widening them project-wide.
+//
+// Guards the hand-maintained DRIFT between the SPA's shared markdown stylesheet
+// and the sandboxed app-editor's inlined copy (TKT-D2JML7).
+//
+// The EasyMDE live-preview element rules exist in two places because the
+// app-editor bundle inlines its own CSS and cannot load the SPA global sheet:
+//   - styles/markdown-content.css      → `.EasyMDEContainer .editor-preview ...`
+//   - app-editor/relaEditorTheme.css   → `.EasyMDEContainer .editor-preview ...`
+// They must stay identical. This test extracts every `.editor-preview` rule
+// from both files and asserts the selector→declaration map matches, so a
+// change to one that isn't mirrored in the other fails CI instead of silently
+// drifting (which is exactly the failure this whole stylesheet consolidation
+// was undoing).
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8')
+
+// Parse a stylesheet into a map of `selector` → normalized declaration block,
+// keeping only rules whose selector mentions `.editor-preview`. Declarations
+// are whitespace-normalized so formatting differences don't cause failures —
+// only real value changes do. Comments are stripped first.
+function editorPreviewRules(css: string): Map<string, string> {
+  const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '')
+  const rules = new Map<string, string>()
+  const ruleRe = /([^{}]+)\{([^{}]*)\}/g
+  let match: RegExpExecArray | null
+  while ((match = ruleRe.exec(withoutComments)) !== null) {
+    const selector = match[1].trim().replace(/\s+/g, ' ')
+    // Only the element rules inside the preview are mirrored. Bare container
+    // selectors (`.editor-preview`, `.editor-preview-side`) carry chrome
+    // (padding/background/border, the --md-list-pad definition) that differs
+    // by host: in the SPA it lives in MarkdownEditor.vue's scoped block, in
+    // the app-editor it's in relaEditorTheme.css. Compare only rules that
+    // target a descendant element of `.editor-preview`.
+    if (!/\.editor-preview\s+\S/.test(selector)) continue
+    const body = match[2]
+      .split(';')
+      .map((d) => d.trim())
+      .filter(Boolean)
+      .sort()
+      .join('; ')
+    rules.set(selector, body)
+  }
+  return rules
+}
+
+describe('markdown-content editor-preview mirror', () => {
+  const shared = editorPreviewRules(read('./markdown-content.css'))
+  const mirror = editorPreviewRules(read('../app-editor/relaEditorTheme.css'))
+
+  it('both files actually define editor-preview rules (guards a broken extractor)', () => {
+    expect(shared.size).toBeGreaterThan(10)
+    expect(mirror.size).toBeGreaterThan(10)
+  })
+
+  it('the shared sheet and the app-editor mirror define the same editor-preview rules', () => {
+    // Compare as sorted selector lists first for a readable diff on mismatch.
+    expect([...mirror.keys()].sort()).toEqual([...shared.keys()].sort())
+  })
+
+  it('every mirrored editor-preview rule has identical declarations', () => {
+    for (const [selector, body] of shared) {
+      expect(mirror.get(selector), `declarations for "${selector}" drifted`).toBe(body)
+    }
+  })
+})

--- a/frontend/src/utils/markdown.test.ts
+++ b/frontend/src/utils/markdown.test.ts
@@ -78,6 +78,19 @@ describe('markdown', () => {
       expect(result).toContain('<li>')
     })
 
+    it('renders GFM tables as table/th/td elements', () => {
+      // The shared `.md-body` stylesheet targets these tags on the rendered
+      // container (styles/markdown-content.css). This asserts the structural
+      // contract that styling relies on: GFM table markdown must produce a
+      // real <table> with header and body cells, not a paragraph of pipes.
+      const result = renderMarkdown(
+        '| Kans | Niveau |\n| --- | --- |\n| 1 | Onwaarschijnlijk |',
+      )
+      expect(result).toContain('<table>')
+      expect(result).toContain('<th>Kans</th>')
+      expect(result).toContain('<td>Onwaarschijnlijk</td>')
+    })
+
     it('renders checkboxes', () => {
       const result = renderMarkdown('- [ ] unchecked\n- [x] checked')
       expect(result).toContain('type="checkbox"')

--- a/frontend/src/views/DocumentView.vue
+++ b/frontend/src/views/DocumentView.vue
@@ -167,7 +167,7 @@ onUnmounted(() => {
 
     <div v-else-if="docContent" class="document-content">
       <div v-if="isCached" class="cached-badge">cached</div>
-      <div ref="docBody" class="document-body" @click="handleContentClick" v-html="sanitizedContent" />
+      <div ref="docBody" class="document-body md-body" @click="handleContentClick" v-html="sanitizedContent" />
     </div>
 
     <div v-else class="empty-state">
@@ -335,126 +335,8 @@ onUnmounted(() => {
   text-transform: uppercase;
 }
 
-.document-body {
-  font-size: 15px;
-  line-height: 1.7;
-  color: var(--text-color);
-}
-
-/* Style injected HTML content */
-.document-body :deep(h1),
-.document-body :deep(h2),
-.document-body :deep(h3) {
-  margin: 24px 0 12px;
-  color: var(--text-color);
-}
-
-.document-body :deep(h1:first-child),
-.document-body :deep(h2:first-child),
-.document-body :deep(h3:first-child) {
-  margin-top: 0;
-}
-
-.document-body :deep(h1) {
-  font-size: 28px;
-}
-
-.document-body :deep(h2) {
-  font-size: 22px;
-}
-
-.document-body :deep(h3) {
-  font-size: 18px;
-}
-
-.document-body :deep(p) {
-  margin: 0 0 16px;
-}
-
-.document-body :deep(ul),
-.document-body :deep(ol) {
-  margin: 0 0 16px;
-  padding-left: 24px;
-}
-
-.document-body :deep(li) {
-  margin-bottom: 6px;
-}
-
-.document-body :deep(pre) {
-  background: var(--hover-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  padding: 16px;
-  overflow-x: auto;
-  font-size: 13px;
-}
-
-.document-body :deep(code) {
-  background: var(--hover-bg);
-  color: var(--text-color);
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
-}
-
-.document-body :deep(pre code) {
-  background: none;
-  padding: 0;
-}
-
-.document-body :deep(table) {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 16px 0;
-}
-
-.document-body :deep(th),
-.document-body :deep(td) {
-  padding: 10px 14px;
-  text-align: left;
-  border: 1px solid var(--border-color);
-}
-
-.document-body :deep(th) {
-  background: var(--hover-bg);
-  font-weight: 600;
-}
-
-.document-body :deep(hr) {
-  border: none;
-  border-top: 1px solid var(--border-color);
-  margin: 32px 0;
-}
-
-.document-body :deep(blockquote) {
-  margin: 16px 0;
-  padding: 16px 20px;
-  background: var(--hover-bg);
-  border-left: 4px solid var(--accent-color);
-  color: var(--muted-text);
-}
-
-.document-body :deep(img) {
-  max-width: 100%;
-  height: auto;
-}
-
-.document-body :deep(a) {
-  color: var(--accent-color);
-  text-decoration: none;
-}
-
-.document-body :deep(a:hover) {
-  text-decoration: underline;
-}
-
-kbd {
-  padding: 2px 6px;
-  background: var(--hover-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
-  font-size: 12px;
-  font-family: inherit;
-}
+/* All rendered-markdown element styling (headings, paragraphs, lists, code,
+   pre, blockquote, hr, img, links, tables, kbd) is shared across every
+   markdown surface via the `.md-body` class on the `.document-body` container
+   — see styles/markdown-content.css. */
 </style>

--- a/tickets/entities/implementation-checklists/IMPL-9UKGGQ.md
+++ b/tickets/entities/implementation-checklists/IMPL-9UKGGQ.md
@@ -1,0 +1,55 @@
+---
+id: IMPL-9UKGGQ
+type: implementation-checklist
+title: 'Implementation: Style markdown-rendered tables in data-entry content views'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (markdown.test.ts: "renders GFM tables as table/th/td elements" — guards the structural contract the `.md-body` CSS binds to)
+- [x] ~~Integration tests written~~ (N/A: CSS-only change; the structural contract is unit-tested and both renderers' GFM output is verified below)
+- [x] Happy path implemented (shared `.md-body` table CSS in `frontend/src/styles/markdown-content.css`, applied to all three markdown surfaces)
+- [x] Edge cases handled (wide tables scroll via container `overflow-x: auto`; narrow tables keep `width: 100%` fill — no `display:block` shrink-wrap regression)
+- [x] ~~Error handling~~ (N/A: pure CSS + class attribute; no error paths)
+
+## Test Quality
+
+- [x] ~~Fixture builders/factories~~ (N/A: single inline markdown string is the input under test)
+- [x] No hardcoded values in assertions where an object is in scope (assertions are on rendered HTML fragments, the actual output)
+- [x] Only specifying values that matter (asserts `<table>`, one `<th>`, one `<td>` — the structural contract, not full HTML)
+- [x] ~~Interpolated values from objects~~ (N/A)
+- [x] ~~Property comparisons use original object~~ (N/A)
+
+## Manual Verification
+
+- [x] Feature verified end-to-end (see evidence)
+- [x] Each acceptance criterion verified
+- [x] Edge cases verified (wide-table scroll, narrow-table fill)
+
+**Verification Evidence:**
+
+- Full frontend suite: `npm run test:run` → 72 files, 1160 tests pass (incl. new table test).
+- `npm run typecheck` clean; `npm run lint` 0 errors (only pre-existing warnings, none in touched files); `npm run build` succeeds.
+- Compiled CSS in the production bundle confirmed correct:
+`.md-body{overflow-x:auto}` · `.md-body
+table{border-collapse:collapse;width:100%;margin:16px 0}` · `.md-body
+th,.md-body td{...;border:1px solid var(--border-color);padding:8px 12px}` ·
+`.md-body th{background:var(--hover-bg);font-weight:600}`.
+- Both renderers emit a bare `<table>` that `.md-body table` matches: client `marked` with `gfm:true`
+(unit-tested) and server goldmark with `extension.GFM`/`extension.Table`
+(`internal/dataentry/document.go:334-335`).
+- Live-browser verification was attempted but the Chrome extension was not connected; verified instead via
+compiled-CSS inspection + renderer-output confirmation + the structural unit
+test. Theming is inherited from existing tokens (`--border-color`,
+`--hover-bg`), so light/dark are handled without an override.
+
+## Quality
+
+- [x] Code follows project patterns (global stylesheet + class, mirroring the `styles/back-button.css` / `.scope-nav-btn` precedent)
+- [x] Checked for DRY opportunities (removed the duplicated `.document-body :deep(table/th/td)` blocks from DocumentView + DocumentsPanel; the broader heading/code CSS drift is filed as follow-up TKT-W3OPRX rather than over-scoped here)
+- [x] No security issues introduced (CSS + static class; v-html/DOMPurify path unchanged)
+- [x] No silent failures (N/A — no code paths)
+- [x] No debug code left behind (temporary test-table entity edits reverted via `git checkout`)

--- a/tickets/entities/review-checklists/REV-IX408L.md
+++ b/tickets/entities/review-checklists/REV-IX408L.md
@@ -1,0 +1,60 @@
+---
+id: REV-IX408L
+type: review-checklist
+title: 'Review: Style markdown-rendered tables in data-entry content views'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`npm run test:run` → 72 files, 1160 tests pass)
+- [x] Lint clean (`npm run lint` → 0 errors; only pre-existing warnings, none in touched files)
+- [x] ~~Coverage maintained (`just coverage-check`)~~ (N/A: frontend has no coverage enforcement per CLAUDE.md — "The frontend has no coverage enforcement". No Go code changed.)
+
+## Code Review
+
+- [x] Ran cranky-code-reviewer on the diff
+- [x] ~~All critical review-responses addressed~~ (N/A: no critical findings)
+- [x] All significant review-responses addressed (RR-5ZVPC5: replaced `display:block` with container-scroll + restored `width:100%` fill)
+- [x] Self-reviewed the diff for unrelated changes (net −16 lines in components from de-dup + new shared stylesheet; nothing unrelated)
+
+**Review Responses:** RR-5ZVPC5 (significant, addressed), RR-E6HYNB (minor,
+addressed). Naming nit (`md-table`→`md-body`) applied. Leverage opportunity
+(consolidate remaining triplicated heading/code CSS) filed as follow-up
+TKT-W3OPRX.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented in implementation checklist (IMPL-9UKGGQ)
+
+**Acceptance Status:**
+
+1. GFM table renders with borders/header/padding — **PASS** (compiled CSS: 1px `--border-color` cell borders, `--hover-bg` bold header, 8px 12px padding; structural unit test confirms `<table>/<th>/<td>`).
+2. Wide tables scroll horizontally — **PASS** (`.md-body { overflow-x: auto }` scrolls a table wider than the container without pushing the page).
+3. Identical styling across EntityDetail/DocumentView/DocumentsPanel from one source — **PASS** (all three carry the `md-body` class; per-component table rules removed; single `markdown-content.css`).
+4. Light + dark theming — **PASS** (colors from `--border-color`/`--hover-bg` tokens; no per-theme override needed).
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created~~ (N/A: internal UI styling fix, no user-facing docs surface documents markdown table appearance)
+- [x] ~~User-facing documentation updated~~ (N/A: no documented behavior changes; tables simply render styled now)
+- [x] ~~Docs-checklist marked done~~ (N/A)
+
+**Docs Checklist:** none (N/A)
+
+## Final Checks
+
+- [x] Commit message will explain the why (unstyled markdown tables → shared `.md-body` stylesheet), not just the what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] ~~Run `/pr`~~ (deferred: PR creation is the user's call — changes are committed-ready but not yet committed/pushed pending user go-ahead)
+- [ ] ~~All CI checks pass~~ (pending PR)
+- [ ] ~~PR URL documented~~ (pending PR)
+
+**PR:** not yet created — awaiting user decision to run `/pr`.

--- a/tickets/entities/review-responses/RR-5ZVPC5.md
+++ b/tickets/entities/review-responses/RR-5ZVPC5.md
@@ -1,0 +1,17 @@
+---
+id: RR-5ZVPC5
+type: review-response
+title: display:block breaks width:100% fill on narrow tables; comment misrepresents it
+finding: 'The shared `.md-table table` rule uses `display: block; overflow-x: auto` to make wide tables scroll without a wrapper. But `display: block` drops table-layout at the outer box, so `width: 100%` no longer fills the container — narrow tables shrink-wrap and hug the left, a visible change vs the old `width: 100%` rules. The docblock claim that tables ''still render normally'' when they fit is inaccurate.'
+severity: significant
+resolution: 'Moved `overflow-x: auto` from the table onto the `.md-body` container and restored `display: table; width: 100%` on the table itself. Narrow tables now fill the container as before; a table wider than the container scrolls horizontally within the body (the container only grows a scrollbar when a child overflows on x, and tables are the sole wide block). Renamed the class `md-table` -> `md-body` and removed the inaccurate ''renders normally'' comment; the docblock now describes the container-scroll approach accurately.'
+status: addressed
+---
+
+**Finding:** The shared `.md-table table` rule uses `display: block; overflow-x:
+auto` to make wide tables scroll without a wrapper element. But `display: block`
+takes the table out of table-layout at the outer box, so `width: 100%` no longer
+fills the container — narrow tables shrink-wrap their content and hug the left,
+a visible change vs the old `width: 100%` rules on DocumentView/DocumentsPanel.
+The docblock's claim that tables "still render normally" when they fit is
+inaccurate.

--- a/tickets/entities/review-responses/RR-E6HYNB.md
+++ b/tickets/entities/review-responses/RR-E6HYNB.md
@@ -1,0 +1,15 @@
+---
+id: RR-E6HYNB
+type: review-response
+title: Undocumented padding/margin standardization changes DocumentView/DocumentsPanel spacing
+finding: 'Consolidating to shared rules silently changed spacing: DocumentView cell padding 10px 14px -> 8px 12px (tighter); DocumentsPanel table margin 12px 0 -> 16px 0 (looser). Defensible standardizations but undocumented.'
+severity: minor
+resolution: Added a docblock note in markdown-content.css recording the unified values (cell padding 8px 12px, table margin 16px 0) and the previous per-component values that changed (DocumentView padding 10px 14px, DocumentsPanel margin 12px 0).
+status: addressed
+---
+
+**Finding:** Consolidating to shared rules silently changed spacing:
+DocumentView cell padding 10px 14px → 8px 12px (tighter); DocumentsPanel table
+margin 12px 0 → 16px 0 (looser). Both are defensible standardizations but
+undocumented, so a future reader sees an unexplained density change. Add a
+docblock note recording the unified values and the previous per-component ones.

--- a/tickets/entities/tickets/TKT-W3OPRX.md
+++ b/tickets/entities/tickets/TKT-W3OPRX.md
@@ -1,0 +1,25 @@
+---
+id: TKT-W3OPRX
+type: ticket
+title: Consolidate remaining triplicated markdown-body CSS into shared .md-body stylesheet
+kind: refactor
+priority: low
+effort: s
+status: done
+---
+
+# Consolidate remaining triplicated markdown-body CSS into shared .md-body stylesheet
+
+**RESOLVED / SUBSUMED by TKT-YYZRGW.** That ticket's scope grew from tables-only
+into a full markdown style-fixes PR that moved *all* shared markdown element CSS
+(headings, lists, code, blockquote, hr, img, links, tables, kbd) into
+`frontend/src/styles/markdown-content.css` under `.md-body`, removed the
+per-component copies, re-skinned the EasyMDE preview, and added a mirror-sync
+test. Nothing left to do here.
+
+---
+
+(Original) The three components each carried near-identical `:deep(...)`
+markdown element blocks that had drifted (h1 28px vs 24px). Consolidating them
+into the shared `.md-body` sheet was the follow-up leverage win — now done as
+part of TKT-YYZRGW.

--- a/tickets/entities/tickets/TKT-YYZRGW.md
+++ b/tickets/entities/tickets/TKT-YYZRGW.md
@@ -1,0 +1,71 @@
+---
+id: TKT-YYZRGW
+type: ticket
+title: Consistent markdown styling across data-entry render surfaces
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+# Consistent markdown styling across data-entry render surfaces
+
+## Problem
+
+Rendered markdown looked inconsistent and sometimes broken across the four
+surfaces that display it in the data-entry SPA:
+
+- **Tables** in entity content bodies had no borders/padding at all (the
+original report).
+- **Blockquotes** (`> text`) were unstyled in the EasyMDE live-preview pane.
+- **Lists** rendered with wrong/missing markers in the preview.
+- The EasyMDE preview used the library's hardcoded light-theme defaults
+(borderless `#ddd`/5px tables, no header shading), so it didn't reflect what the
+entity view actually renders.
+
+Root cause: each Vue component (`EntityDetail`, `DocumentView`,
+`DocumentsPanel`) kept its **own copy** of markdown element CSS, and they had
+drifted (h1 24px vs 28px; EntityDetail had no blockquote/pre/hr/img rules at
+all). The EasyMDE preview had no re-skin.
+
+## Solution
+
+Single source of truth: `frontend/src/styles/markdown-content.css` (loaded once
+from `main.ts`), keyed on:
+- `.md-body` — the three v-html surfaces (all now carry the class).
+- `.EasyMDEContainer .editor-preview` — the EasyMDE live preview (specificity
+beats the library's bundled defaults regardless of load order).
+
+Covers every element: headings (h1–h6), p, ul/ol/li (with nested
+disc→circle→square cascade + restored markers), task-list checkboxes (bullet
+removed, aligned; handles both tight `<li><input>` and loose `<li><p><input>`
+shapes), code, pre, blockquote, hr, img, links, tables, kbd. All colors from
+theme tokens → light + dark for free.
+
+The per-component CSS blocks were removed (net −130 lines). The sandboxed
+app-editor bundle (`app-editor/relaEditorTheme.css`) inlines its own CSS and
+can't load the global sheet, so the `.editor-preview` rules are mirrored there —
+and a new test (`markdownContentMirror.test.ts`) asserts the two copies stay
+identical, so the drift this PR fixes can't silently return.
+
+## Acceptance criteria
+
+1. Tables, blockquotes, lists, code, task-lists render styled and consistent
+across EntityDetail, DocumentView, DocumentsPanel, and the EasyMDE preview.
+2. Wide tables scroll horizontally; long unbroken tokens wrap (no body-wide
+scrollbar).
+3. All styling from one shared source; light + dark via tokens.
+4. A test fails CI if the app-editor mirror drifts from the shared sheet.
+
+## Verification
+
+- `npm run typecheck` clean; `npm run test:run` 73 files / 1163 tests pass
+(incl. new GFM-table structural test + mirror sync test); `npm run lint` 0
+errors; `npm run build` succeeds.
+- Puppeteer visual + computed-style verification against a live server on the
+entity view and the EasyMDE side-by-side preview: borders, header shading, list
+markers, nested cascade, task-list bullet removal, blockquote accent bar,
+long-URL wrap (no horizontal overflow) all confirmed in dark mode; theming is
+token-driven so light mode follows by construction.
+
+Subsumes follow-up TKT-W3OPRX (consolidate remaining triplicated markdown CSS).

--- a/tickets/relations/TKT-W3OPRX--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-W3OPRX--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-W3OPRX
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-W3OPRX--implements--FEAT-023.md
+++ b/tickets/relations/TKT-W3OPRX--implements--FEAT-023.md
@@ -1,0 +1,5 @@
+---
+from: TKT-W3OPRX
+relation: implements
+to: FEAT-023
+---

--- a/tickets/relations/TKT-YYZRGW--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-YYZRGW--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YYZRGW
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-YYZRGW--has-implementation--IMPL-9UKGGQ.md
+++ b/tickets/relations/TKT-YYZRGW--has-implementation--IMPL-9UKGGQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YYZRGW
+relation: has-implementation
+to: IMPL-9UKGGQ
+---

--- a/tickets/relations/TKT-YYZRGW--has-review--REV-IX408L.md
+++ b/tickets/relations/TKT-YYZRGW--has-review--REV-IX408L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YYZRGW
+relation: has-review
+to: REV-IX408L
+---

--- a/tickets/relations/TKT-YYZRGW--has-review-response--RR-5ZVPC5.md
+++ b/tickets/relations/TKT-YYZRGW--has-review-response--RR-5ZVPC5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YYZRGW
+relation: has-review-response
+to: RR-5ZVPC5
+---

--- a/tickets/relations/TKT-YYZRGW--has-review-response--RR-E6HYNB.md
+++ b/tickets/relations/TKT-YYZRGW--has-review-response--RR-E6HYNB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YYZRGW
+relation: has-review-response
+to: RR-E6HYNB
+---

--- a/tickets/relations/TKT-YYZRGW--implements--FEAT-023.md
+++ b/tickets/relations/TKT-YYZRGW--implements--FEAT-023.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YYZRGW
+relation: implements
+to: FEAT-023
+---


### PR DESCRIPTION
## Summary

Rendered markdown looked inconsistent (and sometimes broken) across the four surfaces that display it in the data-entry SPA:

- **Tables** in entity content bodies had no borders/padding (the original report).
- **Blockquotes** and **lists** were unstyled / had wrong markers in the EasyMDE live-preview pane.
- The EasyMDE preview used the library's hardcoded light-theme defaults, so it didn't reflect what the entity view actually renders.

Root cause: `EntityDetail`, `DocumentView`, and `DocumentsPanel` each kept their **own copy** of markdown element CSS, and they had drifted (h1 24px vs 28px; EntityDetail had no blockquote/pre/hr/img rules at all). The EasyMDE preview had no re-skin.

## Change

Single source of truth: `frontend/src/styles/markdown-content.css` (loaded once from `main.ts`), keyed on:

- `.md-body` — the three v-html surfaces (all now carry the class).
- `.EasyMDEContainer .editor-preview` — the EasyMDE live preview (specificity beats the library's bundled defaults regardless of load order).

Covers every element: headings (h1–h6), p, ul/ol/li (nested disc→circle→square + restored markers), task-list checkboxes (bullet removed, aligned; handles both tight `<li><input>` and loose `<li><p><input>` shapes), code, pre, blockquote, hr, img, links, tables, kbd. All colors from theme tokens → light + dark for free. Long unbroken tokens wrap; wide tables scroll horizontally.

Per-component CSS blocks removed (**net −130 lines**). The sandboxed app-editor bundle (`app-editor/relaEditorTheme.css`) inlines its own CSS and can't load the global sheet, so the `.editor-preview` rules are mirrored there — and a new test (`markdownContentMirror.test.ts`) asserts the two copies stay identical, so this drift can't silently return.

## Verification

- `npm run typecheck` clean; `npm run test:run` 73 files / 1163 tests pass (incl. new GFM-table structural test + mirror sync test); `npm run lint` 0 errors; `npm run build` succeeds.
- `rela validate` (cardinality/properties/validations) passes.
- Puppeteer visual + computed-style verification on the entity view and the EasyMDE side-by-side preview: borders, header shading, list markers, nested cascade, task-list bullet removal, blockquote accent bar, long-URL wrap all confirmed.

Ticket: TKT-YYZRGW. Subsumes follow-up TKT-W3OPRX.