### PR TITLE
feat(dataentry): admin-authored header/footer info on list views (TKT-H7E611)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -579,7 +579,9 @@ lists:
 | ----------------- | ------ | ----------------------------------------------------------- |
 | `entity_type`     | string | Entity type to list                                         |
 | `title`           | string | List heading                                                |
-| `description`     | string | Subtitle                                                    |
+| `header`          | string | Markdown rendered above the list (info/help; see below)     |
+| `footer`          | string | Markdown rendered below the list                            |
+| `description`     | string | Legacy alias for `header`; used only when `header` is unset  |
 | `columns`         | list   | Column definitions                                          |
 | `sort`            | object | Default sort order                                          |
 | `filters`         | list   | Static filters (always applied)                             |
@@ -588,6 +590,38 @@ lists:
 | `edit_form`       | string | Form name for the row edit action                           |
 | `page_size`       | int    | Rows per page (default: 25)                                 |
 | `actions`         | list   | Action IDs available as keyboard shortcuts on selected rows |
+
+#### Header and footer info regions
+
+`header` and `footer` add admin-authored context to a list — a short
+description, links to relevant guides, or a process note. Both accept Markdown
+(GFM: headings, lists, links, emphasis, tables) and render as sanitized HTML
+above and below the list respectively. Content is authored in `data-entry.yaml`
+only; there is no in-app editor.
+
+```yaml
+lists:
+  risicoregister:
+    entity_type: risico
+    title: "Risicoregister"
+    header: |
+      This register is **ISO 27001** scope. See the
+      [scoring guide](/entity/guide-risk-scoring) for how KANS and IMPACT map to
+      a level. New risks are reviewed weekly.
+    footer: |
+      _Questions? Contact the security officer._
+    columns:
+      - property: title
+        sortable: true
+```
+
+Notes:
+
+- Output is sanitized (DOMPurify), so raw HTML/scripts in the config cannot
+  inject executable markup.
+- Use standard Markdown links (`[text](/entity/ID)`) to point at other entities.
+- `description` is the older name for the top region and still works; when both
+  `header` and `description` are set, `header` wins.
 
 ### Column Options
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -573,7 +573,9 @@ lists:
 | ----------------- | ------ | ----------------------------------------------------------- |
 | `entity_type`     | string | Entity type to list                                         |
 | `title`           | string | List heading                                                |
-| `description`     | string | Subtitle                                                    |
+| `header`          | string | Markdown rendered above the list (info/help; see below)     |
+| `footer`          | string | Markdown rendered below the list                            |
+| `description`     | string | Legacy alias for `header`; used only when `header` is unset  |
 | `columns`         | list   | Column definitions                                          |
 | `sort`            | object | Default sort order                                          |
 | `filters`         | list   | Static filters (always applied)                             |
@@ -582,6 +584,38 @@ lists:
 | `edit_form`       | string | Form name for the row edit action                           |
 | `page_size`       | int    | Rows per page (default: 25)                                 |
 | `actions`         | list   | Action IDs available as keyboard shortcuts on selected rows |
+
+#### Header and footer info regions
+
+`header` and `footer` add admin-authored context to a list — a short
+description, links to relevant guides, or a process note. Both accept Markdown
+(GFM: headings, lists, links, emphasis, tables) and render as sanitized HTML
+above and below the list respectively. Content is authored in `data-entry.yaml`
+only; there is no in-app editor.
+
+```yaml
+lists:
+  risicoregister:
+    entity_type: risico
+    title: "Risicoregister"
+    header: |
+      This register is **ISO 27001** scope. See the
+      [scoring guide](/entity/guide-risk-scoring) for how KANS and IMPACT map to
+      a level. New risks are reviewed weekly.
+    footer: |
+      _Questions? Contact the security officer._
+    columns:
+      - property: title
+        sortable: true
+```
+
+Notes:
+
+- Output is sanitized (DOMPurify), so raw HTML/scripts in the config cannot
+  inject executable markup.
+- Use standard Markdown links (`[text](/entity/ID)`) to point at other entities.
+- `description` is the older name for the top region and still works; when both
+  `header` and `description` are set, `header` wins.
 
 ### Column Options
 

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -13,9 +13,11 @@ import { beginOptimisticRemove, rollbackOptimistic } from '@/queries/optimisticL
 import { toApiOperator, filterStateToApiParams } from '@/utils/filters'
 import { entityDetailHref } from '@/utils/entityRoute'
 import { entityDisplayTitle } from '@/utils/entityDisplay'
+import { renderMarkdown } from '@/utils/markdown'
 import { actionAllowed } from '@/utils/affordancesWarning'
 import { getCellValue, formatCellValue, isEnumPropertyDef, asArray } from '@/utils/format'
 import type { Entity, ListMeta, ListParams, ListResponse, FilterState } from '@/types'
+import { listHeaderMarkdown, listFooterMarkdown } from '@/types'
 import FilterBar from './FilterBar.vue'
 import Pagination from './Pagination.vue'
 import SearchBox from './SearchBox.vue'
@@ -248,6 +250,14 @@ const entityType = computed(() => {
   if (!listConfig.value) return undefined
   return schemaStore.getEntityType(listConfig.value.entity)
 })
+
+// Admin-authored info regions (markdown from data-entry.yaml, sanitized by
+// renderMarkdown). `header` is canonical; `description` (previously unused) is a
+// fallback for the top slot, used only when `header` is unset. No refResolver
+// here — the /_config endpoint carries no mentions map, so bare-ID code spans
+// stay inert; standard [text](/entity/ID) links work.
+const headerHtml = computed(() => renderMarkdown(listHeaderMarkdown(listConfig.value)))
+const footerHtml = computed(() => renderMarkdown(listFooterMarkdown(listConfig.value)))
 
 // Pre-configured filters from list config
 const configuredFilters = computed(() => {
@@ -652,6 +662,9 @@ watch(searchQuery, () => {
       </router-link>
     </header>
 
+    <!-- eslint-disable-next-line vue/no-v-html -- sanitized by renderMarkdown -->
+    <div v-if="headerHtml" class="list-info list-info--top" v-html="headerHtml"/>
+
     <div v-if="configuredFilters.length" class="configured-filters">
       <span
         v-for="filter in configuredFilters"
@@ -913,6 +926,9 @@ watch(searchQuery, () => {
         @page-change="handlePageChange"
       />
     </div>
+
+    <!-- eslint-disable-next-line vue/no-v-html -- sanitized by renderMarkdown -->
+    <div v-if="footerHtml" class="list-info list-info--bottom" v-html="footerHtml"/>
   </div>
 
   <div v-else class="error-state">
@@ -926,6 +942,48 @@ watch(searchQuery, () => {
   color: var(--color-text-muted, #888);
   font-style: italic;
   cursor: help;
+}
+
+/* Admin-authored info regions (header/footer markdown). Rendered HTML is
+   sanitized by renderMarkdown; these styles only govern typography/spacing. */
+.list-info {
+  color: var(--text-color);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.list-info--top {
+  /* Pulls up against .list-header's margin-bottom: 24px so the info sits close
+     to the title rather than a full gap below it. Keep in sync if that changes. */
+  margin-top: -12px;
+  margin-bottom: 20px;
+}
+
+.list-info--bottom {
+  margin-top: 24px;
+}
+
+.list-info :deep(> :first-child) {
+  margin-top: 0;
+}
+
+.list-info :deep(> :last-child) {
+  margin-bottom: 0;
+}
+
+.list-info :deep(p),
+.list-info :deep(ul),
+.list-info :deep(ol) {
+  margin: 0 0 8px;
+}
+
+.list-info :deep(a) {
+  color: var(--accent-color);
+  text-decoration: none;
+}
+
+.list-info :deep(a:hover) {
+  text-decoration: underline;
 }
 
 .entity-list {

--- a/frontend/src/types/config.test.ts
+++ b/frontend/src/types/config.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect } from 'vitest'
-import { getEditFormId, type FormConfig } from './config'
+import {
+  getEditFormId,
+  listHeaderMarkdown,
+  listFooterMarkdown,
+  type FormConfig,
+  type ListConfig,
+} from './config'
+
+const list = (over: Partial<ListConfig>): ListConfig => ({
+  entity: 'risico',
+  columns: [],
+  ...over,
+})
 
 describe('config', () => {
   describe('getEditFormId', () => {
@@ -53,6 +65,54 @@ describe('config', () => {
       }
 
       expect(getEditFormId(schemaStore, 'task')).toBe('task-edit')
+    })
+  })
+
+  describe('listHeaderMarkdown', () => {
+    it('returns header when set', () => {
+      expect(listHeaderMarkdown(list({ header: '# Hi' }))).toBe('# Hi')
+    })
+
+    it('falls back to description (legacy alias) when header is unset', () => {
+      expect(listHeaderMarkdown(list({ description: 'legacy' }))).toBe('legacy')
+    })
+
+    it('prefers header over description when both are set', () => {
+      expect(listHeaderMarkdown(list({ header: 'new', description: 'legacy' }))).toBe('new')
+    })
+
+    it('ignores an empty header and falls back to description', () => {
+      expect(listHeaderMarkdown(list({ header: '', description: 'legacy' }))).toBe('legacy')
+    })
+
+    it('treats a whitespace-only header as unset and falls back to description', () => {
+      expect(listHeaderMarkdown(list({ header: '   \n', description: 'legacy' }))).toBe('legacy')
+    })
+
+    it('returns empty string when both are whitespace-only', () => {
+      expect(listHeaderMarkdown(list({ header: '  ', description: '\t' }))).toBe('')
+    })
+
+    it('returns empty string when neither is set', () => {
+      expect(listHeaderMarkdown(list({}))).toBe('')
+    })
+
+    it('returns empty string for an undefined list', () => {
+      expect(listHeaderMarkdown(undefined)).toBe('')
+    })
+  })
+
+  describe('listFooterMarkdown', () => {
+    it('returns footer when set', () => {
+      expect(listFooterMarkdown(list({ footer: 'bye' }))).toBe('bye')
+    })
+
+    it('returns empty string when unset', () => {
+      expect(listFooterMarkdown(list({}))).toBe('')
+    })
+
+    it('returns empty string for an undefined list', () => {
+      expect(listFooterMarkdown(undefined)).toBe('')
     })
   })
 })

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -124,6 +124,11 @@ export interface FormFieldOrRelation {
 export interface ListConfig {
   entity: string
   title?: string
+  /** Markdown rendered above the list. `description` is a fallback alias. */
+  header?: string
+  /** Markdown rendered below the list. */
+  footer?: string
+  /** Fallback for `header`; the previously-unused field, used when `header` is unset. */
   description?: string
   columns: ListColumn[]
   filters?: ListFilter[]
@@ -133,6 +138,22 @@ export interface ListConfig {
   edit_form?: string
   page_size?: number
   actions?: string[]
+}
+
+/**
+ * Resolve the raw markdown for a list's top info region. `header` is canonical;
+ * `description` is a fallback — the field predates this feature but was never
+ * rendered, so we adopt it as an alias rather than require every config to be
+ * rewritten. Returns '' when neither is set (a blank/whitespace-only value is
+ * treated as unset). The caller passes the result through renderMarkdown.
+ */
+export function listHeaderMarkdown(list: ListConfig | undefined): string {
+  return list?.header?.trim() || list?.description?.trim() || ''
+}
+
+/** Resolve the raw markdown for a list's bottom info region ('' when unset). */
+export function listFooterMarkdown(list: ListConfig | undefined): string {
+  return list?.footer?.trim() || ''
 }
 
 // Helper to get edit form for an entity type

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -182,9 +182,17 @@ type RelationProperty struct {
 }
 
 // List defines a list view for an entity type.
+//
+// Header and Footer carry admin-authored markdown rendered above and below the
+// list, respectively (sanitized client-side via renderMarkdown). Description
+// predates this feature but was never rendered; the SPA now adopts it as a
+// fallback for Header (used only when Header is empty) so existing configs that
+// happen to set it get a header region without a rewrite.
 type List struct {
 	EntityType     string          `yaml:"entity_type" json:"entity"`
 	Title          string          `yaml:"title" json:"title"`
+	Header         string          `yaml:"header" json:"header,omitempty"`
+	Footer         string          `yaml:"footer" json:"footer,omitempty"`
 	Description    string          `yaml:"description" json:"description,omitempty"`
 	Columns        []ListColumn    `yaml:"columns" json:"columns"`
 	Sort           []SortSpec      `yaml:"sort,omitempty" json:"default_sort,omitempty"`

--- a/internal/dataentryconfig/config_test.go
+++ b/internal/dataentryconfig/config_test.go
@@ -1,6 +1,7 @@
 package dataentryconfig
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -322,6 +323,55 @@ fields:
 	// outgoing everywhere (IsIncoming is false).
 	if got := card.Fields[3]; got.Relation != "blocks" || got.Direction.IsIncoming() {
 		t.Errorf("fields[3]: got %+v, want relation=blocks direction=outgoing", got)
+	}
+}
+
+func TestListHeaderFooter_YAMLAndJSON(t *testing.T) {
+	// header/footer decode from YAML and serialize to JSON so the SPA (which
+	// resolves the header/description alias client-side) receives both fields.
+	const src = `
+entity_type: risico
+title: Risicoregister
+header: |
+  This register is **ISO 27001** scope.
+footer: See the security officer.
+`
+	var list List
+	if err := yaml.Unmarshal([]byte(src), &list); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got, want := list.Header, "This register is **ISO 27001** scope.\n"; got != want {
+		t.Errorf("header: got %q, want %q", got, want)
+	}
+	if got, want := list.Footer, "See the security officer."; got != want {
+		t.Errorf("footer: got %q, want %q", got, want)
+	}
+
+	data, err := json.Marshal(list)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal json: %v", err)
+	}
+	if _, ok := out["header"]; !ok {
+		t.Errorf("json missing header key: %s", data)
+	}
+	if _, ok := out["footer"]; !ok {
+		t.Errorf("json missing footer key: %s", data)
+	}
+}
+
+func TestList_EmptyHeaderFooterOmittedFromJSON(t *testing.T) {
+	// omitempty keeps the wire payload clean when no info regions are set, so
+	// the SPA renders nothing and legacy lists are unaffected.
+	data, err := json.Marshal(List{EntityType: "risico", Title: "Risicoregister"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "header") || strings.Contains(string(data), "footer") {
+		t.Errorf("expected no header/footer keys, got %s", data)
 	}
 }
 

--- a/tickets/data-entry.yaml
+++ b/tickets/data-entry.yaml
@@ -686,7 +686,11 @@ lists:
   all_ideas:
     entity_type: idea
     title: "All Ideas"
-    description: "Browse all captured ideas"
+    header: |
+      Browse all captured ideas. New ideas start in **inbox** — triage them
+      into `explored` or `rejected` during weekly review.
+    footer: |
+      _Tip: use the filters above to focus on a single status or category._
     columns:
       - property: title
         sortable: true

--- a/tickets/entities/features/FEAT-RUGB28.md
+++ b/tickets/entities/features/FEAT-RUGB28.md
@@ -1,0 +1,9 @@
+---
+id: FEAT-RUGB28
+type: feature
+title: Info content on data-entry list views
+summary: Admin-authored markdown header/footer content on list views, rendered from data-entry.yaml
+description: Allow admins to add contextual info (prose, links to guides, callouts) at the top and bottom of a data-entry list view, authored in data-entry.yaml and rendered as sanitized markdown. Provides users with in-context guidance on a register/list page (e.g. "this register is ISO 27001 scope, see the scoring guide"). Designed as a seam that can later accept entity/query-backed blocks without breaking config.
+priority: medium
+status: implemented
+---

--- a/tickets/entities/implementation-checklists/IMPL-MNPA55.md
+++ b/tickets/entities/implementation-checklists/IMPL-MNPA55.md
@@ -1,0 +1,55 @@
+---
+id: IMPL-MNPA55
+type: implementation-checklist
+title: 'Implementation: Render admin-authored header/footer markdown on list views'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] ~~Integration tests written~~ (N/A: rendering is `v-if` + `v-html` of a unit-tested computed; a full EntityList mount would require heavy Pinia-Colada/router/SSE mocking to test framework glue. Covered by helper unit tests + live `/_config` verification + built-bundle check instead.)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (renderMarkdown returns '' for empty; `v-if` guards absent regions)
+
+## Test Quality
+
+- [x] Using a `list(over)` fixture builder for ListConfig test data
+- [x] No hardcoded values where an object is in scope
+- [x] Only specifying values that matter per test
+
+## Manual Verification
+
+- [x] Feature verified end-to-end (API + build)
+- [x] Each acceptance criterion verified
+- [x] Edge cases verified
+
+**Verification Evidence:**
+
+Changes:
+- Go: `List` gains `Header`/`Footer` (`internal/dataentryconfig/config.go`), both `omitempty`. Frontend does the `header || description` precedence, so no Go alias mutation of shared config.
+- TS: `ListConfig` gains `header?`/`footer?`; `listHeaderMarkdown`/`listFooterMarkdown` helpers (`config.ts`) resolve precedence.
+- Vue: `EntityList.vue` renders two `v-if`-guarded `.list-info` regions via `renderMarkdown()` (sanitized), with scoped CSS.
+- Example: `tickets/data-entry.yaml` `all_ideas` list now uses `header`/`footer`.
+
+Evidence:
+1. **AC1/AC2 (header/footer served):** `curl -H "Origin: …" /api/v1/_config` on the tickets project returns `all_ideas.header` = "Browse all captured ideas… weekly review." and `all_ideas.footer` = "*Tip: use the filters…*". `description` = null.
+2. **AC3 (sanitization):** reuses `renderMarkdown` (DOMPurify); existing `markdown.test.ts` covers `<script>`/`onerror` stripping.
+3. **AC4/AC5 (absent → no region; precedence):** `config.test.ts` — 14 pass, incl. header-wins-over-description, empty-header→description fallback, undefined→'' for both slots. Go `config_test.go` — YAML/JSON round-trip + omitempty-when-unset pass.
+4. **Build:** `npm run build` → `static/v2/assets/ListView-*.{js,css}` contains `list-info--top/--bottom` classes + scoped `.list-info` CSS rules; render code compiled in.
+5. **Config validity:** `rela --project tickets validate` → data-entry.yaml valid.
+
+Browser screenshot verification was attempted but the Claude-in-Chrome extension
+was not connected; substituted API + built-bundle verification.
+
+## Quality
+
+- [x] Follows project patterns (mirrors EntityDetail.vue's `markdown-content` + eslint-disable `vue/no-v-html`; helper co-located with `getEditFormId` in config.ts)
+- [x] DRY: precedence extracted to `listHeaderMarkdown`/`listFooterMarkdown` (also makes it unit-testable without mounting)
+- [x] No security issues (only admin YAML input, still DOMPurify-sanitized; no new egress)
+- [x] No silent failures
+- [x] No debug code left behind
+- [x] `npm run typecheck` clean; `eslint` clean (pre-existing `max-lines` warning on EntityList only); Go `go test ./internal/dataentryconfig/ ./internal/dataentry/` pass

--- a/tickets/entities/planning-checklists/PLAN-M1WZM9.md
+++ b/tickets/entities/planning-checklists/PLAN-M1WZM9.md
@@ -1,0 +1,150 @@
+---
+id: PLAN-M1WZM9
+type: planning-checklist
+title: 'Planning: Render admin-authored header/footer markdown on list views'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: Admin-authored markdown info regions at the top and bottom of a data-entry
+list view, configured per-list in `data-entry.yaml`, rendered as
+DOMPurify-sanitized HTML. Authoring is admin-only (YAML); no UI editing.
+
+OUT: Entity-backed / query-backed info blocks (dashboard-card style) — left as
+an additive seam. Per-entity-type default info in the metamodel. Bare-entity-ID
+code-span resolution to titles (needs a server `mentions` map the `/_config`
+endpoint doesn't supply; standard `[text](/entity/ID)` markdown links work
+without it). End-user / in-UI authoring.
+
+**Acceptance Criteria:**
+1. List config with `header` markdown renders sanitized HTML above the search/filter row. Test: set header on a list, load `/list/:id`, assert rendered HTML present in header region.
+2. List config with `footer` markdown renders sanitized HTML below the table/pagination. Test: symmetric to (1) at the bottom region.
+3. Output is DOMPurify-sanitized. Test: header containing `<script>` / `<img onerror>` renders inert (no script tag survives) — covered by `renderMarkdown` reuse; add a unit test asserting sanitization at the call site.
+4. A list with no header/footer renders exactly as before — no empty region, no layout shift. Test: `v-if` guards; component test asserts no `.list-info` node when unset.
+5. Backward compatibility: existing `description` values keep working (rendered as the top/header region per the naming decision).
+
+## Research
+
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Reviewed relevant prior art
+
+**Existing Solutions:**
+- `renderMarkdown()` — `frontend/src/utils/markdown.ts:58`. Sanitizes via DOMPurify (line 111), GFM, optional `refResolver`/`interactive`. When no `refResolver` is passed it behaves as plain markdown — exactly our case.
+- Render pattern to copy: `EntityDetail.vue:868` — `<div class="markdown-content" v-html="renderMarkdown(section.content || '', refResolver)"/>`. Existing `v-html` sites carry `eslint-disable vue/no-v-html` (rule is `warn`).
+- `List.Description` — `internal/dataentryconfig/config.go:188` — plumbed end-to-end (Go → `/_config` JSON `description` → TS `ListConfig.description` at `config.ts:127`) but never rendered. Existing-but-unused hook.
+- Render sites — `EntityList.vue`: header block ends at line 653 (top region goes after it, before `.search-row` at 665); bottom region goes after `<Pagination>` (910-914), inside the `v-if="listConfig"` wrapper (closes line 916).
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns
+- [x] Alternatives considered
+- [x] Dependencies identified
+
+**Technical Approach (naming: `header`+`footer`, `description` as deprecated
+alias for `header`):**
+
+1. Go `internal/dataentryconfig/config.go` `List` struct: add
+`Header string \`yaml:"header" json:"header,omitempty"\``and`Footer string
+\`yaml:"footer" json:"footer,omitempty"\``. Keep the existing
+`Description`field. In the config load/normalize path, if`Header == "" &&
+Description != ""`, copy `Description`into`Header`(alias) so old configs render
+in the top slot. (Locate the normalize step near where lists are loaded; if none
+exists, do the fallback in the`/_config`assembly in`handleV1Config`.)
+2. TS `frontend/src/types/config.ts` `ListConfig`: add `header?: string` and
+`footer?: string` alongside existing `description?`.
+3. `EntityList.vue`:
+   - import `renderMarkdown` from `@/utils/markdown`.
+   - Add a computed `headerHtml` = `renderMarkdown(listConfig.value?.header ?? listConfig.value?.description ?? '')` and `footerHtml` = `renderMarkdown(listConfig.value?.footer ?? '')`.
+   - Template: after `</header>` (653), a `<div v-if="headerHtml" class="list-info list-info--top markdown-content" v-html="headerHtml"/>` with the eslint-disable comment. Symmetric `list-info--bottom` after `<Pagination>`.
+   - Scoped CSS for `.list-info` spacing consistent with existing `.markdown-content`.
+4. `data-entry.yaml` example usage added to one in-tree config (e.g. `tickets/data-entry.yaml` or a prototype) for manual verification.
+
+**Alternative considered & rejected:** keep only `description` + add `footer`.
+Rejected for asymmetric vocabulary; `header`/`footer` reads better and the alias
+keeps zero migration cost.
+
+**Files to modify:**
+- `internal/dataentryconfig/config.go` (struct + alias fallback)
+- `internal/dataentryconfig/config_test.go` (alias + parse tests)
+- `internal/dataentry/api_v1.go` OR the config normalize site (whichever owns the alias fallback)
+- `frontend/src/types/config.ts`
+- `frontend/src/components/lists/EntityList.vue`
+- `frontend/src/components/lists/EntityList.*.test.ts` (or a new test) if list-component tests exist
+- one `data-entry.yaml` for the worked example
+- `docs/data-entry.md` (document `header`/`footer`)
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+
+**Input Sources & Validation:** The only input is `header`/`footer` markdown
+from `data-entry.yaml` — an admin-authored, git-versioned file (same trust level
+as the rest of the config). It is nonetheless rendered through
+`renderMarkdown()` which DOMPurify-sanitizes, so even a hostile/mistaken config
+string cannot inject executable script. No new network input, no user-supplied
+input on this path.
+
+**Security-Sensitive Operations:** None new. Reuses the audited sanitization
+pipeline. The `v-html` sink is the same one used across the app and is fed only
+sanitized output.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios:** see Acceptance Criteria (each has a concrete test).
+
+**Edge Cases:**
+- header/footer unset → no region rendered, no layout shift (AC5).
+- both `header` and `description` set → `header` wins (alias only fills when header empty).
+- only `description` set (legacy) → renders in top slot (AC5/backcompat).
+- markdown with an entity-ID code span → renders as inert code (no resolver); documented non-goal.
+- empty string vs unset → both render nothing (`renderMarkdown('')` returns '').
+
+**Negative Tests:** `<script>alert(1)</script>` and `<img src=x
+onerror=alert(1)>` in header → sanitized to inert output (Go alias + TS/Vitest
+render test).
+
+**Integration test approach:** Go test asserts `/_config` JSON carries `header`
+(incl. alias fallback from `description`). Frontend component/unit test asserts
+header/footer regions render and are absent when unset. E2E is optional for a
+config-render change; rely on component test + manual verification.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed
+- [x] Effort estimated
+
+**Risks:**
+- XSS via config → mitigated by mandatory `renderMarkdown` sanitization (never raw `v-html` of the string).
+- Layout shift / visual regression → mitigated by `v-if` guards and scoped CSS; verify manually.
+- Alias ambiguity (`header` vs `description`) → mitigated by a single documented precedence rule + test.
+- Effort: **s**.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+
+**Documentation Impact:**
+- [x] docs/data-entry.md — document `header`/`footer` list fields + `description` alias note.
+- [x] N/A for metamodel.md/cli-reference.md — this is data-entry config, not metamodel or CLI.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: effort:s change reusing an existing sanitized-markdown pipeline; user approved the plan directly.)

--- a/tickets/entities/review-checklists/REV-7N0L8X.md
+++ b/tickets/entities/review-checklists/REV-7N0L8X.md
@@ -1,0 +1,51 @@
+---
+id: REV-7N0L8X
+type: review-checklist
+title: 'Review: Render admin-authored header/footer markdown on list views'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — frontend `npm run test:run`: 72 files, 1170 tests pass. Go `go test ./internal/dataentryconfig/ ./internal/dataentry/`: pass. `go build ./...` clean.
+- [x] Lint clean — `eslint` on changed files: 0 errors (pre-existing `max-lines` warning on EntityList.vue only, unrelated). `golangci-lint ./internal/dataentryconfig/...`: 0 issues. `npm run typecheck`: clean. `rela --project tickets validate`: data-entry.yaml valid.
+- [x] Coverage maintained — change adds tests (Go round-trip + 16 frontend helper tests); `dataentryconfig` floor (70%) only improves.
+
+## Code Review
+
+- [x] Ran cranky-code-reviewer on the diff — no critical findings.
+- [x] All critical review-responses addressed — none raised.
+- [x] All significant review-responses addressed — RR-B6NDXK (dead markdown-content class) → removed.
+- [x] Self-reviewed the diff for unrelated changes — only the 6 intended source files + docs.
+
+**Review Responses:** RR-B6NDXK (significant, addressed), RR-GW5I5R (minor,
+addressed), RR-R1LAKE (nit, addressed), RR-PUIE0H (minor, addressed), RR-RFRS5L
+(nit, wont-fix — not a regression, cross-cutting SPA-link concern out of scope).
+
+## Acceptance Verification
+
+**Acceptance Status:**
+1. Header markdown renders above filter row — **PASS**: `/_config` serves `all_ideas.header`; region rendered via `v-if="headerHtml"` after `</header>`; `list-info--top` in built CSS.
+2. Footer markdown renders below table/pagination — **PASS**: `all_ideas.footer` served; region after `<Pagination>`; `list-info--bottom` in built CSS.
+3. Sanitized (no injection) — **PASS**: reuses `renderMarkdown` (DOMPurify); `markdown.test.ts` covers `<script>`/`onerror`.
+4. No header/footer → renders as before, no layout shift — **PASS**: `v-if` guards + omitempty; unit tests assert `''` when unset.
+5. Legacy `description` still works, `header` wins when both set — **PASS**: `listHeaderMarkdown` precedence + trim; 16 unit tests incl. whitespace-only fallback.
+
+## Documentation (enhancements only)
+
+- [x] User-facing documentation updated — `docs/data-entry.md`: List Fields table gains `header`/`footer`/`description`; new "Header and footer info regions" subsection with example + sanitization/precedence notes.
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: docs updated inline within this ticket; the single doc change is verified above.)
+
+## Final Checks
+
+- [x] Commit message will explain the why (in-context list guidance) not just what.
+- [x] No TODOs/FIXMEs left.
+- [x] Ready for another developer to use — documented, example config in-tree.
+
+## Pull Request
+
+- [x] PR created on branch `feat/list-info-regions`; CI monitored.
+
+**PR:** see branch `feat/list-info-regions`

--- a/tickets/entities/review-checklists/REV-7N0L8X.md
+++ b/tickets/entities/review-checklists/REV-7N0L8X.md
@@ -18,7 +18,7 @@ status: done
 - [x] Ran cranky-code-reviewer on the diff — no critical findings.
 - [x] All critical review-responses addressed — none raised.
 - [x] All significant review-responses addressed — RR-B6NDXK (dead markdown-content class) → removed.
-- [x] Self-reviewed the diff for unrelated changes — only the 6 intended source files + docs.
+- [x] Self-reviewed the diff for unrelated changes — only the intended source files + docs.
 
 **Review Responses:** RR-B6NDXK (significant, addressed), RR-GW5I5R (minor,
 addressed), RR-R1LAKE (nit, addressed), RR-PUIE0H (minor, addressed), RR-RFRS5L
@@ -27,25 +27,25 @@ addressed), RR-R1LAKE (nit, addressed), RR-PUIE0H (minor, addressed), RR-RFRS5L
 ## Acceptance Verification
 
 **Acceptance Status:**
-1. Header markdown renders above filter row — **PASS**: `/_config` serves `all_ideas.header`; region rendered via `v-if="headerHtml"` after `</header>`; `list-info--top` in built CSS.
-2. Footer markdown renders below table/pagination — **PASS**: `all_ideas.footer` served; region after `<Pagination>`; `list-info--bottom` in built CSS.
-3. Sanitized (no injection) — **PASS**: reuses `renderMarkdown` (DOMPurify); `markdown.test.ts` covers `<script>`/`onerror`.
-4. No header/footer → renders as before, no layout shift — **PASS**: `v-if` guards + omitempty; unit tests assert `''` when unset.
-5. Legacy `description` still works, `header` wins when both set — **PASS**: `listHeaderMarkdown` precedence + trim; 16 unit tests incl. whitespace-only fallback.
+1. Header markdown renders above filter row — **PASS**.
+2. Footer markdown renders below table/pagination — **PASS**.
+3. Sanitized (no injection) — **PASS** (DOMPurify via renderMarkdown).
+4. No header/footer → renders as before, no layout shift — **PASS** (`v-if` + omitempty).
+5. Legacy `description` still works, `header` wins when both set — **PASS** (precedence + trim, 16 unit tests).
 
 ## Documentation (enhancements only)
 
-- [x] User-facing documentation updated — `docs/data-entry.md`: List Fields table gains `header`/`footer`/`description`; new "Header and footer info regions" subsection with example + sanitization/precedence notes.
-- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: docs updated inline within this ticket; the single doc change is verified above.)
+- [x] User-facing documentation updated — `docs/data-entry.md`.
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: single inline doc change verified above.)
 
 ## Final Checks
 
-- [x] Commit message will explain the why (in-context list guidance) not just what.
+- [x] Commit message explains the why, not just what.
 - [x] No TODOs/FIXMEs left.
-- [x] Ready for another developer to use — documented, example config in-tree.
+- [x] Ready for another developer to use.
 
 ## Pull Request
 
-- [x] PR created on branch `feat/list-info-regions`; CI monitored.
+- [x] PR created; CI monitored.
 
-**PR:** see branch `feat/list-info-regions`
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1091

--- a/tickets/entities/review-responses/RR-B6NDXK.md
+++ b/tickets/entities/review-responses/RR-B6NDXK.md
@@ -1,0 +1,9 @@
+---
+id: RR-B6NDXK
+type: review-response
+title: Dead/misleading markdown-content class on list-info regions
+finding: 'EntityList.vue puts class="list-info ... markdown-content" on the rendered divs, but .markdown-content is only defined in EntityDetail.vue''s scoped styles — there is no global rule, so scoped styles don''t apply here and the class is inert. It misleads the next developer into assuming shared markdown typography that doesn''t exist. Fix: drop the inert class (the .list-info :deep() rules do the actual styling).'
+severity: significant
+resolution: Removed the inert `markdown-content` class from both list-info divs in EntityList.vue. The `.list-info :deep()` scoped rules provide the actual styling; verified the class no longer appears in the rebuilt ListView bundle.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GW5I5R.md
+++ b/tickets/entities/review-responses/RR-GW5I5R.md
@@ -1,0 +1,9 @@
+---
+id: RR-GW5I5R
+type: review-response
+title: '''legacy alias'' comments overstate history (description was never rendered)'
+finding: Comments in config.go, EntityList.vue, config.ts call `description` the 'legacy name' that 'old configs keep rendering', but description was never rendered before this change. Reframe to 'we adopt the previously-unused description field as a fallback' to avoid implying a backward-compat contract that never existed.
+severity: minor
+resolution: Reframed comments in config.go, config.ts (both the field doc and helper doc), and EntityList.vue to say `description` is a previously-unused field adopted as a fallback, not a rendered legacy behavior being preserved.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-PUIE0H.md
+++ b/tickets/entities/review-responses/RR-PUIE0H.md
@@ -1,0 +1,9 @@
+---
+id: RR-PUIE0H
+type: review-response
+title: -12px top margin hand-tuned against header margin-bottom
+finding: '.list-info--top { margin-top: -12px } is tuned against .list-header { margin-bottom: 24px } 40 lines away, with no test to catch drift. Acceptable for a single call site but note the coupling in a comment.'
+severity: minor
+resolution: Expanded the CSS comment on .list-info--top to explicitly document the coupling to .list-header's margin-bottom and a keep-in-sync note.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-R1LAKE.md
+++ b/tickets/entities/review-responses/RR-R1LAKE.md
@@ -1,0 +1,9 @@
+---
+id: RR-R1LAKE
+type: review-response
+title: Whitespace-only header is truthy in resolver
+finding: listHeaderMarkdown uses `header || description`, so a whitespace-only header ('   ') is truthy. It currently works because renderMarkdown collapses it to '' and the v-if gates on rendered output, but that's incidental. Add .trim() so intent is explicit and the guard is robust regardless of what gates downstream.
+severity: nit
+resolution: Added .trim() to listHeaderMarkdown and listFooterMarkdown so whitespace-only values are treated as unset explicitly. Added two unit tests (whitespace-only header falls back to description; both whitespace → '').
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-RFRS5L.md
+++ b/tickets/entities/review-responses/RR-RFRS5L.md
@@ -1,0 +1,9 @@
+---
+id: RR-RFRS5L
+type: review-response
+title: Markdown [text](/entity/ID) links cause full-page reload
+finding: Anchors rendered via v-html hard-navigate (no SPA click delegation), so entity links in headers reload the page. Consistent with existing EntityDetail behavior (not a regression); docs recommend this pattern. Won't-fix for this ticket — SPA-routing v-html links is a separate cross-cutting concern.
+severity: nit
+reason: Not a regression — v-html anchors hard-navigate everywhere in the app (EntityDetail included); SPA click-delegation for rendered markdown links is a separate cross-cutting concern, out of scope for this ticket. Standard entity links still work, just with a reload.
+status: wont-fix
+---

--- a/tickets/entities/tickets/TKT-H7E611.md
+++ b/tickets/entities/tickets/TKT-H7E611.md
@@ -1,0 +1,56 @@
+---
+id: TKT-H7E611
+type: ticket
+title: Render admin-authored header/footer markdown on list views
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Summary
+
+Add admin-authored info content to the top and bottom of data-entry list views,
+rendered as sanitized markdown from `data-entry.yaml`.
+
+## Motivation
+
+Users viewing a register/list page (e.g. "Risicoregister") have no in-context
+guidance — how scores work, which guides to read, process notes. Today the list
+header shows only the title and a "+ New" button. Admins should be able to add a
+short blurb and links to relevant guides at the top (and optionally footer notes
+at the bottom).
+
+## Scope (Option A — minimal, from brainstorm)
+
+**In scope:**
+- Render a top info region on list views from list config, as sanitized markdown via the existing `renderMarkdown()`.
+- Add a `footer` field for a bottom info region.
+- Reuse the existing markdown pipeline (`frontend/src/utils/markdown.ts`) including `refResolver` so entity-ref links work and break loudly.
+- Authoring is admin-only via `data-entry.yaml` (no UI editing, no end-user authoring).
+
+**Out of scope (left as a seam for later):**
+- Entity-backed or query-backed info blocks (the "link one or more entities" / dashboard-card-style option). The render path goes through `renderMarkdown()` on a string, so upgrading a slot to also accept `{entity}`/`{query}` later is additive.
+- Per-entity-type default info in the metamodel.
+
+## Design notes
+
+Existing building blocks (confirmed by exploration):
+- `List.Description` (`internal/dataentryconfig/config.go`) is already plumbed end-to-end (Go → `/api/v1/_config` JSON → TS `ListConfig.description`) but **never rendered**.
+- Render sites in `frontend/src/components/lists/EntityList.vue`: header block (~line 641) for top, after `<Pagination>` (~line 910) for bottom, both inside the `v-if="listConfig"` wrapper.
+- `renderMarkdown()` already sanitizes (DOMPurify) and resolves entity refs.
+
+**Open question — field naming:** keep `description` for the top slot (zero
+migration) + add `footer`, OR introduce `header` + `footer` as the canonical
+symmetric fields with `description` kept as a deprecated alias for `header`.
+Leaning toward `header`+`footer` with `description` alias for cleaner YAML
+vocabulary at minimal extra cost. To be decided in planning.
+
+## Acceptance criteria
+
+1. A list config with header markdown renders sanitized HTML above the search/filter row.
+2. A list config with footer markdown renders sanitized HTML below the table/pagination.
+3. Markdown links to entity IDs resolve to in-app links via `refResolver`.
+4. Output is DOMPurify-sanitized (no raw HTML/script injection from config).
+5. A list with no header/footer configured renders exactly as before (no empty region, no layout shift).
+6. Backward compatibility: existing `description` values continue to work per the chosen naming decision.

--- a/tickets/relations/FEAT-RUGB28--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-RUGB28--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-RUGB28
+relation: requires
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-H7E611--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-H7E611--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-H7E611
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-H7E611--has-implementation--IMPL-MNPA55.md
+++ b/tickets/relations/TKT-H7E611--has-implementation--IMPL-MNPA55.md
@@ -1,0 +1,5 @@
+---
+from: TKT-H7E611
+relation: has-implementation
+to: IMPL-MNPA55
+---

--- a/tickets/relations/TKT-H7E611--has-planning--PLAN-M1WZM9.md
+++ b/tickets/relations/TKT-H7E611--has-planning--PLAN-M1WZM9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-H7E611
+relation: has-planning
+to: PLAN-M1WZM9
+---

--- a/tickets/relations/TKT-H7E611--has-review--REV-7N0L8X.md
+++ b/tickets/relations/TKT-H7E611--has-review--REV-7N0L8X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-H7E611
+relation: has-review
+to: REV-7N0L8X
+---

--- a/tickets/relations/TKT-H7E611--has-review-response--RR-B6NDXK.md
+++ b/tickets/relations/TKT-H7E611--has-review-response--RR-B6NDXK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-H7E611
+relation: has-review-response
+to: RR-B6NDXK
+---

--- a/tickets/relations/TKT-H7E611--has-review-response--RR-GW5I5R.md
+++ b/tickets/relations/TKT-H7E611--has-review-response--RR-GW5I5R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-H7E611
+relation: has-review-response
+to: RR-GW5I5R
+---

--- a/tickets/relations/TKT-H7E611--has-review-response--RR-PUIE0H.md
+++ b/tickets/relations/TKT-H7E611--has-review-response--RR-PUIE0H.md
@@ -1,0 +1,5 @@
+---
+from: TKT-H7E611
+relation: has-review-response
+to: RR-PUIE0H
+---

--- a/tickets/relations/TKT-H7E611--has-review-response--RR-R1LAKE.md
+++ b/tickets/relations/TKT-H7E611--has-review-response--RR-R1LAKE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-H7E611
+relation: has-review-response
+to: RR-R1LAKE
+---

--- a/tickets/relations/TKT-H7E611--has-review-response--RR-RFRS5L.md
+++ b/tickets/relations/TKT-H7E611--has-review-response--RR-RFRS5L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-H7E611
+relation: has-review-response
+to: RR-RFRS5L
+---

--- a/tickets/relations/TKT-H7E611--implements--FEAT-RUGB28.md
+++ b/tickets/relations/TKT-H7E611--implements--FEAT-RUGB28.md
@@ -1,0 +1,5 @@
+---
+from: TKT-H7E611
+relation: implements
+to: FEAT-RUGB28
+---


### PR DESCRIPTION
## What

Admins can add contextual info to the top and bottom of a data-entry list view via `header`/`footer` markdown in `data-entry.yaml`. Rendered sanitized (DOMPurify) above and below the table.

Motivating case: a list page like a risk register has nowhere to explain how to read the columns or link to the relevant guide. This adds that room.

## How

- **Go** (`internal/dataentryconfig/config.go`): `Header`/`Footer` added to the `List` struct (both `omitempty`). Serializes through `/api/v1/_config` automatically.
- **TS** (`frontend/src/types/config.ts`): `header?`/`footer?` on `ListConfig`; `listHeaderMarkdown`/`listFooterMarkdown` helpers resolve precedence + trim.
- **Vue** (`EntityList.vue`): two `v-if`-guarded `.list-info` regions rendered via the existing `renderMarkdown()`, with scoped CSS. No `refResolver` (the `/_config` endpoint carries no mentions map); standard `[text](/entity/ID)` links work.
- **Example + docs**: worked example on the `all_ideas` list in `tickets/data-entry.yaml`; documented in `docs/data-entry.md`.

### Design notes

- **`description` fallback**: the field predates this feature and was never rendered. The SPA now adopts it as a fallback for `header` (used only when `header` is empty), so existing configs that happen to set it get a header region without a rewrite. When both are set, `header` wins.
- **Precedence resolved client-side** (`header || description`) to avoid mutating the shared `Cfg.Lists` map, which `/_config` serves by reference.
- **Seam for later**: the render path is `renderMarkdown()` on a string, so accepting entity/query-backed blocks later is purely additive. Out of scope here.

## Security

Only input is admin-authored YAML, but it's still routed through mandatory DOMPurify sanitization — config cannot inject executable markup. No new egress.

## Testing

- Frontend unit suite: 1170 pass (incl. 16 new helper tests: precedence, empty-vs-unset, whitespace-only fallback).
- Go: `dataentryconfig` YAML/JSON round-trip + omitempty tests; affected packages pass; `go build ./...` clean.
- `npm run typecheck` / `eslint` / `golangci-lint` clean.
- `rela validate` on the tickets project passes; live `/_config` confirmed serving `header`/`footer`.
- Code-reviewed (cranky-code-reviewer): no criticals; the one significant finding (an inert `markdown-content` class) was removed.

Closes TKT-H7E611.