### PR TITLE
fix(dataentry): persist incoming-direction relation picks on create (BUG-10IPBP)

### DIFF
--- a/e2e/tests/reverse-relations.spec.ts
+++ b/e2e/tests/reverse-relations.spec.ts
@@ -112,6 +112,36 @@ test.describe('Reverse relations', () => {
     expect(fromSource.map((r) => r.id)).toContain(SEED.features.authentication);
   });
 
+  test('non-cards picker add persists on CREATE, not just edit (BUG-10IPBP)', async ({
+    appPage,
+    api,
+  }) => {
+    // Regression for BUG-10IPBP: an incoming-direction picker on the
+    // CREATE form silently dropped every selection, because
+    // loadIncomingValue() short-circuited without setting incomingLoaded
+    // when there was no entityId, so emitIncomingDiff() no-op'd on each
+    // pick. Edit worked; create didn't. Here we create a NEW feature and
+    // pick TASK-002 in its "Implemented by" incoming picker; the edge
+    // `TASK-002 --implements--> <new feature>` must exist afterward.
+    const candidateTitle = 'Refactor auth module'; // matches TASK-002 in the seed
+    const form = new FormPage(appPage);
+    await form.navigateToCreateForm('feature');
+    await form.fillTitle(`Reverse-on-create ${Date.now().toString(36)}`);
+
+    const picker = form.relationPickerByLabel('Implemented by');
+    await expect(picker).toBeVisible();
+    await form.pickInRelationPicker(picker, candidateTitle, candidateTitle);
+    await expect(form.pickerTileByText(picker, candidateTitle)).toBeVisible();
+
+    const created = await form.submitAndExpectCreate('features');
+
+    // Read from the source side: TASK-002's outgoing `implements` must now
+    // include the newly created feature. Before the fix this list was
+    // unchanged because the create POST never carried the incoming edge.
+    const fromSource = await api.listRelations('tasks', SEED.tasks.refactorAuth, 'implements');
+    expect(fromSource.map((r) => r.id)).toContain(created.id);
+  });
+
   test('non-cards picker remove deletes the underlying edge', async ({ appPage, api }) => {
     // Removing the TASK-001 tile from the "Implemented by" picker on
     // FEAT-001 must delete `TASK-001 --implements--> FEAT-001`. Sanity-

--- a/frontend/src/components/forms/RelationPicker.test.ts
+++ b/frontend/src/components/forms/RelationPicker.test.ts
@@ -188,3 +188,139 @@ describe('RelationPicker — affordance verdicts', () => {
     wrapper.unmount()
   })
 })
+
+// BUG-10IPBP: on the CREATE form (no entityId) a `direction: incoming`
+// picker used to silently drop every selection — loadIncomingValue()
+// short-circuited without setting incomingLoaded, so emitIncomingDiff()
+// no-op'd on each pick and nothing reached the create POST body. Edit
+// mode worked because the entity existed and the snapshot loaded. The
+// fix establishes an empty baseline in create mode so incoming picks
+// emit as pure additions.
+describe('RelationPicker — incoming direction on create (BUG-10IPBP)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  function seedIncomingSchema(maxIncoming = 10) {
+    const schemaStore = useSchemaStore()
+    schemaStore.entityTypes.set('ticket', {
+      name: 'ticket',
+      label: 'Ticket',
+      properties: {},
+    } as never)
+    // An incoming picker selects sources from the relation's `from` set.
+    // `max_incoming` drives single- vs multi-select on the picker.
+    schemaStore.relationTypes.set('blocks', {
+      name: 'blocks',
+      from: ['ticket'],
+      to: ['ticket'],
+      inverse: 'blockedBy',
+      max_outgoing: 10,
+      max_incoming: maxIncoming,
+    } as never)
+  }
+
+  async function mountIncoming(
+    entityId: string | undefined,
+    candidates: Entity[],
+    maxIncoming = 10
+  ) {
+    seedIncomingSchema(maxIncoming)
+    seedCandidates(candidates)
+    const field: FormFieldOrRelation = {
+      relation: 'blocks',
+      label: 'Blocked By',
+      direction: 'incoming',
+    }
+    const wrapper = mount(RelationPicker, {
+      props: { field, entityType: 'ticket', entityId, value: [] },
+      attachTo: document.body,
+    })
+    await flushPromises()
+    return wrapper
+  }
+
+  it('create mode: selecting an incoming peer emits incoming-changed as an addition', async () => {
+    const peer = entity('TKT-900', 'A blocker')
+    // No entityId → create form.
+    const wrapper = await mountIncoming(undefined, [peer])
+
+    const search = wrapper.find('input[role="combobox"]')
+    await search.trigger('focus')
+    await flushPromises()
+    await wrapper.find('.dropdown-item').trigger('click')
+    await flushPromises()
+
+    const events = wrapper.emitted('incoming-changed')
+    expect(events).toBeTruthy()
+    const payload = events![events!.length - 1][0] as {
+      added: Array<{ targetId: string }>
+      removed: string[]
+      currentEntries: Array<{ id: string }>
+    }
+    expect(payload.added).toEqual([{ targetId: 'TKT-900' }])
+    expect(payload.removed).toEqual([])
+    expect(payload.currentEntries.map((e) => e.id)).toEqual(['TKT-900'])
+    // The chip renders so the user sees the pending selection.
+    expect(wrapper.find('.selected-entity').text()).toContain('TKT-900')
+    wrapper.unmount()
+  })
+
+  it('create mode: removing a just-added incoming peer emits an empty desired set', async () => {
+    const peer = entity('TKT-901')
+    const wrapper = await mountIncoming(undefined, [peer])
+
+    const search = wrapper.find('input[role="combobox"]')
+    await search.trigger('focus')
+    await flushPromises()
+    await wrapper.find('.dropdown-item').trigger('click')
+    await flushPromises()
+    await wrapper.find('.remove-btn').trigger('click')
+    await flushPromises()
+
+    const events = wrapper.emitted('incoming-changed')!
+    const last = events[events.length - 1][0] as {
+      added: Array<{ targetId: string }>
+      currentEntries: Array<{ id: string }>
+    }
+    expect(last.added).toEqual([])
+    expect(last.currentEntries).toEqual([])
+    wrapper.unmount()
+  })
+
+  it('create mode: an untouched incoming picker emits nothing', async () => {
+    // The fix establishes an empty loaded baseline on create. That must
+    // NOT translate into a spurious emit: a picker the user never touches
+    // has to stay silent, or it would risk a `data: []` wipe in the body.
+    const peer = entity('TKT-902')
+    const wrapper = await mountIncoming(undefined, [peer])
+
+    // No interaction at all — just mounted.
+    expect(wrapper.emitted('incoming-changed')).toBeFalsy()
+    wrapper.unmount()
+  })
+
+  it('create mode: single-select incoming picker (max_incoming=1) emits the addition', async () => {
+    // The empty-baseline fix also feeds the single-select branch
+    // (selectEntity replaces the list with [id] when !isMulti). Cover it
+    // so single-cardinality incoming relations persist on create too.
+    const peer = entity('TKT-903')
+    const wrapper = await mountIncoming(undefined, [peer], 1)
+
+    const search = wrapper.find('input[role="combobox"]')
+    await search.trigger('focus')
+    await flushPromises()
+    await wrapper.find('.dropdown-item').trigger('click')
+    await flushPromises()
+
+    const events = wrapper.emitted('incoming-changed')
+    expect(events).toBeTruthy()
+    const payload = events![events!.length - 1][0] as {
+      added: Array<{ targetId: string }>
+      currentEntries: Array<{ id: string }>
+    }
+    expect(payload.added).toEqual([{ targetId: 'TKT-903' }])
+    expect(payload.currentEntries.map((e) => e.id)).toEqual(['TKT-903'])
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/components/forms/RelationPicker.vue
+++ b/frontend/src/components/forms/RelationPicker.vue
@@ -145,7 +145,20 @@ async function loadCandidates() {
 }
 
 async function loadIncomingValue() {
-  if (!isIncoming.value || !props.entityId || !props.field.relation) return
+  if (!isIncoming.value || !props.field.relation) return
+  // Create mode: the entity doesn't exist yet, so there are no existing
+  // incoming edges to load. Establish an empty baseline and mark the
+  // picker loaded so selections emit as pure additions. Without this,
+  // `incomingLoaded` stays false and emitIncomingDiff() no-ops every
+  // pick — the load-failure-cannot-wipe guard (TKT-GFQK) wrongly
+  // suppressing additions on a brand-new entity (BUG-10IPBP).
+  if (!props.entityId) {
+    incomingValue.value = []
+    incomingOriginal.value = []
+    incomingLoadedEntries.value = []
+    incomingLoaded.value = true
+    return
+  }
   try {
     const edges = await getEntityRelations(
       props.entityType,

--- a/tickets/entities/automated-measures/incoming-picker-create-persist-test.md
+++ b/tickets/entities/automated-measures/incoming-picker-create-persist-test.md
@@ -1,0 +1,14 @@
+---
+id: incoming-picker-create-persist-test
+type: automated-measure
+title: 'Test: incoming-direction relation picker persists selections on the create form'
+description: Unit (RelationPicker.test.ts) + e2e (reverse-relations.spec.ts) coverage asserting that an incoming-direction relation picker persists selections made on the create form, including untouched-picker-emits-nothing and single-select cases. Both verified to fail before the BUG-10IPBP fix.
+kind: test
+location: frontend/src/components/forms/RelationPicker.test.ts (unit), e2e/tests/reverse-relations.spec.ts (e2e, BUG-10IPBP)
+status: active
+---
+
+Locks in the fix for BUG-10IPBP.
+
+- **Unit** (`RelationPicker.test.ts`, describe "incoming direction on create"): mounting an incoming picker with no `entityId` and selecting a peer must emit `incoming-changed` with the peer as a pure addition; removing it emits an empty desired set. Verified to fail before the fix.
+- **E2E** (`reverse-relations.spec.ts`, "non-cards picker add persists on CREATE, not just edit"): create a new feature, pick TASK-002 in its incoming "Implemented by" picker, submit, and assert `TASK-002 --implements--> <new feature>` exists (read from the source side). Verified to fail before the fix.

--- a/tickets/entities/bug-analysis-checklists/BUGA-NLLJDM.md
+++ b/tickets/entities/bug-analysis-checklists/BUGA-NLLJDM.md
@@ -1,0 +1,26 @@
+---
+id: BUGA-NLLJDM
+type: bug-analysis-checklist
+title: 'Analysis: Selection relation not saved when creating an entity in data-entry (edit works)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Reproduction
+
+- [x] Bug reproduced locally (live rela-server + real SPA driven via Puppeteer; captured the create POST body omitting the incoming edge)
+- [x] Minimal reproduction steps documented (create form with a `direction: incoming` picker → select peer → Create → edge dropped; edit works)
+- [x] Environment/conditions noted (affects any `direction: incoming` non-cards relation picker on the create form; independent of project)
+
+## Root Cause
+
+- [x] Immediate cause identified (why1): incoming picker never emits the selection on create
+- [x] Contributing factors found (why2-3): `emitIncomingDiff` early-returns while `incomingLoaded` is false; `loadIncomingValue` short-circuits without an entityId; TKT-GFQK load-failure guard collapses "nothing to load" into "load failed"
+- [x] Systemic cause explored (why4-5): create-mode incoming pickers never tested; asymmetric emit channels for the two directions
+
+## Fix Planning
+
+- [x] Fix approach determined: in `RelationPicker.loadIncomingValue`, treat "no entityId" (create) as an empty loaded baseline (`incomingLoaded = true`) so selections emit as pure additions
+- [x] Regression test planned: unit (RelationPicker incoming-on-create emits) + e2e (create feature form, incoming picker persists) — see `incoming-picker-create-persist-test`; both verified to fail before the fix
+- [x] Related areas checked for similar issues: RelationCards (the other incoming widget) never renders on create (requires entityId), so no parallel create-mode drop

--- a/tickets/entities/bugs/BUG-10IPBP.md
+++ b/tickets/entities/bugs/BUG-10IPBP.md
@@ -1,0 +1,29 @@
+---
+id: BUG-10IPBP
+type: bug
+title: Selection relation not saved when creating an entity in data-entry (edit works)
+description: A relation rendered as a selection widget in the data-entry create form is not persisted when the entity is created; the same field saves correctly on the edit form.
+priority: medium
+why1: 'On the data-entry create form, an incoming-direction relation picker (widget: multi-select/select with `direction: incoming`) never emits the user''s selection, so it''s absent from the create POST body.'
+why2: RelationPicker.emitIncomingDiff() returns early when `incomingLoaded` is false, and on create `incomingLoaded` is always false because loadIncomingValue() short-circuits when there is no entityId.
+why3: 'The `direction: incoming` code path was designed around the edit form (diff a loaded snapshot of existing incoming edges); the ''load-failure-cannot-wipe'' guard (TKT-GFQK) treats ''not loaded'' identically to ''load failed'' and suppresses all emits, including pure additions on a brand-new entity that has no snapshot to load.'
+why4: 'Create mode for incoming pickers was never exercised end-to-end: incoming pickers were added for the edit flow, and no test (unit or e2e) covers selecting an incoming peer on the create form.'
+why5: The two directions use asymmetric emit channels (outgoing emits immediately via update/update:types; incoming emits a loaded-snapshot diff), and create-mode was only validated for the outgoing/default picker path, so the incoming-on-create gap went unnoticed.
+prevention: 'When a widget has a mode-dependent code path (create vs edit, keyed on entityId presence), both modes must be exercised end-to-end before merge. The incoming-direction picker was only tested on edit. Systemic fix: e2e/unit coverage now asserts create-mode persistence for incoming pickers (see incoming-picker-create-persist-test). More broadly, the ''load-failure-cannot-wipe'' guard should distinguish ''nothing to load (new entity)'' from ''load failed'' rather than collapsing both to inert — a create-mode empty baseline is a valid loaded state, not a failure.'
+status: done
+---
+
+In the data-entry create form, a relation rendered as a selection widget is not
+persisted when the entity is created. The same relation field saves correctly on
+the edit form. So creating an entity and picking a relation value drops that
+relation; only after saving and re-editing does setting the relation stick.
+
+**Expected:** a relation selected in the create form is saved as part of entity
+creation, matching the edit-form behavior.
+
+**Steps to reproduce:**
+1. Open the data-entry create form for an entity type that has a relation field shown as a selection widget.
+2. Select a value in that relation field.
+3. Fill required fields and create the entity.
+4. Observe the created entity has no relation.
+5. Edit the same entity, select the same relation value, save — the relation is now persisted.

--- a/tickets/entities/implementation-checklists/IMPL-GI3XIJ.md
+++ b/tickets/entities/implementation-checklists/IMPL-GI3XIJ.md
@@ -1,0 +1,47 @@
+---
+id: IMPL-GI3XIJ
+type: implementation-checklist
+title: 'Implementation: Selection relation not saved when creating an entity in data-entry (edit works)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (`RelationPicker.test.ts` — incoming-on-create emits)
+- [x] Integration tests written (e2e `reverse-relations.spec.ts` — create form incoming picker persists the edge)
+- [x] Happy path implemented (`RelationPicker.loadIncomingValue` establishes an empty loaded baseline on create)
+- [x] Edge cases handled (add then remove on create emits an empty desired set; covered by unit test)
+- [x] ~~Error handling in place~~ (N/A: fix removes a silent no-op; no new error surface. Pre-existing inverse pre-flight in DynamicForm still guards missing-inverse relations)
+
+## Test Quality
+
+- [x] Using fixtures/factories (unit uses the existing `entity()`/`seedCandidates` helpers; e2e uses the seeded `feature`/`task` fixtures + `SEED` constants)
+- [x] No hardcoded values where an object is in scope (e2e asserts against `created.id` from the create response)
+- [x] Only specifying values that matter
+- [x] Interpolated values constructed from objects
+- [x] Property comparisons use the original object (`created.id`, `SEED.tasks.refactorAuth`)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified
+- [x] Edge cases manually verified
+
+**Verification Evidence:** Built `rela-server` with the fix, ran the real SPA
+(Puppeteer) against a live project. On the create form with both an outgoing and
+an incoming `blocks` picker:
+- Captured POST body BEFORE fix: `{"relations":{"blocks":{"data":[{"type":"thing","id":"THG-100"}]}}}` — incoming selection dropped.
+- Captured POST body AFTER fix: `{"relations":{"blocks":{...THG-100...},"blockedBy":{"data":[{"type":"thing","id":"THG-101"}]}}}` — incoming selection sent under the inverse key.
+- On-disk edges after create: both `THG-103--blocks--THG-100.md` (outgoing) and `THG-101--blocks--THG-103.md` (incoming) present; API `?direction=incoming` lists THG-101.
+Both the unit test and the e2e test were confirmed to FAIL without the fix (git
+stash) and PASS with it.
+
+## Quality
+
+- [x] Code follows project patterns (mirrors the existing early-return/guard style in `loadIncomingValue`; comment cites BUG-10IPBP + TKT-GFQK)
+- [x] ~~DRY opportunities~~ (N/A: single localized guard; no repetition introduced)
+- [x] No security issues introduced
+- [x] No silent failures (the fix specifically eliminates a silent no-op)
+- [x] No debug code left behind

--- a/tickets/entities/review-checklists/REV-B6ISCB.md
+++ b/tickets/entities/review-checklists/REV-B6ISCB.md
@@ -1,0 +1,55 @@
+---
+id: REV-B6ISCB
+type: review-checklist
+title: 'Review: Selection relation not saved when creating an entity in data-entry (edit works)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — frontend 1163 unit tests green; e2e forms + reverse-relations (24) green, including the new BUG-10IPBP create-side test
+- [x] Lint clean — `eslint` on changed files rc=0; `vue-tsc` typecheck clean; e2e `tsc` clean
+- [x] ~~Coverage maintained~~ (N/A: frontend has no coverage enforcement per frontend/CLAUDE.md; added tests raise effective coverage)
+
+## Code Review
+
+- [x] Run `/code-review` (cranky-code-reviewer) — verdict: ship it; fix minimal, edit path untouched, no spurious wipe (two independent guards)
+- [x] All critical review-responses addressed (none raised)
+- [x] All significant review-responses addressed (none raised; one minor + two nits)
+- [x] Self-reviewed the diff for unrelated changes — diff is 3 files, all on-topic
+
+**Review Responses:** RR-AYQ1QC (minor, addressed), RR-VQD8FN (nit, addressed),
+RR-WY3CO0 (nit, wont-fix with justification)
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented in implementation checklist (IMPL-GI3XIJ)
+
+**Acceptance Status:**
+- AC "relation selected in create form is saved": **PASS** — e2e creates a feature, picks TASK-002 in the incoming picker, submits; `TASK-002 --implements--> <new feature>` verified from the source side. Manual Puppeteer run captured the create POST body now carrying the incoming edge under the inverse key.
+- AC "matches edit-form behavior": **PASS** — edit path unchanged (verified by review + existing edit-side reverse-relations tests still green).
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist~~ (N/A: bug fix, no user-facing docs change)
+- [x] ~~User-facing documentation~~ (N/A)
+- [x] ~~Docs-checklist done~~ (N/A)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what (pending commit)
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- pending: on develop; needs a feature branch before commit -->

--- a/tickets/entities/review-checklists/REV-B6ISCB.md
+++ b/tickets/entities/review-checklists/REV-B6ISCB.md
@@ -42,14 +42,14 @@ Skip this section for bugs and internal refactors.
 
 ## Final Checks
 
-- [x] Commit message explains the why, not just what (pending commit)
+- [x] Commit message explains the why, not just what
 - [x] No TODOs or FIXMEs left unaddressed
 - [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` — PR opened (#1092)
+- [x] All CI checks pass — see PR (monitored; frontend/e2e/lint green)
+- [x] PR URL documented below
 
-**PR:** <!-- pending: on develop; needs a feature branch before commit -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1092

--- a/tickets/entities/review-responses/RR-AYQ1QC.md
+++ b/tickets/entities/review-responses/RR-AYQ1QC.md
@@ -1,0 +1,9 @@
+---
+id: RR-AYQ1QC
+type: review-response
+title: No test pinned untouched-create picker emitting nothing
+finding: The fix's core promise is that an incoming picker left untouched on create emits nothing (no spurious data:[] wipe). buildRelationsPatch's skip is tested in isolation, but no test asserted that mounting an incoming picker in create mode and never touching it produces zero incoming-changed events.
+severity: minor
+resolution: 'Added unit test ''create mode: an untouched incoming picker emits nothing'' in RelationPicker.test.ts asserting emitted(''incoming-changed'') is falsy after mount with no interaction.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-VQD8FN.md
+++ b/tickets/entities/review-responses/RR-VQD8FN.md
@@ -1,0 +1,9 @@
+---
+id: RR-VQD8FN
+type: review-response
+title: Single-select (max_incoming=1) incoming picker untested on create
+finding: The empty-baseline fix also feeds the single-select branch (selectEntity replaces list with [id] when !isMulti). Both new unit tests used max_incoming=10; the single-cardinality incoming path on create was uncovered.
+severity: nit
+resolution: 'Parameterized the test schema with maxIncoming and added ''create mode: single-select incoming picker (max_incoming=1) emits the addition''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-WY3CO0.md
+++ b/tickets/entities/review-responses/RR-WY3CO0.md
@@ -1,0 +1,9 @@
+---
+id: RR-WY3CO0
+type: review-response
+title: emitIncomingDiff can silently drop a picked id missing from candidates
+finding: 'In emitIncomingDiff, a newly-added id only enters currentEntries if found in candidates; buildRelationsPatch builds data from entries (added is decorative), so a picked id missing from candidates would silently vanish from the POST — the same bug class in a different door. Latent only: every selectable id today enters via selectEntity whose source is candidates (or handleEntityCreated which pushes before selecting).'
+severity: nit
+reason: Latent fragility, not a live bug and not introduced by this change. Every id that can be selected is guaranteed to be in candidates at emit time (dropdown items come from candidates; inline-created targets are pushed to candidates before selection). Hardening emitIncomingDiff with a fallback/warn is a reasonable follow-up but out of scope for this bug fix; deferring to keep the fix minimal and focused.
+status: wont-fix
+---

--- a/tickets/relations/BUG-10IPBP--adds-measure--incoming-picker-create-persist-test.md
+++ b/tickets/relations/BUG-10IPBP--adds-measure--incoming-picker-create-persist-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-10IPBP
+relation: adds-measure
+to: incoming-picker-create-persist-test
+---

--- a/tickets/relations/BUG-10IPBP--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-10IPBP--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-10IPBP
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-10IPBP--caused-by--TKT-GFQK.md
+++ b/tickets/relations/BUG-10IPBP--caused-by--TKT-GFQK.md
@@ -1,0 +1,5 @@
+---
+from: BUG-10IPBP
+relation: caused-by
+to: TKT-GFQK
+---

--- a/tickets/relations/BUG-10IPBP--fixes--FEAT-R7SOT.md
+++ b/tickets/relations/BUG-10IPBP--fixes--FEAT-R7SOT.md
@@ -1,0 +1,5 @@
+---
+from: BUG-10IPBP
+relation: fixes
+to: FEAT-R7SOT
+---

--- a/tickets/relations/BUG-10IPBP--has-bug-analysis--BUGA-NLLJDM.md
+++ b/tickets/relations/BUG-10IPBP--has-bug-analysis--BUGA-NLLJDM.md
@@ -1,0 +1,5 @@
+---
+from: BUG-10IPBP
+relation: has-bug-analysis
+to: BUGA-NLLJDM
+---

--- a/tickets/relations/BUG-10IPBP--has-implementation--IMPL-GI3XIJ.md
+++ b/tickets/relations/BUG-10IPBP--has-implementation--IMPL-GI3XIJ.md
@@ -1,0 +1,5 @@
+---
+from: BUG-10IPBP
+relation: has-implementation
+to: IMPL-GI3XIJ
+---

--- a/tickets/relations/BUG-10IPBP--has-review--REV-B6ISCB.md
+++ b/tickets/relations/BUG-10IPBP--has-review--REV-B6ISCB.md
@@ -1,0 +1,5 @@
+---
+from: BUG-10IPBP
+relation: has-review
+to: REV-B6ISCB
+---

--- a/tickets/relations/BUG-10IPBP--has-review-response--RR-AYQ1QC.md
+++ b/tickets/relations/BUG-10IPBP--has-review-response--RR-AYQ1QC.md
@@ -1,0 +1,5 @@
+---
+from: BUG-10IPBP
+relation: has-review-response
+to: RR-AYQ1QC
+---

--- a/tickets/relations/BUG-10IPBP--has-review-response--RR-VQD8FN.md
+++ b/tickets/relations/BUG-10IPBP--has-review-response--RR-VQD8FN.md
@@ -1,0 +1,5 @@
+---
+from: BUG-10IPBP
+relation: has-review-response
+to: RR-VQD8FN
+---

--- a/tickets/relations/BUG-10IPBP--has-review-response--RR-WY3CO0.md
+++ b/tickets/relations/BUG-10IPBP--has-review-response--RR-WY3CO0.md
@@ -1,0 +1,5 @@
+---
+from: BUG-10IPBP
+relation: has-review-response
+to: RR-WY3CO0
+---

--- a/tickets/relations/incoming-picker-create-persist-test--protects--data-entry-ui.md
+++ b/tickets/relations/incoming-picker-create-persist-test--protects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: incoming-picker-create-persist-test
+relation: protects
+to: data-entry-ui
+---


### PR DESCRIPTION
## Problem

On the data-entry **create** form, a relation picker with `direction: incoming` silently dropped the user's selection — it was never included in the create POST body. The same picker on the **edit** form worked. So creating an entity and picking an incoming relation lost that edge; only re-editing made it stick.

## Root cause

In `frontend/src/components/forms/RelationPicker.vue`, incoming picks are staged via `emitIncomingDiff()`, which early-returns while `incomingLoaded` is false. `incomingLoaded` is only set by `loadIncomingValue()`, which short-circuited whenever there was no `entityId` — i.e. always on create. So every incoming selection on create was a silent no-op and never reached `handleSubmit`'s payload.

This is the TKT-GFQK "load-failure-cannot-wipe" guard over-applying: on create there is no snapshot to load, but pure additions should still be captured. Follow-on defect in FEAT-R7SOT; caused-by TKT-GFQK.

## Fix

Treat create mode (no `entityId`) as a valid **empty loaded baseline** so incoming selections emit as pure additions. The edit path (entityId present) is byte-for-byte unchanged — the fix only adds a branch the edit path never enters.

## Verification

- Reproduced end-to-end against a live `rela-server` + the real SPA (captured the create POST body omitting the incoming edge before the fix, carrying it under the inverse key after).
- **Unit** (`RelationPicker.test.ts`): incoming-on-create emits the addition; untouched picker emits nothing (no spurious `data:[]`); add-then-remove emits an empty set; single-select (`max_incoming=1`) case.
- **E2E** (`reverse-relations.spec.ts`): create a feature, pick a task in its incoming "Implemented by" picker, submit, assert the edge exists read from the source side.
- Both the unit and e2e tests were confirmed to **fail without the fix** and pass with it.
- Full suite green: 1163 frontend unit tests, e2e forms + reverse-relations.

Fixes BUG-10IPBP.