### PR TITLE
docs: reword list header/footer 'description' fallback note

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -581,7 +581,7 @@ lists:
 | `title`           | string | List heading                                                |
 | `header`          | string | Markdown rendered above the list (info/help; see below)     |
 | `footer`          | string | Markdown rendered below the list                            |
-| `description`     | string | Legacy alias for `header`; used only when `header` is unset  |
+| `description`     | string | Fallback for `header`; used only when `header` is unset      |
 | `columns`         | list   | Column definitions                                          |
 | `sort`            | object | Default sort order                                          |
 | `filters`         | list   | Static filters (always applied)                             |
@@ -620,7 +620,8 @@ Notes:
 - Output is sanitized (DOMPurify), so raw HTML/scripts in the config cannot
   inject executable markup.
 - Use standard Markdown links (`[text](/entity/ID)`) to point at other entities.
-- `description` is the older name for the top region and still works; when both
+- `description` is a fallback for the top region: it was previously unused, so a
+  config that already sets it now renders a header without a rewrite. When both
   `header` and `description` are set, `header` wins.
 
 ### Column Options

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -575,7 +575,7 @@ lists:
 | `title`           | string | List heading                                                |
 | `header`          | string | Markdown rendered above the list (info/help; see below)     |
 | `footer`          | string | Markdown rendered below the list                            |
-| `description`     | string | Legacy alias for `header`; used only when `header` is unset  |
+| `description`     | string | Fallback for `header`; used only when `header` is unset      |
 | `columns`         | list   | Column definitions                                          |
 | `sort`            | object | Default sort order                                          |
 | `filters`         | list   | Static filters (always applied)                             |
@@ -614,7 +614,8 @@ Notes:
 - Output is sanitized (DOMPurify), so raw HTML/scripts in the config cannot
   inject executable markup.
 - Use standard Markdown links (`[text](/entity/ID)`) to point at other entities.
-- `description` is the older name for the top region and still works; when both
+- `description` is a fallback for the top region: it was previously unused, so a
+  config that already sets it now renders a header without a rewrite. When both
   `header` and `description` are set, `header` wins.
 
 ### Column Options

--- a/tickets/entities/tickets/TKT-SI02JV.md
+++ b/tickets/entities/tickets/TKT-SI02JV.md
@@ -1,0 +1,31 @@
+---
+id: TKT-SI02JV
+type: ticket
+title: Reword list header/footer 'description' fallback note in docs
+kind: docs
+priority: low
+effort: xs
+status: done
+---
+
+## Summary
+
+Docs-only follow-up to TKT-H7E611 / #1091. During code review of #1091, the
+"legacy alias" framing for the list `description` field was corrected in the
+code comments (review-response RR-GW5I5R): `description` was a previously-unused
+field now adopted as a fallback for `header`, not a previously-rendered legacy
+behavior. That reword landed after #1091 merged, so the docs still carried the
+old "legacy alias" / "older name" phrasing.
+
+This aligns `docs-project/entities/guides/GUIDE-data-entry.md` (and its
+generated `docs/data-entry.md`) with the corrected comments.
+
+## Scope
+
+Docs-only, no behavior change. Two phrasings updated: the List Fields table row
+for `description`, and the header/footer notes bullet.
+
+## Verification
+
+`just docs` regenerates cleanly; `just docs-check` passes (source and generated
+output in sync).

--- a/tickets/relations/TKT-SI02JV--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-SI02JV--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SI02JV
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-SI02JV--implements--FEAT-RUGB28.md
+++ b/tickets/relations/TKT-SI02JV--implements--FEAT-RUGB28.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SI02JV
+relation: implements
+to: FEAT-RUGB28
+---


### PR DESCRIPTION
Follow-up to #1091 (already merged).

During code review of #1091, the "legacy alias" framing for the `description`
field was corrected in the **code comments** (review-response RR-GW5I5R):
`description` was a previously-**unused** field now adopted as a fallback for
`header`, not a previously-rendered legacy behavior being preserved. That
wording fix landed after #1091 merged, so the **docs** still carried the old
"legacy alias" / "older name" phrasing.

This aligns `docs-project/entities/guides/GUIDE-data-entry.md` (and its
generated `docs/data-entry.md`) with the corrected comments. Docs-only, no
behavior change.